### PR TITLE
kata-deploy: Ensure CRI-O uses shimv2 & the "vm" runtime type

### DIFF
--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -135,11 +135,7 @@ from the [Kata Containers release page](https://github.com/kata-containers/runti
 Host artifacts:
 * `cloud-hypervisor`, `firecracker`, `qemu-system-x86_64`, `qemu-virtiofs-system-x86_64` and supporting binaries
 * `containerd-shim-kata-v2`
-* `kata-clh`
 * `kata-collect-data.sh`
-* `kata-fc`
-* `kata-qemu`
-* `kata-qemu-virtiofs`
 * `kata-runtime`
 
 Virtual Machine artifacts:

--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -133,17 +133,18 @@ This image contains all the necessary artifacts for running Kata Containers, all
 from the [Kata Containers release page](https://github.com/kata-containers/runtime/releases).
 
 Host artifacts:
-* `kata-runtime`
+* `cloud-hypervisor`, `firecracker`, `qemu-system-x86_64`, `qemu-virtiofs-system-x86_64` and supporting binaries
+* `containerd-shim-kata-v2`
+* `kata-clh`
+* `kata-collect-data.sh`
 * `kata-fc`
 * `kata-qemu`
-* `kata-proxy`
-* `kata-shim`
-* `firecracker`
-* `qemu-system-x86_64` and supporting binaries
+* `kata-qemu-virtiofs`
+* `kata-runtime`
 
 Virtual Machine artifacts:
-* `kata-containers.img`: pulled from Kata GitHub releases page
-* `vmlinuz.container`: pulled from Kata GitHub releases page
+* `kata-containers.img` and `kata-containers-initrd.img`: pulled from Kata GitHub releases page
+* `vmlinuz.container` and `vmlinuz-virtiofs.container`: pulled from Kata GitHub releases page
 
 ### DaemonSets and RBAC
 

--- a/tools/packaging/release/kata-deploy-binaries.sh
+++ b/tools/packaging/release/kata-deploy-binaries.sh
@@ -215,32 +215,6 @@ install_kata_components() {
 	ln -sf "configuration-qemu.toml" configuration.toml
 	popd
 
-	pushd "${destdir}/${prefix}/bin"
-	cat <<EOT | sudo tee kata-fc
-#!/bin/bash
-${prefix}/bin/kata-runtime --config "${prefix}/share/defaults/${project}/configuration-fc.toml" \$@
-EOT
-	sudo chmod +x kata-fc
-
-	cat <<EOT | sudo tee kata-qemu
-#!/bin/bash
-${prefix}/bin/kata-runtime --config "${prefix}/share/defaults/${project}/configuration-qemu.toml" \$@
-EOT
-	sudo chmod +x kata-qemu
-
-	cat <<EOT | sudo tee kata-clh
-#!/bin/bash
-${prefix}/bin/kata-runtime --config "${prefix}/share/defaults/${project}/configuration-clh.toml" \$@
-EOT
-	sudo chmod +x kata-clh
-
-	cat <<EOT | sudo tee kata-qemu-virtiofs
-#!/bin/bash
-${prefix}/bin/kata-runtime --config "${prefix}/share/defaults/${project}/configuration-qemu-virtiofs.toml" \$@
-EOT
-	sudo chmod +x kata-qemu-virtiofs
-
-	popd
 	pushd ${destdir}
 	tar -czvf ../kata-static-kata-components.tar.gz *
 	popd


### PR DESCRIPTION
This series ensures CRI-O uses shimv2 & the "vm" runtime type.  It also contains some preliminary patches doing some cleanups and re-using some bits from the containerd setup.