### PR TITLE
agent: clear MsFlags if the option has clear flag set

### DIFF
--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -549,8 +549,12 @@ fn parse_mount_flags_and_options(options_vec: Vec<&str>) -> (MsFlags, String) {
         if !opt.is_empty() {
             match FLAGS.get(opt) {
                 Some(x) => {
-                    let (_, f) = *x;
-                    flags |= f;
+                    let (clear, f) = *x;
+                    if clear {
+                        flags &= !f;
+                    } else {
+                        flags |= f;
+                    }
                 }
                 None => {
                     if !options.is_empty() {

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -121,8 +121,12 @@ impl Namespace {
                 let mut flags = MsFlags::empty();
 
                 if let Some(x) = FLAGS.get("rbind") {
-                    let (_, f) = *x;
-                    flags |= f;
+                    let (clear, f) = *x;
+                    if clear {
+                        flags &= !f;
+                    } else {
+                        flags |= f;
+                    }
                 };
 
                 let bare_mount = BareMount::new(source, destination, "none", flags, "", &logger);


### PR DESCRIPTION
'FLAGS' hash map has bool to indicate if the flag should be cleared or
not. But in parse_mount_flags_and_options() we set the flag even 'clear'
is true. This results in a 'rw' mount being mounted as 'MS_RDONLY'.

Fixes: #2262
Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>