### PR TITLE
kata-deploy: Copy config.toml to template file for k3s

### DIFF
--- a/tools/packaging/kata-deploy/kata-deploy/overlays/k3s/mount_k3s_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/k3s/mount_k3s_conf.yaml
@@ -6,6 +6,9 @@ metadata:
 spec:
   template:
     spec:
+      containers:
+      - name: kube-kata
+        command: [ "bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh install; cp /etc/containerd/config.toml /etc/containerd/config.toml.tmpl" ]
       volumes:
         - name: containerd-conf
           hostPath:


### PR DESCRIPTION
This PR will copy `/etc/containerd/config.toml` to `/etc/containerd/config.toml.tmpl`, since [k3s overwrites config.toml at startup](https://rancher.com/docs/k3s/latest/en/advanced/#configuring-containerd)