### PR TITLE
kata-deploy: Remove remote annotation logic

### DIFF
--- a/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy-cc/scripts/kata-deploy.sh
@@ -212,10 +212,8 @@ function configure_containerd_runtime() {
 	local runtime_table="plugins.${pluginid}.containerd.runtimes.$runtime"
 	local runtime_type="io.containerd.$runtime.v2"
 	local cri_handler_value="cc"
-	local pod_annotations='["io.katacontainers.*"]'
 	if [ "$runtime" == "kata-remote" ]; then
 		cri_handler_value=""
-		pod_annotations='[]'
 	fi
 	local options_table="$runtime_table.options"
 	local config_path="/opt/confidential-containers/share/defaults/kata-containers/$configuration.toml"
@@ -228,7 +226,7 @@ function configure_containerd_runtime() {
   cri_handler = "${cri_handler_value}"
   runtime_type = "${runtime_type}"
   privileged_without_host_devices = true
-  pod_annotations = ${pod_annotations}
+  pod_annotations = ["io.katacontainers.*"]
 EOF
 	fi
 


### PR DESCRIPTION
Remove the logic that made the kata-remote containerd config not support io.katacontainers annotations

Fixes: #7265