### PR TITLE
kata-deploy: Fix `test-kata.sh` and do some small cleanups / improvements in the kata-deploy script

### DIFF
--- a/tools/packaging/kata-deploy/action/test-kata.sh
+++ b/tools/packaging/kata-deploy/action/test-kata.sh
@@ -98,6 +98,7 @@ function test_kata() {
     [[ -z "$PKG_SHA" ]] && die "no PKG_SHA provided"
 
     YAMLPATH="./tools/packaging/kata-deploy/"
+    VERSION=$(cat ./VERSION)
 
     # This action could be called in two contexts:
     #  1. Packaging workflows: testing in packaging repository, where we assume yaml/packaging
@@ -120,8 +121,8 @@ function test_kata() {
     kubectl get runtimeclasses
 
     # update deployment daemonset to utilize the container under test:
-    sed -i "s#katadocker/kata-deploy#katadocker/kata-deploy-ci:${PKG_SHA}#g" $YAMLPATH/kata-deploy/base/kata-deploy.yaml
-    sed -i "s#katadocker/kata-deploy#katadocker/kata-deploy-ci:${PKG_SHA}#g" $YAMLPATH/kata-cleanup/base/kata-cleanup.yaml
+    sed -i "s#katadocker/kata-deploy:${VERSION}#katadocker/kata-deploy-ci:${PKG_SHA}#g" $YAMLPATH/kata-deploy/base/kata-deploy.yaml
+    sed -i "s#katadocker/kata-deploy:${VERSION}#katadocker/kata-deploy-ci:${PKG_SHA}#g" $YAMLPATH/kata-cleanup/base/kata-cleanup.yaml
 
     cat $YAMLPATH/kata-deploy/base/kata-deploy.yaml
 

--- a/tools/packaging/release/Makefile
+++ b/tools/packaging/release/Makefile
@@ -9,7 +9,7 @@ MK_DIR :=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 .PHONY: bump-kata-version
 
 NEW_VERSION :=
-TARGET_BRANCH ?= "master"
+TARGET_BRANCH ?= "main"
 
 # Run update-repository-version.sh
 # $1 : repository to bump

--- a/tools/packaging/release/kata-deploy-binaries.sh
+++ b/tools/packaging/release/kata-deploy-binaries.sh
@@ -81,7 +81,7 @@ verify_hub() {
 		go get -d ${hub_repo} || true
 		pushd ${GOPATH}/src/${hub_repo}
 		make
-		make install prefix=/usr/local
+		sudo -E make install prefix=/usr/local
 		popd
 	fi
 }

--- a/tools/packaging/release/tag_repos.sh
+++ b/tools/packaging/release/tag_repos.sh
@@ -15,7 +15,7 @@ script_name="$(basename "${BASH_SOURCE[0]}")"
 OWNER=${OWNER:-"kata-containers"}
 PROJECT="Kata Containers"
 PUSH="${PUSH:-"false"}"
-branch="master"
+branch="main"
 readonly URL_RAW_FILE="https://raw.githubusercontent.com/${OWNER}"
 #The runtime version is used as reference of latest release
 # This is set to the right value later.
@@ -134,9 +134,9 @@ tag_repos() {
 
 		do_tag "${tag}"
 
-		if [ "${branch}" == "master" ]; then
+		if [ "${branch}" == "main" ]; then
 			if echo "${tag}" | grep -oP '.*-rc0$'; then
-				info "This is a rc0 for master - creating stable branch"
+				info "This is a rc0 for main - creating stable branch"
 				stable_branch=$(echo ${tag} | awk 'BEGIN{FS=OFS="."}{print $1 "." $2}')
 				stable_branch="stable-${stable_branch}"
 				info "creating branch ${stable_branch} for ${repo}"

--- a/tools/packaging/release/update-repository-version_test.sh
+++ b/tools/packaging/release/update-repository-version_test.sh
@@ -49,6 +49,6 @@ OK
 
 echo "Local update version update should work"
 new_version="50.0.0-rc0"
-out=$("${script_dir}/update-repository-version.sh" "${new_version}" "master" 2>&1)
+out=$("${script_dir}/update-repository-version.sh" "${new_version}" "main" 2>&1)
 output_should_contain "${out}" "release: Kata Containers ${new_version}"
 OK


### PR DESCRIPTION
On commit 60f6315 we've started adding the specific version of the image
to be used, in order to ensure people using our content from a tarball
would be relying on the correct image.

However, later on, @bergwolf figured out it had some undesired side
effects, such as
https://github.com/kata-containers/kata-containers/runs/2235812941?check_suite_focus=true

What happens there is that the regular expression used to point the
image to a testing one doesn't take into consideration the $VERSION, and
that breaks the deployment.

Fixes: #1632