### PR TITLE
runtime: add rootless check to cgroup readPids function

### DIFF
--- a/src/runtime/virtcontainers/pkg/cgroups/manager.go
+++ b/src/runtime/virtcontainers/pkg/cgroups/manager.go
@@ -172,6 +172,10 @@ func New(config *Config) (*Manager, error) {
 
 // read all the pids in cgroupPath
 func readPids(cgroupPath string) ([]int, error) {
+	if rootless.IsRootless() {
+		return nil, errors.New("unable to read pids from cgroup.procs: running rootless")
+	}
+
 	pids := []int{}
 	f, err := os.Open(filepath.Join(cgroupPath, cgroupProcs))
 	if err != nil {


### PR DESCRIPTION
The "cgroup.procs" file was created with "0000" mode,
`ioutil.WriteFile(cgroupProcsPath, []byte(strconv.Itoa(pid)), os.FileMode(0), )`.
Rootless user's open permission is denied. This PR add a check to rootless user.

Fixes: #2581

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>