### PR TITLE
[backport] snap: fix snap release channel

### DIFF
--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -33,5 +33,5 @@ jobs:
           snap_file="kata-containers_${snap_version}_amd64.snap"
           # Upload the snap if it exists
           if [ -f ${snap_file} ]; then
-            snapcraft upload --release=stable ${snap_file}
+            snapcraft upload --release=candidate ${snap_file}
           fi


### PR DESCRIPTION
According to the new snap document
`docs/install/snap-installation-guide.md`, Kata Containers 2.x should
be available in the snapcraft `candidate` channel.

fixes #1174

Signed-off-by: Julio Montes <julio.montes@intel.com>