### PR TITLE
agent/rustjail: Fix accidental damage from tokio conversion

### DIFF
--- a/src/agent/rustjail/src/cgroups/notifier.rs
+++ b/src/agent/rustjail/src/cgroups/notifier.rs
@@ -117,12 +117,12 @@ async fn register_memory_event_v2(
                     return;
                 }
             }
-        }
 
-        // When a cgroup is destroyed, an event is sent to eventfd.
-        // So if the control path is gone, return instead of notifying.
-        if !Path::new(&event_control_path).exists() {
-            return;
+            // When a cgroup is destroyed, an event is sent to eventfd.
+            // So if the control path is gone, return instead of notifying.
+            if !Path::new(&event_control_path).exists() {
+                return;
+            }
         }
     });
 


### PR DESCRIPTION
register_memory_event_v2() includes a closure spawned as an async task
with tokio.  At the end of that closure, there's a test for a closed fd
exiting if so.  But this is right at the end of the closure when it was
about to exit anyway, so this does nothing.

This code was originally an explicit thread, converted to a tokio task
by 332fa4c "agent: switch to async runtime".  It looks like there was an
error during conversion, where this logic was accidentally moved out of the
while loop above, where it makes a lot more sense.

Put it back into the loop.

fixes #1702

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>