### PR TITLE
virtcontainers: Move virtiofsd logs to its own file

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -211,6 +211,7 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 			sourcePath: filepath.Join(getSharePath(clh.id)),
 			debug:      clh.config.Debug,
 			socketPath: virtiofsdSocketPath,
+			logPath:    filepath.Join(clh.store.RunVMStoragePath(), id, "virtiofsd.log"),
 		}
 		return nil
 	}
@@ -317,6 +318,7 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 		extraArgs:  clh.config.VirtioFSExtraArgs,
 		debug:      clh.config.Debug,
 		cache:      clh.config.VirtioFSCache,
+		logPath:    filepath.Join(clh.store.RunVMStoragePath(), id, "virtiofsd.log"),
 	}
 
 	if clh.config.SGXEPCSize > 0 {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -643,6 +643,7 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 		extraArgs:  q.config.VirtioFSExtraArgs,
 		debug:      q.config.Debug,
 		cache:      q.config.VirtioFSCache,
+		logPath:    filepath.Join(q.store.RunVMStoragePath(), id, "virtiofsd.log"),
 	}
 
 	return nil


### PR DESCRIPTION
The virtiofsd logs are currently going to the journal, thanks
to the `--syslog` passed to the command when startint it up.

However, the magnitute of the virtiofsd logs is not exactly
small and it can cause issues due to systemd throttling the
journal.

Fixes: #2045

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>