### PR TITLE
runtime: Provide protection for shared data

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -2044,10 +2044,20 @@ func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (inter
 	}
 
 	msgName := proto.MessageName(request.(proto.Message))
+
+	k.Lock()
+
+	if k.reqHandlers == nil {
+		return nil, errors.New("Client has already disconnected")
+	}
+
 	handler := k.reqHandlers[msgName]
 	if msgName == "" || handler == nil {
 		return nil, errors.New("Invalid request type")
 	}
+
+	k.Unlock()
+
 	message := request.(proto.Message)
 	ctx, cancel := k.getReqContext(spanCtx, msgName)
 	if cancel != nil {


### PR DESCRIPTION
The k.reqHandlers should be protected by locks when used

Fixes #3440

Signed-off-by: liangxianlong <liang.xianlong@zte.com.cn>