### PR TITLE
runtime/tests: Change "moo FAILURE" message

### DIFF
--- a/src/runtime/cli/main_test.go
+++ b/src/runtime/cli/main_test.go
@@ -869,7 +869,7 @@ func TestMainCreateRuntime(t *testing.T) {
 	assert := assert.New(t)
 
 	const cmd = "foo"
-	const msg = "moo FAILURE"
+	const msg = "moo message"
 
 	resetCLIGlobals()
 
@@ -942,7 +942,7 @@ func TestMainFatalWriter(t *testing.T) {
 	assert := assert.New(t)
 
 	const cmd = "foo"
-	const msg = "moo FAILURE"
+	const msg = "moo message"
 
 	// create buffer to save logger output
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
Change the "moo FAILURE" message shown in a couple of the unit tests to
"moo message".  This means that searching for unrelated failures in the
test output by looking for "FAIL" won't show these messages as false
positives any more.

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>