### PR TITLE
runtime: go fix code for 1.19

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-check_generic_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_generic_test.go
@@ -4,7 +4,6 @@
 //
 
 //go:build arm64 || ppc64le
-// +build arm64 ppc64le
 
 package main
 

--- a/src/runtime/cmd/kata-runtime/kata-env_generic_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_generic_test.go
@@ -4,7 +4,6 @@
 //
 
 //go:build arm64 || ppc64le
-// +build arm64 ppc64le
 
 package main
 

--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -50,7 +50,6 @@ require (
 	go.opentelemetry.io/otel/exporters/jaeger v1.0.0
 	go.opentelemetry.io/otel/sdk v1.3.0
 	go.opentelemetry.io/otel/trace v1.3.0
-	golang.org/x/net v0.0.0-20220722155237-a158d28d115b
 	golang.org/x/oauth2 v0.0.0-20220622183110-fd043fe589d2
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f
 	google.golang.org/grpc v1.47.0
@@ -99,6 +98,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	go.mongodb.org/mongo-driver v1.7.5 // indirect
 	go.opencensus.io v0.23.0 // indirect
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
 	golang.org/x/sync v0.0.0-20220601150217-0de741cfad7f // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.7 // indirect

--- a/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
@@ -1,5 +1,4 @@
 //go:build !s390x
-// +build !s390x
 
 // Copyright contributors to the Virtual Machine Manager for Go project
 //

--- a/src/runtime/pkg/resourcecontrol/cgroups.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2021-2022 Apple Inc.
 //

--- a/src/runtime/virtcontainers/acrn.go
+++ b/src/runtime/virtcontainers/acrn.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2019 Intel Corporation
 //

--- a/src/runtime/virtcontainers/acrn_arch_base.go
+++ b/src/runtime/virtcontainers/acrn_arch_base.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2019 Intel Corporation
 //

--- a/src/runtime/virtcontainers/acrn_test.go
+++ b/src/runtime/virtcontainers/acrn_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2019 Intel Corporation
 //

--- a/src/runtime/virtcontainers/agent.go
+++ b/src/runtime/virtcontainers/agent.go
@@ -9,12 +9,12 @@ import (
 	"syscall"
 	"time"
 
+	"context"
 	persistapi "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/api"
 	pbTypes "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/net/context"
 )
 
 type newAgentFuncKey struct{}

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2019 Ericsson Eurolab Deutschland GmbH
 //

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2019 Ericsson Eurolab Deutschland G.m.b.H.
 //

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/fc_metrics.go
+++ b/src/runtime/virtcontainers/fc_metrics.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2020 Ant Group
 //

--- a/src/runtime/virtcontainers/fc_test.go
+++ b/src/runtime/virtcontainers/fc_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2019 Intel Corporation
 //

--- a/src/runtime/virtcontainers/ipvlan_endpoint.go
+++ b/src/runtime/virtcontainers/ipvlan_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/ipvlan_endpoint_test.go
+++ b/src/runtime/virtcontainers/ipvlan_endpoint_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -34,10 +34,10 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 
+	"context"
 	"github.com/gogo/protobuf/proto"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/net/context"
 	"golang.org/x/sys/unix"
 	"google.golang.org/grpc/codes"
 	grpcStatus "google.golang.org/grpc/status"

--- a/src/runtime/virtcontainers/macvlan_endpoint.go
+++ b/src/runtime/virtcontainers/macvlan_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/macvlan_endpoint_test.go
+++ b/src/runtime/virtcontainers/macvlan_endpoint_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/macvtap_endpoint.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/macvtap_endpoint_test.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/mock_agent.go
+++ b/src/runtime/virtcontainers/mock_agent.go
@@ -9,12 +9,12 @@ import (
 	"syscall"
 	"time"
 
+	"context"
 	persistapi "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/persist/api"
 	pbTypes "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
-	"golang.org/x/net/context"
 )
 
 // mockAgent is an empty Agent implementation, for testing and

--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/physical_endpoint_test.go
+++ b/src/runtime/virtcontainers/physical_endpoint_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2016 Intel Corporation
 //

--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/qemu_amd64_test.go
+++ b/src/runtime/virtcontainers/qemu_amd64_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 IBM
 //

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 IBM
 //

--- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 IBM
 //

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 IBM
 //

--- a/src/runtime/virtcontainers/qemu_s390x_test.go
+++ b/src/runtime/virtcontainers/qemu_s390x_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 IBM
 //

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2016 Intel Corporation
 //

--- a/src/runtime/virtcontainers/tap_endpoint.go
+++ b/src/runtime/virtcontainers/tap_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Huawei Corporation
 //

--- a/src/runtime/virtcontainers/tuntap_endpoint.go
+++ b/src/runtime/virtcontainers/tuntap_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Huawei Corporation
 // Copyright (c) 2019 Intel Corporation

--- a/src/runtime/virtcontainers/utils/utils_linux_generic.go
+++ b/src/runtime/virtcontainers/utils/utils_linux_generic.go
@@ -1,5 +1,4 @@
 //go:build amd64 || arm64 || s390x || !ppc64le
-// +build amd64 arm64 s390x !ppc64le
 
 // Copyright (c) 2019 IBM
 //

--- a/src/runtime/virtcontainers/veth_endpoint.go
+++ b/src/runtime/virtcontainers/veth_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/veth_endpoint_test.go
+++ b/src/runtime/virtcontainers/veth_endpoint_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/vhostuser_endpoint.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //

--- a/src/runtime/virtcontainers/vhostuser_endpoint_test.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Copyright (c) 2018 Intel Corporation
 //


### PR DESCRIPTION
We have starting to use golang 1.19, some features are not supported later, so run `go fix` to fix them.

Fixes: #5750

Signed-off-by: Bin Liu <bin@hyper.sh>