### PR TITLE
tools: Remove missing references to pkgsync

### DIFF
--- a/tools/packaging/Makefile
+++ b/tools/packaging/Makefile
@@ -31,7 +31,4 @@ snap: $(YQ)
 	fi
 	snapcraft -d
 
-cmd-kata-pkgsync:
-	@make -C $(MK_DIR)/cmd/kata-pkgsync
-
-.PHONY: test-static-build snap cmd-kata-pkgsync
+.PHONY: test-static-build snap

--- a/tools/packaging/README.md
+++ b/tools/packaging/README.md
@@ -36,10 +36,6 @@ See [the release documentation](release).
 
 See the [scripts documentation](scripts).
 
-## Sync packages
-
-See [the `kata-pkgsync` documentation](cmd/kata-pkgsync).
-
 ## Credits
 
 Kata Containers packaging uses [packagecloud](https://packagecloud.io) for


### PR DESCRIPTION
pkgsync has been removed as part of #3494, but it seems some references
to it could still be found.

Let's remove them all now, and link it to the original issue.

Fixes: #3493
Related: #github.com/kata-containers/tests/issues#4388

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>