### PR TITLE
kata-ctl: check: only-list-releases and include-all-releases options

### DIFF
--- a/src/tools/kata-ctl/Cargo.lock
+++ b/src/tools/kata-ctl/Cargo.lock
@@ -1517,6 +1517,7 @@ dependencies = [
  "reqwest",
  "runtimes",
  "semver",
+ "serde",
  "serde_json",
  "tempfile",
  "thiserror",
@@ -2858,18 +2859,18 @@ checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
 
 [[package]]
 name = "serde"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728eb6351430bccb993660dfffc5a72f91ccc1295abaa8ce19b27ebe4f75568b"
+checksum = "256b9932320c590e707b94576e3cc1f7c9024d0ee6612dfbcf1cb106cbe8e055"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.145"
+version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fa1584d3d1bcacd84c277a0dfe21f5b0f6accf4a23d04d4c6d61f1af522b4c"
+checksum = "b4eae9b04cbffdfd550eb462ed33bc6a1b68c935127d008b27444d08380f94e4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3043,9 +3044,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.102"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fcd952facd492f9be3ef0d0b7032a6e442ee9b361d4acc2b1d0c4aaa5f613a1"
+checksum = "60b9b43d45702de4c839cb9b51d9f529c5dd26a4aff255b42b1ebc03e88ee908"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -21,6 +21,7 @@ privdrop = "0.5.2"
 nix = "0.25.0"
 
 runtimes = { path = "../../runtime-rs/crates/runtimes" }
+serde = "1.0.149"
 
 [target.'cfg(target_arch = "s390x")'.dependencies]
 reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "native-tls"] }

--- a/src/tools/kata-ctl/src/args.rs
+++ b/src/tools/kata-ctl/src/args.rs
@@ -58,6 +58,12 @@ pub enum CheckSubCommand {
 
     /// Only compare the current and latest available versions
     CheckVersionOnly,
+
+    /// List official release packages
+    OnlyListReleases,
+
+    /// List all official and pre-release packages
+    IncludeAllReleases,
 }
 
 #[derive(Debug, Args)]

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -147,11 +147,6 @@ fn get_kata_all_releases_by_url() -> std::result::Result<Vec<Release>, reqwest::
     Ok(releases)
 }
 
