### PR TITLE
runtime: also check kvm module `sev` parameter as bool

### DIFF
--- a/src/runtime/virtcontainers/hypervisor_amd64.go
+++ b/src/runtime/virtcontainers/hypervisor_amd64.go
@@ -18,9 +18,9 @@ func availableGuestProtection() (guestProtection, error) {
 	if d, err := os.Stat(tdxSysFirmwareDir); (err == nil && d.IsDir()) || flags[tdxCPUFlag] {
 		return tdxProtection, nil
 	}
-	// SEV is supported and enabled when the kvm module `sev` parameter is set to `1`
+	// SEV is supported and enabled when the kvm module `sev` parameter is set to `1` (or `Y` for linux >= 5.12)
 	if _, err := os.Stat(sevKvmParameterPath); err == nil {
-		if c, err := os.ReadFile(sevKvmParameterPath); err == nil && len(c) > 0 && c[0] == '1' {
+		if c, err := os.ReadFile(sevKvmParameterPath); err == nil && len(c) > 0 && (c[0] == '1' || c[0] == 'Y') {
 			return sevProtection, nil
 		}
 	}


### PR DESCRIPTION
Since linux 5.12, `kvm` module declares the `sev` parameters as a `boolean` (instead of an `int`) .

This PR fixes the verification of this parameter made by the runtime for linux 5.12 and above.

This was successfully tested against linux 5.15.

Edit:
Fixes #3273
Signed-off-by: Pierre Kohler <pierre.kohler@cysec.systems>