### PR TITLE
clh: Enforce API timeout only for vm.boot request

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -652,9 +652,6 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
 	span, _ := katatrace.Trace(ctx, clh.Logger(), "StartVM", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
-	ctx, cancel := context.WithTimeout(context.Background(), clh.getClhAPITimeout()*time.Second)
-	defer cancel()
-
 	clh.Logger().WithField("function", "StartVM").Info("starting Sandbox")
 
 	vmPath := filepath.Join(clh.config.VMStorePath, clh.id)
@@ -692,6 +689,9 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
 		return fmt.Errorf("failed to launch cloud-hypervisor: %q", err)
 	}
 	clh.state.PID = pid
+
+	ctx, cancel := context.WithTimeout(ctx, clh.getClhAPITimeout()*time.Second)
+	defer cancel()
 
 	if err := clh.bootVM(ctx); err != nil {
 		return err


### PR DESCRIPTION
launchClh already has a timeout of 10seconds for launching clh, e.g. if launchClh or setupVirtiofsDaemon takes a few seconds the context's deadline will already be expired by the time it reaches bootVM

Signed-off-by: Alexandru Matei <alexandru.matei@uipath.com>