### PR TITLE
Enable virtio-fs on s390x

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/gogo/protobuf v1.3.1
 	github.com/hashicorp/go-multierror v1.0.0
-	github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca
+	github.com/kata-containers/govmm v0.0.0-20210329205824-7fbc685865d2
 	github.com/mdlayher/vsock v0.0.0-20191108225356-d9c65923cb8f
 	github.com/opencontainers/image-spec v1.0.1 // indirect
 	github.com/opencontainers/runc v1.0.0-rc9.0.20200102164712-2b52db75279c

--- a/src/runtime/go.sum
+++ b/src/runtime/go.sum
@@ -276,6 +276,8 @@ github.com/juju/testing v0.0.0-20190613124551-e81189438503/go.mod h1:63prj8cnj0t
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca h1:UdXFthwasAPnmv37gLJUEFsW9FaabYA+mM6FoSi8kzU=
 github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca/go.mod h1:VmAHbsL5lLfzHW/MNL96NVLF840DNEV5i683kISgFKk=
+github.com/kata-containers/govmm v0.0.0-20210329205824-7fbc685865d2 h1:oDJsQ5avmW8PFUkSJdsuaGL3SR4/YQRno51GNGl+IDU=
+github.com/kata-containers/govmm v0.0.0-20210329205824-7fbc685865d2/go.mod h1:VmAHbsL5lLfzHW/MNL96NVLF840DNEV5i683kISgFKk=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=

--- a/src/runtime/vendor/modules.txt
+++ b/src/runtime/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-multierror v1.0.0
 ## explicit
 github.com/hashicorp/go-multierror
