### PR TITLE
DNM: Add docker integration tests

### DIFF
--- a/ci/go-test.sh
+++ b/ci/go-test.sh
@@ -8,4 +8,5 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
+export TEST_DOCKER=true
 run_go_test


### PR DESCRIPTION
Enable docker integration tests for rust agent CI.

Fixes #116

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>