### PR TITLE
Stable-3.0 | Upgrade to Cloud Hypervisor v28.2 

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v28.1"
+      version: "v28.2"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This patch upgrade Cloud Hypervisor to its latest bug release v28.2: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v28.2

Fixes: #6138

Signed-off-by: Bo Chen <chen.bo@intel.com>