### PR TITLE
runtime: fix nil reference in cleanup rootless user

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1024,10 +1024,12 @@ func (q *qemu) cleanupVM() error {
 		u, err := user.LookupId(strconv.Itoa(int(q.config.Uid)))
 		if err != nil {
 			q.Logger().WithError(err).WithField("uid", q.config.Uid).Warn("failed to find the user")
+			return nil
 		}
 		userdelPath, err := pkgUtils.FirstValidExecutable([]string{"/usr/sbin/userdel", "/sbin/userdel", "/bin/userdel"})
 		if err != nil {
 			q.Logger().WithError(err).WithField("user", u.Username).Warn("failed to delete the user")
+			return nil
 		}
 		_, err = pkgUtils.RunCommand([]string{userdelPath, "-f", u.Username})
 		if err != nil {


### PR DESCRIPTION
It seems the client (crio) can send multiple requests to stop the Kata VM,
resulting a nil reference if the uid has already been cleaned up by a different thread.

Fixes #2743

Signed-off-by: Feng Wang <feng.wang@databricks.com>