### PR TITLE
runtime-rs: add unit tests for network resource

### DIFF
--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -2153,6 +2153,7 @@ dependencies = [
  "serde",
  "slog",
  "slog-scope",
+ "test-utils",
  "tokio",
  "uuid",
 ]
@@ -2586,6 +2587,13 @@ dependencies = [
  "redox_syscall",
  "remove_dir_all",
  "winapi",
+]
+
+[[package]]
+name = "test-utils"
+version = "0.1.0"
+dependencies = [
+ "nix 0.24.2",
 ]
 
 [[package]]

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -4,6 +4,9 @@ version = "0.1.0"
 authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2018"
 
+[dev-dependencies]
+test-utils = { path = "../../../libs/test-utils" }
+
 [dependencies]
 anyhow = "^1.0"
 async-trait = "0.1.48"

--- a/src/runtime-rs/crates/resource/src/network/endpoint/endpoints_test.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/endpoints_test.rs
@@ -20,6 +20,7 @@ mod tests {
             NetworkModelType, TC_FILTER_NET_MODEL_STR,
         },
         network_pair::{NetworkInterface, NetworkPair, TapInterface},
+        utils::link::net_test_utils::delete_link,
     };
 
     // this unit test tests the integrity of MacVlanEndpoint::new()
@@ -124,14 +125,10 @@ mod tests {
                         }
                         assert_eq!(manual.net_pair.network_qos, result.net_pair.network_qos);
                     }
-                    let link_index = fetch_index(&handle, manual_vlan_iface_name.as_str())
+                    assert!(delete_link(&handle, manual_vlan_iface_name.as_str())
                         .await
-                        .expect("failed to fetch index");
-                    assert!(handle.link().del(link_index).execute().await.is_ok());
-                    let link_index = fetch_index(&handle, tap_iface_name.as_str())
-                        .await
-                        .expect("failed to fetch index");
-                    assert!(handle.link().del(link_index).execute().await.is_ok());
+                        .is_ok());
+                    assert!(delete_link(&handle, tap_iface_name.as_str()).await.is_ok());
                     assert!(handle.link().del(dummy_index).execute().await.is_ok());
                 }
             }
@@ -253,14 +250,10 @@ mod tests {
                         assert_eq!(manual.net_pair.network_qos, result.net_pair.network_qos);
                     }
                     // delete the manually created links
-                    let link_index = fetch_index(&handle, manual_macvlan_iface_name.as_str())
+                    assert!(delete_link(&handle, manual_macvlan_iface_name.as_str())
                         .await
-                        .expect("failed to fetch index");
-                    assert!(handle.link().del(link_index).execute().await.is_ok());
-                    let link_index = fetch_index(&handle, tap_iface_name.as_str())
-                        .await
-                        .expect("failed to fetch index");
-                    assert!(handle.link().del(link_index).execute().await.is_ok());
+                        .is_ok());
+                    assert!(delete_link(&handle, tap_iface_name.as_str()).await.is_ok());
                     assert!(handle.link().del(dummy_index).execute().await.is_ok());
                 }
             }
@@ -355,14 +348,10 @@ mod tests {
                     }
                     assert_eq!(manual.net_pair.network_qos, result.net_pair.network_qos);
                 }
-                let link_index = fetch_index(&handle, manual_virt_iface_name.as_str())
+                assert!(delete_link(&handle, manual_virt_iface_name.as_str())
                     .await
-                    .expect("failed to fetch index");
-                assert!(handle.link().del(link_index).execute().await.is_ok());
-                let link_index = fetch_index(&handle, tap_iface_name.as_str())
-                    .await
-                    .expect("failed to fetch index");
-                assert!(handle.link().del(link_index).execute().await.is_ok());
+                    .is_ok());
+                assert!(delete_link(&handle, tap_iface_name.as_str()).await.is_ok());
             }
         }
     }

