### PR TITLE
Makefile: update `make go-test` call

### DIFF
--- a/ci/go-test.sh
+++ b/ci/go-test.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright (c) 2020 Intel Corporation
 #

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -602,14 +602,12 @@ test: install-hook go-test
 
 install-hook:
 	make -C virtcontainers hook
-ifeq ($(shell id -u), 0)
 	echo "installing mock hook"
-	make -C virtcontainers install
-endif
+	sudo -E make -C virtcontainers install
 
 go-test: $(GENERATED_FILES)
 	go clean -testcache
-	go test -v -mod=vendor ./...
+	$(QUIET_TEST)../../ci/go-test.sh
 
 fast-test: $(GENERATED_FILES)
 	go clean -testcache

--- a/src/runtime/pkg/containerd-shim-v2/stream.go
+++ b/src/runtime/pkg/containerd-shim-v2/stream.go
@@ -36,6 +36,7 @@ func (tty *ttyIO) close() {
 
 	if tty.Stdin != nil {
 		tty.Stdin.Close()
+		tty.Stdin = nil
 	}
 	cf := func(w io.Writer) {
 		if w == nil {
@@ -111,7 +112,6 @@ func ioCopy(exitch, stdinCloser chan struct{}, tty *ttyIO, stdinPipe io.WriteClo
 			if tty.Stdin != nil {
 				// close stdin to make the other routine stop
 				tty.Stdin.Close()
-				tty.Stdin = nil
 			}
 		}()
 	}


### PR DESCRIPTION
 1. use ci/go-test.sh to replace the direct call to go test
 2. fix data race test
    
 Fixes #1494
    
 Signed-off-by: Binbin Zhang <binbin36520@gmail.com>