### PR TITLE
github: Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,17 @@
+# Description of problem
+
+(replace this text with the list of steps you followed)
+
+# Expected result
+
+(replace this text with an explanation of what you thought would happen)
+
+# Actual result
+
+(replace this text with details of what actually happened)
+
+---
+
+(replace this text with the output of the `kata-collect-data.sh` script, after
+you have reviewed its content to ensure it does not contain any private
+information).


### PR DESCRIPTION
Add a template to guide the user on raising github issues.

Fixes #19.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>