### PR TITLE
runtime: Fix trace span ordering and static checks

### DIFF
--- a/src/runtime/containerd-shim-v2/service_test.go
+++ b/src/runtime/containerd-shim-v2/service_test.go
@@ -19,12 +19,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func NewService(id string) (service, error) {
+func newService(id string) (*service, error) {
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	s := service{
+	s := &service{
 		id:         id,
 		pid:        uint32(os.Getpid()),
 		ctx:        ctx,
@@ -43,16 +43,16 @@ func TestServiceCreate(t *testing.T) {
 
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, _ := ioutil.TempDir("", "")
 	defer os.RemoveAll(tmpdir)
 
 	bundleDir := filepath.Join(tmpdir, "bundle")
-	err = makeOCIBundle(bundleDir)
+	err := makeOCIBundle(bundleDir)
 	assert.NoError(err)
 
 	ctx := context.Background()
 
-	s, err := NewService("foo")
+	s, err := newService("foo")
 	assert.NoError(err)
 
 	for i, d := range ktu.ContainerIDTestData {

--- a/src/runtime/pkg/katatestutils/utils.go
+++ b/src/runtime/pkg/katatestutils/utils.go
@@ -53,7 +53,7 @@ type ContainerIDTestDataType struct {
 	Valid bool
 }
 
-// Set of test data that lists valid and invalid Container IDs
+// ContainerIDTestData is a set of test data that lists valid and invalid Container IDs
 var ContainerIDTestData = []ContainerIDTestDataType{
 	{"", false},   // Cannot be blank
 	{" ", false},  // Cannot be a space

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -420,7 +420,7 @@ func (a *Acrn) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 
 // startSandbox will start the Sandbox's VM.
 func (a *Acrn) startSandbox(ctx context.Context, timeoutSecs int) error {
-	span, _ := a.trace(ctx, "startSandbox")
+	span, ctx := a.trace(ctx, "startSandbox")
 	defer span.End()
 
 	if a.config.Debug {

--- a/src/runtime/virtcontainers/api.go
+++ b/src/runtime/virtcontainers/api.go
@@ -53,7 +53,7 @@ func SetLogger(ctx context.Context, logger *logrus.Entry) {
 // CreateSandbox is the virtcontainers sandbox creation entry point.
 // CreateSandbox creates a sandbox and its containers. It does not start them.
 func CreateSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (VCSandbox, error) {
-	span, _ := trace(ctx, "CreateSandbox")
+	span, ctx := trace(ctx, "CreateSandbox")
 	defer span.End()
 
 	s, err := createSandboxFromConfig(ctx, sandboxConfig, factory)
@@ -62,7 +62,7 @@ func CreateSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 }
 
 func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (_ *Sandbox, err error) {
-	span, _ := trace(ctx, "createSandboxFromConfig")
+	span, ctx := trace(ctx, "createSandboxFromConfig")
 	defer span.End()
 
 	// Create the sandbox.
@@ -136,7 +136,7 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 // in the sandbox left, do stop the sandbox and delete it. Those serial operations will be done exclusively by
 // locking the sandbox.
 func CleanupContainer(ctx context.Context, sandboxID, containerID string, force bool) error {
-	span, _ := trace(ctx, "CleanupContainer")
+	span, ctx := trace(ctx, "CleanupContainer")
 	defer span.End()
 
 	if sandboxID == "" {

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -700,7 +700,7 @@ func (c *Container) createBlockDevices(ctx context.Context) error {
 
 // newContainer creates a Container structure from a sandbox and a container configuration.
 func newContainer(ctx context.Context, sandbox *Sandbox, contConfig *ContainerConfig) (*Container, error) {
-	span, _ := sandbox.trace(ctx, "newContainer")
+	span, ctx := sandbox.trace(ctx, "newContainer")
 	defer span.End()
 
 	if !contConfig.valid() {

--- a/src/runtime/virtcontainers/factory/factory.go
+++ b/src/runtime/virtcontainers/factory/factory.go
@@ -141,7 +141,7 @@ func (f *factory) checkConfig(config vc.VMConfig) error {
 
 // GetVM returns a working blank VM created by the factory.
 func (f *factory) GetVM(ctx context.Context, config vc.VMConfig) (*vc.VM, error) {
-	span, _ := trace(ctx, "GetVM")
+	span, ctx := trace(ctx, "GetVM")
 	defer span.End()
 
 	hypervisorConfig := config.HypervisorConfig

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -495,7 +495,7 @@ func (k *kataAgent) setupSharedPath(ctx context.Context, sandbox *Sandbox) error
 }
 
 func (k *kataAgent) createSandbox(ctx context.Context, sandbox *Sandbox) error {
-	span, _ := k.trace(ctx, "createSandbox")
+	span, ctx := k.trace(ctx, "createSandbox")
 	defer span.End()
 
 	if err := k.setupSharedPath(ctx, sandbox); err != nil {
@@ -582,7 +582,7 @@ func cmdEnvsToStringSlice(ev []types.EnvVar) []string {
 }
 
 func (k *kataAgent) exec(ctx context.Context, sandbox *Sandbox, c Container, cmd types.Cmd) (*Process, error) {
-	span, _ := k.trace(ctx, "exec")
+	span, ctx := k.trace(ctx, "exec")
 	defer span.End()
 
 	var kataProcess *grpc.Process
@@ -754,7 +754,7 @@ func (k *kataAgent) getDNS(sandbox *Sandbox) ([]string, error) {
 }
 
 func (k *kataAgent) startSandbox(ctx context.Context, sandbox *Sandbox) error {
-	span, _ := k.trace(ctx, "startSandbox")
+	span, ctx := k.trace(ctx, "startSandbox")
 	defer span.End()
 
 	if err := k.setAgentURL(); err != nil {
@@ -909,7 +909,7 @@ func setupStorages(ctx context.Context, sandbox *Sandbox) []*grpc.Storage {
 }
 
 func (k *kataAgent) stopSandbox(ctx context.Context, sandbox *Sandbox) error {
-	span, _ := k.trace(ctx, "stopSandbox")
+	span, ctx := k.trace(ctx, "stopSandbox")
 	defer span.End()
 
 	req := &grpc.DestroySandboxRequest{}
@@ -1271,7 +1271,7 @@ func (k *kataAgent) buildContainerRootfs(ctx context.Context, sandbox *Sandbox, 
 }
 
 func (k *kataAgent) createContainer(ctx context.Context, sandbox *Sandbox, c *Container) (p *Process, err error) {
-	span, _ := k.trace(ctx, "createContainer")
+	span, ctx := k.trace(ctx, "createContainer")
 	defer span.End()
 
 	var ctrStorages []*grpc.Storage
@@ -1593,7 +1593,7 @@ func (k *kataAgent) handlePidNamespace(grpcSpec *grpc.Spec, sandbox *Sandbox) bo
 }
 
 func (k *kataAgent) startContainer(ctx context.Context, sandbox *Sandbox, c *Container) error {
-	span, _ := k.trace(ctx, "startContainer")
+	span, ctx := k.trace(ctx, "startContainer")
 	defer span.End()
 
 	req := &grpc.StartContainerRequest{
@@ -1605,7 +1605,7 @@ func (k *kataAgent) startContainer(ctx context.Context, sandbox *Sandbox, c *Con
 }
 
 func (k *kataAgent) stopContainer(ctx context.Context, sandbox *Sandbox, c Container) error {
-	span, _ := k.trace(ctx, "stopContainer")
+	span, ctx := k.trace(ctx, "stopContainer")
 	defer span.End()
 
 	_, err := k.sendReq(ctx, &grpc.RemoveContainerRequest{ContainerId: c.id})
@@ -1815,7 +1815,7 @@ func (k *kataAgent) disconnect(ctx context.Context) error {
 
 // check grpc server is serving
 func (k *kataAgent) check(ctx context.Context) error {
-	span, _ := k.trace(ctx, "check")
+	span, ctx := k.trace(ctx, "check")
 	defer span.End()
 
 	_, err := k.sendReq(ctx, &grpc.CheckRequest{})
@@ -1826,7 +1826,7 @@ func (k *kataAgent) check(ctx context.Context) error {
 }
 
 func (k *kataAgent) waitProcess(ctx context.Context, c *Container, processID string) (int32, error) {
-	span, _ := k.trace(ctx, "waitProcess")
+	span, ctx := k.trace(ctx, "waitProcess")
 	defer span.End()
 
 	resp, err := k.sendReq(ctx, &grpc.WaitProcessRequest{

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -347,7 +347,7 @@ func bindUnmountContainerRootfs(ctx context.Context, sharedDir, cID string) erro
 }
 
 func bindUnmountAllRootfs(ctx context.Context, sharedDir string, sandbox *Sandbox) error {
-	span, _ := trace(ctx, "bindUnmountAllRootfs")
+	span, ctx := trace(ctx, "bindUnmountAllRootfs")
 	defer span.End()
 
 	var errors *merr.Error

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -1273,7 +1273,7 @@ func (n *Network) Run(ctx context.Context, networkNSPath string, cb func() error
 
 // Add adds all needed interfaces inside the network namespace.
 func (n *Network) Add(ctx context.Context, config *NetworkConfig, s *Sandbox, hotplug bool) ([]Endpoint, error) {
-	span, _ := n.trace(ctx, "Add")
+	span, ctx := n.trace(ctx, "Add")
 	defer span.End()
 
 	endpoints, err := createEndpointsFromScan(config.NetNSPath, config)
@@ -1354,7 +1354,7 @@ func (n *Network) PostAdd(ctx context.Context, ns *NetworkNamespace, hotplug boo
 // Remove network endpoints in the network namespace. It also deletes the network
 // namespace in case the namespace has been created by us.
 func (n *Network) Remove(ctx context.Context, ns *NetworkNamespace, hypervisor hypervisor) error {
-	span, _ := n.trace(ctx, "Remove")
+	span, ctx := n.trace(ctx, "Remove")
 	defer span.End()
 
 	for _, endpoint := range ns.Endpoints {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -468,7 +468,7 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 	// Save the tracing context
 	q.ctx = ctx
 
-	span, _ := q.trace(ctx, "createSandbox")
+	span, ctx := q.trace(ctx, "createSandbox")
 	defer span.End()
 
 	if err := q.setup(ctx, id, hypervisorConfig); err != nil {
@@ -772,7 +772,7 @@ func (q *qemu) setupVirtioMem() error {
 
 // startSandbox will start the Sandbox's VM.
 func (q *qemu) startSandbox(ctx context.Context, timeout int) error {
-	span, _ := q.trace(ctx, "startSandbox")
+	span, ctx := q.trace(ctx, "startSandbox")
 	defer span.End()
 
 	if q.config.Debug {
@@ -1609,7 +1609,7 @@ func (q *qemu) hotplugDevice(ctx context.Context, devInfo interface{}, devType d
 }
 
 func (q *qemu) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := q.trace(ctx, "hotplugAddDevice")
+	span, ctx := q.trace(ctx, "hotplugAddDevice")
 	defer span.End()
 
 	data, err := q.hotplugDevice(ctx, devInfo, devType, addDevice)
@@ -1621,7 +1621,7 @@ func (q *qemu) hotplugAddDevice(ctx context.Context, devInfo interface{}, devTyp
 }
 
 func (q *qemu) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := q.trace(ctx, "hotplugRemoveDevice")
+	span, ctx := q.trace(ctx, "hotplugRemoveDevice")
 	defer span.End()
 
 	data, err := q.hotplugDevice(ctx, devInfo, devType, removeDevice)
@@ -1833,14 +1833,14 @@ func (q *qemu) hotplugAddMemory(memDev *memoryDevice) (int, error) {
 }
 
 func (q *qemu) pauseSandbox(ctx context.Context) error {
-	span, _ := q.trace(ctx, "pauseSandbox")
+	span, ctx := q.trace(ctx, "pauseSandbox")
 	defer span.End()
 
 	return q.togglePauseSandbox(ctx, true)
 }
 
 func (q *qemu) resumeSandbox(ctx context.Context) error {
-	span, _ := q.trace(ctx, "resumeSandbox")
+	span, ctx := q.trace(ctx, "resumeSandbox")
 	defer span.End()
 
 	return q.togglePauseSandbox(ctx, false)

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -445,7 +445,7 @@ func (s *Sandbox) getAndStoreGuestDetails(ctx context.Context) error {
 // to physically create that sandbox i.e. starts a VM for that sandbox to eventually
 // be started.
 func createSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (*Sandbox, error) {
-	span, _ := trace(ctx, "createSandbox")
+	span, ctx := trace(ctx, "createSandbox")
 	defer span.End()
 
 	if err := createAssets(ctx, &sandboxConfig); err != nil {
@@ -483,7 +483,7 @@ func createSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 }
 
 func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (sb *Sandbox, retErr error) {
-	span, _ := trace(ctx, "newSandbox")
+	span, ctx := trace(ctx, "newSandbox")
 	defer span.End()
 
 	if !sandboxConfig.valid() {
@@ -752,7 +752,7 @@ func (s *Sandbox) createNetwork(ctx context.Context) error {
 		return nil
 	}
 
-	span, _ := s.trace(ctx, "createNetwork")
+	span, ctx := s.trace(ctx, "createNetwork")
 	defer span.End()
 
 	s.networkNS = NetworkNamespace{
@@ -994,7 +994,7 @@ func (cw *consoleWatcher) stop() {
 
 // startVM starts the VM.
 func (s *Sandbox) startVM(ctx context.Context) (err error) {
-	span, _ := s.trace(ctx, "startVM")
+	span, ctx := s.trace(ctx, "startVM")
 	defer span.End()
 
 	s.Logger().Info("Starting VM")
@@ -1075,7 +1075,7 @@ func (s *Sandbox) startVM(ctx context.Context) (err error) {
 
 // stopVM: stop the sandbox's VM
 func (s *Sandbox) stopVM(ctx context.Context) error {
-	span, _ := s.trace(ctx, "stopVM")
+	span, ctx := s.trace(ctx, "stopVM")
 	defer span.End()
 
 	s.Logger().Info("Stopping sandbox in the VM")
@@ -1451,7 +1451,7 @@ func (s *Sandbox) ResumeContainer(ctx context.Context, containerID string) error
 // createContainers registers all containers, create the
 // containers in the guest and starts one shim per container.
 func (s *Sandbox) createContainers(ctx context.Context) error {
-	span, _ := s.trace(ctx, "createContainers")
+	span, ctx := s.trace(ctx, "createContainers")
 	defer span.End()
 
 	for _, contConfig := range s.config.Containers {
@@ -1523,7 +1523,7 @@ func (s *Sandbox) Start(ctx context.Context) error {
 // will be destroyed.
 // When force is true, ignore guest related stop failures.
 func (s *Sandbox) Stop(ctx context.Context, force bool) error {
-	span, _ := s.trace(ctx, "Stop")
+	span, ctx := s.trace(ctx, "Stop")
 	defer span.End()
 
 	if s.state.State == types.StateStopped {
@@ -1634,7 +1634,7 @@ func (s *Sandbox) unsetSandboxBlockIndex(index int) error {
 // HotplugAddDevice is used for add a device to sandbox
 // Sandbox implement DeviceReceiver interface from device/api/interface.go
 func (s *Sandbox) HotplugAddDevice(ctx context.Context, device api.Device, devType config.DeviceType) error {
-	span, _ := s.trace(ctx, "HotplugAddDevice")
+	span, ctx := s.trace(ctx, "HotplugAddDevice")
 	defer span.End()
 
 	if s.config.SandboxCgroupOnly {


### PR DESCRIPTION
Return ctx in trace() functions to correct span ordering.

Fixes #1550

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>