### PR TITLE
stable-2.3 | packaging: Use `patch` for applying patches

### DIFF
--- a/tools/packaging/scripts/apply_patches.sh
+++ b/tools/packaging/scripts/apply_patches.sh
@@ -40,7 +40,7 @@ if [ -d "$patches_dir" ]; then
 	echo "INFO: Found ${#patches[@]} patches"
 	for patch in ${patches[@]}; do
 		echo "INFO: Apply $patch"
-		git apply "$patch" || \
+		patch -p1 < "$patch" || \
 			{ echo >&2 "ERROR: Not applied. Exiting..."; exit 1; }
 	done
 else

--- a/tools/packaging/static-build/kernel/Dockerfile
+++ b/tools/packaging/static-build/kernel/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
 	    flex \
 	    git \
 	    iptables \
-	    libelf-dev && \
+	    libelf-dev \
+	    patch && \
     if [ "$(uname -m)" = "s390x" ]; then apt-get install -y --no-install-recommends libssl-dev; fi && \
     apt-get clean && rm -rf /var/lib/lists/

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get upgrade -y && \
 	    pkg-config \
 	    libseccomp-dev \
 	    libseccomp2 \
+	    patch \
 	    python \
 	    python-dev \
 	    rsync \


### PR DESCRIPTION
`tools/packaging/scripts/apply_patches.sh` uses `git apply $patch`, but
this will not apply to subdirectories. If one wanted to apply with
`git apply`, they'd have to run it with `--directory=...`
_relative to the Git tree's root_ (absolute will not work!). I suggest
we just use `patch`, which will do what we expected `git apply` would
do.

`patch` is also added to build containers that require it.

Fixes: #3690
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>

Backport of #3691