### PR TITLE
fix wrong notes for func GetSandboxesStoragePathRust()

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/shim_management.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management.go
@@ -307,7 +307,7 @@ func GetSandboxesStoragePath() string {
 	return "/run/vc/sbs"
 }
 
-// GetSandboxesStoragePath returns the storage path where sandboxes info are stored in runtime-rs
+// GetSandboxesStoragePathRust returns the storage path where sandboxes info are stored in runtime-rs
 func GetSandboxesStoragePathRust() string {
 	return "/run/kata"
 }


### PR DESCRIPTION
fix wrong notes for func GetSandboxesStoragePathRust()