### PR TITLE
CCv0|agent-ctl: fix compile error

### DIFF
--- a/tools/agent-ctl/src/client.rs
+++ b/tools/agent-ctl/src/client.rs
@@ -2067,9 +2067,9 @@ fn agent_cmd_pull_image(
 
     let ctx = clone_context(ctx);
 
-    let image = utils::get_option("image", options, args);
-    let cid = utils::get_option("cid", options, args);
-    let source_creds = utils::get_option("source_creds", options, args);
+    let image = utils::get_option("image", options, args)?;
+    let cid = utils::get_option("cid", options, args)?;
+    let source_creds = utils::get_option("source_creds", options, args)?;
 
     req.set_image(image);
     req.set_container_id(cid);


### PR DESCRIPTION
Since the `utils::get_option` interface is modified,
PullImage needs to adapt to this modification in CCv0 branch.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>