### PR TITLE
versions: Upgrade to Cloud Hypervisor v17.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -353,6 +353,7 @@ components:
             iommu: false
           balloon:
             size: 9
+            deflate_on_oom: false
           memory:
             hugepages: false
             shared: false
@@ -449,6 +450,9 @@ components:
             cpus:
             - 5
             - 5
+            sgx_epc_sections:
+            - sgx_epc_sections
+            - sgx_epc_sections
             memory_zones:
             - memory_zones
             - memory_zones
@@ -461,6 +465,9 @@ components:
             cpus:
             - 5
             - 5
+            sgx_epc_sections:
+            - sgx_epc_sections
+            - sgx_epc_sections
             memory_zones:
             - memory_zones
             - memory_zones
@@ -471,8 +478,10 @@ components:
           sgx_epc:
           - prefault: false
             size: 6
+            id: id
           - prefault: false
             size: 6
+            id: id
           fs:
           - num_queues: 6
             queue_size: 3
@@ -649,6 +658,7 @@ components:
           iommu: false
         balloon:
           size: 9
+          deflate_on_oom: false
         memory:
           hugepages: false
           shared: false
@@ -745,6 +755,9 @@ components:
           cpus:
           - 5
           - 5
+          sgx_epc_sections:
+          - sgx_epc_sections
+          - sgx_epc_sections
           memory_zones:
           - memory_zones
           - memory_zones
@@ -757,6 +770,9 @@ components:
           cpus:
           - 5
           - 5
+          sgx_epc_sections:
+          - sgx_epc_sections
+          - sgx_epc_sections
           memory_zones:
           - memory_zones
           - memory_zones
@@ -767,8 +783,10 @@ components:
         sgx_epc:
         - prefault: false
           size: 6
+          id: id
         - prefault: false
           size: 6
+          id: id
         fs:
         - num_queues: 6
           queue_size: 3
@@ -1283,10 +1301,16 @@ components:
     BalloonConfig:
       example:
         size: 9
+        deflate_on_oom: false
       properties:
         size:
           format: int64
           type: integer
+        deflate_on_oom:
+          default: false
+          description: Whether the balloon should deflate when the guest is under
+            memory pressure.
+          type: boolean
       required:
       - size
       type: object
@@ -1420,7 +1444,10 @@ components:
       example:
         prefault: false
         size: 6
+        id: id
       properties:
+        id:
+          type: string
         size:
           format: int64
           type: integer
@@ -1428,6 +1455,7 @@ components:
           default: false
           type: boolean
       required:
+      - id
       - size
       type: object
     NumaDistance:
@@ -1455,6 +1483,9 @@ components:
         cpus:
         - 5
         - 5
+        sgx_epc_sections:
+        - sgx_epc_sections
+        - sgx_epc_sections
         memory_zones:
         - memory_zones
         - memory_zones
@@ -1473,6 +1504,10 @@ components:
             $ref: '#/components/schemas/NumaDistance'
           type: array
         memory_zones:
+          items:
+            type: string
+          type: array
+        sgx_epc_sections:
           items:
             type: string
           type: array

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/BalloonConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/BalloonConfig.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Size** | **int64** |  | 
+**DeflateOnOom** | **bool** | Whether the balloon should deflate when the guest is under memory pressure. | [optional] [default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NumaConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NumaConfig.md
@@ -8,6 +8,7 @@ Name | Type | Description | Notes
 **Cpus** | **[]int32** |  | [optional] 
 **Distances** | [**[]NumaDistance**](NumaDistance.md) |  | [optional] 
 **MemoryZones** | **[]string** |  | [optional] 
+**SgxEpcSections** | **[]string** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/SgxEpcConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/SgxEpcConfig.md
@@ -4,6 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**Id** | **string** |  | 
 **Size** | **int64** |  | 
 **Prefault** | **bool** |  | [optional] [default to false]
 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_balloon_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_balloon_config.go
@@ -12,4 +12,6 @@ package openapi
 // BalloonConfig struct for BalloonConfig
 type BalloonConfig struct {
 	Size int64 `json:"size"`
+	// Whether the balloon should deflate when the guest is under memory pressure.
+	DeflateOnOom bool `json:"deflate_on_oom,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_numa_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_numa_config.go
@@ -11,8 +11,9 @@ package openapi
 
 // NumaConfig struct for NumaConfig
 type NumaConfig struct {
-	GuestNumaId int32          `json:"guest_numa_id"`
-	Cpus        []int32        `json:"cpus,omitempty"`
-	Distances   []NumaDistance `json:"distances,omitempty"`
-	MemoryZones []string       `json:"memory_zones,omitempty"`
+	GuestNumaId    int32          `json:"guest_numa_id"`
+	Cpus           []int32        `json:"cpus,omitempty"`
+	Distances      []NumaDistance `json:"distances,omitempty"`
+	MemoryZones    []string       `json:"memory_zones,omitempty"`
+	SgxEpcSections []string       `json:"sgx_epc_sections,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_sgx_epc_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_sgx_epc_config.go
@@ -11,6 +11,7 @@ package openapi
 
 // SgxEpcConfig struct for SgxEpcConfig
 type SgxEpcConfig struct {
-	Size     int64 `json:"size"`
-	Prefault bool  `json:"prefault,omitempty"`
+	Id       string `json:"id"`
+	Size     int64  `json:"size"`
+	Prefault bool   `json:"prefault,omitempty"`
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -745,6 +745,10 @@ components:
         size:
           type: integer
           format: int64
+        deflate_on_oom:
+          type: boolean
+          default: false
+          description: Whether the balloon should deflate when the guest is under memory pressure.
 
     FsConfig:
       required:
@@ -847,9 +851,12 @@ components:
 
     SgxEpcConfig:
       required:
+      - id
       - size
       type: object
       properties:
+        id:
+          type: string
         size:
           type: integer
           format: int64
@@ -888,6 +895,10 @@ components:
           items:
             $ref: '#/components/schemas/NumaDistance'
         memory_zones:
+          type: array
+          items:
+            type: string
+        sgx_epc_sections:
           type: array
           items:
             type: string

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v16.0"
+      version: "v17.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
Highlights from the Cloud Hypervisor release v17.0:

1. ARM64 NUMA support using ACPI; 
2. `Seccomp` support for MSHV backend;
3. Hotplug of macvtap devices; 
4. Improved SGX support;
5. Inflight tracking for `vhost-user` devices;
6. Bug fixes.

Details can be found: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v17.0

Note: The client code of cloud-hypervisor's OpenAPI is automatically
generated by `openapi-generator` [1-2]. As the API changes do not
impact usages in Kata, no additional changes in kata's runtime are
needed to work with the current version of cloud-hypervisor.

[1] https://github.com/OpenAPITools/openapi-generator
[2] https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/pkg/cloud-hypervisor/README.md

Fixes: #2333

Signed-off-by: Bo Chen <chen.bo@intel.com>