### PR TITLE
Makefile: add CLHCMD in arm64-options.mk

### DIFF
--- a/src/runtime/arch/arm64-options.mk
+++ b/src/runtime/arch/arm64-options.mk
@@ -16,3 +16,6 @@ QEMUCMD := qemu-system-aarch64
 FCCMD := firecracker
 # Firecracker's jailer binary name
 FCJAILERCMD := jailer
+
+# cloud-hypervisor binary name
+CLHCMD := cloud-hypervisor


### PR DESCRIPTION
As cloud-hypervisor has enabled for arm64, add CLHCMD in
arm64-options.mk

Fixes: #468
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@jodh-intel @devimc 