### PR TITLE
packaging/kata-cleanup: add k3s containerd volume

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../base
+
+patchesStrategicMerge:
+- mount_k3s_conf.yaml

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/mount_k3s_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/mount_k3s_conf.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubelet-kata-cleanup
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-kata-cleanup
+        volumeMounts:
+        - name: containerd-conf
+          mountPath: /etc/containerd/
+      volumes:
+        - name: containerd-conf
+          hostPath:
+            path: /var/lib/rancher/k3s/agent/etc/containerd/


### PR DESCRIPTION
kata-deploy cleanup expects to find containerd configuration
in /etc/containerd/config.toml. In case of k3s mount the k3s
containerd config as a volume.

Original PR #1802

Fixes #1801

Signed-off-by: Orestis Lagkas Nikolos <olagkasn@nubificus.co.uk>