### PR TITLE
agent: fix the issue of exec hang with a backgroud process

### DIFF
--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -161,7 +161,7 @@ impl Process {
 
     pub fn notify_term_close(&mut self) {
         let notify = self.term_exit_notifier.clone();
-        notify.notify_one();
+        notify.notify_waiters();
     }
 
     pub fn close_stdin(&mut self) {

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -603,15 +603,16 @@ impl AgentService {
         let cid = req.container_id;
         let eid = req.exec_id;
 
-        let mut term_exit_notifier = Arc::new(tokio::sync::Notify::new());
+        let term_exit_notifier;
         let reader = {
             let s = self.sandbox.clone();
             let mut sandbox = s.lock().await;
 
             let p = sandbox.find_container_process(cid.as_str(), eid.as_str())?;
 
+            term_exit_notifier = p.term_exit_notifier.clone();
+
             if p.term_master.is_some() {
-                term_exit_notifier = p.term_exit_notifier.clone();
                 p.get_reader(StreamType::TermMaster)
             } else if stdout {
                 if p.parent_stdout.is_some() {


### PR DESCRIPTION
When run a exec process in backgroud without tty, the
exec will hang and didn't terminated.

For example:

crictl -i <container id> sh -c 'nohup tail -f /dev/null &'

Fixes: #4747

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>