### PR TITLE
runtime-rs: bugfix for direct volume path's validation.

### DIFF
--- a/src/runtime-rs/crates/resource/src/volume/utils.rs
+++ b/src/runtime-rs/crates/resource/src/volume/utils.rs
@@ -13,7 +13,9 @@ use crate::{
     volume::share_fs_volume::generate_mount_path,
 };
 use kata_sys_util::eother;
-use kata_types::mount::{get_volume_mount_info, DirectVolumeMountInfo};
+use kata_types::mount::{
+    get_volume_mount_info, join_path, DirectVolumeMountInfo, KATA_DIRECT_VOLUME_ROOT_PATH,
+};
 
 pub const DEFAULT_VOLUME_FS_TYPE: &str = "ext4";
 pub const KATA_MOUNT_BIND_TYPE: &str = "bind";
@@ -25,6 +27,14 @@ pub const KATA_SPOOL_VOLUME_TYPE: &str = "spoolvol";
 // volume mount info load infomation from mountinfo.json
 pub fn volume_mount_info(volume_path: &str) -> Result<DirectVolumeMountInfo> {
     get_volume_mount_info(volume_path)
+}
+
+// get direct volume path whose volume_path encoded with base64
+pub fn get_direct_volume_path(volume_path: &str) -> Result<String> {
+    let volume_full_path =
+        join_path(KATA_DIRECT_VOLUME_ROOT_PATH, volume_path).context("failed to join path.")?;
+
+    Ok(volume_full_path.display().to_string())
 }
 
 pub fn get_file_name<P: AsRef<Path>>(src: P) -> Result<String> {


### PR DESCRIPTION
The failure mainly caused by the encoded volume path and the mount/src. As the src will be validated with stat,but it's not a full path and encoded, which causes the stat mount source failed.

Fixes: #7186