### PR TITLE
add EnterNetNS in virtcontainers

### DIFF
--- a/src/runtime/pkg/katautils/network_linux.go
+++ b/src/runtime/pkg/katautils/network_linux.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	goruntime "runtime"
 	"strings"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -27,30 +26,7 @@ const procMountInfoFile = "/proc/self/mountinfo"
 // into runtime.LockOSThread(), meaning it won't be executed in a
 // different thread than the one expected by the caller.
 func EnterNetNS(networkID string, cb func() error) error {
-	if networkID == "" {
-		return cb()
-	}
-
-	goruntime.LockOSThread()
-	defer goruntime.UnlockOSThread()
-
-	currentNS, err := ns.GetCurrentNS()
-	if err != nil {
-		return err
-	}
-	defer currentNS.Close()
-
-	targetNS, err := ns.GetNS(networkID)
-	if err != nil {
-		return err
-	}
-
-	if err := targetNS.Set(); err != nil {
-		return err
-	}
-	defer currentNS.Set()
-
-	return cb()
+	return vc.EnterNetNS(networkID, cb)
 }
 
 // SetupNetworkNamespace create a network namespace

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -1045,6 +1045,15 @@ func doNetNS(netNSPath string, cb func(ns.NetNS) error) error {
 	return cb(targetNS)
 }
 
+// EnterNetNS is free from any call to a go routine, and it calls
+// into runtime.LockOSThread(), meaning it won't be executed in a
+// different thread than the one expected by the caller.
+func EnterNetNS(networkID string, cb func() error) error {
+	return doNetNS(networkID, func(nn ns.NetNS) error {
+		return cb()
+	})
+}
+
 func deleteNetNS(netNSPath string) error {
 	n, err := ns.GetNS(netNSPath)
 	if err != nil {


### PR DESCRIPTION
Add a `EnterNetNS` in `virtcontainers` to remove same code in `katautils`
Fixes #5394
Signed-off-by: Rouzip <1226015390@qq.com>