### PR TITLE
agent: Add each condition for seccomp as a separate rule

### DIFF
--- a/src/agent/rustjail/src/seccomp.rs
+++ b/src/agent/rustjail/src/seccomp.rs
@@ -99,7 +99,13 @@ pub fn init_seccomp(scmp: &LinuxSeccomp) -> Result<()> {
                 filter.add_rule(action, syscall_num, None)?;
             } else {
                 let conditions = get_rule_conditions(&syscall.args)?;
-                filter.add_rule(action, syscall_num, Some(&conditions))?;
+                // If two or more arguments have the same condition,
+                // adding each condition as a separate rule.
+                // Otherwise, the adding will return EINVAL on failure.
+                // Ref. https://man7.org/linux/man-pages/man3/seccomp_rule_add.3.html
+                for cond in conditions {
+                    filter.add_rule(action, syscall_num, Some(&[cond]))?;
+                }
             }
         }
     }


### PR DESCRIPTION
If two or more arguments have the same condition, adding each
condition as a separate rule because the libseccomp can only
compare each argument once in a single rule.
Otherwise, the adding will return EINVAL on failure.
Ref. https://man7.org/linux/man-pages/man3/seccomp_rule_add.3.html

Fixes: #4912

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>