### PR TITLE
virtcontainers: Fix missing contexts in s390x

### DIFF
--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -179,11 +180,11 @@ func (q *qemuAmd64) supportGuestMemoryHotplug() bool {
 	return q.qemuMachine.Type != govmmQemu.MachineTypeMicrovm
 }
 
-func (q *qemuAmd64) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+func (q *qemuAmd64) appendImage(ctx context.Context, devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
 	if !q.disableNvdimm {
 		return q.appendNvdimmImage(devices, path)
 	}
-	return q.appendBlockImage(devices, path)
+	return q.appendBlockImage(ctx, devices, path)
 }
 
 // appendBridges appends to devices the given bridges

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -155,7 +156,7 @@ func TestQemuAmd64AppendImage(t *testing.T) {
 		},
 	}
 
-	devices, err := amd64.appendImage(nil, f.Name())
+	devices, err := amd64.appendImage(context.Background(), nil, f.Name())
 	assert.NoError(err)
 	assert.Equal(expectedOut, devices)
 
@@ -168,7 +169,7 @@ func TestQemuAmd64AppendImage(t *testing.T) {
 	assert.NotContains(amd64.machine().Options, qemuNvdimmOption)
 
 	found := false
-	devices, err = amd64.appendImage(nil, f.Name())
+	devices, err = amd64.appendImage(context.Background(), nil, f.Name())
 	assert.NoError(err)
 	for _, d := range devices {
 		if b, ok := d.(govmmQemu.BlockDevice); ok {

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -63,37 +63,37 @@ type qemuArch interface {
 	memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory
 
 	// appendConsole appends a console to devices
-	appendConsole(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
+	appendConsole(ctx context.Context, devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
 
 	// appendImage appends an image to devices
-	appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
+	appendImage(ctx context.Context, devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
 
 	// appendBlockImage appends an image as block device
-	appendBlockImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
+	appendBlockImage(ctx context.Context, devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
 
 	// appendNvdimmImage appends an image as nvdimm device
 	appendNvdimmImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error)
 
 	// appendSCSIController appens a SCSI controller to devices
-	appendSCSIController(devices []govmmQemu.Device, enableIOThreads bool) ([]govmmQemu.Device, *govmmQemu.IOThread, error)
+	appendSCSIController(context context.Context, devices []govmmQemu.Device, enableIOThreads bool) ([]govmmQemu.Device, *govmmQemu.IOThread, error)
 
 	// appendBridges appends bridges to devices
 	appendBridges(devices []govmmQemu.Device) []govmmQemu.Device
 
 	// append9PVolume appends a 9P volume to devices
-	append9PVolume(devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error)
+	append9PVolume(ctx context.Context, devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error)
 
 	// appendSocket appends a socket to devices
 	appendSocket(devices []govmmQemu.Device, socket types.Socket) []govmmQemu.Device
 
 	// appendVSock appends a vsock PCI to devices
-	appendVSock(devices []govmmQemu.Device, vsock types.VSock) ([]govmmQemu.Device, error)
+	appendVSock(ctx context.Context, devices []govmmQemu.Device, vsock types.VSock) ([]govmmQemu.Device, error)
 
 	// appendNetwork appends a endpoint device to devices
-	appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) ([]govmmQemu.Device, error)
+	appendNetwork(ctx context.Context, devices []govmmQemu.Device, endpoint Endpoint) ([]govmmQemu.Device, error)
 
 	// appendBlockDevice appends a block drive to devices
-	appendBlockDevice(devices []govmmQemu.Device, drive config.BlockDrive) ([]govmmQemu.Device, error)
+	appendBlockDevice(ctx context.Context, devices []govmmQemu.Device, drive config.BlockDrive) ([]govmmQemu.Device, error)
 
 	// appendVhostUserDevice appends a vhost user device to devices
 	appendVhostUserDevice(devices []govmmQemu.Device, drive config.VhostUserDeviceAttrs) ([]govmmQemu.Device, error)
@@ -102,7 +102,7 @@ type qemuArch interface {
 	appendVFIODevice(devices []govmmQemu.Device, vfioDevice config.VFIODev) []govmmQemu.Device
 
 	// appendRNGDevice appends a RNG device to devices
-	appendRNGDevice(devices []govmmQemu.Device, rngDevice config.RNGDev) ([]govmmQemu.Device, error)
+	appendRNGDevice(ctx context.Context, devices []govmmQemu.Device, rngDevice config.RNGDev) ([]govmmQemu.Device, error)
 
 	// addDeviceToBridge adds devices to the bus
 	addDeviceToBridge(ctx context.Context, ID string, t types.Type) (string, types.Bridge, error)
@@ -313,7 +313,7 @@ func (q *qemuArchBase) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8
 	return memory
 }
 
-func (q *qemuArchBase) appendConsole(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) appendConsole(_ context.Context, devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
 	serial := govmmQemu.SerialDevice{
 		Driver:        govmmQemu.VirtioSerial,
 		ID:            "serial0",
@@ -385,16 +385,16 @@ func (q *qemuArchBase) appendNvdimmImage(devices []govmmQemu.Device, path string
 	return devices, nil
 }
 
-func (q *qemuArchBase) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
-	return q.appendBlockImage(devices, path)
+func (q *qemuArchBase) appendImage(ctx context.Context, devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+	return q.appendBlockImage(ctx, devices, path)
 }
 
-func (q *qemuArchBase) appendBlockImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) appendBlockImage(ctx context.Context, devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
 	drive, err := genericImage(path)
 	if err != nil {
 		return nil, err
 	}
-	devices, err = q.appendBlockDevice(devices, drive)
+	devices, err = q.appendBlockDevice(ctx, devices, drive)
 	if err != nil {
 		return nil, err
 	}
@@ -422,7 +422,7 @@ func genericSCSIController(enableIOThreads, nestedRun bool) (govmmQemu.SCSIContr
 	return scsiController, t
 }
 
-func (q *qemuArchBase) appendSCSIController(devices []govmmQemu.Device, enableIOThreads bool) ([]govmmQemu.Device, *govmmQemu.IOThread, error) {
+func (q *qemuArchBase) appendSCSIController(_ context.Context, devices []govmmQemu.Device, enableIOThreads bool) ([]govmmQemu.Device, *govmmQemu.IOThread, error) {
 	d, t := genericSCSIController(enableIOThreads, q.nestedRun)
 	devices = append(devices, d)
 	return devices, t, nil
@@ -480,7 +480,7 @@ func genericAppend9PVolume(devices []govmmQemu.Device, volume types.Volume, nest
 	return d, nil
 }
 
-func (q *qemuArchBase) append9PVolume(devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) append9PVolume(_ context.Context, devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error) {
 	if volume.MountTag == "" || volume.HostPath == "" {
 		return devices, nil
 	}
@@ -514,7 +514,7 @@ func (q *qemuArchBase) appendSocket(devices []govmmQemu.Device, socket types.Soc
 	return devices
 }
 
-func (q *qemuArchBase) appendVSock(devices []govmmQemu.Device, vsock types.VSock) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) appendVSock(_ context.Context, devices []govmmQemu.Device, vsock types.VSock) ([]govmmQemu.Device, error) {
 	devices = append(devices,
 		govmmQemu.VSOCKDevice{
 			ID:            fmt.Sprintf("vsock-%d", vsock.ContextID),
@@ -592,7 +592,7 @@ func genericNetwork(endpoint Endpoint, vhost, nestedRun bool, index int) (govmmQ
 	return d, nil
 }
 
-func (q *qemuArchBase) appendNetwork(devices []govmmQemu.Device, endpoint Endpoint) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) appendNetwork(_ context.Context, devices []govmmQemu.Device, endpoint Endpoint) ([]govmmQemu.Device, error) {
 	d, err := genericNetwork(endpoint, q.vhost, q.nestedRun, q.networkIndex)
 	if err != nil {
 		return devices, fmt.Errorf("Failed to append network %v", err)
@@ -624,7 +624,7 @@ func genericBlockDevice(drive config.BlockDrive, nestedRun bool) (govmmQemu.Bloc
 	}, nil
 }
 
-func (q *qemuArchBase) appendBlockDevice(devices []govmmQemu.Device, drive config.BlockDrive) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) appendBlockDevice(_ context.Context, devices []govmmQemu.Device, drive config.BlockDrive) ([]govmmQemu.Device, error) {
 	d, err := genericBlockDevice(drive, q.nestedRun)
 	if err != nil {
 		return devices, fmt.Errorf("Failed to append block device %v", err)
@@ -678,7 +678,7 @@ func (q *qemuArchBase) appendVFIODevice(devices []govmmQemu.Device, vfioDev conf
 	return devices
 }
 
-func (q *qemuArchBase) appendRNGDevice(devices []govmmQemu.Device, rngDev config.RNGDev) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) appendRNGDevice(_ context.Context, devices []govmmQemu.Device, rngDev config.RNGDev) ([]govmmQemu.Device, error) {
 	devices = append(devices,
 		govmmQemu.RngDevice{
 			ID:       rngDev.ID,

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -216,11 +216,11 @@ func testQemuArchBaseAppend(t *testing.T, structure interface{}, expected []govm
 
 	switch s := structure.(type) {
 	case types.Volume:
-		devices, err = qemuArchBase.append9PVolume(devices, s)
+		devices, err = qemuArchBase.append9PVolume(context.Background(), devices, s)
 	case types.Socket:
 		devices = qemuArchBase.appendSocket(devices, s)
 	case config.BlockDrive:
-		devices, err = qemuArchBase.appendBlockDevice(devices, s)
+		devices, err = qemuArchBase.appendBlockDevice(context.Background(), devices, s)
 	case config.VFIODev:
 		devices = qemuArchBase.appendVFIODevice(devices, s)
 	case config.VhostUserDeviceAttrs:
@@ -254,7 +254,7 @@ func TestQemuArchBaseAppendConsoles(t *testing.T) {
 		},
 	}
 
-	devices, err = qemuArchBase.appendConsole(devices, path)
+	devices, err = qemuArchBase.appendConsole(context.Background(), devices, path)
 	assert.NoError(err)
 	assert.Equal(expectedOut, devices)
 }
@@ -270,7 +270,7 @@ func TestQemuArchBaseAppendImage(t *testing.T) {
 	err = image.Close()
 	assert.NoError(err)
 
-	devices, err = qemuArchBase.appendImage(devices, image.Name())
+	devices, err = qemuArchBase.appendImage(context.Background(), devices, image.Name())
 	assert.NoError(err)
 	assert.Len(devices, 1)
 
@@ -469,12 +469,12 @@ func TestQemuArchBaseAppendSCSIController(t *testing.T) {
 		},
 	}
 
-	devices, ioThread, err := qemuArchBase.appendSCSIController(devices, false)
+	devices, ioThread, err := qemuArchBase.appendSCSIController(context.Background(), devices, false)
 	assert.Equal(expectedOut, devices)
 	assert.Nil(ioThread)
 	assert.NoError(err)
 
-	_, ioThread, err = qemuArchBase.appendSCSIController(devices, true)
+	_, ioThread, err = qemuArchBase.appendSCSIController(context.Background(), devices, true)
 	assert.NotNil(ioThread)
 	assert.NoError(err)
 }
@@ -539,9 +539,9 @@ func TestQemuArchBaseAppendNetwork(t *testing.T) {
 		},
 	}
 
-	devices, err = qemuArchBase.appendNetwork(devices, macvlanEp)
+	devices, err = qemuArchBase.appendNetwork(context.Background(), devices, macvlanEp)
 	assert.NoError(err)
-	devices, err = qemuArchBase.appendNetwork(devices, macvtapEp)
+	devices, err = qemuArchBase.appendNetwork(context.Background(), devices, macvtapEp)
 	assert.NoError(err)
 	assert.Equal(expectedOut, devices)
 }

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -93,11 +93,11 @@ func (q *qemuArm64) appendBridges(devices []govmmQemu.Device) []govmmQemu.Device
 	return genericAppendBridges(devices, q.Bridges, q.qemuMachine.Type)
 }
 
-func (q *qemuArm64) appendImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
+func (q *qemuArm64) appendImage(ctx context.Context, devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
 	if !q.disableNvdimm {
 		return q.appendNvdimmImage(devices, path)
 	}
-	return q.appendBlockImage(devices, path)
+	return q.appendBlockImage(ctx, devices, path)
 }
 
 func (q *qemuArm64) setIgnoreSharedMemoryMigrationCaps(_ context.Context, _ *govmmQemu.QMP) error {
@@ -109,7 +109,7 @@ func (q *qemuArm64) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device,
 	return devices, fmt.Errorf("Arm64 architecture does not support vIOMMU")
 }
 
-func (q *qemuArm64) append9PVolume(devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error) {
+func (q *qemuArm64) append9PVolume(_ context.Context, devices []govmmQemu.Device, volume types.Volume) ([]govmmQemu.Device, error) {
 	d, err := genericAppend9PVolume(devices, volume, q.nestedRun)
 	if err != nil {
 		return nil, err

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -121,7 +122,7 @@ func TestQemuArm64AppendImage(t *testing.T) {
 		},
 	}
 
-	devices, err = arm64.appendImage(devices, f.Name())
+	devices, err = arm64.appendImage(context.Background(), devices, f.Name())
 	assert.NoError(err)
 	assert.Equal(expectedOut, devices)
 

--- a/src/runtime/virtcontainers/qemu_s390x_test.go
+++ b/src/runtime/virtcontainers/qemu_s390x_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	govmmQemu "github.com/kata-containers/govmm/qemu"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/device/config"
 	"github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
 #1389 has added a context for many signatures to improve trace spans.
Functions specific to s390x lack this. Add context where required. This
affects some common code signatures, since some functions that do not
require context on other architectures do require it on s390x.
Also remove an unnecessary import in test_qemu_s390x.go.

Fixes: #1562

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>
/cc @cmaf 
no backport required