### PR TITLE
stable-2.3-backports

### DIFF
--- a/.github/workflows/PR-wip-checks.yaml
+++ b/.github/workflows/PR-wip-checks.yaml
@@ -15,6 +15,7 @@ jobs:
     name: WIP Check
     steps:
     - name: WIP Check
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       uses: tim-actions/wip-check@1c2a1ca6c110026b3e2297bb2ef39e1747b5a755
       with:
         labels: '["do-not-merge", "wip", "rfc"]'

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -18,24 +18,26 @@ jobs:
     name: Commit Message Check
     steps:
     - name: Get PR Commits
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       id: 'get-pr-commits'
       uses: tim-actions/get-pr-commits@v1.0.0
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
 
     - name: DCO Check
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       uses: tim-actions/dco@2fd0504dc0d27b33f542867c300c60840c6dcb20
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
 
     - name: Commit Body Missing Check
-      if: ${{ success() || failure() }}
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
       uses: tim-actions/commit-body-check@v1.0.2
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
 
     - name: Check Subject Line Length
-      if: ${{ success() || failure() }}
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
@@ -44,7 +46,7 @@ jobs:
         post_error: ${{ env.error_msg }}
 
     - name: Check Body Line Length
-      if: ${{ success() || failure() }}
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
@@ -71,7 +73,7 @@ jobs:
         post_error: ${{ env.error_msg }}
 
     - name: Check Fixes
-      if: ${{ success() || failure() }}
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
@@ -82,7 +84,7 @@ jobs:
         one_pass_all_pass: 'true'
 
     - name: Check Subsystem
-      if: ${{ success() || failure() }}
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && ( success() || failure() ) }}
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -5,6 +5,8 @@ on:
       - opened
       - reopened
       - synchronize
+      - labeled
+      - unlabeled
 
 env:
   error_msg: |+

--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -19,11 +19,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Install docker
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           curl -fsSL https://test.docker.com -o test-docker.sh
           sh test-docker.sh
 
       - name: Build ${{ matrix.asset }}
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
@@ -33,6 +35,7 @@ jobs:
           KATA_ASSET: ${{ matrix.asset }}
 
       - name: store-artifact ${{ matrix.asset }}
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         uses: actions/upload-artifact@v2
         with:
           name: kata-artifacts
@@ -45,14 +48,17 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: get-artifacts
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         uses: actions/download-artifact@v2
         with:
           name: kata-artifacts
           path: build
       - name: merge-artifacts
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           make merge-builds
       - name: store-artifacts
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         uses: actions/upload-artifact@v2
         with:
           name: kata-static-tarball
@@ -63,6 +69,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: make kata-tarball
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           make kata-tarball
           sudo make install-tarball

--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -9,7 +9,7 @@ on:
       - synchronize
       - labeled
       - unlabeled
-  push
+  push:
 
 jobs:
   build-asset:

--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -1,6 +1,15 @@
 name: kata deploy build
 
-on: [push, pull_request]
+on: 
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+  push
 
 jobs:
   build-asset:

--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -48,7 +48,18 @@ jobs:
           - rootfs-initrd
           - shim-v2
     steps:
+      # As Github action event `issue_comment` does not provide the right ref
+      # (commit/branch) to be tested, let's use this third part action to work
+      # this limitation around.
+      - name: resolve pr refs
+        id: refs
+        uses: kata-containers/resolve-pr-refs@v0.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
       - name: Install docker
         run: |
           curl -fsSL https://test.docker.com -o test-docker.sh
@@ -75,7 +86,17 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-asset
     steps:
+      # As Github action event `issue_comment` does not provide the right ref
+      # (commit/branch) to be tested, let's use this third part action to work
+      # this limitation around.
+      - name: resolve pr refs
+        id: refs
+        uses: kata-containers/resolve-pr-refs@v0.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
       - name: get-artifacts
         uses: actions/download-artifact@v2
         with:
@@ -94,7 +115,17 @@ jobs:
     needs: create-kata-tarball
     runs-on: ubuntu-latest
     steps:
