### PR TITLE
ci: skip s390x for dragonball.

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -116,5 +116,4 @@ jobs:
           cd src/dragonball
           /root/.cargo/bin/cargo version
           rustc --version
-          # TODO: Using the cargo command directly will get `sudo: cargo: command not found` error.
-          sudo -E /root/.cargo/bin/cargo test --all-features -- --nocapture
+          sudo -E env PATH=$PATH LIBC=gnu SUPPORT_VIRTUALIZATION=true make test

--- a/src/dragonball/Makefile
+++ b/src/dragonball/Makefile
@@ -2,6 +2,14 @@
 # Copyright (c) 2019-2022 Ant Group. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+include ../../utils.mk
+
+ifeq ($(ARCH), s390x)
+default build check test clippy:
+	@echo "s390x not support currently"
+	exit 0
+else
+
 default: build
 
 build:
@@ -27,3 +35,5 @@ clean:
 
 test:
 	@echo "INFO: skip testing dragonball"
+
+endif # ifeq ($(ARCH), s390x)

--- a/src/dragonball/Makefile
+++ b/src/dragonball/Makefile
@@ -13,7 +13,8 @@ else
 default: build
 
 build:
-	cargo build --all-features
+	@echo "INFO: cargo build..."
+	cargo build --all-features --target $(TRIPLE)
 
 check: clippy format
 
@@ -34,6 +35,13 @@ clean:
 	cargo clean
 
 test:
-	@echo "INFO: skip testing dragonball"
+ifdef SUPPORT_VIRTUALIZATION
+	cargo test --all-features --target $(TRIPLE) -- --nocapture
+else
+	@echo "INFO: skip testing dragonball, it need virtualization support."
+	exit 0
+endif
 
 endif # ifeq ($(ARCH), s390x)
+
+.DEFAULT_GOAL := default

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -795,13 +795,14 @@ impl DeviceManager {
     fn allocate_mmio_device_resource(
         &self,
     ) -> std::result::Result<DeviceResources, StartMicroVmError> {
-        let mut requests = Vec::new();
-        requests.push(ResourceConstraint::MmioAddress {
-            range: None,
-            align: MMIO_DEFAULT_CFG_SIZE,
-            size: MMIO_DEFAULT_CFG_SIZE,
-        });
-        requests.push(ResourceConstraint::LegacyIrq { irq: None });
+        let requests = vec![
+            ResourceConstraint::MmioAddress {
+                range: None,
+                align: MMIO_DEFAULT_CFG_SIZE,
+                size: MMIO_DEFAULT_CFG_SIZE,
+            },
+            ResourceConstraint::LegacyIrq { irq: None },
+        ];
 
         self.res_manager
             .allocate_device_resources(&requests, false)

--- a/src/dragonball/src/vcpu/aarch64.rs
+++ b/src/dragonball/src/vcpu/aarch64.rs
@@ -39,6 +39,7 @@ impl Vcpu {
     ///   vcpu thread to vmm thread.
     /// * `create_ts` - A timestamp used by the vcpu to calculate its lifetime.
     /// * `support_immediate_exit` -  whether kvm uses supports immediate_exit flag.
+    #[allow(clippy::too_many_arguments)]
     pub fn new_aarch64(
         id: u8,
         vcpu_fd: Arc<VcpuFd>,

--- a/src/dragonball/src/vcpu/vcpu_impl.rs
+++ b/src/dragonball/src/vcpu/vcpu_impl.rs
@@ -851,7 +851,7 @@ pub mod tests {
 
         let kvm = Kvm::new().unwrap();
         let vm = Arc::new(kvm.create_vm().unwrap());
-        let kvm_context = KvmContext::new(Some(kvm.as_raw_fd())).unwrap();
+        let _kvm_context = KvmContext::new(Some(kvm.as_raw_fd())).unwrap();
         let vcpu_fd = Arc::new(vm.create_vcpu(0).unwrap());
         let io_manager = IoManagerCached::new(Arc::new(ArcSwap::new(Arc::new(IoManager::new()))));
         let reset_event_fd = EventFd::new(libc::EFD_NONBLOCK).unwrap();

--- a/src/dragonball/src/vcpu/vcpu_manager.rs
+++ b/src/dragonball/src/vcpu/vcpu_manager.rs
@@ -774,7 +774,7 @@ impl VcpuManager {
             self.reset_event_fd.as_ref().unwrap().try_clone().unwrap(),
             self.vcpu_state_event.try_clone().unwrap(),
             self.vcpu_state_sender.clone(),
-            request_ts.clone(),
+            request_ts,
             self.support_immediate_exit,
         )
         .map_err(VcpuManagerError::Vcpu)

--- a/src/dragonball/src/vm/aarch64.rs
+++ b/src/dragonball/src/vm/aarch64.rs
@@ -35,6 +35,7 @@ use crate::event_manager::EventManager;
 /// * `device_info` - A hashmap containing the attached devices for building FDT device nodes.
 /// * `gic_device` - The GIC device.
 /// * `initrd` - Information about an optional initrd.
+#[allow(clippy::borrowed_box)]
 fn configure_system<T: DeviceInfoForFDT + Clone + Debug, M: GuestMemory>(
     guest_mem: &M,
     cmdline: &str,
@@ -58,8 +59,9 @@ fn configure_system<T: DeviceInfoForFDT + Clone + Debug, M: GuestMemory>(
 #[cfg(target_arch = "aarch64")]
 impl Vm {
     /// Gets a reference to the irqchip of the VM
+    #[allow(clippy::borrowed_box)]
     pub fn get_irqchip(&self) -> &Box<dyn GICDevice> {
-        &self.irqchip_handle.as_ref().unwrap()
+        self.irqchip_handle.as_ref().unwrap()
     }
 
     /// Creates the irq chip in-kernel device model.

--- a/utils.mk
+++ b/utils.mk
@@ -173,6 +173,7 @@ TRIPLE = $(ARCH)-unknown-linux-$(LIBC)
 CWD := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 standard_rust_check:
+	@echo "standard rust check..."
 	cargo fmt -- --check
 	cargo clippy --all-targets --all-features --release \
 		-- \


### PR DESCRIPTION
Currently, Dragonball only supports x86_64 and aarch64 platforms.

Fixes: #4381

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>