### PR TITLE
docs: Adding hyperlink to virtio-net in kata documentation 2.0

### DIFF
--- a/docs/design/virtualization.md
+++ b/docs/design/virtualization.md
@@ -62,7 +62,7 @@ be changed by editing the runtime [`configuration`](./architecture.md/#configura
 Devices and features used:
 - virtio VSOCK or virtio serial
 - virtio block or virtio SCSI
-- virtio net
+- [virtio net](https://www.redhat.com/en/virtio-networking-series)
 - virtio fs or virtio 9p (recommend: virtio fs)
 - VFIO
 - hotplug


### PR DESCRIPTION
Referring virtio-net mentioning in the kata virtualization
documentation to the virtio-networking blog series published
and explaining how it works.

Fixes #612

Signed-off-by: Ariel Adam <aadam@redhat.com>