### PR TITLE
doc: Update crictl pod-config

### DIFF
--- a/docs/how-to/ccv0.sh
+++ b/docs/how-to/ccv0.sh
@@ -432,8 +432,8 @@ call_crictl_create_cc_pod() {
     # Update iptables to allow forwarding to the cni0 bridge avoiding issues caused by the docker0 bridge
     sudo iptables -P FORWARD ACCEPT
     
-    # Create crictl pod config
-    local pod_config="${FIXTURES_DIR}/pod-config.yaml"
+    # get_pod_config in tests_common exports `pod_config` that points to the prepared pod config yaml 
+    get_pod_config
 
     crictl_delete_cc_pod_if_exists "${crictl_sandbox_name}"
     crictl_create_cc_pod "${pod_config}"
@@ -442,7 +442,9 @@ call_crictl_create_cc_pod() {
 
 call_crictl_create_cc_container() {
     # Create container configuration yaml based on our test copy of busybox
-    local pod_config="${FIXTURES_DIR}/pod-config.yaml"
+    # get_pod_config in tests_common exports `pod_config` that points to the prepared pod config yaml 
+    get_pod_config
+
     local container_config="${FIXTURES_DIR}/${CONTAINER_CONFIG_FILE:-container-config.yaml}"
     local pod_name=${crictl_sandbox_name}
     crictl_create_cc_container ${pod_name} ${pod_config} ${container_config}

--- a/docs/how-to/how-to-setup-swap-devices-in-guest-kernel.md
+++ b/docs/how-to/how-to-setup-swap-devices-in-guest-kernel.md
@@ -27,6 +27,8 @@ $ image="quay.io/prometheus/busybox:latest"
 $ cat << EOF > "${pod_yaml}"
 metadata:
   name: busybox-sandbox1
+  uid: $(uuidgen)
+  namespace: default
 EOF
 $ cat << EOF > "${container_yaml}"
 metadata:

--- a/docs/how-to/how-to-use-virtio-fs-nydus-with-kata.md
+++ b/docs/how-to/how-to-use-virtio-fs-nydus-with-kata.md
@@ -32,6 +32,7 @@ The `nydus-sandbox.yaml` looks like below:
 metadata:
   attempt: 1
   name: nydus-sandbox
+  uid: nydus-uid
   namespace: default
 log_directory: /tmp
 linux:

--- a/docs/how-to/how-to-use-virtio-mem-with-kata.md
+++ b/docs/how-to/how-to-use-virtio-mem-with-kata.md
@@ -42,6 +42,8 @@ $ image="quay.io/prometheus/busybox:latest"
 $ cat << EOF > "${pod_yaml}"
 metadata:
   name: busybox-sandbox1
+  uid: $(uuidgen)
+  namespace: default
 EOF
 $ cat << EOF > "${container_yaml}"
 metadata:


### PR DESCRIPTION
- Ensure that our documented crictl pod config file contents have
uid  and namespace fields for compatibility with crictl 1.24+

Fixes: https://github.com/kata-containers/kata-containers/issues/4513
Signed-off-by: stevenhorsman <steven@uk.ibm.com>