### PR TITLE
readme: remove libraries mentioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,8 @@ The table below lists the core parts of the project:
 | [runtime](src/runtime) | core | Main component run by a container manager and providing a containerd shimv2 runtime implementation. |
 | [runtime-rs](src/runtime-rs) | core | The Rust version runtime. |
 | [agent](src/agent) | core | Management process running inside the virtual machine / POD that sets up the container environment. |
-| [libraries](src/libs) | core | Library crates shared by multiple Kata Container components or published to [`crates.io`](https://crates.io/index.html) |
 | [`dragonball`](src/dragonball) | core | An optional built-in VMM brings out-of-the-box Kata Containers experience with optimizations on container workloads |
 | [documentation](docs) | documentation | Documentation common to all components (such as design and install documentation). |
-| [libraries](src/libs) | core | Library crates shared by multiple Kata Container components or published to [`crates.io`](https://crates.io/index.html) |
 | [tests](https://github.com/kata-containers/tests) | tests | Excludes unit tests which live with the main code. |
 
 ### Additional components

--- a/src/runtime-rs/README.md
+++ b/src/runtime-rs/README.md
@@ -97,6 +97,10 @@ Currently, only built-in `Dragonball` has been implemented.
 
 Persist defines traits and functions to help different components save state to disk and load state from disk.
 
+### helper libraries
+
+Some helper libraries are maintained in [the library directory](../libs) so that they can be shared with other rust components.
+
 ## Build and install
 
 ```bash


### PR DESCRIPTION
There are two duplicated mentioning of the rust libraries in README.md. Let's just remove them all as the section is intended to list out core Kata components rather than general libraries.

Fixes: #5275