### PR TITLE
agent: Update rust version for tokio

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -249,7 +249,7 @@ languages:
   rust:
     description: "Rust language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.38.0"
+    version: "1.45.0"
     meta:
       description: |
         'newest-version' is the latest version known to work when


### PR DESCRIPTION
This was fixed for tokio's version 
requirements for rust, see:
[supported-rust-versions](https://github.com/tokio-rs/tokio#supported-rust-versions)

Fixes: [#2008](https://github.com/kata-containers/kata-containers/issues/2008)

Signed-off-by: houfangdong <houfangdong@loongson.cn>