### PR TITLE
workflow: call cargo in user's $PATH

### DIFF
--- a/.github/workflows/static-checks-dragonball.yaml
+++ b/.github/workflows/static-checks-dragonball.yaml
@@ -28,6 +28,6 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           cd src/dragonball
-          /root/.cargo/bin/cargo version
+          cargo version
           rustc --version
           sudo -E env PATH=$PATH LIBC=gnu SUPPORT_VIRTUALIZATION=true make test


### PR DESCRIPTION
Call cargo in root's HOME may lead to permission error, should call cargo installed in user's HOME/PATH.

Fixes: #5813

Signed-off-by: Bin Liu <bin@hyper.sh>