### PR TITLE
agent: Fix unused import warning in unit tests

### DIFF
--- a/src/agent/rustjail/src/utils.rs
+++ b/src/agent/rustjail/src/utils.rs
@@ -87,7 +87,7 @@ pub fn home_dir(uid: uid_t) -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{self, Write};
+    use std::io::Write;
     use tempfile::Builder;
 
     #[test]


### PR DESCRIPTION
This unneeded import was accidentally introduced by 81607e34.

fixes #1507

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>