### PR TITLE
virtiofsd: Switch to the rust version for x86_64

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -176,6 +176,9 @@ DEFDISABLEBLOCK := false
 DEFSHAREDFS_CLH_VIRTIOFS := virtio-fs
 DEFSHAREDFS_QEMU_VIRTIOFS := virtio-fs
 DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/kata-qemu/virtiofsd
+ifeq ($(ARCH),amd64)
+DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/virtiofsd
+endif
 DEFVALIDVIRTIOFSDAEMONPATHS := [\"$(DEFVIRTIOFSDAEMON)\"]
 # Default DAX mapping cache size in MiB
 #if value is 0, DAX is not enabled

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -322,7 +322,26 @@ generate_qemu_options() {
 	# But since QEMU 5.2 the daemon is built as part of the tools set
 	# (disabled with --disable-tools) thus it needs to be explicitely
 	# enabled.
-	qemu_options+=(functionality:--enable-virtiofsd)
+	#
+	# From Kata Containers 2.5.0-alpha2 x86_64 has been using the new
+	# implementation of virtiofs daemon, which is not part of QEMU.
+	# For the other arches, at least for now, keep building from while
+	# building QEMU.
+	#
+	# IOW, other arches are still using the C version of the virtiofsd.
+	case "$arch" in
+	aarch64)
+		qemu_options+=(functionality:--enable-virtiofsd)
+		;;
+	x86_64)
+		;;
+	ppc64le)
+		qemu_options+=(functionality:--enable-virtiofsd)
+		;;
+	s390x)
+		qemu_options+=(functionality:--enable-virtiofsd)
+		;;
+	esac
 	qemu_options+=(functionality:--enable-virtfs)
 
 	# Don't build linux-user bsd-user

--- a/tools/packaging/static-build/scripts/qemu-build-post.sh
+++ b/tools/packaging/static-build/scripts/qemu-build-post.sh
@@ -26,7 +26,9 @@ done
 if [[ -n "${BUILD_SUFFIX}" ]]; then
 	echo "Rename binaries using $BUILD_SUFFIX"
 	find -name 'qemu-system-*' -exec mv {} {}-experimental \;
-	find -name 'virtiofsd' -exec mv {} {}-experimental \;
+	if [[ ${ARCH} != "x86_64" ]]; then
+		find -name 'virtiofsd' -exec mv {} {}-experimental \;
+	fi
 fi
 
 echo "INFO: create the tarball"


### PR DESCRIPTION
This is the first concrete step to actually using the rust version of virtiofsd as part of our project.

Preliminary PRs added support to downloading its pre-built image, and shipping it as part of kata-deploy, but here's where we actually stop building the C version and default to using the rust one (for x86_64 only, at least for now).

I've started the conversation about adding support for other architectures (see: https://katacontainers.slack.com/archives/C879ACQ00/p1652288278597539), and that will be done as a second step, by the maintainers of the different architectures (I will open issues for each one of the other arches).

Fixes: #4249 