### PR TITLE
CC | Dragonball TDX: add is_tdx_enabled to identify tdx VM type

### DIFF
--- a/src/dragonball/src/api/v1/instance_info.rs
+++ b/src/dragonball/src/api/v1/instance_info.rs
@@ -83,6 +83,11 @@ impl InstanceInfo {
             confidential_vm_type: None,
         }
     }
+
+    /// return true if VM confidential type is TDX
+    pub fn is_tdx_enabled(&self) -> bool {
+        matches!(self.confidential_vm_type, Some(ConfidentialVmType::TDX))
+    }
 }
 
 impl Default for InstanceInfo {

--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -350,6 +350,15 @@ impl Vm {
         instance_state == InstanceState::Running
     }
 
+    /// return true if VM confidential type is TDX
+    pub fn is_tdx_enabled(&self) -> bool {
+        let shared_info = self
+            .shared_info()
+            .read()
+            .expect("failed to get instance state, because shared info is poisoned lock");
+        shared_info.is_tdx_enabled()
+    }
+
     /// Save VM instance exit state
     pub fn vm_exit(&self, exit_code: i32) {
         if let Ok(mut info) = self.shared_info.write() {


### PR DESCRIPTION
In order to disable or enable some features when running tdx vms, we need to add is_tdx_enabled() function to identify whether the VM confidiential type is TDX.

fixes: #6276

Signed-off-by: fengshifang <fengshifang@linux.alibaba.com>
Signed-off-by: Chao Wu <chaowu@linux.alibaba.com>