### PR TITLE
CI: Set docker version to v20.10 in ubuntu:20.04 for s390x|ppc64le

### DIFF
--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -8,17 +8,19 @@ ENV INSTALL_IN_GOPATH=false
 
 COPY install_yq.sh /usr/bin/install_yq.sh
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 # Install yq and docker
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends \
-  ca-certificates \
-  curl \
-  sudo && \
-  apt-get clean && rm -rf /var/lib/apt/lists/ && \
-  install_yq.sh && \
-  curl -fsSL https://get.docker.com -o get-docker.sh && \
-  sh get-docker.sh
+    apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        sudo && \
+    apt-get clean && rm -rf /var/lib/apt/lists/ && \
+    install_yq.sh && \
+    curl -fsSL https://get.docker.com -o get-docker.sh && \
+    if uname -m | grep -Eq 's390x|ppc64le'; then export VERSION="v20.10"; fi && \
+    sh get-docker.sh
 
 ARG IMG_USER=kata-builder
 ARG UID=1000


### PR DESCRIPTION
This is to make a docker version to v20.10 in docker upstream image ubuntu:20.04 for s390x and ppc64le.

Fixes: #6211
Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
Cherry-picked: f49b89b