### PR TITLE
runtime-rs: persist file

### DIFF
--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -13,7 +13,9 @@ dbs-utils = "0.1.0"
 go-flag = "0.1.0"
 libc = ">=0.2.39"
 nix = "0.24.1"
+persist = { path = "../persist" }
 seccompiler = "0.2.0"
+serde = { version = "1.0.138", features = ["derive"] }
 serde_json = ">=1.0.9"
 slog = "2.5.2"
 slog-scope = "4.4.0"

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
@@ -13,8 +13,7 @@ use anyhow::{Context, Result};
 
 use super::inner::DragonballInner;
 use crate::{utils, VcpuThreadIds, VmmState};
-
-const KATA_PATH: &str = "/run/kata";
+use persist::KATA_PATH;
 const DEFAULT_HYBRID_VSOCK_NAME: &str = "kata.hvsock";
 
 fn get_vsock_path(root: &str) -> String {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -14,7 +14,7 @@ pub mod vmm_instance;
 
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 use tokio::sync::RwLock;
@@ -128,8 +128,8 @@ impl Hypervisor for Dragonball {
         inner.get_jailer_root().await
     }
 
-    async fn save(&self) -> Result<HypervisorState> {
-        Hypervisor::save(self).await
+    async fn save_state(&self) -> Result<HypervisorState> {
+        self.save().await
     }
 }
 
@@ -140,7 +140,7 @@ impl Persist for Dragonball {
     /// Save a state of the component.
     async fn save(&self) -> Result<Self::State> {
         let inner = self.inner.read().await;
-        inner.save().await
+        inner.save().await.context("save hypervisor state")
     }
     /// Restore a component from a specified state.
     async fn restore(

--- a/src/runtime-rs/crates/hypervisor/src/hypervisor_persist.rs
+++ b/src/runtime-rs/crates/hypervisor/src/hypervisor_persist.rs
@@ -1,0 +1,36 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::HypervisorConfig;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct HypervisorState {
+    // Type of hypervisor, E.g. dragonball/qemu/firecracker/acrn.
+    pub hypervisor_type: String,
+    pub pid: Option<i32>,
+    pub uuid: String,
+    // clh sepcific: refer to 'virtcontainers/clh.go:CloudHypervisorState'
+    pub api_socket: String,
+    /// sandbox id
+    pub id: String,
+    /// vm path
+    pub vm_path: String,
+    /// jailed flag
+    pub jailed: bool,
+    /// chroot base for the jailer
+    pub jailer_root: String,
+    /// netns
+    pub netns: Option<String>,
+    /// hypervisor config
+    pub config: HypervisorConfig,
+    /// hypervisor run dir
+    pub run_dir: String,
+    /// cached block device
+    pub cached_block_devices: HashSet<String>,
+    pub virtiofs_daemon_pid: i32,
+}

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -64,5 +64,5 @@ pub trait Hypervisor: Send + Sync {
     async fn cleanup(&self) -> Result<()>;
     async fn check(&self) -> Result<()>;
     async fn get_jailer_root(&self) -> Result<String>;
-    async fn save(&self) -> Result<HypervisorState>;
+    async fn save_state(&self) -> Result<HypervisorState>;
 }

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -10,22 +10,24 @@ extern crate slog;
 logging::logger_with_subsystem!(sl, "hypervisor");
 
 pub mod device;
+pub mod hypervisor_persist;
 pub use device::*;
 pub mod dragonball;
 mod kernel_param;
 pub use kernel_param::Param;
 mod utils;
-
 use std::collections::HashMap;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use hypervisor_persist::HypervisorState;
 use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 
 // Config which driver to use as vm root dev
 const VM_ROOTFS_DRIVER_BLK: &str = "virtio-blk";
 const VM_ROOTFS_DRIVER_PMEM: &str = "virtio-pmem";
 
+pub const HYPERVISOR_DRAGONBALL: &str = "dragonball";
 #[derive(PartialEq)]
 pub(crate) enum VmmState {
     NotReady,
@@ -62,4 +64,5 @@ pub trait Hypervisor: Send + Sync {
     async fn cleanup(&self) -> Result<()>;
     async fn check(&self) -> Result<()>;
     async fn get_jailer_root(&self) -> Result<String>;
+    async fn save(&self) -> Result<HypervisorState>;
 }

--- a/src/runtime-rs/crates/persist/Cargo.toml
+++ b/src/runtime-rs/crates/persist/Cargo.toml
@@ -8,9 +8,9 @@ edition = "2018"
 async-trait = "0.1.48"
 anyhow = "^1.0"
 kata-sys-util = { path = "../../../libs/kata-sys-util"}
+kata-types = { path = "../../../libs/kata-types" }
 libc = "0.2"
 rustc-serialize = "0.3.24"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.82"
 safe-path = { path = "../../../libs/safe-path"}
-

--- a/src/runtime-rs/crates/persist/Cargo.toml
+++ b/src/runtime-rs/crates/persist/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "persist"
+version = "0.1.0"
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
+edition = "2018"
+
+[dependencies]
+async-trait = "0.1.48"
+anyhow = "^1.0"
+kata-sys-util = { path = "../../../libs/kata-sys-util"}
+libc = "0.2"
+rustc-serialize = "0.3.24"
+serde = { version = "1.0.138", features = ["derive"] }
+serde_json = "1.0.82"
+safe-path = { path = "../../../libs/safe-path"}
+

--- a/src/runtime-rs/crates/persist/src/lib.rs
+++ b/src/runtime-rs/crates/persist/src/lib.rs
@@ -1,0 +1,85 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+pub mod sandbox_persist;
+use anyhow::{anyhow, Context, Ok, Result};
+use serde::de;
+use std::{fs::File, io::BufReader};
+
+pub const KATA_PATH: &str = "/run/kata";
+pub const PERSIST_FILE: &str = "state.json";
+use kata_sys_util::validate::verify_id;
+use safe_path::scoped_join;
+
+pub fn to_disk<T: serde::Serialize>(value: &T, sid: &str) -> Result<()> {
+    verify_id(sid).context("failed to verify sid")?;
+    let mut path = scoped_join(KATA_PATH, sid)?;
+    if path.exists() {
+        path.push(PERSIST_FILE);
+        let f = File::create(path)
+            .context("failed to create the file")
+            .context("failed to join the path")?;
+        let j = serde_json::to_value(value).context("failed to convert to the json value")?;
+        serde_json::to_writer_pretty(f, &j)?;
+        return Ok(());
+    }
+    return Err(anyhow!("invalid sid {}", sid));
+}
+
+pub fn from_disk<T>(sid: &str) -> Result<T>
+where
+    T: de::DeserializeOwned,
+{
+    verify_id(sid).context("failed to verify sid")?;
+    let mut path = scoped_join(KATA_PATH, sid)?;
+    if path.exists() {
+        path.push(PERSIST_FILE);
+        let file = File::open(path).context("failed to open the file")?;
+        let reader = BufReader::new(file);
+        return serde_json::from_reader(reader).map_err(|e| anyhow!(e.to_string()));
+    }
+    return Err(anyhow!("invalid sid {}", sid));
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{from_disk, to_disk, KATA_PATH};
+    use serde::{Deserialize, Serialize};
+    use std::fs::DirBuilder;
+    use std::{fs, result::Result::Ok};
+    #[test]
+    fn test_to_from_disk() {
+        #[derive(Serialize, Deserialize, Debug)]
+        struct Kata {
+            name: String,
+            key: u8,
+        }
+        let data = Kata {
+            name: "kata".to_string(),
+            key: 1,
+        };
+        // invalid sid
+        assert!(to_disk(&data, "..3").is_err());
+        assert!(to_disk(&data, "../../../3").is_err());
+        assert!(to_disk(&data, "a/b/c").is_err());
+        assert!(to_disk(&data, ".#cdscd.").is_err());
+
+        let sid = "aadede";
+        let sandbox_dir = [KATA_PATH, sid].join("/");
+        if DirBuilder::new()
+            .recursive(true)
+            .create(&sandbox_dir)
+            .is_ok()
+        {
+            assert!(to_disk(&data, sid).is_ok());
+            if let Ok(result) = from_disk::<Kata>(sid) {
+                assert_eq!(result.name, data.name);
+                assert_eq!(result.key, data.key);
+            }
+            assert!(fs::remove_dir_all(&sandbox_dir).is_ok());
+        }
+    }
+}

--- a/src/runtime-rs/crates/persist/src/sandbox_persist.rs
+++ b/src/runtime-rs/crates/persist/src/sandbox_persist.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait Persist
+where
+    Self: Sized,
+{
+    /// The type of the object representing the state of the component.
+    type State;
+    /// The type of the object holding the constructor arguments.
+    type ConstructorArgs;
+    /// Save a state of the component.
+    async fn save(&self) -> Result<Self::State>;
+    /// Restore a component from a specified state.
+    async fn restore(constructor_args: Self::ConstructorArgs, state: Self::State) -> Result<Self>;
+}

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -18,6 +18,7 @@ nix = "0.24.1"
 rand = "^0.7.2"
 rtnetlink = "0.10.0"
 scopeguard = "1.0.0"
+serde = { version = "1.0.138", features = ["derive"] }
 slog = "2.5.2"
 slog-scope = "4.4.0"
 tokio = { version = "1.8.0", features = ["process"] }
@@ -30,4 +31,5 @@ kata-sys-util = { path = "../../../libs/kata-sys-util" }
 logging = { path = "../../../libs/logging" }
 oci = { path = "../../../libs/oci" }
 actix-rt = "2.7.0"
+persist = { path = "../persist"}
 [features]

--- a/src/runtime-rs/crates/resource/src/cgroups/cgroup_persist.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/cgroup_persist.rs
@@ -1,0 +1,13 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Default)]
+pub struct CgroupState {
+    pub path: Option<String>,
+    pub overhead_path: Option<String>,
+    pub sandbox_cgroup_only: bool,
+}

--- a/src/runtime-rs/crates/resource/src/cgroups/mod.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/mod.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+pub mod cgroup_persist;
 mod utils;
 
 use std::{
@@ -13,11 +14,14 @@ use std::{
 };
 
 use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use cgroup_persist::CgroupState;
 use cgroups_rs::{cgroup_builder::CgroupBuilder, Cgroup, CgroupPid, CpuResources, Resources};
 use hypervisor::Hypervisor;
 use kata_sys_util::spec::load_oci_spec;
 use kata_types::config::TomlConfig;
 use oci::LinuxResources;
+use persist::sandbox_persist::Persist;
 use tokio::sync::RwLock;
 
 pub struct CgroupConfig {
@@ -48,6 +52,7 @@ pub struct CgroupsResource {
     resources: Arc<RwLock<HashMap<String, Resources>>>,
     cgroup_manager: Cgroup,
     overhead_cgroup_manager: Option<Cgroup>,
+    cgroup_config: CgroupConfig,
 }
 
 impl CgroupsResource {
@@ -91,6 +96,7 @@ impl CgroupsResource {
             cgroup_manager,
             resources: Arc::new(RwLock::new(HashMap::new())),
             overhead_cgroup_manager,
+            cgroup_config: config,
         })
     }
 
@@ -216,5 +222,39 @@ impl CgroupsResource {
             cpu: self.calc_cpu_resources(linux_resources),
             ..Default::default()
         }
+    }
+}
+
+#[async_trait]
+impl Persist for CgroupsResource {
+    type State = CgroupState;
+    type ConstructorArgs = ();
+    /// Save a state of the component.
+    async fn save(&self) -> Result<Self::State> {
+        Ok(CgroupState {
+            path: Some(self.cgroup_config.path.clone()),
+            overhead_path: Some(self.cgroup_config.overhead_path.clone()),
+            sandbox_cgroup_only: self.cgroup_config.sandbox_cgroup_only,
+        })
+    }
+    /// Restore a component from a specified state.
+    async fn restore(
+        _resource_args: Self::ConstructorArgs,
+        cgroup_state: Self::State,
+    ) -> Result<Self> {
+        let hier = cgroups_rs::hierarchies::auto();
+        let config = CgroupConfig {
+            path: "".to_string(),
+            overhead_path: "".to_string(),
+            sandbox_cgroup_only: true,
+        };
+        let path = cgroup_state.path.unwrap_or_default();
+        let cgroup_manager = Cgroup::load(hier, path.as_str());
+        Ok(Self {
+            cgroup_manager,
+            resources: Arc::new(RwLock::new(HashMap::new())),
+            overhead_cgroup_manager: None,
+            cgroup_config: config,
+        })
     }
 }

--- a/src/runtime-rs/crates/resource/src/lib.rs
+++ b/src/runtime-rs/crates/resource/src/lib.rs
@@ -16,6 +16,7 @@ pub mod cgroups;
 pub mod manager;
 mod manager_inner;
 pub mod network;
+pub mod resource_persist;
 use network::NetworkConfig;
 pub mod rootfs;
 pub mod share_fs;

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -4,17 +4,25 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::sync::Arc;
-
+use crate::resource_persist::ResourceState;
+use crate::{manager_inner::ResourceManagerInner, rootfs::Rootfs, volume::Volume, ResourceConfig};
 use agent::{Agent, Storage};
 use anyhow::Result;
+use async_trait::async_trait;
 use hypervisor::Hypervisor;
 use kata_types::config::TomlConfig;
 use kata_types::mount::Mount;
 use oci::LinuxResources;
+use persist::sandbox_persist::Persist;
+use std::sync::Arc;
 use tokio::sync::RwLock;
 
-use crate::{manager_inner::ResourceManagerInner, rootfs::Rootfs, volume::Volume, ResourceConfig};
+pub struct ManagerArgs {
+    pub sid: String,
+    pub agent: Arc<dyn Agent>,
+    pub hypervisor: Arc<dyn Hypervisor>,
+    pub config: TomlConfig,
+}
 
 pub struct ResourceManager {
     inner: Arc<RwLock<ResourceManagerInner>>,
@@ -93,5 +101,26 @@ impl ResourceManager {
     pub async fn delete_cgroups(&self) -> Result<()> {
         let inner = self.inner.read().await;
         inner.delete_cgroups().await
+    }
+}
+
+#[async_trait]
+impl Persist for ResourceManager {
+    type State = ResourceState;
+    type ConstructorArgs = ManagerArgs;
+    /// Save a state of the component.
+    async fn save(&self) -> Result<Self::State> {
+        let inner = self.inner.read().await;
+        inner.save().await
+    }
+    /// Restore a component from a specified state.
+    async fn restore(
+        resource_args: Self::ConstructorArgs,
+        resource_state: Self::State,
+    ) -> Result<Self> {
+        let inner = ResourceManagerInner::restore(resource_args, resource_state).await?;
+        Ok(Self {
+            inner: Arc::new(RwLock::new(inner)),
+        })
     }
 }

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -17,7 +17,7 @@ use oci::LinuxResources;
 use persist::sandbox_persist::Persist;
 
 use crate::{
-    cgroups::CgroupsResource,
+    cgroups::{CgroupArgs, CgroupsResource},
     manager::ManagerArgs,
     network::{self, Network},
     rootfs::{RootFsResource, Rootfs},
@@ -226,8 +226,12 @@ impl Persist for ResourceManagerInner {
         resource_args: Self::ConstructorArgs,
         resource_state: Self::State,
     ) -> Result<Self> {
+        let args = CgroupArgs {
+            sid: resource_args.sid.clone(),
+            config: resource_args.config,
+        };
         Ok(Self {
-            sid: "".to_string(),
+            sid: resource_args.sid,
             agent: resource_args.agent,
             hypervisor: resource_args.hypervisor,
             network: None,
@@ -235,11 +239,11 @@ impl Persist for ResourceManagerInner {
             rootfs_resource: RootFsResource::new(),
             volume_resource: VolumeResource::new(),
             cgroups_resource: CgroupsResource::restore(
-                (),
+                args,
                 resource_state.cgroup_state.unwrap_or_default(),
             )
             .await?,
-            toml_config: Arc::new(resource_args.config),
+            toml_config: Arc::new(TomlConfig::default()),
         })
     }
 }

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -6,15 +6,19 @@
 
 use std::sync::Arc;
 
+use crate::resource_persist::ResourceState;
 use agent::{Agent, Storage};
 use anyhow::{Context, Result};
+use async_trait::async_trait;
 use hypervisor::Hypervisor;
 use kata_types::config::TomlConfig;
 use kata_types::mount::Mount;
 use oci::LinuxResources;
+use persist::sandbox_persist::Persist;
 
 use crate::{
     cgroups::CgroupsResource,
+    manager::ManagerArgs,
     network::{self, Network},
     rootfs::{RootFsResource, Rootfs},
     share_fs::{self, ShareFs},
@@ -196,5 +200,46 @@ impl ResourceManagerInner {
     pub async fn dump(&self) {
         self.rootfs_resource.dump().await;
         self.volume_resource.dump().await;
+    }
+}
+
+#[async_trait]
+impl Persist for ResourceManagerInner {
+    type State = ResourceState;
+    type ConstructorArgs = ManagerArgs;
+    /// Save a state of the component.
+    async fn save(&self) -> Result<Self::State> {
+        let mut endpoint_state = vec![];
+        if let Some(network) = &self.network {
+            if let Some(ens) = network.save().await {
+                endpoint_state = ens;
+            }
+        }
+        let cgroup_state = self.cgroups_resource.save().await?;
+        Ok(ResourceState {
+            endpoint: endpoint_state,
+            cgroup_state: Some(cgroup_state),
+        })
+    }
+    /// Restore a component from a specified state.
+    async fn restore(
+        resource_args: Self::ConstructorArgs,
+        resource_state: Self::State,
+    ) -> Result<Self> {
+        Ok(Self {
+            sid: "".to_string(),
+            agent: resource_args.agent,
+            hypervisor: resource_args.hypervisor,
+            network: None,
+            share_fs: None,
+            rootfs_resource: RootFsResource::new(),
+            volume_resource: VolumeResource::new(),
+            cgroups_resource: CgroupsResource::restore(
+                (),
+                resource_state.cgroup_state.unwrap_or_default(),
+            )
+            .await?,
+            toml_config: Arc::new(resource_args.config),
+        })
     }
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
@@ -1,0 +1,50 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct PhysicalEndpointState {
+    pub bdf: String,
+    pub driver: String,
+    pub vendor_id: String,
+    pub device_id: String,
+    pub hard_addr: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct MacvlanEndpointState {
+    pub if_name: String,
+    pub network_qos: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct VlanEndpointState {
+    pub if_name: String,
+    pub network_qos: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct VethEndpointState {
+    pub if_name: String,
+    pub network_qos: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct IpVlanEndpointState {
+    pub if_name: String,
+    pub network_qos: bool,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
+pub struct EndpointState {
+    pub physical_endpoint: Option<PhysicalEndpointState>,
+    pub veth_endpoint: Option<VethEndpointState>,
+    pub ipvlan_endpoint: Option<IpVlanEndpointState>,
+    pub macvlan_endpoint: Option<MacvlanEndpointState>,
+    pub vlan_endpoint: Option<VlanEndpointState>,
+    // TODO : other endpoint
+}

--- a/src/runtime-rs/crates/resource/src/network/endpoint/ipvlan_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/ipvlan_endpoint.rs
@@ -6,6 +6,7 @@
 
 use std::io::{self, Error};
 
+use super::endpoint_persist::{EndpointState, IpVlanEndpointState};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 
@@ -86,5 +87,15 @@ impl Endpoint for IPVlanEndpoint {
             .context("error removing device by hypervisor")?;
 
         Ok(())
+    }
+
+    async fn save(&self) -> Option<EndpointState> {
+        Some(EndpointState {
+            ipvlan_endpoint: Some(IpVlanEndpointState {
+                if_name: self.net_pair.virt_iface.name.clone(),
+                network_qos: self.net_pair.network_qos,
+            }),
+            ..Default::default()
+        })
     }
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/macvlan_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/macvlan_endpoint.rs
@@ -6,12 +6,12 @@
 
 use std::io::{self, Error};
 
+use super::endpoint_persist::{EndpointState, MacvlanEndpointState};
+use super::Endpoint;
+use crate::network::{utils, NetworkPair};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use hypervisor::{device::NetworkConfig, Device, Hypervisor};
-
-use super::Endpoint;
-use crate::network::{utils, NetworkPair};
 
 #[derive(Debug)]
 pub struct MacVlanEndpoint {
@@ -80,5 +80,15 @@ impl Endpoint for MacVlanEndpoint {
             .await
             .context("remove device")?;
         Ok(())
+    }
+
+    async fn save(&self) -> Option<EndpointState> {
+        Some(EndpointState {
+            macvlan_endpoint: Some(MacvlanEndpointState {
+                if_name: self.net_pair.virt_iface.name.clone(),
+                network_qos: self.net_pair.network_qos,
+            }),
+            ..Default::default()
+        })
     }
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
@@ -14,11 +14,14 @@ mod vlan_endpoint;
 pub use vlan_endpoint::VlanEndpoint;
 mod macvlan_endpoint;
 pub use macvlan_endpoint::MacVlanEndpoint;
+pub mod endpoint_persist;
 mod endpoints_test;
 
 use anyhow::Result;
 use async_trait::async_trait;
 use hypervisor::Hypervisor;
+
+use super::EndpointState;
 
 #[async_trait]
 pub trait Endpoint: std::fmt::Debug + Send + Sync {
@@ -26,4 +29,5 @@ pub trait Endpoint: std::fmt::Debug + Send + Sync {
     async fn hardware_addr(&self) -> String;
     async fn attach(&self, hypervisor: &dyn Hypervisor) -> Result<()>;
     async fn detach(&self, hypervisor: &dyn Hypervisor) -> Result<()>;
+    async fn save(&self) -> Option<EndpointState>;
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
@@ -10,9 +10,9 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use hypervisor::{device, Hypervisor};
 
+use super::endpoint_persist::{EndpointState, PhysicalEndpointState};
 use super::Endpoint;
 use crate::network::utils::{self, link};
-
 pub const SYS_PCI_DEVICES_PATH: &str = "/sys/bus/pci/devices";
 
 #[derive(Debug)]
@@ -140,5 +140,18 @@ impl Endpoint for PhysicalEndpoint {
             )
         })?;
         Ok(())
+    }
+
+    async fn save(&self) -> Option<EndpointState> {
+        Some(EndpointState {
+            physical_endpoint: Some(PhysicalEndpointState {
+                bdf: self.bdf.clone(),
+                driver: self.driver.clone(),
+                vendor_id: self.vendor_device_id.vendor_id.clone(),
+                device_id: self.vendor_device_id.device_id.clone(),
+                hard_addr: self.hard_addr.clone(),
+            }),
+            ..Default::default()
+        })
     }
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
@@ -6,12 +6,12 @@
 
 use std::io::{self, Error};
 
+use super::endpoint_persist::{EndpointState, VethEndpointState};
+use super::Endpoint;
+use crate::network::{utils, NetworkPair};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use hypervisor::{device::NetworkConfig, Device, Hypervisor};
-
-use super::Endpoint;
-use crate::network::{utils, NetworkPair};
 
 #[derive(Debug)]
 pub struct VethEndpoint {
@@ -80,5 +80,14 @@ impl Endpoint for VethEndpoint {
             .await
             .context("remove device")?;
         Ok(())
+    }
+    async fn save(&self) -> Option<EndpointState> {
+        Some(EndpointState {
+            veth_endpoint: Some(VethEndpointState {
+                if_name: self.net_pair.virt_iface.name.clone(),
+                network_qos: self.net_pair.network_qos,
+            }),
+            ..Default::default()
+        })
     }
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/vlan_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/vlan_endpoint.rs
@@ -9,11 +9,11 @@ use std::io::{self, Error};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 
+use super::endpoint_persist::{EndpointState, VlanEndpointState};
 use super::Endpoint;
 use crate::network::network_model::TC_FILTER_NET_MODEL_STR;
 use crate::network::{utils, NetworkPair};
 use hypervisor::{device::NetworkConfig, Device, Hypervisor};
-
 #[derive(Debug)]
 pub struct VlanEndpoint {
     pub(crate) net_pair: NetworkPair,
@@ -84,5 +84,15 @@ impl Endpoint for VlanEndpoint {
             .context("error removing device by hypervisor")?;
 
         Ok(())
+    }
+
+    async fn save(&self) -> Option<EndpointState> {
+        Some(EndpointState {
+            vlan_endpoint: Some(VlanEndpointState {
+                if_name: self.net_pair.virt_iface.name.clone(),
+                network_qos: self.net_pair.network_qos,
+            }),
+            ..Default::default()
+        })
     }
 }

--- a/src/runtime-rs/crates/resource/src/network/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/mod.rs
@@ -17,6 +17,7 @@ use network_with_netns::NetworkWithNetns;
 mod network_pair;
 use network_pair::NetworkPair;
 mod utils;
+pub use endpoint::endpoint_persist::EndpointState;
 
 use std::sync::Arc;
 
@@ -35,6 +36,7 @@ pub trait Network: Send + Sync {
     async fn interfaces(&self) -> Result<Vec<agent::Interface>>;
     async fn routes(&self) -> Result<Vec<agent::Route>>;
     async fn neighs(&self) -> Result<Vec<agent::ARPNeighbor>>;
+    async fn save(&self) -> Option<Vec<EndpointState>>;
 }
 
 pub async fn new(config: &NetworkConfig) -> Result<Arc<dyn Network>> {

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -9,6 +9,7 @@ use std::sync::{
     Arc,
 };
 
+use super::endpoint::endpoint_persist::EndpointState;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use futures::stream::TryStreamExt;
@@ -107,6 +108,17 @@ impl Network for NetworkWithNetns {
             neighs.append(&mut list);
         }
         Ok(neighs)
+    }
+
+    async fn save(&self) -> Option<Vec<EndpointState>> {
+        let inner = self.inner.read().await;
+        let mut endpoint = vec![];
+        for e in &inner.entity_list {
+            if let Some(state) = e.endpoint.save().await {
+                endpoint.push(state);
+            }
+        }
+        Some(endpoint)
     }
 }
 

--- a/src/runtime-rs/crates/resource/src/resource_persist.rs
+++ b/src/runtime-rs/crates/resource/src/resource_persist.rs
@@ -1,0 +1,15 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::network::EndpointState;
+use serde::{Deserialize, Serialize};
+
+use crate::cgroups::cgroup_persist::CgroupState;
+#[derive(Serialize, Deserialize, Default)]
+pub struct ResourceState {
+    pub endpoint: Vec<EndpointState>,
+    pub cgroup_state: Option<CgroupState>,
+}

--- a/src/runtime-rs/crates/runtimes/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/Cargo.toml
@@ -15,7 +15,7 @@ common = { path = "./common" }
 kata-types = { path = "../../../libs/kata-types" }
 logging = { path = "../../../libs/logging"}
 oci = { path = "../../../libs/oci" }
-
+persist = { path = "../persist" }
 # runtime handler
 linux_container = { path = "./linux_container", optional = true }
 virt_container = { path = "./virt_container", optional = true }

--- a/src/runtime-rs/crates/runtimes/common/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/common/Cargo.toml
@@ -20,7 +20,7 @@ strum = { version = "0.24.0", features = ["derive"] }
 thiserror = "^1.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread", "process", "fs"] }
 ttrpc = { version = "0.6.1" }
-
+persist = {path = "../../persist"}
 agent = { path = "../../agent" }
 kata-sys-util = { path = "../../../../libs/kata-sys-util" }
 kata-types = { path = "../../../../libs/kata-types" }

--- a/src/runtime-rs/crates/runtimes/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/src/lib.rs
@@ -9,5 +9,5 @@ extern crate slog;
 
 logging::logger_with_subsystem!(sl, "runtimes");
 
-mod manager;
+pub mod manager;
 pub use manager::RuntimeHandlerManager;

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -16,12 +16,13 @@ nix = "0.16.0"
 protobuf = "2.27.0"
 serde = { version = "1.0.100", features = ["derive"] }
 serde_derive = "1.0.27"
-serde_json = "1.0.39"
+serde_json = "1.0.82"
 slog = "2.5.2"
 slog-scope = "4.4.0"
 tokio = { version = "1.8.0" }
 toml = "0.4.2"
 url = "2.1.1"
+async-std = "0.99.5"
 
 agent = { path = "../../agent" }
 common = { path = "../common" }
@@ -30,4 +31,6 @@ kata-sys-util = { path = "../../../../libs/kata-sys-util" }
 kata-types = { path = "../../../../libs/kata-types" }
 logging = { path = "../../../../libs/logging"}
 oci = { path = "../../../../libs/oci" }
+persist = { path = "../../persist"}
 resource = { path = "../../resource" }
+

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -12,6 +12,7 @@ logging::logger_with_subsystem!(sl, "virt-container");
 mod container_manager;
 pub mod health_check;
 pub mod sandbox;
+pub mod sandbox_persist;
 
 use std::sync::Arc;
 
@@ -19,12 +20,10 @@ use agent::kata::KataAgent;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use common::{message::Message, RuntimeHandler, RuntimeInstance};
-use hypervisor::{dragonball::Dragonball, Hypervisor};
+use hypervisor::{dragonball::Dragonball, Hypervisor, HYPERVISOR_DRAGONBALL};
 use kata_types::config::{hypervisor::register_hypervisor_plugin, DragonballConfig, TomlConfig};
 use resource::ResourceManager;
 use tokio::sync::mpsc::Sender;
-
-const HYPERVISOR_DRAGONBALL: &str = "dragonball";
 
 unsafe impl Send for VirtContainer {}
 unsafe impl Sync for VirtContainer {}

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -21,16 +21,14 @@ use resource::{
     network::{NetworkConfig, NetworkWithNetNsConfig},
     ResourceConfig, ResourceManager,
 };
-use tokio::sync::{
-    mpsc::{channel, Sender},
-    Mutex, RwLock,
-};
+use tokio::sync::{mpsc::Sender, Mutex, RwLock};
 
 use crate::{health_check::HealthCheck, sandbox_persist::SandboxTYPE};
 use persist::{self, sandbox_persist::Persist};
 pub struct SandboxRestoreArgs {
     pub sid: String,
     pub toml_config: TomlConfig,
+    pub sender: Sender<Message>,
 }
 
 #[derive(Clone, Copy, PartialEq, Debug)]
@@ -171,7 +169,12 @@ impl Sandbox for VirtSandbox {
                 .context("get storages for sandbox")?,
             sandbox_pidns: false,
             sandbox_id: id.to_string(),
-            guest_hook_path: "".to_string(),
+            guest_hook_path: self
+                .hypervisor
+                .hypervisor_config()
+                .await
+                .security_info
+                .guest_hook_path,
             kernel_modules: vec![],
         };
 
@@ -252,7 +255,9 @@ impl Sandbox for VirtSandbox {
     }
 
     async fn cleanup(&self, _id: &str) -> Result<()> {
-        // TODO: cleanup
+        self.resource_manager.delete_cgroups().await?;
+        self.hypervisor.cleanup().await?;
+        // TODO: cleanup other snadbox resource
         Ok(())
     }
 }
@@ -266,7 +271,7 @@ impl Persist for VirtSandbox {
         let sandbox_state = crate::sandbox_persist::SandboxState {
             sandbox_type: SandboxTYPE::VIRTCONTAINER,
             resource: Some(self.resource_manager.save().await?),
-            hypervisor: Some(self.hypervisor.save().await?),
+            hypervisor: Some(self.hypervisor.save_state().await?),
         };
         persist::to_disk(&sandbox_state, &self.sid)?;
         Ok(sandbox_state)
@@ -305,10 +310,9 @@ impl Persist for VirtSandbox {
             config,
         };
         let resource_manager = Arc::new(ResourceManager::restore(args, r).await?);
-        let (sender, _receiver) = channel::<Message>(1);
         Ok(Self {
             sid: sid.to_string(),
-            msg_sender: Arc::new(Mutex::new(sender)),
+            msg_sender: Arc::new(Mutex::new(sandbox_args.sender)),
             inner: Arc::new(RwLock::new(SandboxInner::new())),
             agent,
             hypervisor,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox_persist.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox_persist.rs
@@ -1,0 +1,23 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use hypervisor::hypervisor_persist::HypervisorState;
+use resource::resource_persist::ResourceState;
+use serde::{Deserialize, Serialize};
+
+#[derive(Serialize, Deserialize)]
+pub enum SandboxTYPE {
+    VIRTCONTAINER,
+    LINUXCONTAINER,
+    WASMCONTAINER,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SandboxState {
+    pub sandbox_type: SandboxTYPE,
+    pub resource: Option<ResourceState>,
+    pub hypervisor: Option<HypervisorState>,
+}

--- a/src/runtime-rs/crates/service/Cargo.toml
+++ b/src/runtime-rs/crates/service/Cargo.toml
@@ -16,3 +16,4 @@ common = { path = "../runtimes/common" }
 containerd-shim-protos = { version = "0.2.0", features = ["async"]}
 logging = { path = "../../../libs/logging"}
 runtimes = { path = "../runtimes" }
+persist = { path = "../persist" }

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -29,8 +29,7 @@ use crate::task_service::TaskService;
 
 /// message buffer size
 const MESSAGE_BUFFER_SIZE: usize = 8;
-
-pub const KATA_PATH: &str = "/run/kata";
+use persist::KATA_PATH;
 
 pub struct ServiceManager {
     receiver: Option<Receiver<Message>>,

--- a/src/runtime-rs/crates/shim/src/bin/main.rs
+++ b/src/runtime-rs/crates/shim/src/bin/main.rs
@@ -142,7 +142,11 @@ fn real_main() -> Result<()> {
     let action = parse_args(&args).context("parse args")?;
     match action {
         Action::Start(args) => ShimExecutor::new(args).start().context("shim start")?,
-        Action::Delete(args) => ShimExecutor::new(args).delete().context("shim delete")?,
+        Action::Delete(args) => {
+            let mut shim = ShimExecutor::new(args);
+            let rt = get_tokio_runtime().context("get tokio runtime")?;
+            rt.block_on(shim.delete())?
+        }
         Action::Run(args) => {
             // set mnt namespace
             // need setup before other async call


### PR DESCRIPTION
Support the functionality of persist file (save, restore, cleanup). In Dragonball case, we only need to save the state of passthrough devices. But we left the interface for other VMM, and plan to support them in the future. 
Fixes: #4657
Signed-off-by: Zhongtao Hu <zhongtaohu.tim@linux.alibaba.com>