### PR TITLE
runtime-rs: bind mount volumes in sandbox level

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,8 @@
 **/*.rej
 **/target
 **/.vscode
+**/.idea
+**/.fleet
 pkg/logging/Cargo.lock
 src/agent/src/version.rs
 src/agent/kata-agent.service

--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -225,7 +225,7 @@ pub fn bind_remount<P: AsRef<Path>>(dst: P, readonly: bool) -> Result<()> {
     let dst = dst
         .canonicalize()
         .map_err(|_e| Error::InvalidPath(dst.to_path_buf()))?;
-    
+
     do_rebind_mount(dst, readonly, MsFlags::empty())
 }
 

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -250,6 +250,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1352,6 +1358,8 @@ dependencies = [
 name = "kata-types"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "base64",
  "bitmask-enum",
  "byte-unit",
  "glob",
@@ -2288,6 +2296,7 @@ dependencies = [
  "rtnetlink",
  "scopeguard",
  "serde",
+ "serde_json",
  "slog",
  "slog-scope",
  "test-utils",

--- a/src/runtime-rs/crates/resource/src/share_fs/utils.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/utils.rs
@@ -18,6 +18,7 @@ pub(crate) fn ensure_dir_exist(path: &Path) -> Result<()> {
     Ok(())
 }
 
+/// Bind mount the original path to the runtime directory.
 pub(crate) fn share_to_guest(
     // absolute path for source
     source: &str,
@@ -37,7 +38,7 @@ pub(crate) fn share_to_guest(
     // to remount the read only dir mount point directly.
     if readonly {
         let dst = do_get_host_path(target, sid, cid, is_volume, true);
-        mount::bind_remount_read_only(&dst).context("bind remount readonly")?;
+        mount::bind_remount(&dst, readonly).context("bind remount readonly")?;
     }
 
     Ok(do_get_guest_path(target, cid, is_volume, is_rafs))
@@ -114,3 +115,17 @@ pub(crate) fn do_get_host_path(
     };
     path.to_str().unwrap().to_string()
 }
+
+// /// Get the bind mounted path on the host that will be shared to the guest in
+// /// **sandbox level**.
+// /// The filename is in format of "sandbox-{uuid}-examplename".
+// pub(crate) fn do_get_sandbox_level_host_path(sid: &str, filename: &str, readonly: bool) -> String {
+//     do_get_host_path(filename, sid, "", true, readonly)
+// }
+
+// /// Get the bind mounted path on the guest that will be shared from the host in
+// /// **sandbox level**.
+// /// The filename is in format of "sandbox-{uuid}-examplename".
+// pub(crate) fn do_get_sandbox_level_guest_path(filename: &str) -> String {
+//     do_get_guest_any_path(filename, "", true, false)
+// }

--- a/src/runtime-rs/crates/resource/src/share_fs/utils.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/utils.rs
@@ -115,17 +115,3 @@ pub(crate) fn do_get_host_path(
     };
     path.to_str().unwrap().to_string()
 }
-
-// /// Get the bind mounted path on the host that will be shared to the guest in
-// /// **sandbox level**.
-// /// The filename is in format of "sandbox-{uuid}-examplename".
-// pub(crate) fn do_get_sandbox_level_host_path(sid: &str, filename: &str, readonly: bool) -> String {
-//     do_get_host_path(filename, sid, "", true, readonly)
-// }
-
-// /// Get the bind mounted path on the guest that will be shared from the host in
-// /// **sandbox level**.
-// /// The filename is in format of "sandbox-{uuid}-examplename".
-// pub(crate) fn do_get_sandbox_level_guest_path(filename: &str) -> String {
-//     do_get_guest_any_path(filename, "", true, false)
-// }

--- a/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
@@ -170,7 +170,7 @@ impl ShareFsMount for VirtiofsShareMount {
         })
     }
 
