### PR TITLE
docs: Updated link for CRI-O

### DIFF
--- a/docs/install/minikube-installation-guide.md
+++ b/docs/install/minikube-installation-guide.md
@@ -55,11 +55,11 @@ Here are the features to set up a CRI-O based Minikube, and why you need them:
 
 | what | why |
 | ---- | --- |
-| `--bootstrapper=kubeadm` | As recommended for [minikube CRI-o](https://kubernetes.io/docs/setup/minikube/#cri-o) |
+| `--bootstrapper=kubeadm` | As recommended for [minikube CRI-O](https://minikube.sigs.k8s.io/docs/handbook/config/#runtime-configuration) |
 | `--container-runtime=cri-o` | Using CRI-O for Kata |
-| `--enable-default-cni` | As recommended for [minikube CRI-o](https://kubernetes.io/docs/setup/minikube/#cri-o) |
+| `--enable-default-cni` | As recommended for [minikube CRI-O](https://minikube.sigs.k8s.io/docs/handbook/config/#runtime-configuration) |
 | `--memory 6144` | Allocate sufficient memory, as Kata Containers default to 1 or 2Gb |
-| `--network-plugin=cni` | As recommended for [minikube CRI-o](https://kubernetes.io/docs/setup/minikube/#cri-o) |
+| `--network-plugin=cni` | As recommended for [minikube CRI-O](https://minikube.sigs.k8s.io/docs/handbook/config/#runtime-configuration) |
 | `--vm-driver kvm2` | The host VM driver |
 
 To use containerd, modify the `--container-runtime` argument:

--- a/src/agent/src/tracer.rs
+++ b/src/agent/src/tracer.rs
@@ -69,6 +69,8 @@ macro_rules! trace_rpc_call {
             propagator.extract(&extract_carrier_from_ttrpc($ctx))
         });
 
+        info!(sl!(), "rpc call from shim to agent: {:?}", $name);
+
         // generate tracing span
         let rpc_span = span!(tracing::Level::INFO, $name, "mod"="rpc.rs", req=?$req);
 

--- a/tools/packaging/static-build/ovmf/Dockerfile
+++ b/tools/packaging/static-build/ovmf/Dockerfile
@@ -1,0 +1,21 @@
+# Copyright (c) 2022 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        g++ \
+        gcc \
+        git \
+        iasl  \
+        make \
+        nasm \
+        python \
+        python3 \
+        uuid-dev && \
+    apt-get clean && rm -rf /var/lib/lists/

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/../../scripts/lib.sh"
+
+# disabling set -u because scripts attempt to expand undefined variables
+set +u
+ovmf_repo="${ovmf_repo:-}"
+ovmf_dir="edk2"
+ovmf_version="${ovmf_version:-}"
+ovmf_package="${ovmf_package:-}"
+package_output_dir="${package_output_dir:-}"
+DESTDIR=${DESTDIR:-${PWD}}
+PREFIX="${PREFIX:-/opt/kata}"
+architecture="${architecture:-X64}"
+toolchain="${toolchain:-GCC5}"
+build_target="${build_target:-RELEASE}"
+
+[ -n "$ovmf_repo" ] || die "failed to get ovmf repo"
+[ -n "$ovmf_version" ] || die "failed to get ovmf version or commit"
+[ -n "$ovmf_package" ] || die "failed to get ovmf package or commit"
+[ -n "$package_output_dir" ] || die "failed to get ovmf package or commit"
+
+info "Build ${ovmf_repo} version: ${ovmf_version}"
+
+build_root=$(mktemp -d)
+pushd $build_root
+git clone "${ovmf_repo}"
+cd "${ovmf_dir}"
+git checkout "${ovmf_version}"
+git submodule init
+git submodule update
+
+info "Using BaseTools make target"
+make -C BaseTools/
+
+info "Calling edksetup script"
+source edksetup.sh
+
+info "Building ovmf"
+build -b "${build_target}" -t "${toolchain}" -a "${architecture}" -p "${ovmf_package}"
+
+info "Done Building"
+
+build_path="Build/${package_output_dir}/${build_target}_${toolchain}/FV/OVMF.fd"
+stat "${build_path}"
+
+#need to leave tmp dir
+popd
+
+info "Install fd to destdir"
+mkdir -p "$DESTDIR/$PREFIX/share/ovmf"
+cp $build_root/$ovmf_dir/"${build_path}" "$DESTDIR/$PREFIX/share/ovmf"

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -13,6 +13,7 @@ source "${script_dir}/../../scripts/lib.sh"
 
 # disabling set -u because scripts attempt to expand undefined variables
 set +u
+ovmf_build="${ovmf_build:-x86_64}"
 ovmf_repo="${ovmf_repo:-}"
 ovmf_dir="edk2"
 ovmf_version="${ovmf_version:-}"
@@ -44,6 +45,12 @@ make -C BaseTools/
 
 info "Calling edksetup script"
 source edksetup.sh
+
+if [ "${ovmf_build}" == "sev" ]; then
+       info "Creating dummy grub file"
+       #required for building AmdSev package without grub
+       touch OvmfPkg/AmdSev/Grub/grub.efi
+fi
 
 info "Building ovmf"
 build -b "${build_target}" -t "${toolchain}" -a "${architecture}" -p "${ovmf_package}"

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -34,6 +34,10 @@ if [ "${ovmf_build}" == "x86_64" ]; then
        [ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps "externals.ovmf.x86_64.version" "${kata_version}")
        [ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps "externals.ovmf.x86_64.package" "${kata_version}")
        [ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps "externals.ovmf.x86_64.package_output_dir" "${kata_version}")
+elif [ "${ovmf_build}" == "sev" ]; then
+       [ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps "externals.ovmf.sev.version" "${kata_version}")
+       [ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps "externals.ovmf.sev.package" "${kata_version}")
+       [ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps "externals.ovmf.sev.package_output_dir" "${kata_version}")
 fi
 
 [ -n "$ovmf_version" ] || die "failed to get ovmf version or commit"
@@ -45,6 +49,7 @@ sudo docker build -t "${container_image}" "${script_dir}"
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \
 	--env DESTDIR="${DESTDIR}" --env PREFIX="${PREFIX}" \
+	--env ovmf_build="${ovmf_build}" \
 	--env ovmf_repo="${ovmf_repo}" \
 	--env ovmf_version="${ovmf_version}" \
 	--env ovmf_package="${ovmf_package}" \

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
+readonly ovmf_builder="${script_dir}/build-ovmf.sh"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+DESTDIR=${DESTDIR:-${PWD}}
+PREFIX=${PREFIX:-/opt/kata}
+container_image="kata-ovmf-builder"
+ovmf_build="${ovmf_build:-x86_64}"
+kata_version="${kata_version:-}"
+ovmf_repo="${ovmf_repo:-}"
+ovmf_version="${ovmf_version:-}"
+ovmf_package="${ovmf_package:-}"
+package_output_dir="${package_output_dir:-}"
+
+if [ -z "$ovmf_repo" ]; then
+       ovmf_repo=$(get_from_kata_deps "externals.ovmf.url" "${kata_version}")
+fi
+
+[ -n "$ovmf_repo" ] || die "failed to get ovmf repo"
+
+if [ "${ovmf_build}" == "x86_64" ]; then
+       [ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps "externals.ovmf.x86_64.version" "${kata_version}")
+       [ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps "externals.ovmf.x86_64.package" "${kata_version}")
+       [ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps "externals.ovmf.x86_64.package_output_dir" "${kata_version}")
+fi
+
+[ -n "$ovmf_version" ] || die "failed to get ovmf version or commit"
+[ -n "$ovmf_package" ] || die "failed to get ovmf package or commit"
+[ -n "$package_output_dir" ] || die "failed to get ovmf package or commit"
+
+sudo docker build -t "${container_image}" "${script_dir}"
+
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${PWD}" \
+	--env DESTDIR="${DESTDIR}" --env PREFIX="${PREFIX}" \
+	--env ovmf_repo="${ovmf_repo}" \
+	--env ovmf_version="${ovmf_version}" \
+	--env ovmf_package="${ovmf_package}" \
+	--env package_output_dir="${package_output_dir}" \
+	"${container_image}" \
+	bash -c "${ovmf_builder}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -248,6 +248,15 @@ externals:
     url: "https://github.com/containerd/nydus-snapshotter"
     version: "v0.2.3"
 
+  ovmf:
+    description: "Firmware, implementation of UEFI for virtual machines."
+    url: "https://github.com/tianocore/edk2"
+    x86_64:
+      description: "Vanilla firmware build"
+      version: "edk2-stable202202"
+      package: "OvmfPkg/OvmfPkgX64.dsc"
+      package_output_dir: "OvmfX64"
+      
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"
     url: "https://gitlab.com/virtio-fs/virtiofsd"

--- a/versions.yaml
+++ b/versions.yaml
@@ -256,7 +256,12 @@ externals:
       version: "edk2-stable202202"
       package: "OvmfPkg/OvmfPkgX64.dsc"
       package_output_dir: "OvmfX64"
-      
+    sev:
+      description: "AmdSev build needed for SEV measured direct boot."
+      version: "edk2-stable202202"
+      package: "OvmfPkg/AmdSev/AmdSevX64.dsc"
+      package_output_dir: "AmdSev"
+
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"
     url: "https://gitlab.com/virtio-fs/virtiofsd"


### PR DESCRIPTION
In file `docs/install/minikube-installation-guide.md`, updated the link target of CRI-O to https://minikube.sigs.k8s.io/docs/handbook/config/#runtime-configuration
Fixed #4767 