### PR TITLE
Forward port device conflict fixes from Kata 1 / Go agent

### DIFF
--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -262,10 +262,14 @@ fn update_spec_device_list(device: &Device, spec: &mut Spec) -> Result<()> {
                     }
                 }
             }
+            return Ok(());
         }
     }
 
-    Ok(())
+    Err(anyhow!(
+        "Should have found a matching device {} in the spec",
+        device.vm_path
+    ))
 }
 
 // device.Id should be the predicted device name (vda, vdb, ...)


### PR DESCRIPTION
https://github.com/kata-containers/agent/issues/834 and https://github.com/kata-containers/agent/issues/835 covered possible misbehaviour of the agent due to conflicts between device major:minor numbers, either between guest and host or between block and character devices.

Here, forward port those fixes to address #703.

@bergwolf's PR #924 solves the same bugs.  This PR takes an approach that's closer to how they were solved in the Go agent, which will make dependent forward ports I'm working on easier.