### PR TITLE
runtime-rs: add kata-monitor support for runtime-rs

### DIFF
--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -854,11 +854,10 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
- "matches",
  "percent-encoding",
 ]
 
@@ -1092,6 +1091,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f29bc9dda355256b2916cf526ab02ce0aeaaaf2bad60d65ef3f12f11dd0f4"
+dependencies = [
+ "bytes 1.1.0",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1189,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -1237,11 +1256,10 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418a0a6fab821475f634efe3ccc45c013f742efe03d853e8d3355d5cb850ecf8"
+checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
 dependencies = [
- "matches",
  "unicode-bidi",
  "unicode-normalization",
 ]
@@ -1270,6 +1288,12 @@ name = "io-lifetimes"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9448015e586b611e5d322f6703812bbca2f1e709d5773ecd38ddb4e3bb649504"
+
+[[package]]
+name = "io-lifetimes"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ce5ef949d49ee85593fc4d3f3f95ad61657076395cbbce23e2121fc5542074"
 
 [[package]]
 name = "io-uring"
@@ -1402,9 +1426,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "linux-loader"
@@ -1483,12 +1507,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "matches"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
-
-[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1521,7 +1539,26 @@ dependencies = [
  "libc",
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys",
+ "windows-sys 0.36.1",
+]
+
+[[package]]
+name = "monitor"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "futures-util",
+ "go-flag",
+ "hyper",
+ "lazy_static",
+ "logging",
+ "procfs 0.12.0",
+ "prometheus",
+ "runtimes",
+ "slog",
+ "slog-scope",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -1882,7 +1919,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-sys 0.36.1",
 ]
 
 [[package]]
@@ -1893,9 +1930,9 @@ checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "percent-encoding"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
 
 [[package]]
 name = "persist"
@@ -1980,6 +2017,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c54b25569025b7fc9651de43004ae593a75ad88543b17178aa5e1b9c4f15f56f"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "procfs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0941606b9934e2d98a3677759a971756eb821f75764d0e0d26946d08e74d9104"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "flate2",
+ "hex",
+ "lazy_static",
+ "libc",
+]
+
+[[package]]
+name = "procfs"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfb6451c91904606a1abe93e83a8ec851f45827fa84273f256ade45dc095818"
+dependencies = [
+ "bitflags",
+ "byteorder",
+ "hex",
+ "lazy_static",
+ "rustix 0.35.13",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fnv",
+ "lazy_static",
+ "libc",
+ "memchr",
+ "parking_lot 0.12.1",
+ "procfs 0.14.1",
+ "protobuf",
+ "thiserror",
 ]
 
 [[package]]
