### PR TITLE
docs: add link to CRI Configuration for pods

### DIFF
--- a/docs/how-to/how-to-load-kernel-modules-with-kata.md
+++ b/docs/how-to/how-to-load-kernel-modules-with-kata.md
@@ -101,6 +101,8 @@ spec:
     tty: true
 ```
 
+> **Note**: To pass annotations to Kata containers, [cri must to be configurated correctly](how-to-set-sandbox-config-kata.md#cri-configuration)
+
 [1]: https://github.com/kata-containers/runtime
 [2]: https://github.com/kata-containers/agent
 [3]: https://kubernetes.io/docs/concepts/workloads/pods/pod/


### PR DESCRIPTION
To pass annotations from CRI to Kata containers, user must configure containerd if containerd is used.

User may miss this configuration.

Signed-off-by: bin liu <bin@hyper.sh>

Related https://github.com/kata-containers/documentation/issues/683