### PR TITLE
docs: fix unix socket address in agent-ctl doc

### DIFF
--- a/src/tools/agent-ctl/README.md
+++ b/src/tools/agent-ctl/README.md
@@ -220,7 +220,7 @@ $ sudo install -o root -g root -m 0755 ~/.cargo/bin/kata-agent-ctl /usr/local/bi
 1. Start the agent, specifying a local socket for it to communicate on:
 
    ```sh
-   $ sudo KATA_AGENT_SERVER_ADDR=unix:///tmp/foo.socket target/x86_64-unknown-linux-musl/release/kata-agent
+   $ sudo KATA_AGENT_SERVER_ADDR=unix://@/tmp/foo.socket target/x86_64-unknown-linux-musl/release/kata-agent
    ```
 
    > **Note:** This example assumes an Intel x86-64 system.


### PR DESCRIPTION
Following the instructions in guidance doc will result in the ECONNREFUSED, thus we need to keep the unix socket address in the two commands consistent.

Fixes: #5085

Signed-off-by: Yuan-Zhuo <yuanzhuo0118@outlook.com>