### PR TITLE
runtime: use enable_vcpus_pinning from toml

### DIFF
--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -963,6 +963,8 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid st
 
 		DisableGuestSeccomp: runtime.DisableGuestSeccomp,
 
+		EnableVCPUsPinning: runtime.EnableVCPUsPinning,
+
 		GuestSeLinuxLabel: runtime.GuestSeLinuxLabel,
 
 		Experimental: runtime.Experimental,


### PR DESCRIPTION
Set the default value of runtime's EnableVCPUsPinning to value read from .toml.

Fixes: #6836