### PR TITLE
runtime: connect guest debug console bypass kata-monitor

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -491,7 +491,7 @@ exit
 ```
 
 `kata-runtime exec` has a command-line option `runtime-namespace`, which is used to specify under which [runtime namespace](https://github.com/containerd/containerd/blob/master/docs/namespaces.md) the particular pod was created. By default, it is set to `k8s.io` and works for containerd when configured
- with Kubernetes. This should not be confused with [Kubernetes namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
+ with Kubernetes. For CRI-O, the namespace should set to `default` explicitly. This should not be confused with [Kubernetes namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
 For other CRI-runtimes and configurations, you may need to set the namespace utilizing the `runtime-namespace` option.
 
 If you want to access guest OS through a traditional way, see [Traditional debug console setup)](#traditional-debug-console-setup).

--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -37,7 +37,6 @@
     * [Set up a debug console](#set-up-a-debug-console)
       * [Simple debug console setup](#simple-debug-console-setup)
           * [Enable agent debug console](#enable-agent-debug-console)
-          * [Start `kata-monitor`](#start-kata-monitor)
           * [Connect to debug console](#connect-to-debug-console)
       * [Traditional debug console setup](#traditional-debug-console-setup)
           * [Create a custom image containing a shell](#create-a-custom-image-containing-a-shell)
@@ -477,17 +476,6 @@ debug_console_enabled = true
 
 This will pass `agent.debug_console agent.debug_console_vport=1026` to agent as kernel parameters, and sandboxes created using this parameters will start a shell in guest if new connection is accept from VSOCK.
 
-#### Start `kata-monitor`
-
-The `kata-runtime exec` command needs `kata-monitor` to get the sandbox's `vsock` address to connect to, first start `kata-monitor`.
-
-```
-$ sudo kata-monitor
-```
-
-`kata-monitor` will serve at `localhost:8090` by default.
-
-
 #### Connect to debug console
 
 Command `kata-runtime exec` is used to connect to the debug console.
@@ -501,6 +489,8 @@ bash-4.2# pwd
 bash-4.2# exit
 exit
 ```
+
+`kata-runtime exec` has a command-line option `runtime-namespace`, which is used to specify under which namespace the containers(Pods) are created. By default, it is set to `k8s.io` and works for containerd, for other upper runtimes, you may need to set the namespace by `runtime-namespace` option.
 
 If you want to access guest OS through a traditional way, see [Traditional debug console setup)](#traditional-debug-console-setup).
 

--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -490,7 +490,9 @@ bash-4.2# exit
 exit
 ```
 
-`kata-runtime exec` has a command-line option `runtime-namespace`, which is used to specify under which namespace the containers(Pods) are created. By default, it is set to `k8s.io` and works for containerd, for other upper runtimes, you may need to set the namespace by `runtime-namespace` option.
+`kata-runtime exec` has a command-line option `runtime-namespace`, which is used to specify under which [runtime namespace](https://github.com/containerd/containerd/blob/master/docs/namespaces.md) the particular pod was created. By default, it is set to `k8s.io` and works for containerd when configured
+ with Kubernetes. This should not be confused with [Kubernetes namespaces](https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/).
+For other CRI-runtimes and configurations, you may need to set the namespace utilizing the `runtime-namespace` option.
 
 If you want to access guest OS through a traditional way, see [Traditional debug console setup)](#traditional-debug-console-setup).
 

--- a/src/runtime/cli/kata-exec.go
+++ b/src/runtime/cli/kata-exec.go
@@ -14,6 +14,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"sync"
@@ -175,7 +176,7 @@ func (s *iostream) Read(data []byte) (n int, err error) {
 }
 
 func getConn(namespace, sandboxID string, port uint64) (net.Conn, error) {
-	socketAddr := fmt.Sprintf("/containerd-shim/%s/%s/shim-monitor.sock", namespace, sandboxID)
+	socketAddr := filepath.Join(string(filepath.Separator), "containerd-shim", namespace, sandboxID, "shim-monitor.sock")
 	client, err := kataMonitor.BuildUnixSocketClient(socketAddr, defaultTimeout)
 	if err != nil {
 		return nil, err

--- a/src/runtime/pkg/kata-monitor/shim_client.go
+++ b/src/runtime/pkg/kata-monitor/shim_client.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020 Ant Financial
+// Copyright (c) 2020-2021 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -34,15 +34,19 @@ func getSandboxIdFromReq(r *http.Request) (string, error) {
 }
 
 func (km *KataMonitor) buildShimClient(sandboxID, namespace string, timeout time.Duration) (*http.Client, error) {
-	socket, err := km.getMonitorAddress(sandboxID, namespace)
+	socketAddr, err := km.getMonitorAddress(sandboxID, namespace)
 	if err != nil {
 		return nil, err
 	}
+	return BuildUnixSocketClient(socketAddr, timeout)
+}
 
+// BuildUnixSocketClient build http client for Unix socket
+func BuildUnixSocketClient(socketAddr string, timeout time.Duration) (*http.Client, error) {
 	transport := &http.Transport{
 		DisableKeepAlives: true,
 		Dial: func(proto, addr string) (conn net.Conn, err error) {
-			return net.Dial("unix", "\x00"+socket)
+			return net.Dial("unix", "\x00"+socketAddr)
 		},
 	}
 


### PR DESCRIPTION
Parse agent socket address by conversation to improve usability of
using guest debug console.

Fixes: #1329

Signed-off-by: bin <bin@hyper.sh>