### PR TITLE
CCv0 | version: Update CCv0 fork of containerd used

### DIFF
--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ARG IMAGE_REGISTRY=registry.fedoraproject.org
-FROM ${IMAGE_REGISTRY}/fedora:latest
+FROM ${IMAGE_REGISTRY}/fedora:34
 
 RUN [ -n "$http_proxy" ] && sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -182,14 +182,15 @@ externals:
   containerd:
     description: |
       Containerd for Kubernetes Container Runtime Interface.
-    url: "github.com/containerd/containerd"
+    # CCv0 is using our fork of containerd as the changes can't be merged yet
+    url: "github.com/confidential-containers/containerd"
     tarball_url: "https://github.com/containerd/containerd/releases/download"
     # containerd from v1.5.0 used the path unix socket
     # instead of abstract socket, thus kata wouldn's support the containerd's
     # version older than them.
     version: "v1.5.2"
-    # CCv0 is using a containerd PR build as our changes are still PoC
-    pr_id: "5911"
+    # CCv0 needs to build a branch from our fork to install containerd
+    branch: "current-CCv0"
 
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"


### PR DESCRIPTION
- Update CCv0 to use the new confidential containers fork of containerd
- Start using the current-CCv0 branch

Fixes: #2947

Signed-off-by: stevenhorsman <steven@uk.ibm.com>