### PR TITLE
wip: osbuilder: Build agent in the container if feasible

### DIFF
--- a/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
@@ -8,4 +8,5 @@ From docker.io/alpine:3.11.6
 RUN apk update && apk add \
 		  bash \
 		  coreutils \
+		  curl \
 		  binutils

--- a/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
@@ -34,6 +34,6 @@ RUN yum -y update && yum install -y \
     which
 
 @INSTALL_MUSL@
-# This will install the proper golang to build Kata components
+# This will install the proper golang, rustc to build Kata components
 @INSTALL_GO@
 @INSTALL_RUST@


### PR DESCRIPTION
Some cleanup, and refactoring. Rather than relying on host to build the
agent, for all guest-distributions except Alpine, build the agent within
the build-container.

Minor refactoring to facilitate this in a sane way. We are still
installing GoLang in the build-container, and bind mounting in our
GoPath, seemingly just because of yq. We should look at cleaning this up
in the future.

Removed Go-Agent'isms.


Testing still in progress, though initial issues are also observed with main:
 - [ ] - gentoo rootfs creation appears broken (why do we support gentoo? :) )
 - [ ] - Alpine fails when you create the resulting image, but this is same with main
 - [ ] - Suse is created with rootfs- instead of rootfs-Suse, but this is same with main

Opens: do we have CI in place to exercise each of the (many) distros we are currently supporting?
