### PR TITLE
runtime: run the QEMU VMM process with a non-root user

### DIFF
--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -24,6 +24,11 @@ machine_type = "@MACHINETYPE@"
 # Default false
 # confidential_guest = true
 
+# Enable running QEMU VMM as a non-root user.
+# By default QEMU VMM run as root. When this is set to true, QEMU VMM process runs as
+# a non-root random user. See documentation for the limitations of this mode.
+# rootless = true
+
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name
 # of the annotation, e.g. "path" for io.katacontainers.config.hypervisor.path"

--- a/src/runtime/pkg/katautils/config-settings.go.in
+++ b/src/runtime/pkg/katautils/config-settings.go.in
@@ -86,6 +86,7 @@ const defaultRxRateLimiterMaxRate = uint64(0)
 const defaultTxRateLimiterMaxRate = uint64(0)
 const defaultConfidentialGuest = false
 const defaultGuestSwap = false
+const defaultRootlessHypervisor = false
 
 var defaultSGXEPCSize = int64(0)
 

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -105,15 +105,15 @@ type hypervisor struct {
 	EnableAnnotations       []string `toml:"enable_annotations"`
 	RxRateLimiterMaxRate    uint64   `toml:"rx_rate_limiter_max_rate"`
 	TxRateLimiterMaxRate    uint64   `toml:"tx_rate_limiter_max_rate"`
+	MemOffset               uint64   `toml:"memory_offset"`
 	VirtioFSCacheSize       uint32   `toml:"virtio_fs_cache_size"`
-	NumVCPUs                int32    `toml:"default_vcpus"`
 	DefaultMaxVCPUs         uint32   `toml:"default_maxvcpus"`
 	MemorySize              uint32   `toml:"default_memory"`
 	MemSlots                uint32   `toml:"memory_slots"`
-	MemOffset               uint64   `toml:"memory_offset"`
 	DefaultBridges          uint32   `toml:"default_bridges"`
 	Msize9p                 uint32   `toml:"msize_9p"`
 	PCIeRootPort            uint32   `toml:"pcie_root_port"`
+	NumVCPUs                int32    `toml:"default_vcpus"`
 	BlockDeviceCacheSet     bool     `toml:"block_device_cache_set"`
 	BlockDeviceCacheDirect  bool     `toml:"block_device_cache_direct"`
 	BlockDeviceCacheNoflush bool     `toml:"block_device_cache_noflush"`
@@ -134,6 +134,7 @@ type hypervisor struct {
 	GuestMemoryDumpPaging   bool     `toml:"guest_memory_dump_paging"`
 	ConfidentialGuest       bool     `toml:"confidential_guest"`
 	GuestSwap               bool     `toml:"enable_guest_swap"`
+	Rootless                bool     `toml:"rootless"`
 }
 
 type runtime struct {
@@ -713,6 +714,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		GuestMemoryDumpPaging:   h.GuestMemoryDumpPaging,
 		ConfidentialGuest:       h.ConfidentialGuest,
 		GuestSwap:               h.GuestSwap,
+		Rootless:                h.Rootless,
 	}, nil
 }
 
@@ -1069,6 +1071,7 @@ func GetDefaultHypervisorConfig() vc.HypervisorConfig {
 		SGXEPCSize:              defaultSGXEPCSize,
 		ConfidentialGuest:       defaultConfidentialGuest,
 		GuestSwap:               defaultGuestSwap,
+		Rootless:                defaultRootlessHypervisor,
 	}
 }
 

--- a/src/runtime/pkg/utils/utils.go
+++ b/src/runtime/pkg/utils/utils.go
@@ -80,3 +80,22 @@ func EnsureDir(path string, mode os.FileMode) error {
 
 	return nil
 }
