### PR TITLE
CC | docs: Add https_proxy to confidential agent config

### DIFF
--- a/docs/how-to/data/confidential-agent-config.toml.in
+++ b/docs/how-to/data/confidential-agent-config.toml.in
@@ -4,6 +4,7 @@
 #
 
 aa_kbc_params = "$AA_KBC_PARAMS"
+https_proxy = "$HTTPS_PROXY"
 [endpoints]
 allowed = [
 "AddARPNeighborsRequest",


### PR DESCRIPTION
The agent configuration file, which is part of the docs, is used by the
confidential containers CIs and, right now, cannot be run behind a
firewall, which is exactly how the TDX CIs are reunning, as https_proxy
is not set there.

Fixes: #5020

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>