### PR TITLE
packaging: Add support for building TDVF

### DIFF
--- a/tools/packaging/static-build/ovmf/Dockerfile
+++ b/tools/packaging/static-build/ovmf/Dockerfile
@@ -17,5 +17,6 @@ RUN apt-get update && \
         nasm \
         python \
         python3 \
+        python3-distutils \
         uuid-dev && \
     apt-get clean && rm -rf /var/lib/lists/

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -67,3 +67,8 @@ popd
 info "Install fd to destdir"
 mkdir -p "$DESTDIR/$PREFIX/share/ovmf"
 cp $build_root/$ovmf_dir/"${build_path}" "$DESTDIR/$PREFIX/share/ovmf"
+
+pushd $DESTDIR
+tar -czvf "${ovmf_dir}-${ovmf_build}.tar.gz" "./$PREFIX"
+rm -rf $(dirname ./$PREFIX) 
+popd

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 #
 # Copyright (c) 2022 IBM
+# Copyright (c) 2022 Intel
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -15,7 +16,6 @@ source "${script_dir}/../../scripts/lib.sh"
 set +u
 ovmf_build="${ovmf_build:-x86_64}"
 ovmf_repo="${ovmf_repo:-}"
-ovmf_dir="edk2"
 ovmf_version="${ovmf_version:-}"
 ovmf_package="${ovmf_package:-}"
 package_output_dir="${package_output_dir:-}"
@@ -29,6 +29,8 @@ build_target="${build_target:-RELEASE}"
 [ -n "$ovmf_version" ] || die "failed to get ovmf version or commit"
 [ -n "$ovmf_package" ] || die "failed to get ovmf package or commit"
 [ -n "$package_output_dir" ] || die "failed to get ovmf package or commit"
+
+ovmf_dir="${ovmf_repo##*/}"
 
 info "Build ${ovmf_repo} version: ${ovmf_version}"
 

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -36,9 +36,8 @@ info "Build ${ovmf_repo} version: ${ovmf_version}"
 
 build_root=$(mktemp -d)
 pushd $build_root
-git clone "${ovmf_repo}"
+git clone --single-branch --depth 1 -b "${ovmf_version}" "${ovmf_repo}"
 cd "${ovmf_dir}"
-git checkout "${ovmf_version}"
 git submodule init
 git submodule update
 

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -25,7 +25,11 @@ ovmf_package="${ovmf_package:-}"
 package_output_dir="${package_output_dir:-}"
 
 if [ -z "$ovmf_repo" ]; then
-       ovmf_repo=$(get_from_kata_deps "externals.ovmf.url" "${kata_version}")
+       if [ "${ovmf_build}" == "tdx" ]; then
+	       ovmf_repo=$(get_from_kata_deps "externals.ovmf.tdx.url" "${kata_version}")
+       else
+	       ovmf_repo=$(get_from_kata_deps "externals.ovmf.url" "${kata_version}")
+       fi
 fi
 
 [ -n "$ovmf_repo" ] || die "failed to get ovmf repo"
@@ -38,6 +42,10 @@ elif [ "${ovmf_build}" == "sev" ]; then
        [ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps "externals.ovmf.sev.version" "${kata_version}")
        [ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps "externals.ovmf.sev.package" "${kata_version}")
        [ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps "externals.ovmf.sev.package_output_dir" "${kata_version}")
+elif [ "${ovmf_build}" == "tdx" ]; then
+       [ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps "externals.ovmf.tdx.version" "${kata_version}")
+       [ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps "externals.ovmf.tdx.package" "${kata_version}")
+       [ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps "externals.ovmf.tdx.package_output_dir" "${kata_version}")
 fi
 
 [ -n "$ovmf_version" ] || die "failed to get ovmf version or commit"

--- a/versions.yaml
+++ b/versions.yaml
@@ -261,6 +261,12 @@ externals:
       version: "edk2-stable202202"
       package: "OvmfPkg/AmdSev/AmdSevX64.dsc"
       package_output_dir: "AmdSev"
+    tdx:
+      url: "https://github.com/tianocore/edk2-staging"
+      description: "TDVF build needed for TDX measured direct boot."
+      version: "2022-tdvf-ww28.5"
+      package: "OvmfPkg/OvmfPkgX64.dsc"
+      package_output_dir: "OvmfX64"
 
   td-shim:
     description: "Confidential Containers Shim Firmware"


### PR DESCRIPTION
TDVF is the firmware used by QEMU to start TDX capable VMs.  Let's start
tracking it as it'll become part of the Confidential Containers sooner
or later.

TDVF lives in the public https://github.com/tianocore/edk2-staging repo
and we're using as its version tags that are consumed internally at
Intel.

Fixes: #4624 