### PR TITLE
agent: fix the issue of missing create a new session for container

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -663,8 +663,8 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     let _ = unistd::close(crfd);
     let _ = unistd::close(cwfd);
 
+    unistd::setsid().context("create a new session")?;
     if oci_process.terminal {
-        unistd::setsid()?;
         unsafe {
             libc::ioctl(0, libc::TIOCSCTTY);
         }


### PR DESCRIPTION
When the container didn't had a tty console, it would be in a same
process group with the kata-agent, which wasn't expected. Thus,
create a new session for the container process.

Fixes: #3063

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>