### PR TITLE
runtime-rs: fix some bugs to make runtime-rs on aarch64

### DIFF
--- a/src/dragonball/src/vm/aarch64.rs
+++ b/src/dragonball/src/vm/aarch64.rs
@@ -98,7 +98,8 @@ impl Vm {
         );
         self.vcpu_manager()
             .map_err(StartMicroVmError::Vcpu)?
-            .set_reset_event_fd(reset_eventfd);
+            .set_reset_event_fd(reset_eventfd)
+            .map_err(StartMicroVmError::Vcpu)?;
 
         // On aarch64, the vCPUs need to be created (i.e call KVM_CREATE_VCPU) and configured before
         // setting up the IRQ chip because the `KVM_CREATE_VCPU` ioctl will return error if the IRQCHIP

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -455,8 +455,7 @@ dependencies = [
 [[package]]
 name = "dbs-arch"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d235999408e59e60d18461debfb31d504813cfa5e497ff9d45c1c319980cf74a"
+source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=7a8e832b53d66994d6a16f0513d69f540583dcd0#7a8e832b53d66994d6a16f0513d69f540583dcd0"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
@@ -469,8 +468,7 @@ dependencies = [
 [[package]]
 name = "dbs-boot"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37036c65dc89724ff5628cee6c48ebe75027f989398317b2a5155924ba9c2bf7"
+source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=7a8e832b53d66994d6a16f0513d69f540583dcd0#7a8e832b53d66994d6a16f0513d69f540583dcd0"
 dependencies = [
  "dbs-arch",
  "kvm-bindings",
@@ -485,7 +483,7 @@ dependencies = [
 [[package]]
 name = "dbs-device"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=84eee5737cc7d85f9921c94a93e6b9dc4ae24a39#84eee5737cc7d85f9921c94a93e6b9dc4ae24a39"
+source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=7a8e832b53d66994d6a16f0513d69f540583dcd0#7a8e832b53d66994d6a16f0513d69f540583dcd0"
 dependencies = [
  "thiserror",
 ]
@@ -493,7 +491,7 @@ dependencies = [
 [[package]]
 name = "dbs-interrupt"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=84eee5737cc7d85f9921c94a93e6b9dc4ae24a39#84eee5737cc7d85f9921c94a93e6b9dc4ae24a39"
+source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=7a8e832b53d66994d6a16f0513d69f540583dcd0#7a8e832b53d66994d6a16f0513d69f540583dcd0"
 dependencies = [
  "dbs-device",
  "kvm-bindings",
@@ -505,7 +503,7 @@ dependencies = [
 [[package]]
 name = "dbs-legacy-devices"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=84eee5737cc7d85f9921c94a93e6b9dc4ae24a39#84eee5737cc7d85f9921c94a93e6b9dc4ae24a39"
+source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=7a8e832b53d66994d6a16f0513d69f540583dcd0#7a8e832b53d66994d6a16f0513d69f540583dcd0"
 dependencies = [
  "dbs-device",
  "dbs-utils",
@@ -528,7 +526,7 @@ dependencies = [
 [[package]]
 name = "dbs-utils"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=84eee5737cc7d85f9921c94a93e6b9dc4ae24a39#84eee5737cc7d85f9921c94a93e6b9dc4ae24a39"
+source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=7a8e832b53d66994d6a16f0513d69f540583dcd0#7a8e832b53d66994d6a16f0513d69f540583dcd0"
 dependencies = [
  "anyhow",
  "event-manager",
@@ -543,7 +541,7 @@ dependencies = [
 [[package]]
 name = "dbs-virtio-devices"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=84eee5737cc7d85f9921c94a93e6b9dc4ae24a39#84eee5737cc7d85f9921c94a93e6b9dc4ae24a39"
+source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=7a8e832b53d66994d6a16f0513d69f540583dcd0#7a8e832b53d66994d6a16f0513d69f540583dcd0"
 dependencies = [
  "blobfs",
  "byteorder",
@@ -3060,4 +3058,4 @@ dependencies = [
 [[patch.unused]]
 name = "dbs-upcall"
 version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=84eee5737cc7d85f9921c94a93e6b9dc4ae24a39#84eee5737cc7d85f9921c94a93e6b9dc4ae24a39"
+source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=7a8e832b53d66994d6a16f0513d69f540583dcd0#7a8e832b53d66994d6a16f0513d69f540583dcd0"

--- a/src/runtime-rs/Cargo.toml
+++ b/src/runtime-rs/Cargo.toml
@@ -4,9 +4,11 @@ members = [
 ]
 
 [patch.'crates-io']
-dbs-device = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "84eee5737cc7d85f9921c94a93e6b9dc4ae24a39" }
-dbs-utils = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "84eee5737cc7d85f9921c94a93e6b9dc4ae24a39" }
-dbs-interrupt = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "84eee5737cc7d85f9921c94a93e6b9dc4ae24a39" }
-dbs-legacy-devices = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "84eee5737cc7d85f9921c94a93e6b9dc4ae24a39" }
-dbs-virtio-devices = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "84eee5737cc7d85f9921c94a93e6b9dc4ae24a39" }
-dbs-upcall = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "84eee5737cc7d85f9921c94a93e6b9dc4ae24a39" }
+dbs-device = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "7a8e832b53d66994d6a16f0513d69f540583dcd0" }
+dbs-utils = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "7a8e832b53d66994d6a16f0513d69f540583dcd0" }
+dbs-interrupt = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "7a8e832b53d66994d6a16f0513d69f540583dcd0" }
+dbs-legacy-devices = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "7a8e832b53d66994d6a16f0513d69f540583dcd0" }
+dbs-virtio-devices = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "7a8e832b53d66994d6a16f0513d69f540583dcd0" }
+dbs-boot = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "7a8e832b53d66994d6a16f0513d69f540583dcd0" }
+dbs-arch = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "7a8e832b53d66994d6a16f0513d69f540583dcd0" }
+dbs-upcall = { git = "https://github.com/openanolis/dragonball-sandbox.git", rev = "7a8e832b53d66994d6a16f0513d69f540583dcd0" }

--- a/src/runtime-rs/arch/aarch64-options.mk
+++ b/src/runtime-rs/arch/aarch64-options.mk
@@ -1,0 +1,15 @@
+# Copyright (c) 2019-2022 Alibaba Cloud
+# Copyright (c) 2019-2022 Ant Group
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+MACHINETYPE :=
+KERNELPARAMS :=
+MACHINEACCELERATORS :=
+CPUFEATURES := pmu=off
+
+QEMUCMD := qemu-system-aarch64
+
+# dragonball binary name
+DBCMD := dragonball

--- a/src/runtime-rs/crates/hypervisor/src/device/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/vfio.rs
@@ -6,7 +6,9 @@
 
 use std::{fs, path::Path, process::Command};
 
-use anyhow::{anyhow, Context, Result};
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+use anyhow::anyhow;
+use anyhow::{Context, Result};
 
 fn override_driver(bdf: &str, driver: &str) -> Result<()> {
     let driver_override = format!("/sys/bus/pci/devices/{}/driver_override", bdf);


### PR DESCRIPTION
This PR fixes some bugs when use "make" in runtime-rs directory. 

1. fix a vcpu_manager warning in dragonball
2. fix a module use warning in runtime-rs
3. add compile option file for aarch64
4. update dbs-xxx dependencies in runtime-rs/Cargo.toml