### PR TITLE
virtiofsd: Not use "link-self-contained=yes" on s390x

### DIFF
--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -47,6 +47,7 @@ pull_virtiofsd_released_binary() {
 init_env() {
    source "$HOME/.cargo/env"
 
+   extra_rust_flags=" -C link-self-contained=yes"
    case ${ARCH} in
      "aarch64")
        LIBC="musl"
@@ -60,6 +61,7 @@ init_env() {
      "s390x")
        LIBC="gnu"
        ARCH_LIBC=${ARCH}-linux-${LIBC}
+       extra_rust_flags=""
      ;;
      "x86_64")
        LIBC="musl"
@@ -76,7 +78,7 @@ build_virtiofsd_from_source() {
    git clone --depth 1 --branch ${virtiofsd_version} ${virtiofsd_repo} virtiofsd
    pushd virtiofsd
 
-   export RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes'
+   export RUSTFLAGS='-C target-feature=+crt-static'${extra_rust_flags}
    export LIBSECCOMP_LINK_TYPE=static
    export LIBSECCOMP_LIB_PATH=/usr/lib/${ARCH_LIBC}
    export LIBCAPNG_LINK_TYPE=static


### PR DESCRIPTION
The compile option `link-self-contained=yes` asks rustc to use C library startup object files that come with the compiler, which are not available on the target `s390x-unknown-linux-gnu`. A build does not contain any startup files leading to a broken executable entry point (causing segmentation fault). This PR is to make the compile option able to be skipped for `s390x`. 

Fixes: #5522

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>