### PR TITLE
s390x: Enable virtio-blk-ccw

### DIFF
--- a/src/agent/src/ccw.rs
+++ b/src/agent/src/ccw.rs
@@ -1,0 +1,140 @@
+// Copyright (c) IBM Corp. 2021
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::anyhow;
+
+// CCW bus ID follow the format <xx>.<d>.<xxxx> [1, p. 11], where
+//   - <xx> is the channel subsystem ID, which is always 0 from the guest side, but different from
+//     the host side, e.g. 0xfe for virtio-*-ccw [1, p. 435],
+//   - <d> is the subchannel set ID, which ranges from 0-3 [2], and
+//   - <xxxx> is the device number (0000-ffff; leading zeroes can be omitted,
+//      e.g. 3 instead of 0003).
+// [1] https://www.ibm.com/docs/en/linuxonibm/pdf/lku4dd04.pdf
+// [2] https://qemu.readthedocs.io/en/latest/system/s390x/css.html
+
+// Maximum subchannel set ID
+const SUBCHANNEL_SET_MAX: u8 = 3;
+
+// CCW device. From the guest side, the first field is always 0 and can therefore be omitted.
+#[derive(Copy, Clone, Debug)]
+pub struct Device {
+    subchannel_set_id: u8,
+    device_number: u16,
+}
+
+impl Device {
+    pub fn new(subchannel_set_id: u8, device_number: u16) -> anyhow::Result<Self> {
+        if subchannel_set_id > SUBCHANNEL_SET_MAX {
+            return Err(anyhow!(
+                "Subchannel set ID {:?} should be in range [0..{}]",
+                subchannel_set_id,
+                SUBCHANNEL_SET_MAX
+            ));
+        }
+
+        Ok(Device {
+            subchannel_set_id,
+            device_number,
+        })
+    }
+}
+
+impl FromStr for Device {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let split: Vec<&str> = s.split('.').collect();
+        if split.len() != 3 {
+            return Err(anyhow!(
+                "Wrong bus format. It needs to be in the form 0.<d>.<xxxx>, got {:?}",
+                s
+            ));
+        }
+
+        if split[0] != "0" {
+            return Err(anyhow!(
+                "Wrong bus format. First digit needs to be 0, but is {:?}",
+                split[0]
+            ));
+        }
+
+        let subchannel_set_id = match split[1].parse::<u8>() {
+            Ok(id) => id,
+            Err(_) => {
+                return Err(anyhow!(
+                    "Wrong bus format. Second digit needs to be 0-3, but is {:?}",
+                    split[1]
+                ))
+            }
+        };
+
+        let device_number = match u16::from_str_radix(split[2], 16) {
+            Ok(id) => id,
+            Err(_) => {
+                return Err(anyhow!(
+                    "Wrong bus format. Third digit needs to be 0-ffff, but is {:?}",
+                    split[2]
+                ))
+            }
+        };
+
+        Device::new(subchannel_set_id, device_number)
+    }
+}
+
+impl fmt::Display for Device {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "0.{}.{:04x}", self.subchannel_set_id, self.device_number)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::ccw::Device;
+    use std::str::FromStr;
+
+    #[test]
+    fn test_new_device() {
+        // Valid devices
+        let device = Device::new(0, 0).unwrap();
+        assert_eq!(format!("{}", device), "0.0.0000");
+
+        let device = Device::new(3, 0xffff).unwrap();
+        assert_eq!(format!("{}", device), "0.3.ffff");
+
+        // Invalid device
+        let device = Device::new(4, 0);
+        assert!(device.is_err());
+    }
+
+    #[test]
+    fn test_device_from_str() {
+        // Valid devices
+        let device = Device::from_str("0.0.0").unwrap();
+        assert_eq!(format!("{}", device), "0.0.0000");
+
+        let device = Device::from_str("0.0.0000").unwrap();
+        assert_eq!(format!("{}", device), "0.0.0000");
+
+        let device = Device::from_str("0.3.ffff").unwrap();
+        assert_eq!(format!("{}", device), "0.3.ffff");
+
+        // Invalid devices
+        let device = Device::from_str("0.0");
+        assert!(device.is_err());
+
+        let device = Device::from_str("1.0.0");
+        assert!(device.is_err());
+
+        let device = Device::from_str("0.not_a_subchannel_set_id.0");
+        assert!(device.is_err());
+
+        let device = Device::from_str("0.0.not_a_device_number");
+        assert!(device.is_err());
+    }
+}

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -65,6 +65,10 @@ pub fn create_pci_root_bus_path() -> String {
     ret
 }
 
+#[cfg(target_arch = "s390x")]
+pub fn create_ccw_root_bus_path() -> String {
+    String::from("/devices/css0")
+}
 // From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
 // The Linux kernel's core ACPI subsystem creates struct acpi_device
 // objects for ACPI namespace objects representing devices, power resources

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -34,6 +34,8 @@ use std::process::exit;
 use std::sync::Arc;
 use tracing::{instrument, span};
 
+#[cfg(target_arch = "s390x")]
+mod ccw;
 mod config;
 mod console;
 mod device;

--- a/src/agent/src/uevent.rs
+++ b/src/agent/src/uevent.rs
@@ -114,7 +114,7 @@ pub async fn wait_for_uevent(
     let mut sb = sandbox.lock().await;
     for uev in sb.uevent_map.values() {
         if matcher.is_match(uev) {
-            info!(sl!(), "Device {:?} found in pci device map", uev);
+            info!(sl!(), "Device {:?} found in device map", uev);
             return Ok(uev.clone());
         }
     }

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -510,6 +510,8 @@ func (conf *HypervisorConfig) valid() error {
 
 	if conf.BlockDeviceDriver == "" {
 		conf.BlockDeviceDriver = defaultBlockDriver
+	} else if conf.BlockDeviceDriver == config.VirtioBlock && conf.HypervisorMachineType == "s390-ccw-virtio" {
+		conf.BlockDeviceDriver = config.VirtioBlockCCW
 	}
 
 	if conf.DefaultMaxVCPUs == 0 {


### PR DESCRIPTION
The s390x architecture uses `virtio-blk-ccw` instead of `virtio-blk-pci`. It has been enabled in the runtime in the v1 days (https://github.com/kata-containers/runtime/pull/1965), and support in the Go agent was also added then (https://github.com/kata-containers/agent/pull/600). This is basically a forward port of the latter to the v2 Rust agent.

- agent/s390x: Enable `virtio-blk-ccw`, with tests. Includes a new CCW device structure and a respective uevent matcher and device handler.
- runtime/virtcontainers/s390x: The QEMU [`configuration.toml`](https://github.com/kata-containers/kata-containers/blob/main/src/runtime/cli/config/configuration-qemu.toml.in#L169) says
```
# Block storage driver to be used for the hypervisor in case the container
# rootfs is backed by a block device. This is virtio-scsi, virtio-blk
# or nvdimm.
```
when it should be `virtio-blk-ccw` for s390x. I suggest to simply override the block driver to `virtio-blk-ccw` when `virtio-blk` (~ PCI) is to be used on s390x. If you disagree on that, we can put a hint in the config comment above. Also, please tell me if you think there is a better place to put this than `HypervisorConfig.valid()`.

Fixes: #2026