### PR TITLE
gha: dragonball: Run only on the dragonball labeled machine

### DIFF
--- a/.github/workflows/static-checks-dragonball.yaml
+++ b/.github/workflows/static-checks-dragonball.yaml
@@ -14,7 +14,7 @@ concurrency:
 name: Static checks dragonball
 jobs:
   test-dragonball:
-    runs-on: self-hosted
+    runs-on: dragonball
     env:
       RUST_BACKTRACE: "1"
     steps:


### PR DESCRIPTION
Static checks for dragonball are landing on any of the self-hosted runners, and the reason for that is because "self-hosted" was the label selector used.

Let's use "dragonball" instead, as the machine has that label as well.

Fixes: #7464