### PR TITLE
runtime: fix package declaration for ppc64le

### DIFF
--- a/src/runtime/pkg/govmm/vmm_ppc64le.go
+++ b/src/runtime/pkg/govmm/vmm_ppc64le.go
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-package qemu
+package govmm
 
 // MaxVCPUs returns the maximum number of vCPUs supported
 func MaxVCPUs() uint32 {


### PR DESCRIPTION
Incorrect package name causes build to fail. Fix it
in `vm_ppc64le.go`

Fixes: #3761

Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>