### PR TITLE
CC | kernel: Ensure `kata_config_version` is taken into account

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -310,10 +310,12 @@ install_cc_kernel() {
 	export KATA_BUILD_CC=yes
 	export kernel_version="$(yq r $versions_yaml assets.kernel.version)"
 
+	local kernel_kata_config_version="$(cat ${repo_root_dir}/tools/packaging/kernel/kata_config_version)"
+
 	install_cached_component \
 		"kernel" \
 		"${jenkins_url}/job/kata-containers-2.0-kernel-cc-$(uname -m)/${cached_artifacts_path}" \
-		"${kernel_version}" \
+		"${kernel_version}-${kernel_kata_config_version}" \
 		"$(get_kernel_image_name)" \
 		"${final_tarball_name}" \
 		"${final_tarball_path}" \
@@ -409,10 +411,12 @@ install_cached_kernel_component() {
 	kernel_version="${2}"
 	module_dir="${3:-}"
 
+	local kernel_kata_config_version="$(cat ${repo_root_dir}/tools/packaging/kernel/kata_config_version)"
+
 	install_cached_component \
 		"kernel" \
 		"${jenkins_url}/job/kata-containers-2.0-kernel-${tee}-cc-$(uname -m)/${cached_artifacts_path}" \
-		"${kernel_version}" \
+		"${kernel_version}-${kernel_kata_config_version}" \
 		"$(get_kernel_image_name)" \
 		"${final_tarball_name}" \
 		"${final_tarball_path}" \

--- a/tools/packaging/static-build/cache_components.sh
+++ b/tools/packaging/static-build/cache_components.sh
@@ -39,17 +39,18 @@ cache_kernel_artifacts() {
 	local kernel_tarball_name="kata-static-cc-kernel.tar.xz"
 	local current_kernel_image="$(get_kernel_image_name)"
 	local current_kernel_version="$(get_from_kata_deps "assets.kernel.version")"
+	local current_kernel_kata_config_version="$(cat ${repo_root_dir}/tools/packaging/kernel/kata_config_version)"
 	if [ -n "${TEE}" ]; then
 		kernel_tarball_name="kata-static-cc-${TEE}-kernel.tar.xz"
 		[ "${TEE}" == "tdx" ] && current_kernel_version="$(get_from_kata_deps "assets.kernel.${TEE}.tag")"
 		[ "${TEE}" == "sev" ] && current_kernel_version="$(get_from_kata_deps "assets.kernel.${TEE}.version")"
 	fi
-	create_cache_asset "${kernel_tarball_name}" "${current_kernel_version}" "${current_kernel_image}"
+	create_cache_asset "${kernel_tarball_name}" "${current_kernel_version}-${current_kernel_kata_config_version}" "${current_kernel_image}"
 
 	if [ "${TEE}" == "sev" ]; then
 		module_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/cc-sev-kernel/builddir/kata-linux-${current_kernel_version#v}-$(get_config_version)/lib/modules/${current_kernel_version#v}"
 		tar cvfJ "${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/kata-static-cc-sev-kernel-modules.tar.xz" "${module_dir}/kernel/drivers/virt/coco/efi_secret/"
-		create_cache_asset "kata-static-cc-sev-kernel-modules.tar.xz" "${current_kernel_version}" "${current_kernel_image}"
+		create_cache_asset "kata-static-cc-sev-kernel-modules.tar.xz" "${current_kernel_version}-${current_kernel_kata_config_version}" "${current_kernel_image}"
 	fi
 
 }


### PR DESCRIPTION
We need to ensure `kata_config_version` is taken into account when:
* consuming a cached kernel, otherwise we may introduce changes to a kernel that will never be validated as part of the PR
* caching the kernel, otherwise we won't update the artefacts if just a config is changed

Fixes: #6485