### PR TITLE
Allow Cloud Hypervisor to run under the `container_kvm_t`

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -99,6 +99,8 @@ type clhClient interface {
 	VmAddDiskPut(ctx context.Context, diskConfig chclient.DiskConfig) (chclient.PciDeviceInfo, *http.Response, error)
 	// Remove a device from the VM
 	VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error)
+	// Add a new net device to the VM
+	VmAddNetPut(ctx context.Context, netConfig chclient.NetConfig) (chclient.PciDeviceInfo, *http.Response, error)
 }
 
 type clhClientApi struct {
@@ -140,6 +142,10 @@ func (c *clhClientApi) VmAddDiskPut(ctx context.Context, diskConfig chclient.Dis
 
 func (c *clhClientApi) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error) {
 	return c.ApiInternal.VmRemoveDevicePut(ctx).VmRemoveDevice(vmRemoveDevice).Execute()
+}
+
+func (c *clhClientApi) VmAddNetPut(ctx context.Context, netConfig chclient.NetConfig) (chclient.PciDeviceInfo, *http.Response, error) {
+	return c.ApiInternal.VmAddNetPut(ctx).NetConfig(netConfig).Execute()
 }
 
 //

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -161,6 +161,8 @@ var vmAddNetPutRequest = func(clh *cloudHypervisor) error {
 	defer conn.Close()
 
 	for _, netDevice := range *clh.netDevices {
+		clh.Logger().Infof("Adding the net device to the Cloud Hypervisor VM configuration: %+v", netDevice)
+
 		netDeviceAsJson, err := json.Marshal(netDevice)
 		if err != nil {
 			return err
@@ -1465,10 +1467,6 @@ func (clh *cloudHypervisor) addNet(e Endpoint) error {
 	}
 	clh.netDevicesFiles[mac] = netPair.TapInterface.VMFds
 
-	clh.Logger().WithFields(log.Fields{
-		"mac": mac,
-	}).Info("Adding Net")
-
 	netRateLimiterConfig := clh.getNetRateLimiterConfig()
 
 	net := chclient.NewNetConfig()
@@ -1482,6 +1480,8 @@ func (clh *cloudHypervisor) addNet(e Endpoint) error {
 	} else {
 		clh.netDevices = &[]chclient.NetConfig{*net}
 	}
+
+	clh.Logger().Infof("Storing the Cloud Hypervisor network configuration: %+v", net)
 
 	return nil
 }

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1457,25 +1457,22 @@ func (clh *cloudHypervisor) addNet(e Endpoint) error {
 	mac := e.HardwareAddr()
 	netPair := e.NetworkPair()
 	if netPair == nil {
-		return errors.New("net Pair to be added is nil, needed to get TAP path")
+		return errors.New("net Pair to be added is nil, needed to get TAP file descriptors")
 	}
 
-	tapPath := netPair.TapInterface.TAPIface.Name
-	if tapPath == "" {
-		return errors.New("TAP path in network pair is empty")
+	if len(netPair.TapInterface.VMFds) == 0 {
+		return errors.New("The file descriptors for the network pair are not present")
 	}
 	clh.netDevicesFiles[mac] = netPair.TapInterface.VMFds
 
 	clh.Logger().WithFields(log.Fields{
 		"mac": mac,
-		"tap": tapPath,
 	}).Info("Adding Net")
 
 	netRateLimiterConfig := clh.getNetRateLimiterConfig()
 
 	net := chclient.NewNetConfig()
 	net.Mac = &mac
-	net.Tap = &tapPath
 	if netRateLimiterConfig != nil {
 		net.SetRateLimiterConfig(*netRateLimiterConfig)
 	}

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -10,6 +10,7 @@ package virtcontainers
 
 import (
 	"context"
+	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -129,25 +130,30 @@ func TestCloudHypervisorAddVSock(t *testing.T) {
 // Check addNet appends to the network config list new configurations.
 // Check that the elements in the list has the correct values
 func TestCloudHypervisorAddNetCheckNetConfigListValues(t *testing.T) {
-	macTest := "00:00:00:00:00"
-	tapPath := "/path/to/tap"
-
 	assert := assert.New(t)
+
+	macTest := "00:00:00:00:00"
+
+	file, err := ioutil.TempFile("", "netFd")
+	assert.Nil(err)
+	defer os.Remove(file.Name())
+
+	vmFds := make([]*os.File, 1)
+	vmFds = append(vmFds, file)
 
 	clh := cloudHypervisor{}
 	clh.netDevicesFiles = make(map[string][]*os.File)
 
 	e := &VethEndpoint{}
 	e.NetPair.TAPIface.HardAddr = macTest
-	e.NetPair.TapInterface.TAPIface.Name = tapPath
+	e.NetPair.TapInterface.VMFds = vmFds
 
-	err := clh.addNet(e)
+	err = clh.addNet(e)
 	assert.Nil(err)
 
 	assert.Equal(len(*clh.netDevices), 1)
 	if err == nil {
 		assert.Equal(*(*clh.netDevices)[0].Mac, macTest)
-		assert.Equal(*(*clh.netDevices)[0].Tap, tapPath)
 	}
 
 	err = clh.addNet(e)
@@ -156,7 +162,6 @@ func TestCloudHypervisorAddNetCheckNetConfigListValues(t *testing.T) {
 	assert.Equal(len(*clh.netDevices), 2)
 	if err == nil {
 		assert.Equal(*(*clh.netDevices)[1].Mac, macTest)
-		assert.Equal(*(*clh.netDevices)[1].Tap, tapPath)
 	}
 }
 
@@ -165,10 +170,18 @@ func TestCloudHypervisorAddNetCheckNetConfigListValues(t *testing.T) {
 func TestCloudHypervisorAddNetCheckEnpointTypes(t *testing.T) {
 	assert := assert.New(t)
 
-	tapPath := "/path/to/tap"
+	macTest := "00:00:00:00:00"
+
+	file, err := ioutil.TempFile("", "netFd")
+	assert.Nil(err)
+	defer os.Remove(file.Name())
+
+	vmFds := make([]*os.File, 1)
+	vmFds = append(vmFds, file)
 
 	validVeth := &VethEndpoint{}
-	validVeth.NetPair.TapInterface.TAPIface.Name = tapPath
+	validVeth.NetPair.TAPIface.HardAddr = macTest
+	validVeth.NetPair.TapInterface.VMFds = vmFds
 
 	type args struct {
 		e Endpoint
@@ -189,9 +202,9 @@ func TestCloudHypervisorAddNetCheckEnpointTypes(t *testing.T) {
 			clh.netDevicesFiles = make(map[string][]*os.File)
 			if err := clh.addNet(tt.args.e); (err != nil) != tt.wantErr {
 				t.Errorf("cloudHypervisor.addNet() error = %v, wantErr %v", err, tt.wantErr)
-
 			} else if err == nil {
-				assert.Equal(*(*clh.netDevices)[0].Tap, tapPath)
+				files := clh.netDevicesFiles[macTest]
+				assert.Equal(files, vmFds)
 			}
 		})
 	}
@@ -201,10 +214,15 @@ func TestCloudHypervisorAddNetCheckEnpointTypes(t *testing.T) {
 func TestCloudHypervisorNetRateLimiter(t *testing.T) {
 	assert := assert.New(t)
 
-	tapPath := "/path/to/tap"
+	file, err := ioutil.TempFile("", "netFd")
+	assert.Nil(err)
+	defer os.Remove(file.Name())
+
+	vmFds := make([]*os.File, 1)
+	vmFds = append(vmFds, file)
 
 	validVeth := &VethEndpoint{}
-	validVeth.NetPair.TapInterface.TAPIface.Name = tapPath
+	validVeth.NetPair.TapInterface.VMFds = vmFds
 
 	type args struct {
 		bwMaxRate       int64

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -117,6 +117,11 @@ func (c *clhClientMock) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice ch
 	return nil, nil
 }
 
+//nolint:golint
+func (c *clhClientMock) VmAddNetPut(ctx context.Context, netConfig chclient.NetConfig) (chclient.PciDeviceInfo, *http.Response, error) {
+	return chclient.PciDeviceInfo{}, nil, nil
+}
+
 func TestCloudHypervisorAddVSock(t *testing.T) {
 	assert := assert.New(t)
 	clh := cloudHypervisor{}

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -135,6 +135,7 @@ func TestCloudHypervisorAddNetCheckNetConfigListValues(t *testing.T) {
 	assert := assert.New(t)
 
 	clh := cloudHypervisor{}
+	clh.netDevicesFiles = make(map[string][]*os.File)
 
 	e := &VethEndpoint{}
 	e.NetPair.TAPIface.HardAddr = macTest
@@ -185,6 +186,7 @@ func TestCloudHypervisorAddNetCheckEnpointTypes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			clh := &cloudHypervisor{}
+			clh.netDevicesFiles = make(map[string][]*os.File)
 			if err := clh.addNet(tt.args.e); (err != nil) != tt.wantErr {
 				t.Errorf("cloudHypervisor.addNet() error = %v, wantErr %v", err, tt.wantErr)
 
@@ -339,6 +341,7 @@ func TestCloudHypervisorNetRateLimiter(t *testing.T) {
 			clhConfig.NetRateLimiterOpsOneTimeBurst = tt.args.opsOneTimeBurst
 
 			clh := &cloudHypervisor{}
+			clh.netDevicesFiles = make(map[string][]*os.File)
 			clh.config = clhConfig
 			clh.APIClient = &clhClientMock{}
 

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -117,11 +117,6 @@ func (c *clhClientMock) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice ch
 	return nil, nil
 }
 
-//nolint:golint
-func (c *clhClientMock) VmAddNetPut(ctx context.Context, netConfig chclient.NetConfig) (chclient.PciDeviceInfo, *http.Response, error) {
-	return chclient.PciDeviceInfo{}, nil, nil
-}
-
 func TestCloudHypervisorAddVSock(t *testing.T) {
 	assert := assert.New(t)
 	clh := cloudHypervisor{}
@@ -380,7 +375,7 @@ func TestCloudHypervisorBootVM(t *testing.T) {
 	clh.APIClient = &clhClientMock{}
 
 	savedVmAddNetPutRequestFunc := vmAddNetPutRequest
-	vmAddNetPutRequest = func(clh *cloudHypervisor, ctx context.Context) error { return nil }
+	vmAddNetPutRequest = func(clh *cloudHypervisor) error { return nil }
 	defer func() {
 		vmAddNetPutRequest = savedVmAddNetPutRequestFunc
 	}()
@@ -499,7 +494,7 @@ func TestCloudHypervisorStartSandbox(t *testing.T) {
 	assert.NoError(err)
 
 	savedVmAddNetPutRequestFunc := vmAddNetPutRequest
-	vmAddNetPutRequest = func(clh *cloudHypervisor, ctx context.Context) error { return nil }
+	vmAddNetPutRequest = func(clh *cloudHypervisor) error { return nil }
 	defer func() {
 		vmAddNetPutRequest = savedVmAddNetPutRequestFunc
 	}()

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -927,6 +927,12 @@ func (fc *firecracker) fcAddNetDevice(ctx context.Context, endpoint Endpoint) {
 
 	ifaceID := endpoint.Name()
 
+	// VMFds are not used by Firecracker, as it opens the tuntap
+	// device by its name.  Let's just close those.
+	for _, f := range endpoint.NetworkPair().TapInterface.VMFds {
+		f.Close()
+	}
+
 	// The implementation of rate limiter is based on TBF.
 	// Rate Limiter defines a token bucket with a maximum capacity (size) to store tokens, and an interval for refilling purposes (refill_time).
 	// The refill-rate is derived from size and refill_time, and it is the constant rate at which the tokens replenish.

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -408,7 +408,7 @@ func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Lin
 
 	switch expectedLink.Type() {
 	case (&netlink.Tuntap{}).Type():
-		flags := netlink.TUNTAP_VNET_HDR
+		flags := netlink.TUNTAP_VNET_HDR | netlink.TUNTAP_NO_PI
 		if queues > 0 {
 			flags |= netlink.TUNTAP_MULTI_QUEUE_DEFAULTS
 		}

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -411,6 +411,16 @@ func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Lin
 		flags := netlink.TUNTAP_VNET_HDR | netlink.TUNTAP_NO_PI
 		if queues > 0 {
 			flags |= netlink.TUNTAP_MULTI_QUEUE_DEFAULTS
+		} else {
+			// We need to enforce `queues = 1` here in case
+			// multi-queue is *not* supported, the reason being
+			// `linkModify()`, a method called by `LinkAdd()`, only
+			// returning the file descriptor of the opened tuntap
+			// device when the queues are set to *non zero*.
+			//
+			// Please, for more information, refer to:
+			// https://github.com/kata-containers/kata-containers/blob/e6e5d2593ac319329269d7b58c30f99ba7b2bf5a/src/runtime/vendor/github.com/vishvananda/netlink/link_linux.go#L1164-L1316
+			queues = 1
 		}
 		newLink = &netlink.Tuntap{
 			LinkAttrs: netlink.LinkAttrs{Name: name},


### PR DESCRIPTION
Cloud Hypervisor, currently, cannot run under the `container_kvm_t` label, as it opens the tuntap device using device's name, causing the following SELinux AVC:
```
type=PROCTITLE msg=audit(1653421182.755:146064): proctitle=2F6F70742F6B6174612F62696E2F636C6F75642D68797065727669736F72002D2D6170692D736F636B6574002F72756E2F76632F766D2F366331626530336235653437396639666637363265313566633937306266663932303337663562376334353562663639656237323630663838343964373632382F636C682D6170692E
type=SYSCALL msg=audit(1653421182.755:146064): arch=c000003e syscall=2 success=yes exit=54 a0=7f964538e51b a1=80802 a2=0 a3=0 items=0 ppid=344244 pid=344254 auid=4294967295 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=4294967295 comm="vmm" exe="/opt/kata/bin/cloud-hypervisor" subj=system_u:system_r:container_kvm_t:s0:c357,c803 key=(null)
type=AVC msg=audit(1653421182.755:146064): avc:  denied  { open } for  pid=344254 comm="vmm" path="/dev/net/tun" dev="devtmpfs" ino=14491 scontext=system_u:system_r:container_kvm_t:s0:c357,c803 tcontext=system_u:object_r:tun_tap_device_t:s0 tclass=chr_file permissive=1
```

So, instead of passing to cloud-hypervisor the name of the bridge and letting it open the tuntap device, which is not an allowed operation for container_kvm_t processes, let's just pass the file descriptors to the VMM, in a similar manner of what's done with QEMU.