### PR TITLE
gha: Fix snap creation workflow

### DIFF
--- a/.github/workflows/snap-release.yaml
+++ b/.github/workflows/snap-release.yaml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check out Git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
@@ -32,6 +32,7 @@ jobs:
         run: |
           # Removing man-db, workflow kept failing, fixes: #4480
           sudo apt -y remove --purge man-db
+          sudo apt-get update
           sudo apt-get install -y git git-extras
           kata_url="https://github.com/kata-containers/kata-containers"
           latest_version=$(git ls-remote --tags ${kata_url}  | egrep -o "refs.*" | egrep -v "\-alpha|\-rc|{}" | egrep -o "[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+" | sort -V -r | head -1)

--- a/.github/workflows/snap.yaml
+++ b/.github/workflows/snap.yaml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Check out
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Fix recurring issues of failing to install dependencies due to stale apt cache. Uprev actions/checkout to v3 to resolve issue "Node.js 12 actions are deprecated."

Fixes: #5659