### PR TITLE
docs: Update url for breaking compatibility

### DIFF
--- a/tools/packaging/kernel/README.md
+++ b/tools/packaging/kernel/README.md
@@ -176,5 +176,5 @@ repository and which pull request [it depends on][depends-on-docs].
 
 [kata-containers-versions-file]: ../../../versions.yaml
 [patches-dir]: patches
-[depends-on-docs]: https://github.com/kata-containers/tests/blob/master/README.md#breaking-compatibility
+[depends-on-docs]: https://github.com/kata-containers/tests/blob/main/README.md#breaking-compatibility
 [cache-job]: http://jenkins.katacontainers.io/job/image-nightly-x86_64/


### PR DESCRIPTION
This PR updates the proper url for breaking compatibility for
kata 2.x

Fixes #2031

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>