### PR TITLE
runtime-rs: handle copy files when share_fs is not available

### DIFF
--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -10,6 +10,7 @@ use crate::{network::NetworkConfig, resource_persist::ResourceState};
 use agent::{types::Device, Agent, Storage};
 use anyhow::{anyhow, Context, Ok, Result};
 use async_trait::async_trait;
+
 use hypervisor::{
     device::{device_manager::DeviceManager, DeviceConfig},
     BlockConfig, Hypervisor,
@@ -255,6 +256,7 @@ impl ResourceManagerInner {
                 spec,
                 self.device_manager.as_ref(),
                 &self.sid,
+                self.agent.clone(),
             )
             .await
     }

--- a/versions.yaml
+++ b/versions.yaml
@@ -324,12 +324,12 @@ languages:
   rust:
     description: "Rust language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.68.0"
+    version: "1.69.0"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.68.0"
+      newest-version: "1.69.0"
 
   golangci-lint:
     description: "golangci-lint"


### PR DESCRIPTION
In hypervisors that do not support virtiofs we have to copy files in the VM sandbox to properly setup the network (resolv.conf, hosts, and hostname).

To do that, we construct the volume as before, with the addition of an extra variable that designates the path where the file will reside in the sandbox.

In this case, we issue a `copy_file` agent request *and* we patch the spec to account for this change.

Fixes: #6978