### PR TITLE
runtime: pkg/sev: Docs improvements and allow measurement without initrd

### DIFF
--- a/src/runtime/pkg/sev/README.md
+++ b/src/runtime/pkg/sev/README.md
@@ -1,14 +1,15 @@
 # AMD SEV confidential guest utilities
 
-This package provides utilities for launching AMD SEV confidential guests.
+This package provides utilities for launching AMD SEV/SEV-ES confidential
+guests.
 
 ## Calculating expected launch digests
 
-The `CalculateLaunchDigest` function can be used to calculate the expected
-SHA-256 of an SEV confidential guest given its firmware, kernel, initrd, and
-kernel command-line.
+The `CalculateLaunchDigest` and `CalculateSEVESLaunchDigest` function can be
+used to calculate the expected SHA-256 of an SEV/SEV-ES confidential guest
+given its firmware, kernel, initrd, and kernel command-line.
 
 ### Unit test data
 
 The [`testdata`](testdata) directory contains file used for testing
-`CalculateLaunchDigest`.
+launch digest calculation.

--- a/src/runtime/pkg/sev/ovmf.go
+++ b/src/runtime/pkg/sev/ovmf.go
@@ -26,7 +26,7 @@ type ovmf struct {
 	table map[guidLE][]byte
 }
 
-func NewOvmf(filename string) (ovmf, error) {
+func newOvmf(filename string) (ovmf, error) {
 	buf, err := os.ReadFile(filename)
 	if err != nil {
 		return ovmf{}, err
@@ -38,7 +38,13 @@ func NewOvmf(filename string) (ovmf, error) {
 	return ovmf{table}, nil
 }
 
-// Parse the OVMF footer table and return a map from GUID to entry value
+// Parse the OVMF footer table and return a map from GUID to entry value.
+//
+// The OVMF footer table is described in this source file:
+// https://github.com/tianocore/edk2/blob/master/OvmfPkg/ResetVector/Ia16/ResetVectorVtf0.asm
+//
+// This table is also parsed in QEMU and described in its documentation:
+// https://qemu.readthedocs.io/en/latest/specs/sev-guest-firmware.html
 func parseFooterTable(data []byte) (map[guidLE][]byte, error) {
 	table := make(map[guidLE][]byte)
 

--- a/src/runtime/pkg/sev/sev.go
+++ b/src/runtime/pkg/sev/sev.go
@@ -181,7 +181,7 @@ func CalculateSEVESLaunchDigest(vcpus int, vcpuSig VCPUSig, firmwarePath, kernel
 		digest.Write(ht)
 	}
 
-	o, err := NewOvmf(firmwarePath)
+	o, err := newOvmf(firmwarePath)
 	if err != nil {
 		return res, err
 	}

--- a/src/runtime/pkg/sev/sev.go
+++ b/src/runtime/pkg/sev/sev.go
@@ -4,7 +4,7 @@
 //
 
 // Package sev can be used to compute the expected hash values for
-// SEV/-ES pre-launch attestation
+// SEV/-ES pre-launch attestation.
 package sev
 
 import (

--- a/src/runtime/pkg/sev/sev_test.go
+++ b/src/runtime/pkg/sev/sev_test.go
@@ -31,6 +31,17 @@ func TestCalculateLaunchDigestWithKernelHashes(t *testing.T) {
 	}
 }
 
+func TestCalculateLaunchDigestWithKernelHashesWithoutInitrd(t *testing.T) {
+	ld, err := CalculateLaunchDigest("testdata/ovmf_suffix.bin", "/dev/null", "", "")
+	if err != nil {
+		t.Fatalf("unexpected err value: %s", err)
+	}
+	hexld := hex.EncodeToString(ld[:])
+	if hexld != "d59d7696efd7facfaa653758586e6120c4b6eaec3e327771d278cc6a44786ba5" {
+		t.Fatalf("wrong measurement: %s", hexld)
+	}
+}
+
 func TestCalculateLaunchDigestWithKernelHashesSevEs(t *testing.T) {
 	ld, err := CalculateSEVESLaunchDigest(1, SigEpycV4, "testdata/ovmf_suffix.bin", "/dev/null", "/dev/null", "")
 	if err != nil {

--- a/src/runtime/pkg/sev/vcpu_sigs.go
+++ b/src/runtime/pkg/sev/vcpu_sigs.go
@@ -45,6 +45,12 @@ const (
 
 	// 'EPYC-Milan-v2': family=25, model=1, stepping=1
 	SigEpycMilanV2 VCPUSig = 0xa00f11
+
+	// 'EPYC-Genoa': family=25, model=17, stepping=0
+	SigEpycGenoa VCPUSig = 0xa10f10
+
+	// 'EPYC-Genoa-v1': family=25, model=17, stepping=0
+	SigEpycGenoaV1 VCPUSig = 0xa10f10
 )
 
 // NewVCPUSig computes the CPU signature (32-bit value) from the given family,

--- a/src/runtime/pkg/sev/vcpu_sigs_test.go
+++ b/src/runtime/pkg/sev/vcpu_sigs_test.go
@@ -18,4 +18,7 @@ func TestNewVCPUSig(t *testing.T) {
 	if NewVCPUSig(25, 1, 1) != SigEpycMilan {
 		t.Errorf("wrong EPYC-Milan CPU signature")
 	}
+	if NewVCPUSig(25, 17, 0) != SigEpycGenoa {
+		t.Errorf("wrong EPYC-Genoa CPU signature")
+	}
 }


### PR DESCRIPTION
Four commits here:

* Add Genoa CPU signatures
* Improve pkg/sev/README.md (following comments in reviews of #6789)
* Improve docs in ovmf.go (following comments in reviews of #6789) + make `func newOvmf` unexported
* Allow calculating SEV/-ES launch digest without initrd (when `initrdPath == ""`).

FYI @wainersm @c3d @fitzthum 
