### PR TITLE
safe-path: fix clippy warning

### DIFF
--- a/src/libs/safe-path/src/pinned_path_buf.rs
+++ b/src/libs/safe-path/src/pinned_path_buf.rs
@@ -253,7 +253,7 @@ mod tests {
         fs::write(rootfs_path.join("endpoint"), "test").unwrap();
 
         // Pin the target and validate the path/content.
-        let path = PinnedPathBuf::new(rootfs_path.to_path_buf(), "symlink_dir/endpoint").unwrap();
+        let path = PinnedPathBuf::new(rootfs_path, "symlink_dir/endpoint").unwrap();
         assert!(!path.is_dir());
         let path_ref = path.deref();
         let target = fs::read_link(path_ref).unwrap();
@@ -344,6 +344,7 @@ mod tests {
         PinnedPathBuf::new(rootfs_path, "does_not_exist").unwrap_err();
     }
 
+    #[allow(clippy::zero_prefixed_literal)]
     #[test]
     fn test_new_pinned_path_buf_without_read_perm() {
         let rootfs_dir = tempfile::tempdir().expect("failed to create tmpdir");

--- a/src/libs/safe-path/src/scoped_dir_builder.rs
+++ b/src/libs/safe-path/src/scoped_dir_builder.rs
@@ -87,7 +87,7 @@ impl ScopedDirBuilder {
             )
         })?;
 
-        self.do_mkdir(&stripped_path)
+        self.do_mkdir(stripped_path)
     }
 
     /// Creates sub-directory with the options configured in this builder.
@@ -134,7 +134,7 @@ impl ScopedDirBuilder {
                     if !self.recursive && idx != levels {
                         return Err(Error::new(
                             ErrorKind::NotFound,
-                            format!("parent directory does not exist"),
+                            "parent directory does not exist".to_string(),
                         ));
                     }
                     dir = dir.mkdir(comp, self.mode)?;
@@ -146,6 +146,7 @@ impl ScopedDirBuilder {
     }
 }
 
+#[allow(clippy::zero_prefixed_literal)]
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
fix clippy warnings in safe-path lib to make clippy happy.

fixes: #4443 

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>