### PR TITLE
agent: Optimize error handling

### DIFF
--- a/src/agent/rustjail/src/capabilities.rs
+++ b/src/agent/rustjail/src/capabilities.rs
@@ -126,13 +126,12 @@ pub fn drop_privileges(cfd_log: RawFd, caps: &LinuxCapabilities) -> Result<()> {
     )
     .map_err(|e| anyhow!(e.to_string()))?;
 
-    if let Err(_) = caps::set(
+    let _ = caps::set(
         None,
         CapSet::Ambient,
         to_capshashset(cfd_log, caps.ambient.as_ref()),
-    ) {
-        log_child!(cfd_log, "failed to set ambient capability");
-    }
+    )
+    .map_err(|_| log_child!(cfd_log, "failed to set ambient capability"));
 
     Ok(())
 }

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -335,10 +335,7 @@ pub fn init_child() {
         Ok(_) => (),
         Err(e) => {
             log_child!(cfd_log, "child exit: {:?}", e);
-            check!(
-                write_sync(cwfd, SYNC_FAILED, format!("{:?}", e).as_str()),
-                "write_sync in init_child()"
-            );
+            let _ = write_sync(cwfd, SYNC_FAILED, format!("{:?}", e).as_str());
             return;
         }
     }
@@ -490,19 +487,13 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
         sched::setns(fd, s).or_else(|e| {
             if s == CloneFlags::CLONE_NEWUSER {
                 if e.as_errno().unwrap() != Errno::EINVAL {
-                    check!(
-                        write_sync(cwfd, SYNC_FAILED, format!("{:?}", e).as_str()),
-                        "write_sync for CLONE_NEWUSER"
-                    );
+                    let _ = write_sync(cwfd, SYNC_FAILED, format!("{:?}", e).as_str());
                     return Err(e);
                 }
 
                 Ok(())
             } else {
-                check!(
-                    write_sync(cwfd, SYNC_FAILED, format!("{:?}", e).as_str()),
-                    "write_sync for sched::setns"
-                );
+                let _ = write_sync(cwfd, SYNC_FAILED, format!("{:?}", e).as_str());
                 Err(e)
             }
         })?;
@@ -578,14 +569,12 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
 
     if guser.additional_gids.len() > 0 {
         setgroups(guser.additional_gids.as_slice()).map_err(|e| {
-            check!(
-                write_sync(
-                    cwfd,
-                    SYNC_FAILED,
-                    format!("setgroups failed: {:?}", e).as_str()
-                ),
-                "write_sync for setgroups"
+            let _ = write_sync(
+                cwfd,
+                SYNC_FAILED,
+                format!("setgroups failed: {:?}", e).as_str(),
             );
+
             e
         })?;
     }
@@ -650,9 +639,9 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     // notify parent that the child's ready to start
     write_sync(cwfd, SYNC_SUCCESS, "")?;
     log_child!(cfd_log, "ready to run exec");
-    check!(unistd::close(cfd_log), "closing cfd log");
-    check!(unistd::close(crfd), "closing crfd");
-    check!(unistd::close(cwfd), "closing cwfd");
+    let _ = unistd::close(cfd_log);
+    let _ = unistd::close(crfd);
+    let _ = unistd::close(cwfd);
 
     if oci_process.terminal {
         unistd::setsid()?;

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -397,7 +397,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
                         ns.r#type.clone(),
                         ns.path.clone()
                     );
-                    log_child!(cfd_log, "error is : {}", e.as_errno().unwrap().desc());
+                    log_child!(cfd_log, "error is : {:?}", e.as_errno());
                     e
                 })?;
 
@@ -1080,7 +1080,7 @@ fn get_pid_namespace(logger: &Logger, linux: &Linux) -> Result<Option<RawFd>> {
                         ns.r#type.clone(),
                         ns.path.clone()
                     );
