### PR TITLE
actions: skip some jobs using "paths-ignore" filter

### DIFF
--- a/.github/workflows/cargo-deny-runner.yaml
+++ b/.github/workflows/cargo-deny-runner.yaml
@@ -1,5 +1,12 @@
 name: Cargo Crates Check Runner
-on: [pull_request]
+on:
+  - pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+    paths-ignore: [ '**.md', '**.png', '**.jpg', '**.jpeg', '**.svg', '/docs/**' ]
 jobs:
   cargo-deny-runner:
     runs-on: ubuntu-latest

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -5,7 +5,7 @@ on:
       - edited
       - reopened
       - synchronize
-
+    paths-ignore: [ '**.md', '**.png', '**.jpg', '**.jpeg', '**.svg', '/docs/**' ]
 name: Darwin tests
 jobs:
   test:

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -6,6 +6,7 @@ on:
       - synchronize
       - reopened
       - edited
+    paths-ignore: [ '**.md', '**.png', '**.jpg', '**.jpeg', '**.svg', '/docs/**' ]
 
 jobs:
   test:


### PR DESCRIPTION
If only docs/images are changed, some jobs should not run.

Fixes: #5759

Signed-off-by: Bin Liu <bin@hyper.sh>