### PR TITLE
kata-ctl:  Add the option to install kata-ctl to a user specified directory

### DIFF
--- a/src/tools/kata-ctl/Makefile
+++ b/src/tools/kata-ctl/Makefile
@@ -10,6 +10,7 @@ PROJECT_URL = https://github.com/kata-containers
 PROJECT_COMPONENT = kata-ctl
 
 TARGET = $(PROJECT_COMPONENT)
+INSTALL_PATH = $(HOME)/.cargo
 
 VERSION_FILE := ./VERSION
 export VERSION := $(shell grep -v ^\# $(VERSION_FILE))
@@ -55,7 +56,7 @@ test:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo test --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES) -- --nocapture
 
 install:
-	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --locked --target $(TRIPLE) --path .
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --locked --target $(TRIPLE) --path . --root $(INSTALL_PATH)
 
 check: standard_rust_check
 

--- a/src/tools/kata-ctl/README.md
+++ b/src/tools/kata-ctl/README.md
@@ -27,6 +27,11 @@ $ make
 $ make install
 ```
 
+If you would like to install the tool to a specific directory, then you can provide it through the `INSTALL_PATH` variable.
+```bash
+$ make install INSTALL_PATH=/path/to/your/custom/install/directory
+```
+
 ## Run the tool
 
 ```bash


### PR DESCRIPTION
Fixes #5403 

The Makefile was updated to use an INSTALL_PATH variable to track where the kata-ctl binary should be installed.  If the user doesn't specify anything, then it uses the default path that cargo uses.  Otherwise, it will install it in the directory that the user specified.  The README.md file was also updated to show how to use the new option.

This work was done by pair programming by the following contributors: Cesar Tamayo
Kevin Mora Jimenez
Narendra Patel
Ray Karrenbauer
Srinath Duraisamy

Fixes #5403