### PR TITLE
runtime: readonly volume should be bind mounted readonly on the host

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -470,7 +470,7 @@ func (c *Container) shareFiles(m Mount, idx int, hostSharedDir, guestSharedDir s
 	} else {
 		// These mounts are created in the shared dir
 		mountDest := filepath.Join(hostSharedDir, filename)
-		if err := bindMount(c.ctx, m.Source, mountDest, false, "private"); err != nil {
+		if err := bindMount(c.ctx, m.Source, mountDest, m.ReadOnly, "private"); err != nil {
 			return "", false, err
 		}
 		// Save HostPath mount value into the mount list of the container.
@@ -546,22 +546,12 @@ func (c *Container) mountSharedDirMounts(hostSharedDir, guestSharedDir string) (
 			continue
 		}
 
-		// Check if mount is readonly, let the agent handle the readonly mount
-		// within the VM.
-		readonly := false
-		for _, flag := range m.Options {
-			if flag == "ro" {
-				readonly = true
-				break
-			}
-		}
-
 		sharedDirMount := Mount{
 			Source:      guestDest,
 			Destination: m.Destination,
 			Type:        m.Type,
 			Options:     m.Options,
-			ReadOnly:    readonly,
+			ReadOnly:    m.ReadOnly,
 		}
 
 		sharedDirMounts[sharedDirMount.Destination] = sharedDirMount

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1256,7 +1256,7 @@ func (k *kataAgent) createContainer(sandbox *Sandbox, c *Container) (p *Process,
 	}
 
 	// Handle container mounts
-	newMounts, ignoredMounts, err := c.mountSharedDirMounts(getMountPath(sandbox.id), kataGuestSharedDir())
+	newMounts, ignoredMounts, err := c.mountSharedDirMounts(getSharePath(sandbox.id), getMountPath(sandbox.id), kataGuestSharedDir())
 	if err != nil {
 		return nil, err
 	}

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -277,6 +277,11 @@ func remount(ctx context.Context, mountflags uintptr, src string) error {
 	return nil
 }
 
+// remount a mount point as readonly
+func remountRo(ctx context.Context, src string) error {
+	return remount(ctx, syscall.MS_BIND|syscall.MS_RDONLY, src)
+}
+
 // bindMountContainerRootfs bind mounts a container rootfs into a 9pfs shared
 // directory between the guest and the host.
 func bindMountContainerRootfs(ctx context.Context, shareDir, cid, cRootFs string, readonly bool) error {

--- a/src/runtime/virtcontainers/pkg/oci/utils.go
+++ b/src/runtime/virtcontainers/pkg/oci/utils.go
@@ -160,11 +160,19 @@ func cmdEnvs(spec specs.Spec, envs []types.EnvVar) []types.EnvVar {
 }
 
 func newMount(m specs.Mount) vc.Mount {
+	readonly := false
+	for _, flag := range m.Options {
+		if flag == "ro" {
+			readonly = true
+			break
+		}
+	}
 	return vc.Mount{
 		Source:      m.Source,
 		Destination: m.Destination,
 		Type:        m.Type,
 		Options:     m.Options,
+		ReadOnly:    readonly,
 	}
 }
 

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -1175,7 +1175,7 @@ func TestPreAddDevice(t *testing.T) {
 		},
 	}
 
-	mounts, ignoreMounts, err := container.mountSharedDirMounts("", "")
+	mounts, ignoreMounts, err := container.mountSharedDirMounts("", "", "")
 	assert.Nil(t, err)
 	assert.Equal(t, len(mounts), 0,
 		"mounts should contain nothing because it only contains a block device")

--- a/versions.yaml
+++ b/versions.yaml
@@ -179,7 +179,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    version: "v1.18.4"
+    version: "v1.18.3"
     meta:
       openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
       crictl: 1.0.0-beta.2


### PR DESCRIPTION
So that even if the guest is compromised, we still ensure that readonly volumes cannot be modified.