### PR TITLE
Remove forced PCI rescans from agent

### DIFF
--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -17,10 +17,6 @@ use tokio::sync::Mutex;
 #[cfg(target_arch = "s390x")]
 use crate::ccw;
 use crate::linux_abi::*;
-use crate::mount::{
-    DRIVER_BLK_CCW_TYPE, DRIVER_BLK_TYPE, DRIVER_MMIO_BLK_TYPE, DRIVER_NVDIMM_TYPE,
-    DRIVER_SCSI_TYPE,
-};
 use crate::pci;
 use crate::sandbox::Sandbox;
 use crate::uevent::{wait_for_uevent, Uevent, UeventMatcher};
@@ -37,6 +33,17 @@ macro_rules! sl {
 }
 
 const VM_ROOTFS: &str = "/";
+
+pub const DRIVER_9P_TYPE: &str = "9p";
+pub const DRIVER_VIRTIOFS_TYPE: &str = "virtio-fs";
+pub const DRIVER_BLK_TYPE: &str = "blk";
+pub const DRIVER_BLK_CCW_TYPE: &str = "blk-ccw";
+pub const DRIVER_MMIO_BLK_TYPE: &str = "mmioblk";
+pub const DRIVER_SCSI_TYPE: &str = "scsi";
+pub const DRIVER_NVDIMM_TYPE: &str = "nvdimm";
+pub const DRIVER_EPHEMERAL_TYPE: &str = "ephemeral";
+pub const DRIVER_LOCAL_TYPE: &str = "local";
+pub const DRIVER_WATCHABLE_BIND_TYPE: &str = "watchable-bind";
 
 #[derive(Debug)]
 struct DevIndexEntry {

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -57,11 +57,6 @@ struct DevIndexEntry {
 struct DevIndex(HashMap<String, DevIndexEntry>);
 
 #[instrument]
-pub fn rescan_pci_bus() -> Result<()> {
-    online_device(SYSFS_PCI_BUS_RESCAN_FILE)
-}
-
-#[instrument]
 pub fn online_device(path: &str) -> Result<()> {
     fs::write(path, "1")?;
     Ok(())
@@ -170,8 +165,6 @@ pub async fn get_virtio_blk_pci_device_name(
     let root_bus_sysfs = format!("{}{}", SYSFS_DIR, create_pci_root_bus_path());
     let sysfs_rel_path = pcipath_to_sysfs(&root_bus_sysfs, pcipath)?;
     let matcher = VirtioBlkPciMatcher::new(&sysfs_rel_path);
-
-    rescan_pci_bus()?;
 
     let uev = wait_for_uevent(sandbox, matcher).await?;
     Ok(format!("{}/{}", SYSTEM_DEV_PATH, &uev.devname))

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -9,7 +9,6 @@
 use std::fs;
 
 pub const SYSFS_DIR: &str = "/sys";
-pub const SYSFS_PCI_BUS_RESCAN_FILE: &str = "/sys/bus/pci/rescan";
 #[cfg(any(
     target_arch = "powerpc64",
     target_arch = "s390x",

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -22,6 +22,9 @@ use regex::Regex;
 
 use crate::device::{
     get_scsi_device_name, get_virtio_blk_pci_device_name, online_device, wait_for_pmem_device,
+    DRIVER_9P_TYPE, DRIVER_BLK_CCW_TYPE, DRIVER_BLK_TYPE, DRIVER_EPHEMERAL_TYPE, DRIVER_LOCAL_TYPE,
+    DRIVER_MMIO_BLK_TYPE, DRIVER_NVDIMM_TYPE, DRIVER_SCSI_TYPE, DRIVER_VIRTIOFS_TYPE,
+    DRIVER_WATCHABLE_BIND_TYPE,
 };
 use crate::linux_abi::*;
 use crate::pci;
@@ -32,17 +35,6 @@ use crate::{ccw, device::get_virtio_blk_ccw_device_name};
 use anyhow::{anyhow, Context, Result};
 use slog::Logger;
 use tracing::instrument;
-
-pub const DRIVER_9P_TYPE: &str = "9p";
-pub const DRIVER_VIRTIOFS_TYPE: &str = "virtio-fs";
-pub const DRIVER_BLK_TYPE: &str = "blk";
-pub const DRIVER_BLK_CCW_TYPE: &str = "blk-ccw";
-pub const DRIVER_MMIO_BLK_TYPE: &str = "mmioblk";
-pub const DRIVER_SCSI_TYPE: &str = "scsi";
-pub const DRIVER_NVDIMM_TYPE: &str = "nvdimm";
-pub const DRIVER_EPHEMERAL_TYPE: &str = "ephemeral";
-pub const DRIVER_LOCAL_TYPE: &str = "local";
-pub const DRIVER_WATCHABLE_BIND_TYPE: &str = "watchable-bind";
 
 pub const TYPE_ROOTFS: &str = "rootfs";
 

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::pci;
 use async_trait::async_trait;
 use rustjail::{pipestream::PipeStream, process::StreamType};
 use tokio::io::{AsyncReadExt, AsyncWriteExt, ReadHalf};
@@ -44,12 +43,15 @@ use nix::sys::stat;
 use nix::unistd::{self, Pid};
 use rustjail::process::ProcessOperations;
 
-use crate::device::{add_devices, pcipath_to_sysfs, rescan_pci_bus, update_device_cgroup};
+use crate::device::{
+    add_devices, get_virtio_blk_pci_device_name, rescan_pci_bus, update_device_cgroup,
+};
 use crate::linux_abi::*;
 use crate::metrics::get_metrics;
 use crate::mount::{add_storages, baremount, remove_mounts, STORAGE_HANDLER_LIST};
 use crate::namespace::{NSTYPEIPC, NSTYPEPID, NSTYPEUTS};
 use crate::network::setup_guest_dns;
+use crate::pci;
 use crate::random;
 use crate::sandbox::Sandbox;
 use crate::version::{AGENT_VERSION, API_VERSION};
@@ -1204,7 +1206,9 @@ impl protocols::agent_ttrpc::AgentService for AgentService {
     ) -> ttrpc::Result<Empty> {
         trace_rpc_call!(ctx, "add_swap", req);
 
-        do_add_swap(&req).map_err(|e| ttrpc_error(ttrpc::Code::INTERNAL, e.to_string()))?;
+        do_add_swap(&self.sandbox, &req)
+            .await
+            .map_err(|e| ttrpc_error(ttrpc::Code::INTERNAL, e.to_string()))?;
 
         Ok(Empty::new())
     }
@@ -1557,43 +1561,13 @@ fn do_copy_file(req: &CopyFileRequest) -> Result<()> {
     Ok(())
 }
 
-pub fn path_name_lookup<P: std::clone::Clone + AsRef<Path> + std::fmt::Debug>(
-    path: P,
-    lookup: &str,
-) -> Result<(PathBuf, String)> {
-    for entry in fs::read_dir(path.clone())? {
-        let entry = entry?;
-        if let Some(name) = entry.path().file_name() {
-            if let Some(name) = name.to_str() {
-                if Some(0) == name.find(lookup) {
-                    return Ok((entry.path(), name.to_string()));
-                }
-            }
-        }
-    }
-    Err(anyhow!("cannot get {} dir in {:?}", lookup, path))
-}
-
-fn do_add_swap(req: &AddSwapRequest) -> Result<()> {
-    // re-scan PCI bus
-    // looking for hidden devices
-    rescan_pci_bus().context("Could not rescan PCI bus")?;
-
+async fn do_add_swap(sandbox: &Arc<Mutex<Sandbox>>, req: &AddSwapRequest) -> Result<()> {
     let mut slots = Vec::new();
     for slot in &req.PCIPath {
-        slots.push(pci::Slot::new(*slot as u8)?);
+        slots.push(pci::Slot::new(*slot)?);
     }
     let pcipath = pci::Path::new(slots)?;
-    let root_bus_sysfs = format!("{}{}", SYSFS_DIR, create_pci_root_bus_path());
-    let sysfs_rel_path = format!(
-        "{}{}",
-        root_bus_sysfs,
-        pcipath_to_sysfs(&root_bus_sysfs, &pcipath)?
-    );
-    let (mut virtio_path, _) = path_name_lookup(sysfs_rel_path, "virtio")?;
-    virtio_path.push("block");
-    let (_, dev_name) = path_name_lookup(virtio_path, "vd")?;
-    let dev_name = format!("/dev/{}", dev_name);
+    let dev_name = get_virtio_blk_pci_device_name(sandbox, &pcipath).await?;
 
     let c_str = CString::new(dev_name)?;
     let ret = unsafe { libc::swapon(c_str.as_ptr() as *const c_char, 0) };

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -43,9 +43,7 @@ use nix::sys::stat;
 use nix::unistd::{self, Pid};
 use rustjail::process::ProcessOperations;
 
-use crate::device::{
-    add_devices, get_virtio_blk_pci_device_name, rescan_pci_bus, update_device_cgroup,
-};
+use crate::device::{add_devices, get_virtio_blk_pci_device_name, update_device_cgroup};
 use crate::linux_abi::*;
 use crate::metrics::get_metrics;
 use crate::mount::{add_storages, baremount, remove_mounts, STORAGE_HANDLER_LIST};
@@ -135,10 +133,6 @@ impl AgentService {
         };
 
         info!(sl!(), "receive createcontainer, spec: {:?}", &oci);
-
-        // re-scan PCI bus
-        // looking for hidden devices
-        rescan_pci_bus().context("Could not rescan PCI bus")?;
 
         // Some devices need some extra processing (the ones invoked with
         // --device for instance), and that's what this call is doing. It

--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -224,6 +224,9 @@ type VFIODev struct {
 	// Bus of VFIO PCIe device
 	Bus string
 
+	// Guest PCI path of device
+	GuestPciPath vcTypes.PciPath
+
 	// Type of VFIO device
 	Type VFIODeviceType
 

--- a/src/runtime/virtcontainers/hypervisor_s390x.go
+++ b/src/runtime/virtcontainers/hypervisor_s390x.go
@@ -90,7 +90,7 @@ func availableGuestProtection() (guestProtection, error) {
 		return noneProtection, err
 	}
 	if !seCmdlinePresent {
-		return noneProtection, fmt.Errorf("Protected Virtualization is not enabled on kernel command line! " +
+		return noneProtection, fmt.Errorf("Protected Virtualization is not enabled on kernel command line! "+
 			"Need %s=%s (or %s) to enable Secure Execution",
 			seCmdlineParam, seCmdlineValues[0], strings.Join(seCmdlineValues[1:], ", "))
 	}

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1144,9 +1144,7 @@ func (k *kataAgent) handleShm(mounts []specs.Mount, sandbox *Sandbox) {
 	}
 }
 
-func (k *kataAgent) appendBlockDevice(dev ContainerDevice, c *Container) *grpc.Device {
-	device := c.sandbox.devManager.GetDeviceByID(dev.ID)
-
+func (k *kataAgent) appendBlockDevice(dev ContainerDevice, device api.Device, c *Container) *grpc.Device {
 	d, ok := device.GetDeviceInfo().(*config.BlockDrive)
 	if !ok || d == nil {
 		k.Logger().WithField("device", device).Error("malformed block drive")
@@ -1187,9 +1185,7 @@ func (k *kataAgent) appendBlockDevice(dev ContainerDevice, c *Container) *grpc.D
 	return kataDevice
 }
 
-func (k *kataAgent) appendVhostUserBlkDevice(dev ContainerDevice, c *Container) *grpc.Device {
-	device := c.sandbox.devManager.GetDeviceByID(dev.ID)
-
+func (k *kataAgent) appendVhostUserBlkDevice(dev ContainerDevice, device api.Device, c *Container) *grpc.Device {
 	d, ok := device.GetDeviceInfo().(*config.VhostUserDeviceAttrs)
 	if !ok || d == nil {
 		k.Logger().WithField("device", device).Error("malformed vhost-user-blk drive")
@@ -1217,9 +1213,9 @@ func (k *kataAgent) appendDevices(deviceList []*grpc.Device, c *Container) []*gr
 
 		switch device.DeviceType() {
 		case config.DeviceBlock:
-			kataDevice = k.appendBlockDevice(dev, c)
+			kataDevice = k.appendBlockDevice(dev, device, c)
 		case config.VhostUserBlk:
-			kataDevice = k.appendVhostUserBlkDevice(dev, c)
+			kataDevice = k.appendVhostUserBlkDevice(dev, device, c)
 		}
 
 		if kataDevice == nil {

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -92,6 +92,7 @@ var (
 	kataNvdimmDevType           = "nvdimm"
 	kataVirtioFSDevType         = "virtio-fs"
 	kataWatchableBindDevType    = "watchable-bind"
+	kataVfioGuestKernelDevType  = "vfio-gk" // VFIO device for consumption by the guest kernel
 	sharedDir9pOptions          = []string{"trans=virtio,version=9p2000.L,cache=mmap", "nodev"}
 	sharedDirVirtioFSOptions    = []string{}
 	sharedDirVirtioFSDaxOptions = "dax"
@@ -1201,6 +1202,38 @@ func (k *kataAgent) appendVhostUserBlkDevice(dev ContainerDevice, device api.Dev
 	return kataDevice
 }
 
+func (k *kataAgent) appendVfioDevice(dev ContainerDevice, device api.Device, c *Container) *grpc.Device {
+	devList, ok := device.GetDeviceInfo().([]*config.VFIODev)
+	if !ok || devList == nil {
+		k.Logger().WithField("device", device).Error("malformed vfio device")
+		return nil
+	}
+
+	groupNum := filepath.Base(dev.ContainerPath)
+
+	// Each /dev/vfio/NN device represents a VFIO group, which
+	// could include several PCI devices.  So we give group
+	// information in the main structure, then list each
+	// individual PCI device in the Options array.
+	//
+	// Each option is formatted as "DDDD:BB:DD.F=<pcipath>"
+	// DDDD:BB:DD.F is the device's PCI address on the
+	// *host*. <pcipath> is the device's PCI path in the guest
+	// (see qomGetPciPath() for details).
+	kataDevice := &grpc.Device{
+		ContainerPath: dev.ContainerPath,
+		Type:          kataVfioGuestKernelDevType,
+		Id:            groupNum,
+		Options:       make([]string, len(devList)),
+	}
+
+	for i, pciDev := range devList {
+		kataDevice.Options[i] = fmt.Sprintf("0000:%s=%s", pciDev.BDF, pciDev.GuestPciPath)
+	}
+
+	return kataDevice
+}
+
 func (k *kataAgent) appendDevices(deviceList []*grpc.Device, c *Container) []*grpc.Device {
 	var kataDevice *grpc.Device
 
@@ -1216,6 +1249,8 @@ func (k *kataAgent) appendDevices(deviceList []*grpc.Device, c *Container) []*gr
 			kataDevice = k.appendBlockDevice(dev, device, c)
 		case config.VhostUserBlk:
 			kataDevice = k.appendVhostUserBlkDevice(dev, device, c)
+		case config.DeviceVFIO:
+			kataDevice = k.appendVfioDevice(dev, device, c)
 		}
 
 		if kataDevice == nil {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1438,6 +1438,69 @@ func (q *qemu) hotplugVhostUserDevice(ctx context.Context, vAttr *config.VhostUs
 	}
 }
 
+// Query QMP to find the PCI slot of a device, given its QOM path or ID
+func (q *qemu) qomGetSlot(qomPath string) (vcTypes.PciSlot, error) {
+	addr, err := q.qmpMonitorCh.qmp.ExecQomGet(q.qmpMonitorCh.ctx, qomPath, "addr")
+	if err != nil {
+		return vcTypes.PciSlot{}, err
+	}
+	addrf, ok := addr.(float64)
+	// XXX going via float makes no real sense, but that's how
+	// JSON works, and we'll get away with it for the small values
+	// we have here
+	if !ok {
+		return vcTypes.PciSlot{}, fmt.Errorf("addr QOM property of %q is %T not a number", qomPath, addr)
+	}
+	addri := int(addrf)
+
+	slotNum, funcNum := addri>>3, addri&0x7
+	if funcNum != 0 {
+		return vcTypes.PciSlot{}, fmt.Errorf("Unexpected non-zero PCI function (%02x.%1x) on %q",
+			slotNum, funcNum, qomPath)
+	}
+
+	return vcTypes.PciSlotFromInt(slotNum)
+}
+
+// Query QMP to find a device's PCI path given its QOM path or ID
+func (q *qemu) qomGetPciPath(qemuID string) (vcTypes.PciPath, error) {
+	// XXX: For now we assume there's exactly one bridge, since
+	// that's always how we configure qemu from Kata for now.  It
+	// would be good to generalize this to different PCI
+	// topologies
+	devSlot, err := q.qomGetSlot(qemuID)
+	if err != nil {
+		return vcTypes.PciPath{}, err
+	}
+
+	busq, err := q.qmpMonitorCh.qmp.ExecQomGet(q.qmpMonitorCh.ctx, qemuID, "parent_bus")
+	if err != nil {
+		return vcTypes.PciPath{}, err
+	}
+
+	bus, ok := busq.(string)
+	if !ok {
+		return vcTypes.PciPath{}, fmt.Errorf("parent_bus QOM property of %s is %t not a string", qemuID, busq)
+	}
+
+	// `bus` is the QOM path of the QOM bus object, but we need
+	// the PCI bridge which manages that bus.  There doesn't seem
+	// to be a way to get that other than to simply drop the last
+	// path component.
+	idx := strings.LastIndex(bus, "/")
+	if idx == -1 {
+		return vcTypes.PciPath{}, fmt.Errorf("Bus has unexpected QOM path %s", bus)
+	}
+	bridge := bus[:idx]
+
+	bridgeSlot, err := q.qomGetSlot(bridge)
+	if err != nil {
+		return vcTypes.PciPath{}, err
+	}
+
+	return vcTypes.PciPathFromSlots(bridgeSlot, devSlot)
+}
+
 func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op operation) (err error) {
 	if err = q.qmpSetup(); err != nil {
 		return err
@@ -1509,6 +1572,16 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 				return fmt.Errorf("Incorrect VFIO device type found")
 			}
 		}
+		if err != nil {
+			return err
+		}
+		// XXX: Depending on whether we're doing root port or
+		// bridge hotplug, and how the bridge is set up in
+		// other parts of the code, we may or may not already
+		// have information about the slot number of the
+		// bridge and or the device.  For simplicity, just
+		// query both of them back from qemu
+		device.GuestPciPath, err = q.qomGetPciPath(devID)
 		return err
 	} else {
 		q.Logger().WithField("dev-id", devID).Info("Start hot-unplug VFIO device")

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -8,8 +8,8 @@ package virtcontainers
 import (
 	"context"
 	"fmt"
-	"time"
 	"os"
+	"time"
 
 	govmmQemu "github.com/kata-containers/govmm/qemu"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
@@ -100,29 +100,29 @@ func (q *qemuArm64) appendImage(ctx context.Context, devices []govmmQemu.Device,
 // so we temporarily add this specific implementation for arm64 here until
 // the qemu used by arm64 is capable for that feature
 func (q *qemuArm64) appendNvdimmImage(devices []govmmQemu.Device, path string) ([]govmmQemu.Device, error) {
-        imageFile, err := os.Open(path)
-        if err != nil {
-                return nil, err
-        }
-        defer imageFile.Close()
+	imageFile, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer imageFile.Close()
 
-        imageStat, err := imageFile.Stat()
-        if err != nil {
-                return nil, err
-        }
+	imageStat, err := imageFile.Stat()
+	if err != nil {
+		return nil, err
+	}
 
 	object := govmmQemu.Object{
-                Driver:   govmmQemu.NVDIMM,
-                Type:     govmmQemu.MemoryBackendFile,
-                DeviceID: "nv0",
-                ID:       "mem0",
-                MemPath:  path,
-                Size:     (uint64)(imageStat.Size()),
-        }
+		Driver:   govmmQemu.NVDIMM,
+		Type:     govmmQemu.MemoryBackendFile,
+		DeviceID: "nv0",
+		ID:       "mem0",
+		MemPath:  path,
+		Size:     (uint64)(imageStat.Size()),
+	}
 
-        devices = append(devices, object)
+	devices = append(devices, object)
 
-        return devices, nil
+	return devices, nil
 }
 
 func (q *qemuArm64) setIgnoreSharedMemoryMigrationCaps(_ context.Context, _ *govmmQemu.QMP) error {


### PR DESCRIPTION
As described in #683, kata-containers/agent#781, the PCI rescan in the agent code causes a bunch of problems (up to and including making VFIO devices unusable until the next *host* reboot).

This series is intended to avoid this by instead using the agent's uevent watching mechanism to wait for PCI devices to be "naturally" ready.

This is a (loose) forward port of both https://github.com/kata-containers/agent/pull/850 and https://github.com/kata-containers/runtime/pull/2981
