### PR TITLE
versions: Bump k8s to 1.25.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -221,7 +221,7 @@ externals:
     uscan-url: >-
       https://github.com/kubernetes/kubernetes/tags
       .*/v?([\d\.]+)\.tar\.gz
-    version: "1.23.1-00"
+    version: "1.25.0-00"
 
   libseccomp:
     description: "High level interface to Linux seccomp filter"


### PR DESCRIPTION
Kubernetes 1.25.0 was released on August 23rd and as we're falling
behind on the versions being tested, let's bump it to its latest
release.

Fixes: #0000

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>