### PR TITLE
hypervisor:arm: gic v2 max support 8 arm core

### DIFF
--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -30,7 +30,7 @@ const defaultQemuMachineType = QemuVirt
 
 const qmpMigrationWaitTimeout = 10 * time.Second
 
-const defaultQemuMachineOptions = "usb=off,accel=kvm,gic-version=host"
+const defaultQemuMachineOptions = "usb=off,accel=kvm,gic-version=max"
 
 var kernelParams = []Param{
 	{"iommu.passthrough", "0"},


### PR DESCRIPTION
arm64 maxvcpus only support 8 arm cores, limited by gicv2. The gic v3/v4 support more arm cores. This patch update the gic version.

Fixes: #5226

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>