### PR TITLE
docs: Fix volumeMounts in SGX usage example

### DIFF
--- a/docs/use-cases/using-Intel-SGX-and-kata.md
+++ b/docs/use-cases/using-Intel-SGX-and-kata.md
@@ -61,6 +61,9 @@ spec:
           name: eosgx-demo-job-1
           image: oeciteam/oe-helloworld:latest
           imagePullPolicy: IfNotPresent
+          volumeMounts:
+          - mountPath: /dev
+            name: dev-mount
           securityContext:
             readOnlyRootFilesystem: true
             capabilities:


### PR DESCRIPTION
The /dev/sgx is not mounted and the enclave is not available, causing the demo job to report an error in the logs. Add volumeMounts to container in order to have the device available in the container.

Fixes: #5514

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>