### PR TITLE
osbuilder: add cc_kbc module to AA build in SEV initrd for SNP support

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -664,6 +664,7 @@ EOF
 			info "Adding agent config for ${AA_KBC}"
 			#KBC URI will be specified in the config file via kernel params
 			AA_KBC_PARAMS="online_sev_kbc::123.123.123.123:44444" envsubst < "${script_dir}/agent-config.toml.in" | tee "${ROOTFS_DIR}/etc/agent-config.toml"
+			AA_KBC="cc_kbc online_sev_kbc"
 		fi
 		attestation_agent_url="$(get_package_version_from_kata_yaml externals.attestation-agent.url)"
 		attestation_agent_version="$(get_package_version_from_kata_yaml externals.attestation-agent.version)"


### PR DESCRIPTION
SNP will also be using the same initrd as SEV, so adding the cc_kbc to the attestation agent that is built inside the rootfs for SEV.

Switching attestation agent source to tobin's fork with an SNP attester.

Fixes: #6353