### PR TITLE
virtcontainers: revert CleanupContainer from PR 1079

### DIFF
--- a/src/runtime/containerd-shim-v2/service.go
+++ b/src/runtime/containerd-shim-v2/service.go
@@ -312,17 +312,17 @@ func (s *service) Cleanup(ctx context.Context) (_ *taskAPI.DeleteResponse, err e
 
 	switch containerType {
 	case vc.PodSandbox:
-		err = cleanupContainer(ctx, s.sandbox, s.id, path)
+		err = cleanupContainer(ctx, s.id, s.id, path)
 		if err != nil {
 			return nil, err
 		}
 	case vc.PodContainer:
-		_, err := oci.SandboxID(ociSpec)
+		sandboxID, err := oci.SandboxID(ociSpec)
 		if err != nil {
 			return nil, err
 		}
 
-		err = cleanupContainer(ctx, s.sandbox, s.id, path)
+		err = cleanupContainer(ctx, sandboxID, s.id, path)
 		if err != nil {
 			return nil, err
 		}

--- a/src/runtime/containerd-shim-v2/utils.go
+++ b/src/runtime/containerd-shim-v2/utils.go
@@ -31,10 +31,10 @@ func cReap(s *service, status int, id, execid string, exitat time.Time) {
 	}
 }
 
-func cleanupContainer(ctx context.Context, sandbox vc.VCSandbox, cid, bundlePath string) error {
+func cleanupContainer(ctx context.Context, sandboxID, cid, bundlePath string) error {
 	shimLog.WithField("service", "cleanup").WithField("container", cid).Info("Cleanup container")
 
-	err := vci.CleanupContainer(ctx, sandbox, cid, true)
+	err := vci.CleanupContainer(ctx, sandboxID, cid, true)
 	if err != nil {
 		shimLog.WithError(err).WithField("container", cid).Warn("failed to cleanup container")
 		return err

--- a/src/runtime/virtcontainers/api_test.go
+++ b/src/runtime/virtcontainers/api_test.go
@@ -307,7 +307,7 @@ func TestCleanupContainer(t *testing.T) {
 	}
 
 	for _, c := range p.GetAllContainers() {
-		CleanupContainer(ctx, p, c.ID(), true)
+		CleanupContainer(ctx, p.ID(), c.ID(), true)
 	}
 
 	s, ok := p.(*Sandbox)

--- a/src/runtime/virtcontainers/implementation.go
+++ b/src/runtime/virtcontainers/implementation.go
@@ -38,6 +38,6 @@ func (impl *VCImpl) CreateSandbox(ctx context.Context, sandboxConfig SandboxConf
 // CleanupContainer is used by shimv2 to stop and delete a container exclusively, once there is no container
 // in the sandbox left, do stop the sandbox and delete it. Those serial operations will be done exclusively by
 // locking the sandbox.
-func (impl *VCImpl) CleanupContainer(ctx context.Context, sandbox VCSandbox, containerID string, force bool) error {
-	return CleanupContainer(ctx, sandbox, containerID, force)
+func (impl *VCImpl) CleanupContainer(ctx context.Context, sandboxID, containerID string, force bool) error {
+	return CleanupContainer(ctx, sandboxID, containerID, force)
 }

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -24,7 +24,7 @@ type VC interface {
 	SetFactory(ctx context.Context, factory Factory)
 
 	CreateSandbox(ctx context.Context, sandboxConfig SandboxConfig) (VCSandbox, error)
-	CleanupContainer(ctx context.Context, sandbox VCSandbox, containerID string, force bool) error
+	CleanupContainer(ctx context.Context, sandboxID, containerID string, force bool) error
 }
 
 // VCSandbox is the Sandbox interface

--- a/src/runtime/virtcontainers/pkg/vcmock/mock.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/mock.go
@@ -50,9 +50,9 @@ func (m *VCMock) CreateSandbox(ctx context.Context, sandboxConfig vc.SandboxConf
 	return nil, fmt.Errorf("%s: %s (%+v): sandboxConfig: %v", mockErrorPrefix, getSelf(), m, sandboxConfig)
 }
 
-func (m *VCMock) CleanupContainer(ctx context.Context, sandbox vc.VCSandbox, containerID string, force bool) error {
+func (m *VCMock) CleanupContainer(ctx context.Context, sandboxID, containerID string, force bool) error {
 	if m.CleanupContainerFunc != nil {
-		return m.CleanupContainerFunc(ctx, sandbox, containerID, true)
+		return m.CleanupContainerFunc(ctx, sandboxID, containerID, true)
 	}
-	return fmt.Errorf("%s: %s (%+v): sandbox: %v", mockErrorPrefix, getSelf(), m, sandbox)
+	return fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }

--- a/src/runtime/virtcontainers/pkg/vcmock/mock_test.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/mock_test.go
@@ -17,13 +17,13 @@ import (
 )
 
 const (
+	testSandboxID   = "testSandboxID"
 	testContainerID = "testContainerID"
 )
 
 var (
-	loggerTriggered               = 0
-	factoryTriggered              = 0
-	testSandbox      vc.VCSandbox = &Sandbox{}
+	loggerTriggered  = 0
+	factoryTriggered = 0
 )
 
 func TestVCImplementations(t *testing.T) {
@@ -178,21 +178,21 @@ func TestVCMockCleanupContainer(t *testing.T) {
 	assert.Nil(m.CleanupContainerFunc)
 
 	ctx := context.Background()
-	err := m.CleanupContainer(ctx, testSandbox, testContainerID, false)
+	err := m.CleanupContainer(ctx, testSandboxID, testContainerID, false)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.CleanupContainerFunc = func(ctx context.Context, sandbox vc.VCSandbox, containerID string, force bool) error {
+	m.CleanupContainerFunc = func(ctx context.Context, sandboxID, containerID string, force bool) error {
 		return nil
 	}
 
-	err = m.CleanupContainer(ctx, testSandbox, testContainerID, false)
+	err = m.CleanupContainer(ctx, testSandboxID, testContainerID, false)
 	assert.NoError(err)
 
 	// reset
 	m.CleanupContainerFunc = nil
 
-	err = m.CleanupContainer(ctx, testSandbox, testContainerID, false)
+	err = m.CleanupContainer(ctx, testSandboxID, testContainerID, false)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }
@@ -204,21 +204,21 @@ func TestVCMockForceCleanupContainer(t *testing.T) {
 	assert.Nil(m.CleanupContainerFunc)
 
 	ctx := context.Background()
-	err := m.CleanupContainer(ctx, testSandbox, testContainerID, true)
+	err := m.CleanupContainer(ctx, testSandboxID, testContainerID, true)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 
-	m.CleanupContainerFunc = func(ctx context.Context, sandbox vc.VCSandbox, containerID string, force bool) error {
+	m.CleanupContainerFunc = func(ctx context.Context, sandboxID, containerID string, force bool) error {
 		return nil
 	}
 
-	err = m.CleanupContainer(ctx, testSandbox, testContainerID, true)
+	err = m.CleanupContainer(ctx, testSandboxID, testContainerID, true)
 	assert.NoError(err)
 
 	// reset
 	m.CleanupContainerFunc = nil
 
-	err = m.CleanupContainer(ctx, testSandbox, testContainerID, true)
+	err = m.CleanupContainer(ctx, testSandboxID, testContainerID, true)
 	assert.Error(err)
 	assert.True(IsMockError(err))
 }

--- a/src/runtime/virtcontainers/pkg/vcmock/types.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/types.go
@@ -88,5 +88,5 @@ type VCMock struct {
 	SetFactoryFunc func(ctx context.Context, factory vc.Factory)
 
 	CreateSandboxFunc    func(ctx context.Context, sandboxConfig vc.SandboxConfig) (vc.VCSandbox, error)
-	CleanupContainerFunc func(ctx context.Context, sandbox vc.VCSandbox, containerID string, force bool) error
+	CleanupContainerFunc func(ctx context.Context, sandboxID, containerID string, force bool) error
 }


### PR DESCRIPTION
In PR 1079, CleanupContainer's parameter of sandboxID is changed to VCSandbox, but at cleanup,
there is no VCSandbox is constructed, we should load it from disk by loadSandboxConfig() in
persist.go. This commit reverts parts of #1079

Fixes: #1119

Signed-off-by: bin liu <bin@hyper.sh>