### PR TITLE
actions: Fix pushing the shim-v2 build image to quay.io

### DIFF
--- a/.github/workflows/cc-payload-after-push-amd64.yaml
+++ b/.github/workflows/cc-payload-after-push-amd64.yaml
@@ -75,6 +75,13 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-asset
     steps:
+      - name: Login to Kata Containers quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
+          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+
       - uses: actions/checkout@v3
 
       - name: Get root_hash_tdx.txt

--- a/.github/workflows/cc-payload-after-push-s390x.yaml
+++ b/.github/workflows/cc-payload-after-push-s390x.yaml
@@ -63,6 +63,13 @@ jobs:
     runs-on: s390x
     needs: build-asset
     steps:
+      - name: Login to Kata Containers quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
+          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+
       - name: Adjust a permission for repo
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE


### PR DESCRIPTION
e1f075dc60794dbcf680e6e9bd424781126b7f5c reworked the action so the shim-v2 was split out of the matrix build.  With that done I ended up not realising I'd need to log into the quay.io as one step of the build-asset-cc-shim-v2 job.

Fixes: #5885

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>