### PR TITLE
CCv0: agent: validate cid using oci-distribution crate

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -2385,6 +2385,7 @@ dependencies = [
  "netlink-sys",
  "nix 0.24.3",
  "oci",
+ "oci-distribution",
  "openssl",
  "opentelemetry",
  "procfs 0.12.0",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -24,6 +24,7 @@ serial_test = "0.5.1"
 kata-sys-util = { path = "../libs/kata-sys-util" }
 kata-types = { path = "../libs/kata-types" }
 url = "2.2.2"
+oci-distribution = "0.9.4"
 
 # Async helpers
 async-trait = "0.1.42"


### PR DESCRIPTION
which is also used by image-rs, that will allow support in container images digest

Fixes: #5961
Signed-off-by: Snir Sheriber <ssheribe@redhat.com>