### PR TITLE
docs: Update limitation document regarding docker swarm

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -86,21 +86,6 @@ All other configurations are supported and are working properly.
 
 ## Networking
 
-### Docker swarm and compose support
-
-The newest version of Docker supported is specified by the
-`externals.docker.version` variable in the
-[versions database](https://github.com/kata-containers/runtime/blob/master/versions.yaml).
-
-Basic Docker swarm support works. However, if you want to use custom networks
-with Docker's swarm, an older version of Docker is required. This is specified
-by the `externals.docker.meta.swarm-version` variable in the
-[versions database](https://github.com/kata-containers/runtime/blob/master/versions.yaml).
-
-See issue https://github.com/kata-containers/runtime/issues/175 for more information.
-
-Docker compose normally uses custom networks, so also has the same limitations.
-
 ## Resource management
 
 Due to the way VMs differ in their CPU and memory allocation, and sharing


### PR DESCRIPTION
This PR removes the information about docker swarm and docker compose
as currently for kata 2.0 we have not support for docker swarm and docker compose and the links and references that the document is referring are currently not part of kata 2.0

Fixes #3174

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>