### PR TITLE
cargo: Disable verbose build

### DIFF
--- a/src/trace-forwarder/Makefile
+++ b/src/trace-forwarder/Makefile
@@ -6,7 +6,7 @@
 default: build
 
 build:
-	RUSTFLAGS="--deny warnings" cargo build -v
+	RUSTFLAGS="--deny warnings" cargo build
 
 clean:
 	cargo clean

--- a/tools/agent-ctl/Makefile
+++ b/tools/agent-ctl/Makefile
@@ -6,7 +6,7 @@
 default: build
 
 build:
-	RUSTFLAGS="--deny warnings" cargo build -v
+	RUSTFLAGS="--deny warnings" cargo build
 
 clean:
 	cargo clean


### PR DESCRIPTION
There are no reasons why we'd want all those gory details by default.

Fixes #2112

Signed-off-by: Samuel Ortiz <samuel.e.ortiz@protonmail.com>