### PR TITLE
rootfs: Fix chronyd.service failing on boot

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -540,8 +540,13 @@ EOF
 
 	if [ -f "$chrony_systemd_service" ]; then
 		# Remove user option, user could not exist in the rootfs
+		# Set the /var/lib/chrony for ReadWritePaths to be ignored if
+		# its nonexistent, this broke the service on boot previously
+		# due to the directory not being present "(code=exited, status=226/NAMESPACE)"
 		sed -i -e 's/^\(ExecStart=.*\)-u [[:alnum:]]*/\1/g' \
-		       -e '/^\[Unit\]/a ConditionPathExists=\/dev\/ptp0' ${chrony_systemd_service}
+		       -e '/^\[Unit\]/a ConditionPathExists=\/dev\/ptp0' \
+		       -e 's/^ReadWritePaths=\(.\+\) \/var\/lib\/chrony \(.\+\)$/ReadWritePaths=\1 -\/var\/lib\/chrony \2/m' \
+		       ${chrony_systemd_service}
 	fi
 
 	AGENT_DIR="${ROOTFS_DIR}/usr/bin"


### PR DESCRIPTION
In at least kata versions 2.3.3 and 2.4.0 it was noticed that the guest operating system's clock would drift out of sync slowly over time whilst the pod was running.

This had previously been raised and fixed in the old reposity via [1] . In essence kvm_ptp and chrony were paired together in order to keep the system clock up to date with the host.

In the recent versions of kata metioned above, the chronyd.service fails upon boot with status `266/NAMESPACE` which seems to be due to the fact that the `/var/lib/chrony` directory no longer exists.

This change sets the `/var/lib/chrony` directory for the `ReadWritePaths` to be ignored when the directory does not exist, as per [2].

[1] https://github.com/kata-containers/runtime/issues/1279
[2] https://www.freedesktop.org/software/systemd/man/systemd.exec.html#ReadWritePaths=

Fixes: https://github.com/kata-containers/kata-containers/issues/4167

Signed-off-by: Cameron McDermott <cameron_mcdermott@yahoo.co.uk>