### PR TITLE
docs: Update containerd link to installation guide

### DIFF
--- a/docs/install/container-manager/containerd/containerd-install.md
+++ b/docs/install/container-manager/containerd/containerd-install.md
@@ -81,7 +81,7 @@
   - Download the standard `systemd(1)` service file and install to
     `/etc/systemd/system/`:
 
-    - https://raw.githubusercontent.com/containerd/containerd/master/containerd.service
+    - https://raw.githubusercontent.com/containerd/containerd/main/containerd.service
 
     > **Notes:**
     >


### PR DESCRIPTION
This PR updates the containerd url link for the installation guide

Fixes #4162

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>