### PR TITLE
[backport] snap: Test variable instead of executing "branch"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -299,7 +299,7 @@ parts:
         | xargs ./configure
 
       # Copy QEMU configurations (Kconfigs)
-      case "$(branch)" in
+      case "${branch}" in
       "v5.1.0")
         cp -a ${kata_dir}/tools/packaging/qemu/default-configs/* default-configs
         ;;


### PR DESCRIPTION
In snapcraft.yaml we have a case statement on $(branch) - that is on the
output of executing a command "branch".  From the selections it appears
that what it actually wants is to simply select on the contents of the
$branch variable, which should be ${branch} instead.

fixes #2558

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>