### PR TITLE
fix guest panic when running agent as init

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.rej
 **/target
 **/.vscode
+src/agent/src/version.rs


### PR DESCRIPTION
We should mount procfs before trying to parse kernel command lines.

Fixes: #771
