### PR TITLE
libs/protocols: remove useless cfg

### DIFF
--- a/src/libs/protocols/src/serde_config.rs
+++ b/src/libs/protocols/src/serde_config.rs
@@ -6,7 +6,6 @@
 use protobuf::{EnumOrUnknown, MessageField};
 use serde::{Deserialize, Serialize};
 
-#[cfg(feature = "with-serde")]
 pub fn serialize_enum_or_unknown<E: protobuf::EnumFull, S: serde::Serializer>(
     e: &protobuf::EnumOrUnknown<E>,
     s: S,


### PR DESCRIPTION
Since the file is imported under conditional compilation, the same conditional compilation sentence in the file is redundant.

Fixes: #6646