### PR TITLE
agent: log RPC calls for debugging

### DIFF
--- a/src/agent/src/tracer.rs
+++ b/src/agent/src/tracer.rs
@@ -69,6 +69,8 @@ macro_rules! trace_rpc_call {
             propagator.extract(&extract_carrier_from_ttrpc($ctx))
         });
 
+        info!(sl!(), "rpc call from shim to agent: {:?}", $name);
+
         // generate tracing span
         let rpc_span = span!(tracing::Level::INFO, $name, "mod"="rpc.rs", req=?$req);
 


### PR DESCRIPTION
We can log all RPC calls to the agent for debugging purposes
to check which RPC is called, which can help us to understand
the container lifespan.

Fixes: #4738

Signed-off-by: liubin <liubin0329@gmail.com>