### PR TITLE
versions: Upgrade TDVF to provide the same CCEL format with TD-Shim

### DIFF
--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -71,7 +71,6 @@ if [ "${ovmf_build}" == "tdx" ]; then
 	build_path_arch="${build_path_target_toolchain}/X64"
 	stat "${build_path_fv}/OVMF_CODE.fd"
 	stat "${build_path_fv}/OVMF_VARS.fd"
-	stat "${build_path_arch}/DumpTdxEventLog.efi"
 fi
 
 #need to leave tmp dir
@@ -92,7 +91,6 @@ fi
 if [ "${ovmf_build}" == "tdx" ]; then
 	install $build_root/$ovmf_dir/"${build_path_fv}"/OVMF_CODE.fd ${install_dir}
 	install $build_root/$ovmf_dir/"${build_path_fv}"/OVMF_VARS.fd ${install_dir}
-	install $build_root/$ovmf_dir/"${build_path_arch}"/DumpTdxEventLog.efi ${install_dir}
 fi
 
 local_dir=${PWD}

--- a/versions.yaml
+++ b/versions.yaml
@@ -304,7 +304,7 @@ externals:
     tdx:
       url: "https://github.com/tianocore/edk2-staging"
       description: "TDVF build needed for TDX measured direct boot."
-      version: "2022-tdvf-ww28.5"
+      version: "2022-tdvf-ww44.4"
       package: "OvmfPkg/OvmfPkgX64.dsc"
       package_output_dir: "OvmfX64"
 


### PR DESCRIPTION
From TDX MVP WW44 release, TDVF + Qemu: “ACPI table TDEL is renamed to CCEL according to ACPI 6.5 specification.” TD-Shim will use the latest CCEL format which is different with previous TDEL. To support CoCo generic attestation service, we need provide the same CCEL format.

Tool `DumpTdxEventLog.efi` is removed in new release.

Fixes: #6548