### PR TITLE
server: Allow address to be specified

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -31,6 +31,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b585a98a234c46fc563103e9278c9391fde1f4e6850334da895d27edb9580f62"
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+
+[[package]]
 name = "autocfg"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -50,10 +62,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+
+[[package]]
 name = "bitflags"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
+
+[[package]]
+name = "blake2b_simd"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "byteorder"
@@ -96,6 +125,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "crc32fast"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -123,6 +158,26 @@ dependencies = [
  "autocfg",
  "cfg-if",
  "lazy_static",
+]
+
+[[package]]
+name = "dirs"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "142995ed02755914747cc6ca76fc7e4583cd18578746716d0508ea6ed558b9ff"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e93d7f5705de3e49895a2b5e0b8855a1c27f080192ae9c32a6432d50741a57a"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -532,6 +587,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2439c63f3f6139d1b57529d16bc3b8bb855230c8efcc5d3a896c8bea7c3b1e84"
 
 [[package]]
+name = "redox_users"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "rust-argon2",
+]
+
+[[package]]
 name = "regex"
 version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -565,6 +631,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cabe4fa914dec5870285fa7f71f602645da47c486e68486d2b4ceb4a343e90ac"
 
 [[package]]
+name = "rust-argon2"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+dependencies = [
+ "base64",
+ "blake2b_simd",
+ "constant_time_eq",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -575,6 +653,7 @@ name = "rustjail"
 version = "0.1.0"
 dependencies = [
  "caps",
+ "dirs",
  "error-chain",
  "lazy_static",
  "libc",

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 use rustjail::errors::*;
+use std::env;
 use std::fs;
 use std::time;
 
@@ -17,6 +18,9 @@ const CONTAINER_PIPE_SIZE_OPTION: &str = "agent.container_pipe_size";
 const DEFAULT_LOG_LEVEL: slog::Level = slog::Level::Info;
 const DEFAULT_HOTPLUG_TIMEOUT: time::Duration = time::Duration::from_secs(3);
 const DEFAULT_CONTAINER_PIPE_SIZE: i32 = 0;
+const VSOCK_ADDR: &str = "vsock://-1";
+const VSOCK_PORT: u16 = 1024;
+const SERVER_ADDR_ENV_VAR: &str = "KATA_AGENT_SERVER_ADDR";
 
 // FIXME: unused
 const TRACE_MODE_FLAG: &str = "agent.trace";
@@ -31,6 +35,7 @@ pub struct agentConfig {
     pub debug_console_vport: i32,
     pub log_vport: i32,
     pub container_pipe_size: i32,
+    pub server_addr: String,
 }
 
 impl agentConfig {
@@ -43,6 +48,7 @@ impl agentConfig {
             debug_console_vport: 0,
             log_vport: 0,
             container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+            server_addr: format!("{}:{}", VSOCK_ADDR, VSOCK_PORT),
         }
     }
 
@@ -89,6 +95,10 @@ impl agentConfig {
                 let container_pipe_size = get_container_pipe_size(param)?;
                 self.container_pipe_size = container_pipe_size
             }
+        }
+
+        if let Ok(addr) = env::var(SERVER_ADDR_ENV_VAR) {
+            self.server_addr = addr;
         }
 
         Ok(())

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -72,8 +72,6 @@ use uevent::watch_uevents;
 mod rpc;
 
 const NAME: &str = "kata-agent";
-const VSOCK_ADDR: &str = "vsock://-1";
-const VSOCK_PORT: u16 = 1024;
 const KERNEL_CMDLINE_FILE: &str = "/proc/cmdline";
 const CONSOLE_PATH: &str = "/dev/console";
 
@@ -229,7 +227,7 @@ fn main() -> Result<()> {
     sandbox.lock().unwrap().sender = Some(tx);
 
     //vsock:///dev/vsock, port
-    let mut server = rpc::start(sandbox.clone(), VSOCK_ADDR, VSOCK_PORT);
+    let mut server = rpc::start(sandbox.clone(), config.server_addr.as_str());
 
     /*
         let _ = fs::remove_file("/tmp/testagent");

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1438,7 +1438,7 @@ fn find_process<'a>(
     Ok(p)
 }
 
-pub fn start<S: Into<String>>(s: Arc<Mutex<Sandbox>>, host: S, port: u16) -> ttrpc::Server {
+pub fn start(s: Arc<Mutex<Sandbox>>, server_address: &str) -> ttrpc::Server {
     let agent_service = Box::new(agentService {
         sandbox: s,
         test: 1,
@@ -1454,17 +1454,13 @@ pub fn start<S: Into<String>>(s: Arc<Mutex<Sandbox>>, host: S, port: u16) -> ttr
 
     let hservice = protocols::health_ttrpc::create_health(health_worker);
 
-    let mut addr: String = host.into();
-    addr.push_str(":");
-    addr.push_str(&port.to_string());
-
     let server = ttrpc::Server::new()
-        .bind(addr.as_str())
+        .bind(server_address)
         .unwrap()
         .register_service(aservice)
         .register_service(hservice);
 
-    info!(sl!(), "ttRPC server started");
+    info!(sl!(), "ttRPC server started"; "address" => server_address);
 
     server
 }


### PR DESCRIPTION
Allow the default (VSOCK) ttRPC server address to be changed using a new `KATA_AGENT_SERVER_ADDR` environment variable (for testing and debugging).

Fixes: #552.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>