### PR TITLE
runtime-rs: fix default kernel location and add more default config paths

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -203,7 +203,7 @@ ifneq (,$(DBCMD))
     DEFNETWORKMODEL_DB := tcfilter
     KERNELPARAMS = console=ttyS1 agent.log_vport=1025
 	KERNELTYPE_DB = uncompressed
-    KERNEL_NAME_DB = $(call MAKE_KERNEL_NAME,$(KERNELTYPE_DB))
+    KERNEL_NAME_DB = $(call MAKE_KERNEL_NAME_DB,$(KERNELTYPE_DB))
     KERNELPATH_DB = $(KERNELDIR)/$(KERNEL_NAME_DB)
     DEFSANDBOXCGROUPONLY = true
     RUNTIMENAME := virt_container
@@ -371,8 +371,8 @@ endef
 
 # Returns the name of the kernel file to use based on the provided KERNELTYPE.
 # $1 : KERNELTYPE (compressed or uncompressed)
-define MAKE_KERNEL_NAME
-$(if $(findstring uncompressed,$1),vmlinux.container,vmlinuz.container)
+define MAKE_KERNEL_NAME_DB
+$(if $(findstring uncompressed,$1),vmlinux-dragonball-experimental.container,vmlinuz-dragonball-experimental.container)
 endef
 
 .DEFAULT_GOAL := default


### PR DESCRIPTION
---

build: Use the correct kernel name

When calling `MAKE_KERNEL_NAME` we're considering the default kernel
name will be `vmlinux.container` or `vmlinuz.container`, which is not
the case as the runtime-rs, when used with dragonball, relies on the
`vmlinu[zx]-dragonball-experimental.container` kernel.

Other hypervisors will have to introduce a similar
`MAKE_KERNEL_NAME_${HYPERVISOR}` to adapt this to the kernel they want
to use, similarly to what's already done for the go runtime.

By doing this we also ensure that no changes in the configuration file
will be required to run runtime-rs, with dragonball, as part of our CI
or as part of kata-deploy.

Fixes: #6290

---

kata-types/config: Add more default config paths

This is not ideal, but this is what it is right now, as the
configurations end up being loaded from that list in case
`KATA_CONF_FILE` is not set.

As part of our CI, as part of kata-deploy, and as part of the payload we
provide to Confidential Containers, we do not set `KATA_CONF_FILE`, thus
expanding the list seems like the most reasonable approach to take, at
least till github.com/kata-containers/kata-containers#3961 gets solved.

While expanding the list, let's also make sure to add the
`-dragonball.toml` as first options as nothing guarantees that the
default configuration will be pointing to that one.

Fixes: #6291

---