### PR TITLE
Revert "kata-deploy: Use readinessProbe to ensure everything is ready"

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -21,9 +21,6 @@ spec:
         image: quay.io/kata-containers/kata-deploy:latest
         imagePullPolicy: Always
         command: [ "bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh reset" ]
-        readinessProbe:
-          exec:
-            command: [ "bash", "-c", "[ -f /opt/kata/kata-deployed ]", "&&", "bash", "-c", "[ $? == 1 ]" ]
         env:
         - name: NODE_NAME
           valueFrom:

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -18,9 +18,6 @@ spec:
       - name: kube-kata
         image: quay.io/kata-containers/kata-deploy:latest
         imagePullPolicy: Always
-        readinessProbe:
-          exec:
-            command: [ "bash", "-c", "[ -f /opt/kata/kata-deployed ]", "&&", "bash", "-c", "[ $? == 0 ]" ]
         lifecycle:
           preStop:
             exec:

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -325,13 +325,11 @@ function main() {
 			install_artifacts
 			configure_cri_runtime "$runtime"
 			kubectl label node "$NODE_NAME" --overwrite katacontainers.io/kata-runtime=true
-			touch /opt/kata/kata-deployed
 			;;
 		cleanup)
 			cleanup_cri_runtime "$runtime"
 			kubectl label node "$NODE_NAME" --overwrite katacontainers.io/kata-runtime=cleanup
 			remove_artifacts
-			rm /opt/kata/kata-deployed
 			;;
 		reset)
 			reset_runtime $runtime


### PR DESCRIPTION
This reverts commit 5ec9ae0f0498b7366fc85ed1448d36e3c9b6ac35, for two main reasons:
* The readinessProbe was misintepreted by myself when working on the original PR
* It's actually causing issues, as the pod ends up marked as not healthy.