### PR TITLE
runtime-rs: delete socket from shim command-line options

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/health_check.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/health_check.rs
@@ -91,7 +91,7 @@ impl HealthCheck {
                                         ::std::process::exit(1);
                                     }
                                 } else {
-                                    info!(sl!(), "wait to exit exit {}", id);
+                                    info!(sl!(), "wait to exit {}", id);
                                     break;
                                 }
                             }

--- a/src/runtime-rs/crates/shim/src/args.rs
+++ b/src/runtime-rs/crates/shim/src/args.rs
@@ -15,7 +15,7 @@ use crate::Error;
 /// from a shimv2 container manager such as containerd.
 ///
 /// For detailed information, please refer to the
-/// [shim spec](https://github.com/containerd/containerd/blob/main/runtime/v2/README.md).
+/// [shim spec](https://github.com/containerd/containerd/blob/v1.6.8/runtime/v2/README.md).
 #[derive(Debug, Default, Clone)]
 pub struct Args {
     /// the id of the container
@@ -26,8 +26,6 @@ pub struct Args {
     pub address: String,
     /// the binary path to publish events back to containerd
     pub publish_binary: String,
-    ///  Abstract socket path to serve.
-    pub socket: String,
     /// the path to the bundle to delete
     pub bundle: String,
     /// Whether or not to enable debug
@@ -123,7 +121,6 @@ mod tests {
         let default_namespace = "ns1".to_string();
         let default_address = bind_address.to_string();
         let default_publish_binary = "containerd".to_string();
-        let default_socket = "socket".to_string();
         let default_bundle = path.to_string();
         let default_debug = false;
 
@@ -132,7 +129,6 @@ mod tests {
             namespace: default_namespace.clone(),
             address: default_address.clone(),
             publish_binary: default_publish_binary.clone(),
-            socket: default_socket,
             bundle: default_bundle.clone(),
             debug: default_debug,
         };

--- a/src/runtime-rs/crates/shim/src/bin/main.rs
+++ b/src/runtime-rs/crates/shim/src/bin/main.rs
@@ -43,7 +43,6 @@ fn parse_args(args: &[OsString]) -> Result<Action> {
         flags.add_flag("id", &mut shim_args.id);
         flags.add_flag("namespace", &mut shim_args.namespace);
         flags.add_flag("publish-binary", &mut shim_args.publish_binary);
-        flags.add_flag("socket", &mut shim_args.socket);
         flags.add_flag("help", &mut help);
         flags.add_flag("version", &mut version);
     })
@@ -87,8 +86,6 @@ fn show_help(cmd: &OsStr) {
         namespace that owns the shim
   -publish-binary string
         path to publish binary (used for publishing events) (default "containerd")
-  -socket string
-        socket path to serve
   --version
         show the runtime version detail and exit
 "#,

--- a/src/runtime-rs/crates/shim/src/shim.rs
+++ b/src/runtime-rs/crates/shim/src/shim.rs
@@ -68,7 +68,7 @@ impl ShimExecutor {
         let data = [&self.args.address, &self.args.namespace, id].join("/");
         let mut hasher = sha2::Sha256::new();
         hasher.update(data);
-        // https://github.com/containerd/containerd/blob/main/runtime/v2/shim/util_unix.go#L68 to
+        // https://github.com/containerd/containerd/blob/v1.6.8/runtime/v2/shim/util_unix.go#L68 to
         // generate a shim socket path.
         Ok(PathBuf::from(format!(
             "unix://{}/s/{:X}",
@@ -97,7 +97,6 @@ mod tests {
             namespace: "test_namespace".into(),
             address: "containerd_socket".into(),
             publish_binary: "containerd".into(),
-            socket: "socket".into(),
             bundle: bundle_path.to_str().unwrap().into(),
             debug: false,
         };

--- a/src/runtime-rs/crates/shim/src/shim_start.rs
+++ b/src/runtime-rs/crates/shim/src/shim_start.rs
@@ -157,7 +157,6 @@ mod tests {
             namespace: "ns".into(),
             address: "address".into(),
             publish_binary: "containerd".into(),
-            socket: "socket".into(),
             bundle: bundle_path.to_str().unwrap().into(),
             debug: false,
         };
@@ -189,7 +188,6 @@ mod tests {
             namespace: "ns1".into(),
             address: "containerd_socket".into(),
             publish_binary: "containerd".into(),
-            socket: "socket".into(),
             bundle: bundle_path.to_str().unwrap().into(),
             debug: false,
         };
@@ -209,7 +207,6 @@ mod tests {
             namespace: "ns1".into(),
             address: "containerd_socket".into(),
             publish_binary: "containerd".into(),
-            socket: "socket".into(),
             bundle: bundle_path2.to_str().unwrap().into(),
             debug: false,
         };


### PR DESCRIPTION
The socket is not used to specify the socket address, but
an ENV variable is used for runtime-rs.

Fixes: #4995

Signed-off-by: Bin Liu <bin@hyper.sh>