### PR TITLE
runtime: get podoverhead from kata_overhead

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1660,16 +1660,12 @@ func (s *Sandbox) Stats(ctx context.Context) (SandboxStats, error) {
 	var metrics interface{}
 	var err error
 	if !s.config.SandboxCgroupOnly {
-
 		metrics, err = s.overheadController.Stat()
-		if err != nil {
-			return SandboxStats{}, err
-		}
 	} else {
 		metrics, err = s.sandboxController.Stat()
-		if err != nil {
-			return SandboxStats{}, err
-		}
+	}
+	if err != nil {
+		return SandboxStats{}, err
 	}
 
 	stats := SandboxStats{}

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1657,9 +1657,19 @@ func (s *Sandbox) StatsContainer(ctx context.Context, containerID string) (Conta
 // Stats returns the stats of a running sandbox
 func (s *Sandbox) Stats(ctx context.Context) (SandboxStats, error) {
 
-	metrics, err := s.sandboxController.Stat()
-	if err != nil {
-		return SandboxStats{}, err
+	var metrics interface{}
+	var err error
+	if !s.config.SandboxCgroupOnly {
+
+		metrics, err = s.overheadController.Stat()
+		if err != nil {
+			return SandboxStats{}, err
+		}
+	} else {
+		metrics, err = s.sandboxController.Stat()
+		if err != nil {
+			return SandboxStats{}, err
+		}
 	}
 
 	stats := SandboxStats{}


### PR DESCRIPTION
kata metrics get error infomation about podoverhead

Fixes: #7145