### PR TITLE
qemu: stop the virtiofsd specifically

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -668,7 +668,8 @@ func (q *qemu) setupVirtiofsd(ctx context.Context) (err error) {
 
 func (q *qemu) stopVirtiofsd(ctx context.Context) (err error) {
 	if q.state.VirtiofsdPid == 0 {
-		return errors.New("invalid virtiofsd PID(0)")
+		q.Logger().Warn("The virtiofsd had stopped")
+		return nil
 	}
 
 	err = q.virtiofsd.Stop(ctx)
@@ -973,6 +974,10 @@ func (q *qemu) stopSandbox(ctx context.Context, waitOnly bool) error {
 			q.Logger().WithError(err).Error("Fail to execute qmp QUIT")
 			return err
 		}
+	}
+
+	if err := q.stopVirtiofsd(ctx); err != nil {
+		return err
 	}
 
 	return nil


### PR DESCRIPTION
We'd better stop the virtiofsd specifically after stop qemu,
instead of depending on the qemu's termination to notify virtiofsd
to exit.

Fixes: #2211

Signed-off-by: fupan.lfp <fupan.lfp@antgroup.com>