### PR TITLE
cache: Fix OVMF caching

### DIFF
--- a/tools/packaging/static-build/cache_components_main.sh
+++ b/tools/packaging/static-build/cache_components_main.sh
@@ -77,9 +77,8 @@ cache_nydus_artifacts() {
 
 cache_ovmf_artifacts() {
 	local current_ovmf_version="$(get_from_kata_deps "externals.ovmf.${OVMF_FLAVOUR}.version")"
-	[ "${OVMF_FLAVOUR}" == "tdx" ] && OVMF_FLAVOUR="tdvf"
-	[ "${OVMF_FLAVOUR}" == "sev" ] && OVMF_FLAVOUR="ovmf-sev"
-	local ovmf_tarball_name="kata-static-${OVMF_FLAVOUR}.tar.xz"
+	local ovmf_tarball_name="kata-static-ovmf-${OVMF_FLAVOUR}.tar.xz"
+	[ "${OVMF_FLAVOUR}" == "tdx" ] && ovmf_tarball_name="kata-static-tdvf.tar.xz"
 	local current_ovmf_image="$(get_ovmf_image_name)"
 	create_cache_asset "${ovmf_tarball_name}" "${current_ovmf_version}" "${current_ovmf_image}"
 }


### PR DESCRIPTION
OVMF has been cached, but it's not been used from cache as the `version` set in the cached builds has always been empty.

The reason for that is because we've been trying to look for `externals.ovmf.ovmf.version`, while we should be actually looking for `externals.ovmf.x86_64.version`.

Setting `x86_64` as the OVMF_FLAVOUR would cause another bug, as the expected tarball name would then be `kata-static-x86_64.tar.xz`, instead of `kata-static-ovmf-x86_64.tar.xz`.

With everything said, let's simplify the OVMF_FLAVOUR usage, by using it as it's passed, and only adapting the tarball name for the TDVF case, which is the abnormal one.

Fixes: #6897