### PR TITLE
Revert "version: revert back to crio 1.8.3"

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -179,7 +179,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    version: "v1.18.3"
+    version: "v1.18.4"
     meta:
       openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
       crictl: 1.0.0-beta.2


### PR DESCRIPTION
This reverts commit ff13bde3c1bd03b5ed0c93e7ea315befd24a75b7, which
moved back CRI-O to v1.18.3.

This was, IMHO, a little bit premature.  We want to know exactly what are
the issues on v1.18.4, solve those, and be prepared for a v1.18.5 bump
(or even a bump to a specific commit, if needed).

Just for the sake of the completeness, v1.18.4 caused a regression on
"k8s-copy-file" tests, which is tracked on CRI-O side as
https://github.com/cri-o/cri-o/issues/4353.

Fixes: #1080

/cc @bergwolf 