### PR TITLE
docs: Update the stable branch strategy to what was proposed in our ML

### DIFF
--- a/docs/Stable-Branch-Strategy.md
+++ b/docs/Stable-Branch-Strategy.md
@@ -32,7 +32,7 @@ provides additional information regarding release `99.123.77` in the previous ex
   changing the existing behavior*.
 
 - When `MAJOR` increases, the new release adds **new features, bug fixes, or
-  both** and which *changes the behavior from the previous release* (incompatible with previous releases).
+  both** and which **changes the behavior from the previous release** (incompatible with previous releases).
 
   A major release will also likely require a change of the container manager version used, 
 for example Docker\*. Please refer to the release notes for further details.

--- a/docs/Stable-Branch-Strategy.md
+++ b/docs/Stable-Branch-Strategy.md
@@ -35,7 +35,7 @@ provides additional information regarding release `99.123.77` in the previous ex
   both** and which **changes the behavior from the previous release** (incompatible with previous releases).
 
   A major release will also likely require a change of the container manager version used, 
-for example Docker\*. Please refer to the release notes for further details.
+for example Containerd or CRI-O. Please refer to the release notes for further details.
 
 ## Release Strategy
 

--- a/docs/Stable-Branch-Strategy.md
+++ b/docs/Stable-Branch-Strategy.md
@@ -41,7 +41,7 @@ for example Docker\*. Please refer to the release notes for further details.
 
 Any new features added since the last release will be available in the next minor
 release. These will include bug fixes as well. To facilitate a stable user environment, 
-Kata provides stable branch-based releases and a master branch release.
+Kata provides stable branch-based releases and a main branch release.
 
 ## Stable branch patch criteria
 
@@ -49,8 +49,8 @@ No new features should be introduced to stable branches.  This is intended to li
 providing only bug and security fixes.
 
 ## Branch Management
-Kata Containers will maintain two stable release branches in addition to the master branch.
-Once a new MAJOR or MINOR release is created from master, a new stable branch is created for
+Kata Containers will maintain two stable release branches in addition to the main branch.
+Once a new MAJOR or MINOR release is created from main, a new stable branch is created for
 the prior MAJOR or MINOR release and the older stable branch is no longer maintained. End of
 maintenance for a branch is announced on the Kata Containers mailing list.  Users can determine
 the version currently installed by running `kata-runtime kata-env`. It is recommended to use the
@@ -61,12 +61,12 @@ A couple of examples follow to help clarify this process.
 ### New bug fix introduced
 
 A bug fix is submitted against the runtime which does not introduce new inter-component dependencies.
-This fix is applied to both the master and stable branches, and there is no need to create a new
+This fix is applied to both the main and stable branches, and there is no need to create a new
 stable branch.
 
 | Branch | Original version | New version |
 |--|--|--|
-| `master` | `1.3.0-rc0` | `1.3.0-rc1` |
+| `main` | `1.3.0-rc0` | `1.3.0-rc1` |
 | `stable-1.2` | `1.2.0` | `1.2.1` |
 | `stable-1.1` | `1.1.2` | `1.1.3` |
 
@@ -74,19 +74,19 @@ stable branch.
 ### New release made feature or change adding new inter-component dependency
 
 A new feature is introduced, which adds a new inter-component dependency. In this case a new stable
-branch is created (stable-1.3) starting from master and the older stable branch (stable-1.1)
+branch is created (stable-1.3) starting from main and the older stable branch (stable-1.1)
 is dropped from maintenance.
 
 
 | Branch | Original version | New version |
 |--|--|--|
-| `master` | `1.3.0-rc1` | `1.3.0` |
+| `main` | `1.3.0-rc1` | `1.3.0` |
 | `stable-1.3` | N/A| `1.3.0` |
 | `stable-1.2` | `1.2.1` | `1.2.2` |
 | `stable-1.1` | `1.1.3` | (unmaintained) |
 
 Note, the stable-1.1 branch will still exist with tag 1.1.3, but under current plans it is
-not maintained further. The next tag applied to master will be 1.4.0-alpha0. We would then
+not maintained further. The next tag applied to main will be 1.4.0-alpha0. We would then
 create a couple of alpha releases gathering features targeted for that particular release (in
 this case 1.4.0), followed by a release candidate. The release candidate marks a feature freeze.
 A new stable branch is created for the release candidate. Only bug fixes and any security issues
@@ -94,26 +94,26 @@ are added to the branch going forward until release 1.4.0 is made.
    
 ## Backporting Process 
 
-Development that occurs against the master branch and applicable code commits should also be submitted
+Development that occurs against the main branch and applicable code commits should also be submitted
 against the stable branches. Some guidelines for this process follow::
   1. Only bug and security fixes which do not introduce inter-component dependencies are
  candidates for stable branches. These PRs should be marked with "bug" in GitHub.
