### PR TITLE
runtime: Add podman and containerd shim v2 to data collection script

### DIFF
--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -356,6 +356,11 @@ show_container_mgr_details()
 		run_cmd_and_show_quoted_output "" "cat /etc/containerd/config.toml"
 	fi
 
+	if have_cmd "podman"; then
+		subheading "podman"
+		run_cmd_and_show_quoted_output "" "podman --version"
+	fi
+
 	separator
 }
 

--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -241,6 +241,14 @@ find_system_journal_problems()
 	fi
 }
 
+show_containerd_shimv2_log_details()
+{
+	local name="Kata Containerd Shim v2"
+	subheading "$name logs"
+
+	find_system_journal_problems "$name" "kata"
+}
+
 show_proxy_log_details()
 {
 	subheading "Proxy logs"
@@ -277,6 +285,7 @@ show_log_details()
 	show_proxy_log_details
 	show_shim_log_details
 	show_throttler_log_details
+	show_containerd_shimv2_log_details
 
 	separator
 }

--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -292,8 +292,8 @@ show_package_versions()
 	# CC 2.x, 3.0 and runv runtimes. They shouldn't be installed but let's
 	# check anyway.
 	pattern+="cc-oci-runtime"
-	pattern+="cc-runtime"
-	pattern+="runv"
+	pattern+="|cc-runtime"
+	pattern+="|runv"
 
 	# core components
 	for project in @PROJECT_TYPE@

--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -217,25 +217,6 @@ show_runtime_configs()
 	separator
 }
 
-show_log_details()
-{
-	heading "Logfiles"
-
-	show_runtime_log_details
-	show_proxy_log_details
-	show_shim_log_details
-	show_throttler_log_details
-
-	separator
-}
-
-show_runtime_log_details()
-{
-	subheading "Runtime logs"
-
-	find_system_journal_problems "runtime" "@RUNTIME_NAME@" ""
-}
-
 find_system_journal_problems()
 {
 	local name="$1"
@@ -268,6 +249,13 @@ show_proxy_log_details()
 	find_system_journal_problems "proxy" "@PROJECT_TYPE@-proxy" ""
 }
 
+show_runtime_log_details()
+{
+	subheading "Runtime logs"
+
+	find_system_journal_problems "runtime" "@RUNTIME_NAME@" ""
+}
+
 show_shim_log_details()
 {
 	subheading "Shim logs"
@@ -280,6 +268,18 @@ show_throttler_log_details()
 	subheading "Throttler logs"
 
 	find_system_journal_problems "throttler" "" "@PROJECT_TYPE@-ksm-throttler"
+}
+
+show_log_details()
+{
+	heading "Logfiles"
+
+	show_runtime_log_details
+	show_proxy_log_details
+	show_shim_log_details
+	show_throttler_log_details
+
+	separator
 }
 
 show_package_versions()

--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -184,7 +184,7 @@ show_runtime_configs()
 	local configs config
 
 	heading "Runtime config files"
-	
+
 	configs=$($runtime --@PROJECT_TYPE@-show-default-config-paths)
 	if [ $? -ne 0 ]; then
 		version=$($runtime --version|tr '\n' ' ')
@@ -624,7 +624,7 @@ show_image_details()
 {
 	local image
 	local details
-	
+
 	image=$(get_image_file)
 
 	heading "Image details"
@@ -646,7 +646,7 @@ show_initrd_details()
 {
 	local initrd
 	local details
-	
+
 	initrd=$(get_initrd_file)
 
 	heading "Initrd details"

--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -221,7 +221,6 @@ find_system_journal_problems()
 {
 	local name="$1"
 	local program="$2"
-	local unit="$3"
 
 	# select by identifier
 	local selector="-t"
@@ -246,28 +245,28 @@ show_proxy_log_details()
 {
 	subheading "Proxy logs"
 
-	find_system_journal_problems "proxy" "@PROJECT_TYPE@-proxy" ""
+	find_system_journal_problems "proxy" "@PROJECT_TYPE@-proxy"
 }
 
 show_runtime_log_details()
 {
 	subheading "Runtime logs"
 
-	find_system_journal_problems "runtime" "@RUNTIME_NAME@" ""
+	find_system_journal_problems "runtime" "@RUNTIME_NAME@"
 }
 
 show_shim_log_details()
 {
 	subheading "Shim logs"
 
-	find_system_journal_problems "shim" "@PROJECT_TYPE@-shim" ""
+	find_system_journal_problems "shim" "@PROJECT_TYPE@-shim"
 }
 
 show_throttler_log_details()
 {
 	subheading "Throttler logs"
 
-	find_system_journal_problems "throttler" "" "@PROJECT_TYPE@-ksm-throttler"
+	find_system_journal_problems "throttler" "@PROJECT_TYPE@-ksm-throttler"
 }
 
 show_log_details()


### PR DESCRIPTION
Updated `kata-collect-data.sh` to gather basic podman details and containerd shim v2 logs.

Also fixed a minor legacy package bug, ksm throttler log collection issue and whitespace and ordering issues.

Fixes: #243.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
