### PR TITLE
gha: Increaste timeout for AKS jobs and give more time to start running the tests

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -76,7 +76,7 @@ jobs:
           # This is needed as the kata-deploy pod will be set to "Ready" when it starts running,
           # which may cause issues like not having the node properly labeled or the artefacts
           # properly deployed when the tests actually start running.
-          sleep 150s
+          sleep 240s
 
           pushd tests/integration/kubernetes
           sed -i -e 's|runtimeClassName: kata|runtimeClassName: kata-${{ matrix.vmm }}|' runtimeclass_workloads/*.yaml

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -62,7 +62,7 @@ jobs:
           az aks get-credentials -g "kataCI" -n ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.vmm }}-amd64
 
       - name: Run tests
-        timeout-minutes: 35
+        timeout-minutes: 60
         run: |
           sed -i -e "s|quay.io/kata-containers/kata-deploy:latest|${{ inputs.registry }}/${{ inputs.repo }}:${{ inputs.tag }}|g" tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
           cat tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml


### PR DESCRIPTION
---

gha: aks: Increase the timeout time

We've seen tests being aborted close to the end of the run due to the
timeout.  Let's increase it, avoiding to hit such cases again..

Fixes: #6964

---

gha: aks: Wait longer to start running the tests

We're still facing issues related to the time taken to deploy the
kata-deplot daemonset and starting to run the tests.

Ideally, we should solve this with a readiness probe, and that's the
approach we want to take in the future.  However, for now, let's just
make sure those tests are not on the way of the community.

---