### PR TITLE
versions: Update TDX QEMU

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -100,8 +100,8 @@ assets:
         .*/v?(\d\S+)\.tar\.gz
       tdx:
         description: "VMM that uses KVM and supports TDX"
-        url: "https://github.com/intel/qemu-dcp"
-        tag: "SPR-BKC-QEMU-v2.5"
+        url: "https://github.com/kata-containers/qemu"
+        tag: "TDX-v3.1"
       snp:
         description: "VMM that uses KVM and supports AMD SEV-SNP"
         url: "https://github.com/AMDESE/qemu"


### PR DESCRIPTION
The previously used repo will be removed by Intel, as done with the one used for TDX kernel.  The TDX team has already worked on providing the patches that were hosted atop of the QEMU commit with the following hash 4c127fdbe81d66e7cafed90908d0fd1f6f2a6cd0 as a tarball in the https://github.com/intel/tdx-tools repo, see
https://github.com/intel/tdx-tools/pull/162.

On the Kata Containers side, in order to simplify the process and to avoid adding hundreds of patches to our repo, we've revived the https://github.com/kata-containers/qemu repo, and created a branch and a tag with those hundreds of patches atop of the QEMU commit hash 4c127fdbe81d66e7cafed90908d0fd1f6f2a6cd0.  The branch is called 4c127fdbe81d66e7cafed90908d0fd1f6f2a6cd0-plus-TDX-v3.1 and the tag is called TDX-v3.1.

Knowing the whole background, let's switch the repo we're getting the TDX QEMU from.

Fixes: #5419

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>