### PR TITLE
runk: Upgrade liboci-cli to v0.0.4

### DIFF
--- a/src/tools/runk/Cargo.lock
+++ b/src/tools/runk/Cargo.lock
@@ -259,16 +259,16 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.12"
+version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c167e37342afc5f33fd87bbc870cedd020d2a6dffa05d45ccd9241fbdd146db"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
  "clap_lex",
  "indexmap",
- "lazy_static",
+ "once_cell",
  "strsim",
  "termcolor",
  "textwrap",
@@ -276,9 +276,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.7"
+version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -289,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.1.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
  "os_str_bytes",
 ]
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "liboci-cli"
-version = "0.0.3"
+version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c25aa929b6575121059b01bfd7289dedf25a988534b6550d3472ccd5064be8ce"
+checksum = "6f707717247a34421d9c8aa0448452cde6d5d2ac455257f5fc4d53ec607264a4"
 dependencies = [
  "clap",
 ]
@@ -1529,6 +1529,7 @@ dependencies = [
  "slog",
  "slog-scope",
  "tokio",
+ "xattr",
  "zbus",
 ]
 
@@ -1768,9 +1769,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
@@ -2141,6 +2142,15 @@ name = "windows_x86_64_msvc"
 version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
+
+[[package]]
+name = "xattr"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "zbus"

--- a/src/tools/runk/Cargo.toml
+++ b/src/tools/runk/Cargo.toml
@@ -11,7 +11,7 @@ libcontainer = { path = "./libcontainer" }
 rustjail = { path = "../../agent/rustjail", features = ["standard-oci-runtime"] }
 oci = { path = "../../libs/oci" }
 logging = { path = "../../libs/logging" }
-liboci-cli = "0.0.3"
+liboci-cli = "0.0.4"
 clap = { version = "3.0.6", features = ["derive", "cargo"] }
 libc = "0.2.108"
 nix = "0.23.0"

--- a/src/tools/runk/src/commands/kill.rs
+++ b/src/tools/runk/src/commands/kill.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::Kill;
 use anyhow::Result;
 use libcontainer::container::Container;
+use liboci_cli::Kill;
 use nix::sys::signal::Signal;
 use slog::{info, Logger};
 use std::{convert::TryFrom, path::Path, str::FromStr};
@@ -15,9 +15,6 @@ pub fn run(opts: Kill, state_root: &Path, logger: &Logger) -> Result<()> {
     let container = Container::load(state_root, container_id)?;
     let sig = parse_signal(&opts.signal)?;
 
-    // TODO: liboci-cli does not support --all option for kill command.
-    // After liboci-cli supports the option, we will change the following code.
-    // as a workaround we use a custom Kill command.
     let all = opts.all;
     container.kill(sig, all)?;
 


### PR DESCRIPTION
We can remove the custom kill command.

Fix: https://github.com/kata-containers/kata-containers/issues/6083