### PR TITLE
kernel: Export KATA_BUILD_CC in install_cc_tee_kernel()

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -254,6 +254,7 @@ install_cc_virtiofsd() {
 
 #Install CC kernel assert, with TEE support
 install_cc_tee_kernel() {
+	export KATA_BUILD_CC=yes
 	tee="${1}"
 	kernel_version="${2}"
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -181,8 +181,6 @@ install_cc_tdx_image() {
 
 #Install CC kernel asset
 install_cc_kernel() {
-	info "build initramfs for cc kernel"
-
 	export KATA_BUILD_CC=yes
 	export kernel_version="$(yq r $versions_yaml assets.kernel.version)"
 
@@ -195,6 +193,7 @@ install_cc_kernel() {
 		"${final_tarball_path}" \
 		&& return 0
 
+	info "build initramfs for CC kernel"
 	"${initramfs_builder}"
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -f -v "${kernel_version}"
 }
@@ -260,7 +259,6 @@ install_cc_tee_kernel() {
 
 	[[ "${tee}" != "tdx" && "${tee}" != "sev" ]] && die "Non supported TEE"
 
-	info "build initramfs for tee kernel"
 	export kernel_version=${kernel_version}
 
 	install_cached_component \
@@ -272,6 +270,7 @@ install_cc_tee_kernel() {
 		"${final_tarball_path}" \
 		&& return 0
 
+	info "build initramfs for TEE kernel"
 	"${initramfs_builder}"
 	kernel_url="$(yq r $versions_yaml assets.kernel.${tee}.url)"
 	DESTDIR="${destdir}" PREFIX="${cc_prefix}" "${kernel_builder}" -x "${tee}" -v "${kernel_version}" -u "${kernel_url}"


### PR DESCRIPTION
As already done for install_cc_kernel(), let's ensure we export
KATA_BUILD_CC=yes as part of the install_cc_tee_kernel.

This is used to generate the hash of the devices in the initramfs.

Fixes: #5845

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>