### PR TITLE
ci: snap: add event filtering

### DIFF
--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,5 +1,15 @@
 name: snap CI
-on: ["pull_request"]
+on:
+  pull_request:
+    paths:
+      - "**/Makefile"
+      - "**/*.go"
+      - "**/*.mk"
+      - "**/*.rs"
+      - "**/*.sh"
+      - "**/*.toml"
+      - "**/*.yaml"
+      - "**/*.yml"
 jobs:
   test:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Run the snap CI on every PR is not needed. Don't run the snap CI
on PRs that don't change the source (*.go/*.rs) or yaml files.

fixes #896

Signed-off-by: Julio Montes <julio.montes@intel.com>