### PR TITLE
kata-deploy: add .dockerignore file

### DIFF
--- a/tools/packaging/kata-deploy/.dockerignore
+++ b/tools/packaging/kata-deploy/.dockerignore
@@ -1,0 +1,1 @@
+local-build


### PR DESCRIPTION
.dockerignore file is similar to .gitignore and serves the purpose to
simply ignore paths in the build context.

For now, let me just use it to fix the following problem:
```
docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz .
error checking context: 'no permission to read from '/home/fidencio/go/src/github.com/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/firecracker/builddir/firecracker/build/cargo_registry/src/github.com-1ecc6299db9ec823/crc64-1.0.0/.gitignore''.
```

Fixes: #2845

Signed-off-by: Fabiano Fidêncio <fabiano@fidencio.org>