### PR TITLE
versions: Update k8s to its v1.25.x release

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -214,7 +214,7 @@ externals:
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"
     url: "https://github.com/kubernetes-sigs/cri-tools"
-    version: "1.23.0"
+    version: "1.25.0"
 
   gperf:
     description: "GNU gperf is a perfect hash function generator"

--- a/versions.yaml
+++ b/versions.yaml
@@ -229,7 +229,7 @@ externals:
     uscan-url: >-
       https://github.com/kubernetes/kubernetes/tags
       .*/v?([\d\.]+)\.tar\.gz
-    version: "1.23.1-00"
+    version: "1.25.1-00"
 
   libseccomp:
     description: "High level interface to Linux seccomp filter"

--- a/versions.yaml
+++ b/versions.yaml
@@ -193,7 +193,7 @@ externals:
   conmon:
     description: "An OCI container runtime monitor"
     url: "https://github.com/containers/conmon"
-    version: "v2.0.5"
+    version: "v2.1.5"
 
   crio:
     description: |

--- a/versions.yaml
+++ b/versions.yaml
@@ -199,7 +199,7 @@ externals:
     description: |
       OCI-based Kubernetes Container Runtime Interface implementation
     url: "https://github.com/cri-o/cri-o"
-    branch: "release-1.23"
+    branch: "release-1.25"
 
   containerd:
     description: |

--- a/versions.yaml
+++ b/versions.yaml
@@ -244,7 +244,7 @@ externals:
     uscan-url: >-
       https://github.com/opencontainers/runc/tags
       .*/v?(\d\S+)\.tar\.gz
-    version: "v1.1.0"
+    version: "v1.1.4"
 
   nydus:
     description: "Nydus image acceleration service"


### PR DESCRIPTION
versions: Update Kubernetes to its latest release

Let's ensure we're testing against the latest Kubernetes release.

Fixes: #5681
Depends-on: github.com/kata-containers/tests#5264

---

versions: Update to the latest critools release

As we've bumped the k8s version, let's also bump critools together.

---

versions: Update CRI-O to its release-1.25 branch

Let's make sure we're testing against the latest CRI-O stable release.

---

versions: Update runc to its latest release

We're not actually depending on runc, but as already updating k8s
related stuff, let's make sure to update this one as well.

---