### PR TITLE
versions: Upgrade to Cloud Hypervisor v31.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v30.0"
+      version: "v31.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
Details of this release can be found in our new roadmap project as iteration v31.0: https://github.com/orgs/cloud-hypervisor/projects/6.

This release has been tracked in our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
v31.0. The following user visible changes have been made:

### Update to Latest `acpi_tables`

Adapted to the latest [acpi_tables](https://github.com/rust-vmm/acpi_tables). There has been significant API changes in
the crate.

### Update Reference Kernel to 6.2

Updated the recommended guest kernel version from 6.1.6 to 6.2.

### Improvements on Console `SIGWINCH` Handler

A separate thread had been created to capture the `SIGWINCH` signal and resize
the guest console. Now the thread is skipped if the console is not resizable.

Two completely different code paths existed for handling console resizing, one
for `tty` and the other for `pty`. That makes the understanding of the console
handling code unnecessarily complicated. Now the code paths are unified. Both
`tty` and `pty` are supported in single `SIGWINCH` handler. And the new handler
can works with kernel versions earlier than v5.5.

### Remove Directory Support from `MemoryZoneConfig::file`

Setting a directory to `MemoryZoneConfig::file` is no longer supported.

Before this change, user can set a directory to `file` of the `--memory-zone`
option. In that case, a temporary file will be created as the backing file for
the `mmap(2)` operation. This functionality has been unnecessary since we had
the native support for hugepages and allocating anonymous shared memory.

### Documentation Improvements

* Various improvements in API document
* Improvements in Doc comments
* Updated Slack channel information in README

### Notable Bug Fixes

* Fixed the offset setting while removing the entire mapping of `vhost-user` FS
  client.
* Fixed the `ShutdownVmm` and `Shutdown` commands to call the correct API
  endpoint.

Fixes: #6632