### PR TITLE
kata-deploy: Properly get the path of the versions.yaml file

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -14,6 +14,7 @@ kata_build_dir=${1:-build}
 kata_versions_yaml_file=${2:-""}
 
 tar_path="${PWD}/kata-static.tar.xz"
+kata_versions_yaml_file_path="${PWD}/${kata_versions_yaml_file}"
 
 pushd "${kata_build_dir}"
 tarball_content_dir="${PWD}/kata-tarball-content"
@@ -32,7 +33,7 @@ pushd ${tarball_content_dir}
 	prefix=${shim_path%"bin/${shim}"}
 
 	echo "$(git describe)" > ${prefix}/VERSION
-	[[ -n "${kata_versions_yaml_file}" ]] && cp ${kata_versions_yaml_file} ${prefix}/
+	[[ -n "${kata_versions_yaml_file}" ]] && cp ${kata_versions_yaml_file_path} ${prefix}/
 popd
 
 echo "create ${tar_path}"


### PR DESCRIPTION
We need to correctly get the full path of the versions.yaml file as part of the merge-builds.sh script, as we do a `pushd` there and that leads to a fail merging the artefacts as the `versions.yaml` file does not exists in that path.

Fixes: #7405