### PR TITLE
trace-forwarder/agent-ctl: run cargo fmt/clippy in make check

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -98,6 +98,8 @@ define INSTALL_FILE
 	install -D -m 644 $1 $(DESTDIR)$2/$1 || exit 1;
 endef
 
+.DEFAULT_GOAL := default
+
 ##TARGET default: build code
 default: $(TARGET) show-header
 
@@ -115,17 +117,6 @@ $(GENERATED_FILES): %: %.in
 ##TARGET optimize: optimized  build
 optimize: $(SOURCES) | show-summary show-header
 	@RUSTFLAGS="-C link-arg=-s $(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE) $(EXTRA_RUSTFEATURES)
-
-##TARGET clippy: run clippy linter
-clippy: $(GENERATED_CODE)
-	cargo clippy --all-targets --all-features --release \
-		-- \
-		-Aclippy::redundant_allocation \
-		-D warnings
-
-format:
-	cargo fmt -- --check
-
 
 ##TARGET install: install agent
 install: install-services
@@ -146,7 +137,7 @@ test:
 	@cargo test --all --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
 
 ##TARGET check: run test
-check: clippy format
+check: $(GENERATED_FILES) standard_rust_check
 
 ##TARGET run: build and run agent
 run:

--- a/src/tools/agent-ctl/Makefile
+++ b/src/tools/agent-ctl/Makefile
@@ -25,7 +25,7 @@ test:
 install:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --target $(TRIPLE) --path .
 
-check:
+check: standard_rust_check
 
 .PHONY: \
 	build \

--- a/src/tools/agent-ctl/Makefile
+++ b/src/tools/agent-ctl/Makefile
@@ -5,6 +5,7 @@
 
 include ../../../utils.mk
 
+.DEFAULT_GOAL := default
 default: build
 
 build: logging-crate-tests

--- a/src/tools/agent-ctl/src/main.rs
+++ b/src/tools/agent-ctl/src/main.rs
@@ -191,11 +191,7 @@ fn connect(name: &str, global_args: clap::ArgMatches) -> Result<()> {
 
     let result = rpc::run(&logger, &cfg, commands);
 
-    if result.is_err() {
-        return result;
-    }
-
-    Ok(())
+    result.map_err(|e| anyhow!(e))
 }
 
 fn real_main() -> Result<()> {

--- a/src/tools/trace-forwarder/Makefile
+++ b/src/tools/trace-forwarder/Makefile
@@ -5,6 +5,7 @@
 
 include ../../../utils.mk
 
+.DEFAULT_GOAL := default
 default: build
 
 build: logging-crate-tests
@@ -24,7 +25,7 @@ test:
 
 install:
 
-check:
+check: standard_rust_check
 
 .PHONY: \
 	build \

--- a/src/tools/trace-forwarder/src/handler.rs
+++ b/src/tools/trace-forwarder/src/handler.rs
@@ -73,8 +73,7 @@ async fn handle_trace_data<'a>(
 
         let payload_len: u64 = NetworkEndian::read_u64(&header);
 
-        let mut encoded_payload = Vec::with_capacity(payload_len as usize);
-        encoded_payload.resize(payload_len as usize, 0);
+        let mut encoded_payload = vec![0; payload_len as usize];
 
         reader
             .read_exact(&mut encoded_payload)

--- a/utils.mk
+++ b/utils.mk
@@ -145,3 +145,9 @@ endif
 TRIPLE = $(ARCH)-unknown-linux-$(LIBC)
 
 CWD := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+standard_rust_check:
+	cargo fmt -- --check
+	cargo clippy --all-targets --all-features --release \
+		-- \
+		-D warnings


### PR DESCRIPTION
Add make check to run cargo fmt/clippy
for Rust projects.

Fixes: #3656

Signed-off-by: bin <bin@hyper.sh>