### PR TITLE
kata-ctl: add host check for aarch64

### DIFF
--- a/src/tools/kata-ctl/src/arch/aarch64/mod.rs
+++ b/src/tools/kata-ctl/src/arch/aarch64/mod.rs
@@ -8,8 +8,18 @@ pub use arch_specific::*;
 
 mod arch_specific {
     use anyhow::Result;
+    use std::path::Path;
+
+    const KVM_DEV: &str = "/dev/kvm";
 
     pub fn check() -> Result<()> {
-        unimplemented!("Check not implemented in aarch64")
+        println!("INFO: check: aarch64");
+        if Path::new(KVM_DEV).exists() {
+            println!("Kata Containers can run on this host\n");
+        } else {
+            eprintln!("WARNING: Kata Containers can't run on this host as lack of virtulization support\n");
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
For now, we can check if host support running kata by check if "/dev/kvm" exist on aarch64.

Fixes: #5768
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>