### PR TITLE
kata-deploy: Change how we get the Ubuntu k8s key

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -16,9 +16,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN \
 apt-get update && \
-apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl xz-utils systemd && \
+apt-get install -y --no-install-recommends apt-transport-https ca-certificates curl gpg xz-utils systemd && \
 mkdir -p /etc/apt/keyrings/ && \
-curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.gpg https://dl.k8s.io/apt/doc/apt-key.gpg && \
+curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/kubernetes-archive-keyring.gpg && \
 echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.gpg] https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list && \
 apt-get update && \
 apt-get install -y --no-install-recommends kubectl && \


### PR DESCRIPTION
The current method has been failing every now and then, and was reported on https://github.com/kubernetes/release/issues/2862.

Ding poked me and suggested to do this change here, so here we go. :-)

Fixes: #7006