### PR TITLE
kata-deploy: Update RuntimeClass' API Version to v1

### DIFF
--- a/docs/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
+++ b/docs/how-to/how-to-use-k8s-with-cri-containerd-and-kata.md
@@ -153,15 +153,15 @@ By default, all pods are created with the default runtime configured in CRI cont
 From Kubernetes v1.12, users can use [`RuntimeClass`](https://kubernetes.io/docs/concepts/containers/runtime-class/#runtime-class) to specify a different runtime for Pods.
 
 ```bash
-$ cat > runtime.yaml <<EOF
-apiVersion: node.k8s.io/v1beta1
+$ cat > kata-runtimeclass.yaml <<EOF
+apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
   name: kata
 handler: kata
 EOF
 
-$ sudo -E kubectl apply -f runtime.yaml
+$ sudo -E kubectl apply -f kata-runtimeclass.yaml
 ```
 
 ## Run pod in Kata Containers

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -1,6 +1,6 @@
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 metadata:
     name: kata-qemu
 handler: kata-qemu
@@ -13,7 +13,7 @@ scheduling:
     katacontainers.io/kata-runtime: "true"
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 metadata:
     name: kata-clh
 handler: kata-clh
@@ -26,7 +26,7 @@ scheduling:
     katacontainers.io/kata-runtime: "true"
 ---
 kind: RuntimeClass
-apiVersion: node.k8s.io/v1beta1
+apiVersion: node.k8s.io/v1
 metadata:
     name: kata-fc
 handler: kata-fc


### PR DESCRIPTION
RuntimeClass' API Version of node.k8s.io/v1beta1 is
deprecated in v1.22+, unavailable in v1.25+

Fixes: #3185

Signed-off-by: Binbin Zhang <binbin36520@gmail.com>