### PR TITLE
shim: Ensure pagesize is set when reporting hugetlb stats

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/metrics.go
+++ b/src/runtime/pkg/containerd-shim-v2/metrics.go
@@ -51,13 +51,14 @@ func statsToMetrics(stats *vc.ContainerStats) *cgroupsv1.Metrics {
 
 func setHugetlbStats(vcHugetlb map[string]vc.HugetlbStats) []*cgroupsv1.HugetlbStat {
 	var hugetlbStats []*cgroupsv1.HugetlbStat
-	for _, v := range vcHugetlb {
+	for k, v := range vcHugetlb {
 		hugetlbStats = append(
 			hugetlbStats,
 			&cgroupsv1.HugetlbStat{
-				Usage:   v.Usage,
-				Max:     v.MaxUsage,
-				Failcnt: v.Failcnt,
+				Usage:    v.Usage,
+				Max:      v.MaxUsage,
+				Failcnt:  v.Failcnt,
+				Pagesize: k,
 			})
 	}
 


### PR DESCRIPTION
The containerd stats method and metrics API are broken with Kata 2.5.x, the stats fail to load and the metrics API responds with status code 500

This seems to be down to the conversion from the stats reported by the agent RPC `StatsContainer` where the field `Pagesize` is not completed by the `setHugetlbStats` method. In the case where multiple sized tables stats are reported, this causes containerd to register two metrics with the same label set, rather than each being partitioned by the `page` label.

Fixes: #5316