### PR TITLE
Fix kata-deploy to work on CI context

### DIFF
--- a/tools/packaging/kata-deploy/local-build/.gitignore
+++ b/tools/packaging/kata-deploy/local-build/.gitignore
@@ -1,1 +1,2 @@
 build/
+dockerbuild/install_yq.sh

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -40,6 +40,7 @@ docker build -q -t build-kata-deploy \
 
 docker run \
 	-v /var/run/docker.sock:/var/run/docker.sock \
+	--env CI="${CI:-}" \
 	--env USER=${USER} -v "${kata_dir}:${kata_dir}" \
 	--rm \
 	-w ${script_dir} \


### PR DESCRIPTION
It is needed to pass the `CI` variable down to the kata-deploy build container so that scripts behave as expected. As for example, the `clone_tests_repo()` in `ci/lib.sh` relies on that variable in order to checkout (or not) the tests repository.

This fix can be tested with:

* have at least one file in tests repo in stage
* run `make CI=yes rootfs-image-tarball`

Fixes #4949 