### PR TITLE
action: Fix subsystem check

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -68,6 +68,6 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^[\h]*([^:\h\n]+)[\h]*:'
+        pattern: '^[\s\t]*[^:\s\t]+[\s\t]*:'
         error: 'Failed to find subsystem in subject'
         post_error: ${{ env.error_msg }}


### PR DESCRIPTION
\h is not a valid metacharacter in javascript which is used in
github-action.
Use \s\t to replace it.

Fixes: #551

Signed-off-by: Tim Zhang <tim@hyper.sh>