### PR TITLE
Dechat deruntime

### DIFF
--- a/src/runtime/pkg/katautils/tracing.go
+++ b/src/runtime/pkg/katautils/tracing.go
@@ -30,7 +30,7 @@ var _ export.SpanExporter = (*kataSpanExporter)(nil)
 // ExportSpans exports SpanData to Jaeger.
 func (e *kataSpanExporter) ExportSpans(ctx context.Context, spans []*export.SpanData) error {
 	for _, span := range spans {
-		kataUtilsLogger.Infof("Reporting span %+v", span)
+		kataUtilsLogger.Tracef("Reporting span %+v", span)
 	}
 	return nil
 }

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -2010,7 +2010,7 @@ func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (inter
 	if cancel != nil {
 		defer cancel()
 	}
-	k.Logger().WithField("name", msgName).WithField("req", message.String()).Debug("sending request")
+	k.Logger().WithField("name", msgName).WithField("req", message.String()).Trace("sending request")
 
 	defer func() {
 		agentRPCDurationsHistogram.WithLabelValues(msgName).Observe(float64(time.Since(start).Nanoseconds() / int64(time.Millisecond)))


### PR DESCRIPTION
There are some prints which are output very frequently when the workload is up and running. Let's move these ones from info/debug to trace.

If we are losing visibility, let's add debug prints to the request caller, rather than in the request handler, so we can view just the useful calls when debugging.