### PR TITLE
Cleanup some unused variables, definitions

### DIFF
--- a/src/agent/src/network.rs
+++ b/src/agent/src/network.rs
@@ -20,9 +20,7 @@ pub struct Network {
 
 impl Network {
     pub fn new() -> Network {
-        Network {
-            dns: Vec::new(),
-        }
+        Network { dns: Vec::new() }
     }
 
     pub fn set_dns(&mut self, dns: String) {

--- a/src/agent/src/network.rs
+++ b/src/agent/src/network.rs
@@ -5,28 +5,22 @@
 
 use anyhow::{anyhow, Result};
 use nix::mount::{self, MsFlags};
-use protocols::types::{Interface, Route};
 use slog::Logger;
-use std::collections::HashMap;
 use std::fs;
 
 const KATA_GUEST_SANDBOX_DNS_FILE: &str = "/run/kata-containers/sandbox/resolv.conf";
 const GUEST_DNS_FILE: &str = "/etc/resolv.conf";
 
-// Network fully describes a sandbox network with its interfaces, routes and dns
+// Network describes a sandbox network, includings its dns
 // related information.
 #[derive(Debug, Default)]
 pub struct Network {
-    ifaces: HashMap<String, Interface>,
-    routes: Vec<Route>,
     dns: Vec<String>,
 }
 
 impl Network {
     pub fn new() -> Network {
         Network {
-            ifaces: HashMap::new(),
-            routes: Vec::new(),
             dns: Vec::new(),
         }
     }


### PR DESCRIPTION
1.57 rust toolchain introduces additional lints, which highlight some unread fields in the agent.

Let's clean this up!