### PR TITLE
gha: aks: Add the host_os as part of the aks cluster's name

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -50,7 +50,7 @@ jobs:
         run: |
           az aks create \
             -g "kataCI" \
-            -n "${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.vmm }}-amd64" \
+            -n "${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}-${{ matrix.vmm }}-${{ matrix.host_os }}-amd64" \
             -s "Standard_D4s_v5" \
             --node-count 1 \
             --generate-ssh-keys \


### PR DESCRIPTION
We need to do so, otherwise we'll create two clusters for testing Cloud Hypervisor with exactly the same name, one using Ubuntu, and one using Mariner.

Fixes: #6999