### PR TITLE
runtime: Call s.newStore.Destroy if globalSandboxList.addSandbox

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -513,6 +513,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 	}
 
 	if err = globalSandboxList.addSandbox(s); err != nil {
+		s.newStore.Destroy(s.id)
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes:  #696

backport from https://github.com/kata-containers/runtime/pull/2920

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>