### PR TITLE
virtcontainers: Use FilesystemSharer for sharing the containers files

### DIFF
--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -388,6 +388,19 @@ func bindUnmountContainerSnapshotDir(ctx context.Context, sharedDir, cID string)
 	return bindUnmountContainerShareDir(ctx, sharedDir, cID, snapshotDir)
 }
 
+func getVirtiofsDaemonForNydus(sandbox *Sandbox) (VirtiofsDaemon, error) {
+	var virtiofsDaemon VirtiofsDaemon
+	switch sandbox.GetHypervisorType() {
+	case string(QemuHypervisor):
+		virtiofsDaemon = sandbox.hypervisor.(*qemu).virtiofsDaemon
+	case string(ClhHypervisor):
+		virtiofsDaemon = sandbox.hypervisor.(*cloudHypervisor).virtiofsDaemon
+	default:
+		return nil, errNydusdNotSupport
+	}
+	return virtiofsDaemon, nil
+}
+
 func nydusContainerCleanup(ctx context.Context, sharedDir string, c *Container) error {
 	sandbox := c.sandbox
 	virtiofsDaemon, err := getVirtiofsDaemonForNydus(sandbox)


### PR DESCRIPTION
Switching to the generic FilesystemSharer brings 2 majors improvements:

1. Remove container and sandbox specific code from kata_agent.go
2. Allow for non Linux implementations to provide ways to share
   container files and root filesystems with the Kata Linux guest.

This is a rebase of #2861 

Fixes #3622

Signed-off-by: Samuel Ortiz <s.ortiz@apple.com>
Signed-off-by: Matt Ickstadt <mattico8@gmail.com>