### PR TITLE
agent: Agent invokes OCI hooks with wrong PID

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -834,8 +834,6 @@ impl BaseContainer for LinuxContainer {
         }
         let linux = spec.linux.as_ref().unwrap();
 
-        let st = self.oci_state()?;
-
         let (pfd_log, cfd_log) = unistd::pipe().context("failed to create pipe")?;
 
         let _ = fcntl::fcntl(pfd_log, FcntlArg::F_SETFD(FdFlag::FD_CLOEXEC))
@@ -937,6 +935,8 @@ impl BaseContainer for LinuxContainer {
         }
 
         info!(logger, "child pid: {}", p.pid);
+
+        let st = self.oci_state()?;
 
         join_namespaces(
             &logger,


### PR DESCRIPTION
Agent sends -1 PID when invoking OCI hooks.

How to reproduce:

```
mount guest image
echo -e '#!/bin/sh\nread line\necho "$line" >> /var/run/kata-containers/shared/containers/repro-test/rootfs/home/log' >> ${GUEST_ROOTFS_PATH}/usr/share/oci/hooks/prestart/test.sh
chmod a+x ${GUEST_ROOTFS_PATH}/usr/share/oci/hooks/prestart/test.sh
sudo umount ~/mnt
sudo ctr run --rm --runtime io.containerd.kata-clh.v2  -t docker.io/library/busybox:latest repro-test sh -c "cat /home/log"
{"ociVersion":"1.0.2-dev","id":"repro-test","status":"created","pid":-1,"bundle":"/run/kata-containers/repro-test"}
```

OCI state struct is initialized before obtaining PID, so this PR moves `oci_state` call down, right after we get the id.

Fixes: #1458

Signed-off-by: Maksym Pavlenko <pavlenko.maksym@gmail.com>