### PR TITLE
runtime: delete not used codes

### DIFF
--- a/src/runtime/virtcontainers/pkg/oci/utils.go
+++ b/src/runtime/virtcontainers/pkg/oci/utils.go
@@ -1020,49 +1020,6 @@ func getShmSize(c vc.ContainerConfig) (uint64, error) {
 	return shmSize, nil
 }
 
-// EnvVars converts an OCI process environment variables slice
-// into a virtcontainers EnvVar slice.
-func EnvVars(envs []string) ([]types.EnvVar, error) {
-	var envVars []types.EnvVar
-
-	envDelimiter := "="
-	expectedEnvLen := 2
-
-	for _, env := range envs {
-		envSlice := strings.SplitN(env, envDelimiter, expectedEnvLen)
-
-		if len(envSlice) < expectedEnvLen {
-			return []types.EnvVar{}, fmt.Errorf("Wrong string format: %s, expecting only %v parameters separated with %q",
-				env, expectedEnvLen, envDelimiter)
-		}
-
-		if envSlice[0] == "" {
-			return []types.EnvVar{}, fmt.Errorf("Environment variable cannot be empty")
-		}
-
-		envSlice[1] = strings.Trim(envSlice[1], "' ")
-
-		envVar := types.EnvVar{
-			Var:   envSlice[0],
-			Value: envSlice[1],
-		}
-
-		envVars = append(envVars, envVar)
-	}
-
-	return envVars, nil
-}
-
-// GetOCIConfig returns an OCI spec configuration from the annotation
-// stored into the container status.
-func GetOCIConfig(status vc.ContainerStatus) (specs.Spec, error) {
-	if status.Spec == nil {
-		return specs.Spec{}, fmt.Errorf("missing OCI spec for container")
-	}
-
-	return *status.Spec, nil
-}
-
 // IsCRIOContainerManager check if a Pod is created from CRI-O
 func IsCRIOContainerManager(spec *specs.Spec) bool {
 	if val, ok := spec.Annotations[crioAnnotations.ContainerType]; ok {

--- a/src/runtime/virtcontainers/pkg/oci/utils_test.go
+++ b/src/runtime/virtcontainers/pkg/oci/utils_test.go
@@ -188,52 +188,6 @@ func TestMinimalSandboxConfig(t *testing.T) {
 	assert.NoError(os.Remove(configPath))
 }
 
-func TestEnvVars(t *testing.T) {
-	assert := assert.New(t)
-	envVars := []string{"foo=bar", "TERM=xterm", "HOME=/home/foo", "TERM=\"bar\"", "foo=\"\""}
-	expectecVcEnvVars := []types.EnvVar{
-		{
-			Var:   "foo",
-			Value: "bar",
-		},
-		{
-			Var:   "TERM",
-			Value: "xterm",
-		},
-		{
-			Var:   "HOME",
-			Value: "/home/foo",
-		},
-		{
-			Var:   "TERM",
-			Value: "\"bar\"",
-		},
-		{
-			Var:   "foo",
-			Value: "\"\"",
-		},
-	}
-
-	vcEnvVars, err := EnvVars(envVars)
-	assert.NoError(err)
-	assert.Exactly(vcEnvVars, expectecVcEnvVars)
-}
-
-func TestMalformedEnvVars(t *testing.T) {
-	assert := assert.New(t)
-	envVars := []string{"foo"}
-	_, err := EnvVars(envVars)
-	assert.Error(err)
-
-	envVars = []string{"=foo"}
-	_, err = EnvVars(envVars)
-	assert.Error(err)
-
-	envVars = []string{"=foo="}
-	_, err = EnvVars(envVars)
-	assert.Error(err)
-}
-
 func testGetContainerTypeSuccessful(t *testing.T, annotations map[string]string, expected vc.ContainerType) {
 	assert := assert.New(t)
 	containerType, err := GetContainerType(annotations)


### PR DESCRIPTION
Functions EnvVars and GetOCIConfig in runtime/virtcontainers/pkg/oci/utils.go
are not used anymore.

Fixes: #3029

Signed-off-by: bin <bin@hyper.sh>