### PR TITLE
Fix some GitHub actions workflow issues

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -47,7 +47,7 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^.{0,75}(\n.*)*$|^Merge pull request (?:kata-containers)?#[\d]+ from.*'
+        pattern: '^.{0,75}(\n.*)*$'
         error: 'Subject too long (max 75)'
         post_error: ${{ env.error_msg }}
 
@@ -95,6 +95,6 @@ jobs:
       uses: tim-actions/commit-message-checker-with-regex@v0.3.1
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
-        pattern: '^[\s\t]*[^:\s\t]+[\s\t]*:|^Merge pull request (?:kata-containers)?#[\d]+ from.*'
+        pattern: '^[\s\t]*[^:\s\t]+[\s\t]*:'
         error: 'Failed to find subsystem in subject'
         post_error: ${{ env.error_msg }}

--- a/.github/workflows/move-issues-to-in-progress.yaml
+++ b/.github/workflows/move-issues-to-in-progress.yaml
@@ -59,7 +59,7 @@ jobs:
             exit 1
           }
 
-          project_name="runtime-rs"
+          project_name="Issue backlog"
           project_type="org"
           project_column="In progress"
 


### PR DESCRIPTION
These two commits changed some workflow jobs in runtime-rs branch, now this branch has been merged into main, so these custom configurations should be reset.

This PR includes two reverts of these two commits:

https://github.com/kata-containers/kata-containers/commit/97d8c6c0fa2f537340c8587dee6467a26f2bb583
https://github.com/kata-containers/kata-containers/commit/575df4dc4d76ad142206ef18dbcc7a47858f2dfc
