### PR TITLE
clh: return error if apiSocketPath failed

### DIFF
--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -36,7 +36,7 @@ func newClhConfig() (HypervisorConfig, error) {
 	}
 
 	if testVirtiofsdPath == "" {
-		return HypervisorConfig{}, errors.New("hypervisor fake path is empty")
+		return HypervisorConfig{}, errors.New("virtiofsd fake path is empty")
 	}
 
 	if _, err := os.Stat(testClhPath); os.IsNotExist(err) {


### PR DESCRIPTION
If apiSocketPath failed, should return the error, but not nil

Fixes: #1724

Signed-off-by: bin <bin@hyper.sh>