### PR TITLE
agent: fix scan_path ensure order for too many watched files

### DIFF
--- a/src/agent/src/watcher.rs
+++ b/src/agent/src/watcher.rs
@@ -203,14 +203,6 @@ impl Storage {
                 debug!(logger, "New entry: {}", path.display());
                 update_list.push(PathBuf::from(&path))
             }
-
-            ensure!(
-                self.watched_files.len() <= MAX_ENTRIES_PER_STORAGE,
-                WatcherError::MountTooManyFiles {
-                    count: self.watched_files.len(),
-                    mnt: self.source_mount_point.display().to_string()
-                }
-            );
         } else {
             // Scan dir recursively
             let mut entries = fs::read_dir(path)
@@ -226,6 +218,14 @@ impl Storage {
                 size += res_size;
             }
         }
+
+        ensure!(
+            self.watched_files.len() <= MAX_ENTRIES_PER_STORAGE,
+            WatcherError::MountTooManyFiles {
+                count: self.watched_files.len(),
+                mnt: self.source_mount_point.display().to_string()
+            }
+        );
 
         ensure!(
             size <= MAX_SIZE_PER_WATCHABLE_MOUNT,


### PR DESCRIPTION
Move the ensure!() check for too many watched files to the
end of scan_path to fix a potential error in the following case:

Test watch_directory_too_large covered a case where it creates 16
files in the source_dir to ensure that the scan detected 16 new watched
entries, next it created the 17th file and expected a return of
`WatcherError::MountTooManyFiles`. This however depends on the order
which the recursive scan_path on the 17 files. If the new file
was the last file scanned in the list, at this point, the watched_files
length is still at 16 which is less or equal to `MAX_ENTRIES_PER_STORAGE`
and the ensure!() check would pass and proceed to insert the 17th
file into the watched_files HashMap which is incorrect.

This change will move the ensure!() check to the end similar to the
check for max size per watchable mount to make sure we switch over
to from watchable to bind mount once we have exceeded 16 entries
per mount path.

Fixes #2640

Signed-off-by: Yibo Zhuang <yibzhuang@gmail.com>