### PR TITLE
runtime-rs: enable start container from bundle

### DIFF
--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -68,11 +68,14 @@ impl ResourceManager {
     pub async fn handler_rootfs(
         &self,
         cid: &str,
+        root: &oci::Root,
         bundle_path: &str,
         rootfs_mounts: &[Mount],
     ) -> Result<Arc<dyn Rootfs>> {
         let inner = self.inner.read().await;
-        inner.handler_rootfs(cid, bundle_path, rootfs_mounts).await
+        inner
+            .handler_rootfs(cid, root, bundle_path, rootfs_mounts)
+            .await
     }
 
     pub async fn handler_volumes(

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -196,6 +196,7 @@ impl ResourceManagerInner {
     pub async fn handler_rootfs(
         &self,
         cid: &str,
+        root: &oci::Root,
         bundle_path: &str,
         rootfs_mounts: &[Mount],
     ) -> Result<Arc<dyn Rootfs>> {
@@ -205,6 +206,7 @@ impl ResourceManagerInner {
                 self.hypervisor.as_ref(),
                 &self.sid,
                 cid,
+                root,
                 bundle_path,
                 rootfs_mounts,
             )

--- a/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
@@ -23,14 +23,18 @@ impl ShareFsRootfs {
         share_fs_mount: &Arc<dyn ShareFsMount>,
         cid: &str,
         bundle_path: &str,
-        rootfs: &Mount,
+        rootfs: Option<&Mount>,
     ) -> Result<Self> {
-        let bundle_rootfs = format!("{}/{}", bundle_path, ROOTFS);
-        rootfs.mount(&bundle_rootfs).context(format!(
-            "mount rootfs from {:?} to {}",
-            &rootfs, &bundle_rootfs
-        ))?;
-
+        let bundle_rootfs = if let Some(rootfs) = rootfs {
+            let bundle_rootfs = format!("{}/{}", bundle_path, ROOTFS);
+            rootfs.mount(&bundle_rootfs).context(format!(
+                "mount rootfs from {:?} to {}",
+                &rootfs, &bundle_rootfs
+            ))?;
+            bundle_rootfs
+        } else {
+            bundle_path.to_string()
+        };
         let mount_result = share_fs_mount
             .share_rootfs(ShareFsRootfsConfig {
                 cid: cid.to_string(),

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -16,6 +16,7 @@ use common::{
     },
 };
 use kata_sys_util::k8s::update_ephemeral_storage_type;
+
 use oci::{LinuxResources, Process as OCIProcess};
 use resource::ResourceManager;
 use tokio::sync::RwLock;
@@ -84,23 +85,30 @@ impl Container {
         amend_spec(&mut spec, toml_config.runtime.disable_guest_seccomp).context("amend spec")?;
         let sandbox_pidns = is_pid_namespace_enabled(&spec);
 
+        // get mutable root from oci spec
+        let mut root = match spec.root.as_mut() {
+            Some(root) => root,
+            None => return Err(anyhow!("spec miss root field")),
+        };
+
         // handler rootfs
         let rootfs = self
             .resource_manager
-            .handler_rootfs(&config.container_id, &config.bundle, &config.rootfs_mounts)
+            .handler_rootfs(
+                &config.container_id,
+                root,
+                &config.bundle,
+                &config.rootfs_mounts,
+            )
             .await
             .context("handler rootfs")?;
 
         // update rootfs
-        match spec.root.as_mut() {
-            Some(root) => {
-                root.path = rootfs
-                    .get_guest_rootfs_path()
-                    .await
-                    .context("get guest rootfs path")?
-            }
-            None => return Err(anyhow!("spec miss root field")),
-        };
+        root.path = rootfs
+            .get_guest_rootfs_path()
+            .await
+            .context("get guest rootfs path")?;
+
         let mut storages = vec![];
         if let Some(storage) = rootfs.get_storage().await {
             storages.push(storage);


### PR DESCRIPTION
enable start container from bundle in this way

$ ls ./bundle
config.json  rootfs
$ sudo ctr run -d --runtime io.containerd.kata.v2 --config bundle/config.json test_kata

Fixes:#5872
Signed-off-by: Zhongtao Hu <zhongtaohu.tim@linux.alibaba.com>