### PR TITLE
CC | packaging: Build SEV capable kernel + efi_secret module

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -82,6 +82,7 @@ cc: cc-cloud-hypervisor-tarball \
 	cc-shim-v2-tarball \
 	cc-virtiofsd-tarball \
 	cc-tdx-kernel-tarball \
+	cc-sev-kernel-tarball \
 	cc-tdx-qemu-tarball \
 	cc-tdx-tdvf-tarball
 
@@ -107,6 +108,9 @@ cc-tdx-cloud-hypervisor-tarball:
 	${MAKE} $@-build
 
 cc-tdx-kernel-tarball:
+	${MAKE} $@-build
+
+cc-sev-kernel-tarball:
 	${MAKE} $@-build
 
 cc-tdx-qemu-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -87,6 +87,7 @@ options:
 	cc-cloud-hypervisor
 	cc-kernel
 	cc-tdx-kernel
+	cc-sev-kernel
 	cc-qemu
 	cc-tdx-qemu
 	cc-rootfs-image
@@ -161,17 +162,23 @@ install_tdx_cc_clh() {
 #Install CC kernel assert, with TEE support
 install_cc_tee_kernel() {
 	tee="${1}"
+	kernel_version="${2}"
 
-	[ "${tee}" != "tdx" ] && die "Non supported TEE"
+	[[ "${tee}" != "tdx" && "${tee}" != "sev" ]] && die "Non supported TEE"
 
-	export kernel_version="$(yq r $versions_yaml assets.kernel.${tee}.tag)"
-	export kernel_url="$(yq r $versions_yaml assets.kernel.${tee}.url)"
+	kernel_url="$(yq r $versions_yaml assets.kernel.${tee}.url)"
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -x "${tee}" -v "${kernel_version}" -u "${kernel_url}"
 }
 
 #Install CC kernel assert for Intel TDX
 install_cc_tdx_kernel() {
-	install_cc_tee_kernel "tdx"
+	kernel_version="$(yq r $versions_yaml assets.kernel.tdx.tag)"
+	install_cc_tee_kernel "tdx" "${kernel_version}"
+}
+
+install_cc_sev_kernel() {
+	kernel_version="$(yq r $versions_yaml assets.kernel.sev.version)"
+	install_cc_tee_kernel "sev" "${kernel_version}"
 }
 
 install_cc_tee_qemu() {
@@ -328,6 +335,8 @@ handle_build() {
 	cc-tdx-cloud-hypervisor) install_tdx_cc_clh ;;
 
 	cc-tdx-kernel) install_cc_tdx_kernel ;;
+
+	cc-sev-kernel) install_cc_sev_kernel ;;
 
 	cc-tdx-qemu) install_cc_tdx_qemu ;;
 

--- a/tools/packaging/static-build/kernel/Dockerfile
+++ b/tools/packaging/static-build/kernel/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && \
 	    git \
 	    iptables \
 	    libelf-dev \
+	    libssl-dev \
 	    patch && \
     if [ "$(uname -m)" = "s390x" ]; then apt-get install -y --no-install-recommends libssl-dev; fi && \
     apt-get clean && rm -rf /var/lib/lists/


### PR DESCRIPTION
Adds a new make target for an sev kernel which can be built and put into payload bundles for the operator.

Currently not including this sev kernel target in the cc payload bundle.

Unfortunately having to breakflow from using the generic cc_tee_kernel functions in either the kata-deploy-binaries or build-kernel.
Largely based on using an upstreamed kernel release, meaning the url is the defaul cdn, and e.g. we use version rather than tag.
The upside of this is that we can use the sha sum checking functionality from the generic get_kernel function.

Fixes: #5037

Signed-off-by: Alex Carter <Alex.Carter@ibm.com>