### PR TITLE
CC | versions: Always use ubuntu as rootfs for CC

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -124,7 +124,7 @@ assets:
         name: "ubuntu"
         version: "latest"
       x86_64:
-        name: &default-image-name "clearlinux"
+        name: &default-image-name "ubuntu"
         version: "latest"
     meta:
       image-type: *default-image-name


### PR DESCRIPTION
As we're still depending on components that are only being tested on
Ubuntu, let's make sure the VM image distributed is exactly the same
we've been testing.

Fixes: #4551

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>