### PR TITLE
kata-types: change return type of getting CPU period/quota function

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -379,17 +379,17 @@ impl Annotation {
     }
 
     /// Get the annotation of cpu quota for sandbox
-    pub fn get_sandbox_cpu_quota(&self) -> u64 {
+    pub fn get_sandbox_cpu_quota(&self) -> i64 {
         let value = self
-            .get_value::<u64>(SANDBOX_CPU_QUOTA_KEY)
+            .get_value::<i64>(SANDBOX_CPU_QUOTA_KEY)
             .unwrap_or(Some(0));
         value.unwrap_or(0)
     }
 
     /// Get the annotation of cpu period for sandbox
-    pub fn get_sandbox_cpu_period(&self) -> i64 {
+    pub fn get_sandbox_cpu_period(&self) -> u64 {
         let value = self
-            .get_value::<i64>(SANDBOX_CPU_PERIOD_KEY)
+            .get_value::<u64>(SANDBOX_CPU_PERIOD_KEY)
             .unwrap_or(Some(0));
         value.unwrap_or(0)
     }

--- a/src/runtime-rs/crates/runtimes/src/static_resource.rs
+++ b/src/runtime-rs/crates/runtimes/src/static_resource.rs
@@ -128,8 +128,8 @@ fn get_sizing_info(annotation: Annotation) -> Result<(u64, i64, i64)> {
     // since we are *adding* our result to the config, a value of 0 will cause no change
     // and if the annotation is not assigned (but static resource management is), we will
     // log a *warning* to fill that with zero value
-    let period = annotation.get_sandbox_cpu_quota();
-    let quota = annotation.get_sandbox_cpu_period();
+    let period = annotation.get_sandbox_cpu_period();
+    let quota = annotation.get_sandbox_cpu_quota();
     let memory = annotation.get_sandbox_mem();
     Ok((period, quota, memory))
 }


### PR DESCRIPTION
period should have a type of u64, and quota should be i64, the
function of getting CPU period and quota from annotations should
use the same data type as function return type.

Fixes: #5100

Signed-off-by: Bin Liu <bin@hyper.sh>