### PR TITLE
docs: update the kata release url in the kata deploy document

### DIFF
--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -112,7 +112,7 @@ $ kubectl delete -f runtimeclasses/kata-runtimeClasses.yaml
 
 The [Dockerfile](Dockerfile)  used to create the container image deployed in the DaemonSet is provided here.
 This image contains all the necessary artifacts for running Kata Containers, all of which are pulled
-from the [Kata Containers release page](https://github.com/kata-containers/runtime/releases).
+from the [Kata Containers release page](https://github.com/kata-containers/kata-containers/releases).
 
 Host artifacts:
 * `cloud-hypervisor`, `firecracker`, `qemu-system-x86_64`, and supporting binaries


### PR DESCRIPTION
fixed the url error, updated the path to kata 2.x release
(https://github.com/kata-containers/kata-containers/releases) from kata 1.x release
(https://github.com/kata-containers/runtime/releases) in the kata-deploy README.md file.

Fixes: #2355.

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>