### PR TITLE
github: Do not run require porting labels on stable-2.1

### DIFF
--- a/.github/workflows/require-pr-porting-labels.yaml
+++ b/.github/workflows/require-pr-porting-labels.yaml
@@ -6,6 +6,9 @@
 name: Ensure PR has required porting labels
 
 on:
+  pull_request:
+    branches:
+      - main
   pull_request_target:
     types:
       - opened


### PR DESCRIPTION
When we are creating a PR in stable-2.1 we do not need to run
the github action of porting labels as we are doing backports or
new releases in stable-2.1 and it is unnecessary to put labels
like no-backport-needed or no-forwardport-needed, etc.

Fixes #1847

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>