### PR TITLE
runtime: delete types or const that no longer needed

### DIFF
--- a/src/runtime/virtcontainers/agent.go
+++ b/src/runtime/virtcontainers/agent.go
@@ -38,27 +38,6 @@ func WithNewAgentFunc(ctx context.Context, f newAgentFuncType) context.Context {
 	return context.WithValue(ctx, newAgentFuncKey{}, f)
 }
 
-// ProcessListOptions contains the options used to list running
-// processes inside the container
-type ProcessListOptions struct {
-	// Format describes the output format to list the running processes.
-	// Formats are unrelated to ps(1) formats, only two formats can be specified:
-	// "json" and "table"
-	Format string
-
-	// Args contains the list of arguments to run ps(1) command.
-	// If Args is empty the agent will use "-ef" as options to ps(1).
-	Args []string
-}
-
-// ProcessList represents the list of running processes inside the container
-type ProcessList []byte
-
-const (
-	// SocketTypeVSOCK is a VSOCK socket type for talking to an agent.
-	SocketTypeVSOCK = "vsock"
-)
-
 // agent is the virtcontainers agent interface.
 // Agents are running in the guest VM and handling
 // communications between the host and guest.

--- a/src/runtime/virtcontainers/documentation/api/1.0/api.md
+++ b/src/runtime/virtcontainers/documentation/api/1.0/api.md
@@ -680,7 +680,6 @@ to manage the container lifecycle through the rest of the
   * [Container `DeviceInfo`](#container-deviceinfo)
 * [`Process`](#process)
 * [`ContainerStatus`](#containerstatus)
-* [`ProcessListOptions`](#processlistoptions)
 * [`VCContainer`](#vccontainer)
 
 
@@ -870,22 +869,6 @@ type ContainerStatus struct {
 	// for example to add additional status values required
 	// to support particular specifications.
 	Annotations map[string]string
-}
-```
-
-#### `ProcessListOptions`
-```Go
-// ProcessListOptions contains the options used to list running
-// processes inside the container
-type ProcessListOptions struct {
-	// Format describes the output format to list the running processes.
-	// Formats are unrelated to ps(1) formats, only two formats can be specified:
-	// "json" and "table"
-	Format string
-
-	// Args contains the list of arguments to run ps(1) command.
-	// If Args is empty the agent will use "-ef" as options to ps(1).
-	Args []string
 }
 ```
 


### PR DESCRIPTION
type: ProcessListOptions; ProcessList
const: SocketTypeVSOCK

Fixes: #2285

Signed-off-by: Binbin Zhang <binbin36520@gmail.com>