### PR TITLE
do-not-merge: Add FFI_NO_PI to the netlink flags

### DIFF
--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -408,7 +408,7 @@ func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Lin
 
 	switch expectedLink.Type() {
 	case (&netlink.Tuntap{}).Type():
-		flags := netlink.TUNTAP_VNET_HDR
+		flags := netlink.TUNTAP_VNET_HDR | netlink.TUNTAP_NO_PI
 		if queues > 0 {
 			flags |= netlink.TUNTAP_MULTI_QUEUE_DEFAULTS
 		}


### PR DESCRIPTION
Let's check whether setting FFI_NO_PI has some impact on different
hypervisors / architectures supported by Kata Containers.

Fixes: #0000

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>