### PR TITLE
Updating go version to match operator CI version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -309,7 +309,7 @@ languages:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.17.3"
+      newest-version: "1.19.3"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
CI: Fixing go version in kata CI to match the go version in confidential container operator CI job.

Fixes: #5632

Signed-off-by: Unmesh Deodhar <udeodhar@amd.com>