### PR TITLE
makefile: remove sudo when create symbolic link

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -490,7 +490,7 @@ install-runtime: runtime
 
 install-configs: $(CONFIGS)
 	$(foreach f,$(CONFIGS),$(call INSTALL_FILE,$f,$(dir $(CONFIG_PATH)))) \
-    sudo ln -sf $(DEFAULT_HYPERVISOR_CONFIG) $(DESTDIR)/$(CONFIG_PATH)
+	ln -sf $(DEFAULT_HYPERVISOR_CONFIG) $(DESTDIR)/$(CONFIG_PATH)
 
 .PHONY: \
 	help \


### PR DESCRIPTION
when using mock to package rpm, we cannot have sudo permission

Fixes: #5473
Signed-off-by: Zhongtao Hu <zhongtaohu.tim@linux.alibaba.com>