### PR TITLE
utils: Make kata-manager.sh runs checks

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -638,6 +638,8 @@ test_installation()
 {
 	info "Testing $kata_project\n"
 
+	sudo kata-runtime check -v
+
 	local image="docker.io/library/busybox:latest"
 	sudo ctr image pull "$image"
 


### PR DESCRIPTION
Updated the `kata-manager.sh` script to make it run all the checks on the host system before attempting to create a container. If any checks fail, they will indicate to the user what the problem is in a clearer manner than those reported by the container manager.

Fixes: #6281.