### PR TITLE
Update lib.h to build rootfs on ubuntu

### DIFF
--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -126,8 +126,10 @@ build_rootfs()
 		PKG_MANAGER="dnf"
 	elif check_program "yum" ; then
 		PKG_MANAGER="yum"
+	elif check_program "apt-get" ; then
+		PKG_MANAGER="apt-get"
 	else
-		die "neither yum nor dnf is installed"
+		die "neither yum, apt-get nor dnf is installed"
 	fi
 
 	DNF="${PKG_MANAGER} -y --installroot=${ROOTFS_DIR} --noplugins"


### PR DESCRIPTION
Update lib.h to build rootfs on ubuntu, added "apt-get" option.  Tested and successfully build rootfs on ubuntu.
Log:
```
...
Installing systemd unit files...
install -D -m 644 kata-agent.service /rootfs/usr/lib/systemd/system/kata-agent.service || exit 1; 	install -D -m 644 kata-containers.target /rootfs/usr/lib/systemd/system/kata-containers.target || exit 1;
/
[OK] Agent installed
INFO: Check init is installed
[OK] init is installed
INFO: Create /etc/resolv.conf file in rootfs if not exist
INFO: Creating summary file
INFO: Created summary file '/var/lib/osbuilder/osbuilder.yaml' inside rootfs
Script done, file is typescript
```