### PR TITLE
CCv0: Update dependencies to v0.6.0 for release

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1849,7 +1849,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/image-rs?rev=22224d9#22224d9e3e795022c009150cd405b95b0f94aa83"
+source = "git+https://github.com/confidential-containers/image-rs?tag=v0.6.0#62288ee4cd275c3c9d02c7f650d2cad8d8920b04"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2705,7 +2705,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/ocicrypt-rs.git?rev=defbacc#defbacc393ea26c78f207eceb21ce8090b6a161e"
+source = "git+https://github.com/confidential-containers/ocicrypt-rs.git?tag=v0.6.0#c8d248d2a56ba4fd48263f8c442e1f9598b4c8f5"
 dependencies = [
  "aes 0.8.2",
  "anyhow",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -71,7 +71,7 @@ clap = { version = "3.0.1", features = ["derive"] }
 openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
-image-rs = { git = "https://github.com/confidential-containers/image-rs", rev = "22224d9", default-features = false, features = ["kata-cc-native-tls"] }
+image-rs = { git = "https://github.com/confidential-containers/image-rs", tag = "v0.6.0", default-features = false, features = ["kata-cc-native-tls"] }
 
 [patch.crates-io]
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }

--- a/versions.yaml
+++ b/versions.yaml
@@ -194,7 +194,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/attestation-agent"
-    version: "aa1d3c510350cd2f2668aca374abba19e2b73b3f"
+    version: "v0.6.0"
 
   cni-plugins:
     description: "CNI network plugins"

--- a/versions.yaml
+++ b/versions.yaml
@@ -311,7 +311,7 @@ externals:
   td-shim:
     description: "Confidential Containers Shim Firmware"
     url: "https://github.com/confidential-containers/td-shim"
-    version: "3252047213b2c580c21bdc52f67e8515ca1e374a"
+    version: "v0.6.0"
     toolchain: "nightly-2022-11-15"
 
   virtiofsd:


### PR DESCRIPTION
This updates image-rs, attestation-agent, and td-shim to v0.6.0 for the upcoming release.