### PR TITLE
CCv0: kata-deploy-cc: Ignore pod annotations in kata-remote

### DIFF
--- a/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
@@ -211,9 +211,11 @@ function configure_containerd_runtime() {
 	fi
 	local runtime_table="plugins.${pluginid}.containerd.runtimes.$runtime"
 	local runtime_type="io.containerd.$runtime.v2"
-	local cri_handler_value=""
-        if echo "${runtime_type}" | grep -q -v -e "kata-remote\.v2" -e "kata\.v2"; then
-                cri_handler_value="cc"
+	local cri_handler_value="cc"
+	local pod_annotations='["io.katacontainers.*"]'
+	if [ "$runtime" == "kata-remote" ]; then
+		cri_handler_value=""
+		pod_annotations='[]'
 	fi
 	local options_table="$runtime_table.options"
 	local config_path="/opt/confidential-containers/share/defaults/kata-containers/$configuration.toml"
@@ -226,7 +228,7 @@ function configure_containerd_runtime() {
   cri_handler = "${cri_handler_value}"
   runtime_type = "${runtime_type}"
   privileged_without_host_devices = true
-  pod_annotations = ["io.katacontainers.*"]
+  pod_annotations = ${pod_annotations}
 EOF
 	fi
 


### PR DESCRIPTION
Pod annotations (io.katacontainers.*) are not meaningful for the remote hypervisor.
https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/how-to-set-sandbox-config-kata.md

This patch disables pod annotations in the kata-remote settings of the containerd configuration.

Fixes #6345

`config.toml` of containerd will look like this.

```
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata]
  cri_handler = "cc"
  runtime_type = "io.containerd.kata.v2"
  privileged_without_host_devices = true
  pod_annotations = ["io.katacontainers.*"]
  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata.options]
    ConfigPath = "/opt/confidential-containers/share/defaults/kata-containers/configuration.toml"
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-remote]
  cri_handler = ""
  runtime_type = "io.containerd.kata-remote.v2"
  privileged_without_host_devices = true
  pod_annotations = []
  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-remote.options]
    ConfigPath = "/opt/confidential-containers/share/defaults/kata-containers/configuration-remote.toml"
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu]
  cri_handler = "cc"
  runtime_type = "io.containerd.kata-qemu.v2"
  privileged_without_host_devices = true
  pod_annotations = ["io.katacontainers.*"]
  [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-qemu.options]
    ConfigPath = "/opt/confidential-containers/share/defaults/kata-containers/configuration-qemu.toml"
```