### PR TITLE
runtime: test revendor GoVMM memory backend

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -63,6 +63,7 @@ require (
 )
 
 replace (
+	github.com/kata-containers/govmm => github.com/Jakob-Naucke/govmm v0.0.0-20210225154910-fe1ddaa40bd9
 	github.com/uber-go/atomic => go.uber.org/atomic v1.5.1
 	google.golang.org/genproto => google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 	google.golang.org/grpc => google.golang.org/grpc v1.19.0

--- a/src/runtime/go.sum
+++ b/src/runtime/go.sum
@@ -36,6 +36,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/sketches-go v0.0.1/go.mod h1:Q5DbzQ+3AkgGwymQO7aZFNP7ns2lZKGtvRBzRXfdi60=
+github.com/Jakob-Naucke/govmm v0.0.0-20210225154910-fe1ddaa40bd9 h1:Krx8rOoe5DyY+c7cxi4UEJ1aZASJ8byrREpwTyyYDR4=
+github.com/Jakob-Naucke/govmm v0.0.0-20210225154910-fe1ddaa40bd9/go.mod h1:+fllL1p0wrIe9+h005LrxipimP6ODYALjVbWMzWCRnU=
 github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.8.6 h1:ZfF0+zZeYdzMIVMZHKtDKJvLHj76XCuVae/jNkjj0IA=
@@ -274,8 +276,6 @@ github.com/juju/errors v0.0.0-20180806074554-22422dad46e1/go.mod h1:W54LbzXuIE0b
 github.com/juju/loggo v0.0.0-20190526231331-6e530bcce5d8/go.mod h1:vgyd7OREkbtVEN/8IXZe5Ooef3LQePvuBm9UWj6ZL8U=
 github.com/juju/testing v0.0.0-20190613124551-e81189438503/go.mod h1:63prj8cnj0tU0S9OHjGJn+b1h0ZghCndfnbQolrYTwA=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
-github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca h1:UdXFthwasAPnmv37gLJUEFsW9FaabYA+mM6FoSi8kzU=
-github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca/go.mod h1:VmAHbsL5lLfzHW/MNL96NVLF840DNEV5i683kISgFKk=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
+++ b/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
@@ -2528,9 +2528,6 @@ func (config *Config) appendMemoryKnobs() {
 	if config.Memory.Size == "" {
 		return
 	}
-	if !isDimmSupported(config) {
-		return
-	}
 	var objMemParam, numaMemParam string
 	dimmName := "dimm1"
 	if config.Knobs.HugePages {
@@ -2553,8 +2550,13 @@ func (config *Config) appendMemoryKnobs() {
 	config.qemuParams = append(config.qemuParams, "-object")
 	config.qemuParams = append(config.qemuParams, objMemParam)
 
-	config.qemuParams = append(config.qemuParams, "-numa")
-	config.qemuParams = append(config.qemuParams, numaMemParam)
+	if isDimmSupported(config) {
+		config.qemuParams = append(config.qemuParams, "-numa")
+		config.qemuParams = append(config.qemuParams, numaMemParam)
+	} else {
+		config.qemuParams = append(config.qemuParams, "-machine")
+		config.qemuParams = append(config.qemuParams, "memory-backend="+dimmName)
+	}
 }
 
 func (config *Config) appendKnobs() {

--- a/src/runtime/vendor/modules.txt
+++ b/src/runtime/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-multierror v1.0.0
 ## explicit
 github.com/hashicorp/go-multierror
-# github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca
+# github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca => github.com/Jakob-Naucke/govmm v0.0.0-20210225154910-fe1ddaa40bd9
 ## explicit
 github.com/kata-containers/govmm/qemu
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
@@ -462,6 +462,7 @@ gopkg.in/yaml.v3
 # k8s.io/apimachinery v0.18.2
 ## explicit
 k8s.io/apimachinery/pkg/api/resource
+# github.com/kata-containers/govmm => github.com/Jakob-Naucke/govmm v0.0.0-20210225154910-fe1ddaa40bd9
 # github.com/uber-go/atomic => go.uber.org/atomic v1.5.1
 # google.golang.org/genproto => google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 # google.golang.org/grpc => google.golang.org/grpc v1.19.0


### PR DESCRIPTION
Do not merge. Test https://github.com/kata-containers/govmm/pull/161
to ensure functionality with Kata. Backport theoretically required.

Fixes: #1469
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>