### PR TITLE
runtime/template: Handling new attributes for hypervisor config

### DIFF
--- a/src/runtime/virtcontainers/factory/factory.go
+++ b/src/runtime/virtcontainers/factory/factory.go
@@ -113,20 +113,23 @@ func resetHypervisorConfig(config *vc.VMConfig) {
 	config.HypervisorConfig.BootFromTemplate = false
 	config.HypervisorConfig.MemoryPath = ""
 	config.HypervisorConfig.DevicesStatePath = ""
+	config.HypervisorConfig.SharedPath = ""
+	config.HypervisorConfig.VMStorePath = ""
+	config.HypervisorConfig.RunStorePath = ""
 }
 
 // It's important that baseConfig and newConfig are passed by value!
-func checkVMConfig(config1, config2 vc.VMConfig) error {
-	if config1.HypervisorType != config2.HypervisorType {
-		return fmt.Errorf("hypervisor type does not match: %s vs. %s", config1.HypervisorType, config2.HypervisorType)
+func checkVMConfig(baseConfig, newConfig vc.VMConfig) error {
+	if baseConfig.HypervisorType != newConfig.HypervisorType {
+		return fmt.Errorf("hypervisor type does not match: %s vs. %s", baseConfig.HypervisorType, newConfig.HypervisorType)
 	}
 
 	// check hypervisor config details
-	resetHypervisorConfig(&config1)
-	resetHypervisorConfig(&config2)
+	resetHypervisorConfig(&baseConfig)
+	resetHypervisorConfig(&newConfig)
 
-	if !utils.DeepCompare(config1, config2) {
-		return fmt.Errorf("hypervisor config does not match, base: %+v. new: %+v", config1, config2)
+	if !utils.DeepCompare(baseConfig, newConfig) {
+		return fmt.Errorf("hypervisor config does not match, base: %+v. new: %+v", baseConfig, newConfig)
 	}
 
 	return nil

--- a/src/runtime/virtcontainers/factory/template/template.go
+++ b/src/runtime/virtcontainers/factory/template/template.go
@@ -163,6 +163,10 @@ func (t *template) createFromTemplateVM(ctx context.Context, c vc.VMConfig) (*vc
 	config.HypervisorConfig.BootFromTemplate = true
 	config.HypervisorConfig.MemoryPath = t.statePath + "/memory"
 	config.HypervisorConfig.DevicesStatePath = t.statePath + "/state"
+	config.HypervisorConfig.SharedPath = c.HypervisorConfig.SharedPath
+	config.HypervisorConfig.VMStorePath = c.HypervisorConfig.VMStorePath
+	config.HypervisorConfig.RunStorePath = c.HypervisorConfig.RunStorePath
+
 	return vc.NewVM(ctx, config)
 }
 


### PR DESCRIPTION
Some new attributes are added to hypervisor config:
- VMStorePath
- RunStorePath
- SharedPath

These attributes should be handled in two places:

- reset when check the new hypervisor's config is suitable
  to the base config.
- copy from new hypervisor's config when create new VM

Fixes: #3193

Signed-off-by: bin <bin@hyper.sh>