### PR TITLE
stable-2.0 | agent: update cpuset of container path

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -1022,11 +1022,11 @@ impl Manager {
         })
     }
 
-    pub fn update_cpuset_path(&self, cpuset_cpus: &str) -> Result<()> {
-        if cpuset_cpus == "" {
+    pub fn update_cpuset_path(&self, guest_cpuset: &str, container_cpuset: &str) -> Result<()> {
+        if guest_cpuset == "" {
             return Ok(());
         }
-        info!(sl!(), "update_cpuset_path to: {}", cpuset_cpus);
+        info!(sl!(), "update_cpuset_path to: {}", guest_cpuset);
 
         let h = cgroups::hierarchies::auto();
         let h = Box::new(&*h);
@@ -1040,8 +1040,8 @@ impl Manager {
         let h = cgroups::hierarchies::auto();
         let h = Box::new(&*h);
         let cg = load_or_create(h, &self.cpath);
-        let cpuset_controller: &CpuSetController = cg.controller_of().unwrap();
-        let path = cpuset_controller.path();
+        let container_cpuset_controller: &CpuSetController = cg.controller_of().unwrap();
+        let path = container_cpuset_controller.path();
         let container_path = Path::new(path);
         info!(sl!(), "container cpuset path: {:?}", &path);
 
@@ -1050,11 +1050,9 @@ impl Manager {
             if ancestor == root_path {
                 break;
             }
-            if ancestor != container_path {
-                paths.push(ancestor);
-            }
+            paths.push(ancestor);
         }
-        info!(sl!(), "paths to update cpuset: {:?}", &paths);
+        info!(sl!(), "parent paths to update cpuset: {:?}", &paths);
 
         let mut i = paths.len();
         loop {
@@ -1070,10 +1068,20 @@ impl Manager {
                 .to_str()
                 .unwrap()
                 .trim_start_matches(root_path.to_str().unwrap());
-            info!(sl!(), "updating cpuset for path {:?}", &r_path);
+            info!(sl!(), "updating cpuset for parent path {:?}", &r_path);
             let cg = load_or_create(h, &r_path);
             let cpuset_controller: &CpuSetController = cg.controller_of().unwrap();
-            cpuset_controller.set_cpus(cpuset_cpus)?;
+            cpuset_controller.set_cpus(guest_cpuset)?;
+        }
+
+        if !container_cpuset.is_empty() {
+            info!(
+                sl!(),
+                "updating cpuset for container path: {:?} cpuset: {}",
+                &container_path,
+                container_cpuset
+            );
+            container_cpuset_controller.set_cpus(container_cpuset)?;
         }
 
         Ok(())

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -236,14 +236,29 @@ impl Sandbox {
             return Ok(());
         }
 
-        let cpuset = rustjail_cgroups::fs::get_guest_cpuset()?;
+        let guest_cpuset = rustjail_cgroups::fs::get_guest_cpuset()?;
 
         for (_, ctr) in self.containers.iter() {
+            let cpu = ctr
+                .config
+                .spec
+                .as_ref()
+                .unwrap()
+                .linux
+                .as_ref()
+                .unwrap()
+                .resources
+                .as_ref()
+                .unwrap()
+                .cpu
+                .as_ref();
+            let container_cpust = if let Some(c) = cpu { &c.cpus } else { "" };
+
             info!(self.logger, "updating {}", ctr.id.as_str());
             ctr.cgroup_manager
                 .as_ref()
                 .unwrap()
-                .update_cpuset_path(cpuset.as_str())?;
+                .update_cpuset_path(guest_cpuset.as_str(), &container_cpust)?;
         }
 
         Ok(())


### PR DESCRIPTION
After cpu hot-plugged is available, cpuset for containers will be written into
    cgroup files recursively, the paths should include container's cgroup path, and up
    to root path of cgroup filesystem.

Fixes: #1365