### PR TITLE
forwarder: Add dump only option

### DIFF
--- a/src/trace-forwarder/src/server.rs
+++ b/src/trace-forwarder/src/server.rs
@@ -21,6 +21,7 @@ pub struct VsockTraceServer {
     pub jaeger_service_name: String,
 
     pub logger: Logger,
+    pub dump_only: bool,
 }
 
 impl VsockTraceServer {
@@ -31,16 +32,18 @@ impl VsockTraceServer {
         jaeger_host: &str,
         jaeger_port: u32,
         jaeger_service_name: &str,
+        dump_only: bool,
     ) -> Self {
         let logger = logger.new(o!("subsystem" => "server"));
 
         VsockTraceServer {
-            vsock_port: vsock_port,
-            vsock_cid: vsock_cid,
+            vsock_port,
+            vsock_cid,
             jaeger_host: jaeger_host.to_string(),
-            jaeger_port: jaeger_port,
+            jaeger_port,
             jaeger_service_name: jaeger_service_name.to_string(),
-            logger: logger,
+            logger,
+            dump_only,
         }
     }
 
@@ -71,7 +74,7 @@ impl VsockTraceServer {
 
                     let logger = self.logger.new(o!());
 
-                    let f = handler::handle_connection(logger, conn, &mut exporter);
+                    let f = handler::handle_connection(logger, conn, &mut exporter, self.dump_only);
 
                     block_on(f)?;
                 }


### PR DESCRIPTION
Added a `--dump-only` option which disables forwarding of trace spans.
This essentially makes the forwarder a NOP but can be useful for testing
purposes.

Fixes: #2132.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>