### PR TITLE
runtime: Switch to using the rust version of virtiofsd (all arches but powerpc)

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -52,6 +52,36 @@ parts:
       curl -LO https://golang.org/dl/${tarfile}
       tar -xf ${tarfile} --strip-components=1
 
+  rustdeps:
+    after: [metadata]
+    plugin: nil
+    prime:
+      - -*
+    build-packages:
+      - curl
+    override-build: |
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
+
+      # put everything in stage
+      cd "${SNAPCRAFT_STAGE}"
+
+      version="$(${yq} r ${kata_dir}/versions.yaml languages.rust.meta.newest-version)"
+      if ! command -v rustup > /dev/null; then
+        curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${version}
+      fi
+
+      export PATH=${PATH}:${HOME}/.cargo/bin
+      rustup toolchain install ${version}
+      rustup default ${version}
+      if [ "${arch}" == "ppc64le" ] || [ "${arch}" == "s390x" ] ; then
+        [ ${arch} == "ppc64le"] && arch="powerpc64le"
+        rustup target add ${arch}-unknown-linux-gnu
+      else
+        rustup target add ${arch}-unknown-linux-musl
+        $([ "$(whoami)" != "root" ] && echo sudo) ln -sf /usr/bin/g++ /bin/musl-g++
+      fi
+      rustup component add rustfmt
+
   image:
     after: [godeps, qemu, kernel]
     plugin: nil
@@ -271,25 +301,26 @@ parts:
 
   virtiofsd:
     plugin: nil
-    after: [godeps]
+    after: [godeps, rustdeps]
     override-build: |
       source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
 
-      # Currently, only one platform uses the new rust virtiofsd. The
-      # others make use of QEMU's C implementation.
+      # Currently, powerpc makes use of the QEMU's C implementation.
+      # The other platforms make use of the new rust virtiofsd.
       #
       # See "tools/packaging/scripts/configure-hypervisor.sh".
-      if [ "${arch}" = 'x86_64' ]
+      if [ "${arch}" == "ppc64le" ]
       then
-          echo "INFO: Building rust version of virtiofsd"
-      else
           echo "INFO: Building QEMU's C version of virtiofsd"
           # Handled by the 'qemu' part, so nothing more to do here.
           exit 0
+      else
+          echo "INFO: Building rust version of virtiofsd"
       fi
 
       cd "${kata_dir}"
 
+      export PATH=${PATH}:${HOME}/.cargo/bin
       # Download the rust implementation of virtiofsd
       tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
       sudo install \

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -175,9 +175,9 @@ DEFVALIDENTROPYSOURCES := [\"/dev/urandom\",\"/dev/random\",\"\"]
 DEFDISABLEBLOCK := false
 DEFSHAREDFS_CLH_VIRTIOFS := virtio-fs
 DEFSHAREDFS_QEMU_VIRTIOFS := virtio-fs
-DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/kata-qemu/virtiofsd
-ifeq ($(ARCH),amd64)
 DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/virtiofsd
+ifeq ($(ARCH),ppc64le)
+DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/kata-qemu/virtiofsd
 endif
 DEFVALIDVIRTIOFSDAEMONPATHS := [\"$(DEFVIRTIOFSDAEMON)\"]
 # Default DAX mapping cache size in MiB

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -317,6 +317,29 @@ generate_qemu_options() {
 	# Don't build the qemu-io, qemu-nbd and qemu-image tools
 	qemu_options+=(size:--disable-tools)
 
+	# Kata Containers may be configured to use the virtiofs daemon.
+	#
+	# But since QEMU 5.2 the daemon is built as part of the tools set
+	# (disabled with --disable-tools) thus it needs to be explicitely
+	# enabled.
+	#
+	# From Kata Containers 2.5.0-alpha2 all arches but powerpc have been
+        # using the new implementation of virtiofs daemon, which is not part
+       	# of QEMU.
+	# For the powwer, at least for now, keep building virtiofsd while
+	# building QEMU.
+	case "$arch" in
+	aarch64)
+	        ;;
+	x86_64)
+	        ;;
+	ppc64le)
+	        qemu_options+=(functionality:--enable-virtiofsd)
+	        ;;
+	s390x)
+	        ;;
+	esac
+
 	qemu_options+=(functionality:--enable-virtfs)
 
 	# Don't build linux-user bsd-user

--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -71,11 +71,11 @@ build_virtiofsd_from_source() {
    git clone --depth 1 --branch ${virtiofsd_version} ${virtiofsd_url} virtiofsd
    pushd virtiofsd
 
-   RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes'
-   LIBSECCOMP_LINK_TYPE=static
-   LIBSECCOMP_LIB_PATH=/usr/lib/${ARCH_LIBC}
-   LIBCAPNG_LINK_TYPE=static
-   LIBCAPNG_LIB_PATH=/usr/lib/${ARCH_LIBC}
+   export RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes'
+   export LIBSECCOMP_LINK_TYPE=static
+   export LIBSECCOMP_LIB_PATH=/usr/lib/${ARCH_LIBC}
+   export LIBCAPNG_LINK_TYPE=static
+   export LIBCAPNG_LIB_PATH=/usr/lib/${ARCH_LIBC}
    
    cargo build --release --target ${ARCH}-unknown-linux-${LIBC}
 


### PR DESCRIPTION
So far this has been done for x86_64.  Now that the support for building
and testing has been added for all arches, let's do the full switch.

Fixes: #4258, #4259, #4260

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>