### PR TITLE
runtime: no need to write virtiofsd error to log

### DIFF
--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -6,7 +6,6 @@
 package virtcontainers
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"net"
@@ -134,24 +133,14 @@ func (v *virtiofsd) Start(ctx context.Context, onQuit onQuitFunc) (int, error) {
 
 	v.Logger().WithField("path", v.path).Info()
 	v.Logger().WithField("args", strings.Join(args, " ")).Info()
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return pid, err
-	}
 
 	if err = utils.StartCmd(cmd); err != nil {
 		return pid, err
 	}
 
-	// Monitor virtiofsd's stderr and stop sandbox if virtiofsd quits
 	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			v.Logger().WithField("source", "virtiofsd").Info(scanner.Text())
-		}
-		v.Logger().Info("virtiofsd quits")
-		// Wait to release resources of virtiofsd process
 		cmd.Process.Wait()
+		v.Logger().Info("virtiofsd quits")
 		if onQuit != nil {
 			onQuit()
 		}


### PR DESCRIPTION
The scanner readis nothing from viriofsd stderr pipe, because param
'--syslog' rediercts stderr to syslog. So there is no need to write
scanner.Text() to kata log.

Fixes: #4063

Signed-off-by: tiezhuoyu <tiezhuoyu@outlook.com>