### PR TITLE
Add kernel-dragonball-experimental to kata-deploy, kata-deploy-test, and the release

### DIFF
--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         asset:
           - kernel
+          - kernel-dragonball-experimental
           - shim-v2
           - qemu
           - cloud-hypervisor

--- a/.github/workflows/kata-deploy-test.yaml
+++ b/.github/workflows/kata-deploy-test.yaml
@@ -50,6 +50,7 @@ jobs:
           - cloud-hypervisor
           - firecracker
           - kernel
+          - kernel-dragonball-experimental
           - nydus
           - qemu
           - rootfs-image

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
           - cloud-hypervisor
           - firecracker
           - kernel
+          - kernel-dragonball-experimental
           - nydus
           - qemu
           - rootfs-image

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -24,6 +24,7 @@ all-parallel: $(MK_DIR)/dockerbuild/install_yq.sh
 all: serial-targets \
 	firecracker-tarball \
 	kernel-tarball \
+	kernel-dragonball-experimental-tarball \
 	nydus-tarball \
 	qemu-tarball \
 	shim-v2-tarball \
@@ -45,6 +46,9 @@ firecracker-tarball:
 	${MAKE} $@-build
 
 kernel-tarball:
+	${MAKE} $@-build
+
+kernel-dragonball-experimental-tarball:
 	${MAKE} $@-build
 
 kernel-experimental-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -73,6 +73,7 @@ options:
 	cloud-hypervisor
 	firecracker
 	kernel
+	kernel-dragonball-experimental
 	kernel-experimental
 	nydus
 	qemu
@@ -103,6 +104,13 @@ install_kernel() {
 	DESTDIR="${destdir}" PREFIX="${prefix}" "${kernel_builder}" -f -v "${kernel_version}"
 }
 
+#Install dragonball experimental kernel asset
+install_dragonball_experimental_kernel() {
+	info "build dragonball experimental kernel"
+	export kernel_version="$(yq r $versions_yaml assets.dragonball-kernel-experimental.version)"
+	info "kernel version ${kernel_version}"
+	DESTDIR="${destdir}" PREFIX="${prefix}" "${kernel_builder}" -e -t dragonball -v ${kernel_version}	
+}
 
 #Install experimental kernel asset
 install_experimental_kernel() {
@@ -203,6 +211,8 @@ handle_build() {
 	kernel) install_kernel ;;
 
 	nydus) install_nydus ;;
+
+	kernel-dragonball-experimental) install_dragonball_experimental_kernel;;
 
 	kernel-experimental) install_experimental_kernel;;
 


### PR DESCRIPTION
kata-deploy: Add kernel-dragonball-experimental target

As Chao Wu added the support for building the dragonball kernel as a new
experimental kernel, let's make sure we reflect that as part of the
kata-deploy build scripts.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

---

release: Add the dragonball-experimental kernel

Let's add the dragonball specific kernel, which takes advantage of
upcall, as part of the release tarball, so it can be used from the
release tarball / kata-deploy.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

---

kata-deploy-test: Ensure we build dragonball specific kernel

As the dragonball specific kernel is now part of the release, let's make
sure we build it as part of the kata-deploy-test action.

Fixes: #5859

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

---