### PR TITLE
agent: fix wrong regular exp to fetch guest-cid

### DIFF
--- a/tools/agent-ctl/README.md
+++ b/tools/agent-ctl/README.md
@@ -80,7 +80,7 @@ $ sudo docker export $(sudo docker create "$image") | tar -C "$rootfs_dir" -xvf 
    value:
 
    ```sh
-   $ guest_cid=$(ps -ef | grep qemu-system-x86_64 | egrep -o "guest-cid=[^,][^,]*" | cut -d= -f2)
+   $ guest_cid=$(ps -ef | grep qemu-system-x86_64 | egrep -o "guest-cid=[0-9]*" | cut -d= -f2)
    ```
 
 1. Run the tool to connect to the agent:


### PR DESCRIPTION
Fix the incorrect regular expression to fetch the guest context ID.
In " [^,][^,]* ", [^,]* will match to the next ",", 
which is after "socket",  so finally got incorrect result.
It's better to match the contect ID by using " egrep -o "guest-cid=[0-9]*" ".

Fixes: #2124

Signed-off-by: Liang Zhou <zhoul110@chinatelecom.cn>