### PR TITLE
rate-limiter: network I/O throttling on VM level 

### DIFF
--- a/src/runtime/cli/config/configuration-fc.toml.in
+++ b/src/runtime/cli/config/configuration-fc.toml.in
@@ -196,6 +196,17 @@ use_vsock = true
 # Warnings will be logged if any error is encountered will scanning for hooks,
 # but it will not abort container execution.
 #guest_hook_path = "/usr/share/oci/hooks"
+#
+# Use rx Rate Limiter to control network I/O inbound bandwidth(size in bits/sec for SB/VM).
+# In Firecracker, it provides a built-in rate limiter, which is based on TBF(Token Bucket Filter)
+# queueing discipline.
+# Default 0-sized value means unlimited rate.
+#rx_rate_limiter_max_rate = 0
+# Use tx Rate Limiter to control network I/O outbound bandwidth(size in bits/sec for SB/VM).
+# In Firecracker, it provides a built-in rate limiter, which is based on TBF(Token Bucket Filter)
+# queueing discipline.
+# Default 0-sized value means unlimited rate.
+#tx_rate_limiter_max_rate = 0
 
 [factory]
 # VM templating support. Once enabled, new VMs are created from template

--- a/src/runtime/cli/config/configuration-qemu.toml.in
+++ b/src/runtime/cli/config/configuration-qemu.toml.in
@@ -280,6 +280,16 @@ vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 # Warnings will be logged if any error is encountered will scanning for hooks,
 # but it will not abort container execution.
 #guest_hook_path = "/usr/share/oci/hooks"
+#
+# Use rx Rate Limiter to control network I/O inbound bandwidth(size in bits/sec for SB/VM).
+# In Qemu, we use classful qdiscs HTB(Hierarchy Token Bucket) to discipline traffic.
+# Default 0-sized value means unlimited rate.
+#rx_rate_limiter_max_rate = 0
+# Use tx Rate Limiter to control network I/O outbound bandwidth(size in bits/sec for SB/VM).
+# In Qemu, we use classful qdiscs HTB(Hierarchy Token Bucket) and ifb(Intermediate Functional Block)
+# to discipline traffic.
+# Default 0-sized value means unlimited rate.
+#tx_rate_limiter_max_rate = 0
 
 [factory]
 # VM templating support. Once enabled, new VMs are created from template

--- a/src/runtime/pkg/katautils/config-settings.go.in
+++ b/src/runtime/pkg/katautils/config-settings.go.in
@@ -51,6 +51,8 @@ const defaultGuestHookPath string = ""
 const defaultVirtioFSCacheMode = "none"
 const defaultDisableImageNvdimm = false
 const defaultVhostUserStorePath string = "/var/run/kata-containers/vhost-user/"
+const defaultRxRateLimiterMaxRate = uint64(0)
+const defaultTxRateLimiterMaxRate = uint64(0)
 
 const defaultTemplatePath string = "/run/vc/vm/template"
 const defaultVMCacheEndpoint string = "/var/run/kata-containers/cache.sock"

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -786,6 +786,9 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 		utils.VHostVSockDevicePath = orgVHostVSockDevicePath
 	}()
 	utils.VHostVSockDevicePath = "/dev/abc/xyz"
+	// 10Mbits/sec
+	rxRateLimiterMaxRate := uint64(10000000)
+	txRateLimiterMaxRate := uint64(10000000)
 
 	hypervisor := hypervisor{
 		Path:                  hypervisorPath,
@@ -797,6 +800,8 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 		HotplugVFIOOnRootBus:  hotplugVFIOOnRootBus,
 		PCIeRootPort:          pcieRootPort,
 		UseVSock:              true,
+		RxRateLimiterMaxRate:  rxRateLimiterMaxRate,
+		TxRateLimiterMaxRate:  txRateLimiterMaxRate,
 	}
 
 	files := []string{hypervisorPath, kernelPath, imagePath}
