### PR TITLE
 packaging/qemu: Build and package completely inside the container

### DIFF
--- a/tools/packaging/static-build/qemu-virtiofs/Dockerfile
+++ b/tools/packaging/static-build/qemu-virtiofs/Dockerfile
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from ubuntu:20.04
 
+ARG QEMU_DESTDIR
 ARG QEMU_VIRTIOFS_REPO
 # commit/tag/branch
 ARG QEMU_VIRTIOFS_TAG
@@ -69,7 +70,8 @@ RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-qemu | sed -e 's|--
 
 RUN make -j$(nproc)
 RUN make -j$(nproc) virtiofsd
-RUN make install DESTDIR=/tmp/qemu-virtiofs-static
-RUN mv /tmp/qemu-virtiofs-static/"${PREFIX}"/bin/qemu-system-x86_64 /tmp/qemu-virtiofs-static/"${PREFIX}"/bin/qemu-virtiofs-system-x86_64
-RUN mv /tmp/qemu-virtiofs-static/"${PREFIX}"/libexec/kata-qemu/virtiofsd /tmp/qemu-virtiofs-static/opt/kata/bin/virtiofsd-dax
-RUN cd /tmp/qemu-virtiofs-static && tar -czvf "${QEMU_TARBALL}"  *
+RUN make install DESTDIR="${QEMU_DESTDIR}"
+RUN cd "${QEMU_DESTDIR}/${PREFIX}" && \
+	mv bin/qemu-system-x86_64 bin/qemu-virtiofs-system-x86_64 && \
+	mv libexec/kata-qemu/virtiofsd bin/virtiofsd-dax
+RUN cd "${QEMU_DESTDIR}" && tar -czvf "${QEMU_TARBALL}"  *

--- a/tools/packaging/static-build/qemu-virtiofs/Dockerfile
+++ b/tools/packaging/static-build/qemu-virtiofs/Dockerfile
@@ -56,6 +56,7 @@ RUN git checkout "${QEMU_VIRTIOFS_TAG}"
 ADD scripts/configure-hypervisor.sh /root/configure-hypervisor.sh
 ADD qemu /root/kata_qemu
 ADD scripts/apply_patches.sh /root/apply_patches.sh
+ADD static-build /root/static-build
 
 # Apply experimental specific patches
 # Patches to quick fix virtiofs fork
@@ -74,4 +75,4 @@ RUN make install DESTDIR="${QEMU_DESTDIR}"
 RUN cd "${QEMU_DESTDIR}/${PREFIX}" && \
 	mv bin/qemu-system-x86_64 bin/qemu-virtiofs-system-x86_64 && \
 	mv libexec/kata-qemu/virtiofsd bin/virtiofsd-dax
-RUN cd "${QEMU_DESTDIR}" && tar -czvf "${QEMU_TARBALL}"  *
+RUN /root/static-build/scripts/qemu-build-post.sh

