### PR TITLE
versions: Update to current Rust 1.56.1

### DIFF
--- a/src/agent/src/uevent.rs
+++ b/src/agent/src/uevent.rs
@@ -240,7 +240,6 @@ pub(crate) fn spawn_test_watcher(sandbox: Arc<Mutex<Sandbox>>, uev: Uevent) {
                     if matcher.is_match(&uev) {
                         let (_, sender) = watch.take().unwrap();
                         let _ = sender.send(uev.clone());
-                        return;
                     }
                 }
             });

--- a/versions.yaml
+++ b/versions.yaml
@@ -258,12 +258,12 @@ languages:
   rust:
     description: "Rust language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.45.0"
+    version: "1.56"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.54.0"
+      newest-version: "1.56"
 
 specs:
   description: "Details of important specifications"


### PR DESCRIPTION
This updates the Rust versions listed in versions.yaml, both the minimum
and latest listed, to 1.56.1.  This Rust version:

- stabilizes the 2021 Rust edition, allowing us to use new edition
  features when we're ready

- introduces a rust-version flag in the Cargo.toml which will allow
  better Rust compiler version management (since native tools will
  understand it, not just our own scripts)

- A number of useful standard library extensions

fixes #3061

Signed-off-by: David Gibson <david@gibson.dropbear.id.au>