### PR TITLE
snap: fix wrong snap build version issue for non-x86

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -147,12 +147,12 @@ parts:
       initrd_distro=$(${yq} r -X ${kata_dir}/versions.yaml assets.initrd.architecture.${arch}.name)
       image_distro=$(${yq} r -X ${kata_dir}/versions.yaml assets.image.architecture.${arch}.name)
       case "$arch" in
-        x86_64)
+        aarch64|x86_64)
           # In some build systems it's impossible to build a rootfs image, try with the initrd image
           sudo -E PATH=$PATH make image DISTRO="${image_distro}" || sudo -E PATH="$PATH" make initrd DISTRO="${initrd_distro}"
         ;;
 
-        aarch64|ppc64le|s390x)
+        ppc64le|s390x)
           sudo -E PATH="$PATH" make initrd DISTRO="${initrd_distro}"
         ;;
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,9 +23,11 @@ parts:
 
       version="9999"
 
-      if echo "${GITHUB_REF:-}" | grep -q -E "^refs/tags"; then
-        version=$(echo ${GITHUB_REF:-} | cut -d/ -f3)
-        git checkout ${version}
+      kata_url="https://github.com/kata-containers/kata-containers"
+      latest_version=$(git ls-remote --tags ${kata_url}  | egrep -o "refs.*" | egrep -v "\-alpha|\-rc|{}" | egrep -o "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+" | sort -V -r | head -1)
+      if [ -n "${latest_version}" ]; then
+        version=${latest_version}
+        git clean -f && git checkout ${version}
       fi
 
       snapcraftctl set-grade "stable"


### PR DESCRIPTION
snap build version is "9999" for non-x86 arches, as GITHUB_REF is not set in Jenkins CI. Calculate kata version instead of using GITHUB_REF to solve this issue.

Also, kata image is used for now other than initrd for aarch64, thus change it according. 