### PR TITLE
workflows: Actually push the release to quay.io

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,9 @@ jobs:
           # tag the container image we created and push to DockerHub
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           docker tag katadocker/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci.outputs.PKG_SHA}} katadocker/kata-deploy:${tag}
+          docker tag quay.io/kata-containers/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci.outputs.PKG_SHA}} quay.io/kata-containers/kata-deploy:${tag}
           docker push katadocker/kata-deploy:${tag}
+          docker push quay.io/kata-containers/kata-deploy:${tag}
 
   upload-static-tarball:
     needs: kata-deploy


### PR DESCRIPTION
As quay.io is becoming our de-facto image registry, let's actually push
the kata-deploy release to it.  This commit should've been part of
9fa1febfd9e6372fc1fd9ec3416082182c2f8c21 but ended up slipping out.

Fixes: #2306

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>