### PR TITLE
virtcontainers: Improved test coverage for fc.go from 4.6% to 18.5%

### DIFF
--- a/src/runtime/virtcontainers/fc_test.go
+++ b/src/runtime/virtcontainers/fc_test.go
@@ -8,6 +8,7 @@
 package virtcontainers
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -54,11 +55,185 @@ func TestFCParseVersion(t *testing.T) {
 
 	fc := firecracker{}
 
+	// correct versions
 	for rawVersion, v := range map[string]string{"Firecracker v0.23.1": "0.23.1", "Firecracker v0.25.0\nSupported snapshot data format versions: 0.23.0": "0.25.0"} {
 		parsedVersion, err := fc.parseVersion(rawVersion)
 		assert.NoError(err)
 		assert.Equal(parsedVersion, v)
 	}
+
+	// wrong version str
+	rawVersion := "Firecracker_v0.23.0"
+	parsedVersion, err := fc.parseVersion(rawVersion)
+	assert.Error(err)
+	assert.Equal(parsedVersion, "")
+}
+
+func TestFCCheckVersion(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+
+	// correct version
+	v := "0.23.0"
+	err := fc.checkVersion(v)
+	assert.NoError(err)
+
+	// version too low
+	v = "0.1.1"
+	err = fc.checkVersion(v)
+	assert.Error(err)
+	b := err.Error()
+	assert.True(strings.Contains(b, "version 0.1.1 is not supported")) // sanity
+
+	// version is malformed
+	v = "Firecracker v0.23.0"
+	err = fc.checkVersion(v)
+	assert.Error(err)
+	b = err.Error()
+	assert.True(strings.Contains(b, "Malformed firecracker version:")) // sanity
+}
+
+func TestFCGetVersionNumber(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	_, err := fc.getVersionNumber()
+	assert.Error(err)
+}
+
+func TestFCDriveIndexToID(t *testing.T) {
+	assert := assert.New(t)
+
+	d := fcDriveIndexToID(5)
+	assert.Equal(d, "drive_5")
+}
+
+func TestFCPauseVM(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	ctx := context.Background()
+	err := fc.PauseVM(ctx)
+	assert.NoError(err)
+}
+
+func TestFCSaveVM(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	err := fc.SaveVM()
+	assert.NoError(err)
+}
+
+func TestFCResumeVM(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	ctx := context.Background()
+	err := fc.ResumeVM(ctx)
+	assert.NoError(err)
+}
+
+func TestFCGetVirtioFsPid(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	pid := fc.GetVirtioFsPid()
+	assert.Nil(pid)
+}
+
+func TestFCIsRateLimiterBuiltin(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	rl := fc.IsRateLimiterBuiltin()
+	assert.True(rl)
+}
+
+func TestFCCheck(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	err := fc.Check()
+	assert.NoError(err)
+}
+
+func TestFCGetPids(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	pids := fc.GetPids()
+	assert.Equal(len(pids), 1)
+}
+
+func TestFCCleanup(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	ctx := context.Background()
+	err := fc.Cleanup(ctx)
+	assert.NoError(err)
+}
+
+func TestFCToGrpc(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	ctx := context.Background()
+	_, err := fc.toGrpc(ctx)
+	assert.Error(err)
+}
+
+func TestFCHypervisorConfig(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	config := fc.HypervisorConfig()
+	assert.Equal(fc.config, config)
+}
+
+func TestFCGetTotalMemoryMB(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	ctx := context.Background()
+
+	var initialMemSize uint32
+	initialMemSize = 1024
+
+	fc.config.MemorySize = 1024
+	memSize := fc.GetTotalMemoryMB(ctx)
+	assert.Equal(memSize, initialMemSize)
+}
+
+func TestFCClient(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	ctx := context.Background()
+
+	conn := fc.client(ctx)
+	assert.Equal(conn, fc.connection)
+}
+
+func TestFCVmRunning(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+	ctx := context.Background()
+	sr := fc.vmRunning(ctx)
+	assert.False(sr)
+}
+
+func TestFCCreateJailedDrive(t *testing.T) {
+	assert := assert.New(t)
+
+	fc := firecracker{}
+
+	driveID := fcDriveIndexToID(0)
+	_, err := fc.createJailedDrive(driveID)
+	assert.NoError(err)
 }
 
 func TestFcSetConfig(t *testing.T) {

--- a/src/runtime/virtcontainers/fc_test.go
+++ b/src/runtime/virtcontainers/fc_test.go
@@ -199,8 +199,7 @@ func TestFCGetTotalMemoryMB(t *testing.T) {
 	fc := firecracker{}
 	ctx := context.Background()
 
-	var initialMemSize uint32
-	initialMemSize = 1024
+	var initialMemSize uint32 = 1024
 
 	fc.config.MemorySize = 1024
 	memSize := fc.GetTotalMemoryMB(ctx)


### PR DESCRIPTION
Expanded tests on fc_test.go to cover more lines of code. Coverage went from 4.6% to 18.5%.

Fixes: #266