### PR TITLE
Upgrade to Cloud Hypervisor v31.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v31.0"
+      version: "v31.1"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
Cloud Hypervisor published a bug fix release v33.1 with the following issues being addressed:
* Ignore and warn TAP FDs sent via the HTTP request body
* Properly preserve and close valid FDs for TAP devices
* Only use `KVM_ARM_VCPU_PMU_V3` if available
* Only touch the tty flags if it's being used
* Fix seccomp filter lists for vhost-user devices

Details can be found here: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v31.1

Fixes: #6682