### PR TITLE
runtime-rs: return the error of kill_process

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -377,6 +377,7 @@ impl AgentService {
             "signal process";
             "container-id" => cid.clone(),
             "exec-id" => eid.clone(),
+            "signal" => req.signal,
         );
 
         let mut sig: libc::c_int = req.signal as libc::c_int;

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -176,9 +176,13 @@ impl RuntimeHandlerManager {
     }
 
     pub async fn handler_message(&self, req: Request) -> Result<Response> {
-        if let Request::CreateContainer(req) = req {
+        if let Request::CreateContainer(container_config) = req {
             // get oci spec
-            let bundler_path = format!("{}/{}", req.bundle, oci::OCI_SPEC_CONFIG_FILE_NAME);
+            let bundler_path = format!(
+                "{}/{}",
+                container_config.bundle,
+                oci::OCI_SPEC_CONFIG_FILE_NAME
+            );
             let spec = oci::Spec::load(&bundler_path).context("load spec")?;
 
             self.try_init_runtime_instance(&spec)
@@ -191,7 +195,7 @@ impl RuntimeHandlerManager {
 
             let shim_pid = instance
                 .container_manager
-                .create_container(req, spec)
+                .create_container(container_config, spec)
                 .await
                 .context("create container")?;
             Ok(Response::CreateContainer(shim_pid))

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -297,6 +297,11 @@ impl Container {
             .context("stop process")
     }
 
+    pub async fn is_stopped(&self) -> bool {
+        let inner = self.inner.write().await;
+        inner.is_stopped().await
+    }
+
     pub async fn pause(&self) -> Result<()> {
         let inner = self.inner.read().await;
         if inner.init_process.get_status().await == ProcessStatus::Paused {

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -91,8 +91,8 @@ impl Container {
 
         // update rootfs
         match spec.root.as_mut() {
-            Some(spec) => {
-                spec.path = rootfs
+            Some(root) => {
+                root.path = rootfs
                     .get_guest_rootfs_path()
                     .await
                     .context("get guest rootfs path")?

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -65,7 +65,7 @@ async fn send_event(
             &namespace,
         ])
         .spawn()
-        .context("sawn cmd")?;
+        .context("spawn containerd cmd")?;
 
     let stdin = child.stdin.as_mut().context("failed to open stdin")?;
     stdin

--- a/src/runtime-rs/crates/service/src/task_service.rs
+++ b/src/runtime-rs/crates/service/src/task_service.rs
@@ -40,7 +40,7 @@ where
     let r = req
         .try_into()
         .map_err(|err| ttrpc::Error::Others(format!("failed to translate from shim {:?}", err)))?;
-    let logger = sl!().new(o!("steam id" =>  ctx.mh.stream_id));
+    let logger = sl!().new(o!("stream id" =>  ctx.mh.stream_id));
     debug!(logger, "====> task service {:?}", &r);
     let resp = s
         .handler_message(r)


### PR DESCRIPTION
`.ok()` will convert Result to Option, if there is an error,
the error will not be returned to the callers.

Fixes: #5018

Signed-off-by: Bin Liu <bin@hyper.sh>