### PR TITLE
kata-manager: Fix '-o' syntax and logic error

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -262,7 +262,7 @@ pre_checks()
 	command -v "${kata_shim_v2}" &>/dev/null \
 		&& die "Please remove existing $kata_project installation"
 
-	[skip_containerd = "false" ] && return 0
+	[ "$skip_containerd" = 'true' ] && return 0
 
 	local ret
 


### PR DESCRIPTION
Fix the syntax and logic error that is only displayed if the user runs the script with `-o`. This option requests that "only" Kata Containers is installed and stops containerd from being installed.

Fixes: #6822.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>