### PR TITLE
docs: Use --ignore-preflight-errors=all flag

### DIFF
--- a/docs/how-to/run-kata-with-k8s.md
+++ b/docs/how-to/run-kata-with-k8s.md
@@ -171,10 +171,10 @@ $ sudo systemctl daemon-reload
 $ sudo systemctl restart kubelet
 
 # If using CRI-O
-$ sudo kubeadm init --skip-preflight-checks --cri-socket /var/run/crio/crio.sock --pod-network-cidr=10.244.0.0/16
+$ sudo kubeadm init --ignore-preflight-errors=all --cri-socket /var/run/crio/crio.sock --pod-network-cidr=10.244.0.0/16
 
 # If using CRI-containerd
-$ sudo kubeadm init --skip-preflight-checks --cri-socket /run/containerd/containerd.sock --pod-network-cidr=10.244.0.0/16
+$ sudo kubeadm init --ignore-preflight-errors=all --cri-socket /run/containerd/containerd.sock --pod-network-cidr=10.244.0.0/16
 
 $ export KUBECONFIG=/etc/kubernetes/admin.conf
 ```


### PR DESCRIPTION
The `--skip-preflight-checks` flag has been deprecated in the Kubernetes v1.9 and removed from Kubernetes v1.12.
We should use `--ignore-preflight-errors=all` flag instead of `--skip-preflight-checks`.

Fixes: #1919

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>