### PR TITLE
runtime-rs: enhancement of Device Manager for network endpoints.

### DIFF
--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -35,6 +35,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,7 +141,7 @@ dependencies = [
  "js-sys",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.43",
  "wasm-bindgen",
  "winapi",
 ]
@@ -170,6 +181,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dirs-next"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
+dependencies = [
+ "cfg-if",
+ "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys-next"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebda144c4fe02d1f7ea1a7d9641b6fc6b580adcfa024ae48797ecdeb6825b4d"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
 ]
 
 [[package]]
@@ -559,6 +591,7 @@ dependencies = [
  "slog-async",
  "slog-json",
  "slog-scope",
+ "slog-term",
  "tempfile",
 ]
 
@@ -678,6 +711,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
+ "libc",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
  "libc",
 ]
 
@@ -950,11 +992,22 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -982,6 +1035,12 @@ checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
 dependencies = [
  "winapi",
 ]
+
+[[package]]
+name = "rustversion"
+version = "1.0.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
 
 [[package]]
 name = "ryu"
@@ -1114,6 +1173,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "slog-term"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87d29185c55b7b258b4f120eab00f48557d4d9bc814f41713f449d35b0f8977c"
+dependencies = [
+ "atty",
+ "slog",
+ "term",
+ "thread_local",
+ "time 0.3.22",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1171,6 +1243,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "term"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c59df8ac95d96ff9bede18eb7300b0fda5e5d8d90960e76f8e14ae765eedbf1f"
+dependencies = [
+ "dirs-next",
+ "rustversion",
+ "winapi",
+]
+
+[[package]]
 name = "test-utils"
 version = "0.1.0"
 dependencies = [
@@ -1214,6 +1297,35 @@ checksum = "ca8a50ef2360fbd1eeb0ecd46795a87a19024eb4b53c5dc916ca1fd95fe62438"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "time"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+dependencies = [
+ "itoa",
+ "libc",
+ "num_threads",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
+
+[[package]]
+name = "time-macros"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+dependencies = [
+ "time-core",
 ]
 
 [[package]]

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_net.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_net.rs
@@ -6,6 +6,14 @@
 
 use std::fmt;
 
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+use crate::{
+    device::{Device, DeviceType},
+    Hypervisor as hypervisor,
+};
+
 #[derive(Clone)]
 pub struct Address(pub [u8; 6]);
 
@@ -20,20 +28,71 @@ impl fmt::Debug for Address {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct NetworkConfig {
+    /// for detach, now it's default value 0.
+    pub index: u64,
+
     /// Host level path for the guest network interface.
     pub host_dev_name: String,
+
+    /// Guest iface name for the guest network interface.
+    pub virt_iface_name: String,
 
     /// Guest MAC address.
     pub guest_mac: Option<Address>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct NetworkDevice {
     /// Unique identifier of the device
-    pub id: String,
+    pub device_id: String,
 
     /// Network Device config info
     pub config: NetworkConfig,
+}
+
+impl NetworkDevice {
+    // new creates a NetworkDevice
+    pub fn new(device_id: String, config: &NetworkConfig) -> Self {
+        Self {
+            device_id,
+            config: config.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl Device for NetworkDevice {
+    async fn attach(&mut self, h: &dyn hypervisor) -> Result<()> {
+        h.add_device(DeviceType::Network(self.clone()))
+            .await
+            .context("add network device.")?;
+
+        return Ok(());
+    }
+
+    async fn detach(&mut self, h: &dyn hypervisor) -> Result<Option<u64>> {
+        h.remove_device(DeviceType::Network(self.clone()))
+            .await
+            .context("remove network device.")?;
+
+        Ok(Some(self.config.index))
+    }
+
+    async fn get_device_info(&self) -> DeviceType {
+        DeviceType::Network(self.clone())
+    }
+
+    async fn increase_attach_count(&mut self) -> Result<bool> {
+        // network devices will not be attached multiple times, Just return Ok(false)
+
+        Ok(false)
+    }
+
+    async fn decrease_attach_count(&mut self) -> Result<bool> {
+        // network devices will not be detached multiple times, Just return Ok(false)
+
+        Ok(false)
+    }
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
@@ -27,7 +27,7 @@ use super::EndpointState;
 pub trait Endpoint: std::fmt::Debug + Send + Sync {
     async fn name(&self) -> String;
     async fn hardware_addr(&self) -> String;
-    async fn attach(&self, hypervisor: &dyn Hypervisor) -> Result<()>;
+    async fn attach(&self) -> Result<()>;
     async fn detach(&self, hypervisor: &dyn Hypervisor) -> Result<()>;
     async fn save(&self) -> Option<EndpointState>;
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
@@ -99,7 +99,7 @@ impl Endpoint for PhysicalEndpoint {
         self.hard_addr.clone()
     }
 
-    async fn attach(&self, _hypervisor: &dyn Hypervisor) -> Result<()> {
+    async fn attach(&self) -> Result<()> {
         // bind physical interface from host driver and bind to vfio
         driver::bind_device_to_vfio(
             &self.bdf,

--- a/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
@@ -4,24 +4,39 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::io::{self, Error};
+use std::{
+    io::{self, Error},
+    sync::Arc,
+};
 
-use super::endpoint_persist::{EndpointState, VethEndpointState};
-use super::Endpoint;
-use crate::network::{utils, NetworkPair};
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use hypervisor::device::DeviceType;
-use hypervisor::NetworkDevice;
-use hypervisor::{device::driver::NetworkConfig, Hypervisor};
+use tokio::sync::RwLock;
+
+use hypervisor::{
+    device::{
+        device_manager::{do_handle_device, DeviceManager},
+        driver::NetworkConfig,
+        DeviceConfig, DeviceType,
+    },
+    Hypervisor, NetworkDevice,
+};
+
+use super::{
+    endpoint_persist::{EndpointState, VethEndpointState},
+    Endpoint,
+};
+use crate::network::{utils, NetworkPair};
 
 #[derive(Debug)]
 pub struct VethEndpoint {
-    net_pair: NetworkPair,
+    pub(crate) net_pair: NetworkPair,
+    pub(crate) d: Arc<RwLock<DeviceManager>>,
 }
 
 impl VethEndpoint {
     pub async fn new(
+        d: &Arc<RwLock<DeviceManager>>,
         handle: &rtnetlink::Handle,
         name: &str,
         idx: u32,
@@ -30,8 +45,12 @@ impl VethEndpoint {
     ) -> Result<Self> {
         let net_pair = NetworkPair::new(handle, idx, name, model, queues)
             .await
-            .context("new networkInterfacePair")?;
-        Ok(VethEndpoint { net_pair })
+            .context("new network interface pair failed.")?;
+
+        Ok(VethEndpoint {
+            net_pair,
+            d: d.clone(),
+        })
     }
 
     fn get_network_config(&self) -> Result<NetworkConfig> {
@@ -42,9 +61,12 @@ impl VethEndpoint {
                 format!("hard_addr {}", &iface.hard_addr),
             )
         })?;
+
         Ok(NetworkConfig {
             host_dev_name: iface.name.clone(),
+            virt_iface_name: self.net_pair.virt_iface.name.clone(),
             guest_mac: Some(guest_mac),
+            ..Default::default()
         })
     }
 }
@@ -59,18 +81,17 @@ impl Endpoint for VethEndpoint {
         self.net_pair.tap.tap_iface.hard_addr.clone()
     }
 
-    async fn attach(&self, h: &dyn Hypervisor) -> Result<()> {
+    async fn attach(&self) -> Result<()> {
         self.net_pair
             .add_network_model()
             .await
             .context("add network model")?;
+
         let config = self.get_network_config().context("get network config")?;
-        h.add_device(DeviceType::Network(NetworkDevice {
-            id: self.net_pair.virt_iface.name.clone(),
-            config,
-        }))
-        .await
-        .context("error adding device by hypervisor")?;
+        do_handle_device(&self.d, &DeviceConfig::NetworkCfg(config))
+            .await
+            .context("do handle network Veth endpoint device failed.")?;
+
         Ok(())
     }
 
@@ -78,16 +99,19 @@ impl Endpoint for VethEndpoint {
         self.net_pair
             .del_network_model()
             .await
-            .context("del network model")?;
+            .context("del network model failed.")?;
+
         let config = self.get_network_config().context("get network config")?;
         h.remove_device(DeviceType::Network(NetworkDevice {
-            id: self.net_pair.virt_iface.name.clone(),
             config,
+            ..Default::default()
         }))
         .await
-        .context("error removing device by hypervisor")?;
+        .context("remove Veth endpoint device by hypervisor failed.")?;
+
         Ok(())
     }
+
     async fn save(&self) -> Option<EndpointState> {
         Some(EndpointState {
             veth_endpoint: Some(VethEndpointState {

--- a/src/runtime-rs/crates/resource/src/network/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/mod.rs
@@ -35,7 +35,7 @@ pub enum NetworkConfig {
 
 #[async_trait]
 pub trait Network: Send + Sync {
-    async fn setup(&self, h: &dyn Hypervisor) -> Result<()>;
+    async fn setup(&self) -> Result<()>;
     async fn interfaces(&self) -> Result<Vec<agent::Interface>>;
     async fn routes(&self) -> Result<Vec<agent::Route>>;
     async fn neighs(&self) -> Result<Vec<agent::ARPNeighbor>>;

--- a/src/runtime-rs/crates/resource/src/network/network_pair.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_pair.rs
@@ -39,6 +39,7 @@ pub struct NetworkPair {
     pub model: Arc<dyn network_model::NetworkModel>,
     pub network_qos: bool,
 }
+
 impl NetworkPair {
     pub(crate) async fn new(
         handle: &rtnetlink::Handle,

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -82,11 +82,11 @@ impl NetworkWithNetns {
 
 #[async_trait]
 impl Network for NetworkWithNetns {
-    async fn setup(&self, h: &dyn Hypervisor) -> Result<()> {
+    async fn setup(&self) -> Result<()> {
         let inner = self.inner.read().await;
         let _netns_guard = netns::NetnsGuard::new(&inner.netns_path).context("net netns guard")?;
         for e in &inner.entity_list {
-            e.endpoint.attach(h).await.context("attach")?;
+            e.endpoint.attach().await.context("attach")?;
         }
         Ok(())
     }
@@ -225,6 +225,7 @@ async fn create_endpoint(
         match link_type {
             "veth" => {
                 let ret = VethEndpoint::new(
+                    &d,
                     handle,
                     &attrs.name,
                     idx,
@@ -236,19 +237,20 @@ async fn create_endpoint(
                 Arc::new(ret)
             }
             "vlan" => {
-                let ret = VlanEndpoint::new(handle, &attrs.name, idx, config.queues)
+                let ret = VlanEndpoint::new(&d, handle, &attrs.name, idx, config.queues)
                     .await
                     .context("vlan endpoint")?;
                 Arc::new(ret)
             }
             "ipvlan" => {
-                let ret = IPVlanEndpoint::new(handle, &attrs.name, idx, config.queues)
+                let ret = IPVlanEndpoint::new(&d, handle, &attrs.name, idx, config.queues)
                     .await
                     .context("ipvlan endpoint")?;
                 Arc::new(ret)
             }
             "macvlan" => {
                 let ret = MacVlanEndpoint::new(
+                    &d,
                     handle,
                     &attrs.name,
                     idx,


### PR DESCRIPTION
Currently the network endpoints are alone out of device manager, we should include them into the device manager for management.

If so, refactoring network endpoints' implementation is needed.

First, restruct NetworkConfig and NetworkDevice structures; Second, do implementation for virtio-net driver and add Network device into Device Manager;
Third, unified the entry with do_handle_device for each endpoint;

Fixes: #7215