### PR TITLE
use-cases: clarify SPDK vhost-user-nvme target status in using-spdk-v…

### DIFF
--- a/docs/use-cases/using-SPDK-vhostuser-and-kata.md
+++ b/docs/use-cases/using-SPDK-vhostuser-and-kata.md
@@ -104,7 +104,7 @@ devices:
 
 - `vhost-user-blk`
 - `vhost-user-scsi`
-- `vhost-user-nvme`
+- `vhost-user-nvme` (deprecated from SPDK 21.07 release)
 
 For more information, visit [SPDK](https://spdk.io) and [SPDK vhost-user target](https://spdk.io/doc/vhost.html).
 


### PR DESCRIPTION
…host-user

SPDK vhost-user-nvme target is removed from SPDK 21.07 release since
upstreamed QEMU version does not support.

Fixes #3371 

Signed-off-by: Ziye Yang <ziye.yang@intel.com>