### PR TITLE
stable-2.3 | packaging: Fix missing commit message in building kata-runtime

### DIFF
--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -5,7 +5,13 @@
 FROM ubuntu
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y make curl sudo gcc
+RUN apt-get update && \
+    apt-get install -y \
+        curl \
+        gcc \
+        git \
+        make \
+        sudo
 
 ADD install_go.sh /usr/bin/install_go.sh
 ARG GO_VERSION


### PR DESCRIPTION
add `git` package to the shim-v2 build image

Fixes: #3196
Backport PR: #3197

Signed-off-by: Binbin Zhang <binbin36520@gmail.com>