### PR TITLE
runtime: tracing: End root span at end of trace

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -97,9 +97,10 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 		}
 
 		// create root span
+		// rootSpan will be ended when the entire trace is ended
 		rootSpan, newCtx := katatrace.Trace(s.ctx, shimLog, "rootSpan", shimTracingTags)
 		s.rootCtx = newCtx
-		defer rootSpan.End()
+		s.rootSpan = rootSpan
 
 		// create span
 		span, newCtx := katatrace.Trace(s.rootCtx, shimLog, "create", shimTracingTags)


### PR DESCRIPTION
The root span should exist the duration of the trace. Defer ending span
until the end of the trace instead of end of function. Add the span to
the service struct to do so.

Fixes #4902

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>


The output of the rest of the trace is not affected since the rest of the spans are ultimately derived from a context saved in the service struct, but this is technically a bug and should be backported.