### PR TITLE
runtime: Short the shim-monitor path

### DIFF
--- a/src/runtime/cli/kata-exec.go
+++ b/src/runtime/cli/kata-exec.go
@@ -94,7 +94,7 @@ var kataExecCLICommand = cli.Command{
 
 		span.SetAttributes(label.Key("sandbox").String(sandboxID))
 
-		conn, err := getConn(namespace, sandboxID, port)
+		conn, err := getConn(sandboxID, port)
 		if err != nil {
 			return err
 		}
@@ -177,8 +177,8 @@ func (s *iostream) Read(data []byte) (n int, err error) {
 	return s.conn.Read(data)
 }
 
-func getConn(namespace, sandboxID string, port uint64) (net.Conn, error) {
-	socketAddr := filepath.Join(string(filepath.Separator), "containerd-shim", namespace, sandboxID, "shim-monitor.sock")
+func getConn(sandboxID string, port uint64) (net.Conn, error) {
+	socketAddr := filepath.Join(string(filepath.Separator), "run", "vc", sandboxID, "shim-monitor")
 	client, err := kataMonitor.BuildUnixSocketClient(socketAddr, defaultTimeout)
 	if err != nil {
 		return nil, err

--- a/src/runtime/containerd-shim-v2/shim_management.go
+++ b/src/runtime/containerd-shim-v2/shim_management.go
@@ -16,7 +16,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/containerd/containerd/namespaces"
 	cdshim "github.com/containerd/containerd/runtime/v2/shim"
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
 	vcAnnotations "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations"
@@ -189,9 +188,5 @@ func (s *service) mountPprofHandle(m *http.ServeMux, ociSpec *specs.Spec) {
 }
 
 func socketAddress(ctx context.Context, id string) (string, error) {
-	ns, err := namespaces.NamespaceRequired(ctx)
-	if err != nil {
-		return "", err
-	}
-	return filepath.Join(string(filepath.Separator), "containerd-shim", ns, id, "shim-monitor.sock"), nil
+	return filepath.Join(string(filepath.Separator), "run", "vc", id, "shim-monitor"), nil
 }


### PR DESCRIPTION
Instead of having something like
"/containerd-shim/$namespace/$sandboxID/shim-monitor.sock", let's change
the approach to:
* create the file in a more neutral location "/run/vc", instead of
  "/containerd-shim";
* drop the namespace, as the sandboxID should be unique;
* remove ".sock" from the socket name.

This will result on a name that looks like:
"/run/vc/$sandboxID/shim-monitor"

Fixes: #497

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>