### PR TITLE
Re-work the way we cache components for the CCv0 branch

### DIFF
--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -14,7 +14,9 @@ set -o pipefail
 readonly script_name="$(basename "${BASH_SOURCE[0]}")"
 readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly packaging_root_dir="$(cd "${script_dir}/../" && pwd)"
-readonly repo_root_dir="$(cd "${script_dir}/../../../" && pwd)"
+
+source "${packaging_root_dir}/scripts/lib.sh"
+
 readonly osbuilder_dir="$(cd "${repo_root_dir}/tools/osbuilder" && pwd)"
 
 patches_path=""
@@ -25,8 +27,6 @@ export GOPATH=${GOPATH:-${HOME}/go}
 final_image_name="kata-containers"
 final_initrd_name="kata-containers-initrd"
 image_initrd_extension=".img"
-
-source "${packaging_root_dir}/scripts/lib.sh"
 
 arch_target="$(uname -m)"
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -15,8 +15,9 @@ readonly project="kata-containers"
 readonly script_name="$(basename "${BASH_SOURCE[0]}")"
 readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+source "${script_dir}/../../scripts/lib.sh"
+
 readonly prefix="/opt/kata"
-readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
 readonly static_build_dir="${repo_root_dir}/tools/packaging/static-build"
 readonly version_file="${repo_root_dir}/VERSION"
 readonly versions_yaml="${repo_root_dir}/versions.yaml"

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -173,7 +173,6 @@ sha256sum_from_files() {
 	files="$(echo $files | tr ' ' '\n' | LC_ALL=C sort -u)"
 	# Concate the files and calculate a hash.
 	shasum="$(cat $files | sha256sum -b)" || true
-	info "shasum of files $shasum"
 	if [ -n "$shasum" ];then
 		# Return only the SHA field.
 		echo $(awk '{ print $1 }' <<< $shasum)

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -13,6 +13,8 @@ export PUSH_TO_REGISTRY="${PUSH_TO_REGISTRY:-"no"}"
 
 this_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+export repo_root_dir="$(cd "${this_script_dir}/../../../" && pwd)"
+
 short_commit_length=10
 
 hub_bin="hub-bin"

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -123,12 +123,11 @@ get_config_version() {
 	fi
 }
 
-# $1 - Repo's root dir
-# $2 - The file we're looking for the last modification
+# $1 - The file we're looking for the last modification
 get_last_modification() {
-	local repo_root_dir="${1}"
-	local file="${2}"
+	local file="${1}"
 
+	pushd ${repo_root_dir} &> /dev/null
 	# This is a workaround needed for when running this code on Jenkins
 	git config --global --add safe.directory ${repo_root_dir} &> /dev/null
 
@@ -136,6 +135,7 @@ get_last_modification() {
 	[ $(git status --porcelain | grep "${file#${repo_root_dir}/}" | wc -l) -gt 0 ] && dirty="-dirty"
 
 	echo "$(git log -1 --pretty=format:"%H" ${file})${dirty}"
+	popd &> /dev/null
 }
 
 # $1 - The tag to be pushed to the registry
@@ -187,4 +187,55 @@ calc_qemu_files_sha256sum() {
 		${this_script_dir}/../static-build/scripts"
 
 	sha256sum_from_files "$files"
+}
+
+get_initramfs_image_name() {
+	initramfs_script_dir="${this_script_dir}/../static-build/initramfs"
+	echo "${CC_BUILDER_REGISTRY}:initramfs-cryptosetup$(get_from_kata_deps "externals.cryptsetup.version")-lvm2-$(get_from_kata_deps "externals.lvm2.version")-$(get_last_modification ${initramfs_script_dir})-$(uname -m)"
+}
+
+get_kernel_image_name() {
+	kernel_script_dir="${this_script_dir}/../static-build/kernel"
+	echo "${CC_BUILDER_REGISTRY}:kernel-$(get_last_modification ${kernel_script_dir})-$(uname -m)"
+}
+
+get_ovmf_image_name() {
+	ovmf_script_dir="${this_script_dir}/../static-build/ovmf"
+	echo "${CC_BUILDER_REGISTRY}:ovmf-$(get_last_modification ${ovmf_script_dir})-$(uname -m)"
+}
+
+get_qemu_image_name() {
+	qemu_script_dir="${this_script_dir}/../static-build/qemu"
+	echo "${CC_BUILDER_REGISTRY}:qemu-$(get_last_modification ${qemu_script_dir})-$(uname -m)"
+}
+
+get_shim_v2_image_name() {
+	shim_v2_script_dir="${this_script_dir}/../static-build/shim-v2"
+	echo "${CC_BUILDER_REGISTRY}:shim-v2-go-$(get_from_kata_deps "languages.golang.meta.newest-version")-rust-$(get_from_kata_deps "languages.rust.meta.newest-version")-$(get_last_modification ${shim_v2_script_dir})-$(uname -m)"
+}
+
+get_td_shim_image_name() {
+	td_shim_script_dir="${this_script_dir}/../static-build/td-shim"
+	echo "${CC_BUILDER_REGISTRY}:td-shim-$(get_last_modification ${td_shim_script_dir})-$(uname -m)"
+}
+
+get_virtiofsd_image_name() {
+	ARCH=$(uname -m)
+	case ${ARCH} in
+	        "aarch64")
+	                libc="musl"
+	                ;;
+	        "ppc64le")
+	                libc="gnu"
+	                ;;
+	        "s390x")
+	                libc="gnu"
+	                ;;
+	        "x86_64")
+	                libc="musl"
+	                ;;
+	esac
+
+	virtiofsd_script_dir="${this_script_dir}/../static-build/virtiofsd"
+	echo "${CC_BUILDER_REGISTRY}:virtiofsd-$(get_from_kata_deps "externals.virtiofsd.toolchain")-${libc}-$(get_last_modification ${virtiofsd_script_dir})-$(uname -m)"
 }

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -178,3 +178,11 @@ sha256sum_from_files() {
 		echo $(awk '{ print $1 }' <<< $shasum)
 	fi
 }
