### PR TITLE
Agent: return error on trying to persist a pid namespace and minor improvements

### DIFF
--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -16,7 +16,6 @@ use std::thread::{self};
 use crate::mount::{BareMount, FLAGS};
 use slog::Logger;
 
-//use container::Process;
 const PERSISTENT_NS_DIR: &str = "/var/run/sandbox-ns";
 pub const NSTYPEIPC: &str = "ipc";
 pub const NSTYPEUTS: &str = "uts";

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -202,7 +202,7 @@ mod tests {
         assert!(remove_mounts(&[ns_ipc.unwrap().path]).is_ok());
 
         let logger = slog::Logger::root(slog::Discard, o!());
-        let tmpdir = Builder::new().prefix("ipc").tempdir().unwrap();
+        let tmpdir = Builder::new().prefix("uts").tempdir().unwrap();
 
         let ns_uts = Namespace::new(&logger)
             .get_uts("test_hostname")

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-//use crate::container::Container;
 use crate::linux_abi::*;
 use crate::mount::{get_mount_fs_type, remove_mounts, TYPEROOTFS};
 use crate::namespace::Namespace;
@@ -412,7 +411,6 @@ fn online_memory(logger: &Logger) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    //use rustjail::Error;
     use super::Sandbox;
     use crate::{mount::BareMount, skip_if_not_root};
     use anyhow::Error;


### PR DESCRIPTION
The main goal of this PR is to fix #1220 . According to an annotation on code a pid namespace should not be persisted (I assume this information is true) so I added a checking for that condition.

Some minor improvements are sent alongside.