### PR TITLE
kata-deploy: Use "alpine" as base image

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM centos/systemd
+FROM alpine
 ARG KUBE_ARCH=amd64
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts
@@ -10,8 +10,7 @@ ARG DESTINATION=/opt/kata-artifacts
 COPY ${KATA_ARTIFACTS} .
 
 RUN \
-yum install -y epel-release && \
-yum install -y bzip2 jq && \
+apk add bzip2 curl jq && \
 mkdir -p ${DESTINATION} && \
 tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION}/ && \
 chown -R root:root ${DESTINATION}/


### PR DESCRIPTION
By using alpine as base image we can ensure we're using an up-to-date
image, differently than the centos-systemd one*, and also using a
smaller image.

*: centos-systemd image has not been updated in the past 3 years or so,
   and quay.io has found several vulnerabilities in the image:
   https://quay.io/repository/kata-containers/kata-deploy?tag=latest&tab=tags

Fixes: #2303, #2304

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>