### PR TITLE
docs: fix brackets usage error for developer guide

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -356,10 +356,10 @@ You MUST choose one of `alpine`, `centos`, `clearlinux`, `euleros`, and `fedora`
 
 Optionally, add your custom agent binary to the rootfs with the following, `LIBC` default is `musl`, if `ARCH` is `ppc64le`, should set the `LIBC=gnu` and `ARCH=powerpc64le`:
 ```
-$ export ARCH=$(shell uname -m)
+$ export ARCH=$(uname -m)
 $ [ ${ARCH} == "ppc64le" ] && export LIBC=gnu || export LIBC=musl
 $ [ ${ARCH} == "ppc64le" ] && export ARCH=powerpc64le
-$ sudo install -o root -g root -m 0550 -T ../../../src/agent/target/$(ARCH)-unknown-linux-$(LIBC)/release/kata-agent ${ROOTFS_DIR}/sbin/init
+$ sudo install -o root -g root -m 0550 -T ../../../src/agent/target/${ARCH}-unknown-linux-${LIBC}/release/kata-agent ${ROOTFS_DIR}/sbin/init
 ```
 
 ### Build an initrd image


### PR DESCRIPTION
Fixed 3 errors which misused the bracket to substitute parameter for initrd-img creation at the developer guide.

Fixes: #2079

Signed-off-by: Sheng Zhao <zhaosheng.ste@bytedance.com>