### PR TITLE
runtime-rs: Introduce directly attachable network

### DIFF
--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -137,6 +137,17 @@ pub struct Runtime {
     /// This option is typically used to retain abnormal information for debugging.
     #[serde(default)]
     pub keep_abnormal: bool,
+
+    /// Base directory of directly attachable network config, the default value
+    /// is "/run/kata-containers/dans".
+    ///
+    /// Network devices for VM-based containers are allowed to be placed in the
+    /// host netns to eliminate as many hops as possible, which is what we
+    /// called a "directly attachable network". The config, set by special CNI
+    /// plugins, is used to tell the Kata Containers what devices are attached
+    /// to the hypervisor.
+    #[serde(default)]
+    pub dan_conf: String,
 }
 
 impl ConfigOps for Runtime {

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -162,6 +162,7 @@ DEFVFIOMODE := guest-kernel
 DEFSANDBOXCGROUPONLY ?= false
 DEFSTATICRESOURCEMGMT_DB ?= false
 DEFBINDMOUNTS := []
+DEFDANCONF := /run/kata-containers/dans
 SED = sed
 CLI_DIR = cmd
 SHIMV2 = containerd-shim-kata-v2
@@ -308,6 +309,7 @@ USER_VARS += DBSHAREDFS
 USER_VARS += KATA_INSTALL_GROUP
 USER_VARS += KATA_INSTALL_OWNER
 USER_VARS += KATA_INSTALL_CFG_PERMS
+USER_VARS += DEFDANCONF
 
 SOURCES := \
   $(shell find . 2>&1 | grep -E '.*\.rs$$') \

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -323,3 +323,12 @@ static_sandbox_resource_mgmt=@DEFSTATICRESOURCEMGMT_DB@
 # - "/path/to:ro", readonly mode.
 # - "/path/to:rw", readwrite mode.
 sandbox_bind_mounts=@DEFBINDMOUNTS@
+
+# Base directory of directly attachable network config.
+# Network devices for VM-based containers are allowed to be placed in the
+# host netns to eliminate as many hops as possible, which is what we
+# called a "Directly Attachable Network". The config, set by special CNI
+# plugins, is used to tell the Kata containers what devices are attached
+# to the hypervisor.
+# (default: /run/kata-containers/dans)
+dan_conf = "@DEFDANCONF@"

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_net.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_net.rs
@@ -41,6 +41,12 @@ pub struct NetworkConfig {
 
     /// Guest MAC address.
     pub guest_mac: Option<Address>,
+
+    /// Virtio queue size
+    pub queue_size: usize,
+
+    /// Virtio queue num
+    pub queue_num: usize,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -214,6 +214,8 @@ impl DragonballInner {
                 Some(mac) => MacAddr::from_bytes(&mac.0).ok(),
                 None => None,
             },
+            num_queues: config.queue_num,
+            queue_size: config.queue_size as u16,
             ..Default::default()
         };
 

--- a/src/runtime-rs/crates/resource/src/network/dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/dan.rs
@@ -1,0 +1,406 @@
+// Copyright (c) 2019-2023 Alibaba Cloud
+// Copyright (c) 2019-2023 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Directly Attachable Network (DAN) is a type of network that runs in the host
+//! netns. It supports host-tap, vhost-user (DPDK), etc.
+//! The device information is retrieved from a JSON file, the type of which is
+//! `Vec<DanDevice>`.
+//! In this module, `IPAddress`, `Interface`, etc., are duplicated mostly from
+//! `agent::IPAddress`, `agent::Interface`, and so on. They can't be referenced
+//! directly because the former represents the structure of the JSON file written
+//! by CNI plugins. They might have some slight differences, and may be revised in
+//! the future.
+
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::str::FromStr;
+use std::sync::Arc;
+
+use agent::IPFamily;
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use hypervisor::device::device_manager::DeviceManager;
+use hypervisor::Hypervisor;
+use kata_types::config::TomlConfig;
+use scopeguard::defer;
+use serde::{Deserialize, Serialize};
+use tokio::fs;
+use tokio::sync::RwLock;
+
+use super::network_entity::NetworkEntity;
+use super::utils::address::{ip_family_from_ip_addr, parse_ip_cidr};
+use super::{EndpointState, NetnsGuard, Network};
+use crate::network::endpoint::TapEndpoint;
+use crate::network::network_info::network_info_from_dan::NetworkInfoFromDan;
+use crate::network::utils::generate_private_mac_addr;
+
+/// Directly attachable network
+pub struct Dan {
+    inner: Arc<RwLock<DanInner>>,
+}
+
+pub struct DanInner {
+    netns: Option<String>,
+    entity_list: Vec<NetworkEntity>,
+}
+
+impl Dan {
+    pub async fn new(
+        config: &DanNetworkConfig,
+        dev_mgr: Arc<RwLock<DeviceManager>>,
+    ) -> Result<Self> {
+        Ok(Self {
+            inner: Arc::new(RwLock::new(DanInner::new(config, &dev_mgr).await?)),
+        })
+    }
+}
+
+impl DanInner {
+    /// DanInner initialization deserializes DAN devices from a file writen
+    /// by CNI plugins. Respective endpoint and network_info are retrieved
+    /// from the devices, and compose NetworkEntity.
+    async fn new(config: &DanNetworkConfig, dev_mgr: &Arc<RwLock<DeviceManager>>) -> Result<Self> {
+        let json_str = fs::read_to_string(&config.dan_conf_path)
+            .await
+            .context("Read DAN config from file")?;
+        let config: DanConfig = serde_json::from_str(&json_str).context("Invalid DAN config")?;
+        info!(sl!(), "Dan config is loaded = {:?}", config);
+
+        let (connection, handle, _) = rtnetlink::new_connection().context("New connection")?;
+        let thread_handler = tokio::spawn(connection);
+        defer!({
+            thread_handler.abort();
+        });
+
+        let mut entity_list = Vec::with_capacity(config.devices.len());
+        for (idx, device) in config.devices.iter().enumerate() {
+            let name = format!("eth{}", idx);
+            let endpoint = match &device.device {
+                // TODO: Support VhostUserNet protocol
+                Device::VhostUser {
+                    path,
+                    queue_num: _,
+                    queue_size: _,
+                } => {
+                    warn!(sl!(), "A DAN device whose type is \"vhost-user\" and socket path is {} is ignored.", path);
+                    continue;
+                }
+                Device::HostTap {
+                    tap_name,
+                    queue_num,
+                    queue_size,
+                } => Arc::new(
+                    TapEndpoint::new(
+                        &handle,
+                        idx as u32,
+                        &name,
+                        tap_name,
+                        &device.guest_mac,
+                        *queue_num,
+                        *queue_size,
+                        dev_mgr,
+                    )
+                    .await
+                    .with_context(|| format!("New a {} tap endpoint", tap_name))?,
+                ),
+            };
+
+            let network_info = Arc::new(
+                NetworkInfoFromDan::new(device)
+                    .await
+                    .context("Network info from DAN")?,
+            );
+
+            entity_list.push(NetworkEntity {
+                endpoint,
+                network_info,
+            })
+        }
+
+        Ok(Self {
+            netns: config.netns,
+            entity_list,
+        })
+    }
+}
+
+#[async_trait]
+impl Network for Dan {
+    async fn setup(&self) -> Result<()> {
+        let inner = self.inner.read().await;
+        let _netns_guard;
+        if let Some(netns) = inner.netns.as_ref() {
+            _netns_guard = NetnsGuard::new(netns).context("New netns guard")?;
+        }
+        for e in inner.entity_list.iter() {
+            e.endpoint.attach().await.context("Attach")?;
+        }
+        Ok(())
+    }
+
+    async fn interfaces(&self) -> Result<Vec<agent::Interface>> {
+        let inner = self.inner.read().await;
+        let mut interfaces = vec![];
+        for e in inner.entity_list.iter() {
+            interfaces.push(e.network_info.interface().await.context("Interface")?);
+        }
+        Ok(interfaces)
+    }
+
+    async fn routes(&self) -> Result<Vec<agent::Route>> {
+        let inner = self.inner.read().await;
+        let mut routes = vec![];
+        for e in inner.entity_list.iter() {
+            let mut list = e.network_info.routes().await.context("Routes")?;
+            routes.append(&mut list);
+        }
+        Ok(routes)
+    }
+
+    async fn neighs(&self) -> Result<Vec<agent::ARPNeighbor>> {
+        let inner = self.inner.read().await;
+        let mut neighs = vec![];
+        for e in &inner.entity_list {
+            let mut list = e.network_info.neighs().await.context("Neighs")?;
+            neighs.append(&mut list);
+        }
+        Ok(neighs)
+    }
+
+    async fn save(&self) -> Option<Vec<EndpointState>> {
+        let inner = self.inner.read().await;
+        let mut ep_states = vec![];
+        for e in &inner.entity_list {
+            if let Some(state) = e.endpoint.save().await {
+                ep_states.push(state);
+            }
+        }
+        Some(ep_states)
+    }
+
+    async fn remove(&self, h: &dyn Hypervisor) -> Result<()> {
+        let inner = self.inner.read().await;
+        let _netns_guard;
+        if let Some(netns) = inner.netns.as_ref() {
+            _netns_guard = NetnsGuard::new(netns).context("New netns guard")?;
+        }
+        for e in inner.entity_list.iter() {
+            e.endpoint.detach(h).await.context("Detach")?;
+        }
+        Ok(())
+    }
+}
+
+/// Directly attachable network config
+#[derive(Debug)]
+pub struct DanNetworkConfig {
+    pub dan_conf_path: PathBuf,
+}
+
+/// Directly attachable network config written by CNI plugins
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DanConfig {
+    netns: Option<String>,
+    devices: Vec<DanDevice>,
+}
+
+/// Directly attachable network device
+/// This struct is serilized from a file containing devices information,
+/// sent from CNI plugins.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct DanDevice {
+    // Name of device (interface name on the guest)
+    pub(crate) name: String,
+    // Mac address of interface on the guest, if it is not specified, a
+    // private address is generated as default.
+    #[serde(default = "generate_private_mac_addr")]
+    pub(crate) guest_mac: String,
+    // Device
+    pub(crate) device: Device,
+    // Network info
+    pub(crate) network_info: NetworkInfo,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "type")]
+pub(crate) enum Device {
+    #[serde(rename = "vhost-user")]
+    VhostUser {
+        // Vhost-user socket path
+        path: String,
+        #[serde(default)]
+        queue_num: usize,
+        #[serde(default)]
+        queue_size: usize,
+    },
+    #[serde(rename = "host-tap")]
+    HostTap {
+        tap_name: String,
+        #[serde(default)]
+        queue_num: usize,
+        #[serde(default)]
+        queue_size: usize,
+    },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct NetworkInfo {
+    pub(crate) interface: Interface,
+    #[serde(default)]
+    pub(crate) routes: Vec<Route>,
+    #[serde(default)]
+    pub(crate) neighbors: Vec<ARPNeighbor>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct Interface {
+    // IP addresses in the format of CIDR
+    pub ip_addresses: Vec<String>,
+    #[serde(default = "default_mtu")]
+    pub mtu: u64,
+    #[serde(default)]
+    // Link type
+    pub ntype: String,
+    #[serde(default)]
+    pub flags: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct Route {
+    #[serde(default)]
+    // Destination(CIDR), an empty string denotes no destination
+    pub dest: String,
+    #[serde(default)]
+    // Gateway(IP Address), an empty string denotes no gateway
+    pub gateway: String,
+    // Source(IP Address), an empty string denotes no gateway
+    #[serde(default)]
+    pub source: String,
+    // Scope
+    #[serde(default)]
+    pub scope: u32,
+}
+
+impl Route {
+    pub(crate) fn ip_family(&self) -> Result<IPFamily> {
+        if !self.dest.is_empty() {
+            return Ok(ip_family_from_ip_addr(
+                &parse_ip_cidr(&self.dest)
+                    .context("Parse ip addr from dest")?
+                    .0,
+            ));
+        }
+
+        if !self.gateway.is_empty() {
+            return Ok(ip_family_from_ip_addr(
+                &IpAddr::from_str(&self.gateway).context("Parse ip addr from gateway")?,
+            ));
+        }
+
+        if !self.source.is_empty() {
+            return Ok(ip_family_from_ip_addr(
+                &IpAddr::from_str(&self.source).context("Parse ip addr from source")?,
+            ));
+        }
+
+        Err(anyhow!("Failed to retrieve IP family from {:?}", self))
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub(crate) struct ARPNeighbor {
+    // IP address in the format of CIDR
+    pub ip_address: Option<String>,
+    #[serde(default)]
+    pub hardware_addr: String,
+    #[serde(default)]
+    pub state: u32,
+    #[serde(default)]
+    pub flags: u32,
+}
+
+fn default_mtu() -> u64 {
+    1500
+}
+
+/// Path of DAN config, the file contains an array of DanDevices.
+#[inline]
+pub fn dan_config_path(config: &TomlConfig, sandbox_id: &str) -> PathBuf {
+    PathBuf::from(config.runtime.dan_conf.as_str()).join(format!("{}.json", sandbox_id))
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::network::dan::{ARPNeighbor, DanDevice, Device, Interface, NetworkInfo, Route};
+
+    #[test]
+    fn test_dan_json() {
+        let json_str = r#"{
+            "name": "eth0",
+            "guest_mac": "xx:xx:xx:xx:xx",
+            "device": {
+                "type": "vhost-user",
+                "path": "/tmp/test",
+                "queue_num": 1,
+                "queue_size": 1
+            },
+            "network_info": {
+                "interface": {
+                    "ip_addresses": ["192.168.0.1/24"],
+                    "mtu": 1500,
+                    "ntype": "tuntap",
+                    "flags": 0
+                },
+                "routes": [{
+                    "dest": "172.18.0.0/16",
+                    "source": "172.18.0.1",
+                    "gateway": "172.18.31.1",
+                    "scope": 0,
+                    "flags": 0
+                }],
+                "neighbors": [{
+                    "ip_address": "192.168.0.3/16",
+                    "device": "",
+                    "state": 0,
+                    "flags": 0,
+                    "hardware_addr": "xx:xx:xx:xx:xx"
+                }]
+            }
+        }"#;
+        let dev_from_json: DanDevice = serde_json::from_str(json_str).unwrap();
+        let dev = DanDevice {
+            name: "eth0".to_owned(),
+            guest_mac: "xx:xx:xx:xx:xx".to_owned(),
+            device: Device::VhostUser {
+                path: "/tmp/test".to_owned(),
+                queue_num: 1,
+                queue_size: 1,
+            },
+            network_info: NetworkInfo {
+                interface: Interface {
+                    ip_addresses: vec!["192.168.0.1/24".to_owned()],
+                    mtu: 1500,
+                    ntype: "tuntap".to_owned(),
+                    flags: 0,
+                },
+                routes: vec![Route {
+                    dest: "172.18.0.0/16".to_owned(),
+                    source: "172.18.0.1".to_owned(),
+                    gateway: "172.18.31.1".to_owned(),
+                    scope: 0,
+                }],
+                neighbors: vec![ARPNeighbor {
+                    ip_address: Some("192.168.0.3/16".to_owned()),
+                    hardware_addr: "xx:xx:xx:xx:xx".to_owned(),
+                    state: 0,
+                    flags: 0,
+                }],
+            },
+        };
+
+        assert_eq!(dev_from_json, dev);
+    }
+}

--- a/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
@@ -40,11 +40,17 @@ pub struct IpVlanEndpointState {
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]
+pub struct TapEndpointState {
+    pub if_name: String,
+}
+
+#[derive(Serialize, Deserialize, Clone, Default)]
 pub struct EndpointState {
     pub physical_endpoint: Option<PhysicalEndpointState>,
     pub veth_endpoint: Option<VethEndpointState>,
     pub ipvlan_endpoint: Option<IpVlanEndpointState>,
     pub macvlan_endpoint: Option<MacvlanEndpointState>,
     pub vlan_endpoint: Option<VlanEndpointState>,
+    pub tap_endpoint: Option<TapEndpointState>,
     // TODO : other endpoint
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/mod.rs
@@ -16,6 +16,8 @@ mod macvlan_endpoint;
 pub use macvlan_endpoint::MacVlanEndpoint;
 pub mod endpoint_persist;
 mod endpoints_test;
+mod tap_endpoint;
+pub use tap_endpoint::TapEndpoint;
 
 use anyhow::Result;
 use async_trait::async_trait;

--- a/src/runtime-rs/crates/resource/src/network/endpoint/tap_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/tap_endpoint.rs
@@ -1,0 +1,124 @@
+// Copyright (c) 2019-2023 Alibaba Cloud
+// Copyright (c) 2019-2023 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use hypervisor::device::device_manager::{do_handle_device, DeviceManager};
+use hypervisor::device::{DeviceConfig, DeviceType};
+use hypervisor::{Hypervisor, NetworkConfig, NetworkDevice};
+use tokio::sync::RwLock;
+
+use super::endpoint_persist::TapEndpointState;
+use super::Endpoint;
+use crate::network::network_pair::{get_link_by_name, NetworkInterface};
+use crate::network::{utils, EndpointState};
+
+/// TapEndpoint is used to attach to the hypervisor directly
+#[derive(Debug)]
+pub struct TapEndpoint {
+    // Index
+    #[allow(dead_code)]
+    index: u32,
+    // Name of virt interface
+    name: String,
+    // Hardware address of virt interface
+    guest_mac: String,
+    // Tap interface on the host
+    tap_iface: NetworkInterface,
+    // Device manager
+    dev_mgr: Arc<RwLock<DeviceManager>>,
+    // Virtio queue num
+    queue_num: usize,
+    // Virtio queue size
+    queue_size: usize,
+}
+
+impl TapEndpoint {
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new(
+        handle: &rtnetlink::Handle,
+        index: u32,
+        name: &str,
+        tap_name: &str,
+        guest_mac: &str,
+        queue_num: usize,
+        queue_size: usize,
+        dev_mgr: &Arc<RwLock<DeviceManager>>,
+    ) -> Result<Self> {
+        let tap_link = get_link_by_name(handle, tap_name)
+            .await
+            .context("get link by name")?;
+        let tap_hard_addr =
+            utils::get_mac_addr(&tap_link.attrs().hardware_addr).context("Get mac addr of tap")?;
+
+        Ok(TapEndpoint {
+            index,
+            name: name.to_owned(),
+            guest_mac: guest_mac.to_owned(),
+            tap_iface: NetworkInterface {
+                name: tap_name.to_owned(),
+                hard_addr: tap_hard_addr,
+                ..Default::default()
+            },
+            dev_mgr: dev_mgr.clone(),
+            queue_num,
+            queue_size,
+        })
+    }
+
+    fn get_network_config(&self) -> Result<NetworkConfig> {
+        let guest_mac = utils::parse_mac(&self.guest_mac).context("Parse mac address")?;
+        Ok(NetworkConfig {
+            host_dev_name: self.tap_iface.name.clone(),
+            virt_iface_name: self.name.clone(),
+            guest_mac: Some(guest_mac),
+            queue_num: self.queue_num,
+            queue_size: self.queue_size,
+            ..Default::default()
+        })
+    }
+}
+
+#[async_trait]
+impl Endpoint for TapEndpoint {
+    async fn name(&self) -> String {
+        self.name.clone()
+    }
+
+    async fn hardware_addr(&self) -> String {
+        self.guest_mac.clone()
+    }
+
+    async fn attach(&self) -> Result<()> {
+        let config = self.get_network_config().context("Get network config")?;
+        do_handle_device(&self.dev_mgr, &DeviceConfig::NetworkCfg(config))
+            .await
+            .context("Handle device")?;
+        Ok(())
+    }
+
+    async fn detach(&self, h: &dyn Hypervisor) -> Result<()> {
+        let config = self.get_network_config().context("Get network config")?;
+        h.remove_device(DeviceType::Network(NetworkDevice {
+            config,
+            ..Default::default()
+        }))
+        .await
+        .context("Remove device")?;
+        Ok(())
+    }
+
+    async fn save(&self) -> Option<EndpointState> {
+        Some(EndpointState {
+            tap_endpoint: Some(TapEndpointState {
+                if_name: self.name.clone(),
+            }),
+            ..Default::default()
+        })
+    }
+}

--- a/src/runtime-rs/crates/resource/src/network/network_info/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/mod.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+pub(crate) mod network_info_from_dan;
 pub(crate) mod network_info_from_link;
 
 use agent::{ARPNeighbor, Interface, Route};

--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_dan.rs
@@ -1,0 +1,213 @@
+// Copyright (c) 2019-2023 Alibaba Cloud
+// Copyright (c) 2019-2023 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use agent::{ARPNeighbor, IPAddress, Interface, Route};
+use anyhow::Result;
+use async_trait::async_trait;
+use netlink_packet_route::IFF_NOARP;
+
+use super::NetworkInfo;
+use crate::network::dan::DanDevice;
+use crate::network::utils::address::{ip_family_from_ip_addr, parse_ip_cidr};
+
+/// NetworkInfoFromDan is responsible for converting network info in JSON
+/// to agent's network info.
+#[derive(Debug)]
+pub(crate) struct NetworkInfoFromDan {
+    interface: Interface,
+    routes: Vec<Route>,
+    neighs: Vec<ARPNeighbor>,
+}
+
+impl NetworkInfoFromDan {
+    pub async fn new(dan_device: &DanDevice) -> Result<Self> {
+        let ip_addresses = dan_device
+            .network_info
+            .interface
+            .ip_addresses
+            .iter()
+            .filter_map(|addr| {
+                let (ipaddr, mask) = match parse_ip_cidr(addr) {
+                    Ok(ip_cidr) => (ip_cidr.0, ip_cidr.1),
+                    Err(_) => return None,
+                };
+                // Skip if it is a loopback address
+                if ipaddr.is_loopback() {
+                    return None;
+                }
+
+                Some(IPAddress {
+                    family: ip_family_from_ip_addr(&ipaddr),
+                    address: ipaddr.to_string(),
+                    mask: format!("{}", mask),
+                })
+            })
+            .collect();
+
+        let interface = Interface {
+            device: dan_device.name.clone(),
+            name: dan_device.name.clone(),
+            ip_addresses,
+            mtu: dan_device.network_info.interface.mtu,
+            hw_addr: dan_device.guest_mac.clone(),
+            pci_addr: String::default(),
+            field_type: dan_device.network_info.interface.ntype.clone(),
+            raw_flags: dan_device.network_info.interface.flags & IFF_NOARP,
+        };
+
+        let routes = dan_device
+            .network_info
+            .routes
+            .iter()
+            .filter_map(|route| {
+                let family = match route.ip_family() {
+                    Ok(family) => family,
+                    Err(_) => return None,
+                };
+                Some(Route {
+                    dest: route.dest.clone(),
+                    gateway: route.gateway.clone(),
+                    device: dan_device.name.clone(),
+                    source: route.source.clone(),
+                    scope: route.scope,
+                    family,
+                })
+            })
+            .collect();
+
+        let neighs = dan_device
+            .network_info
+            .neighbors
+            .iter()
+            .map(|neigh| {
+                let to_ip_address = neigh.ip_address.as_ref().and_then(|ip_address| {
+                    parse_ip_cidr(ip_address)
+                        .ok()
+                        .map(|(ipaddr, mask)| IPAddress {
+                            family: ip_family_from_ip_addr(&ipaddr),
+                            address: ipaddr.to_string(),
+                            mask: format!("{}", mask),
+                        })
+                });
+
+                ARPNeighbor {
+                    to_ip_address,
+                    device: dan_device.name.clone(),
+                    ll_addr: neigh.hardware_addr.clone(),
+                    state: neigh.state as i32,
+                    flags: neigh.flags as i32,
+                }
+            })
+            .collect();
+
+        Ok(Self {
+            interface,
+            routes,
+            neighs,
+        })
+    }
+}
+
+#[async_trait]
+impl NetworkInfo for NetworkInfoFromDan {
+    async fn interface(&self) -> Result<Interface> {
+        Ok(self.interface.clone())
+    }
+
+    async fn routes(&self) -> Result<Vec<Route>> {
+        Ok(self.routes.clone())
+    }
+
+    async fn neighs(&self) -> Result<Vec<ARPNeighbor>> {
+        Ok(self.neighs.clone())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use agent::{ARPNeighbor, IPAddress, IPFamily, Interface, Route};
+
+    use super::NetworkInfoFromDan;
+    use crate::network::dan::{
+        ARPNeighbor as DanARPNeighbor, DanDevice, Device, Interface as DanInterface,
+        NetworkInfo as DanNetworkInfo, Route as DanRoute,
+    };
+    use crate::network::NetworkInfo;
+
+    #[tokio::test]
+    async fn test_network_info_from_dan() {
+        let dan_device = DanDevice {
+            name: "eth0".to_owned(),
+            guest_mac: "xx:xx:xx:xx:xx".to_owned(),
+            device: Device::HostTap {
+                tap_name: "tap0".to_owned(),
+                queue_num: 0,
+                queue_size: 0,
+            },
+            network_info: DanNetworkInfo {
+                interface: DanInterface {
+                    ip_addresses: vec!["192.168.0.1/24".to_owned()],
+                    mtu: 1500,
+                    ntype: "tuntap".to_owned(),
+                    flags: 0,
+                },
+                routes: vec![DanRoute {
+                    dest: "172.18.0.0/16".to_owned(),
+                    source: "172.18.0.1".to_owned(),
+                    gateway: "172.18.31.1".to_owned(),
+                    scope: 0,
+                }],
+                neighbors: vec![DanARPNeighbor {
+                    ip_address: Some("192.168.0.3/16".to_owned()),
+                    hardware_addr: "yy:yy:yy:yy:yy".to_owned(),
+                    state: 0,
+                    flags: 0,
+                }],
+            },
+        };
+
+        let network_info = NetworkInfoFromDan::new(&dan_device).await.unwrap();
+
+        let interface = Interface {
+            device: "eth0".to_owned(),
+            name: "eth0".to_owned(),
+            ip_addresses: vec![IPAddress {
+                family: IPFamily::V4,
+                address: "192.168.0.1".to_owned(),
+                mask: "24".to_owned(),
+            }],
+            mtu: 1500,
+            hw_addr: "xx:xx:xx:xx:xx".to_owned(),
+            pci_addr: String::default(),
+            field_type: "tuntap".to_owned(),
+            raw_flags: 0,
+        };
+        assert_eq!(interface, network_info.interface().await.unwrap());
+
+        let routes = vec![Route {
+            dest: "172.18.0.0/16".to_owned(),
+            gateway: "172.18.31.1".to_owned(),
+            device: "eth0".to_owned(),
+            source: "172.18.0.1".to_owned(),
+            scope: 0,
+            family: IPFamily::V4,
+        }];
+        assert_eq!(routes, network_info.routes().await.unwrap());
+
+        let neighbors = vec![ARPNeighbor {
+            to_ip_address: Some(IPAddress {
+                family: IPFamily::V4,
+                address: "192.168.0.3".to_owned(),
+                mask: "16".to_owned(),
+            }),
+            device: "eth0".to_owned(),
+            ll_addr: "yy:yy:yy:yy:yy".to_owned(),
+            state: 0,
+            flags: 0,
+        }];
+        assert_eq!(neighbors, network_info.neighs().await.unwrap());
+    }
+}


### PR DESCRIPTION
Kata containers as VM-based containers are allowed to run in the host netns. That is, the network is able to isolate in the L2. The network performance will benefit from this architecture, which eliminates as many hops as possible. We called it a Directly Attachable Network (DAN for short).

The network devices are placed at the host netns by the CNI plugins. The configs are saved at {dan_conf}/{sandbox_id}.json in the format of JSON, including device name, type, and network info. At the very beginning stage, the DAN only supports host tap devices. More devices, like the DPDK, will be supported in later versions.

The format of file looks like as below:

```json
{
	"netns": "/path/to/netns",
	"devices": [{
		"name": "eth0",
		"guest_mac": "xx:xx:xx:xx:xx",
		"device": {
			"type": "vhost-user",
			"path": "/tmp/test",
			"queue_num": 1,
			"queue_size": 1
		},
		"network_info": {
			"interface": {
				"ip_addresses": ["192.168.0.1/24"],
				"mtu": 1500,
				"ntype": "tuntap",
				"flags": 0
			},
			"routes": [{
				"dest": "172.18.0.0/16",
				"source": "172.18.0.1",
				"gateway": "172.18.31.1",
				"scope": 0,
				"flags": 0
			}],
			"neighbors": [{
				"ip_address": "192.168.0.3/16",
				"device": "",
				"state": 0,
				"flags": 0,
				"hardware_addr": "xx:xx:xx:xx:xx"
			}]
		}
	}]
}
```

Fixes: #1922

Signed-off-by: Xuewei Niu <niuxuewei.nxw@antgroup.com>