### PR TITLE
tracing: Make runHooks() span creation return context

### DIFF
--- a/src/runtime/pkg/katautils/hook.go
+++ b/src/runtime/pkg/katautils/hook.go
@@ -88,7 +88,7 @@ func runHook(ctx context.Context, hook specs.Hook, cid, bundlePath string) error
 }
 
 func runHooks(ctx context.Context, hooks []specs.Hook, cid, bundlePath, hookType string) error {
-	span, _ := Trace(ctx, "runHooks", []label.KeyValue{label.Key("source").String("runtime"), label.Key("package").String("katautils"), label.Key("subsystem").String("hook"), label.Key("type").String(hookType)}...)
+	span, ctx := Trace(ctx, "runHooks", []label.KeyValue{label.Key("source").String("runtime"), label.Key("package").String("katautils"), label.Key("subsystem").String("hook"), label.Key("type").String(hookType)}...)
 	defer span.End()
 
 	for _, hook := range hooks {


### PR DESCRIPTION
The call to Trace() in runHooks() does not return a context; fix this so
that the subsequent calls to runHook() produces a properly ordered trace
span.

Fixes #2001

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>