### PR TITLE
docs: update containerd CRI plugin url

### DIFF
--- a/docs/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
+++ b/docs/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
@@ -3,7 +3,7 @@
 This document describes how to set up a single-machine Kubernetes (k8s) cluster.
 
 The Kubernetes cluster will use the
-[CRI containerd plugin](https://github.com/containerd/cri) and
+[CRI containerd plugin](https://github.com/containerd/containerd/tree/main/pkg/cri) and
 [Kata Containers](https://katacontainers.io) to launch untrusted workloads.
 
 ## Requirements


### PR DESCRIPTION
update cri plugin source path to containerd pkg in the
 how-to-use-k8s-with-cri-containerd-and-kata.md file. The cri project was moved to containerd project pkg directory.

Fixes: #2490

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>