### PR TITLE
kernel: update experimental kernel to 5.10.x

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -162,8 +162,8 @@ assets:
 
   kernel-experimental:
     description: "Linux kernel with virtio-fs support"
-    url: "https://gitlab.com/virtio-fs/linux.git"
-    tag: "kata-v5.6-april-09-2020"
+    url: "https://cdn.kernel.org/pub/linux/kernel/v4.x/"
+    tag: "v5.10.25"
 
 externals:
   description: "Third-party projects used by the system"


### PR DESCRIPTION
Relevant changes for experimental :

42d3e2d04 virtiofs: calculate number of scatter-gather elements accurately
413daa1a3 fuse: connection remove fix
bf109c640 fuse: implement crossmounts
1866d779d fuse: Allow fuse_fill_super_common() for submounts
fcee216be fuse: split fuse_mount off of fuse_conn
8f622e949 fuse: drop fuse_conn parameter where possible
24754db27 fuse: store fuse_conn in fuse_req
c6ff213fe fuse: add submount support to <uapi/linux/fuse.h>
d78092e49 fuse: fix page dereference after free
9a752d18c virtiofs: add logic to free up a memory range
d0cfb9dcb virtiofs: maintain a list of busy elements
6ae330cad virtiofs: serialize truncate/punch_hole and dax fault path
9483e7d58 virtiofs: define dax address space operations
2a9a609a0 virtiofs: add DAX mmap support
c2d0ad00d virtiofs: implement dax read/write operations
ceec02d43 virtiofs: introduce setupmapping/removemapping commands
fd1a1dc6f virtiofs: implement FUSE_INIT map_alignment field
45f2348ec virtiofs: keep a list of free dax memory ranges
1dd539577 virtiofs: add a mount option to enable dax
22f3787e9 virtiofs: set up virtio_fs dax_device
f4fd4ae35 virtiofs: get rid of no_mount_options
b43b7e81e virtiofs: provide a helper function for virtqueue initialization

Signed-off-by: Carlos Venegas <jos.c.venegas.munoz@intel.com>