### PR TITLE
GitHub-actions: backport kata-deploy workflow fixes

### DIFF
--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -9,7 +9,8 @@ on:
       - synchronize
       - labeled
       - unlabeled
-  push:
+    paths:
+      - tools/**
 
 jobs:
   build-asset:

--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -48,18 +48,16 @@ jobs:
           - rootfs-initrd
           - shim-v2
     steps:
-      # As Github action event `issue_comment` does not provide the right ref
-      # (commit/branch) to be tested, let's use this third part action to work
-      # this limitation around.
-      - name: resolve pr refs
-        id: refs
-        uses: kata-containers/resolve-pr-refs@v0.0.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-
+      - name: get-PR-ref
+        id: get-PR-ref
+        run: |
+            ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
+            echo "reference for PR: " ${ref}
+            echo "##[set-output name=pr-ref;]${ref}"
       - uses: actions/checkout@v2
         with:
-          ref: ${{ steps.refs.outputs.base_ref }}
+          ref: ${{ steps.get-PR-ref.outputs.pr-ref }}
+
       - name: Install docker
         run: |
           curl -fsSL https://test.docker.com -o test-docker.sh
@@ -86,17 +84,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-asset
     steps:
-      # As Github action event `issue_comment` does not provide the right ref
-      # (commit/branch) to be tested, let's use this third part action to work
-      # this limitation around.
-      - name: resolve pr refs
-        id: refs
-        uses: kata-containers/resolve-pr-refs@v0.0.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: get-PR-ref
+        id: get-PR-ref
+        run: |
+            ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
+            echo "reference for PR: " ${ref}
+            echo "##[set-output name=pr-ref;]${ref}"
       - uses: actions/checkout@v2
         with:
-          ref: ${{ steps.refs.outputs.base_ref }}
+          ref: ${{ steps.get-PR-ref.outputs.pr-ref }}
       - name: get-artifacts
         uses: actions/download-artifact@v2
         with:
@@ -115,17 +111,15 @@ jobs:
     needs: create-kata-tarball
     runs-on: ubuntu-latest
     steps:
-      # As Github action event `issue_comment` does not provide the right ref
-      # (commit/branch) to be tested, let's use this third part action to work
-      # this limitation around.
-      - name: resolve pr refs
-        id: refs
-        uses: kata-containers/resolve-pr-refs@v0.0.3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      - name: get-PR-ref
+        id: get-PR-ref
+        run: |
+            ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
+            echo "reference for PR: " ${ref}
+            echo "##[set-output name=pr-ref;]${ref}"
       - uses: actions/checkout@v2
         with:
-          ref: ${{ steps.refs.outputs.base_ref }}
+          ref: ${{ steps.get-PR-ref.outputs.pr-ref }}
       - name: get-kata-tarball
         uses: actions/download-artifact@v2
         with:
@@ -133,18 +127,14 @@ jobs:
       - name: build-and-push-kata-deploy-ci
         id: build-and-push-kata-deploy-ci
         run: |
-          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
-          pushd $GITHUB_WORKSPACE
-          git checkout $tag
-          pkg_sha=$(git rev-parse HEAD)
-          popd
+          PR_SHA=$(git log --format=format:%H -n1)
           mv kata-static.tar.xz $GITHUB_WORKSPACE/tools/packaging/kata-deploy/kata-static.tar.xz
-          docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t quay.io/kata-containers/kata-deploy-ci:$pkg_sha $GITHUB_WORKSPACE/tools/packaging/kata-deploy
+          docker build --build-arg KATA_ARTIFACTS=kata-static.tar.xz -t quay.io/kata-containers/kata-deploy-ci:$PR_SHA $GITHUB_WORKSPACE/tools/packaging/kata-deploy
           docker login -u ${{ secrets.QUAY_DEPLOYER_USERNAME }} -p ${{ secrets.QUAY_DEPLOYER_PASSWORD }} quay.io
-          docker push quay.io/kata-containers/kata-deploy-ci:$pkg_sha
+          docker push quay.io/kata-containers/kata-deploy-ci:$PR_SHA
           mkdir -p packaging/kata-deploy
           ln -s $GITHUB_WORKSPACE/tools/packaging/kata-deploy/action packaging/kata-deploy/action
-          echo "::set-output name=PKG_SHA::${pkg_sha}"
+          echo "::set-output name=PKG_SHA::${PR_SHA}"
       - name: test-kata-deploy-ci-in-aks
         uses: ./packaging/kata-deploy/action
         with:


### PR DESCRIPTION
Backport of https://github.com/kata-containers/kata-containers/pull/3587

abf329390  kata-deploy-push: only run if PR modifying tools path
3b04d8d82 kata-deploy: for testing, make sure we use the PR branch