### PR TITLE
packaging: Fix vmlinux kernel install on s390x

### DIFF
--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -403,6 +403,8 @@ install_kata() {
 	# Install uncompressed kernel
 	if [ "${arch_target}" = "arm64" ]; then
 		install --mode 0644 -D "arch/${arch_target}/boot/Image" "${install_path}/${vmlinux}"
+	elif [ "${arch_target}" = "s390" ]; then
+		install --mode 0644 -D "arch/${arch_target}/boot/compressed/vmlinux" "${install_path}/${vmlinux}"
 	else
 		install --mode 0644 -D "vmlinux" "${install_path}/${vmlinux}"
 	fi


### PR DESCRIPTION
Installing the built uncompressed vmlinux kernel will not work on s390x, QEMU will complain:
```
Linux kernel boot failure: An attempt to boot a vmlinux ELF image failed.
This image does not contain all parts necessary for starting up.
Use bzImage or arch/s390/boot/compressed/vmlinux instead.
```
Hence, use that kernel image on s390x.

Fixes: #1264