### PR TITLE
WIP: Add attestation support to main

### DIFF
--- a/tests/integration/kubernetes/k8s-confidential-resource.bats
+++ b/tests/integration/kubernetes/k8s-confidential-resource.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2023 IBM
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../../ci/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+RESOURCE_PATH_BASE="/opt/confidential-containers/kbs/repository/"
+RESOURCE_ONE_ID="default/resource/one"
+RESOURCE_ONE="resource_one"
+
+add_kernel_params() {
+    local params="$@"
+    load_runtime_config_path
+
+    sudo sed -i -e 's#^\(kernel_params\) = "\(.*\)"#\1 = "\2 '"$params"'"#g' \
+        "$RUNTIME_CONFIG_PATH"
+}
+
+setup_cc_kbs() {
+	# checkout kbs
+	kbs_dir=$(mktemp -d /tmp/kbs.XXXX)
+	pushd "$kbs_dir"
+	git clone https://github.com/confidential-containers/kbs.git 
+	pushd kbs
+
+	# configure KBS
+	openssl genpkey -algorithm ed25519 > config/private.key
+	openssl pkey -in config/private.key -pubout -out config/public.pub
+
+	# build and start kbs
+	docker compose build
+	docker compose up -d
+	
+	popd
+	popd
+}
+
+stop_cc_kbs() {
+	pushd "$kbs_dir"
+	pushd kbs
+
+	docker compose down
+	docker compose remove
+
+	popd
+	rm -rf kbs
+	popd
+
+}
+
+setup() {
+	extract_kata_env
+	get_pod_config_dir
+
+	case $KATA_HYPERVISOR in
+		qemu-snp | qemu-tdx)
+			kbc="cc_kbc"
+			setup_cc_kbs
+
+			# add resource to KBS
+			resource_one_path="$RESOURCE_PATH_BASE$RESOURCE_ONE_ID"
+			mkdir -p "$resource_one_path" 
+			echo -n "$RESOURCE_ONE" >> resource_one_path
+			;;
+		*)
+			skip "KBS not supported"
+		;;
+	esac
+
+	# set aa_kbc_params to point to the KBS that was started
+	kbs_ip="$(ip -o route get to 8.8.8.8 | sed -n 's/.*src \([0-9.]\+\).*/\1/p')"
+	aa_kbc_params="agent.aa_kbc_params=$kbc::$kbs_ip:8080"
+	add_kernel_params "$aa_kbc_params"
+	
+}
+
+@test "Request resource from Attestation Agent" {
+
+	# Create pod
+	pod_name="pod-confidential-resource"
+	ctr_name="ctr-confidential-resource"
+
+	pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
+	cp "$pod_config_dir/pod-confidential-resource.yaml" "$pod_config"
+	sed -i "s/POD_NAME/$pod_name/" "$pod_config"
+	sed -i "s/CTR_NAME/$ctr_name/" "$pod_config"
+
+	kubectl create -f "${pod_config}"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+
+	# get a resource. the AA ignores the KbsUri set here
+	kubectl exec $pod_name -- grpcurl -plaintext -proto getresource.proto -d "\{\"ResourcePath\":\"$RESOURCE_ONE_ID\",\"KbcName\":\"$kbc\",\"KbsUri\"\:\"0\"\}" 127.0.0.1:50001 getresource.GetResourceService/GetResource | grep "$RESOURCE_ONE"
+
+}
+
+teardown() {
+
+	case $KATA_HYPERVISOR in
+		qemu-snp | qemu-tdx)
+			stop_cc_kbc
+
+			# cleanup resources
+			rm -rf "$resource_one_path" 
+			;;
+		*)
+			skip "KBS not supported"
+		;;
+	esac
+
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
+	kubectl delete pod "$pod_name"
+
+	rm -f "$pod_config"
+
+
+}

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-confidential-resource.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-confidential-resource.yaml
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: POD_NAME 
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata-qemu-sev
+  shareProcessNamespace: true
+  containers:
+  - name: CTR_NAME 
+    image: ghcr.io/fitzthum/confidential-resource-container:latest 
+    command: ["/bin/sh", "-c", "tail -f /dev/null"]

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -199,6 +199,8 @@ install_initrd() {
 
 	local jenkins="${jenkins_url}/job/kata-containers-main-rootfs-${initrd_type}-$(uname -m)/${cached_artifacts_path}"
 	local component="rootfs-${initrd_type}"
+	
+	export AA_KBC="${3:-""}"
 
 	local osbuilder_last_commit="$(get_last_modification "${repo_root_dir}/tools/osbuilder")"
 	local guest_image_last_commit="$(get_last_modification "${repo_root_dir}/tools/packaging/guest-image")"
@@ -237,7 +239,7 @@ install_initrd_mariner() {
 
 #Install guest initrd for sev
 install_initrd_sev() {
-	install_initrd "sev"
+	install_initrd "initrd-sev" "sev" "online_sev_kbc,cc_kbc_snp" 
 }
 
 #Install kernel component helper

--- a/versions.yaml
+++ b/versions.yaml
@@ -198,6 +198,11 @@ assets:
 externals:
   description: "Third-party projects used by the system"
 
+  attestation-agent:
+    description: "In-guest utility for attestation and secret delivery"
+    url: "https://github.com/confidential-containers/attestation-agent"
+    version: "v0.6.0"
+
   cni-plugins:
     description: "CNI network plugins"
     url: "https://github.com/containernetworking/plugins"


### PR DESCRIPTION
This is not ready yet, but I will put it out here to avoid any conflicts.

- [x] Add support for AA to rootfs builder (may need cleanup)
- [x] Add KBC for SEV/SNP initrd
- [ ] Add KBC for other TEEs
- [x] Add AA_KBC_PARAMS to config
- [x] Start the AA via the Kata Agent (early on) - not sure about placement
- [x] Add a test -- not sure if this works yet

See thread below for updates.

I have a pretty interesting plan for a test. Hopefully I will be able to push that tomorrow.

cc: @ryansavino @stevenhorsman 