### PR TITLE
docs: Clarifying minimum version of containerd for annotations

### DIFF
--- a/docs/how-to/how-to-set-sandbox-config-kata.md
+++ b/docs/how-to/how-to-set-sandbox-config-kata.md
@@ -79,13 +79,14 @@ There are several kinds of Kata configurations and they are listed below.
 # CRI Configuration
 
 In case of CRI-O, all annotations specified in the pod spec are passed down to Kata.
+
 For containerd, annotations specified in the pod spec are passed down to Kata
-starting with version `1.3.0`. Additionally, extra configuration is needed for containerd,
-by providing a `pod_annotations` field in the containerd config file.  The `pod_annotations`
-field is a list of annotations that can be passed down to Kata as OCI annotations. 
-It supports golang match patterns. Since annotations supported by Kata follow the pattern
-`io.katacontainers.*`, the following configuration would work for passing annotations to 
-Kata from containerd:
+starting with version `1.3.0` of containerd. Additionally, extra configuration is
+needed for containerd, by providing a `pod_annotations` field in the containerd config
+file.  The `pod_annotations` field is a list of annotations that can be passed down to
+Kata as OCI annotations. It supports golang match patterns. Since annotations supported
+by Kata follow the pattern `io.katacontainers.*`, the following configuration would work
+for passing annotations to Kata from containerd:
 
 ```
 $ cat /etc/containerd/config


### PR DESCRIPTION
Using pod annotations requires a minimum version of v1.3.0 of containerd
to pass annotations down to kata. This is already somewhat mentioned in
the corresponding how-to, however, it can be mis-read as the minimum
version of kata-containers instead of containerd. This can cause
extended and futile troubleshooting on older distributions such as
Ubuntu 16.04 which ship a version of 1.2.x of containerd. This patch
attempts to clarify this.

Fixes: #690

Signed-off-by: Georg Kunz <georg.kunz@est.tech>