### PR TITLE
virtcontainers: Append max_ports to virtio-serial device

### DIFF
--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -308,6 +308,7 @@ func (q *qemuArchBase) appendConsole(devices []govmmQemu.Device, path string) ([
 		Driver:        govmmQemu.VirtioSerial,
 		ID:            "serial0",
 		DisableModern: q.nestedRun,
+		MaxPorts:      uint(2),
 	}
 
 	devices = append(devices, serial)

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -240,8 +240,9 @@ func TestQemuArchBaseAppendConsoles(t *testing.T) {
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.SerialDevice{
-			Driver: govmmQemu.VirtioSerial,
-			ID:     "serial0",
+			Driver:   govmmQemu.VirtioSerial,
+			ID:       "serial0",
+			MaxPorts: uint(2),
 		},
 		govmmQemu.CharDevice{
 			Driver:   govmmQemu.Console,


### PR DESCRIPTION
 Allow API consumers to change the maximum number of ports in the
 virtio-serial devices, setting a lower number of ports can improve the
 boot time and reduce the attack surface.

 Before this patch on arm64:
 [    0.028664] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
 [    0.055031] printk: console [hvc0] enabled

 After this patch on arm64:
 [    0.028484] Serial: 8250/16550 driver, 4 ports, IRQ sharing disabled
 [    0.031370] printk: console [hvc0] enabled

 Fixes: #2676
 Signed-off-by: Jia He <justin.he@arm.com>