### PR TITLE
CC | config: Drop `force_tdx_guest` unneeded parameter

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -115,7 +115,7 @@ FIRMWAREPATH :=
 FIRMWAREVOLUMEPATH :=
 TDVFFIRMWAREPATH := $(PREFIXDEPS)/share/tdvf/OVMF_CODE.fd
 TDVFFIRMWAREVOLUMEPATH := $(PREFIXDEPS)/share/tdvf/OVMF_VARS.fd
-TDXKERNELPARAMS := force_tdx_guest tdx_disable_filter
+TDXKERNELPARAMS := tdx_disable_filter
 
 # Name of default configuration file the runtime will use.
 CONFIG_FILE = configuration.toml


### PR DESCRIPTION
The `force_tdx_guest` kernel parameter was only needed in the early
development stages of the TDX kernel driver.  We can safely drop it with
the kernel version we've been currently using.

Fixes: #4985

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>