### PR TITLE
agent-ctl: Add an empty [workspace]

### DIFF
--- a/src/tools/agent-ctl/Cargo.toml
+++ b/src/tools/agent-ctl/Cargo.toml
@@ -39,3 +39,5 @@ humantime = "2.1.0"
 # For Options (state passing)
 serde = { version = "1.0.131", features = ["derive"] }
 serde_json = "1.0.73"
+
+[workspace]


### PR DESCRIPTION
"An empty [workspace] can be used with a package to conveniently create a
workspace with the package and all of its path dependencies", according
to the https://doc.rust-lang.org/cargo/reference/workspaces.html

This is also matches with the suggestion provided by the Cargo itself,
due to the errors faced with the Cloud Hypervisor CI:
```
10:46:23 this may be fixable by adding `go/src/github.com/kata-containers/kata-containers/src/tools/agent-ctl` to the `workspace.members` array of the manifest located at: /tmp/jenkins/workspace/kata-containers-2-clh-PR/Cargo.toml
10:46:23 Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
```

Fixes: #4843

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>