### PR TITLE
drivers: Correct isPCIeDevice logic

### DIFF
--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -89,9 +89,6 @@ var SysIOMMUPath = "/sys/kernel/iommu_groups"
 // SysBusPciDevicesPath is static string of /sys/bus/pci/devices
 var SysBusPciDevicesPath = "/sys/bus/pci/devices"
 
-// SysBusPciSlotsPath is static string of /sys/bus/pci/slots
-var SysBusPciSlotsPath = "/sys/bus/pci/slots"
-
 var getSysDevPath = getSysDevPathImpl
 
 // DeviceInfo is an embedded type that contains device data common to all types of devices.


### PR DESCRIPTION
Currently, isPCIeDevice() attempts to determine if a (host) device is
PCI-Express capable by looking up its link speed via the PCI slots
information in sysfs.  This is a) complicated and b) wrong.  PCI-e devices
don't have to have slots information, so this frequently fails.

Instead determine if devices are PCI-e by checking for the presence of
PCIe extended configuration space by looking at the size of the "config"
file in sysfs.

Forward ported from 6bf93b23 in the Kata 1.x runtime repository.

Fixes: #611

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>