### PR TITLE
agent: Fix s390x agent build

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1903,7 +1903,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/image-rs?rev=76e6abed950152f000d8f70026d11a86cf95fb0c#76e6abed950152f000d8f70026d11a86cf95fb0c"
+source = "git+https://github.com/confidential-containers/image-rs?rev=78a5114444629ad0af82174cb4bbaa1787b627a3#78a5114444629ad0af82174cb4bbaa1787b627a3"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -67,10 +67,15 @@ serde = { version = "1.0.129", features = ["derive"] }
 toml = "0.5.8"
 clap = { version = "3.0.1", features = ["derive"] }
 
-# Image pull/decrypt
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "76e6abed950152f000d8f70026d11a86cf95fb0c" }
 # "vendored" feature for openssl is required by musl build
 openssl = { version = "0.10.38", features = ["vendored"] }
+
+# Image pull/decrypt
+[target.'cfg(target_arch = "s390x")'.dependencies]
+image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "78a5114444629ad0af82174cb4bbaa1787b627a3", default-features = false, features = ["default_s390x"] }
+
+[target.'cfg(not(target_arch = "s390x"))'.dependencies]
+image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "78a5114444629ad0af82174cb4bbaa1787b627a3", default-features = true }
 
 [dev-dependencies]
 tempfile = "3.1.0"
@@ -78,6 +83,7 @@ test-utils = { path = "../libs/test-utils" }
 which = "4.3.0"
 
 [workspace]
+resolver = "2"
 members = [
     "rustjail",
 ]

--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -85,14 +85,6 @@ ifeq ($(INIT),no)
     UNIT_FILES += kata-containers.target
 endif
 
-# The following will be reverted, after
-# https://github.com/kata-containers/kata-containers/issues/5582
-# is resolved.
-IMAGE_RS_COMMIT = a1d7ba31201d9d7a575d05c5fed1f2cb2142a842
-ifeq ($(ARCH),s390x)
-    $(shell sed -i -e "s/^\(image-rs.*\)tag\(.*\)/\1rev\2/" -e "s/^\(image-rs.*rev = \"\).*\(\".*\)/\1$(IMAGE_RS_COMMIT)\2/" Cargo.toml)
-endif
-
 # Display name of command and it's version (or a message if not available).
 #
 # Arguments:


### PR DESCRIPTION
Exclude the image-rs cosign feature when the build target is the s390x architecture.

Change Cargo to use workspace resolver 2 so that conditional include for the image-rs crate is resolved correctly for different targets.

Fixes: kata-containers#5582

Signed-off-by: Matthew Arnold <mattarno@uk.ibm.com>