### PR TITLE
dragonball: fix no "as_str" error on Arm

### DIFF
--- a/src/dragonball/src/vm/aarch64.rs
+++ b/src/dragonball/src/vm/aarch64.rs
@@ -136,7 +136,7 @@ impl Vm {
 
         configure_system(
             guest_memory,
-            cmdline.as_str(),
+            cmdline.as_cstring().unwrap().to_str().unwrap(),
             vcpu_mpidr,
             self.device_manager.get_mmio_device_info(),
             self.get_irqchip(),


### PR DESCRIPTION
Cmdline struct update in the latest linux-loader lib and its as_str method is changed to as_cstring, thus we need fix it according whereas the old as_str method is used.

Fixes: #5287
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>