### PR TITLE
cache-components: Fix caching of TDVF and QEMU for TDX

### DIFF
--- a/.github/workflows/run-k8s-tests-on-tdx.yaml
+++ b/.github/workflows/run-k8s-tests-on-tdx.yaml
@@ -34,7 +34,7 @@ jobs:
           cat tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml | grep "${{ inputs.registry }}/${{ inputs.repo }}:${{ inputs.tag }}" || die "Failed to setup the tests image"
 
           kubectl apply -f tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
-          kubectl apply -k tools/packaging/kata-deploy/kata-deploy/overlay/k3s
+          kubectl apply -k tools/packaging/kata-deploy/kata-deploy/overlays/k3s
           kubectl -n kube-system wait --timeout=10m --for=condition=Ready -l name=kata-deploy pod
           kubectl apply -f tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
 
@@ -51,7 +51,7 @@ jobs:
       - name: Delete kata-deploy
         if: always()
         run: |
-          kubectl delete -k tools/packaging/kata-deploy/kata-deploy/overlay/k3s
+          kubectl delete -k tools/packaging/kata-deploy/kata-deploy/overlays/k3s
           kubectl -n kube-system wait --timeout=10m --for=delete -l name=kata-deploy pod
 
           sed -i -e "s|quay.io/kata-containers/kata-deploy:latest|${{ inputs.registry }}/${{ inputs.repo }}:${{ inputs.tag }}|g" tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml

--- a/tools/packaging/static-build/cache_components_main.sh
+++ b/tools/packaging/static-build/cache_components_main.sh
@@ -53,6 +53,7 @@ cache_ovmf_artifacts() {
 cache_qemu_artifacts() {
 	local qemu_tarball_name="kata-static-${QEMU_FLAVOUR}.tar.xz"
 	local current_qemu_version=$(get_from_kata_deps "assets.hypervisor.${QEMU_FLAVOUR}.version")
+	[ -z "${current_qemu_version}" ] && current_qemu_version=$(get_from_kata_deps "assets.hypervisor.${QEMU_FLAVOUR}.tag")
 	local qemu_sha=$(calc_qemu_files_sha256sum)
 	local current_qemu_image="$(get_qemu_image_name)"
 	create_cache_asset "${qemu_tarball_name}" "${current_qemu_version}-${qemu_sha}" "${current_qemu_image}"

--- a/tools/packaging/static-build/cache_components_main.sh
+++ b/tools/packaging/static-build/cache_components_main.sh
@@ -44,8 +44,9 @@ cache_nydus_artifacts() {
 }
 
 cache_ovmf_artifacts() {
-	local ovmf_tarball_name="kata-static-${OVMF_FLAVOUR}.tar.xz"
 	local current_ovmf_version="$(get_from_kata_deps "externals.ovmf.${OVMF_FLAVOUR}.version")"
+	[ "${OVMF_FLAVOUR}" == "tdx" ] && OVMF_FLAVOUR="tdvf"
+	local ovmf_tarball_name="kata-static-${OVMF_FLAVOUR}.tar.xz"
 	local current_ovmf_image="$(get_ovmf_image_name)"
 	create_cache_asset "${ovmf_tarball_name}" "${current_ovmf_version}" "${current_ovmf_image}"
 }


### PR DESCRIPTION
---

cached-components: Fix TDX QEMU caching

TDX QEMU caching is not working as expected, as we're checking for its
version looking at "assets.hypervisor.${QEMU_FLAVOUR}.version", which is
correct for standard QEMU. However, for TDX QEMU we should be checking
for "assets.hypervisor.${QEMU_FLAVOUR}.tag"

---

cache-components: Fix TDVF caching

TDVF caching is not working as the tarball name is incorrect. The result
expected is kata-static-tdvf.tar.xz, but it's looking for
kata-static-tdx.tar.xz.

This happens as a logic to convert tdx -> tdvf has been added as part of
the building scripts, but I missed doing this as part of the caching
scripts.

---