### PR TITLE
ccv0: Support kata-deploy

### DIFF
--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -28,6 +28,7 @@ RUN sh -c "echo '${IMG_USER} ALL=NOPASSWD: ALL' >> /etc/sudoers"
 #FIXME: gcc is required as agent is build out of a container build.
 RUN apt-get update && \
   apt install -y \
+  cpio \
   gcc \
   git \
   make \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -37,7 +37,11 @@ docker build -q -t build-kata-deploy \
 docker run ${TTY_OPT} \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	--user ${uid}:${gid} \
-	--env USER=${USER} -v "${kata_dir}:${kata_dir}" \
+	--env USER=${USER} \
+	--env SKOPEO_UMOCI="${SKOPEO_UMOCI:-}" \
+	--env AA_KBC="${AA_KBC:-}" \
+	--env INCLUDE_ROOTFS="${INCLUDE_ROOTFS:-}" \
+	-v "${kata_dir}:${kata_dir}" \
 	--rm \
 	-w ${script_dir} \
 	build-kata-deploy "${kata_deploy_create}" $@

--- a/versions.yaml
+++ b/versions.yaml
@@ -138,8 +138,8 @@ assets:
     url: "https://github.com/kata-containers/kata-containers/tools/osbuilder"
     architecture:
       aarch64:
-        name: &default-initrd-name "alpine"
-        version: &default-initrd-version "3.13.5"
+        name: &default-initrd-name "ubuntu"
+        version: &default-initrd-version "20.04"
       ppc64le:
         name: *default-initrd-name
         version: *default-initrd-version


### PR DESCRIPTION
This is still a draft, but it is supposed to shine a little light on how we might deploy CCv0 along with the [operator payload image config](https://github.com/confidential-containers/operator/tree/ccv0-demo/demo/payload-image).
The image would be built with something like `SKOPEO_UMOCI=yes AA_KBC=offline_fs_kbc INCLUDE_ETC="$(realpath aa-offline_fs_kbc-keys.json) $(realpath kata-config.toml)" make` (files must be in repo so they're included in the build container).

@sameo do you think this is the way to go at all?
/cc @bpradipt