### PR TITLE
Upgrade to Cloud Hypervisor v32.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -415,10 +415,17 @@ components:
     VmmPingResponse:
       description: Virtual Machine Monitor information
       example:
+        build_version: build_version
+        pid: 0
         version: version
       properties:
+        build_version:
+          type: string
         version:
           type: string
+        pid:
+          format: int64
+          type: integer
       required:
       - version
       type: object

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/VmmPingResponse.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/VmmPingResponse.md
@@ -4,7 +4,9 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**BuildVersion** | Pointer to **string** |  | [optional] 
 **Version** | **string** |  | 
+**Pid** | Pointer to **int64** |  | [optional] 
 
 ## Methods
 
@@ -25,6 +27,31 @@ NewVmmPingResponseWithDefaults instantiates a new VmmPingResponse object
 This constructor will only assign default values to properties that have it defined,
 but it doesn't guarantee that properties required by API are set
 
+### GetBuildVersion
+
+`func (o *VmmPingResponse) GetBuildVersion() string`
+
+GetBuildVersion returns the BuildVersion field if non-nil, zero value otherwise.
+
+### GetBuildVersionOk
+
+`func (o *VmmPingResponse) GetBuildVersionOk() (*string, bool)`
+
+GetBuildVersionOk returns a tuple with the BuildVersion field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetBuildVersion
+
+`func (o *VmmPingResponse) SetBuildVersion(v string)`
+
+SetBuildVersion sets BuildVersion field to given value.
+
+### HasBuildVersion
+
+`func (o *VmmPingResponse) HasBuildVersion() bool`
+
+HasBuildVersion returns a boolean if a field has been set.
+
 ### GetVersion
 
 `func (o *VmmPingResponse) GetVersion() string`
@@ -44,6 +71,31 @@ and a boolean to check if the value has been set.
 
 SetVersion sets Version field to given value.
 
+
+### GetPid
+
+`func (o *VmmPingResponse) GetPid() int64`
+
+GetPid returns the Pid field if non-nil, zero value otherwise.
+
+### GetPidOk
+
+`func (o *VmmPingResponse) GetPidOk() (*int64, bool)`
+
+GetPidOk returns a tuple with the Pid field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetPid
+
+`func (o *VmmPingResponse) SetPid(v int64)`
+
+SetPid sets Pid field to given value.
+
+### HasPid
+
+`func (o *VmmPingResponse) HasPid() bool`
+
+HasPid returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vmm_ping_response.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vmm_ping_response.go
@@ -16,7 +16,9 @@ import (
 
 // VmmPingResponse Virtual Machine Monitor information
 type VmmPingResponse struct {
-	Version string `json:"version"`
+	BuildVersion *string `json:"build_version,omitempty"`
+	Version      string  `json:"version"`
+	Pid          *int64  `json:"pid,omitempty"`
 }
 
 // NewVmmPingResponse instantiates a new VmmPingResponse object
@@ -35,6 +37,38 @@ func NewVmmPingResponse(version string) *VmmPingResponse {
 func NewVmmPingResponseWithDefaults() *VmmPingResponse {
 	this := VmmPingResponse{}
 	return &this
+}
+
+// GetBuildVersion returns the BuildVersion field value if set, zero value otherwise.
+func (o *VmmPingResponse) GetBuildVersion() string {
+	if o == nil || o.BuildVersion == nil {
+		var ret string
+		return ret
+	}
+	return *o.BuildVersion
+}
+
+// GetBuildVersionOk returns a tuple with the BuildVersion field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *VmmPingResponse) GetBuildVersionOk() (*string, bool) {
+	if o == nil || o.BuildVersion == nil {
+		return nil, false
+	}
+	return o.BuildVersion, true
+}
+
+// HasBuildVersion returns a boolean if a field has been set.
+func (o *VmmPingResponse) HasBuildVersion() bool {
+	if o != nil && o.BuildVersion != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetBuildVersion gets a reference to the given string and assigns it to the BuildVersion field.
+func (o *VmmPingResponse) SetBuildVersion(v string) {
+	o.BuildVersion = &v
 }
 
 // GetVersion returns the Version field value
@@ -61,10 +95,48 @@ func (o *VmmPingResponse) SetVersion(v string) {
 	o.Version = v
 }
 
+// GetPid returns the Pid field value if set, zero value otherwise.
+func (o *VmmPingResponse) GetPid() int64 {
+	if o == nil || o.Pid == nil {
+		var ret int64
+		return ret
+	}
+	return *o.Pid
+}
+
+// GetPidOk returns a tuple with the Pid field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *VmmPingResponse) GetPidOk() (*int64, bool) {
+	if o == nil || o.Pid == nil {
+		return nil, false
+	}
+	return o.Pid, true
+}
+
+// HasPid returns a boolean if a field has been set.
+func (o *VmmPingResponse) HasPid() bool {
+	if o != nil && o.Pid != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPid gets a reference to the given int64 and assigns it to the Pid field.
+func (o *VmmPingResponse) SetPid(v int64) {
+	o.Pid = &v
+}
+
 func (o VmmPingResponse) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
+	if o.BuildVersion != nil {
+		toSerialize["build_version"] = o.BuildVersion
+	}
 	if true {
 		toSerialize["version"] = o.Version
+	}
+	if o.Pid != nil {
+		toSerialize["pid"] = o.Pid
 	}
 	return json.Marshal(toSerialize)
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -438,8 +438,13 @@ components:
         - version
       type: object
       properties:
+        build_version:
+          type: string
         version:
           type: string
+        pid:
+          type: integer
+          format: int64
       description: Virtual Machine Monitor information
 
     VmInfo:

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v31.0"
+      version: "v32.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This release has been tracked in our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration v32.0. The following user visible changes have been made:

### Increased PCI Segment Limit

The maximum number of PCI segments that can be used is now 96 (up from 16).

### API Changes

* The VmmPingResponse now includes the PID as well as the build details.  

### Notable Bug Fixes

* Ignore and warn TAP FDs sent via the HTTP request body
* Properly preserve and close valid FDs for TAP devices
* Only use `KVM_ARM_VCPU_PMU_V3` if available
* Only touch the tty flags if it's being used
* Fix seccomp filter lists for vhost-user devices
* The number of vCPUs is capped at the hypervisor maximum
* Fixes for TTY reset
* CPU topology fixes on MSHV
* Seccomp fixes for older distributions

Details can be found here: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v32.0