### PR TITLE
gha: Fix `stage` definition in matrix

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        stage: ${{ inputs.stage }}
+        stage:
+          - ${{ inputs.stage }}
         asset:
           - cloud-hypervisor
           - cloud-hypervisor-glibc


### PR DESCRIPTION
This defines `stage` as a list instead of a literal to fix the GHA CI.

Fixes: #7086