### PR TITLE
bugfix: add get_ns_path API for Hypervisor

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -473,7 +473,20 @@ impl CloudHypervisorInner {
     }
 
     pub(crate) async fn get_vmm_master_tid(&self) -> Result<u32> {
-        todo!()
+        if let Some(pid) = self.pid {
+            Ok(pid)
+        } else {
+            Err(anyhow!("could not get vmm master tid"))
+        }
+    }
+
+    pub(crate) async fn get_ns_path(&self) -> Result<String> {
+        if let Some(pid) = self.pid {
+            let ns_path = format!("/proc/{}/ns", pid);
+            Ok(ns_path)
+        } else {
+            Err(anyhow!("could not get ns path"))
+        }
     }
 
     pub(crate) async fn check(&self) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -123,6 +123,11 @@ impl Hypervisor for CloudHypervisor {
         inner.get_vmm_master_tid().await
     }
 
+    async fn get_ns_path(&self) -> Result<String> {
+        let inner = self.inner.read().await;
+        inner.get_ns_path().await
+    }
+
     async fn check(&self) -> Result<()> {
         let inner = self.inner.read().await;
         inner.check().await

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
@@ -132,6 +132,11 @@ impl DragonballInner {
         Ok(master_tid)
     }
 
+    pub(crate) async fn get_ns_path(&self) -> Result<String> {
+        let ns_path = self.vmm_instance.get_ns_path();
+        Ok(ns_path)
+    }
+
     pub(crate) async fn check(&self) -> Result<()> {
         Ok(())
     }

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -122,6 +122,11 @@ impl Hypervisor for Dragonball {
         inner.get_vmm_master_tid().await
     }
 
+    async fn get_ns_path(&self) -> Result<String> {
+        let inner = self.inner.read().await;
+        inner.get_ns_path().await
+    }
+
     async fn check(&self) -> Result<()> {
         let inner = self.inner.read().await;
         inner.check().await

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -81,6 +81,13 @@ impl VmmInstance {
         result
     }
 
+    pub fn get_ns_path(&self) -> String {
+        let info_binding = self.vmm_shared_info.clone();
+        let info = info_binding.read().unwrap();
+        let result = format!("/proc/{}/task/{}/ns", info.pid, info.master_tid);
+        result
+    }
+
     pub fn get_vcpu_tids(&self) -> Vec<(u8, u32)> {
         let info = self.vmm_shared_info.clone();
         let result = info.read().unwrap().tids.clone();

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -88,6 +88,7 @@ pub trait Hypervisor: Send + Sync {
     async fn get_thread_ids(&self) -> Result<VcpuThreadIds>;
     async fn get_pids(&self) -> Result<Vec<u32>>;
     async fn get_vmm_master_tid(&self) -> Result<u32>;
+    async fn get_ns_path(&self) -> Result<String>;
     async fn cleanup(&self) -> Result<()>;
     async fn check(&self) -> Result<()>;
     async fn get_jailer_root(&self) -> Result<String>;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -94,6 +94,11 @@ impl QemuInner {
         todo!()
     }
 
+    pub(crate) async fn get_ns_path(&self) -> Result<String> {
+        info!(sl!(), "QemuInner::get_ns_path()");
+        todo!()
+    }
+
     pub(crate) async fn cleanup(&self) -> Result<()> {
         info!(sl!(), "QemuInner::cleanup()");
         todo!()

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -108,6 +108,11 @@ impl Hypervisor for Qemu {
         inner.get_vmm_master_tid().await
     }
 
+    async fn get_ns_path(&self) -> Result<String> {
+        let inner = self.inner.read().await;
+        inner.get_ns_path().await
+    }
+
     async fn cleanup(&self) -> Result<()> {
         let inner = self.inner.read().await;
         inner.cleanup().await

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -73,7 +73,8 @@ impl ContainerManager for VirtContainerManager {
         // * should be run after the vm is started, before container is created, and after CreateRuntime Hooks
         // * spec details: https://github.com/opencontainers/runtime-spec/blob/c1662686cff159595277b79322d0272f5182941b/config.md#createcontainer-hooks
         let vmm_master_tid = self.hypervisor.get_vmm_master_tid().await?;
-        let vmm_netns_path = format!("/proc/{}/task/{}/ns/{}", self.pid, vmm_master_tid, "net");
+        let vmm_ns_path = self.hypervisor.get_ns_path().await?;
+        let vmm_netns_path = format!("{}/{}", vmm_ns_path, "net");
         let state = oci::State {
             version: spec.version.clone(),
             id: config.container_id.clone(),


### PR DESCRIPTION
For external hypervisors(qemu, cloud-hypervisor, ...), the ns they launch vm in is different from internal hypervisor(dragonball). And when we doing CreateContainer hook, we will rely on the netns path. So we add a get_ns_path API.

Fixes: #6442

/cc @jodh-intel @pmores @amshinde 