### PR TITLE
container: on cleanup, rm container directory for mounts path

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1047,7 +1047,7 @@ func (c *Container) stop(ctx context.Context, force bool) error {
 		return err
 	}
 
-	shareDir := filepath.Join(kataHostSharedDir(), c.sandbox.id, c.id)
+	shareDir := filepath.Join(getMountPath(c.sandbox.id), c.id)
 	if err := syscall.Rmdir(shareDir); err != nil {
 		c.Logger().WithError(err).WithField("share-dir", shareDir).Warn("Could not remove container share dir")
 	}


### PR DESCRIPTION
A wrong path was being used for container directory when
virtiofs is utilized. This resulted in a warning message in
logs when a container is killed, or completes:

level=warning msg="Could not remove container share dir"

Without proper removal, they'd later be cleaned up when the shared
path is removed as part of stopping the sandbox.

Fixes: #1559

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>


Before, we would create a container directory at
/run/kata-containers/share/sandboxes/<sandboxid>/<container-id>

This is no longer the case with our slavemount setup. container path is now at:
/run/kata-containers/share/sandboxes/<sandbox-id>/mounts/<container-id>