### PR TITLE
oci: fix serde skip serializing condition

### DIFF
--- a/src/libs/oci/src/lib.rs
+++ b/src/libs/oci/src/lib.rs
@@ -43,7 +43,7 @@ pub struct Spec {
     pub process: Option<Process>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub root: Option<Root>,
-    #[serde(default, skip_serializing_if = "String:: is_empty")]
+    #[serde(default, skip_serializing_if = "String::is_empty")]
     pub hostname: String,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub mounts: Vec<Mount>,


### PR DESCRIPTION
There is an extra space on the serde serialization condition.

Fixes: #4578 

Signed-off-by: haining.cao <haining.cao@daocloud.io>