### PR TITLE
Refine build/makefile framework for src/libs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@
 # List of available components
 COMPONENTS =
 
+COMPONENTS += libs
 COMPONENTS += agent
 COMPONENTS += runtime
 
@@ -18,11 +19,6 @@ TOOLS += trace-forwarder
 STANDARD_TARGETS = build check clean install test vendor
 
 default: all
-
-all: libs-crate-tests build
-
-libs-crate-tests:
-	make -C src/libs
 
 include utils.mk
 include ./tools/packaging/kata-deploy/local-build/Makefile
@@ -44,5 +40,4 @@ static-checks: build
 	binary-tarball \
 	default \
 	install-binary-tarball \
-	libs-crate-tests \
 	static-checks

--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -101,10 +101,7 @@ endef
 ##TARGET default: build code
 default: $(TARGET) show-header
 
-$(TARGET): $(GENERATED_CODE) libs-crate-tests $(TARGET_PATH)
-
-libs-crate-tests:
-	make -C $(CWD)/../libs
+$(TARGET): $(GENERATED_CODE) $(TARGET_PATH)
 
 $(TARGET_PATH): $(SOURCES) | show-summary
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE) $(EXTRA_RUSTFEATURES)
@@ -208,7 +205,6 @@ codecov-html: check_tarpaulin
 
 .PHONY: \
 	help \
-	libs-crate-tests \
 	optimize \
 	show-header \
 	show-summary \

