### PR TITLE
Action check kernel config version

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -27,7 +27,6 @@ jobs:
       target_branch: ${{ github.base_ref }}
     steps:
     - name: Checkout code
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
@@ -38,6 +37,22 @@ jobs:
         go-version: 1.19.3
       env:
         GOPATH: ${{ runner.workspace }}/kata-containers
+    - name: Check kernel config version
+      run: |
+        cd "${{ github.workspace }}/src/github.com/${{ github.repository }}"
+        kernel_dir="tools/packaging/kernel/"
+        kernel_version_file="${kernel_dir}kata_config_version"
+        modified_files=$(git diff --name-only origin/main..HEAD)
+        result=$(git whatchanged origin/main..HEAD "${kernel_dir}" >>"/dev/null")
+        if git whatchanged origin/main..HEAD "${kernel_dir}" >>"/dev/null"; then
+          echo "Kernel directory has changed, checking if $kernel_version_file has been updated"
+          if echo "$modified_files" | grep -v "README.md" | grep "${kernel_dir}" >>"/dev/null"; then
+            echo "$modified_files" | grep "$kernel_version_file" >>/dev/null || ( echo "Please bump version in $kernel_version_file" && exit 1)
+          else
+            echo "Readme file changed, no need for kernel config version update."
+          fi
+          echo "Check passed"
+        fi
     - name: Setup GOPATH
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |

--- a/tools/packaging/kernel/README.md
+++ b/tools/packaging/kernel/README.md
@@ -107,6 +107,10 @@ Kata Containers packaging repository holds the kernel configs and patches. The
 config and patches can work for many versions, but we only test the
 kernel version defined in the [Kata Containers versions file][kata-containers-versions-file].
 
+For any change to the kernel configs or patches, the version defined in the file
+[`kata_config_version`][kata-containers-versions-file] needs to be incremented
+so that the CI can test with these changes.
+
 For further details, see [the kernel configuration documentation](configs).
 
 ## How is it tested


### PR DESCRIPTION
 github-action: Add step to verify kernel config version id updated
    
The version mentioned in the `kata_config_version` needs to be
updated for any kernel config change or changed to the patches applied.
Without this, CI would not test with the latest kernel changes.
We use to enforce this earlier as part of CI when `packaging` was
a standalone repo.
Add back this check as part of a github action so that the check is
performed early on instead of a CI job.

Fixes: kata-containers/tests#5419