### PR TITLE
runtime: handle unimplemented RPC call by NotFound status code

### DIFF
--- a/src/runtime/containerd-shim-v2/errors_test.go
+++ b/src/runtime/containerd-shim-v2/errors_test.go
@@ -35,5 +35,6 @@ func TestIsGRPCErrorCode(t *testing.T) {
 	assert := assert.New(t)
 
 	assert.True(isGRPCErrorCode(codes.Unimplemented, status.New(codes.Unimplemented, "foobar").Err()))
+	assert.True(isGRPCErrorCode(codes.NotFound, status.New(codes.NotFound, "foobar").Err()))
 	assert.False(isGRPCErrorCode(codes.Unimplemented, errors.New("foobar")))
 }

--- a/src/runtime/containerd-shim-v2/wait.go
+++ b/src/runtime/containerd-shim-v2/wait.go
@@ -145,7 +145,8 @@ func watchOOMEvents(ctx context.Context, s *service) {
 				logrus.WithField("sandbox", s.sandbox.ID()).WithError(err).Warn("failed to get OOM event from sandbox")
 				// If the GetOOMEvent call is not implemented, then the agent is most likely an older version,
 				// stop attempting to get OOM events.
-				if isGRPCErrorCode(codes.Unimplemented, err) {
+				// for rust agent, the response code is not found
+				if isGRPCErrorCode(codes.NotFound, err) {
 					return
 				}
 				continue


### PR DESCRIPTION
For now, agent return status of NotFound when calling getOOMEvents, runtime should handle it correctly.

Fixes: #393

Signed-off-by: bin liu <bin@hyper.sh>