### PR TITLE
CC | rootfs builder: add agent config file to rootfs for offline_sev_kbc

### DIFF
--- a/tools/osbuilder/rootfs-builder/agent-config.toml.in
+++ b/tools/osbuilder/rootfs-builder/agent-config.toml.in
@@ -1,0 +1,44 @@
+# Copyright (c) 2022 IBM Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+aa_kbc_params = "$AA_KBC_PARAMS"
+
+[endpoints]
+allowed = [
+"AddARPNeighborsRequest",
+"AddSwapRequest",
+"CloseStdinRequest",
+"CopyFileRequest",
+"CreateContainerRequest",
+"CreateSandboxRequest",
+"DestroySandboxRequest",
+# "ExecProcessRequest",
+"GetMetricsRequest",
+"GetOOMEventRequest",
+"GuestDetailsRequest",
+"ListInterfacesRequest",
+"ListRoutesRequest",
+"MemHotplugByProbeRequest",
+"OnlineCPUMemRequest",
+"PauseContainerRequest",
+"PullImageRequest",
+"ReadStreamRequest",
+"RemoveContainerRequest",
+# "ReseedRandomDevRequest",
+"ResumeContainerRequest",
+"SetGuestDateTimeRequest",
+"SignalProcessRequest",
+"StartContainerRequest",
+"StartTracingRequest",
+"StatsContainerRequest",
+"StopTracingRequest",
+"TtyWinResizeRequest",
+"UpdateContainerRequest",
+"UpdateInterfaceRequest",
+"UpdateRoutesRequest",
+"WaitProcessRequest",
+"WriteStreamRequest"
+]
+

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -654,7 +654,10 @@ EOF
           UMOCI="yes"
           warning "UMOCI wasn't set, but is required for attestation, so overridden"
         fi
-
+		if [ "${AA_KBC}" == "offline_sev_kbc" ]; then
+			info "Adding agent config for ${AA_KBC}"
+			AA_KBC_PARAMS="offline_sev_kbc::null" envsubst < "${script_dir}/agent-config.toml.in" | tee "${ROOTFS_DIR}/etc/agent-config.toml"
+		fi
 		attestation_agent_url="$(get_package_version_from_kata_yaml externals.attestation-agent.url)"
 		attestation_agent_branch="$(get_package_version_from_kata_yaml externals.attestation-agent.branch)"
 		info "Install attestation-agent with KBC ${AA_KBC}"

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -39,6 +39,7 @@ RUN apt-get update && \
     musl-tools \
     pkg-config \
     protobuf-compiler \
+    gettext-base \
     umoci
 
 # aarch64 requires this name -- link for all


### PR DESCRIPTION
Adds default config file.
Adds case in rootfs.sh to copy config.

Fixes kata-containers#5023

Signed-Off-By: Alex Carter <alex.carter@ibm.com>