### PR TITLE
CI: Honour force-skip-ci label

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -1,7 +1,15 @@
-on: ["pull_request"]
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - labeled
+      - unlabeled
+
 name: Static checks
 jobs:
   test:
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
     strategy:
       matrix:
         go-version: [1.13.x, 1.14.x, 1.15.x]


### PR DESCRIPTION
If a PR has the `force-skip-ci` label set, don't run the static tests.

Fixes: #2220.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>