### PR TITLE
runtime-rs: remove redundant sections in the config file

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -12,9 +12,6 @@ use std::u32;
 
 use serde::Deserialize;
 
-use crate::config::default::DEFAULT_AGENT_TYPE_NAME;
-use crate::config::default::DEFAULT_HYPERVISOR;
-use crate::config::default::DEFAULT_RUNTIME_NAME;
 use crate::config::hypervisor::get_hypervisor_plugin;
 
 use crate::config::TomlConfig;
@@ -433,26 +430,21 @@ impl Annotation {
 impl Annotation {
     /// update config info by annotation
     pub fn update_config_by_annotation(&self, config: &mut TomlConfig) -> Result<()> {
+        // change the default runtime by annotation
+        if let Some(name) = self.annotations.get(KATA_ANNO_CFG_RUNTIME_NAME) {
+            config.runtime.name = name.to_string();
+        }
+        // change the default hypervisor by annotation
         if let Some(hv) = self.annotations.get(KATA_ANNO_CFG_RUNTIME_HYPERVISOR) {
             if config.hypervisor.get(hv).is_some() {
                 config.runtime.hypervisor_name = hv.to_string();
             }
         }
+        // change the default agent by annotation
         if let Some(ag) = self.annotations.get(KATA_ANNO_CFG_RUNTIME_AGENT) {
             if config.agent.get(ag).is_some() {
                 config.runtime.agent_name = ag.to_string();
             }
-        }
-
-        // set default values for runtime.name, runtime.hypervisor_name and runtime.agent
-        if config.runtime.name.is_empty() {
-            config.runtime.name = DEFAULT_RUNTIME_NAME.to_string()
-        }
-        if config.runtime.hypervisor_name.is_empty() {
-            config.runtime.hypervisor_name = DEFAULT_HYPERVISOR.to_string()
-        }
-        if config.runtime.agent_name.is_empty() {
-            config.runtime.agent_name = DEFAULT_AGENT_TYPE_NAME.to_string()
         }
 
         let hypervisor_name = &config.runtime.hypervisor_name;

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -207,8 +207,6 @@ container_pipe_size=@PIPESIZE@
 internetworking_model="@DEFNETWORKMODEL_DB@"
 
 name="@RUNTIMENAME@"
-hypervisor_name="@HYPERVISOR_DB@"
-agent_name="@PROJECT_TYPE@"
 
 # disable guest seccomp
 # Determines whether container seccomp profiles are passed to the virtual


### PR DESCRIPTION
1. we use annotation to choose which hypervisor and agent to use if multiple hypervisors and agents are configured in the same file

2. use the default hypervisor and agent if annotation is not set

Fixes: #5954
Signed-off-by: Zhongtao Hu <zhongtaohu.tim@linux.alibaba.com>