### PR TITLE
rootfs-builder: fix unbootable dracut-based initramfs on Fedora

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -441,8 +441,7 @@ prepare_overlay()
 	# we were passed a pre-populated rootfs directory
 	if [ ! -e ./sbin/init ]; then
 		ln -sf  ./usr/lib/systemd/systemd ./init
-		ln -sf  ../../init ./lib/systemd/systemd
-		ln -sf  ../init ./sbin/init
+		ln -sf  /init ./sbin/init
 	fi
 
 	# Kata systemd unit file


### PR DESCRIPTION
This is a forward port of Kata 1.x PR
https://github.com/kata-containers/osbuilder/pull/480 .

Fixes #646

Signed-off-by: Pavel Mores <pmores@redhat.com>