### PR TITLE
runtime: Fix stdout/stderr output from container being truncated

### DIFF
--- a/src/runtime/containerd-shim-v2/stream.go
+++ b/src/runtime/containerd-shim-v2/stream.go
@@ -87,7 +87,6 @@ func newTtyIO(ctx context.Context, stdin, stdout, stderr string, console bool) (
 
 func ioCopy(exitch, stdinCloser chan struct{}, tty *ttyIO, stdinPipe io.WriteCloser, stdoutPipe, stderrPipe io.Reader) {
 	var wg sync.WaitGroup
-	var closeOnce sync.Once
 
 	if tty.Stdin != nil {
 		wg.Add(1)
@@ -109,7 +108,11 @@ func ioCopy(exitch, stdinCloser chan struct{}, tty *ttyIO, stdinPipe io.WriteClo
 			defer bufPool.Put(p)
 			io.CopyBuffer(tty.Stdout, stdoutPipe, *p)
 			wg.Done()
-			closeOnce.Do(tty.close)
+			if tty.Stdin != nil {
+				// close stdin to make the other routine stop
+				tty.Stdin.Close()
+				tty.Stdin = nil
+			}
 		}()
 	}
 
@@ -124,6 +127,6 @@ func ioCopy(exitch, stdinCloser chan struct{}, tty *ttyIO, stdinPipe io.WriteClo
 	}
 
 	wg.Wait()
-	closeOnce.Do(tty.close)
+	tty.close()
 	close(exitch)
 }


### PR DESCRIPTION
Do not close the tty as part of the stdout redirection routine.
The close is already happening a couple lines below, after all routines
have finished.

Fixes #1713

Signed-off-by: Julien Ropé <jrope@redhat.com>