### PR TITLE
Fix cache for OVMF and rootfs-initrd (both x86_64)

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -159,7 +159,7 @@ install_image() {
 
 #Install guest initrd
 install_initrd() {
-	local initrd_type="${1:-""}"
+	local initrd_type="${1:-"initrd"}"
 	local initrd_suffix="${2:-""}"
 	local jenkins="${jenkins_url}/job/kata-containers-main-rootfs-${initrd_type}-$(uname -m)/${cached_artifacts_path}"
 	local component="rootfs-${initrd_type}"

--- a/tools/packaging/static-build/cache_components_main.sh
+++ b/tools/packaging/static-build/cache_components_main.sh
@@ -77,8 +77,18 @@ cache_nydus_artifacts() {
 
 cache_ovmf_artifacts() {
 	local current_ovmf_version="$(get_from_kata_deps "externals.ovmf.${OVMF_FLAVOUR}.version")"
-	local ovmf_tarball_name="kata-static-ovmf-${OVMF_FLAVOUR}.tar.xz"
-	[ "${OVMF_FLAVOUR}" == "tdx" ] && ovmf_tarball_name="kata-static-tdvf.tar.xz"
+	case ${OVMF_FLAVOUR} in
+		"tdx")
+			ovmf_tarball_name="kata-static-tdvf.tar.xz"
+			;;
+		"x86_64")
+			ovmf_tarball_name="kata-static-ovmf.tar.xz"
+			;;
+		*)
+			ovmf_tarball_name="kata-static-ovmf-${OVMF_FLAVOUR}.tar.xz"
+			;;
+	esac
+			
 	local current_ovmf_image="$(get_ovmf_image_name)"
 	create_cache_asset "${ovmf_tarball_name}" "${current_ovmf_version}" "${current_ovmf_image}"
 }


### PR DESCRIPTION
---

cache: Use "initrd" as `initrd_type` to build rootfs-initrd

We've been defaulting to "", which would lead to a mismatch with the
latest version from the cache, causing a miss, and finally having to
build the rootfs-initrd as part of the tests, every single time.

Fixes: #6917

---

cache: Fix OVMF tarball name for different flavours

75330ab3f96f644fff48312e2954ecb1c2fa4081 tried to fix OVMF caching, but
didn't consider that the "vanilla" OVMF tarball name is not
"kata-static-ovmf-x86_64.tar.xz", but rather "kata-static-ovmf.tar.xz".

The fact we missed that, led to the cache builds of OVMF failing, and
the need to build the component on every single PR.

Fixes: #6917 (hopefully for good this time).

---
