### PR TITLE
kata-deploy: Fix building the kata static shim-v2 arm64 package occurred an error

### DIFF
--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -16,6 +16,17 @@ RUN apt-get update && \
         musl-tools \
         protobuf-compiler \
         sudo && \
+    if [ "$(uname -m)" = "aarch64" ]; then \
+        apt-get install -y --no-install-recommends wget && \
+        git clone https://github.com/richfelker/musl-cross-make.git && \
+        cd musl-cross-make/ && \
+        cp config.mak.dist config.mak && \
+        sed -i 'N;16 a TARGET = aarch64-linux-musl\n' config.mak && \
+        sed -i 'N;26 a OUTPUT = /usr/local/\n' config.mak && \
+        make && \
+        make install \
+    ; fi && \
+    cd .. && rm -rf musl-cross-make && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 
 COPY install_go_rust.sh /usr/bin/install_go_rust.sh


### PR DESCRIPTION
kata-deploy: Fix kata static shim-v2 arm64 package build error

When building the kata static arm64 package, the stages of shim-v2 report errors.

Fixes: #6320

Signed-off-by: Singh Wang <wangxin_0611@126.com>