### PR TITLE
versions: Use CRI-O v1.18.4-4-g6dee3891e

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -179,7 +179,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    version: "v1.18.4-2-gee9128444"
+    version: "v1.18.4-4-g6dee3891e"
     meta:
       openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
       crictl: 1.0.0-beta.2


### PR DESCRIPTION
This (unreleased) version of CRI-O brings in the possibility of enabling
the `k8s-oom.bats` test.

Depends-on: https://github.com/kata-containers/tests#3060

Fixes: #1116

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>