### PR TITLE
[backport]runtime: only call stopVirtiofsd when shared_fs is virtio-fs

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -992,8 +992,10 @@ func (q *qemu) StopVM(ctx context.Context, waitOnly bool) error {
 		}
 	}
 
-	if err := q.stopVirtiofsd(ctx); err != nil {
-		return err
+	if q.config.SharedFS == config.VirtioFS {
+		if err := q.stopVirtiofsd(ctx); err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
If shared_fs is set to virtio-9p, the virtiofsd is not started,
so there is no need to stop it.

Fixes: #3219

Backport: #3220 