### PR TITLE
runtime-rs: add parameter for propagation of (u)mount events

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -16,11 +16,13 @@ use dragonball::{
     api::v1::{BlockDeviceConfigInfo, BootSourceConfig, VcpuResizeInfo},
     vm::VmConfigInfo,
 };
+
 use kata_sys_util::mount;
 use kata_types::{
     capabilities::{Capabilities, CapabilityBits},
     config::hypervisor::Hypervisor as HypervisorConfig,
 };
+use nix::mount::MsFlags;
 use persist::sandbox_persist::Persist;
 use shim_interface::KATA_PATH;
 use std::{collections::HashSet, fs::create_dir_all, path::PathBuf};
@@ -232,7 +234,8 @@ impl DragonballInner {
         }
 
         let jailed_location = [self.jailer_root.as_str(), dst].join("/");
-        mount::bind_mount_unchecked(src, jailed_location.as_str(), false).context("bind_mount")?;
+        mount::bind_mount_unchecked(src, jailed_location.as_str(), false, MsFlags::MS_SLAVE)
+            .context("bind_mount")?;
 
         let mut abs_path = String::from("/");
         abs_path.push_str(dst);

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
@@ -18,6 +18,7 @@ use hypervisor::{
     Hypervisor, ShareFsDeviceConfig,
 };
 use kata_sys_util::mount;
+use nix::mount::MsFlags;
 
 use super::{utils, PASSTHROUGH_FS_DIR};
 
@@ -45,7 +46,7 @@ pub(crate) async fn prepare_virtiofs(
     let host_rw_dest = utils::get_host_rw_shared_path(id);
     utils::ensure_dir_exist(&host_rw_dest)?;
 
-    mount::bind_mount_unchecked(&host_rw_dest, &host_ro_dest, true)
+    mount::bind_mount_unchecked(&host_rw_dest, &host_ro_dest, true, MsFlags::MS_SLAVE)
         .context("bind mount shared_fs directory")?;
 
     let share_fs_device = ShareFsDevice {

--- a/src/runtime-rs/crates/resource/src/share_fs/utils.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/utils.rs
@@ -11,6 +11,7 @@ use std::{
 
 use anyhow::Result;
 use kata_sys_util::mount;
+use nix::mount::MsFlags;
 
 use super::*;
 
@@ -45,7 +46,7 @@ pub(crate) fn share_to_guest(
     is_rafs: bool,
 ) -> Result<String> {
     let host_dest = do_get_host_path(target, sid, cid, is_volume, false);
-    mount::bind_mount_unchecked(source, &host_dest, readonly)
+    mount::bind_mount_unchecked(source, &host_dest, readonly, MsFlags::MS_SLAVE)
         .with_context(|| format!("failed to bind mount {} to {}", source, &host_dest))?;
 
     // bind mount remount event is not propagated to mount subtrees, so we have


### PR DESCRIPTION
Add an extra parameter in `bind_mount_unchecked` to specify the propagation type: "shared" or "slave".

Fixes: #7017