### PR TITLE
runtime: Disable trace for healthcheck

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1837,9 +1837,6 @@ func (k *kataAgent) disconnect(ctx context.Context) error {
 
 // check grpc server is serving
 func (k *kataAgent) check(ctx context.Context) error {
-	span, ctx := k.trace(ctx, "check")
-	defer span.End()
-
 	_, err := k.sendReq(ctx, &grpc.CheckRequest{})
 	if err != nil {
 		err = fmt.Errorf("Failed to check if grpc server is working: %s", err)
@@ -2011,9 +2008,6 @@ func (k *kataAgent) getReqContext(reqName string) (ctx context.Context, cancel c
 
 func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (interface{}, error) {
 	start := time.Now()
-	span, spanCtx := k.trace(spanCtx, "sendReq")
-	span.SetAttributes(label.Key("request").String(fmt.Sprintf("%+v", request)))
-	defer span.End()
 
 	if err := k.connect(spanCtx); err != nil {
 		return nil, err


### PR DESCRIPTION
With tracing enabled, grpc health check generates a large number of
spans which creates too much data for tasks running longer than a few
minutes. To solve this, remove span creation from kata agent check() and
sendReq() where the majority of the spans come from. Leave contexts in
functions for subsequent calls that create spans.

Fixes #1395

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>