### PR TITLE
kata-deploy: Fix indentation on kata deploy merge script

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -20,8 +20,8 @@ mkdir "${tarball_content_dir}"
 
 for c in kata-static-*.tar.xz
 do
-    echo "untarring tarball "${c}" into ${tarball_content_dir}"
-    tar -xvf "${c}" -C "${tarball_content_dir}"
+	echo "untarring tarball "${c}" into ${tarball_content_dir}"
+	tar -xvf "${c}" -C "${tarball_content_dir}"
 done
 
 echo "create ${tar_path}"


### PR DESCRIPTION
This PR fixes the indentation on the kata deploy merge script that instead of single spaces uses a tap.

Fixes #6925