### PR TITLE
cli: Use genericGetExpectedHostDetails on s390x

### DIFF
--- a/src/runtime/cli/kata-env_s390x_test.go
+++ b/src/runtime/cli/kata-env_s390x_test.go
@@ -1,91 +1,13 @@
-// Copyright (c) 2018 IBM
+// Copyright (c) 2021 IBM
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 
 package main
 
-import (
-	"fmt"
-	vcUtils "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
-	"path/filepath"
-	goruntime "runtime"
-)
-
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
-	type filesToCreate struct {
-		file     string
-		contents string
-	}
-
-	const expectedKernelVersion = "99.1"
-	const expectedArch = goruntime.GOARCH
-
-	expectedDistro := DistroInfo{
-		Name:    "Foo",
-		Version: "42",
-	}
-
-	expectedCPU := CPUInfo{
-		Vendor: "moi",
-		Model:  "awesome XI",
-	}
-
-	expectedHostDetails := HostInfo{
-		Kernel:             expectedKernelVersion,
-		Architecture:       expectedArch,
-		Distro:             expectedDistro,
-		CPU:                expectedCPU,
-		VMContainerCapable: true,
-		SupportVSocks:      vcUtils.SupportsVsocks(),
-	}
-
-	testProcCPUInfo := filepath.Join(tmpdir, "cpuinfo")
-	testOSRelease := filepath.Join(tmpdir, "os-release")
-
-	// XXX: This file is *NOT* created by this function on purpose
-	// (to ensure the only file checked by the tests is
-	// testOSRelease). osReleaseClr handling is tested in
-	// utils_test.go.
-	testOSReleaseClr := filepath.Join(tmpdir, "os-release-clr")
-
-	testProcVersion := filepath.Join(tmpdir, "proc-version")
-
-	// override
-	procVersion = testProcVersion
-	osRelease = testOSRelease
-	osReleaseClr = testOSReleaseClr
-	procCPUInfo = testProcCPUInfo
-
-	procVersionContents := fmt.Sprintf("Linux version %s a b c",
-		expectedKernelVersion)
-
-	osReleaseContents := fmt.Sprintf(`
-NAME="%s"
-VERSION_ID="%s"
-`, expectedDistro.Name, expectedDistro.Version)
-
-	procCPUInfoContents := fmt.Sprintf(`
-%s	: %s
-processor 0: version = 00,  identification = 3929E7,  %s = %s
-`,
-		archCPUVendorField,
-		expectedCPU.Vendor,
-		archCPUModelField,
-		expectedCPU.Model)
-
-	data := []filesToCreate{
-		{procVersion, procVersionContents},
-		{osRelease, osReleaseContents},
-		{procCPUInfo, procCPUInfoContents},
-	}
-
-	for _, d := range data {
-		err := createFile(d.file, d.contents)
-		if err != nil {
-			return HostInfo{}, err
-		}
-	}
-
-	return expectedHostDetails, nil
+	expectedVendor := "moi"
+	expectedModel := "awesome XI"
+	expectedVMContainerCapable := true
+	return genericGetExpectedHostDetails(tmpdir, expectedVendor, expectedModel, expectedVMContainerCapable)
 }


### PR DESCRIPTION
`getExpectedHostDetails` did not offload any work to
`genericGetExpectedHostDetails` on s390x. By using that function, much
redundant code can be saved. This also resolves 2 issues with the
previous version:

- The number of CPUs was not calculated.
- vcUtils.SupportsVsocks() still used the Kata v1 signature.

Fixes: #1564

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>
backport required