### PR TITLE
CC | packaging: Build and ship TDVF and TD-shim

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -85,19 +85,10 @@ cc: cc-cloud-hypervisor-tarball \
 cc-cloud-hypervisor-tarball:
 	${MAKE} $@-build
 
-cc-tdx-cloud-hypervisor-tarball:
-	${MAKE} $@-build
-
 cc-kernel-tarball:
 	${MAKE} $@-build
 
-cc-tdx-kernel-tarball:
-	${MAKE} $@-build
-
 cc-qemu-tarball:
-	${MAKE} $@-build
-
-cc-tdx-qemu-tarball:
 	${MAKE} $@-build
 
 cc-rootfs-image-tarball:
@@ -108,3 +99,13 @@ cc-shim-v2-tarball:
 
 cc-virtiofsd-tarball:
 	${MAKE} $@-build
+
+cc-tdx-cloud-hypervisor-tarball:
+	${MAKE} $@-build
+
+cc-tdx-kernel-tarball:
+	${MAKE} $@-build
+
+cc-tdx-qemu-tarball:
+	${MAKE} $@-build
+

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -109,3 +109,5 @@ cc-tdx-kernel-tarball:
 cc-tdx-qemu-tarball:
 	${MAKE} $@-build
 
+cc-tdx-tdvf-tarball:
+	${MAKE} $@-build

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -109,5 +109,8 @@ cc-tdx-kernel-tarball:
 cc-tdx-qemu-tarball:
 	${MAKE} $@-build
 
+cc-tdx-td-shim-tarball:
+	${MAKE} $@-build
+
 cc-tdx-tdvf-tarball:
 	${MAKE} $@-build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -108,11 +108,6 @@ install_cc_clh() {
 	sudo install -D --owner root --group root --mode 0744 cloud-hypervisor/cloud-hypervisor "${destdir}/${cc_prefix}/bin/cloud-hypervisor"
 }
 
-# Install static CC cloud-hypervisor asset
-install_tdx_cc_clh() {
-	install_cc_clh
-}
-
 #Install cc capable guest image
 install_cc_image() {
 	info "Create CC image"
@@ -123,43 +118,10 @@ install_cc_image() {
 	"${rootfs_builder}" --imagetype=image --prefix="${cc_prefix}" --destdir="${destdir}"
 }
 
-#Install CC kernel assert, with TEE support
-install_cc_tee_kernel() {
-	tee="${1}"
-
-	[ "${tee}" != "tdx" ] && die "Non supported TEE"
-
-	export kernel_version="$(yq r $versions_yaml assets.kernel.${tee}.tag)"
-	export kernel_url="$(yq r $versions_yaml assets.kernel.${tee}.url)"
-	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -x "${tee}" -v "${kernel_version}" -u "${kernel_url}"
-}
-
-#Install CC kernel assert for Intel TDX
-install_cc_tdx_kernel() {
-	install_cc_tee_kernel "tdx"
-}
-
 #Install CC kernel asset
 install_cc_kernel() {
 	export kernel_version="$(yq r $versions_yaml assets.kernel.version)"
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -f -v "${kernel_version}"
-}
-
-install_cc_tee_qemu() {
-	tee="${1}"
-
-	[ "${tee}" != "tdx" ] && die "Non supported TEE"
-
-	export qemu_repo="$(yq r $versions_yaml assets.hypervisor.qemu.${tee}.url)"
-	export qemu_version="$(yq r $versions_yaml assets.hypervisor.qemu.${tee}.tag)"
-	export tee="${tee}"
-	"${qemu_cc_builder}"
-	tar xvf "${builddir}/kata-static-${tee}-qemu-cc.tar.gz" -C "${destdir}"
-}
-
-
-install_cc_tdx_qemu() {
-	install_cc_tee_qemu "tdx"
 }
 
 # Install static CC qemu asset
@@ -186,6 +148,43 @@ install_cc_virtiofsd() {
 	info "Install static CC virtiofsd"
 	mkdir -p "${destdir}/${cc_prefix}/libexec/"
 	sudo install -D --owner root --group root --mode 0744 virtiofsd/virtiofsd "${destdir}/${cc_prefix}/libexec/virtiofsd"
+}
+
+# Install static CC cloud-hypervisor asset
+install_tdx_cc_clh() {
+	install_cc_clh
+}
+
+#Install CC kernel assert, with TEE support
+install_cc_tee_kernel() {
+	tee="${1}"
+
+	[ "${tee}" != "tdx" ] && die "Non supported TEE"
+
+	export kernel_version="$(yq r $versions_yaml assets.kernel.${tee}.tag)"
+	export kernel_url="$(yq r $versions_yaml assets.kernel.${tee}.url)"
+	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -x "${tee}" -v "${kernel_version}" -u "${kernel_url}"
+}
+
+#Install CC kernel assert for Intel TDX
+install_cc_tdx_kernel() {
+	install_cc_tee_kernel "tdx"
+}
+
+install_cc_tee_qemu() {
+	tee="${1}"
+
+	[ "${tee}" != "tdx" ] && die "Non supported TEE"
+
+	export qemu_repo="$(yq r $versions_yaml assets.hypervisor.qemu.${tee}.url)"
+	export qemu_version="$(yq r $versions_yaml assets.hypervisor.qemu.${tee}.tag)"
+	export tee="${tee}"
+	"${qemu_cc_builder}"
+	tar xvf "${builddir}/kata-static-${tee}-qemu-cc.tar.gz" -C "${destdir}"
+}
+
+install_cc_tdx_qemu() {
+	install_cc_tee_qemu "tdx"
 }
 
 #Install guest image
@@ -296,21 +295,21 @@ handle_build() {
 
 	cc-cloud-hypervisor) install_cc_clh ;;
 
-	cc-tdx-cloud-hypervisor) install_tdx_cc_clh ;;
-
 	cc-kernel) install_cc_kernel ;;
 
