### PR TITLE
ci: Don't run Docs URL Alive Check workflow on forks

### DIFF
--- a/.github/workflows/docs-url-alive-check.yaml
+++ b/.github/workflows/docs-url-alive-check.yaml
@@ -14,31 +14,31 @@ jobs:
       target_branch: ${{ github.base_ref }}
     steps:
     - name: Install Go
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+      if: github.repository_owner == 'kata-containers'
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
       env:
         GOPATH: ${{ runner.workspace }}/kata-containers
     - name: Set env
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+      if: github.repository_owner == 'kata-containers'
       run: |
         echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Checkout code
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+      if: github.repository_owner == 'kata-containers'
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
         path: ./src/github.com/${{ github.repository }}
     - name: Setup
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+      if: github.repository_owner == 'kata-containers'
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && ./ci/setup.sh
       env:
         GOPATH: ${{ runner.workspace }}/kata-containers
     # docs url alive check
     - name: Docs URL Alive Check
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+      if: github.repository_owner == 'kata-containers'
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && make docs-url-alive-check


### PR DESCRIPTION
This workflow is a scheduled job that runs at 23:00
every Sunday, it should only run the main repo
but not the forked ones.

Fixes: #4219

**NOTE:** This is review-able but I added a DNM label for verification.

/cc @Bevisy @jodh-intel 