### PR TITLE
Runtime: Clarify mutability of global var

### DIFF
--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -19,6 +19,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+// Mutable and not constant so we can mock in tests
 var urandomDev = "/dev/urandom"
 
 // VM is abstraction of a virtual machine.


### PR DESCRIPTION
Was about to change `urandomdev` to a constant when I realized it's intentionally mutable so it can be mocked in tests. There's other comments to the same effect so clarify here as well.

Fixes: https://github.com/kata-containers/kata-containers/issues/5965