### PR TITLE
kata-ctl: ignore src/ops/version.rs and Cargo.lock

### DIFF
--- a/src/tools/kata-ctl/.gitignore
+++ b/src/tools/kata-ctl/.gitignore
@@ -1,1 +1,3 @@
+Cargo.lock
+src/ops/version.rs
 /vendor/


### PR DESCRIPTION
src/ops/version.rs and Cargo.lock are generated when building, they should be ignored.

Fixes: #5429

Signed-off-by: Bin Liu <bin@hyper.sh>