### PR TITLE
snap: fixed snap aarch64 qemu patches dir in snapcraft.yaml file

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -256,7 +256,8 @@ parts:
           branch="$(${yq} r ${versions_file} assets.hypervisor.qemu.architecture.aarch64.branch)"
           url="$(${yq} r ${versions_file} assets.hypervisor.qemu.url)"
           commit="$(${yq} r ${versions_file} assets.hypervisor.qemu.architecture.aarch64.commit)"
-          patches_dir="${kata_dir}/tools/packaging/obs-packaging/qemu-aarch64/patches/"
+          patches_dir="${kata_dir}/tools/packaging/qemu/patches/$(echo ${branch} | sed -e 's/.[[:digit:]]*$//' -e 's/^v//').x"
+          patches_version_dir="${kata_dir}/tools/packaging/qemu/patches/tag_patches/${branch}"
         ;;
 
         *)


### PR DESCRIPTION
fixed arm qemu patches dir in snap part. Clear the old `packaging/obs-packaging` path.

Fixes: #2279

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>