### PR TITLE
Dragonball: delete redundant comments in blk_dev_mgr

### DIFF
--- a/src/dragonball/src/device_manager/blk_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/blk_dev_mgr.rs
@@ -285,7 +285,6 @@ impl std::fmt::Debug for BlockDeviceInfo {
 pub type BlockDeviceInfo = DeviceConfigInfo<BlockDeviceConfigInfo>;
 
 /// Wrapper for the collection that holds all the Block Devices Configs
-//#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[derive(Clone)]
 pub struct BlockDeviceMgr {
     /// A list of `BlockDeviceInfo` objects.


### PR DESCRIPTION
delete redundent derive part for BlockDeviceMgr.

fixes: #5396

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>