### PR TITLE
doc: Improve kata-deploy README.md by changing sh blocks to bash blocks

### DIFF
--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -27,7 +27,7 @@ The stable image refers to the last stable releases content.
 > **Note:** if you use a tagged version of the repo, the stable image does match that version.
 > For instance, if you use the 2.2.1 tagged version of the kata-deploy.yaml file, then the version 2.2.1 of the kata runtime will be deployed.
 
-```sh
+```bash
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy-stable.yaml
 ```
@@ -36,12 +36,15 @@ $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-contai
 
 ```sh
 $ GO111MODULE=auto go get github.com/kata-containers/kata-containers
+```
+
+```bash
 $ cd $GOPATH/src/github.com/kata-containers/kata-containers/tools/packaging/kata-deploy
 $ kubectl apply -k kata-deploy/overlays/k3s
 ```
 
 #### Ensure kata-deploy is ready
-```sh
+```bash
 kubectl -n kube-system wait --timeout=10m --for=condition=Ready -l name=kata-deploy pod
 ```
 
@@ -52,7 +55,7 @@ the `Pod` specification. The `runtimeClass` examples provided define a node sele
 which will ensure the workload is only scheduled on a node that has Kata Containers installed
 
 `runtimeClass` is a built-in type in Kubernetes. To apply each Kata Containers `runtimeClass`:
-```sh
+```bash
   $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
 ```
 
@@ -85,25 +88,25 @@ spec:
 
 To run an example with `kata-clh`:
 
-```sh
+```bash
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/examples/test-deploy-kata-clh.yaml
 ```
 
 To run an example with `kata-fc`:
 
-```sh
+```bash
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/examples/test-deploy-kata-fc.yaml
 ```
 
 To run an example with `kata-qemu`:
 
-```sh
+```bash
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/examples/test-deploy-kata-qemu.yaml
 ```
 
 The following removes the test pods:
 
-```sh
+```bash
 $ kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/examples/test-deploy-kata-clh.yaml
 $ kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/examples/test-deploy-kata-fc.yaml
 $ kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/examples/test-deploy-kata-qemu.yaml
@@ -136,13 +139,13 @@ $ kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-conta
 
 #### Removing the stable image
 
-```sh
+```bash
 $ kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy-stable.yaml
 $ kubectl -n kube-system wait --timeout=10m --for=delete -l name=kata-deploy pod
 ```
 
 After ensuring kata-deploy has been deleted, cleanup the cluster:
-```sh
+```bash
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup-stable.yaml
 ```
 
@@ -150,7 +153,7 @@ The cleanup daemon-set will run a single time, cleaning up the node-label, which
 This process should take, at most, 5 minutes.
 
 After that, let's delete the cleanup daemon-set, the added RBAC and runtime classes:
-```sh
+```bash
 $ kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup-stable.yaml
 $ kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
 $ kubectl delete -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml


### PR DESCRIPTION
The idea is to pass this README file to kata-doc-to-script.sh script and
then execute the result.

Added comments with a file name on top of each YAML snippet.
This helps in assigning a file name when we cat the YAML to a file.

Fixes: #3943

Signed-off-by: David Esparza <david.esparza.borquez@intel.com>