### PR TITLE
CCv0 | version: Add support for using containerd PR

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -190,6 +190,8 @@ externals:
     # instead of abstract socket, thus kata wouldn's support the containerd's
     # version older than them.
     version: "v1.5.2"
+    # CCv0 is using a containerd PR build as our changes are still PoC
+    pr_id: "5911"
 
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"


### PR DESCRIPTION
Add a pr_id field to the cri-containerd config in versions.yaml
so the CI scripts can use this in the CCv0 builds as part of https://github.com/kata-containers/tests/pull/3888

Fixes #2576

Signed-off-by: stevenhorsman <steven@uk.ibm.com>