### PR TITLE
versions: Update firecracker version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -83,7 +83,7 @@ assets:
       uscan-url: >-
         https://github.com/firecracker-microvm/firecracker/tags
         .*/v?(\d\S+)\.tar\.gz
-      version: "v0.23.4"
+      version: "v0.23.5"
 
     qemu:
       description: "VMM that uses KVM"


### PR DESCRIPTION
This PR updates the firecracker version that is being
used in kata CI.

Fixes #4717

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>