### PR TITLE
packaging/static-build: s390x fixes

### DIFF
--- a/tools/packaging/static-build/kernel/Dockerfile
+++ b/tools/packaging/static-build/kernel/Dockerfile
@@ -15,4 +15,6 @@ RUN apt install -y \
 	    flex \
 	    git \
 	    iptables \
-	    libelf-dev \
+	    libelf-dev
+
+RUN [ "$(uname -m)" = "s390x" ] && apt-get install -y libssl-dev || true

--- a/tools/packaging/static-build/qemu.blacklist
+++ b/tools/packaging/static-build/qemu.blacklist
@@ -16,7 +16,6 @@ qemu_black_list=(
 */share/*/efi-rtl8139.rom
 */share/*/efi-vmxnet3.rom
 */share/*/icons
-*/share/*/*.img
 */share/*/keymaps
 */share/*/multiboot.bin
 */share/*/npcm7xx_bootrom.bin

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -36,7 +36,6 @@ RUN apt-get --no-install-recommends install -y \
 	    libltdl-dev \
 	    libmount-dev \
 	    libpixman-1-dev \
-	    libpmem-dev \
 	    libselinux1-dev \
 	    libtool \
 	    make \
@@ -48,6 +47,8 @@ RUN apt-get --no-install-recommends install -y \
 	    python-dev \
 	    rsync \
 	    zlib1g-dev
+
+RUN [ "$(uname -m)" != "s390x" ] && apt-get install -y libpmem-dev || true
 
 ARG QEMU_REPO
 


### PR DESCRIPTION
- Install OpenSSL for key generation in kernel build
- Do not install libpmem
- Do not exclude `*/share/*/*.img` files in QEMU tarball since among
  them are boot loader files critical for IPLing.

Fixes: #2895
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>