### PR TITLE
runtime: Fix linter errors in release files

### DIFF
--- a/src/runtime/cli/release.go
+++ b/src/runtime/cli/release.go
@@ -128,7 +128,7 @@ func makeRelease(release map[string]interface{}) (version string, details releas
 	key := "tag_name"
 
 	version, ok := release[key].(string)
-	if ok != true {
+	if !ok {
 		return "", details, fmt.Errorf("failed to find key %s in release data", key)
 	}
 
@@ -144,7 +144,7 @@ func makeRelease(release map[string]interface{}) (version string, details releas
 	key = "assets"
 
 	assetsArray, ok := release[key].([]interface{})
-	if ok != true {
+	if !ok {
 		return "", details, fmt.Errorf("failed to find key %s in release version %q data", key, version)
 	}
 
@@ -163,7 +163,7 @@ func makeRelease(release map[string]interface{}) (version string, details releas
 	key = "browser_download_url"
 
 	downloadURL, ok = assets.(map[string]interface{})[key].(string)
-	if ok != true {
+	if !ok {
 		return "", details, fmt.Errorf("failed to find key %s in release version %q asset data", key, version)
 	}
 
@@ -174,7 +174,7 @@ func makeRelease(release map[string]interface{}) (version string, details releas
 	key = "name"
 
 	filename, ok = assets.(map[string]interface{})[key].(string)
-	if ok != true {
+	if !ok {
 		return "", details, fmt.Errorf("failed to find key %s in release version %q asset data", key, version)
 	}
 
@@ -185,7 +185,7 @@ func makeRelease(release map[string]interface{}) (version string, details releas
 	key = "created_at"
 
 	createDate, ok = assets.(map[string]interface{})[key].(string)
-	if ok != true {
+	if !ok {
 		return "", details, fmt.Errorf("failed to find key %s in release version %q asset data", key, version)
 	}
 
@@ -400,10 +400,6 @@ func HandleReleaseVersions(cmd ReleaseCmd, currentVersion string, includeAll boo
 	details, ok := releases[newest.String()]
 	if !ok {
 		return fmt.Errorf("Release %v has no details", newest)
-	}
-
-	if err != nil {
-		return err
 	}
 
 	return showLatestRelease(output, currentSemver, details)

--- a/src/runtime/cli/release_test.go
+++ b/src/runtime/cli/release_test.go
@@ -397,11 +397,11 @@ func TestFindNewestRelease(t *testing.T) {
 	assert := assert.New(t)
 
 	type testData struct {
-		currentVer      semver.Version
 		versions        []semver.Version
-		expectAvailable bool
+		currentVer      semver.Version
 		expectVersion   semver.Version
 		expectError     bool
+		expectAvailable bool
 	}
 
 	ver1, err := semver.Make("1.11.1")
@@ -414,15 +414,15 @@ func TestFindNewestRelease(t *testing.T) {
 	assert.NoError(err)
 
 	data := []testData{
-		{semver.Version{}, []semver.Version{}, false, semver.Version{}, true},
-		{ver1, []semver.Version{}, false, semver.Version{}, true},
-		{ver1, []semver.Version{ver1}, false, semver.Version{}, false},
-		{ver2, []semver.Version{ver1}, false, semver.Version{}, false},
-		{ver1, []semver.Version{ver2}, true, ver2, false},
-		{ver1, []semver.Version{ver3}, true, ver3, false},
-		{ver1, []semver.Version{ver2, ver3}, true, ver3, false},
-		{ver2, []semver.Version{ver1, ver3}, true, ver3, false},
-		{ver2, []semver.Version{ver1}, false, semver.Version{}, false},
+		{[]semver.Version{}, semver.Version{}, semver.Version{}, true, false},
+		{[]semver.Version{}, ver1, semver.Version{}, true, false},
+		{[]semver.Version{ver1}, ver1, semver.Version{}, false, false},
+		{[]semver.Version{ver1}, ver2, semver.Version{}, false, false},
+		{[]semver.Version{ver2}, ver1, ver2, false, true},
+		{[]semver.Version{ver3}, ver1, ver3, false, true},
+		{[]semver.Version{ver2, ver3}, ver1, ver3, false, true},
+		{[]semver.Version{ver1, ver3}, ver2, ver3, false, true},
+		{[]semver.Version{ver1}, ver2, semver.Version{}, false, false},
 	}
 
 	for i, d := range data {


### PR DESCRIPTION
Fix the linter errors caught in the `runtime` repos `master` branch [1], but not in the `2.0-dev` branch [2]. See [3] for further details.

[1] - https://github.com/kata-containers/runtime/pull/2976
[2] - https://github.com/kata-containers/kata-containers/pull/735
[3] - https://github.com/kata-containers/tests/issues/2870

Fixes: #783.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>