### PR TITLE
agent: enable lto flag for Cargo to get better optimized code

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -46,3 +46,6 @@ members = [
     "protocols",
     "rustjail",
 ]
+
+[profile.release]
+lto = true


### PR DESCRIPTION
The lto setting controls the -C lto flag which controls LLVM's link time optimizations.
LTO can produce better optimized code, using whole-program analysis,
at the cost of longer linking time.

https://doc.rust-lang.org/cargo/reference/profiles.html#lto

Fixes: #1125

Signed-off-by: bin liu <bin@hyper.sh>