### PR TITLE
runk: Add cli message for init command

### DIFF
--- a/src/tools/runk/src/main.rs
+++ b/src/tools/runk/src/main.rs
@@ -28,6 +28,7 @@ enum SubCommand {
     Common(CommonCmd),
     #[clap(flatten)]
     Custom(CustomCmd),
+    /// Launch an init process (do not call it outside of runk)
     Init {},
 }
 


### PR DESCRIPTION
Add cli message for init command to tell the user
not to run this command directly.

Fixes: #4367

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>