### PR TITLE
runtime: fix empty cgroup path validation error

### DIFF
--- a/src/runtime/virtcontainers/pkg/cgroups/utils.go
+++ b/src/runtime/virtcontainers/pkg/cgroups/utils.go
@@ -26,7 +26,7 @@ const DefaultCgroupPath = "/vc"
 
 func RenameCgroupPath(path string) (string, error) {
 	if path == "" {
-		return "", fmt.Errorf("Cgroup path is empty")
+		path = DefaultCgroupPath
 	}
 
 	cgroupPathDir := filepath.Dir(path)


### PR DESCRIPTION
An empty cgroup path shouldn't fail cgroup creation

Fixes #2674

Signed-off-by: Feng Wang <feng.wang@databricks.com>