### PR TITLE
CCv0 | Update guest components dependency version

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1390,19 +1390,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.10.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "pin-project",
- "spin 0.9.8",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1849,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=af35c064#af35c0649bab2d000b5c350bc5e60db67ef9e1a5"
+source = "git+https://github.com/confidential-containers/guest-components?rev=43f6832#43f68320ed78cef438c838c10a6f462c06bad83f"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1857,7 +1844,6 @@ dependencies = [
  "base64 0.13.1",
  "cfg-if 1.0.0",
  "flate2",
- "flume",
  "futures",
  "futures-util",
  "hex",
@@ -2198,7 +2184,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -2389,15 +2375,6 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom 0.2.9",
-]
 
 [[package]]
 name = "native-tls"
@@ -2716,7 +2693,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=af35c064#af35c0649bab2d000b5c350bc5e60db67ef9e1a5"
+source = "git+https://github.com/confidential-containers/guest-components?rev=43f6832#43f68320ed78cef438c838c10a6f462c06bad83f"
 dependencies = [
  "aes 0.8.2",
  "anyhow",
@@ -4436,15 +4413,6 @@ name = "spin"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -71,7 +71,7 @@ clap = { version = "3.0.1", features = ["derive"] }
 openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
-image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "af35c064", default-features = false, features = ["kata-cc-native-tls"] }
+image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "43f6832", default-features = false, features = ["kata-cc-native-tls"] }
 
 [patch.crates-io]
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }

--- a/versions.yaml
+++ b/versions.yaml
@@ -194,7 +194,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/guest-components/"
-    version: "af35c0649bab2d000b5c350bc5e60db67ef9e1a5"
+    version: "43f68320ed78cef438c838c10a6f462c06bad83f"
 
   cni-plugins:
     description: "CNI network plugins"


### PR DESCRIPTION
Update Attestation-Agent and  image-rs version. They are needed to fix the CI error. Refer to https://github.com/confidential-containers/kbs/issues/124

Fixes: #7285 
