### PR TITLE
storage: cleanup and support read only block dev hotplug

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/hashicorp/go-multierror v1.0.0
-	github.com/kata-containers/govmm v0.0.0-20201020052039-99f43ec18864
+	github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca
 	github.com/mdlayher/vsock v0.0.0-20191108225356-d9c65923cb8f
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v1.0.0-rc9.0.20200102164712-2b52db75279c

--- a/src/runtime/go.sum
+++ b/src/runtime/go.sum
@@ -198,6 +198,8 @@ github.com/juju/testing v0.0.0-20190613124551-e81189438503/go.mod h1:63prj8cnj0t
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kata-containers/govmm v0.0.0-20201020052039-99f43ec18864 h1:ETwjbdr9aU/J90P5D/HAxRW8M4r0HQSPmuBDIaNr9EM=
 github.com/kata-containers/govmm v0.0.0-20201020052039-99f43ec18864/go.mod h1:VmAHbsL5lLfzHW/MNL96NVLF840DNEV5i683kISgFKk=
+github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca h1:UdXFthwasAPnmv37gLJUEFsW9FaabYA+mM6FoSi8kzU=
+github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca/go.mod h1:VmAHbsL5lLfzHW/MNL96NVLF840DNEV5i683kISgFKk=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
+++ b/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
@@ -135,7 +135,7 @@ const (
 
 func isDimmSupported(config *Config) bool {
 	switch runtime.GOARCH {
-	case "amd64", "386", "ppc64le":
+	case "amd64", "386", "ppc64le", "arm64":
 		if config != nil && config.Machine.Type == MachineTypeMicrovm {
 			// microvm does not support NUMA
 			return false
@@ -2300,6 +2300,9 @@ type Config struct {
 	// Bios is the -bios parameter
 	Bios string
 
+	// PFlash specifies the parallel flash images (-pflash parameter)
+	PFlash []string
+
 	// Incoming controls migration source preparation
 	Incoming Incoming
 
@@ -2490,6 +2493,13 @@ func (config *Config) appendGlobalParam() {
 	}
 }
 
+func (config *Config) appendPFlashParam() {
+	for _, p := range config.PFlash {
+		config.qemuParams = append(config.qemuParams, "-pflash")
+		config.qemuParams = append(config.qemuParams, p)
+	}
+}
+
 func (config *Config) appendVGA() {
 	if config.VGA != "" {
 		config.qemuParams = append(config.qemuParams, "-vga")
@@ -2675,6 +2685,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendDevices()
 	config.appendRTC()
 	config.appendGlobalParam()
+	config.appendPFlashParam()
 	config.appendVGA()
 	config.appendKnobs()
 	config.appendKernel()

--- a/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qmp.go
+++ b/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qmp.go
@@ -773,11 +773,12 @@ func (q *QMP) ExecuteQuit(ctx context.Context) error {
 	return q.executeCommand(ctx, "quit", nil, nil)
 }
 
-func (q *QMP) blockdevAddBaseArgs(device, blockdevID string) (map[string]interface{}, map[string]interface{}) {
+func (q *QMP) blockdevAddBaseArgs(device, blockdevID string, ro bool) (map[string]interface{}, map[string]interface{}) {
 	var args map[string]interface{}
 
 	blockdevArgs := map[string]interface{}{
-		"driver": "raw",
+		"driver":    "raw",
+		"read-only": ro,
 		"file": map[string]interface{}{
 			"driver":   "file",
 			"filename": device,
@@ -801,8 +802,8 @@ func (q *QMP) blockdevAddBaseArgs(device, blockdevID string) (map[string]interfa
 // path of the device to add, e.g., /dev/rdb0, and blockdevID is an identifier
 // used to name the device.  As this identifier will be passed directly to QMP,
 // it must obey QMP's naming rules, e,g., it must start with a letter.
-func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string) error {
-	args, _ := q.blockdevAddBaseArgs(device, blockdevID)
+func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string, ro bool) error {
+	args, _ := q.blockdevAddBaseArgs(device, blockdevID, ro)
 
 	return q.executeCommand(ctx, "blockdev-add", args, nil)
 }
@@ -814,8 +815,8 @@ func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string)
 // direct denotes whether use of O_DIRECT (bypass the host page cache)
 // is enabled.  noFlush denotes whether flush requests for the device are
 // ignored.
-func (q *QMP) ExecuteBlockdevAddWithCache(ctx context.Context, device, blockdevID string, direct, noFlush bool) error {
-	args, blockdevArgs := q.blockdevAddBaseArgs(device, blockdevID)
+func (q *QMP) ExecuteBlockdevAddWithCache(ctx context.Context, device, blockdevID string, direct, noFlush, ro bool) error {
+	args, blockdevArgs := q.blockdevAddBaseArgs(device, blockdevID, ro)
 
 	if q.version.Major < 2 || (q.version.Major == 2 && q.version.Minor < 9) {
 		return fmt.Errorf("versions of qemu (%d.%d) older than 2.9 do not support set cache-related options for block devices",

--- a/src/runtime/vendor/github.com/sirupsen/logrus/go.mod
+++ b/src/runtime/vendor/github.com/sirupsen/logrus/go.mod
@@ -1,7 +1,5 @@
 module github.com/sirupsen/logrus
 
-go 1.15
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/konsorten/go-windows-terminal-sequences v1.0.1

--- a/src/runtime/vendor/modules.txt
+++ b/src/runtime/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-multierror v1.0.0
 ## explicit
 github.com/hashicorp/go-multierror
-# github.com/kata-containers/govmm v0.0.0-20201020052039-99f43ec18864
+# github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca
 ## explicit
 github.com/kata-containers/govmm/qemu
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -669,6 +669,7 @@ func (c *Container) createBlockDevices() error {
 				DevType:       "b",
 				Major:         int64(unix.Major(stat.Rdev)),
 				Minor:         int64(unix.Minor(stat.Rdev)),
+				ReadOnly:      m.ReadOnly,
 			}
 			// check whether source can be used as a pmem device
 		} else if di, err = config.PmemDeviceInfo(m.Source, m.Destination); err != nil {

--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -114,6 +114,9 @@ type DeviceInfo struct {
 	// for a nvdimm device in the guest.
 	Pmem bool
 
+	// If applicable, should this device be considered RO
+	ReadOnly bool
+
 	// ColdPlug specifies whether the device must be cold plugged (true)
 	// or hot plugged (false).
 	ColdPlug bool

--- a/src/runtime/virtcontainers/device/drivers/block.go
+++ b/src/runtime/virtcontainers/device/drivers/block.go
@@ -61,11 +61,12 @@ func (device *BlockDevice) Attach(devReceiver api.DeviceReceiver) (err error) {
 	}
 
 	drive := &config.BlockDrive{
-		File:   device.DeviceInfo.HostPath,
-		Format: "raw",
-		ID:     utils.MakeNameID("drive", device.DeviceInfo.ID, maxDevIDSize),
-		Index:  index,
-		Pmem:   device.DeviceInfo.Pmem,
+		File:     device.DeviceInfo.HostPath,
+		Format:   "raw",
+		ID:       utils.MakeNameID("drive", device.DeviceInfo.ID, maxDevIDSize),
+		Index:    index,
+		Pmem:     device.DeviceInfo.Pmem,
+		ReadOnly: device.DeviceInfo.ReadOnly,
 	}
 
 	if fs, ok := device.DeviceInfo.DriverOptions["fstype"]; ok {

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -228,6 +228,7 @@ func TestHandleDeviceBlockVolume(t *testing.T) {
 
 	tests := []struct {
 		BlockDeviceDriver string
+		inputMount        Mount
 		inputDev          *drivers.BlockDevice
 		resultVol         *pb.Storage
 	}{
@@ -239,6 +240,7 @@ func TestHandleDeviceBlockVolume(t *testing.T) {
 					Format:   testBlkDriveFormat,
 				},
 			},
+			inputMount: Mount{},
 			resultVol: &pb.Storage{
 				Driver:  kataNvdimmDevType,
 				Source:  fmt.Sprintf("/dev/pmem%s", testNvdimmID),
@@ -248,18 +250,25 @@ func TestHandleDeviceBlockVolume(t *testing.T) {
 		},
 		{
 			BlockDeviceDriver: config.VirtioBlockCCW,
+			inputMount: Mount{
+				Type:    "bind",
+				Options: []string{"ro"},
+			},
 			inputDev: &drivers.BlockDevice{
 				BlockDrive: &config.BlockDrive{
 					DevNo: testDevNo,
 				},
 			},
 			resultVol: &pb.Storage{
-				Driver: kataBlkCCWDevType,
-				Source: testDevNo,
+				Driver:  kataBlkCCWDevType,
+				Source:  testDevNo,
+				Fstype:  "bind",
+				Options: []string{"ro"},
 			},
 		},
 		{
 			BlockDeviceDriver: config.VirtioBlock,
+			inputMount:        Mount{},
 			inputDev: &drivers.BlockDevice{
 				BlockDrive: &config.BlockDrive{
 					PCIAddr:  testPCIAddr,
@@ -320,7 +329,7 @@ func TestHandleDeviceBlockVolume(t *testing.T) {
 			},
 		}
 
-		vol, _ := k.handleDeviceBlockVolume(c, test.inputDev)
+		vol, _ := k.handleDeviceBlockVolume(c, test.inputMount, test.inputDev)
 		assert.True(t, reflect.DeepEqual(vol, test.resultVol),
 			"Volume didn't match: got %+v, expecting %+v",
 			vol, test.resultVol)
@@ -336,22 +345,27 @@ func TestHandleBlockVolume(t *testing.T) {
 	containers := map[string]*Container{}
 	containers[c.id] = c
 
-	// Create a VhostUserBlk device and a DeviceBlock device
+	// Create a devices for VhostUserBlk, standard DeviceBlock and direct assigned Block device
 	vDevID := "MockVhostUserBlk"
 	bDevID := "MockDeviceBlock"
+	dDevID := "MockDeviceBlockDirect"
 	vDestination := "/VhostUserBlk/destination"
 	bDestination := "/DeviceBlock/destination"
+	dDestination := "/DeviceDirectBlock/destination"
 	vPCIAddr := "0001:01"
 	bPCIAddr := "0002:01"
+	dPCIAddr := "0003:01"
 
 	vDev := drivers.NewVhostUserBlkDevice(&config.DeviceInfo{ID: vDevID})
 	bDev := drivers.NewBlockDevice(&config.DeviceInfo{ID: bDevID})
+	dDev := drivers.NewBlockDevice(&config.DeviceInfo{ID: dDevID})
 
 	vDev.VhostUserDeviceAttrs = &config.VhostUserDeviceAttrs{PCIAddr: vPCIAddr}
 	bDev.BlockDrive = &config.BlockDrive{PCIAddr: bPCIAddr}
+	dDev.BlockDrive = &config.BlockDrive{PCIAddr: dPCIAddr}
 
 	var devices []api.Device
-	devices = append(devices, vDev, bDev)
+	devices = append(devices, vDev, bDev, dDev)
 
 	// Create a VhostUserBlk mount and a DeviceBlock mount
 	var mounts []Mount
@@ -362,8 +376,16 @@ func TestHandleBlockVolume(t *testing.T) {
 	bMount := Mount{
 		BlockDeviceID: bDevID,
 		Destination:   bDestination,
+		Type:          "bind",
+		Options:       []string{"bind"},
 	}
-	mounts = append(mounts, vMount, bMount)
+	dMount := Mount{
+		BlockDeviceID: dDevID,
+		Destination:   dDestination,
+		Type:          "ext4",
+		Options:       []string{"ro"},
+	}
+	mounts = append(mounts, vMount, bMount, dMount)
 
 	tmpDir := "/vhost/user/dir"
 	dm := manager.NewDeviceManager(manager.VirtioBlock, true, tmpDir, devices)
@@ -398,9 +420,17 @@ func TestHandleBlockVolume(t *testing.T) {
 		Driver:     kataBlkDevType,
 		Source:     bPCIAddr,
 	}
+	dStorage := &pb.Storage{
+		MountPoint: dDestination,
+		Fstype:     "ext4",
+		Options:    []string{"ro"},
+		Driver:     kataBlkDevType,
+		Source:     dPCIAddr,
+	}
 
 	assert.Equal(t, vStorage, volumeStorages[0], "Error while handle VhostUserBlk type block volume")
 	assert.Equal(t, bStorage, volumeStorages[1], "Error while handle BlockDevice type block volume")
+	assert.Equal(t, dStorage, volumeStorages[2], "Error while handle direct BlockDevice type block volume")
 }
 
 func TestAppendDevicesEmptyContainerDeviceList(t *testing.T) {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1233,9 +1233,9 @@ func (q *qemu) hotplugAddBlockDevice(drive *config.BlockDrive, op operation, dev
 	}
 
 	if q.config.BlockDeviceCacheSet {
-		err = q.qmpMonitorCh.qmp.ExecuteBlockdevAddWithCache(q.qmpMonitorCh.ctx, drive.File, drive.ID, q.config.BlockDeviceCacheDirect, q.config.BlockDeviceCacheNoflush, false)
+		err = q.qmpMonitorCh.qmp.ExecuteBlockdevAddWithCache(q.qmpMonitorCh.ctx, drive.File, drive.ID, q.config.BlockDeviceCacheDirect, q.config.BlockDeviceCacheNoflush, drive.ReadOnly)
 	} else {
-		err = q.qmpMonitorCh.qmp.ExecuteBlockdevAdd(q.qmpMonitorCh.ctx, drive.File, drive.ID, false)
+		err = q.qmpMonitorCh.qmp.ExecuteBlockdevAdd(q.qmpMonitorCh.ctx, drive.File, drive.ID, drive.ReadOnly)
 	}
 	if err != nil {
 		return err

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1233,9 +1233,9 @@ func (q *qemu) hotplugAddBlockDevice(drive *config.BlockDrive, op operation, dev
 	}
 
 	if q.config.BlockDeviceCacheSet {
-		err = q.qmpMonitorCh.qmp.ExecuteBlockdevAddWithCache(q.qmpMonitorCh.ctx, drive.File, drive.ID, q.config.BlockDeviceCacheDirect, q.config.BlockDeviceCacheNoflush)
+		err = q.qmpMonitorCh.qmp.ExecuteBlockdevAddWithCache(q.qmpMonitorCh.ctx, drive.File, drive.ID, q.config.BlockDeviceCacheDirect, q.config.BlockDeviceCacheNoflush, false)
 	} else {
-		err = q.qmpMonitorCh.qmp.ExecuteBlockdevAdd(q.qmpMonitorCh.ctx, drive.File, drive.ID)
+		err = q.qmpMonitorCh.qmp.ExecuteBlockdevAdd(q.qmpMonitorCh.ctx, drive.File, drive.ID, false)
 	}
 	if err != nil {
 		return err

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1098,13 +1098,13 @@ func (s *Sandbox) addContainer(c *Container) error {
 // This should be called only when the sandbox is already created.
 // It will add new container config to sandbox.config.Containers
 func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, error) {
-	// Create the container.
+	// Create the container object, add devices to the sandbox's device-manager:
 	c, err := newContainer(s, &contConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	// Update sandbox config.
+	// Update sandbox config to include the new container's config
 	s.config.Containers = append(s.config.Containers, contConfig)
 
 	defer func() {
@@ -1116,6 +1116,7 @@ func (s *Sandbox) CreateContainer(contConfig ContainerConfig) (VCContainer, erro
 		}
 	}()
 
+	// create and start the container
 	err = c.create()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
If a volume is backed by a block device, let's make sure we take into account whether it should be hot plugged RO or not.

While updating this, I made some minor non-functional changes to correct comments, make storage handling a bit more clear.