### PR TITLE
kernel: Don't fail if "experimental" dir doesn't exist

### DIFF
--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -188,7 +188,12 @@ get_kernel_frag_path() {
 	local arch_configs="$(ls ${arch_path}/*.conf)"
 	# Exclude configs if they have !$arch tag in the header
 	local common_configs="$(grep "\!${arch}" ${common_path}/*.conf -L)"
-	local experimental_configs="$(ls ${common_path}/experimental/*.conf)"
+
+	local experimental_configs=""
+	local experimental_dir="${common_path}/experimental"
+	if [ -d "$experimental_dir" ]; then
+		experimental_configs=$(find "$experimental_dir" -name '*.conf')
+	fi
 
 	# These are the strings that the kernel merge_config.sh script kicks out
 	# when it reports an error or warning condition. We search for them in the


### PR DESCRIPTION
This directory has been automatically removed as there's no files inside
it, as part of d3c98620591f902fec9cc2abbe6f03f93122052d

Let's improve the logic in the scripts to avoid failing in case the
"experimental" dir is not present.

Fixes: #1328