### PR TITLE
docs: Update virtiofsd build script in the developer guide

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -441,7 +441,7 @@ When using the file system type virtio-fs (default), `virtiofsd` is required
 
 ```bash
 $ pushd kata-containers/tools/packaging/static-build/virtiofsd
-$ ./build-static-virtiofsd.sh
+$ ./build.sh
 $ popd
 ```
 


### PR DESCRIPTION
Script to execute to build virtiofsd has been changed in #5426 but not in the doc. This commit update the developer guide.

Fixes: #5860

Signed-off-by: Mathias Flagey <mathiasflagey1201@gmail.com>