### PR TITLE
agent: Fix CI and rustfmt issues

### DIFF
--- a/ci/static-checks.sh
+++ b/ci/static-checks.sh
@@ -9,5 +9,4 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
-cd ${TRAVIS_BUILD_DIR}/src/agent
 run_static_checks

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -138,8 +138,8 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Write;
-    use tempfile::tempdir;
     use std::time;
+    use tempfile::tempdir;
 
     const ERR_INVALID_LOG_LEVEL: &str = "invalid log level";
     const ERR_INVALID_LOG_LEVEL_PARAM: &str = "invalid log level parameter";

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -13,11 +13,9 @@ use std::path::Path;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
-use crate::mount::{
-    DRIVERBLKTYPE, DRIVERMMIOBLKTYPE, DRIVERNVDIMMTYPE, DRIVERSCSITYPE,
-};
+use crate::mount::{DRIVERBLKTYPE, DRIVERMMIOBLKTYPE, DRIVERNVDIMMTYPE, DRIVERSCSITYPE};
 use crate::sandbox::Sandbox;
-use crate::{GLOBAL_DEVICE_WATCHER, AGENT_CONFIG};
+use crate::{AGENT_CONFIG, GLOBAL_DEVICE_WATCHER};
 use protocols::agent::Device;
 use protocols::oci::Spec;
 

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -51,9 +51,10 @@ pub mod netlink;
 mod network;
 pub mod random;
 mod sandbox;
+#[cfg(test)]
+mod test_utils;
 mod uevent;
 mod version;
-#[cfg(test)] mod test_utils;
 
 use mount::{cgroups_mount, general_mount};
 use sandbox::Sandbox;
@@ -71,7 +72,8 @@ const CONSOLE_PATH: &'static str = "/dev/console";
 lazy_static! {
     static ref GLOBAL_DEVICE_WATCHER: Arc<Mutex<HashMap<String, Sender<String>>>> =
         Arc::new(Mutex::new(HashMap::new()));
-    static ref AGENT_CONFIG: Arc<RwLock<agentConfig>> = Arc::new(RwLock::new(config::agentConfig::new()));
+    static ref AGENT_CONFIG: Arc<RwLock<agentConfig>> =
+        Arc::new(RwLock::new(config::agentConfig::new()));
 }
 
 use std::mem::MaybeUninit;
@@ -299,12 +301,12 @@ lazy_static! {
 // pub static mut LOG_LEVEL: ;
 // pub static mut TRACE_MODE: ;
 
+use crate::config::agentConfig;
 use nix::fcntl::{self, OFlag};
 use nix::sys::stat::Mode;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
-use crate::config::agentConfig;
 
 fn setup_debug_console(shells: Vec<String>) -> Result<()> {
     for shell in shells.iter() {

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -600,7 +600,7 @@ pub fn get_cgroup_mounts(logger: &Logger, cg_path: &str) -> Result<Vec<INIT_MOUN
                 fstype: "cgroup",
                 src: "cgroup",
                 dest: *value,
-                options: vec!["nosuid", "nodev", "noexec", "relatime", key]
+                options: vec!["nosuid", "nodev", "noexec", "relatime", key],
             });
         }
     }
@@ -688,17 +688,13 @@ fn parse_options(option_list: Vec<String>) -> HashMap<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{skip_if_not_root, skip_loop_if_not_root, skip_loop_if_root};
     use libc::umount;
     use std::fs::File;
     use std::fs::OpenOptions;
     use std::io::Write;
     use std::path::PathBuf;
     use tempfile::tempdir;
-    use crate::{
-        skip_if_not_root,
-        skip_loop_if_not_root,
-        skip_loop_if_root,
-    };
 
     #[derive(Debug, PartialEq)]
     enum TestUserType {


### PR DESCRIPTION
The CI was failing due to two problems.

1. The `ci/static-checks.sh` was run from an incorrect place.
2. `rustfmt` was failing as some code wasn't correctly formatted.

This patch address all the changed requested by rustfmt and the
`static-checks.sh` script was updated

Fixes: #83

Signed-off-by: Erich Cordoba <erich.cordoba.malibran@intel.com>