-                    error!(logger, "error is : {}", e.as_errno().unwrap().desc());
+                    error!(logger, "error is : {:?}", e.as_errno());
 
                     e
                 })?;

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -407,20 +407,17 @@ fn mount_cgroups(
 
         if key != base {
             let src = format!("{}/{}", m.destination.as_str(), key);
-            match unix::fs::symlink(destination.as_str(), &src[1..]) {
-                Err(e) => {
-                    log_child!(
-                        cfd_log,
-                        "symlink: {} {} err: {}",
-                        key,
-                        destination.as_str(),
-                        e.to_string()
-                    );
+            unix::fs::symlink(destination.as_str(), &src[1..]).map_err(|e| {
+                log_child!(
+                    cfd_log,
+                    "symlink: {} {} err: {}",
+                    key,
+                    destination.as_str(),
+                    e.to_string()
+                );
 
-                    return Err(e.into());
-                }
-                Ok(_) => {}
-            }
+                e
+            })?;
         }
     }
 
@@ -689,18 +686,14 @@ fn mount_from(
             Path::new(&dest)
         };
 
-        // let _ = fs::create_dir_all(&dir);
-        match fs::create_dir_all(&dir) {
-            Ok(_) => {}
-            Err(e) => {
-                log_child!(
-                    cfd_log,
-                    "creat dir {}: {}",
-                    dir.to_str().unwrap(),
-                    e.to_string()
-                );
-            }
-        }
+        let _ = fs::create_dir_all(&dir).map_err(|e| {
+            log_child!(
+                cfd_log,
+                "creat dir {}: {}",
+                dir.to_str().unwrap(),
+                e.to_string()
+            )
+        });
 
         // make sure file exists so we can bind over it
         if src.is_file() {
@@ -717,31 +710,26 @@ fn mount_from(
         }
     };
 
-    match stat::stat(dest.as_str()) {
-        Ok(_) => {}
-        Err(e) => {
-            log_child!(
-                cfd_log,
-                "dest stat error. {}: {}",
-                dest.as_str(),
-                e.as_errno().unwrap().desc()
-            );
-        }
-    }
+    let _ = stat::stat(dest.as_str()).map_err(|e| {
+        log_child!(
+            cfd_log,
+            "dest stat error. {}: {}",
+            dest.as_str(),
+            e.as_errno().unwrap().desc()
+        )
+    });
 
-    match mount(
+    mount(
         Some(src.as_str()),
         dest.as_str(),
         Some(m.r#type.as_str()),
         flags,
         Some(d.as_str()),
-    ) {
-        Ok(_) => {}
-        Err(e) => {
-            log_child!(cfd_log, "mount error: {}", e.as_errno().unwrap().desc());
-            return Err(e.into());
-        }
-    }
+    )
+    .map_err(|e| {
+        log_child!(cfd_log, "mount error: {}", e.as_errno().unwrap().desc());
+        e
+    })?;
 
     if flags.contains(MsFlags::MS_BIND)
         && flags.intersects(
@@ -753,24 +741,22 @@ fn mount_from(
                 | MsFlags::MS_SLAVE),
         )
     {
-        match mount(
+        mount(
             Some(dest.as_str()),
             dest.as_str(),
             None::<&str>,
             flags | MsFlags::MS_REMOUNT,
             None::<&str>,
-        ) {
-            Err(e) => {
-                log_child!(
-                    cfd_log,
-                    "remout {}: {}",
-                    dest.as_str(),
-                    e.as_errno().unwrap().desc()
-                );
-                return Err(e.into());
-            }
-            Ok(_) => {}
-        }
+        )
+        .map_err(|e| {
+            log_child!(
+                cfd_log,
+                "remout {}: {}",
+                dest.as_str(),
+                e.as_errno().unwrap().desc()
+            );
+            e
+        })?;
     }
     Ok(())
 }

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -712,9 +712,9 @@ fn mount_from(
     let _ = stat::stat(dest.as_str()).map_err(|e| {
         log_child!(
             cfd_log,
-            "dest stat error. {}: {}",
+            "dest stat error. {}: {:?}",
             dest.as_str(),
-            e.as_errno().unwrap().desc()
+            e.as_errno()
         )
     });
 
@@ -726,7 +726,7 @@ fn mount_from(
         Some(d.as_str()),
     )
     .map_err(|e| {
-        log_child!(cfd_log, "mount error: {}", e.as_errno().unwrap().desc());
+        log_child!(cfd_log, "mount error: {:?}", e.as_errno());
         e
     })?;
 
@@ -748,12 +748,7 @@ fn mount_from(
             None::<&str>,
         )
         .map_err(|e| {
-            log_child!(
-                cfd_log,
-                "remout {}: {}",
-                dest.as_str(),
-                e.as_errno().unwrap().desc()
-            );
+            log_child!(cfd_log, "remout {}: {:?}", dest.as_str(), e.as_errno());
             e
         })?;
     }

