### PR TITLE
versions: Update Nydus Snapshotter version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -266,7 +266,7 @@ externals:
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.3.3"
+    version: "v0.4.0"
 
   ovmf:
     description: "Firmware, implementation of UEFI for virtual machines."


### PR DESCRIPTION
This PR updates the Nydus Snapshotter version to v0.4.0. This version has the following changes:
- The snapshotter's root dir can be a relative path from now on
- Blobs manager which downloads the nydus image blobs has be removed
- Nydus image optimizer gracefully exits when SIGTERM is signaled and flushes out all the pending filesystem events and replace json with csv
- Nydus-snapshotter now can directly be started even if no TOML configuration file is associated.

Fixes #6990