### PR TITLE
arm64: enable acpi for qemu/virt.

### DIFF
--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -25,9 +25,17 @@ pub fn create_pci_root_bus_path() -> String {
 pub fn create_pci_root_bus_path() -> String {
     let ret = String::from("/devices/platform/4010000000.pcie/pci0000:00");
 
+    let acpi_root_bus_path = String::from("/devices/pci0000:00");
+    let mut acpi_sysfs_dir = String::from(SYSFS_DIR);
     let mut sysfs_dir = String::from(SYSFS_DIR);
     let mut start_root_bus_path = String::from("/devices/platform/");
     let end_root_bus_path = String::from("/pci0000:00");
+
+    // check if there is pci bus path for acpi
+    acpi_sysfs_dir.push_str(&acpi_root_bus_path);
+    if let Ok(_) = fs::metadata(&acpi_sysfs_dir) {
+        return acpi_root_bus_path;
+    }
 
     sysfs_dir.push_str(&start_root_bus_path);
     let entries = match fs::read_dir(sysfs_dir) {

--- a/src/runtime/cli/config/configuration-qemu.toml.in
+++ b/src/runtime/cli/config/configuration-qemu.toml.in
@@ -241,6 +241,10 @@ valid_file_mem_backends = @DEFVALIDFILEMEMBACKENDS@
 # The behaviour is undefined if mem_prealloc is also set to true
 #enable_swap = true
 
+# -pflash can add image file to VM. The arguments of it should be in format
+# of ["/path/to/flash0.img", "/path/to/flash1.img"]
+pflashes = []
+
 # This option changes the default hypervisor and kernel parameters
 # to enable debug output where available.
 #

--- a/src/runtime/pkg/katatestutils/utils.go
+++ b/src/runtime/pkg/katatestutils/utils.go
@@ -28,6 +28,7 @@ type RuntimeConfigOptions struct {
 	AgentTraceType       string
 	SharedFS             string
 	VirtioFSDaemon       string
+	PFlash               []string
 	PCIeRootPort         uint32
 	DisableBlock         bool
 	EnableIOThreads      bool

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -333,6 +333,9 @@ type HypervisorConfig struct {
 	// FileBackedMemRootList is the list of valid root directories values for annotations
 	FileBackedMemRootList []string
 
+	// PFlash image paths
+	PFlash []string
+
 	// customAssets is a map of assets.
 	// Each value in that map takes precedence over the configured assets.
 	// For example, if there is a value for the "kernel" key in this map,

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -262,6 +262,7 @@ func (q *qemu) setup(id string, hypervisorConfig *HypervisorConfig) error {
 	}
 
 	q.arch.setBridges(q.state.Bridges)
+	q.arch.setPFlash(q.config.PFlash)
 
 	if create {
 		q.Logger().Debug("Creating bridges")
@@ -572,6 +573,11 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 		return err
 	}
 
+	pflash, err := q.arch.getPFlash()
+	if err != nil {
+		return err
+	}
+
 	qemuPath, err := q.qemuPath()
 	if err != nil {
 		return err
@@ -595,6 +601,7 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 		VGA:         "none",
 		GlobalParam: "kvm-pit.lost_tick_policy=discard",
 		Bios:        firmwarePath,
+		PFlash:      pflash,
 		PidFile:     filepath.Join(q.store.RunVMStoragePath(), q.id, "pid"),
 	}
 

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -119,6 +119,12 @@ type qemuArch interface {
 	// addBridge adds a new Bridge to the list of Bridges
 	addBridge(types.Bridge)
 
+	// getPFlash() get pflash from configuration
+	getPFlash() ([]string, error)
+
+	// setPFlash() grants access to pflash
+	setPFlash([]string)
+
 	// handleImagePath handles the Hypervisor Config image path
 	handleImagePath(config HypervisorConfig)
 
@@ -151,6 +157,7 @@ type qemuArchBase struct {
 	kernelParamsDebug    []Param
 	kernelParams         []Param
 	Bridges              []types.Bridge
+	PFlash		     []string
 }
 
 const (
@@ -797,4 +804,12 @@ func (q *qemuArchBase) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Devi
 func (q *qemuArchBase) appendPVPanicDevice(devices []govmmQemu.Device) ([]govmmQemu.Device, error) {
 	devices = append(devices, govmmQemu.PVPanicDevice{NoShutdown: true})
 	return devices, nil
+}
+
+func (q *qemuArchBase) getPFlash() ([]string, error) {
+	return q.PFlash, nil
+}
+
+func (q *qemuArchBase) setPFlash(p []string) {
+	q.PFlash = p
 }

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -119,3 +119,16 @@ func (q *qemuArm64) append9PVolume(devices []govmmQemu.Device, volume types.Volu
 	devices = append(devices, d)
 	return devices, nil
 }
+
+func (q *qemuArm64) getPFlash() ([]string, error) {
+	length := len(q.PFlash)
+	if length == 0 {
+		return nil, nil
+	} else if length == 1 {
+		return nil, fmt.Errorf("two pflash images needed for arm64")
+	} else if length == 2 {
+		return q.PFlash, nil
+	} else {
+		return nil, fmt.Errorf("too many pflash images for arm64")
+	}
+}

--- a/tools/packaging/kernel/configs/fragments/arm64/acpi.conf
+++ b/tools/packaging/kernel/configs/fragments/arm64/acpi.conf
@@ -3,3 +3,4 @@ CONFIG_EFI=y
 CONFIG_EFI_STUB=y
 # ARM64 can run properly in ACPI hardware reduced mode.
 CONFIG_ACPI_REDUCED_HARDWARE_ONLY=y
+CONFIG_RTC_DRV_EFI=y

--- a/tools/packaging/kernel/configs/fragments/arm64/base.conf
+++ b/tools/packaging/kernel/configs/fragments/arm64/base.conf
@@ -24,10 +24,6 @@ CONFIG_PERF_EVENTS=y
 CONFIG_ARM64_PSEUDO_NMI=y
 CONFIG_ARM64_SVE=y
 
-# Arm64 prefers to use REFCOUNT_FULL by default, disable it as the
-# latest kernel has discarded it, add it to whitelist.
-CONFIG_REFCOUNT_FULL=y
-
 #
 # ARMv8.1 architectural features
 #


### PR DESCRIPTION
acpi is enabled for kata 1.x, port and rebase code for 2.x
including:
runtime: enable pflash;
agent: add acpi support for pci bus path;
packaging: enable CONFIG_RTC_DRV_EFI;

Fixes: #1317
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@bergwolf  @jodh-intel 