### PR TITLE
gha: k8s: Ensure cluster doesn't exist before creating it

### DIFF
--- a/tests/integration/gha-run.sh
+++ b/tests/integration/gha-run.sh
@@ -31,6 +31,9 @@ function login_azure() {
 }
 
 function create_cluster() {
+    # First, ensure that the cluster didn't fail to get cleaned up from a previous run.
+    delete_cluster || true
+
     az aks create \
         -g "kataCI" \
         -n "$(_print_cluster_name)" \
@@ -115,8 +118,7 @@ function delete_cluster() {
     az aks delete \
         -g "kataCI" \
         -n "$(_print_cluster_name)" \
-        --yes \
-        --no-wait
+        --yes
 }
 
 function main() {


### PR DESCRIPTION
The cluster cleanup step will sometimes fail to run, meaning the next run would fail in the cluster creation step. This PR addresses that.

Example: https://github.com/kata-containers/kata-containers/actions/runs/5349582743/jobs/9867845852

Fixes: #7242