### PR TITLE
tools/packaging: Fix error path in `kata-deploy-binaries.sh -s`

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -64,6 +64,7 @@ version: The kata version that will be use to create the tarball
 options:
 
 -h|--help      	      : Show this help
+-s             	      : Silent mode (produce output in case of failure only)
 --build=<asset>       :
 	all
 	cloud-hypervisor

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -8,6 +8,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -o errtrace
 
 readonly project="kata-containers"
 
@@ -196,6 +197,18 @@ handle_build() {
 	tar tvf "${tarball_name}"
 }
 
+silent_mode_error_trap() {
+	local stdout="$1"
+	local stderr="$2"
+	local t="$3"
+	local log_file="$4"
+	exec 1>&${stdout}
+	exec 2>&${stderr}
+	error "Failed to build: $t, logs:"
+	cat "${log_file}"
+	exit 1
+}
+
 main() {
 	local build_targets
 	local silent
@@ -248,11 +261,15 @@ main() {
 		(
 			cd "${builddir}"
 			if [ "${silent}" == true ]; then
-				if ! handle_build "${t}" &>"$log_file"; then
-					error "Failed to build: $t, logs:"
-					cat "${log_file}"
-					exit 1
-				fi
+				local stdout
+				local stderr
+				# Save stdout and stderr, to be restored
+				# by silent_mode_error_trap() in case of
+				# build failure.
+				exec {stdout}>&1
+				exec {stderr}>&2
+				trap "silent_mode_error_trap $stdout $stderr $t \"$log_file\"" ERR
+				handle_build "${t}" &>"$log_file"
 			else
 				handle_build "${t}"
 			fi


### PR DESCRIPTION
`make kata-tarball` relies on `kata-deploy-binaries.sh -s` which silently ignores errors, and you may end up with an incomplete tarball without noticing it because `make`'s exit status is 0. This is due to a non-obvious behaviour of `bash` when mixing the 'errexit' option and calling functions from conditional pipelines.

While here, document `-s` in the script's usage.

Fixes #3757

Signed-off-by: Greg Kurz <groug@kaod.org>