### PR TITLE
[backport stable-2.1] versions: Upgrade to cloud-hypervisor v16.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -519,12 +519,8 @@ components:
           net:
           - tap: tap
             num_queues: 9
-            iommu: false
             queue_size: 6
-            vhost_socket: vhost_socket
-            vhost_user: false
             ip: 192.168.249.1
-            id: id
             rate_limiter_config:
               ops:
                 size: 0
@@ -535,18 +531,19 @@ components:
                 one_time_burst: 0
                 refill_time: 0
             mac: mac
+            vhost_mode: client
+            iommu: false
+            vhost_socket: vhost_socket
+            vhost_user: false
+            id: id
             fd:
             - 8
             - 8
             mask: 255.255.255.0
           - tap: tap
             num_queues: 9
-            iommu: false
             queue_size: 6
-            vhost_socket: vhost_socket
-            vhost_user: false
             ip: 192.168.249.1
-            id: id
             rate_limiter_config:
               ops:
                 size: 0
@@ -557,6 +554,11 @@ components:
                 one_time_burst: 0
                 refill_time: 0
             mac: mac
+            vhost_mode: client
+            iommu: false
+            vhost_socket: vhost_socket
+            vhost_user: false
+            id: id
             fd:
             - 8
             - 8
@@ -813,12 +815,8 @@ components:
         net:
         - tap: tap
           num_queues: 9
-          iommu: false
           queue_size: 6
-          vhost_socket: vhost_socket
-          vhost_user: false
           ip: 192.168.249.1
-          id: id
           rate_limiter_config:
             ops:
               size: 0
@@ -829,18 +827,19 @@ components:
               one_time_burst: 0
               refill_time: 0
           mac: mac
+          vhost_mode: client
+          iommu: false
+          vhost_socket: vhost_socket
+          vhost_user: false
+          id: id
           fd:
           - 8
           - 8
           mask: 255.255.255.0
         - tap: tap
           num_queues: 9
-          iommu: false
           queue_size: 6
-          vhost_socket: vhost_socket
-          vhost_user: false
           ip: 192.168.249.1
-          id: id
           rate_limiter_config:
             ops:
               size: 0
@@ -851,6 +850,11 @@ components:
               one_time_burst: 0
               refill_time: 0
           mac: mac
+          vhost_mode: client
+          iommu: false
+          vhost_socket: vhost_socket
+          vhost_user: false
+          id: id
           fd:
           - 8
           - 8
@@ -1202,12 +1206,8 @@ components:
       example:
         tap: tap
         num_queues: 9
-        iommu: false
         queue_size: 6
-        vhost_socket: vhost_socket
-        vhost_user: false
         ip: 192.168.249.1
-        id: id
         rate_limiter_config:
           ops:
             size: 0
@@ -1218,6 +1218,11 @@ components:
             one_time_burst: 0
             refill_time: 0
         mac: mac
+        vhost_mode: client
+        iommu: false
+        vhost_socket: vhost_socket
+        vhost_user: false
+        id: id
         fd:
         - 8
         - 8
@@ -1247,6 +1252,9 @@ components:
           default: false
           type: boolean
         vhost_socket:
+          type: string
+        vhost_mode:
+          default: client
           type: string
         id:
           type: string

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/client.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/client.go
@@ -372,9 +372,6 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 			return
 		}
 		_, err = (*f).Write(b)
-		if err != nil {
-			return
-		}
 		_, err = (*f).Seek(0, io.SeekStart)
 		return
 	}

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
@@ -13,6 +13,7 @@ Name | Type | Description | Notes
 **QueueSize** | **int32** |  | [optional] [default to 256]
 **VhostUser** | **bool** |  | [optional] [default to false]
 **VhostSocket** | **string** |  | [optional] 
+**VhostMode** | **string** |  | [optional] [default to client]
 **Id** | **string** |  | [optional] 
 **Fd** | **[]int32** |  | [optional] 
 **RateLimiterConfig** | [**RateLimiterConfig**](RateLimiterConfig.md) |  | [optional] 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
@@ -20,6 +20,7 @@ type NetConfig struct {
 	QueueSize         int32             `json:"queue_size,omitempty"`
 	VhostUser         bool              `json:"vhost_user,omitempty"`
 	VhostSocket       string            `json:"vhost_socket,omitempty"`
+	VhostMode         string            `json:"vhost_mode,omitempty"`
 	Id                string            `json:"id,omitempty"`
 	Fd                []int32           `json:"fd,omitempty"`
 	RateLimiterConfig RateLimiterConfig `json:"rate_limiter_config,omitempty"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -712,6 +712,9 @@ components:
           default: false
         vhost_socket:
           type: string
+        vhost_mode:
+          type: string
+          default: "client"
         id:
           type: string
         fd:

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v15.0"
+      version: "v16.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
Back-porting PR https://github.com/kata-containers/kata-containers/pull/1993.

Highlights from the Cloud Hypervisor release v16.0: 

1. Improved live migration support;
2. Improved `vhost-user` support; 
3. ARM64 ACPI and UEFI support; 
4. Bug fixes.

Details can be found: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v16.0

Note: The client code of cloud-hypervisor's OpenAPI is automatically
generated by `openapi-generator` [1-2]. As the API changes do not
impact usages in Kata, no additional changes in kata's runtime are
needed to work with the current version of cloud-hypervisor.

[1] https://github.com/OpenAPITools/openapi-generator
[2] https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/pkg/cloud-hypervisor/README.md

Fixes: #1992

Signed-off-by: Bo Chen <chen.bo@intel.com>
(cherry picked from commit 85c40001dab1f51eae0d2920cfbc74ee86a70d64)