### PR TITLE
gha: release: Fix s390x worklow

### DIFF
--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
 
   kata-deploy:
-    needs: create-kata-tarball
+    needs: build-kata-static-tarball-s390x
     runs-on: s390x
     steps:
       - name: Login to Kata Containers docker.io


### PR DESCRIPTION
GitHub is warning us that:
"""
The workflow is not valid. In .github/workflows/release.yaml (Line: 21, Col: 11): Error from called workflow
kata-containers/kata-containers/.github/workflows/release-s390x.yaml@d2e92c9ec993f56537044950a4673e50707369b5 (Line: 14, Col: 12): Job 'kata-deploy' depends on unknown job 'create-kata-tarball'.
"""

This is happening as we need to reference
"build-kata-static-tarball-s390x" instead of "create-kata-tarball".