### PR TITLE
runtime-rs: support guest-hook-path setup when starting sandbox

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -73,7 +73,7 @@ impl RuntimeHandler for VirtContainer {
             sid,
             agent.clone(),
             hypervisor.clone(),
-            config,
+            Arc::clone(&config),
         )?);
         let pid = std::process::id();
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -158,6 +158,15 @@ impl Sandbox for VirtSandbox {
             .await
             .context("setup device after start vm")?;
 
+        // get guest hook path
+        let guest_hook_path = self
+            .hypervisor
+            .hypervisor_config()
+            .await
+            .security_info
+            .guest_hook_path
+            .clone();
+
         // create sandbox in vm
         let req = agent::CreateSandboxRequest {
             hostname: "".to_string(),
@@ -169,12 +178,7 @@ impl Sandbox for VirtSandbox {
                 .context("get storages for sandbox")?,
             sandbox_pidns: false,
             sandbox_id: id.to_string(),
-            guest_hook_path: self
-                .hypervisor
-                .hypervisor_config()
-                .await
-                .security_info
-                .guest_hook_path,
+            guest_hook_path,
             kernel_modules: vec![],
         };
 


### PR DESCRIPTION
The runtime now handled guest_hook_path in toml config file, when
sandbox starts and stops.

Fixes: #4818
Signed-off-by: Ji-Xinyou <jerryji0414@outlook.com>