### PR TITLE
CC | Fix up issues with cached images

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -41,15 +41,12 @@ fi
 
 container_image="${CC_BUILDER_REGISTRY}:build-kata-deploy-$(get_last_modification ${kata_dir} ${script_dir})"
 
-docker pull "${container_image}" || \
-	(docker build -q -t "${container_image}" \
-		--build-arg IMG_USER="${USER}" \
-		--build-arg UID=${uid} \
-		--build-arg GID=${gid} \
-		--build-arg HOST_DOCKER_GID=${docker_gid} \
-		"${script_dir}/dockerbuild/" && \
- 	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"
-	 push_to_registry "${container_image}" "no")
+docker pull "${container_image}" || docker build -q -t "${container_image}" \
+	--build-arg IMG_USER="${USER}" \
+	--build-arg UID=${uid} \
+	--build-arg GID=${gid} \
+	--build-arg HOST_DOCKER_GID=${docker_gid} \
+	"${script_dir}/dockerbuild/"
 
 docker run \
 	--privileged \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -16,8 +16,6 @@ kata_deploy_create="${script_dir}/kata-deploy-binaries.sh"
 uid=$(id -u ${USER})
 gid=$(id -g ${USER})
 
-source "${script_dir}/../../scripts/lib.sh"
-
 if [ "${script_dir}" != "${PWD}" ]; then
 	ln -sf "${script_dir}/build" "${PWD}/build"
 fi
@@ -39,9 +37,7 @@ if [ ! -d "$HOME/.docker" ]; then
 	remove_dot_docker_dir=true
 fi
 
-container_image="${CC_BUILDER_REGISTRY}:build-kata-deploy-$(get_last_modification ${kata_dir} ${script_dir})"
-
-docker pull "${container_image}" || docker build -q -t "${container_image}" \
+docker build -q -t build-kata-deploy \
 	--build-arg IMG_USER="${USER}" \
 	--build-arg UID=${uid} \
 	--build-arg GID=${gid} \
@@ -64,7 +60,7 @@ docker run \
 	-v "${kata_dir}:${kata_dir}" \
 	--rm \
 	-w ${script_dir} \
-	"${container_image}" "${kata_deploy_create}" $@
+	build-kata-deploy "${kata_deploy_create}" $@
 
 if [ $remove_dot_docker_dir == true ]; then
 	rm -rf "$HOME/.docker"

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -126,7 +126,7 @@ get_last_modification() {
 	git config --global --add safe.directory ${repo_root_dir} &> /dev/null
 
 	dirty=""
-	[ $(git status --porcelain | grep "${file}" | wc -l) -gt 0 ] && dirty="-dirty"
+	[ $(git status --porcelain | grep "${file#${repo_root_dir}/}" | wc -l) -gt 0 ] && dirty="-dirty"
 
 	echo "$(git log -1 --pretty=format:"%H" ${file})${dirty}"
 }

--- a/tools/packaging/static-build/initramfs/Dockerfile
+++ b/tools/packaging/static-build/initramfs/Dockerfile
@@ -4,6 +4,13 @@
 from ubuntu:20.04
 
 ARG DEBIAN_FRONTEND=noninteractive
+ARG cryptsetup_repo=${cryptsetup_repo}
+ARG cryptsetup_version=${cryptsetup_version}
+ARG lvm2_repo=${lvm2_repo}
+ARG lvm2_version=${lvm2_version}
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 ENV TZ=UTC
 RUN apt-get update &&\
     apt-get --no-install-recommends install -y software-properties-common &&\
@@ -35,4 +42,31 @@ RUN apt-get update &&\
 	    libseccomp-dev \
 	    libseccomp2 \
 	    zlib1g-dev &&\
-    apt-get clean && rm -rf /var/lib/apt/lists/
+    apt-get clean && rm -rf /var/lib/apt/lists/ && \
+    build_root=$(mktemp -d) && \
+    pushd ${build_root} && \
+    echo "Build ${lvm2_repo} version: ${lvm2_version}" && \
+    git clone --depth 1 --branch "${lvm2_version}" "${lvm2_repo}" lvm2 && \
+    pushd lvm2 && \
+    ./configure --enable-static_link --disable-selinux && \
+    make && make install && \
+    cp ./libdm/libdevmapper.pc /usr/lib/pkgconfig/devmapper.pc && \
+    popd && \
+    echo "Build ${cryptsetup_repo} version: ${cryptsetup_version}" && \
+    git clone --depth 1 --branch "${cryptsetup_version}" "${cryptsetup_repo}" cryptsetup && \
+    pushd cryptsetup && \
+    ./autogen.sh && \
+    ./configure  --enable-static --enable-static-cryptsetup --disable-udev --disable-external-tokens --disable-ssh-token && \
+    make && make install && \
+    strip /usr/sbin/veritysetup.static && \
+    popd && \
+    echo "Build gen_init_cpio tool" && \
+    git clone --depth 1 --filter=blob:none --sparse https://github.com/torvalds/linux.git && \
+    pushd linux && \
+    git sparse-checkout add usr && cd usr && make gen_init_cpio && \
+    install gen_init_cpio /usr/sbin/ && \
+    popd && \
+    popd && \
+    rm -rf ${build_root}
+
+COPY init.sh /usr/sbin/init.sh

