### PR TITLE
kata-ctl: checks for kvm, kvm_intel modules loaded

### DIFF
--- a/src/tools/kata-ctl/src/arch/aarch64/mod.rs
+++ b/src/tools/kata-ctl/src/arch/aarch64/mod.rs
@@ -20,7 +20,7 @@ mod arch_specific {
 
     // List of check functions
     static CHECK_LIST: &[CheckItem] = &[CheckItem {
-        name: CheckType::CheckCpu,
+        name: CheckType::Cpu,
         descr: "This parameter performs the host check",
         fp: check,
         perm: PermissionType::NonPrivileged,

--- a/src/tools/kata-ctl/src/arch/s390x/mod.rs
+++ b/src/tools/kata-ctl/src/arch/s390x/mod.rs
@@ -60,7 +60,7 @@ mod arch_specific {
 
     // List of check functions
     static CHECK_LIST: &[CheckItem] = &[CheckItem {
-        name: CheckType::CheckCpu,
+        name: CheckType::Cpu,
         descr: "This parameter performs the cpu check",
         fp: check,
         perm: PermissionType::NonPrivileged,

--- a/src/tools/kata-ctl/src/ops/check_ops.rs
+++ b/src/tools/kata-ctl/src/ops/check_ops.rs
@@ -73,15 +73,18 @@ pub fn handle_check(checkcmd: CheckArgument) -> Result<()> {
     match command {
         CheckSubCommand::All => {
             // run architecture-specific tests
-            handle_builtin_check(CheckType::CheckCpu, "")?;
+            handle_builtin_check(CheckType::Cpu, "")?;
 
             // run code that uses network checks
             check::run_network_checks()?;
+
+            // run kernel module checks
+            handle_builtin_check(CheckType::KernelModules, "")?;
         }
 
         CheckSubCommand::NoNetworkChecks => {
             // run architecture-specific tests
-            handle_builtin_check(CheckType::CheckCpu, "")?;
+            handle_builtin_check(CheckType::Cpu, "")?;
         }
 
         CheckSubCommand::CheckVersionOnly => {

--- a/src/tools/kata-ctl/src/types.rs
+++ b/src/tools/kata-ctl/src/types.rs
@@ -12,8 +12,9 @@ pub type BuiltinCmdFp = fn(args: &str) -> Result<()>;
 // CheckType encodes the name of each check provided by kata-ctl.
 #[derive(Debug, strum_macros::Display, EnumString, PartialEq)]
 pub enum CheckType {
-    CheckCpu,
-    CheckNetwork,
+    Cpu,
+    Network,
+    KernelModules,
 }
 
 // PermissionType is used to show whether a check needs to run with elevated (super-user)
@@ -32,4 +33,40 @@ pub struct CheckItem<'a> {
     pub descr: &'a str,
     pub fp: BuiltinCmdFp,
     pub perm: PermissionType,
+}
+
+// Builtin module parameter check handler type.
+//
+// BuiltinModuleParamFp represents a predicate function to determine if a
+// kernel parameter _value_ is as expected. If not, the returned Error will
+// explain what is wrong.
+//
+// Parameters:
+//
+// - module: name of kernel module.
+// - param: name of parameter for the kernel module.
+// - value: value of the kernel parameter.
+pub type BuiltinModuleParamFp = fn(module: &str, param: &str, value: &str) -> Result<()>;
+
+// KernelParamType encodes the value and a handler
+// function for kernel module parameters
+#[allow(dead_code)]
+#[derive(Clone)]
+pub enum KernelParamType<'a> {
+    Simple(&'a str),
+    Predicate(BuiltinModuleParamFp),
+}
+
+// Parameters is used to encode the module parameters
+#[derive(Clone)]
+pub struct KernelParam<'a> {
+    pub name: &'a str,
+    pub value: KernelParamType<'a>,
+}
+
+// KernelModule is used to describe a kernel module along with its required parameters.
+#[allow(dead_code)]
+pub struct KernelModule<'a> {
+    pub name: &'a str,
+    pub parameter: KernelParam<'a>,
 }


### PR DESCRIPTION
Ensure that kvm and kvm_intel modules are loaded

Fixes #5332