### PR TITLE
should ignore  invalid a key-value pair as an env

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -682,9 +682,10 @@ fn do_exec(logger: &Logger, path: &str, args: &[String], env: &[String]) -> Resu
     }
 
     for e in env.iter() {
-        let v: Vec<&str> = e.split("=").collect();
+        let v: Vec<&str> = e.splitn(2, "=").collect();
         if v.len() != 2 {
             info!(logger, "incorrect env config!");
+            continue;
         }
         env::set_var(v[0], v[1]);
     }


### PR DESCRIPTION
For cases:

- `a`:  no value, will be omit
- `a=b=c`: key is `a`, value will be `b=c`

Fix #135 

Thanks @jodh-intel  for suggestion.