### PR TITLE
metrics: use rm -f to remove the oldest continerd config file.

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -257,7 +257,7 @@ function create_symbolic_links() {
 # Configures containerd
 function overwrite_containerd_config() {
 	containerd_config="/etc/containerd/config.toml"
-	sudo rm "${containerd_config}"
+	sudo rm -f "${containerd_config}"
 	sudo tee "${containerd_config}" << EOF
 version = 2
 [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]


### PR DESCRIPTION
In order to run kata metrics we need to check that the containerd config file is properly set. When this is not the case, we need to remove that file, and generate a valid one.

This PR runs rm -f in order to ignore errors in case the file to delete does not exist.

Fixes: #7336