### PR TITLE
vendor: Update containernetworking/cni to 0.8.1

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/containerd/fifo v1.0.0
 	github.com/containerd/ttrpc v1.0.2
 	github.com/containerd/typeurl v1.0.2
+	github.com/containernetworking/cni v0.8.1 // indirect
 	github.com/containernetworking/plugins v0.9.1
 	github.com/cri-o/cri-o v1.0.0-rc2.0.20170928185954-3394b3b2d6af
 	github.com/docker/distribution v2.7.1+incompatible // indirect

--- a/src/runtime/vendor/modules.txt
+++ b/src/runtime/vendor/modules.txt
@@ -152,6 +152,7 @@ github.com/containerd/ttrpc
 ## explicit
 github.com/containerd/typeurl
 # github.com/containernetworking/cni v0.8.1
+## explicit
 github.com/containernetworking/cni/pkg/skel
 github.com/containernetworking/cni/pkg/types
 github.com/containernetworking/cni/pkg/types/020


### PR DESCRIPTION
SourceClear scan of the source code on branch main exposed the following:

CVE-2021-20206 Medium Risk Arbitrary Path Injection
github.com/containernetworking/cni v0.7.0

Fixes: #2160

Reported-by: Przemyslaw Roguski <proguski@redhat.com>
Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>