### PR TITLE
qemu: fix snap build on ppc64le

### DIFF
--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -310,6 +310,11 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-qom-cast-debug)
 	qemu_options+=(size:--disable-tcmalloc)
 
+	# Disable libudev for static build
+	if gt_eq "${qemu_version}" "5.2.0" ; then
+		[ "${static}" == "true" ] && qemu_options+=(size:--disable-libudev)
+	fi
+
 	# Disallow network downloads
 	qemu_options+=(security:--disable-curl)
 


### PR DESCRIPTION
While building snap, static qemu is considered. Disable libudev
as it doesn't have static libraries on ppc64le.

Fixes: #3002

Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>