### PR TITLE
CC | actions: Fix runtime-payload-ci registry address

### DIFF
--- a/.github/workflows/cc-payload-after-push.yaml
+++ b/.github/workflows/cc-payload-after-push.yaml
@@ -84,4 +84,4 @@ jobs:
       - name: build-and-push-kata-payload
         id: build-and-push-kata-payload
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh $(pwd)/kata-static.tar.xz "quay.io/repository/confidential-containers/runtime-payload-ci" "kata-containers-latest"
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh $(pwd)/kata-static.tar.xz "quay.io/confidential-containers/runtime-payload-ci" "kata-containers-latest"


### PR DESCRIPTION
There was a typo in the registry name, which should be quay.io/confidential-containers/runtime-payload-ci instead of quay.io/repository/confidential-containers/runtime-payload-ci

Fixes: #5469

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>