### PR TITLE
runk: add ps sub-command

### DIFF
--- a/src/tools/runk/libcontainer/src/builder.rs
+++ b/src/tools/runk/libcontainer/src/builder.rs
@@ -503,11 +503,7 @@ mod tests {
         let root = tempdir().unwrap();
         // let bundle = temp
         let id = "test".to_string();
-        create_activated_dirs(
-            &root.path().to_path_buf(),
-            &id,
-            &bundle_dir.path().to_path_buf(),
-        );
+        create_activated_dirs(root.path(), &id, bundle_dir.path());
         let pid = getpid().as_raw();
 
         let mut spec = create_dummy_spec();
@@ -517,7 +513,7 @@ mod tests {
             .to_string_lossy()
             .to_string();
 
-        let status = create_dummy_status(&id, pid, &root.path().to_path_buf(), &spec);
+        let status = create_dummy_status(&id, pid, root.path(), &spec);
         status.save().unwrap();
 
         let result = ActivatedContainerBuilder::default()
@@ -600,13 +596,9 @@ mod tests {
             .join(TEST_ROOTFS_PATH)
             .to_string_lossy()
             .to_string();
-        create_activated_dirs(
-            &root.path().to_path_buf(),
-            &id,
-            &bundle_dir.path().to_path_buf(),
-        );
+        create_activated_dirs(root.path(), &id, bundle_dir.path());
 
-        let status = create_dummy_status(&id, pid, &root.path().to_path_buf(), &spec);
+        let status = create_dummy_status(&id, pid, root.path(), &spec);
         status.save().unwrap();
         let launcher = ActivatedContainerBuilder::default()
             .id(id)

--- a/src/tools/runk/src/commands/mod.rs
+++ b/src/tools/runk/src/commands/mod.rs
@@ -8,6 +8,7 @@ pub mod delete;
 pub mod exec;
 pub mod kill;
 pub mod list;
+pub mod ps;
 pub mod run;
 pub mod spec;
 pub mod start;

--- a/src/tools/runk/src/commands/ps.rs
+++ b/src/tools/runk/src/commands/ps.rs
@@ -1,0 +1,63 @@
+// Copyright 2021-2022 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::anyhow;
+use anyhow::Result;
+use libcontainer::container::Container;
+use liboci_cli::Ps;
+use slog::{info, Logger};
+use std::path::Path;
+use std::process::Command;
+use std::str;
+
+pub fn run(opts: Ps, root: &Path, logger: &Logger) -> Result<()> {
+    let container = Container::load(root, opts.container_id.as_str())?;
+    let pids = container
+        .processes()?
+        .iter()
+        .map(|pid| pid.as_raw())
+        .collect::<Vec<_>>();
+
+    match opts.format.as_str() {
+        "json" => println!("{}", serde_json::to_string(&pids)?),
+        "table" => {
+            let ps_options = if opts.ps_options.is_empty() {
+                vec!["-ef".to_string()]
+            } else {
+                opts.ps_options
+            };
+            let output = Command::new("ps").args(ps_options).output()?;
+            if !output.status.success() {
+                return Err(anyhow!("{}", std::str::from_utf8(&output.stderr)?));
+            }
+            let lines = str::from_utf8(&output.stdout)?.lines().collect::<Vec<_>>();
+            if lines.is_empty() {
+                return Err(anyhow!("no processes found"));
+            }
+            let pid_index = lines[0]
+                .split_whitespace()
+                .position(|field| field == "PID")
+                .ok_or_else(|| anyhow!("could't find PID field in ps output"))?;
+            println!("{}", lines[0]);
+            for &line in &lines[1..] {
+                if line.is_empty() {
+                    continue;
+                }
+                let fields = line.split_whitespace().collect::<Vec<_>>();
+                if pid_index >= fields.len() {
+                    continue;
+                }
+                let pid: i32 = fields[pid_index].parse()?;
+                if pids.contains(&pid) {
+                    println!("{}", line);
+                }
+            }
+        }
+        _ => return Err(anyhow!("unknown format: {}", opts.format)),
+    }
+
+    info!(&logger, "ps command finished successfully");
+    Ok(())
+}

--- a/src/tools/runk/src/main.rs
+++ b/src/tools/runk/src/main.rs
@@ -80,6 +80,7 @@ async fn cmd_run(subcmd: SubCommand, root_path: &Path, logger: &Logger) -> Resul
             CommonCmd::Spec(spec) => commands::spec::run(spec, logger),
             CommonCmd::List(list) => commands::list::run(list, root_path, logger),
             CommonCmd::Exec(exec) => commands::exec::run(exec, root_path, logger).await,
+            CommonCmd::Ps(ps) => commands::ps::run(ps, root_path, logger),
             _ => {
                 return Err(anyhow!("command is not implemented yet"));
             }


### PR DESCRIPTION
ps command supprot two formats, `json` and `table`. `json` format just
outputs pids in the container. `table` format will use `ps` utilty in
the host, search and output all processes in the container. Add a struct
`container` to represent a spawned container. Move the `kill`
implemention from kill.rs as a method of `container`.

Fixes: #4361

Signed-off-by: Chen Yiyang <cyyzero@qq.com>