### PR TITLE
README: Display badge for the "Publish Artefacts" job and update the Kata Containers logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <img src="https://www.openstack.org/assets/kata/kata-vertical-on-white.png" width="150">
 
+[![CI | Publish Kata Containers payload](https://github.com/kata-containers/kata-containers/actions/workflows/payload-after-push.yaml/badge.svg)](https://github.com/kata-containers/kata-containers/actions/workflows/payload-after-push.yaml)
+
 # Kata Containers
 
 Welcome to Kata Containers!

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="https://www.openstack.org/assets/kata/kata-vertical-on-white.png" width="150">
+<img src="https://object-storage-ca-ymq-1.vexxhost.net/swift/v1/6e4619c416ff4bd19e1c087f27a43eea/www-images-prod/openstack-logo/kata/SVG/kata-1.svg" width="900">
 
 [![CI | Publish Kata Containers payload](https://github.com/kata-containers/kata-containers/actions/workflows/payload-after-push.yaml/badge.svg)](https://github.com/kata-containers/kata-containers/actions/workflows/payload-after-push.yaml)
 


### PR DESCRIPTION
---

readme: Add status badge for the "Publish Artefacts" job

Let's start adding the status of our jobs as part of our main page, so
folks monitoring those can easily check whether they're okay, or if
someone has to be pinged about those.

Fixes: #7008 

---

readme: Update Kata Containers logo

Let's use the horizontal logo, as it occupies better the space the we
have.

The logo comes from:
https://openinfra.dev/brand/logos

---