### PR TITLE
virtcontainers: Lint protection types

### DIFF
--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -159,22 +159,22 @@ const (
 	//Intel Trust Domain Extensions
 	//https://software.intel.com/content/www/us/en/develop/articles/intel-trust-domain-extensions.html
 	// Exclude from lint checking for it won't be used on arm64 code
-	tdxProtection //nolint
+	tdxProtection
 
 	// AMD Secure Encrypted Virtualization
 	// https://developer.amd.com/sev/
 	// Exclude from lint checking for it won't be used on arm64 code
-	sevProtection //nolint
+	sevProtection
 
 	// IBM POWER 9 Protected Execution Facility
 	// https://www.kernel.org/doc/html/latest/powerpc/ultravisor.html
 	// Exclude from lint checking for it won't be used on arm64 code
-	pefProtection //nolint
+	pefProtection
 
 	// IBM Secure Execution (IBM Z & LinuxONE)
 	// https://www.kernel.org/doc/html/latest/virt/kvm/s390-pv.html
 	// Exclude from lint checking for it won't be used on arm64 code
-	seProtection //nolint
+	seProtection
 )
 
 var guestProtectionStr = [...]string{

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -170,3 +170,46 @@ func TestQemuArm64WithInitrd(t *testing.T) {
 
 	assert.NotContains(arm64.machine().Options, qemuNvdimmOption)
 }
+
+func TestQemuArm64AppendProtectionDevice(t *testing.T) {
+	assert := assert.New(t)
+	arm64 := newTestQemu(assert, QemuVirt)
+
+	var devices []govmmQemu.Device
+	var bios, firmware string
+	var err error
+
+	// no protection
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware)
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	// PEF protection
+	arm64.(*qemuArm64).protection = pefProtection
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware)
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	// Secure Execution protection
+	arm64.(*qemuArm64).protection = seProtection
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware)
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	// SEV protection
+	arm64.(*qemuArm64).protection = sevProtection
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware)
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	// TDX protection
+	arm64.(*qemuArm64).protection = tdxProtection
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware)
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+}


### PR DESCRIPTION
Protection types like tdxProtection or seProtection were marked nolint,
remove this. As a side effect, ARM needs dummy tests for these.

Fixes: #2801
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

obviously I couldn't test this just yet