### PR TITLE
rustjail: Use CPUWeight with systemd and CgroupsV2

### DIFF
--- a/src/agent/rustjail/src/cgroups/systemd/subsystem/cpu.rs
+++ b/src/agent/rustjail/src/cgroups/systemd/subsystem/cpu.rs
@@ -71,7 +71,7 @@ impl Cpu {
     }
 
     // v2:
-    // cpu.shares <-> CPUShares
+    // cpu.shares <-> CPUWeight
     // cpu.period <-> CPUQuotaPeriodUSec
     // cpu.period & cpu.quota <-> CPUQuotaPerSecUSec
     fn unified_apply(
@@ -80,8 +80,8 @@ impl Cpu {
         systemd_version: &str,
     ) -> Result<()> {
         if let Some(shares) = cpu_resources.shares {
-            let unified_shares = get_unified_cpushares(shares);
-            properties.push(("CPUShares", Value::U64(unified_shares)));
+            let weight = shares_to_weight(shares);
+            properties.push(("CPUWeight", Value::U64(weight)));
         }
 
         if let Some(period) = cpu_resources.period {
@@ -104,7 +104,7 @@ impl Cpu {
 
 // ref: https://github.com/containers/crun/blob/main/crun.1.md#cgroup-v2
 // [2-262144] to [1-10000]
-fn get_unified_cpushares(shares: u64) -> u64 {
+fn shares_to_weight(shares: u64) -> u64 {
     if shares == 0 {
         return 100;
     }


### PR DESCRIPTION
The CPU shares property belongs to CgroupsV1. CgroupsV2 uses CPU weight instead. The correct value is computed in the latter case but it is passed to systemd using the legacy property. Systemd rejects the request and the agent exists with the following error :

        Value specified in CPUShares is out of range: unknown

Replace the "shares" wording with "weight" in the CgroupsV2 code to avoid confusions. Use the "CPUWeight" property since this is what systemd expects in this case.

Fixes #6636

References:

https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#CPUWeight=weight https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#systemd%20252 https://github.com/containers/crun/blob/main/crun.1.md#cpu-controller

Signed-off-by: Greg Kurz <groug@kaod.org>
(cherry picked from commit c1fbaae8d6c72cb64e8a4681012cac9c3f5ccdf1)