### PR TITLE
runtime: improve unit test coverage for virtcontainers/pkg/cgroups

### DIFF
--- a/src/runtime/virtcontainers/pkg/cgroups/cgroups_test.go
+++ b/src/runtime/virtcontainers/pkg/cgroups/cgroups_test.go
@@ -1,0 +1,293 @@
+// Copyright (c) 2021 Inspur Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cgroups
+
+import (
+	"testing"
+
+	"github.com/containerd/cgroups"
+	ktu "github.com/kata-containers/kata-containers/src/runtime/pkg/katatestutils"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+var tc ktu.TestConstraint
+
+func init() {
+	tc = ktu.NewTestConstraint(false)
+}
+
+func newCgroup() *Cgroup {
+	return &Cgroup{
+		cgroup:  &mockCgroup{},
+		path:    "",
+		cpusets: &specs.LinuxCPU{},
+		devices: []specs.LinuxDeviceCgroup{},
+	}
+}
+
+func TestSandboxDevices(t *testing.T) {
+	assert := assert.New(t)
+
+	devices := sandboxDevices()
+	assert.NotNil(devices)
+
+	assertDevices := []specs.LinuxDeviceCgroup{}
+	defaultDevices := []string{
+		"/dev/null",
+		"/dev/random",
+		"/dev/full",
+		"/dev/tty",
+		"/dev/zero",
+		"/dev/urandom",
+		"/dev/console",
+		"/dev/kvm",
+		"/dev/vhost-net",
+		"/dev/vfio/vfio",
+	}
+	for _, device := range defaultDevices {
+		ldevice, err := DeviceToLinuxDevice(device)
+		if err != nil {
+			continue
+		}
+		assertDevices = append(assertDevices, ldevice)
+	}
+	wildcardMajor := int64(-1)
+	wildcardMinor := int64(-1)
+	ptsMajor := int64(136)
+	tunMajor := int64(10)
+	tunMinor := int64(200)
+	assertDevices = append(assertDevices, []specs.LinuxDeviceCgroup{
+		// allow mknod for any device
+		{
+			Allow:  true,
+			Type:   "c",
+			Major:  &wildcardMajor,
+			Minor:  &wildcardMinor,
+			Access: "m",
+		},
+		{
+			Allow:  true,
+			Type:   "b",
+			Major:  &wildcardMajor,
+			Minor:  &wildcardMinor,
+			Access: "m",
+		},
+		// /dev/pts/ - pts namespaces are "coming soon"
+		{
+			Allow:  true,
+			Type:   "c",
+			Major:  &ptsMajor,
+			Minor:  &wildcardMinor,
+			Access: "rwm",
+		},
+		// tuntap
+		{
+			Allow:  true,
+			Type:   "c",
+			Major:  &tunMajor,
+			Minor:  &tunMinor,
+			Access: "rwm",
+		},
+	}...)
+	assert.Equal(len(assertDevices), len(devices))
+	for i, assertCgroup := range assertDevices {
+		assert.Equal(assertCgroup.Major, devices[i].Major)
+		assert.Equal(assertCgroup.Minor, devices[i].Minor)
+		assert.Equal(assertCgroup.Access, devices[i].Access)
+		assert.Equal(assertCgroup.Type, devices[i].Type)
+	}
+}
+
+func TestNewCgroup(t *testing.T) {
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(ktu.TestDisabledNeedRoot)
+	}
+	assert := assert.New(t)
+
+	for _, t := range []struct {
+		path string
+	}{
+		{""},
+		{"system.slice:kata:dfb3b2a6af34d"},
+	} {
+		cg, err := NewCgroup(t.path, &specs.LinuxResources{})
+		assert.NoError(err)
+		assert.NotNil(cg)
+		_ = cg.Delete()
+	}
+}
+
+func TestNewSandboxCgroup(t *testing.T) {
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(ktu.TestDisabledNeedRoot)
+	}
+	assert := assert.New(t)
+
+	for _, path := range []string{"", "system.slice:kata:dfb3b2a6af34d"} {
+		cg, err := NewSandboxCgroup(path, &specs.LinuxResources{})
+		assert.NoError(err)
+		assert.NotNil(cg)
+		_ = cg.Delete()
+	}
+}
+
+func TestLoad(t *testing.T) {
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(ktu.TestDisabledNeedRoot)
+	}
+	assert := assert.New(t)
+
+	for _, t := range []struct {
+		path         string
+		createCgroup bool
+		error        bool
+	}{
+		{"test", false, true},
+		{"test", true, false},
+	} {
+		cg, _ := cgroups.New(cgroups.V1, cgroups.StaticPath(t.path), &specs.LinuxResources{})
+		if !t.createCgroup && cg != nil {
+			if err := cg.Delete(); err != nil {
+				continue
+			}
+		}
+		_, err := Load(t.path)
+		if t.error {
+			assert.Error(err)
+		} else {
+			assert.NoError(err)
+			_ = cg.Delete()
+		}
+	}
+}
+
+func TestLogger(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := &Cgroup{}
+	logger := cg.Logger()
+	assert.NotNil(logger)
+}
+
+func TestDelete(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := newCgroup()
+	err := cg.Delete()
+	assert.NoError(err)
+}
+
+func TestStat(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := newCgroup()
+	metrics, err := cg.Stat()
+	assert.NoError(err)
+	assert.Nil(metrics)
+}
+
+func TestAddProcess(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := newCgroup()
+	err := cg.AddProcess(0, "test")
+	assert.NoError(err)
+}
+
+func TestAddTask(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := newCgroup()
+	err := cg.AddTask(0, "test")
+	assert.NoError(err)
+}
+
+func TestUpdate(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := newCgroup()
+	err := cg.Update(&specs.LinuxResources{})
+	assert.NoError(err)
+}
+
+func TestMoveTo(t *testing.T) {
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(ktu.TestDisabledNeedRoot)
+	}
+	assert := assert.New(t)
+
+	path := "test"
+	cg := newCgroup()
+	err := cg.MoveTo(path)
+	assert.Error(err)
+
+	cGroup, err := cgroups.New(cgroups.V1, cgroups.StaticPath(path), &specs.LinuxResources{})
+	if err != nil {
+		t.Skipf("create cGroup failed, path: %s", path)
+	}
+	defer func() {
+		_ = cGroup.Delete()
+	}()
+	err = cg.MoveTo(path)
+	assert.NoError(err)
+}
+
+func TestMoveToParent(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := newCgroup()
+
+	err := cg.MoveToParent()
+	assert.NoError(err)
+}
+
+func TestAddDevice(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := newCgroup()
+	err := cg.AddDevice("/dev/null")
+	assert.NoError(err)
+}
+
+func TestRemoveDevice(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := newCgroup()
+	err := cg.RemoveDevice("/dev/null")
+	assert.NoError(err)
+}
+
+func TestUpdateCpuSet(t *testing.T) {
+	assert := assert.New(t)
+	for _, t := range []struct {
+		cpusets *specs.LinuxCPU
+		cpuset  string
+		memset  string
+	}{
+		{nil, "", ""},
+		{nil, "1,2,4", "1024"},
+		{&specs.LinuxCPU{}, "1", "512"},
+	} {
+		cg := &Cgroup{
+			cgroup:  &mockCgroup{},
+			path:    "",
+			cpusets: t.cpusets,
+			devices: nil,
+		}
+		err := cg.UpdateCpuSet(t.cpuset, t.memset)
+		assert.NoError(err)
+	}
+}
+
+func TestPath(t *testing.T) {
+	assert := assert.New(t)
+
+	cg := newCgroup()
+	path := cg.Path()
+	assert.NotNil(path)
+	assert.Equal("", path)
+}

