### PR TITLE
agent: Fix OCI Windows network shared container name typo

### DIFF
--- a/src/agent/oci/src/lib.rs
+++ b/src/agent/oci/src/lib.rs
@@ -653,7 +653,7 @@ pub struct WindowsNetwork {
     #[serde(
         default,
         skip_serializing_if = "String::is_empty",
-        rename = "nwtworkSharedContainerName"
+        rename = "networkSharedContainerName"
     )]
     pub network_shared_container_name: String,
 }


### PR DESCRIPTION
Correct the typo which would break the Windows-specific OCI network shared container name feature.

See: https://github.com/opencontainers/runtime-spec/blob/master/config-windows.md#network

Fixes: #685.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>