### PR TITLE
runtime-rs: debug console support in runtime

### DIFF
--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -18,9 +18,11 @@ lazy_static! {
         "/usr/share/defaults/kata-containers/configuration.toml",
     ];
 }
+
 pub const DEFAULT_AGENT_NAME: &str = "kata-agent";
 pub const DEFAULT_AGENT_VSOCK_PORT: u32 = 1024;
 pub const DEFAULT_AGENT_LOG_PORT: u32 = 1025;
+pub const DEFAULT_AGENT_DBG_CONSOLE_PORT: u32 = 1026;
 pub const DEFAULT_AGENT_TYPE_NAME: &str = AGENT_NAME_KATA;
 
 pub const DEFAULT_RUNTIME_NAME: &str = RUNTIME_NAME_VIRTCONTAINER;

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -50,6 +50,8 @@ const VIRTIO_FS: &str = "virtio-fs";
 const VIRTIO_FS_INLINE: &str = "inline-virtio-fs";
 const MAX_BRIDGE_SIZE: u32 = 5;
 
+const KERNEL_PARAM_DELIMITER: &str = " ";
+
 lazy_static! {
     static ref HYPERVISOR_PLUGINS: Mutex<HashMap<String, Arc<dyn ConfigPlugin>>> =
         Mutex::new(HashMap::new());
@@ -235,6 +237,14 @@ impl BootInfo {
             return Err(eother!("Can not configure both initrd and image for boot"));
         }
         Ok(())
+    }
+
+    /// Add kernel parameters to bootinfo. It is always added before the original
+    /// to let the original one takes priority
+    pub fn add_kparams(&mut self, params: Vec<String>) {
+        let mut p = params;
+        p.push(self.kernel_params.clone()); // [new_params0, new_params1, ..., original_params]
+        self.kernel_params = p.join(KERNEL_PARAM_DELIMITER);
     }
 
     /// Validate guest kernel image annotaion

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -241,14 +241,12 @@ impl BootInfo {
 
     /// Add kernel parameters to bootinfo. It is always added before the original
     /// to let the original one takes priority
-    pub fn add_kparams(&mut self, params: Vec<String>) {
+    pub fn add_kernel_params(&mut self, params: Vec<String>) {
         let mut p = params;
-        if self.kernel_params.is_empty() {
-            self.kernel_params = p.join(KERNEL_PARAM_DELIMITER);
-        } else {
+        if !self.kernel_params.is_empty() {
             p.push(self.kernel_params.clone()); // [new_params0, new_params1, ..., original_params]
-            self.kernel_params = p.join(KERNEL_PARAM_DELIMITER);
         }
+        self.kernel_params = p.join(KERNEL_PARAM_DELIMITER);
     }
 
     /// Validate guest kernel image annotaion
@@ -1083,7 +1081,7 @@ mod tests {
     }
 
     #[test]
-    fn test_add_kparams() {
+    fn test_add_kernel_params() {
         let mut boot_info = BootInfo {
             ..Default::default()
         };
@@ -1092,7 +1090,7 @@ mod tests {
             String::from("bar"),
             String::from("baz=faz"),
         ];
-        boot_info.add_kparams(params);
+        boot_info.add_kernel_params(params);
 
         assert_eq!(boot_info.kernel_params, String::from("foo bar baz=faz"));
 
@@ -1101,7 +1099,7 @@ mod tests {
             String::from("a"),
             String::from("b=c"),
         ];
-        boot_info.add_kparams(new_params);
+        boot_info.add_kernel_params(new_params);
 
         assert_eq!(
             boot_info.kernel_params,

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -171,7 +171,7 @@ impl TomlConfig {
     }
 
     /// Get agent-specfic kernel parameters for further Hypervisor config revision
-    pub fn get_agent_kparams(&self) -> Result<HashMap<String, String>> {
+    pub fn get_agent_kernel_params(&self) -> Result<HashMap<String, String>> {
         let mut kv = HashMap::new();
         if let Some(cfg) = self.agent.get(&self.runtime.agent_name) {
             if cfg.debug {
@@ -349,7 +349,7 @@ mod tests {
     }
 
     #[test]
-    fn test_get_agent_kparams() {
+    fn test_get_agent_kernel_params() {
         let mut config = TomlConfig {
             ..Default::default()
         };
@@ -364,7 +364,7 @@ mod tests {
         config.runtime.agent_name = agent_name.to_string();
         config.agent.insert(agent_name.to_owned(), agent_config);
 
-        let kv = config.get_agent_kparams().unwrap();
+        let kv = config.get_agent_kernel_params().unwrap();
         assert_eq!(kv.get("agent.log").unwrap(), "debug");
         assert_eq!(kv.get("agent.trace").unwrap(), "true");
         assert_eq!(kv.get("agent.container_pipe_size").unwrap(), "20");

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -151,7 +151,29 @@ impl TomlConfig {
         Ok(())
     }
 
-    ///  Probe configuration file according to the default configuration file list.
+    /// Get agent-specfic kernel parameters for further Hypervisor config revision
+    pub fn get_agent_kparams(&self) -> Result<HashMap<String, String>> {
+        let mut kv = HashMap::new();
+        if let Some(cfg) = self.agent.get(&self.runtime.agent_name) {
+            if cfg.debug {
+                kv.insert("agent.log".to_string(), "debug".to_string());
+            }
+            if cfg.enable_tracing {
+                kv.insert("agent.trace".to_string(), "true".to_string());
+            }
+            if cfg.container_pipe_size > 0 {
+                let container_pipe_size = cfg.container_pipe_size.to_string();
+                kv.insert("agent.container_pipe_size".to_string(), container_pipe_size);
+            }
+            if cfg.debug_console_enabled {
+                kv.insert("agent.debug_console".to_string(), "".to_string());
+                kv.insert("agent.debug_console_vport".to_string(), "1026".to_string());
+            }
+        }
+        Ok(kv)
+    }
+
+    /// Probe configuration file according to the default configuration file list.
     fn get_default_config_file() -> Result<PathBuf> {
         for f in default::DEFAULT_RUNTIME_CONFIGURATIONS.iter() {
             if let Ok(path) = fs::canonicalize(f) {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -91,6 +91,7 @@ impl DragonballInner {
         kernel_params.append(&mut KernelParams::from_string(
             &self.config.boot_info.kernel_params,
         ));
+        info!(sl!(), "prepared kernel_params={:?}", kernel_params);
 
         // set boot source
         let kernel_path = self.config.boot_info.kernel.clone();

--- a/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
+++ b/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
@@ -7,6 +7,7 @@
 use anyhow::{anyhow, Result};
 
 use crate::{VM_ROOTFS_DRIVER_BLK, VM_ROOTFS_DRIVER_PMEM};
+use kata_types::config::LOG_VPORT_OPTION;
 
 // Port where the agent will send the logs. Logs are sent through the vsock in cases
 // where the hypervisor has no console.sock, i.e dragonball
@@ -60,7 +61,7 @@ impl KernelParams {
         ];
 
         if debug {
-            params.push(Param::new("agent.log_vport", VSOCK_LOGS_PORT));
+            params.push(Param::new(LOG_VPORT_OPTION, VSOCK_LOGS_PORT));
         }
 
         Self { params }

--- a/src/runtime-rs/crates/runtimes/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/Cargo.toml
@@ -19,6 +19,7 @@ kata-types = { path = "../../../libs/kata-types" }
 logging = { path = "../../../libs/logging"}
 oci = { path = "../../../libs/oci" }
 persist = { path = "../persist" }
+hypervisor = { path = "../hypervisor" }
 # runtime handler
 linux_container = { path = "./linux_container", optional = true }
 virt_container = { path = "./virt_container", optional = true }

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -324,7 +324,7 @@ fn load_config(spec: &oci::Spec) -> Result<TomlConfig> {
     let (mut toml_config, _) =
         TomlConfig::load_from_file(&config_path).context("load toml config")?;
     annotation.update_config_by_annotation(&mut toml_config)?;
-    update_agent_kparams(&mut toml_config)?;
+    update_agent_kernel_params(&mut toml_config)?;
 
     // validate configuration and return the error
     toml_config.validate()?;
@@ -351,16 +351,16 @@ fn load_config(spec: &oci::Spec) -> Result<TomlConfig> {
 
 // this update the agent-specfic kernel parameters into hypervisor's bootinfo
 // the agent inside the VM will read from file cmdline to get the params and function
-fn update_agent_kparams(config: &mut TomlConfig) -> Result<()> {
+fn update_agent_kernel_params(config: &mut TomlConfig) -> Result<()> {
     let mut params = vec![];
-    if let Ok(kv) = config.get_agent_kparams() {
+    if let Ok(kv) = config.get_agent_kernel_params() {
         for (k, v) in kv.into_iter() {
             if let Ok(s) = Param::new(k.as_str(), v.as_str()).to_string() {
                 params.push(s);
             }
         }
         if let Some(h) = config.hypervisor.get_mut(&config.runtime.hypervisor_name) {
-            h.boot_info.add_kparams(params);
+            h.boot_info.add_kernel_params(params);
         }
     }
     Ok(())


### PR DESCRIPTION
Read debug console configuration in kernel params. The debug console is opened when the configuration is set, and to be consistent with kata 2.x, the port is default to be 1026 in runtime. A console can log into the pod's shell by connecting to vport 1026.

Fixes: #5068
Signed-Off-By: Ji-Xinyou <jerryji0414@outlook.com>