### PR TITLE
CI: Enable pullapprove

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,0 +1,43 @@
+version: 2
+
+requirements:
+  signed_off_by:
+    required: true
+
+# Disallow approval of PRs still under development
+always_pending:
+  title_regex: '(WIP|RFC)'
+  labels:
+    - do-not-merge
+    - wip
+    - rfc
+  explanation: 'Work in progress - do not merge'
+
+group_defaults:
+  approve_by_comment:
+    enabled: true
+    approve_regex: '^(LGTM|lgtm|Approved|\+1|:\+1:)'
+    reject_regex: '^(Rejected|-1|:-1:)'
+  reset_on_push:
+    enabled: false
+  reset_on_reopened:
+    enabled: false
+  author_approval:
+    ignored: true
+
+groups:
+  approvers:
+    required: 2
+    teams:
+      - kata-containers
+
+  documentation:
+    required: 1
+    teams:
+      - documentation
+    conditions:
+      files:
+        include:
+          - "*.md"
+        exclude:
+          - "vendor/*"


### PR DESCRIPTION
Add the pullapprove config file to ensure all PRs are approved before
landing.

Fixes #9.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>