### PR TITLE
tests: Add `k8s-volume` and `k8s-file-volume` tests to GHA CI

### DIFF
--- a/tests/integration/kubernetes/k8s-file-volume.bats
+++ b/tests/integration/kubernetes/k8s-file-volume.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2022 Ant Group
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+TEST_INITRD="${TEST_INITRD:-no}"
+
+setup() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	pod_name="test-file-volume"
+	container_name="busybox-file-volume-container"
+	tmp_file=$(exec_host mktemp /tmp/file-volume-test-foo.XXXXX)
+	mount_path="/tmp/foo.txt"
+	file_body="test"
+	get_pod_config_dir
+}
+
+@test "Test readonly volume for pods" {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	# Write test body to temp file
+	exec_host "echo "$file_body" > $tmp_file"
+
+	# Create test yaml
+	sed -e "s|HOST_FILE|$tmp_file|" ${pod_config_dir}/pod-file-volume.yaml > ${pod_config_dir}/test-pod-file-volume.yaml
+	sed -i "s|MOUNT_PATH|$mount_path|" ${pod_config_dir}/test-pod-file-volume.yaml
+
+	# Create pod
+	kubectl create -f "${pod_config_dir}/test-pod-file-volume.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+
+	# Validate file volume body inside the pod
+	file_in_container=$(kubectl exec $pod_name -- cat $mount_path)
+	[ "$file_body" == "$file_in_container" ]
+}
+
+teardown() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	kubectl delete pod "$pod_name"
+	exec_host rm -f $tmp_file
+	rm -f ${pod_config_dir}/test-pod-file-volume.yaml.yaml
+}

--- a/tests/integration/kubernetes/k8s-volume.bats
+++ b/tests/integration/kubernetes/k8s-volume.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+TEST_INITRD="${TEST_INITRD:-no}"
+
+setup() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
+	get_pod_config_dir
+
+	tmp_file=$(exec_host mktemp -d /tmp/data.XXXX)
+	pod_yaml=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
+	msg="Hello from Kubernetes"
+	exec_host "echo $msg > $tmp_file/index.html"
+	pod_name="pv-pod"
+	# Define temporary file at yaml
+	sed -e "s|tmp_data|${tmp_file}|g" ${pod_config_dir}/pv-volume.yaml > "$pod_yaml"
+}
+
+@test "Create Persistent Volume" {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
+	volume_name="pv-volume"
+	volume_claim="pv-claim"
+
+	# Create the persistent volume
+	kubectl create -f "$pod_yaml"
+
+	# Check the persistent volume is Available
+	cmd="kubectl get pv $volume_name | grep Available"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+
+	# Create the persistent volume claim
+	kubectl create -f "${pod_config_dir}/volume-claim.yaml"
+
+	# Check the persistent volume claim is Bound.
+	cmd="kubectl get pvc $volume_claim | grep Bound"
+	waitForProcess "$wait_time" "$sleep_time" "$cmd"
+
+	# Create pod
+	kubectl create -f "${pod_config_dir}/pv-pod.yaml"
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+
+	cmd="cat /mnt/index.html"
+	kubectl exec $pod_name -- sh -c "$cmd" | grep "$msg"
+}
+
+teardown() {
+	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
+	kubectl delete pod "$pod_name"
+	kubectl delete pvc "$volume_claim"
+	kubectl delete pv "$volume_name"
+	rm -f "$pod_yaml"
+	exec_host rm -rf "$tmp_file"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -51,6 +51,7 @@ else
 		"k8s-sysctls.bats" \
 		"k8s-security-context.bats" \
 		"k8s-shared-volume.bats" \
+		"k8s-volume.bats" \
 		"k8s-nginx-connectivity.bats" \
 	)
 fi

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -28,6 +28,7 @@ else
 		"k8s-empty-dirs.bats" \
 		"k8s-env.bats" \
 		"k8s-exec.bats" \
+		"k8s-file-volume.bats" \
 		"k8s-inotify.bats" \
 		"k8s-job.bats" \
 		"k8s-kill-all-process-in-container.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+kind: Pod
+apiVersion: v1
+metadata:
+  name: pv-pod
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  volumes:
+    - name: pv-storage
+      persistentVolumeClaim:
+       claimName: pv-claim
+  containers:
+    - name: pv-container
+      image: quay.io/prometheus/busybox:latest
+      ports:
+      command:
+        - sleep
+        - "120"
+      volumeMounts:
+        - mountPath: "/mnt/"
+          name: pv-storage

--- a/tests/integration/kubernetes/runtimeclass_workloads/pv-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pv-volume.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+kind: PersistentVolume
+apiVersion: v1
+metadata:
+  name: pv-volume
+  labels:
+    type: local
+spec:
+  storageClassName: manual
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteOnce
+  hostPath:
+    path: "tmp_data"

--- a/tests/integration/kubernetes/runtimeclass_workloads/volume-claim.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/volume-claim.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: pv-claim
+spec:
+  storageClassName: manual
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 3Gi


### PR DESCRIPTION
This imports the following tests from the tests repo and modifies them slightly to set up volumes on the AKS host to make volume tests work with our GitHub Actions CI.

 * `k8s-volume`
 * `k8s-file-volume`

The flow of each test is preserved and the bats file were only slightly edited to allow running commands on the host (grep for `exec_host`).

See draft PRs for the remaining tests (issues to debug): https://github.com/kata-containers/kata-containers/pull/7476 https://github.com/kata-containers/kata-containers/pull/7165

Fixes: #6566