### PR TITLE
Revert: "Makefile: Fix rust agent build using "--release"."

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -23,12 +23,11 @@ COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)
 # Exported to allow cargo to see it
 export VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
 
-BUILD_TYPE = release
+BUILD_TYPE = debug
 
 ARCH = $(shell uname -m)
 LIBC = musl
 TRIPLE = $(ARCH)-unknown-linux-$(LIBC)
-RUSTFLAGS = -C linker=musl-gcc
 
 TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)
 
@@ -53,7 +52,7 @@ default: $(TARGET) show-header
 $(TARGET): $(TARGET_PATH)
 
 $(TARGET_PATH): $(SOURCES) | show-summary
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
+	@cargo build --target $(TRIPLE)
 
 show-header:
 	@printf "%s - version %s (commit %s)\n\n" "$(TARGET)" "$(VERSION)" "$(COMMIT_MSG)"
@@ -65,10 +64,10 @@ clean:
 	@cargo clean
 
 check:
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo test --target $(TRIPLE) --$(BUILD_TYPE)
+	@cargo test --target $(TRIPLE)
 
 run:
-	@RUSTFLAGS="$(RUSTFLAGS)" cargo run --target $(TRIPLE) --$(BUILD_TYPE)
+	@cargo run --target $(TRIPLE)
 
 show-summary: show-header
 	@printf "project:\n"


### PR DESCRIPTION
This reverts commit a3e46a369f0bd51b146a7f618d50f53258890327.

There is still problem with static link, built binary will
segmentfault on clearlinux. So revert this patch for now.

Depends-on: github.com/kata-containers/tests#2293

Fixes: #69

Signed-off-by: Yang Bo <bo@hyper.sh>