### PR TITLE
CC | packaging: Add a build target for all the "unmodified" components

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -70,6 +70,9 @@ install-tarball:
 image: kata-tarball
 	$(MK_DIR)kata-deploy-build-and-upload-image.sh $(CURDIR)/kata-static.tar.xz
 
+cc-cloud-hypervisor-tarball:
+	${MAKE} $@-build
+
 cc-rootfs-image-tarball:
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -76,6 +76,9 @@ cc-cloud-hypervisor-tarball:
 cc-kernel-tarball:
 	${MAKE} $@-build
 
+cc-qemu-tarball:
+	${MAKE} $@-build
+
 cc-rootfs-image-tarball:
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -70,6 +70,9 @@ install-tarball:
 image: kata-tarball
 	$(MK_DIR)kata-deploy-build-and-upload-image.sh $(CURDIR)/kata-static.tar.xz
 
+cc-parallel: $(MK_DIR)/dockerbuild/install_yq.sh
+	${MAKE} -f $(MK_PATH) cc -j$$(( $$(nproc) - 1  )) V=
+
 cc: cc-cloud-hypervisor-tarball \
 	cc-kernel-tarball \
 	cc-qemu-tarball \

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -84,3 +84,6 @@ cc-rootfs-image-tarball:
 
 cc-shim-v2-tarball:
 	${MAKE} $@-build
+
+cc-virtiofsd-tarball:
+	${MAKE} $@-build

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -73,6 +73,9 @@ image: kata-tarball
 cc-cloud-hypervisor-tarball:
 	${MAKE} $@-build
 
+cc-kernel-tarball:
+	${MAKE} $@-build
+
 cc-rootfs-image-tarball:
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -70,6 +70,13 @@ install-tarball:
 image: kata-tarball
 	$(MK_DIR)kata-deploy-build-and-upload-image.sh $(CURDIR)/kata-static.tar.xz
 
+cc: cc-cloud-hypervisor-tarball \
+	cc-kernel-tarball \
+	cc-qemu-tarball \
+	cc-rootfs-image-tarball \
+	cc-shim-v2-tarball \
+	cc-virtiofsd-tarball
+
 cc-cloud-hypervisor-tarball:
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -70,6 +70,8 @@ install-tarball:
 image: kata-tarball
 	$(MK_DIR)kata-deploy-build-and-upload-image.sh $(CURDIR)/kata-static.tar.xz
 
+cc-tarball: | cc-parallel merge-builds
+
 cc-parallel: $(MK_DIR)/dockerbuild/install_yq.sh
 	${MAKE} -f $(MK_PATH) cc -j$$(( $$(nproc) - 1  )) V=
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -81,6 +81,13 @@ options:
 	rootfs-initrd
 	shim-v2
 	virtiofsd
+	cc
+	cc-cloud-hypervisor
+	cc-kernel
+	cc-qemu
+	cc-rootfs-image
+	cc-shimv2
+	cc-virtiofsd
 EOF
 
 	exit "${return_code}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -31,6 +31,7 @@ readonly virtiofsd_builder="${static_build_dir}/virtiofsd/build-static-virtiofsd
 readonly rootfs_builder="${repo_root_dir}/tools/packaging/guest-image/build_image.sh"
 
 readonly cc_prefix="/opt/confidential-containers"
+readonly qemu_cc_builder="${static_build_dir}/qemu/build-static-qemu-cc.sh"
 
 ARCH=$(uname -m)
 
@@ -112,6 +113,15 @@ install_cc_image() {
 install_cc_kernel() {
 	export kernel_version="$(yq r $versions_yaml assets.kernel.version)"
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -f -v "${kernel_version}"
+}
+
+# Install static CC qemu asset
+install_cc_qemu() {
+	info "build static CC qemu"
+	export qemu_repo="$(yq r $versions_yaml assets.hypervisor.qemu.url)"
+	export qemu_version="$(yq r $versions_yaml assets.hypervisor.qemu.version)"
+	"${qemu_cc_builder}"
+	tar xvf "${builddir}/kata-static-qemu-cc.tar.gz" -C "${destdir}"
 }
 
 #Install all components that are not assets
@@ -222,6 +232,8 @@ handle_build() {
 	cc-cloud-hypervisor) install_cc_clh ;;
 
 	cc-kernel) install_cc_kernel ;;
+
+	cc-qemu) install_cc_qemu ;;
 
 	cc-rootfs-image) install_cc_image ;;
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -132,6 +132,15 @@ install_cc_shimv2() {
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" EXTRA_OPTS="DEFSERVICEOFFLOAD=true" "${shimv2_builder}"
 }
 
