### PR TITLE
CC| packaging: Add AmdSev OVMF target for use in payload images

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -88,7 +88,8 @@ cc: cc-cloud-hypervisor-tarball \
 	cc-tdx-kernel-tarball \
 	cc-tdx-qemu-tarball \
 	cc-tdx-td-shim-tarball \
-	cc-tdx-tdvf-tarball
+	cc-tdx-tdvf-tarball \
+	cc-sev-ovmf-tarball
 
 cc-cloud-hypervisor-tarball:
 	${MAKE} $@-build
@@ -121,4 +122,7 @@ cc-tdx-td-shim-tarball:
 	${MAKE} $@-build
 
 cc-tdx-tdvf-tarball:
+	${MAKE} $@-build
+
+cc-sev-ovmf-tarball:
 	${MAKE} $@-build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -92,6 +92,7 @@ options:
 	cc-rootfs-image
 	cc-shimv2
 	cc-virtiofsd
+	cc-sev-ovmf
 EOF
 
 	exit "${return_code}"
@@ -205,6 +206,10 @@ install_cc_tee_ovmf() {
 
 install_cc_tdx_tdvf() {
 	install_cc_tee_ovmf "tdx" "edk2-staging-tdx.tar.gz"
+}
+
+install_cc_sev_ovmf(){
+ 	install_cc_tee_ovmf "sev" "edk2-sev.tar.gz"
 }
 
 #Install guest image
@@ -334,6 +339,8 @@ handle_build() {
 	cc-tdx-td-shim) install_cc_tdx_td_shim ;;
 
 	cc-tdx-tdvf) install_cc_tdx_tdvf ;;
+
+	cc-sev-ovmf) install_cc_sev_ovmf ;;
 
 	cloud-hypervisor) install_clh ;;
 


### PR DESCRIPTION
Currently leaving the cc-sev-ovmf-tarball target out of the cc payload.
I was not sure where discussion had landed on the number of payload bundles.
e.g. could be included in a cc bundle along with tdx support or create an SEV bundle.

Fixes: kata-containers#5025

Signed-off-by: Alex Carter <Alex.Carter@ibm.com>