### PR TITLE
gha: k8s: Ensure tests are running on a specific namespace

### DIFF
--- a/tests/integration/kubernetes/k8s-pod-quota.bats
+++ b/tests/integration/kubernetes/k8s-pod-quota.bats
@@ -14,13 +14,12 @@ setup() {
 @test "Pod quota" {
 	resource_name="pod-quota"
 	deployment_name="deploymenttest"
-	namespace="test-quota-ns"
 
 	# Create the resourcequota
 	kubectl create -f "${pod_config_dir}/resource-quota.yaml"
 
 	# View information about resourcequota
-	kubectl get -n "$namespace" resourcequota "$resource_name" \
+	kubectl get resourcequota "$resource_name" \
 		--output=yaml | grep 'pods: "2"'
 
 	# Create deployment
@@ -28,10 +27,9 @@ setup() {
 
 	# View deployment
 	kubectl wait --for=condition=Available --timeout=$timeout \
-		-n "$namespace" deployment/${deployment_name}
+		deployment/${deployment_name}
 }
 
 teardown() {
-	kubectl delete -n "$namespace" deployment "$deployment_name"
 	kubectl delete -f "${pod_config_dir}/resource-quota.yaml"
 }

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
@@ -6,7 +6,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: default
   name: custom-dns-test
 spec:
   terminationGracePeriodSeconds: 0

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-oom.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-oom.yaml
@@ -8,7 +8,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-oom
-  namespace: default
 spec:
   runtimeClassName: kata
   restartPolicy: Never

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
@@ -7,7 +7,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: deploymenttest
-  namespace: test-quota-ns
 spec:
   selector:
     matchLabels:

--- a/tests/integration/kubernetes/runtimeclass_workloads/resource-quota.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/resource-quota.yaml
@@ -14,7 +14,6 @@ items:
   kind: ResourceQuota
   metadata:
     name: pod-quota
-    namespace: test-quota-ns
   spec:
     hard:
       pods: "2"

--- a/tests/integration/kubernetes/runtimeclass_workloads/tests-namespace.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/tests-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kata-containers-k8s-tests


### PR DESCRIPTION
Let's make sure we run our tests in a specific namespace, as in case of
any kind of issue, we will just get rid of the namespace itself, which
will take care of cleaning up any leftover from failing tests.

One important thing to mention is why we can get rid of the `namespace:
${namespace}` on the tests that are already using it, and let's do it in
parts:
* namespace: default
  We can easily get rid of this as that's the default namespace where
  pods are created, so it was a no-op so far.
* namespace: test-quota-ns
  My understanding is that we'd need this in order to get a clean
  namespace where we'd be setting a quota for.  Doing this in the
  namespace that's only used for tests should **not** cause any
  side-effect on the tests, as we're running those in serial and there's
  no other pods running on the `kata-containers-k8s-tests` namespace

Last but not least, we're not dynamically creating namespaces as the
tests are not running in parallel, **never**, not in the case of having
2 tests being ran at same time, neither in the case of having 2 jobs
being scheduled to the same machine.

Fixes: #6864