### PR TITLE
Delint dockerfiles

### DIFF
--- a/ci/openshift-ci/images/Dockerfile.buildroot
+++ b/ci/openshift-ci/images/Dockerfile.buildroot
@@ -6,4 +6,9 @@
 #
 FROM registry.centos.org/centos:8
 
-RUN yum -y update && yum -y install git sudo wget
+RUN yum -y update && \
+    yum -y install \
+    git \
+    sudo \
+    wget && \
+    yum clean all

--- a/tools/osbuilder/dockerfiles/QAT/Dockerfile
+++ b/tools/osbuilder/dockerfiles/QAT/Dockerfile
@@ -42,7 +42,8 @@ RUN dnf install -y \
     systemd-devel \
     sudo \
     xz \
-    yasm
+    yasm && \
+    dnf clean all
 
 # Add in non-privileged user
 RUN useradd qatbuilder -p "" && \

--- a/tools/osbuilder/dracut/Dockerfile.in
+++ b/tools/osbuilder/dracut/Dockerfile.in
@@ -3,8 +3,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# openSUSE Tumbleweed image has only 'latest' tag so ignore DL3006 rule.
+# hadolint ignore=DL3006
 from opensuse/tumbleweed
 
+# zypper -y or --non-interactive can be used interchangeably here so ignore
+# DL3034 rule.
+# hadolint ignore=DL3034
 RUN zypper --non-interactive refresh; \
     zypper --non-interactive install --no-recommends --force-resolution \
     autoconf \

--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -5,6 +5,14 @@
 ARG IMAGE_REGISTRY=registry.fedoraproject.org
 FROM ${IMAGE_REGISTRY}/fedora:34
 
-RUN [ -n "$http_proxy" ] && sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true
-
-RUN dnf install -y qemu-img parted gdisk e2fsprogs gcc xfsprogs findutils
+RUN ([ -n "$http_proxy" ] && \
+    sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true) && \
+    dnf install -y \
+        e2fsprogs \
+        findutils \
+        gcc \
+        gdisk \
+        parted \
+        qemu-img \
+        xfsprogs && \
+    dnf clean all

--- a/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
@@ -32,7 +32,8 @@ RUN yum -y update && yum install -y \
     sed \
     tar \
     vim \
-    which
+    which && \
+    yum clean all
 
 # This will install the proper packages to build Kata components
 @INSTALL_MUSL@

--- a/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
@@ -35,7 +35,8 @@ RUN dnf -y update && dnf install -y \
     systemd \
     tar \
     vim \
-    which
+    which && \
+    dnf clean all
 
 # This will install the proper packages to build Kata components
 @INSTALL_MUSL@

--- a/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/fedora/Dockerfile.in
@@ -35,7 +35,8 @@ RUN dnf -y update && dnf install -y \
     systemd \
     tar \
     vim \
-    which
+    which && \
+    dnf clean all
 
 # This will install the proper packages to build Kata components
 @INSTALL_MUSL@

--- a/tools/osbuilder/rootfs-builder/gentoo/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/gentoo/Dockerfile.in
@@ -4,6 +4,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG IMAGE_REGISTRY=docker.io
+# stage3-amd64 image has only 'latest' tag so ignore DL3006 rule.
+# hadolint ignore=DL3007
 FROM ${IMAGE_REGISTRY}/gentoo/stage3-amd64:latest
 
 # This dockerfile needs to provide all the componets need to build a rootfs

--- a/tools/osbuilder/rootfs-builder/suse/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/suse/Dockerfile.in
@@ -6,7 +6,7 @@
 ARG IMAGE_REGISTRY=docker.io
 #suse: docker image to be used to create a rootfs
 #@OS_VERSION@: Docker image version to build this dockerfile
-FROM ${IMAGE_REGISTRY}/opensuse/leap
+FROM ${IMAGE_REGISTRY}/opensuse/leap:15.0
 
 # This dockerfile needs to provide all the componets need to build a rootfs
 # Install any package need to create a rootfs (package manager, extra tools)

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in
@@ -35,7 +35,9 @@ RUN apt-get update && apt-get install -y \
     sed \
     systemd \
     tar \
