### PR TITLE
feat(runtime-rs): introduce huge page mode to select VM RAM's backend

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -227,6 +227,9 @@ pub const KATA_ANNO_CFG_HYPERVISOR_MEMORY_PREALLOC: &str =
 /// A sandbox annotation to specify if the memory should be pre-allocated from huge pages.
 pub const KATA_ANNO_CFG_HYPERVISOR_HUGE_PAGES: &str =
     "io.katacontainers.config.hypervisor.enable_hugepages";
+/// A sandbox annotation to specify huge page mode.
+pub const KATA_ANNO_CFG_HYPERVISOR_HUGE_PAGES_MODE: &str =
+    "io.katacontainers.config.hypervisor.enable_hugepages_mode";
 /// A sandbox annotation to soecify file based memory backend root directory.
 pub const KATA_ANNO_CFG_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR: &str =
     "io.katacontainers.config.hypervisor.file_mem_backend";
@@ -744,6 +747,9 @@ impl Annotation {
                             return Err(bool_err);
                         }
                     },
+                    KATA_ANNO_CFG_HYPERVISOR_HUGE_PAGES_MODE => {
+                        hv.memory_info.hugepages_mode = value.to_string();
+                    }
                     KATA_ANNO_CFG_HYPERVISOR_FILE_BACKED_MEM_ROOT_DIR => {
                         hv.memory_info.validate_memory_backend_path(value)?;
                         hv.memory_info.file_mem_backend = value.to_string();

--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -11,6 +11,7 @@ use std::u32;
 use super::{default, register_hypervisor_plugin};
 use crate::config::default::MAX_DRAGONBALL_VCPUS;
 use crate::config::default::MIN_DRAGONBALL_MEMORY_SIZE_MB;
+use crate::config::hypervisor::{HUGE_PAGE_MODE_HUGETLBFS, HUGE_PAGE_MODE_THP};
 use crate::config::hypervisor::{
     VIRTIO_BLK, VIRTIO_BLK_MMIO, VIRTIO_FS, VIRTIO_FS_INLINE, VIRTIO_PMEM,
 };
@@ -190,6 +191,17 @@ impl ConfigPlugin for DragonballConfig {
                     "dragonball hypervisor has minimal memory limitation {}",
                     MIN_DRAGONBALL_MEMORY_SIZE_MB
                 ));
+            }
+            if db.memory_info.enable_hugepages {
+                if !db.memory_info.hugepages_mode.is_empty()
+                    && db.memory_info.hugepages_mode != HUGE_PAGE_MODE_THP
+                    && db.memory_info.hugepages_mode != HUGE_PAGE_MODE_HUGETLBFS
+                {
+                    return Err(eother!(
+                        "{} is unsupported huge page type.",
+                        db.memory_info.hugepages_mode
+                    ));
+                }
             }
         }
 

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -53,6 +53,11 @@ const VIRTIO_FS: &str = "virtio-fs";
 const VIRTIO_FS_INLINE: &str = "inline-virtio-fs";
 const MAX_BRIDGE_SIZE: u32 = 5;
 
+/// use transparent huge page as VM RAM's backend
+pub const HUGE_PAGE_MODE_THP: &str = "thp";
+/// use hugetlbfs as VM RAM's backend
+pub const HUGE_PAGE_MODE_HUGETLBFS: &str = "hugetlbfs";
+
 const KERNEL_PARAM_DELIMITER: &str = " ";
 
 lazy_static! {
@@ -558,6 +563,10 @@ pub struct MemoryInfo {
     /// result in memory pre allocation.
     #[serde(default)]
     pub enable_hugepages: bool,
+
+    /// Hugepage mode for VM RAM, default Hugetlbfs
+    #[serde(default)]
+    pub hugepages_mode: String,
 
     /// Specifies virtio-mem will be enabled or not.
     ///

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -50,6 +50,7 @@ const VM_ROOTFS_FILESYSTEM_EROFS: &str = "erofs";
 const DEV_HUGEPAGES: &str = "/dev/hugepages";
 pub const HUGETLBFS: &str = "hugetlbfs";
 const SHMEM: &str = "shmem";
+const HUGE_SHMEM: &str = "hugeshmem";
 
 pub const HYPERVISOR_DRAGONBALL: &str = "dragonball";
 pub const HYPERVISOR_QEMU: &str = "qemu";


### PR DESCRIPTION
Currently, we support two backends: thp and hugetlbfs

Fixes: #6703

This commit allow us to specific the hugepage backend while enable hugepage.
Currently, we support two backends: thp and hugetlbfs, the default is hugetlbfs.