--- a/src/runtime/virtcontainers/pkg/cgroups/mock.go
+++ b/src/runtime/virtcontainers/pkg/cgroups/mock.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2021 Inspur Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package cgroups
+
+import (
+	"github.com/containerd/cgroups"
+	v1 "github.com/containerd/cgroups/stats/v1"
+	"github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// mockCgroup is an empty github.com/containerd/cgroups Cgroup implementation, for testing and mocking purposes.
+type mockCgroup struct {
+	subsystems []cgroups.Subsystem
+}
+
+// New returns a new sub cgroup
+func (c *mockCgroup) New(name string, resources *specs.LinuxResources) (cgroups.Cgroup, error) {
+	return &mockCgroup{}, nil
+}
+
+// Subsystems returns all the subsystems that are currently being
+// consumed by the group
+func (c *mockCgroup) Subsystems() []cgroups.Subsystem {
+	return c.subsystems
+}
+
+// Add moves the provided process into the new cgroup
+func (c *mockCgroup) Add(process cgroups.Process) error {
+	return nil
+}
+
+// AddProc moves the provided process id into the new cgroup
+func (c *mockCgroup) AddProc(pid uint64) error {
+	return nil
+}
+
+// AddTask moves the provided tasks (threads) into the new cgroup
+func (c *mockCgroup) AddTask(process cgroups.Process) error {
+	return nil
+}
+
+// Delete will remove the control group from each of the subsystems registered
+func (c *mockCgroup) Delete() error {
+	return nil
+}
+
+// Stat returns the current metrics for the cgroup
+func (c *mockCgroup) Stat(handlers ...cgroups.ErrorHandler) (*v1.Metrics, error) {
+	return nil, nil
+}
+
+// Update updates the cgroup with the new resource values provided
+//
+// Be prepared to handle EBUSY when trying to update a cgroup with
+// live processes and other operations like Stats being performed at the
+// same time
+func (c *mockCgroup) Update(resources *specs.LinuxResources) error {
+	return nil
+}
+
+// Processes returns the processes running inside the cgroup along
+// with the subsystem used, pid, and path
+func (c *mockCgroup) Processes(subsystem cgroups.Name, recursive bool) ([]cgroups.Process, error) {
+	return nil, nil
+}
+
+// Tasks returns the tasks running inside the cgroup along
+// with the subsystem used, pid, and path
+func (c *mockCgroup) Tasks(subsystem cgroups.Name, recursive bool) ([]cgroups.Task, error) {
+	return nil, nil
+}
+
+// Freeze freezes the entire cgroup and all the processes inside it
+func (c *mockCgroup) Freeze() error {
+	return nil
+}
+
+// Thaw thaws out the cgroup and all the processes inside it
+func (c *mockCgroup) Thaw() error {
+	return nil
+}
+
+// OOMEventFD returns the memory cgroup's out of memory event fd that triggers
+// when processes inside the cgroup receive an oom event. Returns
+// ErrMemoryNotSupported if memory cgroups is not supported.
+func (c *mockCgroup) OOMEventFD() (uintptr, error) {
+	return 0, nil
+}
+
+// RegisterMemoryEvent allows the ability to register for all v1 memory cgroups
+// notifications.
+func (c *mockCgroup) RegisterMemoryEvent(event cgroups.MemoryEvent) (uintptr, error) {
+	return 0, nil
+}
+
+// State returns the state of the cgroup and its processes
+func (c *mockCgroup) State() cgroups.State {
+	return cgroups.Unknown
+}
+
+// MoveTo does a recursive move subsystem by subsystem of all the processes
+// inside the group
+func (c *mockCgroup) MoveTo(destination cgroups.Cgroup) error {
+	return nil
+}

--- a/src/runtime/virtcontainers/pkg/cgroups/utils_test.go
+++ b/src/runtime/virtcontainers/pkg/cgroups/utils_test.go
@@ -159,3 +159,17 @@ func TestDeviceToLinuxDevice(t *testing.T) {
 	assert.NotEmpty(dev.Access)
 	assert.True(dev.Allow)
 }
+
+func TestRenameCgroupPath(t *testing.T) {
+	assert := assert.New(t)
+
+	path := ""
+	filePath, err := RenameCgroupPath(path)
+	assert.NoError(err)
+	assert.Equal("/kata_vc", filePath)
+
+	path = "/test"
+	filePath, err = RenameCgroupPath(path)
+	assert.NoError(err)
+	assert.NotNil(filePath)
+}


### PR DESCRIPTION
Improve unit test coverage for virtcontainers/pkg/cgroups for Kata 2.0 runtime

Fixes: #262

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>