### PR TITLE
kata-ctl: Disable network check on s390x

### DIFF
--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -12,9 +12,12 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.31"
 clap = { version = "3.2.20", features = ["derive", "cargo"] }
-reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 serde_json = "1.0.85"
 thiserror = "1.0.35"
+
+# See: https://github.com/kata-containers/kata-containers/issues/5438
+[target.'cfg(not(target_arch = "s390x"))'.dependencies]
+reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 
 [dev-dependencies]
 semver = "1.0.12"

--- a/src/tools/kata-ctl/src/arch/mod.rs
+++ b/src/tools/kata-ctl/src/arch/mod.rs
@@ -7,36 +7,32 @@ use anyhow::Result;
 
 #[cfg(target_arch = "aarch64")]
 pub mod aarch64;
+#[cfg(target_arch = "aarch64")]
+pub use aarch64 as arch_specific;
 
 #[cfg(target_arch = "powerpc64le")]
 pub mod powerpc64le;
+#[cfg(target_arch = "powerpc64le")]
+pub use powerpc64le as arch_specific;
 
 #[cfg(target_arch = "s390x")]
 pub mod s390x;
+#[cfg(target_arch = "s390x")]
+pub use s390x as arch_specific;
 
 #[cfg(target_arch = "x86_64")]
 pub mod x86_64;
+#[cfg(target_arch = "x86_64")]
+pub use x86_64 as arch_specific;
+
+#[cfg(not(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64le",
+    target_arch = "s390x",
+    target_arch = "x86_64"
+)))]
+compile_error!("unknown architecture");
 
 pub fn check() -> Result<()> {
-    #[cfg(target_arch = "aarch64")]
-    let result = aarch64::check();
-
-    #[cfg(target_arch = "powerpc64le")]
-    let result = powerpc64le::check();
-
-    #[cfg(target_arch = "s390x")]
-    let result = s390x::check();
-
-    #[cfg(target_arch = "x86_64")]
-    let result = x86_64::check();
-
-    #[cfg(not(any(
-        target_arch = "aarch64",
-        target_arch = "powerpc64le",
-        target_arch = "s390x",
-        target_arch = "x86_64"
-    )))]
-    compile_error!("unknown architecture");
-
-    result
+    arch_specific::check()
 }

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -6,8 +6,19 @@
 // Contains checks that are not architecture-specific
 
 use anyhow::{anyhow, Result};
+// See: https://github.com/kata-containers/kata-containers/issues/5438
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64le",
+    target_arch = "x86_64"
+))]
 use reqwest::header::{CONTENT_TYPE, USER_AGENT};
 use serde_json::Value;
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64le",
+    target_arch = "x86_64"
+))]
 use std::collections::HashMap;
 use std::fs;
 
@@ -99,6 +110,11 @@ pub fn run_network_checks() -> Result<()> {
     Ok(())
 }
 
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64le",
+    target_arch = "x86_64"
+))]
 fn get_kata_version_by_url(url: &str) -> std::result::Result<String, reqwest::Error> {
     let content = reqwest::blocking::Client::new()
         .get(url)
@@ -111,6 +127,11 @@ fn get_kata_version_by_url(url: &str) -> std::result::Result<String, reqwest::Er
     Ok(version.to_string())
 }
 
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64le",
+    target_arch = "x86_64"
+))]
 fn handle_reqwest_error(e: reqwest::Error) -> anyhow::Error {
     if e.is_connect() {
         return anyhow!(e).context("http connection failure: connection refused");
@@ -131,6 +152,11 @@ fn handle_reqwest_error(e: reqwest::Error) -> anyhow::Error {
     anyhow!(e).context("unknown http connection failure: {:?}")
 }
 
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64le",
+    target_arch = "x86_64"
+))]
 pub fn check_version() -> Result<()> {
     let version = get_kata_version_by_url(KATA_GITHUB_URL).map_err(handle_reqwest_error)?;
 
@@ -164,6 +190,11 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "powerpc64le",
+        target_arch = "x86_64"
+    ))]
     #[test]
     fn check_version_by_empty_url() {
         const TEST_URL: &str = "http:";
@@ -172,6 +203,11 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "powerpc64le",
+        target_arch = "x86_64"
+    ))]
     #[test]
     fn check_version_by_garbage_url() {
         const TEST_URL: &str = "_localhost_";
@@ -180,6 +216,11 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "powerpc64le",
+        target_arch = "x86_64"
+    ))]
     #[test]
     fn check_version_by_invalid_url() {
         const TEST_URL: &str = "http://localhost :80";
@@ -188,6 +229,11 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
+    #[cfg(any(
+        target_arch = "aarch64",
+        target_arch = "powerpc64le",
+        target_arch = "x86_64"
+    ))]
     #[test]
     fn check_latest_version() {
         let version = get_kata_version_by_url(KATA_GITHUB_URL).unwrap();

--- a/src/tools/kata-ctl/src/ops/check_ops.rs
+++ b/src/tools/kata-ctl/src/ops/check_ops.rs
@@ -32,7 +32,16 @@ pub fn handle_check(checkcmd: CheckArgument) -> Result<()> {
 
         CheckSubCommand::CheckVersionOnly => {
             // retrieve latest release
+            #[cfg(any(
+                target_arch = "aarch64",
+                target_arch = "powerpc64le",
+                target_arch = "x86_64"
+            ))]
             check::check_version()?;
+
+            // See: https://github.com/kata-containers/kata-containers/issues/5438
+            #[cfg(target_arch = "s390x")]
+            unimplemented!("Network check not implemented on s390x")
         }
     }
 


### PR DESCRIPTION
s390x apparently does not support rust-tls, which is required by the
network check (due to the `reqwest` crate dependency).

Disable the network check on s390x until we can find a solution to the
problem.

> **Note:**
>
> This fix is assumed to be a temporary one until we find a solution.
> Hence, I have not moved the network check code (which should be entirely
> generic) into an architecture specific module.

Fixes: #5435.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>

-----
Also fixes:

kata-ctl: arch: Improve check call

Rework the architecture-specific `check()` call by moving all the
conditional logic out of the function.

Fixes: #5402.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>