### PR TITLE
DO-NOT-MERGE: clh: Support QAT

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1096,8 +1096,18 @@ func (k *kataAgent) appendVfioDevice(dev ContainerDevice, device api.Device, c *
 		kataDevice.Type = kataVfioGuestKernelDevType
 	}
 
+	skipped := 0
 	for i, pciDev := range devList {
+		if pciDev.GuestPciPath.IsNil() {
+			skipped += 1
+			continue
+		}
+
 		kataDevice.Options[i] = fmt.Sprintf("0000:%s=%s", pciDev.BDF, pciDev.GuestPciPath)
+	}
+
+	if skipped == len(devList) {
+		return nil
 	}
 
 	return kataDevice


### PR DESCRIPTION
This patch is more a request for opinions / help then a patch itself, and it tries to add support to QAT accelerators, using Cloud Hypervisor, with the newest QAT device plugin container provided by Intel.

There are several things here that I don't fully understand and that I'd like to get the help from someone more experienced (bergwolf, zvonko, mikko, archana) on this.

First thing, the way the QAT device plugin container works is that it requires the QAT device to be plugged behind an IOMMU bar.  In order to do so with Cloud Hypervisor, we have to add a second PCI segment, and on this PCI segment plug in the QAT device.  We need to do this because either all the devices in that PCI segmnet use IOMMU, or none of the devices do.

Looking at the agent error below, it makes me think that the agent is only scanning the 0000 bus, and it should be expanded to scan other buses.
```
Events:
  Type     Reason     Age              From               Message
  ----     ------     ----             ----               -------
  Normal   Scheduled  11s              default-scheduler  Successfully assigned default/openssl-qat-engine-dpgithub-june16-clh to 984fee00bf41
  Normal   Pulled     9s               kubelet            Successfully pulled image "localhost/openssl-qat-engine-dpgithub-june16:latest" in 10.788116ms
  Normal   Pulling    5s (x2 over 9s)  kubelet            Pulling image "localhost/openssl-qat-engine-dpgithub-june16:latest"
  Normal   Pulled     5s               kubelet            Successfully pulled image "localhost/openssl-qat-engine-dpgithub-june16:latest" in 11.126763ms
  Warning  Failed     2s (x2 over 6s)  kubelet            Error: CreateContainer failed: Timeout after 3s waiting for uevent PciMatcher { devpath: "/devices/pci0000:00/0000:00:01.0" }: unknown
```

However, one thing that bugs me quite a lot is that if we simply don't pass the device to the agent, as forced in this patch, everything simply works as expected and the QAT device plugin container will do everything needed magically, and things will work as expected.  With this in mind, I started questioning whether actually scanning for more buses would be the right approach, instead of simply filtering out such devices.  But then, if we filter out the devices, how to do that in a programatically way? :-)

So, this is where I hit my knowledge limitation, and where I'd appreciate feedback and ideas from others.

QAT plugin container: https://hub.docker.com/r/intel/intel-qat-plugin

Fixes: #0000

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>