### PR TITLE
tools: packaging: Update the KUBE_ARCH parameter setting by system info

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -21,7 +21,6 @@ CMD ["/usr/sbin/init"]
 
 FROM base
 
-ARG KUBE_ARCH=amd64
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts
 
@@ -37,6 +36,7 @@ tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION}/ && \
 chown -R root:root ${DESTINATION}/
 
 RUN \
+KUBE_ARCH=$(uname -m | sed s/x86_64/amd64/ | sed s/aarch64/arm64/) && \
 curl -Lso /bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${KUBE_ARCH}/kubectl" && \
 chmod +x /bin/kubectl
 


### PR DESCRIPTION
The kata-deploy Dockerfile download the kubectl with the hardcode `amd64`.
The kube_arch should be changed by our system arch, such as x86_64 to amd64, aarch64
 to arm64. This PR update the kube_arch set with `$(uname -m)`.

Fixes: #3701

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>