### PR TITLE
runtime: tracing: Fix missing ctx return

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -647,7 +647,7 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 
 // StartVM will start the VMM and boot the virtual machine for the given sandbox.
 func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
-	span, _ := katatrace.Trace(ctx, clh.Logger(), "StartVM", clhTracingTags, map[string]string{"sandbox_id": clh.id})
+	span, ctx := katatrace.Trace(ctx, clh.Logger(), "StartVM", clhTracingTags, map[string]string{"sandbox_id": clh.id})
 	defer span.End()
 
 	clh.Logger().WithField("function", "StartVM").Info("starting Sandbox")


### PR DESCRIPTION
Normally we return the context when creating a trace span so that the ordering of spans w.r.t. calls is maintained in tracing output. Add missing context for StartVM() for Cloud Hypervisor.

Fixes #6271

Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>