### PR TITLE
kata-ctl: remove version check in tests

### DIFF
--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -194,7 +194,6 @@ pub fn check_official_releases() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use semver::Version;
 
     #[test]
     fn test_get_cpu_info_empty_input() {
@@ -262,13 +261,6 @@ mod tests {
             return;
         }
         let releases = releases.unwrap();
-
         assert!(!releases.is_empty());
-        let release = &releases[0];
-
-        let v = Version::parse(&release.tag_name).unwrap();
-        assert!(!v.major.to_string().is_empty());
-        assert!(!v.minor.to_string().is_empty());
-        assert!(!v.patch.to_string().is_empty());
     }
 }


### PR DESCRIPTION
check_latest_version currently check the first tag_name returned by the releases from GitHub, but in some cases it may be not a valid semver like `CC-1.2.3`.

Indeed the check of the version/tag is not required and can be deleted.

Fixes: #6107

Signed-off-by: Bin Liu <bin@hyper.sh>