### PR TITLE
runtime: add unlock before return in sendReq

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -2015,11 +2015,13 @@ func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (inter
 	k.Lock()
 
 	if k.reqHandlers == nil {
+		k.Unlock()
 		return nil, errors.New("Client has already disconnected")
 	}
 
 	handler := k.reqHandlers[msgName]
 	if msgName == "" || handler == nil {
+		k.Unlock()
 		return nil, errors.New("Invalid request type")
 	}
 


### PR DESCRIPTION
Unlock is required before return, so there need to add unlock

Fixes: #4827

Signed-off-by: chmod100 <letfu@outlook.com>