### PR TITLE
tools/packaging: Expose docker config to build-kata-deploy container

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -28,6 +28,7 @@ docker build -q -t build-kata-deploy \
 
 docker run \
 	-v /var/run/docker.sock:/var/run/docker.sock \
+	-v $HOME/.docker:$HOME/.docker \
 	--user ${uid}:${gid} \
 	--env USER=${USER} -v "${kata_dir}:${kata_dir}" \
 	--rm \


### PR DESCRIPTION
`make kata-tarball` may fail consistently because it hits the
docker rate limit when building the firecracker asset. This is
especially painful when used behind the firewall of a large
organization because this aggregates all docker requests as
coming from a few IP addresses, and `make kata-tarball` may
stay broken for an indefinite period of time.

The usual mitigation for this is to have an account at docker.io
and to `docker login`. Unfortunately this doesn't work here
because the failing docker is running nested and doesn't see the
user's auth tokens.

Expose `$HOME/.docker` to the `build-kata-deploy` container so
that nested docker invocations can access the auth tokens.

Fixes #4001

Signed-off-by: Greg Kurz <groug@kaod.org>