### PR TITLE
runtime-rs: delete duplicated PASSTHROUGH_FS_DIR const

### DIFF
--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
@@ -13,7 +13,6 @@ use kata_sys_util::mount;
 use super::utils;
 
 pub(crate) const MOUNT_GUEST_TAG: &str = "kataShared";
-pub(crate) const PASSTHROUGH_FS_DIR: &str = "passthrough";
 
 pub(crate) const FS_TYPE_VIRTIO_FS: &str = "virtiofs";
 pub(crate) const KATA_VIRTIO_FS_DEV_TYPE: &str = "virtio-fs";

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_inline.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_inline.rs
@@ -16,9 +16,8 @@ use kata_types::config::hypervisor::SharedFsInfo;
 use super::{
     share_virtio_fs::{
         prepare_virtiofs, FS_TYPE_VIRTIO_FS, KATA_VIRTIO_FS_DEV_TYPE, MOUNT_GUEST_TAG,
-        PASSTHROUGH_FS_DIR,
     },
-    utils, ShareFs, *,
+    utils, ShareFs, PASSTHROUGH_FS_DIR, *,
 };
 
 lazy_static! {


### PR DESCRIPTION
The const PASSTHROUGH_FS_DIR defined twice, delte one.

Fixes: #5301

Signed-off-by: Bin Liu <bin@hyper.sh>