### PR TITLE
Move kata deploy install instruction to docs

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,22 +1,19 @@
-# Kata Containers installation user guides
+# Kata Containers installation guides
 
-The following is an overview of the different installation methods available. All of these methods equally result
-in a system configured to run Kata Containers.
+The following is an overview of the different installation methods available. 
 
 ## Prerequisites
 
-Kata Containers requires nested virtualization or bare metal.
-See the
-[hardware requirements](/src/runtime/README.md#hardware-requirements)
-to see if your system is capable of running Kata Containers.
+Kata Containers requires nested virtualization or bare metal. Check 
+[hardware requirements](/src/runtime/README.md#hardware-requirements) to see if your system is capable of running Kata 
+Containers.
 
 ## Packaged installation methods
 
-> **Notes:**
->
-> - Packaged installation methods uses your distribution's native package format (such as RPM or DEB).
-> - You are strongly encouraged to choose an installation method that provides
->   automatic updates, to ensure you benefit from security updates and bug fixes.
+Packaged installation methods uses your distribution's native package format (such as RPM or DEB).
+
+*Note:* We encourage installation methods that provides automatic updates, it ensures security updates and bug fixes are
+easily applied.
 
 | Installation method                                  | Description                                                         | Automatic updates | Use case                                                 |
 |------------------------------------------------------|---------------------------------------------------------------------|-------------------|----------------------------------------------------------|
@@ -35,16 +32,9 @@ Kata packages are provided by official distribution repositories for:
 | [CentOS](centos-installation-guide.md)                   | 8                                                                              |
 | [Fedora](fedora-installation-guide.md)                   | 34                                                                             |
 
-> **Note:**
->
-> All users are encouraged to uses the official distribution versions of Kata
-> Containers unless they understand the implications of alternative methods.
-
 ### Snap Installation
 
-> **Note:** The snap installation is available for all distributions which support `snapd`.
-
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/kata-containers)
+The snap installation is available for all distributions which support `snapd`.
 
 [Use snap](snap-installation-guide.md) to install Kata Containers from https://snapcraft.io.
 
@@ -58,11 +48,9 @@ Follow the [containerd installation guide](container-manager/containerd/containe
 
 ## Build from source installation
 
-> **Note:**
->
-> Power users who decide to build from sources should be aware of the
-> implications of using an unpackaged system which will not be automatically
-> updated as new [releases](../Stable-Branch-Strategy.md) are made available.
+*Note:* Power users who decide to build from sources should be aware of the
+implications of using an unpackaged system which will not be automatically
+updated as new [releases](../Stable-Branch-Strategy.md) are made available.
 
 [Building from sources](../Developer-Guide.md#initial-setup)  allows power users
 who are comfortable building software from source to use the latest component
@@ -78,6 +66,6 @@ versions. This is not recommended for normal users.
 
 ## Further information
 
-* The [upgrading document](../Upgrading.md).
-* The [developer guide](../Developer-Guide.md).
-* The [runtime documentation](../../src/runtime/README.md).
+* [upgrading document](../Upgrading.md)
+* [developer guide](../Developer-Guide.md)
+* [runtime documentation](../../src/runtime/README.md)

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -2,6 +2,23 @@
 
 The following is an overview of the different installation methods available. 
 
+# Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Packaged installation methods](#packaged-installation-methods)
+- [Official packages](#official-packages)
+- [Kata Deploy](#kata-deploy)
+- [Snap Installation](#snap-installation)
+- [Automatic Installation](#automatic-installation)
+- [Build from source Installation](#build-from-source-installation)
+- [Installing on a Cloud Service Platform](#installing-on-a-cloud-service-platform)
+  - [Amazon Web Services (AWS)](aws-installation-guide.md)
+  - [Google Compute Engine (GCE)](gce-installation-guide.md)
+  - [Microsoft Azure](azure-installation-guide.md)
+  - [Minikube](minikube-installation-guide.md)
+  - [VEXXHOST OpenStack Cloud](vexxhost-installation-guide.md) 
+- [Further information](#further-information)
+
 ## Prerequisites
 
 Kata Containers requires nested virtualization or bare metal. Check 
@@ -32,11 +49,15 @@ Kata packages are provided by official distribution repositories for:
 | [CentOS](centos-installation-guide.md)                   | 8                                                                              |
 | [Fedora](fedora-installation-guide.md)                   | 34                                                                             |
 
+### Kata Deploy
+
+Kata Deploy is the preferred way for using kata-containers when your distro does not provide it. You can find more
+details following our [Kata Deploy install documentation](kata-deploy-installation.md).
+
 ### Snap Installation
 
-The snap installation is available for all distributions which support `snapd`.
-
-[Use snap](snap-installation-guide.md) to install Kata Containers from https://snapcraft.io.
+The snap installation is available for all distributions which support `snapd`. [Use snap](snap-installation-guide.md) 
+to install Kata Containers from https://snapcraft.io.
 
 ### Automatic Installation
 
@@ -46,7 +67,7 @@ The snap installation is available for all distributions which support `snapd`.
 
 Follow the [containerd installation guide](container-manager/containerd/containerd-install.md).
 
-## Build from source installation
+## Build from source Installation
 
 *Note:* Power users who decide to build from sources should be aware of the
 implications of using an unpackaged system which will not be automatically
@@ -55,14 +76,6 @@ updated as new [releases](../Stable-Branch-Strategy.md) are made available.
 [Building from sources](../Developer-Guide.md#initial-setup)  allows power users
 who are comfortable building software from source to use the latest component
 versions. This is not recommended for normal users.
-
-## Installing on a Cloud Service Platform
-
-* [Amazon Web Services (AWS)](aws-installation-guide.md)
-* [Google Compute Engine (GCE)](gce-installation-guide.md)
-* [Microsoft Azure](azure-installation-guide.md)
-* [Minikube](minikube-installation-guide.md)
-* [VEXXHOST OpenStack Cloud](vexxhost-installation-guide.md)
 
 ## Further information
 

--- a/docs/install/kata-deploy-installation.md
+++ b/docs/install/kata-deploy-installation.md
@@ -1,11 +1,20 @@
-# `kata-deploy`
+# Kata Deploy
 
-[`kata-deploy`](.) provides a Dockerfile, which contains all of the binaries
-and artifacts required to run Kata Containers, as well as reference DaemonSets, which can
-be utilized to install Kata Containers on a running Kubernetes cluster.
+Kata Deploy provides a Dockerfile, which contains all the binaries and artifacts required to run Kata Containers, as 
+well as reference DaemonSets, which can be utilized to install Kata Containers on a running Kubernetes cluster.
 
-Note, installation through DaemonSets successfully installs `katacontainers.io/kata-runtime` on
-a node only if it uses either containerd or CRI-O CRI-shims.
+*Note:* installation through DaemonSets successfully installs **katacontainers.io/kata-runtime** on a node only if it 
+uses either containerd or CRI-O CRI-shims.
+
+# Table of Contents
+
+- [Kubernetes quick start](#kubernetes-quick-start)
+  - [Install Kata on a running Kubernetes cluster](#install-kata-on-a-running-kubernetes-cluster)
+  - [Run a sample workload](#run-a-sample-workload)
+  - [Remove Kata from the Kubernetes cluster](#remove-kata-from-the-kubernetes-cluster)
+- [Kata Deploy details](#kata-deploy-details)
+- [DaemonSets and RBAC](#daemonsets-and-rbac)
+
 
 ## Kubernetes quick start
 
@@ -17,7 +26,7 @@ $ kubectl apply -f kata-rbac/base/kata-rbac.yaml
 $ kubectl apply -f kata-deploy/base/kata-deploy.yaml
 ```
 
-or on a [k3s](https://k3s.io/) cluster:
+Or on a [k3s](https://k3s.io/) cluster:
 
 ```sh
 $ cd $GOPATH/src/github.com/kata-containers/kata-containers/tools/packaging/kata-deploy
@@ -26,11 +35,12 @@ $ kubectl apply -k kata-deploy/overlays/k3s
 
 ### Run a sample workload
 
-Workloads specify the runtime they'd like to utilize by setting the appropriate `runtimeClass` object within
-the `Pod` specification. The `runtimeClass` examples provided define a node selector to match node label `katacontainers.io/kata-runtime:"true"`,
-which will ensure the workload is only scheduled on a node that has Kata Containers installed
+Workloads specify the runtime they'd like to utilize by setting the appropriate **runtimeClass** object within the 
+**Pod** specification. The **runtimeClass** examples provided define a node selector to match node label `katacontainers.io/kata-runtime:"true"`,
+which will ensure the workload is only scheduled on a node that has Kata Containers installed.
 
-`runtimeClass` is a built-in type in Kubernetes. To apply each Kata Containers `runtimeClass`:
+**runtimeClass** is a built-in type in Kubernetes. To apply each Kata Containers **runtimeClass**:
+
 ```sh
   $ cd $GOPATH/src/github.com/kata-containers/kata-containers/tools/packaging/kata-deploy/runtimeclasses
   $ kubectl apply -f kata-runtimeClasses.yaml
@@ -63,14 +73,14 @@ spec:
       runtimeClassName: kata-qemu
 ```
 
-To run an example with `kata-qemu`:
+To run an example with **kata-qemu**:
 
 ```sh
 $ cd $GOPATH/src/github.com/kata-containers/kata-containers/tools/packaging/kata-deploy/examples
 $ kubectl apply -f test-deploy-kata-qemu.yaml
 ```
 
-To run an example with `kata-fc`:
+To run an example with **kata-fc**:
 
 ```sh
 $ cd $GOPATH/src/github.com/kata-containers/kata-containers/tools/packaging/kata-deploy/examples
@@ -96,38 +106,40 @@ $ kubectl delete -f kata-rbac/base/kata-rbac.yaml
 $ kubectl delete -f runtimeclasses/kata-runtimeClasses.yaml
 ```
 
-## `kata-deploy` details
+## Kata Deploy details
 
-### Dockerfile
+**Dockerfile**
 
-The [Dockerfile](Dockerfile)  used to create the container image deployed in the DaemonSet is provided here.
+The [Dockerfile](../../tools/packaging/kata-deploy/Dockerfile)  used to create the container image deployed in the DaemonSet is provided here.
 This image contains all the necessary artifacts for running Kata Containers, all of which are pulled
 from the [Kata Containers release page](https://github.com/kata-containers/kata-containers/releases).
 
-Host artifacts:
-* `cloud-hypervisor`, `firecracker`, `qemu-system-x86_64`, and supporting binaries
-* `containerd-shim-kata-v2`
-* `kata-collect-data.sh`
-* `kata-runtime`
+**Host artifacts:**
 
-Virtual Machine artifacts:
-* `kata-containers.img` and `kata-containers-initrd.img`: pulled from Kata GitHub releases page
-* `vmlinuz.container` and `vmlinuz-virtiofs.container`: pulled from Kata GitHub releases page
+- cloud-hypervisor, firecracker, qemu-system-x86_64, and supporting binaries
+- containerd-shim-kata-v2
+- kata-collect-data.sh
+- kata-runtime
+
+**Virtual Machine artifacts:**
+
+- kata-containers.img and kata-containers-initrd.img: pulled from Kata GitHub releases page
+- vmlinuz.container and vmlinuz-virtiofs.container: pulled from Kata GitHub releases page
 
 ### DaemonSets and RBAC
 
-Two DaemonSets are introduced for `kata-deploy`, as well as an RBAC to facilitate
+Two DaemonSets are introduced for **Kata Deploy**, as well as an **RBAC** to facilitate
 applying labels to the nodes.
 
-#### Kata deploy
+**Kata Deploy**
 
 This DaemonSet installs the necessary Kata binaries, configuration files, and virtual machine artifacts on
 the node. Once installed, the DaemonSet adds a node label `katacontainers.io/kata-runtime=true` and reconfigures
-either CRI-O or containerd to register three `runtimeClasses`: `kata-clh` (for Cloud Hypervisor isolation), `kata-qemu` (for QEMU isolation),
+either CRI-O or containerd to register three `runtimeClasses: kata-clh` (for Cloud Hypervisor isolation), `kata-qemu` (for QEMU isolation),
 and `kata-fc` (for Firecracker isolation). As a final step the DaemonSet restarts either CRI-O or containerd. Upon deletion,
 the DaemonSet removes the Kata binaries and VM artifacts and updates the node label to `katacontainers.io/kata-runtime=cleanup`.
 
-#### Kata cleanup
+**Kata cleanup**
 
 This DaemonSet runs of the node has the label `katacontainers.io/kata-runtime=cleanup`. These DaemonSets removes
 the `katacontainers.io/kata-runtime` label as well as restarts either CRI-O or `containerd` `systemctl`


### PR DESCRIPTION
This PR move kata deploy install instructions to docs/install folder, update wording and document format, adds an index to general installation documentation.

Fixes: #2450