### PR TITLE
osbuilder: fix kernel module copy logic in rootfs builder

### DIFF
--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -41,7 +41,7 @@ build_initrd() {
 	export AGENT_INIT="yes"
 	# ROOTFS_BUILD_DEST is a Make variable
 
-	if [ -z "${AA_KBC}" == "offline_sev_kbc" ]; then
+	if [ "${AA_KBC:-}" == "offline_sev_kbc" ]; then
 		config_version=$(get_config_version)
 		kernel_version="$(get_from_kata_deps "assets.kernel.sev.version")"
 		kernel_version=${kernel_version#v}


### PR DESCRIPTION
the switch to cases lets AA_KBC to be parsed correctly.

There will be an addition to the offline_sev_kbc case to do the same for online_sev_kbc

There will also be an addition for SNP

Fixes: #5909
Signed-off-by: Alex Carter <Alex.Carter@ibm.com>