-#[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "powerpc64le",
-    target_arch = "x86_64"
-))]
 fn handle_reqwest_error(e: reqwest::Error) -> anyhow::Error {
     if e.is_connect() {
         return anyhow!(e).context("http connection failure: connection refused");
@@ -186,7 +181,7 @@ pub fn check_all_releases() -> Result<()> {
     for release in releases {
         if !release.prerelease {
             println!(
-                "Official:   Release {:15}; created {} ; {}",
+                "Official  : Release {:15}; created {} ; {}",
                 release.tag_name, release.created_at, release.tarball_url
             );
         } else {

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -7,11 +7,32 @@
 
 use anyhow::{anyhow, Result};
 use reqwest::header::{CONTENT_TYPE, USER_AGENT};
+use serde::{Deserialize, Serialize};
+#[derive(Debug, Deserialize, Serialize, PartialEq)]
+struct Release {
+    tag_name: String,
+    prerelease: bool,
+    created_at: String,
+    tarball_url: String,
+}
+
 use serde_json::Value;
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64le",
+    target_arch = "x86_64"
+))]
 use std::collections::HashMap;
 
 const KATA_GITHUB_URL: &str =
     "https://api.github.com/repos/kata-containers/kata-containers/releases/latest";
+
+const KATA_GITHUB_RELEASE_URL: &str =
+    "https://api.github.com/repos/kata-containers/kata-containers/releases";
+
+const JSON_TYPE: &str = "application/json";
+
+const USER_AGT: &str = "kata";
 
 #[cfg(any(target_arch = "s390x", target_arch = "x86_64"))]
 fn get_cpu_info(cpu_info_file: &str) -> Result<String> {
@@ -107,8 +128,8 @@ pub fn run_network_checks() -> Result<()> {
 fn get_kata_version_by_url(url: &str) -> std::result::Result<String, reqwest::Error> {
     let content = reqwest::blocking::Client::new()
         .get(url)
-        .header(CONTENT_TYPE, "application/json")
-        .header(USER_AGENT, "kata")
+        .header(CONTENT_TYPE, JSON_TYPE)
+        .header(USER_AGENT, USER_AGT)
         .send()?
         .json::<HashMap<String, Value>>()?;
 
@@ -116,6 +137,21 @@ fn get_kata_version_by_url(url: &str) -> std::result::Result<String, reqwest::Er
     Ok(version.to_string())
 }
 
+fn get_kata_all_releases_by_url() -> std::result::Result<Vec<Release>, reqwest::Error> {
+    let releases: Vec<Release> = reqwest::blocking::Client::new()
+        .get(KATA_GITHUB_RELEASE_URL)
+        .header(CONTENT_TYPE, JSON_TYPE)
+        .header(USER_AGENT, USER_AGT)
+        .send()?
+        .json()?;
+    Ok(releases)
+}
+
+#[cfg(any(
+    target_arch = "aarch64",
+    target_arch = "powerpc64le",
+    target_arch = "x86_64"
+))]
 fn handle_reqwest_error(e: reqwest::Error) -> anyhow::Error {
     if e.is_connect() {
         return anyhow!(e).context("http connection failure: connection refused");
@@ -140,6 +176,41 @@ pub fn check_version() -> Result<()> {
     let version = get_kata_version_by_url(KATA_GITHUB_URL).map_err(handle_reqwest_error)?;
 
     println!("Version: {}", version);
+
+    Ok(())
+}
+
+pub fn check_all_releases() -> Result<()> {
+    let releases: Vec<Release> = get_kata_all_releases_by_url().map_err(handle_reqwest_error)?;
+
+    for release in releases {
+        if !release.prerelease {
+            println!(
+                "Official:   Release {:15}; created {} ; {}",
+                release.tag_name, release.created_at, release.tarball_url
+            );
+        } else {
+            println!(
+                "PreRelease: Release {:15}; created {} ; {}",
+                release.tag_name, release.created_at, release.tarball_url
+            );
+        }
+    }
+    Ok(())
+}
+
+pub fn check_official_releases() -> Result<()> {
+    let releases: Vec<Release> = get_kata_all_releases_by_url().map_err(handle_reqwest_error)?;
+
+    println!("Official Releases...");
+    for release in releases {
+        if !release.prerelease {
+            println!(
+                "Release {:15}; created {} ; {}",
+                release.tag_name, release.created_at, release.tarball_url
+            );
+        }
+    }
 
     Ok(())
 }

--- a/src/tools/kata-ctl/src/ops/check_ops.rs
+++ b/src/tools/kata-ctl/src/ops/check_ops.rs
@@ -34,6 +34,24 @@ pub fn handle_check(checkcmd: CheckArgument) -> Result<()> {
             // retrieve latest release
             check::check_version()?;
         }
+        CheckSubCommand::OnlyListReleases => {
+            // retrieve official release
+            #[cfg(any(
+                target_arch = "aarch64",
+                target_arch = "powerpc64le",
+                target_arch = "x86_64"
+            ))]
+            check::check_official_releases()?;
+        }
+        CheckSubCommand::IncludeAllReleases => {
+            // retrieve ALL releases including prerelease
+            #[cfg(any(
+                target_arch = "aarch64",
+                target_arch = "powerpc64le",
+                target_arch = "x86_64"
+            ))]
+            check::check_all_releases()?;
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This pull request adds kata-ctl check **only-list-releases** and **include-all-releases**

Fixes: [#5345](https://github.com/kata-containers/kata-containers/issues/5345)

Signed-off-by: Alex Lee [alee23@bu.edu](mailto:alee23@bu.edu)

