### PR TITLE
gha: Add nightly jobs

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -13,6 +13,9 @@ on:
         required: false
         type: string
         default: no
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   build-asset:
@@ -60,7 +63,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
 
       - name: Build ${{ matrix.asset }}
@@ -88,7 +91,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -9,6 +9,9 @@ on:
         required: false
         type: string
         default: no
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   build-asset:
@@ -41,7 +44,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
       - name: Build ${{ matrix.asset }}
         run: |
@@ -72,7 +75,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -9,6 +9,9 @@ on:
         required: false
         type: string
         default: no
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   build-asset:
@@ -37,7 +40,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
       - name: Build ${{ matrix.asset }}
         run: |
@@ -69,7 +72,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
       - name: get-artifacts
         uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -1,0 +1,20 @@
+name: Kata Containers Nightly CI
+on:
+  schedule:
+    cron: '0 0 * * *'
+
+env:
+  COMMIT_HASH: ${GITHUB_REF}
+
+jobs:
+  set-fake-pr-number:
+    runs-on: ubuntu-latest
+    run: |
+      echo "PR_NUMBER=$(date +%Y%m%d%H%M%S)" >> "$GITHUB_ENV"
+
+  kata-containers-ci-on-push:
+    uses: ./.github/workflows/ci.yaml
+    with:
+      commit-hash: ${{ env.COMMIT_HASH }}
+      pr-number: ${{ env.PR_NUMBER }}
+      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-nightly

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -17,71 +17,10 @@ env:
   PR_NUMBER: ${{ github.event.pull_requesst.number }}
 
 jobs:
-  build-kata-static-tarball-amd64:
+  kata-containers-ci-on-push:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
+    uses: ./.github/workflows/ci.yaml
     with:
-      tarball-suffix: -${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}
       commit-hash: ${{ env.COMMIT_HASH }}
-
-  publish-kata-deploy-payload-amd64:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    needs: build-kata-static-tarball-amd64
-    uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
-    with:
-      tarball-suffix: -${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}
-      registry: ghcr.io
-      repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
-      commit-hash: ${{ env.COMMIT_HASH }}
-    secrets: inherit
-
-  run-k8s-tests-on-aks:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    needs: publish-kata-deploy-payload-amd64
-    uses: ./.github/workflows/run-k8s-tests-on-aks.yaml
-    with:
-      registry: ghcr.io
-      repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
-      commit-hash: ${{ env.COMMIT_HASH }}
-    secrets: inherit
-
-  run-k8s-tests-on-sev:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    needs: publish-kata-deploy-payload-amd64
-    uses: ./.github/workflows/run-k8s-tests-on-sev.yaml
-    with:
-      registry: ghcr.io
-      repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
-      commit-hash: ${{ env.COMMIT_HASH }}
-
-  run-k8s-tests-on-snp:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    needs: publish-kata-deploy-payload-amd64
-    uses: ./.github/workflows/run-k8s-tests-on-snp.yaml
-    with:
-      registry: ghcr.io
-      repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
       pr-number: ${{ env.PR_NUMBER }}
