### PR TITLE
kata-deploy: Use the correct image for 2.0.2 release

### DIFF
--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kata-label-node
       containers:
       - name: kube-kata
-        image: katadocker/kata-deploy
+        image: katadocker/kata-deploy:2.0.2
         imagePullPolicy: Always
         lifecycle:
           preStop:


### PR DESCRIPTION
Let's tag the yet non existent 2.0.2 image, so whoever deploys kata
using kata-deploy from the release tarball is pointed to the correct
image.

Fixes: #1493

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>