### PR TITLE
runtime-rs: use hypervisor.enable_debug to control log output

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -180,7 +180,6 @@ ifneq (,$(DBCMD))
     DEFMAXVCPUS_DB := 1
     DEFBLOCKSTORAGEDRIVER_DB := virtio-blk
     DEFNETWORKMODEL_DB := tcfilter
-    KERNELPARAMS = console=ttyS1 agent.log_vport=1025
 	KERNELTYPE_DB = uncompressed
     KERNEL_NAME_DB = $(call MAKE_KERNEL_NAME,$(KERNELTYPE_DB))
     KERNELPATH_DB = $(KERNELDIR)/$(KERNEL_NAME_DB)

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -146,6 +146,7 @@ shared_fs = "@DBSHAREDFS@"
 
 [agent.@PROJECT_TYPE@]
 container_pipe_size=@PIPESIZE@
+
 # If enabled, make the agent display debug-level messages.
 # (default: disabled)
 #enable_debug = true
@@ -165,10 +166,9 @@ container_pipe_size=@PIPESIZE@
 #enable_tracing = true
 
 # Enable debug console.
-
+#
 # If enabled, user can connect guest OS running inside hypervisor
 # through "kata-runtime exec <sandbox-id>" command
-
 #debug_console_enabled = true
 
 # Agent connection dialing timeout value in seconds
@@ -240,7 +240,7 @@ disable_guest_seccomp=@DEFDISABLEGUESTSECCOMP@
 # (default: false)
 #disable_new_netns = true
 
-# if enabled, the runtime will add all the kata processes inside one dedicated cgroup.
+# If enabled, the runtime will add all the kata processes inside one dedicated cgroup.
 # The container cgroups in the host are not created, just one single cgroup per sandbox.
 # The runtime caller is free to restrict or collect cgroup stats of the overall Kata sandbox.
 # The sandbox cgroup path is the parent cgroup of a container with the PodSandbox annotation.

--- a/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
+++ b/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
@@ -7,11 +7,6 @@
 use anyhow::{anyhow, Result};
 
 use crate::{VM_ROOTFS_DRIVER_BLK, VM_ROOTFS_DRIVER_PMEM};
-use kata_types::config::LOG_VPORT_OPTION;
-
-// Port where the agent will send the logs. Logs are sent through the vsock in cases
-// where the hypervisor has no console.sock, i.e dragonball
-const VSOCK_LOGS_PORT: &str = "1025";
 
 const KERNEL_KV_DELIMITER: &str = "=";
 const KERNEL_PARAM_DELIMITER: &str = " ";
@@ -49,9 +44,9 @@ pub(crate) struct KernelParams {
 }
 
 impl KernelParams {
-    pub(crate) fn new(debug: bool) -> Self {
+    pub(crate) fn new() -> Self {
         // default kernel params
-        let mut params = vec![
+        let params = vec![
             Param::new("reboot", "k"),
             Param::new("earlyprintk", "ttyS0"),
             Param::new("initcall_debug", ""),
@@ -59,10 +54,6 @@ impl KernelParams {
             Param::new("systemd.unit", "kata-containers.target"),
             Param::new("systemd.mask", "systemd-networkd.service"),
         ];
-
-        if debug {
-            params.push(Param::new(LOG_VPORT_OPTION, VSOCK_LOGS_PORT));
-        }
 
         Self { params }
     }
@@ -108,6 +99,10 @@ impl KernelParams {
 
     pub(crate) fn append(&mut self, params: &mut KernelParams) {
         self.params.append(&mut params.params);
+    }
+
+    pub(crate) fn push(&mut self, param: Param) {
+        self.params.push(param);
     }
 
     pub(crate) fn from_string(params_string: &str) -> Self {

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::{str::from_utf8, sync::Arc};
+use std::{str::from_utf8, sync::Arc, vec};
 
 use anyhow::{anyhow, Context, Result};
 


### PR DESCRIPTION
Currently, when users want kata-agent's log and guest kernel's log with runtime-rs+dragonball, they need to append kernel_params(agent.log_vport=1025 console=ttyS1) in the configuration file.

Now we change to use hypervisor.enable_debug to control the log output.

Fixes: #6016

Signed-off-by: Yushuo <y-shuo@linux.alibaba.com>