### PR TITLE
Remove install scripts dependency on jq

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -103,7 +103,7 @@ for tag in response:
 	#   so attempt to perform a semver sort manually.
 	# - Pre-releases are excluded via the select() call.
 	local latest=$(curl -sL "$url" |\
-		python3 -c "$python_jq" |\
+		python -c "$python_jq" |\
 		sort -t "." -k1,1n -k2,2n -k3,3n |\
 		tail -1 || true)
 


### PR DESCRIPTION
Jq is not installed by default on most distrubutions, and with #6259 encouraging the use of the -f option, it was found that kata-manager does not check for its presence, even though it is needed for the script to work. In addition to doing the checks needed for the script to work even when -f is passed, it would be nice to replace the dependence on jq with one on python, as the latter is more widely found on systems.