### PR TITLE
gha: k8s: tdx: Temporarily disable TDX tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,14 +59,14 @@ jobs:
       tag: ${{ inputs.tag }}-amd64
       commit-hash: ${{ inputs.commit-hash }}
 
-  run-k8s-tests-on-tdx:
-    needs: publish-kata-deploy-payload-amd64
-    uses: ./.github/workflows/run-k8s-tests-on-tdx.yaml
-    with:
-      registry: ghcr.io
-      repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ inputs.tag }}-amd64
-      commit-hash: ${{ inputs.commit-hash }}
+#  run-k8s-tests-on-tdx:
+#    needs: publish-kata-deploy-payload-amd64
+#    uses: ./.github/workflows/run-k8s-tests-on-tdx.yaml
+#    with:
+#      registry: ghcr.io
+#      repo: ${{ github.repository_owner }}/kata-deploy-ci
+#      tag: ${{ inputs.tag }}-amd64
+#      commit-hash: ${{ inputs.commit-hash }}
 
   run-metrics-tests:
     needs: build-kata-static-tarball-amd64


### PR DESCRIPTION
TDX tests need to be temporarily disabled as the current machine allocated for this will be off for some time, and a new machine only will be added next week.

Fixes: #7307