### PR TITLE
tests: Enable running k8s tests on Mariner

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -19,8 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stage:
-          - ${{ inputs.stage }}
         asset:
           - cloud-hypervisor
           - cloud-hypervisor-glibc
@@ -46,9 +44,11 @@ jobs:
           - shim-v2
           - tdvf
           - virtiofsd
+        stage:
+          - ${{ inputs.stage }}
         exclude:
-          - stage: release
-            asset: cloud-hypervisor-glibc
+          - asset: cloud-hypervisor-glibc
+            stage: release
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}

--- a/tests/integration/gha-run.sh
+++ b/tests/integration/gha-run.sh
@@ -68,8 +68,10 @@ function run_tests() {
     ensure_yq
 
     sed -i -e "s|quay.io/kata-containers/kata-deploy:latest|${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}|g" "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
-    yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[+].name' "HOST_OS"
-    yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[-1].value' "${KATA_HOST_OS}"
+    if [ "${KATA_HOST_OS}" = "cbl-mariner" ]; then
+        yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[+].name' "HOST_OS"
+        yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[-1].value' "${KATA_HOST_OS}"
+    fi
     cat "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
     cat "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" | grep "${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}" || die "Failed to setup the tests image"
 
@@ -131,6 +133,8 @@ function delete_cluster() {
 }
 
 function main() {
+    export KATA_HOST_OS="${KATA_HOST_OS:-}"
+
     action="${1:-}"
 
     case "${action}" in

--- a/tests/integration/gha-run.sh
+++ b/tests/integration/gha-run.sh
@@ -38,7 +38,7 @@ function create_cluster() {
         -s "Standard_D4s_v5" \
         --node-count 1 \
         --generate-ssh-keys \
-        $([ "${KATA_HOST_OS}" = "cbl-mariner" ] && echo "--os-sku mariner --workload-runtime KataMshvVmIsolation")
+        $([ "${KATA_HOST_OS}" = "cbl-mariner" ] && echo "--os-sku AzureLinux --workload-runtime KataMshvVmIsolation")
 }
 
 function install_bats() {

--- a/tests/integration/gha-run.sh
+++ b/tests/integration/gha-run.sh
@@ -56,10 +56,16 @@ function get_cluster_credentials() {
         -n "$(_print_cluster_name)"
 }
 
-function run_tests() {
-    INSTALL_IN_GOPATH=false bash "${repo_root_dir}/ci/install_yq.sh"
+function ensure_yq() {
+    : "${GOPATH:=${GITHUB_WORKSPACE}}"
+    export GOPATH
+    export PATH="${GOPATH}/bin:${PATH}"
+    INSTALL_IN_GOPATH=true "${repo_root_dir}/ci/install_yq.sh"
+}
 
+function run_tests() {
     platform="${1}"
+    ensure_yq
 
     sed -i -e "s|quay.io/kata-containers/kata-deploy:latest|${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}|g" "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
     yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[+].name' "HOST_OS"

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -54,10 +54,6 @@ else
 	)
 fi
 
-if [ ${KATA_HOST_OS} == "cbl-mariner" ]; then
-	exit 0
-fi
-
 # we may need to skip a few test cases when running on non-x86_64 arch
 arch_config_file="${kubernetes_dir}/filter_out_per_arch/${TARGET_ARCH}.yaml"
 if [ -f "${arch_config_file}" ]; then

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -14,6 +14,13 @@ set_runtime_class() {
     sed -i -e "s|runtimeClassName: kata|runtimeClassName: kata-${KATA_HYPERVISOR}|" ${kubernetes_dir}/runtimeclass_workloads/*.yaml
 }
 
+set_kernel_path() {
+    if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
+        mariner_kernel_path="/usr/share/cloud-hypervisor/vmlinux.bin"
+        find ${kubernetes_dir}/runtimeclass_workloads/*.yaml -exec yq write -i {} 'metadata.annotations[io.katacontainers.config.hypervisor.kernel]' "${mariner_kernel_path}" \;
+    fi
+}
+
 set_initrd_path() {
     if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
         initrd_path="/opt/kata/share/kata-containers/kata-containers-initrd-cbl-mariner.img"
@@ -24,6 +31,7 @@ set_initrd_path() {
 main() {
     INSTALL_IN_GOPATH=false bash "${repo_root_dir}/ci/install_yq.sh"
     set_runtime_class
+    set_kernel_path
     set_initrd_path
 }
 

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -8,13 +8,23 @@ set -o nounset
 set -o pipefail
 
 kubernetes_dir=$(dirname "$(readlink -f "$0")")
+repo_root_dir="$(cd "${kubernetes_dir}/../../../" && pwd)"
 
 set_runtime_class() {
     sed -i -e "s|runtimeClassName: kata|runtimeClassName: kata-${KATA_HYPERVISOR}|" ${kubernetes_dir}/runtimeclass_workloads/*.yaml
 }
 
+set_initrd_path() {
+    if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
+        initrd_path="/opt/kata/share/kata-containers/kata-containers-initrd-cbl-mariner.img"
+        find ${kubernetes_dir}/runtimeclass_workloads/*.yaml -exec yq write -i {} 'metadata.annotations[io.katacontainers.config.hypervisor.initrd]' "${initrd_path}" \;
+    fi
+}
+
 main() {
+    INSTALL_IN_GOPATH=false bash "${repo_root_dir}/ci/install_yq.sh"
     set_runtime_class
+    set_initrd_path
 }
 
 main "$@"

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -29,7 +29,6 @@ set_initrd_path() {
 }
 
 main() {
-    INSTALL_IN_GOPATH=false bash "${repo_root_dir}/ci/install_yq.sh"
     set_runtime_class
     set_kernel_path
     set_initrd_path

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -65,6 +65,7 @@ docker run \
 	--env TDSHIM_CONTAINER_BUILDER="${TDSHIM_CONTAINER_BUILDER:-}" \
 	--env VIRTIOFSD_CONTAINER_BUILDER="${VIRTIOFSD_CONTAINER_BUILDER:-}" \
 	--env MEASURED_ROOTFS="${MEASURED_ROOTFS:-}" \
+	--env USE_CACHE="${USE_CACHE:-}" \
 	--rm \
 	-w ${script_dir} \
 	build-kata-deploy "${kata_deploy_create}" $@

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -40,6 +40,7 @@ readonly cached_artifacts_path="lastSuccessfulBuild/artifact/artifacts"
 
 ARCH=$(uname -m)
 MEASURED_ROOTFS=${MEASURED_ROOTFS:-no}
+USE_CACHE="${USE_CACHE:-"yes"}"
 
 workdir="${WORKDIR:-$PWD}"
 
@@ -115,6 +116,10 @@ cleanup_and_fail() {
 }
 
 install_cached_tarball_component() {
+	if [ "${USE_CACHE}" != "yes" ]; then
+		return 1
+	fi
+
 	local component="${1}"
 	local jenkins_build_url="${2}"
 	local current_version="${3}"

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -64,6 +64,11 @@ function install_artifacts() {
 	chmod +x /opt/kata/bin/*
 	[ -d /opt/kata/runtime-rs/bin ] && \
 		chmod +x /opt/kata/runtime-rs/bin/*
+
+	# Allow Mariner to specify a Mariner guest initrd.
+	if [ "${HOST_OS:-}" == "cbl-mariner" ]; then
+		sed -i -E 's|(enable_annotations) = .+|\1 = ["enable_iommu", "initrd"]|' /opt/kata/share/defaults/kata-containers/configuration-clh.toml
+	fi
 }
 
 function wait_till_node_is_ready() {

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -65,9 +65,9 @@ function install_artifacts() {
 	[ -d /opt/kata/runtime-rs/bin ] && \
 		chmod +x /opt/kata/runtime-rs/bin/*
 
-	# Allow Mariner to specify a Mariner guest initrd.
+	# Allow Mariner to use custom configuration.
 	if [ "${HOST_OS:-}" == "cbl-mariner" ]; then
-		sed -i -E 's|(enable_annotations) = .+|\1 = ["enable_iommu", "initrd"]|' /opt/kata/share/defaults/kata-containers/configuration-clh.toml
+		sed -i -E 's|(enable_annotations) = .+|\1 = ["enable_iommu", "initrd", "kernel"]|' /opt/kata/share/defaults/kata-containers/configuration-clh.toml
 	fi
 }
 

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -67,7 +67,11 @@ function install_artifacts() {
 
 	# Allow Mariner to use custom configuration.
 	if [ "${HOST_OS:-}" == "cbl-mariner" ]; then
-		sed -i -E 's|(enable_annotations) = .+|\1 = ["enable_iommu", "initrd", "kernel"]|' /opt/kata/share/defaults/kata-containers/configuration-clh.toml
+		config_path="/opt/kata/share/defaults/kata-containers/configuration-clh.toml"
+		clh_path="/opt/kata/bin/cloud-hypervisor-glibc"
+		sed -i -E 's|(enable_annotations) = .+|\1 = ["enable_iommu", "initrd", "kernel"]|' "${config_path}"
+		sed -i -E "s|(valid_hypervisor_paths) = .+|\1 = [\"${clh_path}\"]|" "${config_path}"
+		sed -i -E "s|(path) = \".+/cloud-hypervisor\"|\1 = \"${clh_path}\"|" "${config_path}"
 	fi
 }
 

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -76,12 +76,12 @@ build_clh_from_source() {
 
 	if [ -n "${features}" ]; then
 		info "Build cloud-hypervisor enabling the following features: ${features}"
-		./scripts/dev_cli.sh build --release --libc musl --features "${features}"
+		./scripts/dev_cli.sh build --release --libc "${libc}" --features "${features}"
 	else
-		./scripts/dev_cli.sh build --release --libc musl
+		./scripts/dev_cli.sh build --release --libc "${libc}"
 	fi
 	rm -f cloud-hypervisor
-	cp build/cargo_target/$(uname -m)-unknown-linux-musl/release/cloud-hypervisor .
+	cp build/cargo_target/$(uname -m)-unknown-linux-${libc}/release/cloud-hypervisor .
 	popd
 }
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -122,17 +122,20 @@ assets:
     url: "https://github.com/kata-containers/kata-containers/tools/osbuilder"
     architecture:
       aarch64:
-        name: "ubuntu"
-        version: "latest"
-      ppc64le:
-        name: "ubuntu"
-        version: "latest"
-      s390x:
-        name: "ubuntu"
-        version: "latest"
-      x86_64:
         name: &default-image-name "ubuntu"
-        version: "latest"
+        version: &default-image-version "latest"
+      ppc64le:
+        name: *default-image-name
+        version: *default-image-version
+      s390x:
+        name: *default-image-name
+        version: *default-image-version
+      x86_64:
+        name: *default-image-name
+        version: *default-image-version
+        tdx:
+          name: *default-image-name
+          version: *default-image-version
     meta:
       image-type: *default-image-name
 
@@ -156,6 +159,9 @@ assets:
       x86_64:
         name: *default-initrd-name
         version: *default-initrd-version
+        cbl-mariner:
+          name: "cbl-mariner"
+          version: "2.0"
         sev:
           name: *glibc-initrd-name
           version: *glibc-initrd-version


### PR DESCRIPTION
Depends on: ~#6686~ ~#7027~

This PR adapts the test code so that we can actually run k8s tests on Mariner. The change is essentially summarized as below:

1) We allow building the Mariner rootfs initrd as part of CI, and we specify it at test time using an annotation.
2) Again using an annotation, we specify the custom bleeding-edge kernel used by Mariner. This is enabled by setting the `enable_annotations` config in `kata-deploy.sh`.
3) Build Cloud Hypervisor with glibc and the `mshv` feature for Mariner.

Fixes #6840.