### PR TITLE
versions: change qemu tdx url and tag

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -100,8 +100,8 @@ assets:
         .*/v?(\d\S+)\.tar\.gz
       tdx:
         description: "VMM that uses KVM and supports TDX"
-        url: "https://github.com/intel/qemu-tdx"
-        tag: "tdx-qemu-2021.11.29-v6.0.0-rc1-mvp"
+        url: "https://github.com/intel/qemu-dcp"
+        tag: "SPR-BKC-QEMU-v2.2"
 
     qemu-experimental:
       description: "QEMU with virtiofs support"


### PR DESCRIPTION
https://github.com/intel/qemu-dcp is the new repo that supports
qemu with Intel TDX

fixes #4171

Signed-off-by: Julio Montes <julio.montes@intel.com>