### PR TITLE
[Forward port] Bring ppc64le fixes to 2.0 dev tree

### DIFF
--- a/src/runtime/arch/ppc64le-options.mk
+++ b/src/runtime/arch/ppc64le-options.mk
@@ -9,4 +9,4 @@ MACHINETYPE := pseries
 KERNELPARAMS :=
 MACHINEACCELERATORS :=
 KERNELTYPE := uncompressed #This architecture must use an uncompressed kernel.
-QEMUCMD := qemu-system-ppc64le
+QEMUCMD := qemu-system-ppc64

--- a/src/runtime/arch/ppc64le-options.mk
+++ b/src/runtime/arch/ppc64le-options.mk
@@ -7,6 +7,6 @@
 
 MACHINETYPE := pseries
 KERNELPARAMS :=
-MACHINEACCELERATORS :=
+MACHINEACCELERATORS := "cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large-decr=off,cap-ccf-assist=off"
 KERNELTYPE := uncompressed #This architecture must use an uncompressed kernel.
 QEMUCMD := qemu-system-ppc64

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -22,7 +22,7 @@ const defaultQemuPath = "/usr/bin/qemu-system-ppc64"
 
 const defaultQemuMachineType = QemuPseries
 
-const defaultQemuMachineOptions = "accel=kvm,usb=off,cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large-decr=off"
+const defaultQemuMachineOptions = "accel=kvm,usb=off"
 
 const defaultMemMaxPPC64le = 32256 // Restrict MemMax to 32Gb on PPC64le
 

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -18,7 +18,7 @@ type qemuPPC64le struct {
 	qemuArchBase
 }
 
-const defaultQemuPath = "/usr/bin/qemu-system-ppc64le"
+const defaultQemuPath = "/usr/bin/qemu-system-ppc64"
 
 const defaultQemuMachineType = QemuPseries
 


### PR DESCRIPTION
This series brings the following ppc64le fixes to the 2.0 tree

- #2657 - Remove hard coding qemu-options to work with qemu-5.0
- #2738 - default qemu binary path to work with Fedora and Ubuntu distros