### PR TITLE
packaging: Backport QEMU's switch to GitLab repos

### DIFF
--- a/tools/packaging/qemu/patches/5.1.x/0014-gitmodules-use-GitLab-repos-instead-of-qemu.org.patch
+++ b/tools/packaging/qemu/patches/5.1.x/0014-gitmodules-use-GitLab-repos-instead-of-qemu.org.patch
@@ -1,0 +1,118 @@
+From 9911ca0d1bca846f159ebdb48b9d8a784c959589 Mon Sep 17 00:00:00 2001
+From: Stefan Hajnoczi <stefanha@redhat.com>
+Date: Mon, 11 Jan 2021 11:50:13 +0000
+Subject: [PATCH] gitmodules: use GitLab repos instead of qemu.org
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qemu.org is running out of bandwidth and the QEMU project is moving
+towards a gating CI on GitLab. Use the GitLab repos instead of qemu.org
+(they will become mirrors).
+
+Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>
+Reviewed-by: Wainer dos Santos Moschetta <wainersm@redhat.com>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Reviewed-by: Philippe Mathieu-Daudé <philmd@redhat.com>
+Message-id: 20210111115017.156802-3-stefanha@redhat.com
+Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>
+---
+ .gitmodules | 44 ++++++++++++++++++++++----------------------
+ 1 file changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/.gitmodules b/.gitmodules
+index 2bdeeacef8..08b1b48a09 100644
+--- a/.gitmodules
++++ b/.gitmodules
+@@ -1,66 +1,66 @@
+ [submodule "roms/seabios"]
+ 	path = roms/seabios
+-	url = https://git.qemu.org/git/seabios.git/
++	url = https://gitlab.com/qemu-project/seabios.git/
+ [submodule "roms/SLOF"]
+ 	path = roms/SLOF
+-	url = https://git.qemu.org/git/SLOF.git
++	url = https://gitlab.com/qemu-project/SLOF.git
+ [submodule "roms/ipxe"]
+ 	path = roms/ipxe
+-	url = https://git.qemu.org/git/ipxe.git
++	url = https://gitlab.com/qemu-project/ipxe.git
+ [submodule "roms/openbios"]
+ 	path = roms/openbios
+-	url = https://git.qemu.org/git/openbios.git
++	url = https://gitlab.com/qemu-project/openbios.git
+ [submodule "roms/qemu-palcode"]
+ 	path = roms/qemu-palcode
+-	url = https://git.qemu.org/git/qemu-palcode.git
++	url = https://gitlab.com/qemu-project/qemu-palcode.git
+ [submodule "roms/sgabios"]
+ 	path = roms/sgabios
+-	url = https://git.qemu.org/git/sgabios.git
++	url = https://gitlab.com/qemu-project/sgabios.git
+ [submodule "dtc"]
+ 	path = dtc
+-	url = https://git.qemu.org/git/dtc.git
++	url = https://gitlab.com/qemu-project/dtc.git
+ [submodule "roms/u-boot"]
+ 	path = roms/u-boot
+-	url = https://git.qemu.org/git/u-boot.git
++	url = https://gitlab.com/qemu-project/u-boot.git
+ [submodule "roms/skiboot"]
+ 	path = roms/skiboot
+-	url = https://git.qemu.org/git/skiboot.git
++	url = https://gitlab.com/qemu-project/skiboot.git
+ [submodule "roms/QemuMacDrivers"]
+ 	path = roms/QemuMacDrivers
+-	url = https://git.qemu.org/git/QemuMacDrivers.git
++	url = https://gitlab.com/qemu-project/QemuMacDrivers.git
+ [submodule "ui/keycodemapdb"]
+ 	path = ui/keycodemapdb
+-	url = https://git.qemu.org/git/keycodemapdb.git
++	url = https://gitlab.com/qemu-project/keycodemapdb.git
+ [submodule "capstone"]
+ 	path = capstone
+-	url = https://git.qemu.org/git/capstone.git
++	url = https://gitlab.com/qemu-project/capstone.git
+ [submodule "roms/seabios-hppa"]
+ 	path = roms/seabios-hppa
+-	url = https://git.qemu.org/git/seabios-hppa.git
++	url = https://gitlab.com/qemu-project/seabios-hppa.git
+ [submodule "roms/u-boot-sam460ex"]
+ 	path = roms/u-boot-sam460ex
+-	url = https://git.qemu.org/git/u-boot-sam460ex.git
++	url = https://gitlab.com/qemu-project/u-boot-sam460ex.git
+ [submodule "tests/fp/berkeley-testfloat-3"]
+ 	path = tests/fp/berkeley-testfloat-3
+-	url = https://git.qemu.org/git/berkeley-testfloat-3.git
++	url = https://gitlab.com/qemu-project/berkeley-testfloat-3.git
+ [submodule "tests/fp/berkeley-softfloat-3"]
+ 	path = tests/fp/berkeley-softfloat-3
+-	url = https://git.qemu.org/git/berkeley-softfloat-3.git
++	url = https://gitlab.com/qemu-project/berkeley-softfloat-3.git
+ [submodule "roms/edk2"]
+ 	path = roms/edk2
+-	url = https://git.qemu.org/git/edk2.git
++	url = https://gitlab.com/qemu-project/edk2.git
+ [submodule "slirp"]
+ 	path = slirp
+-	url = https://git.qemu.org/git/libslirp.git
++	url = https://gitlab.com/qemu-project/libslirp.git
+ [submodule "roms/opensbi"]
+ 	path = roms/opensbi
+-	url = 	https://git.qemu.org/git/opensbi.git
++	url = 	https://gitlab.com/qemu-project/opensbi.git
+ [submodule "roms/qboot"]
+ 	path = roms/qboot
+-	url = https://git.qemu.org/git/qboot.git
++	url = https://gitlab.com/qemu-project/qboot.git
+ [submodule "meson"]
+ 	path = meson
+-	url = https://git.qemu.org/git/meson.git
++	url = https://gitlab.com/qemu-project/meson.git
+ [submodule "roms/vbootrom"]
+ 	path = roms/vbootrom
+-	url = https://git.qemu.org/git/vbootrom.git
++	url = https://gitlab.com/qemu-project/vbootrom.git
+-- 
+2.27.0
+

