### PR TITLE
Backport CI fixes for s390x and ppc64le to stable-3.0

### DIFF
--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -8,6 +8,7 @@ ENV INSTALL_IN_GOPATH=false
 
 COPY install_yq.sh /usr/bin/install_yq.sh
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install yq and docker
 RUN apt-get update && \
@@ -18,6 +19,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/ && \
     install_yq.sh && \
     curl -fsSL https://get.docker.com -o get-docker.sh && \
+    if uname -m | grep -Eq 's390x|ppc64le'; then export VERSION="v20.10"; fi && \
     sh get-docker.sh
 
 ARG IMG_USER=kata-builder

--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -47,6 +47,7 @@ pull_virtiofsd_released_binary() {
 init_env() {
    source "$HOME/.cargo/env"
 
+   extra_rust_flags=" -C link-self-contained=yes"
    case ${ARCH} in
      "aarch64")
        LIBC="musl"
@@ -60,6 +61,7 @@ init_env() {
      "s390x")
        LIBC="gnu"
        ARCH_LIBC=${ARCH}-linux-${LIBC}
+       extra_rust_flags=""
      ;;
      "x86_64")
        LIBC="musl"
@@ -76,7 +78,7 @@ build_virtiofsd_from_source() {
    git clone --depth 1 --branch ${virtiofsd_version} ${virtiofsd_repo} virtiofsd
    pushd virtiofsd
 
-   export RUSTFLAGS='-C target-feature=+crt-static -C link-self-contained=yes'
+   export RUSTFLAGS='-C target-feature=+crt-static'${extra_rust_flags}
    export LIBSECCOMP_LINK_TYPE=static
    export LIBSECCOMP_LIB_PATH=/usr/lib/${ARCH_LIBC}
    export LIBCAPNG_LINK_TYPE=static


### PR DESCRIPTION
This backports #6212 and #5523 to stable-3.0 :

f49b89b632e6 ("CI: Set docker version to v20.10 in ubuntu:20.04 for s390x|ppc64le")
43fcb8fd0906 ("virtiofsd: Not use "link-self-contained=yes" on s390x")

Fixes: #6211 for stable-3.0
Fixes: #5522 for stable-3.0