### PR TITLE
cc: gha: Avoid building twice the components set as "include"

### DIFF
--- a/.github/workflows/cc-payload-after-push-amd64.yaml
+++ b/.github/workflows/cc-payload-after-push-amd64.yaml
@@ -15,17 +15,13 @@ jobs:
           - no
         asset:
           - cc-cloud-hypervisor
-          - cc-kernel
           - cc-qemu
-          - cc-rootfs-image
           - cc-virtiofsd
           - cc-sev-kernel
           - cc-sev-ovmf
           - cc-x86_64-ovmf
           - cc-snp-qemu
           - cc-sev-rootfs-initrd
-          - cc-tdx-kernel
-          - cc-tdx-rootfs-image
           - cc-tdx-qemu
           - cc-tdx-td-shim
           - cc-tdx-tdvf

--- a/.github/workflows/cc-payload-after-push-s390x.yaml
+++ b/.github/workflows/cc-payload-after-push-s390x.yaml
@@ -14,9 +14,7 @@ jobs:
         measured_rootfs:
           - no
         asset:
-          - cc-kernel
           - cc-qemu
-          - cc-rootfs-image
           - cc-rootfs-initrd
           - cc-se-image
           - cc-virtiofsd

--- a/.github/workflows/cc-payload-amd64.yaml
+++ b/.github/workflows/cc-payload-amd64.yaml
@@ -15,17 +15,13 @@ jobs:
           - no
         asset:
           - cc-cloud-hypervisor
-          - cc-kernel
           - cc-qemu
-          - cc-rootfs-image
           - cc-virtiofsd
           - cc-sev-kernel
           - cc-sev-ovmf
           - cc-x86_64-ovmf
           - cc-snp-qemu
           - cc-sev-rootfs-initrd
-          - cc-tdx-kernel
-          - cc-tdx-rootfs-image
           - cc-tdx-qemu
           - cc-tdx-td-shim
           - cc-tdx-tdvf

--- a/.github/workflows/cc-payload-s390x.yaml
+++ b/.github/workflows/cc-payload-s390x.yaml
@@ -13,9 +13,7 @@ jobs:
       matrix:
         measured_rootfs: no
         asset:
-          - cc-kernel
           - cc-qemu
-          - cc-rootfs-image
           - cc-virtiofsd
         include:
           - measured_rootfs: yes


### PR DESCRIPTION
Those components are being built twice, one as part of the normal matrix assets, and the second one as part of the include.

Fixes: #7235