### PR TITLE
runtime: makefile allow override DAX value

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -191,7 +191,7 @@ DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/kata-qemu/virtiofsd
 DEFVALIDVIRTIOFSDAEMONPATHS := [\"$(DEFVIRTIOFSDAEMON)\"]
 # Default DAX mapping cache size in MiB
 #if value is 0, DAX is not enabled
-DEFVIRTIOFSCACHESIZE := 0
+DEFVIRTIOFSCACHESIZE ?= 0
 DEFVIRTIOFSCACHE ?= auto
 # Format example:
 #   [\"-o\", \"arg1=xxx,arg2\", \"-o\", \"hello world\", \"--arg3=yyy\"]


### PR DESCRIPTION
Allow enable DAX using env variable.

Fixes: #1547

Signed-off-by: Carlos Venegas <jos.c.venegas.munoz@intel.com>