### PR TITLE
runtime: support cold addition vfio for clh

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1181,6 +1181,8 @@ func (clh *cloudHypervisor) AddDevice(ctx context.Context, devInfo interface{}, 
 		clh.addVSock(defaultGuestVSockCID, v.UdsPath)
 	case types.Volume:
 		err = clh.addVolume(v)
+	case config.VFIODev:
+		err = clh.addVfioDevice(v)
 	default:
 		clh.Logger().WithField("function", "AddDevice").Warnf("Add device of type %v is not supported.", v)
 		return fmt.Errorf("Not implemented support for %s", v)
@@ -1642,6 +1644,22 @@ func (clh *cloudHypervisor) addVolume(volume types.Volume) error {
 	clh.vmconfig.Fs = &[]chclient.FsConfig{*fs}
 
 	clh.Logger().Debug("Adding share volume to hypervisor: ", volume.MountTag)
+	return nil
+}
+
+// Add vfio device to virtual machine
+func (clh *cloudHypervisor) addVfioDevice(vfiodev config.VFIODev) error {
+	vfioConfig := &chclient.DeviceConfig{
+		Path: vfiodev.SysfsDev,
+		Id:   &vfiodev.ID,
+	}
+
+	if clh.vmconfig.Devices != nil {
+		*clh.vmconfig.Devices = append(*clh.vmconfig.Devices, *vfioConfig)
+	} else {
+		clh.vmconfig.Devices = &[]chclient.DeviceConfig{*vfioConfig}
+	}
+
 	return nil
 }
 

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -127,6 +127,31 @@ func TestCloudHypervisorAddVSock(t *testing.T) {
 	assert.Equal(clh.vmconfig.Vsock.Socket, "path")
 }
 
+func TestCloudHypervisorAddVfioDevice(t *testing.T) {
+	Id := "vfio123"
+	path := "/dev/vfio/101"
+
+	vfDevice := config.VFIODev{
+		ID:       Id,
+		SysfsDev: path,
+	}
+	testCloudHypervisorAddDevice(t, vfDevice)
+}
+
+func testCloudHypervisorAddDevice(t *testing.T, structure interface{}) {
+	assert := assert.New(t)
+	clh := cloudHypervisor{}
+	switch s := structure.(type) {
+	case config.VFIODev:
+		Id := "vfio123"
+		path := "/dev/vfio/101"
+		_ = clh.addVfioDevice(s)
+
+		assert.Equal(s.ID, Id)
+		assert.Equal(s.SysfsDev, path)
+	}
+}
+
 // Check addNet appends to the network config list new configurations.
 // Check that the elements in the list has the correct values
 func TestCloudHypervisorAddNetCheckNetConfigListValues(t *testing.T) {


### PR DESCRIPTION
In some scenarios, cold addition of vfio network cards is required.

Fixes: #6854