### PR TITLE
versions: Bump virtiofsd to v1.7.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -318,11 +318,11 @@ externals:
     version: "v1.6.1"
     toolchain: "1.66.0"
     meta:
-      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.6.1,
-      # this is the link labelled virtiofsd-v1.6.1.zip
+      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.7.0,
+      # this is the link labelled virtiofsd-v1.7.0.zip
       #
       # yamllint disable-line rule:line-length
-      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/14c1e8a7acc82d515cec6608727a1e4a/virtiofsd-v1.6.1.zip"
+      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/dc56ecbf86ce1226bdc31f946cfded75/virtiofsd-v1.7.0.zip"
 
 languages:
   description: |


### PR DESCRIPTION
https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.7.0 was released Today.

Fixes: #7371