### PR TITLE
add rust agent sandbox shared pid namespace support

### DIFF
--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -65,6 +65,11 @@ impl Namespace {
         self
     }
 
+    pub fn as_pid(mut self) -> Self {
+        self.ns_type = NamespaceType::PID;
+        self
+    }
+
     pub fn set_root_dir(mut self, dir: &str) -> Self {
         self.persistent_ns_dir = dir.to_string();
         self

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -79,6 +79,7 @@ impl agentService {
         let cid = req.container_id.clone();
 
         let mut oci_spec = req.OCI.clone();
+        let use_sandbox_pidns = req.get_sandbox_pidns();
 
         let sandbox;
         let mut s;
@@ -121,7 +122,7 @@ impl agentService {
             s.container_mounts.insert(cid.clone(), m);
         }
 
-        update_container_namespaces(&s, &mut oci)?;
+        update_container_namespaces(&s, &mut oci, use_sandbox_pidns)?;
 
         // Add the root partition to the device cgroup to prevent access
         update_device_cgroup(&mut oci)?;
@@ -162,6 +163,7 @@ impl agentService {
 
         ctr.start(p)?;
 
+        s.update_shared_pidns(&ctr)?;
         s.add_container(ctr);
         info!(sl!(), "created container!");
 
@@ -1478,7 +1480,11 @@ pub fn start<S: Into<String>>(s: Arc<Mutex<Sandbox>>, host: S, port: u16) -> ttr
 // path set by the spec, since we will always ignore it. Indeed, it makes no
 // sense to rely on the namespace path provided by the host since namespaces
 // are different inside the guest.
-fn update_container_namespaces(sandbox: &Sandbox, spec: &mut Spec) -> Result<()> {
+fn update_container_namespaces(
+    sandbox: &Sandbox,
+    spec: &mut Spec,
+    sandbox_pidns: bool,
+) -> Result<()> {
     let linux = match spec.linux.as_mut() {
         None => {
             return Err(
@@ -1488,14 +1494,8 @@ fn update_container_namespaces(sandbox: &Sandbox, spec: &mut Spec) -> Result<()>
         Some(l) => l,
     };
 
-    let mut pidNs = false;
-
     let namespaces = linux.namespaces.as_mut_slice();
     for namespace in namespaces.iter_mut() {
-        if namespace.r#type == NSTYPEPID {
-            pidNs = true;
-            continue;
-        }
         if namespace.r#type == NSTYPEIPC {
             namespace.path = sandbox.shared_ipcns.path.clone();
             continue;
@@ -1505,13 +1505,19 @@ fn update_container_namespaces(sandbox: &Sandbox, spec: &mut Spec) -> Result<()>
             continue;
         }
     }
+    // update pid namespace
+    let mut pid_ns = LinuxNamespace::default();
+    pid_ns.r#type = NSTYPEPID.to_string();
 
-    if !pidNs && !sandbox.sandbox_pid_ns {
-        let mut pid_ns = LinuxNamespace::default();
-        pid_ns.r#type = NSTYPEPID.to_string();
-        linux.namespaces.push(pid_ns);
+    // Use shared pid ns if useSandboxPidns has been set in either
+    // the create_sandbox request or create_container request.
+    // Else set this to empty string so that a new pid namespace is
+    // created for the container.
+    if sandbox_pidns && sandbox.sandbox_pidns.is_some() {
+        pid_ns.path = String::from(sandbox.sandbox_pidns.as_ref().unwrap().path.as_str());
     }
 
+    linux.namespaces.push(pid_ns);
     Ok(())
 }
 


### PR DESCRIPTION
Add rust agent sandbox shared pid namespace.
this PR only support shared pid namespace by
sharing the infrastructure pause container's pid namespace
with other containers, instead of creating a new pid
namespace different from pause container.