### PR TITLE
versions: Upgrade to Cloud Hypervisor v22.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "b0324f85571c441f840e9bdeb25410514a00bb74"
+      version: "v22.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
Highlights from the Cloud Hypervisor release v22.0:

1. GDB Debug Stub Support;
2. `virtio-iommu` Backed Segments (to facilitate hotplug devices that require being behind an IOMMU, e.g. QAT) ;
3. Before Boot Configuration Changes;
4. `virtio-balloon` Free Page Reporting;
5. Support for Direct Kernel Booting with TDX;
6. PMU Support for AArch64;
7. Documentation Under CC-BY-4.0 License;
8. Deprecation of "Classic" virtiofsd (rust-based virtiofsd now is recommended);
9. Bug fixes on `virtio-balloon`, `virtio-net` with multiple TAP fd support, REST APIs, seccomp filters, migration with `vhost-user`, etc;

Details can be found: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v22.0

Fixes: #3825

Signed-off-by: Bo Chen <chen.bo@intel.com>