### PR TITLE
gha: Create Mariner host as part of k8s tests

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -17,10 +17,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        host_os:
+          - ubuntu
         vmm:
           - clh
           - dragonball
           - qemu
+        include:
+          - host_os: cbl-mariner
+            vmm: clh
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -46,7 +51,8 @@ jobs:
             -n "${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.vmm }}-amd64" \
             -s "Standard_D4s_v5" \
             --node-count 1 \
-            --generate-ssh-keys
+            --generate-ssh-keys \
+            ${{ matrix.host_os == 'cbl-mariner' && '--os-sku mariner --workload-runtime KataMshvVmIsolation' }}
 
       - name: Install `bats`
         run: |
@@ -79,10 +85,11 @@ jobs:
           sleep 240s
 
           pushd tests/integration/kubernetes
-          sed -i -e 's|runtimeClassName: kata|runtimeClassName: kata-${{ matrix.vmm }}|' runtimeclass_workloads/*.yaml
+          bash setup.sh
           bash run_kubernetes_tests.sh
           popd
         env:
+          KATA_HOST_OS: ${{ matrix.host_os }}
           KATA_HYPERVISOR: ${{ matrix.vmm }}
 
       - name: Delete AKS cluster

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -54,6 +54,10 @@ else
 	)
 fi
 
+if [ ${KATA_HOST_OS} == "cbl-mariner" ]; then
+	exit 0
+fi
+
 # we may need to skip a few test cases when running on non-x86_64 arch
 arch_config_file="${kubernetes_dir}/filter_out_per_arch/${TARGET_ARCH}.yaml"
 if [ -f "${arch_config_file}" ]; then

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Copyright (c) 2023 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+kubernetes_dir=$(dirname "$(readlink -f "$0")")
+
+set_runtime_class() {
+    sed -i -e "s|runtimeClassName: kata|runtimeClassName: kata-${KATA_HYPERVISOR}|" ${kubernetes_dir}/runtimeclass_workloads/*.yaml
+}
+
+main() {
+    set_runtime_class
+}
+
+main "$@"


### PR DESCRIPTION
This PR kickstarts the onboarding of Mariner onto the CI.

The current testing setup only supports running Kata on top of an Ubuntu host. This adds Mariner to the matrix of testable hosts for k8s tests, with Cloud Hypervisor as a VMM.

As preparation for the upcoming PR (#6839) that will change the actual test code (rather than workflow YAMLs), this also introduces a new file `setup.sh` that will be used to set host-specific parameters at test time.

Fixes: #6961