### PR TITLE
CCv0 | kata-deploy: Support Secure Execution

### DIFF
--- a/.github/workflows/deploy-ccv0-demo.yaml
+++ b/.github/workflows/deploy-ccv0-demo.yaml
@@ -57,8 +57,11 @@ jobs:
       - name: Prepare confidential container rootfs
         if: ${{ matrix.asset == 'rootfs-initrd' }}
         run: |
-          wget -P include_rootfs/etc/ https://raw.githubusercontent.com/confidential-containers/documentation/main/demos/ssh-demo/aa-offline_fs_kbc-keys.json
-          envsubst < docs/how-to/data/confidential-agent-config.toml.in > include_rootfs/etc/kata-config.toml
+          pushd include_rootfs/etc
+          curl -LO https://raw.githubusercontent.com/confidential-containers/documentation/main/demos/ssh-demo/aa-offline_fs_kbc-keys.json
+          mkdir kata-containers
+          envsubst < docs/how-to/data/confidential-agent-config.toml.in > kata-containers/agent.toml
+          popd
         env:
           AA_KBC_PARAMS: offline_fs_kbc::null
 

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -465,11 +465,13 @@ func (h hypervisor) getInitrdAndImage() (initrd string, image string, err error)
 
 	image, errImage := h.image()
 
