### PR TITLE
docs: update `how-to` README file for Firecracker config

### DIFF
--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -17,10 +17,9 @@
 - `firecracker`
 - `ACRN`
 
-  While `qemu` and `cloud-hypervisor` work out of the box with installation of Kata,
-  some additional configuration is needed in case of `firecracker` and `ACRN`.
+  While `qemu` , `cloud-hypervisor` and `firecracker` work out of the box with installation of Kata,
+  some additional configuration is needed in case of `ACRN`.
   Refer to the following guides for additional configuration steps:
-- [Kata Containers with Firecracker](https://github.com/kata-containers/documentation/wiki/Initial-release-of-Kata-Containers-with-Firecracker-support)
 - [Kata Containers with ACRN Hypervisor](how-to-use-kata-containers-with-acrn.md)
 
 ## Advanced Topics


### PR DESCRIPTION
Remove the `Kata Containers with Firecracker` additional configuration steps.
From kata 2.x,  the config of `firecracker` is same to `qemu` and `cloud-hypervisor`.

Fixes: #2492

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>