--- a/tools/packaging/static-build/initramfs/build-initramfs.sh
+++ b/tools/packaging/static-build/initramfs/build-initramfs.sh
@@ -12,44 +12,4 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${script_dir}/../../scripts/lib.sh"
 install_dir="${1:-.}"
 
-cryptsetup_repo="${cryptsetup_repo:-}"
-cryptsetup_version="${cryptsetup_version:-}"
-lvm2_repo="${lvm2_repo:-}"
-lvm2_version="${lvm2_version:-}"
-
-[ -n "${cryptsetup_repo}" ] || die "Failed to get cryptsetup repo"
-[ -n "${cryptsetup_version}" ] || die "Failed to get cryptsetup version"
-[ -n "${lvm2_repo}" ] || die "Failed to get lvm2 repo"
-[ -n "${lvm2_version}" ] || die "Failed to get lvm2 version"
-
-build_root=$(mktemp -d)
-pushd ${build_root}
-
-info "Build ${lvm2_repo} version: ${lvm2_version}"
-git clone --depth 1 --branch "${lvm2_version}" "${lvm2_repo}" lvm2
-pushd lvm2
-./configure --enable-static_link --disable-selinux
-make && make install
-cp ./libdm/libdevmapper.pc /usr/lib/pkgconfig/devmapper.pc
-popd #lvm2
-
-info "Build ${cryptsetup_repo} version: ${cryptsetup_version}"
-git clone --depth 1 --branch "${cryptsetup_version}" "${cryptsetup_repo}" cryptsetup
-pushd cryptsetup
-./autogen.sh
-./configure  --enable-static --enable-static-cryptsetup --disable-udev --disable-external-tokens --disable-ssh-token
-make && make install
-strip /usr/sbin/veritysetup.static
-popd #cryptsetup
-
-info "Build gen_init_cpio tool"
-git clone --depth 1 --filter=blob:none --sparse https://github.com/torvalds/linux.git
-pushd linux
-git sparse-checkout add usr && cd usr && make gen_init_cpio
-install gen_init_cpio /usr/sbin/
-popd #linux
-
-popd #${build_root}
-
-install "${script_dir}/init.sh" /usr/sbin/
 gen_init_cpio "${script_dir}/initramfs.list" | gzip -9 -n > "${install_dir}"/initramfs.cpio.gz

--- a/tools/packaging/static-build/initramfs/build.sh
+++ b/tools/packaging/static-build/initramfs/build.sh
@@ -32,7 +32,7 @@ package_output_dir="${package_output_dir:-}"
 [ -n "${lvm2_repo}" ] || die "Failed to get lvm2 repo"
 [ -n "${lvm2_version}" ] || die "Failed to get lvm2 version"
 
