### PR TITLE
runk: use custom Kill command to support --all option

### DIFF
--- a/src/tools/runk/src/commands/kill.rs
+++ b/src/tools/runk/src/commands/kill.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::Kill;
 use anyhow::{anyhow, Result};
 use libcontainer::status::{self, get_current_container_state, Status};
-use liboci_cli::Kill;
 use nix::{
     sys::signal::{kill, Signal},
     unistd::Pid,
@@ -22,7 +22,8 @@ pub fn run(opts: Kill, state_root: &Path, logger: &Logger) -> Result<()> {
 
     // TODO: liboci-cli does not support --all option for kill command.
     // After liboci-cli supports the option, we will change the following code.
-    let all = false;
+    // as a workaround we use a custom Kill command.
+    let all = opts.all;
     if all {
         let pids = status::get_all_pid(&status.cgroup_manager)?;
         for pid in pids {

--- a/src/tools/runk/src/main.rs
+++ b/src/tools/runk/src/main.rs
@@ -5,7 +5,8 @@
 
 use anyhow::{anyhow, Result};
 use clap::{crate_description, crate_name, Parser};
-use liboci_cli::{CommonCmd, GlobalOpts, StandardCmd};
+use liboci_cli::{CommonCmd, GlobalOpts};
+use liboci_cli::{Create, Delete, Start, State};
 use slog::{o, Logger};
 use slog_async::AsyncGuard;
 use std::{
@@ -25,6 +26,35 @@ enum SubCommand {
     Standard(StandardCmd),
     #[clap(flatten)]
     Common(CommonCmd),
+    #[clap(flatten)]
+    Custom(CustomCmd),
+}
+
+// Copy from https://github.com/containers/youki/blob/v0.0.3/crates/liboci-cli/src/lib.rs#L38-L44
+// but without Kill command.
+#[derive(Parser, Debug)]
+pub enum StandardCmd {
+    Create(Create),
+    Start(Start),
+    State(State),
+    Delete(Delete),
+}
+
+// as a workaround to support --all option for kill command,
+// we use a custom implementation of Kill.
+#[derive(Parser, Debug)]
+pub enum CustomCmd {
+    Kill(Kill),
+}
+
+/// Send the specified signal to the container
+#[derive(Parser, Debug)]
+pub struct Kill {
+    #[clap(forbid_empty_values = true, required = true)]
+    pub container_id: String,
+    pub signal: String,
+    #[clap(short, long)]
+    pub all: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -41,7 +71,6 @@ async fn cmd_run(subcmd: SubCommand, root_path: &Path, logger: &Logger) -> Resul
         SubCommand::Standard(cmd) => match cmd {
             StandardCmd::Create(create) => commands::create::run(create, root_path, logger).await,
             StandardCmd::Start(start) => commands::start::run(start, root_path, logger),
-            StandardCmd::Kill(kill) => commands::kill::run(kill, root_path, logger),
             StandardCmd::Delete(delete) => commands::delete::run(delete, root_path, logger).await,
             StandardCmd::State(state) => commands::state::run(state, root_path, logger),
         },
@@ -51,6 +80,9 @@ async fn cmd_run(subcmd: SubCommand, root_path: &Path, logger: &Logger) -> Resul
             _ => {
                 return Err(anyhow!("command is not implemented yet"));
             }
+        },
+        SubCommand::Custom(cmd) => match cmd {
+            CustomCmd::Kill(kill) => commands::kill::run(kill, root_path, logger),
         },
     }
 }


### PR DESCRIPTION
runk uses liboci-cli crate to parse command line options,
but liboci-cli does not support --all option for kill command,
though this is the runtime spec behavior.

But crictl will issue kill --all command when stopping containers,
as a workaround, we use a custom kill command instead of the one
provided by liboci-cli.

Fixes: #4182

Signed-off-by: Bin Liu <bin@hyper.sh>

PTAL @ManaSugi 