### PR TITLE
Improve agent shutdown handling

### DIFF
--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -479,7 +479,7 @@ func (a *Acrn) waitSandbox(ctx context.Context, timeoutSecs int) error {
 }
 
 // stopSandbox will stop the Sandbox's VM.
-func (a *Acrn) stopSandbox(ctx context.Context) (err error) {
+func (a *Acrn) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
 	span, _ := a.trace(ctx, "stopSandbox")
 	defer span.End()
 
@@ -512,6 +512,11 @@ func (a *Acrn) stopSandbox(ctx context.Context) (err error) {
 	pid := a.state.PID
 
 	shutdownSignal := syscall.SIGINT
+
+	if waitOnly {
+		// NOP
+		shutdownSignal = syscall.Signal(0)
+	}
 
 	return utils.WaitLocalProcess(pid, acrnStopSandboxTimeoutSecs, shutdownSignal, a.Logger())
 }

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -786,31 +786,8 @@ func (clh *cloudHypervisor) terminate(ctx context.Context) (err error) {
 		}
 	}
 
-	// At this point the VMM was stop nicely, but need to check if PID is still running
-	// Wait for the VM process to terminate
-	tInit := time.Now()
-	for {
-		if err = syscall.Kill(pid, syscall.Signal(0)); err != nil {
-			pidRunning = false
-			break
-		}
-
-		if time.Since(tInit).Seconds() >= clhStopSandboxTimeout {
-			pidRunning = true
-			clh.Logger().Warnf("VM still running after waiting %ds", clhStopSandboxTimeout)
-			break
-		}
-
-		// Let's avoid to run a too busy loop
-		time.Sleep(time.Duration(50) * time.Millisecond)
-	}
-
-	// Let's try with a hammer now, a SIGKILL should get rid of the
-	// VM process.
-	if pidRunning {
-		if err = syscall.Kill(pid, syscall.SIGKILL); err != nil {
-			return fmt.Errorf("Fatal, failed to kill hypervisor process, error: %s", err)
-		}
+	if err = utils.WaitLocalProcess(pid, clhStopSandboxTimeout, syscall.Signal(0), clh.Logger()); err != nil {
+		return err
 	}
 
 	if clh.virtiofsd == nil {

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -652,11 +652,11 @@ func (clh *cloudHypervisor) resumeSandbox(ctx context.Context) error {
 }
 
 // stopSandbox will stop the Sandbox's VM.
-func (clh *cloudHypervisor) stopSandbox(ctx context.Context) (err error) {
+func (clh *cloudHypervisor) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
 	span, _ := clh.trace(ctx, "stopSandbox")
 	defer span.End()
 	clh.Logger().WithField("function", "stopSandbox").Info("Stop Sandbox")
-	return clh.terminate(ctx)
+	return clh.terminate(ctx, waitOnly)
 }
 
 func (clh *cloudHypervisor) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, j []byte) error {
@@ -756,7 +756,7 @@ func (clh *cloudHypervisor) trace(parent context.Context, name string) (otelTrac
 	return span, ctx
 }
 
-func (clh *cloudHypervisor) terminate(ctx context.Context) (err error) {
+func (clh *cloudHypervisor) terminate(ctx context.Context, waitOnly bool) (err error) {
 	span, _ := clh.trace(ctx, "terminate")
 	defer span.End()
 
@@ -775,7 +775,7 @@ func (clh *cloudHypervisor) terminate(ctx context.Context) (err error) {
 
 	clh.Logger().Debug("Stopping Cloud Hypervisor")
 
-	if pidRunning {
+	if pidRunning && !waitOnly {
 		clhRunning, _ := clh.isClhRunning(clhStopSandboxTimeout)
 		if clhRunning {
 			ctx, cancel := context.WithTimeout(context.Background(), clhStopSandboxTimeout*time.Second)

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -425,33 +425,10 @@ func (fc *firecracker) fcEnd(ctx context.Context) (err error) {
 
 	pid := fc.info.PID
 
-	// Send a SIGTERM to the VM process to try to stop it properly
-	if err = syscall.Kill(pid, syscall.SIGTERM); err != nil {
-		if err == syscall.ESRCH {
-			return nil
-		}
-		return err
-	}
+	shutdownSignal := syscall.SIGTERM
 
 	// Wait for the VM process to terminate
-	tInit := time.Now()
-	for {
-		if err = syscall.Kill(pid, syscall.Signal(0)); err != nil {
-			return nil
-		}
-
-		if time.Since(tInit).Seconds() >= fcStopSandboxTimeout {
-			fc.Logger().Warnf("VM still running after waiting %ds", fcStopSandboxTimeout)
-			break
-		}
-
-		// Let's avoid to run a too busy loop
-		time.Sleep(time.Duration(50) * time.Millisecond)
-	}
-
-	// Let's try with a hammer now, a SIGKILL should get rid of the
-	// VM process.
-	return syscall.Kill(pid, syscall.SIGKILL)
+	return utils.WaitLocalProcess(pid, fcStopSandboxTimeout, shutdownSignal, fc.Logger())
 }
 
 func (fc *firecracker) client(ctx context.Context) *client.Firecracker {

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -787,7 +787,9 @@ func generateVMSocket(id string, vmStogarePath string) (interface{}, error) {
 type hypervisor interface {
 	createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error
 	startSandbox(ctx context.Context, timeout int) error
-	stopSandbox(ctx context.Context) error
+	// If wait is set, don't actively stop the sandbox:
+	// just perform cleanup.
+	stopSandbox(ctx context.Context, waitOnly bool) error
 	pauseSandbox(ctx context.Context) error
 	saveSandbox() error
 	resumeSandbox(ctx context.Context) error

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -41,7 +41,7 @@ func (m *mockHypervisor) startSandbox(ctx context.Context, timeout int) error {
 	return nil
 }
 
-func (m *mockHypervisor) stopSandbox(ctx context.Context) error {
+func (m *mockHypervisor) stopSandbox(ctx context.Context, waitOnly bool) error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/mock_hypervisor_test.go
+++ b/src/runtime/virtcontainers/mock_hypervisor_test.go
@@ -53,7 +53,7 @@ func TestMockHypervisorStartSandbox(t *testing.T) {
 func TestMockHypervisorStopSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	assert.NoError(t, m.stopSandbox(context.Background()))
+	assert.NoError(t, m.stopSandbox(context.Background(), false))
 }
 
 func TestMockHypervisorAddDevice(t *testing.T) {

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1027,7 +1027,7 @@ func (s *Sandbox) startVM(ctx context.Context) (err error) {
 
 	defer func() {
 		if err != nil {
-			s.hypervisor.stopSandbox(ctx)
+			s.hypervisor.stopSandbox(ctx, false)
 		}
 	}()
 
@@ -1081,14 +1081,9 @@ func (s *Sandbox) stopVM(ctx context.Context) error {
 		s.Logger().WithError(err).WithField("sandboxid", s.id).Warning("Agent did not stop sandbox")
 	}
 
-	if s.disableVMShutdown {
-		// Do not kill the VM - allow the agent to shut it down
-		// (only used to support static agent tracing).
-		return nil
-	}
-
 	s.Logger().Info("Stopping VM")
-	return s.hypervisor.stopSandbox(ctx)
+
+	return s.hypervisor.stopSandbox(ctx, s.disableVMShutdown)
 }
 
 func (s *Sandbox) addContainer(c *Container) error {

--- a/src/runtime/virtcontainers/utils/utils.go
+++ b/src/runtime/virtcontainers/utils/utils.go
@@ -349,6 +349,18 @@ func WaitLocalProcess(pid int, timeoutSecs uint, initialSignal syscall.Signal, l
 	startTime := time.Now()
 
 	for {
+		var _status syscall.WaitStatus
+		var _rusage syscall.Rusage
+		var waitedPid int
+
+		// "A watched pot never boils" and an unwaited-for process never appears to die!
+		waitedPid, err = syscall.Wait4(pid, &_status, syscall.WNOHANG, &_rusage)
+
+		if waitedPid == pid && err == nil {
+			pidRunning = false
+			break
+		}
+
 		if err = syscall.Kill(pid, syscall.Signal(0)); err != nil {
 			pidRunning = false
 			break

--- a/src/runtime/virtcontainers/utils/utils.go
+++ b/src/runtime/virtcontainers/utils/utils.go
@@ -12,7 +12,10 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"syscall"
+	"time"
 
+	"github.com/sirupsen/logrus"
 	"github.com/vishvananda/netlink"
 
 	pbTypes "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols"
@@ -311,4 +314,64 @@ func ConvertNetlinkFamily(netlinkFamily int32) pbTypes.IPFamily {
 	default:
 		return pbTypes.IPFamily_v4
 	}
+}
+
+// WaitLocalProcess waits for the specified process for up to timeoutSecs seconds.
+//
+// Notes:
+//
+// - If the initial signal is zero, the specified process is assumed to be
+//   attempting to stop itself.
+// - If the initial signal is not zero, it will be sent to the process before
+//   checking if it is running.
+// - If the process has not ended after the timeout value, it will be forcibly killed.
+func WaitLocalProcess(pid int, timeoutSecs uint, initialSignal syscall.Signal, logger *logrus.Entry) error {
+	var err error
+
+	// Don't support process groups
+	if pid <= 0 {
+		return errors.New("can only wait for a single process")
+	}
+
+	if initialSignal != syscall.Signal(0) {
+		if err = syscall.Kill(pid, initialSignal); err != nil {
+			if err == syscall.ESRCH {
+				return nil
+			}
+
+			return fmt.Errorf("Failed to send initial signal %v to process %v: %v", initialSignal, pid, err)
+		}
+	}
+
+	pidRunning := true
+
+	// Wait for the VM process to terminate
+	startTime := time.Now()
+
+	for {
+		if err = syscall.Kill(pid, syscall.Signal(0)); err != nil {
+			pidRunning = false
+			break
+		}
+
+		if time.Since(startTime).Seconds() >= float64(timeoutSecs) {
+			pidRunning = true
+
+			logger.Warnf("process %v still running after waiting %ds", pid, timeoutSecs)
+
+			break
+		}
+
+		// Brief pause to avoid a busy loop
+		time.Sleep(time.Duration(50) * time.Millisecond)
+	}
+
+	if pidRunning {
+		// Force process to die
+		if err = syscall.Kill(pid, syscall.SIGKILL); err != nil {
+			return fmt.Errorf("Failed to stop process %v: %s", pid, err)
+		}
+	}
+
+	return nil
 }

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -137,7 +137,7 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 	defer func() {
 		if err != nil {
 			virtLog.WithField("vm", id).WithError(err).Info("clean up vm")
-			hypervisor.stopSandbox(ctx)
+			hypervisor.stopSandbox(ctx, false)
 		}
 	}()
 
@@ -251,7 +251,7 @@ func (v *VM) Disconnect(ctx context.Context) error {
 func (v *VM) Stop(ctx context.Context) error {
 	v.logger().Info("stop vm")
 
-	if err := v.hypervisor.stopSandbox(ctx); err != nil {
+	if err := v.hypervisor.stopSandbox(ctx, false); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Fixed logic used to handle static agent tracing.

For a standard (untraced) hypervisor shutdown, the runtime kills the VM
process once the workload has finished. But if static agent tracing is
enabled, the agent running inside the VM is responsible for the
shutdown. The existing code handled this scenario but did not wait for
the hypervisor process to end. The outcome of this being that the
console watcher thread was killed too early.

Although not a problem for an untraced system, if static agent tracing
was enabled, the logs from the hypervisor would be truncated, missing the
crucial final stages of the agents shutdown sequence.

The fix necessitated adding a new parameter to the `stopSandbox()` API,
which if true requests the runtime hypervisor logic simply to wait for
the hypervisor process to exit rather than killing it.

Fixes: #1696.

PR also includes some code refactoring along with a potential speed improvement for hypervisor shutdown.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>
