### PR TITLE
rustjail: Add tests for hooks_grpc_to_oci

### DIFF
--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -737,4 +737,171 @@ mod tests {
             assert_eq!(d.result, result, "{}", msg);
         }
     }
+
+    #[test]
+    fn test_hooks_grpc_to_oci() {
+        #[derive(Debug)]
+        struct TestData {
+            grpchooks: grpc::Hooks,
+            result: oci::Hooks,
+        }
+
+        let tests = &[
+            TestData {
+                // Default fields
+                grpchooks: grpc::Hooks {
+                    ..Default::default()
+                },
+                result: oci::Hooks {
+                    ..Default::default()
+                },
+            },
+            TestData {
+                // All specified
+                grpchooks: grpc::Hooks {
+                    Prestart: protobuf::RepeatedField::from(Vec::from([
+                        grpc::Hook {
+                            Path: String::from("prestartpath"),
+                            Args: protobuf::RepeatedField::from(Vec::from([
+                                String::from("arg1"),
+                                String::from("arg2"),
+                            ])),
+                            Env: protobuf::RepeatedField::from(Vec::from([
+                                String::from("env1"),
+                                String::from("env2"),
+                            ])),
+                            Timeout: 10,
+                            ..Default::default()
+                        },
+                        grpc::Hook {
+                            Path: String::from("prestartpath2"),
+                            Args: protobuf::RepeatedField::from(Vec::from([
+                                String::from("arg3"),
+                                String::from("arg4"),
+                            ])),
+                            Env: protobuf::RepeatedField::from(Vec::from([
+                                String::from("env3"),
+                                String::from("env4"),
+                            ])),
+                            Timeout: 25,
+                            ..Default::default()
+                        },
+                    ])),
+                    Poststart: protobuf::RepeatedField::from(Vec::from([grpc::Hook {
+                        Path: String::from("poststartpath"),
+                        Args: protobuf::RepeatedField::from(Vec::from([
+                            String::from("arg1"),
+                            String::from("arg2"),
+                        ])),
+                        Env: protobuf::RepeatedField::from(Vec::from([
+                            String::from("env1"),
+                            String::from("env2"),
+                        ])),
+                        Timeout: 10,
+                        ..Default::default()
+                    }])),
+                    Poststop: protobuf::RepeatedField::from(Vec::from([grpc::Hook {
+                        Path: String::from("poststoppath"),
+                        Args: protobuf::RepeatedField::from(Vec::from([
+                            String::from("arg1"),
+                            String::from("arg2"),
+                        ])),
+                        Env: protobuf::RepeatedField::from(Vec::from([
+                            String::from("env1"),
+                            String::from("env2"),
+                        ])),
+                        Timeout: 10,
+                        ..Default::default()
+                    }])),
+                    ..Default::default()
+                },
+                result: oci::Hooks {
+                    prestart: Vec::from([
+                        oci::Hook {
+                            path: String::from("prestartpath"),
+                            args: Vec::from([String::from("arg1"), String::from("arg2")]),
+                            env: Vec::from([String::from("env1"), String::from("env2")]),
+                            timeout: Some(10),
+                        },
+                        oci::Hook {
+                            path: String::from("prestartpath2"),
+                            args: Vec::from([String::from("arg3"), String::from("arg4")]),
+                            env: Vec::from([String::from("env3"), String::from("env4")]),
+                            timeout: Some(25),
+                        },
+                    ]),
+                    poststart: Vec::from([oci::Hook {
+                        path: String::from("poststartpath"),
+                        args: Vec::from([String::from("arg1"), String::from("arg2")]),
+                        env: Vec::from([String::from("env1"), String::from("env2")]),
+                        timeout: Some(10),
+                    }]),
+                    poststop: Vec::from([oci::Hook {
+                        path: String::from("poststoppath"),
+                        args: Vec::from([String::from("arg1"), String::from("arg2")]),
+                        env: Vec::from([String::from("env1"), String::from("env2")]),
+                        timeout: Some(10),
+                    }]),
+                },
+            },
+            TestData {
+                // Prestart empty
+                grpchooks: grpc::Hooks {
+                    Prestart: protobuf::RepeatedField::from(Vec::from([])),
+                    Poststart: protobuf::RepeatedField::from(Vec::from([grpc::Hook {
+                        Path: String::from("poststartpath"),
+                        Args: protobuf::RepeatedField::from(Vec::from([
+                            String::from("arg1"),
+                            String::from("arg2"),
+                        ])),
+                        Env: protobuf::RepeatedField::from(Vec::from([
+                            String::from("env1"),
+                            String::from("env2"),
+                        ])),
+                        Timeout: 10,
+                        ..Default::default()
+                    }])),
+                    Poststop: protobuf::RepeatedField::from(Vec::from([grpc::Hook {
+                        Path: String::from("poststoppath"),
+                        Args: protobuf::RepeatedField::from(Vec::from([
+                            String::from("arg1"),
+                            String::from("arg2"),
+                        ])),
+                        Env: protobuf::RepeatedField::from(Vec::from([
+                            String::from("env1"),
+                            String::from("env2"),
+                        ])),
+                        Timeout: 10,
+                        ..Default::default()
+                    }])),
+                    ..Default::default()
+                },
+                result: oci::Hooks {
+                    prestart: Vec::from([]),
+                    poststart: Vec::from([oci::Hook {
+                        path: String::from("poststartpath"),
+                        args: Vec::from([String::from("arg1"), String::from("arg2")]),
+                        env: Vec::from([String::from("env1"), String::from("env2")]),
+                        timeout: Some(10),
+                    }]),
+                    poststop: Vec::from([oci::Hook {
+                        path: String::from("poststoppath"),
+                        args: Vec::from([String::from("arg1"), String::from("arg2")]),
+                        env: Vec::from([String::from("env1"), String::from("env2")]),
+                        timeout: Some(10),
+                    }]),
+                },
+            },
+        ];
+
+        for (i, d) in tests.iter().enumerate() {
+            let msg = format!("test[{}]: {:?}", i, d);
+
+            let result = hooks_grpc_to_oci(&d.grpchooks);
+
+            let msg = format!("{}, result: {:?}", msg, result);
+
+            assert_eq!(d.result, result, "{}", msg);
+        }
+    }
 }


### PR DESCRIPTION
Add test coverage for hooks_grpc_to_oci in rustjail/src/lib.rs

Fixes: #4142

Signed-off-by: Garrett Mahin <garrett.mahin@gmail.com>