### PR TITLE
versions: Update TD-shim due to build breakage

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -271,8 +271,8 @@ externals:
   td-shim:
     description: "Confidential Containers Shim Firmware"
     url: "https://github.com/confidential-containers/td-shim"
-    version: "5f62a0e367b1845a54e534d103ed4a697a599ac3"
-    toolchain: "nightly-2022-04-07"
+    version: "cf9592ef70bd6ba4c7ab1330d278a743f5ba3133"
+    toolchain: "nightly-2022-05-15"
 
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"


### PR DESCRIPTION
"We need a newer nightly 1.62 rust to deal with the change
rust-lang/libc@576f778 on crate libc which breaks the compilation."

This comes from the a pull-request raised on TD-shim repo,
https://github.com/confidential-containers/td-shim/pull/354, which fixes
the issues with the commit being used with Kata Containers.

Let's bump to a newer commit of TD-shim and to a newer version of the
nightly toolchain as part of our versions file.

Fixes: #4840

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>