### PR TITLE
agent-ctl: Update for Hybrid VSOCK

### DIFF
--- a/src/trace-forwarder/README.md
+++ b/src/trace-forwarder/README.md
@@ -120,7 +120,7 @@ forwarder.
 
 ```bash
 $ sandbox_id="foo"
-$ socket_path=$(echo "$socket_path_template" | sed "s/{ID}/${sandbox_id}/g")
+$ socket_path=$(echo "$socket_path_template" | sed "s/{ID}/${sandbox_id}/g" | tr -d '"')
 $ sudo mkdir -p $(dirname "$socket_path")
 ```
 

--- a/tools/agent-ctl/Makefile
+++ b/tools/agent-ctl/Makefile
@@ -19,6 +19,7 @@ vendor:
 test:
 
 install:
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --target $(TRIPLE) --path .
 
 check:
 

--- a/tools/agent-ctl/src/client.rs
+++ b/tools/agent-ctl/src/client.rs
@@ -89,6 +89,11 @@ static AGENT_CMDS: &'static [AgentCmd] = &[
         fp: agent_cmd_sandbox_add_arp_neighbors,
     },
     AgentCmd {
+        name: "AddSwap",
+        st: ServiceType::Agent,
+        fp: agent_cmd_sandbox_add_swap,
+    },
+    AgentCmd {
         name: "Check",
         st: ServiceType::Health,
         fp: agent_cmd_health_check,
@@ -1991,4 +1996,30 @@ fn get_repeat_count(cmdline: &str) -> i64 {
         Ok(n) => return n,
         Err(_) => return default_repeat_count,
     }
+}
+
+fn agent_cmd_sandbox_add_swap(
+    ctx: &Context,
+    client: &AgentServiceClient,
+    _health: &HealthClient,
+    _options: &mut Options,
+    _args: &str,
+) -> Result<()> {
+    let req = AddSwapRequest::default();
+
+    let ctx = clone_context(ctx);
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
+    let reply = client
+        .add_swap(ctx, &req)
+        .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
+
+    // FIXME: Implement 'AddSwap' fully.
+    eprintln!("FIXME: 'AddSwap' not fully implemented");
+
+    info!(sl!(), "response received";
+        "response" => format!("{:?}", reply));
+
+    Ok(())
 }

--- a/tools/agent-ctl/src/client.rs
+++ b/tools/agent-ctl/src/client.rs
@@ -88,6 +88,11 @@ static AGENT_CMDS: &'static [AgentCmd] = &[
         fp: agent_cmd_sandbox_add_arp_neighbors,
     },
     AgentCmd {
+        name: "AddSwap",
+        st: ServiceType::Agent,
+        fp: agent_cmd_sandbox_add_swap,
+    },
+    AgentCmd {
         name: "Check",
         st: ServiceType::Health,
         fp: agent_cmd_health_check,
@@ -1917,4 +1922,30 @@ fn get_repeat_count(cmdline: &str) -> i64 {
         Ok(n) => return n,
         Err(_) => return default_repeat_count,
     }
+}
+
+fn agent_cmd_sandbox_add_swap(
+    ctx: &Context,
+    client: &AgentServiceClient,
+    _health: &HealthClient,
+    _options: &mut Options,
+    _args: &str,
+) -> Result<()> {
+    let req = AddSwapRequest::default();
+
+    let ctx = clone_context(ctx);
+
+    debug!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
+    let reply = client
+        .add_swap(ctx, &req)
+        .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
+
+    // FIXME: Implement 'AddSwap' fully.
+    eprintln!("FIXME: 'AddSwap' not fully implemented");
+
+    info!(sl!(), "response received";
+        "response" => format!("{:?}", reply));
+
+    Ok(())
 }

--- a/tools/agent-ctl/src/rpc.rs
+++ b/tools/agent-ctl/src/rpc.rs
@@ -11,25 +11,9 @@ use slog::{o, Logger};
 use crate::client::client;
 use crate::types::Config;
 
-pub fn run(
-    logger: &Logger,
-    server_address: &str,
-    bundle_dir: &str,
-    interactive: bool,
-    ignore_errors: bool,
-    timeout_nano: i64,
-    commands: Vec<&str>,
-) -> Result<()> {
-    let cfg = Config {
-        server_address: server_address.to_string(),
-        bundle_dir: bundle_dir.to_string(),
-        timeout_nano: timeout_nano,
-        interactive: interactive,
-        ignore_errors: ignore_errors,
-    };
-
+pub fn run(logger: &Logger, cfg: &Config, commands: Vec<&str>) -> Result<()> {
     // Maintain the global logger for the duration of the ttRPC comms
     let _guard = slog_scope::set_global_logger(logger.new(o!("subsystem" => "rpc")));
 
-    client(&cfg, commands)
+    client(cfg, commands)
 }

--- a/tools/agent-ctl/src/types.rs
+++ b/tools/agent-ctl/src/types.rs
@@ -14,6 +14,8 @@ pub struct Config {
     pub server_address: String,
     pub bundle_dir: String,
     pub timeout_nano: i64,
+    pub hybrid_vsock_port: u64,
     pub interactive: bool,
+    pub hybrid_vsock: bool,
     pub ignore_errors: bool,
 }


### PR DESCRIPTION
Allow the `agent-ctl` tool to connect to a Hybrid VSOCK hypervisor such
as Cloud Hypervisor or Firecracker.

Fixes: #2914.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>