### PR TITLE
runtime/agent: Add log_level to the configuration of runtime and kata-agent 

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-env.go
+++ b/src/runtime/cmd/kata-runtime/kata-env.go
@@ -76,6 +76,7 @@ type RuntimeConfigInfo struct {
 type RuntimeInfo struct {
 	Config              RuntimeConfigInfo
 	Path                string
+	LogLevel            string
 	GuestSeLinuxLabel   string
 	Experimental        []exp.Feature
 	Version             RuntimeVersionInfo
@@ -119,8 +120,9 @@ type HypervisorInfo struct {
 
 // AgentInfo stores agent details
 type AgentInfo struct {
-	Debug bool
-	Trace bool
+	LogLevel string
+	Debug    bool
+	Trace    bool
 }
 
 // DistroInfo stores host operating system distribution details.
@@ -145,6 +147,7 @@ type HostInfo struct {
 // env command.
 //
 // XXX: Any changes must be coupled with a change to formatVersion.
+// nolint: govet
 type EnvInfo struct {
 	Kernel     KernelInfo
 	Meta       MetaInfo
@@ -179,6 +182,7 @@ func getRuntimeInfo(configFile string, config oci.RuntimeConfig) RuntimeInfo {
 
 	return RuntimeInfo{
 		Debug:               config.Debug,
+		LogLevel:            config.LogLevel,
 		Trace:               config.Trace,
 		Version:             runtimeVersion,
 		Config:              runtimeConfig,
@@ -278,6 +282,7 @@ func getAgentInfo(config oci.RuntimeConfig) (AgentInfo, error) {
 
 	agentConfig := config.AgentConfig
 	agent.Debug = agentConfig.Debug
+	agent.LogLevel = agentConfig.LogLevel
 	agent.Trace = agentConfig.Trace
 
 	return agent, nil

--- a/src/runtime/config/configuration-acrn.toml.in
+++ b/src/runtime/config/configuration-acrn.toml.in
@@ -126,6 +126,11 @@ disable_selinux=@DEFDISABLESELINUX@
 # (default: disabled)
 #enable_debug = true
 
+# Specify the agent log level, will override the enable_debug value (if both are set).
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+log_level = warn
+
 # Enable agent tracing.
 #
 # If enabled, the agent will generate OpenTelemetry trace spans.
@@ -156,7 +161,12 @@ disable_selinux=@DEFDISABLESELINUX@
 # system log
 # (default: disabled)
 #enable_debug = true
-#
+
+# Specify the runtime log level, will override the enable_debug value (if both are set).
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+log_level = warn
+
 # Internetworking model
 # Determines how the VM should be connected to the
 # the container network interface

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -272,6 +272,11 @@ block_device_driver = "virtio-blk"
 # (default: disabled)
 #enable_debug = true
 
+# Specify the agent log level, will override the enable_debug value (if both are set).
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+log_level = warn
+
 # Enable agent tracing.
 #
 # If enabled, the agent will generate OpenTelemetry trace spans.
@@ -302,7 +307,12 @@ block_device_driver = "virtio-blk"
 # system log
 # (default: disabled)
 #enable_debug = true
-#
+
+# Specify the runtime log level, will override the enable_debug value (if both are set).
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+log_level = warn
+
 # Internetworking model
 # Determines how the VM should be connected to the
 # the container network interface

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -243,6 +243,11 @@ disable_selinux=@DEFDISABLESELINUX@
 # (default: disabled)
 #enable_debug = true
 
+# Specify the agent log level, will override the enable_debug value (if both are set).
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+log_level = warn
+
 # Enable agent tracing.
 #
 # If enabled, the agent will generate OpenTelemetry trace spans.
@@ -286,7 +291,12 @@ kernel_modules=[]
 # system log
 # (default: disabled)
 #enable_debug = true
-#
+
+# Specify the runtime log level, will override the enable_debug value (if both are set).
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+log_level = warn
+
 # Internetworking model
 # Determines how the VM should be connected to the
 # the container network interface

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -489,6 +489,11 @@ disable_guest_selinux=@DEFDISABLEGUESTSELINUX@
 # (default: disabled)
 #enable_debug = true
 
+# Specify the agent log level, will override the enable_debug value (if both are set).
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+log_level = warn
+
 # Enable agent tracing.
 #
 # If enabled, the agent will generate OpenTelemetry trace spans.
@@ -532,7 +537,12 @@ kernel_modules=[]
 # system log
 # (default: disabled)
 #enable_debug = true
-#
+
+# Specify the runtime log level, will override the enable_debug value (if both are set).
+# loglevel optional values: panic, fatal, error, warn/warning, info, debug, trace
+# (default: "warn")
+log_level = warn
+
 # Internetworking model
 # Determines how the VM should be connected to the
 # the container network interface

--- a/src/runtime/pkg/katautils/logger.go
+++ b/src/runtime/pkg/katautils/logger.go
@@ -8,6 +8,7 @@ package katautils
 
 import (
 	"context"
+	"fmt"
 	"log/syslog"
 	"time"
 
@@ -31,6 +32,14 @@ func SetLogger(ctx context.Context, logger *logrus.Entry, level logrus.Level) {
 
 	originalLoggerLevel = level
 	kataUtilsLogger = logger.WithFields(fields)
+}
+
+func parseLogLevel(level string) (*logrus.Level, error) {
+	logLevel, err := logrus.ParseLevel(level)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse the log level, err: %+v", err)
+	}
+	return &logLevel, err
 }
 
 // sysLogHook wraps a syslog logrus hook and a formatter to be used for all

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -99,39 +99,40 @@ type FactoryConfig struct {
 // RuntimeConfig aggregates all runtime specific settings
 // nolint: govet
 type RuntimeConfig struct {
-	//Paths to be bindmounted RO into the guest.
+	// Paths to be bindmounted RO into the guest.
 	SandboxBindMounts []string
 
-	//Experimental features enabled
+	// Experimental features enabled
 	Experimental []exp.Feature
 
 	JaegerEndpoint string
 	JaegerUser     string
 	JaegerPassword string
+	LogLevel       string
 	HypervisorType vc.HypervisorType
 
 	FactoryConfig    FactoryConfig
 	HypervisorConfig vc.HypervisorConfig
 	AgentConfig      vc.KataAgentConfig
 
-	//Determines how the VM should be connected to the
-	//the container network interface
+	// Determines how the VM should be connected to the
+	// the container network interface
 	InterNetworkModel vc.NetInterworkingModel
 
-	//Determines how VFIO devices should be presented to the
-	//container
+	// Determines how VFIO devices should be presented to the
+	// container
 	VfioMode config.VFIOModeType
 
 	Debug bool
 	Trace bool
 
-	//Determines if seccomp should be applied inside guest
+	// Determines if seccomp should be applied inside guest
 	DisableGuestSeccomp bool
 
 	// EnableVCPUsPinning controls whether each vCPU thread should be scheduled to a fixed CPU
 	EnableVCPUsPinning bool
 
-	//SELinux security context applied to the container process inside guest.
+	// SELinux security context applied to the container process inside guest.
 	GuestSeLinuxLabel string
 
 	// Sandbox sizing information which, if provided, indicates the size of
@@ -146,7 +147,7 @@ type RuntimeConfig struct {
 	// Determines if create a netns for hypervisor process
 	DisableNewNetNs bool
 
-	//Determines kata processes are managed only in sandbox cgroup
+	// Determines kata processes are managed only in sandbox cgroup
 	SandboxCgroupOnly bool
 
 	// Determines if enable pprof


### PR DESCRIPTION
This PR introduced the `log_level` configuration for `runtime` and `kata-agent` to enable more granular control of which log lines are produced. The `log_level` configuration takes precedence over `debug` if both are set. Currently, kata-agent's log is streamed out by `consoleWatcher` and is [always logged with Debug](https://github.com/kata-containers/kata-containers/blob/54f2b296e373f24722dc82045b5f1b6315feadad/src/runtime/virtcontainers/sandbox.go#L1058). This PR improves this by parsing the log line and log using the same log level used in `kata-agent`. 

In addition to the feature added, this PR has the following small changes: 
1. This PR sets the default `log_level` to be `warn` for both runtime and agent.
2. This PR makes the `consoleWatcher` always start. As consoleWatcher's job is to stream the kata agent's log, if people are worried about too many logs from agent, now we can control it by using the correct log_level.

A rewritten and some enhancements based from https://github.com/kata-containers/kata-containers/pull/4148.

Fixes: https://github.com/kata-containers/kata-containers/issues/366
Signed-off-by: yumingqiao qym316@gmail.com