### PR TITLE
osbuilder: Build attestation-agent and friends

### DIFF
--- a/docs/how-to/ccv0.sh
+++ b/docs/how-to/ccv0.sh
@@ -230,18 +230,7 @@ create_a_local_rootfs() {
     cd ${katacontainers_repo_dir}/tools/osbuilder/rootfs-builder
     export distro="ubuntu"
     [[ -z "${USE_PODMAN:-}" ]] && use_docker="${use_docker:-1}"
-    sudo -E OS_VERSION="${OS_VERSION:-}" GOPATH=$GOPATH EXTRA_PKGS="ca-certificates vim iputils-ping net-tools gnupg libgpgme-dev" DEBUG="${DEBUG}" USE_DOCKER="${use_docker:-}" SECCOMP=yes ./rootfs.sh -r ${ROOTFS_DIR} ${distro}
-
-    # Build and add skopeo binary - TODO LATER replace with install from Ubuntu when the base is 20.10+, or 
-    git clone --branch release-1.4 https://github.com/containers/skopeo ${GOPATH}/src/github.com/containers/skopeo
-    cd ${GOPATH}/src/github.com/containers/skopeo && make bin/skopeo
-    cp "${GOPATH}/src/github.com/containers/skopeo/bin/skopeo" "${ROOTFS_DIR}/usr/bin/skopeo"
-
-    # Add umoci binary - TODO LATER replace with install from Ubuntu when the base is 20.10+
-    go_arch=$("${tests_repo_dir}"/.ci/kata-arch.sh -g)
-    mkdir -p ${ROOTFS_DIR}/usr/local/bin/
-    sudo curl -Lo ${ROOTFS_DIR}/usr/local/bin/umoci https://github.com/opencontainers/umoci/releases/download/v0.4.7/umoci.${go_arch}
-    sudo chmod u+x ${ROOTFS_DIR}/usr/local/bin/umoci
+    sudo -E OS_VERSION="${OS_VERSION:-}" GOPATH=$GOPATH DEBUG="${DEBUG}" USE_DOCKER="${use_docker:-}" SKOPEO_UMOCI=yes SECCOMP=yes ./rootfs.sh -r ${ROOTFS_DIR} ${distro}
 
     # During the ./rootfs.sh call the kata agent is built as root, so we need to update the permissions, so we can rebuild it
     sudo chown -R ${USER}:${USER} "${katacontainers_repo_dir}/src/agent/"

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
@@ -28,10 +28,15 @@ RUN apt-get update && apt-get install -y \
     g++ \
     gcc \
     git \
+    golang-go \
+    libdevmapper-dev \
     libc6-dev \
+    libgpgme-dev \
+    libssl-dev \
     libstdc++-8-dev \
     m4 \
     make \
+    pkg-config \
     sed \
     systemd \
     tar \

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -27,13 +27,18 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
     g++ \
     gcc \
     git \
+    golang-go \
+    libdevmapper-dev \
     libc6-dev \
+    libgpgme-dev \
+    libssl-dev \
     libstdc++-8-dev \
     m4 \
     make \
     musl \
     musl-dev \
     musl-tools \
+    pkg-config \
     protobuf-compiler \
     sed \
     systemd \

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -32,3 +32,4 @@ INIT_PROCESS=systemd
 ARCH_EXCLUDE_LIST=()
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2" || true
+[ -n "$SKOPEO_UMOCI" ] && PACKAGES+=" ca-certificates libgpgme11" || true

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -219,6 +219,25 @@ ${extra}
 	  agent-is-init-daemon: "${AGENT_INIT}"
 EOT
 
+	if [ "${SKOPEO_UMOCI}" = "yes" ]; then
+		cat >> "${file}" <<-EOF
+	skopeo:
+	  url: "${skopeo_url}"
+	  version: "${skopeo_branch}"
+	umoci:
+	  url: "${umoci_url}"
+	  version: "${umoci_tag}"
+EOF
+	fi
+
+	if [ -n "${AA_KBC}" ]; then
+		cat >> "${file}" <<-EOF
+	attestation-agent:
+	  url: "${attestation_agent_url}"
+	  kbc: "${AA_KBC}"
+EOF
+	fi
+
 	local rootfs_file="${file_dir}/$(basename "${file}")"
 	info "Created summary file '${rootfs_file}' inside rootfs"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -163,6 +163,11 @@ assets:
 externals:
   description: "Third-party projects used by the system"
 
+  attestation-agent:
+    description: "Provide attested key unwrapping for image decryption"
+    url: "https://github.com/confidential-containers/attestation-agent"
+    branch: "main"
+
   cni-plugins:
     description: "CNI network plugins"
     url: "https://github.com/containernetworking/plugins"
@@ -226,6 +231,16 @@ externals:
       https://github.com/opencontainers/runc/tags
       .*/v?(\d\S+)\.tar\.gz
     version: "v1.0.1"
+
+  skopeo:
+    description: "Utility for container images and image repositories"
+    url: "https://github.com/containers/skopeo"
+    branch: "release-1.4"
+
+  umoci:
+    description: "Utility for creating and manipulating container images"
+    url: "https://github.com/opencontainers/umoci"
+    tag: "v0.4.7"
 
   musl:
     description: |


### PR DESCRIPTION
When the environment variable $AA_KBC is set, skopeo, umoci, and
attestation-agent (with that KBC) are built inside the guest build
container and installed to the guest rootfs. The respective build- and
runtime dependencies are added. This respects the (existing) $LIBC
variable (gnu/musl) and avoids issues with glibc mismatches. (musl
depends on https://github.com/containers/attestation-agent/pull/20)
At this time, only Ubuntu is supported, due to issues with building
Golang applications on Fedora/CentOS.

Fixes: #2907
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @sameo @fitzthum @davidhay1969 @bpradipt