### PR TITLE
runtime: improve sandbox cleanup logic

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -686,13 +686,13 @@ func (s *Sandbox) Delete(ctx context.Context) error {
 
 	for _, c := range s.containers {
 		if err := c.delete(ctx); err != nil {
-			return err
+			s.Logger().WithError(err).WithField("cid", c.id).Debug("failed to delete container")
 		}
 	}
 
 	if !rootless.IsRootless() {
 		if err := s.cgroupsDelete(); err != nil {
-			return err
+			s.Logger().WithError(err).Error("failed to cleanup cgroups")
 		}
 	}
 


### PR DESCRIPTION
When reading the cleanup code path, we have several problems:

1. cgroups cleanup should ignore non-existing directories
2. sandbox delete should always succeeds after verifying sandbox states. otherwise we end up leaving orphan containers and inconsistent container states