### PR TITLE
feat(Tracing): tracing in Rust runtime

### DIFF
--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -89,6 +89,25 @@ Containers agent:
   The [Jaeger "all-in-one" Docker image][jaeger-all-in-one] method
   is the quickest and simplest way to run the collector for testing.
 
+  - It is worth noting that the **default collector endpoint** url 
+    is set to http://localhost:14268/api/traces
+    When custom endpoint url is used, make sure you are setting the correct
+    collector port
+
+  - Following is a example command to run all jaeger parts in a docker
+    container.
+    ```shell
+    docker run -d -e COLLECTOR_ZIPKIN_HTTP_PORT=9411 \
+    -p5775:5775/udp \
+    -p6831:6831/udp \
+    -p6832:6832/udp \
+    -p5778:5778 \
+    -p16686:16686 \
+    -p14268:14268 \
+    -p9411:9411 \
+    jaegertracing/all-in-one:latest
+    ```
+
 - If you wish to trace the agent, you must start the
   [trace forwarder][trace-forwarder].
 

--- a/src/runtime-rs/crates/agent/Cargo.toml
+++ b/src/runtime-rs/crates/agent/Cargo.toml
@@ -19,6 +19,7 @@ slog = "2.5.2"
 slog-scope = "4.4.0"
 ttrpc = { version = "0.6.1" }
 tokio = { version = "1.8.0", features = ["fs", "rt"] }
+tracing = "0.1.36"
 url = "2.2.2"
 
 kata-types = { path = "../../../libs/kata-types"}

--- a/src/runtime-rs/crates/agent/src/kata/agent.rs
+++ b/src/runtime-rs/crates/agent/src/kata/agent.rs
@@ -6,6 +6,7 @@
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
+use tracing::instrument;
 use ttrpc::context as ttrpc_ctx;
 
 use kata_types::config::Agent as AgentConfig;
