### PR TITLE
kata-deploy: Take NFD into consideration

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -86,6 +86,8 @@ function deploy_kata() {
     yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[4].value' --tag '!!str' "true"
     # Let the `kata-deploy` create the default `kata` runtime class
     yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[5].value' --tag '!!str' "true"
+    # Ensure USING_NFD is set according to the GHA env var
+    yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[6].value' --tag '!!str' "${USING_NFD}"
 
     if [ "${KATA_HOST_OS}" = "cbl-mariner" ]; then
         yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[+].name' "HOST_OS"

--- a/tests/integration/kubernetes/kata-deploy-test-usig-nfd.bats
+++ b/tests/integration/kubernetes/kata-deploy-test-usig-nfd.bats
@@ -1,0 +1,99 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	node_name="$(kubectl get node -o name)"
+	pod_name="busybox"
+	nfd_tee_pod_name="nfd-tee-test"
+
+	get_pod_config_dir
+	get_tee
+	get_tee_key_resource
+	get_tee_key_label_jsonpath
+}
+
+@test "USING_NFD: true | Ensure the NodeFeatureRule is properly created" {
+	[[ "${USING_NFD}" == "true" ]] || skip "Test skipped as NFD is not used"
+
+	[[ $(kubectl get nodefeaturerule -o name | grep ${tee}-total-keys) ]]
+}
+
+@test "USING_NFD: false | Ensure the NodeFeatureRule is not created" {
+	[[ "${USING_NFD}" == "false" ]] || skip "Test skipped as NFD is used"
+
+	[[ ! $(kubectl get nodefeaturerule -o name | grep ${tee}-total-keys) ]]
+}
+
+@test "USING_NFD: true | Ensure the runtimeclass is properly created" {
+	[[ "${USING_NFD}" == "true" ]] || skip "Test skipped as NFD is not used"
+
+	kubectl describe runtimeclass kata-"${KATA_HYPERVISOR}"
+	kubectl describe runtimeclass kata-"${KATA_HYPERVISOR}" | grep "${tee_key_resource}"
+
+	[[ $(kubectl describe runtimeclass kata-"${KATA_HYPERVISOR}" | grep "${tee_key_resource}") ]]
+}
+
+@test "USING_NFD: false | Ensure the runtimeclass is properly created" {
+	[[ "${USING_NFD}" == "false" ]] || skip "Test skipped as NFD is not used"
+
+	for t in "${tees_key_resource[@]}"; do
+		# Ensure no tee_key_resource is added to a runtimeclass it does not belong to
+		[[ ! $(kubectl describe runtimeclass kata-"${KATA_HYPERVISOR}" | grep "${t}") ]]
+	done
+}
+
+@test "USING_NFD: true | Validate keys book keeping" {
+	[[ "${USING_NFD}" == "true" ]] || skip "Test skipped as NFD is not used"
+
+	# NOTE: I hate using `tr -s ' ' | grep ...` to get such info, but as `kubectl describe node`
+	# does *NOT* provide a json output, and checking for Allocatable is out of question, for now,
+	# due to https://github.com/kubernetes/kubernetes/issues/115190, this is the best we can do.
+
+	# Create a pod, which should decrease the key capacity for the specific TEE
+	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
+	kubectl wait --for=condition=Ready --timeout=${timeout} pod ${pod_name}
+
+	# Ensure we have 1 key marked as allocated
+	[[ $(kubectl describe ${node_name} | tr -s ' ' | grep "${tee_key_resource} 1 0") ]]
+
+	# Delete a pod, which should increase the keys allocated for the specific TEE
+	kubectl delete -f "${pod_config_dir}/busybox-pod.yaml"
+	[[ $(kubectl describe ${node_name} | tr -s ' ' | grep "${tee_key_resource} 0 0") ]]
+}
+
+@test "USING_NFD: true | Fail if the limit of keys is reached" {
+	[[ "${USING_NFD}" == "true" ]] || skip "Test skipped as NFD is not used"
+
+	# Get the amount of keys provided by the TEE
+	eval keys=$(kubectl get ${node_name} ${tee_key_label_jsonpath})
+	[[ ${keys} -gt 0 ]]
+
+	# Let's make sure we add the ${keys} amount to the limit requested, as when Kubernetes sums it
+	# up with the one key set as part of the podOverhead, it'll exceed the limit of available keys.
+	sed -i -e "s|KEY_RESOURCE: KEYS|${tee_key_resource}: ${keys}|g" "${pod_config_dir}/pod-tee-maximum-keys.yaml"
+	kubectl create -f "${pod_config_dir}/pod-tee-maximum-keys.yaml"
+
+	sleep 20s
+
+	kubectl describe pod ${nfd_tee_pod_name}
+	[[ $(kubectl describe pod ${nfd_tee_pod_name} | grep "Insufficient ${tee_key_resource}") ]]
+}
+
+teardown() {
+	# Debugging information
+	kubectl get runtimeclass || true
+	kubectl describe runtimeclass || true
+	kubectl get nodefeaturerule -A || true
+	kubectl describe nodefeaturerule -A || true
+	kubectl describe "pod/${pod_name}" || true
+	kubectl delete pod "${pod_name}" || true
+	kubectl describe "pod/${nfd_tee_pod_name}" || true
+	kubectl delete pod "${nfd_tee_pod_name}" || true
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -13,12 +13,14 @@ source "${kubernetes_dir}/../../common.bash"
 TARGET_ARCH="${TARGET_ARCH:-x86_64}"
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 K8S_TEST_DEBUG="${K8S_TEST_DEBUG:-false}"
+USING_NFD="${USING_NFD:-"false"}"
 
 if [ -n "${K8S_TEST_UNION:-}" ]; then
 	K8S_TEST_UNION=($K8S_TEST_UNION)
 else
 	K8S_TEST_UNION=( \
 		"kata-deploy-ensure-runtimec-classes-created.bats" \
+		"kata-deploy-test-usig-nfd.bats"
 		"k8s-attach-handlers.bats" \
 		"k8s-caps.bats" \
 		"k8s-configmap.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-tee-maximum-keys.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-tee-maximum-keys.yaml
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: nfd-tee-test
+spec:
+  terminationGracePeriodSeconds: 0
+  shareProcessNamespace: true
+  runtimeClassName: kata
+  containers:
+  - name: first-test-container
+    image: quay.io/prometheus/busybox:latest
+    resources:
+      limits:
+        KEY_RESOURCE: KEYS
+    env:
+    - name: CONTAINER_NAME
+      value: "first-test-container"
+    command:
+        - sleep
+        - "30"
+  - name: second-test-container
+    image: quay.io/prometheus/busybox:latest
+    env:
+    - name: CONTAINER_NAME
+      value: "second-test-container"
+    command:
+        - sleep
+        - "30"
+    stdin: true
+    tty: true

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -38,6 +38,29 @@ get_pod_config_dir() {
 	info "k8s configured to use runtimeclass"
 }
 
+get_tee() {
+	tees[qemu-tdx]="tdx"
+
+	tee=${tees[${KATA_HYPERVISOR}]}
+}
+
+get_tee_key_resource() {
+	tees_key_resource[qemu-tdx]="tdx.intel.io/keys"
+
+	tee_key_resource=${tees_key_resource[${KATA_HYPERVISOR}]}
+}
+
+get_tee_key_label_jsonpath() {
+	# Sadly we need to declare the whole `-o jsonpath={...}`, as I couldn't find a reliable
+	# way to just set the TEE specific capacity string in a way I could pass it as an env
+	# var to the -o jsonpath option.
+	#
+	# We need to escape the dots in order to make jsonpath happy
+	tees_key_label_jsonpath[qemu-tdx]="-o jsonpath='{.status.capacity.tdx\.intel\.io/keys}'"
+
+	tee_key_label_jsonpath=${tees_key_label_jsonpath[${KATA_HYPERVISOR}]}
+}
+
 # Runs a command in the host filesystem.
 exec_host() {
 	node="$(kubectl get node -o name)"

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -29,3 +29,4 @@ rm -f ${WORKDIR}/${KATA_ARTIFACTS}
 
 COPY scripts ${DESTINATION}/scripts
 COPY runtimeclasses ${DESTINATION}/runtimeclasses
+COPY nodefeaturerules ${DESTINATION}/nodefeaturerules

--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -23,20 +23,44 @@ spec:
         imagePullPolicy: Always
         command: [ "bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh reset" ]
         env:
+
+        # The Kubernetes node name
+        # NOTE: Do NOT change this, as this is dynamically read for each one of the nodes in your cluster
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+
+        # Whether to enable debug for the CRI engine / kata-containers or not
+        # value: A string with one of the valid values:
+        #          -  "false" | "true"
         - name: DEBUG
           value: "false"
+
+        # Which shims will be configured for Kata Containers
+        # value: A string containing at least one of the following valid values:
+        #          - "clh" | "dragonball" | "fc" | "qemu-nvidia-gpu" | "qemu-sev" | "qemu-snp" | "qemu-tdx | "qemu"
         - name: SHIMS
           value: "clh dragonball fc qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx qemu"
+
+        # Which is the default shim to be configured to be used as "containerd.shim.kata.v2"
+        # value: A string containing one of the following valid values:
+        #          - "clh" | "dragonball" | "fc" | "qemu" | "qemu-nvidia-gpu" | "qemu-sev" | "qemu-snp" | "qemu-tdx"
         - name: DEFAULT_SHIM
           value: "qemu"
+
+        # Whether to delegate the runtime classes creation to the kata-deploy script
+        # value: A string with one of the valid values:
+        #          -  "false" | "true"
         - name: CREATE_RUNTIMECLASSES
           value: "false"
+
+        # Whether to create the default "kata" runtime class for the DEFAULT_SHIM
+        # value: A string with one of the valid values:
+        #          -  "false" | "true"
         - name: CREATE_DEFAULT_RUNTIMECLASS
           value: "false"
+
         securityContext:
           privileged: true
   updateStrategy:

--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -61,6 +61,18 @@ spec:
         - name: CREATE_DEFAULT_RUNTIMECLASS
           value: "false"
 
+        # Whether the admin is relying on NFD (Node Feature Discovery) to do their node labeling
+        # value: A string with one of the valid values:
+        #          -  "false" | "true"
+        # NOTE: This will only be relevant in case CREATE_RUNTIMECLASSES is set to "true", and it'll perform
+        #       operations like:
+        #          - Creating an extended resource rule for the TEEs related runtime classes, such as
+        #            "qemu-sev", "qemu-snp", "qemu-tdx" -- NOT YET IMPLEMENTED
+        #          - Adjusting the podOverhead to be used together with the extensed resource, so the TEE
+        #            keys book keeping is taken care of
+        - name: USING_NFD
+          value: "false"
+
         securityContext:
           privileged: true
   updateStrategy:

--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -67,7 +67,7 @@ spec:
         # NOTE: This will only be relevant in case CREATE_RUNTIMECLASSES is set to "true", and it'll perform
         #       operations like:
         #          - Creating an extended resource rule for the TEEs related runtime classes, such as
-        #            "qemu-sev", "qemu-snp", "qemu-tdx" -- NOT YET IMPLEMENTED
+        #            "qemu-sev", "qemu-snp", "qemu-tdx" -- ONLY IMPLEMENTED for "qemu-tdx"
         #          - Adjusting the podOverhead to be used together with the extensed resource, so the TEE
         #            keys book keeping is taken care of
         - name: USING_NFD

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -63,6 +63,18 @@ spec:
         - name: CREATE_DEFAULT_RUNTIMECLASS
           value: "false"
 
+        # Whether the admin is relying on NFD (Node Feature Discovery) to do their node labeling
+        # value: A string with one of the valid values:
+        #          -  "false" | "true"
+        # NOTE: This will only be relevant in case CREATE_RUNTIMECLASSES is set to "true", and it'll perform
+        #       operations like:
+        #          - Creating an extended resource rule for the TEEs related runtime classes, such as
+        #            "qemu-sev", "qemu-snp", "qemu-tdx" -- NOT YET IMPLEMENTED
+        #          - Adjusting the podOverhead to be used together with the extensed resource, so the TEE
+        #            keys book keeping is taken care of
+        - name: USING_NFD
+          value: "false"
+
         securityContext:
           privileged: true
         volumeMounts:

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -69,7 +69,7 @@ spec:
         # NOTE: This will only be relevant in case CREATE_RUNTIMECLASSES is set to "true", and it'll perform
         #       operations like:
         #          - Creating an extended resource rule for the TEEs related runtime classes, such as
-        #            "qemu-sev", "qemu-snp", "qemu-tdx" -- NOT YET IMPLEMENTED
+        #            "qemu-sev", "qemu-snp", "qemu-tdx" -- ONLY IMPLEMENTED for "qemu-tdx"
         #          - Adjusting the podOverhead to be used together with the extensed resource, so the TEE
         #            keys book keeping is taken care of
         - name: USING_NFD

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -25,20 +25,44 @@ spec:
               command: ["bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh cleanup"]
         command: [ "bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh install" ]
         env:
+
+        # The Kubernetes node name
+        # NOTE: Do NOT change this, as this is dynamically read for each one of the nodes in your cluster
         - name: NODE_NAME
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+
+        # Whether to enable debug for the CRI engine / kata-containers or not
+        # value: A string with one of the valid values:
+        #          -  "false" | "true"
         - name: DEBUG
           value: "false"
+
+        # Which shims will be configured for Kata Containers
+        # value: A string containing at least one of the following valid values:
+        #          - "clh" | "dragonball" | "fc" | "qemu-nvidia-gpu" | "qemu-sev" | "qemu-snp" | "qemu-tdx | "qemu""
         - name: SHIMS
-          value: "clh dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx"
+          value: "clh dragonball fc qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx qemu"
+
+        # Which is the default shim to be configured to be used as "containerd.shim.kata.v2"
+        # value: A string containing one of the following valid values:
+        #          - "clh" | "dragonball" | "fc" | "qemu" | "qemu-nvidia-gpu" | "qemu-sev" | "qemu-snp" | "qemu-tdx"
         - name: DEFAULT_SHIM
           value: "qemu"
+
+        # Whether to delegate the runtime classes creation to the kata-deploy script
+        # value: A string with one of the valid values:
+        #          -  "false" | "true"
         - name: CREATE_RUNTIMECLASSES
           value: "false"
+
+        # Whether to create the default "kata" runtime class for the DEFAULT_SHIM
+        # value: A string with one of the valid values:
+        #          -  "false" | "true"
         - name: CREATE_DEFAULT_RUNTIMECLASS
           value: "false"
+
         securityContext:
           privileged: true
         volumeMounts:

--- a/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
@@ -13,9 +13,15 @@ rules:
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "patch"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
 - apiGroups: ["node.k8s.io"]
   resources: ["runtimeclasses"]
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["nfd.k8s-sigs.io"]
+  resources: ["nodefeaturerules"]
+  verbs: ["create", "delete", "get", "update"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tools/packaging/kata-deploy/nodefeaturerules/tdx-nfd-rule.yaml
+++ b/tools/packaging/kata-deploy/nodefeaturerules/tdx-nfd-rule.yaml
@@ -1,0 +1,15 @@
+apiVersion: nfd.k8s-sigs.io/v1alpha1
+kind: NodeFeatureRule
+metadata:
+  name: tdx-total-keys
+spec:
+  rules:
+  - name: "TDX total keys rule"
+    labels:
+      "intel.feature.node.kubernetes.io/tdx": "true"
+    extendedResources:
+      tdx.intel.io/keys: "@cpu.security.tdx.total_keys"
+    matchFeatures:
+      - feature: cpu.security
+        matchExpressions:
+          tdx.enabled: {op: Exists}

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-tdx.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-tdx.yaml
@@ -8,6 +8,7 @@ overhead:
     podFixed:
         memory: "2048Mi"
         cpu: "1.0"
+        #tdx.intel.io/keys: "1"
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -86,6 +86,7 @@ overhead:
     podFixed:
         memory: "2048Mi"
         cpu: "1.0"
+        #tdx.intel.io/keys: "1"
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -392,6 +392,7 @@ function main() {
 	echo "* DEFAULT_SHIM: ${DEFAULT_SHIM}"
 	echo "* CREATE_RUNTIMECLASSES: ${CREATE_RUNTIMECLASSES}"
 	echo "* CREATE_DEFAULT_RUNTIMECLASS: ${CREATE_DEFAULT_RUNTIMECLASS}"
+	echo "* USING_NFD: ${USING_NFD}"
 
 	# script requires that user is root
 	euid=$(id -u)


### PR DESCRIPTION
kata-deploy: Start relying on NFD

In case `USING_NFD` is set to "true", let's assume NodeFeatureDiscovery
is present, and do the following:
* Create a NodeFeatureRule for the supported TEEs (for now, only Intel
  TDX), which will give us information about the amount of keys
  available for the TEE
* Extend the TEE specific runtime-class(es) to inform that one key is
  being used each time a Kata Containers VM is launch, so the book
  keeping of the TEE keys is automagically done