### PR TITLE
workflows:  Fixes for the `payload-after-push` action

### DIFF
--- a/.github/workflows/payload-after-push-amd64.yaml
+++ b/.github/workflows/payload-after-push-amd64.yaml
@@ -75,7 +75,7 @@ jobs:
     needs: create-kata-tarball
     runs-on: ubuntu-latest
     steps:
-      - name: Login to Confidential Containers quay.io
+      - name: Login to Kata Containers quay.io
         uses: docker/login-action@v2
         with:
           registry: quay.io

--- a/.github/workflows/payload-after-push-arm64.yaml
+++ b/.github/workflows/payload-after-push-arm64.yaml
@@ -83,7 +83,7 @@ jobs:
     needs: create-kata-tarball
     runs-on: arm64
     steps:
-      - name: Login to Confidential Containers quay.io
+      - name: Login to Kata Containers quay.io
         uses: docker/login-action@v2
         with:
           registry: quay.io

--- a/.github/workflows/payload-after-push-s390x.yaml
+++ b/.github/workflows/payload-after-push-s390x.yaml
@@ -82,7 +82,7 @@ jobs:
     needs: create-kata-tarball
     runs-on: s390x
     steps:
-      - name: Login to Confidential Containers quay.io
+      - name: Login to Kata Containers quay.io
         uses: docker/login-action@v2
         with:
           registry: quay.io

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -7,19 +7,19 @@ on:
 
 jobs:
   build-assets-amd64:
-    uses: ./.github/workflows/cc-payload-after-push-amd64.yaml
+    uses: ./.github/workflows/payload-after-push-amd64.yaml
     with:
       target-arch: amd64
     secrets: inherit
 
   build-assets-arm64:
-    uses: ./.github/workflows/cc-payload-after-push-arm64.yaml
+    uses: ./.github/workflows/payload-after-push-arm64.yaml
     with:
       target-arch: arm64
     secrets: inherit
 
   build-assets-s390x:
-    uses: ./.github/workflows/cc-payload-after-push-s390x.yaml
+    uses: ./.github/workflows/payload-after-push-s390x.yaml
     with:
       target-arch: s390x
     secrets: inherit

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -31,7 +31,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Login to Confidential Containers quay.io
+      - name: Login to Kata Containers quay.io
         uses: docker/login-action@v2
         with:
           registry: quay.io


### PR DESCRIPTION
---

workflows: Fix action name

We have a few actions in the `payload-after-push.*.yaml` that are
referring to Confidential Containers, but they should be referring to
Kata Containers instead.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

---

workflows: Fix the path of imported workflows

In `payload-after-push.yaml` we ended up mentioning cc-*.yaml workflows,
which are non existent in the main branch.

Let's adapt the name to the correct ones.

Fixes: #6343

---