### PR TITLE
CC | packaging: Build and ship Cloud Hypervisor

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -85,6 +85,9 @@ cc: cc-cloud-hypervisor-tarball \
 cc-cloud-hypervisor-tarball:
 	${MAKE} $@-build
 
+cc-tdx-cloud-hypervisor-tarball:
+	${MAKE} $@-build
+
 cc-kernel-tarball:
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -108,6 +108,11 @@ install_cc_clh() {
 	sudo install -D --owner root --group root --mode 0744 cloud-hypervisor/cloud-hypervisor "${destdir}/${cc_prefix}/bin/cloud-hypervisor"
 }
 
+# Install static CC cloud-hypervisor asset
+install_tdx_cc_clh() {
+	install_cc_clh
+}
+
 #Install cc capable guest image
 install_cc_image() {
 	info "Create CC image"
@@ -290,6 +295,8 @@ handle_build() {
 		;;
 
 	cc-cloud-hypervisor) install_cc_clh ;;
+
+	cc-tdx-cloud-hypervisor) install_tdx_cc_clh ;;
 
 	cc-kernel) install_cc_kernel ;;
 


### PR DESCRIPTION
We're adding a new target for building a TDX capable Cloud Hypervisor
for CC.

As the current version of Cloud Hypervisor is already built with TDX
support, we just rely on calling the same `install_cc_clh()` function,
as done for the non-tee `cc` target.

Fixes: #4659

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>