### PR TITLE
Add hyperlink and fix typo

### DIFF
--- a/docs/design/virtualization.md
+++ b/docs/design/virtualization.md
@@ -62,7 +62,7 @@ be changed by editing the runtime [`configuration`](./architecture.md/#configura
 Devices and features used:
 - virtio VSOCK or virtio serial
 - virtio block or virtio SCSI
-- virtio net
+- [virtio net](https://www.redhat.com/en/virtio-networking-series)
 - virtio fs or virtio 9p (recommend: virtio fs)
 - VFIO
 - hotplug

--- a/docs/design/virtualization.md
+++ b/docs/design/virtualization.md
@@ -22,10 +22,10 @@ the multiple hypervisors and virtual machine monitors that Kata supports.
 ## Mapping container concepts to virtual machine technologies
 
 A typical deployment of Kata Containers will be in Kubernetes by way of a Container Runtime Interface (CRI) implementation. On every node,
-Kubelet will interact with a CRI implementor (such as containerd or CRI-O), which will in turn interface with Kata Containers (an OCI based runtime).
+Kubelet will interact with a CRI implementer (such as containerd or CRI-O), which will in turn interface with Kata Containers (an OCI based runtime).
 
 The CRI API, as defined at the [Kubernetes CRI-API repo](https://github.com/kubernetes/cri-api/), implies a few constructs being supported by the
-CRI implementation, and ultimately in Kata Containers. In order to support the full [API](https://github.com/kubernetes/cri-api/blob/a6f63f369f6d50e9d0886f2eda63d585fbd1ab6a/pkg/apis/runtime/v1alpha2/api.proto#L34-L110) with the CRI-implementor, Kata must provide the following constructs:
+CRI implementation, and ultimately in Kata Containers. In order to support the full [API](https://github.com/kubernetes/cri-api/blob/a6f63f369f6d50e9d0886f2eda63d585fbd1ab6a/pkg/apis/runtime/v1alpha2/api.proto#L34-L110) with the CRI-implementer, Kata must provide the following constructs:
 
 ![API to construct](./arch-images/api-to-construct.png)
 


### PR DESCRIPTION
This is a PR with two fixes by Ariel Adam. It supersedes #855 which was failing due to the typo.

commit 8ec3cf08f3928d3e7ef03a5d9c67e837730d37ba (HEAD -> docs/855-hyperlinks, c3d/docs/855-hyperlinks)
Author: Ariel Adam <aadam@redhat.com>
Date:   Wed Aug 26 20:22:36 2020 +0300

    docs: Adding hyperlink to virtio-net in kata documentation 2.0
    
    Referring virtio-net mentioning in the kata virtualization
    documentation to the virtio-networking blog series published
    and explaining how it works.
    
    Fixes #612
    
    Signed-off-by: Ariel Adam <aadam@redhat.com>

commit b5b67db8d727c0003e2ec69bc40c7f938e69a8a5
Author: Ariel Adam <aadam@redhat.com>
Date:   Mon Oct 12 15:36:16 2020 +0300

    docs: Fixing typo in virtualization.md file
    
    Changing "implementor" to "implementer"
    
    Fixes: #612
    
    Signed-off-by: Ariel Adam <aadam@redhat.com>
    Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>

