### PR TITLE
runtime: enable vmcache for qemu and clh

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -252,6 +252,30 @@ block_device_driver = "virtio-blk"
 # set to a non zero value.
 #disk_rate_limiter_ops_one_time_burst = 0
 
+# The number of caches of VMCache:
+# unspecified or == 0   --> VMCache is disabled
+# > 0                   --> will be set to the specified number
+#
+# VMCache is a function that creates VMs as caches before using it.
+# It helps speed up new container creation.
+# The function consists of a server and some clients communicating
+# through Unix socket.  The protocol is gRPC in protocols/cache/cache.proto.
+# The VMCache server will create some VMs and cache them by factory cache.
+# It will convert the VM to gRPC format and transport it when gets
+# requestion from clients.
+# Factory grpccache is the VMCache client.  It will request gRPC format
+# VM and convert it back to a VM.  If VMCache function is enabled,
+# kata-runtime will request VM from factory grpccache when it creates
+# a new sandbox.
+#
+# Default 0
+#vm_cache_number = 0
+
+# Specify the address of the Unix socket that is used by VMCache.
+#
+# Default /var/run/kata-containers/cache.sock
+#vm_cache_endpoint = "/var/run/kata-containers/cache.sock"
+
 [agent.@PROJECT_TYPE@]
 # If enabled, make the agent display debug-level messages.
 # (default: disabled)

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1341,8 +1341,8 @@ func checkFactoryConfig(config oci.RuntimeConfig) error {
 	}
 
 	if config.FactoryConfig.VMCacheNumber > 0 {
-		if config.HypervisorType != vc.QemuHypervisor {
-			return errors.New("VM cache just support qemu")
+		if config.HypervisorType != vc.QemuHypervisor && config.HypervisorType != vc.ClhHypervisor {
+			return errors.New("VM cache just support qemu and cloud hypervisor")
 		}
 	}
 

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -97,6 +97,14 @@ func (c *clhClientMock) BootVM(ctx context.Context) (*http.Response, error) {
 	return nil, nil
 }
 
+func (c *clhClientMock) PauseVM(ctx context.Context) (*http.Response, error) {
+	return nil, nil
+}
+
+func (c *clhClientMock) ResumeVM(ctx context.Context) (*http.Response, error) {
+	return nil, nil
+}
+
 //nolint:golint
 func (c *clhClientMock) VmResizePut(ctx context.Context, vmResize chclient.VmResize) (*http.Response, error) {
 	return nil, nil
@@ -115,6 +123,10 @@ func (c *clhClientMock) VmAddDiskPut(ctx context.Context, diskConfig chclient.Di
 //nolint:golint
 func (c *clhClientMock) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error) {
 	return nil, nil
+}
+
+func (c *clhClientMock) VmAddNetPut(ctx context.Context, netConfig chclient.NetConfig) (chclient.PciDeviceInfo, *http.Response, error) {
+	return chclient.PciDeviceInfo{}, nil, nil
 }
 
 func TestCloudHypervisorAddVSock(t *testing.T) {

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -131,6 +131,9 @@ func (v *virtiofsd) Start(ctx context.Context, onQuit onQuitFunc) (int, error) {
 	}
 	cmd.Args = append(cmd.Args, args...)
 
+	// to be a daemon process
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true,}
+
 	v.Logger().WithField("path", v.path).Info()
 	v.Logger().WithField("args", strings.Join(args, " ")).Info()
 

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -116,6 +116,13 @@ func NewVM(ctx context.Context, config VMConfig) (*VM, error) {
 		}
 	}()
 
+	// set default path if store path is not set
+	if config.HypervisorConfig.VMStorePath == "" && config.HypervisorConfig.RunStorePath == "" {
+		config.HypervisorConfig.VMStorePath = store.RunVMStoragePath()
+		config.HypervisorConfig.RunStorePath = store.RunStoragePath()
+		config.HypervisorConfig.SharedPath = buildVMSharePath(id, store.RunVMStoragePath())
+	}
+
 	if err = hypervisor.CreateVM(ctx, id, network, &config.HypervisorConfig); err != nil {
 		return nil, err
 	}
@@ -188,6 +195,12 @@ func NewVMFromGrpc(ctx context.Context, v *pb.GrpcVM, config VMConfig) (*VM, err
 		}
 	}()
 
+	// set default path if store path is not set
+	if config.HypervisorConfig.VMStorePath == "" && config.HypervisorConfig.RunStorePath == "" {
+		config.HypervisorConfig.VMStorePath = store.RunVMStoragePath()
+		config.HypervisorConfig.RunStorePath = store.RunStoragePath()
+	}
+
 	err = hypervisor.fromGrpc(ctx, &config.HypervisorConfig, v.Hypervisor)
 	if err != nil {
 		return nil, err
@@ -197,6 +210,10 @@ func NewVMFromGrpc(ctx context.Context, v *pb.GrpcVM, config VMConfig) (*VM, err
 	newAagentFunc := getNewAgentFunc(ctx)
 	agent := newAagentFunc()
 	agent.configureFromGrpc(ctx, hypervisor, v.Id, config.AgentConfig)
+	err = agent.setAgentURL()
+	if err != nil {
+		return nil, err
+	}
 
 	return &VM{
 		id:         v.Id,


### PR DESCRIPTION
1. Enable vmcache for qemu (virtio-9p and virtio-fs). The cache
server have to send context id of vsock, path and pid info of
virtiofsd to the client.
2. Enable vmacahe for clh (virtio-fs) in a similar way.
3. Set sid for clh and virtiofsd process to avoid process exit
with cache server shutdown. Add monitor in function fromGrpc to
check aliveness of virtiofsd.

Fixes: #4214

Signed-off-by: Zhuoyu Tie <tiezhuoyu@outlook.com>