### PR TITLE
release: Include all the rust vendored code into the vendored tarball

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,13 +141,10 @@ jobs:
       - uses: actions/checkout@v2
       - name: generate-and-upload-tarball
         run: |
-          pushd $GITHUB_WORKSPACE/src/agent
-          cargo vendor >> .cargo/config
-          popd
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           tarball="kata-containers-$tag-vendor.tar.gz"
           pushd $GITHUB_WORKSPACE
-          tar -cvzf "${tarball}" src/agent/.cargo/config src/agent/vendor
+          bash -c "tools/packaging/release/generate_vendor.sh ${tarball}"
           GITHUB_TOKEN=${{ secrets.GIT_UPLOAD_TOKEN }} hub release edit -m "" -a "${tarball}" "${tag}" 
           popd
 

--- a/tools/packaging/release/generate_vendor.sh
+++ b/tools/packaging/release/generate_vendor.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_name="$(basename "${BASH_SOURCE[0]}")"
+
+# This is very much error prone in case we re-structure our
+# repos again, but it's also used in a few other places :-/
+repo_dir="${script_dir}/../../.."
+
+function usage() {
+
+	cat <<EOF
+Usage: ${script_name} tarball-name
+This script creates a tarball with all the cargo vendored code
+that a distro would need to do a full build of the project in
+a disconnected environment, generating a "tarball-name" file.
+
+EOF
+
+}
+
+create_vendor_tarball() {
+	vendor_dir_list=""
+	pushd ${repo_dir}
+		for i in $(find . -name 'Cargo.lock'); do
+			dir="$(dirname $i)"
+			pushd "${dir}"
+				[ -d .cargo ] || mkdir .cargo
+				cargo vendor >> .cargo/config
+				vendor_dir_list+=" $dir/vendor $dir/.cargo/config"
+				echo "${vendor_dir_list}"
+			popd
+		done
+	popd
+	
+	tar -cvzf ${1} ${vendor_dir_list}
+}
+
+main () {
+	[ $# -ne 1 ] && usage && exit 0
+	create_vendor_tarball ${1}
+}
+
+main "$@"


### PR DESCRIPTION
workflows,release: Ship *all* the rust vendored code

Instead of only vendoring the code needed by the agent, let's ensure we
vendor all the needed rust code, and let's do it using the newly
introduced enerate_vendor.sh script.

Fixes: #3973

---

tools: Add a generate_vendor.sh script

This script is responsible for generating a tarball with all the rust
vendored code that is needed for fully building kata-containers on a
disconnected environment.

---

How to verify:
* From the top dir of the project, do:
```
bash -c "tools/packaging/release/generate_vendor.sh kata-containers-vendor.tar.gz"
```
* Do a downstream build using the vendored source, instead of the one currently used.

@etrunko, please, verify if it works on Fedora and let us know ASAP.