### PR TITLE
ci: Run static checks when PRs are updated

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -2,7 +2,9 @@ on:
   pull_request:
     types:
       - opened
+      - edited
       - reopened
+      - synchronize
       - labeled
       - unlabeled
 


### PR DESCRIPTION
Looking at the changes that could cause the static-checks to not run
when a PR is updated I think 7db8a85a1f3b4a2ccecd959c33fd88386e4a8691
could be the one that introduced such a regression.

Let's (try to) fix this by enforcing the workflow to run also when the
PR has been "edited" and "synchronized".

Fixes: #2343

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>