### PR TITLE
main | kata-deploy: Fix kata deploy arm64 image build error

### DIFF
--- a/.github/workflows/payload-after-push-amd64.yaml
+++ b/.github/workflows/payload-after-push-amd64.yaml
@@ -45,7 +45,7 @@ jobs:
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v3
         with:
-          name: kata-artifacts
+          name: kata-artifacts-amd64
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
           retention-days: 1
           if-no-files-found: error
@@ -58,7 +58,7 @@ jobs:
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:
-          name: kata-artifacts
+          name: kata-artifacts-amd64
           path: kata-artifacts
       - name: merge-artifacts
         run: |
@@ -66,7 +66,7 @@ jobs:
       - name: store-artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: kata-static-tarball
+          name: kata-static-tarball-amd64
           path: kata-static.tar.xz
           retention-days: 1
           if-no-files-found: error
@@ -86,7 +86,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@v3
         with:
-          name: kata-static-tarball
+          name: kata-static-tarball-amd64
 
       - name: build-and-push-kata-payload
         id: build-and-push-kata-payload

--- a/.github/workflows/payload-after-push-arm64.yaml
+++ b/.github/workflows/payload-after-push-arm64.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v3
         with:
-          name: kata-artifacts
+          name: kata-artifacts-arm64
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
           retention-days: 1
           if-no-files-found: error
@@ -66,7 +66,7 @@ jobs:
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:
-          name: kata-artifacts
+          name: kata-artifacts-arm64
           path: kata-artifacts
       - name: merge-artifacts
         run: |
@@ -74,7 +74,7 @@ jobs:
       - name: store-artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: kata-static-tarball
+          name: kata-static-tarball-arm64
           path: kata-static.tar.xz
           retention-days: 1
           if-no-files-found: error
@@ -98,7 +98,7 @@ jobs:
       - name: get-kata-tarball
         uses: actions/download-artifact@v3
         with:
-          name: kata-static-tarball
+          name: kata-static-tarball-arm64
 
       - name: build-and-push-kata-payload
         id: build-and-push-kata-payload

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -3,28 +3,27 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Specify alternative base image, e.g. clefos for s390x
-ARG BASE_IMAGE_NAME=registry.centos.org/centos
-ARG BASE_IMAGE_TAG=7
+ARG BASE_IMAGE_NAME=ubuntu
+ARG BASE_IMAGE_TAG=20.04
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
+ENV DEBIAN_FRONTEND=noninteractive
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts
 
 COPY ${KATA_ARTIFACTS} ${WORKDIR}
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN \
-yum -y update && \
-yum -y install xz && \
-yum clean all && \
+apt-get update && \
+apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl xz-utils systemd && \
+mkdir -p /etc/apt/keyrings/ && \
+curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg && \
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
+apt-get update && \
+apt-get install -y --no-install-recommends kubectl && \
+apt-get clean && rm -rf /var/lib/apt/lists/ && \
 mkdir -p ${DESTINATION} && \
 tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION}
-
-# hadolint will deny echo -e, heredocs don't work in Dockerfiles, shell substitution doesn't work with $'...'
-RUN \
-echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$(uname -m)" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo && \
-yum -y install kubectl && \
-yum clean all
 
 COPY scripts ${DESTINATION}/scripts

--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -27,19 +27,19 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         securityContext:
-          privileged: false
+          privileged: true
         volumeMounts:
         - name: dbus
-          mountPath: /var/run/dbus
+          mountPath: /var/run/dbus/system_bus_socket
         - name: systemd
-          mountPath: /run/systemd
+          mountPath: /run/systemd/system
       volumes:
         - name: dbus
           hostPath:
-            path: /var/run/dbus
+            path: /var/run/dbus/system_bus_socket
         - name: systemd
           hostPath:
-            path: /run/systemd
+            path: /run/systemd/system
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -29,7 +29,7 @@ spec:
             fieldRef:
               fieldPath: spec.nodeName
         securityContext:
-          privileged: false
+          privileged: true
         volumeMounts:
         - name: crio-conf
           mountPath: /etc/crio/
@@ -38,9 +38,9 @@ spec:
         - name: kata-artifacts
           mountPath: /opt/kata/
         - name: dbus
-          mountPath: /var/run/dbus
+          mountPath: /var/run/dbus/system_bus_socket
         - name: systemd
-          mountPath: /run/systemd
+          mountPath: /run/systemd/system
         - name: local-bin
           mountPath: /usr/local/bin/
       volumes:
@@ -56,10 +56,10 @@ spec:
             type: DirectoryOrCreate
         - name: dbus
           hostPath:
-            path: /var/run/dbus
+            path: /var/run/dbus/system_bus_socket
         - name: systemd
           hostPath:
-            path: /run/systemd
+            path: /run/systemd/system
         - name: local-bin
           hostPath:
             path: /usr/local/bin/

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -18,23 +18,7 @@ pushd ${KATA_DEPLOY_DIR}
 IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-$(uname -m)"
 
 echo "Building the image"
-case $(uname -m) in
-	aarch64)
-		docker build \
-			--build-arg BASE_IMAGE_NAME=cdocker.io/library/centos \
-			--build-arg BASE_IMAGE_TAG=7 \
-			--tag ${IMAGE_TAG} .
-		;;
-	s390x)
-		docker build \
-			--build-arg BASE_IMAGE_NAME=docker.io/library/clefos \
-			--build-arg BASE_IMAGE_TAG=7 \
-			--tag ${IMAGE_TAG} .
-		;;
-	*)
-		docker build --tag ${IMAGE_TAG} .
-		;;
-esac
+docker build --tag ${IMAGE_TAG} .
 
 echo "Pushing the image to quay.io"
 docker push ${IMAGE_TAG}
@@ -44,23 +28,7 @@ if [ -n "${TAG}" ]; then
 
 	echo "Building the ${ADDITIONAL_TAG} image"
 
-	case $(uname -m) in
-		aarch64)
-			docker build \
-				--build-arg BASE_IMAGE_NAME=docker.io/library/centos  \
-				--build-arg BASE_IMAGE_TAG=7 \
-				--tag ${ADDITIONAL_TAG} .
-			;;
-		s390x)
-			docker build \
-				--build-arg BASE_IMAGE_NAME=docker.io/library/clefos \
-				--build-arg BASE_IMAGE_TAG=7 \
-				--tag ${ADDITIONAL_TAG} .
-			;;
-		*)
-			docker build --tag ${ADDITIONAL_TAG} .
-			;;
-	esac
+	docker build --tag ${ADDITIONAL_TAG} .
 
 	echo "Pushing the image ${ADDITIONAL_TAG} to quay.io"
 	docker push ${ADDITIONAL_TAG}


### PR DESCRIPTION
kata-deploy: Fix kata deploy image build error

When building the kata deploy arm64 image, using default base image report errors.

Fixes: #6358

Signed-off-by: Singh Wang <wangxin_0611@126.com>