### PR TITLE
arm/runtime: bring back pci shpc for qemu on arm

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -21,6 +21,7 @@ import (
 	"os/user"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -2399,6 +2400,11 @@ func (q *qemu) ResizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSiz
 // genericAppendBridges appends to devices the given bridges
 // nolint: unused, deadcode
 func genericAppendBridges(devices []govmmQemu.Device, bridges []types.Bridge, machineType string) []govmmQemu.Device {
+	shpc := false
+	if runtime.GOARCH == "arm64" {
+		shpc = true
+	}
+
 	bus := defaultPCBridgeBus
 	switch machineType {
 	case QemuQ35, QemuVirt:
@@ -2423,7 +2429,7 @@ func genericAppendBridges(devices []govmmQemu.Device, bridges []types.Bridge, ma
 				ID:   b.ID,
 				// Each bridge is required to be assigned a unique chassis id > 0
 				Chassis: idx + 1,
-				SHPC:    false,
+				SHPC:    shpc,
 				Addr:    strconv.FormatInt(int64(bridges[idx].Addr), 10),
 				// Certain guest BIOS versions think
 				// !SHPC means no hotplug, and won't


### PR DESCRIPTION
Currently, shpc is the only way for pci hotplug for qemu on Arm and there is no pci-acpi hotplug like x86 does for now.

We have disabled shpc drive in guest kernel which removes the 5s delay when perform shpc hotplug , but we may need pci bus rescan for device discovery explicitly. I don't do the recan op in a common path but only in "find_netlink" as I just encounter this case for now and may improve it later some way ( I have no idea for now).

I test this patch by using "nerdctl run --runtime io.containerd.kata.v2 --rm -it docker.io/library/ubuntu:latest bash". Without the first commit, network interface won't be hot added to kata and without the second commit, network device can't be found.