### PR TITLE
osbuilder: Enable dbus in the dracut case (backport for 3.1)

### DIFF
--- a/tools/osbuilder/dracut/dracut.conf.d/05-base.conf
+++ b/tools/osbuilder/dracut/dracut.conf.d/05-base.conf
@@ -14,4 +14,4 @@ hostonly_cmdline="no"
 # create reproducible images
 reproducible="yes"
 # dracut modules to include (NOTE: these are NOT kernel modules)
-dracutmodules="kernel-modules udev-rules syslog systemd"
+dracutmodules="kernel-modules udev-rules syslog systemd dbus"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -475,6 +475,8 @@ prepare_overlay()
 	# Kata systemd unit file
 	mkdir -p ./etc/systemd/system/basic.target.wants/
 	ln -sf /usr/lib/systemd/system/kata-containers.target ./etc/systemd/system/basic.target.wants/kata-containers.target
+	mkdir -p ./etc/systemd/system/kata-containers.target.wants/
+	ln -sf /usr/lib/systemd/system/dbus.socket  ./etc/systemd/system/kata-containers.target.wants/dbus.socket
 	popd  > /dev/null
 }
 


### PR DESCRIPTION
The agent now offloads cgroup configuration to systemd when possible. This requires to enable D-Bus in order to communicate with systemd.

Fixes #6657


(cherry picked from commit eb1762e813c52d5b593bacb04932d6fbf0ca3a19)