### PR TITLE
metrics: Stop running kata-env before kata is properly installed.

### DIFF
--- a/tests/metrics/density/memory_usage.sh
+++ b/tests/metrics/density/memory_usage.sh
@@ -342,6 +342,9 @@ EOF
 }
 
 function main(){
+	# Collect kata-env data
+	common_init
+
 	# Verify enough arguments
 	if [ $# != 2 ] && [ $# != 3 ];then
 		echo >&2 "error: Not enough arguments [$@]"

--- a/tests/metrics/lib/common.bash
+++ b/tests/metrics/lib/common.bash
@@ -18,7 +18,6 @@ DOCKER_EXE="${DOCKER_EXE:-docker}"
 CTR_RUNTIME="${CTR_RUNTIME:-io.containerd.kata.v2}"
 RUNTIME="${RUNTIME:-containerd-shim-kata-v2}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
-TEST_REPO="${TEST_REPO:-github.com/kata-containers/tests}"
 JSON_HOST="${JSON_HOST:-}"
 
 KSM_BASE="/sys/kernel/mm/ksm"
@@ -220,11 +219,11 @@ function show_system_ctr_state()
 
 function common_init()
 {
-	if [ "$CTR_RUNTIME" == "io.containerd.kata.v2" ] || [ "$RUNTIME" == "containerd-shim-kata-v2" ]; then
+	if [ "${CTR_RUNTIME}" = "io.containerd.kata.v2" ] || [ "${RUNTIME}" = "containerd-shim-kata-v2" ]; then
 		extract_kata_env
 	else
 		# We know we have nothing to do for runc or shimv2
-		if [ "$CTR_RUNTIME" != "io.containerd.runc.v2" ] || [ "$RUNTIME" != "runc" ]; then
+		if [ "${CTR_RUNTIME}" != "io.containerd.runc.v2" ] && [ "${RUNTIME}" != "runc" ]; then
 			warn "Unrecognised runtime"
 		fi
 	fi
@@ -359,5 +358,3 @@ function wait_ksm_settle()
 	done
 	info "Timed out after ${1}s waiting for KSM to settle"
 }
-
-common_init

--- a/tests/metrics/lib/json.bash
+++ b/tests/metrics/lib/json.bash
@@ -32,8 +32,11 @@ timestamp_ms() {
 	echo $(($(date +%s%N)/1000000))
 }
 
-# Intialise the json subsystem
+# Initialise the json subsystem
 metrics_json_init() {
+	#  collect kata-env data
+	common_init
+
 	# Clear out any previous results
 	json_result_array=()
 


### PR DESCRIPTION
This PR makes kata-env is called only after some metrics have completed his workload. This fixes a bug that occurs when kata-env was being called before kata is already installed on the testing platform.

Fixes: #7348