### PR TITLE
kata-deploy: Use the correct tag for 2.1-alpha1 release

### DIFF
--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -16,7 +16,7 @@ spec:
       serviceAccountName: kata-label-node
       containers:
       - name: kube-kata
-        image: katadocker/kata-deploy
+        image: katadocker/kata-deploy:2.1-alpha1
         imagePullPolicy: Always
         lifecycle:
           preStop:


### PR DESCRIPTION
Let's ensure we use the appropriate tag for the release, even before it
was actually created.

Fixes: #1493

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>