### PR TITLE
dragonball: config_manager: preserve device when update

### DIFF
--- a/src/dragonball/src/config_manager.rs
+++ b/src/dragonball/src/config_manager.rs
@@ -231,7 +231,7 @@ where
                         info.config.check_conflicts(config)?;
                     }
                 }
-                self.info_list[index] = device_info;
+                self.info_list[index].config = config.clone();
                 index
             }
             None => {


### PR DESCRIPTION
DeviceConfigInfo contains config and device, so when we want to do update we could simply update config part of the info, and device would not be changed during update.

Fixes: #6324