### PR TITLE
osbuilder: Export directory variables for libseccomp

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -575,8 +575,8 @@ EOF
 			info "Set up libseccomp"
 			detect_libseccomp_info || \
 				die "Could not detect the required libseccomp version and url"
-			libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
-			gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)
+			export libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
+			export gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)
 			${script_dir}/../../../ci/install_libseccomp.sh "${libseccomp_install_dir}" "${gperf_install_dir}"
 			echo "Set environment variables for the libseccomp crate to link the libseccomp library statically"
 			export LIBSECCOMP_LINK_TYPE=static


### PR DESCRIPTION
To avoid the random failures when we are building the rootfs as it seems that it does not find the value for the libseccomp and gperf directory, this PR export these variables.

Fixes #5232

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>