@@ -2353,10 +2435,24 @@ checksum = "2079c267b8394eb529872c3cf92e181c378b41fea36e68130357b52493701d2e"
 dependencies = [
  "bitflags",
  "errno",
- "io-lifetimes",
+ "io-lifetimes 0.6.1",
  "libc",
  "linux-raw-sys",
  "winapi",
+]
+
+[[package]]
+name = "rustix"
+version = "0.35.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "727a1a6d65f786ec22df8a81ca3121107f235970dc1705ed681d3e6e8b9cd5f9"
+dependencies = [
+ "bitflags",
+ "errno",
+ "io-lifetimes 0.7.5",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -2761,7 +2857,7 @@ version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f85a7c965b8e7136952f59f2a359694c78f105b2d2ff99cf6c2c404bf7e33f"
 dependencies = [
- "rustix",
+ "rustix 0.34.8",
 ]
 
 [[package]]
@@ -2822,6 +2918,20 @@ dependencies = [
  "slab",
  "socket2",
  "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc463cd8deddc3770d20f9852143d50bf6094e640b485cb2e189a2099085ff45"
+dependencies = [
+ "bytes 1.1.0",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2977,13 +3087,12 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.2.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507c383b2d33b5fc35d1861e77e6b383d158b2da5e14fe51b83dfedf6fd578c"
+checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
 dependencies = [
  "form_urlencoded",
  "idna",
- "matches",
  "percent-encoding",
 ]
 
@@ -3284,12 +3393,33 @@ version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_msvc",
+ "windows_aarch64_msvc 0.36.1",
+ "windows_i686_gnu 0.36.1",
+ "windows_i686_msvc 0.36.1",
+ "windows_x86_64_gnu 0.36.1",
+ "windows_x86_64_msvc 0.36.1",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3298,10 +3428,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
+name = "windows_aarch64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
 name = "windows_i686_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3310,16 +3452,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
 
 [[package]]
 name = "zstd"

--- a/src/runtime-rs/Cargo.toml
+++ b/src/runtime-rs/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
     "crates/shim",
+    "crates/monitor",
 ]

--- a/src/runtime-rs/crates/monitor/Cargo.toml
+++ b/src/runtime-rs/crates/monitor/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "monitor"
+version = "0.1.0"
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
+edition = "2018"
+license = "Apache-2.0"
+
+[[bin]]
+name = "kata-monitor"
+path = "src/bin/main.rs"
+
+[dependencies]
+anyhow = "^1.0"
+hyper = { version = "0.14", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
+url = "2.3.1"
+go-flag = "0.1.0"
+futures-util = { version = "0.3", default-features = false }
+logging = { path = "../../../libs/logging"}
+slog = "2.5.2"
+slog-scope = "4.4.0"
+runtimes = { path = "../runtimes" }
+prometheus = { version = "0.13.0", features = ["process"] }
+procfs = "0.12.0"
+lazy_static = "1.2"

--- a/src/runtime-rs/crates/monitor/src/bin/main.rs
+++ b/src/runtime-rs/crates/monitor/src/bin/main.rs
@@ -1,0 +1,96 @@
+// Copyright 2021-2022 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::{bail, Context, Result};
+use monitor::http_server::http_server;
+use std::{
+    ffi::{OsStr, OsString},
+    path::PathBuf,
+};
+
+pub enum Action {
+    Run(Args),
+    Help,
+}
+
+pub struct Args {
+    pub socket_addr: String,
+    pub loglevel: slog::Level,
+}
+
+const BIN_NAME: &str = "kata_monitor";
+
+const DEFAULT_SOCKET_ADDR: &str = "127.0.0.1:8090";
+const DEFAULT_LOG_LEVEL: &str = "info";
+
+fn main() -> Result<()> {
+    let args = std::env::args_os().collect::<Vec<_>>();
+
+    let action = parse_args(&args).context("parse args")?;
+
+    match action {
+        // TODO: log
+        Action::Run(args) => http_server(&args.socket_addr),
+        Action::Help => show_help(&args[0]),
+    }
+}
+
+fn parse_args(args: &[OsString]) -> Result<Action> {
+    let mut socket_addr = DEFAULT_SOCKET_ADDR.to_string();
+    let mut log_level = DEFAULT_LOG_LEVEL.to_string();
+    let mut help = false;
+
+    go_flag::parse_args_with_warnings::<String, _, _>(&args[1..], None, |flags| {
+        flags.add_flag("address", &mut socket_addr);
+        flags.add_flag("loglevel", &mut log_level);
+        flags.add_flag("help", &mut help);
+    })?;
+
+    if help {
+        Ok(Action::Help)
+    } else {
+        Ok(Action::Run(Args {
+            socket_addr,
+            loglevel: parse_loglevel(log_level.as_str())?,
+        }))
+    }
+}
+
+fn show_help(cmd: &OsStr) -> Result<()> {
+    let path = PathBuf::from(cmd);
+    let name = match path.file_name() {
+        Some(v) => v.to_str(),
+        None => None,
+    };
+
+    let name = name.unwrap_or(BIN_NAME);
+
+    println!(
+        r#"Usage of {}:
+  -listen-address string
+        The address to listen on for HTTP requests. (default "127.0.0.1:8090")
+  -log-level string
+        Log level of logrus(trace/debug/info/warn/error/fatal/panic). (default "info")
+"#,
+        name
+    );
+
+    Ok(())
+}
+
+fn parse_loglevel(loglevel_str: &str) -> Result<slog::Level> {
+    let level = match loglevel_str {
+        "fatal" | "panic" => slog::Level::Critical,
+        "critical" => slog::Level::Critical,
+        "error" => slog::Level::Error,
+        "warn" | "warning" => slog::Level::Warning,
+        "info" => slog::Level::Info,
+        "debug" => slog::Level::Debug,
+        "trace" => slog::Level::Trace,
+        _ => bail!("invalid log level"),
+    };
+
+    Ok(level)
+}

--- a/src/runtime-rs/crates/monitor/src/http_server.rs
+++ b/src/runtime-rs/crates/monitor/src/http_server.rs
@@ -1,0 +1,130 @@
+// Copyright 2021-2022 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::metrics::get_metrics;
+use anyhow::{anyhow, Result};
+use hyper::body;
+use hyper::service::{make_service_fn, service_fn};
+use hyper::{Body, Method, Request, Response, Server, StatusCode};
+use runtimes::MgmtClient;
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::time::Duration;
+
+const ROOT_URI: &str = "/";
+const METRICS_URI: &str = "/metrics";
+
+async fn handler_mux(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    info!(
+        sl!(),
+        "mgmt-svr(mux): recv req, method: {}, uri: {}",
+        req.method(),
+        req.uri().path()
+    );
+
+    match (req.method(), req.uri().path()) {
+        (&Method::GET, ROOT_URI) => root_uri_handler(req).await,
+        (&Method::GET, METRICS_URI) => metrics_uri_handler(req).await,
+        _ => Ok(not_found_uri_handler(req).await),
+    }
+}
+
+#[tokio::main]
+pub async fn http_server(socket_addr: &str) -> Result<()> {
+    let addr: SocketAddr = socket_addr.parse()?;
+
+    let make_svc =
+        make_service_fn(|_conn| async { Ok::<_, hyper::Error>(service_fn(handler_mux)) });
+
+    let server = Server::bind(&addr).serve(make_svc);
+
+    if let Err(e) = server.await {
+        eprintln!("server error: {}", e);
+    }
+
+    Ok(())
+}
+
+async fn root_uri_handler(_req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::from(
+            r#"Available HTTP endpoints:
+    /metrics : Get metrics from sandboxes.
+"#,
+        ))
+        .unwrap())
+}
+
+async fn metrics_uri_handler(req: Request<Body>) -> Result<Response<Body>, hyper::Error> {
+    let mut response_body = String::new();
+
+    if let Ok(monitor_metrics) = get_metrics().await {
+        response_body += &monitor_metrics;
+    } else {
+        return Ok(Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::from("failed to get monitor metrics"))
+            .unwrap());
+    }
+
+    if let Some(uri_query) = req.uri().query() {
+        if let Ok(sandbox_id) = parse_sandbox_id(uri_query) {
+            let mut runtime_metrics_flag = false;
+            let runtime_metrics = get_runtime_metrics(sandbox_id).await;
+            if runtime_metrics.is_ok() {
+                let runtime_metrics = runtime_metrics.unwrap();
+                if !runtime_metrics.is_empty() {
+                    response_body += &runtime_metrics;
+                    runtime_metrics_flag = true;
+                }
+            }
+            if !runtime_metrics_flag {
+                return Ok(Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
+                    .body(Body::from("failed to get runtime metrics"))
+                    .unwrap());
+            }
+        }
+    }
+
+    Ok(Response::builder()
+        .status(StatusCode::OK)
+        .body(Body::from(response_body))
+        .unwrap())
+}
+
+async fn get_runtime_metrics(sandbox_id: &str) -> Result<String> {
+    // build shim client
+    let shim_client = MgmtClient::new(sandbox_id.to_string(), Some(Duration::new(5, 0)))?;
+
+    // get METRICS_URI
+    let shim_response = shim_client.get(METRICS_URI).await?;
+
+    // get runtime_metrics
+    let runtime_metrics = String::from_utf8(body::to_bytes(shim_response).await?.to_vec())?;
+
+    Ok(runtime_metrics)
+}
+
+async fn not_found_uri_handler(_req: Request<Body>) -> Response<Body> {
+    Response::builder()
+        .status(StatusCode::NOT_FOUND)
+        .body(Body::from("NOT FOUND"))
+        .unwrap()
+}
+
+fn parse_sandbox_id(uri: &str) -> Result<&str> {
+    let uri_pairs: HashMap<_, _> = uri
+        .split_whitespace()
+        .map(|s| s.split_at(s.find('=').unwrap_or(0)))
+        .map(|(key, val)| (key, &val[1..]))
+        .collect();
+
+    match uri_pairs.get("sandbox") {
+        Some(sid) => Ok(sid.to_owned()),
+        None => Err(anyhow!("params sandbox not found")),
+    }
+}

