### PR TITLE
osbuilder: Add protoc to the alpine container

### DIFF
--- a/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
@@ -26,4 +26,5 @@ RUN apk update && apk add \
     make \
     musl \
     musl-dev \
+    protoc \
     tar


### PR DESCRIPTION
It seems the lack of protoc in the alpine containers is causing issues
with some of our CIs, such as the VFIO one.

Fixes: #3323

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>