### PR TITLE
docs: Update containerd configuration format

### DIFF
--- a/docs/install/container-manager/containerd/containerd-install.md
+++ b/docs/install/container-manager/containerd/containerd-install.md
@@ -98,12 +98,12 @@
 
     ```toml
     [plugins]
-        [plugins.cri]
-            [plugins.cri.containerd]
-            default_runtime_name = "kata"
-
-            [plugins.cri.containerd.runtimes.kata]
-            runtime_type = "io.containerd.kata.v2"
+      [plugins."io.containerd.grpc.v1.cri"]
+        [plugins."io.containerd.grpc.v1.cri".containerd]
+          default_runtime_name = "kata"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
+              runtime_type = "io.containerd.kata.v2"
     ```
 
     > **Note:**


### PR DESCRIPTION
`containerd` has adopted a new configuration style. Update the example configuration to reflect the change.

Resolves https://github.com/kata-containers/kata-containers/issues/2180