### PR TITLE
runtime: Use CC=gcc on all RPM-based s390x

### DIFF
--- a/src/runtime/arch/s390x-options.mk
+++ b/src/runtime/arch/s390x-options.mk
@@ -13,8 +13,8 @@ CPUFEATURES :=
 QEMUCMD := qemu-system-s390x
 
 # See https://github.com/kata-containers/osbuilder/issues/217
-FEDORA_LIKE = $(shell grep -E "\<fedora\>" /etc/os-release 2> /dev/null)
-ifneq (,$(FEDORA_LIKE))
+NEEDS_CC_SETTING = $(shell grep -E "\<(fedora|suse)\>" /etc/os-release 2> /dev/null)
+ifneq (,$(NEEDS_CC_SETTING))
 	CC := gcc
 	export CC
 endif


### PR DESCRIPTION
as both Fedora-likes and SUSE need this.

Fixes: #2167
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>