### PR TITLE
kata-deploy: Deal with empty containerd conf file

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -266,6 +266,11 @@ function main() {
 
 		containerd_conf_file="${containerd_conf_tmpl_file}"
 		containerd_conf_file_backup="${containerd_conf_file}.bak"
+	else
+		# runtime == containerd
+		if [ ! -f "$containerd_conf_file" ]; then
+			containerd config default > "$containerd_conf_file"
+		fi
 	fi
 
 	action=${1:-}


### PR DESCRIPTION
As containerd can properly run without having a existent
`/etc/containerd/config.toml` file (it'd run using the default
cobnfiguration), let's explicitly create the file in those cases.

This will avoid issues on ammending runtime classes to a non-existent
file.

Fixes: #3229

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>
Tested-by: Jakob Naucke <jakob.naucke@ibm.com>