### PR TITLE
qemu: Remove Qemu version check in ppc64le unit test

### DIFF
--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -24,8 +24,6 @@ const defaultQemuMachineType = QemuPseries
 
 const defaultQemuMachineOptions = "accel=kvm,usb=off,cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large-decr=off"
 
-const defaultMemMaxPPC64le = 32256 // Restrict MemMax to 32Gb on PPC64le
-
 const qmpMigrationWaitTimeout = 5 * time.Second
 
 var qemuPaths = map[string]string{
@@ -114,14 +112,8 @@ func (q *qemuPPC64le) cpuModel() string {
 
 func (q *qemuPPC64le) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory {
 
-	if (qemuMajorVersion > 2) || (qemuMajorVersion == 2 && qemuMinorVersion >= 10) {
-		q.Logger().Debug("Aligning maxmem to multiples of 256MB. Assumption: Kernel Version >= 4.11")
-		hostMemoryMb -= (hostMemoryMb % 256)
-	} else {
-		q.Logger().Debug("Restricting maxmem to 32GB as Qemu Version < 2.10, Assumption: Kernel Version >= 4.11")
-		hostMemoryMb = defaultMemMaxPPC64le
-	}
-
+	q.Logger().Debug("Aligning maxmem to multiples of 256MB. Assumption: Kernel Version >= 4.11")
+	hostMemoryMb -= (hostMemoryMb % 256)
 	return genericMemoryTopology(memoryMb, hostMemoryMb, slots, q.memoryOffset)
 }
 

--- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
@@ -7,16 +7,11 @@ package virtcontainers
 
 import (
 	"fmt"
-	"os/exec"
-	"regexp"
-	"strconv"
 	"testing"
 
 	govmmQemu "github.com/intel/govmm/qemu"
 	"github.com/stretchr/testify/assert"
 )
-
-var qemuVersionArgs = "--version"
 
 func newTestQemu(machineType string) qemuArch {
 	config := HypervisorConfig{
@@ -39,31 +34,6 @@ func TestQemuPPC64leCPUModel(t *testing.T) {
 	assert.Equal(expectedOut, model)
 }
 
-func getQemuVersion() (qemuMajorVersion int, qemuMinorVersion int) {
-
-	cmd := exec.Command(defaultQemuPath, qemuVersionArgs)
-	additionalEnv := "LANG=C"
-	cmd.Env = append(cmd.Env, additionalEnv)
-	out, err := cmd.Output()
-	if err != nil {
-		err = fmt.Errorf("Could not execute command %s %s", defaultQemuPath, qemuVersionArgs)
-		fmt.Println(err.Error())
-	}
-
-	re := regexp.MustCompile("[0-9]+")
-	qVer := re.FindAllString(string(out), -1)
-
-	qMajor, err := strconv.Atoi(qVer[0])
-	qMinor, err1 := strconv.Atoi(qVer[1])
-
-	if err != nil || err1 != nil {
-		err = fmt.Errorf("Could not convert string to int")
-		fmt.Println(err.Error())
-	}
-
-	return qMajor, qMinor
-}
-
 func TestQemuPPC64leMemoryTopology(t *testing.T) {
 	assert := assert.New(t)
 	ppc64le := newTestQemu(QemuPseries)
@@ -73,12 +43,7 @@ func TestQemuPPC64leMemoryTopology(t *testing.T) {
 	mem := uint64(120)
 	slots := uint8(10)
 
-	qemuMajorVersion, qemuMinorVersion = getQemuVersion()
 	m := ppc64le.memoryTopology(mem, hostMem, slots)
-
-	if qemuMajorVersion <= 2 && qemuMinorVersion < 10 {
-		hostMem = uint64(defaultMemMaxPPC64le)
-	}
 
 	expectedMemory := govmmQemu.Memory{
 		Size:   fmt.Sprintf("%dM", mem),


### PR DESCRIPTION
The Qemu version check in unit test case is no longer needed for
Power since we don't support Kata with Qemu version < 4.x.

Fixes: #315

Signed-off-by: bpradipt@in.ibm.com