### PR TITLE
runtime: Test revendor GoVMM for Secure Execution [do not merge]

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -63,6 +63,7 @@ require (
 )
 
 replace (
+	github.com/kata-containers/govmm => github.com/Jakob-Naucke/govmm v0.0.0-20210520084539-03b55ea51dca
 	github.com/uber-go/atomic => go.uber.org/atomic v1.5.1
 	google.golang.org/genproto => google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 	google.golang.org/grpc => google.golang.org/grpc v1.19.0

--- a/src/runtime/go.sum
+++ b/src/runtime/go.sum
@@ -36,6 +36,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/sketches-go v0.0.1/go.mod h1:Q5DbzQ+3AkgGwymQO7aZFNP7ns2lZKGtvRBzRXfdi60=
+github.com/Jakob-Naucke/govmm v0.0.0-20210520084539-03b55ea51dca h1:e41bxDOfWwToAo3TOlWNZmGiGCqdPkotM04BtlZIaps=
+github.com/Jakob-Naucke/govmm v0.0.0-20210520084539-03b55ea51dca/go.mod h1:+fllL1p0wrIe9+h005LrxipimP6ODYALjVbWMzWCRnU=
 github.com/Microsoft/go-winio v0.4.11 h1:zoIOcVf0xPN1tnMVbTtEdI+P8OofVk3NObnwOQ6nK2Q=
 github.com/Microsoft/go-winio v0.4.11/go.mod h1:VhR8bwka0BXejwEJY73c50VrPtXAaKcyvVC4A4RozmA=
 github.com/Microsoft/hcsshim v0.8.6 h1:ZfF0+zZeYdzMIVMZHKtDKJvLHj76XCuVae/jNkjj0IA=

--- a/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
+++ b/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
@@ -230,6 +230,12 @@ const (
 
 	// TDXGuest represents a TDX object
 	TDXGuest ObjectType = "tdx-guest"
+
+	// SEVGuest represents an SEV guest object
+	SEVGuest ObjectType = "sev-guest"
+
+	// SecExecGuest represents an s390x Secure Execution (Protected Virtualization in QEMU) object
+	SecExecGuest ObjectType = "s390-pv-guest"
 )
 
 // Object is a qemu object representation.
@@ -258,36 +264,38 @@ type Object struct {
 
 	// File is the device file
 	File string
+
+	// CBitPos is the location of the C-bit in a guest page table entry
+	// This is only relevant for sev-guest objects
+	CBitPos uint32
+
+	// ReducedPhysBits is the reduction in the guest physical address space
+	// This is only relevant for sev-guest objects
+	ReducedPhysBits uint32
 }
 
 // Valid returns true if the Object structure is valid and complete.
 func (object Object) Valid() bool {
 	switch object.Type {
 	case MemoryBackendFile:
-		if object.ID == "" || object.MemPath == "" || object.Size == 0 {
-			return false
-		}
-
+		return object.ID != "" && object.MemPath != "" && object.Size != 0
 	case TDXGuest:
-		if object.ID == "" || object.File == "" || object.DeviceID == "" {
-			return false
-		}
-
+		return object.ID != "" && object.File != "" && object.DeviceID != ""
+	case SEVGuest:
+		return object.ID != "" && object.File != "" && object.CBitPos != 0 && object.ReducedPhysBits != 0
+	case SecExecGuest:
+		return object.ID != ""
 	default:
 		return false
 	}
-
-	return true
 }
 
 // QemuParams returns the qemu parameters built out of this Object device.
 func (object Object) QemuParams(config *Config) []string {
 	var objectParams []string
 	var deviceParams []string
+	var driveParams []string
 	var qemuParams []string
-
-	deviceParams = append(deviceParams, string(object.Driver))
-	deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", object.DeviceID))
 
 	switch object.Type {
 	case MemoryBackendFile:
@@ -296,6 +304,8 @@ func (object Object) QemuParams(config *Config) []string {
 		objectParams = append(objectParams, fmt.Sprintf(",mem-path=%s", object.MemPath))
 		objectParams = append(objectParams, fmt.Sprintf(",size=%d", object.Size))
 
+		deviceParams = append(deviceParams, string(object.Driver))
+		deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", object.DeviceID))
 		deviceParams = append(deviceParams, fmt.Sprintf(",memdev=%s", object.ID))
 	case TDXGuest:
 		objectParams = append(objectParams, string(object.Type))
@@ -303,14 +313,36 @@ func (object Object) QemuParams(config *Config) []string {
 		if object.Debug {
 			objectParams = append(objectParams, ",debug=on")
 		}
+		deviceParams = append(deviceParams, string(object.Driver))
+		deviceParams = append(deviceParams, fmt.Sprintf(",id=%s", object.DeviceID))
 		deviceParams = append(deviceParams, fmt.Sprintf(",file=%s", object.File))
+	case SEVGuest:
+		objectParams = append(objectParams, string(object.Type))
+		objectParams = append(objectParams, fmt.Sprintf(",id=%s", object.ID))
+		objectParams = append(objectParams, fmt.Sprintf(",cbitpos=%d", object.CBitPos))
+		objectParams = append(objectParams, fmt.Sprintf(",reduced-phys-bits=%d", object.ReducedPhysBits))
+
+		driveParams = append(driveParams, "if=pflash,format=raw,readonly=on")
+		driveParams = append(driveParams, fmt.Sprintf(",file=%s", object.File))
+	case SecExecGuest:
+		objectParams = append(objectParams, string(object.Type))
+		objectParams = append(objectParams, fmt.Sprintf(",id=%s", object.ID))
 	}
 
-	qemuParams = append(qemuParams, "-device")
-	qemuParams = append(qemuParams, strings.Join(deviceParams, ""))
+	if len(deviceParams) > 0 {
+		qemuParams = append(qemuParams, "-device")
+		qemuParams = append(qemuParams, strings.Join(deviceParams, ""))
+	}
 
-	qemuParams = append(qemuParams, "-object")
-	qemuParams = append(qemuParams, strings.Join(objectParams, ""))
+	if len(objectParams) > 0 {
+		qemuParams = append(qemuParams, "-object")
+		qemuParams = append(qemuParams, strings.Join(objectParams, ""))
+	}
+
+	if len(driveParams) > 0 {
+		qemuParams = append(qemuParams, "-drive")
+		qemuParams = append(qemuParams, strings.Join(driveParams, ""))
+	}
 
 	return qemuParams
 }

--- a/src/runtime/vendor/modules.txt
+++ b/src/runtime/vendor/modules.txt
@@ -222,7 +222,7 @@ github.com/hashicorp/errwrap
 # github.com/hashicorp/go-multierror v1.0.0
 ## explicit
 github.com/hashicorp/go-multierror
-# github.com/kata-containers/govmm v0.0.0-20210428163604-f0e9a35308ee
+# github.com/kata-containers/govmm v0.0.0-20210428163604-f0e9a35308ee => github.com/Jakob-Naucke/govmm v0.0.0-20210520084539-03b55ea51dca
 ## explicit
 github.com/kata-containers/govmm/qemu
 # github.com/konsorten/go-windows-terminal-sequences v1.0.1
@@ -462,6 +462,7 @@ gopkg.in/yaml.v3
 # k8s.io/apimachinery v0.18.2
 ## explicit
 k8s.io/apimachinery/pkg/api/resource
+# github.com/kata-containers/govmm => github.com/Jakob-Naucke/govmm v0.0.0-20210520084539-03b55ea51dca
 # github.com/uber-go/atomic => go.uber.org/atomic v1.5.1
 # google.golang.org/genproto => google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
 # google.golang.org/grpc => google.golang.org/grpc v1.19.0


### PR DESCRIPTION
for Secure Execution support. Just for testing, do not merge.

shortlog:
1951250 qemu: Add support for Secure Execution
2660614 qemu: Simplify (Object).Valid()
59782a0 qemu: add support for SevGuest object
7183b12 Merge pull request #166 from kata-containers/egernst-patch-1
092293f Merge pull request #169 from QiuMike/master
511cf58 Fix qemu commandline issue with empty romfile
8ba62b0 Merge pull request #164 from devimc/2021-03-30/tdxSupport
b3eac95 qmp: remove frequent, chatty log
3141894 qemu: add support for tdx-guest object

Fixes: #1771 (theoretically)
no backport required

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>