### PR TITLE
dragonball: Remove virtio-net and vsock devices gracefully

### DIFF
--- a/src/dragonball/src/config_manager.rs
+++ b/src/dragonball/src/config_manager.rs
@@ -278,6 +278,11 @@ where
         self.info_list.iter_mut()
     }
 
+    /// Remove the last device config info from the `info_list`.
+    pub fn pop(&mut self) -> Option<DeviceConfigInfo<T>> {
+        self.info_list.pop()
+    }
+
     fn get_index_by_id(&self, config: &T) -> Option<usize> {
         self.info_list
             .iter()

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -714,6 +714,14 @@ impl DeviceManager {
 
         #[cfg(feature = "virtio-blk")]
         self.block_manager.remove_devices(&mut ctx)?;
+        // FIXME: To acquire the full abilities for gracefully removing
+        // virtio-net and virtio-vsock devices, updating dragonball-sandbox
+        // is required.
+        #[cfg(feature = "virtio-net")]
+        self.virtio_net_manager.remove_devices(&mut ctx)?;
+        #[cfg(feature = "virtio-vsock")]
+        self.vsock_manager.remove_devices(&mut ctx)?;
+
         Ok(())
     }
 }

--- a/src/dragonball/src/device_manager/virtio_net_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/virtio_net_dev_mgr.rs
@@ -374,6 +374,21 @@ impl VirtioNetDeviceMgr {
 
         Ok(Box::new(net_device))
     }
+
+    /// Remove all virtio-net devices.
+    pub fn remove_devices(&mut self, ctx: &mut DeviceOpContext) -> Result<(), DeviceMgrError> {
+        while let Some(mut info) = self.info_list.pop() {
+            slog::info!(
+                ctx.logger(),
+                "remove virtio-net device: {}",
+                info.config.iface_id
+            );
+            if let Some(device) = info.device.take() {
+                DeviceManager::destroy_mmio_virtio_device(device, ctx)?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl Default for VirtioNetDeviceMgr {


### PR DESCRIPTION
This MR implements removing virtio-net and virtio-vsock devices gracefully when shutting down VMM.

Fixes: #6684