### PR TITLE
gha: ci: Fix refernce passed to checkout@v3

### DIFF
--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -17,7 +17,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     uses: ./.github/workflows/ci.yaml
     with:
-      commit-hash: ${{ github.event.pull_request.sha }}
+      commit-hash: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}
       tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
     secrets: inherit


### PR DESCRIPTION
On cc3993d860339f4fcf669429a9e5948755dfaa75 we introduced a regression, where we started passing inputs.commit-hash, instead of github.event.pull_request.head.sha. However, we have been setting commit-hash to github.event.pull_request.sha, meaning that we're mssing a `.head.` there.

github.event.pull_request.sha is empty for the pull_request_target event, leading the CI to pull the content from `main` instead of the content from the PR.

Fixes: #7247