### PR TITLE
bugfix: fix the incomplete delete operation of runtime-rs

### DIFF
--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -12,8 +12,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use hypervisor::device::device_manager::DeviceManager;
 use hypervisor::Hypervisor;
-use kata_types::config::TomlConfig;
-use kata_types::mount::Mount;
+use kata_types::{config::TomlConfig, mount::Mount};
 use oci::{Linux, LinuxResources};
 use persist::sandbox_persist::Persist;
 use tokio::sync::RwLock;
@@ -123,6 +122,16 @@ impl ResourceManager {
     pub async fn cleanup(&self) -> Result<()> {
         let inner = self.inner.read().await;
         inner.cleanup().await
+    }
+
+    pub async fn remove_container_resources(
+        &self,
+        cid: &str,
+        rootfs: Vec<Arc<dyn Rootfs>>,
+        volumes: Vec<Arc<dyn Volume>>,
+    ) -> Result<(Vec<Arc<dyn Rootfs>>, Vec<Arc<dyn Volume>>)> {
+        let inner = self.inner.read().await;
+        inner.remove_container_resources(cid, rootfs, volumes).await
     }
 }
 

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -385,6 +385,26 @@ impl ResourceManagerInner {
         Ok(())
     }
 
+    pub async fn remove_container_resources(
+        &self,
+        cid: &str,
+        rootfs: Vec<Arc<dyn Rootfs>>,
+        volumes: Vec<Arc<dyn Volume>>,
+    ) -> Result<(Vec<Arc<dyn Rootfs>>, Vec<Arc<dyn Volume>>)> {
+        // remove rootfs
+        let unremoved_rootfs = self
+            .rootfs_resource
+            .remove(&self.device_manager, cid.to_owned(), rootfs)
+            .await?;
+        // remove volumes
+        let unremoved_volumes = self
+            .volume_resource
+            .remove(&self.device_manager, cid.to_owned(), volumes)
+            .await?;
+
+        Ok((unremoved_rootfs, unremoved_volumes))
+    }
+
     pub async fn dump(&self) {
         self.rootfs_resource.dump().await;
         self.volume_resource.dump().await;

--- a/src/runtime-rs/crates/resource/src/volume/default_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/default_volume.rs
@@ -10,17 +10,20 @@ use tokio::sync::RwLock;
 use anyhow::Result;
 use async_trait::async_trait;
 
-use super::Volume;
+use super::{generate_volume_id, Volume};
 
 #[derive(Debug)]
 pub(crate) struct DefaultVolume {
+    id: String,
     mount: oci::Mount,
 }
 
 /// DefaultVolume: passthrough the mount to guest
 impl DefaultVolume {
     pub fn new(mount: &oci::Mount) -> Result<Self> {
+        let id = generate_volume_id();
         Ok(Self {
+            id,
             mount: mount.clone(),
         })
     }
@@ -28,6 +31,10 @@ impl DefaultVolume {
 
 #[async_trait]
 impl Volume for DefaultVolume {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
     fn get_volume_mount(&self) -> anyhow::Result<Vec<oci::Mount>> {
         Ok(vec![self.mount.clone()])
     }

--- a/src/runtime-rs/crates/resource/src/volume/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/spdk_volume.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 use nix::sys::{stat, stat::SFlag};
 use tokio::sync::RwLock;
 
-use super::Volume;
+use super::{generate_volume_id, Volume};
 use crate::volume::utils::{
     generate_shared_path, volume_mount_info, DEFAULT_VOLUME_FS_TYPE, KATA_SPDK_VOLUME_TYPE,
     KATA_SPOOL_VOLUME_TYPE,
@@ -25,6 +25,7 @@ use hypervisor::{
 /// SPDKVolume: spdk block device volume
 #[derive(Clone)]
 pub(crate) struct SPDKVolume {
+    id: String,
     storage: Option<agent::Storage>,
     mount: oci::Mount,
     device_id: String,
@@ -38,6 +39,7 @@ impl SPDKVolume {
         cid: &str,
         sid: &str,
     ) -> Result<Self> {
+        let id = generate_volume_id();
         let mnt_src: &str = &m.source;
 
         // deserde Information from mountinfo.json
@@ -142,6 +144,7 @@ impl SPDKVolume {
         };
 
         Ok(Self {
+            id,
             storage: Some(storage),
             mount,
             device_id,
@@ -151,6 +154,10 @@ impl SPDKVolume {
 
 #[async_trait]
 impl Volume for SPDKVolume {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
     fn get_volume_mount(&self) -> Result<Vec<oci::Mount>> {
         Ok(vec![self.mount.clone()])
     }

--- a/src/runtime-rs/crates/resource/src/volume/vfio_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/vfio_volume.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use tokio::sync::RwLock;
 
-use super::Volume;
+use super::{generate_volume_id, Volume};
 use crate::volume::utils::{
     generate_shared_path, volume_mount_info, DEFAULT_VOLUME_FS_TYPE, KATA_VFIO_VOLUME_TYPE,
 };
@@ -21,6 +21,7 @@ use hypervisor::{
 };
 
 pub(crate) struct VfioVolume {
+    id: String,
     storage: Option<agent::Storage>,
     mount: oci::Mount,
     device_id: String,
@@ -35,6 +36,7 @@ impl VfioVolume {
         cid: &str,
         sid: &str,
     ) -> Result<Self> {
+        let id = generate_volume_id();
         let mnt_src: &str = &m.source;
 
         // deserde Information from mountinfo.json
@@ -96,6 +98,7 @@ impl VfioVolume {
         };
 
         Ok(Self {
+            id,
             storage: Some(storage),
             mount,
             device_id,
@@ -105,6 +108,10 @@ impl VfioVolume {
 
 #[async_trait]
 impl Volume for VfioVolume {
+    fn id(&self) -> String {
+        self.id.clone()
+    }
+
     fn get_volume_mount(&self) -> Result<Vec<oci::Mount>> {
         Ok(vec![self.mount.clone()])
     }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -12,19 +12,17 @@ use common::{
     error::Error,
     types::{ContainerID, ContainerProcess, ProcessExitStatus, ProcessStatus, ProcessType},
 };
-use hypervisor::device::device_manager::DeviceManager;
 use nix::sys::signal::Signal;
 use oci::LinuxResources;
 use resource::{rootfs::Rootfs, volume::Volume};
 use tokio::sync::RwLock;
-
-use crate::container_manager::logger_with_process;
 
 use super::{
     io::ContainerIo,
     process::{Process, ProcessWatcher},
     Exec,
 };
+use crate::container_manager::logger_with_process;
 
 pub struct ContainerInner {
     agent: Arc<dyn Agent>,
@@ -166,52 +164,9 @@ impl ContainerInner {
         }
     }
 
-    async fn cleanup_container(&mut self, cid: &str, force: bool) -> Result<()> {
-        // wait until the container process
-        // terminated and the status write lock released.
-        info!(self.logger, "wait on container terminated");
-        let exit_status = self.get_exit_status().await;
-        let _locked_exit_status = exit_status.read().await;
-        info!(self.logger, "container terminated");
-        let remove_request = agent::RemoveContainerRequest {
-            container_id: cid.to_string(),
-            ..Default::default()
-        };
-        self.agent
-            .remove_container(remove_request)
-            .await
-            .or_else(|e| {
-                if force {
-                    warn!(
-                        self.logger,
-                        "stop container: agent remove container failed: {}", e
-                    );
-                    Ok(agent::Empty::new())
-                } else {
-                    Err(e)
-                }
-            })?;
-
-        // close the exit channel to wakeup wait service
-        // send to notify watchers who are waiting for the process exit
-        self.init_process.stop().await;
-        Ok(())
-    }
-
-    pub(crate) async fn stop_process(
-        &mut self,
-        process: &ContainerProcess,
-        force: bool,
-        device_manager: &RwLock<DeviceManager>,
-    ) -> Result<()> {
+    pub(crate) async fn stop_process(&mut self, process: &ContainerProcess) -> Result<()> {
         let logger = logger_with_process(process);
         info!(logger, "begin to stop process");
-
-        // do not stop again when state stopped, may cause multi cleanup resource
-        let state = self.init_process.get_status().await;
-        if state == ProcessStatus::Stopped {
-            return Ok(());
-        }
 
         self.check_state(vec![
             ProcessStatus::Created,
@@ -221,12 +176,13 @@ impl ContainerInner {
         .await
         .context("check state")?;
 
-        if state == ProcessStatus::Running {
+        let status = self.init_process.get_status().await;
+        if status == ProcessStatus::Running {
             // if use force mode to stop container, stop always successful
             // send kill signal to container
             // ignore the error of sending signal, since the process would
             // have been killed and exited yet.
-            self.signal_process(process, Signal::SIGKILL as u32, false, device_manager)
+            self.signal_process(process, Signal::SIGKILL as u32, false)
                 .await
                 .map_err(|e| {
                     warn!(logger, "failed to signal kill. {:?}", e);
@@ -235,10 +191,18 @@ impl ContainerInner {
         }
 
         match process.process_type {
-            ProcessType::Container => self
-                .cleanup_container(&process.container_id.container_id, force)
-                .await
-                .context("stop container")?,
+            ProcessType::Container => {
+                // wait until the container process
+                // terminated and the status write lock released.
+                info!(self.logger, "wait on container terminated");
+                let exit_status = self.get_exit_status().await;
+                let _locked_exit_status = exit_status.read().await;
+                info!(self.logger, "container terminated");
+
+                // close the exit channel to wakeup wait service
+                // send to notify watchers who are waiting for the process exit
+                self.init_process.stop().await;
+            }
             ProcessType::Exec => {
                 let exec = self
                     .exec_processes
@@ -256,7 +220,6 @@ impl ContainerInner {
         process: &ContainerProcess,
         signal: u32,
         all: bool,
-        device_manager: &RwLock<DeviceManager>,
     ) -> Result<()> {
         let mut process_id: agent::ContainerProcessID = process.clone().into();
         if all {
@@ -267,13 +230,6 @@ impl ContainerInner {
         self.agent
             .signal_process(agent::SignalProcessRequest { process_id, signal })
             .await?;
-
-        self.clean_volumes(device_manager)
-            .await
-            .context("clean volumes")?;
-        self.clean_rootfs(device_manager)
-            .await
-            .context("clean rootfs")?;
 
         Ok(())
     }
@@ -294,44 +250,6 @@ impl ContainerInner {
             }
         };
 
-        Ok(())
-    }
-
-    async fn clean_volumes(&mut self, device_manager: &RwLock<DeviceManager>) -> Result<()> {
-        let mut unhandled = Vec::new();
-        for v in self.volumes.iter() {
-            if let Err(err) = v.cleanup(device_manager).await {
-                unhandled.push(Arc::clone(v));
-                warn!(
-                    sl!(),
-                    "Failed to clean the volume = {:?}, error = {:?}",
-                    v.get_volume_mount(),
-                    err
-                );
-            }
-        }
-        if !unhandled.is_empty() {
-            self.volumes = unhandled;
-        }
-        Ok(())
-    }
-
-    async fn clean_rootfs(&mut self, device_manager: &RwLock<DeviceManager>) -> Result<()> {
-        let mut unhandled = Vec::new();
-        for rootfs in self.rootfs.iter() {
-            if let Err(err) = rootfs.cleanup(device_manager).await {
-                unhandled.push(Arc::clone(rootfs));
-                warn!(
-                    sl!(),
-                    "Failed to umount rootfs, cid = {:?}, error = {:?}",
-                    self.container_id(),
-                    err
-                );
-            }
-        }
-        if !unhandled.is_empty() {
-            self.rootfs = unhandled;
-        }
         Ok(())
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -128,7 +128,7 @@ impl ContainerInner {
     }
 
     pub(crate) async fn start_container(&mut self, cid: &ContainerID) -> Result<()> {
-        self.check_state(vec![ProcessStatus::Created, ProcessStatus::Stopped])
+        self.check_state(vec![ProcessStatus::Created, ProcessStatus::Exited])
             .await
             .context("check state")?;
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -213,9 +213,13 @@ impl ContainerInner {
             return Ok(());
         }
 
-        self.check_state(vec![ProcessStatus::Running, ProcessStatus::Exited])
-            .await
-            .context("check state")?;
+        self.check_state(vec![
+            ProcessStatus::Created,
+            ProcessStatus::Running,
+            ProcessStatus::Exited,
+        ])
+        .await
+        .context("check state")?;
 
         if state == ProcessStatus::Running {
             // if use force mode to stop container, stop always successful

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -120,6 +120,9 @@ impl ContainerManager for VirtContainerManager {
                     .remove(container_id)
                     .ok_or_else(|| Error::ContainerNotFound(container_id.to_string()))?;
 
+                // Delete the container that is created but never started
+                c.stop_process(process).await.context("delete container")?;
+
                 // Poststop Hooks:
                 // * should be run in runtime namespace
                 // * should be run after the container is deleted but before delete operation returns


### PR DESCRIPTION
This PR consists of three commits:

- The first commit solves the problem of resource deletion of Containers that are created but never started.
- The second commit solves the problem of checking states in start_container by mistake.
- The third commit solves the problem of inconsistent information stored after the cleanup of container's rootfs and volumes.

Fixes: #6743

Signed-off-by: Yushuo <y-shuo@linux.alibaba.com>