### PR TITLE
rust-agent: Set BUILDTYPE to debug.

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -23,7 +23,7 @@ COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)
 # Exported to allow cargo to see it
 export VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
 
-BUILD_TYPE = release
+BUILD_TYPE = debug
 
 ARCH = $(shell uname -m)
 LIBC = musl


### PR DESCRIPTION
Since build with --release produces corrupted binary in ci, we removed
--release. However, the make install target cannot find the binary,
set BUILDTYPE to debug

Signed-off-by: Yang Bo <bo@hyper.sh>