### PR TITLE
runtime-rs: support loading kernel modules in guest vm

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -625,6 +625,7 @@ dependencies = [
  "futures",
  "ipnetwork",
  "kata-sys-util",
+ "kata-types",
  "lazy_static",
  "libc",
  "log",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -21,6 +21,7 @@ thiserror = "1.0.26"
 regex = "1.5.5"
 serial_test = "0.5.1"
 kata-sys-util = { path = "../libs/kata-sys-util" }
+kata-types = { path = "../libs/kata-types" }
 sysinfo = "0.23.0"
 
 # Async helpers

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -12,6 +12,8 @@ use std::str::FromStr;
 use std::time;
 use tracing::instrument;
 
+use kata_types::config::default::DEFAULT_AGENT_VSOCK_PORT;
+
 const DEBUG_CONSOLE_FLAG: &str = "agent.debug_console";
 const DEV_MODE_FLAG: &str = "agent.devmode";
 const TRACE_MODE_OPTION: &str = "agent.trace";
@@ -28,7 +30,6 @@ const DEFAULT_LOG_LEVEL: slog::Level = slog::Level::Info;
 const DEFAULT_HOTPLUG_TIMEOUT: time::Duration = time::Duration::from_secs(3);
 const DEFAULT_CONTAINER_PIPE_SIZE: i32 = 0;
 const VSOCK_ADDR: &str = "vsock://-1";
-const VSOCK_PORT: u16 = 1024;
 
 // Environment variables used for development and testing
 const SERVER_ADDR_ENV_VAR: &str = "KATA_AGENT_SERVER_ADDR";
@@ -147,7 +148,7 @@ impl Default for AgentConfig {
             debug_console_vport: 0,
             log_vport: 0,
             container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
-            server_addr: format!("{}:{}", VSOCK_ADDR, VSOCK_PORT),
+            server_addr: format!("{}:{}", VSOCK_ADDR, DEFAULT_AGENT_VSOCK_PORT),
             unified_cgroup_hierarchy: false,
             tracing: false,
             endpoints: Default::default(),

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -9,8 +9,10 @@ use crate::config::{ConfigOps, TomlConfig};
 
 pub use vendor::AgentVendor;
 
+use super::default::{DEFAULT_AGENT_LOG_PORT, DEFAULT_AGENT_VSOCK_PORT};
+
 /// Kata agent configuration information.
-#[derive(Debug, Default, Deserialize, Serialize)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Agent {
     /// If enabled, the agent will log additional debug messages to the system log.
     #[serde(default, rename = "enable_debug")]
@@ -34,11 +36,11 @@ pub struct Agent {
     pub debug_console_enabled: bool,
 
     /// Agent server port
-    #[serde(default)]
+    #[serde(default = "default_server_port")]
     pub server_port: u32,
 
     /// Agent log port
-    #[serde(default)]
+    #[serde(default = "default_log_port")]
     pub log_port: u32,
 
     /// Agent connection dialing timeout value in millisecond
@@ -75,23 +77,31 @@ pub struct Agent {
     pub container_pipe_size: u32,
 }
 
+fn default_server_port() -> u32 {
+    DEFAULT_AGENT_VSOCK_PORT
+}
+
+fn default_log_port() -> u32 {
+    DEFAULT_AGENT_LOG_PORT
+}
+
 fn default_dial_timeout() -> u32 {
-    // 10ms
+    // ms
     10
 }
 
 fn default_reconnect_timeout() -> u32 {
-    // 3s
+    // ms
     3_000
 }
 
 fn default_request_timeout() -> u32 {
-    // 30s
+    // ms
     30_000
 }
 
 fn default_health_check_timeout() -> u32 {
-    // 90s
+    // ms
     90_000
 }
 

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -16,6 +16,8 @@ lazy_static! {
     ];
 }
 pub const DEFAULT_AGENT_NAME: &str = "kata-agent";
+pub const DEFAULT_AGENT_VSOCK_PORT: u32 = 1024;
+pub const DEFAULT_AGENT_LOG_PORT: u32 = 1025;
 
 pub const DEFAULT_INTERNETWORKING_MODEL: &str = "tcfilter";
 

--- a/src/runtime-rs/crates/agent/src/kata/agent.rs
+++ b/src/runtime-rs/crates/agent/src/kata/agent.rs
@@ -8,6 +8,8 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use ttrpc::context as ttrpc_ctx;
 
+use kata_types::config::Agent as AgentConfig;
+
 use crate::{kata::KataAgent, Agent, AgentManager, HealthService};
 
 /// millisecond to nanosecond
@@ -36,6 +38,10 @@ impl AgentManager for KataAgent {
 
     async fn stop(&self) {
         self.stop_log_forwarder().await;
+    }
+
+    async fn agent_config(&self) -> AgentConfig {
+        self.agent_config().await
     }
 }
 

--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -126,4 +126,9 @@ impl KataAgent {
         let mut inner = self.inner.lock().await;
         inner.log_forwarder.stop();
     }
+
+    pub(crate) async fn agent_config(&self) -> AgentConfig {
+        let inner = self.inner.lock().await;
+        inner.config.clone()
+    }
 }

--- a/src/runtime-rs/crates/agent/src/lib.rs
+++ b/src/runtime-rs/crates/agent/src/lib.rs
@@ -29,10 +29,16 @@ pub use types::{
 use anyhow::Result;
 use async_trait::async_trait;
 
+use kata_types::config::Agent as AgentConfig;
+
+pub const AGENT_KATA: &str = "kata";
+
 #[async_trait]
 pub trait AgentManager: Send + Sync {
     async fn start(&self, address: &str) -> Result<()>;
     async fn stop(&self);
+
+    async fn agent_config(&self) -> AgentConfig;
 }
 
 #[async_trait]

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use agent::{self, kata::KataAgent, Agent};
+use agent::{self, kata::KataAgent, types::KernelModule, Agent};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use common::{
@@ -159,6 +159,8 @@ impl Sandbox for VirtSandbox {
             .context("setup device after start vm")?;
 
         // create sandbox in vm
+        let agent_config = self.agent.agent_config().await;
+        let kernel_modules = KernelModule::set_kernel_modules(agent_config.kernel_modules)?;
         let req = agent::CreateSandboxRequest {
             hostname: "".to_string(),
             dns: vec![],
@@ -175,7 +177,7 @@ impl Sandbox for VirtSandbox {
                 .await
                 .security_info
                 .guest_hook_path,
-            kernel_modules: vec![],
+            kernel_modules,
         };
 
         self.agent

--- a/src/tools/agent-ctl/src/utils.rs
+++ b/src/tools/agent-ctl/src/utils.rs
@@ -98,13 +98,11 @@ pub fn signame_to_signum(name: &str) -> Result<u8> {
         return Ok(n);
     }
 
-    let mut search_term: String;
-
-    if name.starts_with("SIG") {
-        search_term = name.to_string();
+    let mut search_term = if name.starts_with("SIG") {
+        name.to_string()
     } else {
-        search_term = format!("SIG{}", name);
-    }
+        format!("SIG{}", name)
+    };
 
     search_term = search_term.to_uppercase();
 


### PR DESCRIPTION
Users can specify the kernel module to be loaded through the agent
configuration in kata configuration file or in pod anotation file.

And information of those modules will be sent to kata agent when
sandbox is created.

Fixes: #4894 

Signed-off-by: Yushuo <y-shuo@linux.alibaba.com>