-  2. Once a PR is created against master which meets requirement of (1), a comparable one
+  2. Once a PR is created against main which meets requirement of (1), a comparable one
  should also be submitted against the stable branches. It is the responsibility of the submitter
  to apply their pull request against stable, and it is the responsibility of the
  reviewers to help identify stable-candidate pull requests.
  
 ## Continuous Integration Testing
 
-The test repository is forked to create stable branches from master. Full CI
-runs on each stable and master PR using its respective tests repository branch.
+The test repository is forked to create stable branches from main. Full CI
+runs on each stable and main PR using its respective tests repository branch.
 
 ### An alternative method for CI testing:
 
-Ideally, the continuous integration infrastructure will run the same test suite on both master
+Ideally, the continuous integration infrastructure will run the same test suite on both main
 and the stable branches.  When tests are modified or new feature tests are introduced, explicit
 logic should exist within the testing CI to make sure only applicable tests are executed against
-stable and master. While this is not in place currently, it should be considered in the long term.
+stable and main. While this is not in place currently, it should be considered in the long term.
 
 ## Release Management
 
@@ -121,7 +121,7 @@ stable and master. While this is not in place currently, it should be considered
 
 Releases are made every three weeks, which include a GitHub release as
 well as binary packages. These patch releases are made for both stable branches, and a "release candidate"
-for the next `MAJOR` or `MINOR` is created from master. If there are no changes across all the repositories, no
+for the next `MAJOR` or `MINOR` is created from main. If there are no changes across all the repositories, no
 release is created and an announcement is made on the developer mailing list to highlight this.
 If a release is being made, each repository is tagged for this release, regardless
 of whether changes are introduced. The release schedule can be seen on the

--- a/docs/Stable-Branch-Strategy.md
+++ b/docs/Stable-Branch-Strategy.md
@@ -49,9 +49,10 @@ No new features should be introduced to stable branches.  This is intended to li
 providing only bug and security fixes.
 
 ## Branch Management
-Kata Containers will maintain two stable release branches in addition to the main branch.
+Kata Containers will maintain **one** stable release branch, in addition to the main branch, for
+each active major release.
 Once a new MAJOR or MINOR release is created from main, a new stable branch is created for
-the prior MAJOR or MINOR release and the older stable branch is no longer maintained. End of
+the prior MAJOR or MINOR release and the previous stable branch is no longer maintained. End of
 maintenance for a branch is announced on the Kata Containers mailing list.  Users can determine
 the version currently installed by running `kata-runtime kata-env`. It is recommended to use the
 latest stable branch available.
@@ -68,13 +69,13 @@ stable branch.
 |--|--|--|
 | `main` | `1.3.0-rc0` | `1.3.0-rc1` |
 | `stable-1.2` | `1.2.0` | `1.2.1` |
-| `stable-1.1` | `1.1.2` | `1.1.3` |
+| `stable-1.1` | (unmaintained) | (unmaintained) |
 
 
 ### New release made feature or change adding new inter-component dependency
 
 A new feature is introduced, which adds a new inter-component dependency. In this case a new stable
-branch is created (stable-1.3) starting from main and the older stable branch (stable-1.1)
+branch is created (stable-1.3) starting from main and the previous stable branch (stable-1.2)
 is dropped from maintenance.
 
 
@@ -82,10 +83,10 @@ is dropped from maintenance.
 |--|--|--|
 | `main` | `1.3.0-rc1` | `1.3.0` |
 | `stable-1.3` | N/A| `1.3.0` |
-| `stable-1.2` | `1.2.1` | `1.2.2` |
-| `stable-1.1` | `1.1.3` | (unmaintained) |
+| `stable-1.2` | `1.2.1` | (unmaintained) |
+| `stable-1.1` | (unmaintained) | (unmaintained) |
 
-Note, the stable-1.1 branch will still exist with tag 1.1.3, but under current plans it is
+Note, the stable-1.2 branch will still exist with tag 1.2.1, but under current plans it is
 not maintained further. The next tag applied to main will be 1.4.0-alpha0. We would then
 create a couple of alpha releases gathering features targeted for that particular release (in
 this case 1.4.0), followed by a release candidate. The release candidate marks a feature freeze.

--- a/docs/Stable-Branch-Strategy.md
+++ b/docs/Stable-Branch-Strategy.md
@@ -143,10 +143,10 @@ maturity, we have increased the cadence from six weeks to twelve weeks. The rele
 ### Compatibility
 Kata guarantees compatibility between components that are within one minor release of each other. 
  
