### PR TITLE
stable-2.4: runtime: Adding the correct detection of mediated PCIe devices

### DIFF
--- a/src/runtime/virtcontainers/device/drivers/utils.go
+++ b/src/runtime/virtcontainers/device/drivers/utils.go
@@ -45,9 +45,8 @@ func deviceLogger() *logrus.Entry {
 	return api.DeviceLogger()
 }
 
-// Identify PCIe device by /sys/bus/pci/slots/xx/max_bus_speed, sample content "8.0 GT/s PCIe"
-// The /sys/bus/pci/slots/xx/address contains bdf, sample content "0000:04:00"
-// bdf format: bus:slot.function
+// Identify PCIe device by reading the size of the PCI config space
+// Plain PCI device have 256 bytes of config space where PCIe devices have 4K
 func isPCIeDevice(bdf string) bool {
 	if len(strings.Split(bdf, ":")) == 2 {
 		bdf = PCIDomain + ":" + bdf

--- a/src/runtime/virtcontainers/device/drivers/vfio.go
+++ b/src/runtime/virtcontainers/device/drivers/vfio.go
@@ -222,6 +222,7 @@ func getVFIODetails(deviceFileName, iommuDevicesPath string) (deviceBDF, deviceS
 		// Get sysfsdev of device eg. /sys/devices/pci0000:00/0000:00:02.0/f79944e4-5a3d-11e8-99ce-479cbab002e4
 		sysfsDevStr := filepath.Join(iommuDevicesPath, deviceFileName)
 		deviceSysfsDev, err = getSysfsDev(sysfsDevStr)
+		deviceBDF = getBDF(getMediatedBDF(deviceSysfsDev))
 	default:
 		err = fmt.Errorf("Incorrect tokens found while parsing vfio details: %s", deviceFileName)
 	}
@@ -229,10 +230,23 @@ func getVFIODetails(deviceFileName, iommuDevicesPath string) (deviceBDF, deviceS
 	return deviceBDF, deviceSysfsDev, vfioDeviceType, err
 }
 
+// getMediatedBDF returns the BDF of a VF
+// Expected input string format is /sys/devices/pci0000:d7/BDF0/BDF1/.../MDEVBDF/UUID
+func getMediatedBDF(deviceSysfsDev string) string {
+	tokens := strings.SplitN(deviceSysfsDev, "/", -1)
+	if len(tokens) < 4 {
+		return ""
+	}
+	return tokens[len(tokens)-2]
+}
+
 // getBDF returns the BDF of pci device
 // Expected input string format is [<domain>]:[<bus>][<slot>].[<func>] eg. 0000:02:10.0
 func getBDF(deviceSysStr string) string {
 	tokens := strings.SplitN(deviceSysStr, ":", 2)
+	if len(tokens) == 1 {
+		return ""
+	}
 	return tokens[1]
 }
 

--- a/src/runtime/virtcontainers/device/drivers/vfio_test.go
+++ b/src/runtime/virtcontainers/device/drivers/vfio_test.go
@@ -46,4 +46,5 @@ func TestGetVFIODetails(t *testing.T) {
 			assert.Nil(t, err)
 		}
 	}
+
 }


### PR DESCRIPTION
Fixes #4212

Backport-of: https://github.com/kata-containers/kata-containers/pull/4213
Signed-off-by: Zvonko Kaiser <zkaiser@nvidia.com>