### PR TITLE
osbuilder: Fix D-Bus enabling in the dracut case (backport for 3.1)

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -472,11 +472,6 @@ prepare_overlay()
 		ln -sf  /init ./sbin/init
 	fi
 
-	# Kata systemd unit file
-	mkdir -p ./etc/systemd/system/basic.target.wants/
-	ln -sf /usr/lib/systemd/system/kata-containers.target ./etc/systemd/system/basic.target.wants/kata-containers.target
-	mkdir -p ./etc/systemd/system/kata-containers.target.wants/
-	ln -sf /usr/lib/systemd/system/dbus.socket  ./etc/systemd/system/kata-containers.target.wants/dbus.socket
 	popd  > /dev/null
 }
 
@@ -625,9 +620,12 @@ EOF
 	if [ "${AGENT_INIT}" == "yes" ]; then
 		setup_agent_init "${AGENT_DEST}" "${init}"
 	else
-		# Setup systemd service for kata-agent
+		# Setup systemd-based environment for kata-agent
 		mkdir -p "${ROOTFS_DIR}/etc/systemd/system/basic.target.wants"
 		ln -sf "/usr/lib/systemd/system/kata-containers.target" "${ROOTFS_DIR}/etc/systemd/system/basic.target.wants/kata-containers.target"
+		mkdir -p "${ROOTFS_DIR}/etc/systemd/system/kata-containers.target.wants"
+		ln -sf "/usr/lib/systemd/system/dbus.socket" "${ROOTFS_DIR}/etc/systemd/system/kata-containers.target.wants/dbus.socket"
+		chmod g+rx,o+x "${ROOTFS_DIR}"
 	fi
 
 	info "Check init is installed"


### PR DESCRIPTION
- D-Bus enabling now occurs only in `setup_rootfs` (instead of `prepare_overlay` and `setup_rootfs`)
- Adjust permissions of `/` so `dbus-broker` will be able to traverse FS

These changes enables `kata-agent` to successfully communicate with D-Bus.

Fixes #6677


(cherry picked from commit 3e7b902265c6f5d1c4eece2ea778eb2cc3d6faa5)