### PR TITLE
docs: Update CNM url in networking document

### DIFF
--- a/docs/design/architecture/networking.md
+++ b/docs/design/architecture/networking.md
@@ -36,7 +36,7 @@ compatibility, and performance on par with MACVTAP.
 Kata Containers has deprecated support for bridge due to lacking performance relative to TC-filter and MACVTAP.
 
 Kata Containers supports both
-[CNM](https://github.com/docker/libnetwork/blob/master/docs/design.md#the-container-network-model)
+[CNM](https://github.com/moby/libnetwork/blob/master/docs/design.md#the-container-network-model)
 and [CNI](https://github.com/containernetworking/cni) for networking management.
 
 ## Network Hotplug


### PR DESCRIPTION
This PR updates the url for the Container Network Model in the network document.

Fixes #6563