### PR TITLE
osbuilder: Skip installing golang for building rootfs

### DIFF
--- a/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
@@ -34,7 +34,6 @@ RUN yum -y update && yum install -y \
     vim \
     which
 
+# This will install the proper packages to build Kata components
 @INSTALL_MUSL@
-# This will install the proper golang to build Kata components
-@INSTALL_GO@
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
@@ -37,7 +37,6 @@ RUN dnf -y update && dnf install -y \
     vim \
     which
 
-# This will install the proper golang to build Kata components
+# This will install the proper packages to build Kata components
 @INSTALL_MUSL@
-@INSTALL_GO@
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in
@@ -29,7 +29,6 @@ RUN apt-get update && apt-get install -y \
     systemd \
     tar \
     vim
-# This will install the proper golang to build Kata components
-@INSTALL_GO@
+# This will install the proper packages to build Kata components
 @INSTALL_MUSL@
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
@@ -36,6 +36,5 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
     vim \
     wget
 
-# This will install the proper golang to build Kata components
-@INSTALL_GO@
+# This will install the proper packages to build Kata components
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
@@ -37,7 +37,6 @@ RUN dnf -y update && dnf install -y \
     vim \
     which
 
-# This will install the proper golang to build Kata components
+# This will install the proper packages to build Kata components
 @INSTALL_MUSL@
-@INSTALL_GO@
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/gentoo/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/gentoo/Dockerfile.in
@@ -9,6 +9,5 @@ FROM ${IMAGE_REGISTRY}/gentoo/stage3-amd64:latest
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)
 
-# This will install the proper golang to build Kata components
-@INSTALL_GO@
+# This will install the proper rust to build Kata components
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/suse/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/suse/Dockerfile.in
@@ -15,7 +15,6 @@ COPY install-packages.sh config.sh /
 # RUN commands
 RUN chmod +x /install-packages.sh; /install-packages.sh
 
-# This will install the proper golang to build Kata components
+# This will install the proper packages to build Kata components
 @INSTALL_MUSL@
-@INSTALL_GO@
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/template/Dockerfile.template
+++ b/tools/osbuilder/rootfs-builder/template/Dockerfile.template
@@ -13,5 +13,6 @@ FROM ${IMAGE_REGISTRY}/@distro@:@OS_VERSION@
 
 # RUN commands
 
-# This will install the proper golang to build Kata components
-@INSTALL_GO@
+# This will install the proper packages to build Kata components
+@INSTALL_MUSL@
+@INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
@@ -33,7 +33,6 @@ RUN apt-get update && apt-get install -y \
     systemd \
     tar \
     vim
-# This will install the proper golang to build Kata components
-@INSTALL_GO@
+# This will install the proper packages to build Kata components
 @INSTALL_MUSL@
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -40,6 +40,6 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
     tar \
     vim \
     wget
-# This will install the proper golang to build Kata components
-@INSTALL_GO@
+
+# This will install the proper packages to build Kata components
 @INSTALL_RUST@

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -150,6 +150,8 @@ build_rootfs()
 	else
 		DNF="${DNF} --releasever=${OS_VERSION}"
 	fi
+
+	info "install packages for rootfs"
 	$DNF install ${EXTRA_PKGS} ${PACKAGES}
 }
 
@@ -190,14 +192,8 @@ create_summary_file()
 	local agent="${AGENT_DEST}"
 	[ "$AGENT_INIT" = yes ] && agent="${init}"
 
-	local agent_version
-	if [ "${RUST_AGENT}" == "no" ]; then
-		agent_version=$("$agent" --version|awk '{print $NF}')
-	else
-		local -r agentdir="${script_dir}/../../../"
-		agent_version=$(cat ${agentdir}/VERSION)
-	fi
-
+	local -r agentdir="${script_dir}/../../../"
+	local -r agent_version=$(cat ${agentdir}/VERSION)
 
 	cat >"$file"<<-EOT
 	---
@@ -241,36 +237,19 @@ generate_dockerfile()
 	local libc=musl
 	case "$(uname -m)" in
 		"ppc64le")
-			goarch=ppc64le
 			rustarch=powerpc64le
 			muslarch=powerpc64
 			libc=gnu
 			;;
-
-		"aarch64")
-			goarch=arm64
-			;;
 		"s390x")
