### PR TITLE
tracing: Accept multiple dynamic tags

### DIFF
--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -112,7 +112,7 @@ func SetEphemeralStorageType(ociSpec specs.Spec) specs.Spec {
 func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec specs.Spec, runtimeConfig oci.RuntimeConfig, rootFs vc.RootFs,
 	containerID, bundlePath, console string, disableOutput, systemdCgroup bool) (_ vc.VCSandbox, _ vc.Process, err error) {
 	span, ctx := katatrace.Trace(ctx, nil, "CreateSandbox", createTracingTags)
-	katatrace.AddTag(span, "container_id", containerID)
+	katatrace.AddTags(span, "container_id", containerID)
 	defer span.End()
 
 	sandboxConfig, err := oci.SandboxConfig(ociSpec, runtimeConfig, bundlePath, containerID, console, disableOutput, systemdCgroup)
@@ -167,7 +167,7 @@ func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec specs.Spec, runtimeCo
 
 	sid := sandbox.ID()
 	kataUtilsLogger = kataUtilsLogger.WithField("sandbox", sid)
-	katatrace.AddTag(span, "sandbox_id", sid)
+	katatrace.AddTags(span, "sandbox_id", sid)
 
 	containers := sandbox.GetAllContainers()
 	if len(containers) != 1 {
@@ -211,7 +211,7 @@ func CreateContainer(ctx context.Context, sandbox vc.VCSandbox, ociSpec specs.Sp
 	var c vc.VCContainer
 
 	span, ctx := katatrace.Trace(ctx, nil, "CreateContainer", createTracingTags)
-	katatrace.AddTag(span, "container_id", containerID)
+	katatrace.AddTags(span, "container_id", containerID)
 	defer span.End()
 
 	ociSpec = SetEphemeralStorageType(ociSpec)
@@ -237,7 +237,7 @@ func CreateContainer(ctx context.Context, sandbox vc.VCSandbox, ociSpec specs.Sp
 		return vc.Process{}, err
 	}
 
-	katatrace.AddTag(span, "sandbox_id", sandboxID)
+	katatrace.AddTags(span, "sandbox_id", sandboxID)
 
 	c, err = sandbox.CreateContainer(ctx, contConfig)
 	if err != nil {

--- a/src/runtime/pkg/katautils/hook.go
+++ b/src/runtime/pkg/katautils/hook.go
@@ -35,8 +35,7 @@ func hookLogger() *logrus.Entry {
 func runHook(ctx context.Context, hook specs.Hook, cid, bundlePath string) error {
 	span, _ := katatrace.Trace(ctx, hookLogger(), "runHook", hookTracingTags)
 	defer span.End()
-	katatrace.AddTag(span, "path", hook.Path)
-	katatrace.AddTag(span, "args", hook.Args)
+	katatrace.AddTags(span, "path", hook.Path, "args", hook.Args)
 
 	state := specs.State{
 		Pid:    syscall.Gettid(),
@@ -93,7 +92,7 @@ func runHook(ctx context.Context, hook specs.Hook, cid, bundlePath string) error
 
 func runHooks(ctx context.Context, hooks []specs.Hook, cid, bundlePath, hookType string) error {
 	span, ctx := katatrace.Trace(ctx, hookLogger(), "runHooks", hookTracingTags)
-	katatrace.AddTag(span, "type", hookType)
+	katatrace.AddTags(span, "type", hookType)
 	defer span.End()
 
 	for _, hook := range hooks {

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -344,7 +344,7 @@ func (k *kataAgent) internalConfigure(ctx context.Context, h Hypervisor, id stri
 	}
 	k.keepConn = config.LongLiveConn
 
-	katatrace.AddTag(span, "socket", k.vmSocket)
+	katatrace.AddTags(span, "socket", k.vmSocket)
 
 	return nil
 }

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -1304,10 +1304,10 @@ func getNetworkTrace(networkType EndpointType) func(ctx context.Context, name st
 	return func(ctx context.Context, name string, endpoint interface{}) (otelTrace.Span, context.Context) {
 		span, ctx := katatrace.Trace(ctx, networkLogger(), name, networkTracingTags)
 		if networkType != "" {
-			katatrace.AddTag(span, "type", string(networkType))
+			katatrace.AddTags(span, "type", string(networkType))
 		}
 		if endpoint != nil {
-			katatrace.AddTag(span, "endpoint", endpoint)
+			katatrace.AddTags(span, "endpoint", endpoint)
 		}
 		return span, ctx
 	}
@@ -1315,7 +1315,7 @@ func getNetworkTrace(networkType EndpointType) func(ctx context.Context, name st
 
 func closeSpan(span otelTrace.Span, err error) {
 	if err != nil {
-		katatrace.AddTag(span, "error", err)
+		katatrace.AddTags(span, "error", err.Error())
 	}
 	span.End()
 }
@@ -1333,15 +1333,14 @@ func (n *Network) Run(ctx context.Context, networkNSPath string, cb func() error
 // Add adds all needed interfaces inside the network namespace.
 func (n *Network) Add(ctx context.Context, config *NetworkConfig, s *Sandbox, hotplug bool) ([]Endpoint, error) {
 	span, ctx := n.trace(ctx, "Add")
-	katatrace.AddTag(span, "type", config.InterworkingModel.GetModel())
+	katatrace.AddTags(span, "type", config.InterworkingModel.GetModel())
 	defer span.End()
 
 	endpoints, err := createEndpointsFromScan(config.NetNSPath, config)
 	if err != nil {
 		return endpoints, err
 	}
-	katatrace.AddTag(span, "endpoints", endpoints)
-	katatrace.AddTag(span, "hotplug", hotplug)
+	katatrace.AddTags(span, "endpoints", endpoints, "hotplug", hotplug)
 
 	err = doNetNS(config.NetNSPath, func(_ ns.NetNS) error {
 		for _, endpoint := range endpoints {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1726,8 +1726,8 @@ func (q *qemu) hotplugDevice(ctx context.Context, devInfo interface{}, devType D
 }
 
 func (q *qemu) HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "HotplugAddDevice", qemuTracingTags, map[string]string{"sandbox_id": q.id})
-	katatrace.AddTag(span, "device", devInfo)
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "HotplugAddDevice", qemuTracingTags)
+	katatrace.AddTags(span, "sandbox_id", q.id, "device", devInfo)
 	defer span.End()
 
 	data, err := q.hotplugDevice(ctx, devInfo, devType, AddDevice)
@@ -1739,8 +1739,8 @@ func (q *qemu) HotplugAddDevice(ctx context.Context, devInfo interface{}, devTyp
 }
 
 func (q *qemu) HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "HotplugRemoveDevice", qemuTracingTags, map[string]string{"sandbox_id": q.id})
-	katatrace.AddTag(span, "device", devInfo)
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "HotplugRemoveDevice", qemuTracingTags)
+	katatrace.AddTags(span, "sandbox_id", q.id, "device", devInfo)
 	defer span.End()
 
 	data, err := q.hotplugDevice(ctx, devInfo, devType, RemoveDevice)
@@ -1968,8 +1968,8 @@ func (q *qemu) ResumeVM(ctx context.Context) error {
 // addDevice will add extra devices to Qemu command line.
 func (q *qemu) AddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
 	var err error
-	span, _ := katatrace.Trace(ctx, q.Logger(), "AddDevice", qemuTracingTags, map[string]string{"sandbox_id": q.id})
-	katatrace.AddTag(span, "device", devInfo)
+	span, _ := katatrace.Trace(ctx, q.Logger(), "AddDevice", qemuTracingTags)
+	katatrace.AddTags(span, "sandbox_id", q.id, "device", devInfo)
 	defer span.End()
 
 	switch v := devInfo.(type) {

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -822,8 +822,7 @@ func (s *Sandbox) createNetwork(ctx context.Context) error {
 		NetNsCreated: s.config.NetworkConfig.NetNsCreated,
 	}
 
-	katatrace.AddTag(span, "networkNS", s.networkNS)
-	katatrace.AddTag(span, "NetworkConfig", s.config.NetworkConfig)
+	katatrace.AddTags(span, "networkNS", s.networkNS, "NetworkConfig", s.config.NetworkConfig)
 
 	// In case there is a factory, network interfaces are hotplugged
 	// after vm is started.


### PR DESCRIPTION
    In later versions of OpenTelemetry label.Any() is deprecated. Change
    AddTag() to accept only strings for values. Add AddTagMarshal() which
    accepts an interface as a value and formats it for output.

    Change names AddTag and AddTagMarshal to AddTags and AddTagsMarshal
    respectively. Instead of taking a key and value as arguments, change
    them to use a map of string keys and values, or in the case of
    AddTagsMarshal, a map of string keys and interface values.
    
    I chose a map to represent the tags for several reasons:
    1. For consistency, since we already use a map of span tags for each
    subsystem,
    2. To keep these functions similar to how we accept tags when creating a
    span, which uses maps,
    3. To hopefully reduce possible errors by developers adding tags to
    spans. For example, an alternative is a variadic function that relies on
    a developer using an even number of strings or interfaces which would
    then be arranged into pairs in AddTags; if a key or value is missing it
    will cause incorrect output.
    
    Fixes #2547

