### PR TITLE
CC | runtime: config: Fix image path for QEMU TDX

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -152,7 +152,7 @@ SEVKERNELPARAMS := $(AGENTCONFIGFILEKERNELPARAM) agent.enable_signature_verifica
 SNPKERNELPARAMS := $(AGENTCONFIGFILEKERNELPARAM) agent.enable_signature_verification=false $(AGENT_AA_KBC_PARAMS_SNP)
 KERNELPARAMS += $(ROOTMEASURECONFIG) agent.enable_signature_verification=false $(AGENT_AA_KBC_PARAMS)
 
-FIRMWARETDVFPATH := $(PREFIXDEPS)/share/tdvf/OVMF.fd
+FIRMWARETDVFPATH := $(PREFIXDEPS)/share/tdvf/OVMF_CODE.fd
 FIRMWARETDVFVOLUMEPATH := $(PREFIXDEPS)/share/tdvf/OVMF_VARS.fd
 
 # Name of default configuration file the runtime will use.

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -14,7 +14,7 @@
 [hypervisor.qemu]
 path = "@QEMUTDXPATH@"
 kernel = "@KERNELTDXPATH@"
-image = "@IMAGEPATH@"
+image = "@IMAGETDXPATH@"
 # initrd = "@INITRDPATH@"
 machine_type = "@MACHINETYPE@"
 

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -664,7 +664,7 @@ experimental=@DEFAULTEXPFEATURES@
 #
 # Offload the CRI image management service to the Kata agent.
 # (default: false)
-#service_offload = true
+service_offload = true
 
 # Container image decryption keys provisioning.
 # Applies only if service_offload is true.


### PR DESCRIPTION
The rebase from `main` to `CCv0` ended up overwriting the image path that should be used for QEMU, in the CCv0 branch.

Fixes: #6932