### PR TITLE
CCv0: Fix ccv0.sh to install virtiofsd

### DIFF
--- a/docs/how-to/ccv0.sh
+++ b/docs/how-to/ccv0.sh
@@ -328,14 +328,12 @@ install_guest_kernel_image() {
 }
 
 build_qemu() {
+    ${tests_repo_dir}/.ci/install_virtiofsd.sh
     ${tests_repo_dir}/.ci/install_qemu.sh
 }
 
 build_cloud_hypervisor() {
-    # While we still rely on the C version of virtiofsd, let's
-    # install QEMU, which will then bring virtiofsd together.
-    build_qemu
-
+    ${tests_repo_dir}/.ci/install_virtiofsd.sh
     ${tests_repo_dir}/.ci/install_cloud_hypervisor.sh
 }
 


### PR DESCRIPTION
- Add call to install_virtiofsd.sh
- Remove the qemu build in the cloud_hypervisor path

Fixes: #4286
Signed-off-by: stevenhorsman <steven@uk.ibm.com>