### PR TITLE
Feature/1004 add version for kata monitor

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -603,8 +603,9 @@ $(SHIMV2_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
 	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && ln -fs $(GENERATED_CONFIG))
 	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build $(KATA_LDFLAGS) $(BUILDFLAGS) -o $@ .)
 
-$(MONITOR_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
-	$(QUIET_BUILD)(cd $(MONITOR_DIR)/ && go build $(KATA_LDFLAGS) $(BUILDFLAGS) -o $@ .)
+$(MONITOR_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) .git-commit
+	$(QUIET_BUILD)(cd $(MONITOR_DIR)/ && go build \
+		--ldflags "-X main.GitCommit=$(shell cat .git-commit)" -o $@ .)
 
 .PHONY: \
 	check \

--- a/src/runtime/cli/kata-monitor/main.go
+++ b/src/runtime/cli/kata-monitor/main.go
@@ -9,6 +9,8 @@ import (
 	"flag"
 	"net/http"
 	"os"
+	"runtime"
+	"text/template"
 	"time"
 
 	kataMonitor "github.com/kata-containers/kata-containers/src/runtime/pkg/kata-monitor"
@@ -20,11 +22,76 @@ var containerdAddr = flag.String("containerd-address", "/run/containerd/containe
 var containerdConfig = flag.String("containerd-conf", "/etc/containerd/config.toml", "Containerd config file.")
 var logLevel = flag.String("log-level", "info", "Log level of logrus(trace/debug/info/warn/error/fatal/panic).")
 
+// These values are overridden via ldflags
+var (
+	appName = "kata-monitor"
+	// version is the kata monitor version.
+	version = "0.1.0"
+
+	GitCommit = "unknown-commit"
+)
+
+type versionInfo struct {
+	AppName   string
+	Version   string
+	GitCommit string
+	GoVersion string
+	Os        string
+	Arch      string
+}
+
+var versionTemplate = `{{.AppName}}
+ Version:	{{.Version}}
+ Go version:	{{.GoVersion}}
+ Git commit:	{{.GitCommit}}
+ OS/Arch:	{{.Os}}/{{.Arch}}
+`
+
+func printVersion(ver versionInfo) {
+	t, err := template.New("version").Parse(versionTemplate)
+
+	if err = t.Execute(os.Stdout, ver); err != nil {
+		panic(err)
+	}
+}
+
 func main() {
+	ver := versionInfo{
+		AppName:   appName,
+		Version:   version,
+		GoVersion: runtime.Version(),
+		Os:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+		GitCommit: GitCommit,
+	}
+
+	if len(os.Args) == 2 && (os.Args[1] == "--version" || os.Args[1] == "version") {
+		printVersion(ver)
+		return
+	}
+
 	flag.Parse()
 
 	// init logrus
 	initLog()
+
+	announceFields := logrus.Fields{
+		// properties from version info
+		"app":        ver.AppName,
+		"version":    ver.Version,
+		"go-version": ver.GoVersion,
+		"os":         ver.Os,
+		"arch":       ver.Arch,
+		"git-commit": ver.GitCommit,
+
+		// properties from command-line options
+		"listen-address":     *monitorListenAddr,
+		"containerd-address": *containerdAddr,
+		"containerd-conf":    *containerdConfig,
+		"log-level":          *logLevel,
+	}
+
+	logrus.WithFields(announceFields).Info("announce")
 
 	// create new kataMonitor
 	km, err := kataMonitor.NewKataMonitor(*containerdAddr, *containerdConfig)

--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -15,6 +15,9 @@ typeset -r runtime=${runtime_path:-"$runtime_snap_path"}
 typeset -r containerd_shim_v2_name="containerd-shim-kata-v2"
 typeset -r containerd_shim_v2=$(command -v "$containerd_shim_v2_name" 2>/dev/null)
 
+typeset -r kata_monitor_name="kata-monitor"
+typeset -r kata_monitor=$(command -v "$kata_monitor_name" 2>/dev/null)
+
 typeset -r issue_url="@PROJECT_BUG_URL@"
 typeset -r script_version="@VERSION@ (commit @COMMIT@)"
 
@@ -770,6 +773,21 @@ show_throttler_details()
 	end_section
 }
 
+show_kata_monitor_version()
+{
+	start_section "Kata Monitor"
+
+	local cmd="${kata_monitor_name} --version"
+
+	msg "Kata Monitor \`$kata_monitor_name\`."
+
+	run_cmd_and_show_quoted_output "" "$cmd"
+
+	separator
+
+	end_section
+}
+
 # Retrieve details of the image containing
 # the rootfs used to boot the virtual machine.
 show_image_details()
@@ -850,6 +868,7 @@ show_details()
 	show_log_details
 	show_container_mgr_details
 	show_package_versions
+	show_kata_monitor_version
 
 	show_footer
 }


### PR DESCRIPTION
This PR will add `--version` to `kata-monitor` command, and print version info like this:

```
kata-monitor
 Version:	0.1.0
 Go version:	go1.14.6
 Git commit:	e1b3c90ac7e458d4c3b0ec69b3b374b1e7276472-dirty
 Built:	2020-10-21T02:11:26Z
 OS/Arch:	linux/amd64
```

And `data/kata-collect-data.sh` will collect this info.

Fixes: #1004 

