### PR TITLE
agent: copy empty directories for watchable-bind mounts

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -777,7 +777,7 @@ fn mount_from(
         let _ = fs::create_dir_all(&dir).map_err(|e| {
             log_child!(
                 cfd_log,
-                "creat dir {}: {}",
+                "create dir {}: {}",
                 dir.to_str().unwrap(),
                 e.to_string()
             )


### PR DESCRIPTION
In function `update_target`, if the updated source is a directory,
    we should create the corresponding directory.

Fixes: #3140

Signed-off-by: bin <bin@hyper.sh>