### PR TITLE
qemu: no state to save if QEMU isn't running

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -2316,6 +2316,12 @@ func (q *qemu) toGrpc() ([]byte, error) {
 }
 
 func (q *qemu) save() (s persistapi.HypervisorState) {
+
+	// If QEMU isn't even running, there isn't any state to save
+	if q.stopped {
+		return
+	}
+
 	pids := q.getPids()
 	if len(pids) != 0 {
 		s.Pid = pids[0]


### PR DESCRIPTION
On pod delete, we were looking to read files that we had just deleted. In particular,
stopSandbox for QEMU was called (we cleanup up vmpath), and then QEMU's
save function was called, which immediately checks for the PID file.

Let's only update the persist store for QEMU if QEMU is actually
running. This'll avoid Error messages being displayed when we are
stopping and deleting a sandbox:

```
level=error msg="Could not read qemu pid file"
```

I reviewed CLH, and it looks like it is already taking appropriate
action, so no changes needed.

Ideally we won't spend much time saving state to persist.json unless
there's an actual error during stop/delete/shutdown path, as the persist will
also be removed after the pod is removed. We may want to optimize this,
as currently we are doing a persist store when deleting each container
(after the sandbox is stopped, VM is killed), and when we stop the sandbox.
This'll require more rework...

Fixes: #1179

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>