### PR TITLE
gha: Also run k8s tests on AKS with dragonball

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         vmm:
           - clh
+          - dragonball
           - qemu
     uses: ./.github/workflows/create-aks.yaml
     with:
@@ -30,6 +31,7 @@ jobs:
       matrix:
         vmm:
           - clh
+          - dragonball
           - qemu
     runs-on: ubuntu-latest
     needs: create-aks
@@ -82,6 +84,7 @@ jobs:
       matrix:
         vmm:
           - clh
+          - dragonball
           - qemu
     needs: run-k8s-tests
     if: always()

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -54,6 +54,10 @@ else
 	)
 fi
 
+if [ ${KATA_HYPERVISOR} == "dragonball" ]; then
+	exit 0
+fi
+
 # we may need to skip a few test cases when running on non-x86_64 arch
 arch_config_file="${kubernetes_dir}/filter_out_per_arch/${TARGET_ARCH}.yaml"
 if [ -f "${arch_config_file}" ]; then


### PR DESCRIPTION
As already done for Cloud Hypervisor and QEMU, let's make sure we can run the AKS tests using dragonball.

Fixes: #6583