### PR TITLE
runtime: support non-root for clh

### DIFF
--- a/docs/how-to/how-to-run-rootless-vmm.md
+++ b/docs/how-to/how-to-run-rootless-vmm.md
@@ -1,5 +1,5 @@
 ## Introduction
-To improve security, Kata Container supports running the VMM process (currently only QEMU) as a non-`root` user.
+To improve security, Kata Container supports running the VMM process (QEMU and cloud-hypervisor) as a non-`root` user. 
 This document describes how to enable the rootless VMM mode and its limitations.
 
 ## Pre-requisites
@@ -27,7 +27,7 @@ Another necessary change is to move the hypervisor runtime files (e.g. `vhost-fs
 ## Limitations
 
 1. Only the VMM process is running as a non-root user. Other processes such as Kata Container shimv2 and `virtiofsd` still run as the root user.
-2. Currently, this feature is only supported in QEMU. Still need to bring it to Firecracker and Cloud Hypervisor (see https://github.com/kata-containers/kata-containers/issues/2567).
+2. Currently, this feature is only supported in QEMU and cloud-hypervisor. For firecracker, you can use jailer to run the VMM process with a non-root user.
 3. Certain features will not work when rootless VMM is enabled, including:
    1. Passing devices to the guest (`virtio-blk`, `virtio-scsi`) will not work if the non-privileged user does not have permission to access it (leading to a permission denied error). A more permissive permission (e.g. 666) may overcome this issue. However, you need to be aware of the potential security implications of reducing the security on such devices.
    2. `vfio` device will also not work because of permission denied error.

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -41,6 +41,11 @@ rootfs_type=@DEFROOTFSTYPE@
 # Default false
 # confidential_guest = true
 
+# Enable running clh VMM as a non-root user.
+# By default clh VMM run as root. When this is set to true, clh VMM process runs as
+# a non-root random user. See documentation for the limitations of this mode.
+# rootless = true
+
 # disable applying SELinux on the VMM process (default false)
 disable_selinux=@DEFDISABLESELINUX@
 

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1046,6 +1046,7 @@ func newClhHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		EnableAnnotations:              h.EnableAnnotations,
 		DisableSeccomp:                 h.DisableSeccomp,
 		ConfidentialGuest:              h.ConfidentialGuest,
+		Rootless:                       h.Rootless,
 		DisableSeLinux:                 h.DisableSeLinux,
 		DisableGuestSeLinux:            h.DisableGuestSeLinux,
 		NetRateLimiterBwMaxRate:        h.getNetRateLimiterBwMaxRate(),

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httputil"
 	"os"
 	"os/exec"
+	"os/user"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -37,6 +38,8 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
 	hv "github.com/kata-containers/kata-containers/src/runtime/pkg/hypervisors"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
+	pkgUtils "github.com/kata-containers/kata-containers/src/runtime/pkg/utils"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/rootless"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 )
@@ -653,7 +656,7 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
 	clh.Logger().WithField("function", "StartVM").Info("starting Sandbox")
 
 	vmPath := filepath.Join(clh.config.VMStorePath, clh.id)
-	err := os.MkdirAll(vmPath, DirMode)
+	err := utils.MkdirAllWithInheritedOwner(vmPath, DirMode)
 	if err != nil {
 		return err
 	}
@@ -1352,8 +1355,15 @@ func (clh *cloudHypervisor) launchClh() (int, error) {
 			cmdHypervisor.Stdout = clh.console
 		}
 	}
-
 	cmdHypervisor.Stderr = cmdHypervisor.Stdout
+
+	attr := syscall.SysProcAttr{}
+	attr.Credential = &syscall.Credential{
+		Uid:    clh.config.Uid,
+		Gid:    clh.config.Gid,
+		Groups: clh.config.Groups,
+	}
+	cmdHypervisor.SysProcAttr = &attr
 
 	err = utils.StartCmd(cmdHypervisor)
 	if err != nil {
@@ -1678,6 +1688,30 @@ func (clh *cloudHypervisor) cleanupVM(force bool) error {
 			}
 			clh.Logger().WithError(err).WithField("path", dir).Warnf("failed to remove vm path")
 		}
+	}
+	if rootless.IsRootless() {
+		if _, err := user.Lookup(clh.config.User); err != nil {
+			clh.Logger().WithError(err).WithFields(
+				log.Fields{
+					"user": clh.config.User,
+					"uid":  clh.config.Uid,
+				}).Warn("failed to find the user, it might have been removed")
+			return nil
+		}
+
+		if err := pkgUtils.RemoveVmmUser(clh.config.User); err != nil {
+			clh.Logger().WithError(err).WithFields(
+				log.Fields{
+					"user": clh.config.User,
+					"uid":  clh.config.Uid,
+				}).Warn("failed to delete the user")
+			return nil
+		}
+		clh.Logger().WithFields(
+			log.Fields{
+				"user": clh.config.User,
+				"uid":  clh.config.Uid,
+			}).Debug("successfully removed the non root user")
 	}
 
 	clh.reset()

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1183,6 +1183,7 @@ func (q *qemu) cleanupVM() error {
 					"user": q.config.User,
 					"uid":  q.config.Uid,
 				}).Warn("failed to delete the user")
+			return nil
 		}
 		q.Logger().WithFields(
 			logrus.Fields{


### PR DESCRIPTION
This change enables to run cloud-hypervisor VMM using a non-root user when rootless flag is set true in the configuration

Fixes: #2567

Signed-off-by: Feng Wang <fwang@confluent.io>

### Test

I tested this change locally and verified that cloud-hypervisor processes are running using a nonroot user.
```
[root@ip-10-10-1-227 bin]# ps aux | grep cloud-hypervisor
kata-15+ 73449 14.1  1.1 10648792 2331536 ?    Sl   18:09   1:59 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1127/run/vc/vm/81ca7e3197d266259589e60aeb57f6aff98647d221ee13ad9796a5808ad58e21/clh-api.sock -v
kata-50+ 73627 14.2  1.2 10648792 2483084 ?    Sl   18:09   2:00 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1128/run/vc/vm/aa0f117bfe03336e34b60c30e66ef17d07c3dfa407bccb2a39e74d3e20ddc703/clh-api.sock -v
kata-24+ 88123 58.7  0.4 6452276 936232 ?      Sl   18:22   1:04 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1130/run/vc/vm/9ded0c38fe399a3641fe65263459f646477de8c404b28d64b069d42b7b4acf8c/clh-api.sock -v
kata-82+ 89005 50.7  0.4 6452276 836820 ?      Sl   18:22   0:49 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1131/run/vc/vm/e1dd712184b28f2ed7c8a69a646b2a3a9a1d4b83ea0853e2cf379a5956964609/clh-api.sock -v
kata-71+ 89261 54.8  0.4 6452276 840184 ?      Sl   18:22   0:52 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1132/run/vc/vm/fbccb24687cfe9579eb9b0fc0712b68e031587f4ac1c9fbc3093185517a8d277/clh-api.sock -v
kata-52+ 89704 52.0  0.3 6452276 790748 ?      Sl   18:22   0:47 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1133/run/vc/vm/8b794d49aae43dca2df5e125e54325b28757214866ca721cd0ecbe6c50968f65/clh-api.sock -v
kata-18+ 90724 81.0  0.8 6452276 1617216 ?     Sl   18:22   0:58 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1134/run/vc/vm/48489e575d9c3d0bf7c485a2fbf1bce19a1ee3a60432427de562d81694b981eb/clh-api.sock -v
kata-63+ 91324 60.5  0.3 6452276 699096 ?      Sl   18:22   0:36 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1135/run/vc/vm/c04e2ef136f45b94ebff3efe7e0be44a0ceaf3ee72bcbcf483e279ff30b55da0/clh-api.sock -v
kata-14+ 92744  107  0.5 6452276 1066604 ?     Sl   18:23   0:33 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1136/run/vc/vm/b939ff77434e14fe3e237e7c694f4b440ac4e73b6142b0ac88cd0570f3b7df41/clh-api.sock -v
kata-87+ 92892  111  0.4 6452276 933088 ?      Sl   18:23   0:33 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1137/run/vc/vm/a3041f444c6aaef2c3d2e95f1c1a85cbd80d2b5e87487dc54c75733e2d199ba3/clh-api.sock -v
kata-67+ 93046  109  0.5 6452276 1072920 ?     Sl   18:23   0:32 /opt/kata/bin/cloud-hypervisor --api-socket /run/user/1138/run/vc/vm/82eb58649dfa9fccaf01eb1d124481d738efda9e9839b0a32f444b1c0ff58fdf/clh-api.sock -v
```

And the VMM process doesn't have capabilities: 
```
[root@ip-10-10-1-227 bin]# cat /proc/93046/status | grep Cap
CapInh: 0000000000000000
CapPrm: 0000000000000000
CapEff: 0000000000000000
CapBnd: 0000003fffffffff
CapAmb: 0000000000000000
```
