### PR TITLE
Fix Go unit tests to clean up /tmp after themselves

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/create_test.go
@@ -50,7 +50,6 @@ func TestCreateSandboxSuccess(t *testing.T) {
 	}()
 
 	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
-	// defer os.RemoveAll(tmpdir)
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -99,7 +98,6 @@ func TestCreateSandboxFail(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -137,7 +135,6 @@ func TestCreateSandboxConfigFail(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, bundlePath, _ := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -187,7 +184,6 @@ func TestCreateContainerSuccess(t *testing.T) {
 	}
 
 	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -227,7 +223,6 @@ func TestCreateContainerFail(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -278,7 +273,6 @@ func TestCreateContainerConfigFail(t *testing.T) {
 	}()
 
 	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)

--- a/src/runtime/pkg/containerd-shim-v2/delete_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/delete_test.go
@@ -7,7 +7,6 @@
 package containerdshim
 
 import (
-	"os"
 	"testing"
 
 	taskAPI "github.com/containerd/containerd/runtime/v2/task"
@@ -25,8 +24,8 @@ func TestDeleteContainerSuccessAndFail(t *testing.T) {
 		MockID: testSandboxID,
 	}
 
-	rootPath, bundlePath, _ := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(rootPath)
+	_, bundlePath, _ := ktu.SetupOCIConfigFile(t)
+
 	_, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
 

--- a/src/runtime/pkg/containerd-shim-v2/service_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/service_test.go
@@ -41,8 +41,7 @@ func TestServiceCreate(t *testing.T) {
 
 	assert := assert.New(t)
 
-	tmpdir, bundleDir, _ := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
+	_, bundleDir, _ := ktu.SetupOCIConfigFile(t)
 
 	ctx := context.Background()
 

--- a/src/runtime/pkg/katatestutils/utils.go
+++ b/src/runtime/pkg/katatestutils/utils.go
@@ -346,11 +346,10 @@ func IsInGitHubActions() bool {
 func SetupOCIConfigFile(t *testing.T) (rootPath string, bundlePath, ociConfigFile string) {
 	assert := assert.New(t)
 
-	tmpdir, err := os.MkdirTemp("", "katatest-")
-	assert.NoError(err)
+	tmpdir := t.TempDir()
 
 	bundlePath = filepath.Join(tmpdir, "bundle")
-	err = os.MkdirAll(bundlePath, testDirMode)
+	err := os.MkdirAll(bundlePath, testDirMode)
 	assert.NoError(err)
 
 	ociConfigFile = filepath.Join(bundlePath, "config.json")

--- a/src/runtime/pkg/katautils/create_test.go
+++ b/src/runtime/pkg/katautils/create_test.go
@@ -212,7 +212,6 @@ func TestCreateSandboxConfigFail(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, bundlePath, _ := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -246,7 +245,6 @@ func TestCreateSandboxFail(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, bundlePath, _ := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -269,7 +267,6 @@ func TestCreateSandboxAnnotations(t *testing.T) {
 	assert := assert.New(t)
 
 	tmpdir, bundlePath, _ := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
 
 	runtimeConfig, err := newTestRuntimeConfig(tmpdir, testConsole, true)
 	assert.NoError(err)
@@ -342,8 +339,7 @@ func TestCheckForFips(t *testing.T) {
 func TestCreateContainerContainerConfigFail(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
+	_, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
 
 	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
@@ -370,8 +366,7 @@ func TestCreateContainerContainerConfigFail(t *testing.T) {
 func TestCreateContainerFail(t *testing.T) {
 	assert := assert.New(t)
 
-	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
+	_, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
 
 	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)
@@ -405,8 +400,7 @@ func TestCreateContainer(t *testing.T) {
 		mockSandbox.CreateContainerFunc = nil
 	}()
 
-	tmpdir, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
-	defer os.RemoveAll(tmpdir)
+	_, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
 
 	spec, err := compatoci.ParseConfigJSON(bundlePath)
 	assert.NoError(err)

--- a/src/runtime/pkg/katautils/hook_test.go
+++ b/src/runtime/pkg/katautils/hook_test.go
@@ -22,6 +22,7 @@ var testContainerIDHook = "test-container-id"
 var testControllerIDHook = "test-controller-id"
 var testBinHookPath = "mockhook/hook"
 var testBundlePath = "/test/bundle"
+var mockHookLogFile = "/tmp/mock_hook.log"
 
 func getMockHookBinPath() string {
 	return testBinHookPath
@@ -49,12 +50,17 @@ func createWrongHook() specs.Hook {
 	}
 }
 
+func cleanMockHookLogFile() {
+	_ = os.Remove(mockHookLogFile)
+}
+
 func TestRunHook(t *testing.T) {
 	if tc.NotValid(ktu.NeedRoot()) {
 		t.Skip(ktu.TestDisabledNeedRoot)
 	}
 
 	assert := assert.New(t)
+	t.Cleanup(cleanMockHookLogFile)
 
 	ctx := context.Background()
 	spec := specs.Spec{}
@@ -87,6 +93,7 @@ func TestPreStartHooks(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	t.Cleanup(cleanMockHookLogFile)
 
 	ctx := context.Background()
 
@@ -129,6 +136,7 @@ func TestPostStartHooks(t *testing.T) {
 	}
 
 	assert := assert.New(t)
+	t.Cleanup(cleanMockHookLogFile)
 
 	ctx := context.Background()
 
@@ -173,6 +181,7 @@ func TestPostStopHooks(t *testing.T) {
 	assert := assert.New(t)
 
 	ctx := context.Background()
+	t.Cleanup(cleanMockHookLogFile)
 
 	// Hooks field is nil
 	spec := specs.Spec{}

--- a/src/runtime/virtcontainers/factory/cache/cache_test.go
+++ b/src/runtime/virtcontainers/factory/cache/cache_test.go
@@ -13,14 +13,12 @@ import (
 
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/factory/direct"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/fs"
 )
 
 func TestTemplateFactory(t *testing.T) {
 	assert := assert.New(t)
 
-	testDir := fs.MockStorageRootPath()
-	defer fs.MockStorageDestroy()
+	testDir := t.TempDir()
 
 	hyperConfig := vc.HypervisorConfig{
 		KernelPath: testDir,

--- a/src/runtime/virtcontainers/factory/direct/direct_test.go
+++ b/src/runtime/virtcontainers/factory/direct/direct_test.go
@@ -12,14 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/fs"
 )
 
 func TestTemplateFactory(t *testing.T) {
 	assert := assert.New(t)
 
-	testDir := fs.MockStorageRootPath()
-	defer fs.MockStorageDestroy()
+	testDir := t.TempDir()
 
 	hyperConfig := vc.HypervisorConfig{
 		KernelPath: testDir,

--- a/src/runtime/virtcontainers/factory/factory_test.go
+++ b/src/runtime/virtcontainers/factory/factory_test.go
@@ -12,7 +12,6 @@ import (
 
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/factory/base"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/mock"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 	"github.com/sirupsen/logrus"
@@ -39,10 +38,10 @@ func TestNewFactory(t *testing.T) {
 	_, err = NewFactory(ctx, config, false)
 	assert.Error(err)
 
-	defer fs.MockStorageDestroy()
+	testDir := t.TempDir()
 	config.VMConfig.HypervisorConfig = vc.HypervisorConfig{
-		KernelPath: fs.MockStorageRootPath(),
-		ImagePath:  fs.MockStorageRootPath(),
+		KernelPath: testDir,
+		ImagePath:  testDir,
 	}
 
 	// direct
@@ -69,7 +68,7 @@ func TestNewFactory(t *testing.T) {
 	defer hybridVSockTTRPCMock.Stop()
 
 	config.Template = true
-	config.TemplatePath = fs.MockStorageRootPath()
+	config.TemplatePath = testDir
 	f, err = NewFactory(ctx, config, false)
 	assert.Nil(err)
 	f.CloseFactory(ctx)
@@ -134,8 +133,7 @@ func TestCheckVMConfig(t *testing.T) {
 	err = checkVMConfig(config1, config2)
 	assert.Nil(err)
 
-	testDir := fs.MockStorageRootPath()
-	defer fs.MockStorageDestroy()
+	testDir := t.TempDir()
 
 	config1.HypervisorConfig = vc.HypervisorConfig{
 		KernelPath: testDir,
@@ -155,8 +153,7 @@ func TestCheckVMConfig(t *testing.T) {
 func TestFactoryGetVM(t *testing.T) {
 	assert := assert.New(t)
 
-	testDir := fs.MockStorageRootPath()
-	defer fs.MockStorageDestroy()
+	testDir := t.TempDir()
 
 	hyperConfig := vc.HypervisorConfig{
 		KernelPath: testDir,
@@ -321,8 +318,7 @@ func TestDeepCompare(t *testing.T) {
 	config.VMConfig = vc.VMConfig{
 		HypervisorType: vc.MockHypervisor,
 	}
-	testDir := fs.MockStorageRootPath()
-	defer fs.MockStorageDestroy()
+	testDir := t.TempDir()
 
 	config.VMConfig.HypervisorConfig = vc.HypervisorConfig{
 		KernelPath: testDir,

--- a/src/runtime/virtcontainers/factory/template/template_test.go
+++ b/src/runtime/virtcontainers/factory/template/template_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/mock"
 )
 
@@ -32,8 +31,7 @@ func TestTemplateFactory(t *testing.T) {
 
 	templateWaitForAgent = 1 * time.Microsecond
 
-	testDir := fs.MockStorageRootPath()
-	defer fs.MockStorageDestroy()
+	testDir := t.TempDir()
 
 	hyperConfig := vc.HypervisorConfig{
 		KernelPath: testDir,

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -27,6 +27,7 @@ import (
 	hv "github.com/kata-containers/kata-containers/src/runtime/pkg/hypervisors"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/device/config"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/firecracker/client"
 	models "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/firecracker/client/models"
 	ops "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/firecracker/client/operations"
@@ -84,8 +85,6 @@ const (
 	fcMetricsFifo = "metrics.fifo"
 
 	defaultFcConfig = "fcConfig.json"
-	// storagePathSuffix mirrors persist/fs/fs.go:storagePathSuffix
-	storagePathSuffix = "vc"
 )
 
 // Specify the minimum version of firecracker supported
@@ -244,7 +243,7 @@ func (fc *firecracker) setPaths(hypervisorConfig *HypervisorConfig) {
 	// <cgroups_base>/<exec_file_name>/<id>/
 	hypervisorName := filepath.Base(hypervisorConfig.HypervisorPath)
 	//fs.RunStoragePath cannot be used as we need exec perms
-	fc.chrootBaseDir = filepath.Join("/run", storagePathSuffix)
+	fc.chrootBaseDir = filepath.Join("/run", fs.StoragePathSuffix)
 
 	fc.vmPath = filepath.Join(fc.chrootBaseDir, hypervisorName, fc.id)
 	fc.jailerRoot = filepath.Join(fc.vmPath, "root") // auto created by jailer

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -191,8 +191,7 @@ func TestKataAgentSendReq(t *testing.T) {
 func TestHandleEphemeralStorage(t *testing.T) {
 	k := kataAgent{}
 	var ociMounts []specs.Mount
-	mountSource := "/tmp/mountPoint"
-	os.Mkdir(mountSource, 0755)
+	mountSource := t.TempDir()
 
 	mount := specs.Mount{
 		Type:   KataEphemeralDevType,
@@ -212,8 +211,7 @@ func TestHandleEphemeralStorage(t *testing.T) {
 func TestHandleLocalStorage(t *testing.T) {
 	k := kataAgent{}
 	var ociMounts []specs.Mount
-	mountSource := "/tmp/mountPoint"
-	os.Mkdir(mountSource, 0755)
+	mountSource := t.TempDir()
 
 	mount := specs.Mount{
 		Type:   KataLocalDevType,
@@ -688,8 +686,7 @@ func TestHandleShm(t *testing.T) {
 	// In case the type of mount is ephemeral, the container mount is not
 	// shared with the sandbox shm.
 	ociMounts[0].Type = KataEphemeralDevType
-	mountSource := "/tmp/mountPoint"
-	os.Mkdir(mountSource, 0755)
+	mountSource := t.TempDir()
 	ociMounts[0].Source = mountSource
 	k.handleShm(ociMounts, sandbox)
 

--- a/src/runtime/virtcontainers/mount_test.go
+++ b/src/runtime/virtcontainers/mount_test.go
@@ -381,6 +381,12 @@ func TestBindMountFailingMount(t *testing.T) {
 	assert.Error(err)
 }
 
+func cleanupFooMount() {
+	dest := filepath.Join(testDir, "fooDirDest")
+
+	syscall.Unmount(dest, 0)
+}
+
 func TestBindMountSuccessful(t *testing.T) {
 	assert := assert.New(t)
 	if tc.NotValid(ktu.NeedRoot()) {
@@ -389,9 +395,7 @@ func TestBindMountSuccessful(t *testing.T) {
 
 	source := filepath.Join(testDir, "fooDirSrc")
 	dest := filepath.Join(testDir, "fooDirDest")
-	syscall.Unmount(dest, 0)
-	os.Remove(source)
-	os.Remove(dest)
+	t.Cleanup(cleanupFooMount)
 
 	err := os.MkdirAll(source, mountPerm)
 	assert.NoError(err)
@@ -401,8 +405,6 @@ func TestBindMountSuccessful(t *testing.T) {
 
 	err = bindMount(context.Background(), source, dest, false, "private")
 	assert.NoError(err)
-
-	syscall.Unmount(dest, 0)
 }
 
 func TestBindMountReadonlySuccessful(t *testing.T) {
@@ -413,9 +415,7 @@ func TestBindMountReadonlySuccessful(t *testing.T) {
 
 	source := filepath.Join(testDir, "fooDirSrc")
 	dest := filepath.Join(testDir, "fooDirDest")
-	syscall.Unmount(dest, 0)
-	os.Remove(source)
-	os.Remove(dest)
+	t.Cleanup(cleanupFooMount)
 
 	err := os.MkdirAll(source, mountPerm)
 	assert.NoError(err)
@@ -425,8 +425,6 @@ func TestBindMountReadonlySuccessful(t *testing.T) {
 
 	err = bindMount(context.Background(), source, dest, true, "private")
 	assert.NoError(err)
-
-	defer syscall.Unmount(dest, 0)
 
 	// should not be able to create file in read-only mount
 	destFile := filepath.Join(dest, "foo")
@@ -442,9 +440,7 @@ func TestBindMountInvalidPgtypes(t *testing.T) {
 
 	source := filepath.Join(testDir, "fooDirSrc")
 	dest := filepath.Join(testDir, "fooDirDest")
-	syscall.Unmount(dest, 0)
-	os.Remove(source)
-	os.Remove(dest)
+	t.Cleanup(cleanupFooMount)
 
 	err := os.MkdirAll(source, mountPerm)
 	assert.NoError(err)

--- a/src/runtime/virtcontainers/persist/fs/fs.go
+++ b/src/runtime/virtcontainers/persist/fs/fs.go
@@ -29,11 +29,11 @@ const dirMode = os.FileMode(0700) | os.ModeDir
 // fileMode is the permission bits used for creating a file
 const fileMode = os.FileMode(0600)
 
-// storagePathSuffix is the suffix used for all storage paths
+// StoragePathSuffix is the suffix used for all storage paths
 //
 // Note: this very brief path represents "virtcontainers". It is as
 // terse as possible to minimise path length.
-const storagePathSuffix = "vc"
+const StoragePathSuffix = "vc"
 
 // sandboxPathSuffix is the suffix used for sandbox storage
 const sandboxPathSuffix = "sbs"
@@ -64,7 +64,7 @@ func Init() (persistapi.PersistDriver, error) {
 	return &FS{
 		sandboxState:    &persistapi.SandboxState{},
 		containerState:  make(map[string]persistapi.ContainerState),
-		storageRootPath: filepath.Join("/run", storagePathSuffix),
+		storageRootPath: filepath.Join("/run", StoragePathSuffix),
 		driverName:      "fs",
 	}, nil
 }

--- a/src/runtime/virtcontainers/persist/fs/fs_test.go
+++ b/src/runtime/virtcontainers/persist/fs/fs_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func getFsDriver() (*FS, error) {
-	driver, err := MockFSInit()
+func getFsDriver(t *testing.T) (*FS, error) {
+	driver, err := MockFSInit(t.TempDir())
 	if err != nil {
 		return nil, fmt.Errorf("failed to init fs driver")
 	}
@@ -27,16 +27,8 @@ func getFsDriver() (*FS, error) {
 	return fs.FS, nil
 }
 
-func initTestDir() func() {
-	return func() {
-		os.RemoveAll(MockStorageRootPath())
-	}
-}
-
 func TestFsLockShared(t *testing.T) {
-	defer initTestDir()()
-
-	fs, err := getFsDriver()
+	fs, err := getFsDriver(t)
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
 
@@ -61,9 +53,7 @@ func TestFsLockShared(t *testing.T) {
 }
 
 func TestFsLockExclusive(t *testing.T) {
-	defer initTestDir()()
-
-	fs, err := getFsDriver()
+	fs, err := getFsDriver(t)
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
 
@@ -89,9 +79,7 @@ func TestFsLockExclusive(t *testing.T) {
 }
 
 func TestFsDriver(t *testing.T) {
-	defer initTestDir()()
-
-	fs, err := getFsDriver()
+	fs, err := getFsDriver(t)
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
 
@@ -162,12 +150,10 @@ func TestFsDriver(t *testing.T) {
 }
 
 func TestGlobalReadWrite(t *testing.T) {
-	defer initTestDir()()
-
 	relPath := "test/123/aaa.json"
 	data := "hello this is testing global read write"
 
-	fs, err := getFsDriver()
+	fs, err := getFsDriver(t)
 	assert.Nil(t, err)
 	assert.NotNil(t, fs)
 

--- a/src/runtime/virtcontainers/persist/fs/mockfs.go
+++ b/src/runtime/virtcontainers/persist/fs/mockfs.go
@@ -30,10 +30,6 @@ func MockRunVMStoragePath() string {
 	return filepath.Join(MockStorageRootPath(), vmPathSuffix)
 }
 
-func MockStorageDestroy() {
-	os.RemoveAll(MockStorageRootPath())
-}
-
 func MockFSInit() (persistapi.PersistDriver, error) {
 	driver, err := Init()
 	if err != nil {

--- a/src/runtime/virtcontainers/persist/fs/mockfs.go
+++ b/src/runtime/virtcontainers/persist/fs/mockfs.go
@@ -13,9 +13,15 @@ import (
 	persistapi "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/api"
 )
 
+var mockTesting = false
+
 type MockFS struct {
 	// inherit from FS. Overwrite if needed.
 	*FS
+}
+
+func EnableMockTesting() {
+	mockTesting = true
 }
 
 func MockStorageRootPath() string {
@@ -45,4 +51,11 @@ func MockFSInit() (persistapi.PersistDriver, error) {
 	fsDriver.driverName = "mockfs"
 
 	return &MockFS{fsDriver}, nil
+}
+
+func MockAutoInit() (persistapi.PersistDriver, error) {
+	if mockTesting {
+		return MockFSInit()
+	}
+	return nil, nil
 }

--- a/src/runtime/virtcontainers/persist/fs/mockfs.go
+++ b/src/runtime/virtcontainers/persist/fs/mockfs.go
@@ -7,25 +7,27 @@ package fs
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	persistapi "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/api"
 )
 
-var mockTesting = false
+var mockRootPath = ""
 
 type MockFS struct {
 	// inherit from FS. Overwrite if needed.
 	*FS
 }
 
-func EnableMockTesting() {
-	mockTesting = true
+func EnableMockTesting(rootPath string) {
+	mockRootPath = rootPath
 }
 
 func MockStorageRootPath() string {
-	return filepath.Join(os.TempDir(), "vc", "mockfs")
+	if mockRootPath == "" {
+		panic("Using uninitialized mock storage root path")
+	}
+	return mockRootPath
 }
 
 func MockRunStoragePath() string {
@@ -54,7 +56,7 @@ func MockFSInit(rootPath string) (persistapi.PersistDriver, error) {
 }
 
 func MockAutoInit() (persistapi.PersistDriver, error) {
-	if mockTesting {
+	if mockRootPath != "" {
 		return MockFSInit(MockStorageRootPath())
 	}
 	return nil, nil

--- a/src/runtime/virtcontainers/persist/fs/mockfs.go
+++ b/src/runtime/virtcontainers/persist/fs/mockfs.go
@@ -36,7 +36,7 @@ func MockRunVMStoragePath() string {
 	return filepath.Join(MockStorageRootPath(), vmPathSuffix)
 }
 
-func MockFSInit() (persistapi.PersistDriver, error) {
+func MockFSInit(rootPath string) (persistapi.PersistDriver, error) {
 	driver, err := Init()
 	if err != nil {
 		return nil, fmt.Errorf("Could not create Mock FS driver: %v", err)
@@ -47,7 +47,7 @@ func MockFSInit() (persistapi.PersistDriver, error) {
 		return nil, fmt.Errorf("Could not create Mock FS driver")
 	}
 
-	fsDriver.storageRootPath = MockStorageRootPath()
+	fsDriver.storageRootPath = rootPath
 	fsDriver.driverName = "mockfs"
 
 	return &MockFS{fsDriver}, nil
@@ -55,7 +55,7 @@ func MockFSInit() (persistapi.PersistDriver, error) {
 
 func MockAutoInit() (persistapi.PersistDriver, error) {
 	if mockTesting {
-		return MockFSInit()
+		return MockFSInit(MockStorageRootPath())
 	}
 	return nil, nil
 }

--- a/src/runtime/virtcontainers/persist/fs/mockfs_test.go
+++ b/src/runtime/virtcontainers/persist/fs/mockfs_test.go
@@ -13,19 +13,19 @@ import (
 
 func TestMockAutoInit(t *testing.T) {
 	assert := assert.New(t)
-	orgMockTesting := mockTesting
+	orgMockRootPath := mockRootPath
 	defer func() {
-		mockTesting = orgMockTesting
+		mockRootPath = orgMockRootPath
 	}()
 
-	mockTesting = false
+	mockRootPath = ""
 
 	fsd, err := MockAutoInit()
 	assert.Nil(fsd)
 	assert.NoError(err)
 
 	// Testing mock driver
-	mockTesting = true
+	mockRootPath = t.TempDir()
 	fsd, err = MockAutoInit()
 	assert.NoError(err)
 	expectedFS, err := MockFSInit(MockStorageRootPath())

--- a/src/runtime/virtcontainers/persist/fs/mockfs_test.go
+++ b/src/runtime/virtcontainers/persist/fs/mockfs_test.go
@@ -28,7 +28,7 @@ func TestMockAutoInit(t *testing.T) {
 	mockTesting = true
 	fsd, err = MockAutoInit()
 	assert.NoError(err)
-	expectedFS, err := MockFSInit()
+	expectedFS, err := MockFSInit(MockStorageRootPath())
 	assert.NoError(err)
 	assert.Equal(expectedFS, fsd)
 }

--- a/src/runtime/virtcontainers/persist/fs/mockfs_test.go
+++ b/src/runtime/virtcontainers/persist/fs/mockfs_test.go
@@ -1,0 +1,34 @@
+// Copyright Red Hat.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package fs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMockAutoInit(t *testing.T) {
+	assert := assert.New(t)
+	orgMockTesting := mockTesting
+	defer func() {
+		mockTesting = orgMockTesting
+	}()
+
+	mockTesting = false
+
+	fsd, err := MockAutoInit()
+	assert.Nil(fsd)
+	assert.NoError(err)
+
+	// Testing mock driver
+	mockTesting = true
+	fsd, err = MockAutoInit()
+	assert.NoError(err)
+	expectedFS, err := MockFSInit()
+	assert.NoError(err)
+	assert.Equal(expectedFS, fsd)
+}

--- a/src/runtime/virtcontainers/persist/manager.go
+++ b/src/runtime/virtcontainers/persist/manager.go
@@ -28,12 +28,7 @@ var (
 		RootFSName:     fs.Init,
 		RootlessFSName: fs.RootlessInit,
 	}
-	mockTesting = false
 )
-
-func EnableMockTesting() {
-	mockTesting = true
-}
 
 // GetDriver returns new PersistDriver according to driver name
 func GetDriverByName(name string) (persistapi.PersistDriver, error) {
@@ -56,8 +51,9 @@ func GetDriver() (persistapi.PersistDriver, error) {
 		return nil, expErr
 	}
 
-	if mockTesting {
-		return fs.MockFSInit()
+	mock, err := fs.MockAutoInit()
+	if mock != nil || err != nil {
+		return mock, err
 	}
 
 	if rootless.IsRootless() {

--- a/src/runtime/virtcontainers/persist/manager_test.go
+++ b/src/runtime/virtcontainers/persist/manager_test.go
@@ -27,12 +27,6 @@ func TestGetDriverByName(t *testing.T) {
 
 func TestGetDriver(t *testing.T) {
 	assert := assert.New(t)
-	orgMockTesting := mockTesting
-	defer func() {
-		mockTesting = orgMockTesting
-	}()
-
-	mockTesting = false
 
 	fsd, err := GetDriver()
 	assert.NoError(err)
@@ -44,14 +38,6 @@ func TestGetDriver(t *testing.T) {
 		expectedFS, err = fs.Init()
 	}
 
-	assert.NoError(err)
-	assert.Equal(expectedFS, fsd)
-
-	// Testing mock driver
-	mockTesting = true
-	fsd, err = GetDriver()
-	assert.NoError(err)
-	expectedFS, err = fs.MockFSInit()
 	assert.NoError(err)
 	assert.Equal(expectedFS, fsd)
 }

--- a/src/runtime/virtcontainers/virtcontainers_test.go
+++ b/src/runtime/virtcontainers/virtcontainers_test.go
@@ -15,7 +15,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/fs"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 	"github.com/sirupsen/logrus"
@@ -108,7 +107,7 @@ func setupClh() {
 func TestMain(m *testing.M) {
 	var err error
 
-	persist.EnableMockTesting()
+	fs.EnableMockTesting()
 
 	flag.Parse()
 

--- a/src/runtime/virtcontainers/virtcontainers_test.go
+++ b/src/runtime/virtcontainers/virtcontainers_test.go
@@ -57,8 +57,6 @@ var testHyperstartTtySocket = ""
 // cleanUp Removes any stale sandbox/container state that can affect
 // the next test to run.
 func cleanUp() {
-	os.RemoveAll(fs.MockRunStoragePath())
-	os.RemoveAll(fs.MockRunVMStoragePath())
 	syscall.Unmount(GetSharePath(testSandboxID), syscall.MNT_DETACH|UmountNoFollow)
 	os.RemoveAll(testDir)
 	os.MkdirAll(testDir, DirMode)
@@ -107,8 +105,6 @@ func setupClh() {
 func TestMain(m *testing.M) {
 	var err error
 
-	fs.EnableMockTesting()
-
 	flag.Parse()
 
 	logger := logrus.NewEntry(logrus.New())
@@ -124,6 +120,8 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		panic(err)
 	}
+
+	fs.EnableMockTesting(filepath.Join(testDir, "mockfs"))
 
 	fmt.Printf("INFO: Creating virtcontainers test directory %s\n", testDir)
 	err = os.MkdirAll(testDir, DirMode)


### PR DESCRIPTION
A number of the Go unit tests leave things behind in `/tmp`.  As described in #4140, this isn't ideal.  Fix them to clean up after themselves.