### PR TITLE
osbuilder: avoid to copy versions.txt which already deprecated

### DIFF
--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -182,7 +182,6 @@ SCRIPTS += image-builder/image_builder.sh
 SCRIPTS += initrd-builder/initrd_builder.sh
 
 HELPER_FILES :=
-HELPER_FILES += rootfs-builder/versions.txt
 HELPER_FILES += scripts/lib.sh
 HELPER_FILES += image-builder/nsdax.gpl.c
 
@@ -202,7 +201,7 @@ install-scripts:
 	@$(foreach f,$(SCRIPTS),$(call INSTALL_SCRIPT,$f,$(INSTALL_DIR)))
 	@echo "Installing helper files"
 	@$(foreach f,$(HELPER_FILES),$(call INSTALL_FILE,$f,$(INSTALL_DIR)))
-	@echo "Installing installing config files"
+	@echo "Installing config files"
 	@$(foreach f,$(DIST_CONFIGS),$(call INSTALL_FILE,$f,$(INSTALL_DIR)))
 
 .PHONY: clean


### PR DESCRIPTION
Currently the versions.txt in rootfs-builder dir is already removed,
so avoid to copy it in list of helper files.

Fixes: #3267

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>