### PR TITLE
Running rust-agent on AArch64

### DIFF
--- a/src/agent/.cargo/config
+++ b/src/agent/.cargo/config
@@ -1,0 +1,11 @@
+## Copyright (c) 2020 ARM Limited
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+
+[target.aarch64-unknown-linux-musl]
+## The __addtf3, __subtf3 and __multf3 symbols are used by aarch64-musl,
+## but are not provided by rust compiler-builtins.
+## For now, the only functional workaround accepted by rust communities
+## is to get them from libgcc.
+rustflags = [ "-C", "link-arg=-lgcc" ]

--- a/src/agent/.cargo/config
+++ b/src/agent/.cargo/config
@@ -4,6 +4,10 @@
 ##
 
 [target.aarch64-unknown-linux-musl]
+## Only setting linker with `aarch64-linux-musl-gcc`, the
+## `rust-agent` could be totally statically linked.
+linker = "aarch64-linux-musl-gcc"
+
 ## The __addtf3, __subtf3 and __multf3 symbols are used by aarch64-musl,
 ## but are not provided by rust compiler-builtins.
 ## For now, the only functional workaround accepted by rust communities

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -16,7 +16,7 @@ pub const SYSFS_PCI_BUS_RESCAN_FILE: &str = "/sys/bus/pci/rescan";
     target_arch = "x86"
 ))]
 pub const PCI_ROOT_BUS_PATH: &str = "/devices/pci0000:00";
-#[cfg(target_arch = "arm")]
+#[cfg(target_arch = "aarch64")]
 pub const PCI_ROOT_BUS_PATH: &str = "/devices/platform/4010000000.pcie/pci0000:00";
 
 pub const SYSFS_CPU_ONLINE_PATH: &str = "/sys/devices/system/cpu";


### PR DESCRIPTION
# Description of problem
Hi, guys
I'm starting to work on running rust-agent on AArch64.
I'm already found a few bugs:

- **Like Kata Containers, for now, aarch64 is the only supported platform**

```
error[E0425]: cannot find value `PCI_ROOT_BUS_PATH` in this scope
  --> src/uevent.rs:53:41
   |
53 |             && self.devpath.starts_with(PCI_ROOT_BUS_PATH)
   |                                         ^^^^^^^^^^^^^^^^^ not found in this scope

error[E0425]: cannot find value `PCI_ROOT_BUS_PATH` in this scope
  --> src/uevent.rs:72:46
   |
72 |                 let pci_p = format!("{}/{}", PCI_ROOT_BUS_PATH, *dev_addr);
   |                                              ^^^^^^^^^^^^^^^^^ not found in this scope
```

- **Missing symbols on target `aarch64-unknown-linux-musl`**
```
  = note: /root/.rustup/toolchains/stable-aarch64-unknown-linux-gnu/lib/rustlib/aarch64-unknown-linux-musl/lib/liblibc-68fabc677efa98de.rlib(vfprintf.lo): In function `fmt_fp':
          /build/musl-1.1.22/src/stdio/vfprintf.c:210: undefined reference to `__addtf3'
          /build/musl-1.1.22/src/stdio/vfprintf.c:225: undefined reference to `__multf3'
          /build/musl-1.1.22/src/stdio/vfprintf.c:228: undefined reference to `__subtf3'

```
The `__addtf3, __subtf3` and `__multf3` symbols are used by` aarch64-musl`, but are not provided by rust compiler-builtins.
For now, the only temporary but functional [workaround](https://github.com/rust-lang/rust/issues/46651#issuecomment-402850885) accepted by rust communities is to get them from `libgcc`.

**Update:**

- **`no such file` linking error on AArch64**
When using default `cc` linker, we will encounter segfault at runtime. 
Debugging with `rust-gdb`, the specific error is as follows:
```
Program received signal SIGSEGV, Segmentation fault.
0x00000000008973dc in memcpy (dest=0xffffbf6fe7a8 <__stack_chk_guard>, src=<optimized out>,
    n=<optimized out>, n@entry=8) at src/string/memcpy.c:33
33      src/string/memcpy.c: No such file or directory.
```
Only way to work-around here is to change linker with `aarch64-linker-musl-gcc`. 
And finally, `rust-agent` could be totally statically linked and run successfully.
```
$ file kata-agent
kata-agent: ELF 64-bit LSB executable, ARM aarch64, version 1 (GNU/Linux), statically linked, with debug_info, not stripped
```
```
$  ./kata-agent
{"msg":"announce","level":"INFO","ts":"2020-01-06T17:57:50.360950879+08:00","version":"0.1.0","source":"agent","name":"kata-agent","pid":"209146","subsystem":"root","api-version":"0.0.1","agent-type":"rust","agent-commit":"","agent-version":"1.4.5"}
E0106 17:57:50.363890618  209146 socket_utils_common_posix.cc:397] call socket
{"msg":"gRPC server started","level":"INFO","ts":"2020-01-06T17:57:50.365477905+08:00","pid":"209146","version":"0.1.0","name":"kata-agent","subsystem":"grpc","source":"agent"}
{"msg":"listening","level":"INFO","ts":"2020-01-06T17:57:50.365518239+08:00","pid":"209146","source":"agent","subsystem":"grpc","name":"kata-agent","version":"0.1.0","host":"vsock://-1","port":"1024"}

```
