### PR TITLE
versions: update vmm-sys-util and related crates to v0.11.0

### DIFF
--- a/src/dragonball/Cargo.toml
+++ b/src/dragonball/Cargo.toml
@@ -12,8 +12,8 @@ edition = "2018"
 [dependencies]
 arc-swap = "1.5.0"
 bytes = "1.1.0"
-dbs-address-space = "0.2.1"
-dbs-allocator = "0.1.1"
+dbs-address-space = "0.2.0"
+dbs-allocator = "0.1.0"
 dbs-arch = "0.2.0"
 dbs-boot = "0.3.0"
 dbs-device = "0.2.0"
@@ -36,7 +36,7 @@ serde_json = "1.0.9"
 slog = "2.5.2"
 slog-scope = "4.4.0"
 thiserror = "1"
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 virtio-queue = { version = "0.4.0", optional = true }
 vm-memory = { version = "0.9.0", features = ["backend-mmap"] }
 

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -536,41 +536,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "dashmap"
 version = "4.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,15 +547,16 @@ dependencies = [
 
 [[package]]
 name = "dbs-address-space"
-version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323#c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bcc37dc0b8ffae1c5911d13ae630dc7a9020fa0de0edd178d6ab71daf56c8fc"
 dependencies = [
  "arc-swap",
  "libc",
  "nix 0.23.1",
  "thiserror",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -604,21 +570,23 @@ dependencies = [
 
 [[package]]
 name = "dbs-arch"
-version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323#c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f89357fc97fb3608473073be037ea0b22787b1fa4c68b8eb3dd51f3c5fd6b41"
 dependencies = [
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
  "memoffset",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
 name = "dbs-boot"
-version = "0.2.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323#c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6930547e688d8527705d1b7c4163c090c8535b8dd526d8251aa4dfdcbf2f82"
 dependencies = [
  "dbs-arch",
  "kvm-bindings",
@@ -632,35 +600,38 @@ dependencies = [
 
 [[package]]
 name = "dbs-device"
-version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323#c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14ecea44b4bc861c0c2ccb51868bea781286dc70e40ae46b54d4511e690a654a"
 dependencies = [
  "thiserror",
 ]
 
 [[package]]
 name = "dbs-interrupt"
-version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323#c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f217820329cea9d8d2870f9cdda426c5ca4379e33283c39338841a86bdc36c"
 dependencies = [
  "dbs-device",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
 name = "dbs-legacy-devices"
-version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323#c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4d089ac1c4d186c8133be59de09462e9793f7add10017c5b040318a3a7f431f"
 dependencies = [
  "dbs-device",
  "dbs-utils",
  "log",
  "serde",
  "vm-superio",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -675,8 +646,9 @@ dependencies = [
 
 [[package]]
 name = "dbs-utils"
-version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323#c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cb6ff873451b76e22789af7fbe1d0478c42c717f817e66908be7a3a2288068c"
 dependencies = [
  "anyhow",
  "event-manager",
@@ -685,13 +657,14 @@ dependencies = [
  "serde",
  "thiserror",
  "timerfd",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
 name = "dbs-virtio-devices"
-version = "0.1.0"
-source = "git+https://github.com/openanolis/dragonball-sandbox.git?rev=c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323#c3d7831aee7c3962b8a90f0afbfd0fb7e4d30323"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f70cc3a62fa1c169beca6921ef0d3cf38fdfe7cd732ac76c8517bc8a3df9338"
 dependencies = [
  "byteorder",
  "caps",
@@ -716,7 +689,7 @@ dependencies = [
  "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -781,7 +754,7 @@ dependencies = [
  "thiserror",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -834,7 +807,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "377fa591135fbe23396a18e2655a6d5481bf7c5823cdfa3cc81b01a229cbe640"
 dependencies = [
  "libc",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -917,7 +890,7 @@ dependencies = [
  "tokio-uring",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.10.0",
 ]
 
 [[package]]
@@ -1246,7 +1219,7 @@ dependencies = [
  "slog-scope",
  "thiserror",
  "tokio",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -1261,12 +1234,6 @@ dependencies = [
  "wasm-bindgen",
  "winapi",
 ]
-
-[[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
@@ -1413,7 +1380,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a78c049190826fff959994b7c1d8a2930d0a348f1b8f3aa4f9bb34cd5d7f2952"
 dependencies = [
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -1424,7 +1391,7 @@ checksum = "97422ba48d7ffb66fd4d18130f72ab66f9bbbf791fb7a87b9291cdcfec437593"
 dependencies = [
  "kvm-bindings",
  "libc",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -1706,8 +1673,9 @@ dependencies = [
 
 [[package]]
 name = "nydus-api"
-version = "0.1.1"
-source = "git+https://github.com/dragonflyoss/image-service.git?rev=e429be3e8623d47db0f97186f761aeda2983c6f4#e429be3e8623d47db0f97186f761aeda2983c6f4"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fbfbdb58ff07bed50b412d4315b3c5808979bb5decb56706ac66d53daf2cf3"
 dependencies = [
  "dbs-uhttp",
  "http",
@@ -1721,13 +1689,14 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "url",
- "vmm-sys-util",
+ "vmm-sys-util 0.10.0",
 ]
 
 [[package]]
 name = "nydus-blobfs"
-version = "0.1.0"
-source = "git+https://github.com/dragonflyoss/image-service.git?rev=e429be3e8623d47db0f97186f761aeda2983c6f4#e429be3e8623d47db0f97186f761aeda2983c6f4"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef818ecadc217f49ce8d48506b885d8d26f877d26b0108d90d8b82547663d95"
 dependencies = [
  "fuse-backend-rs",
  "libc",
@@ -1737,14 +1706,14 @@ dependencies = [
  "nydus-storage",
  "serde",
  "serde_json",
- "serde_with",
  "vm-memory",
 ]
 
 [[package]]
 name = "nydus-error"
-version = "0.2.1"
-source = "git+https://github.com/dragonflyoss/image-service.git?rev=e429be3e8623d47db0f97186f761aeda2983c6f4#e429be3e8623d47db0f97186f761aeda2983c6f4"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90960fb7268286328d11f18e747bed58d8e3bbea6f401bd316e91fe39f4f7213"
 dependencies = [
  "backtrace",
  "httpdate",
@@ -1756,14 +1725,14 @@ dependencies = [
 
 [[package]]
 name = "nydus-rafs"
-version = "0.1.0"
-source = "git+https://github.com/dragonflyoss/image-service.git?rev=e429be3e8623d47db0f97186f761aeda2983c6f4#e429be3e8623d47db0f97186f761aeda2983c6f4"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a06e8b0b4a90acc2d128d2f3b1ab6ae5d325116f1f69754bd3628dbd4499f4"
 dependencies = [
  "anyhow",
  "arc-swap",
  "bitflags",
  "blake3",
- "flate2",
  "fuse-backend-rs",
  "futures 0.3.21",
  "lazy_static",
@@ -1777,7 +1746,6 @@ dependencies = [
  "nydus-utils",
  "serde",
  "serde_json",
- "serde_with",
  "sha2 0.10.5",
  "spmc",
  "vm-memory",
@@ -1785,8 +1753,9 @@ dependencies = [
 
 [[package]]
 name = "nydus-storage"
-version = "0.5.0"
-source = "git+https://github.com/dragonflyoss/image-service.git?rev=e429be3e8623d47db0f97186f761aeda2983c6f4#e429be3e8623d47db0f97186f761aeda2983c6f4"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5dd10c443f47a0ac7d71021f7658a605c2be5b46576a91f3238babbaf3f459e"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1804,17 +1773,17 @@ dependencies = [
  "nydus-utils",
  "serde",
  "serde_json",
- "serde_with",
  "sha2 0.10.5",
  "tokio",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.10.0",
 ]
 
 [[package]]
 name = "nydus-utils"
-version = "0.3.1"
-source = "git+https://github.com/dragonflyoss/image-service.git?rev=e429be3e8623d47db0f97186f761aeda2983c6f4#e429be3e8623d47db0f97186f761aeda2983c6f4"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b7e976c67052c3ff63372e2a07701923796d25a77eac605824b26d406ab0918"
 dependencies = [
  "blake3",
  "flate2",
@@ -2462,28 +2431,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serial_test"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2665,12 +2612,6 @@ name = "spmc"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
@@ -3118,7 +3059,7 @@ checksum = "519c0a333c871650269cba303bc108075d52a0c0d64f9b91fae61829b53725af"
 dependencies = [
  "log",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -3149,6 +3090,16 @@ name = "vmm-sys-util"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc06a16ee8ebf0d9269aed304030b0d20a866b8b3dd3d4ce532596ac567a0d24"
 dependencies = [
  "bitflags",
  "libc",

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -22,7 +22,7 @@ slog = "2.5.2"
 slog-scope = "4.4.0"
 thiserror = "1.0"
 tokio = { version = "1.8.0", features = ["sync"] }
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 
 kata-sys-util = { path = "../../../libs/kata-sys-util" }
 kata-types = { path = "../../../libs/kata-types" }


### PR DESCRIPTION
Since the upstream of vmm-sys-utils upgraded to 0.11.0, some crates automatically upgrade to v0.11.0, and some stay at v0.10.0 ( depending on how they write version dependency in Cargo toml`） which causes the compile error in runtime-rs.

In order to fix this problem, we need to upgrade all vmm-sys-util dependencies in runtime-rs to v0.11.0.

fixes: #5636

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>