### PR TITLE
docs: Update contributions section in limitations document kata 2.0

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -78,7 +78,7 @@ The following link shows the latest list of limitations:
 If you would like to work on resolving a limitation, please refer to the
 [contributors guide](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md).
 If you wish to raise an issue for a new limitation, either
-[raise an issue directly on the runtime](https://github.com/kata-containers/runtime/issues/new)
+[raise an issue directly on the runtime](https://github.com/kata-containers/kata-containers/issues/new)
 or see the
 [project table of contents](https://github.com/kata-containers/kata-containers)
 for advice on which repository to raise the issue against.


### PR DESCRIPTION
This PR updates the contributions sections for the limitations document
for kata 2.0 that instead using the previous runtime repository as example,
it will use the new one.

Fixes #476

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>