### PR TITLE
rust-agent: Update README

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -1,10 +1,10 @@
 # Kata Agent in Rust
 
-This is a rust version of the [`kata-agent`](https://github.com/kata-containers/kata-agent).
+This is a rust version of the [`kata-agent`](https://github.com/kata-containers/agent).
 
 In Denver PTG, [we discussed about re-writing agent in rust](https://etherpad.openstack.org/p/katacontainers-2019-ptg-denver-agenda):
 
-> In general, we all think about re-write agent in rust to reduce the footprint of agent. Moreover, Eric mentioned the possibility to stop using gRPC, which may have some impact on footprint. We may begin to do some PoC to show how much we could save by re-writing agent in rust.
+> In general, we all think about re-write agent in rust to reduce the footprint of agent. Moreover, Eric mentioned the possibility to stop using gRPC, which may have some impact on footprint. We may begin to do some POC to show how much we could save by re-writing agent in rust.
 
 After that, we drafted the initial code here, and any contributions are welcome.
 
@@ -18,7 +18,7 @@ After that, we drafted the initial code here, and any contributions are welcome.
 | exec/list process       | :white_check_mark: |
 | I/O stream              | :white_check_mark: |
 | Cgroups                 | :white_check_mark: |
-| Capabilities, rlimit, readonly path, masked path, users | :white_check_mark: |
+| Capabilities, `rlimit`, readonly path, masked path, users | :white_check_mark: |
 | container stats (`stats_container`)                     | :white_check_mark: |
 | Hooks                   | :white_check_mark: |
 | **Agent Features & APIs** |
@@ -28,7 +28,7 @@ After that, we drafted the initial code here, and any contributions are welcome.
 | network, interface/routes (`update_container`)   | :white_check_mark: |
 | File transfer API (`copy_file`)                  | :white_check_mark: |
 | Device APIs (`reseed_random_device`, , `online_cpu_memory`, `mem_hotplug_probe`, `set_guet_data_time`) | :white_check_mark: |
-| vsock support                                    | :white_check_mark: |
+| VSOCK support                                    | :white_check_mark: |
 | virtio-serial support                            | :heavy_multiplication_x: |
 | OCI Spec validator                               | :white_check_mark: |
 | **Infrastructures**|
@@ -39,25 +39,24 @@ After that, we drafted the initial code here, and any contributions are welcome.
 ## Getting Started
 
 ### Build from Source
-The rust-agent need to be built with rust nightly, and static linked with musl.
+The rust-agent need to be built with rust newer than 1.37, and static linked with `musl`.
 ```bash
 rustup target add x86_64-unknown-linux-musl
-git submodule update --init --recursive  
 sudo ln -s /usr/bin/g++ /bin/musl-g++  
 cargo build --target x86_64-unknown-linux-musl --release
 ```
 
 ## Run Kata CI with rust-agent
-   * Firstly, install kata as noted by ["how to install Kata"](../../docs/install/README.md)
-   * Secondly, build your own kata initrd/image following the steps in ["how to build your own initrd/image"](../../docs/Developer-Guide.md#create-and-install-rootfs-and-initrd-image).
+   * Firstly, install Kata as noted by ["how to install Kata"](../../docs/install/README.md)
+   * Secondly, build your own Kata initrd/image following the steps in ["how to build your own initrd/image"](../../docs/Developer-Guide.md#create-and-install-rootfs-and-initrd-image).
 notes: Please use your rust agent instead of the go agent when building your initrd/image.
-   * Clone the kata ci test cases from: https://github.com/kata-containers/tests.git, and then run the cri test with: 
+   * Clone the Kata CI test cases from: https://github.com/kata-containers/tests.git, and then run the CRI test with: 
 
 ```bash
 $sudo -E PATH=$PATH -E GOPATH=$GOPATH integration/containerd/shimv2/shimv2-tests.sh
 ```
 
 ## Mini Benchmark
-The memory of 'RssAnon' consumed by the go-agent and rust-agent as below:
+The memory of `RssAnon` consumed by the go-agent and rust-agent as below:
 go-agent: about 11M
 rust-agent: about 1.1M


### PR DESCRIPTION
rust agent does not use grpc as submodule for a while, update README
to reflect the change.

This rebases #197 on top of latest master.
