### PR TITLE
runtime: Use containerd v1.6.8

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/blang/semver/v4 v4.0.0
 	github.com/containerd/cgroups v1.0.5-0.20220625035431-cf7417bca682
 	github.com/containerd/console v1.0.3
-	github.com/containerd/containerd v1.6.6
+	github.com/containerd/containerd v1.6.8
 	github.com/containerd/cri-containerd v1.19.0
 	github.com/containerd/fifo v1.0.0
 	github.com/containerd/ttrpc v1.1.0
@@ -60,7 +60,7 @@ require (
 
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
-	github.com/Microsoft/hcsshim v0.9.3 // indirect
+	github.com/Microsoft/hcsshim v0.9.4 // indirect
 	github.com/PuerkitoBio/purell v1.1.1 // indirect
 	github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef // indirect

--- a/src/runtime/go.sum
+++ b/src/runtime/go.sum
@@ -125,8 +125,9 @@ github.com/Microsoft/hcsshim v0.8.21/go.mod h1:+w2gRZ5ReXQhFOrvSQeNfhrYB/dg3oDwT
 github.com/Microsoft/hcsshim v0.8.22/go.mod h1:91uVCVzvX2QD16sMCenoxxXo6L1wJnLMX2PSufFMtF0=
 github.com/Microsoft/hcsshim v0.8.23/go.mod h1:4zegtUJth7lAvFyc6cH2gGQ5B3OFQim01nnU2M8jKDg=
 github.com/Microsoft/hcsshim v0.9.2/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
-github.com/Microsoft/hcsshim v0.9.3 h1:k371PzBuRrz2b+ebGuI2nVgVhgsVX60jMfSw80NECxo=
 github.com/Microsoft/hcsshim v0.9.3/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
+github.com/Microsoft/hcsshim v0.9.4 h1:mnUj0ivWy6UzbB1uLFqKR6F+ZyiDc7j4iGgHTpO+5+I=
+github.com/Microsoft/hcsshim v0.9.4/go.mod h1:7pLA8lDk46WKDWlVsENo92gC0XFa8rbKfyFRBqxEbCc=
 github.com/Microsoft/hcsshim/test v0.0.0-20201218223536-d3e5debf77da/go.mod h1:5hlzMzRKMLyo42nCZ9oml8AdTlq/0cvIaBv6tK1RehU=
 github.com/Microsoft/hcsshim/test v0.0.0-20210227013316-43a75bb4edd3/go.mod h1:mw7qgWloBUl75W/gVH3cQszUg1+gUITj7D6NY7ywVnY=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
@@ -289,8 +290,9 @@ github.com/containerd/containerd v1.5.7/go.mod h1:gyvv6+ugqY25TiXxcZC3L5yOeYgEw0
 github.com/containerd/containerd v1.5.8/go.mod h1:YdFSv5bTFLpG2HIYmfqDpSYYTDX+mc5qtSuYx1YUb/s=
 github.com/containerd/containerd v1.5.9/go.mod h1:fvQqCfadDGga5HZyn3j4+dx56qj2I9YwBrlSdalvJYQ=
 github.com/containerd/containerd v1.6.1/go.mod h1:1nJz5xCZPusx6jJU8Frfct988y0NpumIq9ODB0kLtoE=
-github.com/containerd/containerd v1.6.6 h1:xJNPhbrmz8xAMDNoVjHy9YHtWwEQNS+CDkcIRh7t8Y0=
 github.com/containerd/containerd v1.6.6/go.mod h1:ZoP1geJldzCVY3Tonoz7b1IXk8rIX0Nltt5QE4OMNk0=
+github.com/containerd/containerd v1.6.8 h1:h4dOFDwzHmqFEP754PgfgTeVXFnLiRc6kiqC7tplDJs=
+github.com/containerd/containerd v1.6.8/go.mod h1:By6p5KqPK0/7/CgO/A6t/Gz+CUYUu2zf1hUaaymVXB0=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20190815185530-f2a389ac0a02/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=
 github.com/containerd/continuity v0.0.0-20191127005431-f65d91d395eb/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=

--- a/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/jobobject/iocp.go
+++ b/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/jobobject/iocp.go
@@ -57,7 +57,7 @@ func pollIOCP(ctx context.Context, iocpHandle windows.Handle) {
 				}).Warn("failed to parse job object message")
 				continue
 			}
