### PR TITLE
runtime-rs: Add Cloud Hypervisor network support

### DIFF
--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -59,6 +59,13 @@ impl TryFrom<NamedHypervisorConfig> for VmConfig {
 
         let fs = n.shared_fs_devices;
 
+        let mut net = n.network_devices;
+        if let Some(network_devices) = net.as_mut() {
+            for mut nic in network_devices {
+                nic.num_queues = cfg.network_info.network_queues as usize;
+            }
+        }
+
         let cpus = CpusConfig::try_from(cfg.cpu_info).map_err(VmConfigError::CPUError)?;
 
         let rng = RngConfig::from(cfg.machine_info);
@@ -129,6 +136,7 @@ impl TryFrom<NamedHypervisorConfig> for VmConfig {
             console,
             payload,
             fs,
+            net,
             pmem,
             disks,
             vsock: Some(vsock),

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
@@ -492,4 +492,5 @@ pub struct NamedHypervisorConfig {
     pub tdx_enabled: bool,
 
     pub shared_fs_devices: Option<Vec<FsConfig>>,
+    pub network_devices: Option<Vec<NetConfig>>,
 }

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -108,7 +108,7 @@ impl CloudHypervisorInner {
     }
 
     async fn boot_vm(&mut self) -> Result<()> {
-        let shared_fs_devices = self.get_shared_fs_devices().await?;
+        let (shared_fs_devices, network_devices) = self.get_configs_from_pending_devices().await?;
 
         let socket = self
             .api_socket
@@ -148,6 +148,7 @@ impl CloudHypervisorInner {
             cfg: hypervisor_config.clone(),
             tdx_enabled,
             shared_fs_devices,
+            network_devices,
         };
 
         let cfg = VmConfig::try_from(named_cfg)?;


### PR DESCRIPTION
clh's `NetConfig` struct has tap, mac and num_queues fileds.
- `NetConfig.mac` is from `NetworkDevice.config.guest_mac`
- `NetConfig.num_queues` is from `NetworkInfo.network_queues`

Fixes: #6333