### PR TITLE
fix the issue of missing restore process's cwd

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -20,6 +20,7 @@ prctl = "1.0.0"
 serde_json = "1.0.39"
 signal-hook = "0.1.9"
 scan_fmt = "0.2.3"
+scopeguard = "1.0.0"
 regex = "1"
 # slog:
 # - Dynamic keys required to allow HashMap keys to be slog::Serialized.

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -21,6 +21,9 @@ extern crate scan_fmt;
 extern crate oci;
 
 #[macro_use]
+extern crate scopeguard;
+
+#[macro_use]
 extern crate slog;
 extern crate slog_async;
 extern crate slog_json;


### PR DESCRIPTION
It should restore to it's previous cwd after it
create container in which it would change it's
cwd to container's bundle path.

Fixes: #126

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>