### PR TITLE
Backport cgroup fixes to 3.1

### DIFF
--- a/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
@@ -36,8 +36,9 @@ pub struct DBusClient {}
 
 impl DBusClient {
     fn build_proxy(&self) -> Result<SystemManager<'static>> {
-        let connection = zbus::blocking::Connection::system()?;
-        let proxy = SystemManager::new(&connection)?;
+        let connection =
+            zbus::blocking::Connection::system().context("Establishing a D-Bus connection")?;
+        let proxy = SystemManager::new(&connection).context("Building a D-Bus proxy manager")?;
         Ok(proxy)
     }
 }
@@ -109,7 +110,9 @@ impl SystemdInterface for DBusClient {
     }
 
     fn unit_exists(&self, unit_name: &str) -> Result<bool> {
-        let proxy = self.build_proxy()?;
+        let proxy = self
+            .build_proxy()
+            .with_context(|| format!("Checking if systemd unit {} exists", unit_name))?;
 
         Ok(proxy.get_unit(unit_name).is_ok())
     }

--- a/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/dbus_client.rs
@@ -26,7 +26,7 @@ pub trait SystemdInterface {
 
     fn get_version(&self) -> Result<String>;
 
-    fn unit_exist(&self, unit_name: &str) -> Result<bool>;
+    fn unit_exists(&self, unit_name: &str) -> Result<bool>;
 
     fn add_process(&self, pid: i32, unit_name: &str) -> Result<()>;
 }
@@ -108,7 +108,7 @@ impl SystemdInterface for DBusClient {
         Ok(systemd_version)
     }
 
-    fn unit_exist(&self, unit_name: &str) -> Result<bool> {
+    fn unit_exists(&self, unit_name: &str) -> Result<bool> {
         let proxy = self.build_proxy()?;
 
         Ok(proxy.get_unit(unit_name).is_ok())

--- a/src/agent/rustjail/src/cgroups/systemd/manager.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/manager.rs
@@ -41,7 +41,7 @@ pub struct Manager {
 impl CgroupManager for Manager {
     fn apply(&self, pid: pid_t) -> Result<()> {
         let unit_name = self.unit_name.as_str();
-        if self.dbus_client.unit_exist(unit_name)? {
+        if self.dbus_client.unit_exists(unit_name)? {
             self.dbus_client.add_process(pid, self.unit_name.as_str())?;
         } else {
             self.dbus_client.start_unit(

--- a/src/agent/rustjail/src/cgroups/systemd/manager.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/manager.rs
@@ -41,7 +41,7 @@ pub struct Manager {
 impl CgroupManager for Manager {
     fn apply(&self, pid: pid_t) -> Result<()> {
         let unit_name = self.unit_name.as_str();
-        if self.dbus_client.unit_exist(unit_name).unwrap() {
+        if self.dbus_client.unit_exist(unit_name)? {
             self.dbus_client.add_process(pid, self.unit_name.as_str())?;
         } else {
             self.dbus_client.start_unit(

--- a/src/agent/rustjail/src/cgroups/systemd/subsystem/cpu.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/subsystem/cpu.rs
@@ -71,7 +71,7 @@ impl Cpu {
     }
 
     // v2:
-    // cpu.shares <-> CPUShares
+    // cpu.shares <-> CPUWeight
     // cpu.period <-> CPUQuotaPeriodUSec
     // cpu.period & cpu.quota <-> CPUQuotaPerSecUSec
     fn unified_apply(
@@ -80,8 +80,8 @@ impl Cpu {
         systemd_version: &str,
     ) -> Result<()> {
         if let Some(shares) = cpu_resources.shares {
-            let unified_shares = get_unified_cpushares(shares);
-            properties.push(("CPUShares", Value::U64(unified_shares)));
+            let weight = shares_to_weight(shares);
+            properties.push(("CPUWeight", Value::U64(weight)));
         }
 
         if let Some(period) = cpu_resources.period {
@@ -104,7 +104,7 @@ impl Cpu {
 
 // ref: https://github.com/containers/crun/blob/main/crun.1.md#cgroup-v2
 // [2-262144] to [1-10000]
-fn get_unified_cpushares(shares: u64) -> u64 {
+fn shares_to_weight(shares: u64) -> u64 {
     if shares == 0 {
         return 100;
     }


### PR DESCRIPTION
Backport #6562 and #6637. This is needed to use cgroups v2 with systemd in the guest.
