### PR TITLE
rustjail: Upgrade libseccomp crate to v0.3.0

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -743,10 +743,11 @@ checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
 name = "libseccomp"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49bda1fbf25c42ac8942ff7df1eb6172a3bc36299e84be0dba8c888a7db68c80"
+checksum = "21c57fd8981a80019807b7b68118618d29a87177c63d704fc96e6ecd003ae5b3"
 dependencies = [
+ "bitflags",
  "libc",
  "libseccomp-sys",
  "pkg-config",

--- a/src/agent/rustjail/Cargo.toml
+++ b/src/agent/rustjail/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = "1.2.0", features = ["sync", "io-util", "process", "time", "
 futures = "0.3.17"
 async-trait = "0.1.31"
 inotify = "0.9.2"
-libseccomp = { version = "0.2.3", optional = true }
+libseccomp = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 serial_test = "0.5.0"


### PR DESCRIPTION
The libseccomp crate v0.3.0 has been released, so use it in the agent.

Fixes: #5487

Signed-off-by: Manabu Sugimoto <Manabu.Sugimoto@sony.com>