### PR TITLE
rust-agent: Replaces improper use of match for non-constant patterns

### DIFF
--- a/src/agent/rustjail/src/cgroups/notifier.rs
+++ b/src/agent/rustjail/src/cgroups/notifier.rs
@@ -103,19 +103,16 @@ fn register_memory_event_v2(
                 }
                 info!(sl!(), "event.wd: {:?}", event.wd);
 
-                match event.wd {
-                    ev_fd => {
-                        let oom = get_value_from_cgroup(&event_control_path, "oom_kill");
-                        if oom.unwrap_or(0) > 0 {
-                            sender.send(containere_id.clone()).unwrap();
-                            return;
-                        }
+                if event.wd == ev_fd {
+                    let oom = get_value_from_cgroup(&event_control_path, "oom_kill");
+                    if oom.unwrap_or(0) > 0 {
+                        sender.send(containere_id.clone()).unwrap();
+                        return;
                     }
-                    cg_fd => {
-                        let pids = get_value_from_cgroup(&cgroup_event_control_path, "populated");
-                        if pids.unwrap_or(-1) == 0 {
-                            return;
-                        }
+                } else if event.wd == cg_fd {
+                    let pids = get_value_from_cgroup(&cgroup_event_control_path, "populated");
+                    if pids.unwrap_or(-1) == 0 {
+                        return;
                     }
                 }
             }


### PR DESCRIPTION
The code used `match` as a switch with variable patterns `ev_fd` and
`cf_fd`, but the way Rust interprets the code is that the first
pattern matches all values. The code does not perform as expected.

This addresses the following warning:

   warning: unreachable pattern
      --> rustjail/src/cgroups/notifier.rs:114:21
       |
   107 |                     ev_fd => {
       |                     ----- matches any value
   ...
   114 |                     cg_fd => {
       |                     ^^^^^ unreachable pattern
       |
       = note: `#[warn(unreachable_patterns)]` on by default

Fixes: #750
Fixes: #793

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>