### PR TITLE
runtime: support sizeLimit option for empty dir

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1327,7 +1327,7 @@ func (c *Container) hotplugDrive(ctx context.Context) error {
 			c.rootfsSuffix = ""
 		}
 		// If device mapper device, then fetch the full path of the device
-		devicePath, fsType, err = utils.GetDevicePathAndFsType(dev.mountPoint)
+		devicePath, fsType, _, err = utils.GetMountInfo(dev.mountPoint)
 		if err != nil {
 			return err
 		}

--- a/src/runtime/virtcontainers/device/config/pmem.go
+++ b/src/runtime/virtcontainers/device/config/pmem.go
@@ -75,7 +75,7 @@ func PmemDeviceInfo(source, destination string) (*DeviceInfo, error) {
 		return nil, fmt.Errorf("backing file %v has not PFN signature", device.HostPath)
 	}
 
-	_, fstype, err := utils.GetDevicePathAndFsType(source)
+	_, fstype, _, err := utils.GetMountInfo(source)
 	if err != nil {
 		pmemLog.WithError(err).WithField("mount-point", source).Warn("failed to get fstype: using ext4")
 		fstype = "ext4"

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -439,7 +439,7 @@ func IsEphemeralStorage(path string) bool {
 		return false
 	}
 
-	if _, fsType, _ := utils.GetDevicePathAndFsType(path); fsType == "tmpfs" {
+	if _, fsType, _, _ := utils.GetMountInfo(path); fsType == "tmpfs" {
 		return true
 	}
 
@@ -454,7 +454,7 @@ func Isk8sHostEmptyDir(path string) bool {
 		return false
 	}
 
-	if _, fsType, _ := utils.GetDevicePathAndFsType(path); fsType != "tmpfs" {
+	if _, fsType, _, _ := utils.GetMountInfo(path); fsType != "tmpfs" {
 		return true
 	}
 	return false

--- a/src/runtime/virtcontainers/utils/utils_linux.go
+++ b/src/runtime/virtcontainers/utils/utils_linux.go
@@ -100,11 +100,12 @@ const (
 	procDeviceIndex = iota
 	procPathIndex
 	procTypeIndex
+	procOptionsIndex
 )
 
-// GetDevicePathAndFsType gets the device for the mount point and the file system type
+// GetMountInfo gets the device for the mount point and the file system type
 // of the mount.
-func GetDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err error) {
+func GetMountInfo(mountPoint string) (devicePath, fsType string, options []string, err error) {
 	if mountPoint == "" {
 		err = fmt.Errorf("Mount point cannot be empty")
 		return
@@ -138,6 +139,7 @@ func GetDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err e
 		if mountPoint == fields[procPathIndex] {
 			devicePath = fields[procDeviceIndex]
 			fsType = fields[procTypeIndex]
+			options = strings.Split(fields[procOptionsIndex], ",")
 			return
 		}
 	}

--- a/src/runtime/virtcontainers/utils/utils_linux_test.go
+++ b/src/runtime/virtcontainers/utils/utils_linux_test.go
@@ -34,16 +34,16 @@ func TestFindContextID(t *testing.T) {
 	assert.Error(err)
 }
 
-func TestGetDevicePathAndFsTypeEmptyMount(t *testing.T) {
+func TestGetMountInfoEmptyMount(t *testing.T) {
 	assert := assert.New(t)
-	_, _, err := GetDevicePathAndFsType("")
+	_, _, _, err := GetMountInfo("")
 	assert.Error(err)
 }
 
-func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
+func TestGetMountInfoSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	path, fstype, err := GetDevicePathAndFsType("/proc")
+	path, fstype, _, err := GetMountInfo("/proc")
 	assert.NoError(err)
 
 	assert.Equal(path, "proc")


### PR DESCRIPTION
Before creating containers in guest, parse the empty
dir info in host side and pass the size option
to kata-agent.

Fixes: #2438

PTAL @lifupan 