### PR TITLE
drop qemu-lite support

### DIFF
--- a/docs/how-to/what-is-vm-templating-and-how-do-I-use-it.md
+++ b/docs/how-to/what-is-vm-templating-and-how-do-I-use-it.md
@@ -47,7 +47,7 @@ and can be classified as potentially misunderstood behaviors rather than vulnera
 VM templating can be enabled by changing your Kata Containers config file (`/usr/share/defaults/kata-containers/configuration.toml`,
 overridden by `/etc/kata-containers/configuration.toml` if provided) such that:
 
-  - `qemu-lite` is specified in `hypervisor.qemu`->`path` section
+  - `qemu` version `v4.1.0` or above is specified in `hypervisor.qemu`->`path` section
   - `enable_template = true`
   - `initrd =` is set
   - `image =` option is commented out or removed

--- a/src/runtime/cli/main_test.go
+++ b/src/runtime/cli/main_test.go
@@ -210,7 +210,7 @@ func newTestHypervisorConfig(dir string, create bool) (vc.HypervisorConfig, erro
 		KernelPath:            kernelPath,
 		ImagePath:             imagePath,
 		HypervisorPath:        hypervisorPath,
-		HypervisorMachineType: "pc-lite",
+		HypervisorMachineType: "q35",
 	}, nil
 }
 

--- a/src/runtime/containerd-shim-v2/utils_test.go
+++ b/src/runtime/containerd-shim-v2/utils_test.go
@@ -192,7 +192,7 @@ func newTestHypervisorConfig(dir string, create bool) (vc.HypervisorConfig, erro
 		KernelPath:            kernelPath,
 		ImagePath:             imagePath,
 		HypervisorPath:        hypervisorPath,
-		HypervisorMachineType: "pc-lite",
+		HypervisorMachineType: "q35",
 	}, nil
 }
 

--- a/src/runtime/pkg/katautils/config-settings.go.in
+++ b/src/runtime/pkg/katautils/config-settings.go.in
@@ -8,7 +8,7 @@
 
 package katautils
 
-var defaultHypervisorPath = "/usr/bin/qemu-lite-system-x86_64"
+var defaultHypervisorPath = "/usr/bin/qemu-system-x86_64"
 var defaultHypervisorCtlPath = "/usr/bin/acrnctl"
 var defaultJailerPath = "/usr/bin/jailer"
 var defaultImagePath = "/usr/share/kata-containers/kata-containers.img"

--- a/src/runtime/pkg/katautils/create_test.go
+++ b/src/runtime/pkg/katautils/create_test.go
@@ -138,7 +138,7 @@ func newTestHypervisorConfig(dir string, create bool) (vc.HypervisorConfig, erro
 		KernelPath:            kernelPath,
 		ImagePath:             imagePath,
 		HypervisorPath:        hypervisorPath,
-		HypervisorMachineType: "pc-lite",
+		HypervisorMachineType: "q35",
 	}, nil
 }
 

--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -43,7 +43,6 @@ const (
 )
 
 var qemuPaths = map[string]string{
-	QemuPCLite:  "/usr/bin/qemu-lite-system-x86_64",
 	QemuQ35:     defaultQemuPath,
 	QemuMicrovm: defaultQemuPath,
 }
@@ -66,10 +65,6 @@ var kernelParams = []Param{
 }
 
 var supportedQemuMachines = []govmmQemu.Machine{
-	{
-		Type:    QemuPCLite,
-		Options: defaultQemuMachineOptions,
-	},
 	{
 		Type:    QemuQ35,
 		Options: defaultQemuMachineOptions,

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -209,9 +209,6 @@ const (
 const bridgePCIStartAddr = 2
 
 const (
-	// QemuPCLite is the QEMU pc-lite machine type for amd64
-	QemuPCLite = "pc-lite"
-
 	// QemuQ35 is the QEMU Q35 machine type for amd64
 	QemuQ35 = "q35"
 

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -158,7 +158,7 @@ func TestQemuAddDeviceToBridge(t *testing.T) {
 
 	// addDeviceToBridge fails cause q.Bridges == 0
 	q = newQemuArchBase()
-	q.qemuMachine.Type = QemuPCLite
+	q.qemuMachine.Type = QemuQ35
 	q.bridges(0)
 	_, _, err = q.addDeviceToBridge(context.Background(), "qemu-bridge", types.PCI)
 	if assert.Error(err) {


### PR DESCRIPTION
qemu-lite project has not seen any activity for more than 5 years. We have not been testing against it for a very long time either. Let's just drop the related code.