### PR TITLE
agent: fix make generate-protocols errors

### DIFF
--- a/src/agent/protocols/hack/update-generated-proto.sh
+++ b/src/agent/protocols/hack/update-generated-proto.sh
@@ -47,7 +47,7 @@ show_usage() {
 }
 
 generate_go_sources() {
-    local cmd="protoc -I$GOPATH/src/github.com/kata-containers/agent/vendor/github.com/gogo/protobuf:$GOPATH/src/github.com/kata-containers/agent/vendor:$GOPATH/src/github.com/gogo/protobuf:$GOPATH/src/github.com/gogo/googleapis:$GOPATH/src:/usr/local/include:$GOPATH/src/github.com/kata-containers/kata-containers/src/agent/protocols/protos \
+    local cmd="protoc -I$GOPATH/src/github.com/kata-containers/agent/vendor/github.com/gogo/protobuf:$GOPATH/src/github.com/kata-containers/agent/vendor:$GOPATH/src/github.com/gogo/protobuf:$GOPATH/src/github.com/gogo/googleapis:$GOPATH/src:$GOPATH/src/github.com/kata-containers/kata-containers/src/agent/protocols/protos \
 --gogottrpc_out=plugins=ttrpc+fieldpath,\
 import_path=github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc,\
 \
@@ -68,7 +68,7 @@ generate_rust_sources() {
     local cmd="protoc --rust_out=./protocols/src/ \
 --ttrpc_out=./protocols/src/,plugins=ttrpc:./protocols/src/ \
 --plugin=protoc-gen-ttrpc=`which ttrpc_rust_plugin` \
--I $GOPATH/src/github.com/kata-containers/agent/vendor/github.com/gogo/protobuf:$GOPATH/src/github.com/kata-containers/agent/vendor:$GOPATH/src/github.com/gogo/protobuf:$GOPATH/src/github.com/gogo/googleapis:$GOPATH/src:/usr/local/include:$GOPATH/src/github.com/kata-containers/kata-containers/src/agent/protocols/protos \
+-I $GOPATH/src/github.com/kata-containers/agent/vendor/github.com/gogo/protobuf:$GOPATH/src/github.com/kata-containers/agent/vendor:$GOPATH/src/github.com/gogo/protobuf:$GOPATH/src/github.com/gogo/googleapis:$GOPATH/src:$GOPATH/src/github.com/kata-containers/kata-containers/src/agent/protocols/protos \
 $GOPATH/src/github.com/kata-containers/kata-containers/src/agent/protocols/protos/$1"
 
     echo $cmd


### PR DESCRIPTION
Got:
make PROTO_FILE=agent.proto generate-protocol
google/protobuf/descriptor.proto: Read access is denied for file: /usr/local/include/google/protobuf/descriptor.proto

This commit will fix this error.

Signed-off-by: Tim Zhang <tim@hyper.sh>