### PR TITLE
update apiVersion

### DIFF
--- a/docs/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
+++ b/docs/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
@@ -154,7 +154,7 @@ From Kubernetes v1.12, users can use [`RuntimeClass`](https://kubernetes.io/docs
 
 ```bash
 $ cat > runtime.yaml <<EOF
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: kata

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -1,6 +1,6 @@
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 metadata:
     name: kata-qemu
 handler: kata-qemu
@@ -13,7 +13,7 @@ scheduling:
     katacontainers.io/kata-runtime: "true"
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 metadata:
     name: kata-clh
 handler: kata-clh
@@ -26,7 +26,7 @@ scheduling:
     katacontainers.io/kata-runtime: "true"
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 metadata:
     name: kata-fc
 handler: kata-fc


### PR DESCRIPTION
kata-deploy: Update API Version of RuntimeClass to v1
API Version of node.k8s.io/v1beta1 is deprecated in
v1.22+, unavailable in v1.25+

Fixes: #3185
