### PR TITLE
runtime-rs: moving only vCPU threads into sandbox controller

### DIFF
--- a/src/runtime-rs/crates/resource/src/cgroups/mod.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/mod.rs
@@ -179,7 +179,7 @@ impl CgroupsResource {
         // All vCPU threads move to the sandbox controller.
         for tid in tids {
             self.cgroup_manager
-                .add_task_by_tgid(CgroupPid { pid: *tid as u64 })?
+                .add_task(CgroupPid { pid: *tid as u64 })?
         }
 
         Ok(())


### PR DESCRIPTION
when overhead controller exists, just contrain vCPU threads
in sandbox controller

Fixes:#5760

Signed-off-by: gaohuatao <gaohuatao@bytedance.com>