### PR TITLE
[WIP] cc: agent support for cc

### DIFF
--- a/src/agent/protocols/build.rs
+++ b/src/agent/protocols/build.rs
@@ -13,6 +13,7 @@ fn main() {
         "protos/health.proto",
         "protos/google/protobuf/empty.proto",
         "protos/oci.proto",
+        "protos/image.proto",
     ];
 
     Codegen::new()

--- a/src/agent/protocols/protos/image.proto
+++ b/src/agent/protocols/protos/image.proto
@@ -1,0 +1,74 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// To regenerate api.pb.go run hack/update-generated-runtime.sh
+syntax = "proto3";
+
+package containerd.task.v2;
+
+//import "github.com/gogo/protobuf/gogoproto/gogo.proto";
+
+option go_package = "github.com/containerd/containerd/runtime/v2/task;task";
+
+//option (gogoproto.goproto_stringer_all) = false;
+//option (gogoproto.stringer_all) =  true;
+//option (gogoproto.goproto_getters_all) = true;
+//option (gogoproto.marshaler_all) = true;
+//option (gogoproto.sizer_all) = true;
+//option (gogoproto.unmarshaler_all) = true;
+//option (gogoproto.goproto_unrecognized_all) = false;
+
+// Image defines the public APIs for managing images.
+service Image {
+    // PullImage pulls an image with authentication config.
+    rpc PullImage(PullImageRequest) returns (PullImageResponse) {}
+}
+
+// ImageSpec is an internal representation of an image.
+message ImageSpec {
+    // Container's Image field (e.g. imageID or imageDigest).
+    string image = 1;
+    // Unstructured key-value map holding arbitrary metadata.
+    // ImageSpec Annotations can be used to help the runtime target specific
+    // images in multi-arch images.
+    map<string, string> annotations = 2;
+}
+
+// AuthConfig contains authorization information for connecting to a registry.
+message AuthConfig {
+    string username = 1;
+    string password = 2;
+    string auth = 3;
+    string server_address = 4;
+    // IdentityToken is used to authenticate the user and get
+    // an access token for the registry.
+    string identity_token = 5;
+    // RegistryToken is a bearer token to be sent to a registry
+    string registry_token = 6;
+}
+
+message PullImageRequest {
+    // Spec of the image.
+    ImageSpec image = 1;
+    // Authentication configuration for pulling the image.
+    AuthConfig auth = 2;
+}
+
+message PullImageResponse {
+    // Reference to the image in use. For most runtimes, this should be an
+    // image ID or digest.
+    string image_ref = 1;
+}

--- a/src/agent/protocols/src/lib.rs
+++ b/src/agent/protocols/src/lib.rs
@@ -12,3 +12,5 @@ pub mod health;
 pub mod health_ttrpc;
 pub mod oci;
 pub mod types;
+pub mod image;
+pub mod image_ttrpc;

--- a/src/agent/src/image_rpc.rs
+++ b/src/agent/src/image_rpc.rs
@@ -1,0 +1,86 @@
+use std::process::Stdio;
+use std::sync::Arc;
+use tokio::sync::Mutex;
+
+use anyhow::{anyhow, Result};
+use async_trait::async_trait;
+use protocols::image;
+use ttrpc;
+
+use crate::sandbox::Sandbox;
+
+pub struct ImageService {
+    sandbox: Arc<Mutex<Sandbox>>,
+}
+
+impl ImageService {
+    pub fn new(sandbox: Arc<Mutex<Sandbox>>) -> Self {
+        Self { sandbox }
+    }
+
+    async fn pull_image(&self, image: &str) -> Result<String> {
+        let shell = std::path::PathBuf::from("/opt/pull_image.sh");
+        let child = tokio::process::Command::new(shell)
+            .arg(image)
+            .kill_on_drop(true)
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("pull image command failed to start");
+
+        let join_handler = tokio::spawn(async move {
+            match child.wait_with_output().await {
+                Ok(output) => {
+                    if output.status.success() {
+                        //println!(
+                        //    "child success {}",
+                        //    String::from_utf8(output.stdout).unwrap()
+                        //);
+                        return Ok(String::from_utf8(output.stdout).unwrap());
+                    } else {
+                        //println!("child fail {}", String::from_utf8(output.stderr).unwrap());
+                        return Err(anyhow!(
+                            "child fail {}",
+                            String::from_utf8(output.stderr).unwrap()
+                        ));
+                    }
+                }
+                Err(e) => {
+                    //println!("child exec err. {:?}", e);
+                    return Err(e.into());
+                }
+            }
+        });
+
+        let resp =
+            tokio::time::timeout(std::time::Duration::from_secs(100), join_handler).await???;
+        let mut sandbox = self.sandbox.lock().await;
+        sandbox.images.insert(String::from(image), resp.clone());
+        info!(
+            slog_scope::logger(),
+            "agent pull image success: {:?}", sandbox.images
+        );
+        return Ok(String::from(image));
+    }
+}
+
+#[async_trait]
+impl protocols::image_ttrpc::Image for ImageService {
+    async fn pull_image(
+        &self,
+        _ctx: &ttrpc::r#async::TtrpcContext,
+        req: image::PullImageRequest,
+    ) -> ttrpc::Result<image::PullImageResponse> {
+        match self.pull_image(req.get_image().get_image()).await {
+            Ok(r) => {
+                let mut resp = image::PullImageResponse::new();
+                resp.image_ref = r;
+                return Ok(resp);
+            }
+            Err(e) => {
+                return Err(ttrpc::Error::Others(e.to_string()));
+            }
+        }
+    }
+}

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -74,6 +74,7 @@ use tokio::{
 };
 
 mod rpc;
