### PR TITLE
virtcontainers: replace newStore by store in Sandbox struct

### DIFF
--- a/src/runtime/virtcontainers/api_test.go
+++ b/src/runtime/virtcontainers/api_test.go
@@ -144,7 +144,7 @@ func TestCreateSandboxNoopAgentSuccessful(t *testing.T) {
 	assert.True(ok)
 	assert.NotNil(s)
 
-	sandboxDir := filepath.Join(s.newStore.RunStoragePath(), p.ID())
+	sandboxDir := filepath.Join(s.store.RunStoragePath(), p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 }
@@ -175,7 +175,7 @@ func TestCreateSandboxKataAgentSuccessful(t *testing.T) {
 
 	s, ok := p.(*Sandbox)
 	assert.True(ok)
-	sandboxDir := filepath.Join(s.newStore.RunStoragePath(), p.ID())
+	sandboxDir := filepath.Join(s.store.RunStoragePath(), p.ID())
 	_, err = os.Stat(sandboxDir)
 	assert.NoError(err)
 }
@@ -224,7 +224,7 @@ func createAndStartSandbox(ctx context.Context, config SandboxConfig) (sandbox V
 	if !ok {
 		return nil, "", fmt.Errorf("Could not get Sandbox")
 	}
-	sandboxDir = filepath.Join(s.newStore.RunStoragePath(), sandbox.ID())
+	sandboxDir = filepath.Join(s.store.RunStoragePath(), sandbox.ID())
 	_, err = os.Stat(sandboxDir)
 	if err != nil {
 		return nil, "", err
@@ -285,7 +285,7 @@ func TestCleanupContainer(t *testing.T) {
 
 	s, ok := p.(*Sandbox)
 	assert.True(ok)
-	sandboxDir := filepath.Join(s.newStore.RunStoragePath(), p.ID())
+	sandboxDir := filepath.Join(s.store.RunStoragePath(), p.ID())
 
 	_, err = os.Stat(sandboxDir)
 	if err == nil {

--- a/src/runtime/virtcontainers/container_test.go
+++ b/src/runtime/virtcontainers/container_test.go
@@ -316,11 +316,11 @@ func TestContainerAddDriveDir(t *testing.T) {
 		},
 	}
 
-	sandbox.newStore, err = persist.GetDriver()
+	sandbox.store, err = persist.GetDriver()
 	assert.NoError(err)
-	assert.NotNil(sandbox.newStore)
+	assert.NotNil(sandbox.store)
 
-	defer sandbox.newStore.Destroy(sandbox.id)
+	defer sandbox.store.Destroy(sandbox.id)
 
 	contID := "100"
 	container := Container{

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -831,10 +831,10 @@ func TestAgentCreateContainer(t *testing.T) {
 		hypervisor: &mockHypervisor{},
 	}
 
-	newStore, err := persist.GetDriver()
+	store, err := persist.GetDriver()
 	assert.NoError(err)
-	assert.NotNil(newStore)
-	sandbox.newStore = newStore
+	assert.NotNil(store)
+	sandbox.store = store
 
 	container := &Container{
 		ctx:       sandbox.ctx,

--- a/src/runtime/virtcontainers/persist.go
+++ b/src/runtime/virtcontainers/persist.go
@@ -287,7 +287,7 @@ func (s *Sandbox) Save() error {
 	s.dumpNetwork(&ss)
 	s.dumpConfig(&ss)
 
-	if err := s.newStore.ToDisk(ss, cs); err != nil {
+	if err := s.store.ToDisk(ss, cs); err != nil {
 		return err
 	}
 
@@ -397,7 +397,7 @@ func (s *Sandbox) loadNetwork(netInfo persistapi.NetworkInfo) {
 
 // Restore will restore sandbox data from persist file on disk
 func (s *Sandbox) Restore() error {
-	ss, _, err := s.newStore.FromDisk(s.id)
+	ss, _, err := s.store.FromDisk(s.id)
 	if err != nil {
 		return err
 	}
@@ -412,7 +412,7 @@ func (s *Sandbox) Restore() error {
 
 // Restore will restore container data from persist file on disk
 func (c *Container) Restore() error {
-	_, css, err := c.sandbox.newStore.FromDisk(c.sandbox.id)
+	_, css, err := c.sandbox.store.FromDisk(c.sandbox.id)
 	if err != nil {
 		return err
 	}

--- a/src/runtime/virtcontainers/persist_test.go
+++ b/src/runtime/virtcontainers/persist_test.go
@@ -38,9 +38,9 @@ func TestSandboxRestore(t *testing.T) {
 		state:      types.SandboxState{BlockIndexMap: make(map[int]struct{})},
 	}
 
-	sandbox.newStore, err = persist.GetDriver()
+	sandbox.store, err = persist.GetDriver()
 	assert.NoError(err)
-	assert.NotNil(sandbox.newStore)
+	assert.NotNil(sandbox.store)
 
 	// if we don't call Save(), we can get nothing from disk
 	err = sandbox.Restore()
@@ -67,7 +67,7 @@ func TestSandboxRestore(t *testing.T) {
 
 	// empty the sandbox
 	sandbox.state = types.SandboxState{}
-	if sandbox.newStore, err = persist.GetDriver(); err != nil || sandbox.newStore == nil {
+	if sandbox.store, err = persist.GetDriver(); err != nil || sandbox.store == nil {
 		t.Fatal("failed to get persist driver")
 	}
 

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -194,7 +194,7 @@ func TestQemuKnobs(t *testing.T) {
 	assert.NoError(err)
 
 	q := &qemu{
-		store: sandbox.newStore,
+		store: sandbox.store,
 	}
 	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig)
 	assert.NoError(err)
@@ -462,7 +462,7 @@ func TestQemuFileBackedMem(t *testing.T) {
 	assert.NoError(err)
 
 	q := &qemu{
-		store: sandbox.newStore,
+		store: sandbox.store,
 	}
 	sandbox.config.HypervisorConfig.SharedFS = config.VirtioFS
 	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig)
@@ -477,7 +477,7 @@ func TestQemuFileBackedMem(t *testing.T) {
 	assert.NoError(err)
 
 	q = &qemu{
-		store: sandbox.newStore,
+		store: sandbox.store,
 	}
 	sandbox.config.HypervisorConfig.BootToBeTemplate = true
 	sandbox.config.HypervisorConfig.SharedFS = config.VirtioFS
@@ -493,7 +493,7 @@ func TestQemuFileBackedMem(t *testing.T) {
 	assert.NoError(err)
 
 	q = &qemu{
-		store: sandbox.newStore,
+		store: sandbox.store,
 	}
 	sandbox.config.HypervisorConfig.FileBackedMemRootDir = "/tmp/xyzabc"
 	err = q.createSandbox(context.Background(), sandbox.id, NetworkNamespace{}, &sandbox.config.HypervisorConfig)
@@ -507,7 +507,7 @@ func TestQemuFileBackedMem(t *testing.T) {
 	assert.NoError(err)
 
 	q = &qemu{
-		store: sandbox.newStore,
+		store: sandbox.store,
 	}
 	sandbox.config.HypervisorConfig.EnableVhostUserStore = true
 	sandbox.config.HypervisorConfig.HugePages = true
@@ -520,7 +520,7 @@ func TestQemuFileBackedMem(t *testing.T) {
 	assert.NoError(err)
 
 	q = &qemu{
-		store: sandbox.newStore,
+		store: sandbox.store,
 	}
 	sandbox.config.HypervisorConfig.EnableVhostUserStore = true
 	sandbox.config.HypervisorConfig.HugePages = false
@@ -541,11 +541,11 @@ func createQemuSandboxConfig() (*Sandbox, error) {
 		},
 	}
 
-	newStore, err := persist.GetDriver()
+	store, err := persist.GetDriver()
 	if err != nil {
 		return &Sandbox{}, err
 	}
-	sandbox.newStore = newStore
+	sandbox.store = store
 
 	return &sandbox, nil
 }

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -1009,7 +1009,7 @@ func TestDeleteStoreWhenNewContainerFail(t *testing.T) {
 	}
 	_, err = newContainer(context.Background(), p, &contConfig)
 	assert.NotNil(t, err, "New container with invalid device info should fail")
-	storePath := filepath.Join(p.newStore.RunStoragePath(), testSandboxID, contID)
+	storePath := filepath.Join(p.store.RunStoragePath(), testSandboxID, contID)
 	_, err = os.Stat(storePath)
 	assert.NotNil(t, err, "Should delete configuration root after failed to create a container")
 }


### PR DESCRIPTION
The property name make newcomers confused when reading code.
Since in Kata Containers 2.0 there will only be one type of store,
so it's safe to replace it by `store` simply.

Fixes: #1660

Signed-off-by: bin <bin@hyper.sh>