### PR TITLE
qemu: Keep passing BUILD_SUFFIX

### DIFF
--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -56,6 +56,9 @@ ARG QEMU_REPO
 # commit/tag/branch
 ARG QEMU_VERSION
 ARG PREFIX
+# BUILD_SUFFIX is used by the qemu-build-post.sh script to
+# properly rename non vanilla versions of the QEMU
+ARG BUILD_SUFFIX
 ARG HYPERVISOR_NAME
 ARG PKGVERSION
 ARG QEMU_DESTDIR

--- a/tools/packaging/static-build/qemu/build-base-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-base-qemu.sh
@@ -39,6 +39,7 @@ CACHE_TIMEOUT=$(date +"%Y-%m-%d")
 
 sudo "${container_engine}" build \
 	--build-arg CACHE_TIMEOUT="${CACHE_TIMEOUT}" \
+	--build-arg BUILD_SUFFIX=${build_suffix} \
 	--build-arg HYPERVISOR_NAME="${HYPERVISOR_NAME}" \
 	--build-arg PKGVERSION="${PKGVERSION}" \
 	--build-arg http_proxy="${http_proxy}" \


### PR DESCRIPTION
In the commit 54d6d01754b689a32da852cfd85a69d2c4730baa we ended up
removing the BUILD_SUFFIX argument passed to QEMU as it only seemed to
be used to generate the HYPERVISOR_NAME and PKGVERSION, which were added
as arguments to the dockerfile.

However, it turns out BUILD_SUFFIX is used by the `qemu-build-post.sh`
script, so it can rename the QEMU binary accordingly.

Let's just bring it back.

Fixes: #5078

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>