### PR TITLE
virtiofsd: refactor qemu.go to use code in virtiofsd.go

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -362,7 +362,9 @@ func (clh *cloudHypervisor) startSandbox(ctx context.Context, timeout int) error
 
 	if clh.config.SharedFS == config.VirtioFS {
 		clh.Logger().WithField("function", "startSandbox").Info("Starting virtiofsd")
-		pid, err := clh.virtiofsd.Start(ctx)
+		pid, err := clh.virtiofsd.Start(ctx, func() {
+			clh.stopSandbox(ctx, false)
+		})
 		if err != nil {
 			return err
 		}

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -11,7 +11,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	govmmQemu "github.com/kata-containers/govmm/qemu"
@@ -548,35 +547,6 @@ func createQemuSandboxConfig() (*Sandbox, error) {
 	sandbox.store = store
 
 	return &sandbox, nil
-}
-
-func TestQemuVirtiofsdArgs(t *testing.T) {
-	assert := assert.New(t)
-
-	q := &qemu{
-		id: "foo",
-		config: HypervisorConfig{
-			VirtioFSCache: "none",
-			Debug:         true,
-		},
-	}
-
-	savedKataHostSharedDir := kataHostSharedDir
-	kataHostSharedDir = func() string {
-		return "test-share-dir"
-	}
-	defer func() {
-		kataHostSharedDir = savedKataHostSharedDir
-	}()
-
-	result := "--fd=123 -o source=test-share-dir/foo/shared -o cache=none --syslog -o no_posix_lock -d"
-	args := q.virtiofsdArgs(123)
-	assert.Equal(strings.Join(args, " "), result)
-
-	q.config.Debug = false
-	result = "--fd=123 -o source=test-share-dir/foo/shared -o cache=none --syslog -o no_posix_lock -f"
-	args = q.virtiofsdArgs(123)
-	assert.Equal(strings.Join(args, " "), result)
 }
 
 func TestQemuGetpids(t *testing.T) {

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -7,10 +7,9 @@ package virtcontainers
 
 import (
 	"context"
-	"io"
 	"io/ioutil"
 	"os"
-	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -67,17 +66,81 @@ func TestVirtiofsdStart(t *testing.T) {
 				debug:      tt.fields.debug,
 				PID:        tt.fields.PID,
 				ctx:        tt.fields.ctx,
-				//Mock  wait function
-				wait: func(runningCmd *exec.Cmd, stderr io.ReadCloser, debug bool) error {
-					return nil
-				},
 			}
 			var ctx context.Context
-			_, err := v.Start(ctx)
+			_, err := v.Start(ctx, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("virtiofsd.Start() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 		})
 	}
+}
+
+func TestVirtiofsdArgs(t *testing.T) {
+	assert := assert.New(t)
+
+	v := &virtiofsd{
+		path:       "/usr/bin/virtiofsd",
+		sourcePath: "/run/kata-shared/foo",
+		cache:      "none",
+	}
+
+	expected := "--syslog -o cache=none -o no_posix_lock -o source=/run/kata-shared/foo --fd=123 -f"
+	args, err := v.args(123)
+	assert.NoError(err)
+	assert.Equal(expected, strings.Join(args, " "))
+
+	v.debug = false
+	expected = "--syslog -o cache=none -o no_posix_lock -o source=/run/kata-shared/foo --fd=456 -f"
+	args, err = v.args(456)
+	assert.NoError(err)
+	assert.Equal(expected, strings.Join(args, " "))
+}
+
+func TestValid(t *testing.T) {
+	assert := assert.New(t)
+
+	sourcePath, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(sourcePath)
+
+	socketDir, err := ioutil.TempDir("", "")
+	assert.NoError(err)
+	defer os.RemoveAll(socketDir)
+
+	socketPath := socketDir + "socket.s"
+
+	newVirtiofsdFunc := func() *virtiofsd {
+		return &virtiofsd{
+			path:       "/usr/bin/virtiofsd",
+			sourcePath: sourcePath,
+			socketPath: socketPath,
+		}
+	}
+
+	// valid case
+	v := newVirtiofsdFunc()
+	err = v.valid()
+	assert.NoError(err)
+
+	v = newVirtiofsdFunc()
+	v.path = ""
+	err = v.valid()
+	assert.Equal(errVirtiofsdDaemonPathEmpty, err)
+
+	v = newVirtiofsdFunc()
+	v.sourcePath = ""
+	err = v.valid()
+	assert.Equal(errVirtiofsdSourcePathEmpty, err)
+
+	v = newVirtiofsdFunc()
+	v.socketPath = ""
+	err = v.valid()
+	assert.Equal(errVirtiofsdSocketPathEmpty, err)
+
+	v = newVirtiofsdFunc()
+	v.sourcePath = "/foo/bar"
+	err = v.valid()
+	assert.Equal(errVirtiofsdSourceNotAvailable, err)
 }


### PR DESCRIPTION
CloudHypervisor is using virtiofsd.go to manage virtiofsd process,
but qemu has its code in qemu.go. This commit let qemu to re-use
code in virtiofsd.go to reduce code and improve maintenanceability.

Fixes: #1933

Signed-off-by: bin <bin@hyper.sh>