### PR TITLE
versions: Upgrade to Cloud Hypervisor v18.0

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -240,7 +240,6 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 	clh.vmconfig.Memory = chclient.NewMemoryConfig(int64((utils.MemUnit(clh.config.MemorySize) * utils.MiB).ToBytes()))
 	// shared memory should be enabled if using vhost-user(kata uses virtiofsd)
 	clh.vmconfig.Memory.Shared = func(b bool) *bool { return &b }(true)
-	clh.vmconfig.Memory.HotplugMethod = func(s string) *string { return &s }("Acpi")
 	hostMemKb, err := getHostMemorySizeKb(procMemInfo)
 	if err != nil {
 		return nil
@@ -1116,7 +1115,6 @@ func (clh *cloudHypervisor) addNet(e Endpoint) error {
 	net := chclient.NewNetConfig()
 	net.Mac = &mac
 	net.Tap = &tapPath
-	net.VhostMode = func(s string) *string { return &s }("Client")
 	if clh.vmconfig.Net != nil {
 		*clh.vmconfig.Net = append(*clh.vmconfig.Net, *net)
 	} else {

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -383,7 +383,7 @@ components:
               id: id
               hotplug_size: 1
             hotplug_size: 3
-            hotplug_method: acpi
+            hotplug_method: Acpi
           disks:
           - path: path
             num_queues: 7
@@ -540,7 +540,7 @@ components:
                 one_time_burst: 0
                 refill_time: 0
             mac: mac
-            vhost_mode: client
+            vhost_mode: Client
             iommu: false
             vhost_socket: vhost_socket
             vhost_user: false
@@ -563,7 +563,7 @@ components:
                 one_time_burst: 0
                 refill_time: 0
             mac: mac
-            vhost_mode: client
+            vhost_mode: Client
             iommu: false
             vhost_socket: vhost_socket
             vhost_user: false
@@ -688,7 +688,7 @@ components:
             id: id
             hotplug_size: 1
           hotplug_size: 3
-          hotplug_method: acpi
+          hotplug_method: Acpi
         disks:
         - path: path
           num_queues: 7
@@ -845,7 +845,7 @@ components:
               one_time_burst: 0
               refill_time: 0
           mac: mac
-          vhost_mode: client
+          vhost_mode: Client
           iommu: false
           vhost_socket: vhost_socket
           vhost_user: false
@@ -868,7 +868,7 @@ components:
               one_time_burst: 0
               refill_time: 0
           mac: mac
-          vhost_mode: client
+          vhost_mode: Client
           iommu: false
           vhost_socket: vhost_socket
           vhost_user: false
@@ -1053,7 +1053,7 @@ components:
           id: id
           hotplug_size: 1
         hotplug_size: 3
-        hotplug_method: acpi
+        hotplug_method: Acpi
       properties:
         size:
           format: int64
@@ -1068,7 +1068,7 @@ components:
           default: false
           type: boolean
         hotplug_method:
-          default: acpi
+          default: Acpi
           type: string
         shared:
           default: false
@@ -1236,7 +1236,7 @@ components:
             one_time_burst: 0
             refill_time: 0
         mac: mac
-        vhost_mode: client
+        vhost_mode: Client
         iommu: false
         vhost_socket: vhost_socket
         vhost_user: false
@@ -1272,7 +1272,7 @@ components:
         vhost_socket:
           type: string
         vhost_mode:
-          default: client
+          default: Client
           type: string
         id:
           type: string

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/MemoryConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/MemoryConfig.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **HotplugSize** | Pointer to **int64** |  | [optional] 
 **HotpluggedSize** | Pointer to **int64** |  | [optional] 
 **Mergeable** | Pointer to **bool** |  | [optional] [default to false]
-**HotplugMethod** | Pointer to **string** |  | [optional] [default to "acpi"]
+**HotplugMethod** | Pointer to **string** |  | [optional] [default to "Acpi"]
 **Shared** | Pointer to **bool** |  | [optional] [default to false]
 **Hugepages** | Pointer to **bool** |  | [optional] [default to false]
 **HugepageSize** | Pointer to **int64** |  | [optional] 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
@@ -13,7 +13,7 @@ Name | Type | Description | Notes
 **QueueSize** | Pointer to **int32** |  | [optional] [default to 256]
 **VhostUser** | Pointer to **bool** |  | [optional] [default to false]
 **VhostSocket** | Pointer to **string** |  | [optional] 
-**VhostMode** | Pointer to **string** |  | [optional] [default to "client"]
+**VhostMode** | Pointer to **string** |  | [optional] [default to "Client"]
 **Id** | Pointer to **string** |  | [optional] 
 **Fd** | Pointer to **[]int32** |  | [optional] 
 **RateLimiterConfig** | Pointer to [**RateLimiterConfig**](RateLimiterConfig.md) |  | [optional] 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_memory_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_memory_config.go
@@ -36,7 +36,7 @@ func NewMemoryConfig(size int64) *MemoryConfig {
 	this.Size = size
 	var mergeable bool = false
 	this.Mergeable = &mergeable
-	var hotplugMethod string = "acpi"
+	var hotplugMethod string = "Acpi"
 	this.HotplugMethod = &hotplugMethod
 	var shared bool = false
 	this.Shared = &shared
@@ -52,7 +52,7 @@ func NewMemoryConfigWithDefaults() *MemoryConfig {
 	this := MemoryConfig{}
 	var mergeable bool = false
 	this.Mergeable = &mergeable
-	var hotplugMethod string = "acpi"
+	var hotplugMethod string = "Acpi"
 	this.HotplugMethod = &hotplugMethod
 	var shared bool = false
 	this.Shared = &shared

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
@@ -51,7 +51,7 @@ func NewNetConfig() *NetConfig {
 	this.QueueSize = &queueSize
 	var vhostUser bool = false
 	this.VhostUser = &vhostUser
-	var vhostMode string = "client"
+	var vhostMode string = "Client"
 	this.VhostMode = &vhostMode
 	return &this
 }
@@ -75,7 +75,7 @@ func NewNetConfigWithDefaults() *NetConfig {
 	this.QueueSize = &queueSize
 	var vhostUser bool = false
 	this.VhostUser = &vhostUser
-	var vhostMode string = "client"
+	var vhostMode string = "Client"
 	this.VhostMode = &vhostMode
 	return &this
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -567,7 +567,7 @@ components:
           default: false
         hotplug_method:
           type: string
-          default: "acpi"
+          default: "Acpi"
         shared:
           type: boolean
           default: false
@@ -714,7 +714,7 @@ components:
           type: string
         vhost_mode:
           type: string
-          default: "client"
+          default: "Client"
         id:
           type: string
         fd:

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v17.0"
+      version: "v18.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
Highlights from the Cloud Hypervisor release v18.0:

1. Experimental User Device (`vfio-user`) support;
2. Migration support for `vhost-user` devices;
3. VHDX disk image support
4. Device pass through on MSHV hypervisor
5. AArch64 for support `virtio-mem`
6. Live migration on MSHV hypervisor
7. AArch64 CPU topology support
8. Power button support on AArch64
9. Various bug fixes on PTY, TTY, signal handling, and live-migration on AArch64

Details can be found: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v18.0

Note: The client code of cloud-hypervisor's (CLH) OpenAPI is automatically
generated by openapi-generator [1-2]. Small changes has been made to
CLH's openapi spec file for fixing couple minor bugs [3], and hence small
changes are made from the Kata side.

[1] https://github.com/OpenAPITools/openapi-generator
[2] https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/pkg/cloud-hypervisor/README.md
[3] https://github.com/cloud-hypervisor/cloud-hypervisor/pull/3029

Fixes: #2543