### PR TITLE
packaging: add usage instructions for -a (arch_target) option

### DIFF
--- a/tools/packaging/kernel/README.md
+++ b/tools/packaging/kernel/README.md
@@ -43,16 +43,17 @@ Commands:
 
 Options:
 
-	-c <path>   : Path to config file to build a the kernel.
-	-d          : Enable bash debug.
-	-e          : Enable experimental kernel.
-	-f          : Enable force generate config when setup.
-	-g <vendor> : GPU vendor, intel or nvidia.
-	-h          : Display this help.
-	-k <path>   : Path to kernel to build.
-	-p <path>   : Path to a directory with patches to apply to kernel.
-	-t          : Hypervisor_target.
-	-v          : Kernel version to use if kernel path not provided.
+	-a <arch>       : Arch target to build the kernel, such as aarch64/ppc64le/s390x/x86_64.
+	-c <path>   	: Path to config file to build the kernel.
+	-d          	: Enable bash debug.
+	-e          	: Enable experimental kernel.
+	-f          	: Enable force generate config when setup.
+	-g <vendor> 	: GPU vendor, intel or nvidia.
+	-h          	: Display this help.
+	-k <path>   	: Path to kernel to build.
+	-p <path>   	: Path to a directory with patches to apply to kernel.
+	-t <hypervisor>	: Hypervisor_target.
+	-v <version>	: Kernel version to use if kernel path not provided.
 ```
 
 Example:

--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -88,16 +88,17 @@ Commands:
 
 Options:
 
-	-c <path>   : Path to config file to build a the kernel.
-	-d          : Enable bash debug.
-	-e          : Enable experimental kernel.
-	-f          : Enable force generate config when setup.
-	-g <vendor> : GPU vendor, intel or nvidia.
-	-h          : Display this help.
-	-k <path>   : Path to kernel to build.
-	-p <path>   : Path to a directory with patches to apply to kernel.
-	-t          : Hypervisor_target.
-	-v          : Kernel version to use if kernel path not provided.
+	-a <arch>   	: Arch target to build the kernel, such as aarch64/ppc64le/s390x/x86_64.
+	-c <path>   	: Path to config file to build the kernel.
+	-d          	: Enable bash debug.
+	-e          	: Enable experimental kernel.
+	-f          	: Enable force generate config when setup.
+	-g <vendor> 	: GPU vendor, intel or nvidia.
+	-h          	: Display this help.
+	-k <path>   	: Path to kernel to build.
+	-p <path>   	: Path to a directory with patches to apply to kernel.
+	-t <hypervisor>	: Hypervisor_target.
+	-v <version>	: Kernel version to use if kernel path not provided.
 EOT
 	exit "$exit_code"
 }


### PR DESCRIPTION
Add -a option in script usage function and README.

Fixes #534

Signed-off-by: Jason Zhang <zhanghj.lc@inspur.com>