### PR TITLE
runtime-rs: Enhance flexibility of virtio-fs config

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_fs.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_fs.rs
@@ -67,6 +67,9 @@ pub struct ShareFsDeviceConfig {
 
     /// queue_num: queue number
     pub queue_num: u64,
+
+    /// options: virtiofs device's config options.
+    pub options: Vec<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
@@ -56,6 +56,7 @@ pub(crate) async fn prepare_virtiofs(
             fs_type: fs_type.to_string(),
             queue_size: 0,
             queue_num: 0,
+            options: vec![],
         },
     };
     h.add_device(DeviceType::ShareFs(share_fs_device))


### PR DESCRIPTION
runtime-rs: Enhance flexibility of virtio-fs config

support more and flexible options for inline virtiofs.

Fixes: #7091

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>