### PR TITLE
Revert "kata-deploy: Rely on the configured config path"

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -98,7 +98,10 @@ function configure_different_shims_base() {
 			fi
 		fi
 
-		ln -sf /opt/kata/bin/containerd-shim-kata-v2 "${shim_file}"
+		cat << EOF | tee "$shim_file"
+#!/usr/bin/env bash
+KATA_CONF_FILE=/opt/kata/share/defaults/kata-containers/configuration-${shim}.toml /opt/kata/bin/containerd-shim-kata-v2 "\$@"
+EOF
 		chmod +x "$shim_file"
 
 		if [ "${shim}" == "${default_shim}" ]; then


### PR DESCRIPTION
This reverts commit f7ccf92dc82e9264fafd0ccf565f6dd014786e3e.