### PR TITLE
Revert "workflows: Ensure a label change re-triggers the actions"

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -5,8 +5,6 @@ on:
       - opened
       - reopened
       - synchronize
-      - labeled
-      - unlabeled
 
 env:
   error_msg: |+

--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -7,8 +7,6 @@ on:
       - edited
       - reopened
       - synchronize
-      - labeled
-      - unlabeled
     paths:
       - tools/**
       - versions.yaml

--- a/.github/workflows/move-issues-to-in-progress.yaml
+++ b/.github/workflows/move-issues-to-in-progress.yaml
@@ -10,8 +10,6 @@ on:
     types:
       - opened
       - reopened
-      - labeled
-      - unlabeled
 
 jobs:
   move-linked-issues-to-in-progress:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -6,8 +6,6 @@ on:
       - synchronize
       - reopened
       - edited
-      - labeled
-      - unlabeled
 
 jobs:
   test:

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -5,8 +5,6 @@ on:
       - edited
       - reopened
       - synchronize
-      - labeled
-      - unlabeled
 
 name: Static checks
 jobs:


### PR DESCRIPTION
This reverts commit 7a879164bd2fa1a7aad7954a2fda8374e8af9968, as it's
been proved that re-triggering the checks at every single change is more
painful than having to close / re-open a PR in case we ever use the
`force-skip-ci` label again.

Fixes: #2804

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>