### PR TITLE
test: Fix golangci-lint error for s390x

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_s390x_test.go
@@ -126,7 +126,7 @@ func TestKvmIsUsable(t *testing.T) {
 		kvmDevice = savedKvmDevice
 	}()
 
-	err = kvmIsUsable()
+	err := kvmIsUsable()
 	assert.Error(err)
 
 	err = createEmptyFile(fakeKVMDevice)


### PR DESCRIPTION
This PR is to fix a test failure for the `kata-containers-2.0-ubuntu-20.04-s390x-main-baseline` jenkins job. (See the log http://jenkins.katacontainers.io/job/kata-containers-2.0-ubuntu-20.04-s390x-main-baseline/196/console)

Fixes: #4088 
Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>