### PR TITLE
CI: Call agent shutdown test

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -13,4 +13,5 @@ clone_tests_repo
 
 pushd ${tests_repo_dir}
 .ci/run.sh
+tracing/test-agent-shutdown.sh
 popd


### PR DESCRIPTION
Run the agent shutdown test as part of CI testing code in this repo.

Fixes: #1808.

Depends-on:github.com/kata-containers/tests#3495

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>