### PR TITLE
osbuilder: don't pull ubuntu image from dockerhub

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG IMAGE_REGISTRY=docker.io
+ARG IMAGE_REGISTRY=public.ecr.aws/ubuntu
 #ubuntu: docker image to be used to create a rootfs
 #@OS_VERSION@: Docker image version to build this dockerfile
 FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@


### PR DESCRIPTION
Pull ubuntu image from public.ecr.aws/ubuntu to fix dockerhub rate
limit issue.

fixes #2461

cc @GabyCT  @Jakob-Naucke 

Signed-off-by: Julio Montes <julio.montes@intel.com>