### PR TITLE
clh: Ensure it works with Docker / Moby

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -886,6 +886,15 @@ func (clh *cloudHypervisor) hotPlugVFIODevice(device *config.VFIODev) error {
 	return err
 }
 
+func (clh *cloudHypervisor) hotplugAddNetDevice(e Endpoint) error {
+	err := clh.addNet(e)
+	if err != nil {
+		return err
+	}
+
+	return clh.vmAddNetPut()
+}
+
 func (clh *cloudHypervisor) HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
 	span, _ := katatrace.Trace(ctx, clh.Logger(), "HotplugAddDevice", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
@@ -897,6 +906,9 @@ func (clh *cloudHypervisor) HotplugAddDevice(ctx context.Context, devInfo interf
 	case VfioDev:
 		device := devInfo.(*config.VFIODev)
 		return nil, clh.hotPlugVFIODevice(device)
+	case NetDev:
+		device := devInfo.(Endpoint)
+		return nil, clh.hotplugAddNetDevice(device)
 	default:
 		return nil, fmt.Errorf("cannot hotplug device: unsupported device type '%v'", devType)
 	}

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -220,7 +220,7 @@ var vmAddNetPutRequest = func(clh *cloudHypervisor) error {
 		resp.Body.Close()
 		resp.Body = io.NopCloser(bytes.NewBuffer(respBody))
 
-		if resp.StatusCode != 204 {
+		if resp.StatusCode != 200 && resp.StatusCode != 204 {
 			clh.Logger().Errorf("vmAddNetPut failed with error '%d'. Response: %+v", resp.StatusCode, resp)
 			return fmt.Errorf("Failed to add the network device '%+v' to Cloud Hypervisor: %v", netDevice, resp.StatusCode)
 		}


### PR DESCRIPTION
Docker / Moby 23.0.0-rc1 has added support to other containerd runtimes (see https://github.com/moby/moby/commit/547da0d575519a197fbf4e0543555d508d176084), and it means that Kata Containers will be supported again.  @bergwolf worked on the bits missing as part of https://github.com/kata-containers/kata-containers/pull/5972, which got QEMU working, but not Cloud Hypervisor.

Now we're adding the needed bits to have Cloud Hypervisor working with Docker.

Before this PR:
```
# docker run -it --rm --runtime io.containerd.kata.v2 busybox sh -c "uname -r ; ping -c 3 www.google.com"
docker: Error response from daemon: failed to create shim task: cannot hotplug device: unsupported device type '2': unknown.
```

With this PR:
```
# docker run -it --rm --runtime io.containerd.kata.v2 busybox sh -c "uname -r ; ping -c 3 www.google.com"
5.19.2
PING www.google.com (142.251.36.100): 56 data bytes
64 bytes from 142.251.36.100: seq=0 ttl=114 time=13.217 ms
64 bytes from 142.251.36.100: seq=1 ttl=114 time=15.918 ms
64 bytes from 142.251.36.100: seq=2 ttl=114 time=15.235 ms

--- www.google.com ping statistics ---
3 packets transmitted, 3 packets received, 0% packet loss
round-trip min/avg/max = 13.217/14.790/15.918 ms
```