### PR TITLE
virtcontainers: Remove duplicated assert messages in utils test code

### DIFF
--- a/src/runtime/virtcontainers/utils/utils_test.go
+++ b/src/runtime/virtcontainers/utils/utils_test.go
@@ -297,9 +297,9 @@ func TestBuildSocketPath(t *testing.T) {
 		msg := fmt.Sprintf("test[%d]: %+v", i, d)
 
 		if d.valid {
-			assert.NoErrorf(err, "test %d, data %+v", i, d, msg)
+			assert.NoError(err, msg)
 		} else {
-			assert.Errorf(err, "test %d, data %+v", i, d, msg)
+			assert.Error(err, msg)
 		}
 
 		assert.NotNil(result, msg)


### PR DESCRIPTION
Remove duplicated strings in assert.Errorf() and assert.NoErrorf().

Fixes: #3714

Signed-off-by: zhanghj <zhanghj.lc@inspur.com>