### PR TITLE
gha: Only push images to registry after merging a PR

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -9,6 +9,10 @@ on:
       tarball-suffix:
         required: false
         type: string
+      push-to-registry:
+        required: false
+        type: string
+        default: no
 
 jobs:
   build-asset:
@@ -40,7 +44,7 @@ jobs:
         env:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
-          PUSH_TO_REGISTRY: yes
+          PUSH_TO_REGISTRY: ${{ inputs.push-to-registry }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -2,6 +2,10 @@ name: CI | Build kata-static tarball for amd64
 on:
   workflow_call:
     inputs:
+      checkout-ref:
+        required: false
+        type: string
+        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -25,6 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.checkout-ref }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
       - name: Build ${{ matrix.asset }}
         run: |
@@ -50,6 +55,8 @@ jobs:
     needs: build-asset
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout-ref }}
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -2,6 +2,10 @@ name: CI | Build kata-static tarball for arm64
 on:
   workflow_call:
     inputs:
+      checkout-ref:
+        required: false
+        type: string
+        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -29,6 +33,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.checkout-ref }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
       - name: Build ${{ matrix.asset }}
         run: |
@@ -58,6 +63,8 @@ jobs:
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout-ref }}
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -9,6 +9,10 @@ on:
       tarball-suffix:
         required: false
         type: string
+      push-to-registry:
+        required: false
+        type: string
+        default: no
 
 jobs:
   build-asset:
@@ -44,7 +48,7 @@ jobs:
         env:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
-          PUSH_TO_REGISTRY: yes
+          PUSH_TO_REGISTRY: ${{ inputs.push-to-registry }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -9,6 +9,10 @@ on:
       tarball-suffix:
         required: false
         type: string
+      push-to-registry:
+        required: false
+        type: string
+        default: no
 
 jobs:
   build-asset:
@@ -41,7 +45,7 @@ jobs:
         env:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
-          PUSH_TO_REGISTRY: yes
+          PUSH_TO_REGISTRY: ${{ inputs.push-to-registry }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -2,6 +2,10 @@ name: CI | Build kata-static tarball for s390x
 on:
   workflow_call:
     inputs:
+      checkout-ref:
+        required: false
+        type: string
+        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -25,6 +29,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
+          ref: ${{ inputs.checkout-ref }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
       - name: Build ${{ matrix.asset }}
         run: |
@@ -55,6 +60,8 @@ jobs:
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout-ref }}
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -11,16 +11,16 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
-      tarball-suffix: -${{ github.event.pull_request.number}}-${{ github.sha }}
+      tarball-suffix: -${{ github.event.workflow_run.head_sha }}
 
   publish-kata-deploy-payload-amd64:
     needs: build-kata-static-tarball-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
-      tarball-suffix: -${{ github.event.pull_request.number}}-${{ github.sha }}
+      tarball-suffix: -${{ github.event.workflow_run.head_sha }}
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ github.event.pull_request.number }}-${{ github.sha }}-amd64
+      tag: ${{ github.event.workflow_run.head_sha }}-amd64
       quay-io-login-continue-on-error: true
     secrets: inherit
 
@@ -30,5 +30,5 @@ jobs:
     with:
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ github.event.pull_request.number }}-${{ github.sha }}-amd64
+      tag: ${{ github.event.workflow_run.head_sha }}-amd64
     secrets: inherit

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -11,12 +11,14 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
+      checkout-ref: ${{ github.event.workflow_run.head_sha }}
       tarball-suffix: -${{ github.event.workflow_run.head_sha }}
 
   publish-kata-deploy-payload-amd64:
     needs: build-kata-static-tarball-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
+      checkout-ref: ${{ github.event.workflow_run.head_sha }}
       tarball-suffix: -${{ github.event.workflow_run.head_sha }}
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
@@ -28,6 +30,7 @@ jobs:
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-k8s-tests-on-aks.yaml
     with:
+      checkout-ref: ${{ github.event.workflow_run.head_sha }}
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
       tag: ${{ github.event.workflow_run.head_sha }}-amd64

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -23,7 +23,6 @@ jobs:
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
       tag: ${{ github.event.workflow_run.head_sha }}-amd64
-      quay-io-login-continue-on-error: true
     secrets: inherit
 
   run-k8s-tests-on-aks:

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -1,21 +1,19 @@
 name: Kata Containers CI
 on:
-  pull_request_target:
+  workflow_run:
+    workflows:
+      - Commit Message Check
     types:
-      - opened
-      - reopened
-      - labeled
-      - synchronize
+      - completed
 
 jobs:
   build-kata-static-tarball-amd64:
-    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
       tarball-suffix: -${{ github.event.pull_request.number}}-${{ github.sha }}
 
   publish-kata-deploy-payload-amd64:
-    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     needs: build-kata-static-tarball-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
@@ -27,7 +25,6 @@ jobs:
     secrets: inherit
 
   run-k8s-tests-on-aks:
-    if: contains(github.event.pull_request.labels.*.name, 'ok-to-test')
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-k8s-tests-on-aks.yaml
     with:

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -8,12 +8,18 @@ on:
 jobs:
   build-assets-amd64:
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
+    with:
+      push-to-registry: yes
 
   build-assets-arm64:
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
+    with:
+      push-to-registry: yes
 
   build-assets-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
