### PR TITLE
sandbox: Disconnect from agent after VM shutdown

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1623,6 +1623,11 @@ func (s *Sandbox) Stop(force bool) error {
 		return err
 	}
 
+	// Stop communicating with the agent.
+	if err := s.agent.disconnect(); err != nil && !force {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
When a one-shot pod dies in CRI-O, the shimv2 process isn't killed until the pod is actually deleted, even though the VM is shut down. In this case, the shim appears to busyloop when attempting to talk to the (now dead) agent via VSOCK. To address this, we disconnect from the agent after the VM is shut down.

This is especially catastrophic for one-shot pods that may persist for hours or days, but it also applies to any shimv2 pod where Kata is configured to use VSOCK for communication.

Fixes kata-containers/runtime#2719

Signed-off-by: Evan Foster <efoster@adobe.com>