### PR TITLE
qemu: prepare to upgrade qemu version to 6.1.0 for arm

### DIFF
--- a/tools/packaging/kernel/patches/5.10.x/0001-arm64-sparsemem-reduce-SECTION_SIZE_BITS.patch
+++ b/tools/packaging/kernel/patches/5.10.x/0001-arm64-sparsemem-reduce-SECTION_SIZE_BITS.patch
@@ -1,0 +1,94 @@
+From 5745513881520f48401ac40306ac8cd6ef35beaf Mon Sep 17 00:00:00 2001
+From: Sudarshan Rajagopalan <sudaraja@codeaurora.org>
+Date: Sun, 26 Sep 2021 13:10:41 +0800
+Subject: [PATCH] arm64/sparsemem: reduce SECTION_SIZE_BITS
+
+memory_block_size_bytes() determines the memory hotplug granularity i.e the
+amount of memory which can be hot added or hot removed from the kernel. The
+generic value here being MIN_MEMORY_BLOCK_SIZE (1UL << SECTION_SIZE_BITS)
+for memory_block_size_bytes() on platforms like arm64 that does not override.
+
+Current SECTION_SIZE_BITS is 30 i.e 1GB which is large and a reduction here
+increases memory hotplug granularity, thus improving its agility. A reduced
+section size also reduces memory wastage in vmemmmap mapping for sections
+with large memory holes. So we try to set the least section size as possible.
+
+A section size bits selection must follow:
+(MAX_ORDER - 1 + PAGE_SHIFT) <= SECTION_SIZE_BITS
+
+CONFIG_FORCE_MAX_ZONEORDER is always defined on arm64 and so just following it
+would help achieve the smallest section size.
+
+SECTION_SIZE_BITS = (CONFIG_FORCE_MAX_ZONEORDER - 1 + PAGE_SHIFT)
+
+SECTION_SIZE_BITS = 22 (11 - 1 + 12) i.e 4MB   for 4K pages
+SECTION_SIZE_BITS = 24 (11 - 1 + 14) i.e 16MB  for 16K pages without THP
+SECTION_SIZE_BITS = 25 (12 - 1 + 14) i.e 32MB  for 16K pages with THP
+SECTION_SIZE_BITS = 26 (11 - 1 + 16) i.e 64MB  for 64K pages without THP
+SECTION_SIZE_BITS = 29 (14 - 1 + 16) i.e 512MB for 64K pages with THP
+
+But there are other problems in reducing SECTION_SIZE_BIT. Reducing it by too
+much would over populate /sys/devices/system/memory/ and also consume too many
+page->flags bits in the !vmemmap case. Also section size needs to be multiple
+of 128MB to have PMD based vmemmap mapping with CONFIG_ARM64_4K_PAGES.
+
+Given these constraints, lets just reduce the section size to 128MB for 4K
+
+Signed-off-by: Sudarshan Rajagopalan <sudaraja@codeaurora.org>
+Suggested-by: Anshuman Khandual <anshuman.khandual@arm.com>
+Suggested-by: David Hildenbrand <david@redhat.com>
+Cc: Catalin Marinas <catalin.marinas@arm.com>
+Cc: Will Deacon <will@kernel.org>
+Cc: Anshuman Khandual <anshuman.khandual@arm.com>
+Cc: David Hildenbrand <david@redhat.com>
+Cc: Mike Rapoport <rppt@linux.ibm.com>
+Cc: Mark Rutland <mark.rutland@arm.com>
+Cc: Logan Gunthorpe <logang@deltatee.com>
+Cc: Andrew Morton <akpm@linux-foundation.org>
+Cc: Steven Price <steven.price@arm.com>
+Cc: Suren Baghdasaryan <surenb@google.com>
+Reviewed-by: David Hildenbrand <david@redhat.com>
+Acked-by: Mike Rapoport <rppt@linux.ibm.com>
+Reviewed-by: Catalin Marinas <catalin.marinas@arm.com>
+Link: https://lore.kernel.org/r/43843c5e092bfe3ec4c41e3c8c78a7ee35b69bb0.1611206601.git.sudaraja@codeaurora.org
+Signed-off-by: Will Deacon <will@kernel.org>
+---
+ arch/arm64/include/asm/sparsemem.h | 23 +++++++++++++++++++++--
+ 1 file changed, 21 insertions(+), 2 deletions(-)
+
+diff --git a/arch/arm64/include/asm/sparsemem.h b/arch/arm64/include/asm/sparsemem.h
+index 1f43fcc79738..eb4a75d720ed 100644
+--- a/arch/arm64/include/asm/sparsemem.h
++++ b/arch/arm64/include/asm/sparsemem.h
+@@ -7,7 +7,26 @@
+ 
+ #ifdef CONFIG_SPARSEMEM
+ #define MAX_PHYSMEM_BITS	CONFIG_ARM64_PA_BITS
+-#define SECTION_SIZE_BITS	30
+-#endif
++
++/*
++ * Section size must be at least 512MB for 64K base
++ * page size config. Otherwise it will be less than
++ * (MAX_ORDER - 1) and the build process will fail.
++ */
++#ifdef CONFIG_ARM64_64K_PAGES
++#define SECTION_SIZE_BITS 29
++
++#else
++
++/*
++ * Section size must be at least 128MB for 4K base
++ * page size config. Otherwise PMD based huge page
++ * entries could not be created for vmemmap mappings.
++ * 16K follows 4K for simplicity.
++ */
++#define SECTION_SIZE_BITS 27
++#endif /* CONFIG_ARM64_64K_PAGES */
++
++#endif /* CONFIG_SPARSEMEM*/
+ 
+ #endif
+-- 
+2.17.1
+

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -437,6 +437,8 @@ generate_qemu_options() {
 	# aarch64 need to explictly set --enable-pie
 	if [ -z "${static}" ] && [ "${arch}" = "aarch64" ]; then
 		qemu_options+=(arch:"--enable-pie")
+		# pie is conflict with plugins build for qemu 6.1.0
+		[ "${qemu_version}" == "6.1.0" ] && qemu_options+=(arch:"--disable-plugins")
 	fi
 
 	_qemu_cflags=""


### PR DESCRIPTION
there are 2 issue to upgrade qemu version to 6.1.0 for arm:

1. using the current qemu config will lead to compile error: 

       qemu/build/../tests/plugin/bb.c:134: undefined reference to `qemu_plugin_register_vcpu_tb_trans_cb'
       qemu/build/../tests/plugin/bb.c:135: undefined reference to `qemu_plugin_register_atexit_cb'
       qemu/build/../tests/plugin/bb.c:131: undefined reference to `qemu_plugin_register_vcpu_idle_cb'
       collect2: error: ld returned 1 exit status
 that's why I disable plugin in the first patch.

2. when memory hotplug, kernel will check the alignment size of start hotplug size which is at the end of nvidmm memory size. The current nvdimm size align with 128M, however, in kernel it's 1G which will lead to error.
that's why I port the upstreamed patch to reduce the memory alignment size to 128M.
