### PR TITLE
osbuilder: Document no Alpine support on s390x

### DIFF
--- a/tools/osbuilder/README.md
+++ b/tools/osbuilder/README.md
@@ -213,5 +213,5 @@ any Linux distribution and architecture where dracut is available.
 |--         |--                |--                |--                |--                |--                |--                |
 |**ARM64**  |:heavy_check_mark:|:heavy_check_mark:|                  |                  |:heavy_check_mark:|:heavy_check_mark:|
 |**PPC64le**|:heavy_check_mark:|:heavy_check_mark:|                  |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|
-|**s390x**  |:heavy_check_mark:|                  |                  |:heavy_check_mark:|:heavy_check_mark:|                  |
+|**s390x**  |                  |                  |                  |:heavy_check_mark:|:heavy_check_mark:|                  |
 |**x86_64** |:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|:heavy_check_mark:|


### PR DESCRIPTION
Alpine used to work as guest under 1.x, but because there is no musl
target for Rust on s390x, Alpine will not work for 2.x. Document this.

Fixes: #2436
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>