### PR TITLE
tools/packaging: use clone_tests_repo() from ci/lib.sh

### DIFF
--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -6,24 +6,13 @@
 #
 
 export GOPATH=${GOPATH:-${HOME}/go}
-export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
-export tests_repo_dir="$GOPATH/src/$tests_repo"
 
 this_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${this_script_dir}/../../../ci/lib.sh"
 
 short_commit_length=10
 
 hub_bin="hub-bin"
-
-clone_tests_repo() {
-	# KATA_CI_NO_NETWORK is (has to be) ignored if there is
-	# no existing clone.
-	if [ -d "${tests_repo_dir}" ] && [ -n "${KATA_CI_NO_NETWORK:-}" ]; then
-		return
-	fi
-
-	go get -d -u "$tests_repo" || true
-}
 
 install_yq() {
 	clone_tests_repo
@@ -35,6 +24,8 @@ install_yq() {
 get_from_kata_deps() {
 	local dependency="$1"
 	versions_file="${this_script_dir}/../../../versions.yaml"
+
+	install_yq >/dev/null
 
 	result=$("yq" read -X "$versions_file" "$dependency")
 	[ "$result" = "null" ] && result=""

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -12,7 +12,6 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
 readonly kernel_builder="${repo_root_dir}/tools/packaging/kernel/build-kernel.sh"
 
-
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
 container_image="kata-kernel-builder"
@@ -21,16 +20,19 @@ sudo docker build -t "${container_image}" "${script_dir}"
 
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \
+	--env GOPATH="${GOPATH}" \
 	"${container_image}" \
-	bash -c "${kernel_builder} $* setup"
+	bash -c "PATH=\$PATH:\$GOPATH/bin ${kernel_builder} $* setup"
 
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \
+	--env GOPATH="${GOPATH}" \
 	"${container_image}" \
-	bash -c "${kernel_builder} $* build"
+	bash -c "$PATH=\$PATH:\$GOPATH/bin {kernel_builder} $* build"
 
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \
+	--env GOPATH="${GOPATH}" \
 	--env DESTDIR="${DESTDIR}" --env PREFIX="${PREFIX}" \
 	"${container_image}" \
-	bash -c "${kernel_builder} $* install"
+	bash -c "PATH=\$PATH:\$GOPATH/bin ${kernel_builder} $* install"


### PR DESCRIPTION
This changed the tools/packaging/scripts/lib.sh to source from
ci/lib.sh so that clone_tests_repo() is reused. Its implementation
from clone_tests_repo() is more convenient because doesn't use
go to clone the tests repository (some scripts run on containers
where golang is not installed).
    
Fixes: #3086

Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>
Signed-off-by: Binbin Zhang <binbin36520@gmail.com>