### PR TITLE
versions: Upgrade to Cloud Hypervisor v28.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v28.0"
+      version: "v28.1"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
Cloud Hypervisor published a bug fix release v28.1 with the following issues being addressed:

* Update dependencies including a version of `linux-loader` that addresses an infinite loop issue ([details](https://github.com/rust-vmm/linux-loader/security/advisories/GHSA-52h2-m2cf-9jh6))
* Fix bugs related to `virtio-net` including an integer overflow issue
* Use host `cpuid` information for L2 cache for older KVM on x86 
* Improve README and documentation

Details can be found here: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v28.1

Fixes: #5973

Signed-off-by: Bo Chen <chen.bo@intel.com>