### PR TITLE
dragonball: refactor legacy device initialization

### DIFF
--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -406,19 +406,10 @@ impl VmmService {
         }
         config.vpmu_feature = machine_config.vpmu_feature;
 
-        let vm_id = vm.shared_info().read().unwrap().id.clone();
-        let serial_path = match machine_config.serial_path {
-            Some(value) => value,
-            None => {
-                if config.serial_path.is_none() {
-                    String::from("/run/dragonball/") + &vm_id + "_com1"
-                } else {
-                    // Safe to unwrap() because we have checked it has a value.
-                    config.serial_path.as_ref().unwrap().clone()
-                }
-            }
-        };
-        config.serial_path = Some(serial_path);
+        // If serial_path is:
+        // - None, legacy_manager will create_stdio_console.
+        // - Some(path), legacy_manager will create_socket_console on that path.
+        config.serial_path = machine_config.serial_path;
 
         vm.set_vm_config(config.clone());
         self.machine_config = config;

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -595,23 +595,17 @@ impl DeviceManager {
             .map_err(|_| StartMicroVmError::EventFd)?;
 
         info!(self.logger, "init console path: {:?}", com1_sock_path);
-
         if let Some(legacy_manager) = self.legacy_manager.as_ref() {
-            if let Some(path) = com1_sock_path {
-                // Currently, the `com1_sock_path` "stdio" is only reserved for creating the stdio console
-                if path != "stdio" {
-                    let com1 = legacy_manager.get_com1_serial();
-                    self.con_manager
-                        .create_socket_console(com1, path)
-                        .map_err(StartMicroVmError::DeviceManager)?;
-                    return Ok(());
-                }
-            }
-
             let com1 = legacy_manager.get_com1_serial();
-            self.con_manager
-                .create_stdio_console(com1)
-                .map_err(StartMicroVmError::DeviceManager)?;
+            if let Some(path) = com1_sock_path {
+                self.con_manager
+                    .create_socket_console(com1, path)
+                    .map_err(StartMicroVmError::DeviceManager)?;
+            } else {
+                self.con_manager
+                    .create_stdio_console(com1)
+                    .map_err(StartMicroVmError::DeviceManager)?;
+            }
         }
 
         Ok(())


### PR DESCRIPTION
If the serial path is given, legacy_manager should create socket console based on that path. Or the console should be created based on stdio.

Fixes: #5914

Signed-off-by: Yushuo <y-shuo@linux.alibaba.com>