### PR TITLE
[backport] runtime: Fix missing 'name' field on containerd-shim-v2 logs

### DIFF
--- a/src/runtime/containerd-shim-v2/service.go
+++ b/src/runtime/containerd-shim-v2/service.go
@@ -59,7 +59,10 @@ var (
 var vci vc.VC = &vc.VCImpl{}
 
 // shimLog is logger for shim package
-var shimLog = logrus.WithField("source", "containerd-kata-shim-v2")
+var shimLog = logrus.WithFields(logrus.Fields{
+	"source": "containerd-kata-shim-v2",
+	"name":   "containerd-shim-v2",
+})
 
 // New returns a new shim service that can be used via GRPC
 func New(ctx context.Context, id string, publisher events.Publisher) (cdshim.Shim, error) {


### PR DESCRIPTION
Each Kata Containers application should generate log records with a specified
structure. Currently on containerd-shim-v2's logs, the required 'name' field
is missing. This changed its logger to append the application name on each
and every emitted entries.

Fixes #1479
Related-to: github.com/kata-containers/tests/issues/3260
Suggested-by: James O. D. Hunt <james.o.hunt@intel.com>
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>