### PR TITLE
tools: Build cloud-hypervisor with "--features tdx"

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -125,11 +125,6 @@ install_firecracker() {
 
 # Install static cloud-hypervisor asset
 install_clh() {
-	local cloud_hypervisor_repo
-	local cloud_hypervisor_version
-
-	cloud_hypervisor_repo="$(yq r $versions_yaml assets.hypervisor.cloud_hypervisor.url)"
-	cloud_hypervisor_version="$(yq r $versions_yaml assets.hypervisor.cloud_hypervisor.version)"
 	export extra_build_args="--features tdx"
 
 	info "build static cloud-hypervisor"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -130,6 +130,7 @@ install_clh() {
 
 	cloud_hypervisor_repo="$(yq r $versions_yaml assets.hypervisor.cloud_hypervisor.url)"
 	cloud_hypervisor_version="$(yq r $versions_yaml assets.hypervisor.cloud_hypervisor.version)"
+	export extra_build_args="--features tdx"
 
 	info "build static cloud-hypervisor"
 	"${clh_builder}"


### PR DESCRIPTION
Right now TDx support on Cloud Hypervisor is gated behind a "--features
tdx" flag.  However, having TDx support enabled should not and does not
impact on the general usability of cloud-hypervisor.

As sooner than later we'll need kata-deploy binaries to be tested on a
CI that's TDx capable, for the confidential containers effort, let's
take the bullet and already enable it by default.

By the way, touching kata-deploy-binaries.sh as it's ensure the change
will be used in the following workflows:
* kata-deploy-push
* kata-deploy-test
* release

Fixes: #3688

Together with this one, in a separate commit, there's also a small cleanup.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>