### PR TITLE
osbuilder: Restore Debian as a rootfs

### DIFF
--- a/src/runtime/pkg/katatestutils/constraints_test.go
+++ b/src/runtime/pkg/katatestutils/constraints_test.go
@@ -43,6 +43,7 @@ type testDataDistro struct {
 var distros = []string{
 	"centos",
 	"clear-linux-os",
+	"debian",
 	"fedora",
 	"opensuse",
 	"rhel",

--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile-aarch64.in
@@ -1,0 +1,34 @@
+#
+# Copyright (c) 2020 ARM Limited
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG IMAGE_REGISTRY=docker.io
+# NOTE: OS_VERSION is set according to config.sh
+FROM ${IMAGE_REGISTRY}/debian:@OS_VERSION@
+
+# RUN commands
+RUN apt-get update && apt-get install -y \
+    autoconf \
+    automake \
+    binutils \
+    build-essential \
+    chrony \
+    coreutils \
+    curl \
+    debianutils \
+    debootstrap \
+    g++ \
+    gcc \
+    git \
+    libc-dev \
+    libstdc++-8-dev \
+    m4 \
+    make \
+    sed \
+    systemd \
+    tar \
+    vim
+# This will install the proper packages to build Kata components
+@INSTALL_MUSL@
+@INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
@@ -1,0 +1,40 @@
+#
+# Copyright (c) 2018 SUSE
+#
+# SPDX-License-Identifier: Apache-2.0
+
+ARG IMAGE_REGISTRY=docker.io
+# NOTE: OS_VERSION is set according to config.sh
+FROM ${IMAGE_REGISTRY}/debian:@OS_VERSION@
+
+# RUN commands
+RUN apt-get update && apt-get --no-install-recommends install -y \
+    apt-utils \
+    autoconf \
+    automake \
+    binutils \
+    build-essential \
+    ca-certificates \
+    chrony \
+    coreutils \
+    curl \
+    debianutils \
+    debootstrap \
+    g++ \
+    gcc \
+    git \
+    libc-dev \
+    libstdc++-8-dev \
+    m4 \
+    make \
+    musl \
+    musl-dev \
+    musl-tools \
+    sed \
+    systemd \
+    tar \
+    vim \
+    wget
+
+# This will install the proper packages to build Kata components
+@INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/debian/config.sh
+++ b/tools/osbuilder/rootfs-builder/debian/config.sh
@@ -1,0 +1,20 @@
+#
+# Copyright (c) 2018 SUSE
+#
+# SPDX-License-Identifier: Apache-2.0
+
+OS_VERSION=${OS_VERSION:-10.11}
+
+# Set OS_NAME to the desired debian "codename"
+OS_NAME=${OS_NAME:-"stretch"}
+
+PACKAGES="systemd coreutils init chrony kmod"
+
+# NOTE: Re-using ubuntu rootfs configuration, see 'ubuntu' folder for full content.
+source $script_dir/ubuntu/$CONFIG_SH
+
+# Init process must be one of {systemd,kata-agent}
+INIT_PROCESS=systemd
+# List of zero or more architectures to exclude from build,
+# as reported by  `uname -m`
+ARCH_EXCLUDE_LIST=()

--- a/tools/osbuilder/rootfs-builder/debian/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/debian/rootfs_lib.sh
@@ -1,0 +1,7 @@
+#
+# Copyright (c) 2018 SUSE
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: Re-using ubuntu rootfs lib, see 'ubuntu' folder for details.
+source ${script_dir}/ubuntu/$LIB_SH

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -193,7 +193,7 @@ docker_extra_args()
 		args+=" -v ${gentoo_local_portage_dir}:/usr/portage/packages"
 		args+=" --volumes-from ${gentoo_portage_container}"
 		;;
-	ubuntu | suse)
+        debian | ubuntu | suse)
 		source /etc/os-release
 
 		case "$ID" in
@@ -520,8 +520,8 @@ EOT
 			chrony_conf_file="${ROOTFS_DIR}/etc/chrony/chrony.conf"
 			chrony_systemd_service="${ROOTFS_DIR}/lib/systemd/system/chronyd.service"
 			;;
-		"ubuntu")
-			echo "I am ubuntu"
+		"ubuntu" | "debian")
+			echo "I am ubuntu or debian"
 			chrony_conf_file="${ROOTFS_DIR}/etc/chrony/chrony.conf"
 			chrony_systemd_service="${ROOTFS_DIR}/lib/systemd/system/chrony.service"
 			;;

--- a/tools/packaging/static-build/scripts/kata-configure-docker.sh
+++ b/tools/packaging/static-build/scripts/kata-configure-docker.sh
@@ -122,7 +122,7 @@ setup()
 
 	case "$distro" in
 		centos|rhel) $chronic sudo -E yum -y install "$pkg" ;;
-		ubuntu) $chronic sudo -E apt-get --no-install-recommends install -y "$pkg" ;;
+		debian|ubuntu) $chronic sudo -E apt-get --no-install-recommends install -y "$pkg" ;;
 		fedora) $chronic sudo -E dnf -y install "$pkg" ;;
 		opensuse|sles) $chronic sudo -E zypper -y install "$pkg" ;;
 		*) die "do not know how to install command $pkg' for distro '$distro'" ;;

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -290,7 +290,7 @@ check_deps()
 
 	case "$ID" in
 		centos|rhel) sudo yum -y install $packages ;;
-		ubuntu) sudo apt-get -y install $packages ;;
+		debian|ubuntu) sudo apt-get -y install $packages ;;
 		fedora) sudo dnf -y install $packages ;;
 		opensuse*|sles) sudo zypper install -y $packages ;;
 		*) die "Unsupported distro: $ID"


### PR DESCRIPTION
Restore Debian as a rootfs. Relate Issue #3372 
1. revert of #3154, but some change
2. update debian version to `10.11`
3. update  `libstdc++-6-dev` to `libstdc++-8-dev`
4.  changes discarded in QAT are not restored

Fixes: #3372
Signed-off-by: zhaojizhuang <571130360@qq.com>