### PR TITLE
CC: Remove target directory for umoci before unpacking

### DIFF
--- a/src/agent/src/image_rpc.rs
+++ b/src/agent/src/image_rpc.rs
@@ -129,6 +129,7 @@ impl ImageService {
         let source_path_oci = tmp_cid_path.join(IMAGE_OCI);
 
         let target_path_bundle = Path::new(CONTAINER_BASE).join(cid);
+        let _ = fs::remove_dir_all(&target_path_bundle);
 
         info!(sl!(), "unpack image {:?} to {:?}", cid, target_path_bundle);
 


### PR DESCRIPTION
Fixes #5602

Signed-off-by: Xuejun Yang <xuejya@microsoft.com>