### PR TITLE
ci: Use versions.yaml for the libseccomp

### DIFF
--- a/ci/install_libseccomp.sh
+++ b/ci/install_libseccomp.sh
@@ -23,25 +23,27 @@ arch=${ARCH:-$(uname -m)}
 workdir="$(mktemp -d --tmpdir build-libseccomp.XXXXX)"
 
 # Variables for libseccomp
-# Currently, specify the libseccomp version directly without using `versions.yaml`
-# because the current Snap workflow is incomplete.
-# After solving the issue, replace this code by using the `versions.yaml`.
-# libseccomp_version=$(get_version "externals.libseccomp.version")
-# libseccomp_url=$(get_version "externals.libseccomp.url")
-libseccomp_version="2.5.4"
-libseccomp_url="https://github.com/seccomp/libseccomp"
+libseccomp_version="${LIBSECCOMP_VERSION:-""}"
+if [ -z "${libseccomp_version}" ]; then
+    libseccomp_version=$(get_version "externals.libseccomp.version")
+fi
+libseccomp_url="${LIBSECCOMP_URL:-""}"
+if [ -z "${libseccomp_url}" ]; then
+    libseccomp_url=$(get_version "externals.libseccomp.url")
+fi
 libseccomp_tarball="libseccomp-${libseccomp_version}.tar.gz"
 libseccomp_tarball_url="${libseccomp_url}/releases/download/v${libseccomp_version}/${libseccomp_tarball}"
 cflags="-O2"
 
 # Variables for gperf
-# Currently, specify the gperf version directly without using `versions.yaml`
-# because the current Snap workflow is incomplete.
-# After solving the issue, replace this code by using the `versions.yaml`.
-# gperf_version=$(get_version "externals.gperf.version")
-# gperf_url=$(get_version "externals.gperf.url")
-gperf_version="3.1"
-gperf_url="https://ftp.gnu.org/gnu/gperf"
+gperf_version="${GPERF_VERSION:-""}"
+if [ -z "${gperf_version}" ]; then
+    gperf_version=$(get_version "externals.gperf.version")
+fi
+gperf_url="${GPERF_URL:-""}"
+if [ -z "${gperf_url}" ]; then
+    gperf_url=$(get_version "externals.gperf.url")
+fi
 gperf_tarball="gperf-${gperf_version}.tar.gz"
 gperf_tarball_url="${gperf_url}/${gperf_tarball}"
 

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -568,6 +568,8 @@ EOF
 
 		if [ "${SECCOMP}" == "yes" ]; then
 			info "Set up libseccomp"
+			detect_libseccomp_info || \
+				die "Could not detect the required libseccomp version and url"
 			libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
 			gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)
 			${script_dir}/../../../ci/install_libseccomp.sh "${libseccomp_install_dir}" "${gperf_install_dir}"

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -264,6 +264,25 @@ detect_rust_version()
 	[ -n "$RUST_VERSION" ]
 }
 
+detect_libseccomp_info()
+{
+	info "Detecting libseccomp version"
+
+	info "Get libseccomp version and url from ${kata_versions_file}"
+	local libseccomp_ver_yq_path="externals.libseccomp.version"
+	local libseccomp_url_yq_path="externals.libseccomp.url"
+	export LIBSECCOMP_VERSION="$(get_package_version_from_kata_yaml "$libseccomp_ver_yq_path")"
+	export LIBSECCOMP_URL="$(get_package_version_from_kata_yaml "$libseccomp_url_yq_path")"
+
+	info "Get gperf version and url from ${kata_versions_file}"
+	local gperf_ver_yq_path="externals.gperf.version"
+	local gperf_url_yq_path="externals.gperf.url"
+	export GPERF_VERSION="$(get_package_version_from_kata_yaml "$gperf_ver_yq_path")"
+	export GPERF_URL="$(get_package_version_from_kata_yaml "$gperf_url_yq_path")"
+
+	[ -n "$LIBSECCOMP_VERSION" ] && [ -n $GPERF_VERSION ] && [ -n "$LIBSECCOMP_URL" ] && [ -n $GPERF_URL ]
+}
+
 before_starting_container() {
 	return 0
 }


### PR DESCRIPTION
It would be nice to use `versions.yaml` for the maintainability.
Previously, we have been specified the `libseccomp` and the `gperf` version
directly in this script without using the `versions.yaml` because the current
snap workflow is incomplete and fails.
This is because snap CI environment does not have kata-cotnainers repository
under ${GOPATH}. To avoid the failure, the `rootfs.sh` extracts the libseccomp
version and url in advance and pass them to the `install_libseccomp.sh` as
environment variables.
Fixes: #4941

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>