### PR TITLE
utils/kata-manager.sh: Remove target machine arch check

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -143,11 +143,6 @@ github_get_release_file_url()
 	[ "$download_url" = null ] && download_url=""
 	[ -z "$download_url" ] && die "Cannot determine download URL for version $version ($url)"
 
-	local arch=$(uname -m)
-
-	[ "$arch" = x86_64 ] && arch="($arch|amd64)"
-	echo "$download_url" | egrep -q "$arch" || die "No release for '$arch architecture ($url)"
-
 	echo "$download_url"
 }
 


### PR DESCRIPTION
Download url does not contain the arch name, let's remove it and don't
fail installation with kata-manager.sh.

Fixes: #3254