### PR TITLE
osbuilder: Streamline s390x CMake & musl handling

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -570,7 +570,10 @@ EOT
 	AGENT_DEST="${AGENT_DIR}/${AGENT_BIN}"
 
 	if [ -z "${AGENT_SOURCE_BIN}" ] ; then
-		[ "$ARCH" == "ppc64le" ] && { LIBC=gnu; echo "WARNING: Forcing LIBC=gnu for ppc64le because musl toolchain is not supported on ppc64le"; }
+		if [ "$ARCH" == "ppc64le" ] || [ "$ARCH" == "s390x" ]; then
+			LIBC=gnu
+			echo "WARNING: Forcing LIBC=gnu because $ARCH has no musl Rust target"
+		fi
 		[ "$LIBC" == "musl" ] && bash ${script_dir}/../../../ci/install_musl.sh
 		# rust agent needs ${arch}-unknown-linux-${LIBC}
 		rustup show | grep linux-${LIBC} > /dev/null || bash ${script_dir}/../../../ci/install_rust.sh

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -339,24 +339,11 @@ RUN ln -sf /usr/bin/g++ /bin/musl-g++
                 [ -f "${dockerfile_template}" ] || die "${dockerfile_template}: file not found"
         fi
 
-	# powerpc have no musl target, don't setup rust enviroment
-	# since we cannot static link agent. Besides, there is
-	# also long double representation problem when building musl-libc
-	if [ "${architecture}" == "ppc64le" ]; then
+	# ppc64le and s390x have no musl target
+	if [ "${architecture}" == "ppc64le" ] || [ "${architecture}" == "s390x" ]; then
 		sed \
 			-e "s|@GO_VERSION@|${GO_VERSION}|g" \
 			-e "s|@OS_VERSION@|${OS_VERSION:-}|g" \
-			-e "s|@INSTALL_MUSL@||g" \
-			-e "s|@INSTALL_GO@|${install_go//$'\n'/\\n}|g" \
-			-e "s|@INSTALL_RUST@|${install_rust//$'\n'/\\n}|g" \
-			-e "s|@SET_PROXY@|${set_proxy:-}|g" \
-			"${dockerfile_template}" > Dockerfile
-	# no musl target on s390x, will use GNU
-	elif [ "${architecture}" == "s390x" ]; then
-		sed \
-			-e "s|@GO_VERSION@|${GO_VERSION}|g" \
-			-e "s|@OS_VERSION@|${OS_VERSION:-}|g" \
-			-e "s|@INSTALL_CMAKE@|${install_cmake//$'\n'/\\n}|g" \
 			-e "s|@INSTALL_MUSL@||g" \
 			-e "s|@INSTALL_GO@|${install_go//$'\n'/\\n}|g" \
 			-e "s|@INSTALL_RUST@|${install_rust//$'\n'/\\n}|g" \


### PR DESCRIPTION
- Merge codepath in lib.sh with ppc64le -- do not install CMake
- Like ppc64le, do not install musl rather than just not using it

Fixes: #1975