### PR TITLE
mount: support checking multiple kinds of block device driver

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1319,12 +1319,12 @@ func (c *Container) hotplugDrive(ctx context.Context) error {
 		"mount-point":  dev.mountPoint,
 	}).Info("device details")
 
-	isDM, err := checkStorageDriver(dev.major, dev.minor)
+	isBD, err := checkStorageDriver(dev.major, dev.minor)
 	if err != nil {
 		return err
 	}
 
-	if !isDM {
+	if !isBD {
 		return nil
 	}
 

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -194,14 +194,14 @@ func getDeviceForPath(path string) (device, error) {
 	return dev, nil
 }
 
-var blockFormatTemplate = "/sys/dev/block/%d:%d/dm"
+var blockFormatTemplate = "/sys/dev/block/%d:%d/"
 
-var checkStorageDriver = isDeviceMapper
+var checkStorageDriver = isBlockDevice
 
-// isDeviceMapper checks if the device with the major and minor numbers is a devicemapper block device
-func isDeviceMapper(major, minor int) (bool, error) {
+// isBlockDevice checks if the device with the major and minor numbers is a block device
+func isBlockDevice(major, minor int) (bool, error) {
 
-	//Check if /sys/dev/block/${major}-${minor}/dm exists
+	//Check if /sys/dev/block/${major}-${minor}/ exists
 	sysPath := fmt.Sprintf(blockFormatTemplate, major, minor)
 
 	_, err := os.Stat(sysPath)
@@ -209,9 +209,9 @@ func isDeviceMapper(major, minor int) (bool, error) {
 		return true, nil
 	} else if os.IsNotExist(err) {
 		return false, nil
+	} else {
+		return false, err
 	}
-
-	return false, err
 }
 
 const mountPerm = os.FileMode(0755)

--- a/src/runtime/virtcontainers/mount_linux_test.go
+++ b/src/runtime/virtcontainers/mount_linux_test.go
@@ -305,20 +305,31 @@ func TestGetDeviceForPathValidMount(t *testing.T) {
 	assert.Equal(dev.mountPoint, expected)
 }
 
-func TestIsDeviceMapper(t *testing.T) {
+func TestIsBlockDevice(t *testing.T) {
 	assert := assert.New(t)
 
 	// known major, minor for /dev/tty
 	major := 5
 	minor := 0
 
-	isDM, err := isDeviceMapper(major, minor)
+	isBD, err := isBlockDevice(major, minor)
 	assert.NoError(err)
-	assert.False(isDM)
+	assert.False(isBD)
 
 	// fake the block device format
+	blockFormatTemplateOld := blockFormatTemplate
+	defer func() {
+		blockFormatTemplate = blockFormatTemplateOld
+	}()
+
 	blockFormatTemplate = "/sys/dev/char/%d:%d"
-	isDM, err = isDeviceMapper(major, minor)
+	isBD, err = isBlockDevice(major, minor)
 	assert.NoError(err)
-	assert.True(isDM)
+	assert.True(isBD)
+
+	// invalid template
+	blockFormatTemplate = "\000/sys/dev/char/%d:%d"
+	isBD, err = isBlockDevice(major, minor)
+	assert.Error(err)
+	assert.False(isBD)
 }


### PR DESCRIPTION
Device mapper is the only supported block device driver so far, which seems limiting. Kata Containers can work well with other block devices. It is necessary to enhance supporting of multiple kinds of host block device.

Fixes #4714

Signed-off-by: yuchen.cc <yuchen.cc@alibaba-inc.com>