### PR TITLE
agent: Add context to errors that may occur when AgentConfig file is …

### DIFF
--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -200,7 +200,7 @@ impl AgentConfig {
         let config_position = args.iter().position(|a| a == "--config" || a == "-c");
         if let Some(config_position) = config_position {
             if let Some(config_file) = args.get(config_position + 1) {
-                return AgentConfig::from_config_file(config_file);
+                return AgentConfig::from_config_file(config_file).context("AgentConfig from args");
             } else {
                 panic!("The config argument wasn't formed properly: {:?}", args);
             }
@@ -216,7 +216,8 @@ impl AgentConfig {
             // or if it can't be parsed properly.
             if param.starts_with(format!("{}=", CONFIG_FILE).as_str()) {
                 let config_file = get_string_value(param)?;
-                return AgentConfig::from_config_file(&config_file);
+                return AgentConfig::from_config_file(&config_file)
+                    .context("AgentConfig from kernel cmdline");
             }
 
             // parse cmdline flags
@@ -304,7 +305,8 @@ impl AgentConfig {
 
     #[instrument]
     pub fn from_config_file(file: &str) -> Result<AgentConfig> {
-        let config = fs::read_to_string(file)?;
+        let config = fs::read_to_string(file)
+            .with_context(|| format!("Failed to read config file {}", file))?;
         AgentConfig::from_str(&config)
     }
 


### PR DESCRIPTION
…missing

When the agent config file is missing, the panic message says "no such file or directory" but doesn't inform the user about which file was missing. Add context to the parsing (with filename) and to the from_config_file() calls (with information where the path is coming from).

Fixes: #6771