### PR TITLE
network: Handle InterworkingModel of none

### DIFF
--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -564,6 +564,8 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) err
 	case NetXConnectTCFilterModel:
 		networkLogger().Info("connect TCFilter to VM network")
 		err = setupTCFiltering(ctx, endpoint, queues, disableVhostNet)
+	case NetXConnectNoneModel:
+		// internetworking_model is none, so do nothing?
 	default:
 		err = fmt.Errorf("Invalid internetworking model")
 	}


### PR DESCRIPTION
- Add a case to handle `NetXConnectNoneModel` in `xConnectVMNetwork`

Fixes: #6021
Signed-off-by: stevenhorsman <steven@uk.ibm.com>