### PR TITLE
versions: update clh to v0.10.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v0.9.0"
+      version: "v0.10.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
`kata-deploy` test failed on `v0.9.0` and succeeded on `v0.10.0`.

See
https://github.com/kata-containers/kata-containers/runs/1139077520?check_suite_focus=true
and
https://github.com/bergwolf/kata-containers/runs/1139304442?check_suite_focus=true

Fixes: #765