### PR TITLE
agent: Ignore already mounted dev/fs/pseudo-fs

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -842,6 +842,7 @@ dependencies = [
  "slog",
  "slog-scope",
  "slog-stdlog",
+ "slog-term",
  "tempfile",
  "test-utils",
  "thiserror",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -43,6 +43,7 @@ ipnetwork = "0.17.0"
 logging = { path = "../libs/logging" }
 slog = "2.5.2"
 slog-scope = "4.1.2"
+slog-term = "2.9.0"
 
 # Redirect ttrpc log calls
 slog-stdlog = "4.0.0"


### PR DESCRIPTION
Using an initrd and setting KATA_INIT=yes meaning we're using the kata-agent as the init process we need to make sure that the agent is not segfaulting if mounts  already happened.

Some workloads need to configure several things in the initrd before the kata-agent starts which involves having /proc or /sys already mounted.

Add functionality to ignore already mounted devs/fs/pseudo-fs.

Fixes: #6992