### PR TITLE
runtime-rs: remove unnecessary Send/Sync trait implement

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -27,7 +27,6 @@ use std::{collections::HashSet, fs::create_dir_all, path::PathBuf};
 const DRAGONBALL_KERNEL: &str = "vmlinux";
 const DRAGONBALL_ROOT_FS: &str = "rootfs";
 
-unsafe impl Send for DragonballInner {}
 unsafe impl Sync for DragonballInner {}
 pub struct DragonballInner {
     /// sandbox id

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -22,8 +22,6 @@ use tokio::sync::RwLock;
 
 use crate::{device::Device, Hypervisor, VcpuThreadIds};
 
-unsafe impl Send for Dragonball {}
-unsafe impl Sync for Dragonball {}
 pub struct Dragonball {
     inner: Arc<RwLock<DragonballInner>>,
 }

--- a/src/runtime-rs/crates/runtimes/linux_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/linux_container/src/lib.rs
@@ -11,8 +11,6 @@ use common::{message::Message, RuntimeHandler, RuntimeInstance};
 use kata_types::config::TomlConfig;
 use tokio::sync::mpsc::Sender;
 
-unsafe impl Send for LinuxContainer {}
-unsafe impl Sync for LinuxContainer {}
 pub struct LinuxContainer {}
 
 #[async_trait]

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -145,8 +145,6 @@ impl RuntimeHandlerManagerInner {
     }
 }
 
-unsafe impl Send for RuntimeHandlerManager {}
-unsafe impl Sync for RuntimeHandlerManager {}
 pub struct RuntimeHandlerManager {
     inner: Arc<RwLock<RuntimeHandlerManagerInner>>,
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -25,8 +25,6 @@ use tokio::sync::RwLock;
 
 use super::{logger_with_process, Container};
 
-unsafe impl Send for VirtContainerManager {}
-unsafe impl Sync for VirtContainerManager {}
 pub struct VirtContainerManager {
     sid: String,
     pid: u32,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -35,8 +35,6 @@ use resource::ResourceManager;
 use sandbox::VIRTCONTAINER;
 use tokio::sync::mpsc::Sender;
 
-unsafe impl Send for VirtContainer {}
-unsafe impl Sync for VirtContainer {}
 pub struct VirtContainer {}
 
 #[async_trait]

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -57,8 +57,6 @@ impl SandboxInner {
     }
 }
 
-unsafe impl Send for VirtSandbox {}
-unsafe impl Sync for VirtSandbox {}
 #[derive(Clone)]
 pub struct VirtSandbox {
     sid: String,

--- a/src/runtime-rs/crates/runtimes/wasm_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/wasm_container/src/lib.rs
@@ -10,8 +10,6 @@ use async_trait::async_trait;
 use common::{message::Message, RuntimeHandler, RuntimeInstance};
 use kata_types::config::TomlConfig;
 use tokio::sync::mpsc::Sender;
-unsafe impl Send for WasmContainer {}
-unsafe impl Sync for WasmContainer {}
 pub struct WasmContainer {}
 
 #[async_trait]


### PR DESCRIPTION
Send and Sync are automatically derived traits,
if a type is composed entirely of Send or Sync types, then it is Send or Sync. Almost all primitives are Send and Sync,
so we don't need to implement them manually most of the time.

Fixes: #6307