### PR TITLE
initrd: Increase Alpine Version to 3.12

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -139,7 +139,7 @@ assets:
     architecture:
       aarch64:
         name: &default-initrd-name "alpine"
-        version: &default-initrd-version "3.7"
+        version: &default-initrd-version "3.12"
       ppc64le:
         name: *default-initrd-name
         version: *default-initrd-version


### PR DESCRIPTION
Upgrade Alpine version from unsupported 3.7 to supported 3.12

Fixes #610

Signed-off-by: Jan Schintag jan.schintag@de.ibm.com