### PR TITLE
docs: Update licensing strategy to use kata 2.0 repository

### DIFF
--- a/docs/Licensing-strategy.md
+++ b/docs/Licensing-strategy.md
@@ -22,4 +22,4 @@ licensing and allows automated tooling to check the license of individual
 files.
 
 This SPDX licence identifier requirement is enforced by the
-[CI (Continuous Integration) system](https://github.com/kata-containers/tests/blob/master/.ci/static-checks.sh).
+[CI (Continuous Integration) system](https://github.com/kata-containers/tests/blob/main/.ci/static-checks.sh).


### PR DESCRIPTION
This PR updates the licensing strategy document to use the proper
tests repository for kata 2.0

Fixes #1413

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>