### PR TITLE
rootfs: Don't fallthrough in the docker_extra_args() switch

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -181,29 +181,22 @@ docker_extra_args()
 {
 	local args=""
 
+	# Required to mount inside a container
+	args+=" --cap-add SYS_ADMIN"
+	# Requred to chroot
+	args+=" --cap-add SYS_CHROOT"
+	# debootstrap needs to create device nodes to properly function
+	args+=" --cap-add MKNOD"
+
 	case "$1" in
 	 gentoo)
-		# Requred to chroot
-		args+=" --cap-add SYS_CHROOT"
-		# debootstrap needs to create device nodes to properly function
-		args+=" --cap-add MKNOD"
-		# Required to mount inside a container
-		args+=" --cap-add SYS_ADMIN"
 		# Required to build glibc
 		args+=" --cap-add SYS_PTRACE"
 		# mount portage volume
 		args+=" -v ${gentoo_local_portage_dir}:/usr/portage/packages"
 		args+=" --volumes-from ${gentoo_portage_container}"
 		;;
-	 ubuntu | debian)
-		# Requred to chroot
-		args+=" --cap-add SYS_CHROOT"
-		# debootstrap needs to create device nodes to properly function
-		args+=" --cap-add MKNOD"
-		;;
 	suse)
-		# Required to mount inside a container
-		args+=" --cap-add SYS_ADMIN"
 		# When AppArmor is enabled, mounting inside a container is blocked with docker-default profile.
 		# See https://github.com/moby/moby/issues/16429
 		args+=" --security-opt apparmor=unconfined"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -189,7 +189,7 @@ docker_extra_args()
 	args+=" --cap-add MKNOD"
 
 	case "$1" in
-	 gentoo)
+	gentoo)
 		# Required to build glibc
 		args+=" --cap-add SYS_PTRACE"
 		# mount portage volume

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -200,7 +200,7 @@ docker_extra_args()
 		args+=" --cap-add SYS_CHROOT"
 		# debootstrap needs to create device nodes to properly function
 		args+=" --cap-add MKNOD"
-		;&
+		;;
 	suse)
 		# Required to mount inside a container
 		args+=" --cap-add SYS_ADMIN"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -196,10 +196,23 @@ docker_extra_args()
 		args+=" -v ${gentoo_local_portage_dir}:/usr/portage/packages"
 		args+=" --volumes-from ${gentoo_portage_container}"
 		;;
-	suse)
-		# When AppArmor is enabled, mounting inside a container is blocked with docker-default profile.
-		# See https://github.com/moby/moby/issues/16429
-		args+=" --security-opt apparmor=unconfined"
+        debian | ubuntu | suse)
+		source /etc/os-release
+
+		case "$ID" in
+                fedora | centos | rhel)
+			# Depending on the podman version, we'll face issues when passing
+		        # `--security-opt apparmor=unconfined` on a system where not apparmor is not installed.
+			# Because of this, let's just avoid adding this option when the host OS comes from Red Hat.
+
+			# A explict check for podman, at least for now, can be avoided.
+			;;
+		*)
+			# When AppArmor is enabled, mounting inside a container is blocked with docker-default profile.
+			# See https://github.com/moby/moby/issues/16429
+			args+=" --security-opt apparmor=unconfined"
+			;;
+		esac
 		;;
 	*)
 		;;


### PR DESCRIPTION
Falling through the switch cases in docker_extra_args() looks like a
typo and causes issues when building with podman, as `--security-opt
apparmor=unconfinded" shouldn't be passed if Apparmor is no enable on
the system.

Fixes: #1241 

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>