-	if image != "" && initrd != "" {
+	if h.ConfidentialGuest && h.MachineType == vc.QemuCCWVirtio {
+		if image != "" || initrd != "" {
+			return "", "", errors.New("Neither the image or initrd path may be set for Secure Execution")
+		}
+	} else if image != "" && initrd != "" {
 		return "", "", errors.New("having both an image and an initrd defined in the configuration file is not supported")
-	}
-
-	if errInitrd != nil && errImage != nil {
+	} else if errInitrd != nil && errImage != nil {
 		return "", "", fmt.Errorf("Either initrd or image must be set to a valid path (initrd: %v) (image: %v)", errInitrd, errImage)
 	}
 
@@ -599,16 +601,6 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 	pflashes, err := h.PFlash()
 	if err != nil {
 		return vc.HypervisorConfig{}, err
-	}
-
-	if image != "" && initrd != "" {
-		return vc.HypervisorConfig{},
-			errors.New("having both an image and an initrd defined in the configuration file is not supported")
-	}
-
-	if image == "" && initrd == "" {
-		return vc.HypervisorConfig{},
-			errors.New("either image or initrd must be defined in the configuration file")
 	}
 
 	firmware, err := h.firmware()

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -544,11 +544,13 @@ func (conf *HypervisorConfig) Valid() error {
 		return fmt.Errorf("Missing kernel path")
 	}
 
-	if conf.ImagePath == "" && conf.InitrdPath == "" {
+	if conf.ConfidentialGuest && conf.HypervisorMachineType == QemuCCWVirtio {
+		if conf.ImagePath != "" || conf.InitrdPath != "" {
+			return fmt.Errorf("Neither the image or initrd path may be set for Secure Execution")
+		}
+	} else if conf.ImagePath == "" && conf.InitrdPath == "" {
 		return fmt.Errorf("Missing image and initrd path")
-	}
-
-	if conf.ImagePath != "" && conf.InitrdPath != "" {
+	} else if conf.ImagePath != "" && conf.InitrdPath != "" {
 		return fmt.Errorf("Image and initrd path cannot be both set")
 	}
 
@@ -570,7 +572,7 @@ func (conf *HypervisorConfig) Valid() error {
 
 	if conf.BlockDeviceDriver == "" {
 		conf.BlockDeviceDriver = defaultBlockDriver
-	} else if conf.BlockDeviceDriver == config.VirtioBlock && conf.HypervisorMachineType == "s390-ccw-virtio" {
+	} else if conf.BlockDeviceDriver == config.VirtioBlock && conf.HypervisorMachineType == QemuCCWVirtio {
 		conf.BlockDeviceDriver = config.VirtioBlockCCW
 	}
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1835,7 +1835,7 @@ func (q *qemu) hotplugAddCPUs(amount uint32) (uint32, error) {
 		threadID := fmt.Sprintf("%d", hc.Properties.Thread)
 
 		// If CPU type is IBM pSeries or Z, we do not set socketID and threadID
-		if machine.Type == "pseries" || machine.Type == "s390-ccw-virtio" {
+		if machine.Type == "pseries" || machine.Type == QemuCCWVirtio {
 			socketID = ""
 			threadID = ""
 			dieID = ""

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -345,6 +345,7 @@ RUN ln -sf /usr/bin/g++ /bin/musl-g++
 			-e "s|@INSTALL_MUSL@||g" \
 			-e "s|@INSTALL_RUST@|${install_rust//$'\n'/\\n}|g" \
 			-e "s|@SET_PROXY@|${set_proxy:-}|g" \
+			-e "s|@INSTALL_AA_KBC@|${AA_KBC_EXTRAS//$'\n'/\\n}|g" \
 			"${dockerfile_template}" > Dockerfile
 	else
 		sed \

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -15,8 +15,8 @@ endef
 
 kata-tarball: | all-parallel merge-builds
 
-all-parallel:
-	${MAKE} -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true" V=
+%-parallel:
+	${MAKE} -f $(MK_PATH) $(subst -parallel,,$@) -j$$(( $$(nproc) - 1  )) NO_TTY="true" V=
 
 all: cloud-hypervisor-tarball \
 	firecracker-tarball \

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -62,3 +62,8 @@ install-tarball:
 
 image: kata-tarball
 	$(MK_DIR)kata-deploy-build-and-upload-image.sh $(CURDIR)/kata-static.tar.xz
+
+secure-execution-tarballs: kernel-tarball qemu-tarball rootfs-initrd-tarball shim-v2-tarball
+
+secure-execution: secure-execution-tarballs-parallel
+	$(MK_DIR)/kata-deploy-secure-execution.sh

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-secure-execution.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-secure-execution.sh
@@ -1,0 +1,87 @@
+#!/bin/bash -eu
+# Copyright (c) 2021 IBM Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[ -n "${DEBUG:-}" ] && set -x
+[ "$(uname -m)" = s390x ] || (echo >&2 "ERROR: Creation of Secure Execution images is currently only supported on s390x." && exit 1)
+
+kata_build_dir=build
+cmdline="loglevel=0 panic= scsi_mod.scan=none swiotlb=262144 agent.config_file=/etc/kata-containers/agent.toml"
+
+usage() {
+	cat >&2 << EOF
+Usage:
+  $0 [options]
+
+Options:
+  -b <build dir>     : Kata build directory, containing kata-static tarballs
+                       Default: "$kata_build_dir"
+  -c <kernel cmdline>: Guest kernel command line
+                       Default: "$cmdline"
+  -h                 : Show this help
+
+Environment variables:
+  HKD (required): Secure Execution host key document, generally specific to your machine. See
+                  https://www.ibm.com/docs/en/linux-on-systems?topic=tasks-verify-host-key-document
+                  for information on how to retrieve and verify this document.
+  DEBUG         : If set, display debug information.
+EOF
+	exit "${1:-0}"
+}
+
+while getopts "b:c:h" opt; do
+	case $opt in
+		b) kata_build_dir="$OPTARG";;
+		c) cmdline="$OPTARG";;
+		h) usage;;
+		*) usage 1;;
+	esac
+done
+shift $(( OPTIND - 1 ))
+
+[ -n "${HKD:-}" ] || (echo >&2 "No host key document specified." && usage 1)
+command -v genprotimg || (echo >&2 "genprotimg is not installed. Install s390-tools." && usage 1)
+
+declare hkd_options
+eval "for hkd in $HKD; do
+	hkd_options+=\"--host-key-document=\\\"\$hkd\\\" \"
+done"
+
+tar_path="kata-static.tar.xz"
+
+tarball_content_dir="$PWD/kata-tarball-content"
+protimg_content_dir="$PWD/kata-protimg-content"
+rm -rf "$tarball_content_dir" "$protimg_content_dir"
+mkdir "$tarball_content_dir" "$protimg_content_dir"
+
+pushd "$kata_build_dir"
+for c in qemu shim-v2; do
+	tar xvf kata-static-$c.tar.xz -C "$tarball_content_dir"
+done
+
+for c in kernel rootfs-initrd; do
+	tar xvf kata-static-$c.tar.xz -C "$protimg_content_dir"
+done
+popd
+
+parmfile="$(mktemp --suffix=-cmdline)"
+trap 'rm -f "$parmfile"' EXIT
+chmod 600 "$parmfile"
+echo "$cmdline" > "$parmfile"
+
+protimg_kata_dir="$protimg_content_dir/opt/kata/share/kata-containers"
+tarball_kata_dir="$tarball_content_dir/opt/kata/share/kata-containers"
+mkdir "$tarball_kata_dir"
+
+eval genprotimg \
+	"$hkd_options" \
+	--output="$tarball_kata_dir/kata-containers-secure.img" \
+	--image="$protimg_kata_dir/vmlinuz.container" \
+	--ramdisk="$protimg_kata_dir/kata-containers-initrd.img" \
+	--parmfile="$parmfile" \
+	--no-verify # TODO add support once available
+
+pushd "$tarball_content_dir"
+tar cJvf "$tar_path" .
+popd

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -222,7 +222,7 @@ function configure_kata() {
 	if [ "${CONFIGURE_CC:-}" == "yes" ]; then
 		sed -E \
 			-e 's#^image = .+#initrd = "/opt/kata/share/kata-containers/kata-containers-initrd.img"#' \
-			-e 's#^(kernel_params = .+)"#\1 agent.config_file=/etc/kata-config.toml"#' \
+			-e 's#^(kernel_params = .+)"#\1 agent.config_file=/etc/kata-containers/agent.toml"#' \
 			-e 's#.*service_offload = .+#service_offload = true#' \
 			"/opt/kata/share/defaults/kata-containers/configuration-qemu.toml" > \
 			"/opt/kata/share/defaults/kata-containers/configuration-cc.toml"


### PR DESCRIPTION
Add script and Makefile target for Secure Execution. This way, a full
Kata image can be deployed just by preparing offline keys, agent config,
and the host key document.

Fixes: #3242

I have tested this end-to-end. The command is something like `UMOCI=yes AA_KBC=offline_fs_kbc INCLUDE_ROOTFS=include_rootfs/ HKD=/path/to/HKD-8561-0123456.crt make secure-execution`, which creates an `/opt/kata` tarball.
/cc @fitzthum @magowan @sameo @stevenhorsman