### PR TITLE
ci: k8s: Bring TDX tests back

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,14 +59,14 @@ jobs:
       tag: ${{ inputs.tag }}-amd64
       commit-hash: ${{ inputs.commit-hash }}
 
-#  run-k8s-tests-on-tdx:
-#    needs: publish-kata-deploy-payload-amd64
-#    uses: ./.github/workflows/run-k8s-tests-on-tdx.yaml
-#    with:
-#      registry: ghcr.io
-#      repo: ${{ github.repository_owner }}/kata-deploy-ci
-#      tag: ${{ inputs.tag }}-amd64
-#      commit-hash: ${{ inputs.commit-hash }}
+  run-k8s-tests-on-tdx:
+    needs: publish-kata-deploy-payload-amd64
+    uses: ./.github/workflows/run-k8s-tests-on-tdx.yaml
+    with:
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-amd64
+      commit-hash: ${{ inputs.commit-hash }}
 
   run-metrics-tests:
     needs: build-kata-static-tarball-amd64


### PR DESCRIPTION
Now that we have a new TDX machine plugged into our CI, let's re-enable the TDX tests.

Fixes: #7368