### PR TITLE
CCv0: runtime: Support launching SEV-ES guests

### DIFF
--- a/src/runtime/pkg/sev/vcpu_sigs.go
+++ b/src/runtime/pkg/sev/vcpu_sigs.go
@@ -46,3 +46,31 @@ const (
 	// 'EPYC-Milan-v2': family=25, model=1, stepping=1
 	SigEpycMilanV2 VCPUSig = 0xa00f11
 )
+
+// NewVCPUSig computes the CPU signature (32-bit value) from the given family,
+// model, and stepping.
+//
+// This computation is described in AMD's CPUID Specification, publication #25481
+// https://www.amd.com/system/files/TechDocs/25481.pdf
+// See section: CPUID Fn0000_0001_EAX Family, Model, Stepping Identifiers
+func NewVCPUSig(family, model, stepping uint32) VCPUSig {
+	var family_low, family_high uint32
+	if family > 0xf {
+		family_low = 0xf
+		family_high = (family - 0x0f) & 0xff
+	} else {
+		family_low = family
+		family_high = 0
+	}
+
+	model_low := model & 0xf
+	model_high := (model >> 4) & 0xf
+
+	stepping_low := stepping & 0xf
+
+	return VCPUSig((family_high << 20) |
+		(model_high << 16) |
+		(family_low << 8) |
+		(model_low << 4) |
+		stepping_low)
+}

--- a/src/runtime/pkg/sev/vcpu_sigs_test.go
+++ b/src/runtime/pkg/sev/vcpu_sigs_test.go
@@ -1,0 +1,21 @@
+// Copyright contributors to AMD SEV/-ES in Go
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package sev
+
+import (
+	"testing"
+)
+
+func TestNewVCPUSig(t *testing.T) {
+	if NewVCPUSig(23, 1, 2) != SigEpyc {
+		t.Errorf("wrong EPYC CPU signature")
+	}
+	if NewVCPUSig(23, 49, 0) != SigEpycRome {
+		t.Errorf("wrong EPYC-Rome CPU signature")
+	}
+	if NewVCPUSig(25, 1, 1) != SigEpycMilan {
+		t.Errorf("wrong EPYC-Milan CPU signature")
+	}
+}


### PR DESCRIPTION
The `sev_guest_policy` configuration field distinguishes between SEV and SEV-ES guests (according to standard AMD SEV policy values).

Modify the kata runtime to detect SEV-ES guests and calculate calculate the expected launch digest taking into account the number of VCPUs and their CPU signature (model/family/stepping).

Fixes: #5471

Signed-off-by: Dov Murik <dovmurik@linux.ibm.com>

----

Note that the default SEV policy will remain `3` for now (see #5665), which is SEV mode.

I think that after this successfully lands in CCv0, we can add a CI test which starts an SEV-ES pod. No corresponding change is needed in simple-kbs. It will be easier to choose between SEV and SEV-ES pods after we have the annotations override for `sev_guest_policy` (= `io.katacontainers.config.sev.policy`) in PR #5665 .

In the future if we're confident with SEV-ES we can make it the default.

Cc: @fitzthum @Alex-Carter01 @jimcadden @ryansavino