### PR TITLE
virtcontainers: delete duplicated notify in watchHypervisor function

### DIFF
--- a/src/runtime/virtcontainers/monitor.go
+++ b/src/runtime/virtcontainers/monitor.go
@@ -142,7 +142,6 @@ func (m *monitor) watchAgent(ctx context.Context) {
 func (m *monitor) watchHypervisor(ctx context.Context) error {
 	if err := m.sandbox.hypervisor.Check(); err != nil {
 		m.notify(ctx, errors.Wrapf(err, "failed to ping hypervisor process"))
-		m.notify(ctx, errors.Wrapf(err, "failed to ping Hypervisor process"))
 		return err
 	}
 	return nil


### PR DESCRIPTION
When hypervisor check failed, the notify function is called twice.

Fixes: #2901

Signed-off-by: bin <bin@hyper.sh>