### PR TITLE
runtime: Build golang components with extra security options

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -28,6 +28,9 @@ ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 ARCH_FILES = $(wildcard arch/*$(ARCH_FILE_SUFFIX))
 ALL_ARCHES = $(patsubst $(ARCH_DIR)/%$(ARCH_FILE_SUFFIX),%,$(ARCH_FILES))
 
+# Build as safely as possible
+export CGO_CPPFLAGS = -D_FORTIFY_SOURCE=2 -fstack-protector
+
 ifeq (,$(realpath $(ARCH_FILE)))
     $(error "ERROR: invalid architecture: '$(ARCH)'")
 else


### PR DESCRIPTION
Enable stack protector and fortify source for golang builds.

Fixes: #3817.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>