### PR TITLE
osbuilder: fix log message that is not error but seems like an error

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -584,7 +584,9 @@ EOT
 
 		info "Build agent"
 		pushd "${agent_dir}"
-		[ -n "${AGENT_VERSION}" ] && git checkout "${AGENT_VERSION}" && OK "git checkout successful" || info "checkout failed!"
+		if [ -n "${AGENT_VERSION}" ]; then
+			git checkout "${AGENT_VERSION}" && OK "git checkout successful" || die "checkout agent ${AGENT_VERSION} failed!"
+		fi
 		make clean
 		make LIBC=${LIBC} INIT=${AGENT_INIT}
 		make install DESTDIR="${ROOTFS_DIR}" LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP}


### PR DESCRIPTION
Only show checkout faile message if AGENT_VERSION is set
and the checkout is failed.

Fixes: #1989

Signed-off-by: bin <bin@hyper.sh>