### PR TITLE
runtime: fix incorrect comment for SetFsSharingSupport function

### DIFF
--- a/src/runtime/virtcontainers/types/capabilities.go
+++ b/src/runtime/virtcontainers/types/capabilities.go
@@ -53,7 +53,7 @@ func (caps *Capabilities) IsFsSharingSupported() bool {
 	return caps.flags&fsSharingSupported != 0
 }
 
-// SetFsSharingUnsupported sets the host filesystem sharing capability to true.
+// SetFsSharingSupport sets the host filesystem sharing capability to true.
 func (caps *Capabilities) SetFsSharingSupport() {
 	caps.flags |= fsSharingSupported
 }


### PR DESCRIPTION
The comment for SetFsSharingSupport is not suitable, correct the function name.

Fixes: #5285

Signed-off-by: Bin Liu <bin@hyper.sh>