### PR TITLE
kata-deploy: Add support to RKE2

### DIFF
--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -11,7 +11,25 @@ be utilized to install Kata Containers on a running Kubernetes cluster.
 
 ### Install Kata on a running Kubernetes cluster
 
-#### Installing the latest image
+#### k3s cluster
+
+For your [k3s](https://k3s.io/) cluster, run:
+
+```sh
+$ git clone github.com/kata-containers/kata-containers
+```
+
+Check and switch to the stable branch of your choice, if wanted, and then run:
+
+```bash
+$ cd kata-containers/kata-containers/tools/packaging/kata-deploy
+$ kubectl apply -f kata-rbac/base/kata-rbac.yaml
+$ kubectl apply -k kata-deploy/overlays/k3s
+```
+
+#### Vanilla Kubernetes cluster
+
+##### Installing the latest image
 
 The latest image refers to pre-release and release candidate content.  For stable releases, please, use the "stable" instructions.
 
@@ -20,7 +38,7 @@ $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-contai
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
 ```
 
-#### Installing the stable image
+##### Installing the stable image
 
 The stable image refers to the last stable releases content.
 
@@ -30,17 +48,6 @@ The stable image refers to the last stable releases content.
 ```bash
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy-stable.yaml
-```
-
-#### For your [k3s](https://k3s.io/) cluster, do:
-
-```sh
-$ GO111MODULE=auto go get github.com/kata-containers/kata-containers
-```
-
-```bash
-$ cd $GOPATH/src/github.com/kata-containers/kata-containers/tools/packaging/kata-deploy
-$ kubectl apply -k kata-deploy/overlays/k3s
 ```
 
 #### Ensure kata-deploy is ready

--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -45,7 +45,7 @@ $ kubectl apply -k kata-deploy/overlays/k3s
 
 #### Ensure kata-deploy is ready
 ```bash
-kubectl -n kube-system wait --timeout=10m --for=condition=Ready -l name=kata-deploy pod
+$ kubectl -n kube-system wait --timeout=10m --for=condition=Ready -l name=kata-deploy pod
 ```
 
 ### Run a sample workload

--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -27,6 +27,22 @@ $ kubectl apply -f kata-rbac/base/kata-rbac.yaml
 $ kubectl apply -k kata-deploy/overlays/k3s
 ```
 
+#### RKE2 cluster
+
+For your [RKE2](https://docs.rke2.io/) cluster, run:
+
+```sh
+$ git clone github.com/kata-containers/kata-containers
+```
+
+Check and switch to the stable branch of your choice, if wanted, and then run:
+
+```bash
+$ cd kata-containers/kata-containers/tools/packaging/kata-deploy
+$ kubectl apply -f kata-rbac/base/kata-rbac.yaml
+$ kubectl apply -k kata-deploy/overlays/rke2
+```
+
 #### Vanilla Kubernetes cluster
 
 ##### Installing the latest image

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../base
+
+patchesStrategicMerge:
+- mount_rke2_conf.yaml

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/mount_rke2_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/mount_rke2_conf.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kubelet-kata-cleanup
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-kata-cleanup
+        volumeMounts:
+        - name: containerd-conf
+          mountPath: /etc/containerd/
+      volumes:
+        - name: containerd-conf
+          hostPath:
+            path: /var/lib/rancher/rke2/agent/etc/containerd/

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/rke2/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/rke2/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+- ../../base
+
+patchesStrategicMerge:
+- mount_rke2_conf.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/rke2/mount_rke2_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/rke2/mount_rke2_conf.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kata-deploy
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: containerd-conf
+          hostPath:
+            path: /var/lib/rancher/rke2/agent/etc/containerd/

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -39,7 +39,11 @@ function get_container_runtime() {
                 die "invalid node name"
 	fi
 	if echo "$runtime" | grep -qE 'containerd.*-k3s'; then
-		if systemctl is-active --quiet k3s-agent; then
+		if systemctl is-active --quiet rke2-agent; then
+			echo "rke2-agent"
+		elif systemctl is-active --quiet rke2-server; then
+			echo "rke2-server"
+		elif systemctl is-active --quiet k3s-agent; then
 			echo "k3s-agent"
 		else
 			echo "k3s"
@@ -62,7 +66,7 @@ function configure_cri_runtime() {
 	crio)
 		configure_crio
 		;;
-	containerd | k3s | k3s-agent)
+	containerd | k3s | k3s-agent | rke2-agent | rke2-server)
 		configure_containerd
 		;;
 	esac
@@ -228,7 +232,7 @@ function cleanup_cri_runtime() {
 	crio)
 		cleanup_crio
 		;;
-	containerd | k3s | k3s-agent)
+	containerd | k3s | k3s-agent | rke2-agent | rke2-server)
 		cleanup_containerd
 		;;
 	esac
@@ -267,7 +271,7 @@ function main() {
 	# CRI-O isn't consistent with the naming -- let's use crio to match the service file
 	if [ "$runtime" == "cri-o" ]; then
 		runtime="crio"
-	elif [ "$runtime" == "k3s" ] || [ "$runtime" == "k3s-agent" ]; then
+	elif [ "$runtime" == "k3s" ] || [ "$runtime" == "k3s-agent" ] || [ "$runtime" == "rke2-agent" ] || [ "$runtime" == "rke2-server" ]; then
 		containerd_conf_tmpl_file="${containerd_conf_file}.tmpl"
 		if [ ! -f "$containerd_conf_tmpl_file" ]; then
 			cp "$containerd_conf_file" "$containerd_conf_tmpl_file"
@@ -290,11 +294,10 @@ function main() {
 	fi
 
 	# only install / remove / update if we are dealing with CRIO or containerd
-	if [[ "$runtime" =~ ^(crio|containerd|k3s|k3s-agent)$ ]]; then
+	if [[ "$runtime" =~ ^(crio|containerd|k3s|k3s-agent|rke2-agent|rke2-server)$ ]]; then
 
 		case "$action" in
 		install)
-
 			install_artifacts
 			configure_cri_runtime "$runtime"
 			kubectl label node "$NODE_NAME" --overwrite katacontainers.io/kata-runtime=true


### PR DESCRIPTION
"RKE2 - Rancher's Next Generation Kuberentes Distribution" can easily be
supported by kata-deploy with some simple adjustments to what we've been
relying on for "k3s".

The main differences between k3s and RKE2 are, basically:
1. The location where the containerd configuration is stored
   - k3s: /var/lib/rancher/k3s/agent/etc/containerd/
   - rke2: /var/lib/rancher/rke2/agent/etc/containerd/
2. The name of the systemd services used:
   - k3s: k3s.service or k3s-agent.service
   - rke2: rke2-server.service or rke2-agent.service

Knowing this, let's add a new overlay for RKE2, adapt the kata-deploy
and the kata-cleanup scripts, and that's it.

Fixes: #4160

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>