### PR TITLE
runtime: correct span name for stopSandbox function

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -908,7 +908,7 @@ func setupStorages(ctx context.Context, sandbox *Sandbox) []*grpc.Storage {
 }
 
 func (k *kataAgent) stopSandbox(ctx context.Context, sandbox *Sandbox) error {
-	span, ctx := katatrace.Trace(ctx, k.Logger(), "StopVM", kataAgentTracingTags)
+	span, ctx := katatrace.Trace(ctx, k.Logger(), "stopSandbox", kataAgentTracingTags)
 	defer span.End()
 
 	req := &grpc.DestroySandboxRequest{}


### PR DESCRIPTION
Normally the span name should be the same as function
name, so chagne `StopVM` to `stopSandbox`.

Fixes: #3217

Signed-off-by: bin <bin@hyper.sh>