### PR TITLE
tests: common: Fix quoting when globbing

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -287,7 +287,7 @@ function install_kata() {
 	popd
 
 	# create symbolic links to kata components
-	for b in "${katadir}/bin/*" ; do
+	for b in "${katadir}"/bin/* ; do
 		sudo ln -sf "${b}" "${local_bin_dir}/$(basename $b)"
 	done
 


### PR DESCRIPTION
When the glob star is inside quotes, there is only one iteration of the loop and b holds all matches at once. Move the glob out of the quotes so that we actually iterate over matched paths.