### PR TITLE
[backport] shimv2: return the hypervisor's pid as the container pid

### DIFF
--- a/src/runtime/containerd-shim-v2/create.go
+++ b/src/runtime/containerd-shim-v2/create.go
@@ -87,6 +87,12 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 			return nil, err
 		}
 		s.sandbox = sandbox
+		pid, err := s.sandbox.GetHypervisorPid()
+		if err != nil {
+			return nil, err
+		}
+		s.hpid = uint32(pid)
+
 		go s.startManagementServer(ctx, ociSpec)
 
 	case vc.PodContainer:

--- a/src/runtime/containerd-shim-v2/utils.go
+++ b/src/runtime/containerd-shim-v2/utils.go
@@ -24,7 +24,7 @@ import (
 func cReap(s *service, status int, id, execid string, exitat time.Time) {
 	s.ec <- exit{
 		timestamp: exitat,
-		pid:       s.pid,
+		pid:       s.hpid,
 		status:    status,
 		id:        id,
 		execid:    execid,

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -72,6 +72,7 @@ type VCSandbox interface {
 	ListRoutes() ([]*pbTypes.Route, error)
 
 	GetOOMEvent() (string, error)
+	GetHypervisorPid() (int, error)
 
 	UpdateRuntimeMetrics() error
 	GetAgentMetrics() (string, error)

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -254,3 +254,7 @@ func (s *Sandbox) GetAgentURL() (string, error) {
 	}
 	return "", nil
 }
+
+func (s *Sandbox) GetHypervisorPid() (int, error) {
+	return 0, nil
+}

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -246,6 +246,16 @@ func (s *Sandbox) GetNetNs() string {
 	return s.networkNS.NetNsPath
 }
 
+// GetHypervisorPid returns the hypervisor's pid.
+func (s *Sandbox) GetHypervisorPid() (int, error) {
+	pids := s.hypervisor.getPids()
+	if len(pids) == 0 || pids[0] == 0 {
+		return -1, fmt.Errorf("Invalid hypervisor PID: %+v", pids)
+	}
+
+	return pids[0], nil
+}
+
 // GetAllContainers returns all containers.
 func (s *Sandbox) GetAllContainers() []VCContainer {
 	ifa := make([]VCContainer, len(s.containers))


### PR DESCRIPTION
Enable cAdvisor network stats in stable-2.0 branch:
backport https://github.com/kata-containers/kata-containers/pull/1452 and https://github.com/kata-containers/kata-containers/pull/1498 