### PR TITLE
agent: Log ttrpc messages

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -392,6 +392,7 @@ dependencies = [
  "signal-hook",
  "slog",
  "slog-scope",
+ "slog-stdlog",
  "tempfile",
  "ttrpc",
 ]
@@ -1075,6 +1076,17 @@ dependencies = [
  "arc-swap",
  "lazy_static",
  "slog",
+]
+
+[[package]]
+name = "slog-stdlog"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8228ab7302adbf4fcb37e66f3cda78003feb521e7fd9e3847ec117a7784d0f5a"
+dependencies = [
+ "log",
+ "slog",
+ "slog-scope",
 ]
 
 [[package]]

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -375,6 +375,7 @@ dependencies = [
  "cgroups",
  "lazy_static",
  "libc",
+ "log",
  "logging",
  "netlink",
  "nix 0.17.0",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -30,6 +30,7 @@ slog-scope = "4.1.2"
 
 # Redirect ttrpc log calls
 slog-stdlog = "4.0.0"
+log = "0.4.11"
 
 # for testing
 tempfile = "3.1.0"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -27,6 +27,10 @@ regex = "1"
 #   (by stopping the compiler from removing log calls).
 slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_info"] }
 slog-scope = "4.1.2"
+
+# Redirect ttrpc log calls
+slog-stdlog = "4.0.0"
+
 # for testing
 tempfile = "3.1.0"
 prometheus = { version = "0.9.0", features = ["process"] }

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -22,8 +22,9 @@ const DEFAULT_CONTAINER_PIPE_SIZE: i32 = 0;
 const VSOCK_ADDR: &str = "vsock://-1";
 const VSOCK_PORT: u16 = 1024;
 
-// Environment variable used for development and testing
+// Environment variables used for development and testing
 const SERVER_ADDR_ENV_VAR: &str = "KATA_AGENT_SERVER_ADDR";
+const LOG_LEVEL_ENV_VAR: &str = "KATA_AGENT_LOG_LEVEL";
 
 // FIXME: unused
 const TRACE_MODE_FLAG: &str = "agent.trace";
@@ -139,6 +140,12 @@ impl agentConfig {
 
         if let Ok(addr) = env::var(SERVER_ADDR_ENV_VAR) {
             self.server_addr = addr;
+        }
+
+        if let Ok(addr) = env::var(LOG_LEVEL_ENV_VAR) {
+            if let Ok(level) = logrus_to_slog_level(&addr) {
+                self.log_level = level;
+            }
         }
 
         Ok(())
@@ -374,6 +381,17 @@ mod tests {
                 debug_console: false,
                 dev_mode: false,
                 log_level: slog::Level::Debug,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "agent.log=debug",
+                env_vars: vec!["KATA_AGENT_LOG_LEVEL=trace"],
+                debug_console: false,
+                dev_mode: false,
+                log_level: slog::Level::Trace,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
                 server_addr: TEST_SERVER_ADDR,
@@ -751,6 +769,50 @@ mod tests {
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
                 server_addr: "unix://@/tmp/foo.socket",
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_LOG_LEVEL="],
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_LOG_LEVEL=invalid"],
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_LOG_LEVEL=debug"],
+                debug_console: false,
+                dev_mode: false,
+                log_level: slog::Level::Debug,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_LOG_LEVEL=debugger"],
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
         ];

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -21,6 +21,8 @@ const DEFAULT_HOTPLUG_TIMEOUT: time::Duration = time::Duration::from_secs(3);
 const DEFAULT_CONTAINER_PIPE_SIZE: i32 = 0;
 const VSOCK_ADDR: &str = "vsock://-1";
 const VSOCK_PORT: u16 = 1024;
+
+// Environment variable used for development and testing
 const SERVER_ADDR_ENV_VAR: &str = "KATA_AGENT_SERVER_ADDR";
 
 // FIXME: unused

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -319,296 +319,439 @@ mod tests {
 
     #[test]
     fn test_parse_cmdline() {
+        const TEST_SERVER_ADDR: &str = "vsock://-1:1024";
+
         #[derive(Debug)]
         struct TestData<'a> {
             contents: &'a str,
+            env_vars: Vec<&'a str>,
             debug_console: bool,
             dev_mode: bool,
             log_level: slog::Level,
             hotplug_timeout: time::Duration,
             container_pipe_size: i32,
+            server_addr: &'a str,
             unified_cgroup_hierarchy: bool,
         }
 
         let tests = &[
             TestData {
                 contents: "agent.debug_consolex agent.devmode",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.debug_console agent.devmodex",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.logx=debug",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.log=debug",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: false,
                 log_level: slog::Level::Debug,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo bar",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo bar",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo agent bar",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo debug_console agent bar devmode",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.debug_console",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "   agent.debug_console ",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.debug_console foo",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: " agent.debug_console foo",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo agent.debug_console bar",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo agent.debug_console",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo agent.debug_console ",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: false,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.devmode",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "   agent.devmode ",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.devmode foo",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: " agent.devmode foo",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo agent.devmode bar",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo agent.devmode",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "foo agent.devmode ",
+                env_vars: Vec::new(),
                 debug_console: false,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.devmode agent.debug_console",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.devmode agent.debug_console agent.hotplug_timeout=100 agent.unified_cgroup_hierarchy=a",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: time::Duration::from_secs(100),
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.devmode agent.debug_console agent.hotplug_timeout=0 agent.unified_cgroup_hierarchy=11",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: true,
             },
             TestData {
                 contents: "agent.devmode agent.debug_console agent.container_pipe_size=2097152 agent.unified_cgroup_hierarchy=false",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: 2097152,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.devmode agent.debug_console agent.container_pipe_size=100 agent.unified_cgroup_hierarchy=true",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: 100,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: true,
             },
             TestData {
                 contents: "agent.devmode agent.debug_console agent.container_pipe_size=0 agent.unified_cgroup_hierarchy=0",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: false,
             },
             TestData {
                 contents: "agent.devmode agent.debug_console agent.container_pip_siz=100 agent.unified_cgroup_hierarchy=1",
+                env_vars: Vec::new(),
                 debug_console: true,
                 dev_mode: true,
                 log_level: DEFAULT_LOG_LEVEL,
                 hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
                 container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
                 unified_cgroup_hierarchy: true,
+            },
+            TestData {
+                contents: "",
+                env_vars: Vec::new(),
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: TEST_SERVER_ADDR,
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_SERVER_ADDR=foo"],
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: "foo",
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_SERVER_ADDR=="],
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: "=",
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_SERVER_ADDR==foo"],
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: "=foo",
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_SERVER_ADDR=foo=bar=baz="],
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: "foo=bar=baz=",
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_SERVER_ADDR=unix:///tmp/foo.socket"],
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: "unix:///tmp/foo.socket",
+                unified_cgroup_hierarchy: false,
+            },
+            TestData {
+                contents: "",
+                env_vars: vec!["KATA_AGENT_SERVER_ADDR=unix://@/tmp/foo.socket"],
+                debug_console: false,
+                dev_mode: false,
+                log_level: DEFAULT_LOG_LEVEL,
+                hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
+                container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
+                server_addr: "unix://@/tmp/foo.socket",
+                unified_cgroup_hierarchy: false,
             },
         ];
 
@@ -623,7 +766,8 @@ mod tests {
         let result = config.parse_cmdline(&filename.to_owned());
         assert!(result.is_err());
 
-        // Now, test various combinations of file contents
+        // Now, test various combinations of file contents and environment
+        // variables.
         for (i, d) in tests.iter().enumerate() {
             let msg = format!("test[{}]: {:?}", i, d);
 
@@ -637,6 +781,19 @@ mod tests {
             file.write_all(d.contents.as_bytes())
                 .unwrap_or_else(|_| panic!("{}: failed to write file contents", msg));
 
+            let mut vars_to_unset = Vec::new();
+
+            for v in &d.env_vars {
+                let fields: Vec<&str> = v.split('=').collect();
+
+                let name = fields[0];
+                let value = fields[1..].join("=");
+
+                env::set_var(name, value);
+
+                vars_to_unset.push(name);
+            }
+
             let mut config = agentConfig::new();
             assert_eq!(config.debug_console, false, "{}", msg);
             assert_eq!(config.dev_mode, false, "{}", msg);
@@ -648,6 +805,7 @@ mod tests {
                 msg
             );
             assert_eq!(config.container_pipe_size, 0, "{}", msg);
+            assert_eq!(config.server_addr, TEST_SERVER_ADDR, "{}", msg);
 
             let result = config.parse_cmdline(filename);
             assert!(result.is_ok(), "{}", msg);
@@ -662,6 +820,11 @@ mod tests {
             assert_eq!(d.log_level, config.log_level, "{}", msg);
             assert_eq!(d.hotplug_timeout, config.hotplug_timeout, "{}", msg);
             assert_eq!(d.container_pipe_size, config.container_pipe_size, "{}", msg);
+            assert_eq!(d.server_addr, config.server_addr, "{}", msg);
+
+            for v in vars_to_unset {
+                env::remove_var(v);
+            }
         }
     }
 

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -198,8 +198,12 @@ fn main() -> Result<()> {
     // which is required to satisfy the the lifetime constraints of the auto-generated gRPC code.
     let _guard = slog_scope::set_global_logger(logger.new(o!("subsystem" => "rpc")));
 
-    // Redirect ttrpc log calls to slog
-    let _log_guard = slog_stdlog::init()?;
+    let mut _log_guard: Result<(), log::SetLoggerError> = Ok(());
+
+    if config.log_level == slog::Level::Trace {
+        // Redirect ttrpc log calls to slog iff full debug requested
+        _log_guard = Ok(slog_stdlog::init().map_err(|e| e)?);
+    }
 
     start_sandbox(&logger, &config, init_mode)?;
 

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -198,6 +198,9 @@ fn main() -> Result<()> {
     // which is required to satisfy the the lifetime constraints of the auto-generated gRPC code.
     let _guard = slog_scope::set_global_logger(logger.new(o!("subsystem" => "rpc")));
 
+    // Redirect ttrpc log calls to slog
+    let _log_guard = slog_stdlog::init()?;
+
     start_sandbox(&logger, &config, init_mode)?;
 
     let _ = log_handle.join();


### PR DESCRIPTION
The `ttrpc` crate uses the `log` crate for logging. But the agent uses the `slog` crate. This means that currently, all `ttrpc` log messages are being discarded.

Use the `slog-stdlog` create to redirect `log` crate logging calls into `slog` so they are visible in the agents log output.

Also adds a new `KATA_AGENT_LOG_LEVEL` environment variable to make testing this easier, plus a bunch of new tests.

Fixes: #978.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>