### PR TITLE
versions: Upgrade rust supported version to 1.59.0 for 2.5 branch

### DIFF
--- a/src/tools/agent-ctl/src/utils.rs
+++ b/src/tools/agent-ctl/src/utils.rs
@@ -98,13 +98,11 @@ pub fn signame_to_signum(name: &str) -> Result<u8> {
         return Ok(n);
     }
 
-    let mut search_term: String;
-
-    if name.starts_with("SIG") {
-        search_term = name.to_string();
+    let mut search_term: String = if name.starts_with("SIG") {
+        name.to_string()
     } else {
-        search_term = format!("SIG{}", name);
-    }
+        format!("SIG{}", name)
+    };
 
     search_term = search_term.to_uppercase();
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -280,12 +280,12 @@ languages:
   rust:
     description: "Rust language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.58.1"
+    version: "1.59.0"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.58.1"
+      newest-version: "1.59.0"
 
 specs:
   description: "Details of important specifications"


### PR DESCRIPTION
CI for 2.5 branch is failing with the issue:
"package `time v0.3.14` cannot be built because it requires rustc 1.59.0
or newer, while the currently active rustc version is 1.58.1"

Fixes: #1000

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>