### PR TITLE
agent: Simplify mount point creation

### DIFF
--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -13,7 +13,7 @@ use std::fs::File;
 use std::path::{Path, PathBuf};
 use tracing::instrument;
 
-use crate::mount::{BareMount, FLAGS};
+use crate::mount::{baremount, FLAGS};
 use slog::Logger;
 
 const PERSISTENT_NS_DIR: &str = "/var/run/sandbox-ns";
@@ -129,8 +129,7 @@ impl Namespace {
                     }
                 };
 
-                let bare_mount = BareMount::new(source, destination, "none", flags, "", &logger);
-                bare_mount.mount().map_err(|e| {
+                baremount(source, destination, "none", flags, "", &logger).map_err(|e| {
                     anyhow!(
                         "Failed to mount {} to {} with err:{:?}",
                         source,

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -47,7 +47,7 @@ use rustjail::process::ProcessOperations;
 use crate::device::{add_devices, pcipath_to_sysfs, rescan_pci_bus, update_device_cgroup};
 use crate::linux_abi::*;
 use crate::metrics::get_metrics;
-use crate::mount::{add_storages, remove_mounts, BareMount, STORAGE_HANDLER_LIST};
+use crate::mount::{add_storages, baremount, remove_mounts, STORAGE_HANDLER_LIST};
 use crate::namespace::{NSTYPEIPC, NSTYPEPID, NSTYPEUTS};
 use crate::network::setup_guest_dns;
 use crate::random;
@@ -1624,15 +1624,14 @@ fn setup_bundle(cid: &str, spec: &mut Spec) -> Result<PathBuf> {
     let rootfs_path = bundle_path.join("rootfs");
 
     fs::create_dir_all(&rootfs_path)?;
-    BareMount::new(
+    baremount(
         &spec_root.path,
         rootfs_path.to_str().unwrap(),
         "bind",
         MsFlags::MS_BIND,
         "",
         &sl!(),
-    )
-    .mount()?;
+    )?;
     spec.root = Some(Root {
         path: rootfs_path.to_str().unwrap().to_owned(),
         readonly: spec_root.readonly,

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -449,7 +449,7 @@ fn online_memory(logger: &Logger) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::Sandbox;
-    use crate::{mount::BareMount, skip_if_not_root};
+    use crate::{mount::baremount, skip_if_not_root};
     use anyhow::Error;
     use nix::mount::MsFlags;
     use oci::{Linux, Root, Spec};
@@ -461,8 +461,7 @@ mod tests {
     use tempfile::Builder;
 
     fn bind_mount(src: &str, dst: &str, logger: &Logger) -> Result<(), Error> {
-        let baremount = BareMount::new(src, dst, "bind", MsFlags::MS_BIND, "", logger);
-        baremount.mount()
+        baremount(src, dst, "bind", MsFlags::MS_BIND, "", logger)
     }
 
     #[tokio::test]

--- a/src/agent/src/watcher.rs
+++ b/src/agent/src/watcher.rs
@@ -20,7 +20,7 @@ use tokio::sync::Mutex;
 use tokio::task;
 use tokio::time::{self, Duration};
 
-use crate::mount::BareMount;
+use crate::mount::baremount;
 use crate::protocols::agent as protos;
 
 /// The maximum number of file system entries agent will watch for each mount.
@@ -314,16 +314,14 @@ impl SandboxStorages {
                             }
                         }
 
-                        match BareMount::new(
+                        match baremount(
                             entry.source_mount_point.to_str().unwrap(),
                             entry.target_mount_point.to_str().unwrap(),
                             "bind",
                             MsFlags::MS_BIND,
                             "bind",
                             logger,
-                        )
-                        .mount()
-                        {
+                        ) {
                             Ok(_) => {
                                 entry.watch = false;
                                 info!(logger, "watchable mount replaced with bind mount")
@@ -427,15 +425,14 @@ impl BindWatcher {
     async fn mount(&self, logger: &Logger) -> Result<()> {
         fs::create_dir_all(WATCH_MOUNT_POINT_PATH).await?;
 
-        BareMount::new(
+        baremount(
             "tmpfs",
             WATCH_MOUNT_POINT_PATH,
             "tmpfs",
             MsFlags::empty(),
             "",
             logger,
-        )
-        .mount()?;
+        )?;
 
         Ok(())
     }


### PR DESCRIPTION
mount_storage() first makes sure the mount point for the storage volume
exists.  It uses fs::create_dir_all() in the case of 9p or virtiofs volumes
otherwise ensure_destination_exists().  But.. ensure_destination_exists()
boils down to an fs::create_dir_all() in most cases anyway.  The only case
it doesn't is for a bind fstype, where it creates a file instead of a
directory.  But..
  1) mount_storage() isn't used for bind mounts
  2) That behaviour for bind mounts isn't correct anyway, because we would
     need to create either a file or a directory depending on the source of
     the bind mount, which ensure_destination_exists() doesn't know about.

Furthermore the 9p/virtiofs path checks if the mountpoint exists before
calling fs::create_dir_all(), which is unnecessary, because create_dir_all
has an equivalent test built in.

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>