### PR TITLE
osbuilder: Drop Go agent support

### DIFF
--- a/tools/osbuilder/tests/test_config.sh
+++ b/tools/osbuilder/tests/test_config.sh
@@ -43,23 +43,21 @@ if [ -n "${CI:-}" ]; then
 		skipWhenTestingAll+=("${distro}")
 	done
 
-	if [ "${RUST_AGENT:-}" == "yes" ]; then
-		# add skipForRustDistros to skipWhenTestingAll if it is not
-		for td in "${skipForRustDistros[@]}"; do
-			if distro_in_set "${td}" "${skipWhenTestingAll[@]}"; then
+	# add skipForRustDistros to skipWhenTestingAll if it is not
+	for td in "${skipForRustDistros[@]}"; do
+		if distro_in_set "${td}" "${skipWhenTestingAll[@]}"; then
+			continue
+		fi
+		# not found in skipWhenTestingAll, add to it
+		skipWhenTestingAll+=("${td}")
+	done
+
+	if distro_in_set "${arch}" "${skipForRustArch[@]}"; then
+		for distro in "${test_distros[@]}"; do
+			if distro_in_set "${distro}" "${skipWhenTestingAll[@]}"; then
 				continue
 			fi
-			# not found in skipWhenTestingAll, add to it
-			skipWhenTestingAll+=("${td}")
+			skipWhenTestingAll+=("${distro}")
 		done
-
-		if distro_in_set "${arch}" "${skipForRustArch[@]}"; then
-			for distro in "${test_distros[@]}"; do
-				if distro_in_set "${distro}" "${skipWhenTestingAll[@]}"; then
-					continue
-				fi
-				skipWhenTestingAll+=("${distro}")
-			done
-		fi
 	fi
 fi

--- a/tools/osbuilder/tests/test_images.sh
+++ b/tools/osbuilder/tests/test_images.sh
@@ -388,9 +388,7 @@ install_image_create_container()
 
 	showKataRunFailure=1
 	run_mgr reset-config
-	if [ "${RUST_AGENT:-}" = "yes" ]; then
-		run_mgr enable-vsock
-	fi
+	run_mgr enable-vsock
 	run_mgr configure-image "$file"
 	create_container
 	showKataRunFailure=
@@ -408,9 +406,7 @@ install_initrd_create_container()
 
 	showKataRunFailure=1
 	run_mgr reset-config
-	if [ "${RUST_AGENT:-}" = "yes" ]; then
-		run_mgr enable-vsock
-	fi
+	run_mgr enable-vsock
 	run_mgr configure-initrd "$file"
 	create_container
 	showKataRunFailure=


### PR DESCRIPTION
With Kata 1.x EOL, the Go agent is no more.  So, remove support for it from the Kata tree.er scripts.  This removes the RUST_AGENT variable, treating it as always true.

