### PR TITLE
rustjail: add length check for uid_mappings in rootless euid mapping

### DIFF
--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -225,7 +225,8 @@ fn rootless_euid_mapping(oci: &Spec) -> Result<()> {
         return Err(anyhow!(nix::Error::from_errno(Errno::EINVAL)));
     }
 
-    if linux.gid_mappings.len() == 0 || linux.gid_mappings.len() == 0 {
+    if linux.uid_mappings.len() == 0 || linux.gid_mappings.len() == 0 {
+        // rootless containers requires at least one UID/GID mapping
         return Err(anyhow!(nix::Error::from_errno(Errno::EINVAL)));
     }
 


### PR DESCRIPTION
This might be a copy miss, gid_mappings is checked twice, one should
be uid_mappings.

Fixes: #952

Signed-off-by: bin liu <bin@hyper.sh>