### PR TITLE
runtime: use annotation to config the numbers of NIC queue

### DIFF
--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -764,6 +764,12 @@ func addHypervisporNetworkOverrides(ocispec specs.Spec, sbConfig *vc.SandboxConf
 		return err
 	}
 
+        if err := newAnnotationConfiguration(ocispec, vcAnnotations.NumQueues).setUint(func(numQueues uint64) {
+                sbConfig.HypervisorConfig.NumQueues = uint32(numQueues)
+        }); err != nil {
+                return err
+        }
+
 	if err := newAnnotationConfiguration(ocispec, vcAnnotations.RxRateLimiterMaxRate).setUint(func(rxRateLimiterMaxRate uint64) {
 		sbConfig.HypervisorConfig.RxRateLimiterMaxRate = rxRateLimiterMaxRate
 	}); err != nil {

--- a/src/runtime/virtcontainers/documentation/api/1.0/api.md
+++ b/src/runtime/virtcontainers/documentation/api/1.0/api.md
@@ -348,6 +348,9 @@ type HypervisorConfig struct {
 	// Enable or disable different hardware features, ranging
 	// from memory encryption to both memory and CPU-state encryption and integrity.
 	ConfidentialGuest bool
+
+	// NumQueues is the number of queues for NIC
+	NumQueues uint32
 }
 ```
 

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -501,6 +501,9 @@ type HypervisorConfig struct {
 
 	// Disable selinux from the hypervisor process
 	DisableSeLinux bool
+
+	// NumQueues is the number of queues for NIC
+	NumQueues uint32
 }
 
 // vcpu mapping from vcpu number to thread number
@@ -577,6 +580,13 @@ func (conf *HypervisorConfig) Valid() error {
 	if conf.Msize9p == 0 && conf.SharedFS != config.VirtioFS {
 		conf.Msize9p = defaultMsize9p
 	}
+
+	if conf.NumQueues == 0 {
+		conf.NumQueues = conf.NumVCPUs
+	} else if conf.NumQueues > conf.NumVCPUs {
+		hvLogger.Warnf("The NumQueues should not be larger than NumVCPUs, Setting NumQueues to NumVCPUs (%d)", conf.NumVCPUs)
+		conf.NumQueues = conf.NumVCPUs
+	}	
 
 	return nil
 }

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -516,7 +516,7 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) err
 	queues := 0
 	caps := h.Capabilities(ctx)
 	if caps.IsMultiQueueSupported() {
-		queues = int(h.HypervisorConfig().NumVCPUs)
+		queues = int(h.HypervisorConfig().NumQueues)
 	}
 
 	disableVhostNet := h.HypervisorConfig().DisableVhostNet

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -229,6 +229,13 @@ const (
 
 	// EnableRootlessHypervisor is a sandbox annotation to enable rootless hypervisor (only supported in QEMU currently).
 	EnableRootlessHypervisor = kataAnnotHypervisorPrefix + "rootless"
+
+	//
+	//      NIC Multi Queue annotations
+	// 
+
+	// NumQueues is a sandbox annotation for the number of queues for NIC.
+	NumQueues = kataAnnotHypervisorPrefix + "num_queues"
 )
 
 // Runtime related annotations


### PR DESCRIPTION
The NIC multi-queue only support to use the numbers of vCPU as the numbers of queue. But sometimes it is not necessary to use all the vCPUs, so we add the function to adjust the numbers of NIC queue by annotation.

Fixes: #4087

Signed-off-by: gezhixin <2771485026@qq.com>