### PR TITLE
[backport] runtime: Remove the version check for cloud hypervisor

### DIFF
--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -321,50 +320,6 @@ func TestCloudHypervisorResizeMemory(t *testing.T) {
 				t.Errorf("cloudHypervisor.resizeMemory() got = %+v, want %+v", memDev, tt.expectedMemDev)
 			}
 		})
-	}
-}
-
-func TestCheckVersion(t *testing.T) {
-	clh := &cloudHypervisor{}
-	assert := assert.New(t)
-	testcases := []struct {
-		name  string
-		major int
-		minor int
-		pass  bool
-	}{
-		{
-			name:  "minor lower than supported version",
-			major: supportedMajorVersion,
-			minor: 2,
-			pass:  false,
-		},
-		{
-			name:  "minor equal to supported version",
-			major: supportedMajorVersion,
-			minor: supportedMinorVersion,
-			pass:  true,
-		},
-		{
-			name:  "major exceeding supported version",
-			major: 1,
-			minor: supportedMinorVersion,
-			pass:  true,
-		},
-	}
-	for _, tc := range testcases {
-		clh.version = CloudHypervisorVersion{
-			Major:    tc.major,
-			Minor:    tc.minor,
-			Revision: 0,
-		}
-		err := clh.checkVersion()
-		msg := fmt.Sprintf("test: %+v, clh.version: %v, result: %v", tc, clh.version, err)
-		if tc.pass {
-			assert.NoError(err, msg)
-		} else {
-			assert.Error(err, msg)
-		}
 	}
 }
 


### PR DESCRIPTION
It looks like the version check for cloud hypervisor (clh) was added
initially when clh was actively evolving its API. We no longer need the
version check as clh API has been fairly stable for its recent releases.

Fixes: #1991

Signed-off-by: Bo Chen <chen.bo@intel.com>
(cherry picked from commit d08603bebb28eef8badf1aed8f0543991925a514)