### PR TITLE
runtime: improve unit test coverage for virtcontainers/pkg/cgroups

### DIFF
--- a/src/runtime/virtcontainers/pkg/cgroups/manager_test.go
+++ b/src/runtime/virtcontainers/pkg/cgroups/manager_test.go
@@ -6,8 +6,14 @@
 package cgroups
 
 import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
 	"testing"
 
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/rootless"
+	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,4 +41,262 @@ func TestNew(t *testing.T) {
 	assert.NoError(err)
 	assert.NotNil(mgr.mgr)
 
+}
+
+func TestHypervisorDevices(t *testing.T) {
+	assert := assert.New(t)
+
+	devices := hypervisorDevices()
+	assert.NotNil(devices)
+	assert.NotEmpty(devices)
+}
+
+func TestWritePids(t *testing.T) {
+	if rootless.IsRootless() {
+		t.Skipf("Unable to write pids to cgroup.procs: running rootless")
+		return
+	}
+
+	assert := assert.New(t)
+
+	pids := []int{1}
+	tmpDir := "/vc-pkg-cgroup-test-nil"
+	err := writePids(pids, tmpDir)
+	assert.Error(err)
+
+	tmpDir, err = ioutil.TempDir("", "vc-pkg-cgroup-test")
+	if err != nil {
+		t.Skipf("no such path: %v", tmpDir)
+		return
+	}
+	err = writePids(pids, tmpDir)
+	assert.NoError(err)
+}
+
+func TestReadPids(t *testing.T) {
+	if rootless.IsRootless() {
+		t.Skipf("Unable to read pids from cgroup.procs: running rootless")
+		return
+	}
+
+	assert := assert.New(t)
+
+	pids := []int{1}
+	tmpDir, err := ioutil.TempDir("", "vc-pkg-cgroup-test")
+	if err != nil {
+		t.Skipf("no such path: %v", tmpDir)
+		return
+	}
+	err = writePids(pids, tmpDir)
+	assert.NoError(err)
+	pids, err = readPids(tmpDir)
+	assert.NoError(err)
+	assert.NotEmpty(pids)
+	assert.Equal(1, pids[0])
+
+	pids, err = readPids("/vc-pkg-cgroup-test-nil")
+	assert.Error(err)
+	assert.Nil(pids)
+}
+
+func TestMoveToParent(t *testing.T) {
+	if rootless.IsRootless() {
+		t.Skipf("Unable to move pids to parent: running rootless")
+		return
+	}
+
+	assert := assert.New(t)
+
+	pids := []int{1}
+	path, err := ioutil.TempDir("", "vc-pkg-cgroup-test")
+	if err != nil {
+		t.Skipf("no such path: %v", path)
+		return
+	}
+	err = writePids(pids, path)
+	assert.NoError(err)
+
+	// create a cgroupfs cgroup manager
+	c := &Config{
+		Cgroups:     nil,
+		CgroupPath:  "system.slice:kubepod:container",
+		CgroupPaths: map[string]string{"unit_test": path},
+	}
+	mgr, err := New(c)
+	assert.NoError(err)
+	assert.NotNil(mgr.mgr)
+
+	err = mgr.moveToParent()
+	assert.NoError(err)
+	pids, err = readPids(path + "/..")
+	assert.NoError(err)
+	assert.NotEmpty(pids)
+	assert.Equal(1, pids[0])
+}
+
+func TestMoveToParentWithErrorPath(t *testing.T) {
+	assert := assert.New(t)
+
+	// create a cgroupfs cgroup manager
+	c := &Config{
+		Cgroups:     nil,
+		CgroupPath:  "system.slice:kubepod:container",
+		CgroupPaths: map[string]string{"unit_test": "/tmp/vc-cgroup-not-exist"},
+	}
+	mgr, err := New(c)
+	assert.NoError(err)
+	assert.NotNil(mgr.mgr)
+
+	err = mgr.moveToParent()
+	assert.NoError(err)
+}
+
+func TestMoveToParentWithNoPids(t *testing.T) {
+	assert := assert.New(t)
+
+	path, err := ioutil.TempDir("", "vc-pkg-cgroup-test")
+	if err != nil {
+		t.Skipf("no such path: %v", path)
+		return
+	}
+
+	// create a cgroupfs cgroup manager
+	c := &Config{
+		Cgroups:     nil,
+		CgroupPath:  "system.slice:kubepod:container",
+		CgroupPaths: map[string]string{"unit_test": path},
+	}
+	mgr, err := New(c)
+	assert.NoError(err)
+	assert.NotNil(mgr.mgr)
+
+	err = mgr.moveToParent()
+	assert.NoError(err)
+}
+
+func TestAdd(t *testing.T) {
+	assert := assert.New(t)
+
+	mgr := &Manager{
+		mgr: NewMockManager(),
+	}
+	assert.NotNil(mgr.mgr)
+
+	err := mgr.Add(1)
+	assert.NoError(err)
+}
+
+func TestApply(t *testing.T) {
+	assert := assert.New(t)
+
+	mgr := &Manager{
+		mgr: NewMockManager(),
+	}
+	assert.NotNil(mgr.mgr)
+
+	err := mgr.Apply()
+	assert.NoError(err)
+}
+
+func TestGetCgroups(t *testing.T) {
+	assert := assert.New(t)
+
+	mockCgroups := &configs.Cgroup{
+		Name:        "mock",
+		Path:        "",
+		ScopePrefix: "",
+		Paths:       map[string]string{},
+		Resources:   nil,
+	}
+	// create a cgroupfs cgroup manager
+	c := &Config{
+		Cgroups:    mockCgroups,
+		CgroupPath: "",
+	}
+	mgr, err := New(c)
+	assert.NoError(err)
+	assert.NotNil(mgr.mgr)
+
+	cgroups, err := mgr.GetCgroups()
+	assert.NoError(err)
+	assert.NotNil(cgroups)
+	assert.Equal(mockCgroups.Name, cgroups.Name)
+}
+
+func TestGetPaths(t *testing.T) {
+	assert := assert.New(t)
+
+	key := "unit_test"
+	path := "/tmp/vc-cgroup-path-test"
+	// create a cgroupfs cgroup manager
+	c := &Config{
+		Cgroups:     nil,
+		CgroupPath:  "system.slice:kubepod:container",
+		CgroupPaths: map[string]string{key: path},
+	}
+	mgr, err := New(c)
+	assert.NoError(err)
+	assert.NotNil(mgr.mgr)
+
+	cgroupPaths := mgr.GetPaths()
+	assert.NoError(err)
+	assert.NotNil(cgroupPaths)
+	value, ok := cgroupPaths[key]
+	assert.True(ok)
+	assert.Equal(path, value)
+}
+
+func TestDestroy(t *testing.T) {
+	assert := assert.New(t)
+
+	mgr := &Manager{
+		mgr: NewMockManager(),
+	}
+	assert.NotNil(mgr.mgr)
+
+	err := mgr.Destroy()
+	assert.NoError(err)
+}
+
+func TestAddDevice(t *testing.T) {
+	assert := assert.New(t)
+
+	mgr := &Manager{
+		mgr: NewMockManager(),
+	}
+	assert.NotNil(mgr.mgr)
+
+	ctx := context.Background()
+	device := "/dev/null"
+	if _, err := os.Stat(device); os.IsNotExist(err) {
+		t.Skipf("no such device: %v", device)
+		return
+	}
+	err := mgr.AddDevice(ctx, device)
+	assert.NoError(err)
+}
+
+func TestRemoveDevice(t *testing.T) {
+	assert := assert.New(t)
+
+	device := "/dev/null"
+	if _, err := os.Stat(device); os.IsNotExist(err) {
+		t.Skipf("no such device: %v", device)
+		return
+	}
+	mgr := &Manager{
+		mgr: NewMockManager(),
+	}
+	assert.NotNil(mgr.mgr)
+	err := mgr.RemoveDevice(device)
+	assert.NoError(err)
+
+	device = "/dev/cdrom"
+	if _, err := os.Stat(device); os.IsNotExist(err) {
+		t.Skipf("no such device: %v", device)
+		return
+	}
+	err = mgr.RemoveDevice(device)
+	assert.Error(err)
+	assert.True(strings.Contains(err.Error(), "not found in the cgroup"))
 }

