### PR TITLE
docs: Fix missing critical steps in how-to-hotplug-memory-arm64.md

### DIFF
--- a/docs/how-to/how-to-hotplug-memory-arm64.md
+++ b/docs/how-to/how-to-hotplug-memory-arm64.md
@@ -17,14 +17,13 @@ $ popd
 
 ## Config KATA QEMU
 
-After executing the above script, two files will be generated under the directory /usr/share/kata-containers/ by default, namely kata-flash0.img and kata-flash1.img. Next we need to change the configuration file of kata qemu, which is in /opt/kata/share/defaults/kata-containers/configuration-qemu.toml by default, specify in the configuration file to use the UEFI ROM installed above. Please refer to the following configuration:
+After executing the above script, two files will be generated under the directory `/usr/share/kata-containers/` by default, namely `kata-flash0.img` and `kata-flash1.img`. Next we need to change the configuration file of kata qemu, which is in `/opt/kata/share/defaults/kata-containers/configuration-qemu.toml` by default, specify in the configuration file to use the UEFI ROM installed above. Please refer to the following configuration.
 
 ```
 [hypervisor.qemu]
 
 # -pflash can add image file to VM. The arguments of it should be in format
 # of ["/path/to/flash0.img", "/path/to/flash1.img"]
-# pflashes = []
 pflashes = ["/usr/share/kata-containers/kata-flash0.img", "/usr/share/kata-containers/kata-flash1.img"]
 ```
 

--- a/docs/how-to/how-to-hotplug-memory-arm64.md
+++ b/docs/how-to/how-to-hotplug-memory-arm64.md
@@ -17,7 +17,7 @@ $ popd
 
 ## Config KATA QEMU
 
-After executing the above script, two files will be generated under the directory `/usr/share/kata-containers/` by default, namely `kata-flash0.img` and `kata-flash1.img`. Next we need to change the configuration file of kata qemu, which is in `/opt/kata/share/defaults/kata-containers/configuration-qemu.toml` by default, specify in the configuration file to use the UEFI ROM installed above. Please refer to the following configuration.
+After executing the above script, two files will be generated under the directory `/usr/share/kata-containers/` by default, namely `kata-flash0.img` and `kata-flash1.img`. Next we need to change the configuration file of `kata qemu`, which is in `/opt/kata/share/defaults/kata-containers/configuration-qemu.toml` by default, specify in the configuration file to use the UEFI ROM installed above. Please refer to the following configuration.
 
 ```
 [hypervisor.qemu]

--- a/docs/how-to/how-to-hotplug-memory-arm64.md
+++ b/docs/how-to/how-to-hotplug-memory-arm64.md
@@ -15,6 +15,19 @@ $ sudo .ci/aarch64/install_rom_aarch64.sh
 $ popd
 ```
 
+## Config KATA QEMU
+
+After executing the above script, two files will be generated under the directory /usr/share/kata-containers/ by default, namely kata-flash0.img and kata-flash1.img. Next we need to change the configuration file of kata qemu, which is in /opt/kata/share/defaults/kata-containers/configuration-qemu.toml by default, specify in the configuration file to use the UEFI ROM installed above. Please refer to the following configuration:
+
+```
+[hypervisor.qemu]
+
+# -pflash can add image file to VM. The arguments of it should be in format
+# of ["/path/to/flash0.img", "/path/to/flash1.img"]
+# pflashes = []
+pflashes = ["/usr/share/kata-containers/kata-flash0.img", "/usr/share/kata-containers/kata-flash1.img"]
+```
+
 ## Run for test
 
 Let's test if the memory hotplug is ready for Kata after install the UEFI ROM. Make sure containerd is ready to run Kata before test.


### PR DESCRIPTION
The key steps in how-to-hotplug-memory-arm64.md are missing, resulting in the kata qemu pod not being created successfully.

Fixes: #6105
Signed-off-by: SinghWang <wangxin_0611@126.com>