@@ -22,6 +23,7 @@ fn new_ttrpc_ctx(timeout: i64) -> ttrpc_ctx::Context {
 
 #[async_trait]
 impl AgentManager for KataAgent {
+    #[instrument]
     async fn start(&self, address: &str) -> Result<()> {
         info!(sl!(), "begin to connect agent {:?}", address);
         self.set_socket_address(address)
@@ -73,6 +75,7 @@ macro_rules! impl_agent {
     ($($name: tt | $req: ty | $resp: ty | $new_timeout: expr),*) => {
         #[async_trait]
         impl Agent for KataAgent {
+            #[instrument(skip(req))]
             $(async fn $name(&self, req: $req) -> Result<$resp> {
                 let r = req.into();
                 let (mut client, mut timeout, _) = self.get_agent_client().await.context("get client")?;

--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -44,6 +44,19 @@ pub(crate) struct KataAgentInner {
     log_forwarder: LogForwarder,
 }
 
+impl std::fmt::Debug for KataAgentInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KataAgentInner")
+            .field("client_fd", &self.client_fd)
+            .field("socket_address", &self.socket_address)
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
+unsafe impl Send for KataAgent {}
+unsafe impl Sync for KataAgent {}
+#[derive(Debug)]
 pub struct KataAgent {
     pub(crate) inner: Arc<RwLock<KataAgentInner>>,
 }

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -22,6 +22,7 @@ slog = "2.5.2"
 slog-scope = "4.4.0"
 thiserror = "1.0"
 tokio = { version = "1.8.0", features = ["sync"] }
+tracing = "0.1.36"
 vmm-sys-util = "0.10.0"
 
 kata-sys-util = { path = "../../../libs/kata-sys-util" }

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -18,6 +18,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 use tokio::sync::RwLock;
+use tracing::instrument;
 
 use crate::{device::Device, Hypervisor, VcpuThreadIds};
 
@@ -25,6 +26,12 @@ unsafe impl Send for Dragonball {}
 unsafe impl Sync for Dragonball {}
 pub struct Dragonball {
     inner: Arc<RwLock<DragonballInner>>,
+}
+
+impl std::fmt::Debug for Dragonball {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Dragonball").finish()
+    }
 }
 
 impl Default for Dragonball {
@@ -48,11 +55,13 @@ impl Dragonball {
 
 #[async_trait]
 impl Hypervisor for Dragonball {
+    #[instrument]
     async fn prepare_vm(&self, id: &str, netns: Option<String>) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner.prepare_vm(id, netns).await
     }
 
+    #[instrument]
     async fn start_vm(&self, timeout: i32) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner.start_vm(timeout).await

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -26,6 +26,7 @@ serde = { version = "1.0.138", features = ["derive"] }
 slog = "2.5.2"
 slog-scope = "4.4.0"
 tokio = { version = "1.8.0", features = ["process"] }
+tracing = "0.1.36"
 uuid = { version = "0.4", features = ["v4"] }
 
 agent = { path = "../agent" }

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -16,6 +16,7 @@ use oci::LinuxResources;
 use persist::sandbox_persist::Persist;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tracing::instrument;
 
 pub struct ManagerArgs {
     pub sid: String,
@@ -26,6 +27,12 @@ pub struct ManagerArgs {
 
 pub struct ResourceManager {
     inner: Arc<RwLock<ResourceManagerInner>>,
+}
+
+impl std::fmt::Debug for ResourceManager {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ResourceManager").finish()
+    }
 }
 
 impl ResourceManager {
@@ -50,11 +57,13 @@ impl ResourceManager {
         inner.config()
     }
 
+    #[instrument]
     pub async fn prepare_before_start_vm(&self, device_configs: Vec<ResourceConfig>) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner.prepare_before_start_vm(device_configs).await
     }
 
+    #[instrument]
     pub async fn setup_after_start_vm(&self) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner.setup_after_start_vm().await

--- a/src/runtime-rs/crates/runtimes/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/Cargo.toml
@@ -11,6 +11,11 @@ lazy_static = "1.4.0"
 slog = "2.5.2"
 slog-scope = "4.4.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
+tracing = "0.1.36"
+tracing-opentelemetry = "0.18.0"
+opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread", "trace", "rt-tokio"] }
+opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio", "hyper_collector_client", "collector_client"] }
+tracing-subscriber = { version = "0.3", features = ["registry", "std"] }
 hyper = { version = "0.14.20", features = ["stream", "server", "http1"] }
 hyperlocal = "0.8"
 

--- a/src/runtime-rs/crates/runtimes/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/src/lib.rs
@@ -14,3 +14,4 @@ pub use manager::RuntimeHandlerManager;
 mod shim_mgmt;
 pub use shim_mgmt::{client::MgmtClient, server::sb_storage_path};
 mod static_resource;
+pub mod tracer;

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -288,7 +288,7 @@ impl RuntimeHandlerManager {
                 Ok(Response::KillProcess)
             }
             Request::ShutdownContainer(req) => {
-            if cm.need_shutdown_sandbox(&req).await {
+                if cm.need_shutdown_sandbox(&req).await {
                     sandbox.shutdown().await.context("do shutdown")?;
                     trace_exit_root();
                 }

--- a/src/runtime-rs/crates/runtimes/src/tracer.rs
+++ b/src/runtime-rs/crates/runtimes/src/tracer.rs
@@ -1,0 +1,162 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::cmp::min;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+use anyhow::Result;
+use lazy_static::lazy_static;
+use opentelemetry::global;
+use opentelemetry::runtime::Tokio;
+use tracing::{span, subscriber::NoSubscriber, Span, Subscriber};
+use tracing_subscriber::prelude::*;
+use tracing_subscriber::Registry;
+
+lazy_static! {
+    /// The static KATATRACER is the variable to provide public functions to outside modules
+    static ref KATATRACER: Arc<Mutex<KataTracer>> = Arc::new(Mutex::new(KataTracer::new()));
+
+    /// The ROOTSPAN is a phantom span that is running by calling [`trace_enter_root()`] at the background
+    /// once the configuration is read and config.runtime.enable_tracing is enabled
+    /// The ROOTSPAN exits by calling [`trace_exit_root()`] on shutdown request sent from containerd
+    ///
+    /// NOTE:
+    ///     This allows other threads which are not directly running under some spans to be tracked easily
+    ///     within the entire sandbox's lifetime.
+    ///    To do this, you just need to add attribute #[instrment(parent=&(*ROOTSPAN))]
+    pub static ref ROOTSPAN: Span = span!(tracing::Level::TRACE, "root-span");
+}
+
+/// The tracer wrapper for kata-containers, this contains the global static variable
+/// the tracing utilities might need
+/// The fields and member methods should ALWAYS be PRIVATE and be exposed in a safe
+/// way to other modules
+unsafe impl Send for KataTracer {}
+unsafe impl Sync for KataTracer {}
+struct KataTracer {
+    subscriber: Arc<dyn Subscriber + Send + Sync>,
+    enabled: bool,
+}
+
+impl KataTracer {
+    /// Constructor of KataTracer, this is a dummy implementation for static initialization
+    fn new() -> Self {
+        Self {
+            subscriber: Arc::new(NoSubscriber::default()),
+            enabled: false,
+        }
+    }
+
+    /// Set the tracing enabled flag
+    fn enable(&mut self) {
+        self.enabled = true;
+    }
+
+    /// Return whether the tracing is enabled, enabled by [`trace_setup`]
+    fn enabled(&self) -> bool {
+        self.enabled
+    }
+}
+
+/// Call when the tracing is enabled (set in toml configuration file)
+/// This setup the subscriber, which maintains the span's information, to global and
+/// inside KATATRACER.
+///
+/// Note that the span will be noop(not collected) if a valid subscriber is set
+pub fn trace_setup(
+    sid: &str,
+    jaeger_endpoint: &str,
+    jaeger_username: &str,
+    jaeger_password: &str,
+) -> Result<()> {
+    let mut kt = KATATRACER.lock().unwrap();
+
+    // If varify jaeger config returns an error, it means that the tracing should not be enabled
+    let endpoint = varify_jaeger_config(jaeger_endpoint, jaeger_username, jaeger_password)?;
+
+    // enable tracing
+    kt.enable();
+
+    // derive a subscriber to collect span info
+    let tracer = opentelemetry_jaeger::new_collector_pipeline()
+        .with_service_name(format!("kata-sb-{}", &sid[0..min(8, sid.len())]))
+        .with_endpoint(endpoint)
+        .with_username(jaeger_username)
+        .with_password(jaeger_password)
+        .with_hyper()
+        .install_batch(Tokio)?;
+
+    let layer = tracing_opentelemetry::layer().with_tracer(tracer);
+    let sub = Registry::default().with(layer);
+
+    // we use Arc to let global subscriber and katatracer to SHARE the SAME subscriber
+    // this is for record the global subscriber into a global variable KATATRACER for more usages
+    let subscriber = Arc::new(sub);
+    tracing::subscriber::set_global_default(subscriber.clone())?;
+    kt.subscriber = subscriber;
+
+    info!(sl!(), "Tracing enabled successfully");
+    Ok(())
+}
+
+/// Global function to shutdown the tracer and emit the span info to jaeger agent
+/// The tracing information is only partially update to jaeger agent before this function is called
+pub fn trace_end() {
+    if KATATRACER.lock().unwrap().enabled() {
+        global::shutdown_tracer_provider();
+    }
+}
+
+/// Enter the global ROOTSPAN, called at once if config.runtime.entracing is set
+/// This function is a hack on tracing library's guard approach, letting the span
+/// to enter without using a RAII guard to exit. This function should only be called
+/// once, and also in paired with [`trace_exit_root()`].
+pub fn trace_enter_root() {
+    enter(&ROOTSPAN);
+}
+
+/// Exit the global ROOTSPAN, called when shutdown request is sent by containerd and the
+/// shim actually does decide to shutdown the sandbox. This should be called in paired with [`trace_enter_root()`].
+pub fn trace_exit_root() {
+    exit(&ROOTSPAN);
+}
+
+/// let the subscriber enter the span, this has to be called in pair with exit(span)
+/// This function allows **cross function span** to run without span guard
+fn enter(span: &Span) {
+    let kt = KATATRACER.lock().unwrap();
+    let id: Option<span::Id> = span.into();
+    kt.subscriber.enter(&id.unwrap());
+}
+
+/// let the subscriber exit the span, this has to be called in pair to enter(span)
+fn exit(span: &Span) {
+    let kt = KATATRACER.lock().unwrap();
+    let id: Option<span::Id> = span.into();
+    kt.subscriber.exit(&id.unwrap());
+}
+
+/// Varifying the configuration of jaeger and setup the default value
+fn varify_jaeger_config(endpoint: &str, username: &str, passwd: &str) -> Result<String> {
+    if username.is_empty() && !passwd.is_empty() {
+        warn!(
+            sl!(),
+            "Jaeger password with empty username is now allowed, tracing is NOT enabled"
+        );
+        return Err(anyhow::anyhow!(""));
+    }
+
+    // set the default endpoint address, this expects a jaeger-collector running on localhost:14268
+    let endpt = if endpoint.is_empty() {
+        "http://localhost:14268/api/traces"
+    } else {
+        endpoint
+    }
+    .to_owned();
+
+    Ok(endpt)
+}

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1.8.0" }
 toml = "0.4.2"
 url = "2.1.1"
 async-std = "1.12.0"
+tracing = "0.1.36"
 
 agent = { path = "../../agent" }
 common = { path = "../common" }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -24,9 +24,11 @@ use hypervisor::{dragonball::Dragonball, Hypervisor, HYPERVISOR_DRAGONBALL};
 use kata_types::config::{hypervisor::register_hypervisor_plugin, DragonballConfig, TomlConfig};
 use resource::ResourceManager;
 use tokio::sync::mpsc::Sender;
+use tracing::instrument;
 
 unsafe impl Send for VirtContainer {}
 unsafe impl Sync for VirtContainer {}
+#[derive(Debug)]
 pub struct VirtContainer {}
 
 #[async_trait]
@@ -46,6 +48,7 @@ impl RuntimeHandler for VirtContainer {
         Arc::new(VirtContainer {})
     }
 
+    #[instrument]
     async fn new_instance(
         &self,
         sid: &str,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -22,6 +22,7 @@ use resource::{
     ResourceConfig, ResourceManager,
 };
 use tokio::sync::{mpsc::Sender, Mutex, RwLock};
+use tracing::instrument;
 
 use crate::{health_check::HealthCheck, sandbox_persist::SandboxTYPE};
 use persist::{self, sandbox_persist::Persist};
@@ -63,6 +64,15 @@ pub struct VirtSandbox {
     monitor: Arc<HealthCheck>,
 }
 
+impl std::fmt::Debug for VirtSandbox {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("VirtSandbox")
+            .field("sid", &self.sid)
+            .field("msg_sender", &self.msg_sender)
+            .finish()
+    }
+}
+
 impl VirtSandbox {
     pub async fn new(
         sid: &str,
@@ -82,6 +92,7 @@ impl VirtSandbox {
         })
     }
 
+    #[instrument]
     async fn prepare_for_start_sandbox(
         &self,
         _id: &str,
@@ -116,6 +127,7 @@ impl VirtSandbox {
 
 #[async_trait]
 impl Sandbox for VirtSandbox {
+    #[instrument(name = "sb: start")]
     async fn start(&self, netns: Option<String>) -> Result<()> {
         let id = &self.sid;
 

--- a/src/runtime-rs/crates/service/Cargo.toml
+++ b/src/runtime-rs/crates/service/Cargo.toml
@@ -11,6 +11,8 @@ async-trait = "0.1.48"
 slog = "2.5.2"
 slog-scope = "4.4.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
+tracing = "0.1.36"
+
 ttrpc = { version = "0.6.1" }
 
 common = { path = "../runtimes/common" }

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -39,6 +39,19 @@ pub struct ServiceManager {
     namespace: String,
 }
 
+impl std::fmt::Debug for ServiceManager {
+    // todo: some how to implement debug for handler
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ServiceManager")
+            .field("receiver", &self.receiver)
+            .field("task_server.is_some()", &self.task_server.is_some())
+            .field("binary", &self.binary)
+            .field("address", &self.address)
+            .field("namespace", &self.namespace)
+            .finish()
+    }
+}
+
 async fn send_event(
     containerd_binary: String,
     address: String,

--- a/src/runtime-rs/crates/shim/Cargo.toml
+++ b/src/runtime-rs/crates/shim/Cargo.toml
@@ -27,14 +27,17 @@ slog-async = "2.5.2"
 slog-scope = "4.4.0"
 slog-stdlog = "4.1.0"
 thiserror = "1.0.30"
-tokio = { version = "1.8.0", features = [ "rt", "rt-multi-thread" ] }
 unix_socket2 = "0.5.4"
+tokio = { version = "1.8.0", features = [ "rt", "rt-multi-thread" ] }
+tracing = "0.1.36"
+tracing-opentelemetry = "0.18.0"
 
 kata-types = { path = "../../../libs/kata-types"}
 kata-sys-util = { path = "../../../libs/kata-sys-util"}
 logging = { path = "../../../libs/logging"}
 oci = { path = "../../../libs/oci" }
 service = { path = "../service" }
+runtimes = { path = "../runtimes" }
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/runtime-rs/crates/shim/src/bin/main.rs
+++ b/src/runtime-rs/crates/shim/src/bin/main.rs
@@ -14,7 +14,9 @@ use nix::{
     mount::{mount, MsFlags},
     sched::{self, CloneFlags},
 };
+use runtimes::tracer::trace_end;
 use shim::{config, Args, Error, ShimExecutor};
+// use tracing::span;
 
 // default tokio runtime worker threads
 const DEFAULT_TOKIO_RUNTIME_WORKER_THREADS: usize = 2;
@@ -142,7 +144,11 @@ fn real_main() -> Result<()> {
         Action::Delete(args) => {
             let mut shim = ShimExecutor::new(args);
             let rt = get_tokio_runtime().context("get tokio runtime")?;
-            rt.block_on(shim.delete())?
+            rt.block_on(shim.delete())?;
+
+            // XXX: end tracing when containerd asks kata to stop
+            // XXX: stop here to trace deletion process
+            trace_end();
         }
         Action::Run(args) => {
             // set mnt namespace
@@ -151,7 +157,7 @@ fn real_main() -> Result<()> {
 
             let mut shim = ShimExecutor::new(args);
             let rt = get_tokio_runtime().context("get tokio runtime")?;
-            rt.block_on(shim.run())?
+            rt.block_on(shim.run())?;
         }
         Action::Help => show_help(&args[0]),
         Action::Version => show_version(None),

--- a/src/runtime-rs/crates/shim/src/shim.rs
+++ b/src/runtime-rs/crates/shim/src/shim.rs
@@ -20,6 +20,7 @@ const SHIM_PID_FILE: &str = "shim.pid";
 pub(crate) const ENV_KATA_RUNTIME_BIND_FD: &str = "KATA_RUNTIME_BIND_FD";
 
 /// Command executor for shim.
+#[derive(Debug)]
 pub struct ShimExecutor {
     pub(crate) args: Args,
 }


### PR DESCRIPTION
1. Instrumenting currently only on major booting process, i.e. before sandbox creation to container creation finished
  - all instrumenting spans are child spans of a long running rootspan
  - tracer.rs supports spans **without guard** entering and exiting at any place, this supports the long running rootspan

2. Add some debug trait implementation (maybe not complete) since #[instrument] needs this, and skip instrumenting the parameters is not a good choice.