### PR TITLE
agent/agent-ctl: update tokio to 1.8.1

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1548,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -26,7 +26,7 @@ async-recursion = "0.3.2"
 futures = "0.3.12"
 
 # Async runtime
-tokio = { version = "1.2.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-vsock = "0.3.1"
 
 netlink-sys = { version = "0.7.0", features = ["tokio_socket",]}

--- a/tools/agent-ctl/Cargo.lock
+++ b/tools/agent-ctl/Cargo.lock
@@ -1239,9 +1239,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.6.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd3076b5c8cc18138b8f8814895c11eb4de37114a5d127bafdc5e55798ceef37"
+checksum = "98c8b05dc14c75ea83d63dd391100353789f5f24b8b3866542a5e85c8be8e985"
 dependencies = [
  "autocfg",
  "bytes 1.0.1",


### PR DESCRIPTION
Update to latest tokio to address RUSTSEC-2021-0072:
 Task dropped in wrong thread when aborting `LocalSet` task

Fixes: #2165

Updated by running "cargo update -p tokio" for both agent and agent-ctl

Signed-off-by: Eric Ernst <eric_ernst@apple.com>