### PR TITLE
stable-2.4 | runtime: Stop getting OOM events from agent for "ttrpc closed" error

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/wait.go
+++ b/src/runtime/pkg/containerd-shim-v2/wait.go
@@ -67,6 +67,7 @@ func wait(ctx context.Context, s *service, c *container, execID string) (int32, 
 		if c.cType.IsSandbox() {
 			// cancel watcher
 			if s.monitor != nil {
+				shimLog.WithField("sandbox", s.sandbox.ID()).Info("cancel watcher")
 				s.monitor <- nil
 			}
 			if err = s.sandbox.Stop(ctx, true); err != nil {
@@ -110,6 +111,7 @@ func watchSandbox(ctx context.Context, s *service) {
 		return
 	}
 	err := <-s.monitor
+	shimLog.WithError(err).WithField("sandbox", s.sandbox.ID()).Info("watchSandbox gets an error or stop signal")
 	if err == nil {
 		return
 	}


### PR DESCRIPTION
Stop getting OOM events from agent for "ttrpc closed" error


Backport of #3989 