### PR TITLE
runtime: fix a typo in kata-collect-data.sh

### DIFF
--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -714,7 +714,7 @@ unmount_partition()
 {
 	local mountpoint="$1"
 	[ -n "$mountpoint" ] || die "need mountpoint"
-	[ -n "$mountpoint" ] || die "mountpoint does not exist: $mountpoint"
+	[ -e "$mountpoint" ] || die "mountpoint does not exist: $mountpoint"
 
 	umount "$mountpoint"
 }


### PR DESCRIPTION
Fix a typo while to check if mountpoint exist.

Fixes: #3365

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>