### PR TITLE
Credit packagecloud for package hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,3 +137,8 @@ the environment before switching to the workload.
 The
 [www.katacontainers.io](https://github.com/kata-containers/www.katacontainers.io)
 repository contains all sources for the https://www.katacontainers.io site.
+
+## Credits
+
+Kata Containers uses [packagecloud](https://packagecloud.io) for package
+hosting.


### PR DESCRIPTION
We use a packagecloud OSS account for package hosting.
As part of the arrangement with packagecloud we need to
credit them and add a link back to https://packagecloud.io
on our website and project README.

This repository's README is probably the closest we have to
a "project README", so let's add it here.