--- a/src/runtime-rs/crates/monitor/src/lib.rs
+++ b/src/runtime-rs/crates/monitor/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2021-2022 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#[macro_use]
+extern crate slog;
+
+#[macro_use]
+extern crate lazy_static;
+
+logging::logger_with_subsystem!(sl, "monitor");
+
+pub mod http_server;
+pub mod metrics;

--- a/src/runtime-rs/crates/monitor/src/metrics.rs
+++ b/src/runtime-rs/crates/monitor/src/metrics.rs
@@ -1,0 +1,103 @@
+// Copyright 2021-2022 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+extern crate procfs;
+
+use anyhow::{anyhow, Result};
+use prometheus::{Encoder, Gauge, IntCounter, Registry, TextEncoder};
+use std::sync::Once;
+
+const NAMESPACE_KATA_MONITOR: &str = "kata_monitor";
+
+lazy_static! {
+
+    static ref INIT_REGISTER: Once = Once::new();
+
+    // custom registry
+    static ref REGISTRY: Registry = Registry::new();
+
+    // monitor metrics
+    static ref MONITOR_SCRAPE_COUNT: IntCounter =
+    IntCounter::new(format!("{}_{}",NAMESPACE_KATA_MONITOR,"scrape_count"), "Monitor scrape count").unwrap();
+
+    static ref MONITOR_MAX_FDS: Gauge = Gauge::new(format!("{}_{}", NAMESPACE_KATA_MONITOR, "process_max_fds"), "Open FDs for monitor").unwrap();
+
+    static ref MONITOR_OPEN_FDS: Gauge = Gauge::new(format!("{}_{}", NAMESPACE_KATA_MONITOR, "process_open_fds"), "Open FDs for monitor").unwrap();
+
+    static ref MONITOR_RESIDENT_MEMORY: Gauge = Gauge::new(format!("{}_{}", NAMESPACE_KATA_MONITOR, "process_resident_memory_bytes"), "Resident memory size in bytes for monitor").unwrap();
+
+    // TODO:
+    // MONITOR_SCRAPE_FAILED_COUNT & MONITOR_SCRAPE_DURATIONS_HISTOGRAM & MONITOR_RUNNING_SHIM_COUNT
+
+    //  static ref MONITOR_SCRAPE_FAILED_COUNT: IntCounter = IntCounter::new(format!("{}_{}",NAMESPACE_KATA_MONITOR,"scrape_failed_count"), "Monitor scrape failed count").unwrap();
+
+    // static ref MONITOR_SCRAPE_DURATIONS_HISTOGRAM: HistogramVec = HistogramVec::new(HistogramOpts::new(format!("{}_{}", NAMESPACE_KATA_MONITOR, "scrape_durations_histogram_milliseconds"),"Time used to scrape"),&["action"]).unwrap();
+
+    // static ref MONITOR_RUNNING_SHIM_COUNT: Gauge = Gauge::new(format!("{}_{}",NAMESPACE_KATA_MONITOR,"running_shim_count"), "Running shim count(running sandboxes).").unwrap();
+}
+
+/// get prometheus metrics
+pub async fn get_metrics() -> Result<String> {
+    let handle_init = tokio::task::spawn(async move {
+        INIT_REGISTER.call_once_force(|_| {
+            register_metrics().unwrap();
+        });
+    });
+    if handle_init.await.is_err() {
+        return Err(anyhow!("failed to init register"));
+    }
+
+    update_metrics()?;
+
+    // gather all metrics and return as a String
+    let metric_families = REGISTRY.gather();
+
+    let mut buffer = Vec::new();
+    let encoder = TextEncoder::new();
+    encoder.encode(&metric_families, &mut buffer)?;
+
+    Ok(String::from_utf8(buffer)?)
+}
+
+fn register_metrics() -> Result<()> {
+    REGISTRY.register(Box::new(MONITOR_SCRAPE_COUNT.clone()))?;
+    REGISTRY.register(Box::new(MONITOR_MAX_FDS.clone()))?;
+    REGISTRY.register(Box::new(MONITOR_OPEN_FDS.clone()))?;
+    REGISTRY.register(Box::new(MONITOR_RESIDENT_MEMORY.clone()))?;
+
+    // TODO:
+    // REGISTRY.register(Box::new(MONITOR_SCRAPE_FAILED_COUNT.clone()))?;
+    // REGISTRY.register(Box::new(MONITOR_SCRAPE_DURATIONS_HISTOGRAM.clone()))?;
+    // REGISTRY.register(Box::new(MONITOR_RUNNING_SHIM_COUNT.clone()))?;
+    Ok(())
+}
+
+fn update_metrics() -> Result<()> {
+    MONITOR_SCRAPE_COUNT.inc();
+
+    let me = match procfs::process::Process::myself() {
+        Ok(p) => p,
+        Err(_) => {
+            return Ok(());
+        }
+    };
+
+    if let Ok(fds) = procfs::sys::fs::file_max() {
+        MONITOR_MAX_FDS.set(fds as f64);
+    }
+
+    if let Ok(fds) = me.fd_count() {
+        MONITOR_OPEN_FDS.set(fds as f64);
+    }
+
+    if let Ok(statm) = me.statm() {
+        MONITOR_RESIDENT_MEMORY.set(statm.resident as f64);
+    }
+
+    // TODO:
+    // MONITOR_SCRAPE_FAILED_COUNT & MONITOR_SCRAPE_DURATIONS_HISTOGRAM & MONITOR_RUNNING_SHIM_COUNT
+
+    Ok(())
+}


### PR DESCRIPTION
The previous kata-monitor in golang could not communicate with runtime-rs to gather metrics.
Here is kata-monitor in rust to gather metrics from runtime-rs and monitor itself.

Fixes: #5017
