### PR TITLE
osbuilder: fix inconsistent calculation of fs size

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -242,7 +242,7 @@ calculate_required_disk_size() {
 	local fs_type="$2"
 	local block_size="$3"
 
-	readonly rootfs_size_mb=$(du -B 1MB -s "${rootfs}" | awk '{print $1}')
+	readonly rootfs_size_mb=$(du -B 1M -s "${rootfs}" | awk '{print $1}')
 	readonly image="$(mktemp)"
 	readonly mount_dir="$(mktemp -d)"
 	readonly max_tries=20


### PR DESCRIPTION
This patch fixes inconsistent calculations of the rootfs size.
For `du` and `df`, `-B 1MB` is different from `-BM`. The former is the power of 1000, and the latter is the power of 1024. So comparing them doesn't make sense. The bug may result in a larger image than needed.

Fixes: #2560

Signed-off-by: Yujia Qiao <rapiz3142@gmail.com>

PTAL @devimc