### PR TITLE
metrics: stop hypervirsor and shim at init_env stage

### DIFF
--- a/tests/metrics/lib/common.bash
+++ b/tests/metrics/lib/common.bash
@@ -178,6 +178,7 @@ function init_env()
 	# This clean up is more aggressive, this is in order to
 	# decrease the factors that could affect the metrics results.
 	kill_processes_before_start
+	info "init environment complete"
 }
 
 # This function checks if there are containers or

--- a/tests/metrics/storage/blogbench.sh
+++ b/tests/metrics/storage/blogbench.sh
@@ -39,6 +39,7 @@ function main() {
 	sudo systemctl restart containerd
 	metrics_json_init
 
+	info "Running Blogbench test"
 	local output=$(sudo -E ${CTR_EXE} run --rm --runtime=${CTR_RUNTIME} ${IMAGE} test ${CMD})
 
 	# Save configuration
@@ -66,6 +67,7 @@ EOF
 	metrics_json_end_array "Config"
 
 	# Save results
+	info "Saving Blogbench results"
 	metrics_json_start_array
 
 	local writes=$(tail -2 <<< "${output}" | head -1 | awk '{print $5}')


### PR DESCRIPTION
This PR kills the hypervisor and the kata shim in the init_env stage prior to launch any metric test.
Additionally this PR adds info messages in the main blocks of the blogbench test to help in debugging.