### PR TITLE
nydus: wait nydusd API server ready before mounting share fs

### DIFF
--- a/src/runtime/virtcontainers/nydusd_test.go
+++ b/src/runtime/virtcontainers/nydusd_test.go
@@ -28,6 +28,7 @@ func TestNydusdStart(t *testing.T) {
 		debug           bool
 		extraArgs       []string
 		startFn         func(cmd *exec.Cmd) error
+		waitFn          func() error
 		setupShareDirFn func() error
 	}
 
@@ -44,6 +45,9 @@ func TestNydusdStart(t *testing.T) {
 		sourcePath:  sourcePath,
 		startFn: func(cmd *exec.Cmd) error {
 			cmd.Process = &os.Process{}
+			return nil
+		},
+		waitFn: func() error {
 			return nil
 		},
 		setupShareDirFn: func() error { return nil },
@@ -72,9 +76,11 @@ func TestNydusdStart(t *testing.T) {
 				debug:           tt.fields.debug,
 				pid:             tt.fields.pid,
 				startFn:         tt.fields.startFn,
+				waitFn:          tt.fields.waitFn,
 				setupShareDirFn: tt.fields.setupShareDirFn,
 			}
 			ctx := context.Background()
+
 			_, err := nd.Start(ctx, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("nydusd.Start() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
If the API server is not ready, the mount call will fail, so before
mounting share fs, we should wait the nydusd is started and
the API server is ready.

Fixes: #4710

Signed-off-by: liubin <liubin0329@gmail.com>