### PR TITLE
agent: implement NVDIMM/PMEM block driver

### DIFF
--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -162,6 +162,14 @@ pub async fn get_pci_device_name(sandbox: &Arc<Mutex<Sandbox>>, pci_id: &str) ->
     get_device_name(sandbox, &pci_addr).await
 }
 
+pub async fn get_pmem_device_name(
+    sandbox: &Arc<Mutex<Sandbox>>,
+    pmem_devname: &str,
+) -> Result<String> {
+    let dev_sub_path = format!("/{}/{}", SCSI_BLOCK_SUFFIX, pmem_devname);
+    get_device_name(sandbox, &dev_sub_path).await
+}
+
 /// Scan SCSI bus for the given SCSI address(SCSI-Id and LUN)
 fn scan_scsi_bus(scsi_addr: &str) -> Result<()> {
     let tokens: Vec<&str> = scsi_addr.split(':').collect();

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -58,6 +58,13 @@ pub fn create_pci_root_bus_path() -> String {
     ret
 }
 
+// From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
+// The Linux kernel's core ACPI subsystem creates struct acpi_device
+// objects for ACPI namespace objects representing devices, power resources
+// processors, thermal zones. Those objects are exported to user space via
+// sysfs as directories in the subtree under /sys/devices/LNXSYSTM:00
+pub const ACPI_DEV_PATH: &str = "/devices/LNXSYSTM";
+
 pub const SYSFS_CPU_ONLINE_PATH: &str = "/sys/devices/system/cpu";
 
 pub const SYSFS_MEMORY_BLOCK_SIZE_PATH: &str = "/sys/devices/system/memory/block_size_bytes";


### PR DESCRIPTION
Support pmem-csi[1] k8s pluging, unlike SCSI and virtio devices,
NVDIMM/PMEM devices support DAX, improving IO Read and Write
operations.

fixes #1289

Signed-off-by: Julio Montes <julio.montes@intel.com>

[1]: https://github.com/intel/pmem-csi