### PR TITLE
osbuilder: Change to "=" operator to make script more portable

### DIFF
--- a/tools/osbuilder/rootfs-builder/centos/config.sh
+++ b/tools/osbuilder/rootfs-builder/centos/config.sh
@@ -27,7 +27,7 @@ PACKAGES="iptables chrony"
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
-[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+[ "$AGENT_INIT" = "no" ] && PACKAGES+=" systemd" || true
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd

--- a/tools/osbuilder/rootfs-builder/clearlinux/config.sh
+++ b/tools/osbuilder/rootfs-builder/clearlinux/config.sh
@@ -20,7 +20,7 @@ PACKAGES="libudev0-shim kmod-bin"
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
-[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd chrony iptables-bin util-linux-bin" || true
+[ "$AGENT_INIT" = "no" ] && PACKAGES+=" systemd chrony iptables-bin util-linux-bin" || true
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd

--- a/tools/osbuilder/rootfs-builder/fedora/config.sh
+++ b/tools/osbuilder/rootfs-builder/fedora/config.sh
@@ -14,7 +14,7 @@ PACKAGES="iptables chrony"
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
-[ "$AGENT_INIT" == "no" ] && PACKAGES+=" systemd" || true
+[ "$AGENT_INIT" = "no" ] && PACKAGES+=" systemd" || true
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd


### PR DESCRIPTION
zsh doesn't support "==" as equal comparison operator, so
replace "==" with "=" to make the script more portable

Fixes: #2584

Signed-off-by: Binbin Zhang <binbin36520@gmail.com>