-    vim
+    vim && \
+    apt-get clean && rm -rf /var/lib/apt/lists/
+
 # This will install the proper packages to build Kata components
 @INSTALL_MUSL@
 @INSTALL_RUST@

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -6,7 +6,7 @@ FROM registry.centos.org/centos:7 AS base
 
 ENV container docker
 
-RUN (cd /lib/systemd/system/sysinit.target.wants/; for i in *; do [ $i == systemd-tmpfiles-setup.service ] || rm -f $i; done); \
+RUN (cd /lib/systemd/system/sysinit.target.wants/ && for i in *; do [ "$i" = systemd-tmpfiles-setup.service ] || rm -f "$i"; done); \
 rm -f /lib/systemd/system/multi-user.target.wants/*; \
 rm -f /etc/systemd/system/*.wants/*; \
 rm -f /lib/systemd/system/local-fs.target.wants/*; \
@@ -25,7 +25,7 @@ ARG KUBE_ARCH=amd64
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts
 
-COPY ${KATA_ARTIFACTS} .
+COPY ${KATA_ARTIFACTS} ${WORKDIR}
 
 RUN \
 yum -y update && \
@@ -37,7 +37,7 @@ tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION}/ && \
 chown -R root:root ${DESTINATION}/
 
 RUN \
-curl -Lso /bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${KUBE_ARCH}/kubectl && \
+curl -Lso /bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${KUBE_ARCH}/kubectl" && \
 chmod +x /bin/kubectl
 
 COPY scripts ${DESTINATION}/scripts

--- a/tools/packaging/kata-deploy/action/Dockerfile
+++ b/tools/packaging/kata-deploy/action/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM mcr.microsoft.com/azure-cli:latest
+FROM mcr.microsoft.com/azure-cli:2.9.1
 
 LABEL com.github.actions.name="Test kata-deploy in an AKS cluster"
 LABEL com.github.actions.description="Test kata-deploy in an AKS cluster"
@@ -16,14 +16,14 @@ ENV GITHUB_ACTION_NAME="Test kata-deploy in an AKS cluster"
 # PKG_SHA environment variable
 ENV PKG_SHA=HEAD
 
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl \
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl" \
   && chmod +x ./kubectl \
   && mv ./kubectl /usr/local/bin/kubectl
 
-RUN curl -LO https://github.com/Azure/aks-engine/releases/download/${AKS_ENGINE_VER}/aks-engine-${AKS_ENGINE_VER}-linux-${ARCH}.tar.gz \
-  && tar xvf aks-engine-${AKS_ENGINE_VER}-linux-${ARCH}.tar.gz \
-  && mv aks-engine-${AKS_ENGINE_VER}-linux-${ARCH}/aks-engine /usr/local/bin/aks-engine \
-  && rm aks-engine-${AKS_ENGINE_VER}-linux-${ARCH}.tar.gz
+RUN curl -LO "https://github.com/Azure/aks-engine/releases/download/${AKS_ENGINE_VER}/aks-engine-${AKS_ENGINE_VER}-linux-${ARCH}.tar.gz" \
+  && tar "xvf aks-engine-${AKS_ENGINE_VER}-linux-${ARCH}.tar.gz" \
+  && mv "aks-engine-${AKS_ENGINE_VER}-linux-${ARCH}/aks-engine" /usr/local/bin/aks-engine \
+  && rm "aks-engine-${AKS_ENGINE_VER}-linux-${ARCH}.tar.gz"
 
 COPY kubernetes-containerd.json /
 COPY setup-aks.sh test-kata.sh entrypoint.sh /

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -6,17 +6,19 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV INSTALL_IN_GOPATH=false
 
-ADD install_yq.sh /usr/bin/install_yq.sh
+COPY install_yq.sh /usr/bin/install_yq.sh
 
 
-# yq installer deps
-RUN apt update && apt-get install -y curl sudo
-
-# Install yq
-RUN install_yq.sh
-
-RUN curl -fsSL https://get.docker.com -o get-docker.sh
-RUN sh get-docker.sh
+# Install yq and docker
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        sudo && \
+    apt-get clean && rm -rf /var/lib/apt/lists/ && \
+    install_yq.sh && \
+    curl -fsSL https://get.docker.com -o get-docker.sh && \
+    sh get-docker.sh
 
 ARG IMG_USER=kata-builder
 ARG UID=1000
@@ -27,12 +29,14 @@ RUN sh -c "echo '${IMG_USER} ALL=NOPASSWD: ALL' >> /etc/sudoers"
 
 #FIXME: gcc is required as agent is build out of a container build.
 RUN apt-get update && \
-    apt install --no-install-recommends -y \
-    cpio \
-    gcc \
-    git \
-    make \
-    xz-utils
+  apt-get install --no-install-recommends -y \
+  build-essential \
+  cpio \
+  gcc \
+  git \
+  make \
+  xz-utils && \
+  apt-get clean && rm -rf /var/lib/apt/lists
 
 ENV USER ${IMG_USER}
 USER ${UID}:${GID}

--- a/tools/packaging/kata-monitor/Dockerfile
+++ b/tools/packaging/kata-monitor/Dockerfile
@@ -1,13 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.15-alpine
+FROM golang:1.15-alpine AS builder
 
-RUN apk add bash curl git make
+RUN apk add --no-cache bash curl git make
 WORKDIR /go/src/github.com/kata-containers/kata-containers/src/runtime
 COPY . /go/src/github.com/kata-containers/kata-containers
 RUN SKIP_GO_VERSION_CHECK=true make monitor
 
-FROM alpine:latest
-COPY --from=0 /go/src/github.com/kata-containers/kata-containers/src/runtime/kata-monitor /usr/bin/kata-monitor
+FROM alpine:3.14
+COPY --from=builder /go/src/github.com/kata-containers/kata-containers/src/runtime/kata-monitor /usr/bin/kata-monitor
 CMD ["-h"]
 ENTRYPOINT ["/usr/bin/kata-monitor"]

--- a/tools/packaging/kata-monitor/Dockerfile
+++ b/tools/packaging/kata-monitor/Dockerfile
@@ -1,3 +1,4 @@
+# Copyright (c) 2020 Eric Ernst
 # SPDX-License-Identifier: Apache-2.0
 
 FROM golang:1.15-alpine AS builder

--- a/tools/packaging/static-build/kernel/Dockerfile
+++ b/tools/packaging/static-build/kernel/Dockerfile
@@ -2,19 +2,20 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 # kernel deps
-RUN apt update
-RUN apt install -y \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
 	    bc \
 	    bison \
 	    build-essential \
+	    ca-certificates \
 	    curl \
 	    flex \
 	    git \
 	    iptables \
-	    libelf-dev
-
-RUN [ "$(uname -m)" = "s390x" ] && apt-get install -y libssl-dev || true
+	    libelf-dev && \
+    if [ "$(uname -m)" = "s390x" ]; then apt-get install -y --no-install-recommends libssl-dev; fi && \
+    apt-get clean && rm -rf /var/lib/lists/

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -12,8 +12,8 @@ WORKDIR /root/qemu
 ARG CACHE_TIMEOUT
 RUN echo "$CACHE_TIMEOUT"
 
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get --no-install-recommends install -y \
+RUN apt-get update && apt-get upgrade -y && \
+    apt-get --no-install-recommends install -y \
 	    apt-utils \
 	    autoconf \
 	    automake \
@@ -46,36 +46,33 @@ RUN apt-get --no-install-recommends install -y \
 	    python \
 	    python-dev \
 	    rsync \
-	    zlib1g-dev
-
-RUN [ "$(uname -m)" != "s390x" ] && apt-get install -y libpmem-dev || true
+	    zlib1g-dev && \
+    if [ "$(uname -m)" != "s390x" ]; then apt-get install -y --no-install-recommends libpmem-dev; fi && \
+    apt-get clean && rm -rf /var/lib/apt/lists/
 
 ARG QEMU_REPO
-
-RUN cd  .. && git clone --depth=1 "${QEMU_REPO}" qemu
-
 # commit/tag/branch
 ARG QEMU_VERSION
-
-RUN git fetch --depth=1 origin "${QEMU_VERSION}" && git checkout FETCH_HEAD
-RUN scripts/git-submodule.sh update meson capstone
-
-ADD scripts/configure-hypervisor.sh /root/configure-hypervisor.sh
-ADD qemu /root/kata_qemu
-ADD scripts/apply_patches.sh /root/apply_patches.sh
-ADD scripts/patch_qemu.sh /root/patch_qemu.sh
-
-RUN /root/patch_qemu.sh "${QEMU_VERSION}" "/root/kata_qemu/patches"
-
 ARG PREFIX
 ARG BUILD_SUFFIX
-RUN PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s "kata-qemu${BUILD_SUFFIX}" | xargs ./configure \
-	--with-pkgversion="kata-static${BUILD_SUFFIX}"
-
-RUN make -j$(nproc)
 ARG QEMU_DESTDIR
-RUN make install DESTDIR="${QEMU_DESTDIR}"
 ARG QEMU_TARBALL
-ADD static-build/scripts/qemu-build-post.sh /root/static-build/scripts/qemu-build-post.sh
-ADD static-build/qemu.blacklist /root/static-build/qemu.blacklist
-RUN /root/static-build/scripts/qemu-build-post.sh
+
+COPY scripts/configure-hypervisor.sh /root/configure-hypervisor.sh
+COPY qemu /root/kata_qemu
+COPY scripts/apply_patches.sh /root/apply_patches.sh
+COPY scripts/patch_qemu.sh /root/patch_qemu.sh
+COPY static-build/scripts/qemu-build-post.sh /root/static-build/scripts/qemu-build-post.sh
+COPY static-build/qemu.blacklist /root/static-build/qemu.blacklist
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN git clone --depth=1 "${QEMU_REPO}" qemu && \
+    cd qemu && \
+    git fetch --depth=1 origin "${QEMU_VERSION}" && git checkout FETCH_HEAD && \
+    scripts/git-submodule.sh update meson capstone && \
+    /root/patch_qemu.sh "${QEMU_VERSION}" "/root/kata_qemu/patches" && \
+    (PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s "kata-qemu${BUILD_SUFFIX}" | xargs ./configure \
+	--with-pkgversion="kata-static${BUILD_SUFFIX}") && \
+    make -j"$(nproc)" && \
+    make install DESTDIR="${QEMU_DESTDIR}" && \
+    /root/static-build/scripts/qemu-build-post.sh

--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -2,18 +2,21 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-    apt-get install -y \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
         curl \
         gcc \
         git \
         make \
-        sudo
+        sudo && \
+    apt-get clean && rm -rf /var/lib/apt/lists/
 
-ADD install_go.sh /usr/bin/install_go.sh
+COPY install_go.sh /usr/bin/install_go.sh
 ARG GO_VERSION
 RUN install_go.sh "${GO_VERSION}"
 ENV PATH=/usr/local/go/bin:${PATH}

--- a/tools/packaging/tests/Dockerfile/FedoraDockerfile.in
+++ b/tools/packaging/tests/Dockerfile/FedoraDockerfile.in
@@ -14,15 +14,14 @@ ENV GOPATH=/home/go
 ENV TESTS_REPOSITORY_PATH="${GOPATH}/src/${TESTS_REPO}"
 ENV AGENT_INIT=yes TEST_INITRD=yes OSBUILDER_DISTRO=alpine
 
-# Install packages
-RUN sudo dnf -y install kata-proxy kata-ksm-throttler kata-osbuilder kata-runtime kata-shim
-RUN sudo mkdir "${GOPATH}"
-RUN sudo dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo
-RUN sudo dnf makecache
-RUN sudo dnf -y install docker-ce
-RUN go get -d "${TESTS_REPO}"
-RUN cd "${TESTS_REPOSITORY_PATH}" && .ci/install_kata_image.sh
-RUN cd "${TESTS_REPOSITORY_PATH}" && .ci/install_kata_kernel.sh
-RUN kata-runtime kata-env
+# Install packages and build and install Kata Containers
+RUN dnf -y install kata-proxy kata-ksm-throttler kata-osbuilder kata-runtime kata-shim && \
+    mkdir "${GOPATH}" && \
+    dnf config-manager --add-repo https://download.docker.com/linux/fedora/docker-ce.repo && \
+    dnf makecache && dnf -y install docker-ce && dnf clean all && \
+    go get -d "${TESTS_REPO}" && \
+    cd "${TESTS_REPOSITORY_PATH}" && .ci/install_kata_image.sh && \
+    cd "${TESTS_REPOSITORY_PATH}" && .ci/install_kata_kernel.sh && \
+    kata-runtime kata-env
 
 CMD ["/bin/bash"]


### PR DESCRIPTION
I'm sending this PR in preparation to enable a checker on `static-checks.sh` which aims to [run a linter on the dockerfiles](https://github.com/kata-containers/tests/issues/4149) of the project.

That new checker will be using the [hadolint tool](https://github.com/hadolint/hadolint) to inspect the dockerfiles.  So the changes here were made to silent the warnings/errors pointed out by hadolint 2.7.0.

Note that we have a bunch of dockerfile templates on the project which can't be parsed by the tool without some tricks.  See on https://github.com/kata-containers/tests/pull/4194 how I plan to handle templates, but even with the handling some files fail to get parsed and that explain why they will be ignored.

Below is how I run the hadolint on kata-containers repository. 
```
$ curl -sL https://github.com/hadolint/hadolint/releases/download/v2.7.0/hadolint-Linux-x86_64 -o ~/go/bin/hadolint && chmod +x ~/go/bin/hadolint
$ cat dockerfile_linter.sh 
#!/bin/bash

cmd="$HOME/go/bin/hadolint --ignore DL3003 --ignore DL3048 --ignore DL3041 --ignore DL3033 --ignore DL3008 --ignore DL3018 --ignore DL3037 --failure-threshold warning"

ignore_files=(
	"tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in"
	"tools/osbuilder/rootfs-builder/centos/Dockerfile.in"
	"tools/osbuilder/rootfs-builder/debian/Dockerfile.in"
	"tools/osbuilder/rootfs-builder/fedora/Dockerfile.in"
        "tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in"
	"tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in"
	"tools/packaging/tests/Dockerfile/Dockerfile.in"
	"tools/packaging/tests/Dockerfile/FedoraDockerfile.in"
	)
for f in `git ls-files | grep "Dockerfile" | grep -v '/vendor/' | grep -v 'template$'`; do
	echo "== Linting $f =="
	if echo "${ignore_files[@]}" | grep -q $f ; then
		echo 'skip'
		continue
	elif [[ "$f" =~ Dockerfile.*.in ]]; then
		sed -e 's/@[A-Z_]*@//' "$f" | $cmd - || exit 1
	else
		${cmd} $f || exit 1
	fi
done
$ ./dockerfile_linter.sh
== Linting ci/openshift-ci/images/Dockerfile.buildroot ==
== Linting tools/osbuilder/dockerfiles/QAT/Dockerfile ==
== Linting tools/osbuilder/dracut/Dockerfile.in ==
== Linting tools/osbuilder/image-builder/Dockerfile ==
== Linting tools/osbuilder/rootfs-builder/alpine/Dockerfile.in ==
-:9 DL3019 info: Use the `--no-cache` switch to avoid the need to use `--update` and remove `/var/cache/apk/*` when done installing packages
== Linting tools/osbuilder/rootfs-builder/centos/Dockerfile.in ==
skip
== Linting tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in ==
== Linting tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in ==
skip
== Linting tools/osbuilder/rootfs-builder/debian/Dockerfile.in ==
skip
== Linting tools/osbuilder/rootfs-builder/fedora/Dockerfile.in ==
skip
== Linting tools/osbuilder/rootfs-builder/gentoo/Dockerfile.in ==
== Linting tools/osbuilder/rootfs-builder/suse/Dockerfile.in ==
== Linting tools/osbuilder/rootfs-builder/ubuntu/Dockerfile-aarch64.in ==
skip
== Linting tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in ==
skip
== Linting tools/packaging/kata-deploy/Dockerfile ==
tools/packaging/kata-deploy/Dockerfile:39 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
== Linting tools/packaging/kata-deploy/action/Dockerfile ==
tools/packaging/kata-deploy/action/Dockerfile:23 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
== Linting tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile ==
tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile:26 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile:27 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
== Linting tools/packaging/kata-monitor/Dockerfile ==
== Linting tools/packaging/static-build/kernel/Dockerfile ==
== Linting tools/packaging/static-build/qemu/Dockerfile ==
tools/packaging/static-build/qemu/Dockerfile:15 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
== Linting tools/packaging/static-build/shim-v2/Dockerfile ==
== Linting tools/packaging/tests/Dockerfile/Dockerfile.in ==
skip
== Linting tools/packaging/tests/Dockerfile/FedoraDockerfile.in ==
skip
```