### PR TITLE
test: minor clean up for runtime unit tests

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -1207,6 +1207,7 @@ mod tests {
     fn test_finish_rootfs() {
         let stdout_fd = std::io::stdout().as_raw_fd();
         let mut spec = oci::Spec::default();
+        let process = oci::Process::default();
 
         spec.linux = Some(oci::Linux::default());
         spec.linux.as_mut().unwrap().masked_paths = vec!["/tmp".to_string()];
@@ -1222,7 +1223,7 @@ mod tests {
             options: vec!["ro".to_string(), "shared".to_string()],
         }];
 
-        let ret = finish_rootfs(stdout_fd, &spec, &oci::Process::default());
+        let ret = finish_rootfs(stdout_fd, &spec, &process);
         assert!(ret.is_ok(), "Should pass. Got: {:?}", ret);
     }
 

--- a/src/runtime/virtcontainers/api_test.go
+++ b/src/runtime/virtcontainers/api_test.go
@@ -73,10 +73,10 @@ func newBasicTestCmd() types.Cmd {
 	return cmd
 }
 
-func newTestSandboxConfigNoop() SandboxConfig {
+func newTestSandboxConfig() SandboxConfig {
 	bundlePath := filepath.Join(testDir, testBundle)
 	containerAnnotations[annotations.BundlePathKey] = bundlePath
-	// containerAnnotations["com.github.containers.virtcontainers.pkg.oci.container_type"] = "pod_sandbox"
+	containerAnnotations[annotations.ContainerTypeKey] = string(PodSandbox)
 
 	emptySpec := newEmptySpec()
 
@@ -122,18 +122,11 @@ func newTestSandboxConfigNoop() SandboxConfig {
 	return sandboxConfig
 }
 
-func newTestSandboxConfigKataAgent() SandboxConfig {
-	sandboxConfig := newTestSandboxConfigNoop()
-	sandboxConfig.Containers = nil
-
-	return sandboxConfig
-}
-
 func TestCreateSandboxNoopAgentSuccessful(t *testing.T) {
 	defer cleanUp()
 	assert := assert.New(t)
 
-	config := newTestSandboxConfigNoop()
+	config := newTestSandboxConfig()
 
 	ctx := WithNewAgentFunc(context.Background(), newMockAgent)
 	p, err := CreateSandbox(ctx, config, nil)
@@ -157,7 +150,7 @@ func TestCreateSandboxKataAgentSuccessful(t *testing.T) {
 
 	defer cleanUp()
 
-	config := newTestSandboxConfigKataAgent()
+	config := newTestSandboxConfig()
 
 	url, err := mock.GenerateKataMockHybridVSock()
 	assert.NoError(err)
@@ -242,7 +235,7 @@ func createAndStartSandbox(ctx context.Context, config SandboxConfig) (sandbox V
 func TestReleaseSandbox(t *testing.T) {
 	defer cleanUp()
 
-	config := newTestSandboxConfigNoop()
+	config := newTestSandboxConfig()
 
 	ctx := WithNewAgentFunc(context.Background(), newMockAgent)
 	s, err := CreateSandbox(ctx, config, nil)
@@ -254,7 +247,7 @@ func TestReleaseSandbox(t *testing.T) {
 }
 
 func TestCleanupContainer(t *testing.T) {
-	config := newTestSandboxConfigNoop()
+	config := newTestSandboxConfig()
 	assert := assert.New(t)
 
 	ctx := WithNewAgentFunc(context.Background(), newMockAgent)

--- a/src/runtime/virtcontainers/container_test.go
+++ b/src/runtime/virtcontainers/container_test.go
@@ -603,6 +603,7 @@ func TestMountSharedDirMounts(t *testing.T) {
 	// Create container to utilize this mount/secret
 	//
 	container := Container{
+		ctx:       context.Background(),
 		sandbox:   sandbox,
 		sandboxID: "foobar",
 		id:        "test-ctr",

--- a/src/runtime/virtcontainers/pkg/oci/utils_test.go
+++ b/src/runtime/virtcontainers/pkg/oci/utils_test.go
@@ -850,7 +850,8 @@ func TestAddRuntimeAnnotations(t *testing.T) {
 	ocispec.Annotations[vcAnnotations.DisableNewNetNs] = "true"
 	ocispec.Annotations[vcAnnotations.InterNetworkModel] = "macvtap"
 
-	addAnnotations(ocispec, &config, runtimeConfig)
+	err := addAnnotations(ocispec, &config, runtimeConfig)
+	assert.NoError(err)
 	assert.Equal(config.DisableGuestSeccomp, true)
 	assert.Equal(config.SandboxCgroupOnly, true)
 	assert.Equal(config.NetworkConfig.DisableNewNetNs, true)


### PR DESCRIPTION
Added assertion to TestAddRuntimeAnnotations to ensure no errors.
Cleaned up api_test with creating test sandbox config to combine
newTestSandboxConfigKataAgent and newTestSandboxConfigNoop to
newTestSandboxConfig.

Fixes #2426

Signed-off-by: Yibo Zhuang <yibzhuang@gmail.com>