### PR TITLE
Last backport for 2.5.2

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -335,6 +335,7 @@ func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig, sandboxId stri
 		return err
 	}
 	runtimeConfig.HypervisorConfig.Uid = uint32(uid)
+	runtimeConfig.HypervisorConfig.User = userName
 	runtimeConfig.HypervisorConfig.Gid = uint32(gid)
 	shimLog.WithFields(logrus.Fields{
 		"user_name":  userName,

--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -26,6 +26,7 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/rootless"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 
 	// only register the proto type
 	crioption "github.com/containerd/containerd/pkg/runtimeoptions/v1"
@@ -136,7 +137,7 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 		katautils.HandleFactory(ctx, vci, s.config)
 		rootless.SetRootless(s.config.HypervisorConfig.Rootless)
 		if rootless.IsRootless() {
-			if err := configureNonRootHypervisor(s.config); err != nil {
+			if err := configureNonRootHypervisor(s.config, r.ID); err != nil {
 				return nil, err
 			}
 		}
@@ -303,13 +304,17 @@ func doMount(mounts []*containerd_types.Mount, rootfs string) error {
 	return nil
 }
 
-func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig) error {
+func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig, sandboxId string) error {
 	userName, err := utils.CreateVmmUser()
 	if err != nil {
 		return err
 	}
 	defer func() {
 		if err != nil {
+			shimLog.WithFields(logrus.Fields{
+				"user_name":  userName,
+				"sandbox_id": sandboxId,
+			}).WithError(err).Warn("configure non root hypervisor failed, delete the user")
 			if err2 := utils.RemoveVmmUser(userName); err2 != nil {
 				shimLog.WithField("userName", userName).WithError(err).Warn("failed to remove user")
 			}
@@ -331,6 +336,12 @@ func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig) error {
 	}
 	runtimeConfig.HypervisorConfig.Uid = uint32(uid)
 	runtimeConfig.HypervisorConfig.Gid = uint32(gid)
+	shimLog.WithFields(logrus.Fields{
+		"user_name":  userName,
+		"uid":        uid,
+		"gid":        gid,
+		"sandbox_id": sandboxId,
+	}).Debug("successfully created a non root user for the hypervisor")
 
 	userTmpDir := path.Join("/run/user/", fmt.Sprint(uid))
 	_, err = os.Stat(userTmpDir)

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -371,6 +371,9 @@ type HypervisorConfig struct {
 	// SeccompSandbox is the qemu function which enables the seccomp feature
 	SeccompSandbox string
 
+	// The user maps to the uid.
+	User string
+
 	// KernelParams are additional guest kernel parameters.
 	KernelParams []Param
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1061,13 +1061,26 @@ func (q *qemu) cleanupVM() error {
 	if rootless.IsRootless() {
 		u, err := user.LookupId(strconv.Itoa(int(q.config.Uid)))
 		if err != nil {
-			q.Logger().WithError(err).WithField("uid", q.config.Uid).Warn("failed to find the user")
+			q.Logger().WithError(err).WithFields(
+				logrus.Fields{
+					"user": u.Username,
+					"uid":  q.config.Uid,
+				}).Warn("failed to find the user")
 			return nil
 		}
 
 		if err := pkgUtils.RemoveVmmUser(u.Username); err != nil {
-			q.Logger().WithError(err).WithField("user", u.Username).Warn("failed to delete the user")
+			q.Logger().WithError(err).WithFields(
+				logrus.Fields{
+					"user": u.Username,
+					"uid":  q.config.Uid,
+				}).Warn("failed to delete the user")
 		}
+		q.Logger().WithFields(
+			logrus.Fields{
+				"user": u.Username,
+				"uid":  q.config.Uid,
+			}).Debug("successfully removed the non root user")
 	}
 
 	return nil

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -110,6 +110,8 @@ type qemu struct {
 	nvdimmCount int
 
 	stopped bool
+
+	mu sync.Mutex
 }
 
 const (
@@ -968,6 +970,8 @@ func (q *qemu) waitVM(ctx context.Context, timeout int) error {
 
 // StopVM will stop the Sandbox's VM.
 func (q *qemu) StopVM(ctx context.Context, waitOnly bool) error {
+	q.mu.Lock()
+	defer q.mu.Unlock()
 	span, _ := katatrace.Trace(ctx, q.Logger(), "StopVM", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 


### PR DESCRIPTION
These are the remaining backports for 2.5.2 :

https://github.com/kata-containers/kata-containers/pull/5156 :
- 17dfa43691a3d232d324f3232fc42839f43a979c runtime: add more debug logs for non-root user operation
- 6c6701b136636e74d5926de92a38051a56fbcbaf runtime: make StopVM thread-safe
- 266f08c3be7b85e2004354a0268fd84e4c897c13 runtime: store the user name in hypervisor config