### PR TITLE
kata-agent hugepage support

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1315,7 +1315,7 @@ func (c *Container) hotplugDrive(ctx context.Context) error {
 			c.rootfsSuffix = ""
 		}
 		// If device mapper device, then fetch the full path of the device
-		devicePath, fsType, err = utils.GetDevicePathAndFsType(dev.mountPoint)
+		devicePath, fsType, _, err = utils.GetDevicePathAndFsTypeOptions(dev.mountPoint)
 		if err != nil {
 			return err
 		}

--- a/src/runtime/virtcontainers/device/config/pmem.go
+++ b/src/runtime/virtcontainers/device/config/pmem.go
@@ -75,7 +75,7 @@ func PmemDeviceInfo(source, destination string) (*DeviceInfo, error) {
 		return nil, fmt.Errorf("backing file %v has not PFN signature", device.HostPath)
 	}
 
-	_, fstype, err := utils.GetDevicePathAndFsType(source)
+	_, fstype, _, err := utils.GetDevicePathAndFsTypeOptions(source)
 	if err != nil {
 		pmemLog.WithError(err).WithField("mount-point", source).Warn("failed to get fstype: using ext4")
 		fstype = "ext4"

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -470,7 +470,7 @@ func IsEphemeralStorage(path string) bool {
 		return false
 	}
 
-	if _, fsType, _ := utils.GetDevicePathAndFsType(path); fsType == "tmpfs" {
+	if _, fsType, _, _ := utils.GetDevicePathAndFsTypeOptions(path); fsType == "tmpfs" {
 		return true
 	}
 
@@ -485,7 +485,7 @@ func Isk8sHostEmptyDir(path string) bool {
 		return false
 	}
 
-	if _, fsType, _ := utils.GetDevicePathAndFsType(path); fsType != "tmpfs" {
+	if _, fsType, _, _ := utils.GetDevicePathAndFsTypeOptions(path); fsType != "tmpfs" {
 		return true
 	}
 	return false

--- a/src/runtime/virtcontainers/utils/utils_linux.go
+++ b/src/runtime/virtcontainers/utils/utils_linux.go
@@ -96,11 +96,12 @@ const (
 	procDeviceIndex = iota
 	procPathIndex
 	procTypeIndex
+	procOptionIndex
 )
 
-// GetDevicePathAndFsType gets the device for the mount point and the file system type
-// of the mount.
-func GetDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err error) {
+// GetDevicePathAndFsTypeOptions gets the device for the mount point, the file system type
+// and mount options
+func GetDevicePathAndFsTypeOptions(mountPoint string) (devicePath, fsType string, fsOptions []string, err error) {
 	if mountPoint == "" {
 		err = fmt.Errorf("Mount point cannot be empty")
 		return
@@ -134,6 +135,7 @@ func GetDevicePathAndFsType(mountPoint string) (devicePath, fsType string, err e
 		if mountPoint == fields[procPathIndex] {
 			devicePath = fields[procDeviceIndex]
 			fsType = fields[procTypeIndex]
+			fsOptions = strings.Split(fields[procOptionIndex], ",")
 			return
 		}
 	}

--- a/src/runtime/virtcontainers/utils/utils_linux_test.go
+++ b/src/runtime/virtcontainers/utils/utils_linux_test.go
@@ -6,7 +6,10 @@
 package utils
 
 import (
+	"bytes"
 	"errors"
+	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,20 +37,29 @@ func TestFindContextID(t *testing.T) {
 	assert.Error(err)
 }
 
-func TestGetDevicePathAndFsTypeEmptyMount(t *testing.T) {
+func TestGetDevicePathAndFsTypeOptionsEmptyMount(t *testing.T) {
 	assert := assert.New(t)
-	_, _, err := GetDevicePathAndFsType("")
+	_, _, _, err := GetDevicePathAndFsTypeOptions("")
 	assert.Error(err)
 }
 
-func TestGetDevicePathAndFsTypeSuccessful(t *testing.T) {
+func TestGetDevicePathAndFsTypeOptionsSuccessful(t *testing.T) {
 	assert := assert.New(t)
 
-	path, fstype, err := GetDevicePathAndFsType("/proc")
+	cmdStr := "grep ^proc  /proc/mounts"
+	cmd := exec.Command("sh", "-c", cmdStr)
+	output, err := cmd.Output()
+	assert.NoError(err)
+
+	data := bytes.Split(output, []byte(" "))
+	optsOut := strings.Split(string(data[3]), ",")
+
+	path, fstype, fsOptions, err := GetDevicePathAndFsTypeOptions("/proc")
 	assert.NoError(err)
 
 	assert.Equal(path, "proc")
 	assert.Equal(fstype, "proc")
+	assert.Equal(fsOptions, optsOut)
 }
 
 func TestIsAPVFIOMediatedDeviceFalse(t *testing.T) {


### PR DESCRIPTION
I have read @liubin 's [commit](https://github.com/kata-containers/kata-containers/issues/3342), which have some useless codes. 

In main branch, kata-agent has supported the hugepages feature, but kata-runtime do not.

So I pass the hugepages params in kata-runtime in my commits. It works.

The compressed file [hugepages.cfg.tar.gz](https://github.com/kata-containers/kata-containers/files/8078590/hugepages.cfg.tar.gz) contains my configurations on my environment.
`config.toml` is `/etc/containerd/config.toml`
`configuration.toml` is `/etc/kata-containers/configuration.toml`
`ctnr.hugepages.toml` is container configuration
`pod.hugepages.toml` is pod configuration

### Step 1:
create the pod and container with these configuration which I mentioned upon.
```bash
crictl run --no-pull ctnr.hugepage.json pod.hugepage.json
```
It returns the container id, and pod id we can get with ctr command
- pod id: 7b9dc401b3574c8f7027bcec69dbcc1f361a9435c6f12d07b0c25b0fe768bd6c
- container id: 65188749240715da63bebe94909406b1f5b17c9c043e0afd457afde9b0bdfc4c

### Step 2: 
check the hugepage feature:
```bash
$ kata-runtime exec 7b9dc401b3574c8f7027bcec69dbcc1f361a9435c6f12d07b0c25b0fe768bd6c
bash-4.4# cat/sys/fs/cgroup/hugetlb/k8s.io/65188749240715da63bebe94909406b1f5b17c9c043e0afd457afde9b0bdfc4chugetlb.1GB.limit_in_bytes
1073741824

bash-4.4# cat/sys/fs/cgroup/hugetlb/k8s.io/65188749240715da63bebe94909406b1f5b17c9c043e0afd457afde9b0bdfc4chugetlb.2MB.limit_in_bytes
16777216

bash-4.4# cat /sys/kernel/mm/hugepages/hugepages-1048576kB/*
1
1
0
0
0

bash-4.4# cat /sys/kernel/mm/hugepages/hugepages-2048kB/*   
1024
1024
0
0
0

```
It  works well.