### PR TITLE
agent: add retry between doing CPU hotplug and make it online.

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1179,8 +1179,6 @@ impl protocols::agent_ttrpc::AgentService for agentService {
         _ctx: &ttrpc::TtrpcContext,
         req: protocols::agent::OnlineCPUMemRequest,
     ) -> ttrpc::Result<Empty> {
-        // sleep 5 seconds for debug
-        // thread::sleep(Duration::new(5, 0));
         let s = Arc::clone(&self.sandbox);
         let sandbox = s.lock().unwrap();
 


### PR DESCRIPTION
Somte time runtime will fail in onlining CPU process,
because when the runtime calls to QMP
`device_add`, QEMU doesn't allocate all vCPUs inmediatelly.

Fixes: #665

Signed-off-by: bin liu <bin@hyper.sh>

**Attention:**

This PR only add retries for CPU resources, but not memory. In 1.x, there is no retries for memory resources. 