### PR TITLE
gha: aks: Wait a little bit more before run the tests

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -62,7 +62,7 @@ jobs:
           az aks get-credentials -g "kataCI" -n ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.vmm }}-amd64
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 35
         run: |
           sed -i -e "s|quay.io/kata-containers/kata-deploy:latest|${{ inputs.registry }}/${{ inputs.repo }}:${{ inputs.tag }}|g" tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
           cat tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -76,7 +76,7 @@ jobs:
           # This is needed as the kata-deploy pod will be set to "Ready" when it starts running,
           # which may cause issues like not having the node properly labeled or the artefacts
           # properly deployed when the tests actually start running.
-          sleep 60s
+          sleep 150s
 
           pushd tests/integration/kubernetes
           sed -i -e 's|runtimeClassName: kata|runtimeClassName: kata-${{ matrix.vmm }}|' runtimeclass_workloads/*.yaml


### PR DESCRIPTION
fa832f4709f6213946c11601ccd895ab01ee8bab increased the timeout, which helped a lot, mainly in the TEE machines.  However, we're still seeing some failures here and there with the AKS tests.

Let's bump it yet again and, hopefully, those errors to start the tests will go away.

Fixes: #6905