### PR TITLE
osbuilder: ungzip initrd when extracting

### DIFF
--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -100,7 +100,7 @@ $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX):: rootfs-builder/%
 .PRECIOUS: $(ROOTFS_BUILD_DEST)/.dracut$(ROOTFS_MARKER_SUFFIX)
 $(ROOTFS_BUILD_DEST)/.dracut$(ROOTFS_MARKER_SUFFIX): $(TARGET_INITRD)
 	mkdir -p $(TARGET_ROOTFS)
-	(cd $(TARGET_ROOTFS); cat $< | cpio --extract --preserve-modification-time --make-directories)
+	(cd $(TARGET_ROOTFS); zcat $< | cpio --extract --preserve-modification-time --make-directories)
 	@touch $@
 
 image-%: $(IMAGES_BUILD_DEST)/kata-containers-image-%.img


### PR DESCRIPTION
The initrd that is built is gzip compressed, it needs to be ungzipped before passing to cpio.