### PR TITLE
osbuilder/scripts: fix yq 2.x failed to get rust version in yaml

### DIFF
--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -346,10 +346,10 @@ get_package_version_from_kata_yaml()
 		source "$yq_file"
 	fi
 
-    yq_version=$($yq -V)
+    yq_version=$($yq -V 2>&1)
     case $yq_version in
     *"version "[1-3]*)
-        yq_args="r -X - ${yq_path}"
+        yq_args="r - ${yq_path}"
         ;;
     *)
         yq_args="e .${yq_path} -"


### PR DESCRIPTION
yq 2.x version not support -X flag in read command, so remove it.

Fixes: #2824

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>