--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -77,6 +77,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
+name = "kata-types"
+version = "0.1.0"
+dependencies = [
+ "oci",
+ "serde",
+ "thiserror",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -120,6 +129,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "oci"
+version = "0.1.0"
+dependencies = [
+ "libc",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +149,24 @@ name = "ppv-lite86"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "rand"
@@ -200,6 +237,20 @@ name = "serde"
 version = "1.0.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "serde_json"
@@ -254,6 +305,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "1.0.83"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23a1dfb999630e338648c83e91c59a4e9fb7620f520c3194b6b89e276f2f1959"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "take_mut"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,6 +336,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "854babe52e4df1653706b98fcfc05843010039b406875930a70e4d9644e5c417"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa32fd3f627f367fe16f893e2597ae3c05020f8bba2666a4e6ea73d377e5714b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -291,6 +373,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "wasi"

--- a/src/libs/Cargo.toml
+++ b/src/libs/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "logging",
+    "kata-types",
 ]
 resolver = "2"

--- a/src/libs/Makefile
+++ b/src/libs/Makefile
@@ -3,16 +3,40 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-# It is not necessary to have a build target as this crate is built
-# automatically by the consumers of it.
-#
-# However, it is essential that the crate be tested.
-default: test
+EXTRA_RUSTFEATURES :=
+
+EXTRA_TEST_FLAGS :=
+USERID=$(shell id -u)
+ifeq ($(USERID), 0)
+    override EXTRA_TEST_FLAGS = --ignored
+endif
+
+default: build
+
+build:
+	cargo build --all-features
+
+check: clippy format
+
+clippy:
+	@echo "INFO: cargo clippy..."
+	cargo clippy --all-targets --all-features --release \
+		-- \
+		-D warnings
+
+format:
+	@echo "INFO: cargo fmt..."
+	cargo fmt -- --check
+
+clean:
+	cargo clean
 
 # It is essential to run these tests using *both* build profiles.
 # See the `test_logger_levels()` test for further information.
 test:
-	@echo "INFO: testing log levels for development build"
-	@cargo test
-	@echo "INFO: testing log levels for release build"
-	@cargo test --release
+	@echo "INFO: testing libraries for development build"
+	cargo test --all $(EXTRA_RUSTFEATURES) -- --nocapture $(EXTRA_TEST_FLAGS)
+	@echo "INFO: testing libraries for release build"
+	cargo test --release --all $(EXTRA_RUSTFEATURES) -- --nocapture $(EXTRA_TEST_FLAGS)
+
+.PHONY: install vendor

--- a/src/libs/README.md
+++ b/src/libs/README.md
@@ -5,5 +5,6 @@ or published to [`crates.io`](https://crates.io/index.html).
 Currently it provides following library crates:
 
 | Library | Description |
-|-|-|-|
-| [logging](logging/) | Facilities to setup logging subsystem based slog. |
+|-|-|
+| [logging](logging/) | Facilities to setup logging subsystem based on slog. |
+| [types](kata-types/) | Collection of constants and data types shared by multiple Kata Containers components. |

--- a/src/libs/kata-types/Cargo.toml
+++ b/src/libs/kata-types/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "kata-types"
+version = "0.1.0"
+description = "Constants and data types shared by Kata Containers components"
+keywords = ["kata", "container", "runtime"]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
+repository = "https://github.com/kata-containers/kata-containers.git"
+homepage = "https://katacontainers.io/"
+readme = "README.md"
+license = "Apache-2.0"
+edition = "2018"
+
+[dependencies]
+serde = { version = "1.0.100", features = ["derive"] }
+thiserror = "1.0"
+
+oci = { path = "../../agent/oci" }
+
+[dev-dependencies]

--- a/src/libs/kata-types/README.md
+++ b/src/libs/kata-types/README.md
@@ -1,0 +1,18 @@
+# kata-types
+
+This crate is a collection of constants and data types shared by multiple
+[Kata Containers](https://github.com/kata-containers/kata-containers/) components.
+
+It defines constants and data types used by multiple Kata Containers components. Those constants
+and data types may be defined by Kata Containers or by other projects/specifications, such as:
+- [Containerd](https://github.com/containerd/containerd)
+- [Kubelet](https://github.com/kubernetes/kubelet)
+
+## Support
+
+**Operating Systems**:
+- Linux
+
+## License
+
+This code is licensed under [Apache-2.0](../../../LICENSE).

--- a/src/libs/kata-types/src/annotations/cri_containerd.rs
+++ b/src/libs/kata-types/src/annotations/cri_containerd.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 Alibaba Cloud
+// Copyright (c) 2019 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#![allow(missing_docs)]
+
+pub const CONTAINER_TYPE_LABEL_KEY: &str = "io.kubernetes.cri.container-type";
+pub const SANDBOX: &str = "sandbox";
+pub const CONTAINER: &str = "container";
+
+pub const SANDBOX_ID_LABEL_KEY: &str = "io.kubernetes.cri.sandbox-id";

--- a/src/libs/kata-types/src/annotations/crio.rs
+++ b/src/libs/kata-types/src/annotations/crio.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 Alibaba Cloud
+// Copyright (c) 2019 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#![allow(missing_docs)]
+
+pub const CONTAINER_TYPE_LABEL_KEY: &str = "io.kubernetes.cri.container-type";
+pub const SANDBOX: &str = "sandbox";
+pub const CONTAINER: &str = "container";
+
+pub const SANDBOX_ID_LABEL_KEY: &str = "io.kubernetes.cri-o.SandboxID";

--- a/src/libs/kata-types/src/annotations/dockershim.rs
+++ b/src/libs/kata-types/src/annotations/dockershim.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 Alibaba Cloud
+// Copyright (c) 2019 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#![allow(missing_docs)]
+
+pub const CONTAINER_TYPE_LABEL_KEY: &str = "io.kubernetes.docker.type";
+pub const SANDBOX: &str = "podsandbox";
+pub const CONTAINER: &str = "container";
+
+pub const SANDBOX_ID_LABEL_KEY: &str = "io.kubernetes.sandbox.id";

--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2019 Alibaba Cloud
+// Copyright (c) 2019 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+/// CRI-containerd specific annotations.
+pub mod cri_containerd;
+
+/// CRI-O specific annotations.
+pub mod crio;
+
+/// Dockershim specific annotations.
+pub mod dockershim;

--- a/src/libs/kata-types/src/container.rs
+++ b/src/libs/kata-types/src/container.rs
@@ -1,0 +1,203 @@
+// Copyright (c) 2019-2021 Alibaba Cloud
+// Copyright (c) 2019-2021 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::fmt::{Display, Formatter};
+use std::str::FromStr;
+
+const CONTAINER: &str = "container";
+const SANDBOX: &str = "sandbox";
+const POD_CONTAINER: &str = "pod_container";
+const POD_SANDBOX: &str = "pod_sandbox";
+const POD_SANDBOX2: &str = "podsandbox";
+
+const STATE_READY: &str = "ready";
+const STATE_RUNNING: &str = "running";
+const STATE_STOPPED: &str = "stopped";
+const STATE_PAUSED: &str = "paused";
+
+/// Error codes for container related operations.
+#[derive(thiserror::Error, Debug)]
+pub enum Error {
+    /// Invalid container type
+    #[error("Invalid container type {0}")]
+    InvalidContainerType(String),
+    /// Invalid container state
+    #[error("Invalid sandbox state {0}")]
+    InvalidState(String),
+    /// Invalid container state transition
+    #[error("Can not transit from {0} to {1}")]
+    InvalidStateTransition(State, State),
+}
+
+/// Types of pod containers: container or sandbox.
+#[derive(PartialEq, Debug, Clone)]
+pub enum ContainerType {
+    /// A pod container.
+    PodContainer,
+    /// A pod sandbox.
+    PodSandbox,
+}
+
+impl ContainerType {
+    /// Check whether it's a pod container.
+    pub fn is_pod_container(&self) -> bool {
+        matches!(self, ContainerType::PodContainer)
+    }
+
+    /// Check whether it's a pod container.
+    pub fn is_pod_sandbox(&self) -> bool {
+        matches!(self, ContainerType::PodSandbox)
+    }
+}
+
+impl Display for ContainerType {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            ContainerType::PodContainer => write!(f, "{}", POD_CONTAINER),
+            ContainerType::PodSandbox => write!(f, "{}", POD_SANDBOX),
+        }
+    }
+}
+
+impl FromStr for ContainerType {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            POD_CONTAINER | CONTAINER => Ok(ContainerType::PodContainer),
+            POD_SANDBOX | POD_SANDBOX2 | SANDBOX => Ok(ContainerType::PodSandbox),
+            _ => Err(Error::InvalidContainerType(value.to_owned())),
+        }
+    }
+}
+
+/// Process states.
+#[derive(Clone, Copy, PartialEq, Debug)]
+pub enum State {
+    /// The container is ready to run.
+    Ready,
+    /// The container executed the user-specified program but has not exited
+    Running,
+    /// The container has exited
+    Stopped,
+    /// The container has been paused.
+    Paused,
+}
+
+impl Display for State {
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            State::Ready => write!(f, "{}", STATE_READY),
+            State::Running => write!(f, "{}", STATE_RUNNING),
+            State::Stopped => write!(f, "{}", STATE_STOPPED),
+            State::Paused => write!(f, "{}", STATE_PAUSED),
+        }
+    }
+}
+
+impl FromStr for State {
+    type Err = Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            STATE_READY => Ok(State::Ready),
+            STATE_RUNNING => Ok(State::Running),
+            STATE_STOPPED => Ok(State::Stopped),
+            STATE_PAUSED => Ok(State::Paused),
+            _ => Err(Error::InvalidState(value.to_owned())),
+        }
+    }
+}
+
+impl State {
+    /// Check whether it's a valid state transition from self to the `new_state`.
+    pub fn check_transition(self, new_state: State) -> Result<(), Error> {
+        match self {
+            State::Ready if new_state == State::Running || new_state == State::Stopped => Ok(()),
+            State::Running if new_state == State::Stopped => Ok(()),
+            State::Stopped if new_state == State::Running => Ok(()),
+            State::Paused if new_state == State::Paused => Ok(()),
+            _ => Err(Error::InvalidStateTransition(self, new_state)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_container_type() {
+        assert!(ContainerType::PodContainer.is_pod_container());
+        assert!(!ContainerType::PodContainer.is_pod_sandbox());
+
+        assert!(ContainerType::PodSandbox.is_pod_sandbox());
+        assert!(!ContainerType::PodSandbox.is_pod_container());
+    }
+
+    #[test]
+    fn test_container_type_display() {
+        assert_eq!(format!("{}", ContainerType::PodContainer), POD_CONTAINER);
+        assert_eq!(format!("{}", ContainerType::PodSandbox), POD_SANDBOX);
+    }
+
+    #[test]
+    fn test_container_type_from_str() {
+        assert_eq!(
+            ContainerType::from_str("pod_container").unwrap(),
+            ContainerType::PodContainer
+        );
+        assert_eq!(
+            ContainerType::from_str("container").unwrap(),
+            ContainerType::PodContainer
+        );
+        assert_eq!(
+            ContainerType::from_str("pod_sandbox").unwrap(),
+            ContainerType::PodSandbox
+        );
+        assert_eq!(
+            ContainerType::from_str("podsandbox").unwrap(),
+            ContainerType::PodSandbox
+        );
+        assert_eq!(
+            ContainerType::from_str("sandbox").unwrap(),
+            ContainerType::PodSandbox
+        );
+        ContainerType::from_str("test").unwrap_err();
+    }
+
+    #[test]
+    fn test_valid() {
+        let mut state = State::from_str("invalid_state");
+        assert!(state.is_err());
+
+        state = State::from_str("ready");
+        assert!(state.is_ok());
+
+        state = State::from_str("running");
+        assert!(state.is_ok());
+
+        state = State::from_str("stopped");
+        assert!(state.is_ok());
+    }
+
+    #[test]
+    fn test_valid_transition() {
+        use State::*;
+
+        assert!(Ready.check_transition(Ready).is_err());
+        assert!(Ready.check_transition(Running).is_ok());
+        assert!(Ready.check_transition(Stopped).is_ok());
+
+        assert!(Running.check_transition(Ready).is_err());
+        assert!(Running.check_transition(Running).is_err());
+        assert!(Running.check_transition(Stopped).is_ok());
+
+        assert!(Stopped.check_transition(Ready).is_err());
+        assert!(Stopped.check_transition(Running).is_ok());
+        assert!(Stopped.check_transition(Stopped).is_err());
+    }
+}

--- a/src/libs/kata-types/src/k8s.rs
+++ b/src/libs/kata-types/src/k8s.rs
@@ -1,0 +1,102 @@
+// Copyright (c) 2019-2021 Alibaba Cloud
+// Copyright (c) 2019-2021 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::path::Path;
+
+use crate::annotations;
+use crate::container::ContainerType;
+use std::str::FromStr;
+
+// K8S_EMPTY_DIR is the k8s specific path for `empty-dir` volumes
+const K8S_EMPTY_DIR: &str = "kubernetes.io~empty-dir";
+
+/// Check whether the path is a K8S empty directory.
+///
+/// For a K8S EmptyDir, Kubernetes mounts
+/// "/var/lib/kubelet/pods/<id>/volumes/kubernetes.io~empty-dir/<volumeMount name>"
+/// to "/<mount-point>".
+pub fn is_empty_dir<P: AsRef<Path>>(path: P) -> bool {
+    let path = path.as_ref();
+
+    if let Some(parent) = path.parent() {
+        if let Some(pname) = parent.file_name() {
+            if pname == K8S_EMPTY_DIR && parent.parent().is_some() {
+                return true;
+            }
+        }
+    }
+
+    false
+}
+
+/// Get K8S container type from OCI annotations.
+pub fn container_type(spec: &oci::Spec) -> ContainerType {
+    // PodSandbox:  "sandbox" (Containerd & CRI-O), "podsandbox" (dockershim)
+    // PodContainer: "container" (Containerd & CRI-O & dockershim)
+    for k in [
+        annotations::crio::CONTAINER_TYPE_LABEL_KEY,
+        annotations::cri_containerd::CONTAINER_TYPE_LABEL_KEY,
+        annotations::dockershim::CONTAINER_TYPE_LABEL_KEY,
+    ]
+    .iter()
+    {
+        if let Some(v) = spec.annotations.get(k.to_owned()) {
+            if let Ok(t) = ContainerType::from_str(v) {
+                return t;
+            }
+        }
+    }
+
+    ContainerType::PodSandbox
+}
+
+/// Determine the k8s sandbox ID from OCI annotations.
+///
+/// This function is expected to be called only when the container type is "PodContainer".
+pub fn sandbox_id(spec: &oci::Spec) -> Result<Option<String>, String> {
+    if container_type(spec) != ContainerType::PodSandbox {
+        return Err("Not a sandbox container".to_string());
+    }
+    for k in [
+        annotations::crio::SANDBOX_ID_LABEL_KEY,
+        annotations::cri_containerd::SANDBOX_ID_LABEL_KEY,
+        annotations::dockershim::SANDBOX_ID_LABEL_KEY,
+    ]
+    .iter()
+    {
+        if let Some(id) = spec.annotations.get(k.to_owned()) {
+            return Ok(Some(id.to_string()));
+        }
+    }
+
+    Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_empty_dir() {
+        let empty_dir = "/volumes/kubernetes.io~empty-dir/shm";
+        assert!(is_empty_dir(empty_dir));
+
+        let empty_dir = "/volumes/kubernetes.io~empty-dir//shm";
+        assert!(is_empty_dir(empty_dir));
+
+        let empty_dir = "/volumes/kubernetes.io~empty-dir-test/shm";
+        assert!(!is_empty_dir(empty_dir));
+
+        let empty_dir = "/volumes/kubernetes.io~empty-dir";
+        assert!(!is_empty_dir(empty_dir));
+
+        let empty_dir = "kubernetes.io~empty-dir";
+        assert!(!is_empty_dir(empty_dir));
+
+        let empty_dir = "/kubernetes.io~empty-dir/shm";
+        assert!(is_empty_dir(empty_dir));
+    }
+}

--- a/src/libs/kata-types/src/lib.rs
+++ b/src/libs/kata-types/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright (c) 2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Constants and Data Types shared by Kata Containers components.
+
+#[deny(missing_docs)]
+
+/// Constants and data types annotations.
+pub mod annotations;
+
+/// Constants and data types related to container.
+pub mod container;
+
+/// Constants and data types related to Kubernetes/kubelet.
+pub mod k8s;
+
+/// Constants and data types related to mount point.
+pub mod mount;

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2019-2021 Alibaba Cloud
+// Copyright (c) 2019-2021 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::path::PathBuf;
+
+/// Prefix to mark a volume as Kata special.
+pub const KATA_VOLUME_TYPE_PREFIX: &str = "kata:";
+
+/// The Mount should be ignored by the host and handled by the guest.
+pub const KATA_GUEST_MOUNT_PREFIX: &str = "kata:guest-mount:";
+
+/// KATA_EPHEMERAL_DEV_TYPE creates a tmpfs backed volume for sharing files between containers.
+pub const KATA_EPHEMERAL_VOLUME_TYPE: &str = "kata:ephemeral";
+
+/// KATA_HOST_DIR_TYPE use for host empty dir
+pub const KATA_HOST_DIR_VOLUME_TYPE: &str = "kata:hostdir";
+
+/// Information about a mount.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct Mount {
+    /// A device name, but can also be a file or directory name for bind mounts or a dummy.
+    /// Path values for bind mounts are either absolute or relative to the bundle. A mount is a
+    /// bind mount if it has either bind or rbind in the options.
+    pub source: String,
+    /// Destination of mount point: path inside container. This value MUST be an absolute path.
+    pub destination: PathBuf,
+    /// The type of filesystem for the mountpoint.
+    pub fs_type: String,
+    /// Mount options for the mountpoint.
+    pub options: Vec<String>,
+    /// Optional device id for the block device when:
+    /// - the source is a block device or a mountpoint for a block device
+    /// - block device direct assignment is enabled
+    pub device_id: Option<String>,
+    /// Intermediate path to mount the source on host side and then passthrough to vm by shared fs.
+    pub host_shared_fs_path: Option<PathBuf>,
+    /// Whether to mount the mountpoint in readonly mode
+    pub read_only: bool,
+}
+
+impl Mount {
+    /// Get size of mount options.
+    pub fn option_size(&self) -> usize {
+        self.options.iter().map(|v| v.len() + 1).sum()
+    }
+}
+
+/// Check whether a mount type is a marker for Kata specific volume.
+pub fn is_kata_special_volume(ty: &str) -> bool {
+    ty.len() > KATA_VOLUME_TYPE_PREFIX.len() && ty.starts_with(KATA_VOLUME_TYPE_PREFIX)
+}
+
+/// Check whether a mount type is a marker for Kata guest mount volume.
+pub fn is_kata_guest_mount_volume(ty: &str) -> bool {
+    ty.len() > KATA_GUEST_MOUNT_PREFIX.len() && ty.starts_with(KATA_GUEST_MOUNT_PREFIX)
+}
+
+/// Check whether a mount type is a marker for Kata ephemeral volume.
+pub fn is_kata_ephemeral_volume(ty: &str) -> bool {
+    ty == KATA_EPHEMERAL_VOLUME_TYPE
+}
+
+/// Check whether a mount type is a marker for Kata hostdir volume.
+pub fn is_kata_host_dir_volume(ty: &str) -> bool {
+    ty == KATA_HOST_DIR_VOLUME_TYPE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_kata_special_volume() {
+        assert!(is_kata_special_volume("kata:guest-mount:nfs"));
+        assert!(!is_kata_special_volume("kata:"));
+    }
+
+    #[test]
+    fn test_is_kata_guest_mount_volume() {
+        assert!(is_kata_guest_mount_volume("kata:guest-mount:nfs"));
+        assert!(!is_kata_guest_mount_volume("kata:guest-mount"));
+        assert!(!is_kata_guest_mount_volume("kata:guest-moun"));
+        assert!(!is_kata_guest_mount_volume("Kata:guest-mount:nfs"));
+    }
+}

--- a/src/libs/logging/src/file_rotate.rs
+++ b/src/libs/logging/src/file_rotate.rs
@@ -264,13 +264,13 @@ mod tests {
         rotator.rotate_count(1);
         assert_eq!(rotator.rotate_size, 4);
         assert_eq!(rotator.rotate_keep, 1);
-        assert_eq!(rotator.truncate, false);
+        assert!(!rotator.truncate);
 
-        rotator.write("test".as_bytes()).unwrap();
+        rotator.write_all("test".as_bytes()).unwrap();
         rotator.flush().unwrap();
-        rotator.write("test1".as_bytes()).unwrap();
+        rotator.write_all("test1".as_bytes()).unwrap();
         rotator.flush().unwrap();
-        rotator.write("t2".as_bytes()).unwrap();
+        rotator.write_all("t2".as_bytes()).unwrap();
         rotator.flush().unwrap();
 
         let content = fs::read_to_string(path).unwrap();
@@ -298,16 +298,16 @@ mod tests {
         rotator.rotate_count(1);
         rotator.fail_rename = true;
 
-        rotator.write("test".as_bytes()).unwrap();
+        rotator.write_all("test".as_bytes()).unwrap();
         rotator.flush().unwrap();
         let size1 = path.metadata().unwrap().size();
 
-        rotator.write("test1".as_bytes()).unwrap();
+        rotator.write_all("test1".as_bytes()).unwrap();
         rotator.flush().unwrap();
         let size2 = path.metadata().unwrap().size();
         assert!(size2 > size1);
 
-        rotator.write("test2".as_bytes()).unwrap();
+        rotator.write_all("test2".as_bytes()).unwrap();
         rotator.flush().unwrap();
         let size3 = path.metadata().unwrap().size();
         assert!(size3 > size2);

--- a/src/libs/logging/src/lib.rs
+++ b/src/libs/logging/src/lib.rs
@@ -534,13 +534,13 @@ mod tests {
             let msg = format!("test[{}]", i);
 
             // Create a writer for the logger drain to use
-            let writer =
-                NamedTempFile::new().expect(&format!("{:}: failed to create tempfile", msg));
+            let writer = NamedTempFile::new()
+                .unwrap_or_else(|_| panic!("{:}: failed to create tempfile", msg));
 
             // Used to check file contents before the temp file is unlinked
             let mut writer_ref = writer
                 .reopen()
-                .expect(&format!("{:?}: failed to clone tempfile", msg));
+                .unwrap_or_else(|e| panic!("{:?}: failed to clone tempfile, {}", msg, e));
 
             let (logger, logger_guard) = create_logger(name, source, d.slog_level, writer);
 
@@ -554,52 +554,52 @@ mod tests {
             let mut contents = String::new();
             writer_ref
                 .read_to_string(&mut contents)
-                .expect(&format!("{:?}: failed to read tempfile contents", msg));
+                .unwrap_or_else(|e| panic!("{:?}: failed to read tempfile contents, {}", msg, e));
 
             // Convert file to JSON
             let fields: Value = serde_json::from_str(&contents)
-                .expect(&format!("{:?}: failed to convert logfile to json", msg));
+                .unwrap_or_else(|e| panic!("{:?}: failed to convert logfile to json, {}", msg, e));
 
             // Check the expected JSON fields
 
             let field_ts = fields
                 .get("ts")
-                .expect(&format!("{:?}: failed to find timestamp field", msg));
+                .unwrap_or_else(|| panic!("{:?}: failed to find timestamp field", msg));
             assert_ne!(field_ts, "", "{}", msg);
 
             let field_version = fields
                 .get("version")
-                .expect(&format!("{:?}: failed to find version field", msg));
+                .unwrap_or_else(|| panic!("{:?}: failed to find version field", msg));
             assert_eq!(field_version, env!("CARGO_PKG_VERSION"), "{}", msg);
 
             let field_pid = fields
                 .get("pid")
-                .expect(&format!("{:?}: failed to find pid field", msg));
+                .unwrap_or_else(|| panic!("{:?}: failed to find pid field", msg));
             assert_ne!(field_pid, "", "{}", msg);
 
             let field_level = fields
                 .get("level")
-                .expect(&format!("{:?}: failed to find level field", msg));
+                .unwrap_or_else(|| panic!("{:?}: failed to find level field", msg));
             assert_eq!(field_level, d.slog_level_tag, "{}", msg);
 
             let field_msg = fields
                 .get("msg")
-                .expect(&format!("{:?}: failed to find msg field", msg));
+                .unwrap_or_else(|| panic!("{:?}: failed to find msg field", msg));
             assert_eq!(field_msg, &json!(d.msg), "{}", msg);
 
             let field_name = fields
                 .get("name")
-                .expect(&format!("{:?}: failed to find name field", msg));
+                .unwrap_or_else(|| panic!("{:?}: failed to find name field", msg));
             assert_eq!(field_name, name, "{}", msg);
 
             let field_source = fields
                 .get("source")
-                .expect(&format!("{:?}: failed to find source field", msg));
+                .unwrap_or_else(|| panic!("{:?}: failed to find source field", msg));
             assert_eq!(field_source, source, "{}", msg);
 
             let field_subsystem = fields
                 .get("subsystem")
-                .expect(&format!("{:?}: failed to find subsystem field", msg));
+                .unwrap_or_else(|| panic!("{:?}: failed to find subsystem field", msg));
 
             // No explicit subsystem, so should be the default
             assert_eq!(field_subsystem, &json!(DEFAULT_SUBSYSTEM), "{}", msg);

--- a/src/libs/logging/src/log_writer.rs
+++ b/src/libs/logging/src/log_writer.rs
@@ -54,9 +54,9 @@ mod tests {
         let (logger, guard) = create_logger("test", "hi", slog::Level::Info, rotator);
         let mut writer = LogWriter::new(logger);
 
-        writer.write("test1\nblabla".as_bytes()).unwrap();
+        writer.write_all("test1\nblabla".as_bytes()).unwrap();
         writer.flush().unwrap();
-        writer.write("test2".as_bytes()).unwrap();
+        writer.write_all("test2".as_bytes()).unwrap();
         writer.flush().unwrap();
         drop(guard);
 

--- a/src/tools/agent-ctl/Makefile
+++ b/src/tools/agent-ctl/Makefile
@@ -7,11 +7,8 @@ include ../../../utils.mk
 
 default: build
 
-build: libs-crate-tests
+build:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
-
-libs-crate-tests:
-	make -C $(CWD)/../../libs
 
 clean:
 	cargo clean
@@ -31,6 +28,5 @@ check:
 	check \
 	clean \
 	install \
-	libs-crate-tests \
 	test \
 	vendor

--- a/src/tools/trace-forwarder/Makefile
+++ b/src/tools/trace-forwarder/Makefile
@@ -7,11 +7,8 @@ include ../../../utils.mk
 
 default: build
 
-build: libs-crate-tests
+build:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
-
-libs-crate-tests:
-	make -C $(CWD)/../../libs
 
 clean:
 	cargo clean
@@ -31,6 +28,5 @@ check:
 	check \
 	clean \
 	install \
-	libs-crate-tests \
 	test \
 	vendor


### PR DESCRIPTION
Current src/libs are built as a sub-target of agent, tools/agent-ctl and tools/trace-forwarder. That's not well formed. Let's make src/libs a dedicated main target to simplify the dependency chain.
Also include the kata-type crate, which has been reviewed in #3306, so we could open following-on PRs based on it.