### PR TITLE
runtime-rs: sync the ip rules from host to guest 

### DIFF
--- a/src/libs/protocols/protos/agent.proto
+++ b/src/libs/protocols/protos/agent.proto
@@ -50,11 +50,13 @@ service AgentService {
 	// networking
 	rpc UpdateInterface(UpdateInterfaceRequest) returns (types.Interface);
 	rpc UpdateRoutes(UpdateRoutesRequest) returns (Routes);
+	rpc UpdateRules(UpdateRulesRequest) returns (Rules);
 	rpc ListInterfaces(ListInterfacesRequest) returns(Interfaces);
 	rpc ListRoutes(ListRoutesRequest) returns (Routes);
 	rpc AddARPNeighbors(AddARPNeighborsRequest) returns (google.protobuf.Empty);
 	rpc GetIPTables(GetIPTablesRequest) returns (GetIPTablesResponse);
 	rpc SetIPTables(SetIPTablesRequest) returns (SetIPTablesResponse);
+	
 
 	// observability
 	rpc GetMetrics(GetMetricsRequest) returns (Metrics);
@@ -359,6 +361,14 @@ message SetIPTablesRequest {
 message SetIPTablesResponse{
         // raw stdout from iptables-restore or ip6tables-restore
         bytes data = 1;
+}
+
+message Rules {
+    repeated types.Rule rules = 1;
+}
+
+message UpdateRulesRequest {
+    Rules rules = 1;
 }
 
 message OnlineCPUMemRequest {

--- a/src/libs/protocols/protos/types.proto
+++ b/src/libs/protocols/protos/types.proto
@@ -65,3 +65,17 @@ message ARPNeighbor {
 	int32 state = 4;
 	int32 flags = 5;
 }
+
+
+message Rule {
+    string src = 1;
+    int64 suppressIfgroup = 2;
+    int64 suppressPrefixlen = 3;
+    int64 mark = 4;
+    int64 mask = 5;
+    int64 goto = 6;
+    int64 flow = 7;
+    IPFamily family = 8;
+    int64 priority = 9;
+    int64 table = 10;
+}

--- a/src/runtime-rs/crates/agent/src/kata/agent.rs
+++ b/src/runtime-rs/crates/agent/src/kata/agent.rs
@@ -110,6 +110,7 @@ impl_agent!(
     tty_win_resize | crate::TtyWinResizeRequest | crate::Empty | None,
     update_interface | crate::UpdateInterfaceRequest | crate::Interface | None,
     update_routes | crate::UpdateRoutesRequest | crate::Routes | None,
+    update_rules | crate::UpdateRulesRequest | crate::Rules | None,
     add_arp_neighbors | crate::AddArpNeighborRequest | crate::Empty | None,
     list_interfaces | crate::Empty | crate::Interfaces | None,
     list_routes | crate::Empty | crate::Routes | None,

--- a/src/runtime-rs/crates/agent/src/kata/trans.rs
+++ b/src/runtime-rs/crates/agent/src/kata/trans.rs
@@ -21,10 +21,10 @@ use crate::{
         IPFamily, Interface, Interfaces, KernelModule, MemHotplugByProbeRequest, MemoryData,
         MemoryStats, MetricsResponse, NetworkStats, OnlineCPUMemRequest, PidsStats,
         ReadStreamRequest, ReadStreamResponse, RemoveContainerRequest, ReseedRandomDevRequest,
-        ResizeVolumeRequest, Route, Routes, SetGuestDateTimeRequest, SetIPTablesRequest,
+        ResizeVolumeRequest, Route, Routes, Rule, Rules, SetGuestDateTimeRequest, SetIPTablesRequest,
         SetIPTablesResponse, SignalProcessRequest, StatsContainerResponse, Storage, StringUser,
         ThrottlingData, TtyWinResizeRequest, UpdateContainerRequest, UpdateInterfaceRequest,
-        UpdateRoutesRequest, VersionCheckResponse, VolumeStatsRequest, VolumeStatsResponse,
+        UpdateRoutesRequest, UpdateRulesRequest, VersionCheckResponse, VolumeStatsRequest, VolumeStatsResponse,
         WaitProcessRequest, WriteStreamRequest,
     },
     OomEventResponse, WaitProcessResponse, WriteStreamResponse,
@@ -246,6 +246,60 @@ impl From<agent::Routes> for Routes {
     fn from(src: agent::Routes) -> Self {
         Self {
             routes: trans_vec(src.Routes),
+        }
+    }
+}
+
+impl From<Rule> for types::Rule {
+    fn from(from: Rule) -> Self {
+        Self {
+            src: from.src,
+            suppressIfgroup: from.suppress_if_group,
+            suppressPrefixlen: from.suppress_prefix_len,
+            mark: from.mark,
+            mask: from.mask,
+            goto: from.goto,
+            flow: from.flow,
+            family: from.family.into(),
+            priority: from.priority,
+            table: from.table,
+            unknown_fields: Default::default(),
+            cached_size: Default::default(),
+        }
+    }
+}
+
+impl From<types::Rule> for Rule {
+    fn from(from: types::Rule) -> Self {
+        Self {
+            src: from.src,
+            suppress_if_group: from.suppressIfgroup,
+            suppress_prefix_len: from.suppressPrefixlen,
+            mark: from.mark,
+            mask: from.mask,
+            goto: from.goto,
+            flow: from.flow,
+            family: from.family.into(),
+            priority: from.priority,
+            table: from.table,
+        }
+    }
+}
+
+impl From<Rules> for agent::Rules {
+    fn from(from: Rules) -> Self {
+        Self {
+            rules: from_vec(from.rules),
+            unknown_fields: Default::default(),
+            cached_size: Default::default(),
+        }
+    }
+}
+
+impl From<agent::Rules> for Rules {
+    fn from(src: agent::Rules) -> Self {
+        Self {
+            rules: into_vec(src.rules),
         }
     }
 }
@@ -604,6 +658,16 @@ impl From<UpdateRoutesRequest> for agent::UpdateRoutesRequest {
         Self {
             routes: from_option(from.route),
             ..Default::default()
+        }
+    }
+}
+
+impl From<UpdateRulesRequest> for agent::UpdateRulesRequest {
+    fn from(from: UpdateRulesRequest) -> Self {
+        Self {
+            rules: from_option(from.rules),
+            unknown_fields: Default::default(),
+            cached_size: Default::default(),
         }
     }
 }

--- a/src/runtime-rs/crates/agent/src/lib.rs
+++ b/src/runtime-rs/crates/agent/src/lib.rs
@@ -20,10 +20,10 @@ pub use types::{
     GetIPTablesResponse, GuestDetailsResponse, HealthCheckResponse, IPAddress, IPFamily, Interface,
     Interfaces, ListProcessesRequest, MemHotplugByProbeRequest, MetricsResponse,
     OnlineCPUMemRequest, OomEventResponse, ReadStreamRequest, ReadStreamResponse,
-    RemoveContainerRequest, ReseedRandomDevRequest, ResizeVolumeRequest, Route, Routes,
+    RemoveContainerRequest, ReseedRandomDevRequest, ResizeVolumeRequest, Route, Routes, Rule, Rules,
     SetGuestDateTimeRequest, SetIPTablesRequest, SetIPTablesResponse, SignalProcessRequest,
     StatsContainerResponse, Storage, TtyWinResizeRequest, UpdateContainerRequest,
-    UpdateInterfaceRequest, UpdateRoutesRequest, VersionCheckResponse, VolumeStatsRequest,
+    UpdateInterfaceRequest, UpdateRoutesRequest, UpdateRulesRequest, VersionCheckResponse, VolumeStatsRequest,
     VolumeStatsResponse, WaitProcessRequest, WaitProcessResponse, WriteStreamRequest,
     WriteStreamResponse,
 };
@@ -63,6 +63,7 @@ pub trait Agent: AgentManager + HealthService + Send + Sync {
     async fn list_routes(&self, req: Empty) -> Result<Routes>;
     async fn update_interface(&self, req: UpdateInterfaceRequest) -> Result<Interface>;
     async fn update_routes(&self, req: UpdateRoutesRequest) -> Result<Routes>;
+    async fn update_rules(&self, req: UpdateRulesRequest) -> Result<Rules>;
 
     // container
     async fn create_container(&self, req: CreateContainerRequest) -> Result<Empty>;

--- a/src/runtime-rs/crates/agent/src/types.rs
+++ b/src/runtime-rs/crates/agent/src/types.rs
@@ -109,6 +109,25 @@ pub struct Routes {
     pub routes: Vec<Route>,
 }
 
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct Rule {
+    pub src: String,
+    pub suppress_if_group: i64,
+    pub suppress_prefix_len: i64,
+    pub mark: i64,
+    pub mask: i64,
+    pub goto: i64,
+    pub flow: i64,
+    pub family: IPFamily,
+    pub priority: i64,
+    pub table: i64,
+}
+
+#[derive(Deserialize, Debug, PartialEq, Eq, Clone, Default)]
+pub struct Rules {
+    pub rules: Vec<Rule>,
+}
+
 #[derive(PartialEq, Clone, Default)]
 pub struct CreateContainerRequest {
     pub process_id: ContainerProcessID,
@@ -387,6 +406,11 @@ pub struct UpdateInterfaceRequest {
 #[derive(PartialEq, Clone, Default, Debug)]
 pub struct UpdateRoutesRequest {
     pub route: Option<Routes>,
+}
+
+#[derive(PartialEq, Eq, Clone, Default, Debug)]
+pub struct UpdateRulesRequest {
+    pub rules: Option<Rules>,
 }
 
 #[derive(Deserialize, PartialEq, Clone, Default, Debug)]

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -204,6 +204,20 @@ impl ResourceManagerInner {
         Ok(())
     }
 
+    async fn handle_rules(&self, network: &dyn Network) -> Result<()> {
+        let rules = network.rules().await.context("rules")?;
+        if !rules.is_empty() {
+            info!(sl!(), "update rules {:?}", rules);
+            self.agent
+                .update_rules(agent::UpdateRulesRequest {
+                    rules: Some(agent::Rules { rules }),
+                })
+                .await
+                .context("update rules")?;
+        }
+        Ok(())
+    }
+
     pub async fn setup_after_start_vm(&mut self) -> Result<()> {
         if let Some(share_fs) = self.share_fs.as_ref() {
             share_fs
@@ -221,6 +235,7 @@ impl ResourceManagerInner {
                 .await
                 .context("handle neighbors")?;
             self.handle_routes(network).await.context("handle routes")?;
+            self.handle_rules(network).await.context("handle rules")?;
         }
         Ok(())
     }

--- a/src/runtime-rs/crates/resource/src/network/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/mod.rs
@@ -43,6 +43,7 @@ pub trait Network: Send + Sync {
     async fn neighs(&self) -> Result<Vec<agent::ARPNeighbor>>;
     async fn save(&self) -> Option<Vec<EndpointState>>;
     async fn remove(&self, h: &dyn Hypervisor) -> Result<()>;
+    async fn rules(&self) -> Result<Vec<agent::Rule>>;
 }
 
 pub async fn new(

--- a/src/runtime-rs/crates/resource/src/network/utils/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/mod.rs
@@ -7,6 +7,7 @@
 pub(crate) mod address;
 pub(crate) mod link;
 pub(crate) mod netns;
+pub(crate) mod policy_rule;
 
 use anyhow::{anyhow, Result};
 use rand::rngs::OsRng;

--- a/src/runtime-rs/crates/resource/src/network/utils/policy_rule.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/policy_rule.rs
@@ -1,0 +1,128 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use agent::{IPFamily, Rule};
+use anyhow::{Context, Result};
+use futures::stream::TryStreamExt;
+use netlink_packet_route::rule::RuleMessage;
+use std::net::IpAddr;
+
+pub(crate) struct NetworkRule {
+    pub(crate) rules: Vec<Rule>,
+}
+
+impl NetworkRule {
+    pub async fn new(handle: &rtnetlink::Handle) -> Result<NetworkRule> {
+        let rule_list = handle_rules(handle).await.context("handle rules")?;
+
+        Ok(NetworkRule { rules: rule_list })
+    }
+}
+
+fn octets_to_addr(octets: &[u8], prefix_len: u8) -> Option<(IpAddr, u8)> {
+    return match octets.len() {
+        4 => {
+            let mut ary: [u8; 4] = Default::default();
+            ary.copy_from_slice(octets);
+            Some((IpAddr::from(ary), prefix_len))
+        }
+        16 => {
+            let mut ary: [u8; 16] = Default::default();
+            ary.copy_from_slice(octets);
+            Some((IpAddr::from(ary), prefix_len))
+        }
+        _ => None,
+    };
+}
+
+fn generate_rule(mut msg: RuleMessage) -> Result<Option<Rule>> {
+    use netlink_packet_route::rule::Nla;
+
+    let mut rule = Rule {
+        src: String::new(),
+        family: if msg.header.family == libc::AF_INET as u8 {
+            IPFamily::V4
+        } else {
+            IPFamily::V6
+        },
+        suppress_if_group: -1,
+        suppress_prefix_len: -1,
+        priority: -1,
+        mark: -1,
+        mask: -1,
+        goto: -1,
+        flow: -1,
+        table: -1,
+    };
+
+    while let Some(attr) = msg.nlas.pop() {
+        match attr {
+            Nla::Source(src) => {
+                let data = octets_to_addr(&src, msg.header.src_len)
+                    .map(|(addr, prefix)| format!("{}/{}", addr, prefix))
+                    .unwrap_or_default();
+                // CIDR notation, such as "192.0.2.0/24"
+                rule.src = data;
+            }
+            Nla::SuppressIfGroup(suppress_group) => {
+                if suppress_group != 0xffffffff {
+                    rule.suppress_if_group = suppress_group as i64;
+                }
+            }
+            Nla::SuppressPrefixLen(suppress_len) => {
+                if suppress_len != 0xffffffff {
+                    rule.suppress_prefix_len = suppress_len as i64;
+                }
+            }
+            Nla::FwMark(mark) => {
+                rule.mark = mark as i64;
+            }
+            Nla::FwMask(mask) => {
+                rule.mask = mask as i64;
+            }
+            Nla::Goto(goto) => {
+                rule.goto = goto as i64;
+            }
+            Nla::Flow(flow) => {
+                rule.flow = flow as i64;
+            }
+            Nla::Priority(p) => {
+                rule.priority = p as i64;
+            }
+            Nla::Table(t) => {
+                rule.table = t as i64;
+            }
+            _ => {
+                // skip unused attr
+            }
+        }
+    }
+    Ok(Some(rule))
+}
+
+async fn get_rule_from_msg(
+    handle: &rtnetlink::Handle,
+    ip_version: rtnetlink::IpVersion,
+) -> Result<Vec<Rule>> {
+    let mut rules = vec![];
+    let mut rule_msg_list = handle.rule().get(ip_version).execute();
+    while let Some(rule) = rule_msg_list.try_next().await? {
+        if let Some(r) = generate_rule(rule).context("generate rule")? {
+            rules.push(r);
+        }
+    }
+    Ok(rules)
+}
+
+async fn handle_rules(handle: &rtnetlink::Handle) -> Result<Vec<Rule>> {
+    let rules_v4 = get_rule_from_msg(handle, rtnetlink::IpVersion::V4)
+        .await
+        .context("get ip v4 rule")?;
+    let rules_v6 = get_rule_from_msg(handle, rtnetlink::IpVersion::V6)
+        .await
+        .context("get ip v6 rule")?;
+    Ok([rules_v4, rules_v6].concat())
+}


### PR DESCRIPTION
Synchronize the ip rules in the network namespace on the host side to
the VM.

Fixes: https://github.com/kata-containers/kata-containers/issues/6565