### PR TITLE
version: bump to kubernetes 1.23

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -209,7 +209,7 @@ externals:
     uscan-url: >-
       https://github.com/kubernetes/kubernetes/tags
       .*/v?([\d\.]+)\.tar\.gz
-    version: "1.22.0-00"
+    version: "1.23.1-00"
 
   libseccomp:
     description: "High level interface to Linux seccomp filter"


### PR DESCRIPTION
Current latest release is 1.23.1. Let's update to this version for our
integration testing.

Fixes: #3477

Signed-off-by: Eric Ernst <eric_ernst@apple.com>