### PR TITLE
Runtime-rs: load, parse, access kata configuration and optionally modify them by annotations

### DIFF
--- a/.github/workflows/move-issues-to-in-progress.yaml
+++ b/.github/workflows/move-issues-to-in-progress.yaml
@@ -55,7 +55,7 @@ jobs:
             exit 1
           }
 
-          project_name="Issue backlog"
+          project_name="runtime-rs"
           project_type="org"
           project_column="In progress"
 

--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +80,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,8 +104,11 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 name = "kata-types"
 version = "0.1.0"
 dependencies = [
+ "glob",
  "lazy_static",
+ "num_cpus",
  "oci",
+ "regex",
  "serde",
  "slog",
  "slog-scope",
@@ -114,6 +141,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "memchr"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
 name = "num-integer"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -150,24 +193,24 @@ checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed0cfbc8191465bed66e1718596ee0b0b35d5ee1f41c5df2189d0fe8bde535ba"
+checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.34"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.10"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
 dependencies = [
  "proc-macro2",
 ]
@@ -222,6 +265,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
 name = "remove_dir_all"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -238,18 +298,18 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "serde"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -258,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.73"
+version = "1.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
 dependencies = [
  "itoa",
  "ryu",
@@ -310,9 +370,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.83"
+version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23a1dfb999630e338648c83e91c59a4e9fb7620f520c3194b6b89e276f2f1959"
+checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -44,15 +44,14 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
  "winapi",
 ]
 
 [[package]]
 name = "crossbeam-channel"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
+checksum = "e54ea8bc3fb1ee042f5aace6e3c6e025d3874866da222930f70ce62aceba0bfa"
 dependencies = [
  "cfg-if",
  "crossbeam-utils",
@@ -60,23 +59,21 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
+checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if",
  "lazy_static",
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.3"
+name = "fastrand"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
 dependencies = [
- "cfg-if",
- "libc",
- "wasi",
+ "instant",
 ]
 
 [[package]]
@@ -95,6 +92,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +116,7 @@ dependencies = [
  "oci",
  "regex",
  "serde",
+ "serde_json",
  "slog",
  "slog-scope",
  "thiserror",
@@ -124,9 +131,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.112"
+version = "0.2.113"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b03d17f364a3a042d5e5d46b053bbbf82c92c9430c592dd4c064dc6ee997125"
+checksum = "eef78b64d87775463c549fbd80e19249ef436ea3bf1de2a1eb7e717ec7fab1e9"
 
 [[package]]
 name = "logging"
@@ -192,12 +199,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -208,51 +209,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47aa80447ce4daf1717500037052af176af5d38cc3e571d9ec1c7353fc10c87d"
+checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7573632e6454cf6b99d7aac4ccca54be06da05aca2ef7423d22d27d4d4bcd8"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
 ]
 
 [[package]]
@@ -298,18 +259,18 @@ checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
 name = "serde"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97565067517b60e2d1ea8b268e59ce036de907ac523ad83a0475da04e818989a"
+checksum = "2cf9235533494ea2ddcdb794665461814781c53f19d87b76e571a1c35acbad2b"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.133"
+version = "1.0.135"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed201699328568d8d08208fdd080e3ff594e6c422e438b6705905da01005d537"
+checksum = "8dcde03d87d4c973c04be249e7d8f0b35db1c848c487bd43032808e59dd8328d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -318,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.74"
+version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2bb9cd061c5865d345bb02ca49fcef1391741b672b54a0bf7b679badec3142"
+checksum = "d23c1ba4cf0efd44be32017709280b32d1cea5c3f1275c3b6d9e8bc54f758085"
 dependencies = [
  "itoa",
  "ryu",
@@ -347,9 +308,9 @@ dependencies = [
 
 [[package]]
 name = "slog-json"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52e9b96fb6b5e80e371423b4aca6656eb537661ce8f82c2697e619f8ca85d043"
+checksum = "0f7f7a952ce80fca9da17bf0a53895d11f8aa1ba063668ca53fc72e7869329e9"
 dependencies = [
  "chrono",
  "serde",
@@ -370,9 +331,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.85"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a684ac3dcd8913827e18cd09a68384ee66c1de24157e3c556c9ab16d85695fb7"
+checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -387,13 +348,13 @@ checksum = "f764005d11ee5f36500a149ace24e00e3da98b0158b3e2d53a7495660d3f4d60"
 
 [[package]]
 name = "tempfile"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
 dependencies = [
  "cfg-if",
+ "fastrand",
  "libc",
- "rand",
  "redox_syscall",
  "remove_dir_all",
  "winapi",
@@ -429,16 +390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "toml"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,12 +403,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "wasi"
-version = "0.10.2+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
 name = "winapi"

--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -80,9 +80,13 @@ checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 name = "kata-types"
 version = "0.1.0"
 dependencies = [
+ "lazy_static",
  "oci",
  "serde",
+ "slog",
+ "slog-scope",
  "thiserror",
+ "toml",
 ]
 
 [[package]]
@@ -372,6 +376,15 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "toml"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a31142970826733df8241ef35dc040ef98c679ab14d7c3e54d827099b3acecaa"
+dependencies = [
+ "serde",
 ]
 
 [[package]]

--- a/src/libs/kata-types/Cargo.toml
+++ b/src/libs/kata-types/Cargo.toml
@@ -11,7 +11,10 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+glob = "0.3.0"
 lazy_static = "1.4.0"
+num_cpus = "1.13.1"
+regex = "1.5.4"
 serde = { version = "1.0.100", features = ["derive"] }
 slog = "2.5.2"
 slog-scope = "4.4.0"

--- a/src/libs/kata-types/Cargo.toml
+++ b/src/libs/kata-types/Cargo.toml
@@ -18,6 +18,7 @@ regex = "1.5.4"
 serde = { version = "1.0.100", features = ["derive"] }
 slog = "2.5.2"
 slog-scope = "4.4.0"
+serde_json = "1.0.73"
 thiserror = "1.0"
 toml = "0.5.8"
 

--- a/src/libs/kata-types/Cargo.toml
+++ b/src/libs/kata-types/Cargo.toml
@@ -11,9 +11,17 @@ license = "Apache-2.0"
 edition = "2018"
 
 [dependencies]
+lazy_static = "1.4.0"
 serde = { version = "1.0.100", features = ["derive"] }
+slog = "2.5.2"
+slog-scope = "4.4.0"
 thiserror = "1.0"
+toml = "0.5.8"
 
 oci = { path = "../../agent/oci" }
 
 [dev-dependencies]
+
+[features]
+default = []
+enable-vendor = []

--- a/src/libs/kata-types/src/annotations/dockershim.rs
+++ b/src/libs/kata-types/src/annotations/dockershim.rs
@@ -6,8 +6,18 @@
 
 #![allow(missing_docs)]
 
+//! Copied from k8s.io/pkg/kubelet/dockershim/docker_service.go, used to identify whether a docker
+//! container is a sandbox or a regular container, will be removed after defining those as public
+//! fields in dockershim.
+
+///  ContainerTypeLabelKey is the container type (podsandbox or container) of key.
 pub const CONTAINER_TYPE_LABEL_KEY: &str = "io.kubernetes.docker.type";
+
+/// ContainerTypeLabelSandbox represents a sandbox sandbox container.
 pub const SANDBOX: &str = "podsandbox";
+
+/// ContainerTypeLabelContainer represents a container running within a sandbox.
 pub const CONTAINER: &str = "container";
 
+/// SandboxIDLabelKey is the sandbox ID annotation.
 pub const SANDBOX_ID_LABEL_KEY: &str = "io.kubernetes.sandbox.id";

--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -1,8 +1,19 @@
-// Copyright (c) 2019 Alibaba Cloud
+// Copyright (c) 2019-2021 Alibaba Cloud
 // Copyright (c) 2019 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::{self, BufReader, Result};
+use std::u32;
+
+use serde::Deserialize;
+
+use crate::config::hypervisor::get_hypervisor_plugin;
+use crate::config::TomlConfig;
+use crate::sl;
 
 /// CRI-containerd specific annotations.
 pub mod cri_containerd;
@@ -12,3 +23,754 @@ pub mod crio;
 
 /// Dockershim specific annotations.
 pub mod dockershim;
+
+/// Third-party annotations.
+pub mod thirdparty;
+
+// Common section
+/// Prefix for Kata specific annotations
+pub const KATA_ANNO_PREFIX: &str = "io.katacontainers.";
+/// Prefix for Kata configuration annotations
+pub const KATA_ANNO_CONF_PREFIX: &str = "io.katacontainers.config.";
+/// Prefix for Kata container annotations
+pub const KATA_ANNO_CONTAINER_PREFIX: &str = "io.katacontainers.container.";
+/// The annotation key to fetch runtime configuration file.
+pub const SANDBOX_CONFIG_PATH_KEY: &str = "io.katacontainers.config_path";
+
+// OCI section
+/// The annotation key to fetch the OCI configuration file path.
+pub const BUNDLE_PATH_KEY: &str = "io.katacontainers.pkg.oci.bundle_path";
+/// The annotation key to fetch container type.
+pub const CONTAINER_TYPE_KEY: &str = "io.katacontainers.pkg.oci.container_type";
+
+// Container resource related annotations
+/// Prefix for Kata container resource related annotations.
+pub const KATA_ANNO_CONTAINER_RESOURCE_PREFIX: &str = "io.katacontainers.container.resource";
+/// A container annotation to specify the Resources.Memory.Swappiness.
+pub const KATA_ANNO_CONTAINER_RESOURCE_SWAPPINESS: &str =
+    "io.katacontainers.container.resource.swappiness";
+/// A container annotation to specify the Resources.Memory.Swap.
+pub const KATA_ANNO_CONTAINER_RESOURCE_SWAP_IN_BYTES: &str =
+    "io.katacontainers.container.resource.swap_in_bytes";
+
+// Agent related annotations
+/// Prefix for Agent configurations.
+pub const KATA_ANNO_CONF_AGENT_PREFIX: &str = "io.katacontainers.config.agent.";
+/// KernelModules is the annotation key for passing the list of kernel modules and their parameters
+/// that will be loaded in the guest kernel.
+///
+/// Semicolon separated list of kernel modules and their parameters. These modules will be loaded
+/// in the guest kernel using modprobe(8).
+/// The following example can be used to load two kernel modules with parameters
+///
+///   annotations:
+///     io.katacontainers.config.agent.kernel_modules: "e1000e InterruptThrottleRate=3000,3000,3000 EEE=1; i915 enable_ppgtt=0"
+///
+/// The first word is considered as the module name and the rest as its parameters.
+pub const KATA_ANNO_CONF_KERNEL_MODULES: &str = "io.katacontainers.config.agent.kernel_modules";
+/// A sandbox annotation to enable tracing for the agent.
+pub const KATA_ANNO_CONF_AGENT_TRACE: &str = "io.katacontainers.config.agent.enable_tracing";
+/// An annotation to specify the size of the pipes created for containers.
+pub const KATA_ANNO_CONF_AGENT_CONTAINER_PIPE_SIZE: &str =
+    "io.katacontainers.config.agent.container_pipe_size";
+/// An annotation key to specify the size of the pipes created for containers.
+pub const CONTAINER_PIPE_SIZE_KERNEL_PARAM: &str = "agent.container_pipe_size";
+
+// Hypervisor related annotations
+/// Prefix for Hypervisor configurations.
+pub const KATA_ANNO_CONF_HYPERVISOR_PREFIX: &str = "io.katacontainers.config.hypervisor.";
+/// A sandbox annotation for passing a per container path pointing at the hypervisor that will run
+/// the container VM.
+pub const KATA_ANNO_CONF_HYPERVISOR_PATH: &str = "io.katacontainers.config.hypervisor.path";
+/// A sandbox annotation for passing a container hypervisor binary SHA-512 hash value.
+pub const KATA_ANNO_CONF_HYPERVISOR_HASH: &str = "io.katacontainers.config.hypervisor.path_hash";
+/// A sandbox annotation for passing a per container path pointing at the hypervisor control binary
+/// that will run the container VM.
+pub const KATA_ANNO_CONF_HYPERVISOR_CTLPATH: &str = "io.katacontainers.config.hypervisor.ctlpath";
+/// A sandbox annotation for passing a container hypervisor control binary SHA-512 hash value.
+pub const KATA_ANNO_CONF_HYPERVISOR_CTLHASH: &str =
+    "io.katacontainers.config.hypervisor.hypervisorctl_hash";
+/// A sandbox annotation for passing a per container path pointing at the jailer that will constrain
+/// the container VM.
+pub const KATA_ANNO_CONF_HYPERVISOR_JAILER_PATH: &str =
+    "io.katacontainers.config.hypervisor.jailer_path";
+/// A sandbox annotation for passing a jailer binary SHA-512 hash value.
+pub const KATA_ANNO_CONF_HYPERVISOR_JAILER_HASH: &str =
+    "io.katacontainers.config.hypervisor.jailer_hash";
+/// A sandbox annotation to enable IO to be processed in a separate thread.
+/// Supported currently for virtio-scsi driver.
+pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS: &str =
+    "io.katacontainers.config.hypervisor.enable_iothreads";
+/// The hash type used for assets verification
+pub const KATA_ANNO_CONF_HYPERVISOR_ASSET_HASH_TYPE: &str =
+    "io.katacontainers.config.hypervisor.asset_hash_type";
+/// SHA512 is the SHA-512 (64) hash algorithm
+pub const SHA512: &str = "sha512";
+
+// Hypervisor Block Device related annotations
+/// Specify the driver to be used for block device either VirtioSCSI or VirtioBlock
+pub const KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER: &str =
+    "io.katacontainers.config.hypervisor.block_device_driver";
+/// A sandbox annotation that disallows a block device from being used.
+pub const KATA_ANNO_CONF_HYPERVISOR_DISABLE_BLOCK_DEVICE_USE: &str =
+    "io.katacontainers.config.hypervisor.disable_block_device_use";
+/// A sandbox annotation that specifies cache-related options will be set to block devices or not.
+pub const KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_SET: &str =
+    "io.katacontainers.config.hypervisor.block_device_cache_set";
+/// A sandbox annotation that specifies cache-related options for block devices.
+/// Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
+pub const KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_DIRECT: &str =
+    "io.katacontainers.config.hypervisor.block_device_cache_direct";
+/// A sandbox annotation that specifies cache-related options for block devices.
+/// Denotes whether flush requests for the device are ignored.
+pub const KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_NOFLUSH: &str =
+    "io.katacontainers.config.hypervisor.block_device_cache_noflush";
+/// A sandbox annotation to specify use of nvdimm device for guest rootfs image.
+pub const KATA_ANNO_CONF_HYPERVISOR_DISABLE_IMAGE_NVDIMM: &str =
+    "io.katacontainers.config.hypervisor.disable_image_nvdimm";
+/// A sandbox annotation that specifies the memory space used for nvdimm device by the hypervisor.
+pub const KATA_ANNO_CONF_HYPERVISOR_MEMORY_OFFSET: &str =
+    "io.katacontainers.config.hypervisor.memory_offset";
+/// A sandbox annotation to specify if vhost-user-blk/scsi is abailable on the host
+pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_VHOSTUSER_STORE: &str =
+    "io.katacontainers.config.hypervisor.enable_vhost_user_store";
+/// A sandbox annotation to specify the directory path where vhost-user devices related folders,
+/// sockets and device nodes should be.
+pub const KATA_ANNO_CONF_HYPERVISOR_VHOSTUSER_STORE_PATH: &str =
+    "io.katacontainers.config.hypervisor.vhost_user_store_path";
+
+// Hypervisor Guest Boot related annotations
+/// A sandbox annotation for passing a per container path pointing at the kernel needed to boot
+/// the container VM.
+pub const KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH: &str =
+    "io.katacontainers.config.hypervisor.kernel";
+/// A sandbox annotation for passing a container kernel image SHA-512 hash value.
+pub const KATA_ANNO_CONF_HYPERVISOR_KERNEL_HASH: &str =
+    "io.katacontainers.config.hypervisor.kernel_hash";
+/// A sandbox annotation for passing a per container path pointing at the guest image that will run
+/// in the container VM.
+/// A sandbox annotation for passing additional guest kernel parameters.
+pub const KATA_ANNO_CONF_HYPERVISOR_KERNEL_PARAMS: &str =
+    "io.katacontainers.config.hypervisor.kernel_params";
+/// A sandbox annotation for passing a container guest image path.
+pub const KATA_ANNO_CONF_HYPERVISOR_IMAGE_PATH: &str = "io.katacontainers.config.hypervisor.image";
+/// A sandbox annotation for passing a container guest image SHA-512 hash value.
+pub const KATA_ANNO_CONF_HYPERVISOR_IMAGE_HASH: &str =
+    "io.katacontainers.config.hypervisor.image_hash";
+/// A sandbox annotation for passing a per container path pointing at the initrd that will run
+/// in the container VM.
+pub const KATA_ANNO_CONF_HYPERVISOR_INITRD_PATH: &str =
+    "io.katacontainers.config.hypervisor.initrd";
+/// A sandbox annotation for passing a container guest initrd SHA-512 hash value.
+pub const KATA_ANNO_CONF_HYPERVISOR_INITRD_HASH: &str =
+    "io.katacontainers.config.hypervisor.initrd_hash";
+/// A sandbox annotation for passing a per container path pointing at the guest firmware that will
+/// run the container VM.
+pub const KATA_ANNO_CONF_HYPERVISOR_FIRMWARE_PATH: &str =
+    "io.katacontainers.config.hypervisor.firmware";
+/// A sandbox annotation for passing a container guest firmware SHA-512 hash value.
+pub const KATA_ANNO_CONF_HYPERVISOR_FIRMWARE_HASH: &str =
+    "io.katacontainers.config.hypervisor.firmware_hash";
+
+// Hypervisor CPU related annotations
+/// A sandbox annotation to specify cpu specific features.
+pub const KATA_ANNO_CONF_HYPERVISOR_CPU_FEATURES: &str =
+    "io.katacontainers.config.hypervisor.cpu_features";
+/// A sandbox annotation for passing the default vcpus assigned for a VM by the hypervisor.
+pub const KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS: &str =
+    "io.katacontainers.config.hypervisor.default_vcpus";
+/// A sandbox annotation that specifies the maximum number of vCPUs allocated for the VM by the hypervisor.
+pub const KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MAX_VCPUS: &str =
+    "io.katacontainers.config.hypervisor.default_max_vcpus";
+
+// Hypervisor Device related annotations
+/// A sandbox annotation used to indicate if devices need to be hotplugged on the root bus instead
+/// of a bridge.
+pub const KATA_ANNO_CONF_HYPERVISOR_HOTPLUG_VFIO_ON_ROOT_BUS: &str =
+    "io.katacontainers.config.hypervisor.hotplug_vfio_on_root_bus";
+/// PCIeRootPort is used to indicate the number of PCIe Root Port devices
+pub const KATA_ANNO_CONF_HYPERVISOR_PCIE_ROOT_PORT: &str =
+    "io.katacontainers.config.hypervisor.pcie_root_port";
+/// A sandbox annotation to specify if the VM should have a vIOMMU device.
+pub const KATA_ANNO_CONF_HYPERVISOR_IOMMU: &str =
+    "io.katacontainers.config.hypervisor.enable_iommu";
+/// Enable Hypervisor Devices IOMMU_PLATFORM
+pub const KATA_ANNO_CONF_HYPERVISOR_IOMMU_PLATFORM: &str =
+    "io.katacontainers.config.hypervisor.enable_iommu_platform";
+
+//	Hypervisor Machine related annotations
+/// A sandbox annotation to specify the type of machine being emulated by the hypervisor.
+pub const KATA_ANNO_CONF_HYPERVISOR_MACHINE_TYPE: &str =
+    "io.katacontainers.config.hypervisor.machine_type";
+/// A sandbox annotation to specify machine specific accelerators for the hypervisor.
+pub const KATA_ANNO_CONF_HYPERVISOR_MACHINE_ACCELERATORS: &str =
+    "io.katacontainers.config.hypervisor.machine_accelerators";
+/// EntropySource is a sandbox annotation to specify the path to a host source of
+/// entropy (/dev/random, /dev/urandom or real hardware RNG device)
+pub const KATA_ANNO_CONF_HYPERVISOR_ENTROPY_SOURCE: &str =
+    "io.katacontainers.config.hypervisor.entropy_source";
+
+// Hypervisor Memory related annotations
+/// A sandbox annotation for the memory assigned for a VM by the hypervisor.
+pub const KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY: &str =
+    "io.katacontainers.config.hypervisor.default_memory";
+/// A sandbox annotation to specify the memory slots assigned to the VM by the hypervisor.
+pub const KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS: &str =
+    "io.katacontainers.config.hypervisor.memory_slots";
+/// A sandbox annotation that specifies the memory space used for nvdimm device by the hypervisor.
+pub const KATA_ANNO_CONF_HYPERVISOR_MEMORY_PREALLOC: &str =
+    "io.katacontainers.config.hypervisor.enable_mem_prealloc";
+/// A sandbox annotation to specify if the memory should be pre-allocated from huge pages.
+pub const KATA_ANNO_CONF_HYPERVISOR_HUGE_PAGES: &str =
+    "io.katacontainers.config.hypervisor.enable_hugepages";
+/// A sandbox annotation to soecify file based memory backend root directory.
+pub const KATA_ANNO_CONF_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR: &str =
+    "io.katacontainers.config.hypervisor.file_mem_backend";
+/// A sandbox annotation that is used to enable/disable virtio-mem.
+pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_MEM: &str =
+    "io.katacontainers.config.hypervisor.enable_virtio_mem";
+/// A sandbox annotation to enable swap of vm memory.
+pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_SWAP: &str =
+    "io.katacontainers.config.hypervisor.enable_swap";
+/// A sandbox annotation to enable swap in the guest.
+pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP: &str =
+    "io.katacontainers.config.hypervisor.enable_guest_swap";
+
+// Hypervisor Network related annotations
+/// A sandbox annotation to specify if vhost-net is not available on the host.
+pub const KATA_ANNO_CONF_HYPERVISOR_DISABLE_VHOST_NET: &str =
+    "io.katacontainers.config.hypervisor.disable_vhost_net";
+/// A sandbox annotation that specifies max rate on network I/O inbound bandwidth.
+pub const KATA_ANNO_CONF_HYPERVISOR_RX_RATE_LIMITER_MAX_RATE: &str =
+    "io.katacontainers.config.hypervisor.rx_rate_limiter_max_rate";
+/// A sandbox annotation that specifies max rate on network I/O outbound bandwidth.
+pub const KATA_ANNO_CONF_HYPERVISOR_TX_RATE_LIMITER_MAX_RATE: &str =
+    "io.katacontainers.config.hypervisor.tx_rate_limiter_max_rate";
+
+// Hypervisor Security related annotations
+/// A sandbox annotation to specify the path within the VM that will be used for 'drop-in' hooks.
+pub const KATA_ANNO_CONF_HYPERVISOR_GUEST_HOOK_PATH: &str =
+    "io.katacontainers.config.hypervisor.guest_hook_path";
+/// A sandbox annotation to enable rootless hypervisor (only supported in QEMU currently).
+pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_ROOTLESS_HYPERVISOR: &str =
+    "io.katacontainers.config.hypervisor.rootless";
+
+// Hypervisor Shared File System related annotations
+/// A sandbox annotation to specify the shared file system type, either virtio-9p or virtio-fs.
+pub const KATA_ANNO_CONF_HYPERVISOR_SHARED_FS: &str =
+    "io.katacontainers.config.hypervisor.shared_fs";
+/// A sandbox annotations to specify virtio-fs vhost-user daemon path.
+pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_DAEMON: &str =
+    "io.katacontainers.config.hypervisor.virtio_fs_daemon";
+/// A sandbox annotation to specify the cache mode for fs version cache or "none".
+pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_CACHE: &str =
+    "io.katacontainers.config.hypervisor.virtio_fs_cache";
+/// A sandbox annotation to specify the DAX cache size in MiB.
+pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_CACHE_SIZE: &str =
+    "io.katacontainers.config.hypervisor.virtio_fs_cache_size";
+/// A sandbox annotation to pass options to virtiofsd daemon.
+pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS: &str =
+    "io.katacontainers.config.hypervisor.virtio_fs_extra_args";
+/// A sandbox annotation to specify as the msize for 9p shares.
+pub const KATA_ANNO_CONF_HYPERVISOR_MSIZE_9P: &str = "io.katacontainers.config.hypervisor.msize_9p";
+
+// Runtime related annotations
+/// Prefix for Runtime configurations.
+pub const KATA_ANNO_CONF_RUNTIME_PREFIX: &str = "io.katacontainers.config.runtime.";
+/// A sandbox annotation that determines if seccomp should be applied inside guest.
+pub const KATA_ANNO_CONF_DISABLE_GUEST_SECCOMP: &str =
+    "io.katacontainers.config.runtime.disable_guest_seccomp";
+/// A sandbox annotation that determines if pprof enabled.
+pub const KATA_ANNO_CONF_ENABLE_PPROF: &str = "io.katacontainers.config.runtime.enable_pprof";
+/// A sandbox annotation that determines if experimental features enabled.
+pub const KATA_ANNO_CONF_EXPERIMENTAL: &str = "io.katacontainers.config.runtime.experimental";
+/// A sandbox annotaion that determines how the VM should be connected to the the container network
+/// interface.
+pub const KATA_ANNO_CONF_INTER_NETWORK_MODEL: &str =
+    "io.katacontainers.config.runtime.internetworking_model";
+/// SandboxCgroupOnly is a sandbox annotation that determines if kata processes are managed only in sandbox cgroup.
+pub const KATA_ANNO_CONF_SANDBOX_CGROUP_ONLY: &str =
+    "io.katacontainers.config.runtime.sandbox_cgroup_only";
+/// A sandbox annotation that determines if create a netns for hypervisor process.
+pub const KATA_ANNO_CONF_DISABLE_NEW_NETNS: &str =
+    "io.katacontainers.config.runtime.disable_new_netns";
+/// A sandbox annotation to specify how attached VFIO devices should be treated.
+pub const KATA_ANNO_CONF_VFIO_MODE: &str = "io.katacontainers.config.runtime.vfio_mode";
+
+/// A helper structure to query configuration information by check annotations.
+#[derive(Debug, Default, Deserialize)]
+pub struct Annotation {
+    annotations: HashMap<String, String>,
+}
+
+impl From<HashMap<String, String>> for Annotation {
+    fn from(annotations: HashMap<String, String>) -> Self {
+        Annotation { annotations }
+    }
+}
+
+impl Annotation {
+    /// Create a new instance of [`Annotation`].
+    pub fn new(annotations: HashMap<String, String>) -> Annotation {
+        Annotation { annotations }
+    }
+
+    /// Deserialize an object from a json string.
+    pub fn deserialize<T>(path: &str) -> Result<T>
+    where
+        for<'a> T: Deserialize<'a>,
+    {
+        let f = BufReader::new(File::open(path)?);
+        Ok(serde_json::from_reader(f)?)
+    }
+
+    /// Get an immutable reference to the annotation hashmap.
+    pub fn get_annotation(&self) -> &HashMap<String, String> {
+        &self.annotations
+    }
+
+    /// Get a mutable reference to the annotation hashmap.
+    pub fn get_annotation_mut(&mut self) -> &mut HashMap<String, String> {
+        &mut self.annotations
+    }
+
+    /// Get the value of annotation with `key` as string.
+    pub fn get(&self, key: &str) -> Option<String> {
+        let v = self.annotations.get(key)?;
+        let value = v.trim();
+
+        if !value.is_empty() {
+            Some(String::from(value))
+        } else {
+            None
+        }
+    }
+
+    /// Get the value of annotation with `key` as bool.
+    pub fn get_bool(&self, key: &str) -> Option<bool> {
+        if let Some(value) = self.get(key) {
+            let value = value.trim();
+            if value.parse::<bool>().is_err() {
+                warn!(sl!(), "failed to parse bool value from {}", value);
+            } else {
+                return Some(value.parse::<bool>().unwrap());
+            }
+        }
+
+        None
+    }
+
+    /// Get the value of annotation with `key` as u32.
+    pub fn get_u32(&self, key: &str) -> Option<u32> {
+        let s = self.get(key)?;
+        match s.parse::<u32>() {
+            Ok(nums) => {
+                if nums > 0 {
+                    Some(nums)
+                } else {
+                    None
+                }
+            }
+
+            Err(e) => {
+                warn!(
+                    sl!(),
+                    "failed to parse u32 value from {}, error: {:?}", s, e
+                );
+                None
+            }
+        }
+    }
+
+    /// Get the value of annotation with `key` as i32.
+    pub fn get_i32(&self, key: &str) -> Option<i32> {
+        let s = self.get(key)?;
+        s.parse::<i32>()
+            .map_or(None, |x| if x < 0 { None } else { Some(x) })
+    }
+
+    /// Get the value of annotation with `key` as u64.
+    pub fn get_u64(&self, key: &str) -> Option<u64> {
+        let s = self.get(key)?;
+        match s.parse::<u64>() {
+            Ok(nums) => {
+                if nums > 0 {
+                    Some(nums)
+                } else {
+                    None
+                }
+            }
+
+            Err(e) => {
+                warn!(
+                    sl!(),
+                    "failed to parse u64 value from {}, error: {:?}", s, e
+                );
+                None
+            }
+        }
+    }
+}
+
+// Miscellaneous annotations.
+impl Annotation {
+    /// Get the annotation of sandbox configuration file path.
+    pub fn get_sandbox_config_path(&self) -> Option<String> {
+        self.get(SANDBOX_CONFIG_PATH_KEY)
+    }
+
+    /// Get the annotation of bundle path.
+    pub fn get_bundle_path(&self) -> Option<String> {
+        self.get(BUNDLE_PATH_KEY)
+    }
+
+    /// Get the annotation of container type.
+    pub fn get_container_type(&self) -> Option<String> {
+        self.get(CONTAINER_TYPE_KEY)
+    }
+
+    /// Get the annotation to specify the Resources.Memory.Swappiness.
+    pub fn get_container_resource_swappiness(&self) -> Option<u32> {
+        let v = self.get_u32(KATA_ANNO_CONTAINER_RESOURCE_SWAPPINESS)?;
+        if v > 100 {
+            None
+        } else {
+            Some(v)
+        }
+    }
+
+    /// Get the annotation to specify the Resources.Memory.Swap.
+    pub fn get_container_resource_swap_in_bytes(&self) -> Option<String> {
+        self.get(KATA_ANNO_CONTAINER_RESOURCE_SWAP_IN_BYTES)
+    }
+}
+
+impl Annotation {
+    /// update config info by annotation
+    pub fn update_config_by_annotation(
+        &self,
+        config: &mut TomlConfig,
+        hypervisor_name: &str,
+        agent_name: &str,
+    ) -> Result<()> {
+        if config.hypervisor.get_mut(hypervisor_name).is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("hypervisor {} not found", hypervisor_name),
+            ));
+        }
+
+        if config.agent.get_mut(agent_name).is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("agent {} not found", agent_name),
+            ));
+        }
+        let mut hv = config.hypervisor.get_mut(hypervisor_name).unwrap();
+        let mut ag = config.agent.get_mut(agent_name).unwrap();
+        for (key, value) in &self.annotations {
+            if hv.security_info.is_annotation_enabled(key) {
+                match key.as_str() {
+                    // update hypervisor config
+                    //	Hypervisor related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_PATH => {
+                        hv.validate_hypervisor_path(value)?;
+                        hv.path = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_CTLPATH => {
+                        hv.validate_hypervisor_ctlpath(value)?;
+                        hv.ctlpath = value.to_string();
+                    }
+
+                    KATA_ANNO_CONF_HYPERVISOR_JAILER_PATH => {
+                        hv.validate_jailer_path(value)?;
+                        hv.jailer_path = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS => {
+                        hv.enable_iothreads = self.get_bool(key).unwrap_or_default();
+                    }
+                    //	Hypervisor Block Device related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER => {
+                        hv.blockdev_info.block_device_driver = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_DISABLE_BLOCK_DEVICE_USE => {
+                        hv.blockdev_info.disable_block_device_use =
+                            self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_SET => {
+                        hv.blockdev_info.block_device_cache_set =
+                            self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_DIRECT => {
+                        hv.blockdev_info.block_device_cache_direct =
+                            self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_NOFLUSH => {
+                        hv.blockdev_info.block_device_cache_noflush =
+                            self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_DISABLE_IMAGE_NVDIMM => {
+                        hv.blockdev_info.disable_image_nvdimm =
+                            self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_MEMORY_OFFSET => {
+                        hv.blockdev_info.memory_offset = self.get_u64(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_VHOSTUSER_STORE => {
+                        hv.blockdev_info.enable_vhost_user_store =
+                            self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_VHOSTUSER_STORE_PATH => {
+                        hv.blockdev_info.validate_vhost_user_store_path(value)?;
+                        hv.blockdev_info.vhost_user_store_path = value.to_string();
+                    }
+                    // Hypervisor Guest Boot related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH => {
+                        hv.boot_info.validate_boot_path(value)?;
+                        hv.boot_info.kernel = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_KERNEL_PARAMS => {
+                        hv.boot_info.kernel_params = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_IMAGE_PATH => {
+                        hv.boot_info.validate_boot_path(value)?;
+                        hv.boot_info.image = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_INITRD_PATH => {
+                        hv.boot_info.validate_boot_path(value)?;
+                        hv.boot_info.initrd = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_FIRMWARE_PATH => {
+                        hv.boot_info.validate_boot_path(value)?;
+                        hv.boot_info.firmware = value.to_string();
+                    }
+                    //	Hypervisor CPU related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_CPU_FEATURES => {
+                        hv.cpu_info.cpu_features = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS => {
+                        let num_cpus = self.get_i32(key).unwrap_or_default();
+                        if num_cpus
+                            > get_hypervisor_plugin(hypervisor_name)
+                                .unwrap()
+                                .get_max_cpus() as i32
+                        {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "Vcpus specified in annotation {} is more than maximum limitation {}",
+                                    num_cpus,
+                                    get_hypervisor_plugin(hypervisor_name)
+                                        .unwrap()
+                                        .get_max_cpus()
+                                ),
+                            ));
+                        } else {
+                            hv.cpu_info.default_vcpus = num_cpus;
+                        }
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MAX_VCPUS => {
+                        hv.cpu_info.default_maxvcpus = self.get_u32(key).unwrap_or_default();
+                    }
+                    //	Hypervisor Device related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_HOTPLUG_VFIO_ON_ROOT_BUS => {
+                        hv.device_info.hotplug_vfio_on_root_bus =
+                            self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_PCIE_ROOT_PORT => {
+                        hv.device_info.pcie_root_port = self.get_u32(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_IOMMU => {
+                        hv.device_info.enable_iommu = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_IOMMU_PLATFORM => {
+                        hv.device_info.enable_iommu_platform =
+                            self.get_bool(key).unwrap_or_default();
+                    }
+                    //	Hypervisor Machine related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_MACHINE_TYPE => {
+                        hv.machine_info.machine_type = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_MACHINE_ACCELERATORS => {
+                        hv.machine_info.machine_accelerators = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_ENTROPY_SOURCE => {
+                        hv.machine_info.validate_entropy_source(value)?;
+                        hv.machine_info.entropy_source = value.to_string();
+                    }
+                    //	Hypervisor Memory related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY => {
+                        let mem = self.get_u32(key).unwrap_or_default();
+                        if mem
+                            < get_hypervisor_plugin(hypervisor_name)
+                                .unwrap()
+                                .get_min_memory()
+                        {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!(
+                                    "Memory specified in annotation {} is less than minmum required {}",
+                                    mem,
+                                    get_hypervisor_plugin(hypervisor_name)
+                                        .unwrap()
+                                        .get_min_memory()
+                                ),
+                            ));
+                        } else {
+                            hv.memory_info.default_memory = mem;
+                        }
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS => match self.get_u32(key) {
+                        Some(v) => {
+                            hv.memory_info.memory_slots = v;
+                        }
+                        None => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!("{}in annotation is less than zero", key),
+                            ));
+                        }
+                    },
+
+                    KATA_ANNO_CONF_HYPERVISOR_MEMORY_PREALLOC => {
+                        hv.memory_info.enable_mem_prealloc = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_HUGE_PAGES => {
+                        hv.memory_info.enable_hugepages = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR => {
+                        hv.memory_info.validate_memory_backend_path(value)?;
+                        hv.memory_info.file_mem_backend = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_MEM => {
+                        hv.memory_info.enable_virtio_mem = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_SWAP => {
+                        hv.memory_info.enable_swap = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP => {
+                        hv.memory_info.enable_guest_swap = self.get_bool(key).unwrap_or_default();
+                    }
+                    //	Hypervisor Network related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_DISABLE_VHOST_NET => {
+                        hv.network_info.disable_vhost_net = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_RX_RATE_LIMITER_MAX_RATE => match self.get_u64(key) {
+                        Some(v) => {
+                            hv.network_info.rx_rate_limiter_max_rate = v;
+                        }
+                        None => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!("{} in annotation is less than zero", key),
+                            ));
+                        }
+                    },
+                    KATA_ANNO_CONF_HYPERVISOR_TX_RATE_LIMITER_MAX_RATE => match self.get_u64(key) {
+                        Some(v) => {
+                            hv.network_info.tx_rate_limiter_max_rate = v;
+                        }
+                        None => {
+                            return Err(io::Error::new(
+                                io::ErrorKind::InvalidData,
+                                format!("{} in annotation is less than zero", key),
+                            ));
+                        }
+                    },
+                    //	Hypervisor Security related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_GUEST_HOOK_PATH => {
+                        hv.security_info.validate_path(value)?;
+                        hv.security_info.guest_hook_path = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_ROOTLESS_HYPERVISOR => {
+                        hv.security_info.rootless = self.get_bool(key).unwrap_or_default();
+                    }
+                    //	Hypervisor Shared File System related annotations
+                    KATA_ANNO_CONF_HYPERVISOR_SHARED_FS => {
+                        hv.shared_fs.shared_fs = self.get(key);
+                    }
+
+                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_DAEMON => {
+                        hv.shared_fs.validate_virtiofs_daemon_path(value)?;
+                        hv.shared_fs.virtio_fs_daemon = value.to_string();
+                    }
+
+                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_CACHE => {
+                        hv.shared_fs.virtio_fs_cache = value.to_string();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_CACHE_SIZE => {
+                        hv.shared_fs.virtio_fs_cache_size = self.get_u32(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS => {
+                        let args: Vec<String> =
+                            value.to_string().split(',').map(str::to_string).collect();
+                        for arg in args {
+                            hv.shared_fs.virtio_fs_extra_args.push(arg.to_string());
+                        }
+                    }
+                    KATA_ANNO_CONF_HYPERVISOR_MSIZE_9P => {
+                        hv.shared_fs.msize_9p = self.get_u32(key).unwrap_or_default();
+                    }
+
+                    _ => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidInput,
+                            format!("Invalid Annotation Type {}", key),
+                        ));
+                    }
+                }
+            } else {
+                match key.as_str() {
+                    //update agent config
+                    KATA_ANNO_CONF_KERNEL_MODULES => {
+                        let kernel_mod: Vec<String> =
+                            value.to_string().split(';').map(str::to_string).collect();
+                        for modules in kernel_mod {
+                            ag.kernel_modules.push(modules.to_string());
+                        }
+                    }
+                    KATA_ANNO_CONF_AGENT_TRACE => {
+                        ag.enable_tracing = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_AGENT_CONTAINER_PIPE_SIZE => {
+                        ag.container_pipe_size = self.get_u32(key).unwrap_or_default();
+                    }
+                    //update runtume config
+                    KATA_ANNO_CONF_DISABLE_GUEST_SECCOMP => {
+                        config.runtime.disable_guest_seccomp =
+                            self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_ENABLE_PPROF => {
+                        config.runtime.enable_pprof = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_EXPERIMENTAL => {
+                        let args: Vec<String> =
+                            value.to_string().split(',').map(str::to_string).collect();
+                        for arg in args {
+                            config.runtime.experimental.push(arg.to_string());
+                        }
+                    }
+                    KATA_ANNO_CONF_INTER_NETWORK_MODEL => {
+                        config.runtime.internetworking_model = value.to_string();
+                    }
+                    KATA_ANNO_CONF_SANDBOX_CGROUP_ONLY => {
+                        config.runtime.disable_new_netns = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_DISABLE_NEW_NETNS => {
+                        config.runtime.disable_new_netns = self.get_bool(key).unwrap_or_default();
+                    }
+                    KATA_ANNO_CONF_VFIO_MODE => {
+                        config.runtime.vfio_mode = value.to_string();
+                    }
+                    _ => {
+                        return Err(io::Error::new(
+                            io::ErrorKind::InvalidData,
+                            format!("Annotation {} not enabled", key),
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -30,11 +30,11 @@ pub mod thirdparty;
 /// Prefix for Kata specific annotations
 pub const KATA_ANNO_PREFIX: &str = "io.katacontainers.";
 /// Prefix for Kata configuration annotations
-pub const KATA_ANNO_CONF_PREFIX: &str = "io.katacontainers.config.";
+pub const KATA_ANNO_CFG_PREFIX: &str = "io.katacontainers.config.";
 /// Prefix for Kata container annotations
 pub const KATA_ANNO_CONTAINER_PREFIX: &str = "io.katacontainers.container.";
 /// The annotation key to fetch runtime configuration file.
-pub const SANDBOX_CONFIG_PATH_KEY: &str = "io.katacontainers.config_path";
+pub const SANDBOX_CFG_PATH_KEY: &str = "io.katacontainers.config_path";
 
 // OCI section
 /// The annotation key to fetch the OCI configuration file path.
@@ -44,17 +44,17 @@ pub const CONTAINER_TYPE_KEY: &str = "io.katacontainers.pkg.oci.container_type";
 
 // Container resource related annotations
 /// Prefix for Kata container resource related annotations.
-pub const KATA_ANNO_CONTAINER_RESOURCE_PREFIX: &str = "io.katacontainers.container.resource";
+pub const KATA_ANNO_CONTAINER_RES_PREFIX: &str = "io.katacontainers.container.resource";
 /// A container annotation to specify the Resources.Memory.Swappiness.
-pub const KATA_ANNO_CONTAINER_RESOURCE_SWAPPINESS: &str =
+pub const KATA_ANNO_CONTAINER_RES_SWAPPINESS: &str =
     "io.katacontainers.container.resource.swappiness";
 /// A container annotation to specify the Resources.Memory.Swap.
-pub const KATA_ANNO_CONTAINER_RESOURCE_SWAP_IN_BYTES: &str =
+pub const KATA_ANNO_CONTAINER_RES_SWAP_IN_BYTES: &str =
     "io.katacontainers.container.resource.swap_in_bytes";
 
 // Agent related annotations
 /// Prefix for Agent configurations.
-pub const KATA_ANNO_CONF_AGENT_PREFIX: &str = "io.katacontainers.config.agent.";
+pub const KATA_ANNO_CFG_AGENT_PREFIX: &str = "io.katacontainers.config.agent.";
 /// KernelModules is the annotation key for passing the list of kernel modules and their parameters
 /// that will be loaded in the guest kernel.
 ///
@@ -66,235 +66,232 @@ pub const KATA_ANNO_CONF_AGENT_PREFIX: &str = "io.katacontainers.config.agent.";
 ///     io.katacontainers.config.agent.kernel_modules: "e1000e InterruptThrottleRate=3000,3000,3000 EEE=1; i915 enable_ppgtt=0"
 ///
 /// The first word is considered as the module name and the rest as its parameters.
-pub const KATA_ANNO_CONF_KERNEL_MODULES: &str = "io.katacontainers.config.agent.kernel_modules";
+pub const KATA_ANNO_CFG_KERNEL_MODULES: &str = "io.katacontainers.config.agent.kernel_modules";
 /// A sandbox annotation to enable tracing for the agent.
-pub const KATA_ANNO_CONF_AGENT_TRACE: &str = "io.katacontainers.config.agent.enable_tracing";
+pub const KATA_ANNO_CFG_AGENT_TRACE: &str = "io.katacontainers.config.agent.enable_tracing";
 /// An annotation to specify the size of the pipes created for containers.
-pub const KATA_ANNO_CONF_AGENT_CONTAINER_PIPE_SIZE: &str =
+pub const KATA_ANNO_CFG_AGENT_CONTAINER_PIPE_SIZE: &str =
     "io.katacontainers.config.agent.container_pipe_size";
 /// An annotation key to specify the size of the pipes created for containers.
 pub const CONTAINER_PIPE_SIZE_KERNEL_PARAM: &str = "agent.container_pipe_size";
 
 // Hypervisor related annotations
 /// Prefix for Hypervisor configurations.
-pub const KATA_ANNO_CONF_HYPERVISOR_PREFIX: &str = "io.katacontainers.config.hypervisor.";
+pub const KATA_ANNO_CFG_HYPERVISOR_PREFIX: &str = "io.katacontainers.config.hypervisor.";
 /// A sandbox annotation for passing a per container path pointing at the hypervisor that will run
 /// the container VM.
-pub const KATA_ANNO_CONF_HYPERVISOR_PATH: &str = "io.katacontainers.config.hypervisor.path";
+pub const KATA_ANNO_CFG_HYPERVISOR_PATH: &str = "io.katacontainers.config.hypervisor.path";
 /// A sandbox annotation for passing a container hypervisor binary SHA-512 hash value.
-pub const KATA_ANNO_CONF_HYPERVISOR_HASH: &str = "io.katacontainers.config.hypervisor.path_hash";
+pub const KATA_ANNO_CFG_HYPERVISOR_HASH: &str = "io.katacontainers.config.hypervisor.path_hash";
 /// A sandbox annotation for passing a per container path pointing at the hypervisor control binary
 /// that will run the container VM.
-pub const KATA_ANNO_CONF_HYPERVISOR_CTLPATH: &str = "io.katacontainers.config.hypervisor.ctlpath";
+pub const KATA_ANNO_CFG_HYPERVISOR_CTLPATH: &str = "io.katacontainers.config.hypervisor.ctlpath";
 /// A sandbox annotation for passing a container hypervisor control binary SHA-512 hash value.
-pub const KATA_ANNO_CONF_HYPERVISOR_CTLHASH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_CTLHASH: &str =
     "io.katacontainers.config.hypervisor.hypervisorctl_hash";
 /// A sandbox annotation for passing a per container path pointing at the jailer that will constrain
 /// the container VM.
-pub const KATA_ANNO_CONF_HYPERVISOR_JAILER_PATH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_JAILER_PATH: &str =
     "io.katacontainers.config.hypervisor.jailer_path";
 /// A sandbox annotation for passing a jailer binary SHA-512 hash value.
-pub const KATA_ANNO_CONF_HYPERVISOR_JAILER_HASH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_JAILER_HASH: &str =
     "io.katacontainers.config.hypervisor.jailer_hash";
 /// A sandbox annotation to enable IO to be processed in a separate thread.
 /// Supported currently for virtio-scsi driver.
-pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_ENABLE_IO_THREADS: &str =
     "io.katacontainers.config.hypervisor.enable_iothreads";
 /// The hash type used for assets verification
-pub const KATA_ANNO_CONF_HYPERVISOR_ASSET_HASH_TYPE: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_ASSET_HASH_TYPE: &str =
     "io.katacontainers.config.hypervisor.asset_hash_type";
 /// SHA512 is the SHA-512 (64) hash algorithm
 pub const SHA512: &str = "sha512";
 
 // Hypervisor Block Device related annotations
 /// Specify the driver to be used for block device either VirtioSCSI or VirtioBlock
-pub const KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_DRIVER: &str =
     "io.katacontainers.config.hypervisor.block_device_driver";
 /// A sandbox annotation that disallows a block device from being used.
-pub const KATA_ANNO_CONF_HYPERVISOR_DISABLE_BLOCK_DEVICE_USE: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_DISABLE_BLOCK_DEV_USE: &str =
     "io.katacontainers.config.hypervisor.disable_block_device_use";
 /// A sandbox annotation that specifies cache-related options will be set to block devices or not.
-pub const KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_SET: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_CACHE_SET: &str =
     "io.katacontainers.config.hypervisor.block_device_cache_set";
 /// A sandbox annotation that specifies cache-related options for block devices.
 /// Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
-pub const KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_DIRECT: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_CACHE_DIRECT: &str =
     "io.katacontainers.config.hypervisor.block_device_cache_direct";
 /// A sandbox annotation that specifies cache-related options for block devices.
 /// Denotes whether flush requests for the device are ignored.
-pub const KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_NOFLUSH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_CACHE_NOFLUSH: &str =
     "io.katacontainers.config.hypervisor.block_device_cache_noflush";
 /// A sandbox annotation to specify use of nvdimm device for guest rootfs image.
-pub const KATA_ANNO_CONF_HYPERVISOR_DISABLE_IMAGE_NVDIMM: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_DISABLE_IMAGE_NVDIMM: &str =
     "io.katacontainers.config.hypervisor.disable_image_nvdimm";
 /// A sandbox annotation that specifies the memory space used for nvdimm device by the hypervisor.
-pub const KATA_ANNO_CONF_HYPERVISOR_MEMORY_OFFSET: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_MEMORY_OFFSET: &str =
     "io.katacontainers.config.hypervisor.memory_offset";
 /// A sandbox annotation to specify if vhost-user-blk/scsi is abailable on the host
-pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_VHOSTUSER_STORE: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_ENABLE_VHOSTUSER_STORE: &str =
     "io.katacontainers.config.hypervisor.enable_vhost_user_store";
 /// A sandbox annotation to specify the directory path where vhost-user devices related folders,
 /// sockets and device nodes should be.
-pub const KATA_ANNO_CONF_HYPERVISOR_VHOSTUSER_STORE_PATH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_VHOSTUSER_STORE_PATH: &str =
     "io.katacontainers.config.hypervisor.vhost_user_store_path";
 
 // Hypervisor Guest Boot related annotations
 /// A sandbox annotation for passing a per container path pointing at the kernel needed to boot
 /// the container VM.
-pub const KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH: &str =
-    "io.katacontainers.config.hypervisor.kernel";
+pub const KATA_ANNO_CFG_HYPERVISOR_KERNEL_PATH: &str = "io.katacontainers.config.hypervisor.kernel";
 /// A sandbox annotation for passing a container kernel image SHA-512 hash value.
-pub const KATA_ANNO_CONF_HYPERVISOR_KERNEL_HASH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_KERNEL_HASH: &str =
     "io.katacontainers.config.hypervisor.kernel_hash";
 /// A sandbox annotation for passing a per container path pointing at the guest image that will run
 /// in the container VM.
 /// A sandbox annotation for passing additional guest kernel parameters.
-pub const KATA_ANNO_CONF_HYPERVISOR_KERNEL_PARAMS: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_KERNEL_PARAMS: &str =
     "io.katacontainers.config.hypervisor.kernel_params";
 /// A sandbox annotation for passing a container guest image path.
-pub const KATA_ANNO_CONF_HYPERVISOR_IMAGE_PATH: &str = "io.katacontainers.config.hypervisor.image";
+pub const KATA_ANNO_CFG_HYPERVISOR_IMAGE_PATH: &str = "io.katacontainers.config.hypervisor.image";
 /// A sandbox annotation for passing a container guest image SHA-512 hash value.
-pub const KATA_ANNO_CONF_HYPERVISOR_IMAGE_HASH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_IMAGE_HASH: &str =
     "io.katacontainers.config.hypervisor.image_hash";
 /// A sandbox annotation for passing a per container path pointing at the initrd that will run
 /// in the container VM.
-pub const KATA_ANNO_CONF_HYPERVISOR_INITRD_PATH: &str =
-    "io.katacontainers.config.hypervisor.initrd";
+pub const KATA_ANNO_CFG_HYPERVISOR_INITRD_PATH: &str = "io.katacontainers.config.hypervisor.initrd";
 /// A sandbox annotation for passing a container guest initrd SHA-512 hash value.
-pub const KATA_ANNO_CONF_HYPERVISOR_INITRD_HASH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_INITRD_HASH: &str =
     "io.katacontainers.config.hypervisor.initrd_hash";
 /// A sandbox annotation for passing a per container path pointing at the guest firmware that will
 /// run the container VM.
-pub const KATA_ANNO_CONF_HYPERVISOR_FIRMWARE_PATH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_FIRMWARE_PATH: &str =
     "io.katacontainers.config.hypervisor.firmware";
 /// A sandbox annotation for passing a container guest firmware SHA-512 hash value.
-pub const KATA_ANNO_CONF_HYPERVISOR_FIRMWARE_HASH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_FIRMWARE_HASH: &str =
     "io.katacontainers.config.hypervisor.firmware_hash";
 
 // Hypervisor CPU related annotations
 /// A sandbox annotation to specify cpu specific features.
-pub const KATA_ANNO_CONF_HYPERVISOR_CPU_FEATURES: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_CPU_FEATURES: &str =
     "io.katacontainers.config.hypervisor.cpu_features";
 /// A sandbox annotation for passing the default vcpus assigned for a VM by the hypervisor.
-pub const KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_DEFAULT_VCPUS: &str =
     "io.katacontainers.config.hypervisor.default_vcpus";
 /// A sandbox annotation that specifies the maximum number of vCPUs allocated for the VM by the hypervisor.
-pub const KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MAX_VCPUS: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MAX_VCPUS: &str =
     "io.katacontainers.config.hypervisor.default_max_vcpus";
 
 // Hypervisor Device related annotations
 /// A sandbox annotation used to indicate if devices need to be hotplugged on the root bus instead
 /// of a bridge.
-pub const KATA_ANNO_CONF_HYPERVISOR_HOTPLUG_VFIO_ON_ROOT_BUS: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_HOTPLUG_VFIO_ON_ROOT_BUS: &str =
     "io.katacontainers.config.hypervisor.hotplug_vfio_on_root_bus";
 /// PCIeRootPort is used to indicate the number of PCIe Root Port devices
-pub const KATA_ANNO_CONF_HYPERVISOR_PCIE_ROOT_PORT: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_PCIE_ROOT_PORT: &str =
     "io.katacontainers.config.hypervisor.pcie_root_port";
 /// A sandbox annotation to specify if the VM should have a vIOMMU device.
-pub const KATA_ANNO_CONF_HYPERVISOR_IOMMU: &str =
-    "io.katacontainers.config.hypervisor.enable_iommu";
+pub const KATA_ANNO_CFG_HYPERVISOR_IOMMU: &str = "io.katacontainers.config.hypervisor.enable_iommu";
 /// Enable Hypervisor Devices IOMMU_PLATFORM
-pub const KATA_ANNO_CONF_HYPERVISOR_IOMMU_PLATFORM: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_IOMMU_PLATFORM: &str =
     "io.katacontainers.config.hypervisor.enable_iommu_platform";
 
 //	Hypervisor Machine related annotations
 /// A sandbox annotation to specify the type of machine being emulated by the hypervisor.
-pub const KATA_ANNO_CONF_HYPERVISOR_MACHINE_TYPE: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_MACHINE_TYPE: &str =
     "io.katacontainers.config.hypervisor.machine_type";
 /// A sandbox annotation to specify machine specific accelerators for the hypervisor.
-pub const KATA_ANNO_CONF_HYPERVISOR_MACHINE_ACCELERATORS: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_MACHINE_ACCELERATORS: &str =
     "io.katacontainers.config.hypervisor.machine_accelerators";
 /// EntropySource is a sandbox annotation to specify the path to a host source of
 /// entropy (/dev/random, /dev/urandom or real hardware RNG device)
-pub const KATA_ANNO_CONF_HYPERVISOR_ENTROPY_SOURCE: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_ENTROPY_SOURCE: &str =
     "io.katacontainers.config.hypervisor.entropy_source";
 
 // Hypervisor Memory related annotations
 /// A sandbox annotation for the memory assigned for a VM by the hypervisor.
-pub const KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MEMORY: &str =
     "io.katacontainers.config.hypervisor.default_memory";
 /// A sandbox annotation to specify the memory slots assigned to the VM by the hypervisor.
-pub const KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_MEMORY_SLOTS: &str =
     "io.katacontainers.config.hypervisor.memory_slots";
 /// A sandbox annotation that specifies the memory space used for nvdimm device by the hypervisor.
-pub const KATA_ANNO_CONF_HYPERVISOR_MEMORY_PREALLOC: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_MEMORY_PREALLOC: &str =
     "io.katacontainers.config.hypervisor.enable_mem_prealloc";
 /// A sandbox annotation to specify if the memory should be pre-allocated from huge pages.
-pub const KATA_ANNO_CONF_HYPERVISOR_HUGE_PAGES: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_HUGE_PAGES: &str =
     "io.katacontainers.config.hypervisor.enable_hugepages";
 /// A sandbox annotation to soecify file based memory backend root directory.
-pub const KATA_ANNO_CONF_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR: &str =
     "io.katacontainers.config.hypervisor.file_mem_backend";
 /// A sandbox annotation that is used to enable/disable virtio-mem.
-pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_MEM: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_VIRTIO_MEM: &str =
     "io.katacontainers.config.hypervisor.enable_virtio_mem";
 /// A sandbox annotation to enable swap of vm memory.
-pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_SWAP: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_ENABLE_SWAP: &str =
     "io.katacontainers.config.hypervisor.enable_swap";
 /// A sandbox annotation to enable swap in the guest.
-pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_ENABLE_GUEST_SWAP: &str =
     "io.katacontainers.config.hypervisor.enable_guest_swap";
 
 // Hypervisor Network related annotations
 /// A sandbox annotation to specify if vhost-net is not available on the host.
-pub const KATA_ANNO_CONF_HYPERVISOR_DISABLE_VHOST_NET: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_DISABLE_VHOST_NET: &str =
     "io.katacontainers.config.hypervisor.disable_vhost_net";
 /// A sandbox annotation that specifies max rate on network I/O inbound bandwidth.
-pub const KATA_ANNO_CONF_HYPERVISOR_RX_RATE_LIMITER_MAX_RATE: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_RX_RATE_LIMITER_MAX_RATE: &str =
     "io.katacontainers.config.hypervisor.rx_rate_limiter_max_rate";
 /// A sandbox annotation that specifies max rate on network I/O outbound bandwidth.
-pub const KATA_ANNO_CONF_HYPERVISOR_TX_RATE_LIMITER_MAX_RATE: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_TX_RATE_LIMITER_MAX_RATE: &str =
     "io.katacontainers.config.hypervisor.tx_rate_limiter_max_rate";
 
 // Hypervisor Security related annotations
 /// A sandbox annotation to specify the path within the VM that will be used for 'drop-in' hooks.
-pub const KATA_ANNO_CONF_HYPERVISOR_GUEST_HOOK_PATH: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_GUEST_HOOK_PATH: &str =
     "io.katacontainers.config.hypervisor.guest_hook_path";
 /// A sandbox annotation to enable rootless hypervisor (only supported in QEMU currently).
-pub const KATA_ANNO_CONF_HYPERVISOR_ENABLE_ROOTLESS_HYPERVISOR: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_ENABLE_ROOTLESS_HYPERVISOR: &str =
     "io.katacontainers.config.hypervisor.rootless";
 
 // Hypervisor Shared File System related annotations
 /// A sandbox annotation to specify the shared file system type, either virtio-9p or virtio-fs.
-pub const KATA_ANNO_CONF_HYPERVISOR_SHARED_FS: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_SHARED_FS: &str =
     "io.katacontainers.config.hypervisor.shared_fs";
 /// A sandbox annotations to specify virtio-fs vhost-user daemon path.
-pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_DAEMON: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_DAEMON: &str =
     "io.katacontainers.config.hypervisor.virtio_fs_daemon";
 /// A sandbox annotation to specify the cache mode for fs version cache or "none".
-pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_CACHE: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_CACHE: &str =
     "io.katacontainers.config.hypervisor.virtio_fs_cache";
 /// A sandbox annotation to specify the DAX cache size in MiB.
-pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_CACHE_SIZE: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_CACHE_SIZE: &str =
     "io.katacontainers.config.hypervisor.virtio_fs_cache_size";
 /// A sandbox annotation to pass options to virtiofsd daemon.
-pub const KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS: &str =
+pub const KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS: &str =
     "io.katacontainers.config.hypervisor.virtio_fs_extra_args";
 /// A sandbox annotation to specify as the msize for 9p shares.
-pub const KATA_ANNO_CONF_HYPERVISOR_MSIZE_9P: &str = "io.katacontainers.config.hypervisor.msize_9p";
+pub const KATA_ANNO_CFG_HYPERVISOR_MSIZE_9P: &str = "io.katacontainers.config.hypervisor.msize_9p";
 
 // Runtime related annotations
 /// Prefix for Runtime configurations.
-pub const KATA_ANNO_CONF_RUNTIME_PREFIX: &str = "io.katacontainers.config.runtime.";
+pub const KATA_ANNO_CFG_RUNTIME_PREFIX: &str = "io.katacontainers.config.runtime.";
 /// A sandbox annotation that determines if seccomp should be applied inside guest.
-pub const KATA_ANNO_CONF_DISABLE_GUEST_SECCOMP: &str =
+pub const KATA_ANNO_CFG_DISABLE_GUEST_SECCOMP: &str =
     "io.katacontainers.config.runtime.disable_guest_seccomp";
 /// A sandbox annotation that determines if pprof enabled.
-pub const KATA_ANNO_CONF_ENABLE_PPROF: &str = "io.katacontainers.config.runtime.enable_pprof";
+pub const KATA_ANNO_CFG_ENABLE_PPROF: &str = "io.katacontainers.config.runtime.enable_pprof";
 /// A sandbox annotation that determines if experimental features enabled.
-pub const KATA_ANNO_CONF_EXPERIMENTAL: &str = "io.katacontainers.config.runtime.experimental";
+pub const KATA_ANNO_CFG_EXPERIMENTAL: &str = "io.katacontainers.config.runtime.experimental";
 /// A sandbox annotaion that determines how the VM should be connected to the the container network
 /// interface.
-pub const KATA_ANNO_CONF_INTER_NETWORK_MODEL: &str =
+pub const KATA_ANNO_CFG_INTER_NETWORK_MODEL: &str =
     "io.katacontainers.config.runtime.internetworking_model";
 /// SandboxCgroupOnly is a sandbox annotation that determines if kata processes are managed only in sandbox cgroup.
-pub const KATA_ANNO_CONF_SANDBOX_CGROUP_ONLY: &str =
+pub const KATA_ANNO_CFG_SANDBOX_CGROUP_ONLY: &str =
     "io.katacontainers.config.runtime.sandbox_cgroup_only";
 /// A sandbox annotation that determines if create a netns for hypervisor process.
-pub const KATA_ANNO_CONF_DISABLE_NEW_NETNS: &str =
+pub const KATA_ANNO_CFG_DISABLE_NEW_NETNS: &str =
     "io.katacontainers.config.runtime.disable_new_netns";
 /// A sandbox annotation to specify how attached VFIO devices should be treated.
-pub const KATA_ANNO_CONF_VFIO_MODE: &str = "io.katacontainers.config.runtime.vfio_mode";
+pub const KATA_ANNO_CFG_VFIO_MODE: &str = "io.katacontainers.config.runtime.vfio_mode";
 
 /// A helper structure to query configuration information by check annotations.
 #[derive(Debug, Default, Deserialize)]
@@ -407,7 +404,7 @@ impl Annotation {
 impl Annotation {
     /// Get the annotation of sandbox configuration file path.
     pub fn get_sandbox_config_path(&self) -> Option<String> {
-        self.get(SANDBOX_CONFIG_PATH_KEY)
+        self.get(SANDBOX_CFG_PATH_KEY)
     }
 
     /// Get the annotation of bundle path.
@@ -422,7 +419,7 @@ impl Annotation {
 
     /// Get the annotation to specify the Resources.Memory.Swappiness.
     pub fn get_container_resource_swappiness(&self) -> Result<Option<u32>> {
-        match self.get_u32(KATA_ANNO_CONTAINER_RESOURCE_SWAPPINESS) {
+        match self.get_u32(KATA_ANNO_CONTAINER_RES_SWAPPINESS) {
             Ok(r) => {
                 if r.unwrap_or_default() > 100 {
                     return Err(io::Error::new(
@@ -439,7 +436,7 @@ impl Annotation {
 
     /// Get the annotation to specify the Resources.Memory.Swap.
     pub fn get_container_resource_swap_in_bytes(&self) -> Option<String> {
-        self.get(KATA_ANNO_CONTAINER_RESOURCE_SWAP_IN_BYTES)
+        self.get(KATA_ANNO_CONTAINER_RES_SWAP_IN_BYTES)
     }
 }
 
@@ -471,20 +468,20 @@ impl Annotation {
                 match key.as_str() {
                     // update hypervisor config
                     //	Hypervisor related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_PATH => {
+                    KATA_ANNO_CFG_HYPERVISOR_PATH => {
                         hv.validate_hypervisor_path(value)?;
                         hv.path = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_CTLPATH => {
+                    KATA_ANNO_CFG_HYPERVISOR_CTLPATH => {
                         hv.validate_hypervisor_ctlpath(value)?;
                         hv.ctlpath = value.to_string();
                     }
 
-                    KATA_ANNO_CONF_HYPERVISOR_JAILER_PATH => {
+                    KATA_ANNO_CFG_HYPERVISOR_JAILER_PATH => {
                         hv.validate_jailer_path(value)?;
                         hv.jailer_path = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_ENABLE_IO_THREADS => match self.get_bool(key) {
                         Ok(r) => {
                             hv.enable_iothreads = r.unwrap_or_default();
                         }
@@ -493,20 +490,18 @@ impl Annotation {
                         }
                     },
                     //	Hypervisor Block Device related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER => {
+                    KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_DRIVER => {
                         hv.blockdev_info.block_device_driver = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_DISABLE_BLOCK_DEVICE_USE => {
-                        match self.get_bool(key) {
-                            Ok(r) => {
-                                hv.blockdev_info.disable_block_device_use = r.unwrap_or_default();
-                            }
-                            Err(e) => {
-                                return Err(e);
-                            }
+                    KATA_ANNO_CFG_HYPERVISOR_DISABLE_BLOCK_DEV_USE => match self.get_bool(key) {
+                        Ok(r) => {
+                            hv.blockdev_info.disable_block_device_use = r.unwrap_or_default();
                         }
-                    }
-                    KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_SET => match self.get_bool(key) {
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    },
+                    KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_CACHE_SET => match self.get_bool(key) {
                         Ok(r) => {
                             hv.blockdev_info.block_device_cache_set = r.unwrap_or_default();
                         }
@@ -514,8 +509,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_DIRECT => match self.get_bool(key)
-                    {
+                    KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_CACHE_DIRECT => match self.get_bool(key) {
                         Ok(r) => {
                             hv.blockdev_info.block_device_cache_direct = r.unwrap_or_default();
                         }
@@ -523,17 +517,15 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_NOFLUSH => {
-                        match self.get_bool(key) {
-                            Ok(r) => {
-                                hv.blockdev_info.block_device_cache_noflush = r.unwrap_or_default();
-                            }
-                            Err(e) => {
-                                return Err(e);
-                            }
+                    KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_CACHE_NOFLUSH => match self.get_bool(key) {
+                        Ok(r) => {
+                            hv.blockdev_info.block_device_cache_noflush = r.unwrap_or_default();
                         }
-                    }
-                    KATA_ANNO_CONF_HYPERVISOR_DISABLE_IMAGE_NVDIMM => match self.get_bool(key) {
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    },
+                    KATA_ANNO_CFG_HYPERVISOR_DISABLE_IMAGE_NVDIMM => match self.get_bool(key) {
                         Ok(r) => {
                             hv.blockdev_info.disable_image_nvdimm = r.unwrap_or_default();
                         }
@@ -541,7 +533,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_MEMORY_OFFSET => match self.get_u64(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_MEMORY_OFFSET => match self.get_u64(key) {
                         Ok(r) => {
                             hv.blockdev_info.memory_offset = r.unwrap_or_default();
                         }
@@ -549,7 +541,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_VHOSTUSER_STORE => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_ENABLE_VHOSTUSER_STORE => match self.get_bool(key) {
                         Ok(r) => {
                             hv.blockdev_info.enable_vhost_user_store = r.unwrap_or_default();
                         }
@@ -557,35 +549,35 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_VHOSTUSER_STORE_PATH => {
+                    KATA_ANNO_CFG_HYPERVISOR_VHOSTUSER_STORE_PATH => {
                         hv.blockdev_info.validate_vhost_user_store_path(value)?;
                         hv.blockdev_info.vhost_user_store_path = value.to_string();
                     }
                     // Hypervisor Guest Boot related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH => {
+                    KATA_ANNO_CFG_HYPERVISOR_KERNEL_PATH => {
                         hv.boot_info.validate_boot_path(value)?;
                         hv.boot_info.kernel = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_KERNEL_PARAMS => {
+                    KATA_ANNO_CFG_HYPERVISOR_KERNEL_PARAMS => {
                         hv.boot_info.kernel_params = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_IMAGE_PATH => {
+                    KATA_ANNO_CFG_HYPERVISOR_IMAGE_PATH => {
                         hv.boot_info.validate_boot_path(value)?;
                         hv.boot_info.image = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_INITRD_PATH => {
+                    KATA_ANNO_CFG_HYPERVISOR_INITRD_PATH => {
                         hv.boot_info.validate_boot_path(value)?;
                         hv.boot_info.initrd = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_FIRMWARE_PATH => {
+                    KATA_ANNO_CFG_HYPERVISOR_FIRMWARE_PATH => {
                         hv.boot_info.validate_boot_path(value)?;
                         hv.boot_info.firmware = value.to_string();
                     }
                     //	Hypervisor CPU related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_CPU_FEATURES => {
+                    KATA_ANNO_CFG_HYPERVISOR_CPU_FEATURES => {
                         hv.cpu_info.cpu_features = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS => match self.get_i32(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_DEFAULT_VCPUS => match self.get_i32(key) {
                         Ok(num_cpus) => {
                             let num_cpus = num_cpus.unwrap_or_default();
                             if num_cpus
@@ -611,7 +603,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MAX_VCPUS => match self.get_u32(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MAX_VCPUS => match self.get_u32(key) {
                         Ok(r) => {
                             hv.cpu_info.default_maxvcpus = r.unwrap_or_default();
                         }
@@ -620,17 +612,15 @@ impl Annotation {
                         }
                     },
                     //	Hypervisor Device related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_HOTPLUG_VFIO_ON_ROOT_BUS => {
-                        match self.get_bool(key) {
-                            Ok(r) => {
-                                hv.device_info.hotplug_vfio_on_root_bus = r.unwrap_or_default();
-                            }
-                            Err(e) => {
-                                return Err(e);
-                            }
+                    KATA_ANNO_CFG_HYPERVISOR_HOTPLUG_VFIO_ON_ROOT_BUS => match self.get_bool(key) {
+                        Ok(r) => {
+                            hv.device_info.hotplug_vfio_on_root_bus = r.unwrap_or_default();
                         }
-                    }
-                    KATA_ANNO_CONF_HYPERVISOR_PCIE_ROOT_PORT => match self.get_u32(key) {
+                        Err(e) => {
+                            return Err(e);
+                        }
+                    },
+                    KATA_ANNO_CFG_HYPERVISOR_PCIE_ROOT_PORT => match self.get_u32(key) {
                         Ok(r) => {
                             hv.device_info.pcie_root_port = r.unwrap_or_default();
                         }
@@ -638,7 +628,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_IOMMU => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_IOMMU => match self.get_bool(key) {
                         Ok(r) => {
                             hv.device_info.enable_iommu = r.unwrap_or_default();
                         }
@@ -646,7 +636,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_IOMMU_PLATFORM => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_IOMMU_PLATFORM => match self.get_bool(key) {
                         Ok(r) => {
                             hv.device_info.enable_iommu_platform = r.unwrap_or_default();
                         }
@@ -655,18 +645,18 @@ impl Annotation {
                         }
                     },
                     //	Hypervisor Machine related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_MACHINE_TYPE => {
+                    KATA_ANNO_CFG_HYPERVISOR_MACHINE_TYPE => {
                         hv.machine_info.machine_type = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_MACHINE_ACCELERATORS => {
+                    KATA_ANNO_CFG_HYPERVISOR_MACHINE_ACCELERATORS => {
                         hv.machine_info.machine_accelerators = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_ENTROPY_SOURCE => {
+                    KATA_ANNO_CFG_HYPERVISOR_ENTROPY_SOURCE => {
                         hv.machine_info.validate_entropy_source(value)?;
                         hv.machine_info.entropy_source = value.to_string();
                     }
                     //	Hypervisor Memory related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY => match self.get_u32(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MEMORY => match self.get_u32(key) {
                         Ok(r) => {
                             let mem = r.unwrap_or_default();
                             if mem
@@ -692,7 +682,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS => match self.get_u32(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_MEMORY_SLOTS => match self.get_u32(key) {
                         Ok(v) => {
                             hv.memory_info.memory_slots = v.unwrap_or_default();
                         }
@@ -701,7 +691,7 @@ impl Annotation {
                         }
                     },
 
-                    KATA_ANNO_CONF_HYPERVISOR_MEMORY_PREALLOC => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_MEMORY_PREALLOC => match self.get_bool(key) {
                         Ok(r) => {
                             hv.memory_info.enable_mem_prealloc = r.unwrap_or_default();
                         }
@@ -709,7 +699,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_HUGE_PAGES => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_HUGE_PAGES => match self.get_bool(key) {
                         Ok(r) => {
                             hv.memory_info.enable_hugepages = r.unwrap_or_default();
                         }
@@ -717,11 +707,11 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR => {
+                    KATA_ANNO_CFG_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR => {
                         hv.memory_info.validate_memory_backend_path(value)?;
                         hv.memory_info.file_mem_backend = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_MEM => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_VIRTIO_MEM => match self.get_bool(key) {
                         Ok(r) => {
                             hv.memory_info.enable_virtio_mem = r.unwrap_or_default();
                         }
@@ -729,7 +719,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_SWAP => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_ENABLE_SWAP => match self.get_bool(key) {
                         Ok(r) => {
                             hv.memory_info.enable_swap = r.unwrap_or_default();
                         }
@@ -737,7 +727,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_ENABLE_GUEST_SWAP => match self.get_bool(key) {
                         Ok(r) => {
                             hv.memory_info.enable_guest_swap = r.unwrap_or_default();
                         }
@@ -746,7 +736,7 @@ impl Annotation {
                         }
                     },
                     //	Hypervisor Network related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_DISABLE_VHOST_NET => match self.get_bool(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_DISABLE_VHOST_NET => match self.get_bool(key) {
                         Ok(r) => {
                             hv.network_info.disable_vhost_net = r.unwrap_or_default();
                         }
@@ -754,7 +744,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_RX_RATE_LIMITER_MAX_RATE => match self.get_u64(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_RX_RATE_LIMITER_MAX_RATE => match self.get_u64(key) {
                         Ok(r) => {
                             hv.network_info.rx_rate_limiter_max_rate = r.unwrap_or_default();
                         }
@@ -762,7 +752,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_TX_RATE_LIMITER_MAX_RATE => match self.get_u64(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_TX_RATE_LIMITER_MAX_RATE => match self.get_u64(key) {
                         Ok(r) => {
                             hv.network_info.tx_rate_limiter_max_rate = r.unwrap_or_default();
                         }
@@ -771,11 +761,11 @@ impl Annotation {
                         }
                     },
                     //	Hypervisor Security related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_GUEST_HOOK_PATH => {
+                    KATA_ANNO_CFG_HYPERVISOR_GUEST_HOOK_PATH => {
                         hv.security_info.validate_path(value)?;
                         hv.security_info.guest_hook_path = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_ENABLE_ROOTLESS_HYPERVISOR => {
+                    KATA_ANNO_CFG_HYPERVISOR_ENABLE_ROOTLESS_HYPERVISOR => {
                         match self.get_bool(key) {
                             Ok(r) => {
                                 hv.security_info.rootless = r.unwrap_or_default();
@@ -786,19 +776,19 @@ impl Annotation {
                         }
                     }
                     //	Hypervisor Shared File System related annotations
-                    KATA_ANNO_CONF_HYPERVISOR_SHARED_FS => {
+                    KATA_ANNO_CFG_HYPERVISOR_SHARED_FS => {
                         hv.shared_fs.shared_fs = self.get(key);
                     }
 
-                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_DAEMON => {
+                    KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_DAEMON => {
                         hv.shared_fs.validate_virtiofs_daemon_path(value)?;
                         hv.shared_fs.virtio_fs_daemon = value.to_string();
                     }
 
-                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_CACHE => {
+                    KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_CACHE => {
                         hv.shared_fs.virtio_fs_cache = value.to_string();
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_CACHE_SIZE => match self.get_u32(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_CACHE_SIZE => match self.get_u32(key) {
                         Ok(r) => {
                             hv.shared_fs.virtio_fs_cache_size = r.unwrap_or_default();
                         }
@@ -806,14 +796,14 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS => {
+                    KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS => {
                         let args: Vec<String> =
                             value.to_string().split(',').map(str::to_string).collect();
                         for arg in args {
                             hv.shared_fs.virtio_fs_extra_args.push(arg.to_string());
                         }
                     }
-                    KATA_ANNO_CONF_HYPERVISOR_MSIZE_9P => match self.get_u32(key) {
+                    KATA_ANNO_CFG_HYPERVISOR_MSIZE_9P => match self.get_u32(key) {
                         Ok(v) => {
                             hv.shared_fs.msize_9p = v.unwrap_or_default();
                         }
@@ -832,14 +822,14 @@ impl Annotation {
             } else {
                 match key.as_str() {
                     //update agent config
-                    KATA_ANNO_CONF_KERNEL_MODULES => {
+                    KATA_ANNO_CFG_KERNEL_MODULES => {
                         let kernel_mod: Vec<String> =
                             value.to_string().split(';').map(str::to_string).collect();
                         for modules in kernel_mod {
                             ag.kernel_modules.push(modules.to_string());
                         }
                     }
-                    KATA_ANNO_CONF_AGENT_TRACE => match self.get_bool(key) {
+                    KATA_ANNO_CFG_AGENT_TRACE => match self.get_bool(key) {
                         Ok(r) => {
                             ag.enable_tracing = r.unwrap_or_default();
                         }
@@ -847,7 +837,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_AGENT_CONTAINER_PIPE_SIZE => match self.get_u32(key) {
+                    KATA_ANNO_CFG_AGENT_CONTAINER_PIPE_SIZE => match self.get_u32(key) {
                         Ok(v) => {
                             ag.container_pipe_size = v.unwrap_or_default();
                         }
@@ -856,7 +846,7 @@ impl Annotation {
                         }
                     },
                     //update runtume config
-                    KATA_ANNO_CONF_DISABLE_GUEST_SECCOMP => match self.get_bool(key) {
+                    KATA_ANNO_CFG_DISABLE_GUEST_SECCOMP => match self.get_bool(key) {
                         Ok(r) => {
                             config.runtime.disable_guest_seccomp = r.unwrap_or_default();
                         }
@@ -864,7 +854,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_ENABLE_PPROF => match self.get_bool(key) {
+                    KATA_ANNO_CFG_ENABLE_PPROF => match self.get_bool(key) {
                         Ok(r) => {
                             config.runtime.enable_pprof = r.unwrap_or_default();
                         }
@@ -872,17 +862,17 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_EXPERIMENTAL => {
+                    KATA_ANNO_CFG_EXPERIMENTAL => {
                         let args: Vec<String> =
                             value.to_string().split(',').map(str::to_string).collect();
                         for arg in args {
                             config.runtime.experimental.push(arg.to_string());
                         }
                     }
-                    KATA_ANNO_CONF_INTER_NETWORK_MODEL => {
+                    KATA_ANNO_CFG_INTER_NETWORK_MODEL => {
                         config.runtime.internetworking_model = value.to_string();
                     }
-                    KATA_ANNO_CONF_SANDBOX_CGROUP_ONLY => match self.get_bool(key) {
+                    KATA_ANNO_CFG_SANDBOX_CGROUP_ONLY => match self.get_bool(key) {
                         Ok(r) => {
                             config.runtime.sandbox_cgroup_only = r.unwrap_or_default();
                         }
@@ -890,7 +880,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_DISABLE_NEW_NETNS => match self.get_bool(key) {
+                    KATA_ANNO_CFG_DISABLE_NEW_NETNS => match self.get_bool(key) {
                         Ok(r) => {
                             config.runtime.disable_new_netns = r.unwrap_or_default();
                         }
@@ -898,7 +888,7 @@ impl Annotation {
                             return Err(e);
                         }
                     },
-                    KATA_ANNO_CONF_VFIO_MODE => {
+                    KATA_ANNO_CFG_VFIO_MODE => {
                         config.runtime.vfio_mode = value.to_string();
                     }
                     _ => {

--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -325,12 +325,12 @@ impl Annotation {
     }
 
     /// Get an immutable reference to the annotation hashmap.
-    pub fn get_annotation(&self) -> &HashMap<String, String> {
+    pub fn get_annotations(&self) -> &HashMap<String, String> {
         &self.annotations
     }
 
     /// Get a mutable reference to the annotation hashmap.
-    pub fn get_annotation_mut(&mut self) -> &mut HashMap<String, String> {
+    pub fn get_annotations_mut(&mut self) -> &mut HashMap<String, String> {
         &mut self.annotations
     }
 
@@ -609,7 +609,7 @@ impl Annotation {
                             return Err(io::Error::new(
                                 io::ErrorKind::InvalidData,
                                 format!(
-                                    "Memory specified in annotation {} is less than minmum required {}",
+                                    "Memory specified in annotation {} is less than minimum required {}",
                                     mem,
                                     get_hypervisor_plugin(hypervisor_name)
                                         .unwrap()
@@ -627,7 +627,7 @@ impl Annotation {
                         None => {
                             return Err(io::Error::new(
                                 io::ErrorKind::InvalidData,
-                                format!("{}in annotation is less than zero", key),
+                                format!("{} in annotation is less than zero", key),
                             ));
                         }
                     },
@@ -715,7 +715,7 @@ impl Annotation {
                     _ => {
                         return Err(io::Error::new(
                             io::ErrorKind::InvalidInput,
-                            format!("Invalid Annotation Type {}", key),
+                            format!("Invalid annotation type {}", key),
                         ));
                     }
                 }

--- a/src/libs/kata-types/src/annotations/thirdparty.rs
+++ b/src/libs/kata-types/src/annotations/thirdparty.rs
@@ -9,6 +9,4 @@
 /// Annotation to enable SGX.
 ///
 /// Hardware-based isolation and memory encryption.
-// Supported suffixes are: Ki | Mi | Gi | Ti | Pi | Ei . For example: 4Mi
-// For more information about supported suffixes see https://physics.nist.gov/cuu/Units/binary.html
 pub const SGXEPC: &str = "sgx.intel.com/epc";

--- a/src/libs/kata-types/src/annotations/thirdparty.rs
+++ b/src/libs/kata-types/src/annotations/thirdparty.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Third-party annotations - annotations defined by other projects or k8s plugins but that can
+//! change Kata Containers behaviour.
+
+/// Annotation to enable SGX.
+///
+/// Hardware-based isolation and memory encryption.
+// Supported suffixes are: Ki | Mi | Gi | Ti | Pi | Ei . For example: 4Mi
+// For more information about supported suffixes see https://physics.nist.gov/cuu/Units/binary.html
+pub const SGXEPC: &str = "sgx.intel.com/epc";

--- a/src/libs/kata-types/src/annotations/thirdparty.rs
+++ b/src/libs/kata-types/src/annotations/thirdparty.rs
@@ -9,4 +9,4 @@
 /// Annotation to enable SGX.
 ///
 /// Hardware-based isolation and memory encryption.
-pub const SGXEPC: &str = "sgx.intel.com/epc";
+pub const SGX_EPC: &str = "sgx.intel.com/epc";

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -50,6 +50,9 @@ pub struct Agent {
     ///    requirements, like architecture and version.
     #[serde(default)]
     pub kernel_modules: Vec<String>,
+
+    /// contianer pipe size
+    pub container_pipe_size: u32,
 }
 
 impl ConfigOps for Agent {

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -51,7 +51,7 @@ pub struct Agent {
     #[serde(default)]
     pub kernel_modules: Vec<String>,
 
-    /// contianer pipe size
+    /// container pipe size
     pub container_pipe_size: u32,
 }
 

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::Result;
+
+use crate::config::{ConfigOps, TomlConfig};
+
+pub use vendor::AgentVendor;
+
+/// Kata agent configuration information.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Agent {
+    /// If enabled, the agent will log additional debug messages to the system log.
+    #[serde(default, rename = "enable_debug")]
+    pub debug: bool,
+
+    /// Enable agent tracing.
+    ///
+    /// If enabled, the agent will generate OpenTelemetry trace spans.
+    /// # Notes:
+    /// - If the runtime also has tracing enabled, the agent spans will be associated with the
+    ///   appropriate runtime parent span.
+    /// - If enabled, the runtime will wait for the container to shutdown, increasing the container
+    ///   shutdown time slightly.
+    #[serde(default)]
+    pub enable_tracing: bool,
+
+    /// Enable debug console.
+    /// If enabled, user can connect guest OS running inside hypervisor through
+    /// "kata-runtime exec <sandbox-id>" command
+    #[serde(default)]
+    pub debug_console_enabled: bool,
+
+    /// Agent connection dialing timeout value in seconds
+    #[serde(default)]
+    pub dial_timeout: u32,
+
+    /// Comma separated list of kernel modules and their parameters.
+    ///
+    /// These modules will be loaded in the guest kernel using modprobe(8).
+    /// The following example can be used to load two kernel modules with parameters:
+    ///  - kernel_modules=["e1000e InterruptThrottleRate=3000,3000,3000 EEE=1", "i915 enable_ppgtt=0"]
+    /// The first word is considered as the module name and the rest as its parameters.
+    /// Container will not be started when:
+    /// - A kernel module is specified and the modprobe command is not installed in the guest
+    ///   or it fails loading the module.
+    /// - The module is not available in the guest or it doesn't met the guest kernel
+    ///    requirements, like architecture and version.
+    #[serde(default)]
+    pub kernel_modules: Vec<String>,
+}
+
+impl ConfigOps for Agent {
+    fn adjust_configuration(conf: &mut TomlConfig) -> Result<()> {
+        AgentVendor::adjust_configuration(conf)?;
+        Ok(())
+    }
+
+    fn validate(conf: &TomlConfig) -> Result<()> {
+        AgentVendor::validate(conf)?;
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "enable-vendor"))]
+mod vendor {
+    use super::*;
+
+    /// Vendor customization agent configuration.
+    #[derive(Debug, Default, Deserialize, Serialize)]
+    pub struct AgentVendor {}
+
+    impl ConfigOps for AgentVendor {}
+}
+
+#[cfg(feature = "enable-vendor")]
+#[path = "agent_vendor.rs"]
+mod vendor;

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -56,8 +56,8 @@ pub struct Agent {
 }
 
 impl ConfigOps for Agent {
-    fn adjust_configuration(conf: &mut TomlConfig) -> Result<()> {
-        AgentVendor::adjust_configuration(conf)?;
+    fn adjust_config(conf: &mut TomlConfig) -> Result<()> {
+        AgentVendor::adjust_config(conf)?;
         Ok(())
     }
 

--- a/src/libs/kata-types/src/config/agent_vendor.rs
+++ b/src/libs/kata-types/src/config/agent_vendor.rs
@@ -1,0 +1,12 @@
+// Copyright (c) 2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use super::*;
+
+/// Vendor customization agent configuration.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct AgentVendor {}
+
+impl ConfigOps for AgentVendor {}

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -23,7 +23,7 @@ pub const DEFAULT_BLOCK_DEVICE_TYPE: &str = "virtio-blk";
 pub const DEFAULT_VHOST_USER_STORE_PATH: &str = "/var/run/vhost-user";
 pub const DEFAULT_BLOCK_NVDIMM_MEM_OFFSET: u64 = 0;
 
-pub const DEFAULT_SHARED_FS_TYPE: &str = "virtio-9p";
+pub const DEFAULT_SHARED_FS_TYPE: &str = "virtio-fs";
 pub const DEFAULT_VIRTIO_FS_CACHE_MODE: &str = "none";
 pub const DEFAULT_VIRTIO_FS_DAX_SIZE_MB: u32 = 1024;
 pub const DEFAULT_SHARED_9PFS_SIZE: u32 = 128 * 1024;

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -15,7 +15,7 @@ lazy_static! {
         "/usr/share/defaults/kata-containers/configuration.toml",
     ];
 }
-pub const DEFAULT_AGENT_NAME: &str = "kata";
+pub const DEFAULT_AGENT_NAME: &str = "kata-agent";
 
 pub const DEFAULT_INTERNETWORKING_MODEL: &str = "tcfilter";
 
@@ -35,13 +35,13 @@ pub const DEFAULT_GUEST_HOOK_PATH: &str = "/opt";
 pub const DEFAULT_GUEST_VCPUS: u32 = 1;
 
 // Default configuration for Dragonball
-pub const DEFAULT_DB_GUEST_KERNEL_IMAGE: &str = "vmlinuz";
-pub const DEFAULT_DB_GUEST_KERNEL_PARAMS: &str = "";
-pub const DEFAULT_DB_ENTROPY_SOURCE: &str = "/dev/urandom";
-pub const DEFAULT_DB_MEMORY_SIZE: u32 = 128;
-pub const DEFAULT_DB_MEMORY_SLOTS: u32 = 128;
-pub const MAX_DB_VCPUS: u32 = 256;
-pub const MIN_DB_MEMORY_SIZE: u32 = 64;
+pub const DEFAULT_DRAGONBALL_GUEST_KERNEL_IMAGE: &str = "vmlinuz";
+pub const DEFAULT_DRAGONBALL_GUEST_KERNEL_PARAMS: &str = "";
+pub const DEFAULT_DRAGONBALL_ENTROPY_SOURCE: &str = "/dev/urandom";
+pub const DEFAULT_DRAGONBALL_MEMORY_SIZE: u32 = 128;
+pub const DEFAULT_DRAGONBALL_MEMORY_SLOTS: u32 = 128;
+pub const MAX_DRAGONBALL_VCPUS: u32 = 256;
+pub const MIN_DRAGONBALL_MEMORY_SIZE: u32 = 64;
 // Default configuration for qemu
 pub const DEFAULT_QEMU_BINARY_PATH: &str = "qemu";
 pub const DEFAULT_QEMU_CONTROL_PATH: &str = "";

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -9,17 +9,12 @@
 use lazy_static::lazy_static;
 
 lazy_static! {
-    /// Default configuration file paths.
+    /// Default configuration file paths, vendor may extend the list
     pub static ref DEFAULT_RUNTIME_CONFIGURATIONS: Vec::<&'static str> = vec![
-        "/etc/kata-containers2/configuration.toml",
-        "/usr/share/defaults/kata-containers2/configuration.toml",
-        "/etc/kata-containers/configuration_v2.toml",
-        "/usr/share/defaults/kata-containers/configuration_v2.toml",
         "/etc/kata-containers/configuration.toml",
         "/usr/share/defaults/kata-containers/configuration.toml",
     ];
 }
-
 pub const DEFAULT_AGENT_NAME: &str = "kata";
 
 pub const DEFAULT_INTERNETWORKING_MODEL: &str = "tcfilter";
@@ -46,7 +41,7 @@ pub const DEFAULT_DB_ENTROPY_SOURCE: &str = "/dev/urandom";
 pub const DEFAULT_DB_MEMORY_SIZE: u32 = 128;
 pub const DEFAULT_DB_MEMORY_SLOTS: u32 = 128;
 pub const MAX_DB_VCPUS: u32 = 256;
-
+pub const MIN_DB_MEMORY_SIZE: u32 = 64;
 // Default configuration for qemu
 pub const DEFAULT_QEMU_BINARY_PATH: &str = "qemu";
 pub const DEFAULT_QEMU_CONTROL_PATH: &str = "";
@@ -60,3 +55,4 @@ pub const DEFAULT_QEMU_MEMORY_SLOTS: u32 = 128;
 pub const DEFAULT_QEMU_PCI_BRIDGES: u32 = 2;
 pub const MAX_QEMU_PCI_BRIDGES: u32 = 5;
 pub const MAX_QEMU_VCPUS: u32 = 256;
+pub const MIN_QEMU_MEMORY_SIZE: u32 = 64;

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Default configuration values.
+#![allow(missing_docs)]
+
+use lazy_static::lazy_static;
+
+lazy_static! {
+    /// Default configuration file paths.
+    pub static ref DEFAULT_RUNTIME_CONFIGURATIONS: Vec::<&'static str> = vec![
+        "/etc/kata-containers2/configuration.toml",
+        "/usr/share/defaults/kata-containers2/configuration.toml",
+        "/etc/kata-containers/configuration_v2.toml",
+        "/usr/share/defaults/kata-containers/configuration_v2.toml",
+        "/etc/kata-containers/configuration.toml",
+        "/usr/share/defaults/kata-containers/configuration.toml",
+    ];
+}
+
+pub const DEFAULT_INTERNETWORKING_MODEL: &str = "tcfilter";

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -21,3 +21,40 @@ lazy_static! {
 }
 
 pub const DEFAULT_INTERNETWORKING_MODEL: &str = "tcfilter";
+
+pub const DEFAULT_BLOCK_DEVICE_TYPE: &str = "virtio-blk";
+pub const DEFAULT_VHOST_USER_STORE_PATH: &str = "/var/run/vhost-user";
+pub const DEFAULT_BLOCK_NVDIMM_MEM_OFFSET: u64 = 0;
+
+pub const DEFAULT_SHARED_FS_TYPE: &str = "virtio-9p";
+pub const DEFAULT_VIRTIO_FS_CACHE_MODE: &str = "none";
+pub const DEFAULT_VIRTIO_FS_DAX_SIZE_MB: u32 = 1024;
+pub const DEFAULT_SHARED_9PFS_SIZE: u32 = 128 * 1024;
+pub const MIN_SHARED_9PFS_SIZE: u32 = 4 * 1024;
+pub const MAX_SHARED_9PFS_SIZE: u32 = 8 * 1024 * 1024;
+
+pub const DEFAULT_GUEST_HOOK_PATH: &str = "/opt";
+
+pub const DEFAULT_GUEST_VCPUS: u32 = 1;
+
+// Default configuration for Dragonball
+pub const DEFAULT_DB_GUEST_KENREL_IMAGE: &str = "vmlinuz";
+pub const DEFAULT_DB_GUEST_KENREL_PARAMS: &str = "";
+pub const DEFAULT_DB_ENTROPY_SOURCE: &str = "/dev/urandom";
+pub const DEFAULT_DB_MEMORY_SIZE: u32 = 128;
+pub const DEFAULT_DB_MEMORY_SLOTS: u32 = 128;
+pub const MAX_DB_VCPUS: u32 = 256;
+
+// Default configuration for qemu
+pub const DEFAULT_QEMU_BINARY_PATH: &str = "qemu";
+pub const DEFAULT_QEMU_CONTROL_PATH: &str = "";
+pub const DEFAULT_QEMU_MACHINE_TYPE: &str = "q35";
+pub const DEFAULT_QEMU_ENTROPY_SOURCE: &str = "/dev/urandom";
+pub const DEFAULT_QEMU_GUEST_KENREL_IMAGE: &str = "vmlinuz";
+pub const DEFAULT_QEMU_GUEST_KENREL_PARAMS: &str = "";
+pub const DEFAULT_QEMU_FIRMWARE_PATH: &str = "";
+pub const DEFAULT_QEMU_MEMORY_SIZE: u32 = 128;
+pub const DEFAULT_QEMU_MEMORY_SLOTS: u32 = 128;
+pub const DEFAULT_QEMU_PCI_BRIDGES: u32 = 2;
+pub const MAX_QEMU_PCI_BRIDGES: u32 = 5;
+pub const MAX_QEMU_VCPUS: u32 = 256;

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -20,6 +20,8 @@ lazy_static! {
     ];
 }
 
+pub const DEFAULT_AGENT_NAME: &str = "kata";
+
 pub const DEFAULT_INTERNETWORKING_MODEL: &str = "tcfilter";
 
 pub const DEFAULT_BLOCK_DEVICE_TYPE: &str = "virtio-blk";

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -26,33 +26,33 @@ pub const DEFAULT_BLOCK_NVDIMM_MEM_OFFSET: u64 = 0;
 pub const DEFAULT_SHARED_FS_TYPE: &str = "virtio-fs";
 pub const DEFAULT_VIRTIO_FS_CACHE_MODE: &str = "none";
 pub const DEFAULT_VIRTIO_FS_DAX_SIZE_MB: u32 = 1024;
-pub const DEFAULT_SHARED_9PFS_SIZE: u32 = 128 * 1024;
-pub const MIN_SHARED_9PFS_SIZE: u32 = 4 * 1024;
-pub const MAX_SHARED_9PFS_SIZE: u32 = 8 * 1024 * 1024;
+pub const DEFAULT_SHARED_9PFS_SIZE_MB: u32 = 128 * 1024;
+pub const MIN_SHARED_9PFS_SIZE_MB: u32 = 4 * 1024;
+pub const MAX_SHARED_9PFS_SIZE_MB: u32 = 8 * 1024 * 1024;
 
-pub const DEFAULT_GUEST_HOOK_PATH: &str = "/opt";
+pub const DEFAULT_GUEST_HOOK_PATH: &str = "/opt/kata/hooks";
 
 pub const DEFAULT_GUEST_VCPUS: u32 = 1;
 
-// Default configuration for Dragonball
+// Default configuration for dragonball
 pub const DEFAULT_DRAGONBALL_GUEST_KERNEL_IMAGE: &str = "vmlinuz";
 pub const DEFAULT_DRAGONBALL_GUEST_KERNEL_PARAMS: &str = "";
 pub const DEFAULT_DRAGONBALL_ENTROPY_SOURCE: &str = "/dev/urandom";
-pub const DEFAULT_DRAGONBALL_MEMORY_SIZE: u32 = 128;
+pub const DEFAULT_DRAGONBALL_MEMORY_SIZE_MB: u32 = 128;
 pub const DEFAULT_DRAGONBALL_MEMORY_SLOTS: u32 = 128;
 pub const MAX_DRAGONBALL_VCPUS: u32 = 256;
-pub const MIN_DRAGONBALL_MEMORY_SIZE: u32 = 64;
+pub const MIN_DRAGONBALL_MEMORY_SIZE_MB: u32 = 64;
 // Default configuration for qemu
-pub const DEFAULT_QEMU_BINARY_PATH: &str = "qemu";
+pub const DEFAULT_QEMU_BINARY_PATH: &str = "/usr/bin/qemu-system-x86_64";
 pub const DEFAULT_QEMU_CONTROL_PATH: &str = "";
 pub const DEFAULT_QEMU_MACHINE_TYPE: &str = "q35";
 pub const DEFAULT_QEMU_ENTROPY_SOURCE: &str = "/dev/urandom";
 pub const DEFAULT_QEMU_GUEST_KERNEL_IMAGE: &str = "vmlinuz";
 pub const DEFAULT_QEMU_GUEST_KERNEL_PARAMS: &str = "";
 pub const DEFAULT_QEMU_FIRMWARE_PATH: &str = "";
-pub const DEFAULT_QEMU_MEMORY_SIZE: u32 = 128;
+pub const DEFAULT_QEMU_MEMORY_SIZE_MB: u32 = 128;
 pub const DEFAULT_QEMU_MEMORY_SLOTS: u32 = 128;
 pub const DEFAULT_QEMU_PCI_BRIDGES: u32 = 2;
 pub const MAX_QEMU_PCI_BRIDGES: u32 = 5;
 pub const MAX_QEMU_VCPUS: u32 = 256;
-pub const MIN_QEMU_MEMORY_SIZE: u32 = 64;
+pub const MIN_QEMU_MEMORY_SIZE_MB: u32 = 64;

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -35,8 +35,8 @@ pub const DEFAULT_GUEST_HOOK_PATH: &str = "/opt";
 pub const DEFAULT_GUEST_VCPUS: u32 = 1;
 
 // Default configuration for Dragonball
-pub const DEFAULT_DB_GUEST_KENREL_IMAGE: &str = "vmlinuz";
-pub const DEFAULT_DB_GUEST_KENREL_PARAMS: &str = "";
+pub const DEFAULT_DB_GUEST_KERNEL_IMAGE: &str = "vmlinuz";
+pub const DEFAULT_DB_GUEST_KERNEL_PARAMS: &str = "";
 pub const DEFAULT_DB_ENTROPY_SOURCE: &str = "/dev/urandom";
 pub const DEFAULT_DB_MEMORY_SIZE: u32 = 128;
 pub const DEFAULT_DB_MEMORY_SLOTS: u32 = 128;
@@ -47,8 +47,8 @@ pub const DEFAULT_QEMU_BINARY_PATH: &str = "qemu";
 pub const DEFAULT_QEMU_CONTROL_PATH: &str = "";
 pub const DEFAULT_QEMU_MACHINE_TYPE: &str = "q35";
 pub const DEFAULT_QEMU_ENTROPY_SOURCE: &str = "/dev/urandom";
-pub const DEFAULT_QEMU_GUEST_KENREL_IMAGE: &str = "vmlinuz";
-pub const DEFAULT_QEMU_GUEST_KENREL_PARAMS: &str = "";
+pub const DEFAULT_QEMU_GUEST_KERNEL_IMAGE: &str = "vmlinuz";
+pub const DEFAULT_QEMU_GUEST_KERNEL_PARAMS: &str = "";
 pub const DEFAULT_QEMU_FIRMWARE_PATH: &str = "";
 pub const DEFAULT_QEMU_MEMORY_SIZE: u32 = 128;
 pub const DEFAULT_QEMU_MEMORY_SLOTS: u32 = 128;

--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -6,8 +6,11 @@
 use std::io::Result;
 use std::path::Path;
 use std::sync::Arc;
+use std::u32;
 
 use super::{default, register_hypervisor_plugin};
+use crate::config::default::MAX_DB_VCPUS;
+use crate::config::default::MIN_DB_MEMORY_SIZE;
 use crate::config::hypervisor::{
     VIRTIO_BLK, VIRTIO_BLK_MMIO, VIRTIO_FS, VIRTIO_FS_INLINE, VIRTIO_PMEM,
 };
@@ -35,6 +38,12 @@ impl DragonballConfig {
 }
 
 impl ConfigPlugin for DragonballConfig {
+    fn get_max_cpus(&self) -> u32 {
+        MAX_DB_VCPUS
+    }
+    fn get_min_memory(&self) -> u32 {
+        MIN_DB_MEMORY_SIZE
+    }
     fn name(&self) -> &str {
         HYPERVISOR_NAME_DRAGONBALL
     }

--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -54,10 +54,10 @@ impl ConfigPlugin for DragonballConfig {
             resolve_path!(db.jailer_path, "Dragonball jailer path {} is invalid: {}")?;
 
             if db.boot_info.kernel.is_empty() {
-                db.boot_info.kernel = default::DEFAULT_DB_GUEST_KENREL_IMAGE.to_string();
+                db.boot_info.kernel = default::DEFAULT_DB_GUEST_KERNEL_IMAGE.to_string();
             }
             if db.boot_info.kernel_params.is_empty() {
-                db.boot_info.kernel_params = default::DEFAULT_DB_GUEST_KENREL_PARAMS.to_string();
+                db.boot_info.kernel_params = default::DEFAULT_DB_GUEST_KERNEL_PARAMS.to_string();
             }
 
             if db.cpu_info.default_maxvcpus > default::MAX_DB_VCPUS {

--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -1,0 +1,176 @@
+// Copyright (c) 2019-2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::Result;
+use std::path::Path;
+use std::sync::Arc;
+
+use super::{default, register_hypervisor_plugin};
+use crate::config::hypervisor::{
+    VIRTIO_BLK, VIRTIO_BLK_MMIO, VIRTIO_FS, VIRTIO_FS_INLINE, VIRTIO_PMEM,
+};
+use crate::config::{ConfigPlugin, TomlConfig};
+use crate::{eother, resolve_path, validate_path};
+
+/// Hypervisor name for qemu, used to index `TomlConfig::hypervisor`.
+pub const HYPERVISOR_NAME_DRAGONBALL: &str = "dragonball";
+
+/// Configuration information for dragonball.
+#[derive(Default, Debug)]
+pub struct DragonballConfig {}
+
+impl DragonballConfig {
+    /// Create a new instance of `DragonballConfig`.
+    pub fn new() -> Self {
+        DragonballConfig {}
+    }
+
+    /// Register the dragonball plugin.
+    pub fn register(self) {
+        let plugin = Arc::new(self);
+        register_hypervisor_plugin(HYPERVISOR_NAME_DRAGONBALL, plugin);
+    }
+}
+
+impl ConfigPlugin for DragonballConfig {
+    fn name(&self) -> &str {
+        HYPERVISOR_NAME_DRAGONBALL
+    }
+
+    /// Adjust the configuration information after loading from configuration file.
+    fn adjust_configuration(&self, conf: &mut TomlConfig) -> Result<()> {
+        if let Some(db) = conf.hypervisor.get_mut(HYPERVISOR_NAME_DRAGONBALL) {
+            resolve_path!(db.jailer_path, "Dragonball jailer path {} is invalid: {}")?;
+
+            if db.boot_info.kernel.is_empty() {
+                db.boot_info.kernel = default::DEFAULT_DB_GUEST_KENREL_IMAGE.to_string();
+            }
+            if db.boot_info.kernel_params.is_empty() {
+                db.boot_info.kernel_params = default::DEFAULT_DB_GUEST_KENREL_PARAMS.to_string();
+            }
+
+            if db.cpu_info.default_maxvcpus > default::MAX_DB_VCPUS {
+                db.cpu_info.default_maxvcpus = default::MAX_DB_VCPUS;
+            }
+
+            if db.machine_info.entropy_source.is_empty() {
+                db.machine_info.entropy_source = default::DEFAULT_DB_ENTROPY_SOURCE.to_string();
+            }
+
+            if db.memory_info.default_memory == 0 {
+                db.memory_info.default_memory = default::DEFAULT_DB_MEMORY_SIZE;
+            }
+            if db.memory_info.memory_slots == 0 {
+                db.memory_info.memory_slots = default::DEFAULT_DB_MEMORY_SLOTS;
+            }
+        }
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    fn validate(&self, conf: &TomlConfig) -> Result<()> {
+        if let Some(db) = conf.hypervisor.get(HYPERVISOR_NAME_DRAGONBALL) {
+            if !db.path.is_empty() {
+                return Err(eother!("Path for dragonball hypervisor should be empty"));
+            }
+            if !db.valid_hypervisor_paths.is_empty() {
+                return Err(eother!(
+                    "Valid hypervisor path for dragonball hypervisor should be empty"
+                ));
+            }
+            if !db.ctlpath.is_empty() {
+                return Err(eother!("CtlPath for dragonball hypervisor should be empty"));
+            }
+            if !db.valid_ctlpaths.is_empty() {
+                return Err(eother!("CtlPath for dragonball hypervisor should be empty"));
+            }
+            validate_path!(db.jailer_path, "Dragonball jailer path {} is invalid: {}")?;
+            if db.enable_iothreads {
+                return Err(eother!("Dragonball hypervisor doesn't support IO threads."));
+            }
+
+            if !db.blockdev_info.disable_block_device_use
+                && db.blockdev_info.block_device_driver != VIRTIO_BLK
+                && db.blockdev_info.block_device_driver != VIRTIO_BLK_MMIO
+                && db.blockdev_info.block_device_driver != VIRTIO_PMEM
+            {
+                return Err(eother!(
+                    "{} is unsupported block device type.",
+                    db.blockdev_info.block_device_driver
+                ));
+            }
+
+            if db.boot_info.kernel.is_empty() {
+                return Err(eother!(
+                    "Guest kernel image for dragonball hypervisor is empty"
+                ));
+            }
+            if db.boot_info.image.is_empty() {
+                return Err(eother!(
+                    "Guest boot image for dragonball hypervisor is empty"
+                ));
+            }
+            if !db.boot_info.initrd.is_empty() {
+                return Err(eother!("Initrd for dragonball hypervisor should be empty"));
+            }
+            if !db.boot_info.firmware.is_empty() {
+                return Err(eother!(
+                    "Firmware for dragonball hypervisor should be empty"
+                ));
+            }
+
+            if (db.cpu_info.default_vcpus > 0
+                && db.cpu_info.default_vcpus as u32 > default::MAX_DB_VCPUS)
+                || db.cpu_info.default_maxvcpus > default::MAX_DB_VCPUS
+            {
+                return Err(eother!(
+                    "Dragonball hypervisor can not support {} vCPUs",
+                    db.cpu_info.default_maxvcpus
+                ));
+            }
+
+            if db.device_info.enable_iommu || db.device_info.enable_iommu_platform {
+                return Err(eother!("Dragonball hypervisor does not support vIOMMU"));
+            }
+            if db.device_info.hotplug_vfio_on_root_bus
+                || db.device_info.default_bridges > 0
+                || db.device_info.pcie_root_port > 0
+            {
+                return Err(eother!(
+                    "Dragonball hypervisor does not support PCI hotplug options"
+                ));
+            }
+
+            if !db.machine_info.machine_type.is_empty() {
+                return Err(eother!(
+                    "Dragonball hypervisor does not support machine_type"
+                ));
+            }
+            if !db.machine_info.pflashes.is_empty() {
+                return Err(eother!("Dragonball hypervisor does not support pflashes"));
+            }
+
+            if db.memory_info.enable_guest_swap {
+                return Err(eother!(
+                    "Dragonball hypervisor doesn't support enable_guest_swap"
+                ));
+            }
+
+            if db.security_info.rootless {
+                return Err(eother!(
+                    "Dragonball hypervisor does not support rootless mode"
+                ));
+            }
+
+            if let Some(v) = db.shared_fs.shared_fs.as_ref() {
+                if v != VIRTIO_FS && v != VIRTIO_FS_INLINE {
+                    return Err(eother!("Dragonball hypervisor doesn't support {}", v));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -9,8 +9,8 @@ use std::sync::Arc;
 use std::u32;
 
 use super::{default, register_hypervisor_plugin};
-use crate::config::default::MAX_DB_VCPUS;
-use crate::config::default::MIN_DB_MEMORY_SIZE;
+use crate::config::default::MAX_DRAGONBALL_VCPUS;
+use crate::config::default::MIN_DRAGONBALL_MEMORY_SIZE;
 use crate::config::hypervisor::{
     VIRTIO_BLK, VIRTIO_BLK_MMIO, VIRTIO_FS, VIRTIO_FS_INLINE, VIRTIO_PMEM,
 };
@@ -39,10 +39,10 @@ impl DragonballConfig {
 
 impl ConfigPlugin for DragonballConfig {
     fn get_max_cpus(&self) -> u32 {
-        MAX_DB_VCPUS
+        MAX_DRAGONBALL_VCPUS
     }
     fn get_min_memory(&self) -> u32 {
-        MIN_DB_MEMORY_SIZE
+        MIN_DRAGONBALL_MEMORY_SIZE
     }
     fn name(&self) -> &str {
         HYPERVISOR_NAME_DRAGONBALL
@@ -54,25 +54,27 @@ impl ConfigPlugin for DragonballConfig {
             resolve_path!(db.jailer_path, "Dragonball jailer path {} is invalid: {}")?;
 
             if db.boot_info.kernel.is_empty() {
-                db.boot_info.kernel = default::DEFAULT_DB_GUEST_KERNEL_IMAGE.to_string();
+                db.boot_info.kernel = default::DEFAULT_DRAGONBALL_GUEST_KERNEL_IMAGE.to_string();
             }
             if db.boot_info.kernel_params.is_empty() {
-                db.boot_info.kernel_params = default::DEFAULT_DB_GUEST_KERNEL_PARAMS.to_string();
+                db.boot_info.kernel_params =
+                    default::DEFAULT_DRAGONBALL_GUEST_KERNEL_PARAMS.to_string();
             }
 
-            if db.cpu_info.default_maxvcpus > default::MAX_DB_VCPUS {
-                db.cpu_info.default_maxvcpus = default::MAX_DB_VCPUS;
+            if db.cpu_info.default_maxvcpus > default::MAX_DRAGONBALL_VCPUS {
+                db.cpu_info.default_maxvcpus = default::MAX_DRAGONBALL_VCPUS;
             }
 
             if db.machine_info.entropy_source.is_empty() {
-                db.machine_info.entropy_source = default::DEFAULT_DB_ENTROPY_SOURCE.to_string();
+                db.machine_info.entropy_source =
+                    default::DEFAULT_DRAGONBALL_ENTROPY_SOURCE.to_string();
             }
 
             if db.memory_info.default_memory == 0 {
-                db.memory_info.default_memory = default::DEFAULT_DB_MEMORY_SIZE;
+                db.memory_info.default_memory = default::DEFAULT_DRAGONBALL_MEMORY_SIZE;
             }
             if db.memory_info.memory_slots == 0 {
-                db.memory_info.memory_slots = default::DEFAULT_DB_MEMORY_SLOTS;
+                db.memory_info.memory_slots = default::DEFAULT_DRAGONBALL_MEMORY_SLOTS;
             }
         }
         Ok(())
@@ -131,8 +133,8 @@ impl ConfigPlugin for DragonballConfig {
             }
 
             if (db.cpu_info.default_vcpus > 0
-                && db.cpu_info.default_vcpus as u32 > default::MAX_DB_VCPUS)
-                || db.cpu_info.default_maxvcpus > default::MAX_DB_VCPUS
+                && db.cpu_info.default_vcpus as u32 > default::MAX_DRAGONBALL_VCPUS)
+                || db.cpu_info.default_maxvcpus > default::MAX_DRAGONBALL_VCPUS
             {
                 return Err(eother!(
                     "Dragonball hypervisor can not support {} vCPUs",

--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -10,14 +10,14 @@ use std::u32;
 
 use super::{default, register_hypervisor_plugin};
 use crate::config::default::MAX_DRAGONBALL_VCPUS;
-use crate::config::default::MIN_DRAGONBALL_MEMORY_SIZE;
+use crate::config::default::MIN_DRAGONBALL_MEMORY_SIZE_MB;
 use crate::config::hypervisor::{
     VIRTIO_BLK, VIRTIO_BLK_MMIO, VIRTIO_FS, VIRTIO_FS_INLINE, VIRTIO_PMEM,
 };
 use crate::config::{ConfigPlugin, TomlConfig};
 use crate::{eother, resolve_path, validate_path};
 
-/// Hypervisor name for qemu, used to index `TomlConfig::hypervisor`.
+/// Hypervisor name for dragonball, used to index `TomlConfig::hypervisor`.
 pub const HYPERVISOR_NAME_DRAGONBALL: &str = "dragonball";
 
 /// Configuration information for dragonball.
@@ -42,16 +42,16 @@ impl ConfigPlugin for DragonballConfig {
         MAX_DRAGONBALL_VCPUS
     }
     fn get_min_memory(&self) -> u32 {
-        MIN_DRAGONBALL_MEMORY_SIZE
+        MIN_DRAGONBALL_MEMORY_SIZE_MB
     }
     fn name(&self) -> &str {
         HYPERVISOR_NAME_DRAGONBALL
     }
 
     /// Adjust the configuration information after loading from configuration file.
-    fn adjust_configuration(&self, conf: &mut TomlConfig) -> Result<()> {
+    fn adjust_config(&self, conf: &mut TomlConfig) -> Result<()> {
         if let Some(db) = conf.hypervisor.get_mut(HYPERVISOR_NAME_DRAGONBALL) {
-            resolve_path!(db.jailer_path, "Dragonball jailer path {} is invalid: {}")?;
+            resolve_path!(db.jailer_path, "dragonball jailer path {} is invalid: {}")?;
 
             if db.boot_info.kernel.is_empty() {
                 db.boot_info.kernel = default::DEFAULT_DRAGONBALL_GUEST_KERNEL_IMAGE.to_string();
@@ -71,7 +71,7 @@ impl ConfigPlugin for DragonballConfig {
             }
 
             if db.memory_info.default_memory == 0 {
-                db.memory_info.default_memory = default::DEFAULT_DRAGONBALL_MEMORY_SIZE;
+                db.memory_info.default_memory = default::DEFAULT_DRAGONBALL_MEMORY_SIZE_MB;
             }
             if db.memory_info.memory_slots == 0 {
                 db.memory_info.memory_slots = default::DEFAULT_DRAGONBALL_MEMORY_SLOTS;
@@ -97,9 +97,9 @@ impl ConfigPlugin for DragonballConfig {
             if !db.valid_ctlpaths.is_empty() {
                 return Err(eother!("CtlPath for dragonball hypervisor should be empty"));
             }
-            validate_path!(db.jailer_path, "Dragonball jailer path {} is invalid: {}")?;
+            validate_path!(db.jailer_path, "dragonball jailer path {} is invalid: {}")?;
             if db.enable_iothreads {
-                return Err(eother!("Dragonball hypervisor doesn't support IO threads."));
+                return Err(eother!("dragonball hypervisor doesn't support IO threads."));
             }
 
             if !db.blockdev_info.disable_block_device_use
@@ -137,48 +137,55 @@ impl ConfigPlugin for DragonballConfig {
                 || db.cpu_info.default_maxvcpus > default::MAX_DRAGONBALL_VCPUS
             {
                 return Err(eother!(
-                    "Dragonball hypervisor can not support {} vCPUs",
+                    "dragonball hypervisor can not support {} vCPUs",
                     db.cpu_info.default_maxvcpus
                 ));
             }
 
             if db.device_info.enable_iommu || db.device_info.enable_iommu_platform {
-                return Err(eother!("Dragonball hypervisor does not support vIOMMU"));
+                return Err(eother!("dragonball hypervisor does not support vIOMMU"));
             }
             if db.device_info.hotplug_vfio_on_root_bus
                 || db.device_info.default_bridges > 0
                 || db.device_info.pcie_root_port > 0
             {
                 return Err(eother!(
-                    "Dragonball hypervisor does not support PCI hotplug options"
+                    "dragonball hypervisor does not support PCI hotplug options"
                 ));
             }
 
             if !db.machine_info.machine_type.is_empty() {
                 return Err(eother!(
-                    "Dragonball hypervisor does not support machine_type"
+                    "dragonball hypervisor does not support machine_type"
                 ));
             }
             if !db.machine_info.pflashes.is_empty() {
-                return Err(eother!("Dragonball hypervisor does not support pflashes"));
+                return Err(eother!("dragonball hypervisor does not support pflashes"));
             }
 
             if db.memory_info.enable_guest_swap {
                 return Err(eother!(
-                    "Dragonball hypervisor doesn't support enable_guest_swap"
+                    "dragonball hypervisor doesn't support enable_guest_swap"
                 ));
             }
 
             if db.security_info.rootless {
                 return Err(eother!(
-                    "Dragonball hypervisor does not support rootless mode"
+                    "dragonball hypervisor does not support rootless mode"
                 ));
             }
 
             if let Some(v) = db.shared_fs.shared_fs.as_ref() {
                 if v != VIRTIO_FS && v != VIRTIO_FS_INLINE {
-                    return Err(eother!("Dragonball hypervisor doesn't support {}", v));
+                    return Err(eother!("dragonball hypervisor doesn't support {}", v));
                 }
+            }
+
+            if db.memory_info.default_memory < MIN_DRAGONBALL_MEMORY_SIZE_MB {
+                return Err(eother!(
+                    "dragonball hypervisor has minimal memory limitation {}",
+                    MIN_DRAGONBALL_MEMORY_SIZE_MB
+                ));
             }
         }
 

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -23,7 +23,7 @@
 //! hypervisors, so let's contain it...
 
 use std::collections::HashMap;
-use std::io::Result;
+use std::io::{self, Result};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
@@ -974,7 +974,9 @@ impl ConfigOps for Hypervisor {
             if let Some(plugin) = get_hypervisor_plugin(hypervisor) {
                 plugin.adjust_configuration(conf)?;
                 // Safe to unwrap() because `hypervisor` is a valid key in the hash map.
-                let hv = conf.hypervisor.get_mut(hypervisor).unwrap();
+                let hv = conf.hypervisor.get_mut(hypervisor).ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "hypervisor not found".to_string())
+                })?;
                 hv.blockdev_info.adjust_configuration()?;
                 hv.boot_info.adjust_configuration()?;
                 hv.cpu_info.adjust_configuration()?;

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1,0 +1,1052 @@
+// Copyright (c) 2019-2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Configuration information for hypervisors.
+//!
+//! The configuration information for hypervisors is complex, and different hypervisor requires
+//! different configuration information. To make it flexible and extensible, we build a multi-layer
+//! architecture to manipulate hypervisor configuration information.
+//! - the vendor layer. The `HypervisorVendor` structure provides hook points for vendors to
+//!   customize the configuration for its deployment.
+//! - the hypervisor plugin layer. The hypervisor plugin layer provides hook points for different
+//!   hypervisors to manipulate the configuration information.
+//! - the hypervisor common layer. This layer handles generic logic for all types of hypervisors.
+//!
+//! These three layers are applied in order. So changes made by the vendor layer will be visible
+//! to the hypervisor plugin layer and the common layer. And changes made by the plugin layer will
+//! only be visible to the common layer.
+//!
+//! Ideally the hypervisor configuration information should be split into hypervisor specific
+//! part and common part. But the Kata 2.0 has adopted a policy to build a superset for all
+//! hypervisors, so let's contain it...
+
+use std::collections::HashMap;
+use std::io::Result;
+use std::path::Path;
+use std::sync::{Arc, Mutex};
+
+use lazy_static::lazy_static;
+use regex::RegexSet;
+
+use super::{default, ConfigOps, ConfigPlugin, TomlConfig};
+use crate::{eother, resolve_path, validate_path};
+
+mod dragonball;
+pub use self::dragonball::{DragonballConfig, HYPERVISOR_NAME_DRAGONBALL};
+
+mod qemu;
+pub use self::qemu::{QemuConfig, HYPERVISOR_NAME_QEMU};
+
+const VIRTIO_BLK: &str = "virtio-blk";
+const VIRTIO_BLK_MMIO: &str = "virtio-mmio";
+const VIRTIO_BLK_CCW: &str = "virtio-blk-ccw";
+const VIRTIO_SCSI: &str = "virtio-scsi";
+const VIRTIO_PMEM: &str = "nvdimm";
+const VIRTIO_9P: &str = "virtio-9p";
+const VIRTIO_FS: &str = "virtio-fs";
+const VIRTIO_FS_INLINE: &str = "inline-virtio-fs";
+
+lazy_static! {
+    static ref HYPERVISOR_PLUGINS: Mutex<HashMap<String, Arc<dyn ConfigPlugin>>> =
+        Mutex::new(HashMap::new());
+}
+
+/// Register a hypervisor plugin with `name`.
+pub fn register_hypervisor_plugin(name: &str, plugin: Arc<dyn ConfigPlugin>) {
+    let mut hypervisors = HYPERVISOR_PLUGINS.lock().unwrap();
+    hypervisors.insert(name.to_string(), plugin);
+}
+
+/// Get the hypervisor plugin with `name`.
+pub fn get_hypervisor_plugin(name: &str) -> Option<Arc<dyn ConfigPlugin>> {
+    let hypervisors = HYPERVISOR_PLUGINS.lock().unwrap();
+    hypervisors.get(name).cloned()
+}
+
+/// Configuration information for block device.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct BlockDeviceInfo {
+    /// Disable block device from being used for a container's rootfs.
+    ///
+    /// In case of a storage driver like devicemapper where a container's root file system is
+    /// backed by a block device, the block device is passed directly to the hypervisor for
+    /// performance reasons. This flag prevents the block device from being passed to the
+    /// hypervisor, shared fs is used instead to pass the rootfs.
+    #[serde(default)]
+    pub disable_block_device_use: bool,
+
+    /// Block storage driver to be used for the hypervisor in case the container rootfs is backed
+    /// by a block device. This is virtio-scsi, virtio-blk or nvdimm.
+    #[serde(default)]
+    pub block_device_driver: String,
+
+    /// Specifies cache-related options will be set to block devices or not.
+    #[serde(default)]
+    pub block_device_cache_set: bool,
+
+    /// Specifies cache-related options for block devices.
+    ///
+    /// Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
+    #[serde(default)]
+    pub block_device_cache_direct: bool,
+
+    /// Specifies cache-related options for block devices.
+    /// Denotes whether flush requests for the device are ignored.
+    #[serde(default)]
+    pub block_device_cache_noflush: bool,
+
+    /// If false and nvdimm is supported, use nvdimm device to plug guest image.
+    #[serde(default)]
+    pub disable_image_nvdimm: bool,
+
+    /// The size in MiB will be plused to max memory of hypervisor.
+    ///
+    /// It is the memory address space for the NVDIMM devie. If set block storage driver
+    /// (block_device_driver) to "nvdimm", should set memory_offset to the size of block device.
+    #[serde(default)]
+    pub memory_offset: u64,
+
+    /// Enable vhost-user storage device, default false
+    ///
+    /// Enabling this will result in some Linux reserved block type major range 240-254 being
+    /// chosen to represent vhost-user devices.
+    #[serde(default)]
+    pub enable_vhost_user_store: bool,
+
+    /// The base directory specifically used for vhost-user devices.
+    ///
+    /// Its sub-path "block" is used for block devices; "block/sockets" is where we expect
+    /// vhost-user sockets to live; "block/devices" is where simulated block device nodes for
+    /// vhost-user devices to live.
+    #[serde(default)]
+    pub vhost_user_store_path: String,
+
+    /// List of valid annotations values for the vhost user store path.
+    ///
+    /// The default if not set is empty (all annotations rejected.)
+    #[serde(default)]
+    pub valid_vhost_user_store_paths: Vec<String>,
+}
+
+impl BlockDeviceInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        if self.disable_block_device_use {
+            self.block_device_driver = "".to_string();
+            self.enable_vhost_user_store = false;
+            self.memory_offset = 0;
+            return Ok(());
+        }
+
+        if self.block_device_driver.is_empty() {
+            self.block_device_driver = default::DEFAULT_BLOCK_DEVICE_TYPE.to_string();
+        }
+        if self.memory_offset == 0 {
+            self.memory_offset = default::DEFAULT_BLOCK_NVDIMM_MEM_OFFSET;
+        }
+        if !self.enable_vhost_user_store {
+            self.vhost_user_store_path = String::new();
+        } else if self.vhost_user_store_path.is_empty() {
+            self.vhost_user_store_path = default::DEFAULT_VHOST_USER_STORE_PATH.to_string();
+        }
+        resolve_path!(
+            self.vhost_user_store_path,
+            "Invalid vhost-user-store-path {}: {}"
+        )?;
+
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        if self.disable_block_device_use {
+            return Ok(());
+        }
+        if self.block_device_driver != VIRTIO_BLK
+            && self.block_device_driver != VIRTIO_BLK_CCW
+            && self.block_device_driver != VIRTIO_BLK_MMIO
+            && self.block_device_driver != VIRTIO_SCSI
+            && self.block_device_driver != VIRTIO_PMEM
+        {
+            return Err(eother!(
+                "{} is unsupported block device type.",
+                self.block_device_driver
+            ));
+        }
+        validate_path!(
+            self.vhost_user_store_path,
+            "Invalid vhost-user-store-path {}: {}"
+        )?;
+
+        Ok(())
+    }
+
+    /// Validate path of vhost-user storage backend.
+    pub fn validate_vhost_user_store_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        validate_path_pattern(&self.valid_vhost_user_store_paths, path)
+    }
+}
+
+/// Guest kernel boot information.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct BootInfo {
+    /// Path to guest kernel file on host
+    #[serde(default)]
+    pub kernel: String,
+    /// Guest kernel commandline.
+    #[serde(default)]
+    pub kernel_params: String,
+    /// Path to initrd file on host
+    #[serde(default)]
+    pub initrd: String,
+    /// Path to root device on host
+    #[serde(default)]
+    pub image: String,
+    /// Path to the firmware.
+    ///
+    /// If you want that qemu uses the default firmware leave this option empty.
+    #[serde(default)]
+    pub firmware: String,
+}
+
+impl BootInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        resolve_path!(self.kernel, "guest kernel image file {} is invalid: {}")?;
+        resolve_path!(self.image, "guest boot image file {} is invalid: {}")?;
+        resolve_path!(self.initrd, "guest initrd image file {} is invalid: {}")?;
+        resolve_path!(self.firmware, "firmware image file {} is invalid: {}")?;
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        validate_path!(self.kernel, "guest kernel image file {} is invalid: {}")?;
+        validate_path!(self.image, "guest boot image file {} is invalid: {}")?;
+        validate_path!(self.initrd, "guest initrd image file {} is invalid: {}")?;
+        validate_path!(self.firmware, "firmware image file {} is invalid: {}")?;
+        if !self.image.is_empty() && !self.initrd.is_empty() {
+            return Err(eother!("Can not configure both initrd and image for boot"));
+        }
+        Ok(())
+    }
+}
+
+/// Virtual CPU configuration information.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct CpuInfo {
+    /// CPU features, comma-separated list of cpu features to pass to the cpu.
+    /// For example, `cpu_features = "pmu=off,vmx=off"
+    #[serde(default)]
+    pub cpu_features: String,
+
+    /// Default number of vCPUs per SB/VM:
+    /// - unspecified or 0                --> will be set to @DEFVCPUS@
+    /// - < 0                             --> will be set to the actual number of physical cores
+    ///  > 0 <= number of physical cores --> will be set to the specified number
+    ///  > number of physical cores      --> will be set to the actual number of physical cores
+    #[serde(default)]
+    pub default_vcpus: i32,
+
+    /// Default maximum number of vCPUs per SB/VM:
+    /// - unspecified or == 0             --> will be set to the actual number of physical cores or
+    ///                                       to the maximum number of vCPUs supported by KVM
+    ///                                       if that number is exceeded
+    /// - > 0 <= number of physical cores --> will be set to the specified number
+    /// - > number of physical cores      --> will be set to the actual number of physical cores or
+    ///                                       to the maximum number of vCPUs supported by KVM
+    ///                                       if that number is exceeded
+    ///
+    /// WARNING: Depending of the architecture, the maximum number of vCPUs supported by KVM is used
+    /// when the actual number of physical cores is greater than it.
+    ///
+    /// WARNING: Be aware that this value impacts the virtual machine's memory footprint and CPU
+    /// the hotplug functionality. For example, `default_maxvcpus = 240` specifies that until 240
+    /// vCPUs can be added to a SB/VM, but the memory footprint will be big. Another example, with
+    /// `default_maxvcpus = 8` the memory footprint will be small, but 8 will be the maximum number
+    /// of vCPUs supported by the SB/VM. In general, we recommend that you do not edit this
+    /// variable, unless you know what are you doing.
+    ///
+    /// NOTICE: on arm platform with gicv2 interrupt controller, set it to 8.
+    #[serde(default)]
+    pub default_maxvcpus: u32,
+}
+
+impl CpuInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        let features: Vec<&str> = self.cpu_features.split(',').map(|v| v.trim()).collect();
+        self.cpu_features = features.join(",");
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Get default number of guest vCPUs.
+    pub fn get_default_vcpus(&self) -> u32 {
+        let cpus = num_cpus::get() as u32;
+        if self.default_vcpus < 0 || self.default_vcpus as u32 > cpus {
+            cpus
+        } else if self.default_vcpus == 0 {
+            default::DEFAULT_GUEST_VCPUS
+        } else {
+            self.default_vcpus as u32
+        }
+    }
+
+    /// Get default maximal number of guest vCPUs.
+    pub fn get_default_max_vcpus(&self) -> u32 {
+        let cpus = num_cpus::get() as u32;
+        if self.default_maxvcpus == 0 || self.default_maxvcpus > cpus {
+            cpus
+        } else {
+            self.default_maxvcpus
+        }
+    }
+}
+
+/// Configuration information for shared filesystem, such virtio-9p and virtio-fs.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct DebugInfo {
+    /// This option changes the default hypervisor and kernel parameters to enable debug output
+    /// where available.
+    #[serde(default)]
+    pub enable_debug: bool,
+
+    /// Enable dumping information about guest page structures if true.
+    #[serde(default)]
+    pub guest_memory_dump_paging: bool,
+
+    /// Set where to save the guest memory dump file.
+    ///
+    /// If set, when GUEST_PANICKED event occurred, guest memory will be dumped to host filesystem
+    /// under guest_memory_dump_path. This directory will be created automatically if it does not
+    /// exist. The dumped file(also called vmcore) can be processed with crash or gdb.
+    ///
+    /// # WARNING:
+    ///  Dump guest’s memory can take very long depending on the amount of guest memory and use
+    /// much disk space.
+    #[serde(default)]
+    pub guest_memory_dump_path: String,
+}
+
+impl DebugInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Virtual machine device configuration information.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct DeviceInfo {
+    /// Bridges can be used to hot plug devices.
+    ///
+    /// Limitations:
+    /// - Currently only pci bridges are supported
+    /// - Until 30 devices per bridge can be hot plugged.
+    /// - Until 5 PCI bridges can be cold plugged per VM.
+    ///
+    /// This limitation could be a bug in qemu or in the kernel
+    /// Default number of bridges per SB/VM:
+    /// - unspecified or 0   --> will be set to @DEFBRIDGES@
+    /// - > 1 <= 5           --> will be set to the specified number
+    /// - > 5                --> will be set to 5
+    #[serde(default)]
+    pub default_bridges: u32,
+
+    /// VFIO devices are hotplugged on a bridge by default.
+    ///
+    /// Enable hotplugging on root bus. This may be required for devices with a large PCI bar,
+    /// as this is a current limitation with hotplugging on a bridge.
+    #[serde(default)]
+    pub hotplug_vfio_on_root_bus: bool,
+
+    /// Before hot plugging a PCIe device, you need to add a pcie_root_port device.
+    ///
+    /// Use this parameter when using some large PCI bar devices, such as Nvidia GPU.
+    /// The value means the number of pcie_root_port.
+    /// This value is valid when hotplug_vfio_on_root_bus is true and machine_type is "q35"
+    #[serde(default)]
+    pub pcie_root_port: u32,
+
+    /// Enable vIOMMU, default false
+    ///
+    /// Enabling this will result in the VM having a vIOMMU device. This will also add the
+    /// following options to the kernel's command line: intel_iommu=on,iommu=pt
+    #[serde(default)]
+    pub enable_iommu: bool,
+
+    /// Enable IOMMU_PLATFORM, default false
+    ///
+    /// Enabling this will result in the VM device having iommu_platform=on set
+    #[serde(default)]
+    pub enable_iommu_platform: bool,
+}
+
+impl DeviceInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        if self.default_bridges > 5 {
+            self.default_bridges = 5;
+        }
+
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        if self.default_bridges > 5 {
+            return Err(eother!(
+                "The configured PCI bridges {} is too big",
+                self.default_bridges
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Configuration information for virtual machine.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct MachineInfo {
+    /// Virtual machine model/type.
+    #[serde(default)]
+    pub machine_type: String,
+
+    /// Machine accelerators.
+    /// Comma-separated list of machine accelerators to pass to the hypervisor.
+    /// For example, `machine_accelerators = "nosmm,nosmbus,nosata,nopit,static-prt,nofw"`
+    #[serde(default)]
+    pub machine_accelerators: String,
+
+    /// Add flash image file to VM.
+    ///
+    /// The arguments of it should be in format of ["/path/to/flash0.img", "/path/to/flash1.img"].
+    #[serde(default)]
+    pub pflashes: Vec<String>,
+
+    /// Default entropy source.
+    /// The path to a host source of entropy (including a real hardware RNG).
+    /// `/dev/urandom` and `/dev/random` are two main options. Be aware that `/dev/random` is a
+    /// blocking source of entropy.  If the host runs out of entropy, the VMs boot time will
+    /// increase leading to get startup timeouts. The source of entropy `/dev/urandom` is
+    /// non-blocking and provides a generally acceptable source of entropy. It should work well
+    /// for pretty much all practical purposes.
+    #[serde(default)]
+    pub entropy_source: String,
+
+    /// List of valid annotations values for entropy_source.
+    /// The default if not set is empty (all annotations rejected.)
+    #[serde(default)]
+    pub valid_entropy_sources: Vec<String>,
+}
+
+impl MachineInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        let accelerators: Vec<&str> = self
+            .machine_accelerators
+            .split(',')
+            .map(|v| v.trim())
+            .collect();
+        self.machine_accelerators = accelerators.join(",");
+
+        for pflash in self.pflashes.iter_mut() {
+            resolve_path!(*pflash, "Flash image file {} is invalide: {}")?;
+        }
+        resolve_path!(self.entropy_source, "Entropy source {} is invalid: {}")?;
+
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        for pflash in self.pflashes.iter() {
+            validate_path!(*pflash, "Flash image file {} is invalide: {}")?;
+        }
+        validate_path!(self.entropy_source, "Entropy source {} is invalid: {}")?;
+        Ok(())
+    }
+
+    /// Validate path of entropy source.
+    pub fn validate_entropy_source<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        validate_path_pattern(&self.valid_entropy_sources, path)
+    }
+}
+
+/// Virtual machine memory configuration information.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct MemoryInfo {
+    /// Default memory size in MiB for SB/VM.
+    #[serde(default)]
+    pub default_memory: u32,
+
+    /// Default memory slots per SB/VM.
+    ///
+    /// This is will determine the times that memory will be hotadded to sandbox/VM.
+    #[serde(default)]
+    pub memory_slots: u32,
+
+    /// Enable file based guest memory support.
+    ///
+    /// The default is an empty string which will disable this feature. In the case of virtio-fs,
+    /// this is enabled automatically and '/dev/shm' is used as the backing folder. This option
+    /// will be ignored if VM templating is enabled.
+    #[serde(default)]
+    pub file_mem_backend: String,
+
+    /// List of valid annotations values for the file_mem_backend annotation
+    ///
+    /// The default if not set is empty (all annotations rejected.)
+    #[serde(default)]
+    pub valid_file_mem_backends: Vec<String>,
+
+    /// Enable pre allocation of VM RAM, default false
+    ///
+    /// Enabling this will result in lower container density as all of the memory will be allocated
+    /// and locked. This is useful when you want to reserve all the memory upfront or in the cases
+    /// where you want memory latencies to be very predictable
+    #[serde(default)]
+    pub enable_mem_prealloc: bool,
+
+    /// Enable huge pages for VM RAM, default false
+    ///
+    /// Enabling this will result in the VM memory being allocated using huge pages. This is useful
+    /// when you want to use vhost-user network stacks within the container. This will automatically
+    /// result in memory pre allocation.
+    #[serde(default)]
+    pub enable_hugepages: bool,
+
+    /// Specifies virtio-mem will be enabled or not.
+    ///
+    /// Please note that this option should be used with the command
+    /// "echo 1 > /proc/sys/vm/overcommit_memory".
+    #[serde(default)]
+    pub enable_virtio_mem: bool,
+
+    /// Enable swap of vm memory. Default false.
+    ///
+    /// The behaviour is undefined if mem_prealloc is also set to true
+    #[serde(default)]
+    pub enable_swap: bool,
+
+    /// Enable swap in the guest. Default false.
+    ///
+    /// When enable_guest_swap is enabled, insert a raw file to the guest as the swap device if the
+    /// swappiness of a container (set by annotation "io.katacontainers.container.resource.swappiness")
+    /// is bigger than 0.
+    ///
+    /// The size of the swap device should be swap_in_bytes (set by annotation
+    /// "io.katacontainers.container.resource.swap_in_bytes") - memory_limit_in_bytes.
+    /// If swap_in_bytes is not set, the size should be memory_limit_in_bytes.
+    /// If swap_in_bytes and memory_limit_in_bytes is not set, the size should be default_memory.
+    #[serde(default)]
+    pub enable_guest_swap: bool,
+}
+
+impl MemoryInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        resolve_path!(
+            self.file_mem_backend,
+            "Memory backend file {} is invalid: {}"
+        )?;
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        validate_path!(
+            self.file_mem_backend,
+            "Memory backend file {} is invalid: {}"
+        )?;
+        if self.default_memory == 0 {
+            return Err(eother!("Configured memory size for guest vm is zero"));
+        }
+        if self.memory_slots == 0 {
+            return Err(eother!("Configured memory slots for guest vm is zero"));
+        }
+
+        Ok(())
+    }
+
+    /// Validate path of memory backend files.
+    pub fn validate_memory_backend_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        validate_path_pattern(&self.valid_file_mem_backends, path)
+    }
+}
+
+/// Configuration information for virtual machine.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct NetworkInfo {
+    /// If vhost-net backend for virtio-net is not desired, set to true.
+    ///
+    /// Default is false, which trades off security (vhost-net runs ring0) for network I/O
+    /// performance.
+    #[serde(default)]
+    pub disable_vhost_net: bool,
+
+    /// Use rx Rate Limiter to control network I/O inbound bandwidth(size in bits/sec for SB/VM).
+    ///
+    /// In Qemu, we use classful qdiscs HTB(Hierarchy Token Bucket) to discipline traffic.
+    /// Default 0-sized value means unlimited rate.
+    #[serde(default)]
+    pub rx_rate_limiter_max_rate: u64,
+
+    /// Use tx Rate Limiter to control network I/O outbound bandwidth(size in bits/sec for SB/VM).
+    ///
+    /// In Qemu, we use classful qdiscs HTB(Hierarchy Token Bucket) and ifb(Intermediate Functional
+    /// Block) to discipline traffic.
+    /// Default 0-sized value means unlimited rate.
+    #[serde(default)]
+    pub tx_rate_limiter_max_rate: u64,
+}
+
+impl NetworkInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Configuration information for virtual machine.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct SecurityInfo {
+    /// Enable running QEMU VMM as a non-root user.
+    ///
+    /// By default QEMU VMM run as root. When this is set to true, QEMU VMM process runs as
+    /// a non-root random user. See documentation for the limitations of this mode.
+    #[serde(default)]
+    pub rootless: bool,
+
+    /// Disable seccomp.
+    #[serde(default)]
+    pub disable_seccomp: bool,
+
+    /// Enable confidential guest support.
+    ///
+    /// Toggling that setting may trigger different hardware features, ranging from memory
+    /// encryption to both memory and CPU-state encryption and integrity.The Kata Containers
+    /// runtime dynamically detects the available feature set and aims at enabling the largest
+    /// possible one.
+    #[serde(default)]
+    pub confidential_guest: bool,
+
+    /// Path to OCI hook binaries in the *guest rootfs*.
+    ///
+    /// This does not affect host-side hooks which must instead be added to the OCI spec passed to
+    /// the runtime.
+    ///
+    /// You can create a rootfs with hooks by customizing the osbuilder scripts:
+    /// https://github.com/kata-containers/kata-containers/tree/main/tools/osbuilder
+    ///
+    /// Hooks must be stored in a subdirectory of guest_hook_path according to their hook type,
+    /// i.e. "guest_hook_path/{prestart,poststart,poststop}". The agent will scan these directories
+    /// for executable files and add them, in lexicographical order, to the lifecycle of the guest
+    /// container.
+    ///
+    /// Hooks are executed in the runtime namespace of the guest. See the official documentation:
+    /// https://github.com/opencontainers/runtime-spec/blob/v1.0.1/config.md#posix-platform-hooks
+    ///
+    /// Warnings will be logged if any error is encountered while scanning for hooks, but it will
+    /// not abort container execution.
+    #[serde(default)]
+    pub guest_hook_path: String,
+
+    /// List of valid annotation names for the hypervisor.
+    ///
+    /// Each member of the list is a regular expression, which is the base name of the annotation,
+    /// e.g. "path" for io.katacontainers.config.hypervisor.path"
+    #[serde(default)]
+    pub enable_annotations: Vec<String>,
+}
+
+impl SecurityInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        if self.guest_hook_path.is_empty() {
+            self.guest_hook_path = default::DEFAULT_GUEST_HOOK_PATH.to_string();
+        }
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Check whether annotation key is enabled or not.
+    pub fn is_annotation_enabled(&self, path: &str) -> bool {
+        if !path.starts_with("io.katacontainers.config.hypervisor.") {
+            return false;
+        }
+        let pos = "io.katacontainers.config.hypervisor.".len();
+        let key = &path[pos..];
+        if let Ok(set) = RegexSet::new(&self.enable_annotations) {
+            return set.is_match(key);
+        }
+
+        false
+    }
+}
+
+/// Configuration information for shared filesystem, such virtio-9p and virtio-fs.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct SharedFsInfo {
+    /// Shared file system type:
+    /// - virtio-fs (default)
+    /// - virtio-9p`
+    pub shared_fs: Option<String>,
+
+    /// Path to vhost-user-fs daemon.
+    #[serde(default)]
+    pub virtio_fs_daemon: String,
+
+    /// List of valid annotations values for the virtiofs daemon
+    /// The default if not set is empty (all annotations rejected.)
+    #[serde(default)]
+    pub valid_virtio_fs_daemon_paths: Vec<String>,
+
+    /// Extra args for virtiofsd daemon
+    ///
+    /// Format example:
+    ///    ["-o", "arg1=xxx,arg2", "-o", "hello world", "--arg3=yyy"]
+    ///
+    ///  see `virtiofsd -h` for possible options.
+    #[serde(default)]
+    pub virtio_fs_extra_args: Vec<String>,
+
+    /// Cache mode:
+    /// - none: Metadata, data, and pathname lookup are not cached in guest. They are always
+    ///   fetched from host and any changes are immediately pushed to host.
+    /// - auto: Metadata and pathname lookup cache expires after a configured amount of time
+    ///   (default is 1 second). Data is cached while the file is open (close to open consistency).
+    /// - always: Metadata, data, and pathname lookup are cached in guest and never expire.
+    #[serde(default)]
+    pub virtio_fs_cache: String,
+
+    /// Default size of DAX cache in MiB
+    #[serde(default)]
+    pub virtio_fs_cache_size: u32,
+
+    /// Enable virtio-fs DAX window if true.
+    #[serde(default)]
+    pub virtio_fs_is_dax: bool,
+
+    /// This is the msize used for 9p shares. It is the number of bytes used for 9p packet payload.
+    #[serde(default)]
+    pub msize_9p: u32,
+}
+
+impl SharedFsInfo {
+    /// Adjust the configuration information after loading from configuration file.
+    pub fn adjust_configuration(&mut self) -> Result<()> {
+        if self.shared_fs.as_deref() == Some("") {
+            self.shared_fs = Some(default::DEFAULT_SHARED_FS_TYPE.to_string());
+        }
+        match self.shared_fs.as_deref() {
+            Some(VIRTIO_FS) => self.adjust_virtio_fs(false)?,
+            Some(VIRTIO_FS_INLINE) => self.adjust_virtio_fs(true)?,
+            Some(VIRTIO_9P) => {
+                if self.msize_9p == 0 {
+                    self.msize_9p = default::DEFAULT_SHARED_9PFS_SIZE;
+                }
+            }
+            _ => {}
+        }
+
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    pub fn validate(&self) -> Result<()> {
+        match self.shared_fs.as_deref() {
+            None => Ok(()),
+            Some(VIRTIO_FS) => self.validate_virtio_fs(false),
+            Some(VIRTIO_FS_INLINE) => self.validate_virtio_fs(true),
+            Some(VIRTIO_9P) => {
+                if self.msize_9p < default::MIN_SHARED_9PFS_SIZE
+                    || self.msize_9p > default::MAX_SHARED_9PFS_SIZE
+                {
+                    return Err(eother!(
+                        "Invalid 9p configuration msize 0x{:x}",
+                        self.msize_9p
+                    ));
+                }
+                Ok(())
+            }
+            Some(v) => Err(eother!("Invalid shared_fs type {}", v)),
+        }
+    }
+
+    /// Validate path of virtio-fs daemon, especially for annotations.
+    pub fn validate_virtiofs_daemon_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        validate_path_pattern(&self.valid_virtio_fs_daemon_paths, path)
+    }
+
+    fn adjust_virtio_fs(&mut self, _inline: bool) -> Result<()> {
+        resolve_path!(
+            self.virtio_fs_daemon,
+            "Virtio-fs daemon path {} is invalid: {}"
+        )?;
+        if self.virtio_fs_cache.is_empty() {
+            self.virtio_fs_cache = default::DEFAULT_VIRTIO_FS_CACHE_MODE.to_string();
+        }
+        if self.virtio_fs_is_dax && self.virtio_fs_cache_size == 0 {
+            self.virtio_fs_cache_size = default::DEFAULT_VIRTIO_FS_DAX_SIZE_MB;
+        }
+        if !self.virtio_fs_is_dax && self.virtio_fs_cache_size != 0 {
+            self.virtio_fs_is_dax = true;
+        }
+        Ok(())
+    }
+
+    fn validate_virtio_fs(&self, inline: bool) -> Result<()> {
+        if inline && !self.virtio_fs_daemon.is_empty() {
+            return Err(eother!(
+                "Executable path for inline-virtio-fs is not empty: {}",
+                &self.virtio_fs_daemon
+            ));
+        }
+        validate_path!(
+            self.virtio_fs_daemon,
+            "Virtio-fs daemon path {} is invalid: {}"
+        )?;
+
+        if self.virtio_fs_cache != "none"
+            && self.virtio_fs_cache != "auto"
+            && self.virtio_fs_cache != "always"
+        {
+            return Err(eother!(
+                "Invalid virtio-fs cache mode: {}",
+                &self.virtio_fs_cache
+            ));
+        }
+        if self.virtio_fs_is_dax && self.virtio_fs_cache_size == 0 {
+            return Err(eother!(
+                "Invalid virtio-fs DAX window size: {}",
+                &self.virtio_fs_cache_size
+            ));
+        }
+        Ok(())
+    }
+}
+
+/// Common configuration information for hypervisors.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Hypervisor {
+    /// Path to the hypervisor executable.
+    #[serde(default)]
+    pub path: String,
+    /// List of valid annotations values for the hypervisor.
+    ///
+    /// Each member of the list is a path pattern as described by glob(3). The default if not set
+    /// is empty (all annotations rejected.)
+    #[serde(default)]
+    pub valid_hypervisor_paths: Vec<String>,
+
+    /// Hypervisor control executable path.
+    #[serde(default)]
+    pub ctlpath: String,
+    /// List of valid annotations values for the hypervisor control executable.
+    ///
+    /// Each member of the list is a path pattern as described by glob(3). The default if not set
+    /// is empty (all annotations rejected.)
+    #[serde(default)]
+    pub valid_ctlpaths: Vec<String>,
+
+    /// Control channel path.
+    #[serde(default)]
+    pub jailer_path: String,
+    /// List of valid annotations values for the hypervisor jailer path.
+    ///
+    /// Each member of the list is a path pattern as described by glob(3). The default if not set
+    /// is empty (all annotations rejected.)
+    #[serde(default)]
+    pub valid_jailer_paths: Vec<String>,
+
+    /// Disable the customizations done in the runtime when it detects that it is running on top
+    /// a VMM. This will result in the runtime behaving as it would when running on bare metal.
+    #[serde(default)]
+    pub disable_nesting_checks: bool,
+
+    /// Enable iothreads (data-plane) to be used. This causes IO to be handled in a separate IO
+    /// thread. This is currently only implemented for SCSI.
+    #[serde(default)]
+    pub enable_iothreads: bool,
+
+    /// Block device configuration information.
+    #[serde(default, flatten)]
+    pub blockdev_info: BlockDeviceInfo,
+
+    /// Guest system boot information.
+    #[serde(default, flatten)]
+    pub boot_info: BootInfo,
+
+    /// Guest virtual CPU configuration information.
+    #[serde(default, flatten)]
+    pub cpu_info: CpuInfo,
+
+    /// Debug configuration information.
+    #[serde(default, flatten)]
+    pub debug_info: DebugInfo,
+
+    /// Device configuration information.
+    #[serde(default, flatten)]
+    pub device_info: DeviceInfo,
+
+    /// Virtual machine configuration information.
+    #[serde(default, flatten)]
+    pub machine_info: MachineInfo,
+
+    /// Virtual machine memory configuration information.
+    #[serde(default, flatten)]
+    pub memory_info: MemoryInfo,
+
+    /// Network configuration information.
+    #[serde(default, flatten)]
+    pub network_info: NetworkInfo,
+
+    /// Security configuration information.
+    #[serde(default, flatten)]
+    pub security_info: SecurityInfo,
+
+    /// Shared file system configuration information.
+    #[serde(default, flatten)]
+    pub shared_fs: SharedFsInfo,
+
+    /// Vendor customized runtime configuration.
+    #[serde(default, flatten)]
+    pub vendor: HypervisorVendor,
+}
+
+impl Hypervisor {
+    /// Validate path of hypervisor executable.
+    pub fn validate_hypervisor_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        validate_path_pattern(&self.valid_hypervisor_paths, path)
+    }
+
+    /// Validate path of hypervisor control executable.
+    pub fn validate_hypervisor_ctlpath<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        validate_path_pattern(&self.valid_ctlpaths, path)
+    }
+
+    /// Validate path of jailer executable.
+    pub fn validate_jailer_path<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        validate_path_pattern(&self.valid_jailer_paths, path)
+    }
+}
+
+impl ConfigOps for Hypervisor {
+    fn adjust_configuration(conf: &mut TomlConfig) -> Result<()> {
+        HypervisorVendor::adjust_configuration(conf)?;
+
+        let hypervisors: Vec<String> = conf.hypervisor.keys().cloned().collect();
+        for hypervisor in hypervisors.iter() {
+            if let Some(plugin) = get_hypervisor_plugin(hypervisor) {
+                plugin.adjust_configuration(conf)?;
+
+                // Safe to unwrap() because `hypervisor` is a valid key in the hash map.
+                let hv = conf.hypervisor.get_mut(hypervisor).unwrap();
+                hv.blockdev_info.adjust_configuration()?;
+                hv.boot_info.adjust_configuration()?;
+                hv.cpu_info.adjust_configuration()?;
+                hv.debug_info.adjust_configuration()?;
+                hv.device_info.adjust_configuration()?;
+                hv.machine_info.adjust_configuration()?;
+                hv.memory_info.adjust_configuration()?;
+                hv.network_info.adjust_configuration()?;
+                hv.security_info.adjust_configuration()?;
+                hv.shared_fs.adjust_configuration()?;
+            } else {
+                return Err(eother!("Can not find plugin for hypervisor {}", hypervisor));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate(conf: &TomlConfig) -> Result<()> {
+        HypervisorVendor::validate(conf)?;
+
+        let hypervisors: Vec<String> = conf.hypervisor.keys().cloned().collect();
+        for hypervisor in hypervisors.iter() {
+            if let Some(plugin) = get_hypervisor_plugin(hypervisor) {
+                plugin.validate(conf)?;
+
+                // Safe to unwrap() because `hypervisor` is a valid key in the hash map.
+                let hv = conf.hypervisor.get(hypervisor).unwrap();
+                hv.blockdev_info.validate()?;
+                hv.boot_info.validate()?;
+                hv.cpu_info.validate()?;
+                hv.debug_info.validate()?;
+                hv.device_info.validate()?;
+                hv.machine_info.validate()?;
+                hv.memory_info.validate()?;
+                hv.network_info.validate()?;
+                hv.security_info.validate()?;
+                hv.shared_fs.validate()?;
+                validate_path!(hv.path, "Hypervisor binary path `{}` is invalid: {}")?;
+                validate_path!(
+                    hv.ctlpath,
+                    "Hypervisor control executable `{}` is invalid: {}"
+                )?;
+                validate_path!(hv.jailer_path, "Hypervisor jailer path `{}` is invalid: {}")?;
+            } else {
+                return Err(eother!("Can not find plugin for hypervisor {}", hypervisor));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(not(feature = "enable-vendor"))]
+mod vendor {
+    use super::*;
+
+    /// Vendor customization runtime configuration.
+    #[derive(Debug, Default, Deserialize, Serialize)]
+    pub struct HypervisorVendor {}
+
+    impl ConfigOps for HypervisorVendor {}
+}
+
+#[cfg(feature = "enable-vendor")]
+#[path = "vendor.rs"]
+mod vendor;
+
+use crate::config::validate_path_pattern;
+pub use vendor::HypervisorVendor;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_register_plugin() {
+        let db = DragonballConfig::new();
+        db.register();
+
+        let db = Arc::new(DragonballConfig::new());
+        register_hypervisor_plugin("dragonball", db);
+
+        assert!(get_hypervisor_plugin("dragonball").is_some());
+        assert!(get_hypervisor_plugin("dragonball2").is_none());
+    }
+}

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -336,7 +336,7 @@ pub struct DebugInfo {
     /// exist. The dumped file(also called vmcore) can be processed with crash or gdb.
     ///
     /// # WARNING:
-    ///  Dump guest’s memory can take very long depending on the amount of guest memory and use
+    ///  Dump guest's memory can take very long depending on the amount of guest memory and use
     /// much disk space.
     #[serde(default)]
     pub guest_memory_dump_path: String,
@@ -415,7 +415,7 @@ impl DeviceInfo {
     pub fn validate(&self) -> Result<()> {
         if self.default_bridges > 5 {
             return Err(eother!(
-                "The configured PCI bridges {} is too big",
+                "The configured PCI bridges {} are too many",
                 self.default_bridges
             ));
         }
@@ -479,7 +479,7 @@ impl MachineInfo {
     /// Validate the configuration information.
     pub fn validate(&self) -> Result<()> {
         for pflash in self.pflashes.iter() {
-            validate_path!(*pflash, "Flash image file {} is invalide: {}")?;
+            validate_path!(*pflash, "Flash image file {} is invalid: {}")?;
         }
         validate_path!(self.entropy_source, "Entropy source {} is invalid: {}")?;
         Ok(())
@@ -578,10 +578,10 @@ impl MemoryInfo {
             "Memory backend file {} is invalid: {}"
         )?;
         if self.default_memory == 0 {
-            return Err(eother!("Configured memory size for guest vm is zero"));
+            return Err(eother!("Configured memory size for guest VM is zero"));
         }
         if self.memory_slots == 0 {
-            return Err(eother!("Configured memory slots for guest vm is zero"));
+            return Err(eother!("Configured memory slots for guest VM are zero"));
         }
 
         Ok(())

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -165,12 +165,14 @@ impl BlockDeviceInfo {
         if self.disable_block_device_use {
             return Ok(());
         }
-        if self.block_device_driver != VIRTIO_BLK
-            && self.block_device_driver != VIRTIO_BLK_CCW
-            && self.block_device_driver != VIRTIO_BLK_MMIO
-            && self.block_device_driver != VIRTIO_SCSI
-            && self.block_device_driver != VIRTIO_PMEM
-        {
+        let l = [
+            VIRTIO_BLK,
+            VIRTIO_BLK_CCW,
+            VIRTIO_BLK_MMIO,
+            VIRTIO_SCSI,
+            VIRTIO_PMEM,
+        ];
+        if !l.contains(&self.block_device_driver.as_str()) {
             return Err(eother!(
                 "{} is unsupported block device type.",
                 self.block_device_driver

--- a/src/libs/kata-types/src/config/hypervisor/qemu.rs
+++ b/src/libs/kata-types/src/config/hypervisor/qemu.rs
@@ -61,11 +61,11 @@ impl ConfigPlugin for QemuConfig {
             resolve_path!(qemu.ctlpath, "Qemu ctlpath `{}` is invalid: {}")?;
 
             if qemu.boot_info.kernel.is_empty() {
-                qemu.boot_info.kernel = default::DEFAULT_QEMU_GUEST_KENREL_IMAGE.to_string();
+                qemu.boot_info.kernel = default::DEFAULT_QEMU_GUEST_KERNEL_IMAGE.to_string();
             }
             if qemu.boot_info.kernel_params.is_empty() {
                 qemu.boot_info.kernel_params =
-                    default::DEFAULT_QEMU_GUEST_KENREL_PARAMS.to_string();
+                    default::DEFAULT_QEMU_GUEST_KERNEL_PARAMS.to_string();
             }
             if qemu.boot_info.firmware.is_empty() {
                 qemu.boot_info.firmware = default::DEFAULT_QEMU_FIRMWARE_PATH.to_string();
@@ -99,10 +99,10 @@ impl ConfigPlugin for QemuConfig {
     /// Validate the configuration information.
     fn validate(&self, conf: &TomlConfig) -> Result<()> {
         if let Some(qemu) = conf.hypervisor.get(HYPERVISOR_NAME_QEMU) {
-            validate_path!(qemu.path, "Qemu binary path `{}` is invalid: {}")?;
-            validate_path!(qemu.ctlpath, "Qemu control path `{}` is invalid: {}")?;
+            validate_path!(qemu.path, "QEMU binary path `{}` is invalid: {}")?;
+            validate_path!(qemu.ctlpath, "QEMU control path `{}` is invalid: {}")?;
             if !qemu.jailer_path.is_empty() {
-                return Err(eother!("Path for Qemu jailer should be empty"));
+                return Err(eother!("Path for QEMU jailer should be empty"));
             }
             if !qemu.valid_jailer_paths.is_empty() {
                 return Err(eother!("Valid Qemu jailer path list should be empty"));

--- a/src/libs/kata-types/src/config/hypervisor/qemu.rs
+++ b/src/libs/kata-types/src/config/hypervisor/qemu.rs
@@ -1,0 +1,135 @@
+// Copyright (c) 2019-2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::Result;
+use std::path::Path;
+use std::sync::Arc;
+
+use super::{default, register_hypervisor_plugin};
+use crate::config::hypervisor::VIRTIO_BLK_MMIO;
+use crate::config::{ConfigPlugin, TomlConfig};
+use crate::{eother, resolve_path, validate_path};
+
+/// Hypervisor name for qemu, used to index `TomlConfig::hypervisor`.
+pub const HYPERVISOR_NAME_QEMU: &str = "qemu";
+
+/// Configuration information for qemu.
+#[derive(Default, Debug)]
+pub struct QemuConfig {}
+
+impl QemuConfig {
+    /// Create a new instance of `QemuConfig`.
+    pub fn new() -> Self {
+        QemuConfig {}
+    }
+
+    /// Register the qemu plugin.
+    pub fn register(self) {
+        let plugin = Arc::new(self);
+        register_hypervisor_plugin(HYPERVISOR_NAME_QEMU, plugin);
+    }
+}
+
+impl ConfigPlugin for QemuConfig {
+    fn name(&self) -> &str {
+        HYPERVISOR_NAME_QEMU
+    }
+
+    /// Adjust the configuration information after loading from configuration file.
+    fn adjust_configuration(&self, conf: &mut TomlConfig) -> Result<()> {
+        if let Some(qemu) = conf.hypervisor.get_mut(HYPERVISOR_NAME_QEMU) {
+            if qemu.path.is_empty() {
+                qemu.path = default::DEFAULT_QEMU_BINARY_PATH.to_string();
+            }
+            resolve_path!(qemu.path, "Qemu binary path `{}` is invalid: {}")?;
+            if qemu.ctlpath.is_empty() {
+                qemu.ctlpath = default::DEFAULT_QEMU_CONTROL_PATH.to_string();
+            }
+            resolve_path!(qemu.ctlpath, "Qemu ctlpath `{}` is invalid: {}")?;
+
+            if qemu.boot_info.kernel.is_empty() {
+                qemu.boot_info.kernel = default::DEFAULT_QEMU_GUEST_KENREL_IMAGE.to_string();
+            }
+            if qemu.boot_info.kernel_params.is_empty() {
+                qemu.boot_info.kernel_params =
+                    default::DEFAULT_QEMU_GUEST_KENREL_PARAMS.to_string();
+            }
+            if qemu.boot_info.firmware.is_empty() {
+                qemu.boot_info.firmware = default::DEFAULT_QEMU_FIRMWARE_PATH.to_string();
+            }
+
+            if qemu.device_info.default_bridges == 0 {
+                qemu.device_info.default_bridges = default::DEFAULT_QEMU_PCI_BRIDGES;
+                if qemu.device_info.default_bridges > default::MAX_QEMU_PCI_BRIDGES {
+                    qemu.device_info.default_bridges = default::MAX_QEMU_PCI_BRIDGES;
+                }
+            }
+
+            if qemu.machine_info.machine_type.is_empty() {
+                qemu.machine_info.machine_type = default::DEFAULT_QEMU_MACHINE_TYPE.to_string();
+            }
+            if qemu.machine_info.entropy_source.is_empty() {
+                qemu.machine_info.entropy_source = default::DEFAULT_QEMU_ENTROPY_SOURCE.to_string();
+            }
+
+            if qemu.memory_info.default_memory == 0 {
+                qemu.memory_info.default_memory = default::DEFAULT_QEMU_MEMORY_SIZE;
+            }
+            if qemu.memory_info.memory_slots == 0 {
+                qemu.memory_info.memory_slots = default::DEFAULT_QEMU_MEMORY_SLOTS;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    fn validate(&self, conf: &TomlConfig) -> Result<()> {
+        if let Some(qemu) = conf.hypervisor.get(HYPERVISOR_NAME_QEMU) {
+            validate_path!(qemu.path, "Qemu binary path `{}` is invalid: {}")?;
+            validate_path!(qemu.ctlpath, "Qemu control path `{}` is invalid: {}")?;
+            if !qemu.jailer_path.is_empty() {
+                return Err(eother!("Path for Qemu jailer should be empty"));
+            }
+            if !qemu.valid_jailer_paths.is_empty() {
+                return Err(eother!("Valid Qemu jailer path list should be empty"));
+            }
+
+            if !qemu.blockdev_info.disable_block_device_use
+                && qemu.blockdev_info.block_device_driver == VIRTIO_BLK_MMIO
+            {
+                return Err(eother!("Qemu doesn't support virtio-blk-mmio"));
+            }
+
+            if qemu.boot_info.kernel.is_empty() {
+                return Err(eother!("Guest kernel image for qemu is empty"));
+            }
+            if qemu.boot_info.image.is_empty() && qemu.boot_info.initrd.is_empty() {
+                return Err(eother!(
+                    "Both guest boot image and initrd for qemu are empty"
+                ));
+            }
+
+            if (qemu.cpu_info.default_vcpus > 0
+                && qemu.cpu_info.default_vcpus as u32 > default::MAX_QEMU_VCPUS)
+                || qemu.cpu_info.default_maxvcpus > default::MAX_QEMU_VCPUS
+            {
+                return Err(eother!(
+                    "Qemu hypervisor can not support {} vCPUs",
+                    qemu.cpu_info.default_maxvcpus
+                ));
+            }
+
+            if qemu.device_info.default_bridges > default::MAX_QEMU_PCI_BRIDGES {
+                return Err(eother!(
+                    "Qemu hypervisor can not support {} PCI bridges",
+                    qemu.device_info.default_bridges
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/libs/kata-types/src/config/hypervisor/qemu.rs
+++ b/src/libs/kata-types/src/config/hypervisor/qemu.rs
@@ -73,9 +73,6 @@ impl ConfigPlugin for QemuConfig {
 
             if qemu.device_info.default_bridges == 0 {
                 qemu.device_info.default_bridges = default::DEFAULT_QEMU_PCI_BRIDGES;
-                if qemu.device_info.default_bridges > default::MAX_QEMU_PCI_BRIDGES {
-                    qemu.device_info.default_bridges = default::MAX_QEMU_PCI_BRIDGES;
-                }
             }
 
             if qemu.machine_info.machine_type.is_empty() {

--- a/src/libs/kata-types/src/config/hypervisor/qemu.rs
+++ b/src/libs/kata-types/src/config/hypervisor/qemu.rs
@@ -8,6 +8,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use super::{default, register_hypervisor_plugin};
+
+use crate::config::default::MAX_QEMU_VCPUS;
+use crate::config::default::MIN_QEMU_MEMORY_SIZE;
+
 use crate::config::hypervisor::VIRTIO_BLK_MMIO;
 use crate::config::{ConfigPlugin, TomlConfig};
 use crate::{eother, resolve_path, validate_path};
@@ -33,6 +37,13 @@ impl QemuConfig {
 }
 
 impl ConfigPlugin for QemuConfig {
+    fn get_max_cpus(&self) -> u32 {
+        MAX_QEMU_VCPUS
+    }
+
+    fn get_min_memory(&self) -> u32 {
+        MIN_QEMU_MEMORY_SIZE
+    }
     fn name(&self) -> &str {
         HYPERVISOR_NAME_QEMU
     }

--- a/src/libs/kata-types/src/config/hypervisor/vendor.rs
+++ b/src/libs/kata-types/src/config/hypervisor/vendor.rs
@@ -1,0 +1,14 @@
+// Copyright (c) 2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! A sample for vendor to customize the hypervisor implementation.
+
+use super::*;
+
+/// Vendor customization runtime configuration.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct HypervisorVendor {}
+
+impl ConfigOps for HypervisorVendor {}

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -14,6 +14,9 @@ use crate::{eother, sl};
 /// Default configuration values.
 pub mod default;
 
+mod agent;
+pub use self::agent::{Agent, AgentVendor};
+
 mod hypervisor;
 pub use self::hypervisor::{
     BootInfo, DragonballConfig, Hypervisor, QemuConfig, HYPERVISOR_NAME_DRAGONBALL,
@@ -64,6 +67,9 @@ pub trait ConfigObjectOps {
 /// Kata configuration information.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TomlConfig {
+    /// Configuration information for agents.
+    #[serde(default)]
+    pub agent: HashMap<String, Agent>,
     /// Configuration information for hypervisors.
     #[serde(default)]
     pub hypervisor: HashMap<String, Hypervisor>,
@@ -123,6 +129,7 @@ impl TomlConfig {
 
         Hypervisor::adjust_configuration(&mut config)?;
         Runtime::adjust_configuration(&mut config)?;
+        Agent::adjust_configuration(&mut config)?;
         info!(sl!(), "get kata config: {:?}", config);
 
         Ok(config)
@@ -132,6 +139,7 @@ impl TomlConfig {
     pub fn validate(&self) -> Result<()> {
         Hypervisor::validate(self)?;
         Runtime::validate(self)?;
+        Agent::validate(self)?;
 
         Ok(())
     }

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -1,0 +1,125 @@
+// Copyright (c) 2019-2021 Ant Financial
+// Copyright (c) 2019-2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::fs;
+use std::io::{self, Result};
+use std::path::{Path, PathBuf};
+
+use crate::sl;
+
+/// Default configuration values.
+pub mod default;
+
+mod runtime;
+pub use self::runtime::{Runtime, RuntimeVendor};
+
+/// Trait to manipulate global Kata configuration information.
+pub trait ConfigOps {
+    /// Adjust the configuration information after loading from configuration file.
+    fn adjust_configuration(_conf: &mut TomlConfig) -> Result<()> {
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    fn validate(_conf: &TomlConfig) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Trait to manipulate global Kata configuration information.
+pub trait ConfigObjectOps {
+    /// Adjust the configuration information after loading from configuration file.
+    fn adjust_configuration(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    fn validate(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+/// Kata configuration information.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct TomlConfig {
+    /// Kata runtime configuration information.
+    #[serde(default)]
+    pub runtime: Runtime,
+}
+
+impl TomlConfig {
+    /// Load Kata configuration information from configuration files.
+    ///
+    /// If `config_file` is valid, it will used, otherwise a built-in default path list will be
+    /// scanned.
+    pub fn load_from_file<P: AsRef<Path>>(config_file: P) -> Result<(TomlConfig, PathBuf)> {
+        let file_path = if !config_file.as_ref().as_os_str().is_empty() {
+            fs::canonicalize(config_file)?
+        } else {
+            Self::get_default_config_file()?
+        };
+
+        info!(
+            sl!(),
+            "load configuration from: {}",
+            file_path.to_string_lossy()
+        );
+        let content = fs::read_to_string(&file_path)?;
+        let config = Self::load(&content)?;
+
+        Ok((config, file_path))
+    }
+
+    /// Load raw Kata configuration information from configuration files.
+    ///
+    /// If `config_file` is valid, it will used, otherwise a built-in default path list will be
+    /// scanned.
+    pub fn load_raw_from_file<P: AsRef<Path>>(config_file: P) -> Result<(TomlConfig, PathBuf)> {
+        let file_path = if !config_file.as_ref().as_os_str().is_empty() {
+            fs::canonicalize(config_file)?
+        } else {
+            Self::get_default_config_file()?
+        };
+
+        info!(
+            sl!(),
+            "load configuration from: {}",
+            file_path.to_string_lossy()
+        );
+        let content = fs::read_to_string(&file_path)?;
+        let config: TomlConfig = toml::from_str(&content)?;
+
+        Ok((config, file_path))
+    }
+
+    /// Load Kata configuration information from string.
+    pub fn load(content: &str) -> Result<TomlConfig> {
+        let mut config: TomlConfig = toml::from_str(content)?;
+
+        Runtime::adjust_configuration(&mut config)?;
+        info!(sl!(), "get kata config: {:?}", config);
+
+        Ok(config)
+    }
+
+    /// Validate Kata configuration information.
+    pub fn validate(&self) -> Result<()> {
+        Runtime::validate(self)?;
+
+        Ok(())
+    }
+
+    ///  Probe configuration file according to the default configuration file list.
+    fn get_default_config_file() -> Result<PathBuf> {
+        for f in default::DEFAULT_RUNTIME_CONFIGURATIONS.iter() {
+            if let Ok(path) = fs::canonicalize(f) {
+                return Ok(path);
+            }
+        }
+
+        Err(io::Error::from(io::ErrorKind::NotFound))
+    }
+}

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -185,7 +185,7 @@ pub fn validate_path_pattern<P: AsRef<Path>>(patterns: &[String], path: P) -> Re
 
 /// Kata configuration information.
 pub struct KataConfig {
-    config: TomlConfig,
+    config: Option<TomlConfig>,
     agent: String,
     hypervisor: String,
 }
@@ -194,7 +194,7 @@ impl KataConfig {
     /// Set the default Kata configuration object.
     ///
     /// The default Kata configuration information is loaded from system configuration file.
-    pub fn set_default_config(config: TomlConfig, hypervisor: &str, agent: &str) {
+    pub fn set_default_config(config: Option<TomlConfig>, hypervisor: &str, agent: &str) {
         let kata = KataConfig {
             config,
             agent: agent.to_string(),
@@ -214,7 +214,7 @@ impl KataConfig {
     ///
     /// The active Kata configuration information is default configuration information patched
     /// with tunable configuration information from annotations.
-    pub fn set_active_config(config: TomlConfig, hypervisor: &str, agent: &str) {
+    pub fn set_active_config(config: Option<TomlConfig>, hypervisor: &str, agent: &str) {
         let kata = KataConfig {
             config,
             agent: agent.to_string(),
@@ -232,13 +232,13 @@ impl KataConfig {
     }
     /// Get the config in use
     pub fn get_config(&self) -> &TomlConfig {
-        &self.config
+        self.config.as_ref().unwrap()
     }
 
     /// Get the agent configuration in use.
     pub fn get_agent(&self) -> Option<&Agent> {
         if !self.agent.is_empty() {
-            self.config.agent.get(&self.agent)
+            self.config.as_ref().unwrap().agent.get(&self.agent)
         } else {
             None
         }
@@ -247,7 +247,11 @@ impl KataConfig {
     /// Get the hypervisor configuration in use.
     pub fn get_hypervisor(&self) -> Option<&Hypervisor> {
         if !self.hypervisor.is_empty() {
-            self.config.hypervisor.get(&self.hypervisor)
+            self.config
+                .as_ref()
+                .unwrap()
+                .hypervisor
+                .get(&self.hypervisor)
         } else {
             None
         }
@@ -256,7 +260,7 @@ impl KataConfig {
 
 lazy_static! {
     static ref KATA_DEFAULT_CONFIG: Mutex<Arc<KataConfig>> = {
-        let config = TomlConfig::load("").unwrap();
+        let config = Some(TomlConfig::load("").unwrap());
         let kata = KataConfig {
             config,
             agent: String::new(),
@@ -266,7 +270,7 @@ lazy_static! {
         Mutex::new(Arc::new(kata))
     };
     static ref KATA_ACTIVE_CONFIG: Mutex<Arc<KataConfig>> = {
-        let config = TomlConfig::load("").unwrap();
+        let config = Some(TomlConfig::load("").unwrap());
         let kata = KataConfig {
             config,
             agent: String::new(),

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -36,7 +36,7 @@ pub trait ConfigPlugin: Send + Sync {
     fn name(&self) -> &str;
 
     /// Adjust the configuration information after loading from configuration file.
-    fn adjust_configuration(&self, _conf: &mut TomlConfig) -> Result<()>;
+    fn adjust_config(&self, _conf: &mut TomlConfig) -> Result<()>;
 
     /// Validate the configuration information.
     fn validate(&self, _conf: &TomlConfig) -> Result<()>;
@@ -51,7 +51,7 @@ pub trait ConfigPlugin: Send + Sync {
 /// Trait to manipulate Kata configuration information.
 pub trait ConfigOps {
     /// Adjust the configuration information after loading from configuration file.
-    fn adjust_configuration(_conf: &mut TomlConfig) -> Result<()> {
+    fn adjust_config(_conf: &mut TomlConfig) -> Result<()> {
         Ok(())
     }
 
@@ -64,7 +64,7 @@ pub trait ConfigOps {
 /// Trait to manipulate global Kata configuration information.
 pub trait ConfigObjectOps {
     /// Adjust the configuration information after loading from configuration file.
-    fn adjust_configuration(&mut self) -> Result<()> {
+    fn adjust_config(&mut self) -> Result<()> {
         Ok(())
     }
 
@@ -136,9 +136,9 @@ impl TomlConfig {
     /// Load Kata configuration information from string.
     pub fn load(content: &str) -> Result<TomlConfig> {
         let mut config: TomlConfig = toml::from_str(content)?;
-        Hypervisor::adjust_configuration(&mut config)?;
-        Runtime::adjust_configuration(&mut config)?;
-        Agent::adjust_configuration(&mut config)?;
+        Hypervisor::adjust_config(&mut config)?;
+        Runtime::adjust_config(&mut config)?;
+        Agent::adjust_config(&mut config)?;
         info!(sl!(), "get kata config: {:?}", config);
         Ok(config)
     }

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -115,7 +115,6 @@ pub struct Runtime {
 impl ConfigOps for Runtime {
     fn adjust_configuration(conf: &mut TomlConfig) -> Result<()> {
         RuntimeVendor::adjust_configuration(conf)?;
-
         if conf.runtime.internetworking_model.is_empty() {
             conf.runtime.internetworking_model = default::DEFAULT_INTERNETWORKING_MODEL.to_owned();
         }

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -1,0 +1,272 @@
+// Copyright (c) 2019-2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::Result;
+use std::path::Path;
+
+use super::default;
+use crate::config::{ConfigOps, TomlConfig};
+use crate::{eother, resolve_path, validate_path};
+
+/// Kata runtime configuration information.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct Runtime {
+    /// If enabled, the runtime will log additional debug messages to the system log.
+    #[serde(default, rename = "enable_debug")]
+    pub debug: bool,
+
+    /// Enabled experimental feature list, format: ["a", "b"].
+    ///
+    /// Experimental features are features not stable enough for production, they may break
+    /// compatibility, and are prepared for a big version bump.
+    #[serde(default)]
+    pub experimental: Vec<String>,
+
+    /// Determines how the VM should be connected to the container network interface.
+    ///
+    /// Options:
+    /// - macvtap: used when the Container network interface can be bridged using macvtap.
+    /// - none: used when customize network. Only creates a tap device. No veth pair.
+    /// - tcfilter: uses tc filter rules to redirect traffic from the network interface provided
+    ///   by plugin to a tap interface connected to the VM.
+    #[serde(default)]
+    pub internetworking_model: String,
+
+    /// If enabled, the runtime won't create a network namespace for shim and hypervisor processes.
+    ///
+    /// This option may have some potential impacts to your host. It should only be used when you
+    /// know what you're doing.
+    ///
+    /// `disable_new_netns` conflicts with `internetworking_model=tcfilter` and
+    /// `internetworking_model=macvtap`. It works only with `internetworking_model=none`.
+    /// The tap device will be in the host network namespace and can connect to a bridge (like OVS)
+    /// directly.
+    ///
+    /// If you are using docker, `disable_new_netns` only works with `docker run --net=none`
+    #[serde(default)]
+    pub disable_new_netns: bool,
+
+    /// If specified, sandbox_bind_mounts identifies host paths to be mounted into the sandboxes
+    /// shared path.
+    ///
+    /// This is only valid if filesystem sharing is utilized. The provided path(s) will be bind
+    /// mounted into the shared fs directory. If defaults are utilized, these mounts should be
+    /// available in the guest at `/run/kata-containers/shared/containers/passthrough/sandbox-mounts`.
+    /// These will not be exposed to the container workloads, and are only provided for potential
+    /// guest services.
+    #[serde(default)]
+    pub sandbox_bind_mounts: Vec<String>,
+
+    /// If enabled, the runtime will add all the kata processes inside one dedicated cgroup.
+    ///
+    /// The container cgroups in the host are not created, just one single cgroup per sandbox.
+    /// The runtime caller is free to restrict or collect cgroup stats of the overall Kata sandbox.
+    /// The sandbox cgroup path is the parent cgroup of a container with the PodSandbox annotation.
+    /// The sandbox cgroup is constrained if there is no container type annotation.
+    /// See: https://pkg.go.dev/github.com/kata-containers/kata-containers/src/runtime/virtcontainers#ContainerType
+    #[serde(default)]
+    pub sandbox_cgroup_only: bool,
+
+    /// If enabled, the runtime will create opentracing.io traces and spans.
+    /// See https://www.jaegertracing.io/docs/getting-started.
+    #[serde(default)]
+    pub enable_tracing: bool,
+    /// The full url to the Jaeger HTTP Thrift collector.
+    #[serde(default)]
+    pub jaeger_endpoint: String,
+    /// The username to be used if basic auth is required for Jaeger.
+    #[serde(default)]
+    pub jaeger_user: String,
+    /// The password to be used if basic auth is required for Jaeger.
+    #[serde(default)]
+    pub jaeger_password: String,
+
+    /// If enabled, user can run pprof tools with shim v2 process through kata-monitor.
+    #[serde(default)]
+    pub enable_pprof: bool,
+
+    /// Determines whether container seccomp profiles are passed to the virtual machine and
+    /// applied by the kata agent. If set to true, seccomp is not applied within the guest.
+    #[serde(default)]
+    pub disable_guest_seccomp: bool,
+
+    /// Determines how VFIO devices should be be presented to the container.
+    ///
+    /// Options:
+    /// - vfio: Matches behaviour of OCI runtimes (e.g. runc) as much as possible.  VFIO devices
+    ///   will appear in the container as VFIO character devices under /dev/vfio. The exact names
+    ///   may differ from the host (they need to match the VM's IOMMU group numbers rather than
+    ///   the host's)
+    /// - guest-kernel: This is a Kata-specific behaviour that's useful in certain cases.
+    ///   The VFIO device is managed by whatever driver in the VM kernel claims it. This means
+    ///   it will appear as one or more device nodes or network interfaces depending on the nature
+    ///   of the device. Using this mode requires specially built workloads that know how to locate
+    ///   the relevant device interfaces within the VM.
+    #[serde(default)]
+    pub vfio_mode: String,
+
+    /// Vendor customized runtime configuration.
+    #[serde(default, flatten)]
+    pub vendor: RuntimeVendor,
+}
+
+impl ConfigOps for Runtime {
+    fn adjust_configuration(conf: &mut TomlConfig) -> Result<()> {
+        RuntimeVendor::adjust_configuration(conf)?;
+
+        if conf.runtime.internetworking_model.is_empty() {
+            conf.runtime.internetworking_model = default::DEFAULT_INTERNETWORKING_MODEL.to_owned();
+        }
+
+        for bind in conf.runtime.sandbox_bind_mounts.iter_mut() {
+            resolve_path!(*bind, "sandbox bind mount `{}` is invalid: {}")?;
+        }
+
+        Ok(())
+    }
+
+    fn validate(conf: &TomlConfig) -> Result<()> {
+        RuntimeVendor::validate(conf)?;
+
+        let net_model = &conf.runtime.internetworking_model;
+        if !net_model.is_empty()
+            && net_model != "macvtap"
+            && net_model != "none"
+            && net_model != "tcfilter"
+        {
+            return Err(eother!(
+                "Invalid internetworking_model `{}` in configuration file",
+                net_model
+            ));
+        }
+
+        let vfio_mode = &conf.runtime.vfio_mode;
+        if !vfio_mode.is_empty() && vfio_mode != "vfio" && vfio_mode != "guest-kernel" {
+            return Err(eother!(
+                "Invalid vfio_mode `{}` in configuration file",
+                vfio_mode
+            ));
+        }
+
+        for bind in conf.runtime.sandbox_bind_mounts.iter() {
+            validate_path!(*bind, "sandbox bind mount `{}` is invalid: {}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl Runtime {
+    /// Check whether experiment `feature` is enabled or not.
+    pub fn is_experiment_enabled(&self, feature: &str) -> bool {
+        self.experimental.contains(&feature.to_string())
+    }
+}
+
+#[cfg(not(feature = "enable-vendor"))]
+mod vendor {
+    use super::*;
+
+    /// Vendor customization runtime configuration.
+    #[derive(Debug, Default, Deserialize, Serialize)]
+    pub struct RuntimeVendor {}
+
+    impl ConfigOps for RuntimeVendor {}
+}
+
+#[cfg(feature = "enable-vendor")]
+#[path = "runtime_vendor.rs"]
+mod vendor;
+
+pub use vendor::RuntimeVendor;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_config() {
+        let content = r#"
+[runtime]
+enable_debug = 10
+"#;
+        TomlConfig::load(content).unwrap_err();
+
+        let content = r#"
+[runtime]
+enable_debug = true
+internetworking_model = "test"
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        let content = r#"
+[runtime]
+enable_debug = true
+internetworking_model = "macvtap,none"
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        let content = r#"
+[runtime]
+enable_debug = true
+vfio_mode = "none"
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        let content = r#"
+[runtime]
+enable_debug = true
+vfio_mode = "vfio,guest-kernel"
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        let content = r#"
+[runtime]
+enable_debug = true
+vfio_mode = "guest_kernel"
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+    }
+
+    #[test]
+    fn test_config() {
+        let content = r#"
+[runtime]
+enable_debug = true
+experimental = ["a", "b"]
+internetworking_model = "macvtap"
+disable_new_netns = true
+sandbox_bind_mounts = []
+sandbox_cgroup_only = true
+enable_tracing = true
+jaeger_endpoint = "localhost:1234"
+jaeger_user = "user"
+jaeger_password = "pw"
+enable_pprof = true
+disable_guest_seccomp = true
+vfio_mode = "vfio"
+field_should_be_ignored = true
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+        assert!(config.runtime.debug);
+        assert_eq!(config.runtime.experimental.len(), 2);
+        assert_eq!(&config.runtime.experimental[0], "a");
+        assert_eq!(&config.runtime.experimental[1], "b");
+        assert_eq!(&config.runtime.internetworking_model, "macvtap");
+        assert!(config.runtime.disable_new_netns);
+        assert_eq!(config.runtime.sandbox_bind_mounts.len(), 0);
+        assert!(config.runtime.sandbox_cgroup_only);
+        assert!(config.runtime.enable_tracing);
+        assert!(config.runtime.is_experiment_enabled("a"));
+        assert!(config.runtime.is_experiment_enabled("b"));
+        assert!(!config.runtime.is_experiment_enabled("c"));
+    }
+}

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -113,8 +113,8 @@ pub struct Runtime {
 }
 
 impl ConfigOps for Runtime {
-    fn adjust_configuration(conf: &mut TomlConfig) -> Result<()> {
-        RuntimeVendor::adjust_configuration(conf)?;
+    fn adjust_config(conf: &mut TomlConfig) -> Result<()> {
+        RuntimeVendor::adjust_config(conf)?;
         if conf.runtime.internetworking_model.is_empty() {
             conf.runtime.internetworking_model = default::DEFAULT_INTERNETWORKING_MODEL.to_owned();
         }

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2019-2021 Alibaba Cloud
+// Copyright (c) 2021 Alibaba Cloud
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/libs/kata-types/src/config/runtime_vendor.rs
+++ b/src/libs/kata-types/src/config/runtime_vendor.rs
@@ -20,7 +20,7 @@ pub struct RuntimeVendor {
 }
 
 impl ConfigOps for RuntimeVendor {
-    fn adjust_configuration(conf: &mut TomlConfig) -> Result<()> {
+    fn adjust_config(conf: &mut TomlConfig) -> Result<()> {
         if conf.runtime.vendor.log_level > Level::Debug as u32 {
             conf.runtime.debug = true;
         }

--- a/src/libs/kata-types/src/config/runtime_vendor.rs
+++ b/src/libs/kata-types/src/config/runtime_vendor.rs
@@ -32,10 +32,6 @@ impl ConfigOps for RuntimeVendor {
     /// Validate the configuration information.
     fn validate(conf: &TomlConfig) -> Result<()> {
         if conf.runtime.vendor.log_level > 10 {
-            warn!(
-                sl!(),
-                "log level {} in configuration file is invalid", conf.runtime.vendor.log_level
-            );
             return Err(eother!(
                 "log level {} in configuration file is invalid",
                 conf.runtime.vendor.log_level

--- a/src/libs/kata-types/src/config/runtime_vendor.rs
+++ b/src/libs/kata-types/src/config/runtime_vendor.rs
@@ -1,0 +1,88 @@
+// Copyright (c) 2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! A sample for vendor to customize the runtime implementation.
+
+use super::*;
+use crate::{eother, sl};
+use slog::Level;
+/// Vendor customization runtime configuration.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct RuntimeVendor {
+    /// Log level
+    #[serde(default)]
+    pub log_level: u32,
+
+    /// Prefix for log messages
+    #[serde(default)]
+    pub log_prefix: String,
+}
+
+impl ConfigOps for RuntimeVendor {
+    fn adjust_configuration(conf: &mut TomlConfig) -> Result<()> {
+        if conf.runtime.vendor.log_level > Level::Debug as u32 {
+            conf.runtime.debug = true;
+        }
+
+        Ok(())
+    }
+
+    /// Validate the configuration information.
+    fn validate(conf: &TomlConfig) -> Result<()> {
+        if conf.runtime.vendor.log_level > 10 {
+            warn!(
+                sl!(),
+                "log level {} in configuration file is invalid", conf.runtime.vendor.log_level
+            );
+            return Err(eother!(
+                "log level {} in configuration file is invalid",
+                conf.runtime.vendor.log_level
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_vendor_config() {
+        let content = r#"
+[runtime]
+debug = false
+log_level = 20
+log_prefix = "test"
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap_err();
+
+        let content = r#"
+[runtime]
+debug = false
+log_level = "test"
+log_prefix = "test"
+"#;
+        TomlConfig::load(content).unwrap_err();
+    }
+
+    #[test]
+    fn test_vendor_config() {
+        let content = r#"
+[runtime]
+debug = false
+log_level = 10
+log_prefix = "test"
+log_fmt = "nouse"
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+        assert!(config.runtime.debug);
+        assert_eq!(config.runtime.vendor.log_level, 10);
+        assert_eq!(&config.runtime.vendor.log_prefix, "test");
+    }
+}

--- a/src/libs/kata-types/src/config/runtime_vendor.rs
+++ b/src/libs/kata-types/src/config/runtime_vendor.rs
@@ -6,7 +6,6 @@
 //! A sample for vendor to customize the runtime implementation.
 
 use super::*;
-use crate::{eother, sl};
 use slog::Level;
 /// Vendor customization runtime configuration.
 #[derive(Debug, Default, Deserialize, Serialize)]

--- a/src/libs/kata-types/src/lib.rs
+++ b/src/libs/kata-types/src/lib.rs
@@ -5,10 +5,17 @@
 
 //! Constants and Data Types shared by Kata Containers components.
 
-#[deny(missing_docs)]
+#![deny(missing_docs)]
+#[macro_use]
+extern crate slog;
+#[macro_use]
+extern crate serde;
 
 /// Constants and data types annotations.
 pub mod annotations;
+
+/// Kata configuration information from configuration file.
+pub mod config;
 
 /// Constants and data types related to container.
 pub mod container;
@@ -18,3 +25,56 @@ pub mod k8s;
 
 /// Constants and data types related to mount point.
 pub mod mount;
+
+/// Convenience macro to obtain the scoped logger
+#[macro_export]
+macro_rules! sl {
+    () => {
+        slog_scope::logger()
+    };
+}
+
+/// Helper to create std::io::Error(std::io::ErrorKind::Other)
+#[macro_export]
+macro_rules! eother {
+    () => (std::io::Error::new(std::io::ErrorKind::Other, ""));
+    ($fmt:expr) => ({
+        std::io::Error::new(std::io::ErrorKind::Other, format!($fmt))
+    });
+    ($fmt:expr, $($arg:tt)*) => ({
+        std::io::Error::new(std::io::ErrorKind::Other, format!($fmt, $($arg)*))
+    });
+}
+
+/// Resolve a path to its final value.
+#[macro_export]
+macro_rules! resolve_path {
+    ($field:expr, $fmt:expr) => {{
+        if !$field.is_empty() {
+            match Path::new(&$field).canonicalize() {
+                Err(e) => Err(eother!($fmt, &$field, e)),
+                Ok(path) => {
+                    $field = path.to_string_lossy().to_string();
+                    Ok(())
+                }
+            }
+        } else {
+            Ok(())
+        }
+    }};
+}
+
+/// Validate a path.
+#[macro_export]
+macro_rules! validate_path {
+    ($field:expr, $fmt:expr) => {{
+        if !$field.is_empty() {
+            Path::new(&$field)
+                .canonicalize()
+                .map_err(|e| eother!($fmt, &$field, e))
+                .map(|_| ())
+        } else {
+            Ok(())
+        }
+    }};
+}

--- a/src/libs/kata-types/tests/test-config.rs
+++ b/src/libs/kata-types/tests/test-config.rs
@@ -34,7 +34,7 @@ mod tests {
         qemu.register();
 
         let config = TomlConfig::load(&content).unwrap();
-        KataConfig::set_active_config(config, "qemu", "agent0");
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         std::process::Command::new("mkdir")
             .arg("./hypervisor_path")
@@ -175,7 +175,7 @@ mod tests {
         assert!(anno
             .update_config_by_annotation(&mut config, "qemu", "agent0")
             .is_ok());
-        KataConfig::set_active_config(config, "qemu", "agnet0");
+        KataConfig::set_active_config(Some(config), "qemu", "agnet0");
         if let Some(ag) = KataConfig::get_default_config().get_agent() {
             assert_eq!(
                 ag.kernel_modules[0],
@@ -287,7 +287,7 @@ mod tests {
         qemu.register();
 
         let config = TomlConfig::load(&content).unwrap();
-        KataConfig::set_active_config(config, "qemu", "agent0");
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
@@ -312,7 +312,7 @@ mod tests {
         qemu.register();
 
         let config = TomlConfig::load(&content).unwrap();
-        KataConfig::set_active_config(config, "qemu", "agent0");
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
@@ -337,7 +337,7 @@ mod tests {
         qemu.register();
 
         let config = TomlConfig::load(&content).unwrap();
-        KataConfig::set_active_config(config, "qemu", "agent0");
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
@@ -365,7 +365,7 @@ mod tests {
         qemu.register();
 
         let config = TomlConfig::load(&content).unwrap();
-        KataConfig::set_active_config(config, "qemu", "agent0");
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
@@ -386,7 +386,7 @@ mod tests {
         let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
         let content = fs::read_to_string(&path).unwrap();
         let config = TomlConfig::load(&content).unwrap();
-        KataConfig::set_active_config(config, "qemu", "agent0");
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let qemu = QemuConfig::new();
         qemu.register();
@@ -414,7 +414,7 @@ mod tests {
         qemu.register();
 
         let config = TomlConfig::load(&content).unwrap();
-        KataConfig::set_active_config(config, "qemu", "agent0");
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
@@ -439,7 +439,7 @@ mod tests {
         qemu.register();
 
         let config = TomlConfig::load(&content).unwrap();
-        KataConfig::set_active_config(config, "qemu", "agent0");
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(

--- a/src/libs/kata-types/tests/test-config.rs
+++ b/src/libs/kata-types/tests/test-config.rs
@@ -438,4 +438,50 @@ mod tests {
             .update_config_by_annotation(&mut config, "qemu", "agent0")
             .is_err());
     }
+
+    #[test]
+    fn test_fail_to_change_enable_guest_swap_because_invalid_input() {
+        let content = include_str!("texture/configuration-anno-0.toml");
+
+        let qemu = QemuConfig::new();
+        qemu.register();
+
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
+
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP.to_string(),
+            "false1".to_string(),
+        );
+        let anno = Annotation::new(anno_hash);
+        let mut config = TomlConfig::load(&content).unwrap();
+
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_err());
+    }
+
+    #[test]
+    fn test_fail_to_change_default_vcpus_becuase_invalid_input() {
+        let content = include_str!("texture/configuration-anno-0.toml");
+
+        let qemu = QemuConfig::new();
+        qemu.register();
+
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(Some(config), "qemu", "agent0");
+
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS.to_string(),
+            "ddc".to_string(),
+        );
+        let anno = Annotation::new(anno_hash);
+        let mut config = TomlConfig::load(&content).unwrap();
+
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_err());
+    }
 }

--- a/src/libs/kata-types/tests/test-config.rs
+++ b/src/libs/kata-types/tests/test-config.rs
@@ -26,10 +26,7 @@ mod tests {
     use std::path::Path;
     #[test]
     fn test_change_config_annotation() {
-        let path = env!("CARGO_MANIFEST_DIR");
-        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
-        let content = fs::read_to_string(&path).unwrap();
-
+        let content = include_str!("texture/configuration-anno-0.toml");
         let qemu = QemuConfig::new();
         qemu.register();
 
@@ -279,9 +276,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_change_block_device_driver_because_not_enabled() {
-        let path = env!("CARGO_MANIFEST_DIR");
-        let path = Path::new(path).join("tests/texture/configuration-anno-1.toml");
-        let content = fs::read_to_string(&path).unwrap();
+        let content = include_str!("texture/configuration-anno-1.toml");
 
         let qemu = QemuConfig::new();
         qemu.register();
@@ -304,9 +299,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_change_enable_guest_swap_because_not_enabled() {
-        let path = env!("CARGO_MANIFEST_DIR");
-        let path = Path::new(path).join("tests/texture/configuration-anno-1.toml");
-        let content = fs::read_to_string(&path).unwrap();
+        let content = include_str!("texture/configuration-anno-1.toml");
 
         let qemu = QemuConfig::new();
         qemu.register();
@@ -329,9 +322,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_change_hypervisor_path_because_of_invalid_path() {
-        let path = env!("CARGO_MANIFEST_DIR");
-        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
-        let content = fs::read_to_string(&path).unwrap();
+        let content = include_str!("texture/configuration-anno-0.toml");
 
         let qemu = QemuConfig::new();
         qemu.register();
@@ -382,9 +373,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_change_memory_slots_because_of_less_than_zero() {
-        let path = env!("CARGO_MANIFEST_DIR");
-        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
-        let content = fs::read_to_string(&path).unwrap();
+        let content = include_str!("texture/configuration-anno-0.toml");
         let config = TomlConfig::load(&content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
@@ -406,9 +395,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_change_default_memory_because_less_than_min_memory_size() {
-        let path = env!("CARGO_MANIFEST_DIR");
-        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
-        let content = fs::read_to_string(&path).unwrap();
+        let content = include_str!("texture/configuration-anno-0.toml");
 
         let qemu = QemuConfig::new();
         qemu.register();
@@ -431,9 +418,7 @@ mod tests {
 
     #[test]
     fn test_fail_to_change_default_vcpus_becuase_more_than_max_cpu_size() {
-        let path = env!("CARGO_MANIFEST_DIR");
-        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
-        let content = fs::read_to_string(&path).unwrap();
+        let content = include_str!("texture/configuration-anno-0.toml");
 
         let qemu = QemuConfig::new();
         qemu.register();

--- a/src/libs/kata-types/tests/test-config.rs
+++ b/src/libs/kata-types/tests/test-config.rs
@@ -1,41 +1,452 @@
-use kata_types::config::{QemuConfig, TomlConfig, HYPERVISOR_NAME_QEMU};
-use std::fs;
-use std::path::Path;
+#[cfg(test)]
+mod tests {
+    use kata_types::annotations::{
+        Annotation, KATA_ANNO_CONF_AGENT_CONTAINER_PIPE_SIZE, KATA_ANNO_CONF_AGENT_TRACE,
+        KATA_ANNO_CONF_DISABLE_GUEST_SECCOMP, KATA_ANNO_CONF_ENABLE_PPROF,
+        KATA_ANNO_CONF_EXPERIMENTAL, KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_NOFLUSH,
+        KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER, KATA_ANNO_CONF_HYPERVISOR_CTLPATH,
+        KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY, KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS,
+        KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP, KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS,
+        KATA_ANNO_CONF_HYPERVISOR_ENABLE_SWAP, KATA_ANNO_CONF_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR,
+        KATA_ANNO_CONF_HYPERVISOR_GUEST_HOOK_PATH, KATA_ANNO_CONF_HYPERVISOR_HUGE_PAGES,
+        KATA_ANNO_CONF_HYPERVISOR_JAILER_PATH, KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH,
+        KATA_ANNO_CONF_HYPERVISOR_MEMORY_PREALLOC, KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS,
+        KATA_ANNO_CONF_HYPERVISOR_PATH, KATA_ANNO_CONF_HYPERVISOR_VHOSTUSER_STORE_PATH,
+        KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_DAEMON, KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS,
+        KATA_ANNO_CONF_HYPERVISOR_VIRTIO_MEM, KATA_ANNO_CONF_KERNEL_MODULES,
+    };
+    use kata_types::config::KataConfig;
+    use kata_types::config::{QemuConfig, TomlConfig};
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::Path;
+    #[test]
+    fn test_change_config_annotation() {
+        let path = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
+        let content = fs::read_to_string(&path).unwrap();
 
-#[test]
-fn test_load_qemu_config() {
-    let plugin = QemuConfig::new();
-    plugin.register();
+        let qemu = QemuConfig::new();
+        qemu.register();
 
-    let path = env!("CARGO_MANIFEST_DIR");
-    let path = Path::new(path).join("tests/texture/configuration-qemu.toml");
-    let content = fs::read_to_string(&path).unwrap();
-    let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(config, "qemu", "agent0");
 
-    let qemu = config.hypervisor.get(HYPERVISOR_NAME_QEMU).unwrap();
-    assert_eq!(qemu.path, "/usr/bin/ls");
-    assert_eq!(qemu.valid_hypervisor_paths.len(), 2);
-    assert_eq!(qemu.valid_hypervisor_paths[0], "/usr/bin/qemu*");
-    assert_eq!(qemu.valid_hypervisor_paths[1], "/opt/qemu?");
-    qemu.validate_hypervisor_path("/usr/bin/qemu0").unwrap();
-    qemu.validate_hypervisor_path("/usr/bin/qemu1").unwrap();
-    qemu.validate_hypervisor_path("/usr/bin/qemu2222").unwrap();
-    qemu.validate_hypervisor_path("/opt/qemu3").unwrap();
-    qemu.validate_hypervisor_path("/opt/qemu").unwrap_err();
-    qemu.validate_hypervisor_path("/opt/qemu33").unwrap_err();
-    assert_eq!(qemu.ctlpath, "/usr/bin/ls");
-    assert_eq!(qemu.valid_ctlpaths.len(), 0);
-    assert!(qemu.jailer_path.is_empty());
-    assert_eq!(qemu.valid_jailer_paths.len(), 0);
-    assert_eq!(qemu.disable_nesting_checks, true);
-    assert_eq!(qemu.enable_iothreads, true);
+        std::process::Command::new("mkdir")
+            .arg("./hypervisor_path")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("mkdir")
+            .arg("./store_path")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("mkdir")
+            .arg("./test_hypervisor_hook_path")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("mkdir")
+            .arg("./jvm")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("mkdir")
+            .arg("./test_file_backend_mem_root")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("mkdir")
+            .arg("./test_jailer_path")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("mkdir")
+            .arg("./test_kernel_path")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("mkdir")
+            .arg("./virtio_fs")
+            .output()
+            .expect("failed to execute process");
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_KERNEL_MODULES.to_string(),
+            "j465 aaa=1;r33w".to_string(),
+        );
+        anno_hash.insert(KATA_ANNO_CONF_AGENT_TRACE.to_string(), "false".to_string());
+        anno_hash.insert(
+            KATA_ANNO_CONF_AGENT_CONTAINER_PIPE_SIZE.to_string(),
+            "3".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_PATH.to_string(),
+            "./hypervisor_path".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER.to_string(),
+            "device".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_NOFLUSH.to_string(),
+            "false".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_VHOSTUSER_STORE_PATH.to_string(),
+            "./store_path".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_DISABLE_GUEST_SECCOMP.to_string(),
+            "true".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_GUEST_HOOK_PATH.to_string(),
+            "./test_hypervisor_hook_path".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_MEMORY_PREALLOC.to_string(),
+            "false".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_CTLPATH.to_string(),
+            "./jvm".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS.to_string(),
+            "12".to_string(),
+        );
+        anno_hash.insert(KATA_ANNO_CONF_ENABLE_PPROF.to_string(), "false".to_string());
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP.to_string(),
+            "false".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY.to_string(),
+            "100".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS.to_string(),
+            "false".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS.to_string(),
+            "false".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_ENABLE_SWAP.to_string(),
+            "false".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR.to_string(),
+            "./test_file_backend_mem_root".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_HUGE_PAGES.to_string(),
+            "false".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_JAILER_PATH.to_string(),
+            "./test_jailer_path".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH.to_string(),
+            "./test_kernel_path".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS.to_string(),
+            "100".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS.to_string(),
+            "rr,dg,er".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_VIRTIO_MEM.to_string(),
+            "false".to_string(),
+        );
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_DAEMON.to_string(),
+            "./virtio_fs".to_string(),
+        );
+        anno_hash.insert(KATA_ANNO_CONF_EXPERIMENTAL.to_string(), "c,d,e".to_string());
 
-    assert_eq!(qemu.boot_info.image, "/usr/bin/echo");
-    assert_eq!(qemu.boot_info.kernel, "/usr/bin/id");
-    assert_eq!(qemu.boot_info.kernel_params, "ro");
-    assert_eq!(qemu.boot_info.firmware, "/etc/hostname");
+        let anno = Annotation::new(anno_hash);
+        let mut config = TomlConfig::load(&content).unwrap();
 
-    assert_eq!(qemu.cpu_info.cpu_features, "pmu=off,vmx=off");
-    assert_eq!(qemu.cpu_info.default_vcpus, 2);
-    assert_eq!(qemu.cpu_info.default_maxvcpus, 64);
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_ok());
+        KataConfig::set_active_config(config, "qemu", "agnet0");
+        if let Some(ag) = KataConfig::get_default_config().get_agent() {
+            assert_eq!(
+                ag.kernel_modules[0],
+                "e1000e InterruptThrottleRate=3000,3000,3000 EEE=1"
+            );
+
+            assert_eq!(ag.kernel_modules[1], "i915_enabled_ppgtt=0");
+            assert_eq!(ag.kernel_modules[2], "j465 aaa=1");
+            assert_eq!(ag.kernel_modules[3], "r33w");
+            assert!(!ag.enable_tracing);
+            assert_eq!(ag.container_pipe_size, 3);
+        }
+        if let Some(hv) = KataConfig::get_default_config().get_hypervisor() {
+            assert_eq!(hv.path, "./hypervisor_path".to_string());
+            assert_eq!(hv.blockdev_info.block_device_driver, "device");
+            assert!(!hv.blockdev_info.block_device_cache_noflush);
+            assert!(hv.blockdev_info.block_device_cache_set);
+            assert_eq!(hv.blockdev_info.vhost_user_store_path, "./store_path");
+            assert_eq!(
+                hv.security_info.guest_hook_path,
+                "./test_hypervisor_hook_path"
+            );
+            assert!(!hv.memory_info.enable_mem_prealloc);
+            assert_eq!(hv.ctlpath, "./jvm".to_string());
+            assert_eq!(hv.cpu_info.default_vcpus, 12);
+            assert!(!hv.memory_info.enable_guest_swap);
+            assert_eq!(hv.memory_info.default_memory, 100);
+            assert!(!hv.enable_iothreads);
+            assert!(!hv.enable_iothreads);
+            assert!(!hv.memory_info.enable_swap);
+            assert_eq!(
+                hv.memory_info.file_mem_backend,
+                "./test_file_backend_mem_root"
+            );
+            assert!(!hv.memory_info.enable_hugepages);
+            assert_eq!(hv.jailer_path, "./test_jailer_path".to_string());
+            assert_eq!(hv.boot_info.kernel, "./test_kernel_path");
+            assert_eq!(hv.memory_info.memory_slots, 100);
+            assert_eq!(hv.shared_fs.virtio_fs_extra_args[5], "rr");
+            assert_eq!(hv.shared_fs.virtio_fs_extra_args[6], "dg");
+            assert_eq!(hv.shared_fs.virtio_fs_extra_args[7], "er");
+            assert!(!hv.memory_info.enable_virtio_mem);
+            assert_eq!(hv.shared_fs.virtio_fs_daemon, "./virtio_fs");
+        }
+
+        assert!(
+            KataConfig::get_active_config()
+                .get_config()
+                .runtime
+                .disable_guest_seccomp
+        );
+
+        assert!(
+            !KataConfig::get_active_config()
+                .get_config()
+                .runtime
+                .enable_pprof
+        );
+        assert_eq!(
+            KataConfig::get_active_config()
+                .get_config()
+                .runtime
+                .experimental,
+            ["a", "b", "c", "d", "e"]
+        );
+        std::process::Command::new("rmdir")
+            .arg("./hypervisor_path")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("rmdir")
+            .arg("./test_hypervisor_hook_path")
+            .output()
+            .expect("failed to execute process");
+
+        std::process::Command::new("rmdir")
+            .arg("./test_file_backend_mem_root")
+            .output()
+            .expect("failed to execute process");
+
+        std::process::Command::new("rmdir")
+            .arg("./test_jailer_path")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("rmdir")
+            .arg("./test_kernel_path")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("rmdir")
+            .arg("./virtio_fs")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("rmdir")
+            .arg("./jvm")
+            .output()
+            .expect("failed to execute process");
+        std::process::Command::new("rmdir")
+            .arg("./store_path")
+            .output()
+            .expect("failed to execute process");
+    }
+
+    #[test]
+    fn test_fail_to_change_block_device_driver_because_not_enabled() {
+        let path = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(path).join("tests/texture/configuration-anno-1.toml");
+        let content = fs::read_to_string(&path).unwrap();
+
+        let qemu = QemuConfig::new();
+        qemu.register();
+
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(config, "qemu", "agent0");
+
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER.to_string(),
+            "fvfvfvfvf".to_string(),
+        );
+        let anno = Annotation::new(anno_hash);
+        let mut config = TomlConfig::load(&content).unwrap();
+
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_err());
+    }
+
+    #[test]
+    fn test_fail_to_change_enable_guest_swap_because_not_enabled() {
+        let path = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(path).join("tests/texture/configuration-anno-1.toml");
+        let content = fs::read_to_string(&path).unwrap();
+
+        let qemu = QemuConfig::new();
+        qemu.register();
+
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(config, "qemu", "agent0");
+
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP.to_string(),
+            "false".to_string(),
+        );
+        let anno = Annotation::new(anno_hash);
+        let mut config = TomlConfig::load(&content).unwrap();
+
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_err());
+    }
+
+    #[test]
+    fn test_fail_to_change_hypervisor_path_because_of_invalid_path() {
+        let path = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
+        let content = fs::read_to_string(&path).unwrap();
+
+        let qemu = QemuConfig::new();
+        qemu.register();
+
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(config, "qemu", "agent0");
+
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_PATH.to_string(),
+            "/usr/bin/nle".to_string(),
+        );
+        let anno = Annotation::new(anno_hash);
+
+        let path = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
+        let content = fs::read_to_string(&path).unwrap();
+        let mut config = TomlConfig::load(&content).unwrap();
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_err());
+    }
+
+    #[test]
+    fn test_fail_to_change_kernel_path_because_of_invalid_path() {
+        let path = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
+        let content = fs::read_to_string(&path).unwrap();
+
+        let qemu = QemuConfig::new();
+        qemu.register();
+
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(config, "qemu", "agent0");
+
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH.to_string(),
+            "/usr/bin/cdcd".to_string(),
+        );
+        let anno = Annotation::new(anno_hash);
+        let mut config = TomlConfig::load(&content).unwrap();
+
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_err());
+    }
+
+    #[test]
+    fn test_fail_to_change_memory_slots_because_of_less_than_zero() {
+        let path = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
+        let content = fs::read_to_string(&path).unwrap();
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(config, "qemu", "agent0");
+
+        let qemu = QemuConfig::new();
+        qemu.register();
+
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS.to_string(),
+            "-1".to_string(),
+        );
+        let anno = Annotation::new(anno_hash);
+        let mut config = TomlConfig::load(&content).unwrap();
+
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_err());
+    }
+
+    #[test]
+    fn test_fail_to_change_default_memory_because_less_than_min_memory_size() {
+        let path = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
+        let content = fs::read_to_string(&path).unwrap();
+
+        let qemu = QemuConfig::new();
+        qemu.register();
+
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(config, "qemu", "agent0");
+
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY.to_string(),
+            "10".to_string(),
+        );
+        let anno = Annotation::new(anno_hash);
+        let mut config = TomlConfig::load(&content).unwrap();
+
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_err());
+    }
+
+    #[test]
+    fn test_fail_to_change_default_vcpus_becuase_more_than_max_cpu_size() {
+        let path = env!("CARGO_MANIFEST_DIR");
+        let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
+        let content = fs::read_to_string(&path).unwrap();
+
+        let qemu = QemuConfig::new();
+        qemu.register();
+
+        let config = TomlConfig::load(&content).unwrap();
+        KataConfig::set_active_config(config, "qemu", "agent0");
+
+        let mut anno_hash = HashMap::new();
+        anno_hash.insert(
+            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS.to_string(),
+            "400".to_string(),
+        );
+        let anno = Annotation::new(anno_hash);
+        let mut config = TomlConfig::load(&content).unwrap();
+
+        assert!(anno
+            .update_config_by_annotation(&mut config, "qemu", "agent0")
+            .is_err());
+    }
 }

--- a/src/libs/kata-types/tests/test-config.rs
+++ b/src/libs/kata-types/tests/test-config.rs
@@ -1,3 +1,7 @@
+// Copyright (c) 2019-2021 Alibaba Cloud
+//
+// SPDX-License-Identifier: Apache-2.0
+//
 #[cfg(test)]
 mod tests {
     use kata_types::annotations::{

--- a/src/libs/kata-types/tests/test-config.rs
+++ b/src/libs/kata-types/tests/test-config.rs
@@ -1,0 +1,41 @@
+use kata_types::config::{QemuConfig, TomlConfig, HYPERVISOR_NAME_QEMU};
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn test_load_qemu_config() {
+    let plugin = QemuConfig::new();
+    plugin.register();
+
+    let path = env!("CARGO_MANIFEST_DIR");
+    let path = Path::new(path).join("tests/texture/configuration-qemu.toml");
+    let content = fs::read_to_string(&path).unwrap();
+    let config = TomlConfig::load(&content).unwrap();
+
+    let qemu = config.hypervisor.get(HYPERVISOR_NAME_QEMU).unwrap();
+    assert_eq!(qemu.path, "/usr/bin/ls");
+    assert_eq!(qemu.valid_hypervisor_paths.len(), 2);
+    assert_eq!(qemu.valid_hypervisor_paths[0], "/usr/bin/qemu*");
+    assert_eq!(qemu.valid_hypervisor_paths[1], "/opt/qemu?");
+    qemu.validate_hypervisor_path("/usr/bin/qemu0").unwrap();
+    qemu.validate_hypervisor_path("/usr/bin/qemu1").unwrap();
+    qemu.validate_hypervisor_path("/usr/bin/qemu2222").unwrap();
+    qemu.validate_hypervisor_path("/opt/qemu3").unwrap();
+    qemu.validate_hypervisor_path("/opt/qemu").unwrap_err();
+    qemu.validate_hypervisor_path("/opt/qemu33").unwrap_err();
+    assert_eq!(qemu.ctlpath, "/usr/bin/ls");
+    assert_eq!(qemu.valid_ctlpaths.len(), 0);
+    assert!(qemu.jailer_path.is_empty());
+    assert_eq!(qemu.valid_jailer_paths.len(), 0);
+    assert_eq!(qemu.disable_nesting_checks, true);
+    assert_eq!(qemu.enable_iothreads, true);
+
+    assert_eq!(qemu.boot_info.image, "/usr/bin/echo");
+    assert_eq!(qemu.boot_info.kernel, "/usr/bin/id");
+    assert_eq!(qemu.boot_info.kernel_params, "ro");
+    assert_eq!(qemu.boot_info.firmware, "/etc/hostname");
+
+    assert_eq!(qemu.cpu_info.cpu_features, "pmu=off,vmx=off");
+    assert_eq!(qemu.cpu_info.default_vcpus, 2);
+    assert_eq!(qemu.cpu_info.default_maxvcpus, 64);
+}

--- a/src/libs/kata-types/tests/test_config.rs
+++ b/src/libs/kata-types/tests/test_config.rs
@@ -5,19 +5,19 @@
 #[cfg(test)]
 mod tests {
     use kata_types::annotations::{
-        Annotation, KATA_ANNO_CONF_AGENT_CONTAINER_PIPE_SIZE, KATA_ANNO_CONF_AGENT_TRACE,
-        KATA_ANNO_CONF_DISABLE_GUEST_SECCOMP, KATA_ANNO_CONF_ENABLE_PPROF,
-        KATA_ANNO_CONF_EXPERIMENTAL, KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_NOFLUSH,
-        KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER, KATA_ANNO_CONF_HYPERVISOR_CTLPATH,
-        KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY, KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS,
-        KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP, KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS,
-        KATA_ANNO_CONF_HYPERVISOR_ENABLE_SWAP, KATA_ANNO_CONF_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR,
-        KATA_ANNO_CONF_HYPERVISOR_GUEST_HOOK_PATH, KATA_ANNO_CONF_HYPERVISOR_HUGE_PAGES,
-        KATA_ANNO_CONF_HYPERVISOR_JAILER_PATH, KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH,
-        KATA_ANNO_CONF_HYPERVISOR_MEMORY_PREALLOC, KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS,
-        KATA_ANNO_CONF_HYPERVISOR_PATH, KATA_ANNO_CONF_HYPERVISOR_VHOSTUSER_STORE_PATH,
-        KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_DAEMON, KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS,
-        KATA_ANNO_CONF_HYPERVISOR_VIRTIO_MEM, KATA_ANNO_CONF_KERNEL_MODULES,
+        Annotation, KATA_ANNO_CFG_AGENT_CONTAINER_PIPE_SIZE, KATA_ANNO_CFG_AGENT_TRACE,
+        KATA_ANNO_CFG_DISABLE_GUEST_SECCOMP, KATA_ANNO_CFG_ENABLE_PPROF,
+        KATA_ANNO_CFG_EXPERIMENTAL, KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_CACHE_NOFLUSH,
+        KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_DRIVER, KATA_ANNO_CFG_HYPERVISOR_CTLPATH,
+        KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MEMORY, KATA_ANNO_CFG_HYPERVISOR_DEFAULT_VCPUS,
+        KATA_ANNO_CFG_HYPERVISOR_ENABLE_GUEST_SWAP, KATA_ANNO_CFG_HYPERVISOR_ENABLE_IO_THREADS,
+        KATA_ANNO_CFG_HYPERVISOR_ENABLE_SWAP, KATA_ANNO_CFG_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR,
+        KATA_ANNO_CFG_HYPERVISOR_GUEST_HOOK_PATH, KATA_ANNO_CFG_HYPERVISOR_HUGE_PAGES,
+        KATA_ANNO_CFG_HYPERVISOR_JAILER_PATH, KATA_ANNO_CFG_HYPERVISOR_KERNEL_PATH,
+        KATA_ANNO_CFG_HYPERVISOR_MEMORY_PREALLOC, KATA_ANNO_CFG_HYPERVISOR_MEMORY_SLOTS,
+        KATA_ANNO_CFG_HYPERVISOR_PATH, KATA_ANNO_CFG_HYPERVISOR_VHOSTUSER_STORE_PATH,
+        KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_DAEMON, KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS,
+        KATA_ANNO_CFG_HYPERVISOR_VIRTIO_MEM, KATA_ANNO_CFG_KERNEL_MODULES,
     };
     use kata_types::config::KataConfig;
     use kata_types::config::{QemuConfig, TomlConfig};
@@ -67,104 +67,104 @@ mod tests {
             .expect("failed to execute process");
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_KERNEL_MODULES.to_string(),
+            KATA_ANNO_CFG_KERNEL_MODULES.to_string(),
             "j465 aaa=1;r33w".to_string(),
         );
-        anno_hash.insert(KATA_ANNO_CONF_AGENT_TRACE.to_string(), "false".to_string());
+        anno_hash.insert(KATA_ANNO_CFG_AGENT_TRACE.to_string(), "false".to_string());
         anno_hash.insert(
-            KATA_ANNO_CONF_AGENT_CONTAINER_PIPE_SIZE.to_string(),
+            KATA_ANNO_CFG_AGENT_CONTAINER_PIPE_SIZE.to_string(),
             "3".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_PATH.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_PATH.to_string(),
             "./hypervisor_path".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_DRIVER.to_string(),
             "device".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_CACHE_NOFLUSH.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_CACHE_NOFLUSH.to_string(),
             "false".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_VHOSTUSER_STORE_PATH.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_VHOSTUSER_STORE_PATH.to_string(),
             "./store_path".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_DISABLE_GUEST_SECCOMP.to_string(),
+            KATA_ANNO_CFG_DISABLE_GUEST_SECCOMP.to_string(),
             "true".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_GUEST_HOOK_PATH.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_GUEST_HOOK_PATH.to_string(),
             "./test_hypervisor_hook_path".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_MEMORY_PREALLOC.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_MEMORY_PREALLOC.to_string(),
             "false".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_CTLPATH.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_CTLPATH.to_string(),
             "./jvm".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_DEFAULT_VCPUS.to_string(),
             "12".to_string(),
         );
-        anno_hash.insert(KATA_ANNO_CONF_ENABLE_PPROF.to_string(), "false".to_string());
+        anno_hash.insert(KATA_ANNO_CFG_ENABLE_PPROF.to_string(), "false".to_string());
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_ENABLE_GUEST_SWAP.to_string(),
             "false".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MEMORY.to_string(),
             "100".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_ENABLE_IO_THREADS.to_string(),
             "false".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_ENABLE_IO_THREADS.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_ENABLE_IO_THREADS.to_string(),
             "false".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_ENABLE_SWAP.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_ENABLE_SWAP.to_string(),
             "false".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR.to_string(),
             "./test_file_backend_mem_root".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_HUGE_PAGES.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_HUGE_PAGES.to_string(),
             "false".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_JAILER_PATH.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_JAILER_PATH.to_string(),
             "./test_jailer_path".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_KERNEL_PATH.to_string(),
             "./test_kernel_path".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_MEMORY_SLOTS.to_string(),
             "100".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS.to_string(),
             "rr,dg,er".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_VIRTIO_MEM.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_VIRTIO_MEM.to_string(),
             "false".to_string(),
         );
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_VIRTIO_FS_DAEMON.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_DAEMON.to_string(),
             "./virtio_fs".to_string(),
         );
-        anno_hash.insert(KATA_ANNO_CONF_EXPERIMENTAL.to_string(), "c,d,e".to_string());
+        anno_hash.insert(KATA_ANNO_CFG_EXPERIMENTAL.to_string(), "c,d,e".to_string());
 
         let anno = Annotation::new(anno_hash);
         let mut config = TomlConfig::load(&content).unwrap();
@@ -286,7 +286,7 @@ mod tests {
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_BLOCK_DEVICE_DRIVER.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_DRIVER.to_string(),
             "fvfvfvfvf".to_string(),
         );
         let anno = Annotation::new(anno_hash);
@@ -309,7 +309,7 @@ mod tests {
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_ENABLE_GUEST_SWAP.to_string(),
             "false".to_string(),
         );
         let anno = Annotation::new(anno_hash);
@@ -332,7 +332,7 @@ mod tests {
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_PATH.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_PATH.to_string(),
             "/usr/bin/nle".to_string(),
         );
         let anno = Annotation::new(anno_hash);
@@ -360,7 +360,7 @@ mod tests {
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_KERNEL_PATH.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_KERNEL_PATH.to_string(),
             "/usr/bin/cdcd".to_string(),
         );
         let anno = Annotation::new(anno_hash);
@@ -382,7 +382,7 @@ mod tests {
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_MEMORY_SLOTS.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_MEMORY_SLOTS.to_string(),
             "-1".to_string(),
         );
         let anno = Annotation::new(anno_hash);
@@ -405,7 +405,7 @@ mod tests {
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_MEMORY.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MEMORY.to_string(),
             "10".to_string(),
         );
         let anno = Annotation::new(anno_hash);
@@ -428,7 +428,7 @@ mod tests {
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_DEFAULT_VCPUS.to_string(),
             "400".to_string(),
         );
         let anno = Annotation::new(anno_hash);
@@ -451,7 +451,7 @@ mod tests {
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_ENABLE_GUEST_SWAP.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_ENABLE_GUEST_SWAP.to_string(),
             "false1".to_string(),
         );
         let anno = Annotation::new(anno_hash);
@@ -474,7 +474,7 @@ mod tests {
 
         let mut anno_hash = HashMap::new();
         anno_hash.insert(
-            KATA_ANNO_CONF_HYPERVISOR_DEFAULT_VCPUS.to_string(),
+            KATA_ANNO_CFG_HYPERVISOR_DEFAULT_VCPUS.to_string(),
             "ddc".to_string(),
         );
         let anno = Annotation::new(anno_hash);

--- a/src/libs/kata-types/tests/test_config.rs
+++ b/src/libs/kata-types/tests/test_config.rs
@@ -30,7 +30,7 @@ mod tests {
         let qemu = QemuConfig::new();
         qemu.register();
 
-        let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         std::process::Command::new("mkdir")
@@ -167,7 +167,7 @@ mod tests {
         anno_hash.insert(KATA_ANNO_CFG_EXPERIMENTAL.to_string(), "c,d,e".to_string());
 
         let anno = Annotation::new(anno_hash);
-        let mut config = TomlConfig::load(&content).unwrap();
+        let mut config = TomlConfig::load(content).unwrap();
 
         assert!(anno
             .update_config_by_annotation(&mut config, "qemu", "agent0")
@@ -281,7 +281,7 @@ mod tests {
         let qemu = QemuConfig::new();
         qemu.register();
 
-        let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
@@ -290,7 +290,7 @@ mod tests {
             "fvfvfvfvf".to_string(),
         );
         let anno = Annotation::new(anno_hash);
-        let mut config = TomlConfig::load(&content).unwrap();
+        let mut config = TomlConfig::load(content).unwrap();
 
         assert!(anno
             .update_config_by_annotation(&mut config, "qemu", "agent0")
@@ -304,7 +304,7 @@ mod tests {
         let qemu = QemuConfig::new();
         qemu.register();
 
-        let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
@@ -313,7 +313,7 @@ mod tests {
             "false".to_string(),
         );
         let anno = Annotation::new(anno_hash);
-        let mut config = TomlConfig::load(&content).unwrap();
+        let mut config = TomlConfig::load(content).unwrap();
 
         assert!(anno
             .update_config_by_annotation(&mut config, "qemu", "agent0")
@@ -327,7 +327,7 @@ mod tests {
         let qemu = QemuConfig::new();
         qemu.register();
 
-        let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
@@ -374,7 +374,7 @@ mod tests {
     #[test]
     fn test_fail_to_change_memory_slots_because_of_less_than_zero() {
         let content = include_str!("texture/configuration-anno-0.toml");
-        let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let qemu = QemuConfig::new();
@@ -386,7 +386,7 @@ mod tests {
             "-1".to_string(),
         );
         let anno = Annotation::new(anno_hash);
-        let mut config = TomlConfig::load(&content).unwrap();
+        let mut config = TomlConfig::load(content).unwrap();
 
         assert!(anno
             .update_config_by_annotation(&mut config, "qemu", "agent0")
@@ -400,7 +400,7 @@ mod tests {
         let qemu = QemuConfig::new();
         qemu.register();
 
-        let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
@@ -409,7 +409,7 @@ mod tests {
             "10".to_string(),
         );
         let anno = Annotation::new(anno_hash);
-        let mut config = TomlConfig::load(&content).unwrap();
+        let mut config = TomlConfig::load(content).unwrap();
 
         assert!(anno
             .update_config_by_annotation(&mut config, "qemu", "agent0")
@@ -423,7 +423,7 @@ mod tests {
         let qemu = QemuConfig::new();
         qemu.register();
 
-        let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
@@ -432,7 +432,7 @@ mod tests {
             "400".to_string(),
         );
         let anno = Annotation::new(anno_hash);
-        let mut config = TomlConfig::load(&content).unwrap();
+        let mut config = TomlConfig::load(content).unwrap();
 
         assert!(anno
             .update_config_by_annotation(&mut config, "qemu", "agent0")
@@ -446,7 +446,7 @@ mod tests {
         let qemu = QemuConfig::new();
         qemu.register();
 
-        let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
@@ -455,7 +455,7 @@ mod tests {
             "false1".to_string(),
         );
         let anno = Annotation::new(anno_hash);
-        let mut config = TomlConfig::load(&content).unwrap();
+        let mut config = TomlConfig::load(content).unwrap();
 
         assert!(anno
             .update_config_by_annotation(&mut config, "qemu", "agent0")
@@ -469,7 +469,7 @@ mod tests {
         let qemu = QemuConfig::new();
         qemu.register();
 
-        let config = TomlConfig::load(&content).unwrap();
+        let config = TomlConfig::load(content).unwrap();
         KataConfig::set_active_config(Some(config), "qemu", "agent0");
 
         let mut anno_hash = HashMap::new();
@@ -478,7 +478,7 @@ mod tests {
             "ddc".to_string(),
         );
         let anno = Annotation::new(anno_hash);
-        let mut config = TomlConfig::load(&content).unwrap();
+        let mut config = TomlConfig::load(content).unwrap();
 
         assert!(anno
             .update_config_by_annotation(&mut config, "qemu", "agent0")

--- a/src/libs/kata-types/tests/texture/configuration-anno-0.toml
+++ b/src/libs/kata-types/tests/texture/configuration-anno-0.toml
@@ -1,12 +1,14 @@
 [hypervisor.qemu]
-path = "/usr/bin/ls"
-valid_hypervisor_paths = ["/usr/bin/qemu*", "/opt/qemu?"]
-ctlpath = "/usr/bin/ls"
+path = "/usr/bin/lsns"
+valid_hypervisor_paths = ["/usr/bin/qemu*", "/opt/qemu?","/usr/bin/ls*","./hypervisor_path"]
+valid_jailer_paths = ["/usr/lib/rust","./test_jailer_path"]
+ctlpath = "/usr/bin/"
+valid_ctlpaths = ["/usr/lib/jvm","usr/bin/qemu-io","./jvm"]
 disable_nesting_checks = true
 enable_iothreads = true
-
-kernel = "/usr/bin/../bin/id"
-image = "/usr/bin/./echo"
+jailer_path = "/usr/local"
+kernel = "/usr/bin/../bin/zcmp"
+image = "/usr/bin/./tabs"
 kernel_params = "ro"
 firmware = "/etc/hostname"
 
@@ -17,7 +19,7 @@ default_maxvcpus = 64
 machine_type = "q35"
 confidential_guest = true
 rootless = true
-enable_annotations = ["path", "ctlpath"] 
+enable_annotations = ["shared_fs","path", "ctlpath","jailer_path","enable_iothreads","default_memory","memory_slots","enable_mem_prealloc","enable_hugepages","file_mem_backend","enable_virtio_mem","enable_swap","enable_guest_swap","default_vcpus","virtio_fs_extra_args","block_device_driver","vhost_user_store_path","kernel","guest_hook_path","block_device_cache_noflush","virtio_fs_daemon"] 
 machine_accelerators="noapic"
 default_bridges = 2
 default_memory = 128
@@ -26,8 +28,8 @@ memory_offset = 0x100000
 enable_virtio_mem = true
 disable_block_device_use = false
 shared_fs = "virtio-fs"
-virtio_fs_daemon = "/usr/bin/id"
-valid_virtio_fs_daemon_paths = ["/usr/local/bin/virtiofsd*"]
+virtio_fs_daemon = "/usr/bin/uptime"
+valid_virtio_fs_daemon_paths = ["/usr/local/bin/virtiofsd*","./virtio_fs"]
 virtio_fs_cache_size = 512
 virtio_fs_extra_args = ["-o", "arg1=xxx,arg2", "-o", "hello world", "--arg3=yyy"]
 virtio_fs_cache = "always"
@@ -39,11 +41,11 @@ enable_mem_prealloc = true
 enable_hugepages = true
 enable_vhost_user_store = true
 vhost_user_store_path = "/tmp"
-valid_vhost_user_store_paths = ["/var/kata/vhost-user-store*", "/tmp/kata?"]
+valid_vhost_user_store_paths = ["/var/kata/vhost-user-store*", "/tmp/kata?","/var/tmp","./store_path"]
 enable_iommu = true
 enable_iommu_platform = true
 file_mem_backend = "/dev/shm"
-valid_file_mem_backends = ["/dev/shm"]
+valid_file_mem_backends = ["/dev/shm","/dev/snd","./test_file_backend_mem_root"]
 enable_swap = true
 pflashes = ["/proc/mounts"]
 enable_debug = true
@@ -54,17 +56,24 @@ pcie_root_port = 2
 disable_vhost_net = true
 entropy_source= "/dev/urandom"
 valid_entropy_sources = ["/dev/urandom", "/dev/random"]
-guest_hook_path = "/usr/share/oci/hooks"
+guest_hook_path = "/usr/share"
 rx_rate_limiter_max_rate = 10000
 tx_rate_limiter_max_rate = 10000
 guest_memory_dump_path="/var/crash/kata"
 guest_memory_dump_paging = true
 enable_guest_swap = true
 
+[agent.agent0]
+enable_tracing = true
+debug_console_enabled = true
+debug = true
+dial_timeout = 1
+kernel_modules = ["e1000e InterruptThrottleRate=3000,3000,3000 EEE=1","i915_enabled_ppgtt=0"]
+container_pipe_size = 2
 [runtime]
 enable_debug = true
 internetworking_model="macvtap"
-disable_guest_seccomp=true
+disable_guest_seccomp=false
 enable_tracing = true
 jaeger_endpoint = "localhost:1234"
 jaeger_user = "user"
@@ -75,4 +84,5 @@ sandbox_bind_mounts=["/proc/self"]
 vfio_mode="vfio"
 experimental=["a", "b"]
 enable_pprof = true
+
 

--- a/src/libs/kata-types/tests/texture/configuration-anno-1.toml
+++ b/src/libs/kata-types/tests/texture/configuration-anno-1.toml
@@ -1,0 +1,87 @@
+[hypervisor.qemu]
+path = "/usr/bin/lsns"
+valid_hypervisor_paths = ["/usr/bin/qemu*", "/opt/qemu?","/usr/bin/lsns","./hypervisor_path"]
+valid_jailer_paths = ["/usr/lib/rust"]
+ctlpath = "/usr/bin"
+disable_nesting_checks = true
+enable_iothreads = true
+jailer_path = "/usr/local"
+kernel = "/usr/bin/../bin/uptime"
+image = "/usr/bin/./lessecho"
+kernel_params = "ro"
+firmware = "/etc/hostname"
+
+cpu_features="pmu=off,vmx=off"
+default_vcpus = 2
+default_maxvcpus = 64
+
+machine_type = "q35"
+confidential_guest = true
+rootless = true
+enable_annotations = ["path", "ctlpath","jailer_path"] 
+machine_accelerators="noapic"
+default_bridges = 2
+default_memory = 128
+memory_slots = 128
+memory_offset = 0x100000
+enable_virtio_mem = true
+disable_block_device_use = false
+shared_fs = "virtio-fs"
+virtio_fs_daemon = "/usr/bin/uptime"
+valid_virtio_fs_daemon_paths = ["/usr/local/bin/virtiofsd*"]
+virtio_fs_cache_size = 512
+virtio_fs_extra_args = ["-o", "arg1=xxx,arg2", "-o", "hello world", "--arg3=yyy"]
+virtio_fs_cache = "always"
+block_device_driver = "virtio-blk"
+block_device_cache_set = true
+block_device_cache_direct = true
+block_device_cache_noflush = true
+enable_mem_prealloc = true
+enable_hugepages = true
+enable_vhost_user_store = true
+vhost_user_store_path = "/tmp"
+valid_vhost_user_store_paths = ["/var/kata/vhost-user-store*", "/tmp/kata?"]
+enable_iommu = true
+enable_iommu_platform = true
+file_mem_backend = "/dev/shm"
+valid_file_mem_backends = ["/dev/shm"]
+enable_swap = true
+pflashes = ["/proc/mounts"]
+enable_debug = true
+msize_9p = 16384
+disable_image_nvdimm = true
+hotplug_vfio_on_root_bus = true
+pcie_root_port = 2
+disable_vhost_net = true
+entropy_source= "/dev/urandom"
+valid_entropy_sources = ["/dev/urandom", "/dev/random"]
+guest_hook_path = "/usr/share/oci/hooks"
+rx_rate_limiter_max_rate = 10000
+tx_rate_limiter_max_rate = 10000
+guest_memory_dump_path="/var/crash/kata"
+guest_memory_dump_paging = true
+enable_guest_swap = true
+
+[agent.agent0]
+enable_tracing = true
+debug_console_enabled = true
+debug = true
+dial_timeout = 1
+kernel_modules = ["e1000e InterruptThrottleRate=3000,3000,3000 EEE=1","i915_enabled_ppgtt=0"]
+container_pipe_size = 2
+[runtime]
+enable_debug = true
+internetworking_model="macvtap"
+pdisable_guest_seccomp=true
+enable_tracing = true
+jaeger_endpoint = "localhost:1234"
+jaeger_user = "user"
+jaeger_password = "pw"
+disable_new_netns = true
+sandbox_cgroup_only=true
+sandbox_bind_mounts=["/proc/self"]
+vfio_mode="vfio"
+experimental=["a", "b"]
+enable_pprof = true
+
+

--- a/src/libs/kata-types/tests/texture/configuration-qemu.toml
+++ b/src/libs/kata-types/tests/texture/configuration-qemu.toml
@@ -1,0 +1,78 @@
+[hypervisor.qemu]
+path = "/usr/bin/ls"
+valid_hypervisor_paths = ["/usr/bin/qemu*", "/opt/qemu?"]
+ctlpath = "/usr/bin/ls"
+disable_nesting_checks = true
+enable_iothreads = true
+
+kernel = "/usr/bin/../bin/id"
+image = "/usr/bin/./echo"
+kernel_params = "ro"
+firmware = "/etc/hostname"
+
+cpu_features="pmu=off,vmx=off"
+default_vcpus = 2
+default_maxvcpus = 64
+
+machine_type = "q35"
+confidential_guest = true
+rootless = true
+enable_annotations = ["path", "ctlpath"] 
+machine_accelerators="noapic"
+default_bridges = 2
+default_memory = 128
+memory_slots = 128
+memory_offset = 0x100000
+enable_virtio_mem = true
+disable_block_device_use = false
+shared_fs = "virtio-fs"
+virtio_fs_daemon = "/usr/bin/id"
+valid_virtio_fs_daemon_paths = ["/usr/local/bin/virtiofsd*"]
+virtio_fs_cache_size = 512
+virtio_fs_extra_args = ["-o", "arg1=xxx,arg2", "-o", "hello world", "--arg3=yyy"]
+virtio_fs_cache = "always"
+block_device_driver = "virtio-blk"
+block_device_cache_set = true
+block_device_cache_direct = true
+block_device_cache_noflush = true
+enable_mem_prealloc = true
+enable_hugepages = true
+enable_vhost_user_store = true
+vhost_user_store_path = "/tmp"
+valid_vhost_user_store_paths = ["/var/kata/vhost-user-store*", "/tmp/kata?"]
+enable_iommu = true
+enable_iommu_platform = true
+file_mem_backend = "/dev/shm"
+valid_file_mem_backends = ["/dev/shm"]
+enable_swap = true
+pflashes = ["/proc/mounts"]
+enable_debug = true
+msize_9p = 16384
+disable_image_nvdimm = true
+hotplug_vfio_on_root_bus = true
+pcie_root_port = 2
+disable_vhost_net = true
+entropy_source= "/dev/urandom"
+valid_entropy_sources = ["/dev/urandom", "/dev/random"]
+guest_hook_path = "/usr/share/oci/hooks"
+rx_rate_limiter_max_rate = 10000
+tx_rate_limiter_max_rate = 10000
+guest_memory_dump_path="/var/crash/kata"
+guest_memory_dump_paging = true
+enable_guest_swap = true
+
+[runtime]
+enable_debug = true
+internetworking_model="macvtap"
+disable_guest_seccomp=true
+enable_tracing = true
+jaeger_endpoint = "localhost:1234"
+jaeger_user = "user"
+jaeger_password = "pw"
+disable_new_netns = true
+sandbox_cgroup_only=true
+sandbox_bind_mounts=["/proc/self"]
+vfio_mode="vfio"
+experimental=["a", "b"]
+enable_pprof = true
+


### PR DESCRIPTION
Redefined the data structure for kata config and be able to update kata config securely by annotation
Fixes: #3523
