### PR TITLE
rustjail: allow network sysctls

### DIFF
--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -207,6 +207,11 @@ fn sysctl(oci: &Spec) -> Result<()> {
             }
         }
 
+        if key.starts_with("net.") {
+            // the network ns is shared with the guest, don't expect to find it in spec
+            continue;
+        }
+
         if contain_namespace(&linux.namespaces, "uts") {
             if key == "kernel.domainname" {
                 continue;


### PR DESCRIPTION
The network ns is shared with the guest, skip looking for it
in the spec

Fixes: #1228
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>