### PR TITLE
versions: Revert "versions: update QEMU to 5.0.0"

### DIFF
--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -30,9 +30,9 @@ install_yq() {
 
 get_from_kata_deps() {
 	local dependency="$1"
-	BRANCH=${BRANCH:-master}
+	BRANCH=${branch:-master}
 	local branch="${2:-${BRANCH}}"
-	local runtime_repo="github.com/kata-containers/runtime"
+	local runtime_repo="github.com/kata-containers/kata-containers"
 	GOPATH=${GOPATH:-${HOME}/go}
 	local runtime_repo_dir="${GOPATH}/src/${runtime_repo}"
 	# For our CI, we will query the local versions.yaml file both for kernel and

--- a/versions.yaml
+++ b/versions.yaml
@@ -88,8 +88,8 @@ assets:
     qemu:
       description: "VMM that uses KVM"
       url: "https://github.com/qemu/qemu"
-      version: "5.0.0"
-      tag: "v5.0.0"
+      version: "4.1.1"
+      tag: "v4.1.1"
       # Do not include any non-full release versions
       # Break the line *without CR or space being appended*, to appease
       # yamllint, and note the deliberate ' ' at the end of the expression.


### PR DESCRIPTION
This reverts commit 15af20b6dac6f427892405c3e4b064e0c8fe2cd6.

kubernetes test are failing randomly with QEMU 5.0.0, let's go back to
QEMU 4.1.1 and debug the failures with QEMU 5

Depends-on: github.com/kata-containers/tests#2701

fixes #379