### PR TITLE
trivial: Fix spelling of "privilege"

### DIFF
--- a/src/agent/rustjail/src/capabilities.rs
+++ b/src/agent/rustjail/src/capabilities.rs
@@ -100,7 +100,7 @@ pub fn reset_effective() -> Result<()> {
     Ok(())
 }
 
-pub fn drop_priviledges(cfd_log: RawFd, caps: &LinuxCapabilities) -> Result<()> {
+pub fn drop_privileges(cfd_log: RawFd, caps: &LinuxCapabilities) -> Result<()> {
     let all = caps::all();
 
     for c in all.difference(&to_capshashset(cfd_log, caps.bounding.as_ref())) {

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -575,7 +575,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
 
     if oci_process.capabilities.is_some() {
         let c = oci_process.capabilities.as_ref().unwrap();
-        capabilities::drop_priviledges(cfd_log, c)?;
+        capabilities::drop_privileges(cfd_log, c)?;
     }
 
     if init {

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -1453,7 +1453,7 @@ func addHTBQdisc(linkIndex int, maxRate uint64) error {
 		Parent:    netlink.HANDLE_ROOT,
 	}
 	qdisc := netlink.NewHtb(qdiscAttrs)
-	// all non-priviledged traffic go to classid 1:2.
+	// all non-privileged traffic go to classid 1:2.
 	qdisc.Defcls = 2
 
 	err := netlink.QdiscAdd(qdisc)
@@ -1476,7 +1476,7 @@ func addHTBQdisc(linkIndex int, maxRate uint64) error {
 		return fmt.Errorf("Failed to add htb classid 1:1 : %v", err)
 	}
 
-	// above class has at least one default child class(1:2) for all non-priviledged traffic.
+	// above class has at least one default child class(1:2) for all non-privileged traffic.
 	classAttrs = netlink.ClassAttrs{
 		LinkIndex: linkIndex,
 		Parent:    netlink.MakeHandle(1, 1),


### PR DESCRIPTION
I noticed the spelling mistake while reviewing another change and
doing a "grep" for "privilege" that turned up nothing.

Fixes: #671

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>