### PR TITLE
vendor: Update url for governance.md

### DIFF
--- a/src/runtime/vendor/google.golang.org/grpc/CONTRIBUTING.md
+++ b/src/runtime/vendor/google.golang.org/grpc/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # How to contribute
 
 We definitely welcome your patches and contributions to gRPC! Please read the gRPC
-organization's [governance rules](https://github.com/grpc/grpc-community/blob/master/governance.md)
-and [contribution guidelines](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md) before proceeding.
+organization's [governance rules](https://github.com/grpc/grpc-community/blob/main/governance.md)
+and [contribution guidelines](https://github.com/grpc/grpc-community/blob/main/CONTRIBUTING.md) before proceeding.
 
 If you are new to github, please start by reading [Pull Request howto](https://help.github.com/articles/about-pull-requests/)
 

--- a/src/runtime/vendor/google.golang.org/grpc/GOVERNANCE.md
+++ b/src/runtime/vendor/google.golang.org/grpc/GOVERNANCE.md
@@ -1,1 +1,1 @@
-This repository is governed by the gRPC organization's [governance rules](https://github.com/grpc/grpc-community/blob/master/governance.md).
+This repository is governed by the gRPC organization's [governance rules](https://github.com/grpc/grpc-community/blob/main/governance.md).

--- a/src/runtime/vendor/google.golang.org/grpc/MAINTAINERS.md
+++ b/src/runtime/vendor/google.golang.org/grpc/MAINTAINERS.md
@@ -2,9 +2,9 @@ This page lists all active maintainers of this repository. If you were a
 maintainer and would like to add your name to the Emeritus list, please send us a
 PR.
 
-See [GOVERNANCE.md](https://github.com/grpc/grpc-community/blob/master/governance.md)
+See [GOVERNANCE.md](https://github.com/grpc/grpc-community/blob/main/governance.md)
 for governance guidelines and how to become a maintainer.
-See [CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/master/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/grpc/grpc-community/blob/main/CONTRIBUTING.md)
 for general contribution guidelines.
 
 ## Maintainers (in alphabetical order)


### PR DESCRIPTION
This PR updates the url for the goverance.md document.

Fixes #4133

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>