### PR TITLE
kata-ctl: fix checkcpu bug in non-x86 arches

### DIFF
--- a/src/tools/kata-ctl/src/arch/aarch64/mod.rs
+++ b/src/tools/kata-ctl/src/arch/aarch64/mod.rs
@@ -7,12 +7,21 @@
 pub use arch_specific::*;
 
 mod arch_specific {
+    use crate::types::*;
     use anyhow::Result;
     use std::path::Path;
 
     const KVM_DEV: &str = "/dev/kvm";
 
-    pub fn check() -> Result<()> {
+    // List of check functions
+    static CHECK_LIST: &[CheckItem] = &[CheckItem {
+        name: CheckType::CheckCpu,
+        descr: "This parameter performs the host check",
+        fp: check,
+        perm: PermissionType::NonPrivileged,
+    }];
+
+    pub fn check(_args: &str) -> Result<()> {
         println!("INFO: check: aarch64");
         if Path::new(KVM_DEV).exists() {
             println!("Kata Containers can run on this host\n");
@@ -21,5 +30,9 @@ mod arch_specific {
         }
 
         Ok(())
+    }
+
+    pub fn get_checks() -> Option<&'static [CheckItem<'static>]> {
+        Some(CHECK_LIST)
     }
 }

--- a/src/tools/kata-ctl/src/arch/powerpc64le/mod.rs
+++ b/src/tools/kata-ctl/src/arch/powerpc64le/mod.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::types::*;
 #[cfg(target_arch = "powerpc64le")]
 pub use arch_specific::*;
 
@@ -11,5 +12,9 @@ mod arch_specific {
 
     pub fn check() -> Result<()> {
         unimplemented!("Check not implemented in powerpc64le");
+    }
+
+    pub fn get_checks() -> Option<&'static [CheckItem<'static>]> {
+        None
     }
 }

--- a/src/tools/kata-ctl/src/arch/s390x/mod.rs
+++ b/src/tools/kata-ctl/src/arch/s390x/mod.rs
@@ -48,4 +48,16 @@ mod arch_specific {
 
         Ok(())
     }
+
+    // List of check functions
+    static CHECK_LIST: &[CheckItem] = &[CheckItem {
+        name: CheckType::CheckCpu,
+        descr: "This parameter performs the cpu check",
+        fp: check,
+        perm: PermissionType::NonPrivileged,
+    }];
+
+    pub fn get_checks() -> Option<&'static [CheckItem<'static>]> {
+        Some(CHECK_LIST)
+    }
 }

--- a/src/tools/kata-ctl/src/arch/x86_64/mod.rs
+++ b/src/tools/kata-ctl/src/arch/x86_64/mod.rs
@@ -25,8 +25,8 @@ mod arch_specific {
         perm: PermissionType::NonPrivileged,
     }];
 
-    pub fn get_checks() -> &'static [CheckItem<'static>] {
-        CHECK_LIST
+    pub fn get_checks() -> Option<&'static [CheckItem<'static>]> {
+        Some(CHECK_LIST)
     }
 
     fn check_cpu(_args: &str) -> Result<()> {

--- a/src/tools/kata-ctl/src/ops/check_ops.rs
+++ b/src/tools/kata-ctl/src/ops/check_ops.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::arch::x86_64::get_checks;
+use crate::arch::arch_specific::get_checks;
 
 use crate::args::{CheckArgument, CheckSubCommand, IptablesCommand, MetricsCommand};
 
@@ -19,11 +19,11 @@ const NAME: &str = "kata-ctl";
 
 // This function retrieves the cmd function passes as argument
 fn get_builtin_check_func(name: CheckType) -> Result<BuiltinCmdFp> {
-    let check_list = get_checks();
-
-    for check in check_list {
-        if check.name.eq(&name) {
-            return Ok(check.fp);
+    if let Some(check_list) = get_checks() {
+        for check in check_list {
+            if check.name.eq(&name) {
+                return Ok(check.fp);
+            }
         }
     }
 
@@ -42,10 +42,10 @@ fn handle_builtin_check(check: CheckType, args: &str) -> Result<()> {
 
 fn get_client_cmd_details() -> Vec<String> {
     let mut cmds = Vec::new();
-    let check_list = get_checks();
-
-    for cmd in check_list {
-        cmds.push(format!("{} ({}. Mode: {})", cmd.name, cmd.descr, cmd.perm));
+    if let Some(check_list) = get_checks() {
+        for cmd in check_list {
+            cmds.push(format!("{} ({}. Mode: {})", cmd.name, cmd.descr, cmd.perm));
+        }
     }
 
     cmds


### PR DESCRIPTION
https://github.com/kata-containers/kata-containers/pull/5735 break CI for non-x86 arches. Fix it here.