### PR TITLE
config: there is no need to check vhost-vosck for FC

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -561,10 +561,6 @@ func newFirecrackerHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		return vc.HypervisorConfig{}, err
 	}
 
-	if !utils.SupportsVsocks() {
-		return vc.HypervisorConfig{}, errors.New("No vsock support, firecracker cannot be used")
-	}
-
 	rxRateLimiterMaxRate, err := h.getRxRateLimiterCfg()
 	if err != nil {
 		return vc.HypervisorConfig{}, err


### PR DESCRIPTION
Since the FC used the hybrid vsock, there's no need
to check whether the vhost vsock suported by host.

Fixes: #387

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>