### PR TITLE
qemu: Re-work static-build Dockerfile

### DIFF
--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -4,15 +4,12 @@
 # SPDX-License-Identifier: Apache-2.0
 from ubuntu:20.04
 
-
-WORKDIR /root/qemu
-
 # CACHE_TIMEOUT: date to invalid cache, if the date changes the image will be rebuild
 # This is required to keep build dependencies with security fixes.
 ARG CACHE_TIMEOUT
-RUN echo "$CACHE_TIMEOUT"
 ARG DEBIAN_FRONTEND=noninteractive
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && apt-get upgrade -y && \
     apt-get --no-install-recommends install -y \
 	    apt-utils \
@@ -52,38 +49,7 @@ RUN apt-get update && apt-get upgrade -y && \
     if [ "$(uname -m)" != "s390x" ]; then apt-get install -y --no-install-recommends libpmem-dev; fi && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 
-ARG QEMU_REPO
-# commit/tag/branch
-ARG QEMU_VERSION
-ARG PREFIX
-# BUILD_SUFFIX is used by the qemu-build-post.sh script to
-# properly rename non vanilla versions of the QEMU
-ARG BUILD_SUFFIX
-ARG HYPERVISOR_NAME
-ARG PKGVERSION
-ARG QEMU_DESTDIR
-ARG QEMU_TARBALL
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN git clone  https://github.com/axboe/liburing/ ~/liburing && \
     cd ~/liburing && \
     git checkout tags/liburing-2.1 && \
     make && make install && ldconfig
-
-COPY scripts/configure-hypervisor.sh /root/configure-hypervisor.sh
-COPY qemu /root/kata_qemu
-COPY scripts/apply_patches.sh /root/apply_patches.sh
-COPY scripts/patch_qemu.sh /root/patch_qemu.sh
-COPY static-build/scripts/qemu-build-post.sh /root/static-build/scripts/qemu-build-post.sh
-COPY static-build/qemu.blacklist /root/static-build/qemu.blacklist
-
-RUN git clone --depth=1 "${QEMU_REPO}" qemu && \
-    cd qemu && \
-    git fetch --depth=1 origin "${QEMU_VERSION}" && git checkout FETCH_HEAD && \
-    scripts/git-submodule.sh update meson capstone && \
-    /root/patch_qemu.sh "${QEMU_VERSION}" "/root/kata_qemu/patches" && \
-    (PREFIX="${PREFIX}" /root/configure-hypervisor.sh -s "${HYPERVISOR_NAME}" | xargs ./configure \
-	--with-pkgversion="${PKGVERSION}") && \
-    make -j"$(nproc ${CI:+--ignore 1})" && \
-    make install DESTDIR="${QEMU_DESTDIR}" && \
-    /root/static-build/scripts/qemu-build-post.sh

--- a/tools/packaging/static-build/qemu/build-base-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-base-qemu.sh
@@ -9,6 +9,8 @@ set -o nounset
 set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
+readonly qemu_builder="${script_dir}/build-qemu.sh"
 
 source "${script_dir}/../../scripts/lib.sh"
 source "${script_dir}/../qemu.blacklist"
@@ -39,16 +41,8 @@ CACHE_TIMEOUT=$(date +"%Y-%m-%d")
 
 sudo "${container_engine}" build \
 	--build-arg CACHE_TIMEOUT="${CACHE_TIMEOUT}" \
-	--build-arg BUILD_SUFFIX=${build_suffix} \
-	--build-arg HYPERVISOR_NAME="${HYPERVISOR_NAME}" \
-	--build-arg PKGVERSION="${PKGVERSION}" \
 	--build-arg http_proxy="${http_proxy}" \
 	--build-arg https_proxy="${https_proxy}" \
-	--build-arg QEMU_DESTDIR="${qemu_destdir}" \
-	--build-arg QEMU_REPO="${qemu_repo}" \
-	--build-arg QEMU_VERSION="${qemu_version}" \
-	--build-arg QEMU_TARBALL="${qemu_tar}" \
-	--build-arg PREFIX="${prefix}" \
 	"${packaging_dir}" \
 	-f "${script_dir}/Dockerfile" \
 	-t qemu-static
@@ -56,7 +50,16 @@ sudo "${container_engine}" build \
 sudo "${container_engine}" run \
 	--rm \
 	-i \
+	--env BUILD_SUFFIX="${build_suffix}" \
+	--env HYPERVISOR_NAME="${HYPERVISOR_NAME}" \
+	--env PKGVERSION="${PKGVERSION}" \
+	--env QEMU_DESTDIR="${qemu_destdir}" \
+	--env QEMU_REPO="${qemu_repo}" \
+	--env QEMU_VERSION="${qemu_version}" \
+	--env QEMU_TARBALL="${qemu_tar}" \
+	--env PREFIX="${prefix}" \
+	-v "${repo_root_dir}:/root/kata-containers" \
 	-v "${PWD}":/share qemu-static \
-	mv "${qemu_destdir}/${qemu_tar}" /share/
+	bash -c "/root/kata-containers/tools/packaging/static-build/qemu/build-qemu.sh"
 
 sudo chown ${USER}:$(id -gn ${USER}) "${PWD}/${qemu_tar}"

--- a/tools/packaging/static-build/qemu/build-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-qemu.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2022 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+kata_packaging_dir="/root/kata-containers/tools/packaging"
+kata_packaging_scripts="${kata_packaging_dir}/scripts"
+
+kata_static_build_dir="${kata_packaging_dir}/static-build"
+kata_static_build_scripts="${kata_static_build_dir}/scripts"
+
+git clone --depth=1 "${QEMU_REPO}" qemu
+pushd qemu
+git fetch --depth=1 origin "${QEMU_VERSION}"
+git checkout FETCH_HEAD
+scripts/git-submodule.sh update meson capstone
+${kata_packaging_scripts}/patch_qemu.sh "${QEMU_VERSION}" "${kata_packaging_dir}/qemu/patches"
+PREFIX="${PREFIX}" ${kata_packaging_scripts}/configure-hypervisor.sh -s "${HYPERVISOR_NAME}" | xargs ./configure  --with-pkgversion="${PKGVERSION}"
+make -j"$(nproc +--ignore 1)"
+make install DESTDIR="${QEMU_DESTDIR}"
+popd
+${kata_static_build_scripts}/qemu-build-post.sh
+mv "${QEMU_DESTDIR}/${QEMU_TARBALL}" /share/


### PR DESCRIPTION
Differently than every single other bit that's part of our repo, QEMU has been using a single Dockerfile that prepares an environment where the project can be built, but *also* building the project as part of that very same Dockerfile.

This is a problem, for several different reasons, including:
* It's very hard to have a reproducible build if you don't have an archived image of the builder
* One cannot cache / ipload the image of the builder, as that contains already a specific version of QEMU
* Every single CI run we end up building the builder image, which includes building dependencies (such as liburing)

Let's split the logic into a new build script, and pass the build script to be executed inside the builder image, which will be only responsible for providing an environment where QEMU can be built.

Fixes: #5464

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>