### PR TITLE
versions: Upgrade to Cloud Hypervisor v28.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v28.0"
+      version: "v28.1"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This patch upgrade Cloud Hypervisor to its latest bug release v28.1: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v28.1

Backport: #5974

Signed-off-by: Bo Chen <chen.bo@intel.com>
(cherry picked from commit 652021ad95dbe943db9b9b247c29ea9bdefef893)