### PR TITLE
WIP: virtio: add nydus support

### DIFF
--- a/docs/how-to/how-to-use-virtio-fs-nydus-with-kata.md
+++ b/docs/how-to/how-to-use-virtio-fs-nydus-with-kata.md
@@ -6,14 +6,12 @@ Research shows that time to take for pull operation accounts for 76% of containe
 
 The feature is not completely finished, if you want to try, you can do as follows,
 
-1. Modify nydus-snapshotter code as [commit](https://github.com/luodw/image-service/commit/e3499aefa3a1b5aa073d332ad3553335a93765ee);
+1. Use nydus-snapshotter branch [https://github.com/dragonflyoss/image-service/pull/184](https://github.com/dragonflyoss/image-service/pull/184)
 
-2. Modify containerd code as [commit](https://github.com/luodw/containerd/commit/5ce208e2d79da8c14330e24c9b1253fa07b81605);
+2. Depoly nydus run environment as [Nydus Setup for Containerd Environment](https://github.com/dragonflyoss/image-service/blob/master/docs/containerd-env-setup.md);
 
-3. Depoly nydus run environment as [Nydus Setup for Containerd Environment](https://github.com/dragonflyoss/image-service/blob/master/docs/containerd-env-setup.md);
+3. Use kata-containers `support_nydus` branch to compile and build kata-containers.img;
 
-4. Use kata-containers `support_nydus` branch to compile and build kata-containers.img;
+4. Update shared_fs to `virtio-fs-nydus` [here](https://github.com/luodw/kata-containers/blob/support_nydus/src/runtime/cli/config/configuration-qemu.toml.in#L134);
 
-5. Update shared_fs to `virtio-fs-nydus` [here](https://github.com/luodw/kata-containers/blob/support_nydus/src/runtime/cli/config/configuration-qemu.toml.in#L134);
-
-6. As kata-shim,nydusd,qemu are in isolated net namespace, nydusd can not connect to hub in my local env, so I run nydus image in runc first to cache the blob, and next you can run kata containers with nydusd format image as usual. `crictl run -r kata-qemu container-config.yaml pod-config.yaml`
+5. As kata-shim,nydusd,qemu are in isolated net namespace, nydusd can not connect to hub in my local env, so I run nydus image in runc first to cache the blob, and next you can run kata containers with nydusd format image as usual. `crictl run -r kata-qemu container-config.yaml pod-config.yaml`

--- a/docs/how-to/how-to-use-virtio-fs-nydus-with-kata.md
+++ b/docs/how-to/how-to-use-virtio-fs-nydus-with-kata.md
@@ -1,0 +1,19 @@
+# Kata Containers with virtio-fs-nydus
+
+## Introduction
+
+Research shows that time to take for pull operation accounts for 76% of container startup time but only 6.4% of that data is read. so if we can get data on demand(lazyload), it will speed up the container start. [Nydusd](https://github.com/dragonflyoss/image-service) is the project which build image with new format and can get data on demand when container start.
+
+The feature is not completely finished, if you want to try, you can do as follows,
+
+1. Modify nydus-snapshotter code as [commit](https://github.com/luodw/image-service/commit/e3499aefa3a1b5aa073d332ad3553335a93765ee);
+
+2. Modify containerd code as [commit](https://github.com/luodw/containerd/commit/5ce208e2d79da8c14330e24c9b1253fa07b81605);
+
+3. Depoly nydus run environment as [Nydus Setup for Containerd Environment](https://github.com/dragonflyoss/image-service/blob/master/docs/containerd-env-setup.md);
+
+4. Use kata-containers `support_nydus` branch to compile and build kata-containers.img;
+
+5. Update shared_fs to `virtio-fs-nydus` [here](https://github.com/luodw/kata-containers/blob/support_nydus/src/runtime/cli/config/configuration-qemu.toml.in#L134);
+
+6. As kata-shim,nydusd,qemu are in isolated net namespace, nydusd can not connect to hub in my local env, so I run nydus image in runc first to cache the blob, and next you can run kata containers with nydusd format image as usual. `crictl run -r kata-qemu container-config.yaml pod-config.yaml`

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -12,6 +12,7 @@ use std::io::{BufRead, BufReader};
 use std::iter;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;
+use std::path::PathBuf;
 use std::ptr::null;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -45,6 +46,7 @@ pub const DRIVER_MMIO_BLK_TYPE: &str = "mmioblk";
 pub const DRIVER_SCSI_TYPE: &str = "scsi";
 pub const DRIVER_NVDIMM_TYPE: &str = "nvdimm";
 pub const DRIVER_EPHEMERAL_TYPE: &str = "ephemeral";
+pub const DRIVER_NYDUS_TYPE: &str = "nydus-overlay";
 pub const DRIVER_LOCAL_TYPE: &str = "local";
 pub const DRIVER_WATCHABLE_BIND_TYPE: &str = "watchable-bind";
 
@@ -52,6 +54,8 @@ pub const TYPE_ROOTFS: &str = "rootfs";
 
 pub const MOUNT_GUEST_TAG: &str = "kataShared";
 
+pub const SNAPSHOTDIR: &str = "snapshotdir";
+pub const LOWERDIR: &str = "lowerdir";
 // Allocating an FSGroup that owns the pod's volumes
 const FS_GID: &str = "fsgid";
 
@@ -142,6 +146,7 @@ pub const STORAGE_HANDLER_LIST: &[&str] = &[
     DRIVER_9P_TYPE,
     DRIVER_VIRTIOFS_TYPE,
     DRIVER_EPHEMERAL_TYPE,
+    DRIVER_NYDUS_TYPE,
     DRIVER_MMIO_BLK_TYPE,
     DRIVER_LOCAL_TYPE,
     DRIVER_SCSI_TYPE,
@@ -285,6 +290,52 @@ async fn ephemeral_storage_handler(
         common_storage_handler(logger, storage)?;
     }
 
+    Ok("".to_string())
+}
+
+#[instrument]
+async fn nydus_storage_handler(
+    _logger: &Logger,
+    storage: &Storage,
+    sandbox: Arc<Mutex<Sandbox>>,
+) -> Result<String> {
+    let logger = _logger.new(o!("subsystem" => "mount", "driver"=> "nydus"));
+    let opts_vec: Vec<String> = storage.driver_options.to_vec();
+    let opts = parse_options(opts_vec);
+
+    let snapshot_dir=  opts.get(SNAPSHOTDIR).ok_or_else(||
+        anyhow!("failed to get snapshot_dir"))?;
+    let lower_dir = opts.get(LOWERDIR).ok_or_else(||
+        anyhow!("failed to get lower_dir"))?;
+
+
+    let mut upper_path = PathBuf::from(snapshot_dir);
+    upper_path.push("fs");
+    let upper_dir = upper_path.to_str().ok_or_else(||
+        anyhow!("failed to get upper_dir"))?;
+    fs::create_dir_all(upper_dir)?;
+
+    let mut work_path = PathBuf::from(snapshot_dir);
+    work_path.push("work");
+    let work_dir = work_path.to_str().ok_or_else(||
+        anyhow!("failed to get work_dir"))?;
+    fs::create_dir_all(work_dir)?;
+
+    let mut options: String = "".to_string();
+    options.push_str(format!("workdir={}", work_dir).as_str());
+    options.push_str(format!(",upperdir={}", upper_dir).as_str());
+    options.push_str(format!(",lowerdir={}", lower_dir).as_str());
+    options.push_str(",index=off");
+
+    let dest = storage.mount_point.as_str();
+    let bare_mount = BareMount::new("overlay",dest,
+      "overlay", MsFlags::empty(), options.as_str(), &logger);
+
+    info!(logger, "mounting storage dest: {}, options: {}", dest, options.as_str());
+
+    bare_mount.mount().or_else(|e| {
+        return Err(e);
+    })?;
     Ok("".to_string())
 }
 
@@ -598,6 +649,9 @@ pub async fn add_storages(
             }
             DRIVER_EPHEMERAL_TYPE => {
                 ephemeral_storage_handler(&logger, &storage, sandbox.clone()).await
+            }
+            DRIVER_NYDUS_TYPE => {
+                nydus_storage_handler(&logger, &storage, sandbox.clone()).await
             }
             DRIVER_MMIO_BLK_TYPE => {
                 virtiommio_blk_storage_handler(&logger, &storage, sandbox.clone()).await

--- a/src/runtime/cli/config/configuration-qemu.toml.in
+++ b/src/runtime/cli/config/configuration-qemu.toml.in
@@ -130,7 +130,7 @@ disable_block_device_use = @DEFDISABLEBLOCK@
 # Shared file system type:
 #   - virtio-fs (default)
 #   - virtio-9p
-#   - virtio-nydus
+#   - virtio-fs-nydus
 shared_fs = "@DEFSHAREDFS_QEMU_VIRTIOFS@"
 
 # Path to nydusd daemon

--- a/src/runtime/cli/config/configuration-qemu.toml.in
+++ b/src/runtime/cli/config/configuration-qemu.toml.in
@@ -130,7 +130,11 @@ disable_block_device_use = @DEFDISABLEBLOCK@
 # Shared file system type:
 #   - virtio-fs (default)
 #   - virtio-9p
+#   - virtio-nydus
 shared_fs = "@DEFSHAREDFS_QEMU_VIRTIOFS@"
+
+# Path to nydusd daemon
+virtio_fs_nydusd="/usr/libexec/kata-qemu/nydusd"
 
 # Path to vhost-user-fs daemon.
 virtio_fs_daemon = "@DEFVIRTIOFSDAEMON@"

--- a/src/runtime/containerd-shim-v2/create.go
+++ b/src/runtime/containerd-shim-v2/create.go
@@ -228,6 +228,10 @@ func checkAndMount(s *service, r *taskAPI.CreateTaskRequest) (bool, error) {
 		if katautils.IsBlockDevice(m.Source) && !s.config.HypervisorConfig.DisableBlockDeviceUse {
 			return false, nil
 		}
+		if m.Type == "nydus" {
+			// if kata + nydus, do not mount
+			return false, nil
+		}
 	}
 	rootfs := filepath.Join(r.Bundle, "rootfs")
 	if err := doMount(r.Rootfs, rootfs); err != nil {

--- a/src/runtime/containerd-shim-v2/create.go
+++ b/src/runtime/containerd-shim-v2/create.go
@@ -228,7 +228,7 @@ func checkAndMount(s *service, r *taskAPI.CreateTaskRequest) (bool, error) {
 		if katautils.IsBlockDevice(m.Source) && !s.config.HypervisorConfig.DisableBlockDeviceUse {
 			return false, nil
 		}
-		if m.Type == "nydus" {
+		if m.Type == vc.NydusRootFSType {
 			// if kata + nydus, do not mount
 			return false, nil
 		}

--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/blang/semver/v4 v4.0.0
+	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/containerd/cgroups v1.0.1
 	github.com/containerd/console v1.0.2
 	github.com/containerd/containerd v1.5.4

--- a/src/runtime/go.sum
+++ b/src/runtime/go.sum
@@ -86,6 +86,8 @@ github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/buger/jsonparser v0.0.0-20180808090653-f4dd9f5a6b44/go.mod h1:bbYlZJ7hK1yFx9hf58LP0zeX7UjIGs20ufpu3evjr+s=
+github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
+github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=

--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -222,7 +222,7 @@ func CreateContainer(ctx context.Context, sandbox vc.VCSandbox, ociSpec specs.Sp
 	}
 
 	if !rootFs.Mounted {
-		if rootFs.Source != "" {
+		if rootFs.Source != "" && rootFs.Type != "nydus" {
 			realPath, err := ResolvePath(rootFs.Source)
 			if err != nil {
 				return vc.Process{}, err

--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -222,7 +222,7 @@ func CreateContainer(ctx context.Context, sandbox vc.VCSandbox, ociSpec specs.Sp
 	}
 
 	if !rootFs.Mounted {
-		if rootFs.Source != "" && rootFs.Type != "nydus" {
+		if rootFs.Source != "" && rootFs.Type != vc.NydusRootFSType {
 			realPath, err := ResolvePath(rootFs.Source)
 			if err != nil {
 				return vc.Process{}, err
@@ -231,7 +231,6 @@ func CreateContainer(ctx context.Context, sandbox vc.VCSandbox, ociSpec specs.Sp
 		}
 		contConfig.RootFs = rootFs
 	}
-
 	sandboxID, err := oci.SandboxID(ociSpec)
 	if err != nil {
 		return vc.Process{}, err

--- a/src/runtime/vendor/github.com/cenkalti/backoff/.gitignore
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/.gitignore
@@ -1,0 +1,22 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe

--- a/src/runtime/vendor/github.com/cenkalti/backoff/.travis.yml
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go:
+  - 1.7
+  - 1.x
+  - tip
+before_install:
+  - go get github.com/mattn/goveralls
+  - go get golang.org/x/tools/cmd/cover
+script:
+  - $HOME/gopath/bin/goveralls -service=travis-ci

--- a/src/runtime/vendor/github.com/cenkalti/backoff/LICENSE
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2014 Cenk Altı
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/runtime/vendor/github.com/cenkalti/backoff/README.md
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/README.md
@@ -1,0 +1,30 @@
+# Exponential Backoff [![GoDoc][godoc image]][godoc] [![Build Status][travis image]][travis] [![Coverage Status][coveralls image]][coveralls]
+
+This is a Go port of the exponential backoff algorithm from [Google's HTTP Client Library for Java][google-http-java-client].
+
+[Exponential backoff][exponential backoff wiki]
+is an algorithm that uses feedback to multiplicatively decrease the rate of some process,
+in order to gradually find an acceptable rate.
+The retries exponentially increase and stop increasing when a certain threshold is met.
+
+## Usage
+
+See https://godoc.org/github.com/cenkalti/backoff#pkg-examples
+
+## Contributing
+
+* I would like to keep this library as small as possible.
+* Please don't send a PR without opening an issue and discussing it first.
+* If proposed change is not a common use case, I will probably not accept it.
+
+[godoc]: https://godoc.org/github.com/cenkalti/backoff
+[godoc image]: https://godoc.org/github.com/cenkalti/backoff?status.png
+[travis]: https://travis-ci.org/cenkalti/backoff
+[travis image]: https://travis-ci.org/cenkalti/backoff.png?branch=master
+[coveralls]: https://coveralls.io/github/cenkalti/backoff?branch=master
+[coveralls image]: https://coveralls.io/repos/github/cenkalti/backoff/badge.svg?branch=master
+
+[google-http-java-client]: https://github.com/google/google-http-java-client/blob/da1aa993e90285ec18579f1553339b00e19b3ab5/google-http-client/src/main/java/com/google/api/client/util/ExponentialBackOff.java
+[exponential backoff wiki]: http://en.wikipedia.org/wiki/Exponential_backoff
+
+[advanced example]: https://godoc.org/github.com/cenkalti/backoff#example_

--- a/src/runtime/vendor/github.com/cenkalti/backoff/backoff.go
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/backoff.go
@@ -1,0 +1,66 @@
+// Package backoff implements backoff algorithms for retrying operations.
+//
+// Use Retry function for retrying operations that may fail.
+// If Retry does not meet your needs,
+// copy/paste the function into your project and modify as you wish.
+//
+// There is also Ticker type similar to time.Ticker.
+// You can use it if you need to work with channels.
+//
+// See Examples section below for usage examples.
+package backoff
+
+import "time"
+
+// BackOff is a backoff policy for retrying an operation.
+type BackOff interface {
+	// NextBackOff returns the duration to wait before retrying the operation,
+	// or backoff. Stop to indicate that no more retries should be made.
+	//
+	// Example usage:
+	//
+	// 	duration := backoff.NextBackOff();
+	// 	if (duration == backoff.Stop) {
+	// 		// Do not retry operation.
+	// 	} else {
+	// 		// Sleep for duration and retry operation.
+	// 	}
+	//
+	NextBackOff() time.Duration
+
+	// Reset to initial state.
+	Reset()
+}
+
+// Stop indicates that no more retries should be made for use in NextBackOff().
+const Stop time.Duration = -1
+
+// ZeroBackOff is a fixed backoff policy whose backoff time is always zero,
+// meaning that the operation is retried immediately without waiting, indefinitely.
+type ZeroBackOff struct{}
+
+func (b *ZeroBackOff) Reset() {}
+
+func (b *ZeroBackOff) NextBackOff() time.Duration { return 0 }
+
+// StopBackOff is a fixed backoff policy that always returns backoff.Stop for
+// NextBackOff(), meaning that the operation should never be retried.
+type StopBackOff struct{}
+
+func (b *StopBackOff) Reset() {}
+
+func (b *StopBackOff) NextBackOff() time.Duration { return Stop }
+
+// ConstantBackOff is a backoff policy that always returns the same backoff delay.
+// This is in contrast to an exponential backoff policy,
+// which returns a delay that grows longer as you call NextBackOff() over and over again.
+type ConstantBackOff struct {
+	Interval time.Duration
+}
+
+func (b *ConstantBackOff) Reset()                     {}
+func (b *ConstantBackOff) NextBackOff() time.Duration { return b.Interval }
+
+func NewConstantBackOff(d time.Duration) *ConstantBackOff {
+	return &ConstantBackOff{Interval: d}
+}

--- a/src/runtime/vendor/github.com/cenkalti/backoff/context.go
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/context.go
@@ -1,0 +1,63 @@
+package backoff
+
+import (
+	"context"
+	"time"
+)
+
+// BackOffContext is a backoff policy that stops retrying after the context
+// is canceled.
+type BackOffContext interface {
+	BackOff
+	Context() context.Context
+}
+
+type backOffContext struct {
+	BackOff
+	ctx context.Context
+}
+
+// WithContext returns a BackOffContext with context ctx
+//
+// ctx must not be nil
+func WithContext(b BackOff, ctx context.Context) BackOffContext {
+	if ctx == nil {
+		panic("nil context")
+	}
+
+	if b, ok := b.(*backOffContext); ok {
+		return &backOffContext{
+			BackOff: b.BackOff,
+			ctx:     ctx,
+		}
+	}
+
+	return &backOffContext{
+		BackOff: b,
+		ctx:     ctx,
+	}
+}
+
+func ensureContext(b BackOff) BackOffContext {
+	if cb, ok := b.(BackOffContext); ok {
+		return cb
+	}
+	return WithContext(b, context.Background())
+}
+
+func (b *backOffContext) Context() context.Context {
+	return b.ctx
+}
+
+func (b *backOffContext) NextBackOff() time.Duration {
+	select {
+	case <-b.ctx.Done():
+		return Stop
+	default:
+	}
+	next := b.BackOff.NextBackOff()
+	if deadline, ok := b.ctx.Deadline(); ok && deadline.Sub(time.Now()) < next {
+		return Stop
+	}
+	return next
+}

--- a/src/runtime/vendor/github.com/cenkalti/backoff/exponential.go
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/exponential.go
@@ -1,0 +1,153 @@
+package backoff
+
+import (
+	"math/rand"
+	"time"
+)
+
+/*
+ExponentialBackOff is a backoff implementation that increases the backoff
+period for each retry attempt using a randomization function that grows exponentially.
+
+NextBackOff() is calculated using the following formula:
+
+ randomized interval =
+     RetryInterval * (random value in range [1 - RandomizationFactor, 1 + RandomizationFactor])
+
+In other words NextBackOff() will range between the randomization factor
+percentage below and above the retry interval.
+
+For example, given the following parameters:
+
+ RetryInterval = 2
+ RandomizationFactor = 0.5
+ Multiplier = 2
+
+the actual backoff period used in the next retry attempt will range between 1 and 3 seconds,
+multiplied by the exponential, that is, between 2 and 6 seconds.
+
+Note: MaxInterval caps the RetryInterval and not the randomized interval.
+
+If the time elapsed since an ExponentialBackOff instance is created goes past the
+MaxElapsedTime, then the method NextBackOff() starts returning backoff.Stop.
+
+The elapsed time can be reset by calling Reset().
+
+Example: Given the following default arguments, for 10 tries the sequence will be,
+and assuming we go over the MaxElapsedTime on the 10th try:
+
+ Request #  RetryInterval (seconds)  Randomized Interval (seconds)
+
+  1          0.5                     [0.25,   0.75]
+  2          0.75                    [0.375,  1.125]
+  3          1.125                   [0.562,  1.687]
+  4          1.687                   [0.8435, 2.53]
+  5          2.53                    [1.265,  3.795]
+  6          3.795                   [1.897,  5.692]
+  7          5.692                   [2.846,  8.538]
+  8          8.538                   [4.269, 12.807]
+  9         12.807                   [6.403, 19.210]
+ 10         19.210                   backoff.Stop
+
+Note: Implementation is not thread-safe.
+*/
+type ExponentialBackOff struct {
+	InitialInterval     time.Duration
+	RandomizationFactor float64
+	Multiplier          float64
+	MaxInterval         time.Duration
+	// After MaxElapsedTime the ExponentialBackOff stops.
+	// It never stops if MaxElapsedTime == 0.
+	MaxElapsedTime time.Duration
+	Clock          Clock
+
+	currentInterval time.Duration
+	startTime       time.Time
+}
+
+// Clock is an interface that returns current time for BackOff.
+type Clock interface {
+	Now() time.Time
+}
+
+// Default values for ExponentialBackOff.
+const (
+	DefaultInitialInterval     = 500 * time.Millisecond
+	DefaultRandomizationFactor = 0.5
+	DefaultMultiplier          = 1.5
+	DefaultMaxInterval         = 60 * time.Second
+	DefaultMaxElapsedTime      = 15 * time.Minute
+)
+
+// NewExponentialBackOff creates an instance of ExponentialBackOff using default values.
+func NewExponentialBackOff() *ExponentialBackOff {
+	b := &ExponentialBackOff{
+		InitialInterval:     DefaultInitialInterval,
+		RandomizationFactor: DefaultRandomizationFactor,
+		Multiplier:          DefaultMultiplier,
+		MaxInterval:         DefaultMaxInterval,
+		MaxElapsedTime:      DefaultMaxElapsedTime,
+		Clock:               SystemClock,
+	}
+	b.Reset()
+	return b
+}
+
+type systemClock struct{}
+
+func (t systemClock) Now() time.Time {
+	return time.Now()
+}
+
+// SystemClock implements Clock interface that uses time.Now().
+var SystemClock = systemClock{}
+
+// Reset the interval back to the initial retry interval and restarts the timer.
+func (b *ExponentialBackOff) Reset() {
+	b.currentInterval = b.InitialInterval
+	b.startTime = b.Clock.Now()
+}
+
+// NextBackOff calculates the next backoff interval using the formula:
+// 	Randomized interval = RetryInterval +/- (RandomizationFactor * RetryInterval)
+func (b *ExponentialBackOff) NextBackOff() time.Duration {
+	// Make sure we have not gone over the maximum elapsed time.
+	if b.MaxElapsedTime != 0 && b.GetElapsedTime() > b.MaxElapsedTime {
+		return Stop
+	}
+	defer b.incrementCurrentInterval()
+	return getRandomValueFromInterval(b.RandomizationFactor, rand.Float64(), b.currentInterval)
+}
+
+// GetElapsedTime returns the elapsed time since an ExponentialBackOff instance
+// is created and is reset when Reset() is called.
+//
+// The elapsed time is computed using time.Now().UnixNano(). It is
+// safe to call even while the backoff policy is used by a running
+// ticker.
+func (b *ExponentialBackOff) GetElapsedTime() time.Duration {
+	return b.Clock.Now().Sub(b.startTime)
+}
+
+// Increments the current interval by multiplying it with the multiplier.
+func (b *ExponentialBackOff) incrementCurrentInterval() {
+	// Check for overflow, if overflow is detected set the current interval to the max interval.
+	if float64(b.currentInterval) >= float64(b.MaxInterval)/b.Multiplier {
+		b.currentInterval = b.MaxInterval
+	} else {
+		b.currentInterval = time.Duration(float64(b.currentInterval) * b.Multiplier)
+	}
+}
+
+// Returns a random value from the following interval:
+// 	[randomizationFactor * currentInterval, randomizationFactor * currentInterval].
+func getRandomValueFromInterval(randomizationFactor, random float64, currentInterval time.Duration) time.Duration {
+	var delta = randomizationFactor * float64(currentInterval)
+	var minInterval = float64(currentInterval) - delta
+	var maxInterval = float64(currentInterval) + delta
+
+	// Get a random value from the range [minInterval, maxInterval].
+	// The formula used below has a +1 because if the minInterval is 1 and the maxInterval is 3 then
+	// we want a 33% chance for selecting either 1, 2 or 3.
+	return time.Duration(minInterval + (random * (maxInterval - minInterval + 1)))
+}

--- a/src/runtime/vendor/github.com/cenkalti/backoff/retry.go
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/retry.go
@@ -1,0 +1,82 @@
+package backoff
+
+import "time"
+
+// An Operation is executing by Retry() or RetryNotify().
+// The operation will be retried using a backoff policy if it returns an error.
+type Operation func() error
+
+// Notify is a notify-on-error function. It receives an operation error and
+// backoff delay if the operation failed (with an error).
+//
+// NOTE that if the backoff policy stated to stop retrying,
+// the notify function isn't called.
+type Notify func(error, time.Duration)
+
+// Retry the operation o until it does not return error or BackOff stops.
+// o is guaranteed to be run at least once.
+//
+// If o returns a *PermanentError, the operation is not retried, and the
+// wrapped error is returned.
+//
+// Retry sleeps the goroutine for the duration returned by BackOff after a
+// failed operation returns.
+func Retry(o Operation, b BackOff) error { return RetryNotify(o, b, nil) }
+
+// RetryNotify calls notify function with the error and wait duration
+// for each failed attempt before sleep.
+func RetryNotify(operation Operation, b BackOff, notify Notify) error {
+	var err error
+	var next time.Duration
+	var t *time.Timer
+
+	cb := ensureContext(b)
+
+	b.Reset()
+	for {
+		if err = operation(); err == nil {
+			return nil
+		}
+
+		if permanent, ok := err.(*PermanentError); ok {
+			return permanent.Err
+		}
+
+		if next = cb.NextBackOff(); next == Stop {
+			return err
+		}
+
+		if notify != nil {
+			notify(err, next)
+		}
+
+		if t == nil {
+			t = time.NewTimer(next)
+			defer t.Stop()
+		} else {
+			t.Reset(next)
+		}
+
+		select {
+		case <-cb.Context().Done():
+			return err
+		case <-t.C:
+		}
+	}
+}
+
+// PermanentError signals that the operation should not be retried.
+type PermanentError struct {
+	Err error
+}
+
+func (e *PermanentError) Error() string {
+	return e.Err.Error()
+}
+
+// Permanent wraps the given err in a *PermanentError.
+func Permanent(err error) *PermanentError {
+	return &PermanentError{
+		Err: err,
+	}
+}

--- a/src/runtime/vendor/github.com/cenkalti/backoff/ticker.go
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/ticker.go
@@ -1,0 +1,82 @@
+package backoff
+
+import (
+	"sync"
+	"time"
+)
+
+// Ticker holds a channel that delivers `ticks' of a clock at times reported by a BackOff.
+//
+// Ticks will continue to arrive when the previous operation is still running,
+// so operations that take a while to fail could run in quick succession.
+type Ticker struct {
+	C        <-chan time.Time
+	c        chan time.Time
+	b        BackOffContext
+	stop     chan struct{}
+	stopOnce sync.Once
+}
+
+// NewTicker returns a new Ticker containing a channel that will send
+// the time at times specified by the BackOff argument. Ticker is
+// guaranteed to tick at least once.  The channel is closed when Stop
+// method is called or BackOff stops. It is not safe to manipulate the
+// provided backoff policy (notably calling NextBackOff or Reset)
+// while the ticker is running.
+func NewTicker(b BackOff) *Ticker {
+	c := make(chan time.Time)
+	t := &Ticker{
+		C:    c,
+		c:    c,
+		b:    ensureContext(b),
+		stop: make(chan struct{}),
+	}
+	t.b.Reset()
+	go t.run()
+	return t
+}
+
+// Stop turns off a ticker. After Stop, no more ticks will be sent.
+func (t *Ticker) Stop() {
+	t.stopOnce.Do(func() { close(t.stop) })
+}
+
+func (t *Ticker) run() {
+	c := t.c
+	defer close(c)
+
+	// Ticker is guaranteed to tick at least once.
+	afterC := t.send(time.Now())
+
+	for {
+		if afterC == nil {
+			return
+		}
+
+		select {
+		case tick := <-afterC:
+			afterC = t.send(tick)
+		case <-t.stop:
+			t.c = nil // Prevent future ticks from being sent to the channel.
+			return
+		case <-t.b.Context().Done():
+			return
+		}
+	}
+}
+
+func (t *Ticker) send(tick time.Time) <-chan time.Time {
+	select {
+	case t.c <- tick:
+	case <-t.stop:
+		return nil
+	}
+
+	next := t.b.NextBackOff()
+	if next == Stop {
+		t.Stop()
+		return nil
+	}
+
+	return time.After(next)
+}

--- a/src/runtime/vendor/github.com/cenkalti/backoff/tries.go
+++ b/src/runtime/vendor/github.com/cenkalti/backoff/tries.go
@@ -1,0 +1,35 @@
+package backoff
+
+import "time"
+
+/*
+WithMaxRetries creates a wrapper around another BackOff, which will
+return Stop if NextBackOff() has been called too many times since
+the last time Reset() was called
+
+Note: Implementation is not thread-safe.
+*/
+func WithMaxRetries(b BackOff, max uint64) BackOff {
+	return &backOffTries{delegate: b, maxTries: max}
+}
+
+type backOffTries struct {
+	delegate BackOff
+	maxTries uint64
+	numTries uint64
+}
+
+func (b *backOffTries) NextBackOff() time.Duration {
+	if b.maxTries > 0 {
+		if b.maxTries <= b.numTries {
+			return Stop
+		}
+		b.numTries++
+	}
+	return b.delegate.NextBackOff()
+}
+
+func (b *backOffTries) Reset() {
+	b.numTries = 0
+	b.delegate.Reset()
+}

--- a/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
+++ b/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
@@ -1428,6 +1428,8 @@ func (vhostuserDev VhostUserDevice) QemuFSParams(config *Config) []string {
 	deviceParams = append(deviceParams, driver)
 	deviceParams = append(deviceParams, fmt.Sprintf("chardev=%s", vhostuserDev.CharDevID))
 	deviceParams = append(deviceParams, fmt.Sprintf("tag=%s", vhostuserDev.Tag))
+	deviceParams = append(deviceParams, "indirect_desc=false,event_idx=false")
+
 	if vhostuserDev.CacheSize != 0 {
 		deviceParams = append(deviceParams, fmt.Sprintf("cache-size=%dM", vhostuserDev.CacheSize))
 	}

--- a/src/runtime/vendor/modules.txt
+++ b/src/runtime/vendor/modules.txt
@@ -45,6 +45,9 @@ github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0
 ## explicit
 github.com/blang/semver/v4
+# github.com/cenkalti/backoff v2.2.1+incompatible
+## explicit
+github.com/cenkalti/backoff
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/checkpoint-restore/go-criu/v5 v5.0.0

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -159,7 +159,7 @@ func (s *CloudHypervisorState) reset() {
 type cloudHypervisor struct {
 	store     persistapi.PersistDriver
 	console   console.Console
-	virtiofsd Virtiofsd
+	virtiofsd VirtiofsDaemon
 	APIClient clhClient
 	ctx       context.Context
 	id        string
@@ -718,14 +718,14 @@ func (clh *cloudHypervisor) toGrpc(ctx context.Context) ([]byte, error) {
 func (clh *cloudHypervisor) save() (s persistapi.HypervisorState) {
 	s.Pid = clh.state.PID
 	s.Type = string(ClhHypervisor)
-	s.VirtiofsdPid = clh.state.VirtiofsdPID
+	s.VirtiofsDaemonPid = clh.state.VirtiofsdPID
 	s.APISocket = clh.state.apiSocket
 	return
 }
 
 func (clh *cloudHypervisor) load(s persistapi.HypervisorState) {
 	clh.state.PID = s.Pid
-	clh.state.VirtiofsdPID = s.VirtiofsdPid
+	clh.state.VirtiofsdPID = s.VirtiofsDaemonPid
 	clh.state.apiSocket = s.APISocket
 }
 

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -863,7 +863,7 @@ func (c *Container) rollbackFailingContainerCreation(ctx context.Context) {
 		c.Logger().WithError(err).Error("rollback failed unmountHostMounts()")
 	}
 
-	if c.rootFs.Type == nydusRootFSType {
+	if c.rootFs.Type == NydusRootFSType {
 		if err := nydusContainerCleanup(ctx, getMountPath(c.sandbox.id), c); err != nil {
 			c.Logger().WithError(err).Error("rollback failed nydusContainerCleanup")
 		}
@@ -899,7 +899,7 @@ func (c *Container) create(ctx context.Context) (err error) {
 		}
 	}()
 
-	if c.checkBlockDeviceSupport(ctx) {
+	if c.checkBlockDeviceSupport(ctx) && c.rootFs.Type != NydusRootFSType {
 		// If the rootfs is backed by a block device, go ahead and hotplug it to the guest
 		if err = c.hotplugDrive(ctx); err != nil {
 			return
@@ -1098,7 +1098,7 @@ func (c *Container) stop(ctx context.Context, force bool) error {
 		return err
 	}
 
-	if c.rootFs.Type == nydusRootFSType {
+	if c.rootFs.Type == NydusRootFSType {
 		if err := nydusContainerCleanup(ctx, getMountPath(c.sandbox.id), c); err != nil && !force {
 			return err
 		}

--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -69,7 +69,7 @@ const (
 	// VirtioFS means use virtio-fs for the shared file system
 	VirtioFS = "virtio-fs"
 
-	// VirtioFS means use nydus for the shared file system
+	// VirtioNydus means use nydus for the shared file system
 	VirtioNydus = "virtio-nydus"
 )
 

--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -68,6 +68,9 @@ const (
 
 	// VirtioFS means use virtio-fs for the shared file system
 	VirtioFS = "virtio-fs"
+
+	// VirtioFS means use nydus for the shared file system
+	VirtioNydus = "virtio-nydus"
 )
 
 const (

--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -70,7 +70,7 @@ const (
 	VirtioFS = "virtio-fs"
 
 	// VirtioNydus means use nydus for the shared file system
-	VirtioNydus = "virtio-nydus"
+	VirtioNydus = "virtio-fs-nydus"
 )
 
 const (

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -325,7 +325,7 @@ type HypervisorConfig struct {
 	// VirtioFSExtraArgs passes options to virtiofsd daemon
 	VirtioFSExtraArgs []string
 
-	// VirtioFSNydus is the virtiofs nydusd daemon path
+	// VirtioFSNydusd is the virtiofs nydusd daemon path
 	VirtioFSNydusd string
 
 	// VirtioFSNydusExtraArgs passes options to virtiofs nydusd daemon

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -325,6 +325,12 @@ type HypervisorConfig struct {
 	// VirtioFSExtraArgs passes options to virtiofsd daemon
 	VirtioFSExtraArgs []string
 
+	// VirtioFSNydus is the virtiofs nydusd daemon path
+	VirtioFSNydusd string
+
+	// VirtioFSNydusExtraArgs passes options to virtiofs nydusd daemon
+	VirtioFSNydusdExtraArgs []string
+
 	// Enable annotations by name
 	EnableAnnotations []string
 

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -64,6 +64,7 @@ const (
 
 	sandboxMountsDir = "sandbox-mounts"
 
+	nydusRootFSType = "nydus"
 	// enable debug console
 	kernelParamDebugConsole           = "agent.debug_console"
 	kernelParamDebugConsoleVPort      = "agent.debug_console_vport"
@@ -1270,6 +1271,11 @@ func (k *kataAgent) rollbackFailingContainerCreation(ctx context.Context, c *Con
 		if err2 := bindUnmountContainerRootfs(ctx, getMountPath(c.sandbox.id), c.id); err2 != nil {
 			k.Logger().WithError(err2).Error("rollback failed bindUnmountContainerRootfs()")
 		}
+		if c.rootFs.Type == nydusRootFSType {
+			if err2 := bindUnmountContainerSnapshotDir(ctx, getMountPath(c.sandbox.id), c.id); err2 != nil {
+				k.Logger().WithError(err2).Error("rollback failed bindUnmountContainerSnapshotDir()")
+			}
+		}
 	}
 }
 
@@ -1315,7 +1321,7 @@ func (k *kataAgent) buildContainerRootfsWithNydus(sandbox *Sandbox, c *Container
 }
 
 func (k *kataAgent) buildContainerRootfs(ctx context.Context, sandbox *Sandbox, c *Container, rootPathParent string) (*grpc.Storage, error) {
-	if c.rootFs.Type == "nydus" {
+	if c.rootFs.Type == nydusRootFSType {
 		return k.buildContainerRootfsWithNydus(sandbox, c, rootPathParent)
 	}
 	if c.state.Fstype != "" && c.state.BlockDeviceID != "" {

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -439,7 +439,7 @@ func bindUnmountAllRootfs(ctx context.Context, sharedDir string, sandbox *Sandbo
 		if c.state.Fstype == "" {
 			// even if error found, don't break out of loop until all mounts attempted
 			// to be unmounted, and collect all errors
-			if c.rootFs.Type == nydusRootFSType {
+			if c.rootFs.Type == NydusRootFSType {
 				errors = merr.Append(errors, nydusContainerCleanup(ctx, sharedDir, c))
 			} else {
 				errors = merr.Append(errors, bindUnmountContainerRootfs(ctx, sharedDir, c.id))

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -31,6 +31,10 @@ const UmountNoFollow = 0x8
 
 var rootfsDir = "rootfs"
 
+var lowerDir = "lowerdir"
+
+var snapshotDir = "snapshotdir"
+
 var systemMountPrefixes = []string{"/proc", "/sys"}
 
 // mountTracingTags defines tags for the trace span

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -32,6 +32,8 @@ const UmountNoFollow = 0x8
 var rootfsDir = "rootfs"
 
 var lowerDir = "lowerdir"
+var upperDir = "upperdir"
+var workDir = "workdir"
 
 var snapshotDir = "snapshotdir"
 
@@ -415,7 +417,7 @@ func nydusContainerCleanup(ctx context.Context, sharedDir string, c *Container) 
 	if err := bindUnmountContainerSnapshotDir(ctx, sharedDir, c.id); err != nil {
 		return fmt.Errorf("umount snapshotdir err, %v", err)
 	}
-	destDir := filepath.Join(sharedDir, c.id, rootfsDir)
+	destDir := filepath.Join(sharedDir, c.id, c.rootfsSuffix)
 	if err := syscall.Rmdir(destDir); err != nil {
 		return fmt.Errorf("remove container rootfs err, %v", err)
 	}

--- a/src/runtime/virtcontainers/nydus.go
+++ b/src/runtime/virtcontainers/nydus.go
@@ -1,0 +1,350 @@
+package virtcontainers
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
+	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	infoEndpoint  = "/api/v1/daemon"
+	mountEndpoint = "/api/v1/mount"
+
+	defaultHttpClientTimeout = 30 * time.Second
+	contentType              = "application/json"
+
+	nydusRafsType          = "rafs"
+	nydusPassthroughfsType = "passthrough_fs"
+
+	configPrefix   = "config="
+	snapshotPrefix = "snapshotdir="
+
+	sharedPathInGuest = "/containers"
+)
+
+var nydusdTracingTags = map[string]string{
+	"source":    "runtime",
+	"package":   "virtcontainers",
+	"subsystem": "nydusd",
+}
+
+type nydusd struct {
+	pid         int
+	path        string
+	sockPath    string
+	apiSockPath string
+	sourcePath  string
+	logFile     string
+	extraArgs   []string
+}
+
+func (nd *nydusd) Start(ctx context.Context, onQuit onQuitFunc) (int, error) {
+	span, _ := katatrace.Trace(ctx, nd.Logger(), "Start", nydusdTracingTags)
+	defer span.End()
+	pid := 0
+
+	args := []string{
+		"--log-level", "debug",
+		"--log-file", nd.logFile,
+		"--apisock", nd.apiSockPath,
+		"--sock", nd.sockPath,
+	}
+	if len(nd.extraArgs) > 0 {
+		args = append(args, nd.extraArgs...)
+	}
+	cmd := exec.Command(nd.path, args...)
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return pid, err
+	}
+	nd.Logger().WithField("path", nd.path).Info()
+	nd.Logger().WithField("args", strings.Join(args, " ")).Info()
+	if err := cmd.Start(); err != nil {
+		return pid, err
+	}
+	// Monitor virtiofsd's stderr and stop sandbox if virtiofsd quits
+	go func() {
+		scanner := bufio.NewScanner(stderr)
+		for scanner.Scan() {
+			nd.Logger().WithField("source", "nydusd").Info(scanner.Text())
+		}
+		nd.Logger().Info("nydusd quits")
+		// Wait to release resources of virtiofsd process
+		cmd.Process.Wait()
+		if onQuit != nil {
+			onQuit()
+		}
+	}()
+	if err := nd.setupPassthroughFS(); err != nil {
+		return pid, err
+	}
+	nd.pid = cmd.Process.Pid
+	return nd.pid, nil
+}
+
+func (nd *nydusd) setupPassthroughFS() error {
+	if err := os.MkdirAll(nd.sourcePath, DirMode); err != nil {
+		return err
+	}
+	nc, err := NewNydusClient(nd.apiSockPath)
+	if err != nil {
+		return err
+	}
+	nd.Logger().WithField("from", nd.sourcePath).
+		WithField("dest", sharedPathInGuest).Info("prepare mount passthroughfs")
+
+	mr := NewMountRequest(nydusPassthroughfsType, nd.sourcePath, "")
+	return nc.Mount(sharedPathInGuest, mr)
+}
+
+func (nd *nydusd) MountRAFS(opt MountOption) error {
+	nc, err := NewNydusClient(nd.apiSockPath)
+	if err != nil {
+		return err
+	}
+	nd.Logger().WithField("from", opt.bootstrap).
+		WithField("dest", opt.mountpoint).Info("prepare mount rafs")
+
+	mr := NewMountRequest(nydusRafsType, opt.bootstrap, opt.daemonConfig)
+	return nc.Mount(opt.mountpoint, mr)
+}
+
+func (nd *nydusd) Stop(ctx context.Context) error {
+	if err := nd.kill(ctx); err != nil {
+		return nil
+	}
+
+	err := os.Remove(nd.sockPath)
+	if err != nil {
+		nd.Logger().WithError(err).WithField("path", nd.sockPath).Warn("removing nydusd socket failed")
+	}
+	return nil
+}
+
+func (nd *nydusd) Logger() *log.Entry {
+	return virtLog.WithField("subsystem", "nydusd")
+}
+
+func (nd *nydusd) kill(ctx context.Context) (err error) {
+	span, _ := katatrace.Trace(ctx, nd.Logger(), "kill", virtiofsdTracingTags)
+	defer span.End()
+
+	if nd.pid == 0 {
+		return errors.New("invalid virtiofsd PID(0)")
+	}
+
+	err = syscall.Kill(nd.pid, syscall.SIGKILL)
+	if err != nil {
+		nd.pid = 0
+	}
+
+	return err
+}
+
+type BuildTimeInfo struct {
+	PackageVer string `json:"package_ver"`
+	GitCommit  string `json:"git_commit"`
+	BuildTime  string `json:"build_time"`
+	Profile    string `json:"profile"`
+	Rustc      string `json:"rustc"`
+}
+
+type DaemonInfo struct {
+	ID      string        `json:"id"`
+	Version BuildTimeInfo `json:"version"`
+	State   string        `json:"state"`
+}
+
+type ErrorMessage struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+type MountOption struct {
+	mountpoint   string
+	bootstrap    string
+	daemonConfig string
+}
+type MountRequest struct {
+	FsType string `json:"fs_type"`
+	Source string `json:"source"`
+	Config string `json:"config"`
+}
+
+func NewMountRequest(fsType, source, config string) *MountRequest {
+	return &MountRequest{
+		FsType: fsType,
+		Source: source,
+		Config: config,
+	}
+}
+
+type Interface interface {
+	CheckStatus() (DaemonInfo, error)
+	Mount(string, *MountRequest) error
+	Umount(sharedMountPoint string) error
+}
+
+type NydusClient struct {
+	httpClient *http.Client
+}
+
+func NewNydusClient(sock string) (Interface, error) {
+	transport, err := buildTransport(sock)
+	if err != nil {
+		return nil, err
+	}
+	return &NydusClient{
+		httpClient: &http.Client{
+			Timeout:   defaultHttpClientTimeout,
+			Transport: transport,
+		},
+	}, nil
+}
+
+func waitUntilSocketReady(sock string) error {
+	b := &backoff.ExponentialBackOff{
+		InitialInterval:     300 * time.Microsecond,
+		RandomizationFactor: 0.5,
+		Multiplier:          2,
+		MaxInterval:         1 * time.Second,
+		MaxElapsedTime:      5 * time.Second,
+		Clock:               backoff.SystemClock,
+	}
+	b.Reset()
+	err := backoff.Retry(func() error {
+		_, err := os.Stat(sock)
+		return err
+	}, b)
+	if err != nil {
+		return errors.Wrap(err, "nydusd daemon socket not ready")
+	}
+	return nil
+}
+
+func buildTransport(sock string) (http.RoundTripper, error) {
+	err := waitUntilSocketReady(sock)
+	if err != nil {
+		return nil, err
+	}
+	return &http.Transport{
+		MaxIdleConns:          10,
+		IdleConnTimeout:       10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			dialer := &net.Dialer{
+				Timeout:   5 * time.Second,
+				KeepAlive: 5 * time.Second,
+			}
+			return dialer.DialContext(ctx, "unix", sock)
+		},
+	}, nil
+}
+
+func (c *NydusClient) CheckStatus() (DaemonInfo, error) {
+	resp, err := c.httpClient.Get(fmt.Sprintf("http://unix%s", infoEndpoint))
+	if err != nil {
+		return DaemonInfo{}, err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return DaemonInfo{}, err
+	}
+	var info DaemonInfo
+	if err = json.Unmarshal(b, &info); err != nil {
+		return DaemonInfo{}, err
+	}
+	return info, nil
+}
+
+func (c *NydusClient) Mount(mountPoint string, mr *MountRequest) error {
+	requestURL := fmt.Sprintf("http://unix%s?mountpoint=%s", mountEndpoint, mountPoint)
+	body, err := json.Marshal(mr)
+	if err != nil {
+		return errors.Wrap(err, "failed to create mount request")
+	}
+
+	resp, err := c.httpClient.Post(requestURL, contentType, bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	return handleMountError(resp.Body)
+}
+
+func (c *NydusClient) Umount(sharedMountPoint string) error {
+	requestURL := fmt.Sprintf("http://unix%s?mountpoint=%s", mountEndpoint, sharedMountPoint)
+	req, err := http.NewRequest(http.MethodDelete, requestURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	return handleMountError(resp.Body)
+}
+
+func handleMountError(r io.Reader) error {
+	b, err := ioutil.ReadAll(r)
+	if err != nil {
+		return err
+	}
+	var errMessage ErrorMessage
+	if err = json.Unmarshal(b, &errMessage); err != nil {
+		return err
+	}
+	return errors.New(errMessage.Message)
+}
+
+func parseConfigs(configs []string) (string, string, error) {
+	handleErr := func(msg string) (string, string, error) {
+		return "", "", errors.New(msg)
+	}
+	if len(configs) != 2 {
+		msg := fmt.Sprintf("config should has two items, %v", configs)
+		return handleErr(msg)
+	}
+
+	var (
+		daemonConfig string
+		snapshotDir  string
+	)
+	for _, str := range configs {
+		if strings.HasPrefix(str, configPrefix) {
+			daemonConfig = strings.TrimPrefix(str, configPrefix)
+		} else if strings.HasPrefix(str, snapshotPrefix) {
+			snapshotDir = strings.TrimPrefix(str, snapshotPrefix)
+		} else {
+		}
+	}
+	if len(daemonConfig) == 0 || len(snapshotDir) == 0 {
+		msg := fmt.Sprintf("daemonConfig or snapshotDir has wrong format, %v", configs)
+		return handleErr(msg)
+	}
+	return daemonConfig, snapshotDir, nil
+}

--- a/src/runtime/virtcontainers/nydus.go
+++ b/src/runtime/virtcontainers/nydus.go
@@ -125,6 +125,15 @@ func (nd *nydusd) MountRAFS(opt MountOption) error {
 	return nc.Mount(opt.mountpoint, mr)
 }
 
+func (nd *nydusd) UmountRAFS(mountpoint string) error {
+	nc, err := NewNydusClient(nd.apiSockPath)
+	if err != nil {
+		return err
+	}
+	nd.Logger().WithField("mountpoint", mountpoint).Info("umount rafs")
+	return nc.Umount(mountpoint)
+}
+
 func (nd *nydusd) Stop(ctx context.Context) error {
 	if err := nd.kill(ctx); err != nil {
 		nd.Logger().WithError(err).WithField("pid", nd.pid).Warn("kill nydusd failed")

--- a/src/runtime/virtcontainers/nydus.go
+++ b/src/runtime/virtcontainers/nydus.go
@@ -50,7 +50,7 @@ type nydusd struct {
 	sockPath    string
 	apiSockPath string
 	sourcePath  string
-	logFile     string
+	logLevel    string
 	extraArgs   []string
 }
 
@@ -60,8 +60,7 @@ func (nd *nydusd) Start(ctx context.Context, onQuit onQuitFunc) (int, error) {
 	pid := 0
 
 	args := []string{
-		"--log-level", "debug",
-		"--log-file", nd.logFile,
+		"--log-level", "info",
 		"--apisock", nd.apiSockPath,
 		"--sock", nd.sockPath,
 	}

--- a/src/runtime/virtcontainers/persist/api/hypervisor.go
+++ b/src/runtime/virtcontainers/persist/api/hypervisor.go
@@ -41,10 +41,10 @@ type HypervisorState struct {
 	// HotpluggedCPUs is the list of CPUs that were hot-added
 	HotpluggedVCPUs []CPUDevice
 
-	HotpluggedMemory int
-	VirtiofsdPid     int
-	Pid              int
-	PCIeRootPort     int
+	HotpluggedMemory  int
+	VirtiofsDaemonPid int
+	Pid               int
+	PCIeRootPort      int
 
 	HotplugVFIOOnRootBus bool
 }

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -472,16 +472,16 @@ func (q *qemu) createVirtiofsDaemon() (VirtiofsDaemon, error) {
 		if err != nil {
 			return nil, err
 		}
-		logfile, err := q.nydusdLogFilePath(q.id)
-		if err != nil {
-			return nil, err
+		logLevel := "info"
+		if q.config.Debug {
+			logLevel = "debug"
 		}
 		return &nydusd{
 			path:        q.config.VirtioFSNydusd,
 			sockPath:    virtiofsdSocketPath,
 			apiSockPath: apiSockPath,
 			sourcePath:  filepath.Join(getSharePath(q.id)),
-			logFile:     logfile,
+			logLevel:    logLevel,
 			extraArgs:   q.config.VirtioFSNydusdExtraArgs,
 		}, nil
 	}
@@ -675,10 +675,6 @@ func (q *qemu) vhostFSSocketPath(id string) (string, error) {
 
 func (q *qemu) nydusdAPISocketPath(id string) (string, error) {
 	return utils.BuildSocketPath(q.store.RunVMStoragePath(), id, nydusdAPISock)
-}
-
-func (q *qemu) nydusdLogFilePath(id string) (string, error) {
-	return utils.BuildSocketPath(q.store.RunVMStoragePath(), id, "nydusd.log")
 }
 
 func (q *qemu) setupVirtiofsDaemon(ctx context.Context) (err error) {

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -34,6 +34,8 @@ var (
 	errVirtiofsdSocketPathEmpty    = errors.New("virtiofsd socket path is empty")
 	errVirtiofsdSourcePathEmpty    = errors.New("virtiofsd source path is empty")
 	errVirtiofsdSourceNotAvailable = errors.New("virtiofsd source path not available")
+
+	errUnimplemented = errors.New("unimplemented")
 )
 
 type Virtiofsd interface {
@@ -41,6 +43,8 @@ type Virtiofsd interface {
 	Start(context.Context, onQuitFunc) (pid int, err error)
 	// Stop virtiofsd process
 	Stop(context.Context) error
+	// for NydusdVirtiofs to mount rafs
+	MountRAFS(opt MountOption) error
 }
 
 // Helper function to execute when virtiofsd quit
@@ -159,6 +163,10 @@ func (v *virtiofsd) Stop(ctx context.Context) error {
 	return nil
 }
 
+func (v *virtiofsd) MountRAFS(opt MountOption) error {
+	return errUnimplemented
+}
+
 func (v *virtiofsd) args(FdSocketNumber uint) ([]string, error) {
 
 	args := []string{
@@ -237,6 +245,10 @@ type virtiofsdMock struct {
 // Start the virtiofsd daemon
 func (v *virtiofsdMock) Start(ctx context.Context, onQuit onQuitFunc) (int, error) {
 	return 9999999, nil
+}
+
+func (v *virtiofsdMock) MountRAFS(opt MountOption) error {
+	return errUnimplemented
 }
 
 func (v *virtiofsdMock) Stop(ctx context.Context) error {

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -153,6 +153,7 @@ func (v *virtiofsd) Start(ctx context.Context, onQuit onQuitFunc) (int, error) {
 
 func (v *virtiofsd) Stop(ctx context.Context) error {
 	if err := v.kill(ctx); err != nil {
+		v.Logger().WithError(err).WithField("pid", v.PID).Warn("kill virtiofsd failed")
 		return nil
 	}
 
@@ -234,7 +235,6 @@ func (v *virtiofsd) kill(ctx context.Context) (err error) {
 	if err != nil {
 		v.PID = 0
 	}
-
 	return err
 }
 

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -38,13 +38,15 @@ var (
 	errUnimplemented = errors.New("unimplemented")
 )
 
-type Virtiofsd interface {
+type VirtiofsDaemon interface {
 	// Start virtiofsd, return pid of virtiofsd process
 	Start(context.Context, onQuitFunc) (pid int, err error)
 	// Stop virtiofsd process
 	Stop(context.Context) error
 	// for NydusdVirtiofs to mount rafs
 	MountRAFS(opt MountOption) error
+	// for NydusdVirtiofs to umount rafs
+	UmountRAFS(mountpoint string) error
 }
 
 // Helper function to execute when virtiofsd quit
@@ -168,6 +170,10 @@ func (v *virtiofsd) MountRAFS(opt MountOption) error {
 	return errUnimplemented
 }
 
+func (v *virtiofsd) UmountRAFS(mountpoint string) error {
+	return errUnimplemented
+}
+
 func (v *virtiofsd) args(FdSocketNumber uint) ([]string, error) {
 
 	args := []string{
@@ -248,6 +254,10 @@ func (v *virtiofsdMock) Start(ctx context.Context, onQuit onQuitFunc) (int, erro
 }
 
 func (v *virtiofsdMock) MountRAFS(opt MountOption) error {
+	return errUnimplemented
+}
+
+func (v *virtiofsdMock) UmountRAFS(mountpoint string) error {
 	return errUnimplemented
 }
 

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -74,7 +74,6 @@ retries=5
 EOF
 	if [ "$BASE_URL" != "" ]; then
 		cat >> "${DNF_CONF}" << EOF
-
 [base]
 name=${OS_NAME}-${OS_VERSION} ${REPO_NAME}
 failovermethod=priority
@@ -83,7 +82,6 @@ enabled=1
 EOF
 	elif [ "$MIRROR_LIST" != "" ]; then
 		cat >> "${DNF_CONF}" << EOF
-
 [base]
 name=${OS_NAME}-${OS_VERSION} ${REPO_NAME}
 mirrorlist=${MIRROR_LIST}


### PR DESCRIPTION
virtio: add nydusd support

[Research](https://www.usenix.org/conference/fast16/technical-sessions/presentation/harter) shows that time to take for pull operation accounts for 76% of container startup time but only 6.4% of that data is read. so if we can get data on demand(lazyload), it will speed up the container start.

nydusd(https://github.com/dragonflyoss/image-service) is the project which build image with different format and can get data on demand in runc, so this pr aims to add lazyload ability to kata. 

There are two cases:
1. if OCI image, it will use nydusd passthrough instead of virtiofsd and has the same logic；
2. if Nydus format image, it will also use nydusd passthrough instead of virtiofsd, and
    2.1 bind mount snapshotdir which snapshotter assign to host sharedir. in guest, it is in /run/kata-containers/shared/containers/\<cid\>/snapshotdir
    2.2 create "rootfs" dir in sharedir. in guest, it is in /run/kata-containers/shared/containers/\<cid\>/rootfs
    2.3 mount image rafs to guest path /run/kata-containers/shared/images/\<cid\>/lowerdir

when create container, kata-agent will mount overlay /run/kata-containers/shared/containers/\<cid\>/rootfs = overlay(lowerdir=/run/kata-containers/shared/images/\<cid\>/lowerdir, upperdir=/run/kata-containers/shared/containers/\<cid\>/snapshotdir/fs,workdir=/run/kata-containers/shared/containers/\<cid\>/snapshotdir/work)