### PR TITLE
ci: let static checks don't depend on build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ TOOLS += log-parser
 TOOLS += runk
 TOOLS += trace-forwarder
 
-STANDARD_TARGETS = build check clean install test vendor
+STANDARD_TARGETS = build check clean install static-checks-build test vendor
 
 default: all
 
@@ -37,7 +37,7 @@ generate-protocols:
 	make -C src/agent generate-protocols
 
 # Some static checks rely on generated source files of components.
-static-checks: build
+static-checks: static-checks-build
 	bash ci/static-checks.sh
 
 docs-url-alive-check:

--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -107,6 +107,8 @@ endef
 ##TARGET default: build code
 default: $(TARGET) show-header
 
+static-checks-build: $(GENERATED_CODE)
+
 $(TARGET): $(GENERATED_CODE) $(TARGET_PATH)
 
 $(TARGET_PATH): show-summary

--- a/src/dragonball/Makefile
+++ b/src/dragonball/Makefile
@@ -16,6 +16,9 @@ build:
 	@echo "INFO: cargo build..."
 	cargo build --all-features --target $(TRIPLE)
 
+static-checks-build:
+	@echo "INFO: static-checks-build do nothing.."
+
 check: clippy format
 
 clippy:

--- a/src/libs/Makefile
+++ b/src/libs/Makefile
@@ -16,6 +16,9 @@ default: build
 build:
 	cargo build --all-features
 
+static-checks-build:
+	@echo "INFO: static-checks-build do nothing.."
+
 check: clippy format
 
 clippy:

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -361,6 +361,8 @@ GENERATED_FILES += $(CONFIGS)
 
 runtime: $(TARGET)
 
+static-checks-build: $(GENERATED_FILES)
+
 $(TARGET): $(GENERATED_FILES) $(TARGET_PATH)
 
 $(TARGET_PATH): $(SOURCES) | show-summary

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -680,6 +680,8 @@ handle_vendor:
 vendor: handle_vendor
 	./hack/tree_status.sh
 
+static-checks-build: $(GENERATED_FILES)
+
 clean:
 	$(QUIET_CLEAN)rm -f \
 		$(CONFIGS) \

--- a/src/tools/agent-ctl/Makefile
+++ b/src/tools/agent-ctl/Makefile
@@ -11,6 +11,9 @@ default: build
 build:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
 
+static-checks-build:
+	@echo "INFO: static-checks-build do nothing.."
+
 clean:
 	cargo clean
 

--- a/src/tools/kata-ctl/Makefile
+++ b/src/tools/kata-ctl/Makefile
@@ -36,6 +36,8 @@ $(TARGET): $(GENERATED_CODE)
 build:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES)
 
+static-checks-build: $(GENERATED_CODE)
+
 $(GENERATED_FILES): %: %.in
 	@sed $(foreach r,$(GENERATED_REPLACEMENTS),-e 's|@$r@|$($r)|g') "$<" > "$@"
 

--- a/src/tools/log-parser/Makefile
+++ b/src/tools/log-parser/Makefile
@@ -29,6 +29,9 @@ install: $(TARGET)
 	install -d $(shell dirname $(DESTTARGET))
 	install $(TARGET) $(DESTTARGET)
 
+static-checks-build:
+	@echo "INFO: static-checks-build do nothing.."
+
 clean:
 	rm -f $(TARGET)
 

--- a/src/tools/runk/Makefile
+++ b/src/tools/runk/Makefile
@@ -34,6 +34,9 @@ default: build
 build:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE) $(EXTRA_RUSTFEATURES)
 
+static-checks-build:
+	@echo "INFO: static-checks-build do nothing.."
+
 install:
 	install -D $(TARGET_PATH) $(BINDIR)/$(TARGET)
 

--- a/src/tools/trace-forwarder/Makefile
+++ b/src/tools/trace-forwarder/Makefile
@@ -11,6 +11,9 @@ default: build
 build:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
 
+static-checks-build:
+	@echo "INFO: static-checks-build do nothing.."
+
 clean:
 	cargo clean
 

--- a/utils.mk
+++ b/utils.mk
@@ -39,6 +39,9 @@ $(2) : $(1)/$(2)/Makefile
 	make -C $(1)/$(2)
 build-$(2) : $(2)
 
+static-checks-build-$(2):
+	make -C $(1)/$(2) static-checks-build
+
 check-$(2) : $(2)
 	make -C $(1)/$(2) check
 


### PR DESCRIPTION
Since the static-checks only need some config/version files to be generated, we can add a new target/rule to create the code required to let static-checks pass.

Fixes: #5777

Signed-off-by: Bin Liu <bin@hyper.sh>