### PR TITLE
Revert "workflows: Push the builder image to quay.io"

### DIFF
--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -28,13 +28,6 @@ jobs:
           - virtiofsd
           - nydus
     steps:
-      - name: Login to Kata Containers quay.io
-        uses: docker/login-action@v2
-        with:
-          registry: quay.io
-          username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
-          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
       - uses: actions/checkout@v2
       - name: Install docker
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
@@ -51,7 +44,6 @@ jobs:
           sudo cp -r --preserve=all "${build_dir}" "kata-build"
         env:
           KATA_ASSET: ${{ matrix.asset }}
-          PUSH_TO_REGISTRY: yes
 
       - name: store-artifact ${{ matrix.asset }}
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}


### PR DESCRIPTION
This reverts commit b835c40bbdc126e97256c0342d10aa0b09ac14e4.

Right now I'm reverting this one as this should only run *after* commits get pushed to our repo, not on very PR.