### PR TITLE
CCv0: set dependencies to v0.4.0 tag

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1887,7 +1887,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/image-rs?rev=948db858579be538724266a650e840e75e7e824d#948db858579be538724266a650e840e75e7e824d"
+source = "git+https://github.com/confidential-containers/image-rs?rev=v0.4.0#948db858579be538724266a650e840e75e7e824d"
 dependencies = [
  "anyhow",
  "async-compression",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -70,13 +70,11 @@ clap = { version = "3.0.1", features = ["derive"] }
 openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
-# TODO: this image-rs rev pulls in wrong attestation_agent
 [target.'cfg(target_arch = "s390x")'.dependencies]
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "948db858579be538724266a650e840e75e7e824d", default-features = false, features = ["kata-cc-s390x"] }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "v0.4.0", default-features = false, features = ["kata-cc-s390x"] }
 
-# TODO: this image-rs rev pulls in wrong attestation_agent
 [target.'cfg(not(target_arch = "s390x"))'.dependencies]
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "948db858579be538724266a650e840e75e7e824d", default-features = true, features = ["kata-cc", "signature-simple"] }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "v0.4.0", default-features = true, features = ["kata-cc", "signature-simple"] }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/versions.yaml
+++ b/versions.yaml
@@ -191,8 +191,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/attestation-agent"
-    # v0.3.0-4-gc6cdff6
-    version: "c6cdff6dcd4f4ca45fa0fb7df439057d2dba15ea"
+    version: "v0.4.0"
 
   cni-plugins:
     description: "CNI network plugins"
@@ -312,8 +311,7 @@ externals:
   td-shim:
     description: "Confidential Containers Shim Firmware"
     url: "https://github.com/confidential-containers/td-shim"
-    # v0.3.0-32-g5fa81ef
-    version: "5fa81efa1e43c8005d6d8099b5c099125c17b4b0"
+    version: "v0.4.0"
     toolchain: "nightly-2022-11-15"
 
   virtiofsd:


### PR DESCRIPTION
This covers td-shim, attestation-agent and image-rs.

Fixes: #6366