### PR TITLE
workflows: fix malformed CC payload s390x yaml

### DIFF
--- a/.github/workflows/cc-payload-s390x.yaml
+++ b/.github/workflows/cc-payload-s390x.yaml
@@ -11,7 +11,8 @@ jobs:
     runs-on: s390x
     strategy:
       matrix:
-        measured_rootfs: no
+        measured_rootfs:
+          - no
         asset:
           - cc-qemu
           - cc-virtiofsd


### PR DESCRIPTION
The measured_boot matrix parameter should be a list.

Fixes ##7400
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>