### PR TITLE
stable-2.2 | fc: fix version parsing for fc >= 0.25

### DIFF
--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -280,10 +280,18 @@ func (fc *firecracker) getVersionNumber() (string, error) {
 		return "", fmt.Errorf("Running checking FC version command failed: %v", err)
 	}
 
+	return fc.parseVersion(string(data))
+}
+
+func (fc *firecracker) parseVersion(data string) (string, error) {
+	// Firecracker versions 0.25 and over contains multiline output on "version" command.
+	// So we have to check it and use first line of output to parse version.
+	lines := strings.Split(data, "\n")
+
 	var version string
-	fields := strings.Split(string(data), " ")
+	fields := strings.Split(lines[0], " ")
 	if len(fields) > 1 {
-		// The output format of `Firecracker --verion` is as follows
+		// The output format of `Firecracker --version` is as follows
 		// Firecracker v0.23.1
 		version = strings.TrimPrefix(strings.TrimSpace(fields[1]), "v")
 		return version, nil

--- a/src/runtime/virtcontainers/fc_test.go
+++ b/src/runtime/virtcontainers/fc_test.go
@@ -52,3 +52,15 @@ func TestRevertBytes(t *testing.T) {
 	num := revertBytes(testNum)
 	assert.Equal(expectedNum, num)
 }
+
+func TestFCParseVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+
+	for rawVersion, v := range map[string]string{"Firecracker v0.23.1": "0.23.1", "Firecracker v0.25.0\nSupported snapshot data format versions: 0.23.0": "0.25.0"} {
+		parsedVersion, err := fc.parseVersion(rawVersion)
+		assert.NoError(err)
+		assert.Equal(parsedVersion, v)
+	}
+}


### PR DESCRIPTION
Allows to use firecracker version >=0.25.

Fixes: #2471
Backports: #2466 

Signed-off-by: Bl1tz23 <alex3angle@gmail.com>
(cherry picked from commit 87bbae1bd7d2563d39a47a125e9f4a7609caf5ad)