### PR TITLE
runtime: don't start shim management server in tests

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/utils_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/utils_test.go
@@ -125,6 +125,10 @@ func init() {
 	}
 
 	tc = ktu.NewTestConstraint(false)
+
+	// disable shim management server.
+	// all tests are not using this, so just set it to nil
+	defaultStartManagementServerFunc = nil
 }
 
 // createOCIConfig creates an OCI configuration (spec) file in


### PR DESCRIPTION
Shim management server is running in a go routine, in test mode
this will cause the directory where the listen socket
file(/run/vc/sbs/777-77-77777777/shim-monitor.sock) in leak
after the tests finished.

Fixes: #2805

Signed-off-by: bin <bin@hyper.sh>