### PR TITLE
ci/openshift-ci: Pull centos from registry.centos.org

### DIFF
--- a/ci/openshift-ci/images/Dockerfile.buildroot
+++ b/ci/openshift-ci/images/Dockerfile.buildroot
@@ -4,6 +4,6 @@
 #
 # This is the build root image for Kata Containers on OpenShift CI.
 #
-FROM centos:8
+FROM registry.centos.org/centos:8
 
 RUN yum -y update && yum -y install git sudo wget


### PR DESCRIPTION
In order to avoid hit the pull requests limit of docker.io, this changed the
openshift-ci/images/Dockerfile.buildroot dockerfile to pull the centos image
from registry.centos.org.

Fixes #1636

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>