### PR TITLE
stable-2.3 | kata-deploy: Use (kata with) qemu as the default shim-v2 binary

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -19,6 +19,8 @@ shims=(
 	"clh"
 )
 
+default_shim="qemu"
+
 # If we fail for any reason a message will be displayed
 die() {
         msg="$*"
@@ -97,6 +99,11 @@ function configure_different_shims_base() {
 KATA_CONF_FILE=/opt/kata/share/defaults/kata-containers/configuration-${shim}.toml /opt/kata/bin/containerd-shim-kata-v2 "\$@"
 EOT
 		chmod +x "$shim_file"
+
+		if [ "${shim}" == "${default_shim}" ]; then
+			echo "Creating the default shim-v2 binary"
+			ln -sf "${shim_file}" /usr/local/bin/containerd-shim-kata-v2
+		fi
 	done
 }
 
@@ -112,6 +119,8 @@ function cleanup_different_shims_base() {
 			mv "$shim_backup" "$shim_file"
 		fi
 	done
+
+	rm /usr/local/bin/containerd-shim-kata-v2
 }
 
 function configure_crio_runtime() {


### PR DESCRIPTION
When using kata-deploy, no `containerd-shim-kata-v2` binary is deployed,
but we do deploy a `kata` runtime class, which seems very much
incosistent.

As the default configuration for kata-containers points to QEMU, let's
also use kata with QEMU as the default shim-v2 binary.

Fixes: #3228, #3734
Backports: #3735

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>
(cherry picked from commit 11220f052f3a7e7c2efd9db188d5aaf26b152ab7)