### PR TITLE
logging: Enable agent debug output for release builds

### DIFF
--- a/pkg/logging/Cargo.toml
+++ b/pkg/logging/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0.39"
 # - Dynamic keys required to allow HashMap keys to be slog::Serialized.
 # - The 'max_*' features allow changing the log level at runtime
 #   (by stopping the compiler from removing log calls).
-slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_info"] }
+slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_debug"] }
 slog-json = "2.3.0"
 slog-async = "2.3.0"
 slog-scope = "4.1.2"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -6,7 +6,6 @@ edition = "2018"
 
 [dependencies]
 oci = { path = "oci" }
-logging = { path = "../../pkg/logging" }
 rustjail = { path = "rustjail" }
 protocols = { path = "protocols" }
 lazy_static = "1.3.0"
@@ -36,11 +35,10 @@ rtnetlink = "0.8.0"
 netlink-packet-utils = "0.4.1"
 ipnetwork = "0.17.0"
 
-# slog:
-# - Dynamic keys required to allow HashMap keys to be slog::Serialized.
-# - The 'max_*' features allow changing the log level at runtime
-#   (by stopping the compiler from removing log calls).
-slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_info"] }
+# Note: this crate sets the slog 'max_*' features which allows the log level
+# to be modified at runtime.
+logging = { path = "../../pkg/logging" }
+slog = "2.5.2"
 slog-scope = "4.1.2"
 
 # Redirect ttrpc log calls

--- a/src/agent/vsock-exporter/Cargo.toml
+++ b/src/agent/vsock-exporter/Cargo.toml
@@ -15,6 +15,6 @@ serde = { version = "1.0.126", features = ["derive"] }
 tokio-vsock = "0.3.1"
 bincode = "1.3.3"
 byteorder = "1.4.3"
-slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_info"] }
+slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_debug"] }
 async-trait = "0.1.50"
 tokio = "1.2.0"

--- a/src/trace-forwarder/Cargo.toml
+++ b/src/trace-forwarder/Cargo.toml
@@ -27,11 +27,10 @@ tracing-opentelemetry = "0.13.0"
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 
+# Note: this crate sets the slog 'max_*' features which allows the log level
+# to be modified at runtime.
 logging = { path = "../../pkg/logging" }
-
-# Note: The 'max_*' features allow changing the log level at runtime
-# (by stopping the compiler from removing log calls).
-slog = { version = "2.5.2", features = ["dynamic-keys", "max_level_trace", "release_max_level_trace"] }
+slog = "2.5.2"
 
 privdrop = "0.5.1"
 


### PR DESCRIPTION
Raise the `slog` maximum log level feature for release code from `info`
to `debug` by changing the `slog` maximum level features in the shared
`logging` crate. This allows the consumers of the `logging` crate (the
agent, the `trace-forwarder` and the `agent-ctl` tool) to produce debug
output when their debug options are enabled. Currently, those options
will essentially be a NOP (unless using a debug version of the code).

Testing showed that setting the `slog` maximum level features in the
rust manifest files for the consumers of the `logging` crate has no
impact: those values are ignored, so they have been removed and replaced
with a comment stating the levels are set in the `logging` crate.

Fixes: #2966.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>