### PR TITLE
tracing: Consolidate tracing into a new katatrace package

### DIFF
--- a/src/runtime/containerd-shim-v2/create.go
+++ b/src/runtime/containerd-shim-v2/create.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containerd/typeurl"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
-	otelTrace "go.opentelemetry.io/otel/trace"
 
 	// only register the proto type
 	crioption "github.com/containerd/containerd/pkg/runtimeoptions/v1"
@@ -27,6 +26,7 @@ import (
 	_ "github.com/containerd/containerd/runtime/v2/runc/options"
 
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/compatoci"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/oci"
@@ -69,19 +69,24 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 		// create tracer
 		// This is the earliest location we can create the tracer because we must wait
 		// until the runtime config is loaded
-		_, err = katautils.CreateTracer("kata", s.config)
+		jaegerConfig := &katatrace.JaegerConfig{
+			JaegerEndpoint: s.config.JaegerEndpoint,
+			JaegerUser:     s.config.JaegerUser,
+			JaegerPassword: s.config.JaegerPassword,
+		}
+		_, err = katatrace.CreateTracer("kata", jaegerConfig)
 		if err != nil {
 			return nil, err
 		}
 
 		// create root span
-		var rootSpan otelTrace.Span
-		rootSpan, s.rootCtx = trace(s.ctx, "root span")
+		rootSpan, newCtx := katatrace.Trace(s.ctx, shimLog, "root span", shimTracingTags)
+		s.rootCtx = newCtx
 		defer rootSpan.End()
 
 		// create span
-		var span otelTrace.Span
-		span, s.ctx = trace(s.rootCtx, "create")
+		span, newCtx := katatrace.Trace(s.rootCtx, shimLog, "create", shimTracingTags)
+		s.ctx = newCtx
 		defer span.End()
 
 		if rootFs.Mounted, err = checkAndMount(s, r); err != nil {
@@ -116,8 +121,7 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 		go s.startManagementServer(ctx, ociSpec)
 
 	case vc.PodContainer:
-		var span otelTrace.Span
-		span, ctx = trace(s.ctx, "create")
+		span, ctx := katatrace.Trace(s.ctx, shimLog, "create", shimTracingTags)
 		defer span.End()
 
 		if s.sandbox == nil {

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	govmmQemu "github.com/kata-containers/govmm/qemu"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/device/config"
 	exp "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/experimental"
@@ -26,11 +27,6 @@ import (
 
 const (
 	defaultHypervisor = vc.QemuHypervisor
-)
-
-var (
-	// if true, enable opentracing support.
-	tracing = false
 )
 
 // The TOML configuration file contains a number of sections (or
@@ -1116,7 +1112,7 @@ func LoadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 	}
 
 	config.Trace = tomlConf.Runtime.Tracing
-	tracing = config.Trace
+	katatrace.SetTracing(config.Trace)
 
 	if tomlConf.Runtime.InterNetworkModel != "" {
 		err = config.InterNetworkModel.SetModel(tomlConf.Runtime.InterNetworkModel)

--- a/src/runtime/pkg/katautils/hook.go
+++ b/src/runtime/pkg/katautils/hook.go
@@ -15,10 +15,17 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
-	"go.opentelemetry.io/otel/label"
 )
+
+// hookTracingTags defines tags for the trace span
+var hookTracingTags = map[string]string{
+	"source":    "runtime",
+	"package":   "katautils",
+	"subsystem": "hook",
+}
 
 // Logger returns a logrus logger appropriate for logging hook messages
 func hookLogger() *logrus.Entry {
@@ -26,7 +33,7 @@ func hookLogger() *logrus.Entry {
 }
 
 func runHook(ctx context.Context, hook specs.Hook, cid, bundlePath string) error {
-	span, _ := Trace(ctx, "runHook", []label.KeyValue{label.Key("source").String("runtime"), label.Key("package").String("katautils"), label.Key("subsystem").String("hook")}...)
+	span, _ := katatrace.Trace(ctx, hookLogger(), "runHook", hookTracingTags)
 	defer span.End()
 
 	// FIXME
@@ -88,7 +95,8 @@ func runHook(ctx context.Context, hook specs.Hook, cid, bundlePath string) error
 }
 
 func runHooks(ctx context.Context, hooks []specs.Hook, cid, bundlePath, hookType string) error {
-	span, ctx := Trace(ctx, "runHooks", []label.KeyValue{label.Key("source").String("runtime"), label.Key("package").String("katautils"), label.Key("subsystem").String("hook"), label.Key("type").String(hookType)}...)
+	span, _ := katatrace.Trace(ctx, hookLogger(), "runHooks", hookTracingTags)
+	katatrace.AddTag(span, "type", hookType)
 	defer span.End()
 
 	for _, hook := range hooks {

--- a/src/runtime/pkg/katautils/katatrace/tracing.go
+++ b/src/runtime/pkg/katautils/katatrace/tracing.go
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package katautils
+package katatrace
 
 import (
 	"context"
 
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/oci"
+	"github.com/sirupsen/logrus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/trace/jaeger"
 	"go.opentelemetry.io/otel/label"
@@ -30,7 +30,7 @@ var _ export.SpanExporter = (*kataSpanExporter)(nil)
 // ExportSpans exports SpanData to Jaeger.
 func (e *kataSpanExporter) ExportSpans(ctx context.Context, spans []*export.SpanData) error {
 	for _, span := range spans {
-		kataUtilsLogger.Tracef("Reporting span %+v", span)
+		kataTraceLogger.Tracef("Reporting span %+v", span)
 	}
 	return nil
 }
@@ -43,8 +43,25 @@ func (e *kataSpanExporter) Shutdown(ctx context.Context) error {
 // is used by stopTracing().
 var tracerCloser func()
 
+var kataTraceLogger = logrus.NewEntry(logrus.New())
+
+// tracing determines whether tracing is enabled.
+var tracing bool
+
+// SetTracing turns tracing on or off. Called by the configuration.
+func SetTracing(isTracing bool) {
+	tracing = isTracing
+}
+
+// JaegerConfig defines necessary Jaeger config for exporting traces.
+type JaegerConfig struct {
+	JaegerEndpoint string
+	JaegerUser     string
+	JaegerPassword string
+}
+
 // CreateTracer create a tracer
-func CreateTracer(name string, config *oci.RuntimeConfig) (func(), error) {
+func CreateTracer(name string, config *JaegerConfig) (func(), error) {
 	if !tracing {
 		otel.SetTracerProvider(trace.NewNoopTracerProvider())
 		return func() {}, nil
@@ -109,12 +126,25 @@ func StopTracing(ctx context.Context) {
 	}
 }
 
-// Trace creates a new tracing span based on the specified name and parent
-// context and an opentelemetry label.KeyValue slice for span attributes.
-func Trace(parent context.Context, name string, tags ...label.KeyValue) (otelTrace.Span, context.Context) {
+// Trace creates a new tracing span based on the specified name and parent context.
+// It also accepts a logger to record nil context errors and a map of tracing tags.
+// Tracing tag keys and values are strings.
+func Trace(parent context.Context, logger *logrus.Entry, name string, tags map[string]string) (otelTrace.Span, context.Context) {
+	if parent == nil {
+		if logger == nil {
+			logger = kataTraceLogger
+		}
+		logger.WithField("type", "bug").Error("trace called before context set")
+		parent = context.Background()
+	}
+
+	var otelTags []label.KeyValue
+	for k, v := range tags {
+		otelTags = append(otelTags, label.Key(k).String(v))
+	}
 
 	tracer := otel.Tracer("kata")
-	ctx, span := tracer.Start(parent, name, otelTrace.WithAttributes(tags...))
+	ctx, span := tracer.Start(parent, name, otelTrace.WithAttributes(otelTags...))
 
 	// This is slightly confusing: when tracing is disabled, trace spans
 	// are still created - but the tracer used is a NOP. Therefore, only
@@ -122,8 +152,14 @@ func Trace(parent context.Context, name string, tags ...label.KeyValue) (otelTra
 	if tracing {
 		// This log message is *essential*: it is used by:
 		// https: //github.com/kata-containers/tests/blob/master/tracing/tracing-test.sh
-		kataUtilsLogger.Debugf("created span %v", span)
+		kataTraceLogger.Debugf("created span %v", span)
 	}
 
 	return span, ctx
+}
+
+// AddTag adds an additional key-value pair to a tracing span. This can be used to
+// provide dynamic tags that are determined at runtime.
+func AddTag(span otelTrace.Span, key string, value interface{}) {
+	span.SetAttributes(label.Any(key, value))
 }

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -16,6 +16,7 @@ import (
 	"syscall"
 
 	merr "github.com/hashicorp/go-multierror"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 	"github.com/sirupsen/logrus"
 	otelLabel "go.opentelemetry.io/otel/label"
@@ -239,7 +240,7 @@ func evalMountPath(source, destination string) (string, string, error) {
 // * ensure the source exists
 // * recursively create the destination
 func moveMount(ctx context.Context, source, destination string) error {
-	span, _ := trace(ctx, "moveMount")
+	span, _ := katatrace.Trace(ctx, nil, "moveMount", apiTracingTags)
 	defer span.End()
 
 	source, destination, err := evalMountPath(source, destination)
@@ -257,7 +258,7 @@ func moveMount(ctx context.Context, source, destination string) error {
 // * recursively create the destination
 // pgtypes stands for propagation types, which are shared, private, slave, and ubind.
 func bindMount(ctx context.Context, source, destination string, readonly bool, pgtypes string) error {
-	span, _ := trace(ctx, "bindMount")
+	span, _ := katatrace.Trace(ctx, nil, "bindMount", apiTracingTags)
 	defer span.End()
 	span.SetAttributes(otelLabel.String("source", source), otelLabel.String("destination", destination))
 
@@ -294,7 +295,7 @@ func bindMount(ctx context.Context, source, destination string, readonly bool, p
 // The mountflags should match the values used in the original mount() call,
 // except for those parameters that you are trying to change.
 func remount(ctx context.Context, mountflags uintptr, src string) error {
-	span, _ := trace(ctx, "remount")
+	span, _ := katatrace.Trace(ctx, nil, "remount", apiTracingTags)
 	defer span.End()
 	span.SetAttributes(otelLabel.String("source", src))
 
@@ -319,7 +320,7 @@ func remountRo(ctx context.Context, src string) error {
 // bindMountContainerRootfs bind mounts a container rootfs into a 9pfs shared
 // directory between the guest and the host.
 func bindMountContainerRootfs(ctx context.Context, shareDir, cid, cRootFs string, readonly bool) error {
-	span, _ := trace(ctx, "bindMountContainerRootfs")
+	span, _ := katatrace.Trace(ctx, nil, "bindMountContainerRootfs", apiTracingTags)
 	defer span.End()
 
 	rootfsDest := filepath.Join(shareDir, cid, rootfsDir)
@@ -359,7 +360,7 @@ func isSymlink(path string) bool {
 }
 
 func bindUnmountContainerRootfs(ctx context.Context, sharedDir, cID string) error {
-	span, _ := trace(ctx, "bindUnmountContainerRootfs")
+	span, _ := katatrace.Trace(ctx, nil, "bindUnmountContainerRootfs", apiTracingTags)
 	defer span.End()
 	span.SetAttributes(otelLabel.String("shared_dir", sharedDir), otelLabel.String("container_id", cID))
 
@@ -382,7 +383,7 @@ func bindUnmountContainerRootfs(ctx context.Context, sharedDir, cID string) erro
 }
 
 func bindUnmountAllRootfs(ctx context.Context, sharedDir string, sandbox *Sandbox) error {
-	span, ctx := trace(ctx, "bindUnmountAllRootfs")
+	span, ctx := katatrace.Trace(ctx, nil, "bindUnmountAllRootfs", apiTracingTags)
 	defer span.End()
 	span.SetAttributes(otelLabel.String("shared_dir", sharedDir), otelLabel.String("sandbox_id", sandbox.id))
 


### PR DESCRIPTION
Removes custom trace functions defined across the repo and creates
a single trace function in a new katatrace package. Also moves
span tag management into this package and provides a function to
dynamically add a tag at runtime, such as a container id, etc.

Fixes #1162

Signed-off-by: Benjamin Porter <bporter816@gmail.com>