### PR TITLE
runtime: update .gitignore to ignore monitor_address file

### DIFF
--- a/src/runtime/.gitignore
+++ b/src/runtime/.gitignore
@@ -8,7 +8,7 @@ coverage.html
 /config/*.toml
 config-generated.go
 /containerd-shim-kata-v2
-/cmd/containerd-shim-v2/monitor_address
+/pkg/containerd-shim-v2/monitor_address
 /data/kata-collect-data.sh
 /kata-monitor
 /kata-netmon


### PR DESCRIPTION
Run tests sometimes generate pkg/containerd-shim-v2/monitor_address,
and `git status` will treat it as a new file.

Package containerd-shim-v2 has moved to pkg/containerd-shim-v2,
the monitor_address in .gitignore should be updated too.

Fixes: #2762

Signed-off-by: bin <bin@hyper.sh>