### PR TITLE
CC | Build the rootfs image with skopeo, umoci, and using an offline_fs_kbc

### DIFF
--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -48,10 +48,6 @@ build_image() {
 	info "Build image"
 	info "image os: $img_distro"
 	info "image os version: $img_os_version"
-	# CCv0 on image is currently unsupported, do not pass
-	unset SKOPEO
-	unset UMOCI
-	unset AA_KBC
 	sudo -E PATH="${PATH}" make image \
 		DISTRO="${img_distro}" \
 		DEBUG="${DEBUG:-}" \

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -69,3 +69,6 @@ install-tarball:
 
 image: kata-tarball
 	$(MK_DIR)kata-deploy-build-and-upload-image.sh $(CURDIR)/kata-static.tar.xz
+
+cc-rootfs-image-tarball:
+	${MAKE} $@-build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -30,6 +30,8 @@ readonly virtiofsd_builder="${static_build_dir}/virtiofsd/build-static-virtiofsd
 
 readonly rootfs_builder="${repo_root_dir}/tools/packaging/guest-image/build_image.sh"
 
+readonly cc_prefix="/opt/confidential-containers"
+
 ARCH=$(uname -m)
 
 workdir="${WORKDIR:-$PWD}"
@@ -81,6 +83,16 @@ options:
 EOF
 
 	exit "${return_code}"
+}
+
+#Install cc capable guest image
+install_cc_image() {
+	info "Create CC image"
+	export SKOPEO=yes
+	export UMOCI=yes
+	export AA_KBC="offline_fs_kbc"
+
+	"${rootfs_builder}" --imagetype=image --prefix="${cc_prefix}" --destdir="${destdir}"
 }
 
 #Install guest image
@@ -180,6 +192,8 @@ handle_build() {
 		install_virtiofsd
 		;;
 
+	cc-rootfs-image) install_cc_image ;;
+
 	cloud-hypervisor) install_clh ;;
 
 	firecracker) install_firecracker ;;
@@ -227,6 +241,7 @@ main() {
 	local build_targets
 	local silent
 	build_targets=(
+		cc-rootfs-image
 		cloud-hypervisor
 		firecracker
 		kernel


### PR DESCRIPTION
Let's add a new build target for our local-build scripts,
cc-rootfs-image-tarball, and use it to build an image that has skopeo
and umoci embedded in, and that using the offline_fs_kbc as the
attenstation agent KBC.

Fixes: #4557

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>