### PR TITLE
workflow: fix require-pr-porting-labels

### DIFF
--- a/.github/workflows/require-pr-porting-labels.yaml
+++ b/.github/workflows/require-pr-porting-labels.yaml
@@ -12,8 +12,8 @@ on:
       - reopened
       - labeled
       - unlabeled
-   pull_request:
-     branches:
+  pull_request:
+    branches:
       - main
 
 jobs:


### PR DESCRIPTION
Change the indent of workflow file to make it valid

Fixes: #2506

Signed-off-by: Yujia Qiao <rapiz3142@gmail.com>