### PR TITLE
CCv0: Add image_ttrpc_async.rs to .gitignore

### DIFF
--- a/src/libs/protocols/.gitignore
+++ b/src/libs/protocols/.gitignore
@@ -9,5 +9,6 @@ src/health_ttrpc.rs
 src/health_ttrpc_async.rs
 src/image.rs
 src/image_ttrpc.rs
+src/image_ttrpc_async.rs
 src/oci.rs
 src/types.rs


### PR DESCRIPTION
This patch adds `image_ttrpc_async.rs` to `.gitignore`, since the file is a generated one.

Fixes: #5318
