### PR TITLE
runtime: use system pagesize for hugepage test

### DIFF
--- a/src/runtime/virtcontainers/kata_agent_linux_test.go
+++ b/src/runtime/virtcontainers/kata_agent_linux_test.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"os"
 	"path"
-	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -34,17 +33,12 @@ func TestHandleHugepages(t *testing.T) {
 	var mounts []specs.Mount
 	var hugepageLimits []specs.LinuxHugepageLimit
 
-	// On s390x, hugepage sizes must be set at boot and cannot be created ad hoc. Use any that
-	// are present (default is 1M, can only be changed on LPAR). See
-	// https://www.ibm.com/docs/en/linuxonibm/pdf/lku5dd05.pdf, p. 345 for more information.
-	if runtime.GOARCH == "s390x" {
-		dirs, err := os.ReadDir(sysHugepagesDir)
-		assert.Nil(err)
-		for _, dir := range dirs {
-			formattedSizes = append(formattedSizes, strings.TrimPrefix(dir.Name(), "hugepages-"))
-		}
-	} else {
-		formattedSizes = []string{"1G", "2M"}
+	// Hugepage sizes must be set at boot time and cannot be created ad hoc.
+	// Use any that are present.
+	dirs, err := os.ReadDir(sysHugepagesDir)
+	assert.Nil(err)
+	for _, dir := range dirs {
+		formattedSizes = append(formattedSizes, strings.TrimPrefix(dir.Name(), "hugepages-"))
 	}
 
 	for _, formattedSize := range formattedSizes {


### PR DESCRIPTION
In TestHandleHugepages it will do a mount operation with different pagesizes, but some systems only support 2M pagesize, test for a 1g pagesize will fail.

This commit try to fix by only mount pagesizes under `/sys/kernel/mm/hugepages`, which are supported to mount by the OS.

Fixes: #6029

Signed-off-by: Bin Liu <bin@hyper.sh>