### PR TITLE
branch: change 2.0-dev to main

### DIFF
--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -34,7 +34,7 @@ jobs:
         id: build-container-image
         run: |
             PR_SHA=$(git log --format=format:%H -n1)
-            VERSION=$(curl https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/VERSION)
+            VERSION=$(curl https://raw.githubusercontent.com/kata-containers/kata-containers/main/VERSION)
             ARTIFACT_URL="https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-static-${VERSION}-x86_64.tar.xz"
             wget "${ARTIFACT_URL}" -O ./kata-deploy/kata-static.tar.xz
             docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t katadocker/kata-deploy-ci:${PR_SHA} ./kata-deploy

--- a/README.md
+++ b/README.md
@@ -126,9 +126,9 @@ The following repositories are used by both the current and first generation Kat
 
 | Component | Description | Current | First generation | Notes |
 |-|-|-|-|-|
-| CI | Continuous Integration configuration files and scripts. | [Kata 2.x](https://github.com/kata-containers/ci/tree/2.0-dev) | [Kata 1.x](https://github.com/kata-containers/ci/tree/master) | |
+| CI | Continuous Integration configuration files and scripts. | [Kata 2.x](https://github.com/kata-containers/ci/tree/main) | [Kata 1.x](https://github.com/kata-containers/ci/tree/master) | |
 | kernel | The Linux kernel used by the hypervisor to boot the guest image. | [Kata 2.x][kernel] | [Kata 1.x][kernel] | Patches are stored in the packaging component. |
-| tests | Test code. | [Kata 2.x](https://github.com/kata-containers/tests/tree/2.0-dev) | [Kata 1.x](https://github.com/kata-containers/tests/tree/master) | Excludes unit tests which live with the main code. |
+| tests | Test code. | [Kata 2.x](https://github.com/kata-containers/tests/tree/main) | [Kata 1.x](https://github.com/kata-containers/tests/tree/master) | Excludes unit tests which live with the main code. |
 | www.katacontainers.io | Contains the source for the [main web site](https://www.katacontainers.io). | [Kata 2.x][github-katacontainers.io] | [Kata 1.x][github-katacontainers.io] | | |
 
 ### Packaging and releases

--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -5,7 +5,7 @@
 
 export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 export tests_repo_dir="$GOPATH/src/$tests_repo"
-export branch="${branch:-2.0-dev}"
+export branch="${branch:-main}"
 
 clone_tests_repo()
 {

--- a/docs/how-to/how-to-set-prometheus-in-k8s.md
+++ b/docs/how-to/how-to-set-prometheus-in-k8s.md
@@ -34,7 +34,7 @@ Also you should ensure that `kubectl` working correctly.
 Start Prometheus by utilizing our sample manifest:
 
 ```
-$ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/docs/how-to/data/prometheus.yml
+$ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/docs/how-to/data/prometheus.yml
 ```
 
 This will create a new namespace, `prometheus`, and create the following resources:
@@ -60,7 +60,7 @@ go_gc_duration_seconds{quantile="0.75"} 0.000229911
 `kata-monitor` can be started on the cluster as follows:
 
 ```
-$ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/docs/how-to/data/kata-monitor-daemonset.yml
+$ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/docs/how-to/data/kata-monitor-daemonset.yml
 ```
 
 This will create a new namespace `kata-system` and a `daemonset` in it.
@@ -73,7 +73,7 @@ Once the `daemonset` is running, Prometheus should discover `kata-monitor` as a 
 Run this command to run Grafana in Kubernetes:
 
 ```
-$ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/docs/how-to/data/grafana.yml
+$ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/docs/how-to/data/grafana.yml
 ```
 
 This will create deployment and service for Grafana under namespace `prometheus`.
@@ -99,7 +99,7 @@ You can import this dashboard using Grafana UI, or using `curl` command in conso
 $ curl -XPOST -i localhost:3000/api/dashboards/import \
     -u admin:admin \
     -H "Content-Type: application/json" \
-	-d "{\"dashboard\":$(curl -sL https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/docs/how-to/data/dashboard.json )}"
+	-d "{\"dashboard\":$(curl -sL https://raw.githubusercontent.com/kata-containers/kata-containers/main/docs/how-to/data/dashboard.json )}"
 ```
 
 ## References

--- a/docs/install/snap-installation-guide.md
+++ b/docs/install/snap-installation-guide.md
@@ -110,8 +110,8 @@ can be used as runtime.
 
 Read the following documents to know how to run Kata Containers 2.x with `containerd`.
 
-* [How to use Kata Containers and Containerd](https://github.com/kata-containers/kata-containers/blob/2.0-dev/docs/how-to/containerd-kata.md)
-* [Install Kata Containers with containerd](https://github.com/kata-containers/kata-containers/blob/2.0-dev/docs/install/container-manager/containerd/containerd-install.md)
+* [How to use Kata Containers and Containerd](https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/containerd-kata.md)
+* [Install Kata Containers with containerd](https://github.com/kata-containers/kata-containers/blob/main/docs/install/container-manager/containerd/containerd-install.md)
 
 
 ## Remove Kata Containers snap package

--- a/tools/packaging/kernel/README.md
+++ b/tools/packaging/kernel/README.md
@@ -127,9 +127,9 @@ configuration.
 Example:
 
 ```bash
-# From https://github.com/kata-containers/kata-containers/blob/2.0-dev/versions.yaml
+# From https://github.com/kata-containers/kata-containers/blob/main/versions.yaml
 $ kernel_version_in_versions_file=5.4.60
-# From https://github.com/kata-containers/kata-containers/blob/2.0-dev/tools/packaging/kernel/kata_config_version
+# From https://github.com/kata-containers/kata-containers/blob/main/tools/packaging/kernel/kata_config_version
 $ kata_config_version=83
 $ latest_kernel_version=${kernel_version_in_versions_file}-${kata_config_version}
 ```

--- a/tools/packaging/release/tag_repos_test.sh
+++ b/tools/packaging/release/tag_repos_test.sh
@@ -19,7 +19,7 @@ echo "Check tag_repos.sh status"
 ./release/tag_repos.sh status | grep kata-containers
 
 echo "Check tag_repos.sh pre-release"
-./release/tag_repos.sh pre-release $(curl -sL https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/VERSION) | grep "Not checking runtime"
+./release/tag_repos.sh pre-release $(curl -sL https://raw.githubusercontent.com/kata-containers/kata-containers/main/VERSION) | grep "Not checking runtime"
 
 echo "Check tag_repos.sh pre-release with invalid information"
 ./release/tag_repos.sh pre-release 1000000 | grep "ERROR" || true

--- a/tools/packaging/scripts/gen_versions_txt.sh
+++ b/tools/packaging/scripts/gen_versions_txt.sh
@@ -144,7 +144,7 @@ main() {
 		local repo_dir="kata-containers"
 		git clone --quiet "https://${repo}.git" "${repo_dir}"
 		pushd "${repo_dir}" >> /dev/null
-		local branch=$(git branch -r -q --contains "${tag}" | grep -E "master|stable|2.0-dev" | grep -v HEAD)
+		local branch=$(git branch -r -q --contains "${tag}" | grep -E "master|stable|main" | grep -v HEAD)
 
 		popd >> /dev/null
 		rm -rf ${repo_dir}

--- a/utils/README.md
+++ b/utils/README.md
@@ -41,7 +41,7 @@ If you still wish to continue, but prefer a manual installation, see
 To install and configure a system with Kata Containers and containerd, run:
 
 ```bash
-$ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/2.0-dev/utils/kata-manager.sh)"
+$ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh)"
 ```
 
 > **Notes:**


### PR DESCRIPTION
Change all mentioning of 2.0-dev to main so that we can rename the
default branch to main.

Fixes: #1310