### PR TITLE
stable-2.2 | runtime: tracing: Use root context to stop tracing

### DIFF
--- a/src/runtime/containerd-shim-v2/service.go
+++ b/src/runtime/containerd-shim-v2/service.go
@@ -911,7 +911,7 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (_ *
 	s.mu.Unlock()
 
 	span.End()
-	katatrace.StopTracing(s.ctx)
+	katatrace.StopTracing(s.rootCtx)
 
 	s.cancel()
 


### PR DESCRIPTION
Call StopTracing with s.rootCtx, which is the root context for tracing,
instead of s.ctx, which is parent to a subset of trace spans.

Backport of #2662

Fixes #2663

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>