### PR TITLE
Refactor the way of creating container process

### DIFF
--- a/src/agent/oci/src/lib.rs
+++ b/src/agent/oci/src/lib.rs
@@ -27,7 +27,7 @@ where
     *d == T::default()
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Spec {
     #[serde(
         default,
@@ -69,7 +69,7 @@ impl Spec {
 
 pub type LinuxRlimit = POSIXRlimit;
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Process {
     #[serde(default)]
     pub terminal: bool,
@@ -112,7 +112,7 @@ pub struct Process {
     pub selinux_label: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxCapabilities {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub bounding: Vec<String>,
@@ -126,7 +126,7 @@ pub struct LinuxCapabilities {
     pub ambient: Vec<String>,
 }
 
-#[derive(Default, Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Box {
     #[serde(default)]
     pub height: u32,
@@ -134,7 +134,7 @@ pub struct Box {
     pub width: u32,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct User {
     #[serde(default)]
     pub uid: u32,
@@ -150,7 +150,7 @@ pub struct User {
     pub username: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Root {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub path: String,
@@ -158,7 +158,7 @@ pub struct Root {
     pub readonly: bool,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Mount {
     #[serde(default)]
     pub destination: String,
@@ -170,7 +170,7 @@ pub struct Mount {
     pub options: Vec<String>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Hook {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub path: String,
@@ -182,7 +182,7 @@ pub struct Hook {
     pub timeout: Option<i32>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Hooks {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub prestart: Vec<Hook>,
@@ -192,7 +192,7 @@ pub struct Hooks {
     pub poststop: Vec<Hook>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Linux {
     #[serde(default, rename = "uidMappings", skip_serializing_if = "Vec::is_empty")]
     pub uid_mappings: Vec<LinuxIDMapping>,
@@ -238,7 +238,7 @@ pub struct Linux {
     pub intel_rdt: Option<LinuxIntelRdt>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxNamespace {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub r#type: LinuxNamespaceType,
@@ -256,7 +256,7 @@ pub const USERNAMESPACE: &str = "user";
 pub const UTSNAMESPACE: &str = "uts";
 pub const CGROUPNAMESPACE: &str = "cgroup";
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxIDMapping {
     #[serde(default, rename = "containerID")]
     pub container_id: u32,
@@ -266,7 +266,7 @@ pub struct LinuxIDMapping {
     pub size: u32,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct POSIXRlimit {
     #[serde(default)]
     pub r#type: String,
@@ -276,7 +276,7 @@ pub struct POSIXRlimit {
     pub soft: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxHugepageLimit {
     #[serde(default, rename = "pageSize", skip_serializing_if = "String::is_empty")]
     pub page_size: String,
@@ -284,7 +284,7 @@ pub struct LinuxHugepageLimit {
     pub limit: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxInterfacePriority {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub name: String,
@@ -292,7 +292,7 @@ pub struct LinuxInterfacePriority {
     pub priority: u32,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxBlockIODevice {
     #[serde(default)]
     pub major: i64,
@@ -300,7 +300,7 @@ pub struct LinuxBlockIODevice {
     pub minor: i64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxWeightDevice {
     pub blk: LinuxBlockIODevice,
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -313,14 +313,14 @@ pub struct LinuxWeightDevice {
     pub leaf_weight: Option<u16>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxThrottleDevice {
     pub blk: LinuxBlockIODevice,
     #[serde(default)]
     pub rate: u64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxBlockIO {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub weight: Option<u16>,
@@ -362,7 +362,7 @@ pub struct LinuxBlockIO {
     pub throttle_write_iops_device: Vec<LinuxThrottleDevice>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxMemory {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<i64>,
@@ -384,7 +384,7 @@ pub struct LinuxMemory {
     pub disable_oom_killer: Option<bool>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxCPU {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shares: Option<u64>,
@@ -410,13 +410,13 @@ pub struct LinuxCPU {
     pub mems: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxPids {
     #[serde(default)]
     pub limit: i64,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxNetwork {
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "classID")]
     pub class_id: Option<u32>,
@@ -424,7 +424,7 @@ pub struct LinuxNetwork {
     pub priorities: Vec<LinuxInterfacePriority>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxRdma {
     #[serde(
         default,
@@ -440,7 +440,7 @@ pub struct LinuxRdma {
     pub hca_objects: Option<u32>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxResources {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub devices: Vec<LinuxDeviceCgroup>,
@@ -464,7 +464,7 @@ pub struct LinuxResources {
     pub rdma: HashMap<String, LinuxRdma>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxDevice {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub path: String,
@@ -482,7 +482,7 @@ pub struct LinuxDevice {
     pub gid: Option<u32>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxDeviceCgroup {
     #[serde(default)]
     pub allow: bool,
@@ -496,7 +496,7 @@ pub struct LinuxDeviceCgroup {
     pub access: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Solaris {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub milestone: String,
@@ -520,13 +520,13 @@ pub struct Solaris {
     pub capped_memory: Option<SolarisCappedMemory>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct SolarisCappedCPU {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub ncpus: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct SolarisCappedMemory {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub physical: String,
@@ -534,7 +534,7 @@ pub struct SolarisCappedMemory {
     pub swap: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct SolarisAnet {
     #[serde(default, skip_serializing_if = "String::is_empty", rename = "linkname")]
     pub link_name: String,
@@ -572,7 +572,7 @@ pub struct SolarisAnet {
     pub mac_address: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct Windows<T> {
     #[serde(
         default,
@@ -594,7 +594,7 @@ pub struct Windows<T> {
     pub network: Option<WindowsNetwork>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct WindowsResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub memory: Option<WindowsMemoryResources>,
@@ -604,13 +604,13 @@ pub struct WindowsResources {
     pub storage: Option<WindowsStorageResources>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct WindowsMemoryResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub limit: Option<u64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct WindowsCPUResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub count: Option<u64>,
@@ -620,7 +620,7 @@ pub struct WindowsCPUResources {
     pub maximum: Option<u64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct WindowsStorageResources {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub iops: Option<u64>,
@@ -634,7 +634,7 @@ pub struct WindowsStorageResources {
     pub sandbox_size: Option<u64>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct WindowsNetwork {
     #[serde(
         default,
@@ -658,7 +658,7 @@ pub struct WindowsNetwork {
     pub network_shared_container_name: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct WindowsHyperV {
     #[serde(
         default,
@@ -668,14 +668,14 @@ pub struct WindowsHyperV {
     pub utility_vm_path: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct VM {
     pub hypervisor: VMHypervisor,
     pub kernel: VMKernel,
     pub image: VMImage,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct VMHypervisor {
     #[serde(default)]
     pub path: String,
@@ -683,7 +683,7 @@ pub struct VMHypervisor {
     pub parameters: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct VMKernel {
     #[serde(default)]
     pub path: String,
@@ -693,7 +693,7 @@ pub struct VMKernel {
     pub initrd: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct VMImage {
     #[serde(default)]
     pub path: String,
@@ -701,7 +701,7 @@ pub struct VMImage {
     pub format: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxSeccomp {
     #[serde(default, rename = "defaultAction")]
     pub default_action: LinuxSeccompAction,
@@ -750,7 +750,7 @@ pub const OPGREATEREQUAL: &str = "SCMP_CMP_GE";
 pub const OPGREATERTHAN: &str = "SCMP_CMP_GT";
 pub const OPMASKEDEQUAL: &str = "SCMP_CMP_MASKED_EQ";
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxSeccompArg {
     #[serde(default)]
     pub index: u32,
@@ -762,7 +762,7 @@ pub struct LinuxSeccompArg {
     pub op: LinuxSeccompOperator,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxSyscall {
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub names: Vec<String>,
@@ -772,7 +772,7 @@ pub struct LinuxSyscall {
     pub args: Vec<LinuxSeccompArg>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct LinuxIntelRdt {
     #[serde(
         default,
@@ -782,7 +782,7 @@ pub struct LinuxIntelRdt {
     pub l3_cache_schema: String,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
 pub struct State {
     #[serde(
         default,

--- a/src/agent/rustjail/src/capabilities.rs
+++ b/src/agent/rustjail/src/capabilities.rs
@@ -9,10 +9,12 @@
 use lazy_static;
 
 use crate::errors::*;
+use crate::log_child;
+use crate::sync::write_count;
 use caps::{self, CapSet, Capability, CapsHashSet};
 use oci::LinuxCapabilities;
-use slog::Logger;
 use std::collections::HashMap;
+use std::os::unix::io::RawFd;
 
 lazy_static! {
     pub static ref CAPSMAP: HashMap<String, Capability> = {
@@ -76,14 +78,14 @@ lazy_static! {
     };
 }
 
-fn to_capshashset(logger: &Logger, caps: &[String]) -> CapsHashSet {
+fn to_capshashset(cfd_log: RawFd, caps: &[String]) -> CapsHashSet {
     let mut r = CapsHashSet::new();
 
     for cap in caps.iter() {
         let c = CAPSMAP.get(cap);
 
         if c.is_none() {
-            warn!(logger, "{} is not a cap", cap);
+            log_child!(cfd_log, "{} is not a cap", cap);
             continue;
         }
 
@@ -98,37 +100,35 @@ pub fn reset_effective() -> Result<()> {
     Ok(())
 }
 
-pub fn drop_priviledges(logger: &Logger, caps: &LinuxCapabilities) -> Result<()> {
-    let logger = logger.new(o!("subsystem" => "capabilities"));
-
+pub fn drop_priviledges(cfd_log: RawFd, caps: &LinuxCapabilities) -> Result<()> {
     let all = caps::all();
 
-    for c in all.difference(&to_capshashset(&logger, caps.bounding.as_ref())) {
+    for c in all.difference(&to_capshashset(cfd_log, caps.bounding.as_ref())) {
         caps::drop(None, CapSet::Bounding, *c)?;
     }
 
     caps::set(
         None,
         CapSet::Effective,
-        to_capshashset(&logger, caps.effective.as_ref()),
+        to_capshashset(cfd_log, caps.effective.as_ref()),
     )?;
     caps::set(
         None,
         CapSet::Permitted,
-        to_capshashset(&logger, caps.permitted.as_ref()),
+        to_capshashset(cfd_log, caps.permitted.as_ref()),
     )?;
     caps::set(
         None,
         CapSet::Inheritable,
-        to_capshashset(&logger, caps.inheritable.as_ref()),
+        to_capshashset(cfd_log, caps.inheritable.as_ref()),
     )?;
 
     if let Err(_) = caps::set(
         None,
         CapSet::Ambient,
-        to_capshashset(&logger, caps.ambient.as_ref()),
+        to_capshashset(cfd_log, caps.ambient.as_ref()),
     ) {
-        warn!(logger, "failed to set ambient capability");
+        log_child!(cfd_log, "failed to set ambient capability");
     }
 
     Ok(())

--- a/src/agent/rustjail/src/capabilities.rs
+++ b/src/agent/rustjail/src/capabilities.rs
@@ -10,7 +10,7 @@ use lazy_static;
 
 use crate::errors::*;
 use caps::{self, CapSet, Capability, CapsHashSet};
-use protocols::oci::LinuxCapabilities;
+use oci::LinuxCapabilities;
 use slog::Logger;
 use std::collections::HashMap;
 
@@ -103,30 +103,30 @@ pub fn drop_priviledges(logger: &Logger, caps: &LinuxCapabilities) -> Result<()>
 
     let all = caps::all();
 
-    for c in all.difference(&to_capshashset(&logger, caps.Bounding.as_ref())) {
+    for c in all.difference(&to_capshashset(&logger, caps.bounding.as_ref())) {
         caps::drop(None, CapSet::Bounding, *c)?;
     }
 
     caps::set(
         None,
         CapSet::Effective,
-        to_capshashset(&logger, caps.Effective.as_ref()),
+        to_capshashset(&logger, caps.effective.as_ref()),
     )?;
     caps::set(
         None,
         CapSet::Permitted,
-        to_capshashset(&logger, caps.Permitted.as_ref()),
+        to_capshashset(&logger, caps.permitted.as_ref()),
     )?;
     caps::set(
         None,
         CapSet::Inheritable,
-        to_capshashset(&logger, caps.Inheritable.as_ref()),
+        to_capshashset(&logger, caps.inheritable.as_ref()),
     )?;
 
     if let Err(_) = caps::set(
         None,
         CapSet::Ambient,
-        to_capshashset(&logger, caps.Ambient.as_ref()),
+        to_capshashset(&logger, caps.ambient.as_ref()),
     ) {
         warn!(logger, "failed to set ambient capability");
     }

--- a/src/agent/rustjail/src/cgroups/mod.rs
+++ b/src/agent/rustjail/src/cgroups/mod.rs
@@ -5,8 +5,8 @@
 
 use crate::errors::*;
 // use crate::configs::{FreezerState, Config};
+use oci::LinuxResources;
 use protocols::agent::CgroupStats;
-use protocols::oci::LinuxResources;
 use std::collections::HashMap;
 
 pub mod fs;

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -44,7 +44,7 @@ use nix::unistd::{self, ForkResult, Gid, Pid, Uid};
 use nix::Error;
 
 use libc;
-use protobuf::{CachedSize, SingularPtrField, UnknownFields};
+use protobuf::SingularPtrField;
 
 use oci::State as OCIState;
 use std::collections::HashMap;

--- a/src/agent/rustjail/src/errors.rs
+++ b/src/agent/rustjail/src/errors.rs
@@ -16,11 +16,13 @@ error_chain! {
         Ffi(std::ffi::NulError);
         Caps(caps::errors::Error);
         Serde(serde_json::Error);
-        UTF8(std::string::FromUtf8Error);
+        FromUTF8(std::string::FromUtf8Error);
         Parse(std::num::ParseIntError);
         Scanfmt(scan_fmt::parse::ScanError);
         Ip(std::net::AddrParseError);
         Regex(regex::Error);
+        EnvVar(std::env::VarError);
+        UTF8(std::str::Utf8Error);
     }
     // define new errors
     errors {

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -68,7 +68,6 @@ pub mod validator;
 
 use std::collections::HashMap;
 use std::mem::MaybeUninit;
-
 use oci::{
     Box as ociBox, Hooks as ociHooks, Linux as ociLinux, LinuxCapabilities as ociLinuxCapabilities,
     Mount as ociMount, POSIXRlimit as ociPOSIXRlimit, Process as ociProcess, Root as ociRoot,
@@ -79,7 +78,7 @@ use protocols::oci::{
     Root as grpcRoot, Spec as grpcSpec,
 };
 
-fn process_grpc_to_oci(p: &grpcProcess) -> ociProcess {
+pub fn process_grpc_to_oci(p: &grpcProcess) -> ociProcess {
     let console_size = if p.ConsoleSize.is_some() {
         let c = p.ConsoleSize.as_ref().unwrap();
         Some(ociBox {
@@ -296,7 +295,7 @@ fn blockio_grpc_to_oci(blk: &grpcLinuxBlockIO) -> ociLinuxBlockIO {
     }
 }
 
-fn resources_grpc_to_oci(res: &grpcLinuxResources) -> ociLinuxResources {
+pub fn resources_grpc_to_oci(res: &grpcLinuxResources) -> ociLinuxResources {
     let devices = {
         let mut d = Vec::new();
         for dev in res.Devices.iter() {

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -42,14 +42,14 @@ macro_rules! sl {
     };
 }
 
+pub mod capabilities;
 pub mod cgroups;
 pub mod container;
 pub mod errors;
 pub mod mount;
 pub mod process;
 pub mod specconv;
-// pub mod sync;
-pub mod capabilities;
+pub mod sync;
 pub mod validator;
 
 // pub mod factory;
@@ -66,8 +66,6 @@ pub mod validator;
 // construtc ociSpec from grpcSpec, which is needed for hook
 // execution. since hooks read config.json
 
-use std::collections::HashMap;
-use std::mem::MaybeUninit;
 use oci::{
     Box as ociBox, Hooks as ociHooks, Linux as ociLinux, LinuxCapabilities as ociLinuxCapabilities,
     Mount as ociMount, POSIXRlimit as ociPOSIXRlimit, Process as ociProcess, Root as ociRoot,
@@ -77,6 +75,8 @@ use protocols::oci::{
     Hooks as grpcHooks, Linux as grpcLinux, Mount as grpcMount, Process as grpcProcess,
     Root as grpcRoot, Spec as grpcSpec,
 };
+use std::collections::HashMap;
+use std::mem::MaybeUninit;
 
 pub fn process_grpc_to_oci(p: &grpcProcess) -> ociProcess {
     let console_size = if p.ConsoleSize.is_some() {

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -26,7 +26,6 @@ use crate::errors::*;
 use lazy_static;
 use std::string::ToString;
 
-use protobuf::{CachedSize, RepeatedField, UnknownFields};
 use slog::Logger;
 
 // Info reveals information about a particular mounted filesystem. This

--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -20,7 +20,7 @@ use nix::unistd::{self, Pid};
 use nix::Result;
 
 use nix::Error;
-use protocols::oci::Process as OCIProcess;
+use oci::Process as OCIProcess;
 use slog::Logger;
 
 #[derive(Debug)]
@@ -104,7 +104,7 @@ impl Process {
 
         info!(logger, "before create console socket!");
 
-        if ocip.Terminal {
+        if ocip.terminal {
             let (psocket, csocket) = match socket::socketpair(
                 AddressFamily::Unix,
                 SockType::Stream,

--- a/src/agent/rustjail/src/specconv.rs
+++ b/src/agent/rustjail/src/specconv.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use protocols::oci::Spec;
+use oci::Spec;
 // use crate::configs::namespaces;
 // use crate::configs::device::Device;
 

--- a/src/agent/rustjail/src/sync.rs
+++ b/src/agent/rustjail/src/sync.rs
@@ -1,0 +1,177 @@
+// Copyright (c) 2019 Ant Financial
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::errors::*;
+use nix::errno::Errno;
+use nix::unistd;
+use nix::Error;
+use std::mem;
+use std::os::unix::io::RawFd;
+
+pub const SYNC_SUCCESS: i32 = 1;
+pub const SYNC_FAILED: i32 = 2;
+pub const SYNC_DATA: i32 = 3;
+
+const DATA_SIZE: usize = 100;
+const MSG_SIZE: usize = mem::size_of::<i32>();
+
+#[macro_export]
+macro_rules! log_child {
+    ($fd:expr, $($arg:tt)+) => ({
+        let lfd = $fd;
+        let mut log_str = format_args!($($arg)+).to_string();
+        log_str.push('\n');
+        write_count(lfd, log_str.as_bytes(), log_str.len());
+    })
+}
+
+pub fn write_count(fd: RawFd, buf: &[u8], count: usize) -> Result<usize> {
+    let mut len = 0;
+
+    loop {
+        match unistd::write(fd, &buf[len..]) {
+            Ok(l) => {
+                len += l;
+                if len == count {
+                    break;
+                }
+            }
+
+            Err(e) => {
+                if e != Error::from_errno(Errno::EINTR) {
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    Ok(len)
+}
+
+fn read_count(fd: RawFd, count: usize) -> Result<Vec<u8>> {
+    let mut v: Vec<u8> = vec![0; count];
+    let mut len = 0;
+
+    loop {
+        match unistd::read(fd, &mut v[len..]) {
+            Ok(l) => {
+                len += l;
+                if len == count || l == 0 {
+                    break;
+                }
+            }
+
+            Err(e) => {
+                if e != Error::from_errno(Errno::EINTR) {
+                    return Err(e.into());
+                }
+            }
+        }
+    }
+
+    Ok(v[0..len].to_vec())
+}
+
+pub fn read_sync(fd: RawFd) -> Result<Vec<u8>> {
+    let buf = read_count(fd, MSG_SIZE)?;
+    if buf.len() != MSG_SIZE {
+        return Err(ErrorKind::ErrorCode(format!(
+            "process: {} failed to receive sync message from peer: got msg length: {}, expected: {}",
+            std::process::id(),
+            buf.len(),
+            MSG_SIZE
+        ))
+        .into());
+    }
+    let buf_array: [u8; MSG_SIZE] = [buf[0], buf[1], buf[2], buf[3]];
+    let msg: i32 = i32::from_be_bytes(buf_array);
+    match msg {
+        SYNC_SUCCESS => return Ok(Vec::new()),
+        SYNC_DATA => {
+            let buf = read_count(fd, MSG_SIZE)?;
+            let buf_array: [u8; MSG_SIZE] = [buf[0], buf[1], buf[2], buf[3]];
+            let msg_length: i32 = i32::from_be_bytes(buf_array);
+            let data_buf = read_count(fd, msg_length as usize)?;
+
+            return Ok(data_buf);
+        }
+        SYNC_FAILED => {
+            let mut error_buf = vec![];
+            loop {
+                let buf = read_count(fd, DATA_SIZE)?;
+
+                error_buf.extend(&buf);
+                if DATA_SIZE == buf.len() {
+                    continue;
+                } else {
+                    break;
+                }
+            }
+
+            let error_str = match std::str::from_utf8(&error_buf) {
+                Ok(v) => v,
+                Err(e) => {
+                    return Err(ErrorKind::ErrorCode(format!(
+                        "receive error message from child process failed: {:?}",
+                        e
+                    ))
+                    .into())
+                }
+            };
+
+            return Err(ErrorKind::ErrorCode(String::from(error_str)).into());
+        }
+        _ => return Err(ErrorKind::ErrorCode("error in receive sync message".to_string()).into()),
+    }
+}
+
+pub fn write_sync(fd: RawFd, msg_type: i32, data_str: &str) -> Result<()> {
+    let buf = msg_type.to_be_bytes();
+
+    let count = write_count(fd, &buf, MSG_SIZE)?;
+    if count != MSG_SIZE {
+        return Err(ErrorKind::ErrorCode("error in send sync message".to_string()).into());
+    }
+
+    match msg_type {
+        SYNC_FAILED => match write_count(fd, data_str.as_bytes(), data_str.len()) {
+            Ok(_count) => unistd::close(fd)?,
+            Err(e) => {
+                unistd::close(fd)?;
+                return Err(
+                    ErrorKind::ErrorCode("error in send message to process".to_string()).into(),
+                );
+            }
+        },
+        SYNC_DATA => {
+            let length: i32 = data_str.len() as i32;
+            match write_count(fd, &length.to_be_bytes(), MSG_SIZE) {
+                Ok(_count) => (),
+                Err(e) => {
+                    unistd::close(fd)?;
+                    return Err(ErrorKind::ErrorCode(
+                        "error in send message to process".to_string(),
+                    )
+                    .into());
+                }
+            }
+
+            match write_count(fd, data_str.as_bytes(), data_str.len()) {
+                Ok(_count) => (),
+                Err(e) => {
+                    unistd::close(fd)?;
+                    return Err(ErrorKind::ErrorCode(
+                        "error in send message to process".to_string(),
+                    )
+                    .into());
+                }
+            }
+        }
+
+        _ => (),
+    };
+
+    Ok(())
+}

--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -4,7 +4,6 @@ use lazy_static;
 use nix::errno::Errno;
 use nix::Error;
 use oci::{LinuxIDMapping, LinuxNamespace, Spec};
-use protobuf::RepeatedField;
 use std::collections::HashMap;
 use std::path::{Component, PathBuf};
 

--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -1,9 +1,15 @@
+// Copyright (c) 2019 Ant Financial
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 use crate::container::Config;
 use crate::errors::*;
 use lazy_static;
 use nix::errno::Errno;
 use nix::Error;
 use oci::{LinuxIDMapping, LinuxNamespace, Spec};
+use protobuf::RepeatedField;
 use std::collections::HashMap;
 use std::path::{Component, PathBuf};
 

--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -3,14 +3,14 @@ use crate::errors::*;
 use lazy_static;
 use nix::errno::Errno;
 use nix::Error;
+use oci::{LinuxIDMapping, LinuxNamespace, Spec};
 use protobuf::RepeatedField;
-use protocols::oci::{LinuxIDMapping, LinuxNamespace, Spec};
 use std::collections::HashMap;
 use std::path::{Component, PathBuf};
 
-fn contain_namespace(nses: &RepeatedField<LinuxNamespace>, key: &str) -> bool {
+fn contain_namespace(nses: &Vec<LinuxNamespace>, key: &str) -> bool {
     for ns in nses {
-        if ns.Type.as_str() == key {
+        if ns.r#type.as_str() == key {
             return true;
         }
     }
@@ -18,10 +18,10 @@ fn contain_namespace(nses: &RepeatedField<LinuxNamespace>, key: &str) -> bool {
     false
 }
 
-fn get_namespace_path(nses: &RepeatedField<LinuxNamespace>, key: &str) -> Result<String> {
+fn get_namespace_path(nses: &Vec<LinuxNamespace>, key: &str) -> Result<String> {
     for ns in nses {
-        if ns.Type.as_str() == key {
-            return Ok(ns.Path.clone());
+        if ns.r#type.as_str() == key {
+            return Ok(ns.path.clone());
         }
     }
 
@@ -71,15 +71,15 @@ fn network(_oci: &Spec) -> Result<()> {
 }
 
 fn hostname(oci: &Spec) -> Result<()> {
-    if oci.Hostname.is_empty() || oci.Hostname == "".to_string() {
+    if oci.hostname.is_empty() || oci.hostname == "".to_string() {
         return Ok(());
     }
 
-    if oci.Linux.is_none() {
+    if oci.linux.is_none() {
         return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
     }
-    let linux = oci.Linux.as_ref().unwrap();
-    if !contain_namespace(&linux.Namespaces, "uts") {
+    let linux = oci.linux.as_ref().unwrap();
+    if !contain_namespace(&linux.namespaces, "uts") {
         return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
     }
 
@@ -87,12 +87,12 @@ fn hostname(oci: &Spec) -> Result<()> {
 }
 
 fn security(oci: &Spec) -> Result<()> {
-    let linux = oci.Linux.as_ref().unwrap();
-    if linux.MaskedPaths.len() == 0 && linux.ReadonlyPaths.len() == 0 {
+    let linux = oci.linux.as_ref().unwrap();
+    if linux.masked_paths.len() == 0 && linux.readonly_paths.len() == 0 {
         return Ok(());
     }
 
-    if !contain_namespace(&linux.Namespaces, "mount") {
+    if !contain_namespace(&linux.namespaces, "mount") {
         return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
     }
 
@@ -101,9 +101,9 @@ fn security(oci: &Spec) -> Result<()> {
     Ok(())
 }
 
-fn idmapping(maps: &RepeatedField<LinuxIDMapping>) -> Result<()> {
+fn idmapping(maps: &Vec<LinuxIDMapping>) -> Result<()> {
     for map in maps {
-        if map.Size > 0 {
+        if map.size > 0 {
             return Ok(());
         }
     }
@@ -112,19 +112,19 @@ fn idmapping(maps: &RepeatedField<LinuxIDMapping>) -> Result<()> {
 }
 
 fn usernamespace(oci: &Spec) -> Result<()> {
-    let linux = oci.Linux.as_ref().unwrap();
-    if contain_namespace(&linux.Namespaces, "user") {
+    let linux = oci.linux.as_ref().unwrap();
+    if contain_namespace(&linux.namespaces, "user") {
         let user_ns = PathBuf::from("/proc/self/ns/user");
         if !user_ns.exists() {
             return Err(ErrorKind::ErrorCode("user namespace not supported!".to_string()).into());
         }
         // check if idmappings is correct, at least I saw idmaps
         // with zero size was passed to agent
-        idmapping(&linux.UIDMappings)?;
-        idmapping(&linux.GIDMappings)?;
+        idmapping(&linux.uid_mappings)?;
+        idmapping(&linux.gid_mappings)?;
     } else {
         // no user namespace but idmap
-        if linux.UIDMappings.len() != 0 || linux.GIDMappings.len() != 0 {
+        if linux.uid_mappings.len() != 0 || linux.gid_mappings.len() != 0 {
             return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
         }
     }
@@ -133,8 +133,8 @@ fn usernamespace(oci: &Spec) -> Result<()> {
 }
 
 fn cgroupnamespace(oci: &Spec) -> Result<()> {
-    let linux = oci.Linux.as_ref().unwrap();
-    if contain_namespace(&linux.Namespaces, "cgroup") {
+    let linux = oci.linux.as_ref().unwrap();
+    if contain_namespace(&linux.namespaces, "cgroup") {
         let path = PathBuf::from("/proc/self/ns/cgroup");
         if !path.exists() {
             return Err(ErrorKind::ErrorCode("cgroup unsupported!".to_string()).into());
@@ -178,10 +178,10 @@ fn check_host_ns(path: &str) -> Result<()> {
 }
 
 fn sysctl(oci: &Spec) -> Result<()> {
-    let linux = oci.Linux.as_ref().unwrap();
-    for (key, _) in linux.Sysctl.iter() {
+    let linux = oci.linux.as_ref().unwrap();
+    for (key, _) in linux.sysctl.iter() {
         if SYSCTLS.contains_key(key.as_str()) || key.starts_with("fs.mqueue.") {
-            if contain_namespace(&linux.Namespaces, "ipc") {
+            if contain_namespace(&linux.namespaces, "ipc") {
                 continue;
             } else {
                 return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
@@ -189,11 +189,11 @@ fn sysctl(oci: &Spec) -> Result<()> {
         }
 
         if key.starts_with("net.") {
-            if !contain_namespace(&linux.Namespaces, "network") {
+            if !contain_namespace(&linux.namespaces, "network") {
                 return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
             }
 
-            let net = get_namespace_path(&linux.Namespaces, "network")?;
+            let net = get_namespace_path(&linux.namespaces, "network")?;
             if net.is_empty() || net == "".to_string() {
                 continue;
             }
@@ -201,7 +201,7 @@ fn sysctl(oci: &Spec) -> Result<()> {
             check_host_ns(net.as_str())?;
         }
 
-        if contain_namespace(&linux.Namespaces, "uts") {
+        if contain_namespace(&linux.namespaces, "uts") {
             if key == "kernel.domainname" {
                 continue;
             }
@@ -217,21 +217,21 @@ fn sysctl(oci: &Spec) -> Result<()> {
 }
 
 fn rootless_euid_mapping(oci: &Spec) -> Result<()> {
-    let linux = oci.Linux.as_ref().unwrap();
-    if !contain_namespace(&linux.Namespaces, "user") {
+    let linux = oci.linux.as_ref().unwrap();
+    if !contain_namespace(&linux.namespaces, "user") {
         return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
     }
 
-    if linux.UIDMappings.len() == 0 || linux.GIDMappings.len() == 0 {
+    if linux.gid_mappings.len() == 0 || linux.gid_mappings.len() == 0 {
         return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
     }
 
     Ok(())
 }
 
-fn has_idmapping(maps: &RepeatedField<LinuxIDMapping>, id: u32) -> bool {
+fn has_idmapping(maps: &Vec<LinuxIDMapping>, id: u32) -> bool {
     for map in maps {
-        if id >= map.ContainerID && id < map.ContainerID + map.Size {
+        if id >= map.container_id && id < map.container_id + map.size {
             return true;
         }
     }
@@ -239,9 +239,9 @@ fn has_idmapping(maps: &RepeatedField<LinuxIDMapping>, id: u32) -> bool {
 }
 
 fn rootless_euid_mount(oci: &Spec) -> Result<()> {
-    let linux = oci.Linux.as_ref().unwrap();
+    let linux = oci.linux.as_ref().unwrap();
 
-    for mnt in oci.Mounts.iter() {
+    for mnt in oci.mounts.iter() {
         for opt in mnt.options.iter() {
             if opt.starts_with("uid=") || opt.starts_with("gid=") {
                 let fields: Vec<&str> = opt.split('=').collect();
@@ -253,13 +253,13 @@ fn rootless_euid_mount(oci: &Spec) -> Result<()> {
                 let id = fields[1].trim().parse::<u32>()?;
 
                 if opt.starts_with("uid=") {
-                    if !has_idmapping(&linux.UIDMappings, id) {
+                    if !has_idmapping(&linux.uid_mappings, id) {
                         return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
                     }
                 }
 
                 if opt.starts_with("gid=") {
-                    if !has_idmapping(&linux.GIDMappings, id) {
+                    if !has_idmapping(&linux.gid_mappings, id) {
                         return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
                     }
                 }
@@ -279,14 +279,14 @@ pub fn validate(conf: &Config) -> Result<()> {
     lazy_static::initialize(&SYSCTLS);
     let oci = conf.spec.as_ref().unwrap();
 
-    if oci.Linux.is_none() {
+    if oci.linux.is_none() {
         return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
     }
 
-    if oci.Root.is_none() {
+    if oci.root.is_none() {
         return Err(ErrorKind::Nix(Error::from_errno(Errno::EINVAL)).into());
     }
-    let root = oci.Root.get_ref().Path.as_str();
+    let root = oci.root.as_ref().unwrap().path.as_str();
 
     rootfs(root)?;
     network(oci)?;

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -15,7 +15,7 @@ use crate::mount::{DRIVERBLKTYPE, DRIVERMMIOBLKTYPE, DRIVERNVDIMMTYPE, DRIVERSCS
 use crate::sandbox::Sandbox;
 use crate::{AGENT_CONFIG, GLOBAL_DEVICE_WATCHER};
 use protocols::agent::Device;
-use protocols::oci::Spec;
+use oci::Spec;
 use rustjail::errors::*;
 
 // Convenience macro to obtain the scope logger
@@ -207,7 +207,7 @@ fn update_spec_device_list(device: &Device, spec: &mut Spec) -> Result<()> {
         .into());
     }
 
-    let linux = match spec.Linux.as_mut() {
+    let linux = match spec.linux.as_mut() {
         None => {
             return Err(
                 ErrorKind::ErrorCode("Spec didn't container linux field".to_string()).into(),
@@ -232,14 +232,14 @@ fn update_spec_device_list(device: &Device, spec: &mut Spec) -> Result<()> {
         "got the device: dev_path: {}, major: {}, minor: {}\n", &device.vm_path, major_id, minor_id
     );
 
-    let devices = linux.Devices.as_mut_slice();
+    let devices = linux.devices.as_mut_slice();
     for dev in devices.iter_mut() {
-        if dev.Path == device.container_path {
-            let host_major = dev.Major;
-            let host_minor = dev.Minor;
+        if dev.path == device.container_path {
+            let host_major = dev.major;
+            let host_minor = dev.minor;
 
-            dev.Major = major_id as i64;
-            dev.Minor = minor_id as i64;
+            dev.major = major_id as i64;
+            dev.minor = minor_id as i64;
 
             info!(
                 sl!(),
@@ -252,12 +252,12 @@ fn update_spec_device_list(device: &Device, spec: &mut Spec) -> Result<()> {
 
             // Resources must be updated since they are used to identify the
             // device in the devices cgroup.
-            if let Some(res) = linux.Resources.as_mut() {
-                let ds = res.Devices.as_mut_slice();
+            if let Some(res) = linux.resources.as_mut() {
+                let ds = res.devices.as_mut_slice();
                 for d in ds.iter_mut() {
-                    if d.Major == host_major && d.Minor == host_minor {
-                        d.Major = major_id as i64;
-                        d.Minor = minor_id as i64;
+                    if d.major == Some(host_major) && d.minor == Some(host_minor) {
+                        d.major = Some(major_id as i64);
+                        d.minor = Some(minor_id as i64);
 
                         info!(
                             sl!(),

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -14,8 +14,8 @@ use crate::linux_abi::*;
 use crate::mount::{DRIVERBLKTYPE, DRIVERMMIOBLKTYPE, DRIVERNVDIMMTYPE, DRIVERSCSITYPE};
 use crate::sandbox::Sandbox;
 use crate::{AGENT_CONFIG, GLOBAL_DEVICE_WATCHER};
-use protocols::agent::Device;
 use oci::Spec;
+use protocols::agent::Device;
 use rustjail::errors::*;
 
 // Convenience macro to obtain the scope logger

--- a/src/agent/src/grpc.rs
+++ b/src/agent/src/grpc.rs
@@ -578,11 +578,11 @@ impl protocols::agent_grpc::AgentService for agentService {
         req: protocols::agent::ExecProcessRequest,
         sink: ::grpcio::UnarySink<protocols::empty::Empty>,
     ) {
-        if let Err(_) = self.do_exec_process(req) {
+        if let Err(e) = self.do_exec_process(req) {
             let f = sink
                 .fail(RpcStatus::new(
                     RpcStatusCode::Internal,
-                    Some(String::from("fail to exec process!")),
+                    Some(format!("{}", e)),
                 ))
                 .map_err(|_e| error!(sl!(), "fail to exec process!"));
             ctx.spawn(f);

--- a/src/agent/src/grpc.rs
+++ b/src/agent/src/grpc.rs
@@ -8,6 +8,7 @@ use grpcio::{EnvBuilder, Server, ServerBuilder};
 use grpcio::{RpcStatus, RpcStatusCode};
 use std::sync::{Arc, Mutex};
 
+use oci::{LinuxNamespace, Spec};
 use protobuf::{RepeatedField, SingularPtrField};
 use protocols::agent::CopyFileRequest;
 use protocols::agent::{
@@ -16,7 +17,6 @@ use protocols::agent::{
 };
 use protocols::empty::Empty;
 use protocols::health::{HealthCheckResponse, HealthCheckResponse_ServingStatus};
-use protocols::oci::{LinuxNamespace, Spec};
 use rustjail;
 use rustjail::container::{BaseContainer, LinuxContainer};
 use rustjail::errors::*;
@@ -81,8 +81,8 @@ impl agentService {
         let sandbox;
         let mut s;
 
-        let oci = match oci_spec.as_mut() {
-            Some(spec) => spec,
+        let mut oci = match oci_spec.as_mut() {
+            Some(spec) => rustjail::grpc_to_oci(spec),
             None => {
                 error!(sl!(), "no oci spec in the create container request!");
                 return Err(
@@ -103,7 +103,7 @@ impl agentService {
         // updates the devices listed in the OCI spec, so that they actually
         // match real devices inside the VM. This step is necessary since we
         // cannot predict everything from the caller.
-        add_devices(&req.devices.to_vec(), oci, &self.sandbox)?;
+        add_devices(&req.devices.to_vec(), &mut oci, &self.sandbox)?;
 
         // Both rootfs and volumes (invoked with --volume for instance) will
         // be processed the same way. The idea is to always mount any provided
@@ -119,11 +119,11 @@ impl agentService {
             s.container_mounts.insert(cid.clone(), m);
         }
 
-        update_container_namespaces(&s, oci)?;
+        update_container_namespaces(&s, &mut oci)?;
 
         // write spec to bundle path, hooks might
         // read ocispec
-        let olddir = setup_bundle(oci)?;
+        let olddir = setup_bundle(&oci)?;
         // restore the cwd for kata-agent process.
         defer!(unistd::chdir(&olddir).unwrap());
 
@@ -141,8 +141,14 @@ impl agentService {
             LinuxContainer::new(cid.as_str(), CONTAINER_BASE, opts, &sl!())?;
 
         let pipe_size = AGENT_CONFIG.read().unwrap().container_pipe_size;
-        let p = if oci.Process.is_some() {
-            let tp = Process::new(&sl!(), oci.get_Process(), eid.as_str(), true, pipe_size)?;
+        let p = if oci.process.is_some() {
+            let tp = Process::new(
+                &sl!(),
+                &oci.process.as_ref().unwrap(),
+                eid.as_str(),
+                true,
+                pipe_size,
+            )?;
             tp
         } else {
             info!(sl!(), "no process configurations!");
@@ -270,14 +276,15 @@ impl agentService {
         let mut sandbox = s.lock().unwrap();
 
         // ignore string_user, not sure what it is
-        let ocip = if req.process.is_some() {
+        let process = if req.process.is_some() {
             req.process.as_ref().unwrap()
         } else {
             return Err(ErrorKind::Nix(nix::Error::from_errno(nix::errno::Errno::EINVAL)).into());
         };
 
         let pipe_size = AGENT_CONFIG.read().unwrap().container_pipe_size;
-        let p = Process::new(&sl!(), ocip, exec_id.as_str(), false, pipe_size)?;
+        let ocip = rustjail::process_grpc_to_oci(process);
+        let p = Process::new(&sl!(), &ocip, exec_id.as_str(), false, pipe_size)?;
 
         let ctr = match sandbox.get_container(cid.as_str()) {
             Some(v) => v,
@@ -732,7 +739,7 @@ impl protocols::agent_grpc::AgentService for agentService {
         sink: ::grpcio::UnarySink<protocols::empty::Empty>,
     ) {
         let cid = req.container_id.clone();
-        let res = req.resources.clone();
+        let res = req.resources;
 
         let s = Arc::clone(&self.sandbox);
         let mut sandbox = s.lock().unwrap();
@@ -742,7 +749,8 @@ impl protocols::agent_grpc::AgentService for agentService {
         let resp = Empty::new();
 
         if res.is_some() {
-            match ctr.set(res.unwrap()) {
+            let ociRes = rustjail::resources_grpc_to_oci(&res.unwrap());
+            match ctr.set(ociRes) {
                 Err(_e) => {
                     let f = sink
                         .fail(RpcStatus::new(
@@ -1605,7 +1613,7 @@ pub fn start<S: Into<String>>(sandbox: Arc<Mutex<Sandbox>>, host: S, port: u16) 
 // sense to rely on the namespace path provided by the host since namespaces
 // are different inside the guest.
 fn update_container_namespaces(sandbox: &Sandbox, spec: &mut Spec) -> Result<()> {
-    let linux = match spec.Linux.as_mut() {
+    let linux = match spec.linux.as_mut() {
         None => {
             return Err(
                 ErrorKind::ErrorCode("Spec didn't container linux field".to_string()).into(),
@@ -1616,26 +1624,26 @@ fn update_container_namespaces(sandbox: &Sandbox, spec: &mut Spec) -> Result<()>
 
     let mut pidNs = false;
 
-    let namespaces = linux.Namespaces.as_mut_slice();
+    let namespaces = linux.namespaces.as_mut_slice();
     for namespace in namespaces.iter_mut() {
-        if namespace.Type == NSTYPEPID {
+        if namespace.r#type == NSTYPEPID {
             pidNs = true;
             continue;
         }
-        if namespace.Type == NSTYPEIPC {
-            namespace.Path = sandbox.shared_ipcns.path.clone();
+        if namespace.r#type == NSTYPEIPC {
+            namespace.path = sandbox.shared_ipcns.path.clone();
             continue;
         }
-        if namespace.Type == NSTYPEUTS {
-            namespace.Path = sandbox.shared_utsns.path.clone();
+        if namespace.r#type == NSTYPEUTS {
+            namespace.path = sandbox.shared_utsns.path.clone();
             continue;
         }
     }
 
     if !pidNs && !sandbox.sandbox_pid_ns {
-        let mut pid_ns = LinuxNamespace::new();
-        pid_ns.set_Type(NSTYPEPID.to_string());
-        linux.Namespaces.push(pid_ns);
+        let mut pid_ns = LinuxNamespace::default();
+        pid_ns.r#type = NSTYPEPID.to_string();
+        linux.namespaces.push(pid_ns);
     }
 
     Ok(())
@@ -1764,24 +1772,23 @@ fn do_copy_file(req: &CopyFileRequest) -> Result<()> {
     Ok(())
 }
 
-fn setup_bundle(gspec: &Spec) -> Result<PathBuf> {
-    if gspec.Root.is_none() {
+fn setup_bundle(spec: &Spec) -> Result<PathBuf> {
+    if spec.root.is_none() {
         return Err(nix::Error::Sys(Errno::EINVAL).into());
     }
-    let root = gspec.Root.as_ref().unwrap().Path.as_str();
+    let root = spec.root.as_ref().unwrap().path.as_str();
 
     let rootfs = fs::canonicalize(root)?;
     let bundle_path = rootfs.parent().unwrap().to_str().unwrap();
 
     let config = format!("{}/{}", bundle_path, "config.json");
 
-    let oci = rustjail::grpc_to_oci(gspec);
     info!(
         sl!(),
         "{:?}",
-        oci.process.as_ref().unwrap().console_size.as_ref()
+        spec.process.as_ref().unwrap().console_size.as_ref()
     );
-    let _ = oci.save(config.as_str());
+    let _ = spec.save(config.as_str());
 
     let olddir = unistd::getcwd().chain_err(|| "cannot getcwd")?;
     unistd::chdir(bundle_path)?;

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -10,14 +10,14 @@
 #![allow(non_snake_case)]
 #[macro_use]
 extern crate lazy_static;
+extern crate oci;
 extern crate prctl;
 extern crate protocols;
 extern crate regex;
 extern crate rustjail;
+extern crate scan_fmt;
 extern crate serde_json;
 extern crate signal_hook;
-extern crate scan_fmt;
-extern crate oci;
 
 #[macro_use]
 extern crate scopeguard;
@@ -100,6 +100,10 @@ fn announce(logger: &Logger) {
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
+    if args.len() == 2 && args[1] == "init" {
+        rustjail::container::init_child();
+        exit(0);
+    }
 
     env::set_var("RUST_BACKTRACE", "full");
 

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -16,7 +16,6 @@ extern crate regex;
 extern crate rustjail;
 extern crate serde_json;
 extern crate signal_hook;
-#[macro_use]
 extern crate scan_fmt;
 extern crate oci;
 

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -282,7 +282,7 @@ mod tests {
     use super::Sandbox;
     use crate::{mount::BareMount, skip_if_not_root};
     use nix::mount::MsFlags;
-    use protocols::oci::{Linux, Root, Spec};
+    use oci::{Linux, Root, Spec};
     use rustjail::container::LinuxContainer;
     use rustjail::specconv::CreateOpts;
     use slog::Logger;
@@ -489,13 +489,13 @@ mod tests {
     }
 
     fn create_dummy_opts() -> CreateOpts {
-        let mut root = Root::new();
-        root.Path = String::from("/");
+        let mut root = Root::default();
+        root.path = String::from("/");
 
-        let linux = Linux::new();
-        let mut spec = Spec::new();
-        spec.Root = Some(root).into();
-        spec.Linux = Some(linux).into();
+        let linux = Linux::default();
+        let mut spec = Spec::default();
+        spec.root = Some(root).into();
+        spec.linux = Some(linux).into();
 
         CreateOpts {
             cgroup_name: "".to_string(),


### PR DESCRIPTION
In the previous implementation, create a container process
by forking the parent process as the container process,
and then at the forked child process do much more setting,
such as rootfs mounting, drop capabilities and so on, at
last exec the container entry cmd to switch into container
process.

But since the parent is a muti thread process, which would
cause a dead lock in the forked child. For example, if one
of the parent process's thread do some malloc operation, which
would take a mutex lock, and at the same time, the parent forked
a child process, since the mutex lock status would be inherited
by the child process but there's no chance to release the lock
in the child since the child process only has a single thread
which would meet a dead lock if it would do some malloc operation.

Thus, the new implementation would do exec directly after forked
and then do the setting in the exec process. Of course, this requred
a data communication between parent and child since the child cannot
depends on the shared memory by fork way.
