### PR TITLE
[stable-2.1] Weekly backports to stable-2.1 branch, May 31st 2021

### DIFF
--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -75,6 +75,8 @@ func (v *virtiofsd) getSocketFD() (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// no longer needed since fd is a dup
 	defer listener.Close()
 
 	listener.SetUnlinkOnClose(false)
@@ -98,6 +100,7 @@ func (v *virtiofsd) Start(ctx context.Context) (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	defer socketFD.Close()
 
 	cmd.ExtraFiles = append(cmd.ExtraFiles, socketFD)
 
@@ -128,7 +131,7 @@ func (v *virtiofsd) Start(ctx context.Context) (int, error) {
 		v.wait = waitVirtiofsReady
 	}
 
-	return pid, socketFD.Close()
+	return cmd.Process.Pid, nil
 }
 
 func (v *virtiofsd) Stop(ctx context.Context) error {


### PR DESCRIPTION
This week we're backporting:
~727bfc4556451433468cb5ede72f8b2df196b3b8 runtime: and cgroup and SandboxCgroupOnly check for check sub-command (#1934)~ Please, see: #1940
009a200151c24af553577665484531fad2b65277 virtiofsd: Fix file descriptors leak and return correct PID (#1932)
ad7658e16ee99613612f8fc9dfc8c58708ba32fa agent: re-enable the standard SIGPIPE behavior (#1939)
26beb7a6a866aba6980be3db0a61fb12aad26520 cgroup: fix the issue of set mem.limit and mem.swap (#1918)