### PR TITLE
agent: allow the clippy needless_return for the for_each block

### DIFF
--- a/src/agent/src/uevent.rs
+++ b/src/agent/src/uevent.rs
@@ -230,6 +230,7 @@ pub async fn watch_uevents(
 
 // Used in the device module unit tests
 #[cfg(test)]
+#[allow(clippy::needless_return)]
 pub(crate) fn spawn_test_watcher(sandbox: Arc<Mutex<Sandbox>>, uev: Uevent) {
     tokio::spawn(async move {
         loop {


### PR DESCRIPTION
the clippy needless_return would break the `make clippy` command,
when the for_each block using the `return;`. This PR fixed this bug
by using `#[allow(clippy::needless_return)]`. Keep the `make clippy`
command executing correctly.

Fixes: #3093

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>