### PR TITLE
shim: change the log level for GetOOMEvent call failures

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/wait.go
+++ b/src/runtime/pkg/containerd-shim-v2/wait.go
@@ -158,10 +158,10 @@ func watchOOMEvents(ctx context.Context, s *service) {
 			containerID, err := s.sandbox.GetOOMEvent(ctx)
 			if err != nil {
 				if err.Error() == "ttrpc: closed" || err.Error() == "Dead agent" {
-					shimLog.WithError(err).Warn("agent has shutdown, return from watching of OOM events")
+					shimLog.WithError(err).Info("agent has shutdown, return from watching of OOM events")
 					return
 				}
-				shimLog.WithError(err).Warn("failed to get OOM event from sandbox")
+				shimLog.WithError(err).Info("failed to get OOM event from sandbox")
 				time.Sleep(defaultCheckInterval)
 				continue
 			}


### PR DESCRIPTION
GetOOMEvent is a blocking call that will fail if
the container exit, in this case, it's not an error or warning.

Changing the log level for logs in case of GetOOMEvent call fails
will reduce log noise in a large cluster that has pods
creating/deleting frequently.

Fixes: #4376

Signed-off-by: Bin Liu <bin@hyper.sh>