### PR TITLE
kernel: Add crypto kernel config for s390

### DIFF
--- a/tools/packaging/kernel/configs/fragments/s390/crypto.conf
+++ b/tools/packaging/kernel/configs/fragments/s390/crypto.conf
@@ -30,3 +30,16 @@ CONFIG_CRYPTO_AES_S390=y
 CONFIG_CRYPTO_CRC32_S390=y
 # Pseudo random number generator device driver
 CONFIG_S390_PRNG=y
+
+# Support for Galois/Counter Mode (GCM)
+CONFIG_CRYPTO_GCM=y
+# SHA3 and its variants for s390
+CONFIG_CRYPTO_SHA3=y
+CONFIG_CRYPTO_SHA3_256_S390=y
+CONFIG_CRYPTO_SHA3_512_S390=y
+# Support for ChaCha stream cipher algorithms
+CONFIG_CRYPTO_CHACHA20=y
+CONFIG_CRYPTO_CHACHA20POLY1305=y
+CONFIG_CRYPTO_CHACHA_S390=y
+# When PKEY is enabled and dm-crypt wants to use protected keys
+CONFIG_CRYPTO_PAES_S390=y


### PR DESCRIPTION
This config update supports new crypto algorithms for s390.

Fixes: kata-containers#5158

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>