### PR TITLE
CC | build: export kernel_version to be used with its build script

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -195,6 +195,7 @@ install_cc_tee_kernel() {
 	[[ "${tee}" != "tdx" && "${tee}" != "sev" ]] && die "Non supported TEE"
 
 	info "build initramfs for tee kernel"
+	export kernel_version=${kernel_version}
 	"${initramfs_builder}"
 	kernel_url="$(yq r $versions_yaml assets.kernel.${tee}.url)"
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -x "${tee}" -v "${kernel_version}" -u "${kernel_url}"

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -69,7 +69,7 @@ check_cached_kernel() {
 
 install_cached_kernel() {
 	local kernel_directory="${cached_path}/tools/packaging/kata-deploy/local-build/build/cc-kernel/destdir/opt/confidential-containers/share/kata-containers"
-        local vmlinux_kernel_name="vmlinux-${cached_kernel_version}-${cached_kernel_config}"
+	local vmlinux_kernel_name="vmlinux-${cached_kernel_version}-${cached_kernel_config}"
 	local vmlinuz_kernel_name="vmlinuz-${cached_kernel_version}-${cached_kernel_config}"
 	mkdir -p "${kernel_directory}"
 	pushd "${kernel_directory}"


### PR DESCRIPTION
Now that we're caching the kernel, we're relying on the kernel version
being exported.  This is already done for the CC kernel, but not for the
TEE specific ones.

Fixes: #5770

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>
