### PR TITLE
docs: make kata-deploy more visible

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -12,8 +12,8 @@ Containers.
 
 Packaged installation methods uses your distribution's native package format (such as RPM or DEB).
 
-*Note:* We encourage installation methods that provides automatic updates, it ensures security updates and bug fixes are
-easily applied.
+> **Note:** We encourage installation methods that provides automatic updates, it ensures security updates and bug fixes are
+> easily applied.
 
 | Installation method                                  | Description                                                         | Automatic updates | Use case                                                 |
 |------------------------------------------------------|---------------------------------------------------------------------|-------------------|----------------------------------------------------------|
@@ -48,9 +48,9 @@ Follow the [containerd installation guide](container-manager/containerd/containe
 
 ## Build from source installation
 
-*Note:* Power users who decide to build from sources should be aware of the
-implications of using an unpackaged system which will not be automatically
-updated as new [releases](../Stable-Branch-Strategy.md) are made available.
+> **Note:** Power users who decide to build from sources should be aware of the
+> implications of using an unpackaged system which will not be automatically
+> updated as new [releases](../Stable-Branch-Strategy.md) are made available.
 
 [Building from sources](../Developer-Guide.md#initial-setup)  allows power users
 who are comfortable building software from source to use the latest component

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -15,13 +15,23 @@ Packaged installation methods uses your distribution's native package format (su
 > **Note:** We encourage installation methods that provides automatic updates, it ensures security updates and bug fixes are
 > easily applied.
 
-| Installation method                                  | Description                                                         | Automatic updates | Use case                                                 |
-|------------------------------------------------------|---------------------------------------------------------------------|-------------------|----------------------------------------------------------|
-| [Using official distro packages](#official-packages) | Kata packages provided by Linux distributions official repositories | yes               | Recommended for most users.                              |
-| [Using snap](#snap-installation)                     | Easy to install                                                     | yes               | Good alternative to official distro packages.            |
-| [Automatic](#automatic-installation)                 | Run a single command to install a full system                       | **No!**           | For those wanting the latest release quickly.            |
-| [Manual](#manual-installation)                       | Follow a guide step-by-step to install a working system             | **No!**           | For those who want the latest release with more control. |
-| [Build from source](#build-from-source-installation) | Build the software components manually                              | **No!**           | Power users and developers only.                         |
+| Installation method                                  | Description                                                                                  | Automatic updates | Use case                                                                                      |
+|------------------------------------------------------|----------------------------------------------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------------------|
+| [Using kata-deploy](#kata-deploy-installation)       | The preferred way to deploy the Kata Containers distributed binaries on a Kubernetes cluster | **No!**           | Best way to give it a try on kata-containers on an already up and running Kubernetes cluster. | 
+| [Using official distro packages](#official-packages) | Kata packages provided by Linux distributions official repositories                          | yes               | Recommended for most users.                                                                   |
+| [Using snap](#snap-installation)                     | Easy to install                                                                              | yes               | Good alternative to official distro packages.                                                 |
+| [Automatic](#automatic-installation)                 | Run a single command to install a full system                                                | **No!**           | For those wanting the latest release quickly.                                                 |
+| [Manual](#manual-installation)                       | Follow a guide step-by-step to install a working system                                      | **No!**           | For those who want the latest release with more control.                                      |
+| [Build from source](#build-from-source-installation) | Build the software components manually                                                       | **No!**           | Power users and developers only.                                                              |
+
+### Kata Deploy Installation
+
+Kata Deploy provides a Dockerfile, which contains all of the binaries and
+artifacts required to run Kata Containers, as well as reference DaemonSets,
+which can be utilized to install Kata Containers on a running Kubernetes
+cluster.
+
+[Use Kata Deploy](/tools/packaging/kata-deploy/README.md) to install Kata Containers on a Kubernetes Cluster.
 
 ### Official packages
 

--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -165,7 +165,7 @@ This image contains all the necessary artifacts for running Kata Containers, all
 from the [Kata Containers release page](https://github.com/kata-containers/kata-containers/releases).
 
 Host artifacts:
-* `cloud-hypervisor`, `firecracker`, `qemu-system-x86_64`, and supporting binaries
+* `cloud-hypervisor`, `firecracker`, `qemu`, and supporting binaries
 * `containerd-shim-kata-v2`
 * `kata-collect-data.sh`
 * `kata-runtime`

--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -4,8 +4,8 @@
 and artifacts required to run Kata Containers, as well as reference DaemonSets, which can
 be utilized to install Kata Containers on a running Kubernetes cluster.
 
-Note, installation through DaemonSets successfully installs `katacontainers.io/kata-runtime` on
-a node only if it uses either containerd or CRI-O CRI-shims.
+> **Note**: installation through DaemonSets successfully installs `katacontainers.io/kata-runtime`
+> on a node only if it uses either containerd or CRI-O CRI-shims.
 
 ## Kubernetes quick start
 
@@ -24,8 +24,8 @@ $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-contai
 
 The stable image refers to the last stable releases content.
 
-Note that if you use a tagged version of the repo, the stable image does match that version.
-For instance, if you use the 2.2.1 tagged version of the kata-deploy.yaml file, then the version 2.2.1 of the kata runtime will be deployed.
+> **Note:** if you use a tagged version of the repo, the stable image does match that version.
+> For instance, if you use the 2.2.1 tagged version of the kata-deploy.yaml file, then the version 2.2.1 of the kata runtime will be deployed.
 
 ```sh
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml


### PR DESCRIPTION
This PR moves kata deploy installation instructions to docs/install
folder, update wording and document format, adds an index to general
installation documentat

Fixes: #2450

Signed-off-by: João Vanzuita <joao.vanzuita@de.bosch.com>
Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>