### PR TITLE
Fix clh tarball build

### DIFF
--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -23,8 +23,13 @@ RUN apt-get update && \
 ARG IMG_USER=kata-builder
 ARG UID=1000
 ARG GID=1000
+# gid of the docker group on the host, required for running docker in docker builds.
+ARG HOST_DOCKER_GID
+
 RUN if [ ${IMG_USER} != "root" ]; then groupadd --gid=${GID} ${IMG_USER};fi
 RUN if [ ${IMG_USER} != "root" ]; then adduser ${IMG_USER} --uid=${UID} --gid=${GID};fi
+RUN if [ ${IMG_USER} != "root" ] && [ ! -z ${HOST_DOCKER_GID} ]; then groupadd --gid=${HOST_DOCKER_GID} docker_on_host;fi
+RUN if [ ${IMG_USER} != "root" ] && [ ! -z ${HOST_DOCKER_GID} ]; then usermod -a -G docker_on_host ${IMG_USER};fi
 RUN sh -c "echo '${IMG_USER} ALL=NOPASSWD: ALL' >> /etc/sudoers"
 
 #FIXME: gcc is required as agent is build out of a container build.
@@ -40,4 +45,4 @@ RUN apt-get update && \
   apt-get clean && rm -rf /var/lib/apt/lists
 
 ENV USER ${IMG_USER}
-USER ${UID}:${GID}
+USER ${IMG_USER}

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -20,17 +20,27 @@ if [ "${script_dir}" != "${PWD}" ]; then
 	ln -sf "${script_dir}/build" "${PWD}/build"
 fi
 
+# This is the gid of the "docker" group on host. In case of docker in docker builds
+# for some of the targets (clh builds from source), the nested container user needs to
+# be part of this group.
+docker_gid=$(getent group docker | cut -d: -f3 || { echo >&2 "Missing docker group, docker needs to be installed" && false; })
+
+# If docker gid is the effective group id of the user, do not pass it as
+# an additional group.
+if [ ${docker_gid} == ${gid} ]; then
+	docker_gid=""
+fi
+
 docker build -q -t build-kata-deploy \
 	--build-arg IMG_USER="${USER}" \
 	--build-arg UID=${uid} \
 	--build-arg GID=${gid} \
+	--build-arg HOST_DOCKER_GID=${docker_gid} \
 	"${script_dir}/dockerbuild/"
 
 docker run \
 	-v /var/run/docker.sock:/var/run/docker.sock \
-	--user ${uid}:${gid} \
 	--env USER=${USER} -v "${kata_dir}:${kata_dir}" \
 	--rm \
 	-w ${script_dir} \
 	build-kata-deploy "${kata_deploy_create}" $@
-

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -56,6 +56,7 @@ build_clh_from_source() {
     repo_dir="${repo_dir//.git}"
     rm -rf "${repo_dir}"
     git clone "${cloud_hypervisor_repo}"
+    git config --global --add safe.directory "$PWD/repo_dir"
     pushd "${repo_dir}"
 
     if [ -n "${cloud_hypervisor_pr}" ]; then


### PR DESCRIPTION
While running make as non-privileged user, the make errors out with
  the following message:
    "INFO: Build cloud-hypervisor enabling the following features: tdx
    Got permission denied while trying to connect to the Docker daemon
    socket at unix:///var/run/docker.sock: Post
    "http://%2Fvar%2Frun%2Fdocker.sock/v1.24/images/create?fromImage=cloudhypervisor%2Fdev&tag=20220524-0":
    dial unix /var/run/docker.sock: connect: permission denied"
    
  Even though the user may be part of docker group, the clh build from
  source does a docker in docker build. It is necessary for the user of
  the nested container to be part of docker build for the build to
  succeed.
    
   Fixes #4594
