### PR TITLE
runtime-rs: fix sandbox_cgroup_only=false panic

### DIFF
--- a/src/runtime-rs/crates/resource/src/cgroups/utils.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/utils.rs
@@ -12,5 +12,5 @@
 // /sys/fs/cgroup/memory/kata_overhead/$CGPATH where $CGPATH is
 // defined by the orchestrator.
 pub(crate) fn gen_overhead_path(path: &str) -> String {
-    format!("/kata_overhead/{}", path.trim_start_matches('/'))
+    format!("kata_overhead/{}", path.trim_start_matches('/'))
 }


### PR DESCRIPTION
When run with configuration `sandbox_cgroup_only=false`, we will call
`gen_overhead_path()` as the overhead path. The `cgroup-rs` will push
the path with the subsystem prefix by `PathBuf::push()`. When the path
has prefix “/” it will act as root path, such as
```
let mut path = PathBuf::from("/tmp");
path.push("/etc");
assert_eq!(path, PathBuf::from("/etc"));
```
So we shoud not set overhead path with prefix "/".

Fixes: #4687
Signed-off-by: Quanwei Zhou <quanweiZhou@linux.alibaba.com>