### PR TITLE
cross-compile: Include documentation and configuration for cross-compile

### DIFF
--- a/src/tools/kata-ctl/Cross.toml
+++ b/src/tools/kata-ctl/Cross.toml
@@ -1,0 +1,12 @@
+[target.s390x-unknown-linux-gnu]
+pre-build = ["dpkg --add-architecture s390x && apt-get update && apt-get install -y libssl-dev:s390x"]
+
+[target.aarch64-unknown-linux-musl]
+pre-build = ["dpkg --add-architecture arm64 && apt-get update && apt-get install -y libssl-dev:arm64"]
+
+[target.x86-64-unknown-linux-musl]
+pre-build = ["dpkg --add-architecture amd64 && apt-get update && apt-get install -y libssl-dev:amd64"]
+
+# Powerpc compile seems to be broken, due to `ring` crate not being supported on powerpc.
+[target.powerpc64le-unknown-linux-gnu]
+pre-build = ["dpkg --add-architecture ppc64le && apt-get update && apt-get install -y libssl-dev:ppc64le"]

--- a/src/tools/kata-ctl/README.md
+++ b/src/tools/kata-ctl/README.md
@@ -47,3 +47,34 @@ For a usage statement, run:
 ```bash
 $ kata-ctl --help
 ```
+
+## Cross-builds
+
+For developers that want to build and test the `kata-ctl` tool on various architectures,
+the makefile included does have support for that. This would however, require installing 
+the cross compile toolchain for the target architecture on the host along with required libraries.
+
+[Cross](https://github.com/cross-rs/cross) is an open source tool that offers zero setup
+cross compile and requires no changes to the system installation for cross-compiling
+rust binaries. It makes use of docker containers for cross-compilation.
+
+You can install cross with:
+```
+cargo install -f cross
+```
+
+`cross` relies on `docker` or `podman`. For dependencies take a look at: https://github.com/cross-rs/cross#dependencies
+
+There is an included `cross` configuration file [Cross.yaml](./Cross.toml) that can be used
+to compile `kata-ctl` for various targets. This configuration helps install required
+dependencies inside a docker container.
+
+For example, to compile for target `s390x-unknown-linux-gnu` included in `Cross.yaml` simple run:
+```
+cross build --target=s390x-unknown-linux-gnu
+```
+
+You may also need to add the target on your host system prior to the above step as:
+```
+rustup target add s390x-unknown-linux-gnu
+``` 


### PR DESCRIPTION
`cross` is an open source tool that provides zero-setup cross compile for rust binaries. Add documentation on this tool for compiling kata-ctl tool and Cross.toml file that provides required configuration for installing dependencies for various targets.
This is pretty useful for a developer to make sure code compiles and passes checks for various architectures.

Fixes: #1000