### PR TITLE
workflows: Use the correct branch ref on test kata-deploy

### DIFF
--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -48,7 +48,18 @@ jobs:
           - rootfs-initrd
           - shim-v2
     steps:
+      # As Github action event `issue_comment` does not provide the right ref
+      # (commit/branch) to be tested, let's use this third part action to work
+      # this limitation around.
+      - name: resolve pr refs
+        id: refs
+        uses: kata-containers/resolve-pr-refs@v0.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
       - name: Install docker
         run: |
           curl -fsSL https://test.docker.com -o test-docker.sh
@@ -75,7 +86,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-asset
     steps:
+      # As Github action event `issue_comment` does not provide the right ref
+      # (commit/branch) to be tested, let's use this third part action to work
+      # this limitation around.
+      - name: resolve pr refs
+        id: refs
+        uses: kata-containers/resolve-pr-refs@v0.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
       - name: get-artifacts
         uses: actions/download-artifact@v2
         with:
@@ -94,7 +115,17 @@ jobs:
     needs: create-kata-tarball
     runs-on: ubuntu-latest
     steps:
+      # As Github action event `issue_comment` does not provide the right ref
+      # (commit/branch) to be tested, let's use this third part action to work
+      # this limitation around.
+      - name: resolve pr refs
+        id: refs
+        uses: kata-containers/resolve-pr-refs@v0.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
       - name: get-kata-tarball
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
The action used for testing kata-deploy is entirely based on the action
used to build the kata-deploy tarball, but while the latter is able to
use the correct branch, the former always uses `main`.

This happens as the `issue_comment`, from GitHub actions, passed the
"default branch" as the GITHUB_REF.

As we're not the first ones to face such a issue, I've decided to take
one of the approaches suggested at one of the checkout's issues,
https://github.com/actions/checkout/issues/331, and take advantage of a
new action provided by the community, which will get the PR where the
comment was made, give us that ref, and that then can be used with the
checkout action, resulting on what we originally wanted.

Fixes: #3443

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>