### PR TITLE
runtime: Use consts in `kata-runtime check`

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-check_amd64.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_amd64.go
@@ -115,13 +115,13 @@ func setCPUtype(hypervisorType vc.HypervisorType) error {
 		}
 
 		switch hypervisorType {
-		case "firecracker":
+		case vc.FirecrackerHypervisor:
 			fallthrough
-		case "clh":
+		case vc.ClhHypervisor:
 			fallthrough
-		case "dragonball":
+		case vc.DragonballHypervisor:
 			fallthrough
-		case "qemu":
+		case vc.QemuHypervisor:
 			archRequiredCPUFlags = map[string]string{
 				cpuFlagVMX:    "Virtualization support",
 				cpuFlagLM:     "64Bit CPU",
@@ -153,7 +153,7 @@ func setCPUtype(hypervisorType vc.HypervisorType) error {
 					required: false,
 				},
 			}
-		case "acrn":
+		case vc.AcrnHypervisor:
 			archRequiredCPUFlags = map[string]string{
 				cpuFlagLM:     "64Bit CPU",
 				cpuFlagSSE4_1: "SSE4.1",
@@ -175,7 +175,7 @@ func setCPUtype(hypervisorType vc.HypervisorType) error {
 					required: false,
 				},
 			}
-		case "mock":
+		case vc.MockHypervisor:
 			archRequiredCPUFlags = map[string]string{
 				cpuFlagVMX:    "Virtualization support",
 				cpuFlagLM:     "64Bit CPU",
@@ -310,17 +310,16 @@ func acrnIsUsable() error {
 }
 
 func archHostCanCreateVMContainer(hypervisorType vc.HypervisorType) error {
-
 	switch hypervisorType {
-	case "qemu":
+	case vc.QemuHypervisor:
 		fallthrough
-	case "clh":
+	case vc.ClhHypervisor:
 		fallthrough
-	case "firecracker":
+	case vc.FirecrackerHypervisor:
 		return kvmIsUsable()
-	case "acrn":
+	case vc.AcrnHypervisor:
 		return acrnIsUsable()
-	case "mock":
+	case vc.MockHypervisor:
 		return nil
 	default:
 		return fmt.Errorf("archHostCanCreateVMContainer: Unknown hypervisor type %s", hypervisorType)


### PR DESCRIPTION
Fixes: #6095

We're already importing the virtcontainers package so might as well use the constants for the hypervisor types we're checking against instead of typing the names out in the switch cases.