### PR TITLE
runtime-rs: fix typo get_contaier_type to get_container_type

### DIFF
--- a/src/libs/kata-sys-util/src/spec.rs
+++ b/src/libs/kata-sys-util/src/spec.rs
@@ -49,7 +49,7 @@ pub enum ShimIdInfo {
 }
 
 /// get container type
-pub fn get_contaier_type(spec: &oci::Spec) -> Result<ContainerType, Error> {
+pub fn get_container_type(spec: &oci::Spec) -> Result<ContainerType, Error> {
     for k in CRI_CONTAINER_TYPE_KEY_LIST.iter() {
         if let Some(type_value) = spec.annotations.get(*k) {
             match type_value.as_str() {
@@ -67,7 +67,7 @@ pub fn get_contaier_type(spec: &oci::Spec) -> Result<ContainerType, Error> {
 /// get shim id info
 pub fn get_shim_id_info() -> Result<ShimIdInfo, Error> {
     let spec = load_oci_spec()?;
-    match get_contaier_type(&spec)? {
+    match get_container_type(&spec)? {
         ContainerType::PodSandbox => Ok(ShimIdInfo::Sandbox),
         ContainerType::PodContainer => {
             for k in CRI_SANDBOX_ID_KEY_LIST {

--- a/src/runtime-rs/crates/shim/src/shim_delete.rs
+++ b/src/runtime-rs/crates/shim/src/shim_delete.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{Context, Result};
 use containerd_shim_protos::api;
-use kata_sys_util::spec::{get_bundle_path, get_contaier_type, load_oci_spec};
+use kata_sys_util::spec::{get_bundle_path, get_container_type, load_oci_spec};
 use kata_types::container::ContainerType;
 use nix::{sys::signal::kill, sys::signal::SIGKILL, unistd::Pid};
 use protobuf::Message;
@@ -53,7 +53,7 @@ impl ShimExecutor {
 
             let bundle_path = get_bundle_path().context("get bundle path")?;
             if let Ok(spec) = load_oci_spec() {
-                if let Ok(ContainerType::PodSandbox) = get_contaier_type(&spec) {
+                if let Ok(ContainerType::PodSandbox) = get_container_type(&spec) {
                     // only force shutdown for sandbox container
                     if let Ok(shim_pid) = self.read_pid_file(&bundle_path) {
                         info!(sl!(), "force to shutdown shim process {}", shim_pid);


### PR DESCRIPTION
Change get_contaier_type to get_container_type

Fixes: #5415

Signed-off-by: Bin Liu <bin@hyper.sh>