### PR TITLE
runtime: fix virtiofsd RO volume sharing

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -152,9 +152,10 @@ var kataHostSharedDir = func() string {
 }
 
 // Shared path handling:
-// 1. create two directories for each sandbox:
+// 1. create three directories for each sandbox:
 // -. /run/kata-containers/shared/sandboxes/$sbx_id/mounts/, a directory to hold all host/guest shared mounts
 // -. /run/kata-containers/shared/sandboxes/$sbx_id/shared/, a host/guest shared directory (9pfs/virtiofs source dir)
+// -. /run/kata-containers/shared/sandboxes/$sbx_id/private/, a directory to hold all temporary private mounts when creating ro mounts
 //
 // 2. /run/kata-containers/shared/sandboxes/$sbx_id/mounts/ is bind mounted readonly to /run/kata-containers/shared/sandboxes/$sbx_id/shared/, so guest cannot modify it
 //
@@ -165,6 +166,10 @@ func getSharePath(id string) string {
 
 func getMountPath(id string) string {
 	return filepath.Join(kataHostSharedDir(), id, "mounts")
+}
+
+func getPrivatePath(id string) string {
+	return filepath.Join(kataHostSharedDir(), id, "private")
 }
 
 func getSandboxPath(id string) string {


### PR DESCRIPTION
Right now we rely heavily on mount propagation to share host
files/directories to the guest. However, because virtiofsd
pivots and moves itself to a separate mount namespace, the remount
mount is not present in virtiofsd's mount. And it causes guest to be
able to write to the host RO volume.

To fix it, create a private RO mount and then move it to the host mounts
dir so that it will be present readonly in the host-guest shared dir.
