### PR TITLE
runtime: Add method to vcmock sandbox

### DIFF
--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -255,3 +255,8 @@ func (s *Sandbox) GetAgentURL() (string, error) {
 	}
 	return "", nil
 }
+
+// GetHypervisorPid implements the VCSandbox function of the same name
+func (s *Sandbox) GetHypervisorPid() (int, error) {
+	return s.MockHypervisorPid, nil
+}

--- a/src/runtime/virtcontainers/pkg/vcmock/types.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/types.go
@@ -21,11 +21,12 @@ import (
 
 // Sandbox is a fake Sandbox type used for testing
 type Sandbox struct {
-	MockID          string
-	MockURL         string
-	MockAnnotations map[string]string
-	MockContainers  []*Container
-	MockNetNs       string
+	MockID            string
+	MockURL           string
+	MockAnnotations   map[string]string
+	MockContainers    []*Container
+	MockNetNs         string
+	MockHypervisorPid int
 
 	// functions for mocks
 	AnnotationsFunc          func(key string) (string, error)


### PR DESCRIPTION
GetHypervisorPid() was added to VCSandbox interface but not updated in
vcmock Sandbox. Add to vcmock to prevent unit test failure.

Fixes #1526

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>