### PR TITLE
runtime: explicitly mark the source of the log is from qemu.log

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -990,7 +990,7 @@ func (q *qemu) StopVM(ctx context.Context, waitOnly bool) error {
 		if err == nil {
 			scanner := bufio.NewScanner(f)
 			for scanner.Scan() {
-				q.Logger().Debug(scanner.Text())
+				q.Logger().WithField("file", q.qemuConfig.LogFile).Debug(scanner.Text())
 			}
 			if err := scanner.Err(); err != nil {
 				q.Logger().WithError(err).Debug("read qemu log failed")


### PR DESCRIPTION
In qemu.StopVM(), if debug is enabled, the shim will dump logs
from qemu.log, but users don't know which logs are from qemu.log
and shim itself. Adding some additional messages will
help users to distinguish these logs.

Fixes: #4745

Signed-off-by: Bin Liu <bin@hyper.sh>