### PR TITLE
fix network failed for kata ci

### DIFF
--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
@@ -163,7 +163,7 @@ fn generate_route(name: &str, route: &RouteMessage) -> Result<Option<Route>> {
     Ok(Some(Route {
         dest: route
             .destination_prefix()
-            .map(|(addr, _)| addr.to_string())
+            .map(|(addr, prefix)| format!("{}/{}", addr, prefix))
             .unwrap_or_default(),
         gateway: route.gateway().map(|v| v.to_string()).unwrap_or_default(),
         device: name.to_string(),

--- a/src/runtime-rs/crates/resource/src/network/network_model/tc_filter_model.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_model/tc_filter_model.rs
@@ -20,6 +20,7 @@ impl TcFilterModel {
         Ok(Self {})
     }
 }
+
 #[async_trait]
 impl NetworkModel for TcFilterModel {
     fn model_type(&self) -> NetworkModelType {
@@ -60,22 +61,25 @@ impl NetworkModel for TcFilterModel {
         handle
             .traffic_filter(tap_index as i32)
             .add()
-            .protocol(0x0003)
-            .egress()
+            .parent(0xffff0000)
+            // get protocol with network byte order
+            .protocol(0x0003_u16.to_be())
             .redirect(virt_index)
             .execute()
             .await
-            .context("add tap egress")?;
+            .context("add redirect for tap")?;
 
         handle
             .traffic_filter(virt_index as i32)
             .add()
-            .protocol(0x0003)
-            .egress()
+            .parent(0xffff0000)
+            // get protocol with network byte order
+            .protocol(0x0003_u16.to_be())
             .redirect(tap_index)
             .execute()
             .await
-            .context("add virt egress")?;
+            .context("add redirect for virt")?;
+
         Ok(())
     }
 


### PR DESCRIPTION
## patch 1: runtime-rs: fix tc filter setup failed

Fix bug using tc filter and protocol needs to use network byte order.

Fixes: #4726
Signed-off-by: Quanwei Zhou <quanweiZhou@linux.alibaba.com>

## patch 2: runtime-rs: update route destination with prefix
Update route destination with prefix.

Fixes: #4726
Signed-off-by: Quanwei Zhou <quanweiZhou@linux.alibaba.com>