### PR TITLE
versions: Bump firecracker to v0.23.4

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -83,7 +83,7 @@ assets:
       uscan-url: >-
         https://github.com/firecracker-microvm/firecracker/tags
         .*/v?(\d\S+)\.tar\.gz
-      version: "v0.23.1"
+      version: "v0.23.4"
 
     qemu:
       description: "VMM that uses KVM"


### PR DESCRIPTION
This release changes Docker images repository from DockerHub to Amazon
ECR. This resolves the `You have reached your pull rate limit` error
when building the firecracker tarball.

Fixes #4001

Signed-off-by: Greg Kurz <groug@kaod.org>