### PR TITLE
virtiofsd: Build inside a container

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -321,35 +321,23 @@ parts:
 
   virtiofsd:
     plugin: nil
-    after: [godeps, rustdeps]
+    after: [godeps, rustdeps, docker]
     override-build: |
       source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
 
-      # Currently, powerpc makes use of the QEMU's C implementation.
-      # The other platforms make use of the new rust virtiofsd.
-      #
-      # See "tools/packaging/scripts/configure-hypervisor.sh".
-      if [ "${arch}" == "ppc64le" ]
-      then
-          echo "INFO: Building QEMU's C version of virtiofsd"
-          # Handled by the 'qemu' part, so nothing more to do here.
-          exit 0
-      else
-          echo "INFO: Building rust version of virtiofsd"
-      fi
+      echo "INFO: Building rust version of virtiofsd"
 
-      cd "${kata_dir}"
+      cd "${SNAPCRAFT_PROJECT_DIR}"
+      # Clean-up build dir in case it already exists
+      sudo -E NO_TTY=true make virtiofsd-tarball
 
-      export PATH=${PATH}:${HOME}/.cargo/bin
-      # Download the rust implementation of virtiofsd
-      tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
       sudo install \
         --owner='root' \
         --group='root' \
         --mode=0755 \
         -D \
         --target-directory="${SNAPCRAFT_PART_INSTALL}/usr/libexec/" \
-        virtiofsd/virtiofsd
+        build/virtiofsd/builddir/virtiofsd/virtiofsd
 
   cloud-hypervisor:
     plugin: nil

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -82,8 +82,36 @@ parts:
       fi
       rustup component add rustfmt
 
+  docker:
+    after: [metadata]
+    plugin: nil
+    prime:
+      - -*
+    build-packages:
+      - curl
+    override-build: |
+      source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
+
+      sudo apt-get -y update
+      sudo apt-get -y install ca-certificates curl gnupg lsb-release
+      curl -fsSL https://download.docker.com/linux/ubuntu/gpg |\
+          sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+      distro_codename=$(lsb_release -cs)
+      echo "deb [arch=${dpkg_arch} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu ${distro_codename} stable" |\
+          sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+      sudo apt-get -y update
+      sudo apt-get -y install docker-ce docker-ce-cli containerd.io
+
+      echo "Unmasking docker service"
+      sudo -E systemctl unmask docker.service || true
+      sudo -E systemctl unmask docker.socket || true
+      echo "Adding $USER into docker group"
+      sudo -E gpasswd -a $USER docker
+      echo "Starting docker"
+      sudo -E systemctl start docker || true
+
   image:
-    after: [godeps, qemu, kernel]
+    after: [godeps, docker, qemu, kernel]
     plugin: nil
     build-packages:
       - docker.io
@@ -106,14 +134,6 @@ parts:
 
       # Copy yq binary. It's used in the container
       cp -a "${yq}" "${GOPATH}/bin/"
-
-      echo "Unmasking docker service"
-      sudo -E systemctl unmask docker.service || true
-      sudo -E systemctl unmask docker.socket || true
-      echo "Adding $USER into docker group"
-      sudo -E gpasswd -a $USER docker
-      echo "Starting docker"
-      sudo -E systemctl start docker || true
 
       cd "${kata_dir}/tools/osbuilder"
 
@@ -333,22 +353,11 @@ parts:
 
   cloud-hypervisor:
     plugin: nil
-    after: [godeps]
+    after: [godeps, docker]
     override-build: |
       source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
 
       if [ "${arch}" == "aarch64" ] || [ "${arch}" == "x86_64" ]; then
-          sudo apt-get -y update
-          sudo apt-get -y install ca-certificates curl gnupg lsb-release
-          curl -fsSL https://download.docker.com/linux/ubuntu/gpg |\
-              sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-          distro_codename=$(lsb_release -cs)
-          echo "deb [arch=${dpkg_arch} signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu ${distro_codename} stable" |\
-              sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-          sudo apt-get -y update
-          sudo apt-get -y install docker-ce docker-ce-cli containerd.io
-          sudo systemctl start docker.socket
-
           cd "${SNAPCRAFT_PROJECT_DIR}"
           sudo -E NO_TTY=true make cloud-hypervisor-tarball
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -26,7 +26,7 @@ readonly firecracker_builder="${static_build_dir}/firecracker/build-static-firec
 readonly kernel_builder="${static_build_dir}/kernel/build.sh"
 readonly qemu_builder="${static_build_dir}/qemu/build-static-qemu.sh"
 readonly shimv2_builder="${static_build_dir}/shim-v2/build.sh"
