### PR TITLE
kata-monitor: use regexp to check if runtime is kata containers

### DIFF
--- a/src/runtime/cli/containerd-shim-kata-v2/main.go
+++ b/src/runtime/cli/containerd-shim-kata-v2/main.go
@@ -22,9 +22,9 @@ func shimConfig(config *shim.Config) {
 func main() {
 
 	if len(os.Args) == 2 && os.Args[1] == "--version" {
-		fmt.Printf("%s containerd shim: id: %q, version: %s, commit: %v\n", project, types.KataRuntimeName, version, commit)
+		fmt.Printf("%s containerd shim: id: %q, version: %s, commit: %v\n", project, types.DefaultKataRuntimeName, version, commit)
 		os.Exit(0)
 	}
 
-	shim.Run(types.KataRuntimeName, containerdshim.New, shimConfig)
+	shim.Run(types.DefaultKataRuntimeName, containerdshim.New, shimConfig)
 }

--- a/src/runtime/pkg/kata-monitor/containerd.go
+++ b/src/runtime/pkg/kata-monitor/containerd.go
@@ -82,7 +82,7 @@ func (ka *KataMonitor) getSandboxes() (map[string]string, error) {
 			namespacedCtx := namespaces.WithNamespace(ctx, namespace)
 			// only list Kata Containers pods/containers
 			containers, err := client.ContainerService().List(namespacedCtx,
-				"runtime.name=="+types.KataRuntimeName+`,labels."io.cri-containerd.kind"==sandbox`)
+				"runtime.name~="+types.KataRuntimeNameRegexp+`,labels."io.cri-containerd.kind"==sandbox`)
 			if err != nil {
 				return err
 			}

--- a/src/runtime/pkg/kata-monitor/sandbox_cache.go
+++ b/src/runtime/pkg/kata-monitor/sandbox_cache.go
@@ -8,6 +8,7 @@ package katamonitor
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"sync"
 
 	"github.com/containerd/containerd"
@@ -97,6 +98,11 @@ func (sc *sandboxCache) startEventsListener(addr string) error {
 		`topic=="/containers/delete"`,
 	}
 
+	runtimeNameRegexp, err := regexp.Compile(types.KataRuntimeNameRegexp)
+	if err != nil {
+		return err
+	}
+
 	eventsCh, errCh := eventsClient.Subscribe(ctx, eventFilters...)
 	for {
 		var e *events.Envelope
@@ -138,7 +144,7 @@ func (sc *sandboxCache) startEventsListener(addr string) error {
 				}
 
 				// skip non-kata contaienrs
-				if cc.Runtime.Name != types.KataRuntimeName {
+				if !runtimeNameRegexp.MatchString(cc.Runtime.Name) {
 					continue
 				}
 

--- a/src/runtime/pkg/types/types.go
+++ b/src/runtime/pkg/types/types.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Ant Financial
+// Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -6,6 +6,7 @@
 package types
 
 const (
-	KataRuntimeName           = "io.containerd.kata.v2"
+	DefaultKataRuntimeName    = "io.containerd.kata.v2"
+	KataRuntimeNameRegexp     = `io\.containerd\.kata.*\.v2`
 	ContainerdRuntimeTaskPath = "io.containerd.runtime.v2.task"
 )

--- a/src/runtime/pkg/types/types_test.go
+++ b/src/runtime/pkg/types/types_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2020 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+package types
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKataRuntimeNameRegexp(t *testing.T) {
+	assert := assert.New(t)
+
+	runtimeNameRegexp, err := regexp.Compile(KataRuntimeNameRegexp)
+	assert.NoError(err)
+
+	// valid Kata containers name
+	assert.Equal(true, runtimeNameRegexp.MatchString("io.containerd.kata.v2"))
+	assert.Equal(true, runtimeNameRegexp.MatchString("io.containerd.kataclh.v2"))
+	assert.Equal(true, runtimeNameRegexp.MatchString("io.containerd.kata-clh.v2"))
+	assert.Equal(true, runtimeNameRegexp.MatchString("io.containerd.kata.1.2.3-clh.4.v2"))
+
+	// invalid Kata containers name
+	assert.Equal(false, runtimeNameRegexp.MatchString("io2containerd.kata.v2"))
+	assert.Equal(false, runtimeNameRegexp.MatchString("io.c3ontainerd.kata.v2"))
+	assert.Equal(false, runtimeNameRegexp.MatchString("io.containerd.runc.v1"))
+}


### PR DESCRIPTION
To support a few common configurations for Kata, including:

- `io.containerd.kata.v2`
- `io.containerd.kata-qemu.v2`
- `io.containerd.kata-clh.v2`

`kata-monintor` changes to use regexp instead of direct string comparison.

Fixes: #957

Signed-off-by: bin liu <bin@hyper.sh>