### PR TITLE
kata-containers: Add test target to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,6 @@ generate-protocols:
 	make -C src/agent generate-protocols
 
 .PHONY: all default
+
+test:
+	cd src/runtime && make test


### PR DESCRIPTION
Add test target to high level Makefile to enable codecov reporting.

Fixes #514

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>