### PR TITLE
tracing: Fix typo in "package" tag name

### DIFF
--- a/src/runtime/virtcontainers/api.go
+++ b/src/runtime/virtcontainers/api.go
@@ -21,7 +21,7 @@ import (
 // apiTracingTags defines tags for the trace span
 var apiTracingTags = map[string]string{
 	"source":    "runtime",
-	"packages":  "virtcontainers",
+	"package":   "virtcontainers",
 	"subsystem": "api",
 }
 


### PR DESCRIPTION
The tracing tags for api.go contain `"packages"` as a tag name,
whereas all other tags contain `"package"`.

Fixes: #2847

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>