### PR TITLE
runtime: Remove comments about unsupported features in config for clh

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -105,8 +105,7 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
 # Block storage driver to be used for the hypervisor in case the container
-# rootfs is backed by a block device. This is virtio-scsi, virtio-blk
-# or nvdimm.
+# rootfs is backed by a block device. This is virtio-blk.
 block_device_driver = "virtio-blk"
 
 # Enable huge pages for VM RAM, default false


### PR DESCRIPTION
Cloud hypervisor is only supporting virtio-blk, this PR removes comments
that make a wrong reference of other features that are not supported
by clh.

Fixes #2924

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>