### PR TITLE
osbuilder: update centos arm rootfs image config 'GPG_KEY_ARCH_URL'

### DIFF
--- a/tools/osbuilder/rootfs-builder/centos/config_aarch64.sh
+++ b/tools/osbuilder/rootfs-builder/centos/config_aarch64.sh
@@ -13,6 +13,6 @@ CENTOS_EXTRAS_URL="http://mirror.centos.org/altarch/${OS_VERSION}/extras/${ARCH}
 
 CENTOS_PLUS_URL="http://mirror.centos.org/altarch/${OS_VERSION}/centosplus/${ARCH}/"
 
-GPG_KEY_ARCH_URL="http://mirror.centos.org/altarch/7/os/aarch64/RPM-GPG-KEY-CentOS-7-aarch64"
+GPG_KEY_ARCH_URL="http://mirror.centos.org/altarch/7/os/aarch64/RPM-GPG-KEY-CentOS-7"
 
 GPG_KEY_ARCH_FILE="RPM-GPG-KEY-CentOS-7-aarch64"


### PR DESCRIPTION
fix GPG_KEY_ARCH_URL config of centos's config_aarch64, update to "http://mirror.centos.org/altarch/7/os/aarch64/RPM-GPG-KEY-CentOS-7".

Fixes: #2181

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>