### PR TITLE
CCv0 | github: Use `/etc/kata-containers/agent.toml`

### DIFF
--- a/.github/workflows/deploy-ccv0-demo.yaml
+++ b/.github/workflows/deploy-ccv0-demo.yaml
@@ -57,8 +57,11 @@ jobs:
       - name: Prepare confidential container rootfs
         if: ${{ matrix.asset == 'rootfs-initrd' }}
         run: |
-          wget -P include_rootfs/etc/ https://raw.githubusercontent.com/confidential-containers/documentation/main/demos/ssh-demo/aa-offline_fs_kbc-keys.json
-          envsubst < docs/how-to/data/confidential-agent-config.toml.in > include_rootfs/etc/kata-config.toml
+          pushd include_rootfs/etc
+          curl -LO https://raw.githubusercontent.com/confidential-containers/documentation/main/demos/ssh-demo/aa-offline_fs_kbc-keys.json
+          mkdir kata-containers
+          envsubst < docs/how-to/data/confidential-agent-config.toml.in > kata-containers/agent.toml
+          popd
         env:
           AA_KBC_PARAMS: offline_fs_kbc::null
 

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -222,7 +222,7 @@ function configure_kata() {
 	if [ "${CONFIGURE_CC:-}" == "yes" ]; then
 		sed -E \
 			-e 's#^image = .+#initrd = "/opt/kata/share/kata-containers/kata-containers-initrd.img"#' \
-			-e 's#^(kernel_params = .+)"#\1 agent.config_file=/etc/kata-config.toml"#' \
+			-e 's#^(kernel_params = .+)"#\1 agent.config_file=/etc/kata-containers/agent.toml"#' \
 			-e 's#.*service_offload = .+#service_offload = true#' \
 			"/opt/kata/share/defaults/kata-containers/configuration-qemu.toml" > \
 			"/opt/kata/share/defaults/kata-containers/configuration-cc.toml"


### PR DESCRIPTION
for config, as per suggestion from @jodh-intel in #3243.
- Uses the pre-established `kata-containers` folder which we can also
  use for more
- Makes it clear the agent is used

Also, use curl instead of wget for uniformity.

Fixes: #3920
Signed-off-by: Jakob Naucke <jakob.naucke@ibm.com>