### PR TITLE
runtime: Enable "memory_offset" annotation by default

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -159,7 +159,7 @@ DEFMEMSZ := 2048
 DEFMEMSLOTS := 10
 #Default number of bridges
 DEFBRIDGES := 1
-DEFENABLEANNOTATIONS := []
+DEFENABLEANNOTATIONS := [ \"memory_offset\" ]
 DEFDISABLEGUESTSECCOMP := true
 #Default experimental features enabled
 DEFAULTEXPFEATURES := []


### PR DESCRIPTION
Let's ease the life of our uses by allowing them to set "memory_offset"
annotation, which is needed when using PMEM-CSI (see:
https://github.com/intel/pmem-csi/issues/987#issuecomment-864187971),
by default.

Fixes: #2088

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>