### PR TITLE
osbuiler: fixing USE_DOCKER for ppc64le

### DIFF
--- a/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
@@ -26,6 +26,7 @@ RUN dnf -y update && dnf install -y \
     libseccomp-devel \
     libstdc++-devel \
     libstdc++-static \
+    protobuf-compiler \
     m4 \
     make \
     pkgconfig \

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -244,6 +244,7 @@ generate_dockerfile()
 			goarch=ppc64le
 			rustarch=powerpc64le
 			muslarch=powerpc64
+			libc=gnu
 			;;
 
 		"aarch64")
@@ -337,7 +338,7 @@ RUN ln -sf /usr/bin/g++ /bin/musl-g++
 			-e "s|@OS_VERSION@|${OS_VERSION:-}|g" \
 			-e "s|@INSTALL_MUSL@||g" \
 			-e "s|@INSTALL_GO@|${install_go//$'\n'/\\n}|g" \
-			-e "s|@INSTALL_RUST@||g" \
+			-e "s|@INSTALL_RUST@|${install_rust//$'\n'/\\n}|g" \
 			-e "s|@SET_PROXY@|${set_proxy:-}|g" \
 			"${dockerfile_template}" > Dockerfile
 	# no musl target on s390x, will use GNU


### PR DESCRIPTION
For building rootfs with docker, glibc based rust target should be installed on ppc64le.

Fixes: #1417

Signed-off-by: Amulya Meka <amulmek1@in.ibm.com>