### PR TITLE
osbuilder: Update image-builder to use Fedora 35

### DIFF
--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ARG IMAGE_REGISTRY=registry.fedoraproject.org
-FROM ${IMAGE_REGISTRY}/fedora:34
+FROM ${IMAGE_REGISTRY}/fedora:35
 
 RUN ([ -n "$http_proxy" ] && \
     sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true) && \

--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -7,6 +7,8 @@ FROM ${IMAGE_REGISTRY}/fedora:35
 
 RUN ([ -n "$http_proxy" ] && \
     sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true) && \
+    echo "Printing dnf.conf" && \
+    cat /etc/dnf/dnf.conf && \
     dnf install -y \
         e2fsprogs \
         findutils \


### PR DESCRIPTION
This PR updates the image-builder to use Fedora 35 in order
to match the current Fedora version that we are using in our CI.

Fixes #5122

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>