### PR TITLE
agent: Remove some unwrap and expect calls

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -113,10 +113,10 @@ async fn create_logger_task(rfd: RawFd, vsock_port: u32, shutdown: Receiver<bool
         )?;
 
         let addr = SockAddr::new_vsock(libc::VMADDR_CID_ANY, vsock_port);
-        socket::bind(listenfd, &addr).unwrap();
-        socket::listen(listenfd, 1).unwrap();
+        socket::bind(listenfd, &addr)?;
+        socket::listen(listenfd, 1)?;
 
-        writer = Box::new(util::get_vsock_stream(listenfd).await.unwrap());
+        writer = Box::new(util::get_vsock_stream(listenfd).await?);
     } else {
         writer = Box::new(tokio::io::stdout());
     }
@@ -326,7 +326,7 @@ async fn start_sandbox(
     sandbox.lock().await.sender = Some(tx);
 
     // vsock:///dev/vsock, port
-    let mut server = rpc::start(sandbox.clone(), config.server_addr.as_str());
+    let mut server = rpc::start(sandbox.clone(), config.server_addr.as_str())?;
     server.start().await?;
 
     rx.await?;

--- a/src/agent/src/metrics.rs
+++ b/src/agent/src/metrics.rs
@@ -140,7 +140,7 @@ fn update_agent_metrics() -> Result<()> {
         Ok(status) => set_gauge_vec_proc_status(&AGENT_PROC_STATUS, &status),
     }
 
-    return Ok(());
+    Ok(())
 }
 
 #[instrument]

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -139,8 +139,8 @@ pub const STORAGE_HANDLER_LIST: &[&str] = &[
 
 #[instrument]
 pub fn baremount(
-    source: &str,
-    destination: &str,
+    source: &Path,
+    destination: &Path,
     fs_type: &str,
     flags: MsFlags,
     options: &str,
@@ -148,11 +148,11 @@ pub fn baremount(
 ) -> Result<()> {
     let logger = logger.new(o!("subsystem" => "baremount"));
 
-    if source.is_empty() {
+    if source.as_os_str().is_empty() {
         return Err(anyhow!("need mount source"));
     }
 
-    if destination.is_empty() {
+    if destination.as_os_str().is_empty() {
         return Err(anyhow!("need mount destination"));
     }
 
@@ -444,16 +444,19 @@ fn mount_storage(logger: &Logger, storage: &Storage) -> Result<()> {
     let options_vec = options_vec.iter().map(String::as_str).collect();
     let (flags, options) = parse_mount_flags_and_options(options_vec);
 
+    let source = Path::new(&storage.source);
+    let mount_point = Path::new(&storage.mount_point);
+
     info!(logger, "mounting storage";
-    "mount-source:" => storage.source.as_str(),
-    "mount-destination" => storage.mount_point.as_str(),
+    "mount-source" => source.display(),
+    "mount-destination" => mount_point.display(),
     "mount-fstype"  => storage.fstype.as_str(),
     "mount-options" => options.as_str(),
     );
 
     baremount(
-        storage.source.as_str(),
-        storage.mount_point.as_str(),
+        source,
+        mount_point,
         storage.fstype.as_str(),
         flags,
         options.as_str(),
@@ -579,7 +582,10 @@ fn mount_to_rootfs(logger: &Logger, m: &InitMount) -> Result<()> {
 
     fs::create_dir_all(Path::new(m.dest)).context("could not create directory")?;
 
-    baremount(m.src, m.dest, m.fstype, flags, &options, logger).or_else(|e| {
+    let source = Path::new(m.src);
+    let dest = Path::new(m.dest);
+
+    baremount(source, dest, m.fstype, flags, &options, logger).or_else(|e| {
         if m.src != "dev" {
             return Err(e);
         }
@@ -937,14 +943,10 @@ mod tests {
                 std::fs::create_dir_all(d).expect("failed to created directory");
             }
 
-            let result = baremount(
-                &src_filename,
-                &dest_filename,
-                d.fs_type,
-                d.flags,
-                d.options,
-                &logger,
-            );
+            let src = Path::new(&src_filename);
+            let dest = Path::new(&dest_filename);
+
+            let result = baremount(src, dest, d.fs_type, d.flags, d.options, &logger);
 
             let msg = format!("{}: result: {:?}", msg, result);
 
@@ -1021,15 +1023,11 @@ mod tests {
                 .unwrap_or_else(|_| panic!("failed to create directory {}", d));
         }
 
+        let src = Path::new(mnt_src_filename);
+        let dest = Path::new(mnt_dest_filename);
+
         // Create an actual mount
-        let result = baremount(
-            mnt_src_filename,
-            mnt_dest_filename,
-            "bind",
-            MsFlags::MS_BIND,
-            "",
-            &logger,
-        );
+        let result = baremount(src, dest, "bind", MsFlags::MS_BIND, "", &logger);
         assert!(result.is_ok(), "mount for test setup failed");
 
         let tests = &[

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -104,7 +104,10 @@ impl Namespace {
             if let Err(err) = || -> Result<()> {
                 let origin_ns_path = get_current_thread_ns_path(ns_type.get());
 
-                File::open(Path::new(&origin_ns_path))?;
+                let source = Path::new(&origin_ns_path);
+                let destination = new_ns_path.as_path();
+
+                File::open(&source)?;
 
                 // Create a new netns on the current thread.
                 let cf = ns_type.get_flags();
@@ -115,8 +118,6 @@ impl Namespace {
                     nix::unistd::sethostname(hostname.unwrap())?;
                 }
                 // Bind mount the new namespace from the current thread onto the mount point to persist it.
-                let source: &str = origin_ns_path.as_str();
-                let destination: &str = new_ns_path.as_path().to_str().unwrap_or("none");
 
                 let mut flags = MsFlags::empty();
 
@@ -131,7 +132,7 @@ impl Namespace {
 
                 baremount(source, destination, "none", flags, "", &logger).map_err(|e| {
                     anyhow!(
-                        "Failed to mount {} to {} with err:{:?}",
+                        "Failed to mount {:?} to {:?} with err:{:?}",
                         source,
                         destination,
                         e

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -111,11 +111,18 @@ pub struct AgentService {
 //     ^[a-zA-Z0-9][a-zA-Z0-9_.-]+$
 //
 fn verify_cid(id: &str) -> Result<()> {
-    let valid = id.len() > 1
-        && id.chars().next().unwrap().is_alphanumeric()
-        && id
-            .chars()
-            .all(|c| (c.is_alphanumeric() || ['.', '-', '_'].contains(&c)));
+    let mut chars = id.chars();
+
+    let valid = match chars.next() {
+        Some(first)
+            if first.is_alphanumeric()
+                && id.len() > 1
+                && chars.all(|c| c.is_alphanumeric() || ['.', '-', '_'].contains(&c)) =>
+        {
+            true
+        }
+        _ => false,
+    };
 
     match valid {
         true => Ok(()),

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -458,10 +458,14 @@ mod tests {
     use slog::Logger;
     use std::fs::{self, File};
     use std::os::unix::fs::PermissionsExt;
+    use std::path::Path;
     use tempfile::Builder;
 
     fn bind_mount(src: &str, dst: &str, logger: &Logger) -> Result<(), Error> {
-        baremount(src, dst, "bind", MsFlags::MS_BIND, "", logger)
+        let src_path = Path::new(src);
+        let dst_path = Path::new(dst);
+
+        baremount(src_path, dst_path, "bind", MsFlags::MS_BIND, "", logger)
     }
 
     use serial_test::serial;

--- a/src/agent/src/watcher.rs
+++ b/src/agent/src/watcher.rs
@@ -366,8 +366,8 @@ impl SandboxStorages {
                         }
 
                         match baremount(
-                            entry.source_mount_point.to_str().unwrap(),
-                            entry.target_mount_point.to_str().unwrap(),
+                            entry.source_mount_point.as_path(),
+                            entry.target_mount_point.as_path(),
                             "bind",
                             MsFlags::MS_BIND,
                             "bind",
@@ -477,8 +477,8 @@ impl BindWatcher {
         fs::create_dir_all(WATCH_MOUNT_POINT_PATH).await?;
 
         baremount(
-            "tmpfs",
-            WATCH_MOUNT_POINT_PATH,
+            Path::new("tmpfs"),
+            Path::new(WATCH_MOUNT_POINT_PATH),
             "tmpfs",
             MsFlags::empty(),
             "",

--- a/tools/agent-ctl/src/main.rs
+++ b/tools/agent-ctl/src/main.rs
@@ -153,8 +153,9 @@ fn connect(name: &str, global_args: clap::ArgMatches) -> Result<()> {
             .collect();
     }
 
-    // Cannot fail as a default has been specified
-    let log_level_name = global_args.value_of("log-level").unwrap();
+    let log_level_name = global_args
+        .value_of("log-level")
+        .ok_or_else(|| anyhow!("cannot get log level"))?;
 
     let log_level = logging::level_name_to_slog_level(log_level_name).map_err(|e| anyhow!(e))?;
 
@@ -166,10 +167,10 @@ fn connect(name: &str, global_args: clap::ArgMatches) -> Result<()> {
         None => 0,
     };
 
-    let hybrid_vsock_port: u64 = args
+    let hybrid_vsock_port = args
         .value_of("hybrid-vsock-port")
-        .ok_or("Need Hybrid VSOCK port number")
-        .map(|p| p.parse::<u64>().unwrap())
+        .ok_or_else(|| anyhow!("Need Hybrid VSOCK port number"))?
+        .parse::<u64>()
         .map_err(|e| anyhow!("VSOCK port number must be an integer: {:?}", e))?;
 
     let bundle_dir = args.value_of("bundle-dir").unwrap_or("").to_string();
@@ -215,7 +216,7 @@ fn real_main() -> Result<()> {
                 .long("log-level")
                 .short("l")
                 .help("specific log level")
-                .default_value(logging::slog_level_to_level_name(DEFAULT_LOG_LEVEL).unwrap())
+                .default_value(logging::slog_level_to_level_name(DEFAULT_LOG_LEVEL).map_err(|e| anyhow!(e))?)
                 .possible_values(&logging::get_log_levels())
                 .takes_value(true)
                 .required(false),

--- a/tools/agent-ctl/src/main.rs
+++ b/tools/agent-ctl/src/main.rs
@@ -324,11 +324,8 @@ fn real_main() -> Result<()> {
 }
 
 fn main() {
-    match real_main() {
-        Err(e) => {
-            eprintln!("ERROR: {}", e);
-            exit(1);
-        }
-        _ => (),
-    };
+    if let Err(e) = real_main() {
+        eprintln!("ERROR: {}", e);
+        exit(1);
+    }
 }

--- a/tools/agent-ctl/src/main.rs
+++ b/tools/agent-ctl/src/main.rs
@@ -306,19 +306,17 @@ fn real_main() -> Result<()> {
     match subcmd {
         "generate-cid" => {
             println!("{}", utils::random_container_id());
-            return Ok(());
+            Ok(())
         }
         "generate-sid" => {
             println!("{}", utils::random_sandbox_id());
-            return Ok(());
+            Ok(())
         }
         "examples" => {
             println!("{}", make_examples_text(name));
-            return Ok(());
+            Ok(())
         }
-        "connect" => {
-            return connect(name, args);
-        }
+        "connect" => connect(name, args),
         _ => return Err(anyhow!(format!("invalid sub-command: {:?}", subcmd))),
     }
 }

--- a/tools/agent-ctl/src/main.rs
+++ b/tools/agent-ctl/src/main.rs
@@ -134,16 +134,14 @@ fn make_examples_text(program_name: &str) -> String {
 fn connect(name: &str, global_args: clap::ArgMatches) -> Result<()> {
     let args = global_args
         .subcommand_matches("connect")
-        .ok_or("BUG: missing sub-command arguments".to_string())
-        .map_err(|e| anyhow!(e))?;
+        .ok_or_else(|| anyhow!("BUG: missing sub-command arguments"))?;
 
     let interactive = args.is_present("interactive");
     let ignore_errors = args.is_present("ignore-errors");
 
     let server_address = args
         .value_of("server-address")
-        .ok_or("need server adddress".to_string())
-        .map_err(|e| anyhow!(e))?
+        .ok_or_else(|| anyhow!("need server adddress"))?
         .to_string();
 
     let mut commands: Vec<&str> = Vec::new();
@@ -151,8 +149,7 @@ fn connect(name: &str, global_args: clap::ArgMatches) -> Result<()> {
     if !interactive {
         commands = args
             .values_of("cmd")
-            .ok_or("need commands to send to the server".to_string())
-            .map_err(|e| anyhow!(e))?
+            .ok_or_else(|| anyhow!("need commands to send to the server"))?
             .collect();
     }
 
@@ -304,8 +301,7 @@ fn real_main() -> Result<()> {
 
     let subcmd = args
         .subcommand_name()
-        .ok_or("need sub-command".to_string())
-        .map_err(|e| anyhow!(e))?;
+        .ok_or_else(|| anyhow!("need sub-command"))?;
 
     match subcmd {
         "generate-cid" => {


### PR DESCRIPTION
Replace some `unwrap()` and `expect()` calls with code to return the
error to the caller.

Fixes: #3011.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>