### PR TITLE
runtime-rs: debug update neighbours

### DIFF
--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -106,6 +106,7 @@ impl ResourceManagerInner {
 
     async fn handle_neighbours(&self, network: &dyn Network) -> Result<()> {
         let neighbors = network.neighs().await.context("neighs")?;
+        let neighbors_copy = neighbors.clone();
         if !neighbors.is_empty() {
             info!(sl!(), "update neighbors {:?}", neighbors);
             self.agent
@@ -113,7 +114,7 @@ impl ResourceManagerInner {
                     neighbors: Some(agent::ARPNeighbors { neighbors }),
                 })
                 .await
-                .context("update neighbors")?;
+                .with_context(|| format!("failed to update neighbors {:?}", neighbors_copy))?;
         }
         Ok(())
     }


### PR DESCRIPTION
This commit is just for debuging. Sometimes updating neighbors will fail with a netlink error File exists.
we need to check if there is any duplicate neighbour ip before pass that
to the agent.

Fixes: #4895
Signed-off-by: Zhongtao Hu <zhongtaohu.tim@linux.alibaba.com>