### PR TITLE
backport: release: actions: pin artifact to v1

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,7 +17,7 @@ jobs:
          popd
          ./packaging/artifact-list.sh > artifact-list.txt
       - name: save-artifact-list
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: artifact-list
           path: artifact-list.txt
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifact-list
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: artifact-list
       - run: |
@@ -45,7 +45,7 @@ jobs:
          fi
       - name: store-artifacts
         if: env.artifact-built == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
           path: kata-static-kernel.tar.gz
@@ -58,7 +58,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifact-list
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: artifact-list
       - run: |
@@ -73,7 +73,7 @@ jobs:
          fi
       - name: store-artifacts
         if: env.artifact-built == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
           path: kata-static-experimental-kernel.tar.gz
@@ -86,7 +86,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifact-list
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: artifact-list
       - name: build-qemu
@@ -99,7 +99,7 @@ jobs:
          fi
       - name: store-artifacts
         if: env.artifact-built == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
           path: kata-static-qemu.tar.gz
@@ -112,7 +112,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifact-list
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: artifact-list
       - name: build-nemu
@@ -125,7 +125,7 @@ jobs:
          fi
       - name: store-artifacts
         if: env.artifact-built == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
           path: kata-static-nemu.tar.gz
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifact-list
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: artifact-list
       - name: build-qemu-virtiofsd
@@ -152,7 +152,7 @@ jobs:
          fi
       - name: store-artifacts
         if: env.artifact-built == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
           path: kata-static-qemu-virtiofsd.tar.gz
@@ -166,7 +166,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifact-list
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: artifact-list
       - name: build-image
@@ -179,7 +179,7 @@ jobs:
          fi
       - name: store-artifacts
         if: env.artifact-built == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
           path: kata-static-image.tar.gz
@@ -193,7 +193,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifact-list
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: artifact-list
       - name: build-firecracker
@@ -206,7 +206,7 @@ jobs:
          fi
       - name: store-artifacts
         if: env.artifact-built == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
           path: kata-static-firecracker.tar.gz
@@ -220,7 +220,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifact-list
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: artifact-list
       - name: build-clh
@@ -233,7 +233,7 @@ jobs:
          fi
       - name: store-artifacts
         if: env.artifact-built == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
           path: kata-static-clh.tar.gz
@@ -247,7 +247,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifact-list
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: artifact-list
       - name: build-kata-components
@@ -260,7 +260,7 @@ jobs:
          fi
       - name: store-artifacts
         if: env.artifact-built == 'true'
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
           path: kata-static-kata-components.tar.gz
@@ -271,14 +271,14 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: get-artifacts
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: kata-artifacts
       - name: colate-artifacts
         run: |
           $GITHUB_WORKSPACE/.github/workflows/gather-artifacts.sh
       - name: store-artifacts
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v1
         with:
           name: release-candidate
           path: kata-static.tar.xz
@@ -288,7 +288,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: get-artifacts
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: release-candidate
       - name: build-and-push-kata-deploy-ci
@@ -329,7 +329,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: download-artifacts
-        uses: actions/download-artifact@master
+        uses: actions/download-artifact@v1
         with:
           name: release-candidate
       - name: install hub


### PR DESCRIPTION
the actions upload/download-artifact moved to a new version
and master now is not comptible.

Fixes: #211

Signed-off-by: Jose Carlos Venegas Munoz <jose.carlos.venegas.munoz@intel.com>