--- a/src/agent/rustjail/src/sync.rs
+++ b/src/agent/rustjail/src/sync.rs
@@ -143,21 +143,15 @@ pub fn write_sync(fd: RawFd, msg_type: i32, data_str: &str) -> Result<()> {
         },
         SYNC_DATA => {
             let length: i32 = data_str.len() as i32;
-            match write_count(fd, &length.to_be_bytes(), MSG_SIZE) {
-                Ok(_count) => (),
-                Err(e) => {
-                    unistd::close(fd)?;
-                    return Err(anyhow!(e).context("error in send message to process"));
-                }
-            }
+            write_count(fd, &length.to_be_bytes(), MSG_SIZE).or_else(|e| {
+                unistd::close(fd)?;
+                Err(anyhow!(e).context("error in send message to process"))
+            })?;
 
-            match write_count(fd, data_str.as_bytes(), data_str.len()) {
-                Ok(_count) => (),
-                Err(e) => {
-                    unistd::close(fd)?;
-                    return Err(anyhow!(e).context("error in send message to process"));
-                }
-            }
+            write_count(fd, data_str.as_bytes(), data_str.len()).or_else(|e| {
+                unistd::close(fd)?;
+                Err(anyhow!(e).context("error in send message to process"))
+            })?;
         }
 
         _ => (),

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -130,17 +130,14 @@ fn get_device_name(sandbox: &Arc<Mutex<Sandbox>>, dev_addr: &str) -> Result<Stri
 
     info!(sl!(), "Waiting on channel for device notification\n");
     let hotplug_timeout = AGENT_CONFIG.read().unwrap().hotplug_timeout;
-    let dev_name = match rx.recv_timeout(hotplug_timeout) {
-        Ok(name) => name,
-        Err(_) => {
-            GLOBAL_DEVICE_WATCHER.lock().unwrap().remove_entry(dev_addr);
-            return Err(anyhow!(
-                "Timeout reached after {:?} waiting for device {}",
-                hotplug_timeout,
-                dev_addr
-            ));
-        }
-    };
+    let dev_name = rx.recv_timeout(hotplug_timeout).map_err(|_| {
+        GLOBAL_DEVICE_WATCHER.lock().unwrap().remove_entry(dev_addr);
+        anyhow!(
+            "Timeout reached after {:?} waiting for device {}",
+            hotplug_timeout,
+            dev_addr
+        )
+    })?;
 
     Ok(format!("{}/{}", SYSTEM_DEV_PATH, &dev_name))
 }

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -204,10 +204,10 @@ fn update_spec_device_list(device: &Device, spec: &mut Spec) -> Result<()> {
         ));
     }
 
