### PR TITLE
agent: respect cpu which is already online

### DIFF
--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -388,16 +388,16 @@ fn online_resources(logger: &Logger, path: &str, pattern: &str, num: i32) -> Res
             }
             let c = c.unwrap();
 
-            if c.trim().contains('0') {
+            if c.trim().contains('0') { // otherwise, cpu is already online
                 let r = fs::write(file.as_str(), "1");
                 if r.is_err() {
                     continue;
                 }
-                count += 1;
+            }
+            count += 1;
 
-                if num > 0 && count == num {
-                    break;
-                }
+            if num > 0 && count == num {
+                break;
             }
         }
     }


### PR DESCRIPTION
If an hotplugged cpu was onlined by some other component, agent
will fail use it.

Fixes: #2130
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>