### PR TITLE
runtime-rs: remove the version number from the commit display message

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -290,9 +290,6 @@ COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})
 COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)
 
-# Exported to allow cargo to see it
-export VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
-
 EXTRA_RUSTFEATURES :=
 
 ifneq ($(EXTRA_RUSTFEATURES),)
@@ -322,8 +319,8 @@ GENERATED_REPLACEMENTS= \
     CONTAINERD_RUNTIME_NAME \
     RUNTIME_VERSION \
     BINDIR \
-    COMMIT \
-    VERSION_COMMIT
+    COMMIT
+
 GENERATED_FILES :=
 
 GENERATED_FILES += $(GENERATED_CODE)

--- a/src/runtime-rs/crates/shim/src/bin/main.rs
+++ b/src/runtime-rs/crates/shim/src/bin/main.rs
@@ -99,7 +99,7 @@ fn show_version(err: Option<anyhow::Error>) {
         config::PROJECT_NAME,
         config::CONTAINERD_RUNTIME_NAME,
         config::RUNTIME_VERSION,
-        config::RUNTIME_VERSION_COMMIT,
+        config::RUNTIME_GIT_COMMIT,
     );
 
     if let Some(err) = err {

--- a/src/runtime-rs/crates/shim/src/config.rs.in
+++ b/src/runtime-rs/crates/shim/src/config.rs.in
@@ -9,7 +9,6 @@
 
 pub const PROJECT_NAME: &str = "@PROJECT_NAME@";
 pub const RUNTIME_VERSION: &str = "@RUNTIME_VERSION@";
-pub const RUNTIME_VERSION_COMMIT: &str = "@VERSION_COMMIT@";
 pub const RUNTIME_GIT_COMMIT: &str = "@COMMIT@";
 pub const RUNTIME_NAME: &str = "@RUNTIME_NAME@";
 pub const CONTAINERD_RUNTIME_NAME: &str = "@CONTAINERD_RUNTIME_NAME@";


### PR DESCRIPTION
The displayed commit message and version message are partially duplicated. Remove the version number from the commit display message.

Fixes:#5735

Signed-off-by: Chen Taotao <chentt10@chinatelecom.cn>