### PR TITLE
libs/kata-types: replace tabs by spaces in comments

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -177,7 +177,7 @@ pub const KATA_ANNO_CFG_HYPERVISOR_FIRMWARE_HASH: &str =
 /// A sandbox annotation to specify cpu specific features.
 pub const KATA_ANNO_CFG_HYPERVISOR_CPU_FEATURES: &str =
     "io.katacontainers.config.hypervisor.cpu_features";
-/// A sandbox annotation for passing the default vcpus assigned for a VM by the hypervisor.
+/// A sandbox annotation for passing the default vCPUs assigned for a VM by the hypervisor.
 pub const KATA_ANNO_CFG_HYPERVISOR_DEFAULT_VCPUS: &str =
     "io.katacontainers.config.hypervisor.default_vcpus";
 /// A sandbox annotation that specifies the maximum number of vCPUs allocated for the VM by the hypervisor.
@@ -198,7 +198,7 @@ pub const KATA_ANNO_CFG_HYPERVISOR_IOMMU: &str = "io.katacontainers.config.hyper
 pub const KATA_ANNO_CFG_HYPERVISOR_IOMMU_PLATFORM: &str =
     "io.katacontainers.config.hypervisor.enable_iommu_platform";
 
-//	Hypervisor Machine related annotations
+// Hypervisor Machine related annotations
 /// A sandbox annotation to specify the type of machine being emulated by the hypervisor.
 pub const KATA_ANNO_CFG_HYPERVISOR_MACHINE_TYPE: &str =
     "io.katacontainers.config.hypervisor.machine_type";
@@ -256,7 +256,7 @@ pub const KATA_ANNO_CFG_HYPERVISOR_ENABLE_ROOTLESS_HYPERVISOR: &str =
     "io.katacontainers.config.hypervisor.rootless";
 
 // Hypervisor Shared File System related annotations
-/// A sandbox annotation to specify the shared file system type, either virtio-9p or virtio-fs.
+/// A sandbox annotation to specify the shared file system type, either inline-virtio-fs (default), virtio-9p, virtio-fs or virtio-fs-nydus.
 pub const KATA_ANNO_CFG_HYPERVISOR_SHARED_FS: &str =
     "io.katacontainers.config.hypervisor.shared_fs";
 /// A sandbox annotations to specify virtio-fs vhost-user daemon path.
@@ -452,7 +452,7 @@ impl Annotation {
             if hv.security_info.is_annotation_enabled(key) {
                 match key.as_str() {
                     // update hypervisor config
-                    //	Hypervisor related annotations
+                    // Hypervisor related annotations
                     KATA_ANNO_CFG_HYPERVISOR_PATH => {
                         hv.validate_hypervisor_path(value)?;
                         hv.path = value.to_string();
@@ -475,7 +475,7 @@ impl Annotation {
                             return Err(bool_err);
                         }
                     },
-                    //	Hypervisor Block Device related annotations
+                    // Hypervisor Block Device related annotations
                     KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_DRIVER => {
                         hv.blockdev_info.block_device_driver = value.to_string();
                     }
@@ -571,7 +571,7 @@ impl Annotation {
                         hv.boot_info.validate_boot_path(value)?;
                         hv.boot_info.firmware = value.to_string();
                     }
-                    //	Hypervisor CPU related annotations
+                    // Hypervisor CPU related annotations
                     KATA_ANNO_CFG_HYPERVISOR_CPU_FEATURES => {
                         hv.cpu_info.cpu_features = value.to_string();
                     }
@@ -611,7 +611,7 @@ impl Annotation {
                             }
                         }
                     }
-                    //	Hypervisor Device related annotations
+                    // Hypervisor Device related annotations
                     KATA_ANNO_CFG_HYPERVISOR_HOTPLUG_VFIO_ON_ROOT_BUS => {
                         match self.get_value::<bool>(key) {
                             Ok(r) => {
@@ -646,7 +646,7 @@ impl Annotation {
                             return Err(bool_err);
                         }
                     },
-                    //	Hypervisor Machine related annotations
+                    // Hypervisor Machine related annotations
                     KATA_ANNO_CFG_HYPERVISOR_MACHINE_TYPE => {
                         hv.machine_info.machine_type = value.to_string();
                     }
@@ -657,7 +657,7 @@ impl Annotation {
                         hv.machine_info.validate_entropy_source(value)?;
                         hv.machine_info.entropy_source = value.to_string();
                     }
-                    //	Hypervisor Memory related annotations
+                    // Hypervisor Memory related annotations
                     KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MEMORY => {
                         match byte_unit::Byte::from_str(value) {
                             Ok(mem_bytes) => {
@@ -746,7 +746,7 @@ impl Annotation {
                             return Err(bool_err);
                         }
                     },
-                    //	Hypervisor Network related annotations
+                    // Hypervisor Network related annotations
                     KATA_ANNO_CFG_HYPERVISOR_DISABLE_VHOST_NET => match self.get_value::<bool>(key)
                     {
                         Ok(r) => {
@@ -776,7 +776,7 @@ impl Annotation {
                             }
                         }
                     }
-                    //	Hypervisor Security related annotations
+                    // Hypervisor Security related annotations
                     KATA_ANNO_CFG_HYPERVISOR_GUEST_HOOK_PATH => {
                         hv.security_info.validate_path(value)?;
                         hv.security_info.guest_hook_path = value.to_string();
@@ -791,7 +791,7 @@ impl Annotation {
                             }
                         }
                     }
-                    //	Hypervisor Shared File System related annotations
+                    // Hypervisor Shared File System related annotations
                     KATA_ANNO_CFG_HYPERVISOR_SHARED_FS => {
                         hv.shared_fs.shared_fs = self.get(key);
                     }
@@ -839,7 +839,7 @@ impl Annotation {
                 }
             } else {
                 match key.as_str() {
-                    //update agent config
+                    // update agent config
                     KATA_ANNO_CFG_KERNEL_MODULES => {
                         let kernel_mod: Vec<String> =
                             value.to_string().split(';').map(str::to_string).collect();
@@ -863,7 +863,7 @@ impl Annotation {
                             return Err(u32_err);
                         }
                     },
-                    //update runtime config
+                    // update runtime config
                     KATA_ANNO_CFG_RUNTIME_NAME => {
                         let runtime = vec!["virt-container", "linux-container", "wasm-container"];
                         if runtime.contains(&value.as_str()) {


### PR DESCRIPTION
Replace tabs by spaces in the comments of file
libs/kata-types/src/annotations/mod.rs.

Fixes: #5115

Signed-off-by: Bin Liu <bin@hyper.sh>