### PR TITLE
ci: set -o nounset

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -3,6 +3,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+set -o nounset
+
 export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 export tests_repo_dir="$GOPATH/src/$tests_repo"
 export branch="${target_branch:-main}"


### PR DESCRIPTION
This avoids confusion e.g. when `$GOPATH` is unset.

Fixes: #2251
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>