### PR TITLE
tracing: Change runtime tracing tags to vars

### DIFF
--- a/src/runtime/pkg/katautils/katatrace/tracing.go
+++ b/src/runtime/pkg/katautils/katatrace/tracing.go
@@ -129,7 +129,7 @@ func StopTracing(ctx context.Context) {
 // Trace creates a new tracing span based on the specified name and parent context.
 // It also accepts a logger to record nil context errors and a map of tracing tags.
 // Tracing tag keys and values are strings.
-func Trace(parent context.Context, logger *logrus.Entry, name string, tags map[string]string) (otelTrace.Span, context.Context) {
+func Trace(parent context.Context, logger *logrus.Entry, name string, tags ...map[string]string) (otelTrace.Span, context.Context) {
 	if parent == nil {
 		if logger == nil {
 			logger = kataTraceLogger
@@ -139,8 +139,13 @@ func Trace(parent context.Context, logger *logrus.Entry, name string, tags map[s
 	}
 
 	var otelTags []label.KeyValue
-	for k, v := range tags {
-		otelTags = append(otelTags, label.Key(k).String(v))
+	// do not append tags if tracing is disabled
+	if tracing {
+		for _, tagSet := range tags {
+			for k, v := range tagSet {
+				otelTags = append(otelTags, label.Key(k).String(v))
+			}
+		}
 	}
 
 	tracer := otel.Tracer("kata")

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -29,15 +29,12 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 )
 
-// tracingTags defines tags for the trace span
-func (a *Acrn) tracingTags() map[string]string {
-	return map[string]string{
-		"source":     "runtime",
-		"package":    "virtcontainers",
-		"subsystem":  "hypervisor",
-		"type":       "acrn",
-		"sandbox_id": a.id,
-	}
+// acrnTracingTags defines tags for the trace span
+var acrnTracingTags = map[string]string{
+	"source":    "runtime",
+	"package":   "virtcontainers",
+	"subsystem": "hypervisor",
+	"type":      "acrn",
 }
 
 // Since ACRN is using the store in a quite abnormal way, let's first draw it back from store to here
@@ -159,7 +156,8 @@ func (a *Acrn) kernelParameters() string {
 
 // Adds all capabilities supported by Acrn implementation of hypervisor interface
 func (a *Acrn) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "capabilities", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "capabilities", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	return a.arch.capabilities()
@@ -284,7 +282,8 @@ func (a *Acrn) buildDevices(ctx context.Context, imagePath string) ([]Device, er
 
 // setup sets the Acrn structure up.
 func (a *Acrn) setup(ctx context.Context, id string, hypervisorConfig *HypervisorConfig) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "setup", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "setup", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	err := hypervisorConfig.valid()
@@ -327,7 +326,8 @@ func (a *Acrn) setup(ctx context.Context, id string, hypervisorConfig *Hyperviso
 }
 
 func (a *Acrn) createDummyVirtioBlkDev(ctx context.Context, devices []Device) ([]Device, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "createDummyVirtioBlkDev", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "createDummyVirtioBlkDev", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	// Since acrn doesn't support hot-plug, dummy virtio-blk
@@ -350,7 +350,8 @@ func (a *Acrn) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 	// Save the tracing context
 	a.ctx = ctx
 
-	span, ctx := katatrace.Trace(ctx, a.Logger(), "createSandbox", a.tracingTags())
+	span, ctx := katatrace.Trace(ctx, a.Logger(), "createSandbox", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	if err := a.setup(ctx, id, hypervisorConfig); err != nil {
@@ -415,7 +416,8 @@ func (a *Acrn) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 
 // startSandbox will start the Sandbox's VM.
 func (a *Acrn) startSandbox(ctx context.Context, timeoutSecs int) error {
-	span, ctx := katatrace.Trace(ctx, a.Logger(), "startSandbox", a.tracingTags())
+	span, ctx := katatrace.Trace(ctx, a.Logger(), "startSandbox", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	if a.config.Debug {
@@ -461,7 +463,8 @@ func (a *Acrn) startSandbox(ctx context.Context, timeoutSecs int) error {
 
 // waitSandbox will wait for the Sandbox's VM to be up and running.
 func (a *Acrn) waitSandbox(ctx context.Context, timeoutSecs int) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "waitSandbox", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "waitSandbox", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	if timeoutSecs < 0 {
@@ -475,7 +478,8 @@ func (a *Acrn) waitSandbox(ctx context.Context, timeoutSecs int) error {
 
 // stopSandbox will stop the Sandbox's VM.
 func (a *Acrn) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "stopSandbox", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "stopSandbox", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	a.Logger().Info("Stopping acrn VM")
@@ -547,7 +551,8 @@ func (a *Acrn) updateBlockDevice(drive *config.BlockDrive) error {
 }
 
 func (a *Acrn) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugAddDevice", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugAddDevice", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	switch devType {
@@ -561,7 +566,8 @@ func (a *Acrn) hotplugAddDevice(ctx context.Context, devInfo interface{}, devTyp
 }
 
 func (a *Acrn) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugRemoveDevice", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugRemoveDevice", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	// Not supported. return success
@@ -570,7 +576,8 @@ func (a *Acrn) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, dev
 }
 
 func (a *Acrn) pauseSandbox(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "pauseSandbox", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "pauseSandbox", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	// Not supported. return success
@@ -579,7 +586,8 @@ func (a *Acrn) pauseSandbox(ctx context.Context) error {
 }
 
 func (a *Acrn) resumeSandbox(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "resumeSandbox", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "resumeSandbox", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	// Not supported. return success
@@ -590,7 +598,8 @@ func (a *Acrn) resumeSandbox(ctx context.Context) error {
 // addDevice will add extra devices to acrn command line.
 func (a *Acrn) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
 	var err error
-	span, _ := katatrace.Trace(ctx, a.Logger(), "addDevice", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "addDevice", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	switch v := devInfo.(type) {
@@ -623,7 +632,8 @@ func (a *Acrn) addDevice(ctx context.Context, devInfo interface{}, devType devic
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
 func (a *Acrn) getSandboxConsole(ctx context.Context, id string) (string, string, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "getSandboxConsole", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "getSandboxConsole", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	consoleURL, err := utils.BuildSocketPath(a.store.RunVMStoragePath(), id, acrnConsoleSocket)
@@ -643,14 +653,16 @@ func (a *Acrn) saveSandbox() error {
 }
 
 func (a *Acrn) disconnect(ctx context.Context) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "disconnect", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "disconnect", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	// Not supported.
 }
 
 func (a *Acrn) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "getThreadIDs", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "getThreadIDs", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	// Not supported. return success
@@ -668,7 +680,8 @@ func (a *Acrn) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs u
 }
 
 func (a *Acrn) cleanup(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "cleanup", a.tracingTags())
+	span, _ := katatrace.Trace(ctx, a.Logger(), "cleanup", acrnTracingTags)
+	katatrace.AddTag(span, "sandbox_id", a.id)
 	defer span.End()
 
 	return nil

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -156,8 +156,7 @@ func (a *Acrn) kernelParameters() string {
 
 // Adds all capabilities supported by Acrn implementation of hypervisor interface
 func (a *Acrn) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "capabilities", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "capabilities", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	return a.arch.capabilities()
@@ -282,8 +281,7 @@ func (a *Acrn) buildDevices(ctx context.Context, imagePath string) ([]Device, er
 
 // setup sets the Acrn structure up.
 func (a *Acrn) setup(ctx context.Context, id string, hypervisorConfig *HypervisorConfig) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "setup", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "setup", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	err := hypervisorConfig.valid()
@@ -326,8 +324,7 @@ func (a *Acrn) setup(ctx context.Context, id string, hypervisorConfig *Hyperviso
 }
 
 func (a *Acrn) createDummyVirtioBlkDev(ctx context.Context, devices []Device) ([]Device, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "createDummyVirtioBlkDev", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "createDummyVirtioBlkDev", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Since acrn doesn't support hot-plug, dummy virtio-blk
@@ -350,8 +347,7 @@ func (a *Acrn) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 	// Save the tracing context
 	a.ctx = ctx
 
-	span, ctx := katatrace.Trace(ctx, a.Logger(), "createSandbox", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, ctx := katatrace.Trace(ctx, a.Logger(), "createSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	if err := a.setup(ctx, id, hypervisorConfig); err != nil {
@@ -416,8 +412,7 @@ func (a *Acrn) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 
 // startSandbox will start the Sandbox's VM.
 func (a *Acrn) startSandbox(ctx context.Context, timeoutSecs int) error {
-	span, ctx := katatrace.Trace(ctx, a.Logger(), "startSandbox", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, ctx := katatrace.Trace(ctx, a.Logger(), "startSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	if a.config.Debug {
@@ -463,8 +458,7 @@ func (a *Acrn) startSandbox(ctx context.Context, timeoutSecs int) error {
 
 // waitSandbox will wait for the Sandbox's VM to be up and running.
 func (a *Acrn) waitSandbox(ctx context.Context, timeoutSecs int) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "waitSandbox", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "waitSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	if timeoutSecs < 0 {
@@ -478,8 +472,7 @@ func (a *Acrn) waitSandbox(ctx context.Context, timeoutSecs int) error {
 
 // stopSandbox will stop the Sandbox's VM.
 func (a *Acrn) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "stopSandbox", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "stopSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	a.Logger().Info("Stopping acrn VM")
@@ -551,8 +544,7 @@ func (a *Acrn) updateBlockDevice(drive *config.BlockDrive) error {
 }
 
 func (a *Acrn) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugAddDevice", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugAddDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	switch devType {
@@ -566,8 +558,7 @@ func (a *Acrn) hotplugAddDevice(ctx context.Context, devInfo interface{}, devTyp
 }
 
 func (a *Acrn) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugRemoveDevice", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugRemoveDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported. return success
@@ -576,8 +567,7 @@ func (a *Acrn) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, dev
 }
 
 func (a *Acrn) pauseSandbox(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "pauseSandbox", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "pauseSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported. return success
@@ -586,8 +576,7 @@ func (a *Acrn) pauseSandbox(ctx context.Context) error {
 }
 
 func (a *Acrn) resumeSandbox(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "resumeSandbox", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "resumeSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported. return success
@@ -598,8 +587,7 @@ func (a *Acrn) resumeSandbox(ctx context.Context) error {
 // addDevice will add extra devices to acrn command line.
 func (a *Acrn) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
 	var err error
-	span, _ := katatrace.Trace(ctx, a.Logger(), "addDevice", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "addDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	switch v := devInfo.(type) {
@@ -632,8 +620,7 @@ func (a *Acrn) addDevice(ctx context.Context, devInfo interface{}, devType devic
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
 func (a *Acrn) getSandboxConsole(ctx context.Context, id string) (string, string, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "getSandboxConsole", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "getSandboxConsole", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	consoleURL, err := utils.BuildSocketPath(a.store.RunVMStoragePath(), id, acrnConsoleSocket)
@@ -653,16 +640,14 @@ func (a *Acrn) saveSandbox() error {
 }
 
 func (a *Acrn) disconnect(ctx context.Context) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "disconnect", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "disconnect", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported.
 }
 
 func (a *Acrn) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "getThreadIDs", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "getThreadIDs", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported. return success
@@ -680,8 +665,7 @@ func (a *Acrn) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs u
 }
 
 func (a *Acrn) cleanup(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "cleanup", acrnTracingTags)
-	katatrace.AddTag(span, "sandbox_id", a.id)
+	span, _ := katatrace.Trace(ctx, a.Logger(), "cleanup", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	return nil

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -152,8 +152,7 @@ var clhDebugKernelParams = []Param{
 func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
 	clh.ctx = ctx
 
-	span, newCtx := katatrace.Trace(clh.ctx, clh.Logger(), "createSandbox", clhTracingTags)
-	katatrace.AddTag(span, "sandbox_id", clh.id)
+	span, newCtx := katatrace.Trace(clh.ctx, clh.Logger(), "createSandbox", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	clh.ctx = newCtx
 	defer span.End()
 
@@ -318,8 +317,7 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 
 // startSandbox will start the VMM and boot the virtual machine for the given sandbox.
 func (clh *cloudHypervisor) startSandbox(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "startSandbox", clhTracingTags)
-	katatrace.AddTag(span, "sandbox_id", clh.id)
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "startSandbox", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	ctx, cancel := context.WithTimeout(context.Background(), clhAPITimeout*time.Second)
@@ -482,7 +480,7 @@ func (clh *cloudHypervisor) hotPlugVFIODevice(device config.VFIODev) error {
 }
 
 func (clh *cloudHypervisor) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugAddDevice", clhTracingTags)
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugAddDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	switch devType {
@@ -499,8 +497,7 @@ func (clh *cloudHypervisor) hotplugAddDevice(ctx context.Context, devInfo interf
 }
 
 func (clh *cloudHypervisor) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugRemoveDevice", clhTracingTags)
-	katatrace.AddTag(span, "sandbox_id", clh.id)
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugRemoveDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	var deviceID string
@@ -660,8 +657,7 @@ func (clh *cloudHypervisor) resumeSandbox(ctx context.Context) error {
 
 // stopSandbox will stop the Sandbox's VM.
 func (clh *cloudHypervisor) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "stopSandbox", clhTracingTags)
-	katatrace.AddTag(span, "sandbox_id", clh.id)
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "stopSandbox", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 	clh.Logger().WithField("function", "stopSandbox").Info("Stop Sandbox")
 	return clh.terminate(ctx, waitOnly)
@@ -711,8 +707,7 @@ func (clh *cloudHypervisor) getVirtioFsPid() *int {
 }
 
 func (clh *cloudHypervisor) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "addDevice", clhTracingTags)
-	katatrace.AddTag(span, "sandbox_id", clh.id)
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "addDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	var err error
@@ -746,8 +741,7 @@ func (clh *cloudHypervisor) Logger() *log.Entry {
 
 // Adds all capabilities supported by cloudHypervisor implementation of hypervisor interface
 func (clh *cloudHypervisor) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "capabilities", clhTracingTags)
-	katatrace.AddTag(span, "sandbox_id", clh.id)
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "capabilities", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	clh.Logger().WithField("function", "capabilities").Info("get Capabilities")
@@ -758,8 +752,7 @@ func (clh *cloudHypervisor) capabilities(ctx context.Context) types.Capabilities
 }
 
 func (clh *cloudHypervisor) terminate(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "terminate", clhTracingTags)
-	katatrace.AddTag(span, "sandbox_id", clh.id)
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "terminate", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	pid := clh.state.PID

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -33,15 +33,12 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 )
 
-// tracingTags defines tags for the trace span
-func (clh *cloudHypervisor) tracingTags() map[string]string {
-	return map[string]string{
-		"source":     "runtime",
-		"package":    "virtcontainers",
-		"subsystem":  "hypervisor",
-		"type":       "clh",
-		"sandbox_id": clh.id,
-	}
+// clhTracingTags defines tags for the trace span
+var clhTracingTags = map[string]string{
+	"source":    "runtime",
+	"package":   "virtcontainers",
+	"subsystem": "hypervisor",
+	"type":      "clh",
 }
 
 //
@@ -155,7 +152,8 @@ var clhDebugKernelParams = []Param{
 func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
 	clh.ctx = ctx
 
-	span, newCtx := katatrace.Trace(clh.ctx, clh.Logger(), "createSandbox", clh.tracingTags())
+	span, newCtx := katatrace.Trace(clh.ctx, clh.Logger(), "createSandbox", clhTracingTags)
+	katatrace.AddTag(span, "sandbox_id", clh.id)
 	clh.ctx = newCtx
 	defer span.End()
 
@@ -320,7 +318,8 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 
 // startSandbox will start the VMM and boot the virtual machine for the given sandbox.
 func (clh *cloudHypervisor) startSandbox(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "startSandbox", clh.tracingTags())
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "startSandbox", clhTracingTags)
+	katatrace.AddTag(span, "sandbox_id", clh.id)
 	defer span.End()
 
 	ctx, cancel := context.WithTimeout(context.Background(), clhAPITimeout*time.Second)
@@ -483,7 +482,7 @@ func (clh *cloudHypervisor) hotPlugVFIODevice(device config.VFIODev) error {
 }
 
 func (clh *cloudHypervisor) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugAddDevice", clh.tracingTags())
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugAddDevice", clhTracingTags)
 	defer span.End()
 
 	switch devType {
@@ -500,7 +499,8 @@ func (clh *cloudHypervisor) hotplugAddDevice(ctx context.Context, devInfo interf
 }
 
 func (clh *cloudHypervisor) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugRemoveDevice", clh.tracingTags())
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugRemoveDevice", clhTracingTags)
+	katatrace.AddTag(span, "sandbox_id", clh.id)
 	defer span.End()
 
 	var deviceID string
@@ -660,7 +660,8 @@ func (clh *cloudHypervisor) resumeSandbox(ctx context.Context) error {
 
 // stopSandbox will stop the Sandbox's VM.
 func (clh *cloudHypervisor) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "stopSandbox", clh.tracingTags())
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "stopSandbox", clhTracingTags)
+	katatrace.AddTag(span, "sandbox_id", clh.id)
 	defer span.End()
 	clh.Logger().WithField("function", "stopSandbox").Info("Stop Sandbox")
 	return clh.terminate(ctx, waitOnly)
@@ -710,7 +711,8 @@ func (clh *cloudHypervisor) getVirtioFsPid() *int {
 }
 
 func (clh *cloudHypervisor) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "addDevice", clh.tracingTags())
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "addDevice", clhTracingTags)
+	katatrace.AddTag(span, "sandbox_id", clh.id)
 	defer span.End()
 
 	var err error
@@ -744,7 +746,8 @@ func (clh *cloudHypervisor) Logger() *log.Entry {
 
 // Adds all capabilities supported by cloudHypervisor implementation of hypervisor interface
 func (clh *cloudHypervisor) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "capabilities", clh.tracingTags())
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "capabilities", clhTracingTags)
+	katatrace.AddTag(span, "sandbox_id", clh.id)
 	defer span.End()
 
 	clh.Logger().WithField("function", "capabilities").Info("get Capabilities")
@@ -755,7 +758,8 @@ func (clh *cloudHypervisor) capabilities(ctx context.Context) types.Capabilities
 }
 
 func (clh *cloudHypervisor) terminate(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "terminate", clh.tracingTags())
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "terminate", clhTracingTags)
+	katatrace.AddTag(span, "sandbox_id", clh.id)
 	defer span.End()
 
 	pid := clh.state.PID

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -616,15 +616,12 @@ func (c *Container) mountSharedDirMounts(ctx context.Context, sharedDirMounts, i
 }
 
 func (c *Container) unmountHostMounts(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, c.Logger(), "unmountHostMounts", containerTracingTags)
-	katatrace.AddTag(span, "container_id", c.id)
+	span, ctx := katatrace.Trace(ctx, c.Logger(), "unmountHostMounts", containerTracingTags, map[string]string{"container_id": c.id})
 	defer span.End()
 
 	for _, m := range c.mounts {
 		if m.HostPath != "" {
-			span, _ := katatrace.Trace(ctx, c.Logger(), "unmount", containerTracingTags)
-			katatrace.AddTag(span, "container_id", c.id)
-			katatrace.AddTag(span, "host-path", m.HostPath)
+			span, _ := katatrace.Trace(ctx, c.Logger(), "unmount", containerTracingTags, map[string]string{"container_id": c.id, "host-path": m.HostPath})
 
 			if err := syscall.Unmount(m.HostPath, syscall.MNT_DETACH|UmountNoFollow); err != nil {
 				c.Logger().WithFields(logrus.Fields{
@@ -752,9 +749,7 @@ func (c *Container) initConfigResourcesMemory() {
 
 // newContainer creates a Container structure from a sandbox and a container configuration.
 func newContainer(ctx context.Context, sandbox *Sandbox, contConfig *ContainerConfig) (*Container, error) {
-	span, ctx := katatrace.Trace(ctx, sandbox.Logger(), "newContainer", containerTracingTags)
-	katatrace.AddTag(span, "sandbox_id", sandbox.id)
-	katatrace.AddTag(span, "container_id", contConfig.ID)
+	span, ctx := katatrace.Trace(ctx, sandbox.Logger(), "newContainer", containerTracingTags, map[string]string{"container_id": contConfig.ID, "sandbox_id": sandbox.id})
 	defer span.End()
 
 	if !contConfig.valid() {
@@ -1050,8 +1045,7 @@ func (c *Container) start(ctx context.Context) error {
 }
 
 func (c *Container) stop(ctx context.Context, force bool) error {
-	span, ctx := katatrace.Trace(ctx, c.Logger(), "stop", containerTracingTags)
-	katatrace.AddTag(span, "container_id", c.id)
+	span, ctx := katatrace.Trace(ctx, c.Logger(), "stop", containerTracingTags, map[string]string{"container_id": c.id})
 	defer span.End()
 
 	// In case the container status has been updated implicitly because

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -41,15 +41,12 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-// tracingTags defines tags for the trace span
-func (fc *firecracker) tracingTags() map[string]string {
-	return map[string]string{
-		"source":     "runtime",
-		"package":    "virtcontainers",
-		"subsystem":  "hypervisor",
-		"type":       "firecracker",
-		"sandbox_id": fc.id,
-	}
+// fcTracingTags defines tags for the trace span
+var fcTracingTags = map[string]string{
+	"source":    "runtime",
+	"package":   "virtcontainers",
+	"subsystem": "hypervisor",
+	"type":      "firecracker",
 }
 
 type vmmState uint8
@@ -194,7 +191,8 @@ func (fc *firecracker) truncateID(id string) string {
 func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
 	fc.ctx = ctx
 
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "createSandbox", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "createSandbox", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	//TODO: check validity of the hypervisor config provided
@@ -237,7 +235,8 @@ func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS N
 }
 
 func (fc *firecracker) newFireClient(ctx context.Context) *client.Firecracker {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "newFireClient", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "newFireClient", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 	httpClient := client.NewHTTPClient(strfmt.NewFormats())
 
@@ -315,7 +314,8 @@ func (fc *firecracker) checkVersion(version string) error {
 
 // waitVMMRunning will wait for timeout seconds for the VMM to be up and running.
 func (fc *firecracker) waitVMMRunning(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "wait VMM to be running", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "wait VMM to be running", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	if timeout < 0 {
@@ -337,7 +337,8 @@ func (fc *firecracker) waitVMMRunning(ctx context.Context, timeout int) error {
 }
 
 func (fc *firecracker) fcInit(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcInit", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcInit", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	var err error
@@ -412,7 +413,8 @@ func (fc *firecracker) fcInit(ctx context.Context, timeout int) error {
 }
 
 func (fc *firecracker) fcEnd(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcEnd", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcEnd", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	fc.Logger().Info("Stopping firecracker VM")
@@ -439,7 +441,8 @@ func (fc *firecracker) fcEnd(ctx context.Context, waitOnly bool) (err error) {
 }
 
 func (fc *firecracker) client(ctx context.Context) *client.Firecracker {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "client", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "client", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	if fc.connection == nil {
@@ -506,7 +509,8 @@ func (fc *firecracker) fcJailResource(src, dst string) (string, error) {
 }
 
 func (fc *firecracker) fcSetBootSource(ctx context.Context, path, params string) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetBootSource", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetBootSource", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 	fc.Logger().WithFields(logrus.Fields{"kernel-path": path,
 		"kernel-params": params}).Debug("fcSetBootSource")
@@ -527,7 +531,8 @@ func (fc *firecracker) fcSetBootSource(ctx context.Context, path, params string)
 }
 
 func (fc *firecracker) fcSetVMRootfs(ctx context.Context, path string) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetVMRootfs", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetVMRootfs", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	jailedRootfs, err := fc.fcJailResource(path, fcRootfs)
@@ -554,7 +559,8 @@ func (fc *firecracker) fcSetVMRootfs(ctx context.Context, path string) error {
 }
 
 func (fc *firecracker) fcSetVMBaseConfig(ctx context.Context, mem int64, vcpus int64, htEnabled bool) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetVMBaseConfig", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetVMBaseConfig", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 	fc.Logger().WithFields(logrus.Fields{"mem": mem,
 		"vcpus":     vcpus,
@@ -570,7 +576,8 @@ func (fc *firecracker) fcSetVMBaseConfig(ctx context.Context, mem int64, vcpus i
 }
 
 func (fc *firecracker) fcSetLogger(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetLogger", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetLogger", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	fcLogLevel := "Error"
@@ -593,7 +600,8 @@ func (fc *firecracker) fcSetLogger(ctx context.Context) error {
 }
 
 func (fc *firecracker) fcSetMetrics(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetMetrics", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetMetrics", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	// listen to metrics file and transfer error info
@@ -748,7 +756,8 @@ func (fc *firecracker) fcInitConfiguration(ctx context.Context) error {
 // In the context of firecracker, this will start the hypervisor,
 // for configuration, but not yet start the actual virtual machine
 func (fc *firecracker) startSandbox(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "startSandbox", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "startSandbox", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	if err := fc.fcInitConfiguration(ctx); err != nil {
@@ -800,7 +809,8 @@ func fcDriveIndexToID(i int) string {
 }
 
 func (fc *firecracker) createDiskPool(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "createDiskPool", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "createDiskPool", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	for i := 0; i < fcDiskPoolSize; i++ {
@@ -838,7 +848,8 @@ func (fc *firecracker) umountResource(jailedPath string) {
 
 // cleanup all jail artifacts
 func (fc *firecracker) cleanupJail(ctx context.Context) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "cleanupJail", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "cleanupJail", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	fc.umountResource(fcKernel)
@@ -861,7 +872,8 @@ func (fc *firecracker) cleanupJail(ctx context.Context) {
 
 // stopSandbox will stop the Sandbox's VM.
 func (fc *firecracker) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "stopSandbox", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "stopSandbox", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	return fc.fcEnd(ctx, waitOnly)
@@ -880,7 +892,8 @@ func (fc *firecracker) resumeSandbox(ctx context.Context) error {
 }
 
 func (fc *firecracker) fcAddVsock(ctx context.Context, hvs types.HybridVSock) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddVsock", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddVsock", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	udsPath := hvs.UdsPath
@@ -900,7 +913,8 @@ func (fc *firecracker) fcAddVsock(ctx context.Context, hvs types.HybridVSock) {
 }
 
 func (fc *firecracker) fcAddNetDevice(ctx context.Context, endpoint Endpoint) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddNetDevice", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddNetDevice", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	ifaceID := endpoint.Name()
@@ -956,7 +970,8 @@ func (fc *firecracker) fcAddNetDevice(ctx context.Context, endpoint Endpoint) {
 }
 
 func (fc *firecracker) fcAddBlockDrive(ctx context.Context, drive config.BlockDrive) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddBlockDrive", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddBlockDrive", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	driveID := drive.ID
@@ -982,7 +997,8 @@ func (fc *firecracker) fcAddBlockDrive(ctx context.Context, drive config.BlockDr
 
 // Firecracker supports replacing the host drive used once the VM has booted up
 func (fc *firecracker) fcUpdateBlockDrive(ctx context.Context, path, id string) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcUpdateBlockDrive", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcUpdateBlockDrive", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	// Use the global block index as an index into the pool of the devices
@@ -1006,7 +1022,8 @@ func (fc *firecracker) fcUpdateBlockDrive(ctx context.Context, path, id string) 
 // addDevice will add extra devices to firecracker.  Limited to configure before the
 // virtual machine starts.  Devices include drivers and network interfaces only.
 func (fc *firecracker) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "addDevice", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "addDevice", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	fc.state.RLock()
@@ -1076,7 +1093,8 @@ func (fc *firecracker) hotplugBlockDevice(ctx context.Context, drive config.Bloc
 
 // hotplugAddDevice supported in Firecracker VMM
 func (fc *firecracker) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugAddDevice", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugAddDevice", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	switch devType {
@@ -1092,7 +1110,8 @@ func (fc *firecracker) hotplugAddDevice(ctx context.Context, devInfo interface{}
 
 // hotplugRemoveDevice supported in Firecracker VMM
 func (fc *firecracker) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugRemoveDevice", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugRemoveDevice", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 
 	switch devType {
@@ -1125,7 +1144,8 @@ func (fc *firecracker) disconnect(ctx context.Context) {
 
 // Adds all capabilities supported by firecracker implementation of hypervisor interface
 func (fc *firecracker) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "capabilities", fc.tracingTags())
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "capabilities", fcTracingTags)
+	katatrace.AddTag(span, "sandbox_id", fc.id)
 	defer span.End()
 	var caps types.Capabilities
 	caps.SetBlockDeviceHotplugSupport()

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -191,8 +191,7 @@ func (fc *firecracker) truncateID(id string) string {
 func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
 	fc.ctx = ctx
 
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "createSandbox", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "createSandbox", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	//TODO: check validity of the hypervisor config provided
@@ -235,8 +234,7 @@ func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS N
 }
 
 func (fc *firecracker) newFireClient(ctx context.Context) *client.Firecracker {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "newFireClient", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "newFireClient", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 	httpClient := client.NewHTTPClient(strfmt.NewFormats())
 
@@ -314,8 +312,7 @@ func (fc *firecracker) checkVersion(version string) error {
 
 // waitVMMRunning will wait for timeout seconds for the VMM to be up and running.
 func (fc *firecracker) waitVMMRunning(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "wait VMM to be running", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "wait VMM to be running", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	if timeout < 0 {
@@ -337,8 +334,7 @@ func (fc *firecracker) waitVMMRunning(ctx context.Context, timeout int) error {
 }
 
 func (fc *firecracker) fcInit(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcInit", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcInit", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	var err error
@@ -413,8 +409,7 @@ func (fc *firecracker) fcInit(ctx context.Context, timeout int) error {
 }
 
 func (fc *firecracker) fcEnd(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcEnd", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcEnd", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	fc.Logger().Info("Stopping firecracker VM")
@@ -441,8 +436,7 @@ func (fc *firecracker) fcEnd(ctx context.Context, waitOnly bool) (err error) {
 }
 
 func (fc *firecracker) client(ctx context.Context) *client.Firecracker {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "client", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "client", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	if fc.connection == nil {
@@ -509,8 +503,7 @@ func (fc *firecracker) fcJailResource(src, dst string) (string, error) {
 }
 
 func (fc *firecracker) fcSetBootSource(ctx context.Context, path, params string) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetBootSource", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetBootSource", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 	fc.Logger().WithFields(logrus.Fields{"kernel-path": path,
 		"kernel-params": params}).Debug("fcSetBootSource")
@@ -531,8 +524,7 @@ func (fc *firecracker) fcSetBootSource(ctx context.Context, path, params string)
 }
 
 func (fc *firecracker) fcSetVMRootfs(ctx context.Context, path string) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetVMRootfs", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetVMRootfs", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	jailedRootfs, err := fc.fcJailResource(path, fcRootfs)
@@ -559,8 +551,7 @@ func (fc *firecracker) fcSetVMRootfs(ctx context.Context, path string) error {
 }
 
 func (fc *firecracker) fcSetVMBaseConfig(ctx context.Context, mem int64, vcpus int64, htEnabled bool) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetVMBaseConfig", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetVMBaseConfig", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 	fc.Logger().WithFields(logrus.Fields{"mem": mem,
 		"vcpus":     vcpus,
@@ -576,8 +567,7 @@ func (fc *firecracker) fcSetVMBaseConfig(ctx context.Context, mem int64, vcpus i
 }
 
 func (fc *firecracker) fcSetLogger(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetLogger", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetLogger", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	fcLogLevel := "Error"
@@ -600,8 +590,7 @@ func (fc *firecracker) fcSetLogger(ctx context.Context) error {
 }
 
 func (fc *firecracker) fcSetMetrics(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetMetrics", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcSetMetrics", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	// listen to metrics file and transfer error info
@@ -756,8 +745,7 @@ func (fc *firecracker) fcInitConfiguration(ctx context.Context) error {
 // In the context of firecracker, this will start the hypervisor,
 // for configuration, but not yet start the actual virtual machine
 func (fc *firecracker) startSandbox(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "startSandbox", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "startSandbox", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	if err := fc.fcInitConfiguration(ctx); err != nil {
@@ -809,8 +797,7 @@ func fcDriveIndexToID(i int) string {
 }
 
 func (fc *firecracker) createDiskPool(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "createDiskPool", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "createDiskPool", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	for i := 0; i < fcDiskPoolSize; i++ {
@@ -848,8 +835,7 @@ func (fc *firecracker) umountResource(jailedPath string) {
 
 // cleanup all jail artifacts
 func (fc *firecracker) cleanupJail(ctx context.Context) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "cleanupJail", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "cleanupJail", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	fc.umountResource(fcKernel)
@@ -872,8 +858,7 @@ func (fc *firecracker) cleanupJail(ctx context.Context) {
 
 // stopSandbox will stop the Sandbox's VM.
 func (fc *firecracker) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "stopSandbox", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "stopSandbox", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	return fc.fcEnd(ctx, waitOnly)
@@ -892,8 +877,7 @@ func (fc *firecracker) resumeSandbox(ctx context.Context) error {
 }
 
 func (fc *firecracker) fcAddVsock(ctx context.Context, hvs types.HybridVSock) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddVsock", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddVsock", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	udsPath := hvs.UdsPath
@@ -913,8 +897,7 @@ func (fc *firecracker) fcAddVsock(ctx context.Context, hvs types.HybridVSock) {
 }
 
 func (fc *firecracker) fcAddNetDevice(ctx context.Context, endpoint Endpoint) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddNetDevice", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddNetDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	ifaceID := endpoint.Name()
@@ -970,8 +953,7 @@ func (fc *firecracker) fcAddNetDevice(ctx context.Context, endpoint Endpoint) {
 }
 
 func (fc *firecracker) fcAddBlockDrive(ctx context.Context, drive config.BlockDrive) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddBlockDrive", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcAddBlockDrive", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	driveID := drive.ID
@@ -997,8 +979,7 @@ func (fc *firecracker) fcAddBlockDrive(ctx context.Context, drive config.BlockDr
 
 // Firecracker supports replacing the host drive used once the VM has booted up
 func (fc *firecracker) fcUpdateBlockDrive(ctx context.Context, path, id string) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcUpdateBlockDrive", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "fcUpdateBlockDrive", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	// Use the global block index as an index into the pool of the devices
@@ -1022,8 +1003,7 @@ func (fc *firecracker) fcUpdateBlockDrive(ctx context.Context, path, id string) 
 // addDevice will add extra devices to firecracker.  Limited to configure before the
 // virtual machine starts.  Devices include drivers and network interfaces only.
 func (fc *firecracker) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "addDevice", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "addDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	fc.state.RLock()
@@ -1093,8 +1073,7 @@ func (fc *firecracker) hotplugBlockDevice(ctx context.Context, drive config.Bloc
 
 // hotplugAddDevice supported in Firecracker VMM
 func (fc *firecracker) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugAddDevice", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugAddDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	switch devType {
@@ -1110,8 +1089,7 @@ func (fc *firecracker) hotplugAddDevice(ctx context.Context, devInfo interface{}
 
 // hotplugRemoveDevice supported in Firecracker VMM
 func (fc *firecracker) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugRemoveDevice", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugRemoveDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	switch devType {
@@ -1144,8 +1122,7 @@ func (fc *firecracker) disconnect(ctx context.Context) {
 
 // Adds all capabilities supported by firecracker implementation of hypervisor interface
 func (fc *firecracker) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "capabilities", fcTracingTags)
-	katatrace.AddTag(span, "sandbox_id", fc.id)
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "capabilities", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 	var caps types.Capabilities
 	caps.SetBlockDeviceHotplugSupport()

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -33,6 +33,13 @@ var rootfsDir = "rootfs"
 
 var systemMountPrefixes = []string{"/proc", "/sys"}
 
+// mountTracingTags defines tags for the trace span
+var mountTracingTags = map[string]string{
+	"source":    "runtime",
+	"package":   "virtcontainers",
+	"subsystem": "mount",
+}
+
 func mountLogger() *logrus.Entry {
 	return virtLog.WithField("subsystem", "mount")
 }
@@ -240,7 +247,7 @@ func evalMountPath(source, destination string) (string, string, error) {
 // * ensure the source exists
 // * recursively create the destination
 func moveMount(ctx context.Context, source, destination string) error {
-	span, _ := katatrace.Trace(ctx, nil, "moveMount", apiTracingTags)
+	span, _ := katatrace.Trace(ctx, nil, "moveMount", mountTracingTags)
 	defer span.End()
 
 	source, destination, err := evalMountPath(source, destination)
@@ -258,7 +265,7 @@ func moveMount(ctx context.Context, source, destination string) error {
 // * recursively create the destination
 // pgtypes stands for propagation types, which are shared, private, slave, and ubind.
 func bindMount(ctx context.Context, source, destination string, readonly bool, pgtypes string) error {
-	span, _ := katatrace.Trace(ctx, nil, "bindMount", apiTracingTags)
+	span, _ := katatrace.Trace(ctx, nil, "bindMount", mountTracingTags)
 	defer span.End()
 	span.SetAttributes(otelLabel.String("source", source), otelLabel.String("destination", destination))
 
@@ -295,7 +302,7 @@ func bindMount(ctx context.Context, source, destination string, readonly bool, p
 // The mountflags should match the values used in the original mount() call,
 // except for those parameters that you are trying to change.
 func remount(ctx context.Context, mountflags uintptr, src string) error {
-	span, _ := katatrace.Trace(ctx, nil, "remount", apiTracingTags)
+	span, _ := katatrace.Trace(ctx, nil, "remount", mountTracingTags)
 	defer span.End()
 	span.SetAttributes(otelLabel.String("source", src))
 
@@ -320,7 +327,7 @@ func remountRo(ctx context.Context, src string) error {
 // bindMountContainerRootfs bind mounts a container rootfs into a 9pfs shared
 // directory between the guest and the host.
 func bindMountContainerRootfs(ctx context.Context, shareDir, cid, cRootFs string, readonly bool) error {
-	span, _ := katatrace.Trace(ctx, nil, "bindMountContainerRootfs", apiTracingTags)
+	span, _ := katatrace.Trace(ctx, nil, "bindMountContainerRootfs", mountTracingTags)
 	defer span.End()
 
 	rootfsDest := filepath.Join(shareDir, cid, rootfsDir)
@@ -360,7 +367,7 @@ func isSymlink(path string) bool {
 }
 
 func bindUnmountContainerRootfs(ctx context.Context, sharedDir, cID string) error {
-	span, _ := katatrace.Trace(ctx, nil, "bindUnmountContainerRootfs", apiTracingTags)
+	span, _ := katatrace.Trace(ctx, nil, "bindUnmountContainerRootfs", mountTracingTags)
 	defer span.End()
 	span.SetAttributes(otelLabel.String("shared_dir", sharedDir), otelLabel.String("container_id", cID))
 
@@ -383,7 +390,7 @@ func bindUnmountContainerRootfs(ctx context.Context, sharedDir, cID string) erro
 }
 
 func bindUnmountAllRootfs(ctx context.Context, sharedDir string, sandbox *Sandbox) error {
-	span, ctx := katatrace.Trace(ctx, nil, "bindUnmountAllRootfs", apiTracingTags)
+	span, ctx := katatrace.Trace(ctx, nil, "bindUnmountAllRootfs", mountTracingTags)
 	defer span.End()
 	span.SetAttributes(otelLabel.String("shared_dir", sharedDir), otelLabel.String("sandbox_id", sandbox.id))
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -192,8 +192,7 @@ func (q *qemu) kernelParameters() string {
 
 // Adds all capabilities supported by qemu implementation of hypervisor interface
 func (q *qemu) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "capabilities", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "capabilities", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	return q.arch.capabilities()
@@ -223,8 +222,7 @@ func (q *qemu) qemuPath() (string, error) {
 
 // setup sets the Qemu structure up.
 func (q *qemu) setup(ctx context.Context, id string, hypervisorConfig *HypervisorConfig) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "setup", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "setup", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	err := hypervisorConfig.valid()
@@ -467,8 +465,7 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 	// Save the tracing context
 	q.ctx = ctx
 
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "createSandbox", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "createSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	if err := q.setup(ctx, id, hypervisorConfig); err != nil {
@@ -753,8 +750,7 @@ func (q *qemu) setupVirtioMem(ctx context.Context) error {
 
 // startSandbox will start the Sandbox's VM.
 func (q *qemu) startSandbox(ctx context.Context, timeout int) error {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "startSandbox", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "startSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	if q.config.Debug {
@@ -872,8 +868,7 @@ func (q *qemu) bootFromTemplate() error {
 
 // waitSandbox will wait for the Sandbox's VM to be up and running.
 func (q *qemu) waitSandbox(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "waitSandbox", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "waitSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	if timeout < 0 {
@@ -924,8 +919,7 @@ func (q *qemu) waitSandbox(ctx context.Context, timeout int) error {
 
 // stopSandbox will stop the Sandbox's VM.
 func (q *qemu) stopSandbox(ctx context.Context, waitOnly bool) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "stopSandbox", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "stopSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	q.Logger().Info("Stopping Sandbox")
@@ -1017,8 +1011,7 @@ func (q *qemu) cleanupVM() error {
 }
 
 func (q *qemu) togglePauseSandbox(ctx context.Context, pause bool) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "togglePauseSandbox", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "togglePauseSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	if err := q.qmpSetup(); err != nil {
@@ -1623,10 +1616,9 @@ func (q *qemu) hotplugDevice(ctx context.Context, devInfo interface{}, devType d
 }
 
 func (q *qemu) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugAddDevice", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
-	defer span.End()
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugAddDevice", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	katatrace.AddTag(span, "device", devInfo)
+	defer span.End()
 
 	data, err := q.hotplugDevice(ctx, devInfo, devType, addDevice)
 	if err != nil {
@@ -1637,10 +1629,9 @@ func (q *qemu) hotplugAddDevice(ctx context.Context, devInfo interface{}, devTyp
 }
 
 func (q *qemu) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugRemoveDevice", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
-	defer span.End()
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugRemoveDevice", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	katatrace.AddTag(span, "device", devInfo)
+	defer span.End()
 
 	data, err := q.hotplugDevice(ctx, devInfo, devType, removeDevice)
 	if err != nil {
@@ -1851,16 +1842,14 @@ func (q *qemu) hotplugAddMemory(memDev *memoryDevice) (int, error) {
 }
 
 func (q *qemu) pauseSandbox(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "pauseSandbox", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "pauseSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	return q.togglePauseSandbox(ctx, true)
 }
 
 func (q *qemu) resumeSandbox(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "resumeSandbox", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "resumeSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	return q.togglePauseSandbox(ctx, false)
@@ -1869,10 +1858,9 @@ func (q *qemu) resumeSandbox(ctx context.Context) error {
 // addDevice will add extra devices to Qemu command line.
 func (q *qemu) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
 	var err error
-	span, _ := katatrace.Trace(ctx, q.Logger(), "addDevice", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
-	defer span.End()
+	span, _ := katatrace.Trace(ctx, q.Logger(), "addDevice", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	katatrace.AddTag(span, "device", devInfo)
+	defer span.End()
 
 	switch v := devInfo.(type) {
 	case types.Volume:
@@ -1929,8 +1917,7 @@ func (q *qemu) addDevice(ctx context.Context, devInfo interface{}, devType devic
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
 func (q *qemu) getSandboxConsole(ctx context.Context, id string) (string, string, error) {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "getSandboxConsole", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "getSandboxConsole", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	consoleURL, err := utils.BuildSocketPath(q.store.RunVMStoragePath(), id, consoleSocket)
@@ -1995,8 +1982,7 @@ func (q *qemu) waitMigration() error {
 }
 
 func (q *qemu) disconnect(ctx context.Context) {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "disconnect", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "disconnect", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	q.qmpShutdown()
@@ -2200,8 +2186,7 @@ func genericAppendPCIeRootPort(devices []govmmQemu.Device, number uint32, machin
 }
 
 func (q *qemu) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "getThreadIDs", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "getThreadIDs", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	tid := vcpuThreadIDs{}
@@ -2266,8 +2251,7 @@ func (q *qemu) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs u
 }
 
 func (q *qemu) cleanup(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "cleanup", qemuTracingTags)
-	katatrace.AddTag(span, "sandbox_id", q.id)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "cleanup", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	for _, fd := range q.fds {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -38,15 +38,12 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 )
 
-// tracingTags defines tags for the trace span
-func (q *qemu) tracingTags() map[string]string {
-	return map[string]string{
-		"source":     "runtime",
-		"package":    "virtcontainers",
-		"subsystem":  "hypervisor",
-		"type":       "qemu",
-		"sandbox_id": q.id,
-	}
+// qemuTracingTags defines tags for the trace span
+var qemuTracingTags = map[string]string{
+	"source":    "runtime",
+	"package":   "virtcontainers",
+	"subsystem": "hypervisor",
+	"type":      "qemu",
 }
 
 // romFile is the file name of the ROM that can be used for virtio-pci devices.
@@ -195,7 +192,8 @@ func (q *qemu) kernelParameters() string {
 
 // Adds all capabilities supported by qemu implementation of hypervisor interface
 func (q *qemu) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "capabilities", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "capabilities", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	return q.arch.capabilities()
@@ -225,7 +223,8 @@ func (q *qemu) qemuPath() (string, error) {
 
 // setup sets the Qemu structure up.
 func (q *qemu) setup(ctx context.Context, id string, hypervisorConfig *HypervisorConfig) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "setup", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "setup", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	err := hypervisorConfig.valid()
@@ -468,7 +467,8 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 	// Save the tracing context
 	q.ctx = ctx
 
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "createSandbox", q.tracingTags())
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "createSandbox", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	if err := q.setup(ctx, id, hypervisorConfig); err != nil {
@@ -753,7 +753,8 @@ func (q *qemu) setupVirtioMem(ctx context.Context) error {
 
 // startSandbox will start the Sandbox's VM.
 func (q *qemu) startSandbox(ctx context.Context, timeout int) error {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "startSandbox", q.tracingTags())
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "startSandbox", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	if q.config.Debug {
@@ -871,7 +872,8 @@ func (q *qemu) bootFromTemplate() error {
 
 // waitSandbox will wait for the Sandbox's VM to be up and running.
 func (q *qemu) waitSandbox(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "waitSandbox", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "waitSandbox", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	if timeout < 0 {
@@ -922,7 +924,8 @@ func (q *qemu) waitSandbox(ctx context.Context, timeout int) error {
 
 // stopSandbox will stop the Sandbox's VM.
 func (q *qemu) stopSandbox(ctx context.Context, waitOnly bool) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "stopSandbox", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "stopSandbox", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	q.Logger().Info("Stopping Sandbox")
@@ -1014,7 +1017,8 @@ func (q *qemu) cleanupVM() error {
 }
 
 func (q *qemu) togglePauseSandbox(ctx context.Context, pause bool) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "togglePauseSandbox", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "togglePauseSandbox", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	if err := q.qmpSetup(); err != nil {
@@ -1619,7 +1623,8 @@ func (q *qemu) hotplugDevice(ctx context.Context, devInfo interface{}, devType d
 }
 
 func (q *qemu) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugAddDevice", q.tracingTags())
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugAddDevice", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 	katatrace.AddTag(span, "device", devInfo)
 
@@ -1632,7 +1637,8 @@ func (q *qemu) hotplugAddDevice(ctx context.Context, devInfo interface{}, devTyp
 }
 
 func (q *qemu) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugRemoveDevice", q.tracingTags())
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugRemoveDevice", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 	katatrace.AddTag(span, "device", devInfo)
 
@@ -1845,14 +1851,16 @@ func (q *qemu) hotplugAddMemory(memDev *memoryDevice) (int, error) {
 }
 
 func (q *qemu) pauseSandbox(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "pauseSandbox", q.tracingTags())
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "pauseSandbox", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	return q.togglePauseSandbox(ctx, true)
 }
 
 func (q *qemu) resumeSandbox(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "resumeSandbox", q.tracingTags())
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "resumeSandbox", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	return q.togglePauseSandbox(ctx, false)
@@ -1861,7 +1869,8 @@ func (q *qemu) resumeSandbox(ctx context.Context) error {
 // addDevice will add extra devices to Qemu command line.
 func (q *qemu) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
 	var err error
-	span, _ := katatrace.Trace(ctx, q.Logger(), "addDevice", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "addDevice", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 	katatrace.AddTag(span, "device", devInfo)
 
@@ -1920,7 +1929,8 @@ func (q *qemu) addDevice(ctx context.Context, devInfo interface{}, devType devic
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
 func (q *qemu) getSandboxConsole(ctx context.Context, id string) (string, string, error) {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "getSandboxConsole", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "getSandboxConsole", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	consoleURL, err := utils.BuildSocketPath(q.store.RunVMStoragePath(), id, consoleSocket)
@@ -1985,7 +1995,8 @@ func (q *qemu) waitMigration() error {
 }
 
 func (q *qemu) disconnect(ctx context.Context) {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "disconnect", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "disconnect", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	q.qmpShutdown()
@@ -2189,7 +2200,8 @@ func genericAppendPCIeRootPort(devices []govmmQemu.Device, number uint32, machin
 }
 
 func (q *qemu) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "getThreadIDs", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "getThreadIDs", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	tid := vcpuThreadIDs{}
@@ -2254,7 +2266,8 @@ func (q *qemu) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs u
 }
 
 func (q *qemu) cleanup(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "cleanup", q.tracingTags())
+	span, _ := katatrace.Trace(ctx, q.Logger(), "cleanup", qemuTracingTags)
+	katatrace.AddTag(span, "sandbox_id", q.id)
 	defer span.End()
 
 	for _, fd := range q.fds {

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -49,14 +49,11 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 )
 
-// tracingTags defines tags for the trace span
-func (s *Sandbox) tracingTags() map[string]string {
-	return map[string]string{
-		"source":     "runtime",
-		"package":    "virtcontainers",
-		"subsystem":  "sandbox",
-		"sandbox_id": s.id,
-	}
+// sandboxTracingTags defines tags for the trace span
+var sandboxTracingTags = map[string]string{
+	"source":    "runtime",
+	"package":   "virtcontainers",
+	"subsystem": "sandbox",
 }
 
 const (
@@ -399,9 +396,8 @@ func (s *Sandbox) IOStream(containerID, processID string) (io.WriteCloser, io.Re
 }
 
 func createAssets(ctx context.Context, sandboxConfig *SandboxConfig) error {
-	span, _ := katatrace.Trace(ctx, nil, "createAssets", nil)
+	span, _ := katatrace.Trace(ctx, nil, "createAssets", sandboxTracingTags)
 	katatrace.AddTag(span, "sandbox_id", sandboxConfig.ID)
-	katatrace.AddTag(span, "subsystem", "sandbox")
 	defer span.End()
 
 	for _, name := range types.AssetTypes() {
@@ -451,9 +447,8 @@ func (s *Sandbox) getAndStoreGuestDetails(ctx context.Context) error {
 // to physically create that sandbox i.e. starts a VM for that sandbox to eventually
 // be started.
 func createSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (*Sandbox, error) {
-	span, ctx := katatrace.Trace(ctx, nil, "createSandbox", nil)
+	span, ctx := katatrace.Trace(ctx, nil, "createSandbox", sandboxTracingTags)
 	katatrace.AddTag(span, "sandbox_id", sandboxConfig.ID)
-	katatrace.AddTag(span, "subsystem", "sandbox")
 	defer span.End()
 
 	if err := createAssets(ctx, &sandboxConfig); err != nil {
@@ -491,9 +486,8 @@ func createSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 }
 
 func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (sb *Sandbox, retErr error) {
-	span, ctx := katatrace.Trace(ctx, nil, "newSandbox", nil)
+	span, ctx := katatrace.Trace(ctx, nil, "newSandbox", sandboxTracingTags)
 	katatrace.AddTag(span, "sandbox_id", sandboxConfig.ID)
-	katatrace.AddTag(span, "subsystem", "sandbox")
 	defer span.End()
 
 	if !sandboxConfig.valid() {
@@ -630,7 +624,8 @@ func (s *Sandbox) createCgroupManager() error {
 
 // storeSandbox stores a sandbox config.
 func (s *Sandbox) storeSandbox(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, s.Logger(), "storeSandbox", s.tracingTags())
+	span, _ := katatrace.Trace(ctx, s.Logger(), "storeSandbox", sandboxTracingTags)
+	katatrace.AddTag(span, "sandbox_id", s.id)
 	defer span.End()
 
 	// flush data to storage
@@ -724,7 +719,8 @@ func (s *Sandbox) Delete(ctx context.Context) error {
 }
 
 func (s *Sandbox) startNetworkMonitor(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "startNetworkMonitor", s.tracingTags())
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "startNetworkMonitor", sandboxTracingTags)
+	katatrace.AddTag(span, "sandbox_id", s.id)
 	defer span.End()
 
 	binPath, err := os.Executable()
@@ -763,7 +759,8 @@ func (s *Sandbox) createNetwork(ctx context.Context) error {
 		return nil
 	}
 
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "createNetwork", s.tracingTags())
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "createNetwork", sandboxTracingTags)
+	katatrace.AddTag(span, "sandbox_id", s.id)
 	defer span.End()
 
 	s.networkNS = NetworkNamespace{
@@ -800,7 +797,8 @@ func (s *Sandbox) postCreatedNetwork(ctx context.Context) error {
 }
 
 func (s *Sandbox) removeNetwork(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "removeNetwork", s.tracingTags())
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "removeNetwork", sandboxTracingTags)
+	katatrace.AddTag(span, "sandbox_id", s.id)
 	defer span.End()
 
 	if s.config.NetworkConfig.NetmonConfig.Enable {
@@ -1116,7 +1114,8 @@ func (s *Sandbox) cleanSwap(ctx context.Context) {
 
 // startVM starts the VM.
 func (s *Sandbox) startVM(ctx context.Context) (err error) {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "startVM", s.tracingTags())
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "startVM", sandboxTracingTags)
+	katatrace.AddTag(span, "sandbox_id", s.id)
 	defer span.End()
 
 	s.Logger().Info("Starting VM")
@@ -1205,7 +1204,8 @@ func (s *Sandbox) startVM(ctx context.Context) (err error) {
 
 // stopVM: stop the sandbox's VM
 func (s *Sandbox) stopVM(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "stopVM", s.tracingTags())
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "stopVM", sandboxTracingTags)
+	katatrace.AddTag(span, "sandbox_id", s.id)
 	defer span.End()
 
 	s.Logger().Info("Stopping sandbox in the VM")
@@ -1558,7 +1558,8 @@ func (s *Sandbox) ResumeContainer(ctx context.Context, containerID string) error
 // createContainers registers all containers, create the
 // containers in the guest and starts one shim per container.
 func (s *Sandbox) createContainers(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "createContainers", s.tracingTags())
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "createContainers", sandboxTracingTags)
+	katatrace.AddTag(span, "sandbox_id", s.id)
 	defer span.End()
 
 	for i := range s.config.Containers {
@@ -1630,7 +1631,8 @@ func (s *Sandbox) Start(ctx context.Context) error {
 // will be destroyed.
 // When force is true, ignore guest related stop failures.
 func (s *Sandbox) Stop(ctx context.Context, force bool) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "Stop", s.tracingTags())
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "Stop", sandboxTracingTags)
+	katatrace.AddTag(span, "sandbox_id", s.id)
 	defer span.End()
 
 	if s.state.State == types.StateStopped {
@@ -1732,7 +1734,8 @@ func (s *Sandbox) unsetSandboxBlockIndex(index int) error {
 // HotplugAddDevice is used for add a device to sandbox
 // Sandbox implement DeviceReceiver interface from device/api/interface.go
 func (s *Sandbox) HotplugAddDevice(ctx context.Context, device api.Device, devType config.DeviceType) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "HotplugAddDevice", s.tracingTags())
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "HotplugAddDevice", sandboxTracingTags)
+	katatrace.AddTag(span, "sandbox_id", s.id)
 	defer span.End()
 
 	if s.config.SandboxCgroupOnly {

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -396,8 +396,7 @@ func (s *Sandbox) IOStream(containerID, processID string) (io.WriteCloser, io.Re
 }
 
 func createAssets(ctx context.Context, sandboxConfig *SandboxConfig) error {
-	span, _ := katatrace.Trace(ctx, nil, "createAssets", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", sandboxConfig.ID)
+	span, _ := katatrace.Trace(ctx, nil, "createAssets", sandboxTracingTags, map[string]string{"sandbox_id": sandboxConfig.ID})
 	defer span.End()
 
 	for _, name := range types.AssetTypes() {
@@ -447,8 +446,7 @@ func (s *Sandbox) getAndStoreGuestDetails(ctx context.Context) error {
 // to physically create that sandbox i.e. starts a VM for that sandbox to eventually
 // be started.
 func createSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (*Sandbox, error) {
-	span, ctx := katatrace.Trace(ctx, nil, "createSandbox", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", sandboxConfig.ID)
+	span, ctx := katatrace.Trace(ctx, nil, "createSandbox", sandboxTracingTags, map[string]string{"sandbox_id": sandboxConfig.ID})
 	defer span.End()
 
 	if err := createAssets(ctx, &sandboxConfig); err != nil {
@@ -486,8 +484,7 @@ func createSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Fac
 }
 
 func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factory) (sb *Sandbox, retErr error) {
-	span, ctx := katatrace.Trace(ctx, nil, "newSandbox", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", sandboxConfig.ID)
+	span, ctx := katatrace.Trace(ctx, nil, "newSandbox", sandboxTracingTags, map[string]string{"sandbox_id": sandboxConfig.ID})
 	defer span.End()
 
 	if !sandboxConfig.valid() {
@@ -624,8 +621,7 @@ func (s *Sandbox) createCgroupManager() error {
 
 // storeSandbox stores a sandbox config.
 func (s *Sandbox) storeSandbox(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, s.Logger(), "storeSandbox", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", s.id)
+	span, _ := katatrace.Trace(ctx, s.Logger(), "storeSandbox", sandboxTracingTags, map[string]string{"sandbox_id": s.id})
 	defer span.End()
 
 	// flush data to storage
@@ -719,8 +715,7 @@ func (s *Sandbox) Delete(ctx context.Context) error {
 }
 
 func (s *Sandbox) startNetworkMonitor(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "startNetworkMonitor", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", s.id)
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "startNetworkMonitor", sandboxTracingTags, map[string]string{"sandbox_id": s.id})
 	defer span.End()
 
 	binPath, err := os.Executable()
@@ -759,8 +754,7 @@ func (s *Sandbox) createNetwork(ctx context.Context) error {
 		return nil
 	}
 
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "createNetwork", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", s.id)
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "createNetwork", sandboxTracingTags, map[string]string{"sandbox_id": s.id})
 	defer span.End()
 
 	s.networkNS = NetworkNamespace{
@@ -797,8 +791,7 @@ func (s *Sandbox) postCreatedNetwork(ctx context.Context) error {
 }
 
 func (s *Sandbox) removeNetwork(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "removeNetwork", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", s.id)
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "removeNetwork", sandboxTracingTags, map[string]string{"sandbox_id": s.id})
 	defer span.End()
 
 	if s.config.NetworkConfig.NetmonConfig.Enable {
@@ -1114,8 +1107,7 @@ func (s *Sandbox) cleanSwap(ctx context.Context) {
 
 // startVM starts the VM.
 func (s *Sandbox) startVM(ctx context.Context) (err error) {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "startVM", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", s.id)
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "startVM", sandboxTracingTags, map[string]string{"sandbox_id": s.id})
 	defer span.End()
 
 	s.Logger().Info("Starting VM")
@@ -1204,8 +1196,7 @@ func (s *Sandbox) startVM(ctx context.Context) (err error) {
 
 // stopVM: stop the sandbox's VM
 func (s *Sandbox) stopVM(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "stopVM", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", s.id)
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "stopVM", sandboxTracingTags, map[string]string{"sandbox_id": s.id})
 	defer span.End()
 
 	s.Logger().Info("Stopping sandbox in the VM")
@@ -1558,8 +1549,7 @@ func (s *Sandbox) ResumeContainer(ctx context.Context, containerID string) error
 // createContainers registers all containers, create the
 // containers in the guest and starts one shim per container.
 func (s *Sandbox) createContainers(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "createContainers", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", s.id)
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "createContainers", sandboxTracingTags, map[string]string{"sandbox_id": s.id})
 	defer span.End()
 
 	for i := range s.config.Containers {
@@ -1631,8 +1621,7 @@ func (s *Sandbox) Start(ctx context.Context) error {
 // will be destroyed.
 // When force is true, ignore guest related stop failures.
 func (s *Sandbox) Stop(ctx context.Context, force bool) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "Stop", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", s.id)
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "Stop", sandboxTracingTags, map[string]string{"sandbox_id": s.id})
 	defer span.End()
 
 	if s.state.State == types.StateStopped {
@@ -1734,8 +1723,7 @@ func (s *Sandbox) unsetSandboxBlockIndex(index int) error {
 // HotplugAddDevice is used for add a device to sandbox
 // Sandbox implement DeviceReceiver interface from device/api/interface.go
 func (s *Sandbox) HotplugAddDevice(ctx context.Context, device api.Device, devType config.DeviceType) error {
-	span, ctx := katatrace.Trace(ctx, s.Logger(), "HotplugAddDevice", sandboxTracingTags)
-	katatrace.AddTag(span, "sandbox_id", s.id)
+	span, ctx := katatrace.Trace(ctx, s.Logger(), "HotplugAddDevice", sandboxTracingTags, map[string]string{"sandbox_id": s.id})
 	defer span.End()
 
 	if s.config.SandboxCgroupOnly {


### PR DESCRIPTION
1. Tracing tags are stored inconsistently throughout the runtime. Change
all instances of tracing tags to variables.

2. Add function so that you can dynamically add more attributes when calling `katatrace.Trace()`

Fixes #2512 