### PR TITLE
kata-ctl/exec: add new command exec to enter guest VM.

### DIFF
--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -60,7 +60,7 @@ use crate::sl;
 /// Default permission for directories created for mountpoint.
 const MOUNT_PERM: u32 = 0o755;
 
-const PROC_MOUNTS_FILE: &str = "/proc/mounts";
+pub const PROC_MOUNTS_FILE: &str = "/proc/mounts";
 const PROC_FIELDS_PER_LINE: usize = 6;
 const PROC_DEVICE_INDEX: usize = 0;
 const PROC_PATH_INDEX: usize = 1;

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -330,6 +330,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "415301c9de11005d4b92193c0eb7ac7adc37e5a49e0ac9bed0a42343512744b8"
 
 [[package]]
+name = "byte-unit"
+version = "4.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581ad4b3d627b0c09a0ccb2912148f839acaca0b93cf54cbe42b6c674e86079c"
+dependencies = [
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1362,7 +1372,7 @@ dependencies = [
  "anyhow",
  "base64",
  "bitmask-enum",
- "byte-unit",
+ "byte-unit 3.1.4",
  "glob",
  "lazy_static",
  "num_cpus",
@@ -2281,6 +2291,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bitflags",
+ "byte-unit 4.0.17",
  "cgroups-rs",
  "futures 0.3.21",
  "hypervisor",
@@ -2301,6 +2312,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-scope",
+ "tempfile",
  "test-utils",
  "tokio",
  "uuid",
@@ -3022,6 +3034,12 @@ dependencies = [
  "matches",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
 
 [[package]]
 name = "uuid"

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1223,6 +1223,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "shim-interface",
  "slog",
  "slog-scope",
  "thiserror",
@@ -1919,6 +1920,7 @@ dependencies = [
  "safe-path",
  "serde",
  "serde_json",
+ "shim-interface",
 ]
 
 [[package]]
@@ -2343,6 +2345,7 @@ dependencies = [
  "logging",
  "oci",
  "persist",
+ "shim-interface",
  "slog",
  "slog-scope",
  "tokio",
@@ -2474,6 +2477,7 @@ dependencies = [
  "logging",
  "persist",
  "runtimes",
+ "shim-interface",
  "slog",
  "slog-scope",
  "tokio",
@@ -2539,9 +2543,20 @@ dependencies = [
 name = "shim-ctl"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "common",
  "logging",
  "runtimes",
+ "tokio",
+]
+
+[[package]]
+name = "shim-interface"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hyper",
+ "hyperlocal",
  "tokio",
 ]
 

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -136,6 +136,14 @@ block_device_driver = "@DEFBLOCKSTORAGEDRIVER_DB@"
 # of shim, does not need an external virtiofsd process.
 shared_fs = "@DBSHAREDFS@"
 
+# Enable huge pages for VM RAM, default false
+# Enabling this will result in the VM memory
+# being allocated using huge pages.
+# This is useful when you want to use vhost-user network
+# stacks within the container. This will automatically
+# result in memory pre allocation
+#enable_hugepages = true
+
 [agent.@PROJECT_TYPE@]
 container_pipe_size=@PIPESIZE@
 # If enabled, make the agent display debug-level messages.

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -7,7 +7,7 @@
 use super::vmm_instance::VmmInstance;
 use crate::{
     device::Device, hypervisor_persist::HypervisorState, kernel_param::KernelParams, VmmState,
-    HYPERVISOR_DRAGONBALL, VM_ROOTFS_DRIVER_BLK,
+    DEV_HUGEPAGES, HUGETLBFS, HYPERVISOR_DRAGONBALL, SHMEM, VM_ROOTFS_DRIVER_BLK,
 };
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -187,11 +187,18 @@ impl DragonballInner {
 
     fn set_vm_base_config(&mut self) -> Result<()> {
         let serial_path = [&self.run_dir, "console.sock"].join("/");
+        let (mem_type, mem_file_path) = if self.config.memory_info.enable_hugepages {
+            (String::from(HUGETLBFS), String::from(DEV_HUGEPAGES))
+        } else {
+            (String::from(SHMEM), String::from(""))
+        };
         let vm_config = VmConfigInfo {
             serial_path: Some(serial_path),
             mem_size_mib: self.config.memory_info.default_memory as usize,
             vcpu_count: self.config.cpu_info.default_vcpus as u8,
             max_vcpu_count: self.config.cpu_info.default_maxvcpus as u8,
+            mem_type,
+            mem_file_path,
             ..Default::default()
         };
         info!(sl!(), "vm config: {:?}", vm_config);

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -327,9 +327,9 @@ impl VmmInstance {
                 }
             }
         }
-        return Err(anyhow::anyhow!(
+        Err(anyhow::anyhow!(
             "After {} attempts, it still doesn't work.",
             REQUEST_RETRY
-        ));
+        ))
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -27,6 +27,13 @@ use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 // Config which driver to use as vm root dev
 const VM_ROOTFS_DRIVER_BLK: &str = "virtio-blk";
 const VM_ROOTFS_DRIVER_PMEM: &str = "virtio-pmem";
+// before using hugepages for VM, we need to mount hugetlbfs
+// /dev/hugepages will be the mount point
+// mkdir -p /dev/hugepages
+// mount -t hugetlbfs none /dev/hugepages
+const DEV_HUGEPAGES: &str = "/dev/hugepages";
+pub const HUGETLBFS: &str = "hugetlbfs";
+const SHMEM: &str = "shmem";
 
 pub const HYPERVISOR_DRAGONBALL: &str = "dragonball";
 pub const HYPERVISOR_QEMU: &str = "qemu";

--- a/src/runtime-rs/crates/persist/src/lib.rs
+++ b/src/runtime-rs/crates/persist/src/lib.rs
@@ -26,7 +26,7 @@ pub fn to_disk<T: serde::Serialize>(value: &T, sid: &str) -> Result<()> {
         serde_json::to_writer_pretty(f, &j)?;
         return Ok(());
     }
-    return Err(anyhow!("invalid sid {}", sid));
+    Err(anyhow!("invalid sid {}", sid))
 }
 
 pub fn from_disk<T>(sid: &str) -> Result<T>
@@ -41,7 +41,7 @@ where
         let reader = BufReader::new(file);
         return serde_json::from_reader(reader).map_err(|e| anyhow!(e.to_string()));
     }
-    return Err(anyhow!("invalid sid {}", sid));
+    Err(anyhow!("invalid sid {}", sid))
 }
 
 #[cfg(test)]

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -7,11 +7,13 @@ license = "Apache-2.0"
 
 [dev-dependencies]
 test-utils = { path = "../../../libs/test-utils" }
+tempfile = "3.2.0"
 
 [dependencies]
 anyhow = "^1.0"
 async-trait = "0.1.48"
 bitflags = "1.2.1"
+byte-unit = "4.0.14"
 cgroups-rs = "0.2.9"
 futures = "0.3.11"
 lazy_static = "1.4.0"

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -81,10 +81,10 @@ impl ResourceManager {
     pub async fn handler_volumes(
         &self,
         cid: &str,
-        oci_mounts: &[oci::Mount],
+        spec: &oci::Spec,
     ) -> Result<Vec<Arc<dyn Volume>>> {
         let inner = self.inner.read().await;
-        inner.handler_volumes(cid, oci_mounts).await
+        inner.handler_volumes(cid, spec).await
     }
 
     pub async fn dump(&self) {

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -216,10 +216,10 @@ impl ResourceManagerInner {
     pub async fn handler_volumes(
         &self,
         cid: &str,
-        oci_mounts: &[oci::Mount],
+        spec: &oci::Spec,
     ) -> Result<Vec<Arc<dyn Volume>>> {
         self.volume_resource
-            .handler_volumes(&self.share_fs, cid, oci_mounts)
+            .handler_volumes(&self.share_fs, cid, spec)
             .await
     }
 

--- a/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
@@ -48,7 +48,7 @@ impl ShareFsRootfs {
         };
 
         let mount_result = share_fs_mount
-            .share_rootfs(config.clone())
+            .share_rootfs(&config)
             .await
             .context("share rootfs")?;
 
@@ -78,7 +78,7 @@ impl Rootfs for ShareFsRootfs {
         // Umount the mount point shared to guest
         let share_fs_mount = self.share_fs.get_share_fs_mount();
         share_fs_mount
-            .umount_rootfs(self.config.clone())
+            .umount_rootfs(&self.config)
             .await
             .context("umount shared rootfs")?;
 

--- a/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/share_fs_rootfs.rs
@@ -7,20 +7,22 @@
 use agent::Storage;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use kata_sys_util::mount::Mounter;
+use kata_sys_util::mount::{umount_timeout, Mounter};
 use kata_types::mount::Mount;
 use std::sync::Arc;
 
 use super::{Rootfs, ROOTFS};
-use crate::share_fs::{ShareFsMount, ShareFsRootfsConfig};
+use crate::share_fs::{ShareFs, ShareFsRootfsConfig};
 
 pub(crate) struct ShareFsRootfs {
     guest_path: String,
+    share_fs: Arc<dyn ShareFs>,
+    config: ShareFsRootfsConfig,
 }
 
 impl ShareFsRootfs {
     pub async fn new(
-        share_fs_mount: &Arc<dyn ShareFsMount>,
+        share_fs: &Arc<dyn ShareFs>,
         cid: &str,
         bundle_path: &str,
         rootfs: Option<&Mount>,
@@ -35,19 +37,25 @@ impl ShareFsRootfs {
         } else {
             bundle_path.to_string()
         };
+
+        let share_fs_mount = share_fs.get_share_fs_mount();
+        let config = ShareFsRootfsConfig {
+            cid: cid.to_string(),
+            source: bundle_rootfs.to_string(),
+            target: ROOTFS.to_string(),
+            readonly: false,
+            is_rafs: false,
+        };
+
         let mount_result = share_fs_mount
-            .share_rootfs(ShareFsRootfsConfig {
-                cid: cid.to_string(),
-                source: bundle_rootfs.to_string(),
-                target: ROOTFS.to_string(),
-                readonly: false,
-                is_rafs: false,
-            })
+            .share_rootfs(config.clone())
             .await
             .context("share rootfs")?;
 
         Ok(ShareFsRootfs {
             guest_path: mount_result.guest_path,
+            share_fs: Arc::clone(share_fs),
+            config,
         })
     }
 }
@@ -64,5 +72,18 @@ impl Rootfs for ShareFsRootfs {
 
     async fn get_storage(&self) -> Option<Storage> {
         None
+    }
+
+    async fn cleanup(&self) -> Result<()> {
+        // Umount the mount point shared to guest
+        let share_fs_mount = self.share_fs.get_share_fs_mount();
+        share_fs_mount
+            .umount_rootfs(self.config.clone())
+            .await
+            .context("umount shared rootfs")?;
+
+        // Umount the bundle rootfs
+        umount_timeout(&self.config.source, 0).context("umount bundle rootfs")?;
+        Ok(())
     }
 }

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -47,7 +47,7 @@ pub trait ShareFs: Send + Sync {
     fn mounted_info_set(&self) -> Arc<Mutex<HashMap<String, MountedInfo>>>;
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ShareFsRootfsConfig {
     // TODO: for nydus v5/v6 need to update ShareFsMount
     pub cid: String,
@@ -127,7 +127,9 @@ pub trait ShareFsMount: Send + Sync {
     /// Downgrade to readonly permission
     async fn downgrade_to_ro(&self, file_name: &str) -> Result<()>;
     /// Umount the volume
-    async fn umount(&self, file_name: &str) -> Result<()>;
+    async fn umount_volume(&self, file_name: &str) -> Result<()>;
+    /// Umount the rootfs
+    async fn umount_rootfs(&self, config: ShareFsRootfsConfig) -> Result<()>;
 }
 
 pub fn new(id: &str, config: &SharedFsInfo) -> Result<Arc<dyn ShareFs>> {

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -120,8 +120,8 @@ impl MountedInfo {
 
 #[async_trait]
 pub trait ShareFsMount: Send + Sync {
-    async fn share_rootfs(&self, config: ShareFsRootfsConfig) -> Result<ShareFsMountResult>;
-    async fn share_volume(&self, config: ShareFsVolumeConfig) -> Result<ShareFsMountResult>;
+    async fn share_rootfs(&self, config: &ShareFsRootfsConfig) -> Result<ShareFsMountResult>;
+    async fn share_volume(&self, config: &ShareFsVolumeConfig) -> Result<ShareFsMountResult>;
     /// Upgrade to readwrite permission
     async fn upgrade_to_rw(&self, file_name: &str) -> Result<()>;
     /// Downgrade to readonly permission
@@ -129,7 +129,7 @@ pub trait ShareFsMount: Send + Sync {
     /// Umount the volume
     async fn umount_volume(&self, file_name: &str) -> Result<()>;
     /// Umount the rootfs
-    async fn umount_rootfs(&self, config: ShareFsRootfsConfig) -> Result<()>;
+    async fn umount_rootfs(&self, config: &ShareFsRootfsConfig) -> Result<()>;
 }
 
 pub fn new(id: &str, config: &SharedFsInfo) -> Result<Arc<dyn ShareFs>> {

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -15,6 +15,7 @@ use tokio::sync::Mutex;
 pub use utils::{do_get_guest_path, do_get_guest_share_path, get_host_rw_shared_path};
 mod virtio_fs_share_mount;
 use virtio_fs_share_mount::VirtiofsShareMount;
+pub use virtio_fs_share_mount::EPHEMERAL_PATH;
 
 use std::{collections::HashMap, fmt::Debug, path::PathBuf, sync::Arc};
 

--- a/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
@@ -38,7 +38,7 @@ impl VirtiofsShareMount {
 
 #[async_trait]
 impl ShareFsMount for VirtiofsShareMount {
-    async fn share_rootfs(&self, config: ShareFsRootfsConfig) -> Result<ShareFsMountResult> {
+    async fn share_rootfs(&self, config: &ShareFsRootfsConfig) -> Result<ShareFsMountResult> {
         // TODO: select virtiofs or support nydus
         let guest_path = utils::share_to_guest(
             &config.source,
@@ -56,7 +56,7 @@ impl ShareFsMount for VirtiofsShareMount {
         })
     }
 
-    async fn share_volume(&self, config: ShareFsVolumeConfig) -> Result<ShareFsMountResult> {
+    async fn share_volume(&self, config: &ShareFsVolumeConfig) -> Result<ShareFsMountResult> {
         let mut guest_path = utils::share_to_guest(
             &config.source,
             &config.target,
@@ -103,7 +103,7 @@ impl ShareFsMount for VirtiofsShareMount {
                 source: guest_path,
                 fs_type: String::from("bind"),
                 fs_group: None,
-                options: config.mount_options,
+                options: config.mount_options.clone(),
                 mount_point: watchable_guest_mount.clone(),
             };
 
@@ -211,7 +211,7 @@ impl ShareFsMount for VirtiofsShareMount {
         Ok(())
     }
 
-    async fn umount_rootfs(&self, config: ShareFsRootfsConfig) -> Result<()> {
+    async fn umount_rootfs(&self, config: &ShareFsRootfsConfig) -> Result<()> {
         let host_dest = do_get_host_path(&config.target, &self.id, &config.cid, false, false);
         umount_timeout(&host_dest, 0).context("umount rootfs")?;
 

--- a/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
@@ -17,7 +17,7 @@ use std::path::Path;
 
 const WATCHABLE_PATH_NAME: &str = "watchable";
 const WATCHABLE_BIND_DEV_TYPE: &str = "watchable-bind";
-const EPHEMERAL_PATH: &str = "/run/kata-containers/sandbox/ephemeral";
+pub const EPHEMERAL_PATH: &str = "/run/kata-containers/sandbox/ephemeral";
 
 use super::{
     utils::{self, do_get_host_path},

--- a/src/runtime-rs/crates/resource/src/volume/block_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/block_volume.rs
@@ -30,6 +30,7 @@ impl Volume for BlockVolume {
     }
 
     async fn cleanup(&self) -> Result<()> {
+        // TODO: Clean up BlockVolume
         warn!(sl!(), "Cleaning up BlockVolume is still unimplemented.");
         Ok(())
     }

--- a/src/runtime-rs/crates/resource/src/volume/default_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/default_volume.rs
@@ -34,6 +34,7 @@ impl Volume for DefaultVolume {
     }
 
     async fn cleanup(&self) -> Result<()> {
+        // TODO: Clean up DefaultVolume
         warn!(sl!(), "Cleaning up DefaultVolume is still unimplemented.");
         Ok(())
     }

--- a/src/runtime-rs/crates/resource/src/volume/hugepage.rs
+++ b/src/runtime-rs/crates/resource/src/volume/hugepage.rs
@@ -1,0 +1,223 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufRead, BufReader},
+};
+
+use crate::share_fs::EPHEMERAL_PATH;
+use agent::Storage;
+use anyhow::{anyhow, Context, Ok, Result};
+use async_trait::async_trait;
+use byte_unit::Byte;
+use hypervisor::HUGETLBFS;
+use kata_sys_util::{fs::get_base_name, mount::PROC_MOUNTS_FILE};
+use kata_types::mount::KATA_EPHEMERAL_VOLUME_TYPE;
+
+use super::{Volume, BIND};
+
+type PageSize = Byte;
+type Limit = u64;
+
+const NODEV: &str = "nodev";
+
+// container hugepage
+pub(crate) struct Hugepage {
+    // storage info
+    storage: Option<Storage>,
+    // mount info
+    mount: oci::Mount,
+}
+
+// handle hugepage
+impl Hugepage {
+    pub(crate) fn new(
+        mount: &oci::Mount,
+        hugepage_limits_map: HashMap<PageSize, Limit>,
+        fs_options: Vec<String>,
+    ) -> Result<Self> {
+        // Create mount option string
+        let page_size = get_page_size(fs_options).context("failed to get page size")?;
+        let option = hugepage_limits_map
+            .get(&page_size)
+            .map(|limit| format!("pagesize={},size={}", page_size.get_bytes(), limit))
+            .context("failed to get hugepage option")?;
+        let base_name = get_base_name(mount.source.clone())?
+            .into_string()
+            .map_err(|e| anyhow!("failed to convert to string{:?}", e))?;
+        let mut mount = mount.clone();
+        // Set the mount source path to a path that resides inside the VM
+        mount.source = format!("{}{}{}", EPHEMERAL_PATH, "/", base_name);
+        // Set the mount type to "bind"
+        mount.r#type = BIND.to_string();
+
+        // Create a storage struct so that kata agent is able to create
+        // hugetlbfs backed volume inside the VM
+        let storage = Storage {
+            driver: KATA_EPHEMERAL_VOLUME_TYPE.to_string(),
+            source: NODEV.to_string(),
+            fs_type: HUGETLBFS.to_string(),
+            mount_point: mount.source.clone(),
+            options: vec![option],
+            ..Default::default()
+        };
+        Ok(Self {
+            storage: Some(storage),
+            mount,
+        })
+    }
+}
+
+#[async_trait]
+impl Volume for Hugepage {
+    fn get_volume_mount(&self) -> Result<Vec<oci::Mount>> {
+        Ok(vec![self.mount.clone()])
+    }
+
+    fn get_storage(&self) -> Result<Vec<agent::Storage>> {
+        let s = if let Some(s) = self.storage.as_ref() {
+            vec![s.clone()]
+        } else {
+            vec![]
+        };
+        Ok(s)
+    }
+
+    async fn cleanup(&self) -> Result<()> {
+        Ok(())
+    }
+}
+
+pub(crate) fn get_huge_page_option(m: &oci::Mount) -> Result<Option<Vec<String>>> {
+    if m.source.is_empty() {
+        return Err(anyhow!("empty mount source"));
+    }
+    let file = File::open(PROC_MOUNTS_FILE).context("failed open file")?;
+    let reader = BufReader::new(file);
+    for line in reader.lines().flatten() {
+        let items: Vec<&str> = line.split(' ').collect();
+        if m.source == items[1] && items[2] == HUGETLBFS {
+            let fs_options: Vec<&str> = items[3].split(',').collect();
+            return Ok(Some(
+                fs_options
+                    .iter()
+                    .map(|&s| s.to_string())
+                    .collect::<Vec<String>>(),
+            ));
+        }
+    }
+    Ok(None)
+}
+
+// TODO add hugepage limit to sandbox memory once memory hotplug is enabled
+// https://github.com/kata-containers/kata-containers/issues/5880
+pub(crate) fn get_huge_page_limits_map(spec: &oci::Spec) -> Result<HashMap<PageSize, Limit>> {
+    let mut hugepage_limits_map: HashMap<PageSize, Limit> = HashMap::new();
+    if let Some(l) = &spec.linux {
+        if let Some(r) = &l.resources {
+            let hugepage_limits = r.hugepage_limits.clone();
+            for hugepage_limit in hugepage_limits {
+                // the pagesize send from oci spec is MB or GB, change it to Mi and Gi
+                let page_size = hugepage_limit.page_size.replace('B', "i");
+                let page_size = Byte::from_str(page_size)
+                    .context("failed to create Byte object from String")?;
+                hugepage_limits_map.insert(page_size, hugepage_limit.limit);
+            }
+            return Ok(hugepage_limits_map);
+        }
+        return Ok(hugepage_limits_map);
+    }
+    Ok(hugepage_limits_map)
+}
+
+fn get_page_size(fs_options: Vec<String>) -> Result<Byte> {
+    for fs_option in fs_options {
+        if fs_option.starts_with("pagesize=") {
+            let page_size = fs_option
+                .strip_prefix("pagesize=")
+                // the parameters passed are in unit M or G, append i to be Mi and Gi
+                .map(|s| format!("{}i", s))
+                .context("failed to strip prefix pagesize")?;
+            return Byte::from_str(page_size)
+                .map_err(|_| anyhow!("failed to convert string to byte"));
+        }
+    }
+    Err(anyhow!("failed to get page size"))
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::{collections::HashMap, fs};
+
+    use crate::volume::hugepage::{get_page_size, HUGETLBFS, NODEV};
+
+    use super::{get_huge_page_limits_map, get_huge_page_option};
+    use byte_unit::Byte;
+    use nix::mount::{mount, umount, MsFlags};
+    use oci::{Linux, LinuxHugepageLimit, LinuxResources};
+    use test_utils::skip_if_not_root;
+
+    #[test]
+    fn test_get_huge_page_option() {
+        let format_sizes = ["1GB", "2MB"];
+        let mut huge_page_limits: Vec<LinuxHugepageLimit> = vec![];
+        for format_size in format_sizes {
+            huge_page_limits.push(LinuxHugepageLimit {
+                page_size: format_size.to_string(),
+                limit: 100000,
+            });
+        }
+
+        let spec = oci::Spec {
+            linux: Some(Linux {
+                resources: Some(LinuxResources {
+                    hugepage_limits: huge_page_limits,
+                    ..Default::default()
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert!(get_huge_page_limits_map(&spec).is_ok());
+
+        let mut expect_res = HashMap::new();
+        expect_res.insert(Byte::from_str("1Gi").ok().unwrap(), 100000);
+        expect_res.insert(Byte::from_str("2Mi").ok().unwrap(), 100000);
+        assert_eq!(get_huge_page_limits_map(&spec).unwrap(), expect_res);
+    }
+
+    #[test]
+    fn test_get_huge_page_size() {
+        skip_if_not_root!();
+        let format_sizes = ["1Gi", "2Mi"];
+        for format_size in format_sizes {
+            let dir = tempfile::tempdir().unwrap();
+            let dst = dir.path().join(format!("hugepages-{}", format_size));
+            fs::create_dir_all(&dst).unwrap();
+            mount(
+                Some(NODEV),
+                &dst,
+                Some(HUGETLBFS),
+                MsFlags::MS_NODEV,
+                Some(format!("pagesize={}", format_size).as_str()),
+            )
+            .unwrap();
+            let mount = oci::Mount {
+                source: dst.to_str().unwrap().to_string(),
+                ..Default::default()
+            };
+            let option = get_huge_page_option(&mount).unwrap().unwrap();
+            let page_size = get_page_size(option).unwrap();
+            assert_eq!(page_size, Byte::from_str(format_size).unwrap());
+            umount(&dst).unwrap();
+            fs::remove_dir(&dst).unwrap();
+        }
+    }
+}

--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -112,7 +112,7 @@ impl ShareFsVolume {
                 } else {
                     // Not mounted ever
                     let mount_result = share_fs_mount
-                        .share_volume(ShareFsVolumeConfig {
+                        .share_volume(&ShareFsVolumeConfig {
                             // The scope of shared volume is sandbox
                             cid: String::from(""),
                             source: m.source.clone(),
@@ -158,10 +158,10 @@ impl Volume for ShareFsVolume {
     }
 
     async fn cleanup(&self) -> Result<()> {
-        if self.share_fs.is_none() {
-            return Ok(());
-        }
-        let share_fs = self.share_fs.as_ref().unwrap();
+        let share_fs = match self.share_fs.as_ref() {
+            Some(fs) => fs,
+            None => return Ok(()),
+        };
 
         let mounted_info_set = share_fs.mounted_info_set();
         let mut mounted_info_set = mounted_info_set.lock().await;

--- a/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
@@ -100,6 +100,7 @@ impl Volume for ShmVolume {
     }
 
     async fn cleanup(&self) -> Result<()> {
+        // TODO: Clean up ShmVolume
         warn!(sl!(), "Cleaning up ShmVolume is still unimplemented.");
         Ok(())
     }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -119,7 +119,7 @@ impl Container {
         // handler volumes
         let volumes = self
             .resource_manager
-            .handler_volumes(&config.container_id, &spec.mounts)
+            .handler_volumes(&config.container_id, &spec)
             .await
             .context("handler volumes")?;
         let mut oci_mounts = vec![];
@@ -400,7 +400,6 @@ fn amend_spec(spec: &mut oci::Spec, disable_guest_seccomp: bool) -> Result<()> {
             resource.devices = Vec::new();
             resource.pids = None;
             resource.block_io = None;
-            resource.hugepage_limits = Vec::new();
             resource.network = None;
             resource.rdma = HashMap::new();
         }

--- a/src/tools/kata-ctl/Cargo.lock
+++ b/src/tools/kata-ctl/Cargo.lock
@@ -1382,6 +1382,7 @@ dependencies = [
  "seccompiler",
  "serde",
  "serde_json",
+ "shim-interface",
  "slog",
  "slog-scope",
  "thiserror",
@@ -1512,6 +1513,9 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "clap",
+ "epoll",
+ "glob",
+ "libc",
  "nix 0.25.0",
  "privdrop",
  "reqwest",
@@ -1519,10 +1523,13 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "slog",
+ "slog-scope",
  "strum",
  "strum_macros",
  "tempfile",
  "thiserror",
+ "vmm-sys-util 0.11.0",
 ]
 
 [[package]]
@@ -1606,9 +1613,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.135"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68783febc7782c6c5cb401fbda4de5a9898be1762314da0bb2c10ced61f18b0c"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "link-cplusplus"
@@ -2188,6 +2195,7 @@ dependencies = [
  "safe-path",
  "serde",
  "serde_json",
+ "shim-interface",
 ]
 
 [[package]]
@@ -2717,6 +2725,7 @@ dependencies = [
  "logging",
  "oci",
  "persist",
+ "shim-interface",
  "slog",
  "slog-scope",
  "tokio",
@@ -2911,6 +2920,16 @@ dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "shim-interface"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "hyper",
+ "hyperlocal",
+ "tokio",
 ]
 
 [[package]]

--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -24,6 +24,12 @@ strum_macros = "0.24.3"
 
 runtimes = { path = "../../runtime-rs/crates/runtimes" }
 serde = "1.0.149"
+vmm-sys-util = "0.11.0"
+epoll = "4.0.1"
+glob = ">=0.3.0"
+libc = "0.2.138"
+slog = "2.7.0"
+slog-scope = "4.4.0"
 
 [target.'cfg(target_arch = "s390x")'.dependencies]
 reqwest = { version = "0.11", default-features = false, features = ["json", "blocking", "native-tls"] }

--- a/src/tools/kata-ctl/src/args.rs
+++ b/src/tools/kata-ctl/src/args.rs
@@ -26,7 +26,7 @@ pub enum Commands {
     Env,
 
     /// Enter into guest VM by debug console
-    Exec,
+    Exec(ExecArguments),
 
     /// Manage VM factory
     Factory,
@@ -92,4 +92,15 @@ pub struct IptablesCommand {
 pub enum IpTablesArguments {
     /// Configure iptables
     Metrics,
+}
+
+#[derive(Debug, Args, Error)]
+#[error("Argument is not valid")]
+pub struct ExecArguments {
+    #[clap(short, long, forbid_empty_values = true)]
+    /// pod sandbox ID or pouch container ID
+    pub sandbox_id: String,
+    #[clap(short = 'p', long, default_value_t = 1026)]
+    /// hvsock debug port, default is 1026.
+    pub vport: u64,
 }

--- a/src/tools/kata-ctl/src/exec.rs
+++ b/src/tools/kata-ctl/src/exec.rs
@@ -1,0 +1,330 @@
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::{
+    io::{self, BufRead, BufReader, Read, Write},
+    os::unix::{
+        io::{AsRawFd, RawFd},
+        net::UnixStream,
+    },
+    path::PathBuf,
+    time::Duration,
+};
+
+use anyhow::anyhow;
+use glob::glob;
+use serde::{Deserialize, Serialize};
+use slog::debug;
+use vmm_sys_util::terminal::Terminal;
+
+const KATA_RUN_PATH: &str = "/run/kata";
+const KATA_HYBRID_VSOCK: &str = "kata.hvsock";
+const CONNECT_CMD: &str = "CONNECT";
+const OK_CMD: &str = "OK";
+
+// 5 seconds
+const KATA_AGENT_VSOCK_TIMEOUT: u64 = 5;
+
+// Convenience macro to obtain the scope logger
+#[macro_export]
+macro_rules! sl {
+    () => {
+        slog_scope::logger()
+    };
+}
+
+#[derive(Debug)]
+pub enum Error {
+    EpollWait(io::Error),
+    EpollCreate(io::Error),
+    EpollAdd(io::Error),
+    SocketWrite(io::Error),
+    StdioErr(io::Error),
+}
+
+type Result<T> = std::result::Result<T, Error>;
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    pub server_address: String,
+    pub hybrid_vsock: bool,
+    pub hybrid_vsock_port: u64,
+    pub bundle_dir: String,
+    pub interactive: bool,
+}
+
+enum EpollDispatch {
+    Stdin,
+    ServerSock,
+}
+
+struct EpollContext {
+    epoll_raw_fd: RawFd,
+    stdin_index: u64,
+    dispatch_table: Vec<EpollDispatch>,
+    stdin_handle: io::Stdin,
+    debug_console_sock: Option<UnixStream>,
+}
+
+impl EpollContext {
+    fn new() -> Result<Self> {
+        let epoll_raw_fd = epoll::create(true).map_err(Error::EpollCreate)?;
+        let dispatch_table = Vec::with_capacity(2);
+        let stdin_index = 0;
+
+        Ok(EpollContext {
+            epoll_raw_fd,
+            stdin_index,
+            dispatch_table,
+            stdin_handle: io::stdin(),
+            debug_console_sock: None,
+        })
+    }
+
+    fn enable_debug_console_sock(&mut self, sock: UnixStream) -> Result<()> {
+        let dispatch_index = self.dispatch_table.len() as u64;
+        epoll::ctl(
+            self.epoll_raw_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            sock.as_raw_fd(),
+            epoll::Event::new(epoll::Events::EPOLLIN, dispatch_index),
+        )
+        .map_err(Error::EpollAdd)?;
+
+        self.dispatch_table.push(EpollDispatch::ServerSock);
+        self.debug_console_sock = Some(sock);
+
+        Ok(())
+    }
+
+    fn enable_stdin_event(&mut self) -> Result<()> {
+        let stdin_index = self.dispatch_table.len() as u64;
+        epoll::ctl(
+            self.epoll_raw_fd,
+            epoll::ControlOptions::EPOLL_CTL_ADD,
+            libc::STDIN_FILENO,
+            epoll::Event::new(epoll::Events::EPOLLIN, stdin_index),
+        )
+        .map_err(Error::EpollAdd)?;
+
+        self.stdin_index = stdin_index;
+        self.dispatch_table.push(EpollDispatch::Stdin);
+
+        Ok(())
+    }
+
+    fn do_exit(&self) {
+        self.stdin_handle
+            .lock()
+            .set_canon_mode()
+            .expect("Fail to set stdin to RAW mode");
+    }
+
+    fn process_handler(&mut self) -> Result<()> {
+        const EPOLL_EVENTS_LEN: usize = 16;
+        let mut events = vec![epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
+
+        let epoll_raw_fd = self.epoll_raw_fd;
+        let debug_console_sock = self.debug_console_sock.as_mut().unwrap();
+
+        loop {
+            let num_events =
+                epoll::wait(epoll_raw_fd, -1, &mut events[..]).map_err(Error::EpollWait)?;
+
+            for event in events.iter().take(num_events) {
+                let dispatch_index = event.data as usize;
+                match self.dispatch_table[dispatch_index] {
+                    EpollDispatch::Stdin => {
+                        let mut out = [0u8; 128];
+                        let stdin_lock = self.stdin_handle.lock();
+                        match stdin_lock.read_raw(&mut out[..]) {
+                            Ok(0) => {
+                                return Ok(());
+                            }
+                            Err(_e) => {
+                                return Ok(());
+                            }
+                            Ok(count) => {
+                                debug_console_sock
+                                    .write(&out[..count])
+                                    .map_err(Error::SocketWrite)?;
+                            }
+                        }
+                    }
+                    EpollDispatch::ServerSock => {
+                        let mut out = [0u8; 128];
+                        match debug_console_sock.read(&mut out[..]) {
+                            Ok(0) => {
+                                return Ok(());
+                            }
+                            Err(_e) => {
+                                println!("error while reading server");
+                                return Ok(());
+                            }
+                            Ok(count) => {
+                                io::stdout()
+                                    .write_all(&out[..count])
+                                    .map_err(Error::StdioErr)?;
+                                io::stdout().flush().map_err(Error::StdioErr)?;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn setup_hybrid_vsock(
+    stdin_handle: io::Stdin,
+    mut stream: &UnixStream,
+    hybrid_vsock_port: u64,
+) -> anyhow::Result<()> {
+    let msg = format!("{} {}\n", CONNECT_CMD, hybrid_vsock_port);
+
+    stream.set_read_timeout(Some(Duration::new(KATA_AGENT_VSOCK_TIMEOUT, 0)))?;
+    stream.set_write_timeout(Some(Duration::new(KATA_AGENT_VSOCK_TIMEOUT, 0)))?;
+
+    stream.write_all(msg.as_bytes())?;
+
+    // Now, see if we get the expected response
+    let stream_reader = stream.try_clone()?;
+    let mut reader = BufReader::new(&stream_reader);
+
+    let mut msg = String::new();
+    reader.read_line(&mut msg)?;
+    if msg.is_empty() {
+        stdin_handle
+            .lock()
+            .set_canon_mode()
+            .expect("Fail to set stdin to Cannon mode in setup_hybrid_vsock.");
+
+        return Err(anyhow!("stream reader get message is empty"));
+    }
+
+    if msg.starts_with(OK_CMD) {
+        let response = msg
+            .strip_prefix(OK_CMD)
+            .ok_or(format!("invalid response: {:?}", msg))
+            .map_err(|e| anyhow!(e))?
+            .trim();
+        debug!(sl!(), "Hybrid Vsock host-side port: {:?}", response);
+        // Unset the timeout in order to turn the sokect to bloking mode.
+        stream.set_read_timeout(None)?;
+        stream.set_write_timeout(None)?;
+    } else {
+        stdin_handle
+            .lock()
+            .set_canon_mode()
+            .expect("Fail to set stdin to Canon mode in starts_with");
+
+        return Err(anyhow!(
+            "failed to setup Hybrid Vsock connection: response was: {:?}",
+            msg
+        ));
+    }
+
+    Ok(())
+}
+
+fn create_ttrpc_socket(
+    stdin_handle: io::Stdin,
+    server_addr: String,
+    hybrid_vsock_port: u64,
+) -> anyhow::Result<UnixStream> {
+    let stream = match UnixStream::connect(server_addr) {
+        Ok(s) => s,
+        Err(e) => {
+            return Err(anyhow!(e).context("failed to create named UNIX Domain stream socket"))
+        }
+    };
+
+    // when vport > 0, setup hvsock.
+    if hybrid_vsock_port > 0 {
+        setup_hybrid_vsock(stdin_handle, &stream, hybrid_vsock_port)?
+    }
+
+    Ok(stream)
+}
+
+fn debug_console_uds(sid: &str) -> PathBuf {
+    // we use pattern to get the full sandbox run path,
+    // eg. pattern: `/run/kata/02abcd*`. As sandbox_id is unique,
+    // so iterator will do once, and the entry will be the path we want.
+    let sandbox_id = format!("{}{}", sid, "*");
+
+    // ${KATA_RUN_PATH}/root/{SANDBOX_ID}/kata.hvsock will be the path.
+    let sandbox_path: String = [
+        KATA_RUN_PATH,
+        sandbox_id.as_str(),
+        "root",
+        KATA_HYBRID_VSOCK,
+    ]
+    .join("/");
+
+    glob(sandbox_path.as_str())
+        .unwrap()
+        .filter_map(std::result::Result::ok)
+        .last()
+        .unwrap_or_else(|| PathBuf::from(sandbox_path.as_str()))
+}
+
+pub fn do_run_exec(sandbox_id: &str, debug_port: u64) -> anyhow::Result<()> {
+    let server_addr = debug_console_uds(sandbox_id)
+        .into_os_string()
+        .into_string()
+        .unwrap();
+
+    if !PathBuf::from(server_addr.clone()).exists() {
+        return Err(anyhow!("sandbox with run path {:?} not found", server_addr));
+    }
+
+    let mut epoll_context = EpollContext::new().expect("Fail to create epoll");
+    let stdin_handle = io::stdin();
+    epoll_context
+        .enable_stdin_event()
+        .expect("Fail to enable stdin");
+
+    let sock_addr: UnixStream = {
+        println!("Hybrid Vsock Mode");
+        stdin_handle
+            .lock()
+            .set_raw_mode()
+            .expect("Fail to set stdin to RAW mode");
+
+        // by kata agent hvsock
+        create_ttrpc_socket(stdin_handle, server_addr, debug_port)?
+    };
+
+    epoll_context
+        .enable_debug_console_sock(sock_addr)
+        .expect("Fail to connect to the server");
+
+    epoll_context.process_handler().unwrap_or_default();
+    epoll_context.do_exit();
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{self, File};
+    use std::os::unix::io::AsRawFd;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_debug_console_uds() {
+        let sandbox_id = "0x01-test-kata-exec-001";
+        let sid = "0x01";
+
+        let sandbox01 = [KATA_RUN_PATH, sandbox_id, "root", KATA_HYBRID_VSOCK].join("/");
+        let _f = File::create(sandbox01)?;
+
+        let target_path = debug_console_uds(sid);
+        assert_eq!(target_path, PathBuf::from(sandbox01));
+
+        fs::remove_file(sandbox01)?;
+    }
+}

--- a/src/tools/kata-ctl/src/main.rs
+++ b/src/tools/kata-ctl/src/main.rs
@@ -6,6 +6,7 @@
 mod arch;
 mod args;
 mod check;
+mod exec;
 mod ops;
 mod types;
 mod utils;
@@ -28,7 +29,7 @@ fn real_main() -> Result<()> {
         Commands::Check(args) => handle_check(args),
         Commands::DirectVolume => handle_check_volume(),
         Commands::Env => handle_env(),
-        Commands::Exec => handle_exec(),
+        Commands::Exec(args) => handle_exec(args),
         Commands::Factory => handle_factory(),
         Commands::Iptables(args) => handle_iptables(args),
         Commands::Metrics(args) => handle_metrics(args),

--- a/src/tools/kata-ctl/src/ops/check_ops.rs
+++ b/src/tools/kata-ctl/src/ops/check_ops.rs
@@ -5,9 +5,10 @@
 
 use crate::arch::arch_specific::get_checks;
 
-use crate::args::{CheckArgument, CheckSubCommand, IptablesCommand, MetricsCommand};
+use crate::args::{CheckArgument, CheckSubCommand, ExecArguments, IptablesCommand, MetricsCommand};
 
 use crate::check;
+use crate::exec;
 
 use crate::ops::version;
 
@@ -122,7 +123,9 @@ pub fn handle_env() -> Result<()> {
     Ok(())
 }
 
-pub fn handle_exec() -> Result<()> {
+pub fn handle_exec(exec_args: ExecArguments) -> Result<()> {
+    exec::do_run_exec(exec_args.sandbox_id.as_str(), exec_args.vport)?;
+
     Ok(())
 }
 


### PR DESCRIPTION
The patchset will help users to easily enter guest VM
by debug console with kata.hvsock.

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>