### PR TITLE
Clean up some unnecessary data structures

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -238,7 +238,10 @@ func (q *qemu) setup(id string, hypervisorConfig *HypervisorConfig) error {
 
 	q.id = id
 	q.config = *hypervisorConfig
-	q.arch = newQemuArch(q.config)
+	q.arch, err = newQemuArch(q.config)
+	if err != nil {
+		return err
+	}
 
 	initrdPath, err := q.config.InitrdAssetPath()
 	if err != nil {
@@ -2172,7 +2175,10 @@ func (q *qemu) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig,
 	q.qmpMonitorCh.path = qp.QmpChannelpath
 	q.qemuConfig.Ctx = ctx
 	q.state = qp.State
-	q.arch = newQemuArch(q.config)
+	q.arch, err = newQemuArch(q.config)
+	if err != nil {
+		return err
+	}
 	q.ctx = ctx
 	q.nvdimmCount = qp.NvdimmCount
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -199,10 +199,7 @@ func (q *qemu) qemuPath() (string, error) {
 	}
 
 	if p == "" {
-		p, err = q.arch.qemuPath()
-		if err != nil {
-			return "", err
-		}
+		p = q.arch.qemuPath()
 	}
 
 	if _, err = os.Stat(p); os.IsNotExist(err) {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -335,10 +335,7 @@ func (q *qemu) qmpSocketPath(id string) (string, error) {
 }
 
 func (q *qemu) getQemuMachine() (govmmQemu.Machine, error) {
-	machine, err := q.arch.machine()
-	if err != nil {
-		return govmmQemu.Machine{}, err
-	}
+	machine := q.arch.machine()
 
 	accelerators := q.config.MachineAccelerators
 	if accelerators != "" {
@@ -1542,10 +1539,7 @@ func (q *qemu) hotplugAddCPUs(amount uint32) (uint32, error) {
 		return 0, fmt.Errorf("failed to query hotpluggable CPUs: %v", err)
 	}
 
-	machine, err := q.arch.machine()
-	if err != nil {
-		return 0, fmt.Errorf("failed to query machine type: %v", err)
-	}
+	machine := q.arch.machine()
 
 	var hotpluggedVCPUs uint32
 	for _, hc := range hotpluggableVCPUs {

--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
@@ -77,10 +78,21 @@ func MaxQemuVCPUs() uint32 {
 	return uint32(240)
 }
 
-func newQemuArch(config HypervisorConfig) qemuArch {
+func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 	machineType := config.HypervisorMachineType
 	if machineType == "" {
 		machineType = defaultQemuMachineType
+	}
+
+	var mp *govmmQemu.Machine
+	for _, m := range supportedQemuMachines {
+		if m.Type == machineType {
+			mp = &m
+			break
+		}
+	}
+	if mp == nil {
+		return nil, fmt.Errorf("unrecognised machinetype: %v", machineType)
 	}
 
 	factory := false
@@ -124,7 +136,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 
 	q.handleImagePath(config)
 
-	return q
+	return q, nil
 }
 
 func (q *qemuAmd64) capabilities() types.Capabilities {

--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -116,8 +116,8 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 	q := &qemuAmd64{
 		qemuArchBase: qemuArchBase{
 			qemuMachine:           *mp,
+			qemuExePath:           qemuPaths[machineType],
 			memoryOffset:          config.MemOffset,
-			qemuPaths:             qemuPaths,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -27,6 +27,15 @@ func newTestQemu(machineType string) qemuArch {
 	return newQemuArch(config)
 }
 
+func TestQemuAmd64BadMachineType(t *testing.T) {
+	assert := assert.New(t)
+
+	amd64 := newTestQemu("no-such-machine-type")
+	amd64.bridges(5)
+	bridges := amd64.getBridges()
+	assert.Nil(bridges)
+}
+
 func TestQemuAmd64Capabilities(t *testing.T) {
 	assert := assert.New(t)
 
@@ -66,11 +75,6 @@ func TestQemuAmd64Bridges(t *testing.T) {
 		assert.Equal(id, b.ID)
 		assert.NotNil(b.Devices)
 	}
-
-	amd64 = newTestQemu(QemuQ35 + QemuPC)
-	amd64.bridges(uint32(len))
-	bridges = amd64.getBridges()
-	assert.Nil(bridges)
 }
 
 func TestQemuAmd64CPUModel(t *testing.T) {

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -22,35 +22,36 @@ func qemuConfig(machineType string) HypervisorConfig {
 	}
 }
 
-func newTestQemu(machineType string) qemuArch {
+func newTestQemu(assert *assert.Assertions, machineType string) qemuArch {
 	config := qemuConfig(machineType)
-	return newQemuArch(config)
+	arch, err := newQemuArch(config)
+	assert.NoError(err)
+	return arch
 }
 
 func TestQemuAmd64BadMachineType(t *testing.T) {
 	assert := assert.New(t)
 
-	amd64 := newTestQemu("no-such-machine-type")
-	amd64.bridges(5)
-	bridges := amd64.getBridges()
-	assert.Nil(bridges)
+	config := qemuConfig("no-such-machine-type")
+	_, err := newQemuArch(config)
+	assert.Error(err)
 }
 
 func TestQemuAmd64Capabilities(t *testing.T) {
 	assert := assert.New(t)
 
-	amd64 := newTestQemu(QemuPC)
+	amd64 := newTestQemu(assert, QemuPC)
 	caps := amd64.capabilities()
 	assert.True(caps.IsBlockDeviceHotplugSupported())
 
-	amd64 = newTestQemu(QemuQ35)
+	amd64 = newTestQemu(assert, QemuQ35)
 	caps = amd64.capabilities()
 	assert.True(caps.IsBlockDeviceHotplugSupported())
 }
 
 func TestQemuAmd64Bridges(t *testing.T) {
 	assert := assert.New(t)
-	amd64 := newTestQemu(QemuPC)
+	amd64 := newTestQemu(assert, QemuPC)
 	len := 5
 
 	amd64.bridges(uint32(len))
@@ -64,7 +65,7 @@ func TestQemuAmd64Bridges(t *testing.T) {
 		assert.NotNil(b.Devices)
 	}
 
-	amd64 = newTestQemu(QemuQ35)
+	amd64 = newTestQemu(assert, QemuQ35)
 	amd64.bridges(uint32(len))
 	bridges = amd64.getBridges()
 	assert.Len(bridges, len)
@@ -79,7 +80,7 @@ func TestQemuAmd64Bridges(t *testing.T) {
 
 func TestQemuAmd64CPUModel(t *testing.T) {
 	assert := assert.New(t)
-	amd64 := newTestQemu(QemuPC)
+	amd64 := newTestQemu(assert, QemuPC)
 
 	expectedOut := defaultCPUModel
 	model := amd64.cpuModel()
@@ -101,7 +102,7 @@ func TestQemuAmd64CPUModel(t *testing.T) {
 
 func TestQemuAmd64MemoryTopology(t *testing.T) {
 	assert := assert.New(t)
-	amd64 := newTestQemu(QemuPC)
+	amd64 := newTestQemu(assert, QemuPC)
 	memoryOffset := 1024
 
 	hostMem := uint64(100)
@@ -135,7 +136,8 @@ func TestQemuAmd64AppendImage(t *testing.T) {
 	cfg := qemuConfig(QemuPC)
 	cfg.ImagePath = f.Name()
 	cfg.DisableImageNvdimm = false
-	amd64 := newQemuArch(cfg)
+	amd64, err := newQemuArch(cfg)
+	assert.NoError(err)
 	for _, m := range amd64.(*qemuAmd64).supportedQemuMachines {
 		assert.Contains(m.Options, qemuNvdimmOption)
 	}
@@ -159,7 +161,8 @@ func TestQemuAmd64AppendImage(t *testing.T) {
 	assert.Equal(len(supportedQemuMachines), copy(supportedQemuMachines, machinesCopy))
 
 	cfg.DisableImageNvdimm = true
-	amd64 = newQemuArch(cfg)
+	amd64, err = newQemuArch(cfg)
+	assert.NoError(err)
 	for _, m := range amd64.(*qemuAmd64).supportedQemuMachines {
 		assert.NotContains(m.Options, qemuNvdimmOption)
 	}
@@ -185,7 +188,7 @@ func TestQemuAmd64AppendBridges(t *testing.T) {
 	assert := assert.New(t)
 
 	// check PC
-	amd64 := newTestQemu(QemuPC)
+	amd64 := newTestQemu(assert, QemuPC)
 
 	amd64.bridges(1)
 	bridges := amd64.getBridges()
@@ -208,7 +211,7 @@ func TestQemuAmd64AppendBridges(t *testing.T) {
 	assert.Equal(expectedOut, devices)
 
 	// Check Q35
-	amd64 = newTestQemu(QemuQ35)
+	amd64 = newTestQemu(assert, QemuQ35)
 
 	amd64.bridges(1)
 	bridges = amd64.getBridges()
@@ -237,7 +240,8 @@ func TestQemuAmd64WithInitrd(t *testing.T) {
 
 	cfg := qemuConfig(QemuPC)
 	cfg.InitrdPath = "dummy-initrd"
-	amd64 := newQemuArch(cfg)
+	amd64, err := newQemuArch(cfg)
+	assert.NoError(err)
 
 	for _, m := range amd64.(*qemuAmd64).supportedQemuMachines {
 		assert.NotContains(m.Options, qemuNvdimmOption)
@@ -249,7 +253,8 @@ func TestQemuAmd64Iommu(t *testing.T) {
 
 	config := qemuConfig(QemuQ35)
 	config.IOMMU = true
-	qemu := newQemuArch(config)
+	qemu, err := newQemuArch(config)
+	assert.NoError(err)
 
 	p := qemu.kernelParameters(false)
 	assert.Contains(p, Param{"intel_iommu", "on"})

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -138,9 +138,7 @@ func TestQemuAmd64AppendImage(t *testing.T) {
 	cfg.DisableImageNvdimm = false
 	amd64, err := newQemuArch(cfg)
 	assert.NoError(err)
-	for _, m := range amd64.(*qemuAmd64).supportedQemuMachines {
-		assert.Contains(m.Options, qemuNvdimmOption)
-	}
+	assert.Contains(amd64.machine().Options, qemuNvdimmOption)
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.Object{
@@ -163,9 +161,7 @@ func TestQemuAmd64AppendImage(t *testing.T) {
 	cfg.DisableImageNvdimm = true
 	amd64, err = newQemuArch(cfg)
 	assert.NoError(err)
-	for _, m := range amd64.(*qemuAmd64).supportedQemuMachines {
-		assert.NotContains(m.Options, qemuNvdimmOption)
-	}
+	assert.NotContains(amd64.machine().Options, qemuNvdimmOption)
 
 	found := false
 	devices, err = amd64.appendImage(nil, f.Name())
@@ -243,9 +239,7 @@ func TestQemuAmd64WithInitrd(t *testing.T) {
 	amd64, err := newQemuArch(cfg)
 	assert.NoError(err)
 
-	for _, m := range amd64.(*qemuAmd64).supportedQemuMachines {
-		assert.NotContains(m.Options, qemuNvdimmOption)
-	}
+	assert.NotContains(amd64.machine().Options, qemuNvdimmOption)
 }
 
 func TestQemuAmd64Iommu(t *testing.T) {
@@ -259,8 +253,6 @@ func TestQemuAmd64Iommu(t *testing.T) {
 	p := qemu.kernelParameters(false)
 	assert.Contains(p, Param{"intel_iommu", "on"})
 
-	m, err := qemu.machine()
-
-	assert.NoError(err)
+	m := qemu.machine()
 	assert.Contains(m.Options, "kernel_irqchip=split")
 }

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -41,7 +41,7 @@ type qemuArch interface {
 	machine() govmmQemu.Machine
 
 	// qemuPath returns the path to the QEMU binary
-	qemuPath() (string, error)
+	qemuPath() string
 
 	// kernelParameters returns the kernel parameters
 	// if debug is true then kernel debug parameters are included
@@ -137,13 +137,13 @@ type qemuArch interface {
 
 type qemuArchBase struct {
 	qemuMachine           govmmQemu.Machine
+	qemuExePath           string
 	memoryOffset          uint32
 	nestedRun             bool
 	vhost                 bool
 	disableNvdimm         bool
 	dax                   bool
 	networkIndex          int
-	qemuPaths             map[string]string
 	kernelParamsNonDebug  []Param
 	kernelParamsDebug     []Param
 	kernelParams          []Param
@@ -242,13 +242,8 @@ func (q *qemuArchBase) machine() govmmQemu.Machine {
 	return q.qemuMachine
 }
 
-func (q *qemuArchBase) qemuPath() (string, error) {
-	p, ok := q.qemuPaths[q.qemuMachine.Type]
-	if !ok {
-		return "", fmt.Errorf("Unknown machine type: %s", q.qemuMachine.Type)
-	}
-
-	return p, nil
+func (q *qemuArchBase) qemuPath() string {
+	return q.qemuExePath
 }
 
 func (q *qemuArchBase) kernelParameters(debug bool) []Param {

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -38,7 +38,7 @@ type qemuArch interface {
 	disableVhostNet()
 
 	// machine returns the machine type
-	machine() (govmmQemu.Machine, error)
+	machine() govmmQemu.Machine
 
 	// qemuPath returns the path to the QEMU binary
 	qemuPath() (string, error)
@@ -136,7 +136,7 @@ type qemuArch interface {
 }
 
 type qemuArchBase struct {
-	machineType           string
+	qemuMachine           govmmQemu.Machine
 	memoryOffset          uint32
 	nestedRun             bool
 	vhost                 bool
@@ -144,7 +144,6 @@ type qemuArchBase struct {
 	dax                   bool
 	networkIndex          int
 	qemuPaths             map[string]string
-	supportedQemuMachines []govmmQemu.Machine
 	kernelParamsNonDebug  []Param
 	kernelParamsDebug     []Param
 	kernelParams          []Param
@@ -239,20 +238,14 @@ func (q *qemuArchBase) disableVhostNet() {
 	q.vhost = false
 }
 
-func (q *qemuArchBase) machine() (govmmQemu.Machine, error) {
-	for _, m := range q.supportedQemuMachines {
-		if m.Type == q.machineType {
-			return m, nil
-		}
-	}
-
-	return govmmQemu.Machine{}, fmt.Errorf("unrecognised machine type: %v", q.machineType)
+func (q *qemuArchBase) machine() govmmQemu.Machine {
+	return q.qemuMachine
 }
 
 func (q *qemuArchBase) qemuPath() (string, error) {
-	p, ok := q.qemuPaths[q.machineType]
+	p, ok := q.qemuPaths[q.qemuMachine.Type]
 	if !ok {
-		return "", fmt.Errorf("Unknown machine type: %s", q.machineType)
+		return "", fmt.Errorf("Unknown machine type: %s", q.qemuMachine.Type)
 	}
 
 	return p, nil
@@ -681,12 +674,9 @@ func (q *qemuArchBase) handleImagePath(config HypervisorConfig) {
 	if config.ImagePath != "" {
 		kernelRootParams := commonVirtioblkKernelRootParams
 		if !q.disableNvdimm {
-			for i := range q.supportedQemuMachines {
-				q.supportedQemuMachines[i].Options = strings.Join([]string{
-					q.supportedQemuMachines[i].Options,
-					qemuNvdimmOption,
-				}, ",")
-			}
+			q.qemuMachine.Options = strings.Join([]string{
+				q.qemuMachine.Options, qemuNvdimmOption,
+			}, ",")
 			if q.dax {
 				kernelRootParams = commonNvdimmKernelRootParams
 			} else {
@@ -767,13 +757,12 @@ func (q *qemuArchBase) addBridge(b types.Bridge) {
 
 // appendPCIeRootPortDevice appends to devices the given pcie-root-port
 func (q *qemuArchBase) appendPCIeRootPortDevice(devices []govmmQemu.Device, number uint32) []govmmQemu.Device {
-	return genericAppendPCIeRootPort(devices, number, q.machineType)
-
+	return genericAppendPCIeRootPort(devices, number, q.qemuMachine.Type)
 }
 
 // appendIOMMU appends a virtual IOMMU device
 func (q *qemuArchBase) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {
-	switch q.machineType {
+	switch q.qemuMachine.Type {
 	case QemuQ35:
 		iommu := govmmQemu.IommuDev{
 			Intremap:    true,
@@ -784,6 +773,6 @@ func (q *qemuArchBase) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Devi
 		devices = append(devices, iommu)
 		return devices, nil
 	default:
-		return devices, fmt.Errorf("Machine Type %s does not support vIOMMU", q.machineType)
+		return devices, fmt.Errorf("Machine Type %s does not support vIOMMU", q.qemuMachine.Type)
 	}
 }

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -53,8 +53,8 @@ var qemuArchBaseKernelParams = []Param{
 func newQemuArchBase() *qemuArchBase {
 	return &qemuArchBase{
 		qemuMachine:           qemuArchBaseMachine,
+		qemuExePath:           qemuArchBaseQemuPaths[qemuArchBaseMachine.Type],
 		nestedRun:             false,
-		qemuPaths:             qemuArchBaseQemuPaths,
 		kernelParamsNonDebug:  qemuArchBaseKernelParamsNonDebug,
 		kernelParamsDebug:     qemuArchBaseKernelParamsDebug,
 		kernelParams:          qemuArchBaseKernelParams,
@@ -89,17 +89,8 @@ func TestQemuArchBaseQemuPath(t *testing.T) {
 	assert := assert.New(t)
 	qemuArchBase := newQemuArchBase()
 
-	p, err := qemuArchBase.qemuPath()
-	assert.NoError(err)
+	p := qemuArchBase.qemuPath()
 	assert.Equal(p, qemuArchBaseQemuPath)
-
-	paths := map[string]string{
-		"bad": qemuArchBaseQemuPath,
-	}
-	qemuArchBase.qemuPaths = paths
-	p, err = qemuArchBase.qemuPath()
-	assert.Error(err)
-	assert.Equal("", p)
 }
 
 func TestQemuArchBaseKernelParameters(t *testing.T) {

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -23,12 +23,15 @@ import (
 )
 
 const (
-	qemuArchBaseMachineType = "pc"
 	qemuArchBaseQemuPath    = "/usr/bin/qemu-system-x86_64"
 )
 
+var qemuArchBaseMachine = govmmQemu.Machine{
+	Type: "pc",
+}
+
 var qemuArchBaseQemuPaths = map[string]string{
-	qemuArchBaseMachineType: qemuArchBaseQemuPath,
+	qemuArchBaseMachine.Type: qemuArchBaseQemuPath,
 }
 
 var qemuArchBaseKernelParamsNonDebug = []Param{
@@ -47,18 +50,11 @@ var qemuArchBaseKernelParams = []Param{
 	{"rootfstype", "ext4"},
 }
 
-var qemuArchBaseSupportedQemuMachines = []govmmQemu.Machine{
-	{
-		Type: qemuArchBaseMachineType,
-	},
-}
-
 func newQemuArchBase() *qemuArchBase {
 	return &qemuArchBase{
-		machineType:           qemuArchBaseMachineType,
+		qemuMachine:           qemuArchBaseMachine,
 		nestedRun:             false,
 		qemuPaths:             qemuArchBaseQemuPaths,
-		supportedQemuMachines: qemuArchBaseSupportedQemuMachines,
 		kernelParamsNonDebug:  qemuArchBaseKernelParamsNonDebug,
 		kernelParamsDebug:     qemuArchBaseKernelParamsDebug,
 		kernelParams:          qemuArchBaseKernelParams,
@@ -85,19 +81,8 @@ func TestQemuArchBaseMachine(t *testing.T) {
 	assert := assert.New(t)
 	qemuArchBase := newQemuArchBase()
 
-	m, err := qemuArchBase.machine()
-	assert.NoError(err)
-	assert.Equal(m.Type, qemuArchBaseMachineType)
-
-	machines := []govmmQemu.Machine{
-		{
-			Type: "bad",
-		},
-	}
-	qemuArchBase.supportedQemuMachines = machines
-	m, err = qemuArchBase.machine()
-	assert.Error(err)
-	assert.Equal("", m.Type)
+	m := qemuArchBase.machine()
+	assert.Equal(m.Type, qemuArchBaseMachine.Type)
 }
 
 func TestQemuArchBaseQemuPath(t *testing.T) {
@@ -166,7 +151,7 @@ func TestQemuAddDeviceToBridge(t *testing.T) {
 
 	// addDeviceToBridge successfully
 	q := newQemuArchBase()
-	q.machineType = QemuPC
+	q.qemuMachine.Type = QemuPC
 
 	q.bridges(1)
 	for i := uint32(1); i <= types.PCIBridgeMaxCapacity; i++ {
@@ -181,7 +166,7 @@ func TestQemuAddDeviceToBridge(t *testing.T) {
 
 	// addDeviceToBridge fails cause q.Bridges == 0
 	q = newQemuArchBase()
-	q.machineType = QemuPCLite
+	q.qemuMachine.Type = QemuPCLite
 	q.bridges(0)
 	_, _, err = q.addDeviceToBridge("qemu-bridge", types.PCI)
 	if assert.Error(err) {
@@ -581,11 +566,11 @@ func TestQemuArchBaseAppendIOMMU(t *testing.T) {
 		},
 	}
 	// Test IOMMU is not appended to PC machine type
-	qemuArchBase.machineType = QemuPC
+	qemuArchBase.qemuMachine.Type = QemuPC
 	devices, err = qemuArchBase.appendIOMMU(devices)
 	assert.Error(err)
 
-	qemuArchBase.machineType = QemuQ35
+	qemuArchBase.qemuMachine.Type = QemuQ35
 	devices, err = qemuArchBase.appendIOMMU(devices)
 	assert.NoError(err)
 	assert.Equal(expectedOut, devices)

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -30,10 +30,6 @@ const qmpMigrationWaitTimeout = 10 * time.Second
 
 var defaultQemuMachineOptions = "usb=off,accel=kvm,gic-version=" + getGuestGICVersion()
 
-var qemuPaths = map[string]string{
-	QemuVirt: defaultQemuPath,
-}
-
 var kernelParams = []Param{
 	{"console", "hvc0"},
 	{"console", "hvc1"},
@@ -136,8 +132,8 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 	q := &qemuArm64{
 		qemuArchBase{
 		        qemuMachine:           supportedQemuMachine,
+			qemuExePath:           defaultQemuPath,
 			memoryOffset:          config.MemOffset,
-			qemuPaths:             qemuPaths,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -125,10 +125,14 @@ func MaxQemuVCPUs() uint32 {
 	return uint32(runtime.NumCPU())
 }
 
-func newQemuArch(config HypervisorConfig) qemuArch {
+func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 	machineType := config.HypervisorMachineType
 	if machineType == "" {
 		machineType = defaultQemuMachineType
+	}
+
+	if machineType != defaultQemuMachineType {
+		return nil, fmt.Errorf("unrecognised machinetype: %v", machineType)
 	}
 
 	q := &qemuArm64{
@@ -146,7 +150,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 
 	q.handleImagePath(config)
 
-	return q
+	return q, nil
 }
 
 func (q *qemuArm64) bridges(number uint32) {

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -40,11 +40,9 @@ var kernelParams = []Param{
 	{"iommu.passthrough", "0"},
 }
 
-var supportedQemuMachines = []govmmQemu.Machine{
-	{
-		Type:    QemuVirt,
-		Options: defaultQemuMachineOptions,
-	},
+var supportedQemuMachine = govmmQemu.Machine {
+	Type:    QemuVirt,
+	Options: defaultQemuMachineOptions,
 }
 
 // Logger returns a logrus logger appropriate for logging qemu-aarch64 messages
@@ -137,10 +135,9 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 
 	q := &qemuArm64{
 		qemuArchBase{
-			machineType:           machineType,
+		        qemuMachine:           supportedQemuMachine,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,
@@ -154,12 +151,12 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 }
 
 func (q *qemuArm64) bridges(number uint32) {
-	q.Bridges = genericBridges(number, q.machineType)
+	q.Bridges = genericBridges(number, q.qemuMachine.Type)
 }
 
 // appendBridges appends to devices the given bridges
 func (q *qemuArm64) appendBridges(devices []govmmQemu.Device) []govmmQemu.Device {
-	return genericAppendBridges(devices, q.Bridges, q.machineType)
+	return genericAppendBridges(devices, q.Bridges, q.qemuMachine.Type)
 }
 
 func (q *qemuArm64) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -23,14 +23,16 @@ func qemuConfig(machineType string) HypervisorConfig {
 	}
 }
 
-func newTestQemu(machineType string) qemuArch {
+func newTestQemu(assert *assert.Assertions, machineType string) qemuArch {
 	config := qemuConfig(machineType)
-	return newQemuArch(config)
+	arch, err := newQemuArch(config)
+	assert.NoError(err)
+	return arch
 }
 
 func TestQemuArm64CPUModel(t *testing.T) {
 	assert := assert.New(t)
-	arm64 := newTestQemu(QemuVirt)
+	arm64 := newTestQemu(assert, QemuVirt)
 
 	expectedOut := defaultCPUModel
 	model := arm64.cpuModel()
@@ -39,7 +41,7 @@ func TestQemuArm64CPUModel(t *testing.T) {
 
 func TestQemuArm64MemoryTopology(t *testing.T) {
 	assert := assert.New(t)
-	arm64 := newTestQemu(QemuVirt)
+	arm64 := newTestQemu(assert, QemuVirt)
 
 	hostMem := uint64(4096)
 	mem := uint64(1024)
@@ -107,7 +109,7 @@ func TestQemuArm64AppendBridges(t *testing.T) {
 	var devices []govmmQemu.Device
 	assert := assert.New(t)
 
-	arm64 := newTestQemu(QemuVirt)
+	arm64 := newTestQemu(assert, QemuVirt)
 
 	arm64.bridges(1)
 	bridges := arm64.getBridges()

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -152,9 +152,7 @@ func TestQemuArm64AppendImage(t *testing.T) {
 	cfg := qemuConfig(QemuVirt)
 	cfg.ImagePath = f.Name()
 	arm64 := newQemuArch(cfg)
-	for _, m := range arm64.(*qemuArm64).supportedQemuMachines {
-		assert.Contains(m.Options, qemuNvdimmOption)
-	}
+	assert.Contains(m.machine().Options, qemuNvdimmOption)
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.Object{
@@ -182,7 +180,5 @@ func TestQemuArm64WithInitrd(t *testing.T) {
 	cfg.InitrdPath = "dummy-initrd"
 	arm64 := newQemuArch(cfg)
 
-	for _, m := range arm64.(*qemuArm64).supportedQemuMachines {
-		assert.NotContains(m.Options, qemuNvdimmOption)
-	}
+	assert.NotContains(m.machine().Options, qemuNvdimmOption)
 }

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -40,11 +40,9 @@ var kernelParams = []Param{
 	{"net.ifnames", "0"},
 }
 
-var supportedQemuMachines = []govmmQemu.Machine{
-	{
-		Type:    QemuPseries,
-		Options: defaultQemuMachineOptions,
-	},
+var supportedQemuMachine = govmmQemu.Machine {
+	Type:    QemuPseries,
+	Options: defaultQemuMachineOptions,
 }
 
 // Logger returns a logrus logger appropriate for logging qemu messages
@@ -69,10 +67,9 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 
 	q := &qemuPPC64le{
 		qemuArchBase{
-			machineType:           machineType,
+			qemuMachine:           supportedQemuMachine,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,
@@ -90,7 +87,7 @@ func (q *qemuPPC64le) capabilities() types.Capabilities {
 	var caps types.Capabilities
 
 	// pseries machine type supports hotplugging drives
-	if q.machineType == QemuPseries {
+	if q.qemuMachine.Type == QemuPseries {
 		caps.SetBlockDeviceHotplugSupport()
 	}
 
@@ -101,7 +98,7 @@ func (q *qemuPPC64le) capabilities() types.Capabilities {
 }
 
 func (q *qemuPPC64le) bridges(number uint32) {
-	q.Bridges = genericBridges(number, q.machineType)
+	q.Bridges = genericBridges(number, q.qemuMachine.Type)
 }
 
 func (q *qemuPPC64le) cpuModel() string {
@@ -117,7 +114,7 @@ func (q *qemuPPC64le) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8)
 
 // appendBridges appends to devices the given bridges
 func (q *qemuPPC64le) appendBridges(devices []govmmQemu.Device) []govmmQemu.Device {
-	return genericAppendBridges(devices, q.Bridges, q.machineType)
+	return genericAppendBridges(devices, q.Bridges, q.qemuMachine.Type)
 }
 
 func (q *qemuPPC64le) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -57,10 +57,14 @@ func MaxQemuVCPUs() uint32 {
 	return uint32(128)
 }
 
-func newQemuArch(config HypervisorConfig) qemuArch {
+func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 	machineType := config.HypervisorMachineType
 	if machineType == "" {
 		machineType = defaultQemuMachineType
+	}
+
+	if machineType != defaultQemuMachineType {
+		return nil, fmt.Errorf("unrecognised machinetype: %v", machineType)
 	}
 
 	q := &qemuPPC64le{
@@ -79,7 +83,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 
 	q.memoryOffset = config.MemOffset
 
-	return q
+	return q, nil
 }
 
 func (q *qemuPPC64le) capabilities() types.Capabilities {

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -27,10 +27,6 @@ const defaultQemuMachineOptions = "accel=kvm,usb=off"
 
 const qmpMigrationWaitTimeout = 5 * time.Second
 
-var qemuPaths = map[string]string{
-	QemuPseries: defaultQemuPath,
-}
-
 var kernelParams = []Param{
 	{"rcupdate.rcu_expedited", "1"},
 	{"reboot", "k"},
@@ -68,8 +64,8 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 	q := &qemuPPC64le{
 		qemuArchBase{
 			qemuMachine:           supportedQemuMachine,
+			qemuExePath:           defaultQemuPath,
 			memoryOffset:          config.MemOffset,
-			qemuPaths:             qemuPaths,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,

--- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
@@ -13,16 +13,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestQemu(machineType string) qemuArch {
+func newTestQemu(assert *assert.Assertions, machineType string) qemuArch {
 	config := HypervisorConfig{
 		HypervisorMachineType: machineType,
 	}
-	return newQemuArch(config)
+	arch, err := newQemuArch(config)
+	assert.NoError(err)
+	return arch
 }
 
 func TestQemuPPC64leCPUModel(t *testing.T) {
 	assert := assert.New(t)
-	ppc64le := newTestQemu(QemuPseries)
+	ppc64le := newTestQemu(assert, QemuPseries)
 
 	expectedOut := defaultCPUModel
 	model := ppc64le.cpuModel()
@@ -31,7 +33,7 @@ func TestQemuPPC64leCPUModel(t *testing.T) {
 
 func TestQemuPPC64leMemoryTopology(t *testing.T) {
 	assert := assert.New(t)
-	ppc64le := newTestQemu(QemuPseries)
+	ppc64le := newTestQemu(assert, QemuPseries)
 	memoryOffset := 1024
 
 	hostMem := uint64(1024)

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -40,11 +40,9 @@ var kernelParams = []Param{
 
 var ccwbridge = types.NewBridge(types.CCW, "", make(map[uint32]string, types.CCWBridgeMaxCapacity), 0)
 
-var supportedQemuMachines = []govmmQemu.Machine{
-	{
-		Type:    QemuCCWVirtio,
-		Options: defaultQemuMachineOptions,
-	},
+var supportedQemuMachine = govmmQemu.Machine {
+	Type:    QemuCCWVirtio,
+	Options: defaultQemuMachineOptions,
 }
 
 // MaxQemuVCPUs returns the maximum number of vCPUs supported
@@ -67,10 +65,9 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 
 	q := &qemuS390x{
 		qemuArchBase{
-			machineType:           machineType,
+			qemuMachine:           supportedQemuMachine,
 			memoryOffset:          config.MemOffset,
 			qemuPaths:             qemuPaths,
-			supportedQemuMachines: supportedQemuMachines,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,
@@ -89,7 +86,7 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 }
 
 func (q *qemuS390x) bridges(number uint32) {
-	q.Bridges = genericBridges(number, q.machineType)
+	q.Bridges = genericBridges(number, q.qemuMachine.Type)
 }
 
 // appendConsole appends a console to devices.
@@ -230,7 +227,7 @@ func (q *qemuS390x) append9PVolume(devices []govmmQemu.Device, volume types.Volu
 
 // appendBridges appends to devices the given bridges
 func (q *qemuS390x) appendBridges(devices []govmmQemu.Device) []govmmQemu.Device {
-	return genericAppendBridges(devices, q.Bridges, q.machineType)
+	return genericAppendBridges(devices, q.Bridges, q.qemuMachine.Type)
 }
 
 func (q *qemuS390x) appendSCSIController(devices []govmmQemu.Device, enableIOThreads bool) ([]govmmQemu.Device, *govmmQemu.IOThread, error) {

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -29,10 +29,6 @@ const virtioSerialCCW = "virtio-serial-ccw"
 
 const qmpMigrationWaitTimeout = 5 * time.Second
 
-var qemuPaths = map[string]string{
-	QemuCCWVirtio: defaultQemuPath,
-}
-
 // Verify needed parameters
 var kernelParams = []Param{
 	{"console", "ttysclp0"},
@@ -66,8 +62,8 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 	q := &qemuS390x{
 		qemuArchBase{
 			qemuMachine:           supportedQemuMachine,
+			qemuExePath:           defaultQemuPath,
 			memoryOffset:          config.MemOffset,
-			qemuPaths:             qemuPaths,
 			kernelParamsNonDebug:  kernelParamsNonDebug,
 			kernelParamsDebug:     kernelParamsDebug,
 			kernelParams:          kernelParams,

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -55,10 +55,14 @@ func MaxQemuVCPUs() uint32 {
 	return uint32(248)
 }
 
-func newQemuArch(config HypervisorConfig) qemuArch {
+func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 	machineType := config.HypervisorMachineType
 	if machineType == "" {
 		machineType = defaultQemuMachineType
+	}
+
+	if machineType != defaultQemuMachineType {
+		return nil, fmt.Errorf("unrecognised machinetype: %v", machineType)
 	}
 
 	q := &qemuS390x{
@@ -81,7 +85,7 @@ func newQemuArch(config HypervisorConfig) qemuArch {
 		q.kernelParamsDebug = append(q.kernelParamsDebug, kernelParamsSystemdDebug...)
 	}
 
-	return q
+	return q, nil
 }
 
 func (q *qemuS390x) bridges(number uint32) {

--- a/src/runtime/virtcontainers/qemu_s390x_test.go
+++ b/src/runtime/virtcontainers/qemu_s390x_test.go
@@ -14,16 +14,18 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func newTestQemu(machineType string) qemuArch {
+func newTestQemu(assert *assert.Assertions, machineType string) qemuArch {
 	config := HypervisorConfig{
 		HypervisorMachineType: machineType,
 	}
-	return newQemuArch(config)
+	arch, err := newQemuArch(config)
+	assert.NoError(err)
+	return arch
 }
 
 func TestQemuS390xCPUModel(t *testing.T) {
 	assert := assert.New(t)
-	s390x := newTestQemu(QemuCCWVirtio)
+	s390x := newTestQemu(assert, QemuCCWVirtio)
 
 	expectedOut := defaultCPUModel
 	model := s390x.cpuModel()
@@ -37,7 +39,7 @@ func TestQemuS390xCPUModel(t *testing.T) {
 
 func TestQemuS390xMemoryTopology(t *testing.T) {
 	assert := assert.New(t)
-	s390x := newTestQemu(QemuCCWVirtio)
+	s390x := newTestQemu(assert, QemuCCWVirtio)
 
 	hostMem := uint64(1024)
 	mem := uint64(120)

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -346,9 +346,7 @@ func TestQemuQemuPath(t *testing.T) {
 			Type: "pc",
 			Options: "",
 		},
-		qemuPaths: map[string]string{
-			"pc": expectedPath,
-		},
+		qemuExePath: expectedPath,
 	}
 
 	q := &qemu{
@@ -372,13 +370,6 @@ func TestQemuQemuPath(t *testing.T) {
 	path, err = q.qemuPath()
 	assert.NoError(err)
 	assert.Equal(path, expectedPath)
-
-	// bad machine type, arch should fail
-	qkvm.qemuMachine.Type = "rgb"
-	q.arch = qkvm
-	path, err = q.qemuPath()
-	assert.Error(err)
-	assert.Equal(path, "")
 }
 
 func TestHotplugUnsupportedDeviceType(t *testing.T) {

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -342,7 +342,10 @@ func TestQemuQemuPath(t *testing.T) {
 	qemuConfig := newQemuConfig()
 	qemuConfig.HypervisorPath = expectedPath
 	qkvm := &qemuArchBase{
-		machineType: "pc",
+		qemuMachine: govmmQemu.Machine{
+			Type: "pc",
+			Options: "",
+		},
 		qemuPaths: map[string]string{
 			"pc": expectedPath,
 		},
@@ -371,7 +374,7 @@ func TestQemuQemuPath(t *testing.T) {
 	assert.Equal(path, expectedPath)
 
 	// bad machine type, arch should fail
-	qkvm.machineType = "rgb"
+	qkvm.qemuMachine.Type = "rgb"
 	q.arch = qkvm
 	path, err = q.qemuPath()
 	assert.Error(err)


### PR DESCRIPTION
We have some tables in qemuArchBase where only one element is actually used.  Here are some simple cleanups to simplify those.