### PR TITLE
vsock-exporter: switch to tokio runtime

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -872,6 +872,8 @@ dependencies = [
  "rand",
  "serde",
  "thiserror",
+ "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -1575,6 +1577,17 @@ dependencies = [
  "proc-macro2 1.0.26",
  "quote 1.0.9",
  "syn 1.0.72",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8864d706fdb3cc0843a49647ac892720dac98a6eeb818b77190592cf4994066"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1798,7 +1798,8 @@ dependencies = [
  "serde",
  "slog",
  "thiserror",
- "vsock",
+ "tokio",
+ "tokio-vsock",
 ]
 
 [[package]]

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -54,7 +54,7 @@ cgroups = { package = "cgroups-rs", version = "0.2.5" }
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 tracing-opentelemetry = "0.13.0"
-opentelemetry = "0.14.0"
+opentelemetry = { version = "0.14.0", features = ["rt-tokio-current-thread"]}
 vsock-exporter = { path = "vsock-exporter" }
 
 [dev-dependencies]

--- a/src/agent/src/tracer.rs
+++ b/src/agent/src/tracer.rs
@@ -66,7 +66,7 @@ pub fn setup_tracing(name: &'static str, logger: &Logger, _agent_cfg: &AgentConf
     let config = Config::default();
 
     let builder = opentelemetry::sdk::trace::TracerProvider::builder()
-        .with_simple_exporter(exporter)
+        .with_batch_exporter(exporter, opentelemetry::runtime::TokioCurrentThread)
         .with_config(config);
 
     let provider = builder.build();

--- a/src/agent/vsock-exporter/Cargo.toml
+++ b/src/agent/vsock-exporter/Cargo.toml
@@ -12,8 +12,9 @@ libc = "0.2.94"
 thiserror = "1.0.24"
 opentelemetry = { version = "0.14.0", features=["serialize"] }
 serde = { version = "1.0.126", features = ["derive"] }
-vsock = "0.2.3"
+tokio-vsock = "0.3.1"
 bincode = "1.3.3"
 byteorder = "1.4.3"
 slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_info"] }
 async-trait = "0.1.50"
+tokio = "1.2.0"


### PR DESCRIPTION
- Make the vsock-exporter async totally using tokio runtime.
- Delay the timing of the connection to trace-forwarder so that it is easy to reconnect when the connection was broken.