### PR TITLE
rustjail: Fix panic when cgroup manager fails

### DIFF
--- a/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
@@ -36,8 +36,9 @@ pub struct DBusClient {}
 
 impl DBusClient {
     fn build_proxy(&self) -> Result<SystemManager<'static>> {
-        let connection = zbus::blocking::Connection::system()?;
-        let proxy = SystemManager::new(&connection)?;
+        let connection =
+            zbus::blocking::Connection::system().context("Establishing a D-Bus connection")?;
+        let proxy = SystemManager::new(&connection).context("Building a D-Bus proxy manager")?;
         Ok(proxy)
     }
 }
@@ -109,7 +110,9 @@ impl SystemdInterface for DBusClient {
     }
 
     fn unit_exists(&self, unit_name: &str) -> Result<bool> {
-        let proxy = self.build_proxy()?;
+        let proxy = self
+            .build_proxy()
+            .with_context(|| format!("Checking if systemd unit {} exists", unit_name))?;
 
         Ok(proxy.get_unit(unit_name).is_ok())
     }

--- a/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
@@ -26,7 +26,7 @@ pub trait SystemdInterface {
 
     fn get_version(&self) -> Result<String>;
 
-    fn unit_exist(&self, unit_name: &str) -> Result<bool>;
+    fn unit_exists(&self, unit_name: &str) -> Result<bool>;
 
     fn add_process(&self, pid: i32, unit_name: &str) -> Result<()>;
 }
@@ -108,7 +108,7 @@ impl SystemdInterface for DBusClient {
         Ok(systemd_version)
     }
 
-    fn unit_exist(&self, unit_name: &str) -> Result<bool> {
+    fn unit_exists(&self, unit_name: &str) -> Result<bool> {
         let proxy = self.build_proxy()?;
 
         Ok(proxy.get_unit(unit_name).is_ok())

--- a/src/agent/rustjail/src/cgroups/systemd/manager.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/manager.rs
@@ -41,7 +41,7 @@ pub struct Manager {
 impl CgroupManager for Manager {
     fn apply(&self, pid: pid_t) -> Result<()> {
         let unit_name = self.unit_name.as_str();
-        if self.dbus_client.unit_exist(unit_name)? {
+        if self.dbus_client.unit_exists(unit_name)? {
             self.dbus_client.add_process(pid, self.unit_name.as_str())?;
         } else {
             self.dbus_client.start_unit(

--- a/src/agent/rustjail/src/cgroups/systemd/manager.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/manager.rs
@@ -41,7 +41,7 @@ pub struct Manager {
 impl CgroupManager for Manager {
     fn apply(&self, pid: pid_t) -> Result<()> {
         let unit_name = self.unit_name.as_str();
-        if self.dbus_client.unit_exist(unit_name).unwrap() {
+        if self.dbus_client.unit_exist(unit_name)? {
             self.dbus_client.add_process(pid, self.unit_name.as_str())?;
         } else {
             self.dbus_client.start_unit(


### PR DESCRIPTION
There can be an error while connecting to the cgroups managager, for
example a `ENOENT` if a file is not found. Make sure that this is
reported through the proper channels instead of causing a `panic()`
that does not provide much information.

Fixes: #6561 

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>
Reported-by: Greg Kurz <gkurz@redhat.com>

While I'm at it, rename `unit_exist` to `unit_exits` to match English grammar.