### PR TITLE
actions: fix error with nemu build job

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -44,7 +44,7 @@ jobs:
            echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: ${{ env.artifact-built }} == 'true'
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
@@ -72,7 +72,7 @@ jobs:
            echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: ${{ env.artifact-built }} == 'true'
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
@@ -98,7 +98,7 @@ jobs:
            echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: ${{ env.artifact-built }} == 'true'
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
@@ -124,7 +124,7 @@ jobs:
            echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: ${{ env.artifact-built }} == 'true'
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
@@ -151,7 +151,7 @@ jobs:
            echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: ${{ env.artifact-built }} == 'true'
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
@@ -178,7 +178,7 @@ jobs:
            echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: ${{ env.artifact-built }} == 'true'
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
@@ -205,7 +205,7 @@ jobs:
            echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: ${{ env.artifact-built }} == 'true'
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
@@ -232,7 +232,7 @@ jobs:
            echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: ${{ env.artifact-built }} == 'true'
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts
@@ -259,7 +259,7 @@ jobs:
            echo "artifact-built=false" >> $GITHUB_ENV
          fi
       - name: store-artifacts
-        if: ${{ env.artifact-built }} == 'true'
+        if: env.artifact-built == 'true'
         uses: actions/upload-artifact@v1
         with:
           name: kata-artifacts


### PR DESCRIPTION
No need to dereference the environment variable. Doing so will result in
a true evaluation, which was causing NEMU to be tracked as built, when
it actually wasn't. This only impacts 1.x workflows, and is why it
wasn't caught with 2.x release process.

Fixes: #1273

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>