### PR TITLE
runtime-rs: force shutdown shim process in it can't exit

### DIFF
--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
@@ -67,7 +67,10 @@ impl ShareVirtioFsStandalone {
     fn virtiofsd_args(&self, sock_path: &str) -> Result<Vec<String>> {
         let source_path = get_host_ro_shared_path(&self.config.id);
         if !source_path.exists() {
-            return Err(anyhow!("The virtiofs shared path didn't exist"));
+            return Err(anyhow!(
+                "The virtiofs shared path({:?}) didn't exist",
+                source_path
+            ));
         }
 
         let mut args: Vec<String> = vec![

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -155,7 +155,7 @@ impl ServiceManager {
         let handler = RuntimeHandlerManager::new(sid, sender)
             .await
             .context("new runtime handler")?;
-        handler.cleanup().await?;
+        handler.cleanup().await.context("runtime handler cleanup")?;
         let temp_dir = [KATA_PATH, sid].join("/");
         if std::fs::metadata(temp_dir.as_str()).is_ok() {
             // try to remove dir and skip the result


### PR DESCRIPTION
In some case the call of cleanup from shim to service manager will fail,
and the shim process will continue to running, that will make process leak.

This commit will force shutdown the shim process in case of any errors in
service crate.

Fixes: #5087

Signed-off-by: Bin Liu <bin@hyper.sh>