### PR TITLE
runtime: [Do not merge] Test VFIO-AP hotplug PR of GoVMM

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -64,6 +64,7 @@ require (
 )
 
 replace (
+	github.com/intel/govmm => github.com/Jakob-Naucke/govmm v0.0.0-20200806123926-d6752d6216de
 	github.com/uber-go/atomic => go.uber.org/atomic v1.5.1
 	gotest.tools/v3 => gotest.tools v2.2.0+incompatible
 )

--- a/src/runtime/go.sum
+++ b/src/runtime/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Jakob-Naucke/govmm v0.0.0-20200806123926-d6752d6216de h1:VtRGyIXmWlcqEgSWP7vKCuFWTd9m77lnGxADhlOZLGQ=
+github.com/Jakob-Naucke/govmm v0.0.0-20200806123926-d6752d6216de/go.mod h1:+fllL1p0wrIe9+h005LrxipimP6ODYALjVbWMzWCRnU=
 github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.8.6 h1:ZfF0+zZeYdzMIVMZHKtDKJvLHj76XCuVae/jNkjj0IA=

--- a/src/runtime/vendor/github.com/intel/govmm/qemu/qemu.go
+++ b/src/runtime/vendor/github.com/intel/govmm/qemu/qemu.go
@@ -123,6 +123,9 @@ const (
 	// VfioCCW is the vfio driver with CCW transport.
 	VfioCCW DeviceDriver = "vfio-ccw"
 
+	// VfioAP is the vfio driver with AP transport.
+	VfioAP DeviceDriver = "vfio-ap"
+
 	// VHostVSockPCI is a generic Vsock vhost device with PCI transport.
 	VHostVSockPCI DeviceDriver = "vhost-vsock-pci"
 
@@ -406,6 +409,9 @@ func (fsdev FSDevice) QemuParams(config *Config) []string {
 		deviceParams = append(deviceParams, fmt.Sprintf(",romfile=%s", fsdev.ROMFile))
 	}
 	if fsdev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", fsdev.DevNo))
 	}
 
@@ -537,6 +543,9 @@ func (cdev CharDevice) QemuParams(config *Config) []string {
 	}
 
 	if cdev.Driver == VirtioSerial && cdev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", cdev.DevNo))
 	}
 
@@ -804,6 +813,9 @@ func (netdev NetDevice) QemuDeviceParams(config *Config) []string {
 	}
 
 	if netdev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", netdev.DevNo))
 	}
 
@@ -937,6 +949,9 @@ func (dev SerialDevice) QemuParams(config *Config) []string {
 	}
 
 	if dev.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", dev.DevNo))
 	}
 
@@ -1528,6 +1543,9 @@ func (scsiCon SCSIController) QemuParams(config *Config) []string {
 	}
 
 	if scsiCon.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			devParams = append(devParams, ",iommu_platform=on")
+		}
 		devParams = append(devParams, fmt.Sprintf("devno=%s", scsiCon.DevNo))
 	}
 
@@ -1710,6 +1728,9 @@ func (vsock VSOCKDevice) QemuParams(config *Config) []string {
 	}
 
 	if vsock.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf(",devno=%s", vsock.DevNo))
 	}
 
@@ -1780,6 +1801,9 @@ func (v RngDevice) QemuParams(config *Config) []string {
 	}
 
 	if v.Transport.isVirtioCCW(config) {
+		if config.Knobs.IOMMUPlatform {
+			deviceParams = append(deviceParams, ",iommu_platform=on")
+		}
 		deviceParams = append(deviceParams, fmt.Sprintf("devno=%s", v.DevNo))
 	}
 
@@ -2125,6 +2149,9 @@ type Knobs struct {
 
 	// Exit instead of rebooting
 	NoReboot bool
+
+	// IOMMUPlatform will enable IOMMU for supported devices
+	IOMMUPlatform bool
 }
 
 // IOThread allows IO to be performed on a separate thread.

--- a/src/runtime/vendor/github.com/intel/govmm/qemu/qmp.go
+++ b/src/runtime/vendor/github.com/intel/govmm/qemu/qmp.go
@@ -1217,6 +1217,15 @@ func (q *QMP) ExecutePCIVFIOMediatedDeviceAdd(ctx context.Context, devID, sysfsd
 	return q.executeCommand(ctx, "device_add", args, nil)
 }
 
+// ExecuteAPVFIOMediatedDeviceAdd adds a VFIO mediated AP device to a QEMU instance using the device_add command.
+func (q *QMP) ExecuteAPVFIOMediatedDeviceAdd(ctx context.Context, sysfsdev string) error {
+	args := map[string]interface{}{
+		"driver":   VfioAP,
+		"sysfsdev": sysfsdev,
+	}
+	return q.executeCommand(ctx, "device_add", args, nil)
+}
+
 // isSocketIDSupported returns if the cpu driver supports the socket id option
 func isSocketIDSupported(driver string) bool {
 	if driver == "host-s390x-cpu" || driver == "host-powerpc64-cpu" {

--- a/src/runtime/vendor/modules.txt
+++ b/src/runtime/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-multierror v1.0.0
 ## explicit
 github.com/hashicorp/go-multierror
-# github.com/intel/govmm v0.0.0-20200728135209-6c3315ba8a42
+# github.com/intel/govmm v0.0.0-20200728135209-6c3315ba8a42 => github.com/Jakob-Naucke/govmm v0.0.0-20200806123926-d6752d6216de
 ## explicit
 github.com/intel/govmm/qemu
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
@@ -456,5 +456,6 @@ google.golang.org/protobuf/types/known/timestamppb
 gopkg.in/yaml.v2
 # gotest.tools v2.2.0+incompatible
 ## explicit
+# github.com/intel/govmm => github.com/Jakob-Naucke/govmm v0.0.0-20200806123926-d6752d6216de
 # github.com/uber-go/atomic => go.uber.org/atomic v1.5.1
 # gotest.tools/v3 => gotest.tools v2.2.0+incompatible


### PR DESCRIPTION
This is a do-not-merge re-vendoring PR regarding PR [#134](https://github.com/intel/govmm/pull/134) in GoVMM, which adds support for hot-plugging IBM Adjunct Processor (AP) devices over VFIO. This is to ensure that the proposed changes in GoVMM do not break Kata.
See also the issue #491 on supporting VFIO-AP in Kata.

/cc @alicefr

Fixes: #491