### PR TITLE
fix kata deploy error after node reboot.

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -56,7 +56,7 @@ function get_container_runtime() {
 
 function install_artifacts() {
 	echo "copying kata artifacts onto host"
-	cp -a /opt/kata-artifacts/opt/kata/* /opt/kata/
+	cp -au /opt/kata-artifacts/opt/kata/* /opt/kata/
 	chmod +x /opt/kata/bin/*
 	chmod +x /opt/kata/runtime-rs/bin/*
 }


### PR DESCRIPTION
kata-deploy:  Fix after the node restarts, the pod of kata depoy starts to report an error

If a pod of type kata is deployed on a machine, after the machine restarts, the pod status corresponding to kata-deploy will be CrashLoopBackOff. The reason is that kata-deploy will update the installation files in the /opt/kata/ directory. At this time, the pod of the kata type is started, and some files in this directory are occupied and are not allowed to be updated. The -u parameter of the cp command is just suitable for solving it.

The following is the error message before modification, and it has been resolved after modification.

$ kubectl logs -f kata-deploy-hjtc6 -n kube-system
copying kata artifacts onto host
cp: cannot create regular file '/opt/kata/bin/qemu-system-x86_64': Text file busy
cp: cannot create regular file '/opt/kata/bin/containerd-shim-kata-v2': Text file busy
cp: cannot create regular file '/opt/kata/libexec/virtiofsd': Text file busy

Fixes: #5868