### PR TITLE
runtime: change containers from slice to map

### DIFF
--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -136,7 +136,7 @@ func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec specs.Spec, runtimeCo
 			}
 			rootFs.Source = realPath
 		}
-		sandboxConfig.Containers[0].RootFs = rootFs
+		sandboxConfig.Containers[sandboxConfig.ID].RootFs = rootFs
 	}
 
 	// Important to create the network namespace before the sandbox is
@@ -252,7 +252,7 @@ func CreateContainer(ctx context.Context, sandbox vc.VCSandbox, ociSpec specs.Sp
 
 	katatrace.AddTags(span, "sandbox_id", sandboxID)
 
-	c, err = sandbox.CreateContainer(ctx, contConfig)
+	c, err = sandbox.CreateContainer(ctx, &contConfig)
 	if err != nil {
 		return vc.Process{}, err
 	}

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -939,7 +939,7 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid st
 
 		NetworkConfig: networkConfig,
 
-		Containers: []vc.ContainerConfig{containerConfig},
+		Containers: map[string]*vc.ContainerConfig{cid: &containerConfig},
 
 		Annotations: map[string]string{
 			vcAnnotations.BundlePathKey: bundlePath,

--- a/src/runtime/pkg/oci/utils_test.go
+++ b/src/runtime/pkg/oci/utils_test.go
@@ -169,7 +169,7 @@ func TestMinimalSandboxConfig(t *testing.T) {
 
 		NetworkConfig: expectedNetworkConfig,
 
-		Containers: []vc.ContainerConfig{expectedContainerConfig},
+		Containers: map[string]*vc.ContainerConfig{containerID: &expectedContainerConfig},
 
 		Annotations: map[string]string{
 			vcAnnotations.BundlePathKey: tempBundlePath,

--- a/src/runtime/virtcontainers/api_test.go
+++ b/src/runtime/virtcontainers/api_test.go
@@ -102,7 +102,7 @@ func newTestSandboxConfigNoop() SandboxConfig {
 		HypervisorType:   MockHypervisor,
 		HypervisorConfig: hypervisorConfig,
 
-		Containers: []ContainerConfig{container},
+		Containers: map[string]*ContainerConfig{containerID: &container},
 
 		Annotations: sandboxAnnotations,
 
@@ -287,7 +287,7 @@ func TestCleanupContainer(t *testing.T) {
 	for _, contID := range contIDs {
 		contConfig := newTestContainerConfigNoop(contID)
 
-		c, err := p.CreateContainer(ctx, contConfig)
+		c, err := p.CreateContainer(ctx, &contConfig)
 		if c == nil || err != nil {
 			t.Fatal(err)
 		}

--- a/src/runtime/virtcontainers/example_pod_run_test.go
+++ b/src/runtime/virtcontainers/example_pod_run_test.go
@@ -60,7 +60,7 @@ func Example_createAndStartSandbox() {
 
 		AgentConfig: agConfig,
 
-		Containers: []vc.ContainerConfig{container},
+		Containers: map[string]*vc.ContainerConfig{container.ID: &container},
 	}
 
 	// Create the sandbox

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -46,7 +46,7 @@ type VCSandbox interface {
 	Monitor(ctx context.Context) (chan error, error)
 	Delete(ctx context.Context) error
 	Status() SandboxStatus
-	CreateContainer(ctx context.Context, contConfig ContainerConfig) (VCContainer, error)
+	CreateContainer(ctx context.Context, contConfig *ContainerConfig) (VCContainer, error)
 	DeleteContainer(ctx context.Context, containerID string) (VCContainer, error)
 	StartContainer(ctx context.Context, containerID string) (VCContainer, error)
 	StopContainer(ctx context.Context, containerID string, force bool) (VCContainer, error)

--- a/src/runtime/virtcontainers/iostream_test.go
+++ b/src/runtime/virtcontainers/iostream_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestIOStream(t *testing.T) {
 	hConfig := newHypervisorConfig(nil, nil)
-	s, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NetworkConfig{}, []ContainerConfig{}, nil)
+	s, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NetworkConfig{}, map[string]*ContainerConfig{}, nil)
 	assert.NoError(t, err)
 	defer cleanUp()
 

--- a/src/runtime/virtcontainers/monitor_test.go
+++ b/src/runtime/virtcontainers/monitor_test.go
@@ -20,7 +20,7 @@ func TestMonitorSuccess(t *testing.T) {
 	assert := assert.New(t)
 
 	// create a sandbox
-	s, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NetworkConfig{}, []ContainerConfig{contConfig}, nil)
+	s, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NetworkConfig{}, map[string]*ContainerConfig{contConfig.ID: &contConfig}, nil)
 	assert.NoError(err)
 	defer cleanUp()
 
@@ -44,7 +44,7 @@ func TestMonitorClosedChannel(t *testing.T) {
 	assert := assert.New(t)
 
 	// create a sandbox
-	s, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NetworkConfig{}, []ContainerConfig{contConfig}, nil)
+	s, err := testCreateSandbox(t, testSandboxID, MockHypervisor, hConfig, NetworkConfig{}, map[string]*ContainerConfig{contConfig.ID: &contConfig}, nil)
 	assert.NoError(err)
 	defer cleanUp()
 

--- a/src/runtime/virtcontainers/persist.go
+++ b/src/runtime/virtcontainers/persist.go
@@ -506,15 +506,16 @@ func loadSandboxConfig(id string) (*SandboxConfig, error) {
 		LongLiveConn: savedConf.KataAgentConfig.LongLiveConn,
 	}
 
+	sconfig.Containers = make(map[string]*ContainerConfig)
 	for _, contConf := range savedConf.ContainerConfigs {
-		sconfig.Containers = append(sconfig.Containers, ContainerConfig{
+		sconfig.Containers[contConf.ID] = &ContainerConfig{
 			ID:          contConf.ID,
 			Annotations: contConf.Annotations,
 			Resources:   contConf.Resources,
 			RootFs: RootFs{
 				Target: contConf.RootFs,
 			},
-		})
+		}
 	}
 	return sconfig, nil
 }

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -96,9 +96,9 @@ func (s *Sandbox) Delete(ctx context.Context) error {
 }
 
 // CreateContainer implements the VCSandbox function of the same name.
-func (s *Sandbox) CreateContainer(ctx context.Context, conf vc.ContainerConfig) (vc.VCContainer, error) {
+func (s *Sandbox) CreateContainer(ctx context.Context, conf *vc.ContainerConfig) (vc.VCContainer, error) {
 	if s.CreateContainerFunc != nil {
-		return s.CreateContainerFunc(conf)
+		return s.CreateContainerFunc(*conf)
 	}
 	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v, containerConfig: %v", mockErrorPrefix, getSelf(), s, s.MockID, conf)
 }


### PR DESCRIPTION
runtime: change change conainers from slice to map to avoid avoid data corruption when delete slice items


Fixes: #6475

Signed-off-by: zhaojizhuang <571130360@qq.com>