### PR TITLE
packaging: fix cloud-hypervisor build

### DIFF
--- a/tools/packaging/release/kata-deploy-binaries.sh
+++ b/tools/packaging/release/kata-deploy-binaries.sh
@@ -173,7 +173,7 @@ install_clh() {
 	kata_version="${kata_version}" "${script_dir}/../static-build/cloud-hypervisor/build-static-clh.sh"
 	info "Install static cloud-hypervisor"
 	mkdir -p "${destdir}/opt/kata/bin/"
-	sudo install -D --owner root --group root --mode 0744 cloud-hypervisor/cloud-hypervisor "${destdir}/opt/kata/bin/cloud-hypervisor"
+	sudo install -D --owner root --group root --mode 0744 cloud-hypervisor "${destdir}/opt/kata/bin/cloud-hypervisor"
 	pushd "${destdir}"
 	# create tarball for github release action
 	tar -czvf ../kata-static-clh.tar.gz *

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -13,29 +13,12 @@ kata_version="${kata_version:-}"
 
 source "${script_dir}/../../scripts/lib.sh"
 
-cloud_hypervisor_repo="${cloud_hypervisor_repo:-}"
 cloud_hypervisor_version="${cloud_hypervisor_version:-}"
-
-if [ -z "$cloud_hypervisor_repo" ]; then
-	info "Get cloud_hypervisor information from runtime versions.yaml"
-	cloud_hypervisor_url=$(get_from_kata_deps "assets.hypervisor.cloud_hypervisor.url" "${kata_version}")
-	[ -n "$cloud_hypervisor_url" ] || die "failed to get cloud_hypervisor url"
-	cloud_hypervisor_repo="${cloud_hypervisor_url}.git"
-fi
-[ -n "$cloud_hypervisor_repo" ] || die "failed to get cloud_hypervisor repo"
 
 [ -n "$cloud_hypervisor_version" ] || cloud_hypervisor_version=$(get_from_kata_deps "assets.hypervisor.cloud_hypervisor.version" "${kata_version}")
 [ -n "$cloud_hypervisor_version" ] || die "failed to get cloud_hypervisor version"
 
-info "Build ${cloud_hypervisor_repo} version: ${cloud_hypervisor_version}"
+info "Download cloud-hypervisor version: ${cloud_hypervisor_version}"
+cloud_hypervisor_binary="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${cloud_hypervisor_version}/cloud-hypervisor-static"
 
-repo_dir=$(basename "${cloud_hypervisor_repo}")
-repo_dir="${repo_dir//.git}"
-
-[ -d "${repo_dir}" ] || git clone "${cloud_hypervisor_repo}"
-cd "${repo_dir}"
-git fetch || true
-git checkout "${cloud_hypervisor_version}"
-"${script_dir}/docker-build/build.sh"
-rm -f cloud-hypervisor
-cp ./target/release/cloud-hypervisor .
+curl --fail -L ${cloud_hypervisor_binary} -o cloud-hypervisor


### PR DESCRIPTION
We should just download the official static build binary instead of
trying to build on our own.

Fixes: #760

Ref:
* failure: https://github.com/kata-containers/kata-containers/actions/runs/260953909
* success: https://github.com/bergwolf/kata-containers/runs/1134462133?check_suite_focus=true