### PR TITLE
packaging: Fix broken path in `build-static-clh.sh`

### DIFF
--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -55,7 +55,8 @@ build_clh_from_source() {
     info "Build ${cloud_hypervisor_repo} version: ${cloud_hypervisor_version}"
     repo_dir=$(basename "${cloud_hypervisor_repo}")
     repo_dir="${repo_dir//.git}"
-    [ -d "${repo_dir}" ] || git clone "${cloud_hypervisor_repo}"
+    rm -rf "${repo_dir}"
+    git clone "${cloud_hypervisor_repo}"
     pushd "${repo_dir}"
 
     if [ -n "${cloud_hypervisor_pr}" ]; then

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -48,7 +48,7 @@ pull_clh_released_binary() {
     curl --fail -L ${cloud_hypervisor_binary} -o cloud-hypervisor-static || return 1
     mkdir -p cloud-hypervisor
     mv -f cloud-hypervisor-static cloud-hypervisor/cloud-hypervisor
-    chmod +x cloud_hypervisor/cloud-hypervisor
+    chmod +x cloud-hypervisor/cloud-hypervisor
 }
 
 build_clh_from_source() {


### PR DESCRIPTION
A recent change introduced a typo that could cause `pull_clh_released_binary()` to fail. This in turn revealed a flaw in `build_clh_from_source()` that would simply terminate the build.

This never did visible harm because kata-deploy force-builds clh from source for TDX. Fix these two anyway.

Fixes: #4151

Signed-off-by: Greg Kurz <groug@kaod.org>