### PR TITLE
tools: delete unused param from get_from_kata_deps callers

### DIFF
--- a/tools/packaging/scripts/gen_versions_txt.sh
+++ b/tools/packaging/scripts/gen_versions_txt.sh
@@ -35,21 +35,21 @@ gen_version_file() {
 		ref="refs/tags/${kata_version}^{}"
 	fi
 
-	qemu_vanilla_branch=$(get_from_kata_deps "assets.hypervisor.qemu.version" "${kata_version}")
+	qemu_vanilla_branch=$(get_from_kata_deps "assets.hypervisor.qemu.version")
 	# Check if qemu.version can be used to get the version and hash, otherwise use qemu.tag
 	qemu_vanilla_ref="refs/heads/${qemu_vanilla_branch}"
 	if ! (git ls-remote --heads "https://github.com/qemu/qemu.git" | grep -q "refs/heads/${qemu_vanilla_branch}"); then
-		qemu_vanilla_branch=$(get_from_kata_deps "assets.hypervisor.qemu.tag" "${kata_version}")
+		qemu_vanilla_branch=$(get_from_kata_deps "assets.hypervisor.qemu.tag")
 		qemu_vanilla_ref="refs/tags/${qemu_vanilla_branch}^{}"
 	fi
 	qemu_vanilla_version=$(curl -s -L "https://raw.githubusercontent.com/qemu/qemu/${qemu_vanilla_branch}/VERSION")
 	qemu_vanilla_hash=$(git ls-remote https://github.com/qemu/qemu.git | grep "${qemu_vanilla_ref}" | awk '{print $1}')
 
-	kernel_version=$(get_from_kata_deps "assets.kernel.version" "${kata_version}")
+	kernel_version=$(get_from_kata_deps "assets.kernel.version")
 	#Remove extra 'v'
 	kernel_version=${kernel_version#v}
 
-	golang_version=$(get_from_kata_deps "languages.golang.meta.newest-version" "${kata_version}")
+	golang_version=$(get_from_kata_deps "languages.golang.meta.newest-version")
 
 	# - is not a valid char for rpmbuild
 	# see https://github.com/semver/semver/issues/145

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -14,7 +14,6 @@ ARCH=$(uname -m)
 [ "${ARCH}" != "aarch64" ] && [ "${ARCH}" != "x86_64" ] && exit
 
 script_dir=$(dirname $(readlink -f "$0"))
-kata_version="${kata_version:-}"
 force_build_from_source="${force_build_from_source:-false}"
 features="${features:-}"
 
@@ -27,7 +26,7 @@ cloud_hypervisor_pull_ref_branch="${cloud_hypervisor_pull_ref_branch:-main}"
 
 if [ -z "$cloud_hypervisor_repo" ]; then
        info "Get cloud_hypervisor information from runtime versions.yaml"
-       cloud_hypervisor_url=$(get_from_kata_deps "assets.hypervisor.cloud_hypervisor.url" "${kata_version}")
+       cloud_hypervisor_url=$(get_from_kata_deps "assets.hypervisor.cloud_hypervisor.url")
        [ -n "$cloud_hypervisor_url" ] || die "failed to get cloud_hypervisor url"
        cloud_hypervisor_repo="${cloud_hypervisor_url}.git"
 fi
@@ -37,7 +36,7 @@ if [ -n "$cloud_hypervisor_pr" ]; then
 	force_build_from_source=true
 	cloud_hypervisor_version="PR $cloud_hypervisor_pr"
 else
-	[ -n "$cloud_hypervisor_version" ] || cloud_hypervisor_version=$(get_from_kata_deps "assets.hypervisor.cloud_hypervisor.version" "${kata_version}")
+	[ -n "$cloud_hypervisor_version" ] || cloud_hypervisor_version=$(get_from_kata_deps "assets.hypervisor.cloud_hypervisor.version")
 	[ -n "$cloud_hypervisor_version" ] || die "failed to get cloud_hypervisor version"
 fi
 

--- a/tools/packaging/static-build/firecracker/build-static-firecracker.sh
+++ b/tools/packaging/static-build/firecracker/build-static-firecracker.sh
@@ -17,17 +17,16 @@ config_dir="${script_dir}/../../scripts/"
 firecracker_repo="${firecracker_repo:-}"
 firecracker_dir="firecracker"
 firecracker_version="${firecracker_version:-}"
-kata_version="${kata_version:-}"
 
 if [ -z "$firecracker_repo" ]; then
 	info "Get firecracker information from runtime versions.yaml"
-        firecracker_url=$(get_from_kata_deps "assets.hypervisor.firecracker.url" "${kata_version}")
+        firecracker_url=$(get_from_kata_deps "assets.hypervisor.firecracker.url")
 	[ -n "$firecracker_url" ] || die "failed to get firecracker url"
         firecracker_repo="${firecracker_url}.git"
 fi
 [ -n "$firecracker_repo" ] || die "failed to get firecracker repo"
 
-[ -n "$firecracker_version" ] || firecracker_version=$(get_from_kata_deps "assets.hypervisor.firecracker.version" "${kata_version}")
+[ -n "$firecracker_version" ] || firecracker_version=$(get_from_kata_deps "assets.hypervisor.firecracker.version")
 [ -n "$firecracker_version" ] || die "failed to get firecracker version"
 
 info "Build ${firecracker_repo} version: ${firecracker_version}"


### PR DESCRIPTION
The param was deleted by a09e58fa80ae81c0d336d9a782da4f38f9492da1, so
update the callers not to use it.

Fixes #4245

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>