### PR TITLE
agent: change `AGENT_CONFIG`'s lazy type to just `AgentConfig`

### DIFF
--- a/src/agent/src/image_rpc.rs
+++ b/src/agent/src/image_rpc.rs
@@ -206,12 +206,12 @@ impl ImageService {
     async fn pull_image(&self, req: &image::PullImageRequest) -> Result<String> {
         env::set_var("OCICRYPT_KEYPROVIDER_CONFIG", OCICRYPT_CONFIG_PATH);
 
-        let https_proxy = &AGENT_CONFIG.read().await.https_proxy;
+        let https_proxy = &AGENT_CONFIG.https_proxy;
         if !https_proxy.is_empty() {
             env::set_var("HTTPS_PROXY", https_proxy);
         }
 
-        let no_proxy = &AGENT_CONFIG.read().await.no_proxy;
+        let no_proxy = &AGENT_CONFIG.no_proxy;
         if !no_proxy.is_empty() {
             env::set_var("NO_PROXY", no_proxy);
         }
@@ -219,7 +219,7 @@ impl ImageService {
         let image = req.get_image();
         let mut cid = req.get_container_id().to_string();
 
-        let aa_kbc_params = &AGENT_CONFIG.read().await.aa_kbc_params;
+        let aa_kbc_params = &AGENT_CONFIG.aa_kbc_params;
 
         if cid.is_empty() {
             let v: Vec<&str> = image.rsplit('/').collect();
@@ -259,8 +259,8 @@ impl ImageService {
 
         if Path::new(SKOPEO_PATH).exists() {
             // Read the policy path from the agent config
-            let config_policy_path = &AGENT_CONFIG.read().await.container_policy_path;
-            let policy_path = (!config_policy_path.is_empty()).then(|| config_policy_path.as_str());
+            let config_policy_path = AGENT_CONFIG.container_policy_path.as_str();
+            let policy_path = (!config_policy_path.is_empty()).then(|| config_policy_path);
             Self::pull_image_from_registry(image, &cid, source_creds, policy_path, aa_kbc_params)?;
             Self::unpack_image(&cid)?;
         } else {

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -66,7 +66,7 @@ use tokio::{
     io::AsyncWrite,
     sync::{
         watch::{channel, Receiver},
-        Mutex, RwLock,
+        Mutex,
     },
     task::JoinHandle,
 };
@@ -78,12 +78,11 @@ mod tracer;
 const NAME: &str = "kata-agent";
 
 lazy_static! {
-    static ref AGENT_CONFIG: Arc<RwLock<AgentConfig>> = Arc::new(RwLock::new(
+    static ref AGENT_CONFIG: AgentConfig =
         // Note: We can't do AgentOpts.parse() here to send through the processed arguments to AgentConfig
         // clap::Parser::parse() greedily process all command line input including cargo test parameters,
         // so should only be used inside main.
-        AgentConfig::from_cmdline("/proc/cmdline", env::args().collect()).unwrap()
-    ));
+        AgentConfig::from_cmdline("/proc/cmdline", env::args().collect()).unwrap();
 }
 
 #[derive(Parser)]
@@ -176,13 +175,13 @@ async fn real_main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
         lazy_static::initialize(&AGENT_CONFIG);
 
-        init_agent_as_init(&logger, AGENT_CONFIG.read().await.unified_cgroup_hierarchy)?;
+        init_agent_as_init(&logger, AGENT_CONFIG.unified_cgroup_hierarchy)?;
         drop(logger_async_guard);
     } else {
         lazy_static::initialize(&AGENT_CONFIG);
     }
 
-    let config = AGENT_CONFIG.read().await;
+    let config = &AGENT_CONFIG;
     let log_vport = config.log_vport as u32;
 
     let log_handle = tokio::spawn(create_logger_task(rfd, log_vport, shutdown_rx.clone()));
@@ -195,7 +194,7 @@ async fn real_main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let (logger, logger_async_guard) =
         logging::create_logger(NAME, "agent", config.log_level, writer);
 
-    announce(&logger, &config);
+    announce(&logger, config);
 
     // This variable is required as it enables the global (and crucially static) logger,
     // which is required to satisfy the the lifetime constraints of the auto-generated gRPC code.
@@ -223,7 +222,7 @@ async fn real_main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let span_guard = root_span.enter();
 
     // Start the sandbox and wait for its ttRPC server to end
-    start_sandbox(&logger, &config, init_mode, &mut tasks, shutdown_rx.clone()).await?;
+    start_sandbox(&logger, config, init_mode, &mut tasks, shutdown_rx.clone()).await?;
 
     // Install a NOP logger for the remainder of the shutdown sequence
     // to ensure any log calls made by local crates using the scope logger

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -124,11 +124,7 @@ macro_rules! ttrpc_error {
 
 macro_rules! is_allowed {
     ($req:ident) => {
-        if !AGENT_CONFIG
-            .read()
-            .await
-            .is_allowed_endpoint($req.descriptor().name())
-        {
+        if !AGENT_CONFIG.is_allowed_endpoint($req.descriptor().name()) {
             return Err(ttrpc_error!(
                 ttrpc::Code::UNIMPLEMENTED,
                 format!("{} is blocked", $req.descriptor().name()),
@@ -228,7 +224,7 @@ impl AgentService {
             let dev_major_minor = format!("{}:{}", specdev.major, specdev.minor);
 
             if specdev.path == TRUSTED_STORAGE_DEVICE {
-                let data_integrity = AGENT_CONFIG.read().await.data_integrity;
+                let data_integrity = AGENT_CONFIG.data_integrity;
                 info!(
                     sl!(),
                     "trusted_store device major:min {}, enable data integrity {}",
@@ -290,7 +286,7 @@ impl AgentService {
         let mut ctr: LinuxContainer =
             LinuxContainer::new(cid.as_str(), CONTAINER_BASE, opts, &sl!())?;
 
-        let pipe_size = AGENT_CONFIG.read().await.container_pipe_size;
+        let pipe_size = AGENT_CONFIG.container_pipe_size;
 
         let p = if let Some(p) = oci.process {
             Process::new(&sl!(), &p, cid.as_str(), true, pipe_size)?
@@ -425,7 +421,7 @@ impl AgentService {
         // Apply any necessary corrections for PCI addresses
         update_env_pci(&mut process.Env, &sandbox.pcimap)?;
 
-        let pipe_size = AGENT_CONFIG.read().await.container_pipe_size;
+        let pipe_size = AGENT_CONFIG.container_pipe_size;
         let ocip = rustjail::process_grpc_to_oci(&process);
         let p = Process::new(&sl!(), &ocip, exec_id.as_str(), false, pipe_size)?;
 

--- a/src/agent/src/uevent.rs
+++ b/src/agent/src/uevent.rs
@@ -141,7 +141,7 @@ pub async fn wait_for_uevent(
 
     info!(sl!(), "{}: waiting on channel", logprefix);
 
-    let hotplug_timeout = AGENT_CONFIG.read().await.hotplug_timeout;
+    let hotplug_timeout = AGENT_CONFIG.hotplug_timeout;
 
     let uev = match tokio::time::timeout(hotplug_timeout, rx).await {
         Ok(v) => v?,


### PR DESCRIPTION
Since it is never modified, it doesn't really need a lock of any kind. Removing the `RwLock` wrapper allows us to remove all `.read().await` calls when accessing it.

Additionally, `AGENT_CONFIG` already has a static lifetime, so there is no need to wrap it in a ref-counted heap allocation.

Fixes #5409

Signed-off-by: Wedson Almeida Filho <walmeida@microsoft.com>