### PR TITLE
versions: Bump containerd to 1.7.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -218,7 +218,7 @@ externals:
     # containerd from v1.5.0 used the path unix socket
     # instead of abstract socket, thus kata wouldn's support the containerd's
     # version older than them.
-    version: "v1.6.8"
+    version: "v1.7.0"
 
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"


### PR DESCRIPTION
Release includes features such as experimental Sanbox API, Node Resource Interface for plugging extensions,
gRPC shim support and support for Linux conatiners on FreeBSD.

Fixes: #6750