### PR TITLE
CCv0: fix a prefix to kata for IBM SE image build

### DIFF
--- a/tools/packaging/guest-image/build_se_image.sh
+++ b/tools/packaging/guest-image/build_se_image.sh
@@ -54,7 +54,7 @@ build_image() {
 }
 
 main() {
-	readonly prefix="/opt/confidential-containers"
+	readonly prefix="/opt/kata"
 	builddir="${PWD}"
 	tarball_dir="${builddir}/../.."
 	while getopts "h-:" opt; do


### PR DESCRIPTION
This is to change a prefix from `confidential-containers` to `kata` for IBM SE image build.

Fixes: #7444

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>