### PR TITLE
runtime-rs: remove unneeded 'mut' keywords

### DIFF
--- a/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
@@ -96,7 +96,7 @@ impl InitialSizeManager {
     pub fn setup_config(&self, config: &mut TomlConfig) -> Result<()> {
         // update this data to the hypervisor config for later use by hypervisor
         let hypervisor_name = &config.runtime.hypervisor_name;
-        let mut hv = config
+        let hv = config
             .hypervisor
             .get_mut(hypervisor_name)
             .context("failed to get hypervisor config")?;

--- a/src/runtime-rs/crates/resource/src/volume/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/spdk_volume.rs
@@ -73,7 +73,7 @@ impl SPDKVolume {
             }
         }
 
-        let mut vhu_blk_config = &mut VhostUserConfig {
+        let vhu_blk_config = &mut VhostUserConfig {
             socket_path: device,
             device_type: VhostUserType::Blk("vhost-user-blk-pci".to_owned()),
             ..Default::default()

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -95,7 +95,7 @@ impl Container {
         amend_spec(&mut spec, toml_config.runtime.disable_guest_seccomp).context("amend spec")?;
 
         // get mutable root from oci spec
-        let mut root = match spec.root.as_mut() {
+        let root = match spec.root.as_mut() {
             Some(root) => root,
             None => return Err(anyhow!("spec miss root field")),
         };


### PR DESCRIPTION
These unneeded 'mut' keywords blocks built by rust 1.71.0. Remove them.

Fixes: #7424