### PR TITLE
gha: aks: Use D4s_v5 instance

### DIFF
--- a/.github/workflows/create-aks.yaml
+++ b/.github/workflows/create-aks.yaml
@@ -27,6 +27,6 @@ jobs:
           az aks create \
             -g "kataCI" \
             -n "${{ inputs.name }}" \
-            -s "Standard_D4s_v3" \
+            -s "Standard_D4s_v5" \
             --node-count 1 \
             --generate-ssh-keys


### PR DESCRIPTION
It's been pointed out that D4s_v5 instances are more powerful than the D4s_v3 ones, and have the very same price.  With this in mind, let's switch to the newer machines.

Fixes: #6606