### PR TITLE
factory: Use lazy unmount

### DIFF
--- a/src/runtime/cli/main.go
+++ b/src/runtime/cli/main.go
@@ -22,6 +22,7 @@ import (
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
 	exp "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/experimental"
 	vf "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/factory"
+	tl "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/factory/template"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/oci"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/rootless"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -200,6 +201,9 @@ func setExternalLoggers(ctx context.Context, logger *logrus.Entry) {
 
 	// Set vm factory logger.
 	vf.SetLogger(ctx, logger)
+
+	// Set vm factory template logger.
+	tl.SetLogger(ctx, logger)
 
 	// Set the OCI package logger.
 	oci.SetLogger(ctx, logger)

--- a/src/runtime/virtcontainers/factory/template/template_test.go
+++ b/src/runtime/virtcontainers/factory/template/template_test.go
@@ -121,7 +121,14 @@ func TestTemplateFactory(t *testing.T) {
 	err = vm.Stop(ctx)
 	assert.Nil(err)
 
-	// CloseFactory
+	// make tt.statePath is busy
+	os.Chdir(tt.statePath)
+
+	// CloseFactory, there is no need to call tt.CloseFactory(ctx)
 	f.CloseFactory(ctx)
-	tt.CloseFactory(ctx)
+
+	// expect tt.statePath not exist, if exist, it means this case failed.
+	_, err = os.Stat(tt.statePath)
+	assert.Error(err)
+	assert.True(os.IsNotExist(err))
 }


### PR DESCRIPTION
backport for https://github.com/kata-containers/runtime/pull/2923
we can have the following case,
1. start kata container with factory feature, this need kata-runtime
   config to enable factory and use initrd as base image.
2. start a kata container.
3. cd /root; cd /run/vc/vm/template dir, this will make
   /run/vc/vm/template to be in used.
4. destroy vm template with kata-runtime factory destroy , and check
                the template mountpoint.
we can see  the template mountpoints will add everytime we repeat the above steps .

[root@centos1 template]# mount |grep template
[root@centos1 template]# docker run -ti --rm  --runtime untrusted-runtime --net none busybox echo

[root@centos1 template]# cd /root; cd /run/vc/vm/template/
[root@centos1 template]# /kata/bin/kata-runtime factory destroy
vm factory destroyed
[root@centos1 template]# mount |grep template
tmpfs on /run/vc/vm/template type tmpfs (rw,nosuid,nodev,relatime,seclabel,size=2105344k)
[root@centos1 template]# docker run -ti --rm  --runtime untrusted-runtime --net none busybox echo

[root@centos1 template]# cd /root; cd /run/vc/vm/template/
[root@centos1 template]# /kata/bin/kata-runtime factory destroy
vm factory destroyed
[root@centos1 template]# mount |grep template
tmpfs on /run/vc/vm/template type tmpfs (rw,nosuid,nodev,relatime,seclabel,size=2105344k)
tmpfs on /run/vc/vm/template type tmpfs (rw,nosuid,nodev,relatime,seclabel,size=2105344k)

Fixes: #938

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>