### PR TITLE
workflow: skip some static checks for fast return CI

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -52,6 +52,22 @@ jobs:
       run: |
         echo "TRAVIS_BRANCH=${TRAVIS_BRANCH:-$(echo $GITHUB_REF | awk 'BEGIN { FS = \"/\" } ; { print $3 }')}"
         target_branch=${TRAVIS_BRANCH}
+    - name: CI Fast Return
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+      id: ci-fast-return
+      run: |
+        cd ${GOPATH}/src/github.com/${{ github.repository }}
+        fast_return_ret=1
+        {
+          ./ci/ci-fast-return.sh
+          fast_return_ret=$?
+        } || true
+        if [ "$fast_return_ret" -eq 0 ]; then
+          # return code 0 means a fast return CI.
+          echo "::set-output name=fast_return::true"
+        fi
+      env:
+        PR_NUMBER: ${{ github.event.pull_request.number }}
     - name: Setup
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
@@ -83,14 +99,14 @@ jobs:
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && make static-checks
     - name: Run Compiler Checks
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && steps.ci-fast-return.outputs.fast_return != 'true' }}
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && make check
     - name: Run Unit Tests
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && steps.ci-fast-return.outputs.fast_return != 'true' }}
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && make test
     - name: Run Unit Tests As Root User
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') && steps.ci-fast-return.outputs.fast_return != 'true' }}
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && sudo -E PATH="$PATH" make test

--- a/ci/ci-fast-return.sh
+++ b/ci/ci-fast-return.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Ant Group
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+cidir=$(dirname "$0")
+source "${cidir}/lib.sh"
+
+run_ci_fast_return


### PR DESCRIPTION
In some cases when only docs is updated, there is no need to
run static checks.

This PR will use `.ci/ci-fast-return.sh` to check if more test is needed, that will act as what Jenkins jobs have done, they have called this function:

https://github.com/kata-containers/tests/blob/a93f33bbc3d02e0db5c036d28b118bb2ac713bc0/.ci/jenkins_job_build.sh#L180-L189

And for a `fast reutrn`, these job steps will be omitted:

- Run Compiler Checks
- Run Unit Tests
- Run Unit Tests As Root User

But the `Static Checks` is unchanged, it is the most time-consume steps, this PR will not optimize this one.

Related:

- https://github.com/kata-containers/kata-containers/pull/4195
- https://github.com/kata-containers/kata-containers/pull/4845