### PR TITLE
runtime: fix error when trying to parse sandbox sizing annotations

### DIFF
--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -1114,7 +1114,7 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU, memSizeMB uint32) {
 	// ... to result in VM resources of 1 (MB) for memory, and 3 for CPU (2200 mCPU rounded up to 3).
 	annotation, ok := spec.Annotations[ctrAnnotations.SandboxCPUPeriod]
 	if ok {
-		period, err = strconv.ParseUint(annotation, 10, 32)
+		period, err = strconv.ParseUint(annotation, 10, 64)
 		if err != nil {
 			ociLog.Warningf("sandbox-sizing: failure to parse SandboxCPUPeriod: %s", annotation)
 			period = 0
@@ -1123,7 +1123,7 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU, memSizeMB uint32) {
 
 	annotation, ok = spec.Annotations[ctrAnnotations.SandboxCPUQuota]
 	if ok {
-		quota, err = strconv.ParseInt(annotation, 10, 32)
+		quota, err = strconv.ParseInt(annotation, 10, 64)
 		if err != nil {
 			ociLog.Warningf("sandbox-sizing: failure to parse SandboxCPUQuota: %s", annotation)
 			quota = 0
@@ -1132,7 +1132,7 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU, memSizeMB uint32) {
 
 	annotation, ok = spec.Annotations[ctrAnnotations.SandboxMem]
 	if ok {
-		memory, err = strconv.ParseInt(annotation, 10, 32)
+		memory, err = strconv.ParseInt(annotation, 10, 64)
 		if err != nil {
 			ociLog.Warningf("sandbox-sizing: failure to parse SandboxMem: %s", annotation)
 			memory = 0

--- a/src/runtime/pkg/oci/utils_test.go
+++ b/src/runtime/pkg/oci/utils_test.go
@@ -1196,6 +1196,11 @@ func TestCalculateSandboxSizing(t *testing.T) {
 			expectedCPU: 100,
 			expectedMem: 0,
 		},
+		{
+			spec:        makeSizingAnnotations("4294967296", "400", "100"),
+			expectedCPU: 4,
+			expectedMem: 4096,
+		},
 	}
 
 	for _, tt := range testCases {


### PR DESCRIPTION
Changed bitsize for parsing functions to 64-bit in order to avoid
parsing errors.

Fixes #4435

Signed-off-by: Alexandru Matei <alexandru.matei@uipath.com>