### PR TITLE
fix(agent): fix iptables binary path in guest

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -84,9 +84,15 @@ use std::path::PathBuf;
 const CONTAINER_BASE: &str = "/run/kata-containers";
 const MODPROBE_PATH: &str = "/sbin/modprobe";
 
+/// the iptables seriers binaries could appear either in /sbin
+/// or /usr/sbin, we need to check both of them
+const USR_IPTABLES_SAVE: &str = "/usr/sbin/iptables-save";
 const IPTABLES_SAVE: &str = "/sbin/iptables-save";
+const USR_IPTABLES_RESTORE: &str = "/usr/sbin/iptables-store";
 const IPTABLES_RESTORE: &str = "/sbin/iptables-restore";
+const USR_IP6TABLES_SAVE: &str = "/usr/sbin/ip6tables-save";
 const IP6TABLES_SAVE: &str = "/sbin/ip6tables-save";
+const USR_IP6TABLES_RESTORE: &str = "/usr/sbin/ip6tables-save";
 const IP6TABLES_RESTORE: &str = "/sbin/ip6tables-restore";
 
 const ERR_CANNOT_GET_WRITER: &str = "Cannot get writer";
@@ -998,8 +1004,18 @@ impl agent_ttrpc::AgentService for AgentService {
 
         info!(sl!(), "get_ip_tables: request received");
 
+        // the binary could exists in either /usr/sbin or /sbin
+        // here check both of the places and return the one exists
+        // if none exists, return the /sbin one, and the rpc will
+        // returns an internal error
         let cmd = if req.is_ipv6 {
-            IP6TABLES_SAVE
+            if Path::new(USR_IP6TABLES_SAVE).exists() {
+                USR_IP6TABLES_SAVE
+            } else {
+                IP6TABLES_SAVE
+            }
+        } else if Path::new(USR_IPTABLES_SAVE).exists() {
+            USR_IPTABLES_SAVE
         } else {
             IPTABLES_SAVE
         }
@@ -1027,8 +1043,18 @@ impl agent_ttrpc::AgentService for AgentService {
 
         info!(sl!(), "set_ip_tables request received");
 
+        // the binary could exists in both /usr/sbin and /sbin
+        // here check both of the places and return the one exists
+        // if none exists, return the /sbin one, and the rpc will
+        // returns an internal error
         let cmd = if req.is_ipv6 {
-            IP6TABLES_RESTORE
+            if Path::new(USR_IP6TABLES_RESTORE).exists() {
+                USR_IP6TABLES_RESTORE
+            } else {
+                IP6TABLES_RESTORE
+            }
+        } else if Path::new(USR_IPTABLES_RESTORE).exists() {
+            USR_IPTABLES_RESTORE
         } else {
             IPTABLES_RESTORE
         }
@@ -2756,16 +2782,25 @@ OtherField:other
     async fn test_ip_tables() {
         skip_if_not_root!();
 
-        if !check_command(IPTABLES_SAVE)
-            || !check_command(IPTABLES_RESTORE)
-            || !check_command(IP6TABLES_SAVE)
-            || !check_command(IP6TABLES_RESTORE)
-        {
-            warn!(
-                sl!(),
-                "one or more commands for ip tables test are missing, skip it"
-            );
-            return;
+        let iptables_cmd_list = [
+            USR_IPTABLES_SAVE,
+            USR_IP6TABLES_SAVE,
+            USR_IPTABLES_RESTORE,
+            USR_IP6TABLES_RESTORE,
+            IPTABLES_SAVE,
+            IP6TABLES_SAVE,
+            IPTABLES_RESTORE,
+            IP6TABLES_RESTORE,
+        ];
+
+        for cmd in iptables_cmd_list {
+            if !check_command(cmd) {
+                warn!(
+                    sl!(),
+                    "one or more commands for ip tables test are missing, skip it"
+                );
+                return;
+            }
         }
 
         let logger = slog::Logger::root(slog::Discard, o!());


### PR DESCRIPTION
Some rootfs put iptables-save and iptables-restore under /usr/sbin instead of /sbin. This pr checks both and returns the one exist.

Fixes: #5608
Signed-off-by: Ji-Xinyou <jerryji0414@outlook.com>