### PR TITLE
packaging: fix image build script

### DIFF
--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -13,13 +13,14 @@ set -o pipefail
 
 readonly script_name="$(basename "${BASH_SOURCE[0]}")"
 readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly packaging_root_dir="$(cd "${script_dir}/../" && pwd)"
 readonly repo_root_dir="$(cd "${script_dir}/../../../" && pwd)"
 readonly osbuilder_dir="$(cd "${repo_root_dir}/tools/osbuilder" && pwd)"
 readonly tmp_dir=$(mktemp -d -t build-image-tmp.XXXXXXXXXX)
 export   GOPATH="${tmp_dir}/go"
 
 export GOPATH=${GOPATH:-${HOME}/go}
-source "${repo_root_dir}/scripts/lib.sh"
+source "${packaging_root_dir}/scripts/lib.sh"
 
 exit_handler() {
 	[ -d "${tmp_dir}" ] && sudo rm -rf "$tmp_dir"
@@ -28,7 +29,7 @@ trap exit_handler EXIT
 
 arch_target="$(uname -m)"
 
-source "${repo_root_dir}/versions.txt"
+source "${packaging_root_dir}/versions.txt"
 
 readonly destdir="${PWD}"
 

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -11,6 +11,8 @@ export tests_repo_dir="$GOPATH/src/$tests_repo"
 
 this_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+short_commit_length=10
+
 hub_bin="hub-bin"
 
 clone_tests_repo() {


### PR DESCRIPTION
There were a couple of issues with the build-scripts discovered while
doing release:
 - Relative paths are error prone. Fix error.
 - short_commit_length is used to truncate sha for commits when
 appending agent version to resulting files. Before this was
 in pkglib.sh, which is otherwise an unused file from when we
 supported OBS. Add this define to lib.sh, which is sourced by
 the applicable packaging scripts.

There's plenty of room for improvement, but these fixes make the
existing scripts functional again.

Fixes: #871