### PR TITLE
agent: Fix exec hang issues with a backgroud process

### DIFF
--- a/src/agent/rustjail/src/process.rs
+++ b/src/agent/rustjail/src/process.rs
@@ -161,7 +161,7 @@ impl Process {
 
     pub fn notify_term_close(&mut self) {
         let notify = self.term_exit_notifier.clone();
-        notify.notify_one();
+        notify.notify_waiters();
     }
 
     pub fn close_stdin(&mut self) {


### PR DESCRIPTION
Issue #4747 and pull request #4748 fix exec hang issues where the exec command hangs when a process's stdout is not closed. However, the PR might cause the exec command not to work as expected, leading to CI failure. The PR was reverted in #7042. This PR resolves the exec hang issues and has undergone 1000 rounds of testing to verify that it would not cause any CI failures.

Fixes: #4747

Signed-off-by: Fupan Li <fupan.lfp@antgroup.com>
Signed-off-by: Xuewei Niu <niuxuewei.nxw@antgroup.com>