### PR TITLE
docs: Update agent url

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -1,6 +1,6 @@
 # Kata Agent in Rust
 
-This is a rust version of the [`kata-agent`](https://github.com/kata-containers/agent).
+This is a rust version of the [`kata-agent`](https://github.com/kata-containers/kata-containers/tree/main/src/agent).
 
 In Denver PTG, [we discussed about re-writing agent in rust](https://etherpad.openstack.org/p/katacontainers-2019-ptg-denver-agenda):
 


### PR DESCRIPTION
This PR updates the proper agent url for kata 2.0 in order to fix
the link.

Fixes #2414

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>