### PR TITLE
runtime: rectify passing empty options to -ldflags

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -553,10 +553,10 @@ endef
 GENERATED_FILES += pkg/katautils/config-settings.go
 
 $(RUNTIME_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) | show-summary
-	$(QUIET_BUILD)(cd $(RUNTIME_DIR) && go build -ldflags $(KATA_LDFLAGS) $(BUILDFLAGS) -o $@ .)
+	$(QUIET_BUILD)(cd $(RUNTIME_DIR) && go build -ldflags "$(KATA_LDFLAGS)" $(BUILDFLAGS) -o $@ .)
 
 $(SHIMV2_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
-	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build -ldflags $(KATA_LDFLAGS) $(BUILDFLAGS) -o $@ .)
+	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build -ldflags "$(KATA_LDFLAGS)" $(BUILDFLAGS) -o $@ .)
 
 $(MONITOR_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) .git-commit
 	$(QUIET_BUILD)(cd $(MONITOR_DIR)/ && CGO_ENABLED=0 go build \


### PR DESCRIPTION
When no options are passed to `-ldflags`, it considers
the next string(in this case, `$BUILDFLAGS`) as its value.
Fix passing empty values by passing `$KATA_LDFLAGS`
in quotes.

Fixes: #3521

Signed-off-by: Amulya Meka <amulmek1@in.ibm.com>