### PR TITLE
agent: Adjust OOM Score to avoid agent being killed.

### DIFF
--- a/src/agent/kata-agent.service.in
+++ b/src/agent/kata-agent.service.in
@@ -20,3 +20,5 @@ LimitNOFILE=infinity
 # the runtime handles shutting down the VM.
 ExecStop=/bin/sync ; /usr/bin/systemctl --force poweroff
 FailureAction=poweroff
+# Discourage OOM-killer from touching the agent
+OOMScoreAdjust=-997


### PR DESCRIPTION
Under stress, the agent can be OOM-killed, which exists the sandbox.
One possible hard-to-diagnose manifestation is a virtiofsd crash.

Fixes: #1111

Reported-by: Qian Cai <caiqian@redhat.com>
Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>