### PR TITLE
docs: remove old and misleading instructions for minikube

### DIFF
--- a/docs/install/minikube-installation-guide.md
+++ b/docs/install/minikube-installation-guide.md
@@ -71,12 +71,6 @@ To use containerd, modify the `--container-runtime` argument:
 > **Notes:**
 > - Adjust the `--memory 6144` line to suit your environment and requirements. Kata Containers default to
 > requesting 2048MB per container. We recommended you supply more than that to the Minikube node.
-> - Prior to Minikube/Kubernetes v1.14, the beta `RuntimeClass` feature also needed enabling with
-> the following.
->
-> | what | why |
-> | ---- | --- |
-> | `--feature-gates=RuntimeClass=true` | Kata needs to use the `RuntimeClass` Kubernetes feature |
 
 The full command is therefore:
 
@@ -138,16 +132,8 @@ $ kubectl -n kube-system exec ${podname} -- ps -ef | fgrep infinity
 
 ## Enabling Kata Containers
 
-> **Note:** Only Minikube/Kubernetes versions <= 1.13 require this step. Since version
-> v1.14, the `RuntimeClass` is enabled by default. Performing this step on Kubernetes > v1.14 is
-> however benign.
-
 Now you have installed the Kata Containers components in the Minikube node. Next, you need to configure
 Kubernetes `RuntimeClass` to know when to use Kata Containers to run a pod.
-
-```sh
-$ kubectl apply -f https://raw.githubusercontent.com/kubernetes/node-api/master/manifests/runtimeclass_crd.yaml > runtimeclass_crd.yaml
-```
 
 ### Register the runtime
 


### PR DESCRIPTION
Some instructions are old, delete them to prevent misleading.

Fixes: #5942

Signed-off-by: Bin Liu <bin@hyper.sh>