### PR TITLE
runtime: add CPU cores and memory basic info for `kata-env` sub-command

### DIFF
--- a/src/runtime/cli/kata-env_amd64_test.go
+++ b/src/runtime/cli/kata-env_amd64_test.go
@@ -50,6 +50,9 @@ func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
 	env, err := getEnvInfo(configFile, config)
 	assert.NoError(err)
 
+	// Free/Available are changing
+	expectedEnv.Host.Memory = env.Host.Memory
+
 	assert.Equal(expectedEnv, env)
 
 	assert.NotEmpty(archRequiredCPUFlags)

--- a/src/runtime/cli/kata-env_generic_test.go
+++ b/src/runtime/cli/kata-env_generic_test.go
@@ -45,6 +45,9 @@ func testEnvGetEnvInfoSetsCPUTypeGeneric(t *testing.T) {
 	env, err := getEnvInfo(configFile, config)
 	assert.NoError(err)
 
+	// Free/Available are changing
+	expectedEnv.Host.Memory = env.Host.Memory
+
 	assert.Equal(expectedEnv, env)
 
 	assert.Equal(archRequiredCPUFlags, savedArchRequiredCPUFlags)

--- a/src/runtime/cli/kata-env_test.go
+++ b/src/runtime/cli/kata-env_test.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	goruntime "runtime"
 	"strings"
 	"testing"
@@ -272,6 +273,10 @@ VERSION_ID="%s"
 		expectedHostDetails.CPU.Model = "v8"
 	}
 
+	// set CPU num.
+	// will not set memory info, because memory may be changed.
+	expectedHostDetails.CPU.CPUs = runtime.NumCPU()
+
 	return expectedHostDetails, nil
 }
 
@@ -391,7 +396,16 @@ func TestEnvGetHostInfo(t *testing.T) {
 	host, err := getHostInfo()
 	assert.NoError(t, err)
 
+	// Free/Available are changing
+	expectedHostDetails.Memory = host.Memory
+
 	assert.Equal(t, expectedHostDetails, host)
+
+	// check CPU cores and memory info
+	assert.Equal(t, true, host.CPU.CPUs > 0)
+	assert.Equal(t, true, host.Memory.Total > 0)
+	assert.Equal(t, true, host.Memory.Free > 0)
+	assert.Equal(t, true, host.Memory.Available > 0)
 }
 
 func TestEnvGetHostInfoNoProcCPUInfo(t *testing.T) {
@@ -470,6 +484,9 @@ func TestEnvGetEnvInfo(t *testing.T) {
 		env, err := getEnvInfo(configFile, config)
 		assert.NoError(t, err)
 
+		// Free/Available are changing
+		expectedEnv.Host.Memory = env.Host.Memory
+
 		assert.Equal(t, expectedEnv, env)
 	}
 }
@@ -494,6 +511,9 @@ func TestEnvGetEnvInfoNoHypervisorVersion(t *testing.T) {
 
 	env, err := getEnvInfo(configFile, config)
 	assert.NoError(err)
+
+	// Free/Available are changing
+	expectedEnv.Host.Memory = env.Host.Memory
 
 	assert.Equal(expectedEnv, env)
 }


### PR DESCRIPTION
Add host memory size(Total/Free/Avaiable) and CPU cores in host info
for `kata-runtime kata-env`.

Fixes: #405

Signed-off-by: bin liu <bin@hyper.sh>

Output:

```
[Host]
  Kernel = "5.4.0-31-generic"
  Architecture = "amd64"
  VMContainerCapable = true
  SupportVSocks = true
  [Host.Distro]
    Name = "Ubuntu"
    Version = "20.04"
  [Host.CPU]
    Vendor = "GenuineIntel"
    Model = "Intel(R) Core(TM) i7-8750H CPU @ 2.20GHz"
    CPUs = 2
  [Host.Memory]
    Total = 4030680
    Free = 2914716
    Available = 3612320
```