### PR TITLE
agent: use the same version of netlink lib

### DIFF
--- a/src/agent/.gitignore
+++ b/src/agent/.gitignore
@@ -1,1 +1,2 @@
 tarpaulin-report.html
+vendor/

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -530,8 +530,8 @@ dependencies = [
  "libc",
  "log",
  "logging",
- "netlink-packet-utils 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "netlink-sys 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "netlink-packet-utils",
+ "netlink-sys",
  "nix 0.21.0",
  "oci",
  "opentelemetry",
@@ -689,7 +689,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "libc",
- "netlink-packet-utils 0.4.0 (git+https://github.com/little-dude/netlink?rev=a9367bc4700496ddebc088110c28f40962923326)",
+ "netlink-packet-utils",
 ]
 
 [[package]]
@@ -702,19 +702,7 @@ dependencies = [
  "byteorder",
  "libc",
  "netlink-packet-core",
- "netlink-packet-utils 0.4.0 (git+https://github.com/little-dude/netlink?rev=a9367bc4700496ddebc088110c28f40962923326)",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2afb159d0e3ac700e85f0df25b8438b99d43ed0c0b685242fcdf1b5673e54d"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror",
+ "netlink-packet-utils",
 ]
 
 [[package]]
@@ -737,21 +725,9 @@ dependencies = [
  "futures",
  "log",
  "netlink-packet-core",
- "netlink-sys 0.6.0 (git+https://github.com/little-dude/netlink?rev=a9367bc4700496ddebc088110c28f40962923326)",
+ "netlink-sys",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "netlink-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d61c5374735aa0cd07cb7fd820b656062b187b5588d79517f72956b57c6de9ef"
-dependencies = [
- "futures",
- "libc",
- "log",
- "tokio",
 ]
 
 [[package]]

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -30,10 +30,7 @@ tokio = { version = "1.2.0", features = ["full"] }
 tokio-vsock = "0.3.1"
 
 netlink-sys = { version = "0.6.0", features = ["tokio_socket",]}
-# Because the author has no time to maintain the crate, we switch the dependency to github,
-# Once the new version released on crates.io, we switch it back.
-# https://github.com/little-dude/netlink/issues/161
-rtnetlink = { git = "https://github.com/little-dude/netlink", rev = "a9367bc4700496ddebc088110c28f40962923326" }
+rtnetlink = "0.7.0"
 netlink-packet-utils = "0.4.0"
 ipnetwork = "0.17.0"
 
@@ -72,3 +69,11 @@ members = [
 
 [profile.release]
 lto = true
+
+[patch.crates-io]
+# Because the author has no time to maintain the crate, we switch the dependency to github,
+# Once the new version released on crates.io, we switch it back.
+# https://github.com/little-dude/netlink/issues/161
+rtnetlink = { git = "https://github.com/little-dude/netlink", rev = "a9367bc4700496ddebc088110c28f40962923326" }
+netlink-packet-utils = { git = "https://github.com/little-dude/netlink", rev = "a9367bc4700496ddebc088110c28f40962923326" }
+netlink-sys = { git = "https://github.com/little-dude/netlink", rev = "a9367bc4700496ddebc088110c28f40962923326", features = ["tokio_socket",] }


### PR DESCRIPTION
Using different netlink crate from crate.io and github.com
will not work for `cargo vendor`, using `patch` command to
replace the dependencies will resolve this problem.

Fixes: #2111

Signed-off-by: bin <bin@hyper.sh>