### PR TITLE
docs: remove outdated dependencies from agent docs

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -38,10 +38,6 @@ After that, we drafted the initial code here, and any contributions are welcome.
 
 ## Getting Started
 
-### Dependencies
-The `rust-agent` depends on [`grpc-rs`](https://github.com/pingcap/grpc-rs) by PingCAP. However, the upstream `grpc-rs` and [gRPC](https://github.com/grpc/grpc) need some changes to be used here, which may take some time to be landed. Therefore, we created a temporary fork or `grpc-rs` here:
-- https://github.com/alipay/grpc-rs/tree/rust_agent
-
 ### Build from Source
 The rust-agent need to be built with rust nightly, and static linked with musl.
 ```bash


### PR DESCRIPTION
switched from grpc to ttrpc (a7041c27d)

fixs #558

Signed-off-by: Snir Sheriber <snir911@gmail.com>