### PR TITLE
osbuilder: fix missing cpio package when building rootfs-initrd image

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -4,9 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+[ -z "${DEBUG}" ] || set -x
 
-[ -n "${DEBUG}" ] && set -x
+set -o errexit
+# set -o nounset
+set -o pipefail
 
 DOCKER_RUNTIME=${DOCKER_RUNTIME:-runc}
 

--- a/tools/osbuilder/initrd-builder/initrd_builder.sh
+++ b/tools/osbuilder/initrd-builder/initrd_builder.sh
@@ -4,9 +4,11 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-set -e
+[ -z "${DEBUG}" ] || set -x
 
-[ -n "$DEBUG" ] && set -x
+set -o errexit
+# set -o nounset
+set -o pipefail
 
 script_name="${0##*/}"
 script_dir="$(dirname $(readlink -f $0))"

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV INSTALL_IN_GOPATH=false
 
@@ -27,11 +27,12 @@ RUN sh -c "echo '${IMG_USER} ALL=NOPASSWD: ALL' >> /etc/sudoers"
 
 #FIXME: gcc is required as agent is build out of a container build.
 RUN apt-get update && \
-  apt install -y \
-  gcc \
-  git \
-  make \
-  xz-utils
+    apt install --no-install-recommends -y \
+    cpio \
+    gcc \
+    git \
+    make \
+    xz-utils
 
 ENV USER ${IMG_USER}
 USER ${UID}:${GID}


### PR DESCRIPTION
1. install cpio package before building rootfs-initrd image
2. add `pipefail` check to the script

Fixes: #3144

Signed-off-by: Binbin Zhang <binbin36520@gmail.com>