### PR TITLE
versions: Update the rust toolchain to 1.66.0

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -782,7 +782,7 @@ fn mount_from(
             Path::new(&dest).parent().unwrap()
         };
 
-        fs::create_dir_all(&dir).map_err(|e| {
+        fs::create_dir_all(dir).map_err(|e| {
             log_child!(
                 cfd_log,
                 "create dir {}: {}",

--- a/src/agent/rustjail/src/seccomp.rs
+++ b/src/agent/rustjail/src/seccomp.rs
@@ -63,7 +63,7 @@ pub fn get_unknown_syscalls(scmp: &LinuxSeccomp) -> Option<Vec<String>> {
 // init_seccomp creates a seccomp filter and loads it for the current process
 // including all the child processes.
 pub fn init_seccomp(scmp: &LinuxSeccomp) -> Result<()> {
-    let def_action = ScmpAction::from_str(scmp.default_action.as_str(), Some(libc::EPERM as i32))?;
+    let def_action = ScmpAction::from_str(scmp.default_action.as_str(), Some(libc::EPERM))?;
 
     // Create a new filter context
     let mut filter = ScmpFilterContext::new_filter(def_action)?;

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -414,7 +414,7 @@ fn scan_scsi_bus(scsi_addr: &str) -> Result<()> {
 
     // Scan scsi host passing in the channel, SCSI id and LUN.
     // Channel is always 0 because we have only one SCSI controller.
-    let scan_data = format!("0 {} {}", tokens[0], tokens[1]);
+    let scan_data = &format!("0 {} {}", tokens[0], tokens[1]);
 
     for entry in fs::read_dir(SYSFS_SCSI_HOST_PATH)? {
         let host = entry?.file_name();
@@ -428,7 +428,7 @@ fn scan_scsi_bus(scsi_addr: &str) -> Result<()> {
 
         let scan_path = PathBuf::from(&format!("{}/{}/{}", SYSFS_SCSI_HOST_PATH, host_str, "scan"));
 
-        fs::write(scan_path, &scan_data)?;
+        fs::write(scan_path, scan_data)?;
     }
 
     Ok(())
@@ -1531,7 +1531,7 @@ mod tests {
         pci_driver_override(syspci, dev0, "drv_b").unwrap();
         assert_eq!(fs::read_to_string(&dev0override).unwrap(), "drv_b");
         assert_eq!(fs::read_to_string(&probepath).unwrap(), dev0.to_string());
-        assert_eq!(fs::read_to_string(&drvaunbind).unwrap(), dev0.to_string());
+        assert_eq!(fs::read_to_string(drvaunbind).unwrap(), dev0.to_string());
     }
 
     #[test]
@@ -1543,7 +1543,7 @@ mod tests {
         let dev0 = pci::Address::new(0, 0, pci::SlotFn::new(0, 0).unwrap());
         let dev0path = syspci.join("devices").join(dev0.to_string());
 
-        fs::create_dir_all(&dev0path).unwrap();
+        fs::create_dir_all(dev0path).unwrap();
 
         // Test dev0
         assert!(pci_iommu_group(&syspci, dev0).unwrap().is_none());
@@ -1554,7 +1554,7 @@ mod tests {
         let dev1group = dev1path.join("iommu_group");
 
         fs::create_dir_all(&dev1path).unwrap();
-        std::os::unix::fs::symlink("../../../kernel/iommu_groups/12", &dev1group).unwrap();
+        std::os::unix::fs::symlink("../../../kernel/iommu_groups/12", dev1group).unwrap();
 
         // Test dev1
         assert_eq!(
@@ -1567,7 +1567,7 @@ mod tests {
         let dev2path = syspci.join("devices").join(dev2.to_string());
         let dev2group = dev2path.join("iommu_group");
 
-        fs::create_dir_all(&dev2group).unwrap();
+        fs::create_dir_all(dev2group).unwrap();
 
         // Test dev2
         assert!(pci_iommu_group(&syspci, dev2).is_err());

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -648,7 +648,7 @@ pub fn recursive_ownership_change(
 ) -> Result<()> {
     let mut mask = if read_only { RO_MASK } else { RW_MASK };
     if path.is_dir() {
-        for entry in fs::read_dir(&path)? {
+        for entry in fs::read_dir(path)? {
             recursive_ownership_change(entry?.path().as_path(), uid, gid, read_only)?;
         }
         mask |= EXEC_MASK;
@@ -894,7 +894,7 @@ pub fn get_cgroup_mounts(
         }]);
     }
 
-    let file = File::open(&cg_path)?;
+    let file = File::open(cg_path)?;
     let reader = BufReader::new(file);
 
     let mut has_device_cgroup = false;
@@ -1777,7 +1777,7 @@ mod tests {
             let tempdir = tempdir().unwrap();
 
             let src = if d.mask_src {
-                tempdir.path().join(&d.src)
+                tempdir.path().join(d.src)
             } else {
                 Path::new(d.src).to_path_buf()
             };

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -78,6 +78,7 @@ impl Namespace {
     // setup creates persistent namespace without switching to it.
     // Note, pid namespaces cannot be persisted.
     #[instrument]
+    #[allow(clippy::question_mark)]
     pub async fn setup(mut self) -> Result<Self> {
         fs::create_dir_all(&self.persistent_ns_dir)?;
 

--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -88,7 +88,7 @@ impl Namespace {
         }
         let logger = self.logger.clone();
 
-        let new_ns_path = ns_path.join(&ns_type.get());
+        let new_ns_path = ns_path.join(ns_type.get());
 
         File::create(new_ns_path.as_path())?;
 
@@ -102,7 +102,7 @@ impl Namespace {
                 let source = Path::new(&origin_ns_path);
                 let destination = new_ns_path.as_path();
 
-                File::open(&source)?;
+                File::open(source)?;
 
                 // Create a new netns on the current thread.
                 let cf = ns_type.get_flags();

--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -946,13 +946,13 @@ mod tests {
     fn clean_env_for_test_add_one_arp_neighbor(dummy_name: &str, ip: &str) {
         // ip link delete dummy
         Command::new("ip")
-            .args(&["link", "delete", dummy_name])
+            .args(["link", "delete", dummy_name])
             .output()
             .expect("prepare: failed to delete dummy");
 
         // ip neigh del dev dummy ip
         Command::new("ip")
-            .args(&["neigh", "del", dummy_name, ip])
+            .args(["neigh", "del", dummy_name, ip])
             .output()
             .expect("prepare: failed to delete neigh");
     }
@@ -967,19 +967,19 @@ mod tests {
 
         // ip link add dummy type dummy
         Command::new("ip")
-            .args(&["link", "add", dummy_name, "type", "dummy"])
+            .args(["link", "add", dummy_name, "type", "dummy"])
             .output()
             .expect("failed to add dummy interface");
 
         // ip addr add 192.168.0.2/16 dev dummy
         Command::new("ip")
-            .args(&["addr", "add", "192.168.0.2/16", "dev", dummy_name])
+            .args(["addr", "add", "192.168.0.2/16", "dev", dummy_name])
             .output()
             .expect("failed to add ip for dummy");
 
         // ip link set dummy up;
         Command::new("ip")
-            .args(&["link", "set", dummy_name, "up"])
+            .args(["link", "set", dummy_name, "up"])
             .output()
             .expect("failed to up dummy");
     }
@@ -1011,7 +1011,7 @@ mod tests {
 
         // ip neigh show dev dummy ip
         let stdout = Command::new("ip")
-            .args(&["neigh", "show", "dev", dummy_name, to_ip])
+            .args(["neigh", "show", "dev", dummy_name, to_ip])
             .output()
             .expect("failed to show neigh")
             .stdout;

--- a/src/agent/src/network.rs
+++ b/src/agent/src/network.rs
@@ -64,7 +64,7 @@ fn do_setup_guest_dns(logger: Logger, dns_list: Vec<String>, src: &str, dst: &st
         .map(|x| x.trim())
         .collect::<Vec<&str>>()
         .join("\n");
-    fs::write(src, &content)?;
+    fs::write(src, content)?;
 
     // bind mount to /etc/resolv.conf
     mount::mount(Some(src), dst, Some("bind"), MsFlags::MS_BIND, None::<&str>)

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -2903,7 +2903,7 @@ COMMIT
             .unwrap();
         assert!(!result.data.is_empty(), "we should have non-zero output:");
         assert!(
-            std::str::from_utf8(&*result.data).unwrap().contains(
+            std::str::from_utf8(&result.data).unwrap().contains(
                 "PREROUTING -d 192.168.103.153/32 -j DNAT --to-destination 192.168.188.153"
             ),
             "We should see the resulting rule"
@@ -2941,7 +2941,7 @@ COMMIT
             .unwrap();
         assert!(!result.data.is_empty(), "we should have non-zero output:");
         assert!(
-            std::str::from_utf8(&*result.data)
+            std::str::from_utf8(&result.data)
                 .unwrap()
                 .contains("INPUT -s 2001:db8:100::1/128 -i sit+ -p tcp -m tcp --sport 512:65535"),
             "We should see the resulting rule"

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -1072,7 +1072,7 @@ mod tests {
                 fs::create_dir(&subdir_path).unwrap();
                 for file in j.files {
                     let subfile_path = format!("{}/{}", subdir_path, file.name);
-                    let mut subfile = File::create(&subfile_path).unwrap();
+                    let mut subfile = File::create(subfile_path).unwrap();
                     subfile.write_all(file.content.as_bytes()).unwrap();
                 }
             }

--- a/src/agent/src/watcher.rs
+++ b/src/agent/src/watcher.rs
@@ -124,7 +124,7 @@ impl Storage {
 
         // if we are creating a directory: just create it, nothing more to do
         if metadata.file_type().is_dir() {
-            let dest_file_path = self.make_target_path(&source_file_path)?;
+            let dest_file_path = self.make_target_path(source_file_path)?;
 
             fs::create_dir_all(&dest_file_path)
                 .await
@@ -152,7 +152,7 @@ impl Storage {
             // Assume target mount is a file path
             self.target_mount_point.clone()
         } else {
-            let dest_file_path = self.make_target_path(&source_file_path)?;
+            let dest_file_path = self.make_target_path(source_file_path)?;
 
             if let Some(path) = dest_file_path.parent() {
                 debug!(logger, "Creating destination directory: {}", path.display());
@@ -778,7 +778,7 @@ mod tests {
             22
         );
         assert_eq!(
-            fs::read_to_string(&entries.0[0].target_mount_point.as_path().join("1.txt")).unwrap(),
+            fs::read_to_string(entries.0[0].target_mount_point.as_path().join("1.txt")).unwrap(),
             "updated"
         );
 
@@ -823,7 +823,7 @@ mod tests {
             2
         );
         assert_eq!(
-            fs::read_to_string(&entries.0[1].target_mount_point.as_path().join("foo.txt")).unwrap(),
+            fs::read_to_string(entries.0[1].target_mount_point.as_path().join("foo.txt")).unwrap(),
             "updated"
         );
 
@@ -1000,7 +1000,7 @@ mod tests {
 
         // create a path we'll remove later
         fs::create_dir_all(source_dir.path().join("tmp")).unwrap();
-        fs::write(&source_dir.path().join("tmp/test-file"), "foo").unwrap();
+        fs::write(source_dir.path().join("tmp/test-file"), "foo").unwrap();
         assert_eq!(entry.scan(&logger).await.unwrap(), 3); // root, ./tmp, test-file
 
         // Verify expected directory, file:

--- a/src/dragonball/src/address_space_manager.rs
+++ b/src/dragonball/src/address_space_manager.rs
@@ -401,9 +401,9 @@ impl AddressSpaceMgr {
             let flags = 0u32;
 
             let mem_region = kvm_userspace_memory_region {
-                slot: slot as u32,
+                slot,
                 guest_phys_addr: reg.start_addr().raw_value(),
-                memory_size: reg.len() as u64,
+                memory_size: reg.len(),
                 userspace_addr: host_addr as u64,
                 flags,
             };
@@ -421,7 +421,7 @@ impl AddressSpaceMgr {
         self.base_to_slot
             .lock()
             .unwrap()
-            .insert(reg.start_addr().raw_value(), slot as u32);
+            .insert(reg.start_addr().raw_value(), slot);
 
         Ok(())
     }

--- a/src/dragonball/src/resource_manager.rs
+++ b/src/dragonball/src/resource_manager.rs
@@ -420,6 +420,7 @@ impl ResourceManager {
     }
 
     /// Allocate requested resources for a device.
+    #[allow(clippy::question_mark)]
     pub fn allocate_device_resources(
         &self,
         requests: &[ResourceConstraint],

--- a/src/dragonball/src/resource_manager.rs
+++ b/src/dragonball/src/resource_manager.rs
@@ -435,10 +435,7 @@ impl ResourceManager {
                         constraint.max = r.1 as u64;
                     }
                     match self.allocate_pio_address(&constraint) {
-                        Some(base) => Resource::PioAddressRange {
-                            base: base as u16,
-                            size: *size,
-                        },
+                        Some(base) => Resource::PioAddressRange { base, size: *size },
                         None => {
                             if let Err(e) = self.free_device_resources(&resources) {
                                 return Err(e);

--- a/src/dragonball/src/signal_handler.rs
+++ b/src/dragonball/src/signal_handler.rs
@@ -41,7 +41,7 @@ extern "C" fn sigsys_handler(num: c_int, info: *mut siginfo_t, _unused: *mut c_v
     let si_code = unsafe { (*info).si_code };
 
     // Sanity check. The condition should never be true.
-    if num != si_signo || num != SIGSYS || si_code != SYS_SECCOMP_CODE as i32 {
+    if num != si_signo || num != SIGSYS || si_code != SYS_SECCOMP_CODE {
         // Safe because we're terminating the process anyway.
         unsafe { _exit(i32::from(super::EXIT_CODE_UNEXPECTED_ERROR)) };
     }

--- a/src/dragonball/src/vcpu/x86_64.rs
+++ b/src/dragonball/src/vcpu/x86_64.rs
@@ -96,14 +96,14 @@ impl Vcpu {
         if let Some(start_addr) = kernel_start_addr {
             dbs_arch::regs::setup_regs(
                 &self.fd,
-                start_addr.raw_value() as u64,
+                start_addr.raw_value(),
                 dbs_boot::layout::BOOT_STACK_POINTER,
                 dbs_boot::layout::BOOT_STACK_POINTER,
                 dbs_boot::layout::ZERO_PAGE_START,
             )
             .map_err(VcpuError::REGSConfiguration)?;
             dbs_arch::regs::setup_fpu(&self.fd).map_err(VcpuError::FPUConfiguration)?;
-            let gdt_table: [u64; dbs_boot::layout::BOOT_GDT_MAX as usize] = [
+            let gdt_table: [u64; dbs_boot::layout::BOOT_GDT_MAX] = [
                 gdt_entry(0, 0, 0),            // NULL
                 gdt_entry(0xa09b, 0, 0xfffff), // CODE
                 gdt_entry(0xc093, 0, 0xfffff), // DATA
@@ -129,7 +129,7 @@ impl Vcpu {
     fn set_cpuid(&mut self, vcpu_config: &VcpuConfig) -> Result<()> {
         let cpuid_vm_spec = VmSpec::new(
             self.id,
-            vcpu_config.max_vcpu_count as u8,
+            vcpu_config.max_vcpu_count,
             vcpu_config.threads_per_core,
             vcpu_config.cores_per_die,
             vcpu_config.dies_per_socket,

--- a/src/dragonball/src/vm/x86_64.rs
+++ b/src/dragonball/src/vm/x86_64.rs
@@ -81,10 +81,10 @@ fn configure_system<M: GuestMemory>(
     if mem_end < mmio_start {
         add_e820_entry(
             &mut params.0,
-            himem_start.raw_value() as u64,
+            himem_start.raw_value(),
             // it's safe to use unchecked_offset_from because
             // mem_end > himem_start
-            mem_end.unchecked_offset_from(himem_start) as u64 + 1,
+            mem_end.unchecked_offset_from(himem_start) + 1,
             bootparam::E820_RAM,
         )
         .map_err(Error::BootSystem)?;
@@ -103,7 +103,7 @@ fn configure_system<M: GuestMemory>(
                 &mut params.0,
                 mmio_end.raw_value() + 1,
                 // it's safe to use unchecked_offset_from because mem_end > mmio_end
-                mem_end.unchecked_offset_from(mmio_end) as u64,
+                mem_end.unchecked_offset_from(mmio_end),
                 bootparam::E820_RAM,
             )
             .map_err(Error::BootSystem)?;

--- a/src/libs/kata-sys-util/src/fs.rs
+++ b/src/libs/kata-sys-util/src/fs.rs
@@ -145,7 +145,7 @@ pub fn reflink_copy<S: AsRef<Path>, D: AsRef<Path>>(src: S, dst: D) -> Result<()
 // Copy file using cp command, which handles sparse file copy.
 fn do_regular_copy(src: &str, dst: &str) -> Result<()> {
     let mut cmd = Command::new("/bin/cp");
-    cmd.args(&["--sparse=auto", src, dst]);
+    cmd.args(["--sparse=auto", src, dst]);
 
     match cmd.output() {
         Ok(output) => match output.status.success() {

--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -820,11 +820,11 @@ mod tests {
         let tmpdir2 = tempfile::tempdir().unwrap();
 
         assert!(matches!(
-            bind_remount(&PathBuf::from(""), true),
+            bind_remount(PathBuf::from(""), true),
             Err(Error::NullMountPointPath)
         ));
         assert!(matches!(
-            bind_remount(&PathBuf::from("../______doesn't____exist____nnn"), true),
+            bind_remount(PathBuf::from("../______doesn't____exist____nnn"), true),
             Err(Error::InvalidPath(_))
         ));
 
@@ -1066,7 +1066,7 @@ mod tests {
         .unwrap_err();
 
         let src = path.join("src");
-        fs::write(&src, "test").unwrap();
+        fs::write(src, "test").unwrap();
         let dst = path.join("dst");
         fs::write(&dst, "test1").unwrap();
         mount_at(

--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -592,7 +592,7 @@ fn compact_lowerdir_option(opts: &[String]) -> (Option<PathBuf>, Vec<String>) {
         }
     };
 
-    let idx = idx as usize;
+    let idx = idx;
     let common_dir = match get_longest_common_prefix(&lower_opts) {
         None => return (None, n_opts),
         Some(v) => {
@@ -620,7 +620,7 @@ fn compact_lowerdir_option(opts: &[String]) -> (Option<PathBuf>, Vec<String>) {
         .iter()
         .map(|c| c.replace(&common_prefix, ""))
         .collect();
-    n_opts[idx as usize] = format!("lowerdir={}", lower.join(":"));
+    n_opts[idx] = format!("lowerdir={}", lower.join(":"));
 
     (Some(common_dir), n_opts)
 }

--- a/src/libs/kata-sys-util/src/numa.rs
+++ b/src/libs/kata-sys-util/src/numa.rs
@@ -37,9 +37,9 @@ pub type Result<T> = std::result::Result<T, Error>;
 lazy_static! {
     static ref SYS_FS_PREFIX: PathBuf = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("test/texture");
     // numa node file for UT, we can mock data
-    static ref NUMA_NODE_PATH: PathBuf = (&*SYS_FS_PREFIX).join("sys/devices/system/node");
+    static ref NUMA_NODE_PATH: PathBuf = (*SYS_FS_PREFIX).join("sys/devices/system/node");
     // sysfs directory for CPU devices
-    static ref NUMA_CPU_PATH: PathBuf = (&*SYS_FS_PREFIX).join("sys/devices/system/cpu");
+    static ref NUMA_CPU_PATH: PathBuf = (*SYS_FS_PREFIX).join("sys/devices/system/cpu");
 }
 
 // global config in release

--- a/src/libs/kata-sys-util/src/validate.rs
+++ b/src/libs/kata-sys-util/src/validate.rs
@@ -17,16 +17,9 @@ pub enum Error {
 pub fn verify_id(id: &str) -> Result<(), Error> {
     let mut chars = id.chars();
 
-    let valid = match chars.next() {
-        Some(first)
-            if first.is_alphanumeric()
+    let valid = matches!(chars.next(), Some(first) if first.is_alphanumeric()
                 && id.len() > 1
-                && chars.all(|c| c.is_alphanumeric() || ['.', '-', '_'].contains(&c)) =>
-        {
-            true
-        }
-        _ => false,
-    };
+                && chars.all(|c| c.is_alphanumeric() || ['.', '-', '_'].contains(&c)));
 
     match valid {
         true => Ok(()),

--- a/src/libs/kata-types/src/config/drop_in.rs
+++ b/src/libs/kata-types/src/config/drop_in.rs
@@ -240,7 +240,7 @@ mod drop_in_directory_handling {
                 "drop-in cfg file can only be a regular file or a symlink",
             ));
         }
-        let dropin_contents = fs::read_to_string(&dropin_file.path())?;
+        let dropin_contents = fs::read_to_string(dropin_file.path())?;
         let dropin_config: toml::Value = toml::from_str(&dropin_contents)?;
         super::toml_tree_ops::merge(base_config, dropin_config);
         Ok(())
@@ -267,7 +267,7 @@ mod drop_in_directory_handling {
     }
 
     pub fn load(base_cfg_file_path: &Path) -> Result<TomlConfig> {
-        let base_toml_str = fs::read_to_string(&base_cfg_file_path)?;
+        let base_toml_str = fs::read_to_string(base_cfg_file_path)?;
         let mut base_config: toml::Value = toml::from_str(&base_toml_str)?;
         let dropin_dir = get_dropin_dir_path(base_cfg_file_path)?;
 
@@ -324,7 +324,7 @@ mod drop_in_directory_handling {
             create_file(&config_path, BASE_CONFIG_DATA.as_bytes()).unwrap();
 
             let dropin_dir = tmpdir.path().join("config.d");
-            fs::create_dir(&dropin_dir).unwrap();
+            fs::create_dir(dropin_dir).unwrap();
 
             let config = load(&config_path).unwrap();
             check_base_config(&config);

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1133,7 +1133,7 @@ mod tests {
                 },
                 output: CpuInfo {
                     cpu_features: "".to_string(),
-                    default_vcpus: default_vcpus as i32,
+                    default_vcpus,
                     default_maxvcpus: node_cpus,
                 },
             },

--- a/src/libs/kata-types/tests/test_config.rs
+++ b/src/libs/kata-types/tests/test_config.rs
@@ -340,7 +340,7 @@ mod tests {
 
         let path = env!("CARGO_MANIFEST_DIR");
         let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
-        let content = fs::read_to_string(&path).unwrap();
+        let content = fs::read_to_string(path).unwrap();
         let mut config = TomlConfig::load(&content).unwrap();
         assert!(anno.update_config_by_annotation(&mut config).is_err());
     }
@@ -349,7 +349,7 @@ mod tests {
     fn test_fail_to_change_kernel_path_because_of_invalid_path() {
         let path = env!("CARGO_MANIFEST_DIR");
         let path = Path::new(path).join("tests/texture/configuration-anno-0.toml");
-        let content = fs::read_to_string(&path).unwrap();
+        let content = fs::read_to_string(path).unwrap();
 
         let qemu = QemuConfig::new();
         qemu.register();

--- a/src/libs/logging/src/file_rotate.rs
+++ b/src/libs/logging/src/file_rotate.rs
@@ -168,12 +168,12 @@ impl FileRotator {
         #[cfg(test)]
         if !self.fail_rename && self.path.exists() {
             let rotated_path = self.rotated_path(1);
-            let _ = fs::rename(&self.path, &rotated_path);
+            let _ = fs::rename(&self.path, rotated_path);
         }
         #[cfg(not(test))]
         if self.path.exists() {
             let rotated_path = self.rotated_path(1);
-            let _ = fs::rename(&self.path, &rotated_path);
+            let _ = fs::rename(&self.path, rotated_path);
         }
 
         let delete_path = self.rotated_path(self.rotate_keep + 1);

--- a/src/libs/logging/src/lib.rs
+++ b/src/libs/logging/src/lib.rs
@@ -499,6 +499,7 @@ mod tests {
         let error_closure = |logger: &Logger, msg: String| error!(logger, "{}", msg);
         let critical_closure = |logger: &Logger, msg: String| crit!(logger, "{}", msg);
 
+        #[allow(clippy::type_complexity)]
         struct TestData<'a> {
             slog_level: slog::Level,
             slog_level_tag: &'a str,

--- a/src/libs/protocols/build.rs
+++ b/src/libs/protocols/build.rs
@@ -17,7 +17,7 @@ fn replace_text_in_file(file_name: &str, from: &str, to: &str) -> Result<(), std
 
     let new_contents = contents.replace(from, to);
 
-    let mut dst = File::create(&file_name)?;
+    let mut dst = File::create(file_name)?;
     dst.write_all(new_contents.as_bytes())?;
 
     Ok(())
@@ -67,7 +67,7 @@ fn handle_file(autogen_comment: &str, rust_filename: &str) -> Result<(), std::io
 
         let pattern = "//! Generated file from";
 
-        if line.starts_with(&pattern) {
+        if line.starts_with(pattern) {
             new_contents.push(autogen_comment.into());
         }
 
@@ -76,14 +76,14 @@ fn handle_file(autogen_comment: &str, rust_filename: &str) -> Result<(), std::io
         // Although we've requested serde support via `Customize`, to
         // allow the `kata-agent-ctl` tool to partially deserialise structures
         // specified in JSON, we need this bit of additional magic.
-        if line.starts_with(&struct_pattern) {
+        if line.starts_with(struct_pattern) {
             new_contents.insert(new_contents.len() - 1, serde_default_code.trim().into());
         }
     }
 
     let data = new_contents.join("\n");
 
-    let mut dst = File::create(&rust_filename)?;
+    let mut dst = File::create(rust_filename)?;
 
     dst.write_all(data.as_bytes())?;
 

--- a/src/libs/protocols/src/trans.rs
+++ b/src/libs/protocols/src/trans.rs
@@ -106,8 +106,8 @@ impl From<oci::LinuxDeviceCgroup> for crate::oci::LinuxDeviceCgroup {
         crate::oci::LinuxDeviceCgroup {
             Allow: from.allow,
             Type: from.r#type,
-            Major: from.major.map_or(0, |t| t as i64),
-            Minor: from.minor.map_or(0, |t| t as i64),
+            Major: from.major.map_or(0, |t| t),
+            Minor: from.minor.map_or(0, |t| t),
             Access: from.access,
             unknown_fields: Default::default(),
             cached_size: Default::default(),
@@ -123,7 +123,7 @@ impl From<oci::LinuxMemory> for crate::oci::LinuxMemory {
             Swap: from.swap.map_or(0, |t| t),
             Kernel: from.kernel.map_or(0, |t| t),
             KernelTCP: from.kernel_tcp.map_or(0, |t| t),
-            Swappiness: from.swappiness.map_or(0, |t| t as u64),
+            Swappiness: from.swappiness.map_or(0, |t| t),
             DisableOOMKiller: from.disable_oom_killer.map_or(false, |t| t),
             unknown_fields: Default::default(),
             cached_size: Default::default(),
@@ -332,7 +332,7 @@ impl From<oci::LinuxDevice> for crate::oci::LinuxDevice {
             Type: from.r#type,
             Major: from.major,
             Minor: from.minor,
-            FileMode: from.file_mode.map_or(0, |v| v as u32),
+            FileMode: from.file_mode.map_or(0, |v| v),
             UID: from.uid.map_or(0, |v| v),
             GID: from.gid.map_or(0, |v| v),
             unknown_fields: Default::default(),
@@ -468,12 +468,12 @@ impl From<crate::oci::LinuxDeviceCgroup> for oci::LinuxDeviceCgroup {
     fn from(mut from: crate::oci::LinuxDeviceCgroup) -> Self {
         let mut major = None;
         if from.get_Major() > 0 {
-            major = Some(from.get_Major() as i64);
+            major = Some(from.get_Major());
         }
 
         let mut minor = None;
         if from.get_Minor() > 0 {
-            minor = Some(from.get_Minor() as i64)
+            minor = Some(from.get_Minor())
         }
 
         oci::LinuxDeviceCgroup {

--- a/src/libs/safe-path/src/pinned_path_buf.rs
+++ b/src/libs/safe-path/src/pinned_path_buf.rs
@@ -295,7 +295,7 @@ mod tests {
             barrier2.wait();
         });
 
-        let path = scoped_join(&root_path, "s").unwrap();
+        let path = scoped_join(root_path, "s").unwrap();
         let data = fs::read_to_string(&path).unwrap();
         assert_eq!(&data, "a");
         assert!(path.is_file());
@@ -306,7 +306,7 @@ mod tests {
         assert_eq!(&data, "b");
         PinnedPathBuf::from_path(&path).unwrap_err();
 
-        let pinned_path = PinnedPathBuf::new(&root_path, "s").unwrap();
+        let pinned_path = PinnedPathBuf::new(root_path, "s").unwrap();
         let data = fs::read_to_string(&pinned_path).unwrap();
         assert_eq!(&data, "b");
 

--- a/src/libs/safe-path/src/scoped_dir_builder.rs
+++ b/src/libs/safe-path/src/scoped_dir_builder.rs
@@ -173,7 +173,7 @@ mod tests {
         fs::write(rootfs_path.join("txt"), "test").unwrap();
         ScopedDirBuilder::new(rootfs_path.join("txt")).unwrap_err();
 
-        let mut builder = ScopedDirBuilder::new(&rootfs_path).unwrap();
+        let mut builder = ScopedDirBuilder::new(rootfs_path).unwrap();
 
         // file with the same name already exists.
         builder
@@ -268,7 +268,7 @@ mod tests {
         symlink(rootfs_dir.path().join("b"), rootfs_dir.path().join("a")).unwrap();
         let rootfs_path = &rootfs_dir.path().join("a");
 
-        let mut builder = ScopedDirBuilder::new(&rootfs_path).unwrap();
+        let mut builder = ScopedDirBuilder::new(rootfs_path).unwrap();
         builder.create_with_unscoped_path("/").unwrap_err();
         builder
             .create_with_unscoped_path(rootfs_path.join("../__xxxx___xxx__"))
@@ -278,13 +278,13 @@ mod tests {
             .unwrap_err();
 
         // Return `AlreadyExist` when recursive is false
-        builder.create_with_unscoped_path(&rootfs_path).unwrap_err();
+        builder.create_with_unscoped_path(rootfs_path).unwrap_err();
         builder
             .create_with_unscoped_path(rootfs_path.join("."))
             .unwrap_err();
 
         builder.recursive(true);
-        builder.create_with_unscoped_path(&rootfs_path).unwrap();
+        builder.create_with_unscoped_path(rootfs_path).unwrap();
         builder
             .create_with_unscoped_path(rootfs_path.join("."))
             .unwrap();

--- a/src/libs/safe-path/src/scoped_path_resolver.rs
+++ b/src/libs/safe-path/src/scoped_path_resolver.rs
@@ -329,31 +329,31 @@ mod tests {
         let rootfs_path = &rootfs_dir.path();
 
         assert_eq!(
-            scoped_join(&rootfs_path, "a").unwrap(),
+            scoped_join(rootfs_path, "a").unwrap(),
             rootfs_path.join("a")
         );
         assert_eq!(
-            scoped_join(&rootfs_path, "./a").unwrap(),
+            scoped_join(rootfs_path, "./a").unwrap(),
             rootfs_path.join("a")
         );
         assert_eq!(
-            scoped_join(&rootfs_path, "././a").unwrap(),
+            scoped_join(rootfs_path, "././a").unwrap(),
             rootfs_path.join("a")
         );
         assert_eq!(
-            scoped_join(&rootfs_path, "c/d/../../a").unwrap(),
+            scoped_join(rootfs_path, "c/d/../../a").unwrap(),
             rootfs_path.join("a")
         );
         assert_eq!(
-            scoped_join(&rootfs_path, "c/d/../../../.././a").unwrap(),
+            scoped_join(rootfs_path, "c/d/../../../.././a").unwrap(),
             rootfs_path.join("a")
         );
         assert_eq!(
-            scoped_join(&rootfs_path, "../../a").unwrap(),
+            scoped_join(rootfs_path, "../../a").unwrap(),
             rootfs_path.join("a")
         );
         assert_eq!(
-            scoped_join(&rootfs_path, "./../a").unwrap(),
+            scoped_join(rootfs_path, "./../a").unwrap(),
             rootfs_path.join("a")
         );
     }
@@ -370,18 +370,18 @@ mod tests {
         fs::symlink("b/c", rootfs_dir.path().join("a")).unwrap();
 
         let target = rootfs_path.join("b/c");
-        assert_eq!(scoped_join(&rootfs_path, "a").unwrap(), target);
-        assert_eq!(scoped_join(&rootfs_path, "./a").unwrap(), target);
-        assert_eq!(scoped_join(&rootfs_path, "././a").unwrap(), target);
-        assert_eq!(scoped_join(&rootfs_path, "b/c/../../a").unwrap(), target);
+        assert_eq!(scoped_join(rootfs_path, "a").unwrap(), target);
+        assert_eq!(scoped_join(rootfs_path, "./a").unwrap(), target);
+        assert_eq!(scoped_join(rootfs_path, "././a").unwrap(), target);
+        assert_eq!(scoped_join(rootfs_path, "b/c/../../a").unwrap(), target);
         assert_eq!(
-            scoped_join(&rootfs_path, "b/c/../../../.././a").unwrap(),
+            scoped_join(rootfs_path, "b/c/../../../.././a").unwrap(),
             target
         );
-        assert_eq!(scoped_join(&rootfs_path, "../../a").unwrap(), target);
-        assert_eq!(scoped_join(&rootfs_path, "./../a").unwrap(), target);
-        assert_eq!(scoped_join(&rootfs_path, "a/../../../a").unwrap(), target);
-        assert_eq!(scoped_join(&rootfs_path, "a/../../../b/c").unwrap(), target);
+        assert_eq!(scoped_join(rootfs_path, "../../a").unwrap(), target);
+        assert_eq!(scoped_join(rootfs_path, "./../a").unwrap(), target);
+        assert_eq!(scoped_join(rootfs_path, "a/../../../a").unwrap(), target);
+        assert_eq!(scoped_join(rootfs_path, "a/../../../b/c").unwrap(), target);
     }
 
     #[test]

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
@@ -98,7 +98,7 @@ impl DragonballInner {
         };
 
         for tid in self.vmm_instance.get_vcpu_tids() {
-            vcpu_thread_ids.vcpus.insert(tid.0 as u32, tid.1 as u32);
+            vcpu_thread_ids.vcpus.insert(tid.0 as u32, tid.1);
         }
         info!(sl!(), "get thread ids {:?}", vcpu_thread_ids);
         Ok(vcpu_thread_ids)

--- a/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
@@ -119,7 +119,7 @@ pub fn create_link(name: &str, link_type: LinkType, queues: usize) -> Result<()>
 
 fn create_queue(name: &str, flags: libc::c_int) -> Result<(File, String)> {
     let path = Path::new(DEVICE_PATH);
-    let file = OpenOptions::new().read(true).write(true).open(&path)?;
+    let file = OpenOptions::new().read(true).write(true).open(path)?;
     let mut req = CreateLinkReq::from_name(name)?;
     unsafe {
         req.set_raw_flags(flags as libc::c_short);

--- a/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
@@ -11,6 +11,7 @@ use netlink_packet_route::{
 
 use super::{Link, LinkAttrs};
 
+#[allow(clippy::box_default)]
 pub fn get_link_from_message(mut msg: LinkMessage) -> Box<dyn Link> {
     let mut base = LinkAttrs {
         index: msg.header.index,
@@ -83,6 +84,7 @@ pub fn get_link_from_message(mut msg: LinkMessage) -> Box<dyn Link> {
     ret
 }
 
+#[allow(clippy::box_default)]
 fn link_info(mut infos: Vec<Info>) -> Box<dyn Link> {
     let mut link: Option<Box<dyn Link>> = None;
     while let Some(info) = infos.pop() {

--- a/src/runtime-rs/crates/resource/src/network/utils/netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/netns.rs
@@ -20,7 +20,7 @@ impl NetnsGuard {
             let current_netns_path = format!("/proc/{}/task/{}/ns/{}", getpid(), gettid(), "net");
             let old_netns = File::open(&current_netns_path)
                 .with_context(|| format!("open current netns path {}", &current_netns_path))?;
-            let new_netns = File::open(&new_netns_path)
+            let new_netns = File::open(new_netns_path)
                 .with_context(|| format!("open new netns path {}", &new_netns_path))?;
             setns(new_netns.as_raw_fd(), CloneFlags::CLONE_NEWNET)
                 .with_context(|| "set netns to new netns")?;

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -89,8 +89,8 @@ impl MountedInfo {
     pub fn new(guest_path: PathBuf, readonly: bool) -> Self {
         Self {
             guest_path,
-            ro_ref_count: if readonly { 1 } else { 0 },
-            rw_ref_count: if readonly { 0 } else { 1 },
+            ro_ref_count: readonly.into(),
+            rw_ref_count: (!readonly).into(),
         }
     }
 

--- a/src/runtime-rs/crates/resource/src/share_fs/utils.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/utils.rs
@@ -38,7 +38,7 @@ pub(crate) fn share_to_guest(
     // to remount the read only dir mount point directly.
     if readonly {
         let dst = do_get_host_path(target, sid, cid, is_volume, true);
-        mount::bind_remount(&dst, readonly).context("bind remount readonly")?;
+        mount::bind_remount(dst, readonly).context("bind remount readonly")?;
     }
 
     Ok(do_get_guest_path(target, cid, is_volume, is_rafs))

--- a/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
@@ -173,11 +173,11 @@ impl ShareFsMount for VirtiofsShareMount {
     async fn upgrade_to_rw(&self, file_name: &str) -> Result<()> {
         // Remount readonly directory with readwrite permission
         let host_dest = do_get_host_path(file_name, &self.id, "", true, true);
-        bind_remount(&host_dest, false)
+        bind_remount(host_dest, false)
             .context("remount readonly directory with readwrite permission")?;
         // Remount readwrite directory with readwrite permission
         let host_dest = do_get_host_path(file_name, &self.id, "", true, false);
-        bind_remount(&host_dest, false)
+        bind_remount(host_dest, false)
             .context("remount readwrite directory with readwrite permission")?;
         Ok(())
     }
@@ -185,11 +185,11 @@ impl ShareFsMount for VirtiofsShareMount {
     async fn downgrade_to_ro(&self, file_name: &str) -> Result<()> {
         // Remount readwrite directory with readonly permission
         let host_dest = do_get_host_path(file_name, &self.id, "", true, false);
-        bind_remount(&host_dest, true)
+        bind_remount(host_dest, true)
             .context("remount readwrite directory with readonly permission")?;
         // Remount readonly directory with readonly permission
         let host_dest = do_get_host_path(file_name, &self.id, "", true, true);
-        bind_remount(&host_dest, true)
+        bind_remount(host_dest, true)
             .context("remount readonly directory with readonly permission")?;
         Ok(())
     }

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -55,7 +55,7 @@ async fn send_event(
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .args(&[
+        .args([
             "--address",
             &address,
             "publish",

--- a/src/runtime-rs/crates/shim/src/shim_delete.rs
+++ b/src/runtime-rs/crates/shim/src/shim_delete.rs
@@ -40,7 +40,7 @@ impl ShimExecutor {
         let trim_path = address.strip_prefix("unix://").context("trim path")?;
         let file_path = Path::new("/").join(trim_path);
         let file_path = file_path.as_path();
-        if std::fs::metadata(&file_path).is_ok() {
+        if std::fs::metadata(file_path).is_ok() {
             info!(sl!(), "remote socket path: {:?}", &file_path);
             fs::remove_file(file_path).ok();
         }

--- a/src/tools/runk/src/main.rs
+++ b/src/tools/runk/src/main.rs
@@ -105,7 +105,7 @@ fn setup_logger(
             .read(true)
             .create(true)
             .truncate(true)
-            .open(&file)?;
+            .open(file)?;
 
         // TODO: Support 'text' log format.
         let (logger_local, logger_async_guard_local) =

--- a/versions.yaml
+++ b/versions.yaml
@@ -316,12 +316,12 @@ languages:
   rust:
     description: "Rust language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.62.0"
+    version: "1.66.0"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.62.0"
+      newest-version: "1.66.0"
 
   golangci-lint:
     description: "golangci-lint"


### PR DESCRIPTION
We're doing the bump on main, as we'll need this as part of the CCv0 branch due to the dependencies we have there.

Link to the 1.66.0 release:
https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1660-2022-12-15

Fixes: #5966

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>