### PR TITLE
packaging: Make kernel config accessible to guest

### DIFF
--- a/tools/packaging/kernel/configs/fragments/common/debug.conf
+++ b/tools/packaging/kernel/configs/fragments/common/debug.conf
@@ -1,0 +1,6 @@
+# Debug related settings
+
+# Enable /proc/config.gz to allow the guest to query the kernel
+# configuration used for the running kernel.
+CONFIG_IKCONFIG=y
+CONFIG_IKCONFIG_PROC=y


### PR DESCRIPTION
Provide the `/proc/config.gz` file in guest kernels that allow the guest
to determine the kernel configuration used to build the running kernel.

Note that since `gunzip` expects to rename the gzip'ed file it operates
on, to use this feature you need to run something like the following in
the container environment:

```bash
# cat /proc/config.gz|gunzip -c
```

Fixes: #3445.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>