### PR TITLE
osbuilder: Remove libseccomp from Dockerfile

### DIFF
--- a/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
@@ -19,8 +19,6 @@ RUN apk update && apk add \
     gcc \
     git \
     libc-dev \
-    libseccomp \
-    libseccomp-dev \
     linux-headers \
     m4 \
     make \

--- a/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
@@ -24,8 +24,6 @@ RUN dnf -y update && dnf install -y \
     glibc-headers \
     glibc-static \
     glibc-utils \
-    libseccomp \
-    libseccomp-devel \
     libstdc++-devel \
     libstdc++-static \
     m4 \


### PR DESCRIPTION
Remove the libseccomp package from Dockerfile of `alpine` and `clearlinux`
because the libseccomp library is installed by the `ci/install_libseccomp.sh`
script when building the kata-agent.

Fixes: #3508

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>