### PR TITLE
snap: specify python version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -224,7 +224,7 @@ parts:
     after: [godeps, runtime]
     build-packages:
       - gcc
-      - python
+      - python3
       - zlib1g-dev
       - libcap-ng-dev
       - libglib2.0-dev


### PR DESCRIPTION
In order to avoid `unmet dependencies` error in the CI,
the python version must be specified in the yaml.

fixes #877

Signed-off-by: Julio Montes <julio.montes@intel.com>