### PR TITLE
Dragonball: remove redundant comments in event manager

### DIFF
--- a/src/dragonball/src/event_manager.rs
+++ b/src/dragonball/src/event_manager.rs
@@ -101,7 +101,6 @@ impl EventManager {
     /// Poll pending events and invoke registered event handler.
     ///
     /// # Arguments:
-    /// * max_events: maximum number of pending events to handle
     /// * timeout: maximum time in milliseconds to wait
     pub fn handle_events(&self, timeout: i32) -> std::result::Result<usize, EpollError> {
         self.epoll_mgr


### PR DESCRIPTION
handle_events for EventManager doesn't take max_events as arguments, so we need to update the comments for it.

p.s. max_events is defined when initializing the EventManager.

fixes: #5382

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>