### PR TITLE
virtcontainers: Set nodev, nosuid, and no exec as virtiofsd options

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -78,7 +78,7 @@ var (
 	kataNvdimmDevType           = "nvdimm"
 	kataVirtioFSDevType         = "virtio-fs"
 	sharedDir9pOptions          = []string{"trans=virtio,version=9p2000.L,cache=mmap", "nodev"}
-	sharedDirVirtioFSOptions    = []string{}
+	sharedDirVirtioFSOptions    = []string{"nodev", "nosuid", "noexec"}
 	sharedDirVirtioFSDaxOptions = "dax"
 	shmDir                      = "shm"
 	kataEphemeralDevType        = "ephemeral"


### PR DESCRIPTION
Setting those come as a recommendation from Stefan Hajnoczi as a way to
mitigate the CVE-2020-35517, which is already known and not embargoed.

In the patch sent to the QEMU mailing list[0] Stefan mentions:

"A well-behaved FUSE client does not attempt to open special files with
FUSE_OPEN because they are handled on the client side (e.g. device nodes
are handled by client-side device drivers).

The check to prevent virtiofsd from opening special files is missing in
a few cases, most notably FUSE_OPEN. A malicious client can cause
virtiofsd to open a device node, potentially allowing the guest to
escape. This can be exploited by a modified guest device driver. It is
not exploitable from guest userspace since the guest kernel will handle
special files inside the guest instead of sending FUSE requests."

He also goes further and suggests a mitigation that could be taken on
the Kata Containers and libvirt side:
"A stronger fix, and the long-term solution, is for users to mount the
shared directory and any sub-mounts with nodev, as well as nosuid and
noexec. Unfortunately virtiofsd cannot do this automatically because
bind mounts added by the user after virtiofsd has launched would not be
detected. I suggest the following:

1. Modify libvirt and Kata Containers to explicitly set these mount
   options.
2. Then modify virtiofsd to check that the shared directory has the
   necessary options at startup. Refuse to start if the options are
   missing so that the user is aware of the security requirements."

Knowing that, this patch is temptative fix on our side and the virtiofsd
should also be backported to our QEMU, whenever it gets merged (it's not
been merged by the moment I'm sending this PR).

[0]: https://www.mail-archive.com/qemu-devel@nongnu.org/msg775183.html

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>