### PR TITLE
CCv0: Enable 'policy' for SNP container

### DIFF
--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -65,6 +65,12 @@ machine_type = "@MACHINETYPE@"
 # Default false
 # sev_snp_guest = true
 
+# SNP guest policy
+# Refer SEV Secure Nested Paging Firmware ABI Specification (sectin 4.3) to
+# change this value.
+# unspecified or == 0  -->  0x30000 i.e. Bit#17 is '1' and Bit#16 is '1' (SMT is allowed)
+# snp_guest_policy=0x30000
+
 # Enable running QEMU VMM as a non-root user.
 # By default QEMU VMM run as root. When this is set to true, QEMU VMM process runs as
 # a non-root random user. See documentation for the limitations of this mode.

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -291,6 +291,10 @@ type Object struct {
 	// This is only relevant for sev-guest objects
 	SevPolicy uint32
 
+	// SnpPolicy is the policy for the SNP instance. For more info, see AMD document 56860
+	// This is only relevant for sev-snp-guest objects
+	SnpPolicy uint64
+
 	// SevCertFilePath is the path to the guest Diffie–Hellman key
 	// This is only relevant for sev-guest objects
 	SevCertFilePath string
@@ -392,6 +396,7 @@ func (object Object) QemuParams(config *Config) []string {
 		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))
 		objectParams = append(objectParams, fmt.Sprintf("cbitpos=%d", object.CBitPos))
 		objectParams = append(objectParams, fmt.Sprintf("reduced-phys-bits=%d", object.ReducedPhysBits))
+		objectParams = append(objectParams, fmt.Sprintf("policy=0x%x", object.SnpPolicy))
 		// Add OVMF firmware as pflash drive
 		driveParams = append(driveParams, "if=pflash,format=raw,readonly=on")
 		driveParams = append(driveParams, fmt.Sprintf("file=%s", object.File))

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -274,11 +274,11 @@ type Object struct {
 	FirmwareVolume string
 
 	// CBitPos is the location of the C-bit in a guest page table entry
-	// This is only relevant for sev-guest objects
+	// This is only relevant for sev-guest and sev-snp-guest objects
 	CBitPos uint32
 
 	// ReducedPhysBits is the reduction in the guest physical address space
-	// This is only relevant for sev-guest objects
+	// This is only relevant for sev-guest and sev-snp-guest objects
 	ReducedPhysBits uint32
 
 	// ReadOnly specifies whether `MemPath` is opened read-only or read/write (default)
@@ -370,8 +370,6 @@ func (object Object) QemuParams(config *Config) []string {
 			deviceParams = append(deviceParams, fmt.Sprintf("config-firmware-volume=%s", object.FirmwareVolume))
 		}
 	case SEVGuest:
-		fallthrough
-	case SNPGuest:
 		objectParams = append(objectParams, string(object.Type))
 		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))
 		objectParams = append(objectParams, fmt.Sprintf("cbitpos=%d", object.CBitPos))
@@ -386,6 +384,14 @@ func (object Object) QemuParams(config *Config) []string {
 		if object.SevKernelHashes {
 			objectParams = append(objectParams, "kernel-hashes=on")
 		}
+		// Add OVMF firmware as pflash drive
+		driveParams = append(driveParams, "if=pflash,format=raw,readonly=on")
+		driveParams = append(driveParams, fmt.Sprintf("file=%s", object.File))
+	case SNPGuest:
+		objectParams = append(objectParams, string(object.Type))
+		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))
+		objectParams = append(objectParams, fmt.Sprintf("cbitpos=%d", object.CBitPos))
+		objectParams = append(objectParams, fmt.Sprintf("reduced-phys-bits=%d", object.ReducedPhysBits))
 		// Add OVMF firmware as pflash drive
 		driveParams = append(driveParams, "if=pflash,format=raw,readonly=on")
 		driveParams = append(driveParams, fmt.Sprintf("file=%s", object.File))

--- a/src/runtime/pkg/katautils/config-settings.go.in
+++ b/src/runtime/pkg/katautils/config-settings.go.in
@@ -100,6 +100,7 @@ const defaultGuestPreAttestationSecretGuid string = ""
 const defaultGuestPreAttestationSecretType string = ""
 const defaultSEVCertChainPath string = ""
 const defaultSEVGuestPolicy uint32 = 0
