### PR TITLE
packaging: Backport QEMU's GitLab switch to 5.1.x

### DIFF
--- a/tools/packaging/qemu/patches/5.1.x/0014-gitmodules-use-GitLab-repos-instead-of-qemu.org.patch
+++ b/tools/packaging/qemu/patches/5.1.x/0014-gitmodules-use-GitLab-repos-instead-of-qemu.org.patch
@@ -1,4 +1,4 @@
-From 9911ca0d1bca846f159ebdb48b9d8a784c959589 Mon Sep 17 00:00:00 2001
+From 104e56711f131d80de82caed8759947509576e3b Mon Sep 17 00:00:00 2001
 From: Stefan Hajnoczi <stefanha@redhat.com>
 Date: Mon, 11 Jan 2021 11:50:13 +0000
 Subject: [PATCH] gitmodules: use GitLab repos instead of qemu.org
@@ -16,15 +16,16 @@ Reviewed-by: Thomas Huth <thuth@redhat.com>
 Reviewed-by: Philippe Mathieu-Daudé <philmd@redhat.com>
 Message-id: 20210111115017.156802-3-stefanha@redhat.com
 Signed-off-by: Stefan Hajnoczi <stefanha@redhat.com>
+Backported-by: Jakob Naucke <jakob.naucke@ibm.com>
 ---
- .gitmodules | 44 ++++++++++++++++++++++----------------------
- 1 file changed, 22 insertions(+), 22 deletions(-)
+ .gitmodules | 40 ++++++++++++++++++++--------------------
+ 1 file changed, 20 insertions(+), 20 deletions(-)
 
 diff --git a/.gitmodules b/.gitmodules
-index 2bdeeacef8..08b1b48a09 100644
+index 9c0501a4d4..fec515cec5 100644
 --- a/.gitmodules
 +++ b/.gitmodules
-@@ -1,66 +1,66 @@
+@@ -1,60 +1,60 @@
  [submodule "roms/seabios"]
  	path = roms/seabios
 -	url = https://git.qemu.org/git/seabios.git/
@@ -103,16 +104,8 @@ index 2bdeeacef8..08b1b48a09 100644
 +	url = 	https://gitlab.com/qemu-project/opensbi.git
  [submodule "roms/qboot"]
  	path = roms/qboot
--	url = https://git.qemu.org/git/qboot.git
+-	url = https://github.com/bonzini/qboot
 +	url = https://gitlab.com/qemu-project/qboot.git
- [submodule "meson"]
- 	path = meson
--	url = https://git.qemu.org/git/meson.git
-+	url = https://gitlab.com/qemu-project/meson.git
- [submodule "roms/vbootrom"]
- 	path = roms/vbootrom
--	url = https://git.qemu.org/git/vbootrom.git
-+	url = https://gitlab.com/qemu-project/vbootrom.git
 -- 
-2.27.0
+2.31.1
 


### PR DESCRIPTION
This brings #2699 to 5.1.x for ARM. Add a `no_patches` for 5.1.0 which
was missing apparently.

Fixes: #2701
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @gkurz @jongwu
I hope the attribution is correct this way, PTAL @wainersm