### PR TITLE
release: automatically bump the version of the kata-deploy images

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -18,7 +18,7 @@ spec:
           katacontainers.io/kata-runtime: cleanup
       containers:
       - name: kube-kata-cleanup
-        image: katadocker/kata-deploy
+        image: katadocker/kata-deploy:2.1.0-alpha1
         imagePullPolicy: Always
         command: [ "bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh reset" ]
         env:

--- a/tools/packaging/release/update-repository-version.sh
+++ b/tools/packaging/release/update-repository-version.sh
@@ -110,6 +110,13 @@ bump_repo() {
 		fi
 	fi
 
+	if [ "${repo}" == "kata-containers" ]; then
+		info "Updating kata-deploy / kata-cleanup image tags"
+		sed -i "s#katadocker/kata-deploy:${current_version}#katadocker/kata-deploy:${new_version}#g" tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+		sed -i "s#katadocker/kata-deploy:${current_version}#katadocker/kata-deploy:${new_version}#g" tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+		git diff
+	fi
+
 	info "Creating PR message"
 	notes_file=notes.md
 	cat <<EOT >"${notes_file}"
@@ -128,6 +135,8 @@ EOT
 		info "OK"
 	fi
 
+	git add tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+	git add tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
 	git add VERSION
 	info "Creating commit with new changes"
 	commit_msg="$(generate_commit $new_version $current_version)"


### PR DESCRIPTION
Let's teach `update-repository-version.sh` to automatically bump the
version of the kata-deploy images to be used within that release, when
running against the `kata-containers` repo.

Fixes: #1665
