### PR TITLE
workflows: only allow org members to run `/test_kata_deploy`

### DIFF
--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -5,13 +5,38 @@ on:
 name: test-kata-deploy
 
 jobs:
-  build-asset:
+  check-comment-and-membership:
+    runs-on: ubuntu-latest
     if: |
       github.event.issue.pull_request
       && github.event_name == 'issue_comment'
       && github.event.action == 'created'
       && startsWith(github.event.comment.body, '/test_kata_deploy')
+    steps:
+      - name: Check membership
+        uses: kata-containers/is-organization-member@1.0.1
+        id: is_organization_member
+        with:
+          organization: kata-containers
+          username: ${{ github.event.comment.user.login }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fail if not member
+        run: |
+          result=${{ steps.is_organization_member.outputs.result }}
+          if [ $result == false ]; then
+              user=${{ github.event.comment.user.login }}
+              echo Either ${user} is not part of the kata-containers organization
+              echo or ${user} has its Organization Visibility set to Private at
+              echo https://github.com/orgs/kata-containers/people?query=${user}
+              echo 
+              echo Ensure you change your Organization Visibility to Public and
+              echo trigger the test again.
+              exit 1
+          fi
+
+  build-asset:
     runs-on: ubuntu-latest
+    needs: check-comment-and-membership
     strategy:
       matrix:
         asset:


### PR DESCRIPTION
Let's take advantage of the "is-organization-member" action and only
allow members who are part of the `kata-containers` organization to
trigger `/test_kata_deploy`.

One caveat with this approach is that for the user to be considered as
part of an organization, they **must** have their "Organization
Visibility" configured as Public (and I think the default is Private).

This was found out and suggested by @jcvenegas!

Fixes: #3130

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>