### PR TITLE
[PoC]hooks: support nerdctl to handle CNI network

### DIFF
--- a/src/runtime/pkg/katautils/hook_test.go
+++ b/src/runtime/pkg/katautils/hook_test.go
@@ -205,3 +205,45 @@ func TestPostStopHooks(t *testing.T) {
 	err = PostStopHooks(ctx, spec, testSandboxID, testBundlePath)
 	assert.Error(err)
 }
+
+func TestCreateRuntimeHooks(t *testing.T) {
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(ktu.TestDisabledNeedRoot)
+	}
+
+	assert := assert.New(t)
+
+	ctx := context.Background()
+
+	// Hooks field is nil
+	spec := specs.Spec{}
+	err := CreateRuntimeHooks(ctx, spec, "", "")
+	assert.NoError(err)
+
+	// Hooks list is empty
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{},
+	}
+	err = CreateRuntimeHooks(ctx, spec, "", "")
+	assert.NoError(err)
+
+	// Run with timeout 0
+	hook := createHook(0)
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{
+			CreateRuntime: []specs.Hook{hook},
+		},
+	}
+	err = CreateRuntimeHooks(ctx, spec, testSandboxID, testBundlePath)
+	assert.NoError(err)
+
+	// Failure due to wrong hook
+	hook = createWrongHook()
+	spec = specs.Spec{
+		Hooks: &specs.Hooks{
+			CreateRuntime: []specs.Hook{hook},
+		},
+	}
+	err = CreateRuntimeHooks(ctx, spec, testSandboxID, testBundlePath)
+	assert.Error(err)
+}

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -31,7 +31,7 @@ type VC interface {
 // (required since virtcontainers.Sandbox only contains private fields)
 type VCSandbox interface {
 	Annotations(key string) (string, error)
-	GetNetNs() string
+	GetNetworkNamespace() NetworkNamespace
 	GetAllContainers() []VCContainer
 	GetAnnotations() map[string]string
 	GetContainer(containerID string) VCContainer

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -39,9 +39,11 @@ func (s *Sandbox) GetAnnotations() map[string]string {
 	return s.MockAnnotations
 }
 
-// GetNetNs returns the network namespace of the current sandbox.
-func (s *Sandbox) GetNetNs() string {
-	return s.MockNetNs
+// GetNetworkNamespace returns the network namespace of the current sandbox.
+func (s *Sandbox) GetNetworkNamespace() vc.NetworkNamespace {
+	return vc.NetworkNamespace{
+		NetNsPath: s.MockNetNs,
+	}
 }
 
 // GetAllContainers implements the VCSandbox function of the same name.

--- a/src/runtime/virtcontainers/pkg/vcmock/types.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/types.go
@@ -32,7 +32,7 @@ type Sandbox struct {
 	AnnotationsFunc          func(key string) (string, error)
 	SetAnnotationsFunc       func(annotations map[string]string) error
 	GetAnnotationsFunc       func() map[string]string
-	GetNetNsFunc             func() string
+	GetNetworkNamespaceFunc  func() vc.NetworkNamespace
 	GetAllContainersFunc     func() []vc.VCContainer
 	GetContainerFunc         func(containerID string) vc.VCContainer
 	ReleaseFunc              func() error

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -270,9 +270,9 @@ func (s *Sandbox) GetAnnotations() map[string]string {
 	return s.config.Annotations
 }
 
-// GetNetNs returns the network namespace of the current sandbox.
-func (s *Sandbox) GetNetNs() string {
-	return s.networkNS.NetNsPath
+// GetNetworkNamespace returns the network namespace of the current sandbox.
+func (s *Sandbox) GetNetworkNamespace() NetworkNamespace {
+	return s.networkNS
 }
 
 // GetHypervisorPid returns the hypervisor's pid.

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -1296,20 +1296,23 @@ func TestPreAddDevice(t *testing.T) {
 		"ignoreMounts should contain nothing because it only contains a block device")
 }
 
-func TestGetNetNs(t *testing.T) {
+func TestGetNetworkNamespace(t *testing.T) {
 	s := Sandbox{}
 
 	expected := ""
-	netNs := s.GetNetNs()
-	assert.Equal(t, netNs, expected)
+	netNs := s.GetNetworkNamespace()
+	assert.Equal(t, netNs.NetNsPath, expected)
+	assert.Equal(t, netNs.NetNsCreated, false)
 
 	expected = "/foo/bar/ns/net"
 	s.networkNS = NetworkNamespace{
-		NetNsPath: expected,
+		NetNsPath:    expected,
+		NetNsCreated: true,
 	}
 
-	netNs = s.GetNetNs()
-	assert.Equal(t, netNs, expected)
+	netNs = s.GetNetworkNamespace()
+	assert.Equal(t, netNs.NetNsPath, expected)
+	assert.Equal(t, netNs.NetNsCreated, true)
 }
 
 func TestSandboxStopStopped(t *testing.T) {


### PR DESCRIPTION
Nerdctl uses internal hooks(added by `nerdctl run` to OCI spec and passed to lower runtimes ) to create CNI network, this commit will:

- add more properties passing to hooks that OCI spec required.
- add createRuntime hook support, preStart hook is deprecated.
- run hooks in network namespace only if the network namespace is created
outside, that is, run hooks in host network namespace if the container
namespace is created by Kata Containers.

Fixes: #1935, #3629

Signed-off-by: bin <bin@hyper.sh>


