### PR TITLE
CCv0: agent: Support https_proxy config for image download in guest

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1215,6 +1215,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ttrpc",
+ "url 2.2.2",
  "vsock-exporter",
 ]
 

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "1.0.26"
 regex = "1.5.4"
 serial_test = "0.5.1"
 sysinfo = "0.23.0"
+url = "2.2.2"
 
 # Async helpers
 async-trait = "0.1.42"

--- a/src/agent/src/image_rpc.rs
+++ b/src/agent/src/image_rpc.rs
@@ -177,6 +177,16 @@ impl ImageService {
     async fn pull_image(&self, req: &image::PullImageRequest) -> Result<String> {
         env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", OCICRYPT_CONFIG_PATH);
 
+        let https_proxy = &AGENT_CONFIG.read().await.https_proxy;
+        if !https_proxy.is_empty() {
+            env::set_var("HTTPS_PROXY", https_proxy);
+        }
+
+        let no_proxy = &AGENT_CONFIG.read().await.no_proxy;
+        if !no_proxy.is_empty() {
+            env::set_var("NO_PROXY", no_proxy);
+        }
+
         let image = req.get_image();
         let mut cid = req.get_container_id().to_string();
 


### PR DESCRIPTION
Containerd can support set a proxy when downloading images with a environment variable.
For CC stack, image download is offload to the kata agent, we need support similar feature.

Fixes #3956

Signed-off-by: Arron Wang <arron.wang@intel.com>