### PR TITLE
agent, runk: Enable test for the agent built with standard-oci-runtime feature 

### DIFF
--- a/src/agent/rustjail/src/console.rs
+++ b/src/agent/rustjail/src/console.rs
@@ -58,10 +58,7 @@ pub fn setup_master_console(socket_fd: RawFd) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::skip_if_not_root;
-    use std::fs::File;
     use std::os::unix::net::UnixListener;
-    use std::path::PathBuf;
     use tempfile::{self, tempdir};
 
     const CONSOLE_SOCKET: &str = "console-socket";

--- a/src/tools/runk/Makefile
+++ b/src/tools/runk/Makefile
@@ -7,6 +7,7 @@ include ../../../utils.mk
 
 TARGET = runk
 TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)
+AGENT_SOURCE_PATH = ../../agent
 
 # BINDIR is a directory for installing executable programs
 BINDIR := /usr/local/bin
@@ -26,8 +27,13 @@ clean:
 vendor:
 	cargo vendor
 
-test:
+test: test-runk test-agent
+
+test-runk:
 	cargo test --all --target $(TRIPLE) -- --nocapture
+
+test-agent:
+	make test -C $(AGENT_SOURCE_PATH) STANDARD_OCI_RUNTIME=yes
 
 check: standard_rust_check
 


### PR DESCRIPTION
First commit: 
agent: Remove unused import in console test                
Remove some unused imports in console test module
used by runk's test.                                          

Second commit:
runk: Enable test for the agent built with standard-oci-runtime feature 
This enables tests for the kata-agent for runk that is built            
with standard-oci-runtime feature in CI.                                
                                                                        
Fixes: #4351                                                            
                                                                        
Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>               
                                                                        