### PR TITLE
osbuilder: support for building cc_kbc

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -685,7 +685,8 @@ EOF
 		fi
 		export RUSTFLAGS
 		# Foreign CC is incompatible with libgit2 -- CC is still handled by `-C linker=...` flag
-		CC= cargo build --release --target "${target}" --no-default-features --features "${AA_KBC}"
+		# AA_KBC=cc_kbc: tdx-attest-sys build fails unless a value is provided for SGX_SDK
+		CC= SGX_SDK= cargo build --release --target "${target}" --no-default-features --features "${AA_KBC}"
 		install -D -o root -g root -m 0755 "target/${target}/release/attestation-agent" -t "${ROOTFS_DIR}/usr/local/bin/"
 		popd
 	fi

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -656,11 +656,11 @@ EOF
 	touch "$dns_file"
 
     if [ -n "${AA_KBC}" ]; then
-		if [ "${AA_KBC}" == "offline_sev_kbc" ]; then
+		if [[ "${AA_KBC}" == *"offline_sev_kbc"* ]]; then
 			info "Adding agent config for ${AA_KBC}"
 			AA_KBC_PARAMS="offline_sev_kbc::null" envsubst < "${script_dir}/agent-config.toml.in" | tee "${ROOTFS_DIR}/etc/agent-config.toml"
 		fi
-		if [ "${AA_KBC}" == "online_sev_kbc" ]; then
+		if [[ "${AA_KBC}" == *"online_sev_kbc"* ]]; then
 			info "Adding agent config for ${AA_KBC}"
 			#KBC URI will be specified in the config file via kernel params
 			AA_KBC_PARAMS="online_sev_kbc::123.123.123.123:44444" envsubst < "${script_dir}/agent-config.toml.in" | tee "${ROOTFS_DIR}/etc/agent-config.toml"
@@ -675,7 +675,7 @@ EOF
 		git checkout FETCH_HEAD
 		source "${HOME}/.cargo/env"
 		target="${ARCH}-unknown-linux-${LIBC}"
-		if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
+		if [[ "${AA_KBC}" == *"eaa_kbc"* ]] && [ "${ARCH}" == "x86_64" ]; then
 			RUSTFLAGS="-C link-args=-Wl,-rpath,/usr/local/lib/rats-tls"
 			# Currently eaa_kbc module only support this specific platform
 			target="x86_64-unknown-linux-gnu"

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -37,6 +37,21 @@ RUN echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubu
 	fi
 fi
 
+if [[ "${AA_KBC}" == *"cc_kbc"* ]] && [ "${ARCH}" == "x86_64" ]; then
+	if [ "${OS_VERSION}" == "focal" ] || [ "${OS_VERSION}" == "20.04" ]; then
+		PACKAGES+=" apt gnupg"
+		AA_KBC_EXTRAS+="
+RUN curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - ; \
+    echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list ; \
+    apt-get update \&\& \
+    apt-get install -y libtdx-attest-dev libclang-dev
+"
+	else
+		echo "libtdx-attest-dev is only provided for Ubuntu 20.04; not for ${OS_VERSION}"
+		exit 1
+	fi
+fi
+
 if [ "$(uname -m)" != "$ARCH" ]; then
 	case "$ARCH" in
 		ppc64le) cc_arch=powerpc64le;;

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -19,7 +19,7 @@ case "$ARCH" in
 	*) die "$ARCH not supported"
 esac
 
-if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
+if [[ "${AA_KBC}" == *"eaa_kbc"* ]] && [ "${ARCH}" == "x86_64" ]; then
 	source /etc/os-release
 
 	if [ "${VERSION_ID}" == "20.04" ]; then

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -58,6 +58,23 @@ EOF
 		fi
 	fi
 
+	if [[ "${AA_KBC}" == *"cc_kbc"* ]] && [ "${ARCH}" == "x86_64" ]; then
+		source /etc/os-release
+
+		if [ "${VERSION_ID}" == "20.04" ]; then
+			curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | chroot "${rootfs_dir}" apt-key add -
+			cat << EOF | chroot "$rootfs_dir"
+echo 'deb [arch=amd64] http://security.ubuntu.com/ubuntu focal-security main universe' | tee /etc/apt/sources.list.d/universe.list
+echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list
+apt-get update
+apt-get install -y libtdx-attest
+EOF
+		else
+			echo "libtdx-attest is only provided for Ubuntu 20.04, there's yet no packages for Ubuntu ${VERSION_ID}"
+			exit 1
+		fi
+	fi
+
 	# Reduce image size and memory footprint by removing unnecessary files and directories.
 	rm -rf $rootfs_dir/usr/share/{bash-completion,bug,doc,info,lintian,locale,man,menu,misc,pixmaps,terminfo,zsh}
 }

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -38,7 +38,7 @@ EOF
 		cp --remove-destination "$file" "$rootfs_dir$file"
 	done
 
-	if [ "${AA_KBC}" == "eaa_kbc" ] && [ "${ARCH}" == "x86_64" ]; then
+	if [[ "${AA_KBC}" == *"eaa_kbc"* ]] && [ "${ARCH}" == "x86_64" ]; then
 		source /etc/os-release
 
 		if [ "${VERSION_ID}" == "20.04" ]; then

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -41,7 +41,7 @@ build_initrd() {
 	export AGENT_INIT="yes"
 	# ROOTFS_BUILD_DEST is a Make variable
 	# SNP will also use the SEV guest module
-	if [[ "${AA_KBC:-}" == "offline_sev_kbc" || "${AA_KBC:-}" == "online_sev_kbc" ]]; then
+	if [[ "${AA_KBC:-}" == *"offline_sev_kbc"* || "${AA_KBC:-}" == *"online_sev_kbc"* ]]; then
 		config_version=$(get_config_version)
 		kernel_version="$(get_from_kata_deps "assets.kernel.sev.version")"
 		kernel_version=${kernel_version#v}

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -277,7 +277,7 @@ install_cc_image() {
 }
 
 install_cc_sev_image() {
-	AA_KBC="online_sev_kbc"
+	AA_KBC="online_sev_kbc cc_kbc"
 	image_type="initrd"
 	install_cc_image "${AA_KBC}" "${image_type}" "sev"
 }


### PR DESCRIPTION
- support multiple kbcs in a single AA build
- support building AA[cc_kbc] (which depends on a tdx lib)
- include AA[cc_kbc] in SEV(-SNP) image
