### PR TITLE
virtcontainers: Fix misspelling in error message

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -434,7 +434,7 @@ func (clh *cloudHypervisor) enableProtection() error {
 		return errors.New("SEV-SNP protection is not supported by Cloud Hypervisor")
 
 	default:
-		return errors.New("This system doesn't support Confidentian Computing (Guest Protection)")
+		return errors.New("This system doesn't support Confidential Computing (Guest Protection)")
 	}
 }
 


### PR DESCRIPTION
This PR fixes a misspelling in the error message when it tries to run a system without Confidential computing support.

Fixes #6042

Signed-off-by: Gabriela Cervantes <gabriela.cervantes.tellez@intel.com>