### PR TITLE
kata-deploy: Build improvements

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -436,6 +436,8 @@ install_virtiofsd() {
 
 # Install static nydus asset
 install_nydus() {
+	[ "${ARCH}" == "aarch64" ] && ARCH=arm64
+
 	install_cached_tarball_component \
 		"nydus" \
 		"${jenkins_url}/job/kata-containers-main-nydus-$(uname -m)/${cached_artifacts_path}" \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -377,10 +377,12 @@ install_qemu_snp_experimental() {
 
 # Install static firecracker asset
 install_firecracker() {
+	local firecracker_version=$(get_from_kata_deps "assets.hypervisor.firecracker.version")
+
 	install_cached_tarball_component \
 		"firecracker" \
 		"${jenkins_url}/job/kata-containers-main-firecracker-$(uname -m)/${cached_artifacts_path}" \
-		"$(get_from_kata_deps "assets.hypervisor.firecracker.version")" \
+		"${firecracker_version}" \
 		"" \
 		"${final_tarball_name}" \
 		"${final_tarball_path}" \
@@ -390,8 +392,8 @@ install_firecracker() {
 	"${firecracker_builder}"
 	info "Install static firecracker"
 	mkdir -p "${destdir}/opt/kata/bin/"
-	sudo install -D --owner root --group root --mode 0744 firecracker/firecracker-static "${destdir}/opt/kata/bin/firecracker"
-	sudo install -D --owner root --group root --mode 0744 firecracker/jailer-static "${destdir}/opt/kata/bin/jailer"
+	sudo install -D --owner root --group root --mode 0744 release-${firecracker_version}-${ARCH}/firecracker-${firecracker_version}-${ARCH} "${destdir}/opt/kata/bin/firecracker"
+	sudo install -D --owner root --group root --mode 0744 release-${firecracker_version}-${ARCH}/jailer-${firecracker_version}-${ARCH} "${destdir}/opt/kata/bin/jailer"
 }
 
 # Install static cloud-hypervisor asset

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -44,6 +44,9 @@ pull_clh_released_binary() {
 	info "Download cloud-hypervisor version: ${cloud_hypervisor_version}"
 	cloud_hypervisor_binary="https://github.com/cloud-hypervisor/cloud-hypervisor/releases/download/${cloud_hypervisor_version}/cloud-hypervisor-static"
 
+	[ "${ARCH}" == "aarch64" ] && \
+		cloud_hypervisor_binary="${cloud_hypervisor_binary}-aarch64"
+
 	curl --fail -L ${cloud_hypervisor_binary} -o cloud-hypervisor-static || return 1
 	mkdir -p cloud-hypervisor
 	mv -f cloud-hypervisor-static cloud-hypervisor/cloud-hypervisor
@@ -81,11 +84,6 @@ build_clh_from_source() {
 	cp build/cargo_target/$(uname -m)-unknown-linux-musl/release/cloud-hypervisor .
 	popd
 }
-
-if [ "${ARCH}" == "aarch64" ]; then
-	info "aarch64 binaries are not distributed as part of the Cloud Hypervisor releases, forcing to build from source"
-	force_build_from_source="true"
-fi
 
 if [ -n "${features}" ]; then
 	info "As an extra build argument has been passed to the script, forcing to build from source"

--- a/tools/packaging/static-build/firecracker/build-static-firecracker.sh
+++ b/tools/packaging/static-build/firecracker/build-static-firecracker.sh
@@ -14,30 +14,31 @@ source "${script_dir}/../../scripts/lib.sh"
 
 config_dir="${script_dir}/../../scripts/"
 
-firecracker_repo="${firecracker_repo:-}"
+firecracker_url="${firecracker_url:-}"
 firecracker_dir="firecracker"
 firecracker_version="${firecracker_version:-}"
 
 arch=$(uname -m)
 
-if [ -z "$firecracker_repo" ]; then
-	info "Get firecracker information from runtime versions.yaml"
-	firecracker_url=$(get_from_kata_deps "assets.hypervisor.firecracker.url")
-	[ -n "$firecracker_url" ] || die "failed to get firecracker url"
-	firecracker_repo="${firecracker_url}.git"
-fi
-[ -n "$firecracker_repo" ] || die "failed to get firecracker repo"
+[ -n "$firecracker_url" ] ||firecracker_url=$(get_from_kata_deps "assets.hypervisor.firecracker.url")
+[ -n "$firecracker_url" ] || die "failed to get firecracker url"
 
 [ -n "$firecracker_version" ] || firecracker_version=$(get_from_kata_deps "assets.hypervisor.firecracker.version")
 [ -n "$firecracker_version" ] || die "failed to get firecracker version"
 
-info "Build ${firecracker_repo} version: ${firecracker_version}"
+firecracker_tarball_url="${firecracker_url}/releases/download"
 
-[ -d "${firecracker_dir}" ] || git clone ${firecracker_repo}
-cd "${firecracker_dir}"
-git fetch
-git checkout ${firecracker_version}
-sudo ./tools/devtool --unattended build --release
+file_name="firecracker-${firecracker_version}-${ARCH}.tgz"
+download_url="${firecracker_tarball_url}/${firecracker_version}/${file_name}"
 
-ln -sf ./build/cargo_target/${arch}-unknown-linux-musl/release/firecracker ./firecracker-static
-ln -sf ./build/cargo_target/${arch}-unknown-linux-musl/release/jailer ./jailer-static
+info "Download firecracker version: ${firecracker_version} from ${download_url}"
+curl -o ${file_name} -L $download_url
+
+sha256sum="${file_name}.sha256.txt"
+sha256sum_url="${firecracker_tarball_url}/${firecracker_version}/${sha256sum}"
+
+info "Download firecracker ${sha256sum} from ${sha256sum_url}"
+curl -o ${sha256sum} -L $sha256sum_url
+
+sha256sum -c ${sha256sum}
+tar zxvf ${file_name}


### PR DESCRIPTION
Let's start downloading, instead of building, the binaries for Cloud Hypervisor (aarch64) and Firecracker.

As we're here, we've also fixed the nydus package download for aarch64.

Fixes: #6770 