### PR TITLE
versions: Bump golang to 1.18.x

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.17.x, 1.18.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:

--- a/versions.yaml
+++ b/versions.yaml
@@ -254,12 +254,12 @@ languages:
     issue: "https://github.com/golang/go/issues/20676"
     uscan-url: >-
       https://github.com/golang/go/tags .*/go?([\d\.]+)\.tar\.gz
-    version: "1.16.10"
+    version: "1.17.11"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.17.3"
+      newest-version: "1.18.3"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
golang 1.16.x is no longer supported as of Feb 2021 according to
https://endoflife.date/go
Bumping the minimum version supported to 1.17.11 and the newest
version supported to 1.18.3.

Fixes #4392

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>