### PR TITLE
CC | osbuilder: Install rats-tls-tdx

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -26,7 +26,7 @@ if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
 	if [ "${VERSION_ID}" == "20.04" ]; then
 		PACKAGES+=" apt gnupg"
 		AA_KBC_EXTRAS="
-RUN echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID} bionic main' \| tee /etc/apt/sources.list.d/inclavare-containers.list; \
+RUN echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID} ${OS_VERSION} main' \| tee /etc/apt/sources.list.d/inclavare-containers.list; \
     curl -L http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID}/DEB-GPG-KEY.key \| apt-key add -; \
     apt-get update; \
     apt-get install -y rats-tls

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -28,11 +28,13 @@ if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
 		AA_KBC_EXTRAS="
 RUN echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID} ${OS_VERSION} main' \| tee /etc/apt/sources.list.d/inclavare-containers.list; \
     curl -L http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID}/DEB-GPG-KEY.key \| apt-key add -; \
+    echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${OS_VERSION} main' \| tee /etc/apt/sources.list.d/intel-sgx.list; \
+    curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \| apt-key add -; \
     apt-get update; \
-    apt-get install -y rats-tls
+    apt-get install -y rats-tls-tdx
 "
 	else
-		echo "rats-tls is only provided for Ubuntu 20.04, there's yet no packages for Ubuntu ${VERSION_ID}"
+		echo "rats-tls-tdx is only provided for Ubuntu 20.04, there's yet no packages for Ubuntu ${VERSION_ID}"
 	fi
 fi
 

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -21,13 +21,19 @@ case "$ARCH" in
 esac
 
 if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
-	PACKAGES+=" apt gnupg"
-	AA_KBC_EXTRAS="
-RUN echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04 bionic main' \| tee /etc/apt/sources.list.d/inclavare-containers.list; \
-    curl -L http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04/DEB-GPG-KEY.key \| apt-key add -; \
+	source /etc/os-release
+
+	if [ "${VERSION_ID}" == "20.04" ]; then
+		PACKAGES+=" apt gnupg"
+		AA_KBC_EXTRAS="
+RUN echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID} bionic main' \| tee /etc/apt/sources.list.d/inclavare-containers.list; \
+    curl -L http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID}/DEB-GPG-KEY.key \| apt-key add -; \
     apt-get update; \
     apt-get install -y rats-tls
 "
+	else
+		echo "rats-tls is only provided for Ubuntu 20.04, there's yet no packages for Ubuntu ${VERSION_ID}"
+	fi
 fi
 
 if [ "$(uname -m)" != "$ARCH" ]; then

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -38,13 +38,18 @@ EOF
 
 		if [ "${VERSION_ID}" == "20.04" ]; then
 			curl -L http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID}/DEB-GPG-KEY.key | chroot "$rootfs_dir" apt-key add -
+    			curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | chroot "${rootfs_dir}" apt-key add -
 			cat << EOF | chroot "$rootfs_dir"
+apt-get update
+apt-get install -y software-properties-common
+add-apt-repository universe
+echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list
 echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID} focal main' | tee /etc/apt/sources.list.d/inclavare-containers.list
 apt-get update
-apt-get install -y rats-tls
+apt-get install -y rats-tls-tdx
 EOF
 		else
-			echo "rats-tls is only provided for Ubuntu 20.04, there's yet no packages for Ubuntu ${VERSION_ID}"
+			echo "rats-tls-tdx is only provided for Ubuntu 20.04, there's yet no packages for Ubuntu ${VERSION_ID}"
 		fi
 	fi
 }

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -34,11 +34,17 @@ EOF
 	rm -rf $rootfs_dir/usr/share/{bash-completion,bug,doc,info,lintian,locale,man,menu,misc,pixmaps,terminfo,zsh}
 
 	if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
-		curl -L http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04/DEB-GPG-KEY.key | chroot "$rootfs_dir" apt-key add -
-		cat << EOF | chroot "$rootfs_dir"
-echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu20.04 bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
+		source /etc/os-release
+
+		if [ "${VERSION_ID}" == "20.04" ]; then
+			curl -L http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID}/DEB-GPG-KEY.key | chroot "$rootfs_dir" apt-key add -
+			cat << EOF | chroot "$rootfs_dir"
+echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID} bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
 apt-get update
 apt-get install -y rats-tls
 EOF
+		else
+			echo "rats-tls is only provided for Ubuntu 20.04, there's yet no packages for Ubuntu ${VERSION_ID}"
+		fi
 	fi
 }

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -39,7 +39,7 @@ EOF
 		if [ "${VERSION_ID}" == "20.04" ]; then
 			curl -L http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID}/DEB-GPG-KEY.key | chroot "$rootfs_dir" apt-key add -
 			cat << EOF | chroot "$rootfs_dir"
-echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID} bionic main' | tee /etc/apt/sources.list.d/inclavare-containers.list
+echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID} focal main' | tee /etc/apt/sources.list.d/inclavare-containers.list
 apt-get update
 apt-get install -y rats-tls
 EOF


### PR DESCRIPTION
Inclavare released a rats-tls-tdx package, which we depend on for using
verdictd.

Let's install it when using EAA_KBC, as already done for the rats-tls
package.

Fixes: #5543