### PR TITLE
osbuilder: Bump fedora image version

### DIFF
--- a/tools/osbuilder/dockerfiles/QAT/Dockerfile
+++ b/tools/osbuilder/dockerfiles/QAT/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Kata osbuilder 'works best' on Fedora
-FROM fedora:34
+FROM fedora:38
 
 # Version of the Dockerfile - update if you change this file to avoid 'stale'
 # images being pulled from the registry.

--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ARG IMAGE_REGISTRY=registry.fedoraproject.org
-FROM ${IMAGE_REGISTRY}/fedora:34
+FROM ${IMAGE_REGISTRY}/fedora:38
 
 RUN ([ -n "$http_proxy" ] && \
     sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true) && \


### PR DESCRIPTION
- Swap out an EoL fedora image for the latest

Fixes: #6923