### PR TITLE
agent: Remove bogus check from list_interfaces() unit test

### DIFF
--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -873,7 +873,6 @@ mod tests {
 
         for iface in &list {
             assert_ne!(iface.name.len(), 0);
-            assert_ne!(iface.hwAddr.len(), 0);
             assert_ne!(iface.mtu, 0);
 
             for ip in &iface.IPAddresses {


### PR DESCRIPTION
The unit test for list_interfaces() checks that the hardware address
returned for each interface has non-zero length.  However, that need not be
the case.  Point-to-point devices, such as ppp, or tun devices in certain
configurations may not have a hardware address, which is represented as
a zero length address here.

This happens on my machine with a tun0 device created by OpenVPN.

fixes #1377

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>