### PR TITLE
snap: Fix snapcraft setup (unbreak snap releases)

### DIFF
--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -4,6 +4,9 @@ on:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+*'
 
+env:
+  SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.snapcraft_token }}
+
 jobs:
   release-snap:
     runs-on: ubuntu-20.04
@@ -14,9 +17,16 @@ jobs:
           fetch-depth: 0
 
       - name: Install Snapcraft
-        uses: samuelmeuli/action-snapcraft@v1
-        with:
-          snapcraft_token: ${{ secrets.snapcraft_token }}
+        run: |
+          # Required to avoid snapcraft install failure
+          sudo chown root:root /
+
+          # "--classic" is needed for the GitHub action runner
+          # environment.
+          sudo snap install snapcraft --classic
+
+          # Allow other parts to access snap binaries
+          echo /snap/bin >> "$GITHUB_PATH"
 
       - name: Build snap
         run: |

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -20,7 +20,16 @@ jobs:
 
       - name: Install Snapcraft
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
-        uses: samuelmeuli/action-snapcraft@v1
+        run: |
+          # Required to avoid snapcraft install failure
+          sudo chown root:root /
+
+          # "--classic" is needed for the GitHub action runner
+          # environment.
+          sudo snap install snapcraft --classic
+
+          # Allow other parts to access snap binaries
+          echo /snap/bin >> "$GITHUB_PATH"
 
       - name: Build snap
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}


### PR DESCRIPTION
Setup the snapcraft environment manually as the action we had been using for this does not appear to be actively maintained currently.

Related to this, switch to specifying the snapcraft store credentials using the `SNAPCRAFT_STORE_CREDENTIALS` secret. This unbreaks `snapcraft upload`, which Canonical appear to have broken by removing the previous facility.

Fixes: #5772.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>