### PR TITLE
Kata 2.0-dev port of #2867 (NoReboot Knob)

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/hashicorp/go-multierror v1.0.0
-	github.com/intel/govmm v0.0.0-20200724170648-af9e34b91ae9
+	github.com/intel/govmm v0.0.0-20200728135209-6c3315ba8a42
 	github.com/mdlayher/vsock v0.0.0-20191108225356-d9c65923cb8f
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v1.0.0-rc9.0.20200102164712-2b52db75279c

--- a/src/runtime/go.sum
+++ b/src/runtime/go.sum
@@ -166,6 +166,8 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/intel/govmm v0.0.0-20200724170648-af9e34b91ae9 h1:GSRnVLRNweZV3f8Vo3vtMlPsuzvpj57Gj7Y7TkGVO6U=
 github.com/intel/govmm v0.0.0-20200724170648-af9e34b91ae9/go.mod h1:QKGWoQtjvkvFtzP6ybiM3lxUHqf83Sv3oLqyELUKH4g=
+github.com/intel/govmm v0.0.0-20200728135209-6c3315ba8a42 h1:Yu3/MlZl/kKE0Ipgio/KVorMIrjeHTVOG4+9WAddgOQ=
+github.com/intel/govmm v0.0.0-20200728135209-6c3315ba8a42/go.mod h1:QKGWoQtjvkvFtzP6ybiM3lxUHqf83Sv3oLqyELUKH4g=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=

--- a/src/runtime/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/src/runtime/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -2122,6 +2122,9 @@ type Knobs struct {
 
 	// Realtime will enable realtime QEMU
 	Realtime bool
+
+	// Exit instead of rebooting
+	NoReboot bool
 }
 
 // IOThread allows IO to be performed on a separate thread.
@@ -2455,6 +2458,10 @@ func (config *Config) appendKnobs() {
 
 	if config.Knobs.NoGraphic {
 		config.qemuParams = append(config.qemuParams, "-nographic")
+	}
+
+	if config.Knobs.NoReboot {
+		config.qemuParams = append(config.qemuParams, "--no-reboot")
 	}
 
 	if config.Knobs.Daemonize {

--- a/src/runtime/vendor/modules.txt
+++ b/src/runtime/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-multierror v1.0.0
 ## explicit
 github.com/hashicorp/go-multierror
-# github.com/intel/govmm v0.0.0-20200724170648-af9e34b91ae9
+# github.com/intel/govmm v0.0.0-20200728135209-6c3315ba8a42
 ## explicit
 github.com/intel/govmm/qemu
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -481,6 +481,7 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 		NoUserConfig: true,
 		NoDefaults:   true,
 		NoGraphic:    true,
+		NoReboot:     true,
 		Daemonize:    true,
 		MemPrealloc:  q.config.MemPrealloc,
 		HugePages:    q.config.HugePages,

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -202,6 +202,7 @@ func TestQemuKnobs(t *testing.T) {
 	assert.Equal(q.qemuConfig.Knobs.NoUserConfig, true)
 	assert.Equal(q.qemuConfig.Knobs.NoDefaults, true)
 	assert.Equal(q.qemuConfig.Knobs.NoGraphic, true)
+	assert.Equal(q.qemuConfig.Knobs.NoReboot, true)
 }
 
 func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []govmmQemu.Device) {

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -187,6 +187,23 @@ func TestQemuMemoryTopology(t *testing.T) {
 	assert.Exactly(memory, expectedOut)
 }
 
+func TestQemuKnobs(t *testing.T) {
+	assert := assert.New(t)
+
+	sandbox, err := createQemuSandboxConfig()
+	assert.NoError(err)
+
+	q := &qemu{
+		store: sandbox.newStore,
+	}
+	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig)
+	assert.NoError(err)
+
+	assert.Equal(q.qemuConfig.Knobs.NoUserConfig, true)
+	assert.Equal(q.qemuConfig.Knobs.NoDefaults, true)
+	assert.Equal(q.qemuConfig.Knobs.NoGraphic, true)
+}
+
 func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []govmmQemu.Device) {
 	assert := assert.New(t)
 	q := &qemu{


### PR DESCRIPTION
This is a port of the NoReboot changes [1] merged into 1.12.x

One change needed in qemu_test.go was dropping the last parameter in the call to createSandbox()
I also changed the govmm commit to use go modules. I'm not sure if I should have deleted the old govmm lines (167-168) in go.sum

[1] https://github.com/merwick/runtime/commit/77e3024cd0ab2e865953667ec49ebd742e2fed1b