### PR TITLE
runtime: Add support for VFIO-AP pass-through

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1305,6 +1305,9 @@ func (q *qemu) hotplugVFIODevice(device *config.VFIODev, op operation) (err erro
 			case config.VFIODeviceNormalType:
 				return q.qmpMonitorCh.qmp.ExecuteVFIODeviceAdd(q.qmpMonitorCh.ctx, devID, device.BDF, device.Bus, romFile)
 			case config.VFIODeviceMediatedType:
+				if utils.IsAPVFIOMediatedDevice(device.SysfsDev) {
+					return q.qmpMonitorCh.qmp.ExecuteAPVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, device.SysfsDev)
+				}
 				return q.qmpMonitorCh.qmp.ExecutePCIVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, devID, device.SysfsDev, "", device.Bus, romFile)
 			default:
 				return fmt.Errorf("Incorrect VFIO device type found")
@@ -1326,6 +1329,9 @@ func (q *qemu) hotplugVFIODevice(device *config.VFIODev, op operation) (err erro
 		case config.VFIODeviceNormalType:
 			return q.qmpMonitorCh.qmp.ExecutePCIVFIODeviceAdd(q.qmpMonitorCh.ctx, devID, device.BDF, addr, bridge.ID, romFile)
 		case config.VFIODeviceMediatedType:
+			if utils.IsAPVFIOMediatedDevice(device.SysfsDev) {
+				return q.qmpMonitorCh.qmp.ExecuteAPVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, device.SysfsDev)
+			}
 			return q.qmpMonitorCh.qmp.ExecutePCIVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, devID, device.SysfsDev, addr, bridge.ID, romFile)
 		default:
 			return fmt.Errorf("Incorrect VFIO device type found")

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -269,3 +269,12 @@ func (q *qemuS390x) appendVSock(devices []govmmQemu.Device, vsock types.VSock) (
 func (q *qemuS390x) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {
 	return devices, fmt.Errorf("S390x does not support appending a vIOMMU")
 }
+
+func (q *qemuS390x) addDeviceToBridge(ID string, t types.Type) (string, types.Bridge, error) {
+	addr, b, err := genericAddDeviceToBridge(q.Bridges, ID, types.CCW)
+	if err != nil {
+		return "", b, err
+	}
+
+	return fmt.Sprintf("%04x", addr), b, nil
+}

--- a/src/runtime/virtcontainers/utils/utils_linux.go
+++ b/src/runtime/virtcontainers/utils/utils_linux.go
@@ -92,7 +92,8 @@ func FindContextID() (*os.File, uint64, error) {
 const (
 	procMountsFile = "/proc/mounts"
 
-	fieldsPerLine = 6
+	fieldsPerLine  = 6
+	vfioAPSysfsDir = "vfio_ap"
 )
 
 const (
@@ -140,4 +141,16 @@ func GetDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err e
 			return
 		}
 	}
+}
+
+// IsAPVFIOMediatedDevice decides whether a device is a VFIO-AP device
+// by checking for the existence of "vfio_ap" in the path
+func IsAPVFIOMediatedDevice(sysfsdev string) bool {
+	split := strings.Split(sysfsdev, string(os.PathSeparator))
+	for _, el := range split {
+		if el == vfioAPSysfsDir {
+			return true
+		}
+	}
+	return false
 }

--- a/src/runtime/virtcontainers/utils/utils_linux_test.go
+++ b/src/runtime/virtcontainers/utils/utils_linux_test.go
@@ -49,3 +49,19 @@ func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
 	assert.Equal(path, "proc")
 	assert.Equal(fstype, "proc")
 }
+
+func TestIsAPVFIOMediatedDeviceFalse(t *testing.T) {
+	assert := assert.New(t)
+
+	// Should be false for a PCI device
+	isAPMdev := IsAPVFIOMediatedDevice("/sys/bus/pci/devices/0000:00:02.0/a297db4a-f4c2-11e6-90f6-d3b88d6c9525")
+	assert.False(isAPMdev)
+}
+
+func TestIsAPVFIOMediatedDeviceTrue(t *testing.T) {
+	assert := assert.New(t)
+
+	// Typical AP sysfsdev
+	isAPMdev := IsAPVFIOMediatedDevice("/sys/devices/vfio_ap/matrix/a297db4a-f4c2-11e6-90f6-d3b88d6c9525")
+	assert.True(isAPMdev)
+}


### PR DESCRIPTION
Recognise when a device to be hot-plugged is an IBM Adjunct Processor (AP) device and execute VFIO AP hot-plug accordingly. 
This enables running cryptographic workloads on an IBM CryptoCard inside a Kata container, since these cards use the AP bus on s390x (IBM Z mainframe).
I am momentarily calling this a WIP because I am not entirely sure about documentation.

To use this, one has to make an adapter and domain available for VFIO and assign them to a mediated device as per the [kernel documentation](https://www.kernel.org/doc/html/latest/s390/vfio-ap.html), determine the IOMMU group for this mediated device similar to [Kata's guide on doing this with an Intel i915 GPU](https://github.com/kata-containers/kata-containers/blob/2.0-dev/docs/use-cases/Intel-GPU-passthrough-and-Kata.md), and run something like

```sh
$ ctr run --runtime io.containerd.run.kata.v2 -t --rm --device /dev/vfio/0 docker.io/library/ubuntu:latest foo bash
$ lszcrypt # requires s390-tools to be installed
CARD.DOMAIN TYPE  MODE        STATUS  REQUESTS
----------------------------------------------
09          CEX6C CCA-Coproc  online         1
09.003d     CEX6C CCA-Coproc  online         1
```

Should this be a full guide when it's so similar to the iGPU method? WDYT?

/cc @alicefr

Fixes: #491 