### PR TITLE
qemu: kill virtiofsd if failure to start VMM

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -692,6 +692,28 @@ func (q *qemu) setupVirtiofsd() (err error) {
 	return err
 }
 
+func (q *qemu) stopVirtiofsd() (err error) {
+
+	// kill virtiofsd
+	if q.state.VirtiofsdPid == 0 {
+		return errors.New("invalid virtiofsd PID(0)")
+	}
+
+	err = syscall.Kill(q.state.VirtiofsdPid, syscall.SIGKILL)
+	if err != nil {
+		return err
+	}
+	q.state.VirtiofsdPid = 0
+
+	// remove virtiofsd socket
+	sockPath, err := q.vhostFSSocketPath(q.id)
+	if err != nil {
+		return err
+	}
+
+	return os.Remove(sockPath)
+}
+
 func (q *qemu) getMemArgs() (bool, string, string, error) {
 	share := false
 	target := ""
@@ -813,6 +835,14 @@ func (q *qemu) startSandbox(timeout int) error {
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if err != nil {
+				if shutdownErr := q.stopVirtiofsd(); shutdownErr != nil {
+					q.Logger().WithError(shutdownErr).Warn("failed to stop virtiofsd")
+				}
+			}
+		}()
+
 	}
 
 	var strErr string
@@ -824,7 +854,6 @@ func (q *qemu) startSandbox(timeout int) error {
 				strErr += string(b)
 			}
 		}
-
 		q.Logger().WithError(err).Errorf("failed to launch qemu: %s", strErr)
 		return fmt.Errorf("failed to launch qemu: %s, error messages from qemu log: %s", err, strErr)
 	}


### PR DESCRIPTION
If the QEMU VMM fails to launch, we currently fail to kill virtiofsd,
resulting in leftover processes running on the host. Let's make sure we
kill these, and explicitly cleanup the virtiofs socket on the
filesystem.

Ideally we'll migrate QEMU to utilize the same virtiofsd interface that
CLH uses, but let's fix this bug as a first step.

Fixes: #1755

Signed-off-by: Eric Ernst <eric_ernst@apple.com>