### PR TITLE
versions: bump CRI-O to its 1.23 release

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -194,7 +194,7 @@ externals:
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"
     url: "https://github.com/kubernetes-sigs/cri-tools"
-    version: "1.22.0"
+    version: "1.23.0"
 
   gperf:
     description: "GNU gperf is a perfect hash function generator"

--- a/versions.yaml
+++ b/versions.yaml
@@ -179,7 +179,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    branch: "release-1.22"
+    branch: "release-1.23"
 
   containerd:
     description: |


### PR DESCRIPTION
As done for kubernetes, CRI-O should also be bumped to its 1.23 release
so those are in sync.

Fixes: #3481

And, while here, critools v1.23.0 has been released a few days ago.  As we're already
bumping kubernetes, and CRI-O, let's also update critools.