### PR TITLE
stable-2.2 | osbuilder: build image-builder image from Fedora 34

### DIFF
--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ARG IMAGE_REGISTRY=registry.fedoraproject.org
-FROM ${IMAGE_REGISTRY}/fedora:latest
+FROM ${IMAGE_REGISTRY}/fedora:34
 
 RUN [ -n "$http_proxy" ] && sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true
 


### PR DESCRIPTION
Currently the image-builder image is built from `fedora:latest` and
this is error-prone as any update of the base image can lead to
breakage. Instead let's create the image from Fedora 34, which is the
last known version to build fine.

Fixes #2960
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>
(cherry picked from commit a239a38f457a15e96c5aa1e30a800227324671f6)