### PR TITLE
runtime: unix socket file leak

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -960,6 +960,13 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (_ *
 
 	s.cancel()
 
+	// We must clean up the socket file before os.Exit(0)
+	if address, err := cdshim.ReadAddress("address"); err == nil {
+		if err = cdshim.RemoveSocket(address); err != nil {
+			shimLog.WithError(err).Warnf("failed to rm unix socket file %s", address)
+		}
+	}
+
 	// Since we only send an shutdown qmp command to qemu when do stopSandbox, and
 	// didn't wait until qemu process's exit, thus we'd better to make sure it had
 	// exited when shimv2 terminated. Thus here to do the last cleanup of the hypervisor.


### PR DESCRIPTION
When the shim process starts, a unix socket is created as the service listening address, and it is created in the /run/containerd/s/ directory. But it's not being cleaned up as expected when the shim process exits.

I found the corresponding cleaning logic in the shim framework code, as follows:

// NOTE: If the shim server is down(like oom killer), the address 
// socket might be leaking.
if address, err := ReadAddress("address"); err == nil {
     _ = RemoveSocket(address)
}

But because the shim process will exit through os.Exit(0) in the ShutDown interface, the above code will not be executed. We need to execute it before os.Exit(0).

Fixes: #6171

Signed-off-by: ls <335814617@qq.com>