### PR TITLE
versions: Upgrade to Cloud Hypervisor v33.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v32.0"
+      version: "v33.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This release has been tracked in our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
v33.0. The following user visible changes have been made:

### D-Bus based API

A D-Bus based API has been added as an alternative to the existing REST
API. This feature is gated by the `dbus_api` feature. Details can be
found in the [API documentation](docs/api.md).

### Expose Host CPU Cache Details for AArch64

Now the CPU cache information on the host is properly exposed to the
guest on AArch64.

### Notable Bug Fixes

* Report errors explicitly to users when VM failed to boot
* Fix VFIO on platforms with non-4k page size
* Fix TDX initialization
* Ensure all guest memory regions are page-size aligned
* Fix seccomp filter lists related to virtio-console, serial and pty
* Populate APIC ID properly
* Ignore and warn TAP FDs in more situations

Details can be found here: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/tag/v33.0

Fixes: #7216