### PR TITLE
CCv0: use virtiofsd cache

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -236,10 +236,11 @@ install_cc_shimv2() {
 
 # Install static CC virtiofsd asset
 install_cc_virtiofsd() {
+	local virtiofsd_version="$(get_from_kata_deps "externals.virtiofsd.version")-$(get_from_kata_deps "externals.virtiofsd.toolchain")"
 	install_cached_component \
 		"virtiofsd" \
 		"${jenkins_url}/job/kata-containers-2.0-virtiofsd-cc-$(uname -m)/${cached_artifacts_path}" \
-		"$(get_from_kata_deps "assets.externals.virtiofsd.version")" \
+		"${virtiofsd_version}" \
 		"$(get_virtiofsd_image_name)" \
 		"${final_tarball_name}" \
 		"${final_tarball_path}" \


### PR DESCRIPTION
This PR allow us to use the virtiofsd cache tarball instead of building it from source.

Fixes #5356

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>