### PR TITLE
Qemu logs for stable 3.0

### DIFF
--- a/src/runtime/pkg/govmm/qemu/examples_test.go
+++ b/src/runtime/pkg/govmm/qemu/examples_test.go
@@ -27,13 +27,16 @@ func Example() {
 	// resources
 	params = append(params, "-m", "370", "-smp", "cpus=2")
 
-	// LaunchCustomQemu should return as soon as the instance has launched as we
-	// are using the --daemonize flag.  It will set up a unix domain socket
-	// called /tmp/qmp-socket that we can use to manage the instance.
-	_, err := qemu.LaunchCustomQemu(context.Background(), "", params, nil, nil, nil)
+	// LaunchCustomQemu should return immediately. We must then wait
+	// the returned process to terminate as we are using the --daemonize
+	// flag.
+	// It will set up a unix domain socket called /tmp/qmp-socket that we
+	// can use to manage the instance.
+	proc, err := qemu.LaunchCustomQemu(context.Background(), "", params, nil, nil, nil)
 	if err != nil {
 		panic(err)
 	}
+	proc.Wait()
 
 	// This channel will be closed when the instance dies.
 	disconnectedCh := make(chan struct{})

--- a/src/runtime/pkg/govmm/qemu/examples_test.go
+++ b/src/runtime/pkg/govmm/qemu/examples_test.go
@@ -32,7 +32,7 @@ func Example() {
 	// flag.
 	// It will set up a unix domain socket called /tmp/qmp-socket that we
 	// can use to manage the instance.
-	proc, err := qemu.LaunchCustomQemu(context.Background(), "", params, nil, nil, nil)
+	proc, _, err := qemu.LaunchCustomQemu(context.Background(), "", params, nil, nil, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -16,6 +16,7 @@ package qemu
 import (
 	"context"
 	"fmt"
+	"io"
 	"log"
 	"os"
 	"os/exec"
@@ -2967,7 +2968,7 @@ func (config *Config) appendFwCfg(logger QMPLog) {
 // The Config parameter contains a set of qemu parameters and settings.
 //
 // See LaunchCustomQemu for more information.
-func LaunchQemu(config Config, logger QMPLog) (*exec.Cmd, error) {
+func LaunchQemu(config Config, logger QMPLog) (*exec.Cmd, io.ReadCloser, error) {
 	config.appendName()
 	config.appendUUID()
 	config.appendMachine()
@@ -2990,7 +2991,7 @@ func LaunchQemu(config Config, logger QMPLog) (*exec.Cmd, error) {
 	config.appendSeccompSandbox()
 
 	if err := config.appendCPUs(); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	ctx := config.Ctx
@@ -3021,11 +3022,12 @@ func LaunchQemu(config Config, logger QMPLog) (*exec.Cmd, error) {
 //
 // This function writes its log output via logger parameter.
 //
-// The function returns cmd, nil where cmd is a Go exec.Cmd object
-// representing the QEMU process if launched successfully. Otherwise
-// nil, err where err is a Go error object is returned.
+// The function returns cmd, reader, nil where cmd is a Go exec.Cmd object
+// representing the QEMU process and reader a Go io.ReadCloser object
+// connected to QEMU's stderr, if launched successfully. Otherwise
+// nil, nil, err where err is a Go error object is returned.
 func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*os.File,
-	attr *syscall.SysProcAttr, logger QMPLog) (*exec.Cmd, error) {
+	attr *syscall.SysProcAttr, logger QMPLog) (*exec.Cmd, io.ReadCloser, error) {
 	if logger == nil {
 		logger = qmpNullLogger{}
 	}
@@ -3043,12 +3045,17 @@ func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*
 
 	cmd.SysProcAttr = attr
 
+	reader, err := cmd.StderrPipe()
+	if err != nil {
+		logger.Errorf("Unable to connect stderr to a pipe")
+		return nil, nil, err
+	}
 	logger.Infof("launching %s with: %v", path, params)
 
-	err := cmd.Start()
+	err = cmd.Start()
 	if err != nil {
 		logger.Errorf("Unable to launch %s: %v", path, err)
-		return nil, err
+		return nil, nil, err
 	}
-	return cmd, nil
+	return cmd, reader, nil
 }

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -2611,9 +2611,6 @@ type Config struct {
 	// PidFile is the -pidfile parameter
 	PidFile string
 
-	// LogFile is the -D parameter
-	LogFile string
-
 	qemuParams []string
 }
 
@@ -2941,13 +2938,6 @@ func (config *Config) appendPidFile() {
 	}
 }
 
-func (config *Config) appendLogFile() {
-	if config.LogFile != "" {
-		config.qemuParams = append(config.qemuParams, "-D")
-		config.qemuParams = append(config.qemuParams, config.LogFile)
-	}
-}
-
 func (config *Config) appendFwCfg(logger QMPLog) {
 	if logger == nil {
 		logger = qmpNullLogger{}
@@ -2986,7 +2976,6 @@ func LaunchQemu(config Config, logger QMPLog) (*exec.Cmd, io.ReadCloser, error) 
 	config.appendIOThreads()
 	config.appendIncoming()
 	config.appendPidFile()
-	config.appendLogFile()
 	config.appendFwCfg(logger)
 	config.appendSeccompSandbox()
 

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -14,7 +14,6 @@
 package qemu
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"log"
@@ -2967,12 +2966,8 @@ func (config *Config) appendFwCfg(logger QMPLog) {
 //
 // The Config parameter contains a set of qemu parameters and settings.
 //
-// This function writes its log output via logger parameter.
-//
-// The function will block until the launched qemu process exits.  "", nil
-// will be returned if the launch succeeds.  Otherwise a string containing
-// the contents of stderr + a Go error object will be returned.
-func LaunchQemu(config Config, logger QMPLog) (string, error) {
+// See LaunchCustomQemu for more information.
+func LaunchQemu(config Config, logger QMPLog) (*exec.Cmd, error) {
 	config.appendName()
 	config.appendUUID()
 	config.appendMachine()
@@ -2995,7 +2990,7 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 	config.appendSeccompSandbox()
 
 	if err := config.appendCPUs(); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	ctx := config.Ctx
@@ -3026,16 +3021,14 @@ func LaunchQemu(config Config, logger QMPLog) (string, error) {
 //
 // This function writes its log output via logger parameter.
 //
-// The function will block until the launched qemu process exits.  "", nil
-// will be returned if the launch succeeds.  Otherwise a string containing
-// the contents of stderr + a Go error object will be returned.
+// The function returns cmd, nil where cmd is a Go exec.Cmd object
+// representing the QEMU process if launched successfully. Otherwise
+// nil, err where err is a Go error object is returned.
 func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*os.File,
-	attr *syscall.SysProcAttr, logger QMPLog) (string, error) {
+	attr *syscall.SysProcAttr, logger QMPLog) (*exec.Cmd, error) {
 	if logger == nil {
 		logger = qmpNullLogger{}
 	}
-
-	errStr := ""
 
 	if path == "" {
 		path = "qemu-system-x86_64"
@@ -3050,15 +3043,12 @@ func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*
 
 	cmd.SysProcAttr = attr
 
-	var stderr bytes.Buffer
-	cmd.Stderr = &stderr
 	logger.Infof("launching %s with: %v", path, params)
 
-	err := cmd.Run()
+	err := cmd.Start()
 	if err != nil {
 		logger.Errorf("Unable to launch %s: %v", path, err)
-		errStr = stderr.String()
-		logger.Errorf("%s", errStr)
+		return nil, err
 	}
-	return errStr, err
+	return cmd, nil
 }

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -698,8 +698,8 @@ func TestFailToAppendCPUs(t *testing.T) {
 	}
 }
 
-var qmpSingleSocketServerString = "-qmp unix:cc-qmp,server=on,wait=off"
-var qmpSingleSocketString = "-qmp unix:cc-qmp"
+var qmpSingleSocketServerString = "-qmp unix:path=cc-qmp,server=on,wait=off"
+var qmpSingleSocketString = "-qmp unix:path=cc-qmp"
 
 func TestAppendSingleQMPSocketServer(t *testing.T) {
 	qmp := QMPSocket{
@@ -722,7 +722,27 @@ func TestAppendSingleQMPSocket(t *testing.T) {
 	testAppend(qmp, qmpSingleSocketString, t)
 }
 
-var qmpSocketServerString = "-qmp unix:cc-qmp-1,server=on,wait=off -qmp unix:cc-qmp-2,server=on,wait=off"
+var qmpSocketServerFdString = "-qmp unix:fd=3,server=on,wait=off"
+
+func TestAppendQMPSocketServerFd(t *testing.T) {
+	foo, _ := os.CreateTemp(os.TempDir(), "govmm-qemu-test")
+
+	defer func() {
+		_ = foo.Close()
+		_ = os.Remove(foo.Name())
+	}()
+
+	qmp := QMPSocket{
+		Type:   "unix",
+		FD:     foo,
+		Server: true,
+		NoWait: true,
+	}
+
+	testAppend(qmp, qmpSocketServerFdString, t)
+}
+
+var qmpSocketServerString = "-qmp unix:path=cc-qmp-1,server=on,wait=off -qmp unix:path=cc-qmp-2,server=on,wait=off"
 
 func TestAppendQMPSocketServer(t *testing.T) {
 	qmp := []QMPSocket{

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -764,8 +764,7 @@ func TestAppendQMPSocketServer(t *testing.T) {
 }
 
 var pidfile = "/run/vc/vm/iamsandboxid/pidfile"
-var logfile = "/run/vc/vm/iamsandboxid/logfile"
-var qemuString = "-name cc-qemu -cpu host -uuid " + agentUUID + " -pidfile " + pidfile + " -D " + logfile
+var qemuString = "-name cc-qemu -cpu host -uuid " + agentUUID + " -pidfile " + pidfile
 
 func TestAppendStrings(t *testing.T) {
 	config := Config{
@@ -774,14 +773,12 @@ func TestAppendStrings(t *testing.T) {
 		UUID:     agentUUID,
 		CPUModel: "host",
 		PidFile:  pidfile,
-		LogFile:  logfile,
 	}
 
 	config.appendName()
 	config.appendCPUModel()
 	config.appendUUID()
 	config.appendPidFile()
-	config.appendLogFile()
 
 	result := strings.Join(config.qemuParams, " ")
 	if result != qemuString {

--- a/src/runtime/pkg/govmm/qemu/qmp.go
+++ b/src/runtime/pkg/govmm/qemu/qmp.go
@@ -702,6 +702,16 @@ func QMPStart(ctx context.Context, socket string, cfg QMPConfig, disconnectedCh 
 		return nil, nil, err
 	}
 
+	return QMPStartWithConn(ctx, conn, cfg, disconnectedCh)
+}
+
+// Same as QMPStart but with a pre-established connection
+func QMPStartWithConn(ctx context.Context, conn net.Conn, cfg QMPConfig, disconnectedCh chan struct{}) (*QMP, *QMPVersion, error) {
+	if conn == nil {
+		close(disconnectedCh)
+		return nil, nil, fmt.Errorf("invalid connection")
+	}
+
 	connectedCh := make(chan *QMPVersion)
 
 	q := startQMPLoop(conn, cfg, connectedCh, disconnectedCh)

--- a/src/runtime/pkg/govmm/qemu/qmp_test.go
+++ b/src/runtime/pkg/govmm/qemu/qmp_test.go
@@ -273,6 +273,22 @@ func TestQMPStartBadPath(t *testing.T) {
 	<-disconnectedCh
 }
 
+// Checks that a call to QMPStartWithConn with a nil connection exits gracefully.
+//
+// We call QMPStartWithConn with a nil connection.
+//
+// An error should be returned and the disconnected channel should be closed.
+func TestQMPStartWithConnNil(t *testing.T) {
+	cfg := QMPConfig{Logger: qmpTestLogger{}}
+	disconnectedCh := make(chan struct{})
+	q, _, err := QMPStartWithConn(context.Background(), nil, cfg, disconnectedCh)
+	if err == nil {
+		t.Errorf("Expected error")
+		q.Shutdown()
+	}
+	<-disconnectedCh
+}
+
 // Checks that the qmp_capabilities command is correctly sent.
 //
 // We start a QMPLoop, send the qmp_capabilities command and stop the

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -15,6 +15,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -359,7 +360,6 @@ func (q *qemu) createQmpSocket() ([]govmmQemu.QMPSocket, error) {
 	return []govmmQemu.QMPSocket{
 		{
 			Type:   "unix",
-			Name:   q.qmpMonitorCh.path,
 			Server: true,
 			NoWait: true,
 		},
@@ -796,6 +796,59 @@ func (q *qemu) setupVirtioMem(ctx context.Context) error {
 	return err
 }
 
+// setupEarlyQmpConnection creates a listener socket to be passed to QEMU
+// as a QMP listening endpoint. An initial connection is established, to
+// be used as the QMP client socket. This allows to detect an early failure
+// of QEMU instead of looping on connect until some timeout expires.
+func (q *qemu) setupEarlyQmpConnection() (net.Conn, error) {
+	monitorSockPath := q.qmpMonitorCh.path
+
+	qmpListener, err := net.Listen("unix", monitorSockPath)
+	if err != nil {
+		q.Logger().WithError(err).Errorf("Unable to listen on unix socket address (%s)", monitorSockPath)
+		return nil, err
+	}
+
+	// A duplicate fd of this socket will be passed to QEMU. We must
+	// close the original one when we're done.
+	defer qmpListener.Close()
+
+	if rootless.IsRootless() {
+		err = syscall.Chown(monitorSockPath, int(q.config.Uid), int(q.config.Gid))
+		if err != nil {
+			q.Logger().WithError(err).Errorf("Unable to make unix socket (%s) rootless", monitorSockPath)
+			return nil, err
+		}
+	}
+
+	VMFd, err := qmpListener.(*net.UnixListener).File()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if err != nil {
+			VMFd.Close()
+		}
+	}()
+
+	// This socket will be used to establish the initial QMP connection
+	dialer := net.Dialer{Cancel: q.qmpMonitorCh.ctx.Done()}
+	conn, err := dialer.Dial("unix", monitorSockPath)
+	if err != nil {
+		q.Logger().WithError(err).Errorf("Unable to connect to unix socket (%s)", monitorSockPath)
+		return nil, err
+	}
+
+	// We need to keep the socket file around to be able to re-connect
+	qmpListener.(*net.UnixListener).SetUnlinkOnClose(false)
+
+	// Pass the duplicated fd of the listener socket to QEMU
+	q.qemuConfig.QMPSockets[0].FD = VMFd
+	q.fds = append(q.fds, q.qemuConfig.QMPSockets[0].FD)
+
+	return conn, nil
+}
+
 // StartVM will start the Sandbox's VM.
 func (q *qemu) StartVM(ctx context.Context, timeout int) error {
 	span, ctx := katatrace.Trace(ctx, q.Logger(), "StartVM", qemuTracingTags, map[string]string{"sandbox_id": q.id})
@@ -841,6 +894,12 @@ func (q *qemu) StartVM(ctx context.Context, timeout int) error {
 		}
 	}()
 
+	var qmpConn net.Conn
+	qmpConn, err = q.setupEarlyQmpConnection()
+	if err != nil {
+		return err
+	}
+
 	// This needs to be done as late as possible, just before launching
 	// virtiofsd are executed by kata-runtime after this call, run with
 	// the SELinux label. If these processes require privileged, we do
@@ -880,7 +939,7 @@ func (q *qemu) StartVM(ctx context.Context, timeout int) error {
 		return fmt.Errorf("failed to launch qemu: %s, error messages from qemu log: %s", err, strErr)
 	}
 
-	err = q.waitVM(ctx, timeout)
+	err = q.waitVM(ctx, qmpConn, timeout)
 	if err != nil {
 		return err
 	}
@@ -918,7 +977,7 @@ func (q *qemu) bootFromTemplate() error {
 }
 
 // waitVM will wait for the Sandbox's VM to be up and running.
-func (q *qemu) waitVM(ctx context.Context, timeout int) error {
+func (q *qemu) waitVM(ctx context.Context, qmpConn net.Conn, timeout int) error {
 	span, _ := katatrace.Trace(ctx, q.Logger(), "waitVM", qemuTracingTags, map[string]string{"sandbox_id": q.id})
 	defer span.End()
 
@@ -938,7 +997,7 @@ func (q *qemu) waitVM(ctx context.Context, timeout int) error {
 	timeStart := time.Now()
 	for {
 		disconnectCh = make(chan struct{})
-		qmp, ver, err = govmmQemu.QMPStart(q.qmpMonitorCh.ctx, q.qmpMonitorCh.path, cfg, disconnectCh)
+		qmp, ver, err = govmmQemu.QMPStartWithConn(q.qmpMonitorCh.ctx, qmpConn, cfg, disconnectCh)
 		if err == nil {
 			break
 		}

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -515,7 +515,7 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
 		NoDefaults:    true,
 		NoGraphic:     true,
 		NoReboot:      true,
-		Daemonize:     true,
+		Daemonize:     false,
 		MemPrealloc:   q.config.MemPrealloc,
 		HugePages:     q.config.HugePages,
 		IOMMUPlatform: q.config.IOMMUPlatform,
@@ -936,6 +936,11 @@ func (q *qemu) StartVM(ctx context.Context, timeout int) error {
 		// Wait for it to exit to assume that the QEMU daemon was
 		// actually started.
 		qemuCmd.Wait()
+	} else {
+		// Ensure the QEMU process is reaped after termination
+		go func() {
+			qemuCmd.Wait()
+		}()
 	}
 
 	err = q.waitVM(ctx, qmpConn, timeout)

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -902,10 +902,6 @@ func (q *qemu) StartVM(ctx context.Context, timeout int) error {
 		return err
 	}
 	q.Logger().WithField("vm path", vmPath).Info("created vm path")
-	// append logfile only on debug
-	if q.config.Debug {
-		q.qemuConfig.LogFile = filepath.Join(vmPath, "qemu.log")
-	}
 
 	defer func() {
 		if err != nil {
@@ -1068,19 +1064,6 @@ func (q *qemu) StopVM(ctx context.Context, waitOnly bool) error {
 		q.cleanupVM()
 		q.stopped = true
 	}()
-
-	if q.config.Debug && q.qemuConfig.LogFile != "" {
-		f, err := os.OpenFile(q.qemuConfig.LogFile, os.O_RDONLY, 0)
-		if err == nil {
-			scanner := bufio.NewScanner(f)
-			for scanner.Scan() {
-				q.Logger().WithField("file", q.qemuConfig.LogFile).Debug(scanner.Text())
-			}
-			if err := scanner.Err(); err != nil {
-				q.Logger().WithError(err).Debug("read qemu log failed")
-			}
-		}
-	}
 
 	if err := q.qmpSetup(); err != nil {
 		return err


### PR DESCRIPTION
This backports recent work on QEMU logs:
- don't daemonize QEMU
- collect QEMU logs from stderr
- drop QEMU log file support (unsafe, can fill up host storage)

Fixes #5780 for stable-3.0
Fixes #6173 for stable-3.0