### PR TITLE
hypervisor: move sandbox specific hypervisor validation to sandbox

### DIFF
--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -536,21 +536,9 @@ func (conf *HypervisorConfig) CheckTemplateConfig() error {
 	return nil
 }
 
+// Valid will ensure valid defaults are applied within the HypervisorConfig, and return
+// an error if the config is not valid.
 func (conf *HypervisorConfig) Valid() error {
-
-	// Kata specific checks. Should be done outside the hypervisor
-	if conf.KernelPath == "" {
-		return fmt.Errorf("Missing kernel path")
-	}
-
-	if conf.ImagePath == "" && conf.InitrdPath == "" {
-		return fmt.Errorf("Missing image and initrd path")
-	}
-
-	if conf.ImagePath != "" && conf.InitrdPath != "" {
-		return fmt.Errorf("Image and initrd path cannot be both set")
-	}
-
 	if err := conf.CheckTemplateConfig(); err != nil {
 		return err
 	}

--- a/src/runtime/virtcontainers/hypervisor_test.go
+++ b/src/runtime/virtcontainers/hypervisor_test.go
@@ -94,26 +94,6 @@ func testHypervisorConfigValid(t *testing.T, hypervisorConfig *HypervisorConfig,
 	assert.False(!success && err == nil)
 }
 
-func TestHypervisorConfigNoKernelPath(t *testing.T) {
-	hypervisorConfig := &HypervisorConfig{
-		KernelPath:     "",
-		ImagePath:      fmt.Sprintf("%s/%s", testDir, testImage),
-		HypervisorPath: fmt.Sprintf("%s/%s", testDir, testHypervisor),
-	}
-
-	testHypervisorConfigValid(t, hypervisorConfig, false)
-}
-
-func TestHypervisorConfigNoImagePath(t *testing.T) {
-	hypervisorConfig := &HypervisorConfig{
-		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
-		ImagePath:      "",
-		HypervisorPath: fmt.Sprintf("%s/%s", testDir, testHypervisor),
-	}
-
-	testHypervisorConfigValid(t, hypervisorConfig, false)
-}
-
 func TestHypervisorConfigNoHypervisorPath(t *testing.T) {
 	hypervisorConfig := &HypervisorConfig{
 		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
@@ -122,27 +102,6 @@ func TestHypervisorConfigNoHypervisorPath(t *testing.T) {
 	}
 
 	testHypervisorConfigValid(t, hypervisorConfig, true)
-}
-
-func TestHypervisorConfigIsValid(t *testing.T) {
-	hypervisorConfig := &HypervisorConfig{
-		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
-		ImagePath:      fmt.Sprintf("%s/%s", testDir, testImage),
-		HypervisorPath: fmt.Sprintf("%s/%s", testDir, testHypervisor),
-	}
-
-	testHypervisorConfigValid(t, hypervisorConfig, true)
-}
-
-func TestHypervisorConfigBothInitrdAndImage(t *testing.T) {
-	hypervisorConfig := &HypervisorConfig{
-		KernelPath:     fmt.Sprintf("%s/%s", testDir, testKernel),
-		ImagePath:      fmt.Sprintf("%s/%s", testDir, testImage),
-		InitrdPath:     fmt.Sprintf("%s/%s", testDir, testInitrd),
-		HypervisorPath: "",
-	}
-
-	testHypervisorConfigValid(t, hypervisorConfig, false)
 }
 
 func TestHypervisorConfigValidTemplateConfig(t *testing.T) {

--- a/src/runtime/virtcontainers/mock_hypervisor_test.go
+++ b/src/runtime/virtcontainers/mock_hypervisor_test.go
@@ -31,7 +31,7 @@ func TestMockHypervisorCreateVM(t *testing.T) {
 	ctx := context.Background()
 
 	// wrong config
-	err := m.CreateVM(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig)
+	err := validateHypervisorConfig(&sandbox.config.HypervisorConfig)
 	assert.Error(err)
 
 	sandbox.config.HypervisorConfig = HypervisorConfig{
@@ -39,6 +39,9 @@ func TestMockHypervisorCreateVM(t *testing.T) {
 		ImagePath:      fmt.Sprintf("%s/%s", testDir, testImage),
 		HypervisorPath: fmt.Sprintf("%s/%s", testDir, testHypervisor),
 	}
+
+	err = validateHypervisorConfig(&sandbox.config.HypervisorConfig)
+	assert.NoError(err)
 
 	err = m.CreateVM(ctx, sandbox.config.ID, NetworkNamespace{}, &sandbox.config.HypervisorConfig)
 	assert.NoError(err)


### PR DESCRIPTION
Today we have a check for ensuring a kernel and initrd or image are
specified in the HypervisorConfig. Since it is possible that a
hypervisor could boot with other configurations, it would make more
sense to put this check at the sandbox level. We'll still do agnostic
hypervisor checks in hypervisor.go.

This is done in preparation for making hypervisor its own package which
is agnostic to the sandbox/virtcontainers logic.

Fixes: #2882 

Signed-off-by: Eric Ernst <eric_ernst@apple.com>