### PR TITLE
gha: ci: Add cri-containerd tests skeleton -- follow up 1

### DIFF
--- a/.github/workflows/run-cri-containerd-tests.yaml
+++ b/.github/workflows/run-cri-containerd-tests.yaml
@@ -17,6 +17,7 @@ jobs:
         vmm: ['clh', 'qemu']
     runs-on: garm-ubuntu-2204
     env:
+      GOPATH: ${{ github.workspace }}
       KATA_HYPERVSIOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/run-cri-containerd-tests.yaml
+++ b/.github/workflows/run-cri-containerd-tests.yaml
@@ -14,9 +14,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
+        containerd_version: ['lts', 'active']
         vmm: ['clh', 'qemu']
     runs-on: garm-ubuntu-2204
     env:
+      CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}
       KATA_HYPERVSIOR: ${{ matrix.vmm }}
     steps:

--- a/.github/workflows/run-cri-containerd-tests.yaml
+++ b/.github/workflows/run-cri-containerd-tests.yaml
@@ -23,6 +23,9 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
 
+      - name: Install dependencies
+        run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
+
       - name: get-kata-tarball
         uses: actions/download-artifact@v3
         with:

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -13,6 +13,10 @@ kata_tarball_dir="${2:-kata-artifacts}"
 cri_containerd_dir="$(dirname "$(readlink -f "$0")")" 
 source "${cri_containerd_dir}/../../common.bash"
 
+function install_dependencies() {
+	return 0
+}
+
 function run() {
 	info "Running cri-containerd tests using ${KATA_HYPERVISOR} hypervisor"
 
@@ -23,6 +27,7 @@ function run() {
 function main() {
 	action="${1:-}"
 	case "${action}" in
+		install-dependencies) install_dependencies ;;
 		install-kata) install_kata ;;
 		run) run ;;
 		*) >&2 die "Invalid argument" ;;

--- a/versions.yaml
+++ b/versions.yaml
@@ -228,6 +228,8 @@ externals:
     # instead of abstract socket, thus kata wouldn's support the containerd's
     # version older than them.
     version: "v1.6.8"
+    lts: "v1.6"
+    active: "v1.7"
 
   critools:
     description: "CLI tool for Container Runtime Interface (CRI)"


### PR DESCRIPTION
---

ci: cri-containerd: Ensure deps are installed

Let's make sure we install the needed dependencies for running the
`cri-containerd` tests.

---

ci: cri-containerd: Export GOPATH

Let's make sure this is exported, as it'll be needed in order to install
`yq`, which will be used to get the versions of the dependencies to be
installed.

---

ci: cri-containerd: Add LTS / Active versions for containerd

As we'll be testing against the LTS and the Active versions of
containers, let's add those entries to the versions.yaml file and make
sure we export what we want to use for the tests as an env var.

The approach taken should not break the current way of getting the
containerd version.

LTS and Active versions of containerd can be found at:
https://containerd.io/releases/#support-horizon

Fixes: #6543

---