### PR TITLE
runtime-rs: add default agent/runtime/hypervisor for configuration

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -12,7 +12,11 @@ use std::u32;
 
 use serde::Deserialize;
 
+use crate::config::default::DEFAULT_AGENT_TYPE_NAME;
+use crate::config::default::DEFAULT_HYPERVISOR;
+use crate::config::default::DEFAULT_RUNTIME_NAME;
 use crate::config::hypervisor::get_hypervisor_plugin;
+
 use crate::config::TomlConfig;
 use crate::sl;
 
@@ -439,6 +443,18 @@ impl Annotation {
                 config.runtime.agent_name = ag.to_string();
             }
         }
+
+        // set default values for runtime.name, runtime.hypervisor_name and runtime.agent
+        if config.runtime.name.is_empty() {
+            config.runtime.name = DEFAULT_RUNTIME_NAME.to_string()
+        }
+        if config.runtime.hypervisor_name.is_empty() {
+            config.runtime.hypervisor_name = DEFAULT_HYPERVISOR.to_string()
+        }
+        if config.runtime.agent_name.is_empty() {
+            config.runtime.agent_name = DEFAULT_AGENT_TYPE_NAME.to_string()
+        }
+
         let hypervisor_name = &config.runtime.hypervisor_name;
         let agent_name = &config.runtime.agent_name;
 

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -11,6 +11,9 @@ pub use vendor::AgentVendor;
 
 use super::default::{DEFAULT_AGENT_LOG_PORT, DEFAULT_AGENT_VSOCK_PORT};
 
+/// agent name of Kata agent.
+pub const AGENT_NAME_KATA: &str = "kata";
+
 /// Kata agent configuration information.
 #[derive(Debug, Default, Deserialize, Serialize, Clone)]
 pub struct Agent {

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -6,6 +6,9 @@
 //! Default configuration values.
 #![allow(missing_docs)]
 
+use crate::config::agent::AGENT_NAME_KATA;
+use crate::config::hypervisor::HYPERVISOR_NAME_DRAGONBALL;
+use crate::config::runtime::RUNTIME_NAME_VIRTCONTAINER;
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -18,6 +21,10 @@ lazy_static! {
 pub const DEFAULT_AGENT_NAME: &str = "kata-agent";
 pub const DEFAULT_AGENT_VSOCK_PORT: u32 = 1024;
 pub const DEFAULT_AGENT_LOG_PORT: u32 = 1025;
+pub const DEFAULT_AGENT_TYPE_NAME: &str = AGENT_NAME_KATA;
+
+pub const DEFAULT_RUNTIME_NAME: &str = RUNTIME_NAME_VIRTCONTAINER;
+pub const DEFAULT_HYPERVISOR: &str = HYPERVISOR_NAME_DRAGONBALL;
 
 pub const DEFAULT_INTERNETWORKING_MODEL: &str = "tcfilter";
 

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -29,7 +29,9 @@ pub use self::hypervisor::{
 };
 
 mod runtime;
-pub use self::runtime::{Runtime, RuntimeVendor};
+pub use self::runtime::{Runtime, RuntimeVendor, RUNTIME_NAME_VIRTCONTAINER};
+
+pub use self::agent::AGENT_NAME_KATA;
 
 /// Trait to manipulate global Kata configuration information.
 pub trait ConfigPlugin: Send + Sync {

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -10,6 +10,9 @@ use super::default;
 use crate::config::{ConfigOps, TomlConfig};
 use crate::{eother, resolve_path, validate_path};
 
+/// Type of runtime VirtContainer.
+pub const RUNTIME_NAME_VIRTCONTAINER: &str = "virt_container";
+
 /// Kata runtime configuration information.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Runtime {


### PR DESCRIPTION
Kata 3.0 introduced 3 new configurations under runtime section:

name="virt_container"
hypervisor_name="dragonball"
agent_name="kata"
Blank values will lead to starting to fail.

Adding default values will make user easy to migrate to kata 3.0.

Fixes: #5098

Signed-off-by: Bin Liu <bin@hyper.sh>