### PR TITLE
agent: modify the type of swappiness to u64

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -391,7 +391,7 @@ fn set_memory_resources(cg: &cgroups::Cgroup, memory: &LinuxMemory, update: bool
 
     if let Some(swappiness) = memory.swappiness {
         if (0..=100).contains(&swappiness) {
-            mem_controller.set_swappiness(swappiness as u64)?;
+            mem_controller.set_swappiness(swappiness)?;
         } else {
             return Err(anyhow!(
                 "invalid value:{}. valid memory swappiness range is 0-100",

--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -265,7 +265,7 @@ pub fn resources_grpc_to_oci(res: &grpc::LinuxResources) -> oci::LinuxResources 
             swap: Some(mem.Swap),
             kernel: Some(mem.Kernel),
             kernel_tcp: Some(mem.KernelTCP),
-            swappiness: Some(mem.Swappiness as i64),
+            swappiness: Some(mem.Swappiness),
             disable_oom_killer: Some(mem.DisableOOMKiller),
         })
     } else {

--- a/src/libs/oci/src/lib.rs
+++ b/src/libs/oci/src/lib.rs
@@ -381,7 +381,7 @@ pub struct LinuxMemory {
     #[serde(default, skip_serializing_if = "Option::is_none", rename = "kernelTCP")]
     pub kernel_tcp: Option<i64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub swappiness: Option<i64>,
+    pub swappiness: Option<u64>,
     #[serde(
         default,
         skip_serializing_if = "Option::is_none",

--- a/src/tools/agent-ctl/src/utils.rs
+++ b/src/tools/agent-ctl/src/utils.rs
@@ -400,7 +400,7 @@ fn memory_oci_to_ttrpc(
             Swap: mem.swap.unwrap_or(0),
             Kernel: mem.kernel.unwrap_or(0),
             KernelTCP: mem.kernel_tcp.unwrap_or(0),
-            Swappiness: mem.swappiness.unwrap_or(0) as u64,
+            Swappiness: mem.swappiness.unwrap_or(0),
             DisableOOMKiller: mem.disable_oom_killer.unwrap_or(false),
             unknown_fields: protobuf::UnknownFields::new(),
             cached_size: protobuf::CachedSize::default(),


### PR DESCRIPTION
The type of MemorySwappiness in runtime is uint64, and the type of swappiness in agent is int64,
    if we set max uint64 in runtime and pass it to agent, the value will be equal to -1. We should
    modify the type of swappiness to u64

Fixes: https://github.com/kata-containers/kata-containers/issues/4123

Signed-off-by: yangfeiyu <yangfeiyu20102011@163.com>