### PR TITLE
handle vcpus properly utilized in the guest

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -1018,11 +1018,11 @@ impl Manager {
         })
     }
 
-    pub fn update_cpuset_path(&self, cpuset_cpus: &str) -> Result<()> {
-        if cpuset_cpus == "" {
+    pub fn update_cpuset_path(&self, guest_cpuset: &str, container_cpuset: &str) -> Result<()> {
+        if guest_cpuset == "" {
             return Ok(());
         }
-        info!(sl!(), "update_cpuset_path to: {}", cpuset_cpus);
+        info!(sl!(), "update_cpuset_path to: {}", guest_cpuset);
 
         let h = cgroups::hierarchies::auto();
         let h = Box::new(&*h);
@@ -1036,8 +1036,8 @@ impl Manager {
         let h = cgroups::hierarchies::auto();
         let h = Box::new(&*h);
         let cg = load_or_create(h, &self.cpath);
-        let cpuset_controller: &CpuSetController = cg.controller_of().unwrap();
-        let path = cpuset_controller.path();
+        let container_cpuset_controller: &CpuSetController = cg.controller_of().unwrap();
+        let path = container_cpuset_controller.path();
         let container_path = Path::new(path);
         info!(sl!(), "container cpuset path: {:?}", &path);
 
@@ -1046,11 +1046,9 @@ impl Manager {
             if ancestor == root_path {
                 break;
             }
-            if ancestor != container_path {
-                paths.push(ancestor);
-            }
+            paths.push(ancestor);
         }
-        info!(sl!(), "paths to update cpuset: {:?}", &paths);
+        info!(sl!(), "parent paths to update cpuset: {:?}", &paths);
 
         let mut i = paths.len();
         loop {
@@ -1066,10 +1064,20 @@ impl Manager {
                 .to_str()
                 .unwrap()
                 .trim_start_matches(root_path.to_str().unwrap());
-            info!(sl!(), "updating cpuset for path {:?}", &r_path);
+            info!(sl!(), "updating cpuset for parent path {:?}", &r_path);
             let cg = load_or_create(h, &r_path);
             let cpuset_controller: &CpuSetController = cg.controller_of().unwrap();
-            cpuset_controller.set_cpus(cpuset_cpus)?;
+            cpuset_controller.set_cpus(guest_cpuset)?;
+        }
+
+        if !container_cpuset.is_empty() {
+            info!(
+                sl!(),
+                "updating cpuset for container path: {:?} cpuset: {}",
+                &container_path,
+                container_cpuset
+            );
+            container_cpuset_controller.set_cpus(container_cpuset)?;
         }
 
         Ok(())

--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -365,7 +365,9 @@ fn set_cpu_resources(cg: &cgroups::Cgroup, cpu: &LinuxCPU) -> Result<()> {
     let cpuset_controller: &CpuSetController = cg.controller_of().unwrap();
 
     if !cpu.cpus.is_empty() {
-        cpuset_controller.set_cpus(&cpu.cpus)?;
+        if let Err(e) = cpuset_controller.set_cpus(&cpu.cpus) {
+            warn!(sl!(), "write cpuset failed: {:?}", e);
+        }
     }
 
     if !cpu.mems.is_empty() {

--- a/src/agent/rustjail/src/cgroups/mock.rs
+++ b/src/agent/rustjail/src/cgroups/mock.rs
@@ -64,7 +64,7 @@ impl Manager {
         })
     }
 
-    pub fn update_cpuset_path(&self, _: &str) -> Result<()> {
+    pub fn update_cpuset_path(&self, _: &str, _: &str) -> Result<()> {
         Ok(())
     }
 

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -233,14 +233,29 @@ impl Sandbox {
             online_memory(&self.logger)?;
         }
 
-        let cpuset = rustjail_cgroups::fs::get_guest_cpuset()?;
+        let guest_cpuset = rustjail_cgroups::fs::get_guest_cpuset()?;
 
         for (_, ctr) in self.containers.iter() {
+            let cpu = ctr
+                .config
+                .spec
+                .as_ref()
+                .unwrap()
+                .linux
+                .as_ref()
+                .unwrap()
+                .resources
+                .as_ref()
+                .unwrap()
+                .cpu
+                .as_ref();
+            let container_cpust = if let Some(c) = cpu { &c.cpus } else { "" };
+
             info!(self.logger, "updating {}", ctr.id.as_str());
             ctr.cgroup_manager
                 .as_ref()
                 .unwrap()
-                .update_cpuset_path(cpuset.as_str())?;
+                .update_cpuset_path(guest_cpuset.as_str(), &container_cpust)?;
         }
 
         Ok(())


### PR DESCRIPTION
This PR will fix #1156 , #1159 



### Before

#### In container

```
Mem: 40364K used, 2526712K free, 8K shrd, 992K buff, 1848K cached
CPU:   1% usr  18% sys   0% nic  79% idle   0% io   0% irq   0% sirq
Load average: 3.25 1.14 0.41 5/89 8
  PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
    6     3 root     R     1528   0%   0   5% md5sum /dev/urandom
    7     3 root     R     1528   0%   0   5% md5sum /dev/urandom
    4     3 root     R     1528   0%   0   5% md5sum /dev/urandom
    5     3 root     R     1528   0%   0   5% md5sum /dev/urandom
    2     0 root     S     1532   0%   0   0% top
    3     0 root     S     1532   0%   0   0% sh
    8     3 root     R     1528   0%   0   0% top
    1     0 root     S     1020   0%   0   0% /pause
```

#### In guest

```
top - 02:20:35 up 4 min,  0 users,  load average: 2.76, 0.84, 0.29
Tasks:  72 total,   5 running,  31 sleeping,   0 stopped,   0 zombie
%Cpu(s):  1.1 us, 18.9 sy,  0.0 ni, 80.0 id,  0.0 wa,  0.0 hi,  0.0 si,  0.0 st
KiB Mem :  2567076 total,  2526084 free,    36344 used,     4648 buff/cache
KiB Swap:        0 total,        0 free,        0 used.  2504892 avail Mem 

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND     
  126 root      20   0    1528      4      0 R  25.3  0.0   0:16.94 md5sum      
  125 root      20   0    1528      4      0 R  25.0  0.0   0:17.51 md5sum      
  128 root      20   0    1528      4      0 R  25.0  0.0   0:16.53 md5sum      
  127 root      20   0    1528      4      0 R  24.7  0.0   0:16.68 md5sum      
    1 root      20   0   43088    856      4 S   0.0  0.0   0:00.16 systemd     
```

#### In host


```
Tasks:   1 total,   0 running,   1 sleeping,   0 stopped,   0 zombie
%Cpu(s): 16.7 us,  1.0 sy,  0.0 ni, 77.1 id,  0.0 wa,  0.0 hi,  5.2 si,  0.0 st
MiB Mem :  15790.0 total,   3148.4 free,   2058.9 used,  10582.7 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.  13482.8 avail Mem 

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                                        
2263426 root      20   0 4186448 159164  23908 S 100.0   1.0   1:30.51 qemu-system-x86                                                                


-> sudo crictl stats $c1

CONTAINER           CPU %               MEM                 DISK                INODES
39bd683885db7       99.89               1.86MB              12.37kB             7
```



### After

#### In container

```
Mem: 41088K used, 2525988K free, 8K shrd, 976K buff, 1848K cached
CPU:   1% usr  75% sys   0% nic  22% idle   0% io   0% irq   0% sirq
Load average: 0.32 0.07 0.02 5/92 8
  PID  PPID USER     STAT   VSZ %VSZ CPU %CPU COMMAND
    6     3 root     R     1528   0%   0  19% md5sum /dev/urandom
    7     3 root     R     1528   0%   1  19% md5sum /dev/urandom
    4     3 root     R     1528   0%   3  17% md5sum /dev/urandom
    5     3 root     R     1528   0%   4  17% md5sum /dev/urandom
```

#### In guest

```
top - 02:32:07 up 1 min,  0 users,  load average: 1.37, 0.32, 0.11
Tasks:  73 total,   5 running,  31 sleeping,   0 stopped,   0 zombie
%Cpu(s):  1.4 us, 77.6 sy,  0.0 ni, 20.9 id,  0.0 wa,  0.0 hi,  0.1 si,  0.0 st
KiB Mem :  2567076 total,  2524960 free,    37360 used,     4756 buff/cache
KiB Swap:        0 total,        0 free,        0 used.  2503820 avail Mem 

  PID USER      PR  NI    VIRT    RES    SHR S  %CPU %MEM     TIME+ COMMAND     
  117 root      20   0    1528      4      0 R  99.3  0.0   0:25.61 md5sum      
  118 root      20   0    1528      4      0 R  99.0  0.0   0:25.01 md5sum      
  119 root      20   0    1528      4      0 R  98.3  0.0   0:24.59 md5sum      
  120 root      20   0    1528      4      0 R  98.3  0.0   0:24.06 md5sum      
```

#### In host


```
top - 10:32:40 up 22 days, 13:26,  3 users,  load average: 2.94, 1.22, 0.71
Tasks:   1 total,   0 running,   1 sleeping,   0 stopped,   0 zombie
%Cpu(s): 62.5 us,  0.1 sy,  0.0 ni, 31.3 id,  0.0 wa,  0.0 hi,  6.2 si,  0.0 st
MiB Mem :  15790.0 total,   2389.9 free,   2701.9 used,  10698.2 buff/cache
MiB Swap:      0.0 total,      0.0 free,      0.0 used.  12840.2 avail Mem 

    PID USER      PR  NI    VIRT    RES    SHR S  %CPU  %MEM     TIME+ COMMAND                                                                        
2264597 root      20   0 4189548 159056  24004 S 393.3   1.0   3:50.49 qemu-system-x86                                                                



-> sudo crictl stats $c1

CONTAINER           CPU %               MEM                 DISK                INODES
c8388366610b6       393.21              2.388MB             12.37kB             7
```

Test container:

```
metadata:
  name: stress
image:
  image: containerstack/alpine-stress:latest
command:
- top
mounts:
- container_path: /tmp
  host_path: /tmp
linux:
  resources:
    memory_limit_in_bytes: 524288000
    cpu_period: 100000
    cpu_quota: 400000
```
