### PR TITLE
DNM: runtime: pin vCPU threads

### DIFF
--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -79,6 +79,11 @@ cpu_features="@CPUFEATURES@"
 # > number of physical cores      --> will be set to the actual number of physical cores
 default_vcpus = 1
 
+# Specify whether enabling pinning kvm vcpu threads to L1 cpu cores.
+# If true, then each kvm vcpu thread is pinned to a cpu core if eligible.
+#
+# enable_vcpus_pinning = false
+
 # Default maximum number of vCPUs per SB/VM:
 # unspecified or == 0             --> will be set to the actual number of physical cores or to the maximum number
 #                                     of vCPUs supported by KVM if that number is exceeded

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -135,6 +135,7 @@ type hypervisor struct {
 	GuestSwap               bool     `toml:"enable_guest_swap"`
 	Rootless                bool     `toml:"rootless"`
 	DisableSeccomp          bool     `toml:"disable_seccomp"`
+	EnableVCPUsPinning      bool     `toml:"enable_vcpus_pinning"`
 }
 
 type runtime struct {
@@ -720,6 +721,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		ConfidentialGuest:       h.ConfidentialGuest,
 		GuestSwap:               h.GuestSwap,
 		Rootless:                h.Rootless,
+		EnableVCPUsPinning:      h.EnableVCPUsPinning,
 	}, nil
 }
 

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -630,6 +630,12 @@ func addHypervisorCPUOverrides(ocispec specs.Spec, sbConfig *vc.SandboxConfig) e
 		return err
 	}
 
+	if err := newAnnotationConfiguration(ocispec, vcAnnotations.EnableVCPUsPinning).setBool(func(EnableVCPUsPinning bool) {
+		sbConfig.HypervisorConfig.EnableVCPUsPinning = EnableVCPUsPinning
+	}); err != nil {
+		return err
+	}
+
 	return newAnnotationConfiguration(ocispec, vcAnnotations.DefaultMaxVCPUs).setUintWithCheck(func(maxVCPUs uint64) error {
 		max := uint32(maxVCPUs)
 

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -512,6 +512,9 @@ type HypervisorConfig struct {
 
 	// Disable seccomp from the hypervisor process
 	DisableSeccomp bool
+
+	// Enable vCPU pinning
+	EnableVCPUsPinning bool
 }
 
 // vcpu mapping from vcpu number to thread number

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -229,6 +229,8 @@ const (
 
 	// EnableRootlessHypervisor is a sandbox annotation to enable rootless hypervisor (only supported in QEMU currently).
 	EnableRootlessHypervisor = kataAnnotHypervisorPrefix + "rootless"
+
+	EnableVCPUsPinning = kataAnnotHypervisorPrefix + "enable_vcpus_pinning"
 )
 
 // Runtime related annotations


### PR DESCRIPTION
From our experiment, we noticed pinning KVM vCPU threads to CPU cores (through sched_setaffinity) significantly improves the performance for certain workloads in Kata Containers. However, it's not straightforward to implement this feature. First, how to determine which cores are assigned to which sandbox is tricky. Kata shim is a standalone instance and not aware of other instances. Second, the sched_setaffinity calls need to be consistent with the cpuset configured by the cluster orchestrator (CO). Otherwise, the syscall itself can fail.

After some digging, my current idea is to rely on the CO to set up an exclusive cpuset for the sandbox and only pins the vCPU threads to the cores in the cpuset. In the case of Kubernetes, a Pod get an exclusive cpuset if it is Guaranteed QOS and the static cpu manager policy is enabled. This solves the two problems described above. However, since it doesn't seem there exists an easy way for the Kata runtime to programmatically check whether the sandbox cpuset is exclusive or not, unfortunately we cannot enforce the prerequisite in code and need to rely on documentation. I'd love to know if someone has a better idea on this.

How does this work with host cgroup?
If sandbox_cgroup_only = false, the pod overhead cgroup is not constrained. I'm inclined to leave those threads alone and have the OS scheduler to schedule them because again there is not an easy way to know which cpuset is the shared cpuset. Otherwise, we can just put them into the shared cpuset.

If sandbox_cgroup_only = true, the kata shim, qemu threads will be in the same cgroup as the sandbox. In this case, they will share the same set of cpu cores as the vcpu threads. My preference is to leave them alone and have the OS scheduler to deal with them. Or if we want to be more smarter, let's say the users have accounted for the overhead and provisioned more cpu cores than the vcpu threads, then we can pin these overhead threads to the extra cores. But this seems getting too complicated.