### PR TITLE
tools: release: fix bogus version check

### DIFF
--- a/tools/packaging/release/update-repository-version.sh
+++ b/tools/packaging/release/update-repository-version.sh
@@ -191,7 +191,7 @@ bump_repo() {
 
 				need_commit=true
 			fi
-		elif [ "${new_version}" != *"rc"* ]; then
+		elif [[ ! "${new_version}" =~ "rc" ]]; then
 			## We are on a stable branch and creating new stable releases.
 			## Need to change kata-deploy / kata-cleanup to use the stable tags.
 			if [[ "${version_to_replace}" =~ "rc" ]]; then


### PR DESCRIPTION
Shell expands `*"rc"*` to the top-level `src` directory. This results in comparing a version with a directory name. This doesn't make sense and causes the script to choose the wrong branch of the `if`.

The intent of the check is actually to detect `rc` in the version.

Fixes: #5283
Signed-off-by: Greg Kurz <groug@kaod.org>
(cherry picked from commit 421729f99136522a76ce199947a0a197a1d07801)
Signed-off-by: Greg Kurz <groug@kaod.org>