### PR TITLE
runtime: Don' call bindUnmountContainerRootfs for devicemapper device

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -805,7 +805,7 @@ func (c *Container) rollbackFailingContainerCreation(ctx context.Context) {
 	if err := c.unmountHostMounts(ctx); err != nil {
 		c.Logger().WithError(err).Error("rollback failed unmountHostMounts()")
 	}
-	if err := bindUnmountContainerRootfs(ctx, getMountPath(c.sandbox.id), c.id); err != nil {
+	if err := bindUnmountContainerRootfs(ctx, getMountPath(c.sandbox.id), c); err != nil {
 		c.Logger().WithError(err).Error("rollback failed bindUnmountContainerRootfs()")
 	}
 }
@@ -1035,7 +1035,7 @@ func (c *Container) stop(ctx context.Context, force bool) error {
 		return err
 	}
 
-	if err := bindUnmountContainerRootfs(ctx, getMountPath(c.sandbox.id), c.id); err != nil && !force {
+	if err := bindUnmountContainerRootfs(ctx, getMountPath(c.sandbox.id), c); err != nil && !force {
 		return err
 	}
 

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1195,7 +1195,7 @@ func (k *kataAgent) rollbackFailingContainerCreation(ctx context.Context, c *Con
 			k.Logger().WithError(err2).Error("rollback failed unmountHostMounts()")
 		}
 
-		if err2 := bindUnmountContainerRootfs(ctx, getMountPath(c.sandbox.id), c.id); err2 != nil {
+		if err2 := bindUnmountContainerRootfs(ctx, getMountPath(c.sandbox.id), c); err2 != nil {
 			k.Logger().WithError(err2).Error("rollback failed bindUnmountContainerRootfs()")
 		}
 	}

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -349,13 +349,17 @@ func isSymlink(path string) bool {
 	return stat.Mode()&os.ModeSymlink != 0
 }
 
-func bindUnmountContainerRootfs(ctx context.Context, sharedDir, cID string) error {
+func bindUnmountContainerRootfs(ctx context.Context, sharedDir string, con *Container) error {
 	span, _ := trace(ctx, "bindUnmountContainerRootfs")
 	defer span.End()
 
-	rootfsDest := filepath.Join(sharedDir, cID, rootfsDir)
-	if isSymlink(filepath.Join(sharedDir, cID)) || isSymlink(rootfsDest) {
-		mountLogger().WithField("container", cID).Warnf("container dir is a symlink, malicious guest?")
+	if con.state.Fstype != "" && con.state.BlockDeviceID != "" {
+		return nil
+	}
+
+	rootfsDest := filepath.Join(sharedDir, con.id, rootfsDir)
+	if isSymlink(filepath.Join(sharedDir, con.id)) || isSymlink(rootfsDest) {
+		mountLogger().WithField("container", con.id).Warnf("container dir is a symlink, malicious guest?")
 		return nil
 	}
 
@@ -385,7 +389,7 @@ func bindUnmountAllRootfs(ctx context.Context, sharedDir string, sandbox *Sandbo
 		if c.state.Fstype == "" {
 			// even if error found, don't break out of loop until all mounts attempted
 			// to be unmounted, and collect all errors
-			errors = merr.Append(errors, bindUnmountContainerRootfs(ctx, sharedDir, c.id))
+			errors = merr.Append(errors, bindUnmountContainerRootfs(ctx, sharedDir, c))
 		}
 	}
 	return errors.ErrorOrNil()


### PR DESCRIPTION
backport for https://github.com/kata-containers/runtime/pull/2915
buildContainerRootfs don't call bindMountContainerRootfs if container's rootfs use devicemapper
device in https://github.com/kata-containers/runtime/blob/master/virtcontainers/kata_agent.go#L1300,
so bindUnmountContainerRootfs should not be called if container's rootfs use devicemapper device
in https://github.com/kata-containers/runtime/blob/master/virtcontainers/container.go#L1123

Fixes: #937

Signed-off-by: Shukui Yang <keloyangsk@gmail.com>