### PR TITLE
runtime: fix vmcache for qemu vm

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -2499,6 +2499,9 @@ type qemuGrpc struct {
 	// q.qemuConfig.SMP.
 	// So just transport q.qemuConfig.SMP from VM Cache server to runtime.
 	QemuSMP govmmQemu.SMP
+
+	// send vsock contextid to client
+	ContextID uint64
 }
 
 func (q *qemu) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, j []byte) error {
@@ -2524,6 +2527,13 @@ func (q *qemu) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig,
 	q.qemuConfig.SMP = qp.QemuSMP
 
 	q.arch.setBridges(q.state.Bridges)
+
+	vsock := types.VSock{ContextID: qp.ContextID, Port: uint32(vSockPort)}
+	q.qemuConfig.Devices, err = q.arch.appendVSock(ctx, q.qemuConfig.Devices, vsock)
+	if err != nil {
+		return err
+	}
+	q.qemuConfig.PidFile = filepath.Join(q.config.VMStorePath, q.id, "pid")
 	return nil
 }
 
@@ -2540,6 +2550,13 @@ func (q *qemu) toGrpc(ctx context.Context) ([]byte, error) {
 		QemuSMP: q.qemuConfig.SMP,
 	}
 
+	// set vsock contextid
+	for _, device := range q.qemuConfig.Devices {
+		if vsockdev, ok := device.(govmmQemu.VSOCKDevice); ok {
+			qp.ContextID = vsockdev.ContextID
+			break
+		}
+	}
 	return json.Marshal(&qp)
 }
 
@@ -2617,6 +2634,17 @@ func (q *qemu) Check() error {
 }
 
 func (q *qemu) GenerateSocket(id string) (interface{}, error) {
+	// if vsock already exsist, return it directly
+	// for vmcache, we don't need another random vsock
+	for _, device := range q.qemuConfig.Devices {
+		if vsockdev, ok := device.(govmmQemu.VSOCKDevice); ok {
+			return types.VSock{
+				VhostFd:   vsockdev.VHostFD,
+				ContextID: vsockdev.ContextID,
+				Port:      uint32(vSockPort),
+			}, nil
+		}
+	}
 	return generateVMSocket(id, q.config.VMStorePath)
 }
 

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -116,6 +116,12 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 		}
 	}()
 
+	// set default path if store path is not set
+	if config.HypervisorConfig.VMStorePath == "" && config.HypervisorConfig.RunStorePath == "" {
+		config.HypervisorConfig.VMStorePath = store.RunVMStoragePath()
+		config.HypervisorConfig.RunStorePath = store.RunStoragePath()
+	}
+
 	if err = hypervisor.CreateVM(ctx, id, network, &config.HypervisorConfig); err != nil {
 		return nil, err
 	}
@@ -188,6 +194,12 @@ func NewVMFromGrpc(ctx context.Context, v *pb.GrpcVM, config VMConfig) (*VM, err
 		}
 	}()
 
+	// set default path if store path is not set
+	if config.HypervisorConfig.VMStorePath == "" && config.HypervisorConfig.RunStorePath == "" {
+		config.HypervisorConfig.VMStorePath = store.RunVMStoragePath()
+		config.HypervisorConfig.RunStorePath = store.RunStoragePath()
+	}
+
 	err = hypervisor.fromGrpc(ctx, &config.HypervisorConfig, v.Hypervisor)
 	if err != nil {
 		return nil, err
@@ -197,6 +209,10 @@ func NewVMFromGrpc(ctx context.Context, v *pb.GrpcVM, config VMConfig) (*VM, err
 	newAagentFunc := getNewAgentFunc(ctx)
 	agent := newAagentFunc()
 	agent.configureFromGrpc(ctx, hypervisor, v.Id, config.AgentConfig)
+	err = agent.setAgentURL()
+	if err != nil {
+		return nil, err
+	}
 
 	return &VM{
 		id:         v.Id,


### PR DESCRIPTION
The bug is mainly caused by missing context id of
vsock. To fix it, add a 'ContextID' var into
'qemuGrpc', and modify the function 'GenerateSocket'
to return a existed vsock rather than a random one.

Fixes: #1106

Signed-off-by: tiezhuoyu <tiezhuoyu@outlook.com>