### PR TITLE
gha: Fix Mariner cluster creation

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -35,6 +35,8 @@ jobs:
       - name: Download Azure CLI
         run: |
           curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+          # The aks-preview extension is required while the Mariner Kata host is in preview.
+          az extension add --name aks-preview
 
       - name: Log into the Azure account
         run: |


### PR DESCRIPTION
While the Mariner Kata host is in preview, we need the `aks-preview` extension to enable the `--workload-runtime KataMshvVmIsolation` flag.

Fixes: #6994