### PR TITLE
docs: Add boot time metrics documentation

### DIFF
--- a/tests/metrics/README.md
+++ b/tests/metrics/README.md
@@ -48,6 +48,8 @@ boot into a workload or kill a container.
 This directory does *not* contain "speed" tests that measure network or storage
 for instance.
 
+For further details see the [time tests documentation](time).
+
 ### Density
 
 Tests that measure the size and overheads of the runtime. Generally this is looking at

--- a/tests/metrics/time/README.md
+++ b/tests/metrics/time/README.md
@@ -1,0 +1,16 @@
+# Kata Containers boot time metrics
+The boot time metrics test takes a number of time measurements through 
+the complete launch/shutdown cycle of a single container. From those 
+measurements it derives a number of time measures, such as: 
+- time to payload execution 
+- time to get to VM kernel
+- time in VM kernel boot 
+- time to quit 
+- total time (from launch to finished)
+
+## Running the test
+Boot time test can be run by hand, for example: 
+``` 
+$ cd metrics 
+$ bash time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 1
+```


### PR DESCRIPTION
This PR adds boot time metrics documentation for kata metrics tests.

Fixes #7170