### PR TITLE
agent: Document the configuration options

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -84,6 +84,39 @@ To install the `protoc` command on a Fedora/CentOS/RHEL system:
 $ sudo dnf install -y protobuf-compiler
 ```
 
+## Configuring the agent
+
+The agent can be configured in a couple of ways.
+
+If running under the supervision of the Kata runtime, the agent will be automatically configured according to some properties in the runtime's `configuration.toml` file (see [runtime configuration](../runtime/README.md#configuration)). For example, the `enable_debug` option under the `[agent.kata]` section can be used to set debug-level logs. However, not all the accepted configurations are mapped into `configuration.toml`, so any additional options should be passed directly to the agent via kernel parameters.
+
+Any kernel parameter is be specified in the `kernel_params` property in the runtime's `configuration.toml`. As an example, to enable the Agent support for unified cgroup hierarchy and set debug logs, write the following line in `configuration.toml`:
+
+```
+kernel_params = "agent.unified_cgroup_hierarchy=true agent.log=debug"
+```
+
+The agent options passed via kernel parameters have the `agent.OPTION` format, where `OPTION` can be:
+
+| Option | Description | Example |
+|-|-|-|
+|`debug_console`|Enable debug console|`agent.debug_console`|
+|`devmode`|Enable `devmode`|`agent.devmode`|
+|`trace`|Enable agent [tracing](#tracing)|`agent.trace`|
+|`log`|Set the log level. Accepted values are: fatal, panic, critical, error, warn, info (default), debug, trace.|`agent.log=debug`|
+|`server_addr`|Set the ttRPC server address. The default value is `vsock://-1:1024`|`agent.server_address=unix:///path/to/server.socket`|
+|`hotplug_timeout`|Set the hotplug timeout in seconds. The default value is 3.|`agent.hotplug_timeout=10`|
+|`debug_console_vport`|Set the debug console `vsock` port. Used when debugging for Cloud Hypervisor and Firecracker hypervisors. The default value is 0.|`agent.debug_console_vport=1026`|
+|`log_vport`|Set the `vsock` log port. The default value is 0.|`agent.log_vport=5555`|
+|`container_pipe_size`|Set the container pipe size. The default size is 0.|`agent.container_pipe_size=1024`|
+|`unified_cgroup_hierarchy`|Whether to use unified cgroup hierarchy or not. Accepted values are: true, false (default)|`agent.unified_cgroup_hierarchy=true`|
+
+Alternatively those options can be defined in a configuration file (see a sample file [here](samples/configuration-all-endpoints.toml)) and then passed via `agent.config_file` kernel parameter (note that the file must be in the guest's filesystem). Or if the agent is running in [stand alone](#run-the-agent-stand-alone) mode, you can pass the file's path via `--config` parameter.
+
+Some use cases may require that the agent's API have endpoints blocked (all are allowed by default). If you have such as requirement then you can define a list of only allowed endpoints in the agent configuration file, by writing the list in the `allowed` property under the `[endpoints]` section. See in the sample file [here](samples/configuration-all-endpoints.toml) as an example.
+
+The `KATA_AGENT_SERVER_ADDR`, `KATA_AGENT_LOG_LEVEL`, and `KATA_AGENT_TRACING` environment variables are also recognized by the agent process. They are equivalent to the `agent.server_addr`, `agent.log`, and `agent.trace` options respectively.
+
 ## Custom guest image and kernel assets
 
 If you wish to develop or test changes to the agent, you will need to create a

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -24,9 +24,15 @@ const CONTAINER_PIPE_SIZE_OPTION: &str = "agent.container_pipe_size";
 const UNIFIED_CGROUP_HIERARCHY_OPTION: &str = "agent.unified_cgroup_hierarchy";
 const CONFIG_FILE: &str = "agent.config_file";
 
+const DEFAULT_DEBUG_CONSOLE: bool = false;
+const DEFAULT_DEBUG_CONSOLE_VPORT: i32 = 0;
+const DEFAULT_DEV_MODE: bool = false;
 const DEFAULT_LOG_LEVEL: slog::Level = slog::Level::Info;
+const DEFAULT_LOG_VPORT: i32 = 0;
 const DEFAULT_HOTPLUG_TIMEOUT: time::Duration = time::Duration::from_secs(3);
 const DEFAULT_CONTAINER_PIPE_SIZE: i32 = 0;
+const DEFAULT_TRACING: bool = false;
+const DEFAULT_UNIFIED_CGROUP_HIERARCHY: bool = false;
 const VSOCK_ADDR: &str = "vsock://-1";
 const VSOCK_PORT: u16 = 1024;
 
@@ -140,16 +146,16 @@ macro_rules! parse_cmdline_param {
 impl Default for AgentConfig {
     fn default() -> Self {
         AgentConfig {
-            debug_console: false,
-            dev_mode: false,
+            debug_console: DEFAULT_DEBUG_CONSOLE,
+            dev_mode: DEFAULT_DEV_MODE,
             log_level: DEFAULT_LOG_LEVEL,
             hotplug_timeout: DEFAULT_HOTPLUG_TIMEOUT,
-            debug_console_vport: 0,
-            log_vport: 0,
+            debug_console_vport: DEFAULT_DEBUG_CONSOLE_VPORT,
+            log_vport: DEFAULT_LOG_VPORT,
             container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
             server_addr: format!("{}:{}", VSOCK_ADDR, VSOCK_PORT),
-            unified_cgroup_hierarchy: false,
-            tracing: false,
+            unified_cgroup_hierarchy: DEFAULT_UNIFIED_CGROUP_HIERARCHY,
+            tracing: DEFAULT_TRACING,
             endpoints: Default::default(),
             supports_seccomp: rpc::have_seccomp(),
         }


### PR DESCRIPTION
The information about the configuration options of the agent is spread in documents and is incomplete. Let's have it proper documented.

While here I am sending a small change to the config.rs file.

Fixes: #4015