-    async fn upgrade(&self, file_name: &str) -> Result<()> {
+    async fn upgrade_to_rw(&self, file_name: &str) -> Result<()> {
         // Remount readonly directory with readwrite permission
         let host_dest = do_get_host_path(file_name, &self.id, "", true, true);
         bind_remount(&host_dest, false)
@@ -182,7 +182,7 @@ impl ShareFsMount for VirtiofsShareMount {
         Ok(())
     }
 
-    async fn downgrade(&self, file_name: &str) -> Result<()> {
+    async fn downgrade_to_ro(&self, file_name: &str) -> Result<()> {
         // Remount readwrite directory with readonly permission
         let host_dest = do_get_host_path(file_name, &self.id, "", true, false);
         bind_remount(&host_dest, true)
@@ -195,10 +195,9 @@ impl ShareFsMount for VirtiofsShareMount {
     }
 
     async fn umount(&self, file_name: &str) -> Result<()> {
-        let host_dest = do_get_host_path(file_name, &self.id, "", true, false);
-        umount_timeout(&host_dest, 0).context("Umount readonly host dest")?;
         let host_dest = do_get_host_path(file_name, &self.id, "", true, true);
         umount_timeout(&host_dest, 0).context("Umount readwrite host dest")?;
+        // Umount event will be propagated to ro directory
         Ok(())
     }
 }

--- a/src/runtime-rs/crates/resource/src/volume/block_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/block_volume.rs
@@ -5,9 +5,11 @@
 //
 
 use anyhow::Result;
+use async_trait::async_trait;
 
 use super::Volume;
 
+#[derive(Debug)]
 pub(crate) struct BlockVolume {}
 
 /// BlockVolume: block device volume
@@ -17,6 +19,7 @@ impl BlockVolume {
     }
 }
 
+#[async_trait]
 impl Volume for BlockVolume {
     fn get_volume_mount(&self) -> anyhow::Result<Vec<oci::Mount>> {
         todo!()
@@ -26,8 +29,9 @@ impl Volume for BlockVolume {
         todo!()
     }
 
-    fn cleanup(&self) -> Result<()> {
-        todo!()
+    async fn cleanup(&self) -> Result<()> {
+        warn!(sl!(), "Cleaning up BlockVolume is still unimplemented.");
+        Ok(())
     }
 }
 

--- a/src/runtime-rs/crates/resource/src/volume/default_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/default_volume.rs
@@ -5,9 +5,11 @@
 //
 
 use anyhow::Result;
+use async_trait::async_trait;
 
 use super::Volume;
 
+#[derive(Debug)]
 pub(crate) struct DefaultVolume {
     mount: oci::Mount,
 }
@@ -21,6 +23,7 @@ impl DefaultVolume {
     }
 }
 
+#[async_trait]
 impl Volume for DefaultVolume {
     fn get_volume_mount(&self) -> anyhow::Result<Vec<oci::Mount>> {
         Ok(vec![self.mount.clone()])
@@ -30,7 +33,8 @@ impl Volume for DefaultVolume {
         Ok(vec![])
     }
 
-    fn cleanup(&self) -> Result<()> {
-        todo!()
+    async fn cleanup(&self) -> Result<()> {
+        warn!(sl!(), "Cleaning up DefaultVolume is still unimplemented.");
+        Ok(())
     }
 }

--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -8,6 +8,7 @@ mod block_volume;
 mod default_volume;
 mod share_fs_volume;
 mod shm_volume;
+use async_trait::async_trait;
 
 use std::{sync::Arc, vec::Vec};
 
@@ -16,10 +17,11 @@ use tokio::sync::RwLock;
 
 use crate::share_fs::ShareFs;
 
-pub trait Volume: Send + Sync {
+#[async_trait]
+pub trait Volume: Send + Sync + std::fmt::Debug {
     fn get_volume_mount(&self) -> Result<Vec<oci::Mount>>;
     fn get_storage(&self) -> Result<Vec<agent::Storage>>;
-    fn cleanup(&self) -> Result<()>;
+    async fn cleanup(&self) -> Result<()>;
 }
 
 #[derive(Default)]

--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -18,7 +18,7 @@ use tokio::sync::RwLock;
 use crate::share_fs::ShareFs;
 
 #[async_trait]
-pub trait Volume: Send + Sync + std::fmt::Debug {
+pub trait Volume: Send + Sync {
     fn get_volume_mount(&self) -> Result<Vec<oci::Mount>>;
     fn get_storage(&self) -> Result<Vec<agent::Storage>>;
     async fn cleanup(&self) -> Result<()>;

--- a/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
@@ -7,6 +7,7 @@
 use std::path::Path;
 
 use anyhow::Result;
+use async_trait::async_trait;
 
 use super::Volume;
 use crate::share_fs::DEFAULT_KATA_GUEST_SANDBOX_DIR;
@@ -19,6 +20,7 @@ pub const DEFAULT_SHM_SIZE: u64 = 65536 * 1024;
 // KATA_EPHEMERAL_DEV_TYPE creates a tmpfs backed volume for sharing files between containers.
 pub const KATA_EPHEMERAL_DEV_TYPE: &str = "ephemeral";
 
+#[derive(Debug)]
 pub(crate) struct ShmVolume {
     mount: oci::Mount,
     storage: Option<agent::Storage>,
@@ -82,6 +84,7 @@ impl ShmVolume {
     }
 }
 
+#[async_trait]
 impl Volume for ShmVolume {
     fn get_volume_mount(&self) -> anyhow::Result<Vec<oci::Mount>> {
         Ok(vec![self.mount.clone()])
@@ -96,8 +99,9 @@ impl Volume for ShmVolume {
         Ok(s)
     }
 
-    fn cleanup(&self) -> Result<()> {
-        todo!()
+    async fn cleanup(&self) -> Result<()> {
+        warn!(sl!(), "Cleaning up ShmVolume is still unimplemented.");
+        Ok(())
     }
 }
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -258,7 +258,7 @@ impl Container {
         signal: u32,
         all: bool,
     ) -> Result<()> {
-        let inner = self.inner.read().await;
+        let mut inner = self.inner.write().await;
         inner.signal_process(container_process, signal, all).await
     }
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -180,8 +180,6 @@ impl ContainerInner {
                 }
             })?;
 
-        // TODO(justxuewei): clean mount
-
         // close the exit channel to wakeup wait service
         // send to notify watchers who are waiting for the process exit
         self.init_process.stop().await;
@@ -235,7 +233,7 @@ impl ContainerInner {
     }
 
     pub(crate) async fn signal_process(
-        &self,
+        &mut self,
         process: &ContainerProcess,
         signal: u32,
         all: bool,
@@ -249,6 +247,9 @@ impl ContainerInner {
         self.agent
             .signal_process(agent::SignalProcessRequest { process_id, signal })
             .await?;
+
+        self.clean_volumes().await.context("clean volumes")?;
+
         Ok(())
     }
 
@@ -268,6 +269,20 @@ impl ContainerInner {
             }
         };
 
+        Ok(())
+    }
+
+    async fn clean_volumes(&mut self) -> Result<()> {
+        let mut unhandled = Vec::new();
+        for v in self.volumes.iter() {
+            if let Err(err) = v.cleanup().await {
+                unhandled.push(Arc::clone(v));
+                warn!(sl!(), "Failed to clean volume {:?}, error = {:?}", v, err);
+            }
+        }
+        if !unhandled.is_empty() {
+            self.volumes = unhandled;
+        }
         Ok(())
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -180,6 +180,8 @@ impl ContainerInner {
                 }
             })?;
 
+        // TODO(justxuewei): clean mount
+
         // close the exit channel to wakeup wait service
         // send to notify watchers who are waiting for the process exit
         self.init_process.stop().await;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -277,7 +277,12 @@ impl ContainerInner {
         for v in self.volumes.iter() {
             if let Err(err) = v.cleanup().await {
                 unhandled.push(Arc::clone(v));
-                warn!(sl!(), "Failed to clean volume {:?}, error = {:?}", v, err);
+                warn!(
+                    sl!(),
+                    "Failed to clean volume {:?}, error = {:?}",
+                    v.get_volume_mount(),
+                    err
+                );
             }
         }
         if !unhandled.is_empty() {


### PR DESCRIPTION
This PR fixes the issue mentioned in #5588. In this pull request all shared volumes, except for rootfs, are bind mounted in sandbox level. That is all volumes referred to the same source on the host are bind mounted only once until no container references to it.

It supports dynamic permission controls as well. For example, when a volume mounted with readonly permission and a new coming container needs readwrite permission, the volume should be upgraded to readwrite permission. At the same time, if readwrite permission is no longer needed, then the volume should be downgraded.

Fixes: #5588 

Signed-off-by: Xuewei Niu <justxuewei@apache.org>