### PR TITLE
Upgrade to Cloud Hypervisor v30.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -1131,6 +1131,9 @@ components:
           items:
             type: integer
           type: array
+      required:
+      - host_cpus
+      - vcpu
       type: object
     CpuFeatures:
       example:

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/CpuAffinity.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/CpuAffinity.md
@@ -4,14 +4,14 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Vcpu** | Pointer to **int32** |  | [optional] 
-**HostCpus** | Pointer to **[]int32** |  | [optional] 
+**Vcpu** | **int32** |  | 
+**HostCpus** | **[]int32** |  | 
 
 ## Methods
 
 ### NewCpuAffinity
 
-`func NewCpuAffinity() *CpuAffinity`
+`func NewCpuAffinity(vcpu int32, hostCpus []int32, ) *CpuAffinity`
 
 NewCpuAffinity instantiates a new CpuAffinity object
 This constructor will assign default values to properties that have it defined,
@@ -45,11 +45,6 @@ and a boolean to check if the value has been set.
 
 SetVcpu sets Vcpu field to given value.
 
-### HasVcpu
-
-`func (o *CpuAffinity) HasVcpu() bool`
-
-HasVcpu returns a boolean if a field has been set.
 
 ### GetHostCpus
 
@@ -70,11 +65,6 @@ and a boolean to check if the value has been set.
 
 SetHostCpus sets HostCpus field to given value.
 
-### HasHostCpus
-
-`func (o *CpuAffinity) HasHostCpus() bool`
-
-HasHostCpus returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cpu_affinity.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cpu_affinity.go
@@ -16,16 +16,18 @@ import (
 
 // CpuAffinity struct for CpuAffinity
 type CpuAffinity struct {
-	Vcpu     *int32   `json:"vcpu,omitempty"`
-	HostCpus *[]int32 `json:"host_cpus,omitempty"`
+	Vcpu     int32   `json:"vcpu"`
+	HostCpus []int32 `json:"host_cpus"`
 }
 
 // NewCpuAffinity instantiates a new CpuAffinity object
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewCpuAffinity() *CpuAffinity {
+func NewCpuAffinity(vcpu int32, hostCpus []int32) *CpuAffinity {
 	this := CpuAffinity{}
+	this.Vcpu = vcpu
+	this.HostCpus = hostCpus
 	return &this
 }
 
@@ -37,76 +39,60 @@ func NewCpuAffinityWithDefaults() *CpuAffinity {
 	return &this
 }
 
-// GetVcpu returns the Vcpu field value if set, zero value otherwise.
+// GetVcpu returns the Vcpu field value
 func (o *CpuAffinity) GetVcpu() int32 {
-	if o == nil || o.Vcpu == nil {
+	if o == nil {
 		var ret int32
 		return ret
 	}
-	return *o.Vcpu
+
+	return o.Vcpu
 }
 
-// GetVcpuOk returns a tuple with the Vcpu field value if set, nil otherwise
+// GetVcpuOk returns a tuple with the Vcpu field value
 // and a boolean to check if the value has been set.
 func (o *CpuAffinity) GetVcpuOk() (*int32, bool) {
-	if o == nil || o.Vcpu == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.Vcpu, true
+	return &o.Vcpu, true
 }
 
-// HasVcpu returns a boolean if a field has been set.
-func (o *CpuAffinity) HasVcpu() bool {
-	if o != nil && o.Vcpu != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetVcpu gets a reference to the given int32 and assigns it to the Vcpu field.
+// SetVcpu sets field value
 func (o *CpuAffinity) SetVcpu(v int32) {
-	o.Vcpu = &v
+	o.Vcpu = v
 }
 
-// GetHostCpus returns the HostCpus field value if set, zero value otherwise.
+// GetHostCpus returns the HostCpus field value
 func (o *CpuAffinity) GetHostCpus() []int32 {
-	if o == nil || o.HostCpus == nil {
+	if o == nil {
 		var ret []int32
 		return ret
 	}
-	return *o.HostCpus
+
+	return o.HostCpus
 }
 
-// GetHostCpusOk returns a tuple with the HostCpus field value if set, nil otherwise
+// GetHostCpusOk returns a tuple with the HostCpus field value
 // and a boolean to check if the value has been set.
 func (o *CpuAffinity) GetHostCpusOk() (*[]int32, bool) {
-	if o == nil || o.HostCpus == nil {
+	if o == nil {
 		return nil, false
 	}
-	return o.HostCpus, true
+	return &o.HostCpus, true
 }
 
-// HasHostCpus returns a boolean if a field has been set.
-func (o *CpuAffinity) HasHostCpus() bool {
-	if o != nil && o.HostCpus != nil {
-		return true
-	}
-
-	return false
-}
-
-// SetHostCpus gets a reference to the given []int32 and assigns it to the HostCpus field.
+// SetHostCpus sets field value
 func (o *CpuAffinity) SetHostCpus(v []int32) {
-	o.HostCpus = &v
+	o.HostCpus = v
 }
 
 func (o CpuAffinity) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-	if o.Vcpu != nil {
+	if true {
 		toSerialize["vcpu"] = o.Vcpu
 	}
-	if o.HostCpus != nil {
+	if true {
 		toSerialize["host_cpus"] = o.HostCpus
 	}
 	return json.Marshal(toSerialize)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -578,6 +578,9 @@ components:
       description: Virtual machine configuration
 
     CpuAffinity:
+      required:
+        - vcpu
+        - host_cpus
       type: object
       properties:
         vcpu:

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v29.0"
+      version: "v30.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This release has been tracked in our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
v30.0. The following user visible changes have been made:

Command Line Changes for Reduced Binary Size
--------------------------------------------

The `clap` crate was replaced by the `argh` crate to create our command
line, which reduced our release binary size from 3.6MB to 3.3MB. There
were several syntax changes:

* All `--option=value` commands now are `--option value`.
* The `--disk DISK1 DISK2` command now is `--disk DISK1 --disk DISK2`.
* The  `-vvv` command now is `-v -v -v`

Basic vfio-user Server Support
------------------------------

Our `vfio-user` crate is extended to provide basic server side support
with an example of gpio vfio-user device. This crate now is moved to [its
own repository](https://github.com/rust-vmm/vfio-user) under the
`rust-vmm` organization.

Heap Profiling Support
----------------------

A new building target is added for profiling purposes with examples of
heap profiling using `dhat` gated by the `dhat-heap` feature.

Documentation Improvements
--------------------------

The documentation on Intel TDX is expanded with details of the building
and using [TD-Shim](https://github.com/confidential-containers/td-shim),
references to [TDX Tools](https://github.com/intel/tdx-tools), and
version information of guest/host kernel/TDVF/TDShim being tested. Also,
a new 'heap profiling' documentation is added with improvements on the
existing 'profiling' documentation.

Notable Bug Fixes
-----------------

* Close FDs for TAP devices that are provided to VM
* Set vcpu thread status properly and signal `exit_evt` upon thread exit
* Populate CPUID leaf 0x4000_0010 (TSC frequency) 
* Inform the TPM guest driver upon failed TPM requests on the host 
* Bug fix to OpenAPI specification file

Fixes: #6375 

Signed-off-by: Bo Chen [chen.bo@intel.com](mailto:chen.bo@intel.com)