@@ -856,6 +861,14 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 
 	if config.PCIeRootPort != pcieRootPort {
 		t.Errorf("Expected value for PCIeRootPort %v, got %v", pcieRootPort, config.PCIeRootPort)
+	}
+
+	if config.RxRateLimiterMaxRate != rxRateLimiterMaxRate {
+		t.Errorf("Expected value for rx rate limiter %v, got %v", rxRateLimiterMaxRate, config.RxRateLimiterMaxRate)
+	}
+
+	if config.TxRateLimiterMaxRate != txRateLimiterMaxRate {
+		t.Errorf("Expected value for tx rate limiter %v, got %v", txRateLimiterMaxRate, config.TxRateLimiterMaxRate)
 	}
 }
 

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -811,3 +811,7 @@ func (a *Acrn) loadInfo() error {
 	}
 	return nil
 }
+
+func (a *Acrn) isRateLimiterBuiltin() bool {
+	return false
+}

--- a/src/runtime/virtcontainers/bridgedmacvlan_endpoint.go
+++ b/src/runtime/virtcontainers/bridgedmacvlan_endpoint.go
@@ -18,6 +18,8 @@ type BridgedMacvlanEndpoint struct {
 	EndpointProperties NetworkInfo
 	EndpointType       EndpointType
 	PCIAddr            string
+	RxRateLimiter      bool
+	TxRateLimiter      bool
 }
 
 func createBridgedMacvlanNetworkEndpoint(idx int, ifName string, interworkingModel NetInterworkingModel) (*BridgedMacvlanEndpoint, error) {
@@ -135,4 +137,22 @@ func (endpoint *BridgedMacvlanEndpoint) load(s persistapi.NetworkEndpoint) {
 		netpair := loadNetIfPair(&s.BridgedMacvlan.NetPair)
 		endpoint.NetPair = *netpair
 	}
+}
+
+func (endpoint *BridgedMacvlanEndpoint) GetRxRateLimiter() bool {
+	return endpoint.RxRateLimiter
+}
+
+func (endpoint *BridgedMacvlanEndpoint) SetRxRateLimiter() error {
+	endpoint.RxRateLimiter = true
+	return nil
+}
+
+func (endpoint *BridgedMacvlanEndpoint) GetTxRateLimiter() bool {
+	return endpoint.TxRateLimiter
+}
+
+func (endpoint *BridgedMacvlanEndpoint) SetTxRateLimiter() error {
+	endpoint.TxRateLimiter = true
+	return nil
 }

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1210,3 +1210,7 @@ func (clh *cloudHypervisor) vmInfo() (chclient.VmInfo, error) {
 	return info, openAPIClientError(err)
 
 }
+
+func (clh *cloudHypervisor) isRateLimiterBuiltin() bool {
+	return false
+}

--- a/src/runtime/virtcontainers/endpoint.go
+++ b/src/runtime/virtcontainers/endpoint.go
@@ -29,6 +29,11 @@ type Endpoint interface {
 
 	save() persistapi.NetworkEndpoint
 	load(persistapi.NetworkEndpoint)
+
+	GetRxRateLimiter() bool
+	SetRxRateLimiter() error
+	GetTxRateLimiter() bool
+	SetTxRateLimiter() error
 }
 
 // EndpointType identifies the type of the network endpoint.

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -25,12 +25,12 @@ import (
 
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/device/config"
 	persistapi "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/api"
+	kataclient "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/client"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/firecracker/client"
 	models "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/firecracker/client/models"
 	ops "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/firecracker/client/operations"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
-	kataclient "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/client"
 
 	"github.com/blang/semver"
 	"github.com/containerd/console"
@@ -1211,4 +1211,8 @@ func (fc *firecracker) watchConsole() (*os.File, error) {
 	}()
 
 	return stdio, nil
+}
+
+func (fc *firecracker) isRateLimiterBuiltin() bool {
+	return true
 }

