### PR TITLE
snap: Remove QEMU before clone

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -270,6 +270,7 @@ parts:
 
       # download source
       qemu_dir=${SNAPCRAFT_STAGE}/qemu
+      rm -rf "${qemu_dir}"
       git clone --branch ${branch} --single-branch ${url} "${qemu_dir}"
       cd ${qemu_dir}
       [ -z "${commit}" ] || git checkout ${commit}


### PR DESCRIPTION
If you snap in an environment where you previously snapped,
`git clone`ing QEMU will fail. Remove the checkout directory.

Fixes: #2249
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @devimc