### PR TITLE
versions: Bump virtiofsd to 1.5.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -290,14 +290,14 @@ externals:
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"
     url: "https://gitlab.com/virtio-fs/virtiofsd"
-    version: "v1.3.0"
+    version: "v1.5.1"
     toolchain: "1.62.0"
     meta:
-      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.3.0,
-      # this is the link labelled virtiofsd-v1.3.0.zip
+      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.5.1,
+      # this is the link labelled virtiofsd-v1.5.1.zip
       #
       # yamllint disable-line rule:line-length
-      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/9a4f2261fcb1701f1e709694b5c5d980/virtiofsd-v1.3.0.zip"
+      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/a3f40cdf8fd0754f13ab327b57bfe285/virtiofsd-v1.5.1.zip"
 
 languages:
   description: |


### PR DESCRIPTION
virtiofsd v1.5.0 has been released a month ago, and we should bump to it.

The main changes between v1.3.0 (the version we're using) and v1.5.0 are:
```
v1.3.0 -> v1.4.0
!127  Adds safe versions of `libc::mount()` and `libc::u...  (main) ← (ref-wrap-unsafe-mount)
!118  sandbox: Move parent process code inside sandbox       (main) ← (refactor-parent-sandbox)
!126  Update virtio-queue and vhost-user-backend deps        (main) ← !(update-deps)
!117  sandbox: Fix PR_SET_PDEATHSIG race condition           (main) ← (fix-fork-prctl-rc)
!102  Add capability to create security context (SELinux...  (main) ← (security-label)
!113  Log the errno error description on debug               (main) ← (fix-errmsg)
!125  Fix nightly clippy derive_partial_eq_without_eq wa...  (main) ← (fix-clippy-warn)
!124  Fixes failed open mount point when using file hand...  (main) ← (fix-fh-chroot)
!114  server: Reply FUSE_INIT_EXT on FUSE_INIT               (main) ← (fix-initext)
```

```
v1.4.0 -> v1.5.0
!144  seccomp: Allow `SYS_sigreturn` for s390x                 (main) ← (fix-s390x-crash)
!143  passthrough: Set `RWF_APPEND` on non-cached writes o...  (main) ← (fix-append-mmap)
!142  keep `DAC_OVERRIDE` after changing the uid/gid           (main) ← (fix-supgroup)
!141  passthrough: Replace `openat(2)` with `openat2(2)`       (main) ← (feat-openat2)
!140  Keep DAC_READ_SEARCH on setxattr with posix acl          (main) ← (fix-setxattr-w-filehandles)
!139  Bump rust-vmm crates dependencies                        (main) ← (update-rust-vmm)
!138  descriptor_utils: Remove unnecessary deref               (main) ← (fix-clippy-warn)
!136  sandbox: Allow non-root users run the daemon without...  (main) ← (sandbox-none-non-root)
!135  Add `umask(2)` safe wrapper                              (main) ← (ref-safe-umask)
!134  Add command line documentation details                   (main) ← (fix-cmdline-doc)
!133  Add missing license file header
```

Fixes: #6100

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>