### PR TITLE
agent: fix errorneous parsing for guest block size

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1407,7 +1407,13 @@ fn get_memory_info(block_size: bool, hotplug: bool) -> Result<(u64, bool)> {
                     return Err(anyhow!("Invalid block size"));
                 }
 
-                size = v.trim().parse::<u64>()?;
+                size = match u64::from_str_radix(v.trim(), 16) {
+                    Ok(h) => h,
+                    Err(_) => {
+                        warn!(sl!(), "failed to parse the str {} to hex", size);
+                        return Err(anyhow!("Invalid block size"));
+                    }
+                };
             }
             Err(e) => {
                 info!(sl!(), "memory block size error: {:?}", e.kind());


### PR DESCRIPTION
   We were assuming base 10 string before, when the block size from sysfs
    is actually a hex string. Let's fix that.
    
    Fixes: #908


Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>