### PR TITLE
virtcontainers: Add support for Secure Execution

### DIFF
--- a/src/runtime/virtcontainers/hypervisor_s390x.go
+++ b/src/runtime/virtcontainers/hypervisor_s390x.go
@@ -1,0 +1,99 @@
+// Copyright (c) IBM Corp. 2021
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package virtcontainers
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+const (
+	// This is valid in other architectures, but varcheck will complain
+	// when setting it in common code as it will be regarded unused
+	procKernelCmdline = "/proc/cmdline"
+
+	// Secure Execution
+	// https://www.kernel.org/doc/html/latest/virt/kvm/s390-pv.html
+	seCPUFacilityBit = 158
+	seCmdlineParam   = "prot_virt"
+)
+
+var seCmdlineValues = []string{
+	"1", "on", "y", "yes",
+}
+
+// CPUFacilities retrieves active CPU facilities according to "Facility Indications", Principles of Operation.
+// Takes cpuinfo path (such as /proc/cpuinfo), returns map of all active facility bits.
+func CPUFacilities(cpuInfoPath string) (map[int]bool, error) {
+	facilitiesField := "facilities"
+
+	f, err := os.Open(cpuInfoPath)
+	if err != nil {
+		return map[int]bool{}, err
+	}
+	defer f.Close()
+
+	facilities := make(map[int]bool)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		// Expected format: ["facilities", ":", ...] or ["facilities:", ...]
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 {
+			continue
+		}
+
+		if !strings.HasPrefix(fields[0], facilitiesField) {
+			continue
+		}
+
+		start := 1
+		if fields[1] == ":" {
+			start = 2
+		}
+		for _, field := range fields[start:] {
+			bit, err := strconv.Atoi(field)
+			if err != nil {
+				return map[int]bool{}, err
+			}
+			facilities[bit] = true
+		}
+
+		return facilities, nil
+	}
+
+	if err := scanner.Err(); err != nil {
+		return map[int]bool{}, err
+	}
+
+	return map[int]bool{}, fmt.Errorf("Couldn't find %q from %q output", facilitiesField, cpuInfoPath)
+}
+
+// availableGuestProtection returns seProtection (Secure Execution) if available.
+// Checks that Secure Execution is available (CPU facilities) and enabled (kernel command line).
+func availableGuestProtection() (guestProtection, error) {
+	facilities, err := CPUFacilities(procCPUInfo)
+	if err != nil {
+		return noneProtection, err
+	}
+	if !facilities[seCPUFacilityBit] {
+		return noneProtection, fmt.Errorf("This CPU does not support Secure Execution")
+	}
+
+	seCmdlinePresent, err := CheckCmdline(procKernelCmdline, seCmdlineParam, seCmdlineValues)
+	if err != nil {
+		return noneProtection, err
+	}
+	if !seCmdlinePresent {
+		return noneProtection, fmt.Errorf("Protected Virtualization is not enabled on kernel command line! " +
+			"Need %s=%s (or %s) to enable Secure Execution",
+			seCmdlineParam, seCmdlineValues[0], strings.Join(seCmdlineValues[1:], ", "))
+	}
+
+	return seProtection, nil
+}

--- a/src/runtime/virtcontainers/hypervisor_s390x_test.go
+++ b/src/runtime/virtcontainers/hypervisor_s390x_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) IBM Corp. 2021
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package virtcontainers
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCPUFacilities(t *testing.T) {
+	assert := assert.New(t)
+
+	facilities, err := CPUFacilities(procCPUInfo)
+	assert.NoError(err)
+
+	// z/Architecture facility should always be active (introduced in 2000)
+	assert.Equal(facilities[1], true)
+	// facility bits should not be as high as MaxInt
+	assert.Equal(facilities[math.MaxInt64], false)
+}

--- a/src/runtime/virtcontainers/hypervisor_test.go
+++ b/src/runtime/virtcontainers/hypervisor_test.go
@@ -401,6 +401,21 @@ func TestGetHostMemorySizeKb(t *testing.T) {
 	}
 }
 
