### PR TITLE
runtime: Update the remote hypervisor config

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1071,6 +1071,7 @@ func newRemoteHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 	return vc.HypervisorConfig{
 		RemoteHypervisorSocket:  h.RemoteHypervisorSocket,
 		RemoteHypervisorTimeout: h.RemoteHypervisorTimeout,
+		DisableGuestSeLinux:     h.DisableGuestSeLinux,
 
 		// No valid value so avoid to append block device to list in kata_agent.appendDevices
 		BlockDeviceDriver: "dummy",


### PR DESCRIPTION
Add the SELinux setting to ensure it is passed through to the remote hypervisor

Fixes: #5936

Signed-off-by: stevenhorsman <steven@uk.ibm.com>