### PR TITLE
runtime: delete debug option in virtiofsd

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -125,7 +125,8 @@ virtio_fs_cache_size = @DEFVIRTIOFSCACHESIZE@
 #
 # Format example:
 #   ["-o", "arg1=xxx,arg2", "-o", "hello world", "--arg3=yyy"]
-#
+# Examples:
+#   Set virtiofsd log level to debug : ["-o", "log_level=debug"] or ["-d"]
 # see `virtiofsd -h` for possible options.
 virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -168,6 +168,8 @@ virtio_fs_cache_size = @DEFVIRTIOFSCACHESIZE@
 #
 # Format example:
 #   ["-o", "arg1=xxx,arg2", "-o", "hello world", "--arg3=yyy"]
+# Examples:
+#   Set virtiofsd log level to debug : ["-o", "log_level=debug"] or ["-d"]
 #
 # see `virtiofsd -h` for possible options.
 virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -234,7 +234,6 @@ func (clh *cloudHypervisor) createVirtiofsDaemon(sharedPath string) (VirtiofsDae
 		sourcePath: sharedPath,
 		socketPath: virtiofsdSocketPath,
 		extraArgs:  clh.config.VirtioFSExtraArgs,
-		debug:      clh.config.Debug,
 		cache:      clh.config.VirtioFSCache,
 	}, nil
 }
@@ -302,7 +301,6 @@ func (clh *cloudHypervisor) loadVirtiofsDaemon(sharedPath string) (VirtiofsDaemo
 	return &virtiofsd{
 		PID:        clh.state.VirtiofsDaemonPid,
 		sourcePath: sharedPath,
-		debug:      clh.config.Debug,
 		socketPath: virtiofsdSocketPath,
 	}, nil
 }

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -499,7 +499,6 @@ func (q *qemu) createVirtiofsDaemon(sharedPath string) (VirtiofsDaemon, error) {
 		sourcePath: sharedPath,
 		socketPath: virtiofsdSocketPath,
 		extraArgs:  q.config.VirtioFSExtraArgs,
-		debug:      q.config.Debug,
 		cache:      q.config.VirtioFSCache,
 	}, nil
 }

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -70,8 +70,6 @@ type virtiofsd struct {
 	sourcePath string
 	// extraArgs list of extra args to append to virtiofsd command
 	extraArgs []string
-	// debug flag
-	debug bool
 	// PID process ID of virtiosd process
 	PID int
 }
@@ -199,14 +197,8 @@ func (v *virtiofsd) args(FdSocketNumber uint) ([]string, error) {
 		"-o", "source=" + v.sourcePath,
 		// fd number of vhost-user socket
 		fmt.Sprintf("--fd=%v", FdSocketNumber),
-	}
-
-	if v.debug {
-		// enable debug output (implies -f)
-		args = append(args, "-d")
-	} else {
 		// foreground operation
-		args = append(args, "-f")
+		"-f",
 	}
 
 	if len(v.extraArgs) != 0 {

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -22,7 +22,6 @@ func TestVirtiofsdStart(t *testing.T) {
 		cache      string
 		extraArgs  []string
 		sourcePath string
-		debug      bool
 		PID        int
 		ctx        context.Context
 	}
@@ -58,7 +57,6 @@ func TestVirtiofsdStart(t *testing.T) {
 				cache:      tt.fields.cache,
 				extraArgs:  tt.fields.extraArgs,
 				sourcePath: tt.fields.sourcePath,
-				debug:      tt.fields.debug,
 				PID:        tt.fields.PID,
 				ctx:        tt.fields.ctx,
 			}
@@ -86,7 +84,6 @@ func TestVirtiofsdArgs(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))
 
-	v.debug = false
 	expected = "--syslog -o cache=none -o no_posix_lock -o source=/run/kata-shared/foo --fd=456 -f"
 	args, err = v.args(456)
 	assert.NoError(err)


### PR DESCRIPTION
virtiofsd's debug will be enabled if hypervisor's debug has been
enabled, this will generate too many noisy logs from virtiofsd.

Unbind the relationship of log level between virtiofsd and
hypervisor, if users want to see debug log of virtiofsd,
can set it by:

  virtio_fs_extra_args = ["-o", "log_level=debug"]

Fixes: #3303

Signed-off-by: bin <bin@hyper.sh>