### PR TITLE
shimv2: fix the issue of kata-runtime exec failed

### DIFF
--- a/src/runtime/containerd-shim-v2/shim_management.go
+++ b/src/runtime/containerd-shim-v2/shim_management.go
@@ -186,5 +186,5 @@ func (s *service) mountPprofHandle(m *http.ServeMux, ociSpec *specs.Spec) {
 // SocketAddress returns the address of the abstract domain socket for communicating with the
 // shim management endpoint
 func SocketAddress(id string) string {
-	return filepath.Join(string(filepath.Separator), "run", "vc", id, "shim-monitor")
+	return fmt.Sprintf("unix://%s", filepath.Join(string(filepath.Separator), "run", "vc", id, "shim-monitor"))
 }

--- a/src/runtime/pkg/kata-monitor/shim_client.go
+++ b/src/runtime/pkg/kata-monitor/shim_client.go
@@ -12,6 +12,7 @@ import (
 	"net/http"
 	"time"
 
+	cdshim "github.com/containerd/containerd/runtime/v2/shim"
 	shim "github.com/kata-containers/kata-containers/src/runtime/containerd-shim-v2"
 )
 
@@ -45,7 +46,7 @@ func buildUnixSocketClient(socketAddr string, timeout time.Duration) (*http.Clie
 	transport := &http.Transport{
 		DisableKeepAlives: true,
 		Dial: func(proto, addr string) (conn net.Conn, err error) {
-			return net.Dial("unix", "\x00"+socketAddr)
+			return cdshim.AnonDialer(socketAddr, timeout)
 		},
 	}
 


### PR DESCRIPTION
Commit 32c9ae1388385f10c75d9a76809f1d419e82b020 upgrade the
containerd vendor, which used the socket path to replace
the abstract socket address for socket listen and dial, and
there's an bug in containerd's abstract socket dialing.

Thus we should replace our monitor and exec socket server
with the socket path to fix this issue.

Fixes: #2238

Signed-off-by: fupan.lfp <fupan.lfp@antgroup.com>