### PR TITLE
docs: update doc "NVIDIA-GPU-passthrough-and-Kata"

### DIFF
--- a/docs/use-cases/NVIDIA-GPU-passthrough-and-Kata.md
+++ b/docs/use-cases/NVIDIA-GPU-passthrough-and-Kata.md
@@ -545,6 +545,12 @@ Create the hook execution file for Kata:
 /usr/bin/nvidia-container-toolkit -debug $@
 ```
 
+Make sure the hook shell is executable:
+
+```
+chmod +x $ROOTFS_DIR/usr/share/oci/hooks/prestart/nvidia-container-toolkit.sh
+```
+
 As the last step one can do some cleanup of files or package caches. Build the
 rootfs and configure it for use with Kata according to the development guide.
 


### PR DESCRIPTION
According to the NVIDIA-GPU-passthrough-and-Kata doc, user always forget to make the hook shell executable, as a result, the hook shell can't be executed successfully, and then the kata container with GPU passthrough will not start successfully.

We should make sure the hook shell nvidia-container-toolkit is executable.

Fixes: https://github.com/kata-containers/kata-containers/issues/5594

Signed-off-by: Matt Wang <kinder_yj@hotmail.com>