### PR TITLE
runtime/Makefile: Fix install-containerd-shim-v2 dependency

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -667,7 +667,7 @@ install-bin: $(BINLIST)
 
 install-runtime: runtime install-scripts install-completions install-configs install-bin
 
-install-containerd-shim-v2: $(SHIMV2)
+install-containerd-shim-v2: $(SHIMV2_OUTPUT)
 	$(QUIET_INST)$(call INSTALL_EXEC,$<,$(BINDIR))
 
 install-monitor: $(MONITOR)


### PR DESCRIPTION
```
$ make install
make: *** No rule to make target 'containerd-shim-kata-v2', needed by 'install-containerd-shim-v2'.  Stop.

```
Spotted when building kata-runtime with a different name for SHIMV2_OUTPUT. For instance, trying to keep different runtime binaries installed at the same time, one from master and another from lets say, the CCv0 branch, with the following small change applied.

```
diff --git a/src/runtime/Makefile b/src/runtime/Makefile index 95efaff78..2bab9eb75 100644
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -231,7 +231,7 @@ SED = sed

 CLI_DIR = cmd
 SHIMV2 = containerd-shim-kata-v2
-SHIMV2_OUTPUT = $(bCURDIR)/$(SHIMV2)
+SHIMV2_OUTPUT = $(CURDIR)/$(SHIMV2)-ccv0
 SHIMV2_DIR = $(CLI_DIR)/$(SHIMV2)

 MONITOR = kata-monitor
```