### PR TITLE
support hotplug/hot-unplug device

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-device.go
+++ b/src/runtime/cmd/kata-runtime/kata-device.go
@@ -1,0 +1,133 @@
+// Copyright (c) 2022 NetEase Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	containerdshim "github.com/kata-containers/kata-containers/src/runtime/pkg/containerd-shim-v2"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/utils/shimclient"
+	"github.com/urfave/cli"
+)
+
+var (
+	devPath string
+)
+
+var deviceSubCmds = []cli.Command{
+	listDeviceCommand,
+	attachDeviceCommand,
+	detachDeviceCOmmand,
+}
+
+var kataDeviceCommand = cli.Command{
+	Name:        "device",
+	Usage:       "attach or detach device to or from Kata Containers",
+	Subcommands: deviceSubCmds,
+	Action: func(context *cli.Context) {
+		cli.ShowSubcommandHelp(context)
+	},
+}
+
+var listDeviceCommand = cli.Command{
+	Name:  "list",
+	Usage: "list all assigned device",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:        "sandbox-id",
+			Usage:       "the target sandbox for getting the devices",
+			Required:    true,
+			Destination: &sandboxID,
+		},
+	},
+	Action: func(c *cli.Context) error {
+		// verify sandbox exists:
+		if err := katautils.VerifyContainerID(sandboxID); err != nil {
+			return err
+		}
+
+		url := containerdshim.DeviceUrl
+
+		body, err := shimclient.DoGet(sandboxID, defaultTimeout, url)
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(body))
+		return nil
+	},
+}
+
+var attachDeviceCommand = cli.Command{
+	Name:  "attach",
+	Usage: "attach the device to sandbox",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:        "sandbox-id",
+			Usage:       "the target sandbox for attach the device",
+			Required:    true,
+			Destination: &sandboxID,
+		},
+		cli.StringFlag{
+			Name:        "device",
+			Usage:       "absolute path of the device on the host",
+			Required:    true,
+			Destination: &devPath,
+		},
+	},
+	Action: func(c *cli.Context) error {
+		// verify sandbox exists:
+		if err := katautils.VerifyContainerID(sandboxID); err != nil {
+			return err
+		}
+
+		resizeReq := containerdshim.DeviceRequest{
+			DevicePath: devPath,
+		}
+		encoded, err := json.Marshal(resizeReq)
+		if err != nil {
+			return err
+		}
+
+		return shimclient.DoPut(sandboxID, defaultTimeout*10, containerdshim.DeviceUrl, "application/json", encoded)
+	},
+}
+
+var detachDeviceCOmmand = cli.Command{
+	Name:  "detach",
+	Usage: "detach the device from sandbox",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:        "sandbox-id",
+			Usage:       "the target sandbox for detach the device",
+			Required:    true,
+			Destination: &sandboxID,
+		},
+		cli.StringFlag{
+			Name:        "device",
+			Usage:       "absolute path of the device on the host",
+			Required:    true,
+			Destination: &devPath,
+		},
+	},
+	Action: func(c *cli.Context) error {
+		// verify sandbox exists:
+		if err := katautils.VerifyContainerID(sandboxID); err != nil {
+			return err
+		}
+
+		resizeReq := containerdshim.DeviceRequest{
+			DevicePath: devPath,
+		}
+		encoded, err := json.Marshal(resizeReq)
+		if err != nil {
+			return err
+		}
+
+		return shimclient.DoDelete(sandboxID, defaultTimeout*10, containerdshim.DeviceUrl, "application/json", encoded)
+	},
+}

--- a/src/runtime/cmd/kata-runtime/main.go
+++ b/src/runtime/cmd/kata-runtime/main.go
@@ -126,6 +126,7 @@ var runtimeCommands = []cli.Command{
 	factoryCLICommand,
 	kataVolumeCommand,
 	kataIPTablesCommand,
+	kataDeviceCommand,
 }
 
 // runtimeBeforeSubcommands is the function to run before command-line

