### PR TITLE
kata-deploy: Fix `containerd-shim-kata-v2` location

### DIFF
--- a/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
@@ -101,7 +101,7 @@ function configure_different_shims_base() {
 		local shim_file="/usr/local/bin/${shim_binary}"
 
 		backup_shim "${shim_file}"
-		ln -sf /opt/kata/bin/containerd-shim-kata-v2 "${shim_file}"
+		ln -sf /opt/confidential-containers/bin/containerd-shim-kata-v2 "${shim_file}"
 		chmod +x "$shim_file"
 
 		if [ "${shim}" == "${default_shim}" ]; then


### PR DESCRIPTION
For Confidential Containers the file is present at
`/opt/confidential-containers` instead of `/opt/kata`.

Fixes: #5119

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>