### PR TITLE
kernel: adding kmod to do docker env

### DIFF
--- a/tools/packaging/static-build/kernel/Dockerfile
+++ b/tools/packaging/static-build/kernel/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && \
 	    flex \
 	    git \
 	    iptables \
+	    kmod \
 	    libelf-dev \
 	    patch && \
     if [ "$(uname -m)" = "s390x" ]; then apt-get install -y --no-install-recommends libssl-dev; fi && \


### PR DESCRIPTION
adding kmod to kernel building docker env to remove warning

Fixes: kata-containers#5866
Signed-off-by: Alex Carter <Alex.Carter@ibm.com>