### PR TITLE
Backport github actions to stable 2.0

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -1,0 +1,68 @@
+on: ["pull_request"]
+name: Static checks
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.14.x, 1.15.x]
+        os: [ubuntu-20.04]
+    runs-on: ${{ matrix.os }}
+    env:
+      GO111MODULE: off
+      TRAVIS: "true"
+      TRAVIS_BRANCH: ${{ github.base_ref }}
+      TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
+      TRAVIS_PULL_REQUEST_SHA : ${{ github.event.pull_request.head.sha }}
+      RUST_BACKTRACE: "1"
+      RUST_AGENT: "yes"
+      target_branch: ${{ github.base_ref }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+      env:
+        GOPATH: ${{ runner.workspace }}/kata-containers
+    - name: Setup GOPATH
+      run: |
+        gopath_org=$(go env GOPATH)/src/github.com/kata-containers/
+        mkdir -p ${gopath_org}
+        ln -s ${PWD} ${gopath_org}
+        echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
+        echo "TRAVIS_PULL_REQUEST_BRANCH: ${TRAVIS_PULL_REQUEST_BRANCH}"
+        echo "TRAVIS_PULL_REQUEST_SHA: ${TRAVIS_PULL_REQUEST_SHA}"
+        echo "TRAVIS: ${TRAVIS}"
+    - name: Set env
+      run: |
+        echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+        echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+    - name: Checkout code
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        path: ./src/github.com/${{ github.repository }}
+    - name: Setup travis references
+      run: |
+        echo "TRAVIS_BRANCH=${TRAVIS_BRANCH:-$(echo $GITHUB_REF | awk 'BEGIN { FS = \"/\" } ; { print $3 }')}" 
+        target_branch=${TRAVIS_BRANCH}
+    - name: Setup
+      run: |
+        cd ${GOPATH}/src/github.com/kata-containers/kata-containers && ./ci/setup.sh
+      env:
+        GOPATH: ${{ runner.workspace }}/kata-containers
+    - name: Building rust
+      run: |
+        cd ${GOPATH}/src/github.com/kata-containers/kata-containers && ./ci/install_rust.sh
+        PATH=$PATH:"$HOME/.cargo/bin"
+    - name: Make clippy
+      run: |
+        cd ${GOPATH}/src/github.com/kata-containers/kata-containers/src/agent && rustup target add x86_64-unknown-linux-musl && rustup component add rustfmt && rustup component add clippy && make clippy
+    - name: Static checks
+      run: |
+        cd ${GOPATH}/src/github.com/kata-containers/kata-containers && ./ci/static-checks.sh
+    - name: Build agent
+      run: |
+        cd ${GOPATH}/src/github.com/kata-containers/kata-containers/src/agent && make
+    - name: Run agent unit tests
+      run: |
+        cd ${GOPATH}/src/github.com/kata-containers/kata-containers/src/agent && make check


### PR DESCRIPTION
This PR updates the ubuntu version from 18.04 to 20.04 that will be
used for the github actions.

Fixes #1295

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>