### PR TITLE
runtime: Set default virtiofs cache mode to none

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -173,7 +173,7 @@ DEFSHAREDFS_QEMU_VIRTIOFS := virtio-fs
 DEFVIRTIOFSDAEMON := $(VIRTIOFSDBINDIR)/virtiofsd
 # Default DAX mapping cache size in MiB
 DEFVIRTIOFSCACHESIZE := 1024
-DEFVIRTIOFSCACHE ?= auto
+DEFVIRTIOFSCACHE ?= none
 # Format example:
 #   [\"-o\", \"arg1=xxx,arg2\", \"-o\", \"hello world\", \"--arg3=yyy\"]
 #


### PR DESCRIPTION
This is a follow-up of 9177d3a3b7e8b8b30b4d7083b86332695c315d15, after
having the input from Vivek Goyal that the consistency issues will also
happen with `cache=auto`, but only in a lower amount.

The recommendation is to use `cache=none` as the default behavior.

Fixes: #691

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>