### PR TITLE
runtime: delete cri containerd plugin from versions.yaml

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -179,16 +179,6 @@ externals:
     url: "https://github.com/cri-o/cri-o"
     branch: "release-1.21"
 
-  cri-containerd:
-    description: |
-      Containerd Plugin for Kubernetes Container Runtime Interface.
-    url: "github.com/containerd/containerd"
-    tarball_url: "https://github.com/containerd/containerd/releases/download"
-    # containerd from v1.5.0 used the path unix socket
-    # instead of abstract socket, thus kata wouldn's support the containerd's
-    # version older than them.
-    version: "v1.5.2"
-
   containerd:
     description: |
       Containerd for Kubernetes Container Runtime Interface.


### PR DESCRIPTION
Delete cri containerd plugin from versions.yaml.

This is the last step of deleting cri containerd.

The first two have been merged:
- https://github.com/kata-containers/kata-containers/issues/2791
- https://github.com/kata-containers/tests/issues/4061

Fixes: #2791

Signed-off-by: bin <bin@hyper.sh>