### PR TITLE
runtime: add support for Hyper-V

### DIFF
--- a/src/runtime/pkg/resourcecontrol/cgroups.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups.go
@@ -67,7 +67,8 @@ func sandboxDevices() []specs.LinuxDeviceCgroup {
 	// In order to run Virtual Machines and create virtqueues, hypervisors
 	// need access to certain character devices in the host, like kvm and vhost-net.
 	hypervisorDevices := []string{
-		"/dev/kvm",         // To run virtual machines
+		"/dev/kvm",         // To run virtual machines with KVM
+		"/dev/mshv",        // To run virtual machines with Hyper-V
 		"/dev/vhost-net",   // To create virtqueues
 		"/dev/vfio/vfio",   // To access VFIO devices
 		"/dev/vhost-vsock", // To interact with vsock if


### PR DESCRIPTION
This adds `/dev/mshv` to the list of sandbox devices so that VMMs can create Hyper-V VMs.

In our testing, this also doesn't error out in case `/dev/mshv` isn't present.

Fixes #6454.