### PR TITLE
actions: Pin to a particular sha for actions

### DIFF
--- a/.github/workflows/PR-wip-checks.yaml
+++ b/.github/workflows/PR-wip-checks.yaml
@@ -15,7 +15,7 @@ jobs:
     name: WIP Check
     steps:
     - name: WIP Check
-      uses: tim-actions/wip-check@master
+      uses: tim-actions/wip-check@1c2a1ca6c110026b3e2297bb2ef39e1747b5a755
       with:
         labels: '["do-not-merge", "wip", "rfc"]'
         keywords: '["WIP", "wip", "RFC", "rfc", "dnm", "DNM", "do-not-merge"]'

--- a/.github/workflows/dco-check.yaml
+++ b/.github/workflows/dco-check.yaml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - name: Get PR Commits
       id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@master
+      uses: tim-actions/get-pr-commits@ed97a21c3f83c3417e67a4733ea76887293a2c8f
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
     - name: DCO Check
-      uses: tim-actions/dco@master
+      uses: tim-actions/dco@2fd0504dc0d27b33f542867c300c60840c6dcb20
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}


### PR DESCRIPTION
Since actions can access the github token, lets use a
particular version of sha rather than using master.

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>