### PR TITLE
osbuilder/arm64: build musl toolchain from source code if needed

### DIFF
--- a/ci/install_musl.sh
+++ b/ci/install_musl.sh
@@ -12,10 +12,11 @@ install_aarch64_musl() {
 		local musl_tar="${arch}-linux-musl-native.tgz"
 		local musl_dir="${arch}-linux-musl-native"
 		pushd /tmp
-		curl -sLO https://musl.cc/${musl_tar}
-		tar -zxf ${musl_tar}
-		mkdir -p /usr/local/musl/
-		cp -r ${musl_dir}/* /usr/local/musl/
+		if curl -sLO --fail https://musl.cc/${musl_tar}; then
+			tar -zxf ${musl_tar}
+			mkdir -p /usr/local/musl/
+			cp -r ${musl_dir}/* /usr/local/musl/
+		fi
 		popd
 	fi
 }


### PR DESCRIPTION
Currently, musl toolchain installation on arm64 is just downloading from
a website. It's unsafe in case the website corrupts. So build musl
toolchain from source if it can't be downloaded.

Fixes: #1481
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

@GabyCT @jodh-intel