### PR TITLE
agent: fix symbol undefined bug  when compile agent on arm

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -105,8 +105,10 @@ default: $(TARGET) show-header
 
 $(TARGET): $(GENERATED_CODE) $(TARGET_PATH)
 
+#remember to add '-C link-arg=-lgcc' to RUSTFLAGS when you assign it.
 $(TARGET_PATH): $(SOURCES) | show-summary
-	@RUSTFLAGS="--deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
+	@RUSTFLAGS='-C link-arg=-lgcc --deny warnings' cargo build --target $(TRIPLE) --$(BUILD_TYPE)
+
 
 optimize: $(SOURCES) | show-summary show-header
 	@RUSTFLAGS='-C link-arg=-s --deny-warnings' cargo build --target $(TRIPLE) --$(BUILD_TYPE)


### PR DESCRIPTION
The __addtf3, __subtf3 and __multf3 symbols are used by aarch64-musl,
but are not provided by rust compiler-builtins.
For now, the only functional workaround accepted by rust communities
is to get them from libgcc.
Now, rustflags is set in .cargo/config. But it may be corrupted somewhere
and lead to the bug.

Fixes: #909
Signed-off-by Jianyong Wu <jianyong.wu@arm.com>

@bergwolf @jodh-intel 