### PR TITLE
agent: Remove `get_key_value` to enable building in stable rust.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ os:
 
 language: rust
 rust:
-    - nightly
+    - stable
 
 env:
     - target_branch=$TRAVIS_BRANCH RUST_AGENT=yes

--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -45,9 +45,7 @@ The `rust-agent` depends on [`grpc-rs`](https://github.com/pingcap/grpc-rs) by P
 ### Build from Source
 The rust-agent need to be built with rust nightly, and static linked with musl.
 ```bash
-rustup toolchain install nightly
-rustup default nightly
-rustup target add x86_64-unknown-linux-musl --toolchain=nightly
+rustup target add x86_64-unknown-linux-musl
 git submodule update --init --recursive  
 sudo ln -s /usr/bin/g++ /bin/musl-g++  
 cargo build --target x86_64-unknown-linux-musl --release

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -588,24 +588,22 @@ pub fn get_cgroup_mounts(logger: &Logger, cg_path: &str) -> Result<Vec<INIT_MOUN
             }
         }
 
-        match CGROUPS.get_key_value(fields[0]) {
-            Some((key, value)) => {
-                if *key == "" {
-                    continue;
-                }
+        if fields[0] == "" {
+            continue;
+        }
 
-                if *key == "devices" {
-                    has_device_cgroup = true;
-                }
+        if fields[0] == "devices" {
+            has_device_cgroup = true;
+        }
 
-                cg_mounts.push(INIT_MOUNT {
-                    fstype: "cgroup",
-                    src: "cgroup",
-                    dest: *value,
-                    options: vec!["nosuid", "nodev", "noexec", "relatime", *key],
-                });
-            }
-            None => continue,
+        if let Some(value) = CGROUPS.get(&fields[0]) {
+            let key = CGROUPS.keys().find(|&&f| f == fields[0]).unwrap();
+            cg_mounts.push(INIT_MOUNT {
+                fstype: "cgroup",
+                src: "cgroup",
+                dest: *value,
+                options: vec!["nosuid", "nodev", "noexec", "relatime", key]
+            });
         }
     }
 


### PR DESCRIPTION
The get_key_value method is currently only avaiable in nightly rust.
As only this feature is required it worth to refactor and enable building
in the stable channel.

The method was removed by first getting the value from the CGROUPS hashmap,
then key is get by iterating over all the keys. The checks for an empty key and
key == "devices" were moved out of the hashmap block.

The README.md was updated as well to detail the instructions for stable rust.

Signed-off-by: Erich Cordoba <erich.cordoba.malibran@intel.com>