### PR TITLE
agent: return mount file content if parse mountinfo failed

### DIFF
--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -859,8 +859,9 @@ pub fn get_mount_fs_type_from_file(mount_file: &str, mount_point: &str) -> Resul
     }
 
     Err(anyhow!(
-        "failed to find FS type for mount point {}",
-        mount_point
+        "failed to find FS type for mount point {}, mount file content: {:?}",
+        mount_point,
+        fs::read_to_string(mount_file)
     ))
 }
 


### PR DESCRIPTION
Include mount file content in error message when parsing
mountinfo failed for debug.

Fixes: #4246, #4103

Signed-off-by: Bin Liu <bin@hyper.sh>