### PR TITLE
docs: Update how-to-use-kata-containers-with-firecracker.md

### DIFF
--- a/docs/how-to/how-to-use-kata-containers-with-firecracker.md
+++ b/docs/how-to/how-to-use-kata-containers-with-firecracker.md
@@ -104,7 +104,7 @@ sudo dmsetup create "${POOL_NAME}" \
 
 cat << EOF
 #
-# Add this to your config.toml configuration file and restart `containerd` daemon
+# Add this to your config.toml configuration file and restart containerd daemon
 #
 [plugins]
   [plugins.devmapper]


### PR DESCRIPTION
Removed the `` around containerd, because when you execute this as a script it runs the containerd command within the script, which it shoudn't do I think