### PR TITLE
agent: log the mount point if it is already mounted

### DIFF
--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -405,7 +405,10 @@ fn mount_storage(logger: &Logger, storage: &Storage) -> Result<()> {
     // If so, skip doing the mount. This facilitates mounting the sharedfs automatically
     // in the guest before the agent service starts.
     if storage.source == MOUNT_GUEST_TAG && is_mounted(&storage.mount_point)? {
-        warn!(logger, "kataShared already mounted, ignoring...");
+        warn!(
+            logger,
+            "{} already mounted on {}, ignoring...", MOUNT_GUEST_TAG, &storage.mount_point
+        );
         return Ok(());
     }
 


### PR DESCRIPTION
On commit 17e9a2cff5c8b it was introduced a guard for the case the mount point is already
mounted. Instead of log the mount tag ("kataShared") with this change it will print the
mount point path.

Fixes: #1398
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>