### PR TITLE
Update the information about the release process

### DIFF
--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -18,6 +18,7 @@
 ## Requirements
 
 - [hub](https://github.com/github/hub)
+  * Using an [application token](https://github.com/settings/tokens) is required for hub.
 
 - GitHub permissions to push tags and create releases in Kata repositories.
 

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -31,14 +31,9 @@
 
 ### Bump all Kata repositories
 
-  - We have set up a Jenkins job to bump the version in the `VERSION` file in all Kata repositories. Go to the [Jenkins bump-job page](http://jenkins.katacontainers.io/job/release/build) to trigger a new job.
-  - Start a new job with variables for the job passed as:
-     - `BRANCH=<the-branch-you-want-to-bump>`
-     - `NEW_VERSION=<the-new-kata-version>`
-
-     For example, in the case where you want to make a patch release `1.10.2`, the variable `NEW_VERSION` should be `1.10.2` and `BRANCH` should point to  `stable-1.10`. In case of an alpha or release candidate release, `BRANCH` should point to `master` branch.
-
-  Alternatively, you can also bump the repositories using a script in the Kata packaging repo
+  Bump the repositories using a script in the Kata packaging repo, where:
+  - `BRANCH=<the-branch-you-want-to-bump>`
+  - `NEW_VERSION=<the-new-kata-version>`
   ```
   $ cd ${GOPATH}/src/github.com/kata-containers/kata-containers/tools/packaging/release
   $ export NEW_VERSION=<the-new-kata-version>

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -19,8 +19,6 @@
 
 - [hub](https://github.com/github/hub)
 
-- OBS account with permissions on [`/home:katacontainers`](https://build.opensuse.org/project/subprojects/home:katacontainers)
-
 - GitHub permissions to push tags and create releases in Kata repositories.
 
 - GPG configured to sign git tags. https://help.github.com/articles/generating-a-new-gpg-key/


### PR DESCRIPTION
While working on the release of 2.1.0-alpha2 and 2.0.3 I've noticed that a few things that are part of https://github.com/kata-containers/kata-containers/blob/main/docs/Release-Process.md could be updated and that some of those things would have saved me some time.

The things that clearly need some updates are:

* The person managing the release doesn't need an OBS account, as we don't build packages as part of 2.x releases;
* The person should have hub setup to use app tokens rather than the user password
  * This one hit me quite hard and made me spend a good amount of mine and @jcvenegas's time to understand the issue, thankfully @jcvenegas pointed me to the right direction!
* The release bump section could be simplified to only mention the script, rather than having different alternatives.
  * This helps to simplify the document and have one well stablished process.

Fixes: #1680 