### PR TITLE
Packaging: release notes script using error kernel path urls

### DIFF
--- a/tools/packaging/release/runtime-release-notes.sh
+++ b/tools/packaging/release/runtime-release-notes.sh
@@ -136,8 +136,8 @@ Follow the Kata [installation instructions][installation].
 More information [Limitations][limitations]
 
 [kernel]: ${kernel_url}/linux-${kernel_version#v}.tar.xz
-[kernel-patches]: https://github.com/kata-containers/packaging/tree/${kata_kernel_config_version}/kernel/patches
-[kernel-config]: https://github.com/kata-containers/packaging/tree/${kata_kernel_config_version}/kernel/configs
+[kernel-patches]: https://github.com/kata-containers/kata-containers/tree/${new_release}/tools/packaging/kernel/patches
+[kernel-config]: https://github.com/kata-containers/kata-containers/tree/${new_release}/tools/packaging/kernel/configs
 [ocispec]: https://github.com/opencontainers/runtime-spec/releases/tag/${oci_spec_version}
 [limitations]: https://github.com/kata-containers/kata-containers/blob/${new_release}/docs/Limitations.md
 [installation]: https://github.com/kata-containers/kata-containers/blob/${new_release}/docs/install


### PR DESCRIPTION
2.0 Packaging runtime-release-notes.sh script is using 1.x Packaging
kernel urls. Fixed these urls to 2.0 branch Packaging urls.

Fixes: #829

Signed-off-by: Ychau Wang <wangyongchao.bj@inspur.com>