### PR TITLE
runtime/qemu: Move from query-cpus to query-cpus-fast

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -2194,7 +2194,7 @@ func (q *qemu) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
 		return tid, err
 	}
 
-	cpuInfos, err := q.qmpMonitorCh.qmp.ExecQueryCpus(q.qmpMonitorCh.ctx)
+	cpuInfos, err := q.qmpMonitorCh.qmp.ExecQueryCpusFast(q.qmpMonitorCh.ctx)
 	if err != nil {
 		q.Logger().WithError(err).Error("failed to query cpu infos")
 		return tid, err
@@ -2203,7 +2203,7 @@ func (q *qemu) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
 	tid.vcpus = make(map[int]int, len(cpuInfos))
 	for _, i := range cpuInfos {
 		if i.ThreadID > 0 {
-			tid.vcpus[i.CPU] = i.ThreadID
+			tid.vcpus[i.CPUIndex] = i.ThreadID
 		}
 	}
 	return tid, nil


### PR DESCRIPTION
We recently updated to using qemu-6.1 (from qemu 5.2).  Unfortunately one
breaking change in qemu 6.0 wasn't caught by the CI.

The query-cpus QMP command has been removed, replaced by query-cpus-fast
(which has been available since qemu 2.12).  govmm already had support for
query-cpus-fast, we just weren't using it, so the change is quite easy.

fixes #2643

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>