### PR TITLE
runtime: don't fail mkdir if the folder is already created by another process

### DIFF
--- a/src/runtime/virtcontainers/utils/utils.go
+++ b/src/runtime/virtcontainers/utils/utils.go
@@ -399,7 +399,7 @@ func MkdirAllWithInheritedOwner(path string, perm os.FileMode) error {
 		info, err := os.Stat(curPath)
 
 		if err != nil {
-			if err = os.Mkdir(curPath, perm); err != nil {
+			if err = os.MkdirAll(curPath, perm); err != nil {
 				return fmt.Errorf("mkdir call failed: %v", err.Error())
 			}
 			if err = syscall.Chown(curPath, uid, gid); err != nil {


### PR DESCRIPTION
In case a folder is created by another process continue without generating an error.

Fixes #5713

Signed-off-by: Alexandru Matei <alexandru.matei@uipath.com>