### PR TITLE
packaging: Simplify config path handling

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -129,12 +129,15 @@ function cleanup_different_shims_base() {
 
 function configure_crio_runtime() {
 	local runtime="kata"
+	local configuration="configuration"
 	if [ -n "${1-}" ]; then
 		runtime+="-$1"
+		configuration+="-$1"
 	fi
 
 	local kata_path="/usr/local/bin/containerd-shim-${runtime}-v2"
 	local kata_conf="crio.runtime.runtimes.${runtime}"
+	local kata_config_path="/opt/kata/share/defaults/kata-containers/$configuration.toml"
 
 	cat <<EOF | tee -a "$crio_drop_in_conf_file"
 
@@ -143,6 +146,7 @@ function configure_crio_runtime() {
 	runtime_path = "${kata_path}"
 	runtime_type = "vm"
 	runtime_root = "/run/vc"
+	runtime_config_path = "${kata_config_path}"
 	privileged_without_host_devices = true
 EOF
 }

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -98,10 +98,7 @@ function configure_different_shims_base() {
 			fi
 		fi
 
-		cat << EOF | tee "$shim_file"
-#!/usr/bin/env bash
-KATA_CONF_FILE=/opt/kata/share/defaults/kata-containers/configuration-${shim}.toml /opt/kata/bin/containerd-shim-kata-v2 "\$@"
-EOF
+		ln -sf /opt/kata/bin/containerd-shim-kata-v2 "${shim_file}"
 		chmod +x "$shim_file"
 
 		if [ "${shim}" == "${default_shim}" ]; then


### PR DESCRIPTION
Both CRI-O and containerd expose the option for the admin to set the
configuration path that should be used by a specific runtime.

All the versions of CRI-O and containerd supported have that option, and
switching to using this option makes our code cleaner.

Fixes: #4608

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>