### PR TITLE
versions: Bump golang to 1.19.x

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.18.x, 1.19.x]
         os: [macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.16.x, 1.17.x]
+        go-version: [1.18.x, 1.19.x]
         os: [ubuntu-20.04]
     runs-on: ${{ matrix.os }}
     env:

--- a/versions.yaml
+++ b/versions.yaml
@@ -295,12 +295,12 @@ languages:
     issue: "https://github.com/golang/go/issues/20676"
     uscan-url: >-
       https://github.com/golang/go/tags .*/go?([\d\.]+)\.tar\.gz
-    version: "1.16.10"
+    version: "1.18.6"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.17.3"
+      newest-version: "1.19.1"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
golang 1.17.x is no longer supported as of Aug 2022 according to https://endoflife.date/go
Bumping the minimum version supported to 1.18.6 and the newest version supported to 1.19.1.

Fixes: #5210

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>