### PR TITLE
agent: Fix ut issue caused by fd double closed

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -442,9 +442,8 @@ mod tests {
             let msg = format!("test[{}]: {:?}", i, d);
             let (rfd, wfd) = unistd::pipe2(OFlag::O_CLOEXEC).unwrap();
             defer!({
-                // rfd is closed by the use of PipeStream in the crate_logger_task function,
-                // but we will attempt to close in case of a failure
-                let _ = unistd::close(rfd);
+                // XXX: Never try to close rfd, because it will be closed by PipeStream in
+                // create_logger_task() and it's not safe to close the same fd twice time.
                 unistd::close(wfd).unwrap();
             });
 


### PR DESCRIPTION
Never ever try to close the same fd double times, even in a unit test.

A file descriptor is a number which will be reused, so when you close the same number twice you may close another file descriptor in the second time and then there will be an error 'Bad file descriptor (os error 9)' while the wrongly closed fd is being used.

Fixes: #6679