### PR TITLE
ci: Call agent shutdown test only in the correspondent CI_JOB

### DIFF
--- a/ci/run.sh
+++ b/ci/run.sh
@@ -8,11 +8,14 @@
 set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
+export CI_JOB="${CI_JOB:-}"
 
 clone_tests_repo
 
 pushd ${tests_repo_dir}
 .ci/run.sh
 # temporary fix, see https://github.com/kata-containers/tests/issues/3878
-[ "$(uname -m)" != "s390x" ] && tracing/test-agent-shutdown.sh
+if [ "$(uname -m)" != "s390x" ] && [ "$CI_JOB" == "CRI_CONTAINERD_K8S_MINIMAL" ]; then
+	tracing/test-agent-shutdown.sh
+fi
 popd


### PR DESCRIPTION
The agent shutdown test should only run on the CI JOB of CRI_CONTAINERD_K8S_MINIMAL
which is the only one where testing tracing is being enabled, however, this
test is being triggered in multiple CI jobs where it should not run. This PR
fixes that issue.

Fixes #2683

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>