### PR TITLE
tools: Fix indentation on build kernel script

### DIFF
--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -157,12 +157,12 @@ get_kernel() {
 		major_version=$(echo "${version}" | cut -d. -f1)
 		kernel_tarball="linux-${version}.tar.xz"
 
-                if [ ! -f sha256sums.asc ] || ! grep -q "${kernel_tarball}" sha256sums.asc; then
-                        shasum_url="https://cdn.kernel.org/pub/linux/kernel/v${major_version}.x/sha256sums.asc"
-                        info "Download kernel checksum file: sha256sums.asc from ${shasum_url}"
-                        curl --fail -OL "${shasum_url}"
-                fi
-                grep "${kernel_tarball}" sha256sums.asc >"${kernel_tarball}.sha256"
+		if [ ! -f sha256sums.asc ] || ! grep -q "${kernel_tarball}" sha256sums.asc; then
+			shasum_url="https://cdn.kernel.org/pub/linux/kernel/v${major_version}.x/sha256sums.asc"
+			info "Download kernel checksum file: sha256sums.asc from ${shasum_url}"
+			curl --fail -OL "${shasum_url}"
+		fi
+		grep "${kernel_tarball}" sha256sums.asc >"${kernel_tarball}.sha256"
 
 		if [ -f "${kernel_tarball}" ] && ! sha256sum -c "${kernel_tarball}.sha256"; then
 			info "invalid kernel tarball ${kernel_tarball} removing "


### PR DESCRIPTION
This PR fixes the indentation on the build kernel script.

Fixes #5883

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>