### PR TITLE
Dragonball: add cpu resize ability

### DIFF
--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -35,6 +35,9 @@ pub use crate::device_manager::virtio_net_dev_mgr::{
 #[cfg(feature = "virtio-vsock")]
 pub use crate::device_manager::vsock_dev_mgr::{VsockDeviceConfigInfo, VsockDeviceError};
 
+#[cfg(feature = "hotplug")]
+pub use crate::vcpu::{VcpuResizeError, VcpuResizeInfo};
+
 use super::*;
 
 /// Wrapper for all errors associated with VMM actions.
@@ -44,9 +47,13 @@ pub enum VmmActionError {
     #[error("the virtual machine instance ID is invalid")]
     InvalidVMID,
 
+    /// VM doesn't exist and can't get VM information.
+    #[error("VM doesn't exist and can't get VM information")]
+    VmNotExist,
+
     /// Failed to hotplug, due to Upcall not ready.
     #[error("Upcall not ready, can't hotplug device.")]
-    UpcallNotReady,
+    UpcallServerNotReady,
 
     /// The action `ConfigureBootSource` failed either because of bad user input or an internal
     /// error.
@@ -85,6 +92,11 @@ pub enum VmmActionError {
     /// The action `InsertFsDevice` failed either because of bad user input or an internal error.
     #[error("virtio-fs device error: {0}")]
     FsDevice(#[source] FsDeviceError),
+
+    #[cfg(feature = "hotplug")]
+    /// The action `ResizeVcpu` Failed
+    #[error("vcpu resize error : {0}")]
+    ResizeVcpu(#[source] VcpuResizeError),
 }
 
 /// This enum represents the public interface of the VMM. Each action contains various
@@ -156,6 +168,10 @@ pub enum VmmAction {
     #[cfg(feature = "virtio-fs")]
     /// Update fs rate limiter, after microVM start.
     UpdateFsDevice(FsDeviceConfigUpdateInfo),
+
+    #[cfg(feature = "hotplug")]
+    /// Resize Vcpu number in the guest.
+    ResizeVcpu(VcpuResizeInfo),
 }
 
 /// The enum represents the response sent by the VMM in case of success. The response is either
@@ -256,6 +272,8 @@ impl VmmService {
             VmmAction::UpdateFsDevice(fs_update_cfg) => {
                 self.update_fs_rate_limiters(vmm, fs_update_cfg)
             }
+            #[cfg(feature = "hotplug")]
+            VmmAction::ResizeVcpu(vcpu_resize_cfg) => self.resize_vcpu(vmm, vcpu_resize_cfg),
         };
 
         debug!("send vmm response: {:?}", response);
@@ -462,8 +480,8 @@ impl VmmService {
         let ctx = vm
             .create_device_op_context(Some(event_mgr.epoll_manager()))
             .map_err(|e| {
-                if let StartMicroVmError::UpcallNotReady = e {
-                    return VmmActionError::UpcallNotReady;
+                if let StartMicroVmError::UpcallServerNotReady = e {
+                    return VmmActionError::UpcallServerNotReady;
                 }
                 VmmActionError::Block(BlockDeviceError::UpdateNotAllowedPostBoot)
             })?;
@@ -518,8 +536,8 @@ impl VmmService {
             .map_err(|e| {
                 if let StartMicroVmError::MicroVMAlreadyRunning = e {
                     VmmActionError::VirtioNet(VirtioNetDeviceError::UpdateNotAllowedPostBoot)
-                } else if let StartMicroVmError::UpcallNotReady = e {
-                    VmmActionError::UpcallNotReady
+                } else if let StartMicroVmError::UpcallServerNotReady = e {
+                    VmmActionError::UpcallServerNotReady
                 } else {
                     VmmActionError::StartMicroVm(e)
                 }
@@ -594,6 +612,37 @@ impl VmmService {
         FsDeviceMgr::update_device_ratelimiters(vm.device_manager_mut(), config)
             .map(|_| VmmData::Empty)
             .map_err(VmmActionError::FsDevice)
+    }
+
+    #[cfg(feature = "hotplug")]
+    fn resize_vcpu(&mut self, vmm: &mut Vmm, config: VcpuResizeInfo) -> VmmRequestResult {
+        if !cfg!(target_arch = "x86_64") {
+            // TODO: Arm need to support vcpu hotplug. issue: #6010
+            warn!("This arch do not support vm resize!");
+            return Ok(VmmData::Empty);
+        }
+
+        if !cfg!(feature = "dbs-upcall") {
+            warn!("We only support cpu resize through upcall server in the guest kernel now, please enable dbs-upcall feature.");
+            return Ok(VmmData::Empty);
+        }
+
+        let vm = vmm.get_vm_mut().ok_or(VmmActionError::VmNotExist)?;
+
+        if !vm.is_vm_initialized() {
+            return Err(VmmActionError::ResizeVcpu(
+                VcpuResizeError::UpdateNotAllowedPreBoot,
+            ));
+        }
+
+        vm.resize_vcpu(config, None).map_err(|e| {
+            if let VcpuResizeError::UpcallServerNotReady = e {
+                return VmmActionError::UpcallServerNotReady;
+            }
+            VmmActionError::ResizeVcpu(e)
+        })?;
+
+        Ok(VmmData::Empty)
     }
 }
 

--- a/src/dragonball/src/error.rs
+++ b/src/dragonball/src/error.rs
@@ -100,7 +100,7 @@ pub enum StartMicroVmError {
 
     /// Upcall is not ready
     #[error("the upcall client is not ready")]
-    UpcallNotReady,
+    UpcallServerNotReady,
 
     /// Configuration passed in is invalidate.
     #[error("invalid virtual machine configuration: {0} ")]

--- a/src/dragonball/src/vcpu/mod.rs
+++ b/src/dragonball/src/vcpu/mod.rs
@@ -10,7 +10,10 @@ mod vcpu_manager;
 #[cfg(target_arch = "x86_64")]
 use dbs_arch::cpuid::VpmuFeatureLevel;
 
-pub use vcpu_manager::{VcpuManager, VcpuManagerError};
+pub use vcpu_manager::{VcpuManager, VcpuManagerError, VcpuResizeInfo};
+
+#[cfg(feature = "hotplug")]
+pub use vcpu_manager::VcpuResizeError;
 
 /// vcpu config collection
 pub struct VcpuConfig {

--- a/src/dragonball/src/vcpu/vcpu_impl.rs
+++ b/src/dragonball/src/vcpu/vcpu_impl.rs
@@ -214,10 +214,20 @@ pub enum VcpuResponse {
     CacheRevalidated,
 }
 
+#[derive(Debug, PartialEq)]
+/// Vcpu Hotplug Result returned from the guest
+pub enum VcpuResizeResult {
+    /// All vCPU hotplug / hot-unplug operations are successful
+    Success = 0,
+    /// vCPU hotplug / hot-unplug failed
+    Failed = 1,
+}
+
 /// List of events that the vcpu_state_sender can send.
 pub enum VcpuStateEvent {
-    /// (result, response) for hotplug, result 0 means failure, 1 means success.
-    Hotplug((i32, u32)),
+    /// (result, response) for hotplug / hot-unplugged.
+    /// response records how many cpu has successfully being hotplugged / hot-unplugged.
+    Hotplug((VcpuResizeResult, u32)),
 }
 
 /// Wrapper over vCPU that hides the underlying interactions with the vCPU thread.

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -314,7 +314,7 @@ impl VmmInstance {
                         return Ok(vmm_data);
                     }
                     Err(vmm_action_error) => {
-                        if let VmmActionError::UpcallNotReady = vmm_action_error {
+                        if let VmmActionError::UpcallServerNotReady = vmm_action_error {
                             std::thread::sleep(std::time::Duration::from_millis(10));
                             continue;
                         } else {


### PR DESCRIPTION
Add cpu resize ability upon upcall communication channel. Runtime could use ResizeVcpu VmmAction and pass the desired vCPU number to the Dragonball hypervisor.
Dragonball will trigger the device manager service in guest kernel's upcall server to do cpu resize.

fixes: kata-containers#6008
Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>