### PR TITLE
basic framework for QEMU support in runtime-rs

### DIFF
--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -2527,6 +2527,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "shim-ctl"
+version = "0.1.0"
+dependencies = [
+ "common",
+ "logging",
+ "runtimes",
+ "tokio",
+]
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/src/runtime-rs/Cargo.toml
+++ b/src/runtime-rs/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
 members = [
     "crates/shim",
+    "crates/shim-ctl",
 ]

--- a/src/runtime-rs/README.md
+++ b/src/runtime-rs/README.md
@@ -120,6 +120,8 @@ See the
 See the
 [debugging section of the developer guide](../../docs/Developer-Guide.md#troubleshoot-kata-containers).
 
+An [experimental alternative binary](crates/shim-ctl/README.md) is available that removes containerd dependencies and makes it easier to run the shim proper outside of the runtime's usual deployment environment (i.e. on a developer machine).
+
 ## Limitations
 
 For Kata Containers limitations, see the

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -14,6 +14,7 @@ pub mod hypervisor_persist;
 pub use device::*;
 pub mod dragonball;
 mod kernel_param;
+pub mod qemu;
 pub use kernel_param::Param;
 mod utils;
 use std::collections::HashMap;
@@ -28,6 +29,8 @@ const VM_ROOTFS_DRIVER_BLK: &str = "virtio-blk";
 const VM_ROOTFS_DRIVER_PMEM: &str = "virtio-pmem";
 
 pub const HYPERVISOR_DRAGONBALL: &str = "dragonball";
+pub const HYPERVISOR_QEMU: &str = "qemu";
+
 #[derive(PartialEq)]
 pub(crate) enum VmmState {
     NotReady,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -1,0 +1,125 @@
+// Copyright (c) 2022 Red Hat
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::Result;
+
+use crate::{HypervisorConfig, VcpuThreadIds};
+use kata_types::capabilities::{Capabilities, CapabilityBits};
+
+const VSOCK_SCHEME: &str = "vsock";
+const VSOCK_AGENT_CID: u32 = 3;
+const VSOCK_AGENT_PORT: u32 = 1024;
+
+unsafe impl Send for QemuInner {}
+unsafe impl Sync for QemuInner {}
+
+pub struct QemuInner {
+    config: HypervisorConfig,
+}
+
+impl QemuInner {
+    pub fn new() -> QemuInner {
+        QemuInner {
+            config: Default::default(),
+        }
+    }
+
+    pub(crate) async fn prepare_vm(&mut self, _id: &str, _netns: Option<String>) -> Result<()> {
+        info!(sl!(), "Preparing QEMU VM");
+        Ok(())
+    }
+
+    pub(crate) async fn start_vm(&mut self, _timeout: i32) -> Result<()> {
+        info!(sl!(), "Starting QEMU VM");
+        Ok(())
+    }
+
+    pub(crate) fn stop_vm(&mut self) -> Result<()> {
+        info!(sl!(), "Stopping QEMU VM");
+        todo!()
+    }
+
+    pub(crate) fn pause_vm(&self) -> Result<()> {
+        info!(sl!(), "Pausing QEMU VM");
+        todo!()
+    }
+
+    pub(crate) fn resume_vm(&self) -> Result<()> {
+        info!(sl!(), "Resuming QEMU VM");
+        todo!()
+    }
+
+    pub(crate) async fn save_vm(&self) -> Result<()> {
+        todo!()
+    }
+
+    /// TODO: using a single hardcoded CID is clearly not adequate in the long
+    /// run. Use the recently added VsockConfig infrastructure to fix this.
+    pub(crate) async fn get_agent_socket(&self) -> Result<String> {
+        info!(sl!(), "QemuInner::get_agent_socket()");
+        Ok(format!(
+            "{}://{}:{}",
+            VSOCK_SCHEME, VSOCK_AGENT_CID, VSOCK_AGENT_PORT
+        ))
+    }
+
+    pub(crate) async fn disconnect(&mut self) {
+        info!(sl!(), "QemuInner::disconnect()");
+        todo!()
+    }
+
+    pub(crate) async fn get_thread_ids(&self) -> Result<VcpuThreadIds> {
+        info!(sl!(), "QemuInner::get_thread_ids()");
+        todo!()
+    }
+
+    pub(crate) async fn cleanup(&self) -> Result<()> {
+        info!(sl!(), "QemuInner::cleanup()");
+        todo!()
+    }
+
+    pub(crate) async fn get_pids(&self) -> Result<Vec<u32>> {
+        info!(sl!(), "QemuInner::get_pids()");
+        todo!()
+    }
+
+    pub(crate) async fn check(&self) -> Result<()> {
+        todo!()
+    }
+
+    pub(crate) async fn get_jailer_root(&self) -> Result<String> {
+        todo!()
+    }
+
+    pub(crate) async fn capabilities(&self) -> Result<Capabilities> {
+        let mut caps = Capabilities::default();
+        caps.set(CapabilityBits::FsSharingSupport);
+        Ok(caps)
+    }
+
+    pub fn set_hypervisor_config(&mut self, config: HypervisorConfig) {
+        self.config = config;
+    }
+
+    pub fn hypervisor_config(&self) -> HypervisorConfig {
+        info!(sl!(), "QemuInner::hypervisor_config()");
+        self.config.clone()
+    }
+}
+
+use crate::device::Device;
+
+// device manager part of Hypervisor
+impl QemuInner {
+    pub(crate) async fn add_device(&mut self, device: Device) -> Result<()> {
+        info!(sl!(), "QemuInner::add_device() {}", device);
+        todo!()
+    }
+
+    pub(crate) async fn remove_device(&mut self, device: Device) -> Result<()> {
+        info!(sl!(), "QemuInner::remove_device() {} ", device);
+        todo!()
+    }
+}

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -33,6 +33,23 @@ impl QemuInner {
 
     pub(crate) async fn start_vm(&mut self, _timeout: i32) -> Result<()> {
         info!(sl!(), "Starting QEMU VM");
+
+        let mut command = std::process::Command::new(&self.config.path);
+
+        command
+            .arg("-kernel")
+            .arg(&self.config.boot_info.kernel)
+            .arg("-m")
+            .arg(format!("{}M", &self.config.memory_info.default_memory))
+            .arg("-initrd")
+            .arg(&self.config.boot_info.initrd)
+            .arg("-vga")
+            .arg("none")
+            .arg("-nodefaults")
+            .arg("-nographic");
+
+        command.spawn()?;
+
         Ok(())
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -1,0 +1,134 @@
+// Copyright (c) 2022 Red Hat
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+mod inner;
+
+use crate::device::Device;
+use crate::hypervisor_persist::HypervisorState;
+use crate::Hypervisor;
+use crate::{HypervisorConfig, VcpuThreadIds};
+use inner::QemuInner;
+use kata_types::capabilities::Capabilities;
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+pub struct Qemu {
+    inner: Arc<RwLock<QemuInner>>,
+}
+
+impl Default for Qemu {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Qemu {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(QemuInner::new())),
+        }
+    }
+
+    pub async fn set_hypervisor_config(&mut self, config: HypervisorConfig) {
+        let mut inner = self.inner.write().await;
+        inner.set_hypervisor_config(config)
+    }
+}
+
+#[async_trait]
+impl Hypervisor for Qemu {
+    async fn prepare_vm(&self, id: &str, netns: Option<String>) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.prepare_vm(id, netns).await
+    }
+
+    async fn start_vm(&self, timeout: i32) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.start_vm(timeout).await
+    }
+
+    async fn stop_vm(&self) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.stop_vm()
+    }
+
+    async fn pause_vm(&self) -> Result<()> {
+        let inner = self.inner.read().await;
+        inner.pause_vm()
+    }
+
+    async fn resume_vm(&self) -> Result<()> {
+        let inner = self.inner.read().await;
+        inner.resume_vm()
+    }
+
+    async fn save_vm(&self) -> Result<()> {
+        let inner = self.inner.read().await;
+        inner.save_vm().await
+    }
+
+    async fn add_device(&self, device: Device) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.add_device(device).await
+    }
+
+    async fn remove_device(&self, device: Device) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.remove_device(device).await
+    }
+
+    async fn get_agent_socket(&self) -> Result<String> {
+        let inner = self.inner.read().await;
+        inner.get_agent_socket().await
+    }
+
+    async fn disconnect(&self) {
+        let mut inner = self.inner.write().await;
+        inner.disconnect().await
+    }
+
+    async fn hypervisor_config(&self) -> HypervisorConfig {
+        let inner = self.inner.read().await;
+        inner.hypervisor_config()
+    }
+
+    async fn get_thread_ids(&self) -> Result<VcpuThreadIds> {
+        let inner = self.inner.read().await;
+        inner.get_thread_ids().await
+    }
+
+    async fn cleanup(&self) -> Result<()> {
+        let inner = self.inner.read().await;
+        inner.cleanup().await
+    }
+
+    async fn get_pids(&self) -> Result<Vec<u32>> {
+        let inner = self.inner.read().await;
+        inner.get_pids().await
+    }
+
+    async fn check(&self) -> Result<()> {
+        let inner = self.inner.read().await;
+        inner.check().await
+    }
+
+    async fn get_jailer_root(&self) -> Result<String> {
+        let inner = self.inner.read().await;
+        inner.get_jailer_root().await
+    }
+
+    async fn save_state(&self) -> Result<HypervisorState> {
+        todo!()
+    }
+
+    async fn capabilities(&self) -> Result<Capabilities> {
+        let inner = self.inner.read().await;
+        inner.capabilities().await
+    }
+}

