### PR TITLE
kata-deploy: Update aks / k8s versions

### DIFF
--- a/tools/packaging/kata-deploy/action/Dockerfile
+++ b/tools/packaging/kata-deploy/action/Dockerfile
@@ -1,13 +1,13 @@
 # Copyright (c) 2019 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM mcr.microsoft.com/azure-cli:2.9.1
+FROM mcr.microsoft.com/azure-cli:2.39.0
 
 LABEL com.github.actions.name="Test kata-deploy in an AKS cluster"
 LABEL com.github.actions.description="Test kata-deploy in an AKS cluster"
 
 # Default to latest validated AKS-engine version
-ARG AKS_ENGINE_VER="v0.62.0"
+ARG AKS_ENGINE_VER="v0.70.1"
 ARG ARCH=amd64
 
 ENV GITHUB_ACTION_NAME="Test kata-deploy in an AKS cluster"

--- a/tools/packaging/kata-deploy/action/kubernetes-containerd.json
+++ b/tools/packaging/kata-deploy/action/kubernetes-containerd.json
@@ -3,7 +3,7 @@
   "properties": {
     "orchestratorProfile": {
       "orchestratorType": "Kubernetes",
-      "orchestratorVersion": "1.20.5",
+      "orchestratorVersion": "1.23.4",
       "kubernetesConfig": {
         "containerRuntime": "containerd",
         "useManagedIdentity": false

--- a/tools/packaging/kata-deploy/action/test-kata.sh
+++ b/tools/packaging/kata-deploy/action/test-kata.sh
@@ -75,7 +75,7 @@ function run_test() {
       # our 'wait' for deployment status will fail to find the deployment at all
       sleep 3 
 
-      kubectl wait --timeout=5m --for=condition=Available deployment/${deployment}
+      kubectl wait --timeout=5m --for=condition=Available deployment/${deployment} || kubectl describe pods
       kubectl expose deployment/${deployment}
 
       # test pod connectivity:

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+set -x
 set -o errexit
 set -o pipefail
 set -o nounset
@@ -301,7 +302,9 @@ function main() {
 		install)
 			install_artifacts
 			configure_cri_runtime "$runtime"
+			echo "labeling $NODE_NAME with katacontainers.io/kata-runtime=true"
 			kubectl label node "$NODE_NAME" --overwrite katacontainers.io/kata-runtime=true
+			kubectl get nodes --show-labels
 			;;
 		cleanup)
 			cleanup_cri_runtime "$runtime"


### PR DESCRIPTION
Let's update to the latest AKS version, and avoid pinning to a very old
kubernetes version.

Fixes: #0000

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>