### PR TITLE
docs: Remove old travis reference

### DIFF
--- a/tools/osbuilder/README.md
+++ b/tools/osbuilder/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/kata-containers/osbuilder.svg?branch=master)](https://travis-ci.org/kata-containers/osbuilder)
-
 # osbuilder
 
 * [osbuilder](#osbuilder)


### PR DESCRIPTION
This PR removes the travis reference as we currently for kata 2.0,
travis is not being supported.

Fixes #1994

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>