### PR TITLE
CC|kata-deploy: Add kata-qemu-se runtimeclass

### DIFF
--- a/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
@@ -18,6 +18,7 @@ shims=(
         "qemu"
         "qemu-tdx"
         "qemu-sev"
+        "qemu-se"
         "clh"
         "clh-tdx"
 )
@@ -258,6 +259,7 @@ function remove_artifacts() {
 		/opt/confidential-containers/bin/kata-collect-data.sh \
 		/opt/confidential-containers/bin/qemu-system-x86_64 \
 		/opt/confidential-containers/bin/qemu-system-x86_64-tdx \
+		/opt/confidential-containers/bin/qemu-system-s390x \
 		/opt/confidential-containers/bin/cloud-hypervisor \
 		/opt/confidential-containers/runtime-rs
 


### PR DESCRIPTION
This is to add a new element `qemu-se` to the shims for a new runtime class `kata-qemu-se`.

Fixes: #6549

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>