### PR TITLE
doc: Remove skopeo requirement from doc

### DIFF
--- a/docs/how-to/how-to-build-and-test-ccv0.md
+++ b/docs/how-to/how-to-build-and-test-ccv0.md
@@ -412,7 +412,6 @@ steps:
   configured and created using the VM as a single node cluster and with `AA_KBC` set to `offline_fs_kbc`. 
   ```bash
   $ export KUBERNETES="yes"
-  $ export SKOPEO="yes"
   $ export AA_KBC=offline_fs_kbc
   $ ~/ccv0.sh build_and_install_all
   ```


### PR DESCRIPTION
We don't need skopeo to get the encrypted container image
scenario working, so remove that instruction from the doc

Fixes: #4587
Signed-off-by: stevenhorsman <steven@uk.ibm.com>