### PR TITLE
CC | Take runtime-rs into consideration when building and caching the shim-v2 tarball

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -330,9 +330,11 @@ install_cc_qemu() {
 #Install all components that are not assets
 install_cc_shimv2() {
 	local shim_v2_last_commit="$(get_last_modification "${repo_root_dir}/src/runtime")"
+	local runtime_rs_last_commit="$(get_last_modification "${repo_root_dir}/src/runtime-rs")"
+	local protocols_last_commit="$(get_last_modification "${repo_root_dir}/src/libs/protocols")"
 	local golang_version="$(get_from_kata_deps "languages.golang.meta.newest-version")"
 	local rust_version="$(get_from_kata_deps "languages.rust.meta.newest-version")"
-	local shim_v2_version="${shim_v2_last_commit}-${golang_version}-${rust_version}"
+	local shim_v2_version="${shim_v2_last_commit}-${protocols_last_commit}-${runtime_rs_last_commit}-${golang_version}-${rust_version}"
 
 	install_cached_cc_shim_v2 \
 		"shim-v2" \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -344,7 +344,9 @@ install_cc_shimv2() {
 		&& return 0
 
 	GO_VERSION="$(yq r ${versions_yaml} languages.golang.meta.newest-version)"
+	RUST_VERSION="$(yq r ${versions_yaml} languages.rust.meta.newest-version)"
 	export GO_VERSION
+	export RUST_VERSION
 	export REMOVE_VMM_CONFIGS="acrn fc"
 
         extra_opts="DEFSERVICEOFFLOAD=true"

--- a/tools/packaging/static-build/cache_components.sh
+++ b/tools/packaging/static-build/cache_components.sh
@@ -111,9 +111,11 @@ cache_rootfs_artifacts() {
 cache_shim_v2_artifacts() {
 	local shim_v2_tarball_name="kata-static-cc-shim-v2.tar.xz"
 	local shim_v2_last_commit="$(get_last_modification "${repo_root_dir}/src/runtime")"
+	local protocols_last_commit="$(get_last_modification "${repo_root_dir}/src/libs/protocols")"
+	local runtime_rs_last_commit="$(get_last_modification "${repo_root_dir}/src/runtime-rs")"
 	local golang_version="$(get_from_kata_deps "languages.golang.meta.newest-version")"
 	local rust_version="$(get_from_kata_deps "languages.rust.meta.newest-version")"
-	local current_shim_v2_version="${shim_v2_last_commit}-${golang_version}-${rust_version}"
+	local current_shim_v2_version="${shim_v2_last_commit}-${protocols_last_commit}-${runtime_rs_last_commit}-${golang_version}-${rust_version}"
 	local current_shim_v2_image="$(get_shim_v2_image_name)"
 	create_cache_asset "${shim_v2_tarball_name}" "${current_shim_v2_version}" "${current_shim_v2_image}" "${repo_root_dir}/tools/osbuilder/root_hash_vanilla.txt" "${repo_root_dir}/tools/osbuilder/root_hash_tdx.txt"
 }

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -15,7 +15,7 @@ source "${script_dir}/../../scripts/lib.sh"
 readonly kernel_builder="${repo_root_dir}/tools/packaging/kernel/build-kernel.sh"
 
 GO_VERSION=${GO_VERSION}
-RUST_VERSION=${RUST_VERSION:-}
+RUST_VERSION=${RUST_VERSION}
 
 DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
@@ -38,18 +38,16 @@ if [ ${arch} = "ppc64le" ]; then
 	arch="ppc64"
 fi
 
-if [ -n "${RUST_VERSION}" ]; then
-	sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
-		-w "${repo_root_dir}/src/runtime-rs" \
-		"${container_image}" \
-		bash -c "git config --global --add safe.directory ${repo_root_dir} && make PREFIX=${PREFIX} QEMUCMD=qemu-system-${arch}"
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${repo_root_dir}/src/runtime-rs" \
+	"${container_image}" \
+	bash -c "git config --global --add safe.directory ${repo_root_dir} && make PREFIX=${PREFIX} QEMUCMD=qemu-system-${arch}"
 
-	sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
-		-w "${repo_root_dir}/src/runtime-rs" \
-		"${container_image}" \
-		bash -c "git config --global --add safe.directory ${repo_root_dir} && make PREFIX="${PREFIX}" DESTDIR="${DESTDIR}" install"
-fi
-
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${repo_root_dir}/src/runtime-rs" \
+	"${container_image}" \
+	bash -c "git config --global --add safe.directory ${repo_root_dir} && make PREFIX="${PREFIX}" DESTDIR="${DESTDIR}" install"
+	
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${repo_root_dir}/src/runtime" \
 	"${container_image}" \

--- a/tools/packaging/static-build/shim-v2/install_go_rust.sh
+++ b/tools/packaging/static-build/shim-v2/install_go_rust.sh
@@ -51,13 +51,11 @@ EOF
 trap finish EXIT
 
 rust_version=${2:-}
-if [ -n "${rust_version}" ]; then
-	ARCH=${ARCH:-$(uname -m)}
-	LIBC=${LIBC:-musl}
-	curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSLf | sh -s -- -y --default-toolchain ${rust_version} -t ${ARCH}-unknown-linux-${LIBC}
-	source /root/.cargo/env
-	rustup target add x86_64-unknown-linux-musl
-fi
+ARCH=${ARCH:-$(uname -m)}
+LIBC=${LIBC:-musl}
+curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSLf | sh -s -- -y --default-toolchain ${rust_version} -t ${ARCH}-unknown-linux-${LIBC}
+source /root/.cargo/env
+rustup target add x86_64-unknown-linux-musl
 
 pushd "${tmp_dir}"
 


### PR DESCRIPTION
We've disabled building shim-v2 as part of https://github.com/kata-containers/kata-containers/commit/299829aec09a1f237b85bc6cebd49980766ef33f. However, now TDX support will be implemented there and we must start considering it for building and caching the shim-v2 tarball.