### PR TITLE
CC: Add cc-rootfs-initrd to payload image for s390x

### DIFF
--- a/.github/workflows/cc-payload-after-push-s390x.yaml
+++ b/.github/workflows/cc-payload-after-push-s390x.yaml
@@ -15,6 +15,7 @@ jobs:
           - cc-kernel
           - cc-qemu
           - cc-rootfs-image
+          - cc-rootfs-initrd
           - cc-se-image
           - cc-virtiofsd
     steps:


### PR DESCRIPTION
This is to add an artifact named `cc-rootfs-initrd` to a payload image because it is identified that the artifact is required to run a cc-operator e2e test.

Fixes: #6544

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>