+# Install static CC virtiofsd asset
+install_cc_virtiofsd() {
+	info "build static CC virtiofsd"
+	"${virtiofsd_builder}"
+	info "Install static CC virtiofsd"
+	mkdir -p "${destdir}/${cc_prefix}/libexec/"
+	sudo install -D --owner root --group root --mode 0744 virtiofsd/virtiofsd "${destdir}/${cc_prefix}/libexec/virtiofsd"
+}
+
 #Install guest image
 install_image() {
 	info "Create image"
@@ -238,6 +247,8 @@ handle_build() {
 	cc-rootfs-image) install_cc_image ;;
 
 	cc-shim-v2) install_cc_shimv2 ;;
+
+	cc-virtiofsd) install_cc_virtiofsd ;;
 
 	cloud-hypervisor) install_clh ;;
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -85,6 +85,19 @@ EOF
 	exit "${return_code}"
 }
 
+# Install static CC cloud-hypervisor asset
+install_cc_clh() {
+	if [[ "${ARCH}" == "x86_64" ]]; then
+		export features="tdx"
+	fi
+
+	info "build static CC cloud-hypervisor"
+	"${clh_builder}"
+	info "Install static CC cloud-hypervisor"
+	mkdir -p "${destdir}/${cc_prefix}/bin/"
+	sudo install -D --owner root --group root --mode 0744 cloud-hypervisor/cloud-hypervisor "${destdir}/${cc_prefix}/bin/cloud-hypervisor"
+}
+
 #Install cc capable guest image
 install_cc_image() {
 	info "Create CC image"
@@ -199,6 +212,8 @@ handle_build() {
 		install_shimv2
 		install_virtiofsd
 		;;
+
+	cc-cloud-hypervisor) install_cc_clh ;;
 
 	cc-rootfs-image) install_cc_image ;;
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -238,6 +238,15 @@ handle_build() {
 		install_virtiofsd
 		;;
 
+	cc)
+		install_cc_clh
+		install_cc_kernel
+		install_cc_qemu
+		install_cc_image
+		install_cc_shimv2
+		install_cc_virtiofsd
+		;;
+
 	cc-cloud-hypervisor) install_cc_clh ;;
 
 	cc-kernel) install_cc_kernel ;;

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -108,6 +108,12 @@ install_cc_image() {
 	"${rootfs_builder}" --imagetype=image --prefix="${cc_prefix}" --destdir="${destdir}"
 }
 
+#Install CC kernel asset
+install_cc_kernel() {
+	export kernel_version="$(yq r $versions_yaml assets.kernel.version)"
+	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -f -v "${kernel_version}"
+}
+
 #Install all components that are not assets
 install_cc_shimv2() {
 	GO_VERSION="$(yq r ${versions_yaml} languages.golang.meta.newest-version)"
@@ -214,6 +220,8 @@ handle_build() {
 		;;
 
 	cc-cloud-hypervisor) install_cc_clh ;;
+
+	cc-kernel) install_cc_kernel ;;
 
 	cc-rootfs-image) install_cc_image ;;
 

--- a/tools/packaging/static-build/qemu/build-static-qemu-cc.sh
+++ b/tools/packaging/static-build/qemu/build-static-qemu-cc.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+qemu_repo="${qemu_repo:-}"
+qemu_version="${qemu_version:-}"
+
+export prefix="/opt/confidential-containers/"
+
+if [ -z "$qemu_repo" ]; then
+	info "Get qemu information from runtime versions.yaml"
+	qemu_url=$(get_from_kata_deps "assets.hypervisor.qemu.url")
+	[ -n "$qemu_url" ] || die "failed to get qemu url"
+	qemu_repo="${qemu_url}.git"
+fi
+[ -n "$qemu_repo" ] || die "failed to get qemu repo"
+
+[ -n "$qemu_version" ] || qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.version")
+[ -n "$qemu_version" ] || die "failed to get qemu version"
+
+"${script_dir}/build-base-qemu.sh" "${qemu_repo}" "${qemu_version}" "" "kata-static-qemu-cc.tar.gz"


### PR DESCRIPTION
For the very first milestone towards a release, we're targeting something working with the Operator in a **non**-TEE CI.

For that, we need to have Cloud Hypervisor, QEMU, Kernel, and virtiofsd (as we're not using devmapper in our CI yet) built using a destdir that matches with the modified components ("/opt/confidential-containers/....").

Here, in this series, we're adding all the missing pieces.

Fixes: #4566, #4567, #4568. #4569 