### PR TITLE
runtime# make sure the "Shutdown" trace span have a correct end

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -935,6 +935,10 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (_ *
 	s.mu.Lock()
 	if len(s.containers) != 0 {
 		s.mu.Unlock()
+
+		span.End()
+		katatrace.StopTracing(s.rootCtx)
+
 		return empty, nil
 	}
 	s.mu.Unlock()


### PR DESCRIPTION
We only added span.End() in the main process of the shim2 Shutdown method.
The "Shutdown" span would keep alive, when the containers number is not 0.
This PR make sure the "Shutdown" trace span have a correct end.

Fixes: #2930

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>