### PR TITLE
virtiofs: fix error report in TestVirtiofsdStart when go test running

### DIFF
--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -70,7 +70,7 @@ func TestVirtiofsdStart(t *testing.T) {
 				PID:        tt.fields.PID,
 				ctx:        tt.fields.ctx,
 			}
-			var ctx context.Context
+			ctx := context.Background()
 			_, err := v.Start(ctx, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("virtiofsd.Start() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
Initialize ctx with context.Background() instead of nil value.

Fixes: #2718

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>