### PR TITLE
deploy: Fix arch in image tag

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -15,7 +15,9 @@ cp ${KATA_DEPLOY_ARTIFACT} ${KATA_DEPLOY_DIR}
 
 pushd ${KATA_DEPLOY_DIR}
 
-IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-$(uname -m)"
+local arch=$(uname -m)
+[ "$arch" = "x86_64" ] && arch="amd64"
+IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-${arch}"
 
 echo "Building the image"
 docker build --tag ${IMAGE_TAG} .


### PR DESCRIPTION
`uname -m` produces `x86_64`, but container image convention is to use `amd64`, so update this in the tag

Fixes: #6820
Signed-off-by: stevenhorsman <steven@uk.ibm.com>
(cherry picked from commit 2856d3f23dfb7b844244e006c270fe244c80e81e)