### PR TITLE
kata-deploy: add support for building sev firmware

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -54,6 +54,9 @@ rootfs-initrd-tarball:
 shim-v2-tarball:
 	${MAKE} $@-build
 
+ovmf-tarball:
+ 	${MAKE} $@-build
+
 merge-builds:
 	$(MK_DIR)/kata-deploy-merge-builds.sh build
 
@@ -62,3 +65,7 @@ install-tarball:
 
 image: kata-tarball
 	$(MK_DIR)kata-deploy-build-and-upload-image.sh $(CURDIR)/kata-static.tar.xz
+
+sev-tarballs: kernel-tarball qemu-tarball rootfs-initrd-tarball shim-v2-tarball ovmf-tarball
+
+sev: sev-tarballs-parallel merge-builds

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -15,8 +15,11 @@ endef
 
 kata-tarball: | all-parallel merge-builds
 
-all-parallel:
-	${MAKE} -f $(MK_PATH) all -j$$(( $$(nproc) - 1  )) NO_TTY="true" V=
+$(MK_DIR)/dockerbuild/install_yq.sh:
+	$(MK_DIR)/kata-deploy-copy-yq-installer.sh
+
+%-parallel: $(MK_DIR)/dockerbuild/install_yq.sh
+	${MAKE} -f $(MK_PATH) $(subst -parallel,,$@) -j$$(( $$(nproc) - 1  ))  V=
 
 all: cloud-hypervisor-tarball \
 	firecracker-tarball \
@@ -55,7 +58,7 @@ shim-v2-tarball:
 	${MAKE} $@-build
 
 ovmf-tarball:
- 	${MAKE} $@-build
+	${MAKE} $@-build
 
 merge-builds:
 	$(MK_DIR)/kata-deploy-merge-builds.sh build

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -32,6 +32,10 @@ RUN apt-get update && \
   apt-get install --no-install-recommends -y \
   build-essential \
   cpio \
+  uuid-dev \
+  python \
+  nasm \
+  iasl \
   gcc \
   git \
   make \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -28,6 +28,9 @@ readonly shimv2_builder="${static_build_dir}/shim-v2/build.sh"
 
 readonly rootfs_builder="${repo_root_dir}/tools/packaging/guest-image/build_image.sh"
 
+#is this the right location for this build script?
+readonly ovmf_builder="${static_build_dir}/ovmf/build-ovmf.sh"
+
 ARCH=$(uname -m)
 
 workdir="${WORKDIR:-$PWD}"
@@ -74,6 +77,7 @@ options:
 	rootfs-image
 	rootfs-initrd
 	shim-v2
+	ovmf
 EOF
 
 	exit "${return_code}"
@@ -145,6 +149,11 @@ install_shimv2() {
 	DESTDIR="${destdir}" PREFIX="${prefix}" "${shimv2_builder}"
 }
 
+install_ovmf() {
+	info "build AmdSev ovmf firmware"
+	"${ovmf_builder}"
+}
+
 get_kata_version() {
 	local v
 	v=$(cat "${version_file}")
@@ -164,6 +173,7 @@ handle_build() {
 		install_kernel
 		install_qemu
 		install_shimv2
+		install_ovmf
 		;;
 
 	cloud-hypervisor) install_clh ;;
@@ -181,6 +191,8 @@ handle_build() {
 	rootfs-initrd) install_initrd ;;
 
 	shim-v2) install_shimv2 ;;
+
+	ovmf) install_ovmf ;;
 
 	*)
 		die "Invalid build target ${build_target}"
@@ -207,6 +219,7 @@ main() {
 		rootfs-image
 		rootfs-initrd
 		shim-v2
+		ovmf
 	)
 	silent=false
 	while getopts "hs-:" opt; do

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -28,7 +28,6 @@ readonly shimv2_builder="${static_build_dir}/shim-v2/build.sh"
 
 readonly rootfs_builder="${repo_root_dir}/tools/packaging/guest-image/build_image.sh"
 
-#is this the right location for this build script?
 readonly ovmf_builder="${static_build_dir}/ovmf/build-ovmf.sh"
 
 ARCH=$(uname -m)

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -226,6 +226,7 @@ function configure_kata() {
 			-e 's#.*service_offload = .+#service_offload = true#' \
 			"/opt/kata/share/defaults/kata-containers/configuration-qemu.toml" > \
 			"/opt/kata/share/defaults/kata-containers/configuration-cc.toml"
+		sed -Ei -e 's|(^firmware = ).+|\1 "/opt/kata/share/ovmf/OVMF.fd"|' ${cc_config}
 	fi
 }
 

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -226,7 +226,9 @@ function configure_kata() {
 			-e 's#.*service_offload = .+#service_offload = true#' \
 			"/opt/kata/share/defaults/kata-containers/configuration-qemu.toml" > \
 			"/opt/kata/share/defaults/kata-containers/configuration-cc.toml"
-		sed -Ei -e 's|(^firmware = ).+|\1 "/opt/kata/share/ovmf/OVMF.fd"|' ${cc_config}
+		if [ "${CONFIGURE_SEV:-}" == "yes" ]; then
+			sed -Ei -e 's|(^firmware = ).+|\1 "/opt/kata/share/ovmf/OVMF.fd"|' ${cc_config}
+		fi
 	fi
 }
 