-	cc-tdx-kernel) install_cc_tdx_kernel ;;
-
 	cc-qemu) install_cc_qemu ;;
-
-	cc-tdx-qemu) install_cc_tdx_qemu ;;
 
 	cc-rootfs-image) install_cc_image ;;
 
 	cc-shim-v2) install_cc_shimv2 ;;
 
 	cc-virtiofsd) install_cc_virtiofsd ;;
+
+	cc-tdx-cloud-hypervisor) install_tdx_cc_clh ;;
+
+	cc-tdx-kernel) install_cc_tdx_kernel ;;
+
+	cc-tdx-qemu) install_cc_tdx_qemu ;;
 
 	cloud-hypervisor) install_clh ;;
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -24,6 +24,7 @@ readonly versions_yaml="${repo_root_dir}/versions.yaml"
 readonly clh_builder="${static_build_dir}/cloud-hypervisor/build-static-clh.sh"
 readonly firecracker_builder="${static_build_dir}/firecracker/build-static-firecracker.sh"
 readonly kernel_builder="${static_build_dir}/kernel/build.sh"
+readonly ovmf_builder="${static_build_dir}/ovmf/build.sh"
 readonly qemu_builder="${static_build_dir}/qemu/build-static-qemu.sh"
 readonly shimv2_builder="${static_build_dir}/shim-v2/build.sh"
 readonly virtiofsd_builder="${static_build_dir}/virtiofsd/build-static-virtiofsd.sh"
@@ -187,6 +188,18 @@ install_cc_tdx_qemu() {
 	install_cc_tee_qemu "tdx"
 }
 
+install_cc_tee_ovmf() {
+	tee="${1}"
+	tarball_name="${2}"
+
+	DESTDIR="${destdir}" PREFIX="${cc_prefix}" ovmf_build="${tee}" "${ovmf_builder}"
+	tar xvf "${builddir}/${tarball_name}" -C "${destdir}"
+}
+
+install_cc_tdx_tdvf() {
+	install_cc_tee_ovmf "tdx" "edk2-staging-tdx.tar.gz"
+}
+
 #Install guest image
 install_image() {
 	info "Create image"
@@ -310,6 +323,8 @@ handle_build() {
 	cc-tdx-kernel) install_cc_tdx_kernel ;;
 
 	cc-tdx-qemu) install_cc_tdx_qemu ;;
+
+	cc-tdx-tdvf) install_cc_tdx_tdvf ;;
 
 	cloud-hypervisor) install_clh ;;
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -27,6 +27,7 @@ readonly kernel_builder="${static_build_dir}/kernel/build.sh"
 readonly ovmf_builder="${static_build_dir}/ovmf/build.sh"
 readonly qemu_builder="${static_build_dir}/qemu/build-static-qemu.sh"
 readonly shimv2_builder="${static_build_dir}/shim-v2/build.sh"
+readonly td_shim_builder="${static_build_dir}/td-shim/build.sh"
 readonly virtiofsd_builder="${static_build_dir}/virtiofsd/build-static-virtiofsd.sh"
 
 readonly rootfs_builder="${repo_root_dir}/tools/packaging/guest-image/build_image.sh"
@@ -188,6 +189,11 @@ install_cc_tdx_qemu() {
 	install_cc_tee_qemu "tdx"
 }
 
+install_cc_tdx_td_shim() {
+	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${td_shim_builder}"
+	tar xvf "${builddir}/td-shim.tar.gz" -C "${destdir}"
+}
+
 install_cc_tee_ovmf() {
 	tee="${1}"
 	tarball_name="${2}"
@@ -323,6 +329,8 @@ handle_build() {
 	cc-tdx-kernel) install_cc_tdx_kernel ;;
 
 	cc-tdx-qemu) install_cc_tdx_qemu ;;
+
+	cc-tdx-td-shim) install_cc_tdx_td_shim ;;
 
 	cc-tdx-tdvf) install_cc_tdx_tdvf ;;
 

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -90,7 +90,8 @@ if [ "${ovmf_build}" == "tdx" ]; then
 	install $build_root/$ovmf_dir/"${build_path_arch}"/DumpTdxEventLog.efi ${install_dir}
 fi
 
+local_dir=${PWD}
 pushd $DESTDIR
-tar -czvf "${ovmf_dir}-${ovmf_build}.tar.gz" "./$PREFIX"
+tar -czvf "${local_dir}/${ovmf_dir}-${ovmf_build}.tar.gz" "./$PREFIX"
 rm -rf $(dirname ./$PREFIX) 
 popd

--- a/tools/packaging/static-build/td-shim/build-td-shim.sh
+++ b/tools/packaging/static-build/td-shim/build-td-shim.sh
@@ -35,7 +35,8 @@ install target/x86_64-unknown-uefi/release/final-boot-kernel.bin ${install_dir}/
 popd #td-shim
 popd #${build_root}
 
+local_dir=${PWD}
 pushd ${DESTDIR}
-tar -czvf "td-shim.tar.gz" "./$PREFIX"
+tar -czvf "${local_dir}/td-shim.tar.gz" "./$PREFIX"
 rm -rf $(dirname ./$PREFIX)
 popd #${DESTDIR}


### PR DESCRIPTION
We're adding a new target for building a TDVF and TD-shim, firmwares used with QEMU and Cloud Hypervisor, respectively,
to start TDX capable VMs for CC.

NOTE: This PR backports two patches that are about to be merged on the `main` branch - https://github.com/kata-containers/kata-containers/pull/4810

Fixes: #4625, #4780 