--- a/src/runtime/pkg/katautils/utils_unix.go
+++ b/src/runtime/pkg/katautils/utils_unix.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2022 NetEase Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package katautils
+
+import (
+	"fmt"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+func GetDeviceInfoByPath(devPath string) (config.DeviceInfo, error) {
+	var devInfo *config.DeviceInfo
+	stat, err := os.Stat(devPath)
+	if err != nil {
+		return *devInfo, fmt.Errorf("error stating device path: %w", err)
+	}
+
+	if stat.IsDir() {
+		return *devInfo, fmt.Errorf("the device path is a directory: %s", devPath)
+	}
+
+	devInfo, err = DeviceFromPath(devPath)
+	if err != nil {
+		return *devInfo, err
+	}
+	return *devInfo, nil
+}
+
+const (
+	wildcardDevice = "a" //nolint // currently unused, but should be included when upstreaming to OCI runtime-spec.
+	blockDevice    = "b"
+	charDevice     = "c" // or "u"
+	fifoDevice     = "p"
+)
+
+// DeviceFromPath takes the path to a device to look up the information about a
+// linux device and returns that information as a config.DeviceInfo struct.
+func DeviceFromPath(path string) (*config.DeviceInfo, error) {
+	var stat unix.Stat_t
+	if err := unix.Lstat(path, &stat); err != nil {
+		return nil, err
+	}
+
+	var (
+		devNumber = uint64(stat.Rdev) //nolint: unconvert // the type is 32bit on mips.
+		major     = unix.Major(devNumber)
+		minor     = unix.Minor(devNumber)
+	)
+
+	var (
+		devType string
+		mode    = stat.Mode
+	)
+
+	switch mode & unix.S_IFMT {
+	case unix.S_IFBLK:
+		devType = blockDevice
+	case unix.S_IFCHR:
+		devType = charDevice
+	case unix.S_IFIFO:
+		devType = fifoDevice
+	default:
+		return nil, fmt.Errorf("not a device node")
+	}
+
+	// only get the permission bits for the device. ignore the type bits.
+	fileMode := os.FileMode(mode &^ unix.S_IFMT)
+
+	deviceInfo := &config.DeviceInfo{
+		ContainerPath: path,
+		DevType:       devType,
+		Major:         int64(major),
+		Minor:         int64(minor),
+		UID:           stat.Uid,
+		GID:           stat.Gid,
+		FileMode:      fileMode,
+	}
+
+	return deviceInfo, nil
+}

--- a/src/runtime/pkg/utils/shimclient/shim_management_client.go
+++ b/src/runtime/pkg/utils/shimclient/shim_management_client.go
@@ -123,3 +123,35 @@ func DoPost(sandboxID string, timeoutInSeconds time.Duration, urlPath, contentTy
 
 	return nil
 }
+
+// DoDelete will make a DELETE request to the shim endpoint that handles the given sandbox ID
+func DoDelete(sandboxID string, timeoutInSeconds time.Duration, urlPath, contentType string, payload []byte) error {
+	client, err := BuildShimClient(sandboxID, timeoutInSeconds)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("http://shim%s", urlPath), bytes.NewBuffer(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", contentType)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if resp != nil {
+			resp.Body.Close()
+		}
+	}()
+
+	if resp.StatusCode != http.StatusOK {
+		data, _ := ioutil.ReadAll(resp.Body)
+		return fmt.Errorf("error sending post: url: %s, status code: %d, response data: %s", urlPath, resp.StatusCode, string(data))
+	}
+
+	return nil
+}

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -82,6 +82,10 @@ type VCSandbox interface {
 
 	GetIPTables(ctx context.Context, isIPv6 bool) ([]byte, error)
 	SetIPTables(ctx context.Context, isIPv6 bool, data []byte) error
+
+	ListDevice() []api.Device
+	AttachDevice(ctx context.Context, devInfo config.DeviceInfo) error
+	DetachDevice(ctx context.Context, devPath string) error
 }
 
 // VCContainer is the Container interface

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -269,3 +269,15 @@ func (s *Sandbox) GetIPTables(ctx context.Context, isIPv6 bool) ([]byte, error) 
 func (s *Sandbox) SetIPTables(ctx context.Context, isIPv6 bool, data []byte) error {
 	return nil
 }
+
+func (s *Sandbox) ListDevice() []api.Device {
+	return nil
+}
+
+func (s *Sandbox) AttachDevice(ctx context.Context, devInfo config.DeviceInfo) error {
+	return nil
+}
+
+func (s *Sandbox) DetachDevice(ctx context.Context, devPath string) error {
+	return nil
+}


### PR DESCRIPTION
In serverless scenarios, we need to hot plug/unplug GPUs Device dynamically into kata container without container restart, to implement the GPUs dynamically assign between different kata containers. 
we will manage GPU resources independent of the upper-level container manager(containerd/k8s), and they will be controlled by other components that will hotplug GPU to applications.
Fixes: https://github.com/kata-containers/kata-containers/issues/5172

This PR is aimed at expose the attach/detach interface to the user via `kata-runtime` command, then allowing users to hotplug or hot-unplug Devices. it is similar to `kata -runtime direct-volume` command:

```
kata-runtime device list --sandbox-id=${sandbox-id}
kata-runtime device attach --sandbox-id=$sandbox-id --device=$path_to_device"
kata-runtime device detach --sandbox-id=$sandbox-id --device=$path_to_device"
```




Signed-off-by: soulseen <zhuxiaoyang1996@gmail.com>