### PR TITLE
clh: Enable guest userland output

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -936,7 +936,15 @@ func (clh *cloudHypervisor) launchClh() (int, error) {
 		// and in a nested environment this could increase
 		// the chances to fail because agent is not
 		// ready on time.
-		args = append(args, "-vv")
+		//
+		// Note that for debugging CLH boot failures, the Info level
+		// should be sufficient: Debug level generates so many
+		// messages it floods the output stream to the extent that it
+		// is almost impossible to view the guest kernel and userland
+		// output. For further details, see the discussion on:
+		//
+		//   https://github.com/kata-containers/kata-containers/pull/2751
+		args = append(args, "-v")
 	}
 
 	// Disable the 'seccomp' option in clh for now.


### PR DESCRIPTION
Fix guest userland logging for Cloud Hypervisor (CLH) by:

- Disabling CLH's serial console.
- Enabling CLH's console.
- Booting the kernel specifying a para-virtualised console device.

Previously, CLH's serial console was used, resulting in only
kernel boot output and CLH's own debug output being logged.

Switching to using the CLH console enables userland logging: systemd and
it's jobs, such as the Kata agent.

Fixes: #2726.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>