### PR TITLE
agent: device: Allow "VmPath" to be used when adding block devices

### DIFF
--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -298,7 +298,13 @@ fn virtio_blk_device_handler(
     sandbox: &Arc<Mutex<Sandbox>>,
 ) -> Result<()> {
     let mut dev = device.clone();
-    dev.vm_path = get_pci_device_name(sandbox, &device.id)?;
+
+    // When "Id (PCIAddr)" is not set, we allow to use the predicted "VmPath" passed from kata-runtime
+    // Note this is a special code path for cloud-hypervisor when BDF information is not available
+    if device.id != "" {
+        dev.vm_path = get_pci_device_name(sandbox, &device.id)?;
+    }
+
     update_spec_device_list(&dev, spec)
 }
 


### PR DESCRIPTION
When the "PCIAddr" (BDF information) is available, we allow to use the
predicted "VmPath" (from kata-runtime) to locate the block device in the
agent. This is a special code path for supporting block-device/volume
passthrough w/ cloud-hypervisor when the BDF information is not
available (as of clh v0.8.0).

This is mainly porting the changes from kata-agent PR https://github.com/kata-containers/agent/pull/790,
as the related changes from kata-runtime is ported to kata 2.0 earlier
this week (https://github.com/kata-containers/kata-containers/pull/362).

Note that the upstream clh recently added the support of returning BDF
information for hotplugged devices. We will consolidate/remove this
special code path for the next upgrade of clh version in kata.

Fixes: #248

Signed-off-by: Bo Chen <chen.bo@intel.com>