### PR TITLE
kata-deploy: Update agent without rebuild all rootfs

### DIFF
--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -1,6 +1,6 @@
-name: kata-deploy-build
+name: kata deploy build
 
-on: push
+on: [push, pull_request]
 
 jobs:
   build-asset:
@@ -24,7 +24,7 @@ jobs:
 
       - name: Build ${{ matrix.asset }}
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh --build="${KATA_ASSET}"
+          make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           sudo cp -r --preserve=all "${build_dir}" "kata-build"
@@ -47,10 +47,10 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: kata-artifacts
-          path: kata-artifacts
+          path: build
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts
+          make merge-builds
       - name: store-artifacts
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -56,3 +56,14 @@ jobs:
         with:
           name: kata-static-tarball
           path: kata-static.tar.xz
+
+  make-kata-tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: make kata-tarball
+        run: |
+          # This will take a while
+          # Test as this is the usual a way will use it for first time.
+          make kata-tarball
+          sudo make install-tarball

--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ TOOLS += agent-ctl
 STANDARD_TARGETS = build check clean install test vendor
 
 include utils.mk
+include ./tools/packaging/kata-deploy/local-build/Makefile
 
 all: build
 
@@ -32,11 +33,5 @@ generate-protocols:
 # Some static checks rely on generated source files of components.
 static-checks: build
 	bash ci/static-checks.sh
-
-binary-tarball:
-	make -f ./tools/packaging/kata-deploy/local-build/Makefile
-
-install-binary-tarball:
-	make -f ./tools/packaging/kata-deploy/local-build/Makefile install
 
 .PHONY: all default static-checks binary-tarball install-binary-tarball

--- a/ci/install_rust.sh
+++ b/ci/install_rust.sh
@@ -6,11 +6,42 @@
 
 set -e
 
+[ -n "${KATA_DEV_MODE:-}" ] && exit 0
+
 cidir=$(dirname "$0")
-source "${cidir}/lib.sh"
 
-clone_tests_repo
+rustarch=$(uname -m)
+if [ "${rustarch}" == "ppc64le" ]; then
+	arch="powerpc64le"
+fi
 
-pushd ${tests_repo_dir}
-.ci/install_rust.sh
-popd
+echo "${rustarch}"
+# release="nightly"
+# recent functional version
+version="${1:-""}"
+if [ -z "${version}" ]; then
+	version=$(get_version "languages.rust.meta.newest-version")
+fi
+
+echo "Install rust ${version}"
+
+if ! command -v rustup > /dev/null; then
+	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${version}
+fi
+
+export PATH="${PATH}:${HOME}/.cargo/bin"
+
+## Still try to install the target version of toolchain,
+## in case that the rustup has been installed but
+## with a different version toolchain.
+## Even though the target version toolchain has been installed,
+## this command will not take too long to run.
+rustup toolchain install ${version}
+rustup default ${version}
+if [ "${rustarch}" == "powerpc64le" ] || [ "${rustarch}" == "s390x" ] ; then
+	rustup target add ${rustarch}-unknown-linux-gnu
+else
+	rustup target add ${rustarch}-unknown-linux-musl
+	sudo ln -sf /usr/bin/g++ /bin/musl-g++
+fi
+rustup component add rustfmt

--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -86,6 +86,7 @@ endef
 
 ##TARGET default: build code
 default: $(TARGET) show-header
+	@echo "$(TARGET) build"
 
 $(TARGET): $(GENERATED_CODE) $(TARGET_PATH)
 

--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -122,12 +122,17 @@ all: image initrd
 
 .PHONY: rootfs
 rootfs: $(TARGET_ROOTFS_MARKER)
+	@echo "INFO: Rootfs ready in $(TARGET_ROOTFS_MARKER)"
+
+update-agent:
+	$(call silent_run,Update agent in rootfs $(ROOTFS_BUILD_DEST)/$(DISTRO)_rootfs ,$(ROOTFS_BUILDER) -u -o $(VERSION_COMMIT) -r  $(ROOTFS_BUILD_DEST)/$(DISTRO)_rootfs $(DISTRO))
 
 .PHONY: image
 image: $(TARGET_IMAGE)
+	@echo "INFO: Image ready in $(TARGET_IMAGE)"
 
-$(TARGET_IMAGE): $(TARGET_ROOTFS_MARKER)
-	$(call silent_run,Creating image based on "$(TARGET_ROOTFS)",$(IMAGE_BUILDER) -o $@ "$(TARGET_ROOTFS)")
+$(TARGET_IMAGE): | rootfs update-agent
+	$(call silent_run,INFO: Creating image based on "$(TARGET_ROOTFS)",$(IMAGE_BUILDER) -o $@ "$(TARGET_ROOTFS)")
 
 
 .PHONY: initrd
@@ -135,7 +140,7 @@ initrd: $(TARGET_INITRD)
 
 ifeq (distro,$(BUILD_METHOD))
 $(TARGET_INITRD): $(TARGET_ROOTFS_MARKER)
