### PR TITLE
agent-ctl: Fix abstract socket connections

### DIFF
--- a/src/tools/agent-ctl/README.md
+++ b/src/tools/agent-ctl/README.md
@@ -211,9 +211,11 @@ $ sudo install -o root -g root -m 0755 ~/.cargo/bin/kata-agent-ctl /usr/local/bi
 
 > **Warnings:**
 >
-> - This method is **only** for testing and development!
+> - These methods are **only** for testing and development!
 > - Only continue if you are using a non-critical system
 >   (such as a freshly installed VM environment).
+
+#### Use a Unix abstract domain socket
 
 1. Start the agent, specifying a local socket for it to communicate on:
 
@@ -233,3 +235,31 @@ $ sudo install -o root -g root -m 0755 ~/.cargo/bin/kata-agent-ctl /usr/local/bi
    >
    > The `@` in the server address is required - it denotes an abstract
    > socket which the agent requires (see `unix(7)`).
+
+#### Use a VSOCK loopback socket
+
+VSOCK supports a special CID value of `1` (known symbolically as
+`VMADDR_CID_LOCAL`) which assumes that the VM is actually
+the local environment. This is effectively a `localhost` or loopback
+interface which does not require an actual VM to be
+running.
+
+1. Start the agent, specifying the local VSOCK socket for it to communicate on:
+
+   ```sh
+   $ vsock_loopback_cid=1
+   $ agent_vsock_port=1024
+
+   $ sudo KATA_AGENT_SERVER_ADDR="vsock://${vsock_loopback_cid}:${agent_vsock_port}" target/x86_64-unknown-linux-musl/release/kata-agent
+   ```
+
+   > **Note:** This example assumes an Intel x86-64 system.
+
+1. Run the tool in the same environment:
+
+   ```sh
+   $ vsock_loopback_cid=1
+   $ agent_vsock_port=1024
+
+   $ cargo run -- -l debug connect --server-address "vsock://${vsock_loopback_cid}:${agent_vsock_port}" --bundle-dir "$bundle_dir" -c Check -c GetGuestDetails
+   ```

--- a/src/tools/agent-ctl/README.md
+++ b/src/tools/agent-ctl/README.md
@@ -4,7 +4,7 @@
 
 The Kata Containers agent control tool (`kata-agent-ctl`) is a low-level test
 tool. It allows basic interaction with the Kata Containers agent,
-`kata-agent`, that runs inside the virtual machine.
+`kata-agent`, that runs inside the virtual machine (VM).
 
 Unlike the Kata Runtime, which only ever makes sequences of correctly ordered
 and valid agent API calls, this tool allows users to make arbitrary agent API
@@ -117,7 +117,7 @@ establish the VSOCK guest CID value to connect to the agent.
 
 1. Start a Kata Container
 
-1. Establish the VSOCK guest CID number for the virtual machine:
+1. Establish the VSOCK guest CID number for the VM:
 
    ```sh
    $ guest_cid=$(sudo ss -H --vsock | awk '{print $6}' | cut -d: -f1)

--- a/src/tools/agent-ctl/src/client.rs
+++ b/src/tools/agent-ctl/src/client.rs
@@ -473,10 +473,8 @@ fn create_ttrpc_client(
             if path.starts_with('@') {
                 abstract_socket = true;
 
-                // Remove the magic abstract-socket request character ('@')
-                // and crucially add a trailing nul terminator (required to
-                // interoperate with the ttrpc crate).
-                path = path[1..].to_string() + &"\x00".to_string();
+                // Remove the magic abstract-socket request character ('@').
+                path = path[1..].to_string();
             }
 
             if abstract_socket {


### PR DESCRIPTION
Unbreak the `agent-ctl` tool connecting to the agent with a Unix domain
socket.

It appears that [1] changed the behaviour of connecting to the agent
using a local Unix socket (which is not used by Kata under normal
operation).

The change can be seen by reverting to commit
72b8144b569f1d0fef3001642f244bf79b17ddc6 (the one before [1]) and
running the agent manually as:

```bash
$ sudo KATA_AGENT_SERVER_ADDR=unix:///tmp/foo.socket target/x86_64-unknown-linux-musl/release/kata-agent
```

Before [1], in another terminal we see this:

```bash
$ sudo lsof -U 2>/dev/null |grep foo|awk '{print $9}'
@/tmp/foo.socket@
```

But now, we see the following:

```bash
$ sudo lsof -U 2>/dev/null |grep foo|awk '{print $9}'
@/tmp/foo.socket
```

Note the last byte which represents a nul (`\0`) value.

The `agent-ctl` tool used to add that trailing nul but now it seems to not
be needed, so this change removes it, restoring functionality. No
external changes are necessary so the `agent-ctl` tool can connect to
the agent as below like this:

```bash
$ cargo run -- -l debug connect --server-address "unix://@/tmp/foo.socket" --bundle-dir "$bundle_dir" -c Check -c GetGuestDetails
```

[1] - https://github.com/kata-containers/kata-containers/issues/3124

Fixes: #4164.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>