### PR TITLE
shim-v2: Bump Ubuntu container image  to 22.04

### DIFF
--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \


### PR DESCRIPTION
Let's bump the base container image to use the 22.04 version of Ubuntu, as it does bring up-to-date package dependencies that we need to statically build the runtime-rs on aarch64.

Fixes: #6320