### PR TITLE
gha: Add a skeleton for the VFIO job

### DIFF
--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -20,6 +20,23 @@ jobs:
       tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-amd64
     secrets: inherit
 
+  run-vfio-tests:
+    needs: build-kata-static-tarball-amd64
+    runs-on: vfio
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Get kata-static-tarnall-amd64 artefact
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-static-tarball-amd64-${{ github.event.pull_request.number}}-${{ github.event.pull_request.head.sha }}
+
+      - name: Run VFIO tests
+        run: |
+          ./tests/vfio/run.sh
+
   run-k8s-tests-on-aks:
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-k8s-tests-on-aks.yaml

--- a/tests/vfio/run.sh
+++ b/tests/vfio/run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+main() {
+	echo "Test not yet implemented, skipping it!"
+}
+
+main $@


### PR DESCRIPTION
As the very first step to migrate the VFIO test job from Jenkins to GitHub Actions, let's just create a very basic skeleton for the job, which will do nothing and always pass.

Once this is merged, we can start working on the `tests/vfio/run.sh` script, which then will be responsible for performing the tests, and we'll be targetting a 1:1, bug-by-bug, implementation, when compared to the one used in jenkins.

Fixes: #6555