### PR TITLE
kata-deploy: add tolerations so it will install on a tainted master

### DIFF
--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -14,6 +14,11 @@ spec:
           name: kata-deploy
     spec:
       serviceAccountName: kata-label-node
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Equal"
+          value: ""
+          effect: "NoSchedule"
       containers:
       - name: kube-kata
         image: katadocker/kata-deploy:2.1.0-alpha2


### PR DESCRIPTION
If the master node is set to noSchedule then kata-deploy won't
install kata artifacts to the master node. If another pod
requests a kata runtimeclass and sets tolerations so that
it can/will schedule on master then the pod will fail. This
happened when a Kata webhook was installed into the cluster
and an nfd master pod tried to schedule on master, got mutated
to run kata, but failed to start. This patch will ensure
that the master node gets Kata artifacts installed to it
so that a pod could run if it requests a Kata runtime
and explicitely states it wants to run on master.

Fixes: #1741

Signed-off-by: Eric Adams <eric.adams@intel.com>