### PR TITLE
osbuilder: fix rootfs build on ppc64le

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -539,9 +539,10 @@ EOT
 	AGENT_DEST="${AGENT_DIR}/${AGENT_BIN}"
 
 	if [ -z "${AGENT_SOURCE_BIN}" ] ; then
+		[ "$ARCH" == "ppc64le" ] && ([ "$LIBC" == "gnu" ] || die "LIBC type for ppc64le should be gnu")
 		bash ${script_dir}/../../../ci/install_musl.sh
-		# rust agent needs ${arch}-unknown-linux-musl
-		rustup show | grep linux-musl > /dev/null || bash ${script_dir}/../../../ci/install_rust.sh
+		# rust agent needs ${arch}-unknown-linux-${LIBC}
+		rustup show | grep linux-${LIBC} > /dev/null || bash ${script_dir}/../../../ci/install_rust.sh
 		test -r "${HOME}/.cargo/env" && source "${HOME}/.cargo/env"
 		[ "$ARCH" == "aarch64" ] && OLD_PATH=$PATH && export PATH=$PATH:/usr/local/musl/bin
 


### PR DESCRIPTION
The default toolchain used for building the rust agent would be different for ppc64le.

Fixes: #678

Signed-off-by: Amulya Meka <amulmek1@in.ibm.com>