### PR TITLE
kernel: Add Secure Execution guest

### DIFF
--- a/tools/packaging/kernel/configs/fragments/s390/secure-execution.conf
+++ b/tools/packaging/kernel/configs/fragments/s390/secure-execution.conf
@@ -1,0 +1,3 @@
+# IBM Secure Execution (Protected Virtualization in kernel)
+
+CONFIG_PROTECTED_VIRTUALIZATION_GUEST=y


### PR DESCRIPTION
Add `CONFIG_PROTECTED_VIRTUALIZATION_GUEST=y` to s390's guest kernel
config, which enables running with a secure image (as generated by
s390-tools' `genprotimg`).

Fixes: #2106
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

SEV uses the `-x` flag for enabling a confidential guest kernel build.
However, because enabling `CONFIG_PROTECTED_VIRTUALIZATION_GUEST` does not increase kernel size at all, and because it does no harm when used without Secure Execution, I think it's okay (and just easier) to add it for all.
/cc @sameo @magowan @jimcadden @fitzthum