### PR TITLE
OVMF / td-shim: Adjust final tarball location

### DIFF
--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -90,7 +90,8 @@ if [ "${ovmf_build}" == "tdx" ]; then
 	install $build_root/$ovmf_dir/"${build_path_arch}"/DumpTdxEventLog.efi ${install_dir}
 fi
 
+local_dir=${PWD}
 pushd $DESTDIR
-tar -czvf "${ovmf_dir}-${ovmf_build}.tar.gz" "./$PREFIX"
+tar -czvf "${local_dir}/${ovmf_dir}-${ovmf_build}.tar.gz" "./$PREFIX"
 rm -rf $(dirname ./$PREFIX) 
 popd

--- a/tools/packaging/static-build/td-shim/build-td-shim.sh
+++ b/tools/packaging/static-build/td-shim/build-td-shim.sh
@@ -35,7 +35,8 @@ install target/x86_64-unknown-uefi/release/final-boot-kernel.bin ${install_dir}/
 popd #td-shim
 popd #${build_root}
 
+local_dir=${PWD}
 pushd ${DESTDIR}
-tar -czvf "td-shim.tar.gz" "./$PREFIX"
+tar -czvf "${local_dir}/td-shim.tar.gz" "./$PREFIX"
 rm -rf $(dirname ./$PREFIX)
 popd #${DESTDIR}


### PR DESCRIPTION
Let's create the OVMF / td-shim tarball in the directory where the script was
called from, instead of doing it in the $DESTDIR.

This aligns with the logic being used for creating / extracting the
tarball content, which is already in use by the kata-deploy local build
scripts.

Fixes: #4808, #4809
