### PR TITLE
Fix and re-enable s390x GoVMM tests

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -500,7 +500,7 @@ func (fsdev FSDevice) QemuParams(config *Config) []string {
 	}
 	if fsdev.Transport.isVirtioCCW(config) {
 		if config.Knobs.IOMMUPlatform {
-			deviceParams = append(deviceParams, ",iommu_platform=on")
+			deviceParams = append(deviceParams, "iommu_platform=on")
 		}
 		deviceParams = append(deviceParams, fmt.Sprintf("devno=%s", fsdev.DevNo))
 	}

--- a/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
@@ -1,4 +1,3 @@
-//go:build !s390x
 // +build !s390x
 
 // Copyright contributors to the Virtual Machine Manager for Go project
@@ -89,6 +88,52 @@ func TestAppendVirtioBalloon(t *testing.T) {
 	balloonDevice.DisableModern = true
 	testAppend(balloonDevice, deviceString+OnDeflateOnOMM+OnDisableModern, t)
 
+}
+
+func TestAppendPCIBridgeDevice(t *testing.T) {
+
+	bridge := BridgeDevice{
+		Type:    PCIBridge,
+		ID:      "mybridge",
+		Bus:     "/pci-bus/pcie.0",
+		Addr:    "255",
+		Chassis: 5,
+		SHPC:    true,
+		ROMFile: romfile,
+	}
+
+	testAppend(bridge, devicePCIBridgeString, t)
+}
+
+func TestAppendPCIBridgeDeviceWithReservations(t *testing.T) {
+
+	bridge := BridgeDevice{
+		Type:          PCIBridge,
+		ID:            "mybridge",
+		Bus:           "/pci-bus/pcie.0",
+		Addr:          "255",
+		Chassis:       5,
+		SHPC:          false,
+		ROMFile:       romfile,
+		IOReserve:     "4k",
+		MemReserve:    "1m",
+		Pref64Reserve: "1m",
+	}
+
+	testAppend(bridge, devicePCIBridgeStringReserved, t)
+}
+
+func TestAppendPCIEBridgeDevice(t *testing.T) {
+
+	bridge := BridgeDevice{
+		Type:    PCIEBridge,
+		ID:      "mybridge",
+		Bus:     "/pci-bus/pcie.0",
+		Addr:    "255",
+		ROMFile: "efi-virtio.rom",
+	}
+
+	testAppend(bridge, devicePCIEBridgeString, t)
 }
 
 func TestAppendDevicePCIeRootPort(t *testing.T) {

--- a/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
@@ -11,8 +11,8 @@ import "testing"
 
 var (
 	deviceFSString                 = "-device virtio-9p-pci,disable-modern=true,fsdev=workload9p,mount_tag=rootfs,romfile=efi-virtio.rom -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none,multidevs=remap"
-	deviceNetworkString            = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,romfile=efi-virtio.rom"
-	deviceNetworkStringMq          = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,disable-modern=true,mq=on,vectors=6,romfile=efi-virtio.rom"
+	deviceNetworkString            = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff,disable-modern=true,romfile=efi-virtio.rom"
+	deviceNetworkStringMq          = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff,disable-modern=true,mq=on,vectors=6,romfile=efi-virtio.rom"
 	deviceSerialString             = "-device virtio-serial-pci,disable-modern=true,id=serial0,romfile=efi-virtio.rom,max_ports=2"
 	deviceVhostUserNetString       = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -netdev type=vhost-user,id=net1,chardev=char1,vhostforce -device virtio-net-pci,netdev=net1,mac=00:11:22:33:44:55,romfile=efi-virtio.rom"
 	deviceVSOCKString              = "-device vhost-vsock-pci,disable-modern=true,id=vhost-vsock-pci0,guest-cid=4,romfile=efi-virtio.rom"

--- a/src/runtime/pkg/govmm/qemu/qemu_s390x_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_s390x_test.go
@@ -19,7 +19,7 @@ var (
 	deviceVFIOString               = "-device vfio-ccw,host=02:10.0,devno=" + DevNo
 	deviceSCSIControllerStr        = "-device virtio-scsi-ccw,id=foo,devno=" + DevNo
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-ccw,id=foo,bus=pci.0,addr=00:04.0,iothread=iothread1,devno=" + DevNo
-	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,scsi=off,config-wce=off,devno=" + DevNo + ",share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
+	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,scsi=off,config-wce=off,devno=" + DevNo + ",share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly=on"
 	romfile                        = ""
 )
 

--- a/src/runtime/pkg/govmm/qemu/qemu_s390x_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_s390x_test.go
@@ -1,5 +1,3 @@
-// +build s390x
-
 // Copyright contributors to the Virtual Machine Manager for Go project
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -22,8 +20,6 @@ var (
 	deviceSCSIControllerStr        = "-device virtio-scsi-ccw,id=foo,devno=" + DevNo
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-ccw,id=foo,bus=pci.0,addr=00:04.0,iothread=iothread1,devno=" + DevNo
 	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,scsi=off,config-wce=off,devno=" + DevNo + ",share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
-	devicePCIBridgeString          = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff"
-	devicePCIEBridgeString         = "-device pcie-pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,addr=ff"
 	romfile                        = ""
 )
 

--- a/src/runtime/pkg/govmm/qemu/qemu_s390x_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_s390x_test.go
@@ -13,7 +13,7 @@ import "testing"
 // See https://wiki.qemu.org/Documentation/Platforms/S390X
 var (
 	deviceFSString                 = "-device virtio-9p-ccw,fsdev=workload9p,mount_tag=rootfs,devno=" + DevNo + " -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none,multidevs=remap"
-	deviceFSIOMMUString            = "-device virtio-9p-ccw,fsdev=workload9p,mount_tag=rootfs,iommu_platform=on,devno=" + DevNo + " -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none,multidevs=remap" //nolint
+	deviceFSIOMMUString            = "-device virtio-9p-ccw,fsdev=workload9p,mount_tag=rootfs,iommu_platform=on,devno=" + DevNo + " -fsdev local,id=workload9p,path=/var/lib/docker/devicemapper/mnt/e31ebda2,security_model=none,multidevs=remap"
 	deviceNetworkString            = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device driver=virtio-net-ccw,netdev=tap0,mac=01:02:de:ad:be:ef,devno=" + DevNo
 	deviceNetworkStringMq          = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-ccw,netdev=tap0,mac=01:02:de:ad:be:ef,mq=on,devno=" + DevNo
 	deviceSerialString             = "-device virtio-serial-ccw,id=serial0,devno=" + DevNo
@@ -23,7 +23,6 @@ var (
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-ccw,id=foo,bus=pci.0,addr=00:04.0,iothread=iothread1,devno=" + DevNo
 	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,scsi=off,config-wce=off,devno=" + DevNo + ",share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly"
 	devicePCIBridgeString          = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff"
-	devicePCIBridgeStringReserved  = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff,io-reserve=4k,mem-reserve=1m,pref64-reserve=1m"
 	devicePCIEBridgeString         = "-device pcie-pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,addr=ff"
 	romfile                        = ""
 )
@@ -72,8 +71,6 @@ func TestAppendDeviceFSCCW(t *testing.T) {
 }
 
 func TestAppendDeviceFSCCWIOMMU(t *testing.T) {
-	t.Skip("Skipping on due to: https://github.com/kata-containers/kata-containers/issues/3500")
-
 	defaultKnobs := Knobs{
 		NoUserConfig:  true,
 		IOMMUPlatform: true,

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -495,52 +495,6 @@ func TestAppendDeviceSCSIController(t *testing.T) {
 	testAppend(scsiCon, deviceSCSIControllerBusAddrStr, t)
 }
 
-func TestAppendPCIBridgeDevice(t *testing.T) {
-
-	bridge := BridgeDevice{
-		Type:    PCIBridge,
-		ID:      "mybridge",
-		Bus:     "/pci-bus/pcie.0",
-		Addr:    "255",
-		Chassis: 5,
-		SHPC:    true,
-		ROMFile: romfile,
-	}
-
-	testAppend(bridge, devicePCIBridgeString, t)
-}
-
-func TestAppendPCIBridgeDeviceWithReservations(t *testing.T) {
-
-	bridge := BridgeDevice{
-		Type:          PCIBridge,
-		ID:            "mybridge",
-		Bus:           "/pci-bus/pcie.0",
-		Addr:          "255",
-		Chassis:       5,
-		SHPC:          false,
-		ROMFile:       romfile,
-		IOReserve:     "4k",
-		MemReserve:    "1m",
-		Pref64Reserve: "1m",
-	}
-
-	testAppend(bridge, devicePCIBridgeStringReserved, t)
-}
-
-func TestAppendPCIEBridgeDevice(t *testing.T) {
-
-	bridge := BridgeDevice{
-		Type:    PCIEBridge,
-		ID:      "mybridge",
-		Bus:     "/pci-bus/pcie.0",
-		Addr:    "255",
-		ROMFile: "efi-virtio.rom",
-	}
-
-	testAppend(bridge, devicePCIEBridgeString, t)
-}
-
 func TestAppendEmptyDevice(t *testing.T) {
 	device := SerialDevice{}
 

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -17,11 +17,6 @@ import (
 const agentUUID = "4cb19522-1e18-439a-883a-f9b2a3a95f5e"
 const volumeUUID = "67d86208-b46c-4465-9018-e14187d4010"
 
-var (
-	deviceNetworkPCIString   = "-netdev tap,id=tap0,vhost=on,ifname=ceth0,downscript=no,script=no -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff,disable-modern=true,romfile=efi-virtio.rom"
-	deviceNetworkPCIStringMq = "-netdev tap,id=tap0,vhost=on,fds=3:4 -device driver=virtio-net-pci,netdev=tap0,mac=01:02:de:ad:be:ef,bus=/pci-bus/pcie.0,addr=ff,disable-modern=true,mq=on,vectors=6,romfile=efi-virtio.rom"
-)
-
 const DevNo = "fe.1.1234"
 
 func testAppend(structure interface{}, expected string, t *testing.T) {
@@ -177,10 +172,13 @@ func TestAppendDeviceNetwork(t *testing.T) {
 		VHost:         true,
 		MACAddress:    "01:02:de:ad:be:ef",
 		DisableModern: true,
-		ROMFile:       "efi-virtio.rom",
+		ROMFile:       romfile,
 	}
 
-	if netdev.Transport.isVirtioCCW(nil) {
+	if netdev.Transport.isVirtioPCI(nil) {
+		netdev.Bus = "/pci-bus/pcie.0"
+		netdev.Addr = "255"
+	} else if netdev.Transport.isVirtioCCW(nil) {
 		netdev.DevNo = DevNo
 	}
 
@@ -209,71 +207,17 @@ func TestAppendDeviceNetworkMq(t *testing.T) {
 		VHost:         true,
 		MACAddress:    "01:02:de:ad:be:ef",
 		DisableModern: true,
-		ROMFile:       "efi-virtio.rom",
+		ROMFile:       romfile,
 	}
-	if netdev.Transport.isVirtioCCW(nil) {
+
+	if netdev.Transport.isVirtioPCI(nil) {
+		netdev.Bus = "/pci-bus/pcie.0"
+		netdev.Addr = "255"
+	} else if netdev.Transport.isVirtioCCW(nil) {
 		netdev.DevNo = DevNo
 	}
 
 	testAppend(netdev, deviceNetworkStringMq, t)
-}
-
-func TestAppendDeviceNetworkPCI(t *testing.T) {
-
-	netdev := NetDevice{
-		Driver:        VirtioNet,
-		Type:          TAP,
-		ID:            "tap0",
-		IFName:        "ceth0",
-		Bus:           "/pci-bus/pcie.0",
-		Addr:          "255",
-		Script:        "no",
-		DownScript:    "no",
-		VHost:         true,
-		MACAddress:    "01:02:de:ad:be:ef",
-		DisableModern: true,
-		ROMFile:       romfile,
-	}
-
-	if !netdev.Transport.isVirtioPCI(nil) {
-		t.Skip("Test valid only for PCI devices")
-	}
-
-	testAppend(netdev, deviceNetworkPCIString, t)
-}
-
-func TestAppendDeviceNetworkPCIMq(t *testing.T) {
-	foo, _ := ioutil.TempFile(os.TempDir(), "govmm-qemu-test")
-	bar, _ := ioutil.TempFile(os.TempDir(), "govmm-qemu-test")
-
-	defer func() {
-		_ = foo.Close()
-		_ = bar.Close()
-		_ = os.Remove(foo.Name())
-		_ = os.Remove(bar.Name())
-	}()
-
-	netdev := NetDevice{
-		Driver:        VirtioNet,
-		Type:          TAP,
-		ID:            "tap0",
-		IFName:        "ceth0",
-		Bus:           "/pci-bus/pcie.0",
-		Addr:          "255",
-		Script:        "no",
-		DownScript:    "no",
-		FDs:           []*os.File{foo, bar},
-		VHost:         true,
-		MACAddress:    "01:02:de:ad:be:ef",
-		DisableModern: true,
-		ROMFile:       romfile,
-	}
-
-	if !netdev.Transport.isVirtioPCI(nil) {
-		t.Skip("Test valid only for PCI devices")
-	}
-
-	testAppend(netdev, deviceNetworkPCIStringMq, t)
 }
 
 var deviceLegacySerialString = "-serial chardev:tlserial0"

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -10,7 +10,6 @@ import (
 	"io/ioutil"
 	"os"
 	"reflect"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -332,10 +331,6 @@ func TestAppendDeviceSerialPort(t *testing.T) {
 }
 
 func TestAppendDeviceBlock(t *testing.T) {
-	if runtime.GOARCH == "s390x" {
-		t.Skip("Skipping on s390x due to: https://github.com/kata-containers/kata-containers/issues/3500")
-	}
-
 	blkdev := BlockDevice{
 		Driver:        VirtioBlock,
 		ID:            "hd0",
@@ -516,9 +511,6 @@ func TestAppendPCIBridgeDevice(t *testing.T) {
 }
 
 func TestAppendPCIBridgeDeviceWithReservations(t *testing.T) {
-	if runtime.GOARCH == "s390x" {
-		t.Skip("Skipping on s390x due to: https://github.com/kata-containers/kata-containers/issues/3500")
-	}
 
 	bridge := BridgeDevice{
 		Type:          PCIBridge,


### PR DESCRIPTION
govmm: Unite VirtioNet tests
govmm: readonly=on in s390x blkdev test
govmm: TestAppendPCIBridgeDevice et al. on !s390x
govmm: Remove unnecessary comma in iommu_platform
Revert "govmm: s390x: Skip broken tests"

Fixes: #3500