### PR TITLE
config: Enable jailer by default when using firecracker

### DIFF
--- a/src/runtime/cli/config/configuration-fc.toml.in
+++ b/src/runtime/cli/config/configuration-fc.toml.in
@@ -30,9 +30,7 @@ valid_hypervisor_paths = @FCVALIDHYPERVISORPATHS@
 # If the jailer path is not set kata will launch firecracker
 # without a jail. If the jailer is set firecracker will be
 # launched in a jailed enviornment created by the jailer
-# This is disabled by default as additional setup is required
-# for this feature today.
-#jailer_path = "@FCJAILERPATH@"
+jailer_path = "@FCJAILERPATH@"
 
 # List of valid jailer path values for the hypervisor
 # Each member of the list can be a regular expression


### PR DESCRIPTION
Now that we have enabled CI tests for jailed firecracker and we have
fixed the  issue with removing the block storage device #2387, we
should leverage the full power of firecracker and enable jailer by
default.

Fixes: #2455

Signed-off-by: Jack Rieck <jack.rieck@sendgrid.com>