### PR TITLE
versions: Track and add support for building TD-shim

### DIFF
--- a/tools/packaging/static-build/td-shim/Dockerfile
+++ b/tools/packaging/static-build/td-shim/Dockerfile
@@ -1,0 +1,23 @@
+# Copyright (c) 2022 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+ARG RUST_TOOLCHAIN
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        clang \
+        curl \
+        gcc \
+        git \
+        llvm \
+        nasm && \
+    apt-get clean && rm -rf /var/lib/lists/ && \
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
+    source "$HOME/.cargo/env" && \
+    rustup component add rust-src && \
+    cargo install cargo-xbuild

--- a/tools/packaging/static-build/td-shim/build-td-shim.sh
+++ b/tools/packaging/static-build/td-shim/build-td-shim.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/../../scripts/lib.sh"
+
+tdshim_repo="${tdshim_repo:-}"
+DESTDIR=${DESTDIR:-${PWD}}
+PREFIX="${PREFIX:-/opt/kata}"
+
+[ -n "${tdshim_repo}" ] || die "Failed to get TD-shim repo"
+[ -n "${tdshim_version}" ] || die "Failed to get TD-shim version or commit"
+
+info "Build ${tdshim_repo} version: ${tdshim_version}"
+
+source ${HOME}/.cargo/env
+
+build_root=$(mktemp -d)
+pushd ${build_root}
+git clone --single-branch "${tdshim_repo}"
+pushd td-shim
+git checkout "${tdshim_version}"
+bash sh_script/build_final.sh boot_kernel
+
+install_dir="${DESTDIR}/${PREFIX}/share/td-shim"
+mkdir -p ${install_dir}
+install target/x86_64-unknown-uefi/release/final-boot-kernel.bin ${install_dir}/td-shim.bin
+popd #td-shim
+popd #${build_root}
+
+pushd ${DESTDIR}
+tar -czvf "td-shim.tar.gz" "./$PREFIX"
+rm -rf $(dirname ./$PREFIX)
+popd #${DESTDIR}

--- a/tools/packaging/static-build/td-shim/build.sh
+++ b/tools/packaging/static-build/td-shim/build.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
+readonly tdshim_builder="${script_dir}/build-td-shim.sh"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+DESTDIR=${DESTDIR:-${PWD}}
+PREFIX=${PREFIX:-/opt/kata}
+container_image="kata-td-shim-builder"
+kata_version="${kata_version:-}"
+tdshim_repo="${tdshim_repo:-}"
+tdshim_version="${tdshim_version:-}"
+tdshim_toolchain="${tdshim_toolchain:-}"
+package_output_dir="${package_output_dir:-}"
+
+[ -n "${tdshim_repo}" ] || tdshim_repo=$(get_from_kata_deps "externals.td-shim.url" "${kata_version}")
+[ -n "${tdshim_version}" ] || tdshim_version=$(get_from_kata_deps "externals.td-shim.version" "${kata_version}")
+[ -n "${tdshim_toolchain}" ] || tdshim_toolchain=$(get_from_kata_deps "externals.td-shim.toolchain" "${kata_version}")
+
+[ -n "${tdshim_repo}" ] || die "Failed to get TD-shim repo"
+[ -n "${tdshim_version}" ] || die "Failed to get TD-shim version or commit"
+[ -n "${tdshim_toolchain}" ] || die "Failed to get TD-shim toolchain to be used to build the project"
+
+sudo docker build \
+	--build-arg RUST_TOOLCHAIN="${tdshim_toolchain}" \
+	-t "${container_image}" "${script_dir}"
+
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${PWD}" \
+	--env DESTDIR="${DESTDIR}" \
+	--env PREFIX="${PREFIX}" \
+	--env tdshim_repo="${tdshim_repo}" \
+	--env tdshim_version="${tdshim_version}" \
+	"${container_image}" \
+	bash -c "${tdshim_builder}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -262,6 +262,12 @@ externals:
       package: "OvmfPkg/AmdSev/AmdSevX64.dsc"
       package_output_dir: "AmdSev"
 
+  td-shim:
+    description: "Confidential Containers Shim Firmware"
+    url: "https://github.com/confidential-containers/td-shim"
+    version: "5f62a0e367b1845a54e534d103ed4a697a599ac3"
+    toolchain: "nightly-2022-04-07"
+
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"
     url: "https://gitlab.com/virtio-fs/virtiofsd"


### PR DESCRIPTION
TD-shim is a simplified TDX virtual firmware, used by Cloud Hypervisor,
in order to create a TDX capable VM.

TD-shim is heavily under development, and is hosted as part of the
Confidential Containers project:
https://github.com/confidential-containers/td-shim

The version chosen for this commit, is a version that's being tested
inside Intel, but we, most likely, will need to change it before we have
it officially packaged as part of an official release.

Fixes: #4779

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>