### PR TITLE
docs: Update runc containerd runtime

### DIFF
--- a/docs/how-to/privileged.md
+++ b/docs/how-to/privileged.md
@@ -31,7 +31,7 @@ See below example config:
   [plugins.cri]
     [plugins.cri.containerd]
        [plugins.cri.containerd.runtimes.runc]
-         runtime_type = "io.containerd.runc.v1"
+         runtime_type = "io.containerd.runc.v2"
          privileged_without_host_devices = false
        [plugins.cri.containerd.runtimes.kata]
          runtime_type = "io.containerd.kata.v2"


### PR DESCRIPTION
As we are using a containerd version > 1.4 we need to update
the runc containerd runtime.

Fixes #4263

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>