### PR TITLE
kata-ctl: add vhost kernel module checks

### DIFF
--- a/src/tools/kata-ctl/src/arch/x86_64/mod.rs
+++ b/src/tools/kata-ctl/src/arch/x86_64/mod.rs
@@ -64,6 +64,18 @@ mod arch_specific {
                 value: KernelParamType::Predicate(unrestricted_guest_param_check),
             }),
         },
+        KernelModule {
+            name: "vhost",
+            parameter: None,
+        },
+        KernelModule {
+            name: "vhost_vsock",
+            parameter: None,
+        },
+        KernelModule {
+            name: "vhost_net",
+            parameter: None,
+        },
     ];
 
     pub fn get_checks() -> Option<&'static [CheckItem<'static>]> {

--- a/src/tools/kata-ctl/src/check.rs
+++ b/src/tools/kata-ctl/src/check.rs
@@ -308,10 +308,9 @@ pub fn check_official_releases() -> Result<()> {
 }
 
 #[cfg(any(target_arch = "x86_64"))]
-pub fn check_kernel_module_loaded(module: &str, parameter: &str) -> Result<String, String> {
+pub fn check_kernel_module_loaded(module: &str) -> Result<String, String> {
     const MODPROBE_PARAMETERS_DRY_RUN: &str = "--dry-run";
     const MODPROBE_PARAMETERS_FIRST_TIME: &str = "--first-time";
-    const MODULES_PATH: &str = "/sys/module";
 
     let status_modinfo_success;
 
@@ -370,6 +369,12 @@ pub fn check_kernel_module_loaded(module: &str, parameter: &str) -> Result<Strin
             return Err(msg);
         }
     }
+    Ok(module.to_string())
+}
+
+#[cfg(any(target_arch = "x86_64"))]
+pub fn get_kernel_param_value(module: &str, parameter: &str) -> Result<String, String> {
+    const MODULES_PATH: &str = "/sys/module";
 
     let module_path = format!("{}/{}/parameters/{}", MODULES_PATH, module, parameter);
 

--- a/src/tools/kata-ctl/src/types.rs
+++ b/src/tools/kata-ctl/src/types.rs
@@ -69,5 +69,5 @@ pub struct KernelParam<'a> {
 #[allow(dead_code)]
 pub struct KernelModule<'a> {
     pub name: &'a str,
-    pub parameter: KernelParam<'a>,
+    pub parameter: Option<KernelParam<'a>>,
 }


### PR DESCRIPTION
Add checks for vhost, vhost_vsock, vhost_net.