### PR TITLE
container: kill all of the processes in a container when it terminated

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1092,6 +1092,16 @@ impl BaseContainer for LinuxContainer {
         fs::remove_dir_all(&self.root)?;
 
         if let Some(cgm) = self.cgroup_manager.as_mut() {
+            // Kill all of the processes created in this container to prevent
+            // the leak of some daemon process when this container shared pidns
+            // with the sandbox.
+            let pids = cgm.get_pids().context("get cgroup pids")?;
+            for i in pids {
+                if let Err(e) = signal::kill(Pid::from_raw(i), Signal::SIGKILL) {
+                    warn!(self.logger, "kill the process {} error: {:?}", i, e);
+                }
+            }
+
             cgm.destroy().context("destroy cgroups")?;
         }
         Ok(())


### PR DESCRIPTION
When a container terminated, we should make sure there's no processes
left after destroying the container.

Before this commit, kata-agent depended on the kernel's pidns
to destroy all of the process in a container after the 1 process
exit in a container. This is true for those container using a
separated pidns, but for the case of shared pidns within the
sandbox, the container exit wouldn't trigger the pidns terminated,
and there would be some daemon process left in this container, this
wasn't expected.

Fixes: #4663

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>