--- a/src/runtime-rs/crates/shim-ctl/Cargo.toml
+++ b/src/runtime-rs/crates/shim-ctl/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "shim-ctl"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "^1.0"
+common = { path = "../runtimes/common" }
+logging = { path = "../../../libs/logging"}
+runtimes = { path = "../runtimes" }
+tokio = { version = "1.8.0", features = [ "rt", "rt-multi-thread" ] }
+

--- a/src/runtime-rs/crates/shim-ctl/README.md
+++ b/src/runtime-rs/crates/shim-ctl/README.md
@@ -1,0 +1,51 @@
+### Purpose
+`shim-ctl` is a binary to exercise the shim proper without containerd
+dependencies.
+
+The actual Kata shim is hard to execute outside of deployment environments due
+to its dependency on containerd's shim v2 protocol.  Among others, the
+dependency requires having a socket with a remote end that's capable of driving
+the shim using the shim v2 `ttrpc` protocol, and a binary for shim to publish
+events to.
+
+Since at least some of the shim v2 protocol dependencies are fairly hard to
+mock up, this presents a significant obstacle to development.
+
+`shim-ctl` takes advantage of the fact that due to the shim implementation
+architecture, only the outermost couple of shim layers are
+containerd-dependent and all of the inner layers that do the actual heavy
+lifting don't depend on containerd.  This allows `shim-ctl` to replace the
+containerd-dependent layers with something that's easier to use on a
+developer's machine.
+
+### Usage
+
+After building the binary as usual with `cargo build` run `shim-ctl` as follows.
+
+Even though `shim-ctl` does away with containerd dependencies it still has
+some requirements of its execution environment.  In particular, it needs a
+Kata `configuration.toml` file, some Kata distribution files to point a bunch
+of `configuration.toml` keys to (like hypervisor keys `path`, `kernel` or
+`initrd`) and a container bundle.  These are however much easier to fulfill
+than the original containerd dependencies, and doing so is a one-off task -
+once done they can be reused for an unlimited number of modify-build-run
+development cycles.
+
+`shim-ctl` also needs to be launched from an exported container bundle
+directory.  One can be created by running
+
+```
+mkdir rootfs
+podman export $(podman create busybox) | tar -C ./rootfs -xvf -
+runc spec -b .
+```
+
+in a suitable directory.
+
+The program can then be launched like this:
+
+```
+cd /the/bundle/directory
+KATA_CONF_FILE=/path/to/configuration-qemu.toml /path/to/shim-ctl
+```
+

