### PR TITLE
runtime-rs: cleanup the run dir of hypervisor when shut down

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -248,6 +248,12 @@ impl Sandbox for VirtSandbox {
             .await
             .context("delete cgroups")?;
 
+        info!(sl!(), "delete hypervisor");
+        self.hypervisor
+            .cleanup()
+            .await
+            .context("delete hypervisor")?;
+
         info!(sl!(), "stop monitor");
         self.monitor.stop().await;
 


### PR DESCRIPTION
Cleanup the run dir of hypervisor when shut down.

Fixes: #5825

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>