### PR TITLE
license: add license header

### DIFF
--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -1,3 +1,8 @@
+// Copyright (c) 2019 Ant Financial
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
 use crate::container::Config;
 use crate::errors::*;
 use lazy_static;


### PR DESCRIPTION
add license header to `src/agent/rustjail/src/validator.rs`

Fixes: #184.

Signed-off-by: Salvador Fuentes <salvador.fuentes@intel.com>