### PR TITLE
initramfs: Add build script to generate initramfs

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -23,6 +23,7 @@ readonly versions_yaml="${repo_root_dir}/versions.yaml"
 
 readonly clh_builder="${static_build_dir}/cloud-hypervisor/build-static-clh.sh"
 readonly firecracker_builder="${static_build_dir}/firecracker/build-static-firecracker.sh"
+readonly initramfs_builder="${static_build_dir}/initramfs/build.sh"
 readonly kernel_builder="${static_build_dir}/kernel/build.sh"
 readonly ovmf_builder="${static_build_dir}/ovmf/build.sh"
 readonly qemu_builder="${static_build_dir}/qemu/build-static-qemu.sh"
@@ -133,6 +134,8 @@ install_cc_sev_image() {
 install_cc_kernel() {
 	export KATA_BUILD_CC=yes
 
+	info "build initramfs for cc kernel"
+	"${initramfs_builder}"
 	export kernel_version="$(yq r $versions_yaml assets.kernel.version)"
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -f -v "${kernel_version}"
 }
@@ -183,6 +186,8 @@ install_cc_tee_kernel() {
 
 	[[ "${tee}" != "tdx" && "${tee}" != "sev" ]] && die "Non supported TEE"
 
+	info "build initramfs for tee kernel"
+	"${initramfs_builder}"
 	kernel_url="$(yq r $versions_yaml assets.kernel.${tee}.url)"
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -x "${tee}" -v "${kernel_version}" -u "${kernel_url}"
 }

--- a/tools/packaging/static-build/initramfs/Dockerfile
+++ b/tools/packaging/static-build/initramfs/Dockerfile
@@ -1,0 +1,38 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+from ubuntu:20.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+RUN apt-get update &&\
+    apt-get --no-install-recommends install -y software-properties-common &&\
+    add-apt-repository ppa:git-core/ppa -y &&\
+    apt-get update && apt-get upgrade -y && \
+    apt-get --no-install-recommends install -y \
+	    apt-utils \
+	    asciidoctor \
+	    autoconf \
+            autopoint \
+	    automake \
+	    busybox-static \
+	    ca-certificates \
+	    curl \
+	    gcc \
+	    gettext \
+	    git \
+	    libaio-dev \
+	    libblkid-dev \
+	    libselinux1-dev \
+	    libtool \
+            libpopt-dev \
+            libjson-c-dev \
+	    libssl-dev \
+	    make \
+	    ninja-build \
+	    pkg-config \
+	    uuid-dev \
+	    libseccomp-dev \
+	    libseccomp2 \
+	    zlib1g-dev &&\
+    apt-get clean && rm -rf /var/lib/apt/lists/

--- a/tools/packaging/static-build/initramfs/build-initramfs.sh
+++ b/tools/packaging/static-build/initramfs/build-initramfs.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+#
+# Copyright (c) 2022 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${script_dir}/../../scripts/lib.sh"
+install_dir="${1:-.}"
+
+cryptsetup_repo="${cryptsetup_repo:-}"
+cryptsetup_version="${cryptsetup_version:-}"
+lvm2_repo="${lvm2_repo:-}"
+lvm2_version="${lvm2_version:-}"
+
+[ -n "${cryptsetup_repo}" ] || die "Failed to get cryptsetup repo"
+[ -n "${cryptsetup_version}" ] || die "Failed to get cryptsetup version"
+[ -n "${lvm2_repo}" ] || die "Failed to get lvm2 repo"
+[ -n "${lvm2_version}" ] || die "Failed to get lvm2 version"
+
+build_root=$(mktemp -d)
+pushd ${build_root}
+
+info "Build ${lvm2_repo} version: ${lvm2_version}"
+git clone --depth 1 --branch "${lvm2_version}" "${lvm2_repo}" lvm2
+pushd lvm2
+./configure --enable-static_link --disable-selinux
+make && make install
+cp ./libdm/libdevmapper.pc /usr/lib/pkgconfig/devmapper.pc
+popd #lvm2
+
+info "Build ${cryptsetup_repo} version: ${cryptsetup_version}"
+git clone --depth 1 --branch "${cryptsetup_version}" "${cryptsetup_repo}" cryptsetup
+pushd cryptsetup
+./autogen.sh
+./configure  --enable-static --enable-static-cryptsetup --disable-udev --disable-external-tokens --disable-ssh-token
+make && make install
+strip /usr/sbin/veritysetup.static
+popd #cryptsetup
+
+info "Build gen_init_cpio tool"
+git clone --depth 1 --filter=blob:none --sparse https://github.com/torvalds/linux.git
+pushd linux
+git sparse-checkout add usr && cd usr && make gen_init_cpio
+install gen_init_cpio /usr/sbin/
+popd #linux
+
+popd #${build_root}
+
+install "${script_dir}/init.sh" /usr/sbin/
+gen_init_cpio "${script_dir}/initramfs.list" | gzip -9 -n > "${install_dir}"/initramfs.cpio.gz

--- a/tools/packaging/static-build/initramfs/build.sh
+++ b/tools/packaging/static-build/initramfs/build.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
+readonly initramfs_builder="${script_dir}/build-initramfs.sh"
+readonly default_install_dir="$(cd "${script_dir}/../../kernel" && pwd)"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+container_image="kata-initramfs-builder"
+kata_version="${kata_version:-}"
+cryptsetup_repo="${cryptsetup_repo:-}"
+cryptsetup_version="${cryptsetup_version:-}"
+lvm2_repo="${lvm2_repo:-}"
+lvm2_version="${lvm2_version:-}"
+package_output_dir="${package_output_dir:-}"
+
+[ -n "${cryptsetup_repo}" ] || cryptsetup_repo=$(get_from_kata_deps "externals.cryptsetup.url" "${kata_version}")
+[ -n "${cryptsetup_version}" ] || cryptsetup_version=$(get_from_kata_deps "externals.cryptsetup.version" "${kata_version}")
+[ -n "${lvm2_repo}" ] || lvm2_repo=$(get_from_kata_deps "externals.lvm2.url" "${kata_version}")
+[ -n "${lvm2_version}" ] || lvm2_version=$(get_from_kata_deps "externals.lvm2.version" "${kata_version}")
+
+[ -n "${cryptsetup_repo}" ] || die "Failed to get cryptsetup repo"
+[ -n "${cryptsetup_version}" ] || die "Failed to get cryptsetup version"
+[ -n "${lvm2_repo}" ] || die "Failed to get lvm2 repo"
+[ -n "${lvm2_version}" ] || die "Failed to get lvm2 version"
+
+sudo docker build \
+	-t "${container_image}" "${script_dir}"
+
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${PWD}" \
+	--env cryptsetup_repo="${cryptsetup_repo}" \
+	--env cryptsetup_version="${cryptsetup_version}" \
+	--env lvm2_repo="${lvm2_repo}" \
+	--env lvm2_version="${lvm2_version}" \
+	"${container_image}" \
+	bash -c "${initramfs_builder} ${default_install_dir}"

--- a/tools/packaging/static-build/initramfs/init.sh
+++ b/tools/packaging/static-build/initramfs/init.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+#
+# Copyright (c) 2022 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+[ -d /dev ] || mkdir -m 0755 /dev
+[ -d /root ] || mkdir -m 0700 /root
+[ -d /sys ] || mkdir /sys
+[ -d /proc ] || mkdir /proc
+[ -d /mnt ] || mkdir /mnt
+[ -d /tmp ] || mkdir /tmp
+
+mount -t sysfs -o nodev,noexec,nosuid sysfs /sys
+mount -t proc -o nodev,noexec,nosuid proc /proc
+
+echo "/sbin/mdev" > /proc/sys/kernel/hotplug
+mdev -s
+
+get_option() {
+    local value
+    value=" $(cat /proc/cmdline) "
+    value="${value##* ${1}=}"
+    value="${value%% *}"
+    [ "${value}" != "" ] && echo "${value}"
+}
+
+rootfs_verifier=$(get_option cc_rootfs_verity.scheme)
+rootfs_hash=$(get_option cc_rootfs_verity.hash)
+root_device=$(get_option root)
+hash_device=${root_device%?}2
+
+if [ -e ${root_device} ] && [ -e ${hash_device} ] && [ "${rootfs_verifier}" = "dm-verity" ]
+then
+    veritysetup open "${root_device}" root "${hash_device}" "${rootfs_hash}"
+    mount /dev/mapper/root /mnt
+else
+    echo "No LUKS device found"
+    mount "${root_device}" /mnt
+fi
+
+umount /proc
+umount /sys
+exec switch_root /mnt /sbin/init

--- a/tools/packaging/static-build/initramfs/initramfs.list
+++ b/tools/packaging/static-build/initramfs/initramfs.list
@@ -1,0 +1,21 @@
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# initramfs to setup verified boot for rootfs
+dir /dev 0755 0 0
+dir /root 0700 0 0
+dir /sbin 0755 0 0
+dir /bin 0755 0 0
+dir /run 0755 0 0
+dir /mnt 0755 0 0
+file /init /usr/sbin/init.sh 0755 0 0
+file /sbin/busybox /usr/bin/busybox 0755 0 0
+file /sbin/veritysetup /usr/sbin/veritysetup.static 0755 0 0
+slink /bin/sh /sbin/busybox 0755 0 0
+slink /sbin/mount /sbin/busybox 0755 0 0
+slink /bin/mkdir /sbin/busybox 0755 0 0
+slink /sbin/mdev /sbin/busybox 0755 0 0
+slink /sbin/switch_root /sbin/busybox 0755 0 0
+slink /sbin/umount /sbin/busybox 0755 0 0
+slink /sbin/cat /sbin/busybox 0755 0 0

--- a/versions.yaml
+++ b/versions.yaml
@@ -219,10 +219,20 @@ externals:
     url: "https://github.com/kubernetes-sigs/cri-tools"
     version: "1.23.0"
 
+  cryptsetup:
+    description: "A utility used to setup disk encryption, integrity protection"
+    url: "https://gitlab.com/cryptsetup/cryptsetup"
+    version: "v2.5.0"
+
   gperf:
     description: "GNU gperf is a perfect hash function generator"
     url: "http://ftp.gnu.org/pub/gnu/gperf/"
     version: "3.1"
+
+  lvm2:
+    description: "LVM2 and device-mapper tools and libraries"
+    url: "https://github.com/lvmteam/lvm2"
+    version: "v2_03_16"
 
   kubernetes:
     description: "Kubernetes project container manager"


### PR DESCRIPTION
For https://github.com/confidential-containers/documentation/issues/40#top, we need an initramfs to measure the rootfs with different verity scheme like `dm-verity`.

The init.sh in initramfs will parse the verity scheme, roothash, root device and setup the root device accordingly.
All cryptsetup related binaries are build staticly.

Fixes: #5135

Signed-off-by: Wang, Arron <arron.wang@intel.com>