### PR TITLE
docs: Fix arch doc formatting

### DIFF
--- a/docs/design/architecture/README.md
+++ b/docs/design/architecture/README.md
@@ -475,5 +475,3 @@ Containers system.
 ## Terminology
 
 See the [project glossary](../../../Glossary.md).
-
-[debug-console]: ../../Developer-Guide.md#connect-to-debug-console

--- a/docs/design/architecture/guest-assets.md
+++ b/docs/design/architecture/guest-assets.md
@@ -148,3 +148,5 @@ See also:
 
   The `default-image-name` and `default-initrd-name` options specify
   the default distributions for each image type.
+
+[debug-console]: ../../Developer-Guide.md#connect-to-debug-console


### PR DESCRIPTION
PR #3298 failed to move the named link for the debug console to the
`guest-assets.md` meaning the debug console cells in the "User
accessible" column in the table in the "Root filesystem image" section
do not work as a link.

Fixes: #3311.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>