### PR TITLE
versions: update Rust to 1.58.1

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -685,8 +685,8 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
             Mode::from_bits_truncate(0),
         )?;
         unistd::close(fifofd)?;
-        let mut buf: &mut [u8] = &mut [0];
-        unistd::read(fd, &mut buf)?;
+        let buf: &mut [u8] = &mut [0];
+        unistd::read(fd, buf)?;
     }
 
     // With NoNewPrivileges, we should set seccomp as close to

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -728,7 +728,7 @@ fn secure_join(rootfs: &str, unsafe_path: &str) -> String {
         path.push(it);
         if let Ok(v) = path.read_link() {
             if v.is_absolute() {
-                path = PathBuf::from(format!("{}{}", rootfs, v.to_str().unwrap().to_string()));
+                path = PathBuf::from(format!("{}{}", rootfs, v.to_str().unwrap()));
             } else {
                 path.pop();
                 for it in v.iter() {

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -23,12 +23,7 @@ pub const NSTYPEPID: &str = "pid";
 
 #[instrument]
 pub fn get_current_thread_ns_path(ns_type: &str) -> String {
-    format!(
-        "/proc/{}/task/{}/ns/{}",
-        getpid().to_string(),
-        gettid().to_string(),
-        ns_type
-    )
+    format!("/proc/{}/task/{}/ns/{}", getpid(), gettid(), ns_type)
 }
 
 #[derive(Debug)]

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -436,11 +436,8 @@ fn online_cpus(logger: &Logger, num: i32) -> Result<i32> {
             r"cpu[0-9]+",
             num - onlined_count,
         );
-        if r.is_err() {
-            return r;
-        }
 
-        onlined_count += r.unwrap();
+        onlined_count += r?;
         if onlined_count == num {
             info!(logger, "online {} CPU(s) after {} retries", num, i);
             return Ok(num);

--- a/src/agent/src/watcher.rs
+++ b/src/agent/src/watcher.rs
@@ -284,7 +284,7 @@ impl Storage {
             .with_context(|| {
                 format!(
                     "Failed to strip prefix: {} - {}",
-                    source_file_path.as_ref().display().to_string(),
+                    source_file_path.as_ref().display(),
                     &self.source_mount_point.display()
                 )
             })?;

--- a/versions.yaml
+++ b/versions.yaml
@@ -260,12 +260,12 @@ languages:
   rust:
     description: "Rust language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.45.0"
+    version: "1.58.1"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.54.0"
+      newest-version: "1.58.1"
 
 specs:
   description: "Details of important specifications"


### PR DESCRIPTION
Update Rust to 1.58.1 to fix CVE-2022-21658.

Fixes: #3570

Signed-off-by: bin <bin@hyper.sh>