### PR TITLE
virtiofsd: Fix file descriptors leak and return correct PID

### DIFF
--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -75,6 +75,8 @@ func (v *virtiofsd) getSocketFD() (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// no longer needed since fd is a dup
 	defer listener.Close()
 
 	listener.SetUnlinkOnClose(false)
@@ -98,6 +100,7 @@ func (v *virtiofsd) Start(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	defer socketFD.Close()
 
 	cmd.ExtraFiles = append(cmd.ExtraFiles, socketFD)
 
@@ -128,7 +131,7 @@ func (v *virtiofsd) Start(ctx context.Context) (int, error) {
 		v.wait = waitVirtiofsReady
 	}
 
-	return pid, socketFD.Close()
+	return cmd.Process.Pid, nil
 }
 
 func (v *virtiofsd) Stop(ctx context.Context) error {


### PR DESCRIPTION
This commit will fix two problems:
- Virtiofsd process ID returned to the caller will always be 0,
   the pid var is never being assigned a value.
- Socket listen fd may leak in case of failure of starting virtiofsd process.
  This is a port of https://github.com/kata-containers/kata-containers/commit/be9ca0d58b2b777beda02f59e443c1dc67d0b5f7

Fixes: #1931

Signed-off-by: bin <bin@hyper.sh>