### PR TITLE
gperf: point URL to mirror site

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -209,7 +209,7 @@ externals:
 
   gperf:
     description: "GNU gperf is a perfect hash function generator"
-    url: "https://ftp.gnu.org/gnu/gperf"
+    url: "https://ftpmirror.gnu.org/gnu/gperf"
     version: "3.1"
 
   kubernetes:


### PR DESCRIPTION
gperf download fails intermittently.
Changing to mirror site will hopefully increase download reliability.

Fixes: #5057

Signed-Off-By: Ryan Savino <ryan.savino@amd.com>