### PR TITLE
snap: Don't release Kata Alpha/RC in snap store

### DIFF
--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -21,8 +21,8 @@ jobs:
           kata_url="https://github.com/kata-containers/kata-containers"
           latest_version=$(git ls-remote --tags ${kata_url}  | egrep -o "refs.*" | egrep -v "\-alpha|\-rc|{}" | egrep -o "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+" | sort -V -r | head -1)
           current_version="$(echo ${GITHUB_REF} | cut -d/ -f3)"
-          # Check if the current tag is the latest tag
-          if echo -e "$latest_version\n$current_version" | sort -C -V; then
+          # Check semantic versioning format (x.y.z) and if the current tag is the latest tag
+          if echo "${current_version}" | grep -q "^[[:digit:]]\+\.[[:digit:]]\+\.[[:digit:]]\+$" && echo -e "$latest_version\n$current_version" | sort -C -V; then
             # Current version is the latest version, build it
             snapcraft -d snap --destructive-mode
           fi


### PR DESCRIPTION
Stable and candidate snapcraft's channels are used to release Kata
Containers 1.x and 2.x respectively. Alpha and RC releases shouldn't
be pushed to the snap store because there are not enough channels
for all the releases of Kata Containers 1.x and 2.x.

fixes #1303

Signed-off-by: Julio Montes <julio.montes@intel.com>