### PR TITLE
Enhancement: fix comments/logs and delete not used function

### DIFF
--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -551,7 +551,7 @@ mod tests {
 
         assert!(
             s.remove_sandbox_storage(srcdir_path).is_err(),
-            "Expect Err as the directory i not a mountpoint"
+            "Expect Err as the directory is not a mountpoint"
         );
 
         assert!(s.remove_sandbox_storage("").is_err());
@@ -586,7 +586,6 @@ mod tests {
         let logger = slog::Logger::root(slog::Discard, o!());
         let mut s = Sandbox::new(&logger).unwrap();
 
-        // FIX: This test fails, not sure why yet.
         assert!(
             s.unset_and_remove_sandbox_storage("/tmp/testEphePath")
                 .is_err(),

--- a/src/runtime/pkg/resourcecontrol/controller.go
+++ b/src/runtime/pkg/resourcecontrol/controller.go
@@ -22,14 +22,14 @@ func SetLogger(logger *logrus.Entry) {
 	controllerLogger = logger.WithFields(fields)
 }
 
-// HypervisorType describes an hypervisor type.
+// ResourceControllerType describes a resource controller type.
 type ResourceControllerType string
 
 const (
 	LinuxCgroups ResourceControllerType = "cgroups"
 )
 
-// String converts an hypervisor type to a string.
+// String converts a resource type to a string.
 func (rType *ResourceControllerType) String() string {
 	switch *rType {
 	case LinuxCgroups:

--- a/src/runtime/pkg/resourcecontrol/utils_linux.go
+++ b/src/runtime/pkg/resourcecontrol/utils_linux.go
@@ -20,7 +20,7 @@ import (
 // DefaultResourceControllerID runtime-determined location in the cgroups hierarchy.
 const DefaultResourceControllerID = "/vc"
 
-// validCgroupPath returns a valid cgroup path.
+// ValidCgroupPath returns a valid cgroup path.
 // see https://github.com/opencontainers/runtime-spec/blob/master/config-linux.md#cgroups-path
 func ValidCgroupPath(path string, systemdCgroup bool) (string, error) {
 	if IsSystemdCgroup(path) {


### PR DESCRIPTION
- rustjail: delete function signal in BaseContainer
    
> Function signal in BaseContainer is not used anymore.

- agent: delete meaningless FIXME comment
    
> The test has passed, the FIX comment should
be deleted.


- runtime: fix invalid comments for pkg/resourcecontrol
    
> Some comments are copied and not adjusted to the
pkg/resourcecontrol package.
