### PR TITLE
clh: Refine the usage of guest console and kernel parameters with Cloud Hypervisor 

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -257,6 +257,9 @@ func (clh *cloudHypervisor) createSandbox(ctx context.Context, id string, networ
 	// Followed by extra debug parameters if debug enabled in configuration file
 	if clh.config.Debug {
 		params = append(params, clhDebugKernelParams...)
+	} else {
+		// start the guest kernel with 'quiet' in non-debug mode
+		params = append(params, Param{"quiet", ""})
 	}
 
 	// Followed by extra kernel parameters defined in the configuration file


### PR DESCRIPTION
### virtcontainers: clh: Turn-off serial and virtio-console by default

We will need to have console output from the guest only for debugging
purposes. As a result, we can turn-off both the serial and
virtio-console devices by default for better boot time.

### virtcontainers: clh: Use 'quiet' as the default kernel parameter

The 'quiet' kernel parameter can avoid guest kernel logs while booting,
which can reduce boot time.

Fix: #2820

Signed-off-by: Bo Chen <chen.bo@intel.com>