### PR TITLE
kata-deploy-cc: Switch to using an ubuntu image

### DIFF
--- a/tools/packaging/kata-deploy-cc/Dockerfile
+++ b/tools/packaging/kata-deploy-cc/Dockerfile
@@ -3,29 +3,28 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Specify alternative base image, e.g. clefos for s390x
-ARG BASE_IMAGE_NAME=registry.centos.org/centos
-ARG BASE_IMAGE_TAG=7
+ARG BASE_IMAGE_NAME=ubuntu
+ARG BASE_IMAGE_TAG=20.04
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts
 
 COPY ${KATA_ARTIFACTS} ${WORKDIR}
 
+ENV DEBIAN_FRONTEND=noninteractive
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 RUN \
-yum -y update && \
-yum -y install xz && \
-yum clean all && \
+apt-get update && \
+apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl xz-utils systemd && \
+mkdir -p /etc/apt/keyrings/ && \
+curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://packages.cloud.google.com/apt/doc/apt-key.gpg && \
+echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
+apt-get update && \
+apt-get install -y --no-install-recommends kubectl && \
+apt-get clean && rm -rf /var/lib/apt/lists/ && \
 mkdir -p ${DESTINATION} && \
 tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION} && \
 rm ${WORKDIR}/${KATA_ARTIFACTS}
-
-# hadolint will deny echo -e, heredocs don't work in Dockerfiles, shell substitution doesn't work with $'...'
-RUN \
-echo "[kubernetes]" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "name=Kubernetes" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-$(uname -m)" >> /etc/yum.repos.d/kubernetes.repo && \
-echo "gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg" >> /etc/yum.repos.d/kubernetes.repo && \
-yum -y install kubectl && \
-yum clean all
 
 COPY scripts ${DESTINATION}/scripts

--- a/tools/packaging/kata-deploy-cc/Dockerfile
+++ b/tools/packaging/kata-deploy-cc/Dockerfile
@@ -3,9 +3,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Specify alternative base image, e.g. clefos for s390x
-ARG IMG_NAME=registry.centos.org/centos
-ARG IMG_TAG=7
-FROM $IMG_NAME:$IMG_TAG
+ARG BASE_IMAGE_NAME=registry.centos.org/centos
+ARG BASE_IMAGE_TAG=7
+FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
 ARG KATA_ARTIFACTS=./kata-static.tar.xz
 ARG DESTINATION=/opt/kata-artifacts
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -18,14 +18,7 @@ pushd ${KATA_DEPLOY_DIR}
 IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-$(uname -m)"
 
 echo "Building the image"
-if [ "$(uname -m)" = "s390x" ]; then
-	docker build \
-		--build-arg BASE_IMAGE_NAME=clefos \
-		--build-arg BASE_IMAGE_TAG=7 \
-		--tag ${IMAGE_TAG} .
-else
-	docker build --tag ${IMAGE_TAG} .
-fi
+docker build --tag ${IMAGE_TAG} .
 
 echo "Pushing the image to quay.io"
 docker push ${IMAGE_TAG}
@@ -34,14 +27,7 @@ if [ -n "${TAG}" ]; then
 	ADDITIONAL_TAG="${REGISTRY}:${TAG}"
 
 	echo "Building the ${ADDITIONAL_TAG} image"
-	if [ "$(uname -m)" = "s390x" ]; then
-		docker build \
-			--build-arg IMG_NAME=clefos \
-			--build-arg IMG_TAG=7 \
-			--tag ${ADDITIONAL_TAG} .
-	else
-		docker build --tag ${ADDITIONAL_TAG} .
-	fi
+	docker build --tag ${ADDITIONAL_TAG} .
 
 	echo "Pushing the image ${ADDITIONAL_TAG} to quay.io"
 	docker push ${ADDITIONAL_TAG}

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -20,8 +20,8 @@ IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-$(uname -m)"
 echo "Building the image"
 if [ "$(uname -m)" = "s390x" ]; then
 	docker build \
-		--build-arg IMG_NAME=clefos \
-		--build-arg IMG_TAG=7 \
+		--build-arg BASE_IMAGE_NAME=clefos \
+		--build-arg BASE_IMAGE_TAG=7 \
 		--tag ${IMAGE_TAG} .
 else
 	docker build --tag ${IMAGE_TAG} .


### PR DESCRIPTION
kata-deploy-cc: Switch to using Ubuntu image

This will help us in several ways:
* The first one is not using an image that's close to be EOLed, and
  which doesn't officially provide multi-arch images.
* The second is getting closer to what's been already done on main.
* The third is simplifying the logic to build the payload image.

Fixes: #6446
