### PR TITLE
runtime: add log record to the qemu config method `appendDevices` for…

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -2699,9 +2699,14 @@ func (config *Config) appendQMPSockets() {
 	}
 }
 
-func (config *Config) appendDevices() {
+func (config *Config) appendDevices(logger QMPLog) {
+	if logger == nil {
+		logger = qmpNullLogger{}
+	}
+
 	for _, d := range config.Devices {
 		if !d.Valid() {
+			logger.Errorf("vm device is not valid: %+v", config.Devices)
 			continue
 		}
 
@@ -2976,7 +2981,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendCPUModel()
 	config.appendQMPSockets()
 	config.appendMemory()
-	config.appendDevices()
+	config.appendDevices(logger)
 	config.appendRTC()
 	config.appendGlobalParam()
 	config.appendPFlashParam()

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -34,7 +34,7 @@ func testConfigAppend(config *Config, structure interface{}, expected string, t 
 
 	case Device:
 		config.Devices = []Device{s}
-		config.appendDevices()
+		config.appendDevices(nil)
 
 	case Knobs:
 		config.Knobs = s
@@ -889,7 +889,7 @@ func TestBadQMPSockets(t *testing.T) {
 
 func TestBadDevices(t *testing.T) {
 	c := &Config{}
-	c.appendDevices()
+	c.appendDevices(nil)
 	if len(c.qemuParams) != 0 {
 		t.Errorf("Expected empty qemuParams, found %s", c.qemuParams)
 	}
@@ -941,7 +941,7 @@ func TestBadDevices(t *testing.T) {
 		},
 	}
 
-	c.appendDevices()
+	c.appendDevices(nil)
 	if len(c.qemuParams) != 0 {
 		t.Errorf("Expected empty qemuParams, found %s", c.qemuParams)
 	}


### PR DESCRIPTION
… the invalid devices

When the user tried to add new devices to the VM, there is no error info for the invalid
 device. This PR adds a log record to the `appendDevices` for the invalid device of the
 qemu config.

Fixes: kata-containers#5719

Signed-off-by: wangyongchao.bj <wangyongchao.bj@inspur.com>