### PR TITLE
packaging: Add VFIO-AP fragment for s390x

### DIFF
--- a/tools/packaging/kernel/configs/fragments/s390/vfio-ap.conf
+++ b/tools/packaging/kernel/configs/fragments/s390/vfio-ap.conf
@@ -1,0 +1,13 @@
+# see https://www.kernel.org/doc/html/latest/s390/vfio-ap.html for more information
+
+# VFIO support for AP devices
+CONFIG_VFIO_AP=y
+CONFIG_VFIO_IOMMU_TYPE1=y
+# VFIO Non-Privileged userspace driver framework
+CONFIG_VFIO=y
+# Mediated device driver framework
+CONFIG_VFIO_MDEV=y
+# VFIO driver for Mediated devices
+CONFIG_VFIO_MDEV_DEVICE=y
+# S390 AP IOMMU Support
+CONFIG_S390_AP_IOMMU=y


### PR DESCRIPTION
Add vfio-ap.conf to the s390 kernel config fragments, which includes the necessary flags for passing an IBM Adjunct Processor (AP) device over VFIO.
See also issue #491 on supporting VFIO-AP in Kata.

/cc @alicefr

Fixes: #567 