### PR TITLE
runtime: add runtime loglevel config in the configuration.toml

### DIFF
--- a/src/runtime/config/configuration-acrn.toml.in
+++ b/src/runtime/config/configuration-acrn.toml.in
@@ -154,6 +154,12 @@ block_device_driver = "@DEFBLOCKSTORAGEDRIVER_ACRN@"
 # (default: disabled)
 #enable_debug = true
 #
+# Specifies the runtime debug log level
+# loglevel is valid only with enable_debug config is true
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+#loglevel = "warn"
+#
 # Internetworking model
 # Determines how the VM should be connected to the
 # the container network interface

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -216,6 +216,12 @@ block_device_driver = "virtio-blk"
 # (default: disabled)
 #enable_debug = true
 #
+# Specifies the runtime debug log level
+# loglevel is valid when enable_debug config is true
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+#loglevel = "warn"
+#
 # Internetworking model
 # Determines how the VM should be connected to the
 # the container network interface

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -277,6 +277,12 @@ kernel_modules=[]
 # (default: disabled)
 #enable_debug = true
 #
+# Specifies the runtime debug log level
+# loglevel is valid when enable_debug config is true
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+#loglevel = "warn"
+#
 # Internetworking model
 # Determines how the VM should be connected to the
 # the container network interface

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -481,6 +481,12 @@ kernel_modules=[]
 # (default: disabled)
 #enable_debug = true
 #
+# Specifies the runtime debug log level
+# loglevel is valid when enable_debug config is true
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+#loglevel = "warn"
+#
 # Internetworking model
 # Determines how the VM should be connected to the
 # the container network interface

--- a/src/runtime/pkg/katautils/config-settings.go.in
+++ b/src/runtime/pkg/katautils/config-settings.go.in
@@ -73,6 +73,7 @@ const defaultEnableIOMMU bool = false
 const defaultEnableIOMMUPlatform bool = false
 const defaultFileBackedMemRootDir string = ""
 const defaultEnableDebug bool = false
+const defaultLogLevel string = "warn"
 const defaultDisableNestingChecks bool = false
 const defaultMsize9p uint32 = 8192
 const defaultHotplugVFIOOnRootBus bool = false

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -149,6 +149,7 @@ type runtime struct {
 	SandboxBindMounts         []string `toml:"sandbox_bind_mounts"`
 	Experimental              []string `toml:"experimental"`
 	Debug                     bool     `toml:"enable_debug"`
+	LogLevel                  string   `toml:"loglevel"`
 	Tracing                   bool     `toml:"enable_tracing"`
 	DisableNewNetNs           bool     `toml:"disable_new_netns"`
 	DisableGuestSeccomp       bool     `toml:"disable_guest_seccomp"`
@@ -1104,7 +1105,14 @@ func LoadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 	}
 
 	config.Debug = tomlConf.Runtime.Debug
-	if !tomlConf.Runtime.Debug {
+	config.LogLevel, err = logrus.ParseLevel(tomlConf.Runtime.LogLevel)
+	if err != nil {
+		return "", oci.RuntimeConfig{}, err
+	}
+
+	if tomlConf.Runtime.Debug {
+		kataUtilsLogger.Logger.Level = config.LogLevel
+	} else {
 		// If debug is not required, switch back to the original
 		// default log priority, otherwise continue in debug mode.
 		kataUtilsLogger.Logger.Level = originalLoggerLevel

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -126,6 +126,8 @@ type RuntimeConfig struct {
 	Debug bool
 	Trace bool
 
+	LogLevel logrus.Level
+
 	//Determines if seccomp should be applied inside guest
 	DisableGuestSeccomp bool
 


### PR DESCRIPTION
reason: currently containerd-shim-kata-v2 binary has as an option
` -debug` to control print runtime log into the journal log.
However, runtime default log level is `warn`, which is too little
for debugging usage.
This patch adds a new config `loglevel` under runtime section  in
the configuration.toml to specifies the log level, which makes user
to select the log level simply.

Fixes: #366

Signed-off-by: flyflypeng <flyflyflypeng@gmail.com>