+
+calc_qemu_files_sha256sum() {
+	local files="${this_script_dir}/../qemu \
+		${this_script_dir}/../static-build/qemu.blacklist \
+		${this_script_dir}/../static-build/scripts"
+
+	sha256sum_from_files "$files"
+}

--- a/tools/packaging/static-build/initramfs/build.sh
+++ b/tools/packaging/static-build/initramfs/build.sh
@@ -30,7 +30,7 @@ package_output_dir="${package_output_dir:-}"
 [ -n "${lvm2_repo}" ] || die "Failed to get lvm2 repo"
 [ -n "${lvm2_version}" ] || die "Failed to get lvm2 version"
 
-container_image="${INITRAMFS_CONTAINER_BUILDER:-${CC_BUILDER_REGISTRY}:initramfs-cryptsetup-${cryptsetup_version}-lvm2-${lvm2_version}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)}"
+container_image="${INITRAMFS_CONTAINER_BUILDER:-$(get_initramfs_image_name)}"
 
 sudo docker pull ${container_image} || (sudo docker build \
 	--build-arg cryptsetup_repo="${cryptsetup_repo}" \

--- a/tools/packaging/static-build/initramfs/build.sh
+++ b/tools/packaging/static-build/initramfs/build.sh
@@ -9,7 +9,6 @@ set -o nounset
 set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
 readonly initramfs_builder="${script_dir}/build-initramfs.sh"
 readonly default_install_dir="$(cd "${script_dir}/../../kernel" && pwd)"
 

--- a/tools/packaging/static-build/initramfs/build.sh
+++ b/tools/packaging/static-build/initramfs/build.sh
@@ -15,17 +15,16 @@ readonly default_install_dir="$(cd "${script_dir}/../../kernel" && pwd)"
 
 source "${script_dir}/../../scripts/lib.sh"
 
-kata_version="${kata_version:-}"
 cryptsetup_repo="${cryptsetup_repo:-}"
 cryptsetup_version="${cryptsetup_version:-}"
 lvm2_repo="${lvm2_repo:-}"
 lvm2_version="${lvm2_version:-}"
 package_output_dir="${package_output_dir:-}"
 
-[ -n "${cryptsetup_repo}" ] || cryptsetup_repo=$(get_from_kata_deps "externals.cryptsetup.url" "${kata_version}")
-[ -n "${cryptsetup_version}" ] || cryptsetup_version=$(get_from_kata_deps "externals.cryptsetup.version" "${kata_version}")
-[ -n "${lvm2_repo}" ] || lvm2_repo=$(get_from_kata_deps "externals.lvm2.url" "${kata_version}")
-[ -n "${lvm2_version}" ] || lvm2_version=$(get_from_kata_deps "externals.lvm2.version" "${kata_version}")
+[ -n "${cryptsetup_repo}" ] || cryptsetup_repo=$(get_from_kata_deps "externals.cryptsetup.url")
+[ -n "${cryptsetup_version}" ] || cryptsetup_version=$(get_from_kata_deps "externals.cryptsetup.version")
+[ -n "${lvm2_repo}" ] || lvm2_repo=$(get_from_kata_deps "externals.lvm2.url")
+[ -n "${lvm2_version}" ] || lvm2_version=$(get_from_kata_deps "externals.lvm2.version")
 
 [ -n "${cryptsetup_repo}" ] || die "Failed to get cryptsetup repo"
 [ -n "${cryptsetup_version}" ] || die "Failed to get cryptsetup version"

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -9,10 +9,10 @@ set -o nounset
 set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
-readonly kernel_builder="${repo_root_dir}/tools/packaging/kernel/build-kernel.sh"
 
 source "${script_dir}/../../scripts/lib.sh"
+
+readonly kernel_builder="${repo_root_dir}/tools/packaging/kernel/build-kernel.sh"
 
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -17,82 +17,25 @@ readonly kernel_builder="${repo_root_dir}/tools/packaging/kernel/build-kernel.sh
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
 container_image="${KERNEL_CONTAINER_BUILDER:-$(get_kernel_image_name)}"
-kernel_latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-cc-$(uname -m)/${cached_artifacts_path}"
-current_kernel_version=${kernel_version:-$(get_from_kata_deps "assets.kernel.version")}
-cached_path="$(echo ${script_dir} | sed 's,/*[^/]\+/*$,,' | sed 's,/*[^/]\+/*$,,' | sed 's,/*[^/]\+/*$,,' | sed 's,/*[^/]\+/*$,,')"
-current_kernel_config_file="${cached_path}/tools/packaging/kernel/kata_config_version"
-current_kernel_config="$(cat $current_kernel_config_file)"
-kernel_version="$(echo ${current_kernel_version} | cut -c2- )"
 
-build_from_source() {
-	sudo docker pull ${container_image} || \
-		(sudo docker build -t "${container_image}" "${script_dir}" && \
-	 	# No-op unless PUSH_TO_REGISTRY is exported as "yes"
-	 	push_to_registry "${container_image}")
+sudo docker pull ${container_image} || \
+	(sudo docker build -t "${container_image}" "${script_dir}" && \
+ 	# No-op unless PUSH_TO_REGISTRY is exported as "yes"
+ 	push_to_registry "${container_image}")
 
-	sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
-		-w "${PWD}" \
-		--env KATA_BUILD_CC="${KATA_BUILD_CC:-}" \
-		"${container_image}" \
-		bash -c "${kernel_builder} $* setup"
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${PWD}" \
+	--env KATA_BUILD_CC="${KATA_BUILD_CC:-}" \
+	"${container_image}" \
+	bash -c "${kernel_builder} $* setup"
 
-	sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
-		-w "${PWD}" \
-		"${container_image}" \
-		bash -c "${kernel_builder} $* build"
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${PWD}" \
+	"${container_image}" \
+	bash -c "${kernel_builder} $* build"
 
-	sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
-		-w "${PWD}" \
-		--env DESTDIR="${DESTDIR}" --env PREFIX="${PREFIX}" \
-		"${container_image}" \
-		bash -c "${kernel_builder} $* install"
-}
-
-check_cached_kernel() {
-	local latest=$(curl -sfL "${kernel_latest_build_url}"/latest) || latest="none"
-	local cached_kernel_version="$(echo ${latest} | awk '{print $1}')"
-	info "Current kernel version: ${kernel_version}"
-	info "Cached kernel version: ${cached_kernel_version}"
-	if [ "${kernel_version}" == "${cached_kernel_version}" ] && [ "$(uname -m)" == "x86_64" ]; then
-		local cached_kernel_config="$(echo ${latest} | awk '{print $2}')"
-		info "Cached kernel config: ${cached_kernel_config}"
-		info "Current kernel config: ${current_kernel_config}"
-		if [ -z "${cached_kernel_config}" ]; then
-			build_from_source $*
-		else
-			install_cached_kernel $*
-		fi
-	else
-		build_from_source $*
-	fi
-}
-
-install_cached_kernel() {
-	local kernel_directory="${cached_path}/tools/packaging/kata-deploy/local-build/build/cc-kernel/destdir/opt/confidential-containers/share/kata-containers"
-	local vmlinux_kernel_name="vmlinux-${cached_kernel_version}-${cached_kernel_config}"
-	local vmlinuz_kernel_name="vmlinuz-${cached_kernel_version}-${cached_kernel_config}"
-	mkdir -p "${kernel_directory}"
-	pushd "${kernel_directory}"
-	ls
-	local vmlinux_url="${kernel_latest_build_url}/${vmlinux_kernel_name}"
-	if curl --output /dev/null --silent --head --fail "${vmlinux_url}"; then
-		info "Installing vmlinux cached kernel"
-		curl -fL --progress-bar "${kernel_latest_build_url}/${vmlinux_kernel_name}" -o "${vmlinux_kernel_name}" || return 1
-		sudo -E ln -sf "${kernel_directory}/${vmlinux_kernel_name}" "${kernel_directory}/vmlinux.container"
-	fi
-
-	local vmlinuz_url="${kernel_latest_build_url}/${vmlinuz_kernel_name}"
-	if curl --output /dev/null --silent --head --fail "${vmlinuz_url}"; then
-		info "Installing vmlinuz cached kernel"
-		curl -fL --progress-bar "${kernel_latest_build_url}/${vmlinuz_kernel_name}" -o "${vmlinuz_kernel_name}" || return 1
-		sudo -E ln -sf "${kernel_directory}/${vmlinuz_kernel_name}" "${kernel_directory}/vmlinuz.container"
-	fi
-	popd
-
-}
-
-main() {
-	check_cached_kernel $*
-}
-
-main $*
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${PWD}" \
+	--env DESTDIR="${DESTDIR}" --env PREFIX="${PREFIX}" \
+	"${container_image}" \
+	bash -c "${kernel_builder} $* install"

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -16,7 +16,7 @@ readonly kernel_builder="${repo_root_dir}/tools/packaging/kernel/build-kernel.sh
 
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
-container_image="${KERNEL_CONTAINER_BUILDER:-${CC_BUILDER_REGISTRY}:kernel-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)}"
+container_image="${KERNEL_CONTAINER_BUILDER:-$(get_kernel_image_name)}"
 kernel_latest_build_url="${jenkins_url}/job/kata-containers-2.0-kernel-cc-$(uname -m)/${cached_artifacts_path}"
 current_kernel_version=${kernel_version:-$(get_from_kata_deps "assets.kernel.version")}
 cached_path="$(echo ${script_dir} | sed 's,/*[^/]\+/*$,,' | sed 's,/*[^/]\+/*$,,' | sed 's,/*[^/]\+/*$,,' | sed 's,/*[^/]\+/*$,,')"

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -15,7 +15,7 @@ source "${script_dir}/../../scripts/lib.sh"
 
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
-container_image="${OVMF_CONTAINER_BUILDER:-${CC_BUILDER_REGISTRY}:ovmf-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)}"
+container_image="${OVMF_CONTAINER_BUILDER:-$(get_ovmf_image_name)}"
 ovmf_build="${ovmf_build:-x86_64}"
 kata_version="${kata_version:-}"
 ovmf_repo="${ovmf_repo:-}"

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -9,7 +9,6 @@ set -o nounset
 set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
 readonly ovmf_builder="${script_dir}/build-ovmf.sh"
 
 source "${script_dir}/../../scripts/lib.sh"

--- a/tools/packaging/static-build/qemu/build-base-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-base-qemu.sh
@@ -38,7 +38,7 @@ CACHE_TIMEOUT=$(date +"%Y-%m-%d")
 [ -n "${build_suffix}" ] && HYPERVISOR_NAME="kata-qemu-${build_suffix}" || HYPERVISOR_NAME="kata-qemu"
 [ -n "${build_suffix}" ] && PKGVERSION="kata-static-${build_suffix}" || PKGVERSION="kata-static"
 
-container_image="${QEMU_CONTAINER_BUILDER:-${CC_BUILDER_REGISTRY}:qemu-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)}"
+container_image="${QEMU_CONTAINER_BUILDER:-$(get_qemu_image_name)}"
 
 sudo docker pull ${container_image} || \
 	(sudo "${container_engine}" build \

--- a/tools/packaging/static-build/qemu/build-base-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-base-qemu.sh
@@ -9,7 +9,6 @@ set -o nounset
 set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
 readonly qemu_builder="${script_dir}/build-qemu.sh"
 
 source "${script_dir}/../../scripts/lib.sh"

--- a/tools/packaging/static-build/qemu/build-static-qemu-cc.sh
+++ b/tools/packaging/static-build/qemu/build-static-qemu-cc.sh
@@ -36,15 +36,6 @@ get_qemu_information() {
 	[ -n "${qemu_version}" ] || die "failed to get qemu version"
 }
 
-calc_qemu_files_sha256sum() {
-	info "pkg directory is at ${pkg_dir}"
-	local files="${pkg_dir}/qemu \
-		${pkg_dir}/static-build/qemu.blacklist \
-		${pkg_dir}/static-build/scripts"
-
-	sha256sum_from_files "$files"
-}
-
 cached_or_build_qemu_tar() {
 	# Check latest qemu cc tar version sha256sum
 	local latest=$(curl -sfL "${qemu_latest_build_url}/latest") || latest="none"

--- a/tools/packaging/static-build/qemu/build-static-qemu-cc.sh
+++ b/tools/packaging/static-build/qemu/build-static-qemu-cc.sh
@@ -12,74 +12,23 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "${script_dir}/../../scripts/lib.sh"
 
-export qemu_repo="${qemu_repo:-}"
-export qemu_version="${qemu_version:-}"
-export qemu_latest_build_url="${jenkins_url}/job/kata-containers-2.0-qemu-cc-$(uname -m)/${cached_artifacts_path}"
-export katacontainers_repo="${katacontainers_repo:=github.com/kata-containers/kata-containers}"
-export qemu_tarball_name="kata-static-qemu-cc.tar.gz"
-export pkg_dir="$(echo $script_dir | sed 's,/*[^/]\+/*$,,' | sed 's,/*[^/]\+/*$,,')"
-export qemu_tarball_directory="${pkg_dir}/kata-deploy/local-build/build/cc-qemu/builddir"
-export tee="${tee:-}"
+qemu_repo="${qemu_repo:-}"
+qemu_version="${qemu_version:-}"
+tee="${tee:-}"
 
 export prefix="/opt/confidential-containers/"
 
-get_qemu_information() {
-	if [ -z "${qemu_repo}" ]; then
-		info "Get qemu information from runtime versions.yaml"
-		export qemu_url=$(get_from_kata_deps "assets.hypervisor.qemu.url")
-		[ -n "${qemu_url}" ] || die "failed to get qemu url"
-		export qemu_repo="${qemu_url}.git"
-	fi
+if [ -z "${qemu_repo}" ]; then
+	info "Get qemu information from runtime versions.yaml"
+	export qemu_url=$(get_from_kata_deps "assets.hypervisor.qemu.url")
+	[ -n "${qemu_url}" ] || die "failed to get qemu url"
+	export qemu_repo="${qemu_url}.git"
+fi
 
-	[ -n "${qemu_repo}" ] || die "failed to get qemu repo"
-	[ -n "${qemu_version}" ] || export qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.version")
-	[ -n "${qemu_version}" ] || die "failed to get qemu version"
-}
+[ -n "${qemu_repo}" ] || die "failed to get qemu repo"
+[ -n "${qemu_version}" ] || export qemu_version=$(get_from_kata_deps "assets.hypervisor.qemu.version")
+[ -n "${qemu_version}" ] || die "failed to get qemu version"
 
-cached_or_build_qemu_tar() {
-	# Check latest qemu cc tar version sha256sum
-	local latest=$(curl -sfL "${qemu_latest_build_url}/latest") || latest="none"
-	local cached_qemu_version="$(echo ${latest} | awk '{print $1}')"
-	info "Current qemu version: ${qemu_version}"
-	info "Cached qemu version: ${cached_qemu_version}"
-	if [ "${qemu_version}" == "${cached_qemu_version}" ]; then
-		info "Get latest cached information ${latest}"
-		local cached_sha256sum="$(echo ${latest} | awk '{print $2}')"
-		info "Cached sha256sum version: ${cached_sha256sum}"
-		local current_sha256sum="$(calc_qemu_files_sha256sum)"
-		info "Current sha256sum of the qemu directory ${current_sha256sum}"
-		if [ -z "${cached_sha256sum}" ]; then
-			build_qemu_tar
-		elif [ "${current_sha256sum}" == "${cached_sha256sum}" ]; then
-			install_cached_qemu_tar
-		else
-			build_qemu_tar
-		fi
-	else
-		build_qemu_tar
-	fi
-}
-
-build_qemu_tar() {
-	[ -n "${tee}" ] && qemu_tarball_name="kata-static-${tee}-qemu-cc.tar.gz"
-	"${script_dir}/build-base-qemu.sh" "${qemu_repo}" "${qemu_version}" "${tee}" "${qemu_tarball_name}"
-}
-
-install_cached_qemu_tar() {
-	info "Using cached tarball of qemu"
-	curl -fL --progress-bar "${qemu_latest_build_url}/${qemu_tarball_name}" -o "${qemu_tarball_name}" || return 1
-	curl -fsOL "${qemu_latest_build_url}/sha256sum-${qemu_tarball_name}" || return 1
-	sha256sum -c "sha256sum-${qemu_tarball_name}" || return 1
-}
-
-main() {
-	get_qemu_information
-	# Currently the cached for qemu cc only works in x86_64
-	if [ "$(uname -m)" == "x86_64" ]; then
-		cached_or_build_qemu_tar
-	else
-		build_qemu_tar
-	fi
-}
-
-main $@
+qemu_tarball_name="kata-static-qemu-cc.tar.gz"
+[ -n "${tee}" ] && qemu_tarball_name="kata-static-${tee}-qemu-cc.tar.gz"
+"${script_dir}/build-base-qemu.sh" "${qemu_repo}" "${qemu_version}" "${tee}" "${qemu_tarball_name}"

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -9,10 +9,10 @@ set -o nounset
 set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
-readonly kernel_builder="${repo_root_dir}/tools/packaging/kernel/build-kernel.sh"
 
 source "${script_dir}/../../scripts/lib.sh"
+
+readonly kernel_builder="${repo_root_dir}/tools/packaging/kernel/build-kernel.sh"
 
 GO_VERSION=${GO_VERSION}
 RUST_VERSION=${RUST_VERSION:-}

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -19,7 +19,7 @@ RUST_VERSION=${RUST_VERSION:-}
 
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
-container_image="${SHIM_V2_CONTAINER_BUILDER:-${CC_BUILDER_REGISTRY}:shim-v2-go-${GO_VERSION}-rust-${RUST_VERSION}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)}"
+container_image="${SHIM_V2_CONTAINER_BUILDER:-$(get_shim_v2_image_name)}"
 
 EXTRA_OPTS="${EXTRA_OPTS:-""}"
 VMM_CONFIGS="qemu fc"

--- a/tools/packaging/static-build/td-shim/build.sh
+++ b/tools/packaging/static-build/td-shim/build.sh
@@ -29,7 +29,7 @@ package_output_dir="${package_output_dir:-}"
 [ -n "${tdshim_version}" ] || die "Failed to get TD-shim version or commit"
 [ -n "${tdshim_toolchain}" ] || die "Failed to get TD-shim toolchain to be used to build the project"
 
-container_image="${TDSHIM_CONTAINER_BUILDER:-${CC_BUILDER_REGISTRY}:td-shim-${tdshim_toolchain}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)}"
+container_image="${TDSHIM_CONTAINER_BUILDER:-$(get_td_shim_image_name)}"
 
 sudo docker pull ${container_image} || \
 	(sudo docker build \

--- a/tools/packaging/static-build/td-shim/build.sh
+++ b/tools/packaging/static-build/td-shim/build.sh
@@ -9,7 +9,6 @@ set -o nounset
 set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
 readonly tdshim_builder="${script_dir}/build-td-shim.sh"
 
 source "${script_dir}/../../scripts/lib.sh"

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -48,7 +48,7 @@ case ${ARCH} in
 		;;
 esac
 
-container_image="${VIRTIOFSD_CONTAINER_BUILDER:-${CC_BUILDER_REGISTRY}:virtiofsd-${virtiofsd_toolchain}-${libc}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)}"
+container_image="${VIRTIOFSD_CONTAINER_BUILDER:-$(get_virtiofsd_image_name)}"
 
 sudo docker pull ${container_image} || \
 	(sudo docker build \

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -9,7 +9,6 @@ set -o nounset
 set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
 readonly virtiofsd_builder="${script_dir}/build-static-virtiofsd.sh"
 
 source "${script_dir}/../../scripts/lib.sh"


### PR DESCRIPTION
This is a huge set of changes that basically re-work how we're caching the components for our CI.

Previously to this work, we've been caching specific binaries and having to implement a specific logic for each component cached.  With this work we're trying to have a more generic solution where we're just caching the final tarball generated by `make cc-${component}` and re-using them whenever possible.

The critereas for using a cached tarball are:
* The base container image used to build the tarball did **not** change
* The version of the component did **not** change
  * For components that we carry patches over, we do a check on their folder to see whether something has changed there or not.