--- a/src/runtime/virtcontainers/pkg/cgroups/mock_manager.go
+++ b/src/runtime/virtcontainers/pkg/cgroups/mock_manager.go
@@ -1,0 +1,107 @@
+// Copyright (c) 2020 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cgroups
+
+import (
+	libcontcgroups "github.com/opencontainers/runc/libcontainer/cgroups"
+	"github.com/opencontainers/runc/libcontainer/configs"
+	"github.com/opencontainers/runc/libcontainer/devices"
+)
+
+// mockManager is an empty github.com/opencontainers/runc/libcontainer/cgroups
+// Manager implementation, for testing and mocking purposes.
+type mockManager struct {
+}
+
+// nolint:golint
+func NewMockManager() libcontcgroups.Manager {
+	return &mockManager{}
+}
+
+// Apply creates a cgroup, if not yet created, and adds a process
+// with the specified pid into that cgroup.  A special value of -1
+// can be used to merely create a cgroup.
+func (n *mockManager) Apply(pid int) error {
+	return nil
+}
+
+// GetPids returns the PIDs of all processes inside the cgroup.
+func (n *mockManager) GetPids() ([]int, error) {
+	return nil, nil
+}
+
+// GetAllPids returns the PIDs of all processes inside the cgroup
+// any all its sub-cgroups.
+func (n *mockManager) GetAllPids() ([]int, error) {
+	return nil, nil
+}
+
+// GetStats returns cgroups statistics.
+func (n *mockManager) GetStats() (*libcontcgroups.Stats, error) {
+	return nil, nil
+}
+
+// Freeze sets the freezer cgroup to the specified state.
+func (n *mockManager) Freeze(state configs.FreezerState) error {
+	return nil
+}
+
+// Destroy removes cgroup.
+func (n *mockManager) Destroy() error {
+	return nil
+}
+
+// Path returns a cgroup path to the specified controller/subsystem.
+// For cgroupv2, the argument is unused and can be empty.
+func (n *mockManager) Path(string) string {
+	return ""
+}
+
+// Set sets cgroup resources parameters/limits. If the argument is nil,
+// the resources specified during Manager creation (or the previous call
+// to Set) are used.
+func (n *mockManager) Set(r *configs.Resources) error {
+	return nil
+}
+
+// GetPaths returns cgroup path(s) to save in a state file in order to
+// restore later.
+func (n *mockManager) GetPaths() map[string]string {
+	return nil
+}
+
+// GetCgroups returns the cgroup data as configured.
+func (n *mockManager) GetCgroups() (*configs.Cgroup, error) {
+	devPath := "/dev/null"
+	dev, err := DeviceToCgroupDeviceRule(devPath)
+	if err != nil {
+		dev = &devices.Rule{}
+	}
+	return &configs.Cgroup{
+		Name:        "mock",
+		Path:        "",
+		ScopePrefix: "",
+		Paths:       nil,
+		Resources: &configs.Resources{
+			Devices: []*devices.Rule{dev},
+		},
+	}, nil
+}
+
+// GetFreezerState retrieves the current FreezerState of the cgroup.
+func (n *mockManager) GetFreezerState() (configs.FreezerState, error) {
+	return configs.Undefined, nil
+}
+
+// Exists returns whether the cgroup path exists or not.
+func (n *mockManager) Exists() bool {
+	return false
+}
+
+// OOMKillCount reports OOM kill count for the cgroup.
+func (n *mockManager) OOMKillCount() (uint64, error) {
+	return 0, nil
+}

--- a/src/runtime/virtcontainers/pkg/cgroups/utils_test.go
+++ b/src/runtime/virtcontainers/pkg/cgroups/utils_test.go
@@ -157,3 +157,16 @@ func TestDeviceToLinuxDevice(t *testing.T) {
 	assert.NotEmpty(dev.Access)
 	assert.True(dev.Allow)
 }
+
+func TestRenameCgroupPath(t *testing.T) {
+	assert := assert.New(t)
+
+	path := ""
+	_, err := RenameCgroupPath(path)
+	assert.Error(err)
+
+	path = "/test"
+	filePath, err := RenameCgroupPath(path)
+	assert.NoError(err)
+	assert.NotNil(filePath)
+}


### PR DESCRIPTION
Improve unit test coverage for virtcontainers/pkg/cgroups for Kata 2.0 runtime

Fixes: #262

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>