### PR TITLE
virtcontainers/pkg/rootless/: Improved coverage for Kata 2.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/rootless/rootless_linux.go
+++ b/src/runtime/virtcontainers/pkg/rootless/rootless_linux.go
@@ -100,11 +100,17 @@ func NewNS() (ns.NetNS, error) {
 		}()
 
 		// create a new netns on the current thread
-		err = unix.Unshare(unix.CLONE_NEWNET)
-		if err != nil {
-			rootlessLog.Warnf("cannot create a new network namespace: %q", err)
-			return
-		}
+		if os.Getuid() == 0 { 
+			err = unix.Unshare(unix.CLONE_NEWNET)
+			if err != nil {
+				rootlessLog.Warnf("cannot create a new network namespace: %q", err)
+				return
+			}
+		} else {
+			err = fmt.Errorf("no root permission")
+			rootlessLog.Warnf("cannot create a new network namespace without root permissions")
+			return 
+		}	
 
 		// Put this thread back to the orig ns, since it might get reused (pre go1.10)
 		defer func() {

--- a/src/runtime/virtcontainers/pkg/rootless/rootless_test.go
+++ b/src/runtime/virtcontainers/pkg/rootless/rootless_test.go
@@ -34,3 +34,42 @@ func TestIsRootless(t *testing.T) {
 
 	isRootless = nil
 }
+
+func TestNewNS(t *testing.T) {
+	tmpdir := t.TempDir()
+
+	tcs := []struct {
+		Name    string
+		Dir     string
+		Message string
+		user    string
+	}{
+		{
+			Name:    "No fails with root",
+			Dir:     tmpdir,
+			Message: "",
+			user:    "root",
+		},
+		{
+			Name:    "cannot create ns without root",
+			Dir:     tmpdir,
+			Message: "failed to create namespace: no root permission",
+			user:    "user",
+		},
+	}
+
+	for _, ts := range tcs {
+		rootlessDir = ts.Dir
+		_, err := NewNS()
+		if os.Getuid() != 0 && ts.user == "root" {
+			continue
+		}
+		if os.Getuid() == 0 && ts.user == "user" {
+			continue
+		}
+		if err != nil && err.Error() != ts.Message {
+			t.Errorf("test %v, want %v, got %v", ts.Name, ts.Message, err.Error())
+		}
+	}
+
+}


### PR DESCRIPTION
In this PR, I add some test cases about rootless_linux.go for both admin and non-admin

In addition, I found unix.Unshare function needs root permission, so I modified some code in rootless_linux.go. I am not clear whether my change is reasonable. Looking for your advice @jodh-intel @amshinde 

Credit PR to Hackathon Team3

Fixes: #257