### PR TITLE
gha: ci: Avoid using env also in the ci-nightly and payload-after-push

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -4,18 +4,10 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  set-fake-pr-number:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set fake PR number
-        run: |
-          echo "PR_NUMBER=$(date +%Y%m%d%H%M%S)" >> "$GITHUB_ENV"
-
   kata-containers-ci-on-push:
-    needs: set-fake-pr-number
     uses: ./.github/workflows/ci.yaml
     with:
-      commit-hash: ${GITHUB_REF}
-      pr-number: ${PR_NUMBER}
-      tag: ${PR_NUMBER}-${GITHUB_REF}-nightly
+      commit-hash: ${{ github.ref }}
+      pr-number: ${{ github.ref }}
+      tag: ${{ github.ref }}-nightly
     secrets: inherit

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -9,21 +9,21 @@ jobs:
   build-assets-amd64:
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
-      commit-hash: ${GITHUB_REF}
+      commit-hash: ${{ github.ref }}
       push-to-registry: yes
     secrets: inherit
 
   build-assets-arm64:
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
-      commit-hash: ${GITHUB_REF}
+      commit-hash: ${{ github.ref }}
       push-to-registry: yes
     secrets: inherit
 
   build-assets-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
-      commit-hash: ${GITHUB_REF}
+      commit-hash: ${{ github.ref }}
       push-to-registry: yes
     secrets: inherit
 
@@ -31,7 +31,7 @@ jobs:
     needs: build-assets-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
-      commit-hash: ${GITHUB_REF}
+      commit-hash: ${{ github.ref }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-amd64
@@ -41,7 +41,7 @@ jobs:
     needs: build-assets-arm64
     uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
     with:
-      commit-hash: ${GITHUB_REF}
+      commit-hash: ${{ github.ref }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-arm64
@@ -51,7 +51,7 @@ jobs:
     needs: build-assets-s390x
     uses: ./.github/workflows/publish-kata-deploy-payload-s390x.yaml
     with:
-      commit-hash: ${GITHUB_REF}
+      commit-hash: ${{ github.ref }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-s390x


### PR DESCRIPTION
The latter workflow is breaking as it doesn't recognise ${GITHUB_REF}, the former would most likely break as well, but it didn't get triggered yet.

The error we're facing is:
```
Determining the checkout info
  /usr/bin/git branch --list --remote origin/${GITHUB_REF}
  /usr/bin/git tag --list ${GITHUB_REF}
  Error: A branch or tag with the name '${GITHUB_REF}' could not be found
```

Fixes: #7247