### PR TITLE
CC, packaging: add sev-initrd target, and add efi_secret module to sev's initrd 

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -89,7 +89,8 @@ cc: cc-cloud-hypervisor-tarball \
 	cc-tdx-qemu-tarball \
 	cc-tdx-td-shim-tarball \
 	cc-tdx-tdvf-tarball \
-	cc-sev-ovmf-tarball
+	cc-sev-ovmf-tarball \
+	cc-sev-rootfs-initrd-tarball
 
 cc-cloud-hypervisor-tarball:
 	${MAKE} $@-build
@@ -101,6 +102,9 @@ cc-qemu-tarball:
 	${MAKE} $@-build
 
 cc-rootfs-image-tarball:
+	${MAKE} $@-build
+
+cc-sev-rootfs-initrd-tarball: cc-sev-kernel-tarball
 	${MAKE} $@-build
 
 cc-shim-v2-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -90,6 +90,7 @@ options:
 	cc-qemu
 	cc-tdx-qemu
 	cc-rootfs-image
+	cc-sev-initrd-image
 	cc-shimv2
 	cc-virtiofsd
 	cc-sev-ovmf
@@ -113,13 +114,20 @@ install_cc_clh() {
 
 #Install cc capable guest image
 install_cc_image() {
+	export AA_KBC="${1:-offline_fs_kbc}"
+	image_type="${2:-image}"
 	export SKOPEO="${SKOPEO:-yes}"
 	export UMOCI=yes
-	export AA_KBC="offline_fs_kbc"
 	export KATA_BUILD_CC=yes
 
 	info "Create CC image configured with SKOPEO=${SKOPEO} UMOCI=${UMOCI} AA_KBC=${AA_KBC}"
-	"${rootfs_builder}" --imagetype=image --prefix="${cc_prefix}" --destdir="${destdir}"
+	"${rootfs_builder}" --imagetype="${image_type}" --prefix="${cc_prefix}" --destdir="${destdir}"
+}
+
+install_cc_sev_image() {
+	AA_KBC="offline_sev_kbc"
+	image_type="initrd"
+	install_cc_image "${AA_KBC}" "${image_type}"
 }
 
 #Install CC kernel asset
@@ -316,6 +324,7 @@ handle_build() {
 		install_cc_image
 		install_cc_shimv2
 		install_cc_virtiofsd
+		install_cc_sev_image
 		;;
 
 	cc-cloud-hypervisor) install_cc_clh ;;
@@ -325,6 +334,8 @@ handle_build() {
 	cc-qemu) install_cc_qemu ;;
 
 	cc-rootfs-image) install_cc_image ;;
+
+	cc-sev-initrd-image) install_cc_sev_image ;;
 
 	cc-shim-v2) install_cc_shimv2 ;;
 

--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -331,22 +331,6 @@ get_default_kernel_config() {
 	echo "${config}"
 }
 
-get_config_and_patches() {
-	if [ -z "${patches_path}" ]; then
-		patches_path="${default_patches_dir}"
-	fi
-}
-
-get_config_version() {
-	get_config_and_patches
-	config_version_file="${default_patches_dir}/../kata_config_version"
-	if [ -f "${config_version_file}" ]; then
-		cat "${config_version_file}"
-	else
-		die "failed to find ${config_version_file}"
-	fi
-}
-
 setup_kernel() {
 	local kernel_path=${1:-}
 	[ -n "${kernel_path}" ] || die "kernel_path not provided"

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -97,3 +97,19 @@ get_kata_hash() {
 	ref=$2
 	git ls-remote --heads --tags "https://github.com/${project}/${repo}.git" | grep "${ref}" | awk '{print $1}'
 }
+
+get_config_and_patches() {
+	if [ -z "${patches_path}" ]; then
+		patches_path="${default_patches_dir}"
+	fi
+}
+
+get_config_version() {
+	get_config_and_patches
+	config_version_file="${default_patches_dir}/../kata_config_version"
+	if [ -f "${config_version_file}" ]; then
+		cat "${config_version_file}"
+	else
+		die "failed to find ${config_version_file}"
+	fi
+}


### PR DESCRIPTION
Adds a make target for an sev initrd.

Changes the kata-deploy-binaries functions to be more generic.

Adds efi_secret kernel module to the sev initrd. 

Moved kernel config version checking function from kernel builder to lib script.

First question: should this get added to the cc target?