### PR TITLE
agent: Add VFIO-AP device handling

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -567,6 +567,7 @@ dependencies = [
  "async-recursion",
  "async-trait",
  "capctl",
+ "cfg-if 1.0.0",
  "cgroups-rs",
  "clap",
  "futures",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -46,6 +46,7 @@ slog-scope = "4.1.2"
 slog-stdlog = "4.0.0"
 log = "0.4.11"
 
+cfg-if = "1.0.0"
 prometheus = { version = "0.13.0", features = ["process"] }
 procfs = "0.12.0"
 anyhow = "1.0.32"

--- a/src/agent/src/ap.rs
+++ b/src/agent/src/ap.rs
@@ -1,0 +1,79 @@
+// Copyright (c) IBM Corp. 2022
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::{anyhow, Context};
+
+// IBM Adjunct Processor (AP) is the bus used by IBM Crypto Express hardware security modules on
+// IBM Z & LinuxONE (s390x)
+// AP bus ID follow the format <xx>.<xxxx> [1, p. 476], where
+//   - <xx> is the adapter ID, i.e. the card and
+//   - <xxxx> is the adapter domain.
+// [1] https://www.ibm.com/docs/en/linuxonibm/pdf/lku5dd05.pdf
+
+#[derive(Debug)]
+pub struct Address {
+    pub adapter_id: u8,
+    pub adapter_domain: u16,
+}
+
+impl Address {
+    pub fn new(adapter_id: u8, adapter_domain: u16) -> Address {
+        Address {
+            adapter_id,
+            adapter_domain,
+        }
+    }
+}
+
+impl FromStr for Address {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> anyhow::Result<Self> {
+        let split: Vec<&str> = s.split('.').collect();
+        if split.len() != 2 {
+            return Err(anyhow!(
+                "Wrong AP bus format. It needs to be in the form <xx>.<xxxx>, got {:?}",
+                s
+            ));
+        }
+
+        let adapter_id = u8::from_str_radix(split[0], 16).context(format!(
+            "Wrong AP bus format. AP ID needs to be in the form <xx>, got {:?}",
+            split[0]
+        ))?;
+        let adapter_domain = u16::from_str_radix(split[1], 16).context(format!(
+            "Wrong AP bus format. AP domain needs to be in the form <xxxx>, got {:?}",
+            split[1]
+        ))?;
+
+        Ok(Address::new(adapter_id, adapter_domain))
+    }
+}
+
+impl fmt::Display for Address {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        write!(f, "{:02x}.{:04x}", self.adapter_id, self.adapter_domain)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_from_str() {
+        let device = Address::from_str("a.1").unwrap();
+        assert_eq!(format!("{}", device), "0a.0001");
+
+        assert!(Address::from_str("").is_err());
+        assert!(Address::from_str(".").is_err());
+        assert!(Address::from_str("0.0.0").is_err());
+        assert!(Address::from_str("0g.0000").is_err());
+        assert!(Address::from_str("0a.10000").is_err());
+    }
+}

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -280,7 +280,7 @@ pub async fn get_virtio_blk_ccw_device_name(
     sandbox: &Arc<Mutex<Sandbox>>,
     device: &ccw::Device,
 ) -> Result<String> {
-    let matcher = VirtioBlkCCWMatcher::new(&create_ccw_root_bus_path(), device);
+    let matcher = VirtioBlkCCWMatcher::new(CCW_ROOT_BUS_PATH, device);
     let uev = wait_for_uevent(sandbox, matcher).await?;
     let devname = uev.devname;
     return match Path::new(SYSTEM_DEV_PATH).join(&devname).to_str() {
@@ -1378,7 +1378,7 @@ mod tests {
     #[cfg(target_arch = "s390x")]
     #[tokio::test]
     async fn test_virtio_blk_ccw_matcher() {
-        let root_bus = create_ccw_root_bus_path();
+        let root_bus = CCW_ROOT_BUS_PATH;
         let subsystem = "block";
         let devname = "vda";
         let relpath = "0.0.0002";

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -16,13 +16,12 @@ use std::str::FromStr;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-#[cfg(target_arch = "s390x")]
-use crate::ccw;
 use crate::linux_abi::*;
 use crate::pci;
 use crate::sandbox::Sandbox;
 use crate::uevent::{wait_for_uevent, Uevent, UeventMatcher};
 use anyhow::{anyhow, Context, Result};
+use cfg_if::cfg_if;
 use oci::{LinuxDeviceCgroup, LinuxResources, Spec};
 use protocols::agent::Device;
 use tracing::instrument;
@@ -53,6 +52,12 @@ pub const DRIVER_VFIO_GK_TYPE: &str = "vfio-gk";
 pub const DRIVER_VFIO_TYPE: &str = "vfio";
 pub const DRIVER_OVERLAYFS_TYPE: &str = "overlayfs";
 pub const FS_TYPE_HUGETLB: &str = "hugetlbfs";
+
+cfg_if! {
+    if #[cfg(target_arch = "s390x")] {
+        use crate::ccw;
+    }
+}
 
 #[instrument]
 pub fn online_device(path: &str) -> Result<()> {

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use cfg_if::cfg_if;
+
 /// Linux ABI related constants.
 
 #[cfg(target_arch = "aarch64")]
@@ -64,8 +66,11 @@ pub fn create_pci_root_bus_path() -> String {
     ret
 }
 
-#[cfg(target_arch = "s390x")]
-pub const CCW_ROOT_BUS_PATH: &str = "/devices/css0";
+cfg_if! {
+    if #[cfg(target_arch = "s390x")] {
+        pub const CCW_ROOT_BUS_PATH: &str = "/devices/css0";
+    }
+}
 
 // From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
 // The Linux kernel's core ACPI subsystem creates struct acpi_device

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -69,6 +69,8 @@ pub fn create_pci_root_bus_path() -> String {
 cfg_if! {
     if #[cfg(target_arch = "s390x")] {
         pub const CCW_ROOT_BUS_PATH: &str = "/devices/css0";
+        pub const AP_ROOT_BUS_PATH: &str = "/devices/ap";
+        pub const AP_SCANS_PATH: &str = "/sys/bus/ap/scans";
     }
 }
 

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -65,9 +65,8 @@ pub fn create_pci_root_bus_path() -> String {
 }
 
 #[cfg(target_arch = "s390x")]
-pub fn create_ccw_root_bus_path() -> String {
-    String::from("/devices/css0")
-}
+pub const CCW_ROOT_BUS_PATH: &str = "/devices/css0";
+
 // From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
 // The Linux kernel's core ACPI subsystem creates struct acpi_device
 // objects for ACPI namespace objects representing devices, power resources

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -78,6 +78,7 @@ mod tracer;
 
 cfg_if! {
     if #[cfg(target_arch = "s390x")] {
+        mod ap;
         mod ccw;
     }
 }

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -20,6 +20,7 @@ extern crate scopeguard;
 extern crate slog;
 
 use anyhow::{anyhow, Context, Result};
+use cfg_if::cfg_if;
 use clap::{AppSettings, Parser};
 use nix::fcntl::OFlag;
 use nix::sys::socket::{self, AddressFamily, SockAddr, SockFlag, SockType};
@@ -35,8 +36,6 @@ use std::process::exit;
 use std::sync::Arc;
 use tracing::{instrument, span};
 
-#[cfg(target_arch = "s390x")]
-mod ccw;
 mod config;
 mod console;
 mod device;
@@ -76,6 +75,12 @@ use tokio::{
 
 mod rpc;
 mod tracer;
+
+cfg_if! {
+    if #[cfg(target_arch = "s390x")] {
+        mod ccw;
+    }
+}
 
 const NAME: &str = "kata-agent";
 

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -410,7 +410,7 @@ func TestCloudHypervisorHotplugRemoveDevice(t *testing.T) {
 	_, err = clh.HotplugRemoveDevice(context.Background(), &config.BlockDrive{}, BlockDev)
 	assert.NoError(err, "Hotplug remove block device expected no error")
 
-	_, err = clh.HotplugRemoveDevice(context.Background(), &config.VFIODev{}, VfioDev)
+	_, err = clh.HotplugRemoveDevice(context.Background(), &config.VFIOPCIDev{}, VfioDev)
 	assert.NoError(err, "Hotplug remove vfio block device expected no error")
 
 	_, err = clh.HotplugRemoveDevice(context.Background(), nil, NetDev)

--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -241,6 +241,9 @@ const (
 
 	// VFIOPCIDeviceMediatedType is a VFIO PCI mediated device type
 	VFIOPCIDeviceMediatedType
+
+	// VFIOAPDeviceMediatedType is a VFIO AP mediated device type
+	VFIOAPDeviceMediatedType
 )
 
 type VFIODev interface {
@@ -291,6 +294,32 @@ func (d VFIOPCIDev) GetType() VFIODeviceType {
 }
 
 func (d VFIOPCIDev) GetSysfsDev() *string {
+	return &d.SysfsDev
+}
+
+type VFIOAPDev struct {
+	// ID is used to identify this drive in the hypervisor options.
+	ID string
+
+	// sysfsdev of VFIO mediated device
+	SysfsDev string
+
+	// APDevices are the Adjunct Processor devices assigned to the mdev
+	APDevices []string
+
+	// Type of VFIO device
+	Type VFIODeviceType
+}
+
+func (d VFIOAPDev) GetID() *string {
+	return &d.ID
+}
+
+func (d VFIOAPDev) GetType() VFIODeviceType {
+	return d.Type
+}
+
+func (d VFIOAPDev) GetSysfsDev() *string {
 	return &d.SysfsDev
 }
 

--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -236,11 +236,11 @@ const (
 	// VFIODeviceErrorType is the error type of VFIO device
 	VFIODeviceErrorType VFIODeviceType = iota
 
-	// VFIODeviceNormalType is a normal VFIO device type
-	VFIODeviceNormalType
+	// VFIOPCIDeviceNormalType is a normal VFIO PCI device type
+	VFIOPCIDeviceNormalType
 
-	// VFIODeviceMediatedType is a VFIO mediated device type
-	VFIODeviceMediatedType
+	// VFIOPCIDeviceMediatedType is a VFIO PCI mediated device type
+	VFIOPCIDeviceMediatedType
 )
 
 // VFIODev represents a VFIO drive used for hotplugging

--- a/src/runtime/virtcontainers/device/config/config.go
+++ b/src/runtime/virtcontainers/device/config/config.go
@@ -243,8 +243,14 @@ const (
 	VFIOPCIDeviceMediatedType
 )
 
-// VFIODev represents a VFIO drive used for hotplugging
-type VFIODev struct {
+type VFIODev interface {
+	GetID() *string
+	GetType() VFIODeviceType
+	GetSysfsDev() *string
+}
+
+// VFIOPCIDev represents a VFIO PCI device used for hotplugging
+type VFIOPCIDev struct {
 	// ID is used to identify this drive in the hypervisor options.
 	ID string
 
@@ -274,6 +280,18 @@ type VFIODev struct {
 
 	// IsPCIe specifies device is PCIe or PCI
 	IsPCIe bool
+}
+
+func (d VFIOPCIDev) GetID() *string {
+	return &d.ID
+}
+
+func (d VFIOPCIDev) GetType() VFIODeviceType {
+	return d.Type
+}
+
+func (d VFIOPCIDev) GetSysfsDev() *string {
+	return &d.SysfsDev
 }
 
 // RNGDev represents a random number generator device

--- a/src/runtime/virtcontainers/device/drivers/utils.go
+++ b/src/runtime/virtcontainers/device/drivers/utils.go
@@ -95,12 +95,12 @@ func GetVFIODeviceType(deviceFileName string) config.VFIODeviceType {
 	tokens := strings.Split(deviceFileName, ":")
 	vfioDeviceType := config.VFIODeviceErrorType
 	if len(tokens) == 3 {
-		vfioDeviceType = config.VFIODeviceNormalType
+		vfioDeviceType = config.VFIOPCIDeviceNormalType
 	} else {
 		//For example, 83b8f4f2-509f-382f-3c1e-e6bfe0fa1001
 		tokens = strings.Split(deviceFileName, "-")
 		if len(tokens) == 5 {
-			vfioDeviceType = config.VFIODeviceMediatedType
+			vfioDeviceType = config.VFIOPCIDeviceMediatedType
 		}
 	}
 	return vfioDeviceType

--- a/src/runtime/virtcontainers/device/drivers/utils.go
+++ b/src/runtime/virtcontainers/device/drivers/utils.go
@@ -90,18 +90,47 @@ func readPCIProperty(propertyPath string) (string, error) {
 	return strings.Split(string(buf), "\n")[0], nil
 }
 
-func GetVFIODeviceType(deviceFileName string) config.VFIODeviceType {
+func GetVFIODeviceType(deviceFilePath string) (config.VFIODeviceType, error) {
+	deviceFileName := filepath.Base(deviceFilePath)
+
 	//For example, 0000:04:00.0
 	tokens := strings.Split(deviceFileName, ":")
-	vfioDeviceType := config.VFIODeviceErrorType
 	if len(tokens) == 3 {
-		vfioDeviceType = config.VFIOPCIDeviceNormalType
-	} else {
-		//For example, 83b8f4f2-509f-382f-3c1e-e6bfe0fa1001
-		tokens = strings.Split(deviceFileName, "-")
-		if len(tokens) == 5 {
-			vfioDeviceType = config.VFIOPCIDeviceMediatedType
-		}
+		return config.VFIOPCIDeviceNormalType, nil
 	}
-	return vfioDeviceType
+
+	//For example, 83b8f4f2-509f-382f-3c1e-e6bfe0fa1001
+	tokens = strings.Split(deviceFileName, "-")
+	if len(tokens) != 5 {
+		return config.VFIODeviceErrorType, fmt.Errorf("Incorrect tokens found while parsing VFIO details: %s", deviceFileName)
+	}
+
+	deviceSysfsDev, err := GetSysfsDev(deviceFilePath)
+	if err != nil {
+		return config.VFIODeviceErrorType, err
+	}
+
+	if strings.HasPrefix(deviceSysfsDev, vfioAPSysfsDir) {
+		return config.VFIOAPDeviceMediatedType, nil
+	}
+
+	return config.VFIOPCIDeviceMediatedType, nil
+}
+
+// GetSysfsDev returns the sysfsdev of mediated device
+// Expected input string format is absolute path to the sysfs dev node
+// eg. /sys/kernel/iommu_groups/0/devices/f79944e4-5a3d-11e8-99ce-479cbab002e4
+func GetSysfsDev(sysfsDevStr string) (string, error) {
+	return filepath.EvalSymlinks(sysfsDevStr)
+}
+
+// GetAPVFIODevices retrieves all APQNs associated with a mediated VFIO-AP
+// device
+func GetAPVFIODevices(sysfsdev string) ([]string, error) {
+	data, err := os.ReadFile(filepath.Join(sysfsdev, "matrix"))
+	if err != nil {
+		return []string{}, err
+	}
+	// Split by newlines, omitting final newline
+	return strings.Split(string(data[:len(data)-1]), "\n"), nil
 }

--- a/src/runtime/virtcontainers/device/drivers/vfio.go
+++ b/src/runtime/virtcontainers/device/drivers/vfio.go
@@ -213,12 +213,12 @@ func getVFIODetails(deviceFileName, iommuDevicesPath string) (deviceBDF, deviceS
 	vfioDeviceType = GetVFIODeviceType(deviceFileName)
 
 	switch vfioDeviceType {
-	case config.VFIODeviceNormalType:
+	case config.VFIOPCIDeviceNormalType:
 		// Get bdf of device eg. 0000:00:1c.0
 		deviceBDF = getBDF(deviceFileName)
 		// Get sysfs path used by cloud-hypervisor
 		deviceSysfsDev = filepath.Join(config.SysBusPciDevicesPath, deviceFileName)
-	case config.VFIODeviceMediatedType:
+	case config.VFIOPCIDeviceMediatedType:
 		// Get sysfsdev of device eg. /sys/devices/pci0000:00/0000:00:02.0/f79944e4-5a3d-11e8-99ce-479cbab002e4
 		sysfsDevStr := filepath.Join(iommuDevicesPath, deviceFileName)
 		deviceSysfsDev, err = getSysfsDev(sysfsDevStr)

--- a/src/runtime/virtcontainers/device/drivers/vfio_test.go
+++ b/src/runtime/virtcontainers/device/drivers/vfio_test.go
@@ -34,7 +34,7 @@ func TestGetVFIODetails(t *testing.T) {
 		switch vfioDeviceType {
 		case config.VFIOPCIDeviceNormalType:
 			assert.Equal(t, d.expectedStr, deviceBDF)
-		case config.VFIOPCIDeviceMediatedType:
+		case config.VFIOPCIDeviceMediatedType, config.VFIOAPDeviceMediatedType:
 			assert.Equal(t, d.expectedStr, deviceSysfsDev)
 		default:
 			assert.NotNil(t, err)

--- a/src/runtime/virtcontainers/device/drivers/vfio_test.go
+++ b/src/runtime/virtcontainers/device/drivers/vfio_test.go
@@ -32,9 +32,9 @@ func TestGetVFIODetails(t *testing.T) {
 		deviceBDF, deviceSysfsDev, vfioDeviceType, err := getVFIODetails(d.deviceStr, "")
 
 		switch vfioDeviceType {
-		case config.VFIODeviceNormalType:
+		case config.VFIOPCIDeviceNormalType:
 			assert.Equal(t, d.expectedStr, deviceBDF)
-		case config.VFIODeviceMediatedType:
+		case config.VFIOPCIDeviceMediatedType:
 			assert.Equal(t, d.expectedStr, deviceSysfsDev)
 		default:
 			assert.NotNil(t, err)

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1086,8 +1086,10 @@ func (k *kataAgent) appendVfioDevice(dev ContainerDevice, device api.Device, c *
 		kataDevice.Type = kataVfioPciGuestKernelDevType
 	}
 
-	for i, pciDev := range devList {
-		kataDevice.Options[i] = fmt.Sprintf("0000:%s=%s", pciDev.BDF, pciDev.GuestPciPath)
+	kataDevice.Options = make([]string, len(devList))
+	for i, device := range devList {
+		pciDevice := (*device).(config.VFIOPCIDev)
+		kataDevice.Options[i] = fmt.Sprintf("0000:%s=%s", pciDevice.BDF, pciDevice.GuestPciPath)
 	}
 
 	return kataDevice

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1572,9 +1572,9 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 			}
 
 			switch device.Type {
-			case config.VFIODeviceNormalType:
+			case config.VFIOPCIDeviceNormalType:
 				err = q.qmpMonitorCh.qmp.ExecuteVFIODeviceAdd(q.qmpMonitorCh.ctx, devID, device.BDF, device.Bus, romFile)
-			case config.VFIODeviceMediatedType:
+			case config.VFIOPCIDeviceMediatedType:
 				if utils.IsAPVFIOMediatedDevice(device.SysfsDev) {
 					err = q.qmpMonitorCh.qmp.ExecuteAPVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, device.SysfsDev)
 				} else {
@@ -1596,9 +1596,9 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 			}()
 
 			switch device.Type {
-			case config.VFIODeviceNormalType:
+			case config.VFIOPCIDeviceNormalType:
 				err = q.qmpMonitorCh.qmp.ExecutePCIVFIODeviceAdd(q.qmpMonitorCh.ctx, devID, device.BDF, addr, bridge.ID, romFile)
-			case config.VFIODeviceMediatedType:
+			case config.VFIOPCIDeviceMediatedType:
 				if utils.IsAPVFIOMediatedDevice(device.SysfsDev) {
 					err = q.qmpMonitorCh.qmp.ExecuteAPVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, device.SysfsDev)
 				} else {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1582,6 +1582,8 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 				} else {
 					err = q.qmpMonitorCh.qmp.ExecutePCIVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, devID, *(*device).GetSysfsDev(), "", pciDevice.Bus, romFile)
 				}
+			case config.VFIOAPDeviceMediatedType:
+				err = q.qmpMonitorCh.qmp.ExecuteAPVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, *(*device).GetSysfsDev())
 			}
 		} else {
 			addr, bridge, err := q.arch.addDeviceToBridge(ctx, devID, types.PCI)
@@ -1604,6 +1606,8 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 				err = q.qmpMonitorCh.qmp.ExecutePCIVFIODeviceAdd(q.qmpMonitorCh.ctx, devID, pciDevice.BDF, addr, bridge.ID, romFile)
 			case config.VFIOPCIDeviceMediatedType:
 				err = q.qmpMonitorCh.qmp.ExecutePCIVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, devID, *(*device).GetSysfsDev(), addr, bridge.ID, romFile)
+			case config.VFIOAPDeviceMediatedType:
+				err = q.qmpMonitorCh.qmp.ExecuteAPVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, *(*device).GetSysfsDev())
 			default:
 				return fmt.Errorf("Incorrect VFIO device type found")
 			}

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1542,7 +1542,7 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 		return err
 	}
 
-	devID := device.ID
+	devID := *(*device).GetID()
 	machineType := q.HypervisorConfig().HypervisorMachineType
 
 	if op == AddDevice {
@@ -1559,29 +1559,29 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 		// for pc machine type instead of bridge. This is useful for devices that require
 		// a large PCI BAR which is a currently a limitation with PCI bridges.
 		if q.state.HotplugVFIOOnRootBus {
-
-			// In case MachineType is q35, a PCIe device is hotplugged on a PCIe Root Port.
-			switch machineType {
-			case QemuQ35:
-				if device.IsPCIe && q.state.PCIeRootPort <= 0 {
-					q.Logger().WithField("dev-id", device.ID).Warn("VFIO device is a PCIe device. It's recommended to add the PCIe Root Port by setting the pcie_root_port parameter in the configuration for q35")
-					device.Bus = ""
+			switch (*device).GetType() {
+			case config.VFIOPCIDeviceNormalType, config.VFIOPCIDeviceMediatedType:
+				// In case MachineType is q35, a PCIe device is hotplugged on a PCIe Root Port.
+				pciDevice, ok := (*device).(config.VFIOPCIDev)
+				if !ok {
+					return fmt.Errorf("VFIO device %+v is not PCI, but its Type said otherwise", device)
 				}
-			default:
-				device.Bus = ""
-			}
+				switch machineType {
+				case QemuQ35:
+					if pciDevice.IsPCIe && q.state.PCIeRootPort <= 0 {
+						q.Logger().WithField("dev-id", (*device).GetID()).Warn("VFIO device is a PCIe device. It's recommended to add the PCIe Root Port by setting the pcie_root_port parameter in the configuration for q35")
+						pciDevice.Bus = ""
+					}
+				default:
+					pciDevice.Bus = ""
+				}
+				*device = pciDevice
 
-			switch device.Type {
-			case config.VFIOPCIDeviceNormalType:
-				err = q.qmpMonitorCh.qmp.ExecuteVFIODeviceAdd(q.qmpMonitorCh.ctx, devID, device.BDF, device.Bus, romFile)
-			case config.VFIOPCIDeviceMediatedType:
-				if utils.IsAPVFIOMediatedDevice(device.SysfsDev) {
-					err = q.qmpMonitorCh.qmp.ExecuteAPVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, device.SysfsDev)
+				if pciDevice.Type == config.VFIOPCIDeviceNormalType {
+					err = q.qmpMonitorCh.qmp.ExecuteVFIODeviceAdd(q.qmpMonitorCh.ctx, devID, pciDevice.BDF, pciDevice.Bus, romFile)
 				} else {
-					err = q.qmpMonitorCh.qmp.ExecutePCIVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, devID, device.SysfsDev, "", device.Bus, romFile)
+					err = q.qmpMonitorCh.qmp.ExecutePCIVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, devID, *(*device).GetSysfsDev(), "", pciDevice.Bus, romFile)
 				}
-			default:
-				return fmt.Errorf("Incorrect VFIO device type found")
 			}
 		} else {
 			addr, bridge, err := q.arch.addDeviceToBridge(ctx, devID, types.PCI)
@@ -1595,15 +1595,15 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 				}
 			}()
 
-			switch device.Type {
+			switch (*device).GetType() {
 			case config.VFIOPCIDeviceNormalType:
-				err = q.qmpMonitorCh.qmp.ExecutePCIVFIODeviceAdd(q.qmpMonitorCh.ctx, devID, device.BDF, addr, bridge.ID, romFile)
-			case config.VFIOPCIDeviceMediatedType:
-				if utils.IsAPVFIOMediatedDevice(device.SysfsDev) {
-					err = q.qmpMonitorCh.qmp.ExecuteAPVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, device.SysfsDev)
-				} else {
-					err = q.qmpMonitorCh.qmp.ExecutePCIVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, devID, device.SysfsDev, addr, bridge.ID, romFile)
+				pciDevice, ok := (*device).(config.VFIOPCIDev)
+				if !ok {
+					return fmt.Errorf("VFIO device %+v is not PCI, but its Type said otherwise", device)
 				}
+				err = q.qmpMonitorCh.qmp.ExecutePCIVFIODeviceAdd(q.qmpMonitorCh.ctx, devID, pciDevice.BDF, addr, bridge.ID, romFile)
+			case config.VFIOPCIDeviceMediatedType:
+				err = q.qmpMonitorCh.qmp.ExecutePCIVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, devID, *(*device).GetSysfsDev(), addr, bridge.ID, romFile)
 			default:
 				return fmt.Errorf("Incorrect VFIO device type found")
 			}
@@ -1611,13 +1611,24 @@ func (q *qemu) hotplugVFIODevice(ctx context.Context, device *config.VFIODev, op
 		if err != nil {
 			return err
 		}
-		// XXX: Depending on whether we're doing root port or
-		// bridge hotplug, and how the bridge is set up in
-		// other parts of the code, we may or may not already
-		// have information about the slot number of the
-		// bridge and or the device.  For simplicity, just
-		// query both of them back from qemu
-		device.GuestPciPath, err = q.qomGetPciPath(devID)
+
+		switch (*device).GetType() {
+		case config.VFIOPCIDeviceNormalType, config.VFIOPCIDeviceMediatedType:
+			pciDevice, ok := (*device).(config.VFIOPCIDev)
+			if !ok {
+				return fmt.Errorf("VFIO device %+v is not PCI, but its Type said otherwise", device)
+			}
+			// XXX: Depending on whether we're doing root port or
+			// bridge hotplug, and how the bridge is set up in
+			// other parts of the code, we may or may not already
+			// have information about the slot number of the
+			// bridge and or the device.  For simplicity, just
+			// query both of them back from qemu
+			guestPciPath, err := q.qomGetPciPath(devID)
+			pciDevice.GuestPciPath = guestPciPath
+			*device = pciDevice
+			return err
+		}
 		return err
 	} else {
 		q.Logger().WithField("dev-id", devID).Info("Start hot-unplug VFIO device")

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -643,16 +643,17 @@ func (q *qemuArchBase) appendVhostUserDevice(ctx context.Context, devices []govm
 }
 
 func (q *qemuArchBase) appendVFIODevice(devices []govmmQemu.Device, vfioDev config.VFIODev) []govmmQemu.Device {
-	if vfioDev.BDF == "" {
+	pciDevice := vfioDev.(config.VFIOPCIDev)
+	if pciDevice.BDF == "" {
 		return devices
 	}
 
 	devices = append(devices,
 		govmmQemu.VFIODevice{
-			BDF:      vfioDev.BDF,
-			VendorID: vfioDev.VendorID,
-			DeviceID: vfioDev.DeviceID,
-			Bus:      vfioDev.Bus,
+			BDF:      pciDevice.BDF,
+			VendorID: pciDevice.VendorID,
+			DeviceID: pciDevice.DeviceID,
+			Bus:      pciDevice.Bus,
 		},
 	)
 

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -434,7 +434,7 @@ func TestQemuArchBaseAppendVFIODevice(t *testing.T) {
 		},
 	}
 
-	vfDevice := config.VFIODev{
+	vfDevice := config.VFIOPCIDev{
 		BDF: bdf,
 	}
 
@@ -454,7 +454,7 @@ func TestQemuArchBaseAppendVFIODeviceWithVendorDeviceID(t *testing.T) {
 		},
 	}
 
-	vfDevice := config.VFIODev{
+	vfDevice := config.VFIOPCIDev{
 		BDF:      bdf,
 		VendorID: vendorID,
 		DeviceID: deviceID,

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1789,11 +1789,15 @@ func (s *Sandbox) HotplugAddDevice(ctx context.Context, device api.Device, devTy
 		// adding a group of VFIO devices
 		for _, dev := range vfioDevices {
 			if _, err := s.hypervisor.HotplugAddDevice(ctx, dev, VfioDev); err != nil {
+				bdf := ""
+				if pciDevice, ok := (*dev).(config.VFIOPCIDev); ok {
+					bdf = pciDevice.BDF
+				}
 				s.Logger().
 					WithFields(logrus.Fields{
 						"sandbox":         s.id,
-						"vfio-device-ID":  dev.ID,
-						"vfio-device-BDF": dev.BDF,
+						"vfio-device-ID":  (*dev).GetID(),
+						"vfio-device-BDF": bdf,
 					}).WithError(err).Error("failed to hotplug VFIO device")
 				return err
 			}
@@ -1842,11 +1846,15 @@ func (s *Sandbox) HotplugRemoveDevice(ctx context.Context, device api.Device, de
 		// remove a group of VFIO devices
 		for _, dev := range vfioDevices {
 			if _, err := s.hypervisor.HotplugRemoveDevice(ctx, dev, VfioDev); err != nil {
+				bdf := ""
+				if pciDevice, ok := (*dev).(config.VFIOPCIDev); ok {
+					bdf = pciDevice.BDF
+				}
 				s.Logger().WithError(err).
 					WithFields(logrus.Fields{
 						"sandbox":         s.id,
-						"vfio-device-ID":  dev.ID,
-						"vfio-device-BDF": dev.BDF,
+						"vfio-device-ID":  (*dev).GetID(),
+						"vfio-device-BDF": bdf,
 					}).Error("failed to hot unplug VFIO device")
 				return err
 			}

--- a/src/runtime/virtcontainers/utils/utils_linux.go
+++ b/src/runtime/virtcontainers/utils/utils_linux.go
@@ -88,8 +88,7 @@ func FindContextID() (*os.File, uint64, error) {
 const (
 	procMountsFile = "/proc/mounts"
 
-	fieldsPerLine  = 6
-	vfioAPSysfsDir = "vfio_ap"
+	fieldsPerLine = 6
 )
 
 const (
@@ -139,16 +138,4 @@ func GetDevicePathAndFsTypeOptions(mountPoint string) (devicePath, fsType string
 			return
 		}
 	}
-}
-
-// IsAPVFIOMediatedDevice decides whether a device is a VFIO-AP device
-// by checking for the existence of "vfio_ap" in the path
-func IsAPVFIOMediatedDevice(sysfsdev string) bool {
-	split := strings.Split(sysfsdev, string(os.PathSeparator))
-	for _, el := range split {
-		if el == vfioAPSysfsDir {
-			return true
-		}
-	}
-	return false
 }

--- a/src/runtime/virtcontainers/utils/utils_linux_test.go
+++ b/src/runtime/virtcontainers/utils/utils_linux_test.go
@@ -63,19 +63,3 @@ func TestGetDevicePathAndFsTypeOptionsSuccessful(t *testing.T) {
 	assert.Equal(fstype, fstypeOut)
 	assert.Equal(fsOptions, optsOut)
 }
-
-func TestIsAPVFIOMediatedDeviceFalse(t *testing.T) {
-	assert := assert.New(t)
-
-	// Should be false for a PCI device
-	isAPMdev := IsAPVFIOMediatedDevice("/sys/bus/pci/devices/0000:00:02.0/a297db4a-f4c2-11e6-90f6-d3b88d6c9525")
-	assert.False(isAPMdev)
-}
-
-func TestIsAPVFIOMediatedDeviceTrue(t *testing.T) {
-	assert := assert.New(t)
-
-	// Typical AP sysfsdev
-	isAPMdev := IsAPVFIOMediatedDevice("/sys/devices/vfio_ap/matrix/a297db4a-f4c2-11e6-90f6-d3b88d6c9525")
-	assert.True(isAPMdev)
-}

--- a/tools/packaging/kernel/patches/5.15.x/0001-s390-ap-enable-sysfs-attribute-scans-to-force-AP-bus.patch
+++ b/tools/packaging/kernel/patches/5.15.x/0001-s390-ap-enable-sysfs-attribute-scans-to-force-AP-bus.patch
@@ -1,0 +1,47 @@
+From 8944d05f9bbf910c8b241e29a3de114900e31e42 Mon Sep 17 00:00:00 2001
+From: Harald Freudenberger <freude@linux.ibm.com>
+Date: Wed, 16 Feb 2022 12:30:34 +0100
+Subject: s390/ap: enable sysfs attribute scans to force AP bus rescan
+
+This patch switches the sysfs attribute /sys/bus/ap/scans
+from read-only to read-write. If there is something written
+to this attribute, an AP bus rescan is forced. If an AP
+bus scan is triggered this way a debug feature entry line
+reports this in /sys/kernel/debug/s390dbf/ap/sprintf.
+
+Signed-off-by: Harald Freudenberger <freude@linux.ibm.com>
+Reviewed-by: Jakob Naucke <naucke@linux.ibm.com>
+Reviewed-by: Juergen Christ <jchrist@linux.ibm.com>
+Signed-off-by: Vasily Gorbik <gor@linux.ibm.com>
+---
+ drivers/s390/crypto/ap_bus.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+(limited to 'drivers/s390/crypto/ap_bus.c')
+
+diff --git a/drivers/s390/crypto/ap_bus.c b/drivers/s390/crypto/ap_bus.c
+index f5fae8b62bdf9..555cc3394fe33 100644
+--- a/drivers/s390/crypto/ap_bus.c
++++ b/drivers/s390/crypto/ap_bus.c
+@@ -1472,7 +1472,17 @@ static ssize_t scans_show(struct bus_type *bus, char *buf)
+ 			 atomic64_read(&ap_scan_bus_count));
+ }
+ 
+-static BUS_ATTR_RO(scans);
++static ssize_t scans_store(struct bus_type *bus, const char *buf,
++			   size_t count)
++{
++	AP_DBF_INFO("%s force AP bus rescan\n", __func__);
++
++	ap_bus_force_rescan();
++
++	return count;
++}
++
++static BUS_ATTR_RW(scans);
+ 
+ static ssize_t bindings_show(struct bus_type *bus, char *buf)
+ {
+-- 
+cgit 
+


### PR DESCRIPTION
Initial VFIO-AP support (#578) was simple, but somewhat hacky; a
different code path would be chosen for performing the hotplug, and
agent-side device handling was bound to knowing the assigned queue
numbers (APQNs) through some other means; plus the code for awaiting
them was written for the Go agent and never released. This code also
artificially increased the hotplug timeout to wait for the (relatively
expensive, thus limited to 5 seconds at the quickest) AP rescan, which
is impractical for e.g. common k8s timeouts.

Since then, the general handling logic was improved (#1190), but it
assumed PCI in several places.

In the runtime, introduce and parse AP devices. Annotate them as such
when passing to the agent, and information about the enabled APQNs is
included.

The agent awaits the passed APQNs through uevents and triggers a
rescan directly.

Fixes: #3678