### PR TITLE
Convert `is_allowed`, `ttrpc_error` and `sl` to functions

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1596,10 +1596,8 @@ mod tests {
     use tempfile::tempdir;
     use test_utils::skip_if_not_root;
 
-    macro_rules! sl {
-        () => {
-            slog_scope::logger()
-        };
+    fn sl() -> slog::Logger {
+        slog_scope::logger()
     }
 
     #[test]
@@ -1854,7 +1852,7 @@ mod tests {
         let _ = new_linux_container_and_then(|mut c: LinuxContainer| {
             c.processes.insert(
                 1,
-                Process::new(&sl!(), &oci::Process::default(), "123", true, 1).unwrap(),
+                Process::new(&sl(), &oci::Process::default(), "123", true, 1).unwrap(),
             );
             let p = c.get_process("123");
             assert!(p.is_ok(), "Expecting Ok, Got {:?}", p);
@@ -1881,7 +1879,7 @@ mod tests {
         let (c, _dir) = new_linux_container();
         let ret = c
             .unwrap()
-            .start(Process::new(&sl!(), &oci::Process::default(), "123", true, 1).unwrap())
+            .start(Process::new(&sl(), &oci::Process::default(), "123", true, 1).unwrap())
             .await;
         assert!(ret.is_err(), "Expecting Err, Got {:?}", ret);
     }
@@ -1891,7 +1889,7 @@ mod tests {
         let (c, _dir) = new_linux_container();
         let ret = c
             .unwrap()
-            .run(Process::new(&sl!(), &oci::Process::default(), "123", true, 1).unwrap())
+            .run(Process::new(&sl(), &oci::Process::default(), "123", true, 1).unwrap())
             .await;
         assert!(ret.is_err(), "Expecting Err, Got {:?}", ret);
     }

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -26,11 +26,9 @@ use oci::{LinuxDeviceCgroup, LinuxResources, Spec};
 use protocols::agent::Device;
 use tracing::instrument;
 
-// Convenience macro to obtain the scope logger
-macro_rules! sl {
-    () => {
-        slog_scope::logger().new(o!("subsystem" => "device"))
-    };
+// Convenience function to obtain the scope logger.
+fn sl() -> slog::Logger {
+    slog_scope::logger().new(o!("subsystem" => "device"))
 }
 
 const VM_ROOTFS: &str = "/";
@@ -78,7 +76,7 @@ where
 {
     let syspci = Path::new(&syspci);
     let drv = drv.as_ref();
-    info!(sl!(), "rebind_pci_driver: {} => {:?}", dev, drv);
+    info!(sl(), "rebind_pci_driver: {} => {:?}", dev, drv);
 
     let devpath = syspci.join("devices").join(dev.to_string());
     let overridepath = &devpath.join("driver_override");
@@ -606,7 +604,7 @@ fn update_spec_devices(spec: &mut Spec, mut updates: HashMap<&str, DevUpdate>) -
             let host_minor = specdev.minor;
 
             info!(
-                sl!(),
+                sl(),
                 "update_spec_devices() updating device";
                 "container_path" => &specdev.path,
                 "type" => &specdev.r#type,
@@ -657,7 +655,7 @@ fn update_spec_devices(spec: &mut Spec, mut updates: HashMap<&str, DevUpdate>) -
                 if let Some(update) = res_updates.get(&(r.r#type.as_str(), host_major, host_minor))
                 {
                     info!(
-                        sl!(),
+                        sl(),
                         "update_spec_devices() updating resource";
                         "type" => &r.r#type,
                         "host_major" => host_major,
@@ -921,7 +919,7 @@ pub async fn add_devices(
 #[instrument]
 async fn add_device(device: &Device, sandbox: &Arc<Mutex<Sandbox>>) -> Result<SpecUpdate> {
     // log before validation to help with debugging gRPC protocol version differences.
-    info!(sl!(), "device-id: {}, device-type: {}, device-vm-path: {}, device-container-path: {}, device-options: {:?}",
+    info!(sl(), "device-id: {}, device-type: {}, device-vm-path: {}, device-container-path: {}, device-options: {:?}",
           device.id, device.type_, device.vm_path, device.container_path, device.options);
 
     if device.type_.is_empty() {

--- a/src/agent/src/metrics.rs
+++ b/src/agent/src/metrics.rs
@@ -15,11 +15,9 @@ use tracing::instrument;
 const NAMESPACE_KATA_AGENT: &str = "kata_agent";
 const NAMESPACE_KATA_GUEST: &str = "kata_guest";
 
-// Convenience macro to obtain the scope logger
-macro_rules! sl {
-    () => {
-        slog_scope::logger().new(o!("subsystem" => "metrics"))
-    };
+// Convenience function to obtain the scope logger.
+fn sl() -> slog::Logger {
+    slog_scope::logger().new(o!("subsystem" => "metrics"))
 }
 
 lazy_static! {
@@ -139,7 +137,7 @@ fn update_agent_metrics() -> Result<()> {
         Ok(p) => p,
         Err(e) => {
             // FIXME: return Ok for all errors?
-            warn!(sl!(), "failed to create process instance: {:?}", e);
+            warn!(sl(), "failed to create process instance: {:?}", e);
 
             return Ok(());
         }
@@ -160,7 +158,7 @@ fn update_agent_metrics() -> Result<()> {
     // io
     match me.io() {
         Err(err) => {
-            info!(sl!(), "failed to get process io stat: {:?}", err);
+            info!(sl(), "failed to get process io stat: {:?}", err);
         }
         Ok(io) => {
             set_gauge_vec_proc_io(&AGENT_IO_STAT, &io);
@@ -169,7 +167,7 @@ fn update_agent_metrics() -> Result<()> {
 
     match me.stat() {
         Err(err) => {
-            info!(sl!(), "failed to get process stat: {:?}", err);
+            info!(sl(), "failed to get process stat: {:?}", err);
         }
         Ok(stat) => {
             set_gauge_vec_proc_stat(&AGENT_PROC_STAT, &stat);
@@ -177,7 +175,7 @@ fn update_agent_metrics() -> Result<()> {
     }
 
     match me.status() {
-        Err(err) => error!(sl!(), "failed to get process status: {:?}", err),
+        Err(err) => error!(sl(), "failed to get process status: {:?}", err),
         Ok(status) => set_gauge_vec_proc_status(&AGENT_PROC_STATUS, &status),
     }
 
@@ -189,7 +187,7 @@ fn update_guest_metrics() {
     // try get load and task info
     match procfs::LoadAverage::new() {
         Err(err) => {
-            info!(sl!(), "failed to get guest LoadAverage: {:?}", err);
+            info!(sl(), "failed to get guest LoadAverage: {:?}", err);
         }
         Ok(load) => {
             GUEST_LOAD
@@ -209,7 +207,7 @@ fn update_guest_metrics() {
     // try to get disk stats
     match procfs::diskstats() {
         Err(err) => {
-            info!(sl!(), "failed to get guest diskstats: {:?}", err);
+            info!(sl(), "failed to get guest diskstats: {:?}", err);
         }
         Ok(diskstats) => {
             for diskstat in diskstats {
@@ -221,7 +219,7 @@ fn update_guest_metrics() {
     // try to get vm stats
     match procfs::vmstat() {
         Err(err) => {
-            info!(sl!(), "failed to get guest vmstat: {:?}", err);
+            info!(sl(), "failed to get guest vmstat: {:?}", err);
         }
         Ok(vmstat) => {
             for (k, v) in vmstat {
@@ -233,7 +231,7 @@ fn update_guest_metrics() {
     // cpu stat
     match procfs::KernelStats::new() {
         Err(err) => {
-            info!(sl!(), "failed to get guest KernelStats: {:?}", err);
+            info!(sl(), "failed to get guest KernelStats: {:?}", err);
         }
         Ok(kernel_stats) => {
             set_gauge_vec_cpu_time(&GUEST_CPU_TIME, "total", &kernel_stats.total);
@@ -246,7 +244,7 @@ fn update_guest_metrics() {
     // try to get net device stats
     match procfs::net::dev_status() {
         Err(err) => {
-            info!(sl!(), "failed to get guest net::dev_status: {:?}", err);
+            info!(sl(), "failed to get guest net::dev_status: {:?}", err);
         }
         Ok(devs) => {
             // netdev: map[string]procfs::net::DeviceStatus
@@ -259,7 +257,7 @@ fn update_guest_metrics() {
     // get statistics about memory from /proc/meminfo
     match procfs::Meminfo::new() {
         Err(err) => {
-            info!(sl!(), "failed to get guest Meminfo: {:?}", err);
+            info!(sl(), "failed to get guest Meminfo: {:?}", err);
         }
         Ok(meminfo) => {
             set_gauge_vec_meminfo(&GUEST_MEMINFO, &meminfo);

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -126,11 +126,7 @@ macro_rules! ttrpc_error {
 
 macro_rules! is_allowed {
     ($req:ident) => {
-        if !AGENT_CONFIG
-            .read()
-            .await
-            .is_allowed_endpoint($req.descriptor_dyn().name())
-        {
+        if !AGENT_CONFIG.is_allowed_endpoint($req.descriptor_dyn().name()) {
             return Err(ttrpc_error!(
                 ttrpc::Code::UNIMPLEMENTED,
                 format!("{} is blocked", $req.descriptor_dyn().name()),
@@ -240,7 +236,7 @@ impl AgentService {
         let mut ctr: LinuxContainer =
             LinuxContainer::new(cid.as_str(), CONTAINER_BASE, opts, &sl!())?;
 
-        let pipe_size = AGENT_CONFIG.read().await.container_pipe_size;
+        let pipe_size = AGENT_CONFIG.container_pipe_size;
 
         let p = if let Some(p) = oci.process {
             Process::new(&sl!(), &p, cid.as_str(), true, pipe_size)?
@@ -374,7 +370,7 @@ impl AgentService {
         // Apply any necessary corrections for PCI addresses
         update_env_pci(&mut process.Env, &sandbox.pcimap)?;
 
-        let pipe_size = AGENT_CONFIG.read().await.container_pipe_size;
+        let pipe_size = AGENT_CONFIG.container_pipe_size;
         let ocip = rustjail::process_grpc_to_oci(&process);
         let p = Process::new(&sl!(), &ocip, exec_id.as_str(), false, pipe_size)?;
 

--- a/src/agent/src/tracer.rs
+++ b/src/agent/src/tracer.rs
@@ -69,7 +69,7 @@ macro_rules! trace_rpc_call {
             propagator.extract(&extract_carrier_from_ttrpc($ctx))
         });
 
-        info!(sl!(), "rpc call from shim to agent: {:?}", $name);
+        info!(sl(), "rpc call from shim to agent: {:?}", $name);
 
         // generate tracing span
         let rpc_span = span!(tracing::Level::INFO, $name, "mod"="rpc.rs", req=?$req);

--- a/src/agent/src/uevent.rs
+++ b/src/agent/src/uevent.rs
@@ -141,7 +141,7 @@ pub async fn wait_for_uevent(
 
     info!(sl!(), "{}: waiting on channel", logprefix);
 
-    let hotplug_timeout = AGENT_CONFIG.read().await.hotplug_timeout;
+    let hotplug_timeout = AGENT_CONFIG.hotplug_timeout;
 
     let uev = match tokio::time::timeout(hotplug_timeout, rx).await {
         Ok(v) => v?,

--- a/src/agent/src/uevent.rs
+++ b/src/agent/src/uevent.rs
@@ -19,11 +19,9 @@ use tokio::sync::watch::Receiver;
 use tokio::sync::Mutex;
 use tracing::instrument;
 
-// Convenience macro to obtain the scope logger
-macro_rules! sl {
-    () => {
-        slog_scope::logger().new(o!("subsystem" => "uevent"))
-    };
+// Convenience function to obtain the scope logger.
+fn sl() -> slog::Logger {
+    slog_scope::logger().new(o!("subsystem" => "uevent"))
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -120,11 +118,11 @@ pub async fn wait_for_uevent(
 ) -> Result<Uevent> {
     let logprefix = format!("Waiting for {:?}", &matcher);
 
-    info!(sl!(), "{}", logprefix);
+    info!(sl(), "{}", logprefix);
     let mut sb = sandbox.lock().await;
     for uev in sb.uevent_map.values() {
         if matcher.is_match(uev) {
-            info!(sl!(), "{}: found {:?} in uevent map", logprefix, &uev);
+            info!(sl(), "{}: found {:?} in uevent map", logprefix, &uev);
             return Ok(uev.clone());
         }
     }
@@ -139,7 +137,7 @@ pub async fn wait_for_uevent(
     sb.uevent_watchers.push(Some((Box::new(matcher), tx)));
     drop(sb); // unlock
 
-    info!(sl!(), "{}: waiting on channel", logprefix);
+    info!(sl(), "{}: waiting on channel", logprefix);
 
     let hotplug_timeout = AGENT_CONFIG.hotplug_timeout;
 
@@ -157,7 +155,7 @@ pub async fn wait_for_uevent(
         }
     };
 
-    info!(sl!(), "{}: found {:?} on channel", logprefix, &uev);
+    info!(sl(), "{}: found {:?} on channel", logprefix, &uev);
     Ok(uev)
 }
 


### PR DESCRIPTION
This fixes https://github.com/kata-containers/kata-containers/issues/7201. 

As part of converting `is_allowed`, we also fix https://github.com/kata-containers/kata-containers/issues/5409 because it allows us to avoid having to `.await` all calls.