### PR TITLE
DNM: version: Update the versions of the packages used for our tests

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -196,7 +196,7 @@ externals:
     # containerd from v1.5.0 used the path unix socket
     # instead of abstract socket, thus kata wouldn's support the containerd's
     # version older than them.
-    version: "v1.5.2"
+    version: "v1.6.1"
 
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"

--- a/versions.yaml
+++ b/versions.yaml
@@ -175,7 +175,7 @@ externals:
   cni-plugins:
     description: "CNI network plugins"
     url: "https://github.com/containernetworking/plugins"
-    commit: "485be65581341430f9106a194a98f0f2412245fb"
+    commit: "v1.1.0"
 
   conmon:
     description: "An OCI container runtime monitor"


### PR DESCRIPTION
contaienrd: v1.5.2 -> v1.6.1
cni-plugins: 485be65581341430f9106a194a98f0f2412245fb (a commit from 0.3.0) -> v1.1.0