### PR TITLE
CC, kata-deploy: add kata-qemu-sev runtimeclass

### DIFF
--- a/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
@@ -14,6 +14,7 @@ containerd_conf_file_backup="${containerd_conf_file}.bak"
 shims=(
 	"qemu"
 	"qemu-tdx"
+	"qemu-sev"
 	"clh"
 	"clh-tdx"
 )


### PR DESCRIPTION
Adds to the configuration of containerd so the correct config is selected.

Fixes: #4851

Signed-Off-By: Alex Carter <alex.carter@ibm.com>