### PR TITLE
docs: fix minikube installation guide runtimeclasses error

### DIFF
--- a/docs/install/minikube-installation-guide.md
+++ b/docs/install/minikube-installation-guide.md
@@ -166,8 +166,8 @@ $ kubectl apply -f https://raw.githubusercontent.com/kubernetes/node-api/master/
 Now register the `kata qemu` runtime with that class. This should result in no errors:
 
 ```sh
-$ cd kata-containers/tools/packaging/kata-deploy/k8s-1.14
-$ kubectl apply -f kata-qemu-runtimeClass.yaml
+$ cd kata-containers/tools/packaging/kata-deploy/runtimeclasses
+$ kubectl apply -f kata-runtimeClasses.yaml
 ```
 
 The Kata Containers installation process should be complete and enabled in the Minikube cluster.


### PR DESCRIPTION
the kata-deploy project scripts were changed, but minikube installation guide doc still use old yaml script. fix guide doc use the new yaml script of runtimeClasses.

Fixes: #2276

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>