### PR TITLE
stable-2.3 | osbuilder: add coreutils to guest rootfs

### DIFF
--- a/tools/osbuilder/rootfs-builder/centos/config.sh
+++ b/tools/osbuilder/rootfs-builder/centos/config.sh
@@ -22,7 +22,7 @@ GPG_KEY_URL="https://www.centos.org/keys/RPM-GPG-KEY-CentOS-7"
 
 GPG_KEY_FILE="RPM-GPG-KEY-CentOS-7"
 
-PACKAGES="iptables chrony"
+PACKAGES="coreutils chrony"
 
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent

--- a/tools/osbuilder/rootfs-builder/debian/config.sh
+++ b/tools/osbuilder/rootfs-builder/debian/config.sh
@@ -8,7 +8,7 @@ OS_VERSION=${OS_VERSION:-9.5}
 # Set OS_NAME to the desired debian "codename"
 OS_NAME=${OS_NAME:-"stretch"}
 
-PACKAGES="systemd iptables init chrony kmod"
+PACKAGES="systemd coreutils init chrony kmod"
 
 # NOTE: Re-using ubuntu rootfs configuration, see 'ubuntu' folder for full content.
 source $script_dir/ubuntu/$CONFIG_SH

--- a/tools/osbuilder/rootfs-builder/fedora/config.sh
+++ b/tools/osbuilder/rootfs-builder/fedora/config.sh
@@ -9,7 +9,7 @@ OS_VERSION=${OS_VERSION:-30}
 
 MIRROR_LIST="https://mirrors.fedoraproject.org/metalink?repo=fedora-${OS_VERSION}&arch=\$basearch"
 
-PACKAGES="iptables chrony"
+PACKAGES="coreutils chrony"
 
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent

--- a/tools/osbuilder/rootfs-builder/gentoo/config.sh
+++ b/tools/osbuilder/rootfs-builder/gentoo/config.sh
@@ -11,7 +11,7 @@ OS_VERSION=${OS_VERSION:-latest}
 OS_NAME=${OS_NAME:-"gentoo"}
 
 # packages to be installed by default
-PACKAGES="sys-apps/systemd net-firewall/iptables net-misc/chrony"
+PACKAGES="sys-apps/systemd sys-apps/coreutils net-misc/chrony"
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd

--- a/tools/osbuilder/rootfs-builder/suse/config.sh
+++ b/tools/osbuilder/rootfs-builder/suse/config.sh
@@ -12,7 +12,7 @@ OS_VERSION=${OS_VERSION:-15.0}
 OS_IDENTIFIER="$OS_DISTRO${OS_VERSION:+:$OS_VERSION}"
 
 # Extra packages to install in the rootfs
-PACKAGES="systemd iptables libudev1"
+PACKAGES="systemd coreutils libudev1"
 
 #  http or https
 REPO_TRANSPORT="https"

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -12,7 +12,7 @@ OS_VERSION=${OS_VERSION:-20.04}
 OS_NAME=${OS_NAME:-"focal"}
 
 # packages to be installed by default
-PACKAGES="systemd iptables init kmod"
+PACKAGES="systemd coreutils init kmod"
 EXTRA_PKGS+=" chrony"
 
 DEBOOTSTRAP=${PACKAGE_MANAGER:-"debootstrap"}


### PR DESCRIPTION
So that the debug console is more useful. In the meantime, remove
iptables as it is not used by kata-agent any more.
