### PR TITLE
runtime: Remove the version check for cloud hypervisor

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -63,8 +63,6 @@ const (
 	clhSocket             = "clh.sock"
 	clhAPISocket          = "clh-api.sock"
 	virtioFsSocket        = "virtiofsd.sock"
-	supportedMajorVersion = 0
-	supportedMinorVersion = 5
 	defaultClhPath        = "/usr/local/bin/cloud-hypervisor"
 	virtioFsCacheAlways   = "always"
 )
@@ -95,12 +93,6 @@ type clhClient interface {
 	VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error)
 }
 
-type CloudHypervisorVersion struct {
-	Major    int
-	Minor    int
-	Revision int
-}
-
 //
 // Cloud hypervisor state
 //
@@ -123,7 +115,6 @@ type cloudHypervisor struct {
 	config    HypervisorConfig
 	ctx       context.Context
 	APIClient clhClient
-	version   CloudHypervisorVersion
 	vmconfig  chclient.VmConfig
 	virtiofsd Virtiofsd
 	store     persistapi.PersistDriver
@@ -150,18 +141,6 @@ var clhDebugKernelParams = []Param{
 //
 //###########################################################
 
-func (clh *cloudHypervisor) checkVersion() error {
-	if clh.version.Major < supportedMajorVersion || (clh.version.Major == supportedMajorVersion && clh.version.Minor < supportedMinorVersion) {
-		errorMessage := fmt.Sprintf("Unsupported version: cloud-hypervisor %d.%d not supported by this driver version (%d.%d)",
-			clh.version.Major,
-			clh.version.Minor,
-			supportedMajorVersion,
-			supportedMinorVersion)
-		return errors.New(errorMessage)
-	}
-	return nil
-}
-
 // For cloudHypervisor this call only sets the internal structure up.
 // The VM will be created and started through startSandbox().
 func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
@@ -179,23 +158,6 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 	clh.id = id
 	clh.config = *hypervisorConfig
 	clh.state.state = clhNotReady
-
-	// version check only applicable to 'cloud-hypervisor' executable
-	clhPath, perr := clh.clhPath()
-	if perr != nil {
-		return perr
-
-	}
-	if strings.HasSuffix(clhPath, "cloud-hypervisor") {
-		err = clh.getAvailableVersion()
-		if err != nil {
-			return err
-		}
-
-		if err := clh.checkVersion(); err != nil {
-			return err
-		}
-	}
 
 	clh.Logger().WithField("function", "createSandbox").Info("creating Sandbox")
 
@@ -878,59 +840,6 @@ func (clh *cloudHypervisor) clhPath() (string, error) {
 	}
 
 	return p, nil
-}
-
-func (clh *cloudHypervisor) getAvailableVersion() error {
-
-	clhPath, err := clh.clhPath()
-	if err != nil {
-		return err
-	}
-
-	cmd := exec.Command(clhPath, "--version")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return err
-	}
-
-	words := strings.Fields(string(out))
-	if len(words) != 2 {
-		return errors.New("Failed to parse cloud-hypervisor version response. Illegal length")
-	}
-	versionSplit := strings.SplitN(words[1], ".", -1)
-	if len(versionSplit) != 3 {
-		return errors.New("Failed to parse cloud-hypervisor version field. Illegal length")
-
-	}
-
-	// Remove 'v' prefix if has one
-	versionSplit[0] = strings.TrimLeft(versionSplit[0], "v")
-	major, err := strconv.ParseUint(versionSplit[0], 10, 64)
-	if err != nil {
-		return err
-	}
-	minor, err := strconv.ParseUint(versionSplit[1], 10, 64)
-	if err != nil {
-		return err
-	}
-
-	// revision could have aditional commit information separated by '-'
-	revisionSplit := strings.SplitN(versionSplit[2], "-", -1)
-	if len(revisionSplit) < 1 {
-		return errors.Errorf("Failed parse cloud-hypervisor revision %s", versionSplit[2])
-	}
-	revision, err := strconv.ParseUint(revisionSplit[0], 10, 64)
-	if err != nil {
-		return err
-	}
-
-	clh.version = CloudHypervisorVersion{
-		Major:    int(major),
-		Minor:    int(minor),
-		Revision: int(revision),
-	}
-	return nil
-
 }
 
 func (clh *cloudHypervisor) launchClh() (int, error) {

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -321,50 +320,6 @@ func TestCloudHypervisorResizeMemory(t *testing.T) {
 				t.Errorf("cloudHypervisor.resizeMemory() got = %+v, want %+v", memDev, tt.expectedMemDev)
 			}
 		})
-	}
-}
-
-func TestCheckVersion(t *testing.T) {
-	clh := &cloudHypervisor{}
-	assert := assert.New(t)
-	testcases := []struct {
-		name  string
-		major int
-		minor int
-		pass  bool
-	}{
-		{
-			name:  "minor lower than supported version",
-			major: supportedMajorVersion,
-			minor: 2,
-			pass:  false,
-		},
-		{
-			name:  "minor equal to supported version",
-			major: supportedMajorVersion,
-			minor: supportedMinorVersion,
-			pass:  true,
-		},
-		{
-			name:  "major exceeding supported version",
-			major: 1,
-			minor: supportedMinorVersion,
-			pass:  true,
-		},
-	}
-	for _, tc := range testcases {
-		clh.version = CloudHypervisorVersion{
-			Major:    tc.major,
-			Minor:    tc.minor,
-			Revision: 0,
-		}
-		err := clh.checkVersion()
-		msg := fmt.Sprintf("test: %+v, clh.version: %v, result: %v", tc, clh.version, err)
-		if tc.pass {
-			assert.NoError(err, msg)
-		} else {
-			assert.Error(err, msg)
-		}
 	}
 }
 


### PR DESCRIPTION
It looks like the version check for cloud hypervisor (clh) was added
initially when clh was actively evolving its API. We no longer need the
version check as clh API has been fairly stable for its recent releases.

Fixes: #1991

Signed-off-by: Bo Chen <chen.bo@intel.com>