### PR TITLE
trace-forwarder: Add option rustflags, target, build-type for the make

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -27,40 +27,7 @@ COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)
 # Exported to allow cargo to see it
 export VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
 
-##VAR BUILD_TYPE=release|debug type of rust build
-BUILD_TYPE = release
-
-##VAR ARCH=arch target to build (format: uname -m)
-ARCH = $(shell uname -m)
-##VAR LIBC=musl|gnu
-LIBC ?= musl
-ifneq ($(LIBC),musl)
-    ifeq ($(LIBC),gnu)
-        override LIBC = gnu
-    else
-        $(error "ERROR: A non supported LIBC value was passed. Supported values are musl and gnu")
-    endif
-endif
-
-ifeq ($(ARCH), ppc64le)
-    override ARCH = powerpc64le
-    override LIBC = gnu
-    $(warning "WARNING: powerpc64le-unknown-linux-musl target is unavailable")
-endif
-
-ifeq ($(ARCH), s390x)
-    override LIBC = gnu
-    $(warning "WARNING: s390x-unknown-linux-musl target is unavailable")
-endif
-
-
-EXTRA_RUSTFLAGS :=
-ifeq ($(ARCH), aarch64)
-    override EXTRA_RUSTFLAGS = -C link-arg=-lgcc
-    $(warning "WARNING: aarch64-musl needs extra symbols from libgcc")
-endif
-
-TRIPLE = $(ARCH)-unknown-linux-$(LIBC)
+include ../../utils.mk
 
 TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)
 

--- a/src/trace-forwarder/Makefile
+++ b/src/trace-forwarder/Makefile
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+include ../../utils.mk
+
 default: build
 
 build:
-	RUSTFLAGS="--deny warnings" cargo build -v
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
 
 clean:
 	cargo clean

--- a/utils.mk
+++ b/utils.mk
@@ -105,3 +105,39 @@ $(foreach a,$(3),$(eval $(call make_all_rules,$(a))))
 $(3) : % : %-all
 
 endef
+
+
+##VAR BUILD_TYPE=release|debug type of rust build
+BUILD_TYPE = release
+
+##VAR ARCH=arch target to build (format: uname -m)
+ARCH = $(shell uname -m)
+##VAR LIBC=musl|gnu
+LIBC ?= musl
+ifneq ($(LIBC),musl)
+    ifeq ($(LIBC),gnu)
+        override LIBC = gnu
+    else
+        $(error "ERROR: A non supported LIBC value was passed. Supported values are musl and gnu")
+    endif
+endif
+
+ifeq ($(ARCH), ppc64le)
+    override ARCH = powerpc64le
+    override LIBC = gnu
+    $(warning "WARNING: powerpc64le-unknown-linux-musl target is unavailable")
+endif
+
+ifeq ($(ARCH), s390x)
+    override LIBC = gnu
+    $(warning "WARNING: s390x-unknown-linux-musl target is unavailable")
+endif
+
+
+EXTRA_RUSTFLAGS :=
+ifeq ($(ARCH), aarch64)
+    override EXTRA_RUSTFLAGS = -C link-arg=-lgcc
+    $(warning "WARNING: aarch64-musl needs extra symbols from libgcc")
+endif
+
+TRIPLE = $(ARCH)-unknown-linux-$(LIBC)


### PR DESCRIPTION
Support rust-flags, target and build-type.

Signed-off-by: Tim Zhang <tim@hyper.sh>