### PR TITLE
versions: update cni plugins version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -193,7 +193,7 @@ externals:
   cni-plugins:
     description: "CNI network plugins"
     url: "https://github.com/containernetworking/plugins"
-    version: "v1.1.1"
+    version: "v1.2.0"
 
   conmon:
     description: "An OCI container runtime monitor"


### PR DESCRIPTION
Use cni plugins v1.2.0 to get latest fixes.

Fixes: #6110
