### PR TITLE
agent: README update to install protoc for ppc64le

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -49,6 +49,11 @@ $ rustup target add "${arch}-unknown-linux-musl"
 $ sudo ln -s /usr/bin/g++ /bin/musl-g++
 ```
 
+ppc64le-only: Manually install `protoc`, e.g.
+```bash
+$ sudo dnf install protobuf-compiler
+```
+
 Download the source files in the Kata containers repository and build the agent:
 ```bash
 $ GOPATH="${GOPATH:-$HOME/go}"


### PR DESCRIPTION
Add a bit to the agent README about installing protoc manually for Power (ppc64le)

Fixes: #1068

Signed-off-by: Christy Norman <christy@linux.vnet.ibm.com>