### PR TITLE
osbuilder: don't pull in umoci with attestation

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -665,10 +665,6 @@ EOF
 	fi
 
     if [ -n "${AA_KBC}" ]; then
-        if [ "${UMOCI}" != "yes" ]; then
-          UMOCI="yes"
-          warning "UMOCI wasn't set, but is required for attestation, so overridden"
-        fi
 		if [ "${AA_KBC}" == "offline_sev_kbc" ]; then
 			info "Adding agent config for ${AA_KBC}"
 			AA_KBC_PARAMS="offline_sev_kbc::null" envsubst < "${script_dir}/agent-config.toml.in" | tee "${ROOTFS_DIR}/etc/agent-config.toml"


### PR DESCRIPTION
Umoci is not longer required if we have the attestation-agent, so don't override the user input

Fixes: #5237
Signed-off-by: stevenhorsman <steven@uk.ibm.com>