### PR TITLE
osbuilder: pass env OS_VERSION

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -410,6 +410,7 @@ build_rootfs_distro()
 			--env KERNEL_MODULES_DIR="${KERNEL_MODULES_DIR}" \
 			--env EXTRA_PKGS="${EXTRA_PKGS}" \
 			--env OSBUILDER_VERSION="${OSBUILDER_VERSION}" \
+			--env OS_VERSION="${OS_VERSION}" \
 			--env INSIDE_CONTAINER=1 \
 			--env SECCOMP="${SECCOMP}" \
 			--env DEBUG="${DEBUG}" \


### PR DESCRIPTION
With lines like
https://github.com/kata-containers/kata-containers/blob/0a2e2c6038ff9623610d62cad8db1d723dd500cb/tools/osbuilder/rootfs-builder/fedora/config.sh#L8
we imply that one can set another OS_VERSION and it will get picked up.
This is not the case when building inside Docker/Podman because the
variable is not passed to the container, which can lead to confusion.
Forward this env.

Fixes: #2378
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/test