### PR TITLE
agent: Remove mounts only once when removing container

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -258,8 +258,6 @@ impl AgentService {
             // Find the sandbox storage used by this container
             let mounts = sandbox.container_mounts.get(&cid);
             if let Some(mounts) = mounts {
-                remove_mounts(mounts)?;
-
                 for m in mounts.iter() {
                     if sandbox.storages.get(m).is_some() {
                         cmounts.push(m.to_string());


### PR DESCRIPTION
Container mounts should be removed only once when removing container. If not, there will be an error while removing sandbox storage, making its loop finished in advance and leaving the other storage unhandled.

Fixes #2965 

Signed-off-by: Burning <burning9699@gmail.com>