### PR TITLE
runtime-rs: cleanup kata host share path

### DIFF
--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -101,9 +101,9 @@ impl ResourceManager {
         inner.update_cgroups(cid, linux_resources).await
     }
 
-    pub async fn delete_cgroups(&self) -> Result<()> {
+    pub async fn cleanup(&self) -> Result<()> {
         let inner = self.inner.read().await;
-        inner.delete_cgroups().await
+        inner.cleanup().await
     }
 }
 

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -131,6 +131,8 @@ pub trait ShareFsMount: Send + Sync {
     async fn umount_volume(&self, file_name: &str) -> Result<()>;
     /// Umount the rootfs
     async fn umount_rootfs(&self, config: &ShareFsRootfsConfig) -> Result<()>;
+    /// Clean up share fs mount
+    async fn cleanup(&self, sid: &str) -> Result<()>;
 }
 
 pub fn new(id: &str, config: &SharedFsInfo) -> Result<Arc<dyn ShareFs>> {

--- a/src/runtime-rs/crates/resource/src/share_fs/utils.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/utils.rs
@@ -59,6 +59,10 @@ pub fn get_host_rw_shared_path(sid: &str) -> PathBuf {
     Path::new(KATA_HOST_SHARED_DIR).join(sid).join("rw")
 }
 
+pub fn get_host_shared_path(sid: &str) -> PathBuf {
+    Path::new(KATA_HOST_SHARED_DIR).join(sid)
+}
+
 fn do_get_guest_any_path(
     target: &str,
     cid: &str,

--- a/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
@@ -11,7 +11,7 @@ use async_trait::async_trait;
 pub trait Sandbox: Send + Sync {
     async fn start(&self, netns: Option<String>) -> Result<()>;
     async fn stop(&self) -> Result<()>;
-    async fn cleanup(&self, container_id: &str) -> Result<()>;
+    async fn cleanup(&self) -> Result<()>;
     async fn shutdown(&self) -> Result<()>;
 
     // agent function

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -174,7 +174,7 @@ impl RuntimeHandlerManager {
                     .await
                     .context("failed to restore the sandbox")?;
                 sandbox
-                    .cleanup(&inner.id)
+                    .cleanup()
                     .await
                     .context("failed to cleanup the resource")?;
             }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -242,17 +242,7 @@ impl Sandbox for VirtSandbox {
 
         self.stop().await.context("stop")?;
 
-        info!(sl!(), "delete cgroup");
-        self.resource_manager
-            .delete_cgroups()
-            .await
-            .context("delete cgroups")?;
-
-        info!(sl!(), "delete hypervisor");
-        self.hypervisor
-            .cleanup()
-            .await
-            .context("delete hypervisor")?;
+        self.cleanup().await.context("do the clean up")?;
 
         info!(sl!(), "stop monitor");
         self.monitor.stop().await;
@@ -269,9 +259,19 @@ impl Sandbox for VirtSandbox {
         Ok(())
     }
 
-    async fn cleanup(&self, _id: &str) -> Result<()> {
-        self.resource_manager.delete_cgroups().await?;
-        self.hypervisor.cleanup().await?;
+    async fn cleanup(&self) -> Result<()> {
+        info!(sl!(), "delete hypervisor");
+        self.hypervisor
+            .cleanup()
+            .await
+            .context("delete hypervisor")?;
+
+        info!(sl!(), "resource clean up");
+        self.resource_manager
+            .cleanup()
+            .await
+            .context("resource clean up")?;
+
         // TODO: cleanup other snadbox resource
         Ok(())
     }


### PR DESCRIPTION
cleanup the /run/kata-containers/shared/sandboxes/pid path

Fixes:#5975
Signed-off-by: Zhongtao Hu <zhongtaohu.tim@linux.alibaba.com>