### PR TITLE
virtcontainers: Do not add a virtio-rng-ccw device

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -619,13 +619,16 @@ func (q *qemu) CreateVM(ctx context.Context, id string, networkNS NetworkNamespa
 		qemuConfig.IOThreads = []govmmQemu.IOThread{*ioThread}
 	}
 	// Add RNG device to hypervisor
-	rngDev := config.RNGDev{
-		ID:       rngID,
-		Filename: q.config.EntropySource,
-	}
-	qemuConfig.Devices, err = q.arch.appendRNGDevice(ctx, qemuConfig.Devices, rngDev)
-	if err != nil {
-		return err
+	// Skip for s390x as CPACF is used
+	if machine.Type != QemuCCWVirtio {
+		rngDev := config.RNGDev{
+			ID:       rngID,
+			Filename: q.config.EntropySource,
+		}
+		qemuConfig.Devices, err = q.arch.appendRNGDevice(ctx, qemuConfig.Devices, rngDev)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Add PCIe Root Port devices to hypervisor


### PR DESCRIPTION
On s390x, skip adding a virtio-rng device. The on-chip CPACF provides
entropy instead. For Confidential Containers, when using Secure
Execution, entropy attacks on virtio-rng are mitigated.

Fixes: #3598
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @stevenhorsman -- might be good to have in CCv0 soonish. But I'm creating this upon main because it is a general issue.