### PR TITLE
versions: update ovmf to edk2-stable202208 for x86 and sev

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -261,12 +261,12 @@ externals:
     url: "https://github.com/tianocore/edk2"
     x86_64:
       description: "Vanilla firmware build"
-      version: "edk2-stable202202"
+      version: "edk2-stable202208"
       package: "OvmfPkg/OvmfPkgX64.dsc"
       package_output_dir: "OvmfX64"
     sev:
       description: "AmdSev build needed for SEV measured direct boot."
-      version: "edk2-stable202202"
+      version: "edk2-stable202208"
       package: "OvmfPkg/AmdSev/AmdSevX64.dsc"
       package_output_dir: "AmdSev"
     tdx:


### PR DESCRIPTION
This is the latest tagged release.

Fixes: #5686
Signed-off-by: Alex Carter <Alex.Carter@ibm.com>

@dubek @fitzthum