### PR TITLE
runtime: remove the call to storeSandbox at the end of createSandboxFromConfig 

### DIFF
--- a/src/runtime/virtcontainers/api.go
+++ b/src/runtime/virtcontainers/api.go
@@ -120,11 +120,6 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 		return nil, err
 	}
 
-	// The sandbox is completely created now, we can store it.
-	if err = s.storeSandbox(ctx); err != nil {
-		return nil, err
-	}
-
 	return s, nil
 }
 


### PR DESCRIPTION
Remove the call to storeSandbox() at the end of createSandboxFromConfig(),
because this call chain createSandboxFromConfig -> s.createContainers has already calls storeSandbox().
This can improve the startup speed of the container, even just for a little. 

Fixes: #1980

Signed-off-by: Liang Zhou zhoul110@chinatelecom.cn