### PR TITLE
kata-deploy: Add a debug option to kata-deploy (and also use it as part of our CI)

### DIFF
--- a/tests/integration/gha-run.sh
+++ b/tests/integration/gha-run.sh
@@ -77,6 +77,10 @@ function run_tests() {
     kubectl delete namespace kata-containers-k8s-tests &> /dev/null || true
 
     sed -i -e "s|quay.io/kata-containers/kata-deploy:latest|${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}|g" "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
+
+    # Enable debug for Kata Containers
+    yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[1].value' "\"yes\""
+
     if [ "${KATA_HOST_OS}" = "cbl-mariner" ]; then
         yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[+].name' "HOST_OS"
         yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[-1].value' "${KATA_HOST_OS}"

--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -26,6 +26,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: DEBUG
+          value: "no"
         securityContext:
           privileged: true
         volumeMounts:

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -28,6 +28,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: DEBUG
+          value: "no"
         securityContext:
           privileged: true
         volumeMounts:

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -10,6 +10,7 @@ set -o nounset
 
 crio_drop_in_conf_dir="/etc/crio/crio.conf.d/"
 crio_drop_in_conf_file="${crio_drop_in_conf_dir}/99-kata-deploy"
+crio_drop_in_conf_file_debug="${crio_drop_in_conf_dir}/100-debug"
 containerd_conf_file="/etc/containerd/config.toml"
 containerd_conf_file_backup="${containerd_conf_file}.bak"
 
@@ -64,6 +65,16 @@ function install_artifacts() {
 	chmod +x /opt/kata/bin/*
 	[ -d /opt/kata/runtime-rs/bin ] && \
 		chmod +x /opt/kata/runtime-rs/bin/*
+
+	# Allow enabling debug for Kata Containers
+	if [[ "${DEBUG:-"no"}" == "yes" ]]; then
+		config_path="/opt/kata/share/defaults/kata-containers/"
+		for shim in "${shims[@]}"; do
+			sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${config_path}/configuration-${shim}.toml"
+			sed -i -e 's/^#\(debug_console_enabled\).*=.*$/\1 = true/g' "${config_path}/configuration-${shim}.toml"
+			sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug initcall_debug"/g' "${config_path}/configuration-${shim}.toml"
+		done
+	fi
 
 	# Allow Mariner to use custom configuration.
 	if [ "${HOST_OS:-}" == "cbl-mariner" ]; then
@@ -212,6 +223,14 @@ function configure_crio() {
 	for shim in "${shims[@]}"; do
 		configure_crio_runtime $shim
 	done
+
+
+	if [ "${DEBUG:-"no"}" == "yes" ]; then
+		cat <<EOF | tee -a $crio_drop_in_conf_file_debug
+[crio]
+log_level = "debug"
+EOF
+	fi
 }
 
 function configure_containerd_runtime() {
@@ -249,6 +268,18 @@ EOF
   [$options_table]
     ConfigPath = "${config_path}"
 EOF
+	fi
+
+	if [ "${DEBUG:-"no"}" == "yes" ]; then
+		if grep -q "\[debug\]" $containerd_conf_file; then
+			sed -i 's/level.*/level = \"debug\"/' $containerd_conf_file
+		else
+			cat <<EOF | tee -a "$containerd_conf_file"
+[debug]
+  level = "debug"
+EOF
+		fi
+
 	fi
 }
 
@@ -292,6 +323,9 @@ function cleanup_cri_runtime() {
 
 function cleanup_crio() {
 	rm $crio_drop_in_conf_file
+	if [[ "${DEBUG:-"no"}" == "yes" ]]; then
+		rm $crio_drop_in_conf_file_debug
+	fi
 }
 
 function cleanup_containerd() {


### PR DESCRIPTION
---

kata-deploy: Give users the ability to run it on DEBUG mode

The DEBUG env var introduced to the kata-deploy / kata-cleanup yaml file
will be responsible for:
* Setting up the CRI Engine to run with the debug log level set to debug
  * The default is usually info
* Setting up Kata Containers to enable:
  * debug logs
  * debug console
  * agent logs

This will help a lot folks trying to debug Kata Containers while using
kata-deploy, and also help us to always run with DEBUG=yes as part of
our CI.

Fixes: #7342

---

ci: k8s: Enable debug when running the tests

This will help us to gather more information about Kata Containers in
case of failure.

Fixes: #7343

---