### PR TITLE
release: Upload libseccomp sources with notice to release page

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -149,3 +149,30 @@ jobs:
           tar -cvzf "${tarball}" src/agent/.cargo/config src/agent/vendor
           GITHUB_TOKEN=${{ secrets.GIT_UPLOAD_TOKEN }} hub release edit -m "" -a "${tarball}" "${tag}" 
           popd
+
+  upload-libseccomp-tarball:
+    needs: upload-cargo-vendored-tarball
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: download-and-upload-tarball
+        env:
+          GITHUB_TOKEN: ${{ secrets.GIT_UPLOAD_TOKEN }}
+        run: |
+          pushd $GITHUB_WORKSPACE
+          ./ci/install_yq.sh
+          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+          versions_yaml="versions.yaml"
+          version=$(yq read ${versions_yaml} "externals.libseccomp.version")
+          repo_url=$(yq read ${versions_yaml} "externals.libseccomp.url")
+          download_url="${repo_url}/releases/download/v${version}"
+          tarball="libseccomp-${version}.tar.gz"
+          asc="${tarball}.asc"
+          curl -sSLO "${download_url}/${tarball}"
+          curl -sSLO "${download_url}/${asc}"
+          # "-m" option should be empty to re-use the existing release title
+          # without opening a text editor.
+          # For the details, check https://hub.github.com/hub-release.1.html.
+          hub release edit -m "" -a "${tarball}" "${tag}"
+          hub release edit -m "" -a "${asc}" "${tag}"
+          popd

--- a/tools/packaging/release/release-notes.sh
+++ b/tools/packaging/release/release-notes.sh
@@ -53,6 +53,9 @@ get_release_info() {
 	kubernetes_version=$(get_from_kata_deps "externals.kubernetes.version")
 	oci_spec_version=$(get_from_kata_deps "specs.oci.version")
 
+	libseccomp_version=$(get_from_kata_deps "externals.libseccomp.version")
+	libseccomp_url=$(get_from_kata_deps "externals.libseccomp.url")
+
 	#Image information
 	image_info=$(get_from_kata_deps "assets.image")
 
@@ -110,6 +113,19 @@ Kata Containers ${runtime_version} support the OCI Runtime Specification [${oci_
 ## Compatibility with Kubernetes
 Kata Containers ${runtime_version} is compatible with Kubernetes ${kubernetes_version}
 
+## Libseccomp Notices
+The `kata-agent` binaries inside the Kata Containers images provided with this release are
+statically linked with the following [GNU LGPL-2.1][lgpl-2.1] licensed libseccomp library.
+
+* [`libseccomp`][libseccomp]
+
+The `kata-agent` uses the libseccomp v${libseccomp_version} which is not modified from the upstream version.
+However, in order to comply with the LGPL-2.1 (§6(a)), we attach the complete source code for the library.
+
+If you want to use the `kata-agent` which is not statically linked with the library, you can build
+a custom `kata-agent` that does not use the library from sources.
+For the details, please check the [developer guide][custom-agent-doc].
+
 ## Kata Linux Containers image
 Agent version: ${new_release}
 
@@ -136,6 +152,9 @@ More information [Limitations][limitations]
 [kernel-patches]: https://github.com/kata-containers/kata-containers/tree/${new_release}/tools/packaging/kernel/patches
 [kernel-config]: https://github.com/kata-containers/kata-containers/tree/${new_release}/tools/packaging/kernel/configs
 [ocispec]: https://github.com/opencontainers/runtime-spec/releases/tag/${oci_spec_version}
+[libseccomp]: ${libseccomp_url}
+[lgpl-2.1]: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
+[custom-agent-doc]: https://github.com/kata-containers/kata-containers/blob/main/docs/Developer-Guide.md#build-a-custom-kata-agent---optional
 [limitations]: https://github.com/kata-containers/kata-containers/blob/${new_release}/docs/Limitations.md
 [installation]: https://github.com/kata-containers/kata-containers/blob/${new_release}/docs/install
 EOT


### PR DESCRIPTION
The `kata-agent` binaries inside the Kata Containers images provided
with release are statically linked with the GNU LGPL-2.1 licensed
libseccomp library by default.
Therefore, we attach the complete source code of the libseccomp
to the release page in order to comply with the LGPL-2.1 (6(a)).
In addition, we add the description about the libseccomp license
to the release page.

Fixes: #2922

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>