### PR TITLE
versions: Update gperf url to avoid libseccomp random failures

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -209,7 +209,7 @@ externals:
 
   gperf:
     description: "GNU gperf is a perfect hash function generator"
-    url: "https://ftpmirror.gnu.org/gnu/gperf"
+    url: "http://ftp.gnu.org/pub/gnu/gperf/"
     version: "3.1"
 
   kubernetes:


### PR DESCRIPTION
This PR updates the gperf url to avoid random failures when installing
libseccomp as it seems that the mirrror url produces network random
failures in multiple CIs.

Fixes #5294

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>