### PR TITLE
stable-2.2 | workflows: Fix tag attribution

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -100,8 +100,8 @@ jobs:
         run: |
           # tag the container image we created and push to DockerHub
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
-          tags=$(tag)
-          tags+=$([[ "$tag" =~ "alpha"|"rc" ]] && echo "latest" || echo "stable")
+          tags=($tag)
+          tags+=($([[ "$tag" =~ "alpha"|"rc" ]] && echo "latest" || echo "stable"))
           for tag in ${tags[@]}; do \
             docker tag katadocker/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci.outputs.PKG_SHA}} katadocker/kata-deploy:${tag} && \
             docker tag quay.io/kata-containers/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci.outputs.PKG_SHA}} quay.io/kata-containers/kata-deploy:${tag} && \


### PR DESCRIPTION
While releasing kata-containers 2.3.0-alpha1 we've hit some issues as
the tags attribution is done incorrectly.  We want an array of tags to
iterate over, but the currently code is just lost is the parenthesis.

This issue was introduced in a156288c1f8251bdd3231ec765d324f95a3da33e.

Backports: #2727
Fixes: #2725

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>
(cherry picked from commit 39dcbaa67258b6363f897dd558e81cda34366157)