### PR TITLE
Revert arp neighbour api

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -654,8 +654,8 @@ dependencies = [
  "libc",
  "log",
  "logging",
- "netlink-packet-utils 0.4.1",
- "netlink-sys 0.7.0",
+ "netlink-packet-utils",
+ "netlink-sys",
  "nix 0.24.2",
  "oci",
  "opentelemetry",
@@ -841,28 +841,28 @@ checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.4.2"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "345b8ab5bd4e71a2986663e88c56856699d060e78e152e6e9d7966fcd5491297"
+checksum = "ac48279d5062bdf175bdbcb6b58ff1d6b0ecd54b951f7a0ff4bc0550fe903ccb"
 dependencies = [
  "anyhow",
  "byteorder",
  "libc",
- "netlink-packet-utils 0.5.1",
+ "netlink-packet-utils",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.13.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5dee5ed749373c298237fe694eb0a51887f4cc1a27370c8464bac4382348f1a"
+checksum = "76aed5d3b6e3929713bf1e1334a11fd65180b6d9f5d7c8572664c48b122604f8"
 dependencies = [
  "anyhow",
  "bitflags",
  "byteorder",
  "libc",
  "netlink-packet-core",
- "netlink-packet-utils 0.5.1",
+ "netlink-packet-utils",
 ]
 
 [[package]]
@@ -878,30 +878,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "netlink-packet-utils"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25af9cf0dc55498b7bd94a1508af7a78706aa0ab715a73c5169273e03c84845e"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror",
-]
-
-[[package]]
 name = "netlink-proto"
-version = "0.10.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65b4b14489ab424703c092062176d52ba55485a89c076b4f9db05092b7223aa6"
+checksum = "ddd06e90449ae973fe3888c1ff85949604ef5189b4ac9a2ae39518da1e00762d"
 dependencies = [
  "bytes 1.1.0",
  "futures",
  "log",
  "netlink-packet-core",
- "netlink-sys 0.8.3",
- "thiserror",
+ "netlink-sys",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -917,16 +905,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "netlink-sys"
-version = "0.8.3"
+name = "nix"
+version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92b654097027250401127914afb37cb1f311df6610a9891ff07a757e94199027"
+checksum = "e4916f159ed8e5de0082076562152a76b7a1f64a01fd9d1e0fea002c37624faf"
 dependencies = [
- "bytes 1.1.0",
- "futures",
+ "bitflags",
+ "cc",
+ "cfg-if 1.0.0",
  "libc",
- "log",
- "tokio",
+ "memoffset",
 ]
 
 [[package]]
@@ -1491,15 +1479,15 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.11.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f1cfa18f8cebe685373a2697915d7e0db3b4554918bba118385e0f71f258a7"
+checksum = "7c9a6200d18ec1acfc218ce71363dcc9b6075f399220f903fdfeacd476a876ef"
 dependencies = [
  "futures",
  "log",
  "netlink-packet-route",
  "netlink-proto",
- "nix 0.24.2",
+ "nix 0.22.3",
  "thiserror",
  "tokio",
 ]
@@ -1884,6 +1872,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df54d54117d6fdc4e4fea40fe1e4e566b3505700e148a6827e59b34b0d2600d9"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36943ee01a6d67977dd3f84a5a1d2efeb4ada3a1ae771cadfaa535d9d9fc6507"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "log",
  "pin-project-lite",
  "tokio",
 ]

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1.14.0", features = ["full"] }
 tokio-vsock = "0.3.1"
 
 netlink-sys = { version = "0.7.0", features = ["tokio_socket",]}
-rtnetlink = "0.11.0"
+rtnetlink = "0.8.0"
 netlink-packet-utils = "0.4.1"
 ipnetwork = "0.17.0"
 

--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -955,7 +955,7 @@ mod tests {
             .expect("prepare: failed to delete neigh");
     }
 
-    fn prepare_env_for_test_add_one_arp_neighbor(dummy_name: &str, ip: &str, mac: &str) {
+    fn prepare_env_for_test_add_one_arp_neighbor(dummy_name: &str, ip: &str) {
         clean_env_for_test_add_one_arp_neighbor(dummy_name, ip);
         // modprobe dummy
         Command::new("modprobe")
@@ -966,12 +966,6 @@ mod tests {
         // ip link add dummy type dummy
         Command::new("ip")
             .args(&["link", "add", dummy_name, "type", "dummy"])
-            .output()
-            .expect("failed to add dummy interface");
-
-        // ip link set dummy address 6a:92:3a:59:70:aa
-        Command::new("ip")
-            .args(&["link", "set", dummy_name, "address", mac])
             .output()
             .expect("failed to add dummy interface");
 
@@ -996,7 +990,7 @@ mod tests {
         let to_ip = "169.254.1.1";
         let dummy_name = "dummy_for_arp";
 
-        prepare_env_for_test_add_one_arp_neighbor(dummy_name, to_ip, mac);
+        prepare_env_for_test_add_one_arp_neighbor(dummy_name, to_ip);
 
         let mut ip_address = IPAddress::new();
         ip_address.set_address(to_ip.to_string());

--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -4,7 +4,7 @@
 //
 
 use anyhow::{anyhow, Context, Result};
-use futures::{future, TryStreamExt};
+use futures::{future, StreamExt, TryStreamExt};
 use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
 use nix::errno::Errno;
 use protobuf::RepeatedField;
@@ -164,7 +164,7 @@ impl Handle {
         let request = self.handle.link().get();
 
         let filtered = match filter {
-            LinkFilter::Name(name) => request.match_name(name.to_owned()),
+            LinkFilter::Name(name) => request.set_name_filter(name.to_owned()),
             LinkFilter::Index(index) => request.match_index(index),
             _ => request, // Post filters
         };
@@ -516,6 +516,7 @@ impl Handle {
     }
 
     /// Adds an ARP neighbor.
+    /// TODO: `rtnetlink` has no neighbours API, remove this after https://github.com/little-dude/netlink/pull/135
     async fn add_arp_neighbor(&mut self, neigh: &ARPNeighbor) -> Result<()> {
         let ip_address = neigh
             .toIPAddress
@@ -527,13 +528,58 @@ impl Handle {
         let ip = IpAddr::from_str(ip_address)
             .map_err(|e| anyhow!("Failed to parse IP {}: {:?}", ip_address, e))?;
 
+        // Import rtnetlink objects that make sense only for this function
+        use packet::constants::{NDA_UNSPEC, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST};
+        use packet::neighbour::{NeighbourHeader, NeighbourMessage};
+        use packet::nlas::neighbour::Nla;
+        use packet::{NetlinkMessage, NetlinkPayload, RtnlMessage};
+        use rtnetlink::Error;
+
+        const IFA_F_PERMANENT: u16 = 0x80; // See https://github.com/little-dude/netlink/blob/0185b2952505e271805902bf175fee6ea86c42b8/netlink-packet-route/src/rtnl/constants.rs#L770
+
         let link = self.find_link(LinkFilter::Name(&neigh.device)).await?;
 
-        self.handle
-            .neighbours()
-            .add(link.index(), ip)
-            .execute()
-            .await?;
+        let message = NeighbourMessage {
+            header: NeighbourHeader {
+                family: match ip {
+                    IpAddr::V4(_) => packet::AF_INET,
+                    IpAddr::V6(_) => packet::AF_INET6,
+                } as u8,
+                ifindex: link.index(),
+                state: if neigh.state != 0 {
+                    neigh.state as u16
+                } else {
+                    IFA_F_PERMANENT
+                },
+                flags: neigh.flags as u8,
+                ntype: NDA_UNSPEC as u8,
+            },
+            nlas: {
+                let mut nlas = vec![Nla::Destination(match ip {
+                    IpAddr::V4(v4) => v4.octets().to_vec(),
+                    IpAddr::V6(v6) => v6.octets().to_vec(),
+                })];
+
+                if !neigh.lladdr.is_empty() {
+                    nlas.push(Nla::LinkLocalAddress(
+                        parse_mac_address(&neigh.lladdr)?.to_vec(),
+                    ));
+                }
+
+                nlas
+            },
+        };
+
+        // Send request and ACK
+        let mut req = NetlinkMessage::from(RtnlMessage::NewNeighbour(message));
+        req.header.flags = NLM_F_REQUEST | NLM_F_ACK | NLM_F_EXCL | NLM_F_CREATE;
+
+        let mut response = self.handle.request(req)?;
+        while let Some(message) = response.next().await {
+            if let NetlinkPayload::Error(err) = message.payload {
+                return Err(anyhow!(Error::NetlinkError(err)));
+            }
+        }
 
         Ok(())
     }

--- a/tools/packaging/kata-deploy/action/test-kata.sh
+++ b/tools/packaging/kata-deploy/action/test-kata.sh
@@ -75,7 +75,7 @@ function run_test() {
       # our 'wait' for deployment status will fail to find the deployment at all
       sleep 3 
 
-      kubectl wait --timeout=5m --for=condition=Available deployment/${deployment}
+      kubectl wait --timeout=5m --for=condition=Available deployment/${deployment} || kubectl describe pods
       kubectl expose deployment/${deployment}
 
       # test pod connectivity:


### PR DESCRIPTION
This reverts PR: https://github.com/kata-containers/kata-containers/pull/4770

Using  rtnetlink's neighbours API to add neighbors is causing issues in AKS while adding neighbours. Hence reverting the change for now till we resolve the issue.