### PR TITLE
Set fixed NOFILE limit value for kata-agent

### DIFF
--- a/src/agent/kata-agent.service.in
+++ b/src/agent/kata-agent.service.in
@@ -15,7 +15,7 @@ Wants=kata-containers.target
 StandardOutput=tty
 Type=simple
 ExecStart=@BINDIR@/@AGENT_NAME@
-LimitNOFILE=infinity
+LimitNOFILE=1048576
 # ExecStop is required for static agent tracing; in all other scenarios
 # the runtime handles shutting down the VM.
 ExecStop=/bin/sync ; /usr/bin/systemctl --force poweroff


### PR DESCRIPTION
Some applications may fail if NOFILE limit is set to unlimited.
Although in some environments this value is explicitly overridden,
lets set it to a more sane value in case it doesn't.

This value (2^20) has been chosen as it seems to be commonly used (e.g. crio daemon) and also:
https://stackoverflow.com/questions/1212925/on-linux-set-maximum-open-files-to-unlimited-possible/1213069#1213069

Fixes: https://github.com/kata-containers/kata-containers/issues/1715
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>