### PR TITLE
stable-2.4: Bump QEMU to 6.2 (bringing then SGX support in)

### DIFF
--- a/docs/use-cases/using-Intel-SGX-and-kata.md
+++ b/docs/use-cases/using-Intel-SGX-and-kata.md
@@ -21,20 +21,7 @@ CONFIG_X86_SGX_KVM=y
    * [Intel SGX Kubernetes device plugin](https://github.com/intel/intel-device-plugins-for-kubernetes/tree/main/cmd/sgx_plugin#deploying-with-pre-built-images)
 
 > Note: Kata Containers supports creating VM sandboxes with Intel® SGX enabled
-> using [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor/) VMM only. QEMU support is waiting to get the
-> Intel SGX enabled QEMU upstream release.
-
-## Installation
-
-### Kata Containers Guest Kernel
-
-Follow the instructions to [setup](../../tools/packaging/kernel/README.md#setup-kernel-source-code) and [build](../../tools/packaging/kernel/README.md#build-the-kernel) the experimental guest kernel. Then, install as:
-
-```sh
-$ sudo cp kata-linux-experimental-*/vmlinux /opt/kata/share/kata-containers/vmlinux.sgx
-$ sudo sed -i 's|vmlinux.container|vmlinux.sgx|g' \
-  /opt/kata/share/defaults/kata-containers/configuration-clh.toml
-```
+> using [cloud-hypervisor](https://github.com/cloud-hypervisor/cloud-hypervisor/) and [QEMU](https://www.qemu.org/) VMMs only.
 
 ### Kata Containers Configuration
 
@@ -47,6 +34,8 @@ to the `sandbox` are: `["io.katacontainers.*", "sgx.intel.com/epc"]`.
 ## Usage
 
 With the following sample job deployed using `kubectl apply -f`:
+
+> Note: Change the `runtimeClassName` option accordingly, only `kata-clh` and `kata-qemu` support Intel® SGX.
 
 ```yaml
 apiVersion: batch/v1

--- a/tools/packaging/qemu/patches/6.2.x/Revert-target-ppc-Move-SPR_DSISR-setting-to-powerpc_excp.patch
+++ b/tools/packaging/qemu/patches/6.2.x/Revert-target-ppc-Move-SPR_DSISR-setting-to-powerpc_excp.patch
@@ -1,0 +1,81 @@
+From 29c4a3363bf287bb9a7b0342b1bc2dba3661c96c Mon Sep 17 00:00:00 2001
+From: Fabiano Rosas <farosas@linux.ibm.com>
+Date: Fri, 17 Dec 2021 17:57:18 +0100
+Subject: [PATCH] Revert "target/ppc: Move SPR_DSISR setting to powerpc_excp"
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This reverts commit 336e91f85332dda0ede4c1d15b87a19a0fb898a2.
+
+It breaks the --disable-tcg build:
+
+ ../target/ppc/excp_helper.c:463:29: error: implicit declaration of
+ function ‘cpu_ldl_code’ [-Werror=implicit-function-declaration]
+
+We should not have TCG code in powerpc_excp because some kvm-only
+routines use it indirectly to dispatch interrupts. See
+kvm_handle_debug, spapr_mce_req_event and
+spapr_do_system_reset_on_cpu.
+
+We can re-introduce the change once we have split the interrupt
+injection code between KVM and TCG.
+
+Signed-off-by: Fabiano Rosas <farosas@linux.ibm.com>
+Message-Id: <20211209173323.2166642-1-farosas@linux.ibm.com>
+Signed-off-by: Cédric Le Goater <clg@kaod.org>
+---
+ target/ppc/excp_helper.c | 21 ++++++++++++---------
+ 1 file changed, 12 insertions(+), 9 deletions(-)
+
+diff --git a/target/ppc/excp_helper.c b/target/ppc/excp_helper.c
+index feb3fd42e2..6ba0840e99 100644
+--- a/target/ppc/excp_helper.c
++++ b/target/ppc/excp_helper.c
+@@ -464,15 +464,13 @@ static inline void powerpc_excp(PowerPCCPU *cpu, int excp_model, int excp)
+         break;
+     }
+     case POWERPC_EXCP_ALIGN:     /* Alignment exception                      */
++        /* Get rS/rD and rA from faulting opcode */
+         /*
+-         * Get rS/rD and rA from faulting opcode.
+-         * Note: We will only invoke ALIGN for atomic operations,
+-         * so all instructions are X-form.
++         * Note: the opcode fields will not be set properly for a
++         * direct store load/store, but nobody cares as nobody
++         * actually uses direct store segments.
+          */
+-        {
+-            uint32_t insn = cpu_ldl_code(env, env->nip);
+-            env->spr[SPR_DSISR] |= (insn & 0x03FF0000) >> 16;
+-        }
++        env->spr[SPR_DSISR] |= (env->error_code & 0x03FF0000) >> 16;
+         break;
+     case POWERPC_EXCP_PROGRAM:   /* Program exception                        */
+         switch (env->error_code & ~0xF) {
+@@ -1441,6 +1439,11 @@ void ppc_cpu_do_unaligned_access(CPUState *cs, vaddr vaddr,
+                                  int mmu_idx, uintptr_t retaddr)
+ {
+     CPUPPCState *env = cs->env_ptr;
++    uint32_t insn;
++
++    /* Restore state and reload the insn we executed, for filling in DSISR.  */
++    cpu_restore_state(cs, retaddr, true);
++    insn = cpu_ldl_code(env, env->nip);
+ 
+     switch (env->mmu_model) {
+     case POWERPC_MMU_SOFT_4xx:
+@@ -1456,8 +1459,8 @@ void ppc_cpu_do_unaligned_access(CPUState *cs, vaddr vaddr,
+     }
+ 
+     cs->exception_index = POWERPC_EXCP_ALIGN;
+-    env->error_code = 0;
+-    cpu_loop_exit_restore(cs, retaddr);
++    env->error_code = insn & 0x03FF0000;
++    cpu_loop_exit(cs);
+ }
+ #endif /* CONFIG_TCG */
+ #endif /* !CONFIG_USER_ONLY */
+-- 
+GitLab
+

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -250,7 +250,6 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-auth-pam)
 
 	# Disable unused filesystem support
-	[ "$arch" == x86_64 ] && qemu_options+=(size:--disable-fdt)
 	qemu_options+=(size:--disable-glusterfs)
 	qemu_options+=(size:--disable-libiscsi)
 	qemu_options+=(size:--disable-libnfs)
@@ -303,7 +302,6 @@ generate_qemu_options() {
 		;;
 	esac
 	qemu_options+=(size:--disable-qom-cast-debug)
-	qemu_options+=(size:--disable-tcmalloc)
 
 	# Disable libudev since it is only needed for qemu-pr-helper and USB,
 	# none of which are used with Kata

--- a/versions.yaml
+++ b/versions.yaml
@@ -88,8 +88,8 @@ assets:
     qemu:
       description: "VMM that uses KVM"
       url: "https://github.com/qemu/qemu"
-      version: "v6.1.0"
-      tag: "v6.1.0"
+      version: "v6.2.0"
+      tag: "v6.2.0"
       # Do not include any non-full release versions
       # Break the line *without CR or space being appended*, to appease
       # yamllint, and note the deliberate ' ' at the end of the expression.


### PR DESCRIPTION
This is a controversial one as we passed "-rc0" already, but would be very nice if we could bump QEMU to 6.2.0 (currently using 6.1.0) as part of 2.4.0 release.

SGX code has already been on Kata Containers for a while and it's supported when using Cloud Hypervisor and QEMU as VMMs. The Cloud Hypervisor version used already supports SGX, and so does the Kernel.  The only missing piece is QEMU, which slipped off the "-rc0".

I'd like to ask the @kata-containers/architecture-committee, @Amulyam24 (as the power maintainer), @Jakob-Naucke (as the still s390x maintainer), and @jongwu (as the ARM maintainer) on whether this would be okay to bring in, and what are your concerns from the multi arch point of view.