### PR TITLE
runtime-rs: Don't build on Power, don't break on Power.

### DIFF
--- a/src/runtime-rs/arch/powerpc64le-options.mk
+++ b/src/runtime-rs/arch/powerpc64le-options.mk
@@ -1,0 +1,15 @@
+# Copyright (c) 2019-2022 Alibaba Cloud
+# Copyright (c) 2019-2022 Ant Group
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+MACHINETYPE := pseries
+KERNELPARAMS :=
+MACHINEACCELERATORS := "cap-cfpc=broken,cap-sbbc=broken,cap-ibs=broken,cap-large-decr=off,cap-ccf-assist=off"
+CPUFEATURES := pmu=off
+
+QEMUCMD := qemu-system-ppc64
+
+# dragonball binary name
+DBCMD := dragonball


### PR DESCRIPTION
---

packaging/shim-v2: Install the target depending on the arch/libc

In the `install_go_rust.sh` file we're adding a
x86_64-unknown-linux-musl target unconditionally.  That should be,
instead, based in the ARCH of the host and the appropriate LIBC to be
used with that host.

---

runtime-rs: Add a generic powerpc64le-options.mk

There's a check in the runtime-rs Makefile that basically checks whether
the `arch/$arch-options.mk` exists or not and, if it doesn't, the build
is just aborted.

With this in mind, let's create a generic powerpc64le-options.mk file
and not bail when building for this architecture.

Fixes: #6142

---