### PR TITLE
systemd-service: build rust-agent systemd services

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -34,6 +34,22 @@ TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)
 DESTDIR :=
 BINDIR := /usr/bin
 
+# Define if agent will be installed as init
+INIT := no
+
+# Path to systemd unit directory if installed as not init.
+UNIT_DIR := /usr/lib/systemd/system
+
+GENERATED_FILES :=
+
+ifeq ($(INIT),no)
+    # Unit file to start kata agent in systemd systems
+    UNIT_FILES = kata-agent.service
+    GENERATED_FILES := $(UNIT_FILES)
+    # Target to be reached in systemd services
+    UNIT_FILES += kata-containers.target
+endif
+
 # Display name of command and it's version (or a message if not available).
 #
 # Arguments:
@@ -47,6 +63,10 @@ define get_toolchain_version
 $(shell printf "%s: %s\\n" "toolchain" "$(or $(shell rustup show active-toolchain 2>/dev/null), (unknown))")
 endef
 
+define INSTALL_FILE
+	install -D -m 644 $1 $(DESTDIR)$2/$1 || exit 1;
+endef
+
 default: $(TARGET) show-header
 
 $(TARGET): $(TARGET_PATH)
@@ -57,7 +77,13 @@ $(TARGET_PATH): $(SOURCES) | show-summary
 show-header:
 	@printf "%s - version %s (commit %s)\n\n" "$(TARGET)" "$(VERSION)" "$(COMMIT_MSG)"
 
-install:
+$(GENERATED_FILES): %: %.in
+	@sed \
+		-e 's|[@]bindir[@]|$(BINDIR)|g' \
+		-e 's|[@]kata-agent[@]|$(TARGET)|g' \
+		"$<" > "$@"
+
+install: build-service
 	@install -D $(TARGET_PATH) $(DESTDIR)/$(BINDIR)/$(TARGET)
 
 clean:
@@ -68,6 +94,12 @@ check:
 
 run:
 	@cargo run --target $(TRIPLE)
+
+build-service: $(GENERATED_FILES)
+ifeq ($(INIT),no)
+	@echo "Installing systemd unit files..."
+	$(foreach f,$(UNIT_FILES),$(call INSTALL_FILE,$f,$(UNIT_DIR)))
+endif
 
 show-summary: show-header
 	@printf "project:\n"

--- a/src/agent/kata-agent.service.in
+++ b/src/agent/kata-agent.service.in
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2018-2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[Unit]
+Description=Kata Containers Agent
+Documentation=https://github.com/kata-containers/kata-containers
+Wants=kata-containers.target
+
+[Service]
+# Send agent output to tty to allow capture debug logs
+# from a VM vsock port
+StandardOutput=tty
+Type=simple
+ExecStart=@bindir@/@kata-agent@
+LimitNOFILE=infinity
+# ExecStop is required for static agent tracing; in all other scenarios
+# the runtime handles shutting down the VM.
+ExecStop=/bin/sync ; /usr/bin/systemctl --force poweroff
+FailureAction=poweroff

--- a/src/agent/kata-containers.target
+++ b/src/agent/kata-containers.target
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2018-2019 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[Unit]
+Description=Kata Containers Agent Target
+Requires=basic.target
+Requires=tmp.mount
+Wants=chronyd.service
+Requires=kata-agent.service
+Conflicts=rescue.service rescue.target
+After=basic.target rescue.service rescue.target
+AllowIsolate=yes

--- a/src/agent/rustjail/Cargo.toml
+++ b/src/agent/rustjail/Cargo.toml
@@ -22,4 +22,4 @@ slog = "2.5.2"
 slog-scope = "4.1.2"
 scan_fmt = "0.2"
 regex = "1.1"
-path-absolutize = { git = "git://github.com/magiclen/path-absolutize.git", tag= "v1.1.3" }
+path-absolutize = { git = "git://github.com/magiclen/path-absolutize.git", tag= "v1.2.0" }


### PR DESCRIPTION
I add another sub-command `build-service` in Makefile to generate rust-agent-related systemd service files, which are necessary for building guest rootfs image.
The whole design is following the one in go-agent. 
And since I just copy the file [kata-conatiners.target](https://github.com/kata-containers/agent/blob/master/kata-containers.target) and [kata-agent.service](https://github.com/kata-containers/agent/blob/master/kata-agent.service.in) and paste them here, I don't change the copyright info in the header. Hope I'm doing the right thing???😜

