### PR TITLE
runtime-rs: add Single Container support

### DIFF
--- a/src/libs/kata-sys-util/src/spec.rs
+++ b/src/libs/kata-sys-util/src/spec.rs
@@ -68,7 +68,7 @@ pub fn get_container_type(spec: &oci::Spec) -> Result<ContainerType, Error> {
 pub fn get_shim_id_info() -> Result<ShimIdInfo, Error> {
     let spec = load_oci_spec()?;
     match get_container_type(&spec)? {
-        ContainerType::PodSandbox => Ok(ShimIdInfo::Sandbox),
+        ContainerType::PodSandbox | ContainerType::SingleContainer => Ok(ShimIdInfo::Sandbox),
         ContainerType::PodContainer => {
             for k in CRI_SANDBOX_ID_KEY_LIST {
                 if let Some(sandbox_id) = spec.annotations.get(*k) {

--- a/src/libs/kata-types/src/container.rs
+++ b/src/libs/kata-types/src/container.rs
@@ -19,6 +19,8 @@ pub(crate) const SANDBOX: &str = "sandbox";
 // docker: a sandbox sandbox container
 pub(crate) const PODSANDBOX: &str = "podsandbox";
 
+pub(crate) const SINGLE_CONTAINER: &str = "single_container";
+
 const STATE_READY: &str = "ready";
 const STATE_RUNNING: &str = "running";
 const STATE_STOPPED: &str = "stopped";
@@ -45,6 +47,8 @@ pub enum ContainerType {
     PodContainer,
     /// A pod sandbox.
     PodSandbox,
+    /// A single container.
+    SingleContainer,
 }
 
 impl ContainerType {
@@ -64,6 +68,7 @@ impl Display for ContainerType {
         match self {
             ContainerType::PodContainer => write!(f, "{}", POD_CONTAINER),
             ContainerType::PodSandbox => write!(f, "{}", POD_SANDBOX),
+            ContainerType::SingleContainer => write!(f, "{}", SINGLE_CONTAINER),
         }
     }
 }

--- a/src/libs/kata-types/src/k8s.rs
+++ b/src/libs/kata-types/src/k8s.rs
@@ -69,7 +69,7 @@ pub fn container_type(spec: &oci::Spec) -> ContainerType {
         }
     }
 
-    ContainerType::PodSandbox
+    ContainerType::SingleContainer
 }
 
 /// Determine the k8s sandbox ID from OCI annotations.
@@ -269,7 +269,7 @@ mod tests {
         // default
         assert_eq!(
             container_type_with_id(&spec),
-            (ContainerType::PodSandbox, None)
+            (ContainerType::SingleContainer, None)
         );
 
         // crio sandbox

--- a/src/runtime-rs/crates/shim/src/shim_start.rs
+++ b/src/runtime-rs/crates/shim/src/shim_start.rs
@@ -38,7 +38,7 @@ impl ShimExecutor {
         let (container_type, id) = k8s::container_type_with_id(&spec);
 
         match container_type {
-            ContainerType::PodSandbox => {
+            ContainerType::PodSandbox | ContainerType::SingleContainer => {
                 let address = self.socket_address(&self.args.id)?;
                 let socket = new_listener(&address)?;
                 let child_pid = self.create_shim_process(socket)?;


### PR DESCRIPTION
For now, only pod_sandbox and pod_container are supported. It doesn't cover the case that container started by ctr which is a single_container defined in kata 2.0. Port the single_container kata type from kata 2.0 to kata 3.0.