### PR TITLE
microvm: Remove kernel_irqchip=on option

### DIFF
--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -38,7 +38,7 @@ const (
 
 	defaultQemuMachineType = QemuQ35
 
-	defaultQemuMachineOptions = "accel=kvm,kernel_irqchip=on"
+	defaultQemuMachineOptions = "accel=kvm"
 
 	splitIrqChipMachineOptions = "accel=kvm,kernel_irqchip=split"
 


### PR DESCRIPTION
Closes #1984 and #4386

With microvm machine types, `kernel_irqchip=split` option is necessary (see related issues for more debug info).
