### PR TITLE
kata-ctl: Re-enable network tests on s390x (fixes 5438)

### DIFF
--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -12,12 +12,9 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.31"
 clap = { version = "3.2.20", features = ["derive", "cargo"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 serde_json = "1.0.85"
 thiserror = "1.0.35"
-
-# See: https://github.com/kata-containers/kata-containers/issues/5438
-[target.'cfg(not(target_arch = "s390x"))'.dependencies]
-reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 
 [dev-dependencies]
 semver = "1.0.12"

--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -3,6 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+[workspace]
+resolver = "2"
+
 [package]
 name = "kata-ctl"
 version = "0.0.1"
@@ -12,9 +15,14 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.31"
 clap = { version = "3.2.20", features = ["derive", "cargo"] }
-reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 serde_json = "1.0.85"
 thiserror = "1.0.35"
+
+[target.'cfg(target_arch = "s390x")'.dependencies]
+reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "native-tls"] }
+
+[target.'cfg(not(target_arch = "s390x"))'.dependencies]
+reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "rustls-tls"] }
 
 [dev-dependencies]
 semver = "1.0.12"

--- a/src/tools/kata-ctl/src/arch/s390x/mod.rs
+++ b/src/tools/kata-ctl/src/arch/s390x/mod.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 Intel Corporation
+// Copyright (c) 2022 IBM Corp.
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -7,9 +8,44 @@
 pub use arch_specific::*;
 
 mod arch_specific {
-    use anyhow::Result;
+    use crate::check;
+    use anyhow::{anyhow, Result};
+
+    const PROC_CPUINFO: &str = "/proc/cpuinfo";
+    const CPUINFO_DELIMITER: &str = "processor ";
+    const CPUINFO_FEATURES_TAG: &str = "features";
+    const CPU_FEATURES_REQ: &[&str] = &["sie"];
+
+    // check cpu
+    fn check_cpu() -> Result<()> {
+        println!("INFO: check CPU: s390x");
+
+        let cpu_info = check::get_single_cpu_info(PROC_CPUINFO, CPUINFO_DELIMITER)?;
+
+        let cpu_features = check::get_cpu_flags(&cpu_info, CPUINFO_FEATURES_TAG).map_err(|e| {
+            anyhow!(
+                "Error parsing CPU features, file {:?}, {:?}",
+                PROC_CPUINFO,
+                e
+            )
+        })?;
+
+        let missing_cpu_features = check::check_cpu_flags(&cpu_features, CPU_FEATURES_REQ)?;
+        if !missing_cpu_features.is_empty() {
+            eprintln!("WARNING: Missing CPU flags {:?}", missing_cpu_features);
+        }
+
+        Ok(())
+    }
 
     pub fn check() -> Result<()> {
-        unimplemented!("Check not implemented in s390x");
+        println!("INFO: check: s390x");
+
+        let _cpu_result = check_cpu();
+
+        // TODO: add additional checks, e.g, kernel modules as in go runtime
+        // TODO: collect outcome of tests to determine if checks pass or not
+
+        Ok(())
     }
 }

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -13,7 +13,7 @@ use std::collections::HashMap;
 const KATA_GITHUB_URL: &str =
     "https://api.github.com/repos/kata-containers/kata-containers/releases/latest";
 
