### PR TITLE
stable-2.3 | workflows: Use base instead of head ref for kata-deploy-test

### DIFF
--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -59,7 +59,7 @@ jobs:
 
       - uses: actions/checkout@v2
         with:
-          ref: ${{ steps.refs.outputs.head_ref }}
+          ref: ${{ steps.refs.outputs.base_ref }}
       - name: Install docker
         run: |
           curl -fsSL https://test.docker.com -o test-docker.sh
@@ -96,7 +96,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
-          ref: ${{ steps.refs.outputs.head_ref }}
+          ref: ${{ steps.refs.outputs.base_ref }}
       - name: get-artifacts
         uses: actions/download-artifact@v2
         with:
@@ -125,7 +125,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@v2
         with:
-          ref: ${{ steps.refs.outputs.head_ref }}
+          ref: ${{ steps.refs.outputs.base_ref }}
       - name: get-kata-tarball
         uses: actions/download-artifact@v2
         with:


### PR DESCRIPTION
Although I've done tests on my own fork using `head_ref` and those
worked, it seems those only worked as the PR was coming from exactly the
same repository as the target one.

Let's switch to base_ref, instead, which we for sure have as part of our
repo.

The downside of this is that we run the test with the last merged PR,
rather than with the "to-be-approved" PR, but that's a limitation we've
always had.

Fixes: #3482

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>
(cherry picked from commit 3924470c8ff3cab4e1e628fc5559e83854f1b479)