### PR TITLE
workflows: stop checking revert commit

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -22,9 +22,15 @@ jobs:
     - name: Get PR Commits
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       id: 'get-pr-commits'
-      uses: tim-actions/get-pr-commits@v1.0.0
+      uses: tim-actions/get-pr-commits@v1.2.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
+        # Filter out revert commits
+        # The format of a revert commit is as follows:
+        #
+        # Revert "<original-subject-line>"
+        #
+        filter_out_pattern: '^Revert "'
 
     - name: DCO Check
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}


### PR DESCRIPTION
The commit message of a revert commit usually generated by
`git revert`, we should consider this as legal.

Consider the commit as the merge commit if the subject
starts with 'Reject "'

Follow the pr kata-containers/tests#3938, the suttle diffrence
is we skip all commit checks for revert commit including fixes checking
and subsystem checking. Because the commit was reverted must have passed
the check so the revert-commit should have the Fixes and Subsystem.

Fixes: #3568
Fixes: kata-containers/tests#3934

Signed-off-by: Tim Zhang <tim@hyper.sh>