### PR TITLE
runtime: Fix README link

### DIFF
--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -27,7 +27,7 @@ to work seamlessly with both Docker and Kubernetes respectively.
 
 The code is licensed under an Apache 2.0 license.
 
-See [the license file](LICENSE) for further details.
+See [the license file](../../LICENSE) for further details.
 
 ## Platform support
 


### PR DESCRIPTION
The LICENSE file lives in the project's root.

Fixes #2612

Signed-off-by: Samuel Ortiz <s.ortiz@apple.com>