### PR TITLE
tools: agent-ctl: Fix build failure

### DIFF
--- a/tools/agent-ctl/Cargo.lock
+++ b/tools/agent-ctl/Cargo.lock
@@ -636,19 +636,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3728fec49d363a50a8828a190b379a446cc5cf085c06259bbbeb34447e4ec7"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 1.0.0",
- "libc",
- "memoffset",
-]
-
-[[package]]
 name = "ntapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"


### PR DESCRIPTION
Two nix packages with the same version are specified from the lock file.

Fixes #2126

Signed-off-by: Samuel Ortiz <samuel.e.ortiz@protonmail.com>