### PR TITLE
runtime: qemu: reduce boot time and memory footprint

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -239,6 +239,7 @@ ifneq (,$(QEMUCMD))
     # qemu-specific options (all should be suffixed by "_QEMU")
     DEFBLOCKSTORAGEDRIVER_QEMU := virtio-scsi
     DEFNETWORKMODEL_QEMU := tcfilter
+    KERNELTYPE = uncompressed
     KERNELNAME = $(call MAKE_KERNEL_NAME,$(KERNELTYPE))
     KERNELPATH = $(KERNELDIR)/$(KERNELNAME)
 endif


### PR DESCRIPTION
The linux kernel feature RANDOMIZE_BASE improved the security and at
the same time increased the memory footprint of a kata container,
this feature was enabled in kata-containers/packaging#1006.
In order to mitigate this increase in memory consumption, we can
boot container using the uncompressed kernel.

Reduce boot time by ~5%
Reduce KSM memory footprint by ~14%
Reduce noKSM memory footprint by ~27%

fixes #669

![1](https://user-images.githubusercontent.com/13009432/92256270-2405fa80-ee99-11ea-81b1-5941e4a9c588.png)

![2](https://user-images.githubusercontent.com/13009432/92256301-29fbdb80-ee99-11ea-8dcf-27e51bf715d8.png)

Signed-off-by: Julio Montes <julio.montes@intel.com>