### PR TITLE
runtime: do not check for EOF error in console watcher

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1037,15 +1037,13 @@ func (cw *consoleWatcher) start(s *Sandbox) (err error) {
 		}
 
 		if err := scanner.Err(); err != nil {
-			if err == io.EOF {
-				s.Logger().Info("console watcher quits")
-			} else {
-				s.Logger().WithError(err).WithFields(logrus.Fields{
-					"console-protocol": cw.proto,
-					"console-url":      cw.consoleURL,
-					"sandbox":          s.id,
-				}).Error("Failed to read guest console logs")
-			}
+			s.Logger().WithError(err).WithFields(logrus.Fields{
+				"console-protocol": cw.proto,
+				"console-url":      cw.consoleURL,
+				"sandbox":          s.id,
+			}).Error("Failed to read guest console logs")
+		} else { // The error is `nil` in case of io.EOF
+			s.Logger().Info("console watcher quits")
 		}
 	}()
 


### PR DESCRIPTION
The documentation of the bufio package explicitly says

"Err returns the first non-EOF error that was encountered by the
Scanner."

When io.EOF happens, `Err()` will return `nil` and `Scan()` will return
`false`.

Fixes #4079

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>