### PR TITLE
versions: Update runc version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -236,7 +236,7 @@ externals:
     uscan-url: >-
       https://github.com/opencontainers/runc/tags
       .*/v?(\d\S+)\.tar\.gz
-    version: "v1.0.1"
+    version: "v1.1.0"
 
   nydus:
     description: "Nydus image acceleration service"


### PR DESCRIPTION
This PR updates the runc version to v1.1.0.

Fixes #4757

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>