### PR TITLE
static-build: Docker image pull ubuntu image

### DIFF
--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -18,6 +18,8 @@ DESTDIR=${DESTDIR:-${PWD}}
 PREFIX=${PREFIX:-/opt/kata}
 container_image="${KERNEL_CONTAINER_BUILDER:-$(get_kernel_image_name)}"
 
+sudo docker image pull ubuntu:22.04
+
 sudo docker pull ${container_image} || \
 	(sudo docker build -t "${container_image}" "${script_dir}" && \
 	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"


### PR DESCRIPTION
We need to do a docker image pull of the ubuntu image that we are going to use for the kernel build with the Dockerfile in order to avoid failures like
#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 617B done
#2 DONE 0.0s

#3 [internal] load metadata for docker.io/library/ubuntu:22.04
#3 ERROR: failed to authorize: DeadlineExceeded: failed to fetch anonymous token  

Fixes #7014