### PR TITLE
agent: "Revert agent: Disable seccomp feature on aarch64 temporarily"

### DIFF
--- a/src/agent/rustjail/Cargo.toml
+++ b/src/agent/rustjail/Cargo.toml
@@ -30,9 +30,6 @@ tokio = { version = "1.2.0", features = ["sync", "io-util", "process", "time", "
 futures = "0.3"
 async-trait = "0.1.31"
 inotify = "0.9.2"
-
-# Disable libseccomp on aarch64 temporarily in order to pass CI
-[target.'cfg(not(target_arch = "aarch64"))'.dependencies]
 libseccomp = { version = "0.1.3", optional = true }
 
 [dev-dependencies]

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -25,7 +25,7 @@ use crate::cgroups::mock::Manager as FsManager;
 use crate::cgroups::Manager;
 use crate::log_child;
 use crate::process::Process;
-#[cfg(all(not(target_arch = "aarch64"), feature = "seccomp"))]
+#[cfg(feature = "seccomp")]
 use crate::seccomp;
 use crate::specconv::CreateOpts;
 use crate::{mount, validator};
@@ -603,7 +603,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     // Without NoNewPrivileges, we need to set seccomp
     // before dropping capabilities because the calling thread
     // must have the CAP_SYS_ADMIN.
-    #[cfg(all(not(target_arch = "aarch64"), feature = "seccomp"))]
+    #[cfg(feature = "seccomp")]
     if !oci_process.no_new_privileges {
         if let Some(ref scmp) = linux.seccomp {
             seccomp::init_seccomp(scmp)?;
@@ -685,7 +685,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     // With NoNewPrivileges, we should set seccomp as close to
     // do_exec as possible in order to reduce the amount of
     // system calls in the seccomp profiles.
-    #[cfg(all(not(target_arch = "aarch64"), feature = "seccomp"))]
+    #[cfg(feature = "seccomp")]
     if oci_process.no_new_privileges {
         if let Some(ref scmp) = linux.seccomp {
             seccomp::init_seccomp(scmp)?;

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -34,7 +34,7 @@ pub mod container;
 pub mod mount;
 pub mod pipestream;
 pub mod process;
-#[cfg(all(not(target_arch = "aarch64"), feature = "seccomp"))]
+#[cfg(feature = "seccomp")]
 pub mod seccomp;
 pub mod specconv;
 pub mod sync;

--- a/src/agent/rustjail/src/seccomp.rs
+++ b/src/agent/rustjail/src/seccomp.rs
@@ -95,7 +95,7 @@ pub fn init_seccomp(scmp: &LinuxSeccomp) -> Result<()> {
 mod tests {
     use super::*;
     use crate::skip_if_not_root;
-    use libc::{dup2, process_vm_readv, EPERM};
+    use libc::{dup3, process_vm_readv, EPERM, O_CLOEXEC};
     use std::io::Error;
     use std::ptr::null;
 
@@ -135,7 +135,7 @@ mod tests {
             "syscalls": [
                 {
                    "names": [
-                        "dup2"
+                        "dup3"
                     ],
                     "action": "SCMP_ACT_ERRNO"
                 },
@@ -212,7 +212,7 @@ mod tests {
         init_seccomp(&scmp).unwrap();
 
         // Basic syscall with simple rule
-        syscall_assert!(unsafe { dup2(0, 1) }, -EPERM);
+        syscall_assert!(unsafe { dup3(0, 1, O_CLOEXEC) }, -EPERM);
 
         // Syscall with permitted arguments
         syscall_assert!(unsafe { process_vm_readv(1, null(), 0, null(), 0, 0) }, 0);


### PR DESCRIPTION
Re-enable seccomp feature on aarch64 because CI is ready
by https://github.com/kata-containers/tests/pull/4124.

This reverts commit 42add7f201cf082d0d06d676c5cf20e6088ac2fb.

Fixes: #2939

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>