### PR TITLE
runtime: report finish time in containers stats

### DIFF
--- a/src/runtime/containerd-shim-v2/service.go
+++ b/src/runtime/containerd-shim-v2/service.go
@@ -623,6 +623,7 @@ func (s *service) State(ctx context.Context, r *taskAPI.StateRequest) (_ *taskAP
 			Stderr:     c.stderr,
 			Terminal:   c.terminal,
 			ExitStatus: c.exit,
+			ExitedAt:   c.exitTime,
 		}, nil
 	}
 
@@ -642,6 +643,7 @@ func (s *service) State(ctx context.Context, r *taskAPI.StateRequest) (_ *taskAP
 		Stderr:     execs.tty.stderr,
 		Terminal:   execs.tty.terminal,
 		ExitStatus: uint32(execs.exitCode),
+		ExitedAt:   execs.exitTime,
 	}, nil
 }
 


### PR DESCRIPTION
Make sure we report the exit time for the container when we answer a "Status" request.

Fixes: #2096

Signed-off-by: Julien Ropé <jrope@redhat.com>