### PR TITLE
runtime: add podman configuration to data collection script

### DIFF
--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -466,6 +466,17 @@ show_container_mgr_details()
 		subheading "$title"
 		run_cmd_and_show_quoted_output "" "podman --version"
 
+		run_cmd_and_show_quoted_output "" "podman system info"
+
+		local cmd file
+
+		for file in {/etc,/usr/share}/containers/*.{conf,json}; do
+			if [ -e "$file" ]; then
+				cmd="cat $file"
+				run_cmd_and_show_quoted_output "" "$cmd"
+			fi
+		done
+
 		end_section
 	fi
 


### PR DESCRIPTION
Be more verbose about podman configuration in the output of data
collection script: get the system configuration as seen by podman and
dump the configuration files when present.

Fixes: #243