### PR TITLE
docs: Fix configuration path

### DIFF
--- a/docs/how-to/how-to-use-kata-containers-with-firecracker.md
+++ b/docs/how-to/how-to-use-kata-containers-with-firecracker.md
@@ -212,7 +212,7 @@ Next, we need to configure containerd. Add a file in your path (e.g. `/usr/local
 
 ```
 #!/bin/bash
-KATA_CONF_FILE=/etc/containers/configuration-fc.toml /usr/local/bin/containerd-shim-kata-v2 $@
+KATA_CONF_FILE=/etc/kata-containers/configuration-fc.toml /usr/local/bin/containerd-shim-kata-v2 $@
 ```
 > **Note:** You may need to edit the paths of the configuration file and the `containerd-shim-kata-v2` to correspond to your setup.
 


### PR DESCRIPTION
On install you generate a configuration-fc.toml file when building the kata-runtime and copy it to either /etc/kata-containers/configuration-fc.toml or /usr/share/defaults/kata-containers/configuration-fc.toml. To reflect that the path must be one of the above, we can fix the path in doc.