### PR TITLE
agent: mount: Remove unneeded mount_point local variable

### DIFF
--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -449,18 +449,17 @@ fn mount_storage(logger: &Logger, storage: &Storage) -> Result<()> {
     let (flags, options) = parse_mount_flags_and_options(options_vec);
 
     let source = Path::new(&storage.source);
-    let mount_point = Path::new(&storage.mount_point);
 
     info!(logger, "mounting storage";
     "mount-source" => source.display(),
-    "mount-destination" => mount_point.display(),
+    "mount-destination" => mount_path.display(),
     "mount-fstype"  => storage.fstype.as_str(),
     "mount-options" => options.as_str(),
     );
 
     baremount(
         source,
-        mount_point,
+        mount_path,
         storage.fstype.as_str(),
         flags,
         options.as_str(),


### PR DESCRIPTION
We already have a `mount_path` local Path variable which holds the mount
point (`mount.rs` line 438).

Use it instead of creating a new `mount_point` variable with identical
type and content.

Fixes: #3332

Signed-off-by: Dov Murik <dovmurik@linux.ibm.com>
