### PR TITLE
agent: fix the agent path url of 2.0 version in the README.md

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -1,6 +1,6 @@
 # Kata Agent in Rust
 
-This is a rust version of the [`kata-agent`](https://github.com/kata-containers/agent).
+This is a rust version of the [`kata-agent`](../agent).
 
 In Denver PTG, [we discussed about re-writing agent in rust](https://etherpad.openstack.org/p/katacontainers-2019-ptg-denver-agenda):
 


### PR DESCRIPTION
The README.md of agent path is using kata 1.x project url in the kata
2.0 version. Fixing the url of the agent project path in kata 2.0, from
1.x go version agent link to the 2.0 rust version agent url.

Fixes: #892

Signed-off-by: Ychau Wang <wangyongchao.bj@inspur.com>