### PR TITLE
macvlan: drop bridged part of name

### DIFF
--- a/src/runtime/virtcontainers/endpoint.go
+++ b/src/runtime/virtcontainers/endpoint.go
@@ -51,8 +51,8 @@ const (
 	// VhostUserEndpointType is the vhostuser network interface.
 	VhostUserEndpointType EndpointType = "vhost-user"
 
-	// BridgedMacvlanEndpointType is macvlan network interface.
-	BridgedMacvlanEndpointType EndpointType = "macvlan"
+	// MacvlanEndpointType is macvlan network interface.
+	MacvlanEndpointType EndpointType = "macvlan"
 
 	// MacvtapEndpointType is macvtap network interface.
 	MacvtapEndpointType EndpointType = "macvtap"
@@ -80,7 +80,7 @@ func (endpointType *EndpointType) Set(value string) error {
 		*endpointType = VhostUserEndpointType
 		return nil
 	case "macvlan":
-		*endpointType = BridgedMacvlanEndpointType
+		*endpointType = MacvlanEndpointType
 		return nil
 	case "macvtap":
 		*endpointType = MacvtapEndpointType
@@ -108,8 +108,8 @@ func (endpointType *EndpointType) String() string {
 		return string(VethEndpointType)
 	case VhostUserEndpointType:
 		return string(VhostUserEndpointType)
-	case BridgedMacvlanEndpointType:
-		return string(BridgedMacvlanEndpointType)
+	case MacvlanEndpointType:
+		return string(MacvlanEndpointType)
 	case MacvtapEndpointType:
 		return string(MacvtapEndpointType)
 	case TapEndpointType:

--- a/src/runtime/virtcontainers/endpoint_test.go
+++ b/src/runtime/virtcontainers/endpoint_test.go
@@ -35,8 +35,8 @@ func TestVhostUserEndpointTypeSet(t *testing.T) {
 	testEndpointTypeSet(t, "vhost-user", VhostUserEndpointType)
 }
 
-func TestBridgedMacvlanEndpointTypeSet(t *testing.T) {
-	testEndpointTypeSet(t, "macvlan", BridgedMacvlanEndpointType)
+func TestMacvlanEndpointTypeSet(t *testing.T) {
+	testEndpointTypeSet(t, "macvlan", MacvlanEndpointType)
 }
 
 func TestMacvtapEndpointTypeSet(t *testing.T) {
@@ -69,9 +69,9 @@ func TestVhostUserEndpointTypeString(t *testing.T) {
 	testEndpointTypeString(t, &endpointType, string(VhostUserEndpointType))
 }
 
-func TestBridgedMacvlanEndpointTypeString(t *testing.T) {
-	endpointType := BridgedMacvlanEndpointType
-	testEndpointTypeString(t, &endpointType, string(BridgedMacvlanEndpointType))
+func TestMacvlanEndpointTypeString(t *testing.T) {
+	endpointType := MacvlanEndpointType
+	testEndpointTypeString(t, &endpointType, string(MacvlanEndpointType))
 }
 
 func TestMacvtapEndpointTypeString(t *testing.T) {

--- a/src/runtime/virtcontainers/macvlan_endpoint_test.go
+++ b/src/runtime/virtcontainers/macvlan_endpoint_test.go
@@ -12,10 +12,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCreateBridgedMacvlanEndpoint(t *testing.T) {
+func TestCreateMacvlanEndpoint(t *testing.T) {
 	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
 
-	expected := &BridgedMacvlanEndpoint{
+	expected := &MacvlanEndpoint{
 		NetPair: NetworkInterfacePair{
 			TapInterface: TapInterface{
 				ID:   "uniqueTestID-4",
@@ -30,10 +30,10 @@ func TestCreateBridgedMacvlanEndpoint(t *testing.T) {
 			},
 			NetInterworkingModel: DefaultNetInterworkingModel,
 		},
-		EndpointType: BridgedMacvlanEndpointType,
+		EndpointType: MacvlanEndpointType,
 	}
 
-	result, err := createBridgedMacvlanNetworkEndpoint(4, "", DefaultNetInterworkingModel)
+	result, err := createMacvlanNetworkEndpoint(4, "", DefaultNetInterworkingModel)
 	assert.NoError(t, err)
 
 	// the resulting ID  will be random - so let's overwrite to test the rest of the flow

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -256,8 +256,8 @@ func generateEndpoints(typedEndpoints []TypedJSONEndpoint) ([]Endpoint, error) {
 			var endpoint VhostUserEndpoint
 			endpointInf = &endpoint
 
-		case BridgedMacvlanEndpointType:
-			var endpoint BridgedMacvlanEndpoint
+		case MacvlanEndpointType:
+			var endpoint MacvlanEndpoint
 			endpointInf = &endpoint
 
 		case MacvtapEndpointType:
@@ -378,7 +378,7 @@ func getLinkForEndpoint(endpoint Endpoint, netHandle *netlink.Handle) (netlink.L
 	switch ep := endpoint.(type) {
 	case *VethEndpoint:
 		link = &netlink.Veth{}
-	case *BridgedMacvlanEndpoint:
+	case *MacvlanEndpoint:
 		link = &netlink.Macvlan{}
 	case *IPVlanEndpoint:
 		link = &netlink.IPVlan{}
@@ -1254,7 +1254,7 @@ func createEndpoint(netInfo NetworkInfo, idx int, model NetInterworkingModel, li
 			endpoint, err = createVhostUserEndpoint(netInfo, socketPath)
 		} else if netInfo.Iface.Type == "macvlan" {
 			networkLogger().Infof("macvlan interface found")
-			endpoint, err = createBridgedMacvlanNetworkEndpoint(idx, netInfo.Iface.Name, model)
+			endpoint, err = createMacvlanNetworkEndpoint(idx, netInfo.Iface.Name, model)
 		} else if netInfo.Iface.Type == "macvtap" {
 			networkLogger().Infof("macvtap interface found")
 			endpoint, err = createMacvtapNetworkEndpoint(netInfo)
@@ -1456,7 +1456,7 @@ func (n *Network) Remove(ctx context.Context, ns *NetworkNamespace, hypervisor H
 func addRxRateLimiter(endpoint Endpoint, maxRate uint64) error {
 	var linkName string
 	switch ep := endpoint.(type) {
-	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *BridgedMacvlanEndpoint:
+	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
 		netPair := endpoint.NetworkPair()
 		linkName = netPair.TapInterface.TAPIface.Name
 	case *MacvtapEndpoint, *TapEndpoint:
@@ -1612,7 +1612,7 @@ func addTxRateLimiter(endpoint Endpoint, maxRate uint64) error {
 	var netPair *NetworkInterfacePair
 	var linkName string
 	switch ep := endpoint.(type) {
-	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *BridgedMacvlanEndpoint:
+	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
 		netPair = endpoint.NetworkPair()
 		switch netPair.NetInterworkingModel {
 		// For those endpoints we've already used tcfilter as their inter-networking model,
@@ -1685,7 +1685,7 @@ func removeHTBQdisc(linkName string) error {
 func removeRxRateLimiter(endpoint Endpoint, networkNSPath string) error {
 	var linkName string
 	switch ep := endpoint.(type) {
-	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *BridgedMacvlanEndpoint:
+	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
 		netPair := endpoint.NetworkPair()
 		linkName = netPair.TapInterface.TAPIface.Name
 	case *MacvtapEndpoint, *TapEndpoint:
@@ -1706,7 +1706,7 @@ func removeRxRateLimiter(endpoint Endpoint, networkNSPath string) error {
 func removeTxRateLimiter(endpoint Endpoint, networkNSPath string) error {
 	var linkName string
 	switch ep := endpoint.(type) {
-	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *BridgedMacvlanEndpoint:
+	case *VethEndpoint, *IPVlanEndpoint, *TuntapEndpoint, *MacvlanEndpoint:
 		netPair := endpoint.NetworkPair()
 		switch netPair.NetInterworkingModel {
 		case NetXConnectTCFilterModel:

--- a/src/runtime/virtcontainers/persist.go
+++ b/src/runtime/virtcontainers/persist.go
@@ -380,8 +380,8 @@ func (s *Sandbox) loadNetwork(netInfo persistapi.NetworkInfo) {
 			ep = &VethEndpoint{}
 		case VhostUserEndpointType:
 			ep = &VhostUserEndpoint{}
-		case BridgedMacvlanEndpointType:
-			ep = &BridgedMacvlanEndpoint{}
+		case MacvlanEndpointType:
+			ep = &MacvlanEndpoint{}
 		case MacvtapEndpointType:
 			ep = &MacvtapEndpoint{}
 		case TapEndpointType:

--- a/src/runtime/virtcontainers/persist/api/network.go
+++ b/src/runtime/virtcontainers/persist/api/network.go
@@ -60,7 +60,7 @@ type TuntapEndpoint struct {
 	TuntapInterface TuntapInterface
 }
 
-type BridgedMacvlanEndpoint struct {
+type MacvlanEndpoint struct {
 	NetPair NetworkInterfacePair
 }
 
@@ -82,14 +82,14 @@ type VhostUserEndpoint struct {
 // NetworkEndpoint contains network interface information
 type NetworkEndpoint struct {
 	// One and only one of these below are not nil according to Type.
-	Physical       *PhysicalEndpoint       `json:",omitempty"`
-	Veth           *VethEndpoint           `json:",omitempty"`
-	VhostUser      *VhostUserEndpoint      `json:",omitempty"`
-	BridgedMacvlan *BridgedMacvlanEndpoint `json:",omitempty"`
-	Macvtap        *MacvtapEndpoint        `json:",omitempty"`
-	Tap            *TapEndpoint            `json:",omitempty"`
-	IPVlan         *IPVlanEndpoint         `json:",omitempty"`
-	Tuntap         *TuntapEndpoint         `json:",omitempty"`
+	Physical  *PhysicalEndpoint  `json:",omitempty"`
+	Veth      *VethEndpoint      `json:",omitempty"`
+	VhostUser *VhostUserEndpoint `json:",omitempty"`
+	Macvlan   *MacvlanEndpoint   `json:",omitempty"`
+	Macvtap   *MacvtapEndpoint   `json:",omitempty"`
+	Tap       *TapEndpoint       `json:",omitempty"`
+	IPVlan    *IPVlanEndpoint    `json:",omitempty"`
+	Tuntap    *TuntapEndpoint    `json:",omitempty"`
 
 	Type string
 }

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -571,7 +571,7 @@ func networkModelToQemuType(model NetInterworkingModel) govmmQemu.NetDeviceType 
 func genericNetwork(endpoint Endpoint, vhost, nestedRun bool, index int) (govmmQemu.NetDevice, error) {
 	var d govmmQemu.NetDevice
 	switch ep := endpoint.(type) {
-	case *VethEndpoint, *BridgedMacvlanEndpoint, *IPVlanEndpoint:
+	case *VethEndpoint, *MacvlanEndpoint, *IPVlanEndpoint:
 		netPair := ep.NetworkPair()
 		d = govmmQemu.NetDevice{
 			Type:          networkModelToQemuType(netPair.NetInterworkingModel),

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -490,7 +490,7 @@ func TestQemuArchBaseAppendNetwork(t *testing.T) {
 
 	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
 
-	macvlanEp := &BridgedMacvlanEndpoint{
+	macvlanEp := &MacvlanEndpoint{
 		NetPair: NetworkInterfacePair{
 			TapInterface: TapInterface{
 				ID:   "uniqueTestID-4",
@@ -505,7 +505,7 @@ func TestQemuArchBaseAppendNetwork(t *testing.T) {
 			},
 			NetInterworkingModel: DefaultNetInterworkingModel,
 		},
-		EndpointType: BridgedMacvlanEndpointType,
+		EndpointType: MacvlanEndpointType,
 	}
 
 	macvtapEp := &MacvtapEndpoint{


### PR DESCRIPTION
The fact that we need to "bridge" the endpoint is a bit irrelevant. To
be consistent with the rest of the endpoints, let's just call this
"macvlan"

Note -- this doesn't introduce any functional changes.

Fixes: #3050

Signed-off-by: Eric Ernst <eric_ernst@apple.com>