### PR TITLE
osbuilder: Allow image registry to be customizable

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -86,8 +86,8 @@ Options:
 Extra environment variables:
 	AGENT_BIN:  Use it to change the expected agent binary name
 	AGENT_INIT: Use kata agent as init process
-	NSDAX_BIN:  Use to specify path to pre-compiled 'nsdax' tool.
 	FS_TYPE:    Filesystem type to use. Only xfs and ext4 are supported.
+	NSDAX_BIN:  Use to specify path to pre-compiled 'nsdax' tool.
 	USE_DOCKER: If set will build image in a Docker Container (requries docker)
 		    DEFAULT: not set
 	USE_PODMAN: If set and USE_DOCKER not set, will build image in a Podman Container (requries podman)

--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -84,14 +84,15 @@ Options:
 	-r Free space of the root partition in MB ENV: ROOT_FREE_SPACE
 
 Extra environment variables:
-	AGENT_BIN:  Use it to change the expected agent binary name
-	AGENT_INIT: Use kata agent as init process
-	FS_TYPE:    Filesystem type to use. Only xfs and ext4 are supported.
-	NSDAX_BIN:  Use to specify path to pre-compiled 'nsdax' tool.
-	USE_DOCKER: If set will build image in a Docker Container (requries docker)
-		    DEFAULT: not set
-	USE_PODMAN: If set and USE_DOCKER not set, will build image in a Podman Container (requries podman)
-	            DEFAULT: not set
+	AGENT_BIN:      Use it to change the expected agent binary name
+	AGENT_INIT:     Use kata agent as init process
+	IMAGE_REGISTRY: Hostname for the image registry used to pull down the rootfs build image.
+	FS_TYPE:        Filesystem type to use. Only xfs and ext4 are supported.
+	NSDAX_BIN:      Use to specify path to pre-compiled 'nsdax' tool.
+	USE_DOCKER:     If set will build image in a Docker Container (requries docker)
+	                DEFAULT: not set
+	USE_PODMAN:     If set and USE_DOCKER not set, will build image in a Podman Container (requries podman)
+	                DEFAULT: not set
 
 
 Following diagram shows how the resulting image will look like
@@ -137,7 +138,13 @@ build_with_container() {
 	image_dir=$(readlink -f "$(dirname "${image}")")
 	image_name=$(basename "${image}")
 
+	REGISTRY_ARG=""
+	if [ -n "${IMAGE_REGISTRY}" ]; then
+		REGISTRY_ARG="--build-arg IMAGE_REGISTRY=${IMAGE_REGISTRY}"
+	fi
+
 	"${container_engine}" build  \
+		   ${REGISTRY_ARG} \
 		   --build-arg http_proxy="${http_proxy}" \
 		   --build-arg https_proxy="${https_proxy}" \
 		   -t "${container_image_name}" "${script_dir}"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -100,12 +100,6 @@ AGENT_INIT          When set to "yes", use ${AGENT_BIN} as init process in place
                     of systemd.
                     Default value: no
 
-RUST_AGENT          When set to "no", build kata-agent from go agent instead of kata-rust-agent
-                    Default value: "yes"
-
-RUST_AGENT_PKG      URL of the Git repository hosting the agent package.
-                    Default value: ${RUST_AGENT_PKG}
-
 AGENT_VERSION       Version of the agent to include in the rootfs.
                     Default value: ${AGENT_VERSION:-<not set>}
 
@@ -115,6 +109,9 @@ AGENT_SOURCE_BIN    Path to the directory of agent binary.
 
 DISTRO_REPO         Use host repositories to install guest packages.
                     Default value: <not set>
+
+DOCKER_RUNTIME      Docker runtime to use when USE_DOCKER is set.
+                    Default value: runc
 
 GO_AGENT_PKG        URL of the Git repository hosting the agent package.
                     Default value: ${GO_AGENT_PKG}
@@ -133,6 +130,12 @@ KERNEL_MODULES_DIR  Path to a directory containing kernel modules to include in
 ROOTFS_DIR          Path to the directory that is populated with the rootfs.
                     Default value: <${script_name} path>/rootfs-<DISTRO-name>
 
+RUST_AGENT          When set to "no", build kata-agent from go agent instead of kata-rust-agent
+                    Default value: "yes"
+
+RUST_AGENT_PKG      URL of the Git repository hosting the agent package.
+                    Default value: ${RUST_AGENT_PKG}
+
 USE_DOCKER          If set, build the rootfs inside a container (requires
                     Docker).
                     Default value: <not set>
@@ -140,9 +143,6 @@ USE_DOCKER          If set, build the rootfs inside a container (requires
 USE_PODMAN          If set and USE_DOCKER not set, then build the rootfs inside
                     a podman container (requires podman).
                     Default value: <not set>
-
-DOCKER_RUNTIME      Docker runtime to use when USE_DOCKER is set.
-                    Default value: runc
 
 Refer to the Platform-OS Compatibility Matrix for more details on the supported
 architectures:

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -100,12 +100,12 @@ AGENT_INIT          When set to "yes", use ${AGENT_BIN} as init process in place
                     of systemd.
                     Default value: no
 
-AGENT_VERSION       Version of the agent to include in the rootfs.
-                    Default value: ${AGENT_VERSION:-<not set>}
-
 AGENT_SOURCE_BIN    Path to the directory of agent binary.
                     If set, use the binary as agent but not build agent package.
                     Default value: <not set>
+
+AGENT_VERSION       Version of the agent to include in the rootfs.
+                    Default value: ${AGENT_VERSION:-<not set>}
 
 DISTRO_REPO         Use host repositories to install guest packages.
                     Default value: <not set>
@@ -122,6 +122,10 @@ GRACEFUL_EXIT       If set, and if the DISTRO configuration specifies a
                     This is used when running CI jobs, to tolerate failures for
                     specific distributions.
                     Default value: <not set>
+
+IMAGE_REGISTRY      Hostname for the image registry used to pull down the rootfs
+                    build image.
+                    Default value: docker.io
 
 KERNEL_MODULES_DIR  Path to a directory containing kernel modules to include in
                     the rootfs.
@@ -371,9 +375,15 @@ build_rootfs_distro()
 
 		image_name="${distro}-rootfs-osbuilder"
 
+		REGISTRY_ARG=""
+		if [ -n "${IMAGE_REGISTRY}" ]; then
+			REGISTRY_ARG="--build-arg IMAGE_REGISTRY=${IMAGE_REGISTRY}"
+		fi
+
 		# setup to install go or rust here
 		generate_dockerfile "${distro_config_dir}"
 		"$container_engine" build  \
+			${REGISTRY_ARG} \
 			--build-arg http_proxy="${http_proxy}" \
 			--build-arg https_proxy="${https_proxy}" \
 			-t "${image_name}" "${distro_config_dir}"


### PR DESCRIPTION
Give the user chance to specify their own registry in event the default
provided are not accessible, desirable.

Fixes: #1393

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>