### PR TITLE
CCv0: update td-shim dependency

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -311,7 +311,7 @@ externals:
   td-shim:
     description: "Confidential Containers Shim Firmware"
     url: "https://github.com/confidential-containers/td-shim"
-    version: "v0.5.0"
+    version: "3252047213b2c580c21bdc52f67e8515ca1e374a"
     toolchain: "nightly-2022-11-15"
 
   virtiofsd:


### PR DESCRIPTION
In preparation for CoCo 0.6.0 release, updated td-shim to commit 3252047213b2c580c21bdc52f67e8515ca1e374a