### PR TITLE
runtime: add SingleContainer when obtaining OCI Spec

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -2576,11 +2576,11 @@ func (s *Sandbox) GetPatchedOCISpec() *specs.Spec {
 		return nil
 	}
 
-	// get the container associated with the PodSandbox annotation. In Kubernetes, this
-	// represents the pause container. In Docker, this is the container.
-	// On Linux, we derive the group path from this container.
+	// Get the container associated with the PodSandbox annotation.
+	// In Kubernetes, this represents the pause container. In Docker, this is the container.
+	// On Linux, we derive the cgroup path from this container.
 	for _, cConfig := range s.config.Containers {
-		if cConfig.Annotations[annotations.ContainerTypeKey] == string(PodSandbox) {
+		if ContainerType(cConfig.Annotations[annotations.ContainerTypeKey]).IsSandbox() {
 			return cConfig.CustomSpec
 		}
 	}


### PR DESCRIPTION
When creating a cgroup, add a SingleContainer when obtaining the OCI Spec to apply to ctr, podman, etc. If the CgroupPath is not obtained from the container config, the sandbox id is used as the cgroup path.

Fixes: #5240

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>