### PR TITLE
clh: stop virtofsd if clh fails to boot up the vm

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -565,12 +565,16 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
 	if err != nil {
 		return err
 	}
+	defer func() {
+		if err != nil {
+			if shutdownErr := clh.stopVirtiofsDaemon(ctx); shutdownErr != nil {
+				clh.Logger().WithError(shutdownErr).Warn("error shutting down VirtiofsDaemon")
+			}
+		}
+	}()
 
 	pid, err := clh.launchClh()
 	if err != nil {
-		if shutdownErr := clh.stopVirtiofsDaemon(ctx); shutdownErr != nil {
-			clh.Logger().WithError(shutdownErr).Warn("error shutting down VirtiofsDaemon")
-		}
 		return fmt.Errorf("failed to launch cloud-hypervisor: %q", err)
 	}
 	clh.state.PID = pid


### PR DESCRIPTION
If, for some reason, we're able to launch cloud hypervisor but not able
to boot the VM up, the virtiofsd process would be left behind.

Let's ensure, via defer, that we stop virtiofsd in case of errors.

Fixes: #3819

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>