### PR TITLE
[stable-3.1] backport: versions: Use ubuntu as the default distro for the rootfs-image

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -129,7 +129,7 @@ assets:
         name: "ubuntu"
         version: "latest"
       x86_64:
-        name: &default-image-name "clearlinux"
+        name: &default-image-name "ubuntu"
         version: "latest"
     meta:
       image-type: *default-image-name


### PR DESCRIPTION
Currently ubuntu is already the default distro for all the architectures but x86_64, which uses clearlinux.  However, our CI does *not* test the clearlinux image we ship.

Taking a look at our CI code [0], we've been using ubuntu as base for the tests for a few years already, if not forever.

The minimum we can do is to switch to distributing ubuntu, as the tested rootfs-image, and then decide later on whether we should switch back to clearlinux (once we switch our CI to using that, and make sure all tests will be green), or if we move to slimmer distro, such as alpine.

[0]: https://github.com/kata-containers/tests/blob/0a39dd1a01dc135e76f874b9475a33c5f54afcca/.ci/install_kata_image.sh#L44

Fixes: #7123