### PR TITLE
[backport] versions: Upgrade to cloud-hypervisor v15.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -525,6 +525,15 @@ components:
             vhost_user: false
             ip: 192.168.249.1
             id: id
+            rate_limiter_config:
+              ops:
+                size: 0
+                one_time_burst: 0
+                refill_time: 0
+              bandwidth:
+                size: 0
+                one_time_burst: 0
+                refill_time: 0
             mac: mac
             fd:
             - 8
@@ -538,6 +547,15 @@ components:
             vhost_user: false
             ip: 192.168.249.1
             id: id
+            rate_limiter_config:
+              ops:
+                size: 0
+                one_time_burst: 0
+                refill_time: 0
+              bandwidth:
+                size: 0
+                one_time_burst: 0
+                refill_time: 0
             mac: mac
             fd:
             - 8
@@ -801,6 +819,15 @@ components:
           vhost_user: false
           ip: 192.168.249.1
           id: id
+          rate_limiter_config:
+            ops:
+              size: 0
+              one_time_burst: 0
+              refill_time: 0
+            bandwidth:
+              size: 0
+              one_time_burst: 0
+              refill_time: 0
           mac: mac
           fd:
           - 8
@@ -814,6 +841,15 @@ components:
           vhost_user: false
           ip: 192.168.249.1
           id: id
+          rate_limiter_config:
+            ops:
+              size: 0
+              one_time_burst: 0
+              refill_time: 0
+            bandwidth:
+              size: 0
+              one_time_burst: 0
+              refill_time: 0
           mac: mac
           fd:
           - 8
@@ -1172,6 +1208,15 @@ components:
         vhost_user: false
         ip: 192.168.249.1
         id: id
+        rate_limiter_config:
+          ops:
+            size: 0
+            one_time_burst: 0
+            refill_time: 0
+          bandwidth:
+            size: 0
+            one_time_burst: 0
+            refill_time: 0
         mac: mac
         fd:
         - 8
@@ -1210,6 +1255,8 @@ components:
             format: int32
             type: integer
           type: array
+        rate_limiter_config:
+          $ref: '#/components/schemas/RateLimiterConfig'
       type: object
     RngConfig:
       example:

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **VhostSocket** | **string** |  | [optional] 
 **Id** | **string** |  | [optional] 
 **Fd** | **[]int32** |  | [optional] 
+**RateLimiterConfig** | [**RateLimiterConfig**](RateLimiterConfig.md) |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
@@ -11,15 +11,16 @@ package openapi
 
 // NetConfig struct for NetConfig
 type NetConfig struct {
-	Tap         string  `json:"tap,omitempty"`
-	Ip          string  `json:"ip,omitempty"`
-	Mask        string  `json:"mask,omitempty"`
-	Mac         string  `json:"mac,omitempty"`
-	Iommu       bool    `json:"iommu,omitempty"`
-	NumQueues   int32   `json:"num_queues,omitempty"`
-	QueueSize   int32   `json:"queue_size,omitempty"`
-	VhostUser   bool    `json:"vhost_user,omitempty"`
-	VhostSocket string  `json:"vhost_socket,omitempty"`
-	Id          string  `json:"id,omitempty"`
-	Fd          []int32 `json:"fd,omitempty"`
+	Tap               string            `json:"tap,omitempty"`
+	Ip                string            `json:"ip,omitempty"`
+	Mask              string            `json:"mask,omitempty"`
+	Mac               string            `json:"mac,omitempty"`
+	Iommu             bool              `json:"iommu,omitempty"`
+	NumQueues         int32             `json:"num_queues,omitempty"`
+	QueueSize         int32             `json:"queue_size,omitempty"`
+	VhostUser         bool              `json:"vhost_user,omitempty"`
+	VhostSocket       string            `json:"vhost_socket,omitempty"`
+	Id                string            `json:"id,omitempty"`
+	Fd                []int32           `json:"fd,omitempty"`
+	RateLimiterConfig RateLimiterConfig `json:"rate_limiter_config,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -719,6 +719,8 @@ components:
           items:
             type: integer
             format: int32
+        rate_limiter_config:
+            $ref: '#/components/schemas/RateLimiterConfig'
 
     RngConfig:
       required:

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v0.14.1"
+      version: "v15.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
Quotes from the cloud-hypervisor release v15.0:

This release is the first in a new version numbering scheme to represent that
we believe Cloud Hypervisor is maturing and entering a period of stability.
With this new release we are beginning our new stability guarantees.

Other highlights from the latest release include: 1) Network device rate
limiting; 2) Support for runtime control of `virtio-net` guest offload;
3) `--api-socket` supports file descriptor parameter; 4) Bug fixes on
`virtio-pmem`, PCI BARs alignment, `virtio-net`, etc.; 5) Deprecation of
the "LinuxBoot" protocol for ELF and bzImage in the coming release.

Details can be found: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v15.0

Note: The client code of cloud-hypervisor's OpenAPI is automatically
generated by `openapi-generator` [1-2]. As the API changes do not
impact usages in Kata, no additional changes in kata's runtime are
needed to work with the current version of cloud-hypervisor.

[1] https://github.com/OpenAPITools/openapi-generator
[2] https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/pkg/cloud-hypervisor/README.md

Fixes: #1779

Signed-off-by: Bo Chen <chen.bo@intel.com>
(cherry picked from commit 1ca6bedf3e9e18a4eaf2bcdf0f1bb92c50963709)