### PR TITLE
docs: Fix outdated links

### DIFF
--- a/docs/design/host-cgroups.md
+++ b/docs/design/host-cgroups.md
@@ -242,8 +242,8 @@ On the other hand, running all non vCPU threads under a dedicated overhead cgrou
 accurate metrics on the actual Kata Container pod overhead, allowing for tuning the overhead
 cgroup size and constraints accordingly.
 
-[linux-config]: https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md
-[cgroupspath]: https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#cgroups-path
+[linux-config]: https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md
+[cgroupspath]: https://github.com/opencontainers/runtime-spec/blob/main/config-linux.md#cgroups-path
 
 # Supported cgroups
 

--- a/src/runtime/virtcontainers/README.md
+++ b/src/runtime/virtcontainers/README.md
@@ -17,7 +17,7 @@ or the [Kubernetes CRI][cri]) to the `virtcontainers` API.
 `virtcontainers` was used as a foundational package for the [Clear Containers][cc] [runtime][cc-runtime] implementation.
 
 [oci]: https://github.com/opencontainers/runtime-spec
-[cri]: https://git.k8s.io/community/contributors/devel/sig-node/container-runtime-interface.md
+[cri]: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-node/container-runtime-interface.md
 [cc]: https://github.com/clearcontainers/
 [cc-runtime]: https://github.com/clearcontainers/runtime/
 


### PR DESCRIPTION
renamed branch `master` to `main`

Fixes: #3336
Signed-off-by: Jakob Naucke jakob.naucke@ibm.com

---

Fix outdated link in virtcontainers readme