### PR TITLE
runtime: enable vhost-net for rootless hypervisor

### DIFF
--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -27,7 +27,6 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/uuid"
 	pbTypes "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/rootless"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 )
 
@@ -311,12 +310,7 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) err
 		queues = int(h.HypervisorConfig().NumVCPUs)
 	}
 
-	var disableVhostNet bool
-	if rootless.IsRootless() {
-		disableVhostNet = true
-	} else {
-		disableVhostNet = h.HypervisorConfig().DisableVhostNet
-	}
+	disableVhostNet := h.HypervisorConfig().DisableVhostNet
 
 	if netPair.NetInterworkingModel == NetXConnectDefaultModel {
 		netPair.NetInterworkingModel = DefaultNetInterworkingModel


### PR DESCRIPTION
vhost-net is disabled in the rootless hypervisor. Because I reused the rootless code base for rootless kata runtime, which has been abandoned since kata 2.0. This change removes the disable logic under rootless flag. 

Fixes #3182

Signed-off-by: Feng Wang <feng.wang@databricks.com>