### PR TITLE
ci: Temporarily skip agent shutdown test on s390x

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -13,5 +13,6 @@ clone_tests_repo
 
 pushd ${tests_repo_dir}
 .ci/run.sh
-tracing/test-agent-shutdown.sh
+# temporary fix, see https://github.com/kata-containers/tests/issues/3878
+[ "$(uname -m)" != "s390x" ] && tracing/test-agent-shutdown.sh
 popd


### PR DESCRIPTION
see https://github.com/kata-containers/tests/issues/3878 for tracking

Fixes: #2507
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>