### PR TITLE
Fix developer guide

### DIFF
--- a/docs/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
+++ b/docs/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
@@ -29,7 +29,7 @@ to launch Kata Containers. For the previous version of Kata Containers, the Pods
 
 > **Note:** For information about the supported versions of these components,
 > see the  Kata Containers
-> [`versions.yaml`](https://github.com/kata-containers/runtime/blob/master/versions.yaml)
+> [`versions.yaml`](../../versions.yaml)
 > file.
 
 ## Install and configure containerd


### PR DESCRIPTION
1. Until we restore docker/moby support, we should use crictl as
    developer example.
2. Most of the hyperlinks should point to kata-containers repository.
3. There is no more standalone mode.