### PR TITLE
tracing: Add span name to logging error

### DIFF
--- a/src/runtime/pkg/katautils/katatrace/tracing.go
+++ b/src/runtime/pkg/katautils/katatrace/tracing.go
@@ -130,7 +130,7 @@ func Trace(parent context.Context, logger *logrus.Entry, name string, tags ...ma
 		if logger == nil {
 			logger = kataTraceLogger
 		}
-		logger.WithField("type", "bug").Error("trace called before context set")
+		logger.WithField("type", "bug").WithField("name", name).Error("trace called before context set")
 		parent = context.Background()
 	}
 


### PR DESCRIPTION
Add span name to logging error to help with debugging when the context
is not set before the span is created.

Fixes #3289

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>