### PR TITLE
kata-monitor: allow for building for alpine

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -605,8 +605,8 @@ $(SHIMV2_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
 	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build $(KATA_LDFLAGS) $(BUILDFLAGS) -o $@ .)
 
 $(MONITOR_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) .git-commit
-	$(QUIET_BUILD)(cd $(MONITOR_DIR)/ && go build \
-		--ldflags "-X main.GitCommit=$(shell cat .git-commit)" -o $@ .)
+	$(QUIET_BUILD)(cd $(MONITOR_DIR)/ && CGO_ENABLED=0 go build \
+		--ldflags "-X main.GitCommit=$(shell cat .git-commit)" $(BUILDFLAGS) -o $@ .)
 
 .PHONY: \
 	check \

--- a/tools/packaging/kata-monitor/Dockerfile
+++ b/tools/packaging/kata-monitor/Dockerfile
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+
+FROM golang:1.15-alpine
+
+RUN apk add bash curl git make
+WORKDIR /go/src/github.com/kata-containers/kata-containers/src/runtime
+COPY . /go/src/github.com/kata-containers/kata-containers
+RUN SKIP_GO_VERSION_CHECK=true make monitor
+
+FROM alpine:latest
+COPY --from=0 /go/src/github.com/kata-containers/kata-containers/src/runtime/kata-monitor /usr/bin/kata-monitor
+CMD ["-h"]
+ENTRYPOINT ["/usr/bin/kata-monitor"]


### PR DESCRIPTION
- add a reference Dockerfile to tools
- update kata-monitor build to:
  1) utilize the kata buildflags, which were dropped before
  2) disable CGO, so we have option for building in alpine

From root of the repository, example build:
 $ docker build -f tools/packaging/kata-monitor/Dockerfile -t kata-monitor .

Fixes: #1135