### PR TITLE
CC: Set default value for AA_KBC for cc_rootfs_initrd_tarball

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -654,7 +654,8 @@ install_cached_kernel_tarball_component() {
 }
 
 install_cc_initrd() {
-	info "Create initrd"
+	export AA_KBC="${AA_KBC:-offline_fs_kbc}"
+	info "Create CC initrd configured with AA_KBC=${AA_KBC}"
 	"${rootfs_builder}" --imagetype=initrd --prefix="${cc_prefix}" --destdir="${destdir}"
 }
 


### PR DESCRIPTION
This is to set a default value for `AA_KBC` for the make target `cc_rootfs_initrd_tarball`.

Fixes: #7121

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>