### PR TITLE
action: Update link for format patch documentation

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -10,7 +10,7 @@ env:
   error_msg: |+
     See the document below for help on formatting commits for the project.
 
-    https://github.com/kata-containers/community/blob/master/CONTRIBUTING.md#patch-format
+    https://github.com/kata-containers/community/blob/main/CONTRIBUTING.md#patch-format
 
 jobs:
   commit-message-check:


### PR DESCRIPTION
This PR updates the link for the format patch documentation for the
commit message check.

Fixes #3900

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>