### PR TITLE
kernel: Re-work get_tee_kernel()

### DIFF
--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -128,13 +128,12 @@ get_tee_kernel() {
 
 	[ -z "${kernel_url}" ] && kernel_url=$(get_from_kata_deps "assets.kernel.${tee}.url")
 
-	kernel_tarball="linux-${version}.tar.gz"
-	tarball_name=$(get_from_kata_deps "assets.kernel.${tee}.tarball")
-	[ -z "$tarball_name" ] || kernel_tarball="$tarball_name"
+	local kernel_tarball="${version}.tar.gz"
 
-	if [ ! -f "${kernel_tarball}" ]; then
-	   curl --fail -OL "${kernel_url}/${kernel_tarball}"
-	fi
+	# Depending on where we're getting the terball from it may have a
+	# different name, such as linux-${version}.tar.gz or simply
+	# ${version}.tar.gz.  Let's try both before failing.
+	curl --fail -OL "${kernel_url}/linux-${kernel_tarball}" || curl --fail -OL "${kernel_url}/${kernel_tarball}"
 	
 	mkdir -p ${kernel_path}
 	tar --strip-components=1 -xf ${kernel_tarball} -C ${kernel_path}

--- a/versions.yaml
+++ b/versions.yaml
@@ -158,7 +158,6 @@ assets:
       description: "Linux kernel that supports TDX"
       url: "https://github.com/intel/linux-kernel-dcp/archive/refs/tags"
       tag: "SPR-BKC-PC-v9.6"
-      tarball: "SPR-BKC-PC-v9.6.tar.gz"
     sev:
       description: "Linux kernel that supports SEV"
       url: "https://cdn.kernel.org/pub/linux/kernel/v5.x/"


### PR DESCRIPTION
00aadfe20abdcc81b39e7b284efde58f087ae547 introduced a regression on
`make cc-tdx-kernel-tarball` as we stopped passing all the needed
information to the `build-kernel.sh` script, leading to requiring `yq`
installed in the container used to build the kernel.

This commit partially reverts the faulty one, rewritting it in a way the
old behaviour is brought back, without changing the behaviour that was
added by the faulty commit.

Fixes: #5043

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>