### PR TITLE
#2676: fixing centos gpg key url for ppc64le

### DIFF
--- a/tools/osbuilder/rootfs-builder/centos/config_ppc64le.sh
+++ b/tools/osbuilder/rootfs-builder/centos/config_ppc64le.sh
@@ -13,6 +13,6 @@ CENTOS_EXTRAS_URL="http://mirror.centos.org/altarch/${OS_VERSION}/extras/${ARCH}
 
 CENTOS_PLUS_URL="http://mirror.centos.org/altarch/${OS_VERSION}/centosplus/${ARCH}/"
 
-GPG_KEY_ARCH_URL="http://mirror.centos.org/altarch/7/os/ppc64le/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le"
+GPG_KEY_ARCH_URL="https://raw.githubusercontent.com/CentOS/sig-core-AltArch/master/centos-release-repo/centos-release-7/ppc/RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le"
 
 GPG_KEY_ARCH_FILE="RPM-GPG-KEY-CentOS-SIG-AltArch-7-ppc64le"


### PR DESCRIPTION
#2676: fixing centos gpg key url for ppc64le