### PR TITLE
Revert "agent: fix the issue of exec hang with a backgroud process"

### DIFF
--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -161,7 +161,7 @@ impl Process {
 
     pub fn notify_term_close(&mut self) {
         let notify = self.term_exit_notifier.clone();
-        notify.notify_waiters();
+        notify.notify_one();
     }
 
     pub fn close_stdin(&mut self) {

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -595,16 +595,15 @@ impl AgentService {
         let cid = req.container_id;
         let eid = req.exec_id;
 
-        let term_exit_notifier;
+        let mut term_exit_notifier = Arc::new(tokio::sync::Notify::new());
         let reader = {
             let s = self.sandbox.clone();
             let mut sandbox = s.lock().await;
 
             let p = sandbox.find_container_process(cid.as_str(), eid.as_str())?;
 
-            term_exit_notifier = p.term_exit_notifier.clone();
-
             if p.term_master.is_some() {
+                term_exit_notifier = p.term_exit_notifier.clone();
                 p.get_reader(StreamType::TermMaster)
             } else if stdout {
                 if p.parent_stdout.is_some() {

--- a/tests/integration/kubernetes/k8s-number-cpus.bats
+++ b/tests/integration/kubernetes/k8s-number-cpus.bats
@@ -9,6 +9,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "Test is currently failing, aee: https://github.com/kata-containers/kata-containers/issues/7270"
+
 	pod_name="cpu-test"
 	container_name="c1"
 	get_pod_config_dir
@@ -16,6 +18,8 @@ setup() {
 
 # Skip on aarch64 due to missing cpu hotplug related functionality.
 @test "Check number of cpus" {
+	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "Test is currently failing, see: https://github.com/kata-containers/kata-containers/issues/7270"
+
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-number-cpu.yaml"
 
@@ -40,6 +44,8 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "Test is currently failing, see: https://github.com/kata-containers/kata-containers/issues/7270"
+
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/tests/integration/kubernetes/k8s-oom.bats
+++ b/tests/integration/kubernetes/k8s-oom.bats
@@ -9,11 +9,15 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "Test is currently failing, see: https://github.com/kata-containers/kata-containers/issues/7271"
+
 	pod_name="pod-oom"
 	get_pod_config_dir
 }
 
 @test "Test OOM events for pods" {
+	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "Test is currently failing, see: https://github.com/kata-containers/kata-containers/issues/7271"
+
 	# Create pod
 	kubectl create -f "${pod_config_dir}/$pod_name.yaml"
 
@@ -29,6 +33,8 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "Test is currently failing, see: https://github.com/kata-containers/kata-containers/issues/7271"
+
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 	kubectl get "pod/$pod_name" -o yaml


### PR DESCRIPTION
This reverts commit 25d2fb0fdecf5d76fcb8a4ecde5c54c0d4c3e240.

The reason we're reverting the commit is because it to check whether it's the cause for the regression on devmapper tests.

Fixes: #0000