### PR TITLE
cni: Update cni plugins version to 1.2.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -193,7 +193,7 @@ externals:
   cni-plugins:
     description: "CNI network plugins"
     url: "https://github.com/containernetworking/plugins"
-    version: "v1.1.1"
+    version: "v1.2.0"
 
   conmon:
     description: "An OCI container runtime monitor"


### PR DESCRIPTION
A new release was made for the cni plugins. Use the new version for the CI.

Fixes: #6169

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>