### PR TITLE
osbuilder: Revert to using apk.static for Alpine

### DIFF
--- a/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG IMAGE_REGISTRY=docker.io
-FROM ${IMAGE_REGISTRY}/alpine:3.13.5
+FROM ${IMAGE_REGISTRY}/alpine:3.15
 
 RUN apk update && apk add \
     apk-tools-static \

--- a/tools/osbuilder/rootfs-builder/alpine/config.sh
+++ b/tools/osbuilder/rootfs-builder/alpine/config.sh
@@ -5,7 +5,7 @@
 
 OS_NAME="Alpine"
 
-OS_VERSION=${OS_VERSION:-latest-stable}
+OS_VERSION=${OS_VERSION:-3.15}
 
 BASE_PACKAGES="alpine-base"
 

--- a/tools/osbuilder/rootfs-builder/alpine/config.sh
+++ b/tools/osbuilder/rootfs-builder/alpine/config.sh
@@ -11,7 +11,7 @@ BASE_PACKAGES="alpine-base"
 
 # Alpine mirror to use
 # See a list of mirrors at http://nl.alpinelinux.org/alpine/MIRRORS.txt
-MIRROR=http://dl-5.alpinelinux.org/alpine
+MIRROR=https://dl-5.alpinelinux.org/alpine
 
 PACKAGES=""
 

--- a/tools/osbuilder/rootfs-builder/alpine/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/alpine/rootfs_lib.sh
@@ -9,6 +9,8 @@
 #
 # - Optional environment variables
 #
+# EXTRA_PKGS: Variable to add extra PKGS provided by the user
+#
 # BIN_AGENT: Name of the Kata-Agent binary
 #
 # Any other configuration variable for a specific distro must be added
@@ -22,13 +24,20 @@ build_rootfs() {
 	# Mandatory
 	local ROOTFS_DIR=$1
 
+	# Add extra packages to the rootfs when specified
+	local EXTRA_PKGS=${EXTRA_PKGS:-}
+
 	# Populate ROOTFS_DIR
 	check_root
 	mkdir -p "${ROOTFS_DIR}"
 
-	rm -rf ${ROOTFS_DIR}/var/tmp
-	cp -a -r -f /bin /etc /lib /sbin /usr /var ${ROOTFS_DIR}
-	mkdir -p ${ROOTFS_DIR}{/root,/proc,/dev,/home,/media,/mnt,/opt,/run,/srv,/sys,/tmp}
+	/sbin/apk.static \
+	    -X ${MIRROR}/v${OS_VERSION}/main \
+	    -U \
+	    --allow-untrusted \
+	    --root ${ROOTFS_DIR} \
+	    --initdb add ${BASE_PACKAGES} ${EXTRA_PKGS} ${PACKAGES}
 
-	echo "${MIRROR}/${OS_VERSION}/main" >  ${ROOTFS_DIR}/etc/apk/repositories
+	mkdir -p ${ROOTFS_DIR}{/root,/etc/apk,/proc}
+	echo "${MIRROR}/v${OS_VERSION}/main" >  ${ROOTFS_DIR}/etc/apk/repositories
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -139,7 +139,7 @@ assets:
     architecture:
       aarch64:
         name: &default-initrd-name "alpine"
-        version: &default-initrd-version "3.13.5"
+        version: &default-initrd-version "3.15"
       # Do not use Alpine on ppc64le & s390x, the agent cannot use musl because
       # there is no such Rust target
       ppc64le:


### PR DESCRIPTION
 #2399 partially reverted #418, missing on returning to bootstrapping a
rootfs with `apk.static` instead of copying the entire root, which can
result in drastically larger (more than 10x) images.

Fixes: #3216
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>