### PR TITLE
Add debug and self-test control options to Kata Manager

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -214,6 +214,8 @@ Options:
  -k <version> : Specify Kata Containers version.
  -o           : Only install Kata Containers.
  -r           : Don't cleanup on failure (retain files).
+ -t           : Disable self test (don't try to create a container after install).
+ -T           : Only run self test (do not install anything).
 
 Notes:
 
@@ -697,9 +699,17 @@ handle_installation()
 	local enable_debug="${4:-}"
 	[ -z "$enable_debug" ] && die "no enable debug value"
 
+	local disable_test="${5:-}"
+	[ -z "$disable_test" ] && die "no disable test value"
+
+	local only_run_test="${6:-}"
+	[ -z "$only_run_test" ] && die "no only run test value"
+
 	# These params can be blank
-	local kata_version="${5:-}"
-	local containerd_version="${6:-}"
+	local kata_version="${7:-}"
+	local containerd_version="${8:-}"
+
+	[ "$only_run_test" = "true" ] && test_installation && return 0
 
 	setup "$cleanup" "$force"
 
@@ -710,6 +720,8 @@ handle_installation()
 		"$containerd_version" \
 		"$force" \
 		"$enable_debug"
+
+	[ "$disable_test" = "false" ] && test_installation
 
 	if [ "$only_kata" = "true" ]
 	then
@@ -726,6 +738,8 @@ handle_args()
 	local cleanup="true"
 	local force="false"
 	local only_kata="false"
+	local disable_test="false"
+	local only_run_test="false"
 	local enable_debug="false"
 
 	local opt
@@ -733,7 +747,7 @@ handle_args()
 	local kata_version=""
 	local containerd_version=""
 
-	while getopts "c:dfhk:or" opt "$@"
+	while getopts "c:dfhk:ortT" opt "$@"
 	do
 		case "$opt" in
 			c) containerd_version="$OPTARG" ;;
@@ -743,6 +757,8 @@ handle_args()
 			k) kata_version="$OPTARG" ;;
 			o) only_kata="true" ;;
 			r) cleanup="false" ;;
+			t) disable_test="true" ;;
+			T) only_run_test="true" ;;
 		esac
 	done
 
@@ -756,6 +772,8 @@ handle_args()
 		"$force" \
 		"$only_kata" \
 		"$enable_debug" \
+		"$disable_test" \
+		"$only_run_test" \
 		"$kata_version" \
 		"$containerd_version"
 }

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -402,7 +402,12 @@ install_containerd()
 
 	sudo tar -C /usr/local -xvf "${file}"
 
-	sudo ln -sf /usr/local/bin/ctr "${link_dir}"
+	for file in \
+		/usr/local/bin/containerd \
+		/usr/local/bin/ctr
+		do
+			sudo ln -sf "$file" "${link_dir}"
+		done
 
 	info "$project installed\n"
 }

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -441,7 +441,6 @@ configure_containerd()
 			"$(date -Iseconds)" |\
 			tee -a "$containerd_service_name"
 
-
 		sudo cp "${containerd_service_name}" "${dest}"
 		sudo systemctl daemon-reload
 

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -43,7 +43,7 @@ readonly link_dir=${link_dir:-/usr/bin}
 
 readonly tmpdir=$(mktemp -d)
 
-readonly warnings=$(cat <<EOT
+readonly warnings=$(cat <<EOF
 WARNINGS:
 
 - Use distro-packages where possible
@@ -63,7 +63,7 @@ WARNINGS:
   and $containerd_project from binary release packages. These versions may
   not have been tested with your distribution version.
 
-EOT
+EOF
 )
 
 die()
@@ -199,7 +199,7 @@ github_download_release()
 
 usage()
 {
-	cat <<EOT
+	cat <<EOF
 Usage: $script_name [options] [<kata-version> [<containerd-version>]]
 
 Description: Install $kata_project [1] (and optionally $containerd_project [2])
@@ -235,7 +235,7 @@ Advice:
 
   $ kata-runtime check --only-list-releases
 
-EOT
+EOF
 }
 
 # Determine if the system only supports cgroups v2.
@@ -480,7 +480,7 @@ configure_containerd()
 		"$script_name")
 
 	sudo grep -q "$kata_runtime_type" "$cfg" || {
-		cat <<-EOT | sudo tee -a "$cfg"
+		cat <<-EOF | sudo tee -a "$cfg"
 		# $comment_text
 		[plugins]
 		  [plugins."io.containerd.grpc.v1.cri"]
@@ -489,7 +489,7 @@ configure_containerd()
 		      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
 		        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.${kata_runtime_name}]
 		          runtime_type = "${kata_runtime_type}"
-		EOT
+		EOF
 
 		modified="true"
 	}
@@ -501,11 +501,11 @@ configure_containerd()
 			grep -E "^\s*\<level\>\s*=\s*.*\<debug\>" || true)
 
 		[ -n "$debug_enabled" ] || {
-			cat <<-EOT | sudo tee -a "$cfg"
+			cat <<-EOF | sudo tee -a "$cfg"
 			# $comment_text
 			[debug]
 				level = "debug"
-			EOT
+			EOF
 		}
 
 		modified="true"


### PR DESCRIPTION
Add new CLI options to the `kata-manager` script:

```
-d           : Enable debug for all components.
-t           : Disable self test (don't try to create a container after install).
-T           : Only run self test (do not install anything).
```

- Added a `-d` option to `kata-manager` to enable Kata Containers and containerd debug.

  These are useful for system debugging.

- Added self test options to allow the self test to be disabled, or to only run the self test.

  These features allow changes to be made to the installed system before the self test is run.

Fixes: #3851.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>