### PR TITLE
osbuilder/qat: use centos as base OS

### DIFF
--- a/tools/osbuilder/dockerfiles/QAT/Dockerfile
+++ b/tools/osbuilder/dockerfiles/QAT/Dockerfile
@@ -16,7 +16,7 @@ ENV QAT_DRIVER_URL "https://downloadmirror.intel.com/649693/${QAT_DRIVER_VER}"
 ENV QAT_CONFIGURE_OPTIONS "--enable-icp-sriov=guest"
 ENV KATA_REPO_VERSION "main"
 ENV AGENT_VERSION ""
-ENV ROOTFS_OS "ubuntu"
+ENV ROOTFS_OS "centos"
 ENV OUTPUT_DIR "/output"
 
 RUN dnf install -y \


### PR DESCRIPTION
move away from ubuntu, since now it's easier to build using
CentOS as base OS

Signed-off-by: Julio Montes <julio.montes@intel.com>