### PR TITLE
logging: Replace nix::Error::EINVAL with more descriptive msgs

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -174,7 +174,7 @@ impl CgroupManager for Manager {
                 freezer_controller.freeze()?;
             }
             _ => {
-                return Err(anyhow!(nix::Error::EINVAL));
+                return Err(anyhow!("Invalid FreezerState"));
             }
         }
 

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -106,6 +106,11 @@ impl Default for ContainerStatus {
     }
 }
 
+// We might want to change this to thiserror in the future
+const MissingCGroupManager: &str = "failed to get container's cgroup Manager";
+const MissingLinux: &str = "no linux config";
+const InvalidNamespace: &str = "invalid namespace type";
+
 pub type Config = CreateOpts;
 type NamespaceType = String;
 
@@ -292,7 +297,7 @@ impl Container for LinuxContainer {
             self.status.transition(ContainerState::Paused);
             return Ok(());
         }
-        Err(anyhow!("failed to get container's cgroup manager"))
+        Err(anyhow!(MissingCGroupManager))
     }
 
     fn resume(&mut self) -> Result<()> {
@@ -310,7 +315,7 @@ impl Container for LinuxContainer {
             self.status.transition(ContainerState::Running);
             return Ok(());
         }
-        Err(anyhow!("failed to get container's cgroup manager"))
+        Err(anyhow!(MissingCGroupManager))
     }
 }
 
@@ -397,7 +402,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     };
 
     if spec.linux.is_none() {
-        return Err(anyhow!("no linux config"));
+        return Err(anyhow!(MissingLinux));
     }
     let linux = spec.linux.as_ref().unwrap();
 
@@ -411,7 +416,7 @@ fn do_init_child(cwfd: RawFd) -> Result<()> {
     for ns in &nses {
         let s = NAMESPACES.get(&ns.r#type.as_str());
         if s.is_none() {
-            return Err(anyhow!("invalid ns type"));
+            return Err(anyhow!(InvalidNamespace));
         }
         let s = s.unwrap();
 
@@ -1437,17 +1442,9 @@ impl LinuxContainer {
             Some(unistd::getuid()),
             Some(unistd::getgid()),
         )
-        .context(format!("cannot change onwer of container {} root", id))?;
-
-        if config.spec.is_none() {
-            return Err(anyhow!(nix::Error::EINVAL));
-        }
+        .context(format!("Cannot change owner of container {} root", id))?;
 
         let spec = config.spec.as_ref().unwrap();
-
-        if spec.linux.is_none() {
-            return Err(anyhow!(nix::Error::EINVAL));
-        }
 
         let linux = spec.linux.as_ref().unwrap();
 
@@ -1525,7 +1522,7 @@ pub async fn execute_hook(logger: &Logger, h: &Hook, st: &OCIState) -> Result<()
     let binary = PathBuf::from(h.path.as_str());
     let path = binary.canonicalize()?;
     if !path.exists() {
-        return Err(anyhow!(nix::Error::EINVAL));
+        return Err(anyhow!("Path {:?} does not exist", path));
     }
 
     let mut args = h.args.clone();

--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -523,7 +523,7 @@ impl Handle {
             .as_ref()
             .map(|to| to.address.as_str()) // Extract address field
             .and_then(|addr| if addr.is_empty() { None } else { Some(addr) }) // Make sure it's not empty
-            .ok_or_else(|| anyhow!(nix::Error::EINVAL))?;
+            .ok_or_else(|| anyhow!("Unable to determine ip address of ARP neighbor"))?;
 
         let ip = IpAddr::from_str(ip_address)
             .map_err(|e| anyhow!("Failed to parse IP {}: {:?}", ip_address, e))?;
@@ -612,7 +612,12 @@ fn parse_mac_address(addr: &str) -> Result<[u8; 6]> {
 
     // Parse single Mac address block
     let mut parse_next = || -> Result<u8> {
-        let v = u8::from_str_radix(split.next().ok_or_else(|| anyhow!(nix::Error::EINVAL))?, 16)?;
+        let v = u8::from_str_radix(
+            split
+                .next()
+                .ok_or_else(|| anyhow!("Invalid MAC address {}", addr))?,
+            16,
+        )?;
         Ok(v)
     };
 

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -380,7 +380,7 @@ impl AgentService {
         let mut process = req
             .process
             .into_option()
-            .ok_or_else(|| anyhow!(nix::Error::EINVAL))?;
+            .ok_or_else(|| anyhow!("Unable to parse process from ExecProcessRequest"))?;
 
         // Apply any necessary corrections for PCI addresses
         update_env_pci(&mut process.Env, &sandbox.pcimap)?;
@@ -629,7 +629,7 @@ impl AgentService {
         };
 
         if reader.is_none() {
-            return Err(anyhow!(nix::Error::EINVAL));
+            return Err(anyhow!("Unable to determine stream reader, is None"));
         }
 
         let reader = reader.ok_or_else(|| anyhow!("cannot get stream reader"))?;
@@ -1843,7 +1843,11 @@ fn do_copy_file(req: &CopyFileRequest) -> Result<()> {
     let path = PathBuf::from(req.path.as_str());
 
     if !path.starts_with(CONTAINER_BASE) {
-        return Err(anyhow!(nix::Error::EINVAL));
+        return Err(anyhow!(
+            "Path {:?} does not start with {}",
+            path,
+            CONTAINER_BASE
+        ));
     }
 
     let parent = path.parent();


### PR DESCRIPTION
Replaces instances of anyhow!(nix::Error::EINVAL) with other messages to
make it easier to debug.

Fixes #954

Signed-off-by: Derek Lee <derlee@redhat.com>