### PR TITLE
versions: add plugins section

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -301,3 +301,15 @@ specs:
       https://github.com/opencontainers/runtime-spec/tags
       .*/v?(\d\S+)\.tar\.gz
     version: "v1.0.0-rc5"
+
+plugins:
+  description: |
+    Details of plugins required for the components or testing.
+
+  sriov-network-device:
+    description: |
+      The SR-IOV network device plugin is Kubernetes device plugin for
+      discovering and advertising SR-IOV virtual functions (VFs)
+      available on a Kubernetes host.
+    url: "https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin"
+    version: "b7f6d3e0679796e907ecca88cfab0e32e326850d"


### PR DESCRIPTION
plugins sections contains the details of plugins required for
the components or testing.

Add sriov-network-device-plugin url and version that are consumed
by the VFIO test in the tests repository.

fixes #879

Signed-off-by: Julio Montes <julio.montes@intel.com>