### PR TITLE
docs: Remove docker run and shared memory from limitations

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -97,13 +97,6 @@ See issue https://github.com/clearcontainers/runtime/issues/341 and [the constra
 For CPUs resource management see
 [CPU constraints](design/vcpu-handling.md).
 
-### docker run and shared memory
-
-The runtime does not implement the `docker run --shm-size` command to
-set the size of the `/dev/shm tmpfs` within the container. It is possible to pass this configuration value into the VM container so the appropriate mount command happens at launch time.
-
-See issue https://github.com/kata-containers/kata-containers/issues/21 for more information.
-
 # Architectural limitations
 
 This section lists items that might not be fixed due to fundamental


### PR DESCRIPTION
This PR removes the docker run and shared memory segment from the
limitations document as for kata 2.0 we do not support docker
and this is not longer valid.

Fixes #3676

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>