### PR TITLE
virtiofsd: fix the issue of missing stop virtiofsd

### DIFF
--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -142,6 +142,8 @@ func (v *virtiofsd) Start(ctx context.Context, onQuit onQuitFunc) (int, error) {
 		}
 	}()
 
+	v.PID = cmd.Process.Pid
+
 	return cmd.Process.Pid, nil
 }
 
@@ -216,7 +218,8 @@ func (v *virtiofsd) kill(ctx context.Context) (err error) {
 	defer span.End()
 
 	if v.PID == 0 {
-		return errors.New("invalid virtiofsd PID(0)")
+		v.Logger().WithField("invalid-virtiofsd-pid", v.PID).Warn("cannot kill virtiofsd")
+		return nil
 	}
 
 	err = syscall.Kill(v.PID, syscall.SIGKILL)


### PR DESCRIPTION
The virtiofsd's PID wan't assigned the right pid,
which will result skipping kill it.

Fixes: #2228

Signed-off-by: fupan.lfp <fupan.lfp@antgroup.com>