### PR TITLE
kata-ctl: Check for vm capability

### DIFF
--- a/src/tools/kata-ctl/src/arch/aarch64/mod.rs
+++ b/src/tools/kata-ctl/src/arch/aarch64/mod.rs
@@ -80,6 +80,11 @@ mod arch_specific {
         Some(CHECK_LIST)
     }
 
+    pub fn host_is_vmcontainer_capable() -> Result<bool> {
+        // TODO: Not implemented
+        Ok(true)
+    }
+
     #[allow(dead_code)]
     // Guest protection is not supported on ARM64.
     pub fn available_guest_protection() -> Result<check::GuestProtection, check::ProtectionError> {

--- a/src/tools/kata-ctl/src/arch/powerpc64le/mod.rs
+++ b/src/tools/kata-ctl/src/arch/powerpc64le/mod.rs
@@ -33,6 +33,11 @@ mod arch_specific {
         // to the goloang implementation of function getCPUDetails()
     }
 
+    pub fn host_is_vmcontainer_capable() -> Result<bool> {
+        // TODO: Not implemented
+        Ok(true)
+    }
+
     pub fn available_guest_protection() -> Result<check::GuestProtection, check::ProtectionError> {
         if !Uid::effective().is_root() {
             return Err(check::ProtectionError::NoPerms);

--- a/src/tools/kata-ctl/src/arch/s390x/mod.rs
+++ b/src/tools/kata-ctl/src/arch/s390x/mod.rs
@@ -78,6 +78,21 @@ mod arch_specific {
         Some(CHECK_LIST)
     }
 
+    pub fn host_is_vmcontainer_capable() -> Result<bool> {
+        let mut count = 0;
+        if check_cpu().is_err() {
+            count += 1;
+        };
+
+        // TODO: Add additional checks for kernel modules
+
+        if count == 0 {
+            return Ok(true);
+        };
+
+        Err(anyhow!("System is not capable of running a VM"))
+    }
+
     #[allow(dead_code)]
     fn retrieve_cpu_facilities() -> Result<HashMap<i32, bool>> {
         let f = std::fs::File::open(check::PROC_CPUINFO)?;

--- a/src/tools/kata-ctl/src/arch/x86_64/mod.rs
+++ b/src/tools/kata-ctl/src/arch/x86_64/mod.rs
@@ -343,6 +343,23 @@ mod arch_specific {
         }
         Ok(())
     }
+
+    pub fn host_is_vmcontainer_capable() -> Result<bool> {
+        let mut count = 0;
+        if check_cpu("check_cpu").is_err() {
+            count += 1;
+        };
+
+        if check_kernel_modules("check_modules").is_err() {
+            count += 1;
+        };
+
+        if count == 0 {
+            return Ok(true);
+        };
+
+        Err(anyhow!("System is not capable of running a VM"))
+    }
 }
 
 #[cfg(target_arch = "x86_64")]

--- a/src/tools/kata-ctl/src/arch/x86_64/mod.rs
+++ b/src/tools/kata-ctl/src/arch/x86_64/mod.rs
@@ -238,13 +238,9 @@ mod arch_specific {
 
         let running_on_vmm_alt = running_on_vmm()?;
 
+        // Kernel param "unrestricted_guest" is not required when running under a hypervisor
         if running_on_vmm_alt {
-            let msg = format!("You are running in a VM, where the kernel module '{}' parameter '{:}' has a value '{:}'. This causes conflict when running kata.",
-                module,
-                param_name,
-                param_value_host
-            );
-            return Err(anyhow!(msg));
+            return Ok(());
         }
 
         if param_value_host == expected_param_value.to_string() {

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -5,7 +5,9 @@
 
 // Contains checks that are not architecture-specific
 
+#[cfg(any(target_arch = "x86_64"))]
 use crate::types::KernelModule;
+
 use anyhow::{anyhow, Result};
 use nix::fcntl::{open, OFlag};
 use nix::sys::stat::Mode;
@@ -393,6 +395,7 @@ pub fn check_kernel_module_loaded(kernel_module: &KernelModule) -> Result<(), St
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(any(target_arch = "x86_64"))]
     use crate::types::{KernelModule, KernelParam, KernelParamType};
     use semver::Version;
     use slog::warn;

--- a/src/tools/kata-ctl/src/ops/env_ops.rs
+++ b/src/tools/kata-ctl/src/ops/env_ops.rs
@@ -255,6 +255,12 @@ fn get_host_info() -> Result<HostInfo> {
 
     let guest_protection = guest_protection.to_string();
 
+    let mut vm_container_capable = true;
+
+    if arch_specific::host_is_vmcontainer_capable().is_err() {
+        vm_container_capable = false;
+    }
+
     let support_vsocks = utils::supports_vsocks(utils::VHOST_VSOCK_DEVICE)?;
 
     Ok(HostInfo {
@@ -264,8 +270,7 @@ fn get_host_info() -> Result<HostInfo> {
         cpu: host_cpu,
         memory: memory_info,
         available_guest_protection: guest_protection,
-        // TODO: See https://github.com/kata-containers/kata-containers/issues/6727
-        vm_container_capable: true,
+        vm_container_capable,
         support_vsocks,
     })
 }

--- a/src/tools/kata-ctl/src/types.rs
+++ b/src/tools/kata-ctl/src/types.rs
@@ -69,5 +69,5 @@ pub struct KernelParam<'a> {
 #[allow(dead_code)]
 pub struct KernelModule<'a> {
     pub name: &'a str,
-    pub parameter: KernelParam<'a>,
+    pub params: &'a [KernelParam<'a>],
 }


### PR DESCRIPTION
Implement functionality to add to the env output if the host is capable
of running a VM.
    
Fixes: #6727

 Adding vhost and vhost-net to the kernel modules. These do not require
 any kernel module parameters to be checked. Currently, kernel params is
 a required field. Make this as optional. Could make this as <Option>,
 but making this a slice instead, as a module could have multiple kernel
 params. Refactor the function that checks are for kernel modules into
 two with one specifically checking if the module is loaded and other
 checking for module parameters.