### PR TITLE
agent: Use cgroup.kill where supported

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -180,6 +180,11 @@ impl CgroupManager for Manager {
         Ok(())
     }
 
+    fn kill(&self) -> Result<()> {
+        self.cgroup.kill()?;
+        Ok(())
+    }
+
     fn destroy(&mut self) -> Result<()> {
         let _ = self.cgroup.delete();
         Ok(())

--- a/src/agent/rustjail/src/cgroups/mod.rs
+++ b/src/agent/rustjail/src/cgroups/mod.rs
@@ -33,6 +33,10 @@ pub trait Manager {
         Err(anyhow!("not supported!"))
     }
 
+    fn kill(&self) -> Result<()> {
+        Err(anyhow!("not supported!"))
+    }
+
     fn destroy(&mut self) -> Result<()> {
         Err(anyhow!("not supported!"))
     }

--- a/src/agent/rustjail/src/cgroups/systemd/manager.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/manager.rs
@@ -80,6 +80,10 @@ impl CgroupManager for Manager {
         self.fs_manager.freeze(state)
     }
 
+    fn kill(&self) -> Result<()> {
+        self.fs_manager.kill()
+    }
+
     fn destroy(&mut self) -> Result<()> {
         self.dbus_client.stop_unit(self.unit_name.as_str())?;
         self.fs_manager.destroy()

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1140,10 +1140,18 @@ impl BaseContainer for LinuxContainer {
         // Kill all of the processes created in this container to prevent
         // the leak of some daemon process when this container shared pidns
         // with the sandbox.
-        let pids = cgm.get_pids().context("get cgroup pids")?;
-        for i in pids {
-            if let Err(e) = signal::kill(Pid::from_raw(i), Signal::SIGKILL) {
-                warn!(self.logger, "kill the process {} error: {:?}", i, e);
+        //
+        // Try and fast path (write to cgroup.kill on 5.14+ kernels) first.
+        if let Err(err) = cgm.kill() {
+            warn!(
+                self.logger,
+                "failed to fast path kill cgroup, falling back: {:?}", err
+            );
+            let pids = cgm.get_pids().context("get cgroup pids")?;
+            for i in pids {
+                if let Err(e) = signal::kill(Pid::from_raw(i), Signal::SIGKILL) {
+                    warn!(self.logger, "kill the process {} error: {:?}", i, e);
+                }
             }
         }
 


### PR DESCRIPTION
Fixes: #6077

In 5.14+ you can write to a cgroup.kill file that will send a SIGKILL to every process in the group for you. Support for this was recently added to cgroups-rs and brought in here so we can make use of it. This can avoid the Freeze -> Send signal -> Thaw dance that we use here, as well as looping through the pids of a cgroup and sending SIGKILL manually.