### PR TITLE
CC: kata-deploy add x86 ovmf build for SNP

### DIFF
--- a/.github/workflows/cc-payload-after-push-amd64.yaml
+++ b/.github/workflows/cc-payload-after-push-amd64.yaml
@@ -19,6 +19,7 @@ jobs:
           - cc-virtiofsd
           - cc-sev-kernel
           - cc-sev-ovmf
+          - cc-x86_64-ovmf
           - cc-sev-rootfs-initrd
           - cc-tdx-kernel
           - cc-tdx-rootfs-image

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -17,6 +17,7 @@ EXTRA_TARBALL=cc-cloud-hypervisor-tarball \
 	cc-tdx-td-shim-tarball \
 	cc-tdx-tdvf-tarball \
 	cc-sev-ovmf-tarball \
+	cc-x86_64-ovmf-tarball \
 	cc-sev-rootfs-initrd-tarball \
 	cc-tdx-rootfs-image-tarball
 endif
@@ -151,4 +152,7 @@ cc-tdx-tdvf-tarball:
 	${MAKE} $@-build
 
 cc-sev-ovmf-tarball:
+	${MAKE} $@-build
+
+cc-x86_64-ovmf-tarball:
 	${MAKE} $@-build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -105,6 +105,7 @@ options:
 	cc-shimv2
 	cc-virtiofsd
 	cc-sev-ovmf
+	cc-x86_64-ovmf
 EOF
 
 	exit "${return_code}"
@@ -540,6 +541,10 @@ install_cc_sev_ovmf(){
  	install_cc_tee_ovmf "sev" "edk2-sev.tar.gz"
 }
 
+install_cc_x86_64_ovmf(){
+ 	install_cc_tee_ovmf "x86_64" "edk2-x86_64.tar.gz"
+}
+
 #Install guest image
 install_image() {
 	info "Create image"
@@ -709,6 +714,8 @@ handle_build() {
 	cc-tdx-tdvf) install_cc_tdx_tdvf ;;
 
 	cc-sev-ovmf) install_cc_sev_ovmf ;;
+	
+	cc-x86_64-ovmf) install_cc_x86_64_ovmf ;;
 
 	cloud-hypervisor) install_clh ;;
 

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -79,9 +79,11 @@ popd
 
 info "Install fd to destdir"
 install_dir="${DESTDIR}/${PREFIX}/share/ovmf"
-if [ "${ovmf_build}" == "tdx" ]; then
-	install_dir="$DESTDIR/$PREFIX/share/tdvf"
-fi
+case "${ovmf_build}" in
+	"tdx")
+		install_dir="$DESTDIR/$PREFIX/share/tdvf"
+		;;
+esac
 
 mkdir -p "${install_dir}"
 if [ "${ovmf_build}" == "sev" ]; then


### PR DESCRIPTION
SNP needs two builds of ovmf: the AmdSev build and the normal x86_64 build.

Adds target for vanilla ovmf build for snp

Adding another make target / kata-deploy function, and fixing the ovmf builder so these builds dont overlap.

Fixes: kata-containers#5849
Signed-off-by: Alex Carter <Alex.Carter@ibm.com>