### PR TITLE
stable-2.1 | virtcontainers: fc: properly remove jailed block device

### DIFF
--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -1057,7 +1057,12 @@ func (fc *firecracker) hotplugBlockDevice(ctx context.Context, drive config.Bloc
 		fc.umountResource(driveID)
 		// use previous raw file created at createDiskPool, that way
 		// the resource is released by firecracker and it can be destroyed in the host
-		path = filepath.Join(fc.jailerRoot, driveID)
+		if fc.jailed {
+			// use path relative to the jail
+			path = filepath.Join("/", driveID)
+		} else {
+			path = filepath.Join(fc.jailerRoot, driveID)
+		}
 	}
 
 	return nil, fc.fcUpdateBlockDrive(ctx, path, driveID)


### PR DESCRIPTION
When running a firecracker instance jailed, block devices
are not removed correctly, as the jailerRoot path is not
stripped from the PATCH command sent to the FC API.

This patch differentiates the jailed case from the non-jailed
one and allows the firecracker instance to be properly
terminated.

Fixes #2387

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>
(cherry picked from commit 64dd35b)