### PR TITLE
versions: Update container runtime monitor version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -184,7 +184,7 @@ externals:
   conmon:
     description: "An OCI container runtime monitor"
     url: "https://github.com/containers/conmon"
-    version: "v2.0.5"
+    version: "v2.1.4"
 
   crio:
     description: |


### PR DESCRIPTION
This PR updates the container runtime monitor version that we are currently using for kata containers.

Fixes #5224

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>