### PR TITLE
packaging: fix sev kernel build

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -13,7 +13,6 @@ ARCH := $(shell uname -m)
 ifeq ($(ARCH), x86_64)
 EXTRA_TARBALL=cc-cloud-hypervisor-tarball \
 	cc-tdx-kernel-tarball \
-	cc-sev-kernel-tarball \
 	cc-tdx-qemu-tarball \
 	cc-tdx-td-shim-tarball \
 	cc-tdx-tdvf-tarball \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -421,7 +421,8 @@ install_cached_kernel_component() {
 		"kata-static-cc-sev-kernel-modules.tar.xz" \
 		"${workdir}/kata-static-cc-sev-kernel-modules.tar.xz" \
 	|| return 1
-		
+	
+	mkdir -p "${module_dir}"
 	tar xvf "${workdir}/kata-static-cc-sev-kernel-modules.tar.xz" -C  "${module_dir}" && return 0
 
 	return 1


### PR DESCRIPTION
Remove duplicate SEV kernel builds.
Fixes: #6415

Create a directory where kernel modules tarball will be extracted.
Fixes: #6418 