### PR TITLE
runk: Enable seccomp support by default

### DIFF
--- a/src/tools/runk/Cargo.lock
+++ b/src/tools/runk/Cargo.lock
@@ -581,6 +581,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "libseccomp"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49bda1fbf25c42ac8942ff7df1eb6172a3bc36299e84be0dba8c888a7db68c80"
+dependencies = [
+ "libc",
+ "libseccomp-sys",
+ "pkg-config",
+]
+
+[[package]]
+name = "libseccomp-sys"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a7cbbd4ad467251987c6e5b47d53b11a5a05add08f2447a9e2d70aef1e0d138"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +845,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1070,6 +1093,7 @@ dependencies = [
  "inotify",
  "lazy_static",
  "libc",
+ "libseccomp",
  "nix 0.23.1",
  "oci",
  "path-absolutize",

--- a/src/tools/runk/Cargo.toml
+++ b/src/tools/runk/Cargo.toml
@@ -25,6 +25,9 @@ serde_json = "1.0.74"
 users = "0.11.0"
 tabwriter = "1.2.1"
 
+[features]
+seccomp = ["rustjail/seccomp"]
+
 [dev-dependencies]
 tempfile = "3.3.0"
 

--- a/src/tools/runk/Makefile
+++ b/src/tools/runk/Makefile
@@ -3,20 +3,36 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# LIBC=musl|gnu (default: gnu)
+LIBC ?= gnu
+
 include ../../../utils.mk
 
 TARGET = runk
 TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)
 AGENT_SOURCE_PATH = ../../agent
 
+EXTRA_RUSTFEATURES :=
+
+# Define if runk enables seccomp support (default: yes)
+SECCOMP := yes
+
 # BINDIR is a directory for installing executable programs
 BINDIR := /usr/local/bin
+
+ifeq ($(SECCOMP),yes)
+    override EXTRA_RUSTFEATURES += seccomp
+endif
+
+ifneq ($(EXTRA_RUSTFEATURES),)
+    override EXTRA_RUSTFEATURES := --features "$(EXTRA_RUSTFEATURES)"
+endif
 
 .DEFAULT_GOAL := default
 default: build
 
 build:
-	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE) $(EXTRA_RUSTFEATURES)
 
 install:
 	install -D $(TARGET_PATH) $(BINDIR)/$(TARGET)
@@ -30,7 +46,7 @@ vendor:
 test: test-runk test-agent
 
 test-runk:
-	cargo test --all --target $(TRIPLE) -- --nocapture
+	cargo test --all --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
 
 test-agent:
 	make test -C $(AGENT_SOURCE_PATH) STANDARD_OCI_RUNTIME=yes

--- a/src/tools/runk/README.md
+++ b/src/tools/runk/README.md
@@ -60,17 +60,43 @@ are welcome.
 Regarding features compared to `runc`, see the `Status of runk` section in the [issue](https://github.com/kata-containers/kata-containers/issues/2784).
 
 ## Building
-You can build `runk` as follows.
+
+In order to enable seccomp support, you need to install the `libseccomp` library on
+your platform.
+
+> e.g. `libseccomp-dev` for Ubuntu, or `libseccomp-devel` for CentOS
+
+You can build `runk`:
 
 ```bash
 $ cd runk
 $ make
 ```
 
-To install `runk` into default directory for install executable program (`/usr/local/bin`):
+If you want to build a statically linked binary of `runk`, set the environment
+variables for the [`libseccomp` crate](https://github.com/libseccomp-rs/libseccomp-rs) and
+set the `LIBC` to `musl`:
 
 ```bash
-$ sudo make install
+$ export LIBSECCOMP_LINK_TYPE=static
+$ export LIBSECCOMP_LIB_PATH="the path of the directory containing libseccomp.a"
+$ export LIBC=musl
+$ make
+```
+
+> **Note**:
+>
+> - If the compilation fails when `runk` tries to link the `libseccomp` library statically
+>   against `musl`, you will need to build the `libseccomp` manually with `-U_FORTIFY_SOURCE`.
+>   For the details, see [our script](https://github.com/kata-containers/kata-containers/blob/main/ci/install_libseccomp.sh)
+>   to install the `libseccomp` for the agent.
+> - On `ppc64le` and `s390x`, `glibc` should be used even if `LIBC=musl` is specified.
+> - If you do not want to enable seccomp support, run `make SECCOMP=no`.
+
+To install `runk` into default directory for executable program (`/usr/local/bin`):
+
+```bash
+$ sudo -E make install
 ```
 
 ## Using `runk` directly


### PR DESCRIPTION
Enable seccomp support in `runk` by default.
The user can disable seccomp by `make SECCOMP=no`

Fixes: #4896

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>