### PR TITLE
agent: delete some lint attributes

### DIFF
--- a/src/agent/rustjail/src/cgroups/notifier.rs
+++ b/src/agent/rustjail/src/cgroups/notifier.rs
@@ -139,19 +139,6 @@ async fn notify_on_oom(cid: &str, dir: String) -> Result<Receiver<String>> {
     register_memory_event(cid, dir, "memory.oom_control", "").await
 }
 
-// level is one of "low", "medium", or "critical"
-async fn notify_memory_pressure(cid: &str, dir: String, level: &str) -> Result<Receiver<String>> {
-    if dir.is_empty() {
-        return Err(anyhow!("memory controller missing"));
-    }
-
-    if level != "low" && level != "medium" && level != "critical" {
-        return Err(anyhow!("invalid pressure level {}", level));
-    }
-
-    register_memory_event(cid, dir, "memory.pressure_level", level).await
-}
-
 async fn register_memory_event(
     cid: &str,
     cg_dir: String,

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -62,10 +62,7 @@ use tokio::sync::Mutex;
 
 use crate::utils;
 
-const STATE_FILENAME: &str = "state.json";
 const EXEC_FIFO_FILENAME: &str = "exec.fifo";
-const VER_MARKER: &str = "1.2.5";
-const PID_NS_PATH: &str = "/proc/self/ns/pid";
 
 const INIT: &str = "INIT";
 const NO_PIVOT: &str = "NO_PIVOT";
@@ -92,10 +89,6 @@ impl ContainerStatus {
 
     fn status(&self) -> ContainerState {
         self.cur_status
-    }
-
-    fn pre_status(&self) -> ContainerState {
-        self.pre_status
     }
 
     fn transition(&mut self, to: ContainerState) {
@@ -1401,17 +1394,7 @@ impl LinuxContainer {
             logger: logger.new(o!("module" => "rustjail", "subsystem" => "container", "cid" => id)),
         })
     }
-
-    fn load<T: Into<String>>(_id: T, _base: T) -> Result<Self> {
-        Err(anyhow!("not supported"))
-    }
 }
-
-// Handle the differing rlimit types for different targets
-#[cfg(target_env = "musl")]
-type RlimitsType = libc::c_int;
-#[cfg(target_env = "gnu")]
-type RlimitsType = libc::__rlimit_resource_t;
 
 fn setgroups(grps: &[libc::gid_t]) -> Result<()> {
     let ret = unsafe { libc::setgroups(grps.len(), grps.as_ptr() as *const libc::gid_t) };
@@ -1626,7 +1609,7 @@ mod tests {
             let pre_status = status.status();
             status.transition(*s);
 
-            assert_eq!(pre_status, status.pre_status());
+            assert_eq!(pre_status, status.pre_status);
         }
     }
 

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -3,15 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// #![allow(unused_attributes)]
-// #![allow(unused_imports)]
-// #![allow(unused_variables)]
-// #![allow(unused_mut)]
-#![allow(dead_code)]
-// #![allow(deprecated)]
-// #![allow(unused_must_use)]
 #![allow(non_upper_case_globals)]
-// #![allow(unused_comparisons)]
 #[macro_use]
 #[cfg(test)]
 extern crate serial_test;
@@ -464,10 +456,6 @@ fn linux_grpc_to_oci(l: &grpc::Linux) -> oci::Linux {
     }
 }
 
-fn linux_oci_to_grpc(_l: &oci::Linux) -> grpc::Linux {
-    grpc::Linux::default()
-}
-
 pub fn grpc_to_oci(grpc: &grpc::Spec) -> oci::Spec {
     // process
     let process = if grpc.Process.is_some() {
@@ -523,7 +511,6 @@ pub fn grpc_to_oci(grpc: &grpc::Spec) -> oci::Spec {
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_macros)]
     #[macro_export]
     macro_rules! skip_if_not_root {
         () => {

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -104,7 +104,6 @@ lazy_static! {
 }
 
 #[inline(always)]
-#[allow(unused_variables)]
 pub fn mount<
     P1: ?Sized + NixPath,
     P2: ?Sized + NixPath,
@@ -124,7 +123,6 @@ pub fn mount<
 }
 
 #[inline(always)]
-#[allow(unused_variables)]
 pub fn umount2<P: ?Sized + NixPath>(
     target: &P,
     flags: MntFlags,
@@ -444,7 +442,6 @@ fn mount_cgroups(
     Ok(())
 }
 
-#[allow(unused_variables)]
 fn pivot_root<P1: ?Sized + NixPath, P2: ?Sized + NixPath>(
     new_root: &P1,
     put_old: &P2,
@@ -577,7 +574,6 @@ fn parse_mount_table() -> Result<Vec<Info>> {
 }
 
 #[inline(always)]
-#[allow(unused_variables)]
 fn chroot<P: ?Sized + NixPath>(path: &P) -> Result<(), nix::Error> {
     #[cfg(not(test))]
     return unistd::chroot(path);

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -556,7 +556,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[allow(unused_assignments)]
     async fn unset_and_remove_sandbox_storage() {
         skip_if_not_root!();
 
@@ -590,7 +589,7 @@ mod tests {
         assert_eq!(s.set_sandbox_storage(&destdir_path), true);
         assert!(s.unset_and_remove_sandbox_storage(&destdir_path).is_ok());
 
-        let mut other_dir_str = String::new();
+        let other_dir_str;
         {
             // Create another folder in a separate scope to ensure that is
             // deleted

--- a/src/agent/src/test_utils.rs
+++ b/src/agent/src/test_utils.rs
@@ -7,7 +7,6 @@
 #[cfg(test)]
 mod test_utils {
     #[macro_export]
-    #[allow(unused_macros)]
     macro_rules! skip_if_root {
         () => {
             if nix::unistd::Uid::effective().is_root() {
@@ -18,7 +17,6 @@ mod test_utils {
     }
 
     #[macro_export]
-    #[allow(unused_macros)]
     macro_rules! skip_if_not_root {
         () => {
             if !nix::unistd::Uid::effective().is_root() {
@@ -29,7 +27,6 @@ mod test_utils {
     }
 
     #[macro_export]
-    #[allow(unused_macros)]
     macro_rules! skip_loop_if_root {
         ($msg:expr) => {
             if nix::unistd::Uid::effective().is_root() {
@@ -44,7 +41,6 @@ mod test_utils {
     }
 
     #[macro_export]
-    #[allow(unused_macros)]
     macro_rules! skip_loop_if_not_root {
         ($msg:expr) => {
             if !nix::unistd::Uid::effective().is_root() {


### PR DESCRIPTION
These lint attributes can be deleted to keep clean code.

Fixes: #2059

Signed-off-by: bin <bin@hyper.sh>