### PR TITLE
agent-ctl: Use a common Makefile style like other components

### DIFF
--- a/tools/agent-ctl/Makefile
+++ b/tools/agent-ctl/Makefile
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+include ../../utils.mk
+
 default: build
 
 build:
-	RUSTFLAGS="--deny warnings" cargo build -v
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
 
 clean:
 	cargo clean


### PR DESCRIPTION
Update Makfile like other components, and remove the -v option of
cargo build commond.

Fixes: #2244

Signed-off-by: bin <bin@hyper.sh>