### PR TITLE
Master workflow

### DIFF
--- a/.github/workflows/gather-artifacts.sh
+++ b/.github/workflows/gather-artifacts.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o pipefail
+
+pushd kata-artifacts >>/dev/null
+for c in ./*.tar.gz
+do
+    echo "untarring tarball $c"
+    tar -xvf $c
+done
+
+tar cfJ ../kata-static.tar.xz ./opt
+popd >>/dev/null

--- a/.github/workflows/generate-artifact-tarball.sh
+++ b/.github/workflows/generate-artifact-tarball.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright (c) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o pipefail
+
+
+main() {
+    artifact_stage=${1:-}
+    artifact=$(echo  ${artifact_stage} | sed -n -e 's/^install_//p' | sed -r 's/_/-/g')
+    if [ -z "${artifact}" ]; then
+        "Scripts needs artifact name to build"
+        exit 1
+    fi
+
+    tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+    export GOPATH=$HOME/go
+
+    go get github.com/kata-containers/packaging || true
+    pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
+    git checkout $tag
+    pushd ../obs-packaging
+    ./gen_versions_txt.sh $tag
+    popd
+
+    source ./kata-deploy-binaries.sh
+    ${artifact_stage} $tag
+    popd
+
+    mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-static-${artifact}.tar.gz .
+}
+
+main $@

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -103,6 +103,32 @@ jobs:
           name: kata-artifacts
           path: kata-static-qemu.tar.gz
 
+  build-nemu:
+    runs-on: ubuntu-16.04
+    needs: get-artifact-list
+    env:
+      buildstr: "install_nemu"
+    steps:
+      - uses: actions/checkout@v1
+      - name: get-artifact-list
+        uses: actions/download-artifact@master
+        with:
+          name: artifact-list
+      - name: build-nemu
+        run: |
+         if grep -q $buildstr ./artifact-list/artifact-list.txt; then
+           $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
+           echo ::set-env name=artifact-built::true
+         else
+           echo ::set-env name=artifact-built::false
+         fi
+      - name: store-artifacts
+        if: env.artifact-built == 'true'
+        uses: actions/upload-artifact@master
+        with:
+          name: kata-artifacts
+          path: kata-static-nemu.tar.gz
+
   # Job for building the QEMU binaries with virtiofs support
   build-qemu-virtiofsd:
     runs-on: ubuntu-16.04
@@ -240,7 +266,7 @@ jobs:
 
   gather-artifacts:
     runs-on: ubuntu-16.04
-    needs: [build-kernel, build-qemu, build-qemu-virtiofsd, build-image, build-firecracker, build-kata-components]
+    needs: [build-kernel, build-qemu, build-qemu-virtiofsd, build-image, build-firecracker, build-kata-components, build-nemu]
     steps:
       - uses: actions/checkout@v1
       - name: get-artifacts

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -184,6 +184,33 @@ jobs:
           name: kata-artifacts
           path: kata-static-firecracker.tar.gz
 
+  # Job for building cloud-hypervisor
+  build-clh:
+    runs-on: ubuntu-16.04
+    needs: get-artifact-list
+    env:
+      buildstr: "install_clh"
+    steps:
+      - uses: actions/checkout@v1
+      - name: get-artifact-list
+        uses: actions/download-artifact@master
+        with:
+          name: artifact-list
+      - name: build-clh
+        run: |
+         if grep -q $buildstr ./artifact-list/artifact-list.txt; then
+           $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
+           echo ::set-env name=artifact-built::true
+         else
+           echo ::set-env name=artifact-built::false
+         fi
+      - name: store-artifacts
+        if: env.artifact-built == 'true'
+        uses: actions/upload-artifact@master
+        with:
+          name: kata-artifacts
+          path: kata-static-clh.tar.gz
+
   # Job for building kata components
   build-kata-components:
     runs-on: ubuntu-16.04

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,292 +17,217 @@ jobs:
          ./packaging/artifact-list.sh > artifact-list.txt
       - name: save-artifact-list
         uses: actions/upload-artifact@master
-        with: 
-          name: artifact-list 
+        with:
+          name: artifact-list
           path: artifact-list.txt
+
   build-kernel:
     runs-on: ubuntu-16.04
     needs: get-artifact-list
+    env:
+      buildstr: "install_kernel"
     steps:
+      - uses: actions/checkout@v1
       - name: get-artifact-list
         uses: actions/download-artifact@master
         with:
           name: artifact-list
+      - run: |
+         sudo apt-get update && sudo apt install -y flex bison libelf-dev bc iptables
       - name: build-kernel
         run: |
-         if grep -q "install_kernel" ./artifact-list/artifact-list.txt; then
-           # install kernel dependencies
-           sudo apt-get update && sudo apt install -y flex bison libelf-dev bc iptables
-           export GOPATH=$HOME/go
-           go get github.com/kata-containers/packaging || true
-           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
-           # Get versions information
-           tag=`echo $GITHUB_REF | cut -d/ -f3-`
-           git checkout $tag
-           pushd ../obs-packaging
-           ./gen_versions_txt.sh $tag
-           popd
-           # Build the kernel:
-           source ./kata-deploy-binaries.sh
-           install_kernel
+         if grep -q $buildstr ./artifact-list/artifact-list.txt; then
+           $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
            echo ::set-env name=artifact-built::true
-           popd >>/dev/null
-           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-kernel.tar.gz .
          else
            echo ::set-env name=artifact-built::false
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true' 
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@master
-        with: 
+        with:
           name: kata-artifacts
-          path: kata-kernel.tar.gz
-  
+          path: kata-static-kernel.tar.gz
+
   build-experimental-kernel:
     runs-on: ubuntu-16.04
     needs: get-artifact-list
+    env:
+      buildstr: "install_experimental_kernel"
     steps:
+      - uses: actions/checkout@v1
       - name: get-artifact-list
         uses: actions/download-artifact@master
         with:
           name: artifact-list
+      - run: |
+         sudo apt-get update && sudo apt install -y flex bison libelf-dev bc iptables
       - name: build-experimental-kernel
         run: |
-         if grep -q "install_experimental_kernel" ./artifact-list/artifact-list.txt; then
-           # install kernel dependencies
-           sudo apt-get update && sudo apt install -y flex bison libelf-dev bc iptables
-           export GOPATH=$HOME/go
-           go get github.com/kata-containers/packaging || true
-           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
-           # Get versions information
-           tag=`echo $GITHUB_REF | cut -d/ -f3-`
-           git checkout $tag
-           ../obs-packaging/gen_versions_txt.sh $tag
-           # Build the kernel:
-           source ./kata-deploy-binaries.sh
-           install_experimental_kernel
+         if grep -q $buildstr ./artifact-list/artifact-list.txt; then
+           $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
            echo ::set-env name=artifact-built::true
-           popd >>/dev/null
-           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-kernel-experimental.tar.gz .
          else
            echo ::set-env name=artifact-built::false
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true' 
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@master
-        with: 
+        with:
           name: kata-artifacts
-          path: kata-kernel-experimental.tar.gz
+          path: kata-static-experimental-kernel.tar.gz
 
-  # Job for building the QEMU binaries
   build-qemu:
     runs-on: ubuntu-16.04
     needs: get-artifact-list
+    env:
+      buildstr: "install_qemu"
     steps:
+      - uses: actions/checkout@v1
       - name: get-artifact-list
         uses: actions/download-artifact@master
         with:
           name: artifact-list
       - name: build-qemu
         run: |
-         if grep -q "install_qemu" ./artifact-list/artifact-list.txt; then
-           export GOPATH=$HOME/go
-           go get github.com/kata-containers/packaging || true
-           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
-           # Get versions information
-           tag=`echo $GITHUB_REF | cut -d/ -f3-`
-           git checkout $tag
-           ../obs-packaging/gen_versions_txt.sh $tag
-           # Build the VMM:
-           source ./kata-deploy-binaries.sh
-           install_qemu
+         if grep -q $buildstr ./artifact-list/artifact-list.txt; then
+           $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
            echo ::set-env name=artifact-built::true
-           popd >>/dev/null
-           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-qemu-static.tar.gz .
          else
            echo ::set-env name=artifact-built::false
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true' 
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@master
-        with: 
+        with:
           name: kata-artifacts
-          path: kata-qemu-static.tar.gz
-  
+          path: kata-static-qemu.tar.gz
+
   # Job for building the QEMU binaries with virtiofs support
   build-qemu-virtiofsd:
     runs-on: ubuntu-16.04
     needs: get-artifact-list
+    env:
+      buildstr: "install_qemu_virtiofsd"
     steps:
+      - uses: actions/checkout@v1
       - name: get-artifact-list
         uses: actions/download-artifact@master
         with:
           name: artifact-list
       - name: build-qemu-virtiofsd
         run: |
-         if grep -q "install_qemu_virtiofsd" ./artifact-list/artifact-list.txt; then
-           export GOPATH=$HOME/go
-           go get github.com/kata-containers/packaging || true
-           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
-           # Get versions information
-           tag=`echo $GITHUB_REF | cut -d/ -f3-`
-           git checkout $tag
-           ../obs-packaging/gen_versions_txt.sh $tag
-           # Build the VMM:
-           source ./kata-deploy-binaries.sh
-           install_qemu_virtiofsd
+         if grep -q $buildstr ./artifact-list/artifact-list.txt; then
+           $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
            echo ::set-env name=artifact-built::true
-           popd >>/dev/null
-           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-qemu-virtiofs-static.tar.gz .
          else
            echo ::set-env name=artifact-built::false
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true' 
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@master
-        with: 
+        with:
           name: kata-artifacts
-          path: kata-qemu-virtiofs-static.tar.gz
+          path: kata-static-qemu-virtiofsd.tar.gz
 
   # Job for building the image
   build-image:
     runs-on: ubuntu-16.04
     needs: get-artifact-list
+    env:
+      buildstr: "install_image"
     steps:
+      - uses: actions/checkout@v1
       - name: get-artifact-list
         uses: actions/download-artifact@master
         with:
           name: artifact-list
       - name: build-image
         run: |
-         if grep -q "install_image" ./artifact-list/artifact-list.txt; then
-           export GOPATH=$HOME/go
-           go get github.com/kata-containers/packaging || true
-           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
-           # Get versions information
-           tag=`echo $GITHUB_REF | cut -d/ -f3-`
-           git checkout $tag
-           pushd ../obs-packaging
-           ./gen_versions_txt.sh $tag
-           popd
-           # Build the VMM:
-           source ./kata-deploy-binaries.sh
-           install_image $tag
+         if grep -q $buildstr ./artifact-list/artifact-list.txt; then
+           $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
            echo ::set-env name=artifact-built::true
-           popd >>/dev/null
-           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-image.tar.gz .
          else
            echo ::set-env name=artifact-built::false
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true' 
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@master
-        with: 
+        with:
           name: kata-artifacts
-          path: kata-image.tar.gz
- 
+          path: kata-static-image.tar.gz
+
   # Job for building firecracker hypervisor
   build-firecracker:
     runs-on: ubuntu-16.04
     needs: get-artifact-list
+    env:
+      buildstr: "install_firecracker"
     steps:
+      - uses: actions/checkout@v1
       - name: get-artifact-list
         uses: actions/download-artifact@master
         with:
           name: artifact-list
       - name: build-firecracker
         run: |
-         if grep -q "install_firecracker" ./artifact-list/artifact-list.txt; then
-           export GOPATH=$HOME/go
-           go get github.com/kata-containers/packaging || true
-           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
-           # Get versions information
-           tag=`echo $GITHUB_REF | cut -d/ -f3-`
-           git checkout $tag
-           ../obs-packaging/gen_versions_txt.sh $tag
-           # Build the VMM:
-           source ./kata-deploy-binaries.sh
-           install_firecracker
+         if grep -q $buildstr ./artifact-list/artifact-list.txt; then
+           $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
            echo ::set-env name=artifact-built::true
-           popd >>/dev/null
-           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-firecracker-static.tar.gz .
          else
            echo ::set-env name=artifact-built::false
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true' 
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@master
-        with: 
+        with:
           name: kata-artifacts
-          path: kata-firecracker-static.tar.gz
-  
+          path: kata-static-firecracker.tar.gz
+
   # Job for building kata components
   build-kata-components:
     runs-on: ubuntu-16.04
     needs: get-artifact-list
+    env:
+      buildstr: "install_kata_components"
     steps:
+      - uses: actions/checkout@v1
       - name: get-artifact-list
         uses: actions/download-artifact@master
         with:
           name: artifact-list
       - name: build-kata-components
         run: |
-         if grep -q "install_kata_components" ./artifact-list/artifact-list.txt; then
-           export GOPATH=$HOME/go
-           go get github.com/kata-containers/packaging || true
-           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
-           # Get versions information
-           tag=`echo $GITHUB_REF | cut -d/ -f3-`
-           git checkout $tag
-           ../obs-packaging/gen_versions_txt.sh $tag
-           # Build the VMM:
-           source ./kata-deploy-binaries.sh
-           install_kata_components $tag
+         if grep -q $buildstr ./artifact-list/artifact-list.txt; then
+           $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
            echo ::set-env name=artifact-built::true
-           popd >>/dev/null
-           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-components.tar.gz .
          else
            echo ::set-env name=artifact-built::false
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true' 
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@master
-        with: 
+        with:
           name: kata-artifacts
-          path: kata-components.tar.gz
+          path: kata-static-kata-components.tar.gz
 
   gather-artifacts:
     runs-on: ubuntu-16.04
     needs: [build-kernel, build-qemu, build-qemu-virtiofsd, build-image, build-firecracker, build-kata-components]
     steps:
+      - uses: actions/checkout@v1
       - name: get-artifacts
         uses: actions/download-artifact@master
         with:
           name: kata-artifacts
       - name: colate-artifacts
         run: |
-          export GOPATH=$HOME/go
-          go get github.com/kata-containers/packaging || true
-          pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
-          # Get versions information
-          tag=`echo $GITHUB_REF | cut -d/ -f3-`
-          popd >>/dev/null
-          pushd kata-artifacts >>/dev/null 
-          for c in ./*.tar.gz
-          do 
-                echo "untarring tarball $c"
-                tar -xvf $c
-          done
-          ls ./opt/kata/bin
-          ls ./opt/kata/share
-          tar cfJ ../kata-static.tar.xz ./opt
-          popd >>/dev/null
-          ls -l && ls kata-artifacts
+          $GITHUB_WORKSPACE/.github/workflows/gather-artifacts.sh
       - name: store-artifacts
         uses: actions/upload-artifact@master
-        with: 
+        with:
           name: release-candidate
-          path: kata-static.tar.xz 
+          path: kata-static.tar.xz
 
   kata-deploy:
     needs: gather-artifacts
@@ -330,14 +255,14 @@ jobs:
         uses: ./packaging/kata-deploy/action
         with:
           packaging-sha: env.PKG_SHA
-        env: 
+        env:
           PKG_SHA: ${{ env.PKG_SHA }}
           AZ_APPID: ${{ secrets.AZ_APPID }}
           AZ_PASSWORD: ${{ secrets.AZ_PASSWORD }}
           AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
           AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
       - name: push-tarball
-        run: | 
+        run: |
           # tag the container image we created and push to DockerHub
           docker tag katadocker/kata-deploy-ci:${{ env.PKG_SHA }} katadocker/kata-deploy:${{ env.TAG }}
           docker push katadocker/kata-deploy:${{ env.TAG }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -341,5 +341,24 @@ jobs:
           # tag the container image we created and push to DockerHub
           docker tag katadocker/kata-deploy-ci:${{ env.PKG_SHA }} katadocker/kata-deploy:${{ env.TAG }}
           docker push katadocker/kata-deploy:${{ env.TAG }}
-          
-          
+
+  upload-static-tarball:
+    needs: kata-deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: download-artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: release-candidate
+      - name: install hub
+        run: |
+          HUB_VER=$(curl -s "https://api.github.com/repos/github/hub/releases/latest" | jq -r .tag_name | sed 's/^v//')
+          wget -q -O- https://github.com/github/hub/releases/download/v$HUB_VER/hub-linux-amd64-$HUB_VER.tgz | \
+          tar xz --strip-components=2 --wildcards '*/bin/hub' && sudo mv hub /usr/local/bin/hub
+      - name: push static tarball to github
+        run: |
+          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+          mv release-candidate/kata-static.tar.xz release-candidate/kata-static-$tag-x86_64.tar.xz
+          git clone https://github.com/kata-containers/runtime.git
+          cd runtime
+          GITHUB_TOKEN=${{ secrets.GIT_UPLOAD_TOKEN }} hub release edit -m "" -a ../release-candidate/kata-static-$tag-x86_64.tar.xz "${tag}"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,345 @@
+on: 
+  push: 
+    tags:
+     - '*'
+
+jobs:
+  get-artifact-list:
+    runs-on: ubuntu-latest
+    steps:
+      - name: get the list
+        run: |
+         git clone https://github.com/kata-containers/packaging
+         pushd packaging
+         tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+         git checkout $tag
+         popd
+         ./packaging/artifact-list.sh > artifact-list.txt
+      - name: save-artifact-list
+        uses: actions/upload-artifact@master
+        with: 
+          name: artifact-list 
+          path: artifact-list.txt
+  build-kernel:
+    runs-on: ubuntu-16.04
+    needs: get-artifact-list
+    steps:
+      - name: get-artifact-list
+        uses: actions/download-artifact@master
+        with:
+          name: artifact-list
+      - name: build-kernel
+        run: |
+         if grep -q "install_kernel" ./artifact-list/artifact-list.txt; then
+           # install kernel dependencies
+           sudo apt-get update && sudo apt install -y flex bison libelf-dev bc iptables
+           export GOPATH=$HOME/go
+           go get github.com/kata-containers/packaging || true
+           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
+           # Get versions information
+           tag=`echo $GITHUB_REF | cut -d/ -f3-`
+           git checkout $tag
+           pushd ../obs-packaging
+           ./gen_versions_txt.sh $tag
+           popd
+           # Build the kernel:
+           source ./kata-deploy-binaries.sh
+           install_kernel
+           echo ::set-env name=artifact-built::true
+           popd >>/dev/null
+           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-kernel.tar.gz .
+         else
+           echo ::set-env name=artifact-built::false
+         fi
+      - name: store-artifacts
+        if: env.artifact-built == 'true' 
+        uses: actions/upload-artifact@master
+        with: 
+          name: kata-artifacts
+          path: kata-kernel.tar.gz
+  
+  build-experimental-kernel:
+    runs-on: ubuntu-16.04
+    needs: get-artifact-list
+    steps:
+      - name: get-artifact-list
+        uses: actions/download-artifact@master
+        with:
+          name: artifact-list
+      - name: build-experimental-kernel
+        run: |
+         if grep -q "install_experimental_kernel" ./artifact-list/artifact-list.txt; then
+           # install kernel dependencies
+           sudo apt-get update && sudo apt install -y flex bison libelf-dev bc iptables
+           export GOPATH=$HOME/go
+           go get github.com/kata-containers/packaging || true
+           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
+           # Get versions information
+           tag=`echo $GITHUB_REF | cut -d/ -f3-`
+           git checkout $tag
+           ../obs-packaging/gen_versions_txt.sh $tag
+           # Build the kernel:
+           source ./kata-deploy-binaries.sh
+           install_experimental_kernel
+           echo ::set-env name=artifact-built::true
+           popd >>/dev/null
+           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-kernel-experimental.tar.gz .
+         else
+           echo ::set-env name=artifact-built::false
+         fi
+      - name: store-artifacts
+        if: env.artifact-built == 'true' 
+        uses: actions/upload-artifact@master
+        with: 
+          name: kata-artifacts
+          path: kata-kernel-experimental.tar.gz
+
+  # Job for building the QEMU binaries
+  build-qemu:
+    runs-on: ubuntu-16.04
+    needs: get-artifact-list
+    steps:
+      - name: get-artifact-list
+        uses: actions/download-artifact@master
+        with:
+          name: artifact-list
+      - name: build-qemu
+        run: |
+         if grep -q "install_qemu" ./artifact-list/artifact-list.txt; then
+           export GOPATH=$HOME/go
+           go get github.com/kata-containers/packaging || true
+           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
+           # Get versions information
+           tag=`echo $GITHUB_REF | cut -d/ -f3-`
+           git checkout $tag
+           ../obs-packaging/gen_versions_txt.sh $tag
+           # Build the VMM:
+           source ./kata-deploy-binaries.sh
+           install_qemu
+           echo ::set-env name=artifact-built::true
+           popd >>/dev/null
+           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-qemu-static.tar.gz .
+         else
+           echo ::set-env name=artifact-built::false
+         fi
+      - name: store-artifacts
+        if: env.artifact-built == 'true' 
+        uses: actions/upload-artifact@master
+        with: 
+          name: kata-artifacts
+          path: kata-qemu-static.tar.gz
+  
+  # Job for building the QEMU binaries with virtiofs support
+  build-qemu-virtiofsd:
+    runs-on: ubuntu-16.04
+    needs: get-artifact-list
+    steps:
+      - name: get-artifact-list
+        uses: actions/download-artifact@master
+        with:
+          name: artifact-list
+      - name: build-qemu-virtiofsd
+        run: |
+         if grep -q "install_qemu_virtiofsd" ./artifact-list/artifact-list.txt; then
+           export GOPATH=$HOME/go
+           go get github.com/kata-containers/packaging || true
+           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
+           # Get versions information
+           tag=`echo $GITHUB_REF | cut -d/ -f3-`
+           git checkout $tag
+           ../obs-packaging/gen_versions_txt.sh $tag
+           # Build the VMM:
+           source ./kata-deploy-binaries.sh
+           install_qemu_virtiofsd
+           echo ::set-env name=artifact-built::true
+           popd >>/dev/null
+           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-qemu-virtiofs-static.tar.gz .
+         else
+           echo ::set-env name=artifact-built::false
+         fi
+      - name: store-artifacts
+        if: env.artifact-built == 'true' 
+        uses: actions/upload-artifact@master
+        with: 
+          name: kata-artifacts
+          path: kata-qemu-virtiofs-static.tar.gz
+
+  # Job for building the image
+  build-image:
+    runs-on: ubuntu-16.04
+    needs: get-artifact-list
+    steps:
+      - name: get-artifact-list
+        uses: actions/download-artifact@master
+        with:
+          name: artifact-list
+      - name: build-image
+        run: |
+         if grep -q "install_image" ./artifact-list/artifact-list.txt; then
+           export GOPATH=$HOME/go
+           go get github.com/kata-containers/packaging || true
+           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
+           # Get versions information
+           tag=`echo $GITHUB_REF | cut -d/ -f3-`
+           git checkout $tag
+           pushd ../obs-packaging
+           ./gen_versions_txt.sh $tag
+           popd
+           # Build the VMM:
+           source ./kata-deploy-binaries.sh
+           install_image $tag
+           echo ::set-env name=artifact-built::true
+           popd >>/dev/null
+           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-image.tar.gz .
+         else
+           echo ::set-env name=artifact-built::false
+         fi
+      - name: store-artifacts
+        if: env.artifact-built == 'true' 
+        uses: actions/upload-artifact@master
+        with: 
+          name: kata-artifacts
+          path: kata-image.tar.gz
+ 
+  # Job for building firecracker hypervisor
+  build-firecracker:
+    runs-on: ubuntu-16.04
+    needs: get-artifact-list
+    steps:
+      - name: get-artifact-list
+        uses: actions/download-artifact@master
+        with:
+          name: artifact-list
+      - name: build-firecracker
+        run: |
+         if grep -q "install_firecracker" ./artifact-list/artifact-list.txt; then
+           export GOPATH=$HOME/go
+           go get github.com/kata-containers/packaging || true
+           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
+           # Get versions information
+           tag=`echo $GITHUB_REF | cut -d/ -f3-`
+           git checkout $tag
+           ../obs-packaging/gen_versions_txt.sh $tag
+           # Build the VMM:
+           source ./kata-deploy-binaries.sh
+           install_firecracker
+           echo ::set-env name=artifact-built::true
+           popd >>/dev/null
+           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-firecracker-static.tar.gz .
+         else
+           echo ::set-env name=artifact-built::false
+         fi
+      - name: store-artifacts
+        if: env.artifact-built == 'true' 
+        uses: actions/upload-artifact@master
+        with: 
+          name: kata-artifacts
+          path: kata-firecracker-static.tar.gz
+  
+  # Job for building kata components
+  build-kata-components:
+    runs-on: ubuntu-16.04
+    needs: get-artifact-list
+    steps:
+      - name: get-artifact-list
+        uses: actions/download-artifact@master
+        with:
+          name: artifact-list
+      - name: build-kata-components
+        run: |
+         if grep -q "install_kata_components" ./artifact-list/artifact-list.txt; then
+           export GOPATH=$HOME/go
+           go get github.com/kata-containers/packaging || true
+           pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
+           # Get versions information
+           tag=`echo $GITHUB_REF | cut -d/ -f3-`
+           git checkout $tag
+           ../obs-packaging/gen_versions_txt.sh $tag
+           # Build the VMM:
+           source ./kata-deploy-binaries.sh
+           install_kata_components $tag
+           echo ::set-env name=artifact-built::true
+           popd >>/dev/null
+           mv $HOME/go/src/github.com/kata-containers/packaging/release/kata-components.tar.gz .
+         else
+           echo ::set-env name=artifact-built::false
+         fi
+      - name: store-artifacts
+        if: env.artifact-built == 'true' 
+        uses: actions/upload-artifact@master
+        with: 
+          name: kata-artifacts
+          path: kata-components.tar.gz
+
+  gather-artifacts:
+    runs-on: ubuntu-16.04
+    needs: [build-kernel, build-qemu, build-qemu-virtiofsd, build-image, build-firecracker, build-kata-components]
+    steps:
+      - name: get-artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: kata-artifacts
+      - name: colate-artifacts
+        run: |
+          export GOPATH=$HOME/go
+          go get github.com/kata-containers/packaging || true
+          pushd $GOPATH/src/github.com/kata-containers/packaging/release >>/dev/null
+          # Get versions information
+          tag=`echo $GITHUB_REF | cut -d/ -f3-`
+          popd >>/dev/null
+          pushd kata-artifacts >>/dev/null 
+          for c in ./*.tar.gz
+          do 
+                echo "untarring tarball $c"
+                tar -xvf $c
+          done
+          ls ./opt/kata/bin
+          ls ./opt/kata/share
+          tar cfJ ../kata-static.tar.xz ./opt
+          popd >>/dev/null
+          ls -l && ls kata-artifacts
+      - name: store-artifacts
+        uses: actions/upload-artifact@master
+        with: 
+          name: release-candidate
+          path: kata-static.tar.xz 
+
+  kata-deploy:
+    needs: gather-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: get-artifacts
+        uses: actions/download-artifact@master
+        with:
+          name: release-candidate
+      - name: build-and-push-kata-deploy-ci
+        run: |
+          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+          git clone https://github.com/kata-containers/packaging
+          pushd packaging
+          git checkout $tag
+          pkg_sha=$(git rev-parse HEAD)
+          popd
+          mv release-candidate/kata-static.tar.xz ./packaging/kata-deploy/kata-static.tar.xz
+          docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t katadocker/kata-deploy-ci:$pkg_sha ./packaging/kata-deploy
+          docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
+          docker push katadocker/kata-deploy-ci:$pkg_sha
+          echo ::set-env name=PKG_SHA::$pkg_sha
+          echo ::set-env name=TAG::$tag
+      - name: test-kata-deploy-ci-in-aks
+        uses: ./packaging/kata-deploy/action
+        with:
+          packaging-sha: env.PKG_SHA
+        env: 
+          PKG_SHA: ${{ env.PKG_SHA }}
+          AZ_APPID: ${{ secrets.AZ_APPID }}
+          AZ_PASSWORD: ${{ secrets.AZ_PASSWORD }}
+          AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
+      - name: push-tarball
+        run: | 
+          # tag the container image we created and push to DockerHub
+          docker tag katadocker/kata-deploy-ci:${{ env.PKG_SHA }} katadocker/kata-deploy:${{ env.TAG }}
+          docker push katadocker/kata-deploy:${{ env.TAG }}
+          
+          


### PR DESCRIPTION
Introduce workflow automation for the Kata Containers release process.

This workflow will:
 1. get a list of artifacts from the packaging repo
 2. In parallel, build each of the applicable artifacts
 3. Consolidate the build artifacts from <2>
 4. Test the artifacts in a docker image on AKS
 5. Push the verified docker image to dockerhub
 6. Push tarball to Kata release page.


![image](https://user-images.githubusercontent.com/20174683/68968661-fdef5c80-0797-11ea-82fd-6eafa525228b.png)


Status:
 - [x] needs support for pushing to GH releases page (todo:Carlos)
 - [x] needs to use kata-containers branches of packaging once the
prerequisite commits land there (todo: Eric - depends on https://github.com/kata-containers/packaging/pull/764)
 - [x] should push to katacontainers dockerhub, once flow is verified (todo:
Eric)
 - [x] needs secrets added to kata-containers/kata-containers, once we are
ready to merge there (todo: Eric)