### PR TITLE
docs: Update url for log parser in Developer guide

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -470,7 +470,7 @@ script and paste its output directly into a
 > [runtime](../src/runtime) repository.
 
 To perform analysis on Kata logs, use the
-[`kata-log-parser`](https://github.com/kata-containers/tests/tree/master/cmd/log-parser)
+[`kata-log-parser`](https://github.com/kata-containers/tests/tree/main/cmd/log-parser)
 tool, which can convert the logs into formats (e.g. JSON, TOML, XML, and YAML).
 
 See [Set up a debug console](#set-up-a-debug-console).


### PR DESCRIPTION
This PR updates the proper url for log parser for kata 2.x for
the Developer Guide document.

Fixes #2328

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>