### PR TITLE
CC | clh: Increase the timeouts when using Conf Guests

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -68,12 +68,12 @@ const (
 	// Values based on:
 	clhTimeout                     = 10
 	clhAPITimeout                  = 1
-	clhAPITimeoutConfidentialGuest = 10
+	clhAPITimeoutConfidentialGuest = 20
 	// Timeout for hot-plug - hotplug devices can take more time, than usual API calls
 	// Use longer time timeout for it.
 	clhHotPlugAPITimeout                   = 5
 	clhStopSandboxTimeout                  = 3
-	clhStopSandboxTimeoutConfidentialGuest = 5
+	clhStopSandboxTimeoutConfidentialGuest = 10
 	clhSocket                              = "clh.sock"
 	clhAPISocket                           = "clh-api.sock"
 	virtioFsSocket                         = "virtiofsd.sock"


### PR DESCRIPTION
Launching a pod with measured boot enabled seems to be taking longer than expected with Cloud Hypervisor, which leads to hitting a timeout limit.

Let's double those timeout limits for now.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>