### PR TITLE
agent: Stop receive message from Receiver if got None

### DIFF
--- a/src/agent/rustjail/src/cgroups/notifier.rs
+++ b/src/agent/rustjail/src/cgroups/notifier.rs
@@ -191,7 +191,10 @@ async fn register_memory_event(
                     let content = fs::read_to_string(path.clone());
                     info!(
                         sl!(),
-                        "OOM event for container: {}, content: {:?}", &containere_id, content
+                        "cgroup event for container: {}, path: {:?}, content: {:?}",
+                        &containere_id,
+                        &path,
+                        content
                     );
                 }
             }

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -317,7 +317,13 @@ impl Sandbox {
         tokio::spawn(async move {
             loop {
                 let event = rx.recv().await;
+                // None means the container has exited,
+                // and sender in OOM notifier is dropped.
+                if event.is_none() {
+                    return;
+                }
                 info!(logger, "got an OOM event {:?}", event);
+
                 let _ = tx
                     .send(container_id.clone())
                     .await


### PR DESCRIPTION
If the container has exited, the sender in notifier watching OOM events
will be dropped after the loop exited, and recv() from the according
receiver will get None.

This will lead two problems for get_oom_event rpc all from agent:

- return an wrong OOM event.
- continuously return OOM events.

Fixes: #1369

Signed-off-by: bin <bin@hyper.sh>