### PR TITLE
virtcontainers: Fix ServiceOffload usage with devmapper

### DIFF
--- a/src/runtime/virtcontainers/fs_share_linux.go
+++ b/src/runtime/virtcontainers/fs_share_linux.go
@@ -375,7 +375,7 @@ func (f *FilesystemShare) ShareRootFilesystem(ctx context.Context, c *Container)
 
 	// In the confidential computing, there is no Image information on the host,
 	// so there is no Rootfs.Target.
-	if f.sandbox.config.ServiceOffload && c.rootFs.Target == "" {
+	if f.sandbox.config.ServiceOffload && c.rootFs.Target == "" && c.state.BlockDeviceID == ""{
 		return &SharedFile{
 			storage:   nil,
 			guestPath: rootfsGuestPath,


### PR DESCRIPTION
When using device mapper we shouldn't return early, as we still need the
block device mounted on the guest.

Fixes: #0000

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>