### PR TITLE
docs: Update README for runtime documentation

### DIFF
--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -1,7 +1,4 @@
-[![Build Status](https://travis-ci.org/kata-containers/kata-containers.svg?branch=master)](https://travis-ci.org/kata-containers/kata-containers)
-[![Build Status](http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-18-04-master/badge/icon)](http://jenkins.katacontainers.io/job/kata-containers-runtime-ubuntu-18-04-master/)
 [![Go Report Card](https://goreportcard.com/badge/github.com/kata-containers/kata-containers)](https://goreportcard.com/report/github.com/kata-containers/kata-containers)
-[![GoDoc](https://godoc.org/github.com/kata-containers/runtime?status.svg)](https://godoc.org/github.com/kata-containers/runtime)
 
 # Runtime
 


### PR DESCRIPTION
This PR removes old links that were used in kata 1.x but not
longer valid for kata 2.x

Fixes #2019

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>