### PR TITLE
add support direct volume and refactor device manager

### DIFF
--- a/docs/how-to/README.md
+++ b/docs/how-to/README.md
@@ -45,3 +45,4 @@
 - [How to run Kata Containers with `nydus`](how-to-use-virtio-fs-nydus-with-kata.md)
 - [How to run Kata Containers with AMD SEV-SNP](how-to-run-kata-containers-with-SNP-VMs.md)
 - [How to use EROFS to build rootfs in Kata Containers](how-to-use-erofs-build-rootfs.md)
+- [How to run Kata Containers with kinds of Block Volumes](how-to-run-kata-containers-with-kinds-of-Block-Volumes.md)

--- a/docs/how-to/how-to-run-kata-containers-with-kinds-of-Block-Volumes.md
+++ b/docs/how-to/how-to-run-kata-containers-with-kinds-of-Block-Volumes.md
@@ -1,0 +1,78 @@
+# A new way for Kata Containers to use Kinds of Block Volumes
+
+> **Note:** This guide is only available for runtime-rs with default Hypervisor Dragonball.
+> Now, other hypervisors are still ongoing, and it'll be updated when they're ready.
+
+
+## Background
+
+Currently, there is no widely applicable and convenient method available for users to use some kinds of backend storages, such as File on host based block volume, SPDK based volume or VFIO device based volume for Kata Containers, so we adopt [Proposal: Direct Block Device Assignment](https://github.com/kata-containers/kata-containers/blob/main/docs/design/direct-blk-device-assignment.md) to address it.
+
+## Solution
+
+According to the proposal, it requires to use the `kata-ctl direct-volume` command to add a direct assigned block volume device to the Kata Containers runtime. 
+
+And then with the help of method [get_volume_mount_info](https://github.com/kata-containers/kata-containers/blob/099b4b0d0e3db31b9054e7240715f0d7f51f9a1c/src/libs/kata-types/src/mount.rs#L95), get information from JSON file: `(mountinfo.json)` and parse them into structure [Direct Volume Info](https://github.com/kata-containers/kata-containers/blob/099b4b0d0e3db31b9054e7240715f0d7f51f9a1c/src/libs/kata-types/src/mount.rs#L70) which is used to save device-related information. 
+
+We only fill the `mountinfo.json`, such as `device` ,`volume_type`, `fs_type`, `metadata` and `options`, which correspond to the fields in [Direct Volume Info](https://github.com/kata-containers/kata-containers/blob/099b4b0d0e3db31b9054e7240715f0d7f51f9a1c/src/libs/kata-types/src/mount.rs#L70), to describe a device. 
+
+The JSON file `mountinfo.json` placed in a sub-path `/kubelet/kata-test-vol-001/volume001` which under fixed path `/run/kata-containers/shared/direct-volumes/`. 
+And the full path looks like: `/run/kata-containers/shared/direct-volumes/kubelet/kata-test-vol-001/volume001`, But for some security reasons. it is 
+encoded as `/run/kata-containers/shared/direct-volumes/L2t1YmVsZXQva2F0YS10ZXN0LXZvbC0wMDEvdm9sdW1lMDAx`.
+
+Finally, when running a Kata Containers witch `ctr run --mount type=X, src=Y, dst=Z,,options=rbind:rw`, the `type=X` should be specified a proprietary type specifically designed for some kind of volume. 
+
+Now, supported types: 
+
+- `directvol` for direct volume
+- `spdkvol` for SPDK volume (TBD)
+- `vfiovol` for VFIO device based volume (TBD)
+
+
+## Setup Device and Run a Kata-Containers
+
+### Direct Block Device Based Volume
+
+#### create raw block based backend storage
+
+> **Tips:** raw block based backend storage MUST be formatted with `mkfs`.
+
+```bash
+$ sudo dd if=/dev/zero of=/tmp/stor/rawdisk01.20g bs=1M count=20480
+$ sudo mkfs.ext4 /tmp/stor/rawdisk01.20g
+```
+
+#### setup direct block device for kata-containers
+
+```json
+{
+  "device": "/tmp/stor/rawdisk01.20g", 
+  "volume_type": "directvol", 
+  "fs_type": "ext4", 
+  "metadata":"{}", 
+  "options": []
+}
+```
+
+```bash
+$ sudo ./kata-ctl direct-volume add /kubelet/kata-direct-vol-002/directvol002 "{\"device\": \"/tmp/stor/rawdisk01.20g\", \"volume_type\": \"directvol\", \"fs_type\": \"ext4\", \"metadata\":"{}", \"options\": []}"
+$# /kubelet/kata-direct-vol-002/directvol002 <==> /run/kata-containers/shared/direct-volumes/W1lMa2F0ZXQva2F0YS10a2F0DAxvbC0wMDEvdm9sdW1lMDAx
+$ cat W1lMa2F0ZXQva2F0YS10a2F0DAxvbC0wMDEvdm9sdW1lMDAx/mountInfo.json 
+{"volume_type":"directvol","device":"/tmp/stor/rawdisk01.20g","fs_type":"ext4","metadata":{},"options":[]}
+```
+
+#### Run a Kata container with direct block device volume
+
+```bash
+$ # type=disrectvol,src=/kubelet/kata-direct-vol-002/directvol002,dst=/disk002,options=rbind:rw
+$sudo ctr run -t --rm --runtime io.containerd.kata.v2 --mount type=directvol,src=/kubelet/kata-direct-vol-002/directvol002,dst=/disk002,options=rbind:rw "$image" kata-direct-vol-xx05302045 /bin/bash
+```
+
+
+### SPDK Device Based Volume
+
+TBD
+
+### VFIO Device Based Volume
+
+TBD

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -242,6 +242,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +839,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if 1.0.0",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1211,6 +1243,15 @@ name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "hermit-abi"
@@ -1619,6 +1660,7 @@ dependencies = [
  "slog-async",
  "slog-json",
  "slog-scope",
+ "slog-term",
 ]
 
 [[package]]
@@ -1846,7 +1888,16 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -2435,6 +2486,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom 0.2.8",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
 name = "regex"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,6 +2908,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog-term"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
+dependencies = [
+ "atty",
+ "slog",
+ "term",
+ "thread_local",
+ "time 0.3.20",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2964,6 +3039,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "termcolor"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3129,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd0cbfecb4d19b5ea75bb31ad904eb5b9fa13f21079c3b92017ebdf4999a5890"
 dependencies = [
  "itoa",
+ "libc",
+ "num_threads",
  "serde",
  "time-core",
  "time-macros",

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -7,7 +7,7 @@
 use std::{fs, path::Path, process::Command};
 
 use crate::device::Device;
-use crate::device::DeviceConfig;
+use crate::device::DeviceType;
 use crate::Hypervisor as hypervisor;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use anyhow::anyhow;
@@ -166,7 +166,7 @@ impl Device for VfioConfig {
         todo!()
     }
 
-    async fn get_device_info(&self) -> DeviceConfig {
+    async fn get_device_info(&self) -> DeviceType {
         todo!()
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user.rs
@@ -5,7 +5,7 @@
 //
 
 use crate::device::Device;
-use crate::device::DeviceConfig;
+use crate::device::DeviceType;
 use crate::Hypervisor as hypervisor;
 use anyhow::Result;
 use async_trait::async_trait;
@@ -47,7 +47,7 @@ impl Device for VhostUserConfig {
         todo!()
     }
 
-    async fn get_device_info(&self) -> DeviceConfig {
+    async fn get_device_info(&self) -> DeviceType {
         todo!()
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk.rs
@@ -6,7 +6,7 @@
 
 pub const VIRTIO_BLOCK_MMIO: &str = "virtio-blk-mmio";
 use crate::device::Device;
-use crate::device::{DeviceConfig, DeviceType};
+use crate::device::DeviceType;
 use crate::Hypervisor as hypervisor;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -98,8 +98,8 @@ impl Device for BlockDevice {
         Ok(Some(self.config.index))
     }
 
-    async fn get_device_info(&self) -> DeviceConfig {
-        DeviceConfig::BlockCfg(self.config.clone())
+    async fn get_device_info(&self) -> DeviceType {
+        DeviceType::Block(self.clone())
     }
 
     async fn increase_attach_count(&mut self) -> Result<bool> {

--- a/src/runtime-rs/crates/hypervisor/src/device/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/mod.rs
@@ -53,7 +53,7 @@ pub trait Device: Send + Sync {
     // detach is to unplug device from VM
     async fn detach(&mut self, h: &dyn hypervisor) -> Result<Option<u64>>;
     // get_device_info returns device config
-    async fn get_device_info(&self) -> DeviceConfig;
+    async fn get_device_info(&self) -> DeviceType;
     // increase_attach_count is used to increase the attach count for a device
     // return values:
     // * true: no need to do real attach when current attach count is zero, skip following actions.

--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -9,16 +9,18 @@ mod default_volume;
 pub mod hugepage;
 mod share_fs_volume;
 mod shm_volume;
-use async_trait::async_trait;
+pub mod utils;
 
-use crate::{share_fs::ShareFs, volume::block_volume::is_block_volume};
-use agent::Agent;
-use anyhow::{Context, Result};
-use hypervisor::device::device_manager::DeviceManager;
 use std::{sync::Arc, vec::Vec};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
 use tokio::sync::RwLock;
 
 use self::hugepage::{get_huge_page_limits_map, get_huge_page_option};
+use crate::{share_fs::ShareFs, volume::block_volume::is_block_volume};
+use agent::Agent;
+use hypervisor::device::device_manager::DeviceManager;
 
 const BIND: &str = "bind";
 
@@ -66,7 +68,7 @@ impl VolumeResource {
                     shm_volume::ShmVolume::new(m, shm_size)
                         .with_context(|| format!("new shm volume {:?}", m))?,
                 )
-            } else if is_block_volume(m) {
+            } else if is_block_volume(m).context("block volume type")? {
                 // handle block volume
                 Arc::new(
                     block_volume::BlockVolume::new(d, m, read_only, cid, sid)

--- a/src/runtime-rs/crates/resource/src/volume/utils.rs
+++ b/src/runtime-rs/crates/resource/src/volume/utils.rs
@@ -1,0 +1,65 @@
+// Copyright (c) 2022-2023 Alibaba Cloud
+// Copyright (c) 2022-2023 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::{fs, path::Path};
+
+use anyhow::{anyhow, Context, Result};
+
+use crate::{
+    share_fs::{do_get_guest_path, do_get_host_path},
+    volume::share_fs_volume::generate_mount_path,
+};
+use kata_sys_util::eother;
+use kata_types::mount::{get_volume_mount_info, DirectVolumeMountInfo};
+
+pub const DEFAULT_VOLUME_FS_TYPE: &str = "ext4";
+pub const KATA_MOUNT_BIND_TYPE: &str = "bind";
+pub const KATA_DIRECT_VOLUME_TYPE: &str = "directvol";
+pub const KATA_VFIO_VOLUME_TYPE: &str = "vfiovol";
+pub const KATA_SPDK_VOLUME_TYPE: &str = "spdkvol";
+
+// volume mount info load infomation from mountinfo.json
+pub fn volume_mount_info(volume_path: &str) -> Result<DirectVolumeMountInfo> {
+    get_volume_mount_info(volume_path)
+}
+
+pub fn get_file_name<P: AsRef<Path>>(src: P) -> Result<String> {
+    let file_name = src
+        .as_ref()
+        .file_name()
+        .map(|v| v.to_os_string())
+        .ok_or_else(|| {
+            eother!(
+                "failed to get file name of path {}",
+                src.as_ref().to_string_lossy()
+            )
+        })?
+        .into_string()
+        .map_err(|e| anyhow!("failed to convert to string {:?}", e))?;
+
+    Ok(file_name)
+}
+
+pub(crate) async fn generate_shared_path(
+    dest: String,
+    read_only: bool,
+    cid: &str,
+    sid: &str,
+) -> Result<String> {
+    let file_name = get_file_name(&dest).context("failed to get file name.")?;
+    let mount_name = generate_mount_path(cid, file_name.as_str());
+    let guest_path = do_get_guest_path(&mount_name, cid, true, false);
+    let host_path = do_get_host_path(&mount_name, sid, cid, true, read_only);
+
+    if dest.starts_with("/dev") {
+        fs::File::create(&host_path).context(format!("failed to create file {:?}", &host_path))?;
+    } else {
+        std::fs::create_dir_all(&host_path)
+            .map_err(|e| anyhow!("failed to create dir {}: {:?}", host_path, e))?;
+    }
+
+    Ok(guest_path)
+}


### PR DESCRIPTION
usage:
```bash
#direct volume 
$ sudo ctr run --runtime "io.containerd.kata.v2" --rm -t \
   --mount type=directvol,src=/tmp/directv01,dst=/data2,options=rbind:rw "$image" \
   test-kata2 /bin/bash
$ sudo ctr run --runtime "io.containerd.kata.v2" --rm -t \
   --mount type=directvol,src=/tmp/directv01,dst=/dev/vdc,options=rbind:rw "$image" \
   test-kata2 /bin/bash
```
device manager: refactor device manager implementation
the main aspects of the DM implementation refactoring as below:
1. reduce duplicated code
Many scenarios have similar steps when adding devices. so to reduce duplicated code,
we should create a common method abstracted and use it in various scenarios.
do_handle_device:
(1) new_device with DeviceConfig and return device_id;
(2) try_add_device with device_id and do really add device;
(3) return device info of device's info;
2. return full info of Device Trait get_device_info
replace the original type DeviceConfig with full info DeviceType.
3. refactor find_device method.

block volume/rootfs: add support direct volume.
As block/direct volume use similar steps of device adding,
so making full use of block volume code is a better way to
handle direct volume.

the only different point is that direct volume will use
DirectVolume and get_volume_mount_info to parse mountinfo.json
from the direct volume path. That's to say, direct volume needs
the help of `kata-ctl direct-volume ...`.

Fixes: https://github.com/kata-containers/kata-containers/issues/5656

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>