### PR TITLE
runtime: change name in config settings back to "kata"

### DIFF
--- a/src/runtime/pkg/katautils/logger.go
+++ b/src/runtime/pkg/katautils/logger.go
@@ -20,6 +20,9 @@ import (
 var originalLoggerLevel = logrus.WarnLevel
 var kataUtilsLogger = logrus.NewEntry(logrus.New())
 
+// SYSLOGTAG is for a consistently named syslog identifier
+const SYSLOGTAG = "kata"
+
 // SetLogger sets the logger for the factory.
 func SetLogger(ctx context.Context, logger *logrus.Entry, level logrus.Level) {
 	fields := logrus.Fields{
@@ -61,7 +64,7 @@ func (h *sysLogHook) Fire(e *logrus.Entry) (err error) {
 }
 
 func newSystemLogHook(network, raddr string) (*sysLogHook, error) {
-	hook, err := lSyslog.NewSyslogHook(network, raddr, syslog.LOG_INFO, NAME)
+	hook, err := lSyslog.NewSyslogHook(network, raddr, syslog.LOG_INFO, SYSLOGTAG)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The variable for 'name' in config-settings.go.in was previously
hardcoded as "kata". In e7c42fb it was changed to the name of the
runtime "kata-runtime". Revert to "kata" since some tests depend on
systemd journal logs with kata as the SYSLOG_IDENTIFIER.

Fixes #2806

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>