### PR TITLE
runtime-rs/virtio-fs: add support extra handler for cache mode.

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -188,6 +188,9 @@ impl DragonballInner {
             let args: Vec<&str> = opt_list.split(',').collect();
             for arg in args {
                 match arg {
+                    "cache=none" => fs_cfg.cache_policy = String::from("none"),
+                    "cache=auto" => fs_cfg.cache_policy = String::from("auto"),
+                    "cache=always" => fs_cfg.cache_policy = String::from("always"),
                     "no_open" => fs_cfg.no_open = true,
                     "open" => fs_cfg.no_open = false,
                     "writeback_cache" => fs_cfg.writeback_cache = true,


### PR DESCRIPTION
Add support for virtiofsd when virtio_fs_extra_args with "-o cache auto, ..." users specified.

Fixes: #6615

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>