### PR TITLE
qemu/arm64: disable image nvdimm once no firmware offered

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -768,6 +768,16 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		kataUtilsLogger.Info("Setting 'disable_image_nvdimm = true' as microvm does not support NVDIMM")
 	}
 
+	// Nvdimm can only be support when UEFI/ACPI is enabled on arm64, otherwise disable it.
+	if goruntime.GOARCH == "arm64" && firmware == "" {
+		if p, err := h.PFlash(); err == nil {
+			if len(p) == 0 {
+				h.DisableImageNvdimm = true
+				kataUtilsLogger.Info("Setting 'disable_image_nvdimm = true' if there is no firmware specified")
+			}
+		}
+	}
+
 	blockDriver, err := h.blockDeviceDriver()
 	if err != nil {
 		return vc.HypervisorConfig{}, err

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	goruntime "runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -179,6 +180,10 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (config testRuntimeConf
 		VirtioFSCache:         defaultVirtioFSCacheMode,
 		PFlash:                []string{},
 		SGXEPCSize:            epcSize,
+	}
+
+	if goruntime.GOARCH == "arm64" && len(hypervisorConfig.PFlash) == 0 && hypervisorConfig.FirmwarePath == "" {
+		hypervisorConfig.DisableImageNvdimm = true
 	}
 
 	agentConfig := vc.KataAgentConfig{


### PR DESCRIPTION
For now, image nvdimm on qemu/arm64 depends on UEFI/ACPI, so if there
    is no firmware offered, it should be disabled.