### PR TITLE
agent: support drop cache

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -57,6 +57,7 @@ use crate::network::setup_guest_dns;
 use crate::pci;
 use crate::random;
 use crate::sandbox::Sandbox;
+use crate::util::drop_cache;
 use crate::version::{AGENT_VERSION, API_VERSION};
 use crate::AGENT_CONFIG;
 
@@ -1553,6 +1554,20 @@ impl agent_ttrpc::AgentService for AgentService {
         is_allowed!(req);
 
         do_add_swap(&self.sandbox, &req)
+            .await
+            .map_err(|e| ttrpc_error!(ttrpc::Code::INTERNAL, e))?;
+
+        Ok(Empty::new())
+    }
+
+    async fn drop_cache(
+        &self,
+        ctx: &TtrpcContext,
+        req: protocols::agent::DropCacheRequest,
+    ) -> ttrpc::Result<Empty> {
+        trace_rpc_call!(ctx, "drop_cache", req);
+
+        drop_cache(req.drop_option)
             .await
             .map_err(|e| ttrpc_error!(ttrpc::Code::INTERNAL, e))?;
 

--- a/src/libs/protocols/protos/agent.proto
+++ b/src/libs/protocols/protos/agent.proto
@@ -71,6 +71,7 @@ service AgentService {
 	rpc AddSwap(AddSwapRequest) returns (google.protobuf.Empty);
 	rpc GetVolumeStats(VolumeStatsRequest) returns (VolumeStatsResponse);
 	rpc ResizeVolume(ResizeVolumeRequest) returns (google.protobuf.Empty);
+	rpc DropCache(DropCacheRequest) returns (google.protobuf.Empty);
 }
 
 message CreateContainerRequest {
@@ -561,4 +562,9 @@ message ResizeVolumeRequest {
 	// Full VM guest path of the volume (outside the container)
 	string volume_guest_path = 1;
 	uint64 size = 2;
+}
+
+message DropCacheRequest {
+	// drop cache option, and valid value is 1, 2, 3.
+	uint32 drop_option = 1;
 }

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -3298,6 +3298,7 @@ dependencies = [
  "oci",
  "persist",
  "protobuf",
+ "protocols",
  "resource",
  "serde",
  "serde_derive",

--- a/src/runtime-rs/crates/agent/src/kata/agent.rs
+++ b/src/runtime-rs/crates/agent/src/kata/agent.rs
@@ -117,5 +117,6 @@ impl_agent!(
     get_ip_tables | crate::GetIPTablesRequest | crate::GetIPTablesResponse | None,
     set_ip_tables | crate::SetIPTablesRequest | crate::SetIPTablesResponse | None,
     get_volume_stats | crate::VolumeStatsRequest | crate::VolumeStatsResponse | None,
-    resize_volume | crate::ResizeVolumeRequest | crate::Empty | None
+    resize_volume | crate::ResizeVolumeRequest | crate::Empty | None,
+    drop_cache | crate::DropCacheRequest | crate::Empty | None
 );

--- a/src/runtime-rs/crates/agent/src/lib.rs
+++ b/src/runtime-rs/crates/agent/src/lib.rs
@@ -13,6 +13,7 @@ pub mod kata;
 mod log_forwarder;
 mod sock;
 pub mod types;
+use protocols::agent::DropCacheRequest;
 pub use types::{
     ARPNeighbor, ARPNeighbors, AddArpNeighborRequest, BlkioStatsEntry, CheckRequest,
     CloseStdinRequest, ContainerID, ContainerProcessID, CopyFileRequest, CreateContainerRequest,
@@ -90,4 +91,5 @@ pub trait Agent: AgentManager + HealthService + Send + Sync {
     async fn set_ip_tables(&self, req: SetIPTablesRequest) -> Result<SetIPTablesResponse>;
     async fn get_volume_stats(&self, req: VolumeStatsRequest) -> Result<VolumeStatsResponse>;
     async fn resize_volume(&self, req: ResizeVolumeRequest) -> Result<Empty>;
+    async fn drop_cache(&self, req: DropCacheRequest) -> Result<Empty>;
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -34,6 +34,7 @@ logging = { path = "../../../../libs/logging"}
 oci = { path = "../../../../libs/oci" }
 persist = { path = "../../persist"}
 resource = { path = "../../resource" }
+protocols = { path = "../../../../libs/protocols", features=["async"] }
 
 [features]
 default = []

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -13,6 +13,7 @@ use common::{
     types::{ContainerID, ContainerProcess, ProcessExitStatus, ProcessStatus, ProcessType},
 };
 use nix::sys::signal::Signal;
+use protocols::agent::DropCacheRequest;
 use resource::{rootfs::Rootfs, volume::Volume};
 use tokio::sync::RwLock;
 
@@ -182,6 +183,17 @@ impl ContainerInner {
                     Err(e)
                 }
             })?;
+
+        self.agent
+            .drop_cache(DropCacheRequest {
+                drop_option: 2,
+                ..Default::default()
+            })
+            .await
+            .map_err(|e| {
+                warn!(self.logger, "failed to drop cache: {:?}", e);
+            })
+            .ok();
 
         // close the exit channel to wakeup wait service
         // send to notify watchers who are waiting for the process exit


### PR DESCRIPTION
This PR adds a 'drop_cache' api to the agent, which releases the unreleased file descriptors and resolves the 'EBUSY' error when removing containers.

Fixes: #6643 