+mod image_rpc;
 mod tracer;
 
 const NAME: &str = "kata-agent";

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -46,6 +46,7 @@ use nix::unistd::{self, Pid};
 use rustjail::process::ProcessOperations;
 
 use crate::device::{add_devices, pcipath_to_sysfs, rescan_pci_bus, update_device_cgroup};
+use crate::image_rpc;
 use crate::linux_abi::*;
 use crate::metrics::get_metrics;
 use crate::mount::{add_storages, baremount, remove_mounts, STORAGE_HANDLER_LIST};
@@ -81,6 +82,7 @@ const CONTAINER_BASE: &str = "/run/kata-containers";
 const MODPROBE_PATH: &str = "/sbin/modprobe";
 const SKOPEO_PATH: &str = "/usr/bin/skopeo";
 const UMOCI_PATH: &str = "/usr/local/bin/umoci";
+const ANNO_K8S_IMAGE_NAME: &str = "io.kubernetes.cri.image-name";
 
 // Convenience macro to obtain the scope logger
 macro_rules! sl {
@@ -111,6 +113,34 @@ fn verify_cid(id: &str) -> Result<()> {
     }
 }
 
+fn merge_process(ori: &mut oci::Process, image: &oci::Process) {
+    if ori.args.len() == 0 {
+        if image.args.len() != 0 {
+            ori.args.append(&mut image.args.clone());
+        }
+    }
+    if ori.cwd.len() == 0 {
+        ori.cwd = image.cwd.clone();
+    }
+    ori.env.append(&mut image.env.clone());
+}
+
+fn merge_oci(image_bundle: &str, ori: &mut oci::Spec, image: &oci::Spec) {
+    if let Some(root) = ori.root.as_mut() {
+        if let Some(ir) = image.root.as_ref() {
+            let mut rp = PathBuf::from("/run/images");
+            rp.push(image_bundle);
+            rp.push(ir.path.clone());
+            root.path = String::from(rp.to_str().unwrap());
+        }
+    }
+    if let Some(proc) = ori.process.as_mut() {
+        if let Some(image_proc) = image.process.as_ref() {
+            merge_process(proc, image_proc);
+        }
+    }
+}
+
 impl AgentService {
     #[instrument]
     async fn do_create_container(
@@ -136,6 +166,15 @@ impl AgentService {
         };
 
         info!(sl!(), "receive createcontainer, spec: {:?}", &oci);
+
+        if let Some(image_name) = oci.annotations.get(&ANNO_K8S_IMAGE_NAME.to_string()) {
+            if let Some(image_bundle) = self.sandbox.clone().lock().await.images.get(image_name) {
+                let spec_path = image_bundle.clone() + "/config.json";
+                info!(sl!(), "image bundle path: {}", spec_path);
+                let image_oci = oci::Spec::load(&spec_path).context("load image bundle")?;
+                merge_oci(&image_bundle, &mut oci, &image_oci);
+            }
+        }
 
         // re-scan PCI bus
         // looking for hidden devices
@@ -1361,7 +1400,7 @@ fn find_process<'a>(
 }
 
 pub fn start(s: Arc<Mutex<Sandbox>>, server_address: &str) -> TtrpcServer {
-    let agent_service = Box::new(AgentService { sandbox: s })
+    let agent_service = Box::new(AgentService { sandbox: s.clone() })
         as Box<dyn protocols::agent_ttrpc::AgentService + Send + Sync>;
 
     let agent_worker = Arc::new(agent_service);
@@ -1370,15 +1409,21 @@ pub fn start(s: Arc<Mutex<Sandbox>>, server_address: &str) -> TtrpcServer {
         Box::new(HealthService {}) as Box<dyn protocols::health_ttrpc::Health + Send + Sync>;
     let health_worker = Arc::new(health_service);
 
+    let image_service = Box::new(image_rpc::ImageService::new(s))
+        as Box<dyn protocols::image_ttrpc::Image + Send + Sync>;
+
     let aservice = protocols::agent_ttrpc::create_agent_service(agent_worker);
 
     let hservice = protocols::health_ttrpc::create_health(health_worker);
+
+    let iservice = protocols::image_ttrpc::create_image(Arc::new(image_service));
 
     let server = TtrpcServer::new()
         .bind(server_address)
         .unwrap()
         .register_service(aservice)
-        .register_service(hservice);
+        .register_service(hservice)
+        .register_service(iservice);
 
     info!(sl!(), "ttRPC server started"; "address" => server_address);
 

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -56,6 +56,7 @@ pub struct Sandbox {
     pub event_rx: Arc<Mutex<Receiver<String>>>,
     pub event_tx: Option<Sender<String>>,
     pub bind_watcher: BindWatcher,
+    pub images: HashMap<String, String>,
 }
 
 impl Sandbox {
@@ -88,6 +89,7 @@ impl Sandbox {
             event_rx,
             event_tx: Some(tx),
             bind_watcher: BindWatcher::new(),
+            images: HashMap::new(),
         })
     }
 


### PR DESCRIPTION
* add ImageService in agent, use script to pull image and unpack.

```
IMAGE=$1
BUNDLE=$2

WD=/run/images

mkdir -p $WD
cd $WD

OCI_IMAGE=$(echo $IMAGE | awk -F\/ '{print $NF}')
IMAGE_NAME=$(echo $OCI_IMAGE | awk -F: '{print $1}')

skopeo copy docker://$IMAGE oci:$OCI_IMAGE > /dev/null || exit 1

umoci unpack --image $OCI_IMAGE --rootless ${IMAGE_NAME}_bundle > /dev/null

echo -n "$WD/${IMAGE_NAME}_bundle"
```

* CreateContainer need merge image spec.

Signed-off-by: wlleny <wllenyj@linux.alibaba.com>