### PR TITLE
Replace @RUNTIME_NAME@ with the target in generated files

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -93,6 +93,9 @@ DEFAULTSDIR := $(SHAREDIR)/defaults
 COLLECT_SCRIPT = data/kata-collect-data.sh
 COLLECT_SCRIPT_SRC = $(COLLECT_SCRIPT).in
 
+# @RUNTIME_NAME@ should be replaced with the target in generated files
+RUNTIME_NAME = $(TARGET)
+
 GENERATED_FILES += $(COLLECT_SCRIPT)
 GENERATED_VARS = \
 		VERSION \


### PR DESCRIPTION
In commit 966bd57 for PR #902, the makefile was changed to automate
the replacement of user variables. However, one variable was treated
specially in the original `sed` replacements, namely `RUNTIME_NAME`
which was replaced by `$(TARGET)`.

This commit adds the `RUNTIME_NAME` variable to the makefile in order
to ensure that the replacement works correctly.

Fixes: #993

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>