### PR TITLE
runtime-rs: add support spdk/vhost-user based volume.

### DIFF
--- a/src/dragonball/src/device_manager/blk_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/blk_dev_mgr.rs
@@ -114,6 +114,8 @@ pub enum BlockDeviceType {
     /// SPOOL is a reliable NVMe virtualization system for the cloud environment.
     /// You could learn more SPOOL here: https://www.usenix.org/conference/atc20/presentation/xue
     Spool,
+    /// The standard vhost-user-blk based device such as Spdk device.
+    Spdk,
     /// Local disk/file based low level device.
     RawBlock,
 }
@@ -124,6 +126,8 @@ impl BlockDeviceType {
         // SPOOL path should be started with "spool", e.g. "spool:/device1"
         if path.starts_with("spool:/") {
             BlockDeviceType::Spool
+        } else if path.starts_with("spdk:/") {
+            BlockDeviceType::Spdk
         } else {
             BlockDeviceType::RawBlock
         }
@@ -399,6 +403,10 @@ impl BlockDeviceMgr {
                             );
                             BlockDeviceError::DeviceManager(e)
                         })
+                    }
+                    BlockDeviceType::Spool | BlockDeviceType::Spdk => {
+                        // TBD
+                        todo!()
                     }
                     _ => Err(BlockDeviceError::InvalidBlockDeviceType),
                 }

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
@@ -1,5 +1,5 @@
-// Copyright (c) 2019-2022 Alibaba Cloud
-// Copyright (c) 2019-2022 Ant Group
+// Copyright (c) 2019-2023 Alibaba Cloud
+// Copyright (c) 2019-2023 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0
 //
@@ -25,6 +25,9 @@ pub use virtio_fs::{
 };
 pub use virtio_net::{Address, NetworkConfig, NetworkDevice};
 pub use virtio_vsock::{HybridVsockConfig, HybridVsockDevice, VsockConfig, VsockDevice};
