### PR TITLE
docs: Remove clear containers reference in README

### DIFF
--- a/tools/osbuilder/rootfs-builder/README.md
+++ b/tools/osbuilder/rootfs-builder/README.md
@@ -82,12 +82,6 @@ must be met:
    $ docker info | grep 'Default Runtime: runc'
    ```
 
-   Note:
-
-   This requirement is specific to the Clear Containers runtime.
-   See [issue](https://github.com/clearcontainers/runtime/issues/828) for
-   more information.
-
 3. Export `USE_DOCKER` variable.
 
    ```


### PR DESCRIPTION
This PR removes the clear containers reference as this is not longer
being used and is deprecated at the rootfs builder README.

Fixes #4278

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>