### PR TITLE
stable-2.3 | versions: Upgrade to Cloud Hypervisor v20.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v20.0"
+      version: "v20.1"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This is a bug release from Cloud Hypervisor addressing the following
issues: 1) Networking performance regression with virtio-net; 2) Limit
file descriptors sent in vfio-user support; 3) Fully advertise PCI MMIO
config regions in ACPI tables; 4) Set the TSS and KVM identity maps so
they don't overlap with firmware RAM; 5) Correctly update the DeviceTree
on restore.

Details can be found: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v20.1

Fixes: #3262

Signed-off-by: Bo Chen <chen.bo@intel.com>
(cherry picked from commit bbfb10e16998f3ff3273083cf60875a7e9ce6fa2)