+func TestCheckCmdline(t *testing.T) {
+	assert := assert.New(t)
+
+	cmdlineFp, err := ioutil.TempFile("", "")
+	assert.NoError(err)
+	_, err = cmdlineFp.WriteString("quiet root=/dev/sda2")
+	assert.NoError(err)
+	cmdlinePath := cmdlineFp.Name()
+	defer os.Remove(cmdlinePath)
+
+	assert.True(CheckCmdline(cmdlinePath, "quiet", []string{}))
+	assert.True(CheckCmdline(cmdlinePath, "root", []string{"/dev/sda1", "/dev/sda2"}))
+	assert.False(CheckCmdline(cmdlinePath, "ro", []string{}))
+}
+
 // nolint: unused, deadcode
 type testNestedVMMData struct {
 	content     []byte

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -299,6 +299,12 @@ func TestQemuAmd64AppendProtectionDevice(t *testing.T) {
 	assert.Error(err)
 	assert.Empty(bios)
 
+	// Secure Execution protection
+	amd64.(*qemuAmd64).protection = seProtection
+	devices, bios, err = amd64.appendProtectionDevice(devices, firmware)
+	assert.Error(err)
+	assert.Empty(bios)
+
 	// sev protection
 	// TODO: update once it's supported
 	amd64.(*qemuAmd64).protection = sevProtection

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -168,6 +168,10 @@ const (
 	// IBM POWER 9 Protected Execution Facility
 	// https://www.kernel.org/doc/html/latest/powerpc/ultravisor.html
 	pefProtection
+
+	// IBM Secure Execution (IBM Z & LinuxONE)
+	// https://www.kernel.org/doc/html/latest/virt/kvm/s390-pv.html
+	seProtection
 )
 
 type qemuArchBase struct {

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/device/config"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
+	"github.com/sirupsen/logrus"
 )
 
 type qemuS390x struct {
@@ -27,6 +28,11 @@ const (
 	defaultQemuMachineOptions = "accel=kvm"
 	virtioSerialCCW           = "virtio-serial-ccw"
 	qmpMigrationWaitTimeout   = 5 * time.Second
+	logSubsystem              = "qemuS390x"
+
+	// Secure Execution, also known as Protected Virtualization
+	// https://qemu.readthedocs.io/en/latest/system/s390x/protvirt.html
+	secExecID = "pv0"
 )
 
 // Verify needed parameters
@@ -71,6 +77,12 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 	}
 	// Set first bridge type to CCW
 	q.Bridges = append(q.Bridges, ccwbridge)
+
+	if config.ConfidentialGuest {
+		if err := q.enableProtection(); err != nil {
+			return nil, err
+		}
+	}
 
 	if config.ImagePath != "" {
 		q.kernelParams = append(q.kernelParams, commonVirtioblkKernelRootParams...)
@@ -300,4 +312,43 @@ func (q *qemuS390x) addDeviceToBridge(ctx context.Context, ID string, t types.Ty
 	}
 
 	return fmt.Sprintf("%04x", addr), b, nil
+}
+
+// enableProtection enables guest protection for QEMU's machine option.
+func (q *qemuS390x) enableProtection() error {
+	protection, err := availableGuestProtection()
+	if err != nil {
+		return err
+	}
+	if protection != seProtection {
+		return fmt.Errorf("Got unexpected protection %v, only seProtection (Secure Execution) is supported", protection)
+	}
+
+	q.protection = protection
+	if q.qemuMachine.Options != "" {
+		q.qemuMachine.Options += ","
+	}
+	q.qemuMachine.Options += fmt.Sprintf("confidential-guest-support=%s", secExecID)
+	virtLog.WithFields(logrus.Fields{
+		"subsystem": logSubsystem,
+		"machine":   q.qemuMachine}).
+		Info("Enabling guest protection with Secure Execution")
+	return nil
+}
+
+// appendProtectionDevice appends a QEMU object for Secure Execution.
+// Takes devices and returns updated version. Takes BIOS and returns it (no modification on s390x).
+func (q *qemuS390x) appendProtectionDevice(devices []govmmQemu.Device, firmware string) ([]govmmQemu.Device, string, error) {
+	switch q.protection {
+	case seProtection:
+		return append(devices,
+			govmmQemu.Object{
+				Type: govmmQemu.SecExecGuest,
+				ID:   secExecID,
+			}), firmware, nil
+	case noneProtection:
+		return devices, firmware, nil
+	default:
+		return devices, firmware, fmt.Errorf("Unsupported guest protection technology: %v", q.protection)
+	}
 }

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -21,15 +21,13 @@ type qemuS390x struct {
 	qemuArchBase
 }
 
-const defaultQemuPath = "/usr/bin/qemu-system-s390x"
-
-const defaultQemuMachineType = QemuCCWVirtio
-
-const defaultQemuMachineOptions = "accel=kvm"
-
-const virtioSerialCCW = "virtio-serial-ccw"
-
-const qmpMigrationWaitTimeout = 5 * time.Second
+const (
+	defaultQemuPath           = "/usr/bin/qemu-system-s390x"
+	defaultQemuMachineType    = QemuCCWVirtio
+	defaultQemuMachineOptions = "accel=kvm"
+	virtioSerialCCW           = "virtio-serial-ccw"
+	qmpMigrationWaitTimeout   = 5 * time.Second
+)
 
 // Verify needed parameters
 var kernelParams = []Param{


### PR DESCRIPTION
Secure Execution is a confidential computing technology on s390x (IBM Z
& LinuxONE). Enable the correspondent virtualization technology in QEMU
(where it is referred to as "Protected Virtualization").

- Introduce enableProtection and appendProtectionDevice functions for
  s390x.
- Introduce CheckCmdline to check for `prot_virt=1` being present on the
  kernel command line.
- Introduce CPUFacilities for s390x to check for CPU support.

Also put consts in one block in `virtcontainers/qemu_s390x.go`.

Fixes: #1771
No backport required.
Depends-on: https://github.com/kata-containers/govmm/pull/173 and https://github.com/kata-containers/kata-containers/pull/1590 -- should be revendored/rebased accordingly, which would shrink this PR by those commits.
One question: This uses features that are currently not in the ~latest~ release of QEMU, v5.2.0, which we are also packaging. (e: QEMU 6 is live) Is there a way to ask for qemu-experimental (see also #1692)?

/cc @sameo @hbrueckner @MIHAJLOV @borntraeger @magowan @jimcadden @fitzthum