### PR TITLE
ci: resolve dependencies for static checks driven by Github Action

### DIFF
--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -13,4 +13,5 @@ clone_tests_repo
 
 pushd "${tests_repo_dir}"
 .ci/setup.sh
+.ci/resolve-kata-dependencies.sh
 popd


### PR DESCRIPTION
Files automatically generated by tools should be ignored by license header check.
However, static checks driven by Github Action currently do not fetch prs from 
kata-containers/tests specified in the commit message by Depends-on.
This PR resolves dependencies when setup Github Action environment.

Fixes: #5486

Signed-off-by: Yuan-Zhuo <yuanzhuo0118@outlook.com>