### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/docs/Unit-Test-Advice.md
+++ b/docs/Unit-Test-Advice.md
@@ -277,7 +277,9 @@ mod tests {
 
 ## Temporary files
 
-Always delete temporary files on success.
+Use `t.TempDir()` to create temporary directory. The directory created by
+`t.TempDir()` is automatically removed when the test and all its subtests
+complete.
 
 ### Golang temporary files
 
@@ -286,11 +288,7 @@ func TestSomething(t *testing.T) {
     assert := assert.New(t)
 
     // Create a temporary directory
-    tmpdir, err := os.MkdirTemp("", "")
-    assert.NoError(err)
-
-    // Delete it at the end of the test
-    defer os.RemoveAll(tmpdir) 
+    tmpdir := t.TempDir()
 
     // Add test logic that will use the tmpdir here...
 }

--- a/src/runtime/cmd/kata-runtime/factory_test.go
+++ b/src/runtime/cmd/kata-runtime/factory_test.go
@@ -8,7 +8,6 @@ package main
 import (
 	"context"
 	"flag"
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,9 +42,7 @@ func TestFactoryCLIFunctionNoRuntimeConfig(t *testing.T) {
 func TestFactoryCLIFunctionInit(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -92,9 +89,7 @@ func TestFactoryCLIFunctionInit(t *testing.T) {
 func TestFactoryCLIFunctionDestroy(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -126,9 +121,7 @@ func TestFactoryCLIFunctionDestroy(t *testing.T) {
 func TestFactoryCLIFunctionStatus(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)

--- a/src/runtime/cmd/kata-runtime/kata-check_amd64_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_amd64_test.go
@@ -71,11 +71,7 @@ func TestCCCheckCLIFunction(t *testing.T) {
 func TestCheckCheckKernelModulesNoNesting(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedSysModuleDir := sysModuleDir
 	savedProcCPUInfo := procCPUInfo
@@ -91,7 +87,7 @@ func TestCheckCheckKernelModulesNoNesting(t *testing.T) {
 		procCPUInfo = savedProcCPUInfo
 	}()
 
-	err = os.MkdirAll(sysModuleDir, testDirMode)
+	err := os.MkdirAll(sysModuleDir, testDirMode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -156,11 +152,7 @@ func TestCheckCheckKernelModulesNoNesting(t *testing.T) {
 func TestCheckCheckKernelModulesNoUnrestrictedGuest(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedSysModuleDir := sysModuleDir
 	savedProcCPUInfo := procCPUInfo
@@ -176,7 +168,7 @@ func TestCheckCheckKernelModulesNoUnrestrictedGuest(t *testing.T) {
 		procCPUInfo = savedProcCPUInfo
 	}()
 
-	err = os.MkdirAll(sysModuleDir, testDirMode)
+	err := os.MkdirAll(sysModuleDir, testDirMode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -255,11 +247,7 @@ func TestCheckHostIsVMContainerCapable(t *testing.T) {
 
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedSysModuleDir := sysModuleDir
 	savedProcCPUInfo := procCPUInfo
@@ -275,7 +263,7 @@ func TestCheckHostIsVMContainerCapable(t *testing.T) {
 		procCPUInfo = savedProcCPUInfo
 	}()
 
-	err = os.MkdirAll(sysModuleDir, testDirMode)
+	err := os.MkdirAll(sysModuleDir, testDirMode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,11 +393,7 @@ func TestArchKernelParamHandler(t *testing.T) {
 func TestKvmIsUsable(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedKvmDevice := kvmDevice
 	fakeKVMDevice := filepath.Join(dir, "kvm")
@@ -419,7 +403,7 @@ func TestKvmIsUsable(t *testing.T) {
 		kvmDevice = savedKvmDevice
 	}()
 
-	err = kvmIsUsable()
+	err := kvmIsUsable()
 	assert.Error(err)
 
 	err = createEmptyFile(fakeKVMDevice)
@@ -457,9 +441,7 @@ foo     : bar
 func TestSetCPUtype(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	savedArchRequiredCPUFlags := archRequiredCPUFlags
 	savedArchRequiredCPUAttribs := archRequiredCPUAttribs

--- a/src/runtime/cmd/kata-runtime/kata-check_arm64_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_arm64_test.go
@@ -67,11 +67,7 @@ foo     : bar
 		{validContents, validNormalizeVendorName, validNormalizeModelName, false},
 	}
 
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	savedProcCPUInfo := procCPUInfo
 
@@ -84,7 +80,7 @@ foo     : bar
 		procCPUInfo = savedProcCPUInfo
 	}()
 
-	_, _, err = getCPUDetails()
+	_, _, err := getCPUDetails()
 	// ENOENT
 	assert.Error(t, err)
 	assert.True(t, os.IsNotExist(err))

--- a/src/runtime/cmd/kata-runtime/kata-check_generic_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_generic_test.go
@@ -9,7 +9,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,9 +17,7 @@ import (
 func testSetCPUTypeGeneric(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	savedArchRequiredCPUFlags := archRequiredCPUFlags
 	savedArchRequiredCPUAttribs := archRequiredCPUAttribs

--- a/src/runtime/cmd/kata-runtime/kata-check_ppc64le_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_ppc64le_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -118,11 +117,7 @@ func TestArchKernelParamHandler(t *testing.T) {
 func TestKvmIsUsable(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedKvmDevice := kvmDevice
 	fakeKVMDevice := filepath.Join(dir, "kvm")
@@ -132,7 +127,7 @@ func TestKvmIsUsable(t *testing.T) {
 		kvmDevice = savedKvmDevice
 	}()
 
-	err = kvmIsUsable()
+	err := kvmIsUsable()
 	assert.Error(err)
 
 	err = createEmptyFile(fakeKVMDevice)

--- a/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"testing"
 
@@ -117,11 +116,7 @@ func TestArchKernelParamHandler(t *testing.T) {
 func TestKvmIsUsable(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedKvmDevice := kvmDevice
 	fakeKVMDevice := filepath.Join(dir, "kvm")

--- a/src/runtime/cmd/kata-runtime/kata-check_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_test.go
@@ -155,11 +155,7 @@ func makeCPUInfoFile(path, vendorID, flags string) error {
 
 // nolint: unused, deadcode
 func genericTestGetCPUDetails(t *testing.T, validVendor string, validModel string, validContents string, data []testCPUDetail) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	savedProcCPUInfo := procCPUInfo
 
@@ -172,7 +168,7 @@ func genericTestGetCPUDetails(t *testing.T, validVendor string, validModel strin
 		procCPUInfo = savedProcCPUInfo
 	}()
 
-	_, _, err = getCPUDetails()
+	_, _, err := getCPUDetails()
 	// ENOENT
 	assert.Error(t, err)
 	assert.True(t, os.IsNotExist(err))
@@ -197,11 +193,7 @@ func genericTestGetCPUDetails(t *testing.T, validVendor string, validModel strin
 func genericCheckCLIFunction(t *testing.T, cpuData []testCPUData, moduleData []testModuleData) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	_, config, err := makeRuntimeConfig(dir)
 	assert.NoError(err)
@@ -307,15 +299,11 @@ func TestCheckGetCPUInfo(t *testing.T) {
 		{"foo\n\nbar\nbaz\n\n", "foo", false},
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "cpuinfo")
 	// file doesn't exist
-	_, err = getCPUInfo(file)
+	_, err := getCPUInfo(file)
 	assert.Error(err)
 
 	for _, d := range data {
@@ -527,11 +515,7 @@ func TestCheckHaveKernelModule(t *testing.T) {
 
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedModProbeCmd := modProbeCmd
 	savedSysModuleDir := sysModuleDir
@@ -545,7 +529,7 @@ func TestCheckHaveKernelModule(t *testing.T) {
 		sysModuleDir = savedSysModuleDir
 	}()
 
-	err = os.MkdirAll(sysModuleDir, testDirMode)
+	err := os.MkdirAll(sysModuleDir, testDirMode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -577,11 +561,7 @@ func TestCheckHaveKernelModule(t *testing.T) {
 func TestCheckCheckKernelModules(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedModProbeCmd := modProbeCmd
 	savedSysModuleDir := sysModuleDir
@@ -595,7 +575,7 @@ func TestCheckCheckKernelModules(t *testing.T) {
 		sysModuleDir = savedSysModuleDir
 	}()
 
-	err = os.MkdirAll(sysModuleDir, testDirMode)
+	err := os.MkdirAll(sysModuleDir, testDirMode)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -662,11 +642,7 @@ func TestCheckCheckKernelModulesUnreadableFile(t *testing.T) {
 		t.Skip(ktu.TestDisabledNeedNonRoot)
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	testData := map[string]kernelModule{
 		"foo": {
@@ -691,7 +667,7 @@ func TestCheckCheckKernelModulesUnreadableFile(t *testing.T) {
 	}()
 
 	modPath := filepath.Join(sysModuleDir, "foo/parameters")
-	err = os.MkdirAll(modPath, testDirMode)
+	err := os.MkdirAll(modPath, testDirMode)
 	assert.NoError(err)
 
 	modParamFile := filepath.Join(modPath, "param1")
@@ -710,11 +686,7 @@ func TestCheckCheckKernelModulesUnreadableFile(t *testing.T) {
 func TestCheckCheckKernelModulesInvalidFileContents(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	testData := map[string]kernelModule{
 		"foo": {
@@ -739,7 +711,7 @@ func TestCheckCheckKernelModulesInvalidFileContents(t *testing.T) {
 	}()
 
 	modPath := filepath.Join(sysModuleDir, "foo/parameters")
-	err = os.MkdirAll(modPath, testDirMode)
+	err := os.MkdirAll(modPath, testDirMode)
 	assert.NoError(err)
 
 	modParamFile := filepath.Join(modPath, "param1")
@@ -755,11 +727,7 @@ func TestCheckCheckKernelModulesInvalidFileContents(t *testing.T) {
 func TestCheckCLIFunctionFail(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	_, config, err := makeRuntimeConfig(dir)
 	assert.NoError(err)
@@ -788,11 +756,7 @@ func TestCheckCLIFunctionFail(t *testing.T) {
 func TestCheckKernelParamHandler(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedModProbeCmd := modProbeCmd
 	savedSysModuleDir := sysModuleDir
@@ -870,9 +834,7 @@ func TestCheckKernelParamHandler(t *testing.T) {
 func TestArchRequiredKernelModules(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	_, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(err)
@@ -885,11 +847,7 @@ func TestArchRequiredKernelModules(t *testing.T) {
 		return
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	savedModProbeCmd := modProbeCmd
 	savedSysModuleDir := sysModuleDir

--- a/src/runtime/cmd/kata-runtime/kata-env_amd64_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_amd64_test.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,9 +21,7 @@ func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	savedArchRequiredCPUFlags := archRequiredCPUFlags
 	savedArchRequiredCPUAttribs := archRequiredCPUAttribs

--- a/src/runtime/cmd/kata-runtime/kata-env_generic_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_generic_test.go
@@ -9,7 +9,6 @@
 package main
 
 import (
-	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -18,9 +17,7 @@ import (
 func testEnvGetEnvInfoSetsCPUTypeGeneric(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	savedArchRequiredCPUFlags := archRequiredCPUFlags
 	savedArchRequiredCPUAttribs := archRequiredCPUAttribs

--- a/src/runtime/cmd/kata-runtime/kata-env_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_test.go
@@ -364,11 +364,7 @@ func TestEnvGetMetaInfo(t *testing.T) {
 }
 
 func TestEnvGetHostInfo(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	expectedHostDetails, err := getExpectedHostDetails(tmpdir)
 	assert.NoError(t, err)
@@ -389,13 +385,9 @@ func TestEnvGetHostInfo(t *testing.T) {
 }
 
 func TestEnvGetHostInfoNoProcCPUInfo(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
-	_, err = getExpectedHostDetails(tmpdir)
+	_, err := getExpectedHostDetails(tmpdir)
 	assert.NoError(t, err)
 
 	err = os.Remove(procCPUInfo)
@@ -406,13 +398,9 @@ func TestEnvGetHostInfoNoProcCPUInfo(t *testing.T) {
 }
 
 func TestEnvGetHostInfoNoOSRelease(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
-	_, err = getExpectedHostDetails(tmpdir)
+	_, err := getExpectedHostDetails(tmpdir)
 	assert.NoError(t, err)
 
 	err = os.Remove(osRelease)
@@ -423,13 +411,9 @@ func TestEnvGetHostInfoNoOSRelease(t *testing.T) {
 }
 
 func TestEnvGetHostInfoNoProcVersion(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
-	_, err = getExpectedHostDetails(tmpdir)
+	_, err := getExpectedHostDetails(tmpdir)
 	assert.NoError(t, err)
 
 	err = os.Remove(procVersion)
@@ -440,11 +424,7 @@ func TestEnvGetHostInfoNoProcVersion(t *testing.T) {
 }
 
 func TestEnvGetEnvInfo(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Run test twice to ensure the individual component debug+trace
 	// options are tested.
@@ -474,9 +454,7 @@ func TestEnvGetEnvInfo(t *testing.T) {
 func TestEnvGetEnvInfoNoHypervisorVersion(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(err)
@@ -501,20 +479,14 @@ func TestEnvGetEnvInfoNoHypervisorVersion(t *testing.T) {
 func TestEnvGetEnvInfoAgentError(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
-	_, _, err = makeRuntimeConfig(tmpdir)
+	_, _, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(err)
 }
 
 func TestEnvGetEnvInfoNoOSRelease(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(t, err)
@@ -530,11 +502,7 @@ func TestEnvGetEnvInfoNoOSRelease(t *testing.T) {
 }
 
 func TestEnvGetEnvInfoNoProcCPUInfo(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(t, err)
@@ -550,11 +518,7 @@ func TestEnvGetEnvInfoNoProcCPUInfo(t *testing.T) {
 }
 
 func TestEnvGetEnvInfoNoProcVersion(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(t, err)
@@ -570,11 +534,7 @@ func TestEnvGetEnvInfoNoProcVersion(t *testing.T) {
 }
 
 func TestEnvGetRuntimeInfo(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(t, err)
@@ -587,11 +547,7 @@ func TestEnvGetRuntimeInfo(t *testing.T) {
 }
 
 func TestEnvGetAgentInfo(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	_, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(t, err)
@@ -726,11 +682,7 @@ func testEnvShowJSONSettings(t *testing.T, tmpdir string, tmpfile *os.File) erro
 }
 
 func TestEnvShowSettings(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	tmpfile, err := os.CreateTemp("", "envShowSettings-")
 	assert.NoError(t, err)
@@ -747,11 +699,7 @@ func TestEnvShowSettings(t *testing.T) {
 }
 
 func TestEnvShowSettingsInvalidFile(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	tmpfile, err := os.CreateTemp("", "envShowSettings-")
 	assert.NoError(t, err)
@@ -771,11 +719,7 @@ func TestEnvShowSettingsInvalidFile(t *testing.T) {
 }
 
 func TestEnvHandleSettings(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(t, err)
@@ -805,9 +749,7 @@ func TestEnvHandleSettings(t *testing.T) {
 func TestEnvHandleSettingsInvalidParams(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	configFile, _, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(err)
@@ -859,11 +801,7 @@ func TestEnvHandleSettingsInvalidRuntimeConfigType(t *testing.T) {
 }
 
 func TestEnvCLIFunction(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(t, err)
@@ -904,11 +842,7 @@ func TestEnvCLIFunction(t *testing.T) {
 }
 
 func TestEnvCLIFunctionFail(t *testing.T) {
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	configFile, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(t, err)
@@ -940,9 +874,7 @@ func TestEnvCLIFunctionFail(t *testing.T) {
 func TestGetHypervisorInfo(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	_, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(err)
@@ -962,9 +894,7 @@ func TestGetHypervisorInfo(t *testing.T) {
 func TestGetHypervisorInfoSocket(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	_, config, err := makeRuntimeConfig(tmpdir)
 	assert.NoError(err)

--- a/src/runtime/cmd/kata-runtime/main_test.go
+++ b/src/runtime/cmd/kata-runtime/main_test.go
@@ -258,14 +258,12 @@ func TestMainBeforeSubCommands(t *testing.T) {
 func TestMainBeforeSubCommandsInvalidLogFile(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "katatest")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	logFile := filepath.Join(tmpdir, "log")
 
 	// create the file as the wrong type to force a failure
-	err = os.MkdirAll(logFile, testDirMode)
+	err := os.MkdirAll(logFile, testDirMode)
 	assert.NoError(err)
 
 	set := flag.NewFlagSet("", 0)
@@ -281,9 +279,7 @@ func TestMainBeforeSubCommandsInvalidLogFile(t *testing.T) {
 func TestMainBeforeSubCommandsInvalidLogFormat(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "katatest")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	logFile := filepath.Join(tmpdir, "log")
 
@@ -302,7 +298,7 @@ func TestMainBeforeSubCommandsInvalidLogFormat(t *testing.T) {
 
 	ctx := createCLIContext(set)
 
-	err = beforeSubcommands(ctx)
+	err := beforeSubcommands(ctx)
 	assert.Error(err)
 	assert.NotNil(kataLog.Logger.Out)
 }
@@ -310,9 +306,7 @@ func TestMainBeforeSubCommandsInvalidLogFormat(t *testing.T) {
 func TestMainBeforeSubCommandsLoadConfigurationFail(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "katatest")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	logFile := filepath.Join(tmpdir, "log")
 	configFile := filepath.Join(tmpdir, "config")
@@ -345,9 +339,7 @@ func TestMainBeforeSubCommandsLoadConfigurationFail(t *testing.T) {
 func TestMainBeforeSubCommandsShowCCConfigPaths(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "katatest")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	set := flag.NewFlagSet("", 0)
 	set.Bool("show-default-config-paths", true, "")
@@ -409,9 +401,7 @@ func TestMainBeforeSubCommandsShowCCConfigPaths(t *testing.T) {
 func TestMainFatal(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "katatest")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	var exitStatus int
 	savedExitFunc := exitFunc
@@ -633,9 +623,7 @@ func TestMainCreateRuntime(t *testing.T) {
 func TestMainVersionPrinter(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "katatest")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	savedOutputFile := defaultOutputFile
 

--- a/src/runtime/cmd/kata-runtime/utils_test.go
+++ b/src/runtime/cmd/kata-runtime/utils_test.go
@@ -17,18 +17,14 @@ import (
 )
 
 func TestFileExists(t *testing.T) {
-	dir, err := os.MkdirTemp("", "katatest")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "foo")
 
 	assert.False(t, katautils.FileExists(file),
 		fmt.Sprintf("File %q should not exist", file))
 
-	err = createEmptyFile(file)
+	err := createEmptyFile(file)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -54,14 +50,10 @@ func TestGetKernelVersion(t *testing.T) {
 		{validContents, validVersion, false},
 	}
 
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	subDir := filepath.Join(tmpdir, "subdir")
-	err = os.MkdirAll(subDir, testDirMode)
+	err := os.MkdirAll(subDir, testDirMode)
 	assert.NoError(t, err)
 
 	_, err = getKernelVersion()
@@ -103,11 +95,7 @@ func TestGetDistroDetails(t *testing.T) {
 
 	const unknown = "<<unknown>>"
 
-	tmpdir, err := os.MkdirTemp("", "")
-	if err != nil {
-		panic(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testOSRelease := filepath.Join(tmpdir, "os-release")
 	testOSReleaseClr := filepath.Join(tmpdir, "os-release-clr")
@@ -131,7 +119,7 @@ VERSION_ID="%s"
 `, nonClrExpectedName, nonClrExpectedVersion)
 
 	subDir := filepath.Join(tmpdir, "subdir")
-	err = os.MkdirAll(subDir, testDirMode)
+	err := os.MkdirAll(subDir, testDirMode)
 	assert.NoError(t, err)
 
 	// override

--- a/src/runtime/pkg/containerd-shim-v2/create_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/create_test.go
@@ -382,9 +382,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 func TestCreateLoadRuntimeConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	config, err := createAllRuntimeConfigFiles(tmpdir, "qemu")
 	assert.NoError(err)

--- a/src/runtime/pkg/containerd-shim-v2/stream_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/stream_test.go
@@ -26,9 +26,7 @@ func TestNewTtyIOFifoReopen(t *testing.T) {
 	assert := assert.New(t)
 	ctx := context.TODO()
 
-	testDir, err := os.MkdirTemp("", "kata-")
-	assert.NoError(err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	fifoPath, err := os.MkdirTemp(testDir, "fifo-path-")
 	assert.NoError(err)
@@ -104,9 +102,7 @@ func TestIoCopy(t *testing.T) {
 	testBytes2 := []byte("Test2")
 	testBytes3 := []byte("Test3")
 
-	testDir, err := os.MkdirTemp("", "kata-")
-	assert.NoError(err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	fifoPath, err := os.MkdirTemp(testDir, "fifo-path-")
 	assert.NoError(err)

--- a/src/runtime/pkg/direct-volume/utils_test.go
+++ b/src/runtime/pkg/direct-volume/utils_test.go
@@ -18,9 +18,7 @@ import (
 
 func TestAdd(t *testing.T) {
 	var err error
-	kataDirectVolumeRootPath, err = os.MkdirTemp(os.TempDir(), "add-test")
-	assert.Nil(t, err)
-	defer os.RemoveAll(kataDirectVolumeRootPath)
+	kataDirectVolumeRootPath = t.TempDir()
 	var volumePath = "/a/b/c"
 	var basePath = "a"
 	actual := MountInfo{
@@ -54,9 +52,7 @@ func TestAdd(t *testing.T) {
 
 func TestRecordSandboxId(t *testing.T) {
 	var err error
-	kataDirectVolumeRootPath, err = os.MkdirTemp(os.TempDir(), "recordSanboxId-test")
-	assert.Nil(t, err)
-	defer os.RemoveAll(kataDirectVolumeRootPath)
+	kataDirectVolumeRootPath = t.TempDir()
 
 	var volumePath = "/a/b/c"
 	mntInfo := MountInfo{
@@ -82,9 +78,7 @@ func TestRecordSandboxId(t *testing.T) {
 
 func TestRecordSandboxIdNoMountInfoFile(t *testing.T) {
 	var err error
-	kataDirectVolumeRootPath, err = os.MkdirTemp(os.TempDir(), "recordSanboxId-test")
-	assert.Nil(t, err)
-	defer os.RemoveAll(kataDirectVolumeRootPath)
+	kataDirectVolumeRootPath = t.TempDir()
 
 	var volumePath = "/a/b/c"
 	sandboxId := uuid.Generate().String()

--- a/src/runtime/pkg/katatestutils/constraints_test.go
+++ b/src/runtime/pkg/katatestutils/constraints_test.go
@@ -271,14 +271,12 @@ func TestGetFileContents(t *testing.T) {
 		{"foo\nbar"},
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "foo")
 
 	// file doesn't exist
-	_, err = getFileContents(file)
+	_, err := getFileContents(file)
 	assert.Error(err)
 
 	for _, d := range data {

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -279,17 +279,13 @@ func testLoadConfiguration(t *testing.T, dir string,
 }
 
 func TestConfigLoadConfiguration(t *testing.T) {
-	tmpdir, err := os.MkdirTemp(testDir, "load-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testLoadConfiguration(t, tmpdir, nil)
 }
 
 func TestConfigLoadConfigurationFailBrokenSymLink(t *testing.T) {
-	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testLoadConfiguration(t, tmpdir,
 		func(config testRuntimeConfig, configFile string, ignoreLogging bool) (bool, error) {
@@ -297,7 +293,7 @@ func TestConfigLoadConfigurationFailBrokenSymLink(t *testing.T) {
 
 			if configFile == config.ConfigPathLink {
 				// break the symbolic link
-				err = os.Remove(config.ConfigPathLink)
+				err := os.Remove(config.ConfigPathLink)
 				if err != nil {
 					return expectFail, err
 				}
@@ -310,9 +306,7 @@ func TestConfigLoadConfigurationFailBrokenSymLink(t *testing.T) {
 }
 
 func TestConfigLoadConfigurationFailSymLinkLoop(t *testing.T) {
-	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testLoadConfiguration(t, tmpdir,
 		func(config testRuntimeConfig, configFile string, ignoreLogging bool) (bool, error) {
@@ -320,13 +314,13 @@ func TestConfigLoadConfigurationFailSymLinkLoop(t *testing.T) {
 
 			if configFile == config.ConfigPathLink {
 				// remove the config file
-				err = os.Remove(config.ConfigPath)
+				err := os.Remove(config.ConfigPath)
 				if err != nil {
 					return expectFail, err
 				}
 
 				// now, create a sym-link loop
-				err := os.Symlink(config.ConfigPathLink, config.ConfigPath)
+				err = os.Symlink(config.ConfigPathLink, config.ConfigPath)
 				if err != nil {
 					return expectFail, err
 				}
@@ -339,15 +333,13 @@ func TestConfigLoadConfigurationFailSymLinkLoop(t *testing.T) {
 }
 
 func TestConfigLoadConfigurationFailMissingHypervisor(t *testing.T) {
-	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testLoadConfiguration(t, tmpdir,
 		func(config testRuntimeConfig, configFile string, ignoreLogging bool) (bool, error) {
 			expectFail := true
 
-			err = os.Remove(config.RuntimeConfig.HypervisorConfig.HypervisorPath)
+			err := os.Remove(config.RuntimeConfig.HypervisorConfig.HypervisorPath)
 			if err != nil {
 				return expectFail, err
 			}
@@ -357,15 +349,13 @@ func TestConfigLoadConfigurationFailMissingHypervisor(t *testing.T) {
 }
 
 func TestConfigLoadConfigurationFailMissingImage(t *testing.T) {
-	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testLoadConfiguration(t, tmpdir,
 		func(config testRuntimeConfig, configFile string, ignoreLogging bool) (bool, error) {
 			expectFail := true
 
-			err = os.Remove(config.RuntimeConfig.HypervisorConfig.ImagePath)
+			err := os.Remove(config.RuntimeConfig.HypervisorConfig.ImagePath)
 			if err != nil {
 				return expectFail, err
 			}
@@ -375,15 +365,13 @@ func TestConfigLoadConfigurationFailMissingImage(t *testing.T) {
 }
 
 func TestConfigLoadConfigurationFailMissingKernel(t *testing.T) {
-	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testLoadConfiguration(t, tmpdir,
 		func(config testRuntimeConfig, configFile string, ignoreLogging bool) (bool, error) {
 			expectFail := true
 
-			err = os.Remove(config.RuntimeConfig.HypervisorConfig.KernelPath)
+			err := os.Remove(config.RuntimeConfig.HypervisorConfig.KernelPath)
 			if err != nil {
 				return expectFail, err
 			}
@@ -397,16 +385,14 @@ func TestConfigLoadConfigurationFailUnreadableConfig(t *testing.T) {
 		t.Skip(ktu.TestDisabledNeedNonRoot)
 	}
 
-	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testLoadConfiguration(t, tmpdir,
 		func(config testRuntimeConfig, configFile string, ignoreLogging bool) (bool, error) {
 			expectFail := true
 
 			// make file unreadable by non-root user
-			err = os.Chmod(config.ConfigPath, 0000)
+			err := os.Chmod(config.ConfigPath, 0000)
 			if err != nil {
 				return expectFail, err
 			}
@@ -420,9 +406,7 @@ func TestConfigLoadConfigurationFailTOMLConfigFileInvalidContents(t *testing.T) 
 		t.Skip(ktu.TestDisabledNeedNonRoot)
 	}
 
-	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testLoadConfiguration(t, tmpdir,
 		func(config testRuntimeConfig, configFile string, ignoreLogging bool) (bool, error) {
@@ -446,9 +430,7 @@ func TestConfigLoadConfigurationFailTOMLConfigFileDuplicatedData(t *testing.T) {
 		t.Skip(ktu.TestDisabledNeedNonRoot)
 	}
 
-	tmpdir, err := os.MkdirTemp(testDir, "runtime-config-")
-	assert.NoError(t, err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testLoadConfiguration(t, tmpdir,
 		func(config testRuntimeConfig, configFile string, ignoreLogging bool) (bool, error) {
@@ -471,11 +453,7 @@ func TestConfigLoadConfigurationFailTOMLConfigFileDuplicatedData(t *testing.T) {
 }
 
 func TestMinimalRuntimeConfig(t *testing.T) {
-	dir, err := os.MkdirTemp(testDir, "minimal-runtime-config-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	hypervisorPath := path.Join(dir, "hypervisor")
 	defaultHypervisorPath = hypervisorPath
@@ -510,7 +488,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 	defaultKernelPath = kernelPath
 
 	for _, file := range []string{defaultImagePath, defaultInitrdPath, defaultHypervisorPath, defaultJailerPath, defaultKernelPath} {
-		err = WriteFile(file, "foo", testFileMode)
+		err := WriteFile(file, "foo", testFileMode)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -531,7 +509,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 	utils.VHostVSockDevicePath = "/dev/null"
 
 	configPath := path.Join(dir, "runtime.toml")
-	err = createConfig(configPath, runtimeMinimalConfig)
+	err := createConfig(configPath, runtimeMinimalConfig)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -600,11 +578,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 }
 
 func TestNewQemuHypervisorConfig(t *testing.T) {
-	dir, err := os.MkdirTemp(testDir, "hypervisor-config-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	hypervisorPath := path.Join(dir, "hypervisor")
 	kernelPath := path.Join(dir, "kernel")
@@ -699,11 +673,7 @@ func TestNewQemuHypervisorConfig(t *testing.T) {
 }
 
 func TestNewFirecrackerHypervisorConfig(t *testing.T) {
-	dir, err := os.MkdirTemp(testDir, "hypervisor-config-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	hypervisorPath := path.Join(dir, "hypervisor")
 	kernelPath := path.Join(dir, "kernel")
@@ -794,9 +764,7 @@ func TestNewFirecrackerHypervisorConfig(t *testing.T) {
 func TestNewQemuHypervisorConfigImageAndInitrd(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp(testDir, "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	imagePath := filepath.Join(tmpdir, "image")
 	initrdPath := filepath.Join(tmpdir, "initrd")
@@ -804,7 +772,7 @@ func TestNewQemuHypervisorConfigImageAndInitrd(t *testing.T) {
 	kernelPath := path.Join(tmpdir, "kernel")
 
 	for _, file := range []string{imagePath, initrdPath, hypervisorPath, kernelPath} {
-		err = createEmptyFile(file)
+		err := createEmptyFile(file)
 		assert.NoError(err)
 	}
 
@@ -826,7 +794,7 @@ func TestNewQemuHypervisorConfigImageAndInitrd(t *testing.T) {
 		PCIeRootPort:          pcieRootPort,
 	}
 
-	_, err = newQemuHypervisorConfig(hypervisor)
+	_, err := newQemuHypervisorConfig(hypervisor)
 
 	// specifying both an image+initrd is invalid
 	assert.Error(err)
@@ -836,9 +804,7 @@ func TestNewClhHypervisorConfig(t *testing.T) {
 
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp(testDir, "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	hypervisorPath := path.Join(tmpdir, "hypervisor")
 	kernelPath := path.Join(tmpdir, "kernel")
@@ -846,7 +812,7 @@ func TestNewClhHypervisorConfig(t *testing.T) {
 	virtioFsDaemon := path.Join(tmpdir, "virtiofsd")
 
 	for _, file := range []string{imagePath, hypervisorPath, kernelPath, virtioFsDaemon} {
-		err = createEmptyFile(file)
+		err := createEmptyFile(file)
 		assert.NoError(err)
 	}
 
@@ -931,14 +897,12 @@ func TestHypervisorDefaults(t *testing.T) {
 func TestHypervisorDefaultsHypervisor(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp(testDir, "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testHypervisorPath := filepath.Join(tmpdir, "hypervisor")
 	testHypervisorLinkPath := filepath.Join(tmpdir, "hypervisor-link")
 
-	err = createEmptyFile(testHypervisorPath)
+	err := createEmptyFile(testHypervisorPath)
 	assert.NoError(err)
 
 	err = syscall.Symlink(testHypervisorPath, testHypervisorLinkPath)
@@ -967,14 +931,12 @@ func TestHypervisorDefaultsHypervisor(t *testing.T) {
 func TestHypervisorDefaultsKernel(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp(testDir, "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testKernelPath := filepath.Join(tmpdir, "kernel")
 	testKernelLinkPath := filepath.Join(tmpdir, "kernel-link")
 
-	err = createEmptyFile(testKernelPath)
+	err := createEmptyFile(testKernelPath)
 	assert.NoError(err)
 
 	err = syscall.Symlink(testKernelPath, testKernelLinkPath)
@@ -1010,14 +972,12 @@ func TestHypervisorDefaultsKernel(t *testing.T) {
 func TestHypervisorDefaultsInitrd(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp(testDir, "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testInitrdPath := filepath.Join(tmpdir, "initrd")
 	testInitrdLinkPath := filepath.Join(tmpdir, "initrd-link")
 
-	err = createEmptyFile(testInitrdPath)
+	err := createEmptyFile(testInitrdPath)
 	assert.NoError(err)
 
 	err = syscall.Symlink(testInitrdPath, testInitrdLinkPath)
@@ -1047,14 +1007,12 @@ func TestHypervisorDefaultsInitrd(t *testing.T) {
 func TestHypervisorDefaultsImage(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp(testDir, "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	testImagePath := filepath.Join(tmpdir, "image")
 	testImageLinkPath := filepath.Join(tmpdir, "image-link")
 
-	err = createEmptyFile(testImagePath)
+	err := createEmptyFile(testImagePath)
 	assert.NoError(err)
 
 	err = syscall.Symlink(testImagePath, testImageLinkPath)
@@ -1142,16 +1100,14 @@ func TestGetDefaultConfigFilePaths(t *testing.T) {
 func TestGetDefaultConfigFile(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp(testDir, "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	hypervisor := "qemu"
 	confDir := filepath.Join(tmpdir, "conf")
 	sysConfDir := filepath.Join(tmpdir, "sysconf")
 
 	for _, dir := range []string{confDir, sysConfDir} {
-		err = os.MkdirAll(dir, testDirMode)
+		err := os.MkdirAll(dir, testDirMode)
 		assert.NoError(err)
 	}
 
@@ -1449,11 +1405,7 @@ func TestUpdateRuntimeConfigurationInvalidKernelParams(t *testing.T) {
 func TestCheckHypervisorConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp(testDir, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// Not created on purpose
 	imageENOENT := filepath.Join(dir, "image-ENOENT.img")
@@ -1463,7 +1415,7 @@ func TestCheckHypervisorConfig(t *testing.T) {
 	initrdEmpty := filepath.Join(dir, "initrd-empty.img")
 
 	for _, file := range []string{imageEmpty, initrdEmpty} {
-		err = createEmptyFile(file)
+		err := createEmptyFile(file)
 		assert.NoError(err)
 	}
 
@@ -1478,7 +1430,7 @@ func TestCheckHypervisorConfig(t *testing.T) {
 	fileData := strings.Repeat("X", int(fileSizeBytes))
 
 	for _, file := range []string{image, initrd} {
-		err = WriteFile(file, fileData, testFileMode)
+		err := WriteFile(file, fileData, testFileMode)
 		assert.NoError(err)
 	}
 
@@ -1612,19 +1564,15 @@ func TestCheckFactoryConfig(t *testing.T) {
 func TestValidateBindMounts(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir1, err := os.MkdirTemp(testDir, "tmp1-")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir1)
+	tmpdir1 := t.TempDir()
 
-	tmpdir2, err := os.MkdirTemp(testDir, "tmp2-")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir2)
+	tmpdir2 := t.TempDir()
 
 	duplicate1 := filepath.Join(tmpdir1, "cat.txt")
 	duplicate2 := filepath.Join(tmpdir2, "cat.txt")
 	unique := filepath.Join(tmpdir1, "foobar.txt")
 
-	err = os.WriteFile(duplicate1, []byte("kibble-monster"), 0644)
+	err := os.WriteFile(duplicate1, []byte("kibble-monster"), 0644)
 	assert.NoError(err)
 
 	err = os.WriteFile(duplicate2, []byte("furbag"), 0644)

--- a/src/runtime/pkg/katautils/create_test.go
+++ b/src/runtime/pkg/katautils/create_test.go
@@ -124,14 +124,10 @@ func TestSetEphemeralStorageType(t *testing.T) {
 
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp(testDir, "foo")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	ephePath := filepath.Join(dir, vc.K8sEmptyDir, "tmp-volume")
-	err = os.MkdirAll(ephePath, testDirMode)
+	err := os.MkdirAll(ephePath, testDirMode)
 	assert.Nil(err)
 
 	err = syscall.Mount("tmpfs", ephePath, "tmpfs", 0, "")
@@ -308,17 +304,13 @@ func TestCreateSandboxAnnotations(t *testing.T) {
 func TestCheckForFips(t *testing.T) {
 	assert := assert.New(t)
 
-	path, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(path)
-
 	val := procFIPS
-	procFIPS = filepath.Join(path, "fips-enabled")
+	procFIPS = filepath.Join(t.TempDir(), "fips-enabled")
 	defer func() {
 		procFIPS = val
 	}()
 
-	err = os.WriteFile(procFIPS, []byte("1"), 0644)
+	err := os.WriteFile(procFIPS, []byte("1"), 0644)
 	assert.NoError(err)
 
 	hconfig := vc.HypervisorConfig{

--- a/src/runtime/pkg/katautils/network_test.go
+++ b/src/runtime/pkg/katautils/network_test.go
@@ -23,15 +23,13 @@ import (
 func TestGetNetNsFromBindMount(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	mountFile := filepath.Join(tmpdir, "mountInfo")
 	nsPath := filepath.Join(tmpdir, "ns123")
 
 	// Non-existent namespace path
-	_, err = getNetNsFromBindMount(nsPath, mountFile)
+	_, err := getNetNsFromBindMount(nsPath, mountFile)
 	assert.NotNil(err)
 
 	tmpNSPath := filepath.Join(tmpdir, "testNetNs")
@@ -85,9 +83,7 @@ func TestHostNetworkingRequested(t *testing.T) {
 	assert.Error(err)
 
 	// Bind-mounted Netns
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Create a bind mount to the current network namespace.
 	tmpFile := filepath.Join(tmpdir, "testNetNs")

--- a/src/runtime/pkg/katautils/utils_test.go
+++ b/src/runtime/pkg/katautils/utils_test.go
@@ -26,10 +26,6 @@ const (
 	testContainerID = "1"
 )
 
-var (
-	testDir = ""
-)
-
 func createFile(file, contents string) error {
 	return os.WriteFile(file, []byte(contents), testFileMode)
 }
@@ -44,17 +40,13 @@ func TestUtilsResolvePathEmptyPath(t *testing.T) {
 }
 
 func TestUtilsResolvePathValidPath(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	target := path.Join(dir, "target")
 	linkDir := path.Join(dir, "a/b/c")
 	linkFile := path.Join(linkDir, "link")
 
-	err = createEmptyFile(target)
+	err := createEmptyFile(target)
 	assert.NoError(t, err)
 
 	absolute, err := filepath.Abs(target)
@@ -76,16 +68,13 @@ func TestUtilsResolvePathValidPath(t *testing.T) {
 }
 
 func TestUtilsResolvePathENOENT(t *testing.T) {
-	dir, err := os.MkdirTemp("", "")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 
 	target := path.Join(dir, "target")
 	linkDir := path.Join(dir, "a/b/c")
 	linkFile := path.Join(linkDir, "link")
 
-	err = createEmptyFile(target)
+	err := createEmptyFile(target)
 	assert.NoError(t, err)
 
 	err = os.MkdirAll(linkDir, testDirMode)
@@ -111,16 +100,12 @@ func TestUtilsResolvePathENOENT(t *testing.T) {
 func TestFileSize(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp(testDir, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "foo")
 
 	// ENOENT
-	_, err = fileSize(file)
+	_, err := fileSize(file)
 	assert.Error(err)
 
 	err = createEmptyFile(file)
@@ -152,12 +137,10 @@ func TestWriteFileErrWriteFail(t *testing.T) {
 func TestWriteFileErrNoPath(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp(testDir, "")
-	assert.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	// attempt to write a file over an existing directory
-	err = WriteFile(dir, "", 0000)
+	err := WriteFile(dir, "", 0000)
 	assert.Error(err)
 }
 
@@ -177,16 +160,12 @@ func TestGetFileContents(t *testing.T) {
 		{"processor   : 0\nvendor_id   : GenuineIntel\n"},
 	}
 
-	dir, err := os.MkdirTemp(testDir, "")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "foo")
 
 	// file doesn't exist
-	_, err = GetFileContents(file)
+	_, err := GetFileContents(file)
 	assert.Error(t, err)
 
 	for _, d := range data {

--- a/src/runtime/pkg/oci/utils_test.go
+++ b/src/runtime/pkg/oci/utils_test.go
@@ -410,12 +410,10 @@ func TestGetShmSizeBindMounted(t *testing.T) {
 		t.Skip("Test disabled as requires root privileges")
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	shmPath := filepath.Join(dir, "shm")
-	err = os.Mkdir(shmPath, 0700)
+	err := os.Mkdir(shmPath, 0700)
 	assert.Nil(t, err)
 
 	size := 8192
@@ -473,15 +471,13 @@ func TestMain(m *testing.M) {
 func TestAddAssetAnnotations(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// Create a pretend asset file
 	// (required since the existence of binary asset annotations is verified).
 	fakeAssetFile := filepath.Join(tmpdir, "fake-binary")
 
-	err = os.WriteFile(fakeAssetFile, []byte(""), fileMode)
+	err := os.WriteFile(fakeAssetFile, []byte(""), fileMode)
 	assert.NoError(err)
 
 	expectedAnnotations := map[string]string{

--- a/src/runtime/pkg/utils/utils_test.go
+++ b/src/runtime/pkg/utils/utils_test.go
@@ -51,11 +51,8 @@ func TestGzipAccepted(t *testing.T) {
 
 func TestEnsureDir(t *testing.T) {
 	const testMode = 0755
-	tmpdir, err := os.MkdirTemp("", "TestEnsureDir")
 	assert := assert.New(t)
-
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// nolint: govet
 	testCases := []struct {
@@ -120,9 +117,7 @@ func TestEnsureDir(t *testing.T) {
 
 func TestFirstValidExecutable(t *testing.T) {
 	assert := assert.New(t)
-	tmpdir, err := os.MkdirTemp("", "TestFirstValidPath")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 
 	// nolint: govet
 	testCases := []struct {

--- a/src/runtime/virtcontainers/device/config/config_test.go
+++ b/src/runtime/virtcontainers/device/config/config_test.go
@@ -17,9 +17,7 @@ import (
 func TestGetBackingFile(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "backing")
-	assert.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	orgGetSysDevPath := getSysDevPath
 	getSysDevPath = func(info DeviceInfo) string {

--- a/src/runtime/virtcontainers/device/manager/manager_linux_test.go
+++ b/src/runtime/virtcontainers/device/manager/manager_linux_test.go
@@ -29,22 +29,20 @@ func TestAttachVhostUserBlkDevice(t *testing.T) {
 		rootEnabled = false
 	}
 
-	tmpDir, err := os.MkdirTemp("", "")
+	tmpDir := t.TempDir()
 	dm := &deviceManager{
 		blockDriver:           config.VirtioBlock,
 		devices:               make(map[string]api.Device),
 		vhostUserStoreEnabled: true,
 		vhostUserStorePath:    tmpDir,
 	}
-	assert.Nil(t, err)
-	defer os.RemoveAll(tmpDir)
 
 	vhostUserDevNodePath := filepath.Join(tmpDir, "/block/devices/")
 	vhostUserSockPath := filepath.Join(tmpDir, "/block/sockets/")
 	deviceNodePath := filepath.Join(vhostUserDevNodePath, "vhostblk0")
 	deviceSockPath := filepath.Join(vhostUserSockPath, "vhostblk0")
 
-	err = os.MkdirAll(vhostUserDevNodePath, dirMode)
+	err := os.MkdirAll(vhostUserDevNodePath, dirMode)
 	assert.Nil(t, err)
 	err = os.MkdirAll(vhostUserSockPath, dirMode)
 	assert.Nil(t, err)

--- a/src/runtime/virtcontainers/device/manager/manager_test.go
+++ b/src/runtime/virtcontainers/device/manager/manager_test.go
@@ -34,12 +34,8 @@ func TestNewDevice(t *testing.T) {
 	major := int64(252)
 	minor := int64(3)
 
-	tmpDir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
-
-	config.SysDevPrefix = tmpDir
+	config.SysDevPrefix = t.TempDir()
 	defer func() {
-		os.RemoveAll(tmpDir)
 		config.SysDevPrefix = savedSysDevPrefix
 	}()
 
@@ -53,7 +49,7 @@ func TestNewDevice(t *testing.T) {
 		DevType:       "c",
 	}
 
-	_, err = dm.NewDevice(deviceInfo)
+	_, err := dm.NewDevice(deviceInfo)
 	assert.NotNil(t, err)
 
 	format := strconv.FormatInt(major, 10) + ":" + strconv.FormatInt(minor, 10)
@@ -99,15 +95,13 @@ func TestAttachVFIODevice(t *testing.T) {
 		blockDriver: config.VirtioBlock,
 		devices:     make(map[string]api.Device),
 	}
-	tmpDir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	testFDIOGroup := "2"
 	testDeviceBDFPath := "0000:00:1c.0"
 
 	devicesDir := filepath.Join(tmpDir, testFDIOGroup, "devices")
-	err = os.MkdirAll(devicesDir, dirMode)
+	err := os.MkdirAll(devicesDir, dirMode)
 	assert.Nil(t, err)
 
 	deviceBDFDir := filepath.Join(devicesDir, testDeviceBDFPath)

--- a/src/runtime/virtcontainers/fs_share_linux_test.go
+++ b/src/runtime/virtcontainers/fs_share_linux_test.go
@@ -24,14 +24,11 @@ func TestSandboxSharedFilesystem(t *testing.T) {
 
 	assert := assert.New(t)
 	// create temporary files to mount:
-	testMountPath, err := os.MkdirTemp("", "sandbox-test")
-	assert.NoError(err)
-	defer os.RemoveAll(testMountPath)
+	testMountPath := t.TempDir()
 
 	// create a new shared directory for our test:
 	kataHostSharedDirSaved := kataHostSharedDir
-	testHostDir, err := os.MkdirTemp("", "kata-Cleanup")
-	assert.NoError(err)
+	testHostDir := t.TempDir()
 	kataHostSharedDir = func() string {
 		return testHostDir
 	}
@@ -66,7 +63,6 @@ func TestSandboxSharedFilesystem(t *testing.T) {
 	dir := kataHostSharedDir()
 	err = os.MkdirAll(path.Join(dir, sandbox.id), 0777)
 	assert.Nil(err)
-	defer os.RemoveAll(dir)
 
 	// Test the prepare function. We expect it to succeed
 	err = sandbox.fsShare.Prepare(sandbox.ctx)

--- a/src/runtime/virtcontainers/hypervisor_test.go
+++ b/src/runtime/virtcontainers/hypervisor_test.go
@@ -390,12 +390,10 @@ func TestGetHostMemorySizeKb(t *testing.T) {
 		},
 	}
 
-	dir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "meminfo")
-	_, err = GetHostMemorySizeKb(file)
+	_, err := GetHostMemorySizeKb(file)
 	assert.Error(err)
 
 	for _, d := range data {

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -751,9 +751,7 @@ func TestHandlePidNamespace(t *testing.T) {
 func TestAgentConfigure(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "kata-agent-test")
-	assert.Nil(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	k := &kataAgent{}
 	h := &mockHypervisor{}
@@ -761,7 +759,7 @@ func TestAgentConfigure(t *testing.T) {
 	id := "foobar"
 	ctx := context.Background()
 
-	err = k.configure(ctx, h, id, dir, c)
+	err := k.configure(ctx, h, id, dir, c)
 	assert.Nil(err)
 
 	err = k.configure(ctx, h, id, dir, c)
@@ -872,9 +870,7 @@ func TestAgentCreateContainer(t *testing.T) {
 		},
 	}
 
-	dir, err := os.MkdirTemp("", "kata-agent-test")
-	assert.Nil(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	err = k.configure(context.Background(), &mockHypervisor{}, sandbox.id, dir, KataAgentConfig{})
 	assert.Nil(err)
@@ -984,8 +980,7 @@ func TestKataCleanupSandbox(t *testing.T) {
 
 	kataHostSharedDirSaved := kataHostSharedDir
 	kataHostSharedDir = func() string {
-		td, _ := os.MkdirTemp("", "kata-Cleanup")
-		return td
+		return t.TempDir()
 	}
 	defer func() {
 		kataHostSharedDir = kataHostSharedDirSaved
@@ -996,7 +991,6 @@ func TestKataCleanupSandbox(t *testing.T) {
 	}
 
 	dir := kataHostSharedDir()
-	defer os.RemoveAll(dir)
 	err := os.MkdirAll(path.Join(dir, s.id), 0777)
 	assert.Nil(err)
 
@@ -1144,9 +1138,7 @@ func TestHandleHugepages(t *testing.T) {
 
 	assert := assert.New(t)
 
-	dir, err := ioutil.TempDir("", "hugepages-test")
-	assert.Nil(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	k := kataAgent{}
 	var formattedSizes []string

--- a/src/runtime/virtcontainers/mount_test.go
+++ b/src/runtime/virtcontainers/mount_test.go
@@ -318,14 +318,12 @@ func TestIsWatchable(t *testing.T) {
 	result = isWatchableMount(path)
 	assert.False(result)
 
-	testPath, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(testPath)
+	testPath := t.TempDir()
 
 	// Verify secret is successful (single file mount):
 	//   /tmppath/kubernetes.io~secret/super-secret-thing
 	secretpath := filepath.Join(testPath, K8sSecret)
-	err = os.MkdirAll(secretpath, 0777)
+	err := os.MkdirAll(secretpath, 0777)
 	assert.NoError(err)
 	secret := filepath.Join(secretpath, "super-secret-thing")
 	_, err = os.Create(secret)

--- a/src/runtime/virtcontainers/nydusd_test.go
+++ b/src/runtime/virtcontainers/nydusd_test.go
@@ -8,7 +8,6 @@ package virtcontainers
 import (
 	"context"
 	"encoding/base64"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,7 +18,6 @@ import (
 )
 
 func TestNydusdStart(t *testing.T) {
-	assert := assert.New(t)
 	// nolint: govet
 	type fields struct {
 		pid             int
@@ -33,13 +31,8 @@ func TestNydusdStart(t *testing.T) {
 		setupShareDirFn func() error
 	}
 
-	sourcePath, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(sourcePath)
-
-	socketDir, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(socketDir)
+	sourcePath := t.TempDir()
+	socketDir := t.TempDir()
 
 	sockPath := filepath.Join(socketDir, "vhost-user.sock")
 	apiSockPath := filepath.Join(socketDir, "api.sock")
@@ -115,13 +108,8 @@ func TestNydusdArgs(t *testing.T) {
 func TestNydusdValid(t *testing.T) {
 	assert := assert.New(t)
 
-	sourcePath, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(sourcePath)
-
-	socketDir, err := ioutil.TempDir("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(socketDir)
+	sourcePath := t.TempDir()
+	socketDir := t.TempDir()
 
 	sockPath := filepath.Join(socketDir, "vhost-user.sock")
 	apiSockPath := filepath.Join(socketDir, "api.sock")
@@ -135,7 +123,7 @@ func TestNydusdValid(t *testing.T) {
 		}
 	}
 	nd := newNydsudFunc()
-	err = nd.valid()
+	err := nd.valid()
 	assert.NoError(err)
 
 	nd = newNydsudFunc()

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -308,9 +308,7 @@ func TestQemuAddDeviceSerialPortDev(t *testing.T) {
 func TestQemuAddDeviceKataVSOCK(t *testing.T) {
 	assert := assert.New(t)
 
-	dir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	vsockFilename := filepath.Join(dir, "vsock")
 

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -257,8 +257,8 @@ func testCheckContainerOnDiskState(c *Container, containerState types.ContainerS
 
 // writeContainerConfig write config.json to bundle path
 // and return bundle path.
-// NOTE: don't forget to delete the bundle path
-func writeContainerConfig() (string, error) {
+// NOTE: the bundle path is automatically removed by t.Cleanup
+func writeContainerConfig(t *testing.T) (string, error) {
 
 	basicSpec := `
 {
@@ -269,12 +269,9 @@ func writeContainerConfig() (string, error) {
 	}
 }`
 
-	configDir, err := os.MkdirTemp("", "vc-tmp-")
-	if err != nil {
-		return "", err
-	}
+	configDir := t.TempDir()
 
-	err = os.MkdirAll(configDir, DirMode)
+	err := os.MkdirAll(configDir, DirMode)
 	if err != nil {
 		return "", err
 	}
@@ -293,10 +290,7 @@ func TestSandboxSetSandboxAndContainerState(t *testing.T) {
 	contConfig := newTestContainerConfigNoop(contID)
 	assert := assert.New(t)
 
-	configDir, err := writeContainerConfig()
-	if err != nil {
-		os.RemoveAll(configDir)
-	}
+	configDir, err := writeContainerConfig(t)
 	assert.NoError(err)
 
 	// set bundle path annotation, fetchSandbox need this annotation to get containers
@@ -526,15 +520,14 @@ func TestContainerStateSetFstype(t *testing.T) {
 }
 
 func TestSandboxAttachDevicesVFIO(t *testing.T) {
-	tmpDir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
+	tmpDir := t.TempDir()
 	os.RemoveAll(tmpDir)
 
 	testFDIOGroup := "2"
 	testDeviceBDFPath := "0000:00:1c.0"
 
 	devicesDir := filepath.Join(tmpDir, testFDIOGroup, "devices")
-	err = os.MkdirAll(devicesDir, DirMode)
+	err := os.MkdirAll(devicesDir, DirMode)
 	assert.Nil(t, err)
 
 	deviceFile := filepath.Join(devicesDir, testDeviceBDFPath)
@@ -596,8 +589,7 @@ func TestSandboxAttachDevicesVhostUserBlk(t *testing.T) {
 		rootEnabled = false
 	}
 
-	tmpDir, err := os.MkdirTemp("", "")
-	assert.Nil(t, err)
+	tmpDir := t.TempDir()
 	os.RemoveAll(tmpDir)
 	dm := manager.NewDeviceManager(config.VirtioSCSI, true, tmpDir, nil)
 
@@ -606,7 +598,7 @@ func TestSandboxAttachDevicesVhostUserBlk(t *testing.T) {
 	deviceNodePath := filepath.Join(vhostUserDevNodePath, "vhostblk0")
 	deviceSockPath := filepath.Join(vhostUserSockPath, "vhostblk0")
 
-	err = os.MkdirAll(vhostUserDevNodePath, dirMode)
+	err := os.MkdirAll(vhostUserDevNodePath, dirMode)
 	assert.Nil(t, err)
 	err = os.MkdirAll(vhostUserSockPath, dirMode)
 	assert.Nil(t, err)

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -7,7 +7,6 @@ package virtcontainers
 
 import (
 	"context"
-	"os"
 	"path"
 	"strings"
 	"testing"
@@ -16,7 +15,6 @@ import (
 )
 
 func TestVirtiofsdStart(t *testing.T) {
-	assert := assert.New(t)
 	// nolint: govet
 	type fields struct {
 		path       string
@@ -29,13 +27,8 @@ func TestVirtiofsdStart(t *testing.T) {
 		ctx        context.Context
 	}
 
-	sourcePath, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(sourcePath)
-
-	socketDir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(socketDir)
+	sourcePath := t.TempDir()
+	socketDir := t.TempDir()
 
 	socketPath := path.Join(socketDir, "socket.s")
 
@@ -103,13 +96,8 @@ func TestVirtiofsdArgs(t *testing.T) {
 func TestValid(t *testing.T) {
 	assert := assert.New(t)
 
-	sourcePath, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(sourcePath)
-
-	socketDir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(socketDir)
+	sourcePath := t.TempDir()
+	socketDir := t.TempDir()
 
 	socketPath := socketDir + "socket.s"
 
@@ -123,7 +111,7 @@ func TestValid(t *testing.T) {
 
 	// valid case
 	v := newVirtiofsdFunc()
-	err = v.valid()
+	err := v.valid()
 	assert.NoError(err)
 
 	v = newVirtiofsdFunc()

--- a/src/runtime/virtcontainers/vm_test.go
+++ b/src/runtime/virtcontainers/vm_test.go
@@ -18,9 +18,7 @@ import (
 func TestNewVM(t *testing.T) {
 	assert := assert.New(t)
 
-	testDir, err := os.MkdirTemp("", "vmfactory-tmp-")
-	assert.Nil(err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	config := VMConfig{
 		HypervisorType: MockHypervisor,
@@ -33,7 +31,7 @@ func TestNewVM(t *testing.T) {
 	ctx := WithNewAgentFunc(context.Background(), newMockAgent)
 
 	var vm *VM
-	_, err = NewVM(ctx, config)
+	_, err := NewVM(ctx, config)
 	assert.Error(err)
 
 	config.HypervisorConfig = hyperConfig
@@ -65,9 +63,7 @@ func TestNewVM(t *testing.T) {
 	defer func() {
 		urandomDev = savedUrandomDev
 	}()
-	tmpdir, err := os.MkdirTemp("", "")
-	assert.NoError(err)
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	urandomDev = filepath.Join(tmpdir, "urandom")
 	data := make([]byte, 512)
 	err = os.WriteFile(urandomDev, data, os.FileMode(0640))
@@ -98,9 +94,7 @@ func TestVMConfigValid(t *testing.T) {
 	err := config.Valid()
 	assert.Error(err)
 
-	testDir, err := os.MkdirTemp("", "vmfactory-tmp-")
-	assert.Nil(err)
-	defer os.RemoveAll(testDir)
+	testDir := t.TempDir()
 
 	config.HypervisorConfig = HypervisorConfig{
 		KernelPath: testDir,


### PR DESCRIPTION
A testing cleanup.

We can use the `T.TempDir` function from the `testing` package to create
temporary directory. The directory created by `T.TempDir` is
automatically removed when the test and all its subtests complete.

This PR also updates the unit test advice to use `T.TempDir` to create
temporary directory in tests.

Fixes: #3924

Reference: https://pkg.go.dev/testing#T.TempDir