### PR TITLE
versions: bump golang to 1.17.x

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.15.x, 1.16.x]
+        go-version: [1.16.x, 1.17.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:

--- a/versions.yaml
+++ b/versions.yaml
@@ -253,7 +253,7 @@ languages:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.16.5"
+      newest-version: "1.17.3"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
According to https://endoflife.date/go golang 1.15 is not supported
anymore.  Let's remove it from out tests, add 1.17.x, and bump the
newest version known to work when building kata to 1.17.3.

Fixes: #3016

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>