--- a/tools/packaging/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
+++ b/tools/packaging/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
@@ -26,6 +26,7 @@ qemu_virtiofs_repo=$(get_from_kata_deps "assets.hypervisor.qemu-experimental.url
 qemu_virtiofs_tag=$(get_from_kata_deps "assets.hypervisor.qemu-experimental.tag" "${kata_version}")
 qemu_virtiofs_tar="kata-static-qemu-virtiofsd.tar.gz"
 qemu_tmp_tar="kata-static-qemu-virtiofsd-tmp.tar.gz"
+qemu_destdir="/tmp/qemu-virtiofs-static"
 
 info "Build ${qemu_virtiofs_repo} tag: ${qemu_virtiofs_tag}"
 
@@ -37,6 +38,7 @@ sudo "${DOCKER_CLI}" build \
 	--no-cache \
 	--build-arg http_proxy="${http_proxy}" \
 	--build-arg https_proxy="${https_proxy}" \
+	--build-arg QEMU_DESTDIR="${qemu_destdir}" \
 	--build-arg QEMU_VIRTIOFS_REPO="${qemu_virtiofs_repo}" \
 	--build-arg QEMU_VIRTIOFS_TAG="${qemu_virtiofs_tag}" \
 	--build-arg QEMU_TARBALL="${qemu_virtiofs_tar}" \
@@ -48,7 +50,7 @@ sudo "${DOCKER_CLI}" build \
 sudo "${DOCKER_CLI}" run \
 	-i \
 	-v "${PWD}":/share qemu-virtiofs-static \
-	mv "/tmp/qemu-virtiofs-static/${qemu_virtiofs_tar}" /share/
+	mv "${qemu_destdir}/${qemu_virtiofs_tar}" /share/
 
 sudo chown ${USER}:${USER} "${PWD}/${qemu_virtiofs_tar}"
 

--- a/tools/packaging/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
+++ b/tools/packaging/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
@@ -48,6 +48,7 @@ sudo "${DOCKER_CLI}" build \
 	-t qemu-virtiofs-static
 
 sudo "${DOCKER_CLI}" run \
+	--rm \
 	-i \
 	-v "${PWD}":/share qemu-virtiofs-static \
 	mv "${qemu_destdir}/${qemu_virtiofs_tar}" /share/

--- a/tools/packaging/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
+++ b/tools/packaging/static-build/qemu-virtiofs/build-static-qemu-virtiofs.sh
@@ -53,7 +53,3 @@ sudo "${DOCKER_CLI}" run \
 	mv "${qemu_destdir}/${qemu_virtiofs_tar}" /share/
 
 sudo chown ${USER}:${USER} "${PWD}/${qemu_virtiofs_tar}"
-
-# Remove blacklisted binaries
-gzip -d < "${qemu_virtiofs_tar}" | tar --delete --wildcards -f - ${qemu_black_list[*]} | gzip > "${qemu_tmp_tar}"
-mv -f "${qemu_tmp_tar}" "${qemu_virtiofs_tar}"

--- a/tools/packaging/static-build/qemu.blacklist
+++ b/tools/packaging/static-build/qemu.blacklist
@@ -6,7 +6,7 @@ qemu_black_list=(
 */bin/qemu-pr-helper
 */bin/virtfs-proxy-helper
 */libexec/kata-qemu/qemu*
-*/share/*/applications/
+*/share/*/applications
 */share/*/*.dtb
 */share/*/efi-e1000e.rom
 */share/*/efi-e1000.rom
@@ -15,9 +15,9 @@ qemu_black_list=(
 */share/*/efi-pcnet.rom
 */share/*/efi-rtl8139.rom
 */share/*/efi-vmxnet3.rom
-*/share/*/icons/
+*/share/*/icons
 */share/*/*.img
-*/share/*/keymaps/
+*/share/*/keymaps
 */share/*/multiboot.bin
 */share/*/openbios-ppc
 */share/*/openbios-sparc32

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 from ubuntu:20.04
 
+ARG QEMU_DESTDIR
 ARG QEMU_REPO
 # commit/tag/branch
 ARG QEMU_VERSION
@@ -64,5 +65,5 @@ RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-qemu | xargs ./conf
 
 RUN make -j$(nproc)
 RUN make -j$(nproc) virtiofsd
-RUN make install DESTDIR=/tmp/qemu-static
-RUN cd /tmp/qemu-static && tar -czvf "${QEMU_TARBALL}" *
+RUN make install DESTDIR="${QEMU_DESTDIR}"
+RUN cd "${QEMU_DESTDIR}" && tar -czvf "${QEMU_TARBALL}" *

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -56,6 +56,7 @@ RUN git clone https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
 ADD scripts/configure-hypervisor.sh /root/configure-hypervisor.sh
 ADD qemu /root/kata_qemu
 ADD scripts/apply_patches.sh /root/apply_patches.sh
+ADD static-build /root/static-build
 
 RUN stable_branch=$(cat VERSION | awk 'BEGIN{FS=OFS="."}{print $1 "." $2 ".x"}') && \
 	/root/apply_patches.sh "/root/kata_qemu/patches/${stable_branch}"
@@ -66,4 +67,4 @@ RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s kata-qemu | xargs ./conf
 RUN make -j$(nproc)
 RUN make -j$(nproc) virtiofsd
 RUN make install DESTDIR="${QEMU_DESTDIR}"
-RUN cd "${QEMU_DESTDIR}" && tar -czvf "${QEMU_TARBALL}" *
+RUN /root/static-build/scripts/qemu-build-post.sh

--- a/tools/packaging/static-build/qemu/build-static-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-static-qemu.sh
@@ -16,6 +16,7 @@ source "${script_dir}/../qemu.blacklist"
 packaging_dir="${script_dir}/../.."
 qemu_tar="kata-static-qemu.tar.gz"
 qemu_tmp_tar="kata-static-qemu-tmp.tar.gz"
+qemu_destdir="/tmp/qemu-static/"
 
 qemu_repo="${qemu_repo:-}"
 qemu_version="${qemu_version:-}"
@@ -45,6 +46,7 @@ sudo docker build \
 	--no-cache \
 	--build-arg http_proxy="${http_proxy}" \
 	--build-arg https_proxy="${https_proxy}" \
+	--build-arg QEMU_DESTDIR="${qemu_destdir}" \
 	--build-arg QEMU_REPO="${qemu_repo}" \
 	--build-arg QEMU_VERSION="${qemu_version}" \
 	--build-arg QEMU_TARBALL="${qemu_tar}" \
@@ -56,7 +58,7 @@ sudo docker build \
 sudo docker run \
 	-i \
 	-v "${PWD}":/share qemu-static \
-	mv "/tmp/qemu-static/${qemu_tar}" /share/
+	mv "${qemu_destdir}/${qemu_tar}" /share/
 
 sudo chown ${USER}:${USER} "${PWD}/${qemu_tar}"
 

--- a/tools/packaging/static-build/qemu/build-static-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-static-qemu.sh
@@ -61,7 +61,3 @@ sudo docker run \
 	mv "${qemu_destdir}/${qemu_tar}" /share/
 
 sudo chown ${USER}:${USER} "${PWD}/${qemu_tar}"
-
-# Remove blacklisted binaries
-gzip -d < "${qemu_tar}" | tar --delete --wildcards -f - ${qemu_black_list[*]} | gzip > "${qemu_tmp_tar}"
-mv -f "${qemu_tmp_tar}" "${qemu_tar}"

--- a/tools/packaging/static-build/qemu/build-static-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-static-qemu.sh
@@ -56,6 +56,7 @@ sudo docker build \
 	-t qemu-static
 
 sudo docker run \
+	--rm \
 	-i \
 	-v "${PWD}":/share qemu-static \
 	mv "${qemu_destdir}/${qemu_tar}" /share/

--- a/tools/packaging/static-build/scripts/qemu-build-post.sh
+++ b/tools/packaging/static-build/scripts/qemu-build-post.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+#
+# Copyright (c) 2020 Red Hat, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This script process QEMU post-build.
+#
+set -e
+
+script_dir="$(realpath $(dirname $0))"
+source "${script_dir}/../qemu.blacklist"
+
+if [[ -z "${QEMU_TARBALL}" || -z "${QEMU_DESTDIR}" ]]; then
+	echo "$0: needs QEMU_TARBALL and QEMU_DESTDIR exported"
+	exit 1
+fi
+
+pushd "${QEMU_DESTDIR}"
+# Remove files to reduce the surface.
+echo "INFO: remove uneeded files"
+for pattern in ${qemu_black_list[@]}; do
+	find . -path "$pattern" | xargs rm -rfv
+done
+
+echo "INFO: create the tarball"
+tar -czvf "${QEMU_TARBALL}" *
+popd


### PR DESCRIPTION
Currently QEMU is built inside the container, its tarball pulled to the host, files removed then it is packaged again.

Here I propose to run all those steps inside the container and the resulting tarball will be the final version. It can be refactored so that common code between qemu and qemu-virtiofs will be shared.

The commit https://github.com/kata-containers/kata-containers/commit/c94d9da0fc9a3b4d10e611ab439ea0b5fe337a12 is an unrelated improvement which I am pushing together.

Fixes #1168