### PR TITLE
osbuilder: remove duplicate KATA_BUILD_CC entry

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -454,7 +454,6 @@ build_rootfs_distro()
 			--env OS_VERSION="${OS_VERSION}" \
 			--env INSIDE_CONTAINER=1 \
 			--env AA_KBC="${AA_KBC}" \
-			--env KATA_BUILD_CC="${KATA_BUILD_CC}" \
 			--env SECCOMP="${SECCOMP}" \
 			--env SELINUX="${SELINUX}" \
 			--env DEBUG="${DEBUG}" \


### PR DESCRIPTION
Already being passed 10 lines above the removed one.

Fixes: #6237