### PR TITLE
docs: update the build kata containers kernel document

### DIFF
--- a/tools/packaging/kernel/README.md
+++ b/tools/packaging/kernel/README.md
@@ -63,25 +63,25 @@ $ ./build-kernel.sh -v 4.19.86 -g nvidia -f -d setup
 > **Note**
 > - `-v 4.19.86`: Specify the guest kernel version.
 > - `-g nvidia`: To build a guest kernel supporting Nvidia GPU.
-> - `-f`: The .config file is forced to be generated even if the kernel directory already exists.
+> - `-f`: The `.config` file is forced to be generated even if the kernel directory already exists.
 > - `-d`: Enable bash debug mode.
 
 
 ## Setup kernel source code
 
 ```bash
-$ go get -d -u github.com/kata-containers/packaging
-$ cd $GOPATH/src/github.com/kata-containers/packaging/kernel
+$ go get -d -u github.com/kata-containers/kata-containers
+$ cd $GOPATH/src/github.com/kata-containers/kata-containers/tools/packaging/kernel
 $ ./build-kernel.sh setup
 ```
 
 The script `./build-kernel.sh` tries to apply the patches from
-`${GOPATH}/src/github.com/kata-containers/packaging/kernel/patches/` when it
+`${GOPATH}/src/github.com/kata-containers/kata-containers/tools/packaging/kernel/patches/` when it
 sets up a kernel. If you want to add a source modification, add a patch on this
 directory.
 
 The script also adds a kernel config file from
-`${GOPATH}/src/github.com/kata-containers/packaging/kernel/configs/` to `.config`
+`${GOPATH}/src/github.com/kata-containers/kata-containers/tools/packaging/kernel/configs/` to `.config`
 in the kernel source code. You can modify it as needed.
 
 ## Build the kernel
@@ -106,7 +106,7 @@ $ ./build-kernel.sh install
 
 Kata Containers packaging repository holds the kernel configs and patches. The
 config and patches can work for many versions, but we only test the
-kernel version defined in the [runtime versions file][runtime-versions-file].
+kernel version defined in the [Kata Containers versions file][kata-containers-versions-file].
 
 For further details, see [the kernel configuration documentation](configs).
 
@@ -115,33 +115,33 @@ For further details, see [the kernel configuration documentation](configs).
 The Kata Containers CI scripts install the kernel from [CI cache
 job][cache-job] or build from sources.
 
-If the kernel defined in the [runtime versions file][runtime-versions-file] is
+If the kernel defined in the [Kata Containers versions file][kata-containers-versions-file] is
 built and cached with the latest kernel config and patches, it installs.
 Otherwise, the kernel is built from source.
 
-The Kata kernel version is a mix of the kernel version defined in the [runtime
-versions file][runtime-versions-file] and the file `kata_config_version`. This
+The Kata kernel version is a mix of the kernel version defined in the [Kata Containers
+versions file][kata-containers-versions-file] and the file `kata_config_version`. This
 helps to identify if a kernel build has the latest recommend
 configuration.
 
 Example:
 
 ```bash
-# From https://github.com/kata-containers/runtime/blob/master/versions.yaml
-$ kernel_version_in_versions_file=4.10.1
-# From https://github.com/kata-containers/packaging/blob/master/kernel/kata_config_version
-$ kata_config_version=25
+# From https://github.com/kata-containers/kata-containers/blob/2.0-dev/versions.yaml
+$ kernel_version_in_versions_file=5.4.60
+# From https://github.com/kata-containers/kata-containers/blob/2.0-dev/tools/packaging/kernel/kata_config_version
+$ kata_config_version=83
 $ latest_kernel_version=${kernel_version_in_versions_file}-${kata_config_version}
 ```
 
-The resulting version is 4.10.1-25, this helps identify whether or not the kernel
+The resulting version is 5.4.60-83, this helps identify whether or not the kernel
 configs are up-to-date on a CI version.
 
 ## Contribute
 
 In order to do Kata Kernel changes. There are places to contribute:
 
-1. [Kata runtime versions file][runtime-versions-file]: This file points to the
+1. [Kata Containers versions file][kata-containers-versions-file]: This file points to the
    recommended versions to be used by Kata. To update the kernel version send a
    pull request to update that version. The Kata CI will run all the use cases
    and verify it works.
@@ -174,7 +174,7 @@ In this case, the PR you submit needs to be tested together with a patch from
 another Kata Containers repository. To do this you have to specify which
 repository and which pull request [it depends on][depends-on-docs].
 
-[runtime-versions-file]: https://github.com/kata-containers/runtime/blob/master/versions.yaml
-[patches-dir]: https://github.com/kata-containers/packaging/tree/master/kernel/patches
+[kata-containers-versions-file]: ../../../versions.yaml
+[patches-dir]: patches
 [depends-on-docs]: https://github.com/kata-containers/tests/blob/master/README.md#breaking-compatibility
 [cache-job]: http://jenkins.katacontainers.io/job/image-nightly-x86_64/


### PR DESCRIPTION
Update the build kata containers kernel document for 2.0 release. Fixed
the 1.x release project paths and urls, using the kata-containers
project file paths and urls.

Fixes: #929

Signed-off-by: Ychau Wang <wangyongchao.bj@inspur.com>