### PR TITLE
runtime-rs: Dragonball-sandbox - add virtio device feature support for aarch64

### DIFF
--- a/src/dragonball/src/device_manager/legacy.rs
+++ b/src/dragonball/src/device_manager/legacy.rs
@@ -156,18 +156,26 @@ pub(crate) mod aarch64 {
 
     type Result<T> = ::std::result::Result<T, Error>;
 
+    /// LegacyDeviceType: com1
+    pub const COM1: &str = "com1";
+    /// LegacyDeviceType: com2
+    pub const COM2: &str = "com2";
+    /// LegacyDeviceType: rtc
+    pub const RTC: &str = "rtc";
+
     impl LegacyDeviceManager {
+        /// Create a LegacyDeviceManager instance handling legacy devices.
         pub fn create_manager(
             bus: &mut IoManager,
             vm_fd: Option<Arc<VmFd>>,
             resources: &HashMap<String, DeviceResources>,
         ) -> Result<Self> {
             let (com1_device, com1_eventfd) =
-                Self::create_com_device(bus, vm_fd.as_ref(), resources.get("com1").unwrap())?;
+                Self::create_com_device(bus, vm_fd.as_ref(), resources.get(COM1).unwrap())?;
             let (com2_device, com2_eventfd) =
-                Self::create_com_device(bus, vm_fd.as_ref(), resources.get("com2").unwrap())?;
+                Self::create_com_device(bus, vm_fd.as_ref(), resources.get(COM2).unwrap())?;
             let (rtc_device, rtc_eventfd) =
-                Self::create_rtc_device(bus, vm_fd.as_ref(), resources.get("rtc").unwrap())?;
+                Self::create_rtc_device(bus, vm_fd.as_ref(), resources.get(RTC).unwrap())?;
 
             Ok(LegacyDeviceManager {
                 _rtc_device: rtc_device,

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -54,7 +54,7 @@ pub mod console_manager;
 pub use self::console_manager::ConsoleManager;
 
 mod legacy;
-pub use self::legacy::{Error as LegacyDeviceError, LegacyDeviceManager};
+pub use self::legacy::{Error as LegacyDeviceError, LegacyDeviceManager, aarch64::{COM1, COM2, RTC}};
 
 #[cfg(feature = "virtio-vsock")]
 /// Device manager for user-space vsock devices.
@@ -744,9 +744,9 @@ impl DeviceManager {
     ) -> std::result::Result<HashMap<String, DeviceResources>, StartMicroVmError> {
         let mut resources = HashMap::new();
         let legacy_devices = vec![
-            (DeviceType::Serial, String::from("com1")),
-            (DeviceType::Serial, String::from("com2")),
-            (DeviceType::RTC, String::from("rtc")),
+            (DeviceType::Serial, String::from(COM1)),
+            (DeviceType::Serial, String::from(COM2)),
+            (DeviceType::RTC, String::from(RTC)),
         ];
 
         for (device_type, device_id) in legacy_devices {

--- a/src/dragonball/src/error.rs
+++ b/src/dragonball/src/error.rs
@@ -12,7 +12,7 @@
 #[cfg(feature = "dbs-virtio-devices")]
 use dbs_virtio_devices::Error as VirtIoError;
 
-use crate::{address_space_manager, device_manager, vcpu, vm};
+use crate::{address_space_manager, device_manager, vcpu, vm, resource_manager};
 
 /// Shorthand result type for internal VMM commands.
 pub type Result<T> = std::result::Result<T, Error>;
@@ -73,6 +73,10 @@ pub enum Error {
 /// Errors associated with starting the instance.
 #[derive(Debug, thiserror::Error)]
 pub enum StartMicroVmError {
+    /// Failed to allocate resources.
+    #[error("cannot allocate resources")]
+    AllocateResource(#[source] resource_manager::ResourceError),
+
     /// Cannot read from an Event file descriptor.
     #[error("failure while reading from EventFd file descriptor")]
     EventFd,

--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -63,7 +63,7 @@ pub enum VmError {
     /// Cannot setup GIC
     #[cfg(target_arch = "aarch64")]
     #[error("failed to configure GIC")]
-    SetupGIC(dbs_arch::gic::Error),
+    SetupGIC(GICError),
 }
 
 /// Configuration information for user defined NUMA nodes.
@@ -187,7 +187,7 @@ pub struct Vm {
     // Arm specific fields.
     // On aarch64 we need to keep around the fd obtained by creating the VGIC device.
     #[cfg(target_arch = "aarch64")]
-    irqchip_handle: Option<Box<dyn dbs_arch::gic::GICDevice>>,
+    irqchip_handle: Option<Box<dyn GICDevice>>,
 
     #[cfg(all(feature = "hotplug", feature = "dbs-upcall"))]
     upcall_client: Option<Arc<UpcallClient<DevMgrService>>>,


### PR DESCRIPTION
In this PR, we introduce two virtio device features for aarch64.

First, we implement generate_virtio_device_info() and get_virtio_mmio_device_info() funtions to support the mmio_device_info member, which is used by FDT.

Second, we add the implementation of legacy device on aarch64 platform.