### PR TITLE
Update k8s SR-IOV plugin environment variables to work properly with Kata

### DIFF
--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -845,7 +845,7 @@ mod tests {
 
         spec.linux = Some(Linux::default());
 
-        // linux.devices is empty
+        // linux.devices doesn't contain the updated device
         let res = update_spec_devices(
             &mut spec,
             HashMap::from_iter(vec![(

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -511,8 +511,8 @@ fn update_spec_device(
         Ok(())
     } else {
         Err(anyhow!(
-            "Should have found a matching device {} in the spec",
-            vm_path
+            "Should have found a device {} in the spec",
+            host_path
         ))
     }
 }

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -745,7 +745,15 @@ pub async fn add_devices(
     for device in devices.iter() {
         let update = add_device(device, sandbox).await?;
         if let Some(dev_update) = update.dev {
-            dev_updates.insert(&device.container_path, dev_update);
+            if dev_updates
+                .insert(&device.container_path, dev_update)
+                .is_some()
+            {
+                return Err(anyhow!(
+                    "Conflicting device updates for {}",
+                    &device.container_path
+                ));
+            }
         }
     }
 

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -546,12 +546,10 @@ async fn virtio_blk_device_handler(
     sandbox: &Arc<Mutex<Sandbox>>,
     devidx: &DevIndex,
 ) -> Result<()> {
-    let mut dev = device.clone();
     let pcipath = pci::Path::from_str(&device.id)?;
+    let vm_path = get_virtio_blk_pci_device_name(sandbox, &pcipath).await?;
 
-    dev.vm_path = get_virtio_blk_pci_device_name(sandbox, &pcipath).await?;
-
-    update_spec_device(spec, devidx, &dev.container_path, &dev.vm_path, None)
+    update_spec_device(spec, devidx, &device.container_path, &vm_path, None)
 }
 
 // device.id should be a CCW path string
@@ -563,15 +561,14 @@ async fn virtio_blk_ccw_device_handler(
     sandbox: &Arc<Mutex<Sandbox>>,
     devidx: &DevIndex,
 ) -> Result<()> {
-    let mut dev = device.clone();
     let ccw_device = ccw::Device::from_str(&device.id)?;
-    dev.vm_path = get_virtio_blk_ccw_device_name(sandbox, &ccw_device).await?;
+    let vm_path = get_virtio_blk_ccw_device_name(sandbox, &ccw_device).await?;
     update_spec_device(
         spec,
         devidx,
-        &dev.container_path,
-        &dev.vm_path,
-        &dev.container_path,
+        &device.container_path,
+        &vm_path,
+        &device.container_path,
     )
 }
 
@@ -594,9 +591,8 @@ async fn virtio_scsi_device_handler(
     sandbox: &Arc<Mutex<Sandbox>>,
     devidx: &DevIndex,
 ) -> Result<()> {
-    let mut dev = device.clone();
-    dev.vm_path = get_scsi_device_name(sandbox, &device.id).await?;
-    update_spec_device(spec, devidx, &dev.container_path, &dev.vm_path, None)
+    let vm_path = get_scsi_device_name(sandbox, &device.id).await?;
+    update_spec_device(spec, devidx, &device.container_path, &vm_path, None)
 }
 
 #[instrument]

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -22,7 +22,7 @@ use crate::linux_abi::*;
 use crate::pci;
 use crate::sandbox::Sandbox;
 use crate::uevent::{wait_for_uevent, Uevent, UeventMatcher};
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use oci::{LinuxDeviceCgroup, LinuxResources, Spec};
 use protocols::agent::Device;
 use tracing::instrument;
@@ -484,12 +484,15 @@ impl From<DevNumUpdate> for DevUpdate {
 #[derive(Debug, Clone, Default)]
 struct SpecUpdate {
     dev: Option<DevUpdate>,
+    // optional corrections for PCI addresses
+    pci: Vec<(pci::Address, pci::Address)>,
 }
 
 impl<T: Into<DevUpdate>> From<T> for SpecUpdate {
     fn from(dev: T) -> Self {
         SpecUpdate {
             dev: Some(dev.into()),
+            pci: Vec::new(),
         }
     }
 }
@@ -583,6 +586,43 @@ fn update_spec_devices(spec: &mut Spec, mut updates: HashMap<&str, DevUpdate>) -
     Ok(())
 }
 
+// update_spec_pci PCI addresses in the OCI spec to be guest addresses
+// instead of host addresses.  It is given a map of (host address =>
+// guest address)
+#[instrument]
+fn update_spec_pci(spec: &mut Spec, updates: HashMap<pci::Address, pci::Address>) -> Result<()> {
+    // Correct PCI addresses in the environment
+    if let Some(process) = spec.process.as_mut() {
+        for envvar in process.env.iter_mut() {
+            let eqpos = envvar
+                .find('=')
+                .ok_or_else(|| anyhow!("Malformed OCI env entry {:?}", envvar))?;
+
+            let (name, eqval) = envvar.split_at(eqpos);
+            let val = &eqval[1..];
+
+            if !name.starts_with("PCIDEVICE_") {
+                continue;
+            }
+
+            let mut guest_addrs = Vec::<String>::new();
+
+            for host_addr in val.split(',') {
+                let host_addr = pci::Address::from_str(host_addr)
+                    .with_context(|| format!("Can't parse {} environment variable", name))?;
+                let guest_addr = updates
+                    .get(&host_addr)
+                    .ok_or_else(|| anyhow!("Unable to translate host PCI address {}", host_addr))?;
+                guest_addrs.push(format!("{}", guest_addr));
+            }
+
+            envvar.replace_range(eqpos + 1.., guest_addrs.join(",").as_str());
+        }
+    }
+
+    Ok(())
+}
+
 // device.Id should be the predicted device name (vda, vdb, ...)
 // device.VmPath already provides a way to send it in
 #[instrument]
@@ -668,11 +708,14 @@ fn split_vfio_option(opt: &str) -> Option<(&str, &str)> {
 //     <pcipath> is a PCI path to the device in the guest (see pci.rs)
 async fn vfio_device_handler(device: &Device, sandbox: &Arc<Mutex<Sandbox>>) -> Result<SpecUpdate> {
     let vfio_in_guest = device.field_type != DRIVER_VFIO_GK_TYPE;
+    let mut pci_fixups = Vec::<(pci::Address, pci::Address)>::new();
     let mut group = None;
 
     for opt in device.options.iter() {
-        let (_, pcipath) =
+        let (host, pcipath) =
             split_vfio_option(opt).ok_or_else(|| anyhow!("Malformed VFIO option {:?}", opt))?;
+        let host =
+            pci::Address::from_str(host).context("Bad host PCI address in VFIO option {:?}")?;
         let pcipath = pci::Path::from_str(pcipath)?;
 
         let guestdev = wait_for_pci_device(sandbox, &pcipath).await?;
@@ -698,17 +741,24 @@ async fn vfio_device_handler(device: &Device, sandbox: &Arc<Mutex<Sandbox>>) -> 
             }
 
             group = devgroup;
+
+            pci_fixups.push((host, guestdev));
         }
     }
 
-    Ok(if vfio_in_guest {
+    let dev_update = if vfio_in_guest {
         // If there are any devices at all, logic above ensures that group is not None
         let group = group.unwrap();
         let vm_path = get_vfio_device_name(sandbox, group).await?;
 
-        DevUpdate::from_vm_path(&vm_path, vm_path.clone())?.into()
+        Some(DevUpdate::from_vm_path(&vm_path, vm_path.clone())?)
     } else {
-        SpecUpdate::default()
+        None
+    };
+
+    Ok(SpecUpdate {
+        dev: dev_update,
+        pci: pci_fixups,
     })
 }
 
@@ -719,6 +769,7 @@ pub async fn add_devices(
     sandbox: &Arc<Mutex<Sandbox>>,
 ) -> Result<()> {
     let mut dev_updates = HashMap::<&str, DevUpdate>::with_capacity(devices.len());
+    let mut pci_updates = HashMap::<pci::Address, pci::Address>::new();
 
     for device in devices.iter() {
         let update = add_device(device, sandbox).await?;
@@ -731,6 +782,17 @@ pub async fn add_devices(
                     "Conflicting device updates for {}",
                     &device.container_path
                 ));
+            }
+
+            for (host, guest) in update.pci {
+                if let Some(other_guest) = pci_updates.insert(host, guest) {
+                    return Err(anyhow!(
+                        "Conflicting guest address for host device {} ({} versus {})",
+                        host,
+                        guest,
+                        other_guest
+                    ));
+                }
             }
         }
     }
@@ -802,7 +864,7 @@ pub fn update_device_cgroup(spec: &mut Spec) -> Result<()> {
 mod tests {
     use super::*;
     use crate::uevent::spawn_test_watcher;
-    use oci::Linux;
+    use oci::{Linux, Process};
     use std::iter::FromIterator;
     use tempfile::tempdir;
 
@@ -1138,6 +1200,48 @@ mod tests {
         assert_eq!(guest_major, specdevices[0].major);
         assert_eq!(guest_minor, specdevices[0].minor);
         assert_eq!(final_path, specdevices[0].path);
+    }
+
+    #[test]
+    fn test_update_spec_pci() {
+        let example_map = [
+            // Each is a host,guest pair of pci addresses
+            ("0000:1a:01.0", "0000:01:01.0"),
+            ("0000:1b:02.0", "0000:01:02.0"),
+            // This one has the same host address as guest address
+            // above, to test that we're not double-translating
+            ("0000:01:01.0", "ffff:02:1f.7"),
+        ];
+
+        let mut spec = Spec {
+            process: Some(Process {
+                env: vec![
+                    "PCIDEVICE_x=0000:1a:01.0,0000:1b:02.0".to_string(),
+                    "PCIDEVICE_y=0000:01:01.0".to_string(),
+                    "NOTAPCIDEVICE_blah=abcd:ef:01.0".to_string(),
+                ],
+                ..Process::default()
+            }),
+            ..Spec::default()
+        };
+
+        let pci_fixups = example_map
+            .iter()
+            .map(|(h, g)| {
+                (
+                    pci::Address::from_str(h).unwrap(),
+                    pci::Address::from_str(g).unwrap(),
+                )
+            })
+            .collect();
+
+        let res = update_spec_pci(&mut spec, pci_fixups);
+        assert!(res.is_ok());
+
+        let env = &spec.process.as_ref().unwrap().env;
+        assert_eq!(env[0], "PCIDEVICE_x=0000:01:01.0,0000:01:02.0");
+        assert_eq!(env[1], "PCIDEVICE_y=ffff:02:1f.7");
+        assert_eq!(env[2], "NOTAPCIDEVICE_blah=abcd:ef:01.0");
     }
 
     #[test]

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use libc::{c_uint, major, minor};
 use nix::sys::stat;
 use regex::Regex;
 use std::collections::HashMap;
@@ -450,9 +449,6 @@ fn update_spec_device(
     vm_path: &str,
     final_path: &str,
 ) -> Result<()> {
-    let major_id: c_uint;
-    let minor_id: c_uint;
-
     // If no container_path is provided, we won't be able to match and
     // update the device in the OCI spec device list. This is an error.
     if host_path.is_empty() {
@@ -470,10 +466,8 @@ fn update_spec_device(
 
     let meta = fs::metadata(vm_path)?;
     let dev_id = meta.rdev();
-    unsafe {
-        major_id = major(dev_id);
-        minor_id = minor(dev_id);
-    }
+    let major_id = stat::major(dev_id);
+    let minor_id = stat::minor(dev_id);
 
     info!(
         sl!(),

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -522,12 +522,6 @@ fn update_spec_devices(spec: &mut Spec, updates: HashMap<&str, DevUpdate>) -> Re
     }
 
     for (container_path, update) in updates {
-        // If no container_path is provided, we won't be able to match and
-        // update the device in the OCI spec device list. This is an error.
-        if container_path.is_empty() {
-            return Err(anyhow!("Container path cannot be empty for device"));
-        }
-
         info!(
             sl!(),
             "update_spec_devices() considering device";
@@ -837,20 +831,9 @@ mod tests {
         let update = DevNumUpdate::from_vm_path("");
         assert!(update.is_err());
 
-        // container_path empty
-        let container_path = "";
-        let vm_path = "/dev/null";
-        let res = update_spec_devices(
-            &mut spec,
-            HashMap::from_iter(vec![(
-                container_path,
-                DevNumUpdate::from_vm_path(vm_path).unwrap().into(),
-            )]),
-        );
-        assert!(res.is_err());
-
         // linux is empty
         let container_path = "/dev/null";
+        let vm_path = "/dev/null";
         let res = update_spec_devices(
             &mut spec,
             HashMap::from_iter(vec![(

--- a/src/agent/src/pci.rs
+++ b/src/agent/src/pci.rs
@@ -20,7 +20,7 @@ const FUNCTION_MAX: u8 = (1 << FUNCTION_BITS) - 1;
 
 // Represents a PCI function's slot (a.k.a. device) and function
 // numbers, giving its location on a single logical bus
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SlotFn(u8);
 
 impl SlotFn {
@@ -94,7 +94,7 @@ impl fmt::Display for SlotFn {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub struct Address {
     domain: u16,
     bus: u8,


### PR DESCRIPTION
The Kubernetes SR-IOV plugin communicates which virtual functions to use to container payloads via environment variables giving PCI addresses.  This works fine with traditional containers, however, with Kata the devices will probably have different PCI addresses within the VM.

Therefore we need to update the environment variables to match the guest rather than the host toplogy.

While we're working on this, make a number of cleanups to the adjustments we need to make to the OCI specification for host vs. guest differences.