### PR TITLE
kata-deploy: Do not ship the kata tarball

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -24,6 +24,7 @@ apt-get update && \
 apt-get install -y --no-install-recommends kubectl && \
 apt-get clean && rm -rf /var/lib/apt/lists/ && \
 mkdir -p ${DESTINATION} && \
-tar xvf ${KATA_ARTIFACTS} -C ${DESTINATION}
+tar xvf ${WORKDIR}/${KATA_ARTIFACTS} -C ${DESTINATION} && \
+rm -f ${WORKDIR}/${KATA_ARTIFACTS}
 
 COPY scripts ${DESTINATION}/scripts


### PR DESCRIPTION
There's absolutely no reason to ship the kata-static tarball as part of the payload image, as:
* The tarball is already part of the release process
* The payload image already has uncompressed content of the tarball
* The tarball itself is not used anywhere by the kata-deploy scripts

Fixes: #6828