### PR TITLE
CCv0: update dependencies for CoCo release 0.5.0

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/image-rs?rev=cc626a97a8225475d3a4c3c7490f6b212ca32466#cc626a97a8225475d3a4c3c7490f6b212ca32466"
+source = "git+https://github.com/confidential-containers/image-rs?rev=b28eaae#b28eaae46bcea69ac28d079381b7aa1ef6851ad9"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/ocicrypt-rs.git?rev=1053963#105396323715ea6787b2241c93ed87a3307dec2a"
+source = "git+https://github.com/confidential-containers/ocicrypt-rs?rev=55ab22d#55ab22d572ec385ba466085f3c78f4148dfd287e"
 dependencies = [
  "aes 0.8.2",
  "anyhow",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -72,10 +72,10 @@ openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
 [target.'cfg(target_arch = "s390x")'.dependencies]
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "cc626a97a8225475d3a4c3c7490f6b212ca32466", default-features = false, features = ["kata-cc-s390x"] }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "b28eaae", default-features = false, features = ["kata-cc-s390x"] }
 
 [target.'cfg(not(target_arch = "s390x"))'.dependencies]
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "cc626a97a8225475d3a4c3c7490f6b212ca32466", default-features = false, features = ["kata-cc"] }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "b28eaae", default-features = false, features = ["kata-cc"] }
 
 [patch.crates-io]
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }

--- a/versions.yaml
+++ b/versions.yaml
@@ -310,7 +310,7 @@ externals:
   td-shim:
     description: "Confidential Containers Shim Firmware"
     url: "https://github.com/confidential-containers/td-shim"
-    version: "v0.4.0"
+    version: "10568bab569bc40034cc973f26fbb0a768dcc3e3"
     toolchain: "nightly-2022-11-15"
 
   virtiofsd:

--- a/versions.yaml
+++ b/versions.yaml
@@ -190,7 +190,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/attestation-agent"
-    version: "d7ace56f2f2c861669ab07b50598a3d3c22709af"
+    version: "c939d211fe5ac497715008e36161aff20cabb6e6"
 
   cni-plugins:
     description: "CNI network plugins"


### PR DESCRIPTION
Updated the following dependencies:

 * td-shim to commit [10568bab569bc40034cc973f26fbb0a768dcc3e3](https://github.com/confidential-containers/td-shim/commit/10568bab569bc40034cc973f26fbb0a768dcc3e3)
 * attestation-agent to commit [c939d211fe5ac497715008e36161aff20cabb6e6](https://github.com/confidential-containers/attestation-agent/commit/c939d211fe5ac497715008e36161aff20cabb6e6)
 * image-rs to commit [b28eaae46bcea69ac28d079381b7aa1ef6851ad9](https://github.com/confidential-containers/image-rs/commit/b28eaae46bcea69ac28d079381b7aa1ef6851ad9)