--- a/src/runtime/virtcontainers/fc_test.go
+++ b/src/runtime/virtcontainers/fc_test.go
@@ -45,3 +45,14 @@ func TestFCTruncateID(t *testing.T) {
 	id = fc.truncateID(testShortID)
 	assert.Equal(expectedID, id)
 }
+
+func TestRevertBytes(t *testing.T) {
+	assert := assert.New(t)
+
+	//10MB
+	testNum := uint64(10000000)
+	expectedNum := uint64(10485760)
+
+	num := revertBytes(testNum)
+	assert.Equal(expectedNum, num)
+}

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -802,4 +802,7 @@ type hypervisor interface {
 
 	// generate the socket to communicate the host and guest
 	generateSocket(id string, useVsock bool) (interface{}, error)
+
+	// check if hypervisor supports built-in rate limiter.
+	isRateLimiterBuiltin() bool
 }

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -412,6 +412,12 @@ type HypervisorConfig struct {
 
 	// SELinux label for the VM
 	SELinuxProcessLabel string
+
+	// RxRateLimiterMaxRate is used to control network I/O inbound bandwidth on VM level.
+	RxRateLimiterMaxRate uint64
+
+	// TxRateLimiterMaxRate is used to control network I/O outbound bandwidth on VM level.
+	TxRateLimiterMaxRate uint64
 }
 
 // vcpu mapping from vcpu number to thread number

--- a/src/runtime/virtcontainers/ipvlan_endpoint.go
+++ b/src/runtime/virtcontainers/ipvlan_endpoint.go
@@ -18,6 +18,8 @@ type IPVlanEndpoint struct {
 	EndpointProperties NetworkInfo
 	EndpointType       EndpointType
 	PCIAddr            string
+	RxRateLimiter      bool
+	TxRateLimiter      bool
 }
 
 func createIPVlanNetworkEndpoint(idx int, ifName string) (*IPVlanEndpoint, error) {
@@ -138,4 +140,22 @@ func (endpoint *IPVlanEndpoint) load(s persistapi.NetworkEndpoint) {
 		netpair := loadNetIfPair(&s.IPVlan.NetPair)
 		endpoint.NetPair = *netpair
 	}
+}
+
+func (endpoint *IPVlanEndpoint) GetRxRateLimiter() bool {
+	return endpoint.RxRateLimiter
+}
+
+func (endpoint *IPVlanEndpoint) SetRxRateLimiter() error {
+	endpoint.RxRateLimiter = true
+	return nil
+}
+
+func (endpoint *IPVlanEndpoint) GetTxRateLimiter() bool {
+	return endpoint.TxRateLimiter
+}
+
+func (endpoint *IPVlanEndpoint) SetTxRateLimiter() error {
+	endpoint.TxRateLimiter = true
+	return nil
 }

