### PR TITLE
logging: Always run crate tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,12 @@ TOOLS += agent-ctl
 
 STANDARD_TARGETS = build check clean install test vendor
 
-include utils.mk
-include ./tools/packaging/kata-deploy/local-build/Makefile
+default: all
 
 all: build
+
+include utils.mk
+include ./tools/packaging/kata-deploy/local-build/Makefile
 
 # Create the rules
 $(eval $(call create_all_rules,$(COMPONENTS),$(TOOLS),$(STANDARD_TARGETS)))

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,10 @@ STANDARD_TARGETS = build check clean install test vendor
 
 default: all
 
-all: build
+all: logging-crate-tests build
+
+logging-crate-tests:
+	make -C pkg/logging
 
 include utils.mk
 include ./tools/packaging/kata-deploy/local-build/Makefile
@@ -36,4 +39,10 @@ generate-protocols:
 static-checks: build
 	bash ci/static-checks.sh
 
-.PHONY: all default static-checks binary-tarball install-binary-tarball
+.PHONY: \
+	all \
+	binary-tarball \
+	default \
+	install-binary-tarball \
+	logging-crate-tests \
+	static-checks

--- a/pkg/logging/Makefile
+++ b/pkg/logging/Makefile
@@ -1,0 +1,18 @@
+# Copyright (c) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# It is not necessary to have a build target as this crate is built
+# automatically by the consumers of it.
+#
+# However, it is essential that the crate be tested.
+default: test
+
+# It is essential to run these tests using *both* build profiles.
+# See the `test_logger_levels()` test for further information.
+test:
+	@echo "INFO: testing log levels for development build"
+	@cargo test
+	@echo "INFO: testing log levels for release build"
+	@cargo test --release

--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -101,7 +101,10 @@ endef
 ##TARGET default: build code
 default: $(TARGET) show-header
 
-$(TARGET): $(GENERATED_CODE) $(TARGET_PATH)
+$(TARGET): $(GENERATED_CODE) logging-crate-tests $(TARGET_PATH)
+
+logging-crate-tests:
+	make -C $(CWD)/../../pkg/logging
 
 $(TARGET_PATH): $(SOURCES) | show-summary
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE) $(EXTRA_RUSTFEATURES)
@@ -205,9 +208,10 @@ codecov-html: check_tarpaulin
 
 .PHONY: \
 	help \
+	logging-crate-tests \
+	optimize \
 	show-header \
 	show-summary \
-	optimize \
 	vendor
 
 ##TARGET generate-protocols: generate/update grpc agent protocols

--- a/src/trace-forwarder/Makefile
+++ b/src/trace-forwarder/Makefile
@@ -7,8 +7,11 @@ include ../../utils.mk
 
 default: build
 
-build:
+build: logging-crate-tests
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
+
+logging-crate-tests:
+	make -C $(CWD)/../../pkg/logging
 
 clean:
 	cargo clean
@@ -25,8 +28,9 @@ check:
 
 .PHONY: \
 	build \
-	test \
 	check \
-	install \
 	clean \
+	install \
+	logging-crate-tests \
+	test \
 	vendor

--- a/tools/agent-ctl/Makefile
+++ b/tools/agent-ctl/Makefile
@@ -7,8 +7,11 @@ include ../../utils.mk
 
 default: build
 
-build:
+build: logging-crate-tests
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
+
+logging-crate-tests:
+	make -C $(CWD)/../../pkg/logging
 
 clean:
 	cargo clean
@@ -25,8 +28,9 @@ check:
 
 .PHONY: \
 	build \
-	test \
 	check \
-	install \
 	clean \
+	install \
+	logging-crate-tests \
+	test \
 	vendor

--- a/utils.mk
+++ b/utils.mk
@@ -91,8 +91,6 @@ endef
 # $3 - List of standard targets.
 define create_all_rules
 
-default: all
-
 all: $(1) $(2)
 
 # Create rules for all components.

--- a/utils.mk
+++ b/utils.mk
@@ -143,3 +143,5 @@ ifeq ($(ARCH), aarch64)
 endif
 
 TRIPLE = $(ARCH)-unknown-linux-$(LIBC)
+
+CWD := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))


### PR DESCRIPTION
Ensure the tests in the local `logging` crate are run for all consumers
of it.

Additionally, add a new test which checks that output is generated by a
range of different log level `slog` macros. This is designed to ensure
debug level output is always available for the consumers of the
`logging` crate.

Fixes: #2969.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>