### PR TITLE
ci: Test-PR[DNM]

### DIFF
--- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
@@ -31,6 +31,7 @@ func TestQemuPPC64leCPUModel(t *testing.T) {
 	assert.Equal(expectedOut, model)
 }
 
+//Testing guest protection
 func TestQemuPPC64leMemoryTopology(t *testing.T) {
 	assert := assert.New(t)
 	ppc64le := newTestQemu(assert, QemuPseries)


### PR DESCRIPTION
After the recent enablement of static checks on non-x86,
every PR has to adhere to the patch format.

Fixes: #2735

Signed-off-by: Amulya Meka <amulmek1@in.ibm.com>