### PR TITLE
cache: Update the KERNEL_FLAVOUR list to include nvidia-gpu

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -22,9 +22,9 @@ jobs:
           - kernel-sev
           - kernel-dragonball-experimental
           - kernel-tdx-experimental
-          - kernel-gpu
-          - kernel-gpu-snp
-          - kernel-gpu-tdx-experimental
+          - kernel-nvidia-gpu
+          - kernel-nvidia-gpu-snp
+          - kernel-nvidia-gpu-tdx-experimental
           - nydus
           - ovmf
           - ovmf-sev

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -24,9 +24,9 @@ all-parallel: $(MK_DIR)/dockerbuild/install_yq.sh
 all: serial-targets \
 	firecracker-tarball \
 	kernel-dragonball-experimental-tarball \
-	kernel-gpu \
-	kernel-gpu-snp-tarball \
-	kernel-gpu-tdx-experimental-tarball \
+	kernel-nvidia-gpu \
+	kernel-nvidia-gpu-snp-tarball \
+	kernel-nvidia-gpu-tdx-experimental-tarball \
 	kernel-tarball \
 	kernel-tdx-experimental-tarball \
 	nydus-tarball \
@@ -61,13 +61,13 @@ kernel-dragonball-experimental-tarball:
 kernel-experimental-tarball:
 	${MAKE} $@-build
 
-kernel-gpu-tarball:
+kernel-nvidia-gpu-tarball:
 	${MAKE} $@-build
 
-kernel-gpu-snp-tarball:
+kernel-nvidia-gpu-snp-tarball:
 	${MAKE} $@-build
 
-kernel-gpu-tdx-experimental-tarball:
+kernel-nvidia-gpu-tdx-experimental-tarball:
 	${MAKE} $@-build	
 
 kernel-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -81,9 +81,9 @@ options:
 	kernel
 	kernel-dragonball-experimental
 	kernel-experimental
-	kernel-gpu
-	kernel-gpu-snp
-	kernel-gpu-tdx-experimental
+	kernel-nvidia-gpu
+	kernel-nvidia-gpu-snp
+	kernel-nvidia-gpu-tdx-experimental
 	kernel-sev-tarball
 	kernel-tdx-experimental
 	nydus
@@ -262,32 +262,32 @@ install_kernel_dragonball_experimental() {
 }
 
 #Install GPU enabled kernel asset
-install_kernel_gpu() {
+install_kernel_nvidia_gpu() {
 	local kernel_url="$(get_from_kata_deps assets.kernel.url)"
 
 	install_kernel_helper \
 		"assets.kernel.version" \
-		"kernel-gpu" \
+		"kernel-nvidia-gpu" \
 		"-g nvidia -u ${kernel_url} -H deb"
 }
 
 #Install GPU and SNP enabled kernel asset
-install_kernel_gpu_snp() {
+install_kernel_nvidia_gpu_snp() {
 	local kernel_url="$(get_from_kata_deps assets.kernel.snp.url)"
 
 	install_kernel_helper \
 		"assets.kernel.snp.version" \
-		"kernel-gpu-snp" \
+		"kernel-nvidia-gpu-snp" \
 		"-x snp -g nvidia -u ${kernel_url} -H deb"
 }
 
 #Install GPU and TDX experimental enabled kernel asset
-install_kernel_gpu_tdx_experimental() {
+install_kernel_nvidia_gpu_tdx_experimental() {
 	local kernel_url="$(get_from_kata_deps assets.kernel-tdx-experimental.url)"
 
 	install_kernel_helper \
 		"assets.kernel-tdx-experimental.version" \
-		"kernel-gpu-tdx" \
+		"kernel-nvidia-gpu-tdx" \
 		"-x tdx -g nvidia -u ${kernel_url} -H deb"
 }
 
@@ -553,11 +553,11 @@ handle_build() {
 
 	kernel-experimental) install_kernel_experimental ;;
 
-	kernel-gpu) install_kernel_gpu ;;
+	kernel-nvidia-gpu) install_kernel_nvidia_gpu ;;
 
-	kernel-gpu-snp) install_kernel_gpu_snp;;
+	kernel-nvidia-gpu-snp) install_kernel_nvidia_gpu_snp;;
 
