### PR TITLE
libs: add some generated files to .gitignore

### DIFF
--- a/src/libs/oci/.gitignore
+++ b/src/libs/oci/.gitignore
@@ -1,0 +1,1 @@
+Cargo.lock

--- a/src/libs/protocols/.gitignore
+++ b/src/libs/protocols/.gitignore
@@ -1,0 +1,8 @@
+Cargo.lock
+src/agent.rs
+src/agent_ttrpc.rs
+src/empty.rs
+src/health.rs
+src/health_ttrpc.rs
+src/oci.rs
+src/types.rs


### PR DESCRIPTION
Generated protocols files should not be inclued in Git repo.

And also add Cargo.lock in oci/protocols directory to .gitignore.

Fixes: #3422

Signed-off-by: bin <bin@hyper.sh>