### PR TITLE
docs: Update contributing link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 ## This repo is part of [Kata Containers](https://katacontainers.io)
 
-For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md).
+For details on how to contribute to the Kata Containers project, please see the main [contributing document](https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
This PR updates the contributing documentation link to the
one that is using kata 2.0

Fixes #3740

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>