### PR TITLE
docs: Add instructions for enabling VM templating

### DIFF
--- a/docs/how-to/what-is-vm-templating-and-how-do-I-use-it.md
+++ b/docs/how-to/what-is-vm-templating-and-how-do-I-use-it.md
@@ -46,6 +46,7 @@ overridden by `/etc/kata-containers/configuration.toml` if provided) such that:
   - `enable_template = true`
   - `initrd =` is set
   - `image =` option is commented out or removed
+  - `shared_fs` should not be `virtio-fs`
 
 Then you can create a VM templating for later usage by calling
 ```


### PR DESCRIPTION
Kata 2.0 uses virtio-fs as the shared_fs by default, bug VM templating cannot be used with virtio-fs.

Fixes: #1091

Signed-off-by: AIsland <yuchunyu01@inspur.com>