### PR TITLE
kata-deploy: Simplify Dockerfile and support s390x

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -1,27 +1,10 @@
-# Copyright Intel Corporation.
+# Copyright Intel Corporation, 2022 IBM Corp.
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM registry.centos.org/centos:7 AS base
-
-ENV container docker
-
-RUN (cd /lib/systemd/system/sysinit.target.wants/ && for i in *; do [ "$i" = systemd-tmpfiles-setup.service ] || rm -f "$i"; done); \
-rm -f /lib/systemd/system/multi-user.target.wants/*; \
-rm -f /etc/systemd/system/*.wants/*; \
-rm -f /lib/systemd/system/local-fs.target.wants/*; \
-rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
-rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
-rm -f /lib/systemd/system/basic.target.wants/*; \
-rm -f /lib/systemd/system/anaconda.target.wants/*;
-
-VOLUME [ "/sys/fs/cgroup" ]
-
-CMD ["/usr/sbin/init"]
-
-FROM base
-
-ARG KUBE_ARCH=amd64
+# Specify alternative base image, e.g. clefos for s390x
+ARG IMAGE
+FROM ${IMAGE:-registry.centos.org/centos}:7
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts
 
@@ -29,17 +12,18 @@ COPY ${KATA_ARTIFACTS} ${WORKDIR}
 
 RUN \
 yum -y update && \
-yum install -y epel-release && \
-yum install -y bzip2 jq && \
+yum -y install xz && \
 yum clean all && \
 mkdir -p ${DESTINATION} && \
-tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION}/ && \
-chown -R root:root ${DESTINATION}/
+tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION}
 
+# hadolint will deny echo -e, heredocs don't work in Dockerfiles, shell substitution doesn't work with $'...'
 RUN \
-curl -Lso /bin/kubectl "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${KUBE_ARCH}/kubectl" && \
-chmod +x /bin/kubectl
+echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
+echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
+echo "baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$(uname -m)" >> /etc/yum.repos.d/kubernetes.repo && \
+echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo && \
+yum -y install kubectl && \
+yum clean all
 
 COPY scripts ${DESTINATION}/scripts
-RUN \
-ln -s ${DESTINATION}/scripts/kata-deploy.sh /usr/bin/kata-deploy


### PR DESCRIPTION
The kata-deploy Dockerfile is based on CentOS 7, which has no s390x
support. Add an `IMAGE` argument to specify the registry, which still
defaults to CentOS, but e.g. ClefOS can be selected instead.

Other x86_64 assumptions are also removed. Other general simplicifations
are made.

This does not address the more general issue of #3723 -- what we're
doing here does not seem to be working with systemd >= something between
235-237.

Fixes: #3722
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

/cc @bpradipt since you were asking -- this is a co-requirement for s390x CC operator support.