### PR TITLE
agent: fix hook execution issues

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1489,7 +1489,7 @@ async fn execute_hook(logger: &Logger, h: &Hook, st: &OCIState) -> Result<()> {
         args.remove(0);
     }
 
-    // all invalid envs will be ommit, only valid envs will be passed to hook.
+    // all invalid envs will be omitted, only valid envs will be passed to hook.
     let env: HashMap<&str, &str> = h.env.iter().filter_map(|e| valid_env(e)).collect();
 
     // Avoid the exit signal to be reaped by the global reaper.
@@ -1517,37 +1517,39 @@ async fn execute_hook(logger: &Logger, h: &Hook, st: &OCIState) -> Result<()> {
     let path = h.path.clone();
 
     let join_handle = tokio::spawn(async move {
-        child
-            .stdin
-            .as_mut()
-            .unwrap()
-            .write_all(state.as_bytes())
-            .await
-            .unwrap();
-
-        // Close stdin so that hook program could receive EOF
-        child.stdin.take();
+        if let Some(mut stdin) = child.stdin.take() {
+            match stdin.write_all(state.as_bytes()).await {
+                Ok(_) => {}
+                Err(e) => {
+                    info!(logger, "write to child stdin failed: {:?}", e);
+                }
+            }
+        }
 
         // read something from stdout and stderr for debug
-        let mut out = String::new();
-        child
-            .stdout
-            .as_mut()
-            .unwrap()
-            .read_to_string(&mut out)
-            .await
-            .unwrap();
-        info!(logger, "child stdout: {}", out.as_str());
+        if let Some(stdout) = child.stdout.as_mut() {
+            let mut out = String::new();
+            match stdout.read_to_string(&mut out).await {
+                Ok(_) => {
+                    info!(logger, "child stdout: {}", out.as_str());
+                }
+                Err(e) => {
+                    info!(logger, "read from child stdout failed: {:?}", e);
+                }
+            }
+        }
 
         let mut err = String::new();
-        child
-            .stderr
-            .as_mut()
-            .unwrap()
-            .read_to_string(&mut err)
-            .await
-            .unwrap();
-        info!(logger, "child stderr: {}", err.as_str());
+        if let Some(stderr) = child.stderr.as_mut() {
+            match stderr.read_to_string(&mut err).await {
+                Ok(_) => {
+                    info!(logger, "child stderr: {}", err.as_str());
+                }
+                Err(e) => {
+                    info!(logger, "read from child stderr failed: {:?}", e);
+                }
+            }
+        }
 
         match child.wait().await {
             Ok(exit) => {

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1488,14 +1488,9 @@ async fn execute_hook(logger: &Logger, h: &Hook, st: &OCIState) -> Result<()> {
     if args.len() > 1 {
         args.remove(0);
     }
-    let env: HashMap<String, String> = h
-        .env
-        .iter()
-        .map(|e| {
-            let v: Vec<&str> = e.split('=').collect();
-            (v[0].to_string(), v[1].to_string())
-        })
-        .collect();
+
+    // all invalid envs will be ommit, only valid envs will be passed to hook.
+    let env: HashMap<&str, &str> = h.env.iter().filter_map(|e| valid_env(e)).collect();
 
     // Avoid the exit signal to be reaped by the global reaper.
     let _wait_locker = WAIT_PID_LOCKER.lock().await;
@@ -1506,8 +1501,7 @@ async fn execute_hook(logger: &Logger, h: &Hook, st: &OCIState) -> Result<()> {
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()
-        .unwrap();
+        .spawn()?;
 
     // default timeout 10s
     let mut timeout: u64 = 10;
@@ -1647,13 +1641,16 @@ mod tests {
         let touch = which("touch").await;
 
         defer!(fs::remove_file(temp_file).unwrap(););
+        let invalid_str = vec![97, b'\0', 98];
+        let invalid_string = std::str::from_utf8(&invalid_str).unwrap();
+        let invalid_env = format!("{}=value", invalid_string);
 
         execute_hook(
             &slog_scope::logger(),
             &Hook {
                 path: touch,
                 args: vec!["touch".to_string(), temp_file.to_string()],
-                env: vec![],
+                env: vec![invalid_env],
                 timeout: Some(10),
             },
             &OCIState {


### PR DESCRIPTION
Envs contain null-byte will cause running hooks to panic,
this commit will filter envs and only pass valid envs to hooks.

Fixes: #3667

agent: handle hook process result
The current hook process is handled by just calling
unwrap() on it, sometimes it will cause panic.

Handling all Result types and checking the error can
avoid panic.

Fixes: #3649

Signed-off-by: bin <bin@hyper.sh>