### PR TITLE
tests: Fix `k8s-job` test

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -56,6 +56,7 @@ jobs:
           AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
 
       - name: Create AKS cluster
+        timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh create-cluster
 
       - name: Install `bats`

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -175,6 +175,7 @@ function get_nodes_and_pods_info() {
 	echo "::endgroup::"
     fi
     kubectl debug $(kubectl get nodes -o name) -it --image=quay.io/kata-containers/kata-debug:latest
+    kubectl get pods -o name | grep node-debugger | xargs kubectl delete
 }
 
 function main() {


### PR DESCRIPTION
**tests: k8s: Clean up node debuggers after running**

This deletes node debugger pods after execution since their presence may
affect tests that assume only test workloads pods are present.

For example, in `k8s-job` we wait for *any* pod to be in the `Succeeded`
state before proceeding, which causes failures.

Fixes: https://github.com/kata-containers/kata-containers/issues/7452

---

**tests: gha: Add timeout to cluster creation**

This has been intermittently taking a while lately so let's add a
timeout.