### PR TITLE
runtime: add filter metrics with specific names

### DIFF
--- a/src/runtime/cmd/kata-monitor/README.md
+++ b/src/runtime/cmd/kata-monitor/README.md
@@ -52,6 +52,8 @@ The **log-level** allows the chose how verbose the logs should be. The default i
 
 **NOTE: The debug endpoints are available only if the [Kata Containers configuration file](https://github.com/kata-containers/kata-containers/blob/9d5b03a1b70bbd175237ec4b9f821d6ccee0a1f6/src/runtime/config/configuration-qemu.toml.in#L590-L592) includes** `enable_pprof = true` **in the** `[runtime]` **section**.
 
+The `/metrics` has a query parameter `filter_family`, which filter Kata sandboxes metrics with specific names. If `filter_family` is set to `A` (and `B`, split with `,`), metrics with prefix `A` (and `B`) will only be returned.
+
 The `/sandboxes` endpoint lists the _sandbox ID_ of all the detected Kata runtimes. If accessed via a web browser, it provides html links to the endpoints available for each sandbox.
 
 In order to retrieve data for a specific Kata workload, the _sandbox ID_ should be passed in the query string using the _sandbox_ key. The `/agent-url`, and all the `/debug/`* endpoints require `sandbox_id` to be specified in the query string.

--- a/src/runtime/pkg/kata-monitor/shim_client.go
+++ b/src/runtime/pkg/kata-monitor/shim_client.go
@@ -8,6 +8,7 @@ package katamonitor
 import (
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	shim "github.com/kata-containers/kata-containers/src/runtime/pkg/containerd-shim-v2"
@@ -35,4 +36,12 @@ func getSandboxIDFromReq(r *http.Request) (string, error) {
 
 func getSandboxFS() string {
 	return shim.GetSandboxesStoragePath()
+}
+
+func getFilterFamilyFromReq(r *http.Request) ([]string, error) {
+	filterFamilies := r.URL.Query().Get("filter_family")
+	if filterFamilies != "" {
+		return strings.Split(filterFamilies, ","), nil
+	}
+	return nil, nil
 }


### PR DESCRIPTION
The kata monitor metrics API returns a huge size response, if containers or sandboxs are a large number,
focus on what we need will be harder.

#6500 
