### PR TITLE
workflow: trigger release for 3.x releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,8 +1,8 @@
-name: Publish Kata 2.x release artifacts
+name: Publish Kata release artifacts
 on:
   push:
     tags:
-     - '2.*'
+      - '[0-9]+.[0-9]+.[0-9]+*'
 
 jobs:
   build-asset:

--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -1,8 +1,9 @@
-name: Release Kata 2.x in snapcraft store
+name: Release Kata in snapcraft store
 on:
   push:
     tags:
-      - '2.*'
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
 jobs:
   release-snap:
     runs-on: ubuntu-20.04


### PR DESCRIPTION
So that we can push 3.x artifacts to the release page.

Fixes: #4919