--- a/tools/packaging/qemu/patches/5.2.x/0011-gitmodules-use-GitLab-repos-instead-of-qemu.org.patch
+++ b/tools/packaging/qemu/patches/5.2.x/0011-gitmodules-use-GitLab-repos-instead-of-qemu.org.patch
@@ -1,0 +1,118 @@
+From 9911ca0d1bca846f159ebdb48b9d8a784c959589 Mon Sep 17 00:00:00 2001
+From: Stefan Hajnoczi <stefanha@redhat.com>
+Date: Mon, 11 Jan 2021 11:50:13 +0000
+Subject: [PATCH] gitmodules: use GitLab repos instead of qemu.org
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+qemu.org is running out of bandwidth and the QEMU project is moving
+towards a gating CI on GitLab. Use the GitLab repos instead of qemu.org
+(they will become mirrors).
+
+Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>
+Reviewed-by: Wainer dos Santos Moschetta <wainersm@redhat.com>
+Reviewed-by: Thomas Huth <thuth@redhat.com>
+Reviewed-by: Philippe Mathieu-Daudé <philmd@redhat.com>
+Message-id: 20210111115017.156802-3-stefanha@redhat.com
+Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>
+---
+ .gitmodules | 44 ++++++++++++++++++++++----------------------
+ 1 file changed, 22 insertions(+), 22 deletions(-)
+
+diff --git a/.gitmodules b/.gitmodules
+index 2bdeeacef8..08b1b48a09 100644
+--- a/.gitmodules
++++ b/.gitmodules
+@@ -1,66 +1,66 @@
+ [submodule "roms/seabios"]
+ 	path = roms/seabios
+-	url = https://git.qemu.org/git/seabios.git/
++	url = https://gitlab.com/qemu-project/seabios.git/
+ [submodule "roms/SLOF"]
+ 	path = roms/SLOF
+-	url = https://git.qemu.org/git/SLOF.git
++	url = https://gitlab.com/qemu-project/SLOF.git
+ [submodule "roms/ipxe"]
+ 	path = roms/ipxe
+-	url = https://git.qemu.org/git/ipxe.git
++	url = https://gitlab.com/qemu-project/ipxe.git
+ [submodule "roms/openbios"]
+ 	path = roms/openbios
+-	url = https://git.qemu.org/git/openbios.git
++	url = https://gitlab.com/qemu-project/openbios.git
+ [submodule "roms/qemu-palcode"]
+ 	path = roms/qemu-palcode
+-	url = https://git.qemu.org/git/qemu-palcode.git
++	url = https://gitlab.com/qemu-project/qemu-palcode.git
+ [submodule "roms/sgabios"]
+ 	path = roms/sgabios
+-	url = https://git.qemu.org/git/sgabios.git
++	url = https://gitlab.com/qemu-project/sgabios.git
+ [submodule "dtc"]
+ 	path = dtc
+-	url = https://git.qemu.org/git/dtc.git
++	url = https://gitlab.com/qemu-project/dtc.git
+ [submodule "roms/u-boot"]
+ 	path = roms/u-boot
+-	url = https://git.qemu.org/git/u-boot.git
++	url = https://gitlab.com/qemu-project/u-boot.git
+ [submodule "roms/skiboot"]
+ 	path = roms/skiboot
+-	url = https://git.qemu.org/git/skiboot.git
++	url = https://gitlab.com/qemu-project/skiboot.git
+ [submodule "roms/QemuMacDrivers"]
+ 	path = roms/QemuMacDrivers
+-	url = https://git.qemu.org/git/QemuMacDrivers.git
++	url = https://gitlab.com/qemu-project/QemuMacDrivers.git
+ [submodule "ui/keycodemapdb"]
+ 	path = ui/keycodemapdb
+-	url = https://git.qemu.org/git/keycodemapdb.git
++	url = https://gitlab.com/qemu-project/keycodemapdb.git
+ [submodule "capstone"]
+ 	path = capstone
+-	url = https://git.qemu.org/git/capstone.git
++	url = https://gitlab.com/qemu-project/capstone.git
+ [submodule "roms/seabios-hppa"]
+ 	path = roms/seabios-hppa
+-	url = https://git.qemu.org/git/seabios-hppa.git
++	url = https://gitlab.com/qemu-project/seabios-hppa.git
+ [submodule "roms/u-boot-sam460ex"]
+ 	path = roms/u-boot-sam460ex
+-	url = https://git.qemu.org/git/u-boot-sam460ex.git
++	url = https://gitlab.com/qemu-project/u-boot-sam460ex.git
+ [submodule "tests/fp/berkeley-testfloat-3"]
+ 	path = tests/fp/berkeley-testfloat-3
+-	url = https://git.qemu.org/git/berkeley-testfloat-3.git
++	url = https://gitlab.com/qemu-project/berkeley-testfloat-3.git
+ [submodule "tests/fp/berkeley-softfloat-3"]
+ 	path = tests/fp/berkeley-softfloat-3
+-	url = https://git.qemu.org/git/berkeley-softfloat-3.git
++	url = https://gitlab.com/qemu-project/berkeley-softfloat-3.git
+ [submodule "roms/edk2"]
+ 	path = roms/edk2
+-	url = https://git.qemu.org/git/edk2.git
++	url = https://gitlab.com/qemu-project/edk2.git
+ [submodule "slirp"]
+ 	path = slirp
+-	url = https://git.qemu.org/git/libslirp.git
++	url = https://gitlab.com/qemu-project/libslirp.git
+ [submodule "roms/opensbi"]
+ 	path = roms/opensbi
+-	url = 	https://git.qemu.org/git/opensbi.git
++	url = 	https://gitlab.com/qemu-project/opensbi.git
+ [submodule "roms/qboot"]
+ 	path = roms/qboot
+-	url = https://git.qemu.org/git/qboot.git
++	url = https://gitlab.com/qemu-project/qboot.git
+ [submodule "meson"]
+ 	path = meson
+-	url = https://git.qemu.org/git/meson.git
++	url = https://gitlab.com/qemu-project/meson.git
+ [submodule "roms/vbootrom"]
+ 	path = roms/vbootrom
+-	url = https://git.qemu.org/git/vbootrom.git
++	url = https://gitlab.com/qemu-project/vbootrom.git
+-- 
+2.27.0
+


### PR DESCRIPTION
QEMU's submodule checkout from git.qemu.org can fail. On QEMU 6.x, this
is not a problem because they moved to GitLab. However, we use QEMU 5.2
on stable-2.2, which can be a problem when no cached QEMU is used.
Backport QEMU's switch.

Fixes: #2698
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @jongwu @fidencio @wainersm