### PR TITLE
docs: Add agent-ctl examples section

### DIFF
--- a/src/tools/agent-ctl/README.md
+++ b/src/tools/agent-ctl/README.md
@@ -60,7 +60,6 @@ $ mkdir -p "$rootfs_dir" && (cd "$bundle_dir" && runc spec)
 $ sudo docker export $(sudo docker create "$image") | tar -C "$rootfs_dir" -xvf -
 ```
 
-
 ### Specify API commands to run
 
 The tool allows one or more API commands to be specified using the `-c` or


### PR DESCRIPTION
Add a new `Examples` section to the `agent-ctl` docs giving some
examples of how to use the tool with QEMU and stand-alone.

Fixes: #4414.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>