### PR TITLE
cc: kata-deploy: Adapt the SNP's QEMU name

### DIFF
--- a/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
@@ -272,7 +272,7 @@ function remove_artifacts() {
 		/opt/confidential-containers/bin/kata-runtime \
 		/opt/confidential-containers/bin/kata-collect-data.sh \
 		/opt/confidential-containers/bin/qemu-system-x86_64 \
-		/opt/confidential-containers/bin/qemu-system-x86_64-snp \
+		/opt/confidential-containers/bin/qemu-system-x86_64-snp-experimental \
 		/opt/confidential-containers/bin/qemu-system-x86_64-tdx \
 		/opt/confidential-containers/bin/qemu-system-s390x \
 		/opt/confidential-containers/bin/cloud-hypervisor \


### PR DESCRIPTION
SNP's QEMU has changed its name some time ago and, due to that, we have been leaving the new binary behind during the uninstall process, which lead to the Operator hanging when uninstalling.

Fixes: #7233