### PR TITLE
CCV0 | agent: Enable authenticated agent pull image

### DIFF
--- a/docs/how-to/ccv0.sh
+++ b/docs/how-to/ccv0.sh
@@ -392,7 +392,7 @@ run_agent_ctl_command() {
 }
 
 agent_pull_image() {
-    run_agent_ctl_command "PullImage image=${PULL_IMAGE} cid=${CONTAINER_ID}"
+    run_agent_ctl_command "PullImage image=${PULL_IMAGE} cid=${CONTAINER_ID} source_creds=${SOURCE_CREDS}"
 }
 
 

--- a/docs/how-to/how-to-build-and-test-ccv0.md
+++ b/docs/how-to/how-to-build-and-test-ccv0.md
@@ -65,7 +65,12 @@ drwxr-xr-x 3 root root  60 Sep  6 09:44 shared
 ```
 $ ~/ccv0.sh -d open_kata_console
 ```
-- In the first console list run the pull image agent endpoint using `~/ccv0.sh -d agent_pull_image`: 
+- In the first terminal run the pull image agent endpoint:
+  - Optionally set up some environment variables to set the image and credentials used:
+    - By default the agent pull test in `ccv0.sh` will use the image `registry.fedoraproject.org/fedora:latest` which requires no authentication. If you want to use a different image, first set the `PULL_IMAGE` environment variable e.g. `export PULL_IMAGE="docker.io/library/busybox:latest"`.
+    - If the container registry for the image requires authentication then this can be set with an environment variable `SOURCE_CREDS`. For example to use `docker.io` as an authenticated user first run `export SOURCE_CREDS="<dockerhub username>:<dockerhub api key>"`
+    - *Note: the credentials support on the agent request is a tactical solution for the short-term proof of concept to allow more images to be pulled and tested. Once we have support for getting keys into the kata guest using the attestation-agent and/or KBS I'd expect container registry credentials to be looked up using that mechanism.*
+  - Run the pull image agent endpoint with `~/ccv0.sh -d agent_pull_image`: 
     - *For unknown reasons sometimes the unpack fails the first time and the sandbox crashes, but seems to work the second time and the pod will restart automatically, so just re-open the shell and console and re-run the agent_pull_image.*
 ```
 $ ~/ccv0.sh -d agent_pull_image

--- a/src/agent/protocols/protos/agent.proto
+++ b/src/agent/protocols/protos/agent.proto
@@ -518,4 +518,5 @@ message Metrics {
 message PullImageRequest {
 	string image = 1;
 	string container_id = 2;
+	string source_creds = 3;
 }

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -666,8 +666,9 @@ impl protocols::agent_ttrpc::AgentService for AgentService {
     ) -> ttrpc::Result<protocols::empty::Empty> {
         let image = req.get_image();
         let cid = req.get_container_id();
+        let source_creds = (!req.get_source_creds().is_empty()).then(|| req.get_source_creds());
 
-        pull_image_from_registry(image, cid)
+        pull_image_from_registry(image, cid, &source_creds)
             .map_err(|e| ttrpc_error(ttrpc::Code::INTERNAL, e.to_string()))?;
         unpack_image(cid).map_err(|e| ttrpc_error(ttrpc::Code::INTERNAL, e.to_string()))?;
 
@@ -1746,7 +1747,7 @@ fn load_kernel_module(module: &protocols::agent::KernelModule) -> Result<()> {
     }
 }
 
-fn pull_image_from_registry(image: &str, cid: &str) -> Result<()> {
+fn pull_image_from_registry(image: &str, cid: &str, source_creds: &Option<&str>) -> Result<()> {
     let source_image = format!("{}{}", "docker://", image);
 
     let manifest_path = format!("/tmp/{}/image_manifest", cid);
@@ -1759,11 +1760,19 @@ fn pull_image_from_registry(image: &str, cid: &str) -> Result<()> {
     fs::create_dir_all(&manifest_path)?;
     fs::create_dir_all(&oci_path)?;
 
-    let status: ExitStatus = Command::new(SKOPEO_PATH)
+    info!(sl!(), "Attempting to pull image {}...", &source_image);
+
+    let mut pull_command = Command::new(SKOPEO_PATH);
+    pull_command
         .arg("copy")
         .arg(source_image)
-        .arg(&target_path_manifest)
-        .status()?;
+        .arg(&target_path_manifest);
+
+    if let Some(source_creds) = source_creds {
+        pull_command.arg("--src-creds").arg(source_creds);
+    }
+
+    let status: ExitStatus = pull_command.status()?;
 
     if !status.success() {
         return Err(anyhow!(format!("failed to pull image: {:?}", status)));

--- a/tools/agent-ctl/src/client.rs
+++ b/tools/agent-ctl/src/client.rs
@@ -1872,9 +1872,11 @@ fn agent_cmd_pull_image(
 
     let image = utils::get_option("image", options, args);
     let cid = utils::get_option("cid", options, args);
+    let source_creds = utils::get_option("source_creds", options, args);
 
     req.set_image(image);
     req.set_container_id(cid);
+    req.set_source_creds(source_creds);
 
     debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
 


### PR DESCRIPTION
Add source credentials field to pull_image request
If field is not blank, send to skopeo in image pull command
Add source_creds to agentl-ctl pull command

Fixes: #2653
Signed-off-by: stevenhorsman <steven@uk.ibm.com>