### PR TITLE
CC add tarball naming option when untarring in get_tee_kernel

### DIFF
--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -136,7 +136,9 @@ get_tee_kernel() {
 	curl --fail -OL "${kernel_url}/linux-${kernel_tarball}" || curl --fail -OL "${kernel_url}/${kernel_tarball}"
 	
 	mkdir -p ${kernel_path}
-	tar --strip-components=1 -xf ${kernel_tarball} -C ${kernel_path}
+
+	#try both tarball name options before failing
+	tar --strip-components=1 -xf ${kernel_tarball} -C ${kernel_path} || tar --strip-components=1 -xf "linux-${kernel_tarball}" -C ${kernel_path}
 }
 
 get_kernel() {


### PR DESCRIPTION
In the kernel builder for tee tarballs there are currently two ptions checked when trying to pull a tarball.

Also trying these two options (with or without 'linux-') when untarring.

Fixes: #5139

Signed-off-by: Alex Carter <Alex.Carter@ibm.com>