### PR TITLE
runtime: return fake pid for exec process exit events

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/utils.go
+++ b/src/runtime/pkg/containerd-shim-v2/utils.go
@@ -22,9 +22,15 @@ import (
 )
 
 func cReap(s *service, status int, id, execid string, exitat time.Time) {
+	var pid uint32
+	if execid == "" {
+		pid = s.hpid
+	} else {
+		pid = 0
+	}
 	s.ec <- exit{
 		timestamp: exitat,
-		pid:       s.hpid,
+		pid:       pid,
 		status:    status,
 		id:        id,
 		execid:    execid,


### PR DESCRIPTION
We cannot return the container ID 'cause that can make moby think that the container process itself exits. Let's return a fake pid 0 here.

Fixes: #6154