### PR TITLE
CC | actions: Publish a payload on every CCv0 push

### DIFF
--- a/.github/workflows/cc-payload-after-push.yaml
+++ b/.github/workflows/cc-payload-after-push.yaml
@@ -1,0 +1,87 @@
+name: CI | Publish Kata Containers payload for Confidential Containers
+on:
+  push:
+    branches:
+      - CCv0
+
+jobs:
+  build-asset:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        asset:
+          - cc-cloud-hypervisor
+          - cc-kernel
+          - cc-qemu
+          - cc-rootfs-image
+          - cc-shim-v2
+          - cc-virtiofsd
+          - cc-sev-kernel
+          - cc-sev-ovmf
+          - cc-sev-rootfs-initrd
+          - cc-tdx-kernel
+          - cc-tdx-qemu
+          - cc-tdx-td-shim
+          - cc-tdx-tdvf
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build ${{ matrix.asset }}
+        run: |
+          make "${KATA_ASSET}-tarball"
+          build_dir=$(readlink -f build)
+          # store-artifact does not work with symlink
+          sudo cp -r "${build_dir}" "kata-build"
+        env:
+          KATA_ASSET: ${{ matrix.asset }}
+          TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
+
+      - name: store-artifact ${{ matrix.asset }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: kata-artifacts
+          path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
+          retention-days: 1
+          if-no-files-found: error
+
+  create-kata-tarball:
+    runs-on: ubuntu-latest
+    needs: build-asset
+    steps:
+      - uses: actions/checkout@v3
+      - name: get-artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-artifacts
+          path: kata-artifacts
+      - name: merge-artifacts
+        run: |
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts
+      - name: store-artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: kata-static-tarball
+          path: kata-static.tar.xz
+          retention-days: 1
+          if-no-files-found: error
+
+  kata-payload:
+    needs: create-kata-tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.COCO_QUAY_DEPLOYER_USERNAME }}
+          password: ${{ secrets.COCO_QUAY_DEPLOYER_PASSWORD }}
+
+      - uses: actions/checkout@v3
+      - name: get-kata-tarball
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-static-tarball
+
+      - name: build-and-push-kata-payload
+        id: build-and-push-kata-payload
+        run: |
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh $(pwd)/kata-static.tar.xz "quay.io/repository/confidential-containers/runtime-payload-ci" "kata-containers-latest"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -7,13 +7,14 @@
 
 KATA_DEPLOY_DIR="`dirname $0`/../../kata-deploy-cc"
 KATA_DEPLOY_ARTIFACT="${1:-"kata-static.tar.xz"}"
+REGISTRY="${2:-"quay.io/confidential-containers/runtime-payload"}"
 
 echo "Copying $KATA_DEPLOY_ARTIFACT to $KATA_DEPLOY_DIR"
 cp $KATA_DEPLOY_ARTIFACT $KATA_DEPLOY_DIR
 
 pushd $KATA_DEPLOY_DIR
 
-IMAGE_TAG="quay.io/confidential-containers/runtime-payload:kata-containers-$(git rev-parse HEAD)"
+IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)"
 
 echo "Building the image"
 docker build --tag $IMAGE_TAG .

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -5,23 +5,23 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-KATA_DEPLOY_DIR="`dirname $0`/../../kata-deploy-cc"
+KATA_DEPLOY_DIR="`dirname ${0}`/../../kata-deploy-cc"
 KATA_DEPLOY_ARTIFACT="${1:-"kata-static.tar.xz"}"
 REGISTRY="${2:-"quay.io/confidential-containers/runtime-payload"}"
 TAG="${3:-}"
 
-echo "Copying $KATA_DEPLOY_ARTIFACT to $KATA_DEPLOY_DIR"
-cp $KATA_DEPLOY_ARTIFACT $KATA_DEPLOY_DIR
+echo "Copying ${KATA_DEPLOY_ARTIFACT} to ${KATA_DEPLOY_DIR}"
+cp ${KATA_DEPLOY_ARTIFACT} ${KATA_DEPLOY_DIR}
 
-pushd $KATA_DEPLOY_DIR
+pushd ${KATA_DEPLOY_DIR}
 
 IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)"
 
 echo "Building the image"
-docker build --tag $IMAGE_TAG .
+docker build --tag ${IMAGE_TAG} .
 
 echo "Pushing the image to quay.io"
-docker push $IMAGE_TAG
+docker push ${IMAGE_TAG}
 
 if [ -n "${TAG}" ]; then
 	ADDITIONAL_TAG="${REGISTRY}:${TAG}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -8,6 +8,7 @@
 KATA_DEPLOY_DIR="`dirname $0`/../../kata-deploy-cc"
 KATA_DEPLOY_ARTIFACT="${1:-"kata-static.tar.xz"}"
 REGISTRY="${2:-"quay.io/confidential-containers/runtime-payload"}"
+TAG="${3:-}"
 
 echo "Copying $KATA_DEPLOY_ARTIFACT to $KATA_DEPLOY_DIR"
 cp $KATA_DEPLOY_ARTIFACT $KATA_DEPLOY_DIR
@@ -21,5 +22,15 @@ docker build --tag $IMAGE_TAG .
 
 echo "Pushing the image to quay.io"
 docker push $IMAGE_TAG
+
+if [ -n "${TAG}" ]; then
+	ADDITIONAL_TAG="${REGISTRY}:${TAG}"
+
+	echo "Building the ${ADDITIONAL_TAG} image"
+	docker build  --tag ${ADDITIONAL_TAG} .
+
+	echo "Pushing the image ${ADDITIONAL_TAG} to quay.io"
+	docker push ${ADDITIONAL_TAG}
+fi
 
 popd


### PR DESCRIPTION
Let's have a GitHub action to publish the Kata Containers payload, after
every push to the CCv0 branch, to the Confidential Containers
`runtime-payload-ci` registry.

The intention of this action is to allow developers to test new
features, and easily bisect breakages that could've happened during the
development process.  Ideally we'd have a CI/CD pipeline where every
single change would be tested with the operator, but we're not yet
there.  In any case, this work would still be needed. :-)

It's very important to mention that this should be carefully considered
on whether it should or should not be merged back to `main`, as the flow
of PRs there is way higher than what we currently have as part of the
CCv0 branch.

Fixes: #5460

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>
