### PR TITLE
docs: Fix the kata-pkgsync tool's docs script path

### DIFF
--- a/tools/packaging/cmd/kata-pkgsync/README.md
+++ b/tools/packaging/cmd/kata-pkgsync/README.md
@@ -42,12 +42,12 @@ of packages, to avoid re-downloading files if already done.
 
 Install with:
 ```
-$ go get github.com/kata-containers/packaging/cmd/kata-pkgsync`
+$ go get github.com/kata-containers/kata-containers`
 ```
 
 Create your configuration:
 ```
-$ cd $GOPATH/src/github.com/kata-containers/packaging/cmd/kata-pkgsync
+$ cd $GOPATH/src/github.com/kata-containers/kata-containers/tools/packaging/cmd/kata-pkgsync
 $ cp config-example.yaml config.yaml
 ```
 


### PR DESCRIPTION
Fix the kata-pkgsync tool's docs, change the download path of the
packaging tool in 2.0 release.

Fixes: #773

Signed-off-by: Ychau Wang <wangyongchao.bj@inspur.com>