### PR TITLE
runtime: Define Darwin handled signals list

### DIFF
--- a/src/runtime/pkg/signals/signals.go
+++ b/src/runtime/pkg/signals/signals.go
@@ -23,21 +23,6 @@ var signalLog = logrus.WithField("default-signal-logger", true)
 // or a fatal signal is received.
 var CrashOnError = false
 
-// List of handled signals.
-//
-// The value is true if receiving the signal should be fatal.
-var handledSignalsMap = map[syscall.Signal]bool{
-	syscall.SIGABRT:   true,
-	syscall.SIGBUS:    true,
-	syscall.SIGILL:    true,
-	syscall.SIGQUIT:   true,
-	syscall.SIGSEGV:   true,
-	syscall.SIGSTKFLT: true,
-	syscall.SIGSYS:    true,
-	syscall.SIGTRAP:   true,
-	syscall.SIGUSR1:   false,
-}
-
 // DieCb is the callback function type that needs to be defined for every call
 // into the Die() function. This callback will be run as the first function of
 // the Die() implementation.

--- a/src/runtime/pkg/signals/signals_darwin.go
+++ b/src/runtime/pkg/signals/signals_darwin.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2023 Apple Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package signals
+
+import "syscall"
+
+// List of handled signals.
+//
+// The value is true if receiving the signal should be fatal.
+var handledSignalsMap = map[syscall.Signal]bool{
+	syscall.SIGABRT: true,
+	syscall.SIGBUS:  true,
+	syscall.SIGILL:  true,
+	syscall.SIGQUIT: true,
+	syscall.SIGSEGV: true,
+	syscall.SIGSYS:  true,
+	syscall.SIGTRAP: true,
+	syscall.SIGUSR1: false,
+}

--- a/src/runtime/pkg/signals/signals_linux.go
+++ b/src/runtime/pkg/signals/signals_linux.go
@@ -1,0 +1,23 @@
+// Copyright 2018 Intel Corporation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package signals
+
+import "syscall"
+
+// List of handled signals.
+//
+// The value is true if receiving the signal should be fatal.
+var handledSignalsMap = map[syscall.Signal]bool{
+	syscall.SIGABRT:   true,
+	syscall.SIGBUS:    true,
+	syscall.SIGILL:    true,
+	syscall.SIGQUIT:   true,
+	syscall.SIGSEGV:   true,
+	syscall.SIGSTKFLT: true,
+	syscall.SIGSYS:    true,
+	syscall.SIGTRAP:   true,
+	syscall.SIGUSR1:   false,
+}


### PR DESCRIPTION
Fixes: #5990

Some signals may not be defined on non Linux host OSes, like SIGSTKFLT for example. It's also not defined on certain architectures, but irrelevant for this.

/cc @egernst 