### PR TITLE
CC | gha: add SNP components to amdx86_64 payload workflows

### DIFF
--- a/.github/workflows/cc-payload-after-push-amd64.yaml
+++ b/.github/workflows/cc-payload-after-push-amd64.yaml
@@ -20,6 +20,7 @@ jobs:
           - cc-sev-kernel
           - cc-sev-ovmf
           - cc-x86_64-ovmf
+          - cc-snp-qemu
           - cc-sev-rootfs-initrd
           - cc-tdx-kernel
           - cc-tdx-rootfs-image

--- a/.github/workflows/cc-payload-amd64.yaml
+++ b/.github/workflows/cc-payload-amd64.yaml
@@ -19,6 +19,8 @@ jobs:
           - cc-virtiofsd
           - cc-sev-kernel
           - cc-sev-ovmf
+          - cc-x86_64-ovmf
+          - cc-snp-qemu
           - cc-sev-rootfs-initrd
           - cc-tdx-kernel
           - cc-tdx-rootfs-image


### PR DESCRIPTION
Last SNP component needed in the x86 payload is Qemu. I missed adding an entry in #6062.

Fixes: #6600