### PR TITLE
sandbox: fix the issue of missing setting hostname

### DIFF
--- a/src/agent/src/grpc.rs
+++ b/src/agent/src/grpc.rs
@@ -284,7 +284,7 @@ impl agentService {
 
         let pipe_size = AGENT_CONFIG.read().unwrap().container_pipe_size;
         let ocip = rustjail::process_grpc_to_oci(process);
-        let p = Process::new(&sl!(), &ocip, cid.as_str(), false, pipe_size)?;
+        let p = Process::new(&sl!(), &ocip, exec_id.as_str(), false, pipe_size)?;
 
         let ctr = match sandbox.get_container(cid.as_str()) {
             Some(v) => v,

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -171,7 +171,10 @@ impl Sandbox {
         };
 
         // // Set up shared UTS namespace
-        self.shared_utsns = match Namespace::new(&self.logger).as_uts().setup() {
+        self.shared_utsns = match Namespace::new(&self.logger)
+            .as_uts(self.hostname.as_str())
+            .setup()
+        {
             Ok(ns) => ns,
             Err(err) => {
                 return Err(ErrorKind::ErrorCode(format!(


### PR DESCRIPTION
When setup the persisten uts namespace, it's should
set the hostname for this ns.

Fixes: #175

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>