### PR TITLE
tools: Remove extra tab spaces from kata deploy binaries script

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -195,7 +195,7 @@ handle_build() {
 		install_shimv2
 		install_virtiofsd
 		;;
-	
+
 	cloud-hypervisor) install_clh ;;
 
 	firecracker) install_firecracker ;;
@@ -216,7 +216,6 @@ handle_build() {
 
 	virtiofsd) install_virtiofsd ;;
 
-	
 	*)
 		die "Invalid build target ${build_target}"
 		;;


### PR DESCRIPTION
This PR removes extra tab spaces from the kata deploy binaries script.

Fixes #5747

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>