### PR TITLE
docs: Update configuration reference for snap documentation

### DIFF
--- a/snap/local/README.md
+++ b/snap/local/README.md
@@ -92,7 +92,7 @@ and [configured][7].
 [1]: https://docs.snapcraft.io/snaps/intro
 [2]: ../../docs/design/architecture/README.md#root-filesystem-image
 [3]: https://docs.snapcraft.io/reference/confinement#classic
-[4]: https://github.com/kata-containers/runtime#configuration
+[4]: https://github.com/kata-containers/kata-containers/tree/main/src/runtime#configuration
 [5]: https://docs.docker.com/engine/reference/commandline/dockerd
 [6]: ../../docs/install/docker/ubuntu-docker-install.md
 [7]: ../../docs/Developer-Guide.md#configure-to-use-initrd-or-rootfs-image


### PR DESCRIPTION
This PR updates the url link for the kata containers configuration
for the general snap documentation.

Fixes #4341

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>