### PR TITLE
tools: Remove empty spaces from build kernel script

### DIFF
--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -43,7 +43,7 @@ build_type=""
 force_setup_generate_config="false"
 #GPU kernel support
 gpu_vendor=""
-#Confidential guest type 
+#Confidential guest type
 conf_guest=""
 #
 patches_path=""
@@ -134,7 +134,7 @@ get_tee_kernel() {
 	# different name, such as linux-${version}.tar.gz or simply
 	# ${version}.tar.gz.  Let's try both before failing.
 	curl --fail -L "${kernel_url}/linux-${kernel_tarball}" -o ${kernel_tarball} || curl --fail -OL "${kernel_url}/${kernel_tarball}"
-	
+
 	mkdir -p ${kernel_path}
 	tar --strip-components=1 -xf ${kernel_tarball} -C ${kernel_path}
 }
@@ -473,7 +473,7 @@ install_kata() {
 }
 
 main() {
-	while getopts "a:b:c:deEfg:hk:p:t:u:v:x:" opt; do	
+	while getopts "a:b:c:deEfg:hk:p:t:u:v:x:" opt; do
 		case "$opt" in
 			a)
 				arch_target="${OPTARG}"
@@ -516,7 +516,7 @@ main() {
 			t)
 				hypervisor_target="${OPTARG}"
 				;;
-			u)	
+			u)
 				kernel_url="${OPTARG}"
 				;;
 			v)


### PR DESCRIPTION
This PR removes some extra empty spaces at the build kernel script.

Fixes #5619

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>