### PR TITLE
agent: unmount rootfs on container restart

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -40,7 +40,7 @@ use rustjail::process::Process;
 use rustjail::specconv::CreateOpts;
 
 use nix::errno::Errno;
-use nix::mount::MsFlags;
+use nix::mount::{umount, MsFlags};
 use nix::sys::{stat, statfs};
 use nix::unistd::{self, Pid};
 use rustjail::cgroups::Manager;
@@ -552,6 +552,15 @@ impl AgentService {
                 return Ok(resp);
             }
         };
+
+        let rootfs_path = Path::new(CONTAINER_BASE)
+            .join("shared/containers")
+            .join(&cid)
+            .join("rootfs");
+        umount(rootfs_path.to_str().unwrap()).context(format!(
+            "failed to unmount rootfs on container exit {:?}",
+            rootfs_path
+        ))?;
 
         // need to close all fd
         // ignore errors for some fd might be closed by stream


### PR DESCRIPTION
The current mounting system for the root filesystem was not correctly
handling the unmount steps during a container restart. After restarting
consistently, the agent would have a number of left over mounts from
previous container instances which could be seen with
`cat /proc/mounts`. Each of these mounts would use 1-2MB of guest
buffer/cache memory and therefore would slowly eat host memory over
time.

This patch resolves this by explicitly unmounting the rootfs at
path `/run/kata-containers/shared/containers/<cid>/rootfs` on each
restart.

Fixes: #4698
Signed-off-by: Champ-Goblem <cameron@northflank.com>