### PR TITLE
cli: Add aliases for `kata-` options 

### DIFF
--- a/docs/Documentation-Requirements.md
+++ b/docs/Documentation-Requirements.md
@@ -25,7 +25,7 @@ All documents must:
 - Have a `.md` file extension.
 - Include a TOC (table of contents) at the top of the document with links to
   all heading sections. We recommend using the
-  [`check-markdown`](https://github.com/kata-containers/tests/tree/master/cmd/check-markdown)
+  [`kata-check-markdown`](https://github.com/kata-containers/tests/tree/master/cmd/check-markdown)
   tool to generate the TOC.
 - Be linked to from another document in the same repository.
 

--- a/docs/design/architecture.md
+++ b/docs/design/architecture.md
@@ -137,7 +137,7 @@ The runtime uses a TOML format configuration file called `configuration.toml`. B
 
 The actual configuration file paths can be determined by running:
 ```
-$ kata-runtime --kata-show-default-config-paths
+$ kata-runtime --show-default-config-paths
 ```
 Most users will not need to modify the configuration file.
 

--- a/docs/how-to/how-to-import-kata-logs-with-fluentd.md
+++ b/docs/how-to/how-to-import-kata-logs-with-fluentd.md
@@ -222,7 +222,7 @@ test to check the parsing works. The resulting output from Fluentd is:
   "_COMM":"kata-runtime",
   "_EXE":"/opt/kata/bin/kata-runtime",
   "SYSLOG_TIMESTAMP":"Feb 21 10:31:27 ",
-  "_CMDLINE":"/opt/kata/bin/kata-runtime --kata-config /opt/kata/share/defaults/kata-containers/configuration-qemu.toml --root /run/runc state 7cdd31660d8705facdadeb8598d2c0bd008e8142c54e3b3069abd392c8d58997",
+  "_CMDLINE":"/opt/kata/bin/kata-runtime --config /opt/kata/share/defaults/kata-containers/configuration-qemu.toml --root /run/runc state 7cdd31660d8705facdadeb8598d2c0bd008e8142c54e3b3069abd392c8d58997",
   "SYSLOG_PID":"14314",
   "_PID":"14314",
   "MESSAGE":"time=\"2020-02-21T10:31:27.810781647Z\" level=info msg=\"release sandbox\" arch=amd64 command=state container=7cdd31660d8705facdadeb8598d2c0bd008e8142c54e3b3069abd392c8d58997 name=kata-runtime pid=14314 sandbox=1c3e77cad66aa2b6d8cc846f818370f79cb0104c0b840f67d0f502fd6562b68c source=virtcontainers subsystem=sandbox",
@@ -281,7 +281,7 @@ own file (rather than into the system journal).
 
 ```bash
 #!/bin/bash
-/opt/kata/bin/kata-runtime --kata-config "/opt/kata/share/defaults/kata-containers/configuration-qemu.toml" --log-format=json --log=/var/log/kata-runtime.log $@
+/opt/kata/bin/kata-runtime --config "/opt/kata/share/defaults/kata-containers/configuration-qemu.toml" --log-format=json --log=/var/log/kata-runtime.log $@
 ```
 
 And then we'll add the Fluentd config section to parse that file. Note, we inform the parser that Kata is

--- a/docs/how-to/how-to-import-kata-logs-with-fluentd.md
+++ b/docs/how-to/how-to-import-kata-logs-with-fluentd.md
@@ -185,7 +185,7 @@ in Kibana:
 ![Kata tags in EFK](./images/efk_syslog_entry_detail.png).
 
 We can however further sub-parse the Kata entries using the
-[Fluentd plugins](https://docs.fluentbit.io/manual/parser/logfmt) that will parse
+[Fluentd plugins](https://docs.fluentbit.io/manual/pipeline/parsers/logfmt) that will parse
 `logfmt` formatted data. We can utilise these to parse the sub-fields using a Fluentd filter
 section. At the same time, we will prefix the new fields with `kata_` to make it clear where
 they have come from:

--- a/docs/how-to/how-to-use-kata-containers-with-acrn.md
+++ b/docs/how-to/how-to-use-kata-containers-with-acrn.md
@@ -91,7 +91,7 @@ To configure Kata Containers with ACRN, copy the generated `configuration-acrn.t
 The following command shows full paths to the `configuration.toml` files that the runtime loads. It will use the first path that exists. (Please make sure the kernel and image paths are set correctly in the `configuration.toml` file)
 
 ```bash
-$ sudo kata-runtime --kata-show-default-config-paths
+$ sudo kata-runtime --show-default-config-paths
 ```
 
 >**Warning:** Please offline CPUs using [this](offline_cpu.sh) script, else VM launches will fail.

--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -129,14 +129,14 @@ The below command lists the full paths to the configuration files that the
 runtime attempts to load. The first path that exists will be used:
 
 ```bash
-$ kata-runtime --kata-show-default-config-paths
+$ kata-runtime --show-default-config-paths
 ```
 
 Aside from the built-in locations, it is possible to specify the path to a
-custom configuration file using the `--kata-config` option:
+custom configuration file using the `--config` option:
 
 ```bash
-$ kata-runtime --kata-config=/some/where/configuration.toml ...
+$ kata-runtime --config=/some/where/configuration.toml ...
 ```
 
 The runtime will log the full path to the configuration file it is using. See

--- a/src/runtime/cli/config-generated.go.in
+++ b/src/runtime/cli/config-generated.go.in
@@ -9,10 +9,6 @@
 // by the tests.
 package main
 
-import (
-	"fmt"
-)
-
 // name is the name of the runtime
 const name = "@RUNTIME_NAME@"
 
@@ -35,10 +31,6 @@ var commit = "@COMMIT@"
 
 // version is the runtime version.
 var version = "@VERSION@"
-
-// project-specific option names
-var configFilePathOption = fmt.Sprintf("%s-config", projectPrefix)
-var showConfigPathsOption = fmt.Sprintf("%s-show-default-config-paths", projectPrefix)
 
 // Default config file used by stateless systems.
 var defaultRuntimeConfiguration = "@CONFIG_PATH@"

--- a/src/runtime/cli/main.go
+++ b/src/runtime/cli/main.go
@@ -84,8 +84,8 @@ var defaultErrorFile = os.Stderr
 // runtimeFlags is the list of supported global command-line flags
 var runtimeFlags = []cli.Flag{
 	cli.StringFlag{
-		Name:  configFilePathOption,
-		Usage: project + " config file path",
+		Name:    "config, kata-config",
+		Usage:   project + " config file path",
 	},
 	cli.StringFlag{
 		Name:  "log",
@@ -108,8 +108,8 @@ var runtimeFlags = []cli.Flag{
 		Usage: "ignore cgroup permission errors ('true', 'false', or 'auto')",
 	},
 	cli.BoolFlag{
-		Name:  showConfigPathsOption,
-		Usage: "show config file paths that will be checked for (in order)",
+		Name:    "show-default-config-paths, kata-show-default-config-paths",
+		Usage:   "show config file paths that will be checked for (in order)",
 	},
 	cli.BoolFlag{
 		Name:  "systemd-cgroup",
@@ -319,7 +319,7 @@ func beforeSubcommands(c *cli.Context) error {
 		}
 	}
 
-	configFile, runtimeConfig, err = katautils.LoadConfiguration(c.GlobalString(configFilePathOption), ignoreConfigLogs, false)
+	configFile, runtimeConfig, err = katautils.LoadConfiguration(c.GlobalString("config"), ignoreConfigLogs, false)
 	if err != nil {
 		fatal(err)
 	}
@@ -366,7 +366,7 @@ func beforeSubcommands(c *cli.Context) error {
 // handleShowConfig determines if the user wishes to see the configuration
 // paths. If so, it will display them and then exit.
 func handleShowConfig(context *cli.Context) {
-	if context.GlobalBool(showConfigPathsOption) {
+	if context.GlobalBool("show-default-config-paths") {
 		files := katautils.GetDefaultConfigFilePaths()
 
 		for _, file := range files {

--- a/src/runtime/cli/main_test.go
+++ b/src/runtime/cli/main_test.go
@@ -671,7 +671,7 @@ func TestMainBeforeSubCommandsShowCCConfigPaths(t *testing.T) {
 	defer os.RemoveAll(tmpdir)
 
 	set := flag.NewFlagSet("", 0)
-	set.Bool("kata-show-default-config-paths", true, "")
+	set.Bool("show-default-config-paths", true, "")
 
 	ctx := createCLIContext(set)
 

--- a/tools/packaging/release/kata-deploy-binaries.sh
+++ b/tools/packaging/release/kata-deploy-binaries.sh
@@ -218,25 +218,25 @@ install_kata_components() {
 	pushd "${destdir}/${prefix}/bin"
 	cat <<EOT | sudo tee kata-fc
 #!/bin/bash
-${prefix}/bin/kata-runtime --kata-config "${prefix}/share/defaults/${project}/configuration-fc.toml" \$@
+${prefix}/bin/kata-runtime --config "${prefix}/share/defaults/${project}/configuration-fc.toml" \$@
 EOT
 	sudo chmod +x kata-fc
 
 	cat <<EOT | sudo tee kata-qemu
 #!/bin/bash
-${prefix}/bin/kata-runtime --kata-config "${prefix}/share/defaults/${project}/configuration-qemu.toml" \$@
+${prefix}/bin/kata-runtime --config "${prefix}/share/defaults/${project}/configuration-qemu.toml" \$@
 EOT
 	sudo chmod +x kata-qemu
 
 	cat <<EOT | sudo tee kata-clh
 #!/bin/bash
-${prefix}/bin/kata-runtime --kata-config "${prefix}/share/defaults/${project}/configuration-clh.toml" \$@
+${prefix}/bin/kata-runtime --config "${prefix}/share/defaults/${project}/configuration-clh.toml" \$@
 EOT
 	sudo chmod +x kata-clh
 
 	cat <<EOT | sudo tee kata-qemu-virtiofs
 #!/bin/bash
-${prefix}/bin/kata-runtime --kata-config "${prefix}/share/defaults/${project}/configuration-qemu-virtiofs.toml" \$@
+${prefix}/bin/kata-runtime --config "${prefix}/share/defaults/${project}/configuration-qemu-virtiofs.toml" \$@
 EOT
 	sudo chmod +x kata-qemu-virtiofs
 

--- a/tools/packaging/static-build/scripts/kata-configure-docker.sh
+++ b/tools/packaging/static-build/scripts/kata-configure-docker.sh
@@ -81,7 +81,7 @@ configure_docker()
 			--arg config "$config" \
 			--arg runtime "$runtime" \
 			--arg runtime_path "$runtime_path" \
-			'.runtimes[$runtime] = {path: $runtime_path, "runtimeArgs": ["--kata-config", $config]}')
+			'.runtimes[$runtime] = {path: $runtime_path, "runtimeArgs": ["--config", $config]}')
 
 		echo "$result" > "$docker_config_file"
 	done


### PR DESCRIPTION
Change `--kata-config` and --kata-show-default-config-paths` to be prefixless, but keep the old option as alias.