### PR TITLE
kata-ctl: remove get_kata_version_by_url function

### DIFF
--- a/src/tools/kata-ctl/Makefile
+++ b/src/tools/kata-ctl/Makefile
@@ -50,7 +50,7 @@ vendor:
 	cargo vendor
 
 test:
-	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo test --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES)
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo test --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES) -- --nocapture
 
 install:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --target $(TRIPLE) --path .


### PR DESCRIPTION
In `src/tools/kata-ctl/src/check.rs`, there is a function `get_kata_version_by_url` in the tests mod,
indeed we can use the `get_kata_all_releases_by_url` in the main mod to replace it.

Fixes: #5981

Signed-off-by: Bin Liu <bin@hyper.sh>