### PR TITLE
ci: resurrect travis static checkers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,7 @@ jobs:
   - name: ppc64le test
     os: linux-ppc64le
     install: skip
+    script: skip
   allow_failures:
     - name: ppc64le test
   fast_finish: true

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,4 @@
-# Copyright 2019 Intel Corporation.
+# Copyright (c) 2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -10,4 +10,3 @@
 # used. See https://help.github.com/articles/about-code-owners/
 
 *.md    @kata-containers/documentation
-

--- a/ci/go-no-os-exit.sh
+++ b/ci/go-no-os-exit.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Check there are no os.Exit() calls creeping into the code
+# We don't use that exit path in the Kata codebase.
+
+# Allow the path to check to be over-ridden.
+# Default to the current directory.
+go_packages=${1:-.}
+
+echo "Checking for no os.Exit() calls for package [${go_packages}]"
+
+candidates=`go list -f '{{.Dir}}/*.go' $go_packages`
+for f in $candidates; do
+	filename=`basename $f`
+	# skip all go test files
+	[[ $filename == *_test.go ]] && continue
+	# skip exit.go where, the only file we should call os.Exit() from.
+	[[ $filename == "exit.go" ]] && continue
+	files="$f $files"
+done
+
+[ -z "$files" ] && echo "No files to check, skipping" && exit 0
+
+if egrep -n '\<os\.Exit\>' $files; then
+	echo "Direct calls to os.Exit() are forbidden, please use exit() so atexit() works"
+	exit 1
+fi

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -5,6 +5,7 @@
 
 export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 export tests_repo_dir="$GOPATH/src/$tests_repo"
+export branch="2.0-dev"
 
 clone_tests_repo()
 {
@@ -17,14 +18,15 @@ clone_tests_repo()
 
 	go get -d -u "$tests_repo" || true
 
-	if [ -n "${TRAVIS_BRANCH:-}" ]; then
-		( cd "${tests_repo_dir}" && git checkout "${TRAVIS_BRANCH}" )
-	fi
+	pushd "${tests_repo_dir}" && git checkout "${branch}" && popd
 }
 
 run_static_checks()
 {
 	clone_tests_repo
+	# Make sure we have the targeting branch
+	git remote set-branches --add origin "${branch}"
+	git fetch -a
 	bash "$tests_repo_dir/.ci/static-checks.sh" "github.com/kata-containers/kata-containers"
 }
 

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-## Kata Containers Documentation Code of Conduct
-
-Kata Containers follows the [OpenStack Foundation Code of Conduct](https://www.openstack.org/legal/community-code-of-conduct/).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,5 +1,0 @@
-# Contributing
-
-## This repo is part of [Kata Containers](https://katacontainers.io)
-
-For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md).

