### PR TITLE
static-checks: Add a make target to run static-checks locally

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -63,13 +63,9 @@ jobs:
     - name: Check vendored code
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && make vendor
-    # Must build before static checks as we depend on some generated code in runtime and agent
-    - name: Build
-      run: |
-        cd ${GOPATH}/src/github.com/${{ github.repository }} && make
     - name: Static Checks
       run: |
-        cd ${GOPATH}/src/github.com/${{ github.repository }} && ./ci/static-checks.sh
+        cd ${GOPATH}/src/github.com/${{ github.repository }} && make static-checks
     - name: Run Compiler Checks
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && make check

--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,8 @@ $(eval $(call create_all_rules,$(COMPONENTS),$(TOOLS),$(STANDARD_TARGETS)))
 generate-protocols:
 	make -C src/agent generate-protocols
 
-.PHONY: all default
+# Some static checks rely on generated source files of components.
+static-checks: build
+	bash ci/static-checks.sh
+
+.PHONY: all default static-checks


### PR DESCRIPTION
In this pull request it is introduced the *static-checks* target (`make static-checks`) as the primary interface for developers to run the static checks locally (see #2206).

It would be nice to have a *pre-commit* target as suggested by @liubin which would run not just the static checks but all the checkers/tests executed as part of the github's static-checks workflow (see `.github/workflows/static-checks.yaml`). But I think deserves more thoughts, so I didn't go further than providing aforementioned *static-checks* target. 