### PR TITLE
static-build: add yq to kernel builder docker environment

### DIFF
--- a/tools/packaging/static-build/kernel/Dockerfile
+++ b/tools/packaging/static-build/kernel/Dockerfile
@@ -4,6 +4,9 @@
 
 FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
+ENV INSTALL_IN_GOPATH=false
+
+COPY install_yq.sh /usr/bin/install_yq.sh
 
 # kernel deps
 RUN apt-get update && \
@@ -19,4 +22,5 @@ RUN apt-get update && \
 	    libelf-dev \
 	    patch && \
     if [ "$(uname -m)" = "s390x" ]; then apt-get install -y --no-install-recommends libssl-dev; fi && \
-    apt-get clean && rm -rf /var/lib/lists/
+    apt-get clean && rm -rf /var/lib/lists/ && \
+    install_yq.sh

--- a/tools/packaging/static-build/kernel/install_yq.sh
+++ b/tools/packaging/static-build/kernel/install_yq.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2019 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+# If we fail for any reason a message will be displayed
+die() {
+	msg="$*"
+	echo "ERROR: $msg" >&2
+	exit 1
+}
+
+# Install the yq yaml query package from the mikefarah github repo
+# Install via binary download, as we may not have golang installed at this point
+function install_yq() {
+	local yq_pkg="github.com/mikefarah/yq"
+	local yq_version=3.4.1
+	INSTALL_IN_GOPATH=${INSTALL_IN_GOPATH:-true}
+
+	if [ "${INSTALL_IN_GOPATH}"  == "true" ];then
+		GOPATH=${GOPATH:-${HOME}/go}
+		mkdir -p "${GOPATH}/bin"
+		local yq_path="${GOPATH}/bin/yq"
+	else
+		yq_path="/usr/local/bin/yq"
+	fi
+	[ -x  "${yq_path}" ] && [ "`${yq_path} --version`"X == "yq version ${yq_version}"X ] && return
+
+	read -r -a sysInfo <<< "$(uname -sm)"
+
+	case "${sysInfo[0]}" in
+	"Linux" | "Darwin")
+		goos="${sysInfo[0],}"
+		;;
+	"*")
+		die "OS ${sysInfo[0]} not supported"
+		;;
+	esac
+
+	case "${sysInfo[1]}" in
+	"aarch64")
+		goarch=arm64
+		;;
+	"ppc64le")
+		goarch=ppc64le
+		;;
+	"x86_64")
+		goarch=amd64
+		;;
+	"s390x")
+		goarch=s390x
+		;;
+	"*")
+		die "Arch ${sysInfo[1]} not supported"
+		;;
+	esac
+
+
+	# Check curl
+	if ! command -v "curl" >/dev/null; then
+		die "Please install curl"
+	fi
+
+	## NOTE: ${var,,} => gives lowercase value of var
+	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos,,}_${goarch}"
+	curl -o "${yq_path}" -LSsf "${yq_url}"
+	[ $? -ne 0 ] && die "Download ${yq_url} failed"
+	chmod +x "${yq_path}"
+
+	if ! command -v "${yq_path}" >/dev/null; then
+		die "Cannot not get ${yq_path} executable"
+	fi
+}
+
+install_yq


### PR DESCRIPTION
The build_kernel.sh script expects to be able to use yq to parse version info.
When ran via its docker setup, it previously lacked this dependency.
Adding the install_yq script, and using it in the dockerscript.

Fixes: #5071

Signed-off-by: Alex Carter <Alex.Carter@ibm.com>