### PR TITLE
rootfs: Ensure we use a compatible version of dcap with rats-tls

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -30,7 +30,7 @@ RUN echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubu
     echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu ${OS_VERSION} main' \| tee /etc/apt/sources.list.d/intel-sgx.list; \
     curl -L https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key \| apt-key add -; \
     apt-get update; \
-    apt-get install -y rats-tls-tdx
+    apt-get install -y rats-tls-tdx libtdx-attest=1.15\*
 "
 	else
 		echo "rats-tls-tdx is only provided for Ubuntu 20.04, there's yet no packages for Ubuntu ${VERSION_ID}"

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -49,7 +49,7 @@ echo 'deb [arch=amd64] http://security.ubuntu.com/ubuntu focal-security main uni
 echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu focal main' | tee /etc/apt/sources.list.d/intel-sgx.list
 echo 'deb [arch=amd64] http://mirrors.openanolis.cn/inclavare-containers/ubuntu${VERSION_ID} focal main' | tee /etc/apt/sources.list.d/inclavare-containers.list
 apt-get update
-apt-get install -y rats-tls-tdx
+apt-get install -y rats-tls-tdx libtdx-attest=1.15\*
 
 echo 'port=4050' | tee /etc/tdx-attest.conf
 EOF


### PR DESCRIPTION
DCAP has upgraded to 1.16, which is not compatible with the host OS used as part of our CI (2022ww44).  Let's ensure DCAP 1.15 is used instead.

Fixes: #6529