### PR TITLE
[stable-2.1] versions: Update containerd to v1.3.10

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -184,11 +184,11 @@ externals:
   cri-containerd:
     description: |
       Containerd Plugin for Kubernetes Container Runtime Interface.
-    url: "github.com/containerd/cri"
-    tarball_url: "https://storage.googleapis.com/cri-containerd-release"
+    url: "github.com/containerd/containerd"
+    tarball_url: "https://github.com/containerd/containerd/releases/download"
     # Next commit from 1.3 branch contains fix to be able to run
     # tests using go 1.13
-    version: "v1.3.7"
+    version: "v1.3.10"
 
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"


### PR DESCRIPTION
Bump containerd version to the latest v1.3.x, so we don't have to do
intrusive changes in our codebase (as done for in the main branch).

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>