### PR TITLE
snap: Use helper script and cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ The table below lists the remaining parts of the project:
 
 Kata Containers is now
 [available natively for most distributions](docs/install/README.md#packaged-installation-methods).
-However, packaging scripts and metadata are still used to generate snap and GitHub releases. See
+However, packaging scripts and metadata are still used to generate [snap](snap/local) and GitHub releases. See
 the [components](#components) section for further details.
 
 ## Glossary of Terms

--- a/snap/local/README.md
+++ b/snap/local/README.md
@@ -28,6 +28,20 @@ Run the command below which will use the packaging Makefile to build the snap im
 $ make -C tools/packaging snap
 ```
 
+> **Warning:**
+>
+> By default, `snapcraft` will create a clean virtual machine
+> environment to build the snap in using the `multipass` tool.
+>
+> However, `multipass` is silently disabled when `--destructive-mode` is
+> used.
+>
+> Since building the Kata Containers package currently requires
+> `--destructive-mode`, the snap will be built using the host
+> environment. To avoid parts of the build auto-detecting additional
+> features to enable (for example for QEMU), we recommend that you
+> only run the snap build in a minimal host environment.
+
 To install the resulting snap image, snap must be put in [classic mode][3] and the
 security confinement must be disabled (*--classic*). Also since the resulting snap
 has not been signed the verification of signature must be omitted (*--dangerous*).

--- a/snap/local/README.md
+++ b/snap/local/README.md
@@ -76,12 +76,12 @@ then a new configuration file can be [created](#configure-kata-containers)
 and [configured][7].
 
 [1]: https://docs.snapcraft.io/snaps/intro
-[2]: ../docs/design/architecture/README.md#root-filesystem-image
+[2]: ../../docs/design/architecture/README.md#root-filesystem-image
 [3]: https://docs.snapcraft.io/reference/confinement#classic
 [4]: https://github.com/kata-containers/runtime#configuration
 [5]: https://docs.docker.com/engine/reference/commandline/dockerd
-[6]: ../docs/install/docker/ubuntu-docker-install.md
-[7]: ../docs/Developer-Guide.md#configure-to-use-initrd-or-rootfs-image
+[6]: ../../docs/install/docker/ubuntu-docker-install.md
+[7]: ../../docs/Developer-Guide.md#configure-to-use-initrd-or-rootfs-image
 [8]: https://snapcraft.io/kata-containers
-[9]: ../docs/Developer-Guide.md#run-kata-containers-with-docker
-[10]: ../docs/Developer-Guide.md#run-kata-containers-with-kubernetes
+[9]: ../../docs/Developer-Guide.md#run-kata-containers-with-docker
+[10]: ../../docs/Developer-Guide.md#run-kata-containers-with-kubernetes

--- a/snap/local/README.md
+++ b/snap/local/README.md
@@ -43,14 +43,14 @@ $ make -C tools/packaging snap
 > only run the snap build in a minimal host environment.
 
 To install the resulting snap image, snap must be put in [classic mode][3] and the
-security confinement must be disabled (*--classic*). Also since the resulting snap
-has not been signed the verification of signature must be omitted (*--dangerous*).
+security confinement must be disabled (`--classic`). Also since the resulting snap
+has not been signed the verification of signature must be omitted (`--dangerous`).
 
 ```sh
-$ sudo snap install --classic --dangerous kata-containers_[VERSION]_[ARCH].snap
+$ sudo snap install --classic --dangerous "kata-containers_${version}_${arch}.snap"
 ```
 
-Replace `VERSION` with the current version of Kata Containers and `ARCH` with
+Replace `${version}` with the current version of Kata Containers and `${arch}` with
 the system architecture.
 
 ## Configure Kata Containers

--- a/snap/local/README.md
+++ b/snap/local/README.md
@@ -22,10 +22,10 @@ $ sudo snap install kata-containers --classic
 
 ## Build and install snap image
 
-Run next command at the root directory of the packaging repository.
+Run the command below which will use the packaging Makefile to build the snap image:
 
 ```sh
-$ make snap
+$ make -C tools/packaging snap
 ```
 
 To install the resulting snap image, snap must be put in [classic mode][3] and the

--- a/snap/local/snap-common.sh
+++ b/snap/local/snap-common.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Description: Idempotent script to be sourced by all parts in a
+#   snapcraft config file.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# XXX: Bash-specific code. zsh doesn't support this option and that *does*
+# matter if this script is run sourced... since it'll be using zsh! ;)
+[ -n "$BASH_VERSION" ] && set -o errtrace
+
+[ -n "${DEBUG:-}" ] && set -o xtrace
+
+die()
+{
+	echo >&2 "ERROR: $0: $*"
+}
+
+[ -n "${SNAPCRAFT_STAGE:-}" ] ||\
+	die "must be sourced from a snapcraft config file"
+
+snap_yq_version=3.4.1
+
+snap_common_install_yq()
+{
+      export yq="${SNAPCRAFT_STAGE}/bin/yq"
+
+      local yq_pkg
+      yq_pkg="github.com/mikefarah/yq"
+
+      local yq_url
+      yq_url="https://${yq_pkg}/releases/download/${snap_yq_version}/yq_${goos}_${goarch}"
+      curl -o "${yq}" -L "${yq_url}"
+      chmod +x "${yq}"
+}
+
+# Function that should be called for each snap "part" in
+# snapcraft.yaml.
+snap_common_main()
+{
+	# Architecture
+	arch="$(uname -m)"
+
+	case "${arch}" in
+		aarch64)
+			goarch="arm64"
+			qemu_arch="${arch}"
+			;;
+
+		ppc64le)
+			goarch="ppc64le"
+			qemu_arch="ppc64"
+			;;
+
+		s390x)
+			goarch="${arch}"
+			qemu_arch="${arch}"
+			;;
+
+		x86_64)
+			goarch="amd64"
+			qemu_arch="${arch}"
+			;;
+
+		*) die "unsupported architecture: ${arch}" ;;
+	esac
+
+	dpkg_arch=$(dpkg --print-architecture)
+
+	# golang
+	#
+	# We need the O/S name in golang format, but since we don't
+	# know if the godeps part has run, we don't know if golang is
+	# available yet, hence fall back to a standard system command.
+	goos="$(go env GOOS &>/dev/null || true)"
+	[ -z "$goos" ] && goos=$(uname -s|tr '[A-Z]' '[a-z]')
+
+	export GOROOT="${SNAPCRAFT_STAGE}"
+	export GOPATH="${GOROOT}/gopath"
+	export GO111MODULE="auto"
+
+	mkdir -p "${GOPATH}/bin"
+	export PATH="${GOPATH}/bin:${PATH}"
+
+	# Proxy
+	export http_proxy="${http_proxy:-}"
+	export https_proxy="${https_proxy:-}"
+
+	# Binaries
+	mkdir -p "${SNAPCRAFT_STAGE}/bin"
+
+	export PATH="$PATH:${SNAPCRAFT_STAGE}/bin"
+
+	# YAML query tool
+	export yq="${SNAPCRAFT_STAGE}/bin/yq"
+
+	# Kata paths
+	export kata_dir=$(printf "%s/src/github.com/%s/%s" \
+		"${GOPATH}" \
+		"${SNAPCRAFT_PROJECT_NAME}" \
+		"${SNAPCRAFT_PROJECT_NAME}")
+
+	export versions_file="${kata_dir}/versions.yaml"
+
+	[ -n "${yq:-}" ] && [ -x "${yq:-}" ] || snap_common_install_yq
+}
+
+snap_common_main

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -357,7 +357,7 @@ parts:
     after: [godeps]
     override-build: |
       arch=$(uname -m)
-      if [ "{$arch}" == "aarch64" ] || [ "${arch}" == "x64_64" ]; then
+      if [ "${arch}" == "aarch64" ] || [ "${arch}" == "x86_64" ]; then
           sudo apt-get -y update
           sudo apt-get -y install ca-certificates curl gnupg lsb-release
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,6 +19,8 @@ parts:
       - git
       - git-extras
     override-pull: |
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
+
       version="9999"
 
       if echo "${GITHUB_REF:-}" | grep -q -E "^refs/tags"; then
@@ -29,9 +31,6 @@ parts:
       snapcraftctl set-grade "stable"
       snapcraftctl set-version "${version}"
 
-      # setup GOPATH - this repo dir should be there
-      export GOPATH=${SNAPCRAFT_STAGE}/gopath
-      kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
       mkdir -p $(dirname ${kata_dir})
       ln -sf $(realpath "${SNAPCRAFT_STAGE}/..") ${kata_dir}
 
@@ -43,28 +42,12 @@ parts:
     build-packages:
       - curl
     override-build: |
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
+
       # put everything in stage
-      cd ${SNAPCRAFT_STAGE}
+      cd "${SNAPCRAFT_STAGE}"
 
-      mkdir -p "${SNAPCRAFT_STAGE}/bin/"
-      yq_path="${SNAPCRAFT_STAGE}/bin/yq"
-      yq_pkg="github.com/mikefarah/yq"
-      goos="linux"
-      case "$(uname -m)" in
-        aarch64) goarch="arm64";;
-        ppc64le) goarch="ppc64le";;
-        x86_64) goarch="amd64";;
-        s390x) goarch="s390x";;
-        *) echo "unsupported architecture: $(uname -m)"; exit 1;;
-      esac
-
-      yq_version=3.4.1
-      yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos}_${goarch}"
-      curl -o "${yq_path}" -L "${yq_url}"
-      chmod +x "${yq_path}"
-
-      kata_dir=gopath/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
-      version="$(${yq_path} r ${kata_dir}/versions.yaml languages.golang.meta.newest-version)"
+      version="$(${yq} r ${kata_dir}/versions.yaml languages.golang.meta.newest-version)"
       tarfile="go${version}.${goos}-${goarch}.tar.gz"
       curl -LO https://golang.org/dl/${tarfile}
       tar -xf ${tarfile} --strip-components=1
@@ -81,28 +64,17 @@ parts:
       - uidmap
       - gnupg2
     override-build: |
-      [ "$(uname -m)" = "ppc64le" ] || [ "$(uname -m)" = "s390x" ] && sudo apt-get --no-install-recommends install -y protobuf-compiler
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
 
-      yq=${SNAPCRAFT_STAGE}/bin/yq
+      [ "${arch}" = "ppc64le" ] || [ "${arch}" = "s390x" ] && sudo apt-get --no-install-recommends install -y protobuf-compiler
 
-      # set GOPATH
-      export GOPATH=${SNAPCRAFT_STAGE}/gopath
-      kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
-
-      export GOROOT=${SNAPCRAFT_STAGE}
-      export PATH="${GOROOT}/bin:${PATH}"
-      export GO111MODULE="auto"
-
-      http_proxy=${http_proxy:-""}
-      https_proxy=${https_proxy:-""}
       if [ -n "$http_proxy" ]; then
         echo "Setting proxy $http_proxy"
-        sudo -E systemctl set-environment http_proxy=$http_proxy || true
-        sudo -E systemctl set-environment https_proxy=$https_proxy || true
+        sudo -E systemctl set-environment http_proxy="$http_proxy" || true
+        sudo -E systemctl set-environment https_proxy="$https_proxy" || true
       fi
 
       # Copy yq binary. It's used in the container
-      mkdir -p "${GOPATH}/bin/"
       cp -a "${yq}" "${GOPATH}/bin/"
 
       echo "Unmasking docker service"
@@ -113,63 +85,54 @@ parts:
       echo "Starting docker"
       sudo -E systemctl start docker || true
 
-      cd ${kata_dir}/tools/osbuilder
+      cd "${kata_dir}/tools/osbuilder"
 
       # build image
       export AGENT_INIT=yes
       export USE_DOCKER=1
       export DEBUG=1
-      arch="$(uname -m)"
       initrd_distro=$(${yq} r -X ${kata_dir}/versions.yaml assets.initrd.architecture.${arch}.name)
       image_distro=$(${yq} r -X ${kata_dir}/versions.yaml assets.image.architecture.${arch}.name)
       case "$arch" in
         x86_64)
           # In some build systems it's impossible to build a rootfs image, try with the initrd image
-          sudo -E PATH=$PATH make image DISTRO=${image_distro} || sudo -E PATH=$PATH make initrd DISTRO=${initrd_distro}
+          sudo -E PATH=$PATH make image DISTRO="${image_distro}" || sudo -E PATH="$PATH" make initrd DISTRO="${initrd_distro}"
         ;;
 
         aarch64|ppc64le|s390x)
-          sudo -E PATH=$PATH make initrd DISTRO=${initrd_distro}
+          sudo -E PATH="$PATH" make initrd DISTRO="${initrd_distro}"
         ;;
 
-        *) echo "unsupported architecture: $(uname -m)"; exit 1;;
+        *) die "unsupported architecture: ${arch}" ;;
       esac
 
       # Install image
-      kata_image_dir=${SNAPCRAFT_PART_INSTALL}/usr/share/kata-containers
-      mkdir -p ${kata_image_dir}
-      cp kata-containers*.img ${kata_image_dir}
+      kata_image_dir="${SNAPCRAFT_PART_INSTALL}/usr/share/kata-containers"
+      mkdir -p "${kata_image_dir}"
+      cp kata-containers*.img "${kata_image_dir}"
 
   runtime:
     after: [godeps, image, cloud-hypervisor]
     plugin: nil
     build-attributes: [no-patchelf]
     override-build: |
-      # set GOPATH
-      export GOPATH=${SNAPCRAFT_STAGE}/gopath
-      export GOROOT=${SNAPCRAFT_STAGE}
-      export PATH="${GOROOT}/bin:${PATH}"
-      export GO111MODULE="auto"
-      kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
 
-      cd ${kata_dir}/src/runtime
+      cd "${kata_dir}/src/runtime"
 
-      # setup arch
-      arch=$(uname -m)
-      if [ ${arch} = "ppc64le" ]; then
-        arch="ppc64"
-      fi
+      qemu_cmd="qemu-system-${qemu_arch}"
 
       # build and install runtime
       make \
-        PREFIX=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr \
+        PREFIX="/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr" \
         SKIP_GO_VERSION_CHECK=1 \
-        QEMUCMD=qemu-system-$arch
+        QEMUCMD="${qemu_cmd}"
+
       make install \
         PREFIX=/usr \
-        DESTDIR=${SNAPCRAFT_PART_INSTALL} \
+        DESTDIR="${SNAPCRAFT_PART_INSTALL}" \
         SKIP_GO_VERSION_CHECK=1 \
-        QEMUCMD=qemu-system-$arch
+        QEMUCMD="${qemu_cmd}"
 
       if [ ! -f ${SNAPCRAFT_PART_INSTALL}/../../image/install/usr/share/kata-containers/kata-containers.img ]; then
         sed -i -e "s|^image =.*|initrd = \"/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr/share/kata-containers/kata-containers-initrd.img\"|" \
@@ -186,44 +149,37 @@ parts:
       - bison
       - flex
     override-build: |
-      yq=${SNAPCRAFT_STAGE}/bin/yq
-      export PATH="${PATH}:${SNAPCRAFT_STAGE}"
-      export GOPATH=${SNAPCRAFT_STAGE}/gopath
-      kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
-      versions_file="${kata_dir}/versions.yaml"
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
+
       kernel_version="$(${yq} r $versions_file assets.kernel.version)"
       #Remove extra 'v'
-      kernel_version=${kernel_version#v}
+      kernel_version="${kernel_version#v}"
 
-      [ "$(uname -m)" = "s390x" ] && sudo apt-get --no-install-recommends install -y libssl-dev
+      [ "${arch}" = "s390x" ] && sudo apt-get --no-install-recommends install -y libssl-dev
 
-      export GOPATH=${SNAPCRAFT_STAGE}/gopath
-      export GO111MODULE="auto"
-      kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
-
-      cd ${kata_dir}/tools/packaging/kernel
+      cd "${kata_dir}/tools/packaging/kernel"
       kernel_dir_prefix="kata-linux-"
 
       # Setup and build kernel
-      ./build-kernel.sh -v ${kernel_version} -d setup
+      ./build-kernel.sh -v "${kernel_version}" -d setup
       cd ${kernel_dir_prefix}*
       make -j $(($(nproc)-1)) EXTRAVERSION=".container"
 
-      kernel_suffix=${kernel_version}.container
-      kata_kernel_dir=${SNAPCRAFT_PART_INSTALL}/usr/share/kata-containers
-      mkdir -p ${kata_kernel_dir}
+      kernel_suffix="${kernel_version}.container"
+      kata_kernel_dir="${SNAPCRAFT_PART_INSTALL}/usr/share/kata-containers"
+      mkdir -p "${kata_kernel_dir}"
 
       # Install bz kernel
-      make install INSTALL_PATH=${kata_kernel_dir} EXTRAVERSION=".container" || true
-      vmlinuz_name=vmlinuz-${kernel_suffix}
-      ln -sf ${vmlinuz_name} ${kata_kernel_dir}/vmlinuz.container
+      make install INSTALL_PATH="${kata_kernel_dir}" EXTRAVERSION=".container" || true
+      vmlinuz_name="vmlinuz-${kernel_suffix}"
+      ln -sf "${vmlinuz_name}" "${kata_kernel_dir}/vmlinuz.container"
 
       # Install raw kernel
-      vmlinux_path=vmlinux
-      [ "$(uname -m)" = "s390x" ] && vmlinux_path=arch/s390/boot/compressed/vmlinux
-      vmlinux_name=vmlinux-${kernel_suffix}
-      cp ${vmlinux_path} ${kata_kernel_dir}/${vmlinux_name}
-      ln -sf ${vmlinux_name} ${kata_kernel_dir}/vmlinux.container
+      vmlinux_path="vmlinux"
+      [ "${arch}" = "s390x" ] && vmlinux_path="arch/s390/boot/compressed/vmlinux"
+      vmlinux_name="vmlinux-${kernel_suffix}"
+      cp "${vmlinux_path}" "${kata_kernel_dir}/${vmlinux_name}"
+      ln -sf "${vmlinux_name}" "${kata_kernel_dir}/vmlinux.container"
 
   qemu:
     plugin: make
@@ -250,12 +206,8 @@ parts:
       - libselinux1-dev
       - ninja-build
     override-build: |
-      yq=${SNAPCRAFT_STAGE}/bin/yq
-      export GOPATH=${SNAPCRAFT_STAGE}/gopath
-      export GO111MODULE="auto"
-      kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
 
-      versions_file="${kata_dir}/versions.yaml"
       branch="$(${yq} r ${versions_file} assets.hypervisor.qemu.version)"
       url="$(${yq} r ${versions_file} assets.hypervisor.qemu.url)"
       commit=""
@@ -263,11 +215,11 @@ parts:
       patches_version_dir="${kata_dir}/tools/packaging/qemu/patches/tag_patches/${branch}"
 
       # download source
-      qemu_dir=${SNAPCRAFT_STAGE}/qemu
+      qemu_dir="${SNAPCRAFT_STAGE}/qemu"
       rm -rf "${qemu_dir}"
       git clone --depth 1 --branch ${branch} --single-branch ${url} "${qemu_dir}"
-      cd ${qemu_dir}
-      [ -z "${commit}" ] || git checkout ${commit}
+      cd "${qemu_dir}"
+      [ -z "${commit}" ] || git checkout "${commit}"
 
       [ -n "$(ls -A ui/keycodemapdb)" ] || git clone --depth 1 https://github.com/qemu/keycodemapdb ui/keycodemapdb/
       [ -n "$(ls -A capstone)" ] || git clone --depth 1 https://github.com/qemu/capstone capstone
@@ -278,10 +230,10 @@ parts:
       ${kata_dir}/tools/packaging/scripts/apply_patches.sh "${patches_version_dir}"
 
       # Only x86_64 supports libpmem
-      [ "$(uname -m)" = "x86_64" ] && sudo apt-get --no-install-recommends install -y apt-utils ca-certificates libpmem-dev
+      [ "${arch}" = "x86_64" ] && sudo apt-get --no-install-recommends install -y apt-utils ca-certificates libpmem-dev
 
-      configure_hypervisor=${kata_dir}/tools/packaging/scripts/configure-hypervisor.sh
-      chmod +x ${configure_hypervisor}
+      configure_hypervisor="${kata_dir}/tools/packaging/scripts/configure-hypervisor.sh"
+      chmod +x "${configure_hypervisor}"
       # static build. The --prefix, --libdir, --libexecdir, --datadir arguments are
       # based on PREFIX and set by configure-hypervisor.sh
       echo "$(PREFIX=/snap/${SNAPCRAFT_PROJECT_NAME}/current/usr ${configure_hypervisor} -s kata-qemu) \
@@ -291,17 +243,17 @@ parts:
       # Copy QEMU configurations (Kconfigs)
       case "${branch}" in
       "v5.1.0")
-        cp -a ${kata_dir}/tools/packaging/qemu/default-configs/* default-configs
+        cp -a "${kata_dir}"/tools/packaging/qemu/default-configs/* default-configs
         ;;
 
       *)
-        cp -a ${kata_dir}/tools/packaging/qemu/default-configs/* configs/devices/
+        cp -a "${kata_dir}"/tools/packaging/qemu/default-configs/* configs/devices/
         ;;
       esac
 
       # build and install
       make -j $(($(nproc)-1))
-      make install DESTDIR=${SNAPCRAFT_PART_INSTALL}
+      make install DESTDIR="${SNAPCRAFT_PART_INSTALL}"
     prime:
       - -snap/
       - -usr/bin/qemu-ga
@@ -321,11 +273,13 @@ parts:
     plugin: nil
     after: [godeps]
     override-build: |
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
+
       # Currently, only one platform uses the new rust virtiofsd. The
       # others make use of QEMU's C implementation.
       #
       # See "tools/packaging/scripts/configure-hypervisor.sh".
-      if [ "$(uname -m)" = 'x86_64' ]
+      if [ "${arch}" = 'x86_64' ]
       then
           echo "INFO: Building rust version of virtiofsd"
       else
@@ -334,14 +288,8 @@ parts:
           exit 0
       fi
 
-      # put everything in stage
-      cd ${SNAPCRAFT_STAGE}
-
-      export PATH="$PATH:${SNAPCRAFT_STAGE}/bin"
-      export GOPATH=${SNAPCRAFT_STAGE}/gopath
-
-      kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
       cd "${kata_dir}"
+
       # Download the rust implementation of virtiofsd
       tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
       sudo install \
@@ -356,22 +304,31 @@ parts:
     plugin: nil
     after: [godeps]
     override-build: |
-      arch=$(uname -m)
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
+
       if [ "${arch}" == "aarch64" ] || [ "${arch}" == "x86_64" ]; then
           sudo apt-get -y update
           sudo apt-get -y install ca-certificates curl gnupg lsb-release
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+          curl -fsSL https://download.docker.com/linux/ubuntu/gpg |\
+              sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+          distro_codename=$(lsb_release -cs)
+          echo "deb [arch=${dpkg_arch} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu ${distro_codename} stable" |\
+              sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
           sudo apt-get -y update
           sudo apt-get -y install docker-ce docker-ce-cli containerd.io
           sudo systemctl start docker.socket
 
-          export GOPATH=${SNAPCRAFT_STAGE}/gopath
-          kata_dir=${GOPATH}/src/github.com/${SNAPCRAFT_PROJECT_NAME}/${SNAPCRAFT_PROJECT_NAME}
-          cd ${kata_dir}
+          cd "${SNAPCRAFT_PROJECT_DIR}"
           sudo -E NO_TTY=true make cloud-hypervisor-tarball
-          tar xvJpf build/kata-static-cloud-hypervisor.tar.xz -C /tmp/
-          install -D /tmp/opt/kata/bin/cloud-hypervisor ${SNAPCRAFT_PART_INSTALL}/usr/bin/cloud-hypervisor
+
+          tarfile="${SNAPCRAFT_PROJECT_DIR}/tools/packaging/kata-deploy/local-build/build/kata-static-cloud-hypervisor.tar.xz"
+          tmpdir=$(mktemp -d)
+
+          tar -xvJpf "${tarfile}" -C "${tmpdir}"
+
+          install -D "${tmpdir}/opt/kata/bin/cloud-hypervisor" "${SNAPCRAFT_PART_INSTALL}/usr/bin/cloud-hypervisor"
+
+          rm -rf "${tmpdir}"
       fi
 
 apps:

--- a/tools/packaging/Makefile
+++ b/tools/packaging/Makefile
@@ -29,6 +29,6 @@ snap: $(YQ)
 	@if [ "$$(cat $(VERSION_FILE))" != "$$($(YQ) r $(SNAPCRAFT_FILE) version)" ]; then \
 		>&2 echo "Warning: $(SNAPCRAFT_FILE) version is different to upstream $(VERSION_FILE) file"; \
 	fi
-	snapcraft -d
+	snapcraft -d --destructive-mode
 
 .PHONY: test-static-build snap

--- a/tools/packaging/README.md
+++ b/tools/packaging/README.md
@@ -14,7 +14,7 @@ running Kubernetes Cluster very straightforward.
 
 ## Build a snap package
 
-See [the snap documentation](../../snap).
+See [the snap documentation](../../snap/local).
 
 ## Build static binaries
 


### PR DESCRIPTION
Move the common shell code to a helper script that is sourced by all
parts.

Add extra quoting to some variables in the snap config file
and simplify.

Fixes: #4304.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>