### PR TITLE
client: fix dropped error

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/client.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/client.go
@@ -372,6 +372,9 @@ func (c *APIClient) decode(v interface{}, b []byte, contentType string) (err err
 			return
 		}
 		_, err = (*f).Write(b)
+		if err != nil {
+			return
+		}
 		_, err = (*f).Seek(0, io.SeekStart)
 		return
 	}


### PR DESCRIPTION
This fixes a dropped `err` in the `src/runtime/virtcontainers/pkg/cloud-hypervisor/client` package.