### PR TITLE
agent: Fix is_signal_handled failing parsing str to u64

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1682,7 +1682,7 @@ fn is_signal_handled(proc_status_file: &str, signum: u32) -> bool {
                 warn!(sl!(), "parse the SigCgt field failed");
                 return false;
             }
-            let sig_cgt_str = mask_vec[1];
+            let sig_cgt_str = mask_vec[1].trim();
             let sig_cgt_mask = match u64::from_str_radix(sig_cgt_str, 16) {
                 Ok(h) => h,
                 Err(_) => {
@@ -2450,6 +2450,26 @@ OtherField:other
             },
             TestData {
                 status_file_data: Some("SigCgt:000000004b813efb"),
+                signum: 4,
+                result: true,
+            },
+            TestData {
+                status_file_data: Some("SigCgt:\t000000004b813efb"),
+                signum: 4,
+                result: true,
+            },
+            TestData {
+                status_file_data: Some("SigCgt: 000000004b813efb"),
+                signum: 4,
+                result: true,
+            },
+            TestData {
+                status_file_data: Some("SigCgt:000000004b813efb "),
+                signum: 4,
+                result: true,
+            },
+            TestData {
+                status_file_data: Some("SigCgt:\t000000004b813efb "),
                 signum: 4,
                 result: true,
             },


### PR DESCRIPTION
In the is_signal_handled function, when parsing the hex string returned
from `/proc/<pid>/status` the space/tab character after the colon
is not removed.

This patch trims the result of SigCgt so that
all whitespace characters are removed. It also extends the existing
test cases to check for this scenario.

Fixes: #4250
Signed-off-by: Champ-Goblem <cameron@northflank.com>