### PR TITLE
osbuilder: Fix attestation-agent build

### DIFF
--- a/docs/how-to/how-to-build-and-test-ccv0.md
+++ b/docs/how-to/how-to-build-and-test-ccv0.md
@@ -407,6 +407,7 @@ steps:
   configured and created using the VM as a single node cluster and with `AA_KBC` set to `offline_fs_kbc`. 
   ```bash
   $ export KUBERNETES="yes"
+  $ export SKOPEO="yes"
   $ export AA_KBC=offline_fs_kbc
   $ ~/ccv0.sh build_and_install_all
   ```

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -668,7 +668,7 @@ EOF
 		attestation_agent_branch="$(get_package_version_from_kata_yaml externals.attestation-agent.branch)"
 		info "Install attestation-agent with KBC ${AA_KBC}"
 		git clone "${attestation_agent_url}" --branch "${attestation_agent_branch}"
-		pushd attestation-agent
+		pushd attestation-agent/app
 		source "${HOME}/.cargo/env"
 		target="${ARCH}-unknown-linux-${LIBC}"
 		if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then


### PR DESCRIPTION
Fix of the attestation-agent build and install issue in rootfs.sh after the crate structure changed
Update the doc to clarify the skopeo requirement

Fixes: #4465
Signed-off-by: stevenhorsman <steven@uk.ibm.com>