### PR TITLE
Agent: fix unneeded late initialization lint

### DIFF
--- a/src/agent/rustjail/src/cgroups/notifier.rs
+++ b/src/agent/rustjail/src/cgroups/notifier.rs
@@ -151,12 +151,12 @@ async fn register_memory_event(
     let eventfd = eventfd(0, EfdFlags::EFD_CLOEXEC)?;
 
     let event_control_path = Path::new(&cg_dir).join("cgroup.event_control");
-    let data;
-    if arg.is_empty() {
-        data = format!("{} {}", eventfd, event_file.as_raw_fd());
+
+    let data = if arg.is_empty() {
+        format!("{} {}", eventfd, event_file.as_raw_fd())
     } else {
-        data = format!("{} {} {}", eventfd, event_file.as_raw_fd(), arg);
-    }
+        format!("{} {} {}", eventfd, event_file.as_raw_fd(), arg)
+    };
 
     fs::write(&event_control_path, data)?;
 

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -351,13 +351,12 @@ fn seccomp_grpc_to_oci(sec: &grpc::LinuxSeccomp) -> oci::LinuxSeccomp {
 
         for sys in sec.Syscalls.iter() {
             let mut args = Vec::new();
-            let errno_ret: u32;
 
-            if sys.has_errnoret() {
-                errno_ret = sys.get_errnoret();
+            let errno_ret: u32 = if sys.has_errnoret() {
+                sys.get_errnoret()
             } else {
-                errno_ret = libc::EPERM as u32;
-            }
+                libc::EPERM as u32
+            };
 
             for arg in sys.Args.iter() {
                 args.push(oci::LinuxSeccompArg {

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -125,9 +125,7 @@ fn announce(logger: &Logger, config: &AgentConfig) {
 // output to the vsock port specified, or stdout.
 async fn create_logger_task(rfd: RawFd, vsock_port: u32, shutdown: Receiver<bool>) -> Result<()> {
     let mut reader = PipeStream::from_fd(rfd);
-    let mut writer: Box<dyn AsyncWrite + Unpin + Send>;
-
-    if vsock_port > 0 {
+    let mut writer: Box<dyn AsyncWrite + Unpin + Send> = if vsock_port > 0 {
         let listenfd = socket::socket(
             AddressFamily::Vsock,
             SockType::Stream,
@@ -139,10 +137,10 @@ async fn create_logger_task(rfd: RawFd, vsock_port: u32, shutdown: Receiver<bool
         socket::bind(listenfd, &addr)?;
         socket::listen(listenfd, 1)?;
 
-        writer = Box::new(util::get_vsock_stream(listenfd).await?);
+        Box::new(util::get_vsock_stream(listenfd).await?)
     } else {
-        writer = Box::new(tokio::io::stdout());
-    }
+        Box::new(tokio::io::stdout())
+    };
 
     let _ = util::interruptable_io_copier(&mut reader, &mut writer, shutdown).await;
 

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -1036,7 +1036,7 @@ mod tests {
             let dest_filename: String;
 
             if !d.src.is_empty() {
-                src = dir.path().join(d.src.to_string());
+                src = dir.path().join(d.src);
                 src_filename = src
                     .to_str()
                     .expect("failed to convert src to filename")
@@ -1046,7 +1046,7 @@ mod tests {
             }
 
             if !d.dest.is_empty() {
-                dest = dir.path().join(d.dest.to_string());
+                dest = dir.path().join(d.dest);
                 dest_filename = dest
                     .to_str()
                     .expect("failed to convert dest to filename")

--- a/src/agent/src/signal.rs
+++ b/src/agent/src/signal.rs
@@ -58,17 +58,16 @@ async fn handle_sigchild(logger: Logger, sandbox: Arc<Mutex<Sandbox>>) -> Result
             }
 
             let mut p = process.unwrap();
-            let ret: i32;
 
-            match wait_status {
-                WaitStatus::Exited(_, c) => ret = c,
-                WaitStatus::Signaled(_, sig, _) => ret = sig as i32,
+            let ret: i32 = match wait_status {
+                WaitStatus::Exited(_, c) => c,
+                WaitStatus::Signaled(_, sig, _) => sig as i32,
                 _ => {
                     info!(logger, "got wrong status for process";
                                   "child-status" => format!("{:?}", wait_status));
                     continue;
                 }
-            }
+            };
 
             p.exit_code = ret;
             let _ = p.exit_tx.take();

--- a/src/agent/src/util.rs
+++ b/src/agent/src/util.rs
@@ -237,8 +237,6 @@ mod tests {
                 JoinError,
             >;
 
-            let result: std::result::Result<u64, std::io::Error>;
-
             select! {
                 res = handle => spawn_result = res,
                 _ = &mut timeout => panic!("timed out"),
@@ -246,7 +244,7 @@ mod tests {
 
             assert!(spawn_result.is_ok());
 
-            result = spawn_result.unwrap();
+            let result: std::result::Result<u64, std::io::Error> = spawn_result.unwrap();
 
             assert!(result.is_ok());
 
@@ -278,8 +276,6 @@ mod tests {
 
         let spawn_result: std::result::Result<std::result::Result<u64, std::io::Error>, JoinError>;
 
-        let result: std::result::Result<u64, std::io::Error>;
-
         select! {
             res = handle => spawn_result = res,
             _ = &mut timeout => panic!("timed out"),
@@ -287,7 +283,7 @@ mod tests {
 
         assert!(spawn_result.is_ok());
 
-        result = spawn_result.unwrap();
+        let result: std::result::Result<u64, std::io::Error> = spawn_result.unwrap();
 
         assert!(result.is_ok());
 
@@ -320,8 +316,6 @@ mod tests {
 
         let spawn_result: std::result::Result<std::result::Result<u64, std::io::Error>, JoinError>;
 
-        let result: std::result::Result<u64, std::io::Error>;
-
         select! {
             res = handle => spawn_result = res,
             _ = &mut timeout => panic!("timed out"),
@@ -329,7 +323,7 @@ mod tests {
 
         assert!(spawn_result.is_ok());
 
-        result = spawn_result.unwrap();
+        let result: std::result::Result<u64, std::io::Error> = spawn_result.unwrap();
 
         assert!(result.is_ok());
 

--- a/src/agent/vsock-exporter/src/lib.rs
+++ b/src/agent/vsock-exporter/src/lib.rs
@@ -178,13 +178,11 @@ impl Builder {
     pub fn init(self) -> Exporter {
         let Builder { port, cid, logger } = self;
 
-        let cid_str: String;
-
-        if self.cid == libc::VMADDR_CID_ANY {
-            cid_str = ANY_CID.to_string();
+        let cid_str: String = if self.cid == libc::VMADDR_CID_ANY {
+            ANY_CID.to_string()
         } else {
-            cid_str = format!("{}", self.cid);
-        }
+            format!("{}", self.cid)
+        };
 
         Exporter {
             port,


### PR DESCRIPTION
Clippy v1.58 added needless_late_init.
This breaks agent `make check`.

Fixes #3933
