### PR TITLE
workflow: fix cargo-deny-runner.yaml syntax error

### DIFF
--- a/.github/workflows/cargo-deny-runner.yaml
+++ b/.github/workflows/cargo-deny-runner.yaml
@@ -1,6 +1,6 @@
 name: Cargo Crates Check Runner
 on:
-  - pull_request:
+  pull_request:
     types:
       - opened
       - edited


### PR DESCRIPTION
There is a syntax error in .github/workflows/cargo-deny-runner.yaml

Fixes: #5808

Signed-off-by: Bin Liu <bin@hyper.sh>