### PR TITLE
Fix deprecated virtiofsd args (go shim only)

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -232,7 +232,7 @@ DEFVIRTIOFSQUEUESIZE ?= 1024
 #
 # see `virtiofsd -h` for possible options.
 # Make sure you quote args.
-DEFVIRTIOFSEXTRAARGS ?= [\"--thread-pool-size=1\", \"-o\", \"announce_submounts\"]
+DEFVIRTIOFSEXTRAARGS ?= [\"--thread-pool-size=1\", \"--announce-submounts\"]
 DEFENABLEIOTHREADS := false
 DEFENABLEVHOSTUSERSTORE := false
 DEFVHOSTUSERSTOREPATH := $(PKGRUNDIR)/vhost-user

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -150,9 +150,9 @@ virtio_fs_queue_size = @DEFVIRTIOFSQUEUESIZE@
 # Extra args for virtiofsd daemon
 #
 # Format example:
-#   ["-o", "arg1=xxx,arg2", "-o", "hello world", "--arg3=yyy"]
+#   ["--arg1=xxx", "--arg2=yyy"]
 # Examples:
-#   Set virtiofsd log level to debug : ["-o", "log_level=debug"] or ["-d"]
+#   Set virtiofsd log level to debug : ["--log-level=debug"]
 # see `virtiofsd -h` for possible options.
 virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -197,9 +197,9 @@ virtio_fs_queue_size = @DEFVIRTIOFSQUEUESIZE@
 # Extra args for virtiofsd daemon
 #
 # Format example:
-#   ["-o", "arg1=xxx,arg2", "-o", "hello world", "--arg3=yyy"]
+#   ["--arg1=xxx", "--arg2=yyy"]
 # Examples:
-#   Set virtiofsd log level to debug : ["-o", "log_level=debug"] or ["-d"]
+#   Set virtiofsd log level to debug : ["--log-level=debug"]
 #
 # see `virtiofsd -h` for possible options.
 virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -194,8 +194,6 @@ func (v *virtiofsd) args(FdSocketNumber uint) ([]string, error) {
 		"-o", "source=" + v.sourcePath,
 		// fd number of vhost-user socket
 		fmt.Sprintf("--fd=%v", FdSocketNumber),
-		// foreground operation
-		"-f",
 	}
 
 	if len(v.extraArgs) != 0 {

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -186,9 +186,9 @@ func (v *virtiofsd) args(FdSocketNumber uint) ([]string, error) {
 		// Send logs to syslog
 		"--syslog",
 		// cache mode for virtiofsd
-		"-o", "cache=" + v.cache,
+		"--cache=" + v.cache,
 		// shared directory tree
-		"-o", "source=" + v.sourcePath,
+		"--shared-dir=" + v.sourcePath,
 		// fd number of vhost-user socket
 		fmt.Sprintf("--fd=%v", FdSocketNumber),
 	}

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -187,9 +187,6 @@ func (v *virtiofsd) args(FdSocketNumber uint) ([]string, error) {
 		"--syslog",
 		// cache mode for virtiofsd
 		"-o", "cache=" + v.cache,
-		// disable posix locking in daemon: bunch of basic posix locks properties are broken
-		// apt-get update is broken if enabled
-		"-o", "no_posix_lock",
 		// shared directory tree
 		"-o", "source=" + v.sourcePath,
 		// fd number of vhost-user socket

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -79,12 +79,12 @@ func TestVirtiofsdArgs(t *testing.T) {
 		cache:      "none",
 	}
 
-	expected := "--syslog -o cache=none -o no_posix_lock -o source=/run/kata-shared/foo --fd=123"
+	expected := "--syslog -o cache=none -o source=/run/kata-shared/foo --fd=123"
 	args, err := v.args(123)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))
 
-	expected = "--syslog -o cache=none -o no_posix_lock -o source=/run/kata-shared/foo --fd=456"
+	expected = "--syslog -o cache=none -o source=/run/kata-shared/foo --fd=456"
 	args, err = v.args(456)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -79,12 +79,12 @@ func TestVirtiofsdArgs(t *testing.T) {
 		cache:      "none",
 	}
 
-	expected := "--syslog -o cache=none -o no_posix_lock -o source=/run/kata-shared/foo --fd=123 -f"
+	expected := "--syslog -o cache=none -o no_posix_lock -o source=/run/kata-shared/foo --fd=123"
 	args, err := v.args(123)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))
 
-	expected = "--syslog -o cache=none -o no_posix_lock -o source=/run/kata-shared/foo --fd=456 -f"
+	expected = "--syslog -o cache=none -o no_posix_lock -o source=/run/kata-shared/foo --fd=456"
 	args, err = v.args(456)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -79,12 +79,12 @@ func TestVirtiofsdArgs(t *testing.T) {
 		cache:      "none",
 	}
 
-	expected := "--syslog -o cache=none -o source=/run/kata-shared/foo --fd=123"
+	expected := "--syslog --cache=none --shared-dir=/run/kata-shared/foo --fd=123"
 	args, err := v.args(123)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))
 
-	expected = "--syslog -o cache=none -o source=/run/kata-shared/foo --fd=456"
+	expected = "--syslog --cache=none --shared-dir=/run/kata-shared/foo --fd=456"
 	args, err = v.args(456)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))


### PR DESCRIPTION
This series fixes some deprecated arguments being passed to `virtiofsd`,
either by dropping them when they aren't needed anymore or by
converting them to the replacement arguments expected by the rust
virtiofsd.

Fixes #7111