### PR TITLE
ci: Pass function arguments in static-checks.sh

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -36,7 +36,7 @@ run_static_checks()
 	# Make sure we have the targeting branch
 	git remote set-branches --add origin "${branch}"
 	git fetch -a
-	bash "$tests_repo_dir/.ci/static-checks.sh" "github.com/kata-containers/kata-containers"
+	bash "$tests_repo_dir/.ci/static-checks.sh" "$@"
 }
 
 run_go_test()

--- a/ci/static-checks.sh
+++ b/ci/static-checks.sh
@@ -9,4 +9,4 @@ set -e
 cidir=$(dirname "$0")
 source "${cidir}/lib.sh"
 
-run_static_checks
+run_static_checks "${@:-github.com/kata-containers/kata-containers}"


### PR DESCRIPTION
e.g. when called from the tests repo

Fixes: #3525
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

Forward-port of #3526