### PR TITLE
wip: Upgrade to 22.04 Ubuntu base for Dockerfile

### DIFF
--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) 2020 Ant Group
 #
 # SPDX-License-Identifier: Apache-2.0
-from ubuntu:20.04
+from ubuntu:22.04
 
 
 WORKDIR /root/qemu
@@ -44,10 +44,12 @@ RUN apt-get update && apt-get upgrade -y && \
 	    libseccomp-dev \
 	    libseccomp2 \
 	    patch \
-	    python \
-	    python-dev \
+	    python3 \
+	    python3-dev \
 	    rsync \
-	    zlib1g-dev && \
+	    zlib1g-dev \
+	    liburing-dev \
+	    bzip2 && \
     if [ "$(uname -m)" != "s390x" ]; then apt-get install -y --no-install-recommends libpmem-dev; fi && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 


### PR DESCRIPTION
Trying to upgrade tp 22.04 since liburing-dev was added in this version.
However, with this change, we are seeing some issues in the qemu static
build with regards to libpmem and libndctl library:

```
(.text+0x729a): undefined reference to `ndctl_new'
/usr/bin/ld: (.text+0x72d8): undefined reference to `ndctl_unref'
/usr/bin/ld: (.text+0x730e): undefined reference to `ndctl_namespace_get_dax'
/usr/bin/ld: (.text+0x731b): undefined reference to `ndctl_dax_get_align'
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libpmem.a(libpmem_all.o): in function `pmem2_device_dax_size':
(.text+0x73ca): undefined reference to `ndctl_new'
/usr/bin/ld: (.text+0x7406): undefined reference to `ndctl_unref'
/usr/bin/ld: (.text+0x7436): undefined reference to `ndctl_namespace_get_dax'
/usr/bin/ld: (.text+0x7443): undefined reference to `ndctl_dax_get_size'
/usr/bin/ld: /usr/lib/x86_64-linux-gnu/libpmem.a(libpmem_all.o): in function `pmem2_region_namespace':
(.text+0x7e95): undefined reference to `ndctl_bus_get_first'
```

Raising this PR to debug this issue.

Fixes: #999

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>