### PR TITLE
scripts: fix a typo while to check build_type

### DIFF
--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -352,7 +352,7 @@ setup_kernel() {
 	${packaging_scripts_dir}/apply_patches.sh "${patches_dir_for_version}"
 
 	# Apply version specific patches for build_type build
-	if [ "${build_type}" == "true" ] ;then
+	if [ "${build_type}" != "" ] ;then
 		info "Apply build_type patches from ${build_type_patches_dir}"
 		${packaging_scripts_dir}/apply_patches.sh "${build_type_patches_dir}"
 	fi


### PR DESCRIPTION
check $build_type is not an empty string instead of equal to "true".

Fixes: #3635

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>