### PR TITLE
runtime: use s.ctx instead ctx for checking cancellation

### DIFF
--- a/src/runtime/containerd-shim-v2/wait.go
+++ b/src/runtime/containerd-shim-v2/wait.go
@@ -142,7 +142,7 @@ func watchOOMEvents(ctx context.Context, s *service) {
 
 	for {
 		select {
-		case <-ctx.Done():
+		case <-s.ctx.Done():
 			return
 		default:
 			containerID, err := s.sandbox.GetOOMEvent(ctx)


### PR DESCRIPTION
s.ctx should be used for checking cancellation, and the
local ctx is used for tracing.

Fixes: #1804

Signed-off-by: bin <bin@hyper.sh>