+const defaultSNPGuestPolicy uint64 = 0x30000
 
 var defaultSGXEPCSize = int64(0)
 

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -139,6 +139,7 @@ type hypervisor struct {
 	PCIeRootPort                   uint32   `toml:"pcie_root_port"`
 	GuestPreAttestationGRPCTimeout uint32   `toml:"guest_pre_attestation_grpc_timeout"`
 	SEVGuestPolicy                 uint32   `toml:"sev_guest_policy"`
+	SNPGuestPolicy                 uint64   `toml:"snp_guest_policy"`
 	RemoteHypervisorTimeout        uint32   `toml:"remote_hypervisor_timeout"`
 	NumVCPUs                       int32    `toml:"default_vcpus"`
 	BlockDeviceCacheSet            bool     `toml:"block_device_cache_set"`
@@ -632,6 +633,13 @@ func (a agent) kernelModules() []string {
 	return a.KernelModules
 }
 
+func (h hypervisor) getSnpGuestPolicy() uint64 {
+	if h.SNPGuestPolicy == 0 { // or unspecified
+		return defaultSNPGuestPolicy
+	}
+	return h.SNPGuestPolicy
+}
+
 func newFirecrackerHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 	hypervisor, err := h.path()
 	if err != nil {
@@ -855,6 +863,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		GuestPreAttestationSecretGuid: h.GuestPreAttestationSecretGuid,
 		GuestPreAttestationSecretType: h.GuestPreAttestationSecretType,
 		SEVGuestPolicy:                h.SEVGuestPolicy,
+		SNPGuestPolicy:                h.getSnpGuestPolicy(),
 		SEVCertChainPath:              h.SEVCertChainPath,
 		DisableGuestSeLinux:           h.DisableGuestSeLinux,
 	}, nil
@@ -1276,6 +1285,7 @@ func GetDefaultHypervisorConfig() vc.HypervisorConfig {
 		GuestPreAttestationSecretGuid: defaultGuestPreAttestationSecretGuid,
 		GuestPreAttestationSecretType: defaultGuestPreAttestationSecretType,
 		SEVGuestPolicy:                defaultSEVGuestPolicy,
+		SNPGuestPolicy:                defaultSNPGuestPolicy,
 		SEVCertChainPath:              defaultSEVCertChainPath,
 	}
 }

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -176,6 +176,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		VirtioFSCache:         defaultVirtioFSCacheMode,
 		PFlash:                []string{},
 		SGXEPCSize:            epcSize,
+		SNPGuestPolicy:        defaultSNPGuestPolicy,
 	}
 
 	agentConfig := vc.KataAgentConfig{
@@ -555,6 +556,7 @@ func TestMinimalRuntimeConfig(t *testing.T) {
 		VirtioFSCache:         defaultVirtioFSCacheMode,
 		BlockDeviceAIO:        defaultBlockDeviceAIO,
 		DisableGuestSeLinux:   defaultDisableGuestSeLinux,
+		SNPGuestPolicy:        defaultSNPGuestPolicy,
 	}
 
 	expectedAgentConfig := vc.KataAgentConfig{

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -337,6 +337,7 @@ type HypervisorConfig struct {
 	Uid                            uint32
 	Gid                            uint32
 	SEVGuestPolicy                 uint32
+	SNPGuestPolicy                 uint64
 	PCIeRootPort                   uint32
 	NumVCPUs                       uint32
 	RemoteHypervisorTimeout        uint32

--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -40,6 +40,8 @@ type qemuAmd64 struct {
 
 	sgxEPCSize int64
 
+	snpGuestPolicy uint64
+
 	numVCPUs uint32
 }
 
@@ -144,9 +146,10 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 			protection:           noneProtection,
 			legacySerial:         config.LegacySerial,
 		},
-		vmFactory: factory,
-		snpGuest:  config.SevSnpGuest,
-		numVCPUs:  config.NumVCPUs,
+		vmFactory:      factory,
+		snpGuest:       config.SevSnpGuest,
+		numVCPUs:       config.NumVCPUs,
+		snpGuestPolicy: config.SNPGuestPolicy,
 	}
 
 	if config.ConfidentialGuest {
@@ -313,6 +316,7 @@ func (q *qemuAmd64) appendProtectionDevice(devices []govmmQemu.Device, firmware,
 				Debug:           false,
 				File:            firmware,
 				CBitPos:         cpuid.AMDMemEncrypt.CBitPosition,
+				SnpPolicy:       q.snpGuestPolicy,
 				ReducedPhysBits: 1,
 			}), "", nil
 	case noneProtection:


### PR DESCRIPTION
Removed the qemu paramter 'policy' (and also dh-cert-file, session-file, kernel-hashes=on) for SNP container.

Fixes: #5795

Signed-off-by: Niteesh Dubey <niteesh@linux.ibm.com>