### PR TITLE
qemu/arm: remove nvdimm/"ReadOnly" option on arm64

### DIFF
--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -126,8 +126,41 @@ func TestQemuArm64AppendImage(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(expectedOut, devices)
 
-	// restore default supportedQemuMachines options
+	//restore default supportedQemuMachines options
 	assert.Equal(len(supportedQemuMachines), copy(supportedQemuMachines, machinesCopy))
+}
+
+func TestQemuArm64AppendNvdimmImage(t *testing.T) {
+	var devices []govmmQemu.Device
+	assert := assert.New(t)
+
+	f, err := ioutil.TempFile("", "img")
+	assert.NoError(err)
+	defer func() { _ = f.Close() }()
+	defer func() { _ = os.Remove(f.Name()) }()
+
+	imageStat, err := f.Stat()
+	assert.NoError(err)
+
+	cfg := qemuConfig(QemuVirt)
+	cfg.ImagePath = f.Name()
+	arm64, err := newQemuArch(cfg)
+	assert.NoError(err)
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.Object{
+			Driver:   govmmQemu.NVDIMM,
+			Type:     govmmQemu.MemoryBackendFile,
+			DeviceID: "nv0",
+			ID:       "mem0",
+			MemPath:  f.Name(),
+			Size:     (uint64)(imageStat.Size()),
+		},
+	}
+
+	devices, err = arm64.appendNvdimmImage(devices, f.Name())
+	assert.NoError(err)
+	assert.Equal(expectedOut, devices)
 }
 
 func TestQemuArm64WithInitrd(t *testing.T) {


### PR DESCRIPTION
There is a new "ReadOnly" option added to nvdimm device in qemu
and now added to kata. However, qemu used for arm64 is a little
old and has no this feature. Here we remove this feature for arm.

this issue leads to the failure of arm ci.

Fixes: #2320
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>