### PR TITLE
CC | Update dependencies for the v0.3.0 release

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -2158,7 +2158,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/image-rs?rev=cf1f7f96eb60ec4cc4aaa671c04d574a4ea0e441#cf1f7f96eb60ec4cc4aaa671c04d574a4ea0e441"
+source = "git+https://github.com/confidential-containers/image-rs?rev=v0.3.0#cf1f7f96eb60ec4cc4aaa671c04d574a4ea0e441"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -71,10 +71,10 @@ openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
 [target.'cfg(target_arch = "s390x")'.dependencies]
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "cf1f7f96eb60ec4cc4aaa671c04d574a4ea0e441", default-features = false, features = ["default_s390x"] }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "v0.3.0", default-features = false, features = ["default_s390x"] }
 
 [target.'cfg(not(target_arch = "s390x"))'.dependencies]
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "cf1f7f96eb60ec4cc4aaa671c04d574a4ea0e441", default-features = true }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "v0.3.0", default-features = true }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/versions.yaml
+++ b/versions.yaml
@@ -191,7 +191,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/attestation-agent"
-    version: "v0.2.0"
+    version: "v0.3.0"
 
   cni-plugins:
     description: "CNI network plugins"

--- a/versions.yaml
+++ b/versions.yaml
@@ -316,8 +316,8 @@ externals:
   td-shim:
     description: "Confidential Containers Shim Firmware"
     url: "https://github.com/confidential-containers/td-shim"
-    version: "v0.2.0"
-    toolchain: "nightly-2022-05-15"
+    version: "v0.3.0"
+    toolchain: "nightly-2022-11-15"
 
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"


### PR DESCRIPTION
---

 versions: Update TD-Shim version to v0.3.0

 TD-Shim has released its v0.3.0 release earlier Today, following the
 Confidential Containers v0.3.0 release.

 Let's update it here.  We need to also bump the toolchain to using the
 nightly-2022-11-15

---

 build: Update image-rs to v0.3.0

 image-rs has released its v0.3.0 release earlier Today, following the
 v0.3.0 Confidential Containers release process.

 The v0.3.0 is based on exactly the same commit we've been using already,
 so no changes are expected for us.

---

 versions: Bump attestation-agent to v0.3.0

 The attestation-agent had its v0.3.0 release earlier Today, following
 the Confidential Containers v0.3.0 release process.

 Let's bump it on our side, as we've already tested the version that
 became this release.

---