### PR TITLE
gha: ci: Avoid using env unless it's really needed

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -3,9 +3,6 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
-env:
-  COMMIT_HASH: ${GITHUB_REF}
-
 jobs:
   set-fake-pr-number:
     runs-on: ubuntu-latest
@@ -18,6 +15,6 @@ jobs:
     needs: set-fake-pr-number
     uses: ./.github/workflows/ci.yaml
     with:
-      commit-hash: $COMMIT_HASH
-      pr-number: $PR_NUMBER
-      tag: $PR_NUMBER-$COMMIT_HASH-nightly
+      commit-hash: ${GITHUB_REF}
+      pr-number: ${PR_NUMBER}
+      tag: ${PR_NUMBER}-${GITHUB_REF}-nightly

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -12,15 +12,11 @@ on:
       - synchronize
       - reopened
       - labeled
-env:
-  COMMIT_HASH: ${{ github.event.pull_request.head.sha }}
-  PR_NUMBER: ${{ github.event.pull_request.number }}
-
 jobs:
   kata-containers-ci-on-push:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     uses: ./.github/workflows/ci.yaml
     with:
-      commit-hash: $COMMIT_HASH
-      pr-number: $PR_NUMBER
-      tag: $PR_NUMBER-$COMMIT_HASH
+      commit-hash: ${{ github.event.pull_request.sha }}
+      pr-number: ${{ github.event.pull_request.number }}
+      tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -5,28 +5,25 @@ on:
       - main
       - stable-*
 
-env:
-  COMMIT_HASH: $GITHUB_REF
-
 jobs:
   build-assets-amd64:
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
-      commit-hash: $COMMIT_HASH
+      commit-hash: ${GITHUB_REF}
       push-to-registry: yes
     secrets: inherit
 
   build-assets-arm64:
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
-      commit-hash: $COMMIT_HASH
+      commit-hash: ${GITHUB_REF}
       push-to-registry: yes
     secrets: inherit
 
   build-assets-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
-      commit-hash: $COMMIT_HASH
+      commit-hash: ${GITHUB_REF}
       push-to-registry: yes
     secrets: inherit
 
@@ -34,7 +31,7 @@ jobs:
     needs: build-assets-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
-      commit-hash: $COMMIT_HASH
+      commit-hash: ${GITHUB_REF}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-amd64
@@ -44,7 +41,7 @@ jobs:
     needs: build-assets-arm64
     uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
     with:
-      commit-hash: $COMMIT_HASH
+      commit-hash: ${GITHUB_REF}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-arm64
@@ -54,7 +51,7 @@ jobs:
     needs: build-assets-s390x
     uses: ./.github/workflows/publish-kata-deploy-payload-s390x.yaml
     with:
-      commit-hash: $COMMIT_HASH
+      commit-hash: ${GITHUB_REF}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-s390x


### PR DESCRIPTION
de83cd9de79226b15519e07871dcdee635d501c6 tried to solve an issue, but it clearly seems that I'm using env wrongly, as what ended up being passed as input was "$VAR", instead of the content of the VAR variable.

As we can simply avoid using those here, let's do it and save us a headache.

Fixes: #7247