### PR TITLE
CC | kata-deploy-push more space

### DIFF
--- a/.github/workflows/kata-deploy-push.yaml
+++ b/.github/workflows/kata-deploy-push.yaml
@@ -72,6 +72,10 @@ jobs:
   make-kata-tarball:
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
       - uses: actions/checkout@v2
       - name: make kata-tarball
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -25,4 +25,5 @@ done
 
 echo "create ${tar_path}"
 (cd "${tarball_content_dir}"; tar cvfJ "${tar_path}" .)
+rm -rf "${tarball_content_dir}"
 popd


### PR DESCRIPTION
Remove some tools from runner and some temp files during build so that we (hopefully) don't run out of disk space so often.