### PR TITLE
stable-2.2 | virtcontainers: fc: parse vcpuID correctly

### DIFF
--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -1165,7 +1165,11 @@ func (fc *firecracker) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) 
 		if len(cpus) != 2 {
 			return vcpuInfo, errors.Errorf("Invalid fc thread info: %v", comm)
 		}
-		cpuID, err := strconv.ParseInt(cpus[1], 10, 32)
+
+		//Remove the leading whitespace
+		cpuIdStr := strings.TrimSpace(cpus[1])
+
+		cpuID, err := strconv.ParseInt(cpuIdStr, 10, 32)
 		if err != nil {
 			return vcpuInfo, errors.Wrapf(err, "Invalid fc thread info: %v", comm)
 		}


### PR DESCRIPTION
In getThreadIDs(), the cpuID variable is derived from a string that
already contains a whitespace. As a result, strings.SplitAfter returns
the cpuID with a leading space. This makes any go variant of string to int
fail (strconv.ParseInt() in our case). This patch makes sure that the
leading space character is removed so the string passed to
strconv.ParseInt() is "CPUID" and not " CPUID".

This has been caused by a change in the naming scheme of vcpu threads
for Firecracker after v0.19.1.

Fixes: #2592

Signed-off-by: Anastassios Nanos <ananos@nubificus.co.uk>