### PR TITLE
agent: watcher / inotify stability fixes

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -549,6 +549,7 @@ dependencies = [
  "slog-scope",
  "slog-stdlog",
  "tempfile",
+ "thiserror",
  "tokio",
  "tokio-vsock",
  "tracing",
@@ -1511,18 +1512,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f4a65597094d4483ddaed134f409b2cb7c1beccf25201a9f73c719254fa98e"
+checksum = "93119e4feac1cbe6c798c34d3a53ea0026b0b1de6a120deef895137c0529bfe2"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7765189610d8241a44529806d6fd1f2e0a08734313a35d5b3a556f92b381f3c0"
+checksum = "060d69a0afe7796bf42e9e2ff91f5ee691fb15c53d38b4b62a9a53eb23164745"
 dependencies = [
  "proc-macro2 1.0.26",
  "quote 1.0.9",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -18,6 +18,7 @@ capctl = "0.2.0"
 serde_json = "1.0.39"
 scan_fmt = "0.2.3"
 scopeguard = "1.0.0"
+thiserror = "1.0.26"
 regex = "1"
 
 # Async helpers

--- a/src/agent/src/watcher.rs
+++ b/src/agent/src/watcher.rs
@@ -22,7 +22,7 @@ use crate::mount::BareMount;
 use crate::protocols::agent as protos;
 
 /// The maximum number of file system entries agent will watch for each mount.
-const MAX_ENTRIES_PER_STORAGE: usize = 8;
+const MAX_ENTRIES_PER_STORAGE: usize = 16;
 
 /// The maximum size of a watchable mount in bytes.
 const MAX_SIZE_PER_WATCHABLE_MOUNT: u64 = 1024 * 1024;
@@ -44,7 +44,7 @@ struct Storage {
     target_mount_point: PathBuf,
 
     /// Flag to indicate that the Storage should be watched. Storage will be watched until
-    /// the source becomes too large, either in number of files (>8) or total size (>1MB).
+    /// the source becomes too large, either in number of files (>16) or total size (>1MB).
     watch: bool,
 
     /// The list of files to watch from the source mount point and updated in the target one.
@@ -573,7 +573,7 @@ mod tests {
         fs::remove_file(source_dir.path().join("big.txt")).unwrap();
         fs::remove_file(source_dir.path().join("too-big.txt")).unwrap();
 
-        // Up to eight files should be okay:
+        // Up to 16 files should be okay:
         fs::write(source_dir.path().join("1.txt"), "updated").unwrap();
         fs::write(source_dir.path().join("2.txt"), "updated").unwrap();
         fs::write(source_dir.path().join("3.txt"), "updated").unwrap();
@@ -582,10 +582,18 @@ mod tests {
         fs::write(source_dir.path().join("6.txt"), "updated").unwrap();
         fs::write(source_dir.path().join("7.txt"), "updated").unwrap();
         fs::write(source_dir.path().join("8.txt"), "updated").unwrap();
+        fs::write(source_dir.path().join("9.txt"), "updated").unwrap();
+        fs::write(source_dir.path().join("10.txt"), "updated").unwrap();
+        fs::write(source_dir.path().join("11.txt"), "updated").unwrap();
+        fs::write(source_dir.path().join("12.txt"), "updated").unwrap();
+        fs::write(source_dir.path().join("13.txt"), "updated").unwrap();
+        fs::write(source_dir.path().join("14.txt"), "updated").unwrap();
+        fs::write(source_dir.path().join("15.txt"), "updated").unwrap();
+        fs::write(source_dir.path().join("16.txt"), "updated").unwrap();
         assert_eq!(entry.scan(&logger).await.unwrap(), 8);
 
-        // Nine files is too many:
-        fs::write(source_dir.path().join("9.txt"), "updated").unwrap();
+        // 17 files is too many:
+        fs::write(source_dir.path().join("16.txt"), "updated").unwrap();
         thread::sleep(Duration::from_secs(1));
         assert!(entry.scan(&logger).await.is_err());
     }


### PR DESCRIPTION
BindMount / stopping watching handling changes: Now we will only replace
the watched storage with a bindmount if we observe that there are too
many files. To facilitate this, have scan/scan_path return a bool value
to indicate the mount has grown too large (instead of having this return
error).

When handling an oversided mount, do not remove the prior files -- we'll just
overwrite them with the bindmount. This'll help avoid the files
disappearing from the user, avoid racy cleanup and simplifies the flow.
Similarly, only mark it as a non-watched storage device after the
bindmount is created successfully.

In several spots, we were returning when there was an error (both in
scan and update). For update case, let's just log an warning and continue;
since the scan/update is racy, we should expect that we'll have
transient errors which should resolve the next time the watcher runs.