### PR TITLE
runtime: add log for scan network

### DIFF
--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -1192,6 +1192,7 @@ func createEndpointsFromScan(networkNSPath string, config *NetworkConfig) ([]End
 		// like gre0, gretap0, sit0, ipip0, tunl0 or incorrectly
 		// setup interfaces.
 		if len(netInfo.Addrs) == 0 {
+			networkLogger().Warnf("netInfo found but have no Addrs: %+v", netInfo)
 			continue
 		}
 


### PR DESCRIPTION
If net device in invalid, log it for debug.

Fixe: #2580

Signed-off-by: bin <bin@hyper.sh>