### PR TITLE
actions: Use `git-diff` to get changes in kernel dir

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -43,8 +43,7 @@ jobs:
         kernel_dir="tools/packaging/kernel/"
         kernel_version_file="${kernel_dir}kata_config_version"
         modified_files=$(git diff --name-only origin/main..HEAD)
-        result=$(git whatchanged origin/main..HEAD "${kernel_dir}" >>"/dev/null")
-        if git whatchanged origin/main..HEAD "${kernel_dir}" >>"/dev/null"; then
+        if git diff --name-only origin/main..HEAD "${kernel_dir}" | grep "${kernel_dir}"; then
           echo "Kernel directory has changed, checking if $kernel_version_file has been updated"
           if echo "$modified_files" | grep -v "README.md" | grep "${kernel_dir}" >>"/dev/null"; then
             echo "$modified_files" | grep "$kernel_version_file" >>/dev/null || ( echo "Please bump version in $kernel_version_file" && exit 1)


### PR DESCRIPTION
Use `git-diff` instead of legacy `git-whatchanged` to get differences in the packaging/kernel directory. This also fixes a bug by grepping for the kernel directory in the output of the git command.

Fixes: #6210