### PR TITLE
osbuilder: Call detect_rust_version() right before install_rust.sh

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -552,7 +552,13 @@ EOT
 		fi
 		[ "$LIBC" == "musl" ] && bash ${script_dir}/../../../ci/install_musl.sh
 		# rust agent needs ${arch}-unknown-linux-${LIBC}
-		rustup show | grep linux-${LIBC} > /dev/null || bash ${script_dir}/../../../ci/install_rust.sh ${RUST_VERSION}
+		if ! (rustup show | grep -v linux-${LIBC} > /dev/null); then
+			if [ "$RUST_VERSION" == "null" ]; then
+				detect_rust_version || \
+					die "Could not detect the required rust version for AGENT_VERSION='${AGENT_VERSION:-main}'."
+			fi
+			bash ${script_dir}/../../../ci/install_rust.sh ${RUST_VERSION}
+		fi
 		test -r "${HOME}/.cargo/env" && source "${HOME}/.cargo/env"
 		[ "$ARCH" == "aarch64" ] && OLD_PATH=$PATH && export PATH=$PATH:/usr/local/musl/bin
 


### PR DESCRIPTION
When building with dracut method the build_rootfs_distro() is not called, in turn
detect_rust_version() isn't either, so the install_rust.sh script is gave a null
rust version. This changed the script to call detect_rust_version() right before
install_rust.sh.

Related to commit: f34f67d610146cb954
Fixes #2862
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>