### PR TITLE
CC use depmod in rootfs builder for kernel modules with docker support

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -273,6 +273,8 @@ copy_kernel_modules()
 	info "Copy kernel modules from ${KERNEL_MODULES_DIR}"
 	mkdir -p "${dest_dir}"
 	cp -a "${KERNEL_MODULES_DIR}" "${dest_dir}/"
+	local KERNEL_VER=$(ls ${dest_dir})
+	depmod -b "${rootfs_dir}" ${KERNEL_VER}
 	OK "Kernel modules copied"
 }
 

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -40,7 +40,8 @@ RUN apt-get update && \
     pkg-config \
     protobuf-compiler \
     gettext-base \
-    umoci
+    umoci \ 
+    kmod
 
 # aarch64 requires this name -- link for all
 RUN ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -5,11 +5,11 @@
 OS_NAME=ubuntu
 # This should be Ubuntu's code name, e.g. "focal" (Focal Fossa) for 20.04
 OS_VERSION=${OS_VERSION:-focal}
-PACKAGES="chrony iptables"
+PACKAGES="chrony iptables kmod"
 [ "$AGENT_INIT" = no ] && PACKAGES+=" init"
 [ "$KATA_BUILD_CC" = yes ] && PACKAGES+=" cryptsetup-bin e2fsprogs"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp2"
-[ "$SKOPEO" = yes ] && PACKAGES+=" libgpgme11"
+[ "$SKOPEO" = yes ] && PACKAGES+=" libgpgme11 libdevmapper1.02.1"
 REPO_URL=http://ports.ubuntu.com
 
 case "$ARCH" in


### PR DESCRIPTION
This adds depmod to the rootfs builder to get the dependencies for kernel modules, namely for the efi_secret module needed for sev.

In order to maintain compatibility with the local build docker environment, a few dependencies are needed.