### PR TITLE
versions: Upgrade to Cloud Hypervisor v20.2

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v20.1"
+      version: "v20.2"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This is a bug release from Cloud Hypervisor addressing the following issues:

1. Don't error out when setting up the SIGWINCH handler (for console resize) when this fails due to older kernel
1. Seccomp rules were refined to remove syscalls that are now unused
1. Fix reboot on older host kernels when SIGWINCH handler was not initialised
1. Fix virtio-vsock blocking issue

Details can be found: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v20.2

Fixes: #3383

Signed-off-by: Bo Chen <chen.bo@intel.com>