### PR TITLE
runtime-rs: Clean up mount points shared to guest

### DIFF
--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "shim-interface",
  "slog",
  "slog-scope",
  "thiserror",
@@ -1919,6 +1920,7 @@ dependencies = [
  "safe-path",
  "serde",
  "serde_json",
+ "shim-interface",
 ]
 
 [[package]]
@@ -2343,6 +2345,7 @@ dependencies = [
  "logging",
  "oci",
  "persist",
+ "shim-interface",
  "slog",
  "slog-scope",
  "tokio",
@@ -2474,6 +2477,7 @@ dependencies = [
  "logging",
  "persist",
  "runtimes",
+ "shim-interface",
  "slog",
  "slog-scope",
  "tokio",
@@ -2539,9 +2543,20 @@ dependencies = [
 name = "shim-ctl"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "common",
  "logging",
  "runtimes",
+ "tokio",
+]
+
+[[package]]
+name = "shim-interface"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hyper",
+ "hyperlocal",
  "tokio",
 ]
 

--- a/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
@@ -48,7 +48,7 @@ impl ShareFsRootfs {
         };
 
         let mount_result = share_fs_mount
-            .share_rootfs(config.clone())
+            .share_rootfs(&config)
             .await
             .context("share rootfs")?;
 
@@ -78,7 +78,7 @@ impl Rootfs for ShareFsRootfs {
         // Umount the mount point shared to guest
         let share_fs_mount = self.share_fs.get_share_fs_mount();
         share_fs_mount
-            .umount_rootfs(self.config.clone())
+            .umount_rootfs(&self.config)
             .await
             .context("umount shared rootfs")?;
 

--- a/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
@@ -7,20 +7,22 @@
 use agent::Storage;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use kata_sys_util::mount::Mounter;
+use kata_sys_util::mount::{umount_timeout, Mounter};
 use kata_types::mount::Mount;
 use std::sync::Arc;
 
 use super::{Rootfs, ROOTFS};
-use crate::share_fs::{ShareFsMount, ShareFsRootfsConfig};
+use crate::share_fs::{ShareFs, ShareFsRootfsConfig};
 
 pub(crate) struct ShareFsRootfs {
     guest_path: String,
+    share_fs: Arc<dyn ShareFs>,
+    config: ShareFsRootfsConfig,
 }
 
 impl ShareFsRootfs {
     pub async fn new(
-        share_fs_mount: &Arc<dyn ShareFsMount>,
+        share_fs: &Arc<dyn ShareFs>,
         cid: &str,
         bundle_path: &str,
         rootfs: Option<&Mount>,
@@ -35,19 +37,25 @@ impl ShareFsRootfs {
         } else {
             bundle_path.to_string()
         };
+
+        let share_fs_mount = share_fs.get_share_fs_mount();
+        let config = ShareFsRootfsConfig {
+            cid: cid.to_string(),
+            source: bundle_rootfs.to_string(),
+            target: ROOTFS.to_string(),
+            readonly: false,
+            is_rafs: false,
+        };
+
         let mount_result = share_fs_mount
-            .share_rootfs(ShareFsRootfsConfig {
-                cid: cid.to_string(),
-                source: bundle_rootfs.to_string(),
-                target: ROOTFS.to_string(),
-                readonly: false,
-                is_rafs: false,
-            })
+            .share_rootfs(config.clone())
             .await
             .context("share rootfs")?;
 
         Ok(ShareFsRootfs {
             guest_path: mount_result.guest_path,
+            share_fs: Arc::clone(share_fs),
+            config,
         })
     }
 }
@@ -64,5 +72,18 @@ impl Rootfs for ShareFsRootfs {
 
     async fn get_storage(&self) -> Option<Storage> {
         None
+    }
+
+    async fn cleanup(&self) -> Result<()> {
+        // Umount the mount point shared to guest
+        let share_fs_mount = self.share_fs.get_share_fs_mount();
+        share_fs_mount
+            .umount_rootfs(self.config.clone())
+            .await
+            .context("umount shared rootfs")?;
+
+        // Umount the bundle rootfs
+        umount_timeout(&self.config.source, 0).context("umount bundle rootfs")?;
+        Ok(())
     }
 }

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -47,7 +47,7 @@ pub trait ShareFs: Send + Sync {
     fn mounted_info_set(&self) -> Arc<Mutex<HashMap<String, MountedInfo>>>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ShareFsRootfsConfig {
     // TODO: for nydus v5/v6 need to update ShareFsMount
     pub cid: String,
@@ -127,7 +127,9 @@ pub trait ShareFsMount: Send + Sync {
     /// Downgrade to readonly permission
     async fn downgrade_to_ro(&self, file_name: &str) -> Result<()>;
     /// Umount the volume
-    async fn umount(&self, file_name: &str) -> Result<()>;
+    async fn umount_volume(&self, file_name: &str) -> Result<()>;
+    /// Umount the rootfs
+    async fn umount_rootfs(&self, config: ShareFsRootfsConfig) -> Result<()>;
 }
 
 pub fn new(id: &str, config: &SharedFsInfo) -> Result<Arc<dyn ShareFs>> {

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -120,8 +120,8 @@ impl MountedInfo {
 
 #[async_trait]
 pub trait ShareFsMount: Send + Sync {
-    async fn share_rootfs(&self, config: ShareFsRootfsConfig) -> Result<ShareFsMountResult>;
-    async fn share_volume(&self, config: ShareFsVolumeConfig) -> Result<ShareFsMountResult>;
+    async fn share_rootfs(&self, config: &ShareFsRootfsConfig) -> Result<ShareFsMountResult>;
+    async fn share_volume(&self, config: &ShareFsVolumeConfig) -> Result<ShareFsMountResult>;
     /// Upgrade to readwrite permission
     async fn upgrade_to_rw(&self, file_name: &str) -> Result<()>;
     /// Downgrade to readonly permission
@@ -129,7 +129,7 @@ pub trait ShareFsMount: Send + Sync {
     /// Umount the volume
     async fn umount_volume(&self, file_name: &str) -> Result<()>;
     /// Umount the rootfs
-    async fn umount_rootfs(&self, config: ShareFsRootfsConfig) -> Result<()>;
+    async fn umount_rootfs(&self, config: &ShareFsRootfsConfig) -> Result<()>;
 }
 
 pub fn new(id: &str, config: &SharedFsInfo) -> Result<Arc<dyn ShareFs>> {

--- a/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
@@ -38,7 +38,7 @@ impl VirtiofsShareMount {
 
 #[async_trait]
 impl ShareFsMount for VirtiofsShareMount {
-    async fn share_rootfs(&self, config: ShareFsRootfsConfig) -> Result<ShareFsMountResult> {
+    async fn share_rootfs(&self, config: &ShareFsRootfsConfig) -> Result<ShareFsMountResult> {
         // TODO: select virtiofs or support nydus
         let guest_path = utils::share_to_guest(
             &config.source,
@@ -56,7 +56,7 @@ impl ShareFsMount for VirtiofsShareMount {
         })
     }
 
-    async fn share_volume(&self, config: ShareFsVolumeConfig) -> Result<ShareFsMountResult> {
+    async fn share_volume(&self, config: &ShareFsVolumeConfig) -> Result<ShareFsMountResult> {
         let mut guest_path = utils::share_to_guest(
             &config.source,
             &config.target,
@@ -103,7 +103,7 @@ impl ShareFsMount for VirtiofsShareMount {
                 source: guest_path,
                 fs_type: String::from("bind"),
                 fs_group: None,
-                options: config.mount_options,
+                options: config.mount_options.clone(),
                 mount_point: watchable_guest_mount.clone(),
             };
 
@@ -211,7 +211,7 @@ impl ShareFsMount for VirtiofsShareMount {
         Ok(())
     }
 
-    async fn umount_rootfs(&self, config: ShareFsRootfsConfig) -> Result<()> {
+    async fn umount_rootfs(&self, config: &ShareFsRootfsConfig) -> Result<()> {
         let host_dest = do_get_host_path(&config.target, &self.id, &config.cid, false, false);
         umount_timeout(&host_dest, 0).context("umount rootfs")?;
 

--- a/src/runtime-rs/crates/resource/src/volume/block_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/block_volume.rs
@@ -30,6 +30,7 @@ impl Volume for BlockVolume {
     }
 
     async fn cleanup(&self) -> Result<()> {
+        // TODO: Clean up BlockVolume
         warn!(sl!(), "Cleaning up BlockVolume is still unimplemented.");
         Ok(())
     }

--- a/src/runtime-rs/crates/resource/src/volume/default_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/default_volume.rs
@@ -34,6 +34,7 @@ impl Volume for DefaultVolume {
     }
 
     async fn cleanup(&self) -> Result<()> {
+        // TODO: Clean up DefaultVolume
         warn!(sl!(), "Cleaning up DefaultVolume is still unimplemented.");
         Ok(())
     }

--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -112,7 +112,7 @@ impl ShareFsVolume {
                 } else {
                     // Not mounted ever
                     let mount_result = share_fs_mount
-                        .share_volume(ShareFsVolumeConfig {
+                        .share_volume(&ShareFsVolumeConfig {
                             // The scope of shared volume is sandbox
                             cid: String::from(""),
                             source: m.source.clone(),
@@ -158,10 +158,10 @@ impl Volume for ShareFsVolume {
     }
 
     async fn cleanup(&self) -> Result<()> {
-        if self.share_fs.is_none() {
-            return Ok(());
-        }
-        let share_fs = self.share_fs.as_ref().unwrap();
+        let share_fs = match self.share_fs.as_ref() {
+            Some(fs) => fs,
+            None => return Ok(()),
+        };
 
         let mounted_info_set = share_fs.mounted_info_set();
         let mut mounted_info_set = mounted_info_set.lock().await;

--- a/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
@@ -100,6 +100,7 @@ impl Volume for ShmVolume {
     }
 
     async fn cleanup(&self) -> Result<()> {
+        // TODO: Clean up ShmVolume
         warn!(sl!(), "Cleaning up ShmVolume is still unimplemented.");
         Ok(())
     }


### PR DESCRIPTION
1. Fixed issues where shared volumes couldn't umount correctly. 
2. The rootfs of each container is cleaned up after the container is killed, except
for `NydusRootfs`. `ShareFsRootfs::cleanup()` calls
`VirtiofsShareMount::umount_rootfs()` to umount mount points shared to the
guest, and umounts the bundle rootfs. 

Fixes: #5898

Signed-off-by: Xuewei Niu <niuxuewei.nxw@antgroup.com>