### PR TITLE
kata-deploy: Drop privileged security-context

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -32,8 +32,6 @@ spec:
           value: "clh dragonball fc qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx qemu"
         - name: DEFAULT_SHIM
           value: "qemu"
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: dbus
           mountPath: /var/run/dbus/system_bus_socket

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -34,8 +34,6 @@ spec:
           value: "clh dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx"
         - name: DEFAULT_SHIM
           value: "qemu"
-        securityContext:
-          privileged: true
         volumeMounts:
         - name: crio-conf
           mountPath: /etc/crio/


### PR DESCRIPTION
Let's check whether this is really needed.