### PR TITLE
ci: Remove run_rust_test functions as not being used

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -28,12 +28,6 @@ run_static_checks()
 	bash "$tests_repo_dir/.ci/static-checks.sh" "github.com/kata-containers/kata-containers"
 }
 
-run_rust_test()
-{
-	clone_tests_repo
-	bash "$tests_repo_dir/.ci/rust-test.sh"
-}
-
 run_go_test()
 {
 	clone_tests_repo


### PR DESCRIPTION
This PR removes a function that is never used as the script that is
referring is also non existing at the test repository.

Fixes #113

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>