### PR TITLE
kata deploy: always update the base image

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -2,7 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM centos/systemd
+FROM registry.centos.org/centos:7 AS base
+
+ENV container docker
+
+RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+rm -f /lib/systemd/system/multi-user.target.wants/*; \
+rm -f /etc/systemd/system/*.wants/*; \
+rm -f /lib/systemd/system/local-fs.target.wants/*; \
+rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+rm -f /lib/systemd/system/basic.target.wants/*; \
+rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+VOLUME [ "/sys/fs/cgroup" ]
+
+CMD ["/usr/sbin/init"]
+
+FROM base
+
 ARG KUBE_ARCH=amd64
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -13,6 +13,7 @@ RUN \
 yum -y update && \
 yum install -y epel-release && \
 yum install -y bzip2 jq && \
+yum clean all && \
 mkdir -p ${DESTINATION} && \
 tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION}/ && \
 chown -R root:root ${DESTINATION}/

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -10,6 +10,7 @@ ARG DESTINATION=/opt/kata-artifacts
 COPY ${KATA_ARTIFACTS} .
 
 RUN \
+yum -y update && \
 yum install -y epel-release && \
 yum install -y bzip2 jq && \
 mkdir -p ${DESTINATION} && \


### PR DESCRIPTION
This PR consists in 3 small patches updating the base image we use for kata-deploy.  All in all, the differences are not big, as we keep using CentOS 7, but we ensure that we have it up-to-date and we also lower the delta of the packages that have to be updated during the process of building the image.

If you're curious why we keep using CentOS 7 though, the reason is because CentOS 8, and UBI images have a different systemd configuration that works quite well when mounting the image using podman, but systemd can't connect dbus when running on environments like AKS or even minikube.  So, in order to be as compatible as possible, let's keep
using the CentOS 7 image for now, at least till we find a suitable substitute for that.

Fixes: #2303 