--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -39,15 +39,13 @@
           * [Enable agent debug console](#enable-agent-debug-console)
           * [Start `kata-monitor`](#start-kata-monitor)
           * [Connect to debug console](#connect-to-debug-console)
-      * [Traditional debug console setup](#traditional-simple-debug-console-setup)
+      * [Traditional debug console setup](#traditional-debug-console-setup)
           * [Create a custom image containing a shell](#create-a-custom-image-containing-a-shell)
           * [Create a debug systemd service](#create-a-debug-systemd-service)
           * [Build the debug image](#build-the-debug-image)
           * [Configure runtime for custom debug image](#configure-runtime-for-custom-debug-image)
-          * [Ensure debug options are valid](#ensure-debug-options-are-valid)
           * [Create a container](#create-a-container)
           * [Connect to the virtual machine using the debug console](#connect-to-the-virtual-machine-using-the-debug-console)
-    * [Obtain details of the image](#obtain-details-of-the-image)
     * [Capturing kernel boot logs](#capturing-kernel-boot-logs)
 
 # Warning
@@ -450,7 +448,7 @@ contain either `/bin/sh` or `/bin/bash`.
 
 #### Enable agent debug console
 
-Enable debug_console_enabled in the configuration.toml configuration file:
+Enable debug_console_enabled in the `configuration.toml` configuration file:
 
 ```
 [agent.kata]
@@ -461,7 +459,7 @@ This will pass `agent.debug_console agent.debug_console_vport=1026` to agent as 
 
 #### Start `kata-monitor`
 
-The `kata-runtime exec` command needs `kata-monitor` to get the sandbox's `vsock` address to connect to, firt start `kata-monitor`.
+The `kata-runtime exec` command needs `kata-monitor` to get the sandbox's `vsock` address to connect to, first start `kata-monitor`.
 
 ```
 $ sudo kata-monitor
@@ -503,7 +501,7 @@ the following steps (using rootfs or initrd image).
 >
 > Look for `INIT_PROCESS=systemd` in the `config.sh` osbuilder rootfs config file
 > to verify an osbuilder distro supports systemd for the distro you want to build rootfs for.
-> For an example, see the [Clear Linux config.sh file](../tools/osbuilder/blob/master/rootfs-builder/clearlinux/config.sh).
+> For an example, see the [Clear Linux config.sh file](../tools/osbuilder/rootfs-builder/clearlinux/config.sh).
 >
 > For a non-systemd-based distro, create an equivalent system
 > service using that distro’s init system syntax. Alternatively, you can build a distro
@@ -589,7 +587,7 @@ to avoid all subsequently created containers from using the debug image.
 
 #### Create a container
 
-Create a container as normal. For example using crictl:
+Create a container as normal. For example using `crictl`:
 
 ```
 $ sudo crictl run -r kata container.yaml pod.yaml

--- a/docs/README.md
+++ b/docs/README.md
@@ -54,7 +54,7 @@ Documents that help to understand and contribute to Kata Containers.
 
 * [Developer Guide](Developer-Guide.md): Setup the Kata Containers developing environments
 * [How to contribute to Kata Containers](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md)
-* [Code of Conduct](CODE_OF_CONDUCT.md)
+* [Code of Conduct](../CODE_OF_CONDUCT.md)
 
 ### Code Licensing
 

--- a/snap/README.md
+++ b/snap/README.md
@@ -84,12 +84,12 @@ then a new configuration file can be [created](#configure-kata-containers)
 and [configured][7].
 
 [1]: https://docs.snapcraft.io/snaps/intro
-[2]: ../../../docs/design/architecture.md#root-filesystem-image
+[2]: ../docs/design/architecture.md#root-filesystem-image
 [3]: https://docs.snapcraft.io/reference/confinement#classic
 [4]: https://github.com/kata-containers/runtime#configuration
 [5]: https://docs.docker.com/engine/reference/commandline/dockerd
-[6]: ../../../docs/install/docker/ubuntu-docker-install.md
-[7]: ../../../docs/Developer-Guide.md#configure-to-use-initrd-or-rootfs-image
+[6]: ../docs/install/docker/ubuntu-docker-install.md
+[7]: ../docs/Developer-Guide.md#configure-to-use-initrd-or-rootfs-image
 [8]: https://snapcraft.io/kata-containers
-[9]: ../../../docs/Developer-Guide.md#run-kata-containers-with-docker
-[10]: ../../../docs/Developer-Guide.md#run-kata-containers-with-kubernetes
+[9]: ../docs/Developer-Guide.md#run-kata-containers-with-docker
+[10]: ../docs/Developer-Guide.md#run-kata-containers-with-kubernetes

--- a/src/agent/protocols/src/lib.rs
+++ b/src/agent/protocols/src/lib.rs
@@ -6,11 +6,11 @@
 
 pub mod agent;
 pub mod agent_ttrpc;
+pub mod empty;
 pub mod health;
 pub mod health_ttrpc;
 pub mod oci;
 pub mod types;
-pub mod empty;
 
 #[cfg(test)]
 mod tests {

--- a/src/runtime/CONTRIBUTING.md
+++ b/src/runtime/CONTRIBUTING.md
@@ -1,5 +1,0 @@
-# Contributing
-
-## This repo is part of [Kata Containers](https://katacontainers.io)
-
-For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md).

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -582,7 +582,6 @@ $(MONITOR_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
 .PHONY: \
 	check \
 	check-go-static \
-	check-go-test \
 	coverage \
 	default \
 	install \
@@ -688,9 +687,9 @@ go-test: $(GENERATED_FILES)
 	go test -v -mod=vendor ./...
 
 check-go-static:
-	$(QUIET_CHECK).ci/static-checks.sh
-	$(QUIET_CHECK).ci/go-no-os-exit.sh ./cli
-	$(QUIET_CHECK).ci/go-no-os-exit.sh ./virtcontainers
+	$(QUIET_CHECK)../../ci/static-checks.sh
+	$(QUIET_CHECK)../../ci/go-no-os-exit.sh ./cli
+	$(QUIET_CHECK)../../ci/go-no-os-exit.sh ./virtcontainers
 
 coverage:
 	go test -v -mod=vendor -covermode=atomic -coverprofile=coverage.txt ./...

--- a/src/runtime/cli/console_test.go
+++ b/src/runtime/cli/console_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"testing"
 
+	ktu "github.com/kata-containers/kata-containers/src/runtime/pkg/katatestutils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -22,6 +23,9 @@ func TestConsoleFromFile(t *testing.T) {
 }
 
 func TestNewConsole(t *testing.T) {
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(testDisabledAsNonRoot)
+	}
 	assert := assert.New(t)
 
 	console, err := newConsole()
@@ -34,6 +38,9 @@ func TestNewConsole(t *testing.T) {
 }
 
 func TestIsTerminal(t *testing.T) {
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(testDisabledAsNonRoot)
+	}
 	assert := assert.New(t)
 
 	var fd uintptr = 4

--- a/src/runtime/containerd-shim-v2/shim_metrics_test.go
+++ b/src/runtime/containerd-shim-v2/shim_metrics_test.go
@@ -68,10 +68,10 @@ func TestStatsSandbox(t *testing.T) {
 		StatsFunc:          getSandboxCPUFunc(1000, 100000),
 		StatsContainerFunc: getStatsContainerCPUFunc(100, 200, 10000, 20000),
 		MockContainers: []*vcmock.Container{
-			&vcmock.Container{
+			{
 				MockID: "foo",
 			},
-			&vcmock.Container{
+			{
 				MockID: "bar",
 			},
 		},

--- a/src/runtime/virtcontainers/device/manager/utils_test.go
+++ b/src/runtime/virtcontainers/device/manager/utils_test.go
@@ -75,7 +75,7 @@ func TestIsVhostUserBlk(t *testing.T) {
 		isVhostUserBlk := isVhostUserBlk(
 			config.DeviceInfo{
 				DevType: d.devType,
-				Major: d.major,
+				Major:   d.major,
 			})
 		assert.Equal(t, d.expected, isVhostUserBlk)
 	}
@@ -100,7 +100,7 @@ func TestIsVhostUserSCSI(t *testing.T) {
 		isVhostUserSCSI := isVhostUserSCSI(
 			config.DeviceInfo{
 				DevType: d.devType,
-				Major: d.major,
+				Major:   d.major,
 			})
 		assert.Equal(t, d.expected, isVhostUserSCSI)
 	}

--- a/src/runtime/virtcontainers/documentation/Developers.md
+++ b/src/runtime/virtcontainers/documentation/Developers.md
@@ -51,5 +51,5 @@ This will:
 # Submitting changes
 
 For details on the format and how to submit changes, refer to the
-[Contributing](../../CONTRIBUTING.md) document.
+[Contributing](../../../../CONTRIBUTING.md) document.
 

--- a/src/runtime/virtcontainers/pkg/agent/protocols/client/client.go
+++ b/src/runtime/virtcontainers/pkg/agent/protocols/client/client.go
@@ -1,4 +1,4 @@
-// Copyright 2017 HyperHQ Inc.
+// Copyright (c) 2017 HyperHQ Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -136,18 +136,18 @@ type qemuArch interface {
 }
 
 type qemuArchBase struct {
-	qemuMachine           govmmQemu.Machine
-	qemuExePath           string
-	memoryOffset          uint32
-	nestedRun             bool
-	vhost                 bool
-	disableNvdimm         bool
-	dax                   bool
-	networkIndex          int
-	kernelParamsNonDebug  []Param
-	kernelParamsDebug     []Param
-	kernelParams          []Param
-	Bridges               []types.Bridge
+	qemuMachine          govmmQemu.Machine
+	qemuExePath          string
+	memoryOffset         uint32
+	nestedRun            bool
+	vhost                bool
+	disableNvdimm        bool
+	dax                  bool
+	networkIndex         int
+	kernelParamsNonDebug []Param
+	kernelParamsDebug    []Param
+	kernelParams         []Param
+	Bridges              []types.Bridge
 }
 
 const (

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -36,7 +36,7 @@ var kernelParams = []Param{
 	{"net.ifnames", "0"},
 }
 
-var supportedQemuMachine = govmmQemu.Machine {
+var supportedQemuMachine = govmmQemu.Machine{
 	Type:    QemuPseries,
 	Options: defaultQemuMachineOptions,
 }
@@ -63,12 +63,12 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 
 	q := &qemuPPC64le{
 		qemuArchBase{
-			qemuMachine:           supportedQemuMachine,
-			qemuExePath:           defaultQemuPath,
-			memoryOffset:          config.MemOffset,
-			kernelParamsNonDebug:  kernelParamsNonDebug,
-			kernelParamsDebug:     kernelParamsDebug,
-			kernelParams:          kernelParams,
+			qemuMachine:          supportedQemuMachine,
+			qemuExePath:          defaultQemuPath,
+			memoryOffset:         config.MemOffset,
+			kernelParamsNonDebug: kernelParamsNonDebug,
+			kernelParamsDebug:    kernelParamsDebug,
+			kernelParams:         kernelParams,
 		},
 	}
 

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -36,7 +36,7 @@ var kernelParams = []Param{
 
 var ccwbridge = types.NewBridge(types.CCW, "", make(map[uint32]string, types.CCWBridgeMaxCapacity), 0)
 
-var supportedQemuMachine = govmmQemu.Machine {
+var supportedQemuMachine = govmmQemu.Machine{
 	Type:    QemuCCWVirtio,
 	Options: defaultQemuMachineOptions,
 }
@@ -61,12 +61,12 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 
 	q := &qemuS390x{
 		qemuArchBase{
-			qemuMachine:           supportedQemuMachine,
-			qemuExePath:           defaultQemuPath,
-			memoryOffset:          config.MemOffset,
-			kernelParamsNonDebug:  kernelParamsNonDebug,
-			kernelParamsDebug:     kernelParamsDebug,
-			kernelParams:          kernelParams,
+			qemuMachine:          supportedQemuMachine,
+			qemuExePath:          defaultQemuPath,
+			memoryOffset:         config.MemOffset,
+			kernelParamsNonDebug: kernelParamsNonDebug,
+			kernelParamsDebug:    kernelParamsDebug,
+			kernelParams:         kernelParams,
 		},
 	}
 	// Set first bridge type to CCW

--- a/tools/packaging/CODE_OF_CONDUCT.md
+++ b/tools/packaging/CODE_OF_CONDUCT.md
@@ -1,3 +1,0 @@
-## Kata Containers CI Code of Conduct
-
-Kata Containers follows the [OpenStack Foundation Code of Conduct](https://www.openstack.org/legal/community-code-of-conduct/).

--- a/tools/packaging/CONTRIBUTING.md
+++ b/tools/packaging/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md).

--- a/tools/packaging/README.md
+++ b/tools/packaging/README.md
@@ -31,7 +31,7 @@ running Kubernetes Cluster very straightforward.
 
 ## Build a snap package
 
-See [the snap documentation](snap).
+See [the snap documentation](../../snap).
 
 ## Build static binaries
 
@@ -60,6 +60,10 @@ See [the Jenkins documentation](Jenkinsfiles).
 ## Packaging scripts
 
 See the [scripts documentation](scripts).
+
+## Sync packages
+
+See [the `kata-pkgsync` documentation](cmd/kata-pkgsync).
 
 ## Credits
 


### PR DESCRIPTION
Somehow travis was not running static checkers and it silently reports success. It resulted in a lot of static check failures. Let's resurrect it and fix the static check errors.