### PR TITLE
runtime: update golang to 1.16 and remove ioutil package

### DIFF
--- a/docs/Unit-Test-Advice.md
+++ b/docs/Unit-Test-Advice.md
@@ -286,8 +286,8 @@ func TestSomething(t *testing.T) {
     assert := assert.New(t)
 
     // Create a temporary directory
-    tmpdir, err := ioutil.TempDir("", "")    
-    assert.NoError(err)             
+    tmpdir, err := os.MkdirTemp("", "")
+    assert.NoError(err)
 
     // Delete it at the end of the test
     defer os.RemoveAll(tmpdir) 

--- a/src/runtime/cmd/kata-runtime/factory_test.go
+++ b/src/runtime/cmd/kata-runtime/factory_test.go
@@ -8,7 +8,6 @@ package main
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -44,7 +43,7 @@ func TestFactoryCLIFunctionNoRuntimeConfig(t *testing.T) {
 func TestFactoryCLIFunctionInit(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -93,7 +92,7 @@ func TestFactoryCLIFunctionInit(t *testing.T) {
 func TestFactoryCLIFunctionDestroy(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -127,7 +126,7 @@ func TestFactoryCLIFunctionDestroy(t *testing.T) {
 func TestFactoryCLIFunctionStatus(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 

--- a/src/runtime/cmd/kata-runtime/kata-check_amd64.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_amd64.go
@@ -7,7 +7,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -212,7 +212,7 @@ func setCPUtype(hypervisorType vc.HypervisorType) error {
 }
 
 func getCPUtype() int {
-	content, err := ioutil.ReadFile("/proc/cpuinfo")
+	content, err := os.ReadFile("/proc/cpuinfo")
 	if err != nil {
 		kataLog.WithError(err).Error("failed to read file")
 		return cpuTypeUnknown

--- a/src/runtime/cmd/kata-runtime/kata-check_amd64_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_amd64_test.go
@@ -8,7 +8,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -72,7 +71,7 @@ func TestCCCheckCLIFunction(t *testing.T) {
 func TestCheckCheckKernelModulesNoNesting(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -157,7 +156,7 @@ func TestCheckCheckKernelModulesNoNesting(t *testing.T) {
 func TestCheckCheckKernelModulesNoUnrestrictedGuest(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +255,7 @@ func TestCheckHostIsVMContainerCapable(t *testing.T) {
 
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +405,7 @@ func TestArchKernelParamHandler(t *testing.T) {
 func TestKvmIsUsable(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -458,7 +457,7 @@ foo     : bar
 func TestSetCPUtype(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 

--- a/src/runtime/cmd/kata-runtime/kata-check_arm64_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_arm64_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,7 +67,7 @@ foo     : bar
 		{validContents, validNormalizeVendorName, validNormalizeModelName, false},
 	}
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}

--- a/src/runtime/cmd/kata-runtime/kata-check_data_ppc64le_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_data_ppc64le_test.go
@@ -6,8 +6,9 @@
 package main
 
 import (
+	"os"
+
 	"github.com/sirupsen/logrus"
-	"io/ioutil"
 )
 
 var testCPUInfoTemplate = setTestCPUInfoTemplate()
@@ -15,7 +16,7 @@ var testCPUInfoTemplate = setTestCPUInfoTemplate()
 func setTestCPUInfoTemplate() string {
 
 	var kataLog *logrus.Entry
-	content, err := ioutil.ReadFile("/proc/cpuinfo")
+	content, err := os.ReadFile("/proc/cpuinfo")
 
 	if err != nil {
 		kataLog.WithError(err).Error("failed to read file /proc/cpuinfo")

--- a/src/runtime/cmd/kata-runtime/kata-check_generic_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_generic_test.go
@@ -9,7 +9,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -19,7 +18,7 @@ import (
 func testSetCPUTypeGeneric(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 

--- a/src/runtime/cmd/kata-runtime/kata-check_ppc64le_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_ppc64le_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -119,7 +118,7 @@ func TestArchKernelParamHandler(t *testing.T) {
 func TestKvmIsUsable(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -118,7 +117,7 @@ func TestArchKernelParamHandler(t *testing.T) {
 func TestKvmIsUsable(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/runtime/cmd/kata-runtime/kata-check_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_test.go
@@ -10,7 +10,6 @@ import (
 	"flag"
 	"fmt"
 	"html/template"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -50,7 +49,7 @@ type testCPUDetail struct {
 var fakeCPUData = testCPUData{"", "", false}
 
 func createFile(file, contents string) error {
-	return ioutil.WriteFile(file, []byte(contents), testFileMode)
+	return os.WriteFile(file, []byte(contents), testFileMode)
 }
 
 func createModules(assert *assert.Assertions, cpuInfoFile string, moduleData []testModuleData) {
@@ -151,12 +150,12 @@ func makeCPUInfoFile(path, vendorID, flags string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, contents.Bytes(), testFileMode)
+	return os.WriteFile(path, contents.Bytes(), testFileMode)
 }
 
 // nolint: unused, deadcode
 func genericTestGetCPUDetails(t *testing.T, validVendor string, validModel string, validContents string, data []testCPUDetail) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -198,7 +197,7 @@ func genericTestGetCPUDetails(t *testing.T, validVendor string, validModel strin
 func genericCheckCLIFunction(t *testing.T, cpuData []testCPUData, moduleData []testModuleData) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -308,7 +307,7 @@ func TestCheckGetCPUInfo(t *testing.T) {
 		{"foo\n\nbar\nbaz\n\n", "foo", false},
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +319,7 @@ func TestCheckGetCPUInfo(t *testing.T) {
 	assert.Error(err)
 
 	for _, d := range data {
-		err = ioutil.WriteFile(file, []byte(d.contents), testFileMode)
+		err = os.WriteFile(file, []byte(d.contents), testFileMode)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -528,7 +527,7 @@ func TestCheckHaveKernelModule(t *testing.T) {
 
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -578,7 +577,7 @@ func TestCheckHaveKernelModule(t *testing.T) {
 func TestCheckCheckKernelModules(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -663,7 +662,7 @@ func TestCheckCheckKernelModulesUnreadableFile(t *testing.T) {
 		t.Skip(ktu.TestDisabledNeedNonRoot)
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -711,7 +710,7 @@ func TestCheckCheckKernelModulesUnreadableFile(t *testing.T) {
 func TestCheckCheckKernelModulesInvalidFileContents(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -756,7 +755,7 @@ func TestCheckCheckKernelModulesInvalidFileContents(t *testing.T) {
 func TestCheckCLIFunctionFail(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -789,7 +788,7 @@ func TestCheckCLIFunctionFail(t *testing.T) {
 func TestCheckKernelParamHandler(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -871,7 +870,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 func TestArchRequiredKernelModules(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -886,7 +885,7 @@ func TestArchRequiredKernelModules(t *testing.T) {
 		return
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/runtime/cmd/kata-runtime/kata-env_amd64_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_amd64_test.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -23,7 +22,7 @@ func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 

--- a/src/runtime/cmd/kata-runtime/kata-env_generic_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_generic_test.go
@@ -9,7 +9,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -19,7 +18,7 @@ import (
 func testEnvGetEnvInfoSetsCPUTypeGeneric(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 

--- a/src/runtime/cmd/kata-runtime/kata-env_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_test.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -65,7 +64,7 @@ func makeVersionBinary(file, version string) error {
 
 func createConfig(configPath string, fileData string) error {
 
-	err := ioutil.WriteFile(configPath, []byte(fileData), testFileMode)
+	err := os.WriteFile(configPath, []byte(fileData), testFileMode)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to create config file %s %v\n", configPath, err)
 		return err
@@ -365,7 +364,7 @@ func TestEnvGetMetaInfo(t *testing.T) {
 }
 
 func TestEnvGetHostInfo(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -390,7 +389,7 @@ func TestEnvGetHostInfo(t *testing.T) {
 }
 
 func TestEnvGetHostInfoNoProcCPUInfo(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -407,7 +406,7 @@ func TestEnvGetHostInfoNoProcCPUInfo(t *testing.T) {
 }
 
 func TestEnvGetHostInfoNoOSRelease(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -424,7 +423,7 @@ func TestEnvGetHostInfoNoOSRelease(t *testing.T) {
 }
 
 func TestEnvGetHostInfoNoProcVersion(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -441,7 +440,7 @@ func TestEnvGetHostInfoNoProcVersion(t *testing.T) {
 }
 
 func TestEnvGetEnvInfo(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -475,7 +474,7 @@ func TestEnvGetEnvInfo(t *testing.T) {
 func TestEnvGetEnvInfoNoHypervisorVersion(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -502,7 +501,7 @@ func TestEnvGetEnvInfoNoHypervisorVersion(t *testing.T) {
 func TestEnvGetEnvInfoAgentError(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -511,7 +510,7 @@ func TestEnvGetEnvInfoAgentError(t *testing.T) {
 }
 
 func TestEnvGetEnvInfoNoOSRelease(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -531,7 +530,7 @@ func TestEnvGetEnvInfoNoOSRelease(t *testing.T) {
 }
 
 func TestEnvGetEnvInfoNoProcCPUInfo(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -551,7 +550,7 @@ func TestEnvGetEnvInfoNoProcCPUInfo(t *testing.T) {
 }
 
 func TestEnvGetEnvInfoNoProcVersion(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -571,7 +570,7 @@ func TestEnvGetEnvInfoNoProcVersion(t *testing.T) {
 }
 
 func TestEnvGetRuntimeInfo(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -588,7 +587,7 @@ func TestEnvGetRuntimeInfo(t *testing.T) {
 }
 
 func TestEnvGetAgentInfo(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -727,13 +726,13 @@ func testEnvShowJSONSettings(t *testing.T, tmpdir string, tmpfile *os.File) erro
 }
 
 func TestEnvShowSettings(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpdir)
 
-	tmpfile, err := ioutil.TempFile("", "envShowSettings-")
+	tmpfile, err := os.CreateTemp("", "envShowSettings-")
 	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -748,13 +747,13 @@ func TestEnvShowSettings(t *testing.T) {
 }
 
 func TestEnvShowSettingsInvalidFile(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
 	defer os.RemoveAll(tmpdir)
 
-	tmpfile, err := ioutil.TempFile("", "envShowSettings-")
+	tmpfile, err := os.CreateTemp("", "envShowSettings-")
 	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -772,7 +771,7 @@ func TestEnvShowSettingsInvalidFile(t *testing.T) {
 }
 
 func TestEnvHandleSettings(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -790,7 +789,7 @@ func TestEnvHandleSettings(t *testing.T) {
 	ctx.App.Metadata["configFile"] = configFile
 	ctx.App.Metadata["runtimeConfig"] = config
 
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 
@@ -806,7 +805,7 @@ func TestEnvHandleSettings(t *testing.T) {
 func TestEnvHandleSettingsInvalidParams(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -860,7 +859,7 @@ func TestEnvHandleSettingsInvalidRuntimeConfigType(t *testing.T) {
 }
 
 func TestEnvCLIFunction(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -905,7 +904,7 @@ func TestEnvCLIFunction(t *testing.T) {
 }
 
 func TestEnvCLIFunctionFail(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -941,7 +940,7 @@ func TestEnvCLIFunctionFail(t *testing.T) {
 func TestGetHypervisorInfo(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -963,7 +962,7 @@ func TestGetHypervisorInfo(t *testing.T) {
 func TestGetHypervisorInfoSocket(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 

--- a/src/runtime/cmd/kata-runtime/kata-exec.go
+++ b/src/runtime/cmd/kata-runtime/kata-exec.go
@@ -9,7 +9,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"net/url"
@@ -170,7 +169,7 @@ func getConn(sandboxID string, port uint64) (net.Conn, error) {
 	}
 
 	defer resp.Body.Close()
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/runtime/cmd/kata-runtime/main_test.go
+++ b/src/runtime/cmd/kata-runtime/main_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -100,7 +99,7 @@ func TestMain(m *testing.M) {
 }
 
 func createEmptyFile(path string) (err error) {
-	return ioutil.WriteFile(path, []byte(""), testFileMode)
+	return os.WriteFile(path, []byte(""), testFileMode)
 }
 
 func grep(pattern, file string) error {
@@ -108,7 +107,7 @@ func grep(pattern, file string) error {
 		return errors.New("need file")
 	}
 
-	bytes, err := ioutil.ReadFile(file)
+	bytes, err := os.ReadFile(file)
 	if err != nil {
 		return err
 	}
@@ -259,7 +258,7 @@ func TestMainBeforeSubCommands(t *testing.T) {
 func TestMainBeforeSubCommandsInvalidLogFile(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "katatest")
+	tmpdir, err := os.MkdirTemp("", "katatest")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -282,7 +281,7 @@ func TestMainBeforeSubCommandsInvalidLogFile(t *testing.T) {
 func TestMainBeforeSubCommandsInvalidLogFormat(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "katatest")
+	tmpdir, err := os.MkdirTemp("", "katatest")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -311,7 +310,7 @@ func TestMainBeforeSubCommandsInvalidLogFormat(t *testing.T) {
 func TestMainBeforeSubCommandsLoadConfigurationFail(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "katatest")
+	tmpdir, err := os.MkdirTemp("", "katatest")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -346,7 +345,7 @@ func TestMainBeforeSubCommandsLoadConfigurationFail(t *testing.T) {
 func TestMainBeforeSubCommandsShowCCConfigPaths(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "katatest")
+	tmpdir, err := os.MkdirTemp("", "katatest")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -410,7 +409,7 @@ func TestMainBeforeSubCommandsShowCCConfigPaths(t *testing.T) {
 func TestMainFatal(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "katatest")
+	tmpdir, err := os.MkdirTemp("", "katatest")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -634,7 +633,7 @@ func TestMainCreateRuntime(t *testing.T) {
 func TestMainVersionPrinter(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "katatest")
+	tmpdir, err := os.MkdirTemp("", "katatest")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 

--- a/src/runtime/cmd/kata-runtime/release.go
+++ b/src/runtime/cmd/kata-runtime/release.go
@@ -10,7 +10,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"strings"
@@ -279,7 +279,7 @@ func getReleases(releaseURL string, includeAll bool) ([]semver.Version, map[stri
 
 	releasesArray := []map[string]interface{}{}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to read release details: %v", err)
 	} else if resp.StatusCode == http.StatusForbidden && bytes.Contains(body, []byte("limit exceeded")) {

--- a/src/runtime/cmd/kata-runtime/utils_test.go
+++ b/src/runtime/cmd/kata-runtime/utils_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ import (
 )
 
 func TestFileExists(t *testing.T) {
-	dir, err := ioutil.TempDir("", "katatest")
+	dir, err := os.MkdirTemp("", "katatest")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,7 +54,7 @@ func TestGetKernelVersion(t *testing.T) {
 		{validContents, validVersion, false},
 	}
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}
@@ -104,7 +103,7 @@ func TestGetDistroDetails(t *testing.T) {
 
 	const unknown = "<<unknown>>"
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
 		panic(err)
 	}

--- a/src/runtime/cmd/kata-runtime/version_test.go
+++ b/src/runtime/cmd/kata-runtime/version_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -38,7 +37,7 @@ func TestVersion(t *testing.T) {
 	fn, ok := versionCLICommand.Action.(func(context *cli.Context) error)
 	assert.True(t, ok)
 
-	tmpfile, err := ioutil.TempFile("", "")
+	tmpfile, err := os.CreateTemp("", "")
 	assert.NoError(t, err)
 	defer os.Remove(tmpfile.Name())
 

--- a/src/runtime/pkg/containerd-shim-v2/create_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/create_test.go
@@ -9,7 +9,6 @@ package containerdshim
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -362,7 +361,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 	runtimeConfigFileData := ktu.MakeRuntimeConfigFileData(configFileOptions)
 
 	configPath := path.Join(dir, "runtime.toml")
-	err = ioutil.WriteFile(configPath, []byte(runtimeConfigFileData), os.FileMode(0640))
+	err = os.WriteFile(configPath, []byte(runtimeConfigFileData), os.FileMode(0640))
 	if err != nil {
 		return "", err
 	}
@@ -371,7 +370,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 
 	for _, file := range files {
 		// create the resource (which must be >0 bytes)
-		err := ioutil.WriteFile(file, []byte("foo"), os.FileMode(0640))
+		err := os.WriteFile(file, []byte("foo"), os.FileMode(0640))
 		if err != nil {
 			return "", err
 		}
@@ -383,7 +382,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 func TestCreateLoadRuntimeConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -7,7 +7,7 @@ package containerdshim
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	sysexec "os/exec"
 	"sync"
@@ -80,7 +80,7 @@ func New(ctx context.Context, id string, publisher cdshim.Publisher, shutdown fu
 	// Discard the log before shim init its log output. Otherwise
 	// it will output into stdio, from which containerd would like
 	// to get the shim's socket address.
-	logrus.SetOutput(ioutil.Discard)
+	logrus.SetOutput(io.Discard)
 	opts := ctx.Value(cdshim.OptsKey{}).(cdshim.Opts)
 	if !opts.Debug {
 		logrus.SetLevel(logrus.WarnLevel)

--- a/src/runtime/pkg/containerd-shim-v2/stream_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/stream_test.go
@@ -8,7 +8,6 @@ package containerdshim
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -26,11 +25,11 @@ func TestNewTtyIOFifoReopen(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.TODO()
 
-	testDir, err := ioutil.TempDir("", "kata-")
+	testDir, err := os.MkdirTemp("", "kata-")
 	assert.NoError(err)
 	defer os.RemoveAll(testDir)
 
-	fifoPath, err := ioutil.TempDir(testDir, "fifo-path-")
+	fifoPath, err := os.MkdirTemp(testDir, "fifo-path-")
 	assert.NoError(err)
 	stdout := filepath.Join(fifoPath, "stdout")
 	stderr := filepath.Join(fifoPath, "stderr")
@@ -104,11 +103,11 @@ func TestIoCopy(t *testing.T) {
 	testBytes2 := []byte("Test2")
 	testBytes3 := []byte("Test3")
 
-	testDir, err := ioutil.TempDir("", "kata-")
+	testDir, err := os.MkdirTemp("", "kata-")
 	assert.NoError(err)
 	defer os.RemoveAll(testDir)
 
-	fifoPath, err := ioutil.TempDir(testDir, "fifo-path-")
+	fifoPath, err := os.MkdirTemp(testDir, "fifo-path-")
 	assert.NoError(err)
 	dstStdoutPath := filepath.Join(fifoPath, "dststdout")
 	dstStderrPath := filepath.Join(fifoPath, "dststderr")

--- a/src/runtime/pkg/containerd-shim-v2/utils_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/utils_test.go
@@ -8,7 +8,6 @@ package containerdshim
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -60,7 +59,7 @@ func init() {
 }
 
 func createEmptyFile(path string) (err error) {
-	return ioutil.WriteFile(path, []byte(""), testFileMode)
+	return os.WriteFile(path, []byte(""), testFileMode)
 }
 
 // newTestHypervisorConfig creaets a new virtcontainers

--- a/src/runtime/pkg/kata-monitor/shim_client.go
+++ b/src/runtime/pkg/kata-monitor/shim_client.go
@@ -7,7 +7,7 @@ package katamonitor
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -90,7 +90,7 @@ func doGet(sandboxID string, timeoutInSeconds time.Duration, urlPath string) ([]
 		resp.Body.Close()
 	}()
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/src/runtime/pkg/katatestutils/constraints.go
+++ b/src/runtime/pkg/katatestutils/constraints.go
@@ -8,7 +8,6 @@ package katatestutils
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"strings"
@@ -63,7 +62,7 @@ type Result struct {
 
 // GetFileContents return the file contents as a string.
 func getFileContents(file string) (string, error) {
-	bytes, err := ioutil.ReadFile(file)
+	bytes, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}

--- a/src/runtime/pkg/katatestutils/constraints_test.go
+++ b/src/runtime/pkg/katatestutils/constraints_test.go
@@ -8,7 +8,6 @@ package katatestutils
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -316,7 +315,7 @@ func testGetDistro() (name, version string, err error) {
 func testGetKernelVersion() (version string, err error) {
 	const file = "/proc/version"
 
-	bytes, err := ioutil.ReadFile(file)
+	bytes, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}
@@ -416,7 +415,7 @@ func TestGetFileContents(t *testing.T) {
 		{"foo\nbar"},
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
@@ -428,7 +427,7 @@ func TestGetFileContents(t *testing.T) {
 
 	for _, d := range data {
 		// create the file
-		err = ioutil.WriteFile(file, []byte(d.contents), testFileMode)
+		err = os.WriteFile(file, []byte(d.contents), testFileMode)
 		assert.NoError(err)
 		defer os.Remove(file)
 

--- a/src/runtime/pkg/katatestutils/utils.go
+++ b/src/runtime/pkg/katatestutils/utils.go
@@ -9,7 +9,6 @@ package katatestutils
 import (
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -347,7 +346,7 @@ func IsInGitHubActions() bool {
 func SetupOCIConfigFile(t *testing.T) (rootPath string, bundlePath, ociConfigFile string) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "katatest-")
+	tmpdir, err := os.MkdirTemp("", "katatest-")
 	assert.NoError(err)
 
 	bundlePath = filepath.Join(tmpdir, "bundle")
@@ -355,7 +354,7 @@ func SetupOCIConfigFile(t *testing.T) (rootPath string, bundlePath, ociConfigFil
 	assert.NoError(err)
 
 	ociConfigFile = filepath.Join(bundlePath, "config.json")
-	err = ioutil.WriteFile(ociConfigFile, []byte(busyboxConfigJson), testFileMode)
+	err = os.WriteFile(ociConfigFile, []byte(busyboxConfigJson), testFileMode)
 	assert.NoError(err)
 
 	return tmpdir, bundlePath, ociConfigFile
@@ -372,5 +371,5 @@ func WriteOCIConfigFile(spec specs.Spec, configPath string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(configPath, bytes, testFileMode)
+	return os.WriteFile(configPath, bytes, testFileMode)
 }

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -9,7 +9,7 @@ package katautils
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	goruntime "runtime"
 	"strings"
@@ -1199,7 +1199,7 @@ func decodeConfig(configPath string) (tomlConfig, string, error) {
 		return tomlConf, "", fmt.Errorf("Cannot find usable config file (%v)", err)
 	}
 
-	configData, err := ioutil.ReadFile(resolved)
+	configData, err := os.ReadFile(resolved)
 	if err != nil {
 		return tomlConf, resolved, err
 	}

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -9,7 +9,6 @@ package katautils
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -49,7 +48,7 @@ type testRuntimeConfig struct {
 
 func createConfig(configPath string, fileData string) error {
 
-	err := ioutil.WriteFile(configPath, []byte(fileData), testFileMode)
+	err := os.WriteFile(configPath, []byte(fileData), testFileMode)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to create config file %s %v\n", configPath, err)
 		return err
@@ -280,7 +279,7 @@ func testLoadConfiguration(t *testing.T, dir string,
 }
 
 func TestConfigLoadConfiguration(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(testDir, "load-config-")
+	tmpdir, err := os.MkdirTemp(testDir, "load-config-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -288,7 +287,7 @@ func TestConfigLoadConfiguration(t *testing.T) {
 }
 
 func TestConfigLoadConfigurationFailBrokenSymLink(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(testDir, "runtime-config-")
+	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -311,7 +310,7 @@ func TestConfigLoadConfigurationFailBrokenSymLink(t *testing.T) {
 }
 
 func TestConfigLoadConfigurationFailSymLinkLoop(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(testDir, "runtime-config-")
+	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -340,7 +339,7 @@ func TestConfigLoadConfigurationFailSymLinkLoop(t *testing.T) {
 }
 
 func TestConfigLoadConfigurationFailMissingHypervisor(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(testDir, "runtime-config-")
+	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -358,7 +357,7 @@ func TestConfigLoadConfigurationFailMissingHypervisor(t *testing.T) {
 }
 
 func TestConfigLoadConfigurationFailMissingImage(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(testDir, "runtime-config-")
+	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -376,7 +375,7 @@ func TestConfigLoadConfigurationFailMissingImage(t *testing.T) {
 }
 
 func TestConfigLoadConfigurationFailMissingKernel(t *testing.T) {
-	tmpdir, err := ioutil.TempDir(testDir, "runtime-config-")
+	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -398,7 +397,7 @@ func TestConfigLoadConfigurationFailUnreadableConfig(t *testing.T) {
 		t.Skip(ktu.TestDisabledNeedNonRoot)
 	}
 
-	tmpdir, err := ioutil.TempDir(testDir, "runtime-config-")
+	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -421,7 +420,7 @@ func TestConfigLoadConfigurationFailTOMLConfigFileInvalidContents(t *testing.T) 
 		t.Skip(ktu.TestDisabledNeedNonRoot)
 	}
 
-	tmpdir, err := ioutil.TempDir(testDir, "runtime-config-")
+	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -447,7 +446,7 @@ func TestConfigLoadConfigurationFailTOMLConfigFileDuplicatedData(t *testing.T) {
 		t.Skip(ktu.TestDisabledNeedNonRoot)
 	}
 
-	tmpdir, err := ioutil.TempDir(testDir, "runtime-config-")
+	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
 	assert.NoError(t, err)
 	defer os.RemoveAll(tmpdir)
 
@@ -472,7 +471,7 @@ func TestConfigLoadConfigurationFailTOMLConfigFileDuplicatedData(t *testing.T) {
 }
 
 func TestMinimalRuntimeConfig(t *testing.T) {
-	dir, err := ioutil.TempDir(testDir, "minimal-runtime-config-")
+	dir, err := os.MkdirTemp(testDir, "minimal-runtime-config-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -602,7 +601,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 }
 
 func TestNewQemuHypervisorConfig(t *testing.T) {
-	dir, err := ioutil.TempDir(testDir, "hypervisor-config-")
+	dir, err := os.MkdirTemp(testDir, "hypervisor-config-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -699,7 +698,7 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 }
 
 func TestNewFirecrackerHypervisorConfig(t *testing.T) {
-	dir, err := ioutil.TempDir(testDir, "hypervisor-config-")
+	dir, err := os.MkdirTemp(testDir, "hypervisor-config-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -794,7 +793,7 @@ func TestNewFirecrackerHypervisorConfig(t *testing.T) {
 func TestNewQemuHypervisorConfigImageAndInitrd(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir(testDir, "")
+	tmpdir, err := os.MkdirTemp(testDir, "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -836,7 +835,7 @@ func TestNewClhHypervisorConfig(t *testing.T) {
 
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir(testDir, "")
+	tmpdir, err := os.MkdirTemp(testDir, "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -931,7 +930,7 @@ func TestHypervisorDefaults(t *testing.T) {
 func TestHypervisorDefaultsHypervisor(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir(testDir, "")
+	tmpdir, err := os.MkdirTemp(testDir, "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -967,7 +966,7 @@ func TestHypervisorDefaultsHypervisor(t *testing.T) {
 func TestHypervisorDefaultsKernel(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir(testDir, "")
+	tmpdir, err := os.MkdirTemp(testDir, "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1010,7 +1009,7 @@ func TestHypervisorDefaultsKernel(t *testing.T) {
 func TestHypervisorDefaultsInitrd(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir(testDir, "")
+	tmpdir, err := os.MkdirTemp(testDir, "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1047,7 +1046,7 @@ func TestHypervisorDefaultsInitrd(t *testing.T) {
 func TestHypervisorDefaultsImage(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir(testDir, "")
+	tmpdir, err := os.MkdirTemp(testDir, "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1142,7 +1141,7 @@ func TestGetDefaultConfigFilePaths(t *testing.T) {
 func TestGetDefaultConfigFile(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir(testDir, "")
+	tmpdir, err := os.MkdirTemp(testDir, "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -1232,7 +1231,7 @@ func TestDefaultFirmware(t *testing.T) {
 	// save default firmware path
 	oldDefaultFirmwarePath := defaultFirmwarePath
 
-	f, err := ioutil.TempFile(os.TempDir(), "qboot.bin")
+	f, err := os.CreateTemp(os.TempDir(), "qboot.bin")
 	assert.NoError(err)
 	assert.NoError(f.Close())
 	defer os.RemoveAll(f.Name())
@@ -1420,7 +1419,7 @@ func TestUpdateRuntimeConfigurationInvalidKernelParams(t *testing.T) {
 func TestCheckHypervisorConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir(testDir, "")
+	dir, err := os.MkdirTemp(testDir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1583,11 +1582,11 @@ func TestCheckFactoryConfig(t *testing.T) {
 func TestValidateBindMounts(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir1, err := ioutil.TempDir(testDir, "tmp1-")
+	tmpdir1, err := os.MkdirTemp(testDir, "tmp1-")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir1)
 
-	tmpdir2, err := ioutil.TempDir(testDir, "tmp2-")
+	tmpdir2, err := os.MkdirTemp(testDir, "tmp2-")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir2)
 
@@ -1595,13 +1594,13 @@ func TestValidateBindMounts(t *testing.T) {
 	duplicate2 := filepath.Join(tmpdir2, "cat.txt")
 	unique := filepath.Join(tmpdir1, "foobar.txt")
 
-	err = ioutil.WriteFile(duplicate1, []byte("kibble-monster"), 0644)
+	err = os.WriteFile(duplicate1, []byte("kibble-monster"), 0644)
 	assert.NoError(err)
 
-	err = ioutil.WriteFile(duplicate2, []byte("furbag"), 0644)
+	err = os.WriteFile(duplicate2, []byte("furbag"), 0644)
 	assert.NoError(err)
 
-	err = ioutil.WriteFile(unique, []byte("fuzzball"), 0644)
+	err = os.WriteFile(unique, []byte("fuzzball"), 0644)
 	assert.NoError(err)
 
 	type testData struct {

--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -9,7 +9,7 @@ package katautils
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -183,7 +183,7 @@ func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec specs.Spec, runtimeCo
 var procFIPS = "/proc/sys/crypto/fips_enabled"
 
 func checkForFIPS(sandboxConfig *vc.SandboxConfig) error {
-	content, err := ioutil.ReadFile(procFIPS)
+	content, err := os.ReadFile(procFIPS)
 	if err != nil {
 		// In case file cannot be found or read, simply return
 		return nil

--- a/src/runtime/pkg/katautils/create_test.go
+++ b/src/runtime/pkg/katautils/create_test.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -124,7 +123,7 @@ func TestSetEphemeralStorageType(t *testing.T) {
 
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir(testDir, "foo")
+	dir, err := os.MkdirTemp(testDir, "foo")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +267,7 @@ func TestCreateSandboxFail(t *testing.T) {
 func TestCheckForFips(t *testing.T) {
 	assert := assert.New(t)
 
-	path, err := ioutil.TempDir("", "")
+	path, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(path)
 
@@ -278,7 +277,7 @@ func TestCheckForFips(t *testing.T) {
 		procFIPS = val
 	}()
 
-	err = ioutil.WriteFile(procFIPS, []byte("1"), 0644)
+	err = os.WriteFile(procFIPS, []byte("1"), 0644)
 	assert.NoError(err)
 
 	hconfig := vc.HypervisorConfig{
@@ -297,7 +296,7 @@ func TestCheckForFips(t *testing.T) {
 	assert.Equal(params[1].Value, "1")
 
 	config.HypervisorConfig = hconfig
-	err = ioutil.WriteFile(procFIPS, []byte("unexpected contents"), 0644)
+	err = os.WriteFile(procFIPS, []byte("unexpected contents"), 0644)
 	assert.NoError(err)
 	assert.NoError(checkForFIPS(&config))
 	assert.Equal(config.HypervisorConfig, hconfig)

--- a/src/runtime/pkg/katautils/logger_test.go
+++ b/src/runtime/pkg/katautils/logger_test.go
@@ -8,7 +8,7 @@ package katautils
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"regexp"
 	"strings"
 	"testing"
@@ -29,7 +29,7 @@ func init() {
 	kataUtilsLogger.Logger.Level = logrus.DebugLevel
 
 	// Discard log output
-	kataUtilsLogger.Logger.Out = ioutil.Discard
+	kataUtilsLogger.Logger.Out = io.Discard
 }
 
 func TestHandleSystemLog(t *testing.T) {
@@ -71,7 +71,7 @@ func TestNewSystemLogHook(t *testing.T) {
 
 	// throw away all stdout so that the Format() call
 	// below returns the data in structured form.
-	logger.Out = ioutil.Discard
+	logger.Out = io.Discard
 
 	entry := &logrus.Entry{
 		Logger: logger,

--- a/src/runtime/pkg/katautils/network_test.go
+++ b/src/runtime/pkg/katautils/network_test.go
@@ -7,7 +7,6 @@ package katautils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -24,7 +23,7 @@ import (
 func TestGetNetNsFromBindMount(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -53,7 +52,7 @@ func TestGetNetNsFromBindMount(t *testing.T) {
 	}
 
 	for i, d := range data {
-		err := ioutil.WriteFile(mountFile, []byte(d.contents), 0640)
+		err := os.WriteFile(mountFile, []byte(d.contents), 0640)
 		assert.NoError(err)
 
 		path, err := getNetNsFromBindMount(tmpNSPath, mountFile)
@@ -86,7 +85,7 @@ func TestHostNetworkingRequested(t *testing.T) {
 	assert.Error(err)
 
 	// Bind-mounted Netns
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 

--- a/src/runtime/pkg/katautils/utils.go
+++ b/src/runtime/pkg/katautils/utils.go
@@ -9,7 +9,6 @@ package katautils
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -99,7 +98,7 @@ func WriteFile(filePath string, data string, fileMode os.FileMode) error {
 		return fmt.Errorf("no such file for %s", filePath)
 	}
 
-	if err := ioutil.WriteFile(filePath, []byte(data), fileMode); err != nil {
+	if err := os.WriteFile(filePath, []byte(data), fileMode); err != nil {
 		return fmt.Errorf("failed to write %v to %v: %v", data, filePath, err)
 	}
 
@@ -108,7 +107,7 @@ func WriteFile(filePath string, data string, fileMode os.FileMode) error {
 
 // GetFileContents return the file contents as a string.
 func GetFileContents(file string) (string, error) {
-	bytes, err := ioutil.ReadFile(file)
+	bytes, err := os.ReadFile(file)
 	if err != nil {
 		return "", err
 	}

--- a/src/runtime/pkg/katautils/utils_test.go
+++ b/src/runtime/pkg/katautils/utils_test.go
@@ -8,7 +8,6 @@ package katautils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -32,11 +31,11 @@ var (
 )
 
 func createFile(file, contents string) error {
-	return ioutil.WriteFile(file, []byte(contents), testFileMode)
+	return os.WriteFile(file, []byte(contents), testFileMode)
 }
 
 func createEmptyFile(path string) (err error) {
-	return ioutil.WriteFile(path, []byte(""), testFileMode)
+	return os.WriteFile(path, []byte(""), testFileMode)
 }
 
 func TestUtilsResolvePathEmptyPath(t *testing.T) {
@@ -45,7 +44,7 @@ func TestUtilsResolvePathEmptyPath(t *testing.T) {
 }
 
 func TestUtilsResolvePathValidPath(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -77,7 +76,7 @@ func TestUtilsResolvePathValidPath(t *testing.T) {
 }
 
 func TestUtilsResolvePathENOENT(t *testing.T) {
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +111,7 @@ func TestUtilsResolvePathENOENT(t *testing.T) {
 func TestFileSize(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir(testDir, "")
+	dir, err := os.MkdirTemp(testDir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +152,7 @@ func TestWriteFileErrWriteFail(t *testing.T) {
 func TestWriteFileErrNoPath(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir(testDir, "")
+	dir, err := os.MkdirTemp(testDir, "")
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
@@ -178,7 +177,7 @@ func TestGetFileContents(t *testing.T) {
 		{"processor   : 0\nvendor_id   : GenuineIntel\n"},
 	}
 
-	dir, err := ioutil.TempDir(testDir, "")
+	dir, err := os.MkdirTemp(testDir, "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -192,7 +191,7 @@ func TestGetFileContents(t *testing.T) {
 
 	for _, d := range data {
 		// create the file
-		err = ioutil.WriteFile(file, []byte(d.contents), testFileMode)
+		err = os.WriteFile(file, []byte(d.contents), testFileMode)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/src/runtime/pkg/oci/utils_test.go
+++ b/src/runtime/pkg/oci/utils_test.go
@@ -7,7 +7,6 @@ package oci
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -44,7 +43,7 @@ var (
 func createConfig(fileName string, fileData string) (string, error) {
 	configPath := path.Join(tempBundlePath, fileName)
 
-	err := ioutil.WriteFile(configPath, []byte(fileData), fileMode)
+	err := os.WriteFile(configPath, []byte(fileData), fileMode)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Unable to create config file %s %v\n", configPath, err)
 		return "", err
@@ -361,7 +360,7 @@ func TestGetShmSizeBindMounted(t *testing.T) {
 		t.Skip("Test disabled as requires root privileges")
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.Nil(t, err)
 	defer os.RemoveAll(dir)
 
@@ -399,7 +398,7 @@ func TestGetShmSizeBindMounted(t *testing.T) {
 
 func TestMain(m *testing.M) {
 	var err error
-	tempRoot, err = ioutil.TempDir("", "virtc-")
+	tempRoot, err = os.MkdirTemp("", "virtc-")
 	if err != nil {
 		panic(err)
 	}
@@ -424,7 +423,7 @@ func TestMain(m *testing.M) {
 func TestAddAssetAnnotations(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -432,7 +431,7 @@ func TestAddAssetAnnotations(t *testing.T) {
 	// (required since the existence of binary asset annotations is verified).
 	fakeAssetFile := filepath.Join(tmpdir, "fake-binary")
 
-	err = ioutil.WriteFile(fakeAssetFile, []byte(""), fileMode)
+	err = os.WriteFile(fakeAssetFile, []byte(""), fileMode)
 	assert.NoError(err)
 
 	expectedAnnotations := map[string]string{

--- a/src/runtime/pkg/utils/utils_test.go
+++ b/src/runtime/pkg/utils/utils_test.go
@@ -7,7 +7,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -52,7 +51,7 @@ func TestGzipAccepted(t *testing.T) {
 
 func TestEnsureDir(t *testing.T) {
 	const testMode = 0755
-	tmpdir, err := ioutil.TempDir("", "TestEnsureDir")
+	tmpdir, err := os.MkdirTemp("", "TestEnsureDir")
 	assert := assert.New(t)
 
 	assert.NoError(err)
@@ -121,7 +120,7 @@ func TestEnsureDir(t *testing.T) {
 
 func TestFirstValidExecutable(t *testing.T) {
 	assert := assert.New(t)
-	tmpdir, err := ioutil.TempDir("", "TestFirstValidPath")
+	tmpdir, err := os.MkdirTemp("", "TestFirstValidPath")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 
@@ -145,7 +144,7 @@ func TestFirstValidExecutable(t *testing.T) {
 				err := os.MkdirAll(path.Join(tmpdir, "a", "b"), 0755)
 				assert.NoError(err)
 				// create a non-executable file
-				err = ioutil.WriteFile(path.Join(tmpdir, "a", "b", "c"), []byte("test\n"), 0644)
+				err = os.WriteFile(path.Join(tmpdir, "a", "b", "c"), []byte("test\n"), 0644)
 				assert.NoError(err)
 			},
 			paths:     []string{path.Join(tmpdir, "a", "b", "c"), "c/d"},
@@ -158,7 +157,7 @@ func TestFirstValidExecutable(t *testing.T) {
 				err := os.MkdirAll(path.Join(tmpdir, "d", "e"), 0755)
 				assert.NoError(err)
 				// create an executable file
-				err = ioutil.WriteFile(path.Join(tmpdir, "d", "e", "f"), []byte("test\n"), 0755)
+				err = os.WriteFile(path.Join(tmpdir, "d", "e", "f"), []byte("test\n"), 0755)
 				assert.NoError(err)
 			},
 			paths:     []string{path.Join(tmpdir, "d", "e", "f"), "c/d"},
@@ -171,7 +170,7 @@ func TestFirstValidExecutable(t *testing.T) {
 				err := os.MkdirAll(path.Join(tmpdir, "g", "h"), 0755)
 				assert.NoError(err)
 				// create an executable file
-				err = ioutil.WriteFile(path.Join(tmpdir, "g", "h", "i"), []byte("test\n"), 0755)
+				err = os.WriteFile(path.Join(tmpdir, "g", "h", "i"), []byte("test\n"), 0755)
 				assert.NoError(err)
 			},
 			paths:     []string{"c/d", path.Join(tmpdir, "g", "h", "i")},

--- a/src/runtime/virtcontainers/acrn_arch_base_test.go
+++ b/src/runtime/virtcontainers/acrn_arch_base_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -127,7 +126,7 @@ func TestAcrnArchBaseAppendImage(t *testing.T) {
 	assert := assert.New(t)
 	acrnArchBase := newAcrnArchBase()
 
-	image, err := ioutil.TempFile("", "img")
+	image, err := os.CreateTemp("", "img")
 	assert.NoError(err)
 	defer os.Remove(image.Name())
 	err = image.Close()

--- a/src/runtime/virtcontainers/container_test.go
+++ b/src/runtime/virtcontainers/container_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -131,7 +130,7 @@ func TestUnmountHostMountsRemoveBindHostPath(t *testing.T) {
 	}
 
 	createFakeMountDir := func(t *testing.T, dir, prefix string) string {
-		name, err := ioutil.TempDir(dir, "test-mnt-"+prefix+"-")
+		name, err := os.MkdirTemp(dir, "test-mnt-"+prefix+"-")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -139,7 +138,7 @@ func TestUnmountHostMountsRemoveBindHostPath(t *testing.T) {
 	}
 
 	createFakeMountFile := func(t *testing.T, dir, prefix string) string {
-		f, err := ioutil.TempFile(dir, "test-mnt-"+prefix+"-")
+		f, err := os.CreateTemp(dir, "test-mnt-"+prefix+"-")
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -245,7 +244,7 @@ func testSetupFakeRootfs(t *testing.T) (testRawFile, loopDev, mntDir string, err
 		t.Skip(testDisabledAsNonRoot)
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 
 	testRawFile = filepath.Join(tmpDir, "raw.img")
@@ -556,13 +555,13 @@ func TestMountSharedDirMounts(t *testing.T) {
 
 	assert := assert.New(t)
 
-	testMountPath, err := ioutil.TempDir("", "sandbox-test")
+	testMountPath, err := os.MkdirTemp("", "sandbox-test")
 	assert.NoError(err)
 	defer os.RemoveAll(testMountPath)
 
 	// create a new shared directory for our test:
 	kataHostSharedDirSaved := kataHostSharedDir
-	testHostDir, err := ioutil.TempDir("", "kata-Cleanup")
+	testHostDir, err := os.MkdirTemp("", "kata-Cleanup")
 	assert.NoError(err)
 	kataHostSharedDir = func() string {
 		return testHostDir

--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -8,7 +8,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -353,7 +352,7 @@ func GetHostPath(devInfo DeviceInfo, vhostUserStoreEnabled bool, vhostUserStoreP
 // getBackingFile is used to fetch the backing file for the device.
 func getBackingFile(devInfo DeviceInfo) (string, error) {
 	backingFilePath := filepath.Join(getSysDevPath(devInfo), "loop", "backing_file")
-	data, err := ioutil.ReadFile(backingFilePath)
+	data, err := os.ReadFile(backingFilePath)
 	if err != nil {
 		return "", err
 	}
@@ -409,7 +408,7 @@ func GetVhostUserNodeStat(devNodePath string, devNodeStat *unix.Stat_t) (err err
 
 // Filter out name of the device node whose device type is Major:Minor from directory
 func getVhostUserDevName(dirname string, majorNum, minorNum uint32) (string, error) {
-	files, err := ioutil.ReadDir(dirname)
+	files, err := os.ReadDir(dirname)
 	if err != nil {
 		return "", err
 	}

--- a/src/runtime/virtcontainers/device/config/config_test.go
+++ b/src/runtime/virtcontainers/device/config/config_test.go
@@ -7,7 +7,6 @@ package config
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,7 +17,7 @@ import (
 func TestGetBackingFile(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "backing")
+	dir, err := os.MkdirTemp("", "backing")
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
@@ -39,7 +38,7 @@ func TestGetBackingFile(t *testing.T) {
 
 	backingFile := "/fake-img"
 
-	err = ioutil.WriteFile(filepath.Join(loopDir, "backing_file"), []byte(backingFile), os.FileMode(0755))
+	err = os.WriteFile(filepath.Join(loopDir, "backing_file"), []byte(backingFile), os.FileMode(0755))
 	assert.NoError(err)
 
 	path, err = getBackingFile(info)

--- a/src/runtime/virtcontainers/device/config/pmem_test.go
+++ b/src/runtime/virtcontainers/device/config/pmem_test.go
@@ -6,7 +6,6 @@
 package config
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -33,7 +32,7 @@ func TestHasPFNSignature(t *testing.T) {
 	b := hasPFNSignature("/abc/xyz/123/sw")
 	assert.False(b)
 
-	f, err := ioutil.TempFile("", "pfn")
+	f, err := os.CreateTemp("", "pfn")
 	assert.NoError(err)
 	f.Close()
 	defer os.Remove(f.Name())

--- a/src/runtime/virtcontainers/device/drivers/utils.go
+++ b/src/runtime/virtcontainers/device/drivers/utils.go
@@ -8,7 +8,6 @@ package drivers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -85,7 +84,7 @@ func readPCIProperty(propertyPath string) (string, error) {
 		buf []byte
 		err error
 	)
-	if buf, err = ioutil.ReadFile(propertyPath); err != nil {
+	if buf, err = os.ReadFile(propertyPath); err != nil {
 		return "", fmt.Errorf("failed to read pci sysfs %v, error:%v", propertyPath, err)
 	}
 	return strings.Split(string(buf), "\n")[0], nil

--- a/src/runtime/virtcontainers/device/drivers/vfio.go
+++ b/src/runtime/virtcontainers/device/drivers/vfio.go
@@ -9,7 +9,6 @@ package drivers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -75,7 +74,7 @@ func (device *VFIODevice) Attach(ctx context.Context, devReceiver api.DeviceRece
 	vfioGroup := filepath.Base(device.DeviceInfo.HostPath)
 	iommuDevicesPath := filepath.Join(config.SysIOMMUPath, vfioGroup, "devices")
 
-	deviceFiles, err := ioutil.ReadDir(iommuDevicesPath)
+	deviceFiles, err := os.ReadDir(iommuDevicesPath)
 	if err != nil {
 		return err
 	}

--- a/src/runtime/virtcontainers/device/manager/manager_test.go
+++ b/src/runtime/virtcontainers/device/manager/manager_test.go
@@ -9,7 +9,6 @@ package manager
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -39,7 +38,7 @@ func TestNewDevice(t *testing.T) {
 	major := int64(252)
 	minor := int64(3)
 
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	assert.Nil(t, err)
 
 	config.SysDevPrefix = tmpDir
@@ -75,14 +74,14 @@ func TestNewDevice(t *testing.T) {
 
 	// Should return error for bad data in uevent file
 	content := []byte("nonkeyvaluedata")
-	err = ioutil.WriteFile(ueventPath, content, fileMode0640)
+	err = os.WriteFile(ueventPath, content, fileMode0640)
 	assert.Nil(t, err)
 
 	_, err = dm.NewDevice(deviceInfo)
 	assert.NotNil(t, err)
 
 	content = []byte("MAJOR=252\nMINOR=3\nDEVNAME=vfio/2")
-	err = ioutil.WriteFile(ueventPath, content, fileMode0640)
+	err = os.WriteFile(ueventPath, content, fileMode0640)
 	assert.Nil(t, err)
 
 	device, err := dm.NewDevice(deviceInfo)
@@ -104,7 +103,7 @@ func TestAttachVFIODevice(t *testing.T) {
 		blockDriver: VirtioBlock,
 		devices:     make(map[string]api.Device),
 	}
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	assert.Nil(t, err)
 	defer os.RemoveAll(tmpDir)
 
@@ -225,7 +224,7 @@ func TestAttachVhostUserBlkDevice(t *testing.T) {
 		rootEnabled = false
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	dm := &deviceManager{
 		blockDriver:           VirtioBlock,
 		devices:               make(map[string]api.Device),

--- a/src/runtime/virtcontainers/device/manager/utils.go
+++ b/src/runtime/virtcontainers/device/manager/utils.go
@@ -8,7 +8,7 @@ package manager
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -49,7 +49,7 @@ func IsVFIOLargeBarSpaceDevice(hostPath string) (bool, error) {
 	}
 
 	iommuDevicesPath := filepath.Join(config.SysIOMMUPath, filepath.Base(hostPath), "devices")
-	deviceFiles, err := ioutil.ReadDir(iommuDevicesPath)
+	deviceFiles, err := os.ReadDir(iommuDevicesPath)
 	if err != nil {
 		return false, err
 	}
@@ -89,7 +89,7 @@ func IsVFIOLargeBarSpaceDevice(hostPath string) (bool, error) {
 }
 
 func isLargeBarSpace(resourcePath string) (bool, error) {
-	buf, err := ioutil.ReadFile(resourcePath)
+	buf, err := os.ReadFile(resourcePath)
 	if err != nil {
 		return false, fmt.Errorf("failed to read sysfs resource: %v", err)
 	}

--- a/src/runtime/virtcontainers/device/manager/utils_test.go
+++ b/src/runtime/virtcontainers/device/manager/utils_test.go
@@ -7,7 +7,6 @@
 package manager
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -114,7 +113,7 @@ func TestIsLargeBarSpace(t *testing.T) {
 	assert.Error(err)
 	assert.False(bs)
 
-	f, err := ioutil.TempFile("", "pci")
+	f, err := os.CreateTemp("", "pci")
 	assert.NoError(err)
 	defer f.Close()
 	defer os.RemoveAll(f.Name())

--- a/src/runtime/virtcontainers/endpoint_test.go
+++ b/src/runtime/virtcontainers/endpoint_test.go
@@ -6,7 +6,6 @@
 package virtcontainers
 
 import (
-	"io/ioutil"
 	"net"
 	"os"
 	"reflect"
@@ -87,7 +86,7 @@ func TestIncorrectEndpointTypeString(t *testing.T) {
 func TestSaveLoadIfPair(t *testing.T) {
 	macAddr := net.HardwareAddr{0x02, 0x00, 0xCA, 0xFE, 0x00, 0x04}
 
-	tmpfile, err := ioutil.TempFile("", "vc-Save-Load-net-")
+	tmpfile, err := os.CreateTemp("", "vc-Save-Load-net-")
 	assert.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
 

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -778,7 +777,7 @@ func (fc *firecracker) StartVM(ctx context.Context, timeout int) error {
 		return errJSON
 	}
 
-	if err := ioutil.WriteFile(fc.fcConfigPath, data, 0640); err != nil {
+	if err := os.WriteFile(fc.fcConfigPath, data, 0640); err != nil {
 		return err
 	}
 

--- a/src/runtime/virtcontainers/hook/mock/hook.go
+++ b/src/runtime/virtcontainers/hook/mock/hook.go
@@ -8,7 +8,7 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"strconv"
 	"time"
@@ -55,7 +55,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	stateBuf, err := ioutil.ReadAll(os.Stdin)
+	stateBuf, err := io.ReadAll(os.Stdin)
 	if err != nil {
 		fmt.Fprintf(f, "Could not read on stdin: %s\n", err)
 		os.Exit(1)

--- a/src/runtime/virtcontainers/hypervisor_amd64.go
+++ b/src/runtime/virtcontainers/hypervisor_amd64.go
@@ -6,7 +6,6 @@
 package virtcontainers
 
 import "os"
-import "io/ioutil"
 
 // Implementation of this function is architecture specific
 func availableGuestProtection() (guestProtection, error) {
@@ -21,7 +20,7 @@ func availableGuestProtection() (guestProtection, error) {
 	}
 	// SEV is supported and enabled when the kvm module `sev` parameter is set to `1`
 	if _, err := os.Stat(sevKvmParameterPath); err == nil {
-		if c, err := ioutil.ReadFile(sevKvmParameterPath); err == nil && len(c) > 0 && c[0] == '1' {
+		if c, err := os.ReadFile(sevKvmParameterPath); err == nil && len(c) > 0 && c[0] == '1' {
 			return sevProtection, nil
 		}
 	}

--- a/src/runtime/virtcontainers/hypervisor_amd64_test.go
+++ b/src/runtime/virtcontainers/hypervisor_amd64_test.go
@@ -6,7 +6,6 @@
 package virtcontainers
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -70,7 +69,7 @@ func TestRunningOnVMM(t *testing.T) {
 }
 
 func TestRunningOnVMMNotExistingCPUInfoPathFailure(t *testing.T) {
-	f, err := ioutil.TempFile("", "cpuinfo")
+	f, err := os.CreateTemp("", "cpuinfo")
 	assert.NoError(t, err)
 
 	filePath := f.Name()

--- a/src/runtime/virtcontainers/hypervisor_arm64_test.go
+++ b/src/runtime/virtcontainers/hypervisor_arm64_test.go
@@ -6,7 +6,6 @@
 package virtcontainers
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -17,7 +16,7 @@ func TestRunningOnVMM(t *testing.T) {
 	assert := assert.New(t)
 	expectedOutput := false
 
-	f, err := ioutil.TempFile("", "cpuinfo")
+	f, err := os.CreateTemp("", "cpuinfo")
 	assert.NoError(err)
 	defer os.Remove(f.Name())
 	defer f.Close()

--- a/src/runtime/virtcontainers/hypervisor_test.go
+++ b/src/runtime/virtcontainers/hypervisor_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -391,7 +390,7 @@ func TestGetHostMemorySizeKb(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
@@ -400,7 +399,7 @@ func TestGetHostMemorySizeKb(t *testing.T) {
 	assert.Error(err)
 
 	for _, d := range data {
-		err = ioutil.WriteFile(file, []byte(d.contents), os.FileMode(0640))
+		err = os.WriteFile(file, []byte(d.contents), os.FileMode(0640))
 		assert.NoError(err)
 		defer os.Remove(file)
 
@@ -415,7 +414,7 @@ func TestGetHostMemorySizeKb(t *testing.T) {
 func TestCheckCmdline(t *testing.T) {
 	assert := assert.New(t)
 
-	cmdlineFp, err := ioutil.TempFile("", "")
+	cmdlineFp, err := os.CreateTemp("", "")
 	assert.NoError(err)
 	_, err = cmdlineFp.WriteString("quiet root=/dev/sda2")
 	assert.NoError(err)
@@ -438,7 +437,7 @@ type testNestedVMMData struct {
 func genericTestRunningOnVMM(t *testing.T, data []testNestedVMMData) {
 	assert := assert.New(t)
 	for _, d := range data {
-		f, err := ioutil.TempFile("", "cpuinfo")
+		f, err := os.CreateTemp("", "cpuinfo")
 		assert.NoError(err)
 		defer os.Remove(f.Name())
 		defer f.Close()

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -748,7 +747,7 @@ func (k *kataAgent) getDNS(sandbox *Sandbox) ([]string, error) {
 
 	for _, m := range ociMounts {
 		if m.Destination == GuestDNSFile {
-			content, err := ioutil.ReadFile(m.Source)
+			content, err := os.ReadFile(m.Source)
 			if err != nil {
 				return nil, fmt.Errorf("Could not read file %s: %s", m.Source, err)
 			}
@@ -2127,7 +2126,7 @@ func (k *kataAgent) copyFile(ctx context.Context, src, dst string) error {
 		return fmt.Errorf("Could not get file %s information: %v", src, err)
 	}
 
-	b, err := ioutil.ReadFile(src)
+	b, err := os.ReadFile(src)
 	if err != nil {
 		return fmt.Errorf("Could not read file %s: %v", src, err)
 	}

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -9,7 +9,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -740,7 +739,7 @@ func TestHandlePidNamespace(t *testing.T) {
 func TestAgentConfigure(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "kata-agent-test")
+	dir, err := os.MkdirTemp("", "kata-agent-test")
 	assert.Nil(err)
 	defer os.RemoveAll(dir)
 
@@ -856,7 +855,7 @@ func TestAgentCreateContainer(t *testing.T) {
 		},
 	}
 
-	dir, err := ioutil.TempDir("", "kata-agent-test")
+	dir, err := os.MkdirTemp("", "kata-agent-test")
 	assert.Nil(err)
 	defer os.RemoveAll(dir)
 
@@ -937,7 +936,7 @@ func TestKataCopyFile(t *testing.T) {
 	err = k.copyFile(context.Background(), "/abc/xyz/123", "/tmp")
 	assert.Error(err)
 
-	src, err := ioutil.TempFile("", "src")
+	src, err := os.CreateTemp("", "src")
 	assert.NoError(err)
 	defer os.Remove(src.Name())
 
@@ -946,7 +945,7 @@ func TestKataCopyFile(t *testing.T) {
 	assert.NoError(err)
 	assert.NoError(src.Close())
 
-	dst, err := ioutil.TempFile("", "dst")
+	dst, err := os.CreateTemp("", "dst")
 	assert.NoError(err)
 	assert.NoError(dst.Close())
 	defer os.Remove(dst.Name())
@@ -966,7 +965,7 @@ func TestKataCleanupSandbox(t *testing.T) {
 
 	kataHostSharedDirSaved := kataHostSharedDir
 	kataHostSharedDir = func() string {
-		td, _ := ioutil.TempDir("", "kata-Cleanup")
+		td, _ := os.MkdirTemp("", "kata-Cleanup")
 		return td
 	}
 	defer func() {
@@ -1117,13 +1116,13 @@ func TestSandboxBindMount(t *testing.T) {
 
 	assert := assert.New(t)
 	// create temporary files to mount:
-	testMountPath, err := ioutil.TempDir("", "sandbox-test")
+	testMountPath, err := os.MkdirTemp("", "sandbox-test")
 	assert.NoError(err)
 	defer os.RemoveAll(testMountPath)
 
 	// create a new shared directory for our test:
 	kataHostSharedDirSaved := kataHostSharedDir
-	testHostDir, err := ioutil.TempDir("", "kata-Cleanup")
+	testHostDir, err := os.MkdirTemp("", "kata-Cleanup")
 	assert.NoError(err)
 	kataHostSharedDir = func() string {
 		return testHostDir

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -490,7 +489,7 @@ func countFiles(path string, limit int) (numFiles int, err error) {
 		return 1, nil
 	}
 
-	files, err := ioutil.ReadDir(path)
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return 0, err
 	}

--- a/src/runtime/virtcontainers/mount_test.go
+++ b/src/runtime/virtcontainers/mount_test.go
@@ -9,7 +9,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -241,7 +240,7 @@ func TestIsEphemeralStorage(t *testing.T) {
 		t.Skip(ktu.TestDisabledNeedRoot)
 	}
 
-	dir, err := ioutil.TempDir(testDir, "foo")
+	dir, err := os.MkdirTemp(testDir, "foo")
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
@@ -319,7 +318,7 @@ func TestIsWatchable(t *testing.T) {
 	result = isWatchableMount(path)
 	assert.False(result)
 
-	testPath, err := ioutil.TempDir("", "")
+	testPath, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(testPath)
 

--- a/src/runtime/virtcontainers/persist/fs/fs.go
+++ b/src/runtime/virtcontainers/persist/fs/fs.go
@@ -9,11 +9,12 @@ package fs
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"syscall"
+
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 
 	persistapi "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/api"
 	"github.com/sirupsen/logrus"
@@ -142,7 +143,7 @@ func (fs *FS) ToDisk(ss persistapi.SandboxState, cs map[string]persistapi.Contai
 	}
 
 	// Walk sandbox dir and find container.
-	files, err := ioutil.ReadDir(sandboxDir)
+	files, err := os.ReadDir(sandboxDir)
 	if err != nil {
 		return err
 	}
@@ -190,7 +191,7 @@ func (fs *FS) FromDisk(sid string) (persistapi.SandboxState, map[string]persista
 	}
 
 	// walk sandbox dir and find container
-	files, err := ioutil.ReadDir(sandboxDir)
+	files, err := os.ReadDir(sandboxDir)
 	if err != nil {
 		return ss, nil, err
 	}
@@ -325,7 +326,7 @@ func (fs *FS) GlobalRead(relativePath string) ([]byte, error) {
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		fs.Logger().WithError(err).WithField("file", path).Error("failed to read file")
 		return nil, err

--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -8,7 +8,6 @@ package virtcontainers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -185,7 +184,7 @@ func createPhysicalEndpoint(netInfo NetworkInfo) (*PhysicalEndpoint, error) {
 	// Get vendor and device id from pci space (sys/bus/pci/devices/$bdf)
 
 	ifaceDevicePath := filepath.Join(sysPCIDevicesPath, bdf, "device")
-	contents, err := ioutil.ReadFile(ifaceDevicePath)
+	contents, err := os.ReadFile(ifaceDevicePath)
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +193,7 @@ func createPhysicalEndpoint(netInfo NetworkInfo) (*PhysicalEndpoint, error) {
 
 	// Vendor id
 	ifaceVendorPath := filepath.Join(sysPCIDevicesPath, bdf, "vendor")
-	contents, err = ioutil.ReadFile(ifaceVendorPath)
+	contents, err = os.ReadFile(ifaceVendorPath)
 	if err != nil {
 		return nil, err
 	}

--- a/src/runtime/virtcontainers/pkg/agent/protocols/grpc/utils_test.go
+++ b/src/runtime/virtcontainers/pkg/agent/protocols/grpc/utils_test.go
@@ -8,7 +8,7 @@ package grpc
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -82,7 +82,7 @@ func TestOCItoGRPC(t *testing.T) {
 	assert := assert.New(t)
 	var ociSpec specs.Spec
 
-	configJSONBytes, err := ioutil.ReadFile(ociConfigFile)
+	configJSONBytes, err := os.ReadFile(ociConfigFile)
 	assert.NoError(err, "Could not open OCI config file")
 
 	err = json.Unmarshal(configJSONBytes, &ociSpec)
@@ -97,7 +97,7 @@ func TestProcessOCItoGRPC(t *testing.T) {
 	assert := assert.New(t)
 	var ociSpec specs.Spec
 
-	configJSONBytes, err := ioutil.ReadFile(ociConfigFile)
+	configJSONBytes, err := os.ReadFile(ociConfigFile)
 	assert.NoError(err, "Could not open OCI config file")
 
 	err = json.Unmarshal(configJSONBytes, &ociSpec)
@@ -113,7 +113,7 @@ func TestProcessGRPCtoOCI(t *testing.T) {
 
 	var ociSpec specs.Spec
 
-	configJSONBytes, err := ioutil.ReadFile(ociConfigFile)
+	configJSONBytes, err := os.ReadFile(ociConfigFile)
 	assert.NoError(err, "Could not open OCI config file")
 
 	err = json.Unmarshal(configJSONBytes, &ociSpec)

--- a/src/runtime/virtcontainers/pkg/cgroups/utils_test.go
+++ b/src/runtime/virtcontainers/pkg/cgroups/utils_test.go
@@ -6,7 +6,6 @@
 package cgroups
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -110,7 +109,7 @@ func TestValidCgroupPath(t *testing.T) {
 func TestDeviceToCgroupDeviceRule(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := ioutil.TempFile("", "device")
+	f, err := os.CreateTemp("", "device")
 	assert.NoError(err)
 	f.Close()
 

--- a/src/runtime/virtcontainers/pkg/compatoci/utils.go
+++ b/src/runtime/virtcontainers/pkg/compatoci/utils.go
@@ -8,7 +8,7 @@ package compatoci
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -126,7 +126,7 @@ func ParseConfigJSON(bundlePath string) (specs.Spec, error) {
 	configPath := getConfigPath(bundlePath)
 	ociLog.Debugf("converting %s", configPath)
 
-	configByte, err := ioutil.ReadFile(configPath)
+	configByte, err := os.ReadFile(configPath)
 	if err != nil {
 		return specs.Spec{}, err
 	}

--- a/src/runtime/virtcontainers/pkg/mock/mock.go
+++ b/src/runtime/virtcontainers/pkg/mock/mock.go
@@ -8,9 +8,9 @@ package mock
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"net/url"
+	"os"
 
 	"github.com/containerd/ttrpc"
 	gpb "github.com/gogo/protobuf/types"
@@ -21,7 +21,7 @@ import (
 var testKataMockHybridVSockURLTempl = "mock://%s/kata-mock-hybrid-vsock.sock"
 
 func GenerateKataMockHybridVSock() (string, error) {
-	dir, err := ioutil.TempDir("", "kata-mock-hybrid-vsock-test")
+	dir, err := os.MkdirTemp("", "kata-mock-hybrid-vsock-test")
 	if err != nil {
 		return "", err
 	}

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -11,7 +11,6 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"os/user"
@@ -834,7 +833,7 @@ func (q *qemu) StartVM(ctx context.Context, timeout int) error {
 	strErr, err = govmmQemu.LaunchQemu(q.qemuConfig, newQMPLogger())
 	if err != nil {
 		if q.config.Debug && q.qemuConfig.LogFile != "" {
-			b, err := ioutil.ReadFile(q.qemuConfig.LogFile)
+			b, err := os.ReadFile(q.qemuConfig.LogFile)
 			if err == nil {
 				strErr += string(b)
 			}
@@ -1152,7 +1151,7 @@ func (q *qemu) dumpSandboxMetaInfo(dumpSavePath string) {
 	// Save hypervisor meta information
 	fileName := filepath.Join(dumpSavePath, "hypervisor.conf")
 	data, _ := json.MarshalIndent(q.config, "", " ")
-	if err := ioutil.WriteFile(fileName, data, defaultFilePerms); err != nil {
+	if err := os.WriteFile(fileName, data, defaultFilePerms); err != nil {
 		q.Logger().WithError(err).WithField("hypervisor.conf", data).Error("write to hypervisor.conf file failed")
 	}
 
@@ -1163,7 +1162,7 @@ func (q *qemu) dumpSandboxMetaInfo(dumpSavePath string) {
 	}
 
 	fileName = filepath.Join(dumpSavePath, "hypervisor.version")
-	if err := ioutil.WriteFile(fileName, []byte(hyperVisorVersion), defaultFilePerms); err != nil {
+	if err := os.WriteFile(fileName, []byte(hyperVisorVersion), defaultFilePerms); err != nil {
 		q.Logger().WithError(err).WithField("hypervisor.version", data).Error("write to hypervisor.version file failed")
 	}
 }
@@ -2384,7 +2383,7 @@ func (q *qemu) Cleanup(ctx context.Context) error {
 }
 
 func (q *qemu) GetPids() []int {
-	data, err := ioutil.ReadFile(q.qemuConfig.PidFile)
+	data, err := os.ReadFile(q.qemuConfig.PidFile)
 	if err != nil {
 		q.Logger().WithError(err).Error("Could not read qemu pid file")
 		return []int{0}

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -8,7 +8,6 @@ package virtcontainers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -111,7 +110,7 @@ func TestQemuAmd64MemoryTopology(t *testing.T) {
 func TestQemuAmd64AppendImage(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := ioutil.TempFile("", "img")
+	f, err := os.CreateTemp("", "img")
 	assert.NoError(err)
 	defer func() { _ = f.Close() }()
 	defer func() { _ = os.Remove(f.Name()) }()

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -8,7 +8,6 @@ package virtcontainers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -264,7 +263,7 @@ func TestQemuArchBaseAppendImage(t *testing.T) {
 	assert := assert.New(t)
 	qemuArchBase := newQemuArchBase()
 
-	image, err := ioutil.TempFile("", "img")
+	image, err := os.CreateTemp("", "img")
 	assert.NoError(err)
 	defer os.Remove(image.Name())
 	err = image.Close()

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -8,7 +8,6 @@ package virtcontainers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -97,7 +96,7 @@ func TestQemuArm64AppendImage(t *testing.T) {
 	var devices []govmmQemu.Device
 	assert := assert.New(t)
 
-	f, err := ioutil.TempFile("", "img")
+	f, err := os.CreateTemp("", "img")
 	assert.NoError(err)
 	defer func() { _ = f.Close() }()
 	defer func() { _ = os.Remove(f.Name()) }()
@@ -131,7 +130,7 @@ func TestQemuArm64AppendNvdimmImage(t *testing.T) {
 	var devices []govmmQemu.Device
 	assert := assert.New(t)
 
-	f, err := ioutil.TempFile("", "img")
+	f, err := os.CreateTemp("", "img")
 	assert.NoError(err)
 	defer func() { _ = f.Close() }()
 	defer func() { _ = os.Remove(f.Name()) }()

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -8,7 +8,6 @@ package virtcontainers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -299,7 +298,7 @@ func TestQemuAddDeviceSerialPortDev(t *testing.T) {
 func TestQemuAddDeviceKataVSOCK(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "")
+	dir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(dir)
 
@@ -363,7 +362,7 @@ func TestQemuCapabilities(t *testing.T) {
 func TestQemuQemuPath(t *testing.T) {
 	assert := assert.New(t)
 
-	f, err := ioutil.TempFile("", "qemu")
+	f, err := os.CreateTemp("", "qemu")
 	assert.NoError(err)
 	defer func() { _ = f.Close() }()
 	defer func() { _ = os.Remove(f.Name()) }()
@@ -588,7 +587,7 @@ func TestQemuGetpids(t *testing.T) {
 	q = &qemu{
 		config: qemuConfig,
 	}
-	f, err := ioutil.TempFile("", "qemu-test-")
+	f, err := os.CreateTemp("", "qemu-test-")
 	assert.Nil(err)
 	tmpfile := f.Name()
 	f.Close()
@@ -599,7 +598,7 @@ func TestQemuGetpids(t *testing.T) {
 	assert.True(len(pids) == 1)
 	assert.True(pids[0] == 0)
 
-	err = ioutil.WriteFile(tmpfile, []byte("100"), 0)
+	err = os.WriteFile(tmpfile, []byte("100"), 0)
 	assert.Nil(err)
 	pids = q.GetPids()
 	assert.True(len(pids) == 1)

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -8,7 +8,6 @@ package virtcontainers
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -255,7 +254,7 @@ func writeContainerConfig() (string, error) {
 	}
 }`
 
-	configDir, err := ioutil.TempDir("", "vc-tmp-")
+	configDir, err := os.MkdirTemp("", "vc-tmp-")
 	if err != nil {
 		return "", err
 	}
@@ -266,7 +265,7 @@ func writeContainerConfig() (string, error) {
 	}
 
 	configFilePath := filepath.Join(configDir, "config.json")
-	err = ioutil.WriteFile(configFilePath, []byte(basicSpec), 0644)
+	err = os.WriteFile(configFilePath, []byte(basicSpec), 0644)
 	if err != nil {
 		return "", err
 	}
@@ -512,7 +511,7 @@ func TestContainerStateSetFstype(t *testing.T) {
 }
 
 func TestSandboxAttachDevicesVFIO(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	assert.Nil(t, err)
 	os.RemoveAll(tmpDir)
 
@@ -582,7 +581,7 @@ func TestSandboxAttachDevicesVhostUserBlk(t *testing.T) {
 		rootEnabled = false
 	}
 
-	tmpDir, err := ioutil.TempDir("", "")
+	tmpDir, err := os.MkdirTemp("", "")
 	assert.Nil(t, err)
 	os.RemoveAll(tmpDir)
 	dm := manager.NewDeviceManager(manager.VirtioSCSI, true, tmpDir, nil)
@@ -683,7 +682,7 @@ func TestSandboxCreateAssets(t *testing.T) {
 		annotations map[string]string
 	}
 
-	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	tmpfile, err := os.CreateTemp("", "virtcontainers-test-")
 	assert.Nil(err)
 
 	filename := tmpfile.Name()

--- a/src/runtime/virtcontainers/types/asset.go
+++ b/src/runtime/virtcontainers/types/asset.go
@@ -9,7 +9,7 @@ import (
 	"crypto/sha512"
 	"encoding/hex"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations"
@@ -132,7 +132,7 @@ func (a *Asset) Hash(hashType string) (string, error) {
 	var hash string
 
 	// We read the actual asset content
-	bytes, err := ioutil.ReadFile(a.path)
+	bytes, err := os.ReadFile(a.path)
 	if err != nil {
 		return "", err
 	}

--- a/src/runtime/virtcontainers/types/asset_test.go
+++ b/src/runtime/virtcontainers/types/asset_test.go
@@ -7,7 +7,6 @@ package types
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -22,7 +21,7 @@ var assetContentWrongHash = "92549f8d2018a95a294d28a65e795ed7d1a9d150009a28cea10
 func TestAssetWrongHashType(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	tmpfile, err := os.CreateTemp("", "virtcontainers-test-")
 	assert.Nil(err)
 
 	defer func() {
@@ -45,7 +44,7 @@ func TestAssetWrongHashType(t *testing.T) {
 func TestAssetHash(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	tmpfile, err := os.CreateTemp("", "virtcontainers-test-")
 	assert.Nil(err)
 
 	defer func() {
@@ -90,7 +89,7 @@ func testValid(t *testing.T, a *Asset, msg string) {
 func TestAssetNew(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpfile, err := ioutil.TempFile("", "virtcontainers-test-")
+	tmpfile, err := os.CreateTemp("", "virtcontainers-test-")
 	assert.Nil(err)
 
 	defer func() {

--- a/src/runtime/virtcontainers/utils/proc_linux.go
+++ b/src/runtime/virtcontainers/utils/proc_linux.go
@@ -6,7 +6,7 @@
 package utils
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strconv"
 
@@ -32,7 +32,7 @@ func NewProc(pid int) (*Proc, error) {
 // We should try to upstream this but let's keep it until upstream supports it.
 func (p *Proc) Children() ([]*Proc, error) {
 	parent := strconv.Itoa(p.PID)
-	infos, err := ioutil.ReadDir(filepath.Join(procfs.DefaultMountPoint, parent, taskPath))
+	infos, err := os.ReadDir(filepath.Join(procfs.DefaultMountPoint, parent, taskPath))
 	if err != nil {
 		return nil, errors.Wrapf(err, "Fail to read pid %v proc task dir", p.PID)
 	}

--- a/src/runtime/virtcontainers/utils/utils_test.go
+++ b/src/runtime/virtcontainers/utils/utils_test.go
@@ -7,7 +7,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -27,12 +26,12 @@ func TestFileCopySuccessful(t *testing.T) {
 	assert := assert.New(t)
 	fileContent := "testContent"
 
-	srcFile, err := ioutil.TempFile("", "test_src_copy")
+	srcFile, err := os.CreateTemp("", "test_src_copy")
 	assert.NoError(err)
 	defer os.Remove(srcFile.Name())
 	defer srcFile.Close()
 
-	dstFile, err := ioutil.TempFile("", "test_dst_copy")
+	dstFile, err := os.CreateTemp("", "test_dst_copy")
 	assert.NoError(err)
 	defer os.Remove(dstFile.Name())
 
@@ -46,7 +45,7 @@ func TestFileCopySuccessful(t *testing.T) {
 	err = FileCopy(srcFile.Name(), dstPath)
 	assert.NoError(err)
 
-	dstContent, err := ioutil.ReadFile(dstPath)
+	dstContent, err := os.ReadFile(dstPath)
 	assert.NoError(err)
 	assert.Equal(string(dstContent), fileContent)
 
@@ -75,7 +74,7 @@ func TestFileCopyDestinationEmptyFailure(t *testing.T) {
 
 func TestFileCopySourceNotExistFailure(t *testing.T) {
 	assert := assert.New(t)
-	srcFile, err := ioutil.TempFile("", "test_src_copy")
+	srcFile, err := os.CreateTemp("", "test_src_copy")
 	assert.NoError(err)
 
 	srcPath := srcFile.Name()
@@ -104,7 +103,7 @@ func TestRevereString(t *testing.T) {
 func TestCleanupFds(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpFile, err := ioutil.TempFile("", "testFds1")
+	tmpFile, err := os.CreateTemp("", "testFds1")
 	assert.NoError(err)
 	filename := tmpFile.Name()
 	defer os.Remove(filename)
@@ -129,7 +128,7 @@ func TestWriteToFile(t *testing.T) {
 	err := WriteToFile("/file-does-not-exist", []byte("test-data"))
 	assert.NotNil(err)
 
-	tmpFile, err := ioutil.TempFile("", "test_append_file")
+	tmpFile, err := os.CreateTemp("", "test_append_file")
 	assert.NoError(err)
 
 	filename := tmpFile.Name()
@@ -141,7 +140,7 @@ func TestWriteToFile(t *testing.T) {
 	err = WriteToFile(filename, testData)
 	assert.NoError(err)
 
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	assert.NoError(err)
 
 	assert.True(reflect.DeepEqual(testData, data))
@@ -319,7 +318,7 @@ func TestSupportsVsocks(t *testing.T) {
 	VHostVSockDevicePath = "/abc/xyz/123"
 	assert.False(SupportsVsocks())
 
-	vHostVSockFile, err := ioutil.TempFile("", "vhost-vsock")
+	vHostVSockFile, err := os.CreateTemp("", "vhost-vsock")
 	assert.NoError(err)
 	defer os.Remove(vHostVSockFile.Name())
 	defer vHostVSockFile.Close()
@@ -459,10 +458,10 @@ func TestMkdirAllWithInheritedOwnerSuccessful(t *testing.T) {
 		t.Skip("Test disabled as requires root user")
 	}
 	assert := assert.New(t)
-	tmpDir1, err := ioutil.TempDir("", "test")
+	tmpDir1, err := os.MkdirTemp("", "test")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpDir1)
-	tmpDir2, err := ioutil.TempDir("", "test")
+	tmpDir2, err := os.MkdirTemp("", "test")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpDir2)
 
@@ -521,7 +520,7 @@ func TestChownToParent(t *testing.T) {
 		t.Skip("Test disabled as requires root user")
 	}
 	assert := assert.New(t)
-	rootDir, err := ioutil.TempDir("", "root")
+	rootDir, err := os.MkdirTemp("", "root")
 	assert.NoError(err)
 	defer os.RemoveAll(rootDir)
 	uid := 1234

--- a/src/runtime/virtcontainers/virtcontainers_test.go
+++ b/src/runtime/virtcontainers/virtcontainers_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -121,7 +120,7 @@ func TestMain(m *testing.M) {
 	}
 	SetLogger(context.Background(), logger)
 
-	testDir, err = ioutil.TempDir("", "vc-tmp-")
+	testDir, err = os.MkdirTemp("", "vc-tmp-")
 	if err != nil {
 		panic(err)
 	}

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -30,11 +29,11 @@ func TestVirtiofsdStart(t *testing.T) {
 		ctx        context.Context
 	}
 
-	sourcePath, err := ioutil.TempDir("", "")
+	sourcePath, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(sourcePath)
 
-	socketDir, err := ioutil.TempDir("", "")
+	socketDir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(socketDir)
 
@@ -104,11 +103,11 @@ func TestVirtiofsdArgs(t *testing.T) {
 func TestValid(t *testing.T) {
 	assert := assert.New(t)
 
-	sourcePath, err := ioutil.TempDir("", "")
+	sourcePath, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(sourcePath)
 
-	socketDir, err := ioutil.TempDir("", "")
+	socketDir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(socketDir)
 

--- a/src/runtime/virtcontainers/vm_test.go
+++ b/src/runtime/virtcontainers/vm_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -19,7 +18,7 @@ import (
 func TestNewVM(t *testing.T) {
 	assert := assert.New(t)
 
-	testDir, err := ioutil.TempDir("", "vmfactory-tmp-")
+	testDir, err := os.MkdirTemp("", "vmfactory-tmp-")
 	assert.Nil(err)
 	defer os.RemoveAll(testDir)
 
@@ -66,12 +65,12 @@ func TestNewVM(t *testing.T) {
 	defer func() {
 		urandomDev = savedUrandomDev
 	}()
-	tmpdir, err := ioutil.TempDir("", "")
+	tmpdir, err := os.MkdirTemp("", "")
 	assert.NoError(err)
 	defer os.RemoveAll(tmpdir)
 	urandomDev = filepath.Join(tmpdir, "urandom")
 	data := make([]byte, 512)
-	err = ioutil.WriteFile(urandomDev, data, os.FileMode(0640))
+	err = os.WriteFile(urandomDev, data, os.FileMode(0640))
 	assert.NoError(err)
 
 	err = vm.ReseedRNG(context.Background())
@@ -99,7 +98,7 @@ func TestVMConfigValid(t *testing.T) {
 	err := config.Valid()
 	assert.Error(err)
 
-	testDir, err := ioutil.TempDir("", "vmfactory-tmp-")
+	testDir, err := os.MkdirTemp("", "vmfactory-tmp-")
 	assert.Nil(err)
 	defer os.RemoveAll(testDir)
 

--- a/tools/packaging/cmd/kata-pkgsync/cli/utils.go
+++ b/tools/packaging/cmd/kata-pkgsync/cli/utils.go
@@ -7,14 +7,14 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"gopkg.in/yaml.v2"
 )
 
 func yamlUnmarshal(yamlFile string, cfg interface{}) error {
-	source, err := ioutil.ReadFile(yamlFile)
+	source, err := os.ReadFile(yamlFile)
 	if err != nil {
 		return err
 	}

--- a/versions.yaml
+++ b/versions.yaml
@@ -250,7 +250,7 @@ languages:
     issue: "https://github.com/golang/go/issues/20676"
     uscan-url: >-
       https://github.com/golang/go/tags .*/go?([\d\.]+)\.tar\.gz
-    version: "1.11.10"
+    version: "1.16.10"
     meta:
       description: |
         'newest-version' is the latest version known to work when


### PR DESCRIPTION
This PR includes two commits:

### bump minimum golang version to 1.16.10

According to https://endoflife.date/go golang 1.11.10 is not supported
anymore, 1.16.10 is the minimum supported version.

Fixes: #3016

### runtime: change io/ioutil to io/os packages

Change io/ioutil to io/os packages because io/ioutil package
is deprecated from 1.16:

Discard => io.Discard
NopCloser => io.NopCloser
ReadAll => io.ReadAll
ReadDir => os.ReadDir
ReadFile => os.ReadFile
TempDir => os.MkdirTemp
TempFile => os.CreateTemp
WriteFile => os.WriteFile

Details: https://go.dev/doc/go1.16#ioutil