### PR TITLE
config: add hotplug timeout option

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -38,7 +38,7 @@ use std::os::unix::fs::{self as unixfs};
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::sync::mpsc::{self, Sender};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, RwLock};
 use std::{io, thread};
 use unistd::Pid;
 
@@ -70,6 +70,7 @@ const CONSOLE_PATH: &'static str = "/dev/console";
 lazy_static! {
     static ref GLOBAL_DEVICE_WATCHER: Arc<Mutex<HashMap<String, Sender<String>>>> =
         Arc::new(Mutex::new(HashMap::new()));
+    static ref AGENT_CONFIG: Arc<RwLock<agentConfig>> = Arc::new(RwLock::new(config::agentConfig::new()));
 }
 
 use std::mem::MaybeUninit;
@@ -91,8 +92,9 @@ fn main() -> Result<()> {
 
     lazy_static::initialize(&SHELLS);
 
-    let mut config = config::agentConfig::new();
-
+    lazy_static::initialize(&AGENT_CONFIG);
+    let agentConfig = AGENT_CONFIG.clone();
+    let mut config = agentConfig.write().unwrap();
     config.parse_cmdline(KERNEL_CMDLINE_FILE)?;
 
     let writer = io::stdout();
@@ -301,6 +303,7 @@ use nix::sys::stat::Mode;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
+use crate::config::agentConfig;
 
 fn setup_debug_console(shells: Vec<String>) -> Result<()> {
     for shell in shells.iter() {

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -45,8 +45,6 @@ const ROOTBUSPATH: &'static str = "/devices/pci0000:00";
 const CGROUPPATH: &'static str = "/sys/fs/cgroup";
 const PROCCGROUPS: &'static str = "/proc/cgroups";
 
-pub const TIMEOUT_HOTPLUG: u64 = 3;
-
 #[cfg_attr(rustfmt, rustfmt_skip)]
 lazy_static! {
     pub static ref FLAGS: HashMap<&'static str, (bool, MsFlags)> = {


### PR DESCRIPTION
This adds an option to the agent to control the hotplug timeout of block devices.
Retains the previous behaviour of defaulting to 3 seconds if not specified.
Can be increased when block device hot plugging is taking longer than expected.

fixes #62

Signed-off-by: Alex Price <aprice@atlassian.com>