### PR TITLE
versions: add nydus-snapshotter

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -242,6 +242,11 @@ externals:
     url: "https://github.com/dragonflyoss/image-service"
     version: "v1.1.2"
 
+  nydus-snapshotter:
+    description: "Snapshotter for Nydus image acceleration service"
+    url: "https://github.com/containerd/nydus-snapshotter"
+    version: "v0.1.0"
+
 languages:
   description: |
     Details of programming languages required to build system


### PR DESCRIPTION
Add nydus-snapshotter to versions.yaml to
install nydus-snapshotter from its own
releases.

Fixes: #3698

Signed-off-by: bin <bin@hyper.sh>