### PR TITLE
cc | packaging: Allow building a TDX capable QEMU

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -94,6 +94,9 @@ cc-tdx-kernel-tarball:
 cc-qemu-tarball:
 	${MAKE} $@-build
 
+cc-tdx-qemu-tarball:
+	${MAKE} $@-build
+
 cc-rootfs-image-tarball:
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -86,6 +86,7 @@ options:
 	cc-kernel
 	cc-tdx-kernel
 	cc-qemu
+	cc-tdx-qemu
 	cc-rootfs-image
 	cc-shimv2
 	cc-virtiofsd
@@ -137,6 +138,23 @@ install_cc_tdx_kernel() {
 install_cc_kernel() {
 	export kernel_version="$(yq r $versions_yaml assets.kernel.version)"
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -f -v "${kernel_version}"
+}
+
+install_cc_tee_qemu() {
+	tee="${1}"
+
+	[ "${tee}" != "tdx" ] && die "Non supported TEE"
+
+	export qemu_repo="$(yq r $versions_yaml assets.hypervisor.qemu.${tee}.url)"
+	export qemu_version="$(yq r $versions_yaml assets.hypervisor.qemu.${tee}.tag)"
+	export tee="${tee}"
+	"${qemu_cc_builder}"
+	tar xvf "${builddir}/kata-static-${tee}-qemu-cc.tar.gz" -C "${destdir}"
+}
+
+
+install_cc_tdx_qemu() {
+	install_cc_tee_qemu "tdx"
 }
 
 # Install static CC qemu asset
@@ -278,6 +296,8 @@ handle_build() {
 	cc-tdx-kernel) install_cc_tdx_kernel ;;
 
 	cc-qemu) install_cc_qemu ;;
+
+	cc-tdx-qemu) install_cc_tdx_qemu ;;
 
 	cc-rootfs-image) install_cc_image ;;
 

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -72,8 +72,10 @@ RUN git clone --depth=1 "${QEMU_REPO}" qemu && \
     git fetch --depth=1 origin "${QEMU_VERSION}" && git checkout FETCH_HEAD && \
     scripts/git-submodule.sh update meson capstone && \
     /root/patch_qemu.sh "${QEMU_VERSION}" "/root/kata_qemu/patches" && \
-    (PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s "kata-qemu${BUILD_SUFFIX}" | xargs ./configure \
-	--with-pkgversion="kata-static${BUILD_SUFFIX}") && \
+    [ -n "${BUILD_SUFFIX}" ] && HYPERVISOR_NAME="kata-qemu-${BUILD_SUFFIX}" || HYPERVISOR_NAME="kata-qemu" && \
+    [ -n "${BUILD_SUFFIX}" ] && PKGVERSION="kata-static-${BUILD_SUFFIX}" || PKGVERSION="kata-static" && \
+    (PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s "${HYPERVISOR_NAME}" | xargs ./configure \
+	--with-pkgversion="${PKGVERSION}") && \
     make -j"$(nproc)" && \
     make install DESTDIR="${QEMU_DESTDIR}" && \
     /root/static-build/scripts/qemu-build-post.sh

--- a/tools/packaging/static-build/qemu/build-static-qemu-cc.sh
+++ b/tools/packaging/static-build/qemu/build-static-qemu-cc.sh
@@ -14,6 +14,7 @@ source "${script_dir}/../../scripts/lib.sh"
 
 qemu_repo="${qemu_repo:-}"
 qemu_version="${qemu_version:-}"
+tee="${tee:-}"
 
 export prefix="/opt/confidential-containers/"
 
@@ -28,4 +29,7 @@ fi
 [ -n "$qemu_version" ] || qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.version")
 [ -n "$qemu_version" ] || die "failed to get qemu version"
 
-"${script_dir}/build-base-qemu.sh" "${qemu_repo}" "${qemu_version}" "" "kata-static-qemu-cc.tar.gz"
+
+tarball_name="kata-static-qemu-cc.tar.gz"
+[ -n "${tee}" ] && tarball_name="kata-static-${tee}-qemu-cc.tar.gz"
+"${script_dir}/build-base-qemu.sh" "${qemu_repo}" "${qemu_version}" "${tee}" "${tarball_name}"

--- a/tools/packaging/static-build/qemu/build-static-qemu-experimental.sh
+++ b/tools/packaging/static-build/qemu/build-static-qemu-experimental.sh
@@ -26,4 +26,4 @@ fi
 [ -n "$qemu_version" ] || qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu-experimental.version")
 [ -n "$qemu_version" ] || die "failed to get qemu version"
 
-"${script_dir}/build-base-qemu.sh" "${qemu_repo}" "${qemu_version}" "-experimental" "kata-static-qemu-experimental.tar.gz"
+"${script_dir}/build-base-qemu.sh" "${qemu_repo}" "${qemu_version}" "experimental" "kata-static-qemu-experimental.tar.gz"

--- a/tools/packaging/static-build/scripts/qemu-build-post.sh
+++ b/tools/packaging/static-build/scripts/qemu-build-post.sh
@@ -25,9 +25,9 @@ done
 
 if [[ -n "${BUILD_SUFFIX}" ]]; then
 	echo "Rename binaries using $BUILD_SUFFIX"
-	find -name 'qemu-system-*' -exec mv {} {}-experimental \;
+	find -name 'qemu-system-*' -exec mv {} {}-$BUILD_SUFFIX \;
 	if [[ ${ARCH} != "x86_64" ]]; then
-		find -name 'virtiofsd' -exec mv {} {}-experimental \;
+		find -name 'virtiofsd' -exec mv {} {}-$BUILD_SUFFIX \;
 	fi
 fi
 


### PR DESCRIPTION
We're adding a new target for building a TDX capable QEMU for CC.
This commit, differently than b307531c29d951c18f993c41ff344721f6e42b89,
introduces support for building the artefacts that are TEE specific.

Fixes: #4623

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

---

Note, this PR depends on https://github.com/kata-containers/kata-containers/pull/4639