### PR TITLE
virtiofsd: fix the build on ppc64le

### DIFF
--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -57,6 +57,7 @@ init_env() {
 			LIBC="gnu"
 			ARCH="powerpc64le"
 			ARCH_LIBC=${ARCH}-linux-${LIBC}
+			extra_rust_flags=""
 			;;
 		"s390x")
 			LIBC="gnu"


### PR DESCRIPTION
`link-self-contained` is not supported on ppc64le rust target.
Hence, do not pass it while building virtiofsd.

Fixes: #6195

Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>