-# github.com/kata-containers/govmm v0.0.0-20210112013750-7d320e8f5dca
+# github.com/kata-containers/govmm v0.0.0-20210329205824-7fbc685865d2
 ## explicit
 github.com/kata-containers/govmm/qemu
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1879,7 +1879,7 @@ func (q *qemu) addDevice(ctx context.Context, devInfo interface{}, devType devic
 			vhostDev.SocketPath = sockPath
 			vhostDev.DevID = id
 
-			q.qemuConfig.Devices, err = q.arch.appendVhostUserDevice(q.qemuConfig.Devices, vhostDev)
+			q.qemuConfig.Devices = q.arch.appendVhostUserDevice(q.qemuConfig.Devices, vhostDev)
 		} else {
 			q.Logger().WithField("volume-type", "virtio-9p").Info("adding volume")
 			q.qemuConfig.Devices, err = q.arch.append9PVolume(ctx, q.qemuConfig.Devices, v)
@@ -1894,7 +1894,7 @@ func (q *qemu) addDevice(ctx context.Context, devInfo interface{}, devType devic
 	case config.BlockDrive:
 		q.qemuConfig.Devices, err = q.arch.appendBlockDevice(ctx, q.qemuConfig.Devices, v)
 	case config.VhostUserDeviceAttrs:
-		q.qemuConfig.Devices, err = q.arch.appendVhostUserDevice(q.qemuConfig.Devices, v)
+		q.qemuConfig.Devices = q.arch.appendVhostUserDevice(q.qemuConfig.Devices, v)
 	case config.VFIODev:
 		q.qemuConfig.Devices = q.arch.appendVFIODevice(q.qemuConfig.Devices, v)
 	default:

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -96,7 +96,7 @@ type qemuArch interface {
 	appendBlockDevice(ctx context.Context, devices []govmmQemu.Device, drive config.BlockDrive) ([]govmmQemu.Device, error)
 
 	// appendVhostUserDevice appends a vhost user device to devices
-	appendVhostUserDevice(devices []govmmQemu.Device, drive config.VhostUserDeviceAttrs) ([]govmmQemu.Device, error)
+	appendVhostUserDevice(devices []govmmQemu.Device, drive config.VhostUserDeviceAttrs) []govmmQemu.Device
 
 	// appendVFIODevice appends a VFIO device to devices
 	appendVFIODevice(devices []govmmQemu.Device, vfioDevice config.VFIODev) []govmmQemu.Device
@@ -633,7 +633,7 @@ func (q *qemuArchBase) appendBlockDevice(_ context.Context, devices []govmmQemu.
 	return devices, nil
 }
 
-func (q *qemuArchBase) appendVhostUserDevice(devices []govmmQemu.Device, attr config.VhostUserDeviceAttrs) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) appendVhostUserDevice(devices []govmmQemu.Device, attr config.VhostUserDeviceAttrs) []govmmQemu.Device {
 	qemuVhostUserDevice := govmmQemu.VhostUserDevice{}
 
 	switch attr.Type {
@@ -658,7 +658,7 @@ func (q *qemuArchBase) appendVhostUserDevice(devices []govmmQemu.Device, attr co
 
 	devices = append(devices, qemuVhostUserDevice)
 
-	return devices, nil
+	return devices
 }
 
 func (q *qemuArchBase) appendVFIODevice(devices []govmmQemu.Device, vfioDev config.VFIODev) []govmmQemu.Device {

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -224,7 +224,7 @@ func testQemuArchBaseAppend(t *testing.T, structure interface{}, expected []govm
 	case config.VFIODev:
 		devices = qemuArchBase.appendVFIODevice(devices, s)
 	case config.VhostUserDeviceAttrs:
-		devices, err = qemuArchBase.appendVhostUserDevice(devices, s)
+		devices = qemuArchBase.appendVhostUserDevice(devices, s)
 	}
 
 	assert.NoError(err)

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -152,12 +152,6 @@ func (q *qemuS390x) appendCCWBlockDevice(ctx context.Context, devices []govmmQem
 	return devices, nil
 }
 
-// appendVhostUserDevice throws an error if vhost devices are tried to be used.
-// See issue https://github.com/kata-containers/runtime/issues/659
-func (q *qemuS390x) appendVhostUserDevice(devices []govmmQemu.Device, attr config.VhostUserDeviceAttrs) ([]govmmQemu.Device, error) {
-	return nil, fmt.Errorf("No vhost-user devices supported on s390x")
-}
-
 // supportGuestMemoryHotplug return false for s390x architecture. The pc-dimm backend device for s390x
 // is not support. PC-DIMM is not listed in the devices supported by qemu-system-s390x -device help
 func (q *qemuS390x) supportGuestMemoryHotplug() bool {

--- a/src/runtime/virtcontainers/qemu_s390x_test.go
+++ b/src/runtime/virtcontainers/qemu_s390x_test.go
@@ -52,17 +52,3 @@ func TestQemuS390xMemoryTopology(t *testing.T) {
 	m := s390x.memoryTopology(mem, hostMem, slots)
 	assert.Equal(expectedMemory, m)
 }
-
-func TestQemuS390xAppendVhostUserDevice(t *testing.T) {
-	macAddress := "00:11:22:33:44:55:66"
-	qemu := qemuS390x{}
-	assert := assert.New(t)
-
-	vhostUserDevice := config.VhostUserDeviceAttrs{
-		Type:       config.VhostUserNet,
-		MacAddress: macAddress,
-	}
-
-	_, err := qemu.appendVhostUserDevice(nil, vhostUserDevice)
-	assert.Error(err)
-}


### PR DESCRIPTION
- Use updated GoVMM following the merge of https://github.com/kata-containers/govmm/pull/161 and allow `appendVhostUserDevice` on s390x.
- One thing I'm not so sure about is checking for virtio-fs support. It was only added to s390x in QEMU 5.2.0, which is officially to be used with Kata since the merge of #1349, but which generally hasn't landed in distro releases yet.
We could just assume that a recent enough QEMU is used because Kata's tests/CI use it. If we do this and try virtio-fs on a non-virtio-fs QEMU, the user would receive a message like:
```
ctr: failed to launch qemu: exit status 1, error messages from qemu log: qemu-system-s390x: -device vhost-user-fs-ccw,chardev=char-50b9c9fc5d2491f7,tag=kataShared: 'vhost-user-fs-ccw' is not a valid device model name
```
even though this could be wrapped.
Alternatively, we could check whether the installed QEMU supports it, which would require moving the QEMU installation instructions in the Developer's Guide before the Kata installation.
The more stable way to do this is QAPI, which involves running an "empty" machine and querying it. This would mean the additional `socat` dependency, which would have to be added in https://github.com/kata-containers/tests. Depending on the exact setup, it may also require root access. This is the way that I have included in this PR.
The less stable way to do this is checking the output of `qemu-system-s390x -device help`.
WDYT?

Depends-on: https://github.com/kata-containers/tests/pull/3382
because currently, on s390x, packaged QEMU (=> <5.2) is preferred.
Fixes: #1469
Backport only worth the effort if v1 moves forward to QEMU 5.2 as well (is at 5.0), so no backport required, at least for the time being.