### PR TITLE
rustjail: fix the issue of sync read

### DIFF
--- a/src/agent/rustjail/src/sync.rs
+++ b/src/agent/rustjail/src/sync.rs
@@ -72,7 +72,15 @@ fn read_count(fd: RawFd, count: usize) -> Result<Vec<u8>> {
         }
     }
 
-    Ok(v[0..len].to_vec())
+    if len != count {
+        Err(anyhow::anyhow!(
+            "invalid read count expect {} get {}",
+            count,
+            len
+        ))
+    } else {
+        Ok(v[0..len].to_vec())
+    }
 }
 
 pub fn read_sync(fd: RawFd) -> Result<Vec<u8>> {


### PR DESCRIPTION
It should check the read count and return an
error if read count didn't match the expected
number.

Fixes: #1233

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>