### PR TITLE
tests: Add metrics storage documentation

### DIFF
--- a/tests/metrics/README.md
+++ b/tests/metrics/README.md
@@ -70,6 +70,8 @@ Tests relating to networking. General items could include:
 
 Tests relating to the storage (graph, volume) drivers.
 
+For further details see the [storage tests documentation](storage).
+
 ### Disk
 
 Test relating to measure reading and writing against clusters.

--- a/tests/metrics/storage/README.md
+++ b/tests/metrics/storage/README.md
@@ -1,0 +1,11 @@
+# Kata Containers storage I/O tests
+The metrics tests in this directory are designed to be used to assess storage IO.
+## `Blogbench` test
+The `blogbench` script is based on the `blogbench` program which is designed to emulate a busy blog server with a number of concurrent 
+threads performing a mixture of reads, writes and rewrites.
+### Running the `blogbench` test
+The `blogbench` test can be run by hand, for example:
+```
+$ cd metrics
+$ bash storage/blogbench.sh
+```


### PR DESCRIPTION
This PR adds the metrics storage documentation related with the blogbench performance test as well as a link to the general metrics README.