### PR TITLE
kata-deploy: Fix building the kata static firecracker arm64 package occurred an error

### DIFF
--- a/tools/packaging/static-build/firecracker/build-static-firecracker.sh
+++ b/tools/packaging/static-build/firecracker/build-static-firecracker.sh
@@ -18,6 +18,8 @@ firecracker_repo="${firecracker_repo:-}"
 firecracker_dir="firecracker"
 firecracker_version="${firecracker_version:-}"
 
+arch=$(uname -m)
+
 if [ -z "$firecracker_repo" ]; then
 	info "Get firecracker information from runtime versions.yaml"
 	firecracker_url=$(get_from_kata_deps "assets.hypervisor.firecracker.url")
@@ -37,5 +39,5 @@ git fetch
 git checkout ${firecracker_version}
 sudo ./tools/devtool --unattended build --release
 
-ln -sf ./build/cargo_target/x86_64-unknown-linux-musl/release/firecracker ./firecracker-static
-ln -sf ./build/cargo_target/x86_64-unknown-linux-musl/release/jailer ./jailer-static
+ln -sf ./build/cargo_target/${arch}-unknown-linux-musl/release/firecracker ./firecracker-static
+ln -sf ./build/cargo_target/${arch}-unknown-linux-musl/release/jailer ./jailer-static


### PR DESCRIPTION
kata-deploy: Fix kata static firecracker arm64 package build error

When building the kata static arm64 package, the stages of firecracker report errors.

Fixes: #6318

Signed-off-by: Singh Wang <wangxin_0611@126.com>