### PR TITLE
Update deps for the v0.5.0 release of Confidential Containers

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1802,7 +1802,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/image-rs?rev=b28eaae#b28eaae46bcea69ac28d079381b7aa1ef6851ad9"
+source = "git+https://github.com/confidential-containers/image-rs?tag=v0.5.1#767800855738c559d54b3f84810876b669ec3b83"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2656,7 +2656,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/ocicrypt-rs?rev=55ab22d#55ab22d572ec385ba466085f3c78f4148dfd287e"
+source = "git+https://github.com/confidential-containers/ocicrypt-rs?tag=v0.5.1#3bf5bc4ebabe6d4695edf955b76dd3635c55d118"
 dependencies = [
  "aes 0.8.2",
  "anyhow",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -72,10 +72,10 @@ openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
 [target.'cfg(target_arch = "s390x")'.dependencies]
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "b28eaae", default-features = false, features = ["kata-cc-s390x"] }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", tag = "v0.5.1", default-features = false, features = ["kata-cc-s390x"] }
 
 [target.'cfg(not(target_arch = "s390x"))'.dependencies]
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "b28eaae", default-features = false, features = ["kata-cc"] }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", tag = "v0.5.1", default-features = false, features = ["kata-cc"] }
 
 [patch.crates-io]
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }

--- a/versions.yaml
+++ b/versions.yaml
@@ -190,7 +190,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/attestation-agent"
-    version: "c939d211fe5ac497715008e36161aff20cabb6e6"
+    version: "v0.5.0"
 
   cni-plugins:
     description: "CNI network plugins"

--- a/versions.yaml
+++ b/versions.yaml
@@ -310,7 +310,7 @@ externals:
   td-shim:
     description: "Confidential Containers Shim Firmware"
     url: "https://github.com/confidential-containers/td-shim"
-    version: "10568bab569bc40034cc973f26fbb0a768dcc3e3"
+    version: "v0.5.0"
     toolchain: "nightly-2022-11-15"
 
   virtiofsd:


### PR DESCRIPTION
image-rs, attestation-agent, and td-shim were bumped to v0.5.0 release.