### PR TITLE
ci: checkout TRAVIS_BRANCH

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -16,6 +16,10 @@ clone_tests_repo()
 	fi
 
 	go get -d -u "$tests_repo" || true
+
+       if [ -n "${TRAVIS_BRANCH:-}" ]; then
+               ( cd "${tests_repo_dir}" && git checkout "${TRAVIS_BRANCH}" )
+       fi
 }
 
 run_static_checks()


### PR DESCRIPTION
So that we use 2.0-dev branch for tests.

Fixes: kata-containers/tests#2732