### PR TITLE
versions: Upgrade to Cloud Hypervisor v23.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v23.0"
+      version: "v23.1"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
The following issues have been addressed from the latest bug fix release v23.1 of Cloud Hypervisor:

1. Add some missing seccomp rules;
2. Remove virtio-fs filesystem entries from config on removal;
3. Do not delete API socket on API server start;
4. Reject virtio-mem resize if the guest doesn't activate the device;
5. Fix OpenAPI naming of I/O throttling knobs;

Fixes: #4222

Signed-off-by: Bo Chen <chen.bo@intel.com>