### PR TITLE
build: save lines for repository_owner check

### DIFF
--- a/.github/workflows/docs-url-alive-check.yaml
+++ b/.github/workflows/docs-url-alive-check.yaml
@@ -10,35 +10,32 @@ jobs:
         go-version: [1.17.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
+    # don't run this action on forks
+    if: github.repository_owner == 'kata-containers'
     env:
       target_branch: ${{ github.base_ref }}
     steps:
     - name: Install Go
-      if: github.repository_owner == 'kata-containers'
       uses: actions/setup-go@v2
       with:
         go-version: ${{ matrix.go-version }}
       env:
         GOPATH: ${{ runner.workspace }}/kata-containers
     - name: Set env
-      if: github.repository_owner == 'kata-containers'
       run: |
         echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Checkout code
-      if: github.repository_owner == 'kata-containers'
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
         path: ./src/github.com/${{ github.repository }}
     - name: Setup
-      if: github.repository_owner == 'kata-containers'
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && ./ci/setup.sh
       env:
         GOPATH: ${{ runner.workspace }}/kata-containers
     # docs url alive check
     - name: Docs URL Alive Check
-      if: github.repository_owner == 'kata-containers'
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && make docs-url-alive-check


### PR DESCRIPTION
build: save lines for repository_owner check

repository_owner check in docs-url-alive-check.yaml now is specified for each step, it can be in job level to save lines.

Fixes: #4611 
Signed-off-by: Yuan-Zhuo yuanzhuo0118@outlook.com