### PR TITLE
device: Actually update PCIDEVICE_ environment variables for the guest

### DIFF
--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -765,7 +765,6 @@ pub async fn add_devices(
     sandbox: &Arc<Mutex<Sandbox>>,
 ) -> Result<()> {
     let mut dev_updates = HashMap::<&str, DevUpdate>::with_capacity(devices.len());
-    let mut pci_updates = HashMap::<pci::Address, pci::Address>::new();
 
     for device in devices.iter() {
         let update = add_device(device, sandbox).await?;
@@ -780,8 +779,9 @@ pub async fn add_devices(
                 ));
             }
 
+            let mut sb = sandbox.lock().await;
             for (host, guest) in update.pci {
-                if let Some(other_guest) = pci_updates.insert(host, guest) {
+                if let Some(other_guest) = sb.pcimap.insert(host, guest) {
                     return Err(anyhow!(
                         "Conflicting guest address for host device {} ({} versus {})",
                         host,

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -596,7 +596,10 @@ fn update_spec_devices(spec: &mut Spec, mut updates: HashMap<&str, DevUpdate>) -
 // variables to be correct for the VM instead of the host.  It is
 // given a map of (host address => guest address)
 #[instrument]
-fn update_env_pci(env: &mut [String], pcimap: &HashMap<pci::Address, pci::Address>) -> Result<()> {
+pub fn update_env_pci(
+    env: &mut [String],
+    pcimap: &HashMap<pci::Address, pci::Address>,
+) -> Result<()> {
     for envvar in env {
         let eqpos = envvar
             .find('=')
@@ -793,6 +796,9 @@ pub async fn add_devices(
         }
     }
 
+    if let Some(process) = spec.process.as_mut() {
+        update_env_pci(&mut process.env, &sandbox.lock().await.pcimap)?
+    }
     update_spec_devices(spec, dev_updates)
 }
 

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -8,6 +8,7 @@ use crate::mount::{get_mount_fs_type, remove_mounts, TYPE_ROOTFS};
 use crate::namespace::Namespace;
 use crate::netlink::Handle;
 use crate::network::Network;
+use crate::pci;
 use crate::uevent::{Uevent, UeventMatcher};
 use crate::watcher::BindWatcher;
 use anyhow::{anyhow, Context, Result};
@@ -56,6 +57,7 @@ pub struct Sandbox {
     pub event_rx: Arc<Mutex<Receiver<String>>>,
     pub event_tx: Option<Sender<String>>,
     pub bind_watcher: BindWatcher,
+    pub pcimap: HashMap<pci::Address, pci::Address>,
 }
 
 impl Sandbox {
@@ -88,6 +90,7 @@ impl Sandbox {
             event_rx,
             event_tx: Some(tx),
             bind_watcher: BindWatcher::new(),
+            pcimap: HashMap::new(),
         })
     }
 


### PR DESCRIPTION
In commit `78dff468bf1` we introduced logic to rewrite `PCIDEVICE_` environment variables for the container so that they contain correct addresses for the Kata VM rather than for the host.  Unfortunately, we never actually invoked the function to do this.

It turns out we need to do this not only at container creation time, but also for environment variables supplied to processes exec-ed into the container after creation (e.g. with crictl exec).  Add calls to make both those updates.
