### PR TITLE
Update k8s, critools, and CRI-O to their 1.22 release

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -179,7 +179,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    branch: "release-1.21"
+    branch: "release-1.22"
 
   cri-containerd:
     description: |

--- a/versions.yaml
+++ b/versions.yaml
@@ -194,7 +194,7 @@ externals:
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"
     url: "https://github.com/kubernetes-sigs/cri-tools"
-    version: "1.21.0"
+    version: "1.22.0"
 
   kubernetes:
     description: "Kubernetes project container manager"
@@ -204,7 +204,7 @@ externals:
     uscan-url: >-
       https://github.com/kubernetes/kubernetes/tags
       .*/v?([\d\.]+)\.tar\.gz
-    version: "1.21.1-00"
+    version: "1.22.0-00"
 
   runc:
     description: "OCI CLI reference runtime implementation"


### PR DESCRIPTION
Let's test our `main` branch against the latest version of k8s.  In
order to do the bump, let's also update critools and CRI-O version
accordingly.
