### PR TITLE
SEV: Update ReducedPhysBits

### DIFF
--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -290,7 +290,7 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
 				Debug:           false,
 				File:            firmware,
 				CBitPos:         cpuid.AMDMemEncrypt.CBitPosition,
-				ReducedPhysBits: cpuid.AMDMemEncrypt.PhysAddrReduction,
+				ReducedPhysBits: 1,
 			}), "", nil
 	case snpProtection:
 		return append(devices,

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -286,7 +286,7 @@ func TestQemuAmd64AppendProtectionDevice(t *testing.T) {
 			Debug:           false,
 			File:            firmware,
 			CBitPos:         cpuid.AMDMemEncrypt.CBitPosition,
-			ReducedPhysBits: cpuid.AMDMemEncrypt.PhysAddrReduction,
+			ReducedPhysBits: 1,
 		},
 	}
 


### PR DESCRIPTION
Updating this field, as `cpuid` provides host level data, which is not
what a guest would expect for Reduced Phsycial Bits. In almost all
cases, we should be using `1` for the value here.

Fixes: #5006

Signed-off-by: Larry Dewey <larry.dewey@amd.com>