### PR TITLE
kata-deploy: Allow shim creation based on what's passed to the daemonset

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -28,6 +28,10 @@ spec:
               fieldPath: spec.nodeName
         - name: DEBUG
           value: "no"
+        - name: SHIMS
+          value: "clh dragonball fc qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx qemu"
+        - name: DEFAULT_SHIM
+          value: "qemu"
         securityContext:
           privileged: true
         volumeMounts:

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -30,6 +30,10 @@ spec:
               fieldPath: spec.nodeName
         - name: DEBUG
           value: "no"
+        - name: SHIMS
+          value: "clh dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx"
+        - name: DEFAULT_SHIM
+          value: "qemu"
         securityContext:
           privileged: true
         volumeMounts:

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -14,18 +14,9 @@ crio_drop_in_conf_file_debug="${crio_drop_in_conf_dir}/100-debug"
 containerd_conf_file="/etc/containerd/config.toml"
 containerd_conf_file_backup="${containerd_conf_file}.bak"
 
-shims=(
-	"fc"
-	"qemu"
-	"qemu-nvidia-gpu"
-	"qemu-tdx"
-	"qemu-sev"
-	"qemu-snp"
-	"clh"
-	"dragonball"
-)
+IFS=' ' read -a shims <<< "$SHIMS"
 
-default_shim="qemu"
+default_shim="$DEFAULT_SHIM"
 
 # If we fail for any reason a message will be displayed
 die() {


### PR DESCRIPTION
Instead of hardcoding shims as part of the script, let's ensure we can allow them to be created based on environment variables passed to the daemonset.

This change brings no functionality change as the default values in the daemonset are exactly what has been used as part of the scripts.

Fixes: #7407