### PR TITLE
DNM: Prototype to explore decoupling the Hypervisor logic from Kata and vice versa

### DIFF
--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -631,7 +631,7 @@ func (a *Acrn) GetVMConsole(ctx context.Context, id string) (string, string, err
 	return consoleProtoUnix, consoleURL, nil
 }
 
-func (a *Acrn) saveSandbox() error {
+func (a *Acrn) SaveVM() error {
 	a.Logger().Info("Save sandbox")
 
 	// Not supported. return success

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -448,7 +448,7 @@ func (a *Acrn) startSandbox(ctx context.Context, timeoutSecs int) error {
 	}
 	a.state.PID = PID
 
-	if err = a.waitSandbox(ctx, timeoutSecs); err != nil {
+	if err = a.waitVM(ctx, timeoutSecs); err != nil {
 		a.Logger().WithField("acrn wait failed:", err).Debug()
 		return err
 	}
@@ -456,9 +456,9 @@ func (a *Acrn) startSandbox(ctx context.Context, timeoutSecs int) error {
 	return nil
 }
 
-// waitSandbox will wait for the Sandbox's VM to be up and running.
-func (a *Acrn) waitSandbox(ctx context.Context, timeoutSecs int) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "waitSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+// waitVM will wait for the Sandbox's VM to be up and running.
+func (a *Acrn) waitVM(ctx context.Context, timeoutSecs int) error {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "waitVM", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	if timeoutSecs < 0 {

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -248,7 +248,7 @@ func (a *Acrn) buildDevices(ctx context.Context, imagePath string) ([]Device, er
 		return nil, fmt.Errorf("Image Path should not be empty: %s", imagePath)
 	}
 
-	_, console, err := a.GetSandboxConsole(ctx, a.id)
+	_, console, err := a.GetVMConsole(ctx, a.id)
 	if err != nil {
 		return nil, err
 	}
@@ -619,8 +619,8 @@ func (a *Acrn) AddDevice(ctx context.Context, devInfo interface{}, devType Devic
 
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
-func (a *Acrn) GetSandboxConsole(ctx context.Context, id string) (string, string, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "GetSandboxConsole", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) GetVMConsole(ctx context.Context, id string) (string, string, error) {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "GetVMConsole", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	consoleURL, err := utils.BuildSocketPath(a.store.RunVMStoragePath(), id, acrnConsoleSocket)

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -344,6 +344,11 @@ func (a *Acrn) createDummyVirtioBlkDev(ctx context.Context, devices []Device) ([
 
 // createSandbox is the Hypervisor sandbox creation.
 func (a *Acrn) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
+	hypervisorConfig.IsSandbox = true
+	return a.CreateVM(ctx, id, networkNS, hypervisorConfig)
+}
+
+func (a *Acrn) CreateVM(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
 	// Save the tracing context
 	a.ctx = ctx
 

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -575,8 +575,8 @@ func (a *Acrn) PauseVM(ctx context.Context) error {
 	return nil
 }
 
-func (a *Acrn) resumeSandbox(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "resumeSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) ResumeVM(ctx context.Context) error {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "ResumeVM", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported. return success

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -411,8 +411,8 @@ func (a *Acrn) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 }
 
 // startSandbox will start the Sandbox's VM.
-func (a *Acrn) startSandbox(ctx context.Context, timeoutSecs int) error {
-	span, ctx := katatrace.Trace(ctx, a.Logger(), "startSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) StartVM(ctx context.Context, timeoutSecs int) error {
+	span, ctx := katatrace.Trace(ctx, a.Logger(), "StartVM", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	if a.config.Debug {

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -284,7 +284,7 @@ func (a *Acrn) setup(ctx context.Context, id string, hypervisorConfig *Hyperviso
 	span, _ := katatrace.Trace(ctx, a.Logger(), "setup", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
-	err := hypervisorConfig.valid()
+	err := hypervisorConfig.Valid()
 	if err != nil {
 		return err
 	}
@@ -543,12 +543,12 @@ func (a *Acrn) updateBlockDevice(drive *config.BlockDrive) error {
 	return err
 }
 
-func (a *Acrn) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
+func (a *Acrn) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugAddDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	switch devType {
-	case blockDev:
+	case BlockDev:
 		//The drive placeholder has to exist prior to Update
 		return nil, a.updateBlockDevice(devInfo.(*config.BlockDrive))
 	default:
@@ -557,7 +557,7 @@ func (a *Acrn) hotplugAddDevice(ctx context.Context, devInfo interface{}, devTyp
 	}
 }
 
-func (a *Acrn) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
+func (a *Acrn) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugRemoveDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
@@ -585,7 +585,7 @@ func (a *Acrn) resumeSandbox(ctx context.Context) error {
 }
 
 // addDevice will add extra devices to acrn command line.
-func (a *Acrn) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
+func (a *Acrn) addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
 	var err error
 	span, _ := katatrace.Trace(ctx, a.Logger(), "addDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
@@ -646,18 +646,18 @@ func (a *Acrn) disconnect(ctx context.Context) {
 	// Not supported.
 }
 
-func (a *Acrn) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
+func (a *Acrn) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
 	span, _ := katatrace.Trace(ctx, a.Logger(), "getThreadIDs", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported. return success
 	//Just allocating an empty map
 
-	return vcpuThreadIDs{}, nil
+	return VcpuThreadIDs{}, nil
 }
 
-func (a *Acrn) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, memoryDevice, error) {
-	return 0, memoryDevice{}, nil
+func (a *Acrn) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
+	return 0, MemoryDevice{}, nil
 }
 
 func (a *Acrn) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs uint32, newVCPUs uint32, err error) {

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -471,15 +471,15 @@ func (a *Acrn) waitSandbox(ctx context.Context, timeoutSecs int) error {
 }
 
 // stopSandbox will stop the Sandbox's VM.
-func (a *Acrn) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "stopSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) StopVM(ctx context.Context, waitOnly bool) (err error) {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "StopVM", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	a.Logger().Info("Stopping acrn VM")
 
 	defer func() {
 		if err != nil {
-			a.Logger().Info("stopSandbox failed")
+			a.Logger().Info("StopVM failed")
 		} else {
 			a.Logger().Info("acrn VM stopped")
 		}

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -155,14 +155,14 @@ func (a *Acrn) kernelParameters() string {
 }
 
 // Adds all capabilities supported by Acrn implementation of hypervisor interface
-func (a *Acrn) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "capabilities", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) Capabilities(ctx context.Context) types.Capabilities {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "Capabilities", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	return a.arch.capabilities()
 }
 
-func (a *Acrn) hypervisorConfig() HypervisorConfig {
+func (a *Acrn) HypervisorConfig() HypervisorConfig {
 	return a.config
 }
 
@@ -248,7 +248,7 @@ func (a *Acrn) buildDevices(ctx context.Context, imagePath string) ([]Device, er
 		return nil, fmt.Errorf("Image Path should not be empty: %s", imagePath)
 	}
 
-	_, console, err := a.getSandboxConsole(ctx, a.id)
+	_, console, err := a.GetSandboxConsole(ctx, a.id)
 	if err != nil {
 		return nil, err
 	}
@@ -490,7 +490,7 @@ func (a *Acrn) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
 	Idx := acrnUUIDsToIdx[uuid]
 
 	if err = a.loadInfo(); err != nil {
-		a.Logger().Info("Failed to load UUID availabiity info")
+		a.Logger().Info("Failed to Load UUID availabiity info")
 		return err
 	}
 
@@ -543,8 +543,8 @@ func (a *Acrn) updateBlockDevice(drive *config.BlockDrive) error {
 	return err
 }
 
-func (a *Acrn) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugAddDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "HotplugAddDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	switch devType {
@@ -552,13 +552,13 @@ func (a *Acrn) hotplugAddDevice(ctx context.Context, devInfo interface{}, devTyp
 		//The drive placeholder has to exist prior to Update
 		return nil, a.updateBlockDevice(devInfo.(*config.BlockDrive))
 	default:
-		return nil, fmt.Errorf("hotplugAddDevice: unsupported device: devInfo:%v, deviceType%v",
+		return nil, fmt.Errorf("HotplugAddDevice: unsupported device: devInfo:%v, deviceType%v",
 			devInfo, devType)
 	}
 }
 
-func (a *Acrn) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "hotplugRemoveDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "HotplugRemoveDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported. return success
@@ -585,9 +585,9 @@ func (a *Acrn) resumeSandbox(ctx context.Context) error {
 }
 
 // addDevice will add extra devices to acrn command line.
-func (a *Acrn) addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
+func (a *Acrn) AddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
 	var err error
-	span, _ := katatrace.Trace(ctx, a.Logger(), "addDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+	span, _ := katatrace.Trace(ctx, a.Logger(), "AddDevice", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	switch v := devInfo.(type) {
@@ -619,8 +619,8 @@ func (a *Acrn) addDevice(ctx context.Context, devInfo interface{}, devType Devic
 
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
-func (a *Acrn) getSandboxConsole(ctx context.Context, id string) (string, string, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "getSandboxConsole", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) GetSandboxConsole(ctx context.Context, id string) (string, string, error) {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "GetSandboxConsole", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	consoleURL, err := utils.BuildSocketPath(a.store.RunVMStoragePath(), id, acrnConsoleSocket)
@@ -632,22 +632,22 @@ func (a *Acrn) getSandboxConsole(ctx context.Context, id string) (string, string
 }
 
 func (a *Acrn) saveSandbox() error {
-	a.Logger().Info("save sandbox")
+	a.Logger().Info("Save sandbox")
 
 	// Not supported. return success
 
 	return nil
 }
 
-func (a *Acrn) disconnect(ctx context.Context) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "disconnect", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) Disconnect(ctx context.Context) {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "Disconnect", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported.
 }
 
-func (a *Acrn) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "getThreadIDs", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) GetThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "GetThreadIDs", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported. return success
@@ -656,26 +656,26 @@ func (a *Acrn) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
 	return VcpuThreadIDs{}, nil
 }
 
-func (a *Acrn) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
+func (a *Acrn) ResizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
 	return 0, MemoryDevice{}, nil
 }
 
-func (a *Acrn) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs uint32, newVCPUs uint32, err error) {
+func (a *Acrn) ResizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs uint32, newVCPUs uint32, err error) {
 	return 0, 0, nil
 }
 
-func (a *Acrn) cleanup(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "cleanup", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) Cleanup(ctx context.Context) error {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "Cleanup", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	return nil
 }
 
-func (a *Acrn) getPids() []int {
+func (a *Acrn) GetPids() []int {
 	return []int{a.state.PID}
 }
 
-func (a *Acrn) getVirtioFsPid() *int {
+func (a *Acrn) GetVirtioFsPid() *int {
 	return nil
 }
 
@@ -687,19 +687,19 @@ func (a *Acrn) toGrpc(ctx context.Context) ([]byte, error) {
 	return nil, errors.New("acrn is not supported by VM cache")
 }
 
-func (a *Acrn) save() (s persistapi.HypervisorState) {
+func (a *Acrn) Save() (s persistapi.HypervisorState) {
 	s.Pid = a.state.PID
 	s.Type = string(AcrnHypervisor)
 	s.UUID = a.state.UUID
 	return
 }
 
-func (a *Acrn) load(s persistapi.HypervisorState) {
+func (a *Acrn) Load(s persistapi.HypervisorState) {
 	a.state.PID = s.Pid
 	a.state.UUID = s.UUID
 }
 
-func (a *Acrn) check() error {
+func (a *Acrn) Check() error {
 	if err := syscall.Kill(a.state.PID, syscall.Signal(0)); err != nil {
 		return errors.Wrapf(err, "failed to ping acrn process")
 	}
@@ -707,7 +707,7 @@ func (a *Acrn) check() error {
 	return nil
 }
 
-func (a *Acrn) generateSocket(id string) (interface{}, error) {
+func (a *Acrn) GenerateSocket(id string) (interface{}, error) {
 	return generateVMSocket(id, a.store.RunVMStoragePath())
 }
 
@@ -799,7 +799,7 @@ func (a *Acrn) loadInfo() error {
 	return nil
 }
 
-func (a *Acrn) isRateLimiterBuiltin() bool {
+func (a *Acrn) IsRateLimiterBuiltin() bool {
 	return false
 }
 

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -33,7 +33,7 @@ import (
 var acrnTracingTags = map[string]string{
 	"source":    "runtime",
 	"package":   "virtcontainers",
-	"subsystem": "hypervisor",
+	"subsystem": "Hypervisor",
 	"type":      "acrn",
 }
 
@@ -87,7 +87,7 @@ type AcrnState struct {
 	PID  int
 }
 
-// Acrn is an Hypervisor interface implementation for the Linux acrn hypervisor.
+// Acrn is an Hypervisor interface implementation for the Linux acrn Hypervisor.
 type Acrn struct {
 	sandbox    *Sandbox
 	ctx        context.Context
@@ -154,7 +154,7 @@ func (a *Acrn) kernelParameters() string {
 	return strings.Join(paramsStr, " ")
 }
 
-// Adds all capabilities supported by Acrn implementation of hypervisor interface
+// Adds all capabilities supported by Acrn implementation of Hypervisor interface
 func (a *Acrn) Capabilities(ctx context.Context) types.Capabilities {
 	span, _ := katatrace.Trace(ctx, a.Logger(), "Capabilities", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -566,8 +566,8 @@ func (a *Acrn) HotplugRemoveDevice(ctx context.Context, devInfo interface{}, dev
 	return nil, nil
 }
 
-func (a *Acrn) pauseSandbox(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, a.Logger(), "pauseSandbox", acrnTracingTags, map[string]string{"sandbox_id": a.id})
+func (a *Acrn) PauseVM(ctx context.Context) error {
+	span, _ := katatrace.Trace(ctx, a.Logger(), "PauseVM", acrnTracingTags, map[string]string{"sandbox_id": a.id})
 	defer span.End()
 
 	// Not supported. return success

--- a/src/runtime/virtcontainers/acrn_test.go
+++ b/src/runtime/virtcontainers/acrn_test.go
@@ -205,7 +205,7 @@ func TestAcrnGetSandboxConsole(t *testing.T) {
 	sandboxID := "testSandboxID"
 	expected := filepath.Join(a.store.RunVMStoragePath(), sandboxID, consoleSocket)
 
-	proto, result, err := a.GetSandboxConsole(a.ctx, sandboxID)
+	proto, result, err := a.GetVMConsole(a.ctx, sandboxID)
 	assert.NoError(err)
 	assert.Equal(result, expected)
 	assert.Equal(proto, consoleProtoUnix)

--- a/src/runtime/virtcontainers/acrn_test.go
+++ b/src/runtime/virtcontainers/acrn_test.go
@@ -77,7 +77,7 @@ func TestAcrnCapabilities(t *testing.T) {
 		arch: &acrnArchBase{},
 	}
 
-	caps := a.capabilities(a.ctx)
+	caps := a.Capabilities(a.ctx)
 	assert.True(caps.IsBlockDeviceSupported())
 	assert.True(caps.IsBlockDeviceHotplugSupported())
 }
@@ -89,7 +89,7 @@ func testAcrnAddDevice(t *testing.T, devInfo interface{}, devType DeviceType, ex
 		arch: &acrnArchBase{},
 	}
 
-	err := a.addDevice(context.Background(), devInfo, devType)
+	err := a.AddDevice(context.Background(), devInfo, devType)
 	assert.NoError(err)
 	assert.Exactly(a.acrnConfig.Devices, expected)
 }
@@ -144,7 +144,7 @@ func TestAcrnHotplugUnsupportedDeviceType(t *testing.T) {
 		config: acrnConfig,
 	}
 
-	_, err := a.hotplugAddDevice(a.ctx, &MemoryDevice{0, 128, uint64(0), false}, FsDev)
+	_, err := a.HotplugAddDevice(a.ctx, &MemoryDevice{0, 128, uint64(0), false}, FsDev)
 	assert.Error(err)
 }
 
@@ -205,7 +205,7 @@ func TestAcrnGetSandboxConsole(t *testing.T) {
 	sandboxID := "testSandboxID"
 	expected := filepath.Join(a.store.RunVMStoragePath(), sandboxID, consoleSocket)
 
-	proto, result, err := a.getSandboxConsole(a.ctx, sandboxID)
+	proto, result, err := a.GetSandboxConsole(a.ctx, sandboxID)
 	assert.NoError(err)
 	assert.Equal(result, expected)
 	assert.Equal(proto, consoleProtoUnix)

--- a/src/runtime/virtcontainers/acrn_test.go
+++ b/src/runtime/virtcontainers/acrn_test.go
@@ -82,7 +82,7 @@ func TestAcrnCapabilities(t *testing.T) {
 	assert.True(caps.IsBlockDeviceHotplugSupported())
 }
 
-func testAcrnAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []Device) {
+func testAcrnAddDevice(t *testing.T, devInfo interface{}, devType DeviceType, expected []Device) {
 	assert := assert.New(t)
 	a := &Acrn{
 		ctx:  context.Background(),
@@ -112,7 +112,7 @@ func TestAcrnAddDeviceSerialPortDev(t *testing.T) {
 		Name:     name,
 	}
 
-	testAcrnAddDevice(t, socket, serialPortDev, expectedOut)
+	testAcrnAddDevice(t, socket, SerialPortDev, expectedOut)
 }
 
 func TestAcrnAddDeviceBlockDev(t *testing.T) {
@@ -131,7 +131,7 @@ func TestAcrnAddDeviceBlockDev(t *testing.T) {
 		Index: index,
 	}
 
-	testAcrnAddDevice(t, drive, blockDev, expectedOut)
+	testAcrnAddDevice(t, drive, BlockDev, expectedOut)
 }
 
 func TestAcrnHotplugUnsupportedDeviceType(t *testing.T) {
@@ -144,7 +144,7 @@ func TestAcrnHotplugUnsupportedDeviceType(t *testing.T) {
 		config: acrnConfig,
 	}
 
-	_, err := a.hotplugAddDevice(a.ctx, &memoryDevice{0, 128, uint64(0), false}, fsDev)
+	_, err := a.hotplugAddDevice(a.ctx, &MemoryDevice{0, 128, uint64(0), false}, FsDev)
 	assert.Error(err)
 }
 

--- a/src/runtime/virtcontainers/agent.go
+++ b/src/runtime/virtcontainers/agent.go
@@ -140,10 +140,10 @@ type agent interface {
 	resumeContainer(ctx context.Context, sandbox *Sandbox, c Container) error
 
 	// configure will update agent settings based on provided arguments
-	configure(ctx context.Context, h hypervisor, id, sharePath string, config KataAgentConfig) error
+	configure(ctx context.Context, h Hypervisor, id, sharePath string, config KataAgentConfig) error
 
 	// configureFromGrpc will update agent settings based on provided arguments which from Grpc
-	configureFromGrpc(ctx context.Context, h hypervisor, id string, config KataAgentConfig) error
+	configureFromGrpc(ctx context.Context, h Hypervisor, id string, config KataAgentConfig) error
 
 	// reseedRNG will reseed the guest random number generator
 	reseedRNG(ctx context.Context, data []byte) error

--- a/src/runtime/virtcontainers/api.go
+++ b/src/runtime/virtcontainers/api.go
@@ -63,7 +63,7 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 		return nil, err
 	}
 
-	// cleanup sandbox resources in case of any failure
+	// Cleanup sandbox resources in case of any failure
 	defer func() {
 		if err != nil {
 			s.Delete(ctx)

--- a/src/runtime/virtcontainers/api_test.go
+++ b/src/runtime/virtcontainers/api_test.go
@@ -90,7 +90,7 @@ func newTestSandboxConfigNoop() SandboxConfig {
 		CustomSpec:  emptySpec,
 	}
 
-	// Sets the hypervisor configuration.
+	// Sets the Hypervisor configuration.
 	hypervisorConfig := HypervisorConfig{
 		KernelPath:     filepath.Join(testDir, testKernel),
 		ImagePath:      filepath.Join(testDir, testImage),

--- a/src/runtime/virtcontainers/bridgedmacvlan_endpoint.go
+++ b/src/runtime/virtcontainers/bridgedmacvlan_endpoint.go
@@ -100,7 +100,7 @@ func (endpoint *BridgedMacvlanEndpoint) Attach(ctx context.Context, s *Sandbox) 
 		return err
 	}
 
-	return h.addDevice(ctx, endpoint, NetDev)
+	return h.AddDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for the virtual endpoint tears down the tap and bridge

--- a/src/runtime/virtcontainers/bridgedmacvlan_endpoint.go
+++ b/src/runtime/virtcontainers/bridgedmacvlan_endpoint.go
@@ -89,7 +89,7 @@ func (endpoint *BridgedMacvlanEndpoint) NetworkPair() *NetworkInterfacePair {
 }
 
 // Attach for virtual endpoint bridges the network pair and adds the
-// tap interface of the network pair to the hypervisor.
+// tap interface of the network pair to the Hypervisor.
 func (endpoint *BridgedMacvlanEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 	span, ctx := macvlanTrace(ctx, "Attach", endpoint)
 	defer span.End()
@@ -121,12 +121,12 @@ func (endpoint *BridgedMacvlanEndpoint) Detach(ctx context.Context, netNsCreated
 }
 
 // HotAttach for bridged macvlan endpoint not supported yet
-func (endpoint *BridgedMacvlanEndpoint) HotAttach(ctx context.Context, h hypervisor) error {
+func (endpoint *BridgedMacvlanEndpoint) HotAttach(ctx context.Context, h Hypervisor) error {
 	return fmt.Errorf("BridgedMacvlanEndpoint does not support Hot attach")
 }
 
 // HotDetach for bridged macvlan endpoint not supported yet
-func (endpoint *BridgedMacvlanEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsCreated bool, netNsPath string) error {
+func (endpoint *BridgedMacvlanEndpoint) HotDetach(ctx context.Context, h Hypervisor, netNsCreated bool, netNsPath string) error {
 	return fmt.Errorf("BridgedMacvlanEndpoint does not support Hot detach")
 }
 

--- a/src/runtime/virtcontainers/bridgedmacvlan_endpoint.go
+++ b/src/runtime/virtcontainers/bridgedmacvlan_endpoint.go
@@ -100,7 +100,7 @@ func (endpoint *BridgedMacvlanEndpoint) Attach(ctx context.Context, s *Sandbox) 
 		return err
 	}
 
-	return h.addDevice(ctx, endpoint, netDev)
+	return h.addDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for the virtual endpoint tears down the tap and bridge

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -352,14 +352,14 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 }
 
 // startSandbox will start the VMM and boot the virtual machine for the given sandbox.
-func (clh *cloudHypervisor) startSandbox(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "startSandbox", clhTracingTags, map[string]string{"sandbox_id": clh.id})
+func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "StartVM", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	ctx, cancel := context.WithTimeout(context.Background(), clhAPITimeout*time.Second)
 	defer cancel()
 
-	clh.Logger().WithField("function", "startSandbox").Info("starting Sandbox")
+	clh.Logger().WithField("function", "StartVM").Info("starting Sandbox")
 
 	vmPath := filepath.Join(clh.store.RunVMStoragePath(), clh.id)
 	err := os.MkdirAll(vmPath, DirMode)
@@ -381,7 +381,7 @@ func (clh *cloudHypervisor) startSandbox(ctx context.Context, timeout int) error
 	defer label.SetProcessLabel("")
 
 	if clh.config.SharedFS == config.VirtioFS {
-		clh.Logger().WithField("function", "startSandbox").Info("Starting virtiofsd")
+		clh.Logger().WithField("function", "StartVM").Info("Starting virtiofsd")
 		pid, err := clh.virtiofsd.Start(ctx, func() {
 			clh.StopVM(ctx, false)
 		})

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -412,8 +412,8 @@ func (clh *cloudHypervisor) startSandbox(ctx context.Context, timeout int) error
 
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
-func (clh *cloudHypervisor) GetSandboxConsole(ctx context.Context, id string) (string, string, error) {
-	clh.Logger().WithField("function", "GetSandboxConsole").WithField("id", id).Info("Get Sandbox Console")
+func (clh *cloudHypervisor) GetVMConsole(ctx context.Context, id string) (string, string, error) {
+	clh.Logger().WithField("function", "GetVMConsole").WithField("id", id).Info("Get Sandbox Console")
 	master, slave, err := console.NewPty()
 	if err != nil {
 		clh.Logger().WithError(err).Error("Error create pseudo tty")

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -685,8 +685,8 @@ func (clh *cloudHypervisor) Cleanup(ctx context.Context) error {
 	return nil
 }
 
-func (clh *cloudHypervisor) pauseSandbox(ctx context.Context) error {
-	clh.Logger().WithField("function", "pauseSandbox").Info("Pause Sandbox")
+func (clh *cloudHypervisor) PauseVM(ctx context.Context) error {
+	clh.Logger().WithField("function", "PauseVM").Info("Pause Sandbox")
 	return nil
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -695,8 +695,8 @@ func (clh *cloudHypervisor) SaveVM() error {
 	return nil
 }
 
-func (clh *cloudHypervisor) resumeSandbox(ctx context.Context) error {
-	clh.Logger().WithField("function", "resumeSandbox").Info("Resume Sandbox")
+func (clh *cloudHypervisor) ResumeVM(ctx context.Context) error {
+	clh.Logger().WithField("function", "ResumeVM").Info("Resume Sandbox")
 	return nil
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -37,12 +37,12 @@ import (
 var clhTracingTags = map[string]string{
 	"source":    "runtime",
 	"package":   "virtcontainers",
-	"subsystem": "hypervisor",
+	"subsystem": "Hypervisor",
 	"type":      "clh",
 }
 
 //
-// Constants and type definitions related to cloud hypervisor
+// Constants and type definitions related to cloud Hypervisor
 //
 
 type clhState uint8
@@ -69,7 +69,7 @@ const (
 	clhSocket             = "clh.sock"
 	clhAPISocket          = "clh-api.sock"
 	virtioFsSocket        = "virtiofsd.sock"
-	defaultClhPath        = "/usr/local/bin/cloud-hypervisor"
+	defaultClhPath        = "/usr/local/bin/cloud-Hypervisor"
 	virtioFsCacheAlways   = "always"
 )
 
@@ -141,7 +141,7 @@ func (c *clhClientApi) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chc
 }
 
 //
-// Cloud hypervisor state
+// Cloud Hypervisor state
 //
 type CloudHypervisorState struct {
 	apiSocket    string
@@ -184,7 +184,7 @@ var clhDebugKernelParams = []Param{
 
 //###########################################################
 //
-// hypervisor interface implementation for cloud-hypervisor
+// Hypervisor interface implementation for cloud-Hypervisor
 //
 //###########################################################
 
@@ -230,7 +230,7 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, networkNS N
 	}
 
 	// No need to return an error from there since there might be nothing
-	// to fetch if this is the first time the hypervisor is created.
+	// to fetch if this is the first time the Hypervisor is created.
 	clh.Logger().WithField("function", "createSandbox").Info("Sandbox not found creating")
 
 	// Make sure the kernel path is valid
@@ -269,10 +269,10 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, networkNS N
 
 	clh.vmconfig.Cmdline = chclient.NewCmdLineConfig(kernelParamsToString(params))
 
-	// set random device generator to hypervisor
+	// set random device generator to Hypervisor
 	clh.vmconfig.Rng = chclient.NewRngConfig(clh.config.EntropySource)
 
-	// set the initial root/boot disk of hypervisor
+	// set the initial root/boot disk of Hypervisor
 	imagePath, err := clh.config.ImageAssetPath()
 	if err != nil {
 		return err
@@ -290,7 +290,7 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, networkNS N
 		clh.vmconfig.Pmem = &[]chclient.PmemConfig{*pmem}
 	}
 
-	// set the serial console to the cloud hypervisor
+	// set the serial console to the cloud Hypervisor
 	if clh.config.Debug {
 		clh.vmconfig.Serial = chclient.NewConsoleConfig(cctTTY)
 	} else {
@@ -306,10 +306,10 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, networkNS N
 	cpu_topology.Packages = func(i int32) *int32 { return &i }(1)
 	clh.vmconfig.Cpus.Topology = cpu_topology
 
-	// Overwrite the default value of HTTP API socket path for cloud hypervisor
+	// Overwrite the default value of HTTP API socket path for cloud Hypervisor
 	apiSocketPath, err := clh.apiSocketPath(id)
 	if err != nil {
-		clh.Logger().WithError(err).Info("Invalid api socket path for cloud-hypervisor")
+		clh.Logger().WithError(err).Info("Invalid api socket path for cloud-Hypervisor")
 		return err
 	}
 	clh.state.apiSocket = apiSocketPath
@@ -395,7 +395,7 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
 		}
 		clh.state.VirtiofsdPID = pid
 	} else {
-		return errors.New("cloud-hypervisor only supports virtio based file sharing")
+		return errors.New("cloud-Hypervisor only supports virtio based file sharing")
 	}
 
 	pid, err := clh.launchClh()
@@ -403,7 +403,7 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
 		if shutdownErr := clh.virtiofsd.Stop(ctx); shutdownErr != nil {
 			clh.Logger().WithError(shutdownErr).Warn("error shutting down Virtiofsd")
 		}
-		return fmt.Errorf("failed to launch cloud-hypervisor: %q", err)
+		return fmt.Errorf("failed to launch cloud-Hypervisor: %q", err)
 	}
 	clh.state.PID = pid
 
@@ -448,7 +448,7 @@ func clhDriveIndexToID(i int) string {
 	return "clh_drive_" + strconv.Itoa(i)
 }
 
-// Various cloud-hypervisor APIs report a PCI address in "BB:DD.F"
+// Various cloud-Hypervisor APIs report a PCI address in "BB:DD.F"
 // form within the PciDeviceInfo struct.  This is a broken API,
 // because there's no way clh can reliably know the guest side bdf for
 // a device, since the bus number depends on how the guest firmware
@@ -475,7 +475,7 @@ func (clh *cloudHypervisor) hotplugAddBlockDevice(drive *config.BlockDrive) erro
 	}
 
 	if clh.config.BlockDeviceDriver != config.VirtioBlock {
-		return fmt.Errorf("incorrect hypervisor configuration on 'block_device_driver':"+
+		return fmt.Errorf("incorrect Hypervisor configuration on 'block_device_driver':"+
 			" using '%v' but only support '%v'", clh.config.BlockDeviceDriver, config.VirtioBlock)
 	}
 
@@ -582,7 +582,7 @@ func (clh *cloudHypervisor) ResizeMemory(ctx context.Context, reqMemMB uint32, m
 	// TODO: Add support for virtio-mem
 
 	if probe {
-		return 0, MemoryDevice{}, errors.New("probe memory is not supported for cloud-hypervisor")
+		return 0, MemoryDevice{}, errors.New("probe memory is not supported for cloud-Hypervisor")
 	}
 
 	if reqMemMB == 0 {
@@ -777,7 +777,7 @@ func (clh *cloudHypervisor) AddDevice(ctx context.Context, devInfo interface{}, 
 
 //###########################################################################
 //
-// Local helper methods related to the hypervisor interface implementation
+// Local helper methods related to the Hypervisor interface implementation
 //
 //###########################################################################
 
@@ -785,7 +785,7 @@ func (clh *cloudHypervisor) Logger() *log.Entry {
 	return virtLog.WithField("subsystem", "cloudHypervisor")
 }
 
-// Adds all capabilities supported by cloudHypervisor implementation of hypervisor interface
+// Adds all capabilities supported by cloudHypervisor implementation of Hypervisor interface
 func (clh *cloudHypervisor) Capabilities(ctx context.Context) types.Capabilities {
 	span, _ := katatrace.Trace(ctx, clh.Logger(), "Capabilities", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
@@ -850,7 +850,7 @@ func (clh *cloudHypervisor) reset() {
 func (clh *cloudHypervisor) GenerateSocket(id string) (interface{}, error) {
 	udsPath, err := clh.vsockSocketPath(id)
 	if err != nil {
-		clh.Logger().Info("Can't generate socket path for cloud-hypervisor")
+		clh.Logger().Info("Can't generate socket path for cloud-Hypervisor")
 		return types.HybridVSock{}, err
 	}
 
@@ -911,7 +911,7 @@ func (clh *cloudHypervisor) launchClh() (int, error) {
 
 	args := []string{cscAPIsocket, clh.state.apiSocket}
 	if clh.config.Debug {
-		// Cloud hypervisor log levels
+		// Cloud Hypervisor log levels
 		// 'v' occurrences increase the level
 		//0 =>  Error
 		//1 =>  Warn
@@ -953,7 +953,7 @@ func (clh *cloudHypervisor) launchClh() (int, error) {
 	}
 
 	if err := clh.waitVMM(clhTimeout); err != nil {
-		clh.Logger().WithError(err).Warn("cloud-hypervisor init failed")
+		clh.Logger().WithError(err).Warn("cloud-Hypervisor init failed")
 		return -1, err
 	}
 
@@ -962,7 +962,7 @@ func (clh *cloudHypervisor) launchClh() (int, error) {
 
 //###########################################################################
 //
-// Cloud-hypervisor CLI builder
+// Cloud-Hypervisor CLI builder
 //
 //###########################################################################
 
@@ -1146,14 +1146,14 @@ func (clh *cloudHypervisor) addVolume(volume types.Volume) error {
 	dax := clh.config.VirtioFSCacheSize != 0
 
 	// numQueues and queueSize are required, let's use the
-	// default values defined by cloud-hypervisor
+	// default values defined by cloud-Hypervisor
 	numQueues := int32(1)
 	queueSize := int32(1024)
 
 	fs := chclient.NewFsConfig(volume.MountTag, vfsdSockPath, numQueues, queueSize, dax, int64(clh.config.VirtioFSCacheSize<<20))
 	clh.vmconfig.Fs = &[]chclient.FsConfig{*fs}
 
-	clh.Logger().Debug("Adding share volume to hypervisor: ", volume.MountTag)
+	clh.Logger().Debug("Adding share volume to Hypervisor: ", volume.MountTag)
 	return nil
 }
 
@@ -1217,7 +1217,7 @@ func (clh *cloudHypervisor) cleanupVM(force bool) error {
 	return nil
 }
 
-// vmInfo ask to hypervisor for current VM status
+// vmInfo ask to Hypervisor for current VM status
 func (clh *cloudHypervisor) vmInfo() (chclient.VmInfo, error) {
 	cl := clh.client()
 	ctx, cancelInfo := context.WithTimeout(context.Background(), clhAPITimeout*time.Second)

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -188,9 +188,14 @@ var clhDebugKernelParams = []Param{
 //
 //###########################################################
 
+func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
+	hypervisorConfig.IsSandbox = true
+	return clh.CreateVM(ctx, id, networkNS, hypervisorConfig)
+}
+
 // For cloudHypervisor this call only sets the internal structure up.
 // The VM will be created and started through startSandbox().
-func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
+func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
 	clh.ctx = ctx
 
 	span, newCtx := katatrace.Trace(clh.ctx, clh.Logger(), "createSandbox", clhTracingTags, map[string]string{"sandbox_id": clh.id})

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -383,7 +383,7 @@ func (clh *cloudHypervisor) startSandbox(ctx context.Context, timeout int) error
 	if clh.config.SharedFS == config.VirtioFS {
 		clh.Logger().WithField("function", "startSandbox").Info("Starting virtiofsd")
 		pid, err := clh.virtiofsd.Start(ctx, func() {
-			clh.stopSandbox(ctx, false)
+			clh.StopVM(ctx, false)
 		})
 		if err != nil {
 			return err
@@ -701,10 +701,10 @@ func (clh *cloudHypervisor) ResumeVM(ctx context.Context) error {
 }
 
 // stopSandbox will stop the Sandbox's VM.
-func (clh *cloudHypervisor) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "stopSandbox", clhTracingTags, map[string]string{"sandbox_id": clh.id})
+func (clh *cloudHypervisor) StopVM(ctx context.Context, waitOnly bool) (err error) {
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "StopVM", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
-	clh.Logger().WithField("function", "stopSandbox").Info("Stop Sandbox")
+	clh.Logger().WithField("function", "StopVM").Info("Stop Sandbox")
 	return clh.terminate(ctx, waitOnly)
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -171,7 +171,7 @@ type cloudHypervisor struct {
 var clhKernelParams = []Param{
 	{"root", "/dev/pmem0p1"},
 	{"panic", "1"},         // upon kernel panic wait 1 second before reboot
-	{"no_timer_check", ""}, // do not check broken timer IRQ resources
+	{"no_timer_check", ""}, // do not Check broken timer IRQ resources
 	{"noreplace-smp", ""},  // do not replace SMP instructions
 	{"rootflags", "dax,data=ordered,errors=remount-ro ro"}, // mount the root filesystem as readonly
 	{"rootfstype", "ext4"},
@@ -412,8 +412,8 @@ func (clh *cloudHypervisor) startSandbox(ctx context.Context, timeout int) error
 
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
-func (clh *cloudHypervisor) getSandboxConsole(ctx context.Context, id string) (string, string, error) {
-	clh.Logger().WithField("function", "getSandboxConsole").WithField("id", id).Info("Get Sandbox Console")
+func (clh *cloudHypervisor) GetSandboxConsole(ctx context.Context, id string) (string, string, error) {
+	clh.Logger().WithField("function", "GetSandboxConsole").WithField("id", id).Info("Get Sandbox Console")
 	master, slave, err := console.NewPty()
 	if err != nil {
 		clh.Logger().WithError(err).Error("Error create pseudo tty")
@@ -424,13 +424,13 @@ func (clh *cloudHypervisor) getSandboxConsole(ctx context.Context, id string) (s
 	return consoleProtoPty, slave, nil
 }
 
-func (clh *cloudHypervisor) disconnect(ctx context.Context) {
-	clh.Logger().WithField("function", "disconnect").Info("Disconnecting Sandbox Console")
+func (clh *cloudHypervisor) Disconnect(ctx context.Context) {
+	clh.Logger().WithField("function", "Disconnect").Info("Disconnecting Sandbox Console")
 }
 
-func (clh *cloudHypervisor) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
+func (clh *cloudHypervisor) GetThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
 
-	clh.Logger().WithField("function", "getThreadIDs").Info("get thread ID's")
+	clh.Logger().WithField("function", "GetThreadIDs").Info("get thread ID's")
 
 	var vcpuInfo VcpuThreadIDs
 
@@ -519,8 +519,8 @@ func (clh *cloudHypervisor) hotPlugVFIODevice(device config.VFIODev) error {
 	return err
 }
 
-func (clh *cloudHypervisor) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugAddDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
+func (clh *cloudHypervisor) HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "HotplugAddDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	switch devType {
@@ -536,8 +536,8 @@ func (clh *cloudHypervisor) hotplugAddDevice(ctx context.Context, devInfo interf
 
 }
 
-func (clh *cloudHypervisor) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "hotplugRemoveDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
+func (clh *cloudHypervisor) HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "HotplugRemoveDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	var deviceID string
@@ -549,7 +549,7 @@ func (clh *cloudHypervisor) hotplugRemoveDevice(ctx context.Context, devInfo int
 		deviceID = devInfo.(*config.VFIODev).ID
 	default:
 		clh.Logger().WithFields(log.Fields{"devInfo": devInfo,
-			"deviceType": devType}).Error("hotplugRemoveDevice: unsupported device")
+			"deviceType": devType}).Error("HotplugRemoveDevice: unsupported device")
 		return nil, fmt.Errorf("Could not hot remove device: unsupported device: %v, type: %v",
 			devInfo, devType)
 	}
@@ -568,11 +568,11 @@ func (clh *cloudHypervisor) hotplugRemoveDevice(ctx context.Context, devInfo int
 	return nil, err
 }
 
-func (clh *cloudHypervisor) hypervisorConfig() HypervisorConfig {
+func (clh *cloudHypervisor) HypervisorConfig() HypervisorConfig {
 	return clh.config
 }
 
-func (clh *cloudHypervisor) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
+func (clh *cloudHypervisor) ResizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
 
 	// TODO: Add support for virtio-mem
 
@@ -593,7 +593,7 @@ func (clh *cloudHypervisor) resizeMemory(ctx context.Context, reqMemMB uint32, m
 	currentMem := utils.MemUnit(info.Config.Memory.Size) * utils.Byte
 	newMem := utils.MemUnit(reqMemMB) * utils.MiB
 
-	// Early check to verify if boot memory is the same as requested
+	// Early Check to verify if boot memory is the same as requested
 	if currentMem == newMem {
 		clh.Logger().WithField("memory", reqMemMB).Debugf("VM already has requested memory")
 		return uint32(currentMem.ToMiB()), MemoryDevice{}, nil
@@ -614,7 +614,7 @@ func (clh *cloudHypervisor) resizeMemory(ctx context.Context, reqMemMB uint32, m
 		newMem = alignedRequest
 	}
 
-	// Check if memory is the same as requested, a second check is done
+	// Check if memory is the same as requested, a second Check is done
 	// to consider the memory request now that is updated to be memory aligned
 	if currentMem == newMem {
 		clh.Logger().WithFields(log.Fields{"current-memory": currentMem, "new-memory": newMem}).Debug("VM already has requested memory(after alignment)")
@@ -638,27 +638,27 @@ func (clh *cloudHypervisor) resizeMemory(ctx context.Context, reqMemMB uint32, m
 	return uint32(newMem.ToMiB()), MemoryDevice{SizeMB: int(hotplugSize.ToMiB())}, nil
 }
 
-func (clh *cloudHypervisor) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs uint32, newVCPUs uint32, err error) {
+func (clh *cloudHypervisor) ResizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs uint32, newVCPUs uint32, err error) {
 	cl := clh.client()
 
 	// Retrieve the number of current vCPUs via HTTP API
 	info, err := clh.vmInfo()
 	if err != nil {
-		clh.Logger().WithField("function", "resizeVCPUs").WithError(err).Info("[clh] vmInfo failed")
+		clh.Logger().WithField("function", "ResizeVCPUs").WithError(err).Info("[clh] vmInfo failed")
 		return 0, 0, openAPIClientError(err)
 	}
 
 	currentVCPUs = uint32(info.Config.Cpus.BootVcpus)
 	newVCPUs = currentVCPUs
 
-	// Sanity check
+	// Sanity Check
 	if reqVCPUs == 0 {
-		clh.Logger().WithField("function", "resizeVCPUs").Debugf("Cannot resize vCPU to 0")
+		clh.Logger().WithField("function", "ResizeVCPUs").Debugf("Cannot resize vCPU to 0")
 		return currentVCPUs, newVCPUs, fmt.Errorf("Cannot resize vCPU to 0")
 	}
 	if reqVCPUs > uint32(info.Config.Cpus.MaxVcpus) {
 		clh.Logger().WithFields(log.Fields{
-			"function":    "resizeVCPUs",
+			"function":    "ResizeVCPUs",
 			"reqVCPUs":    reqVCPUs,
 			"clhMaxVCPUs": info.Config.Cpus.MaxVcpus,
 		}).Warn("exceeding the 'clhMaxVCPUs' (resizing to 'clhMaxVCPUs')")
@@ -680,8 +680,8 @@ func (clh *cloudHypervisor) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (c
 	return currentVCPUs, newVCPUs, nil
 }
 
-func (clh *cloudHypervisor) cleanup(ctx context.Context) error {
-	clh.Logger().WithField("function", "cleanup").Info("cleanup")
+func (clh *cloudHypervisor) Cleanup(ctx context.Context) error {
+	clh.Logger().WithField("function", "Cleanup").Info("Cleanup")
 	return nil
 }
 
@@ -716,7 +716,7 @@ func (clh *cloudHypervisor) toGrpc(ctx context.Context) ([]byte, error) {
 	return nil, errors.New("cloudHypervisor is not supported by VM cache")
 }
 
-func (clh *cloudHypervisor) save() (s persistapi.HypervisorState) {
+func (clh *cloudHypervisor) Save() (s persistapi.HypervisorState) {
 	s.Pid = clh.state.PID
 	s.Type = string(ClhHypervisor)
 	s.VirtiofsdPid = clh.state.VirtiofsdPID
@@ -724,13 +724,13 @@ func (clh *cloudHypervisor) save() (s persistapi.HypervisorState) {
 	return
 }
 
-func (clh *cloudHypervisor) load(s persistapi.HypervisorState) {
+func (clh *cloudHypervisor) Load(s persistapi.HypervisorState) {
 	clh.state.PID = s.Pid
 	clh.state.VirtiofsdPID = s.VirtiofsdPid
 	clh.state.apiSocket = s.APISocket
 }
 
-func (clh *cloudHypervisor) check() error {
+func (clh *cloudHypervisor) Check() error {
 	cl := clh.client()
 	ctx, cancel := context.WithTimeout(context.Background(), clhAPITimeout*time.Second)
 	defer cancel()
@@ -739,16 +739,16 @@ func (clh *cloudHypervisor) check() error {
 	return err
 }
 
-func (clh *cloudHypervisor) getPids() []int {
+func (clh *cloudHypervisor) GetPids() []int {
 	return []int{clh.state.PID}
 }
 
-func (clh *cloudHypervisor) getVirtioFsPid() *int {
+func (clh *cloudHypervisor) GetVirtioFsPid() *int {
 	return &clh.state.VirtiofsdPID
 }
 
-func (clh *cloudHypervisor) addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "addDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
+func (clh *cloudHypervisor) AddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "AddDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	var err error
@@ -763,7 +763,7 @@ func (clh *cloudHypervisor) addDevice(ctx context.Context, devInfo interface{}, 
 	case types.Volume:
 		err = clh.addVolume(v)
 	default:
-		clh.Logger().WithField("function", "addDevice").Warnf("Add device of type %v is not supported.", v)
+		clh.Logger().WithField("function", "AddDevice").Warnf("Add device of type %v is not supported.", v)
 		return fmt.Errorf("Not implemented support for %s", v)
 	}
 
@@ -781,11 +781,11 @@ func (clh *cloudHypervisor) Logger() *log.Entry {
 }
 
 // Adds all capabilities supported by cloudHypervisor implementation of hypervisor interface
-func (clh *cloudHypervisor) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "capabilities", clhTracingTags, map[string]string{"sandbox_id": clh.id})
+func (clh *cloudHypervisor) Capabilities(ctx context.Context) types.Capabilities {
+	span, _ := katatrace.Trace(ctx, clh.Logger(), "Capabilities", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
-	clh.Logger().WithField("function", "capabilities").Info("get Capabilities")
+	clh.Logger().WithField("function", "Capabilities").Info("get Capabilities")
 	var caps types.Capabilities
 	caps.SetFsSharingSupport()
 	caps.SetBlockDeviceHotplugSupport()
@@ -803,7 +803,7 @@ func (clh *cloudHypervisor) terminate(ctx context.Context, waitOnly bool) (err e
 	}
 
 	defer func() {
-		clh.Logger().Debug("cleanup VM")
+		clh.Logger().Debug("Cleanup VM")
 		if err1 := clh.cleanupVM(true); err1 != nil {
 			clh.Logger().WithError(err1).Error("failed to cleanupVM")
 		}
@@ -842,7 +842,7 @@ func (clh *cloudHypervisor) reset() {
 	clh.state.reset()
 }
 
-func (clh *cloudHypervisor) generateSocket(id string) (interface{}, error) {
+func (clh *cloudHypervisor) GenerateSocket(id string) (interface{}, error) {
 	udsPath, err := clh.vsockSocketPath(id)
 	if err != nil {
 		clh.Logger().Info("Can't generate socket path for cloud-hypervisor")
@@ -1168,7 +1168,7 @@ func (clh *cloudHypervisor) cleanupVM(force bool) error {
 		}
 	}
 
-	// cleanup vm path
+	// Cleanup vm path
 	dir := filepath.Join(clh.store.RunVMStoragePath(), clh.id)
 
 	// If it's a symlink, remove both dir and the target.
@@ -1180,7 +1180,7 @@ func (clh *cloudHypervisor) cleanupVM(force bool) error {
 	clh.Logger().WithFields(log.Fields{
 		"link": link,
 		"dir":  dir,
-	}).Infof("cleanup vm path")
+	}).Infof("Cleanup vm path")
 
 	if err := os.RemoveAll(dir); err != nil {
 		if !force {
@@ -1225,7 +1225,7 @@ func (clh *cloudHypervisor) vmInfo() (chclient.VmInfo, error) {
 	return info, openAPIClientError(err)
 }
 
-func (clh *cloudHypervisor) isRateLimiterBuiltin() bool {
+func (clh *cloudHypervisor) IsRateLimiterBuiltin() bool {
 	return false
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -690,7 +690,7 @@ func (clh *cloudHypervisor) PauseVM(ctx context.Context) error {
 	return nil
 }
 
-func (clh *cloudHypervisor) saveSandbox() error {
+func (clh *cloudHypervisor) SaveVM() error {
 	clh.Logger().WithField("function", "saveSandboxC").Info("Save Sandbox")
 	return nil
 }

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -280,13 +280,13 @@ func TestCloudHypervisorResizeMemory(t *testing.T) {
 	tests := []struct {
 		name           string
 		args           args
-		expectedMemDev memoryDevice
+		expectedMemDev MemoryDevice
 		wantErr        bool
 	}{
-		{"Resize to zero", args{0, 128}, memoryDevice{probe: false, sizeMB: 0}, FAIL},
-		{"Resize to aligned size", args{clhConfig.MemorySize + 128, 128}, memoryDevice{probe: false, sizeMB: 128}, PASS},
-		{"Resize to aligned size", args{clhConfig.MemorySize + 129, 128}, memoryDevice{probe: false, sizeMB: 256}, PASS},
-		{"Resize to NOT aligned size", args{clhConfig.MemorySize + 125, 128}, memoryDevice{probe: false, sizeMB: 128}, PASS},
+		{"Resize to zero", args{0, 128}, MemoryDevice{Probe: false, SizeMB: 0}, FAIL},
+		{"Resize to aligned size", args{clhConfig.MemorySize + 128, 128}, MemoryDevice{Probe: false, SizeMB: 128}, PASS},
+		{"Resize to aligned size", args{clhConfig.MemorySize + 129, 128}, MemoryDevice{Probe: false, SizeMB: 256}, PASS},
+		{"Resize to NOT aligned size", args{clhConfig.MemorySize + 125, 128}, MemoryDevice{Probe: false, SizeMB: 128}, PASS},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -312,7 +312,7 @@ func TestCloudHypervisorResizeMemory(t *testing.T) {
 				return
 			}
 
-			expectedMem := clhConfig.MemorySize + uint32(tt.expectedMemDev.sizeMB)
+			expectedMem := clhConfig.MemorySize + uint32(tt.expectedMemDev.SizeMB)
 
 			if newMem != expectedMem {
 				t.Errorf("cloudHypervisor.resizeMemory() got = %+v, want %+v", newMem, expectedMem)
@@ -357,12 +357,12 @@ func TestCloudHypervisorHotplugRemoveDevice(t *testing.T) {
 	clh.config = clhConfig
 	clh.APIClient = &clhClientMock{}
 
-	_, err = clh.hotplugRemoveDevice(context.Background(), &config.BlockDrive{}, blockDev)
+	_, err = clh.hotplugRemoveDevice(context.Background(), &config.BlockDrive{}, BlockDev)
 	assert.NoError(err, "Hotplug remove block device expected no error")
 
-	_, err = clh.hotplugRemoveDevice(context.Background(), &config.VFIODev{}, vfioDev)
+	_, err = clh.hotplugRemoveDevice(context.Background(), &config.VFIODev{}, VfioDev)
 	assert.NoError(err, "Hotplug remove vfio block device expected no error")
 
-	_, err = clh.hotplugRemoveDevice(context.Background(), nil, netDev)
+	_, err = clh.hotplugRemoveDevice(context.Background(), nil, NetDev)
 	assert.Error(err, "Hotplug remove pmem block device expected error")
 }

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -31,7 +31,7 @@ func newClhConfig() (HypervisorConfig, error) {
 	setupClh()
 
 	if testClhPath == "" {
-		return HypervisorConfig{}, errors.New("hypervisor fake path is empty")
+		return HypervisorConfig{}, errors.New("Hypervisor fake path is empty")
 	}
 
 	if testVirtiofsdPath == "" {

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -266,7 +266,7 @@ func TestClooudHypervisorStartSandbox(t *testing.T) {
 		store:     store,
 	}
 
-	err = clh.startSandbox(context.Background(), 10)
+	err = clh.StartVM(context.Background(), 10)
 	assert.NoError(err)
 }
 

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -301,10 +301,10 @@ func TestCloudHypervisorResizeMemory(t *testing.T) {
 			clh.APIClient = mockClient
 			clh.config = clhConfig
 
-			newMem, memDev, err := clh.resizeMemory(context.Background(), tt.args.reqMemMB, tt.args.memoryBlockSizeMB, false)
+			newMem, memDev, err := clh.ResizeMemory(context.Background(), tt.args.reqMemMB, tt.args.memoryBlockSizeMB, false)
 
 			if (err != nil) != tt.wantErr {
-				t.Errorf("cloudHypervisor.resizeMemory() error = %v, expected to fail = %v", err, tt.wantErr)
+				t.Errorf("cloudHypervisor.ResizeMemory() error = %v, expected to fail = %v", err, tt.wantErr)
 				return
 			}
 
@@ -315,11 +315,11 @@ func TestCloudHypervisorResizeMemory(t *testing.T) {
 			expectedMem := clhConfig.MemorySize + uint32(tt.expectedMemDev.SizeMB)
 
 			if newMem != expectedMem {
-				t.Errorf("cloudHypervisor.resizeMemory() got = %+v, want %+v", newMem, expectedMem)
+				t.Errorf("cloudHypervisor.ResizeMemory() got = %+v, want %+v", newMem, expectedMem)
 			}
 
 			if !reflect.DeepEqual(memDev, tt.expectedMemDev) {
-				t.Errorf("cloudHypervisor.resizeMemory() got = %+v, want %+v", memDev, tt.expectedMemDev)
+				t.Errorf("cloudHypervisor.ResizeMemory() got = %+v, want %+v", memDev, tt.expectedMemDev)
 			}
 		})
 	}
@@ -357,12 +357,12 @@ func TestCloudHypervisorHotplugRemoveDevice(t *testing.T) {
 	clh.config = clhConfig
 	clh.APIClient = &clhClientMock{}
 
-	_, err = clh.hotplugRemoveDevice(context.Background(), &config.BlockDrive{}, BlockDev)
+	_, err = clh.HotplugRemoveDevice(context.Background(), &config.BlockDrive{}, BlockDev)
 	assert.NoError(err, "Hotplug remove block device expected no error")
 
-	_, err = clh.hotplugRemoveDevice(context.Background(), &config.VFIODev{}, VfioDev)
+	_, err = clh.HotplugRemoveDevice(context.Background(), &config.VFIODev{}, VfioDev)
 	assert.NoError(err, "Hotplug remove vfio block device expected no error")
 
-	_, err = clh.hotplugRemoveDevice(context.Background(), nil, NetDev)
+	_, err = clh.HotplugRemoveDevice(context.Background(), nil, NetDev)
 	assert.Error(err, "Hotplug remove pmem block device expected error")
 }

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -392,7 +392,7 @@ func (c *Container) GetAnnotations() map[string]string {
 // This OCI specification was patched when the sandbox was created
 // by containerCapabilities(), SetEphemeralStorageType() and others
 // in order to support:
-// * capabilities
+// * Capabilities
 // * Ephemeral storage
 // * k8s empty dir
 // If you need the original (vanilla) OCI spec,
@@ -431,7 +431,7 @@ func (c *Container) shareFiles(ctx context.Context, m Mount, idx int) (string, b
 
 	// copy file to contaier's rootfs if filesystem sharing is not supported, otherwise
 	// bind mount it in the shared directory.
-	caps := c.sandbox.hypervisor.capabilities(ctx)
+	caps := c.sandbox.hypervisor.Capabilities(ctx)
 	if !caps.IsFsSharingSupported() {
 		c.Logger().Debug("filesystem sharing is not supported, files will be copied")
 
@@ -573,7 +573,7 @@ func (c *Container) mountSharedDirMounts(ctx context.Context, sharedDirMounts, i
 		// manually update the path that is mounted into the container).
 		// Based on this, let's make sure we update the sharedDirMount structure with the new watchable-mount as
 		// the source (this is what is utilized to update the OCI spec).
-		caps := c.sandbox.hypervisor.capabilities(ctx)
+		caps := c.sandbox.hypervisor.Capabilities(ctx)
 		if isWatchableMount(m.Source) && caps.IsFsSharingSupported() {
 
 			// Create path in shared directory for creating watchable mount:
@@ -663,7 +663,7 @@ func filterDevices(c *Container, devices []ContainerDevice) (ret []ContainerDevi
 	return
 }
 
-// Add any mount based block devices to the device manager and save the
+// Add any mount based block devices to the device manager and Save the
 // device ID for the particular mount. This'll occur when the mountpoint source
 // is a block device.
 func (c *Container) createBlockDevices(ctx context.Context) error {
@@ -705,7 +705,7 @@ func (c *Container) createBlockDevices(ctx context.Context) error {
 				Minor:         int64(unix.Minor(stat.Rdev)),
 				ReadOnly:      m.ReadOnly,
 			}
-			// check whether source can be used as a pmem device
+			// Check whether source can be used as a pmem device
 		} else if di, err = config.PmemDeviceInfo(m.Source, m.Destination); err != nil {
 			c.Logger().WithError(err).
 				WithField("mount-source", m.Source).
@@ -859,7 +859,7 @@ func (c *Container) rollbackFailingContainerCreation(ctx context.Context) {
 func (c *Container) checkBlockDeviceSupport(ctx context.Context) bool {
 	if !c.sandbox.config.HypervisorConfig.DisableBlockDeviceUse {
 		agentCaps := c.sandbox.agent.capabilities()
-		hypervisorCaps := c.sandbox.hypervisor.capabilities(ctx)
+		hypervisorCaps := c.sandbox.hypervisor.Capabilities(ctx)
 
 		if agentCaps.IsBlockDeviceSupported() && hypervisorCaps.IsBlockDeviceHotplugSupported() {
 			return true
@@ -982,7 +982,7 @@ func (c *Container) checkSandboxRunning(cmd string) error {
 }
 
 func (c *Container) getSystemMountInfo() {
-	// check if /dev needs to be bind mounted from host /dev
+	// Check if /dev needs to be bind mounted from host /dev
 	c.systemMountsInfo.BindMountDev = false
 
 	for _, m := range c.mounts {
@@ -1055,7 +1055,7 @@ func (c *Container) stop(ctx context.Context, force bool) error {
 		// Save device and drive data.
 		// TODO: can we merge this saving with setContainerState()?
 		if err := c.sandbox.Save(); err != nil {
-			c.Logger().WithError(err).Info("save container state failed")
+			c.Logger().WithError(err).Info("Save container state failed")
 		}
 	}()
 

--- a/src/runtime/virtcontainers/container_test.go
+++ b/src/runtime/virtcontainers/container_test.go
@@ -99,8 +99,8 @@ func TestContainerRemoveDrive(t *testing.T) {
 	container.state.Fstype = ""
 	err := container.removeDrive(sandbox.ctx)
 
-	// HotplugRemoveDevice for hypervisor should not be called.
-	// test should pass without a hypervisor created for the container's sandbox.
+	// HotplugRemoveDevice for Hypervisor should not be called.
+	// test should pass without a Hypervisor created for the container's sandbox.
 	assert.Nil(t, err, "remove drive should succeed")
 
 	sandbox.hypervisor = &mockHypervisor{}

--- a/src/runtime/virtcontainers/container_test.go
+++ b/src/runtime/virtcontainers/container_test.go
@@ -99,7 +99,7 @@ func TestContainerRemoveDrive(t *testing.T) {
 	container.state.Fstype = ""
 	err := container.removeDrive(sandbox.ctx)
 
-	// hotplugRemoveDevice for hypervisor should not be called.
+	// HotplugRemoveDevice for hypervisor should not be called.
 	// test should pass without a hypervisor created for the container's sandbox.
 	assert.Nil(t, err, "remove drive should succeed")
 
@@ -329,7 +329,7 @@ func TestContainerAddDriveDir(t *testing.T) {
 		rootFs:  RootFs{Target: fakeRootfs, Mounted: true},
 	}
 
-	// Make the checkStorageDriver func variable point to a fake check function
+	// Make the checkStorageDriver func variable point to a fake Check function
 	savedFunc := checkStorageDriver
 	checkStorageDriver = func(major, minor int) (bool, error) {
 		return true, nil
@@ -562,7 +562,7 @@ func TestMountSharedDirMounts(t *testing.T) {
 
 	// create a new shared directory for our test:
 	kataHostSharedDirSaved := kataHostSharedDir
-	testHostDir, err := ioutil.TempDir("", "kata-cleanup")
+	testHostDir, err := ioutil.TempDir("", "kata-Cleanup")
 	assert.NoError(err)
 	kataHostSharedDir = func() string {
 		return testHostDir

--- a/src/runtime/virtcontainers/endpoint.go
+++ b/src/runtime/virtcontainers/endpoint.go
@@ -26,8 +26,8 @@ type Endpoint interface {
 	SetPciPath(vcTypes.PciPath)
 	Attach(context.Context, *Sandbox) error
 	Detach(ctx context.Context, netNsCreated bool, netNsPath string) error
-	HotAttach(ctx context.Context, h hypervisor) error
-	HotDetach(ctx context.Context, h hypervisor, netNsCreated bool, netNsPath string) error
+	HotAttach(ctx context.Context, h Hypervisor) error
+	HotDetach(ctx context.Context, h Hypervisor, netNsCreated bool, netNsPath string) error
 
 	save() persistapi.NetworkEndpoint
 	load(persistapi.NetworkEndpoint)

--- a/src/runtime/virtcontainers/endpoint_test.go
+++ b/src/runtime/virtcontainers/endpoint_test.go
@@ -87,7 +87,7 @@ func TestIncorrectEndpointTypeString(t *testing.T) {
 func TestSaveLoadIfPair(t *testing.T) {
 	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
 
-	tmpfile, err := ioutil.TempFile("", "vc-save-load-net-")
+	tmpfile, err := ioutil.TempFile("", "vc-Save-Load-net-")
 	assert.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -109,7 +109,7 @@ func TestSaveLoadIfPair(t *testing.T) {
 		NetInterworkingModel: DefaultNetInterworkingModel,
 	}
 
-	// Save to disk then load it back.
+	// Save to disk then Load it back.
 	savedIfPair := saveNetIfPair(netPair)
 	loadedIfPair := loadNetIfPair(savedIfPair)
 

--- a/src/runtime/virtcontainers/example_pod_run_test.go
+++ b/src/runtime/virtcontainers/example_pod_run_test.go
@@ -17,7 +17,7 @@ import (
 var containerRootfs = vc.RootFs{Target: "/var/lib/container/bundle/", Mounted: true}
 
 // This example creates and starts a single container sandbox,
-// using qemu as the hypervisor and kata as the VM agent.
+// using qemu as the Hypervisor and kata as the VM agent.
 func Example_createAndStartSandbox() {
 	envs := []types.EnvVar{
 		{
@@ -39,7 +39,7 @@ func Example_createAndStartSandbox() {
 		Cmd:    cmd,
 	}
 
-	// Sets the hypervisor configuration.
+	// Sets the Hypervisor configuration.
 	hypervisorConfig := vc.HypervisorConfig{
 		KernelPath:     "/usr/share/kata-containers/vmlinux.container",
 		ImagePath:      "/usr/share/kata-containers/kata-containers.img",

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -872,7 +872,7 @@ func (fc *firecracker) SaveVM() error {
 	return nil
 }
 
-func (fc *firecracker) resumeSandbox(ctx context.Context) error {
+func (fc *firecracker) ResumeVM(ctx context.Context) error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -868,7 +868,7 @@ func (fc *firecracker) PauseVM(ctx context.Context) error {
 	return nil
 }
 
-func (fc *firecracker) saveSandbox() error {
+func (fc *firecracker) SaveVM() error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -186,9 +186,14 @@ func (fc *firecracker) truncateID(id string) string {
 	return id
 }
 
+func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
+	hypervisorConfig.IsSandbox = true
+	return fc.CreateVM(ctx, id, networkNS, hypervisorConfig)
+}
+
 // For firecracker this call only sets the internal structure up.
 // The sandbox will be created and started through startSandbox().
-func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
+func (fc *firecracker) CreateVM(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
 	fc.ctx = ctx
 
 	span, _ := katatrace.Trace(ctx, fc.Logger(), "createSandbox", fcTracingTags, map[string]string{"sandbox_id": fc.id})

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -45,7 +45,7 @@ import (
 var fcTracingTags = map[string]string{
 	"source":    "runtime",
 	"package":   "virtcontainers",
-	"subsystem": "hypervisor",
+	"subsystem": "Hypervisor",
 	"type":      "firecracker",
 }
 
@@ -116,7 +116,7 @@ func (s vmmState) String() string {
 	return ""
 }
 
-// FirecrackerInfo contains information related to the hypervisor that we
+// FirecrackerInfo contains information related to the Hypervisor that we
 // want to store on disk
 type FirecrackerInfo struct {
 	Version string
@@ -199,7 +199,7 @@ func (fc *firecracker) CreateVM(ctx context.Context, id string, networkNS Networ
 	span, _ := katatrace.Trace(ctx, fc.Logger(), "createSandbox", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
-	//TODO: Check validity of the hypervisor config provided
+	//TODO: Check validity of the Hypervisor config provided
 	//https://github.com/kata-containers/runtime/issues/1065
 	fc.id = fc.truncateID(id)
 	fc.state.set(notReady)
@@ -393,8 +393,8 @@ func (fc *firecracker) fcInit(ctx context.Context, timeout int) error {
 		cmd.Stdout = fc.console
 	}
 
-	fc.Logger().WithField("hypervisor args", args).Debug()
-	fc.Logger().WithField("hypervisor cmd", cmd).Debug()
+	fc.Logger().WithField("Hypervisor args", args).Debug()
+	fc.Logger().WithField("Hypervisor cmd", cmd).Debug()
 
 	fc.Logger().Info("Starting VM")
 	if err := cmd.Start(); err != nil {
@@ -746,8 +746,8 @@ func (fc *firecracker) fcInitConfiguration(ctx context.Context) error {
 	return nil
 }
 
-// startSandbox will start the hypervisor for the given sandbox.
-// In the context of firecracker, this will start the hypervisor,
+// startSandbox will start the Hypervisor for the given sandbox.
+// In the context of firecracker, this will start the Hypervisor,
 // for configuration, but not yet start the actual virtual machine
 func (fc *firecracker) StartVM(ctx context.Context, timeout int) error {
 	span, _ := katatrace.Trace(ctx, fc.Logger(), "StartVM", fcTracingTags, map[string]string{"sandbox_id": fc.id})
@@ -1125,7 +1125,7 @@ func (fc *firecracker) Disconnect(ctx context.Context) {
 	fc.state.set(notReady)
 }
 
-// Adds all capabilities supported by firecracker implementation of hypervisor interface
+// Adds all capabilities supported by firecracker implementation of Hypervisor interface
 func (fc *firecracker) Capabilities(ctx context.Context) types.Capabilities {
 	span, _ := katatrace.Trace(ctx, fc.Logger(), "Capabilities", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -62,7 +62,7 @@ const (
 	fcTimeout = 10
 	fcSocket  = "firecracker.socket"
 	//Name of the files within jailer root
-	//Having predefined names helps with cleanup
+	//Having predefined names helps with Cleanup
 	fcKernel             = "vmlinux"
 	fcRootfs             = "rootfs"
 	fcStopSandboxTimeout = 15
@@ -194,7 +194,7 @@ func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS N
 	span, _ := katatrace.Trace(ctx, fc.Logger(), "createSandbox", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
-	//TODO: check validity of the hypervisor config provided
+	//TODO: Check validity of the hypervisor config provided
 	//https://github.com/kata-containers/runtime/issues/1065
 	fc.id = fc.truncateID(id)
 	fc.state.set(notReady)
@@ -282,7 +282,7 @@ func (fc *firecracker) getVersionNumber() (string, error) {
 
 func (fc *firecracker) parseVersion(data string) (string, error) {
 	// Firecracker versions 0.25 and over contains multiline output on "version" command.
-	// So we have to check it and use first line of output to parse version.
+	// So we have to Check it and use first line of output to parse version.
 	lines := strings.Split(data, "\n")
 
 	var version string
@@ -338,7 +338,7 @@ func (fc *firecracker) fcInit(ctx context.Context, timeout int) error {
 	defer span.End()
 
 	var err error
-	//FC version set and check
+	//FC version set and Check
 	if fc.info.Version, err = fc.getVersionNumber(); err != nil {
 		return err
 	}
@@ -730,7 +730,7 @@ func (fc *firecracker) fcInitConfiguration(ctx context.Context) error {
 
 	fc.state.set(cfReady)
 	for _, d := range fc.pendingDevices {
-		if err := fc.addDevice(ctx, d.dev, d.devType); err != nil {
+		if err := fc.AddDevice(ctx, d.dev, d.devType); err != nil {
 			return err
 		}
 	}
@@ -1002,8 +1002,8 @@ func (fc *firecracker) fcUpdateBlockDrive(ctx context.Context, path, id string) 
 
 // addDevice will add extra devices to firecracker.  Limited to configure before the
 // virtual machine starts.  Devices include drivers and network interfaces only.
-func (fc *firecracker) addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "addDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
+func (fc *firecracker) AddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "AddDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	fc.state.RLock()
@@ -1072,8 +1072,8 @@ func (fc *firecracker) hotplugBlockDevice(ctx context.Context, drive config.Bloc
 }
 
 // hotplugAddDevice supported in Firecracker VMM
-func (fc *firecracker) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugAddDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
+func (fc *firecracker) HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "HotplugAddDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	switch devType {
@@ -1081,15 +1081,15 @@ func (fc *firecracker) hotplugAddDevice(ctx context.Context, devInfo interface{}
 		return fc.hotplugBlockDevice(ctx, *devInfo.(*config.BlockDrive), AddDevice)
 	default:
 		fc.Logger().WithFields(logrus.Fields{"devInfo": devInfo,
-			"deviceType": devType}).Warn("hotplugAddDevice: unsupported device")
+			"deviceType": devType}).Warn("HotplugAddDevice: unsupported device")
 		return nil, fmt.Errorf("Could not hot add device: unsupported device: %v, type: %v",
 			devInfo, devType)
 	}
 }
 
 // hotplugRemoveDevice supported in Firecracker VMM
-func (fc *firecracker) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugRemoveDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
+func (fc *firecracker) HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "HotplugRemoveDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	switch devType {
@@ -1097,7 +1097,7 @@ func (fc *firecracker) hotplugRemoveDevice(ctx context.Context, devInfo interfac
 		return fc.hotplugBlockDevice(ctx, *devInfo.(*config.BlockDrive), RemoveDevice)
 	default:
 		fc.Logger().WithFields(logrus.Fields{"devInfo": devInfo,
-			"deviceType": devType}).Error("hotplugRemoveDevice: unsupported device")
+			"deviceType": devType}).Error("HotplugRemoveDevice: unsupported device")
 		return nil, fmt.Errorf("Could not hot remove device: unsupported device: %v, type: %v",
 			devInfo, devType)
 	}
@@ -1105,7 +1105,7 @@ func (fc *firecracker) hotplugRemoveDevice(ctx context.Context, devInfo interfac
 
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
-func (fc *firecracker) getSandboxConsole(ctx context.Context, id string) (string, string, error) {
+func (fc *firecracker) GetSandboxConsole(ctx context.Context, id string) (string, string, error) {
 	master, slave, err := console.NewPty()
 	if err != nil {
 		fc.Logger().Debugf("Error create pseudo tty: %v", err)
@@ -1116,13 +1116,13 @@ func (fc *firecracker) getSandboxConsole(ctx context.Context, id string) (string
 	return consoleProtoPty, slave, nil
 }
 
-func (fc *firecracker) disconnect(ctx context.Context) {
+func (fc *firecracker) Disconnect(ctx context.Context) {
 	fc.state.set(notReady)
 }
 
 // Adds all capabilities supported by firecracker implementation of hypervisor interface
-func (fc *firecracker) capabilities(ctx context.Context) types.Capabilities {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "capabilities", fcTracingTags, map[string]string{"sandbox_id": fc.id})
+func (fc *firecracker) Capabilities(ctx context.Context) types.Capabilities {
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "Capabilities", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 	var caps types.Capabilities
 	caps.SetBlockDeviceHotplugSupport()
@@ -1130,15 +1130,15 @@ func (fc *firecracker) capabilities(ctx context.Context) types.Capabilities {
 	return caps
 }
 
-func (fc *firecracker) hypervisorConfig() HypervisorConfig {
+func (fc *firecracker) HypervisorConfig() HypervisorConfig {
 	return fc.config
 }
 
-func (fc *firecracker) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
+func (fc *firecracker) ResizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
 	return 0, MemoryDevice{}, nil
 }
 
-func (fc *firecracker) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs uint32, newVCPUs uint32, err error) {
+func (fc *firecracker) ResizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs uint32, newVCPUs uint32, err error) {
 	return 0, 0, nil
 }
 
@@ -1146,7 +1146,7 @@ func (fc *firecracker) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (curren
 //
 // As suggested by https://github.com/firecracker-microvm/firecracker/issues/718,
 // let's use `ps -T -p <pid>` to get fc vcpu info.
-func (fc *firecracker) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
+func (fc *firecracker) GetThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
 	var vcpuInfo VcpuThreadIDs
 
 	vcpuInfo.vcpus = make(map[int]int)
@@ -1184,16 +1184,16 @@ func (fc *firecracker) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) 
 	return vcpuInfo, nil
 }
 
-func (fc *firecracker) cleanup(ctx context.Context) error {
+func (fc *firecracker) Cleanup(ctx context.Context) error {
 	fc.cleanupJail(ctx)
 	return nil
 }
 
-func (fc *firecracker) getPids() []int {
+func (fc *firecracker) GetPids() []int {
 	return []int{fc.info.PID}
 }
 
-func (fc *firecracker) getVirtioFsPid() *int {
+func (fc *firecracker) GetVirtioFsPid() *int {
 	return nil
 }
 
@@ -1205,17 +1205,17 @@ func (fc *firecracker) toGrpc(ctx context.Context) ([]byte, error) {
 	return nil, errors.New("firecracker is not supported by VM cache")
 }
 
-func (fc *firecracker) save() (s persistapi.HypervisorState) {
+func (fc *firecracker) Save() (s persistapi.HypervisorState) {
 	s.Pid = fc.info.PID
 	s.Type = string(FirecrackerHypervisor)
 	return
 }
 
-func (fc *firecracker) load(s persistapi.HypervisorState) {
+func (fc *firecracker) Load(s persistapi.HypervisorState) {
 	fc.info.PID = s.Pid
 }
 
-func (fc *firecracker) check() error {
+func (fc *firecracker) Check() error {
 	if err := syscall.Kill(fc.info.PID, syscall.Signal(0)); err != nil {
 		return errors.Wrapf(err, "failed to ping fc process")
 	}
@@ -1223,7 +1223,7 @@ func (fc *firecracker) check() error {
 	return nil
 }
 
-func (fc *firecracker) generateSocket(id string) (interface{}, error) {
+func (fc *firecracker) GenerateSocket(id string) (interface{}, error) {
 	fc.Logger().Debug("Using hybrid-vsock endpoint")
 	udsPath := filepath.Join(fc.jailerRoot, defaultHybridVSocketName)
 
@@ -1233,7 +1233,7 @@ func (fc *firecracker) generateSocket(id string) (interface{}, error) {
 	}, nil
 }
 
-func (fc *firecracker) isRateLimiterBuiltin() bool {
+func (fc *firecracker) IsRateLimiterBuiltin() bool {
 	return true
 }
 

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -1105,7 +1105,7 @@ func (fc *firecracker) HotplugRemoveDevice(ctx context.Context, devInfo interfac
 
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
-func (fc *firecracker) GetSandboxConsole(ctx context.Context, id string) (string, string, error) {
+func (fc *firecracker) GetVMConsole(ctx context.Context, id string) (string, string, error) {
 	master, slave, err := console.NewPty()
 	if err != nil {
 		fc.Logger().Debugf("Error create pseudo tty: %v", err)

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -220,7 +220,7 @@ func (fc *firecracker) createSandbox(ctx context.Context, id string, networkNS N
 	// with the name of "firecracker.socket"
 	fc.socketPath = filepath.Join(fc.jailerRoot, "run", fcSocket)
 
-	// So we need to repopulate this at startSandbox where it is valid
+	// So we need to repopulate this at StartVM where it is valid
 	fc.netNSPath = networkNS.NetNsPath
 
 	// Till we create lower privileged kata user run as root
@@ -744,8 +744,8 @@ func (fc *firecracker) fcInitConfiguration(ctx context.Context) error {
 // startSandbox will start the hypervisor for the given sandbox.
 // In the context of firecracker, this will start the hypervisor,
 // for configuration, but not yet start the actual virtual machine
-func (fc *firecracker) startSandbox(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "startSandbox", fcTracingTags, map[string]string{"sandbox_id": fc.id})
+func (fc *firecracker) StartVM(ctx context.Context, timeout int) error {
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "StartVM", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	if err := fc.fcInitConfiguration(ctx); err != nil {

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -864,7 +864,7 @@ func (fc *firecracker) stopSandbox(ctx context.Context, waitOnly bool) (err erro
 	return fc.fcEnd(ctx, waitOnly)
 }
 
-func (fc *firecracker) pauseSandbox(ctx context.Context) error {
+func (fc *firecracker) PauseVM(ctx context.Context) error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -857,8 +857,8 @@ func (fc *firecracker) cleanupJail(ctx context.Context) {
 }
 
 // stopSandbox will stop the Sandbox's VM.
-func (fc *firecracker) stopSandbox(ctx context.Context, waitOnly bool) (err error) {
-	span, _ := katatrace.Trace(ctx, fc.Logger(), "stopSandbox", fcTracingTags, map[string]string{"sandbox_id": fc.id})
+func (fc *firecracker) StopVM(ctx context.Context, waitOnly bool) (err error) {
+	span, _ := katatrace.Trace(ctx, fc.Logger(), "StopVM", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	return fc.fcEnd(ctx, waitOnly)

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -165,7 +165,7 @@ type firecracker struct {
 
 type firecrackerDevice struct {
 	dev     interface{}
-	devType deviceType
+	devType DeviceType
 }
 
 // Logger returns a logrus logger appropriate for logging firecracker  messages
@@ -1002,7 +1002,7 @@ func (fc *firecracker) fcUpdateBlockDrive(ctx context.Context, path, id string) 
 
 // addDevice will add extra devices to firecracker.  Limited to configure before the
 // virtual machine starts.  Devices include drivers and network interfaces only.
-func (fc *firecracker) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
+func (fc *firecracker) addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
 	span, _ := katatrace.Trace(ctx, fc.Logger(), "addDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
@@ -1039,7 +1039,7 @@ func (fc *firecracker) addDevice(ctx context.Context, devInfo interface{}, devTy
 
 // hotplugBlockDevice supported in Firecracker VMM
 // hot add or remove a block device.
-func (fc *firecracker) hotplugBlockDevice(ctx context.Context, drive config.BlockDrive, op operation) (interface{}, error) {
+func (fc *firecracker) hotplugBlockDevice(ctx context.Context, drive config.BlockDrive, op Operation) (interface{}, error) {
 	if drive.Swap {
 		return nil, fmt.Errorf("firecracker doesn't support swap")
 	}
@@ -1048,7 +1048,7 @@ func (fc *firecracker) hotplugBlockDevice(ctx context.Context, drive config.Bloc
 	var err error
 	driveID := fcDriveIndexToID(drive.Index)
 
-	if op == addDevice {
+	if op == AddDevice {
 		//The drive placeholder has to exist prior to Update
 		path, err = fc.fcJailResource(drive.File, driveID)
 		if err != nil {
@@ -1072,13 +1072,13 @@ func (fc *firecracker) hotplugBlockDevice(ctx context.Context, drive config.Bloc
 }
 
 // hotplugAddDevice supported in Firecracker VMM
-func (fc *firecracker) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
+func (fc *firecracker) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugAddDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	switch devType {
-	case blockDev:
-		return fc.hotplugBlockDevice(ctx, *devInfo.(*config.BlockDrive), addDevice)
+	case BlockDev:
+		return fc.hotplugBlockDevice(ctx, *devInfo.(*config.BlockDrive), AddDevice)
 	default:
 		fc.Logger().WithFields(logrus.Fields{"devInfo": devInfo,
 			"deviceType": devType}).Warn("hotplugAddDevice: unsupported device")
@@ -1088,13 +1088,13 @@ func (fc *firecracker) hotplugAddDevice(ctx context.Context, devInfo interface{}
 }
 
 // hotplugRemoveDevice supported in Firecracker VMM
-func (fc *firecracker) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
+func (fc *firecracker) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	span, _ := katatrace.Trace(ctx, fc.Logger(), "hotplugRemoveDevice", fcTracingTags, map[string]string{"sandbox_id": fc.id})
 	defer span.End()
 
 	switch devType {
-	case blockDev:
-		return fc.hotplugBlockDevice(ctx, *devInfo.(*config.BlockDrive), removeDevice)
+	case BlockDev:
+		return fc.hotplugBlockDevice(ctx, *devInfo.(*config.BlockDrive), RemoveDevice)
 	default:
 		fc.Logger().WithFields(logrus.Fields{"devInfo": devInfo,
 			"deviceType": devType}).Error("hotplugRemoveDevice: unsupported device")
@@ -1134,8 +1134,8 @@ func (fc *firecracker) hypervisorConfig() HypervisorConfig {
 	return fc.config
 }
 
-func (fc *firecracker) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, memoryDevice, error) {
-	return 0, memoryDevice{}, nil
+func (fc *firecracker) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
+	return 0, MemoryDevice{}, nil
 }
 
 func (fc *firecracker) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs uint32, newVCPUs uint32, err error) {
@@ -1146,8 +1146,8 @@ func (fc *firecracker) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (curren
 //
 // As suggested by https://github.com/firecracker-microvm/firecracker/issues/718,
 // let's use `ps -T -p <pid>` to get fc vcpu info.
-func (fc *firecracker) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
-	var vcpuInfo vcpuThreadIDs
+func (fc *firecracker) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
+	var vcpuInfo VcpuThreadIDs
 
 	vcpuInfo.vcpus = make(map[int]int)
 	parent, err := utils.NewProc(fc.info.PID)

--- a/src/runtime/virtcontainers/fc_metrics.go
+++ b/src/runtime/virtcontainers/fc_metrics.go
@@ -472,7 +472,7 @@ type PerformanceMetrics struct {
 	FullCreateSnapshot uint64 `json:"full_create_snapshot"`
 	// Measures the snapshot diff create time, at the API (user) level, in microseconds.
 	DiffCreateSnapshot uint64 `json:"diff_create_snapshot"`
-	// Measures the snapshot load time, at the API (user) level, in microseconds.
+	// Measures the snapshot Load time, at the API (user) level, in microseconds.
 	LoadSnapshot uint64 `json:"load_snapshot"`
 	// Measures the microVM pausing duration, at the API (user) level, in microseconds.
 	PauseVM uint64 `json:"pause_vm"`
@@ -482,7 +482,7 @@ type PerformanceMetrics struct {
 	VmmFullCreateSnapshot uint64 `json:"vmm_full_create_snapshot"`
 	// Measures the snapshot diff create time, at the VMM level, in microseconds.
 	VmmDiffCreateSnapshot uint64 `json:"vmm_diff_create_snapshot"`
-	// Measures the snapshot load time, at the VMM level, in microseconds.
+	// Measures the snapshot Load time, at the VMM level, in microseconds.
 	VmmLoadSnapshot uint64 `json:"vmm_load_snapshot"`
 	// Measures the microVM pausing duration, at the VMM level, in microseconds.
 	VmmPauseVM uint64 `json:"vmm_pause_vm"`

--- a/src/runtime/virtcontainers/fc_test.go
+++ b/src/runtime/virtcontainers/fc_test.go
@@ -16,7 +16,7 @@ func TestFCGenerateSocket(t *testing.T) {
 	assert := assert.New(t)
 
 	fc := firecracker{}
-	i, err := fc.generateSocket("a")
+	i, err := fc.GenerateSocket("a")
 	assert.NoError(err)
 	assert.NotNil(i)
 

--- a/src/runtime/virtcontainers/hypervisor-abstraction-test/dnsmasq.conf
+++ b/src/runtime/virtcontainers/hypervisor-abstraction-test/dnsmasq.conf
@@ -1,0 +1,12 @@
+bind-interfaces
+interface=clhbr
+listen-address=10.0.2.1
+except-interface=enp0s5
+
+# DHCP range
+log-dhcp
+dhcp-range=10.0.2.100,10.0.2.200
+dhcp-lease-max=25
+
+dhcp-host=0e:49:61:0f:c3:11,10.0.2.15
+dhcp-leasefile=/tmp/clhbr-leases.leases

--- a/src/runtime/virtcontainers/hypervisor-abstraction-test/main.go
+++ b/src/runtime/virtcontainers/hypervisor-abstraction-test/main.go
@@ -147,6 +147,12 @@ func main() {
 			Index:  1,
 		}
 	}
+	cfgDrive := device.BlockDrive{
+		File:   "config-drive.img",
+		Format: "raw",
+		ID:     "configdrive",
+		Index:  2,
+	}
 
 	ctx := context.Background()
 
@@ -159,6 +165,12 @@ func main() {
 
 	if err := vm.hypervisor.AddDevice(ctx, bootDisk, vc.BlockDev); err != nil {
 		fmt.Printf("Failed to attach boot drive: %s\n", err)
+		os.Exit(1)
+	}
+
+	// Cloud init
+	if err := vm.hypervisor.AddDevice(ctx, cfgDrive, vc.BlockDev); err != nil {
+		fmt.Printf("Failed to attach config drive: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/src/runtime/virtcontainers/hypervisor-abstraction-test/main.go
+++ b/src/runtime/virtcontainers/hypervisor-abstraction-test/main.go
@@ -1,0 +1,165 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
+	device "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/uuid"
+	"github.com/sirupsen/logrus"
+)
+
+// VM is abstraction of a virtual machine.
+type VM struct {
+	hypervisor vc.Hypervisor
+	id         string
+	cpu        uint32
+	memory     uint32
+}
+
+// VMConfig is a collection of all info that a new blackbox VM needs.
+type VMConfig struct {
+	HypervisorType   vc.HypervisorType
+	HypervisorConfig vc.HypervisorConfig
+}
+
+// Valid Check VMConfig validity.
+func (c *VMConfig) Valid() error {
+	return c.HypervisorConfig.Valid()
+}
+
+// NewVM creates a new VM based on provided VMConfig.
+func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
+	// 1. setup hypervisor
+	hypervisor, err := vc.NewHypervisor(config.HypervisorType)
+	if err != nil {
+		return nil, err
+	}
+
+	if err = config.Valid(); err != nil {
+		return nil, err
+	}
+
+	id := uuid.Generate().String()
+
+	if err = hypervisor.CreateVM(ctx, id, vc.NetworkNamespace{}, &config.HypervisorConfig); err != nil {
+		return nil, err
+	}
+
+	return &VM{
+		id:         id,
+		hypervisor: hypervisor,
+		cpu:        config.HypervisorConfig.NumVCPUs,
+		memory:     config.HypervisorConfig.MemorySize,
+	}, nil
+}
+
+func (v *VM) logger() logrus.FieldLogger {
+	return logrus.WithFields(logrus.Fields{"vm": v.id})
+}
+
+// Pause pauses a VM.
+func (v *VM) Pause(ctx context.Context) error {
+	v.logger().Info("pause vm")
+	return v.hypervisor.PauseVM(ctx)
+}
+
+func (v *VM) Save() error {
+	// TODO: Not implemented
+	v.logger().Info("Save vm")
+	return v.hypervisor.SaveVM()
+}
+
+// Resume resumes a paused VM.
+func (v *VM) Resume(ctx context.Context) error {
+	v.logger().Info("resume vm")
+	return v.hypervisor.ResumeVM(ctx)
+}
+
+// Start kicks off a configured VM.
+func (v *VM) Start(ctx context.Context) error {
+	v.logger().Info("start vm")
+	return v.hypervisor.StartVM(ctx, vc.VmStartTimeout)
+}
+
+// Stop stops a VM process.
+func (v *VM) Stop(ctx context.Context) error {
+	v.logger().Info("stop vm")
+
+	return v.hypervisor.StopVM(ctx, false)
+}
+
+func main() {
+	vmCfg := VMConfig{}
+	vmCfg.HypervisorType = vc.QemuHypervisor
+	vmCfg.HypervisorConfig = vc.HypervisorConfig{
+		IsSandbox:             false,
+		HypervisorMachineType: "q35",
+		NumVCPUs:              2,
+		DefaultMaxVCPUs:       2,
+		MemorySize:            2048,
+		DefaultBridges:        1,
+		MemSlots:              1,
+		Debug:                 true,
+		MemPrealloc:           false,
+		HugePages:             false,
+		IOMMU:                 false,
+		Realtime:              false,
+		Mlock:                 false,
+	}
+
+	ctx := context.Background()
+
+	vm, err := NewVM(ctx, vmCfg)
+	if err != nil {
+		fmt.Printf("Failed to create VM: %s\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("VM Created:", vm.id)
+
+	bootDisk := device.BlockDrive{
+		File:   "rootfs.img",
+		Format: "qcow2",
+		ID:     "bootdisk",
+	}
+
+	if err := vm.hypervisor.AddDevice(ctx, bootDisk, vc.BlockDev); err != nil {
+		fmt.Printf("Failed to attach boot drive: %s\n", err)
+		os.Exit(1)
+	}
+
+	primaryNet := &vc.TuntapEndpoint{
+		EndpointType: "tap",
+		NetPair: vc.NetworkInterfacePair{
+			TapInterface: vc.TapInterface{
+				TAPIface: vc.NetworkInterface{
+					Name:     "clhtap",
+					HardAddr: "0e:49:61:0f:c3:11",
+				},
+			},
+		},
+	}
+
+	if err := vm.hypervisor.AddDevice(ctx, primaryNet, vc.NetDev); err != nil {
+		fmt.Printf("Failed to attach network device: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := vm.Start(ctx); err != nil {
+		fmt.Printf("Failed to start VM: %s\n", err)
+	}
+
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+	<-c
+
+	fmt.Println("Shutting down")
+
+	if err := vm.Stop(ctx); err != nil {
+		fmt.Printf("Failed to stop VM: %s\n", err)
+	}
+}

--- a/src/runtime/virtcontainers/hypervisor-abstraction-test/setup.sh
+++ b/src/runtime/virtcontainers/hypervisor-abstraction-test/setup.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+
+if ! command -v cloud-localds &> /dev/null
+then 
+   echo "cloud-localdscould not be found. Please install. On Debian" 
+   echo "sudo apt-get install cloud-image-util"
+fi
+
+VMN=${VMN:=1}
+IMAGE=${IMAGE:='focal-server-cloudimg-amd64.img'}
+FIRMWARE=${FIRMWARE:='hypervisor-fw'}
+CONFIG_DRIVE=${CONFIG_DRIVE:='config-drive.img'}
+
+echo "Image: " $IMAGE
+echo "Format: " $FORMAT
+echo "Config drive: " $CONFIG_DRIVE
+
+if [ ! -f "$IMAGE" ]; then
+    >&2 echo "Can't find image file \"$IMAGE\". Downloading..."
+    wget https://cloud-images.ubuntu.com/focal/current/focal-server-cloudimg-amd64.img
+fi
+
+if [ ! -f "$FIRMWARE" ]; then
+    >&2 echo "Can't find firmware file \"$FIRMWARE\". Downloading..."
+    wget https://github.com/cloud-hypervisor/rust-hypervisor-firmware/releases/download/0.3.1/hypervisor-fw
+fi
+
+if [ ! -f "cloud-hypervisor-static" ]; then
+    wget https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/v15.0/cloud-hypervisor-static
+fi
+
+ssh_key=$(cat ~/.ssh/id_rsa.pub)
+cat << EOF > cloud-init-config.cfg
+#cloud-config
+users:
+  - name: ubuntu
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    groups: users, admin
+    home: /home/ubuntu
+    shell: /bin/bash
+    lock_passwd: false
+    ssh-authorized-keys:
+      - $ssh_key
+# only cert auth via ssh (console access can still login)
+ssh_pwauth: false
+disable_root: false
+chpasswd:
+  list: |
+     ubuntu:ubuntu
+  expire: False
+
+# written to /var/log/cloud-init-output.log
+final_message: "The system is finally up, after $UPTIME seconds"
+EOF
+
+cat << EOF > network-config-1.cfg
+version: 1
+config:
+  - type: physical
+    name: ens3
+    mac_address: "52:54:00:12:34:00"
+    subnets:
+      - type: static
+        address: 10.0.2.15
+        netmask: 255.255.255.0
+        gateway: 10.0.2.1
+EOF
+
+cat << EOF > network-config-2.cfg
+version: 2
+ethernets:
+  ens3:
+     match:
+         mac_address: "52:54:00:12:34:00"
+     set-name: eth0
+     addresses:
+     - 10.0.2.15/24
+     gateway4: 10.0.2.1
+EOF
+
+rm -f focal-server-cloudimg-amd64.raw
+qemu-img convert -p -f qcow2 -O raw focal-server-cloudimg-amd64.img focal-server-cloudimg-amd64.raw
+rm -f "$CONFIG_DRIVE"
+cloud-localds -v "$CONFIG_DRIVE" --network-config=network-config-1.cfg cloud-init-config.cfg
+chmod +x ./cloud-hypervisor-static

--- a/src/runtime/virtcontainers/hypervisor-abstraction-test/start_network.sh
+++ b/src/runtime/virtcontainers/hypervisor-abstraction-test/start_network.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Setup a simple fake network (Host -> VM) that looks like SLIRP
+# Run a DHCP Server so that the VM can get an IP Automatically
+sudo ip link del clhtap
+sudo ip link del clhbr
+sudo ip tuntap add mode tap clhtap
+sudo ip link set dev clhtap up
+sudo ip link add clhbr type bridge
+sudo ip link set clhtap master clhbr
+sudo ip addr add 10.0.2.1/24 dev clhbr
+sudo ip link set dev clhbr up
+sudo ip link set dev clhtap up
+
+echo "Starting DHCP Server"
+sudo dnsmasq --conf-file=dnsmasq.conf --no-daemon 

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -871,7 +871,7 @@ type hypervisor interface {
 	HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)
 	ResizeMemory(ctx context.Context, memMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error)
 	ResizeVCPUs(ctx context.Context, vcpus uint32) (uint32, uint32, error)
-	GetSandboxConsole(ctx context.Context, sandboxID string) (string, string, error)
+	GetVMConsole(ctx context.Context, sandboxID string) (string, string, error)
 	Disconnect(ctx context.Context)
 	Capabilities(ctx context.Context) types.Capabilities
 	HypervisorConfig() HypervisorConfig

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -864,7 +864,7 @@ type hypervisor interface {
 	// just perform cleanup.
 	stopSandbox(ctx context.Context, waitOnly bool) error
 	PauseVM(ctx context.Context) error
-	saveSandbox() error
+	SaveVM() error
 	resumeSandbox(ctx context.Context) error
 	AddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error
 	HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -21,7 +21,7 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 )
 
-// HypervisorType describes an hypervisor type.
+// HypervisorType describes an Hypervisor type.
 type HypervisorType string
 
 type Operation int
@@ -32,19 +32,19 @@ const (
 )
 
 const (
-	// FirecrackerHypervisor is the FC hypervisor.
+	// FirecrackerHypervisor is the FC Hypervisor.
 	FirecrackerHypervisor HypervisorType = "firecracker"
 
-	// QemuHypervisor is the QEMU hypervisor.
+	// QemuHypervisor is the QEMU Hypervisor.
 	QemuHypervisor HypervisorType = "qemu"
 
-	// AcrnHypervisor is the ACRN hypervisor.
+	// AcrnHypervisor is the ACRN Hypervisor.
 	AcrnHypervisor HypervisorType = "acrn"
 
-	// ClhHypervisor is the ICH hypervisor.
+	// ClhHypervisor is the ICH Hypervisor.
 	ClhHypervisor HypervisorType = "clh"
 
-	// MockHypervisor is a mock hypervisor for testing purposes
+	// MockHypervisor is a mock Hypervisor for testing purposes
 	MockHypervisor HypervisorType = "mock"
 )
 
@@ -67,7 +67,7 @@ const (
 	vSockPort = 1024
 
 	// Port where the agent will send the logs. Logs are sent through the vsock in cases
-	// where the hypervisor has no console.sock, i.e firecracker
+	// where the Hypervisor has no console.sock, i.e firecracker
 	vSockLogsPort = 1025
 
 	// MinHypervisorMemory is the minimum memory required for a VM.
@@ -144,7 +144,7 @@ type MemoryDevice struct {
 	Probe  bool
 }
 
-// Set sets an hypervisor type based on the input string.
+// Set sets an Hypervisor type based on the input string.
 func (hType *HypervisorType) Set(value string) error {
 	switch value {
 	case "qemu":
@@ -163,11 +163,11 @@ func (hType *HypervisorType) Set(value string) error {
 		*hType = MockHypervisor
 		return nil
 	default:
-		return fmt.Errorf("Unknown hypervisor type %s", value)
+		return fmt.Errorf("Unknown Hypervisor type %s", value)
 	}
 }
 
-// String converts an hypervisor type to a string.
+// String converts an Hypervisor type to a string.
 func (hType *HypervisorType) String() string {
 	switch *hType {
 	case QemuHypervisor:
@@ -185,8 +185,8 @@ func (hType *HypervisorType) String() string {
 	}
 }
 
-// NewHypervisor returns an hypervisor from and hypervisor type.
-func NewHypervisor(hType HypervisorType) (hypervisor, error) {
+// NewHypervisor returns an Hypervisor from and Hypervisor type.
+func NewHypervisor(hType HypervisorType) (Hypervisor, error) {
 	store, err := persist.GetDriver()
 	if err != nil {
 		return nil, err
@@ -210,17 +210,17 @@ func NewHypervisor(hType HypervisorType) (hypervisor, error) {
 	case MockHypervisor:
 		return &mockHypervisor{}, nil
 	default:
-		return nil, fmt.Errorf("Unknown hypervisor type %s", hType)
+		return nil, fmt.Errorf("Unknown Hypervisor type %s", hType)
 	}
 }
 
-// Param is a key/value representation for hypervisor and kernel parameters.
+// Param is a key/value representation for Hypervisor and kernel parameters.
 type Param struct {
 	Key   string
 	Value string
 }
 
-// HypervisorConfig is the hypervisor configuration.
+// HypervisorConfig is the Hypervisor configuration.
 type HypervisorConfig struct {
 	// customAssets is a map of assets.
 	// Each value in that map takes precedence over the configured assets.
@@ -254,10 +254,10 @@ type HypervisorConfig struct {
 	// CPUFeatures are cpu specific features
 	CPUFeatures string
 
-	// HypervisorPath is the hypervisor executable host path.
+	// HypervisorPath is the Hypervisor executable host path.
 	HypervisorPath string
 
-	// HypervisorCtlPath is the hypervisor ctl executable host path.
+	// HypervisorCtlPath is the Hypervisor ctl executable host path.
 	HypervisorCtlPath string
 
 	// JailerPath is the jailer executable host path.
@@ -304,8 +304,8 @@ type HypervisorConfig struct {
 	// GuestHookPath is the path within the VM that will be used for 'drop-in' hooks
 	GuestHookPath string
 
-	// VMid is the id of the VM that create the hypervisor if the VM is created by the factory.
-	// VMid is "" if the hypervisor is not created by the factory.
+	// VMid is the id of the VM that create the Hypervisor if the VM is created by the factory.
+	// VMid is "" if the Hypervisor is not created by the factory.
 	VMid string
 
 	// SELinux label for the VM
@@ -314,10 +314,10 @@ type HypervisorConfig struct {
 	// VirtioFSCache cache mode for fs version cache or "none"
 	VirtioFSCache string
 
-	// HypervisorPathList is the list of hypervisor paths names allowed in annotations
+	// HypervisorPathList is the list of Hypervisor paths names allowed in annotations
 	HypervisorPathList []string
 
-	// HypervisorCtlPathList is the list of hypervisor control paths names allowed in annotations
+	// HypervisorCtlPathList is the list of Hypervisor control paths names allowed in annotations
 	HypervisorCtlPathList []string
 
 	// JailerPathList is the list of jailer paths names allowed in annotations
@@ -347,7 +347,7 @@ type HypervisorConfig struct {
 	// KernelParams are additional guest kernel parameters.
 	KernelParams []Param
 
-	// HypervisorParams are additional hypervisor parameters.
+	// HypervisorParams are additional Hypervisor parameters.
 	HypervisorParams []Param
 
 	// SGXEPCSize specifies the size in bytes for the EPC Section.
@@ -413,7 +413,7 @@ type HypervisorConfig struct {
 	// Supported currently for virtio-scsi driver.
 	EnableIOThreads bool
 
-	// Debug changes the default hypervisor and kernel parameters to
+	// Debug changes the default Hypervisor and kernel parameters to
 	// enable debug output where available.
 	Debug bool
 
@@ -548,7 +548,7 @@ func (conf *HypervisorConfig) Valid() error {
 }
 
 // AddKernelParam allows the addition of new kernel parameters to an existing
-// hypervisor configuration.
+// Hypervisor configuration.
 func (conf *HypervisorConfig) AddKernelParam(p Param) error {
 	if p.Key == "" {
 		return fmt.Errorf("Empty kernel parameter")
@@ -644,7 +644,7 @@ func (conf *HypervisorConfig) CustomInitrdAsset() bool {
 	return conf.isCustomAsset(types.InitrdAsset)
 }
 
-// HypervisorAssetPath returns the VM hypervisor path
+// HypervisorAssetPath returns the VM Hypervisor path
 func (conf *HypervisorConfig) HypervisorAssetPath() (string, error) {
 	return conf.assetPath(types.HypervisorAsset)
 }
@@ -653,12 +653,12 @@ func (conf *HypervisorConfig) IfPVPanicEnabled() bool {
 	return conf.GuestMemoryDumpPath != ""
 }
 
-// HypervisorCtlAssetPath returns the VM hypervisor ctl path
+// HypervisorCtlAssetPath returns the VM Hypervisor ctl path
 func (conf *HypervisorConfig) HypervisorCtlAssetPath() (string, error) {
 	return conf.assetPath(types.HypervisorCtlAsset)
 }
 
-// CustomHypervisorAsset returns true if the hypervisor asset is a custom one, false otherwise.
+// CustomHypervisorAsset returns true if the Hypervisor asset is a custom one, false otherwise.
 func (conf *HypervisorConfig) CustomHypervisorAsset() bool {
 	return conf.isCustomAsset(types.HypervisorAsset)
 }
@@ -834,14 +834,14 @@ func RunningOnVMM(cpuInfoPath string) (bool, error) {
 		if err != nil {
 			return false, err
 		}
-		return flags["hypervisor"], nil
+		return flags["Hypervisor"], nil
 	}
 
 	virtLog.WithField("arch", runtime.GOARCH).Info("Unable to know if the system is running inside a VM")
 	return false, nil
 }
 
-func GetHypervisorPid(h hypervisor) int {
+func GetHypervisorPid(h Hypervisor) int {
 	pids := h.GetPids()
 	if len(pids) == 0 {
 		return 0
@@ -862,9 +862,9 @@ func generateVMSocket(id string, vmStogarePath string) (interface{}, error) {
 	}, nil
 }
 
-// hypervisor is the virtcontainers hypervisor interface.
-// The default hypervisor implementation is Qemu.
-type hypervisor interface {
+// Hypervisor is the virtcontainers Hypervisor interface.
+// The default Hypervisor implementation is Qemu.
+type Hypervisor interface {
 	createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error
 
 	CreateVM(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error
@@ -887,8 +887,8 @@ type hypervisor interface {
 	HypervisorConfig() HypervisorConfig
 	GetThreadIDs(ctx context.Context) (VcpuThreadIDs, error)
 	Cleanup(ctx context.Context) error
-	// getPids returns a slice of hypervisor related process ids.
-	// The hypervisor pid must be put at index 0.
+	// getPids returns a slice of Hypervisor related process ids.
+	// The Hypervisor pid must be put at index 0.
 	GetPids() []int
 	GetVirtioFsPid() *int
 	fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, j []byte) error
@@ -901,7 +901,7 @@ type hypervisor interface {
 	// generate the socket to communicate the host and guest
 	GenerateSocket(id string) (interface{}, error)
 
-	// check if hypervisor supports built-in rate limiter.
+	// check if Hypervisor supports built-in rate limiter.
 	IsRateLimiterBuiltin() bool
 
 	setSandbox(sandbox *Sandbox)

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -860,6 +860,7 @@ func generateVMSocket(id string, vmStogarePath string) (interface{}, error) {
 type hypervisor interface {
 	createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error
 	startSandbox(ctx context.Context, timeout int) error
+
 	// If wait is set, don't actively stop the sandbox:
 	// just perform cleanup.
 	StopVM(ctx context.Context, waitOnly bool) error

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -863,7 +863,7 @@ type hypervisor interface {
 	// If wait is set, don't actively stop the sandbox:
 	// just perform cleanup.
 	stopSandbox(ctx context.Context, waitOnly bool) error
-	pauseSandbox(ctx context.Context) error
+	PauseVM(ctx context.Context) error
 	saveSandbox() error
 	resumeSandbox(ctx context.Context) error
 	AddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -859,7 +859,7 @@ func generateVMSocket(id string, vmStogarePath string) (interface{}, error) {
 // The default hypervisor implementation is Qemu.
 type hypervisor interface {
 	createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error
-	startSandbox(ctx context.Context, timeout int) error
+	StartVM(ctx context.Context, timeout int) error
 
 	// If wait is set, don't actively stop the sandbox:
 	// just perform cleanup.

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -491,7 +491,7 @@ func (conf *HypervisorConfig) CheckTemplateConfig() error {
 		}
 
 		if conf.BootFromTemplate && conf.DevicesStatePath == "" {
-			return fmt.Errorf("Missing DevicesStatePath to load from vm template")
+			return fmt.Errorf("Missing DevicesStatePath to Load from vm template")
 		}
 	}
 
@@ -742,7 +742,7 @@ func GetHostMemorySizeKb(memInfoPath string) (uint64, error) {
 // CheckCmdline checks whether an option or parameter is present in the kernel command line.
 // Search is case-insensitive.
 // Takes path to file that contains the kernel command line, desired option, and permitted values
-// (empty values to check for options).
+// (empty values to Check for options).
 func CheckCmdline(kernelCmdlinePath, searchParam string, searchValues []string) (bool, error) {
 	f, err := os.Open(kernelCmdlinePath)
 	if err != nil {
@@ -750,8 +750,8 @@ func CheckCmdline(kernelCmdlinePath, searchParam string, searchValues []string) 
 	}
 	defer f.Close()
 
-	// Create check function -- either check for verbatim option
-	// or check for parameter and permitted values
+	// Create Check function -- either Check for verbatim option
+	// or Check for parameter and permitted values
 	var check func(string, string, []string) bool
 	if len(searchValues) == 0 {
 		check = func(option, searchParam string, _ []string) bool {
@@ -835,7 +835,7 @@ func RunningOnVMM(cpuInfoPath string) (bool, error) {
 }
 
 func GetHypervisorPid(h hypervisor) int {
-	pids := h.getPids()
+	pids := h.GetPids()
 	if len(pids) == 0 {
 		return 0
 	}
@@ -866,33 +866,33 @@ type hypervisor interface {
 	pauseSandbox(ctx context.Context) error
 	saveSandbox() error
 	resumeSandbox(ctx context.Context) error
-	addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error
-	hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)
-	hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)
-	resizeMemory(ctx context.Context, memMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error)
-	resizeVCPUs(ctx context.Context, vcpus uint32) (uint32, uint32, error)
-	getSandboxConsole(ctx context.Context, sandboxID string) (string, string, error)
-	disconnect(ctx context.Context)
-	capabilities(ctx context.Context) types.Capabilities
-	hypervisorConfig() HypervisorConfig
-	getThreadIDs(ctx context.Context) (VcpuThreadIDs, error)
-	cleanup(ctx context.Context) error
+	AddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error
+	HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)
+	HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)
+	ResizeMemory(ctx context.Context, memMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error)
+	ResizeVCPUs(ctx context.Context, vcpus uint32) (uint32, uint32, error)
+	GetSandboxConsole(ctx context.Context, sandboxID string) (string, string, error)
+	Disconnect(ctx context.Context)
+	Capabilities(ctx context.Context) types.Capabilities
+	HypervisorConfig() HypervisorConfig
+	GetThreadIDs(ctx context.Context) (VcpuThreadIDs, error)
+	Cleanup(ctx context.Context) error
 	// getPids returns a slice of hypervisor related process ids.
 	// The hypervisor pid must be put at index 0.
-	getPids() []int
-	getVirtioFsPid() *int
+	GetPids() []int
+	GetVirtioFsPid() *int
 	fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, j []byte) error
 	toGrpc(ctx context.Context) ([]byte, error)
-	check() error
+	Check() error
 
-	save() persistapi.HypervisorState
-	load(persistapi.HypervisorState)
+	Save() persistapi.HypervisorState
+	Load(persistapi.HypervisorState)
 
 	// generate the socket to communicate the host and guest
-	generateSocket(id string) (interface{}, error)
+	GenerateSocket(id string) (interface{}, error)
 
 	// check if hypervisor supports built-in rate limiter.
-	isRateLimiterBuiltin() bool
+	IsRateLimiterBuiltin() bool
 
 	setSandbox(sandbox *Sandbox)
 }

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -865,7 +865,7 @@ type hypervisor interface {
 	stopSandbox(ctx context.Context, waitOnly bool) error
 	PauseVM(ctx context.Context) error
 	SaveVM() error
-	resumeSandbox(ctx context.Context) error
+	ResumeVM(ctx context.Context) error
 	AddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error
 	HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)
 	HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -862,7 +862,7 @@ type hypervisor interface {
 	startSandbox(ctx context.Context, timeout int) error
 	// If wait is set, don't actively stop the sandbox:
 	// just perform cleanup.
-	stopSandbox(ctx context.Context, waitOnly bool) error
+	StopVM(ctx context.Context, waitOnly bool) error
 	PauseVM(ctx context.Context) error
 	SaveVM() error
 	ResumeVM(ctx context.Context) error

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -24,11 +24,11 @@ import (
 // HypervisorType describes an hypervisor type.
 type HypervisorType string
 
-type operation int
+type Operation int
 
 const (
-	addDevice operation = iota
-	removeDevice
+	AddDevice Operation = iota
+	RemoveDevice
 )
 
 const (
@@ -98,50 +98,50 @@ var commonVirtioblkKernelRootParams = []Param{ //nolint: unused, deadcode, varch
 	{"rootfstype", "ext4"},
 }
 
-// deviceType describes a virtualized device type.
-type deviceType int
+// DeviceType describes a virtualized device type.
+type DeviceType int
 
 const (
 	// ImgDev is the image device type.
-	imgDev deviceType = iota
+	ImgDev DeviceType = iota
 
 	// FsDev is the filesystem device type.
-	fsDev
+	FsDev
 
 	// NetDev is the network device type.
-	netDev
+	NetDev
 
 	// BlockDev is the block device type.
-	blockDev
+	BlockDev
 
 	// SerialPortDev is the serial port device type.
-	serialPortDev
+	SerialPortDev
 
-	// vSockPCIDev is the vhost vsock PCI device type.
-	vSockPCIDev
+	// VSockPCIDev is the vhost vsock PCI device type.
+	VSockPCIDev
 
 	// VFIODevice is VFIO device type
-	vfioDev
+	VfioDev
 
-	// vhostuserDev is a Vhost-user device type
-	vhostuserDev
+	// VhostuserDev is a Vhost-user device type
+	VhostuserDev
 
 	// CPUDevice is CPU device type
-	cpuDev
+	CpuDev
 
-	// memoryDevice is memory device type
-	memoryDev
+	// MemoryDev is memory device type
+	MemoryDev
 
-	// hybridVirtioVsockDev is a hybrid virtio-vsock device supported
+	// HybridVirtioVsockDev is a hybrid virtio-vsock device supported
 	// only on certain hypervisors, like firecracker.
-	hybridVirtioVsockDev
+	HybridVirtioVsockDev
 )
 
-type memoryDevice struct {
-	slot   int
-	sizeMB int
-	addr   uint64
-	probe  bool
+type MemoryDevice struct {
+	Slot   int
+	SizeMB int
+	Addr   uint64
+	Probe  bool
 }
 
 // Set sets an hypervisor type based on the input string.
@@ -185,8 +185,8 @@ func (hType *HypervisorType) String() string {
 	}
 }
 
-// newHypervisor returns an hypervisor from and hypervisor type.
-func newHypervisor(hType HypervisorType) (hypervisor, error) {
+// NewHypervisor returns an hypervisor from and hypervisor type.
+func NewHypervisor(hType HypervisorType) (hypervisor, error) {
 	store, err := persist.GetDriver()
 	if err != nil {
 		return nil, err
@@ -476,11 +476,11 @@ type HypervisorConfig struct {
 }
 
 // vcpu mapping from vcpu number to thread number
-type vcpuThreadIDs struct {
+type VcpuThreadIDs struct {
 	vcpus map[int]int
 }
 
-func (conf *HypervisorConfig) checkTemplateConfig() error {
+func (conf *HypervisorConfig) CheckTemplateConfig() error {
 	if conf.BootToBeTemplate && conf.BootFromTemplate {
 		return fmt.Errorf("Cannot set both 'to be' and 'from' vm tempate")
 	}
@@ -498,7 +498,7 @@ func (conf *HypervisorConfig) checkTemplateConfig() error {
 	return nil
 }
 
-func (conf *HypervisorConfig) valid() error {
+func (conf *HypervisorConfig) Valid() error {
 	if conf.KernelPath == "" {
 		return fmt.Errorf("Missing kernel path")
 	}
@@ -507,7 +507,7 @@ func (conf *HypervisorConfig) valid() error {
 		return fmt.Errorf("Missing image and initrd path")
 	}
 
-	if err := conf.checkTemplateConfig(); err != nil {
+	if err := conf.CheckTemplateConfig(); err != nil {
 		return err
 	}
 
@@ -552,7 +552,7 @@ func (conf *HypervisorConfig) AddKernelParam(p Param) error {
 	return nil
 }
 
-func (conf *HypervisorConfig) addCustomAsset(a *types.Asset) error {
+func (conf *HypervisorConfig) AddCustomAsset(a *types.Asset) error {
 	if a == nil || a.Path() == "" {
 		// We did not get a custom asset, we will use the default one.
 		return nil
@@ -706,7 +706,7 @@ func DeserializeParams(parameters []string) []Param {
 	return params
 }
 
-func getHostMemorySizeKb(memInfoPath string) (uint64, error) {
+func GetHostMemorySizeKb(memInfoPath string) (uint64, error) {
 	f, err := os.Open(memInfoPath)
 	if err != nil {
 		return 0, err
@@ -834,7 +834,7 @@ func RunningOnVMM(cpuInfoPath string) (bool, error) {
 	return false, nil
 }
 
-func getHypervisorPid(h hypervisor) int {
+func GetHypervisorPid(h hypervisor) int {
 	pids := h.getPids()
 	if len(pids) == 0 {
 		return 0
@@ -866,16 +866,16 @@ type hypervisor interface {
 	pauseSandbox(ctx context.Context) error
 	saveSandbox() error
 	resumeSandbox(ctx context.Context) error
-	addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error
-	hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error)
-	hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error)
-	resizeMemory(ctx context.Context, memMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, memoryDevice, error)
+	addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error
+	hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)
+	hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error)
+	resizeMemory(ctx context.Context, memMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error)
 	resizeVCPUs(ctx context.Context, vcpus uint32) (uint32, uint32, error)
 	getSandboxConsole(ctx context.Context, sandboxID string) (string, string, error)
 	disconnect(ctx context.Context)
 	capabilities(ctx context.Context) types.Capabilities
 	hypervisorConfig() HypervisorConfig
-	getThreadIDs(ctx context.Context) (vcpuThreadIDs, error)
+	getThreadIDs(ctx context.Context) (VcpuThreadIDs, error)
 	cleanup(ctx context.Context) error
 	// getPids returns a slice of hypervisor related process ids.
 	// The hypervisor pid must be put at index 0.

--- a/src/runtime/virtcontainers/hypervisor_test.go
+++ b/src/runtime/virtcontainers/hypervisor_test.go
@@ -67,7 +67,7 @@ func TestStringFromUnknownHypervisorType(t *testing.T) {
 
 func testNewHypervisorFromHypervisorType(t *testing.T, hypervisorType HypervisorType, expected hypervisor) {
 	assert := assert.New(t)
-	hy, err := newHypervisor(hypervisorType)
+	hy, err := NewHypervisor(hypervisorType)
 	assert.NoError(err)
 	assert.Exactly(hy, expected)
 }
@@ -82,13 +82,13 @@ func TestNewHypervisorFromUnknownHypervisorType(t *testing.T) {
 	var hypervisorType HypervisorType
 	assert := assert.New(t)
 
-	hy, err := newHypervisor(hypervisorType)
+	hy, err := NewHypervisor(hypervisorType)
 	assert.Error(err)
 	assert.Nil(hy)
 }
 
 func testHypervisorConfigValid(t *testing.T, hypervisorConfig *HypervisorConfig, success bool) {
-	err := hypervisorConfig.valid()
+	err := hypervisorConfig.Valid()
 	assert := assert.New(t)
 	assert.False(success && err != nil)
 	assert.False(!success && err == nil)
@@ -385,7 +385,7 @@ func TestGetHostMemorySizeKb(t *testing.T) {
 	defer os.RemoveAll(dir)
 
 	file := filepath.Join(dir, "meminfo")
-	_, err = getHostMemorySizeKb(file)
+	_, err = GetHostMemorySizeKb(file)
 	assert.Error(err)
 
 	for _, d := range data {
@@ -393,7 +393,7 @@ func TestGetHostMemorySizeKb(t *testing.T) {
 		assert.NoError(err)
 		defer os.Remove(file)
 
-		hostMemKb, err := getHostMemorySizeKb(file)
+		hostMemKb, err := GetHostMemorySizeKb(file)
 
 		assert.False((d.expectError && err == nil))
 		assert.False((!d.expectError && err != nil))

--- a/src/runtime/virtcontainers/hypervisor_test.go
+++ b/src/runtime/virtcontainers/hypervisor_test.go
@@ -65,7 +65,7 @@ func TestStringFromUnknownHypervisorType(t *testing.T) {
 	testStringFromHypervisorType(t, hypervisorType, "")
 }
 
-func testNewHypervisorFromHypervisorType(t *testing.T, hypervisorType HypervisorType, expected hypervisor) {
+func testNewHypervisorFromHypervisorType(t *testing.T, hypervisorType HypervisorType, expected Hypervisor) {
 	assert := assert.New(t)
 	hy, err := NewHypervisor(hypervisorType)
 	assert.NoError(err)
@@ -470,16 +470,16 @@ func TestAssetPath(t *testing.T) {
 	// The values are "paths" (start with a slash), but end with the
 	// annotation name.
 	cfg := HypervisorConfig{
-		HypervisorPath:    "/" + "io.katacontainers.config.hypervisor.path",
-		HypervisorCtlPath: "/" + "io.katacontainers.config.hypervisor.ctlpath",
+		HypervisorPath:    "/" + "io.katacontainers.config.Hypervisor.path",
+		HypervisorCtlPath: "/" + "io.katacontainers.config.Hypervisor.ctlpath",
 
-		KernelPath: "/" + "io.katacontainers.config.hypervisor.kernel",
+		KernelPath: "/" + "io.katacontainers.config.Hypervisor.kernel",
 
-		ImagePath:  "/" + "io.katacontainers.config.hypervisor.image",
-		InitrdPath: "/" + "io.katacontainers.config.hypervisor.initrd",
+		ImagePath:  "/" + "io.katacontainers.config.Hypervisor.image",
+		InitrdPath: "/" + "io.katacontainers.config.Hypervisor.initrd",
 
-		FirmwarePath: "/" + "io.katacontainers.config.hypervisor.firmware",
-		JailerPath:   "/" + "io.katacontainers.config.hypervisor.jailer_path",
+		FirmwarePath: "/" + "io.katacontainers.config.Hypervisor.firmware",
+		JailerPath:   "/" + "io.katacontainers.config.Hypervisor.jailer_path",
 	}
 
 	for _, asset := range types.AssetTypes() {

--- a/src/runtime/virtcontainers/ipvlan_endpoint.go
+++ b/src/runtime/virtcontainers/ipvlan_endpoint.go
@@ -103,7 +103,7 @@ func (endpoint *IPVlanEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 		return err
 	}
 
-	return h.addDevice(ctx, endpoint, NetDev)
+	return h.AddDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for the ipvlan endpoint tears down the tap and bridge

--- a/src/runtime/virtcontainers/ipvlan_endpoint.go
+++ b/src/runtime/virtcontainers/ipvlan_endpoint.go
@@ -92,7 +92,7 @@ func (endpoint *IPVlanEndpoint) NetworkPair() *NetworkInterfacePair {
 }
 
 // Attach for ipvlan endpoint bridges the network pair and adds the
-// tap interface of the network pair to the hypervisor.
+// tap interface of the network pair to the Hypervisor.
 func (endpoint *IPVlanEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 	span, ctx := ipvlanTrace(ctx, "Attach", endpoint)
 	defer span.End()
@@ -124,12 +124,12 @@ func (endpoint *IPVlanEndpoint) Detach(ctx context.Context, netNsCreated bool, n
 }
 
 // HotAttach for ipvlan endpoint not supported yet
-func (endpoint *IPVlanEndpoint) HotAttach(ctx context.Context, h hypervisor) error {
+func (endpoint *IPVlanEndpoint) HotAttach(ctx context.Context, h Hypervisor) error {
 	return fmt.Errorf("IPVlanEndpoint does not support Hot attach")
 }
 
 // HotDetach for ipvlan endpoint not supported yet
-func (endpoint *IPVlanEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsCreated bool, netNsPath string) error {
+func (endpoint *IPVlanEndpoint) HotDetach(ctx context.Context, h Hypervisor, netNsCreated bool, netNsPath string) error {
 	return fmt.Errorf("IPVlanEndpoint does not support Hot detach")
 }
 

--- a/src/runtime/virtcontainers/ipvlan_endpoint.go
+++ b/src/runtime/virtcontainers/ipvlan_endpoint.go
@@ -103,7 +103,7 @@ func (endpoint *IPVlanEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 		return err
 	}
 
-	return h.addDevice(ctx, endpoint, netDev)
+	return h.addDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for the ipvlan endpoint tears down the tap and bridge

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -372,7 +372,7 @@ func (k *kataAgent) capabilities() types.Capabilities {
 	return caps
 }
 
-func (k *kataAgent) internalConfigure(ctx context.Context, h hypervisor, id string, config KataAgentConfig) error {
+func (k *kataAgent) internalConfigure(ctx context.Context, h Hypervisor, id string, config KataAgentConfig) error {
 	span, _ := katatrace.Trace(ctx, k.Logger(), "configure", kataAgentTracingTags)
 	defer span.End()
 
@@ -460,7 +460,7 @@ func (k *kataAgent) cleanupSandboxBindMounts(sandbox *Sandbox) error {
 	return retErr
 }
 
-func (k *kataAgent) configure(ctx context.Context, h hypervisor, id, sharePath string, config KataAgentConfig) error {
+func (k *kataAgent) configure(ctx context.Context, h Hypervisor, id, sharePath string, config KataAgentConfig) error {
 	span, ctx := katatrace.Trace(ctx, k.Logger(), "configure", kataAgentTracingTags)
 	defer span.End()
 
@@ -484,7 +484,7 @@ func (k *kataAgent) configure(ctx context.Context, h hypervisor, id, sharePath s
 		return vcTypes.ErrInvalidConfigType
 	}
 
-	// Neither create shared directory nor add 9p device if hypervisor
+	// Neither create shared directory nor add 9p device if Hypervisor
 	// doesn't support filesystem sharing.
 	caps := h.Capabilities(ctx)
 	if !caps.IsFsSharingSupported() {
@@ -505,7 +505,7 @@ func (k *kataAgent) configure(ctx context.Context, h hypervisor, id, sharePath s
 	return h.AddDevice(ctx, sharedVolume, FsDev)
 }
 
-func (k *kataAgent) configureFromGrpc(ctx context.Context, h hypervisor, id string, config KataAgentConfig) error {
+func (k *kataAgent) configureFromGrpc(ctx context.Context, h Hypervisor, id string, config KataAgentConfig) error {
 	return k.internalConfigure(ctx, h, id, config)
 }
 
@@ -1049,7 +1049,7 @@ func (k *kataAgent) constraintGRPCSpec(grpcSpec *grpc.Spec, passSeccomp bool) {
 	// Disable SELinux inside of the virtual machine, the label will apply
 	// to the KVM process
 	if grpcSpec.Process.SelinuxLabel != "" {
-		k.Logger().Info("SELinux label from config will be applied to the hypervisor process, not the VM workload")
+		k.Logger().Info("SELinux label from config will be applied to the Hypervisor process, not the VM workload")
 		grpcSpec.Process.SelinuxLabel = ""
 	}
 

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -956,7 +956,7 @@ func setupStorages(ctx context.Context, sandbox *Sandbox) []*grpc.Storage {
 }
 
 func (k *kataAgent) stopSandbox(ctx context.Context, sandbox *Sandbox) error {
-	span, ctx := katatrace.Trace(ctx, k.Logger(), "stopSandbox", kataAgentTracingTags)
+	span, ctx := katatrace.Trace(ctx, k.Logger(), "StopVM", kataAgentTracingTags)
 	defer span.End()
 
 	req := &grpc.DestroySandboxRequest{}

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -336,7 +336,7 @@ func (k *kataAgent) handleTraceSettings(config KataAgentConfig) bool {
 }
 
 func (k *kataAgent) init(ctx context.Context, sandbox *Sandbox, config KataAgentConfig) (disableVMShutdown bool, err error) {
-	// save
+	// Save
 	k.ctx = sandbox.ctx
 
 	span, _ := katatrace.Trace(ctx, k.Logger(), "init", kataAgentTracingTags)
@@ -366,7 +366,7 @@ func (k *kataAgent) agentURL() (string, error) {
 func (k *kataAgent) capabilities() types.Capabilities {
 	var caps types.Capabilities
 
-	// add all capabilities supported by agent
+	// add all Capabilities supported by agent
 	caps.SetBlockDeviceSupport()
 
 	return caps
@@ -377,7 +377,7 @@ func (k *kataAgent) internalConfigure(ctx context.Context, h hypervisor, id stri
 	defer span.End()
 
 	var err error
-	if k.vmSocket, err = h.generateSocket(id); err != nil {
+	if k.vmSocket, err = h.GenerateSocket(id); err != nil {
 		return err
 	}
 	k.keepConn = config.LongLiveConn
@@ -406,11 +406,11 @@ func (k *kataAgent) setupSandboxBindMounts(ctx context.Context, sandbox *Sandbox
 		if err != nil {
 			for _, mnt := range mountedList {
 				if derr := syscall.Unmount(mnt, syscall.MNT_DETACH|UmountNoFollow); derr != nil {
-					k.Logger().WithError(derr).Errorf("cleanup: couldn't unmount %s", mnt)
+					k.Logger().WithError(derr).Errorf("Cleanup: couldn't unmount %s", mnt)
 				}
 			}
 			if derr := os.RemoveAll(sandboxMountDir); derr != nil {
-				k.Logger().WithError(derr).Errorf("cleanup: failed to remove %s", sandboxMountDir)
+				k.Logger().WithError(derr).Errorf("Cleanup: failed to remove %s", sandboxMountDir)
 			}
 
 		}
@@ -471,11 +471,11 @@ func (k *kataAgent) configure(ctx context.Context, h hypervisor, id, sharePath s
 
 	switch s := k.vmSocket.(type) {
 	case types.VSock:
-		if err = h.addDevice(ctx, s, VSockPCIDev); err != nil {
+		if err = h.AddDevice(ctx, s, VSockPCIDev); err != nil {
 			return err
 		}
 	case types.HybridVSock:
-		err = h.addDevice(ctx, s, HybridVirtioVsockDev)
+		err = h.AddDevice(ctx, s, HybridVirtioVsockDev)
 		if err != nil {
 			return err
 		}
@@ -486,7 +486,7 @@ func (k *kataAgent) configure(ctx context.Context, h hypervisor, id, sharePath s
 
 	// Neither create shared directory nor add 9p device if hypervisor
 	// doesn't support filesystem sharing.
-	caps := h.capabilities(ctx)
+	caps := h.Capabilities(ctx)
 	if !caps.IsFsSharingSupported() {
 		return nil
 	}
@@ -502,7 +502,7 @@ func (k *kataAgent) configure(ctx context.Context, h hypervisor, id, sharePath s
 		return err
 	}
 
-	return h.addDevice(ctx, sharedVolume, FsDev)
+	return h.AddDevice(ctx, sharedVolume, FsDev)
 }
 
 func (k *kataAgent) configureFromGrpc(ctx context.Context, h hypervisor, id string, config KataAgentConfig) error {
@@ -820,7 +820,7 @@ func (k *kataAgent) startSandbox(ctx context.Context, sandbox *Sandbox) error {
 		return err
 	}
 
-	// check grpc server is serving
+	// Check grpc server is serving
 	if err = k.check(ctx); err != nil {
 		return err
 	}
@@ -892,7 +892,7 @@ func setupKernelModules(kmodules []string) []*grpc.KernelModule {
 
 func setupStorages(ctx context.Context, sandbox *Sandbox) []*grpc.Storage {
 	storages := []*grpc.Storage{}
-	caps := sandbox.hypervisor.capabilities(ctx)
+	caps := sandbox.hypervisor.Capabilities(ctx)
 
 	// append 9p shared volume to storages only if filesystem sharing is supported
 	if caps.IsFsSharingSupported() {
@@ -1858,7 +1858,7 @@ func (k *kataAgent) connect(ctx context.Context) error {
 }
 
 func (k *kataAgent) disconnect(ctx context.Context) error {
-	span, _ := katatrace.Trace(ctx, k.Logger(), "disconnect", kataAgentTracingTags)
+	span, _ := katatrace.Trace(ctx, k.Logger(), "Disconnect", kataAgentTracingTags)
 	defer span.End()
 
 	k.Lock()
@@ -1882,7 +1882,7 @@ func (k *kataAgent) disconnect(ctx context.Context) error {
 func (k *kataAgent) check(ctx context.Context) error {
 	_, err := k.sendReq(ctx, &grpc.CheckRequest{})
 	if err != nil {
-		err = fmt.Errorf("Failed to check if grpc server is working: %s", err)
+		err = fmt.Errorf("Failed to Check if grpc server is working: %s", err)
 	}
 	return err
 }
@@ -2209,12 +2209,12 @@ func (k *kataAgent) markDead(ctx context.Context) {
 
 func (k *kataAgent) cleanup(ctx context.Context, s *Sandbox) {
 	if err := k.cleanupSandboxBindMounts(s); err != nil {
-		k.Logger().WithError(err).Errorf("failed to cleanup sandbox bindmounts")
+		k.Logger().WithError(err).Errorf("failed to Cleanup sandbox bindmounts")
 	}
 
 	// Unmount shared path
 	path := getSharePath(s.id)
-	k.Logger().WithField("path", path).Infof("cleanup agent")
+	k.Logger().WithField("path", path).Infof("Cleanup agent")
 	if err := syscall.Unmount(path, syscall.MNT_DETACH|UmountNoFollow); err != nil {
 		k.Logger().WithError(err).Errorf("failed to unmount vm share path %s", path)
 	}
@@ -2225,7 +2225,7 @@ func (k *kataAgent) cleanup(ctx context.Context, s *Sandbox) {
 		k.Logger().WithError(err).Errorf("failed to unmount vm mount path %s", path)
 	}
 	if err := os.RemoveAll(getSandboxPath(s.id)); err != nil {
-		k.Logger().WithError(err).Errorf("failed to cleanup vm path %s", getSandboxPath(s.id))
+		k.Logger().WithError(err).Errorf("failed to Cleanup vm path %s", getSandboxPath(s.id))
 	}
 }
 

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -471,11 +471,11 @@ func (k *kataAgent) configure(ctx context.Context, h hypervisor, id, sharePath s
 
 	switch s := k.vmSocket.(type) {
 	case types.VSock:
-		if err = h.addDevice(ctx, s, vSockPCIDev); err != nil {
+		if err = h.addDevice(ctx, s, VSockPCIDev); err != nil {
 			return err
 		}
 	case types.HybridVSock:
-		err = h.addDevice(ctx, s, hybridVirtioVsockDev)
+		err = h.addDevice(ctx, s, HybridVirtioVsockDev)
 		if err != nil {
 			return err
 		}
@@ -502,7 +502,7 @@ func (k *kataAgent) configure(ctx context.Context, h hypervisor, id, sharePath s
 		return err
 	}
 
-	return h.addDevice(ctx, sharedVolume, fsDev)
+	return h.addDevice(ctx, sharedVolume, FsDev)
 }
 
 func (k *kataAgent) configureFromGrpc(ctx context.Context, h hypervisor, id string, config KataAgentConfig) error {

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -803,7 +803,7 @@ func (k *kataAgent) getDNS(sandbox *Sandbox) ([]string, error) {
 }
 
 func (k *kataAgent) startSandbox(ctx context.Context, sandbox *Sandbox) error {
-	span, ctx := katatrace.Trace(ctx, k.Logger(), "startSandbox", kataAgentTracingTags)
+	span, ctx := katatrace.Trace(ctx, k.Logger(), "StartVM", kataAgentTracingTags)
 	defer span.End()
 
 	if err := k.setAgentURL(); err != nil {

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -591,7 +591,7 @@ func TestConstraintGRPCSpec(t *testing.T) {
 	k := kataAgent{}
 	k.constraintGRPCSpec(g, true)
 
-	// check nil fields
+	// Check nil fields
 	assert.Nil(g.Hooks)
 	assert.NotNil(g.Linux.Seccomp)
 	assert.Nil(g.Linux.Resources.Devices)
@@ -603,17 +603,17 @@ func TestConstraintGRPCSpec(t *testing.T) {
 	assert.NotNil(g.Linux.Resources.CPU)
 	assert.Equal(g.Process.SelinuxLabel, "")
 
-	// check namespaces
+	// Check namespaces
 	assert.Len(g.Linux.Namespaces, 1)
 	assert.Empty(g.Linux.Namespaces[0].Path)
 
-	// check mounts
+	// Check mounts
 	assert.Len(g.Mounts, 1)
 
-	// check cgroup path
+	// Check cgroup path
 	assert.Equal(expectedCgroupPath, g.Linux.CgroupsPath)
 
-	// check Linux devices
+	// Check Linux devices
 	assert.Empty(g.Linux.Devices)
 }
 
@@ -966,7 +966,7 @@ func TestKataCleanupSandbox(t *testing.T) {
 
 	kataHostSharedDirSaved := kataHostSharedDir
 	kataHostSharedDir = func() string {
-		td, _ := ioutil.TempDir("", "kata-cleanup")
+		td, _ := ioutil.TempDir("", "kata-Cleanup")
 		return td
 	}
 	defer func() {
@@ -1232,7 +1232,7 @@ func TestSandboxBindMount(t *testing.T) {
 
 	// create a new shared directory for our test:
 	kataHostSharedDirSaved := kataHostSharedDir
-	testHostDir, err := ioutil.TempDir("", "kata-cleanup")
+	testHostDir, err := ioutil.TempDir("", "kata-Cleanup")
 	assert.NoError(err)
 	kataHostSharedDir = func() string {
 		return testHostDir
@@ -1284,11 +1284,11 @@ func TestSandboxBindMount(t *testing.T) {
 	err = k.setupSandboxBindMounts(context.Background(), sandbox)
 	assert.NoError(err)
 
-	// Test the cleanup function. We expect it to succeed for the mount to be removed.
+	// Test the Cleanup function. We expect it to succeed for the mount to be removed.
 	err = k.cleanupSandboxBindMounts(sandbox)
 	assert.NoError(err)
 
-	// After successful cleanup, verify there are not any mounts left behind.
+	// After successful Cleanup, verify there are not any mounts left behind.
 	stat := syscall.Stat_t{}
 	mount1CheckPath := filepath.Join(getMountPath(sandbox.id), sandboxMountsDir, filepath.Base(m1Path))
 	err = syscall.Stat(mount1CheckPath, &stat)
@@ -1300,16 +1300,16 @@ func TestSandboxBindMount(t *testing.T) {
 	assert.Error(err)
 	assert.True(os.IsNotExist(err))
 
-	// Now, let's setup the cleanup to fail. Setup the sandbox bind mount twice, which will result in
+	// Now, let's setup the Cleanup to fail. Setup the sandbox bind mount twice, which will result in
 	// extra mounts being present that the sandbox description doesn't account for (ie, duplicate mounts).
-	// We expect cleanup to fail on the first time, since it cannot remove the sandbox-bindmount directory because
+	// We expect Cleanup to fail on the first time, since it cannot remove the sandbox-bindmount directory because
 	// there are leftover mounts.   If we run it a second time, however, it should succeed since it'll remove the
 	// second set of mounts:
 	err = k.setupSandboxBindMounts(context.Background(), sandbox)
 	assert.NoError(err)
 	err = k.setupSandboxBindMounts(context.Background(), sandbox)
 	assert.NoError(err)
-	// Test the cleanup function. We expect it to succeed for the mount to be removed.
+	// Test the Cleanup function. We expect it to succeed for the mount to be removed.
 	err = k.cleanupSandboxBindMounts(sandbox)
 	assert.Error(err)
 	err = k.cleanupSandboxBindMounts(sandbox)

--- a/src/runtime/virtcontainers/macvtap_endpoint.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint.go
@@ -61,7 +61,7 @@ func (endpoint *MacvtapEndpoint) SetProperties(properties NetworkInfo) {
 	endpoint.EndpointProperties = properties
 }
 
-// Attach for macvtap endpoint passes macvtap device to the hypervisor.
+// Attach for macvtap endpoint passes macvtap device to the Hypervisor.
 func (endpoint *MacvtapEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 	var err error
 	span, ctx := macvtapTrace(ctx, "Attach", endpoint)
@@ -91,12 +91,12 @@ func (endpoint *MacvtapEndpoint) Detach(ctx context.Context, netNsCreated bool, 
 }
 
 // HotAttach for macvtap endpoint not supported yet
-func (endpoint *MacvtapEndpoint) HotAttach(ctx context.Context, h hypervisor) error {
+func (endpoint *MacvtapEndpoint) HotAttach(ctx context.Context, h Hypervisor) error {
 	return fmt.Errorf("MacvtapEndpoint does not support Hot attach")
 }
 
 // HotDetach for macvtap endpoint not supported yet
-func (endpoint *MacvtapEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsCreated bool, netNsPath string) error {
+func (endpoint *MacvtapEndpoint) HotDetach(ctx context.Context, h Hypervisor, netNsCreated bool, netNsPath string) error {
 	return fmt.Errorf("MacvtapEndpoint does not support Hot detach")
 }
 

--- a/src/runtime/virtcontainers/macvtap_endpoint.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint.go
@@ -69,20 +69,20 @@ func (endpoint *MacvtapEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 
 	h := s.hypervisor
 
-	endpoint.VMFds, err = createMacvtapFds(endpoint.EndpointProperties.Iface.Index, int(h.hypervisorConfig().NumVCPUs))
+	endpoint.VMFds, err = createMacvtapFds(endpoint.EndpointProperties.Iface.Index, int(h.HypervisorConfig().NumVCPUs))
 	if err != nil {
 		return fmt.Errorf("Could not setup macvtap fds %s: %s", endpoint.EndpointProperties.Iface.Name, err)
 	}
 
-	if !h.hypervisorConfig().DisableVhostNet {
-		vhostFds, err := createVhostFds(int(h.hypervisorConfig().NumVCPUs))
+	if !h.HypervisorConfig().DisableVhostNet {
+		vhostFds, err := createVhostFds(int(h.HypervisorConfig().NumVCPUs))
 		if err != nil {
 			return fmt.Errorf("Could not setup vhost fds %s : %s", endpoint.EndpointProperties.Iface.Name, err)
 		}
 		endpoint.VhostFds = vhostFds
 	}
 
-	return h.addDevice(ctx, endpoint, NetDev)
+	return h.AddDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for macvtap endpoint does nothing.

--- a/src/runtime/virtcontainers/macvtap_endpoint.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint.go
@@ -82,7 +82,7 @@ func (endpoint *MacvtapEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 		endpoint.VhostFds = vhostFds
 	}
 
-	return h.addDevice(ctx, endpoint, netDev)
+	return h.addDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for macvtap endpoint does nothing.

--- a/src/runtime/virtcontainers/mock_agent.go
+++ b/src/runtime/virtcontainers/mock_agent.go
@@ -173,11 +173,11 @@ func (n *mockAgent) resumeContainer(ctx context.Context, sandbox *Sandbox, c Con
 }
 
 // configure is the Noop agent configuration implementation. It does nothing.
-func (n *mockAgent) configure(ctx context.Context, h hypervisor, id, sharePath string, config KataAgentConfig) error {
+func (n *mockAgent) configure(ctx context.Context, h Hypervisor, id, sharePath string, config KataAgentConfig) error {
 	return nil
 }
 
-func (n *mockAgent) configureFromGrpc(ctx context.Context, h hypervisor, id string, config KataAgentConfig) error {
+func (n *mockAgent) configureFromGrpc(ctx context.Context, h Hypervisor, id string, config KataAgentConfig) error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -31,7 +31,7 @@ func (m *mockHypervisor) hypervisorConfig() HypervisorConfig {
 }
 
 func (m *mockHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
-	err := hypervisorConfig.valid()
+	err := hypervisorConfig.Valid()
 	if err != nil {
 		return err
 	}
@@ -59,26 +59,26 @@ func (m *mockHypervisor) saveSandbox() error {
 	return nil
 }
 
-func (m *mockHypervisor) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
+func (m *mockHypervisor) addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
 	return nil
 }
 
-func (m *mockHypervisor) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
+func (m *mockHypervisor) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	switch devType {
-	case cpuDev:
+	case CpuDev:
 		return devInfo.(uint32), nil
-	case memoryDev:
-		memdev := devInfo.(*memoryDevice)
-		return memdev.sizeMB, nil
+	case MemoryDev:
+		memdev := devInfo.(*MemoryDevice)
+		return memdev.SizeMB, nil
 	}
 	return nil, nil
 }
 
-func (m *mockHypervisor) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
+func (m *mockHypervisor) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	switch devType {
-	case cpuDev:
+	case CpuDev:
 		return devInfo.(uint32), nil
-	case memoryDev:
+	case MemoryDev:
 		return 0, nil
 	}
 	return nil, nil
@@ -88,8 +88,8 @@ func (m *mockHypervisor) getSandboxConsole(ctx context.Context, sandboxID string
 	return "", "", nil
 }
 
-func (m *mockHypervisor) resizeMemory(ctx context.Context, memMB uint32, memorySectionSizeMB uint32, probe bool) (uint32, memoryDevice, error) {
-	return 0, memoryDevice{}, nil
+func (m *mockHypervisor) resizeMemory(ctx context.Context, memMB uint32, memorySectionSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
+	return 0, MemoryDevice{}, nil
 }
 func (m *mockHypervisor) resizeVCPUs(ctx context.Context, cpus uint32) (uint32, uint32, error) {
 	return 0, 0, nil
@@ -98,9 +98,9 @@ func (m *mockHypervisor) resizeVCPUs(ctx context.Context, cpus uint32) (uint32, 
 func (m *mockHypervisor) disconnect(ctx context.Context) {
 }
 
-func (m *mockHypervisor) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
+func (m *mockHypervisor) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
 	vcpus := map[int]int{0: os.Getpid()}
-	return vcpuThreadIDs{vcpus}, nil
+	return VcpuThreadIDs{vcpus}, nil
 }
 
 func (m *mockHypervisor) cleanup(ctx context.Context) error {

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -39,7 +39,7 @@ func (m *mockHypervisor) createSandbox(ctx context.Context, id string, networkNS
 	return nil
 }
 
-func (m *mockHypervisor) startSandbox(ctx context.Context, timeout int) error {
+func (m *mockHypervisor) StartVM(ctx context.Context, timeout int) error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -51,7 +51,7 @@ func (m *mockHypervisor) PauseVM(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockHypervisor) resumeSandbox(ctx context.Context) error {
+func (m *mockHypervisor) ResumeVM(ctx context.Context) error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -55,7 +55,7 @@ func (m *mockHypervisor) resumeSandbox(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockHypervisor) saveSandbox() error {
+func (m *mockHypervisor) SaveVM() error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -47,7 +47,7 @@ func (m *mockHypervisor) stopSandbox(ctx context.Context, waitOnly bool) error {
 	return nil
 }
 
-func (m *mockHypervisor) pauseSandbox(ctx context.Context) error {
+func (m *mockHypervisor) PauseVM(ctx context.Context) error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -84,7 +84,7 @@ func (m *mockHypervisor) HotplugRemoveDevice(ctx context.Context, devInfo interf
 	return nil, nil
 }
 
-func (m *mockHypervisor) GetSandboxConsole(ctx context.Context, sandboxID string) (string, string, error) {
+func (m *mockHypervisor) GetVMConsole(ctx context.Context, sandboxID string) (string, string, error) {
 	return "", "", nil
 }
 

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -20,13 +20,13 @@ type mockHypervisor struct {
 	mockPid int
 }
 
-func (m *mockHypervisor) capabilities(ctx context.Context) types.Capabilities {
+func (m *mockHypervisor) Capabilities(ctx context.Context) types.Capabilities {
 	caps := types.Capabilities{}
 	caps.SetFsSharingSupport()
 	return caps
 }
 
-func (m *mockHypervisor) hypervisorConfig() HypervisorConfig {
+func (m *mockHypervisor) HypervisorConfig() HypervisorConfig {
 	return HypervisorConfig{}
 }
 
@@ -59,11 +59,11 @@ func (m *mockHypervisor) saveSandbox() error {
 	return nil
 }
 
-func (m *mockHypervisor) addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
+func (m *mockHypervisor) AddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
 	return nil
 }
 
-func (m *mockHypervisor) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+func (m *mockHypervisor) HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	switch devType {
 	case CpuDev:
 		return devInfo.(uint32), nil
@@ -74,7 +74,7 @@ func (m *mockHypervisor) hotplugAddDevice(ctx context.Context, devInfo interface
 	return nil, nil
 }
 
-func (m *mockHypervisor) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+func (m *mockHypervisor) HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	switch devType {
 	case CpuDev:
 		return devInfo.(uint32), nil
@@ -84,34 +84,34 @@ func (m *mockHypervisor) hotplugRemoveDevice(ctx context.Context, devInfo interf
 	return nil, nil
 }
 
-func (m *mockHypervisor) getSandboxConsole(ctx context.Context, sandboxID string) (string, string, error) {
+func (m *mockHypervisor) GetSandboxConsole(ctx context.Context, sandboxID string) (string, string, error) {
 	return "", "", nil
 }
 
-func (m *mockHypervisor) resizeMemory(ctx context.Context, memMB uint32, memorySectionSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
+func (m *mockHypervisor) ResizeMemory(ctx context.Context, memMB uint32, memorySectionSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
 	return 0, MemoryDevice{}, nil
 }
-func (m *mockHypervisor) resizeVCPUs(ctx context.Context, cpus uint32) (uint32, uint32, error) {
+func (m *mockHypervisor) ResizeVCPUs(ctx context.Context, cpus uint32) (uint32, uint32, error) {
 	return 0, 0, nil
 }
 
-func (m *mockHypervisor) disconnect(ctx context.Context) {
+func (m *mockHypervisor) Disconnect(ctx context.Context) {
 }
 
-func (m *mockHypervisor) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
+func (m *mockHypervisor) GetThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
 	vcpus := map[int]int{0: os.Getpid()}
 	return VcpuThreadIDs{vcpus}, nil
 }
 
-func (m *mockHypervisor) cleanup(ctx context.Context) error {
+func (m *mockHypervisor) Cleanup(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockHypervisor) getPids() []int {
+func (m *mockHypervisor) GetPids() []int {
 	return []int{m.mockPid}
 }
 
-func (m *mockHypervisor) getVirtioFsPid() *int {
+func (m *mockHypervisor) GetVirtioFsPid() *int {
 	return nil
 }
 
@@ -123,23 +123,23 @@ func (m *mockHypervisor) toGrpc(ctx context.Context) ([]byte, error) {
 	return nil, errors.New("mockHypervisor is not supported by VM cache")
 }
 
-func (m *mockHypervisor) save() (s persistapi.HypervisorState) {
+func (m *mockHypervisor) Save() (s persistapi.HypervisorState) {
 	return
 }
 
-func (m *mockHypervisor) load(s persistapi.HypervisorState) {}
+func (m *mockHypervisor) Load(s persistapi.HypervisorState) {}
 
-func (m *mockHypervisor) check() error {
+func (m *mockHypervisor) Check() error {
 	return nil
 }
 
-func (m *mockHypervisor) generateSocket(id string) (interface{}, error) {
+func (m *mockHypervisor) GenerateSocket(id string) (interface{}, error) {
 	return types.MockHybridVSock{
 		UdsPath: MockHybridVSockPath,
 	}, nil
 }
 
-func (m *mockHypervisor) isRateLimiterBuiltin() bool {
+func (m *mockHypervisor) IsRateLimiterBuiltin() bool {
 	return false
 }
 

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -43,7 +43,7 @@ func (m *mockHypervisor) startSandbox(ctx context.Context, timeout int) error {
 	return nil
 }
 
-func (m *mockHypervisor) stopSandbox(ctx context.Context, waitOnly bool) error {
+func (m *mockHypervisor) StopVM(ctx context.Context, waitOnly bool) error {
 	return nil
 }
 

--- a/src/runtime/virtcontainers/mock_hypervisor.go
+++ b/src/runtime/virtcontainers/mock_hypervisor.go
@@ -31,6 +31,11 @@ func (m *mockHypervisor) HypervisorConfig() HypervisorConfig {
 }
 
 func (m *mockHypervisor) createSandbox(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
+	hypervisorConfig.IsSandbox = true
+	return m.CreateVM(ctx, id, networkNS, hypervisorConfig)
+}
+
+func (m *mockHypervisor) CreateVM(ctx context.Context, id string, networkNS NetworkNamespace, hypervisorConfig *HypervisorConfig) error {
 	err := hypervisorConfig.Valid()
 	if err != nil {
 		return err

--- a/src/runtime/virtcontainers/mock_hypervisor_test.go
+++ b/src/runtime/virtcontainers/mock_hypervisor_test.go
@@ -47,7 +47,7 @@ func TestMockHypervisorCreateSandbox(t *testing.T) {
 func TestMockHypervisorStartSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	assert.NoError(t, m.startSandbox(context.Background(), vmStartTimeout))
+	assert.NoError(t, m.StartVM(context.Background(), vmStartTimeout))
 }
 
 func TestMockHypervisorStopSandbox(t *testing.T) {

--- a/src/runtime/virtcontainers/mock_hypervisor_test.go
+++ b/src/runtime/virtcontainers/mock_hypervisor_test.go
@@ -76,7 +76,7 @@ func TestMockHypervisorGetSandboxConsole(t *testing.T) {
 func TestMockHypervisorSaveSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	assert.NoError(t, m.saveSandbox())
+	assert.NoError(t, m.SaveVM())
 }
 
 func TestMockHypervisorDisconnect(t *testing.T) {

--- a/src/runtime/virtcontainers/mock_hypervisor_test.go
+++ b/src/runtime/virtcontainers/mock_hypervisor_test.go
@@ -47,7 +47,7 @@ func TestMockHypervisorCreateSandbox(t *testing.T) {
 func TestMockHypervisorStartSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	assert.NoError(t, m.StartVM(context.Background(), vmStartTimeout))
+	assert.NoError(t, m.StartVM(context.Background(), VmStartTimeout))
 }
 
 func TestMockHypervisorStopSandbox(t *testing.T) {

--- a/src/runtime/virtcontainers/mock_hypervisor_test.go
+++ b/src/runtime/virtcontainers/mock_hypervisor_test.go
@@ -67,7 +67,7 @@ func TestMockHypervisorGetSandboxConsole(t *testing.T) {
 
 	expected := ""
 	expectedProto := ""
-	proto, result, err := m.GetSandboxConsole(context.Background(), "testSandboxID")
+	proto, result, err := m.GetVMConsole(context.Background(), "testSandboxID")
 	assert.NoError(t, err)
 	assert.Equal(t, result, expected)
 	assert.Equal(t, proto, expectedProto)

--- a/src/runtime/virtcontainers/mock_hypervisor_test.go
+++ b/src/runtime/virtcontainers/mock_hypervisor_test.go
@@ -53,7 +53,7 @@ func TestMockHypervisorStartSandbox(t *testing.T) {
 func TestMockHypervisorStopSandbox(t *testing.T) {
 	var m *mockHypervisor
 
-	assert.NoError(t, m.stopSandbox(context.Background(), false))
+	assert.NoError(t, m.StopVM(context.Background(), false))
 }
 
 func TestMockHypervisorAddDevice(t *testing.T) {

--- a/src/runtime/virtcontainers/mock_hypervisor_test.go
+++ b/src/runtime/virtcontainers/mock_hypervisor_test.go
@@ -59,7 +59,7 @@ func TestMockHypervisorStopSandbox(t *testing.T) {
 func TestMockHypervisorAddDevice(t *testing.T) {
 	var m *mockHypervisor
 
-	assert.NoError(t, m.addDevice(context.Background(), nil, imgDev))
+	assert.NoError(t, m.addDevice(context.Background(), nil, ImgDev))
 }
 
 func TestMockHypervisorGetSandboxConsole(t *testing.T) {

--- a/src/runtime/virtcontainers/mock_hypervisor_test.go
+++ b/src/runtime/virtcontainers/mock_hypervisor_test.go
@@ -59,7 +59,7 @@ func TestMockHypervisorStopSandbox(t *testing.T) {
 func TestMockHypervisorAddDevice(t *testing.T) {
 	var m *mockHypervisor
 
-	assert.NoError(t, m.addDevice(context.Background(), nil, ImgDev))
+	assert.NoError(t, m.AddDevice(context.Background(), nil, ImgDev))
 }
 
 func TestMockHypervisorGetSandboxConsole(t *testing.T) {
@@ -67,7 +67,7 @@ func TestMockHypervisorGetSandboxConsole(t *testing.T) {
 
 	expected := ""
 	expectedProto := ""
-	proto, result, err := m.getSandboxConsole(context.Background(), "testSandboxID")
+	proto, result, err := m.GetSandboxConsole(context.Background(), "testSandboxID")
 	assert.NoError(t, err)
 	assert.Equal(t, result, expected)
 	assert.Equal(t, proto, expectedProto)
@@ -82,19 +82,19 @@ func TestMockHypervisorSaveSandbox(t *testing.T) {
 func TestMockHypervisorDisconnect(t *testing.T) {
 	var m *mockHypervisor
 
-	m.disconnect(context.Background())
+	m.Disconnect(context.Background())
 }
 
 func TestMockHypervisorCheck(t *testing.T) {
 	var m *mockHypervisor
 
-	assert.NoError(t, m.check())
+	assert.NoError(t, m.Check())
 }
 
 func TestMockGenerateSocket(t *testing.T) {
 	var m *mockHypervisor
 
-	i, err := m.generateSocket("a")
+	i, err := m.GenerateSocket("a")
 	assert.NoError(t, err)
 	assert.NotNil(t, i)
 }

--- a/src/runtime/virtcontainers/monitor.go
+++ b/src/runtime/virtcontainers/monitor.go
@@ -140,7 +140,7 @@ func (m *monitor) watchAgent(ctx context.Context) {
 }
 
 func (m *monitor) watchHypervisor(ctx context.Context) error {
-	if err := m.sandbox.hypervisor.check(); err != nil {
+	if err := m.sandbox.hypervisor.Check(); err != nil {
 		m.notify(ctx, errors.Wrapf(err, "failed to ping hypervisor process"))
 		return err
 	}

--- a/src/runtime/virtcontainers/monitor.go
+++ b/src/runtime/virtcontainers/monitor.go
@@ -141,7 +141,7 @@ func (m *monitor) watchAgent(ctx context.Context) {
 
 func (m *monitor) watchHypervisor(ctx context.Context) error {
 	if err := m.sandbox.hypervisor.Check(); err != nil {
-		m.notify(ctx, errors.Wrapf(err, "failed to ping hypervisor process"))
+		m.notify(ctx, errors.Wrapf(err, "failed to ping Hypervisor process"))
 		return err
 	}
 	return nil

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -495,7 +495,7 @@ func isSecret(path string) bool {
 // files observed is greater than limit, break and return -1
 func countFiles(path string, limit int) (numFiles int, err error) {
 
-	// First, check to see if the path exists
+	// First, Check to see if the path exists
 	file, err := os.Stat(path)
 	if os.IsNotExist(err) {
 		return 0, err
@@ -531,7 +531,7 @@ func countFiles(path string, limit int) (numFiles int, err error) {
 func isWatchableMount(path string) bool {
 	if isSecret(path) || isConfigMap(path) {
 		// we have a cap on number of FDs which can be present in mount
-		// to determine if watchable. A similar check exists within the agent,
+		// to determine if watchable. A similar Check exists within the agent,
 		// which may or may not help handle case where extra files are added to
 		// a mount after the fact
 		count, _ := countFiles(path, 8)

--- a/src/runtime/virtcontainers/mount_test.go
+++ b/src/runtime/virtcontainers/mount_test.go
@@ -472,7 +472,7 @@ func TestBindUnmountContainerRootfsENOENTNotError(t *testing.T) {
 	cID := "contIDTest"
 	assert := assert.New(t)
 
-	// check to make sure the file doesn't exist
+	// Check to make sure the file doesn't exist
 	testPath := filepath.Join(testMnt, sID, cID, rootfsDir)
 	if _, err := os.Stat(testPath); !os.IsNotExist(err) {
 		assert.NoError(os.Remove(testPath))

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -426,7 +426,7 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 }
 
 // The endpoint type should dictate how the connection needs to happen.
-func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h hypervisor) error {
+func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) error {
 	var err error
 
 	span, ctx := networkTrace(ctx, "xConnectVMNetwork", endpoint)
@@ -603,7 +603,7 @@ func tapNetworkPair(ctx context.Context, endpoint Endpoint, queues int, disableV
 	}
 
 	// Save the veth MAC address to the TAP so that it can later be used
-	// to build the hypervisor command line. This MAC address has to be
+	// to build the Hypervisor command line. This MAC address has to be
 	// the one inside the VM in order to avoid any firewall issues. The
 	// bridge created by the network plugin on the host actually expects
 	// to see traffic from this MAC address and not another one.
@@ -701,7 +701,7 @@ func setupTCFiltering(ctx context.Context, endpoint Endpoint, queues int, disabl
 	attrs = link.Attrs()
 
 	// Save the veth MAC address to the TAP so that it can later be used
-	// to build the hypervisor command line. This MAC address has to be
+	// to build the Hypervisor command line. This MAC address has to be
 	// the one inside the VM in order to avoid any firewall issues. The
 	// bridge created by the network plugin on the host actually expects
 	// to see traffic from this MAC address and not another one.
@@ -1412,7 +1412,7 @@ func (n *Network) PostAdd(ctx context.Context, ns *NetworkNamespace, hotplug boo
 
 // Remove network endpoints in the network namespace. It also deletes the network
 // namespace in case the namespace has been created by us.
-func (n *Network) Remove(ctx context.Context, ns *NetworkNamespace, hypervisor hypervisor) error {
+func (n *Network) Remove(ctx context.Context, ns *NetworkNamespace, hypervisor Hypervisor) error {
 	span, ctx := n.trace(ctx, "Remove")
 	defer span.End()
 

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -59,7 +59,7 @@ const (
 	// NetXConnectNoneModel can be used when the VM is in the host network namespace
 	NetXConnectNoneModel
 
-	// NetXConnectInvalidModel is the last item to check valid values by IsValid()
+	// NetXConnectInvalidModel is the last item to Check valid values by IsValid()
 	NetXConnectInvalidModel
 )
 
@@ -435,16 +435,16 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h hypervisor) err
 	netPair := endpoint.NetworkPair()
 
 	queues := 0
-	caps := h.capabilities(ctx)
+	caps := h.Capabilities(ctx)
 	if caps.IsMultiQueueSupported() {
-		queues = int(h.hypervisorConfig().NumVCPUs)
+		queues = int(h.HypervisorConfig().NumVCPUs)
 	}
 
 	var disableVhostNet bool
 	if rootless.IsRootless() {
 		disableVhostNet = true
 	} else {
-		disableVhostNet = h.hypervisorConfig().DisableVhostNet
+		disableVhostNet = h.HypervisorConfig().DisableVhostNet
 	}
 
 	if netPair.NetInterworkingModel == NetXConnectDefaultModel {
@@ -518,7 +518,7 @@ func createFds(device string, numFds int) ([]*os.File, error) {
 //
 // Till that bug is fixed we need to pick a random non conflicting index and try to
 // create a link. If that fails, we need to try with another.
-// All the kernel does not check if the link id conflicts with a link id on the host
+// All the kernel does not Check if the link id conflicts with a link id on the host
 // hence we need to offset the link id to prevent any overlaps with the host index
 //
 // Here the kernel will ensure that there is no race condition
@@ -1355,15 +1355,15 @@ func (n *Network) Add(ctx context.Context, config *NetworkConfig, s *Sandbox, ho
 				}
 			}
 
-			if !s.hypervisor.isRateLimiterBuiltin() {
-				rxRateLimiterMaxRate := s.hypervisor.hypervisorConfig().RxRateLimiterMaxRate
+			if !s.hypervisor.IsRateLimiterBuiltin() {
+				rxRateLimiterMaxRate := s.hypervisor.HypervisorConfig().RxRateLimiterMaxRate
 				if rxRateLimiterMaxRate > 0 {
 					networkLogger().Info("Add Rx Rate Limiter")
 					if err := addRxRateLimiter(endpoint, rxRateLimiterMaxRate); err != nil {
 						return err
 					}
 				}
-				txRateLimiterMaxRate := s.hypervisor.hypervisorConfig().TxRateLimiterMaxRate
+				txRateLimiterMaxRate := s.hypervisor.HypervisorConfig().TxRateLimiterMaxRate
 				if txRateLimiterMaxRate > 0 {
 					networkLogger().Info("Add Tx Rate Limiter")
 					if err := addTxRateLimiter(endpoint, txRateLimiterMaxRate); err != nil {
@@ -1559,7 +1559,7 @@ func addHTBQdisc(linkIndex int, maxRate uint64) error {
 // By redirecting interface ingress traffic to ifb and treat it as egress traffic there,
 // we could do network shaping to interface inbound traffic.
 func addIFBDevice() (int, error) {
-	// check whether host supports ifb
+	// Check whether host supports ifb
 	if ok, err := utils.SupportsIfb(); !ok {
 		return -1, err
 	}

--- a/src/runtime/virtcontainers/persist.go
+++ b/src/runtime/virtcontainers/persist.go
@@ -60,7 +60,7 @@ func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistap
 
 func (s *Sandbox) dumpHypervisor(ss *persistapi.SandboxState) {
 	ss.HypervisorState = s.hypervisor.Save()
-	// BlockIndexMap will be moved from sandbox state to hypervisor state later
+	// BlockIndexMap will be moved from sandbox state to Hypervisor state later
 	ss.HypervisorState.BlockIndexMap = s.state.BlockIndexMap
 }
 

--- a/src/runtime/virtcontainers/persist.go
+++ b/src/runtime/virtcontainers/persist.go
@@ -59,7 +59,7 @@ func (s *Sandbox) dumpState(ss *persistapi.SandboxState, cs map[string]persistap
 }
 
 func (s *Sandbox) dumpHypervisor(ss *persistapi.SandboxState) {
-	ss.HypervisorState = s.hypervisor.save()
+	ss.HypervisorState = s.hypervisor.Save()
 	// BlockIndexMap will be moved from sandbox state to hypervisor state later
 	ss.HypervisorState.BlockIndexMap = s.state.BlockIndexMap
 }
@@ -316,7 +316,7 @@ func (c *Container) loadContState(cs persistapi.ContainerState) {
 }
 
 func (s *Sandbox) loadHypervisor(hs persistapi.HypervisorState) {
-	s.hypervisor.load(hs)
+	s.hypervisor.Load(hs)
 }
 
 func (s *Sandbox) loadAgent(as persistapi.AgentState) {

--- a/src/runtime/virtcontainers/persist_test.go
+++ b/src/runtime/virtcontainers/persist_test.go
@@ -55,7 +55,7 @@ func TestSandboxRestore(t *testing.T) {
 	assert.Equal(sandbox.state.GuestMemoryBlockSizeMB, uint32(0))
 	assert.Equal(len(sandbox.state.BlockIndexMap), 0)
 
-	// set state data and save again
+	// set state data and Save again
 	sandbox.state.State = types.StateString("running")
 	sandbox.state.GuestMemoryBlockSizeMB = uint32(1024)
 	sandbox.state.BlockIndexMap[2] = struct{}{}

--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -76,7 +76,7 @@ func (endpoint *PhysicalEndpoint) NetworkPair() *NetworkInterfacePair {
 }
 
 // Attach for physical endpoint binds the physical network interface to
-// vfio-pci and adds device to the hypervisor with vfio-passthrough.
+// vfio-pci and adds device to the Hypervisor with vfio-passthrough.
 func (endpoint *PhysicalEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 	span, ctx := physicalTrace(ctx, "Attach", endpoint)
 	defer span.End()
@@ -121,12 +121,12 @@ func (endpoint *PhysicalEndpoint) Detach(ctx context.Context, netNsCreated bool,
 }
 
 // HotAttach for physical endpoint not supported yet
-func (endpoint *PhysicalEndpoint) HotAttach(ctx context.Context, h hypervisor) error {
+func (endpoint *PhysicalEndpoint) HotAttach(ctx context.Context, h Hypervisor) error {
 	return fmt.Errorf("PhysicalEndpoint does not support Hot attach")
 }
 
 // HotDetach for physical endpoint not supported yet
-func (endpoint *PhysicalEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsCreated bool, netNsPath string) error {
+func (endpoint *PhysicalEndpoint) HotDetach(ctx context.Context, h Hypervisor, netNsCreated bool, netNsPath string) error {
 	return fmt.Errorf("PhysicalEndpoint does not support Hot detach")
 }
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1879,8 +1879,8 @@ func (q *qemu) PauseVM(ctx context.Context) error {
 	return q.togglePauseSandbox(ctx, true)
 }
 
-func (q *qemu) resumeSandbox(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "resumeSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
+func (q *qemu) ResumeVM(ctx context.Context) error {
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "ResumeVM", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	return q.togglePauseSandbox(ctx, false)

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -758,8 +758,8 @@ func (q *qemu) setupVirtioMem(ctx context.Context) error {
 }
 
 // startSandbox will start the Sandbox's VM.
-func (q *qemu) startSandbox(ctx context.Context, timeout int) error {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "startSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
+func (q *qemu) StartVM(ctx context.Context, timeout int) error {
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "StartVM", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	if q.config.Debug {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/rootless"
 	"io/ioutil"
 	"math"
 	"os"
@@ -23,6 +22,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/rootless"
 
 	govmmQemu "github.com/kata-containers/govmm/qemu"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -44,7 +45,7 @@ import (
 var qemuTracingTags = map[string]string{
 	"source":    "runtime",
 	"package":   "virtcontainers",
-	"subsystem": "hypervisor",
+	"subsystem": "Hypervisor",
 	"type":      "qemu",
 }
 
@@ -68,7 +69,7 @@ type qmpChannel struct {
 
 // CPUDevice represents a CPU device which was hot-added in a running VM
 type CPUDevice struct {
-	// ID is used to identify this CPU in the hypervisor options.
+	// ID is used to identify this CPU in the Hypervisor options.
 	ID string
 }
 
@@ -193,7 +194,7 @@ func (q *qemu) kernelParameters() string {
 	return strings.Join(paramsStr, " ")
 }
 
-// Adds all capabilities supported by qemu implementation of hypervisor interface
+// Adds all capabilities supported by qemu implementation of Hypervisor interface
 func (q *qemu) Capabilities(ctx context.Context) types.Capabilities {
 	span, _ := katatrace.Trace(ctx, q.Logger(), "Capabilities", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
@@ -615,7 +616,7 @@ func (q *qemu) CreateVM(ctx context.Context, id string, networkNS NetworkNamespa
 	if ioThread != nil {
 		qemuConfig.IOThreads = []govmmQemu.IOThread{*ioThread}
 	}
-	// Add RNG device to hypervisor
+	// Add RNG device to Hypervisor
 	rngDev := config.RNGDev{
 		ID:       rngID,
 		Filename: q.config.EntropySource,
@@ -625,7 +626,7 @@ func (q *qemu) CreateVM(ctx context.Context, id string, networkNS NetworkNamespa
 		return err
 	}
 
-	// Add PCIe Root Port devices to hypervisor
+	// Add PCIe Root Port devices to Hypervisor
 	// The pcie.0 bus do not support hot-plug, but PCIe device can be hot-plugged into PCIe Root Port.
 	// For more details, please see https://github.com/qemu/qemu/blob/master/docs/pcie.txt
 	if hypervisorConfig.PCIeRootPort > 0 {
@@ -1147,7 +1148,7 @@ func (q *qemu) canDumpGuestMemory(dumpSavePath string) error {
 }
 
 // dumpSandboxMetaInfo save meta information for debug purpose, includes:
-// hypervisor version, sandbox/container state, hypervisor config
+// Hypervisor version, sandbox/container state, Hypervisor config
 func (q *qemu) dumpSandboxMetaInfo(dumpSavePath string) {
 	dumpStatePath := filepath.Join(dumpSavePath, "state")
 
@@ -1158,22 +1159,22 @@ func (q *qemu) dumpSandboxMetaInfo(dumpSavePath string) {
 	if output, err := pkgUtils.RunCommandFull(command, true); err != nil {
 		q.Logger().WithError(err).WithField("output", output).Error("failed to Save state")
 	}
-	// Save hypervisor meta information
-	fileName := filepath.Join(dumpSavePath, "hypervisor.conf")
+	// Save Hypervisor meta information
+	fileName := filepath.Join(dumpSavePath, "Hypervisor.conf")
 	data, _ := json.MarshalIndent(q.config, "", " ")
 	if err := ioutil.WriteFile(fileName, data, defaultFilePerms); err != nil {
-		q.Logger().WithError(err).WithField("hypervisor.conf", data).Error("write to hypervisor.conf file failed")
+		q.Logger().WithError(err).WithField("Hypervisor.conf", data).Error("write to Hypervisor.conf file failed")
 	}
 
-	// Save hypervisor version
+	// Save Hypervisor version
 	hyperVisorVersion, err := pkgUtils.RunCommand([]string{q.config.HypervisorPath, "--version"})
 	if err != nil {
-		q.Logger().WithError(err).WithField("HypervisorPath", data).Error("failed to get hypervisor version")
+		q.Logger().WithError(err).WithField("HypervisorPath", data).Error("failed to get Hypervisor version")
 	}
 
-	fileName = filepath.Join(dumpSavePath, "hypervisor.version")
+	fileName = filepath.Join(dumpSavePath, "Hypervisor.version")
 	if err := ioutil.WriteFile(fileName, []byte(hyperVisorVersion), defaultFilePerms); err != nil {
-		q.Logger().WithError(err).WithField("hypervisor.version", data).Error("write to hypervisor.version file failed")
+		q.Logger().WithError(err).WithField("Hypervisor.version", data).Error("write to Hypervisor.version file failed")
 	}
 }
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -659,7 +659,7 @@ func (q *qemu) vhostFSSocketPath(id string) (string, error) {
 
 func (q *qemu) setupVirtiofsd(ctx context.Context) (err error) {
 	pid, err := q.virtiofsd.Start(ctx, func() {
-		q.stopSandbox(ctx, false)
+		q.StopVM(ctx, false)
 	})
 	if err != nil {
 		return err
@@ -928,8 +928,8 @@ func (q *qemu) waitSandbox(ctx context.Context, timeout int) error {
 }
 
 // stopSandbox will stop the Sandbox's VM.
-func (q *qemu) stopSandbox(ctx context.Context, waitOnly bool) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "stopSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
+func (q *qemu) StopVM(ctx context.Context, waitOnly bool) error {
+	span, _ := katatrace.Trace(ctx, q.Logger(), "StopVM", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	q.Logger().Info("Stopping Sandbox")

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -228,6 +228,7 @@ func (q *qemu) setup(ctx context.Context, id string, hypervisorConfig *Hyperviso
 	span, _ := katatrace.Trace(ctx, q.Logger(), "setup", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
+	//MRC: Has Kata specific logic
 	err := hypervisorConfig.Valid()
 	if err != nil {
 		return err
@@ -386,7 +387,7 @@ func (q *qemu) createQmpSocket() ([]govmmQemu.QMPSocket, error) {
 func (q *qemu) buildDevices(ctx context.Context, initrdPath string) ([]govmmQemu.Device, *govmmQemu.IOThread, error) {
 	var devices []govmmQemu.Device
 
-	_, console, err := q.GetSandboxConsole(ctx, q.id)
+	_, console, err := q.GetVMConsole(ctx, q.id)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -471,6 +472,7 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 	span, ctx := katatrace.Trace(ctx, q.Logger(), "createSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
+	// Has Kata Specific logic: See within
 	if err := q.setup(ctx, id, hypervisorConfig); err != nil {
 		return err
 	}
@@ -500,6 +502,7 @@ func (q *qemu) createSandbox(ctx context.Context, id string, networkNS NetworkNa
 		IOMMUPlatform: q.config.IOMMUPlatform,
 	}
 
+	// MRC: Kata specific
 	kernelPath, err := q.config.KernelAssetPath()
 	if err != nil {
 		return err
@@ -1944,8 +1947,8 @@ func (q *qemu) AddDevice(ctx context.Context, devInfo interface{}, devType Devic
 
 // getSandboxConsole builds the path of the console where we can read
 // logs coming from the sandbox.
-func (q *qemu) GetSandboxConsole(ctx context.Context, id string) (string, string, error) {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "GetSandboxConsole", qemuTracingTags, map[string]string{"sandbox_id": q.id})
+func (q *qemu) GetVMConsole(ctx context.Context, id string) (string, string, error) {
+	span, _ := katatrace.Trace(ctx, q.Logger(), "GetVMConsole", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	consoleURL, err := utils.BuildSocketPath(q.store.RunVMStoragePath(), id, consoleSocket)

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -839,7 +839,7 @@ func (q *qemu) startSandbox(ctx context.Context, timeout int) error {
 		return fmt.Errorf("failed to launch qemu: %s, error messages from qemu log: %s", err, strErr)
 	}
 
-	err = q.waitSandbox(ctx, timeout)
+	err = q.waitVM(ctx, timeout)
 	if err != nil {
 		return err
 	}
@@ -876,9 +876,9 @@ func (q *qemu) bootFromTemplate() error {
 	return q.waitMigration()
 }
 
-// waitSandbox will wait for the Sandbox's VM to be up and running.
-func (q *qemu) waitSandbox(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, q.Logger(), "waitSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
+// waitVM will wait for the Sandbox's VM to be up and running.
+func (q *qemu) waitVM(ctx context.Context, timeout int) error {
+	span, _ := katatrace.Trace(ctx, q.Logger(), "waitVM", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	if timeout < 0 {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1872,8 +1872,8 @@ func (q *qemu) hotplugAddMemory(memDev *MemoryDevice) (int, error) {
 	return memDev.SizeMB, nil
 }
 
-func (q *qemu) pauseSandbox(ctx context.Context) error {
-	span, ctx := katatrace.Trace(ctx, q.Logger(), "pauseSandbox", qemuTracingTags, map[string]string{"sandbox_id": q.id})
+func (q *qemu) PauseVM(ctx context.Context) error {
+	span, ctx := katatrace.Trace(ctx, q.Logger(), "PauseVM", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
 	return q.togglePauseSandbox(ctx, true)

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -228,7 +228,7 @@ func (q *qemu) setup(ctx context.Context, id string, hypervisorConfig *Hyperviso
 	span, _ := katatrace.Trace(ctx, q.Logger(), "setup", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
-	err := hypervisorConfig.valid()
+	err := hypervisorConfig.Valid()
 	if err != nil {
 		return err
 	}
@@ -306,7 +306,7 @@ func (q *qemu) cpuTopology() govmmQemu.SMP {
 }
 
 func (q *qemu) hostMemMB() (uint64, error) {
-	hostMemKb, err := getHostMemorySizeKb(procMemInfo)
+	hostMemKb, err := GetHostMemorySizeKb(procMemInfo)
 	if err != nil {
 		return 0, fmt.Errorf("Unable to read memory info: %s", err)
 	}
@@ -1226,7 +1226,7 @@ func (q *qemu) qmpShutdown() {
 	}
 }
 
-func (q *qemu) hotplugAddBlockDevice(ctx context.Context, drive *config.BlockDrive, op operation, devID string) (err error) {
+func (q *qemu) hotplugAddBlockDevice(ctx context.Context, drive *config.BlockDrive, op Operation, devID string) (err error) {
 	// drive can be a pmem device, in which case it's used as backing file for a nvdimm device
 	if q.config.BlockDeviceDriver == config.Nvdimm || drive.Pmem {
 		var blocksize int64
@@ -1347,7 +1347,7 @@ func (q *qemu) hotplugAddBlockDevice(ctx context.Context, drive *config.BlockDri
 	return nil
 }
 
-func (q *qemu) hotplugAddVhostUserBlkDevice(ctx context.Context, vAttr *config.VhostUserDeviceAttrs, op operation, devID string) (err error) {
+func (q *qemu) hotplugAddVhostUserBlkDevice(ctx context.Context, vAttr *config.VhostUserDeviceAttrs, op Operation, devID string) (err error) {
 	err = q.qmpMonitorCh.qmp.ExecuteCharDevUnixSocketAdd(q.qmpMonitorCh.ctx, vAttr.DevID, vAttr.SocketPath, false, false)
 	if err != nil {
 		return err
@@ -1388,14 +1388,14 @@ func (q *qemu) hotplugAddVhostUserBlkDevice(ctx context.Context, vAttr *config.V
 	return nil
 }
 
-func (q *qemu) hotplugBlockDevice(ctx context.Context, drive *config.BlockDrive, op operation) error {
+func (q *qemu) hotplugBlockDevice(ctx context.Context, drive *config.BlockDrive, op Operation) error {
 	if err := q.qmpSetup(); err != nil {
 		return err
 	}
 
 	devID := "virtio-" + drive.ID
 
-	if op == addDevice {
+	if op == AddDevice {
 		return q.hotplugAddBlockDevice(ctx, drive, op, devID)
 	}
 	if !drive.Swap && q.config.BlockDeviceDriver == config.VirtioBlock {
@@ -1411,14 +1411,14 @@ func (q *qemu) hotplugBlockDevice(ctx context.Context, drive *config.BlockDrive,
 	return q.qmpMonitorCh.qmp.ExecuteBlockdevDel(q.qmpMonitorCh.ctx, drive.ID)
 }
 
-func (q *qemu) hotplugVhostUserDevice(ctx context.Context, vAttr *config.VhostUserDeviceAttrs, op operation) error {
+func (q *qemu) hotplugVhostUserDevice(ctx context.Context, vAttr *config.VhostUserDeviceAttrs, op Operation) error {
 	if err := q.qmpSetup(); err != nil {
 		return err
 	}
 
 	devID := "virtio-" + vAttr.DevID
 
-	if op == addDevice {
+	if op == AddDevice {
 		switch vAttr.Type {
 		case config.VhostUserBlk:
 			return q.hotplugAddVhostUserBlkDevice(ctx, vAttr, op, devID)
@@ -1438,7 +1438,7 @@ func (q *qemu) hotplugVhostUserDevice(ctx context.Context, vAttr *config.VhostUs
 	}
 }
 
-func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op operation) (err error) {
+func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op Operation) (err error) {
 	if err = q.qmpSetup(); err != nil {
 		return err
 	}
@@ -1446,7 +1446,7 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 	devID := device.ID
 	machineType := q.hypervisorConfig().HypervisorMachineType
 
-	if op == addDevice {
+	if op == AddDevice {
 
 		buf, _ := json.Marshal(device)
 		q.Logger().WithFields(logrus.Fields{
@@ -1543,7 +1543,7 @@ func (q *qemu) hotAddNetDevice(name, hardAddr string, VMFds, VhostFds []*os.File
 	return q.qmpMonitorCh.qmp.ExecuteNetdevAddByFds(q.qmpMonitorCh.ctx, "tap", name, VMFdNames, VhostFdNames)
 }
 
-func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op operation) (err error) {
+func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op Operation) (err error) {
 	if err = q.qmpSetup(); err != nil {
 		return err
 	}
@@ -1561,7 +1561,7 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op opera
 	}
 
 	devID := "virtio-" + tap.ID
-	if op == addDevice {
+	if op == AddDevice {
 		if err = q.hotAddNetDevice(tap.Name, endpoint.HardwareAddr(), tap.VMFds, tap.VhostFds); err != nil {
 			return err
 		}
@@ -1618,24 +1618,24 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op opera
 	return q.qmpMonitorCh.qmp.ExecuteNetdevDel(q.qmpMonitorCh.ctx, tap.Name)
 }
 
-func (q *qemu) hotplugDevice(ctx context.Context, devInfo interface{}, devType deviceType, op operation) (interface{}, error) {
+func (q *qemu) hotplugDevice(ctx context.Context, devInfo interface{}, devType DeviceType, op Operation) (interface{}, error) {
 	switch devType {
-	case blockDev:
+	case BlockDev:
 		drive := devInfo.(*config.BlockDrive)
 		return nil, q.hotplugBlockDevice(ctx, drive, op)
-	case cpuDev:
+	case CpuDev:
 		vcpus := devInfo.(uint32)
 		return q.hotplugCPUs(vcpus, op)
-	case vfioDev:
+	case VfioDev:
 		device := devInfo.(*config.VFIODev)
 		return nil, q.hotplugVFIODevice(ctx, device, op)
-	case memoryDev:
-		memdev := devInfo.(*memoryDevice)
+	case MemoryDev:
+		memdev := devInfo.(*MemoryDevice)
 		return q.hotplugMemory(memdev, op)
-	case netDev:
+	case NetDev:
 		device := devInfo.(Endpoint)
 		return nil, q.hotplugNetDevice(ctx, device, op)
-	case vhostuserDev:
+	case VhostuserDev:
 		vAttr := devInfo.(*config.VhostUserDeviceAttrs)
 		return nil, q.hotplugVhostUserDevice(ctx, vAttr, op)
 	default:
@@ -1643,12 +1643,12 @@ func (q *qemu) hotplugDevice(ctx context.Context, devInfo interface{}, devType d
 	}
 }
 
-func (q *qemu) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
+func (q *qemu) hotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugAddDevice", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	katatrace.AddTag(span, "device", devInfo)
 	defer span.End()
 
-	data, err := q.hotplugDevice(ctx, devInfo, devType, addDevice)
+	data, err := q.hotplugDevice(ctx, devInfo, devType, AddDevice)
 	if err != nil {
 		return data, err
 	}
@@ -1656,12 +1656,12 @@ func (q *qemu) hotplugAddDevice(ctx context.Context, devInfo interface{}, devTyp
 	return data, nil
 }
 
-func (q *qemu) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType deviceType) (interface{}, error) {
+func (q *qemu) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	span, ctx := katatrace.Trace(ctx, q.Logger(), "hotplugRemoveDevice", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	katatrace.AddTag(span, "device", devInfo)
 	defer span.End()
 
-	data, err := q.hotplugDevice(ctx, devInfo, devType, removeDevice)
+	data, err := q.hotplugDevice(ctx, devInfo, devType, RemoveDevice)
 	if err != nil {
 		return data, err
 	}
@@ -1669,7 +1669,7 @@ func (q *qemu) hotplugRemoveDevice(ctx context.Context, devInfo interface{}, dev
 	return data, nil
 }
 
-func (q *qemu) hotplugCPUs(vcpus uint32, op operation) (uint32, error) {
+func (q *qemu) hotplugCPUs(vcpus uint32, op Operation) (uint32, error) {
 	if vcpus == 0 {
 		q.Logger().Warnf("cannot hotplug 0 vCPUs")
 		return 0, nil
@@ -1679,7 +1679,7 @@ func (q *qemu) hotplugCPUs(vcpus uint32, op operation) (uint32, error) {
 		return 0, err
 	}
 
-	if op == addDevice {
+	if op == AddDevice {
 		return q.hotplugAddCPUs(vcpus)
 	}
 
@@ -1774,46 +1774,46 @@ func (q *qemu) hotplugRemoveCPUs(amount uint32) (uint32, error) {
 	return amount, nil
 }
 
-func (q *qemu) hotplugMemory(memDev *memoryDevice, op operation) (int, error) {
+func (q *qemu) hotplugMemory(memDev *MemoryDevice, op Operation) (int, error) {
 
 	if !q.arch.supportGuestMemoryHotplug() {
 		return 0, noGuestMemHotplugErr
 	}
-	if memDev.sizeMB < 0 {
-		return 0, fmt.Errorf("cannot hotplug negative size (%d) memory", memDev.sizeMB)
+	if memDev.SizeMB < 0 {
+		return 0, fmt.Errorf("cannot hotplug negative size (%d) memory", memDev.SizeMB)
 	}
 	memLog := q.Logger().WithField("hotplug", "memory")
 
-	memLog.WithField("hotplug-memory-mb", memDev.sizeMB).Debug("requested memory hotplug")
+	memLog.WithField("hotplug-memory-mb", memDev.SizeMB).Debug("requested memory hotplug")
 	if err := q.qmpSetup(); err != nil {
 		return 0, err
 	}
 
 	currentMemory := int(q.config.MemorySize) + q.state.HotpluggedMemory
 
-	if memDev.sizeMB == 0 {
+	if memDev.SizeMB == 0 {
 		memLog.Debug("hotplug is not required")
 		return 0, nil
 	}
 
 	switch op {
-	case removeDevice:
-		memLog.WithField("operation", "remove").Debugf("Requested to remove memory: %d MB", memDev.sizeMB)
+	case RemoveDevice:
+		memLog.WithField("operation", "remove").Debugf("Requested to remove memory: %d MB", memDev.SizeMB)
 		// Dont fail but warn that this is not supported.
 		memLog.Warn("hot-remove VM memory not supported")
 		return 0, nil
-	case addDevice:
-		memLog.WithField("operation", "add").Debugf("Requested to add memory: %d MB", memDev.sizeMB)
+	case AddDevice:
+		memLog.WithField("operation", "add").Debugf("Requested to add memory: %d MB", memDev.SizeMB)
 		maxMem, err := q.hostMemMB()
 		if err != nil {
 			return 0, err
 		}
 
 		// Don't exceed the maximum amount of memory
-		if currentMemory+memDev.sizeMB > int(maxMem) {
+		if currentMemory+memDev.SizeMB > int(maxMem) {
 			// Fixme: return a typed error
 			return 0, fmt.Errorf("Unable to hotplug %d MiB memory, the SB has %d MiB and the maximum amount is %d MiB",
-				memDev.sizeMB, currentMemory, maxMem)
+				memDev.SizeMB, currentMemory, maxMem)
 		}
 		memoryAdded, err := q.hotplugAddMemory(memDev)
 		if err != nil {
@@ -1826,7 +1826,7 @@ func (q *qemu) hotplugMemory(memDev *memoryDevice, op operation) (int, error) {
 
 }
 
-func (q *qemu) hotplugAddMemory(memDev *memoryDevice) (int, error) {
+func (q *qemu) hotplugAddMemory(memDev *MemoryDevice) (int, error) {
 	memoryDevices, err := q.qmpMonitorCh.qmp.ExecQueryMemoryDevices(q.qmpMonitorCh.ctx)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query memory devices: %v", err)
@@ -1839,7 +1839,7 @@ func (q *qemu) hotplugAddMemory(memDev *memoryDevice) (int, error) {
 				maxSlot = device.Data.Slot
 			}
 		}
-		memDev.slot = maxSlot + 1
+		memDev.Slot = maxSlot + 1
 	}
 
 	share, target, memoryBack, err := q.getMemArgs()
@@ -1847,26 +1847,26 @@ func (q *qemu) hotplugAddMemory(memDev *memoryDevice) (int, error) {
 		return 0, err
 	}
 
-	err = q.qmpMonitorCh.qmp.ExecHotplugMemory(q.qmpMonitorCh.ctx, memoryBack, "mem"+strconv.Itoa(memDev.slot), target, memDev.sizeMB, share)
+	err = q.qmpMonitorCh.qmp.ExecHotplugMemory(q.qmpMonitorCh.ctx, memoryBack, "mem"+strconv.Itoa(memDev.Slot), target, memDev.SizeMB, share)
 	if err != nil {
 		q.Logger().WithError(err).Error("hotplug memory")
 		return 0, err
 	}
 	// if guest kernel only supports memory hotplug via probe interface, we need to get address of hot-add memory device
-	if memDev.probe {
+	if memDev.Probe {
 		memoryDevices, err := q.qmpMonitorCh.qmp.ExecQueryMemoryDevices(q.qmpMonitorCh.ctx)
 		if err != nil {
 			return 0, fmt.Errorf("failed to query memory devices: %v", err)
 		}
 		if len(memoryDevices) != 0 {
 			q.Logger().WithField("addr", fmt.Sprintf("0x%x", memoryDevices[len(memoryDevices)-1].Data.Addr)).Debug("recently hot-add memory device")
-			memDev.addr = memoryDevices[len(memoryDevices)-1].Data.Addr
+			memDev.Addr = memoryDevices[len(memoryDevices)-1].Data.Addr
 		} else {
 			return 0, fmt.Errorf("failed to probe address of recently hot-add memory device, no device exists")
 		}
 	}
-	q.state.HotpluggedMemory += memDev.sizeMB
-	return memDev.sizeMB, nil
+	q.state.HotpluggedMemory += memDev.SizeMB
+	return memDev.SizeMB, nil
 }
 
 func (q *qemu) pauseSandbox(ctx context.Context) error {
@@ -1884,7 +1884,7 @@ func (q *qemu) resumeSandbox(ctx context.Context) error {
 }
 
 // addDevice will add extra devices to Qemu command line.
-func (q *qemu) addDevice(ctx context.Context, devInfo interface{}, devType deviceType) error {
+func (q *qemu) addDevice(ctx context.Context, devInfo interface{}, devType DeviceType) error {
 	var err error
 	span, _ := katatrace.Trace(ctx, q.Logger(), "addDevice", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	katatrace.AddTag(span, "device", devInfo)
@@ -2027,23 +2027,23 @@ func (q *qemu) disconnect(ctx context.Context) {
 // the memory to remove has to be at least the size of one slot.
 // To return memory back we are resizing the VM memory balloon.
 // A longer term solution is evaluate solutions like virtio-mem
-func (q *qemu) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, memoryDevice, error) {
+func (q *qemu) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSizeMB uint32, probe bool) (uint32, MemoryDevice, error) {
 
 	currentMemory := q.config.MemorySize + uint32(q.state.HotpluggedMemory)
 	if err := q.qmpSetup(); err != nil {
-		return 0, memoryDevice{}, err
+		return 0, MemoryDevice{}, err
 	}
-	var addMemDevice memoryDevice
+	var addMemDevice MemoryDevice
 	if q.config.VirtioMem && currentMemory != reqMemMB {
 		q.Logger().WithField("hotplug", "memory").Debugf("resize memory from %dMB to %dMB", currentMemory, reqMemMB)
 		sizeByte := uint64(reqMemMB - q.config.MemorySize)
 		sizeByte = sizeByte * 1024 * 1024
 		err := q.qmpMonitorCh.qmp.ExecQomSet(q.qmpMonitorCh.ctx, "virtiomem0", "requested-size", sizeByte)
 		if err != nil {
-			return 0, memoryDevice{}, err
+			return 0, MemoryDevice{}, err
 		}
 		q.state.HotpluggedMemory = int(sizeByte / 1024 / 1024)
-		return reqMemMB, memoryDevice{}, nil
+		return reqMemMB, MemoryDevice{}, nil
 	}
 
 	switch {
@@ -2052,13 +2052,13 @@ func (q *qemu) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSiz
 		addMemMB := reqMemMB - currentMemory
 		memHotplugMB, err := calcHotplugMemMiBSize(addMemMB, memoryBlockSizeMB)
 		if err != nil {
-			return currentMemory, memoryDevice{}, err
+			return currentMemory, MemoryDevice{}, err
 		}
 
-		addMemDevice.sizeMB = int(memHotplugMB)
-		addMemDevice.probe = probe
+		addMemDevice.SizeMB = int(memHotplugMB)
+		addMemDevice.Probe = probe
 
-		data, err := q.hotplugAddDevice(ctx, &addMemDevice, memoryDev)
+		data, err := q.hotplugAddDevice(ctx, &addMemDevice, MemoryDev)
 		if err != nil {
 			return currentMemory, addMemDevice, err
 		}
@@ -2072,13 +2072,13 @@ func (q *qemu) resizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSiz
 		addMemMB := currentMemory - reqMemMB
 		memHotunplugMB, err := calcHotplugMemMiBSize(addMemMB, memoryBlockSizeMB)
 		if err != nil {
-			return currentMemory, memoryDevice{}, err
+			return currentMemory, MemoryDevice{}, err
 		}
 
-		addMemDevice.sizeMB = int(memHotunplugMB)
-		addMemDevice.probe = probe
+		addMemDevice.SizeMB = int(memHotunplugMB)
+		addMemDevice.Probe = probe
 
-		data, err := q.hotplugRemoveDevice(ctx, &addMemDevice, memoryDev)
+		data, err := q.hotplugRemoveDevice(ctx, &addMemDevice, MemoryDev)
 		if err != nil {
 			return currentMemory, addMemDevice, err
 		}
@@ -2228,11 +2228,11 @@ func genericAppendPCIeRootPort(devices []govmmQemu.Device, number uint32, machin
 	return devices
 }
 
-func (q *qemu) getThreadIDs(ctx context.Context) (vcpuThreadIDs, error) {
+func (q *qemu) getThreadIDs(ctx context.Context) (VcpuThreadIDs, error) {
 	span, _ := katatrace.Trace(ctx, q.Logger(), "getThreadIDs", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
-	tid := vcpuThreadIDs{}
+	tid := VcpuThreadIDs{}
 	if err := q.qmpSetup(); err != nil {
 		return tid, err
 	}
@@ -2268,7 +2268,7 @@ func (q *qemu) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs u
 	case currentVCPUs < reqVCPUs:
 		//hotplug
 		addCPUs := reqVCPUs - currentVCPUs
-		data, err := q.hotplugAddDevice(ctx, addCPUs, cpuDev)
+		data, err := q.hotplugAddDevice(ctx, addCPUs, CpuDev)
 		if err != nil {
 			return currentVCPUs, newVCPUs, err
 		}
@@ -2280,7 +2280,7 @@ func (q *qemu) resizeVCPUs(ctx context.Context, reqVCPUs uint32) (currentVCPUs u
 	case currentVCPUs > reqVCPUs:
 		//hotunplug
 		removeCPUs := currentVCPUs - reqVCPUs
-		data, err := q.hotplugRemoveDevice(ctx, removeCPUs, cpuDev)
+		data, err := q.hotplugRemoveDevice(ctx, removeCPUs, CpuDev)
 		if err != nil {
 			return currentVCPUs, newVCPUs, err
 		}

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1959,7 +1959,7 @@ func (q *qemu) GetVMConsole(ctx context.Context, id string) (string, string, err
 	return consoleProtoUnix, consoleURL, nil
 }
 
-func (q *qemu) saveSandbox() error {
+func (q *qemu) SaveVM() error {
 	q.Logger().Info("Save sandbox")
 
 	if err := q.qmpSetup(); err != nil {

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -119,7 +119,7 @@ func TestQemuAmd64AppendImage(t *testing.T) {
 	imageStat, err := f.Stat()
 	assert.NoError(err)
 
-	// save default supportedQemuMachines options
+	// Save default supportedQemuMachines options
 	machinesCopy := make([]govmmQemu.Machine, len(supportedQemuMachines))
 	assert.Equal(len(supportedQemuMachines), copy(machinesCopy, supportedQemuMachines))
 

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -28,7 +28,7 @@ type qemuArch interface {
 	// disableNestingChecks nesting checks will be ignored
 	disableNestingChecks()
 
-	// runNested indicates if the hypervisor runs in a nested environment
+	// runNested indicates if the Hypervisor runs in a nested environment
 	runNested() bool
 
 	// enableVhostNet vhost will be enabled

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -105,7 +105,7 @@ func TestQemuArm64AppendImage(t *testing.T) {
 	imageStat, err := f.Stat()
 	assert.NoError(err)
 
-	// save default supportedQemuMachines options
+	// Save default supportedQemuMachines options
 	machinesCopy := make([]govmmQemu.Machine, len(supportedQemuMachines))
 	assert.Equal(len(supportedQemuMachines), copy(machinesCopy, supportedQemuMachines))
 

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -89,12 +89,12 @@ func TestQemuCreateSandbox(t *testing.T) {
 		},
 	}
 
-	// Create the hypervisor fake binary
+	// Create the Hypervisor fake binary
 	testQemuPath := filepath.Join(testDir, testHypervisor)
 	_, err = os.Create(testQemuPath)
 	assert.NoError(err)
 
-	// Create parent dir path for hypervisor.json
+	// Create parent dir path for Hypervisor.json
 	parentDir := filepath.Join(q.store.RunStoragePath(), sandbox.id)
 	assert.NoError(os.MkdirAll(parentDir, DirMode))
 
@@ -121,12 +121,12 @@ func TestQemuCreateSandboxMissingParentDirFail(t *testing.T) {
 		},
 	}
 
-	// Create the hypervisor fake binary
+	// Create the Hypervisor fake binary
 	testQemuPath := filepath.Join(testDir, testHypervisor)
 	_, err = os.Create(testQemuPath)
 	assert.NoError(err)
 
-	// Ensure parent dir path for hypervisor.json does not exist.
+	// Ensure parent dir path for Hypervisor.json does not exist.
 	parentDir := filepath.Join(q.store.RunStoragePath(), sandbox.id)
 	assert.NoError(os.RemoveAll(parentDir))
 
@@ -373,18 +373,18 @@ func TestQemuQemuPath(t *testing.T) {
 		arch:   qkvm,
 	}
 
-	// get config hypervisor path
+	// get config Hypervisor path
 	path, err := q.qemuPath()
 	assert.NoError(err)
 	assert.Equal(path, expectedPath)
 
-	// config hypervisor path does not exist
+	// config Hypervisor path does not exist
 	q.config.HypervisorPath = "/abc/rgb/123"
 	path, err = q.qemuPath()
 	assert.Error(err)
 	assert.Equal(path, "")
 
-	// get arch hypervisor path
+	// get arch Hypervisor path
 	q.config.HypervisorPath = ""
 	path, err = q.qemuPath()
 	assert.NoError(err)

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -171,7 +171,7 @@ func TestQemuMemoryTopology(t *testing.T) {
 		},
 	}
 
-	hostMemKb, err := getHostMemorySizeKb(procMemInfo)
+	hostMemKb, err := GetHostMemorySizeKb(procMemInfo)
 	assert.NoError(err)
 	memMax := fmt.Sprintf("%dM", int(float64(hostMemKb)/1024))
 
@@ -204,7 +204,7 @@ func TestQemuKnobs(t *testing.T) {
 	assert.Equal(q.qemuConfig.Knobs.NoReboot, true)
 }
 
-func testQemuAddDevice(t *testing.T, devInfo interface{}, devType deviceType, expected []govmmQemu.Device) {
+func testQemuAddDevice(t *testing.T, devInfo interface{}, devType DeviceType, expected []govmmQemu.Device) {
 	assert := assert.New(t)
 	q := &qemu{
 		ctx:  context.Background(),
@@ -237,7 +237,7 @@ func TestQemuAddDeviceFsDev(t *testing.T) {
 		HostPath: hostPath,
 	}
 
-	testQemuAddDevice(t, volume, fsDev, expectedOut)
+	testQemuAddDevice(t, volume, FsDev, expectedOut)
 }
 
 func TestQemuAddDeviceVhostUserBlk(t *testing.T) {
@@ -258,7 +258,7 @@ func TestQemuAddDeviceVhostUserBlk(t *testing.T) {
 		Type:       config.VhostUserBlk,
 	}
 
-	testQemuAddDevice(t, vDevice, vhostuserDev, expectedOut)
+	testQemuAddDevice(t, vDevice, VhostuserDev, expectedOut)
 }
 
 func TestQemuAddDeviceSerialPortDev(t *testing.T) {
@@ -285,7 +285,7 @@ func TestQemuAddDeviceSerialPortDev(t *testing.T) {
 		Name:     name,
 	}
 
-	testQemuAddDevice(t, socket, serialPortDev, expectedOut)
+	testQemuAddDevice(t, socket, SerialPortDev, expectedOut)
 }
 
 func TestQemuAddDeviceKataVSOCK(t *testing.T) {
@@ -318,7 +318,7 @@ func TestQemuAddDeviceKataVSOCK(t *testing.T) {
 		VhostFd:   vsockFile,
 	}
 
-	testQemuAddDevice(t, vsock, vSockPCIDev, expectedOut)
+	testQemuAddDevice(t, vsock, VSockPCIDev, expectedOut)
 }
 
 func TestQemuGetSandboxConsole(t *testing.T) {
@@ -401,9 +401,9 @@ func TestHotplugUnsupportedDeviceType(t *testing.T) {
 		config: qemuConfig,
 	}
 
-	_, err := q.hotplugAddDevice(context.Background(), &memoryDevice{0, 128, uint64(0), false}, fsDev)
+	_, err := q.hotplugAddDevice(context.Background(), &MemoryDevice{0, 128, uint64(0), false}, FsDev)
 	assert.Error(err)
-	_, err = q.hotplugRemoveDevice(context.Background(), &memoryDevice{0, 128, uint64(0), false}, fsDev)
+	_, err = q.hotplugRemoveDevice(context.Background(), &MemoryDevice{0, 128, uint64(0), false}, FsDev)
 	assert.Error(err)
 }
 

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -211,7 +211,7 @@ func testQemuAddDevice(t *testing.T, devInfo interface{}, devType DeviceType, ex
 		arch: &qemuArchBase{},
 	}
 
-	err := q.addDevice(context.Background(), devInfo, devType)
+	err := q.AddDevice(context.Background(), devInfo, devType)
 	assert.NoError(err)
 	assert.Exactly(q.qemuConfig.Devices, expected)
 }
@@ -332,7 +332,7 @@ func TestQemuGetSandboxConsole(t *testing.T) {
 	sandboxID := "testSandboxID"
 	expected := filepath.Join(q.store.RunVMStoragePath(), sandboxID, consoleSocket)
 
-	proto, result, err := q.getSandboxConsole(q.ctx, sandboxID)
+	proto, result, err := q.GetSandboxConsole(q.ctx, sandboxID)
 	assert.NoError(err)
 	assert.Equal(result, expected)
 	assert.Equal(proto, consoleProtoUnix)
@@ -345,7 +345,7 @@ func TestQemuCapabilities(t *testing.T) {
 		arch: &qemuArchBase{},
 	}
 
-	caps := q.capabilities(q.ctx)
+	caps := q.Capabilities(q.ctx)
 	assert.True(caps.IsBlockDeviceHotplugSupported())
 }
 
@@ -401,9 +401,9 @@ func TestHotplugUnsupportedDeviceType(t *testing.T) {
 		config: qemuConfig,
 	}
 
-	_, err := q.hotplugAddDevice(context.Background(), &MemoryDevice{0, 128, uint64(0), false}, FsDev)
+	_, err := q.HotplugAddDevice(context.Background(), &MemoryDevice{0, 128, uint64(0), false}, FsDev)
 	assert.Error(err)
-	_, err = q.hotplugRemoveDevice(context.Background(), &MemoryDevice{0, 128, uint64(0), false}, FsDev)
+	_, err = q.HotplugRemoveDevice(context.Background(), &MemoryDevice{0, 128, uint64(0), false}, FsDev)
 	assert.Error(err)
 }
 
@@ -430,7 +430,7 @@ func TestQemuCleanup(t *testing.T) {
 		config: newQemuConfig(),
 	}
 
-	err := q.cleanup(q.ctx)
+	err := q.Cleanup(q.ctx)
 	assert.Nil(err)
 }
 
@@ -554,7 +554,7 @@ func TestQemuGetpids(t *testing.T) {
 
 	qemuConfig := newQemuConfig()
 	q := &qemu{}
-	pids := q.getPids()
+	pids := q.GetPids()
 	assert.NotNil(pids)
 	assert.True(len(pids) == 1)
 	assert.True(pids[0] == 0)
@@ -569,18 +569,18 @@ func TestQemuGetpids(t *testing.T) {
 	defer os.Remove(tmpfile)
 
 	q.qemuConfig.PidFile = tmpfile
-	pids = q.getPids()
+	pids = q.GetPids()
 	assert.True(len(pids) == 1)
 	assert.True(pids[0] == 0)
 
 	err = ioutil.WriteFile(tmpfile, []byte("100"), 0)
 	assert.Nil(err)
-	pids = q.getPids()
+	pids = q.GetPids()
 	assert.True(len(pids) == 1)
 	assert.True(pids[0] == 100)
 
 	q.state.VirtiofsdPid = 200
-	pids = q.getPids()
+	pids = q.GetPids()
 	assert.True(len(pids) == 2)
 	assert.True(pids[0] == 100)
 	assert.True(pids[1] == 200)

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -332,7 +332,7 @@ func TestQemuGetSandboxConsole(t *testing.T) {
 	sandboxID := "testSandboxID"
 	expected := filepath.Join(q.store.RunVMStoragePath(), sandboxID, consoleSocket)
 
-	proto, result, err := q.GetSandboxConsole(q.ctx, sandboxID)
+	proto, result, err := q.GetVMConsole(q.ctx, sandboxID)
 	assert.NoError(err)
 	assert.Equal(result, expected)
 	assert.Equal(proto, consoleProtoUnix)

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1181,7 +1181,7 @@ func (s *Sandbox) startVM(ctx context.Context) (err error) {
 
 	defer func() {
 		if err != nil {
-			s.hypervisor.stopSandbox(ctx, false)
+			s.hypervisor.StopVM(ctx, false)
 		}
 	}()
 
@@ -1264,7 +1264,7 @@ func (s *Sandbox) stopVM(ctx context.Context) error {
 
 	s.Logger().Info("Stopping VM")
 
-	return s.hypervisor.stopSandbox(ctx, s.disableVMShutdown)
+	return s.hypervisor.StopVM(ctx, s.disableVMShutdown)
 }
 
 func (s *Sandbox) addContainer(c *Container) error {

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1199,7 +1199,7 @@ func (s *Sandbox) startVM(ctx context.Context) (err error) {
 			return vm.assignSandbox(s)
 		}
 
-		return s.hypervisor.startSandbox(ctx, vmStartTimeout)
+		return s.hypervisor.StartVM(ctx, vmStartTimeout)
 	}); err != nil {
 		return err
 	}

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -979,7 +979,7 @@ func newConsoleWatcher(ctx context.Context, s *Sandbox) (*consoleWatcher, error)
 		cw  consoleWatcher
 	)
 
-	cw.proto, cw.consoleURL, err = s.hypervisor.GetSandboxConsole(ctx, s.id)
+	cw.proto, cw.consoleURL, err = s.hypervisor.GetVMConsole(ctx, s.id)
 	if err != nil {
 		return nil, err
 	}

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -152,7 +152,7 @@ func (sandboxConfig *SandboxConfig) valid() bool {
 		return false
 	}
 
-	if _, err := newHypervisor(sandboxConfig.HypervisorType); err != nil {
+	if _, err := NewHypervisor(sandboxConfig.HypervisorType); err != nil {
 		sandboxConfig.HypervisorType = QemuHypervisor
 	}
 
@@ -409,7 +409,7 @@ func createAssets(ctx context.Context, sandboxConfig *SandboxConfig) error {
 			return err
 		}
 
-		if err := sandboxConfig.HypervisorConfig.addCustomAsset(a); err != nil {
+		if err := sandboxConfig.HypervisorConfig.AddCustomAsset(a); err != nil {
 			return err
 		}
 	}
@@ -498,7 +498,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 	// create agent instance
 	agent := getNewAgentFunc(ctx)()
 
-	hypervisor, err := newHypervisor(sandboxConfig.HypervisorType)
+	hypervisor, err := NewHypervisor(sandboxConfig.HypervisorType)
 	if err != nil {
 		return nil, err
 	}
@@ -1101,7 +1101,7 @@ func (s *Sandbox) addSwap(ctx context.Context, swapID string, size int64) (*conf
 		ID:     swapID,
 		Swap:   true,
 	}
-	_, err = s.hypervisor.hotplugAddDevice(ctx, blockDevice, blockDev)
+	_, err = s.hypervisor.hotplugAddDevice(ctx, blockDevice, BlockDev)
 	if err != nil {
 		err = fmt.Errorf("add swapfile %s device to VM fail %s", swapFile, err.Error())
 		s.Logger().WithError(err).Error("addSwap")
@@ -1109,7 +1109,7 @@ func (s *Sandbox) addSwap(ctx context.Context, swapID string, size int64) (*conf
 	}
 	defer func() {
 		if err != nil {
-			_, e := s.hypervisor.hotplugRemoveDevice(ctx, blockDevice, blockDev)
+			_, e := s.hypervisor.hotplugRemoveDevice(ctx, blockDevice, BlockDev)
 			if e != nil {
 				s.Logger().Errorf("remove swapfile %s to VM fail %s", swapFile, e.Error())
 			}
@@ -1780,7 +1780,7 @@ func (s *Sandbox) HotplugAddDevice(ctx context.Context, device api.Device, devTy
 
 		// adding a group of VFIO devices
 		for _, dev := range vfioDevices {
-			if _, err := s.hypervisor.hotplugAddDevice(ctx, dev, vfioDev); err != nil {
+			if _, err := s.hypervisor.hotplugAddDevice(ctx, dev, VfioDev); err != nil {
 				s.Logger().
 					WithFields(logrus.Fields{
 						"sandbox":         s.id,
@@ -1796,14 +1796,14 @@ func (s *Sandbox) HotplugAddDevice(ctx context.Context, device api.Device, devTy
 		if !ok {
 			return fmt.Errorf("device type mismatch, expect device type to be %s", devType)
 		}
-		_, err := s.hypervisor.hotplugAddDevice(ctx, blockDevice.BlockDrive, blockDev)
+		_, err := s.hypervisor.hotplugAddDevice(ctx, blockDevice.BlockDrive, BlockDev)
 		return err
 	case config.VhostUserBlk:
 		vhostUserBlkDevice, ok := device.(*drivers.VhostUserBlkDevice)
 		if !ok {
 			return fmt.Errorf("device type mismatch, expect device type to be %s", devType)
 		}
-		_, err := s.hypervisor.hotplugAddDevice(ctx, vhostUserBlkDevice.VhostUserDeviceAttrs, vhostuserDev)
+		_, err := s.hypervisor.hotplugAddDevice(ctx, vhostUserBlkDevice.VhostUserDeviceAttrs, VhostuserDev)
 		return err
 	case config.DeviceGeneric:
 		// TODO: what?
@@ -1831,7 +1831,7 @@ func (s *Sandbox) HotplugRemoveDevice(ctx context.Context, device api.Device, de
 
 		// remove a group of VFIO devices
 		for _, dev := range vfioDevices {
-			if _, err := s.hypervisor.hotplugRemoveDevice(ctx, dev, vfioDev); err != nil {
+			if _, err := s.hypervisor.hotplugRemoveDevice(ctx, dev, VfioDev); err != nil {
 				s.Logger().WithError(err).
 					WithFields(logrus.Fields{
 						"sandbox":         s.id,
@@ -1852,14 +1852,14 @@ func (s *Sandbox) HotplugRemoveDevice(ctx context.Context, device api.Device, de
 			s.Logger().WithField("path", blockDrive.File).Infof("Skip device: cannot hot remove PMEM devices")
 			return nil
 		}
-		_, err := s.hypervisor.hotplugRemoveDevice(ctx, blockDrive, blockDev)
+		_, err := s.hypervisor.hotplugRemoveDevice(ctx, blockDrive, BlockDev)
 		return err
 	case config.VhostUserBlk:
 		vhostUserDeviceAttrs, ok := device.GetDeviceInfo().(*config.VhostUserDeviceAttrs)
 		if !ok {
 			return fmt.Errorf("device type mismatch, expect device type to be %s", devType)
 		}
-		_, err := s.hypervisor.hotplugRemoveDevice(ctx, vhostUserDeviceAttrs, vhostuserDev)
+		_, err := s.hypervisor.hotplugRemoveDevice(ctx, vhostUserDeviceAttrs, VhostuserDev)
 		return err
 	case config.DeviceGeneric:
 		// TODO: what?
@@ -1886,11 +1886,11 @@ func (s *Sandbox) UnsetSandboxBlockIndex(index int) error {
 func (s *Sandbox) AppendDevice(ctx context.Context, device api.Device) error {
 	switch device.DeviceType() {
 	case config.VhostUserSCSI, config.VhostUserNet, config.VhostUserBlk, config.VhostUserFS:
-		return s.hypervisor.addDevice(ctx, device.GetDeviceInfo().(*config.VhostUserDeviceAttrs), vhostuserDev)
+		return s.hypervisor.addDevice(ctx, device.GetDeviceInfo().(*config.VhostUserDeviceAttrs), VhostuserDev)
 	case config.DeviceVFIO:
 		vfioDevs := device.GetDeviceInfo().([]*config.VFIODev)
 		for _, d := range vfioDevs {
-			return s.hypervisor.addDevice(ctx, *d, vfioDev)
+			return s.hypervisor.addDevice(ctx, *d, VfioDev)
 		}
 	default:
 		s.Logger().WithField("device-type", device.DeviceType()).
@@ -1997,10 +1997,10 @@ func (s *Sandbox) updateResources(ctx context.Context) error {
 		}
 	}
 	s.Logger().Debugf("Sandbox memory size: %d MB", newMemory)
-	if s.state.GuestMemoryHotplugProbe && updatedMemoryDevice.addr != 0 {
+	if s.state.GuestMemoryHotplugProbe && updatedMemoryDevice.Addr != 0 {
 		// notify the guest kernel about memory hot-add event, before onlining them
-		s.Logger().Debugf("notify guest kernel memory hot-add event via probe interface, memory device located at 0x%x", updatedMemoryDevice.addr)
-		if err := s.agent.memHotplugByProbe(ctx, updatedMemoryDevice.addr, uint32(updatedMemoryDevice.sizeMB), s.state.GuestMemoryBlockSizeMB); err != nil {
+		s.Logger().Debugf("notify guest kernel memory hot-add event via probe interface, memory device located at 0x%x", updatedMemoryDevice.Addr)
+		if err := s.agent.memHotplugByProbe(ctx, updatedMemoryDevice.Addr, uint32(updatedMemoryDevice.SizeMB), s.state.GuestMemoryBlockSizeMB); err != nil {
 			return err
 		}
 	}

--- a/src/runtime/virtcontainers/sandbox_metrics.go
+++ b/src/runtime/virtcontainers/sandbox_metrics.go
@@ -132,7 +132,7 @@ func RegisterMetrics() {
 
 // UpdateRuntimeMetrics update shim/hypervisor's metrics
 func (s *Sandbox) UpdateRuntimeMetrics() error {
-	pids := s.hypervisor.getPids()
+	pids := s.hypervisor.GetPids()
 	if len(pids) == 0 {
 		return nil
 	}
@@ -183,7 +183,7 @@ func (s *Sandbox) UpdateRuntimeMetrics() error {
 }
 
 func (s *Sandbox) UpdateVirtiofsdMetrics() error {
-	vfsPid := s.hypervisor.getVirtioFsPid()
+	vfsPid := s.hypervisor.GetVirtioFsPid()
 	if vfsPid == nil {
 		// virtiofsd is not mandatory for a VMM.
 		return nil

--- a/src/runtime/virtcontainers/sandbox_metrics.go
+++ b/src/runtime/virtcontainers/sandbox_metrics.go
@@ -19,7 +19,7 @@ const namespaceKatashim = "kata_shim"
 const namespaceVirtiofsd = "kata_virtiofsd"
 
 var (
-	// hypervisor
+	// Hypervisor
 	hypervisorThreads = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespaceHypervisor,
 		Name:      "threads",
@@ -61,7 +61,7 @@ var (
 	hypervisorOpenFDs = prometheus.NewGauge(prometheus.GaugeOpts{
 		Namespace: namespaceHypervisor,
 		Name:      "fds",
-		Help:      "Open FDs for hypervisor.",
+		Help:      "Open FDs for Hypervisor.",
 	})
 
 	// agent
@@ -113,7 +113,7 @@ var (
 )
 
 func RegisterMetrics() {
-	// hypervisor
+	// Hypervisor
 	prometheus.MustRegister(hypervisorThreads)
 	prometheus.MustRegister(hypervisorProcStatus)
 	prometheus.MustRegister(hypervisorProcStat)
@@ -130,7 +130,7 @@ func RegisterMetrics() {
 	prometheus.MustRegister(virtiofsdOpenFDs)
 }
 
-// UpdateRuntimeMetrics update shim/hypervisor's metrics
+// UpdateRuntimeMetrics update shim/Hypervisor's metrics
 func (s *Sandbox) UpdateRuntimeMetrics() error {
 	pids := s.hypervisor.GetPids()
 	if len(pids) == 0 {

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -203,7 +203,7 @@ func testForceSandboxStateChangeAndCheck(t *testing.T, p *Sandbox, newSandboxSta
 	// force sandbox state change
 	err := p.setSandboxState(newSandboxState.State)
 	assert.NoError(t, err)
-	// check the in-memory state is correct
+	// Check the in-memory state is correct
 	if p.state.State != newSandboxState.State {
 		return fmt.Errorf("Expected state %v, got %v", newSandboxState.State, p.state.State)
 	}
@@ -216,7 +216,7 @@ func testForceContainerStateChangeAndCheck(t *testing.T, p *Sandbox, c *Containe
 	err := c.setContainerState(newContainerState.State)
 	assert.NoError(t, err)
 
-	// check the in-memory state is correct
+	// Check the in-memory state is correct
 	if c.state.State != newContainerState.State {
 		return fmt.Errorf("Expected state %v, got %v", newContainerState.State, c.state.State)
 	}
@@ -225,7 +225,7 @@ func testForceContainerStateChangeAndCheck(t *testing.T, p *Sandbox, c *Containe
 }
 
 func testCheckSandboxOnDiskState(p *Sandbox, sandboxState types.SandboxState) error {
-	// check on-disk state is correct
+	// Check on-disk state is correct
 	if p.state.State != sandboxState.State {
 		return fmt.Errorf("Expected state %v, got %v", sandboxState.State, p.state.State)
 	}
@@ -234,7 +234,7 @@ func testCheckSandboxOnDiskState(p *Sandbox, sandboxState types.SandboxState) er
 }
 
 func testCheckContainerOnDiskState(c *Container, containerState types.ContainerState) error {
-	// check on-disk state is correct
+	// Check on-disk state is correct
 	if c.state.State != containerState.State {
 		return fmt.Errorf("Expected state %v, got %v", containerState.State, c.state.State)
 	}
@@ -251,7 +251,7 @@ func writeContainerConfig() (string, error) {
 {
 	"ociVersion": "1.0.0-rc2-dev",
 	"process": {
-		"capabilities": [
+		"Capabilities": [
 		]
 	}
 }`
@@ -311,7 +311,7 @@ func TestSandboxSetSandboxAndContainerState(t *testing.T) {
 	c, err := p.findContainer(contID)
 	assert.NoError(err)
 
-	// check initial sandbox and container states
+	// Check initial sandbox and container states
 	if err := testCheckInitSandboxAndContainerStates(p, initialSandboxState, c, initialContainerState); err != nil {
 		t.Error(err)
 	}
@@ -1377,7 +1377,7 @@ func TestSandboxCreationFromConfigRollbackFromCreateSandbox(t *testing.T) {
 	// Fail at createSandbox: QEMU path does not exist, it is expected. Then rollback is called
 	assert.Error(err)
 
-	// check dirs
+	// Check dirs
 	err = checkSandboxRemains()
 	assert.NoError(err)
 }

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -1370,7 +1370,7 @@ func TestSandboxCreationFromConfigRollbackFromCreateSandbox(t *testing.T) {
 		Containers:       nil,
 	}
 
-	// Ensure hypervisor doesn't exist
+	// Ensure Hypervisor doesn't exist
 	assert.NoError(os.Remove(hConf.HypervisorPath))
 
 	_, err := createSandboxFromConfig(ctx, sConf, nil)

--- a/src/runtime/virtcontainers/tap_endpoint.go
+++ b/src/runtime/virtcontainers/tap_endpoint.go
@@ -69,7 +69,7 @@ func (endpoint *TapEndpoint) SetProperties(properties NetworkInfo) {
 	endpoint.EndpointProperties = properties
 }
 
-// Attach for tap endpoint adds the tap interface to the hypervisor.
+// Attach for tap endpoint adds the tap interface to the Hypervisor.
 func (endpoint *TapEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 	return fmt.Errorf("TapEndpoint does not support Attach, if you're using docker please use --net none")
 }
@@ -90,7 +90,7 @@ func (endpoint *TapEndpoint) Detach(ctx context.Context, netNsCreated bool, netN
 }
 
 // HotAttach for the tap endpoint uses hot plug device
-func (endpoint *TapEndpoint) HotAttach(ctx context.Context, h hypervisor) error {
+func (endpoint *TapEndpoint) HotAttach(ctx context.Context, h Hypervisor) error {
 	networkLogger().Info("Hot attaching tap endpoint")
 
 	span, ctx := tapTrace(ctx, "HotAttach", endpoint)
@@ -109,7 +109,7 @@ func (endpoint *TapEndpoint) HotAttach(ctx context.Context, h hypervisor) error 
 }
 
 // HotDetach for the tap endpoint uses hot pull device
-func (endpoint *TapEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsCreated bool, netNsPath string) error {
+func (endpoint *TapEndpoint) HotDetach(ctx context.Context, h Hypervisor, netNsCreated bool, netNsPath string) error {
 	networkLogger().Info("Hot detaching tap endpoint")
 
 	span, ctx := tapTrace(ctx, "HotDetach", endpoint)

--- a/src/runtime/virtcontainers/tap_endpoint.go
+++ b/src/runtime/virtcontainers/tap_endpoint.go
@@ -96,12 +96,12 @@ func (endpoint *TapEndpoint) HotAttach(ctx context.Context, h hypervisor) error 
 	span, ctx := tapTrace(ctx, "HotAttach", endpoint)
 	defer span.End()
 
-	if err := tapNetwork(endpoint, h.hypervisorConfig().NumVCPUs, h.hypervisorConfig().DisableVhostNet); err != nil {
+	if err := tapNetwork(endpoint, h.HypervisorConfig().NumVCPUs, h.HypervisorConfig().DisableVhostNet); err != nil {
 		networkLogger().WithError(err).Error("Error bridging tap ep")
 		return err
 	}
 
-	if _, err := h.hotplugAddDevice(ctx, endpoint, NetDev); err != nil {
+	if _, err := h.HotplugAddDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error attach tap ep")
 		return err
 	}
@@ -121,7 +121,7 @@ func (endpoint *TapEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsC
 		networkLogger().WithError(err).Warn("Error un-bridging tap ep")
 	}
 
-	if _, err := h.hotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
+	if _, err := h.HotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error detach tap ep")
 		return err
 	}

--- a/src/runtime/virtcontainers/tap_endpoint.go
+++ b/src/runtime/virtcontainers/tap_endpoint.go
@@ -101,7 +101,7 @@ func (endpoint *TapEndpoint) HotAttach(ctx context.Context, h hypervisor) error 
 		return err
 	}
 
-	if _, err := h.hotplugAddDevice(ctx, endpoint, netDev); err != nil {
+	if _, err := h.hotplugAddDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error attach tap ep")
 		return err
 	}
@@ -121,7 +121,7 @@ func (endpoint *TapEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsC
 		networkLogger().WithError(err).Warn("Error un-bridging tap ep")
 	}
 
-	if _, err := h.hotplugRemoveDevice(ctx, endpoint, netDev); err != nil {
+	if _, err := h.hotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error detach tap ep")
 		return err
 	}

--- a/src/runtime/virtcontainers/tuntap_endpoint.go
+++ b/src/runtime/virtcontainers/tuntap_endpoint.go
@@ -82,7 +82,7 @@ func (endpoint *TuntapEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 		return err
 	}
 
-	return h.addDevice(ctx, endpoint, NetDev)
+	return h.AddDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for the tun/tap endpoint tears down the tap
@@ -107,12 +107,12 @@ func (endpoint *TuntapEndpoint) HotAttach(ctx context.Context, h hypervisor) err
 	span, ctx := tuntapTrace(ctx, "HotAttach", endpoint)
 	defer span.End()
 
-	if err := tuntapNetwork(endpoint, h.hypervisorConfig().NumVCPUs, h.hypervisorConfig().DisableVhostNet); err != nil {
+	if err := tuntapNetwork(endpoint, h.HypervisorConfig().NumVCPUs, h.HypervisorConfig().DisableVhostNet); err != nil {
 		networkLogger().WithError(err).Error("Error bridging tun/tap ep")
 		return err
 	}
 
-	if _, err := h.hotplugAddDevice(ctx, endpoint, NetDev); err != nil {
+	if _, err := h.HotplugAddDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error attach tun/tap ep")
 		return err
 	}
@@ -132,7 +132,7 @@ func (endpoint *TuntapEndpoint) HotDetach(ctx context.Context, h hypervisor, net
 		networkLogger().WithError(err).Warn("Error un-bridging tun/tap ep")
 	}
 
-	if _, err := h.hotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
+	if _, err := h.HotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error detach tun/tap ep")
 		return err
 	}

--- a/src/runtime/virtcontainers/tuntap_endpoint.go
+++ b/src/runtime/virtcontainers/tuntap_endpoint.go
@@ -82,7 +82,7 @@ func (endpoint *TuntapEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 		return err
 	}
 
-	return h.addDevice(ctx, endpoint, netDev)
+	return h.addDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for the tun/tap endpoint tears down the tap
@@ -112,7 +112,7 @@ func (endpoint *TuntapEndpoint) HotAttach(ctx context.Context, h hypervisor) err
 		return err
 	}
 
-	if _, err := h.hotplugAddDevice(ctx, endpoint, netDev); err != nil {
+	if _, err := h.hotplugAddDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error attach tun/tap ep")
 		return err
 	}
@@ -132,7 +132,7 @@ func (endpoint *TuntapEndpoint) HotDetach(ctx context.Context, h hypervisor, net
 		networkLogger().WithError(err).Warn("Error un-bridging tun/tap ep")
 	}
 
-	if _, err := h.hotplugRemoveDevice(ctx, endpoint, netDev); err != nil {
+	if _, err := h.hotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error detach tun/tap ep")
 		return err
 	}

--- a/src/runtime/virtcontainers/tuntap_endpoint.go
+++ b/src/runtime/virtcontainers/tuntap_endpoint.go
@@ -71,7 +71,7 @@ func (endpoint *TuntapEndpoint) SetProperties(properties NetworkInfo) {
 	endpoint.EndpointProperties = properties
 }
 
-// Attach for tun/tap endpoint adds the tap interface to the hypervisor.
+// Attach for tun/tap endpoint adds the tap interface to the Hypervisor.
 func (endpoint *TuntapEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 	span, ctx := tuntapTrace(ctx, "Attach", endpoint)
 	defer span.End()
@@ -101,7 +101,7 @@ func (endpoint *TuntapEndpoint) Detach(ctx context.Context, netNsCreated bool, n
 }
 
 // HotAttach for the tun/tap endpoint uses hot plug device
-func (endpoint *TuntapEndpoint) HotAttach(ctx context.Context, h hypervisor) error {
+func (endpoint *TuntapEndpoint) HotAttach(ctx context.Context, h Hypervisor) error {
 	networkLogger().Info("Hot attaching tun/tap endpoint")
 
 	span, ctx := tuntapTrace(ctx, "HotAttach", endpoint)
@@ -120,7 +120,7 @@ func (endpoint *TuntapEndpoint) HotAttach(ctx context.Context, h hypervisor) err
 }
 
 // HotDetach for the tun/tap endpoint uses hot pull device
-func (endpoint *TuntapEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsCreated bool, netNsPath string) error {
+func (endpoint *TuntapEndpoint) HotDetach(ctx context.Context, h Hypervisor, netNsCreated bool, netNsPath string) error {
 	networkLogger().Info("Hot detaching tun/tap endpoint")
 
 	span, ctx := tuntapTrace(ctx, "HotDetach", endpoint)

--- a/src/runtime/virtcontainers/veth_endpoint.go
+++ b/src/runtime/virtcontainers/veth_endpoint.go
@@ -103,7 +103,7 @@ func (endpoint *VethEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 		return err
 	}
 
-	return h.addDevice(ctx, endpoint, netDev)
+	return h.addDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for the veth endpoint tears down the tap and bridge
@@ -133,7 +133,7 @@ func (endpoint *VethEndpoint) HotAttach(ctx context.Context, h hypervisor) error
 		return err
 	}
 
-	if _, err := h.hotplugAddDevice(ctx, endpoint, netDev); err != nil {
+	if _, err := h.hotplugAddDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error attach virtual ep")
 		return err
 	}
@@ -155,7 +155,7 @@ func (endpoint *VethEndpoint) HotDetach(ctx context.Context, h hypervisor, netNs
 		networkLogger().WithError(err).Warn("Error un-bridging virtual ep")
 	}
 
-	if _, err := h.hotplugRemoveDevice(ctx, endpoint, netDev); err != nil {
+	if _, err := h.hotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error detach virtual ep")
 		return err
 	}

--- a/src/runtime/virtcontainers/veth_endpoint.go
+++ b/src/runtime/virtcontainers/veth_endpoint.go
@@ -39,7 +39,7 @@ func createVethNetworkEndpoint(idx int, ifName string, interworkingModel NetInte
 	endpoint := &VethEndpoint{
 		// TODO This is too specific. We may need to create multiple
 		// end point types here and then decide how to connect them
-		// at the time of hypervisor attach and not here
+		// at the time of Hypervisor attach and not here
 		NetPair:      netPair,
 		EndpointType: VethEndpointType,
 	}
@@ -92,7 +92,7 @@ func (endpoint *VethEndpoint) SetProperties(properties NetworkInfo) {
 }
 
 // Attach for veth endpoint bridges the network pair and adds the
-// tap interface of the network pair to the hypervisor.
+// tap interface of the network pair to the Hypervisor.
 func (endpoint *VethEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 	span, ctx := vethTrace(ctx, "Attach", endpoint)
 	defer span.End()
@@ -124,7 +124,7 @@ func (endpoint *VethEndpoint) Detach(ctx context.Context, netNsCreated bool, net
 }
 
 // HotAttach for the veth endpoint uses hot plug device
-func (endpoint *VethEndpoint) HotAttach(ctx context.Context, h hypervisor) error {
+func (endpoint *VethEndpoint) HotAttach(ctx context.Context, h Hypervisor) error {
 	span, ctx := vethTrace(ctx, "HotAttach", endpoint)
 	defer span.End()
 
@@ -141,7 +141,7 @@ func (endpoint *VethEndpoint) HotAttach(ctx context.Context, h hypervisor) error
 }
 
 // HotDetach for the veth endpoint uses hot pull device
-func (endpoint *VethEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsCreated bool, netNsPath string) error {
+func (endpoint *VethEndpoint) HotDetach(ctx context.Context, h Hypervisor, netNsCreated bool, netNsPath string) error {
 	if !netNsCreated {
 		return nil
 	}

--- a/src/runtime/virtcontainers/veth_endpoint.go
+++ b/src/runtime/virtcontainers/veth_endpoint.go
@@ -103,7 +103,7 @@ func (endpoint *VethEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 		return err
 	}
 
-	return h.addDevice(ctx, endpoint, NetDev)
+	return h.AddDevice(ctx, endpoint, NetDev)
 }
 
 // Detach for the veth endpoint tears down the tap and bridge
@@ -133,7 +133,7 @@ func (endpoint *VethEndpoint) HotAttach(ctx context.Context, h hypervisor) error
 		return err
 	}
 
-	if _, err := h.hotplugAddDevice(ctx, endpoint, NetDev); err != nil {
+	if _, err := h.HotplugAddDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error attach virtual ep")
 		return err
 	}
@@ -155,7 +155,7 @@ func (endpoint *VethEndpoint) HotDetach(ctx context.Context, h hypervisor, netNs
 		networkLogger().WithError(err).Warn("Error un-bridging virtual ep")
 	}
 
-	if _, err := h.hotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
+	if _, err := h.HotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
 		networkLogger().WithError(err).Error("Error detach virtual ep")
 		return err
 	}

--- a/src/runtime/virtcontainers/vhostuser_endpoint.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint.go
@@ -82,7 +82,7 @@ func (endpoint *VhostUserEndpoint) Attach(ctx context.Context, s *Sandbox) error
 	span, ctx := vhostuserTrace(ctx, "Attach", endpoint)
 	defer span.End()
 
-	// Generate a unique ID to be used for hypervisor commandline fields
+	// Generate a unique ID to be used for Hypervisor commandline fields
 	randBytes, err := utils.GenerateRandomBytes(8)
 	if err != nil {
 		return err
@@ -105,12 +105,12 @@ func (endpoint *VhostUserEndpoint) Detach(ctx context.Context, netNsCreated bool
 }
 
 // HotAttach for vhostuser endpoint not supported yet
-func (endpoint *VhostUserEndpoint) HotAttach(ctx context.Context, h hypervisor) error {
+func (endpoint *VhostUserEndpoint) HotAttach(ctx context.Context, h Hypervisor) error {
 	return fmt.Errorf("VhostUserEndpoint does not support Hot attach")
 }
 
 // HotDetach for vhostuser endpoint not supported yet
-func (endpoint *VhostUserEndpoint) HotDetach(ctx context.Context, h hypervisor, netNsCreated bool, netNsPath string) error {
+func (endpoint *VhostUserEndpoint) HotDetach(ctx context.Context, h Hypervisor, netNsCreated bool, netNsPath string) error {
 	return fmt.Errorf("VhostUserEndpoint does not support Hot detach")
 }
 

--- a/src/runtime/virtcontainers/vhostuser_endpoint.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint.go
@@ -96,7 +96,7 @@ func (endpoint *VhostUserEndpoint) Attach(ctx context.Context, s *Sandbox) error
 		Type:       config.VhostUserNet,
 	}
 
-	return s.hypervisor.addDevice(ctx, d, VhostuserDev)
+	return s.hypervisor.AddDevice(ctx, d, VhostuserDev)
 }
 
 // Detach for vhostuser endpoint
@@ -133,7 +133,7 @@ func findVhostUserNetSocketPath(netInfo NetworkInfo) (string, error) {
 		return "", nil
 	}
 
-	// check for socket file existence at known location.
+	// Check for socket file existence at known location.
 	for _, addr := range netInfo.Addrs {
 		socketPath := fmt.Sprintf(hostSocketSearchPath, addr.IPNet.IP)
 		if _, err := os.Stat(socketPath); err == nil {

--- a/src/runtime/virtcontainers/vhostuser_endpoint.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint.go
@@ -96,7 +96,7 @@ func (endpoint *VhostUserEndpoint) Attach(ctx context.Context, s *Sandbox) error
 		Type:       config.VhostUserNet,
 	}
 
-	return s.hypervisor.addDevice(ctx, d, vhostuserDev)
+	return s.hypervisor.addDevice(ctx, d, VhostuserDev)
 }
 
 // Detach for vhostuser endpoint

--- a/src/runtime/virtcontainers/virtcontainers_test.go
+++ b/src/runtime/virtcontainers/virtcontainers_test.go
@@ -27,7 +27,7 @@ const testContainerID = "containerID"
 const testKernel = "kernel"
 const testInitrd = "initrd"
 const testImage = "image"
-const testHypervisor = "hypervisor"
+const testHypervisor = "Hypervisor"
 const testJailer = "jailer"
 const testFirmware = "firmware"
 const testVirtiofsd = "virtiofsd"
@@ -134,7 +134,7 @@ func TestMain(m *testing.M) {
 	}
 
 	utils.StartCmd = func(c *exec.Cmd) error {
-		//StartVM will Check if the hypervisor is alive and
+		//StartVM will Check if the Hypervisor is alive and
 		// checks for the PID is running, lets fake it using our
 		// own PID
 		c.Process = &os.Process{Pid: os.Getpid()}

--- a/src/runtime/virtcontainers/virtcontainers_test.go
+++ b/src/runtime/virtcontainers/virtcontainers_test.go
@@ -134,7 +134,7 @@ func TestMain(m *testing.M) {
 	}
 
 	utils.StartCmd = func(c *exec.Cmd) error {
-		//startSandbox will Check if the hypervisor is alive and
+		//StartVM will Check if the hypervisor is alive and
 		// checks for the PID is running, lets fake it using our
 		// own PID
 		c.Process = &os.Process{Pid: os.Getpid()}

--- a/src/runtime/virtcontainers/virtcontainers_test.go
+++ b/src/runtime/virtcontainers/virtcontainers_test.go
@@ -134,7 +134,7 @@ func TestMain(m *testing.M) {
 	}
 
 	utils.StartCmd = func(c *exec.Cmd) error {
-		//startSandbox will check if the hypervisor is alive and
+		//startSandbox will Check if the hypervisor is alive and
 		// checks for the PID is running, lets fake it using our
 		// own PID
 		c.Process = &os.Process{Pid: os.Getpid()}

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -227,7 +227,7 @@ func (v *VM) Save() error {
 // Resume resumes a paused VM.
 func (v *VM) Resume(ctx context.Context) error {
 	v.logger().Info("resume vm")
-	return v.hypervisor.resumeSandbox(ctx)
+	return v.hypervisor.ResumeVM(ctx)
 }
 
 // Start kicks off a configured VM.

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -130,7 +130,7 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 	}
 
 	// 3. boot up guest vm
-	if err = hypervisor.startSandbox(ctx, vmStartTimeout); err != nil {
+	if err = hypervisor.StartVM(ctx, vmStartTimeout); err != nil {
 		return nil, err
 	}
 
@@ -233,7 +233,7 @@ func (v *VM) Resume(ctx context.Context) error {
 // Start kicks off a configured VM.
 func (v *VM) Start(ctx context.Context) error {
 	v.logger().Info("start vm")
-	return v.hypervisor.startSandbox(ctx, vmStartTimeout)
+	return v.hypervisor.StartVM(ctx, vmStartTimeout)
 }
 
 // Disconnect agent connections to a VM

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -137,7 +137,7 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 	defer func() {
 		if err != nil {
 			virtLog.WithField("vm", id).WithError(err).Info("clean up vm")
-			hypervisor.stopSandbox(ctx, false)
+			hypervisor.StopVM(ctx, false)
 		}
 	}()
 
@@ -251,7 +251,7 @@ func (v *VM) Disconnect(ctx context.Context) error {
 func (v *VM) Stop(ctx context.Context) error {
 	v.logger().Info("stop vm")
 
-	if err := v.hypervisor.stopSandbox(ctx, false); err != nil {
+	if err := v.hypervisor.StopVM(ctx, false); err != nil {
 		return err
 	}
 

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -42,7 +42,7 @@ type VMConfig struct {
 	HypervisorConfig HypervisorConfig
 }
 
-// Valid check VMConfig validity.
+// Valid Check VMConfig validity.
 func (c *VMConfig) Valid() error {
 	return c.HypervisorConfig.Valid()
 }
@@ -141,10 +141,10 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 		}
 	}()
 
-	// 4. check agent aliveness
-	// VMs booted from template are paused, do not check
+	// 4. Check agent aliveness
+	// VMs booted from template are paused, do not Check
 	if !config.HypervisorConfig.BootFromTemplate {
-		virtLog.WithField("vm", id).Info("check agent status")
+		virtLog.WithField("vm", id).Info("Check agent status")
 		err = agent.check(ctx)
 		if err != nil {
 			return nil, err
@@ -220,7 +220,7 @@ func (v *VM) Pause(ctx context.Context) error {
 
 // Save saves a VM to persistent disk.
 func (v *VM) Save() error {
-	v.logger().Info("save vm")
+	v.logger().Info("Save vm")
 	return v.hypervisor.saveSandbox()
 }
 
@@ -241,7 +241,7 @@ func (v *VM) Disconnect(ctx context.Context) error {
 	v.logger().Info("kill vm")
 
 	if err := v.agent.disconnect(ctx); err != nil {
-		v.logger().WithError(err).Error("failed to disconnect agent")
+		v.logger().WithError(err).Error("failed to Disconnect agent")
 	}
 
 	return nil
@@ -262,7 +262,7 @@ func (v *VM) Stop(ctx context.Context) error {
 func (v *VM) AddCPUs(ctx context.Context, num uint32) error {
 	if num > 0 {
 		v.logger().Infof("hot adding %d vCPUs", num)
-		if _, err := v.hypervisor.hotplugAddDevice(ctx, num, CpuDev); err != nil {
+		if _, err := v.hypervisor.HotplugAddDevice(ctx, num, CpuDev); err != nil {
 			return err
 		}
 		v.cpuDelta += num
@@ -277,7 +277,7 @@ func (v *VM) AddMemory(ctx context.Context, numMB uint32) error {
 	if numMB > 0 {
 		v.logger().Infof("hot adding %d MB memory", numMB)
 		dev := &MemoryDevice{1, int(numMB), 0, false}
-		if _, err := v.hypervisor.hotplugAddDevice(ctx, dev, MemoryDev); err != nil {
+		if _, err := v.hypervisor.HotplugAddDevice(ctx, dev, MemoryDev); err != nil {
 			return err
 		}
 	}

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -221,7 +221,7 @@ func (v *VM) Pause(ctx context.Context) error {
 // Save saves a VM to persistent disk.
 func (v *VM) Save() error {
 	v.logger().Info("Save vm")
-	return v.hypervisor.saveSandbox()
+	return v.hypervisor.SaveVM()
 }
 
 // Resume resumes a paused VM.

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -44,7 +44,7 @@ type VMConfig struct {
 
 // Valid check VMConfig validity.
 func (c *VMConfig) Valid() error {
-	return c.HypervisorConfig.valid()
+	return c.HypervisorConfig.Valid()
 }
 
 // ToGrpc convert VMConfig struct to grpc format pb.GrpcVMConfig.
@@ -85,7 +85,7 @@ func GrpcToVMConfig(j *pb.GrpcVMConfig) (*VMConfig, error) {
 // NewVM creates a new VM based on provided VMConfig.
 func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 	// 1. setup hypervisor
-	hypervisor, err := newHypervisor(config.HypervisorType)
+	hypervisor, err := NewHypervisor(config.HypervisorType)
 	if err != nil {
 		return nil, err
 	}
@@ -165,7 +165,7 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 func NewVMFromGrpc(ctx context.Context, v *pb.GrpcVM, config VMConfig) (*VM, error) {
 	virtLog.WithField("GrpcVM", v).WithField("config", config).Info("create new vm from Grpc")
 
-	hypervisor, err := newHypervisor(config.HypervisorType)
+	hypervisor, err := NewHypervisor(config.HypervisorType)
 	if err != nil {
 		return nil, err
 	}
@@ -262,7 +262,7 @@ func (v *VM) Stop(ctx context.Context) error {
 func (v *VM) AddCPUs(ctx context.Context, num uint32) error {
 	if num > 0 {
 		v.logger().Infof("hot adding %d vCPUs", num)
-		if _, err := v.hypervisor.hotplugAddDevice(ctx, num, cpuDev); err != nil {
+		if _, err := v.hypervisor.hotplugAddDevice(ctx, num, CpuDev); err != nil {
 			return err
 		}
 		v.cpuDelta += num
@@ -276,8 +276,8 @@ func (v *VM) AddCPUs(ctx context.Context, num uint32) error {
 func (v *VM) AddMemory(ctx context.Context, numMB uint32) error {
 	if numMB > 0 {
 		v.logger().Infof("hot adding %d MB memory", numMB)
-		dev := &memoryDevice{1, int(numMB), 0, false}
-		if _, err := v.hypervisor.hotplugAddDevice(ctx, dev, memoryDev); err != nil {
+		dev := &MemoryDevice{1, int(numMB), 0, false}
+		if _, err := v.hypervisor.hotplugAddDevice(ctx, dev, MemoryDev); err != nil {
 			return err
 		}
 	}
@@ -381,7 +381,7 @@ func (v *VM) ToGrpc(ctx context.Context, config VMConfig) (*pb.GrpcVM, error) {
 
 func (v *VM) GetVMStatus() *pb.GrpcVMStatus {
 	return &pb.GrpcVMStatus{
-		Pid:    int64(getHypervisorPid(v.hypervisor)),
+		Pid:    int64(GetHypervisorPid(v.hypervisor)),
 		Cpu:    v.cpu,
 		Memory: v.memory,
 	}

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -215,7 +215,7 @@ func (v *VM) logger() logrus.FieldLogger {
 // Pause pauses a VM.
 func (v *VM) Pause(ctx context.Context) error {
 	v.logger().Info("pause vm")
-	return v.hypervisor.pauseSandbox(ctx)
+	return v.hypervisor.PauseVM(ctx)
 }
 
 // Save saves a VM to persistent disk.

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -23,7 +23,7 @@ var urandomDev = "/dev/urandom"
 
 // VM is abstraction of a virtual machine.
 type VM struct {
-	hypervisor hypervisor
+	hypervisor Hypervisor
 	agent      agent
 	store      persistapi.PersistDriver
 
@@ -84,7 +84,7 @@ func GrpcToVMConfig(j *pb.GrpcVMConfig) (*VMConfig, error) {
 
 // NewVM creates a new VM based on provided VMConfig.
 func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
-	// 1. setup hypervisor
+	// 1. setup Hypervisor
 	hypervisor, err := NewHypervisor(config.HypervisorType)
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 	}
 
 	// 3. boot up guest vm
-	if err = hypervisor.StartVM(ctx, vmStartTimeout); err != nil {
+	if err = hypervisor.StartVM(ctx, VmStartTimeout); err != nil {
 		return nil, err
 	}
 
@@ -233,7 +233,7 @@ func (v *VM) Resume(ctx context.Context) error {
 // Start kicks off a configured VM.
 func (v *VM) Start(ctx context.Context) error {
 	v.logger().Info("start vm")
-	return v.hypervisor.StartVM(ctx, vmStartTimeout)
+	return v.hypervisor.StartVM(ctx, VmStartTimeout)
 }
 
 // Disconnect agent connections to a VM


### PR DESCRIPTION
# Prototype to explore decoupling the Hypervisor logic from Kata and vice versa

Following up on the discussion in https://github.com/kata-containers/kata-containers/issues/2672 this attempts to identify how tightly coupled the Kata - Hypervisor interface is. 

From the PR the following is obvious
- Besides `create sandbox` and `valid` all other hypervisor interfaces are pretty generic
- The device abstraction helps a bit but does not cover networking
- The networking logic is horribly inter twined and we have Kata isms all over the hypervisor API (but can be eliminated)
- We need to add a networking device type

Let us see if the CI shows any other basic gaps.

@amshinde the network logic does not seem to be hypervisor agnostic. Each hypervisor seems to have its own customization.

Fixes: https://github.com/kata-containers/kata-containers/issues/2672 

Next steps: See if the abstraction holds and we can launch VM's using CLH and FC.

/cc @egernst @amshinde @bergwolf 