### PR TITLE
runtime: add test generated file to .gitignore

### DIFF
--- a/src/runtime/.gitignore
+++ b/src/runtime/.gitignore
@@ -18,3 +18,4 @@ config-generated.go
 /virtcontainers/hook/mock/hook
 /virtcontainers/profile.cov
 /virtcontainers/utils/supportfiles
+/virtcontainers/cpu_affinity_idx


### PR DESCRIPTION
Add test generated file to .gitignore to avoid making the working directory dirty.

Fixes: #6031

Signed-off-by: Bin Liu <bin@hyper.sh>