### PR TITLE
runtime-rs: handle sys_dir bind volume

### DIFF
--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -20,6 +20,7 @@ use crate::share_fs::ShareFs;
 use self::hugepage::{get_huge_page_limits_map, get_huge_page_option};
 
 const BIND: &str = "bind";
+
 #[async_trait]
 pub trait Volume: Send + Sync {
     fn get_volume_mount(&self) -> Result<Vec<oci::Mount>>;


### PR DESCRIPTION
For some cases, users will mount system directories as bind volume. We should not bind mount these kind of directories in the host as it does not make sense.

Fixes: #6299