### PR TITLE
metrics: Fix metrics ts generator to treat numbers as decimals

### DIFF
--- a/tests/metrics/lib/json.bash
+++ b/tests/metrics/lib/json.bash
@@ -22,7 +22,7 @@ timestamp_ns() {
 	t="$(date +%-s:%-N)"
 	s=$(echo $t | awk -F ':' '{print $1}')
 	n=$(echo $t | awk -F ':' '{print $2}')
-	ns=$(( (s * 1000000000) + n ))
+	ns=$(echo "$s * 1000000000 + $n" | bc)
 
 	echo $ns
 }


### PR DESCRIPTION
Use bc tool to perform math operations even when variables contain values with leading zero.

Fixes: #7317