-      commit-hash: ${{ env.COMMIT_HASH }}
-
-  run-k8s-tests-on-tdx:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    needs: publish-kata-deploy-payload-amd64
-    uses: ./.github/workflows/run-k8s-tests-on-tdx.yaml
-    with:
-      registry: ghcr.io
-      repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
-      commit-hash: ${{ env.COMMIT_HASH }}
-
-  run-metrics-tests:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
-    needs: build-kata-static-tarball-amd64
-    uses: ./.github/workflows/run-metrics.yaml
-    with:
-      tarball-suffix: -${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
-      commit-hash: ${{ env.COMMIT_HASH }}
+      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -12,23 +12,28 @@ on:
       - synchronize
       - reopened
       - labeled
+env:
+  COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
+  PR_NUMBER: ${{ github.event.pull_requesst.number }}
 
 jobs:
   build-kata-static-tarball-amd64:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
-      tarball-suffix: -${{ github.event.pull_request.number}}-${{ github.event.pull_request.head.sha }}
+      tarball-suffix: -${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}
+      commit-hash: ${{ env.COMMIT_HASH }}
 
   publish-kata-deploy-payload-amd64:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     needs: build-kata-static-tarball-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
-      tarball-suffix: -${{ github.event.pull_request.number}}-${{ github.event.pull_request.head.sha }}
+      tarball-suffix: -${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-amd64
+      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
+      commit-hash: ${{ env.COMMIT_HASH }}
     secrets: inherit
 
   run-k8s-tests-on-aks:
@@ -38,7 +43,8 @@ jobs:
     with:
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-amd64
+      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
+      commit-hash: ${{ env.COMMIT_HASH }}
     secrets: inherit
 
   run-k8s-tests-on-sev:
@@ -48,7 +54,8 @@ jobs:
     with:
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-amd64
+      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
+      commit-hash: ${{ env.COMMIT_HASH }}
 
   run-k8s-tests-on-snp:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
@@ -57,7 +64,9 @@ jobs:
     with:
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-amd64
+      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
+      pr-number: ${{ env.PR_NUMBER }}
+      commit-hash: ${{ env.COMMIT_HASH }}
 
   run-k8s-tests-on-tdx:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
@@ -66,11 +75,13 @@ jobs:
     with:
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-amd64
+      tag: ${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
+      commit-hash: ${{ env.COMMIT_HASH }}
 
   run-metrics-tests:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     needs: build-kata-static-tarball-amd64
     uses: ./.github/workflows/run-metrics.yaml
     with:
-      tarball-suffix: -${{ github.event.pull_request.number}}-${{ github.event.pull_request.head.sha }}
+      tarball-suffix: -${{ env.PR_NUMBER }}-${{ env.COMMIT_HASH }}-amd64
+      commit-hash: ${{ env.COMMIT_HASH }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,7 +31,6 @@ jobs:
     secrets: inherit
 
   run-k8s-tests-on-aks:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-k8s-tests-on-aks.yaml
     with:
@@ -42,7 +41,6 @@ jobs:
     secrets: inherit
 
   run-k8s-tests-on-sev:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-k8s-tests-on-sev.yaml
     with:
@@ -52,7 +50,6 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
 
   run-k8s-tests-on-snp:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-k8s-tests-on-snp.yaml
     with:
@@ -63,7 +60,6 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
 
   run-k8s-tests-on-tdx:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-k8s-tests-on-tdx.yaml
     with:
@@ -73,7 +69,6 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
 
   run-metrics-tests:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     needs: build-kata-static-tarball-amd64
     uses: ./.github/workflows/run-metrics.yaml
     with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,81 @@
+name: Run the Kata Containers CI
+on:
+  workflow_call:
+    inputs:
+      commit-hash:
+        required: true
+        type: string
+      pr-number:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+
+jobs:
+  build-kata-static-tarball-amd64:
+    uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      commit-hash: ${{ inputs.commit-hash }}
+
+  publish-kata-deploy-payload-amd64:
+    needs: build-kata-static-tarball-amd64
+    uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-amd64
+      commit-hash: ${{ inputs.commit-hash }}
+    secrets: inherit
+
+  run-k8s-tests-on-aks:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    needs: publish-kata-deploy-payload-amd64
+    uses: ./.github/workflows/run-k8s-tests-on-aks.yaml
+    with:
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-amd64
+      commit-hash: ${{ inputs.commit-hash }}
+    secrets: inherit
+
+  run-k8s-tests-on-sev:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    needs: publish-kata-deploy-payload-amd64
+    uses: ./.github/workflows/run-k8s-tests-on-sev.yaml
+    with:
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-amd64
+      commit-hash: ${{ inputs.commit-hash }}
+
+  run-k8s-tests-on-snp:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    needs: publish-kata-deploy-payload-amd64
+    uses: ./.github/workflows/run-k8s-tests-on-snp.yaml
+    with:
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-amd64
+      pr-number: ${{ inputs.pr-number }}
+      commit-hash: ${{ inputs.commit-hash }}
+
+  run-k8s-tests-on-tdx:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    needs: publish-kata-deploy-payload-amd64
+    uses: ./.github/workflows/run-k8s-tests-on-tdx.yaml
+    with:
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-amd64
+      commit-hash: ${{ inputs.commit-hash }}
+
+  run-metrics-tests:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
+    needs: build-kata-static-tarball-amd64
+    uses: ./.github/workflows/run-metrics.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}-amd64
+      commit-hash: ${{ inputs.commit-hash }}

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -5,22 +5,28 @@ on:
       - main
       - stable-*
 
+env:
+  COMMIT_HASH: $GITHUB_REF
+
 jobs:
   build-assets-amd64:
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
+      commit-hash: ${{ env.COMMIT_HASH }}
       push-to-registry: yes
     secrets: inherit
 
   build-assets-arm64:
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
+      commit-hash: ${{ env.COMMIT_HASH }}
       push-to-registry: yes
     secrets: inherit
 
   build-assets-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
+      commit-hash: ${{ env.COMMIT_HASH }}
       push-to-registry: yes
     secrets: inherit
 
@@ -28,6 +34,7 @@ jobs:
     needs: build-assets-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
+      commit-hash: ${{ env.COMMIT_HASH }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-amd64
@@ -37,6 +44,7 @@ jobs:
     needs: build-assets-arm64
     uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
     with:
+      commit-hash: ${{ env.COMMIT_HASH }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-arm64
@@ -46,6 +54,7 @@ jobs:
     needs: build-assets-s390x
     uses: ./.github/workflows/publish-kata-deploy-payload-s390x.yaml
     with:
+      commit-hash: ${{ env.COMMIT_HASH }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-s390x

--- a/.github/workflows/publish-kata-deploy-payload-amd64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-amd64.yaml
@@ -14,6 +14,9 @@ on:
       tag:
         required: true
         type: string
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   kata-payload:
@@ -21,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -14,6 +14,9 @@ on:
       tag:
         required: true
         type: string
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   kata-payload:
@@ -25,7 +28,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -14,6 +14,9 @@ on:
       tag:
         required: true
         type: string
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   kata-payload:
@@ -25,7 +28,7 @@ jobs:
 
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -11,6 +11,12 @@ on:
       tag:
         required: true
         type: string
+      pr-number:
+        required: true
+        type: string
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   run-k8s-tests:
@@ -31,13 +37,13 @@ jobs:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}
       DOCKER_TAG: ${{ inputs.tag }}
-      GH_PR_NUMBER: ${{ github.event.pull_request.number }}
+      GH_PR_NUMBER: ${{ inputs.pr-number }}
       KATA_HOST_OS: ${{ matrix.host_os }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
 
       - name: Download Azure CLI
         run: bash tests/integration/gha-run.sh install-azure-cli

--- a/.github/workflows/run-k8s-tests-on-sev.yaml
+++ b/.github/workflows/run-k8s-tests-on-sev.yaml
@@ -11,6 +11,9 @@ on:
       tag:
         required: true
         type: string
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   run-k8s-tests:
@@ -29,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
 
       - name: Run tests
         timeout-minutes: 30

--- a/.github/workflows/run-k8s-tests-on-snp.yaml
+++ b/.github/workflows/run-k8s-tests-on-snp.yaml
@@ -11,6 +11,9 @@ on:
       tag:
         required: true
         type: string
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   run-k8s-tests:
@@ -29,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
 
       - name: Run tests
         timeout-minutes: 30

--- a/.github/workflows/run-k8s-tests-on-tdx.yaml
+++ b/.github/workflows/run-k8s-tests-on-tdx.yaml
@@ -11,6 +11,9 @@ on:
       tag:
         required: true
         type: string
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   run-k8s-tests:
@@ -29,7 +32,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
 
       - name: Run tests
         timeout-minutes: 30

--- a/.github/workflows/run-metrics.yaml
+++ b/.github/workflows/run-metrics.yaml
@@ -5,6 +5,9 @@ on:
       tarball-suffix:
         required: false
         type: string
+      commit-hash:
+        required: false
+        type: string
 
 jobs:
   run-metrics:
@@ -20,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ inputs.commit-hash }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3


### PR DESCRIPTION
The idea of this PR is to add nightly jobs for the bits we care, and ensure we have something similar to the "Green CI" effort, but as part of GitHub.

This is a draft PR, the idea is to gather feedback from the interested parts.

One thing to mention, how do we track it?  My idea was to add a badge on our `kata-containers/kata-containers/README.md`, and from there folks can monitor the state of the CI.