### PR TITLE
cache: More fixes to nvidia-gpu kernels caching

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -287,7 +287,7 @@ install_kernel_nvidia_gpu_tdx_experimental() {
 
 	install_kernel_helper \
 		"assets.kernel-tdx-experimental.version" \
-		"kernel-nvidia-gpu-tdx" \
+		"kernel-nvidia-gpu-tdx-experimental" \
 		"-x tdx -g nvidia -u ${kernel_url} -H deb"
 }
 

--- a/tools/packaging/static-build/cache_components_main.sh
+++ b/tools/packaging/static-build/cache_components_main.sh
@@ -48,10 +48,16 @@ cache_kernel_artifacts() {
 			;;
 	esac
 
-	local current_kernel_version="$(get_from_kata_deps "assets.${KERNEL_FLAVOUR}.version")"
-	if [[ "${KERNEL_FLAVOUR}" == "kernel-sev" ]]; then
-		current_kernel_version="$(get_from_kata_deps "assets.kernel.sev.version")"
-	fi
+	case ${KERNEL_FLAVOUR} in
+		"kernel-sev"|"kernel-snp")
+			# In these cases, like "kernel-foo", it must be set to "kernel.foo" when looking at
+			# the versions.yaml file
+			current_kernel_version="$(get_from_kata_deps "assets.${KERNEL_FLAVOUR/-/.}.version")"
+			;;
+		*)
+			current_kernel_version="$(get_from_kata_deps "assets.${KERNEL_FLAVOUR}.version")"
+			;;
+	esac
 
 	create_cache_asset "${kernel_tarball_name}" "${current_kernel_version}-${current_kernel_kata_config_version}" "${current_kernel_image}"
 	if [[ "${KERNEL_FLAVOUR}" == "kernel-sev" ]]; then


### PR DESCRIPTION
---

cache: Fix nvidia-gpu-tdx-experimental cache URL

We were passing "kernel-nvidia-gpu-tdx", missing the "-experimental"
part, leading to a non-valid URL.

---

cache: Fix nvidia-snp caching version

All the kernel-foo instances, such as "kernel-sev" or "kernel-snp",
should be transformed into "kernel.foo" when looking at the
versions.yaml file.

This was already done for SEV, but missed on the SNP case.

Fixes: #6777 

---