### PR TITLE
test: install mock hook binary before test

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -636,7 +636,14 @@ generate-config: $(CONFIGS)
 
 check: check-go-static
 
-test: go-test
+test: install-hook go-test
+
+install-hook:
+	make -C virtcontainers hook
+ifeq ($(shell id -u), 0)
+	echo "installing mock hook"
+	make -C virtcontainers install
+endif
 
 go-test: $(GENERATED_FILES)
 	go test -v -mod=vendor ./...
@@ -698,7 +705,8 @@ show-usage: show-header
 	@printf "• Additional targets:\n"
 	@printf "\n"
 	@printf "\tbuild                      : standard build (build everything).\n"
-	@printf "\tcheck                      : run tests.\n"
+	@printf "\ttest                       : run tests.\n"
+	@printf "\tcheck                      : run code checks.\n"
 	@printf "\tclean                      : remove built files.\n"
 	@printf "\tcontainerd-shim-v2         : only build containerd shim v2.\n"
 	@printf "\tcoverage                   : run coverage tests.\n"

--- a/src/runtime/pkg/katautils/hook_test.go
+++ b/src/runtime/pkg/katautils/hook_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 
 	ktu "github.com/kata-containers/kata-containers/src/runtime/pkg/katatestutils"
-	. "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/mock"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,11 +24,7 @@ var testBinHookPath = "/usr/bin/virtcontainers/bin/test/hook"
 var testBundlePath = "/test/bundle"
 
 func getMockHookBinPath() string {
-	if DefaultMockHookBinPath == "" {
-		return testBinHookPath
-	}
-
-	return DefaultMockHookBinPath
+	return testBinHookPath
 }
 
 func createHook(timeout int) specs.Hook {

--- a/src/runtime/virtcontainers/pkg/mock/mock.go
+++ b/src/runtime/virtcontainers/pkg/mock/mock.go
@@ -18,9 +18,6 @@ import (
 	pb "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
 )
 
-// DefaultMockHookBinPath is populated at link time.
-var DefaultMockHookBinPath string
-
 var testKataMockHybridVSockURLTempl = "mock://%s/kata-mock-hybrid-vsock.sock"
 
 func GenerateKataMockHybridVSock() (string, error) {


### PR DESCRIPTION
`make test` depends mock hook in virtcontainers directory,
before test, install it first.

Fixes: #1554

Signed-off-by: bin <bin@hyper.sh>