### PR TITLE
versions: upgrade golang to 1.18

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -309,7 +309,7 @@ languages:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.17.3"
+      newest-version: "1.18"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
containerd has used some new features like strings.Cut, that is introduced by go 1.18, and this will break go get if we are using an older version golang.

Fixes: #5646

Signed-off-by: Bin Liu <bin@hyper.sh>