### PR TITLE
runtime: cloud-hypervisor: reduce memory footprint

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -133,7 +133,7 @@ var clhKernelParams = []Param{
 	{"panic", "1"},         // upon kernel panic wait 1 second before reboot
 	{"no_timer_check", ""}, // do not check broken timer IRQ resources
 	{"noreplace-smp", ""},  // do not replace SMP instructions
-	{"rootflags", "data=ordered,errors=remount-ro ro"}, // mount the root filesystem as readonly
+	{"rootflags", "dax,data=ordered,errors=remount-ro ro"}, // mount the root filesystem as readonly
 	{"rootfstype", "ext4"},
 }
 


### PR DESCRIPTION
Cloud-hypervisor supports DAX, let's enable it to reduce its memory
footprint.

Before this patch:

**19.96M**

```
20448kB -- [/usr/share/kata-containers/kata.img]
```

With this patch:

**10.83M**

```
11100kB -- [/usr/share/kata-containers/kata.img]
```

fixes #1056

Signed-off-by: Julio Montes <julio.montes@intel.com>