### PR TITLE
tracing: Return context in runHooks() span creation

### DIFF
--- a/src/runtime/pkg/katautils/hook.go
+++ b/src/runtime/pkg/katautils/hook.go
@@ -95,7 +95,7 @@ func runHook(ctx context.Context, hook specs.Hook, cid, bundlePath string) error
 }
 
 func runHooks(ctx context.Context, hooks []specs.Hook, cid, bundlePath, hookType string) error {
-	span, _ := katatrace.Trace(ctx, hookLogger(), "runHooks", hookTracingTags)
+	span, ctx := katatrace.Trace(ctx, hookLogger(), "runHooks", hookTracingTags)
 	katatrace.AddTag(span, "type", hookType)
 	defer span.End()
 


### PR DESCRIPTION
This change was made earlier but inadvertently overwritten in another PR.

The call to Trace() in runHooks() should return a context so that
subsequent calls to runHook() produce properly ordered trace spans.

Fixes #2423

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>