### PR TITLE
versions: Update kubernetes to 1.21.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -203,7 +203,7 @@ externals:
     uscan-url: >-
       https://github.com/kubernetes/kubernetes/tags
       .*/v?([\d\.]+)\.tar\.gz
-    version: "1.21.0-00"
+    version: "1.21.1-00"
 
   runc:
     description: "OCI CLI reference runtime implementation"


### PR DESCRIPTION
The reason for doing such is to (try to) avoid random crashes we've been
facing as part of our CI, such as the one reported as part of
https://github.com/kata-containers/tests/issues/3473

Fixes: #1850

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>