### PR TITLE
runtime-rs/kata-ctl: Enhancement of DirectVolumeMount.

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -882,6 +882,7 @@ dependencies = [
  "num_cpus",
  "oci",
  "regex",
+ "safe-path",
  "serde",
  "serde_json",
  "slog",
@@ -1766,6 +1767,13 @@ name = "ryu"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3f6f92acf49d1b98f7a81226834412ada05458b7364277387724a237f062695"
+
+[[package]]
+name = "safe-path"
+version = "0.1.0"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "scan_fmt"

--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -519,6 +519,7 @@ dependencies = [
  "num_cpus",
  "oci",
  "regex",
+ "safe-path",
  "serde",
  "serde_json",
  "slog",

--- a/src/libs/kata-types/Cargo.toml
+++ b/src/libs/kata-types/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "1.0"
 toml = "0.5.8"
 
 oci = { path = "../oci" }
+safe-path = { path = "../safe-path" }
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -5,7 +5,7 @@
 //
 
 use anyhow::{anyhow, Context, Result};
-use std::{collections::HashMap, path::PathBuf};
+use std::{collections::HashMap, fs, path::PathBuf};
 
 /// Prefix to mark a volume as Kata special.
 pub const KATA_VOLUME_TYPE_PREFIX: &str = "kata:";
@@ -69,6 +69,27 @@ pub struct DirectVolumeMountInfo {
     pub metadata: HashMap<String, String>,
     /// Additional mount options.
     pub options: Vec<String>,
+}
+
+/// join_path joins user provided volumepath with kata direct-volume root path
+/// the volume_path is base64-encoded and then safely joined to the end of path prefix
+pub fn join_path(prefix: &str, volume_path: &str) -> Result<PathBuf> {
+    if volume_path.is_empty() {
+        return Err(anyhow!("volume path must not be empty"));
+    }
+    let b64_encoded_path = base64::encode(volume_path.as_bytes());
+
+    Ok(safe_path::scoped_join(prefix, b64_encoded_path)?)
+}
+
+/// get DirectVolume mountInfo from mountinfo.json.
+pub fn get_volume_mount_info(volume_path: &str) -> Result<DirectVolumeMountInfo> {
+    let mount_info_file_path =
+        join_path(KATA_DIRECT_VOLUME_ROOT_PATH, volume_path)?.join(KATA_MOUNT_INFO_FILE_NAME);
+    let mount_info_file = fs::read_to_string(mount_info_file_path)?;
+    let mount_info: DirectVolumeMountInfo = serde_json::from_str(&mount_info_file)?;
+
+    Ok(mount_info)
 }
 
 /// Check whether a mount type is a marker for Kata specific volume.

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1481,6 +1481,7 @@ dependencies = [
  "num_cpus",
  "oci",
  "regex",
+ "safe-path 0.1.0",
  "serde",
  "serde_json",
  "slog",

--- a/src/tools/kata-ctl/Cargo.lock
+++ b/src/tools/kata-ctl/Cargo.lock
@@ -764,7 +764,9 @@ dependencies = [
  "lazy_static",
  "num_cpus",
  "oci",
+ "proc-mounts",
  "regex",
+ "safe-path",
  "serde",
  "serde_json",
  "slog",
@@ -1046,6 +1048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "partition-identity"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa925f9becb532d758b0014b472c576869910929cf4c3f8054b386f19ab9e21"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1116,6 +1127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-mounts"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d652f8435d0ab70bf4f3590a6a851d59604831a458086541b95238cc51ffcf2"
+dependencies = [
+ "partition-identity",
 ]
 
 [[package]]

--- a/src/tools/kata-ctl/src/ops/volume_ops.rs
+++ b/src/tools/kata-ctl/src/ops/volume_ops.rs
@@ -8,12 +8,12 @@ use crate::args::{DirectVolSubcommand, DirectVolumeCommand};
 use anyhow::{anyhow, Ok, Result};
 use futures::executor;
 use kata_types::mount::{
-    DirectVolumeMountInfo, KATA_DIRECT_VOLUME_ROOT_PATH, KATA_MOUNT_INFO_FILE_NAME,
+    get_volume_mount_info, join_path, DirectVolumeMountInfo, KATA_DIRECT_VOLUME_ROOT_PATH,
+    KATA_MOUNT_INFO_FILE_NAME,
 };
 use nix;
 use reqwest::StatusCode;
-use safe_path;
-use std::{fs, path::PathBuf, time::Duration};
+use std::{fs, time::Duration};
 use url;
 
 use agent::ResizeVolumeRequest;
@@ -90,17 +90,6 @@ async fn stats(volume_path: &str) -> Result<Option<String>> {
     Ok(Some(body))
 }
 
-// join_path joins user provided volumepath with kata direct-volume root path
-// the volume_path is base64-encoded and then safely joined to the end of path prefix
-fn join_path(prefix: &str, volume_path: &str) -> Result<PathBuf> {
-    if volume_path.is_empty() {
-        return Err(anyhow!("volume path must not be empty"));
-    }
-    let b64_encoded_path = base64::encode(volume_path.as_bytes());
-
-    Ok(safe_path::scoped_join(prefix, b64_encoded_path)?)
-}
-
 // add writes the mount info (json string) of a direct volume into a filesystem path known to Kata Containers.
 pub fn add(volume_path: &str, mount_info: &str) -> Result<Option<String>> {
     let mount_info_dir_path = join_path(KATA_DIRECT_VOLUME_ROOT_PATH, volume_path)?;
@@ -127,15 +116,6 @@ pub fn remove(volume_path: &str) -> Result<Option<String>> {
     fs::remove_dir_all(path)?;
 
     Ok(None)
-}
-
-pub fn get_volume_mount_info(volume_path: &str) -> Result<DirectVolumeMountInfo> {
-    let mount_info_file_path =
-        join_path(KATA_DIRECT_VOLUME_ROOT_PATH, volume_path)?.join(KATA_MOUNT_INFO_FILE_NAME);
-    let mount_info_file = fs::read_to_string(mount_info_file_path)?;
-    let mount_info: DirectVolumeMountInfo = serde_json::from_str(&mount_info_file)?;
-
-    Ok(mount_info)
 }
 
 // get_sandbox_id_for_volume finds the id of the first sandbox found in the dir.
@@ -170,7 +150,7 @@ mod tests {
     use super::*;
     use kata_types::mount::DirectVolumeMountInfo;
     use serial_test::serial;
-    use std::{collections::HashMap, fs};
+    use std::{collections::HashMap, fs, path::PathBuf};
     use tempfile::tempdir;
     use test_utils::skip_if_not_root;
 


### PR DESCRIPTION
Move the get_volume_mount_info to kata-types/src/mount.rs. If so, it becomes a common method of DirectVolumeMountInfo and reduces duplicated code.

Fixes: #6701

 Signed-off-by: alex.lyn <alex.lyn@antgroup.com>