### PR TITLE
kata-ctl: remove tls support

### DIFF
--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.31"
 clap = { version = "3.2.20", features = ["derive", "cargo"] }
-reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "blocking"] }
 serde_json = "1.0.85"
 thiserror = "1.0.35"
 

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -5,6 +5,9 @@
 
 // Contains checks that are not architecture-specific
 
+// TODO: not all architectures support check functions yet, so disable dead_code rule for check.rs
+#![allow(dead_code)]
+
 use anyhow::{anyhow, Result};
 use reqwest::header::{CONTENT_TYPE, USER_AGENT};
 use serde_json::Value;


### PR DESCRIPTION
TLS needs native packages/crates to support, but s390x don't support ring crate, so disable TLS to let kata-ctl run on s390x.

Fixes: #5424

Signed-off-by: Bin Liu <bin@hyper.sh>