### PR TITLE
gha: tdx: Use the k3s overlay for kata-cleanup

### DIFF
--- a/.github/workflows/run-k8s-tests-on-tdx.yaml
+++ b/.github/workflows/run-k8s-tests-on-tdx.yaml
@@ -57,9 +57,9 @@ jobs:
           sed -i -e "s|quay.io/kata-containers/kata-deploy:latest|${{ inputs.registry }}/${{ inputs.repo }}:${{ inputs.tag }}|g" tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
           cat tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
           cat tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml | grep "${{ inputs.registry }}/${{ inputs.repo }}:${{ inputs.tag }}" || die "Failed to setup the tests image"
-          kubectl apply -f tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+          kubectl apply -k tools/packaging/kata-deploy/kata-cleanup/overlays/k3s
           sleep 180s
 
-          kubectl delete -f tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+          kubectl delete -k tools/packaging/kata-deploy/kata-cleanup/overlays/k3s
           kubectl delete -f tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
           kubectl delete -f tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml


### PR DESCRIPTION
As the TDX CI runs on k3s, we must ensure the cleanup, as already done for the deploy, used the k3s overlay.

Fixes: #6857