### PR TITLE
back port: image_build: align image size to 128M for arm64

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -63,11 +63,8 @@ readonly -a systemd_files=(
 # Set a default value
 AGENT_INIT=${AGENT_INIT:-no}
 
-# Align image to (size in MB) according to different architecture.
-case "$(uname -m)" in
-	aarch64) readonly mem_boundary_mb=16 ;;
-	*) readonly mem_boundary_mb=128 ;;
-esac
+# Align image to 128M
+readonly mem_boundary_mb=128
 
 # shellcheck source=../scripts/lib.sh
 source "${lib_file}"


### PR DESCRIPTION
There is an inconformity between qemu and kernel of memory alignment
check in memory hotplug. Both of qemu and kernel will do the start
address alignment check in memory hotplug. But it's 2M in qemu
while 128M in kernel. It leads to an issue when memory hotplug.

Currently, the kata image is a nvdimm device, which will plug into the VM as
a dimm. If another dimm is pluged, it will reside on top of that nvdimm.
So, the start address of the second dimm may not pass the alginment
check in kernel if the nvdimm size doesn't align with 128M.

There are 3 ways to address this issue I think:
1. fix the alignment size in kernel according to qemu. I think people
in linux kernel community will not accept it.
2. do alignment check in qemu and force the start address of hotplug
in alignment with 128M, which means there maybe holes between memory blocks.
3. obey the rule in user end, which means fix it in kata.

I think the second one is the best, but I can't do that for some reason.
Thus, the last one is the choice here.

Fixes: #1769
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>

back port [#1770 ](https://github.com/kata-containers/kata-containers/pull/1770#issuecomment-839836291)

@GabyCT  @fidencio 