### PR TITLE
stable-2.1 | The last round of backports before releasing 2.1.0

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -28,7 +28,7 @@
 * [Appendices](#appendices)
     * [The constraints challenge](#the-constraints-challenge)
 
----
+***
 
 # Overview
 

--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -94,7 +94,9 @@ This section lists items that might be possible to fix.
 ### checkpoint and restore
 
 The runtime does not provide `checkpoint` and `restore` commands. There
-are discussions about using VM save and restore to give [`criu`](https://github.com/checkpoint-restore/criu)-like functionality, which might provide a solution.
+are discussions about using VM save and restore to give us a
+`[criu](https://github.com/checkpoint-restore/criu)`-like functionality,
+which might provide a solution.
 
 Note that the OCI standard does not specify `checkpoint` and `restore`
 commands.

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -686,13 +686,13 @@ func (s *Sandbox) Delete(ctx context.Context) error {
 
 	for _, c := range s.containers {
 		if err := c.delete(ctx); err != nil {
-			return err
+			s.Logger().WithError(err).WithField("cid", c.id).Debug("failed to delete container")
 		}
 	}
 
 	if !rootless.IsRootless() {
 		if err := s.cgroupsDelete(); err != nil {
-			return err
+			s.Logger().WithError(err).Error("failed to cleanup cgroups")
 		}
 	}
 

--- a/tools/packaging/ccloudvm/README.md
+++ b/tools/packaging/ccloudvm/README.md
@@ -2,7 +2,8 @@
 
 * [How to use Kata workloads for `ccloudvm`](#how-to-use-kata-workloads-for-ccloudvm)
     * [Create Docker\* and Kata Containers virtualized environment](#create-docker-and-kata-containers-virtualized-environment)
----
+
+***
 
 The [ccloudvm](https://github.com/intel/ccloudvm/) tool is a command
 to create development and demo environments. The tool sets up these development


### PR DESCRIPTION
Folks, this is the last round of backports before getting 2.1.0 out, and it includes:

* Two backports related to our spell checker, and I think it's better to backport then now than when we randomly hit some spell checker issue (as happened in the past).
42425456e7dd885360945ed4d508397d9a00d102 docs: Remove horizontal ruler markers that disable spell checks
5fdf617e7fe2cb81c1b274b8bc8f2ff96be3566c docs: Fix spell-check errors found after new text is discovered

* A sandbox cleanup issue, that avoids leaving behind orphan containers
35151f178684e799a1e9885dff71fbe28dce712c runtime: sandbox delete should succeed after verifying sandbox state

* An agent fix separating the propagation and mount flags on the rustjail code
e5fe572f51b8a9316c0c4a84ce90cbfc359f5db6 rustjail: separated the propagation flags from mount flags

Please, let me know if you think some of those should not be here.