### PR TITLE
workflows: Fix typo in kata-deploy-push action

### DIFF
--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -9,7 +9,7 @@ on:
       - synchronize
       - labeled
       - unlabeled
-  push
+  push:
 
 jobs:
   build-asset:


### PR DESCRIPTION
A `:` was missed when d87ab14fa7c2244a631189083cceb6344ae9f306 was
introduced.

Fixes: #3485

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>