### PR TITLE
runtime: using threaded mode to manage cgroupv2

### DIFF
--- a/src/runtime/pkg/resourcecontrol/cgroups_darwin.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups_darwin.go
@@ -17,7 +17,7 @@ func RenameCgroupPath(path string) (string, error) {
 	return "", errors.New("RenameCgroupPath not supported on Darwin")
 }
 
-func NewResourceController(path string, resources *specs.LinuxResources) (ResourceController, error) {
+func NewResourceController(path string, resources *specs.LinuxResources, sandboxCgroupOnly bool) (ResourceController, error) {
 	return &DarwinResourceController{}, nil
 }
 
@@ -25,7 +25,7 @@ func NewSandboxResourceController(path string, resources *specs.LinuxResources, 
 	return &DarwinResourceController{}, nil
 }
 
-func LoadResourceController(path string) (ResourceController, error) {
+func LoadResourceController(path string, sandboxCgroupOnly bool) (ResourceController, error) {
 	return &DarwinResourceController{}, nil
 }
 
@@ -53,7 +53,7 @@ func (c *DarwinResourceController) Update(resources *specs.LinuxResources) error
 	return nil
 }
 
-func (c *DarwinResourceController) MoveTo(path string) error {
+func (c *DarwinResourceController) MoveTo(path string, sandboxCgroupOnly bool) error {
 	return nil
 }
 
@@ -83,4 +83,8 @@ func (c *DarwinResourceController) UpdateCpuSet(cpuset, memset string) error {
 
 func (c *DarwinResourceController) Path() string {
 	return ""
+}
+
+func (c *DarwinResourceController) CgroupType() (string, error) {
+	return "", nil
 }

--- a/src/runtime/pkg/resourcecontrol/controller.go
+++ b/src/runtime/pkg/resourcecontrol/controller.go
@@ -45,7 +45,7 @@ type ResourceController interface {
 	// Type returns the resource controller implementation type.
 	Type() ResourceControllerType
 
-	// The controller identifier, e.g. a Linux cgroups path.
+	// ID return the controller identifier, e.g. a Linux cgroups path.
 	ID() string
 
 	// Parent returns the parent controller, on hierarchically
@@ -69,7 +69,7 @@ type ResourceController interface {
 	Update(*specs.LinuxResources) error
 
 	// MoveTo moves a controller to another one.
-	MoveTo(string) error
+	MoveTo(string, bool) error
 
 	// AddDevice adds a device resource to the controller.
 	AddDevice(string) error
@@ -79,4 +79,7 @@ type ResourceController interface {
 
 	// UpdateCpuSet updates the set of controlled CPUs and memory nodes.
 	UpdateCpuSet(string, string) error
+
+	// CgroupType get cgroup type.
+	CgroupType() (string, error)
 }


### PR DESCRIPTION
In the current cgroupv2, because the process mode cannot separate processes and threads into different cgroups, the vmm process is incorrectly added to the sandbox cgroup. The sandbox and overhead are placed in the same cgroup through thread mode to realize that the vCPU thread is placed in the sandbox and other processes are placed in the overhead.

![image](https://user-images.githubusercontent.com/35447132/189343729-a7d90ef0-c36a-46c1-9db0-f243115a6dd6.png)

Fixes: #4886

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>