### PR TITLE
shimv2: return the hypervisor's pid as the container pid

### DIFF
--- a/src/runtime/containerd-shim-v2/create.go
+++ b/src/runtime/containerd-shim-v2/create.go
@@ -98,12 +98,18 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 			return nil, err
 		}
 		s.sandbox = sandbox
+		pid, err := s.sandbox.GetHypervisorPid()
+		if err != nil {
+			return nil, err
+		}
+		s.hpid = uint32(pid)
+
 		go s.startManagementServer(ctx, ociSpec)
 
 	case vc.PodContainer:
-                var span otelTrace.Span
-                span, s.ctx = trace(s.ctx, "create")
-                defer span.End()
+		var span otelTrace.Span
+		span, s.ctx = trace(s.ctx, "create")
+		defer span.End()
 
 		if s.sandbox == nil {
 			return nil, fmt.Errorf("BUG: Cannot start the container, since the sandbox hasn't been created")

--- a/src/runtime/containerd-shim-v2/service.go
+++ b/src/runtime/containerd-shim-v2/service.go
@@ -113,9 +113,12 @@ type service struct {
 	mu          sync.Mutex
 	eventSendMu sync.Mutex
 
-	// pid Since this shimv2 cannot get the container processes pid from VM,
-	// thus for the returned values needed pid, just return this shim's
+	// hypervisor pid, Since this shimv2 cannot get the container processes pid from VM,
+	// thus for the returned values needed pid, just return the hypervisor's
 	// pid directly.
+	hpid uint32
+
+	// shim's pid
 	pid uint32
 
 	ctx        context.Context
@@ -394,11 +397,11 @@ func (s *service) Create(ctx context.Context, r *taskAPI.CreateTaskRequest) (_ *
 				Terminal: r.Terminal,
 			},
 			Checkpoint: r.Checkpoint,
-			Pid:        s.pid,
+			Pid:        s.hpid,
 		})
 
 		return &taskAPI.CreateTaskResponse{
-			Pid: s.pid,
+			Pid: s.hpid,
 		}, nil
 	}
 }
@@ -434,7 +437,7 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (_ *taskAP
 		}
 		s.send(&eventstypes.TaskStart{
 			ContainerID: c.id,
-			Pid:         s.pid,
+			Pid:         s.hpid,
 		})
 	} else {
 		//start an exec
@@ -445,12 +448,12 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (_ *taskAP
 		s.send(&eventstypes.TaskExecStarted{
 			ContainerID: c.id,
 			ExecID:      r.ExecID,
-			Pid:         s.pid,
+			Pid:         s.hpid,
 		})
 	}
 
 	return &taskAPI.StartResponse{
-		Pid: s.pid,
+		Pid: s.hpid,
 	}, nil
 }
 
@@ -480,7 +483,7 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 
 		s.send(&eventstypes.TaskDelete{
 			ContainerID: c.id,
-			Pid:         s.pid,
+			Pid:         s.hpid,
 			ExitStatus:  c.exit,
 			ExitedAt:    c.exitTime,
 		})
@@ -488,7 +491,7 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 		return &taskAPI.DeleteResponse{
 			ExitStatus: c.exit,
 			ExitedAt:   c.exitTime,
-			Pid:        s.pid,
+			Pid:        s.hpid,
 		}, nil
 	}
 	//deal with the exec case
@@ -502,7 +505,7 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 	return &taskAPI.DeleteResponse{
 		ExitStatus: uint32(execs.exitCode),
 		ExitedAt:   execs.exitTime,
-		Pid:        s.pid,
+		Pid:        s.hpid,
 	}, nil
 }
 
@@ -606,7 +609,7 @@ func (s *service) State(ctx context.Context, r *taskAPI.StateRequest) (_ *taskAP
 		return &taskAPI.StateResponse{
 			ID:         c.id,
 			Bundle:     c.bundle,
-			Pid:        s.pid,
+			Pid:        s.hpid,
 			Status:     c.status,
 			Stdin:      c.stdin,
 			Stdout:     c.stdout,
@@ -625,7 +628,7 @@ func (s *service) State(ctx context.Context, r *taskAPI.StateRequest) (_ *taskAP
 	return &taskAPI.StateResponse{
 		ID:         execs.id,
 		Bundle:     c.bundle,
-		Pid:        s.pid,
+		Pid:        s.hpid,
 		Status:     execs.status,
 		Stdin:      execs.tty.stdin,
 		Stdout:     execs.tty.stdout,
@@ -786,7 +789,7 @@ func (s *service) Pids(ctx context.Context, r *taskAPI.PidsRequest) (_ *taskAPI.
 	}()
 
 	pInfo := task.ProcessInfo{
-		Pid: s.pid,
+		Pid: s.hpid,
 	}
 	processes = append(processes, &pInfo)
 
@@ -867,7 +870,7 @@ func (s *service) Connect(ctx context.Context, r *taskAPI.ConnectRequest) (_ *ta
 	return &taskAPI.ConnectResponse{
 		ShimPid: s.pid,
 		//Since kata cannot get the container's pid in VM, thus only return the shim's pid.
-		TaskPid: s.pid,
+		TaskPid: s.hpid,
 	}, nil
 }
 

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -72,6 +72,7 @@ type VCSandbox interface {
 	ListRoutes() ([]*pbTypes.Route, error)
 
 	GetOOMEvent() (string, error)
+	GetHypervisorPid() (int, error)
 
 	UpdateRuntimeMetrics() error
 	GetAgentMetrics() (string, error)

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -248,6 +248,16 @@ func (s *Sandbox) GetNetNs() string {
 	return s.networkNS.NetNsPath
 }
 
+// GetHypervisorPid returns the hypervisor's pid.
+func (s *Sandbox) GetHypervisorPid() (int, error) {
+	pids := s.hypervisor.getPids()
+	if len(pids) == 0 || pids[0] == 0 {
+		return -1, fmt.Errorf("Invalid hypervisor PID: %+v", pids)
+	}
+
+	return pids[0], nil
+}
+
 // GetAllContainers returns all containers.
 func (s *Sandbox) GetAllContainers() []VCContainer {
 	ifa := make([]VCContainer, len(s.containers))


### PR DESCRIPTION
Since the kata's hypervisor process is in the network namespace,
which is close to container's process, and some host metrics
such as cadvisor can use this pid to access the network namespace
to get some network metrics. Thus this commit replace the shim's
pid with the hypervisor's pid.

Fixes: #1451

Signed-off-by: fupan.lfp <fupan.lfp@antfin.com>