-    let linux = match spec.linux.as_mut() {
-        None => return Err(anyhow!("Spec didn't container linux field")),
-        Some(l) => l,
-    };
+    let linux = spec
+        .linux
+        .as_mut()
+        .ok_or_else(|| anyhow!("Spec didn't container linux field"))?;
 
     if !Path::new(&device.vm_path).exists() {
         return Err(anyhow!("vm_path:{} doesn't exist", device.vm_path));
@@ -365,10 +365,10 @@ pub fn update_device_cgroup(spec: &mut Spec) -> Result<()> {
     let major = stat::major(rdev) as i64;
     let minor = stat::minor(rdev) as i64;
 
-    let linux = match spec.linux.as_mut() {
-        None => return Err(anyhow!("Spec didn't container linux field")),
-        Some(l) => l,
-    };
+    let linux = spec
+        .linux
+        .as_mut()
+        .ok_or_else(|| anyhow!("Spec didn't container linux field"))?;
 
     if linux.resources.is_none() {
         linux.resources = Some(LinuxResources::default());

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -512,14 +512,12 @@ fn run_debug_console_shell(logger: &Logger, shell: &str, socket_fd: RawFd) -> Re
             let args: Vec<&CStr> = vec![];
 
             // run shell
-            if let Err(e) = unistd::execvp(cmd.as_c_str(), args.as_slice()) {
-                match e {
-                    nix::Error::Sys(errno) => {
-                        std::process::exit(errno as i32);
-                    }
-                    _ => std::process::exit(-2),
+            let _ = unistd::execvp(cmd.as_c_str(), args.as_slice()).map_err(|e| match e {
+                nix::Error::Sys(errno) => {
+                    std::process::exit(errno as i32);
                 }
-            }
+                _ => std::process::exit(-2),
+            });
         }
 
         Ok(ForkResult::Parent { child: child_pid }) => {

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -251,10 +251,7 @@ fn ephemeral_storage_handler(
         return Ok("".to_string());
     }
 
-    if let Err(err) = fs::create_dir_all(Path::new(&storage.mount_point)) {
-        return Err(err.into());
-    }
-
+    fs::create_dir_all(Path::new(&storage.mount_point))?;
     common_storage_handler(logger, storage)?;
 
     Ok("".to_string())

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -479,15 +479,18 @@ fn mount_to_rootfs(logger: &Logger, m: &INIT_MOUNT) -> Result<()> {
 
     fs::create_dir_all(Path::new(m.dest)).context("could not create directory")?;
 
-    if let Err(err) = bare_mount.mount() {
+    bare_mount.mount().or_else(|e| {
         if m.src != "dev" {
-            return Err(err.into());
+            return Err(e);
         }
+
         error!(
             logger,
             "Could not mount filesystem from {} to {}", m.src, m.dest
         );
-    }
+
+        Ok(())
+    })?;
 
     Ok(())
 }

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -455,11 +455,8 @@ pub fn add_storages(
                 )
             })?;
 
-        let mount_point = match handler(&logger, &storage, sandbox.clone()) {
-            // Todo need to rollback the mounted storage if err met.
-            Err(e) => return Err(e),
-            Ok(m) => m,
-        };
+        // Todo need to rollback the mounted storage if err met.
+        let mount_point = handler(&logger, &storage, sandbox.clone())?;
 
         if mount_point.len() > 0 {
             mount_list.push(mount_point);

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -131,12 +131,12 @@ impl Namespace {
             };
 
             let bare_mount = BareMount::new(source, destination, "none", flags, "", &logger);
-            if let Err(err) = bare_mount.mount() {
-                return Err(format!(
+            bare_mount.mount().map_err(|e| {
+                format!(
                     "Failed to mount {} to {} with err:{:?}",
-                    source, destination, err
-                ));
-            }
+                    source, destination, e
+                )
+            })?;
 
             Ok(())
         });

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -588,13 +588,9 @@ impl protocols::agent_ttrpc::AgentService for agentService {
         _ctx: &ttrpc::TtrpcContext,
         req: protocols::agent::WaitProcessRequest,
     ) -> ttrpc::Result<WaitProcessResponse> {
-        match self.do_wait_process(req) {
-            Err(e) => Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
-                ttrpc::Code::INTERNAL,
-                e.to_string(),
-            ))),
-            Ok(resp) => Ok(resp),
-        }
+        self.do_wait_process(req).map_err(|e| {
+            ttrpc::Error::RpcStatus(ttrpc::get_status(ttrpc::Code::INTERNAL, e.to_string()))
+        })
     }
 
     fn list_processes(
@@ -734,13 +730,9 @@ impl protocols::agent_ttrpc::AgentService for agentService {
                 "invalid container id".to_string(),
             )))?;
 
