### PR TITLE
agent: Add stacktrace to errors

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -714,4 +714,4 @@ time="2020-09-15T14:56:23.105268162+08:00" level=debug msg="reading guest consol
 time="2020-09-15T14:56:23.121121598+08:00" level=debug msg="reading guest console" console-protocol=unix console-url=/run/vc/vm/ab9f633385d4987828d342e47554fc6442445b32039023eeddaa971c1bb56791/console.sock pid=107642 sandbox=ab9f633385d4987828d342e47554fc6442445b32039023eeddaa971c1bb56791 source=virtcontainers subsystem=sandbox vmconsole="[    0.421324] memmap_init_zone_device initialised 32768 pages in 12ms"
 ...
 ```
-Refer to the [kata-log-parser documentation](../src/tools/log-parser/README.md) which is useful to fetch these.
+Refer to the [kata-log-parser documentation](../src/tools/log-parser) which is useful to fetch these.

--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9ecd88a8c8378ca913a680cd98f0f13ac67383d35993f86c90a70e3f137816b"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,6 +40,9 @@ name = "anyhow"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arc-swap"
@@ -76,6 +88,21 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "backtrace"
+version = "0.3.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11a17d453482a265fd5f8479f2a3f405566e6ca627837aaddb85af8b1ab8ef61"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if 1.0.0",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
 
 [[package]]
 name = "bincode"
@@ -452,6 +479,12 @@ dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "gimli"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78cc372d058dcf6d5ecd98510e7fbc9e5aec4d21de70f65fea8fecebcd881bd4"
 
 [[package]]
 name = "hashbrown"
@@ -881,6 +914,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "object"
+version = "0.28.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e42c982f2d955fac81dd7e1d0e1426a7d702acd9c98d19ab01083a6a0328c424"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1343,6 +1385,12 @@ dependencies = [
  "thiserror",
  "tokio",
 ]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ef03e0a2b150c7a90d01faf6254c9c48a41e95fb2a8c2ac1c6f0d2b9aefc342"
 
 [[package]]
 name = "rustjail"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -48,7 +48,7 @@ log = "0.4.11"
 
 prometheus = { version = "0.13.0", features = ["process"] }
 procfs = "0.12.0"
-anyhow = "1.0.32"
+anyhow = {version = "1.0.57", features = ["backtrace"] }
 cgroups = { package = "cgroups-rs", version = "0.2.8" }
 
 # Tracing

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -19,7 +19,6 @@ scan_fmt = "0.2.3"
 scopeguard = "1.0.0"
 thiserror = "1.0.26"
 regex = "1.5.5"
-serial_test = "0.5.1"
 sysinfo = "0.23.0"
 
 # Async helpers
@@ -65,6 +64,7 @@ clap = { version = "3.0.1", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.1.0"
+serial_test = "0.5.1"
 
 [workspace]
 members = [

--- a/src/agent/rustjail/Cargo.toml
+++ b/src/agent/rustjail/Cargo.toml
@@ -22,7 +22,7 @@ slog-scope = "4.1.2"
 scan_fmt = "0.2.6"
 regex = "1.5.5"
 path-absolutize = "1.2.0"
-anyhow = "1.0.32"
+anyhow = {version = "1.0.57", features = ["backtrace"] }
 cgroups = { package = "cgroups-rs", version = "0.2.8" }
 rlimit = "0.5.3"
 cfg-if = "0.1.0"

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -24,7 +24,7 @@ const CONTAINER_PIPE_SIZE_OPTION: &str = "agent.container_pipe_size";
 const UNIFIED_CGROUP_HIERARCHY_OPTION: &str = "agent.unified_cgroup_hierarchy";
 const CONFIG_FILE: &str = "agent.config_file";
 
-const DEFAULT_LOG_LEVEL: slog::Level = slog::Level::Info;
+pub const DEFAULT_LOG_LEVEL: slog::Level = slog::Level::Info;
 const DEFAULT_HOTPLUG_TIMEOUT: time::Duration = time::Duration::from_secs(3);
 const DEFAULT_CONTAINER_PIPE_SIZE: i32 = 0;
 const VSOCK_ADDR: &str = "vsock://-1";


### PR DESCRIPTION
agent: Add stacktrace to errors

If debug or trace level logging are enabled, add the current stacktrace
to errors so that a error then describes:

- The real (underlying) error.
- The context message which explains the underlying error.
- The stacktrace which helps understand where and why the error
  resulted.

Fixes: #4427.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>