### PR TITLE
Kata manager fix install

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -38,18 +38,36 @@ If you still wish to continue, but prefer a manual installation, see
 
 ## Install a minimal Kata Containers system
 
+By default, the script will attempt to install Kata Containers and
+containerd, and then configure containerd to use Kata Containers. However,
+the script provides a number of options to allow you to change its
+behaviour.
+
+> **Note:**
+>
+> Before running the script to install Kata Containers, we recommend
+> that you [review the available options](#show-available-options).
+
+### Show available options
+
+To show the available options without installing anything, run:
+
+```sh
+$ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh) -h"
+```
+
+### To install Kata Containers only
+
+If your system already has containerd installed, to install Kata Containers and only configure containerd, run:
+
+```sh
+$ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh) -o"
+```
+
+### To install Kata Containers and containerd
+
 To install and configure a system with Kata Containers and containerd, run:
 
 ```bash
 $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh)"
 ```
-
-> **Notes:**
->
-> - The script must be run on a system that does not have Kata Containers or
->   containerd already installed on it.
->
-> - The script accepts up to two parameters which can be used to test
->   pre-release versions (a Kata Containers version, and a containerd
->   version). If either version is unspecified or specified as `""`, the
->   latest official version will be installed.

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -560,9 +560,16 @@ handle_installation()
 
 handle_args()
 {
-	case "${1:-}" in
-		-h|--help|help) usage; exit 0;;
-	esac
+	local opt
+
+	while getopts "h" opt "$@"
+	do
+		case "$opt" in
+			h) usage; exit 0 ;;
+		esac
+	done
+
+	shift $[$OPTIND-1]
 
 	local kata_version="${1:-}"
 	local containerd_version="${2:-}"

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -330,6 +330,8 @@ github_download_package()
 {
 	local releases_url="${1:-}"
 	local requested_version="${2:-}"
+
+	# Only used for error message
 	local project="${3:-}"
 
 	[ -z "$releases_url" ] && die "need releases URL"
@@ -337,7 +339,7 @@ github_download_package()
 
 	local version=$(github_resolve_version_to_download \
 		"$releases_url" \
-		"$version" || true)
+		"$requested_version" || true)
 
 	[ -z "$version" ] && die "Unable to determine $project version to download"
 

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -378,7 +378,7 @@ install_containerd()
 
 	sudo tar -C /usr/local -xvf "${file}"
 
-	sudo ln -s /usr/local/bin/ctr "${link_dir}"
+	sudo ln -sf /usr/local/bin/ctr "${link_dir}"
 
 	info "$project installed\n"
 }

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -191,7 +191,9 @@ Description: Install $kata_project [1] and $containerd_project [2] from GitHub r
 
 Options:
 
- -h : Show this help statement.
+ -c <version> : Specify containerd version.
+ -h           : Show this help statement.
+ -k <version> : Specify Kata Containers version.
 
 Notes:
 
@@ -562,17 +564,22 @@ handle_args()
 {
 	local opt
 
-	while getopts "h" opt "$@"
+	local kata_version=""
+	local containerd_version=""
+
+	while getopts "c:hk:" opt "$@"
 	do
 		case "$opt" in
+			c) containerd_version="$OPTARG" ;;
 			h) usage; exit 0 ;;
+			k) kata_version="$OPTARG" ;;
 		esac
 	done
 
 	shift $[$OPTIND-1]
 
-	local kata_version="${1:-}"
-	local containerd_version="${2:-}"
+	[ -z "$kata_version" ] && kata_version="${1:-}" || true
+	[ -z "$containerd_version" ] && containerd_version="${2:-}" || true
 
 	handle_installation \
 		"$kata_version" \

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -473,7 +473,7 @@ install_kata()
 	# Since we're unpacking to the root directory, perform a sanity check
 	# on the archive first.
 	local unexpected=$(tar -tf "${file}" |\
-		egrep -v "^(\./opt/$|\.${kata_install_dir}/)" || true)
+		egrep -v "^(\./$|\./opt/$|\.${kata_install_dir}/)" || true)
 
 	[ -n "$unexpected" ] && die "File '$file' contains unexpected paths: '$unexpected'"
 


### PR DESCRIPTION
Fix installation of both Kata and containerd for the `kata-manager.sh` script and update the docs.

Fixes: #3674.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>