### PR TITLE
runtime/virtcontainers: Fix typo on qmp error msg

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -116,7 +116,7 @@ const (
 	// memory dump format will be set to elf
 	memoryDumpFormat = "elf"
 
-	qmpCapErrMsg  = "Failed to negoatiate QMP capabilities"
+	qmpCapErrMsg  = "Failed to negotiate QMP capabilities"
 	qmpExecCatCmd = "exec:cat"
 
 	scsiControllerID         = "scsi0"


### PR DESCRIPTION
"negotiate" was misspelled on qemu's qmp error message.

Fixes #1764
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>