### PR TITLE
snap: Unbreak docker install

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -89,9 +89,11 @@ parts:
       - -*
     build-packages:
       - ca-certificates
+      - containerd
       - curl
       - gnupg
       - lsb-release
+      - runc
     override-build: |
       source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -88,12 +88,13 @@ parts:
     prime:
       - -*
     build-packages:
+      - ca-certificates
       - curl
+      - gnupg
+      - lsb-release
     override-build: |
       source "${SNAPCRAFT_PROJECT_DIR}/snap/local/snap-common.sh"
 
-      sudo apt-get -y update
-      sudo apt-get -y install ca-certificates curl gnupg lsb-release
       curl -fsSL https://download.docker.com/linux/ubuntu/gpg |\
           sudo gpg --batch --yes --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
       distro_codename=$(lsb_release -cs)


### PR DESCRIPTION
It appears that _either_ the GitHub workflow runners have changed their
environment, or the Ubuntu archive has changed package dependencies,
resulting in the following error when building the snap:

```
Installing build dependencies: bc bison build-essential cpio curl docker.io flex gcc git git-extras gnupg2 iptables libattr1-dev libblkid-dev libcap-dev libcap-ng-dev l  ibcapstone-dev libelf-dev libfdt-dev libffi-dev libglib2.0-dev libltdl-dev libmount-dev libnuma-dev libpixman-1-dev libseccomp-dev libselinux1-dev make ninja-build python3   software-properties-common uidmap zlib1g-dev

    :

The following packages have unmet dependencies:
docker.io : Depends: containerd (>= 1.2.6-0ubuntu1~)
E: Unable to correct problems, you have held broken packages.
```

This PR uses the simplest solution: install the `containerd` and `runc`
packages. However, we might want to investigate alternative solutions in
the future given that the docker and containerd packages seem to have
gone wild in the Ubuntu GitHub workflow runner environment. If you
include the official docker repo (which the snap uses), a _subset_ of
the related packages is now:

- `containerd`
- `containerd.io`
- `docker-ce`
- `docker.io`
- `moby-containerd`
- `moby-engine`
- `moby-runc`
- `runc`

Fixes: #5545.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>