### PR TITLE
kata-deploy: rename make target for sev initrd

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -90,7 +90,7 @@ options:
 	cc-qemu
 	cc-tdx-qemu
 	cc-rootfs-image
-	cc-sev-initrd-image
+	cc-sev-rootfs-initrd
 	cc-shimv2
 	cc-virtiofsd
 	cc-sev-ovmf
@@ -335,7 +335,7 @@ handle_build() {
 
 	cc-rootfs-image) install_cc_image ;;
 
-	cc-sev-initrd-image) install_cc_sev_image ;;
+	cc-sev-rootfs-initrd) install_cc_sev_image ;;
 
 	cc-shim-v2) install_cc_shimv2 ;;
 


### PR DESCRIPTION
The sev initrd target had been changed to "cc-sev-rootfs-initrd". This was good discussion as part of #5120.
I failed to rename it from "cc-sev-initrd-image" in kata-deploy-binaries. The script will fail for a bad build target.

Fixes: #5166

Signed-Off-By: Alex Carter <alex.carter@ibm.com>