### PR TITLE
gha: aks: Wait longer to start running the tests, again

### DIFF
--- a/tests/integration/gha-run.sh
+++ b/tests/integration/gha-run.sh
@@ -75,7 +75,7 @@ function run_tests() {
     # which may cause issues like not having the node properly labeled or the artefacts
     # properly deployed when the tests actually start running.
     if [ "${platform}" = "aks" ]; then
-        sleep 240s
+        sleep 300s
     else
         sleep 60s
     fi


### PR DESCRIPTION
We're still trying to run the tests when Kata Containers is not fully deployed in the AKS cluter.  Let's increase the sleeping time yet again, this time to 5 minutes.

Fixes: #6964