### PR TITLE
docs: Add storage limits to arch doc

### DIFF
--- a/docs/design/architecture/storage.md
+++ b/docs/design/architecture/storage.md
@@ -1,5 +1,17 @@
 # Storage
 
+## Limits
+
+Kata Containers is [compatible](README.md#compatibility) with existing
+standards and runtime. From the perspective of storage, this means no
+limits are placed on the amount of storage a container
+[workload](README.md#workload) may use.
+
+Since cgroups are not able to set limits on storage allocation, if you
+wish to constrain the amount of storage a container uses, consider
+using an existing facility such as `quota(1)` limits or
+[device mapper](#devicemapper) limits.
+
 ## virtio SCSI
 
 If a block-based graph driver is [configured](README.md#configuration),


### PR DESCRIPTION
Updated the architecture document to explain that if you wish to
constrain the amount of disk space a container uses, you need to use an
existing facility such as `quota(1)`s or device mapper limits.

Fixes: #4430.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>