### PR TITLE
Add openTelemetry tracing with VSOCK

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -207,6 +207,7 @@ checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
 name = "kata-agent"
 version = "0.1.0"
 dependencies = [
+ "crossbeam-channel",
  "error-chain",
  "lazy_static",
  "libc",

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -25,6 +25,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "arc-swap"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,6 +56,16 @@ dependencies = [
  "libc",
  "object",
  "rustc-demangle",
+]
+
+[[package]]
+name = "bincode"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f30d3a39baa26f9651f17b375061f3233dde33424a8b72b0dbe93a68a0bc896d"
+dependencies = [
+ "byteorder",
+ "serde",
 ]
 
 [[package]]
@@ -169,6 +188,101 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b980f2816d6ee8673b6517b52cb0e808a180efc92e5c19d02cdda79066703ef"
 
 [[package]]
+name = "futures"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e05b85ec287aac0dc34db7d4a569323df697f9c55b99b15d6b4ef8cde49f613"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f366ad74c28cca6ba456d95e6422883cfb4b252a83bed929c83abfdbbf2967d5"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59f5fff90fd5d971f936ad674802482ba441b6f09ba5e15fd8b39145582ca399"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d6bb888be1153d3abeb9006b11b02cf5e9b209fda28693c31ae1e4e012e314"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de27142b013a8e869c14957e6d2edeef89e97c289e69d042ee3a49acd8b51789"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b5a30a4328ab5473878237c447333c093297bded83a4983d10f4deea240d39"
+dependencies = [
+ "proc-macro-hack",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f2032893cb734c7a05d85ce0cc8b8c4075278e93b24b66f9de99d6eb0fa8acc"
+
+[[package]]
+name = "futures-task"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb66b5f09e22019b1ab0830f7785bcea8e7a42148683f99214f73f8ec21a626"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "futures-util"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8764574ff08b701a084482c3c7031349104b07ac897393010494beaa18ce32c6"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project",
+ "pin-utils",
+ "proc-macro-hack",
+ "proc-macro-nested",
+ "slab",
+]
+
+[[package]]
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,9 +329,10 @@ dependencies = [
  "netlink",
  "nix 0.17.0",
  "oci",
+ "opentelemetry",
  "prctl",
  "procfs",
- "prometheus",
+ "prometheus 0.9.0",
  "protobuf",
  "protocols",
  "regex",
@@ -229,7 +344,12 @@ dependencies = [
  "slog",
  "slog-scope",
  "tempfile",
+ "tracing",
+ "tracing-futures",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
  "ttrpc",
+ "vsock-exporter",
 ]
 
 [[package]]
@@ -280,6 +400,15 @@ dependencies = [
  "slog-async",
  "slog-json",
  "slog-scope",
+]
+
+[[package]]
+name = "matchers"
+version = "0.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
+dependencies = [
+ "regex-automata",
 ]
 
 [[package]]
@@ -368,6 +497,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+
+[[package]]
+name = "opentelemetry"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc49c2e2f36870923d158ff0e357c28e2ff581cb7d8d2181ac27198882ca4132"
+dependencies = [
+ "bincode",
+ "futures 0.3.5",
+ "lazy_static",
+ "percent-encoding",
+ "pin-project",
+ "prometheus 0.7.0",
+ "rand",
+ "serde",
+]
+
+[[package]]
 name = "path-absolutize"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,6 +538,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12e3a6cdbfe94a5e4572812a0201f8c0ed98c1c452c7b8563ce2276988ef9c17"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "0.4.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a0ffd45cf79d88737d7cc85bfd5d2894bee1139b356e616fe85dc389c61aaf7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +584,18 @@ dependencies = [
  "libc",
  "nix 0.17.0",
 ]
+
+[[package]]
+name = "proc-macro-hack"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e0456befd48169b9f13ef0f0ad46d492cf9d2dbb918bcf38e01eed4ce3ec5e4"
+
+[[package]]
+name = "proc-macro-nested"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba180dafb9038b050a4c280019bbedf9f2467b61e5d892dcad585bb57aadc5a"
 
 [[package]]
 name = "proc-macro2"
@@ -424,6 +619,20 @@ dependencies = [
  "lazy_static",
  "libc",
  "libflate",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5567486d5778e2c6455b1b90ff1c558f29e751fc018130fa182e15828e728af1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "protobuf",
+ "quick-error",
+ "spin",
 ]
 
 [[package]]
@@ -471,10 +680,16 @@ dependencies = [
 name = "protocols"
 version = "0.1.0"
 dependencies = [
- "futures",
+ "futures 0.1.29",
  "protobuf",
  "ttrpc",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -542,6 +757,16 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -621,6 +846,9 @@ name = "serde"
 version = "1.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99e7b308464d16b56eba9964e4972a3eee817760ab60d88c3f86e1fecb08204c"
+dependencies = [
+ "serde_derive",
+]
 
 [[package]]
 name = "serde_derive"
@@ -645,6 +873,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06d5a3f5166fb5b42a5439f2eee8b9de149e235961e3eb21c5808fc3ea17ff3e"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -663,6 +900,12 @@ dependencies = [
  "arc-swap",
  "libc",
 ]
+
+[[package]]
+name = "slab"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 
 [[package]]
 name = "slash-formatter"
@@ -710,6 +953,12 @@ dependencies = [
  "lazy_static",
  "slog",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
 
 [[package]]
 name = "spin"
@@ -788,6 +1037,102 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2e2a2de6b0d5cbb13fc21193a2296888eaab62b6044479aafb3c54c01c29fcd"
+dependencies = [
+ "cfg-if",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0693bf8d6f2bf22c690fc61a9d21ac69efdbb894a17ed596b9af0f01e64b84b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94ae75f0d28ae10786f3b1895c55fe72e79928fd5ccdebb5438c75e93fec178f"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab7bb6f14721aa00656086e9335d363c5c8747bae02ebe32ea2c7dece5689b4c"
+dependencies = [
+ "pin-project",
+ "tracing",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0f8c7178e13481ff6765bd169b33e8d554c5d2bbede5e32c356194be02b9b9"
+dependencies = [
+ "lazy_static",
+ "log",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b64607914c2892f73ebfd19c6777a0dfb3f5457bf3894693dd2125c41b9c208a"
+dependencies = [
+ "opentelemetry",
+ "rand",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ccba2f8f16e0ed268fc765d9b7ff22e965e7185d32f8f1ec8294fe17d86e79"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c72c8cf3ec4ed69fef614d011a5ae4274537a8a8c59133558029bd731eb71659"
+dependencies = [
+ "ansi_term",
+ "chrono",
+ "lazy_static",
+ "matchers",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "ttrpc"
 version = "0.3.0"
 source = "git+https://github.com/containerd/ttrpc-rust.git?branch=0.3.0#ba1efe3bbb8f8af4895b7623ed1d11561e70e566"
@@ -817,6 +1162,30 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
+
+[[package]]
+name = "vsock"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dba063357047c0f2216c7c653879ea4e5e198d0c3cde7efa37ebfd9039b48491"
+dependencies = [
+ "libc",
+ "nix 0.17.0",
+]
+
+[[package]]
+name = "vsock-exporter"
+version = "0.1.0"
+dependencies = [
+ "bincode",
+ "byteorder",
+ "libc",
+ "nix 0.17.0",
+ "opentelemetry",
+ "serde",
+ "slog",
+ "vsock",
+]
 
 [[package]]
 name = "wasi"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -32,6 +32,7 @@ slog-scope = "4.1.2"
 tempfile = "3.1.0"
 prometheus = { version = "0.9.0", features = ["process"] }
 procfs = "0.7.9"
+crossbeam-channel = "0.4.2"
 
 [workspace]
 members = [

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -33,6 +33,12 @@ tempfile = "3.1.0"
 prometheus = { version = "0.9.0", features = ["process"] }
 procfs = "0.7.9"
 crossbeam-channel = "0.4.2"
+opentelemetry = "0.6.0"
+tracing = { version = "0.1.16", features = ["attributes"]}
+tracing-opentelemetry = "0.5.0"
+tracing-subscriber = "0.2.7"
+tracing-futures = "0.2.4"
+vsock-exporter = { path = "vsock-exporter" }
 
 [workspace]
 members = [

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -85,7 +85,7 @@ lazy_static! {
 
 use std::mem::MaybeUninit;
 
-fn announce(logger: &Logger) {
+fn announce(logger: &Logger, config: &agentConfig) {
     let commit = match env::var("VERSION_COMMIT") {
         Ok(s) => s,
         Err(_) => String::from(""),
@@ -99,6 +99,7 @@ fn announce(logger: &Logger) {
 
     "agent-version" =>  version::AGENT_VERSION,
     "api-version" => version::API_VERSION,
+    "config" => format!("{:?}", config),
     );
 }
 
@@ -186,7 +187,7 @@ fn main() -> Result<()> {
     // Recreate a logger with the log level get from "/proc/cmdline".
     let logger = logging::create_logger(NAME, "agent", config.log_level, writer);
 
-    announce(&logger);
+    announce(&logger, &config);
 
     // This "unused" variable is required as it enables the global (and crucially static) logger,
     // which is required to satisfy the the lifetime constraints of the auto-generated gRPC code.

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -193,6 +193,14 @@ fn main() -> Result<()> {
     // which is required to satisfy the the lifetime constraints of the auto-generated gRPC code.
     let _guard = slog_scope::set_global_logger(logger.new(o!("subsystem" => "rpc")));
 
+    start_sandbox(&logger, &config)?;
+
+    let _ = log_handle.join();
+
+    Ok(())
+}
+
+fn start_sandbox(logger: &Logger, config: &agentConfig) -> Result<()> {
     let shells = SHELLS.clone();
     let debug_console_vport = config.debug_console_vport as u32;
 
@@ -252,8 +260,6 @@ fn main() -> Result<()> {
     handle.join().unwrap();
 
     server.shutdown();
-
-    let _ = log_handle.join();
 
     if config.debug_console {
         shell_handle.join().unwrap();

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -241,12 +241,6 @@ fn start_sandbox(logger: &Logger, config: &agentConfig) -> Result<()> {
     //vsock:///dev/vsock, port
     let mut server = rpc::start(sandbox.clone(), VSOCK_ADDR, VSOCK_PORT);
 
-    /*
-        let _ = fs::remove_file("/tmp/testagent");
-        let _ = fs::remove_dir_all("/run/agent");
-        let mut server = grpc::start(sandbox.clone(), "unix:///tmp/testagent", 1);
-    */
-
     let handle = thread::spawn(move || {
         // info!("Press ENTER to exit...");
         // let _ = io::stdin().read(&mut [0]).unwrap();
@@ -254,10 +248,6 @@ fn start_sandbox(logger: &Logger, config: &agentConfig) -> Result<()> {
 
         let _ = rx.recv().unwrap();
     });
-    // receive something from destroy_sandbox here?
-    // or in the thread above? It depneds whether grpc request
-    // are run in another thread or in the main thead?
-    // let _ = rx.wait();
 
     let _ = server.start().unwrap();
 
@@ -268,8 +258,6 @@ fn start_sandbox(logger: &Logger, config: &agentConfig) -> Result<()> {
     if let Some(handle) = shell_handle {
         handle.join().map_err(|e| format!("{:?}", e))?;
     }
-
-    let _ = fs::remove_file("/tmp/testagent");
 
     Ok(())
 }

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -241,17 +241,9 @@ fn start_sandbox(logger: &Logger, config: &agentConfig) -> Result<()> {
     //vsock:///dev/vsock, port
     let mut server = rpc::start(sandbox.clone(), VSOCK_ADDR, VSOCK_PORT);
 
-    let handle = thread::spawn(move || {
-        // info!("Press ENTER to exit...");
-        // let _ = io::stdin().read(&mut [0]).unwrap();
-        // thread::sleep(Duration::from_secs(3000));
-
-        let _ = rx.recv().unwrap();
-    });
-
     let _ = server.start().unwrap();
 
-    handle.join().unwrap();
+    let _ = rx.recv().map_err(|e| format!("{:?}", e));
 
     server.shutdown();
 

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -104,6 +104,19 @@ fn announce(logger: &Logger) {
 
 fn main() -> Result<()> {
     let args: Vec<String> = env::args().collect();
+
+    if args.len() == 2 && args[1] == "--version" {
+        println!(
+            "{} version {} (api version: {}, commit version: {}, type: rust)",
+            NAME,
+            version::AGENT_VERSION,
+            version::API_VERSION,
+            env::var("VERSION_COMMIT").unwrap_or("unknown".to_string())
+        );
+
+        exit(0);
+    }
+
     if args.len() == 2 && args[1] == "init" {
         rustjail::container::init_child();
         exit(0);
@@ -174,13 +187,6 @@ fn main() -> Result<()> {
     let logger = logging::create_logger(NAME, "agent", config.log_level, writer);
 
     announce(&logger);
-
-    if args.len() == 2 && args[1] == "--version" {
-        // force logger to flush
-        drop(logger);
-
-        exit(0);
-    }
 
     // This "unused" variable is required as it enables the global (and crucially static) logger,
     // which is required to satisfy the the lifetime constraints of the auto-generated gRPC code.

--- a/src/agent/src/signal.rs
+++ b/src/agent/src/signal.rs
@@ -1,0 +1,153 @@
+// Copyright (c) 2019-2020 Ant Financial
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::sandbox::Sandbox;
+use crossbeam_channel::{select, unbounded, Receiver, Sender};
+use nix::sys::wait::WaitPidFlag;
+use nix::sys::wait::{self, WaitStatus};
+use nix::unistd;
+use prctl::set_child_subreaper;
+use rustjail::errors::*;
+use signal_hook::{iterator::Signals, SIGCHLD};
+use slog::{error, info, o, warn, Logger};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::thread::JoinHandle;
+use unistd::Pid;
+
+fn handle_signals(logger: Logger, ch: Sender<i32>, signals: Signals) {
+    for sig in signals.forever() {
+        let result = ch.send(sig);
+
+        if result.is_err() {
+            error!(logger, "failed to send signal"; "signal" => sig, "error" => format!("{:?}", result.err()));
+        }
+    }
+}
+
+pub fn setup_signal_handler(
+    logger: &Logger,
+    shutdown: Receiver<bool>,
+    sandbox: Arc<Mutex<Sandbox>>,
+) -> Result<JoinHandle<()>> {
+    let logger = logger.new(o!("subsystem" => "signals"));
+
+    set_child_subreaper(true).map_err(|err| {
+        format!(
+            "failed to setup agent as a child subreaper, failed with {}",
+            err
+        )
+    })?;
+
+    const HANDLED_SIGNALS: &[i32] = &[SIGCHLD];
+
+    let signals = Signals::new(HANDLED_SIGNALS)?;
+
+    let thread_signals = signals.clone();
+
+    let handle = thread::spawn(move || {
+        let s = sandbox.clone();
+
+        let (tx, rx) = unbounded::<i32>();
+
+        let thread_logger = logger.clone();
+
+        let signals_thread =
+            thread::spawn(move || handle_signals(thread_logger, tx, thread_signals));
+
+        'nextevent: loop {
+            select! {
+            recv(rx) -> sig => {
+                    let sig = match sig {
+                        Ok(sig) => sig,
+                        Err(e) => {
+                            error!(logger, "failed to receive signal"; "error" => format!("{:?}", e));
+
+                            break 'nextevent;
+                        },
+                    };
+
+                    info!(logger, "received signal"; "signal" => format!("{:?}", sig));
+
+                    // several signals can be combined together
+                    // as one. So loop around to reap all
+                    // exited children
+                    'inner: loop {
+                        let wait_status = match wait::waitpid(
+                            Some(Pid::from_raw(-1)),
+                            Some(WaitPidFlag::WNOHANG | WaitPidFlag::__WALL),
+                            ) {
+                            Ok(s) => {
+                                if s == WaitStatus::StillAlive {
+                                    break 'nextevent;
+                                }
+                                s
+                            }
+                            Err(e) => {
+                                info!(
+                                    logger,
+                                    "waitpid reaper failed";
+                                    "error" => e.as_errno().unwrap().desc()
+                                );
+                                break 'nextevent;
+                            }
+                        };
+
+                        let pid = wait_status.pid();
+
+                        if pid.is_some() {
+                            let raw_pid = pid.unwrap().as_raw();
+                            let child_pid = format!("{}", raw_pid);
+
+                            let logger = logger.new(o!("child-pid" => child_pid));
+
+                            let mut sandbox = s.lock().unwrap();
+                            let process = sandbox.find_process(raw_pid);
+                            if process.is_none() {
+                                info!(logger, "child exited unexpectedly");
+                                continue 'inner;
+                            }
+
+                            let mut p = process.unwrap();
+
+                            if p.exit_pipe_w.is_none() {
+                                error!(logger, "the process's exit_pipe_w isn't set");
+                                continue 'inner;
+                            }
+                            let pipe_write = p.exit_pipe_w.unwrap();
+                            let ret: i32;
+
+                            match wait_status {
+                                WaitStatus::Exited(_, c) => ret = c,
+                                WaitStatus::Signaled(_, sig, _) => ret = sig as i32,
+                                _ => {
+                                    info!(logger, "got wrong status for process";
+                                        "child-status" => format!("{:?}", wait_status));
+                                    continue 'inner;
+                                }
+                            }
+
+                            p.exit_code = ret;
+                            let _ = unistd::close(pipe_write);
+                        }
+                    }
+            },
+            recv(shutdown) -> _ => {
+                signals.close();
+
+                let result = signals_thread.join();
+
+                if result.is_err() {
+                    warn!(logger, "failed to wait for signal handler thread"; "error" => format!("{:?}", result.err()));
+                }
+                break;
+            },
+            };
+        }
+    });
+
+    Ok(handle)
+}

--- a/src/agent/src/tracer.rs
+++ b/src/agent/src/tracer.rs
@@ -1,0 +1,48 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use opentelemetry::api::trace::provider::Provider;
+use opentelemetry::global::BoxedTracer;
+use slog::{o, Logger};
+
+use opentelemetry::{global, sdk};
+use tracing_opentelemetry::OpenTelemetryLayer;
+use tracing_subscriber::layer::Layered;
+use tracing_subscriber::{Layer, Registry};
+use vsock_exporter;
+
+pub fn setup_tracing(logger: &Logger) {
+    let logger = logger.new(o!("subsystem" => "vsock-tracer"));
+
+    let exporter = vsock_exporter::Exporter::builder()
+        .with_logger(&logger)
+        .init();
+
+    let provider = sdk::Provider::builder()
+        .with_simple_exporter(exporter)
+        .with_config(sdk::Config {
+            default_sampler: Box::new(sdk::Sampler::Always),
+            ..Default::default()
+        })
+        .build();
+
+    global::set_provider(provider);
+}
+
+pub fn shutdown_tracing() {
+    global::set_provider(sdk::Provider::default());
+}
+
+pub fn get_subscriber(
+    name: &'static str,
+) -> Layered<OpenTelemetryLayer<Registry, BoxedTracer>, Registry> {
+    // XXX: Get the tracer (which will be a NOP tracer if no explicit tracer
+    // previously registered).
+    let tracer: opentelemetry::global::BoxedTracer = global::trace_provider().get_tracer(name);
+
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+
+    layer.with_subscriber(Registry::default())
+}

--- a/src/agent/vsock-exporter/Cargo.toml
+++ b/src/agent/vsock-exporter/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "vsock-exporter"
+version = "0.1.0"
+authors = ["James O. D. Hunt <james.o.hunt@intel.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+
+# These three are tightly coupled - we can't bump nix/libc unless it's
+# compatible with vsock.
+nix = "0.17.0"
+libc = "0.2.69"
+vsock = "0.2.0"
+
+opentelemetry = { version = "0.6.0", features=["serialize"] }
+serde = { version = "1.0.110", features = ["derive"] }
+bincode = "1.3.1"
+byteorder = "1.3.4"
+slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_info"] }

--- a/src/agent/vsock-exporter/src/lib.rs
+++ b/src/agent/vsock-exporter/src/lib.rs
@@ -1,0 +1,181 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use byteorder::{ByteOrder, NetworkEndian};
+use nix::sys::socket::{SockAddr, VsockAddr};
+use opentelemetry::exporter::trace::{ExportResult, SpanData, SpanExporter};
+use slog::{error, o, Logger};
+use std::io::{Error, ErrorKind, Write};
+use std::net::Shutdown;
+use std::sync::{Arc, Mutex};
+use vsock::VsockStream;
+
+const ANY_CID: &'static str = "any";
+
+// reserved for "host"
+const DEFAULT_CID: u32 = 2;
+const DEFAULT_PORT: u32 = 10240;
+
+const HEADER_SIZE_BYTES: u64 = std::mem::size_of::<u64>() as u64;
+
+#[derive(Debug)]
+pub struct Exporter {
+    port: u32,
+    cid: u32,
+    conn: Arc<Mutex<VsockStream>>,
+    logger: Logger,
+}
+
+impl Exporter {
+    /// Create a new exporter builder.
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+}
+
+fn make_error(desc: String) -> std::io::Error {
+    Error::new(ErrorKind::Other, desc.to_string())
+}
+
+fn write_span(writer: &mut dyn Write, span: &SpanData) -> Result<(), std::io::Error> {
+    let encoded_payload: Vec<u8> =
+        bincode::serialize(&span).map_err(|e| make_error(e.to_string()))?;
+
+    let payload_len: u64 = encoded_payload.len() as u64;
+
+    let mut payload_len_as_bytes: [u8; HEADER_SIZE_BYTES as usize] =
+        [0; HEADER_SIZE_BYTES as usize];
+
+    NetworkEndian::write_u64(&mut payload_len_as_bytes, payload_len);
+
+    writer
+        .write_all(&payload_len_as_bytes)
+        .map_err(|e| make_error(format!("failed to write trace header: {:?}", e)))?;
+
+    let result = writer
+        .write_all(&encoded_payload)
+        .map_err(|e| make_error(format!("failed to write trace payload: {:?}", e)));
+
+    result
+}
+
+fn handle_batch(writer: &mut dyn Write, batch: Vec<Arc<SpanData>>) -> Result<(), std::io::Error> {
+    for entry in batch {
+        let span_data = &*entry;
+
+        write_span(writer, span_data).map_err(|e| e)?;
+    }
+
+    Ok(())
+}
+
+impl SpanExporter for Exporter {
+    fn export(&self, batch: Vec<Arc<SpanData>>) -> ExportResult {
+        let conn_ref = self.conn.clone();
+
+        let conn = conn_ref.lock();
+
+        if conn.is_err() {
+            error!(self.logger, "failed to obtain connection"; "error" => format!("{}", conn.unwrap_err()));
+
+            return ExportResult::FailedNotRetryable;
+        }
+
+        let mut conn = conn.unwrap();
+
+        let result = handle_batch(&mut *conn, batch);
+
+        if result.is_err() {
+            error!(self.logger, "failed to handle batch"; "error" => format!("{}", result.unwrap_err()));
+
+            return ExportResult::FailedNotRetryable;
+        }
+
+        ExportResult::Success
+    }
+
+    fn shutdown(&self) {
+        let conn = self.conn.lock().map_err(|e| {
+            error!(self.logger, "failed to obtain connection"; "error" => format!("{}", e));
+            return;
+        });
+
+        let conn = conn.unwrap();
+
+        let result = conn.shutdown(Shutdown::Write);
+        if result.is_err() {
+            error!(self.logger, "failed to shutdown VSOCK connection"; "error" => format!("{}", result.unwrap_err()));
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Builder {
+    port: u32,
+    cid: u32,
+    logger: Logger,
+}
+
+impl Default for Builder {
+    fn default() -> Self {
+        let logger = Logger::root(slog::Discard, o!());
+
+        Builder {
+            cid: DEFAULT_CID,
+            port: DEFAULT_PORT,
+            logger: logger,
+        }
+    }
+}
+
+impl Builder {
+    pub fn with_cid(self, cid: u32) -> Self {
+        Builder { cid, ..self }
+    }
+
+    pub fn with_port(self, port: u32) -> Self {
+        Builder { port, ..self }
+    }
+
+    pub fn with_logger(self, logger: &Logger) -> Self {
+        Builder {
+            logger: logger.new(o!()),
+            ..self
+        }
+    }
+
+    pub fn init(self) -> Exporter {
+        let Builder { port, cid, logger } = self;
+
+        let vsock_addr = VsockAddr::new(self.cid, self.port);
+        let sock_addr = SockAddr::Vsock(vsock_addr);
+
+        let cid_str: String;
+
+        if self.cid == libc::VMADDR_CID_ANY {
+            cid_str = ANY_CID.to_string();
+        } else {
+            cid_str = format!("{}", self.cid);
+        }
+
+        // Handle unrecoverable error. The trait doesn't allow an error
+        // return, so force a hard error.
+        let conn = VsockStream::connect(&sock_addr).expect(&format!(
+            "failed to connect to VSOCK server (port: {}, cid: {}) - {}",
+            self.port, cid_str, "tracing enabled so ensure trace forwarder is running on host"
+        ));
+
+        let logger = logger
+            .clone()
+            .new(o!("subsystem" => "vsock", "cid" => cid_str, "port" => self.port));
+
+        Exporter {
+            port: port,
+            cid: cid,
+            conn: Arc::new(Mutex::new(conn)),
+            logger: logger,
+        }
+    }
+}


### PR DESCRIPTION
Implement an openTelemetry custom exporter that sends trace spans to a VSOCK socket. A vsock-to-span converter needs to be running on the host to allow systems like Jaeger to capture the trace spans.

The agent tracer is enabled by specifying `agent.tracing` on the guest kernel command line.

Current limitations:

- Only static isolated tracing is supported.
- Only main, sandbox and RPC functions are traced.

Also contains:

- Some cosmetic changes
- Fix for a nasty crasher bug.
- Added the ability for the agent to shut down gracefully (required for correct tracing operation).

Fixes: #60.