### PR TITLE
runtime: fix containerd-shim-kata failed to cleanup related cgroup files

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -2265,14 +2265,16 @@ func (s *Sandbox) resourceControllerDelete() error {
 		return nil
 	}
 
-	sandboxController, err := resCtrl.LoadResourceController(s.state.SandboxCgroupPath)
+	sandboxController, err := resCtrl.LoadResourceController(s.state.SandboxCgroupPath, s.config.SandboxCgroupOnly)
 	if err != nil {
 		return err
 	}
 
 	resCtrlParent := sandboxController.Parent()
-	if err := sandboxController.MoveTo(resCtrlParent); err != nil {
-		return err
+	if resCtrlParent != "." {
+		if err := sandboxController.MoveTo(resCtrlParent); err != nil {
+			return err
+		}
 	}
 
 	if err := sandboxController.Delete(); err != nil {
@@ -2280,7 +2282,7 @@ func (s *Sandbox) resourceControllerDelete() error {
 	}
 
 	if s.state.OverheadCgroupPath != "" {
-		overheadController, err := resCtrl.LoadResourceController(s.state.OverheadCgroupPath)
+		overheadController, err := resCtrl.LoadResourceController(s.state.OverheadCgroupPath, s.config.SandboxCgroupOnly)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Fixes: #6422


I found that the cause of this issue (#6422) is that The LinuxCgroup type returned by NewSandboxResourceController and LoadResourceController is inconsistent

In the [NewSandboxResourceController](https://github.com/kata-containers/kata-containers/blob/cc1821fb8bedb707ad87d914ff2a0df758ba2f04/src/runtime/pkg/resourcecontrol/cgroups.go#L173) function
```go
func NewSandboxResourceController(path string, resources *specs.LinuxResources, sandboxCgroupOnly bool) (ResourceController, error) {
	sandboxResources := *resources
	sandboxResources.Devices = append(sandboxResources.Devices, sandboxDevices()...)
        // ...
	if !IsSystemdCgroup(path) || !sandboxCgroupOnly {
                // this condition always true if  we set  sandbox_cgroup_only=false in the config file /etc/kata-containers/configuration.toml
               // so NewResourceController func will create an cgroup using cgroupsv2.NewManager
		return NewResourceController(path, &sandboxResources)
	}
        // ...

```

In the [LoadResourceController](https://github.com/kata-containers/kata-containers/blob/cc1821fb8bedb707ad87d914ff2a0df758ba2f04/src/runtime/pkg/resourcecontrol/cgroups.go#L228) function(this function will be call on pod deleting)
```go
func LoadResourceController(path string) (ResourceController, error) {
	var err error
	var cgroup interface{}

	//  ...
	if cgroups.Mode() == cgroups.Legacy || cgroups.Mode() == cgroups.Hybrid {
		// ...
	} else if cgroups.Mode() == cgroups.Unified {
                 // this condition always true because the function  IsSystemdCgroup(path) always return true
                //  so LoadResourceController func will return an cgroup using cgroupsv2.LoadSystemd
		if IsSystemdCgroup(path) {
			slice, unit, err := getSliceAndUnit(path)
			if err != nil {
				return nil, err
			}
			cgroup, err = cgroupsv2.LoadSystemd(slice, unit)
			if err != nil {
				return nil, err
			}
		} else {
			//...
		}
	} else {
        // ...
        }
        // ...
}
```

* edit configuration file such as /etc/kata-containers/configuration.toml, set sandbox_cgroup_only=false
* delete some pod that running on containerd-shim-kata

The solution to this issue is to make the cgroup types returned by NewSandboxResourceController and LoadResourceController be the same.

Signed-off-by: yahaa <1477765176@qq.com>
