### PR TITLE
Fix issue container start fail if io.katacontainers.container.resource.swap_in_bytes and memory_limit_in_bytes are not set

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -777,12 +777,18 @@ func newContainer(ctx context.Context, sandbox *Sandbox, contConfig *ContainerCo
 		if err != nil {
 			return &Container{}, fmt.Errorf("Invalid container configuration Annotations %s %v", vcAnnotations.ContainerResourcesSwappiness, err)
 		}
+		if c.config.Resources.Memory == nil {
+			c.config.Resources.Memory = &specs.LinuxMemory{}
+		}
 		c.config.Resources.Memory.Swappiness = &resourceSwappiness
 	}
 	if resourceSwapInBytesStr, ok := c.config.Annotations[vcAnnotations.ContainerResourcesSwapInBytes]; ok {
 		resourceSwapInBytesInUint, err := strconv.ParseUint(resourceSwapInBytesStr, 0, 64)
 		if err != nil {
 			return &Container{}, fmt.Errorf("Invalid container configuration Annotations %s %v", vcAnnotations.ContainerResourcesSwapInBytes, err)
+		}
+		if c.config.Resources.Memory == nil {
+			c.config.Resources.Memory = &specs.LinuxMemory{}
 		}
 		resourceSwapInBytes := int64(resourceSwapInBytesInUint)
 		c.config.Resources.Memory.Swap = &resourceSwapInBytes

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1938,6 +1938,7 @@ func (s *Sandbox) updateResources(ctx context.Context) error {
 	if sandboxneedPodSwap {
 		sandboxSwapByte += hypervisorMemoryByte
 	}
+	s.Logger().WithField("sandboxMemoryByte", sandboxMemoryByte).WithField("sandboxneedPodSwap", sandboxneedPodSwap).WithField("sandboxSwapByte", sandboxSwapByte).Debugf("updateResources: after calculateSandboxMemory")
 
 	// Setup the SWAP in the guest
 	if sandboxSwapByte > 0 {


### PR DESCRIPTION
container start fail if io.katacontainers.container.resource.swap_in_bytes and memory_limit_in_bytes are not set.

```
$ pod_yaml=pod.yaml
$ container_yaml=container.yaml
$ image="quay.io/prometheus/busybox:latest"
$ cat << EOF > "${pod_yaml}"
metadata:
  name: busybox-sandbox1
EOF
$ cat << EOF > "${container_yaml}"
metadata:
  name: busybox-killed-vmm
annotations:
  io.katacontainers.container.resource.swappiness: "60"
image:
  image: "$image"
command:
- top
EOF
$ sudo crictl pull $image
$ podid=$(sudo crictl runp $pod_yaml)
$ cid=$(sudo crictl create $podid $container_yaml $pod_yaml)
$ sudo crictl start $cid
DEBU[0000] get runtime connection
DEBU[0000] connect using endpoint 'unix:///var/run/containerd/containerd.sock' with '10s' timeout
DEBU[0000] connected successfully using endpoint: unix:///var/run/containerd/containerd.sock
DEBU[0000] StartContainerRequest: &StartContainerRequest{ContainerId:4fea91d16f661931fe33acd247efe831ef9e571588ba18b5a16f04c278fd61b8,}
DEBU[0000] StartContainerResponse: nil
FATA[0000] starting the container "4fea91d16f661931fe33acd247efe831ef9e571588ba18b5a16f04c278fd61b8": rpc error: code = Unknown desc = failed to create containerd task: failed to create shim: ttrpc: closed: unknown
```
The cause of fail if if c.config.Resources.Memory is nil, values of io.katacontainers.container.resource.swappiness and io.katacontainers.container.resource.swap_in_bytes will be store in newContainer.

This PR initialize c.config.Resources.Memory if it is nil in newContainer.

Fixes: #2367

Signed-off-by: Hui Zhu <teawater@antfin.com>
