### PR TITLE
docs: Mark snap installation method as unmaintained

### DIFF
--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -19,7 +19,7 @@ Packaged installation methods uses your distribution's native package format (su
 |------------------------------------------------------|----------------------------------------------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------------------|
 | [Using kata-deploy](#kata-deploy-installation)       | The preferred way to deploy the Kata Containers distributed binaries on a Kubernetes cluster | **No!**           | Best way to give it a try on kata-containers on an already up and running Kubernetes cluster. | 
 | [Using official distro packages](#official-packages) | Kata packages provided by Linux distributions official repositories                          | yes               | Recommended for most users.                                                                   |
-| [Using snap](#snap-installation)                     | Easy to install                                                                              | yes               | Good alternative to official distro packages.                                                 |
+| ~~[Using snap](#snap-installation)~~                     | ~~Easy to install~~                                                                              | ~~yes~~               | **Snap is unmaintained!** ~~Good alternative to official distro packages.~~                                                 |
 | [Automatic](#automatic-installation)                 | Run a single command to install a full system                                                | **No!**           | For those wanting the latest release quickly.                                                 |
 | [Manual](#manual-installation)                       | Follow a guide step-by-step to install a working system                                      | **No!**           | For those who want the latest release with more control.                                      |
 | [Build from source](#build-from-source-installation) | Build the software components manually                                                       | **No!**           | Power users and developers only.                                                              |
@@ -44,9 +44,24 @@ Kata packages are provided by official distribution repositories for:
 
 ### Snap Installation
 
-The snap installation is available for all distributions which support `snapd`.
+> **WARNING:**
+>
+> The Snap package method is **unmaintained** and only provides an old
+> version of Kata Containers:
+> The [latest Kata Containers snap](https://snapcraft.io/kata-containers)
+> provides Kata Containers
+> [version 2.4.2](https://github.com/kata-containers/kata-containers/releases/tag/2.4.2)
+> but the latest stable Kata Containers release at the time of writing is
+> [version 3.1.0](https://github.com/kata-containers/kata-containers/releases/tag/3.1.0).
+>
+> We recommend strongly that you switch to an alternative Kata Containers installation method.
+>
+> See: https://github.com/kata-containers/kata-containers/issues/6769
+> for further details.
 
-[Use snap](snap-installation-guide.md) to install Kata Containers from https://snapcraft.io.
+~~The snap installation is available for all distributions which support `snapd`.~~
+
+~~[Use snap](snap-installation-guide.md) to install Kata Containers from https://snapcraft.io. ~~
 
 ### Automatic Installation
 

--- a/docs/install/snap-installation-guide.md
+++ b/docs/install/snap-installation-guide.md
@@ -1,11 +1,41 @@
 # Kata Containers snap package
 
+> **WARNING:**
+>
+> The Snap package method is **unmaintained** and only provides an old
+> version of Kata Containers:
+> The [latest Kata Containers snap](https://snapcraft.io/kata-containers)
+> provides Kata Containers
+> [version 2.4.2](https://github.com/kata-containers/kata-containers/releases/tag/2.4.2)
+> but the latest stable Kata Containers release at the time of writing is
+> [version 3.1.0](https://github.com/kata-containers/kata-containers/releases/tag/3.1.0).
+>
+> We recommend strongly that you switch to an alternative Kata Containers installation method.
+>
+> See: https://github.com/kata-containers/kata-containers/issues/6769
+> for further details.
+
 ## Install Kata Containers
 
 Kata Containers can be installed in any Linux distribution that supports
 [snapd](https://docs.snapcraft.io/installing-snapd).
 
 Run the following command to install **Kata Containers**:
+
+> **WARNING:**
+>
+> The Snap package method is **unmaintained** and only provides an old
+> version of Kata Containers:
+> The [latest Kata Containers snap](https://snapcraft.io/kata-containers)
+> provides Kata Containers
+> [version 2.4.2](https://github.com/kata-containers/kata-containers/releases/tag/2.4.2)
+> but the latest stable Kata Containers release at the time of writing is
+> [version 3.1.0](https://github.com/kata-containers/kata-containers/releases/tag/3.1.0).
+>
+> We recommend strongly that you switch to an alternative Kata Containers installation method.
+>
+> See: https://github.com/kata-containers/kata-containers/issues/6769
+> for further details.
 
 ```sh
 $ sudo snap install kata-containers --stable --classic


### PR DESCRIPTION
The snap package is no longer being maintained so update the docs to warn readers.

We'll remove the snap installation docs in a few weeks.

See: #6769.
Fixes: #6793.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>