### PR TITLE
runtime: Gofmt fixes

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
@@ -1,3 +1,4 @@
+//go:build !s390x
 // +build !s390x
 
 // Copyright contributors to the Virtual Machine Manager for Go project

--- a/src/runtime/pkg/govmm/vmm_s390x.go
+++ b/src/runtime/pkg/govmm/vmm_s390x.go
@@ -9,7 +9,7 @@ package govmm
 // MaxVCPUs returns the maximum number of vCPUs supported
 func MaxVCPUs() uint32 {
 	// Max number of virtual Cpu defined in qemu. See
- 	// https://github.com/qemu/qemu/blob/80422b00196a7af4c6efb628fae0ad8b644e98af/target/s390x/cpu.h#L55
- 	// #define S390_MAX_CPUS 248
- 	return uint32(248)
+	// https://github.com/qemu/qemu/blob/80422b00196a7af4c6efb628fae0ad8b644e98af/target/s390x/cpu.h#L55
+	// #define S390_MAX_CPUS 248
+	return uint32(248)
 }

--- a/src/runtime/pkg/resourcecontrol/cgroups.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2021-2022 Apple Inc.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2019 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/acrn_arch_base.go
+++ b/src/runtime/virtcontainers/acrn_arch_base.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2019 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/acrn_test.go
+++ b/src/runtime/virtcontainers/acrn_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2019 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1,7 +1,6 @@
 //go:build linux
 // +build linux
 
-//
 // Copyright (c) 2019 Ericsson Eurolab Deutschland GmbH
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2019 Ericsson Eurolab Deutschland G.m.b.H.
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -1,7 +1,6 @@
 //go:build linux
 // +build linux
 
-//
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/fc_metrics.go
+++ b/src/runtime/virtcontainers/fc_metrics.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2020 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/fc_test.go
+++ b/src/runtime/virtcontainers/fc_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2019 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/ipvlan_endpoint.go
+++ b/src/runtime/virtcontainers/ipvlan_endpoint.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/ipvlan_endpoint_test.go
+++ b/src/runtime/virtcontainers/ipvlan_endpoint_test.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/macvlan_endpoint.go
+++ b/src/runtime/virtcontainers/macvlan_endpoint.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/macvlan_endpoint_test.go
+++ b/src/runtime/virtcontainers/macvlan_endpoint_test.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/macvtap_endpoint.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/macvtap_endpoint_test.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint_test.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/physical_endpoint_test.go
+++ b/src/runtime/virtcontainers/physical_endpoint_test.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1,7 +1,6 @@
 //go:build linux
 // +build linux
 
-//
 // Copyright (c) 2016 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 IBM
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 IBM
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 IBM
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 IBM
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_s390x_test.go
+++ b/src/runtime/virtcontainers/qemu_s390x_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 IBM
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 // +build linux
-//
+
 // Copyright (c) 2016 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/tap_endpoint.go
+++ b/src/runtime/virtcontainers/tap_endpoint.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Huawei Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/tuntap_endpoint.go
+++ b/src/runtime/virtcontainers/tuntap_endpoint.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Huawei Corporation
 // Copyright (c) 2019 Intel Corporation
 //

--- a/src/runtime/virtcontainers/veth_endpoint.go
+++ b/src/runtime/virtcontainers/veth_endpoint.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/veth_endpoint_test.go
+++ b/src/runtime/virtcontainers/veth_endpoint_test.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/vhostuser_endpoint.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/src/runtime/virtcontainers/vhostuser_endpoint_test.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint_test.go
@@ -1,5 +1,6 @@
+//go:build linux
 // +build linux
-//
+
 // Copyright (c) 2018 Intel Corporation
 //
 // SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
- Mostly blank lines after `+build` -- see
  https://pkg.go.dev/go/build@go1.14.15 -- this is, to date, enforced by
  `gofmt`.
- 1.17-style go:build directives are also added.
- Spaces in govmm/vmm_s390x.go

Fixes: #3769
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>