### PR TITLE
osbuilder: Include minimal set of device nodes in ubuntu initrd

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -6,6 +6,8 @@ ARG IMAGE_REGISTRY=docker.io
 FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@
 @SET_PROXY@
 
+# makedev tries to mknod from postinst
+RUN [ -x /usr/bin/systemd-detect-virt ] || ( echo "echo docker" >/usr/bin/systemd-detect-virt && chmod +x /usr/bin/systemd-detect-virt )
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive \
     apt-get --no-install-recommends -y install \
@@ -20,6 +22,7 @@ RUN apt-get update && \
          echo "gcc-$gcc_arch-linux-gnu libc6-dev-$libc_arch-cross")) \
     git \
     make \
+    makedev \
     multistrap \
     musl-tools \
     protobuf-compiler

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -34,4 +34,10 @@ EOF
 
 	# Reduce image size and memory footprint by removing unnecessary files and directories.
 	rm -rf $rootfs_dir/usr/share/{bash-completion,bug,doc,info,lintian,locale,man,menu,misc,pixmaps,terminfo,zsh}
+
+	# Minimal set of device nodes needed when AGENT_INIT=yes so that the
+	# kernel can properly setup stdout/stdin/stderr for us
+	pushd $rootfs_dir/dev
+	MAKEDEV -v console tty ttyS null zero fd
+	popd
 }


### PR DESCRIPTION
When starting an initrd the kernel expects to find /dev/console in the initrd, so that it can connect it as stdin/stdout/stderr to the /init process. If the device node is missing the kernel will complain that it was unable to open an initial console. If kata-agent is the initrd init process, it will also result in log messages not being logged to console and thus not forwarded to host syslog.

Add a set of standard device nodes for completeness, so that console logging works.

Fixes: #6261
Signed-off-by: Jeremi Piotrowski <jpiotrowski@microsoft.com>