### PR TITLE
runtime: Enable locking on virtio-fs by default

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -174,7 +174,7 @@ DEFVIRTIOFSCACHE ?= auto
 #
 # see `virtiofsd -h` for possible options.
 # Make sure you quote args.
-DEFVIRTIOFSEXTRAARGS ?= [\"--thread-pool-size=1\"]
+DEFVIRTIOFSEXTRAARGS ?= [\"--thread-pool-size=1\", \"-o\", \"flock\"]
 DEFENABLEIOTHREADS := false
 DEFENABLEVHOSTUSERSTORE := false
 DEFVHOSTUSERSTOREPATH := $(PKGRUNDIR)/vhost-user


### PR DESCRIPTION
When using the virtiofsd defaults `no_flock` and `no_posix_lock`, the corresponding syscalls `flock` and `fcntl` still succeed, so the caller thinks that the file is locked while it's not. This can lead to data corruption/loss. Thus, I believe `flock` and `posix_lock` are important to enable by default.

Fixes #3408 