### PR TITLE
shim-v2/build.sh: Only build runtime-rs for the supported arches

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -28,11 +28,17 @@ default:
 test:
 	@echo "s390x is not currently supported"
 	exit 0
+install:
+	@echo "s390x is not currently supported"
+	exit 0
 else ifeq ($(ARCH), powerpc64le)
 default:
 	@echo "PowerPC 64 LE is not currently supported"
 	exit 0
 test:
+	@echo "PowerPC 64 LE is not currently supported"
+	exit 0
+install:
 	@echo "PowerPC 64 LE is not currently supported"
 	exit 0
 else
@@ -41,6 +47,7 @@ default: runtime show-header
 ##TARGET test: run cargo tests
 test:
 	@cargo test --all --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
+install: install-runtime install-configs
 endif
 
 ifeq (,$(realpath $(ARCH_FILE)))
@@ -490,8 +497,6 @@ codecov: check_tarpaulin
 ##TARGET codecov-html: Generate code coverage html report
 codecov-html: check_tarpaulin
 	cargo tarpaulin $(TARPAULIN_ARGS) -o Html
-
-install: install-runtime install-configs
 
 install-runtime: runtime
 	install -D $(TARGET_PATH) $(DESTDIR)$(BINDIR)/$(notdir $(TARGET_PATH))

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -28,6 +28,13 @@ default:
 test:
 	@echo "s390x not support currently"
 	exit 0
+else ifeq ($(ARCH), powerpc64le)
+default:
+	@echo "PowerPC 64 LE is not currently supported"
+	exit 0
+test:
+	@echo "PowerPC 64 LE is not currently supported"
+	exit 0
 else
 ##TARGET default: build code
 default: runtime show-header

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -23,10 +23,10 @@ ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 
 ifeq ($(ARCH), s390x)
 default:
-	@echo "s390x not support currently"
+	@echo "s390x is not currently supported"
 	exit 0
 test:
-	@echo "s390x not support currently"
+	@echo "s390x is not currently supported"
 	exit 0
 else ifeq ($(ARCH), powerpc64le)
 default:


### PR DESCRIPTION
Right now only x86_64 and ARM are supported.

Fixes: #6142

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>