### PR TITLE
Update dependencies versions

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -195,14 +195,6 @@ externals:
     url: "https://github.com/kubernetes-sigs/cri-tools"
     version: "1.18.0"
 
-  docker:
-    description: "Moby project container manager"
-    notes: "Docker Swarm requires an older version of Docker."
-    url: "https://github.com/moby/moby"
-    version: "v18.06-ce"
-    meta:
-      swarm-version: "1.12.1"
-
   kubernetes:
     description: "Kubernetes project container manager"
     url: "https://github.com/kubernetes/kubernetes"

--- a/versions.yaml
+++ b/versions.yaml
@@ -203,7 +203,7 @@ externals:
     uscan-url: >-
       https://github.com/kubernetes/kubernetes/tags
       .*/v?([\d\.]+)\.tar\.gz
-    version: "1.18.9-00"
+    version: "1.21.0-00"
 
   runc:
     description: "OCI CLI reference runtime implementation"

--- a/versions.yaml
+++ b/versions.yaml
@@ -180,9 +180,6 @@ externals:
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
     version: "v1.18.4-4-g6dee3891e"
-    meta:
-      openshift: "6273bea4c9ed788aeb3d051ebf2d030060c05b6c"
-      crictl: 1.0.0-beta.2
 
   cri-containerd:
     description: |

--- a/versions.yaml
+++ b/versions.yaml
@@ -193,7 +193,7 @@ externals:
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"
     url: "https://github.com/kubernetes-sigs/cri-tools"
-    version: "1.18.0"
+    version: "1.21.0"
 
   kubernetes:
     description: "Kubernetes project container manager"

--- a/versions.yaml
+++ b/versions.yaml
@@ -213,17 +213,6 @@ externals:
       .*/v?([\d\.]+)\.tar\.gz
     version: "1.18.9-00"
 
-  openshift:
-    description: |
-      Distribution of Kubernetes optimized for continuous application
-      development and multi-tenant deployment.
-    url: "https://github.com/openshift/origin"
-    uscan-url: >-
-      https://github.com/openshift/origin/tags
-      .*/v?([\d\.]+)\.tar\.gz
-    version: "v3.10.0"
-    commit: "dd10d17"
-
   runc:
     description: "OCI CLI reference runtime implementation"
     url: "https://github.com/opencontainers/runc"

--- a/versions.yaml
+++ b/versions.yaml
@@ -179,7 +179,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    version: "v1.18.4-4-g6dee3891e"
+    branch: "release-1.21"
 
   cri-containerd:
     description: |

--- a/versions.yaml
+++ b/versions.yaml
@@ -213,7 +213,7 @@ externals:
     uscan-url: >-
       https://github.com/opencontainers/runc/tags
       .*/v?(\d\S+)\.tar\.gz
-    version: "v1.0.0-rc5"
+    version: "v1.0.0-rc93"
 
   musl:
     description: |


### PR DESCRIPTION
In this PR we're updating the versions of the following components:
* kubernetes: 1.18.9-00 -> 1.21.0-00
* critools: 1.18.0 -> 1.21.0
* cri-o: v1.18.4-4-g6dee3891e -> v1.21.0

While touching th file, we're also remove the entries for:
* docker, not used since https://github.com/kata-containers/tests/pull/3272
* openshift, not used in 2.x at all, since kata-containers was added to the OpenShift CI (thanks, @wainersm!)
  * And because of this, CRI-O meta dependencies can be dropped as well.

This PR is a WIP as we're still depending on:
* cri-o v1.21.0 to be released (we're pointing to v1.20.2, which is the latest release), which should happen Today / Tomorrow.
* a PR updating things on the `kata-containers/tests` side.