### PR TITLE
virtiofsd: update to a valid path on ppc64le

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -197,7 +197,7 @@ DEFSHAREDFS_CLH_VIRTIOFS := virtio-fs
 DEFSHAREDFS_QEMU_VIRTIOFS := virtio-fs
 DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/virtiofsd
 ifeq ($(ARCH),ppc64le)
-DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/kata-qemu/virtiofsd
+DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/qemu/virtiofsd
 endif
 DEFVALIDVIRTIOFSDAEMONPATHS := [\"$(DEFVIRTIOFSDAEMON)\"]
 # Default DAX mapping cache size in MiB


### PR DESCRIPTION
Currently the symbolic link for virtiofsd which is used as a valid path is not updated on every CI run. Fix it by using the actual path of installation.

Fixes: #6311