### PR TITLE
rustjail: Fix created time of container

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -995,8 +995,6 @@ impl BaseContainer for LinuxContainer {
 
         info!(logger, "entered namespaces!");
 
-        self.created = SystemTime::now();
-
         if p.init {
             let spec = self.config.spec.as_mut().unwrap();
             update_namespaces(&self.logger, spec, p.pid)?;


### PR DESCRIPTION
Got wrong created time of container after an exec
this commit will fix this problem.

Fixes: #2994

Signed-off-by: Tim Zhang <tim@hyper.sh>