### PR TITLE
snap: do not export agent version

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -115,7 +115,6 @@ parts:
       cd ${kata_dir}/tools/osbuilder
 
       # build image
-      export AGENT_VERSION=$(cat ${kata_dir}/VERSION)
       export AGENT_INIT=yes
       export USE_DOCKER=1
       export DEBUG=1


### PR DESCRIPTION
This causes the repository to be checked out to a version tag, which is
inconsistent with how we build runtime, and reverts us to a buggy
`snap/snapcraft.yaml`.

Fixes: #2313
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

see https://github.com/kata-containers/kata-containers/issues/2190#issuecomment-886798117