### PR TITLE
kata-ctl: fix build error on s390x

### DIFF
--- a/src/tools/kata-ctl/src/arch/s390x/mod.rs
+++ b/src/tools/kata-ctl/src/arch/s390x/mod.rs
@@ -9,6 +9,7 @@ pub use arch_specific::*;
 
 mod arch_specific {
     use crate::check;
+    use crate::types::*;
     use anyhow::{anyhow, Result};
 
     const PROC_CPUINFO: &str = "/proc/cpuinfo";
@@ -38,7 +39,7 @@ mod arch_specific {
         Ok(())
     }
 
-    pub fn check() -> Result<()> {
+    pub fn check(_args: &str) -> Result<()> {
         println!("INFO: check: s390x");
 
         let _cpu_result = check_cpu();

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -16,12 +16,6 @@ struct Release {
     tarball_url: String,
 }
 
-#[cfg(any(
-    target_arch = "aarch64",
-    target_arch = "powerpc64le",
-    target_arch = "x86_64"
-))]
-
 const KATA_GITHUB_RELEASE_URL: &str =
     "https://api.github.com/repos/kata-containers/kata-containers/releases";
 

--- a/src/tools/kata-ctl/src/ops/check_ops.rs
+++ b/src/tools/kata-ctl/src/ops/check_ops.rs
@@ -93,20 +93,10 @@ pub fn handle_check(checkcmd: CheckArgument) -> Result<()> {
         }
         CheckSubCommand::OnlyListReleases => {
             // retrieve official release
-            #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "powerpc64le",
-                target_arch = "x86_64"
-            ))]
             check::check_official_releases()?;
         }
         CheckSubCommand::IncludeAllReleases => {
             // retrieve ALL releases including prerelease
-            #[cfg(any(
-                target_arch = "aarch64",
-                target_arch = "powerpc64le",
-                target_arch = "x86_64"
-            ))]
             check::check_all_releases()?;
         }
     }


### PR DESCRIPTION
Some type is not imported in s390x's mod file.

Fixes: #5987

Signed-off-by: Bin Liu <bin@hyper.sh>