-			goarch=s390x
 			libc=gnu
 			;;
 
 		*)
-			goarch=amd64
 			;;
 	esac
 
 	[ -n "${http_proxy:-}" ] && readonly set_proxy="RUN sed -i '$ a proxy="${http_proxy:-}"' /etc/dnf/dnf.conf /etc/yum.conf; true"
-
-	curlOptions=("-OL")
-	[ -n "${http_proxy:-}" ] && curlOptions+=("-x ${http_proxy:-}")
-
-	readonly install_go="
-RUN cd /tmp ; curl ${curlOptions[@]} https://storage.googleapis.com/golang/go${GO_VERSION}.linux-${goarch}.tar.gz
-RUN tar -C /usr/ -xzf /tmp/go${GO_VERSION}.linux-${goarch}.tar.gz
-ENV GOROOT=/usr/go
-ENV PATH=\$PATH:\$GOROOT/bin:\$GOPATH/bin
-"
 
 	# Rust agent
 	# rust installer should set path apropiately, just in case
@@ -327,8 +306,6 @@ RUN . /root/.cargo/env; \
 	rustup target install ${rustarch}-unknown-linux-${libc}
 RUN ln -sf /usr/bin/g++ /bin/musl-g++
 "
-	# rust agent still need go to build
-	# because grpc-sys need go to build
 	pushd "${dir}"
 	dockerfile_template="Dockerfile.in"
 	dockerfile_arch_template="Dockerfile-${architecture}.in"
@@ -342,38 +319,20 @@ RUN ln -sf /usr/bin/g++ /bin/musl-g++
 	# ppc64le and s390x have no musl target
 	if [ "${architecture}" == "ppc64le" ] || [ "${architecture}" == "s390x" ]; then
 		sed \
-			-e "s|@GO_VERSION@|${GO_VERSION}|g" \
 			-e "s|@OS_VERSION@|${OS_VERSION:-}|g" \
 			-e "s|@INSTALL_MUSL@||g" \
-			-e "s|@INSTALL_GO@|${install_go//$'\n'/\\n}|g" \
 			-e "s|@INSTALL_RUST@|${install_rust//$'\n'/\\n}|g" \
 			-e "s|@SET_PROXY@|${set_proxy:-}|g" \
 			"${dockerfile_template}" > Dockerfile
 	else
 		sed \
-			-e "s|@GO_VERSION@|${GO_VERSION}|g" \
 			-e "s|@OS_VERSION@|${OS_VERSION:-}|g" \
 			-e "s|@INSTALL_MUSL@|${install_musl//$'\n'/\\n}|g" \
-			-e "s|@INSTALL_GO@|${install_go//$'\n'/\\n}|g" \
 			-e "s|@INSTALL_RUST@|${install_rust//$'\n'/\\n}|g" \
 			-e "s|@SET_PROXY@|${set_proxy:-}|g" \
 			"${dockerfile_template}" > Dockerfile
 	fi
 	popd
-}
-
-detect_go_version()
-{
-	info "Detecting go version"
-	typeset yq=$(command -v yq || command -v ${GOPATH}/bin/yq || echo "${GOPATH}/bin/yq")
-	if [ ! -f "$yq" ]; then
-		source "$yq_file"
-	fi
-
-	info "Get Go version from ${kata_versions_file}"
-	GO_VERSION="$(cat "${kata_versions_file}"  | $yq r -X - "languages.golang.meta.newest-version")"
-
-	[ "$?" == "0" ] && [ "$GO_VERSION" != "null" ]
 }
 
 detect_rust_version()
@@ -385,7 +344,7 @@ detect_rust_version()
 	fi
 
 	info "Get rust version from ${kata_versions_file}"
-	RUST_VERSION="$(cat "${kata_versions_file}"  | $yq r -X - "languages.rust.meta.newest-version")"
+	RUST_VERSION="$(cat "${kata_versions_file}" | $yq r -X - "languages.rust.meta.newest-version")"
 
 	[ "$?" == "0" ] && [ "$RUST_VERSION" != "null" ]
 }


### PR DESCRIPTION
Building rootfs does not depend on golang, delete intalling
golang may save build time.

And there is only rust agent now, the code for golang agent should
be deleted too.

Fixes: #2170

Signed-off-by: bin <bin@hyper.sh>