-#[cfg(any(target_arch = "x86_64"))]
+#[cfg(any(target_arch = "s390x", target_arch = "x86_64"))]
 fn get_cpu_info(cpu_info_file: &str) -> Result<String> {
     let contents = std::fs::read_to_string(cpu_info_file)?;
     Ok(contents)
@@ -21,7 +21,7 @@ fn get_cpu_info(cpu_info_file: &str) -> Result<String> {
 
 // get_single_cpu_info returns the contents of the first cpu from
 // the specified cpuinfo file by parsing based on a specified delimiter
-#[cfg(any(target_arch = "x86_64"))]
+#[cfg(any(target_arch = "s390x", target_arch = "x86_64"))]
 pub fn get_single_cpu_info(cpu_info_file: &str, substring: &str) -> Result<String> {
     let contents = get_cpu_info(cpu_info_file)?;
 
@@ -41,7 +41,7 @@ pub fn get_single_cpu_info(cpu_info_file: &str, substring: &str) -> Result<Strin
 
 // get_cpu_flags returns a string of cpu flags from cpuinfo, passed in
 // as a string
-#[cfg(any(target_arch = "x86_64"))]
+#[cfg(any(target_arch = "s390x", target_arch = "x86_64"))]
 pub fn get_cpu_flags(cpu_info: &str, cpu_flags_tag: &str) -> Result<String> {
     if cpu_info.is_empty() {
         return Err(anyhow!("cpu_info string is empty"))?;
@@ -65,7 +65,7 @@ pub fn get_cpu_flags(cpu_info: &str, cpu_flags_tag: &str) -> Result<String> {
 
 // get_missing_strings searches for required (strings) in data and returns
 // a vector containing the missing strings
-#[cfg(any(target_arch = "x86_64"))]
+#[cfg(any(target_arch = "s390x", target_arch = "x86_64"))]
 fn get_missing_strings(data: &str, required: &'static [&'static str]) -> Result<Vec<String>> {
     let mut missing: Vec<String> = Vec::new();
 
@@ -78,7 +78,7 @@ fn get_missing_strings(data: &str, required: &'static [&'static str]) -> Result<
     Ok(missing)
 }
 
-#[cfg(any(target_arch = "x86_64"))]
+#[cfg(any(target_arch = "s390x", target_arch = "x86_64"))]
 pub fn check_cpu_flags(
     retrieved_flags: &str,
     required_flags: &'static [&'static str],
@@ -144,7 +144,7 @@ pub fn check_version() -> Result<()> {
     Ok(())
 }
 
-#[cfg(any(target_arch = "x86_64"))]
+#[cfg(any(target_arch = "s390x", target_arch = "x86_64"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -6,19 +6,8 @@
 // Contains checks that are not architecture-specific
 
 use anyhow::{anyhow, Result};
-// See: https://github.com/kata-containers/kata-containers/issues/5438
-#[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "powerpc64le",
-    target_arch = "x86_64"
-))]
 use reqwest::header::{CONTENT_TYPE, USER_AGENT};
 use serde_json::Value;
-#[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "powerpc64le",
-    target_arch = "x86_64"
-))]
 use std::collections::HashMap;
 use std::fs;
 
@@ -110,11 +99,6 @@ pub fn run_network_checks() -> Result<()> {
     Ok(())
 }
 
-#[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "powerpc64le",
-    target_arch = "x86_64"
-))]
 fn get_kata_version_by_url(url: &str) -> std::result::Result<String, reqwest::Error> {
     let content = reqwest::blocking::Client::new()
         .get(url)
@@ -127,11 +111,6 @@ fn get_kata_version_by_url(url: &str) -> std::result::Result<String, reqwest::Er
     Ok(version.to_string())
 }
 
