### PR TITLE
osbuilder: update dockerfiles to utilize IMAGE_REGISTRY

### DIFF
--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -2,8 +2,8 @@
 # Copyright (c) 2018 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
-From registry.fedoraproject.org/fedora:latest
+ARG IMAGE_REGISTRY=registry.fedoraproject.org
+FROM ${IMAGE_REGISTRY}/fedora:latest
 
 RUN [ -n "$http_proxy" ] && sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true
 

--- a/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From docker.io/alpine:3.11.6
+ARG IMAGE_REGISTRY=docker.io
+FROM ${IMAGE_REGISTRY}/alpine:3.11.6
 
 RUN apk update && apk add \
 		  bash \

--- a/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From registry.centos.org/centos:@OS_VERSION@
+ARG IMAGE_REGISTRY=registry.centos.org
+FROM ${IMAGE_REGISTRY}/centos:@OS_VERSION@
 
 @SET_PROXY@
 

--- a/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-From docker.io/fedora:30
+ARG IMAGE_REGISTRY=docker.io
+FROM ${IMAGE_REGISTRY}/fedora:30
 
 @SET_PROXY@
 

--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+ARG IMAGE_REGISTRY=docker.io
 # NOTE: OS_VERSION is set according to config.sh
-from docker.io/debian:@OS_VERSION@
+FROM ${IMAGE_REGISTRY}/debian:@OS_VERSION@
 
 # RUN commands
 RUN apt-get update && apt-get install -y \

--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
@@ -3,8 +3,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+ARG IMAGE_REGISTRY=docker.io
 # NOTE: OS_VERSION is set according to config.sh
-from docker.io/debian:@OS_VERSION@
+FROM ${IMAGE_REGISTRY}/debian:@OS_VERSION@
 
 # RUN commands
 RUN apt-get update && apt-get --no-install-recommends install -y \

--- a/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
@@ -2,8 +2,8 @@
 # Copyright (c) 2018 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-
-From registry.fedoraproject.org/fedora:@OS_VERSION@
+ARG IMAGE_REGISTRY=registry.fedoraproject.org
+FROM ${IMAGE_REGISTRY}/fedora:@OS_VERSION@
 
 @SET_PROXY@
 

--- a/tools/osbuilder/rootfs-builder/gentoo/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/gentoo/Dockerfile.in
@@ -3,7 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from docker.io/gentoo/stage3-amd64:latest
+ARG IMAGE_REGISTRY=docker.io
+FROM ${IMAGE_REGISTRY}/gentoo/stage3-amd64:latest
 
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)

--- a/tools/osbuilder/rootfs-builder/suse/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/suse/Dockerfile.in
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+ARG IMAGE_REGISTRY=docker.io
 #suse: docker image to be used to create a rootfs
 #@OS_VERSION@: Docker image version to build this dockerfile
-from docker.io/opensuse/leap
+FROM ${IMAGE_REGISTRY}/opensuse/leap
 
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)

--- a/tools/osbuilder/rootfs-builder/template/Dockerfile.template
+++ b/tools/osbuilder/rootfs-builder/template/Dockerfile.template
@@ -4,8 +4,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 #@distro@: docker image to be used to create a rootfs
+ARG IMAGE_REGISTRY=docker.io
 #@OS_VERSION@: Docker image version to build this dockerfile
-from @distro@:@OS_VERSION@
+FROM ${IMAGE_REGISTRY}/@distro@:@OS_VERSION@
 
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+ARG IMAGE_REGISTRY=docker.io
 #ubuntu: docker image to be used to create a rootfs
 #@OS_VERSION@: Docker image version to build this dockerfile
-from docker.io/ubuntu:@OS_VERSION@
+FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@
 
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -3,9 +3,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+ARG IMAGE_REGISTRY=docker.io
 #ubuntu: docker image to be used to create a rootfs
 #@OS_VERSION@: Docker image version to build this dockerfile
-from docker.io/ubuntu:@OS_VERSION@
+FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@
 
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)


### PR DESCRIPTION
While we introduced IMAGE_REGISTRY, we didn't actually update the
corresponding Dockerfiles to utilize it. Let's add

Fixes: #1622

Signed-off-by: Eric Ernst <eric.g.ernst@gmail.com>