### PR TITLE
CC | packaging: Don't build runtime-rs if no RUST_VERSION is provided

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -149,9 +149,7 @@ install_cc_qemu() {
 #Install all components that are not assets
 install_cc_shimv2() {
 	GO_VERSION="$(yq r ${versions_yaml} languages.golang.meta.newest-version)"
-	RUST_VERSION="$(yq r ${versions_yaml} languages.rust.meta.newest-version)"
 	export GO_VERSION
-	export RUST_VERSION
 	export REMOVE_VMM_CONFIGS="acrn fc"
 
         extra_opts="DEFSERVICEOFFLOAD=true"

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -14,7 +14,7 @@ readonly kernel_builder="${repo_root_dir}/tools/packaging/kernel/build-kernel.sh
 
 
 GO_VERSION=${GO_VERSION}
-RUST_VERSION=${RUST_VERSION}
+RUST_VERSION=${RUST_VERSION:-}
 
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
@@ -30,15 +30,17 @@ if [ ${arch} = "ppc64le" ]; then
 	arch="ppc64"
 fi
 
-sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
-	-w "${repo_root_dir}/src/runtime-rs" \
-	"${container_image}" \
-	bash -c "git config --global --add safe.directory ${repo_root_dir} && make PREFIX=${PREFIX} QEMUCMD=qemu-system-${arch}"
+if [ -n "${RUST_VERSION}" ]; then
+	sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+		-w "${repo_root_dir}/src/runtime-rs" \
+		"${container_image}" \
+		bash -c "git config --global --add safe.directory ${repo_root_dir} && make PREFIX=${PREFIX} QEMUCMD=qemu-system-${arch}"
 
-sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
-	-w "${repo_root_dir}/src/runtime-rs" \
-	"${container_image}" \
-	bash -c "git config --global --add safe.directory ${repo_root_dir} && make PREFIX="${PREFIX}" DESTDIR="${DESTDIR}" install"
+	sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+		-w "${repo_root_dir}/src/runtime-rs" \
+		"${container_image}" \
+		bash -c "git config --global --add safe.directory ${repo_root_dir} && make PREFIX="${PREFIX}" DESTDIR="${DESTDIR}" install"
+fi
 	
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${repo_root_dir}/src/runtime" \

--- a/tools/packaging/static-build/shim-v2/install_go_rust.sh
+++ b/tools/packaging/static-build/shim-v2/install_go_rust.sh
@@ -51,11 +51,13 @@ EOF
 trap finish EXIT
 
 rust_version=${2:-}
-ARCH=${ARCH:-$(uname -m)}
-LIBC=${LIBC:-musl}
-curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSLf | sh -s -- -y --default-toolchain ${rust_version} -t ${ARCH}-unknown-linux-${LIBC}
-source /root/.cargo/env
-rustup target add x86_64-unknown-linux-musl
+if [ -n "${rust_version}" ]; then
+	ARCH=${ARCH:-$(uname -m)}
+	LIBC=${LIBC:-musl}
+	curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSLf | sh -s -- -y --default-toolchain ${rust_version} -t ${ARCH}-unknown-linux-${LIBC}
+	source /root/.cargo/env
+	rustup target add x86_64-unknown-linux-musl
+fi
 
 pushd "${tmp_dir}"
 


### PR DESCRIPTION
As the CCv0 effort is not using the runtime-rs, let's add a mechanism to avoid building it.

The easiest way to do so, is to simply *not* build the runtime-rs if the RUST_VERSION is not provided, and then not providing the RUST_VERSION as part of the cc-shim-v2-tarball target.

Fixes: #5462

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>