### PR TITLE
gha: ci: cc-payload-after-push: Add workflow_dispatch trigger

### DIFF
--- a/.github/workflows/cc-payload-after-push.yaml
+++ b/.github/workflows/cc-payload-after-push.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - CCv0
+  workflow_dispatch:
 
 jobs:
   build-assets-amd64:


### PR DESCRIPTION
Allow triggering this action manually, since we noticed it being skipped on push exactly when we needed it the most.