### PR TITLE
Container: Add initConfigResourcesMemory and call it in newContainer

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -745,6 +745,12 @@ func (c *Container) createBlockDevices(ctx context.Context) error {
 	return nil
 }
 
+func (c *Container) initConfigResourcesMemory() {
+	ociSpec := c.GetPatchedOCISpec()
+	c.config.Resources.Memory = &specs.LinuxMemory{}
+	ociSpec.Linux.Resources.Memory = c.config.Resources.Memory
+}
+
 // newContainer creates a Container structure from a sandbox and a container configuration.
 func newContainer(ctx context.Context, sandbox *Sandbox, contConfig *ContainerConfig) (*Container, error) {
 	span, ctx := katatrace.Trace(ctx, sandbox.Logger(), "newContainer", sandbox.tracingTags())
@@ -778,7 +784,7 @@ func newContainer(ctx context.Context, sandbox *Sandbox, contConfig *ContainerCo
 			return &Container{}, fmt.Errorf("Invalid container configuration Annotations %s %v", vcAnnotations.ContainerResourcesSwappiness, err)
 		}
 		if c.config.Resources.Memory == nil {
-			c.config.Resources.Memory = &specs.LinuxMemory{}
+			c.initConfigResourcesMemory()
 		}
 		c.config.Resources.Memory.Swappiness = &resourceSwappiness
 	}
@@ -788,7 +794,7 @@ func newContainer(ctx context.Context, sandbox *Sandbox, contConfig *ContainerCo
 			return &Container{}, fmt.Errorf("Invalid container configuration Annotations %s %v", vcAnnotations.ContainerResourcesSwapInBytes, err)
 		}
 		if c.config.Resources.Memory == nil {
-			c.config.Resources.Memory = &specs.LinuxMemory{}
+			c.initConfigResourcesMemory()
 		}
 		resourceSwapInBytes := int64(resourceSwapInBytesInUint)
 		c.config.Resources.Memory.Swap = &resourceSwapInBytes


### PR DESCRIPTION
The swappiness is not right if just set
io.katacontainers.container.resource.swappiness:
```
$ pod_yaml=pod.yaml
$ container_yaml=container.yaml
$ image="quay.io/prometheus/busybox:latest"
$ cat << EOF > "${pod_yaml}"
metadata:
  name: busybox-sandbox1
EOF
$ cat << EOF > "${container_yaml}"
metadata:
  name: busybox-killed-vmm
annotations:
  io.katacontainers.container.resource.swappiness: "100"
image:
  image: "$image"
command:
- top
EOF
$ sudo crictl pull $image
$ podid=$(sudo crictl runp $pod_yaml)
$ cid=$(sudo crictl create $podid $container_yaml $pod_yaml)
$ sudo crictl start $cid
crictl exec $cid cat /sys/fs/cgroup/memory/memory.swappiness
60
```
The cause of this issue is there are two elements store the resources
infomation.  They are c.config.Resources for calculateSandboxMemory and
c.GetPatchedOCISpec() for agent.
This add initConfigResourcesMemory to Container and call it in
newContainer to handle the issue.

Fixes: #2372

Signed-off-by: Hui Zhu <teawater@antfin.com>