### PR TITLE
protocols: add src/csi.rs to .gitignore

### DIFF
--- a/src/libs/protocols/.gitignore
+++ b/src/libs/protocols/.gitignore
@@ -1,6 +1,7 @@
 Cargo.lock
 src/agent.rs
 src/agent_ttrpc.rs
+src/csi.rs
 src/empty.rs
 src/health.rs
 src/health_ttrpc.rs


### PR DESCRIPTION
After running make in src/agent, the git working area will be changed:

Untracked files:
  (use "git add <file>..." to include in what will be committed)
	src/libs/protocols/src/csi.rs

The generated file by `build.rs` should be ignored in git.

Fixes: #3959

Signed-off-by: bin <bin@hyper.sh>