### PR TITLE
nydus: net-ns handling needs to be only executed on Linux hosts

### DIFF
--- a/src/runtime/virtcontainers/nydusd.go
+++ b/src/runtime/virtcontainers/nydusd.go
@@ -23,7 +23,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils/retry"
@@ -54,8 +53,6 @@ const (
 	nydusPassthroughfs = "passthrough_fs"
 
 	sharedPathInGuest = "/containers"
-
-	shimNsPath = "/proc/self/ns/net"
 )
 
 var (
@@ -83,13 +80,6 @@ type nydusd struct {
 	extraArgs       []string
 	pid             int
 	debug           bool
-}
-
-func startInShimNS(cmd *exec.Cmd) error {
-	// Create nydusd in shim netns as it needs to access host network
-	return doNetNS(shimNsPath, func(_ ns.NetNS) error {
-		return cmd.Start()
-	})
 }
 
 func (nd *nydusd) Start(ctx context.Context, onQuit onQuitFunc) (int, error) {

--- a/src/runtime/virtcontainers/nydusd_linux.go
+++ b/src/runtime/virtcontainers/nydusd_linux.go
@@ -1,0 +1,21 @@
+// Copyright (c) 2017 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package virtcontainers
+
+import (
+	"os/exec"
+
+	"github.com/containernetworking/plugins/pkg/ns"
+)
+
+const shimNsPath = "/proc/self/ns/net"
+
+func startInShimNS(cmd *exec.Cmd) error {
+	// Create nydusd in shim netns as it needs to access host network
+	return doNetNS(shimNsPath, func(_ ns.NetNS) error {
+		return cmd.Start()
+	})
+}

--- a/src/runtime/virtcontainers/nydusd_other.go
+++ b/src/runtime/virtcontainers/nydusd_other.go
@@ -1,0 +1,15 @@
+// Copyright (c) 2023 Apple Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//go:build !linux
+
+package virtcontainers
+
+import "os/exec"
+
+// No-op on net namespace join on other platforms.
+func startInShimNS(cmd *exec.Cmd) error {
+	return cmd.Start()
+}


### PR DESCRIPTION
Fixes: #5985

With nydus not being its own pkg, it is challenging to implement cleanly in a virtcontainers package that isn't necesarily Linux-only. The existing code utilizes network namespace code in order to ensure nydus is launched in the host netns. This is very Linux specific - so let's make sure we only carry this out in a linux specific file.

In the Darwin case, to allow for compilation at least, let's add a stub for doNetNS. Ideally the nydus and vc code can be refactored / decoupled.