### PR TITLE
containerd-shim-v2: Skip TestIoCopy unit test

### DIFF
--- a/src/runtime/containerd-shim-v2/stream_test.go
+++ b/src/runtime/containerd-shim-v2/stream_test.go
@@ -91,6 +91,8 @@ func TestNewTtyIOFifoReopen(t *testing.T) {
 }
 
 func TestIoCopy(t *testing.T) {
+	t.Skip("TestIoCopy is failing randonly, see https://github.com/kata-containers/kata-containers/issues/2042")
+
 	assert := assert.New(t)
 	ctx := context.TODO()
 


### PR DESCRIPTION
TestIoCopy unit test is failing randonly, skip it until we have a fix

fixes #2043

Signed-off-by: Julio Montes <julio.montes@intel.com>

cc @littlejawa 