### PR TITLE
agent: update Cargo files authors

### DIFF
--- a/pkg/logging/Cargo.toml
+++ b/pkg/logging/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "logging"
 version = "0.1.0"
-authors = ["Tim Zhang <tim@hyper.sh>"]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "kata-agent"
 version = "0.1.0"
-authors = ["Yang Bo <bo@hyper.sh>"]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2018"
 
 [dependencies]

--- a/src/agent/netlink/Cargo.toml
+++ b/src/agent/netlink/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "netlink"
 version = "0.1.0"
-authors = ["Yang Bo <yb203166@antfin.com>"]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/src/agent/oci/Cargo.toml
+++ b/src/agent/oci/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "oci"
 version = "0.1.0"
-authors = ["Yang Bo <bo@hyper.sh>"]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2018"
 
 [dependencies]

--- a/src/agent/protocols/Cargo.toml
+++ b/src/agent/protocols/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "protocols"
 version = "0.1.0"
-authors = ["Hui Zhu <teawater@hyper.sh>"]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2018"
 
 [dependencies]

--- a/src/agent/rustjail/Cargo.toml
+++ b/src/agent/rustjail/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rustjail"
 version = "0.1.0"
-authors = ["Yang Bo <bo@hyper.sh>"]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2018"
 
 [dependencies]

--- a/src/trace-forwarder/Cargo.toml
+++ b/src/trace-forwarder/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 name = "kata-trace-forwarder"
 version = "0.0.1"
-authors = ["James O. D. Hunt <james.o.hunt@intel.com>"]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2018"
 
 [dependencies]

--- a/tools/agent-ctl/Cargo.toml
+++ b/tools/agent-ctl/Cargo.toml
@@ -6,7 +6,7 @@
 [package]
 name = "kata-agent-ctl"
 version = "0.0.1"
-authors = ["James O. D. Hunt <james.o.hunt@intel.com>"]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Anyone can collaborate in the Kata Containers project, so instead of
adding her/his name and email to the Cargo.toml files, use
`The Kata Containers community` as name and
`kata-dev@lists.katacontainers.io` as email.

fixes #643

Signed-off-by: Julio Montes <julio.montes@intel.com>