### PR TITLE
snap: clh: Re-use kata-deploy script here

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -320,17 +320,20 @@ parts:
     plugin: nil
     after: [godeps]
     override-build: |
-      export GOPATH=${SNAPCRAFT_STAGE}/gopath
-      yq=${SNAPCRAFT_STAGE}/yq
-      kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
-      versions_file="${kata_dir}/versions.yaml"
-      version="$(${yq} r ${versions_file} assets.hypervisor.cloud_hypervisor.version)"
-      url="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${version}"
-      curl -L ${url}/cloud-hypervisor-static -o cloud-hypervisor
-      curl -LO ${url}/clh-remote
+      sudo apt-get -y update
+      sudo apt-get -y install ca-certificates curl gnupg lsb-release
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+      echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+      sudo apt-get -y update
+      sudo apt-get -y install docker-ce docker-ce-cli containerd.io
+      sudo systemctl start docker.socket
 
-      install -D cloud-hypervisor ${SNAPCRAFT_PART_INSTALL}/usr/bin/cloud-hypervisor
-      install -D clh-remote ${SNAPCRAFT_PART_INSTALL}/usr/bin/clh-remote
+      export GOPATH=${SNAPCRAFT_STAGE}/gopath
+      kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
+      cd ${kata_dir}
+      sudo -E NO_TTY=true make cloud-hypervisor-tarball
+      tar xvJpf build/kata-static-cloud-hypervisor.tar.xz -C /tmp/
+      install -D /tmp/opt/kata/bin/cloud-hypervisor ${SNAPCRAFT_PART_INSTALL}/usr/bin/cloud-hypervisor
 
 apps:
   runtime:

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "5343e09e7b8dbd5dd8ac0d90a3ad52037490dd86"
+      version: "b0324f85571c441f840e9bdeb25410514a00bb74"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
The current snap build for clh is broken as it's not aware of how to
build the binary from sources.

Instead of fixing it here, let's take advantage of the kata-deploy
script, which is capable of building from sources, and re-use it here.

Fixes: #3693

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>