### PR TITLE
gha: release: Simplify the process for tagging the payload

### DIFF
--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -36,27 +36,16 @@ jobs:
       - name: build-and-push-kata-deploy-ci-amd64
         id: build-and-push-kata-deploy-ci-amd64
         run: |
-          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
-          pushd $GITHUB_WORKSPACE
-          git checkout $tag
-          pkg_sha=$(git rev-parse HEAD)
-          popd
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-            $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy-ci" \
-            "${pkg_sha}-${{ inputs.target-arch }}"
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-            $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy-ci" \
-            "${pkg_sha}-${{ inputs.target-arch }}"
-
-      - name: push-tarball
-        run: |
-          # tag the container image we created and push to DockerHub
+          # We need to do such trick here as the format of the $GITHUB_REF 
+          # is "refs/tags/<tag>"
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           tags=($tag)
           tags+=($([[ "$tag" =~ "alpha"|"rc" ]] && echo "latest" || echo "stable"))
           for tag in ${tags[@]}; do
-            docker tag docker.io/katadocker/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci-amd64.outputs.PKG_SHA}}-${{ inputs.target-arch }} docker.io/katadocker/kata-deploy:${tag}-${{ inputs.target-arch }}
-            docker tag quay.io/kata-containers/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci-amd64.outputs.PKG_SHA}}-${{ inputs.target-arch }} quay.io/kata-containers/kata-deploy:${tag}-${{ inputs.target-arch }}
-            docker push docker.io/katadocker/kata-deploy:${tag}-${{ inputs.target-arch }}
-            docker push quay.io/kata-containers/kata-deploy:${tag}-${{ inputs.target-arch }}
+              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+                  $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy" \
+                  "${tag}-${{ inputs.target-arch }}"
+              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+                  $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy" \
+                  "${tag}-${{ inputs.target-arch }}"
           done

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -36,27 +36,16 @@ jobs:
       - name: build-and-push-kata-deploy-ci-arm64
         id: build-and-push-kata-deploy-ci-arm64
         run: |
-          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
-          pushd $GITHUB_WORKSPACE
-          git checkout $tag
-          pkg_sha=$(git rev-parse HEAD)
-          popd
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-            $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy-ci" \
-            "${pkg_sha}-${{ inputs.target-arch }}"
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-            $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy-ci" \
-            "${pkg_sha}-${{ inputs.target-arch }}"
-
-      - name: push-tarball
-        run: |
-          # tag the container image we created and push to DockerHub
+          # We need to do such trick here as the format of the $GITHUB_REF 
+          # is "refs/tags/<tag>"
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           tags=($tag)
           tags+=($([[ "$tag" =~ "alpha"|"rc" ]] && echo "latest" || echo "stable"))
           for tag in ${tags[@]}; do
-            docker tag docker.io/katadocker/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci-arm64.outputs.PKG_SHA}}-${{ inputs.target-arch }} docker.io/katadocker/kata-deploy:${tag}-${{ inputs.target-arch }}
-            docker tag quay.io/kata-containers/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci-arm64.outputs.PKG_SHA}}-${{ inputs.target-arch }} quay.io/kata-containers/kata-deploy:${tag}-${{ inputs.target-arch }}
-            docker push docker.io/katadocker/kata-deploy:${tag}-${{ inputs.target-arch }}
-            docker push quay.io/kata-containers/kata-deploy:${tag}-${{ inputs.target-arch }}
+              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+                  $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy" \
+                  "${tag}-${{ inputs.target-arch }}"
+              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+                  $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy" \
+                  "${tag}-${{ inputs.target-arch }}"
           done

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -36,27 +36,16 @@ jobs:
       - name: build-and-push-kata-deploy-ci-s390x
         id: build-and-push-kata-deploy-ci-s390x
         run: |
-          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
-          pushd $GITHUB_WORKSPACE
-          git checkout $tag
-          pkg_sha=$(git rev-parse HEAD)
-          popd
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-            $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy-ci" \
-            "${pkg_sha}-${{ inputs.target-arch }}"
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-            $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy-ci" \
-            "${pkg_sha}-${{ inputs.target-arch }}"
-
-      - name: push-tarball
-        run: |
-          # tag the container image we created and push to DockerHub
+          # We need to do such trick here as the format of the $GITHUB_REF 
+          # is "refs/tags/<tag>"
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           tags=($tag)
           tags+=($([[ "$tag" =~ "alpha"|"rc" ]] && echo "latest" || echo "stable"))
           for tag in ${tags[@]}; do
-            docker tag docker.io/katadocker/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci-s390x.outputs.PKG_SHA}}-${{ inputs.target-arch }} docker.io/katadocker/kata-deploy:${tag}-${{ inputs.target-arch }}
-            docker tag quay.io/kata-containers/kata-deploy-ci:${{steps.build-and-push-kata-deploy-ci-s390x.outputs.PKG_SHA}}-${{ inputs.target-arch }} quay.io/kata-containers/kata-deploy:${tag}-${{ inputs.target-arch }}
-            docker push docker.io/katadocker/kata-deploy:${tag}-${{ inputs.target-arch }}
-            docker push quay.io/kata-containers/kata-deploy:${tag}-${{ inputs.target-arch }}
+              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+                  $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy" \
+                  "${tag}-${{ inputs.target-arch }}"
+              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+                  $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy" \
+                  "${tag}-${{ inputs.target-arch }}"
           done


### PR DESCRIPTION
We previously were doing:
* Create a new image on kata-deploy-ci using the commit hash of the latest tag
  * This was used to test on AKS, which is no longer needed as we test on AKS on every PR
* Create a new image on kata-deploy using the release tag and "latest" or "stable", by tagging the kata-deploy-ci image accordingly

As part of cfe63527c5328611cac647d0c10916bef6cf0408, we broke the workflow described above, as in the first step we would save the PKG_SHA to be used in the second step, but that part ended up being removed.

Anyways, this back and forth is not needed anymore and we can simplify the process by doing:
* Create a new image on kata-deploy, using:
  - The tag received as ref from the event that triggered this worklow
  - "latest" or "stable" tag, depending on whether it's a stable release or not

Fixes: #6946