### PR TITLE
stable-2.3 | kata-monitor: increase delay before syncing with the container manager

### DIFF
--- a/src/runtime/pkg/kata-monitor/monitor.go
+++ b/src/runtime/pkg/kata-monitor/monitor.go
@@ -24,7 +24,7 @@ const (
 	RuntimeContainerd           = "containerd"
 	RuntimeCRIO                 = "cri-o"
 	fsMonitorRetryDelaySeconds  = 60
-	podCacheRefreshDelaySeconds = 5
+	podCacheRefreshDelaySeconds = 60
 )
 
 // SetLogger sets the logger for katamonitor package.
@@ -85,7 +85,7 @@ func (km *KataMonitor) startPodCacheUpdater() {
 		break
 	}
 	// we refresh the pod cache once if we get multiple add/delete pod events in a short time (< podCacheRefreshDelaySeconds)
-	cacheUpdateTimer := time.NewTimer(podCacheRefreshDelaySeconds * time.Second)
+	cacheUpdateTimer := time.NewTimer(5 * time.Second)
 	cacheUpdateTimerWasSet := false
 	for {
 		select {


### PR DESCRIPTION
This is meant to address #3550 on the stable branch.

### Proposal
We are stable, so we probably don't want to backport #3553 here.
Since we use the sync with the container manager basically to just remove pods from the cache, we can wait some more time before syncing (and so reduce the chance to miss a kata pod just because it was not ready yet) without missing reporting any metric. The sync will just clean-up the sandbox cache from stale entries.

So, let's just raise the waiting time before starting the sync timer to an higher value: this will not fix the issue (if a pod has not completely started when the sync timer fires, we will miss its metrics till a new kata pod starts / is removed) but will make the issue to be much more unlikely to happen.