### PR TITLE
docs: Update url in virtualization document

### DIFF
--- a/docs/design/virtualization.md
+++ b/docs/design/virtualization.md
@@ -110,7 +110,7 @@ Devices and features used:
 - VFIO
 - hotplug
 - seccomp filters
-- [HTTP OpenAPI](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/master/vmm/src/api/openapi/cloud-hypervisor.yaml)
+- [HTTP OpenAPI](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/vmm/src/api/openapi/cloud-hypervisor.yaml)
 
 ### Summary
 


### PR DESCRIPTION
This PR updates the url for the cloud hypervisor in the virtualization document.

Fixes #5203

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>