-This is critical for dependencies which cross between host (runtime, shim, proxy) and
+This is critical for dependencies which cross between host (shimv2 runtime) and
 the guest (hypervisor, rootfs and agent).  For example, consider a cluster with a long-running
 deployment, workload-never-dies, all on Kata version 2.1.3 components. If the operator updates
 the Kata components to the next new minor release (i.e. 2.2.0), we need to guarantee that the 2.2.0
-runtime still communicates with 2.1.3 agent within workload-never-dies.
+shimv2 runtime still communicates with 2.1.3 agent within workload-never-dies.
 
 Handling live-update is out of the scope of this document. See this [`kata-runtime` issue](https://github.com/kata-containers/runtime/issues/492) for details.

--- a/docs/Stable-Branch-Strategy.md
+++ b/docs/Stable-Branch-Strategy.md
@@ -67,31 +67,31 @@ stable branch.
 
 | Branch | Original version | New version |
 |--|--|--|
-| `main` | `1.3.0-rc0` | `1.3.0-rc1` |
-| `stable-1.2` | `1.2.0` | `1.2.1` |
-| `stable-1.1` | (unmaintained) | (unmaintained) |
+| `main` | `2.3.0-rc0` | `2.3.0-rc1` |
+| `stable-2.2` | `2.2.0` | `2.2.1` |
+| `stable-2.1` | (unmaintained) | (unmaintained) |
 
 
 ### New release made feature or change adding new inter-component dependency
 
 A new feature is introduced, which adds a new inter-component dependency. In this case a new stable
-branch is created (stable-1.3) starting from main and the previous stable branch (stable-1.2)
+branch is created (stable-2.3) starting from main and the previous stable branch (stable-2.2)
 is dropped from maintenance.
 
 
 | Branch | Original version | New version |
 |--|--|--|
-| `main` | `1.3.0-rc1` | `1.3.0` |
-| `stable-1.3` | N/A| `1.3.0` |
-| `stable-1.2` | `1.2.1` | (unmaintained) |
-| `stable-1.1` | (unmaintained) | (unmaintained) |
+| `main` | `2.3.0-rc1` | `2.3.0` |
+| `stable-2.3` | N/A| `2.3.0` |
+| `stable-2.2` | `2.2.1` | (unmaintained) |
+| `stable-2.1` | (unmaintained) | (unmaintained) |
 
-Note, the stable-1.2 branch will still exist with tag 1.2.1, but under current plans it is
-not maintained further. The next tag applied to main will be 1.4.0-alpha0. We would then
+Note, the stable-2.2 branch will still exist with tag 2.2.1, but under current plans it is
+not maintained further. The next tag applied to main will be 2.4.0-alpha0. We would then
 create a couple of alpha releases gathering features targeted for that particular release (in
-this case 1.4.0), followed by a release candidate. The release candidate marks a feature freeze.
+this case 2.4.0), followed by a release candidate. The release candidate marks a feature freeze.
 A new stable branch is created for the release candidate. Only bug fixes and any security issues
-are added to the branch going forward until release 1.4.0 is made.
+are added to the branch going forward until release 2.4.0 is made.
    
 ## Backporting Process 
 
@@ -145,8 +145,8 @@ Kata guarantees compatibility between components that are within one minor relea
  
 This is critical for dependencies which cross between host (runtime, shim, proxy) and
 the guest (hypervisor, rootfs and agent).  For example, consider a cluster with a long-running
-deployment, workload-never-dies, all on Kata version 1.1.3 components. If the operator updates
-the Kata components to the next new minor release (i.e. 1.2.0), we need to guarantee that the 1.2.0
-runtime still communicates with 1.1.3 agent within workload-never-dies.
+deployment, workload-never-dies, all on Kata version 2.1.3 components. If the operator updates
+the Kata components to the next new minor release (i.e. 2.2.0), we need to guarantee that the 2.2.0
+runtime still communicates with 2.1.3 agent within workload-never-dies.
 
 Handling live-update is out of the scope of this document. See this [`kata-runtime` issue](https://github.com/kata-containers/runtime/issues/492) for details.


### PR DESCRIPTION
Last week I've proposed a new release cadence in our mailing list, and the email can be found [here](http://lists.katacontainers.io/pipermail/kata-dev/2021-May/001894.html).

As there was no push-back, now I'm trying to make it official by updated the related documents.

All in all, the only change in the proposal involves maintaining **only one** stable branch per active major release;

Please, @kata-containers/architecture-committee, I'd like to have an approval of each one of the active members before going ahead with this one.

Fixes: #1876 

EDITED: There was a light push back on having the releases out in a 8 weeks cadence rather than 12 weeks, so we can rediscuss this for the 2.3 release cycle, if needed. 2.2 release cycle will happen 12 weeks after 2.1 release cycle happened.