--- a/src/runtime-rs/crates/resource/src/network/utils/address.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/address.rs
@@ -85,3 +85,30 @@ pub(crate) fn parse_ip(ip: &[u8], family: u8) -> Result<IpAddr> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ip() {
+        let test_ipv4 = [10, 25, 64, 128];
+        let ipv4 = parse_ip(test_ipv4.as_slice(), AF_INET as u8).unwrap();
+        let expected_ipv4 = IpAddr::V4(Ipv4Addr::new(10, 25, 64, 128));
+        assert_eq!(ipv4, expected_ipv4);
+
+        let test_ipv6 = [0, 2, 4, 0, 0, 2, 4, 0, 0, 2, 4, 0, 0, 2, 4, 0];
+        let ipv6 = parse_ip(test_ipv6.as_slice(), AF_INET6 as u8).unwrap();
+        // two u8 => one u16, (0u8, 2u8 => 0x0002), (4u8, 0u8 => 0x0400)
+        let expected_ipv6 = IpAddr::V6(Ipv6Addr::new(
+            0x0002, 0x0400, 0x0002, 0x0400, 0x0002, 0x0400, 0x0002, 0x0400,
+        ));
+        assert_eq!(ipv6, expected_ipv6);
+
+        let fail_ipv4 = [10, 22, 33, 44, 55];
+        assert!(parse_ip(fail_ipv4.as_slice(), AF_INET as u8).is_err());
+
+        let fail_ipv6 = [1, 2, 3, 4, 5, 6, 7, 8, 2, 3];
+        assert!(parse_ip(fail_ipv6.as_slice(), AF_INET6 as u8).is_err());
+    }
+}

--- a/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
@@ -16,6 +16,9 @@ use std::os::unix::io::RawFd;
 
 use netlink_packet_route::link::nlas::State;
 
+#[cfg(test)]
+pub use create::net_test_utils;
+
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum Namespace {
     NetNsPid(u32),

--- a/src/runtime-rs/crates/resource/src/network/utils/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/mod.rs
@@ -33,3 +33,34 @@ pub(crate) fn get_mac_addr(b: &[u8]) -> Result<String> {
         ))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_mac_addr() {
+        // length is not 6
+        let fail_slice = vec![1, 2, 3];
+        assert!(get_mac_addr(&fail_slice).is_err());
+
+        let expected_slice = vec![10, 11, 128, 3, 4, 5];
+        let expected_mac = String::from("0a:0b:80:03:04:05");
+        let res = get_mac_addr(&expected_slice);
+        assert!(res.is_ok());
+        assert_eq!(expected_mac, res.unwrap());
+    }
+
+    #[test]
+    fn test_parse_mac() {
+        // length is not 6
+        let fail = "1:2:3";
+        assert!(parse_mac(fail).is_none());
+
+        let v = [10, 11, 128, 3, 4, 5];
+        let expected_addr = hypervisor::Address(v);
+        let addr = parse_mac("0a:0b:80:03:04:05");
+        assert!(addr.is_some());
+        assert_eq!(expected_addr.0, addr.unwrap().0);
+    }
+}

--- a/src/runtime-rs/crates/resource/src/network/utils/netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/netns.rs
@@ -49,3 +49,22 @@ impl Drop for NetnsGuard {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use test_utils::skip_if_not_root;
+
+    #[test]
+    fn test_new_netns_guard() {
+        // test run under root
+        skip_if_not_root!();
+
+        let new_netns_path = "/proc/1/task/1/ns/net"; // systemd, always exists
+        let netns_guard = NetnsGuard::new(new_netns_path).unwrap();
+        drop(netns_guard);
+
+        let empty_path = "";
+        assert!(NetnsGuard::new(empty_path).unwrap().old_netns.is_none());
+    }
+}


### PR DESCRIPTION
Add UTs for network resource.

Currently we are lacking UTs for runtime-rs, we should add UTs gradually.

Fixes: #4923
Signed-off-by: Ji-Xinyou <jerryji0414@outlook.com>