### PR TITLE
runtime-rs: skip ipip network interfaces (iff_noarp)

### DIFF
--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -173,7 +173,7 @@ async fn get_entity_from_netns(config: &NetworkWithNetNsConfig) -> Result<Vec<Ne
         let link = link::get_link_from_message(link);
         let attrs = link.attrs();
 
-        if (attrs.flags & libc::IFF_LOOPBACK as u32) != 0 {
+        if (attrs.flags & (libc::IFF_LOOPBACK as u32 | libc::IFF_NOARP as u32)) != 0 {
             continue;
         }
 


### PR DESCRIPTION
when setting up the network, we check whether an interface has the IFF_LOOPBACK flag and we skip it. However, if ipip is enabled, the tunl0 appears first in the new network namespace.

During this network link discovery, we find it first, and try to add it as an endpoint.

Adding the IFF_NOARP flag makes it skip this, and proceed to the veth interface.

A workaround is to set net.core.fb_tunnels_only_for_init_net to 1.

Fixes: #7028