### PR TITLE
runk: Ignore an error when calling kill cmd with --all option

### DIFF
--- a/src/tools/runk/libcontainer/src/status.rs
+++ b/src/tools/runk/libcontainer/src/status.rs
@@ -141,7 +141,7 @@ pub fn is_process_running(pid: Pid) -> Result<bool> {
     match kill(pid, None) {
         Err(errno) => {
             if errno != Errno::ESRCH {
-                return Err(anyhow!("no such process"));
+                return Err(anyhow!("failed to kill process {}: {:?}", pid, errno));
             }
             Ok(false)
         }


### PR DESCRIPTION
Ignore an error handling that is triggered when the kill command is called
with `--all option` to the stopped container.

High-level container runtimes such as containerd call the kill command with
`--all` option in order to terminate all processes inside the container
even if the container already is stopped. Hence, a low-level runtime
should allow `kill --all` regardless of the container state like runc.

This commit reverts to the previous behavior.

Fixes: https://github.com/kata-containers/kata-containers/issues/5555