### PR TITLE
cli: Show available guest protection in env output

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-env.go
+++ b/src/runtime/cmd/kata-runtime/kata-env.go
@@ -130,13 +130,14 @@ type DistroInfo struct {
 
 // HostInfo stores host details
 type HostInfo struct {
-	Kernel             string
-	Architecture       string
-	Distro             DistroInfo
-	CPU                CPUInfo
-	Memory             MemoryInfo
-	VMContainerCapable bool
-	SupportVSocks      bool
+	AvailableGuestProtections []string
+	Kernel                    string
+	Architecture              string
+	Distro                    DistroInfo
+	CPU                       CPUInfo
+	Memory                    MemoryInfo
+	VMContainerCapable        bool
+	SupportVSocks             bool
 }
 
 // NetmonInfo stores netmon details
@@ -241,14 +242,17 @@ func getHostInfo() (HostInfo, error) {
 
 	memoryInfo := getMemoryInfo()
 
+	availableGuestProtection := vc.AvailableGuestProtections()
+
 	host := HostInfo{
-		Kernel:             hostKernelVersion,
-		Architecture:       arch,
-		Distro:             hostDistro,
-		CPU:                hostCPU,
-		Memory:             memoryInfo,
-		VMContainerCapable: hostVMContainerCapable,
-		SupportVSocks:      supportVSocks,
+		Kernel:                    hostKernelVersion,
+		Architecture:              arch,
+		Distro:                    hostDistro,
+		CPU:                       hostCPU,
+		Memory:                    memoryInfo,
+		AvailableGuestProtections: availableGuestProtection,
+		VMContainerCapable:        hostVMContainerCapable,
+		SupportVSocks:             supportVSocks,
 	}
 
 	return host, nil

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -179,10 +179,10 @@ const (
 
 var guestProtectionStr = [...]string{
 	noneProtection: "none",
-	tdxProtection:  "tdx",
-	sevProtection:  "sev",
 	pefProtection:  "pef",
 	seProtection:   "se",
+	sevProtection:  "sev",
+	tdxProtection:  "tdx",
 }
 
 func (gp guestProtection) String() string {

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -177,6 +177,30 @@ const (
 	seProtection //nolint
 )
 
+var guestProtectionStr = [...]string{
+	noneProtection: "none",
+	tdxProtection:  "tdx",
+	sevProtection:  "sev",
+	pefProtection:  "pef",
+	seProtection:   "se",
+}
+
+func (gp guestProtection) String() string {
+	return guestProtectionStr[gp]
+}
+
+func genericAvailableGuestProtections() (protections []string) {
+	return
+}
+
+func AvailableGuestProtections() (protections []string) {
+	gp, err := availableGuestProtection()
+	if err != nil || gp == noneProtection {
+		return genericAvailableGuestProtections()
+	}
+	return []string{gp.String()}
+}
+
 type qemuArchBase struct {
 	qemuExePath          string
 	qemuMachine          govmmQemu.Machine


### PR DESCRIPTION
Show available guest protections in the `kata-runtime env` output. Also bump the `formatVersion`.

Fixes: #1982

Signed-off-by: Yujia Qiao <rapiz3142@gmail.com>