-readonly virtiofsd_builder="${static_build_dir}/virtiofsd/build-static-virtiofsd.sh"
+readonly virtiofsd_builder="${static_build_dir}/virtiofsd/build.sh"
 
 readonly rootfs_builder="${repo_root_dir}/tools/packaging/guest-image/build_image.sh"
 

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
+readonly virtiofsd_builder="${script_dir}/build-static-virtiofsd.sh"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+DESTDIR=${DESTDIR:-${PWD}}
+PREFIX=${PREFIX:-/opt/kata}
+container_image="kata-virtiofsd-builder"
+kata_version="${kata_version:-}"
+virtiofsd_repo="${virtiofsd_repo:-}"
+virtiofsd_version="${virtiofsd_version:-}"
+virtiofsd_zip="${virtiofsd_zip:-}"
+package_output_dir="${package_output_dir:-}"
+
+[ -n "${virtiofsd_repo}" ] || virtiofsd_repo=$(get_from_kata_deps "externals.virtiofsd.url")
+[ -n "${virtiofsd_version}" ] || virtiofsd_version=$(get_from_kata_deps "externals.virtiofsd.version")
+[ -n "${virtiofsd_zip}" ] || virtiofsd_zip=$(get_from_kata_deps "externals.virtiofsd.meta.binary")
+
+[ -n "${virtiofsd_repo}" ] || die "Failed to get virtiofsd repo"
+[ -n "${virtiofsd_version}" ] || die "Failed to get virtiofsd version or commit"
+[ -n "${virtiofsd_zip}" ] || die "Failed to get virtiofsd binary URL"
+
+ARCH=$(uname -m)
+case ${ARCH} in
+	"aarch64")
+		libc="musl"
+		;;
+	"ppc64le")
+		libc="gnu"
+		;;
+	"s390x")
+		libc="gnu"
+		;;
+	"x86_64")
+		libc="musl"
+		;;
+esac
+
+sudo docker build \
+	-t "${container_image}" "${script_dir}/${libc}"
+
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${PWD}" \
+	--env DESTDIR="${DESTDIR}" \
+	--env PREFIX="${PREFIX}" \
+	--env virtiofsd_repo="${virtiofsd_repo}" \
+	--env virtiofsd_version="${virtiofsd_version}" \
+	--env virtiofsd_zip="${virtiofsd_zip}" \
+	"${container_image}" \
+	bash -c "${virtiofsd_builder}"

--- a/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
@@ -1,0 +1,19 @@
+# Copyright (c) 2022 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        git \
+        libcap-ng-dev \
+        libseccomp-dev \
+        unzip && \
+    apt-get clean && rm -rf /var/lib/lists/ && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y

--- a/tools/packaging/static-build/virtiofsd/musl/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/musl/Dockerfile
@@ -1,0 +1,16 @@
+# Copyright (c) 2022 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM alpine:3.16.2
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+RUN apk --no-cache add \
+        bash \
+        curl \
+        gcc \
+        git \
+        libcap-ng-static \
+        libseccomp-static \
+        musl-dev && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y


### PR DESCRIPTION
When moving to building the CI artefacts using the kata-deploy scripts, we've noticed that the build would fail on any machine where the tarball wasn't officially provided.

This happens as rust is missing from the 1st layer container.  However, it's a very common practice to leave the 1st layer container with the minimum possible dependencies and install whatever is needed for building a specific component in a 2nd layer container, which virtiofsd never had.

In this commit we introduce the second layer containers (yes, comtainers), one for building virtiofsd using musl, and one for building virtiofsd using glibc.  The reason for taking this approach was to actually simplify the scripts and avoid building the dependencies (libseccomp, libcap-ng) using musl libc.

Fixes: #5425

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>