### PR TITLE
agent: add some logs for mount operation

### DIFF
--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -169,11 +169,12 @@ pub fn baremount(
 
     info!(
         logger,
-        "mount source={:?}, dest={:?}, fs_type={:?}, options={:?}",
+        "baremount source={:?}, dest={:?}, fs_type={:?}, options={:?}, flags={:?}",
         source,
         destination,
         fs_type,
-        options
+        options,
+        flags
     );
 
     nix::mount::mount(
@@ -779,6 +780,14 @@ pub async fn add_storages(
         };
 
         // Todo need to rollback the mounted storage if err met.
+
+        if res.is_err() {
+            error!(
+                logger,
+                "add_storages failed, storage: {:?}, error: {:?} ", storage, res
+            );
+        }
+
         let mount_point = res?;
 
         if !mount_point.is_empty() {


### PR DESCRIPTION
Somewhere is lack of log info, add more details about
the storage and log when error will help understand
what happened.

Fixes: #4962

Signed-off-by: Bin Liu <bin@hyper.sh>