### PR TITLE
docs: added a glossary to support SEO tactics

### DIFF
--- a/Glossary.md
+++ b/Glossary.md
@@ -1,0 +1,94 @@
+# Glossary
+
+[A](#a), [B](#b), [C](#c), [D](#d), [E](#e), [F](#f), [G](#g), [H](#h), [I](#i), [J](#j), [K](#k), [L](#l), [M](#m), [N](#n), [O](#o), [P](#p), [Q](#q), [R](#r), [S](#s), [T](#t), [U](#u), [V](#v), [W](#w), [X](#x), [Y](#y), [Z](#z)
+
+## A
+
+### Auto Scaling
+a method used in cloud computing, whereby the amount of computational resources in a server farm, typically measured in terms of the number of active servers, which vary automatically based on the load on the farm.
+
+## B
+
+## C
+
+### Container Security Solutions
+The process of implementing security tools and policies that will give you the assurance that everything in your container is running as intended, and only as intended.
+
+### Container Software
+A standard unit of software that packages up code and all its dependencies so the application runs quickly and reliably from one computing environment to another.
+
+### Container Runtime Interface
+A plugin interface which enables Kubelet to use a wide variety of container runtimes, without the need to recompile.
+
+### Container Virtualization
+A container is a virtual runtime environment that runs on top of a single operating system (OS) kernel and emulates an operating system rather than the underlying hardware.
+
+## D
+
+## E
+
+## F
+
+## G
+
+## H
+
+## I
+
+### Infrastructure Architecture
+A structured and modern approach for supporting an organization and facilitating innovation within an enterprise.
+
+## J
+
+## K
+
+### Kata Containers
+Kata containers is an open source project delivering increased container security and Workload isolation through an implementation of lightweight virtual machines.
+
+## L
+
+## M
+
+## N
+
+## O
+
+## P
+
+### Pod Containers
+A Group of one or more containers , with shared storage/network, and a specification for how to run the containers.
+
+### Private Cloud
+A computing model that offers a proprietary environment dedicated to a single business entity.
+
+### Public Cloud
+Computing services offered by third-party providers over the public Internet, making them available to anyone who wants to use or purchase them.
+
+## Q
+
+## R
+
+## S
+
+### Serverless Containers
+An architecture in which code is executed on-demand. Serverless workloads are typically in the cloud, but on-premises serverless platforms exist, too.
+
+## T
+
+## U
+
+## V
+
+### Virtual Machine Monitor
+Computer software, firmware or hardware that creates and runs virtual machines.
+
+### Virtual Machine Software
+A software program or operating system that not only exhibits the behavior of a separate computer, but is also capable of performing tasks such as running applications and programs like a separate computer.
+
+## W
+
+## X
+
+## Y
+
+## Z

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
             * [Kata Containers 1.x components](#kata-containers-1x-components)
         * [Common repositories](#common-repositories)
         * [Packaging and releases](#packaging-and-releases)
+    * [Glossary of Terms](#glossary-of-terms)
 
 ---
 
@@ -138,6 +139,9 @@ Kata Containers is now
 However, packaging scripts and metadata are still used to generate snap and GitHub releases. See
 the [components](#components) section for further details.
 
+## Glossary of Terms
+
+See the [glossary of terms](Glossary.md) related to Kata Containers.
 ---
 
 [kernel]: https://www.kernel.org


### PR DESCRIPTION
This commit is a result of Assisted PR Process for PR #1515.  It
deviates from it in that the original commits were not retained as the
original commit structure was unnecessarily complex - the same commit
was added to two parallel branches which were then merged, producing the
same result in the end as any of the original two non-merge commits.
Also, a squash was requested by an original PR review.

The only other change to the original PR was to change capitalisation of
the word "Kubelet" in Glossary.md to placate spell checker.

The original commit message follows:

The terms added are: Kata Containers, container software, container
runtime interface, virtual machine software, container virtualization,
container security solutions, serverless containers, pod containers,
virtual machine monitor, private cloud, infrastructure architecture,
public cloud, and auto scaling.

Fixes: #1509

Signed-Off-By: Helena Spease <helena@openstack.org>
Signed-Off-By: Pavel Mores <pmores@redhat.com>