### PR TITLE
runtime-rs: fix host device check pattern

### DIFF
--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -121,7 +121,7 @@ fn is_host_device(dest: &str) -> bool {
         return true;
     }
 
-    if dest.starts_with("/dev") {
+    if dest.starts_with("/dev/") {
         let src = match std::fs::canonicalize(dest) {
             Err(_) => return false,
             Ok(src) => src,


### PR DESCRIPTION
Host devices should start with `/dev/` but not `/dev`.

Fixes: #5145

Signed-off-by: bin liu <liubin0329@gmail.com>