### PR TITLE
Fix monitor listen address

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -552,8 +552,8 @@ $(SHIMV2_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST)
 	$(QUIET_BUILD)(cd $(SHIMV2_DIR)/ && go build -ldflags "$(KATA_LDFLAGS)" $(BUILDFLAGS) -o $@ .)
 
 $(MONITOR_OUTPUT): $(SOURCES) $(GENERATED_FILES) $(MAKEFILE_LIST) .git-commit
-	$(QUIET_BUILD)(cd $(MONITOR_DIR)/ && CGO_ENABLED=0 go build \
-		--ldflags "-X main.GitCommit=$(shell cat .git-commit)" $(BUILDFLAGS) -buildmode=exe -o $@ .)
+	$(QUIET_BUILD)(cd $(MONITOR_DIR)/ && go build \
+		--ldflags "-X main.GitCommit=$(shell cat .git-commit)" $(BUILDFLAGS) -o $@ .)
 
 .PHONY: \
 	check \

--- a/src/runtime/cmd/kata-monitor/main.go
+++ b/src/runtime/cmd/kata-monitor/main.go
@@ -18,7 +18,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var monitorListenAddr = flag.String("listen-address", ":8090", "The address to listen on for HTTP requests.")
+const defaultListenAddress = "127.0.0.1:8090"
+
+var monitorListenAddr = flag.String("listen-address", defaultListenAddress, "The address to listen on for HTTP requests.")
 var runtimeEndpoint = flag.String("runtime-endpoint", "/run/containerd/containerd.sock", `Endpoint of CRI container runtime service. (default: "/run/containerd/containerd.sock")`)
 var logLevel = flag.String("log-level", "info", "Log level of logrus(trace/debug/info/warn/error/fatal/panic).")
 


### PR DESCRIPTION
monitor: Listen to localhost only by default

Change `kata-monitor` to listen to port `8090` on the local interface
only by default.

> **Note:**
>
> This is a breaking change as previously it listened on all interfaces.

Fixes: #3795.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>