### PR TITLE
stable-2.3 | versions: Upgrade to Cloud Hypervisor v22.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v21.0"
+      version: "v22.1"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This is a bug fix release. The following issues have been addressed:
1. VFIO ioctl reordering to fix MSI on AMD platforms; 
2. Fix virtio-net control queue.

Details can be found: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v22.1

Note: client code of Cloud Hypervisor is not updated given this is a
backport change.

Fixes: #3872

Signed-off-by: Bo Chen <chen.bo@intel.com>
(cherry picked from commit 7a18e32fa7b4724994fb06c74b7d27ba5b91ec89)