### PR TITLE
runtime-rs: remove meaningless comment

### DIFF
--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -138,7 +138,6 @@ fn is_host_device(dest: &str) -> bool {
 }
 
 // Note, don't generate random name, attaching rafs depends on the predictable name.
-// If template_mnt is passed, just use existed name in it
 pub fn generate_mount_path(id: &str, file_name: &str) -> String {
     let mut nid = String::from(id);
     if nid.len() > 10 {


### PR DESCRIPTION
The comment for `generate_mount_path` function is a copy miss and should be deleted.

Fixes: #5150

Signed-off-by: Bin Liu <bin@hyper.sh>