-container_image="${CC_BUILDER_REGISTRY}:initramfs-cryptsetup-${cryptsetup_version}-lvm2-${lvm2_version}-$(get_last_modification ${repo_root_dir} ${script_dir})"
+container_image="${CC_BUILDER_REGISTRY}:initramfs-cryptsetup-${cryptsetup_version}-lvm2-${lvm2_version}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)"
 
 sudo docker pull ${container_image} || (sudo docker build \
 	--build-arg cryptsetup_repo="${cryptsetup_repo}" \

--- a/tools/packaging/static-build/initramfs/build.sh
+++ b/tools/packaging/static-build/initramfs/build.sh
@@ -35,15 +35,15 @@ package_output_dir="${package_output_dir:-}"
 container_image="${CC_BUILDER_REGISTRY}:initramfs-cryptsetup-${cryptsetup_version}-lvm2-${lvm2_version}-$(get_last_modification ${repo_root_dir} ${script_dir})"
 
 sudo docker pull ${container_image} || (sudo docker build \
+	--build-arg cryptsetup_repo="${cryptsetup_repo}" \
+	--build-arg cryptsetup_version="${cryptsetup_version}" \
+	--build-arg lvm2_repo="${lvm2_repo}" \
+	--build-arg lvm2_version="${lvm2_version}" \
 	-t "${container_image}" "${script_dir}" && \
 	# No-op unless PUSH_TO_REGISTRY is exported as "yes"
 	push_to_registry "${container_image}")
 
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \
-	--env cryptsetup_repo="${cryptsetup_repo}" \
-	--env cryptsetup_version="${cryptsetup_version}" \
-	--env lvm2_repo="${lvm2_repo}" \
-	--env lvm2_version="${lvm2_version}" \
 	"${container_image}" \
 	bash -c "${initramfs_builder} ${default_install_dir}"

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -16,7 +16,7 @@ source "${script_dir}/../../scripts/lib.sh"
 
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
-container_image="${CC_BUILDER_REGISTRY}:kernel-$(get_last_modification ${repo_root_dir} ${script_dir})"
+container_image="${CC_BUILDER_REGISTRY}:kernel-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)"
 
 sudo docker pull ${container_image} || \
 	(sudo docker build -t "${container_image}" "${script_dir}" && \

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -16,7 +16,7 @@ source "${script_dir}/../../scripts/lib.sh"
 
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
-container_image="${CC_BUILDER_REGISTRY}:ovmf-$(get_last_modification ${repo_root_dir} ${script_dir})"
+container_image="${CC_BUILDER_REGISTRY}:ovmf-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)"
 ovmf_build="${ovmf_build:-x86_64}"
 kata_version="${kata_version:-}"
 ovmf_repo="${ovmf_repo:-}"

--- a/tools/packaging/static-build/qemu/build-base-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-base-qemu.sh
@@ -39,7 +39,7 @@ CACHE_TIMEOUT=$(date +"%Y-%m-%d")
 [ -n "${build_suffix}" ] && HYPERVISOR_NAME="kata-qemu-${build_suffix}" || HYPERVISOR_NAME="kata-qemu"
 [ -n "${build_suffix}" ] && PKGVERSION="kata-static-${build_suffix}" || PKGVERSION="kata-static"
 
-container_image="${CC_BUILDER_REGISTRY}:qemu-$(get_last_modification ${repo_root_dir} ${script_dir})"
+container_image="${CC_BUILDER_REGISTRY}:qemu-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)"
 
 sudo docker pull ${container_image} || \
 	(sudo "${container_engine}" build \

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -19,7 +19,7 @@ RUST_VERSION=${RUST_VERSION:-}
 
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
-container_image="${CC_BUILDER_REGISTRY}:shim-v2-go-${GO_VERSION}-rust-${RUST_VERSION}-$(get_last_modification ${repo_root_dir} ${script_dir})"
+container_image="${CC_BUILDER_REGISTRY}:shim-v2-go-${GO_VERSION}-rust-${RUST_VERSION}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)"
 
 EXTRA_OPTS="${EXTRA_OPTS:-""}"
 REMOVE_VMM_CONFIGS="${REMOVE_VMM_CONFIGS:-""}"

--- a/tools/packaging/static-build/td-shim/build.sh
+++ b/tools/packaging/static-build/td-shim/build.sh
@@ -30,7 +30,7 @@ package_output_dir="${package_output_dir:-}"
 [ -n "${tdshim_version}" ] || die "Failed to get TD-shim version or commit"
 [ -n "${tdshim_toolchain}" ] || die "Failed to get TD-shim toolchain to be used to build the project"
 
-container_image="${CC_BUILDER_REGISTRY}:td-shim-${tdshim_toolchain}-$(get_last_modification ${repo_root_dir} ${script_dir})"
+container_image="${CC_BUILDER_REGISTRY}:td-shim-${tdshim_toolchain}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)"
 
 sudo docker pull ${container_image} || \
 	(sudo docker build \

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -49,7 +49,7 @@ case ${ARCH} in
 		;;
 esac
 
-container_image="${CC_BUILDER_REGISTRY}:virtiofsd-${virtiofsd_toolchain}-${libc}-$(get_last_modification ${repo_root_dir} ${script_dir})"
+container_image="${CC_BUILDER_REGISTRY}:virtiofsd-${virtiofsd_toolchain}-${libc}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)"
 
 sudo docker pull ${container_image} || \
 	(sudo docker build \


### PR DESCRIPTION
lib.sh: Fix get_last_modification()

The ${file} path is an absolute path, as /home/fidencio/..., while the
result of the `git status --porcelain` is a path relative to the
${repo_root_dir}.  Because of this, the logic to adding `-dirty` to the
image name would never work.

Let's fix this by removing the ${repo_root_dir} from the ${file} when
grepping for it.

---

Revert "packaging: Add infra to push the kata-deploy builder image"

This reverts commit fe8b246ae4f3945fc5816cefcee5cf67bf233a59.

The reason this has to be reverted is because we cannot cache an image
that has a specific user, uid, gid, docker_host_id, and expect that to
work equally on different machines.  Unfortunately, this is one of the
images that cannot be cached at all.

---

Revert "packaging: Use existing image for the kata-deploy-build"

This reverts commit c1aac0cdeab66b2ee7f2e2fd822d837c3dcd544f.

The reason this has to be reverted is because we cannot cache an image
that has a specific user, uid, gid, docker_host_id, and expect that to
work equally on different machines.  Unfortunately, this is one of the
images that cannot be cached at all.

---

initramfs: Build dependencies as part of the Dockerfile

This will help to not have to build those on every CI run, and rather
take advantage of the cached image.
