### PR TITLE
[backport] runtime: increase dial timeout

### DIFF
--- a/src/runtime/virtcontainers/pkg/agent/protocols/client/client.go
+++ b/src/runtime/virtcontainers/pkg/agent/protocols/client/client.go
@@ -35,7 +35,7 @@ const (
 	MockHybridVSockScheme = "mock"
 )
 
-var defaultDialTimeout = 15 * time.Second
+var defaultDialTimeout = 30 * time.Second
 var defaultCloseTimeout = 5 * time.Second
 
 var hybridVSockPort uint32


### PR DESCRIPTION
On some setups, starting multiple kata pods (qemu) simultaneously on the same node
might cause kata VMs booting time to increase and the pods to fail with:
Failed to check if grpc server is working: rpc error: code = DeadlineExceeded desc = timed
out connecting to vsock 1358662990:1024: unknown

Increasing default dialing timeout to 30s should cover most cases.

Signed-off-by: Snir Sheriber <ssheribe@redhat.com>
Fixes: #1543
(backport https://github.com/kata-containers/kata-containers/pull/1544)