### PR TITLE
Osbuilder: run mount configuration for systemd in rootfs builder

### DIFF
--- a/src/agent/kata-containers.target
+++ b/src/agent/kata-containers.target
@@ -6,7 +6,7 @@
 
 [Unit]
 Description=Kata Containers Agent Target
-Requires=basic.target
+Requires=basic.target systemd-remount-fs.service
 Requires=tmp.mount
 Wants=chronyd.service
 Requires=kata-agent.service

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -520,6 +520,15 @@ Options=mode=1777,strictatime,nosuid,nodev
 EOF
 	fi
 
+    if [ "$AGENT_INIT" != "yes" ]; then
+		local unitFile="./etc/fstab"
+		info "Create or append /etc/fstab listing for /run in ./etc/fstab"
+		mkdir -p `dirname "$unitFile"`
+        cat >> "$unitFile" << EOF
+tmpfs /run tmpfs defaults,size=50% 0 2
+EOF
+    fi
+
 	popd  >> /dev/null
 
 	[ -n "${KERNEL_MODULES_DIR}" ] && copy_kernel_modules ${KERNEL_MODULES_DIR} ${ROOTFS_DIR}


### PR DESCRIPTION
When systemd is agent init, for the Rootfs-image case the allocation and options of /run are different from the the initrd case. 
This changes the options for the image case in line. Most notably including larger, 50% allocation for /run. 
Normally this could be handled with a mount file, but given /run being an API FS, it is different per https://www.freedesktop.org/wiki/Software/systemd/APIFileSystems/, so needs a fstab listing, and a specific systemd service running.
This writes to an fstab file the same way we would a mount file. The service is static, so to enable it, we can set a dependency in the kata-containers.target


Fixes: #6775