### PR TITLE
ci: snap: Fetch history to all branches and tags

### DIFF
--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -6,6 +6,8 @@ jobs:
     steps:
       - name: Check out
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
 
       - name: Install Snapcraft
         uses: samuelmeuli/action-snapcraft@v1


### PR DESCRIPTION
The snap/snapcraft.yaml set AGENT_VERSION to the current VERSION. The osbuilder script
will try to checkout the AGENT_VERSION tag. Let's ensure that all tags and branches
are fetched by the github's checkout action so the tag checkout does not fail.

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>