### PR TITLE
osbuilder: copy efi_secret module for online_sev_kbc

### DIFF
--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -41,7 +41,7 @@ build_initrd() {
 	export AGENT_INIT="yes"
 	# ROOTFS_BUILD_DEST is a Make variable
 	# SNP will also use the SEV guest module
-	if [ "${AA_KBC:-}" == "offline_sev_kbc" | "${AA_KBC:-}" == "online_sev_kbc"]; then
+	if [[ "${AA_KBC:-}" == "offline_sev_kbc" || "${AA_KBC:-}" == "online_sev_kbc" ]]; then
 		config_version=$(get_config_version)
 		kernel_version="$(get_from_kata_deps "assets.kernel.sev.version")"
 		kernel_version=${kernel_version#v}


### PR DESCRIPTION
Bug fix for #5651. Faulty bash syntax let a initrd build complete, but not copy the kernel module. This change fixes the if logic to work as an 'or' as intended.

Fixes: #6024
Signed-off-by: Alex Carter <Alex.Carter@ibm.com>