### PR TITLE
versions: Update TDX kernel

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -161,8 +161,8 @@ assets:
     version: "v5.19.2"
     tdx:
       description: "Linux kernel that supports TDX"
-      url: "https://github.com/intel/linux-kernel-dcp/archive/refs/tags"
-      tag: "SPR-BKC-PC-v9.6"
+      url: "https://github.com/kata-containers/linux/archive/refs/tags"
+      tag: "5.15-plus-TDX"
     sev:
       description: "Linux kernel that supports SEV"
       url: "https://cdn.kernel.org/pub/linux/kernel/v5.x/"


### PR DESCRIPTION
The previously used repo has been removed by Intel.  As this happened, the TDX team worked on providing the patches that were hosted atop of the v5.15 kernel as a tarball present in the
https://github.com/intel/tdx-tools repos, see
https://github.com/intel/tdx-tools/pull/161.

On the Kata Containers side, in order to simplify the process and to avoid adding ~1400 kernel patches to our repo, we've revived the https://github.com/kata-containers/linux repo, and created a branch and a tag with those ~1400 patches atop of the v5.15.  The branch is called v5.15-plus-TDX, and the tag is called 5.15-plus-TDX (in order to avoid having to change how the kernel builder script deals with versioning).

Knowing the whole background, let's switch the repo we're getting the TDX kernel from.

Fixes: #5326

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>