### PR TITLE
stable-2.3: disable libudev when building static QEMU

### DIFF
--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -310,6 +310,11 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-qom-cast-debug)
 	qemu_options+=(size:--disable-tcmalloc)
 
+	# Disable libudev for static build
+	if gt_eq "${qemu_version}" "5.2.0" ; then
+		[ "${static}" == "true" ] && qemu_options+=(size:--disable-libudev)
+	fi
+
 	# Disallow network downloads
 	qemu_options+=(security:--disable-curl)
 


### PR DESCRIPTION
44e757a04b  qemu: fix snap build by disabling libudev

once #3003 is merged
