### PR TITLE
gha: nightly: Fix long name of AKS clusters issue and make the CI easier to test

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -8,6 +8,6 @@ jobs:
     uses: ./.github/workflows/ci.yaml
     with:
       commit-hash: ${{ github.sha }}
-      pr-number: ${{ github.sha }}
+      pr-number: "nightly"
       tag: ${{ github.sha }}-nightly
     secrets: inherit

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -2,6 +2,7 @@ name: Kata Containers Nightly CI
 on:
   schedule:
     - cron: '0 0 * * *'
+  workflow_dispatch:
 
 jobs:
   kata-containers-ci-on-push:


### PR DESCRIPTION
---

gha: nightly: Fix name size limit for AKS

Passing the commit hash as the "pr-number" has shown problematic as it
would make the AKS cluster name longer than what's accepted by AKS.

One easy way to solve this is just passing "nightly" as the PR number,
as that's only used to create the cluster.

Fixes: #7247

---

gha: nightly: Also use `workflow_dispatch` to trigger it

This is a very nice suggestion from Steve Horsman, as with that we can
manually trigger the workflow anytime we need to test it, instead of
waiting for a full day for it to be retriggered via the `schedule`
event.

---