### PR TITLE
kata-deploy: Add VERSION and versions.yaml to the final tarball

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -99,7 +99,7 @@ jobs:
           path: kata-artifacts
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -83,7 +83,7 @@ jobs:
           path: kata-artifacts
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -80,7 +80,7 @@ jobs:
           path: kata-artifacts
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -121,6 +121,19 @@ jobs:
           GITHUB_TOKEN=${{ secrets.GIT_UPLOAD_TOKEN }} hub release edit -m "" -a "${tarball}" "${tag}"
           popd
 
+  upload-versions-yaml-tarball:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: upload versions.yaml
+        run: |
+          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+          pushd $GITHUB_WORKSPACE
+          versions_file="kata-containers-$tag-versions.yaml"
+          cp versions.yaml ${versions_file}
+          hub release edit -m "" -a "${versions_file}" "${tag}"
+          popd
+
   upload-cargo-vendored-tarball:
     needs: upload-multi-arch-static-tarball
     runs-on: ubuntu-latest

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -125,7 +125,7 @@ virtiofsd-tarball:
 	${MAKE} $@-build
 
 merge-builds:
-	$(MK_DIR)/kata-deploy-merge-builds.sh build
+	$(MK_DIR)/kata-deploy-merge-builds.sh build "$(MK_DIR)/../../../../versions.yaml"
 
 install-tarball:
 	tar -xf ./kata-static.tar.xz -C /

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -64,9 +64,6 @@ firecracker-tarball:
 kernel-dragonball-experimental-tarball:
 	${MAKE} $@-build
 
-kernel-experimental-tarball:
-	${MAKE} $@-build
-
 kernel-nvidia-gpu-tarball:
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -346,14 +346,6 @@ install_kernel_nvidia_gpu_tdx_experimental() {
 		"-x tdx -g nvidia -u ${kernel_url} -H deb"
 }
 
-#Install experimental kernel asset
-install_kernel_experimental() {
-	install_kernel_helper \
-		"assets.kernel-experimental.version" \
-		"kernel-experimental" \
-		"-f -b experimental"
-}
-
 #Install experimental TDX kernel asset
 install_kernel_tdx_experimental() {
 	local kernel_url="$(get_from_kata_deps assets.kernel-tdx-experimental.url)"
@@ -647,8 +639,6 @@ handle_build() {
 	kernel) install_kernel ;;
 
 	kernel-dragonball-experimental) install_kernel_dragonball_experimental ;;
-
-	kernel-experimental) install_kernel_experimental ;;
 
 	kernel-nvidia-gpu) install_kernel_nvidia_gpu ;;
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -11,6 +11,8 @@ set -o pipefail
 set -o errtrace
 
 kata_build_dir=${1:-build}
+kata_versions_yaml_file=${2:-""}
+
 tar_path="${PWD}/kata-static.tar.xz"
 
 pushd "${kata_build_dir}"
@@ -23,6 +25,15 @@ do
 	echo "untarring tarball "${c}" into ${tarball_content_dir}"
 	tar -xvf "${c}" -C "${tarball_content_dir}"
 done
+
+pushd ${tarball_content_dir}
+	shim="containerd-shim-kata-v2"
+	shim_path=$(find . -name ${shim} | sort | head -1)
+	prefix=${shim_path%"bin/${shim}"}
+
+	echo "$(git describe)" > ${prefix}/VERSION
+	[[ -n "${kata_versions_yaml_file}" ]] && cp ${kata_versions_yaml_file} ${prefix}/
+popd
 
 echo "create ${tar_path}"
 (cd "${tarball_content_dir}"; tar cvfJ "${tar_path}" .)

--- a/versions.yaml
+++ b/versions.yaml
@@ -179,11 +179,6 @@ assets:
       url: "https://cdn.kernel.org/pub/linux/kernel/v5.x/"
       version: "v5.19.2"
 
-  kernel-experimental:
-    description: "Linux kernel with virtio-fs support"
-    url: "https://cdn.kernel.org/pub/linux/kernel/v5.x/"
-    tag: "v5.13.10"
-
   kernel-arm-experimental:
     description: "Linux kernel with cpu/mem hotplug support on arm64"
     url: "https://cdn.kernel.org/pub/linux/kernel/v5.x/"


### PR DESCRIPTION
Let's make things simpler to figure out which version of Kata
Containers has been deployed, and also which artefacts come with it.

This will help us immensely in the future, for the TEEs use case, so we
can easily know whether we can deploy a specific guest kernel for a
specific host kernel.