### PR TITLE
resource-control: fix setting CPU affinities on Linux

### DIFF
--- a/src/runtime/pkg/resourcecontrol/utils_linux.go
+++ b/src/runtime/pkg/resourcecontrol/utils_linux.go
@@ -156,7 +156,7 @@ func IsCgroupV1() (bool, error) {
 func SetThreadAffinity(threadID int, cpuSetSlice []int) error {
 	unixCPUSet := unix.CPUSet{}
 
-	for cpuId := range cpuSetSlice {
+	for _, cpuId := range cpuSetSlice {
 		unixCPUSet.Set(cpuId)
 	}
 


### PR DESCRIPTION
With this fix the vCPU pinning feature chooses the correct physical cores to pin the vCPU threads on rather than always using core 0.

Fixes #6831