### PR TITLE
backport: build_image: Fix error soft link about initrd.img

### DIFF
--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -36,7 +36,7 @@ build_initrd() {
 	mv "kata-containers-initrd.img" "${install_dir}/${initrd_name}"
 	(
 		cd "${install_dir}"
-		ln -sf "${builddir}" kata-containers-initrd.img
+		ln -sf "${initrd_name}" kata-containers-initrd.img
 	)
 }
 


### PR DESCRIPTION
fix error soft link about initrd.img

Fixes #2503

backport PR: https://github.com/kata-containers/kata-containers/pull/2504

Signed-off-by: Binbin Zhang <binbin36520@gmail.com>