### PR TITLE
tools: Fix no-op builds

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -56,7 +56,7 @@ cloud-hypervisor-tarball:
 	${MAKE} $@-build
 
 cloud-hypervisor-glibc-tarball:
-	exit 0
+	${MAKE} $@-build
 
 firecracker-tarball:
 	${MAKE} $@-build
@@ -110,7 +110,7 @@ rootfs-image-tdx-tarball: kernel-tdx-experimental-tarball
 	${MAKE} $@-build
 
 rootfs-initrd-mariner-tarball:
-	exit 0
+	${MAKE} $@-build
 
 rootfs-initrd-sev-tarball: kernel-sev-tarball
 	${MAKE} $@-build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -578,6 +578,8 @@ handle_build() {
 
 	cloud-hypervisor) install_clh ;;
 
+	cloud-hypervisor-glibc) ;;
+
 	firecracker) install_firecracker ;;
 
 	kernel) install_kernel ;;
@@ -613,6 +615,8 @@ handle_build() {
 	rootfs-image-tdx) install_image_tdx ;;
 
 	rootfs-initrd) install_initrd ;;
+
+	rootfs-initrd-mariner) ;;
 
 	rootfs-initrd-sev) install_initrd_sev ;;
 	


### PR DESCRIPTION
This fixes the builds of `cloud-hypervisor-glibc` and `rootfs-initrd-mariner` to properly create the `build/` directory.

Fixes: #7098