### PR TITLE
osbuilder: Upgrade alpine version to 3.13.5

### DIFF
--- a/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG IMAGE_REGISTRY=docker.io
-FROM ${IMAGE_REGISTRY}/alpine:3.11.6
+FROM ${IMAGE_REGISTRY}/alpine:3.13.5
 
 RUN apk update && apk add \
 		  bash \

--- a/versions.yaml
+++ b/versions.yaml
@@ -139,7 +139,7 @@ assets:
     architecture:
       aarch64:
         name: &default-initrd-name "alpine"
-        version: &default-initrd-version "3.12"
+        version: &default-initrd-version "3.13.5"
       ppc64le:
         name: *default-initrd-name
         version: *default-initrd-version


### PR DESCRIPTION
We are using an older version of alpine, so upgrade to latest 3.13.5.

Fixes #1817

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>