### PR TITLE
agent/src: improve unit test coverage for src/namespace.rs

### DIFF
--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -251,4 +251,126 @@ mod tests {
         assert_eq!("pid", pid.get());
         assert_eq!(CloneFlags::CLONE_NEWPID, pid.get_flags());
     }
+
+    #[test]
+    fn test_new() {
+        // Create dummy logger and temp folder.
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        let ns_ipc = Namespace::new(&logger);
+        assert_eq!(NamespaceType::Ipc, ns_ipc.ns_type);
+    }
+
+    #[test]
+    fn test_get_ipc() {
+        // Create dummy logger and temp folder.
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        let ns_ipc = Namespace::new(&logger).get_ipc();
+        assert_eq!(NamespaceType::Ipc, ns_ipc.ns_type);
+    }
+
+    #[test]
+    fn test_get_uts_with_hostname() {
+        let hostname = String::from("a.test.com");
+        // Create dummy logger and temp folder.
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        let ns_uts = Namespace::new(&logger).get_uts(hostname.as_str());
+        assert_eq!(NamespaceType::Uts, ns_uts.ns_type);
+        assert!(ns_uts.hostname.is_some());
+    }
+
+    #[test]
+    fn test_get_uts() {
+        let hostname = String::from("");
+        // Create dummy logger and temp folder.
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        let ns_uts = Namespace::new(&logger).get_uts(hostname.as_str());
+        assert_eq!(NamespaceType::Uts, ns_uts.ns_type);
+        assert!(ns_uts.hostname.is_none());
+    }
+
+    #[test]
+    fn test_get_pid() {
+        // Create dummy logger and temp folder.
+        let logger = slog::Logger::root(slog::Discard, o!());
+
+        let ns_pid = Namespace::new(&logger).get_pid();
+        assert_eq!(NamespaceType::Pid, ns_pid.ns_type);
+    }
+
+    #[test]
+    fn test_set_root_dir() {
+        // Create dummy logger and temp folder.
+        let logger = slog::Logger::root(slog::Discard, o!());
+        let tmpdir = Builder::new().prefix("pid").tempdir().unwrap();
+
+        let ns_root = Namespace::new(&logger).set_root_dir(tmpdir.path().to_str().unwrap());
+        assert_eq!(NamespaceType::Ipc, ns_root.ns_type);
+        assert_eq!(ns_root.persistent_ns_dir, tmpdir.path().to_str().unwrap());
+    }
+
+    #[test]
+    fn test_namespace_type_get() {
+        #[derive(Debug)]
+        struct TestData<'a> {
+            ns_type: NamespaceType,
+            str: &'a str,
+        }
+
+        let tests = &[
+            TestData {
+                ns_type: NamespaceType::Ipc,
+                str: "ipc",
+            },
+            TestData {
+                ns_type: NamespaceType::Uts,
+                str: "uts",
+            },
+            TestData {
+                ns_type: NamespaceType::Pid,
+                str: "pid",
+            },
+        ];
+
+        // Run the tests
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+            assert_eq!(d.str, d.ns_type.get(), "{}", msg)
+        }
+    }
+
+    #[test]
+    fn test_namespace_type_get_flags() {
+        #[derive(Debug)]
+        struct TestData {
+            ns_type: NamespaceType,
+            ns_flag: CloneFlags,
+        }
+
+        let tests = &[
+            TestData {
+                ns_type: NamespaceType::Ipc,
+                ns_flag: CloneFlags::CLONE_NEWIPC,
+            },
+            TestData {
+                ns_type: NamespaceType::Uts,
+                ns_flag: CloneFlags::CLONE_NEWUTS,
+            },
+            TestData {
+                ns_type: NamespaceType::Pid,
+                ns_flag: CloneFlags::CLONE_NEWPID,
+            },
+        ];
+
+        // Run the tests
+        for (i, d) in tests.iter().enumerate() {
+            // Create a string containing details of the test
+            let msg = format!("test[{}]: {:?}", i, d);
+            assert_eq!(d.ns_flag, d.ns_type.get_flags(), "{}", msg)
+        }
+    }
 }


### PR DESCRIPTION
Improve unit test coverage for src/namespace.rs for Kata 2.0 agent

Fixes: #289

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>