### PR TITLE
github: Add workflow for deploying a CCv0 demo

### DIFF
--- a/.github/workflows/deploy-ccv0-demo.yaml
+++ b/.github/workflows/deploy-ccv0-demo.yaml
@@ -1,0 +1,126 @@
+on:
+  issue_comment:
+    types: [created, edited]
+
+name: deploy-ccv0-demo
+
+jobs:
+  check-comment-and-membership:
+    runs-on: ubuntu-latest
+    if: |
+      github.event.issue.pull_request
+      && github.event_name == 'issue_comment'
+      && github.event.action == 'created'
+      && startsWith(github.event.comment.body, '/deploy-ccv0-demo')
+    steps:
+      - name: Check membership
+        uses: kata-containers/is-organization-member@1.0.1
+        id: is_organization_member
+        with:
+          organization: kata-containers
+          username: ${{ github.event.comment.user.login }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Fail if not member
+        run: |
+          result=${{ steps.is_organization_member.outputs.result }}
+          if [ $result == false ]; then
+              user=${{ github.event.comment.user.login }}
+              echo Either ${user} is not part of the kata-containers organization
+              echo or ${user} has its Organization Visibility set to Private at
+              echo https://github.com/orgs/kata-containers/people?query=${user}
+              echo 
+              echo Ensure you change your Organization Visibility to Public and
+              echo trigger the test again.
+              exit 1
+          fi
+
+  build-asset:
+    runs-on: ubuntu-latest
+    needs: check-comment-and-membership
+    strategy:
+      matrix:
+        asset:
+          - cloud-hypervisor
+          - firecracker
+          - kernel
+          - qemu
+          - rootfs-image
+          - rootfs-initrd
+          - shim-v2
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install docker
+        run: |
+          curl -fsSL https://test.docker.com -o test-docker.sh
+          sh test-docker.sh
+
+      - name: Prepare confidential container rootfs
+        if: ${{ matrix.asset == 'rootfs-initrd' }}
+        run: |
+          wget -P include_rootfs/etc/ https://raw.githubusercontent.com/confidential-containers/documentation/main/demos/ssh-demo/aa-offline_fs_kbc-keys.json
+          envsubst < docs/how-to/data/confidential-agent-config.toml.in > include_rootfs/etc/kata-config.toml
+        env:
+          AA_KBC_PARAMS: offline_fs_kbc::null
+
+      - name: Build ${{ matrix.asset }}
+        run: |
+          make "${KATA_ASSET}-tarball"
+          build_dir=$(readlink -f build)
+          # store-artifact does not work with symlink
+          sudo cp -r "${build_dir}" "kata-build"
+        env:
+          AA_KBC: offline_fs_kbc
+          INCLUDE_ROOTFS: include_rootfs
+          KATA_ASSET: ${{ matrix.asset }}
+          TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
+
+      - name: store-artifact ${{ matrix.asset }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: kata-artifacts
+          path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
+          if-no-files-found: error
+
+  create-kata-tarball:
+    runs-on: ubuntu-latest
+    needs: build-asset
+    steps:
+      - uses: actions/checkout@v2
+      - name: get-artifacts
+        uses: actions/download-artifact@v2
+        with:
+          name: kata-artifacts
+          path: kata-artifacts
+      - name: merge-artifacts
+        run: |
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts
+      - name: store-artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: kata-static-tarball
+          path: kata-static.tar.xz
+
+  kata-deploy:
+    needs: create-kata-tarball
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: get-kata-tarball
+        uses: actions/download-artifact@v2
+        with:
+          name: kata-static-tarball
+      - name: build-and-push-kata-deploy-ci
+        id: build-and-push-kata-deploy-ci
+        run: |
+          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+          pushd $GITHUB_WORKSPACE
+          git checkout $tag
+          pkg_sha=$(git rev-parse HEAD)
+          popd
+          mv kata-static.tar.xz $GITHUB_WORKSPACE/tools/packaging/kata-deploy/kata-static.tar.xz
+          docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t quay.io/confidential-containers/kata-demo:$pkg_sha $GITHUB_WORKSPACE/tools/packaging/kata-deploy
+          docker login -u ${{ secrets.QUAY_DEPLOYER_USERNAME }} -p ${{ secrets.QUAY_DEPLOYER_PASSWORD }} quay.io
+          docker push quay.io/confidential-containers/kata-demo:$pkg_sha
+          mkdir -p packaging/kata-deploy
+          ln -s $GITHUB_WORKSPACE/tools/packaging/kata-deploy/action packaging/kata-deploy/action
+          echo "::set-output name=PKG_SHA::${pkg_sha}"

--- a/docs/how-to/data/confidential-agent-config.toml.in
+++ b/docs/how-to/data/confidential-agent-config.toml.in
@@ -1,0 +1,40 @@
+# Copyright (c) 2021 IBM Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+aa_kbc_params = "$AA_KBC_PARAMS"
+[endpoints]
+allowed = [
+"AddARPNeighborsRequest",
+"AddSwapRequest",
+"CloseStdinRequest",
+"CopyFileRequest",
+"CreateContainerRequest",
+"CreateSandboxRequest",
+"DestroySandboxRequest",
+"GetMetricsRequest",
+"GetOOMEventRequest",
+"GuestDetailsRequest",
+"ListInterfacesRequest",
+"ListRoutesRequest",
+"MemHotplugByProbeRequest",
+"OnlineCPUMemRequest",
+"PauseContainerRequest",
+"PullImageRequest",
+"ReadStreamRequest",
+"RemoveContainerRequest",
+"ResumeContainerRequest",
+"SetGuestDateTimeRequest",
+"SignalProcessRequest",
+"StartContainerRequest",
+"StartTracingRequest",
+"StatsContainerRequest",
+"StopTracingRequest",
+"TtyWinResizeRequest",
+"UpdateContainerRequest",
+"UpdateInterfaceRequest",
+"UpdateRoutesRequest",
+"WaitProcessRequest",
+"WriteStreamRequest"
+]

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -28,6 +28,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: CONFIGURE_CC
+          value: "yes"
         securityContext:
           privileged: false
         volumeMounts:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -41,7 +41,7 @@ docker run ${TTY_OPT} \
 	--env SKOPEO="${SKOPEO:-}" \
 	--env UMOCI="${UMOCI:-}" \
 	--env AA_KBC="${AA_KBC:-}" \
-	--env INCLUDE_ROOTFS="${INCLUDE_ROOTFS:-}" \
+	--env INCLUDE_ROOTFS="$(realpath "${INCLUDE_ROOTFS:-}" 2> /dev/null || true)" \
 	-v "${kata_dir}:${kata_dir}" \
 	--rm \
 	-w ${script_dir} \

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -18,6 +18,7 @@ shims=(
 	"qemu"
 	"clh"
 )
+[ "${CONFIGURE_CC:-}" == "yes" ] && shims+=("cc")
 
 # If we fail for any reason a message will be displayed
 die() {
@@ -171,7 +172,8 @@ function configure_containerd_runtime() {
 	else
 		cat <<EOT | tee -a "$containerd_conf_file"
 [$runtime_table]
-  runtime_type = "${runtime_type}"
+  runtime_type = "${runtime_type}" \
+$([ "$runtime" == "kata-cc" ] && printf '\n  cri_handler = "cc"')
   privileged_without_host_devices = true
   pod_annotations = ["io.katacontainers.*"]
 EOT
@@ -205,6 +207,17 @@ function configure_containerd() {
 	for shim in "${shims[@]}"; do
 		configure_containerd_runtime $shim
 	done
+}
+
+function configure_kata() {
+	if [ "${CONFIGURE_CC:-}" == "yes" ]; then
+		sed -E \
+			-e 's#^image = .+#initrd = "/opt/kata/share/kata-containers/kata-containers-initrd.img"#' \
+			-e 's#^(kernel_params = .+)"#\1 agent.config_file=/etc/kata-config.toml"#' \
+			-e 's#.*service_offload = .+#service_offload = true#' \
+			"/opt/kata/share/defaults/kata-containers/configuration-qemu.toml" > \
+			"/opt/kata/share/defaults/kata-containers/configuration-cc.toml"
+	fi
 }
 
 function remove_artifacts() {
@@ -287,6 +300,7 @@ function main() {
 
 			install_artifacts
 			configure_cri_runtime "$runtime"
+			configure_kata
 			kubectl label node "$NODE_NAME" --overwrite katacontainers.io/kata-runtime=true
 			;;
 		cleanup)


### PR DESCRIPTION
docs: Create sample config for confidential agent

Basic config, no debug endpoints, no exec/reseed. Uses the
`$AA_KBC_PARAMS` variable to be used with `envsubst`.

Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

---

github: Add workflow for deploying a CCv0 demo

using the offline FS KBC [1] and keys from the SSH demo [2]. The
workflow is adapted from `main:kata-deploy-test.yaml`. The image
deployed here is _not_ for a trusted execution environment.

[1] - https://github.com/confidential-containers/attestation-agent/tree/main/src/kbc_modules/offline_fs_kbc
[2] - https://github.com/confidential-containers/documentation/tree/main/demos/ssh-demo

Fixes: #3198
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

---

Here is a diff to `kata-deploy-test.yaml` to make this PR a little more comprehensible:

```diff
@@ -2,7 +2,7 @@ on:
   issue_comment:
     types: [created, edited]
 
-name: test-kata-deploy
+name: deploy-ccv0-demo
 
 jobs:
   check-comment-and-membership:
@@ -11,7 +11,7 @@ jobs:
       github.event.issue.pull_request
       && github.event_name == 'issue_comment'
       && github.event.action == 'created'
-      && startsWith(github.event.comment.body, '/test_kata_deploy')
+      && startsWith(github.event.comment.body, '/deploy-ccv0-demo')
     steps:
       - name: Check membership
         uses: kata-containers/is-organization-member@1.0.1
@@ -54,6 +54,14 @@ jobs:
           curl -fsSL https://test.docker.com -o test-docker.sh
           sh test-docker.sh
 
+      - name: Prepare confidential container rootfs
+        if: ${{ matrix.asset == 'rootfs-initrd' }}
+        run: |
+          wget -P include_rootfs/etc/ https://raw.githubusercontent.com/confidential-containers/documentation/main/demos/ssh-demo/aa-offline_fs_kbc-keys.json
+          envsubst < docs/how-to/data/confidential-agent-config.toml.in > include_rootfs/etc/confidential-agent-config.toml
+        env:
+          AA_KBC_PARAMS: offline_fs_kbc::null
+
       - name: Build ${{ matrix.asset }}
         run: |
           make "${KATA_ASSET}-tarball"
@@ -61,6 +69,8 @@ jobs:
           # store-artifact does not work with symlink
           sudo cp -r "${build_dir}" "kata-build"
         env:
+          AA_KBC: offline_fs_kbc
+          INCLUDE_ROOTFS: include_rootfs
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
 
@@ -108,19 +118,9 @@ jobs:
           pkg_sha=$(git rev-parse HEAD)
           popd
           mv kata-static.tar.xz $GITHUB_WORKSPACE/tools/packaging/kata-deploy/kata-static.tar.xz
-          docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t quay.io/kata-containers/kata-deploy-ci:$pkg_sha $GITHUB_WORKSPACE/tools/packaging/kata-deploy
+          docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t quay.io/confidential-containers/kata-demo:$pkg_sha $GITHUB_WORKSPACE/tools/packaging/kata-deploy
           docker login -u ${{ secrets.QUAY_DEPLOYER_USERNAME }} -p ${{ secrets.QUAY_DEPLOYER_PASSWORD }} quay.io
-          docker push quay.io/kata-containers/kata-deploy-ci:$pkg_sha
+          docker push quay.io/confidential-containers/kata-demo:$pkg_sha
           mkdir -p packaging/kata-deploy
           ln -s $GITHUB_WORKSPACE/tools/packaging/kata-deploy/action packaging/kata-deploy/action
           echo "::set-output name=PKG_SHA::${pkg_sha}"
-      - name: test-kata-deploy-ci-in-aks
-        uses: ./packaging/kata-deploy/action
-        with:
-          packaging-sha: ${{steps.build-and-push-kata-deploy-ci.outputs.PKG_SHA}}
-        env:
-          PKG_SHA: ${{steps.build-and-push-kata-deploy-ci.outputs.PKG_SHA}}
-          AZ_APPID: ${{ secrets.AZ_APPID }}
-          AZ_PASSWORD: ${{ secrets.AZ_PASSWORD }}
-          AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
-          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
```

/cc @fidencio @sameo -- I don't think I got everything about the workflow, but I'd rather start with _something_. Can I just `/deploy-ccv0-demo` from here?
/cc @bpradipt -- I think it would be good to integrate this with https://github.com/confidential-containers/operator/tree/ccv0-demo/demo/payload-image
