### PR TITLE
clh: tdx: Don't use sharedFS with Confidential Guests

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -25,7 +25,6 @@ image = "@IMAGEPATH@"
 # Known limitations:
 # * Does not work by design:
 #   - CPU Hotplug 
-#   - Device Hotplug
 #   - Memory Hotplug
 #   - NVDIMM devices
 #

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -27,6 +27,10 @@ image = "@IMAGEPATH@"
 #   - CPU Hotplug 
 #   - Memory Hotplug
 #   - NVDIMM devices
+#   - SharedFS, such as virtio-fs and virtio-fs-nydus
+#
+# Requirements:
+# * virtio-block used as rootfs, thus the usage of devmapper snapshotter.
 #
 # Supported TEEs:
 # * Intel TDX

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -26,7 +26,6 @@ machine_type = "@MACHINETYPE@"
 # Known limitations:
 # * Does not work by design:
 #   - CPU Hotplug 
-#   - Device Hotplug
 #   - Memory Hotplug
 #   - NVDIMM devices
 #

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -638,10 +638,6 @@ func (clh *cloudHypervisor) HotplugAddDevice(ctx context.Context, devInfo interf
 	span, _ := katatrace.Trace(ctx, clh.Logger(), "HotplugAddDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
-	if clh.config.ConfidentialGuest {
-		return nil, errors.New("Device hotplug addition is not supported in confidential mode")
-	}
-
 	switch devType {
 	case BlockDev:
 		drive := devInfo.(*config.BlockDrive)
@@ -658,10 +654,6 @@ func (clh *cloudHypervisor) HotplugAddDevice(ctx context.Context, devInfo interf
 func (clh *cloudHypervisor) HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	span, _ := katatrace.Trace(ctx, clh.Logger(), "HotplugRemoveDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
-
-	if clh.config.ConfidentialGuest {
-		return nil, errors.New("Device hotplug removal is not supported in confidential mode")
-	}
 
 	var deviceID string
 
@@ -917,9 +909,7 @@ func (clh *cloudHypervisor) Capabilities(ctx context.Context) types.Capabilities
 	clh.Logger().WithField("function", "Capabilities").Info("get Capabilities")
 	var caps types.Capabilities
 	caps.SetFsSharingSupport()
-	if !clh.config.ConfidentialGuest {
-		caps.SetBlockDeviceHotplugSupport()
-	}
+	caps.SetBlockDeviceHotplugSupport()
 	return caps
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -199,6 +199,11 @@ func (clh *cloudHypervisor) setConfig(config *HypervisorConfig) error {
 }
 
 func (clh *cloudHypervisor) createVirtiofsDaemon(sharedPath string) (VirtiofsDaemon, error) {
+	if !clh.supportsSharedFS() {
+		clh.Logger().Info("SharedFS is not supported")
+		return nil, nil
+	}
+
 	virtiofsdSocketPath, err := clh.virtioFsSocketPath(clh.id)
 	if err != nil {
 		return nil, err
@@ -235,6 +240,11 @@ func (clh *cloudHypervisor) createVirtiofsDaemon(sharedPath string) (VirtiofsDae
 }
 
 func (clh *cloudHypervisor) setupVirtiofsDaemon(ctx context.Context) error {
+	if !clh.supportsSharedFS() {
+		clh.Logger().Info("SharedFS is not supported")
+		return nil
+	}
+
 	if clh.config.SharedFS == config.Virtio9P {
 		return errors.New("cloud-hypervisor only supports virtio based file sharing")
 	}
@@ -258,6 +268,11 @@ func (clh *cloudHypervisor) setupVirtiofsDaemon(ctx context.Context) error {
 }
 
 func (clh *cloudHypervisor) stopVirtiofsDaemon(ctx context.Context) (err error) {
+	if !clh.supportsSharedFS() {
+		clh.Logger().Info("SharedFS is not supported")
+		return nil
+	}
+
 	if clh.state.VirtiofsDaemonPid == 0 {
 		clh.Logger().Warn("The virtiofsd had stopped")
 		return nil
@@ -274,6 +289,11 @@ func (clh *cloudHypervisor) stopVirtiofsDaemon(ctx context.Context) (err error) 
 }
 
 func (clh *cloudHypervisor) loadVirtiofsDaemon(sharedPath string) (VirtiofsDaemon, error) {
+	if !clh.supportsSharedFS() {
+		clh.Logger().Info("SharedFS is not supported")
+		return nil, nil
+	}
+
 	virtiofsdSocketPath, err := clh.virtioFsSocketPath(clh.id)
 	if err != nil {
 		return nil, err
@@ -289,6 +309,12 @@ func (clh *cloudHypervisor) loadVirtiofsDaemon(sharedPath string) (VirtiofsDaemo
 
 func (clh *cloudHypervisor) nydusdAPISocketPath(id string) (string, error) {
 	return utils.BuildSocketPath(clh.config.VMStorePath, id, nydusdAPISock)
+}
+
+func (clh *cloudHypervisor) supportsSharedFS() bool {
+	caps := clh.Capabilities(clh.ctx)
+
+	return caps.IsFsSharingSupported()
 }
 
 func (clh *cloudHypervisor) enableProtection() error {

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -988,7 +988,9 @@ func (clh *cloudHypervisor) Capabilities(ctx context.Context) types.Capabilities
 
 	clh.Logger().WithField("function", "Capabilities").Info("get Capabilities")
 	var caps types.Capabilities
-	caps.SetFsSharingSupport()
+	if !clh.config.ConfidentialGuest {
+		caps.SetFsSharingSupport()
+	}
 	caps.SetBlockDeviceHotplugSupport()
 	return caps
 }

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -958,6 +958,10 @@ func (clh *cloudHypervisor) AddDevice(ctx context.Context, devInfo interface{}, 
 	case types.HybridVSock:
 		clh.addVSock(defaultGuestVSockCID, v.UdsPath)
 	case types.Volume:
+		if !clh.supportsSharedFS() {
+			return fmt.Errorf("SharedFS is not supported")
+		}
+
 		err = clh.addVolume(v)
 	default:
 		clh.Logger().WithField("function", "AddDevice").Warnf("Add device of type %v is not supported.", v)

--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -158,9 +158,8 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 func (q *qemuAmd64) capabilities() types.Capabilities {
 	var caps types.Capabilities
 
-	if (q.qemuMachine.Type == QemuQ35 ||
-		q.qemuMachine.Type == QemuVirt) &&
-		q.protection == noneProtection {
+	if q.qemuMachine.Type == QemuQ35 ||
+		q.qemuMachine.Type == QemuVirt {
 		caps.SetBlockDeviceHotplugSupport()
 	}
 

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -277,9 +277,7 @@ func (q *qemuArchBase) kernelParameters(debug bool) []Param {
 
 func (q *qemuArchBase) capabilities() types.Capabilities {
 	var caps types.Capabilities
-	if q.protection == noneProtection {
-		caps.SetBlockDeviceHotplugSupport()
-	}
+	caps.SetBlockDeviceHotplugSupport()
 	caps.SetMultiQueueSupport()
 	caps.SetFsSharingSupport()
 	return caps

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -101,8 +101,7 @@ func (q *qemuPPC64le) capabilities() types.Capabilities {
 	var caps types.Capabilities
 
 	// pseries machine type supports hotplugging drives
-	if q.qemuMachine.Type == QemuPseries &&
-		q.protection == noneProtection {
+	if q.qemuMachine.Type == QemuPseries {
 		caps.SetBlockDeviceHotplugSupport()
 	}
 


### PR DESCRIPTION
clh: Don't use sharedFS with Confidential Guests

kata-containers/pulls#3771 added TDX support for Cloud Hypervisor, but
two big things got overlooked while doing that.

1. virtio-fs, as of now, cannot be part of the trust boundary, so the
   Confidential Guest will not be using it.

2. virtio-block hotplug should be enabled in order to use virtio-block
   for the rootfs (used with the devmapper plugin).

When trying to use cloud-hypervisor with TDX using virtio-fs, we're
facing the following error on the guest kernel:
```
virtiofs virtio2: device must provide VIRTIO_F_ACCESS_PLATFORM
```

After checking and double-checking with virtiofs and cloud-hypervisor
developers, it happens as confidential containers might put some
limitations on the device, so it can't access all of the guests' memory
and that's where this restriction seems to be coming from. Vivek
mentioned that virtiofsd do not support VIRTIO_F_ACCESS_PLATFORM (aka
VIRTIO_F_IOMMU_PLATFORM) yet, and that for ecrypted guests virtiofs may
not be the best solution at the moment.

@sboeuf put this in a very nice way: "if the virtio-fs driver doesn't
support VIRTIO_F_ACCESS_PLATFORM, then the pages corresponding to the
virtqueues and the buffers won't be marked as SHARED, meaning the VMM
won't have access to it".

Interestingly enough, it works with QEMU, and it may be due to some
change done on the patched QEMU that @devimc is packaging, but we won't
take the path to figure out what was the change and patch
cloud-hypervisor on the same way, because of 1.

Fixes: #3810

---

Revert "hypervisors: Confidential Guests do not support Device hotplug"

This reverts commit df8ffecde0b4190c6c8ce8ee21e871ceafe132f9, as device
hotplug *is* supported and, more than that, is very much needed when
using virtio-blk instead of virtio-fs.

---

And here is what I finally am able to get as a result of spawning a simple pod using the proposed patches:
```
# ctr run --snapshotter devmapper --rm --runtime io.containerd.run.kata-clh-tdshim.v2 -t --rm docker.io/library/busybox:latest fidencio sh
/ # dmesg | grep -i tdx
[    0.000000] tdx: Force enabling TDX Guest feature
[    0.000000] TDX: Disabled TDX guest filter support
[    0.000000] tdx: Setting event notification interrupt failed
[    0.000000] tdx: Guest initialized

```