### PR TITLE
kata-tarball: Build and test fixes

### DIFF
--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -1,6 +1,6 @@
-name: kata-deploy-build
+name: kata deploy build
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build-asset:
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build ${{ matrix.asset }}
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh --build="${KATA_ASSET}"
+          make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           sudo cp -r --preserve=all "${build_dir}" "kata-build"
@@ -47,10 +47,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: kata-artifacts
-          path: kata-artifacts
+          path: build
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts
+          make merge-builds
       - name: store-artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -56,3 +56,12 @@ jobs:
         with:
           name: kata-static-tarball
           path: kata-static.tar.xz
+
+  make-kata-tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: make kata-tarball
+        run: |
+          make kata-tarball
+          sudo make install-tarball

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ TOOLS += agent-ctl
 STANDARD_TARGETS = build check clean install test vendor
 
 include utils.mk
+include ./tools/packaging/kata-deploy/local-build/Makefile
 
 all: build
 
@@ -32,11 +33,5 @@ generate-protocols:
 # Some static checks rely on generated source files of components.
 static-checks: build
 	bash ci/static-checks.sh
-
-binary-tarball:
-	make -f ./tools/packaging/kata-deploy/local-build/Makefile
-
-install-binary-tarball:
-	make -f ./tools/packaging/kata-deploy/local-build/Makefile install
 
 .PHONY: all default static-checks binary-tarball install-binary-tarball

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -21,33 +21,42 @@ endef
 kata-tarball: | all-parallel merge-builds
 
 all-parallel:
-	make -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true"
+	${MAKE} -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true"
 
-all: cloud-hypervisor firecracker kernel qemu rootfs-image rootfs-initrd shim-v2
+all: cloud-hypervisor-tarball \
+	firecracker-tarball \
+	kernel-tarball \
+	qemu-tarball \
+	rootfs-image-tarball \
+	rootfs-initrd-tarball \
+	shim-v2-tarball
 
-cloud-hypervisor:
-	$(call BUILD,$@)
+%-tarball-build:
+	$(call BUILD,$*)
 
-firecracker:
-	$(call BUILD,$@)
+cloud-hypervisor-tarball:
+	${MAKE} $@-build
 
-kernel:
-	$(call BUILD,$@)
+firecracker-tarball:
+	${MAKE} $@-build
 
-qemu:
-	$(call BUILD,$@)
+kernel-tarball:
+	${MAKE} $@-build
 
-rootfs-image:
-	$(call BUILD,$@)
+qemu-tarball:
+	${MAKE} $@-build
 
-rootfs-initrd:
-	$(call BUILD,$@)
+rootfs-image-tarball:
+	${MAKE} $@-build
 
-shim-v2:
-	$(call BUILD,$@)
+rootfs-initrd-tarball:
+	${MAKE} $@-build
+
+shim-v2-tarball:
+	${MAKE} $@-build
 
 merge-builds:
 	$(MK_DIR)/kata-deploy-merge-builds.sh build
 
-install:
+install-tarball:
 	tar -xvf ./kata-static.tar.xz -C /

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -7,21 +7,16 @@ MK_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_PATH))
 
 # Verbose build
-V ?=
-ifneq ($(V),)
-SILENT_BUILD_FLAG =
-else
-SILENT_BUILD_FLAG = -s
-endif
+V := 1
 
 define BUILD
-	$(MK_DIR)/kata-deploy-binaries-in-docker.sh $(SILENT_BUILD_FLAG) --build=$1
+	$(MK_DIR)/kata-deploy-binaries-in-docker.sh $(if $(V),,-s) --build=$1
 endef
 
 kata-tarball: | all-parallel merge-builds
 
 all-parallel:
-	${MAKE} -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true"
+	${MAKE} -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true" V=
 
 all: cloud-hypervisor-tarball \
 	firecracker-tarball \


### PR DESCRIPTION
makefile: Include kata-deploy targets
>Use kata-deploy targets from toplevel. This will help if want to build and reinstall just one single kata component.


kata-deploy: Add tarball suffix to makefile targets
>Now that local-build kata-deploy makefile is inlucded in toplevel
makefile, lets use the suffix `-tarball` to avoid name collitions
and identify the tarball releted targets.

kata-deploy: Make verbose single builds
>If a binary tarball for a single component is done, the logs will be shown in stdout.
e.g.
`make kernel-tarball`
To build all a the same time still store logs in files.
`make kata-tarball`

actions: kata-deploy on PRs and use makefile
>- Run kata-deploy tarball generation action on every PR.
- Use kata-deploy makefile targets.

actions: test `make kata-tarball `
> make kata-tarball is the main way to build a kata in a single host. Lets test it to make sure it works on every PR.