### PR TITLE
CC | agent: unset `CC` for cross-build

### DIFF
--- a/utils.mk
+++ b/utils.mk
@@ -169,6 +169,7 @@ ifneq ($(HOST_ARCH),$(ARCH))
          $(warning "WARNING: A foreign ARCH was passed, but no CC alternative. Using $(CC).")
     endif
     override EXTRA_RUSTFLAGS += -C linker=$(CC)
+    undefine CC
 endif
 
 TRIPLE = $(ARCH)-unknown-linux-$(LIBC)


### PR DESCRIPTION
When `HOST_ARCH` != `ARCH` unset `CC`

Specifying a foreign CC is incompatible with building libgit2. Thus after the RUSTFLAGS linker has been set we can safely unset CC to avoid passing this value through the build.

Fixes: #5890

Signed-off-by: James Tumber <james.tumber@ibm.com>
Cherry-picked: 087515a