### PR TITLE
Fix commit-message-check and do some updates about github actions

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -41,7 +41,7 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^.+(\n.{0,72})*$|^.+\n\s*[^a-zA-Z\s\n]'
+        pattern: '^.+(\n.{0,72})*$|^.+\n\s*[^a-zA-Z\s\n]|^.+\n\S+$'
         error: 'Body line too long (max 72)'
         post_error: ${{ env.error_msg }}
 

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -35,6 +35,7 @@ jobs:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
 
     - name: Check Subject Line Length
+      if: ${{ success() || failure() }}
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -61,6 +61,6 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^[\h]*([^:\h]+)[\h]*:'
+        pattern: '^[\h]*([^:\h\n]+)[\h]*:'
         error: 'Failed to find subsystem in subject'
         post_error: ${{ env.error_msg }}

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -28,6 +28,12 @@ jobs:
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
 
+    - name: Commit Body Missing Check
+      if: ${{ success() || failure() }}
+      uses: tim-actions/commit-body-check@v1.0.2
+      with:
+        commits: ${{ steps.get-pr-commits.outputs.commits }}
+
     - name: Check Subject Line Length
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -29,7 +29,7 @@ jobs:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
 
     - name: Check Subject Line Length
-      uses: tim-actions/commit-message-checker-with-regex@v0.3.0
+      uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
         pattern: '^.{0,75}(\n.*)*$'
@@ -38,7 +38,7 @@ jobs:
 
     - name: Check Body Line Length
       if: ${{ success() || failure() }}
-      uses: tim-actions/commit-message-checker-with-regex@v0.3.0
+      uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
         pattern: '^.+(\n.{0,72})*$|^.+\n\s*[^a-zA-Z\s\n]'
@@ -47,17 +47,18 @@ jobs:
 
     - name: Check Fixes
       if: ${{ success() || failure() }}
-      uses: tim-actions/commit-message-checker-with-regex@v0.3.0
+      uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
         pattern: '\s*Fixes\s*:?\s*(#\d+|github\.com\/kata-containers\/[a-z-.]*#\d+)'
         flags: 'i'
         error: 'No "Fixes" found'
         post_error: ${{ env.error_msg }}
+        one_pass_all_pass: 'true'
 
     - name: Check Subsystem
       if: ${{ success() || failure() }}
-      uses: tim-actions/commit-message-checker-with-regex@v0.3.0
+      uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
         pattern: '^[\h]*([^:\h]+)[\h]*:'


### PR DESCRIPTION
- Fixes #519 
- Fixes #520 
- Do not limit the length of single word in commit body
- Add commit-body-missing check
- Some minor updates