### PR TITLE
release: Fix release candidate to major version upgrade check

### DIFF
--- a/src/runtime/cli/release.go
+++ b/src/runtime/cli/release.go
@@ -322,7 +322,7 @@ func getNewReleaseType(current semver.Version, latest semver.Version) (string, e
 	} else if latest.Patch == current.Patch && len(latest.Pre) > 0 {
 		desc = "pre-release"
 	} else {
-		return "", fmt.Errorf("BUG: unhandled scenario: current version: %s, latest version: %v", current, latest)
+		return "", fmt.Errorf("BUG: unhandled scenario: current version: %s, latest version: %s", current, latest)
 	}
 
 	return desc, nil

--- a/src/runtime/cli/release.go
+++ b/src/runtime/cli/release.go
@@ -321,6 +321,12 @@ func getNewReleaseType(current semver.Version, latest semver.Version) (string, e
 		}
 	} else if latest.Patch == current.Patch && len(latest.Pre) > 0 {
 		desc = "pre-release"
+	} else if latest.Major == current.Major &&
+		latest.Minor == current.Minor &&
+		latest.Patch == current.Patch {
+		if len(current.Pre) > 0 && len(latest.Pre) == 0 {
+			desc = "major"
+		}
 	} else {
 		return "", fmt.Errorf("BUG: unhandled scenario: current version: %s, latest version: %s", current, latest)
 	}

--- a/src/runtime/cli/release_test.go
+++ b/src/runtime/cli/release_test.go
@@ -488,6 +488,12 @@ func TestGetNewReleaseType(t *testing.T) {
 		{"1.0.0", "1.0.3", false, "patch"},
 		{"1.0.0-beta29", "1.0.0-beta30", false, "pre-release"},
 		{"1.0.0", "1.0.3-alpha99.1b", false, "patch pre-release"},
+
+		{"2.0.0-rc0", "2.0.0", false, "major"},
+		{"2.0.0-rc1", "2.0.0", false, "major"},
+
+		{"1.12.0-rc0", "1.12.0", false, "major"},
+		{"1.12.0-rc5", "1.12.0", false, "major"},
 	}
 
 	for i, d := range data {

--- a/src/runtime/cli/release_test.go
+++ b/src/runtime/cli/release_test.go
@@ -458,6 +458,21 @@ func TestGetNewReleaseType(t *testing.T) {
 	}
 
 	data := []testData{
+		// Check build metadata (ignored for version comparisions)
+		{"2.0.0+build", "2.0.0", true, ""},
+		{"2.0.0+build-1", "2.0.0+build-2", true, ""},
+		{"1.12.0+build", "1.12.0", true, ""},
+
+		{"2.0.0-rc3+foo", "2.0.0", false, "major"},
+		{"2.0.0-rc3+foo", "2.0.0-rc4", false, "pre-release"},
+		{"1.12.0+foo", "1.13.0", false, "minor"},
+
+		{"1.12.0+build", "2.0.0", false, "major"},
+		{"1.12.0+build", "1.13.0", false, "minor"},
+		{"1.12.0-rc2+build", "1.12.1", false, "patch"},
+		{"1.12.0-rc2+build", "1.12.1-foo", false, "patch pre-release"},
+		{"1.12.0-rc4+wibble", "1.12.0", false, "major"},
+
 		{"2.0.0-alpha3", "1.0.0", true, ""},
 		{"1.0.0", "1.0.0", true, ""},
 		{"2.0.0", "1.0.0", true, ""},


### PR DESCRIPTION
Fix `kata-runtime kata-check`'s network version check which was failing
when the user was running a release candidate build and the latest
release was a major one, two examples of the error being:

- `BUG: unhandled scenario: current version: 1.12.0-rc0, latest version: 1.12.0`
- `BUG: unhandled scenario: current version: 2.0.0-rc0, latest version: 2.0.0`

Fixes: #1104.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>