### PR TITLE
kata-ctl: skip test if access GitHub.com fail

### DIFF
--- a/src/tools/kata-ctl/Cargo.lock
+++ b/src/tools/kata-ctl/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "shim-interface",
  "slog",
  "slog-scope",
  "thiserror",
@@ -2188,6 +2189,7 @@ dependencies = [
  "safe-path",
  "serde",
  "serde_json",
+ "shim-interface",
 ]
 
 [[package]]
@@ -2717,6 +2719,7 @@ dependencies = [
  "logging",
  "oci",
  "persist",
+ "shim-interface",
  "slog",
  "slog-scope",
  "tokio",
@@ -2911,6 +2914,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shim-interface"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hyper",
+ "hyperlocal",
+ "tokio",
 ]
 
 [[package]]


### PR DESCRIPTION
This commit will call `error_for_status` after `send`, this call
will generate errors if status code between 400-499 and 500-599.

And sometime access github.com will fail, in this case we can
skip the test to prevent the CI failing.

Fixes: #5948

Signed-off-by: Bin Liu <bin@hyper.sh>
