### PR TITLE
workflows: fix artifact name in the release yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -113,7 +113,7 @@ jobs:
       - name: download-artifacts
         uses: actions/download-artifact@v2
         with:
-          name: release-candidate
+          name: kata-static-tarball
       - name: install hub
         run: |
           HUB_VER=$(curl -s "https://api.github.com/repos/github/hub/releases/latest" | jq -r .tag_name | sed 's/^v//')


### PR DESCRIPTION
b789a935cf69f1aa4bd8eda2cd3ac0b721f056ba changed the artifact name from
"release-candidate" to "kata-static-tarball".  However, we didn't do the
same for the upload-static-tarball action, causing us the following
error during the release process:
https://github.com/kata-containers/kata-containers/runs/3383157459?check_suite_focus=true

Fixes: #2475

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>