### PR TITLE
CC: Make agent build differently for image-rs on s390x

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -85,6 +85,14 @@ ifeq ($(INIT),no)
     UNIT_FILES += kata-containers.target
 endif
 
+# The following will be reverted, after
+# https://github.com/kata-containers/kata-containers/issues/5582
+# is resolved.
+IMAGE_RS_COMMIT = a1d7ba31201d9d7a575d05c5fed1f2cb2142a842
+ifeq ($(ARCH),s390x)
+    $(shell sed -i -e "s/^\(image-rs.*\)tag\(.*\)/\1rev\2/" -e "s/^\(image-rs.*rev = \"\).*\(\".*\)/\1$(IMAGE_RS_COMMIT)\2/" Cargo.toml)
+endif
+
 # Display name of command and it's version (or a message if not available).
 #
 # Arguments:


### PR DESCRIPTION
This is just to keep the support for s390x without the cosign verification while looking for a solution for #5582.

Fixes: #5599

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>