### PR TITLE
ppc64le: switch virtiofsd from C to rust version

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -217,9 +217,6 @@ DEFSHAREDFS_QEMU_TDX_VIRTIOFS := virtio-9p
 DEFSHAREDFS_QEMU_SEV_VIRTIOFS := virtio-9p
 DEFSHAREDFS_QEMU_SNP_VIRTIOFS := virtio-9p
 DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/virtiofsd
-ifeq ($(ARCH),ppc64le)
-DEFVIRTIOFSDAEMON := $(LIBEXECDIR)/qemu/virtiofsd
-endif
 DEFVALIDVIRTIOFSDAEMONPATHS := [\"$(DEFVIRTIOFSDAEMON)\"]
 # Default DAX mapping cache size in MiB
 #if value is 0, DAX is not enabled

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -341,7 +341,7 @@ generate_qemu_options() {
 		qemu_options+=(functionality:--disable-virtiofsd)
 		;;
 	ppc64le)
-		qemu_options+=(functionality:--enable-virtiofsd)
+		qemu_options+=(functionality:--disable-virtiofsd)
 		;;
 	s390x)
 		qemu_options+=(functionality:--disable-virtiofsd)

--- a/versions.yaml
+++ b/versions.yaml
@@ -297,14 +297,14 @@ externals:
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"
     url: "https://gitlab.com/virtio-fs/virtiofsd"
-    version: "v1.3.0"
-    toolchain: "1.62.0"
+    version: "v1.6.1"
+    toolchain: "1.66.0"
     meta:
-      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.3.0,
-      # this is the link labelled virtiofsd-v1.3.0.zip
+      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.6.1,
+      # this is the link labelled virtiofsd-v1.6.1.zip
       #
       # yamllint disable-line rule:line-length
-      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/9a4f2261fcb1701f1e709694b5c5d980/virtiofsd-v1.3.0.zip"
+      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/14c1e8a7acc82d515cec6608727a1e4a/virtiofsd-v1.6.1.zip"
 
 languages:
   description: |


### PR DESCRIPTION
We have been using the C version of virtiofsd on ppc64le. Now that the issues with rust virtiofsd have been fixed, let's switch to it.

Fixes: #4259