### PR TITLE
Build and distribute the rust version of virtiofsd

### DIFF
--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -24,6 +24,7 @@ jobs:
           - firecracker
           - rootfs-image
           - rootfs-initrd
+          - virtiofsd
     steps:
       - uses: actions/checkout@v2
       - name: Install docker

--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -47,6 +47,7 @@ jobs:
           - rootfs-image
           - rootfs-initrd
           - shim-v2
+          - virtiofsd
     steps:
       - name: get-PR-ref
         id: get-PR-ref

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
           - rootfs-image
           - rootfs-initrd
           - shim-v2
+          - virtiofsd
     steps:
       - uses: actions/checkout@v2
       - name: Install docker

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -27,7 +27,8 @@ all: cloud-hypervisor-tarball \
 	qemu-tarball \
 	rootfs-image-tarball \
 	rootfs-initrd-tarball \
-	shim-v2-tarball
+	shim-v2-tarball \
+	virtiofsd-tarball
 
 %-tarball-build: $(MK_DIR)/dockerbuild/install_yq.sh
 	$(call BUILD,$*)
@@ -55,6 +56,9 @@ rootfs-initrd-tarball:
 	${MAKE} $@-build
 
 shim-v2-tarball:
+	${MAKE} $@-build
+
+virtiofsd-tarball:
 	${MAKE} $@-build
 
 merge-builds:

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -35,6 +35,7 @@ RUN apt-get update && \
   gcc \
   git \
   make \
+  unzip \
   xz-utils && \
   apt-get clean && rm -rf /var/lib/apt/lists
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -26,6 +26,7 @@ readonly firecracker_builder="${static_build_dir}/firecracker/build-static-firec
 readonly kernel_builder="${static_build_dir}/kernel/build.sh"
 readonly qemu_builder="${static_build_dir}/qemu/build-static-qemu.sh"
 readonly shimv2_builder="${static_build_dir}/shim-v2/build.sh"
+readonly virtiofsd_builder="${static_build_dir}/virtiofsd/build-static-virtiofsd.sh"
 
 readonly rootfs_builder="${repo_root_dir}/tools/packaging/guest-image/build_image.sh"
 
@@ -76,6 +77,7 @@ options:
 	rootfs-image
 	rootfs-initrd
 	shim-v2
+	virtiofsd
 EOF
 
 	exit "${return_code}"
@@ -140,6 +142,15 @@ install_clh() {
 	sudo install -D --owner root --group root --mode 0744 cloud-hypervisor/cloud-hypervisor "${destdir}/opt/kata/bin/cloud-hypervisor"
 }
 
+# Install static virtiofsd asset
+install_virtiofsd() {
+	info "build static virtiofsd"
+	"${virtiofsd_builder}"
+	info "Install static virtiofsd"
+	mkdir -p "${destdir}/opt/kata/libexec/"
+	sudo install -D --owner root --group root --mode 0744 virtiofsd/virtiofsd "${destdir}/opt/kata/libexec/virtiofsd"
+}
+
 #Install all components that are not assets
 install_shimv2() {
 	GO_VERSION="$(yq r ${versions_yaml} languages.golang.meta.newest-version)"
@@ -166,6 +177,7 @@ handle_build() {
 		install_kernel
 		install_qemu
 		install_shimv2
+		install_virtiofsd
 		;;
 
 	cloud-hypervisor) install_clh ;;
@@ -183,6 +195,8 @@ handle_build() {
 	rootfs-initrd) install_initrd ;;
 
 	shim-v2) install_shimv2 ;;
+
+	virtiofsd) install_virtiofsd ;;
 
 	*)
 		die "Invalid build target ${build_target}"
@@ -221,6 +235,7 @@ main() {
 		rootfs-image
 		rootfs-initrd
 		shim-v2
+		virtiofsd
 	)
 	silent=false
 	while getopts "hs-:" opt; do

--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+ARCH=$(uname -m)
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+virtiofsd_version="${virtiofsd_version:-}"
+
+[ -n "$virtiofsd_version" ] || virtiofsd_version=$(get_from_kata_deps "externals.virtiofsd.version")
+[ -n "$virtiofsd_version" ] || die "failed to get virtiofsd version"
+
+if [ "${ARCH}" != "x86_64" ]; then
+	info "Only x86_64 binaries are distributed as part of the virtiofsd releases" && exit 1
+fi
+
+pull_virtiofsd_released_binary() {
+    info "Download virtiofsd version: ${virtiofsd_version}"
+    virtiofsd_zip=$(get_from_kata_deps "externals.virtiofsd.meta.binary")
+    [ -n "${virtiofsd_zip}" ] || die "failed to get virtiofsd binary URL"
+
+    mkdir -p virtiofsd
+
+    pushd virtiofsd
+    curl --fail -L ${virtiofsd_zip} -o virtiofsd.zip || return 1
+    unzip virtiofsd.zip
+    mv -f target/x86_64-unknown-linux-musl/release/virtiofsd virtiofsd
+    chmod +x virtiofsd
+    rm -rf target
+    rm virtiofsd.zip
+    popd
+}
+
+pull_virtiofsd_released_binary

--- a/versions.yaml
+++ b/versions.yaml
@@ -243,6 +243,17 @@ externals:
     url: "https://github.com/containerd/nydus-snapshotter"
     version: "v0.1.0"
 
+  virtiofsd:
+    description: "vhost-user virtio-fs device backend written in Rust"
+    url: "https://gitlab.com/virtio-fs/virtiofsd"
+    version: "v1.2.0"
+    meta:
+      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.2.0,
+      # this is the link labelled virtiofsd-v1.2.0.zip
+      #
+      # yamllint disable-line rule:line-length
+      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/b26d9891caac83209a3fdd24bcf2ae86/virtiofsd-v1.2.0.zip"
+
 languages:
   description: |
     Details of programming languages required to build system


### PR DESCRIPTION
This PR is the x86_64 kata-containers part of switching to the rust virtiofsd.  I still need to work on the tests counterpart of this PR, but we need to start from somewhere. :-)

For now we're only adding support for shipping the rust virtiofsd binary, **without** removing the C one.
The removal will be done once the tests counterpart is raised and merged.