### PR TITLE
cc: gha: Export MEASURE_ROOTFS=yes for rootfs-image builds

### DIFF
--- a/.github/workflows/cc-payload-after-push-amd64.yaml
+++ b/.github/workflows/cc-payload-after-push-amd64.yaml
@@ -34,6 +34,10 @@ jobs:
             asset: cc-kernel
           - measured_rootfs: yes
             asset: cc-tdx-kernel
+          - measured_rootfs: yes
+            asset: cc-rootfs-image
+          - measured_rootfs: yes
+            asset: cc-tdx-rootfs-image
     steps:
       - name: Login to Kata Containers quay.io
         uses: docker/login-action@v2

--- a/.github/workflows/cc-payload-after-push-s390x.yaml
+++ b/.github/workflows/cc-payload-after-push-s390x.yaml
@@ -23,6 +23,8 @@ jobs:
         include:
           - measured_rootfs: yes
             asset: cc-kernel
+          - measured_rootfs: yes
+            asset: cc-rootfs-image
     steps:
       - name: Login to Kata Containers quay.io
         uses: docker/login-action@v2

--- a/.github/workflows/cc-payload-amd64.yaml
+++ b/.github/workflows/cc-payload-amd64.yaml
@@ -34,6 +34,10 @@ jobs:
             asset: cc-kernel
           - measured_rootfs: yes
             asset: cc-tdx-kernel
+          - measured_rootfs: yes
+            asset: cc-rootfs-image
+          - measured_rootfs: yes
+            asset: cc-tdx-rootfs-image
     steps:
       - uses: actions/checkout@v3
       - name: Build ${{ matrix.asset }}

--- a/.github/workflows/cc-payload-s390x.yaml
+++ b/.github/workflows/cc-payload-s390x.yaml
@@ -20,6 +20,8 @@ jobs:
         include:
           - measured_rootfs: yes
             asset: cc-kernel
+          - measured_rootfs: yes
+            asset: cc-rootfs-image
     steps:
       - name: Adjust a permission for repo
         run: |

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -255,6 +255,7 @@ install_cc_image() {
 	root_hash_suffix="${4:-""}"
 	tee="${5:-""}"
 	export KATA_BUILD_CC=yes
+	export MEASURED_ROOTFS=${MEASURED_ROOTFS}
 
 	local jenkins="${jenkins_url}/job/kata-containers-2.0-rootfs-image-cc-$(uname -m)/${cached_artifacts_path}"
 	local component="rootfs-image"


### PR DESCRIPTION
We need to export MEASURED_ROOTFS=yes for the rootfs-image builds, as shown here[0], otherwise the root_hash.txt file won't be generated.

A huge thanks to Choi for quickly finding this out.

Fixes: #7235

[0]:
https://github.com/kata-containers/kata-containers/blob/CCv0/tools/osbuilder/image-builder/image_builder.sh#L507,