### PR TITLE
Update `confidential_guest` comments

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -40,7 +40,7 @@ image = "@IMAGEPATH@"
 #
 # For more information about firmwared that can be used with specific TEEs,
 # please, refer to:
-# * TDX:
+# * Intel TDX:
 #   - td-shim: https://github.com/confidential-containers/td-shim
 #
 # firmware = "@FIRMWAREPATH@"

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -19,7 +19,8 @@ image = "@IMAGEPATH@"
 # Toggling that setting may trigger different hardware features, ranging
 # from memory encryption to both memory and CPU-state encryption and integrity.
 # The Kata Containers runtime dynamically detects the available feature set and
-# aims at enabling the largest possible one.
+# aims at enabling the largest possible one, returning an error if none is
+# available, or none is supported by the hypervisor.
 #
 # Known limitations:
 # * Does not work by design:

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -28,6 +28,9 @@ image = "@IMAGEPATH@"
 #   - Memory Hotplug
 #   - NVDIMM devices
 #
+# Supported TEEs:
+# * Intel TDX
+#
 # Default false
 # confidential_guest = true
 

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -20,7 +20,8 @@ machine_type = "@MACHINETYPE@"
 # Toggling that setting may trigger different hardware features, ranging
 # from memory encryption to both memory and CPU-state encryption and integrity.
 # The Kata Containers runtime dynamically detects the available feature set and
-# aims at enabling the largest possible one.
+# aims at enabling the largest possible one, returning an error if none is
+# available, or none is supported by the hypervisor.
 #
 # Known limitations:
 # * Does not work by design:


### PR DESCRIPTION
Let's clarify that an error will be reported in case confidential_guest
is enabled, but the hardware where Kata Containers is running doesn't
provide the required feature set.

Fixes: #3787

And while at this, let's also make it clear that when using Cloud Hypervisor we only support Intel TDX.