### PR TITLE
Don't use some x86 specific kernel and qemu options

### DIFF
--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -102,11 +102,7 @@ func (q *qemuPPC64le) bridges(number uint32) {
 }
 
 func (q *qemuPPC64le) cpuModel() string {
-	cpuModel := defaultCPUModel
-	if q.nestedRun {
-		cpuModel += ",pmu=off"
-	}
-	return cpuModel
+	return defaultCPUModel
 }
 
 func (q *qemuPPC64le) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory {

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -33,10 +33,7 @@ var qemuPaths = map[string]string{
 }
 
 var kernelParams = []Param{
-	{"tsc", "reliable"},
-	{"no_timer_check", ""},
 	{"rcupdate.rcu_expedited", "1"},
-	{"noreplace-smp", ""},
 	{"reboot", "k"},
 	{"console", "hvc0"},
 	{"console", "hvc1"},

--- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
@@ -32,11 +32,6 @@ func TestQemuPPC64leCPUModel(t *testing.T) {
 	expectedOut := defaultCPUModel
 	model := ppc64le.cpuModel()
 	assert.Equal(expectedOut, model)
-
-	ppc64le.enableNestingChecks()
-	expectedOut = defaultCPUModel + ",pmu=off"
-	model = ppc64le.cpuModel()
-	assert.Equal(expectedOut, model)
 }
 
 func getQemuVersion() (qemuMajorVersion int, qemuMinorVersion int) {


### PR DESCRIPTION
qemu_ppc64le.go applies some qemu and kernel options which make no sense for ppc64, since they're x86 specific.  