### PR TITLE
[forward port] Bring to the development branch fixes provided by Christophe De Dinechin and Ted Yu.

### DIFF
--- a/src/runtime/cli/kata-env_test.go
+++ b/src/runtime/cli/kata-env_test.go
@@ -96,6 +96,7 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 	pcieRootPort := uint32(2)
 	disableNewNetNs := false
 	sharedFS := "virtio-9p"
+	virtioFSdaemon := filepath.Join(prefixDir, "virtiofsd")
 
 	filesToCreate := []string{
 		hypervisorPath,
@@ -168,6 +169,7 @@ func makeRuntimeConfig(prefixDir string) (configFile string, config oci.RuntimeC
 		AgentDebug:           agentDebug,
 		AgentTrace:           agentTrace,
 		SharedFS:             sharedFS,
+		VirtioFSDaemon:       virtioFSdaemon,
 	}
 
 	runtimeConfig := katatestutils.MakeRuntimeConfigFileData(configFileOptions)

--- a/src/runtime/containerd-shim-v2/create_test.go
+++ b/src/runtime/containerd-shim-v2/create_test.go
@@ -401,6 +401,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 	pcieRootPort := uint32(2)
 	disableNewNetNs := false
 	sharedFS := "virtio-9p"
+	virtioFSdaemon := path.Join(dir, "virtiofsd")
 
 	configFileOptions := ktu.RuntimeConfigOptions{
 		Hypervisor:           "qemu",
@@ -420,6 +421,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 		PCIeRootPort:         pcieRootPort,
 		DisableNewNetNs:      disableNewNetNs,
 		SharedFS:             sharedFS,
+		VirtioFSDaemon:       virtioFSdaemon,
 	}
 
 	runtimeConfigFileData := ktu.MakeRuntimeConfigFileData(configFileOptions)

--- a/src/runtime/containerd-shim-v2/service.go
+++ b/src/runtime/containerd-shim-v2/service.go
@@ -211,10 +211,10 @@ func (s *service) StartShim(ctx context.Context, id, containerdBinary, container
 
 	// make sure to wait after start
 	go cmd.Wait()
-	if err := cdshim.WritePidFile("shim.pid", cmd.Process.Pid); err != nil {
+	if err = cdshim.WritePidFile("shim.pid", cmd.Process.Pid); err != nil {
 		return "", err
 	}
-	if err := cdshim.WriteAddress("address", address); err != nil {
+	if err = cdshim.WriteAddress("address", address); err != nil {
 		return "", err
 	}
 	return address, nil

--- a/src/runtime/pkg/katatestutils/utils.go
+++ b/src/runtime/pkg/katatestutils/utils.go
@@ -28,6 +28,7 @@ type RuntimeConfigOptions struct {
 	AgentTraceMode       string
 	AgentTraceType       string
 	SharedFS             string
+	VirtioFSDaemon       string
 	PCIeRootPort         uint32
 	DisableBlock         bool
 	EnableIOThreads      bool
@@ -65,7 +66,7 @@ func MakeRuntimeConfigFileData(config RuntimeConfigOptions) string {
 	enable_debug = ` + strconv.FormatBool(config.HypervisorDebug) + `
 	guest_hook_path = "` + config.DefaultGuestHookPath + `"
 	shared_fs = "` + config.SharedFS + `"
-	virtio_fs_daemon = "/path/to/virtiofsd"
+	virtio_fs_daemon = "` + config.VirtioFSDaemon + `"
 
 	[proxy.kata]
 	enable_debug = ` + strconv.FormatBool(config.ProxyDebug) + `

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -85,6 +85,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 	pcieRootPort := uint32(2)
 	disableNewNetNs := false
 	sharedFS := "virtio-9p"
+	virtioFSdaemon := path.Join(dir, "virtiofsd")
 
 	configFileOptions := ktu.RuntimeConfigOptions{
 		Hypervisor:           "qemu",
@@ -117,6 +118,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		AgentDebug:           agentDebug,
 		AgentTrace:           agentTrace,
 		SharedFS:             sharedFS,
+		VirtioFSDaemon:       virtioFSdaemon,
 	}
 
 	runtimeConfigFileData := ktu.MakeRuntimeConfigFileData(configFileOptions)
@@ -167,7 +169,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		GuestHookPath:         defaultGuestHookPath,
 		VhostUserStorePath:    defaultVhostUserStorePath,
 		SharedFS:              sharedFS,
-		VirtioFSDaemon:        "/path/to/virtiofsd",
+		VirtioFSDaemon:        virtioFSdaemon,
 		VirtioFSCache:         defaultVirtioFSCacheMode,
 	}
 

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -235,7 +235,9 @@ func (a *Acrn) appendImage(devices []Device, imagePath string) ([]Device, error)
 	if sandbox == nil && err != nil {
 		return nil, err
 	}
-	sandbox.GetAndSetSandboxBlockIndex()
+	if _, err = sandbox.GetAndSetSandboxBlockIndex(); err != nil {
+		return nil, err
+	}
 
 	devices, err = a.arch.appendImage(devices, imagePath)
 	if err != nil {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -646,10 +646,6 @@ func (q *qemu) setupVirtiofsd() (err error) {
 	var listener *net.UnixListener
 	var fd *os.File
 
-	if _, err = os.Stat(q.config.VirtioFSDaemon); os.IsNotExist(err) {
-		return fmt.Errorf("virtiofsd path (%s) does not exist", q.config.VirtioFSDaemon)
-	}
-
 	sockPath, err := q.vhostFSSocketPath(q.id)
 	if err != nil {
 		return err
@@ -680,9 +676,10 @@ func (q *qemu) setupVirtiofsd() (err error) {
 	}
 
 	err = cmd.Start()
-	if err == nil {
-		q.state.VirtiofsdPid = cmd.Process.Pid
+	if err != nil {
+		return fmt.Errorf("virtiofs daemon %v returned with error: %v", q.config.VirtioFSDaemon, err)
 	}
+	q.state.VirtiofsdPid = cmd.Process.Pid
 	fd.Close()
 
 	// Monitor virtiofsd's stderr and stop sandbox if virtiofsd quits

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1606,7 +1606,6 @@ const maxBlockIndex = 65535
 // the BlockIndexMap and marks it as used. This index is used to maintain the
 // index at which a block device is assigned to a container in the sandbox.
 func (s *Sandbox) getAndSetSandboxBlockIndex() (int, error) {
-	var err error
 	currentIndex := -1
 	for i := 0; i < maxBlockIndex; i++ {
 		if _, ok := s.state.BlockIndexMap[i]; !ok {
@@ -1618,11 +1617,6 @@ func (s *Sandbox) getAndSetSandboxBlockIndex() (int, error) {
 		return -1, errors.New("no available block index")
 	}
 	s.state.BlockIndexMap[currentIndex] = struct{}{}
-	defer func() {
-		if err != nil {
-			delete(s.state.BlockIndexMap, currentIndex)
-		}
-	}()
 
 	return currentIndex, nil
 }


### PR DESCRIPTION
This series bring fixes for the following issues:
- #2727 - Ineffective error variable for deferred func in service#StartShim
- #2726 - the error return from GetAndSetSandboxBlockIndex() should be checked
- #2686 - katatestutils should use config.virtioFSDaemon
- #2682 - Runtime crash when virtiofsd is not executable
