### PR TITLE
shim-v2: Be compatible with the old runtime options

### DIFF
--- a/src/runtime/containerd-shim-v2/create.go
+++ b/src/runtime/containerd-shim-v2/create.go
@@ -24,6 +24,7 @@ import (
 	crioption "github.com/containerd/containerd/pkg/runtimeoptions/v1"
 	_ "github.com/containerd/containerd/runtime/linux/runctypes"
 	_ "github.com/containerd/containerd/runtime/v2/runc/options"
+	oldcrioption "github.com/containerd/cri-containerd/pkg/api/runtimeoptions/v1"
 
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
@@ -188,6 +189,16 @@ func loadRuntimeConfig(s *service, r *taskAPI.CreateTaskRequest, anno map[string
 		// and we'll ignore it.
 		if ok {
 			configPath = option.ConfigPath
+		} else {
+			// Some versions of containerd, such as 1.4.3, and 1.4.4
+			// still rely on the runtime options coming from
+			// github.com/containerd/cri-containerd/pkg/api/runtimeoptions/v1
+			// Knowing that, instead of breaking compatibility with such
+			// versions, let's work this around on our side
+			oldOption, ok := v.(*oldcrioption.Options)
+			if ok {
+				configPath = oldOption.ConfigPath
+			}
 		}
 	}
 


### PR DESCRIPTION
Seems that at least some versions of container, when using ConifgPath,
still rely on the runtime options and its APIs from the not in use
anymore github.com/containerd/cri-containerd/pkg/api/runtimeoptions/v1.

The fact backward compat breaks when moving from the old to the new
runtime options, which happened as part of f60641a6e6d, strongly feels
like a containerd bug.  Regardless, we can easily work this around on
our side without much hassle.

Just by importing old runtime options the unmarshalling doesn't break
anymore and we can easily check whether getting the options fails or not
and fallback to the old way if it does.

Fixes: #2258

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>