### PR TITLE
agent: update cgroups crate

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -100,7 +100,7 @@ checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 [[package]]
 name = "cgroups"
 version = "0.1.1-alpha.0"
-source = "git+https://github.com/kata-containers/cgroups-rs?tag=0.1.1#3852d7c1805499cd6a0e37ec400d81a7085d91a7"
+source = "git+https://github.com/kata-containers/cgroups-rs?branch=stable-0.1.1#8717524f2c95aacd30768b6f0f7d7f2fddef5cac"
 dependencies = [
  "libc",
  "log",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -32,7 +32,7 @@ tempfile = "3.1.0"
 prometheus = { version = "0.9.0", features = ["process"] }
 procfs = "0.7.9"
 anyhow = "1.0.32"
-cgroups = { git = "https://github.com/kata-containers/cgroups-rs", tag = "0.1.1"}
+cgroups = { git = "https://github.com/kata-containers/cgroups-rs", branch = "stable-0.1.1"}
 
 [workspace]
 members = [

--- a/src/agent/rustjail/Cargo.toml
+++ b/src/agent/rustjail/Cargo.toml
@@ -24,5 +24,5 @@ regex = "1.1"
 path-absolutize = "1.2.0"
 dirs = "3.0.1"
 anyhow = "1.0.32"
-cgroups = { git = "https://github.com/kata-containers/cgroups-rs", tag = "0.1.1"}
+cgroups = { git = "https://github.com/kata-containers/cgroups-rs", branch = "stable-0.1.1"}
 tempfile = "3.1.0"


### PR DESCRIPTION
Update cgroups crate to fix the building issue
on Aarch64.

Fixes: #770

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>