### PR TITLE
agent: fix UT failures due to chdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 **/target
 **/.vscode
 src/agent/src/version.rs
+src/agent/kata-agent.service

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -120,6 +120,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cloudabi"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +315,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3286f09f7d4926fc486334f28d8d2e6ebe4f7f9994494b6dab27ddfad2c9b11b"
 
 [[package]]
+name = "lock_api"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,6 +435,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "parking_lot"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
+dependencies = [
+ "cfg-if",
+ "cloudabi",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "winapi",
+]
+
+[[package]]
 name = "path-absolutize"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -448,7 +490,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.17.0",
+ "nix 0.18.0",
 ]
 
 [[package]]
@@ -659,6 +701,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "serial_test",
  "slog",
  "slog-scope",
  "tempfile",
@@ -711,6 +754,28 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b15f74add9a9d4a3eb2bf739c9a427d266d3895b53d992c3a7c234fec2ff1f1"
+dependencies = [
+ "lazy_static",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65f59259be9fc1bf677d06cc1456e97756004a1a5a577480f71430bd7c17ba33"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -779,6 +844,12 @@ dependencies = [
  "lazy_static",
  "slog",
 ]
+
+[[package]]
+name = "smallvec"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbee7696b84bbf3d89a1c2eccff0850e3047ed46bfcd2e92c29a2d074d57e252"
 
 [[package]]
 name = "spin"

--- a/src/agent/rustjail/Cargo.toml
+++ b/src/agent/rustjail/Cargo.toml
@@ -26,3 +26,6 @@ dirs = "3.0.1"
 anyhow = "1.0.32"
 cgroups = { git = "https://github.com/kata-containers/cgroups-rs", branch = "stable-0.1.1"}
 tempfile = "3.1.0"
+
+[dev-dependencies]
+serial_test = "0.5.0"

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -13,6 +13,9 @@
 #![allow(non_upper_case_globals)]
 // #![allow(unused_comparisons)]
 #[macro_use]
+#[cfg(test)]
+extern crate serial_test;
+#[macro_use]
 extern crate serde;
 extern crate serde_json;
 #[macro_use]

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -968,6 +968,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[test]
+    #[serial(chdir)]
     fn test_init_rootfs() {
         let stdout_fd = std::io::stdout().as_raw_fd();
         let mut spec = oci::Spec::default();
@@ -1052,6 +1053,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(chdir)]
     fn test_mount_cgroups() {
         let stdout_fd = std::io::stdout().as_raw_fd();
         let mount = oci::Mount {
@@ -1093,12 +1095,14 @@ mod tests {
     }
 
     #[test]
+    #[serial(chdir)]
     fn test_pivot_root() {
         let ret = pivot_rootfs("/tmp");
         assert!(ret.is_ok(), "Should pass. Got: {:?}", ret);
     }
 
     #[test]
+    #[serial(chdir)]
     fn test_ms_move_rootfs() {
         let ret = ms_move_root("/abc");
         assert!(
@@ -1132,6 +1136,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(chdir)]
     fn test_finish_rootfs() {
         let stdout_fd = std::io::stdout().as_raw_fd();
         let mut spec = oci::Spec::default();
@@ -1167,6 +1172,7 @@ mod tests {
     }
 
     #[test]
+    #[serial(chdir)]
     fn test_mknod_dev() {
         skip_if_not_root!();
 


### PR DESCRIPTION
    Current working directory is a process level resource. We cannot call
    chdir in parallel from multiple threads, which would cause cwd confusion
    and result in UT failures.

    The agent code itself is correct that chdir is only called from spawned
    child init process. Well, there is one exception that it is also called
    in do_create_container() but it is safe to assume that containers are
    never created in parallel (at least for now).

    Fixes: #782