### PR TITLE
runtime: fixed the factory template unit test case

### DIFF
--- a/src/runtime/virtcontainers/factory/template/template_test.go
+++ b/src/runtime/virtcontainers/factory/template/template_test.go
@@ -129,5 +129,5 @@ func TestTemplateFactory(t *testing.T) {
 
 	// expect tt.statePath not exist, if exist, it means this case failed.
 	_, err = os.Stat(tt.statePath)
-	assert.Nil(err)
+	assert.Error(err)
 }


### PR DESCRIPTION
The '/tmp/vc/mockfs' path was removed. We should get a PathError by os.Stat method.
Changed the assert code of this test case.

Fixes: #2691

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>