### PR TITLE
agent: fix device ID conflicts

### DIFF
--- a/src/agent/oci/src/lib.rs
+++ b/src/agent/oci/src/lib.rs
@@ -494,6 +494,9 @@ pub struct LinuxDeviceCgroup {
     pub minor: Option<i64>,
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub access: String,
+    /// A back reference to the index of device in Linux.devices in the spec
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index: Option<usize>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, PartialEq)]
@@ -1415,6 +1418,7 @@ mod tests {
                             major: None,
                             minor: None,
                             access: "rwm".to_string(),
+                            index: None,
                         },
                         crate::LinuxDeviceCgroup {
                             allow: true,
@@ -1422,6 +1426,7 @@ mod tests {
                             major: Some(10),
                             minor: Some(229),
                             access: "rw".to_string(),
+                            index: None,
                         },
                         crate::LinuxDeviceCgroup {
                             allow: true,
@@ -1429,6 +1434,7 @@ mod tests {
                             major: Some(8),
                             minor: Some(0),
                             access: "r".to_string(),
+                            index: None,
                         },
                     ],
                     memory: Some(crate::LinuxMemory {

--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -544,6 +544,7 @@ lazy_static! {
             major: Some(WILDCARD),
             minor: Some(WILDCARD),
             access: "m".to_string(),
+            index: None,
         });
 
         // all mknod to all block devices
@@ -553,6 +554,7 @@ lazy_static! {
             major: Some(WILDCARD),
             minor: Some(WILDCARD),
             access: "m".to_string(),
+            index: None,
         });
 
         // all read/write/mknod to char device /dev/console
@@ -562,6 +564,7 @@ lazy_static! {
             major: Some(5),
             minor: Some(1),
             access: "rwm".to_string(),
+            index: None,
         });
 
         // all read/write/mknod to char device /dev/pts/<N>
@@ -571,6 +574,7 @@ lazy_static! {
             major: Some(136),
             minor: Some(WILDCARD),
             access: "rwm".to_string(),
+            index: None,
         });
 
         // all read/write/mknod to char device /dev/ptmx
@@ -580,6 +584,7 @@ lazy_static! {
             major: Some(5),
             minor: Some(2),
             access: "rwm".to_string(),
+            index: None,
         });
 
         // all read/write/mknod to char device /dev/net/tun
@@ -589,6 +594,7 @@ lazy_static! {
             major: Some(10),
             minor: Some(200),
             access: "rwm".to_string(),
+            index: None,
         });
 
         v


### PR DESCRIPTION
As stated in https://github.com/kata-containers/agent/issues/834 and https://github.com/kata-containers/agent/issues/835, there are two cases that the device IDs can conflict and the rust agent does not handle them correctly.

1. Two devices have the same device IDs on the host
2. Device A's device ID is identical to device B's device ID on the host

The PR handles both of them and adds UTs to make sure it works as expected.

/cc @dgibson 