### PR TITLE
CCv0: update attestation-agent dependency

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -194,7 +194,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/attestation-agent"
-    version: "v0.5.0"
+    version: "aa1d3c510350cd2f2668aca374abba19e2b73b3f"
 
   cni-plugins:
     description: "CNI network plugins"


### PR DESCRIPTION
In preparation for CoCo 0.6.0 release, updated attestation-agent to commit aa1d3c510350cd2f2668aca374abba19e2b73b3f