-	kernel-gpu-tdx-experimental) install_kernel_gpu_tdx_experimental;;
+	kernel-nvidia-gpu-tdx-experimental) install_kernel_nvidia_gpu_tdx_experimental;;
 
 	kernel-tdx-experimental) install_kernel_tdx_experimental ;;
 

--- a/tools/packaging/static-build/cache_components_main.sh
+++ b/tools/packaging/static-build/cache_components_main.sh
@@ -12,7 +12,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "${script_dir}/../scripts/lib.sh"
 
-KERNEL_FLAVOUR="${KERNEL_FLAVOUR:-kernel}" # kernel | kernel-experimental | kernel-arm-experimental | kernel-dragonball-experimental | kernel-tdx-experimental
+KERNEL_FLAVOUR="${KERNEL_FLAVOUR:-kernel}" # kernel | kernel-nvidia-gpu | kernel-experimental | kernel-arm-experimental | kernel-dragonball-experimental | kernel-tdx-experimental | kernel-nvidia-gpu-tdx-experimental | kernel-nvidia-gpu-snp
 OVMF_FLAVOUR="${OVMF_FLAVOUR:-x86_64}" # x86_64 | tdx
 QEMU_FLAVOUR="${QEMU_FLAVOUR:-qemu}" # qemu | qemu-tdx-experimental | qemu-snp-experimental
 ROOTFS_IMAGE_TYPE="${ROOTFS_IMAGE_TYPE:-image}" # image | initrd
@@ -35,6 +35,19 @@ cache_kernel_artifacts() {
 	local current_kernel_kata_config_version="$(cat ${repo_root_dir}/tools/packaging/kernel/kata_config_version)"
 	local current_kernel_version="$(get_from_kata_deps "assets.${KERNEL_FLAVOUR}.version")"
 	local kernel_modules_tarball_path="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/kata-static-kernel-sev-modules.tar.xz"
+
+	# The ${vendor}-gpu kernels are based on an already existing entry, and does not require
+	# adding a new entry to the versions.yaml.
+	#
+	# With this in mind, let's just make sure we get the version from correct entry in the
+	# versions.yaml file.
+	case ${KERNEL_FLAVOUR} in
+		*"nvidia-gpu"*)
+			KERNEL_FLAVOUR=${KERNEL_FLAVOUR//"-nvidia-gpu"/}
+			;;
+		*)
+			;;
+	esac
 
 	if [[ "${KERNEL_FLAVOUR}" == "kernel-sev" ]]; then
 		current_kernel_version="$(get_from_kata_deps "assets.kernel.sev.version")"
@@ -130,7 +143,7 @@ Usage: $0 "[options]"
 		-c	Cloud hypervisor cache
 		-F	Firecracker cache
 		-k	Kernel cache
-			* Export KERNEL_FLAVOUR="kernel | kernel-experimental | kernel-arm-experimental | kernel-dragonball-experimental | kernel-tdx-experimental" for a specific build
+			* Export KERNEL_FLAVOUR="kernel | kernel-nvidia-gpu | kernel-experimental | kernel-arm-experimental | kernel-dragonball-experimental | kernel-tdx-experimental | kernel-nvidia-gpu-tdx-experimental | kernel-nvidia-gpu-snp" for a specific build
 			  The default KERNEL_FLAVOUR value is "kernel"
 		-n	Nydus cache
 		-q 	QEMU cache


### PR DESCRIPTION
We need to make sure that, when caching a `-nvidia-gpu` kernel, we still
look at the version of the base kernel used to build the nvidia-gpu
drivers, as the ${vendor}-gpu kernels are based on already existing
entries in the versions.yaml file and do not require a new entry to be
added.

Fixes: #6777 