### PR TITLE
stable-3.1 | gha: release: Use a specific release of hub

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -119,8 +119,7 @@ jobs:
           name: kata-static-tarball
       - name: install hub
         run: |
-          HUB_VER=$(curl -s "https://api.github.com/repos/github/hub/releases/latest" | jq -r .tag_name | sed 's/^v//')
-          wget -q -O- https://github.com/github/hub/releases/download/v$HUB_VER/hub-linux-amd64-$HUB_VER.tgz | \
+          wget -q -O- https://github.com/mislav/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz | \
           tar xz --strip-components=2 --wildcards '*/bin/hub' && sudo mv hub /usr/local/bin/hub
       - name: push static tarball to github
         run: |


### PR DESCRIPTION
ideally we should never ever use hub again, and switch to a supported / release tool instead.  However, in order to get v3.1.3 released, let's just stick to the last released version of hub, as trying to get its release is leading to:
```
curl -s "https://api.github.com/repos/github/hub/releases/latest"
{
  "message": "Moved Permanently",
  "url": "https://api.github.com/repositories/401025/releases/latest",
  "documentation_url": "https://docs.github.com/v3/#http-redirects"
}
```

And that breaks the release process. :-/

Fixes: #7223
Backport of: #7224