### PR TITLE
version: Update containerd version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -200,7 +200,7 @@ externals:
     # containerd from v1.5.0 used the path unix socket
     # instead of abstract socket, thus kata wouldn's support the containerd's
     # version older than them.
-    version: "v1.5.2"
+    version: "v1.6.8"
 
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"


### PR DESCRIPTION
This PR updates the containerd version that we are using for kata containers. This PR is needed as we will need to update the golang version which requires a newer containerd version to work properly.

Fixes #5247

Depends-on:github.com/https://github.com/kata-containers/tests/pull/5148

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>