### PR TITLE
packaging: Mount $HOME/.docker in the 1st layer container

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -31,6 +31,12 @@ if [ ${docker_gid} == ${gid} ]; then
 	docker_gid=""
 fi
 
+remove_dot_docker_dir=false
+if [ ! -d "$HOME/.docker" ]; then
+	mkdir $HOME/.docker
+	remove_dot_docker_dir=true
+fi
+
 docker build -q -t build-kata-deploy \
 	--build-arg IMG_USER="${USER}" \
 	--build-arg UID=${uid} \
@@ -39,9 +45,14 @@ docker build -q -t build-kata-deploy \
 	"${script_dir}/dockerbuild/"
 
 docker run \
+	-v $HOME/.docker:/root/.docker \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	--env CI="${CI:-}" \
 	--env USER=${USER} -v "${kata_dir}:${kata_dir}" \
 	--rm \
 	-w ${script_dir} \
 	build-kata-deploy "${kata_deploy_create}" $@
+
+if [ $remove_dot_docker_dir == true ]; then
+	rm -rf "$HOME/.docker"
+fi


### PR DESCRIPTION
In order to ensure that the proxy configuration is passed to the 2nd layer container, let's ensure the $HOME/.docker/config.json file is exposed inside the 1st layer container.

For some reason which I still don't fully understand exporting https_proxy / http_proxy / no_proxy was not enough to get those variables exported to the 2nd layer container.

In this commit we're creating a "$HOME/.docker" directory, and removing it after the build, in case it doesn't exist yet.  The reason we do this is to avoid docker not running in case "$HOME/.docker" doesn't exist.

This was not tested with podman, but if there's an issue with podman, the issue was already there beforehand and should be treated as a different problem than the one addressed in this commit.

Fixes: #5077

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>