### PR TITLE
DO-NOT-MERGE: Update TDX kernel & QEMU

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -154,8 +154,8 @@ assets:
     version: "v5.19.2"
     tdx:
       description: "Linux kernel that supports TDX"
-      url: "https://github.com/intel/linux-kernel-dcp/archive/refs/tags"
-      tag: "SPR-BKC-PC-v9.6"
+      url: "https://github.com/intel/tdx/archive/refs/tags"
+      tag: "kvm-upstream-2022.09.30-v6.0-rc7-workaround"
     sev:
       description: "Linux kernel that supports SEV"
       url: "https://cdn.kernel.org/pub/linux/kernel/v5.x/"

--- a/versions.yaml
+++ b/versions.yaml
@@ -100,8 +100,8 @@ assets:
         .*/v?(\d\S+)\.tar\.gz
       tdx:
         description: "VMM that uses KVM and supports TDX"
-        url: "https://github.com/intel/qemu-dcp"
-        tag: "SPR-BKC-QEMU-v2.5"
+        url: "https://github.com/intel/qemu-tdx"
+        tag: "tdx-upstream-wip-2022-08-02-v7.1"
 
     qemu-experimental:
       description: "QEMU with virtiofs support"


### PR DESCRIPTION
Intel switched its development tree to using https://github.com/intel/tdx and https://github.com/intel/qemu-tdx, and I'm using the latest possible tag for both projects.