### PR TITLE
runtime: Fix !x86 static checks

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
@@ -57,51 +57,51 @@ func TestArchKernelParamHandler(t *testing.T) {
 	assert := assert.New(t)
 
 	type testData struct {
-		onVMM        bool
-		expectIgnore bool
 		fields       logrus.Fields
 		msg          string
+		onVMM        bool
+		expectIgnore bool
 	}
 
 	data := []testData{
-		{true, false, logrus.Fields{}, ""},
-		{false, false, logrus.Fields{}, ""},
+		{logrus.Fields{}, "", true, false},
+		{logrus.Fields{}, "", false, false},
 
 		{
-			false,
-			false,
 			logrus.Fields{
 				// wrong type
 				"parameter": 123,
 			},
 			"foo",
+			false,
+			false,
 		},
 
 		{
-			false,
-			false,
 			logrus.Fields{
 				"parameter": "unrestricted_guest",
 			},
 			"",
+			false,
+			false,
 		},
 
 		{
-			true,
-			true,
 			logrus.Fields{
 				"parameter": "unrestricted_guest",
 			},
 			"",
+			true,
+			true,
 		},
 
 		{
-			false,
-			true,
 			logrus.Fields{
 				"parameter": "nested",
 			},
 			"",
+			false,
+			true,
 		},
 	}
 

--- a/src/runtime/virtcontainers/hypervisor_arm64.go
+++ b/src/runtime/virtcontainers/hypervisor_arm64.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2021 Arm Ltd.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package virtcontainers
+
+//Returns pefProtection if the firmware directory exists
+func availableGuestProtection() (guestProtection, error) {
+	return noneProtection, nil
+}

--- a/src/runtime/virtcontainers/hypervisor_arm64_test.go
+++ b/src/runtime/virtcontainers/hypervisor_arm64_test.go
@@ -26,3 +26,10 @@ func TestRunningOnVMM(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(expectedOutput, running)
 }
+
+func TestAvailableGuestProtection(t *testing.T) {
+	assert := assert.New(t)
+
+	out, _ := availableGuestProtection()
+	assert.Equal(out, noneProtection)
+}

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -158,19 +158,23 @@ const (
 
 	//Intel Trust Domain Extensions
 	//https://software.intel.com/content/www/us/en/develop/articles/intel-trust-domain-extensions.html
-	tdxProtection
+	// Exclude from lint checking for it won't be used on arm64 code
+	tdxProtection //nolint
 
 	// AMD Secure Encrypted Virtualization
 	// https://developer.amd.com/sev/
-	sevProtection
+	// Exclude from lint checking for it won't be used on arm64 code
+	sevProtection //nolint
 
 	// IBM POWER 9 Protected Execution Facility
 	// https://www.kernel.org/doc/html/latest/powerpc/ultravisor.html
-	pefProtection
+	// Exclude from lint checking for it won't be used on arm64 code
+	pefProtection //nolint
 
 	// IBM Secure Execution (IBM Z & LinuxONE)
 	// https://www.kernel.org/doc/html/latest/virt/kvm/s390-pv.html
-	seProtection
+	// Exclude from lint checking for it won't be used on arm64 code
+	seProtection //nolint
 )
 
 type qemuArchBase struct {

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -183,11 +183,12 @@ type qemuArchBase struct {
 	Bridges              []types.Bridge
 	memoryOffset         uint64
 	networkIndex         int
-	protection           guestProtection
-	nestedRun            bool
-	vhost                bool
-	disableNvdimm        bool
-	dax                  bool
+	// Exclude from lint checking for it is ultimately only used in architecture-specific code
+	protection    guestProtection //nolint:structcheck
+	nestedRun     bool
+	vhost         bool
+	disableNvdimm bool
+	dax           bool
 }
 
 const (

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -105,14 +105,11 @@ func TestQemuArm64AppendImage(t *testing.T) {
 	imageStat, err := f.Stat()
 	assert.NoError(err)
 
-	// save default supportedQemuMachines options
-	machinesCopy := make([]govmmQemu.Machine, len(supportedQemuMachines))
-	assert.Equal(len(supportedQemuMachines), copy(machinesCopy, supportedQemuMachines))
-
 	cfg := qemuConfig(QemuVirt)
 	cfg.ImagePath = f.Name()
-	arm64 := newQemuArch(cfg)
-	assert.Contains(m.machine().Options, qemuNvdimmOption)
+	arm64, err := newQemuArch(cfg)
+	assert.NoError(err)
+	assert.Contains(arm64.machine().Options, qemuNvdimmOption)
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.Object{
@@ -128,9 +125,6 @@ func TestQemuArm64AppendImage(t *testing.T) {
 	devices, err = arm64.appendImage(context.Background(), devices, f.Name())
 	assert.NoError(err)
 	assert.Equal(expectedOut, devices)
-
-	//restore default supportedQemuMachines options
-	assert.Equal(len(supportedQemuMachines), copy(supportedQemuMachines, machinesCopy))
 }
 
 func TestQemuArm64AppendNvdimmImage(t *testing.T) {
@@ -171,7 +165,8 @@ func TestQemuArm64WithInitrd(t *testing.T) {
 
 	cfg := qemuConfig(QemuVirt)
 	cfg.InitrdPath = "dummy-initrd"
-	arm64 := newQemuArch(cfg)
+	arm64, err := newQemuArch(cfg)
+	assert.NoError(err)
 
-	assert.NotContains(m.machine().Options, qemuNvdimmOption)
+	assert.NotContains(arm64.machine().Options, qemuNvdimmOption)
 }

--- a/src/runtime/virtcontainers/utils/utils_linux_ppc64le.go
+++ b/src/runtime/virtcontainers/utils/utils_linux_ppc64le.go
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+//nolint:deadcode,unused
 package utils
 
 // from <linux/vhost.h>


### PR DESCRIPTION
Follow-up of #2237 for s390x -- field alignment isn't always minimal

Depends-on: github.com/kata-containers/tests#4047
Fixes: #2773
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>