--- a/src/runtime-rs/crates/shim-ctl/src/main.rs
+++ b/src/runtime-rs/crates/shim-ctl/src/main.rs
@@ -1,0 +1,45 @@
+// Copyright (c) 2022 Red Hat
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::{Context, Result};
+use common::{
+    message::Message,
+    types::{ContainerConfig, Request},
+};
+use runtimes::RuntimeHandlerManager;
+use tokio::sync::mpsc::channel;
+
+const MESSAGE_BUFFER_SIZE: usize = 8;
+const WORKER_THREADS: usize = 2;
+
+async fn real_main() {
+    let (sender, _receiver) = channel::<Message>(MESSAGE_BUFFER_SIZE);
+    let manager = RuntimeHandlerManager::new("xxx", sender).await.unwrap();
+
+    let req = Request::CreateContainer(ContainerConfig {
+        container_id: "xxx".to_owned(),
+        bundle: ".".to_owned(),
+        rootfs_mounts: Vec::new(),
+        terminal: false,
+        options: None,
+        stdin: None,
+        stdout: None,
+        stderr: None,
+    });
+
+    manager.handler_message(req).await.ok();
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(WORKER_THREADS)
+        .enable_all()
+        .build()
+        .context("prepare tokio runtime")?;
+
+    runtime.block_on(real_main());
+
+    Ok(())
+}


### PR DESCRIPTION
This PR adds basic boilerplate for QEMU driver in runtime-rs. It's obviously far from a full QEMU support but it does enable runtime-rs to start a very basic QEMU process (along with its supporting virtiofsd instance). It also includes (an embryo of) an alternative shim binary that drops containerd dependency and thus makes it fast and easy to execute shim proper, greatly enhancing dev cycle.

The main purpose of this WIP PR is to publish progress so far and give a common base to enable cooperation on QEMU support.

Fixes: #5817