### PR TITLE
fix exited container bundle not exist causing new container start failed

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -2465,6 +2465,10 @@ func (s *Sandbox) fetchContainers(ctx context.Context) error {
 		// Add spec from bundle path
 		spec, err := compatoci.GetContainerSpec(contConfig.Annotations)
 		if err != nil {
+			if os.IsNotExist(err) {
+				s.Logger().Errorf("get container %s spec err: %v", contConfig.ID, err)
+				continue
+			}
 			return err
 		}
 		contConfig.CustomSpec = &spec


### PR DESCRIPTION
reason:If a previous container exited unexpectedly and bundle path is cleaned up(which is cleaned by docker or isulad rm) but persist.json still exists(which should be cleaned by kata), fetchSandbox will range all containers in pod persist.json to get config.json under bundle during new container in pod starting, it will return error as exited container bundle path not exist anymore, causing new container start failed. So we should ignore exited container bundle path not exist error during new one start.

fix #5819