### PR TITLE
packaging: Fix branch reference in get_from_kata_deps()

### DIFF
--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -34,7 +34,7 @@ install_yq() {
 
 get_from_kata_deps() {
 	local dependency="$1"
-	BRANCH=${branch:-master}
+	BRANCH=${branch:-main}
 	local branch="${2:-${BRANCH}}"
 	GOPATH=${GOPATH:-${HOME}/go}
 	# For our CI, we will query the local versions.yaml file both for kernel and


### PR DESCRIPTION
The get_from_kata_deps() in tools/packaging/scripts/lib.sh still
points to the master branch by default. Fixed it, now it looks for
the 'main' branch.

Fixes: ####

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>