+
+func FirstValidExecutable(paths []string) (string, error) {
+	for _, p := range paths {
+		info, err := os.Stat(p)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return "", err
+		}
+		mode := info.Mode()
+		// check whether the file is an executable
+		if mode&0111 == 0 {
+			continue
+		}
+		return p, nil
+	}
+	return "", fmt.Errorf("all the executables are invalid")
+}

--- a/src/runtime/virtcontainers/api_test.go
+++ b/src/runtime/virtcontainers/api_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -135,6 +136,11 @@ func TestCreateSandboxNoopAgentSuccessful(t *testing.T) {
 		t.Skip(testDisabledAsNonRoot)
 	}
 	defer cleanUp()
+
+	// Pre-create the directory path to avoid panic error. Without this change, ff the test is run as a non-root user,
+	// this test will fail because of permission denied error in chown syscall in the utils.MkdirAllWithInheritedOwner() method
+	err := os.MkdirAll(fs.MockRunStoragePath(), DirMode)
+	assert.NoError(err)
 
 	config := newTestSandboxConfigNoop()
 

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -228,6 +228,9 @@ type HypervisorConfig struct {
 	// it will be used for the sandbox's kernel path instead of KernelPath.
 	customAssets map[types.AssetType]*types.Asset
 
+	// Supplementary group IDs.
+	Groups []uint32
+
 	// KernelPath is the guest kernel host path.
 	KernelPath string
 
@@ -382,6 +385,12 @@ type HypervisorConfig struct {
 	// VirtioFSCacheSize is the DAX cache size in MiB
 	VirtioFSCacheSize uint32
 
+	// User ID.
+	Uid uint32
+
+	// Group ID.
+	Gid uint32
+
 	// BlockDeviceCacheSet specifies cache-related options will be set to block devices or not.
 	BlockDeviceCacheSet bool
 
@@ -461,6 +470,9 @@ type HypervisorConfig struct {
 
 	// GuestSwap Used to enable/disable swap in the guest
 	GuestSwap bool
+
+	// Rootless is used to enable rootless VMM process
+	Rootless bool
 }
 
 // vcpu mapping from vcpu number to thread number

--- a/src/runtime/virtcontainers/persist/fs/fs.go
+++ b/src/runtime/virtcontainers/persist/fs/fs.go
@@ -9,6 +9,7 @@ package fs
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -86,7 +87,7 @@ func (fs *FS) ToDisk(ss persistapi.SandboxState, cs map[string]persistapi.Contai
 		return err
 	}
 
-	if err := os.MkdirAll(sandboxDir, dirMode); err != nil {
+	if err := utils.MkdirAllWithInheritedOwner(sandboxDir, dirMode); err != nil {
 		return err
 	}
 
@@ -123,7 +124,7 @@ func (fs *FS) ToDisk(ss persistapi.SandboxState, cs map[string]persistapi.Contai
 	// persist container configuration data
 	for cid, cstate := range fs.containerState {
 		cdir := filepath.Join(sandboxDir, cid)
-		if dirCreationErr = os.MkdirAll(cdir, dirMode); dirCreationErr != nil {
+		if dirCreationErr = utils.MkdirAllWithInheritedOwner(cdir, dirMode); dirCreationErr != nil {
 			return dirCreationErr
 		}
 		createdDirs = append(createdDirs, cdir)
@@ -288,7 +289,7 @@ func (fs *FS) GlobalWrite(relativePath string, data []byte) error {
 
 	_, err = os.Stat(dir)
 	if os.IsNotExist(err) {
-		if err := os.MkdirAll(dir, dirMode); err != nil {
+		if err := utils.MkdirAllWithInheritedOwner(dir, dirMode); err != nil {
 			fs.Logger().WithError(err).WithField("directory", dir).Error("failed to create dir")
 			return err
 		}

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -223,6 +223,9 @@ const (
 
 	// EnableGuestSwap is a sandbox annotation to enable swap in the guest.
 	EnableGuestSwap = kataAnnotHypervisorPrefix + "enable_guest_swap"
+
+	// EnableRootlessHypervisor is a sandbox annotation to enable rootless hypervisor (only supported in QEMU currently).
+	EnableRootlessHypervisor = kataAnnotHypervisorPrefix + "rootless"
 )
 
 // Runtime related annotations

--- a/src/runtime/virtcontainers/pkg/oci/utils.go
+++ b/src/runtime/virtcontainers/pkg/oci/utils.go
@@ -622,6 +622,12 @@ func addHypervisorMemoryOverrides(ocispec specs.Spec, sbConfig *vc.SandboxConfig
 		return err
 	}
 
+	if err := newAnnotationConfiguration(ocispec, vcAnnotations.EnableRootlessHypervisor).setBool(func(enableRootlessHypervisor bool) {
+		sbConfig.HypervisorConfig.Rootless = enableRootlessHypervisor
+	}); err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/src/runtime/virtcontainers/pkg/rootless/rootless.go
+++ b/src/runtime/virtcontainers/pkg/rootless/rootless.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -106,7 +107,7 @@ func NewNS() (ns.NetNS, error) {
 	// Create the directory for mounting network namespaces
 	// This needs to be a shared mountpoint in case it is mounted in to
 	// other namespaces (containers)
-	err = os.MkdirAll(nsRunDir, 0755)
+	err = utils.MkdirAllWithInheritedOwner(nsRunDir, 0755)
 	if err != nil {
 		return nil, err
 	}

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -79,6 +79,12 @@ func (v *virtiofsd) getSocketFD() (*os.File, error) {
 		return nil, err
 	}
 
+	// Need to change the filesystem ownership of the socket because virtiofsd runs as root while qemu can run as non-root.
+	// This can be removed once virtiofsd can also run as non-root (https://github.com/kata-containers/kata-containers/issues/2542)
+	if err := utils.ChownToParent(v.socketPath); err != nil {
+		return nil, err
+	}
+
 	// no longer needed since fd is a dup
 	defer listener.Close()
 

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path"
 	"strings"
 	"testing"
 
@@ -37,7 +38,7 @@ func TestVirtiofsdStart(t *testing.T) {
 	assert.NoError(err)
 	defer os.RemoveAll(socketDir)
 
-	socketPath := socketDir + "socket.s"
+	socketPath := path.Join(socketDir, "socket.s")
 
 	validConfig := fields{
 		path:       "/usr/bin/virtiofsd-path",


### PR DESCRIPTION
### Description ###
The change is to enable running QEMU VMM process as a non-root user in Kata for better security. A new flag `rootless` is added to the hypervisor config. If the flag is set to true, when the kata shim v2 is creating a Pod sandbox, it creates a random user (e.g. qemu-1180) and uses it to launch the QEMU process. It also creates a file directory structure (`/run/user/[uid]/vc/...`) and use it to store the vmm files (such as qmp.sock, vhost-fs.sock, console.sock). The file directory is owned by the qemu user. This change also utilizes the [existing rootless code path](https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/pkg/rootless/rootless.go).

### Testing ###
Manually tested the change. I was able to manually build the kata-runtime and use it to launch pods and containers using `crictl`, following [the doc](https://github.com/kata-containers/documentation/blob/master/how-to/containerd-kata.md#launch-pods-with-crictl-command-line).  
Manually tested this change in an AWS EKS cluster. The limitations of this feature are documented in [another PR](https://github.com/kata-containers/kata-containers/pull/2546).
 
### Questions ###
1. Does this approach look acceptable? Any better suggestions? Any use case this will break?
2. In the current change I use a random run-as user for QEMU process based on the assumption that it shouldn't matter to the end customers which run-as is used as long as it's not root. I also attempted to use the uid/gid from the linux security context in the pod spec and it also works, but then the end user is put on the burden to specify the non-root uid/gid for QEMU. Any preference on this two options?
3. Any other changes I need to make before this can be accepted?

### Related Issues ###
https://github.com/kata-containers/kata-containers/issues/2444
