### PR TITLE
CC | local-build: Bring back root_hash logic

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -148,6 +148,14 @@ install_cached_component() {
 	wget "${jenkins_build_url}/${component_tarball_name}" || return $(cleanup_and_fail)
 	wget "${jenkins_build_url}/sha256sum-${component_tarball_name}" || return $(cleanup_and_fail)
 	sha256sum -c "sha256sum-${component_tarball_name}" || return $(cleanup_and_fail)
+	if [ -n "${root_hash_vanilla}" ]; then
+		wget "${jenkins_build_url}/${root_hash_vanilla}" || return cleanup_and_fail
+		mv "${root_hash_vanilla}" "${repo_root_dir}/tools/osbuilder/"
+	fi
+	if [ -n "${root_hash_tdx}" ]; then
+		wget "${jenkins_build_url}/${root_hash_tdx}" || return cleanup_and_fail
+		mv "${root_hash_tdx}" "${repo_root_dir}/tools/osbuilder/"
+	fi
 	mv "${component_tarball_name}" "${component_tarball_path}"
 }
 


### PR DESCRIPTION
I cannot easily pin-point which commit dropped it, but my gut feeling is that it's the result of an erroneous conflict resolution when merging content from main to the CCv0 branch.

Regardless of when / why it happened, as the root_hash logic ended up being dropped, workflows that depend on that are now failing.

With everything said in mind, let's bring the logic back.

Fixes: #6901