### PR TITLE
CC | packaging: Allow building a TDX capable kernel

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -88,6 +88,9 @@ cc-cloud-hypervisor-tarball:
 cc-kernel-tarball:
 	${MAKE} $@-build
 
+cc-tdx-kernel-tarball:
+	${MAKE} $@-build
+
 cc-qemu-tarball:
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -84,6 +84,7 @@ options:
 	cc
 	cc-cloud-hypervisor
 	cc-kernel
+	cc-tdx-kernel
 	cc-qemu
 	cc-rootfs-image
 	cc-shimv2
@@ -114,6 +115,22 @@ install_cc_image() {
 	export AA_KBC="offline_fs_kbc"
 
 	"${rootfs_builder}" --imagetype=image --prefix="${cc_prefix}" --destdir="${destdir}"
+}
+
+#Install CC kernel assert, with TEE support
+install_cc_tee_kernel() {
+	tee="${1}"
+
+	[ "${tee}" != "tdx" ] && die "Non supported TEE"
+
+	export kernel_version="$(yq r $versions_yaml assets.kernel.${tee}.tag)"
+	export kernel_url="$(yq r $versions_yaml assets.kernel.${tee}.url)"
+	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -x "${tee}" -v "${kernel_version}" -u "${kernel_url}"
+}
+
+#Install CC kernel assert for Intel TDX
+install_cc_tdx_kernel() {
+	install_cc_tee_kernel "tdx"
 }
 
 #Install CC kernel asset
@@ -257,6 +274,8 @@ handle_build() {
 	cc-cloud-hypervisor) install_cc_clh ;;
 
 	cc-kernel) install_cc_kernel ;;
+
+	cc-tdx-kernel) install_cc_tdx_kernel ;;
 
 	cc-qemu) install_cc_qemu ;;
 

--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -59,6 +59,8 @@ skip_config_checks="false"
 DESTDIR="${DESTDIR:-/}"
 #PREFIX=
 PREFIX="${PREFIX:-/usr}"
+#Kernel URL
+kernel_url=""
 
 packaging_scripts_dir="${script_dir}/../scripts"
 source "${packaging_scripts_dir}/lib.sh"
@@ -97,6 +99,7 @@ Options:
 	-p <path>   	: Path to a directory with patches to apply to kernel.
 	-s          	: Skip .config checks
 	-t <hypervisor>	: Hypervisor_target.
+	-u <url>	: Kernel URL to be used to download the kernel tarball.
 	-v <version>	: Kernel version to use if kernel path not provided.
 	-x <type>	: Confidential guest protection type, such as sev and tdx
 EOF
@@ -123,7 +126,7 @@ get_tee_kernel() {
 
 	mkdir -p ${kernel_path}
 
-	kernel_url=$(get_from_kata_deps "assets.kernel.${tee}.url")
+	[ -z "${kernel_url}" ] && kernel_url=$(get_from_kata_deps "assets.kernel.${tee}.url")
 	kernel_tarball="${version}.tar.gz"
 
 	if [ ! -f "${kernel_tarball}" ]; then
@@ -468,7 +471,7 @@ install_kata() {
 }
 
 main() {
-	while getopts "a:b:c:deEfg:hk:p:t:v:x:" opt; do	
+	while getopts "a:b:c:deEfg:hk:p:t:u:v:x:" opt; do	
 		case "$opt" in
 			a)
 				arch_target="${OPTARG}"
@@ -510,6 +513,9 @@ main() {
 				;;
 			t)
 				hypervisor_target="${OPTARG}"
+				;;
+			u)	
+				kernel_url="${OPTARG}"
 				;;
 			v)
 				kernel_version="${OPTARG}"

--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -116,33 +116,18 @@ arch_to_kernel() {
 	esac
 }
 
-get_tdx_kernel() {
+get_tee_kernel() {
 	local version="${1}"
-	local kernel_path=${2}
+	local kernel_path="${2}"
+	local tee="${3}"
 
 	mkdir -p ${kernel_path}
 
-	kernel_url=$(get_from_kata_deps "assets.kernel.tdx.url")
+	kernel_url=$(get_from_kata_deps "assets.kernel.${tee}.url")
 	kernel_tarball="${version}.tar.gz"
 
 	if [ ! -f "${kernel_tarball}" ]; then
 	   curl --fail -OL "${kernel_url}/${kernel_tarball}"
-	fi
-
-	tar --strip-components=1 -xf ${kernel_tarball} -C ${kernel_path}
-}
-
-get_sev_kernel() {
-	local version="${1}"
-	local kernel_path=${2}
-
-	mkdir -p ${kernel_path}
-
-	kernel_url=$(get_from_kata_deps "assets.kernel.sev.url")
-	kernel_tarball="${version}.tar.gz"
-
-	if [ ! -f "${kernel_tarball}" ]; then
-	   curl --fail -OL "${kernel_url}${kernel_tarball}"
 	fi
 	
 	mkdir -p ${kernel_path}
@@ -156,11 +141,8 @@ get_kernel() {
 	[ -n "${kernel_path}" ] || die "kernel_path not provided"
 	[ ! -d "${kernel_path}" ] || die "kernel_path already exist"
 
-	if [ "${conf_guest}" == "tdx" ]; then
-		get_tdx_kernel ${version} ${kernel_path}
-		return
-	elif [ "${conf_guest}" == "sev" ]; then
-		get_sev_kernel ${version} ${kernel_path}
+	if [ "${conf_guest}" != "" ]; then
+		get_tee_kernel ${version} ${kernel_path} ${conf_guest}
 		return
 	fi
 
@@ -563,11 +545,9 @@ main() {
 				kernel_version=$(get_from_kata_deps "assets.kernel-experimental.tag")
 			;;
 			esac
-		elif [[ "${conf_guest}" == "tdx" ]]; then
-			 kernel_version=$(get_from_kata_deps "assets.kernel.tdx.tag")
-		elif [[ "${conf_guest}" == "sev" ]]; then
+		elif [[ "${conf_guest}" != "" ]]; then
 			#If specifying a tag for kernel_version, must be formatted version-like to avoid unintended parsing issues
-			 kernel_version=$(get_from_kata_deps "assets.kernel.sev.tag")
+			kernel_version=$(get_from_kata_deps "assets.kernel.${conf_guest}.tag")
 		else
 			kernel_version=$(get_from_kata_deps "assets.kernel.version")
 		fi


### PR DESCRIPTION
We're adding a new target for building a TDX capable kernel for CC.
This commit, differently than c4cc16efcd946f225c6b010e5dd916f7fc86a326,
introduces support for building the artefacts that are TEE specific.

Fixes: #4622

---

**NOTE**: This PR has a hard dependency on https://github.com/kata-containers/kata-containers/pull/4628.
For now I'm adding a `do-not-merge` label as we need that PR reviewed and merged before acting on this one.