### PR TITLE
CCv0: SEV prelaunch attestation

### DIFF
--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -24,6 +24,17 @@ machine_type = "@MACHINETYPE@"
 # Default false
 # confidential_guest = true
 
+# Enable attestation for confidential guests.
+# Applies only if confidential_guest is true.  
+# (default: false)
+#guest_attestation = true
+#
+# Guest owner proxy that handles remote attestation
+#guest_attestation_proxy="localhost:50051"
+#
+# Keyset ID for injected secrets 
+#guest_attestation_keyset="KEYSET-1"
+
 # Enable running QEMU VMM as a non-root user.
 # By default QEMU VMM run as root. When this is set to true, QEMU VMM process runs as
 # a non-root random user. See documentation for the limitations of this mode.

--- a/src/runtime/pkg/katautils/config-settings.go.in
+++ b/src/runtime/pkg/katautils/config-settings.go.in
@@ -89,6 +89,9 @@ const defaultGuestSwap = false
 const defaultRootlessHypervisor = false
 const defaultDisableSeccomp = false
 const defaultVfioMode = "guest-kernel"
+const defaultGuestAttestation = false
+const defaultGuestAttestationProxy string = ""
+const defaultGuestAttestationKeyset string = "" 
 
 var defaultSGXEPCSize = int64(0)
 

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -135,6 +135,9 @@ type hypervisor struct {
 	GuestSwap               bool     `toml:"enable_guest_swap"`
 	Rootless                bool     `toml:"rootless"`
 	DisableSeccomp          bool     `toml:"disable_seccomp"`
+	GuestAttestation        bool     `toml:"guest_attestation"`
+	GuestAttestationProxy   string   `toml:"guest_attestation_proxy"`
+	GuestAttestationKeyset  string   `toml:"guest_attestation_keyset"`
 }
 
 type runtime struct {
@@ -697,6 +700,9 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		ConfidentialGuest:       h.ConfidentialGuest,
 		GuestSwap:               h.GuestSwap,
 		Rootless:                h.Rootless,
+		GuestAttestation:        h.GuestAttestation,
+		GuestAttestationProxy:   h.GuestAttestationProxy,
+		GuestAttestationKeyset:  h.GuestAttestationKeyset,
 	}, nil
 }
 
@@ -1044,6 +1050,9 @@ func GetDefaultHypervisorConfig() vc.HypervisorConfig {
 		GuestSwap:               defaultGuestSwap,
 		Rootless:                defaultRootlessHypervisor,
 		DisableSeccomp:          defaultDisableSeccomp,
+		GuestAttestation:        defaultGuestAttestation,
+		GuestAttestationProxy:   defaultGuestAttestationProxy,
+		GuestAttestationKeyset:  defaultGuestAttestationKeyset,
 	}
 }
 

--- a/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
+++ b/src/runtime/vendor/github.com/kata-containers/govmm/qemu/qemu.go
@@ -280,6 +280,22 @@ type Object struct {
 
 	// ReadOnly specifies whether `MemPath` is opened read-only or read/write (default)
 	ReadOnly bool
+
+	// SevPolicy is the policy for the SEV instance. For more info, see AMD document 55766
+	// This is only relevant for sev-guest objects
+	SevPolicy uint32
+
+	// CertFilePath is the path to the guest Diffie–Hellman key
+	// This is only relevant for sev-guest objects
+	CertFilePath string
+
+	// SessionFilePath is the path to the launch blog
+	// This is only relevant for sev-guest objects
+	SessionFilePath string
+
+	// KernelHashes specifies whether the hashes of the kernel, initrd, & cmdline are included in the measurement
+	// This is only relevant for sev-guest objects
+	KernelHashes bool
 }
 
 // Valid returns true if the Object structure is valid and complete.
@@ -337,7 +353,17 @@ func (object Object) QemuParams(config *Config) []string {
 		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))
 		objectParams = append(objectParams, fmt.Sprintf("cbitpos=%d", object.CBitPos))
 		objectParams = append(objectParams, fmt.Sprintf("reduced-phys-bits=%d", object.ReducedPhysBits))
-
+		objectParams = append(objectParams, fmt.Sprintf("policy=%d", object.SevPolicy))
+		if object.CertFilePath != "" {
+			objectParams = append(objectParams, fmt.Sprintf("dh-cert-file=%s", object.CertFilePath))
+		}
+		if object.SessionFilePath != "" {
+			objectParams = append(objectParams, fmt.Sprintf("session-file=%s", object.SessionFilePath))
+		}
+		if object.KernelHashes == true {
+			objectParams = append(objectParams, "kernel-hashes=on")
+		}
+		// Add OVMF firmware as pflash drive
 		driveParams = append(driveParams, "if=pflash,format=raw,readonly=on")
 		driveParams = append(driveParams, fmt.Sprintf("file=%s", object.File))
 	case SecExecGuest:

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -497,6 +497,15 @@ type HypervisorConfig struct {
 	// from memory encryption to both memory and CPU-state encryption and integrity.
 	ConfidentialGuest bool
 
+	// Enable prelaunch attestation for confidential guest.
+	GuestAttestation bool
+
+	// Location of the Guest Owner Proxy for attestation
+	GuestAttestationProxy string
+
+	// Keyset ID for post-attestation secret injection
+	GuestAttestationKeyset string
+
 	// BootToBeTemplate used to indicate if the VM is created to be a template VM
 	BootToBeTemplate bool
 

--- a/src/runtime/virtcontainers/hypervisor_amd64.go
+++ b/src/runtime/virtcontainers/hypervisor_amd64.go
@@ -21,7 +21,7 @@ func availableGuestProtection() (guestProtection, error) {
 	}
 	// SEV is supported and enabled when the kvm module `sev` parameter is set to `1`
 	if _, err := os.Stat(sevKvmParameterPath); err == nil {
-		if c, err := ioutil.ReadFile(sevKvmParameterPath); err == nil && len(c) > 0 && c[0] == '1' {
+		if c, err := ioutil.ReadFile(sevKvmParameterPath); err == nil && len(c) > 0 && (c[0] == '1' || c[0] == 'Y') {
 			return sevProtection, nil
 		}
 	}

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -148,6 +148,12 @@ type qemuArch interface {
 	// a firmware, returns a string containing the path to the firmware that should
 	// be used with the -bios option, ommit -bios option if the path is empty.
 	appendProtectionDevice(devices []govmmQemu.Device, firmware string) ([]govmmQemu.Device, string, error)
+
+	// setup guest attestation
+	setupGuestAttestation(ctx context.Context, config govmmQemu.Config, path string, proxy string) (govmmQemu.Config, error)
+
+	// wait for prelaunch attestation to complete
+	prelaunchAttestation(ctx context.Context, qmp *govmmQemu.QMP, config govmmQemu.Config, path string, proxy string, keyset string) error
 }
 
 // Kind of guest protection


### PR DESCRIPTION
**TODO:**
- [x] Include CCv0 components in guest 
- [x] Validate secret are received by guest 
- [x] Enable measurement validation in GOP
- [x] Rebase onto CCv0 branch
- [x] clean up debug prints 
- [x] Remove hard-coded sev-policy
- [x] Add `kernel-hashes=on` for QEMU 6.2+