### PR TITLE
[backport | stable-2.0] allow network sysctl backport

### DIFF
--- a/src/agent/rustjail/src/capabilities.rs
+++ b/src/agent/rustjail/src/capabilities.rs
@@ -6,8 +6,6 @@
 // looks like we can use caps to manipulate capabilities
 // conveniently, use caps to do it directly.. maybe
 
-use lazy_static;
-
 use crate::log_child;
 use crate::sync::write_count;
 use anyhow::{anyhow, Result};

--- a/src/agent/rustjail/src/cgroups/notifier.rs
+++ b/src/agent/rustjail/src/cgroups/notifier.rs
@@ -41,7 +41,7 @@ fn get_value_from_cgroup(path: &PathBuf, key: &str) -> Result<i64> {
     );
 
     for line in content.lines() {
-        let arr: Vec<&str> = line.split(" ").collect();
+        let arr: Vec<&str> = line.split(' ').collect();
         if arr.len() == 2 && arr[0] == key {
             let r = arr[1].parse::<i64>()?;
             return Ok(r);

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, bail, Context, Error, Result};
+use anyhow::{anyhow, bail, Context, Result};
 use libc::uid_t;
 use nix::errno::Errno;
 use nix::fcntl::{self, OFlag};
@@ -22,13 +22,11 @@ use std::os::unix::io::RawFd;
 use std::path::{Path, PathBuf};
 
 use path_absolutize::*;
-use scan_fmt;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 
 use crate::container::DEFAULT_DEVICES;
 use crate::sync::write_count;
-use lazy_static;
 use std::string::ToString;
 
 use crate::log_child;
@@ -50,7 +48,7 @@ pub struct Info {
     vfs_opts: String,
 }
 
-const MOUNTINFOFORMAT: &'static str = "{d} {d} {d}:{d} {} {} {} {}";
+const MOUNTINFOFORMAT: &str = "{d} {d} {d}:{d} {} {} {} {}";
 const PROC_PATH: &str = "/proc";
 
 // since libc didn't defined this const for musl, thus redefined it here.
@@ -153,7 +151,7 @@ pub fn init_rootfs(
     let linux = &spec
         .linux
         .as_ref()
-        .ok_or::<Error>(anyhow!("Could not get linux configuration from spec"))?;
+        .ok_or_else(|| anyhow!("Could not get linux configuration from spec"))?;
 
     let mut flags = MsFlags::MS_REC;
     match PROPAGATION.get(&linux.rootfs_propagation.as_str()) {
@@ -164,14 +162,14 @@ pub fn init_rootfs(
     let root = spec
         .root
         .as_ref()
-        .ok_or(anyhow!("Could not get rootfs path from spec"))
+        .ok_or_else(|| anyhow!("Could not get rootfs path from spec"))
         .and_then(|r| {
             fs::canonicalize(r.path.as_str()).context("Could not canonicalize rootfs path")
         })?;
 
     let rootfs = (*root)
         .to_str()
-        .ok_or(anyhow!("Could not convert rootfs path to string"))?;
+        .ok_or_else(|| anyhow!("Could not convert rootfs path to string"))?;
 
     mount(None::<&str>, "/", None::<&str>, flags, None::<&str>)?;
 
@@ -187,7 +185,7 @@ pub fn init_rootfs(
 
     for m in &spec.mounts {
         let (mut flags, data) = parse_mount(&m);
-        if !m.destination.starts_with("/") || m.destination.contains("..") {
+        if !m.destination.starts_with('/') || m.destination.contains("..") {
             return Err(anyhow!(
                 "the mount destination {} is invalid",
                 m.destination
@@ -273,9 +271,9 @@ fn check_proc_mount(m: &Mount) -> Result<()> {
         // only allow a mount on-top of proc if it's source is "proc"
         unsafe {
             let mut stats = MaybeUninit::<libc::statfs>::uninit();
-            if let Ok(_) = m
-                .source
+            if m.source
                 .with_nix_path(|path| libc::statfs(path.as_ptr(), stats.as_mut_ptr()))
+                .is_ok()
             {
                 if stats.assume_init().f_type == PROC_SUPER_MAGIC {
                     return Ok(());
@@ -298,7 +296,7 @@ fn check_proc_mount(m: &Mount) -> Result<()> {
         )));
     }
 
-    return Ok(());
+    Ok(())
 }
 
 fn mount_cgroups_v2(cfd_log: RawFd, m: &Mount, rootfs: &str, flags: MsFlags) -> Result<()> {
@@ -586,15 +584,14 @@ pub fn ms_move_root(rootfs: &str) -> Result<bool> {
     let abs_root_buf = root_path.absolutize()?;
     let abs_root = abs_root_buf
         .to_str()
-        .ok_or::<Error>(anyhow!("failed to parse {} to absolute path", rootfs))?;
+        .ok_or_else(|| anyhow!("failed to parse {} to absolute path", rootfs))?;
 
     for info in mount_infos.iter() {
         let mount_point = Path::new(&info.mount_point);
         let abs_mount_buf = mount_point.absolutize()?;
-        let abs_mount_point = abs_mount_buf.to_str().ok_or::<Error>(anyhow!(
-            "failed to parse {} to absolute path",
-            info.mount_point
-        ))?;
+        let abs_mount_point = abs_mount_buf
+            .to_str()
+            .ok_or_else(|| anyhow!("failed to parse {} to absolute path", info.mount_point))?;
         let abs_mount_point_string = String::from(abs_mount_point);
 
         // Umount every syfs and proc file systems, except those under the container rootfs
@@ -755,7 +752,7 @@ fn mount_from(
     Ok(())
 }
 
-static SYMLINKS: &'static [(&'static str, &'static str)] = &[
+static SYMLINKS: &[(&str, &str)] = &[
     ("/proc/self/fd", "dev/fd"),
     ("/proc/self/fd/0", "dev/stdin"),
     ("/proc/self/fd/1", "dev/stdout"),
@@ -888,7 +885,7 @@ pub fn finish_rootfs(cfd_log: RawFd, spec: &Spec) -> Result<()> {
 }
 
 fn mask_path(path: &str) -> Result<()> {
-    if !path.starts_with("/") || path.contains("..") {
+    if !path.starts_with('/') || path.contains("..") {
         return Err(nix::Error::Sys(Errno::EINVAL).into());
     }
 
@@ -917,7 +914,7 @@ fn mask_path(path: &str) -> Result<()> {
 }
 
 fn readonly_path(path: &str) -> Result<()> {
-    if !path.starts_with("/") || path.contains("..") {
+    if !path.starts_with('/') || path.contains("..") {
         return Err(nix::Error::Sys(Errno::EINVAL).into());
     }
 

--- a/src/agent/rustjail/src/sync.rs
+++ b/src/agent/rustjail/src/sync.rs
@@ -88,14 +88,14 @@ pub fn read_sync(fd: RawFd) -> Result<Vec<u8>> {
     let buf_array: [u8; MSG_SIZE] = [buf[0], buf[1], buf[2], buf[3]];
     let msg: i32 = i32::from_be_bytes(buf_array);
     match msg {
-        SYNC_SUCCESS => return Ok(Vec::new()),
+        SYNC_SUCCESS => Ok(Vec::new()),
         SYNC_DATA => {
             let buf = read_count(fd, MSG_SIZE)?;
             let buf_array: [u8; MSG_SIZE] = [buf[0], buf[1], buf[2], buf[3]];
             let msg_length: i32 = i32::from_be_bytes(buf_array);
             let data_buf = read_count(fd, msg_length as usize)?;
 
-            return Ok(data_buf);
+            Ok(data_buf)
         }
         SYNC_FAILED => {
             let mut error_buf = vec![];
@@ -119,9 +119,9 @@ pub fn read_sync(fd: RawFd) -> Result<Vec<u8>> {
                 }
             };
 
-            return Err(anyhow!(error_str));
+            Err(anyhow!(error_str))
         }
-        _ => return Err(anyhow!("error in receive sync message")),
+        _ => Err(anyhow!("error in receive sync message")),
     }
 }
 

--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -188,19 +188,6 @@ fn sysctl(oci: &Spec) -> Result<()> {
             }
         }
 
-        if key.starts_with("net.") {
-            if !contain_namespace(&linux.namespaces, "network") {
-                return Err(anyhow!(nix::Error::from_errno(Errno::EINVAL)));
-            }
-
-            let net = get_namespace_path(&linux.namespaces, "network")?;
-            if net.is_empty() || net == "" {
-                continue;
-            }
-
-            check_host_ns(net.as_str())?;
-        }
-
         if contain_namespace(&linux.namespaces, "uts") {
             if key == "kernel.domainname" {
                 continue;

--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -5,13 +5,12 @@
 
 use crate::container::Config;
 use anyhow::{anyhow, Result};
-use lazy_static;
 use nix::errno::Errno;
 use oci::{LinuxIDMapping, LinuxNamespace, Spec};
 use std::collections::HashMap;
 use std::path::{Component, PathBuf};
 
-fn contain_namespace(nses: &Vec<LinuxNamespace>, key: &str) -> bool {
+fn contain_namespace(nses: &[LinuxNamespace], key: &str) -> bool {
     for ns in nses {
         if ns.r#type.as_str() == key {
             return true;
@@ -21,7 +20,7 @@ fn contain_namespace(nses: &Vec<LinuxNamespace>, key: &str) -> bool {
     false
 }
 
-fn get_namespace_path(nses: &Vec<LinuxNamespace>, key: &str) -> Result<String> {
+fn get_namespace_path(nses: &[LinuxNamespace], key: &str) -> Result<String> {
     for ns in nses {
         if ns.r#type.as_str() == key {
             return Ok(ns.path.clone());
@@ -41,10 +40,8 @@ fn rootfs(root: &str) -> Result<()> {
     // symbolic link? ..?
     let mut stack: Vec<String> = Vec::new();
     for c in path.components() {
-        if stack.is_empty() {
-            if c == Component::RootDir || c == Component::ParentDir {
-                continue;
-            }
+        if stack.is_empty() && (c == Component::RootDir || c == Component::ParentDir) {
+            continue;
         }
 
         if c == Component::ParentDir {
@@ -74,7 +71,7 @@ fn network(_oci: &Spec) -> Result<()> {
 }
 
 fn hostname(oci: &Spec) -> Result<()> {
-    if oci.hostname.is_empty() || oci.hostname == "".to_string() {
+    if oci.hostname.is_empty() || oci.hostname == "" {
         return Ok(());
     }
 
@@ -104,7 +101,7 @@ fn security(oci: &Spec) -> Result<()> {
     Ok(())
 }
 
-fn idmapping(maps: &Vec<LinuxIDMapping>) -> Result<()> {
+fn idmapping(maps: &[LinuxIDMapping]) -> Result<()> {
     for map in maps {
         if map.size > 0 {
             return Ok(());
@@ -197,7 +194,7 @@ fn sysctl(oci: &Spec) -> Result<()> {
             }
 
             let net = get_namespace_path(&linux.namespaces, "network")?;
-            if net.is_empty() || net == "".to_string() {
+            if net.is_empty() || net == "" {
                 continue;
             }
 
@@ -233,7 +230,7 @@ fn rootless_euid_mapping(oci: &Spec) -> Result<()> {
     Ok(())
 }
 
-fn has_idmapping(maps: &Vec<LinuxIDMapping>, id: u32) -> bool {
+fn has_idmapping(maps: &[LinuxIDMapping], id: u32) -> bool {
     for map in maps {
         if id >= map.container_id && id < map.container_id + map.size {
             return true;
@@ -256,16 +253,12 @@ fn rootless_euid_mount(oci: &Spec) -> Result<()> {
 
                 let id = fields[1].trim().parse::<u32>()?;
 
-                if opt.starts_with("uid=") {
-                    if !has_idmapping(&linux.uid_mappings, id) {
-                        return Err(anyhow!(nix::Error::from_errno(Errno::EINVAL)));
-                    }
+                if opt.starts_with("uid=") && !has_idmapping(&linux.uid_mappings, id) {
+                    return Err(anyhow!(nix::Error::from_errno(Errno::EINVAL)));
                 }
 
-                if opt.starts_with("gid=") {
-                    if !has_idmapping(&linux.gid_mappings, id) {
-                        return Err(anyhow!(nix::Error::from_errno(Errno::EINVAL)));
-                    }
+                if opt.starts_with("gid=") && !has_idmapping(&linux.gid_mappings, id) {
+                    return Err(anyhow!(nix::Error::from_errno(Errno::EINVAL)));
                 }
             }
         }

--- a/src/agent/rustjail/src/validator.rs
+++ b/src/agent/rustjail/src/validator.rs
@@ -188,6 +188,11 @@ fn sysctl(oci: &Spec) -> Result<()> {
             }
         }
 
+        if key.starts_with("net.") {
+            // the network ns is shared with the guest, don't expect to find it in spec
+            continue;
+        }
+
         if contain_namespace(&linux.namespaces, "uts") {
             if key == "kernel.domainname" {
                 continue;


### PR DESCRIPTION
This is backporting of #1229, the two first patches are required only for clean porting, can also modified and backported without them