### PR TITLE
gha: dragonball: Correctly propagate PATH update

### DIFF
--- a/.github/workflows/static-checks-dragonball.yaml
+++ b/.github/workflows/static-checks-dragonball.yaml
@@ -23,7 +23,7 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           ./ci/install_rust.sh
-          PATH=$PATH:"$HOME/.cargo/bin"
+          echo PATH="$HOME/.cargo/bin:$PATH" >> $GITHUB_ENV
       - name: Run Unit Test
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |


### PR DESCRIPTION
cargo/rust is installed in one step, we need to write the PATH update to GITHUBENV so that it becomes visible in the next steps.

Fixes: #7221