### PR TITLE
runtime: Format auto-generated client code for cloud-hypervisor API

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/Makefile
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/Makefile
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-all: | update-yaml generate-client-code
+all: | update-yaml generate-client-code go-fmt
 MK_DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 YQ_INSTALLER := "$(MK_DIR)/../../../../../ci/install_yq.sh"
 VERSIONS_FILE := "$(MK_DIR)/../../../../../versions.yaml"
@@ -17,8 +17,9 @@ generate-client-code: clean-generated-code
 		-i /local/cloud-hypervisor.yaml \
 		-g go \
 		-o /local/client
-
-
+go-fmt:
+	rm client/go.mod; \
+	go fmt ./...
 
 update-yaml:
 ifndef YQ

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/client.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/client.go
@@ -157,13 +157,12 @@ func parameterToJson(obj interface{}) (string, error) {
 	return string(jsonBuf), err
 }
 
-
 // callAPI do the request.
 func (c *APIClient) callAPI(request *http.Request) (*http.Response, error) {
 	if c.cfg.Debug {
-	        dump, err := httputil.DumpRequestOut(request, true)
+		dump, err := httputil.DumpRequestOut(request, true)
 		if err != nil {
-		        return nil, err
+			return nil, err
 		}
 		log.Printf("\n%s\n", string(dump))
 	}

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/configuration.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/configuration.go
@@ -37,7 +37,6 @@ var (
 
 	// ContextAPIKey takes an APIKey as authentication for the request
 	ContextAPIKey = contextKey("apikey")
-
 )
 
 // BasicAuth provides basic http authentication to a request passed via context using ContextBasicAuth
@@ -52,7 +51,6 @@ type APIKey struct {
 	Prefix string
 }
 
-
 // ServerVariable stores the information about a server variable
 type ServerVariable struct {
 	Description  string
@@ -62,9 +60,9 @@ type ServerVariable struct {
 
 // ServerConfiguration stores the information about a server
 type ServerConfiguration struct {
-	Url string
+	Url         string
 	Description string
-	Variables map[string]ServerVariable
+	Variables   map[string]ServerVariable
 }
 
 // Configuration stores the configuration of the API client
@@ -86,9 +84,9 @@ func NewConfiguration() *Configuration {
 		DefaultHeader: make(map[string]string),
 		UserAgent:     "OpenAPI-Generator/1.0.0/go",
 		Debug:         false,
-		Servers:       []ServerConfiguration{
+		Servers: []ServerConfiguration{
 			{
-				Url: "http://localhost/api/v1",
+				Url:         "http://localhost/api/v1",
 				Description: "No description provided",
 			},
 		},
@@ -104,7 +102,7 @@ func (c *Configuration) AddDefaultHeader(key string, value string) {
 // ServerUrl returns URL based on server settings
 func (c *Configuration) ServerUrl(index int, variables map[string]string) (string, error) {
 	if index < 0 || len(c.Servers) <= index {
-		return "", fmt.Errorf("Index %v out of range %v", index, len(c.Servers) - 1)
+		return "", fmt.Errorf("Index %v out of range %v", index, len(c.Servers)-1)
 	}
 	server := c.Servers[index]
 	url := server.Url

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_balloon_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_balloon_config.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // BalloonConfig struct for BalloonConfig
 type BalloonConfig struct {
 	Size int64 `json:"size"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cmd_line_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cmd_line_config.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // CmdLineConfig struct for CmdLineConfig
 type CmdLineConfig struct {
 	Args string `json:"args"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_console_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_console_config.go
@@ -8,9 +8,10 @@
  */
 
 package openapi
+
 // ConsoleConfig struct for ConsoleConfig
 type ConsoleConfig struct {
-	File string `json:"file,omitempty"`
-	Mode string `json:"mode"`
-	Iommu bool `json:"iommu,omitempty"`
+	File  string `json:"file,omitempty"`
+	Mode  string `json:"mode"`
+	Iommu bool   `json:"iommu,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cpu_topology.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cpu_topology.go
@@ -8,10 +8,11 @@
  */
 
 package openapi
+
 // CpuTopology struct for CpuTopology
 type CpuTopology struct {
 	ThreadsPerCore int32 `json:"threads_per_core,omitempty"`
-	CoresPerDie int32 `json:"cores_per_die,omitempty"`
+	CoresPerDie    int32 `json:"cores_per_die,omitempty"`
 	DiesPerPackage int32 `json:"dies_per_package,omitempty"`
-	Packages int32 `json:"packages,omitempty"`
+	Packages       int32 `json:"packages,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cpus_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cpus_config.go
@@ -8,10 +8,11 @@
  */
 
 package openapi
+
 // CpusConfig struct for CpusConfig
 type CpusConfig struct {
-	BootVcpus int32 `json:"boot_vcpus"`
-	MaxVcpus int32 `json:"max_vcpus"`
-	Topology CpuTopology `json:"topology,omitempty"`
-	MaxPhysBits int32 `json:"max_phys_bits,omitempty"`
+	BootVcpus   int32       `json:"boot_vcpus"`
+	MaxVcpus    int32       `json:"max_vcpus"`
+	Topology    CpuTopology `json:"topology,omitempty"`
+	MaxPhysBits int32       `json:"max_phys_bits,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_device_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_device_config.go
@@ -8,9 +8,10 @@
  */
 
 package openapi
+
 // DeviceConfig struct for DeviceConfig
 type DeviceConfig struct {
-	Path string `json:"path"`
-	Iommu bool `json:"iommu,omitempty"`
-	Id string `json:"id,omitempty"`
+	Path  string `json:"path"`
+	Iommu bool   `json:"iommu,omitempty"`
+	Id    string `json:"id,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_device_node.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_device_node.go
@@ -8,10 +8,11 @@
  */
 
 package openapi
+
 // DeviceNode struct for DeviceNode
 type DeviceNode struct {
-	Id string `json:"id,omitempty"`
+	Id        string                   `json:"id,omitempty"`
 	Resources []map[string]interface{} `json:"resources,omitempty"`
-	Children []string `json:"children,omitempty"`
-	PciBdf int32 `json:"pci_bdf,omitempty"`
+	Children  []string                 `json:"children,omitempty"`
+	PciBdf    int32                    `json:"pci_bdf,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
@@ -8,17 +8,18 @@
  */
 
 package openapi
+
 // DiskConfig struct for DiskConfig
 type DiskConfig struct {
-	Path string `json:"path"`
-	Readonly bool `json:"readonly,omitempty"`
-	Direct bool `json:"direct,omitempty"`
-	Iommu bool `json:"iommu,omitempty"`
-	NumQueues int32 `json:"num_queues,omitempty"`
-	QueueSize int32 `json:"queue_size,omitempty"`
-	VhostUser bool `json:"vhost_user,omitempty"`
-	VhostSocket string `json:"vhost_socket,omitempty"`
-	PollQueue bool `json:"poll_queue,omitempty"`
+	Path              string            `json:"path"`
+	Readonly          bool              `json:"readonly,omitempty"`
+	Direct            bool              `json:"direct,omitempty"`
+	Iommu             bool              `json:"iommu,omitempty"`
+	NumQueues         int32             `json:"num_queues,omitempty"`
+	QueueSize         int32             `json:"queue_size,omitempty"`
+	VhostUser         bool              `json:"vhost_user,omitempty"`
+	VhostSocket       string            `json:"vhost_socket,omitempty"`
+	PollQueue         bool              `json:"poll_queue,omitempty"`
 	RateLimiterConfig RateLimiterConfig `json:"rate_limiter_config,omitempty"`
-	Id string `json:"id,omitempty"`
+	Id                string            `json:"id,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_fs_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_fs_config.go
@@ -8,13 +8,14 @@
  */
 
 package openapi
+
 // FsConfig struct for FsConfig
 type FsConfig struct {
-	Tag string `json:"tag"`
-	Socket string `json:"socket"`
-	NumQueues int32 `json:"num_queues"`
-	QueueSize int32 `json:"queue_size"`
-	Dax bool `json:"dax"`
-	CacheSize int64 `json:"cache_size"`
-	Id string `json:"id,omitempty"`
+	Tag       string `json:"tag"`
+	Socket    string `json:"socket"`
+	NumQueues int32  `json:"num_queues"`
+	QueueSize int32  `json:"queue_size"`
+	Dax       bool   `json:"dax"`
+	CacheSize int64  `json:"cache_size"`
+	Id        string `json:"id,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_initramfs_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_initramfs_config.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // InitramfsConfig struct for InitramfsConfig
 type InitramfsConfig struct {
 	Path string `json:"path"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_kernel_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_kernel_config.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // KernelConfig struct for KernelConfig
 type KernelConfig struct {
 	Path string `json:"path"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_memory_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_memory_config.go
@@ -8,15 +8,16 @@
  */
 
 package openapi
+
 // MemoryConfig struct for MemoryConfig
 type MemoryConfig struct {
-	Size int64 `json:"size"`
-	HotplugSize int64 `json:"hotplug_size,omitempty"`
-	HotpluggedSize int64 `json:"hotplugged_size,omitempty"`
-	Mergeable bool `json:"mergeable,omitempty"`
-	HotplugMethod string `json:"hotplug_method,omitempty"`
-	Shared bool `json:"shared,omitempty"`
-	Hugepages bool `json:"hugepages,omitempty"`
-	HugepageSize int64 `json:"hugepage_size,omitempty"`
-	Zones []MemoryZoneConfig `json:"zones,omitempty"`
+	Size           int64              `json:"size"`
+	HotplugSize    int64              `json:"hotplug_size,omitempty"`
+	HotpluggedSize int64              `json:"hotplugged_size,omitempty"`
+	Mergeable      bool               `json:"mergeable,omitempty"`
+	HotplugMethod  string             `json:"hotplug_method,omitempty"`
+	Shared         bool               `json:"shared,omitempty"`
+	Hugepages      bool               `json:"hugepages,omitempty"`
+	HugepageSize   int64              `json:"hugepage_size,omitempty"`
+	Zones          []MemoryZoneConfig `json:"zones,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_memory_zone_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_memory_zone_config.go
@@ -8,16 +8,17 @@
  */
 
 package openapi
+
 // MemoryZoneConfig struct for MemoryZoneConfig
 type MemoryZoneConfig struct {
-	Id string `json:"id"`
-	Size int64 `json:"size"`
-	File string `json:"file,omitempty"`
-	Mergeable bool `json:"mergeable,omitempty"`
-	Shared bool `json:"shared,omitempty"`
-	Hugepages bool `json:"hugepages,omitempty"`
-	HugepageSize int64 `json:"hugepage_size,omitempty"`
-	HostNumaNode int32 `json:"host_numa_node,omitempty"`
-	HotplugSize int64 `json:"hotplug_size,omitempty"`
-	HotpluggedSize int64 `json:"hotplugged_size,omitempty"`
+	Id             string `json:"id"`
+	Size           int64  `json:"size"`
+	File           string `json:"file,omitempty"`
+	Mergeable      bool   `json:"mergeable,omitempty"`
+	Shared         bool   `json:"shared,omitempty"`
+	Hugepages      bool   `json:"hugepages,omitempty"`
+	HugepageSize   int64  `json:"hugepage_size,omitempty"`
+	HostNumaNode   int32  `json:"host_numa_node,omitempty"`
+	HotplugSize    int64  `json:"hotplug_size,omitempty"`
+	HotpluggedSize int64  `json:"hotplugged_size,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
@@ -8,17 +8,18 @@
  */
 
 package openapi
+
 // NetConfig struct for NetConfig
 type NetConfig struct {
-	Tap string `json:"tap,omitempty"`
-	Ip string `json:"ip,omitempty"`
-	Mask string `json:"mask,omitempty"`
-	Mac string `json:"mac,omitempty"`
-	Iommu bool `json:"iommu,omitempty"`
-	NumQueues int32 `json:"num_queues,omitempty"`
-	QueueSize int32 `json:"queue_size,omitempty"`
-	VhostUser bool `json:"vhost_user,omitempty"`
-	VhostSocket string `json:"vhost_socket,omitempty"`
-	Id string `json:"id,omitempty"`
-	Fd []int32 `json:"fd,omitempty"`
+	Tap         string  `json:"tap,omitempty"`
+	Ip          string  `json:"ip,omitempty"`
+	Mask        string  `json:"mask,omitempty"`
+	Mac         string  `json:"mac,omitempty"`
+	Iommu       bool    `json:"iommu,omitempty"`
+	NumQueues   int32   `json:"num_queues,omitempty"`
+	QueueSize   int32   `json:"queue_size,omitempty"`
+	VhostUser   bool    `json:"vhost_user,omitempty"`
+	VhostSocket string  `json:"vhost_socket,omitempty"`
+	Id          string  `json:"id,omitempty"`
+	Fd          []int32 `json:"fd,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_numa_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_numa_config.go
@@ -8,10 +8,11 @@
  */
 
 package openapi
+
 // NumaConfig struct for NumaConfig
 type NumaConfig struct {
-	GuestNumaId int32 `json:"guest_numa_id"`
-	Cpus []int32 `json:"cpus,omitempty"`
-	Distances []NumaDistance `json:"distances,omitempty"`
-	MemoryZones []string `json:"memory_zones,omitempty"`
+	GuestNumaId int32          `json:"guest_numa_id"`
+	Cpus        []int32        `json:"cpus,omitempty"`
+	Distances   []NumaDistance `json:"distances,omitempty"`
+	MemoryZones []string       `json:"memory_zones,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_numa_distance.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_numa_distance.go
@@ -8,8 +8,9 @@
  */
 
 package openapi
+
 // NumaDistance struct for NumaDistance
 type NumaDistance struct {
 	Destination int32 `json:"destination"`
-	Distance int32 `json:"distance"`
+	Distance    int32 `json:"distance"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_pci_device_info.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_pci_device_info.go
@@ -8,8 +8,9 @@
  */
 
 package openapi
+
 // PciDeviceInfo Information about a PCI device
 type PciDeviceInfo struct {
-	Id string `json:"id"`
+	Id  string `json:"id"`
 	Bdf string `json:"bdf"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_pmem_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_pmem_config.go
@@ -8,12 +8,13 @@
  */
 
 package openapi
+
 // PmemConfig struct for PmemConfig
 type PmemConfig struct {
-	File string `json:"file"`
-	Size int64 `json:"size,omitempty"`
-	Iommu bool `json:"iommu,omitempty"`
-	Mergeable bool `json:"mergeable,omitempty"`
-	DiscardWrites bool `json:"discard_writes,omitempty"`
-	Id string `json:"id,omitempty"`
+	File          string `json:"file"`
+	Size          int64  `json:"size,omitempty"`
+	Iommu         bool   `json:"iommu,omitempty"`
+	Mergeable     bool   `json:"mergeable,omitempty"`
+	DiscardWrites bool   `json:"discard_writes,omitempty"`
+	Id            string `json:"id,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_rate_limiter_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_rate_limiter_config.go
@@ -8,8 +8,9 @@
  */
 
 package openapi
+
 // RateLimiterConfig Defines an IO rate limiter with independent bytes/s and ops/s limits. Limits are defined by configuring each of the _bandwidth_ and _ops_ token buckets.
 type RateLimiterConfig struct {
 	Bandwidth TokenBucket `json:"bandwidth,omitempty"`
-	Ops TokenBucket `json:"ops,omitempty"`
+	Ops       TokenBucket `json:"ops,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_restore_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_restore_config.go
@@ -8,8 +8,9 @@
  */
 
 package openapi
+
 // RestoreConfig struct for RestoreConfig
 type RestoreConfig struct {
 	SourceUrl string `json:"source_url"`
-	Prefault bool `json:"prefault,omitempty"`
+	Prefault  bool   `json:"prefault,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_rng_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_rng_config.go
@@ -8,8 +8,9 @@
  */
 
 package openapi
+
 // RngConfig struct for RngConfig
 type RngConfig struct {
-	Src string `json:"src"`
-	Iommu bool `json:"iommu,omitempty"`
+	Src   string `json:"src"`
+	Iommu bool   `json:"iommu,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_sgx_epc_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_sgx_epc_config.go
@@ -8,8 +8,9 @@
  */
 
 package openapi
+
 // SgxEpcConfig struct for SgxEpcConfig
 type SgxEpcConfig struct {
-	Size int64 `json:"size"`
-	Prefault bool `json:"prefault,omitempty"`
+	Size     int64 `json:"size"`
+	Prefault bool  `json:"prefault,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_token_bucket.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_token_bucket.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // TokenBucket Defines a token bucket with a maximum capacity (_size_), an initial burst size (_one_time_burst_) and an interval for refilling purposes (_refill_time_). The refill-rate is derived from _size_ and _refill_time_, and it is the constant rate at which the tokens replenish. The refill process only starts happening after the initial burst budget is consumed. Consumption from the token bucket is unbounded in speed which allows for bursts bound in size by the amount of tokens available. Once the token bucket is empty, consumption speed is bound by the refill-rate.
 type TokenBucket struct {
 	// The total number of tokens this bucket can hold.

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_add_device.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_add_device.go
@@ -8,9 +8,10 @@
  */
 
 package openapi
+
 // VmAddDevice struct for VmAddDevice
 type VmAddDevice struct {
-	Path string `json:"path,omitempty"`
-	Iommu bool `json:"iommu,omitempty"`
-	Id string `json:"id,omitempty"`
+	Path  string `json:"path,omitempty"`
+	Iommu bool   `json:"iommu,omitempty"`
+	Id    string `json:"id,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_config.go
@@ -8,25 +8,26 @@
  */
 
 package openapi
+
 // VmConfig Virtual machine configuration
 type VmConfig struct {
-	Cpus CpusConfig `json:"cpus,omitempty"`
-	Memory MemoryConfig `json:"memory,omitempty"`
-	Kernel KernelConfig `json:"kernel"`
+	Cpus      CpusConfig       `json:"cpus,omitempty"`
+	Memory    MemoryConfig     `json:"memory,omitempty"`
+	Kernel    KernelConfig     `json:"kernel"`
 	Initramfs *InitramfsConfig `json:"initramfs,omitempty"`
-	Cmdline CmdLineConfig `json:"cmdline,omitempty"`
-	Disks []DiskConfig `json:"disks,omitempty"`
-	Net []NetConfig `json:"net,omitempty"`
-	Rng RngConfig `json:"rng,omitempty"`
-	Balloon BalloonConfig `json:"balloon,omitempty"`
-	Fs []FsConfig `json:"fs,omitempty"`
-	Pmem []PmemConfig `json:"pmem,omitempty"`
-	Serial ConsoleConfig `json:"serial,omitempty"`
-	Console ConsoleConfig `json:"console,omitempty"`
-	Devices []DeviceConfig `json:"devices,omitempty"`
-	Vsock VsockConfig `json:"vsock,omitempty"`
-	SgxEpc []SgxEpcConfig `json:"sgx_epc,omitempty"`
-	Numa []NumaConfig `json:"numa,omitempty"`
-	Iommu bool `json:"iommu,omitempty"`
-	Watchdog bool `json:"watchdog,omitempty"`
+	Cmdline   CmdLineConfig    `json:"cmdline,omitempty"`
+	Disks     []DiskConfig     `json:"disks,omitempty"`
+	Net       []NetConfig      `json:"net,omitempty"`
+	Rng       RngConfig        `json:"rng,omitempty"`
+	Balloon   BalloonConfig    `json:"balloon,omitempty"`
+	Fs        []FsConfig       `json:"fs,omitempty"`
+	Pmem      []PmemConfig     `json:"pmem,omitempty"`
+	Serial    ConsoleConfig    `json:"serial,omitempty"`
+	Console   ConsoleConfig    `json:"console,omitempty"`
+	Devices   []DeviceConfig   `json:"devices,omitempty"`
+	Vsock     VsockConfig      `json:"vsock,omitempty"`
+	SgxEpc    []SgxEpcConfig   `json:"sgx_epc,omitempty"`
+	Numa      []NumaConfig     `json:"numa,omitempty"`
+	Iommu     bool             `json:"iommu,omitempty"`
+	Watchdog  bool             `json:"watchdog,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_info.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_info.go
@@ -8,10 +8,11 @@
  */
 
 package openapi
+
 // VmInfo Virtual Machine information
 type VmInfo struct {
-	Config VmConfig `json:"config"`
-	State string `json:"state"`
-	MemoryActualSize int64 `json:"memory_actual_size,omitempty"`
-	DeviceTree map[string]DeviceNode `json:"device_tree,omitempty"`
+	Config           VmConfig              `json:"config"`
+	State            string                `json:"state"`
+	MemoryActualSize int64                 `json:"memory_actual_size,omitempty"`
+	DeviceTree       map[string]DeviceNode `json:"device_tree,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_remove_device.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_remove_device.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // VmRemoveDevice struct for VmRemoveDevice
 type VmRemoveDevice struct {
 	Id string `json:"id,omitempty"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_resize.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_resize.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // VmResize struct for VmResize
 type VmResize struct {
 	DesiredVcpus int32 `json:"desired_vcpus,omitempty"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_resize_zone.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_resize_zone.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // VmResizeZone struct for VmResizeZone
 type VmResizeZone struct {
 	Id string `json:"id,omitempty"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_snapshot_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vm_snapshot_config.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // VmSnapshotConfig struct for VmSnapshotConfig
 type VmSnapshotConfig struct {
 	DestinationUrl string `json:"destination_url,omitempty"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vmm_ping_response.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vmm_ping_response.go
@@ -8,6 +8,7 @@
  */
 
 package openapi
+
 // VmmPingResponse Virtual Machine Monitor information
 type VmmPingResponse struct {
 	Version string `json:"version"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vsock_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vsock_config.go
@@ -8,12 +8,13 @@
  */
 
 package openapi
+
 // VsockConfig struct for VsockConfig
 type VsockConfig struct {
 	// Guest Vsock CID
 	Cid int64 `json:"cid"`
 	// Path to UNIX domain socket, used to proxy vsock connections.
 	Socket string `json:"socket"`
-	Iommu bool `json:"iommu,omitempty"`
-	Id string `json:"id,omitempty"`
+	Iommu  bool   `json:"iommu,omitempty"`
+	Id     string `json:"id,omitempty"`
 }


### PR DESCRIPTION
As observed and fixed in a previous commit 0153f76 from @bergwolf, 
the client API code that is generated by openapi-generator can be not 
well formatted.

This patch extends the current process of generating client code for
cloud-hypervisor API with an additional step, `go-fmt`, which will remove
the generated `client/go.mod` file and format all auto-generated code.

Fixes: #1606

Signed-off-by: Bo Chen <chen.bo@intel.com>