### PR TITLE
kata-deploy: Fix the tag replacement logic

### DIFF
--- a/tools/packaging/kata-deploy/action/test-kata.sh
+++ b/tools/packaging/kata-deploy/action/test-kata.sh
@@ -99,6 +99,14 @@ function test_kata() {
 
     YAMLPATH="./tools/packaging/kata-deploy/"
     VERSION=$(cat ./VERSION)
+    # kata-deploy.yaml and kata-cleanup.yaml do not have tags for the non-stable releases, thus
+    # in this cases, let's ensure we use "latest" as version.
+    # For more details, please, see:
+    # https://github.com/kata-containers/kata-containers/blob/f7c7dc8d33288e588b284ae4820df342aa8e2d74/tools/packaging/release/update-repository-version.sh#L143-L179
+    if [[ $VERSION =~ "alpha"|"rc" ]];
+    then
+	    VERSION="latest"
+    fi
 
     # This action could be called in two contexts:
     #  1. Packaging workflows: testing in packaging repository, where we assume yaml/packaging


### PR DESCRIPTION
When building a non-stable release, the tag is **always** "latest¨,
instead of the version. The same magic done for setting the correct
tags up should be done for replacing the tag on the kata-deploy and
kata-cleanup yaml files, as part of the kata-deploy test.

Fixes: #3559

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>