### PR TITLE
gha: Unbreak CI and fix cluster creation step

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -52,7 +52,7 @@ jobs:
             -s "Standard_D4s_v5" \
             --node-count 1 \
             --generate-ssh-keys \
-            ${{ matrix.host_os == 'cbl-mariner' && '--os-sku mariner --workload-runtime KataMshvVmIsolation' }}
+            $([ "${{ matrix.host_os == 'cbl-mariner' }}" = "true" ] && echo "--os-sku mariner --workload-runtime KataMshvVmIsolation")
 
       - name: Install `bats`
         run: |


### PR DESCRIPTION
This fixes the regression introduced by https://github.com/kata-containers/kata-containers/pull/6686 by properly injecting the `--os-sku mariner --workload-runtime KataMshvVmIsolation` flags.

Error reference:
https://github.com/kata-containers/kata-containers/actions/runs/5111460297/jobs/9188819103

Fixes: https://github.com/kata-containers/kata-containers/issues/6982