### PR TITLE
runtime-rs: fix standalone share fs

### DIFF
--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -35,7 +35,7 @@ pub const DEFAULT_VHOST_USER_STORE_PATH: &str = "/var/run/vhost-user";
 pub const DEFAULT_BLOCK_NVDIMM_MEM_OFFSET: u64 = 0;
 
 pub const DEFAULT_SHARED_FS_TYPE: &str = "virtio-fs";
-pub const DEFAULT_VIRTIO_FS_CACHE_MODE: &str = "none";
+pub const DEFAULT_VIRTIO_FS_CACHE_MODE: &str = "never";
 pub const DEFAULT_VIRTIO_FS_DAX_SIZE_MB: u32 = 1024;
 pub const DEFAULT_SHARED_9PFS_SIZE_MB: u32 = 128 * 1024;
 pub const MIN_SHARED_9PFS_SIZE_MB: u32 = 4 * 1024;

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -864,7 +864,7 @@ impl SharedFsInfo {
             )?;
         }
 
-        let l = ["none", "auto", "always"];
+        let l = ["never", "auto", "always"];
 
         if !l.contains(&self.virtio_fs_cache.as_str()) {
             return Err(eother!(

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
@@ -6,6 +6,10 @@
 
 use std::{collections::HashMap, process::Stdio, sync::Arc};
 
+use crate::share_fs::share_virtio_fs::{
+    prepare_virtiofs, FS_TYPE_VIRTIO_FS, KATA_VIRTIO_FS_DEV_TYPE, MOUNT_GUEST_TAG,
+};
+use crate::share_fs::{KATA_GUEST_SHARE_DIR, VIRTIO_FS};
 use agent::Storage;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -28,7 +32,6 @@ use super::{
 #[derive(Debug, Clone)]
 pub struct ShareVirtioFsStandaloneConfig {
     id: String,
-    jail_root: String,
 
     // virtio_fs_daemon is the virtio-fs vhost-user daemon path
     pub virtio_fs_daemon: String,
@@ -56,7 +59,6 @@ impl ShareVirtioFsStandalone {
             inner: Arc::new(RwLock::new(ShareVirtioFsStandaloneInner::default())),
             config: ShareVirtioFsStandaloneConfig {
                 id: id.to_string(),
-                jail_root: "".to_string(),
                 virtio_fs_daemon: config.virtio_fs_daemon.clone(),
                 virtio_fs_cache: config.virtio_fs_cache.clone(),
                 virtio_fs_extra_args: config.virtio_fs_extra_args.clone(),
@@ -69,14 +71,21 @@ impl ShareVirtioFsStandalone {
     fn virtiofsd_args(&self, sock_path: &str) -> Result<Vec<String>> {
         let source_path = get_host_ro_shared_path(&self.config.id);
         ensure_dir_exist(&source_path)?;
+        let shared_dir = source_path
+            .to_str()
+            .ok_or_else(|| anyhow!("convert source path {:?} to str failed", source_path))?;
 
         let mut args: Vec<String> = vec![
-            String::from("-f"),
-            format!("--socket-path={}", sock_path),
-            String::from("-o"),
-            format!("source={}", source_path.to_str().unwrap()),
-            String::from("-o"),
-            format!("cache={}", self.config.virtio_fs_cache),
+            String::from("--socket-path"),
+            String::from(sock_path),
+            String::from("--shared-dir"),
+            String::from(shared_dir),
+            String::from("--cache"),
+            self.config.virtio_fs_cache.clone(),
+            String::from("--sandbox"),
+            String::from("none"),
+            String::from("--seccomp"),
+            String::from("none"),
         ];
 
         if !self.config.virtio_fs_extra_args.is_empty() {
@@ -87,8 +96,8 @@ impl ShareVirtioFsStandalone {
         Ok(args)
     }
 
-    async fn setup_virtiofsd(&self) -> Result<()> {
-        let sock_path = generate_sock_path(&self.config.jail_root);
+    async fn setup_virtiofsd(&self, h: &dyn Hypervisor) -> Result<()> {
+        let sock_path = generate_sock_path(&h.get_jailer_root().await?);
         let args = self.virtiofsd_args(&sock_path).context("virtiofsd args")?;
 
         let mut cmd = Command::new(&self.config.virtio_fs_daemon);
@@ -163,8 +172,11 @@ impl ShareFs for ShareVirtioFsStandalone {
         self.share_fs_mount.clone()
     }
 
-    async fn setup_device_before_start_vm(&self, _h: &dyn Hypervisor) -> Result<()> {
-        self.setup_virtiofsd().await.context("setup virtiofsd")?;
+    async fn setup_device_before_start_vm(&self, h: &dyn Hypervisor) -> Result<()> {
+        prepare_virtiofs(h, VIRTIO_FS, &self.config.id, &h.get_jailer_root().await?)
+            .await
+            .context("prepare virtiofs")?;
+        self.setup_virtiofsd(h).await.context("setup virtiofsd")?;
         Ok(())
     }
 
@@ -173,7 +185,20 @@ impl ShareFs for ShareVirtioFsStandalone {
     }
 
     async fn get_storages(&self) -> Result<Vec<Storage>> {
-        Ok(vec![])
+        let mut storages: Vec<Storage> = Vec::new();
+
+        let shared_volume: Storage = Storage {
+            driver: String::from(KATA_VIRTIO_FS_DEV_TYPE),
+            driver_options: Vec::new(),
+            source: String::from(MOUNT_GUEST_TAG),
+            fs_type: String::from(FS_TYPE_VIRTIO_FS),
+            fs_group: None,
+            options: vec![String::from("nodev")],
+            mount_point: String::from(KATA_GUEST_SHARE_DIR),
+        };
+
+        storages.push(shared_volume);
+        Ok(storages)
     }
 
     fn mounted_info_set(&self) -> Arc<Mutex<HashMap<String, MountedInfo>>> {


### PR DESCRIPTION
Standalone share fs should add virtiofs device in setup_device_before_start_vm
and return the storages to mount the directory in guest. And it uses
hypervisor's jailer root directly instead of jail config.

Besides, we tweaked the parameter, so it adapts to rust version virtiofsd
now. And its cache policy which forbids caching is "never" now,  instead of
"none". Hence, we change the default cache mode.

Fixes: https://github.com/kata-containers/kata-containers/issues/5655

Signed-off-by: Yipeng Yin <yinyipeng@bytedance.com>