### PR TITLE
Stop skopeo being installed by default 

### DIFF
--- a/docs/how-to/ccv0.sh
+++ b/docs/how-to/ccv0.sh
@@ -232,7 +232,7 @@ create_a_local_rootfs() {
     cd ${katacontainers_repo_dir}/tools/osbuilder/rootfs-builder
     export distro="ubuntu"
     [[ -z "${USE_PODMAN:-}" ]] && use_docker="${use_docker:-1}"
-    sudo -E OS_VERSION="${OS_VERSION:-}" GOPATH=$GOPATH DEBUG="${DEBUG}" USE_DOCKER="${use_docker:-}" SKOPEO_UMOCI=yes SECCOMP=yes ./rootfs.sh -r ${ROOTFS_DIR} ${distro}
+    sudo -E OS_VERSION="${OS_VERSION:-}" GOPATH=$GOPATH DEBUG="${DEBUG}" USE_DOCKER="${use_docker:-}" SKOPEO=${SKOPEO:-} UMOCI=yes SECCOMP=yes ./rootfs.sh -r ${ROOTFS_DIR} ${distro}
 
     # During the ./rootfs.sh call the kata agent is built as root, so we need to update the permissions, so we can rebuild it
     sudo chown -R ${USER}:${USER} "${katacontainers_repo_dir}/src/agent/"

--- a/docs/how-to/how-to-build-and-test-ccv0.md
+++ b/docs/how-to/how-to-build-and-test-ccv0.md
@@ -35,6 +35,9 @@ In order to build, and demo the CCv0 functionality, these are the steps I take:
       If you want to build and run these you can export the `katacontainers_repo`, `katacontainers_branch`, `tests_repo`
       and `tests_branch` variables e.g. `export katacontainers_repo=github.com/stevenhorsman/kata-containers && export katacontainers_branch=stevenh/agent-pull-image-endpoint && export tests_repo=github.com/stevenhorsman/tests && export tests_branch=stevenh/add-ccvo-changes-to-build`
       before running the script.
+    - By default `ccv0.sh` enables the agent to use the rust implementation to pull container images on the guest. If
+      you wish to instead build and include the `skopeo` package for this then set `export SKOPEO=yes`. `skopeo` is
+      required for verifying container image signatures of pulled images.
 - Run the full build process with `. ~/ccv0.sh -d build_and_install_all`
     - *I run this script sourced just so that the required installed components are accessible on the `PATH` to the rest*
       *of the process without having to reload the session.*

--- a/tools/osbuilder/rootfs-builder/README.md
+++ b/tools/osbuilder/rootfs-builder/README.md
@@ -196,6 +196,7 @@ needed. Changes affect the files included in the final guest image.
 
 #### Confidential containers support
 
-When building the rootfs for confidential containers if `SKOPEO_UMOCI=yes` is set then the `skopeo` and `umoci`
-packages are built and added into the rootfs. It also adds the signature verification proof of concept files.
+When building the rootfs for confidential containers if `SKOPEO=yes` is set then the `skopeo`
+package is built and added into the rootfs. It also adds the signature verification proof of concept files.
+If `UMOCI=yes` is set then the `umoci` package is built and added into the rootfs.
 For more info on these, see [the documentation](signed-container-artifacts/README.md).

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -12,7 +12,9 @@ OS_VERSION=${OS_VERSION:-20.04}
 OS_NAME=${OS_NAME:-"focal"}
 
 # packages to be installed by default
-PACKAGES="systemd iptables init kmod"
+# Note: ca-certificates is required for confidential containers
+# to pull the container image on the guest
+PACKAGES="systemd iptables init kmod ca-certificates"
 EXTRA_PKGS+=" chrony"
 
 DEBOOTSTRAP=${PACKAGE_MANAGER:-"debootstrap"}
@@ -32,7 +34,7 @@ INIT_PROCESS=systemd
 ARCH_EXCLUDE_LIST=()
 
 [ "$SECCOMP" = "yes" ] && PACKAGES+=" libseccomp2" || true
-[ -n "$SKOPEO_UMOCI" ] && PACKAGES+=" ca-certificates libgpgme11" || true
+[ "$SKOPEO" = "yes" ] && PACKAGES+=" libgpgme11" || true
 
 if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
     AA_KBC_EXTRAS="

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -219,11 +219,16 @@ ${extra}
 	  agent-is-init-daemon: "${AGENT_INIT}"
 EOT
 
-	if [ "${SKOPEO_UMOCI}" = "yes" ]; then
+	if [ "${SKOPEO}" = "yes" ]; then
 		cat >> "${file}" <<-EOF
 	skopeo:
 	  url: "${skopeo_url}"
 	  version: "${skopeo_branch}"
+EOF
+	fi
+
+	if [ "${UMOCI}" = "yes" ]; then
+		cat >> "${file}" <<-EOF
 	umoci:
 	  url: "${umoci_url}"
 	  version: "${umoci_tag}"

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -49,7 +49,8 @@ build_image() {
 	info "image os: $img_distro"
 	info "image os version: $img_os_version"
 	# CCv0 on image is currently unsupported, do not pass
-	unset SKOPEO_UMOCI
+	unset SKOPEO
+	unset UMOCI
 	unset AA_KBC
 	sudo -E PATH="${PATH}" make image \
 		DISTRO="${img_distro}" \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -38,7 +38,8 @@ docker run ${TTY_OPT} \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	--user ${uid}:${gid} \
 	--env USER=${USER} \
-	--env SKOPEO_UMOCI="${SKOPEO_UMOCI:-}" \
+	--env SKOPEO="${SKOPEO:-}" \
+	--env UMOCI="${UMOCI:-}" \
 	--env AA_KBC="${AA_KBC:-}" \
 	--env INCLUDE_ROOTFS="${INCLUDE_ROOTFS:-}" \
 	-v "${kata_dir}:${kata_dir}" \


### PR DESCRIPTION
With the new rust image pull service skopeo we can parameterise whether to build
and install skopeo and turn it off by default if we don't need
signature verification support

Fixes: #3170