### PR TITLE
versions: Update oci version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -340,7 +340,7 @@ specs:
     uscan-url: >-
       https://github.com/opencontainers/runtime-spec/tags
       .*/v?(\d\S+)\.tar\.gz
-    version: "v1.0.0-rc5"
+    version: "v1.0.2"
 
 plugins:
   description: |


### PR DESCRIPTION
This PR updates the oci version that we are using in kata containers.

Fixes #5291

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>