### PR TITLE
runtime: don't wait the second shim process in shim start

### DIFF
--- a/src/runtime/containerd-shim-v2/service.go
+++ b/src/runtime/containerd-shim-v2/service.go
@@ -215,8 +215,6 @@ func (s *service) StartShim(ctx context.Context, id, containerdBinary, container
 		}
 	}()
 
-	// make sure to wait after start
-	go cmd.Wait()
 	if err = cdshim.WritePidFile("shim.pid", cmd.Process.Pid); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
In first shim v2 startup(with `start` command-line option), it will start
the second shim v2 process running as ttrpc server, there is no needs to
wait the second process, because the current shim v2 process will exit immediately.

Fixes: #1127

Signed-off-by: bin liu <bin@hyper.sh>