### PR TITLE
metrics: Update memory usage script

### DIFF
--- a/tests/metrics/density/memory_usage.sh
+++ b/tests/metrics/density/memory_usage.sh
@@ -320,8 +320,6 @@ EOF
 
 	metrics_json_add_array_element "$json"
 	metrics_json_end_array "Results"
-
-	clean_env_ctr
 }
 
 function save_config(){
@@ -378,6 +376,7 @@ function main(){
 	fi
 
 	metrics_json_save
+	clean_env_ctr
 }
 
 main "$@"


### PR DESCRIPTION
This PR updates memory usage script by applying the clean_env_ctr at the main in order to avoid failures of leaving certain processes not removed.

Fixes #7302