### PR TITLE
Fix release scripts

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -38,12 +38,12 @@ jobs:
         run: |
          if grep -q $buildstr ./artifact-list/artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@master
         with:
           name: kata-artifacts
@@ -66,12 +66,12 @@ jobs:
         run: |
          if grep -q $buildstr ./artifact-list/artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@master
         with:
           name: kata-artifacts
@@ -92,12 +92,12 @@ jobs:
         run: |
          if grep -q $buildstr ./artifact-list/artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@master
         with:
           name: kata-artifacts
@@ -118,12 +118,12 @@ jobs:
         run: |
          if grep -q $buildstr ./artifact-list/artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@master
         with:
           name: kata-artifacts
@@ -145,12 +145,12 @@ jobs:
         run: |
          if grep -q $buildstr ./artifact-list/artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@master
         with:
           name: kata-artifacts
@@ -172,12 +172,12 @@ jobs:
         run: |
          if grep -q $buildstr ./artifact-list/artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@master
         with:
           name: kata-artifacts
@@ -199,12 +199,12 @@ jobs:
         run: |
          if grep -q $buildstr ./artifact-list/artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@master
         with:
           name: kata-artifacts
@@ -226,12 +226,12 @@ jobs:
         run: |
          if grep -q $buildstr ./artifact-list/artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@master
         with:
           name: kata-artifacts
@@ -253,12 +253,12 @@ jobs:
         run: |
          if grep -q $buildstr ./artifact-list/artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@master
         with:
           name: kata-artifacts
@@ -303,9 +303,6 @@ jobs:
           docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t katadocker/kata-deploy-ci:$pkg_sha ./packaging/kata-deploy
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker push katadocker/kata-deploy-ci:$pkg_sha
-
-          echo "##[set-output name=PKG_SHA;]${pkg_sha}"
-          echo ::set-env name=TAG::$tag
       - name: test-kata-deploy-ci-in-aks
         uses: ./packaging/kata-deploy/action
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,12 +39,12 @@ jobs:
         run: |
          if grep -q $buildstr artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-local-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: kata-artifacts
@@ -67,12 +67,12 @@ jobs:
         run: |
          if grep -q $buildstr artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-local-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: kata-artifacts
@@ -93,12 +93,12 @@ jobs:
         run: |
          if grep -q $buildstr artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-local-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: kata-artifacts
@@ -119,12 +119,12 @@ jobs:
         run: |
          if grep -q $buildstr artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-local-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: kata-artifacts
@@ -145,12 +145,12 @@ jobs:
         run: |
          if grep -q $buildstr artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-local-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: artifact-built == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: kata-artifacts
@@ -171,12 +171,12 @@ jobs:
         run: |
          if grep -q $buildstr artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-local-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: kata-artifacts
@@ -198,12 +198,12 @@ jobs:
         run: |
          if grep -q $buildstr artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-local-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: kata-artifacts
@@ -224,12 +224,12 @@ jobs:
         run: |
          if grep -q $buildstr artifact-list.txt; then
            $GITHUB_WORKSPACE/.github/workflows/generate-local-artifact-tarball.sh $buildstr
-           echo ::set-env name=artifact-built::true
+           echo "artifact-built=true" >> $GITHUB_ENV
          else
-           echo ::set-env name=artifact-built::false
+           echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: env.artifact-built == 'true'
+        if: $artifact-built == 'true'
         uses: actions/upload-artifact@v2
         with:
           name: kata-artifacts
@@ -275,9 +275,6 @@ jobs:
           docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t katadocker/kata-deploy-ci:$pkg_sha $GITHUB_WORKSPACE/tools/packaging/kata-deploy
           docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_PASSWORD }}
           docker push katadocker/kata-deploy-ci:$pkg_sha
-
-          echo "##[set-output name=PKG_SHA;]${pkg_sha}"
-          echo ::set-env name=TAG::$tag
           mkdir -p packaging/kata-deploy
           ln -s $GITHUB_WORKSPACE/tools/packaging/kata-deploy/action packaging/kata-deploy/action
       - name: test-kata-deploy-ci-in-aks

--- a/tools/packaging/release/tag_repos.sh
+++ b/tools/packaging/release/tag_repos.sh
@@ -69,6 +69,7 @@ info() {
 
 repos=(
 	"kata-containers"
+	"tests"
 )
 
 

--- a/tools/packaging/release/update-repository-version.sh
+++ b/tools/packaging/release/update-repository-version.sh
@@ -165,6 +165,7 @@ EOT
 
 repos=(
 	"kata-containers"
+	"tests"
 )
 
 main(){


### PR DESCRIPTION
 GH Actions deprecated set-env, which was utilized for a couple of workflows (in particular release).  Let's update.

While at it, for 2.0 we weren't tagging/bumping the tests repo. Let's continue to do this.