### PR TITLE
shim: do not return error if deleting already removed sandbox

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/errors.go
+++ b/src/runtime/pkg/containerd-shim-v2/errors.go
@@ -58,7 +58,8 @@ func isInvalidArgument(err error) bool {
 
 func isNotFound(err error) bool {
 	return err == vc.ErrNoSuchContainer || err == syscall.ENOENT ||
-		strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "not exist")
+		strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "not exist") ||
+		strings.Contains(err.Error(), "no such file or directory")
 }
 
 func isGRPCErrorCode(code codes.Code, err error) bool {

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -331,6 +331,11 @@ func (s *service) Cleanup(ctx context.Context) (_ *taskAPI.DeleteResponse, err e
 	logrus.SetOutput(os.Stderr)
 
 	defer func() {
+		// if sandbox/container is not found in path
+		// it means that it is already deleted
+		if err != nil && isNotFound(err) {
+			err = nil
+		}
 		err = toGRPC(err)
 	}()
 
@@ -498,6 +503,11 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 
 	start := time.Now()
 	defer func() {
+		// if sandbox/container is not found in path
+		// it means that it is already deleted
+		if err != nil && isNotFound(err) {
+			err = nil
+		}
 		err = toGRPC(err)
 		rpcDurationsHistogram.WithLabelValues("delete").Observe(float64(time.Since(start).Nanoseconds() / int64(time.Millisecond)))
 	}()
@@ -769,6 +779,11 @@ func (s *service) Kill(ctx context.Context, r *taskAPI.KillRequest) (_ *ptypes.E
 
 	start := time.Now()
 	defer func() {
+		// if sandbox/container is not found in path
+		// it means that it is already deleted
+		if err != nil && isNotFound(err) {
+			err = nil
+		}
 		err = toGRPC(err)
 		rpcDurationsHistogram.WithLabelValues("kill").Observe(float64(time.Since(start).Nanoseconds() / int64(time.Millisecond)))
 	}()


### PR DESCRIPTION
If the sandbox doesn't exist, let's just return 0 rather than throwing an error back to the caller.

 Fixes: 6796