### PR TITLE
runtime-rs: generate config files with the default target

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -357,14 +357,14 @@ endef
 
 .DEFAULT_GOAL := default
 
+GENERATED_FILES += $(CONFIGS)
+
 runtime: $(TARGET)
 
-$(TARGET): $(GENERATED_CODE) $(TARGET_PATH)
+$(TARGET): $(GENERATED_FILES) $(TARGET_PATH)
 
 $(TARGET_PATH): $(SOURCES) | show-summary
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE) $(EXTRA_RUSTFEATURES)
-
-GENERATED_FILES += $(CONFIGS)
 
 $(GENERATED_FILES): %: %.in
 	@sed \


### PR DESCRIPTION
Right now it is not generated with a simple `make`.
