### PR TITLE
docs: update rust version agent project path in the agent README file

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -1,6 +1,6 @@
 # Kata Agent in Rust
 
-This is a rust version of the [`kata-agent`](https://github.com/kata-containers/agent).
+This is a rust version of the [`kata-agent`](.).
 
 In Denver PTG, [we discussed about re-writing agent in rust](https://etherpad.openstack.org/p/katacontainers-2019-ptg-denver-agenda):
 


### PR DESCRIPTION
update agent project path from kata 1.x to kata 2.x. Rust version
agent just from kata 2.x.

Fixes: #2468

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>