### PR TITLE
Bump to QEMU 5.2.0 - respin

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -278,7 +278,7 @@ parts:
       chmod +x ${configure_hypervisor}
       # static build. The --prefix, --libdir, --libexecdir, --datadir arguments are
       # based on PREFIX and set by configure-hypervisor.sh
-      echo "$(PREFIX=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr ${configure_hypervisor} -s qemu) \
+      echo "$(PREFIX=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr ${configure_hypervisor} -s kata-qemu) \
         --disable-rbd " \
         | xargs ./configure
 
@@ -294,7 +294,6 @@ parts:
       - -usr/bin/qemu-pr-helper
       - -usr/bin/virtfs-proxy-helper
       - -usr/include/
-      - -usr/libexec/
       - -usr/share/applications/
       - -usr/share/icons/
       - -usr/var/

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -474,6 +474,8 @@ generate_qemu_options() {
 	# On version 5.2.0 onward the Meson build system warns to not use -O3
 	if ! gt_eq "${qemu_version}" "5.2.0" ; then
 		_qemu_cflags+=" -O3"
+	else
+		_qemu_cflags+=" -O2"
 	fi
 
 	# Improve code quality by assuming identical semantics for interposed


### PR DESCRIPTION
Recently I realized that snapcraft will not have virtiofsd included on snap once QEMU is updated to 5.2.0. Also @egernst reported to me a misbehave related with my changes to `configure-hypervisor.sh` script. Thus I made fixes for those issues and put together on this PR as a respin of https://github.com/kata-containers/kata-containers/pull/1349