### PR TITLE
agent: Remove PCI rescan

### DIFF
--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -44,10 +44,6 @@ lazy_static! {
     };
 }
 
-pub fn rescan_pci_bus() -> Result<()> {
-    online_device(SYSFS_PCI_BUS_RESCAN_FILE)
-}
-
 pub fn online_device(path: &str) -> Result<()> {
     fs::write(path, "1")?;
     Ok(())
@@ -156,7 +152,6 @@ pub fn get_scsi_device_name(sandbox: &Arc<Mutex<Sandbox>>, scsi_addr: &str) -> R
 pub fn get_pci_device_name(sandbox: &Arc<Mutex<Sandbox>>, pci_id: &str) -> Result<String> {
     let pci_addr = get_pci_device_address(pci_id)?;
 
-    rescan_pci_bus()?;
     get_device_name(sandbox, &pci_addr)
 }
 

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -8,7 +8,6 @@
 pub const SYSFS_DIR: &str = "/sys";
 
 pub const SYSFS_PCI_BUS_PREFIX: &str = "/sys/bus/pci/devices";
-pub const SYSFS_PCI_BUS_RESCAN_FILE: &str = "/sys/bus/pci/rescan";
 #[cfg(any(
     target_arch = "powerpc64",
     target_arch = "s390x",

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -32,7 +32,7 @@ use nix::sys::stat;
 use nix::unistd::{self, Pid};
 use rustjail::process::ProcessOperations;
 
-use crate::device::{add_devices, rescan_pci_bus, update_device_cgroup};
+use crate::device::{add_devices, update_device_cgroup};
 use crate::linux_abi::*;
 use crate::metrics::get_metrics;
 use crate::mount::{add_storages, remove_mounts, BareMount, STORAGEHANDLERLIST};
@@ -97,11 +97,6 @@ impl agentService {
         };
 
         info!(sl!(), "receive createcontainer {}", &cid);
-
-        // re-scan PCI bus
-        // looking for hidden devices
-
-        rescan_pci_bus().chain_err(|| "Could not rescan PCI bus")?;
 
         // Some devices need some extra processing (the ones invoked with
         // --device for instance), and that's what this call is doing. It


### PR DESCRIPTION
PCI bus rescan code was added long time ago in Clear Containers due to lack of
ACPI support in QEMU 2.9 + q35 [1]. Now this code is messing up PCIe hotplug
in Kata Containers. A workaround to this issue is the "lazy attach"
mechanism [2] that hotplugs LBS (Large BAR space) devices after re-scanning the
PCI bus, unfourtunately some non-LBS devices are being affected too, for
instance SR-IOV devices. It would not make sense to lazy-attach non-LBS
devices because kata will end up lazy-attaching all the devices, having said
that, the PCI bus rescan code and the "lazy attach" mechanism should be removed

Forward port of: kata-containers/agent#782
Fixes: #683
Suggested-by: Julio Montes <julio.montes@intel.com>
Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>