### PR TITLE
agent: use channel instead of pipe(2) to send exit signal of process

### DIFF
--- a/src/agent/src/signal.rs
+++ b/src/agent/src/signal.rs
@@ -55,13 +55,6 @@ async fn handle_sigchild(logger: Logger, sandbox: Arc<Mutex<Sandbox>>) -> Result
             }
 
             let mut p = process.unwrap();
-
-            if p.exit_pipe_w.is_none() {
-                info!(logger, "process exit pipe not set");
-                continue;
-            }
-
-            let pipe_write = p.exit_pipe_w.unwrap();
             let ret: i32;
 
             match wait_status {
@@ -75,7 +68,7 @@ async fn handle_sigchild(logger: Logger, sandbox: Arc<Mutex<Sandbox>>) -> Result
             }
 
             p.exit_code = ret;
-            let _ = unistd::close(pipe_write);
+            let _ = p.exit_tx.take();
 
             info!(logger, "notify term to close");
             // close the socket file to notify readStdio to close terminal specifically


### PR DESCRIPTION
The situation is not a IPC scene, pipe(2) is too heavy.
    
We have `tokio::sync::watch::channel` after tokio has been introduced.
The channel has better performance and easy to use.
    
Signed-off-by: Tim Zhang <tim@hyper.sh>