### PR TITLE
build: Allow building with gnu target

### DIFF
--- a/src/agent/src/random.rs
+++ b/src/agent/src/random.rs
@@ -14,16 +14,28 @@ pub const RNGDEV: &'static str = "/dev/random";
 pub const RNDADDTOENTCNT: libc::c_int = 0x40045201;
 pub const RNDRESEEDRNG: libc::c_int = 0x5207;
 
+// Handle the differing ioctl(2) request types for different targets
+#[cfg(target_env = "musl")]
+type IoctlRequestType = libc::c_int;
+#[cfg(target_env = "gnu")]
+type IoctlRequestType = libc::c_ulong;
+
 pub fn reseed_rng(data: &[u8]) -> Result<()> {
     let len = data.len() as libc::c_long;
     fs::write(RNGDEV, data)?;
 
     let fd = fcntl::open(RNGDEV, OFlag::O_RDWR, Mode::from_bits_truncate(0o022))?;
 
-    let ret = unsafe { libc::ioctl(fd, RNDADDTOENTCNT, &len as *const libc::c_long) };
+    let ret = unsafe {
+        libc::ioctl(
+            fd,
+            RNDADDTOENTCNT as IoctlRequestType,
+            &len as *const libc::c_long,
+        )
+    };
     let _ = Errno::result(ret).map(drop)?;
 
-    let ret = unsafe { libc::ioctl(fd, RNDRESEEDRNG, 0) };
+    let ret = unsafe { libc::ioctl(fd, RNDRESEEDRNG as IoctlRequestType, 0) };
     let _ = Errno::result(ret).map(drop)?;
 
     Ok(())


### PR DESCRIPTION
Fixes to allow the rust agent to be built using a gnu target. Specifically, remove assumptions about musl-specific types.

Fixes: #70.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>