### PR TITLE
metrics: Add checkmetrics to gha-run.sh for metrics CI

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -16,6 +16,6 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.54
-minpercent = 10.0
-maxpercent = 10.0
+midval = 0.42
+minpercent = 15.0
+maxpercent = 15.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-cloud-hypervisor-kata-metric8.toml
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file contains baseline expectations
+# for checked results by checkmetrics tool.
+#
+# values set specifically for packet.com c1.small worker.
+
+[[metric]]
+name = "boot-times"
+type = "json"
+description = "measure container lifecycle timings"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
+checktype = "mean"
+midval = 0.54
+minpercent = 10.0
+maxpercent = 10.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -5,7 +5,7 @@
 # This file contains baseline expectations
 # for checked results by checkmetrics tool.
 #
-# values set specifically for packet.com c1.small worker.
+# values set specifically for Equinix m3.small.x86.
 
 [[metric]]
 name = "boot-times"

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -1,0 +1,21 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This file contains baseline expectations
+# for checked results by checkmetrics tool.
+#
+# values set specifically for packet.com c1.small worker.
+
+[[metric]]
+name = "boot-times"
+type = "json"
+description = "measure container lifecycle timings"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
+checktype = "mean"
+midval = 0.61
+minpercent = 15.0
+maxpercent = 15.0

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -8,6 +8,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -x
 
 kata_tarball_dir="${2:-kata-artifacts}"
 metrics_dir="$(dirname "$(readlink -f "$0")")"
@@ -94,7 +95,7 @@ function check_metrics() {
 	sudo make install
 	popd
 
-	local cm_base_file="${checkmetrics_config_dir}/checkmetrics-json-${hypervisor}-$(uname -n).toml"
+	local cm_base_file="${checkmetrics_config_dir}/checkmetrics-json-clh-kata-metric8.toml"
 	checkmetrics --debug --percentage --basefile "${cm_base_file}" --metricsdir "${results_dir}"
 	cm_result=$?
 	if [ "${cm_result}" != 0 ]; then
@@ -110,6 +111,10 @@ function run_test_launchtimes() {
 	exit 0
 	create_symbolic_links
 	bash tests/metrics/time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 20
+
+	if [ "${hypervisor}" = "clh" ]; then
+		check_metrics
+	fi
 }
 
 function run_test_memory_usage() {
@@ -139,8 +144,6 @@ function main() {
 		run-test-memory-usage-inside-container) run_test_memory_usage_inside_container ;;
 		*) >&2 die "Invalid argument" ;;
 	esac
-
-	check_metrics
 }
 
 main "$@"

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -9,7 +9,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-kata_tarball_dir=${2:-kata-artifacts}
+kata_tarball_dir="${2:-kata-artifacts}"
 metrics_dir="$(dirname "$(readlink -f "$0")")"
 source "${metrics_dir}/../common.bash"
 
@@ -58,7 +58,7 @@ function install_kata() {
 	# Removing previous kata installation
 	sudo rm -rf "${katadir}"
 
-	pushd ${kata_tarball_dir}
+	pushd "${kata_tarball_dir}"
 	sudo tar -xvf "${kata_tarball}" -C "${destdir}"
 	popd
 
@@ -77,9 +77,9 @@ function check_containerd_config_for_kata() {
 	declare -r line2="runtime_type = \"io.containerd.kata.v2\""
 	declare -r num_lines_containerd=2
 	declare -r containerd_path="/etc/containerd/config.toml"
-	local count_matches=$(grep -ic  "$line1\|$line2" ${containerd_path})
+	local count_matches=$(grep -ic  "$line1\|$line2" "${containerd_path}")
 
-	if [ $count_matches = $num_lines_containerd ]; then
+	if [ "${count_matches}" = "${num_lines_containerd}" ]; then
 		info "containerd ok"
 	else
 		info "overwriting containerd configuration w/ a valid one"

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -22,7 +22,7 @@ function create_symbolic_links() {
 	local link_configuration_file="/opt/kata/share/defaults/kata-containers/configuration.toml"
 	local source_configuration_file="/opt/kata/share/defaults/kata-containers/configuration-${KATA_HYPERVISOR}.toml"
 
-	if [ ${KATA_HYPERVISOR} != 'qemu' ] && [ ${KATA_HYPERVISOR} != 'clh' ]; then
+	if [ "${KATA_HYPERVISOR}" != 'qemu' ] && [ "${KATA_HYPERVISOR}" != 'clh' ]; then
 		die "Failed to set the configuration.toml: '${KATA_HYPERVISOR}' is not recognized as a valid hypervisor name."
 	fi
 
@@ -89,13 +89,14 @@ function check_containerd_config_for_kata() {
 }
 
 function check_metrics() {
+	KATA_HYPERVISOR="${1}"
 	# Ensure we have the latest checkemtrics
 	pushd "${checkmetrics_dir}"
 	make
 	sudo make install
 	popd
 
-	local cm_base_file="${checkmetrics_config_dir}/checkmetrics-json-clh-kata-metric8.toml"
+	local cm_base_file="${checkmetrics_config_dir}/checkmetrics-json-${KATA_HYPERVISOR}-kata-metric8.toml"
 	checkmetrics --debug --percentage --basefile "${cm_base_file}" --metricsdir "${results_dir}"
 	cm_result=$?
 	if [ "${cm_result}" != 0 ]; then
@@ -112,9 +113,7 @@ function run_test_launchtimes() {
 	create_symbolic_links
 	bash tests/metrics/time/launch_times.sh -i public.ecr.aws/ubuntu/ubuntu:latest -n 20
 
-	if [ "${hypervisor}" = "clh" ]; then
-		check_metrics
-	fi
+	check_metrics "${KATA_HYPERVISOR}"
 }
 
 function run_test_memory_usage() {


### PR DESCRIPTION
This PR adds checkmetrics installation for gha-run.sh in order to compare results limits as part of the metrics CI.

Fixes #7198