### PR TITLE
versions: Allow newer Rust versions

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -60,7 +60,7 @@ jobs:
         cd ${GOPATH}/src/github.com/${{ github.repository }} && ./ci/setup.sh
       env:
         GOPATH: ${{ runner.workspace }}/kata-containers
-    - name: Building rust
+    - name: Installing rust
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && ./ci/install_rust.sh

--- a/src/agent/src/watcher.rs
+++ b/src/agent/src/watcher.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#![allow(clippy::unknown_clippy_lints)]
+#![allow(unknown_lints)]
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/src/agent/vsock-exporter/src/lib.rs
+++ b/src/agent/vsock-exporter/src/lib.rs
@@ -12,7 +12,7 @@
 // payload, which allows the forwarder to know how many bytes it must read to
 // consume the trace span. The payload is a serialised version of the trace span.
 
-#![allow(clippy::unknown_clippy_lints)]
+#![allow(unknown_lints)]
 
 use async_trait::async_trait;
 use byteorder::{ByteOrder, NetworkEndian};

--- a/versions.yaml
+++ b/versions.yaml
@@ -255,7 +255,7 @@ languages:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.47.0"
+      newest-version: "1.54.0"
 
 specs:
   description: "Details of important specifications"


### PR DESCRIPTION
Update `versions.yaml` to test with more recent Rust versions than the now fairly old 1.47.0.