### PR TITLE
ci: Add minimal makefile to use central go test script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+test:
+	bash ci/go-test.sh

--- a/ci/go-test.sh
+++ b/ci/go-test.sh
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+run_go_test

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -33,3 +33,9 @@ run_rust_test()
 	clone_tests_repo
 	bash "$tests_repo_dir/.ci/rust-test.sh"
 }
+
+run_go_test()
+{
+	clone_tests_repo
+	bash "$tests_repo_dir/.ci/go-test.sh"
+}


### PR DESCRIPTION
This adds a basic Makefile where we can use a central go test script
in order to run the tests for the CI.

Fixes #109

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>