### PR TITLE
CI: Set docker version to v20.10 in ubuntu:20.04 for s390x|ppc64le

### DIFF
--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -8,6 +8,7 @@ ENV INSTALL_IN_GOPATH=false
 
 COPY install_yq.sh /usr/bin/install_yq.sh
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install yq and docker
 RUN apt-get update && \
@@ -18,6 +19,7 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/ && \
     install_yq.sh && \
     curl -fsSL https://get.docker.com -o get-docker.sh && \
+    if uname -m | grep -Eq 's390x|ppc64le'; then export VERSION="v20.10"; fi && \
     sh get-docker.sh
 
 ARG IMG_USER=kata-builder


### PR DESCRIPTION
This is to make a docker version to v20.10 in docker upstream image ubuntu:20.04 for s390x and ppc64le.

Fixes: #6211

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
(cherry picked from commit f49b89b632e64d0cd72bbe39ed4b5f83abbfb0bb)