### PR TITLE
agent: exit from exec hangs if background process is present

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -249,6 +249,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
 
 [[package]]
+name = "epoll"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20df693c700404f7e19d4d6fae6b15215d2913c27955d2b9d6f2c0f537511cd0"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "errno"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -921,6 +931,7 @@ dependencies = [
  "caps",
  "cgroups",
  "dirs",
+ "epoll",
  "lazy_static",
  "libc",
  "nix 0.17.0",

--- a/src/agent/rustjail/Cargo.toml
+++ b/src/agent/rustjail/Cargo.toml
@@ -26,6 +26,7 @@ dirs = "3.0.1"
 anyhow = "1.0.32"
 cgroups = { git = "https://github.com/kata-containers/cgroups-rs", branch = "stable-0.1.1"}
 tempfile = "3.1.0"
+epoll = "4.3.1"
 
 [dev-dependencies]
 serial_test = "0.5.0"

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -41,6 +41,7 @@ pub mod cgroups;
 pub mod container;
 pub mod mount;
 pub mod process;
+pub mod reaper;
 pub mod specconv;
 pub mod sync;
 pub mod validator;

--- a/src/agent/rustjail/src/reaper.rs
+++ b/src/agent/rustjail/src/reaper.rs
@@ -1,0 +1,150 @@
+// Copyright (c) 2020 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use nix::fcntl::OFlag;
+use slog::Logger;
+
+use nix::unistd;
+use std::os::unix::io::RawFd;
+
+use anyhow::Result;
+
+const MAX_EVENTS: usize = 2;
+
+#[derive(Debug, Clone)]
+pub struct Epoller {
+    logger: Logger,
+    epoll_fd: RawFd,
+    // rfd and wfd are a pipe's files two ends, this pipe is
+    // used to sync between the readStdio and the process exits.
+    // once the process exits, it will close one end to notify
+    // the readStdio that the process has exited and it should not
+    // wait on the process's terminal which has been inherited
+    // by it's children and hasn't exited.
+    rfd: RawFd,
+    wfd: RawFd,
+}
+
+impl Epoller {
+    pub fn new(logger: &Logger, fd: RawFd) -> Result<Epoller> {
+        let epoll_fd = epoll::create(true)?;
+        let (rfd, wfd) = unistd::pipe2(OFlag::O_CLOEXEC)?;
+
+        let mut epoller = Self {
+            logger: logger.clone(),
+            epoll_fd,
+            rfd,
+            wfd,
+        };
+
+        epoller.add(rfd)?;
+        epoller.add(fd)?;
+
+        Ok(epoller)
+    }
+
+    pub fn close_wfd(&self) {
+        let _ = unistd::close(self.wfd);
+    }
+
+    pub fn close(&self) {
+        let _ = unistd::close(self.rfd);
+        let _ = unistd::close(self.wfd);
+        let _ = unistd::close(self.epoll_fd);
+    }
+
+    fn add(&mut self, fd: RawFd) -> Result<()> {
+        info!(self.logger, "Epoller add fd {}", fd);
+        // add creates an epoll which is used to monitor the process's pty's master and
+        // one end of its exit notify pipe. Those files will be registered with level-triggered
+        // notification.
+        epoll::ctl(
+            self.epoll_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            fd,
+            epoll::Event::new(
+                epoll::Events::EPOLLHUP
+                    | epoll::Events::EPOLLIN
+                    | epoll::Events::EPOLLERR
+                    | epoll::Events::EPOLLRDHUP,
+                fd as u64,
+            ),
+        )?;
+
+        Ok(())
+    }
+
+    // There will be three cases on the epoller once it poll:
+    // a: only pty's master get an event(other than self.rfd);
+    // b: only the pipe get an event(self.rfd);
+    // c: both of pty and pipe have event occur;
+    // for case a, it means there is output in process's terminal and what needed to do is
+    // just read the terminal and send them out; for case b, it means the process has exited
+    // and there is no data in the terminal, thus just return the "EOF" to end the io;
+    // for case c, it means the process has exited but there is some data in the terminal which
+    // hasn't been send out, thus it should send those data out first and then send "EOF" last to
+    // end the io.
+    pub fn poll(&self) -> Result<RawFd> {
+        let mut rfd = self.rfd;
+        let mut epoll_events = vec![epoll::Event::new(epoll::Events::empty(), 0); MAX_EVENTS];
+
+        loop {
+            let event_count = match epoll::wait(self.epoll_fd, -1, epoll_events.as_mut_slice()) {
+                Ok(ec) => ec,
+                Err(e) => {
+                    info!(self.logger, "loop wait err {:?}", e);
+                    // EINTR: The call was interrupted by a signal handler before either
+                    // any of the requested events occurred or the timeout expired
+                    if e.kind() == std::io::ErrorKind::Interrupted {
+                        continue;
+                    }
+                    return Err(e.into());
+                }
+            };
+
+            for event in epoll_events.iter().take(event_count) {
+                let fd = event.data as i32;
+                // fd has been assigned with one end of process's exited pipe by default, and
+                // here to check is there any event occur on process's terminal, if "yes", it
+                // should be dealt first, otherwise, it means the process has exited and there
+                // is nothing left in the process's terminal needed to be read.
+                if fd != rfd {
+                    rfd = fd;
+                    break;
+                }
+            }
+            break;
+        }
+
+        Ok(rfd)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Epoller;
+    use nix::fcntl::OFlag;
+    use nix::unistd;
+    use std::thread;
+
+    #[test]
+    fn test_epoller_poll() {
+        let logger = slog::Logger::root(slog::Discard, o!());
+        let (rfd, wfd) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
+        let epoller = Epoller::new(&logger, rfd).unwrap();
+
+        let child = thread::spawn(move || {
+            let _ = unistd::write(wfd, "temporary file's content".as_bytes());
+        });
+
+        // wait write to finish
+        let _ = child.join();
+
+        let fd = epoller.poll().unwrap();
+        assert_eq!(fd, rfd, "Should get rfd");
+
+        epoller.close();
+    }
+}

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -306,6 +306,7 @@ fn setup_signal_handler(logger: &Logger, sandbox: Arc<Mutex<Sandbox>>) -> Result
                         continue 'outer;
                     }
                 };
+                info!(logger, "wait_status"; "wait_status result" => format!("{:?}", wait_status));
 
                 let pid = wait_status.pid();
                 if let Some(pid) = pid {
@@ -342,6 +343,13 @@ fn setup_signal_handler(logger: &Logger, sandbox: Arc<Mutex<Sandbox>>) -> Result
 
                     p.exit_code = ret;
                     let _ = unistd::close(pipe_write);
+
+                    if let Some(ref poller) = p.epoller {
+                        info!(logger, "close epoller");
+                        // close the socket file to notify readStdio to close terminal specifically
+                        // in case this process's terminal has been inherited by its children.
+                        poller.close_wfd()
+                    }
                 }
             }
         }


### PR DESCRIPTION
This is the Rust porting of https://github.com/kata-containers/agent/pull/371

`read_stdout`/`read_stderr` is blocking rpc calls, if exec process exited, these calls is on blocking state for reading on process's term master fd, and can't get a chance to break the wait.

In this PR, `read_stdout`/`read_stderr` will not read directly from a term master of a process, instead, it will first have to get an fd to read from newly added `epoller.poll()`. `epoller.poll()` may returns:

- the term master fd of exec process, if the process is running.
- a fd(piped fd) will return EOF when reading to indicate that th process is exited.

Fixes: #1160 

Signed-off-by: bin liu <bin@hyper.sh>