### PR TITLE
agent: update README.md for building from source

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -52,7 +52,10 @@ $ sudo ln -s /usr/bin/g++ /bin/musl-g++
 ```
 Download the kata-containers source and build the agent:
 ```bash
-$ go get -d -u github.com/kata-containers/kata-containers
+$ GOPATH="${GOPATH:-$HOME/go}"
+$ dir="$GOPATH/src/github.com/kata-containers"
+$ mkdir -p "$dir" && cd "$dir"
+$ git clone --depth 1 https://github.com/kata-containers/kata-containers && cd kata-containers
 $ cd $GOPATH/src/github.com/kata-containers/kata-containers/src/agent
 $ make
 ```

--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -43,12 +43,16 @@ The `rust-agent` depends on [`grpc-rs`](https://github.com/pingcap/grpc-rs) by P
 - https://github.com/alipay/grpc-rs/tree/rust_agent
 
 ### Build from Source
-The rust-agent need to be built with rust nightly, and static linked with musl.
+The rust-agent need to be built with static linked with musl:
 ```bash
-rustup target add x86_64-unknown-linux-musl
-git submodule update --init --recursive  
-sudo ln -s /usr/bin/g++ /bin/musl-g++  
-cargo build --target x86_64-unknown-linux-musl --release
+$ rustup target add x86_64-unknown-linux-musl
+$ sudo ln -s /usr/bin/g++ /bin/musl-g++  
+```
+Download the kata-containers source and build the agent:
+```bash
+$ go get -d -u github.com/kata-containers/kata-containers
+$ cd $GOPATH/src/github.com/kata-containers/kata-containers/src/agent
+$ make
 ```
 
 ## Run Kata CI with rust-agent

--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -45,7 +45,9 @@ The `rust-agent` depends on [`grpc-rs`](https://github.com/pingcap/grpc-rs) by P
 ### Build from Source
 The rust-agent need to be built with static linked with musl:
 ```bash
-$ rustup target add x86_64-unknown-linux-musl
+$ arch=$(uname -m)
+$ [ "$arch" == "ppc64le" ] && arch=powerpc64le
+$ rustup target add "${arch}-unknown-linux-musl"
 $ sudo ln -s /usr/bin/g++ /bin/musl-g++  
 ```
 Download the kata-containers source and build the agent:


### PR DESCRIPTION
agent: Update build instructions

Fix the instructions explaining how to build the agent from source now that `make` needs to be run to auto-generate some source files.

Fixes: #889.

Signed-off-by: LiYa'nan <oliverliyn@gmail.com>