### PR TITLE
versions: Update nydus version to 2.2.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -261,7 +261,7 @@ externals:
   nydus:
     description: "Nydus image acceleration service"
     url: "https://github.com/dragonflyoss/image-service"
-    version: "v2.2.0"
+    version: "v2.2.1"
 
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"


### PR DESCRIPTION
This PR updates the nydus version to 2.2.1. This change includes: 
nydus-image: fix a underflow issue in get_compressed_size()
backport fix/feature to stable 2.2
[backport] contrib: upgrade runc to v1.1.5
service: add README for nydus-service
nydus: fix a possible panic caused by SubCmdArgs::is_present Backports two bugfixes from master into stable/v2.2
 [backport stable/v2.2] action: upgrade golangci-lint to v1.51.2 
[backport] action: fix smoke test for branch pattern

Fixes #6938