### PR TITLE
kernel: add basename kernel symlinks when suffix is used

### DIFF
--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -470,6 +470,13 @@ install_kata() {
 	ln -sf "${vmlinux}" "${install_path}/vmlinux${suffix}.container"
 	ls -la "${install_path}/vmlinux${suffix}.container"
 	ls -la "${install_path}/vmlinuz${suffix}.container"
+
+	if [ -n "$suffix}" ]; then
+		ln -sf "vmlinux${suffix}.container" "${install_path}/vmlinux.container"
+		ln -sf "vmlinuz${suffix}.container" "${install_path}/vmlinuz.container"
+		ls -la "${install_path}/vmlinux.container"
+		ls -la "${install_path}/vmlinuz.container"
+	fi
 	popd >>/dev/null
 }
 


### PR DESCRIPTION
'kata-runtime kata-env' throws an error when the kernel is built for a specific TEE like SEV.
Basename kernel symlinks added to prevent error.

Fixes: #5008

Signed-Off-By: Ryan Savino <ryan.savino@amd.com>