### PR TITLE
versions: Use release-1.18 (commit ee9128444bec10)

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -179,7 +179,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    version: "v1.18.4"
+    version: "v1.18.4-2-gee9128444"
     meta:
       openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
       crictl: 1.0.0-beta.2


### PR DESCRIPTION
Let's update CRI-O version to the commit which introduced the fix for
the "k8s-copy-file" tests.

Fixes: #1080

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>