+    with:
+      push-to-registry: yes
 
   publish-kata-deploy-payload-amd64:
     needs: build-assets-amd64

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -28,7 +28,8 @@ jobs:
     needs: build-assets-arm64
     uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
     with:
-      registry: quay.io/kata-containers/kata-deploy-ci
+      registry: quay.io
+      repo: kata-containers/kata-deploy-ci
       tag: kata-containers-arm64
     secrets: inherit
 
@@ -36,7 +37,8 @@ jobs:
     needs: build-assets-s390x
     uses: ./.github/workflows/publish-kata-deploy-payload-s390x.yaml
     with:
-      registry: quay.io/kata-containers/kata-deploy-ci
+      registry: quay.io
+      repo: kata-containers/kata-deploy-ci
       tag: kata-containers-s390x
     secrets: inherit
 

--- a/.github/workflows/publish-kata-deploy-payload-amd64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-amd64.yaml
@@ -18,10 +18,6 @@ on:
       tag:
         required: true
         type: string
-      quay-io-login-continue-on-error:
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   kata-payload:
@@ -37,14 +33,15 @@ jobs:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
 
       - name: Login to Kata Containers quay.io
+        if: ${{ inputs.registry == 'quay.io' }}
         uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-        continue-on-error: ${{ inputs.quay-io-login-continue-on-error }}
 
       - name: Login to Kata Containers ghcr.io
+        if: ${{ inputs.registry == 'ghcr.io' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/publish-kata-deploy-payload-amd64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-amd64.yaml
@@ -2,6 +2,10 @@ name: CI | Publish kata-deploy payload for amd64
 on:
   workflow_call:
     inputs:
+      checkout-ref:
+        required: false
+        type: string
+        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -24,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout-ref }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -18,10 +18,6 @@ on:
       tag:
         required: true
         type: string
-      quay-io-login-continue-on-error:
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   kata-payload:
@@ -41,14 +37,15 @@ jobs:
           name: kata-static-tarball-arm64${{ inputs.tarball-suffix }}
 
       - name: Login to Kata Containers quay.io
+        if: ${{ inputs.registry == 'quay.io' }}
         uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-        continue-on-error: ${{ inputs.quay-io-login-continue-on-error }}
 
       - name: Login to Kata Containers ghcr.io
+        if: ${{ inputs.registry == 'ghcr.io' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -2,6 +2,10 @@ name: CI | Publish kata-deploy payload for arm64
 on:
   workflow_call:
     inputs:
+      checkout-ref:
+        required: false
+        type: string
+        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -28,6 +32,8 @@ jobs:
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout-ref }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -2,6 +2,10 @@ name: CI | Publish kata-deploy payload for s390x
 on:
   workflow_call:
     inputs:
+      checkout-ref:
+        required: false
+        type: string
+        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -28,6 +32,8 @@ jobs:
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout-ref }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -18,10 +18,6 @@ on:
       tag:
         required: true
         type: string
-      quay-io-login-continue-on-error:
-        required: false
-        type: boolean
-        default: false
 
 jobs:
   kata-payload:
@@ -41,14 +37,15 @@ jobs:
           name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
 
       - name: Login to Kata Containers quay.io
+        if: ${{ inputs.registry == 'quay.io' }}
         uses: docker/login-action@v2
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-        continue-on-error: ${{ inputs.quay-io-login-continue-on-error }}
 
       - name: Login to Kata Containers ghcr.io
+        if: ${{ inputs.registry == 'ghcr.io' }}
         uses: docker/login-action@v2
         with:
           registry: ghcr.io

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -2,6 +2,10 @@ name: CI | Run kubernetes tests on AKS
 on:
   workflow_call:
     inputs:
+      checkout-ref:
+        required: false
+        type: string
+        default: ${{ github.sha }}
       registry:
         required: true
         type: string
@@ -35,6 +39,8 @@ jobs:
     needs: create-aks
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.checkout-ref }}
       - name: Install `bats`
         run: |
           sudo apt-get update

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -20,7 +20,7 @@ IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-$(uname -m)"
 echo "Building the image"
 docker build --tag ${IMAGE_TAG} .
 
-echo "Pushing the image to quay.io"
+echo "Pushing the image to the registry"
 docker push ${IMAGE_TAG}
 
 if [ -n "${TAG}" ]; then
@@ -30,7 +30,7 @@ if [ -n "${TAG}" ]; then
 
 	docker build --tag ${ADDITIONAL_TAG} .
 
-	echo "Pushing the image ${ADDITIONAL_TAG} to quay.io"
+	echo "Pushing the image ${ADDITIONAL_TAG} to the registry"
 	docker push ${ADDITIONAL_TAG}
 fi
 


### PR DESCRIPTION
56331bd7bcfbc6aabd8a732a10c544ba3df84622 oversaw the fact that we mistakenly tried to push the build containers to the registry for a PR, rather than doing so only when the code is merged.

As the workflow is now shared between different actions, let's introduce an input variable to specify which are the cases we actually need to perform a push to the registry.

Fixes: #6592