### PR TITLE
qemu: Disable libudev for QEMU 5.2 and newer

### DIFF
--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -310,9 +310,10 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-qom-cast-debug)
 	qemu_options+=(size:--disable-tcmalloc)
 
-	# Disable libudev for static build
+	# Disable libudev since it is only needed for qemu-pr-helper and USB,
+	# none of which are used with Kata
 	if gt_eq "${qemu_version}" "5.2.0" ; then
-		[ "${static}" == "true" ] && qemu_options+=(size:--disable-libudev)
+		qemu_options+=(size:--disable-libudev)
 	fi
 
 	# Disallow network downloads


### PR DESCRIPTION
Commit 112ea25859d6 disabled libudev for static builds because it was
breaking snap. It turns out that the only users of libudev in QEMU are
qemu-pr-helper and USB. Kata already disables USB and doesn't use
qemu-pr-helper. Disable libudev for all builds if QEMU supports it, i.e.
version 5.2 or newer.

Fixes #3078

Signed-off-by: Greg Kurz <groug@kaod.org>