### PR TITLE
runtime: do not mark agent dead in the first connection

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1792,7 +1792,6 @@ func (k *kataAgent) connect(ctx context.Context) error {
 	k.Logger().WithField("url", k.state.URL).Info("New client")
 	client, err := kataclient.NewAgentClient(k.ctx, k.state.URL, k.dialTimout)
 	if err != nil {
-		k.dead = true
 		return err
 	}
 


### PR DESCRIPTION
runtime: do not mark agent dead when dial fail with kata agent

Sometimes the guest VM boots slowly and may be the runtime will
retry several times to dial the kata agent in VM when start sandbox.

Fixes: https://github.com/kata-containers/kata-containers/issues/4722

Signed-off-by: wxx213 <stellarwxx@163.com>