### PR TITLE
agent: Make LIBC configurable

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -31,7 +31,15 @@ ifdef proto
 endif
 
 ARCH = $(shell uname -m)
-LIBC = musl
+LIBC ?= musl
+ifneq ($(LIBC),musl)
+    ifeq ($(LIBC),gnu)
+        override LIBC = gnu
+    else
+        $(error "ERROR: A non supported LIBC value was passed. Supported values are musl and gnu")
+    endif
+endif
+
 TRIPLE = $(ARCH)-unknown-linux-$(LIBC)
 
 TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)


### PR DESCRIPTION
Currently the default LIBC used to build the agent is "musl". However,
"musl" is not preset in a big portion of the distros *and* "gnu" libc
just works as expected.

Knowing that, let's add the option to the one building the project to
simply do `make LIBC=gnu` instead of expected the person to go through
the Makefile and replace musl by gnu there.

Fixes: #369

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>