### PR TITLE
CC | image-build: generate root hash as an separate partition for rootfs

### DIFF
--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -14,5 +14,6 @@ RUN ([ -n "$http_proxy" ] && \
         gdisk \
         parted \
         qemu-img \
+	veritysetup \
         xfsprogs && \
     dnf clean all

--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -11,6 +11,7 @@ set -o errexit
 set -o pipefail
 
 DOCKER_RUNTIME=${DOCKER_RUNTIME:-runc}
+KATA_BUILD_CC=${KATA_BUILD_CC:-no}
 
 readonly script_name="${0##*/}"
 readonly script_dir=$(dirname "$(readlink -f "$0")")
@@ -170,6 +171,7 @@ build_with_container() {
 		   --env BLOCK_SIZE="${block_size}" \
 		   --env ROOT_FREE_SPACE="${root_free_space}" \
 		   --env NSDAX_BIN="${nsdax_bin}" \
+		   --env KATA_BUILD_CC="${KATA_BUILD_CC}" \
 		   --env DEBUG="${DEBUG}" \
 		   -v /dev:/dev \
 		   -v "${script_dir}":"/osbuilder" \
@@ -371,9 +373,21 @@ create_disk() {
 	# Kata runtime expect an image with just one partition
 	# The partition is the rootfs content
 	info "Creating partitions"
+
+	if [ "${KATA_BUILD_CC}" == "yes" ]; then
+		info "Creating partitions with hash device"
+		# The hash data will take less than one percent disk space to store
+		hash_start=$(echo $img_size | awk '{print $1 * 0.99}' |cut -d $(locale decimal_point) -f 1)
+		partition_param="mkpart primary ${fs_type} ${part_start}M ${hash_start}M "
+		partition_param+="mkpart primary ${fs_type} ${hash_start}M ${rootfs_end}M "
+		partition_param+="set 1 boot on"
+	else
+		partition_param="mkpart primary ${fs_type} ${part_start}M ${rootfs_end}M"
+	fi
+
 	parted -s -a optimal "${image}" -- \
 		   mklabel msdos \
-		   mkpart primary "${fs_type}" "${part_start}"M "${rootfs_end}"M
+		   "${partition_param}"
 
 	OK "Partitions created"
 }
@@ -427,6 +441,12 @@ create_rootfs_image() {
 
 	if [ "${fs_type}" = "${ext4_format}" ]; then
 		fsck.ext4 -D -y "${device}p1"
+	fi
+
+	if [ "${KATA_BUILD_CC}" == "yes" ] && [ -b "${device}p2" ]; then
+		info "veritysetup format rootfs device: ${device}p1, hash device: ${device}p2"
+		local image_dir=$(dirname "${image}")
+		veritysetup format "${device}p1" "${device}p2" > "${image_dir}"/root_hash.txt 2>&1
 	fi
 
 	losetup -d "${device}"


### PR DESCRIPTION
One task for issue: https://github.com/confidential-containers/documentation/issues/40

Generate rootfs hash data during creating the kata rootfs,
current kata image only have one partition, we add another
partition as hash device to save hash data of rootfs data blocks.

Fixes: #4966

Signed-off-by: Wang, Arron <arron.wang@intel.com>