### PR TITLE
gha: Fix format for run launchtimes metrics yaml

### DIFF
--- a/.github/workflows/run-launchtimes-metrics.yaml
+++ b/.github/workflows/run-launchtimes-metrics.yaml
@@ -12,8 +12,8 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
-    - name: run launch times on qemu
-      run: bash tests/metrics/gha-run.sh run-test-launchtimes-qemu
+      - name: run launch times on qemu
+        run: bash tests/metrics/gha-run.sh run-test-launchtimes-qemu
 
-    - name: run launch times on clh
-      run:  bash tests/metrics/gha-run.sh run-test-launchtimes-clh
+      - name: run launch times on clh
+        run:  bash tests/metrics/gha-run.sh run-test-launchtimes-clh


### PR DESCRIPTION
This PR fixes the format for the run launchtimes metrics yaml which is causing to the workflow to fail.

Fixes #7130