### PR TITLE
kata-deploy: Ensure go binaries can run on Ubuntu 20.04

### DIFF
--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/tools/packaging/static-build/shim-v2/install_go_rust.sh
+++ b/tools/packaging/static-build/shim-v2/install_go_rust.sh
@@ -58,6 +58,10 @@ case "${ARCH}" in
 	aarch64)
 		goarch=arm64
 		LIBC=musl
+		# This is a hack needed as part of Ubuntu 20.04
+		if [ ! -f /usr/bin/aarch64-linux-musl-gcc ]; then
+			ln -sf /usr/bin/musl-gcc /usr/bin/aarch64-linux-musl-gcc
+		fi
 		;;
 	ppc64le) 
 		goarch=${ARCH}


### PR DESCRIPTION
---

Revert "kata-deploy: Fix kata static firecracker arm64 package build error"

This reverts commit 697ec8e578f32c238adf7c14262f6bf1437eadd7.

Golang binaries are built statically by default, unless linking against
CGO, which we do.  In this case we dynamically link against glibc,
causing us troubles when running a binary built with Ubuntu 22.04 on
Ubuntu 20.04 (which will still be supported for the next few years ...)

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

---

kata-deploy: Fix kata static shim-v2 arm64 package build error

When building the kata static arm64 package, the stages of shim-v2 report errors.

Fixes: #6320
Signed-off-by: SinghWang <wangxin_0611@126.com>

---