### PR TITLE
docs: fix a typo in host-cgroups.md doc

### DIFF
--- a/docs/design/host-cgroups.md
+++ b/docs/design/host-cgroups.md
@@ -19,7 +19,7 @@ Cgroups are hierarchical, and this can be seen with the following pod example:
   - Container 2: `cgroupsPath=/kubepods/pod1/container2`
 
 - Pod 2: `cgroupsPath=/kubepods/pod2`
-  - Container 1: `cgroupsPath=/kubepods/pod2/container2`
+  - Container 1: `cgroupsPath=/kubepods/pod2/container1`
   - Container 2: `cgroupsPath=/kubepods/pod2/container2`
 
 Depending on the upper-level orchestration layers, the cgroup under which the pod is placed is


### PR DESCRIPTION
Container1's cgroupsPath in pod2 should be /kubepods/pod2/container1.

Fixes: #3431

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>