### PR TITLE
rustjail: fix the issue of missing destroy contaienr cgroups

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1039,6 +1039,10 @@ impl BaseContainer for LinuxContainer {
             MntFlags::MNT_DETACH,
         )?;
         fs::remove_dir_all(&self.root)?;
+
+        if let Some(cgm) = self.cgroup_manager.as_mut() {
+            cgm.destroy().context("destroy cgroups")?;
+        }
         Ok(())
     }
 


### PR DESCRIPTION
In the container's destroy method, it should destroy
the container's cgroups.

Fixes: #1291

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>