### PR TITLE
Update CC=gcc setting for Fedora s390x

### DIFF
--- a/src/runtime/arch/s390x-options.mk
+++ b/src/runtime/arch/s390x-options.mk
@@ -11,3 +11,10 @@ MACHINEACCELERATORS :=
 CPUFEATURES :=
 
 QEMUCMD := qemu-system-s390x
+
+# See https://github.com/kata-containers/osbuilder/issues/217
+FEDORA_LIKE = $(shell grep -E "\<fedora\>" /etc/os-release 2> /dev/null)
+ifneq (,$(FEDORA_LIKE))
+	CC := gcc
+	export CC
+endif

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -562,10 +562,6 @@ EOT
 		       -e '/^\[Unit\]/a ConditionPathExists=\/dev\/ptp0' ${chrony_systemd_service}
 	fi
 
-	# The CC on s390x for fedora needs to be manually set to gcc when the golang is downloaded from the main page.
-	# See issue: https://github.com/kata-containers/osbuilder/issues/217
-	[ "$distro" == "fedora" ] && [ "$ARCH" == "s390x" ] && export CC=gcc
-
 	AGENT_DIR="${ROOTFS_DIR}/usr/bin"
 	AGENT_DEST="${AGENT_DIR}/${AGENT_BIN}"
 


### PR DESCRIPTION
For FFI to C in Go, `CC=gcc` is required on Fedora s390x (see https://github.com/kata-containers/osbuilder/issues/217).

- osbuilder: Remove CC=gcc for Fedora s390x (no longer required for Rust agent)
- runtime: Use CC=gcc on Fedora s390x (is still required and was never added for runtime)

Fixes: #1973