### PR TITLE
packaging: fix missing cloud_hypervisor_repo

### DIFF
--- a/tools/packaging/release/kata-deploy-binaries.sh
+++ b/tools/packaging/release/kata-deploy-binaries.sh
@@ -175,7 +175,7 @@ install_clh() {
 	kata_version="${kata_version}" "${pkg_root_dir}/static-build/cloud-hypervisor/build-static-clh.sh"
 	info "Install static cloud-hypervisor"
 	mkdir -p "${destdir}/opt/kata/bin/"
-	sudo install -D --owner root --group root --mode 0744 cloud-hypervisor "${destdir}/opt/kata/bin/cloud-hypervisor"
+	sudo install -D --owner root --group root --mode 0744 cloud-hypervisor/cloud-hypervisor "${destdir}/opt/kata/bin/cloud-hypervisor"
 	pushd "${destdir}"
 	# create tarball for github release action
 	tar -czvf ../kata-static-clh.tar.gz *

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -13,7 +13,16 @@ kata_version="${kata_version:-}"
 
 source "${script_dir}/../../scripts/lib.sh"
 
+cloud_hypervisor_repo="${cloud_hypervisor_repo:-}"
 cloud_hypervisor_version="${cloud_hypervisor_version:-}"
+
+if [ -z "$cloud_hypervisor_repo" ]; then
+       info "Get cloud_hypervisor information from runtime versions.yaml"
+       cloud_hypervisor_url=$(get_from_kata_deps "assets.hypervisor.cloud_hypervisor.url" "${kata_version}")
+       [ -n "$cloud_hypervisor_url" ] || die "failed to get cloud_hypervisor url"
+       cloud_hypervisor_repo="${cloud_hypervisor_url}.git"
+fi
+[ -n "$cloud_hypervisor_repo" ] || die "failed to get cloud_hypervisor repo"
 
 [ -n "$cloud_hypervisor_version" ] || cloud_hypervisor_version=$(get_from_kata_deps "assets.hypervisor.cloud_hypervisor.version" "${kata_version}")
 [ -n "$cloud_hypervisor_version" ] || die "failed to get cloud_hypervisor version"

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -31,7 +31,9 @@ pull_clh_released_binary() {
     info "Download cloud-hypervisor version: ${cloud_hypervisor_version}"
     cloud_hypervisor_binary="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${cloud_hypervisor_version}/cloud-hypervisor-static"
 
-    curl --fail -L ${cloud_hypervisor_binary} -o cloud-hypervisor || return 1
+    curl --fail -L ${cloud_hypervisor_binary} -o cloud-hypervisor-static || return 1
+    mkdir -p cloud-hypervisor
+    mv -f cloud-hypervisor-static cloud-hypervisor/cloud-hypervisor
 }
 
 build_clh_from_source() {


### PR DESCRIPTION
It is needed in order to build from source.

Fixes: #916