### PR TITLE
[dnm] test vfio CI

### DIFF
--- a/src/runtime/cli/config/configuration-qemu.toml.in
+++ b/src/runtime/cli/config/configuration-qemu.toml.in
@@ -120,8 +120,8 @@ default_memory = @DEFMEMSZ@
 disable_block_device_use = @DEFDISABLEBLOCK@
 
 # Shared file system type:
-#   - virtio-9p (default)
-#   - virtio-fs
+#   - virtio-fs (default)
+#   - virtio-9p
 shared_fs = "@DEFSHAREDFS_QEMU_VIRTIOFS@"
 
 # Path to vhost-user-fs daemon.


### PR DESCRIPTION
Correct the default configuration of [hypervisor.qemu] shared_fs in configuration-qemu.toml to virtio-fs in kata 2.0.

Fixes: #1054

Signed-off-by: AIsland <yuchunyu01@inspur.com>