### PR TITLE
runtime: Remove the explicit VirtioMem set and fix the comment

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -758,7 +758,7 @@ func (q *qemu) setupVirtioMem(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// backend memory size must be multiple of 2Mib
+	// backend memory size must be multiple of 4Mib
 	sizeMB := (int(maxMem) - int(q.config.MemorySize)) >> 2 << 2
 
 	share, target, memoryBack, err := q.getMemArgs()
@@ -783,7 +783,6 @@ func (q *qemu) setupVirtioMem(ctx context.Context) error {
 
 	err = q.qmpMonitorCh.qmp.ExecMemdevAdd(q.qmpMonitorCh.ctx, memoryBack, "virtiomem", target, sizeMB, share, "virtio-mem-pci", "virtiomem0", addr, bridge.ID)
 	if err == nil {
-		q.config.VirtioMem = true
 		q.Logger().Infof("Setup %dMB virtio-mem-pci success", sizeMB)
 	} else {
 		help := ""


### PR DESCRIPTION
Modify the 2Mib in the comment to 4Mib.
VirtioMem is set by configuration file or annotation. And setupVirtioMem is called only when VirtioMem is true.

Fixes: #3750

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>