### PR TITLE
tools: Enable extra detail on error

### DIFF
--- a/src/tools/agent-ctl/src/main.rs
+++ b/src/tools/agent-ctl/src/main.rs
@@ -320,7 +320,7 @@ fn real_main() -> Result<()> {
 
 fn main() {
     if let Err(e) = real_main() {
-        eprintln!("ERROR: {}", e);
+        eprintln!("ERROR: {:#?}", e);
         exit(1);
     }
 }

--- a/src/tools/trace-forwarder/src/main.rs
+++ b/src/tools/trace-forwarder/src/main.rs
@@ -282,7 +282,7 @@ fn real_main() -> Result<()> {
 
 fn main() {
     if let Err(e) = real_main() {
-        eprintln!("ERROR: {}", e);
+        eprintln!("ERROR: {:#?}", e);
         exit(1);
     }
     exit(0);


### PR DESCRIPTION
The `agent-ctl` and `trace-forwarder` tools make use of
`anyhow::Context` to provide additional call site information on error.

However, previously neither tool was using the "alternate debug" format
to display the error, meaning full error output was not displayed.

Fixes: #4411.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>