### PR TITLE
docs: remove the 1.x version description about shim and proxy

### DIFF
--- a/docs/design/kata-api-design.md
+++ b/docs/design/kata-api-design.md
@@ -3,7 +3,6 @@ To fulfill the [Kata design requirements](kata-design-requirements.md), and base
 -  Sandbox based top API
 -  Storage and network hotplug API
 -  Plugin frameworks for external proprietary Kata runtime extensions
--  Built-in shim and proxy types and capabilities
 
 ## Sandbox Based API
 ### Sandbox Management API
@@ -23,17 +22,17 @@ To fulfill the [Kata design requirements](kata-design-requirements.md), and base
 |`sandbox.Stats()`| Get the stats of a running sandbox, return a `SandboxStats` structure.|
 |`sandbox.Status()`| Get the status of the sandbox and containers, return a `SandboxStatus` structure.|
 |`sandbox.Stop(force)`| Stop a sandbox and Destroy the containers in the sandbox. When force is true, ignore guest related stop failures.|
-|`sandbox.CreateContainer(contConfig)`| Create new container in the sandbox with the `ContainerConfig` param. It will add new container config to `sandbox.config.Containers`.|
-|`sandbox.DeleteContainer(containerID)`| Delete a container from the sandbox by containerID, return a `Container` structure.|
+|`sandbox.CreateContainer(contConfig)`| Create new container in the sandbox with the `ContainerConfig` parameter. It will add new container config to `sandbox.config.Containers`.|
+|`sandbox.DeleteContainer(containerID)`| Delete a container from the sandbox by `containerID`, return a `Container` structure.|
 |`sandbox.EnterContainer(containerID, cmd)`| Run a new process in a container, executing customer's `types.Cmd` command.|
-|`sandbox.KillContainer(containerID, signal, all)`| Signal a container in the sandbox by the containerID.|
-|`sandbox.PauseContainer(containerID)`| Pause a running container in the sandbox by the containerID.|
+|`sandbox.KillContainer(containerID, signal, all)`| Signal a container in the sandbox by the `containerID`.|
+|`sandbox.PauseContainer(containerID)`| Pause a running container in the sandbox by the `containerID`.|
 |`sandbox.ProcessListContainer(containerID, options)`| List every process running inside a specific container in the sandbox, return a `ProcessList` structure.|
-|`sandbox.ResumeContainer(containerID)`| Resume a paused container in the sandbox by the containerID.|
-|`sandbox.StartContainer(containerID)`| Start a container in the sandbox by the containerID.|
+|`sandbox.ResumeContainer(containerID)`| Resume a paused container in the sandbox by the `containerID`.|
+|`sandbox.StartContainer(containerID)`| Start a container in the sandbox by the `containerID`.|
 |`sandbox.StatsContainer(containerID)`| Get the stats of a running container, return a `ContainerStats` structure.|
 |`sandbox.StatusContainer(containerID)`| Get the status of a container in the sandbox, return a `ContainerStatus` structure.|
-|`sandbox.StopContainer(containerID, force)`| Stop a container in the sandbox by the containerID.|
+|`sandbox.StopContainer(containerID, force)`| Stop a container in the sandbox by the `containerID`.|
 |`sandbox.UpdateContainer(containerID, resources)`| Update a running container in the sandbox.|
 |`sandbox.WaitProcess(containerID, processID)`| Wait on a process to terminate.|
 ### Sandbox Hotplug API
@@ -57,7 +56,7 @@ To fulfill the [Kata design requirements](kata-design-requirements.md), and base
 |Name|Description|
 |---|---|
 |`sandbox.GetOOMEvent()`| Monitor the OOM events that occur in the sandbox..|
-|`sandbox.UpdateRuntimeMetrics()`| Update the shim/hypervisor's metrics of the running sandbox.|
+|`sandbox.UpdateRuntimeMetrics()`| Update the `shim/hypervisor` metrics of the running sandbox.|
 |`sandbox.GetAgentMetrics()`| Get metrics of the agent and the guest in the running sandbox.|
 
 ## Plugin framework for external proprietary Kata runtime extensions
@@ -99,32 +98,3 @@ Built-in implementations include:
 
 ### Sandbox Connection Plugin Workflow
 ![Sandbox Connection Plugin Workflow](https://raw.githubusercontent.com/bergwolf/raw-contents/master/kata/Sandbox-Connection.png "Sandbox Connection Plugin Workflow")
-
-## Built-in Shim and Proxy Types and Capabilities
-### Built-in shim/proxy sandbox configurations
--  Supported shim configurations:
-
-|Name|Description|
-|---|---|
-|`noopshim`|Do not start any shim process.|
-|`ccshim`| Start the cc-shim binary.|
-|`katashim`| Start the `kata-shim` binary.|
-|`katashimbuiltin`|No standalone shim process but shim functionality APIs are exported.|
--  Supported proxy configurations:
-
-|Name|Description|
-|---|---|
-|`noopProxy`| a dummy proxy implementation of the proxy interface, only used for testing purpose.|
-|`noProxy`|generic implementation for any case where no actual proxy is needed.|
-|`ccProxy`|run `ccProxy` to proxy between runtime and agent.|
-|`kataProxy`|run `kata-proxy` to translate Yamux connections between runtime and Kata agent. |
-|`kataProxyBuiltin`| no standalone proxy process and connect to Kata agent with internal Yamux translation.|
-
-### Built-in Shim Capability
-Built-in shim capability is implemented by removing standalone shim process, and
-supporting the shim related APIs.
-
-### Built-in Proxy Capability
-Built-in proxy capability is achieved by removing standalone proxy process, and
-connecting to Kata agent with a custom gRPC dialer that is internal Yamux translation.
-The behavior is enabled when proxy is configured as `kataProxyBuiltin`.


### PR DESCRIPTION
Remove the build in shim and proxy desgin description from the
kata-api-design.md file.

Fixes: #912

Signed-off-by: Ychau Wang <wangyongchao.bj@inspur.com>