### PR TITLE
runtime: fix handling container spec's memory limit

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1989,7 +1989,7 @@ func (s *Sandbox) calculateSandboxMemory() (int64, bool, int64) {
 
 		if m := c.Resources.Memory; m != nil {
 			currentLimit := int64(0)
-			if m.Limit != nil {
+			if m.Limit != nil && *m.Limit > 0 {
 				currentLimit = *m.Limit
 				memorySandbox += currentLimit
 			}

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -178,6 +178,20 @@ func TestCalculateSandboxMem(t *testing.T) {
 	}
 }
 
+func TestCalculateSandboxMemHandlesNegativeLimits(t *testing.T) {
+	sandbox := &Sandbox{}
+	sandbox.config = &SandboxConfig{}
+	container := newTestContainerConfigNoop("cont-00001")
+	limit := int64(-1)
+	container.Resources.Memory = &specs.LinuxMemory{Limit: &limit}
+
+	sandbox.config.Containers = []ContainerConfig{container}
+	mem, needSwap, swap := sandbox.calculateSandboxMemory()
+	assert.Equal(t, mem, int64(0))
+	assert.Equal(t, needSwap, false)
+	assert.Equal(t, swap, int64(0))
+}
+
 func TestCreateSandboxEmptyID(t *testing.T) {
 	hConfig := newHypervisorConfig(nil, nil)
 	_, err := testCreateSandbox(t, "", MockHypervisor, hConfig, NetworkConfig{}, nil, nil)


### PR DESCRIPTION
The OCI container spec specifies a limit of -1 signifies
unlimited memory. Update the sandbox memory calculator
to reflect this part of the spec.

Fixes: #3512

Signed-off-by: Braden Rayhorn <bradenrayhorn@fastmail.com>