--- a/src/runtime/virtcontainers/macvtap_endpoint.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint.go
@@ -19,6 +19,8 @@ type MacvtapEndpoint struct {
 	VMFds              []*os.File
 	VhostFds           []*os.File
 	PCIAddr            string
+	RxRateLimiter      bool
+	TxRateLimiter      bool
 }
 
 func createMacvtapNetworkEndpoint(netInfo NetworkInfo) (*MacvtapEndpoint, error) {
@@ -120,4 +122,22 @@ func (endpoint *MacvtapEndpoint) load(s persistapi.NetworkEndpoint) {
 	if s.Macvtap != nil {
 		endpoint.PCIAddr = s.Macvtap.PCIAddr
 	}
+}
+
+func (endpoint *MacvtapEndpoint) GetRxRateLimiter() bool {
+	return endpoint.RxRateLimiter
+}
+
+func (endpoint *MacvtapEndpoint) SetRxRateLimiter() error {
+	endpoint.RxRateLimiter = true
+	return nil
+}
+
+func (endpoint *MacvtapEndpoint) GetTxRateLimiter() bool {
+	return endpoint.TxRateLimiter
+}
+
+func (endpoint *MacvtapEndpoint) SetTxRateLimiter() error {
+	endpoint.TxRateLimiter = true
+	return nil
 }

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -128,3 +128,7 @@ func (m *mockHypervisor) check() error {
 func (m *mockHypervisor) generateSocket(id string, useVsock bool) (interface{}, error) {
 	return types.Socket{HostPath: "/tmp/socket", Name: "socket"}, nil
 }
+
+func (m *mockHypervisor) isRateLimiterBuiltin() bool {
+	return false
+}

--- a/src/runtime/virtcontainers/persist.go
+++ b/src/runtime/virtcontainers/persist.go
@@ -256,6 +256,8 @@ func (s *Sandbox) dumpConfig(ss *persistapi.SandboxState) {
 		VhostUserStorePath:      sconfig.HypervisorConfig.VhostUserStorePath,
 		GuestHookPath:           sconfig.HypervisorConfig.GuestHookPath,
 		VMid:                    sconfig.HypervisorConfig.VMid,
+		RxRateLimiterMaxRate:    sconfig.HypervisorConfig.RxRateLimiterMaxRate,
+		TxRateLimiterMaxRate:    sconfig.HypervisorConfig.TxRateLimiterMaxRate,
 	}
 
 	if sconfig.AgentType == "kata" {
@@ -545,6 +547,8 @@ func loadSandboxConfig(id string) (*SandboxConfig, error) {
 		VhostUserStorePath:      hconf.VhostUserStorePath,
 		GuestHookPath:           hconf.GuestHookPath,
 		VMid:                    hconf.VMid,
+		RxRateLimiterMaxRate:    hconf.RxRateLimiterMaxRate,
+		TxRateLimiterMaxRate:    hconf.TxRateLimiterMaxRate,
 	}
 
 	if savedConf.AgentType == "kata" {

--- a/src/runtime/virtcontainers/persist/api/config.go
+++ b/src/runtime/virtcontainers/persist/api/config.go
@@ -179,6 +179,12 @@ type HypervisorConfig struct {
 	// VMid is the id of the VM that create the hypervisor if the VM is created by the factory.
 	// VMid is "" if the hypervisor is not created by the factory.
 	VMid string
+
+	// RxRateLimiterMaxRate is used to control network I/O inbound bandwidth on VM level.
+	RxRateLimiterMaxRate uint64
+
+	// TxRateLimiterMaxRate is used to control network I/O outbound bandwidth on VM level.
+	TxRateLimiterMaxRate uint64
 }
 
 // KataAgentConfig is a structure storing information needed

--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -231,3 +231,21 @@ func (endpoint *PhysicalEndpoint) load(s persistapi.NetworkEndpoint) {
 		endpoint.VendorDeviceID = s.Physical.VendorDeviceID
 	}
 }
+
+// unsupported
+func (endpoint *PhysicalEndpoint) GetRxRateLimiter() bool {
+	return false
+}
+
+func (endpoint *PhysicalEndpoint) SetRxRateLimiter() error {
+	return fmt.Errorf("rx rate limiter is unsupported for physical endpoint")
+}
+
+// unsupported
+func (endpoint *PhysicalEndpoint) GetTxRateLimiter() bool {
+	return false
+}
+
+func (endpoint *PhysicalEndpoint) SetTxRateLimiter() error {
+	return fmt.Errorf("tx rate limiter is unsupported for physical endpoint")
+}

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -200,6 +200,12 @@ const (
 	// BlockDeviceCacheNoflush is a sandbox annotation that specifies cache-related options for block devices.
 	// Denotes whether flush requests for the device are ignored.
 	BlockDeviceCacheNoflush = kataAnnotHypervisorPrefix + "block_device_cache_noflush"
+
+	// RxRateLimiterMaxRate is a sandbox annotation that specifies max rate on network I/O inbound bandwidth.
+	RxRateLimiterMaxRate = kataAnnotHypervisorPrefix + "rx_rate_limiter_max_rate"
+
+	// TxRateLimiter is a sandbox annotation that specifies max rate on network I/O outbound bandwidth
+	TxRateLimiterMaxRate = kataAnnotHypervisorPrefix + "tx_rate_limiter_max_rate"
 )
 
 // Agent related annotations

--- a/src/runtime/virtcontainers/pkg/firecracker/client/models/token_bucket.go
+++ b/src/runtime/virtcontainers/pkg/firecracker/client/models/token_bucket.go
@@ -19,17 +19,17 @@ type TokenBucket struct {
 
 	// The initial size of a token bucket.
 	// Minimum: 0
-	OneTimeBurst *int64 `json:"one_time_burst,omitempty"`
+	OneTimeBurst *uint64 `json:"one_time_burst,omitempty"`
 
 	// The amount of milliseconds it takes for the bucket to refill.
 	// Required: true
 	// Minimum: 0
-	RefillTime *int64 `json:"refill_time"`
+	RefillTime *uint64 `json:"refill_time"`
 
 	// The total number of tokens this bucket can hold.
 	// Required: true
 	// Minimum: 0
-	Size *int64 `json:"size"`
+	Size *uint64 `json:"size"`
 }
 
 // Validate validates this token bucket

--- a/src/runtime/virtcontainers/pkg/firecracker/firecracker.yaml
+++ b/src/runtime/virtcontainers/pkg/firecracker/firecracker.yaml
@@ -615,17 +615,17 @@ definitions:
     properties:
       size:
         type: integer
-        format: int64
+        format: uint64
         description: The total number of tokens this bucket can hold.
         minimum: 0
       one_time_burst:
         type: integer
-        format: int64
+        format: uint64
         description: The initial size of a token bucket.
         minimum: 0
       refill_time:
         type: integer
-        format: int64
+        format: uint64
         description: The amount of milliseconds it takes for the bucket to refill.
         minimum: 0
 

--- a/src/runtime/virtcontainers/pkg/oci/utils.go
+++ b/src/runtime/virtcontainers/pkg/oci/utils.go
@@ -382,6 +382,10 @@ func addHypervisorConfigOverrides(ocispec specs.Spec, config *vc.SandboxConfig) 
 		return err
 	}
 
+	if err := addHypervisporNetworkOverrides(ocispec, config); err != nil {
+		return err
+	}
+
 	if value, ok := ocispec.Annotations[vcAnnotations.KernelParams]; ok {
 		if value != "" {
 			params := vc.DeserializeParams(strings.Fields(value))
@@ -403,15 +407,6 @@ func addHypervisorConfigOverrides(ocispec specs.Spec, config *vc.SandboxConfig) 
 		if value != "" {
 			config.HypervisorConfig.MachineAccelerators = value
 		}
-	}
-
-	if value, ok := ocispec.Annotations[vcAnnotations.DisableVhostNet]; ok {
-		disableVhostNet, err := strconv.ParseBool(value)
-		if err != nil {
-			return fmt.Errorf("Error parsing annotation for disable_vhost_net: Please specify boolean value 'true|false'")
-		}
-
-		config.HypervisorConfig.DisableVhostNet = disableVhostNet
 	}
 
 	if value, ok := ocispec.Annotations[vcAnnotations.GuestHookPath]; ok {
@@ -699,6 +694,35 @@ func addHypervisporVirtioFsOverrides(ocispec specs.Spec, sbConfig *vc.SandboxCon
 		}
 
 		sbConfig.HypervisorConfig.Msize9p = uint32(msize9p)
+	}
+
+	return nil
+}
+
+func addHypervisporNetworkOverrides(ocispec specs.Spec, sbConfig *vc.SandboxConfig) error {
+	if value, ok := ocispec.Annotations[vcAnnotations.DisableVhostNet]; ok {
+		disableVhostNet, err := strconv.ParseBool(value)
+		if err != nil {
+			return fmt.Errorf("Error parsing annotation for disable_vhost_net: Please specify boolean value 'true|false'")
+		}
+
+		sbConfig.HypervisorConfig.DisableVhostNet = disableVhostNet
+	}
+
+	if value, ok := ocispec.Annotations[vcAnnotations.RxRateLimiterMaxRate]; ok {
+		rxRateLimiterMaxRate, err := strconv.ParseUint(value, 10, 64)
+		if err != nil || rxRateLimiterMaxRate < 0 {
+			return fmt.Errorf("Error parsing annotation for rx_rate_limiter_max_rate: %v, Please specify an integer greater than or equal to 0", err)
+		}
+		sbConfig.HypervisorConfig.RxRateLimiterMaxRate = rxRateLimiterMaxRate
+	}
+
+	if value, ok := ocispec.Annotations[vcAnnotations.TxRateLimiterMaxRate]; ok {
+		txRateLimiterMaxRate, err := strconv.ParseUint(value, 10, 64)
+		if err != nil || txRateLimiterMaxRate < 0 {
+			return fmt.Errorf("Error parsing annotation for tx_rate_limiter_max_rate: %v, Please specify an integer greater than or equal to 0", err)
+		}
+		sbConfig.HypervisorConfig.TxRateLimiterMaxRate = txRateLimiterMaxRate
 	}
 
 	return nil

--- a/src/runtime/virtcontainers/pkg/oci/utils_test.go
+++ b/src/runtime/virtcontainers/pkg/oci/utils_test.go
@@ -791,6 +791,9 @@ func TestAddHypervisorAnnotations(t *testing.T) {
 	ocispec.Annotations[vcAnnotations.HotplugVFIOOnRootBus] = "true"
 	ocispec.Annotations[vcAnnotations.PCIeRootPort] = "2"
 	ocispec.Annotations[vcAnnotations.EntropySource] = "/dev/urandom"
+	// 10Mbit
+	ocispec.Annotations[vcAnnotations.RxRateLimiterMaxRate] = "10000000"
+	ocispec.Annotations[vcAnnotations.TxRateLimiterMaxRate] = "10000000"
 
 	addAnnotations(ocispec, &config)
 	assert.Equal(config.HypervisorConfig.NumVCPUs, uint32(1))
@@ -823,6 +826,8 @@ func TestAddHypervisorAnnotations(t *testing.T) {
 	assert.Equal(config.HypervisorConfig.HotplugVFIOOnRootBus, true)
 	assert.Equal(config.HypervisorConfig.PCIeRootPort, uint32(2))
 	assert.Equal(config.HypervisorConfig.EntropySource, "/dev/urandom")
+	assert.Equal(config.HypervisorConfig.RxRateLimiterMaxRate, uint64(10000000))
+	assert.Equal(config.HypervisorConfig.TxRateLimiterMaxRate, uint64(10000000))
 
 	// In case an absurd large value is provided, the config value if not over-ridden
 	ocispec.Annotations[vcAnnotations.DefaultVCPUs] = "655536"

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -2266,3 +2266,7 @@ func (q *qemu) check() error {
 func (q *qemu) generateSocket(id string, useVsock bool) (interface{}, error) {
 	return generateVMSocket(id, useVsock, q.store.RunVMStoragePath())
 }
+
+func (q *qemu) isRateLimiterBuiltin() bool {
+	return false
+}

--- a/src/runtime/virtcontainers/tap_endpoint.go
+++ b/src/runtime/virtcontainers/tap_endpoint.go
@@ -21,6 +21,8 @@ type TapEndpoint struct {
 	EndpointProperties NetworkInfo
 	EndpointType       EndpointType
 	PCIAddr            string
+	RxRateLimiter      bool
+	TxRateLimiter      bool
 }
 
 // Properties returns the properties of the tap interface.
@@ -206,4 +208,22 @@ func (endpoint *TapEndpoint) load(s persistapi.NetworkEndpoint) {
 		tapif := loadTapIf(&s.Tap.TapInterface)
 		endpoint.TapInterface = *tapif
 	}
+}
+
+func (endpoint *TapEndpoint) GetRxRateLimiter() bool {
+	return endpoint.RxRateLimiter
+}
+
+func (endpoint *TapEndpoint) SetRxRateLimiter() error {
+	endpoint.RxRateLimiter = true
+	return nil
+}
+
+func (endpoint *TapEndpoint) GetTxRateLimiter() bool {
+	return endpoint.TxRateLimiter
+}
+
+func (endpoint *TapEndpoint) SetTxRateLimiter() error {
+	endpoint.TxRateLimiter = true
+	return nil
 }

--- a/src/runtime/virtcontainers/tuntap_endpoint.go
+++ b/src/runtime/virtcontainers/tuntap_endpoint.go
@@ -23,6 +23,8 @@ type TuntapEndpoint struct {
 	EndpointProperties NetworkInfo
 	EndpointType       EndpointType
 	PCIAddr            string
+	RxRateLimiter      bool
+	TxRateLimiter      bool
 }
 
 // Properties returns the properties of the tap interface.
@@ -211,4 +213,22 @@ func (endpoint *TuntapEndpoint) load(s persistapi.NetworkEndpoint) {
 		tuntapif := loadTuntapIf(&s.Tuntap.TuntapInterface)
 		endpoint.TuntapInterface = *tuntapif
 	}
+}
+
+func (endpoint *TuntapEndpoint) GetRxRateLimiter() bool {
+	return endpoint.RxRateLimiter
+}
+
+func (endpoint *TuntapEndpoint) SetRxRateLimiter() error {
+	endpoint.RxRateLimiter = true
+	return nil
+}
+
+func (endpoint *TuntapEndpoint) GetTxRateLimiter() bool {
+	return endpoint.TxRateLimiter
+}
+
+func (endpoint *TuntapEndpoint) SetTxRateLimiter() error {
+	endpoint.TxRateLimiter = true
+	return nil
 }

--- a/src/runtime/virtcontainers/veth_endpoint.go
+++ b/src/runtime/virtcontainers/veth_endpoint.go
@@ -18,6 +18,8 @@ type VethEndpoint struct {
 	EndpointProperties NetworkInfo
 	EndpointType       EndpointType
 	PCIAddr            string
+	RxRateLimiter      bool
+	TxRateLimiter      bool
 }
 
 func createVethNetworkEndpoint(idx int, ifName string, interworkingModel NetInterworkingModel) (*VethEndpoint, error) {
@@ -161,4 +163,22 @@ func (endpoint *VethEndpoint) load(s persistapi.NetworkEndpoint) {
 		netpair := loadNetIfPair(&s.Veth.NetPair)
 		endpoint.NetPair = *netpair
 	}
+}
+
+func (endpoint *VethEndpoint) GetRxRateLimiter() bool {
+	return endpoint.RxRateLimiter
+}
+
+func (endpoint *VethEndpoint) SetRxRateLimiter() error {
+	endpoint.RxRateLimiter = true
+	return nil
+}
+
+func (endpoint *VethEndpoint) GetTxRateLimiter() bool {
+	return endpoint.TxRateLimiter
+}
+
+func (endpoint *VethEndpoint) SetTxRateLimiter() error {
+	endpoint.TxRateLimiter = true
+	return nil
 }

--- a/src/runtime/virtcontainers/vhostuser_endpoint.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint.go
@@ -169,3 +169,21 @@ func (endpoint *VhostUserEndpoint) load(s persistapi.NetworkEndpoint) {
 		endpoint.PCIAddr = s.VhostUser.PCIAddr
 	}
 }
+
+// unsupported
+func (endpoint *VhostUserEndpoint) GetRxRateLimiter() bool {
+	return false
+}
+
+func (endpoint *VhostUserEndpoint) SetRxRateLimiter() error {
+	return fmt.Errorf("rx rate limiter is unsupported for vhost user endpoint")
+}
+
+// unsupported
+func (endpoint *VhostUserEndpoint) GetTxRateLimiter() bool {
+	return false
+}
+
+func (endpoint *VhostUserEndpoint) SetTxRateLimiter() error {
+	return fmt.Errorf("tx rate limiter is unsupported for vhost user endpoint")
+}


### PR DESCRIPTION
Hi guys

We've discussed about network throttling on vm level in kata-containers/runtime#2690 and #219.

For some hypervisors which implement rate limiter in itself, like firecracker, we could easily import these features into kata-runtime, see kata-containers/runtime#2690.

For some hypervisors which miss rate limiter implementation, like qemu, I try to use **tcfilter** to fulfill this mission.

For security issue, the tc schemes may need to be enabled in host part. Quoting @stefanha comments here for clear clarification.

> It is safer to apply restrictions on the host rather than inside the guest. That way more layers of defense need to be compromised before a malicious container can disable rate limiting.
> For example, if you use tc inside the guest then rate limiting can be disabled/bypassed after a container escape inside the sandbox VM. If you use tc on the host then a compromised guest is still rate limited.

### Draft Proposal:

- **Network I/O inbound bandwidth throttling on VM level**
We Implement a tc-based rx Rate Limiter to control network I/O inbound traffic per SB/VM.
In some detail, we use HTB(Hierarchical Token Bucket) qdisc shaping schemes to control interfaces egress traffic in host part.
HTB shapes traffic based on the Token Bucket Filter algorithm.
A fundamental part of the HTB qdisc is the borrowing mechanism. Children classes borrow tokens from their parents once they have exceeded _rate_. A child class will continue to attempt to borrow until it reaches _ceil_. See more details in [here](https://tldp.org/HOWTO/Traffic-Control-HOWTO/classful-qdiscs.html).
![image](https://user-images.githubusercontent.com/31910522/84478425-ddeb3180-acc3-11ea-9f96-983113cad88b.png)
Seeing from pic, after the routing decision, all packets will be sent to the interface root htb qdisc.
This root qdisc has only one direct child class (with id 1:1) which shapes the overall rate that will be sent through this endpoint. Then, this class has at least one default child (1:2) meant to control all
non-privileged traffic.
_e.g.
if we try to set VM bandwidth with maximum 10Mbit/s, we should give classid 1:2 rate 10Mbit/s, ceil 10Mbit/s and classid 1:1 rate 10Mbit/s, ceil 10Mbit/s._
_To-do:
Later, if we want to do limitation on some dedicated traffic(special process running in VM), we could create a separate class (1:n) with guarantee throughput._

- **Network I/O outbound bandwidth throttling on VM level**
The implementation of tc-based tx rate limiter is kinds of complicated. 
We need to take different actions, based on various inter-networking models.
**_1. Default Inter-networking model: tcfilter_**
We create a network pair for this inter-networking model, and it has two interfaces, one represents virt part and the other as tap part.
Since we've already used tcfilter to redirect tap part ingress traffic to the egress of the virt part, we could simply add htb queuing discipline to the virt part to control the VM outbound bandwidth.
**_2. Other Inter-networking model: macvtap, etc_**
Interface ingress shaping is very limited, and we couldn't use qdisc schemes like tbf, htb, etc on the ingress traffic.
Here, we resort to ifb(Intermediate Functional Block).
It is an alternative to tc filters for handling ingress traffic, by redirecting interface ingress traffic to ifb egress.
Then, we could add htb queuing discipline to ifb to control the VM outbound bandwidth.
