### PR TITLE
osbuilder: specify Attestation Agent tag for rootfs build

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -670,10 +670,13 @@ EOF
 			AA_KBC_PARAMS="offline_sev_kbc::null" envsubst < "${script_dir}/agent-config.toml.in" | tee "${ROOTFS_DIR}/etc/agent-config.toml"
 		fi
 		attestation_agent_url="$(get_package_version_from_kata_yaml externals.attestation-agent.url)"
-		attestation_agent_branch="$(get_package_version_from_kata_yaml externals.attestation-agent.branch)"
+		attestation_agent_version="$(get_package_version_from_kata_yaml externals.attestation-agent.version)"
 		info "Install attestation-agent with KBC ${AA_KBC}"
-		git clone "${attestation_agent_url}" --branch "${attestation_agent_branch}"
+		#git clone "${attestation_agent_url}" --branch "${attestation_agent_tag}" --single-branch
+		git clone --depth=1 "${attestation_agent_url}" attestation-agent
 		pushd attestation-agent/app
+		git fetch --depth=1 origin "${attestation_agent_version}"
+		git checkout FETCH_HEAD
 		source "${HOME}/.cargo/env"
 		target="${ARCH}-unknown-linux-${LIBC}"
 		if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then

--- a/versions.yaml
+++ b/versions.yaml
@@ -177,7 +177,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/attestation-agent"
-    branch: "main"
+    version: "e930d362c24bad62b5fa7d5079a9dc912dd78fa4"
 
   cni-plugins:
     description: "CNI network plugins"


### PR DESCRIPTION
Add tag entry to the attestation agent entry of the versions file. Checkout tag commit after cloning AA in rootfs builder.

Fixes: #5373
Fixes: kata-containers#5373
Signed-Off-By: Alex Carter <alex.carter@ibm.com>