### PR TITLE
stable-2.4 | clh: Update to the v24.0 release

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -606,6 +606,7 @@ components:
             - 3
             - 3
             num_pci_segments: 3
+            serial_number: serial_number
           pmem:
           - pci_segment: 6
             mergeable: false
@@ -948,6 +949,7 @@ components:
           - 3
           - 3
           num_pci_segments: 3
+          serial_number: serial_number
         pmem:
         - pci_segment: 6
           mergeable: false
@@ -1169,6 +1171,7 @@ components:
         - 3
         - 3
         num_pci_segments: 3
+        serial_number: serial_number
       properties:
         num_pci_segments:
           format: int16
@@ -1178,6 +1181,8 @@ components:
             format: int16
             type: integer
           type: array
+        serial_number:
+          type: string
       type: object
     MemoryZoneConfig:
       example:

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PlatformConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PlatformConfig.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **NumPciSegments** | Pointer to **int32** |  | [optional] 
 **IommuSegments** | Pointer to **[]int32** |  | [optional] 
+**SerialNumber** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
@@ -75,6 +76,31 @@ SetIommuSegments sets IommuSegments field to given value.
 `func (o *PlatformConfig) HasIommuSegments() bool`
 
 HasIommuSegments returns a boolean if a field has been set.
+
+### GetSerialNumber
+
+`func (o *PlatformConfig) GetSerialNumber() string`
+
+GetSerialNumber returns the SerialNumber field if non-nil, zero value otherwise.
+
+### GetSerialNumberOk
+
+`func (o *PlatformConfig) GetSerialNumberOk() (*string, bool)`
+
+GetSerialNumberOk returns a tuple with the SerialNumber field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSerialNumber
+
+`func (o *PlatformConfig) SetSerialNumber(v string)`
+
+SetSerialNumber sets SerialNumber field to given value.
+
+### HasSerialNumber
+
+`func (o *PlatformConfig) HasSerialNumber() bool`
+
+HasSerialNumber returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_platform_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_platform_config.go
@@ -18,6 +18,7 @@ import (
 type PlatformConfig struct {
 	NumPciSegments *int32   `json:"num_pci_segments,omitempty"`
 	IommuSegments  *[]int32 `json:"iommu_segments,omitempty"`
+	SerialNumber   *string  `json:"serial_number,omitempty"`
 }
 
 // NewPlatformConfig instantiates a new PlatformConfig object
@@ -101,6 +102,38 @@ func (o *PlatformConfig) SetIommuSegments(v []int32) {
 	o.IommuSegments = &v
 }
 
+// GetSerialNumber returns the SerialNumber field value if set, zero value otherwise.
+func (o *PlatformConfig) GetSerialNumber() string {
+	if o == nil || o.SerialNumber == nil {
+		var ret string
+		return ret
+	}
+	return *o.SerialNumber
+}
+
+// GetSerialNumberOk returns a tuple with the SerialNumber field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PlatformConfig) GetSerialNumberOk() (*string, bool) {
+	if o == nil || o.SerialNumber == nil {
+		return nil, false
+	}
+	return o.SerialNumber, true
+}
+
+// HasSerialNumber returns a boolean if a field has been set.
+func (o *PlatformConfig) HasSerialNumber() bool {
+	if o != nil && o.SerialNumber != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSerialNumber gets a reference to the given string and assigns it to the SerialNumber field.
+func (o *PlatformConfig) SetSerialNumber(v string) {
+	o.SerialNumber = &v
+}
+
 func (o PlatformConfig) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.NumPciSegments != nil {
@@ -108,6 +141,9 @@ func (o PlatformConfig) MarshalJSON() ([]byte, error) {
 	}
 	if o.IommuSegments != nil {
 		toSerialize["iommu_segments"] = o.IommuSegments
+	}
+	if o.SerialNumber != nil {
+		toSerialize["serial_number"] = o.SerialNumber
 	}
 	return json.Marshal(toSerialize)
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -616,6 +616,8 @@ components:
           items:
             type: integer
             format: int16
+        serial_number:
+          type: string
 
     MemoryZoneConfig:
       required:

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v23.1"
+      version: "v24.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This release has been tracked through the v24.0 project.

virtio-iommu specification describes how a device can be attached by default
to a bypass domain. This feature is particularly helpful for booting a VM with
guest software which doesn't support virtio-iommu but still need to access
the device. Now that Cloud Hypervisor supports this feature, it can boot a VM
with Rust Hypervisor Firmware or OVMF even if the virtio-block device exposing
the disk image is placed behind a virtual IOMMU.

Multiple checks have been added to the code to prevent devices with identical
identifiers from being created, and therefore avoid unexpected behaviors at boot
or whenever a device was hot plugged into the VM.

Sparse mmap support has been added to both VFIO and vfio-user devices. This
allows the device regions that are not fully mappable to be partially mapped.
And the more a device region can be mapped into the guest address space, the
fewer VM exits will be generated when this device is accessed. This directly
impacts the performance related to this device.

A new serial_number option has been added to --platform, allowing a user to
set a specific serial number for the platform. This number is exposed to the
guest through the SMBIOS.

* Fix loading RAW firmware (#4072)
* Reject compressed QCOW images (#4055)
* Reject virtio-mem resize if device is not activated (#4003)
* Fix potential mmap leaks from VFIO/vfio-user MMIO regions (#4069)
* Fix algorithm finding HOB memory resources (#3983)

* Refactor interrupt handling (#4083)
* Load kernel asynchronously (#4022)
* Only create ACPI memory manager DSDT when resizable (#4013)

Deprecated features will be removed in a subsequent release and users should
plan to use alternatives

* The mergeable option from the virtio-pmem support has been deprecated
(#3968)
* The dax option from the virtio-fs support has been deprecated (#3889)

Fixes: #4317

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>