### PR TITLE
runtime-rs:skip the build process when the arch is s390x

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -21,14 +21,19 @@ ARCH_DIR = arch
 ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 
-
 ifeq ($(ARCH), s390x)
-##TARGET default: build code
 default:
 	@echo "s390x not support currently"
 	exit 0
+test:
+	@echo "s390x not support currently"
+	exit 0
 else
+##TARGET default: build code
 default: runtime show-header
+#TARGET test: run cargo tests
+test:
+	@cargo test --all --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
 endif
 
 ifeq (,$(realpath $(ARCH_FILE)))
@@ -365,10 +370,6 @@ clean:
 
 vendor:
 	@cargo vendor
-
-#TARGET test: run cargo tests
-test:
-	@cargo test --all --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
 
 ##TARGET check: run test
 check: $(GENERATED_FILES) standard_rust_check

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -21,6 +21,16 @@ ARCH_DIR = arch
 ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 
+
+ifeq ($(ARCH), s390x)
+##TARGET default: build code
+default:
+	@echo "s390x not support currently"
+	exit 0
+else
+default: runtime show-header
+endif
+
 ifeq (,$(realpath $(ARCH_FILE)))
     $(error "ERROR: invalid architecture: '$(ARCH)'")
 else
@@ -326,9 +336,6 @@ $(if $(findstring uncompressed,$1),vmlinux.container,vmlinuz.container)
 endef
 
 .DEFAULT_GOAL := default
-
-##TARGET default: build code
-default: runtime show-header
 
 runtime: $(TARGET)
 

--- a/src/runtime-rs/arch/s390x-options.mk
+++ b/src/runtime-rs/arch/s390x-options.mk
@@ -1,0 +1,15 @@
+# Copyright (c) 2019-2022 Alibaba Cloud
+# Copyright (c) 2019-2022 Ant Group
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+MACHINETYPE :=
+KERNELPARAMS :=
+MACHINEACCELERATORS :=
+CPUFEATURES := pmu=off
+
+QEMUCMD := qemu-system-s390x
+
+# dragonball binary name
+DBCMD := dragonball


### PR DESCRIPTION
Depends-on: github.com/kata-containers/tests#4986. To avoid returning an error when running the ci, we just skip the build
process if the arch is s390x

Fixes: #4816
Signed-off-by: Zhongtao Hu <zhongtaohu.tim@linux.alibaba.com>