### PR TITLE
CCv0 | kata-deploy: allow to build the image without skopeo

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -112,11 +112,11 @@ install_cc_clh() {
 
 #Install cc capable guest image
 install_cc_image() {
-	info "Create CC image"
-	export SKOPEO=yes
+	export SKOPEO="${SKOPEO:-yes}"
 	export UMOCI=yes
 	export AA_KBC="offline_fs_kbc"
 
+	info "Create CC image configured with SKOPEO=${SKOPEO} UMOCI=${UMOCI} AA_KBC=${AA_KBC}"
 	"${rootfs_builder}" --imagetype=image --prefix="${cc_prefix}" --destdir="${destdir}"
 }
 


### PR DESCRIPTION
The local-build script should honor the value of SKOPEO exported in the
environment so that it will be able to build the image without skopeo
inside. This remove the hard-coded "SKOPEO=yes".

Fixes #4959
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>