### PR TITLE
CC | runtime: Enable kernel hashes for all SEV guests

### DIFF
--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -349,6 +349,7 @@ func (q *qemuAmd64) appendSEVObject(devices []govmmQemu.Device, firmware, firmwa
 				CBitPos:         cpuid.AMDMemEncrypt.CBitPosition,
 				ReducedPhysBits: cpuid.AMDMemEncrypt.PhysAddrReduction,
 				SevPolicy:       config.Policy,
+				SevKernelHashes: true,
 			}), "", nil
 	}
 }


### PR DESCRIPTION
This commit adds the `kernel-hashes=on` flag to the QEMU command line for all SEV guests (previously, this was only enabled for SEV guests with `guest_pre_attestation=on`. This change allows the AmdSev firmware to be used for both encrypted and non-encrypted container images.

**Note:** 
This change makes the AmdSev OVMF build a requirement for all SEV guests. The standard host OVMF package will no longer work.

Fixes #5307 

Signed-off-by: Jim Cadden <jcadden@ibm.com>