### PR TITLE
deploy: fix shell script error

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -15,7 +15,7 @@ cp ${KATA_DEPLOY_ARTIFACT} ${KATA_DEPLOY_DIR}
 
 pushd ${KATA_DEPLOY_DIR}
 
-local arch=$(uname -m)
+arch=$(uname -m)
 [ "$arch" = "x86_64" ] && arch="amd64"
 IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-${arch}"
 


### PR DESCRIPTION
- Remove local introduced by bad copy-paste

Fixes: #6814
Signed-off-by: stevenhorsman <steven@uk.ibm.com>
(cherry picked from commit 1a3f8fc1a23297230b4a9fe532232a753ae2701a)