### PR TITLE
doc: Update git commands

### DIFF
--- a/tools/packaging/kata-deploy/README.md
+++ b/tools/packaging/kata-deploy/README.md
@@ -16,13 +16,13 @@ be utilized to install Kata Containers on a running Kubernetes cluster.
 For your [k3s](https://k3s.io/) cluster, run:
 
 ```sh
-$ git clone github.com/kata-containers/kata-containers
+$ git clone https://github.com/kata-containers/kata-containers.git
 ```
 
 Check and switch to the stable branch of your choice, if wanted, and then run:
 
 ```bash
-$ cd kata-containers/kata-containers/tools/packaging/kata-deploy
+$ cd kata-containers/tools/packaging/kata-deploy
 $ kubectl apply -f kata-rbac/base/kata-rbac.yaml
 $ kubectl apply -k kata-deploy/overlays/k3s
 ```
@@ -32,13 +32,13 @@ $ kubectl apply -k kata-deploy/overlays/k3s
 For your [RKE2](https://docs.rke2.io/) cluster, run:
 
 ```sh
-$ git clone github.com/kata-containers/kata-containers
+$ git clone https://github.com/kata-containers/kata-containers.git
 ```
 
 Check and switch to the stable branch of your choice, if wanted, and then run:
 
 ```bash
-$ cd kata-containers/kata-containers/tools/packaging/kata-deploy
+$ cd kata-containers/tools/packaging/kata-deploy
 $ kubectl apply -f kata-rbac/base/kata-rbac.yaml
 $ kubectl apply -k kata-deploy/overlays/rke2
 ```

--- a/tools/packaging/kernel/README.md
+++ b/tools/packaging/kernel/README.md
@@ -70,7 +70,7 @@ $ ./build-kernel.sh -v 5.10.25 -g nvidia -f -d setup
 ## Setup kernel source code
 
 ```bash
-$ git clone github.com/kata-containers/kata-containers
+$ git clone https://github.com/kata-containers/kata-containers.git
 $ cd kata-containers/tools/packaging/kernel
 $ ./build-kernel.sh setup
 ```


### PR DESCRIPTION
Fix bad migrations from `go get` to `git clone` and update the cloned directory path

Fixes: #6951