### PR TITLE
monitor: mv the monitor socket into sbs directory

### DIFF
--- a/src/runtime/containerd-shim-v2/shim_management.go
+++ b/src/runtime/containerd-shim-v2/shim_management.go
@@ -186,5 +186,5 @@ func (s *service) mountPprofHandle(m *http.ServeMux, ociSpec *specs.Spec) {
 // SocketAddress returns the address of the abstract domain socket for communicating with the
 // shim management endpoint
 func SocketAddress(id string) string {
-	return fmt.Sprintf("unix://%s", filepath.Join(string(filepath.Separator), "run", "vc", id, "shim-monitor"))
+	return fmt.Sprintf("unix://%s", filepath.Join(string(filepath.Separator), "run", "vc", "sbs", id, "shim-monitor.sock"))
 }


### PR DESCRIPTION
Since the monitor socket used the unix socket path file,
which needed to be cleaned after the pod terminated,
thus put it into the sandbox data directory, and it
would be cleaned up once the sandbox termianted.

Fixes: #2269

Signed-off-by: fupan.lfp <fupan.lfp@antgroup.com>