### PR TITLE
runtime: Drop QEMU log file support

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -2628,9 +2628,6 @@ type Config struct {
 	// PidFile is the -pidfile parameter
 	PidFile string
 
-	// LogFile is the -D parameter
-	LogFile string
-
 	qemuParams []string
 }
 
@@ -2968,13 +2965,6 @@ func (config *Config) appendPidFile() {
 	}
 }
 
-func (config *Config) appendLogFile() {
-	if config.LogFile != "" {
-		config.qemuParams = append(config.qemuParams, "-D")
-		config.qemuParams = append(config.qemuParams, config.LogFile)
-	}
-}
-
 func (config *Config) appendFwCfg(logger QMPLog) {
 	if logger == nil {
 		logger = qmpNullLogger{}
@@ -3013,7 +3003,6 @@ func LaunchQemu(config Config, logger QMPLog) (*exec.Cmd, io.ReadCloser, error) 
 	config.appendIOThreads()
 	config.appendIncoming()
 	config.appendPidFile()
-	config.appendLogFile()
 	config.appendFwCfg(logger)
 	config.appendSeccompSandbox()
 

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -764,8 +764,7 @@ func TestAppendQMPSocketServer(t *testing.T) {
 }
 
 var pidfile = "/run/vc/vm/iamsandboxid/pidfile"
-var logfile = "/run/vc/vm/iamsandboxid/logfile"
-var qemuString = "-name cc-qemu -cpu host -uuid " + agentUUID + " -pidfile " + pidfile + " -D " + logfile
+var qemuString = "-name cc-qemu -cpu host -uuid " + agentUUID + " -pidfile " + pidfile
 
 func TestAppendStrings(t *testing.T) {
 	config := Config{
@@ -774,14 +773,12 @@ func TestAppendStrings(t *testing.T) {
 		UUID:     agentUUID,
 		CPUModel: "host",
 		PidFile:  pidfile,
-		LogFile:  logfile,
 	}
 
 	config.appendName()
 	config.appendCPUModel()
 	config.appendUUID()
 	config.appendPidFile()
-	config.appendLogFile()
 
 	result := strings.Join(config.qemuParams, " ")
 	if result != qemuString {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -940,10 +940,6 @@ func (q *qemu) StartVM(ctx context.Context, timeout int) error {
 		return err
 	}
 	q.Logger().WithField("vm path", vmPath).Info("created vm path")
-	// append logfile only on debug
-	if q.config.Debug {
-		q.qemuConfig.LogFile = filepath.Join(vmPath, "qemu.log")
-	}
 
 	defer func() {
 		if err != nil {
@@ -1107,19 +1103,6 @@ func (q *qemu) StopVM(ctx context.Context, waitOnly bool) (err error) {
 			atomic.StoreInt32(&q.stopped, 1)
 		}
 	}()
-
-	if q.config.Debug && q.qemuConfig.LogFile != "" {
-		f, err := os.OpenFile(q.qemuConfig.LogFile, os.O_RDONLY, 0)
-		if err == nil {
-			scanner := bufio.NewScanner(f)
-			for scanner.Scan() {
-				q.Logger().WithField("file", q.qemuConfig.LogFile).Debug(scanner.Text())
-			}
-			if err := scanner.Err(); err != nil {
-				q.Logger().WithError(err).Debug("read qemu log failed")
-			}
-		}
-	}
 
 	if err := q.qmpSetup(); err != nil {
 		return err


### PR DESCRIPTION
The QEMU log file is essentially about fine grain tracing of QEMU internals and mostly useful for developpers, not production. Notably, the log file isn't limited in size, nor rotated in any way. It means that a container running in the VM could possibly flood the log file with a guest triggerable trace. For example, on openshift, the log file is supposed to reside on a per-VM 14 GiB tmpfs mount. This means that each pod running with the kata runtime could potentially consume this amount of host RAM which is not acceptable.

Error messages are best collected from QEMU's stderr as kata is doing now since PR #5736 was merged. Drop support for the QEMU log file because it doesn't bring any value but can certainly do harm.

Fixes #6173

Signed-off-by: Greg Kurz <groug@kaod.org>