### PR TITLE
stable-2.2 | workflows: Fix the config file path for using vendored sources

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,11 +141,11 @@ jobs:
       - name: generate-and-upload-tarball
         run: |
           pushd $GITHUB_WORKSPACE/src/agent
-          cargo vendor >> .cargo/vendor
+          cargo vendor >> .cargo/config
           popd
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           tarball="kata-containers-$tag-vendor.tar.gz"
           pushd $GITHUB_WORKSPACE
-          tar -cvzf "${tarball}" src/agent/.cargo/vendor src/agent/vendor
+          tar -cvzf "${tarball}" src/agent/.cargo/config src/agent/vendor
           GITHUB_TOKEN=${{ secrets.GIT_UPLOAD_TOKEN }} hub release edit -m "" -a "${tarball}" "${tag}" 
           popd


### PR DESCRIPTION
There's a typo in the file that should receive the output of `cargo
vendor`.  We should use forward the output to `.cargo/config` instead of
`.cargo/vendor`.

This was introduced by 21c8511630fefecfcdc4af350ba25139dfac8fde.

Backports: #2730
Fixes: #2729

Signed-off-by: Fabiano Fidêncio <fidencio@redhat.com>
(cherry picked from commit a525991c2c27c5da88d02104a7a83831769ef2ba)