### PR TITLE
agent/wip: Replace String with OsString or Path

### DIFF
--- a/src/agent/rustjail/src/cgroups/mock.rs
+++ b/src/agent/rustjail/src/cgroups/mock.rs
@@ -12,13 +12,14 @@ use cgroups::freezer::FreezerState;
 use libc::{self, pid_t};
 use oci::LinuxResources;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::string::String;
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Manager {
     pub paths: HashMap<String, String>,
     pub mounts: HashMap<String, String>,
-    pub cpath: String,
+    pub cpath: PathBuf,
 }
 
 impl CgroupManager for Manager {
@@ -56,11 +57,11 @@ impl CgroupManager for Manager {
 }
 
 impl Manager {
-    pub fn new(cpath: &str) -> Result<Self> {
+    pub fn new(cpath: &PathBuf) -> Result<Self> {
         Ok(Self {
             paths: HashMap::new(),
             mounts: HashMap::new(),
-            cpath: cpath.to_string(),
+            cpath: cpath.to_path_buf(),
         })
     }
 

--- a/src/agent/rustjail/src/console.rs
+++ b/src/agent/rustjail/src/console.rs
@@ -11,7 +11,7 @@ use nix::unistd::{self, dup2};
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::path::Path;
 
-pub fn setup_console_socket(csocket_path: &str) -> Result<Option<RawFd>> {
+pub fn setup_console_socket(csocket_path: &Path) -> Result<Option<RawFd>> {
     if csocket_path.is_empty() {
         return Ok(None);
     }
@@ -25,7 +25,7 @@ pub fn setup_console_socket(csocket_path: &str) -> Result<Option<RawFd>> {
 
     match socket::connect(
         socket_fd,
-        &socket::SockAddr::Unix(socket::UnixAddr::new(Path::new(csocket_path))?),
+        &socket::SockAddr::Unix(socket::UnixAddr::new(csocket_path)?),
     ) {
         Ok(()) => Ok(Some(socket_fd)),
         Err(errno) => Err(anyhow!("failed to open console fd: {}", errno)),
@@ -72,7 +72,7 @@ mod tests {
 
         let _listener = UnixListener::bind(&socket_path).unwrap();
 
-        let ret = setup_console_socket(socket_path.to_str().unwrap());
+        let ret = setup_console_socket(socket_path.as_os_str());
 
         assert!(ret.is_ok());
     }

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -7,6 +7,7 @@
 
 #[cfg(target_arch = "aarch64")]
 use std::fs;
+use std::path::PathBuf;
 
 pub const SYSFS_DIR: &str = "/sys";
 #[cfg(any(
@@ -15,22 +16,22 @@ pub const SYSFS_DIR: &str = "/sys";
     target_arch = "x86_64",
     target_arch = "x86"
 ))]
-pub fn create_pci_root_bus_path() -> String {
-    String::from("/devices/pci0000:00")
+pub fn create_pci_root_bus_path() -> PathBuf {
+    PathBuf::from("/devices/pci0000:00")
 }
 
 #[cfg(target_arch = "aarch64")]
-pub fn create_pci_root_bus_path() -> String {
-    let ret = String::from("/devices/platform/4010000000.pcie/pci0000:00");
+pub fn create_pci_root_bus_path() -> PathBuf {
+    let ret = PathBuf::from("/devices/platform/4010000000.pcie/pci0000:00");
 
-    let acpi_root_bus_path = String::from("/devices/pci0000:00");
-    let mut acpi_sysfs_dir = String::from(SYSFS_DIR);
-    let mut sysfs_dir = String::from(SYSFS_DIR);
-    let mut start_root_bus_path = String::from("/devices/platform/");
-    let end_root_bus_path = String::from("/pci0000:00");
+    let acpi_root_bus_path = PathBuf::from("/devices/pci0000:00");
+    let mut acpi_sysfs_dir = PathBuf::from(SYSFS_DIR);
+    let mut sysfs_dir = PathBuf::from(SYSFS_DIR);
+    let mut start_root_bus_path = PathBuf::from("/devices/platform/");
+    let end_root_bus_path = PathBuf::from("/pci0000:00");
 
     // check if there is pci bus path for acpi
-    acpi_sysfs_dir.push_str(&acpi_root_bus_path);
+    acpi_sysfs_dir = acpi_sysfs_dir.join(&acpi_root_bus_path);
     if let Ok(_) = fs::metadata(&acpi_sysfs_dir) {
         return acpi_root_bus_path;
     }
@@ -46,17 +47,17 @@ pub fn create_pci_root_bus_path() -> String {
             Err(_) => return ret,
         };
         let dir_name = match pathname.file_name() {
-            Some(p) => p.to_str(),
+            Some(p) => p.to_os_str(),
             None => return ret,
         };
         let dir_name = match dir_name {
             Some(p) => p,
             None => return ret,
         };
-        let dir_name = String::from(dir_name);
+        let dir_name = OsString::from(dir_name);
         if dir_name.ends_with(".pcie") {
-            start_root_bus_path.push_str(&dir_name);
-            start_root_bus_path.push_str(&end_root_bus_path);
+            start_root_bus_path.join(&dir_name);
+            start_root_bus_path.join(&end_root_bus_path);
             return start_root_bus_path;
         }
     }
@@ -65,8 +66,8 @@ pub fn create_pci_root_bus_path() -> String {
 }
 
 #[cfg(target_arch = "s390x")]
-pub fn create_ccw_root_bus_path() -> String {
-    String::from("/devices/css0")
+pub fn create_ccw_root_bus_path() -> PathBuf {
+    PathBuf::from("/devices/css0")
 }
 // From https://www.kernel.org/doc/Documentation/acpi/namespace.txt
 // The Linux kernel's core ACPI subsystem creates struct acpi_device

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -9,7 +9,7 @@ use std::fs::{File, OpenOptions};
 use std::io::{BufRead, BufReader, Write};
 use std::iter;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::str::FromStr;
 use std::sync::Arc;
 
@@ -724,7 +724,7 @@ pub async fn add_storages(
     storages: Vec<Storage>,
     sandbox: Arc<Mutex<Sandbox>>,
     cid: Option<String>,
-) -> Result<Vec<String>> {
+) -> Result<Vec<PathBuf>> {
     let mut mount_list = Vec::new();
 
     for storage in storages {
@@ -735,7 +735,7 @@ pub async fn add_storages(
 
         {
             let mut sb = sandbox.lock().await;
-            let new_storage = sb.set_sandbox_storage(&storage.mount_point);
+            let new_storage = sb.set_sandbox_storage(&PathBuf::from(&storage.mount_point));
             if !new_storage {
                 continue;
             }
@@ -782,7 +782,7 @@ pub async fn add_storages(
         let mount_point = res?;
 
         if !mount_point.is_empty() {
-            mount_list.push(mount_point);
+            mount_list.push(PathBuf::from(mount_point));
         }
     }
 
@@ -968,14 +968,14 @@ pub fn cgroups_mount(logger: &Logger, unified_cgroup_hierarchy: bool) -> Result<
 
     // Enable memory hierarchical account.
     // For more information see https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
-    online_device("/sys/fs/cgroup/memory/memory.use_hierarchy")?;
+    online_device(&Path::new("/sys/fs/cgroup/memory/memory.use_hierarchy"))?;
     Ok(())
 }
 
 #[instrument]
-pub fn remove_mounts(mounts: &[String]) -> Result<()> {
+pub fn remove_mounts(mounts: &[&Path]) -> Result<()> {
     for m in mounts.iter() {
-        nix::mount::umount(m.as_str()).context(format!("failed to umount {:?}", m))?;
+        nix::mount::umount(m.as_os_str()).context(format!("failed to umount {:?}", m))?;
     }
     Ok(())
 }
@@ -1187,7 +1187,7 @@ mod tests {
 
         #[derive(Debug)]
         struct TestData<'a> {
-            mounts: Vec<String>,
+            mounts: Vec<&'a Path>,
 
             // If set, assume an error will be generated,
             // else assume no error.
@@ -1244,19 +1244,19 @@ mod tests {
                 error_contains: "",
             },
             TestData {
-                mounts: vec!["".to_string()],
+                mounts: vec![&Path::new("")],
                 error_contains: "ENOENT: No such file or directory",
             },
             TestData {
-                mounts: vec![test_file_filename.to_string()],
+                mounts: vec![&test_file_path],
                 error_contains: "EINVAL: Invalid argument",
             },
             TestData {
-                mounts: vec![test_dir_filename.to_string()],
+                mounts: vec![&test_dir_path],
                 error_contains: "EINVAL: Invalid argument",
             },
             TestData {
-                mounts: vec![mnt_dest_filename.to_string()],
+                mounts: vec![&mnt_dest],
                 error_contains: "",
             },
         ];

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -186,6 +186,8 @@ impl fmt::Debug for NamespaceType {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::{Namespace, NamespaceType};
     use crate::mount::remove_mounts;
     use nix::sched::CloneFlags;
@@ -206,7 +208,7 @@ mod tests {
             .await;
 
         assert!(ns_ipc.is_ok());
-        assert!(remove_mounts(&[ns_ipc.unwrap().path]).is_ok());
+        assert!(remove_mounts(&[&PathBuf::from(ns_ipc.unwrap().path)]).is_ok());
 
         let logger = slog::Logger::root(slog::Discard, o!());
         let tmpdir = Builder::new().prefix("uts").tempdir().unwrap();
@@ -218,7 +220,7 @@ mod tests {
             .await;
 
         assert!(ns_uts.is_ok());
-        assert!(remove_mounts(&[ns_uts.unwrap().path]).is_ok());
+        assert!(remove_mounts(&[&PathBuf::from(ns_uts.unwrap().path)]).is_ok());
 
         // Check it cannot persist pid namespaces.
         let logger = slog::Logger::root(slog::Discard, o!());

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1720,14 +1720,14 @@ fn update_container_namespaces(
 }
 
 fn remove_container_resources(sandbox: &mut Sandbox, cid: &str) -> Result<()> {
-    let mut cmounts: Vec<String> = vec![];
+    let mut cmounts: Vec<PathBuf> = vec![];
 
     // Find the sandbox storage used by this container
     let mounts = sandbox.container_mounts.get(cid);
     if let Some(mounts) = mounts {
         for m in mounts.iter() {
-            if sandbox.storages.get(m).is_some() {
-                cmounts.push(m.to_string());
+            if sandbox.storages.get(&PathBuf::from(m)).is_some() {
+                cmounts.push(PathBuf::from(m));
             }
         }
     }


### PR DESCRIPTION
To cover the edge case where paths may not be UTF-8 encoded, paths
should be type OsString or Path rather than String.

This replaces most instances of String with Path or OsString.

Fixes #1378

Signed-off-by: Derek Lee <derlee@redhat.com>