### PR TITLE
Fix lints and remove allow attributes which silence these warnings

### DIFF
--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -26,10 +26,6 @@ const VSOCK_PORT: u16 = 1024;
 const SERVER_ADDR_ENV_VAR: &str = "KATA_AGENT_SERVER_ADDR";
 const LOG_LEVEL_ENV_VAR: &str = "KATA_AGENT_LOG_LEVEL";
 
-// FIXME: unused
-const TRACE_MODE_FLAG: &str = "agent.trace";
-const USE_VSOCK_FLAG: &str = "agent.use_vsock";
-
 #[derive(Debug)]
 pub struct agentConfig {
     pub debug_console: bool,

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -105,7 +105,7 @@ impl agentConfig {
                 HOTPLUG_TIMOUT_OPTION,
                 self.hotplug_timeout,
                 get_hotplug_timeout,
-                |hotplugTimeout: time::Duration| hotplugTimeout.as_secs() > 0
+                |hotplug_timeout: time::Duration| hotplug_timeout.as_secs() > 0
             );
 
             // vsock port should be positive values

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -27,7 +27,7 @@ const SERVER_ADDR_ENV_VAR: &str = "KATA_AGENT_SERVER_ADDR";
 const LOG_LEVEL_ENV_VAR: &str = "KATA_AGENT_LOG_LEVEL";
 
 #[derive(Debug)]
-pub struct agentConfig {
+pub struct AgentConfig {
     pub debug_console: bool,
     pub dev_mode: bool,
     pub log_level: slog::Level,
@@ -69,9 +69,9 @@ macro_rules! parse_cmdline_param {
     };
 }
 
-impl agentConfig {
-    pub fn new() -> agentConfig {
-        agentConfig {
+impl AgentConfig {
+    pub fn new() -> AgentConfig {
+        AgentConfig {
             debug_console: false,
             dev_mode: false,
             log_level: DEFAULT_LOG_LEVEL,
@@ -311,7 +311,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let config = agentConfig::new();
+        let config = AgentConfig::new();
         assert_eq!(config.debug_console, false);
         assert_eq!(config.dev_mode, false);
         assert_eq!(config.log_level, DEFAULT_LOG_LEVEL);
@@ -818,7 +818,7 @@ mod tests {
 
         let filename = file_path.to_str().expect("failed to create filename");
 
-        let mut config = agentConfig::new();
+        let mut config = AgentConfig::new();
         let result = config.parse_cmdline(&filename.to_owned());
         assert!(result.is_err());
 
@@ -850,7 +850,7 @@ mod tests {
                 vars_to_unset.push(name);
             }
 
-            let mut config = agentConfig::new();
+            let mut config = AgentConfig::new();
             assert_eq!(config.debug_console, false, "{}", msg);
             assert_eq!(config.dev_mode, false, "{}", msg);
             assert_eq!(config.unified_cgroup_hierarchy, false, "{}", msg);

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -5,7 +5,6 @@
 
 #![allow(non_camel_case_types)]
 #![allow(unused_parens)]
-#![allow(unused_unsafe)]
 #[macro_use]
 extern crate lazy_static;
 extern crate oci;

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -7,7 +7,6 @@
 #![allow(unused_parens)]
 #![allow(unused_unsafe)]
 #![allow(dead_code)]
-#![allow(non_snake_case)]
 #[macro_use]
 extern crate lazy_static;
 extern crate oci;
@@ -161,7 +160,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         // support vsock log
         let (rfd, wfd) = unistd::pipe2(OFlag::O_CLOEXEC)?;
 
-        let agentConfig = AGENT_CONFIG.clone();
+        let agent_config = AGENT_CONFIG.clone();
 
         let init_mode = unistd::getpid() == Pid::from_raw(1);
         if init_mode {
@@ -182,7 +181,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
                 e
             })?;
 
-            let mut config = agentConfig.write().await;
+            let mut config = agent_config.write().await;
             config.parse_cmdline(KERNEL_CMDLINE_FILE)?;
 
             init_agent_as_init(&logger, config.unified_cgroup_hierarchy)?;
@@ -190,10 +189,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
             // once parsed cmdline and set the config, release the write lock
             // as soon as possible in case other thread would get read lock on
             // it.
-            let mut config = agentConfig.write().await;
+            let mut config = agent_config.write().await;
             config.parse_cmdline(KERNEL_CMDLINE_FILE)?;
         }
-        let config = agentConfig.read().await;
+        let config = agent_config.read().await;
 
         let log_vport = config.log_vport as u32;
         let log_handle = tokio::spawn(async move {

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -6,7 +6,6 @@
 #![allow(non_camel_case_types)]
 #![allow(unused_parens)]
 #![allow(unused_unsafe)]
-#![allow(dead_code)]
 #[macro_use]
 extern crate lazy_static;
 extern crate oci;

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -4,7 +4,6 @@
 //
 
 #![allow(non_camel_case_types)]
-#![allow(unused_parens)]
 #[macro_use]
 extern crate lazy_static;
 extern crate oci;

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#![allow(non_camel_case_types)]
 #[macro_use]
 extern crate lazy_static;
 extern crate oci;
@@ -83,11 +82,11 @@ const DEFAULT_BUF_SIZE: usize = 8 * 1024;
 lazy_static! {
     static ref GLOBAL_DEVICE_WATCHER: Arc<Mutex<HashMap<String, Option<Sender<String>>>>> =
         Arc::new(Mutex::new(HashMap::new()));
-    static ref AGENT_CONFIG: Arc<RwLock<agentConfig>> =
-        Arc::new(RwLock::new(config::agentConfig::new()));
+    static ref AGENT_CONFIG: Arc<RwLock<AgentConfig>> =
+        Arc::new(RwLock::new(config::AgentConfig::new()));
 }
 
-fn announce(logger: &Logger, config: &agentConfig) {
+fn announce(logger: &Logger, config: &AgentConfig) {
     info!(logger, "announce";
     "agent-commit" => version::VERSION_COMMIT,
 
@@ -247,7 +246,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     })
 }
 
-async fn start_sandbox(logger: &Logger, config: &agentConfig, init_mode: bool) -> Result<()> {
+async fn start_sandbox(logger: &Logger, config: &AgentConfig, init_mode: bool) -> Result<()> {
     let shells = SHELLS.clone();
     let debug_console_vport = config.debug_console_vport as u32;
 
@@ -446,7 +445,7 @@ lazy_static! {
     };
 }
 
-use crate::config::agentConfig;
+use crate::config::AgentConfig;
 use nix::sys::stat::Mode;
 use std::os::unix::io::{FromRawFd, RawFd};
 use std::path::PathBuf;

--- a/src/agent/src/metrics.rs
+++ b/src/agent/src/metrics.rs
@@ -187,9 +187,9 @@ fn update_guest_metrics() {
             info!(sl!(), "failed to get guest KernelStats: {:?}", err);
         }
         Ok(kernel_stats) => {
-            set_gauge_vec_CPU_time(&GUEST_CPU_TIME, "total", &kernel_stats.total);
+            set_gauge_vec_cpu_time(&GUEST_CPU_TIME, "total", &kernel_stats.total);
             for (i, cpu_time) in kernel_stats.cpu_time.iter().enumerate() {
-                set_gauge_vec_CPU_time(&GUEST_CPU_TIME, format!("{}", i).as_str(), &cpu_time);
+                set_gauge_vec_cpu_time(&GUEST_CPU_TIME, format!("{}", i).as_str(), &cpu_time);
             }
         }
     }
@@ -332,7 +332,7 @@ fn set_gauge_vec_meminfo(gv: &prometheus::GaugeVec, meminfo: &procfs::Meminfo) {
         .set(meminfo.k_reclaimable.unwrap_or(0) as f64);
 }
 
-fn set_gauge_vec_CPU_time(gv: &prometheus::GaugeVec, cpu: &str, cpu_time: &procfs::CpuTime) {
+fn set_gauge_vec_cpu_time(gv: &prometheus::GaugeVec, cpu: &str, cpu_time: &procfs::CpuTime) {
     gv.with_label_values(&[cpu, "user"])
         .set(cpu_time.user as f64);
     gv.with_label_values(&[cpu, "nice"])

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -84,7 +84,7 @@ lazy_static! {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct INIT_MOUNT {
+pub struct InitMount {
     fstype: &'static str,
     src: &'static str,
     dest: &'static str,
@@ -114,13 +114,13 @@ lazy_static!{
 
 #[rustfmt::skip]
 lazy_static! {
-    pub static ref INIT_ROOTFS_MOUNTS: Vec<INIT_MOUNT> = vec![
-        INIT_MOUNT{fstype: "proc", src: "proc", dest: "/proc", options: vec!["nosuid", "nodev", "noexec"]},
-        INIT_MOUNT{fstype: "sysfs", src: "sysfs", dest: "/sys", options: vec!["nosuid", "nodev", "noexec"]},
-        INIT_MOUNT{fstype: "devtmpfs", src: "dev", dest: "/dev", options: vec!["nosuid"]},
-        INIT_MOUNT{fstype: "tmpfs", src: "tmpfs", dest: "/dev/shm", options: vec!["nosuid", "nodev"]},
-        INIT_MOUNT{fstype: "devpts", src: "devpts", dest: "/dev/pts", options: vec!["nosuid", "noexec"]},
-        INIT_MOUNT{fstype: "tmpfs", src: "tmpfs", dest: "/run", options: vec!["nosuid", "nodev"]},
+    pub static ref INIT_ROOTFS_MOUNTS: Vec<InitMount> = vec![
+        InitMount{fstype: "proc", src: "proc", dest: "/proc", options: vec!["nosuid", "nodev", "noexec"]},
+        InitMount{fstype: "sysfs", src: "sysfs", dest: "/sys", options: vec!["nosuid", "nodev", "noexec"]},
+        InitMount{fstype: "devtmpfs", src: "dev", dest: "/dev", options: vec!["nosuid"]},
+        InitMount{fstype: "tmpfs", src: "tmpfs", dest: "/dev/shm", options: vec!["nosuid", "nodev"]},
+        InitMount{fstype: "devpts", src: "devpts", dest: "/dev/pts", options: vec!["nosuid", "noexec"]},
+        InitMount{fstype: "tmpfs", src: "tmpfs", dest: "/run", options: vec!["nosuid", "nodev"]},
     ];
 }
 
@@ -492,7 +492,7 @@ pub async fn add_storages(
     Ok(mount_list)
 }
 
-fn mount_to_rootfs(logger: &Logger, m: &INIT_MOUNT) -> Result<()> {
+fn mount_to_rootfs(logger: &Logger, m: &InitMount) -> Result<()> {
     let options_vec: Vec<&str> = m.options.clone();
 
     let (flags, options) = parse_mount_flags_and_options(options_vec);
@@ -568,11 +568,11 @@ pub fn get_cgroup_mounts(
     logger: &Logger,
     cg_path: &str,
     unified_cgroup_hierarchy: bool,
-) -> Result<Vec<INIT_MOUNT>> {
+) -> Result<Vec<InitMount>> {
     // cgroup v2
     // https://github.com/kata-containers/agent/blob/8c9bbadcd448c9a67690fbe11a860aaacc69813c/agent.go#L1249
     if unified_cgroup_hierarchy {
-        return Ok(vec![INIT_MOUNT {
+        return Ok(vec![InitMount {
             fstype: "cgroup2",
             src: "cgroup2",
             dest: "/sys/fs/cgroup",
@@ -584,7 +584,7 @@ pub fn get_cgroup_mounts(
     let reader = BufReader::new(file);
 
     let mut has_device_cgroup = false;
-    let mut cg_mounts: Vec<INIT_MOUNT> = vec![INIT_MOUNT {
+    let mut cg_mounts: Vec<InitMount> = vec![InitMount {
         fstype: "tmpfs",
         src: "tmpfs",
         dest: SYSFS_CGROUPPATH,
@@ -630,7 +630,7 @@ pub fn get_cgroup_mounts(
 
         if let Some(value) = CGROUPS.get(&fields[0]) {
             let key = CGROUPS.keys().find(|&&f| f == fields[0]).unwrap();
-            cg_mounts.push(INIT_MOUNT {
+            cg_mounts.push(InitMount {
                 fstype: "cgroup",
                 src: "cgroup",
                 dest: *value,
@@ -644,7 +644,7 @@ pub fn get_cgroup_mounts(
         return Ok(Vec::new());
     }
 
-    cg_mounts.push(INIT_MOUNT {
+    cg_mounts.push(InitMount {
         fstype: "tmpfs",
         src: "tmpfs",
         dest: SYSFS_CGROUPPATH,
@@ -1142,21 +1142,21 @@ mod tests {
         let drain = slog::Discard;
         let logger = slog::Logger::root(drain, o!());
 
-        let first_mount = INIT_MOUNT {
+        let first_mount = InitMount {
             fstype: "tmpfs",
             src: "tmpfs",
             dest: SYSFS_CGROUPPATH,
             options: vec!["nosuid", "nodev", "noexec", "mode=755"],
         };
 
-        let last_mount = INIT_MOUNT {
+        let last_mount = InitMount {
             fstype: "tmpfs",
             src: "tmpfs",
             dest: SYSFS_CGROUPPATH,
             options: vec!["remount", "ro", "nosuid", "nodev", "noexec", "mode=755"],
         };
 
-        let cg_devices_mount = INIT_MOUNT {
+        let cg_devices_mount = InitMount {
             fstype: "cgroup",
             src: "cgroup",
             dest: "/sys/fs/cgroup/devices",

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -68,6 +68,7 @@ impl Namespace {
         self
     }
 
+    #[allow(dead_code)]
     pub fn set_root_dir(mut self, dir: &str) -> Self {
         self.persistent_ns_dir = dir.to_string();
         self

--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -40,6 +40,7 @@ pub enum AddressFilter {
     /// Return addresses that belong to the given interface.
     LinkIndex(u32),
     /// Get addresses with the given prefix.
+    #[allow(dead_code)]
     IpAddress(IpAddr),
 }
 
@@ -212,17 +213,6 @@ impl Handle {
         let link_req = self.handle.link().set(link_index);
         let set_req = if up { link_req.up() } else { link_req.down() };
         set_req.execute().await?;
-        Ok(())
-    }
-
-    pub async fn delete_links<I>(&mut self, list: I) -> Result<()>
-    where
-        I: IntoIterator<Item = u32>,
-    {
-        for index in list.into_iter() {
-            self.handle.link().del(index).execute().await?;
-        }
-
         Ok(())
     }
 
@@ -742,6 +732,7 @@ impl Address {
         self.0.header.family == packet::constants::AF_INET6 as u8
     }
 
+    #[allow(dead_code)]
     fn prefix(&self) -> u8 {
         self.0.header.prefix_len
     }

--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -45,7 +45,7 @@ pub enum AddressFilter {
 }
 
 /// A high level wrapper for netlink (and `rtnetlink` crate) for use by the Agent's RPC.
-/// It is expected to be consumed by the `agentService`, so it operates with protobuf
+/// It is expected to be consumed by the `AgentService`, so it operates with protobuf
 /// structures directly for convenience.
 #[derive(Debug)]
 pub struct Handle {

--- a/src/agent/src/network.rs
+++ b/src/agent/src/network.rs
@@ -139,10 +139,10 @@ mod tests {
         assert_eq!(true, content.is_ok());
         let content = content.unwrap();
 
-        let expected_DNS: Vec<&str> = content.split('\n').collect();
+        let expected_dns: Vec<&str> = content.split('\n').collect();
 
         // assert the data are the same as /run/kata-containers/sandbox/resolv.conf
-        assert_eq!(dns, expected_DNS);
+        assert_eq!(dns, expected_dns);
 
         // umount /etc/resolv.conf
         let _ = mount::umount(dst_filename);

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -76,11 +76,11 @@ macro_rules! sl {
 }
 
 #[derive(Clone)]
-pub struct agentService {
+pub struct AgentService {
     sandbox: Arc<Mutex<Sandbox>>,
 }
 
-impl agentService {
+impl AgentService {
     async fn do_create_container(
         &self,
         req: protocols::agent::CreateContainerRequest,
@@ -493,7 +493,7 @@ impl agentService {
 }
 
 #[async_trait]
-impl protocols::agent_ttrpc::AgentService for agentService {
+impl protocols::agent_ttrpc::AgentService for AgentService {
     async fn create_container(
         &self,
         _ctx: &TtrpcContext,
@@ -1203,10 +1203,10 @@ impl protocols::agent_ttrpc::AgentService for agentService {
 }
 
 #[derive(Clone)]
-struct healthService;
+struct HealthService;
 
 #[async_trait]
-impl protocols::health_ttrpc::Health for healthService {
+impl protocols::health_ttrpc::Health for HealthService {
     async fn check(
         &self,
         _ctx: &TtrpcContext,
@@ -1334,13 +1334,13 @@ fn find_process<'a>(
 }
 
 pub fn start(s: Arc<Mutex<Sandbox>>, server_address: &str) -> TtrpcServer {
-    let agent_service = Box::new(agentService { sandbox: s })
+    let agent_service = Box::new(AgentService { sandbox: s })
         as Box<dyn protocols::agent_ttrpc::AgentService + Send + Sync>;
 
     let agent_worker = Arc::new(agent_service);
 
     let health_service =
-        Box::new(healthService {}) as Box<dyn protocols::health_ttrpc::Health + Send + Sync>;
+        Box::new(HealthService {}) as Box<dyn protocols::health_ttrpc::Health + Send + Sync>;
     let health_worker = Arc::new(health_service);
 
     let aservice = protocols::agent_ttrpc::create_agent_service(agent_worker);
@@ -1670,7 +1670,7 @@ fn load_kernel_module(module: &protocols::agent::KernelModule) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocols::agent_ttrpc::AgentService;
+    use crate::protocols::agent_ttrpc::AgentService as _;
     use oci::{Hook, Hooks};
     use ttrpc::{r#async::TtrpcContext, MessageHeader};
 
@@ -1725,7 +1725,7 @@ mod tests {
         let logger = slog::Logger::root(slog::Discard, o!());
         let sandbox = Sandbox::new(&logger).unwrap();
 
-        let agent_service = Box::new(agentService {
+        let agent_service = Box::new(AgentService {
             sandbox: Arc::new(Mutex::new(sandbox)),
         });
 
@@ -1742,7 +1742,7 @@ mod tests {
         let logger = slog::Logger::root(slog::Discard, o!());
         let sandbox = Sandbox::new(&logger).unwrap();
 
-        let agent_service = Box::new(agentService {
+        let agent_service = Box::new(AgentService {
             sandbox: Arc::new(Mutex::new(sandbox)),
         });
 
@@ -1759,7 +1759,7 @@ mod tests {
         let logger = slog::Logger::root(slog::Discard, o!());
         let sandbox = Sandbox::new(&logger).unwrap();
 
-        let agent_service = Box::new(agentService {
+        let agent_service = Box::new(AgentService {
             sandbox: Arc::new(Mutex::new(sandbox)),
         });
 

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -665,8 +665,8 @@ impl protocols::agent_ttrpc::AgentService for agentService {
         let resp = Empty::new();
 
         if res.is_some() {
-            let ociRes = rustjail::resources_grpc_to_oci(&res.unwrap());
-            match ctr.set(ociRes) {
+            let oci_res = rustjail::resources_grpc_to_oci(&res.unwrap());
+            match ctr.set(oci_res) {
                 Err(e) => {
                     return Err(ttrpc_error(ttrpc::Code::INTERNAL, e.to_string()));
                 }

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -150,14 +150,6 @@ impl Sandbox {
         Ok(())
     }
 
-    pub fn is_running(&self) -> bool {
-        self.running
-    }
-
-    pub fn set_hostname(&mut self, hostname: String) {
-        self.hostname = hostname;
-    }
-
     pub async fn setup_shared_namespaces(&mut self) -> Result<bool> {
         // Set up shared IPC namespace
         self.shared_ipcns = Namespace::new(&self.logger)
@@ -730,25 +722,6 @@ mod tests {
         assert!(s.hooks.as_ref().unwrap().prestart.len() == 1);
         assert!(s.hooks.as_ref().unwrap().poststart.is_empty());
         assert!(s.hooks.as_ref().unwrap().poststop.is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_sandbox_is_running() {
-        let logger = slog::Logger::root(slog::Discard, o!());
-        let mut s = Sandbox::new(&logger).unwrap();
-        s.running = true;
-        assert!(s.is_running());
-        s.running = false;
-        assert!(!s.is_running());
-    }
-
-    #[tokio::test]
-    async fn test_sandbox_set_hostname() {
-        let logger = slog::Logger::root(slog::Discard, o!());
-        let mut s = Sandbox::new(&logger).unwrap();
-        let hostname = "abc123";
-        s.set_hostname(hostname.to_string());
-        assert_eq!(s.hostname, hostname);
     }
 
     #[tokio::test]

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -380,7 +380,7 @@ fn online_cpus(logger: &Logger, num: i32) -> Result<i32> {
             logger,
             SYSFS_CPU_ONLINE_PATH,
             r"cpu[0-9]+",
-            (num - onlined_count),
+            num - onlined_count,
         );
         if r.is_err() {
             return r;

--- a/src/agent/src/version.rs.in
+++ b/src/agent/src/version.rs.in
@@ -7,6 +7,8 @@
 // WARNING: This file is auto-generated - DO NOT EDIT!
 //
 
+#![allow(dead_code)]
+
 pub const AGENT_VERSION: &str = "@AGENT_VERSION@";
 pub const API_VERSION: &str = "@API_VERSION@";
 pub const VERSION_COMMIT: &str = "@VERSION_COMMIT@";


### PR DESCRIPTION
Remove following attributes:

`#![allow(non_camel_case_types)]`
`#![allow(unused_parens)]`
`#![allow(unused_unsafe)]`
`#![allow(dead_code)]`
`#![allow(non_snake_case)`