### PR TITLE
docs: Remove horizontal ruler markers that disable spell checks

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -28,7 +28,7 @@
 * [Appendices](#appendices)
     * [The constraints challenge](#the-constraints-challenge)
 
----
+***
 
 # Overview
 

--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -94,7 +94,9 @@ This section lists items that might be possible to fix.
 ### checkpoint and restore
 
 The runtime does not provide `checkpoint` and `restore` commands. There
-are discussions about using VM save and restore to give [`criu`](https://github.com/checkpoint-restore/criu)-like functionality, which might provide a solution.
+are discussions about using VM save and restore to give us a
+`[criu](https://github.com/checkpoint-restore/criu)`-like functionality,
+which might provide a solution.
 
 Note that the OCI standard does not specify `checkpoint` and `restore`
 commands.

--- a/tools/packaging/ccloudvm/README.md
+++ b/tools/packaging/ccloudvm/README.md
@@ -2,7 +2,8 @@
 
 * [How to use Kata workloads for `ccloudvm`](#how-to-use-kata-workloads-for-ccloudvm)
     * [Create Docker\* and Kata Containers virtualized environment](#create-docker-and-kata-containers-virtualized-environment)
----
+
+***
 
 The [ccloudvm](https://github.com/intel/ccloudvm/) tool is a command
 to create development and demo environments. The tool sets up these development


### PR DESCRIPTION
There is a bug in the CI script checking spelling that causes it
to skip any text that follows a horizontal ruler.
(https://github.com/kata-containers/tests/issues/3448)

Solution: replace one horizontal ruler marker with another that
does not trip the spell-checking script.

Fixes: #1793

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>