### PR TITLE
Fix fd leakage in execute_hook

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1495,6 +1495,11 @@ fn execute_hook(logger: &Logger, h: &Hook, st: &OCIState) -> Result<()> {
     //	state.push_str("\n");
 
     let (rfd, wfd) = unistd::pipe2(OFlag::O_CLOEXEC)?;
+    defer!({
+        let _ = unistd::close(rfd);
+        let _ = unistd::close(wfd);
+    });
+
     match unistd::fork()? {
         ForkResult::Parent { child: _ch } => {
             let buf = read_sync(rfd)?;


### PR DESCRIPTION
Close fd in execute_hook.

Signed-off-by: Tim Zhang <tim@hyper.sh>