### PR TITLE
snap: update apps section

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -310,4 +310,8 @@ parts:
 
 apps:
   runtime:
+    command: usr/bin/kata-runtime
+  shim:
     command: usr/bin/containerd-shim-kata-v2
+  collect-data:
+    command: usr/bin/kata-collect-data.sh


### PR DESCRIPTION
Add `kata-runtime` and `kata-collect-data.sh` commands to the apps
section, these two command will be accessible through the commands
`kata-containers.runtime` and `kata-containers.collect-data`
respectively.
Henceforth the snap command for `containerd-shim-kata-v2` will be
`kata-containers.shim`

fixes #1122

Signed-off-by: Julio Montes <julio.montes@intel.com>