### PR TITLE
kata-deploy: use ubi-minimal as the base image

### DIFF
--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -43,7 +43,7 @@ jobs:
         id: build-container-image
         run: |
             PR_SHA=$(git log --format=format:%H -n1)
-            VERSION="2.0.0"
+            VERSION="2.2.0-alpha1"
             ARTIFACT_URL="https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-static-${VERSION}-x86_64.tar.xz"
             wget "${ARTIFACT_URL}" -O tools/packaging/kata-deploy/kata-static.tar.xz
             docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t katadocker/kata-deploy-ci:${PR_SHA} ./tools/packaging/kata-deploy

--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -43,7 +43,7 @@ jobs:
         id: build-container-image
         run: |
             PR_SHA=$(git log --format=format:%H -n1)
-            VERSION="2.2.0-alpha1"
+            VERSION="2.0.0"
             ARTIFACT_URL="https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-static-${VERSION}-x86_64.tar.xz"
             wget "${ARTIFACT_URL}" -O tools/packaging/kata-deploy/kata-static.tar.xz
             docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t katadocker/kata-deploy-ci:${PR_SHA} ./tools/packaging/kata-deploy

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -2,7 +2,27 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM centos/systemd
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest AS base
+
+RUN microdnf update -y && \
+microdnf clean all
+
+RUN microdnf -y install systemd && \
+microdnf clean all && \
+(cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*;\
+rm -f /etc/systemd/system/*.wants/*;\
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*;\
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+CMD [ "/usr/sbin/init" ]
+
+FROM base
+
 ARG KUBE_ARCH=amd64
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts
@@ -10,15 +30,14 @@ ARG DESTINATION=/opt/kata-artifacts
 COPY ${KATA_ARTIFACTS} .
 
 RUN \
-yum install -y epel-release && \
-yum install -y bzip2 jq && \
+microdnf install -y bzip2 dbus jq tar xz && \
 mkdir -p ${DESTINATION} && \
 tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION}/ && \
 chown -R root:root ${DESTINATION}/
 
 RUN \
-curl -Lso /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${KUBE_ARCH}/kubectl && \
-chmod +x /bin/kubectl
+curl -Lso /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${KUBE_ARCH}/kubectl && \
+chmod +x /usr/bin/kubectl
 
 COPY scripts ${DESTINATION}/scripts
 RUN \


### PR DESCRIPTION
By using ubi-minimal as base image we can ensure we're using an up to
date image, differently than the centos-systemd one*.

I've though about using a fedora-minimal image and that was my first
preference, but seems that quay.io cannot scan the content of a Fedora
image**, making ubi-minimal the best choice we have.

Fixes: #2303

*: centos-systemd image has not been updated in the past 3 years or so,
   and quay.io has found several vulnerabilities in the image:
   https://quay.io/repository/kata-containers/kata-deploy?tag=latest&tab=tags

**: https://access.redhat.com/documentation/en-us/red_hat_quay/3.3/html/manage_red_hat_quay/clair-initial-setup#clair-sources