### PR TITLE
kata-deploy: add ACRN runtime to Docker configuration

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy-docker.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy-docker.sh
@@ -51,6 +51,10 @@ function configure_docker() {
      "kata-clh": {
       "path": "/opt/kata/bin/kata-runtime",
       "runtimeArgs": [ "--kata-config", "/opt/kata/share/defaults/kata-containers/configuration-clh.toml" ]
+    },
+     "kata-acrn": {
+      "path": "/opt/kata/bin/kata-runtime",
+      "runtimeArgs": [ "--kata-config", "/opt/kata/share/defaults/kata-containers/configuration-acrn.toml" ]
     }
   }
 }


### PR DESCRIPTION
Add an ACRN runtime ('kata-acrn') to the Docker configuration
('/etc/docker/daemon.json').

Fixes: #579
Signed-off-by: Geoffroy Van Cutsem <geoffroy.vancutsem@intel.com>