### PR TITLE
runtime-rs:add identification in version for runtime-rs

### DIFF
--- a/src/runtime-rs/crates/shim/src/bin/main.rs
+++ b/src/runtime-rs/crates/shim/src/bin/main.rs
@@ -95,7 +95,7 @@ fn show_help(cmd: &OsStr) {
 
 fn show_version(err: Option<anyhow::Error>) {
     let data = format!(
-        r#"{} containerd shim: id: {}, version: {}, commit: {}"#,
+        r#"{} containerd shim: id: {}, version: {} (rust version), commit: {}"#,
         config::PROJECT_NAME,
         config::CONTAINERD_RUNTIME_NAME,
         config::RUNTIME_VERSION,


### PR DESCRIPTION
Since we now have 2 runtime, go runtime and rust runtime, and sometimes it's hard for identifying which version of runtime being used.

In order to support debug runtime, we add identification for runtime-rs version command (containerd-shim-kata-v2 --version) and an extra (rust) will be displayed in version when using rust runtime.

fixes:#5806

Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>