### PR TITLE
ci: Fix travis for stable-2.0

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -5,7 +5,7 @@
 
 export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 export tests_repo_dir="$GOPATH/src/$tests_repo"
-export branch="${branch:-main}"
+export branch="${branch:-$TRAVIS_BRANCH}"
 
 clone_tests_repo()
 {


### PR DESCRIPTION
This PR fixes travis in stable-2.0 as is taking the branch
from the travis environment instead of using main.

Fixes #1663

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>