### PR TITLE
versions: Update crio version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -179,7 +179,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    version: "v1.18.3"
+    version: "v1.18.4"
     meta:
       openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
       crictl: 1.0.0-beta.2


### PR DESCRIPTION
This PR updates the crio version from 1.18.3 to 1.18.4 in order to include
the fix https://github.com/cri-o/cri-o/pull/4284.

Fixes #1036

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>