### PR TITLE
kata-deploy: fix vanilla ovmf tarball name

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -412,7 +412,7 @@ install_shimv2() {
 
 install_ovmf() {
 	ovmf_type="${1:-x86_64}"
-	tarball_name="${2:-edk2.tar.xz}"
+	tarball_name="${2:-edk2-x86_64.tar.gz}"
 
 	local component_name="ovmf"
 	local component_version="$(get_from_kata_deps "externals.ovmf.${ovmf_type}.version")"


### PR DESCRIPTION
The build of vanilla ovmf fails due to wrong name of the tarball file.

Fixes #6761
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>