### PR TITLE
github: Run require porting labels only at main

### DIFF
--- a/.github/workflows/require-pr-porting-labels.yaml
+++ b/.github/workflows/require-pr-porting-labels.yaml
@@ -12,6 +12,9 @@ on:
       - reopened
       - labeled
       - unlabeled
+   pull_request:
+     branches:
+      - main
 
 jobs:
   check-pr-porting-labels:


### PR DESCRIPTION
This PR modifies that require porting labels only run at main.

Fixes #1857

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>