### PR TITLE
agent: remove redundant checks

### DIFF
--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -327,7 +327,7 @@ impl Sandbox {
             // Reject non-file, symlinks and non-executable files
             if !entry.file_type()?.is_file()
                 || entry.file_type()?.is_symlink()
-                || entry.metadata()?.permissions().mode() & 0o777 & 0o111 == 0
+                || entry.metadata()?.permissions().mode() & 0o111 == 0
             {
                 continue;
             }


### PR DESCRIPTION
Remove redundant checks for executable files.

FIXes: #3730

Signed-off-by: Rouzip <1226015390@qq.com>