### PR TITLE
runtime: make dialing timeout configurable

### DIFF
--- a/src/runtime/cli/config/configuration-acrn.toml.in
+++ b/src/runtime/cli/config/configuration-acrn.toml.in
@@ -150,6 +150,10 @@ block_device_driver = "@DEFBLOCKSTORAGEDRIVER_ACRN@"
 
 #debug_console_enabled = true
 
+# Agent connection dialing timeout value in seconds
+# (default: 30)
+#dial_timeout = 30
+
 [netmon]
 # If enabled, the network monitoring process gets started when the
 # sandbox is created. This allows for the detection of some additional

--- a/src/runtime/cli/config/configuration-clh.toml.in
+++ b/src/runtime/cli/config/configuration-clh.toml.in
@@ -165,6 +165,10 @@ block_device_driver = "virtio-blk"
 
 #debug_console_enabled = true
 
+# Agent connection dialing timeout value in seconds
+# (default: 30)
+#dial_timeout = 30
+
 [netmon]
 # If enabled, the network monitoring process gets started when the
 # sandbox is created. This allows for the detection of some additional

--- a/src/runtime/cli/config/configuration-fc.toml.in
+++ b/src/runtime/cli/config/configuration-fc.toml.in
@@ -287,6 +287,10 @@ kernel_modules=[]
 
 #debug_console_enabled = true
 
+# Agent connection dialing timeout value in seconds
+# (default: 30)
+#dial_timeout = 30
+
 [netmon]
 # If enabled, the network monitoring process gets started when the
 # sandbox is created. This allows for the detection of some additional

--- a/src/runtime/cli/config/configuration-qemu.toml.in
+++ b/src/runtime/cli/config/configuration-qemu.toml.in
@@ -437,6 +437,10 @@ kernel_modules=[]
 
 #debug_console_enabled = true
 
+# Agent connection dialing timeout value in seconds
+# (default: 30)
+#dial_timeout = 30
+
 [netmon]
 # If enabled, the network monitoring process gets started when the
 # sandbox is created. This allows for the detection of some additional

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -154,6 +154,7 @@ type agent struct {
 	Debug               bool     `toml:"enable_debug"`
 	Tracing             bool     `toml:"enable_tracing"`
 	DebugConsoleEnabled bool     `toml:"debug_console_enabled"`
+	DialTimeout         uint32   `toml:"dial_timeout"`
 }
 
 type netmon struct {
@@ -469,6 +470,10 @@ func (h hypervisor) getIOMMUPlatform() bool {
 
 func (a agent) debugConsoleEnabled() bool {
 	return a.DebugConsoleEnabled
+}
+
+func (a agent) dialTimout() uint32 {
+	return a.DialTimeout
 }
 
 func (a agent) debug() bool {
@@ -920,6 +925,7 @@ func updateRuntimeConfigAgent(configPath string, tomlConf tomlConfig, config *oc
 			TraceType:          agent.traceType(),
 			KernelModules:      agent.kernelModules(),
 			EnableDebugConsole: agent.debugConsoleEnabled(),
+			DialTimeout:        agent.dialTimout(),
 		}
 	}
 

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -217,6 +217,7 @@ type KataAgentConfig struct {
 	ContainerPipeSize  uint32
 	TraceMode          string
 	TraceType          string
+	DialTimeout        uint32
 	KernelModules      []string
 }
 
@@ -236,6 +237,7 @@ type kataAgent struct {
 	keepConn       bool
 	dynamicTracing bool
 	dead           bool
+	dialTimout     uint32
 	kmodules       []string
 
 	vmSocket interface{}
@@ -344,6 +346,7 @@ func (k *kataAgent) init(ctx context.Context, sandbox *Sandbox, config KataAgent
 	disableVMShutdown = k.handleTraceSettings(config)
 	k.keepConn = config.LongLiveConn
 	k.kmodules = config.KernelModules
+	k.dialTimout = config.DialTimeout
 
 	return disableVMShutdown, nil
 }
@@ -1794,7 +1797,7 @@ func (k *kataAgent) connect(ctx context.Context) error {
 	}
 
 	k.Logger().WithField("url", k.state.URL).Info("New client")
-	client, err := kataclient.NewAgentClient(k.ctx, k.state.URL)
+	client, err := kataclient.NewAgentClient(k.ctx, k.state.URL, k.dialTimout)
 	if err != nil {
 		k.dead = true
 		return err


### PR DESCRIPTION
allow to set dialing timeout in configuration.toml
default is 30s

Fixes: #1789
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>