### PR TITLE
Dragonball: enable mem_file_path config into hugetlbfs process

### DIFF
--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -520,6 +520,7 @@ impl Vm {
         let mem_type = self.vm_config.mem_type.clone();
         let mut mem_file_path = String::from("");
         if mem_type == "hugetlbfs" {
+            mem_file_path = self.vm_config.mem_file_path.clone();
             let shared_info = self.shared_info.read()
                     .expect("Failed to determine if instance is initialized because shared info couldn't be read due to poisoned lock");
             mem_file_path.push_str("/dragonball/");


### PR DESCRIPTION
In the current Dragonball code, mem_file_path config is not used when hugetlbfs is enabled.
In this commit we add mem_file_path into hugetlbfs enable process.

fixes: #5566
Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>