-#[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "powerpc64le",
-    target_arch = "x86_64"
-))]
 fn handle_reqwest_error(e: reqwest::Error) -> anyhow::Error {
     if e.is_connect() {
         return anyhow!(e).context("http connection failure: connection refused");
@@ -152,11 +131,6 @@ fn handle_reqwest_error(e: reqwest::Error) -> anyhow::Error {
     anyhow!(e).context("unknown http connection failure: {:?}")
 }
 
-#[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "powerpc64le",
-    target_arch = "x86_64"
-))]
 pub fn check_version() -> Result<()> {
     let version = get_kata_version_by_url(KATA_GITHUB_URL).map_err(handle_reqwest_error)?;
 
@@ -190,11 +164,6 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "powerpc64le",
-        target_arch = "x86_64"
-    ))]
     #[test]
     fn check_version_by_empty_url() {
         const TEST_URL: &str = "http:";
@@ -203,11 +172,6 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "powerpc64le",
-        target_arch = "x86_64"
-    ))]
     #[test]
     fn check_version_by_garbage_url() {
         const TEST_URL: &str = "_localhost_";
@@ -216,11 +180,6 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "powerpc64le",
-        target_arch = "x86_64"
-    ))]
     #[test]
     fn check_version_by_invalid_url() {
         const TEST_URL: &str = "http://localhost :80";
@@ -229,11 +188,6 @@ mod tests {
         assert_eq!(expected, actual);
     }
 
-    #[cfg(any(
-        target_arch = "aarch64",
-        target_arch = "powerpc64le",
-        target_arch = "x86_64"
-    ))]
     #[test]
     fn check_latest_version() {
         let version = get_kata_version_by_url(KATA_GITHUB_URL).unwrap();

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -9,18 +9,19 @@ use anyhow::{anyhow, Result};
 use reqwest::header::{CONTENT_TYPE, USER_AGENT};
 use serde_json::Value;
 use std::collections::HashMap;
-use std::fs;
 
 const KATA_GITHUB_URL: &str =
     "https://api.github.com/repos/kata-containers/kata-containers/releases/latest";
 
+#[cfg(any(target_arch = "x86_64"))]
 fn get_cpu_info(cpu_info_file: &str) -> Result<String> {
-    let contents = fs::read_to_string(cpu_info_file)?;
+    let contents = std::fs::read_to_string(cpu_info_file)?;
     Ok(contents)
 }
 
 // get_single_cpu_info returns the contents of the first cpu from
 // the specified cpuinfo file by parsing based on a specified delimiter
+#[cfg(any(target_arch = "x86_64"))]
 pub fn get_single_cpu_info(cpu_info_file: &str, substring: &str) -> Result<String> {
     let contents = get_cpu_info(cpu_info_file)?;
 
@@ -40,6 +41,7 @@ pub fn get_single_cpu_info(cpu_info_file: &str, substring: &str) -> Result<Strin
 
 // get_cpu_flags returns a string of cpu flags from cpuinfo, passed in
 // as a string
+#[cfg(any(target_arch = "x86_64"))]
 pub fn get_cpu_flags(cpu_info: &str, cpu_flags_tag: &str) -> Result<String> {
     if cpu_info.is_empty() {
         return Err(anyhow!("cpu_info string is empty"))?;
@@ -63,6 +65,7 @@ pub fn get_cpu_flags(cpu_info: &str, cpu_flags_tag: &str) -> Result<String> {
 
 // get_missing_strings searches for required (strings) in data and returns
 // a vector containing the missing strings
+#[cfg(any(target_arch = "x86_64"))]
 fn get_missing_strings(data: &str, required: &'static [&'static str]) -> Result<Vec<String>> {
     let mut missing: Vec<String> = Vec::new();
 
@@ -75,6 +78,7 @@ fn get_missing_strings(data: &str, required: &'static [&'static str]) -> Result<
     Ok(missing)
 }
 
+#[cfg(any(target_arch = "x86_64"))]
 pub fn check_cpu_flags(
     retrieved_flags: &str,
     required_flags: &'static [&'static str],
@@ -84,6 +88,7 @@ pub fn check_cpu_flags(
     Ok(missing_flags)
 }
 
+#[cfg(any(target_arch = "x86_64"))]
 pub fn check_cpu_attribs(
     cpu_info: &str,
     required_attribs: &'static [&'static str],
@@ -139,6 +144,7 @@ pub fn check_version() -> Result<()> {
     Ok(())
 }
 
+#[cfg(any(target_arch = "x86_64"))]
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/tools/kata-ctl/src/ops/check_ops.rs
+++ b/src/tools/kata-ctl/src/ops/check_ops.rs
@@ -32,16 +32,7 @@ pub fn handle_check(checkcmd: CheckArgument) -> Result<()> {
 
         CheckSubCommand::CheckVersionOnly => {
             // retrieve latest release
-            #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "powerpc64le",
-                target_arch = "x86_64"
-            ))]
             check::check_version()?;
-
-            // See: https://github.com/kata-containers/kata-containers/issues/5438
-            #[cfg(target_arch = "s390x")]
-            unimplemented!("Network check not implemented on s390x")
         }
     }
 


### PR DESCRIPTION
Re-enable network tests on s390x. On s390x, `reqwest` uses `native-tls` instead of `rustls-tls` and its `ring` dependencies that is not available on s390x. Further, `workspace.resolver` was necessary to allow `cfg` checks in `Cargo.toml`.

To let the tests running on s390x, further annotations where required. With that PR, test results look like:
````
git/kata-containers/kata-containers/src/tools/kata-ctl# make test
../../../utils.mk:153: "WARNING: s390x-unknown-linux-musl target is unavailable"
    Finished release [optimized] target(s) in 0.05s
     Running unittests (target/s390x-unknown-linux-gnu/release/deps/kata_ctl-7ef55a9a87c85ded)

running 7 tests
test check::tests::check_version_by_empty_url ... ok
test check::tests::check_version_by_garbage_url ... ok
test check::tests::check_version_by_invalid_url ... ok
test check::tests::test_get_cpu_flags_empty_input ... ok
test check::tests::test_get_cpu_info_empty_input ... ok
test ops::version::tests::test_get ... ok
test check::tests::check_latest_version ... ok

test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.78s
````

Fixes: #5438 

Signed-off-by: Hendrik Brueckner <brueckner@linux.ibm.com>

Cc: @BbolroC @jodh-intel 