### PR TITLE
stable-2.3 | tools/osbuilder: build QAT kernel in fedora 34

### DIFF
--- a/tools/osbuilder/dockerfiles/QAT/Dockerfile
+++ b/tools/osbuilder/dockerfiles/QAT/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Kata osbuilder 'works best' on Fedora
-FROM fedora:latest
+FROM fedora:34
 
 # Version of the Dockerfile - update if you change this file to avoid 'stale'
 # images being pulled from the registry.


### PR DESCRIPTION
kernel compiled in fedora 35 (latest) is not working, following error
is reported:

```
qemu-system-x86_64: Error loading uncompressed kernel without PVH ELF
Note
```

Build QAT kernel in fedora 34 container to fix it

fixes #3135

Signed-off-by: Julio Montes <julio.montes@intel.com>
(cherry picked from commit 857501d8dd7d6c8469c13920d5fad62a47be3219)
Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>