### PR TITLE
osbuilder: be runtime consistent with podman build

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -137,13 +137,16 @@ build_with_container() {
 	image_dir=$(readlink -f "$(dirname "${image}")")
 	image_name=$(basename "${image}")
 
-	REGISTRY_ARG=""
+	engine_build_args=""
 	if [ -n "${IMAGE_REGISTRY}" ]; then
-		REGISTRY_ARG="--build-arg IMAGE_REGISTRY=${IMAGE_REGISTRY}"
+		engine_build_args+=" --build-arg IMAGE_REGISTRY=${IMAGE_REGISTRY}"
+	fi
+	if [ -n "${USE_PODMAN}" ]; then
+		engine_build_args+=" --runtime ${DOCKER_RUNTIME}"
 	fi
 
 	"${container_engine}" build  \
-		   ${REGISTRY_ARG} \
+		   ${engine_build_args} \
 		   --build-arg http_proxy="${http_proxy}" \
 		   --build-arg https_proxy="${https_proxy}" \
 		   -t "${container_image_name}" "${script_dir}"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -353,23 +353,24 @@ build_rootfs_distro()
 		info "build directly"
 		build_rootfs ${ROOTFS_DIR}
 	else
+		engine_build_args=""
 		if [ -n "${USE_DOCKER}" ]; then
 			container_engine="docker"
 		elif [ -n "${USE_PODMAN}" ]; then
 			container_engine="podman"
+			engine_build_args+=" --runtime ${DOCKER_RUNTIME}"
 		fi
 
 		image_name="${distro}-rootfs-osbuilder"
 
-		REGISTRY_ARG=""
 		if [ -n "${IMAGE_REGISTRY}" ]; then
-			REGISTRY_ARG="--build-arg IMAGE_REGISTRY=${IMAGE_REGISTRY}"
+			engine_build_args+=" --build-arg IMAGE_REGISTRY=${IMAGE_REGISTRY}"
 		fi
 
 		# setup to install rust here
 		generate_dockerfile "${distro_config_dir}"
 		"$container_engine" build  \
-			${REGISTRY_ARG} \
+			${engine_build_args} \
 			--build-arg http_proxy="${http_proxy}" \
 			--build-arg https_proxy="${https_proxy}" \
 			-t "${image_name}" "${distro_config_dir}"
@@ -377,21 +378,21 @@ build_rootfs_distro()
 		# fake mapping if KERNEL_MODULES_DIR is unset
 		kernel_mod_dir=${KERNEL_MODULES_DIR:-${ROOTFS_DIR}}
 
-		docker_run_args=""
-		docker_run_args+=" --rm"
+		engine_run_args=""
+		engine_run_args+=" --rm"
 		# apt sync scans all possible fds in order to close them, incredibly slow on VMs
-		docker_run_args+=" --ulimit nofile=262144:262144"
-		docker_run_args+=" --runtime ${DOCKER_RUNTIME}"
+		engine_run_args+=" --ulimit nofile=262144:262144"
+		engine_run_args+=" --runtime ${DOCKER_RUNTIME}"
 
 		if [ -z "${AGENT_SOURCE_BIN}" ] ; then
-			docker_run_args+=" -v ${GOPATH_LOCAL}:${GOPATH_LOCAL} --env GOPATH=${GOPATH_LOCAL}"
+			engine_run_args+=" -v ${GOPATH_LOCAL}:${GOPATH_LOCAL} --env GOPATH=${GOPATH_LOCAL}"
 		else
-			docker_run_args+=" --env AGENT_SOURCE_BIN=${AGENT_SOURCE_BIN}"
-			docker_run_args+=" -v ${AGENT_SOURCE_BIN}:${AGENT_SOURCE_BIN}"
-			docker_run_args+=" -v ${GOPATH_LOCAL}:${GOPATH_LOCAL} --env GOPATH=${GOPATH_LOCAL}"
+			engine_run_args+=" --env AGENT_SOURCE_BIN=${AGENT_SOURCE_BIN}"
+			engine_run_args+=" -v ${AGENT_SOURCE_BIN}:${AGENT_SOURCE_BIN}"
+			engine_run_args+=" -v ${GOPATH_LOCAL}:${GOPATH_LOCAL} --env GOPATH=${GOPATH_LOCAL}"
 		fi
 
-		docker_run_args+=" $(docker_extra_args $distro)"
+		engine_run_args+=" $(docker_extra_args $distro)"
 
 		# Relabel volumes so SELinux allows access (see docker-run(1))
 		if command -v selinuxenabled > /dev/null && selinuxenabled ; then
@@ -432,7 +433,7 @@ build_rootfs_distro()
 			-v "${ROOTFS_DIR}":"/rootfs" \
 			-v "${script_dir}/../scripts":"/scripts" \
 			-v "${kernel_mod_dir}":"${kernel_mod_dir}" \
-			$docker_run_args \
+			$engine_run_args \
 			${image_name} \
 			bash /kata-containers/tools/osbuilder/rootfs-builder/rootfs.sh "${distro}"
 


### PR DESCRIPTION
Use the same runtime used for docker/podman run also for
docker/podman build

Signed-off-by: Snir Sheriber <ssheribe@redhat.com>