### PR TITLE
agent: fix the issue of creating new namespaces for agent

### DIFF
--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -100,7 +100,7 @@ impl Namespace {
         self.path = new_ns_path.clone().into_os_string().into_string().unwrap();
         let hostname = self.hostname.clone();
 
-        let new_thread = tokio::spawn(async move {
+        let new_thread = std::thread::spawn(move || {
             if let Err(err) = || -> Result<()> {
                 let origin_ns_path = get_current_thread_ns_path(ns_type.get());
 
@@ -148,7 +148,7 @@ impl Namespace {
         });
 
         new_thread
-            .await
+            .join()
             .map_err(|e| anyhow!("Failed to join thread {:?}!", e))??;
 
         Ok(self)


### PR DESCRIPTION
The tokio's spawn will only create an future async task
instead of a new real thread, thus executing unshare to
create a new namespace in tokio's async task would make
the agent process to join in the new created namespace,
which isn't expected.

Thus, we'd better to to the unshare in a real thread to
prevent moving the agent process into a new namespace.

Fixes: #3369

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>