### PR TITLE
CCv0|osbuilder: integrate AA's EAA KBC into ubuntu rootfs image

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -681,7 +681,12 @@ EOT
 		pushd attestation-agent
 		source "${HOME}/.cargo/env"
 		target="${ARCH}-unknown-linux-${LIBC}"
-		cargo build --release --target "${target}" --no-default-features --features "${AA_KBC}"
+		if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
+			AA_RUSTFLAG="-C link-args=-Wl,-rpath,/usr/local/lib/rats-tls"
+			# Currently eaa_kbc module only support this specific platform
+			target="x86_64-unknown-linux-gnu"
+		fi
+		RUSTFLAGS=${AA_RUSTFLAG} cargo build --release --target "${target}" --no-default-features --features "${AA_KBC}"
 		install -o root -g root -m 0755 "target/${target}/release/attestation-agent" "${ROOTFS_DIR}/usr/local/bin/"
 		popd
 	fi

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -48,3 +48,4 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
 
 # This will install the proper packages to build Kata components
 @INSTALL_RUST@
+@INSTALL_AA_KBC@

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -33,3 +33,12 @@ ARCH_EXCLUDE_LIST=()
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2" || true
 [ -n "$SKOPEO_UMOCI" ] && PACKAGES+=" ca-certificates libgpgme11" || true
+
+if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
+    AA_KBC_EXTRAS="
+RUN echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04 bionic main' \| tee /etc/apt/sources.list.d/inclavare-containers.list; \
+    wget -qO - http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04/DEB-GPG-KEY.key  \| apt-key add -; \
+    apt-get update; \
+    apt-get install -y rats-tls
+"
+fi

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -75,4 +75,13 @@ build_rootfs() {
     # Reduce image size and memory footprint
     # removing not needed files and directories.
     chroot $ROOTFS_DIR rm -rf /usr/share/{bash-completion,bug,doc,info,lintian,locale,man,menu,misc,pixmaps,terminfo,zoneinfo,zsh}
+
+ 	if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
+		wget -qO - http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04/DEB-GPG-KEY.key  | chroot $ROOTFS_DIR apt-key add -
+		cat << EOF | chroot $ROOTFS_DIR
+echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04 bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
+apt-get update
+apt-get install -y rats-tls
+EOF
+	fi
 }

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -349,6 +349,7 @@ RUN ln -sf /usr/bin/g++ /bin/musl-g++
 			-e "s|@INSTALL_MUSL@|${install_musl//$'\n'/\\n}|g" \
 			-e "s|@INSTALL_RUST@|${install_rust//$'\n'/\\n}|g" \
 			-e "s|@SET_PROXY@|${set_proxy:-}|g" \
+			-e "s|@INSTALL_AA_KBC@|${AA_KBC_EXTRAS//$'\n'/\\n}|g" \
 			"${dockerfile_template}" > Dockerfile
 	fi
 	popd


### PR DESCRIPTION
1.Integrate EAA KBC into CCv0 ubuntu rootfs image. 
2.And also fix the build failure if build rootfs image with "AA_KBC=eaa_kbc" option.