### PR TITLE
runtime: Don't use hard-coded crio config

### DIFF
--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -433,8 +433,7 @@ show_container_mgr_details()
 		local cmd="systemctl show crio"
 		run_cmd_and_show_quoted_output "" "$cmd"
 
-		local file="/etc/crio/crio.conf"
-		cmd="cat $file"
+		cmd="crio config"
 		run_cmd_and_show_quoted_output "" "$cmd"
 
 		end_section


### PR DESCRIPTION
In show_container_mgr_details(), it used "cat /etc/crio/crio.conf"
instead of "crio config".

Fixes: #736
Signed-off-by: Qian Cai <cai@redhat.com>