### PR TITLE
runtime-rs: fix typo in warning message

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
@@ -225,7 +225,7 @@ impl Process {
         };
 
         if let Err(e) = agent.close_stdin(req).await {
-            warn!(self.logger, "failed clsoe process io: {:?}", e);
+            warn!(self.logger, "failed to close process io: {:?}", e);
         }
     }
 


### PR DESCRIPTION
**PR Summary**:
The PR contains a fix to typo found in `src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs`. The issue is at line: [`warn!(self.logger, "failed clsoe process io: {:?}", e);`](https://github.com/kata-containers/kata-containers/blob/ce8e3cc091a7955471c21a5864f8ce187f91adb1/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs#L228). Instead of `clsoe` it should be `to close`.

Fixes: #7176