### PR TITLE
agent: add tests for create_logger_task function

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -416,3 +416,59 @@ fn reset_sigpipe() {
 
 use crate::config::AgentConfig;
 use std::os::unix::io::{FromRawFd, RawFd};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_utils::test_utils::TestUserType;
+
+    #[tokio::test]
+    async fn test_create_logger_task() {
+        #[derive(Debug)]
+        struct TestData {
+            vsock_port: u32,
+            test_user: TestUserType,
+            result: Result<()>,
+        }
+
+        let tests = &[
+            TestData {
+                // non-root user cannot use privileged vsock port
+                vsock_port: 1,
+                test_user: TestUserType::NonRootOnly,
+                result: Err(anyhow!(nix::errno::Errno::from_i32(libc::EACCES))),
+            },
+            TestData {
+                // passing vsock_port 0 causes logger task to write to stdout
+                vsock_port: 0,
+                test_user: TestUserType::Any,
+                result: Ok(()),
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            if d.test_user == TestUserType::RootOnly {
+                skip_if_not_root!();
+            } else if d.test_user == TestUserType::NonRootOnly {
+                skip_if_root!();
+            }
+
+            let msg = format!("test[{}]: {:?}", i, d);
+            let (rfd, wfd) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
+            defer!({
+                // rfd is closed by the use of PipeStream in the crate_logger_task function,
+                // but we will attempt to close in case of a failure
+                let _ = unistd::close(rfd);
+                unistd::close(wfd).unwrap();
+            });
+
+            let (shutdown_tx, shutdown_rx) = channel(true);
+
+            shutdown_tx.send(true).unwrap();
+            let result = create_logger_task(rfd, d.vsock_port, shutdown_rx).await;
+
+            let msg = format!("{}, result: {:?}", msg, result);
+            assert_result!(d.result, result, msg);
+        }
+    }
+}

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -1017,6 +1017,7 @@ fn parse_options(option_list: Vec<String>) -> HashMap<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::test_utils::TestUserType;
     use crate::{skip_if_not_root, skip_loop_if_not_root, skip_loop_if_root};
     use protobuf::RepeatedField;
     use protocols::agent::FSGroup;
@@ -1025,13 +1026,6 @@ mod tests {
     use std::io::Write;
     use std::path::PathBuf;
     use tempfile::tempdir;
-
-    #[derive(Debug, PartialEq)]
-    enum TestUserType {
-        RootOnly,
-        NonRootOnly,
-        Any,
-    }
 
     #[test]
     fn test_mount() {

--- a/src/agent/src/test_utils.rs
+++ b/src/agent/src/test_utils.rs
@@ -5,7 +5,14 @@
 #![allow(clippy::module_inception)]
 
 #[cfg(test)]
-mod test_utils {
+pub mod test_utils {
+    #[derive(Debug, PartialEq)]
+    pub enum TestUserType {
+        RootOnly,
+        NonRootOnly,
+        Any,
+    }
+
     #[macro_export]
     macro_rules! skip_if_root {
         () => {


### PR DESCRIPTION
Add tests for create_logger_task function in src/main.rs.

Fixes: #4113

Signed-off-by: Braden Rayhorn <bradenrayhorn@fastmail.com>

I am interested in feedback on ideas for being able to test more with this function. One particular problem I ran into when trying to add more tests was getting the `util::get_vsock_stream` future used in `create_logger_task` to complete execution.