### PR TITLE
Rust warning fixes

### DIFF
--- a/pkg/logging/src/lib.rs
+++ b/pkg/logging/src/lib.rs
@@ -182,12 +182,6 @@ impl<D> RuntimeLevelFilter<D> {
             level: Mutex::new(level),
         }
     }
-
-    fn set_level(&self, level: slog::Level) {
-        let mut log_level = self.level.lock().unwrap();
-
-        *log_level = level;
-    }
 }
 
 impl<D> Drain for RuntimeLevelFilter<D>

--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -136,6 +136,7 @@ show-summary: show-header
 	@printf "  %s\n" "$(call get_command_version,rustc)"
 	@printf "  %s\n" "$(call get_command_version,rustup)"
 	@printf "  %s\n" "$(call get_toolchain_version)"
+	@printf "  target toolchain: %s\n" "$(TRIPLE)"
 	@printf "\n"
 
 help: show-summary

--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -23,6 +23,9 @@ COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)
 # Exported to allow cargo to see it
 export VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
 
+# Deny any warning
+export RUSTFLAGS = -D warnings
+
 BUILD_TYPE = release
 
 # set proto file to generate

--- a/src/agent/oci/src/serialize.rs
+++ b/src/agent/oci/src/serialize.rs
@@ -28,21 +28,7 @@ impl Display for Error {
     }
 }
 
-impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref e) => e.description(),
-            Error::Json(ref e) => e.description(),
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn error::Error> {
-        match *self {
-            Error::Io(ref e) => Some(e),
-            Error::Json(ref e) => Some(e),
-        }
-    }
-}
+impl error::Error for Error {}
 
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Error {

--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -1321,7 +1321,7 @@ impl CgroupManager for Manager {
             match Blkio().get_stats(self.paths.get("blkio").unwrap()) {
                 Ok(stat) => SingularPtrField::some(stat),
                 Err(e) => {
-                    warn!(sl!(), "failed to get blkio stats");
+                    warn!(sl!(), "failed to get blkio stats {:?}", e);
                     SingularPtrField::none()
                 }
             }

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1589,7 +1589,7 @@ fn execute_hook(logger: &Logger, h: &Hook, st: &OCIState) -> Result<()> {
                         info!(
                             logger,
                             "wait child error: {} {}",
-                            e.description(),
+                            e.to_string(),
                             e.raw_os_error().unwrap()
                         );
 

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -53,7 +53,7 @@ use std::io::BufRead;
 use std::io::BufReader;
 use std::os::unix::io::FromRawFd;
 
-use slog::{debug, info, o, Logger};
+use slog::{info, o, Logger};
 
 const STATE_FILENAME: &'static str = "state.json";
 const EXEC_FIFO_FILENAME: &'static str = "exec.fifo";
@@ -1466,7 +1466,6 @@ fn set_sysctls(sysctls: &HashMap<String, String>) -> Result<()> {
     Ok(())
 }
 
-use std::error::Error as StdError;
 use std::io::Read;
 use std::os::unix::process::ExitStatusExt;
 use std::process::Stdio;

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -369,7 +369,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
 
     let buf = read_sync(crfd)?;
     let process_str = std::str::from_utf8(&buf)?;
-    let mut oci_process: oci::Process = serde_json::from_str(process_str)?;
+    let oci_process: oci::Process = serde_json::from_str(process_str)?;
     log_child!(cfd_log, "notify parent to send cgroup manager");
     write_sync(cwfd, SYNC_SUCCESS, "")?;
 
@@ -865,7 +865,7 @@ impl BaseContainer for LinuxContainer {
             child = child.env(FIFO_FD, format!("{}", fifofd));
         }
 
-        let mut child = child.spawn()?;
+        let child = child.spawn()?;
 
         unistd::close(crfd)?;
         unistd::close(cwfd)?;

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -17,7 +17,7 @@ use libc::pid_t;
 use oci::{LinuxDevice, LinuxIDMapping};
 use std::clone::Clone;
 use std::fmt::Display;
-use std::process::{Child, Command};
+use std::process::Command;
 
 // use crate::configs::namespaces::{NamespaceType};
 use crate::cgroups::Manager as CgroupManager;
@@ -888,7 +888,6 @@ impl BaseContainer for LinuxContainer {
             &p,
             self.cgroup_manager.as_ref().unwrap(),
             &st,
-            &mut child,
             pwfd,
             prfd,
         ) {
@@ -918,7 +917,7 @@ impl BaseContainer for LinuxContainer {
 
         if p.init {
             let spec = self.config.spec.as_mut().unwrap();
-            update_namespaces(&self.logger, spec, p.pid)?;
+            update_namespaces(spec, p.pid)?;
         }
         self.processes.insert(p.pid, p);
 
@@ -1034,7 +1033,7 @@ fn do_exec(args: &[String]) -> Result<()> {
     Ok(())
 }
 
-fn update_namespaces(logger: &Logger, spec: &mut Spec, init_pid: RawFd) -> Result<()> {
+fn update_namespaces(spec: &mut Spec, init_pid: RawFd) -> Result<()> {
     let linux = match spec.linux.as_mut() {
         None => {
             return Err(
@@ -1117,7 +1116,6 @@ fn join_namespaces(
     p: &Process,
     cm: &FsManager,
     st: &OCIState,
-    child: &mut Child,
     pwfd: RawFd,
     prfd: RawFd,
 ) -> Result<()> {

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -3,15 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// #![allow(unused_attributes)]
-// #![allow(unused_imports)]
-// #![allow(unused_variables)]
-// #![allow(unused_mut)]
 #![allow(dead_code)]
-// #![allow(deprecated)]
-// #![allow(unused_must_use)]
 #![allow(non_upper_case_globals)]
-// #![allow(unused_comparisons)]
 #[macro_use]
 extern crate error_chain;
 extern crate serde;
@@ -58,7 +51,6 @@ use protocols::oci::{
     Root as grpcRoot, Spec as grpcSpec,
 };
 use std::collections::HashMap;
-use std::mem::MaybeUninit;
 
 pub fn process_grpc_to_oci(p: &grpcProcess) -> ociProcess {
     let console_size = if p.ConsoleSize.is_some() {
@@ -80,7 +72,7 @@ pub fn process_grpc_to_oci(p: &grpcProcess) -> ociProcess {
             username: u.Username.clone(),
         }
     } else {
-        unsafe { MaybeUninit::zeroed().assume_init() }
+        Default::default()
     };
 
     let capabilities = if p.Capabilities.is_some() {
@@ -125,20 +117,11 @@ pub fn process_grpc_to_oci(p: &grpcProcess) -> ociProcess {
     }
 }
 
-fn process_oci_to_grpc(_p: ociProcess) -> grpcProcess {
-    // dont implement it for now
-    unsafe { MaybeUninit::zeroed().assume_init() }
-}
-
 fn root_grpc_to_oci(root: &grpcRoot) -> ociRoot {
     ociRoot {
         path: root.Path.clone(),
         readonly: root.Readonly,
     }
-}
-
-fn root_oci_to_grpc(_root: &ociRoot) -> grpcRoot {
-    unsafe { MaybeUninit::zeroed().assume_init() }
 }
 
 fn mount_grpc_to_oci(m: &grpcMount) -> ociMount {
@@ -148,10 +131,6 @@ fn mount_grpc_to_oci(m: &grpcMount) -> ociMount {
         source: m.source.clone(),
         options: m.options.clone().into_vec(),
     }
-}
-
-fn mount_oci_to_grpc(_m: &ociMount) -> grpcMount {
-    unsafe { MaybeUninit::zeroed().assume_init() }
 }
 
 use oci::Hook as ociHook;
@@ -182,10 +161,6 @@ fn hooks_grpc_to_oci(h: &grpcHooks) -> ociHooks {
         poststart,
         poststop,
     }
-}
-
-fn hooks_oci_to_grpc(_h: &ociHooks) -> grpcHooks {
-    unsafe { MaybeUninit::zeroed().assume_init() }
 }
 
 use oci::{
@@ -551,17 +526,5 @@ pub fn grpc_to_oci(grpc: &grpcSpec) -> ociSpec {
         solaris: None,
         windows: None,
         vm: None,
-    }
-}
-
-pub fn oci_to_grpc(_oci: &ociSpec) -> grpcSpec {
-    unsafe { MaybeUninit::zeroed().assume_init() }
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
     }
 }

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -35,13 +35,6 @@ extern crate oci;
 extern crate path_absolutize;
 extern crate regex;
 
-// Convenience macro to obtain the scope logger
-macro_rules! sl {
-    () => {
-        slog_scope::logger().new(o!("subsystem" => "rustjail"))
-    };
-}
-
 pub mod capabilities;
 pub mod cgroups;
 pub mod container;
@@ -51,17 +44,6 @@ pub mod process;
 pub mod specconv;
 pub mod sync;
 pub mod validator;
-
-// pub mod factory;
-//pub mod configs;
-// pub mod devices;
-// pub mod init;
-// pub mod rootfs;
-// pub mod capabilities;
-// pub mod console;
-// pub mod stats;
-// pub mod user;
-//pub mod intelrdt;
 
 // construtc ociSpec from grpcSpec, which is needed for hook
 // execution. since hooks read config.json

--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -14,12 +14,9 @@ use std::os::unix::io::RawFd;
 
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 use nix::sys::signal::{self, Signal};
-use nix::sys::socket::{self, AddressFamily, SockFlag, SockType};
 use nix::sys::wait::{self, WaitStatus};
 use nix::unistd::{self, Pid};
 use nix::Result;
-
-use nix::Error;
 use oci::Process as OCIProcess;
 use slog::Logger;
 

--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -147,11 +147,11 @@ mod tests {
     #[test]
     fn test_create_extended_pipe() {
         // Test the default
-        let (r, w) = create_extended_pipe(OFlag::O_CLOEXEC, 0).unwrap();
+        let _ = create_extended_pipe(OFlag::O_CLOEXEC, 0).unwrap();
 
         // Test setting to the max size
         let max_size = get_pipe_max_size();
-        let (r, w) = create_extended_pipe(OFlag::O_CLOEXEC, max_size).unwrap();
+        let (_, w) = create_extended_pipe(OFlag::O_CLOEXEC, max_size).unwrap();
         let actual_size = get_pipe_size(w);
         assert_eq!(max_size, actual_size);
     }

--- a/src/agent/rustjail/src/sync.rs
+++ b/src/agent/rustjail/src/sync.rs
@@ -23,7 +23,7 @@ macro_rules! log_child {
         let lfd = $fd;
         let mut log_str = format_args!($($arg)+).to_string();
         log_str.push('\n');
-        write_count(lfd, log_str.as_bytes(), log_str.len());
+        let _ = write_count(lfd, log_str.as_bytes(), log_str.len());
     })
 }
 

--- a/src/agent/rustjail/src/sync.rs
+++ b/src/agent/rustjail/src/sync.rs
@@ -137,34 +137,38 @@ pub fn write_sync(fd: RawFd, msg_type: i32, data_str: &str) -> Result<()> {
 
     match msg_type {
         SYNC_FAILED => match write_count(fd, data_str.as_bytes(), data_str.len()) {
-            Ok(_count) => unistd::close(fd)?,
+            Ok(_) => unistd::close(fd)?,
             Err(e) => {
                 unistd::close(fd)?;
-                return Err(
-                    ErrorKind::ErrorCode("error in send message to process".to_string()).into(),
-                );
+                return Err(ErrorKind::ErrorCode(format!(
+                    "error in send message to process {}",
+                    e
+                ))
+                .into());
             }
         },
         SYNC_DATA => {
             let length: i32 = data_str.len() as i32;
             match write_count(fd, &length.to_be_bytes(), MSG_SIZE) {
-                Ok(_count) => (),
+                Ok(_) => (),
                 Err(e) => {
                     unistd::close(fd)?;
-                    return Err(ErrorKind::ErrorCode(
-                        "error in send message to process".to_string(),
-                    )
+                    return Err(ErrorKind::ErrorCode(format!(
+                        "error in send message to process {}",
+                        e
+                    ))
                     .into());
                 }
             }
 
             match write_count(fd, data_str.as_bytes(), data_str.len()) {
-                Ok(_count) => (),
+                Ok(_) => (),
                 Err(e) => {
                     unistd::close(fd)?;
-                    return Err(ErrorKind::ErrorCode(
-                        "error in send message to process".to_string(),
-                    )
+                    return Err(ErrorKind::ErrorCode(format!(
+                        "error in send message to process {}",
+                        e
+                    ))
                     .into());
                 }
             }

--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -9,7 +9,6 @@ use lazy_static;
 use nix::errno::Errno;
 use nix::Error;
 use oci::{LinuxIDMapping, LinuxNamespace, Spec};
-use protobuf::RepeatedField;
 use std::collections::HashMap;
 use std::path::{Component, PathBuf};
 

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -457,8 +457,6 @@ fn setup_debug_console(shells: Vec<String>, port: u32) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs::File;
-    use std::io::Write;
     use tempfile::tempdir;
 
     #[test]

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -105,7 +105,7 @@ fn announce(logger: &Logger) {
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
     if args.len() == 2 && args[1] == "init" {
-        rustjail::container::init_child();
+        rustjail::container::init_child()?;
         exit(0);
     }
 

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -734,6 +734,7 @@ impl protocols::agent_ttrpc::AgentService for agentService {
 
         Ok(resp)
     }
+
     fn stats_container(
         &self,
         _ctx: &ttrpc::TtrpcContext,
@@ -764,7 +765,7 @@ impl protocols::agent_ttrpc::AgentService for agentService {
 
     fn pause_container(
         &self,
-        ctx: &ttrpc::TtrpcContext,
+        _ctx: &ttrpc::TtrpcContext,
         req: protocols::agent::PauseContainerRequest,
     ) -> ttrpc::Result<protocols::empty::Empty> {
         let cid = req.get_container_id();
@@ -790,7 +791,7 @@ impl protocols::agent_ttrpc::AgentService for agentService {
 
     fn resume_container(
         &self,
-        ctx: &ttrpc::TtrpcContext,
+        _ctx: &ttrpc::TtrpcContext,
         req: protocols::agent::ResumeContainerRequest,
     ) -> ttrpc::Result<protocols::empty::Empty> {
         let cid = req.get_container_id();

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1367,7 +1367,7 @@ fn get_agent_details() -> AgentDetails {
 
     detail.set_version(AGENT_VERSION.to_string());
     detail.set_supports_seccomp(false);
-    detail.init_daemon = { unistd::getpid() == Pid::from_raw(1) };
+    detail.init_daemon = unistd::getpid() == Pid::from_raw(1);
 
     detail.device_handlers = RepeatedField::new();
     detail.storage_handlers = RepeatedField::from_vec(

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -7,11 +7,9 @@
 use crate::linux_abi::*;
 use crate::mount::{get_mount_fs_type, remove_mounts, TYPEROOTFS};
 use crate::namespace::Namespace;
-use crate::namespace::NSTYPEPID;
 use crate::network::Network;
 use libc::pid_t;
 use netlink::{RtnlHandle, NETLINK_ROUTE};
-use oci::LinuxNamespace;
 use protocols::agent::OnlineCPUMemRequest;
 use regex::Regex;
 use rustjail::cgroups;

--- a/tools/agent-ctl/src/utils.rs
+++ b/tools/agent-ctl/src/utils.rs
@@ -8,8 +8,7 @@ use anyhow::{anyhow, Result};
 use oci::{Process as ociProcess, Root as ociRoot, Spec as ociSpec};
 use protocols::oci::{
     Box as grpcBox, Linux as grpcLinux, LinuxCapabilities as grpcLinuxCapabilities,
-    POSIXRlimit as grpcPOSIXRlimit, Process as grpcProcess, Root as grpcRoot, Spec as grpcSpec,
-    User as grpcUser,
+    Process as grpcProcess, Root as grpcRoot, Spec as grpcSpec, User as grpcUser,
 };
 use rand::Rng;
 use slog::{debug, warn};


### PR DESCRIPTION
Mostly in the agent code, and some tooling/pkg as well.

Some of them are related to serious issues like potentially undefined behaviour, unsafe code or unhandled errors.