### PR TITLE
versions: Update go version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -301,7 +301,7 @@ languages:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.17.3"
+      newest-version: "1.18"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
This PR updates the go version that is being used in the
versions.yaml file for the kata containers CI.

Fixes #4963

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>