### PR TITLE
runtime-rs : fix the shim source in the documentation test is ambiguous

### DIFF
--- a/src/runtime-rs/crates/shim/src/lib.rs
+++ b/src/runtime-rs/crates/shim/src/lib.rs
@@ -16,7 +16,7 @@ pub use error::Error;
 mod logger;
 mod panic_hook;
 mod shim;
-pub use shim::ShimExecutor;
+pub use crate::shim::ShimExecutor;
 mod core_sched;
 #[rustfmt::skip]
 pub mod config;


### PR DESCRIPTION
The name shim has multiple potential sources of import, this patch now gives it a clear source.

Fixes: #5535

Signed-off-by: Chen TaoTao <chentt10@chinatelecom.cn>