### PR TITLE
image_build: add help info for '-f' option and 'BLOCK_SIZE' env.

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -79,14 +79,15 @@ Usage: ${script_name} [options] <rootfs-dir>
 
 Options:
 	-h Show this help
-	-o path to generate image file ENV: IMAGE
-	-r Free space of the root partition in MB ENV: ROOT_FREE_SPACE
+	-o Path to generate image file. ENV: IMAGE
+	-r Free space of the root partition in MB. ENV: ROOT_FREE_SPACE
+	-f Filesystem type to use, only xfs and ext4 are supported. ENV: FS_TYPE
 
 Extra environment variables:
 	AGENT_BIN:      Use it to change the expected agent binary name
 	AGENT_INIT:     Use kata agent as init process
+	BLOCK_SIZE:     Use to specify the size of blocks in bytes. DEFAULT: 4096
 	IMAGE_REGISTRY: Hostname for the image registry used to pull down the rootfs build image.
-	FS_TYPE:        Filesystem type to use. Only xfs and ext4 are supported.
 	NSDAX_BIN:      Use to specify path to pre-compiled 'nsdax' tool.
 	USE_DOCKER:     If set will build image in a Docker Container (requries docker)
 	                DEFAULT: not set


### PR DESCRIPTION
The help information of '-f' option is missing, and same issue
with 'BLOCK_SIZE' env variables, fix it in usage() function.

Fixes: #3231

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>