### PR TITLE
CC|action: Place permission adjustment for s390x kata-payload

### DIFF
--- a/.github/workflows/cc-payload-after-push-s390x.yaml
+++ b/.github/workflows/cc-payload-after-push-s390x.yaml
@@ -135,6 +135,10 @@ jobs:
           username: ${{ secrets.COCO_QUAY_DEPLOYER_USERNAME }}
           password: ${{ secrets.COCO_QUAY_DEPLOYER_PASSWORD }}
 
+      - name: Adjust a permission for repo
+        run: |
+          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+
       - uses: actions/checkout@v3
       - name: get-kata-tarball
         uses: actions/download-artifact@v3


### PR DESCRIPTION
It is just to place a missing stage for permission adjustment in the cc-payload-after-push-s390x workflow.

Fixes #6278

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>