### PR TITLE
Initrd fixes for ubuntu systemd

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -520,6 +520,11 @@ EOF
 			chrony_conf_file="${ROOTFS_DIR}/etc/chrony/chrony.conf"
 			chrony_systemd_service="${ROOTFS_DIR}/lib/systemd/system/chrony.service"
 			;;
+		"ubuntu")
+			# Fix for #4932 - Boot hang at: "A start job is running for /dev/ttyS0"
+			mkdir -p "${ROOTFS_DIR}/etc/systemd/system/getty.target.wants"
+			ln -sf "/lib/systemd/system/getty@.service" "${ROOTFS_DIR}/etc/systemd/system/getty.target.wants/getty@ttyS0.service"
+			;;
 		*)
 			chrony_conf_file="${ROOTFS_DIR}/etc/chrony.conf"
 			chrony_systemd_service="${ROOTFS_DIR}/usr/lib/systemd/system/chronyd.service"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -597,7 +597,13 @@ EOF
 	[ -x "${AGENT_DEST}" ] || die "${AGENT_DEST} is not installed in ${ROOTFS_DIR}"
 	OK "Agent installed"
 
-	[ "${AGENT_INIT}" == "yes" ] && setup_agent_init "${AGENT_DEST}" "${init}"
+	if [ "${AGENT_INIT}" == "yes" ]; then
+		setup_agent_init "${AGENT_DEST}" "${init}"
+	else
+		# Setup systemd service for kata-agent
+		mkdir -p "${ROOTFS_DIR}/etc/systemd/system/basic.target.wants"
+		ln -sf "/usr/lib/systemd/system/kata-containers.target" "${ROOTFS_DIR}/etc/systemd/system/basic.target.wants/kata-containers.target"
+	fi
 
 	info "Check init is installed"
 	[ -x "${init}" ] || [ -L "${init}" ] || die "/sbin/init is not installed in ${ROOTFS_DIR}"


### PR DESCRIPTION
osbuilder: fix ubuntu initrd /dev/ttyS0 hang
osbuilder: add systemd symlinks for kata-agent

Fixes: [#4932](https://github.com/kata-containers/kata-containers/issues/4932)

Signed-Off-By: Ryan Savino <ryan.savino@amd.com>