### PR TITLE
docs: Add contributing and code of conduct docs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+## Kata Containers Code of Conduct
+
+Kata Containers follows the [OpenStack Foundation Code of Conduct](https://www.openstack.org/legal/community-code-of-conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+## This repo is part of [Kata Containers](https://katacontainers.io)
+
+For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Add the standard contributing and code of conduct documents.

Fixes #13.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>