### PR TITLE
osbuilder: add iptables package

### DIFF
--- a/tools/osbuilder/rootfs-builder/alpine/config.sh
+++ b/tools/osbuilder/rootfs-builder/alpine/config.sh
@@ -13,7 +13,7 @@ BASE_PACKAGES="alpine-base"
 # See a list of mirrors at http://nl.alpinelinux.org/alpine/MIRRORS.txt
 MIRROR=https://dl-5.alpinelinux.org/alpine
 
-PACKAGES=""
+PACKAGES="iptables ip6tables"
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=kata-agent

--- a/tools/osbuilder/rootfs-builder/centos/config.sh
+++ b/tools/osbuilder/rootfs-builder/centos/config.sh
@@ -5,7 +5,7 @@
 
 OS_NAME=centos
 OS_VERSION=${OS_VERSION:-stream9}
-PACKAGES=chrony
+PACKAGES="chrony iptables"
 [ "$AGENT_INIT" = no ] && PACKAGES+=" systemd"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp"
 

--- a/tools/osbuilder/rootfs-builder/clearlinux/config.sh
+++ b/tools/osbuilder/rootfs-builder/clearlinux/config.sh
@@ -15,12 +15,12 @@ clr_url="https://download.clearlinux.org"
 
 BASE_URL="${clr_url}/releases/${OS_VERSION}/${REPO_NAME}/${ARCH}/os/"
 
-PACKAGES="libudev0-shim kmod-bin"
+PACKAGES="libudev0-shim kmod-bin iptables-bin"
 
 #Optional packages:
 # systemd: An init system that will start kata-agent if kata-agent
 #          itself is not configured as init process.
-[ "$AGENT_INIT" = "no" ] && PACKAGES+=" systemd chrony iptables-bin util-linux-bin" || true
+[ "$AGENT_INIT" = "no" ] && PACKAGES+=" systemd chrony util-linux-bin" || true
 
 # Init process must be one of {systemd,kata-agent}
 INIT_PROCESS=systemd

--- a/tools/osbuilder/rootfs-builder/debian/config.sh
+++ b/tools/osbuilder/rootfs-builder/debian/config.sh
@@ -8,7 +8,7 @@ OS_VERSION=${OS_VERSION:-10.11}
 # Set OS_NAME to the desired debian "codename"
 OS_NAME=${OS_NAME:-"stretch"}
 
-PACKAGES="systemd coreutils init chrony kmod"
+PACKAGES="systemd coreutils init iptables chrony kmod"
 
 # NOTE: Re-using ubuntu rootfs configuration, see 'ubuntu' folder for full content.
 source $script_dir/ubuntu/$CONFIG_SH

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -5,7 +5,7 @@
 OS_NAME=ubuntu
 # This should be Ubuntu's code name, e.g. "focal" (Focal Fossa) for 20.04
 OS_VERSION=${OS_VERSION:-focal}
-PACKAGES=chrony
+PACKAGES="chrony iptables"
 [ "$AGENT_INIT" = no ] && PACKAGES+=" init"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp2"
 REPO_URL=http://ports.ubuntu.com


### PR DESCRIPTION
Since we are introducing an agent API for interacting with guest
iptables, let's ensure that our example rootfs' have iptables-save/restore
installed.

Fixes: #4356

Signed-off-by: Eric Ernst <eric_ernst@apple.com>