### PR TITLE
ci: run agent test under root user

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ install:
   - export RUST_AGENT=yes
   - make -C ${TRAVIS_BUILD_DIR}/src/agent
   - make -C ${TRAVIS_BUILD_DIR}/src/agent check
+  - sudo -E PATH=$PATH make -C ${TRAVIS_BUILD_DIR}/src/agent check
 
 before_script:
   - "ci/install_go.sh"

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -955,7 +955,7 @@ mod tests {
                 continue;
             }
 
-            let error_msg = format!("{}", result.unwrap_err());
+            let error_msg = format!("{:#}", result.unwrap_err());
 
             assert!(error_msg.contains(d.error_contains), msg);
         }


### PR DESCRIPTION
Running agent test now only support normal user,
under root user also needed.

Fixes: #708

Signed-off-by: bin liu <bin@hyper.sh>