### PR TITLE
agent: Move test macros to a separate module to be commonly used.

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -53,6 +53,7 @@ pub mod random;
 mod sandbox;
 mod uevent;
 mod version;
+#[cfg(test)] mod test_utils;
 
 use mount::{cgroups_mount, general_mount};
 use sandbox::Sandbox;

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -688,7 +688,6 @@ fn parse_options(option_list: Vec<String>) -> HashMap<String, String> {
 }
 
 #[cfg(test)]
-
 mod tests {
     use super::*;
     use libc::umount;
@@ -697,54 +696,11 @@ mod tests {
     use std::io::Write;
     use std::path::PathBuf;
     use tempfile::tempdir;
-
-    #[allow(unused_macros)]
-    macro_rules! skip_if_root {
-        () => {
-            if nix::unistd::Uid::effective().is_root() {
-                println!("INFO: skipping {} which needs non-root", module_path!());
-                return;
-            }
-        };
-    }
-
-    #[allow(unused_macros)]
-    macro_rules! skip_if_not_root {
-        () => {
-            if !nix::unistd::Uid::effective().is_root() {
-                println!("INFO: skipping {} which needs root", module_path!());
-                return;
-            }
-        };
-    }
-
-    #[allow(unused_macros)]
-    macro_rules! skip_loop_if_root {
-        ($msg:expr) => {
-            if nix::unistd::Uid::effective().is_root() {
-                println!(
-                    "INFO: skipping loop {} in {} which needs non-root",
-                    $msg,
-                    module_path!()
-                );
-                continue;
-            }
-        };
-    }
-
-    #[allow(unused_macros)]
-    macro_rules! skip_loop_if_not_root {
-        ($msg:expr) => {
-            if !nix::unistd::Uid::effective().is_root() {
-                println!(
-                    "INFO: skipping loop {} in {} which needs root",
-                    $msg,
-                    module_path!()
-                );
-                continue;
-            }
-        };
-    }
+    use crate::{
+        skip_if_not_root,
+        skip_loop_if_not_root,
+        skip_loop_if_root,
+    };
 
     #[derive(Debug, PartialEq)]
     enum TestUserType {

--- a/src/agent/src/test_utils.rs
+++ b/src/agent/src/test_utils.rs
@@ -1,0 +1,59 @@
+// Copyright (c) 2019 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#[cfg(test)]
+mod test_utils {
+    #[macro_export]
+    #[allow(unused_macros)]
+    macro_rules! skip_if_root {
+        () => {
+            if nix::unistd::Uid::effective().is_root() {
+                println!("INFO: skipping {} which needs non-root", module_path!());
+                return;
+            }
+        };
+    }
+
+    #[macro_export]
+    #[allow(unused_macros)]
+    macro_rules! skip_if_not_root {
+        () => {
+            if !nix::unistd::Uid::effective().is_root() {
+                println!("INFO: skipping {} which needs root", module_path!());
+                return;
+            }
+        };
+    }
+
+    #[macro_export]
+    #[allow(unused_macros)]
+    macro_rules! skip_loop_if_root {
+        ($msg:expr) => {
+            if nix::unistd::Uid::effective().is_root() {
+                println!(
+                    "INFO: skipping loop {} in {} which needs non-root",
+                    $msg,
+                    module_path!()
+                );
+                continue;
+            }
+        };
+    }
+
+    #[macro_export]
+    #[allow(unused_macros)]
+    macro_rules! skip_loop_if_not_root {
+        ($msg:expr) => {
+            if !nix::unistd::Uid::effective().is_root() {
+                println!(
+                    "INFO: skipping loop {} in {} which needs root",
+                    $msg,
+                    module_path!()
+                );
+                continue;
+            }
+        };
+    }
+}


### PR DESCRIPTION
The `skip_*` macros will be useful across the different tests so having
them in a separate module can help with code duplication. This change
creates a new module and exports the macros at crate level.

Signed-off-by: Erich Cordoba <erich.cordoba.malibran@intel.com>