### PR TITLE
versions: Update libseccomp version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -226,7 +226,7 @@ externals:
   libseccomp:
     description: "High level interface to Linux seccomp filter"
     url: "https://github.com/seccomp/libseccomp"
-    version: "2.5.1"
+    version: "2.5.4"
 
   runc:
     description: "OCI CLI reference runtime implementation"


### PR DESCRIPTION
This PR updates the libseccomp version at the versions.yaml that is
being used in the kata CI.

Fixes #4858

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>