### PR TITLE
runtime-rs: fix shared volume permission issue

### DIFF
--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -65,7 +65,7 @@ impl ShareFsVolume {
                         cid: cid.to_string(),
                         source: m.source.clone(),
                         target: file_name,
-                        readonly: false,
+                        readonly: m.options.iter().any(|o| *o == "ro"),
                         mount_options: m.options.clone(),
                         mount: m.clone(),
                     })


### PR DESCRIPTION
Fix the issue where share volumes always have readwrite permission even if
readonly permission is enough.

Fixes: kata-containers#5549

Signed-off-by: Xuewei Niu <justxuewei@apache.org>