### PR TITLE
runtime: remove not used shim configurations

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/create_test.go
@@ -320,7 +320,6 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 	kernelPath := path.Join(dir, "kernel")
 	kernelParams := "foo=bar xyz"
 	imagePath := path.Join(dir, "image")
-	shimPath := path.Join(dir, "shim")
 	logDir := path.Join(dir, "logs")
 	logPath := path.Join(logDir, "runtime.log")
 	machineType := "machineType"
@@ -340,7 +339,6 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 		ImagePath:            imagePath,
 		KernelParams:         kernelParams,
 		MachineType:          machineType,
-		ShimPath:             shimPath,
 		LogPath:              logPath,
 		DisableBlock:         disableBlockDevice,
 		BlockDeviceDriver:    blockDeviceDriver,
@@ -360,7 +358,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config string, err err
 		return "", err
 	}
 
-	files := []string{hypervisorPath, kernelPath, imagePath, shimPath}
+	files := []string{hypervisorPath, kernelPath, imagePath}
 
 	for _, file := range files {
 		// create the resource (which must be >0 bytes)

--- a/src/runtime/pkg/katatestutils/utils.go
+++ b/src/runtime/pkg/katatestutils/utils.go
@@ -213,7 +213,6 @@ type RuntimeConfigOptions struct {
 	ImagePath            string
 	KernelParams         string
 	MachineType          string
-	ShimPath             string
 	LogPath              string
 	BlockDeviceDriver    string
 	BlockDeviceAIO       string
@@ -236,7 +235,6 @@ type RuntimeConfigOptions struct {
 	HypervisorDebug      bool
 	RuntimeDebug         bool
 	RuntimeTrace         bool
-	ShimDebug            bool
 	AgentDebug           bool
 	AgentTrace           bool
 	EnablePprof          bool
@@ -322,10 +320,6 @@ func MakeRuntimeConfigFileData(config RuntimeConfigOptions) string {
 	guest_hook_path = "` + config.DefaultGuestHookPath + `"
 	shared_fs = "` + config.SharedFS + `"
 	virtio_fs_daemon = "` + config.VirtioFSDaemon + `"
-
-	[shim.kata]
-	path = "` + config.ShimPath + `"
-	enable_debug = ` + strconv.FormatBool(config.ShimDebug) + `
 
 	[agent.kata]
 	enable_debug = ` + strconv.FormatBool(config.AgentDebug) + `


### PR DESCRIPTION
ShimPath and ShimDebug are not needed anymore.

Fixes: #6147

Signed-off-by: d3c3mber <tangbo_gl_2022@163.com>