--- a/tools/packaging/static-build/build-ovmf.sh
+++ b/tools/packaging/static-build/build-ovmf.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+#
+# Copyright (c) 2021 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+ovmf_repo="${ovmf_repo:-}"
+ovmf_dir="edk2"
+ovmf_version="${ovmf_version:-}"
+kata_version="${kata_version:-}"
+
+#DESTDIR=${DESTDIR:-${PWD}}
+
+if [ -z "$ovmf_repo" ]; then
+       info "Get ovmf information from runtime versions.yaml"
+       ovmf_url=$(get_from_kata_deps "externals.ovmf.url" "${kata_version}")
+       [ -n "$ovmf_url" ] || die "failed to get ovmf url"
+       ovmf_repo="${ovmf_url}.git"
+fi
+
+[ -n "$ovmf_repo" ] || die "failed to get ovmf repo"
+
+[ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps "externals.ovmf.commit" "${kata_version}")
+[ -n "$ovmf_version" ] || die "failed to get ovmf version or commit"
+
+info "Build ${ovmf_repo} version: ${ovmf_version}"
+
+[ -d "${ovmf_dir}" ] || git clone ${ovmf_repo}
+cd "${ovmf_dir}"
+git checkout "${ovmf_version}"
+git submodule init
+git submodule update
+
+info "Using BaseTools make target"
+set +u
+make -C BaseTools/
+set -u
+
+info "Calling edksetup scipt"
+# disabling set -u because edksetup.sh attempts to expands undefined variables
+set +u
+source edksetup.sh
+set -u
+
+info "Creating dummy grub file"
+touch OvmfPkg/AmdSev/Grub/grub.efi
+
+info "Building ovmf"
+build -t GCC5 -a X64 -p OvmfPkg/AmdSev/AmdSevX64.dsc
+
+info "Done Building"
+pwd
+stat Build/AmdSev/DEBUG_GCC5/FV/OVMF.fd 
+
+info "Install fd to destdir"
+mkdir -p ../../destdir/opt/kata/share/ovmf
+cp Build/AmdSev/DEBUG_GCC5/FV/OVMF.fd ../../destdir/opt/kata/share/ovmf

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -17,8 +17,6 @@ ovmf_dir="edk2"
 ovmf_version="${ovmf_version:-}"
 kata_version="${kata_version:-}"
 
-#DESTDIR=${DESTDIR:-${PWD}}
-
 if [ -z "$ovmf_repo" ]; then
        info "Get ovmf information from runtime versions.yaml"
        ovmf_url=$(get_from_kata_deps "externals.ovmf.url" "${kata_version}")
@@ -28,7 +26,7 @@ fi
 
 [ -n "$ovmf_repo" ] || die "failed to get ovmf repo"
 
-[ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps "externals.ovmf.commit" "${kata_version}")
+[ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps "externals.ovmf.version" "${kata_version}")
 [ -n "$ovmf_version" ] || die "failed to get ovmf version or commit"
 
 info "Build ${ovmf_repo} version: ${ovmf_version}"
@@ -51,6 +49,7 @@ source edksetup.sh
 set -u
 
 info "Creating dummy grub file"
+#required for building AmdSev package without grub
 touch OvmfPkg/AmdSev/Grub/grub.efi
 
 info "Building ovmf"

--- a/versions.yaml
+++ b/versions.yaml
@@ -269,6 +269,12 @@ externals:
     url: "https://github.com/containerd/nydus-snapshotter"
     version: "v0.1.0"
 
+  ovmf:
+    description: "Firmware, implementation of UEFI for virtual machines."
+    notes: "The AmdSev build is needed for SEV measured direct boot support."
+    url: "https://github.com/tianocore/edk2"
+    commit: "b24306f15daa2ff8510b06702114724b33895d3c"
+
 languages:
   description: |
     Details of programming languages required to build system

--- a/versions.yaml
+++ b/versions.yaml
@@ -273,7 +273,7 @@ externals:
     description: "Firmware, implementation of UEFI for virtual machines."
     notes: "The AmdSev build is needed for SEV measured direct boot support."
     url: "https://github.com/tianocore/edk2"
-    commit: "b24306f15daa2ff8510b06702114724b33895d3c"
+    version: "edk2-stable202202"
 
 languages:
   description: |


### PR DESCRIPTION
### SEV with secret injection requires the AmdSev firmware build, adding this build to kata-deploy.

This PR is intended to be one part of the several needed for kata-deploy to handle setting up a node to use AMD SEV.

Fixes: #3982

Details of the required components can be found at:

https://github.com/confidential-containers/documentation/tree/main/demos/sev-demo

AMD SEV support in kata-deploy roughly breaks down into the six areas below. I am aware that @fidencio is in favor of having kata-deploy patches be unified, so my intention would be to update this PR with each additional component. 

- [x]  OVMF

- [ ] Kernel

- [ ] Initrd

- [ ] Shim

- [ ] KBS

- [ ] Image

An initial question: In `kata-deploy.sh` proper, in **configure_kata()**, there currently is a CONFIGURE_CC variable, I would propose introducing a similar option for SEV (perhaps CONFIGURE_SEV ?). I am currently checking for if the cpu has an sev flag, but this does not necessarily mean the user wants to enable SEV. Would this be in line with the expectation for how a user would choose to enable SEV?