### PR TITLE
cmd: Fix mismatched types in testModuleData

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-check_arm64_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_arm64_test.go
@@ -28,9 +28,9 @@ func setupCheckHostIsVMContainerCapable(assert *assert.Assertions, cpuInfoFile s
 func TestCCCheckCLIFunction(t *testing.T) {
 	var cpuData []testCPUData
 	moduleData := []testModuleData{
-		{filepath.Join(sysModuleDir, "kvm"), true, ""},
-		{filepath.Join(sysModuleDir, "vhost"), true, ""},
-		{filepath.Join(sysModuleDir, "vhost_net"), true, ""},
+		{filepath.Join(sysModuleDir, "kvm"), "", true},
+		{filepath.Join(sysModuleDir, "vhost"), "", true},
+		{filepath.Join(sysModuleDir, "vhost_net"), "", true},
 	}
 
 	genericCheckCLIFunction(t, cpuData, moduleData)

--- a/src/runtime/cmd/kata-runtime/kata-check_ppc64le_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_ppc64le_test.go
@@ -47,8 +47,8 @@ func TestCCCheckCLIFunction(t *testing.T) {
 	}
 
 	moduleData := []testModuleData{
-		{filepath.Join(sysModuleDir, "kvm"), false, "Y"},
-		{filepath.Join(sysModuleDir, "kvm_hv"), false, "Y"},
+		{filepath.Join(sysModuleDir, "kvm"), "", true},
+		{filepath.Join(sysModuleDir, "kvm_hv"), "", true},
 	}
 
 	genericCheckCLIFunction(t, cpuData, moduleData)

--- a/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
@@ -47,7 +47,7 @@ func TestCCCheckCLIFunction(t *testing.T) {
 	}
 
 	moduleData := []testModuleData{
-		{filepath.Join(sysModuleDir, "kvm"), false, "Y"},
+		{filepath.Join(sysModuleDir, "kvm"), "", true},
 	}
 
 	genericCheckCLIFunction(t, cpuData, moduleData)


### PR DESCRIPTION
Rectify the values of `testModuleData` with the correct
types in `TestCCCheckCLiFunction` in kata-check_(!x86)_test.go

Fixes: #2735

Signed-off-by: Amulya Meka <amulmek1@in.ibm.com>