### PR TITLE
cc: gha: Pass MEASURED_ROOTFS to the artefacts build

### DIFF
--- a/.github/workflows/cc-payload-after-push-amd64.yaml
+++ b/.github/workflows/cc-payload-after-push-amd64.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        measured_rootfs:
+          - no
         asset:
           - cc-cloud-hypervisor
           - cc-kernel
@@ -27,6 +29,11 @@ jobs:
           - cc-tdx-qemu
           - cc-tdx-td-shim
           - cc-tdx-tdvf
+        include:
+          - measured_rootfs: yes
+            asset:
+              - cc-kernel
+              - cc-tdx-kernel
     steps:
       - name: Login to Kata Containers quay.io
         uses: docker/login-action@v2
@@ -48,6 +55,7 @@ jobs:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
           PUSH_TO_REGISTRY: yes
+          MEASURED_ROOTFS: ${{ matrix.measured_rootfs }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v3
@@ -106,6 +114,7 @@ jobs:
           sudo cp -r "${build_dir}" "kata-build"
         env:
           PUSH_TO_REGISTRY: yes
+          MEASURED_ROOTFS: yes
 
       - name: store-artifact cc-shim-v2
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cc-payload-after-push-s390x.yaml
+++ b/.github/workflows/cc-payload-after-push-s390x.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: s390x
     strategy:
       matrix:
+        measured_rootfs:
+          - no
         asset:
           - cc-kernel
           - cc-qemu
@@ -18,6 +20,10 @@ jobs:
           - cc-rootfs-initrd
           - cc-se-image
           - cc-virtiofsd
+        include:
+          - measured_rootfs: yes
+            asset:
+              - cc-kernel
     steps:
       - name: Login to Kata Containers quay.io
         uses: docker/login-action@v2
@@ -52,6 +58,7 @@ jobs:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
           PUSH_TO_REGISTRY: yes
+          MEASURED_ROOTFS: ${{ matrix.measured_rootfs }}
           HKD_PATH: "host-key-document"
 
       - name: store-artifact ${{ matrix.asset }}
@@ -101,6 +108,7 @@ jobs:
           sudo cp -r "${build_dir}" "kata-build"
         env:
           PUSH_TO_REGISTRY: yes
+          MEASURED_ROOTFS: yes
 
       - name: store-artifact cc-shim-v2
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cc-payload-amd64.yaml
+++ b/.github/workflows/cc-payload-amd64.yaml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        measured_rootfs:
+          - no
         asset:
           - cc-cloud-hypervisor
           - cc-kernel
@@ -27,6 +29,11 @@ jobs:
           - cc-tdx-qemu
           - cc-tdx-td-shim
           - cc-tdx-tdvf
+        include:
+          - measured_rootfs: yes
+            asset:
+              - cc-kernel
+              - cc-tdx-kernel
     steps:
       - uses: actions/checkout@v3
       - name: Build ${{ matrix.asset }}
@@ -38,6 +45,7 @@ jobs:
         env:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
+          MEASURED_ROOTFS: ${{ matrix.measured_rootfs }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v3
@@ -87,6 +95,8 @@ jobs:
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           sudo cp -r "${build_dir}" "kata-build"
+        env:
+          MEASURED_ROOTFS: yes
 
       - name: store-artifact cc-shim-v2
         uses: actions/upload-artifact@v3

--- a/.github/workflows/cc-payload-s390x.yaml
+++ b/.github/workflows/cc-payload-s390x.yaml
@@ -11,11 +11,16 @@ jobs:
     runs-on: s390x
     strategy:
       matrix:
+        measured_rootfs: no
         asset:
           - cc-kernel
           - cc-qemu
           - cc-rootfs-image
           - cc-virtiofsd
+        include:
+          - measured_rootfs: yes
+            asset:
+              - cc-kernel
     steps:
       - name: Adjust a permission for repo
         run: |
@@ -31,6 +36,7 @@ jobs:
         env:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
+          MEASURED_ROOTFS: ${{ matrix.measured_rootfs }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v3
@@ -70,6 +76,8 @@ jobs:
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           sudo cp -r "${build_dir}" "kata-build"
+        env:
+          MEASURED_ROOTFS: yes
 
       - name: store-artifact cc-shim-v2
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
Since the measured rootfs work has been merged to main, and then brought in to the CCv0 via the weekly merge, we have introduced a few regressions related to how we build it / use it.

This PR attempts to make sure the artefacts are properly built, using GitHub Actions, so the feature can be used with the operator.

Fixes: #7235