### PR TITLE
runtime-rs: handle default_vcpus greator than default_maxvcpu

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -65,6 +65,10 @@ impl ConfigPlugin for DragonballConfig {
                 db.cpu_info.default_maxvcpus = default::MAX_DRAGONBALL_VCPUS;
             }
 
+            if db.cpu_info.default_vcpus as u32 > db.cpu_info.default_maxvcpus {
+                db.cpu_info.default_vcpus = db.cpu_info.default_maxvcpus as i32;
+            }
+
             if db.machine_info.entropy_source.is_empty() {
                 db.machine_info.entropy_source =
                     default::DEFAULT_DRAGONBALL_ENTROPY_SOURCE.to_string();


### PR DESCRIPTION
when the default_vcpus is greater than the default_maxvcpus, the default
vcpu number should be set equal to the default_maxvcpus.

Fixes: #4712
Signed-off-by: Zhongtao Hu <zhongtaohu.tim@linux.alibaba.com>