### PR TITLE
CCv0: Attestation Agent Integration

### DIFF
--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -83,6 +83,7 @@ pub struct AgentConfig {
     pub endpoints: AgentEndpoints,
     pub supports_seccomp: bool,
     pub container_policy_path: String,
+    pub aa_kbc_params: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -99,6 +100,7 @@ pub struct AgentConfigBuilder {
     pub tracing: Option<bool>,
     pub endpoints: Option<EndpointsConfig>,
     pub container_policy_path: Option<String>,
+    pub aa_kbc_params: Option<String>,
 }
 
 macro_rules! config_override {
@@ -161,6 +163,7 @@ impl Default for AgentConfig {
             endpoints: Default::default(),
             supports_seccomp: rpc::have_seccomp(),
             container_policy_path: String::from(""),
+            aa_kbc_params: String::from(""),
         }
     }
 }
@@ -190,6 +193,7 @@ impl FromStr for AgentConfig {
         config_override!(agent_config_builder, agent_config, unified_cgroup_hierarchy);
         config_override!(agent_config_builder, agent_config, tracing);
         config_override!(agent_config_builder, agent_config, container_policy_path);
+        config_override!(agent_config_builder, agent_config, aa_kbc_params);
 
         // Populate the allowed endpoints hash set, if we got any from the config file.
         if let Some(endpoints) = agent_config_builder.endpoints {


### PR DESCRIPTION
Use the Attestation Agent as a keyprovider for Skopeo/ocicrypt when we pull the container from inside the guest. This requires starting the Attestation Agent, creating an ocicrypt config file, and amending the arguments of the skopeo copy command.