### PR TITLE
dragonball: update ut for kernel config

### DIFF
--- a/src/dragonball/src/vm/kernel_config.rs
+++ b/src/dragonball/src/vm/kernel_config.rs
@@ -66,7 +66,7 @@ mod tests {
         cmdline.insert_str("ro").unwrap();
         let mut info = KernelConfigInfo::new(kernel.into_file(), Some(initrd.into_file()), cmdline);
 
-        assert_eq!(info.cmdline.as_str(), "ro");
+        assert_eq!(info.cmdline.as_cstring().unwrap().as_bytes(), b"ro");
         assert!(info.initrd_file_mut().is_some());
     }
 }


### PR DESCRIPTION
Since linux loader is updated in the Dragonball and the api for Cmdline has been changed ( as_str() changed to as_cstring() ), we need to update unit test in Dragonball.

fixes: #5277

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>