### PR TITLE
schedcore: Make buildable on !linux

### DIFF
--- a/src/runtime/pkg/utils/schedcore.go
+++ b/src/runtime/pkg/utils/schedcore.go
@@ -5,10 +5,6 @@
 
 package utils
 
-import (
-	"golang.org/x/sys/unix"
-)
-
 // PidType is the type of provided pid value and how it should be treated
 type PidType int
 
@@ -24,13 +20,3 @@ const (
 	// ProcessGroup affects all processes in the group
 	ProcessGroup PidType = pidTypeProcessGroupId
 )
-
-// Create a new sched core domain
-func Create(t PidType) error {
-	return unix.Prctl(unix.PR_SCHED_CORE, unix.PR_SCHED_CORE_CREATE, 0, uintptr(t), 0)
-}
-
-// ShareFrom shares the sched core domain from the provided pid
-func ShareFrom(pid uint64, t PidType) error {
-	return unix.Prctl(unix.PR_SCHED_CORE, unix.PR_SCHED_CORE_SHARE_FROM, uintptr(pid), uintptr(t), 0)
-}

--- a/src/runtime/pkg/utils/schedcore_linux.go
+++ b/src/runtime/pkg/utils/schedcore_linux.go
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 Apple Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package utils
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// Create a new sched core domain
+func Create(t PidType) error {
+	return unix.Prctl(unix.PR_SCHED_CORE, unix.PR_SCHED_CORE_CREATE, 0, uintptr(t), 0)
+}
+
+// ShareFrom shares the sched core domain from the provided pid
+func ShareFrom(pid uint64, t PidType) error {
+	return unix.Prctl(unix.PR_SCHED_CORE, unix.PR_SCHED_CORE_SHARE_FROM, uintptr(pid), uintptr(t), 0)
+}

--- a/src/runtime/pkg/utils/schedcore_other.go
+++ b/src/runtime/pkg/utils/schedcore_other.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2023 Apple Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//go:build !linux
+
+package utils
+
+import (
+	"errors"
+)
+
+// Create a new sched core domain
+func Create(t PidType) error {
+	return errors.New("schedcore not available on non-Linux platforms")
+}
+
+// ShareFrom shares the sched core domain from the provided pid
+func ShareFrom(pid uint64, t PidType) error {
+	return errors.New("schedcore not available on non-Linux platforms")
+}


### PR DESCRIPTION
Fixes: #5983

sched-core only makes sense on Linux hosts. Let's add stub/error for other platforms.