### PR TITLE
osbuilder/dracut: Add missing libraries

### DIFF
--- a/tools/osbuilder/.gitignore
+++ b/tools/osbuilder/.gitignore
@@ -1,5 +1,6 @@
 image-builder/nsdax
 dracut/Dockerfile
+dracut/dracut.conf.d/15-extra-libs.conf
 /.*.done
 /*_rootfs
 /kata-Centos-dnf.conf

--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -52,6 +52,12 @@ ifeq (dracut,$(BUILD_METHOD))
     DRACUT_OPTIONS += --no-kernel
   endif
 
+  ifeq (no,$(AGENT_INIT))
+    AGENT_PATH := $(DRACUT_OVERLAY_DIR)/usr/bin/kata-agent
+  else
+    AGENT_PATH := $(DRACUT_OVERLAY_DIR)/sbin/init
+  endif
+
   ifeq (,$(DRACUT_OVERLAY_DIR))
     $(error DRACUT_OVERLAY_DIR cannot be empty)
   endif
@@ -133,6 +139,7 @@ $(TARGET_INITRD): $(TARGET_ROOTFS_MARKER)
 else
 $(TARGET_INITRD): $(DRACUT_OVERLAY_DIR)
 	@echo Creating initrd image based on the host OS using dracut
+	$(DRACUT_DIR)/add_libs.sh $(AGENT_PATH) > $(DRACUT_CONF_DIR)/15-extra-libs.conf
 	dracut $(DRACUT_OPTIONS) --include $< / $@ $(DRACUT_KVERSION)
 endif
 

--- a/tools/osbuilder/dracut/add_libs.sh
+++ b/tools/osbuilder/dracut/add_libs.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 IBM Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+script_name="$(basename "$0")"
+usage() {
+	cat >&2 << EOF
+Usage: ${script_name} [-h] <agent-binary>
+Output dracut configuration with required additional libraries for the Kata agent.
+
+Example:
+${script_name} \$GOPATH/src/github.com/kata-containers/kata-containers/src/agent/target/x86_64-unknown-linux-gnu/release/kata-agent
+
+Options:
+-h: Show this help
+EOF
+	exit "$1"
+}
+
+if [[ $# != 1 || "$1" == "-h" ]]; then
+	usage 0
+fi
+
+agent_binary="$1"
+non_standard_libs=("libutil.so")
+install_items=""
+
+if [ ! -x "${agent_binary}" ]; then
+	echo >&2 "ERROR: ${agent_binary} is not an executable file"
+	usage 1
+fi
+
+# Cover both cases of "not a dynamic executable" being printed to STDERR
+# and "statically linked" being printed to STDOUT
+linked_libs="$(ldd "${agent_binary}" 2>&1)"
+if [ "$(wc -l <<< "${linked_libs}")" == 1 ]; then
+	echo >&2 "Agent appears to be linked statically, exiting"
+	exit 0
+fi
+
+for lib in "${non_standard_libs[@]}"; do
+	install_items+=" $(grep -F "${lib}" <<< "${linked_libs}" | cut -d" " -f3)"
+done
+
+cat << EOF
+# add libraries that the Kata agent is linked against, but that are not included by default
+install_items+="${install_items} "
+EOF


### PR DESCRIPTION
When the guest is built using dracut and the agent uses glibc (esp.
ppc64le/s390x), libraries might be missing. In my case, it was
`libutil.so`, but more can be added easily. Add a script to configure
`install_items` for dracut w.r.t. `ldd` of the agent.

Fixes: #2384
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>