### PR TITLE
versions: Bump virtiofsd to v1.3.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -246,13 +246,13 @@ externals:
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"
     url: "https://gitlab.com/virtio-fs/virtiofsd"
-    version: "v1.2.0"
+    version: "v1.3.0"
     meta:
-      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.2.0,
-      # this is the link labelled virtiofsd-v1.2.0.zip
+      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.3.0,
+      # this is the link labelled virtiofsd-v1.3.0.zip
       #
       # yamllint disable-line rule:line-length
-      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/b26d9891caac83209a3fdd24bcf2ae86/virtiofsd-v1.2.0.zip"
+      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/9a4f2261fcb1701f1e709694b5c5d980/virtiofsd-v1.3.0.zip"
 
 languages:
   description: |


### PR DESCRIPTION
Changes since v1.2.0:
!123  Update rust-vmm dependencies                           (main) ← (update-deps)
!121  implement std::error::Error trait                      (main) ← (fix-impl-error)
!120  Show the nofile hard limit value in the warning me...  (main) ← (fix-rlimit-warn)
!119  Do not create tmpdir and bind mount /proc/self/fd ...  (main) ← (remove-tmp-dir-for-proc)
!116  Disable killpriv_v2 by default                         (main) ← (no-killpriv-default)

The one that affected Kata Containers the most was !119, as virtiofsd
would get denied when SELinux was set to run on enforcing mode.

Fixes: #4433

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>