### PR TITLE
gha: release: login-action: Don't specify docker.io registry

### DIFF
--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -17,7 +17,6 @@ jobs:
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v2
         with:
-          registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -17,7 +17,6 @@ jobs:
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v2
         with:
-          registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -17,7 +17,6 @@ jobs:
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v2
         with:
-          registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,6 @@ jobs:
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v2
         with:
-          registry: docker.io
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 


### PR DESCRIPTION
For some bizarre reason, the login-action will simply fail to authenticate to docker.io in it's specified as a registry.  The way to proceed, instead, is to *not* specify any registry as it'd be used by default.

Fixes: #6943