### PR TITLE
CC| cc: cache: Enable more cached components back and ensure shim-v2 can be properly cached

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -124,12 +124,6 @@ cleanup_and_fail() {
 }
 
 install_cached_tarball_component() {
-	case ${5} in
-		"kata-static-cc-rootfs-image.tar.xz" | "kata-static-cc-rootfs-initrd.tar.xz" | "kata-static-cc-se-image.tar.xz" | "kata-static-cc-tdx-rootfs-image.tar.xz" | "kata-static-cc-tdx-td-shim.tar.xz" | "kata-static-cc-sev-rootfs-initrd.tar.xz" )
-			USE_CACHE="no"
-			;;
-	esac
-
 	if [ "${USE_CACHE}" != "yes" ]; then
 		return 1
 	fi

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -175,10 +175,6 @@ install_cached_cc_shim_v2() {
 			;;
 	esac
 
-	if [ "${USE_CACHE}" != "yes" ]; then
-		return 1
-	fi
-
 	local component="${1}"
 	local jenkins_build_url="${2}"
 	local current_version="${3}"
@@ -221,6 +217,10 @@ install_cached_cc_shim_v2() {
 
 	wget "${jenkins_build_url}/root_hash_tdx.txt" -O "shim_v2_root_hash_tdx.txt" || return 1
 	diff "${root_hash_tdx}" "shim_v2_root_hash_tdx.txt" > /dev/null || return 1
+
+	if [ "${USE_CACHE}" != "yes" ]; then
+		return 1
+	fi
 
 	install_cached_tarball_component \
 		"${component}" \


### PR DESCRIPTION
We're re-enabling a bunch of other cached targets, mostly related to the rootfs, as those have been re-built using the correct `/opt/kata` prefix.