### PR TITLE
rustjail: remove the network ns validation against container

### DIFF
--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -188,19 +188,6 @@ fn sysctl(oci: &Spec) -> Result<()> {
             }
         }
 
-        if key.starts_with("net.") {
-            if !contain_namespace(&linux.namespaces, "network") {
-                return Err(anyhow!(nix::Error::from_errno(Errno::EINVAL)));
-            }
-
-            let net = get_namespace_path(&linux.namespaces, "network")?;
-            if net.is_empty() || net == "" {
-                continue;
-            }
-
-            check_host_ns(net.as_str())?;
-        }
-
         if contain_namespace(&linux.namespaces, "uts") {
             if key == "kernel.domainname" {
                 continue;


### PR DESCRIPTION
Since kata containers shared the network ns with
the guest system, thus there's no need to do the
network ns check.

Fixes: #1047

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>