### PR TITLE
Fix snap CI

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -57,15 +57,10 @@ parts:
         *) echo "unsupported architecture: $(uname -m)"; exit 1;;
       esac
 
-      # Workaround to get latest release from github (to not use github token).
-      # Get the redirection to latest release on github.
-      yq_latest_url=$(curl -Ls -o /dev/null -w %{url_effective} "https://${yq_pkg}/releases/latest")
-      # The redirected url should include the latest release version
-      # https://github.com/mikefarah/yq/releases/tag/<VERSION-HERE>
-      yq_version=$(basename "${yq_latest_url}")
+      yq_version=3.4.1
       yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos}_${goarch}"
-      curl -o "${yq_path}" -LSsf ${yq_url}
-      chmod +x ${yq_path}
+      curl -o "${yq_path}" -LSsf "${yq_url}"
+      chmod +x "${yq_path}"
 
       kata_dir=gopath/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
       version="$(${yq_path} r ${kata_dir}/versions.yaml languages.golang.meta.newest-version)"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -68,7 +68,7 @@ parts:
       chmod +x ${yq_path}
 
       kata_dir=gopath/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
-      version="$(${yq_path} e .languages.golang.meta.newest-version ${kata_dir}/versions.yaml)"
+      version="$(${yq_path} r ${kata_dir}/versions.yaml languages.golang.meta.newest-version)"
       tarfile="go${version}.${goos}-${goarch}.tar.gz"
       curl -LO https://golang.org/dl/${tarfile}
       tar -xf ${tarfile} --strip-components=1
@@ -240,15 +240,15 @@ parts:
       # arch-specific definition
       case "$(uname -m)" in
         "aarch64")
-          branch="$(${yq} e .assets.hypervisor.qemu.architecture.aarch64.branch ${versions_file})"
-          url="$(${yq} e .assets.hypervisor.qemu.url ${versions_file})"
-          commit="$(${yq} e .assets.hypervisor.qemu.architecture.aarch64.commit ${versions_file})"
+          branch="$(${yq} r ${versions_file} assets.hypervisor.qemu.architecture.aarch64.branch)"
+          url="$(${yq} r ${versions_file} assets.hypervisor.qemu.url)"
+          commit="$(${yq} r ${versions_file} assets.hypervisor.qemu.architecture.aarch64.commit)"
           patches_dir="${kata_dir}/tools/packaging/obs-packaging/qemu-aarch64/patches/"
         ;;
 
         *)
-          branch="$(${yq} e .assets.hypervisor.qemu.tag ${versions_file})"
-          url="$(${yq} e .assets.hypervisor.qemu.url ${versions_file})"
+          branch="$(${yq} r ${versions_file} assets.hypervisor.qemu.tag)"
+          url="$(${yq} r ${versions_file} assets.hypervisor.qemu.url)"
           commit=""
           patches_dir="${kata_dir}/tools/packaging/qemu/patches/$(echo ${branch} | sed -e 's/.[[:digit:]]*$//' -e 's/^v//').x"
         ;;


### PR DESCRIPTION
yq major releases are not backward compatible, install the same
major version used in the CI to avoid conflics building the kata
components.
We should update yq when the CI updates it, not before.

fixes #1232

Signed-off-by: Julio Montes <julio.montes@intel.com>