### PR TITLE
versions: bump golangci-lint version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -324,7 +324,7 @@ languages:
   golangci-lint:
     description: "golangci-lint"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.41.1"
+    version: "1.46.2"
     meta:
       description: |
         'newest-version' is the latest version known to work when


### PR DESCRIPTION
There is little point to maintain backward compatibility for golangci-lint. Let's just use a unified version of it.
