### PR TITLE
osbuilder: show usage if no options/arguments specified

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -474,6 +474,7 @@ set_dax_header() {
 
 main() {
 	[ "$(id -u)" -eq 0 ] || die "$0: must be run as root"
+	[ "$#" -eq 0 ] && usage && return 0
 
 	# variables that can be overwritten by environment variables
 	local agent_bin="${AGENT_BIN:-kata-agent}"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -441,7 +441,7 @@ build_rootfs_distro()
 	fi
 }
 
-# Used to create a minimal directory tree where the agent can be instaleld.
+# Used to create a minimal directory tree where the agent can be installed.
 # This is used when a distro is not specified.
 prepare_overlay()
 {
@@ -624,6 +624,8 @@ EOT
 
 parse_arguments()
 {
+	[ "$#" -eq 0 ] && usage && return 0
+
 	while getopts a:hlo:r:t: opt
 	do
 		case $opt in


### PR DESCRIPTION
Now if no options/arguments specified, the shell scripts will return an error:

ERROR: Invalid rootfs directory: ''

This commit will show usage if no options/arguments specified.

Fixes: #3256

Signed-off-by: bin <bin@hyper.sh>