### PR TITLE
kata-manager: Fix containerd download

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -160,6 +160,8 @@ github_get_release_file_url()
 		-r '.[] | select(.tag_name == $version) | .assets[].browser_download_url' |\
 		grep "/${regex}$")
 
+        download_url=$(echo $download_url | awk '{print $1}')
+
 	[ -z "$download_url" ] && die "Cannot determine download URL for version $version ($url)"
 
 	echo "$download_url"


### PR DESCRIPTION
Newer containerd releases have an additional static package published. Because of this,  download_url contains two urls causing curl to fail. To resolve this, pick the first url from the containerd releases to download containerd.

Fixes: #6695