### PR TITLE
virtcontainers: Enable initrd for Cloud Hypervisor

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -778,14 +778,9 @@ func newClhHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		return vc.HypervisorConfig{}, err
 	}
 
-	if initrd != "" {
+	if image == "" && initrd == "" {
 		return vc.HypervisorConfig{},
-			errors.New("having an initrd defined in the configuration file is not supported")
-	}
-
-	if image == "" {
-		return vc.HypervisorConfig{},
-			errors.New("image must be defined in the configuration file")
+			errors.New("image or initrd must be defined in the configuration file")
 	}
 
 	firmware, err := h.firmware()

--- a/src/runtime/virtcontainers/virtcontainers_test.go
+++ b/src/runtime/virtcontainers/virtcontainers_test.go
@@ -44,6 +44,7 @@ var testQemuImagePath = ""
 var testQemuPath = ""
 var testClhKernelPath = ""
 var testClhImagePath = ""
+var testClhInitrdPath = ""
 var testClhPath = ""
 var testAcrnKernelPath = ""
 var testAcrnImagePath = ""
@@ -157,6 +158,7 @@ func TestMain(m *testing.M) {
 	testVirtiofsdPath = filepath.Join(testDir, testBundle, testVirtiofsd)
 	testClhKernelPath = filepath.Join(testDir, testBundle, testKernel)
 	testClhImagePath = filepath.Join(testDir, testBundle, testImage)
+	testClhInitrdPath = filepath.Join(testDir, testBundle, testInitrd)
 	testClhPath = filepath.Join(testDir, testBundle, testHypervisor)
 
 	setupClh()


### PR DESCRIPTION
Since CH has supported booting with an initramfs since version 0.7.0
[1], allow an `initrd=` to be specified.

Fixes: #3566.

[1] - https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v0.7.0

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>