### PR TITLE
Drop in cfg files support

### DIFF
--- a/src/runtime/README.md
+++ b/src/runtime/README.md
@@ -87,6 +87,27 @@ following locations (in order):
 
 > **Note:** For both binaries, the first path that exists will be used.
 
+#### Drop-in configuration file fragments
+
+To enable changing configuration without changing the configuration file
+itself, drop-in configuration file fragments are supported.  Once a
+configuration file is parsed, if there is a subdirectory called `config.d` in
+the same directory as the configuration file its contents will be loaded
+in alphabetical order and each item will be parsed as a config file.  Settings
+loaded from these configuration file fragments override settings loaded from
+the main configuration file and earlier fragments.  Users are encouraged to use
+familiar naming conventions to order the fragments (e.g. `config.d/10-this`,
+`config.d/20-that` etc.).
+
+Non-existent or empty `config.d` directory is not an error (in other words, not
+using configuration file fragments is fine).  On the other hand, if fragments
+are used, they must be valid - any errors while parsing fragments (unreadable
+fragment files, contents not valid TOML) are treated the same as errors
+while parsing the main configuration file.  A `config.d` subdirectory affects
+only the `configuration.toml` _in the same directory_.  For fragments in
+`config.d` to be parsed, there has to be a valid main configuration file _in
+that location_ (it can be empty though).
+
 ### Hypervisor specific configuration
 
 Kata Containers supports multiple hypervisors so your `configuration.toml`

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1321,6 +1321,11 @@ func decodeConfig(configPath string) (tomlConfig, string, error) {
 		return tomlConf, resolved, err
 	}
 
+	err = decodeDropIns(resolved, &tomlConf)
+	if err != nil {
+		return tomlConf, resolved, err
+	}
+
 	return tomlConf, resolved, nil
 }
 


### PR DESCRIPTION
This PR adds support for drop-in configuration files stored in a `config.d` directory at the same path where the main `configuration.toml` file is located.

The PR is meant to be backwards-compatible - if no drop-in directory is found or if it's empty, the current behaviour is preserved.  Drop-ins will only override the specific settings that they contain, there should be no collateral damage to other settings loaded from the main `configuration.toml` anywhere in the configuration.  Drop-in files handling aims to follow existing conventions - the files are evaluated in alphabetical order and the last one to modify a specific setting wins.

Individual commits in this series are ordered bottom-up so that earlier commits build up foundations that later commits then use until the new functionality is finally fully integrated into pre-existing code in the last commit.

