### PR TITLE
gha: ci: Use github.sha to get the last commit reference

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -7,7 +7,7 @@ jobs:
   kata-containers-ci-on-push:
     uses: ./.github/workflows/ci.yaml
     with:
-      commit-hash: ${{ github.ref }}
-      pr-number: ${{ github.ref }}
-      tag: ${{ github.ref }}-nightly
+      commit-hash: ${{ github.sha }}
+      pr-number: ${{ github.sha }}
+      tag: ${{ github.sha }}-nightly
     secrets: inherit

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -9,21 +9,21 @@ jobs:
   build-assets-amd64:
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
-      commit-hash: ${{ github.ref }}
+      commit-hash: ${{ github.sha }}
       push-to-registry: yes
     secrets: inherit
 
   build-assets-arm64:
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
-      commit-hash: ${{ github.ref }}
+      commit-hash: ${{ github.sha }}
       push-to-registry: yes
     secrets: inherit
 
   build-assets-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
-      commit-hash: ${{ github.ref }}
+      commit-hash: ${{ github.sha }}
       push-to-registry: yes
     secrets: inherit
 
@@ -31,7 +31,7 @@ jobs:
     needs: build-assets-amd64
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
-      commit-hash: ${{ github.ref }}
+      commit-hash: ${{ github.sha }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-amd64
@@ -41,7 +41,7 @@ jobs:
     needs: build-assets-arm64
     uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
     with:
-      commit-hash: ${{ github.ref }}
+      commit-hash: ${{ github.sha }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-arm64
@@ -51,7 +51,7 @@ jobs:
     needs: build-assets-s390x
     uses: ./.github/workflows/publish-kata-deploy-payload-s390x.yaml
     with:
-      commit-hash: ${{ github.ref }}
+      commit-hash: ${{ github.sha }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-s390x


### PR DESCRIPTION
As we need to pass down the commit sha to the jobs that will be
triggered from the `push` / 'schedule' events, we must be careful
on what exactly we're using there.

At first we were using ${{ github.ref }}, but this turns out to be the
**branch name**, rather than the commit hash.  In order to actually get
the commit hash, Let's use ${{ github.sha }} instead.

Fixes: #7247
