### PR TITLE
qemu: Add liburing to qemu build

### DIFF
--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -11,6 +11,7 @@ WORKDIR /root/qemu
 # This is required to keep build dependencies with security fixes.
 ARG CACHE_TIMEOUT
 RUN echo "$CACHE_TIMEOUT"
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get upgrade -y && \
     apt-get --no-install-recommends install -y \
@@ -59,6 +60,12 @@ ARG BUILD_SUFFIX
 ARG QEMU_DESTDIR
 ARG QEMU_TARBALL
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN git clone  https://github.com/axboe/liburing/ ~/liburing && \
+    cd ~/liburing && \
+    git checkout tags/liburing-2.1 && \
+    make && make install && ldconfig
+
 COPY scripts/configure-hypervisor.sh /root/configure-hypervisor.sh
 COPY qemu /root/kata_qemu
 COPY scripts/apply_patches.sh /root/apply_patches.sh
@@ -66,7 +73,6 @@ COPY scripts/patch_qemu.sh /root/patch_qemu.sh
 COPY static-build/scripts/qemu-build-post.sh /root/static-build/scripts/qemu-build-post.sh
 COPY static-build/qemu.blacklist /root/static-build/qemu.blacklist
 
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN git clone --depth=1 "${QEMU_REPO}" qemu && \
     cd qemu && \
     git fetch --depth=1 origin "${QEMU_VERSION}" && git checkout FETCH_HEAD && \


### PR DESCRIPTION
io_uring is a Linux API for asynchronous I/O introduced in qemu 5.0.
It is designed to better performance than older `aio` API.
We could leverage this in order to get better storage performance.

Add liburing-dev to qemu build so that we can make use of it.

Fixes: #4645

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>