### PR TITLE
RFC: Add a YAML representation of the available options

### DIFF
--- a/config/kata-options.yaml
+++ b/config/kata-options.yaml
@@ -1,0 +1,936 @@
+# Copyright (c) 2020 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#---------------------------------------------------------------------
+# FIXME: TODO:
+#
+# - Determine how to handle all hypervisor options.
+# - Check other hypervisor options!
+#
+# - Sort all entries.
+#
+# - Review logic for handling "introduced".
+#
+# - Document format of options including:
+#   - introduced: <quoted semver string>.
+#   - examples: <list of examples>
+#   - value constraints: ?
+#
+# - YAML schema to validate!?!
+#
+#---------------------------------------------------------------------
+# Hypervisor differences:
+#
+# # firecracker (fc)
+#
+# jailer_path = "@FCJAILERPATH@"
+# use_vsock = true
+#
+# # cloud hypervisor (clh)
+#
+# block_device_driver = "virtio-blk"
+#---------------------------------------------------------------------
+
+---
+description: |
+  This file contains full details of all Kata Containers 2.x options.
+
+notes:
+  - If a specific option does not specify an "introduced:" field, the option
+    is assumed to have been added when the "parent" of the option was
+    introduced (probably the component itself).
+  - If a component does not specify an "introduced:" field, it is assumed to
+    be "1.0.0".
+  - Documented options specify when they were added to the particular
+    component they belong to. Note that in some cases those options may not
+    have been made available to users via the runtime configuration file until
+    a later release.
+  - If no "subsystem:" is specified, assume "core".
+
+option-format: |
+  Each option in this file MUST conform to the following format:
+
+  <name>:
+   description: "<Brief description>"
+   notes: "<Notes>"
+   warning: "<warning text>"
+   url: "<Canonical URL providing more details on the option>"
+   introduced: "<quoted semver version showing when option introduced>"
+   deprecated: "<quoted semver version when option was deprecated>"
+   removed: "<quoted semver version when option was removed>"
+   removed-reason: "<explain why the option was removed>"
+   type: "<type>"
+   units: "<human readable units for 'type:'>"
+   subsystem: "<subsystem>"
+   required: [true|false]
+   requires:
+     - \`foo=bar\`
+     - \`baz=wibble\`
+   impacts:
+     - category: "[+-]<category-1>"
+       explanation: |
+         Optional explanation 1. If the name starts with "+", the impact is deemed to be
+         beneficial. If it starts with "-", the impact is considered detrimental.
+     - category: "[+-]<category-2>"
+       explanation: Optional explanation 2.
+   impact-explanation: |
+     If there is an "impact-explanation:", no individual "explanation:" entries are
+     required. However, there must be some explanatory material explaining the impact(s).
+   values:
+     default: <default value>
+     common: <common value - used if not the same as the default>
+     possible:
+       - name: "array of"
+         description: |
+           Explain what this value means.
+         use-case: |
+           Optional details explaining why you would want to use this value.
+       - name: "all possible"
+         description: |
+           Explain what this value means.
+       - name: "values"
+         description: |
+           Explain what this value means.
+         impacts:
+           - category: "[+-]<some-category>"
+             explanation: |
+               Explain this *value-specific* impact.
+   examples:
+     - value: "first example"
+       description: "explanation of first example"
+     - value: "second example"
+       description: "explanation of second example"
+   host-requirements:
+     minimum-kernel-version: "<minimum required host kernel version>"
+
+# FIXME: Add "debug" and "trace"?
+categories:
+  description: All possible option categories.
+  values:
+    - name: "core"
+      description: Provides minimal functionality.
+    - name: "storage-size"
+      description: Affects amount of storage space used.
+    - name: "network"
+      description: Network I/O performance.
+    - name: "security"
+      description: Provides additional security.
+    - name: "speed"
+      description: Container startup speed.
+    - name: "memory-size"
+      description: Amount of memory used (host or guest).
+    - name: "architecture-specific"
+      description: Architecture specific option.
+
+# Required until we can use a YAML schema to validate
+data-types:
+  description: |
+    All possible data types.
+
+    This is a best effort until YAML gets a proper schema language.
+  values:
+    - name: "boolean"
+      description: Binary option.
+      pattern: "\\<(true|false)\\>"
+    - name: "integer"
+      description: Any integer value.
+      pattern: "^-*[0-9][0-9]*$"
+    - name: "positive-integer"
+      description: Any integer value >= 0.
+      pattern: "^[0-9][0-9]*$"
+    - name: "string"
+      description: Any possible string value (including the empty string).
+      pattern: "^.*$"
+    - name: "non-empty-string"
+      description: Non-empty string.
+      pattern: "^[^ ][^]*$"
+    - name: "path"
+      description: Full (absolute) path name.
+      pattern: "^/.*$"
+    - name: "file"
+      description: Full (absolute) path to an existing file.
+      pattern: "^/.*$"
+    - name: "directory"
+      description: Full (absolute) path to an existing directory.
+      pattern: "^/.*$"
+      # FIXME: silly name
+    - name: "creatable-directory"
+      description: Full (absolute) path to a directory which will be created as needed.
+      pattern: "^/.*$"
+      # FIXME: silly name
+    - name: "creatable-file"
+      description: Full (absolute) path to a file which will be created as needed.
+      pattern: "^/.*$"
+    - name: "comma-list"
+      description: Comma-separated list of values.
+      pattern: "[^,]+"
+      exmaple: "one,two,three"
+    - name: "space-list"
+      description: Space-separated list of values.
+      pattern: "[^ ]+"
+      example: "one two three"
+    - name: "array-list"
+      description: Comma-separated list of quoted values inside square brackets.
+      pattern: "((?:\".*?\")|[^,\"]*)"
+      example: "[\"the start\", \"a\", \"b\", \"the end\"]"
+
+common-options:
+  generic:
+    enable_debug: &common-option-debug
+      description: |
+        Increase verbosity of generated logs.
+      type: boolean
+      values:
+        default: false
+        possible: true or false.
+      subsystem: debug
+    enable_tracing: &common-option-tracing
+      description: |
+        Enable component tracing.
+      type: boolean
+      values:
+        default: false
+        possible: true or false.
+      subsystem: tracing
+  hypervisor:
+    options:
+      path: &common-option-hypervisor-path
+        description: Full path to hypervisor binary.
+        type: path
+        required: true
+        introduced: "1.0.0"
+        subsystem: core
+      image: &common-option-hypervisor-image
+        description: Full path to disk image file.
+        type: path
+        required: true
+        introduced: "1.0.0"
+        subsystem: core
+      initrd: &common-option-hypervisor-initrd
+        description: Full path to initial ramdisk / initramfs file.
+        type: path
+        required: true
+        introduced: "1.0.0"
+        subsystem: core
+      kernel: &common-option-hypervisor-kernel
+        description: Full path to guest kernel file.
+        type: path
+        required: true
+        introduced: "1.0.0"
+        subsystem: core
+      kernel_params: &common-option-hypervisor-kernel-params
+        description: |
+          Optional space-separated list of options to pass to the guest kernel.
+
+          For example, use `kernel_params = "vsyscall=emulate"` if you are having
+          trouble running pre-2.15 glibc.
+          WARNING: - any parameter specified here will take priority over the default
+          parameter value of the same name used to start the virtual machine.
+          Do not set values here unless you understand the impact of doing so as you
+          may stop the virtual machine from booting.
+          To see the list of default parameters, enable hypervisor debug, create a
+          container and look for `default-kernel-parameters` log entries.
+        type: space-list
+        introduced: "1.0.0"
+        subsystem: core
+      firmware: &common-option-hypervisor-firmware
+        description: |
+          Full Path to the firmware.
+          Leave the option empty to use the default firmware.
+        type: boolean-path
+        subsystem: core
+
+kata:
+  log-level: info
+  components:
+    internal:
+      description: "Kata developed system elements"
+      agent:
+        introduced: "1.0.0"
+        log-level:
+        options:
+          enable_debug: *common-option-debug
+          enable_tracing:
+            description: |
+              Generate tracing spans.
+
+              If enabled, the default trace mode is "dynamic" and the
+              default trace type is `isolated`. The trace mode and type are set
+              explicity with the `trace_type=` and `trace_mode=` options.
+
+              Notes:
+
+              - Tracing is ONLY enabled when this option is set: explicitly
+                setting `trace_mode=` and/or `trace_type=` without setting `enable_tracing`
+                will NOT activate agent tracing.
+
+              - See https://github.com/kata-containers/kata-containers/blob/master/TRACING.md
+                for full details.
+            type: boolean
+            introduced: "1.6.0"
+            values:
+              default: false
+            subsystem: tracing
+          trace_mode:
+            description: |
+              Specify when tracing should start.
+            type: string
+            introduced: "1.6.0"
+            values:
+              default: "dynamic"
+              possible:
+                - name: "dynamic"
+                  description: |
+                    Traces begin when the RPC `StartTracing()` API is called
+                    and end when the corresponding `StopTracing()` API is
+                    called.
+                  use-case: On-demand (partial) tracing.
+                - name: "static"
+                  description: |
+                    Traces from agent start to agent shutdown.
+                  use-case: Obtain holistic view of agent activities.
+          trace_type:
+            description: |
+              Specify how trace spans should be grouped.
+            type: string
+            introduced: "1.6.0"
+            values:
+              default: "isolated"
+              possible:
+                - name: "isolated"
+                  description: |
+                    The traces only apply to the agent; the first span will
+                    start at agent startup and the last at agent shutdown.
+                  use-case: |
+                    Observing agent lifespan.
+                - name: "collated"
+                  description: |
+                    Agent trace spans are associated with their `kata-runtime` initiated counterparts.
+                  use-case: |
+                    Understanding how the runtime calls the agent.
+
+          kernel_modules:
+            description: |
+              Comma separated list of kernel modules and their parameters.
+              Modules will be loaded in the guest kernel using `modprobe(8)`
+              prior to container startup.
+            examples:
+              - value: \`kernel_modules=["e1000e InterruptThrottleRate=3000,3000,3000 EEE=1", "i915 enable_ppgtt=0"]\`
+                description: Load the `e1000e` and `i915` kernel modules specifying parameters to both.
+            type: comma-list
+            introduced: "1.9.0"
+      factory:
+        description: |
+          VM templating support.
+
+          VM templating support. Once enabled, new VMs are created from template
+          using vm cloning. They will share the same initial kernel, initramfs and
+          agent memory by mapping it readonly. It helps speeding up new container
+          creation and saves a lot of memory if there are many kata containers running
+          on the same host.
+
+          When disabled, new VMs are created from scratch.
+        requires:
+          - \`initrd=\` to be set (\`image=\` is not supported).
+        introduced: "1.1.0"
+        options:
+          enable_template:
+            description: Enable or disable VM templating.
+            type: boolean
+            values:
+              default: false
+          template_path:
+            description: Path to the template.
+            type: creatable-directory
+          vm_cache_number:
+            description: |
+              The number of caches of VMCache:
+                unspecified or == 0   --> VMCache is disabled
+                > 0                   --> will be set to the specified number
+
+                VMCache is a function that creates VMs as caches before using it.
+                It helps speed up new container creation.
+
+                The function consists of a server and some clients communicating
+                through Unix socket. The protocol is gRPC in protocols/cache/cache.proto.
+                The VMCache server will create some VMs and cache them by factory cache.
+                It will convert the VM to gRPC format and transport it when gets
+                requestion from clients.
+
+                Factory grpccache is the VMCache client. It will request gRPC format
+                VM and convert it back to a VM. If VMCache function is enabled,
+                kata-runtime will request VM from factory grpccache when it creates
+                a new sandbox.
+            type: integer
+            values:
+              default: 0
+          vm_cache_endpoint:
+            description: |
+              Specify the address of the Unix socket that is used by VMCache.
+            type: creatable-file
+            values:
+              default: "/var/run/kata-containers/cache.sock"
+      monitor:
+        # FIXME: testing
+        introduced: "2.0.0"
+        log-level:
+      netmon:
+        introduced: "1.3.0"
+        log-level:
+        options:
+          enable_netmon:
+            description: |
+              If enabled, the network monitoring process gets started when the
+              sandbox is created. This allows for the detection of some
+              additional network being added to the existing network
+              namespace, after the sandbox has been created.
+            type: boolean
+            values:
+              default: false
+          enable_debug: *common-option-debug
+          path:
+            description: Full path to netmon binary.
+            type: string
+            values:
+              default: "@NETMONPATH@"
+              possible: Any valid path.
+            subsystem: core
+      proxy:
+        introduced: "1.0.0"
+        removed: "2.0.0"
+        removed-reason: "No proxy required for Kata 2.x which uses vsock."
+        log-level:
+        options:
+          enable_debug: *common-option-debug
+          path:
+            description: Full path to proxy binary.
+            type: string
+            values:
+              default: "@PROXYPATH@"
+              possible: Any valid path.
+            subsystem: core
+      runtime:
+        introduced: "1.0.0"
+        log-level:
+        options:
+          enable_debug: *common-option-debug
+          disable_guest_seccomp:
+            description: |
+              Determines whether container seccomp profiles are passed to the
+              virtual machine and applied by the kata agent. If set to `true`,
+              seccomp is not applied within the guest.
+            type: boolean
+            values:
+              default: true
+            introduced: "FIXME"
+            impacts:
+              - category: "+security"
+                explanation: |
+                  Security is potentially enhanced as the workload
+                  is only permitted to run a particular set of system calls.
+              - category: "-performance"
+                explanation: |
+                  seccomp negatively impacts performance due to the
+                  additioanl system call checks performed.
+          internetworking_model:
+            description: |
+              Determines how the VM should be connected to the container
+              network interface.
+            type: string
+            values:
+              # FIXME: hard-coded hypervisor!
+              default: "@DEFNETWORKMODEL_QEMU@"
+              possible:
+                - name: macvtap
+                  description: |
+                    Used when the Container network interface can
+                    be bridged using macvtap.
+                  introduced: "FIXME"
+                - name: none
+                  description: |
+                    Used to customize the network.
+                    Only creates a tap device (no veth pair).
+                  introduced: "FIXME"
+                - tcfilter:
+                  description: |
+                    Uses tc filter rules to redirect traffic from the network interface
+                    provided by plugin to a tap interface connected to the VM.
+                  introduced: "FIXME"
+          enable_tracing:
+            description: |
+              Generate trace spans.
+            introduced: "1.2.0"
+          disable_new_netns:
+            description: |
+              If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
+              This option may have some potential impacts to your host.
+              It works only with `internetworking_model=none`.
+              The tap device will be in the host network namespace and can connect to a bridge
+              (like OVS) directly.
+              If you are using docker, `disable_new_netns` only works with `docker run --net=none`
+            warning: Only use if you understand the impact on your host.
+            impacts:
+              - category: "-security"
+                explanation: FIXME.
+            conflicts:
+              - enable_netmon
+              - internetworking_model=tcfilter
+              - internetworking_model=macvtap
+            values:
+              default: false
+            type: boolean
+          sandbox_cgroup_only:
+            description: |
+              If enabled, the runtime will add all the kata processes inside one dedicated cgroup.
+              The container cgroups in the host are not created, just one single cgroup per sandbox.
+              The runtime caller is free to restrict or collect cgroup stats of the overall Kata sandbox.
+              The sandbox cgroup path is the parent cgroup of a container with the `PodSandbox` annotation.
+              The sandbox cgroup is constrained if there is no container type annotation.
+            url: https://godoc.org/github.com/kata-containers/runtime/virtcontainers#ContainerType
+            type: boolean
+            values:
+              default: false
+          experimental:
+            description: |
+              Enable experimental features.
+            warning: |
+              Experimental features are features not stable enough for production
+              and may break compatibility.
+            type: array-list
+      shim:
+        introduced: "1.0.0"
+        log-level:
+        options:
+          enable_debug: *common-option-debug
+          enable_tracing: *common-option-tracing
+          path:
+            description: Full path to shim binary.
+            type: string
+            values:
+              default: "@SHIMPATH@"
+              possible: Any valid path.
+            subsystem: core
+    external:
+      description: "Externally developed system elements used by Kata"
+      hypervisors:
+        log-level:
+        available:
+          acrn:
+            title: ACRN
+            description: "Type 1 reference hypervisor stack"
+            url: "https://github.com/projectacrn/acrn-hypervisor/tree/master/hypervisor"
+            architectures:
+              - x86_64
+            introduced: "1.9.0"
+            options:
+              path: *common-option-hypervisor-path
+              kernel: *common-option-hypervisor-kernel
+              image: *common-option-hypervisor-image
+              ctlpath:
+                description: Full path to control binary.
+                values:
+                  default:
+                  possible: Any valid path.
+                subsystem: core
+              kernel_params: *common-option-hypervisor-kernel-params
+          clh:
+            title: Cloud Hypervisor
+            description: "open source Virtual Machine Monitor"
+            url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
+            architectures:
+              - aarch64
+              - x86_64
+            introduced: "1.10.0"
+            options:
+              path: *common-option-hypervisor-path
+              kernel: *common-option-hypervisor-kernel
+              image: *common-option-hypervisor-image
+              kernel_params: *common-option-hypervisor-kernel-params
+          fc:
+            title: Firecracker
+            description: "Firecracker micro-VMM"
+            url: "https://github.com/firecracker-microvm/firecracker"
+            architectures:
+              - aarch64
+              - x86_64
+            introduced: "1.5.0"
+            options:
+              path: *common-option-hypervisor-path
+              kernel: *common-option-hypervisor-kernel
+              image: *common-option-hypervisor-image
+              kernel_params: *common-option-hypervisor-kernel-params
+          qemu:
+            title: QEMU
+            description: "VMM that uses KVM"
+            url: "https://github.com/qemu/qemu"
+            architectures:
+              - all
+            introduced: "1.0.0"
+            options:
+              path: *common-option-hypervisor-path
+              kernel: *common-option-hypervisor-kernel
+              image: *common-option-hypervisor-image
+              initrd: *common-option-hypervisor-initrd
+              kernel_params: *common-option-hypervisor-kernel-params
+              machine_type:
+                description: FIXME.
+                type: string
+                values:
+                  default: "@MACHINETYPE@"
+                  possible: Non-blank string.
+                subsystem: core
+              machine_accelerators:
+                description: |
+                  Comma-separated list of machine accelerators
+                  to pass to the hypervisor.
+                examples:
+                  - value: \`machine_accelerators = "nosmm,nosmbus,nosata,nopit,static-prt,nofw"\`
+                    description: Load six machine accelerators.
+                type: comma-list
+                subsystem: core
+              cpu_features:
+                description: |
+                  Comma-separated list of cpu features to pass to the cpu
+                examples:
+                  - value: \`cpu_features = "pmu=off,vmx=off"\`
+                    description: Disable the `pmu` and `vmx` cpu features.
+                type: comma-list
+                subsystem: core
+                introduced: "1.11.0"
+              default_vcpus:
+                description: |
+                  Default number of vCPUs per sandbox (VM).
+                type: integer
+                values:
+                  default: 1
+              default_maxvcpus:
+                description: |
+                  Default maximum number of vCPUs per sandbox (VM).
+                type: integer
+                values:
+                  default: "@DEFMAXVCPUS@"
+              default_bridges:
+                description: |
+                  Default number of bridges for device hot plug.
+                type: integer
+                values:
+                  default: "@DEFBRIDGES@"
+              default_memory:
+                description: |
+                  Default amount of memory assigned to each sandbox (VM).
+                type: integer
+                units: MiB
+                values:
+                  default: "@DEFBRIDGES@"
+              memory_slots:
+                description: |
+                  Default memory slots per sandbox (VM).
+                  This is will determine the times that memory will be
+                  hot-added to the sandbox.
+                values:
+                  default: "@DEFMEMSLOTS@"
+              memory_offset:
+                description: |
+                  Amount of additional memory added to maximum hypervisor memory.
+                  Set to the size of the device when using an NVDIMM block device.
+                requires:
+                  - \`block_device_driver = "nvdimm"\`
+                values:
+                  default: 0
+                units: MiB
+              enable_virtio_mem:
+                description: |
+                  Specifies if `virtio-mem` will be enabled or not.
+
+                  Please note that this option should be used with the command
+                  \`echo 1 > /proc/sys/vm/overcommit_memory\`
+                type: boolean
+                introduced: "FIXME"
+              disable_block_device_use:
+                description: |
+                  Disable block device from being used for a container's rootfs.
+                type: boolean
+                values:
+                  default: "@DEFDISABLEBLOCK@"
+              block_device_driver:
+                description: |
+                   Block storage driver used by the hypervisor when the container
+                   rootfs is backed by a block device.
+                type: string
+                values:
+                  # FIXME: hard-coded hypervisor on variable name
+                  default: "@DEFBLOCKSTORAGEDRIVER_QEMU@"
+                  # FIXME: each of these needs an "introduced:" value !!
+                  possible:
+                    - name: "virtio-scsi"
+                      description:
+                      introduced: "FIXME"
+                    - name: "virtio-blk"
+                      description:
+                      introduced: "FIXME"
+                    - name: "nvdimm"
+                      description:
+                      introduced: "FIXME"
+              shared_fs:
+                description: |
+                  Shared file system type.
+                values:
+                  default: "@DEFSHAREDFS@"
+                  possible:
+                    - name: "virtio-9p"
+                      description:
+                    - name: "virtio-fs"
+                      description:
+              virtio_fs_daemon:
+                description: |
+                  Path to vhost-user-fs daemon.
+                type: path
+                values:
+                  default: "@DEFVIRTIOFSDAEMON@"
+              virtio_fs_cache_size:
+                description: |
+                  Default size of DAX cache.
+                units: MiB
+                values:
+                  default: "@DEFVIRTIOFSCACHESIZE@"
+              virtio_fs_extra_args:
+                description: |
+                  Extra arguments for virtiofsd daemon.
+                type: array-list
+                values:
+                  default: "@DEFVIRTIOFSEXTRAARGS@"
+              virtio_fs_cache:
+                description: |
+                  Cache mode for virtiofsd daemon.
+                values:
+                  possible:
+                    - name: "none"
+                      description: |
+                        Metadata, data, and pathname lookup are not cached in
+                        guest. They are always fetched from host and any changes
+                        are immediately pushed to host
+                    - name: "auto"
+                      description: |
+                        Metadata and pathname lookup cache expires after a
+                        configured amount of time (default is 1 second). Data
+                        is cached while the file is open (close to open
+                        consistency).
+                    - name: "always"
+                      description: |
+                        Metadata, data, and pathname lookup are cached in guest
+                        and never expire.
+                  default: "@DEFVIRTIOFSCACHE@"
+              block_device_cache_set:
+                description: |
+                  Specifies if cache-related options will be set to block devices.
+                type: boolean
+                values:
+                  default: false
+              block_device_cache_direct:
+                description: |
+                  Specifies cache-related options for block devices.
+                  Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
+                type: boolean
+                values:
+                  default: false
+              block_device_cache_noflush:
+                description: |
+                  Specifies cache-related options for block devices.
+                  Denotes whether flush requests for the device are ignored.
+                type: boolean
+                values:
+                  default: false
+              enable_iothreads:
+                description: |
+                  Enable iothreads (data-plane) to be used. This causes IO to be
+                  handled in a separate IO thread. This is currently only implemented
+                  for SCSI.
+                type: boolean
+                values:
+                  default: "@DEFENABLEIOTHREADS@"
+              enable_mem_prealloc:
+                description: |
+                  Enable pre allocation of VM RAM, default false
+                  Enabling this will result in lower container density
+                  as all of the memory will be allocated and locked
+                  This is useful when you want to reserve all the memory
+                  upfront or in the cases where you want memory latencies
+                  to be very predictable
+                type: boolean
+                values:
+                  default: false
+              enable_hugepages:
+                description: |
+                  Enable huge pages for VM RAM.
+                  Enabling this will result in the VM memory
+                  being allocated using huge pages.
+                  This is useful when you want to use vhost-user network
+                  stacks within the container. This will automatically
+                  result in memory pre allocation.
+                type: boolean
+                values:
+                  default: false
+              enable_vhost_user_store:
+                description: |
+                  Enable vhost-user storage device.
+                  Enabling this will result in some Linux reserved block type
+                  major range 240-254 being chosen to represent vhost-user devices.
+                type: boolean
+                values:
+                  default: "@DEFENABLEVHOSTUSERSTORE@"
+              vhost_user_store_path:
+                description: |
+                  The base directory specifically used for vhost-user devices.
+                  Its sub-path "block" is used for block devices; "block/sockets" is
+                  where we expect vhost-user sockets to live; "block/devices" is where
+                  simulated block device nodes for vhost-user devices to live.
+                type: path
+                values:
+                  default: "@DEFVHOSTUSERSTOREPATH@"
+              enable_iommu:
+                description: |
+                  Enable virtual I/O MMU (vIOMMU).
+                  Enabling this will result in the VM having a vIOMMU device
+                  This will also add the following options to the kernel's
+                  command line: "`intel_iommu=on,iommu=pt`".
+                type: boolean
+                values:
+                  default: false
+              file_mem_backend:
+                description: |
+                  Enable file based guest memory support. An empty string will disable this
+                  feature. In the case of \`virtio-fs\`, this is enabled
+                  automatically and \`/dev/shm\` is used as the backing folder.
+                  This option will be ignored if VM templating is enabled.
+                type: boolean-path
+                values:
+                  default: ""
+              enable_swap:
+                description: |
+                  Enable swap of vm memory.
+                # FIXME: document
+                warning: |
+                    Behaviour is undefined if `enable_mem_prealloc=true`.
+                type: boolean
+                values:
+                  default: false
+              disable_nesting_checks:
+                description: |
+                  Disable the customizations done in the runtime when it detects
+                  that it is running on top of a VMM. This will result in the runtime
+                  behaving as it would when running on bare metal.
+                type: boolean
+                values:
+                  default: false
+              msize_9p:
+                description: |
+                  The `msize` used for 9p shares (size of 9p packet payload).
+                  used for 9p packet payload.
+                type: positive-integer
+                units: bytes
+                values:
+                  default: "@DEFMSIZE9P@"
+              use_vsock:
+                description: |
+                  Use VSOCK sockets to communicate directly with the agent
+                  running in the Sandbox (without starting a proxy). If not
+                  set, use UNIX sockets and start a proxy to communicate with
+                  the agent.
+                notes: Requires host kernel support.
+                host-requirements:
+                  minimum-kernel-version: "4.8"
+                type: boolean
+                removed: "2.0.0"
+                removed-reason: "Redundant as of Kata 2.x which requires vsock."
+                values:
+                  default: false
+              disable_image_nvdimm:
+                description: |
+                  If false and NVDIMM is supported, use NVDIMM device to plug guest image.
+                  Otherwise `virtio-block` device is used.
+                type: boolean
+                values:
+                  default: false
+              hotplug_vfio_on_root_bus:
+                description: |
+                  VFIO devices are hotplugged on a bridge by default.
+                  Enable hotplugging on root bus. This may be required for devices with
+                  a large PCI bar, as this is a current limitation with hotplugging on
+                  a bridge. This value is valid for `pc` machine type.
+                type: boolean
+                values:
+                  default: false
+              pcie_root_port:
+                description: |
+                  Before hot plugging a PCIe device, you need to add a pcie_root_port device.
+                  Use this parameter when using some large PCI bar devices, such as Nvidia GPU
+                  The value means the number of pcie_root_port
+                  This value is valid when hotplug_vfio_on_root_bus is true and machine_type is "q35".
+                type: positive-integer
+                values:
+                  default: 0
+              disable_vhost_net:
+                description: |
+                  If `vhost-net` backend for `virtio-net` is not desired, set to
+                  true. Which trades off security (`vhost-net` runs ring0)
+                  for network I/O performance.
+                type: boolean
+                values:
+                  default: false
+                impacts:
+                  - category: "+security"
+                  - category: "-network"
+                impact-explanation: |
+                  If set to true security is theoretically improved (since
+                  `vhost-net` runs in CPU ring 0), although network I/O
+                  performance will be impacted.
+                introduced: "1.3.0"
+              entropy_source:
+                description: |
+                  Default entropy source.
+                  The path to a host source of entropy (including a real hardware RNG)
+                  "`/dev/urandom`" and "`/dev/random`" are two main options.
+                warning: |
+                  Be aware that `/dev/random` is a blocking source of entropy. If the host
+                  runs out of entropy, the VMs boot time will increase leading to get startup
+                  timeouts.
+                notes: |
+                  The source of entropy `/dev/urandom` is non-blocking and provides a
+                  generally acceptable source of entropy. It should work well for pretty much
+                  all practical purposes.
+                type: boolean-path
+                values:
+                  default: "@DEFENTROPYSOURCE@"
+              guest_hook_path:
+                description: |
+                  Path to OCI hook binaries in the *guest rootfs*. This does
+                  not affect host-side hooks which must instead be added to
+                  the OCI spec passed to the runtime.
+
+                  You can create a rootfs with hooks by customizing the
+                  osbuilder scripts:
+
+                  https://github.com/kata-containers/osbuilder
+
+                  Hooks must be stored in a subdirectory of guest_hook_path
+                  according to their hook type, i.e.
+                  "guest_hook_path/{prestart,postart,poststop}".
+
+                  The agent will scan these directories for executable files
+                  and add them, in lexicographical order, to the lifecycle of
+                  the guest container.
+
+                  Hooks are executed in the runtime namespace of the guest.
+
+                  See the official documentation:
+
+                  https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#posix-platform-hooks
+
+                  Warnings will be logged if any error is encountered will
+                  scanning for hooks, but it will not abort container
+                  execution.
+              type: path
+              values:
+                default: ""
+                common: "/usr/share/oci/hooks"


### PR DESCRIPTION
A YAML version of `configuration.toml` that encoded a *lot* more detail about each option.

Fixes: #494.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>