### PR TITLE
clh: avoid race condition when stopping clh

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1405,16 +1405,16 @@ func (clh *cloudHypervisor) isClhRunning(timeout uint) (bool, error) {
 		return false, nil
 	}
 
-	if err := syscall.Kill(pid, syscall.Signal(0)); err != nil {
-		return false, nil
-	}
-
 	timeStart := time.Now()
 	cl := clh.client()
 	for {
+		err := syscall.Kill(pid, syscall.Signal(0))
+		if err != nil {
+			return false, nil
+		}
 		ctx, cancel := context.WithTimeout(context.Background(), clh.getClhAPITimeout()*time.Second)
-		defer cancel()
-		_, _, err := cl.VmmPingGet(ctx)
+		_, _, err = cl.VmmPingGet(ctx)
+		cancel()
 		if err == nil {
 			return true, nil
 		} else {

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -24,6 +24,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -256,6 +258,8 @@ type cloudHypervisor struct {
 	vmconfig        chclient.VmConfig
 	state           CloudHypervisorState
 	config          HypervisorConfig
+	stopped         int32
+	mu              sync.Mutex
 }
 
 var clhKernelParams = []Param{
@@ -1081,9 +1085,21 @@ func (clh *cloudHypervisor) ResumeVM(ctx context.Context) error {
 
 // StopVM will stop the Sandbox's VM.
 func (clh *cloudHypervisor) StopVM(ctx context.Context, waitOnly bool) (err error) {
+	clh.mu.Lock()
+	defer func() {
+		if err == nil {
+			atomic.StoreInt32(&clh.stopped, 1)
+		}
+		clh.mu.Unlock()
+	}()
 	span, _ := katatrace.Trace(ctx, clh.Logger(), "StopVM", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 	clh.Logger().WithField("function", "StopVM").Info("Stop Sandbox")
+	if atomic.LoadInt32(&clh.stopped) != 0 {
+		clh.Logger().Info("Already stopped")
+		return nil
+	}
+
 	return clh.terminate(ctx, waitOnly)
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1401,6 +1401,10 @@ func (clh *cloudHypervisor) isClhRunning(timeout uint) (bool, error) {
 
 	pid := clh.state.PID
 
+	if atomic.LoadInt32(&clh.stopped) != 0 {
+		return false, nil
+	}
+
 	if err := syscall.Kill(pid, syscall.Signal(0)); err != nil {
 		return false, nil
 	}

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -969,7 +969,7 @@ func (q *qemu) waitVM(ctx context.Context, timeout int) error {
 }
 
 // StopVM will stop the Sandbox's VM.
-func (q *qemu) StopVM(ctx context.Context, waitOnly bool) error {
+func (q *qemu) StopVM(ctx context.Context, waitOnly bool) (err error) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	span, _ := katatrace.Trace(ctx, q.Logger(), "StopVM", qemuTracingTags, map[string]string{"sandbox_id": q.id})
@@ -983,7 +983,9 @@ func (q *qemu) StopVM(ctx context.Context, waitOnly bool) error {
 
 	defer func() {
 		q.cleanupVM()
-		q.stopped = true
+		if err == nil {
+			q.stopped = true
+		}
 	}()
 
 	if q.config.Debug && q.qemuConfig.LogFile != "" {


### PR DESCRIPTION
clh: don't try to stop clh multiple times
clh: fast exit from isClhRunning if the process was stopped
clh: return faster with dead Cloud Hypervisor process from isClhRunning
qemu: set stopped only if StopVM is successful
qemu: early exit from Check if the process was stopped

Avoid executing StopVM concurrently when virtiofs dies as a result of clh being stopped in StopVM.
Proactively check if Cloud Hypervisor process is dead in isClhRunning
Set stopped to 1 in clh and qemu only if StopVM returns without an error.
Fast exit from Check for both clh and qemu if the process was stopped, uses atomic operations instead of acquiring a mutex.
This stops isClhRunning from generating a deadlock by trying to reacquire an already-acquired lock when called via StopVM->terminate.

Fixes #5622, #5623, #5624, #5625

Signed-off-by: Alexandru Matei <alexandru.matei@uipath.com>