### PR TITLE
kata-deploy: Install protobuf-compiler explicitly in shim-v2 Dockerfile

### DIFF
--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && \
         git \
         make \
         musl-tools \
+        protobuf-compiler \
         sudo && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 


### PR DESCRIPTION
This is to install a missing binary protoc in shim-v2 Dockerfile.

Fixes: #6244

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
(cherry picked from commit 10603e3deff8d4f9907ade320d727ef343970a2f)