### PR TITLE
runtime: update .gitignore file cleare the vc shim config

### DIFF
--- a/src/runtime/.gitignore
+++ b/src/runtime/.gitignore
@@ -17,7 +17,4 @@ config-generated.go
 /virtcontainers/hack/virtc/virtc
 /virtcontainers/hook/mock/hook
 /virtcontainers/profile.cov
-/virtcontainers/shim/mock/cc-shim/cc-shim
-/virtcontainers/shim/mock/kata-shim/kata-shim
-/virtcontainers/shim/mock/shim
 /virtcontainers/utils/supportfiles


### PR DESCRIPTION
update .gitignore file, remove the follow configurations:
/virtcontainers/shim/mock/cc-shim/cc-shim
/virtcontainers/shim/mock/kata-shim/kata-shim
/virtcontainers/shim/mock/shim

Fixes: #2670

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>