### PR TITLE
virtcontainers: simplify read-only mount handling

### DIFF
--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -242,22 +242,6 @@ func evalMountPath(source, destination string) (string, string, error) {
 	return absSource, destination, nil
 }
 
-// moveMount moves a mountpoint to another path with some bookkeeping:
-// * evaluate all symlinks
-// * ensure the source exists
-// * recursively create the destination
-func moveMount(ctx context.Context, source, destination string) error {
-	span, _ := katatrace.Trace(ctx, nil, "moveMount", mountTracingTags)
-	defer span.End()
-
-	source, destination, err := evalMountPath(source, destination)
-	if err != nil {
-		return err
-	}
-
-	return syscall.Mount(source, destination, "move", syscall.MS_MOVE, "")
-}
-
 // bindMount bind mounts a source in to a destination. This will
 // do some bookkeeping:
 // * evaluate all symlinks


### PR DESCRIPTION
Current handling of read-only mounts is a little tricky.
However, a clearer solution can be used here:

  1. make a private ro bind mount at privateDest to the mount source
  2. make a bind mount at mountDest to the mount created in step 1
  3. umount the private bind mount created in step 1

One important aspect is that the mount in step 2 is duplicated from
the one we created in step 1. So the MS_RDONLY flag is properly
preserved in all mounts created in the propagtion.

Fixes: #2205

Signed-off-by: Yujia Qiao <rapiz3142@gmail.com>