### PR TITLE
agent/oci: Don't use deprecated Error::description() method

### DIFF
--- a/src/agent/oci/src/serialize.rs
+++ b/src/agent/oci/src/serialize.rs
@@ -29,13 +29,6 @@ impl Display for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        match *self {
-            Error::Io(ref e) => e.description(),
-            Error::Json(ref e) => e.description(),
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             Error::Io(ref e) => Some(e),


### PR DESCRIPTION
We shouldn't use it, and we don't need to implement it.

fixes #791

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>