### PR TITLE
osbuilder: Update default Fedora version to 34

### DIFF
--- a/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
@@ -14,6 +14,7 @@ RUN dnf -y update && dnf install -y \
     chrony \
     coreutils \
     curl \
+    fedora-release-common \
     gcc \
     gcc-c++ \
     git \
@@ -30,7 +31,6 @@ RUN dnf -y update && dnf install -y \
     m4 \
     make \
     pkgconfig \
-    redhat-release \
     sed \
     systemd \
     tar \

--- a/tools/osbuilder/rootfs-builder/fedora/config.sh
+++ b/tools/osbuilder/rootfs-builder/fedora/config.sh
@@ -5,7 +5,7 @@
 
 OS_NAME="Fedora"
 
-OS_VERSION=${OS_VERSION:-30}
+OS_VERSION=${OS_VERSION:-34}
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"
 


### PR DESCRIPTION
In order to do the change, let's also stop installing the
`redhat-release` package, as its been replaced by the
`fedora-release-common` one.

Fixes: #2116

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>