### PR TITLE
runtime: add more traces for network

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -812,7 +812,7 @@ func (k *kataAgent) startSandbox(ctx context.Context, sandbox *Sandbox) error {
 	}
 
 	// Setup network interfaces and routes
-	interfaces, routes, neighs, err := generateVCNetworkStructures(sandbox.networkNS)
+	interfaces, routes, neighs, err := generateVCNetworkStructures(ctx, sandbox.networkNS)
 	if err != nil {
 		return err
 	}

--- a/src/runtime/virtcontainers/macvtap_endpoint.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint.go
@@ -14,6 +14,8 @@ import (
 	vcTypes "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/types"
 )
 
+var macvtapTrace = getNetworkTrace(MacvtapEndpointType)
+
 // MacvtapEndpoint represents a macvtap endpoint
 type MacvtapEndpoint struct {
 	EndpointProperties NetworkInfo
@@ -62,6 +64,9 @@ func (endpoint *MacvtapEndpoint) SetProperties(properties NetworkInfo) {
 // Attach for macvtap endpoint passes macvtap device to the hypervisor.
 func (endpoint *MacvtapEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 	var err error
+	span, ctx := macvtapTrace(ctx, "Attach", endpoint)
+	defer span.End()
+
 	h := s.hypervisor
 
 	endpoint.VMFds, err = createMacvtapFds(endpoint.EndpointProperties.Iface.Index, int(h.hypervisorConfig().NumVCPUs))

--- a/src/runtime/virtcontainers/network_test.go
+++ b/src/runtime/virtcontainers/network_test.go
@@ -6,6 +6,7 @@
 package virtcontainers
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"reflect"
@@ -74,7 +75,7 @@ func TestGenerateInterfacesAndRoutes(t *testing.T) {
 
 	nns := NetworkNamespace{NetNsPath: "foobar", NetNsCreated: true, Endpoints: endpoints}
 
-	resInterfaces, resRoutes, resNeighs, err := generateVCNetworkStructures(nns)
+	resInterfaces, resRoutes, resNeighs, err := generateVCNetworkStructures(context.Background(), nns)
 
 	//
 	// Build expected results:
@@ -275,10 +276,10 @@ func TestTcRedirectNetwork(t *testing.T) {
 	err = netHandle.LinkSetUp(link)
 	assert.NoError(err)
 
-	err = setupTCFiltering(endpoint, 1, true)
+	err = setupTCFiltering(context.Background(), endpoint, 1, true)
 	assert.NoError(err)
 
-	err = removeTCFiltering(endpoint)
+	err = removeTCFiltering(context.Background(), endpoint)
 	assert.NoError(err)
 
 	// Remove the veth created for testing.
@@ -313,7 +314,7 @@ func TestRxRateLimiter(t *testing.T) {
 	err = netHandle.LinkSetUp(link)
 	assert.NoError(err)
 
-	err = setupTCFiltering(endpoint, 1, true)
+	err = setupTCFiltering(context.Background(), endpoint, 1, true)
 	assert.NoError(err)
 
 	// 10Mb
@@ -327,7 +328,7 @@ func TestRxRateLimiter(t *testing.T) {
 	err = removeRxRateLimiter(endpoint, currentNS.Path())
 	assert.NoError(err)
 
-	err = removeTCFiltering(endpoint)
+	err = removeTCFiltering(context.Background(), endpoint)
 	assert.NoError(err)
 
 	// Remove the veth created for testing.
@@ -362,7 +363,7 @@ func TestTxRateLimiter(t *testing.T) {
 	err = netHandle.LinkSetUp(link)
 	assert.NoError(err)
 
-	err = setupTCFiltering(endpoint, 1, true)
+	err = setupTCFiltering(context.Background(), endpoint, 1, true)
 	assert.NoError(err)
 
 	// 10Mb
@@ -376,7 +377,7 @@ func TestTxRateLimiter(t *testing.T) {
 	err = removeTxRateLimiter(endpoint, currentNS.Path())
 	assert.NoError(err)
 
-	err = removeTCFiltering(endpoint)
+	err = removeTCFiltering(context.Background(), endpoint)
 	assert.NoError(err)
 
 	// Remove the veth created for testing.

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -760,6 +760,9 @@ func (s *Sandbox) createNetwork(ctx context.Context) error {
 		NetNsCreated: s.config.NetworkConfig.NetNsCreated,
 	}
 
+	span.SetAttributes(otelLabel.Any("networkNS", s.networkNS))
+	span.SetAttributes(otelLabel.Any("NetworkConfig", s.config.NetworkConfig))
+
 	// In case there is a factory, network interfaces are hotplugged
 	// after vm is started.
 	if s.factory == nil {

--- a/src/runtime/virtcontainers/vhostuser_endpoint.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint.go
@@ -23,6 +23,8 @@ import (
 // using this path.
 const hostSocketSearchPath = "/tmp/vhostuser_%s/vhu.sock"
 
+var vhostuserTrace = getNetworkTrace(VhostUserEndpointType)
+
 // VhostUserEndpoint represents a vhost-user socket based network interface
 type VhostUserEndpoint struct {
 	// Path to the vhost-user socket on the host system
@@ -77,6 +79,9 @@ func (endpoint *VhostUserEndpoint) NetworkPair() *NetworkInterfacePair {
 
 // Attach for vhostuser endpoint
 func (endpoint *VhostUserEndpoint) Attach(ctx context.Context, s *Sandbox) error {
+	span, ctx := vhostuserTrace(ctx, "Attach", endpoint)
+	defer span.End()
+
 	// Generate a unique ID to be used for hypervisor commandline fields
 	randBytes, err := utils.GenerateRandomBytes(8)
 	if err != nil {


### PR DESCRIPTION
Add traces for all the endpoinnt types
and the main interface functions.
Record errors for some traces.

Fixes: #1956

Signed-off-by: bin <bin@hyper.sh>