### PR TITLE
gha: Add base branch on SHA on pull requst

### DIFF
--- a/.github/workflows/run-launchtimes-metrics.yaml
+++ b/.github/workflows/run-launchtimes-metrics.yaml
@@ -8,6 +8,10 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
     steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
     - name: run launch times on qemu
       run: bash tests/metrics/gha-run.sh run-test-launchtimes-qemu
 


### PR DESCRIPTION
The run-launchtimes-metrics workflow needs to get the commit ID for the last commit to the head branch of the PR.

Fixes: #7116