### PR TITLE
gha: k8s-on-aks: Set {create,delete}_aks as steps

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -2,10 +2,6 @@ name: CI | Build kata-static tarball for amd64
 on:
   workflow_call:
     inputs:
-      checkout-ref:
-        required: false
-        type: string
-        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -33,7 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
       - name: Build ${{ matrix.asset }}
         run: |
@@ -60,7 +56,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -2,10 +2,6 @@ name: CI | Build kata-static tarball for arm64
 on:
   workflow_call:
     inputs:
-      checkout-ref:
-        required: false
-        type: string
-        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -37,7 +33,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
       - name: Build ${{ matrix.asset }}
         run: |
@@ -68,7 +64,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -2,10 +2,6 @@ name: CI | Build kata-static tarball for s390x
 on:
   workflow_call:
     inputs:
-      checkout-ref:
-        required: false
-        type: string
-        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -33,7 +29,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
       - name: Build ${{ matrix.asset }}
         run: |
@@ -65,7 +61,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -1,14 +1,9 @@
 name: Kata Containers CI
 on:
-  workflow_run:
-    workflows:
-      - Commit Message Check
-    types:
-      - completed
+  pull_request_target:
 
 jobs:
   build-kata-static-tarball-amd64:
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
       tarball-suffix: -${{ github.event.pull_request.number}}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -1,6 +1,8 @@
 name: Kata Containers CI
 on:
   pull_request_target:
+    branches:
+      - 'main'
 
 jobs:
   build-kata-static-tarball-amd64:

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -11,16 +11,16 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
-      tarball-suffix: -${{ github.event.workflow_run.head_sha }}
+      tarball-suffix: -${{ github.event.pull_request.number}}-${{ github.event.pull_request.head.sha }}
 
   publish-kata-deploy-payload-amd64:
     needs: build-kata-static-tarball-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
-      tarball-suffix: -${{ github.event.workflow_run.head_sha }}
+      tarball-suffix: -${{ github.event.pull_request.number}}-${{ github.event.pull_request.head.sha }}
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ github.event.workflow_run.head_sha }}-amd64
+      tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-amd64
     secrets: inherit
 
   run-k8s-tests-on-aks:
@@ -29,5 +29,5 @@ jobs:
     with:
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ github.event.workflow_run.head_sha }}-amd64
+      tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-amd64
     secrets: inherit

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -11,14 +11,12 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
-      checkout-ref: ${{ github.event.workflow_run.head_sha }}
       tarball-suffix: -${{ github.event.workflow_run.head_sha }}
 
   publish-kata-deploy-payload-amd64:
     needs: build-kata-static-tarball-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
-      checkout-ref: ${{ github.event.workflow_run.head_sha }}
       tarball-suffix: -${{ github.event.workflow_run.head_sha }}
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
@@ -29,7 +27,6 @@ jobs:
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-k8s-tests-on-aks.yaml
     with:
-      checkout-ref: ${{ github.event.workflow_run.head_sha }}
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
       tag: ${{ github.event.workflow_run.head_sha }}-amd64

--- a/.github/workflows/publish-kata-deploy-payload-amd64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-amd64.yaml
@@ -2,10 +2,6 @@ name: CI | Publish kata-deploy payload for amd64
 on:
   workflow_call:
     inputs:
-      checkout-ref:
-        required: false
-        type: string
-        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -25,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -2,10 +2,6 @@ name: CI | Publish kata-deploy payload for arm64
 on:
   workflow_call:
     inputs:
-      checkout-ref:
-        required: false
-        type: string
-        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -29,7 +25,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -2,10 +2,6 @@ name: CI | Publish kata-deploy payload for s390x
 on:
   workflow_call:
     inputs:
-      checkout-ref:
-        required: false
-        type: string
-        default: ${{ github.sha }}
       tarball-suffix:
         required: false
         type: string
@@ -29,7 +25,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -17,18 +17,6 @@ on:
         type: string
 
 jobs:
-  create-aks:
-    strategy:
-      matrix:
-        vmm:
-          - clh
-          - dragonball
-          - qemu
-    uses: ./.github/workflows/create-aks.yaml
-    with:
-      name: ${{ inputs.checkout-ref }}-${{ matrix.vmm }}-amd64
-    secrets: inherit
-
   run-k8s-tests:
     strategy:
       fail-fast: false
@@ -38,8 +26,12 @@ jobs:
           - dragonball
           - qemu
     runs-on: ubuntu-latest
-    needs: create-aks
     steps:
+      - name: Create AKS cluster to test ${{ matrix.vmm }}
+        uses: ./.github/workflows-create-aks.yaml
+        with:
+          name: ${{ inputs.checkout-ref }}-${{ matrix.vmm }}-amd64
+
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.checkout-ref }}
@@ -85,16 +77,8 @@ jobs:
         env:
           KATA_HYPERVISOR: ${{ matrix.vmm }}
 
-  delete-aks:
-    strategy:
-      matrix:
-        vmm:
-          - clh
-          - dragonball
-          - qemu
-    needs: run-k8s-tests
-    if: always()
-    uses: ./.github/workflows/delete-aks.yaml
-    with:
-      name: ${{ inputs.checkout-ref }}-${{ matrix.vmm }}-amd64
-    secrets: inherit
+      - name: Delete AKS cluster used to test ${{ matrix.vmm }}
+        if: always()
+        uses: ./.github/workflows/delete-aks.yaml
+        with:
+          name: ${{ inputs.checkout-ref }}-${{ matrix.vmm }}-amd64

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Create AKS cluster to test ${{ matrix.vmm }}
         uses: ./.github/workflows-create-aks.yaml
         with:
-          name: ${{ inputs.checkout-ref }}-${{ matrix.vmm }}-amd64
+          name: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.vmm }}-amd64
 
       - uses: actions/checkout@v3
         with:
@@ -54,7 +54,7 @@ jobs:
 
       - name: Download credentials for the Kubernetes CLI to use them
         run: |
-          az aks get-credentials -g "kataCI" -n ${{ inputs.checkout-ref }}-${{ matrix.vmm }}-amd64
+          az aks get-credentials -g "kataCI" -n ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.vmm }}-amd64
 
       - name: Deploy kata-deploy
         run: |
@@ -81,4 +81,4 @@ jobs:
         if: always()
         uses: ./.github/workflows/delete-aks.yaml
         with:
-          name: ${{ inputs.checkout-ref }}-${{ matrix.vmm }}-amd64
+          name: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.vmm }}-amd64

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -2,10 +2,6 @@ name: CI | Run kubernetes tests on AKS
 on:
   workflow_call:
     inputs:
-      checkout-ref:
-        required: false
-        type: string
-        default: ${{ github.sha }}
       registry:
         required: true
         type: string
@@ -34,7 +30,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ inputs.checkout-ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Install `bats`
         run: |
           sudo apt-get update


### PR DESCRIPTION
We've been currently using {create,delete}_aks as jobs.  However, it means that if the tests fail we'll end up deleting the AKS cluster (as expected), but not having a way to recreate the cluster without re-running all jobs, which is a waste of resources.

Fixes: #6628