### PR TITLE
virtcontainers/factory: Improved test coverage

### DIFF
--- a/src/runtime/virtcontainers/factory/factory_test.go
+++ b/src/runtime/virtcontainers/factory/factory_test.go
@@ -8,6 +8,7 @@ package factory
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
@@ -330,4 +331,127 @@ func TestDeepCompare(t *testing.T) {
 	f2, err = NewFactory(ctx, config, false)
 	assert.Nil(err)
 	assert.False(utils.DeepCompare(f1, f2))
+}
+
+func TestFactoryConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	// Valid config
+	var config Config
+	config.VMConfig.HypervisorConfig = vc.HypervisorConfig{
+		KernelPath: "foo",
+		ImagePath:  "bar",
+	}
+	ctx := context.Background()
+	vf, err := NewFactory(ctx, config, false)
+	assert.Nil(err)
+
+	f, ok := vf.(*factory)
+	assert.True(ok)
+
+	vmc := f.Config()
+
+	assert.Equal(config.VMConfig.HypervisorConfig.KernelPath, vmc.HypervisorConfig.KernelPath)
+	assert.Equal(config.VMConfig.HypervisorConfig.ImagePath, vmc.HypervisorConfig.ImagePath)
+}
+
+func TestFactoryGetBaseVM(t *testing.T) {
+	assert := assert.New(t)
+
+	// Set configs
+	var config Config
+	testDir := t.TempDir()
+
+	hyperConfig := vc.HypervisorConfig{
+		KernelPath: testDir,
+		ImagePath:  testDir,
+	}
+	vmConfig := vc.VMConfig{
+		HypervisorType:   vc.MockHypervisor,
+		HypervisorConfig: hyperConfig,
+	}
+	config.VMConfig = vmConfig
+	config.TemplatePath = testDir
+
+	err := vmConfig.Valid()
+	assert.Nil(err)
+
+	ctx := context.Background()
+
+	url, err := mock.GenerateKataMockHybridVSock()
+	assert.NoError(err)
+	defer mock.RemoveKataMockHybridVSock(url)
+	vc.MockHybridVSockPath = url
+
+	hybridVSockTTRPCMock := mock.HybridVSockTTRPCMock{}
+	err = hybridVSockTTRPCMock.Start(url)
+	assert.NoError(err)
+	defer hybridVSockTTRPCMock.Stop()
+
+	// New factory
+	vf, err := NewFactory(ctx, config, false)
+	assert.Nil(err)
+
+	f, ok := vf.(*factory)
+	assert.True(ok)
+
+	// Check VM Config
+	assert.Equal(f.Config(), vmConfig)
+
+	// GetBaseVM
+	vm, err := f.GetBaseVM(ctx, vmConfig)
+	assert.Nil(err)
+
+	// Get VM Status
+	defer func() {
+		r := recover()
+		assert.NotNil(r)
+
+		// Close
+		err = vm.Stop(ctx)
+		assert.Nil(err)
+	}()
+	vmStatus := f.GetVMStatus()
+	assert.NotNil(vmStatus) // line of code to make golang happy. This is never executed.
+}
+
+func TestNewFactoryWithCache(t *testing.T) {
+	assert := assert.New(t)
+
+	// Config
+	var config Config
+	config.VMConfig.HypervisorConfig = vc.HypervisorConfig{
+		KernelPath: "foo",
+		ImagePath:  "bar",
+	}
+	ctx := context.Background()
+
+	// cache>0 and fetch only should throw error
+	config.Cache = 1
+	vf, err := NewFactory(ctx, config, true)
+
+	assert.Nil(vf)
+	assert.Error(err)
+	b := err.Error()
+	assert.True(strings.Contains(b, "cache factory does not support fetch"))
+}
+
+func TestNewFactoryWrongCacheEndpoint(t *testing.T) {
+	assert := assert.New(t)
+
+	// Config
+	var config Config
+	config.VMConfig.HypervisorConfig = vc.HypervisorConfig{
+		KernelPath: "foo",
+		ImagePath:  "bar",
+	}
+	ctx := context.Background()
+
+	config.VMCache = true
+	vf, err := NewFactory(ctx, config, false)
+
+	assert.Nil(vf)
+	assert.Error(err)
+	b := err.Error()
+	assert.True(strings.Contains(b, "rpc error")) // sanity check
 }


### PR DESCRIPTION
Expanded tests on factory_test.go to cover more lines of code. Coverage went from 34% to 41.5% in the case of user-mode run tests, and from 77.7% to 84% in the case of priviledge-mode run tests.

Fixes: #260