### PR TITLE
ci/install_libseccomp: Fix libseccomp build and misc improvement

### DIFF
--- a/ci/install_libseccomp.sh
+++ b/ci/install_libseccomp.sh
@@ -20,6 +20,7 @@ source "${tests_repo_dir}/.ci/lib.sh"
 unset PREFIX DESTDIR
 
 arch=$(uname -m)
+workdir="$(mktemp -d --tmpdir build-libseccomp.XXXXX)"
 
 # Variables for libseccomp
 # Currently, specify the libseccomp version directly without using `versions.yaml`
@@ -58,7 +59,7 @@ die() {
 }
 
 finish() {
-    rm -rf "${libseccomp_tarball}" "libseccomp-${libseccomp_version}" "${gperf_tarball}" "gperf-${gperf_version}"
+    rm -rf "${workdir}"
 }
 
 trap finish EXIT
@@ -98,9 +99,11 @@ main() {
         die "Usage: ${0} <libseccomp-install-dir> <gperf-install-dir>"
     fi
 
+    pushd "$workdir"
     # gperf is required for building the libseccomp.
     build_and_install_gperf
     build_and_install_libseccomp
+    popd
 }
 
 main "$@"

--- a/ci/install_libseccomp.sh
+++ b/ci/install_libseccomp.sh
@@ -14,6 +14,11 @@ clone_tests_repo
 
 source "${tests_repo_dir}/.ci/lib.sh"
 
+# The following variables if set on the environment will change the behavior
+# of gperf and libseccomp configure scripts, that may lead this script to
+# fail. So let's ensure they are unset here.
+unset PREFIX DESTDIR
+
 arch=$(uname -m)
 
 # Variables for libseccomp


### PR DESCRIPTION
This PR aims to primarily fix `ci/install_libseccomp` (see #2932) which fails if the environment has the `DESTDIR` variable set. While I am here I provided a small improvement too. 