### PR TITLE
docs: Update container network model url

### DIFF
--- a/src/runtime/virtcontainers/README.md
+++ b/src/runtime/virtcontainers/README.md
@@ -77,7 +77,7 @@ For further details, see the [API documentation](documentation/api/1.0/api.md).
 
 Typically the former is the Docker default networking model while the later is used on Kubernetes deployments.
 
-[cnm]: https://github.com/docker/libnetwork/blob/master/docs/design.md
+[cnm]: https://github.com/moby/libnetwork/blob/master/docs/design.md
 [cni]: https://github.com/containernetworking/cni/
 
 ## CNM


### PR DESCRIPTION
This PR updates the container network model url that is part of the virtcontainers documentation.

Fixes #6889