### PR TITLE
cleanup TODOs in runtime

### DIFF
--- a/src/runtime/virtcontainers/persist/api/sandbox.go
+++ b/src/runtime/virtcontainers/persist/api/sandbox.go
@@ -34,7 +34,6 @@ type SandboxState struct {
 
 	// CgroupPath is the cgroup hierarchy where sandbox's processes
 	// including the hypervisor are placed.
-	// FIXME: sandbox can reuse "SandboxContainer"'s CgroupPath so we can remove this field.
 	CgroupPath string
 
 	// CgroupPath is the cgroup hierarchy where sandbox's processes

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -2256,7 +2256,6 @@ func calcHotplugMemMiBSize(mem uint32, memorySectionSizeMB uint32) (uint32, erro
 		return mem, nil
 	}
 
-	// TODO: hot add memory aligned to memory section should be more properly. See https://github.com/kata-containers/runtime/pull/624#issuecomment-419656853
 	return uint32(math.Ceil(float64(mem)/float64(memorySectionSizeMB))) * memorySectionSizeMB, nil
 }
 

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1271,7 +1271,6 @@ func (s *Sandbox) DeleteContainer(ctx context.Context, containerID string) (VCCo
 }
 
 // StatusContainer gets the status of a container
-// TODO: update container status properly, see kata-containers/runtime#253
 func (s *Sandbox) StatusContainer(containerID string) (ContainerStatus, error) {
 	if containerID == "" {
 		return ContainerStatus{}, vcTypes.ErrNeedContainerID


### PR DESCRIPTION
Some of them are no longer valid. We can just remove them.