### PR TITLE
agent: unset `CC` for cross-build

### DIFF
--- a/utils.mk
+++ b/utils.mk
@@ -169,6 +169,7 @@ ifneq ($(HOST_ARCH),$(ARCH))
          $(warning "WARNING: A foreign ARCH was passed, but no CC alternative. Using gcc.")
     endif
     override EXTRA_RUSTFLAGS += -C linker=$(CC)
+    undefine CC
 endif
 
 TRIPLE = $(ARCH)-unknown-linux-$(LIBC)


### PR DESCRIPTION
When `HOST_ARCH` != `ARCH` unset `CC`

Fixes: #5890

Signed-off-by: James Tumber <james.tumber@ibm.com>