### PR TITLE
cgroups: remove unnecessary get_paths()

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -911,9 +911,8 @@ pub fn get_paths() -> Result<HashMap<String, String>> {
     Ok(m)
 }
 
-pub fn get_mounts() -> Result<HashMap<String, String>> {
+pub fn get_mounts(paths: &HashMap<String, String>) -> Result<HashMap<String, String>> {
     let mut m = HashMap::new();
-    let paths = get_paths()?;
 
     for l in fs::read_to_string(MOUNTS)?.lines() {
         let p: Vec<&str> = l.splitn(2, " - ").collect();
@@ -951,7 +950,7 @@ impl Manager {
         let mut m = HashMap::new();
 
         let paths = get_paths()?;
-        let mounts = get_mounts()?;
+        let mounts = get_mounts(&paths)?;
 
         for key in paths.keys() {
             let mnt = mounts.get(key);


### PR DESCRIPTION
Change get_mounts to get paths from a borrowed argument rather than
calling get_paths a second time.

Fixes #3768

Signed-off-by: Derek Lee <derlee@redhat.com>