-	$(call silent_run,Creating initrd image based on "$(TARGET_ROOTFS)",$(INITRD_BUILDER) "$(TARGET_ROOTFS)")
+	$(call silent_run,INFO: Creating initrd image based on "$(TARGET_ROOTFS)",$(INITRD_BUILDER) "$(TARGET_ROOTFS)")
 else
 $(TARGET_INITRD): $(DRACUT_OVERLAY_DIR)
 	@echo Creating initrd image based on the host OS using dracut

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -32,6 +32,7 @@ build_initrd() {
 		OS_VERSION="${initrd_os_version}" \
 		ROOTFS_BUILD_DEST="${builddir}/initrd-image" \
 		USE_DOCKER=1 \
+		AGENT_TAR_BIN="${agent_tarball}" \
 		AGENT_INIT="yes"
 	mv "kata-containers-initrd.img" "${install_dir}/${initrd_name}"
 	(
@@ -49,6 +50,7 @@ build_image() {
 		DEBUG="${DEBUG:-}" \
 		USE_DOCKER="1" \
 		IMG_OS_VERSION="${img_os_version}" \
+		AGENT_TAR_BIN="${agent_tarball}" \
 		ROOTFS_BUILD_DEST="${builddir}/rootfs-image"
 	mv -f "kata-containers.img" "${install_dir}/${image_name}"
 	(
@@ -76,6 +78,7 @@ EOT
 }
 
 main() {
+	agent_tarball=""
 	image_type=image
 	destdir="$PWD"
 	prefix="/opt/kata"
@@ -84,6 +87,9 @@ main() {
 		case "$opt" in
 		-)
 			case "${OPTARG}" in
+			agent-tarball=*)
+				agent_tarball=${OPTARG#*=}
+					;;
 			imagetype=image)
 				image_type=image
 				#image information
@@ -123,7 +129,7 @@ main() {
 	readonly destdir
 	readonly builddir
 
-	echo "build ${image_type}"
+	info "image type: ${image_type}"
 
 
 

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -21,33 +21,42 @@ endef
 kata-tarball: | all-parallel merge-builds
 
 all-parallel:
-	make -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true"
+	${MAKE} -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true"
 
-all: cloud-hypervisor firecracker kernel qemu rootfs-image rootfs-initrd shim-v2
+all: cloud-hypervisor-tarball \
+	firecracker-tarball \
+	kernel-tarball \
+	qemu-tarball \
+	rootfs-image-tarball \
+	rootfs-initrd-tarball \
+	shim-v2-tarball
 
-cloud-hypervisor:
-	$(call BUILD,$@)
+%-tarball-build:
+	$(call BUILD,$*)
 
-firecracker:
-	$(call BUILD,$@)
+cloud-hypervisor-tarball:
+	${MAKE} $@-build
 
-kernel:
-	$(call BUILD,$@)
+firecracker-tarball:
+	${MAKE} $@-build
 
-qemu:
-	$(call BUILD,$@)
+kernel-tarball:
+	${MAKE} $@-build
 
-rootfs-image:
-	$(call BUILD,$@)
+qemu-tarball:
+	${MAKE} $@-build
 
-rootfs-initrd:
-	$(call BUILD,$@)
+rootfs-image-tarball:
+	${MAKE} $@-build
 
-shim-v2:
-	$(call BUILD,$@)
+rootfs-initrd-tarball:
+	${MAKE} $@-build
+
+shim-v2-tarball:
+	${MAKE} $@-build
 
 merge-builds:
 	$(MK_DIR)/kata-deploy-merge-builds.sh build
 
-install:
+install-tarball:
 	tar -xvf ./kata-static.tar.xz -C /

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -7,21 +7,16 @@ MK_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 MK_DIR := $(dir $(MK_PATH))
 
 # Verbose build
-V ?=
-ifneq ($(V),)
-SILENT_BUILD_FLAG =
-else
-SILENT_BUILD_FLAG = -s
-endif
+V := 1
 
 define BUILD
-	$(MK_DIR)/kata-deploy-binaries-in-docker.sh $(SILENT_BUILD_FLAG) --build=$1
+	$(MK_DIR)/kata-deploy-binaries-in-docker.sh $(if $(V),,-s) --build=$1
 endef
 
 kata-tarball: | all-parallel merge-builds
 
 all-parallel:
-	${MAKE} -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true"
+	${MAKE} -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true" V=
 
 all: cloud-hypervisor-tarball \
 	firecracker-tarball \


### PR DESCRIPTION
For development one changing part may be agent, but not the full
guest rootfs. After update the agentm, if I do:
```
make rootfs-image-tarball
```
The agent will not be updated as rootfs has a mark file to avoid rebuild it again.
While it is useful because can take a lot of time. Agent changes could be common
specially for agent PRs.

Add logic to build agent out of rootfs. Then pass a tarball to osbuilder,
the agent tarball will be installed every make rootfs-image-tarball.

Fixes: #2430

Depends on: https://github.com/kata-containers/kata-containers/pull/2417