### PR TITLE
kata-deploy: for testing, make sure we use the PR branch

### DIFF
--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -9,7 +9,9 @@ on:
       - synchronize
       - labeled
       - unlabeled
-  push:
+    paths:
+      - tools/**
+      - versions.yaml
 
 jobs:
   build-asset:

--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -48,18 +48,16 @@ jobs:
           - rootfs-initrd
           - shim-v2
     steps:
-      # As Github action event `issue_comment` does not provide the right ref
-      # (commit/branch) to be tested, let's use this third part action to work
-      # this limitation around.
-      - name: resolve pr refs
-        id: refs
-        uses: kata-containers/resolve-pr-refs@v0.0.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: get-PR-ref
+        id: get-PR-ref
+        run: |
+            ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
+            echo "reference for PR: " ${ref}
+            echo "##[set-output name=pr-ref;]${ref}"
       - uses: actions/checkout@v2
         with:
-          ref: ${{ steps.refs.outputs.base_ref }}
+          ref: ${{ steps.get-PR-ref.outputs.pr-ref }}
+
       - name: Install docker
         run: |
           curl -fsSL https://test.docker.com -o test-docker.sh
@@ -86,17 +84,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-asset
     steps:
-      # As Github action event `issue_comment` does not provide the right ref
-      # (commit/branch) to be tested, let's use this third part action to work
-      # this limitation around.
-      - name: resolve pr refs
-        id: refs
-        uses: kata-containers/resolve-pr-refs@v0.0.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: get-PR-ref
+        id: get-PR-ref
+        run: |
+            ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
+            echo "reference for PR: " ${ref}
+            echo "##[set-output name=pr-ref;]${ref}"
       - uses: actions/checkout@v2
         with:
-          ref: ${{ steps.refs.outputs.base_ref }}
+          ref: ${{ steps.get-PR-ref.outputs.pr-ref }}
       - name: get-artifacts
         uses: actions/download-artifact@v2
         with:
@@ -115,17 +111,15 @@ jobs:
     needs: create-kata-tarball
     runs-on: ubuntu-latest
     steps:
-      # As Github action event `issue_comment` does not provide the right ref
-      # (commit/branch) to be tested, let's use this third part action to work
-      # this limitation around.
-      - name: resolve pr refs
-        id: refs
-        uses: kata-containers/resolve-pr-refs@v0.0.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: get-PR-ref
+        id: get-PR-ref
+        run: |
+            ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
+            echo "reference for PR: " ${ref}
+            echo "##[set-output name=pr-ref;]${ref}"
       - uses: actions/checkout@v2
         with:
-          ref: ${{ steps.refs.outputs.base_ref }}
+          ref: ${{ steps.get-PR-ref.outputs.pr-ref }}
       - name: get-kata-tarball
         uses: actions/download-artifact@v2
         with:
@@ -133,18 +127,14 @@ jobs:
       - name: build-and-push-kata-deploy-ci
         id: build-and-push-kata-deploy-ci
         run: |
-          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
-          pushd $GITHUB_WORKSPACE
-          git checkout $tag
-          pkg_sha=$(git rev-parse HEAD)
-          popd
+          PR_SHA=$(git log --format=format:%H -n1)
           mv kata-static.tar.xz $GITHUB_WORKSPACE/tools/packaging/kata-deploy/kata-static.tar.xz
-          docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t quay.io/kata-containers/kata-deploy-ci:$pkg_sha $GITHUB_WORKSPACE/tools/packaging/kata-deploy
+          docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t quay.io/kata-containers/kata-deploy-ci:$PR_SHA $GITHUB_WORKSPACE/tools/packaging/kata-deploy
           docker login -u ${{ secrets.QUAY_DEPLOYER_USERNAME }} -p ${{ secrets.QUAY_DEPLOYER_PASSWORD }} quay.io
-          docker push quay.io/kata-containers/kata-deploy-ci:$pkg_sha
+          docker push quay.io/kata-containers/kata-deploy-ci:$PR_SHA
           mkdir -p packaging/kata-deploy
           ln -s $GITHUB_WORKSPACE/tools/packaging/kata-deploy/action packaging/kata-deploy/action
-          echo "::set-output name=PKG_SHA::${pkg_sha}"
+          echo "::set-output name=PKG_SHA::${PR_SHA}"
       - name: test-kata-deploy-ci-in-aks
         uses: ./packaging/kata-deploy/action
         with:


### PR DESCRIPTION
## Changes

This pull request makes two changes to the kata-deploy worfklows.

1. For kata-deploy-test, let's make sure we are exercising changes that are introduced by the PR itself, rather than our base. With this, you can expect changes to our build scripts and/or kata-deploy scripts to be exercised. This doesn't change behavior, however, if changes to the kata-deploy-test workflow itself. Developers will need to continue using a fork to verify these (which is how this PR is tested - details below).
2. For kata-deploy-push:
 *  let's make sure that we only run the workflow if the PR includes changes to ./tools/**. This way, we don't waste cycles for every single PR, and only exercise for use case that we care about (ensuring that ./tools/packaging and ./tools/osbuilder are still running correctly).  This'll reduce our load on GitHub Actions, and should reduce our average queue time for jobs.

## Testing

To verify the change in behavior for (1): 
- In this repo, verify existing behavior, showing that we don't exercise changes, as described in (1). See https://github.com/kata-containers/kata-containers/actions/runs/1781160146, which shows the pipeline succeeding, despite my test PR which breaks the build. 
- In my fork, which is enabled to run the tests, I set *my* main to match this PR. Running same PR on top of this, we can see that the builds are failing, and that the GitHub action is catching this failure: See https://github.com/egernst/kata-containers/runs/5029448370?check_suite_focus=true

### ** Additional test **
To ensure this _also_ works on non-main branch, I tested on my fork, instead with a PR to stable-foobar:
 - action run: https://github.com/egernst/kata-containers/runs/5039331801?check_suite_focus=true#step:5:13
 - PR: https://github.com/egernst/kata-containers/pull/14


To verify (2):
- I have shown following PR which will just run on main without checks, for non ./tools paths:  https://github.com/kata-containers/kata-containers/pull/3588
- With PR in place, we can see that workflow changes are not exercised if path doesn't include ./tools/** in [1] , and that the job will run if tools is touched in [2].
[1] - https://github.com/egernst/kata-containers/pull/12
[2] - https://github.com/egernst/kata-containers/pull/13


Signed-off-by: Eric Ernst <eric_ernst@apple.com>