+
+pub mod vhost_user_blk;
+pub use vhost_user::{VhostUserConfig, VhostUserDevice, VhostUserType};
 
 use anyhow::{anyhow, Context, Result};
 

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user.rs
@@ -1,61 +1,73 @@
-// Copyright (c) 2019-2023 Alibaba Cloud
-// Copyright (c) 2019-2023 Ant Group
+// Copyright (c) 2022-2023 Alibaba Cloud
+// Copyright (c) 2022-2023 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::device::Device;
-use crate::device::DeviceType;
-use crate::Hypervisor as hypervisor;
-use anyhow::Result;
-use async_trait::async_trait;
+#[derive(Debug, Clone)]
+pub enum VhostUserType {
+    /// Blk - represents a block vhostuser device type
+    /// "vhost-user-blk-pci"
+    Blk(String),
+
+    /// SCSI - represents SCSI based vhost-user type
+    /// "vhost-user-scsi-pci"
+    SCSI(String),
+
+    /// Net - represents Net based vhost-user type
+    /// "virtio-net-pci"
+    Net(String),
+
+    /// FS - represents a virtio-fs vhostuser device type
+    /// "vhost-user-fs-pci"
+    FS(String),
+}
+
+impl Default for VhostUserType {
+    fn default() -> Self {
+        VhostUserType::Blk("vhost-user-blk-pci".to_owned())
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 /// VhostUserConfig represents data shared by most vhost-user devices
 pub struct VhostUserConfig {
-    /// Device id
+    /// device id
     pub dev_id: String,
-    /// Socket path
+    /// socket path
     pub socket_path: String,
-    /// Mac_address is only meaningful for vhost user net device
+    /// mac_address is only meaningful for vhost user net device
     pub mac_address: String,
-    /// These are only meaningful for vhost user fs devices
+
+    /// vhost-user-fs is only meaningful for vhost-user-fs device
     pub tag: String,
-    pub cache: String,
-    pub device_type: String,
-    /// Pci_addr is the PCI address used to identify the slot at which the drive is attached.
-    pub pci_addr: Option<String>,
-    /// Block index of the device if assigned
-    pub index: u8,
+    /// vhost-user-fs cache mode
+    pub cache_mode: String,
+    /// vhost-user-fs cache size in MB
     pub cache_size: u32,
-    pub queue_siez: u32,
+
+    /// vhost user device type
+    pub device_type: VhostUserType,
+    /// guest block driver
+    pub driver_option: String,
+    /// pci_addr is the PCI address used to identify the slot at which the drive is attached.
+    pub pci_addr: Option<String>,
+
+    /// Block index of the device if assigned
+    /// type u64 is not OK
+    pub index: u64,
+
+    /// Virtio queue size. Size: byte
+    pub queue_size: u32,
+    /// Block device multi-queue
+    pub num_queues: usize,
+
+    /// device path in guest
+    pub virt_path: String,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct VhostUserDevice {
     pub device_id: String,
     pub config: VhostUserConfig,
-}
-
-#[async_trait]
-impl Device for VhostUserConfig {
-    async fn attach(&mut self, _h: &dyn hypervisor) -> Result<()> {
-        todo!()
-    }
-
-    async fn detach(&mut self, _h: &dyn hypervisor) -> Result<Option<u64>> {
-        todo!()
-    }
-
-    async fn get_device_info(&self) -> DeviceType {
-        todo!()
-    }
-
-    async fn increase_attach_count(&mut self) -> Result<bool> {
-        todo!()
-    }
-
-    async fn decrease_attach_count(&mut self) -> Result<bool> {
-        todo!()
-    }
 }

--- a/src/runtime-rs/crates/hypervisor/src/device/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/mod.rs
@@ -6,10 +6,11 @@
 
 use std::fmt;
 
+use crate::device::driver::vhost_user_blk::VhostUserBlkDevice;
 use crate::{
     BlockConfig, BlockDevice, HybridVsockConfig, HybridVsockDevice, Hypervisor as hypervisor,
     NetworkConfig, NetworkDevice, ShareFsDevice, ShareFsDeviceConfig, ShareFsMountConfig,
-    ShareFsMountDevice, VfioConfig, VfioDevice, VsockConfig, VsockDevice,
+    ShareFsMountDevice, VfioConfig, VfioDevice, VhostUserConfig, VsockConfig, VsockDevice,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -21,6 +22,7 @@ pub mod util;
 #[derive(Debug)]
 pub enum DeviceConfig {
     BlockCfg(BlockConfig),
+    VhostUserBlkCfg(VhostUserConfig),
     NetworkCfg(NetworkConfig),
     ShareFsCfg(ShareFsDeviceConfig),
     VfioCfg(VfioConfig),
@@ -32,6 +34,7 @@ pub enum DeviceConfig {
 #[derive(Debug)]
 pub enum DeviceType {
     Block(BlockDevice),
+    VhostUserBlk(VhostUserBlkDevice),
     Vfio(VfioDevice),
     Network(NetworkDevice),
     ShareFs(ShareFsDevice),

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -35,19 +35,16 @@ pub struct ResourceManager {
 }
 
 impl ResourceManager {
-    pub fn new(
+    pub async fn new(
         sid: &str,
         agent: Arc<dyn Agent>,
         hypervisor: Arc<dyn Hypervisor>,
         toml_config: Arc<TomlConfig>,
     ) -> Result<Self> {
         Ok(Self {
-            inner: Arc::new(RwLock::new(ResourceManagerInner::new(
-                sid,
-                agent,
-                hypervisor,
-                toml_config,
-            )?)),
+            inner: Arc::new(RwLock::new(
+                ResourceManagerInner::new(sid, agent, hypervisor, toml_config).await?,
+            )),
         })
     }
 

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -51,15 +51,16 @@ pub(crate) struct ResourceManagerInner {
 }
 
 impl ResourceManagerInner {
-    pub(crate) fn new(
+    pub(crate) async fn new(
         sid: &str,
         agent: Arc<dyn Agent>,
         hypervisor: Arc<dyn Hypervisor>,
         toml_config: Arc<TomlConfig>,
     ) -> Result<Self> {
         // create device manager
-        let dev_manager =
-            DeviceManager::new(hypervisor.clone()).context("failed to create device manager")?;
+        let dev_manager = DeviceManager::new(hypervisor.clone())
+            .await
+            .context("failed to create device manager")?;
 
         let cgroups_resource = CgroupsResource::new(sid, &toml_config)?;
         let cpu_resource = CpuResource::new(toml_config.clone())?;
@@ -473,7 +474,9 @@ impl Persist for ResourceManagerInner {
             sid: resource_args.sid,
             agent: resource_args.agent,
             hypervisor: resource_args.hypervisor.clone(),
-            device_manager: Arc::new(RwLock::new(DeviceManager::new(resource_args.hypervisor)?)),
+            device_manager: Arc::new(RwLock::new(
+                DeviceManager::new(resource_args.hypervisor).await?,
+            )),
             network: None,
             share_fs: None,
             rootfs_resource: RootFsResource::new(),

--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -14,6 +14,9 @@ pub mod utils;
 pub mod vfio_volume;
 use vfio_volume::is_vfio_volume;
 
+pub mod spdk_volume;
+use spdk_volume::is_spdk_volume;
+
 use std::{sync::Arc, vec::Vec};
 
 use anyhow::{Context, Result};
@@ -83,6 +86,12 @@ impl VolumeResource {
                     vfio_volume::VfioVolume::new(d, m, read_only, cid, sid)
                         .await
                         .with_context(|| format!("new vfio volume {:?}", m))?,
+                )
+            } else if is_spdk_volume(m) {
+                Arc::new(
+                    spdk_volume::SPDKVolume::new(d, m, read_only, cid, sid)
+                        .await
+                        .with_context(|| format!("create spdk volume {:?}", m))?,
                 )
             } else if let Some(options) =
                 get_huge_page_option(m).context("failed to check huge page")?

--- a/src/runtime-rs/crates/resource/src/volume/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/spdk_volume.rs
@@ -1,0 +1,189 @@
+// Copyright (c) 2023 Alibaba Cloud
+// Copyright (c) 2023 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use nix::sys::{stat, stat::SFlag};
+use tokio::sync::RwLock;
+
+use super::Volume;
+use crate::volume::utils::{
+    generate_shared_path, volume_mount_info, DEFAULT_VOLUME_FS_TYPE, KATA_SPDK_VOLUME_TYPE,
+    KATA_SPOOL_VOLUME_TYPE,
+};
+use hypervisor::{
+    device::{
+        device_manager::{do_handle_device, DeviceManager},
+        DeviceConfig, DeviceType,
+    },
+    VhostUserConfig, VhostUserType,
+};
+
+/// SPDKVolume: spdk block device volume
+#[derive(Clone)]
+pub(crate) struct SPDKVolume {
+    storage: Option<agent::Storage>,
+    mount: oci::Mount,
+    device_id: String,
+}
+
+impl SPDKVolume {
+    pub(crate) async fn new(
+        d: &RwLock<DeviceManager>,
+        m: &oci::Mount,
+        read_only: bool,
+        cid: &str,
+        sid: &str,
+    ) -> Result<Self> {
+        let mnt_src: &str = &m.source;
+
+        // deserde Information from mountinfo.json
+        let v = volume_mount_info(mnt_src).context("deserde information from mountinfo.json")?;
+        let device = match v.volume_type.as_str() {
+            KATA_SPDK_VOLUME_TYPE => {
+                if v.device.starts_with("spdk://") {
+                    v.device.clone()
+                } else {
+                    format!("spdk://{}", v.device.as_str())
+                }
+            }
+            KATA_SPOOL_VOLUME_TYPE => {
+                if v.device.starts_with("spool://") {
+                    v.device.clone()
+                } else {
+                    format!("spool://{}", v.device.as_str())
+                }
+            }
+            _ => return Err(anyhow!("mountinfo.json is invalid")),
+        };
+
+        // device format: X:///x/y/z.sock,so just unwrap it.
+        // if file is not S_IFSOCK, return error.
+        {
+            // device tokens: (Type, Socket)
+            let device_tokens = device.split_once("://").unwrap();
+
+            let fstat = stat::stat(device_tokens.1).context("stat socket failed")?;
+            let s_flag = SFlag::from_bits_truncate(fstat.st_mode);
+            if s_flag != SFlag::S_IFSOCK {
+                return Err(anyhow!("device {:?} is not valid", device));
+            }
+        }
+
+        let mut vhu_blk_config = &mut VhostUserConfig {
+            socket_path: device,
+            device_type: VhostUserType::Blk("vhost-user-blk-pci".to_owned()),
+            ..Default::default()
+        };
+
+        if let Some(num) = v.metadata.get("num_queues") {
+            vhu_blk_config.num_queues = num
+                .parse::<usize>()
+                .context("num queues parse usize failed.")?;
+        }
+        if let Some(size) = v.metadata.get("queue_size") {
+            vhu_blk_config.queue_size = size
+                .parse::<u32>()
+                .context("num queues parse u32 failed.")?;
+        }
+
+        // create and insert block device into Kata VM
+        let device_info =
+            do_handle_device(d, &DeviceConfig::VhostUserBlkCfg(vhu_blk_config.clone()))
+                .await
+                .context("do handle device failed.")?;
+
+        // generate host guest shared path
+        let guest_path = generate_shared_path(m.destination.clone(), read_only, cid, sid)
+            .await
+            .context("generate host-guest shared path failed")?;
+
+        // storage
+        let mut storage = agent::Storage {
+            mount_point: guest_path.clone(),
+            ..Default::default()
+        };
+
+        storage.options = if read_only {
+            vec!["ro".to_string()]
+        } else {
+            Vec::new()
+        };
+
+        let mut device_id = String::new();
+        if let DeviceType::VhostUserBlk(device) = device_info {
+            // blk, mmioblk
+            storage.driver = device.config.driver_option;
+            // /dev/vdX
+            storage.source = device.config.virt_path;
+            device_id = device.device_id;
+        }
+
+        if m.r#type != "bind" {
+            storage.fs_type = v.fs_type.clone();
+        } else {
+            storage.fs_type = DEFAULT_VOLUME_FS_TYPE.to_string();
+        }
+
+        if m.destination.clone().starts_with("/dev") {
+            storage.fs_type = "bind".to_string();
+            storage.options.append(&mut m.options.clone());
+        }
+
+        storage.fs_group = None;
+        let mount = oci::Mount {
+            destination: m.destination.clone(),
+            r#type: storage.fs_type.clone(),
+            source: guest_path,
+            options: m.options.clone(),
+        };
+
+        Ok(Self {
+            storage: Some(storage),
+            mount,
+            device_id,
+        })
+    }
+}
+
+#[async_trait]
+impl Volume for SPDKVolume {
+    fn get_volume_mount(&self) -> Result<Vec<oci::Mount>> {
+        Ok(vec![self.mount.clone()])
+    }
+
+    fn get_storage(&self) -> Result<Vec<agent::Storage>> {
+        let s = if let Some(s) = self.storage.as_ref() {
+            vec![s.clone()]
+        } else {
+            vec![]
+        };
+
+        Ok(s)
+    }
+
+    async fn cleanup(&self, device_manager: &RwLock<DeviceManager>) -> Result<()> {
+        device_manager
+            .write()
+            .await
+            .try_remove_device(&self.device_id)
+            .await
+    }
+
+    fn get_device_id(&self) -> Result<Option<String>> {
+        Ok(Some(self.device_id.clone()))
+    }
+}
+
+pub(crate) fn is_spdk_volume(m: &oci::Mount) -> bool {
+    // spdkvol or spoolvol will share the same implementation
+    let vol_types = vec![KATA_SPDK_VOLUME_TYPE, KATA_SPOOL_VOLUME_TYPE];
+    if vol_types.contains(&m.r#type.as_str()) {
+        return true;
+    }
+
+    false
+}

--- a/src/runtime-rs/crates/resource/src/volume/utils.rs
+++ b/src/runtime-rs/crates/resource/src/volume/utils.rs
@@ -20,6 +20,7 @@ pub const KATA_MOUNT_BIND_TYPE: &str = "bind";
 pub const KATA_DIRECT_VOLUME_TYPE: &str = "directvol";
 pub const KATA_VFIO_VOLUME_TYPE: &str = "vfiovol";
 pub const KATA_SPDK_VOLUME_TYPE: &str = "spdkvol";
+pub const KATA_SPOOL_VOLUME_TYPE: &str = "spoolvol";
 
 // volume mount info load infomation from mountinfo.json
 pub fn volume_mount_info(volume_path: &str) -> Result<DirectVolumeMountInfo> {

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -74,12 +74,8 @@ impl RuntimeHandler for VirtContainer {
 
         // get uds from hypervisor and get config from toml_config
         let agent = new_agent(&config).context("new agent")?;
-        let resource_manager = Arc::new(ResourceManager::new(
-            sid,
-            agent.clone(),
-            hypervisor.clone(),
-            config,
-        )?);
+        let resource_manager =
+            Arc::new(ResourceManager::new(sid, agent.clone(), hypervisor.clone(), config).await?);
         let pid = std::process::id();
 
         let sandbox = sandbox::VirtSandbox::new(


### PR DESCRIPTION
Unlike the previous usage which requires creating
/dev/xxx by mknod on the host, the new approach will fully utilize the DirectVolume-related usage method, and pass the spdk controller to vmm.
And a user guide about using the spdk volume when run a kata-containers. it can be found in docs/how-to.

Fixes: #6526

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>