### PR TITLE
runtime: remove overriding ARCH value by default for ppc64le

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -33,6 +33,12 @@ ifeq ($(SECCOMP),yes)
     override EXTRA_RUSTFEATURES += seccomp
 endif
 
+include ../../utils.mk
+
+ifeq ($(ARCH), ppc64le)
+    override ARCH = powerpc64le
+endif
+
 ##VAR STANDARD_OCI_RUNTIME=yes|no define if agent enables standard oci runtime feature
 STANDARD_OCI_RUNTIME := no
 
@@ -44,8 +50,6 @@ endif
 ifneq ($(EXTRA_RUSTFEATURES),)
     override EXTRA_RUSTFEATURES := --features "$(EXTRA_RUSTFEATURES)"
 endif
-
-include ../../utils.mk
 
 TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)
 

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -17,6 +17,10 @@ CONTAINERD_RUNTIME_NAME = io.containerd.kata.v2
 
 include ../../utils.mk
 
+ifeq ($(ARCH), ppc64le)
+    override ARCH = powerpc64le
+endif
+
 ARCH_DIR = arch
 ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)

--- a/src/tools/agent-ctl/Makefile
+++ b/src/tools/agent-ctl/Makefile
@@ -5,6 +5,10 @@
 
 include ../../../utils.mk
 
+ifeq ($(ARCH), ppc64le)
+     override ARCH = powerpc64le
+ endif
+
 .DEFAULT_GOAL := default
 default: build
 

--- a/src/tools/runk/Makefile
+++ b/src/tools/runk/Makefile
@@ -8,6 +8,10 @@ LIBC ?= gnu
 
 include ../../../utils.mk
 
+ifeq ($(ARCH), ppc64le)
+     override ARCH = powerpc64le
+ endif
+
 TARGET = runk
 TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)
 AGENT_SOURCE_PATH = ../../agent

--- a/src/tools/trace-forwarder/Makefile
+++ b/src/tools/trace-forwarder/Makefile
@@ -5,6 +5,10 @@
 
 include ../../../utils.mk
 
+ifeq ($(ARCH), ppc64le)
+     override ARCH = powerpc64le
+ endif
+
 .DEFAULT_GOAL := default
 default: build
 

--- a/utils.mk
+++ b/utils.mk
@@ -146,7 +146,6 @@ ifneq ($(LIBC),musl)
 endif
 
 ifeq ($(ARCH), ppc64le)
-    override ARCH = powerpc64le
     override LIBC = gnu
     $(warning "WARNING: powerpc64le-unknown-linux-musl target is unavailable")
 endif


### PR DESCRIPTION
Currently, `ARCH` value is being set to `powerpc64le` by default. `powerpc64le` is only right in the context of rust and any operation which might use this variable for a different purpose might fail on `ppc64le`.

Fixes: #6741