### PR TITLE
ci: use Travis cache to reduce build time

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,22 @@
 
 dist: bionic
 os: linux
-language: go
-go: 1.14.4
+
+# set cache directories manually, because
+# we are using a non-standard directory struct
+# cargo root is in srs/agent
+#
+# If needed, caches can be cleared
+# by ways documented in
+# https://docs.travis-ci.com/user/caching#clearing-caches
+language: rust
+rust:
+  - 1.44.1
+cache:
+  cargo: true
+  directories:
+    - src/agent/target
+
 env:
   - target_branch=$TRAVIS_BRANCH
   - RUST_BACKTRACE=1
@@ -19,16 +33,17 @@ before_install:
 # we use install to run check agent
 # so that it is easy to skip for non-amd64 platform
 install:
-  - "ci/install_rust.sh"
   - export PATH=$PATH:"$HOME/.cargo/bin"
   - export RUST_AGENT=yes
+  - rustup target add x86_64-unknown-linux-musl
+  - sudo ln -sf /usr/bin/g++ /bin/musl-g++
+  - rustup component add rustfmt
   - make -C ${TRAVIS_BUILD_DIR}/src/agent
   - make -C ${TRAVIS_BUILD_DIR}/src/agent check
   - sudo -E PATH=$PATH make -C ${TRAVIS_BUILD_DIR}/src/agent check
 
 before_script:
   - "ci/install_go.sh"
-  - "ci/install_vc.sh"
   - make -C ${TRAVIS_BUILD_DIR}/src/runtime
   - make -C ${TRAVIS_BUILD_DIR}/src/runtime test
   - sudo -E PATH=$PATH GOPATH=$GOPATH make -C ${TRAVIS_BUILD_DIR}/src/runtime test

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,13 +21,11 @@ cache:
   directories:
     - src/agent/target
 
-env:
-  - target_branch=$TRAVIS_BRANCH
-  - RUST_BACKTRACE=1
-
 before_install:
   - git remote set-branches --add origin "${TRAVIS_BRANCH}"
   - git fetch
+  - export RUST_BACKTRACE=1
+  - export target_branch=$TRAVIS_BRANCH
   - "ci/setup.sh"
 
 # we use install to run check agent


### PR DESCRIPTION
This PR includes these changes:
- use Rust installed by Travis
- install x86_64-unknown-linux-musl
- install rustfmt
- use Travis cache
- delete ci/install_vc.sh

Signed-off-by: bin liu <bin@hyper.sh>