### PR TITLE
agent: Signal the whole process group

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -19,6 +19,7 @@ use ttrpc::{
 };
 
 use anyhow::{anyhow, Context, Result};
+use cgroups::freezer::FreezerState;
 use oci::{LinuxNamespace, Root, Spec};
 use protobuf::{Message, RepeatedField, SingularPtrField};
 use protocols::agent::{
@@ -40,8 +41,9 @@ use rustjail::specconv::CreateOpts;
 use nix::errno::Errno;
 use nix::mount::MsFlags;
 use nix::sys::signal::Signal;
-use nix::sys::stat;
+use nix::sys::{signal, stat};
 use nix::unistd::{self, Pid};
+use rustjail::cgroups::Manager;
 use rustjail::process::ProcessOperations;
 
 use sysinfo::{DiskExt, System, SystemExt};
@@ -391,7 +393,6 @@ impl AgentService {
         let cid = req.container_id.clone();
         let eid = req.exec_id.clone();
         let s = self.sandbox.clone();
-        let mut sandbox = s.lock().await;
 
         info!(
             sl!(),
@@ -400,25 +401,95 @@ impl AgentService {
             "exec-id" => eid.clone(),
         );
 
-        let p = sandbox.find_container_process(cid.as_str(), eid.as_str())?;
-
-        let mut signal = Signal::try_from(req.signal as i32).map_err(|e| {
+        let mut sig = Signal::try_from(req.signal as i32).map_err(|e| {
             anyhow!(e).context(format!(
                 "failed to convert {:?} to signal (container-id: {}, exec-id: {})",
                 req.signal, cid, eid
             ))
         })?;
-
-        // For container initProcess, if it hasn't installed handler for "SIGTERM" signal,
-        // it will ignore the "SIGTERM" signal sent to it, thus send it "SIGKILL" signal
-        // instead of "SIGTERM" to terminate it.
-        if p.init && signal == Signal::SIGTERM && !is_signal_handled(p.pid, req.signal) {
-            signal = Signal::SIGKILL;
+        {
+            let mut sandbox = s.lock().await;
+            let p = sandbox.find_container_process(cid.as_str(), eid.as_str())?;
+            // For container initProcess, if it hasn't installed handler for "SIGTERM" signal,
+            // it will ignore the "SIGTERM" signal sent to it, thus send it "SIGKILL" signal
+            // instead of "SIGTERM" to terminate it.
+            if p.init && sig == Signal::SIGTERM && !is_signal_handled(p.pid, sig as u32) {
+                sig = Signal::SIGKILL;
+            }
+            p.signal(sig)?;
         }
 
-        p.signal(signal)?;
+        if eid.is_empty() {
+            // eid is empty, signal all the remaining processes in the container cgroup
+            info!(
+                sl!(),
+                "signal all the remaining processes";
+                "container-id" => cid.clone(),
+                "exec-id" => eid.clone(),
+            );
 
+            if let Err(err) = self.freeze_cgroup(&cid, FreezerState::Frozen).await {
+                warn!(
+                    sl!(),
+                    "freeze cgroup failed";
+                    "container-id" => cid.clone(),
+                    "exec-id" => eid.clone(),
+                    "error" => format!("{:?}", err),
+                );
+            }
+
+            let pids = self.get_pids(&cid).await?;
+            for pid in pids.iter() {
+                if let Err(err) = signal::kill(Pid::from_raw(*pid), Some(sig)) {
+                    warn!(
+                        sl!(),
+                        "signal failed";
+                        "container-id" => cid.clone(),
+                        "exec-id" => eid.clone(),
+                        "pid" => pid,
+                        "error" => format!("{:?}", err),
+                    );
+                }
+            }
+            if let Err(err) = self.freeze_cgroup(&cid, FreezerState::Thawed).await {
+                warn!(
+                    sl!(),
+                    "unfreeze cgroup failed";
+                    "container-id" => cid.clone(),
+                    "exec-id" => eid.clone(),
+                    "error" => format!("{:?}", err),
+                );
+            }
+        }
         Ok(())
+    }
+
+    async fn freeze_cgroup(&self, cid: &str, state: FreezerState) -> Result<()> {
+        let s = self.sandbox.clone();
+        let mut sandbox = s.lock().await;
+        let ctr = sandbox
+            .get_container(cid)
+            .ok_or_else(|| anyhow!("Invalid container id {}", cid))?;
+        let cm = ctr
+            .cgroup_manager
+            .as_ref()
+            .ok_or_else(|| anyhow!("cgroup manager not exist"))?;
+        cm.freeze(state)?;
+        Ok(())
+    }
+
+    async fn get_pids(&self, cid: &str) -> Result<Vec<i32>> {
+        let s = self.sandbox.clone();
+        let mut sandbox = s.lock().await;
+        let ctr = sandbox
+            .get_container(cid)
+            .ok_or_else(|| anyhow!("Invalid container id {}", cid))?;
+        let cm = ctr
+            .cgroup_manager
+            .as_ref()
+            .ok_or_else(|| anyhow!("cgroup manager not exist"))?;
+        let pids = cm.get_pids()?;
+        Ok(pids)
     }
 
     #[instrument]

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -776,6 +776,8 @@ func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (_ *ptypes.E
 			return empty, errors.New("The exec process does not exist")
 		}
 		processStatus = execs.status
+	} else {
+		r.All = true
 	}
 
 	// According to CRI specs, kubelet will call StopPodSandbox()

--- a/src/runtime/pkg/containerd-shim-v2/stream_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/stream_test.go
@@ -7,6 +7,7 @@ package containerdshim
 
 import (
 	"context"
+	"github.com/sirupsen/logrus"
 	"io"
 	"os"
 	"path/filepath"
@@ -179,7 +180,7 @@ func TestIoCopy(t *testing.T) {
 		defer tty.close()
 
 		// start the ioCopy threads : copy from src to dst
-		go ioCopy(exitioch, stdinCloser, tty, dstInW, srcOutR, srcErrR)
+		go ioCopy(logrus.WithContext(context.Background()), exitioch, stdinCloser, tty, dstInW, srcOutR, srcErrR)
 
 		var firstW, secondW, thirdW io.WriteCloser
 		var firstR, secondR, thirdR io.Reader


### PR DESCRIPTION
This PR addresses #3913.

As described in #3913, the current container termination is insufficient for use cases where a pid namespace is shared among multiple containers. I updated the kata agent container termination logic to follow the [runc](https://github.com/opencontainers/runc/blob/485e6c84e7ef783c126c392af072a974c9fb88ce/libcontainer/init_linux.go#L528) implementation that kills all the processes in the same cgroup, as it's safe to assume each container has its own cgroup. The other change is to set `KillRequest.All` as `true` when the `ExecID` is empty. This separates the container termination versus container exec signaling. 

It's also worth calling out, I didn't change the kata shim v2 service to follow the [runc v2 logic](https://github.com/fengwang666/containerd/blob/e48bbe83949a43dedd3e2727452259f99dd81635/runtime/v2/runc/v2/service.go#L766-L773) where they terminate the child processes after the init process exits. The main reason is because the container termination sequences in runc and kata is a bit different. In runc, the runtime service gets notified immediately after the container process exits by [subscribing](https://github.com/containerd/containerd/blob/e48bbe83949a43dedd3e2727452259f99dd81635/runtime/v2/runc/v2/service.go#L98) to the process reaper, but in kata, the shim needs to poll the kata agent through a [wait](https://github.com/kata-containers/kata-containers/blob/main/src/runtime/pkg/containerd-shim-v2/wait.go) goroutine that blocks on the io copy streams until the container has exited cleanly. It would be quite complicated trying to fit the runc approach to the current kata container termination sequence. And I believe it's sufficient to kill the container processes all at once.
