### PR TITLE
packaging: fix release notes scripts

### DIFF
--- a/tools/packaging/release/runtime-release-notes.sh
+++ b/tools/packaging/release/runtime-release-notes.sh
@@ -42,10 +42,7 @@ EOT
 }
 
 repos=(
-	"agent"
-	"proxy"
-	"runtime"
-	"shim"
+	"kata-containers"
 )
 
 get_release_info() {


### PR DESCRIPTION
It should only check kata-containers repository.

Fixes: #758