### PR TITLE
packaging/qemu: partial git clone

### DIFF
--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -58,11 +58,7 @@ RUN cd  .. && git clone --depth=1 "${QEMU_REPO}" qemu
 ARG QEMU_VERSION
 
 RUN git fetch --depth=1 origin "${QEMU_VERSION}" && git checkout FETCH_HEAD
-RUN git clone https://github.com/qemu/capstone.git capstone
-RUN git clone https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
-RUN git clone https://github.com/qemu/meson.git meson
-RUN git clone https://github.com/qemu/berkeley-softfloat-3.git tests/fp/berkeley-softfloat-3
-RUN git clone https://github.com/qemu/berkeley-testfloat-3.git tests/fp/berkeley-testfloat-3
+RUN scripts/git-submodule.sh update meson capstone
 
 ADD scripts/configure-hypervisor.sh /root/configure-hypervisor.sh
 ADD qemu /root/kata_qemu

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -52,12 +52,12 @@ RUN [ "$(uname -m)" != "s390x" ] && apt-get install -y libpmem-dev || true
 
 ARG QEMU_REPO
 
-RUN cd  .. && git clone "${QEMU_REPO}" qemu
+RUN cd  .. && git clone --depth=1 "${QEMU_REPO}" qemu
 
 # commit/tag/branch
 ARG QEMU_VERSION
 
-RUN git checkout "${QEMU_VERSION}"
+RUN git fetch --depth=1 origin "${QEMU_VERSION}" && git checkout FETCH_HEAD
 RUN git clone https://github.com/qemu/capstone.git capstone
 RUN git clone https://github.com/qemu/keycodemapdb.git ui/keycodemapdb
 RUN git clone https://github.com/qemu/meson.git meson


### PR DESCRIPTION
This PR changes the method to clone the QEMU source tree in order to speed up its build. It is used the `--depth=1` argument of `git` to fetch just the needed objects.

While here I change the way that the submodules are cloned. 

Fixes #3291 