### PR TITLE
runtime: Remove outdated TestStoreContainer

### DIFF
--- a/src/runtime/virtcontainers/container_test.go
+++ b/src/runtime/virtcontainers/container_test.go
@@ -689,18 +689,3 @@ func TestConfigValid(t *testing.T) {
 	result = config.valid()
 	assert.True(result)
 }
-
-func TestStoreContainer(t *testing.T) {
-	hConfig := newHypervisorConfig(nil, nil)
-	sandbox, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NetworkConfig{}, nil, nil)
-	assert.NoError(t, err)
-	defer cleanUp()
-
-	container := &Container{
-		sandbox: sandbox,
-	}
-
-	err = container.storeContainer()
-	assert.Nil(t, err, "store container should succeed")
-
-}


### PR DESCRIPTION
Due to #2332 being merged after running tests for #2604, and the latter
being merged now, a test for the now removed `storeContainer` was added.
Remove it.

Fixes: #2652
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>