### PR TITLE
docs: add a how-to to help users to run DAX

### DIFF
--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -44,3 +44,4 @@
 - [How to run Docker with Kata Containers](how-to-run-docker-with-kata.md)
 - [How to run Kata Containers with `nydus`](how-to-use-virtio-fs-nydus-with-kata.md)
 - [How to run Kata Containers with AMD SEV-SNP](how-to-run-kata-containers-with-SNP-VMs.md)
+- [How to build and use experimental QEMU](how-to-build-experimental-qemu.md)

--- a/docs/how-to/how-to-build-experimental-qemu.md
+++ b/docs/how-to/how-to-build-experimental-qemu.md
@@ -1,0 +1,59 @@
+# How to build and use experimental QEMU
+
+This document describes how to build an experimental QEMU to use features that the
+main branch of QEMU does not support yet, for example, DAX with `Nydus`.
+
+This how-to will show how to build an experimental QEMU and use it with DAX.
+
+## Pre-requisites
+
+You must have cloned the Kata Containers repo first.
+
+## Build experimental QEMU
+
+```bash
+$ cd $GOPATH/github.com/kata-containers/kata-containers/tools/packaging/static-build/qemu
+$ make build-experimental
+```
+
+If the build is finished successfully, you will get the build artifact like this:
+
+```bash
+$ ls -tl
+total 16760
+-rw-r--r-- 1 vagrant vagrant 17139024 Jul 13 06:40 kata-static-qemu-experimental.tar.gz
+```
+
+## Use the experimental QEMU
+
+You need to use the experimental QEMU to overwrite the original QEMU that your previous
+Kata Containers installation installed.
+
+This how-to assumes that you have installed Kata Containers that downloaded from
+Kata Containers [releases page](https://github.com/kata-containers/kata-containers/releases)
+and extract it to `/opt` directory.
+
+
+```bash
+# extract to current directory
+$ tar zxvf kata-static-qemu-experimental.tar.gz
+$ sudo cp opt/kata/bin/qemu-system-x86_64-experimental /opt/kata/bin/qemu-system-x86_64
+$ sudo cp -r opt/kata/share/kata-qemu-experimental/qemu /opt/kata/share/kata-qemu/qemu
+```
+
+## Enable DAX for containers
+
+Edit your `configuration.toml` and ensure these configuration items:
+
+```
+# use nydus for better DAX support
+shared_fs = "virtio-fs-nydus"
+# cache mod should be always or auto to use DAX
+virtio_fs_cache = "auto"
+virtio_fs_cache_size = 256
+```
+
+After updating the `configuration.toml`, you can create new containers with DAX enabled.
+
+**Note:**
+- DAX is disabled if the `virtio_fs_cache_size` is set to 0.

--- a/docs/how-to/how-to-set-sandbox-config-kata.md
+++ b/docs/how-to/how-to-set-sandbox-config-kata.md
@@ -83,7 +83,7 @@ There are several kinds of Kata configurations and they are listed below.
 | `io.katacontainers.config.hypervisor.msize_9p` | uint32 | the `msize` for 9p shares |
 | `io.katacontainers.config.hypervisor.path` | string | the hypervisor that will run the container VM |
 | `io.katacontainers.config.hypervisor.pcie_root_port` | specify the number of PCIe Root Port devices. The PCIe Root Port device is used to hot-plug a PCIe device (QEMU) |
-| `io.katacontainers.config.hypervisor.shared_fs` | string | the shared file system type, either `virtio-9p` or `virtio-fs` |
+| `io.katacontainers.config.hypervisor.shared_fs` | string | the shared file system type, either `virtio-9p`, `virtio-fs` or `virtio-fs-nydus` |
 | `io.katacontainers.config.hypervisor.use_vsock` | `boolean` | specify use of `vsock` for agent communication |
 | `io.katacontainers.config.hypervisor.vhost_user_store_path` (R) | `string` | specify the directory path where vhost-user devices related folders, sockets and device nodes should be (QEMU) |
 | `io.katacontainers.config.hypervisor.virtio_fs_cache_size` | uint32 | virtio-fs DAX cache size in `MiB` |

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -130,7 +130,9 @@ virtio_fs_daemon = "@DEFVIRTIOFSDAEMON@"
 # Your distribution recommends: @DEFVALIDVIRTIOFSDAEMONPATHS@
 valid_virtio_fs_daemon_paths = @DEFVALIDVIRTIOFSDAEMONPATHS@
 
-# Default size of DAX cache in MiB
+# Default size of DAX cache in MiB.
+# To enable DAX the virtio_fs_cache should be whether auto or always.
+# DAX is disabled if is set to 0.
 virtio_fs_cache_size = @DEFVIRTIOFSCACHESIZE@
 
 # Default size of virtqueues

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -187,7 +187,12 @@ virtio_fs_daemon = "@DEFVIRTIOFSDAEMON@"
 # Your distribution recommends: @DEFVALIDVIRTIOFSDAEMONPATHS@
 valid_virtio_fs_daemon_paths = @DEFVALIDVIRTIOFSDAEMONPATHS@
 
-# Default size of DAX cache in MiB
+# Default size of DAX cache in MiB.
+# To enable DAX the virtio_fs_cache should be whether auto or always.
+# DAX is disabled if is set to 0.
+# Currently, you need to build an experimental QEMU to use DAX with virtiofs,
+# see the official documentation for details:
+# https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/how-to-build-experimental-qemu.md
 virtio_fs_cache_size = @DEFVIRTIOFSCACHESIZE@
 
 # Default size of virtqueues

--- a/tools/packaging/static-build/qemu/Makefile
+++ b/tools/packaging/static-build/qemu/Makefile
@@ -14,3 +14,4 @@ build-experimental:
 
 clean:
 	rm -f kata-qemu-static.tar.gz
+	rm -f kata-static-qemu-experimental.tar.gz


### PR DESCRIPTION
Kata supports DAX but not out of the box.
Currently, users need to build an experimental QEMU to use
DAX with virtiofs, but the configuration file makes users confused.

This commit adds comments in the configuration file about the
limitation of DAX support and adds a how-to to help user to
build an experimental QEMU.

Fixes: #4636

Signed-off-by: liubin <liubin0329@gmail.com>