### PR TITLE
stable-3.0: backport agent fixes

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1507,7 +1507,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "libseccomp",
- "nix 0.23.1",
+ "nix 0.24.2",
  "oci",
  "path-absolutize",
  "protobuf",

--- a/src/agent/rustjail/Cargo.toml
+++ b/src/agent/rustjail/Cargo.toml
@@ -12,7 +12,7 @@ serde_derive = "1.0.91"
 oci = { path = "../../libs/oci" }
 protocols = { path ="../../libs/protocols" }
 caps = "0.5.0"
-nix = "0.23.0"
+nix = "0.24.2"
 scopeguard = "1.0.0"
 capctl = "0.2.0"
 lazy_static = "1.3.0"


### PR DESCRIPTION
* agent: reduce reference count for failed mount
* agent: don't exit early if signal fails due to ESRCH