### PR TITLE
Agent: Separate logging into a single crate

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 
 [dependencies]
 oci = { path = "oci" }
+logging = { path = "logging" }
 rustjail = { path = "rustjail" }
 protocols = { path = "protocols" }
 netlink = { path = "netlink" }
@@ -27,8 +28,6 @@ regex = "1"
 # - The 'max_*' features allow changing the log level at runtime
 #   (by stopping the compiler from removing log calls).
 slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_info"] }
-slog-json = "2.3.0"
-slog-async = "2.3.0"
 slog-scope = "4.1.2"
 # for testing
 tempfile = "3.1.0"

--- a/src/agent/logging/Cargo.toml
+++ b/src/agent/logging/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "logging"
+version = "0.1.0"
+authors = ["Tim Zhang <tim@hyper.sh>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+serde_json = "1.0.39"
+# slog:
+# - Dynamic keys required to allow HashMap keys to be slog::Serialized.
+# - The 'max_*' features allow changing the log level at runtime
+#   (by stopping the compiler from removing log calls).
+slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_info"] }
+slog-json = "2.3.0"
+slog-async = "2.3.0"
+slog-scope = "4.1.2"
+# for testing
+tempfile = "3.1.0"

--- a/src/agent/logging/src/lib.rs
+++ b/src/agent/logging/src/lib.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+#[macro_use]
+extern crate slog;
 
 use slog::{BorrowedKV, Drain, Key, OwnedKV, OwnedKVList, Record, KV};
 use std::collections::HashMap;
@@ -145,12 +147,6 @@ impl<D> RuntimeLevelFilter<D> {
             drain,
             level: Mutex::new(level),
         }
-    }
-
-    fn set_level(&self, level: slog::Level) {
-        let mut log_level = self.level.lock().unwrap();
-
-        *log_level = level;
     }
 }
 

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -25,8 +25,6 @@ extern crate scopeguard;
 
 #[macro_use]
 extern crate slog;
-extern crate slog_async;
-extern crate slog_json;
 #[macro_use]
 extern crate netlink;
 
@@ -50,7 +48,6 @@ use unistd::Pid;
 mod config;
 mod device;
 mod linux_abi;
-mod logging;
 mod mount;
 mod namespace;
 mod network;


### PR DESCRIPTION
Since the codes in logging.rs is weakly related to the project,
separating it from the project will reduce coupling and make it reusable.

Fixes: #131

Signed-off-by: Tim Zhang <tim@hyper.sh>