### PR TITLE
docs: Specify language in markdown for syntax highlight

### DIFF
--- a/docs/Unit-Test-Advice.md
+++ b/docs/Unit-Test-Advice.md
@@ -341,7 +341,7 @@ The main repository has the most comprehensive set of skip abilities. See:
 
 One method is to use the `nix` crate along with some custom macros:
 
-```
+```rust
 #[cfg(test)]
 mod tests {
     #[allow(unused_macros)]


### PR DESCRIPTION
Specify language for code block in docs/Unit-Test-Advice.md
for syntax highlight.

Fixes: #5064

Signed-off-by: Bin Liu <bin@hyper.sh>