### PR TITLE
test: remove golint errors for some versions of Golang

### DIFF
--- a/src/runtime/containerd-shim-v2/service_test.go
+++ b/src/runtime/containerd-shim-v2/service_test.go
@@ -44,6 +44,7 @@ func TestServiceCreate(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
 	bundleDir := filepath.Join(tmpdir, "bundle")

--- a/src/runtime/containerd-shim-v2/service_test.go
+++ b/src/runtime/containerd-shim-v2/service_test.go
@@ -19,12 +19,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func NewService(id string) (service, error) {
+func newService(id string) (*service, error) {
 	ctx := context.Background()
 
 	ctx, cancel := context.WithCancel(ctx)
 
-	s := service{
+	s := &service{
 		id:         id,
 		pid:        uint32(os.Getpid()),
 		ctx:        ctx,
@@ -53,7 +53,7 @@ func TestServiceCreate(t *testing.T) {
 
 	ctx := context.Background()
 
-	s, err := NewService("foo")
+	s, err := newService("foo")
 	assert.NoError(err)
 
 	for i, d := range ktu.ContainerIDTestData {

--- a/src/runtime/containerd-shim-v2/utils_test.go
+++ b/src/runtime/containerd-shim-v2/utils_test.go
@@ -73,7 +73,7 @@ func init() {
 	var err error
 
 	fmt.Printf("INFO: creating test directory\n")
-	testDir, err = ioutil.TempDir("", fmt.Sprintf("shimV2-"))
+	testDir, err = ioutil.TempDir("", "shimV2-")
 	if err != nil {
 		panic(fmt.Sprintf("ERROR: failed to create test directory: %v", err))
 	}

--- a/src/runtime/pkg/katatestutils/utils.go
+++ b/src/runtime/pkg/katatestutils/utils.go
@@ -53,7 +53,7 @@ type ContainerIDTestDataType struct {
 	Valid bool
 }
 
-// Set of test data that lists valid and invalid Container IDs
+// ContainerIDTestData Set of test data that lists valid and invalid Container IDs
 var ContainerIDTestData = []ContainerIDTestDataType{
 	{"", false},   // Cannot be blank
 	{" ", false},  // Cannot be a space


### PR DESCRIPTION
Static checks will find that the `err` is never used, ensure it
is nil will resolve the error message.

Fixes: #1556

Signed-off-by: bin <bin@hyper.sh>