### PR TITLE
workflows: Yet more fixes for publishing the kata-deploy payload after every PR merged

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -3,8 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Specify alternative base image, e.g. clefos for s390x
-ARG IMAGE
-FROM ${IMAGE:-registry.centos.org/centos}:7
+ARG BASE_IMAGE_NAME=registry.centos.org/centos
+ARG BASE_IMAGE_TAG=7
+FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -20,8 +20,8 @@ IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-$(uname -m)"
 echo "Building the image"
 if [ "$(uname -m)" = "s390x" ]; then
 	docker build \
-		--build-arg IMG_NAME=clefos \
-		--build-arg IMG_TAG=7 \
+		--build-arg BASE_IMAGE_NAME=clefos \
+		--build-arg BASE_IMAGE_TAG=7 \
 		--tag ${IMAGE_TAG} .
 else
 	docker build --tag ${IMAGE_TAG} .
@@ -36,8 +36,8 @@ if [ -n "${TAG}" ]; then
 	echo "Building the ${ADDITIONAL_TAG} image"
 	if [ "$(uname -m)" = "s390x" ]; then
 		docker build \
-			--build-arg IMG_NAME=clefos \
-			--build-arg IMG_TAG=7 \
+			--build-arg BASE_IMAGE_NAME=clefos \
+			--build-arg BASE_IMAGE_TAG=7 \
 			--tag ${ADDITIONAL_TAG} .
 	else
 		docker build --tag ${ADDITIONAL_TAG} .

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -5,7 +5,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-KATA_DEPLOY_DIR="`dirname ${0}`/../../kata-deploy-cc"
+KATA_DEPLOY_DIR="`dirname ${0}`/../../kata-deploy"
 KATA_DEPLOY_ARTIFACT="${1:-"kata-static.tar.xz"}"
 REGISTRY="${2:-"quay.io/kata-containers/kata-deploy"}"
 TAG="${3:-}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -18,14 +18,23 @@ pushd ${KATA_DEPLOY_DIR}
 IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-$(uname -m)"
 
 echo "Building the image"
-if [ "$(uname -m)" = "s390x" ]; then
-	docker build \
-		--build-arg BASE_IMAGE_NAME=clefos \
-		--build-arg BASE_IMAGE_TAG=7 \
-		--tag ${IMAGE_TAG} .
-else
-	docker build --tag ${IMAGE_TAG} .
-fi
+case $(uname -m) in
+	aarch64)
+		docker build \
+			--build-arg BASE_IMAGE_NAME=cdocker.io/library/centos \
+			--build-arg BASE_IMAGE_TAG=7 \
+			--tag ${IMAGE_TAG} .
+		;;
+	s390x)
+		docker build \
+			--build-arg BASE_IMAGE_NAME=docker.io/library/clefos \
+			--build-arg BASE_IMAGE_TAG=7 \
+			--tag ${IMAGE_TAG} .
+		;;
+	*)
+		docker build --tag ${IMAGE_TAG} .
+		;;
+esac
 
 echo "Pushing the image to quay.io"
 docker push ${IMAGE_TAG}
@@ -34,14 +43,24 @@ if [ -n "${TAG}" ]; then
 	ADDITIONAL_TAG="${REGISTRY}:${TAG}"
 
 	echo "Building the ${ADDITIONAL_TAG} image"
-	if [ "$(uname -m)" = "s390x" ]; then
-		docker build \
-			--build-arg BASE_IMAGE_NAME=clefos \
-			--build-arg BASE_IMAGE_TAG=7 \
-			--tag ${ADDITIONAL_TAG} .
-	else
-		docker build --tag ${ADDITIONAL_TAG} .
-	fi
+
+	case $(uname -m) in
+		aarch64)
+			docker build \
+				--build-arg BASE_IMAGE_NAME=docker.io/library/centos  \
+				--build-arg BASE_IMAGE_TAG=7 \
+				--tag ${ADDITIONAL_TAG} .
+			;;
+		s390x)
+			docker build \
+				--build-arg BASE_IMAGE_NAME=docker.io/library/clefos \
+				--build-arg BASE_IMAGE_TAG=7 \
+				--tag ${ADDITIONAL_TAG} .
+			;;
+		*)
+			docker build --tag ${ADDITIONAL_TAG} .
+			;;
+	esac
 
 	echo "Pushing the image ${ADDITIONAL_TAG} to quay.io"
 	docker push ${ADDITIONAL_TAG}


### PR DESCRIPTION
---

kata-deploy: Allow passing IMG_NAME and IMG_TAG

Let's break the IMAGE build parameter into IMG_NAME and IMG_TAG, as it
makes it easier to replace the default CentOS image by something else.

Spoiler alert, the default CentOS image is **not** multi-arch, and we do
want to support at least aarch64 and s390x in the near term future.

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

---

kata-deploy: Use different images for s390x and aarch64

As the image provided as part of registry.centos.org is not a multi-arch
one, at least not for CentOS 7, we need to expand the script used to
build the image to pass images that are known to work for s390x (ClefOS)
and aarch64 (CentOS, but coming from dockerhub).

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

---

kata-deploy: Fix path to the Dockerfile

As part of bd1ed26c8d0ef8da99bc2ffffb099f93f73a3880, we've pointed to
the Dockerfile that's used in the CC branch, which is wrong.

For what we're doing on main, we should be pointing to the one under the
`kata-deploy` folder, and not the one under the non-existent
`kata-deploy-cc` one.

Fixes: #6343

Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>

---