### PR TITLE
ci: expand $CI to nothing

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -17,7 +17,7 @@ export branch="${target_branch:-main}"
 clone_tests_repo()
 {
 	if [ -d "$tests_repo_dir" ]; then
-		[ -n "$CI" ] && return
+		[ -n "${CI:-}" ] && return
 		pushd "${tests_repo_dir}"
 		git checkout "${branch}"
 		git pull


### PR DESCRIPTION
PR #2252 put `set -o nounset` in `ci/lib.sh`. It turns out that this
won't work when `$CI` is unset (it is always set in CI). Expand `$CI` to
nothing.

Fixes: #2283
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>