### PR TITLE
exec: ensure sup groups are added to agent request

### DIFF
--- a/src/runtime/containerd-shim-v2/exec.go
+++ b/src/runtime/containerd-shim-v2/exec.go
@@ -90,6 +90,10 @@ func newExec(c *container, stdin, stdout, stderr string, terminal bool, jspec *g
 		height = uint32(spec.ConsoleSize.Height)
 		width = uint32(spec.ConsoleSize.Width)
 	}
+	var extraGroups []string
+	for _, g := range spec.User.AdditionalGids {
+		extraGroups = append(extraGroups, fmt.Sprintf("%d", g))
+	}
 
 	tty := &tty{
 		stdin:    stdin,
@@ -101,14 +105,15 @@ func newExec(c *container, stdin, stdout, stderr string, terminal bool, jspec *g
 	}
 
 	cmds := &types.Cmd{
-		Args:            spec.Args,
-		Envs:            getEnvs(spec.Env),
-		User:            fmt.Sprintf("%d", spec.User.UID),
-		PrimaryGroup:    fmt.Sprintf("%d", spec.User.GID),
-		WorkDir:         spec.Cwd,
-		Interactive:     terminal,
-		Detach:          !terminal,
-		NoNewPrivileges: spec.NoNewPrivileges,
+		Args:                spec.Args,
+		Envs:                getEnvs(spec.Env),
+		User:                fmt.Sprintf("%d", spec.User.UID),
+		PrimaryGroup:        fmt.Sprintf("%d", spec.User.GID),
+		SupplementaryGroups: extraGroups,
+		WorkDir:             spec.Cwd,
+		Interactive:         terminal,
+		Detach:              !terminal,
+		NoNewPrivileges:     spec.NoNewPrivileges,
 	}
 
 	exec := &exec{


### PR DESCRIPTION
Extra groups were not being handled when exec'ing. Ensure
that these are handled.

Before this, running a pod with:
```
 ...snippet...
 securityContext:
   fsGroup: 266
   runAsGroup: 51020
   runAsUser: 264
```

And then exec'ing would not supply the fsGroup:
```
$ kubectl exec -it kata-bb  -- sh -c id
uid=264 gid=51020
```

Fixes: #1500

Signed-off-by: Eric Ernst  <eric.g.ernst@gmail.com>