### PR TITLE
tools: clh: Allow to set when to build from sources and the build flags passed down to cargo

### DIFF
--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -15,6 +15,7 @@ ARCH=$(uname -m)
 
 script_dir=$(dirname $(readlink -f "$0"))
 kata_version="${kata_version:-}"
+force_build_from_source="${force_build_from_source:-false}"
 
 source "${script_dir}/../../scripts/lib.sh"
 
@@ -55,7 +56,15 @@ build_clh_from_source() {
     popd
 }
 
-if [ ${ARCH} == "aarch64" ] || ! pull_clh_released_binary; then
-    info "arch is aarch64 or failed to pull cloud-hypervisor released binary on x86_64, trying to build from source"
+if [ "${ARCH}" == "aarch64" ]; then
+    info "aarch64 binaries are not distributed as part of the Cloud Hypervisor releases, forcing to build from source"
+    force_build_from_source="true"
+fi
+
+if [ "${force_build_from_source}" == "true" ]; then
+    info "Build cloud-hypervisor from source as it's been request via the force_build_from_source flag"
     build_clh_from_source
+else
+    pull_clh_released_binary || 
+        (info "Failed to pull cloud-hypervisor released binary, trying to build from source" && build_clh_from_source)
 fi

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -41,6 +41,7 @@ pull_clh_released_binary() {
     curl --fail -L ${cloud_hypervisor_binary} -o cloud-hypervisor-static || return 1
     mkdir -p cloud-hypervisor
     mv -f cloud-hypervisor-static cloud-hypervisor/cloud-hypervisor
+    chmod +x cloud_hypervisor/cloud-hypervisor
 }
 
 build_clh_from_source() {


### PR DESCRIPTION
This short series adds the possibility to force building Cloud Hypervisor from sources as not always the released binary, even if it matches the version we're trying to use / ship, has been built with the needed features enabled.  And talking about building something with the needed features, support for doing this is also added as part of this series.

Fixes: #3672 
Fixes: #3671 