### PR TITLE
tools: Make agent-ctl support more APIs

### DIFF
--- a/tools/agent-ctl/Cargo.lock
+++ b/tools/agent-ctl/Cargo.lock
@@ -258,6 +258,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "644f9158b2f133fd50f5fb3242878846d9eb792e445c893805ff0e3824006e35"
+
+[[package]]
 name = "humantime"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,7 +280,9 @@ name = "kata-agent-ctl"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "byteorder",
  "clap",
+ "hex",
  "humantime",
  "lazy_static",
  "libc",
@@ -435,7 +443,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.17.0",
+ "nix 0.18.0",
 ]
 
 [[package]]

--- a/tools/agent-ctl/Cargo.toml
+++ b/tools/agent-ctl/Cargo.toml
@@ -17,6 +17,8 @@ oci = { path = "../../src/agent/oci" }
 clap = "2.33.0"
 lazy_static = "1.4.0"
 anyhow = "1.0.31"
+hex = "0.4.2"
+byteorder = "1.3.4"
 
 logging = { path = "../../pkg/logging" }
 slog = "2.5.2"

--- a/tools/agent-ctl/README.md
+++ b/tools/agent-ctl/README.md
@@ -3,6 +3,11 @@
 * [Overview](#overview)
 * [Audience and environment](#audience-and-environment)
 * [Full details](#full-details)
+* [Code summary](#code-summary)
+* [Running the tool](#running-the-tool)
+    * [Prerequisites](#prerequisites)
+    * [Connect to a real Kata Container](#connect-to-a-real-kata-container)
+    * [Run the tool and the agent in the same environment](#run-the-tool-and-the-agent-in-the-same-environment)
 
 ## Overview
 
@@ -37,3 +42,80 @@ To see some examples, run:
 ```sh
 $ cargo run -- examples
 ```
+
+## Code summary
+
+The table below summarises where to look to learn more about both this tool,
+the agent protocol and the client and server implementations.
+
+| Description | File | Example RPC or function | Example summary |
+|-|-|-|-|
+| Protocol buffers definition of the Kata Containers Agent API protocol | [`agent.proto`](../../src/agent/protocols/protos/agent.proto) | `CreateContainer` | API to create a Kata container. |
+| Agent Control (client) API calls | [`src/client.rs`](src/client.rs) | `agent_cmd_container_create()` | Agent Control tool function that calls the `CreateContainer` API. |
+| Agent (server) API implementations | [`rpc.rs`](../../src/agent/src/rpc.rs) | `create_container()` | Server function that implements the `CreateContainers` API. |
+
+## Running the tool
+
+### Prerequisites
+
+It is necessary to create an OCI bundle to use the tool. The simplest method
+is:
+
+```sh
+$ bundle_dir="bundle"
+$ rootfs_dir="$bundle_dir/rootfs"
+$ image="busybox"
+$ mkdir -p "$rootfs_dir" && (cd "$bundle_dir" && runc spec)
+$ sudo docker export $(sudo docker create "$image") | tar -C "$rootfs_dir" -xvf -
+```
+
+### Connect to a real Kata Container
+
+1. Start a Kata Container
+
+1. Establish the VSOCK guest CID number for the virtual machine:
+
+   Assuming you are running a single QEMU based Kata Container, you can look
+   at the program arguments to find the (randomly-generated) `guest-cid=` option
+   value:
+
+   ```sh
+   $ guest_cid=$(ps -ef | grep qemu-system-x86_64 | egrep -o "guest-cid=[^,][^,]*" | cut -d= -f2)
+   ```
+
+1. Run the tool to connect to the agent:
+
+   ```sh
+   $ cargo run -- -l debug connect --bundle-dir "${bundle_dir}" --server-address "vsock://${guest_cid}:1024" -c Check -c GetGuestDetails
+   ```
+
+   This examples makes two API calls:
+
+   - It runs `Check` to see if the agent's RPC server is serving.
+   - It then runs `GetGuestDetails` to establish some details of the
+     environment the agent is running in.
+
+### Run the tool and the agent in the same environment
+
+> **Warnings:**
+>
+> - This method is **only** for testing and development!
+> - Only continue if you are using a non-critical system
+>   (such as a freshly installed VM environment).
+
+1. Start the agent, specifying a local socket for it to communicate on:
+
+   ```sh
+   $ sudo KATA_AGENT_SERVER_ADDR=unix:///tmp/foo.socket target/x86_64-unknown-linux-musl/release/kata-agent
+   ```
+
+1. Run the tool in the same environment:
+
+   ```sh
+   $ cargo run -- -l debug connect --server-address "unix://@/tmp/foo.socket" --bundle-dir "$bundle_dir" -c Check -c GetGuestDetails
+   ```
+
+   > **Note:**
+   >
+   > The `@` in the server address is required - it denotes an abstract
+   > socket which the agent requires (see `unix(7)`).

--- a/tools/agent-ctl/src/client.rs
+++ b/tools/agent-ctl/src/client.rs
@@ -684,6 +684,8 @@ fn agent_cmd_health_check(
     // value unused
     req.set_service("".to_string());
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = health
         .check(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -707,6 +709,8 @@ fn agent_cmd_health_version(
     // value unused
     req.set_service("".to_string());
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = health
         .version(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -729,6 +733,8 @@ fn agent_cmd_sandbox_create(
     let sid = utils::get_option("sid", options, args);
     req.set_sandbox_id(sid);
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = client
         .create_sandbox(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -747,6 +753,8 @@ fn agent_cmd_sandbox_destroy(
     _args: &str,
 ) -> Result<()> {
     let req = DestroySandboxRequest::default();
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 
     let reply = client
         .destroy_sandbox(&req, cfg.timeout_nano)
@@ -778,6 +786,8 @@ fn agent_cmd_container_create(
     req.set_exec_id(exec_id);
     req.set_OCI(grpc_spec);
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = client
         .create_container(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -800,6 +810,8 @@ fn agent_cmd_container_remove(
     let cid = utils::get_option("cid", options, args);
 
     req.set_container_id(cid);
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 
     let reply = client
         .remove_container(&req, cfg.timeout_nano)
@@ -838,6 +850,8 @@ fn agent_cmd_container_exec(
     req.set_exec_id(exec_id);
     req.set_process(process);
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = client
         .exec_process(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -860,6 +874,8 @@ fn agent_cmd_container_stats(
     let cid = utils::get_option("cid", options, args);
 
     req.set_container_id(cid);
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 
     let reply = client
         .stats_container(&req, cfg.timeout_nano)
@@ -884,6 +900,8 @@ fn agent_cmd_container_pause(
 
     req.set_container_id(cid);
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = client
         .pause_container(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -906,6 +924,8 @@ fn agent_cmd_container_resume(
     let cid = utils::get_option("cid", options, args);
 
     req.set_container_id(cid);
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 
     let reply = client
         .resume_container(&req, cfg.timeout_nano)
@@ -930,6 +950,8 @@ fn agent_cmd_container_start(
 
     req.set_container_id(cid);
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = client
         .start_container(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -950,6 +972,8 @@ fn agent_cmd_sandbox_get_guest_details(
     let mut req = GuestDetailsRequest::default();
 
     req.set_mem_block_size(true);
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 
     let reply = client
         .get_guest_details(&req, cfg.timeout_nano)
@@ -981,6 +1005,8 @@ fn agent_cmd_container_list_processes(
     req.set_container_id(cid);
     req.set_format(list_format);
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = client
         .list_processes(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -1005,6 +1031,8 @@ fn agent_cmd_container_wait_process(
 
     req.set_container_id(cid);
     req.set_exec_id(exec_id);
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 
     let reply = client
         .wait_process(&req, cfg.timeout_nano)
@@ -1041,6 +1069,8 @@ fn agent_cmd_container_signal_process(
     req.set_exec_id(exec_id);
     req.set_signal(signum as u32);
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = client
         .signal_process(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -1059,6 +1089,8 @@ fn agent_cmd_sandbox_tracing_start(
     _args: &str,
 ) -> Result<()> {
     let req = StartTracingRequest::default();
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 
     let reply = client
         .start_tracing(&req, cfg.timeout_nano)
@@ -1079,6 +1111,8 @@ fn agent_cmd_sandbox_tracing_stop(
 ) -> Result<()> {
     let req = StopTracingRequest::default();
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = client
         .stop_tracing(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -1098,6 +1132,7 @@ fn agent_cmd_sandbox_update_interface(
 ) -> Result<()> {
     let req = UpdateInterfaceRequest::default();
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
     let reply = client
         .update_interface(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -1122,6 +1157,8 @@ fn agent_cmd_sandbox_update_routes(
     _args: &str,
 ) -> Result<()> {
     let req = UpdateRoutesRequest::default();
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 
     let reply = client
         .update_routes(&req, cfg.timeout_nano)
@@ -1148,6 +1185,8 @@ fn agent_cmd_sandbox_list_interfaces(
 ) -> Result<()> {
     let req = ListInterfacesRequest::default();
 
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
     let reply = client
         .list_interfaces(&req, cfg.timeout_nano)
         .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
@@ -1166,6 +1205,8 @@ fn agent_cmd_sandbox_list_routes(
     _args: &str,
 ) -> Result<()> {
     let req = ListRoutesRequest::default();
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 
     let reply = client
         .list_routes(&req, cfg.timeout_nano)

--- a/tools/agent-ctl/src/client.rs
+++ b/tools/agent-ctl/src/client.rs
@@ -1179,7 +1179,7 @@ fn agent_cmd_sandbox_list_routes(
 
 #[inline]
 fn builtin_cmd_repeat(_cfg: &Config, _options: &mut Options, _args: &str) -> (Result<()>, bool) {
-    // XXX: NOP implementation. Due to the way repeat has to work, providing
+    // XXX: NOP implementation. Due to the way repeat has to work, providing a
     // handler like this is "too late" to be useful. However, a handler
     // is required as "repeat" is a valid command.
     //

--- a/tools/agent-ctl/src/client.rs
+++ b/tools/agent-ctl/src/client.rs
@@ -1140,9 +1140,6 @@ fn agent_cmd_sandbox_update_interface(
     // FIXME: Implement 'UpdateInterface' fully.
     eprintln!("FIXME: 'UpdateInterface' not fully implemented");
 
-    // let if = ...;
-    // req.set_interface(if);
-
     info!(sl!(), "response received";
         "response" => format!("{:?}", reply));
 
@@ -1166,9 +1163,6 @@ fn agent_cmd_sandbox_update_routes(
 
     // FIXME: Implement 'UpdateRoutes' fully.
     eprintln!("FIXME: 'UpdateRoutes' not fully implemented");
-
-    // let routes = ...;
-    // req.set_routes(routes);
 
     info!(sl!(), "response received";
         "response" => format!("{:?}", reply));

--- a/tools/agent-ctl/src/client.rs
+++ b/tools/agent-ctl/src/client.rs
@@ -106,9 +106,9 @@ static AGENT_CMDS: &'static [AgentCmd] = &[
         fp: agent_cmd_container_exec,
     },
     AgentCmd {
-        name: "GuestDetails",
+        name: "GetGuestDetails",
         st: ServiceType::Agent,
-        fp: agent_cmd_sandbox_guest_details,
+        fp: agent_cmd_sandbox_get_guest_details,
     },
     AgentCmd {
         name: "ListInterfaces",
@@ -940,7 +940,7 @@ fn agent_cmd_container_start(
     Ok(())
 }
 
-fn agent_cmd_sandbox_guest_details(
+fn agent_cmd_sandbox_get_guest_details(
     cfg: &Config,
     client: &AgentServiceClient,
     _health: &HealthClient,

--- a/tools/agent-ctl/src/main.rs
+++ b/tools/agent-ctl/src/main.rs
@@ -65,7 +65,7 @@ fn make_examples_text(program_name: &str) -> String {
 
 - Query the agent environment:
 
-  $ {program} connect --server-address "{vsock_server_address}" --cmd GuestDetails
+  $ {program} connect --server-address "{vsock_server_address}" --cmd GetGuestDetails
 
 - List all available (built-in and Kata Agent API) commands:
 
@@ -85,7 +85,7 @@ fn make_examples_text(program_name: &str) -> String {
 
 - Query guest details forever:
 
-  $ {program} connect --server-address "{vsock_server_address}" --repeat -1 --cmd GuestDetails
+  $ {program} connect --server-address "{vsock_server_address}" --repeat -1 --cmd GetGuestDetails
 
 - Send a 'SIGUSR1' signal to a container process:
 

--- a/tools/agent-ctl/src/utils.rs
+++ b/tools/agent-ctl/src/utils.rs
@@ -408,3 +408,17 @@ pub fn get_grpc_spec(options: &mut Options, cid: &str) -> Result<grpcSpec> {
 
     Ok(oci_to_grpc(&bundle_dir, cid, &oci_spec)?)
 }
+
+pub fn str_to_bytes(s: &str) -> Result<Vec<u8>> {
+    let prefix = "hex:";
+
+    if s.starts_with(prefix) {
+        let hex_str = s.trim_start_matches(prefix);
+
+        let decoded = hex::decode(hex_str).map_err(|e| anyhow!(e))?;
+
+        Ok(decoded)
+    } else {
+        Ok(s.as_bytes().to_vec())
+    }
+}


### PR DESCRIPTION
Added new `agent-ctl` commands to allow the following agent API calls to be made:

- `AddARPNeighborsRequest`
- `CloseStdinRequest`
- `CopyFileRequest`
- `GetMetricsRequest`
- `GetOOMEventRequest`
- `MemHotplugByProbeRequest`
- `OnlineCPUMemRequest`
- `ReadStreamRequest`
- `ReseedRandomDevRequest`
- `SetGuestDateTimeRequest`
- `TtyWinResizeRequest`
- `UpdateContainerRequest`
- `WriteStreamRequest`

Also did some tidy-up, and added more debug and better docs.

Fixes: #969.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>