### PR TITLE
stable-2.5: runtime fix blockdevAddWithCache parameter

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qmp.go
+++ b/src/runtime/pkg/govmm/qemu/qmp.go
@@ -771,9 +771,7 @@ func (q *QMP) ExecuteQuit(ctx context.Context) error {
 	return q.executeCommand(ctx, "quit", nil, nil)
 }
 
-func (q *QMP) blockdevAddBaseArgs(driver, device, blockdevID string, ro bool) (map[string]interface{}, map[string]interface{}) {
-	var args map[string]interface{}
-
+func (q *QMP) blockdevAddBaseArgs(driver, device, blockdevID string, ro bool) map[string]interface{} {
 	blockdevArgs := map[string]interface{}{
 		"driver":    "raw",
 		"read-only": ro,
@@ -781,12 +779,10 @@ func (q *QMP) blockdevAddBaseArgs(driver, device, blockdevID string, ro bool) (m
 			"driver":   driver,
 			"filename": device,
 		},
+		"node-name": blockdevID,
 	}
 
-	blockdevArgs["node-name"] = blockdevID
-	args = blockdevArgs
-
-	return args, blockdevArgs
+	return blockdevArgs
 }
 
 // ExecuteBlockdevAdd sends a blockdev-add to the QEMU instance.  device is the
@@ -794,7 +790,7 @@ func (q *QMP) blockdevAddBaseArgs(driver, device, blockdevID string, ro bool) (m
 // used to name the device.  As this identifier will be passed directly to QMP,
 // it must obey QMP's naming rules, e,g., it must start with a letter.
 func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string, ro bool) error {
-	args, _ := q.blockdevAddBaseArgs("host_device", device, blockdevID, ro)
+	args := q.blockdevAddBaseArgs("host_device", device, blockdevID, ro)
 
 	return q.executeCommand(ctx, "blockdev-add", args, nil)
 }
@@ -807,28 +803,28 @@ func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, device, blockdevID string,
 // is enabled.  noFlush denotes whether flush requests for the device are
 // ignored.
 func (q *QMP) ExecuteBlockdevAddWithCache(ctx context.Context, device, blockdevID string, direct, noFlush, ro bool) error {
-	args, blockdevArgs := q.blockdevAddBaseArgs("host_device", device, blockdevID, ro)
+	blockdevArgs := q.blockdevAddBaseArgs("host_device", device, blockdevID, ro)
 
 	blockdevArgs["cache"] = map[string]interface{}{
 		"direct":   direct,
 		"no-flush": noFlush,
 	}
 
-	return q.executeCommand(ctx, "blockdev-add", args, nil)
+	return q.executeCommand(ctx, "blockdev-add", blockdevArgs, nil)
 }
 
 // ExecuteBlockdevAddWithDriverCache has three one parameter driver
 // than ExecuteBlockdevAddWithCache.
 // Parameter driver can set the driver of block device.
 func (q *QMP) ExecuteBlockdevAddWithDriverCache(ctx context.Context, driver, device, blockdevID string, direct, noFlush, ro bool) error {
-	args, blockdevArgs := q.blockdevAddBaseArgs(driver, device, blockdevID, ro)
+	blockdevArgs := q.blockdevAddBaseArgs(driver, device, blockdevID, ro)
 
 	blockdevArgs["cache"] = map[string]interface{}{
 		"direct":   direct,
 		"no-flush": noFlush,
 	}
 
-	return q.executeCommand(ctx, "blockdev-add", args, nil)
+	return q.executeCommand(ctx, "blockdev-add", blockdevArgs, nil)
 }
 
 // ExecuteDeviceAdd adds the guest portion of a device to a QEMU instance


### PR DESCRIPTION
Remove a useless parameter in blockdevAddBaseArgs, and fix the problem that the parameter is not used after modification.

Fixes: #5298

Signed-off-by: chmod100 <letfu@outlook.com>