### PR TITLE
static checks workflow improvements

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -21,6 +21,7 @@ jobs:
     env:
       RUST_BACKTRACE: "1"
       target_branch: ${{ github.base_ref }}
+      GOPATH: ${{ github.workspace }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -31,8 +32,6 @@ jobs:
       uses: actions/setup-go@v3
       with:
         go-version: 1.19.3
-      env:
-        GOPATH: ${{ runner.workspace }}/kata-containers
     - name: Check kernel config version
       run: |
         cd "${{ github.workspace }}/src/github.com/${{ github.repository }}"
@@ -48,17 +47,14 @@ jobs:
           fi
           echo "Check passed"
         fi
-    - name: Set env
+    - name: Set PATH
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
-        echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
     - name: Setup
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
         cd ${GOPATH}/src/github.com/${{ github.repository }} && ./ci/setup.sh
-      env:
-        GOPATH: ${{ runner.workspace }}/kata-containers
     - name: Installing rust
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -23,6 +23,10 @@ jobs:
       target_branch: ${{ github.base_ref }}
       GOPATH: ${{ github.workspace }}
     steps:
+    - name: Free disk space
+      run: |
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf "$AGENT_TOOLSDIRECTORY"
     - name: Checkout code
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -20,9 +20,6 @@ jobs:
           - "sudo -E PATH=\"$PATH\" make test"
     env:
       TRAVIS: "true"
-      TRAVIS_BRANCH: ${{ github.base_ref }}
-      TRAVIS_PULL_REQUEST_BRANCH: ${{ github.head_ref }}
-      TRAVIS_PULL_REQUEST_SHA : ${{ github.event.pull_request.head.sha }}
       RUST_BACKTRACE: "1"
       target_branch: ${{ github.base_ref }}
     steps:
@@ -52,23 +49,11 @@ jobs:
           fi
           echo "Check passed"
         fi
-    - name: Setup GOPATH
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
-      run: |
-        echo "TRAVIS_BRANCH: ${TRAVIS_BRANCH}"
-        echo "TRAVIS_PULL_REQUEST_BRANCH: ${TRAVIS_PULL_REQUEST_BRANCH}"
-        echo "TRAVIS_PULL_REQUEST_SHA: ${TRAVIS_PULL_REQUEST_SHA}"
-        echo "TRAVIS: ${TRAVIS}"
     - name: Set env
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |
         echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
         echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
-    - name: Setup travis references
-      if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
-      run: |
-        echo "TRAVIS_BRANCH=${TRAVIS_BRANCH:-$(echo $GITHUB_REF | awk 'BEGIN { FS = \"/\" } ; { print $3 }')}"
-        target_branch=${TRAVIS_BRANCH}
     - name: Setup
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
       run: |

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -19,7 +19,6 @@ jobs:
           - "make test"
           - "sudo -E PATH=\"$PATH\" make test"
     env:
-      TRAVIS: "true"
       RUST_BACKTRACE: "1"
       target_branch: ${{ github.base_ref }}
     steps:

--- a/tools/osbuilder/tests/test_images.sh
+++ b/tools/osbuilder/tests/test_images.sh
@@ -32,6 +32,7 @@ readonly KATA_HYPERVISOR="${KATA_HYPERVISOR:-}"
 readonly KATA_DEV_MODE="${KATA_DEV_MODE:-}"
 readonly ci_results_dir="/var/osbuilder/tests"
 readonly dracut_dir=${project_dir}/dracut
+readonly KVM_MISSING="$([ -e /dev/kvm ] || echo true)"
 
 build_images=1
 build_initrds=1
@@ -166,7 +167,7 @@ exit_handler()
 		rm -rf "${tmp_dir}"
 
 		# Restore the default image in config file
-		[ -n "${TRAVIS:-}" ] || run_mgr configure-image
+		[ -n "${KVM_MISSING:-}" ] || run_mgr configure-image
 
 		return
 	fi
@@ -258,8 +259,7 @@ set_runtime()
 
 	[ -n "${KATA_DEV_MODE}" ] && return
 
-	# Travis doesn't support VT-x
-	[ -n "${TRAVIS:-}" ] && return
+	[ -n "${KVM_MISSING:-}" ] && return
 
 	if [ "$KATA_HYPERVISOR" != "firecracker" ]; then
 		if [ -f "$sysconfig_docker_config_file" ]; then
@@ -285,8 +285,7 @@ setup()
 		sudo -E mkdir -p ${ci_results_dir}
 	fi
 
-	# Travis doesn't support VT-x
-	[ -n "${TRAVIS:-}" ] && return
+	[ -n "${KVM_MISSING:-}" ] && return
 
 	[ ! -d "${tests_repo_dir}" ] && git clone "https://${tests_repo}" "${tests_repo_dir}"
 
@@ -383,8 +382,7 @@ install_image_create_container()
 	[ -z "$file" ] && die "need file"
 	[ ! -e "$file" ] && die "file does not exist: $file"
 
-	# Travis doesn't support VT-x
-	[ -n "${TRAVIS:-}" ] && return
+	[ -n "${KVM_MISSING:-}" ] && return
 
 	showKataRunFailure=1
 	run_mgr reset-config
@@ -401,8 +399,7 @@ install_initrd_create_container()
 	[ -z "$file" ] && die "need file"
 	[ ! -e "$file" ] && die "file does not exist: $file"
 
-	# Travis doesn't support VT-x
-	[ -n "${TRAVIS:-}" ] && return
+	[ -n "${KVM_MISSING:-}" ] && return
 
 	showKataRunFailure=1
 	run_mgr reset-config


### PR DESCRIPTION
- remove all TRAVIS_XXX variables (except TRAVIS because it is still used in kata-containers/tests)
- free some disk space to prevent the sudo test job from running out of space (affects mostly CCv0 branch)
- simplify setting GOPATH

Since these apply to main, I'm submitting against main but would be nice to have them flow into CCv0 soon.