### PR TITLE
[backport | stable-2.0] shimv2: Avoid double removing of container from sandbox

### DIFF
--- a/src/runtime/containerd-shim-v2/delete.go
+++ b/src/runtime/containerd-shim-v2/delete.go
@@ -17,13 +17,12 @@ import (
 func deleteContainer(ctx context.Context, s *service, c *container) error {
 	if !c.cType.IsSandbox() {
 		if c.status != task.StatusStopped {
-			_, err := s.sandbox.StopContainer(c.id, false)
-			if err != nil {
+			if _, err := s.sandbox.StopContainer(c.id, false); err != nil && !isNotFound(err) {
 				return err
 			}
 		}
 
-		if _, err := s.sandbox.DeleteContainer(c.id); err != nil {
+		if _, err := s.sandbox.DeleteContainer(c.id); err != nil && !isNotFound(err) {
 			return err
 		}
 	}


### PR DESCRIPTION
RemoveContainerRequest results in calling to deleteContainer, according
to spec calling to RemoveContainer is idempotent and "must not return
an error if the container has already been removed", hence, don't
return error if the error reports that the container is not found.

Fixes: #836

Signed-off-by: Snir Sheriber <ssheribe@redhat.com>