### PR TITLE
clh: Disable the 'seccomp' option temporarily

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -959,6 +959,12 @@ func (clh *cloudHypervisor) LaunchClh() (int, error) {
 		args = append(args, "-vv")
 	}
 
+	// Disable the 'seccomp' option in clh for now.
+	// In this way, we can separate the periodic failures caused
+	// by incomplete `seccomp` filters from other failures.
+	// We will bring it back after completing the `seccomp` filter.
+	args = append(args, "--seccomp", "false")
+
 	clh.Logger().WithField("path", clhPath).Info()
 	clh.Logger().WithField("args", strings.Join(args, " ")).Info()
 


### PR DESCRIPTION
We kept observing instabilities from CLH CI jobs periodically (kata
1.x). To separate the random failures caused by `seccomp` from other
failures, this patch disables the 'seccomp' option from clh in kata for
now. We will bring this option back after completing the 'seccomp'
filter lists based on Kata's CI workload. Details are tracked in the
following two issues:
https://github.com/kata-containers/runtime/issues/2899 and
https://github.com/kata-containers/runtime/issues/2901

We are facing the similar challenge to stabilize CI jobs related to
cloud-hypervisor in Kata 2.0. We are disabling the `seccomp` option here
for the same reason. Related issue:
https://github.com/kata-containers/tests/issues/2813

Fixes: #614

Signed-off-by: Bo Chen <chen.bo@intel.com>