### PR TITLE
Fix unbound variable / typo on error mesage

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -657,7 +657,7 @@ func (clh *cloudHypervisor) HotplugRemoveDevice(ctx context.Context, devInfo int
 	defer span.End()
 
 	if clh.config.ConfidentialGuest {
-		return nil, errors.New("Device hotplug addition is not supported in confidential mode")
+		return nil, errors.New("Device hotplug removal is not supported in confidential mode")
 	}
 
 	var deviceID string

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -16,7 +16,7 @@ ARCH=$(uname -m)
 script_dir=$(dirname $(readlink -f "$0"))
 kata_version="${kata_version:-}"
 force_build_from_source="${force_build_from_source:-false}"
-extra_build_args="${extra_build_args:-}"
+features="${features:-}"
 
 source "${script_dir}/../../scripts/lib.sh"
 
@@ -68,7 +68,7 @@ if [ "${ARCH}" == "aarch64" ]; then
     force_build_from_source="true"
 fi
 
-if [ -n "${extra_build_args}" ]; then
+if [ -n "${features}" ]; then
     info "As an extra build argument has been passed to the script, forcing to build from source"
     force_build_from_source="true"
 fi


### PR DESCRIPTION
This is a follow-up of #3771, and we're fixing here an issue found by an unrelated PR, where the ARM CI poinnted out about the unbound variable, and also a typo pointed out by @egernst.

Fixes: #3775 