### PR TITLE
shimv2 : Remove workaround for sharedPidNs

### DIFF
--- a/src/runtime/containerd-shim-v2/create.go
+++ b/src/runtime/containerd-shim-v2/create.go
@@ -132,14 +132,6 @@ func loadSpec(r *taskAPI.CreateTaskRequest) (*specs.Spec, string, error) {
 		return nil, "", err
 	}
 
-	// Todo:
-	// Since there is a bug in kata for sharedPidNs, here to
-	// remove the pidns to disable the sharePidNs temporarily,
-	// once kata fixed this issue, we can remove this line.
-	// For the bug, please see:
-	// https://github.com/kata-containers/kata-containers/src/runtime/issues/930
-	removeNamespace(&ociSpec, specs.PIDNamespace)
-
 	return &ociSpec, bundlePath, nil
 }
 

--- a/src/runtime/containerd-shim-v2/utils.go
+++ b/src/runtime/containerd-shim-v2/utils.go
@@ -19,7 +19,6 @@ import (
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/oci"
-	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
 )
 
@@ -123,13 +122,4 @@ func noNeedForOutput(detach bool, tty bool) bool {
 	}
 
 	return true
-}
-
-func removeNamespace(s *specs.Spec, nsType specs.LinuxNamespaceType) {
-	for i, n := range s.Linux.Namespaces {
-		if n.Type == nsType {
-			s.Linux.Namespaces = append(s.Linux.Namespaces[:i], s.Linux.Namespaces[i+1:]...)
-			return
-		}
-	}
 }


### PR DESCRIPTION
Removing code that existed as a workaround for a bug in
how shared process namespaces were handled in the agent.
That has been long fixed in the agent.
With this, sharedPidNs will now work with shimv2.