### PR TITLE
Add void "install" targets for both "trace-forwarder" and "agent-ctl"

### DIFF
--- a/src/trace-forwarder/Makefile
+++ b/src/trace-forwarder/Makefile
@@ -13,10 +13,13 @@ clean:
 
 test:
 
+install:
+
 check:
 
 .PHONY: \
 	build \
 	test \
 	check \
+	install \
 	clean

--- a/tools/agent-ctl/Makefile
+++ b/tools/agent-ctl/Makefile
@@ -13,10 +13,13 @@ clean:
 
 test:
 
+install: 
+
 check:
 
 .PHONY: \
 	build \
 	test \
 	check \
+	install \
 	clean


### PR DESCRIPTION
These simple patches allow us to do a `make install` from the top directory without any issue.

Fixes: #1149