### PR TITLE
stable-2.1 | kata-deploy: Use the correct image for kata-deploy

### DIFF
--- a/tools/packaging/kata-deploy/action/Dockerfile
+++ b/tools/packaging/kata-deploy/action/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM microsoft/azure-cli:latest
+FROM mcr.microsoft.com/azure-cli:latest
 
 LABEL com.github.actions.name="Test kata-deploy in an AKS cluster"
 LABEL com.github.actions.description="Test kata-deploy in an AKS cluster"


### PR DESCRIPTION
While doing the release we've faced the following issue:
```
  Dockerfile for action: '/home/runner/work/kata-containers/kata-containers/./packaging/kata-deploy/action/Dockerfile'.
  /usr/bin/docker build -t 8a33c1:c0625fe487ce5e4c8217747bef28861f -f "/home/runner/work/kata-containers/kata-containers/./packaging/kata-deploy/action/Dockerfile" "/home/runner/work/kata-containers/kata-containers/packaging/kata-deploy/action"
  Sending build context to Docker daemon  15.87kB
  Step 1/12 : FROM microsoft/azure-cli:latest
  pull access denied for microsoft/azure-cli, repository does not exist or may require 'docker login': denied: requested access to the resource is denied
```

Carlos pointed out that the image has gone awry and that we could use
mcr.microsoft.com/azure-cli instead.

Fixes: #2240

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>
(cherry picked from commit fdf973199220e2a0af3b0206b9a7d11c9b8c8736)