### PR TITLE
docs: Update storage documentation link

### DIFF
--- a/docs/design/architecture/storage.md
+++ b/docs/design/architecture/storage.md
@@ -20,7 +20,7 @@ For virtio-fs, the [runtime](README.md#runtime) starts one `virtiofsd` daemon
 ## Devicemapper
 
 The
-[devicemapper `snapshotter`](https://github.com/containerd/containerd/tree/master/snapshots/devmapper)
+[devicemapper `snapshotter`](https://github.com/containerd/containerd/tree/main/snapshots/devmapper)
 is a special case. The `snapshotter` uses dedicated block devices
 rather than formatted filesystems, and operates at the block level
 rather than the file level. This knowledge is used to directly use the


### PR DESCRIPTION
This PR updates the storage documentation link for the devicemapper
snapshotter.

Fixes #4398

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>