### PR TITLE
snap: fix docker start fail issue

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -63,6 +63,9 @@ parts:
       echo "Adding $USER into docker group"
       sudo -E gpasswd -a $USER docker
       echo "Starting docker"
+      # docker may fail to start using "fd://" in docker.service
+      sudo sed -i 's/fd:\/\//unix:\/\//g' /lib/systemd/system/docker.service
+      sudo systemctl daemon-reload
       sudo -E systemctl start docker || true
 
   image:


### PR DESCRIPTION
In Arm baseline CI, docker starts fail with error: "no sockets found via socket activation: make sure the service was started by systemd". I find a solusion in [1] to fix it.

[1] https://forums.docker.com/t/failed-to-load-listeners-no-sockets-found-via-socket-activation-make-sure-the-service-was-started-by-systemd/62505

Fixes: #6619