### PR TITLE
agent: exclude symlinks from recursive ownership change

### DIFF
--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -725,6 +725,14 @@ pub fn recursive_ownership_change(
         mask |= EXEC_MASK;
         mask |= MODE_SETGID;
     }
+
+    // We do not want to change the permission of the underlying file
+    // using symlink. Hence we skip symlinks from recursive ownership
+    // and permission changes.
+    if path.is_symlink() {
+        return Ok(());
+    }
+
     nix::unistd::chown(path, uid, gid)?;
 
     if gid.is_some() {


### PR DESCRIPTION
currently when fsGroup is used with direct-assign, kata agent recursively changes ownership and permission for each file including symlinks. However the problem with symlinks is, the permission of the symlink itself may not be same as the underlying file. So while doing recursive ownership and permission changes we should skip symlinks.

Fixes: #7364