### PR TITLE
agent: Add test to random::reseed_rng()

### DIFF
--- a/src/agent/src/random.rs
+++ b/src/agent/src/random.rs
@@ -46,3 +46,24 @@ pub fn reseed_rng(data: &[u8]) -> Result<()> {
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::skip_if_not_root;
+    use std::fs::File;
+    use std::io::prelude::*;
+
+    #[test]
+    fn test_reseed_rng() {
+        skip_if_not_root!();
+        const POOL_SIZE: usize = 512;
+        let mut f = File::open("/dev/urandom").unwrap();
+        let mut seed = [0; POOL_SIZE];
+        let n = f.read(&mut seed).unwrap();
+        // Ensure the buffer was filled.
+        assert!(n == POOL_SIZE);
+        let ret = reseed_rng(&seed);
+        assert!(ret.is_ok());
+    }
+}


### PR DESCRIPTION
Introduced an unit test for the random::reseed_rng() function.

Fixes #291
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>