### PR TITLE
runtime: Fix QEMU cmdline for TDX

### DIFF
--- a/src/runtime/arch/amd64-options.mk
+++ b/src/runtime/arch/amd64-options.mk
@@ -11,7 +11,7 @@ MACHINEACCELERATORS :=
 CPUFEATURES := pmu=off
 
 QEMUCMD := qemu-system-x86_64
-QEMUTDXCMD := qemu-system-x86_64-tdx-experimental
+QEMUTDXCMD := qemu-system-x86_64-tdx
 TDXCPUFEATURES := -vmx-rdseed-exit,pmu=off
 QEMUSNPCMD := qemu-system-x86_64-snp
 


### PR DESCRIPTION
This commit should've been part of the series that reverted a bunch of TDX changes that are not compatible with the TDX stack we're using in the Jenkins CI machine.

The change made here is in order to match what's been undone here: c29e5036a68f67c556750356e43f7bf88b0fe313

Fixes: #6884