### PR TITLE
github: Only run kata-deploy-test on pull-requests

### DIFF
--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -2,6 +2,8 @@ on: issue_comment
 name: test-kata-deploy
 jobs:
   check_comments:
+    if: ${{ github.event.issue.pull_request }}
+    types: [created, edited]
     runs-on: ubuntu-latest
     steps:
       - name: Check for Command


### PR DESCRIPTION
We're currently running kata-deploy-test for every issue opened, for
every comment in the issue.  Issues, themselves, shouldn't be triggering
those as they can't cause any code change.

With this in mind, let's restrict ourselves to run those on
pull-requests only.

Fixes: #1341

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>