### PR TITLE
qemu: remove multidev in fsdev parameter on arm64

### DIFF
--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -464,12 +464,21 @@ func generic9PVolume(volume types.Volume, nestedRun bool) govmmQemu.FSDevice {
 	}
 }
 
+func genericAppend9PVolume(devices []govmmQemu.Device, volume types.Volume, nestedRun bool) (govmmQemu.FSDevice, error) {
+	d := generic9PVolume(volume, nestedRun)
+	return d, nil
+}
+
 func (q *qemuArchBase) append9PVolume(devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error) {
 	if volume.MountTag == "" || volume.HostPath == "" {
 		return devices, nil
 	}
 
-	d := generic9PVolume(volume, q.nestedRun)
+	d, err := genericAppend9PVolume(devices, volume, q.nestedRun)
+	if err != nil {
+		return nil, err
+	}
+
 	devices = append(devices, d)
 	return devices, nil
 }

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	govmmQemu "github.com/intel/govmm/qemu"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 )
 
 type qemuArm64 struct {
@@ -106,4 +107,15 @@ func (q *qemuArm64) setIgnoreSharedMemoryMigrationCaps(_ context.Context, _ *gov
 
 func (q *qemuArm64) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {
 	return devices, fmt.Errorf("Arm64 architecture does not support vIOMMU")
+}
+
+func (q *qemuArm64) append9PVolume(devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error) {
+	d, err := genericAppend9PVolume(devices, volume, q.nestedRun)
+	if err != nil {
+		return nil, err
+	}
+
+	d.Multidev = ""
+	devices = append(devices, d)
+	return devices, nil
 }


### PR DESCRIPTION
As the current qemu of arm64 is so old, the new multidev parameter
in fsdev is not supported on arm64, so disabled it temporarily.

Fixes:#466
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@bergwolf @devimc @Pennyzct 