### PR TITLE
docs: Remove ccloudvm reference

### DIFF
--- a/tools/packaging/README.md
+++ b/tools/packaging/README.md
@@ -28,10 +28,6 @@ See [the kernel documentation](kernel).
 
 See [the QEMU documentation](qemu).
 
-## Test Kata using ccloudvm
-
-See [the ccloudvm documentation](ccloudvm).
-
 ## Create a Kata Containers release
 
 See [the release documentation](release).


### PR DESCRIPTION
This PR removes the ccloudvm reference at the README document as the
setup of scripts of ccloudvm were removed.

Fixes #3448

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>