### PR TITLE
openshift-ci: switch to CentOS Stream

### DIFF
--- a/ci/openshift-ci/images/Dockerfile.buildroot
+++ b/ci/openshift-ci/images/Dockerfile.buildroot
@@ -4,7 +4,7 @@
 #
 # This is the build root image for Kata Containers on OpenShift CI.
 #
-FROM registry.centos.org/centos:8
+FROM quay.io/centos/centos:stream8
 
 RUN yum -y update && \
     yum -y install \


### PR DESCRIPTION
The build root container is switched from CentOS 8 to Stream 8 as
the former reached EOL.

Fixes #3605
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>