### PR TITLE
how-to-use-virtio-mem-with-kata.md: Remove undefined ${REPORT_DIR}

### DIFF
--- a/docs/how-to/how-to-use-virtio-mem-with-kata.md
+++ b/docs/how-to/how-to-use-virtio-mem-with-kata.md
@@ -41,7 +41,7 @@ $ echo 1 | sudo tee /proc/sys/vm/overcommit_memory
 Use following command to start a Kata Container.
 ```
 $ pod_yaml=pod.yaml
-$ container_yaml=${REPORT_DIR}/container.yaml
+$ container_yaml=container.yaml
 $ image="quay.io/prometheus/busybox:latest"
 $ cat << EOF > "${pod_yaml}"
 metadata:


### PR DESCRIPTION
Remove undefined ${REPORT_DIR} in how-to-use-virtio-mem-with-kata.md.

Fixes: #2348

Signed-off-by: Hui Zhu <teawater@antfin.com>