### PR TITLE
packaging: make BUILDER_REGISTRY configurable

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -55,6 +55,7 @@ docker run \
 	-v "${kata_dir}:${kata_dir}" \
 	--env CI="${CI:-}" \
 	--env USER=${USER} \
+	--env BUILDER_REGISTRY="${BUILDER_REGISTRY:-}" \
 	--env PUSH_TO_REGISTRY="${PUSH_TO_REGISTRY:-"no"}" \
 	--env INITRAMFS_CONTAINER_BUILDER="${INITRAMFS_CONTAINER_BUILDER:-}" \
 	--env KERNEL_CONTAINER_BUILDER="${KERNEL_CONTAINER_BUILDER:-}" \

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -8,7 +8,7 @@
 export GOPATH=${GOPATH:-${HOME}/go}
 export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 export tests_repo_dir="$GOPATH/src/$tests_repo"
-export BUILDER_REGISTRY="quay.io/kata-containers/builders"
+export BUILDER_REGISTRY="${BUILDER_REGISTRY:-quay.io/kata-containers/builders}"
 export PUSH_TO_REGISTRY="${PUSH_TO_REGISTRY:-"no"}"
 
 this_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
This PR is to make an environment variable `BUILDER_REGISTRY` configurable so that those who want to use their own registry for build can set up the registry.

Fixes: #6988

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>