### PR TITLE
runtime: add support for QEMU 6

### DIFF
--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -201,7 +201,7 @@ const (
 
 	qmpCapMigrationIgnoreShared = "x-ignore-shared"
 
-	qemuNvdimmOption = "nvdimm"
+	qemuNvdimmOption = "nvdimm=on"
 )
 
 // kernelParamsNonDebug is a list of the default kernel


### PR DESCRIPTION
Use `on` and `off` to enable or disable features,
`no` prefix is deprecated

fixes #1545

Signed-off-by: Julio Montes <julio.montes@intel.com>