### PR TITLE
versions: Update firecracker version to 1.3.3

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -83,7 +83,7 @@ assets:
       uscan-url: >-
         https://github.com/firecracker-microvm/firecracker/tags
         .*/v?(\d\S+)\.tar\.gz
-      version: "v1.3.1"
+      version: "v1.3.3"
 
     qemu:
       description: "VMM that uses KVM"


### PR DESCRIPTION
This PR updates the firecracker version to 1.3.3 which includes the following changes
Fixed passing through cache information from host in CPUID leaf 0x80000006. A race condition that has been identified between the API thread and the VMM thread due to a misconfiguration of the api_event_fd.

Fixes #7089