### PR TITLE
runtime: return hypervisor Pid in TaskExit event

### DIFF
--- a/src/runtime/containerd-shim-v2/utils.go
+++ b/src/runtime/containerd-shim-v2/utils.go
@@ -24,7 +24,7 @@ import (
 func cReap(s *service, status int, id, execid string, exitat time.Time) {
 	s.ec <- exit{
 		timestamp: exitat,
-		pid:       s.pid,
+		pid:       s.hpid,
 		status:    status,
 		id:        id,
 		execid:    execid,


### PR DESCRIPTION
Other RPC calls return Pid of hypervisor, the TaskExit should
return the same Pid.

Fixes: #1497

Signed-off-by: bin <bin@hyper.sh>