+      # As Github action event `issue_comment` does not provide the right ref
+      # (commit/branch) to be tested, let's use this third part action to work
+      # this limitation around.
+      - name: resolve pr refs
+        id: refs
+        uses: kata-containers/resolve-pr-refs@v0.0.3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.refs.outputs.head_ref }}
       - name: get-kata-tarball
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/move-issues-to-in-progress.yaml
+++ b/.github/workflows/move-issues-to-in-progress.yaml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install hub
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           HUB_ARCH="amd64"
           HUB_VER=$(curl -sL "https://api.github.com/repos/github/hub/releases/latest" |\
@@ -26,6 +27,7 @@ jobs:
           sudo install hub /usr/local/bin
 
       - name: Install hub extension script
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           # Clone into a temporary directory to avoid overwriting
           # any existing github directory.
@@ -35,9 +37,11 @@ jobs:
           popd &>/dev/null
 
       - name: Checkout code to allow hub to communicate with the project
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         uses: actions/checkout@v2
 
       - name: Move issue to "In progress"
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         env:
           GITHUB_TOKEN: ${{ secrets.KATA_GITHUB_ACTIONS_TOKEN }}
         run: |

--- a/.github/workflows/move-issues-to-in-progress.yaml
+++ b/.github/workflows/move-issues-to-in-progress.yaml
@@ -10,6 +10,8 @@ on:
     types:
       - opened
       - reopened
+      - labeled
+      - unlabeled
 
 jobs:
   move-linked-issues-to-in-progress:

--- a/.github/workflows/require-pr-porting-labels.yaml
+++ b/.github/workflows/require-pr-porting-labels.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Install hub
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           HUB_ARCH="amd64"
           HUB_VER=$(curl -sL "https://api.github.com/repos/github/hub/releases/latest" |\
@@ -30,6 +31,7 @@ jobs:
           sudo install hub /usr/local/bin
 
       - name: Checkout code to allow hub to communicate with the project
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         uses: actions/checkout@v2
 
       - name: Install porting checker script
@@ -42,6 +44,7 @@ jobs:
           popd &>/dev/null
 
       - name: Stop PR being merged unless it has a correct set of porting labels
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         env:
           GITHUB_TOKEN: ${{ secrets.KATA_GITHUB_ACTIONS_TOKEN }}
         run: |

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -1,5 +1,14 @@
 name: snap CI
-on: ["pull_request"]
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+      - labeled
+      - unlabeled
+
 jobs:
   test:
     runs-on: ubuntu-20.04

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -5,13 +5,16 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
       - name: Install Snapcraft
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         uses: samuelmeuli/action-snapcraft@v1
 
       - name: Build snap
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           snapcraft -d snap --destructive-mode

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -604,33 +604,44 @@ func (c *Container) unmountHostMounts(ctx context.Context) error {
 	span, ctx := katatrace.Trace(ctx, c.Logger(), "unmountHostMounts", containerTracingTags, map[string]string{"container_id": c.id})
 	defer span.End()
 
+	unmountFunc := func(m Mount) (err error) {
+		span, _ := katatrace.Trace(ctx, c.Logger(), "unmount", containerTracingTags, map[string]string{"container_id": c.id, "host-path": m.HostPath})
+		defer func() {
+			if err != nil {
+				katatrace.AddTags(span, "error", err)
+			}
+			span.End()
+		}()
+
+		if err = syscall.Unmount(m.HostPath, syscall.MNT_DETACH|UmountNoFollow); err != nil {
+			c.Logger().WithFields(logrus.Fields{
+				"host-path": m.HostPath,
+				"error":     err,
+			}).Warn("Could not umount")
+			return err
+		}
+
+		if m.Type == "bind" {
+			s, err := os.Stat(m.HostPath)
+			if err != nil {
+				return errors.Wrapf(err, "Could not stat host-path %v", m.HostPath)
+			}
+			// Remove the empty file or directory
+			if s.Mode().IsRegular() && s.Size() == 0 {
+				os.Remove(m.HostPath)
+			}
+			if s.Mode().IsDir() {
+				syscall.Rmdir(m.HostPath)
+			}
+		}
+		return nil
+	}
+
 	for _, m := range c.mounts {
 		if m.HostPath != "" {
-			span, _ := katatrace.Trace(ctx, c.Logger(), "unmount", containerTracingTags, map[string]string{"container_id": c.id, "host-path": m.HostPath})
-
-			if err := syscall.Unmount(m.HostPath, syscall.MNT_DETACH|UmountNoFollow); err != nil {
-				c.Logger().WithFields(logrus.Fields{
-					"host-path": m.HostPath,
-					"error":     err,
-				}).Warn("Could not umount")
+			if err := unmountFunc(m); err != nil {
 				return err
 			}
-
-			if m.Type == "bind" {
-				s, err := os.Stat(m.HostPath)
-				if err != nil {
-					return errors.Wrapf(err, "Could not stat host-path %v", m.HostPath)
-				}
-				// Remove the empty file or directory
-				if s.Mode().IsRegular() && s.Size() == 0 {
-					os.Remove(m.HostPath)
-				}
-				if s.Mode().IsDir() {
-					syscall.Rmdir(m.HostPath)
-				}
-			}
-
-			span.End()
 		}
 	}
 

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -2068,10 +2068,20 @@ func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (inter
 	}
 
 	msgName := proto.MessageName(request.(proto.Message))
+
+	k.Lock()
+
+	if k.reqHandlers == nil {
+		return nil, errors.New("Client has already disconnected")
+	}
+
 	handler := k.reqHandlers[msgName]
 	if msgName == "" || handler == nil {
 		return nil, errors.New("Invalid request type")
 	}
+
+	k.Unlock()
+
 	message := request.(proto.Message)
 	ctx, cancel := k.getReqContext(spanCtx, msgName)
 	if cancel != nil {

--- a/tools/packaging/static-build/qemu/build-base-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-base-qemu.sh
@@ -54,4 +54,4 @@ sudo "${container_engine}" run \
 	-v "${PWD}":/share qemu-static \
 	mv "${qemu_destdir}/${qemu_tar}" /share/
 
-sudo chown ${USER}:${USER} "${PWD}/${qemu_tar}"
+sudo chown ${USER}:$(id -gn ${USER}) "${PWD}/${qemu_tar}"


### PR DESCRIPTION
99ed596a workflows: Fix typo in kata-deploy-push action
13b7d93b workflows: Ensure a label change re-triggers the actions
b8463224 workflows: Ensure force-skip-ci skips all actions
8c8571f4 workflows: Use the correct branch ref on test kata-deploy
620bb97e runtime: Provide protection for shared data
770d4acf tools: Fix groupname if it differs from username
cedb01d2 runtime: close span before return from function in case of error
