### PR TITLE
CC: Support s390x for target cc-payload in Makefile

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -8,6 +8,19 @@ MK_DIR := $(dir $(MK_PATH))
 
 # Verbose build
 V := 1
+ARCH := $(shell uname -m)
+
+ifeq ($(ARCH), x86_64)
+EXTRA_TARBALL=cc-cloud-hypervisor-tarball \
+	cc-tdx-kernel-tarball \
+	cc-sev-kernel-tarball \
+	cc-tdx-qemu-tarball \
+	cc-tdx-td-shim-tarball \
+	cc-tdx-tdvf-tarball \
+	cc-sev-ovmf-tarball \
+	cc-sev-rootfs-initrd-tarball \
+	cc-tdx-rootfs-image-tarball
+endif
 
 define BUILD
 	$(MK_DIR)/kata-deploy-binaries-in-docker.sh $(if $(V),,-s) --build=$1
@@ -82,20 +95,12 @@ cc-tarball: | cc merge-builds
 cc-parallel: $(MK_DIR)/dockerbuild/install_yq.sh
 	${MAKE} -f $(MK_PATH) cc -j$$(( $$(nproc) - 1  )) V=
 
-cc: cc-cloud-hypervisor-tarball \
-	cc-kernel-tarball \
+cc: cc-kernel-tarball \
 	cc-qemu-tarball \
 	cc-rootfs-image-tarball \
-	cc-shim-v2-tarball \
 	cc-virtiofsd-tarball \
-	cc-tdx-kernel-tarball \
-	cc-sev-kernel-tarball \
-	cc-tdx-qemu-tarball \
-	cc-tdx-td-shim-tarball \
-	cc-tdx-tdvf-tarball \
-	cc-sev-ovmf-tarball \
-	cc-sev-rootfs-initrd-tarball \
-	cc-tdx-rootfs-image-tarball
+	cc-shim-v2-tarball \
+	${EXTRA_TARBALL}
 
 cc-cloud-hypervisor-tarball:
 	${MAKE} $@-build


### PR DESCRIPTION
This is to adjust dependencies for a target `cc-payload` based on architecture. It follows a build order found in the GHA workflow (kernel &rightarrow; qemu &rightarrow; rootfs &rightarrow; virtiofsd &rightarrow; shim-v2)

Fixes: #6028

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>