### PR TITLE
tools: Use a consistent target name when building mariner initrd

### DIFF
--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -23,7 +23,7 @@ set_kernel_path() {
 
 set_initrd_path() {
     if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
-        initrd_path="/opt/kata/share/kata-containers/kata-containers-initrd-cbl-mariner.img"
+        initrd_path="/opt/kata/share/kata-containers/kata-containers-initrd-mariner.img"
         find ${kubernetes_dir}/runtimeclass_workloads/*.yaml -exec yq write -i {} 'metadata.annotations[io.katacontainers.config.hypervisor.initrd]' "${initrd_path}" \;
     fi
 }

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -232,7 +232,7 @@ install_initrd() {
 
 #Install Mariner guest initrd
 install_initrd_mariner() {
-	install_initrd "cbl-mariner"
+	install_initrd "mariner"
 }
 
 #Install guest initrd for sev

--- a/versions.yaml
+++ b/versions.yaml
@@ -159,7 +159,7 @@ assets:
       x86_64:
         name: *default-initrd-name
         version: *default-initrd-version
-        cbl-mariner:
+        mariner:
           name: "cbl-mariner"
           version: "2.0"
         sev:


### PR DESCRIPTION
Currently a mixture of cbl-mariner and mariner is used when creating the mariner initrd. The kata-static tarball has mariner in the name, but the jenkins url uses cbl-mariner. This breaks cache usage.

Use mariner as the target name throughout the build, so that caching works.

Fixes: #7292