### PR TITLE
CCv0: Remove `cc` from kernel for IBM SE image build

### DIFF
--- a/tools/packaging/guest-image/build_se_image.sh
+++ b/tools/packaging/guest-image/build_se_image.sh
@@ -41,7 +41,7 @@ build_image() {
 	image_source_dir="${builddir}/secure-image"
 	mkdir -p "${image_source_dir}"
 	pushd "${tarball_dir}"
-	for tarball_id in cc-kernel cc-rootfs-initrd; do
+	for tarball_id in kernel cc-rootfs-initrd; do
 		tar xvf kata-static-${tarball_id}.tar.xz -C "${image_source_dir}"
 	done
 	popd


### PR DESCRIPTION
This is a quick fix for an error on IBM SE image build.

Fixes: #7444 

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>