-			if err := msq.Write(notification); err == queue.ErrQueueClosed {
+			if err := msq.Enqueue(notification); err == queue.ErrQueueClosed {
 				// Write will only return an error when the queue is closed.
 				// The only time a queue would ever be closed is when we call `Close` on
 				// the job it belongs to which also removes it from the jobMap, so something

--- a/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/jobobject/limits.go
+++ b/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/jobobject/limits.go
@@ -202,7 +202,7 @@ func (job *JobObject) getExtendedInformation() (*windows.JOBOBJECT_EXTENDED_LIMI
 	if err := winapi.QueryInformationJobObject(
 		job.handle,
 		windows.JobObjectExtendedLimitInformation,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {
@@ -224,7 +224,7 @@ func (job *JobObject) getCPURateControlInformation() (*winapi.JOBOBJECT_CPU_RATE
 	if err := winapi.QueryInformationJobObject(
 		job.handle,
 		windows.JobObjectCpuRateControlInformation,
-		uintptr(unsafe.Pointer(&info)),
+		unsafe.Pointer(&info),
 		uint32(unsafe.Sizeof(info)),
 		nil,
 	); err != nil {

--- a/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/queue/mq.go
+++ b/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/queue/mq.go
@@ -5,10 +5,7 @@ import (
 	"sync"
 )
 
-var (
-	ErrQueueClosed = errors.New("the queue is closed for reading and writing")
-	ErrQueueEmpty  = errors.New("the queue is empty")
-)
+var ErrQueueClosed = errors.New("the queue is closed for reading and writing")
 
 // MessageQueue represents a threadsafe message queue to be used to retrieve or
 // write messages to.
@@ -29,8 +26,8 @@ func NewMessageQueue() *MessageQueue {
 	}
 }
 
-// Write writes `msg` to the queue.
-func (mq *MessageQueue) Write(msg interface{}) error {
+// Enqueue writes `msg` to the queue.
+func (mq *MessageQueue) Enqueue(msg interface{}) error {
 	mq.m.Lock()
 	defer mq.m.Unlock()
 
@@ -43,55 +40,37 @@ func (mq *MessageQueue) Write(msg interface{}) error {
 	return nil
 }
 
-// Read will read a value from the queue if available, otherwise return an error.
-func (mq *MessageQueue) Read() (interface{}, error) {
+// Dequeue will read a value from the queue and remove it. If the queue
+// is empty, this will block until the queue is closed or a value gets enqueued.
+func (mq *MessageQueue) Dequeue() (interface{}, error) {
 	mq.m.Lock()
 	defer mq.m.Unlock()
+
+	for !mq.closed && mq.size() == 0 {
+		mq.c.Wait()
+	}
+
+	// We got woken up, check if it's because the queue got closed.
 	if mq.closed {
 		return nil, ErrQueueClosed
 	}
-	if mq.isEmpty() {
-		return nil, ErrQueueEmpty
-	}
+
 	val := mq.messages[0]
 	mq.messages[0] = nil
 	mq.messages = mq.messages[1:]
 	return val, nil
 }
 
-// ReadOrWait will read a value from the queue if available, else it will wait for a
-// value to become available. This will block forever if nothing gets written or until
-// the queue gets closed.
-func (mq *MessageQueue) ReadOrWait() (interface{}, error) {
-	mq.m.Lock()
-	if mq.closed {
-		mq.m.Unlock()
-		return nil, ErrQueueClosed
-	}
-	if mq.isEmpty() {
-		for !mq.closed && mq.isEmpty() {
-			mq.c.Wait()
-		}
-		mq.m.Unlock()
-		return mq.Read()
-	}
-	val := mq.messages[0]
-	mq.messages[0] = nil
-	mq.messages = mq.messages[1:]
-	mq.m.Unlock()
-	return val, nil
-}
-
-// IsEmpty returns if the queue is empty
-func (mq *MessageQueue) IsEmpty() bool {
+// Size returns the size of the queue.
+func (mq *MessageQueue) Size() int {
 	mq.m.RLock()
 	defer mq.m.RUnlock()
-	return len(mq.messages) == 0
+	return mq.size()
 }
 
-// Nonexported empty check that doesn't lock so we can call this in Read and Write.
-func (mq *MessageQueue) isEmpty() bool {
-	return len(mq.messages) == 0
+// Nonexported size check to check if the queue is empty inside already locked functions.
+func (mq *MessageQueue) size() int {
+	return len(mq.messages)
 }
 
 // Close closes the queue for future writes or reads. Any attempts to read or write from the
@@ -99,13 +78,15 @@ func (mq *MessageQueue) isEmpty() bool {
 func (mq *MessageQueue) Close() {
 	mq.m.Lock()
 	defer mq.m.Unlock()
-	// Already closed
+
+	// Already closed, noop
 	if mq.closed {
 		return
 	}
+
 	mq.messages = nil
 	mq.closed = true
-	// If there's anybody currently waiting on a value from ReadOrWait, we need to
+	// If there's anybody currently waiting on a value from Dequeue, we need to
 	// broadcast so the read(s) can return ErrQueueClosed.
 	mq.c.Broadcast()
 }

--- a/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/winapi/jobobject.go
+++ b/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/winapi/jobobject.go
@@ -175,7 +175,7 @@ type JOBOBJECT_ASSOCIATE_COMPLETION_PORT struct {
 //		LPDWORD            lpReturnLength
 // );
 //
-//sys QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo uintptr, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) = kernel32.QueryInformationJobObject
+//sys QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo unsafe.Pointer, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) = kernel32.QueryInformationJobObject
 
 // HANDLE OpenJobObjectW(
 //		DWORD   dwDesiredAccess,

--- a/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
+++ b/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/winapi/process.go
@@ -18,7 +18,7 @@ const ProcessVmCounters = 3
 // 	[out, optional] PULONG           ReturnLength
 // );
 //
-//sys NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo uintptr, processInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQueryInformationProcess
+//sys NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo unsafe.Pointer, processInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQueryInformationProcess
 
 // typedef struct _VM_COUNTERS_EX
 // {

--- a/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/winapi/system.go
+++ b/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/winapi/system.go
@@ -12,7 +12,8 @@ const STATUS_INFO_LENGTH_MISMATCH = 0xC0000004
 // 	ULONG                    SystemInformationLength,
 // 	PULONG                   ReturnLength
 // );
-//sys NtQuerySystemInformation(systemInfoClass int, systemInformation uintptr, systemInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQuerySystemInformation
+//
+//sys NtQuerySystemInformation(systemInfoClass int, systemInformation unsafe.Pointer, systemInfoLength uint32, returnLength *uint32) (status uint32) = ntdll.NtQuerySystemInformation
 
 type SYSTEM_PROCESS_INFORMATION struct {
 	NextEntryOffset              uint32         // ULONG

--- a/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/winapi/zsyscall_windows.go
+++ b/src/runtime/vendor/github.com/Microsoft/hcsshim/internal/winapi/zsyscall_windows.go
@@ -100,7 +100,7 @@ func resizePseudoConsole(hPc windows.Handle, size uint32) (hr error) {
 	return
 }
 
-func NtQuerySystemInformation(systemInfoClass int, systemInformation uintptr, systemInfoLength uint32, returnLength *uint32) (status uint32) {
+func NtQuerySystemInformation(systemInfoClass int, systemInformation unsafe.Pointer, systemInfoLength uint32, returnLength *uint32) (status uint32) {
 	r0, _, _ := syscall.Syscall6(procNtQuerySystemInformation.Addr(), 4, uintptr(systemInfoClass), uintptr(systemInformation), uintptr(systemInfoLength), uintptr(unsafe.Pointer(returnLength)), 0, 0)
 	status = uint32(r0)
 	return
@@ -152,7 +152,7 @@ func IsProcessInJob(procHandle windows.Handle, jobHandle windows.Handle, result 
 	return
 }
 
-func QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo uintptr, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) {
+func QueryInformationJobObject(jobHandle windows.Handle, infoClass uint32, jobObjectInfo unsafe.Pointer, jobObjectInformationLength uint32, lpReturnLength *uint32) (err error) {
 	r1, _, e1 := syscall.Syscall6(procQueryInformationJobObject.Addr(), 5, uintptr(jobHandle), uintptr(infoClass), uintptr(jobObjectInfo), uintptr(jobObjectInformationLength), uintptr(unsafe.Pointer(lpReturnLength)), 0)
 	if r1 == 0 {
 		if e1 != 0 {
@@ -244,7 +244,7 @@ func LocalFree(ptr uintptr) {
 	return
 }
 
-func NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo uintptr, processInfoLength uint32, returnLength *uint32) (status uint32) {
+func NtQueryInformationProcess(processHandle windows.Handle, processInfoClass uint32, processInfo unsafe.Pointer, processInfoLength uint32, returnLength *uint32) (status uint32) {
 	r0, _, _ := syscall.Syscall6(procNtQueryInformationProcess.Addr(), 5, uintptr(processHandle), uintptr(processInfoClass), uintptr(processInfo), uintptr(processInfoLength), uintptr(unsafe.Pointer(returnLength)), 0)
 	status = uint32(r0)
 	return

--- a/src/runtime/vendor/github.com/containerd/containerd/version/version.go
+++ b/src/runtime/vendor/github.com/containerd/containerd/version/version.go
@@ -23,7 +23,7 @@ var (
 	Package = "github.com/containerd/containerd"
 
 	// Version holds the complete version number. Filled in at linking time.
-	Version = "1.6.6+unknown"
+	Version = "1.6.8+unknown"
 
 	// Revision is filled with the VCS (e.g. git) revision being used to build
 	// the program at linking time.

--- a/src/runtime/vendor/modules.txt
+++ b/src/runtime/vendor/modules.txt
@@ -11,7 +11,7 @@ github.com/Microsoft/go-winio
 github.com/Microsoft/go-winio/pkg/guid
 github.com/Microsoft/go-winio/pkg/security
 github.com/Microsoft/go-winio/vhd
-# github.com/Microsoft/hcsshim v0.9.3
+# github.com/Microsoft/hcsshim v0.9.4
 ## explicit; go 1.13
 github.com/Microsoft/hcsshim
 github.com/Microsoft/hcsshim/computestorage
@@ -73,7 +73,7 @@ github.com/containerd/cgroups/v2/stats
 # github.com/containerd/console v1.0.3
 ## explicit; go 1.13
 github.com/containerd/console
-# github.com/containerd/containerd v1.6.6
+# github.com/containerd/containerd v1.6.8
 ## explicit; go 1.17
 github.com/containerd/containerd/api/events
 github.com/containerd/containerd/api/services/ttrpc/events/v1


### PR DESCRIPTION
Let's follow the binary bump used in the CI and also bump the vendored version of containerd to v1.6.8.

Fixes: #5722

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>