### PR TITLE
clh: Pass the tuntap fds to cloud-hypervisor

### DIFF
--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -202,6 +202,16 @@ func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Lin
 		flags := netlink.TUNTAP_VNET_HDR
 		if queues > 0 {
 			flags |= netlink.TUNTAP_MULTI_QUEUE_DEFAULTS
+		} else {
+			// We need to enforce `queues = 1` here in case
+			// multi-queue is *not* supported, the reason being
+			// `linkModify()`, a method called by `LinkAdd()`, only
+			// returning the file descriptor of the opened tuntap
+			// device when the queues are set to *non zero*.
+			//
+			// Please, for more information, refer to:
+			// https://github.com/kata-containers/kata-containers/blob/e6e5d2593ac319329269d7b58c30f99ba7b2bf5a/src/runtime/vendor/github.com/vishvananda/netlink/link_linux.go#L1164-L1316
+			queues = 1
 		}
 		newLink = &netlink.Tuntap{
 			LinkAttrs: netlink.LinkAttrs{Name: name},

--- a/src/runtime/virtcontainers/network_test.go
+++ b/src/runtime/virtcontainers/network_test.go
@@ -194,7 +194,13 @@ func TestCreateGetTunTapLink(t *testing.T) {
 	assert.NoError(err)
 
 	tapName := "testtap0"
-	tapLink, fds, err := createLink(netHandle, tapName, &netlink.Tuntap{}, 1)
+	tapLink, fds, err := createLink(netHandle, tapName, &netlink.Tuntap{}, 0)
+	assert.NoError(err)
+	assert.NotNil(tapLink)
+	assert.NotZero(len(fds))
+
+	tapName = "testtap1"
+	tapLink, fds, err = createLink(netHandle, tapName, &netlink.Tuntap{}, 1)
 	assert.NoError(err)
 	assert.NotNil(tapLink)
 	assert.NotZero(len(fds))


### PR DESCRIPTION
Instead of passing to cloud-hypervisor the name of the bridge and
letting it open the tuntap device, which is not an allowed operation for
`container_kvm_t` processes, let's just pass the file descriptors to the
VMM, in a similar manner of what's done with QEMU.

Fixes: #3533

And here's an example of the outcome of this short series:
```
[centos@crio runtime]$ kubectl get pods
No resources found in default namespace.

[centos@crio runtime]$ getenforce 
Enforcing

[centos@crio runtime]$ kubectl apply -f ~/pod.yaml 
pod/nginx created

[centos@crio runtime]$ kubectl get pods
NAME    READY   STATUS    RESTARTS   AGE
nginx   1/1     Running   0          8s

[centos@crio runtime]$ ps auxZ | grep cloud-hypervisor
system_u:system_r:container_kvm_t:s0:c185,c571 root 167962 3.2  0.6 2256596 99336 ? Sl 20:21   0:00 /usr/bin/cloud-hypervisor --api-socket /run/vc/vm/e03001e1d25806805c61c9facb5a1ec90e83c62c5f327ef08e8c9305d72fcdfa/clh-api.sock
```