### PR TITLE
docs: Remove kata-pkgsync reference

### DIFF
--- a/tools/packaging/Makefile
+++ b/tools/packaging/Makefile
@@ -31,7 +31,4 @@ snap: $(YQ)
 	fi
 	snapcraft -d
 
-cmd-kata-pkgsync:
-	@make -C $(MK_DIR)/cmd/kata-pkgsync
-
-.PHONY: test-static-build snap cmd-kata-pkgsync
+.PHONY: test-static-build snap

--- a/tools/packaging/README.md
+++ b/tools/packaging/README.md
@@ -36,10 +36,6 @@ See [the release documentation](release).
 
 See the [scripts documentation](scripts).
 
-## Sync packages
-
-See [the `kata-pkgsync` documentation](cmd/kata-pkgsync).
-
 ## Credits
 
 Kata Containers packaging uses [packagecloud](https://packagecloud.io) for


### PR DESCRIPTION
Now that kata-pkgsync has been removed, this PR removes the reference
in the documentation.

Fixes #3513

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>