### PR TITLE
CC: static build switching sev ovmf to CC fork

### DIFF
--- a/tools/packaging/static-build/ovmf/Dockerfile
+++ b/tools/packaging/static-build/ovmf/Dockerfile
@@ -14,9 +14,15 @@ RUN apt-get update && \
         git \
         iasl  \
         make \
-        nasm \
         python \
         python3 \
         python3-distutils \
         uuid-dev && \
-    apt-get clean && rm -rf /var/lib/lists/
+    apt-get clean && rm -rf /var/lib/lists/ && \
+    cd /tmp && curl -fsLO https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.gz && \
+    tar xf nasm-2.15.05.tar.gz && \
+    cd nasm-2.15.05 && \
+    ./configure && \
+    make -j"$(nproc)" && \
+    make install && \
+    cd /tmp && rm -r nasm-2.15.05*

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -42,6 +42,7 @@ git submodule init
 git submodule update
 
 info "Using BaseTools make target"
+export PYTHON_COMMAND=python3
 make -C BaseTools/
 
 info "Calling edksetup script"

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -24,11 +24,17 @@ ovmf_package="${ovmf_package:-}"
 package_output_dir="${package_output_dir:-}"
 
 if [ -z "$ovmf_repo" ]; then
-       if [ "${ovmf_build}" == "tdx" ]; then
-	       ovmf_repo=$(get_from_kata_deps "externals.ovmf.tdx.url" "${kata_version}")
-       else
-	       ovmf_repo=$(get_from_kata_deps "externals.ovmf.url" "${kata_version}")
-       fi
+	case "${ovmf_build}" in
+		"tdx")
+			ovmf_repo=$(get_from_kata_deps "externals.ovmf.tdx.url" "${kata_version}")
+			;;
+		"sev")
+			ovmf_repo=$(get_from_kata_deps "externals.ovmf.sev.url" "${kata_version}")
+			;;
+		*)
+			ovmf_repo=$(get_from_kata_deps "externals.ovmf.url" "${kata_version}")
+			;;
+	esac
 fi
 
 [ -n "$ovmf_repo" ] || die "failed to get ovmf repo"

--- a/versions.yaml
+++ b/versions.yaml
@@ -294,7 +294,10 @@ externals:
       package_output_dir: "OvmfX64"
     sev:
       description: "AmdSev build needed for SEV measured direct boot."
-      version: "edk2-stable202202"
+      #CCv0 switching to this fork until new release of edk2 has fix
+      #per #5893, will need to be reverted to upstream
+      url: "https://github.com/kata-containers/edk2"
+      version: "edk2-202208-sev-alloc-runtime-secret-area"
       package: "OvmfPkg/AmdSev/AmdSevX64.dsc"
       package_output_dir: "AmdSev"
     tdx:


### PR DESCRIPTION
Switching sev build of ovmf to the cc fork until patches are upstreamed.

Adding build for dependencies

Fixes: kata-containers#5892
Signed-off-by: Alex Carter <Alex.Carter@ibm.com>

@dubek @fitzthum