### PR TITLE
tools: add wildcard for k3s service name checking

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -62,7 +62,7 @@ function configure_cri_runtime() {
 	crio)
 		configure_crio
 		;;
-	containerd | k3s | k3s-agent)
+	containerd | k3s*)
 		configure_containerd
 		;;
 	esac


### PR DESCRIPTION
k3s service may name differently in different distribution, e.g. 
- k3s for server, k3s-agent for agent in systemd distribution, 
- k3s-service if installed from official k3s install.sh script. 
This commit put a wildcard on k3s service name, make the 
deploy script more robust.

Fixes: partially fixes #4028, more changes will come with PR #4060

Signed-off-by: Liyi Meng <liyi.meng@me.com>