### PR TITLE
kata-deploy: libseccomp.so link not created

### DIFF
--- a/ci/install_libseccomp.sh
+++ b/ci/install_libseccomp.sh
@@ -88,6 +88,12 @@ build_and_install_libseccomp() {
     ./configure --prefix="${libseccomp_install_dir}" CFLAGS="${cflags}" --enable-static --host="${arch}"
     make
     make install
+
+    # 4786 - libseccomp.so link not created
+    if [[ -f /usr/lib64/libseccomp.so.2 && ! -f /usr/lib64/libseccomp.so ]]; then
+      ln -sf libseccomp.so.2 /usr/lib64/libseccomp.so
+    fi
+
     popd
     echo "Libseccomp installed successfully"
 }


### PR DESCRIPTION
Fixes #4786

libseccomp.so link not created in clearlinux image during rootfs building

Signed-Off-By: Ryan Savino <ryan.savino@amd.com>