### PR TITLE
ci: install rust back to 1.42.0 to avoid ci failure.

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -72,6 +72,9 @@ default: $(TARGET) show-header
 $(TARGET): $(TARGET_PATH)
 
 $(TARGET_PATH): $(SOURCES) | show-summary
+	@rustup default 1.42.0
+	@rustup toolchain install 1.42.0-musl
+	@rustup target add $(ARCH)-unknown-linux-musl
 	@cargo build --target $(TRIPLE)
 
 show-header:


### PR DESCRIPTION
There maybe a bug in the 1.43.1 cargo, so we need install rust back
to 1.42.0 to avoid the failure when make the rust agent using the latest
rust.
also, I raise an issue in cargo community, see https://github.com/rust-lang/cargo/issues/8258 
Fixes: #202
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@GabyCT @jodh-intel  @grahamwhaley 