### PR TITLE
ci: nydus: Fix typo in "source"

### DIFF
--- a/tests/integration/nydus/gha-run.sh
+++ b/tests/integration/nydus/gha-run.sh
@@ -11,7 +11,7 @@ set -o pipefail
 
 kata_tarball_dir="${2:-kata-artifacts}"
 nydus_dir="$(dirname "$(readlink -f "$0")")" 
-source "${cri_containerd_dir}/../../common.bash"
+source "${nydus_dir}/../../common.bash"
 
 function install_dependencies() {
 	info "Installing the dependencies needed for running the nydus tests"


### PR DESCRIPTION
We should source from `nydus_dir`, instead of `cri_containerd_dir`, and that was a leftover from fb4f7a002cf40d073868278eb59ba92a7f9514e0.

Fixes: #6543