### PR TITLE
My 2.4 pr backport -- fix shim leak caused by ESRCH in agent destroy

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/wait.go
+++ b/src/runtime/pkg/containerd-shim-v2/wait.go
@@ -78,7 +78,7 @@ func wait(ctx context.Context, s *service, c *container, execID string) (int32, 
 				shimLog.WithField("sandbox", s.sandbox.ID()).Error("failed to delete sandbox")
 			}
 		} else {
-			if _, err = s.sandbox.StopContainer(ctx, c.id, false); err != nil {
+			if _, err = s.sandbox.StopContainer(ctx, c.id, true); err != nil {
 				shimLog.WithError(err).WithField("container", c.id).Warn("stop container failed")
 			}
 		}


### PR DESCRIPTION
See https://github.com/kata-containers/kata-containers/issues/4359