### PR TITLE
workflow: trigger test-kata-deploy with pull_request and fix workflow_dispatch

### DIFF
--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -1,5 +1,10 @@
 on:
   workflow_dispatch: # this is used to trigger the workflow on non-main branches
+    inputs:
+      pr:
+        description: 'PR number from the selected branch to test'
+        type: string
+        required: true
   issue_comment:
     types: [created, edited]
 
@@ -13,19 +18,20 @@ jobs:
       && github.event_name == 'issue_comment'
       && github.event.action == 'created'
       && startsWith(github.event.comment.body, '/test_kata_deploy')
+      || github.event_name == 'workflow_dispatch'
     steps:
-      - name: Check membership
+      - name: Check membership on comment or dispatch
         uses: kata-containers/is-organization-member@1.0.1
         id: is_organization_member
         with:
           organization: kata-containers
-          username: ${{ github.event.comment.user.login }}
+          username: ${{ github.event.comment.user.login || github.event.sender.login }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fail if not member
         run: |
           result=${{ steps.is_organization_member.outputs.result }}
           if [ $result == false ]; then
-              user=${{ github.event.comment.user.login }}
+              user=${{ github.event.comment.user.login || github.event.sender.login }}
               echo Either ${user} is not part of the kata-containers organization
               echo or ${user} has its Organization Visibility set to Private at
               echo https://github.com/orgs/kata-containers/people?query=${user}
@@ -53,8 +59,12 @@ jobs:
       - name: get-PR-ref
         id: get-PR-ref
         run: |
-            ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
-            echo "reference for PR: " ${ref}
+            if [ ${{ github.event_name }} == 'issue_comment' ]; then
+                ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
+            else # workflow_dispatch
+                ref="refs/pull/${{ github.event.inputs.pr }}/merge"
+            fi
+            echo "reference for PR: " ${ref} "event:" ${{ github.event_name }}
             echo "##[set-output name=pr-ref;]${ref}"
       - uses: actions/checkout@v2
         with:
@@ -89,8 +99,12 @@ jobs:
       - name: get-PR-ref
         id: get-PR-ref
         run: |
-            ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
-            echo "reference for PR: " ${ref}
+            if [ ${{ github.event_name }} == 'issue_comment' ]; then
+                ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
+            else # workflow_dispatch
+                ref="refs/pull/${{ github.event.inputs.pr }}/merge"
+            fi
+            echo "reference for PR: " ${ref} "event:" ${{ github.event_name }}
             echo "##[set-output name=pr-ref;]${ref}"
       - uses: actions/checkout@v2
         with:
@@ -116,8 +130,12 @@ jobs:
       - name: get-PR-ref
         id: get-PR-ref
         run: |
-            ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
-            echo "reference for PR: " ${ref}
+            if [ ${{ github.event_name }} == 'issue_comment' ]; then
+                ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
+            else # workflow_dispatch
+                ref="refs/pull/${{ github.event.inputs.pr }}/merge"
+            fi
+            echo "reference for PR: " ${ref} "event:" ${{ github.event_name }}
             echo "##[set-output name=pr-ref;]${ref}"
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -1,11 +1,19 @@
 on:
-  workflow_dispatch: # this is used to trigger the workflow on non-main branches
+  pull_request: # this will trigger the workflow on PRs that changes release version
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+    paths:
+      - VERSION
+  workflow_dispatch: # this allows to trigger the workflow manually on non-main branches
     inputs:
       pr:
         description: 'PR number from the selected branch to test'
         type: string
         required: true
-  issue_comment:
+  issue_comment: # this allows to trigger the workflow from main by commenting "/test_kata_deploy"
     types: [created, edited]
 
 name: test-kata-deploy
@@ -19,13 +27,14 @@ jobs:
       && github.event.action == 'created'
       && startsWith(github.event.comment.body, '/test_kata_deploy')
       || github.event_name == 'workflow_dispatch'
+      || github.event_name == 'pull_request'
     steps:
       - name: Check membership on comment or dispatch
         uses: kata-containers/is-organization-member@1.0.1
         id: is_organization_member
         with:
           organization: kata-containers
-          username: ${{ github.event.comment.user.login || github.event.sender.login }}
+          username: ${{ github.event.comment.user.login || github.event.sender.login }} # first one applies only on issue_comment
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Fail if not member
         run: |
@@ -61,8 +70,10 @@ jobs:
         run: |
             if [ ${{ github.event_name }} == 'issue_comment' ]; then
                 ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
-            else # workflow_dispatch
+            elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
                 ref="refs/pull/${{ github.event.inputs.pr }}/merge"
+            elif [ ${{ github.event_name }} == 'pull_request' ]; then
+                ref="refs/pull/${{ github.event.number }}/merge"
             fi
             echo "reference for PR: " ${ref} "event:" ${{ github.event_name }}
             echo "##[set-output name=pr-ref;]${ref}"
@@ -101,8 +112,10 @@ jobs:
         run: |
             if [ ${{ github.event_name }} == 'issue_comment' ]; then
                 ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
-            else # workflow_dispatch
+            elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
                 ref="refs/pull/${{ github.event.inputs.pr }}/merge"
+            elif [ ${{ github.event_name }} == 'pull_request' ]; then
+                ref="refs/pull/${{ github.event.number }}/merge"
             fi
             echo "reference for PR: " ${ref} "event:" ${{ github.event_name }}
             echo "##[set-output name=pr-ref;]${ref}"
@@ -132,8 +145,10 @@ jobs:
         run: |
             if [ ${{ github.event_name }} == 'issue_comment' ]; then
                 ref=$(cat $GITHUB_EVENT_PATH | jq -r '.issue.pull_request.url' | sed  's#^.*\/pulls#refs\/pull#' | sed 's#$#\/merge#')
-            else # workflow_dispatch
+            elif [ ${{ github.event_name }} == 'workflow_dispatch' ]; then
                 ref="refs/pull/${{ github.event.inputs.pr }}/merge"
+            elif [ ${{ github.event_name }} == 'pull_request' ]; then
+                ref="refs/pull/${{ github.event.number }}/merge"
             fi
             echo "reference for PR: " ${ref} "event:" ${{ github.event_name }}
             echo "##[set-output name=pr-ref;]${ref}"

--- a/docs/Release-Process.md
+++ b/docs/Release-Process.md
@@ -48,7 +48,7 @@
 ### Merge all bump version Pull requests
 
   - The above step will create a GitHub pull request in the Kata projects. Trigger the CI using `/test` command on each bump Pull request.
-  - Trigger the `test-kata-deploy` workflow which is under the `Actions` tab on the repository GitHub page (make sure to select the correct branch and validate it passes).
+  - `test-kata-deploy` workflow should be triggered automatically, validate it passes under the `Actions` tab on the repository GitHub page (you're also able to run it manually from there).
   - Check any failures and fix if needed.
   - Work with the Kata approvers to verify that the CI works and the pull requests are merged.
 


### PR DESCRIPTION
This with those changes **test-kata-deploy** is triggered in 3 ways:
1. **pull_request** events that changes VERSION, essentially, a release PR
2. **workflow_dispatch** event - manually triggered from Github's Actions web UI and required to mention the branch to run against
3. **comment_issue** event - triggered by commenting on PR with `/test_kata_deploy`, works only against main branch

All three methods validates it is triggered by a kata-containers member
Fixes: #4349
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>

**NOTE** This contains essential fixes for https://github.com/kata-containers/kata-containers/pull/4350