### PR TITLE
runtime: Register defer function at early stage

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1555,18 +1555,7 @@ func (s *Sandbox) Stop(ctx context.Context, force bool) error {
 	return nil
 }
 
-// list lists all sandbox running on the host.
-func (s *Sandbox) list() ([]Sandbox, error) {
-	return nil, nil
-}
-
-// enter runs an executable within a sandbox.
-func (s *Sandbox) enter(args []string) error {
-	return nil
-}
-
-// setSandboxState sets both the in-memory and on-disk state of the
-// sandbox.
+// setSandboxState sets the in-memory state of the sandbox.
 func (s *Sandbox) setSandboxState(state types.StateString) error {
 	if state == "" {
 		return vcTypes.ErrNeedState

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1008,6 +1008,12 @@ func (s *Sandbox) startVM(ctx context.Context) (err error) {
 		s.cw = consoleWatcher
 	}
 
+	defer func() {
+		if err != nil {
+			s.hypervisor.stopSandbox(ctx, false)
+		}
+	}()
+
 	if err := s.network.Run(ctx, s.networkNS.NetNsPath, func() error {
 		if s.factory != nil {
 			vm, err := s.factory.GetVM(ctx, VMConfig{
@@ -1026,12 +1032,6 @@ func (s *Sandbox) startVM(ctx context.Context) (err error) {
 	}); err != nil {
 		return err
 	}
-
-	defer func() {
-		if err != nil {
-			s.hypervisor.stopSandbox(ctx, false)
-		}
-	}()
 
 	// In case of vm factory, network interfaces are hotplugged
 	// after vm is started.

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -181,21 +181,6 @@ func TestCreateSandboxEmptyID(t *testing.T) {
 	defer cleanUp()
 }
 
-func TestSandboxListSuccessful(t *testing.T) {
-	sandbox := &Sandbox{}
-
-	sandboxList, err := sandbox.list()
-	assert.NoError(t, err)
-	assert.Nil(t, sandboxList)
-}
-
-func TestSandboxEnterSuccessful(t *testing.T) {
-	sandbox := &Sandbox{}
-
-	err := sandbox.enter([]string{})
-	assert.NoError(t, err)
-}
-
 func testCheckInitSandboxAndContainerStates(p *Sandbox, initialSandboxState types.SandboxState, c *Container, initialContainerState types.ContainerState) error {
 	if p.state.State != initialSandboxState.State {
 		return fmt.Errorf("Expected sandbox state %v, got %v", initialSandboxState.State, p.state.State)


### PR DESCRIPTION
Register defer function at early stage ensure that
it can be called if the startSandbox fails.

Fixes: #2230

Signed-off-by: bin <bin@hyper.sh>