### PR TITLE
osbuilder: remove traces of cmake

### DIFF
--- a/tools/osbuilder/dracut/Dockerfile.in
+++ b/tools/osbuilder/dracut/Dockerfile.in
@@ -10,7 +10,6 @@ RUN zypper --non-interactive refresh; \
     autoconf \
     automake \
     binutils \
-    cmake \
     coreutils \
     cpio \
     curl \

--- a/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
@@ -33,8 +33,6 @@ RUN yum -y update && yum install -y \
     vim \
     which
 
-# install cmake because centos7's cmake is too old
-@INSTALL_CMAKE@
 @INSTALL_MUSL@
 # This will install the proper golang to build Kata components
 @INSTALL_GO@

--- a/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
@@ -12,7 +12,6 @@ RUN dnf -y update && dnf install -y \
     automake \
     binutils \
     chrony \
-    cmake \
     coreutils \
     curl \
     curl \

--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in
@@ -13,7 +13,6 @@ RUN apt-get update && apt-get install -y \
     binutils \
     build-essential \
     chrony \
-    cmake \
     coreutils \
     curl \
     debianutils \

--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
@@ -15,7 +15,6 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
     build-essential \
     ca-certificates \
     chrony \
-    cmake \
     coreutils \
     curl \
     debianutils \

--- a/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
@@ -12,7 +12,6 @@ RUN dnf -y update && dnf install -y \
     automake \
     binutils \
     chrony \
-    cmake \
     coreutils \
     curl \
     gcc \

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -17,7 +17,6 @@ GO_AGENT_PKG=${GO_AGENT_PKG:-github.com/kata-containers/agent}
 RUST_AGENT_PKG=${RUST_AGENT_PKG:-github.com/kata-containers/kata-containers}
 RUST_AGENT=${RUST_AGENT:-yes}
 RUST_VERSION="null"
-CMAKE_VERSION=${CMAKE_VERSION:-"null"}
 MUSL_VERSION=${MUSL_VERSION:-"null"}
 AGENT_BIN=${AGENT_BIN:-kata-agent}
 AGENT_INIT=${AGENT_INIT:-no}
@@ -353,11 +352,6 @@ build_rootfs_distro()
 		die "Could not detect the required rust version for AGENT_VERSION='${AGENT_VERSION:-master}'."
 
 	echo "Required rust version: $RUST_VERSION"
-
-	detect_cmake_version ||
-		die "Could not detect the required cmake version for AGENT_VERSION='${AGENT_VERSION:-master}'."
-
-	echo "Required cmake version: $CMAKE_VERSION"
 
 	detect_musl_version ||
 		die "Could not detect the required musl version for AGENT_VERSION='${AGENT_VERSION:-master}'."

--- a/tools/osbuilder/rootfs-builder/suse/install-packages.sh
+++ b/tools/osbuilder/rootfs-builder/suse/install-packages.sh
@@ -28,7 +28,6 @@ zypper --non-interactive install --no-recommends --force-resolution \
     autoconf \
     automake \
     binutils \
-    cmake \
     coreutils \
     curl \
     gcc \

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
@@ -17,7 +17,6 @@ RUN apt-get update && apt-get install -y \
     binutils \
     build-essential \
     chrony \
-    cmake \
     coreutils \
     curl \
     debianutils \

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -19,7 +19,6 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
     build-essential \
     ca-certificates \
     chrony \
-    cmake \
     coreutils \
     curl \
     debianutils \

--- a/tools/osbuilder/tests/test_images.sh
+++ b/tools/osbuilder/tests/test_images.sh
@@ -644,8 +644,6 @@ test_dracut()
 		die "Could not detect the required Go version for AGENT_VERSION='${AGENT_VERSION:-master}'."
 	detect_rust_version ||
 		die "Could not detect the required rust version for AGENT_VERSION='${AGENT_VERSION:-master}'."
-	detect_cmake_version ||
-		die "Could not detect the required cmake version for AGENT_VERSION='${AGENT_VERSION:-master}'."
 	detect_musl_version ||
 		die "Could not detect the required musl version for AGENT_VERSION='${AGENT_VERSION:-master}'."
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -237,19 +237,6 @@ externals:
       .*/v?(\d\S+)\.tar\.gz
     version: "v1.0.0-rc5"
 
-  cmake:
-    description: |
-      Build system, to build grpc-rs.
-    url: "https://github.com/Kitware/CMake"
-    uscan-url: >-
-      https://github.com/Kitware/CMake/releases/download/
-      v?([\d\.]+)/cmake-([\d\.]+)\.tar\.gz
-    version: "3.15.3"
-    meta:
-      description: |
-        'newest-version' is the latest version known to work.
-      newest-version: "3.15.3"
-
   musl:
     description: |
       The musl library is used to build the rust agent.


### PR DESCRIPTION
AFAICT cmake is referenced in the osbuilder scripts, but never actually invoked.