### PR TITLE
shmv2: should return error from delete()

### DIFF
--- a/src/runtime/containerd-shim-v2/delete.go
+++ b/src/runtime/containerd-shim-v2/delete.go
@@ -44,7 +44,5 @@ func deleteContainer(ctx context.Context, s *service, c *container) error {
 		}
 	}
 
-	delete(s.containers, c.id)
-
-	return nil
+	return delete(s.containers, c.id)
 }


### PR DESCRIPTION
At the end of deleteContainer(), it seems we should return whatever
returns from delete() instead of nil.

Fixes: #723
Signed-off-by: Qian Cai <cai@redhat.com>