-        match ctr.stats() {
-            Err(e) => Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
-                ttrpc::Code::INTERNAL,
-                e.to_string(),
-            ))),
-            Ok(resp) => Ok(resp),
-        }
+        ctr.stats().map_err(|e| {
+            ttrpc::Error::RpcStatus(ttrpc::get_status(ttrpc::Code::INTERNAL, e.to_string()))
+        })
     }
 
     fn pause_container(
@@ -794,13 +786,9 @@ impl protocols::agent_ttrpc::AgentService for agentService {
         _ctx: &ttrpc::TtrpcContext,
         req: protocols::agent::WriteStreamRequest,
     ) -> ttrpc::Result<WriteStreamResponse> {
-        match self.do_write_stream(req) {
-            Err(e) => Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
-                ttrpc::Code::INTERNAL,
-                e.to_string(),
-            ))),
-            Ok(resp) => Ok(resp),
-        }
+        self.do_write_stream(req).map_err(|e| {
+            ttrpc::Error::RpcStatus(ttrpc::get_status(ttrpc::Code::INTERNAL, e.to_string()))
+        })
     }
 
     fn read_stdout(
@@ -808,13 +796,9 @@ impl protocols::agent_ttrpc::AgentService for agentService {
         _ctx: &ttrpc::TtrpcContext,
         req: protocols::agent::ReadStreamRequest,
     ) -> ttrpc::Result<ReadStreamResponse> {
-        match self.do_read_stream(req, true) {
-            Err(e) => Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
-                ttrpc::Code::INTERNAL,
-                e.to_string(),
-            ))),
-            Ok(resp) => Ok(resp),
-        }
+        self.do_read_stream(req, true).map_err(|e| {
+            ttrpc::Error::RpcStatus(ttrpc::get_status(ttrpc::Code::INTERNAL, e.to_string()))
+        })
     }
 
     fn read_stderr(
@@ -822,13 +806,9 @@ impl protocols::agent_ttrpc::AgentService for agentService {
         _ctx: &ttrpc::TtrpcContext,
         req: protocols::agent::ReadStreamRequest,
     ) -> ttrpc::Result<ReadStreamResponse> {
-        match self.do_read_stream(req, false) {
-            Err(e) => Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
-                ttrpc::Code::INTERNAL,
-                e.to_string(),
-            ))),
-            Ok(resp) => Ok(resp),
-        }
+        self.do_read_stream(req, false).map_err(|e| {
+            ttrpc::Error::RpcStatus(ttrpc::get_status(ttrpc::Code::INTERNAL, e.to_string()))
+        })
     }
 
     fn close_stdin(
@@ -841,15 +821,12 @@ impl protocols::agent_ttrpc::AgentService for agentService {
         let s = Arc::clone(&self.sandbox);
         let mut sandbox = s.lock().unwrap();
 
-        let p = match find_process(&mut sandbox, cid.as_str(), eid.as_str(), false) {
-            Ok(v) => v,
-            Err(e) => {
-                return Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
-                    ttrpc::Code::INVALID_ARGUMENT,
-                    format!("invalid argument: {:?}", e),
-                )));
-            }
-        };
+        let p = find_process(&mut sandbox, cid.as_str(), eid.as_str(), false).map_err(|e| {
+            ttrpc::Error::RpcStatus(ttrpc::get_status(
+                ttrpc::Code::INVALID_ARGUMENT,
+                format!("invalid argument: {:?}", e),
+            ))
+        })?;
 
         if p.term_master.is_some() {
             let _ = unistd::close(p.term_master.unwrap());
@@ -873,15 +850,12 @@ impl protocols::agent_ttrpc::AgentService for agentService {
         let eid = req.exec_id.clone();
         let s = Arc::clone(&self.sandbox);
         let mut sandbox = s.lock().unwrap();
-        let p = match find_process(&mut sandbox, cid.as_str(), eid.as_str(), false) {
-            Ok(v) => v,
-            Err(e) => {
-                return Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
-                    ttrpc::Code::UNAVAILABLE,
-                    format!("invalid argument: {:?}", e),
-                )));
-            }
-        };
+        let p = find_process(&mut sandbox, cid.as_str(), eid.as_str(), false).map_err(|e| {
+            ttrpc::Error::RpcStatus(ttrpc::get_status(
+                ttrpc::Code::UNAVAILABLE,
+                format!("invalid argument: {:?}", e),
+            ))
+        })?;
 
         if p.term_master.is_none() {
             return Err(ttrpc::Error::RpcStatus(ttrpc::get_status(
@@ -1335,13 +1309,10 @@ fn get_memory_info(block_size: bool, hotplug: bool) -> Result<(u64, bool)> {
                     return Err(anyhow!("Invalid block size"));
                 }
 
-                size = match u64::from_str_radix(v.trim(), 16) {
-                    Ok(h) => h,
-                    Err(_) => {
-                        warn!(sl!(), "failed to parse the str {} to hex", size);
-                        return Err(anyhow!("Invalid block size"));
-                    }
-                };
+                size = u64::from_str_radix(v.trim(), 16).map_err(|_| {
+                    warn!(sl!(), "failed to parse the str {} to hex", size);
+                    anyhow!("Invalid block size")
+                })?;
             }
             Err(e) => {
                 info!(sl!(), "memory block size error: {:?}", e.kind());

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1610,11 +1610,13 @@ fn do_copy_file(req: &CopyFileRequest) -> Result<()> {
         PathBuf::from("/")
     };
 
-    if let Err(e) = fs::create_dir_all(dir.to_str().unwrap()) {
+    fs::create_dir_all(dir.to_str().unwrap()).or_else(|e| {
         if e.kind() != std::io::ErrorKind::AlreadyExists {
-            return Err(e.into());
+            return Err(e);
         }
-    }
+
+        Ok(())
+    })?;
 
     std::fs::set_permissions(
         dir.to_str().unwrap(),

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -143,16 +143,10 @@ impl Sandbox {
     // It's assumed that caller is calling this method after
     // acquiring a lock on sandbox.
     pub fn unset_and_remove_sandbox_storage(&mut self, path: &str) -> Result<()> {
-        match self.unset_sandbox_storage(path) {
-            Ok(res) => {
-                if res {
-                    return self.remove_sandbox_storage(path);
-                }
-            }
-            Err(err) => {
-                return Err(err);
-            }
+        if self.unset_sandbox_storage(path)? {
+            return self.remove_sandbox_storage(path);
         }
+
         Ok(())
     }
 

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -316,10 +316,9 @@ impl Sandbox {
         thread::spawn(move || {
             for event in rx {
                 info!(logger, "got an OOM event {:?}", event);
-                match tx.send(container_id.clone()) {
-                    Err(err) => error!(logger, "failed to send message: {:?}", err),
-                    Ok(_) => {}
-                }
+                let _ = tx
+                    .send(container_id.clone())
+                    .map_err(|e| error!(logger, "failed to send message: {:?}", e));
             }
         });
     }

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -166,23 +166,17 @@ impl Sandbox {
 
     pub fn setup_shared_namespaces(&mut self) -> Result<bool> {
         // Set up shared IPC namespace
-        self.shared_ipcns = match Namespace::new(&self.logger).as_ipc().setup() {
-            Ok(ns) => ns,
-            Err(err) => {
-                return Err(anyhow!(err).context("Failed to setup persistent IPC namespace"));
-            }
-        };
+        self.shared_ipcns = Namespace::new(&self.logger)
+            .as_ipc()
+            .setup()
+            .context("Failed to setup persistent IPC namespace")?;
 
         // // Set up shared UTS namespace
-        self.shared_utsns = match Namespace::new(&self.logger)
+        self.shared_utsns = Namespace::new(&self.logger)
             .as_uts(self.hostname.as_str())
             .setup()
-        {
-            Ok(ns) => ns,
-            Err(err) => {
-                return Err(anyhow!(err).context("Failed to setup persistent UTS namespace"));
-            }
-        };
+            .context("Failed to setup persistent UTS namespace")?;
+
         Ok(true)
     }
 

--- a/src/agent/src/uevent.rs
+++ b/src/agent/src/uevent.rs
@@ -99,14 +99,14 @@ impl Uevent {
             let online_path = format!("{}/{}/online", SYSFS_DIR, &self.devpath);
             // It's a memory hot-add event.
             if online_path.starts_with(SYSFS_MEMORY_ONLINE_PATH) {
-                if let Err(e) = online_device(online_path.as_ref()) {
+                let _ = online_device(online_path.as_ref()).map_err(|e| {
                     error!(
                         *logger,
                         "failed to online device";
                         "device" => &self.devpath,
                         "error" => format!("{}", e),
-                    );
-                }
+                    )
+                });
                 return;
             }
         }


### PR DESCRIPTION
- Remove `if let Err`
- Remove `check!` macro
- Remove unnecessary `match`
- Remove `unwrap` for `e.as_errno()`, avoid panic caused by error content

Fixes #934