### PR TITLE
CCv0: Fix PS1 unbound error

### DIFF
--- a/docs/how-to/ccv0.sh
+++ b/docs/how-to/ccv0.sh
@@ -37,6 +37,8 @@ export PROFILE="${HOME}/.profile"
 if [ -r "${HOME}/.bash_profile" ]; then
     export PROFILE="${HOME}/.bash_profile"
 fi
+# Stop PS1: unbound variable error happening
+export PS1=${PS1:-}
 
 # Create a bunch of common, derived values up front so we don't need to create them in all the different functions
 . ${PROFILE}


### PR DESCRIPTION
export PS1, so it is bound

Fixes: #4531
Signed-off-by: stevenhorsman <steven@uk.ibm.com>