### PR TITLE
Makefile: fix an typo in runtime-rs makefile

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -177,7 +177,7 @@ ifneq (,$(DBCMD))
     SYSCONFIG_DB = $(abspath $(SYSCONFDIR)/$(CONFIG_FILE_DB))
     SYSCONFIG_PATHS += $(SYSCONFIG_DB)
     CONFIGS += $(CONFIG_DB)
-    # dragonball-specific options (all should be suffixed by "_dragonball")
+    # dragonball-specific options (all should be suffixed by "_DB")
     DEFMAXVCPUS_DB := 1
     DEFBLOCKSTORAGEDRIVER_DB := virtio-blk
     DEFNETWORKMODEL_DB := tcfilter


### PR DESCRIPTION
There is a typo in runtime-rs makefile.
_dragonball should be _DB

fixes: #5452

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>