### PR TITLE
CC | kata-deploy: Add the runtime-classes that are not yet on main

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -24,6 +24,13 @@ shims=(
 	"dragonball"
 )
 
+# THOSE ARE NOT YET ON MAIN, PLEASE, MOVE THEM TO THE UPPDER LIST WHENEVER THEY MAKE THEIR WAY IN.
+shims+=(
+	"remote"
+	"qemu-se"
+	"clh-tdx"
+)
+
 default_shim="qemu"
 
 # If we fail for any reason a message will be displayed


### PR DESCRIPTION
This is another piece that got dropped as part of
6f552b010c51eb9e6dbcbb21cfa122f5c8d6ad36 and is causing regressions on the operator tests.

Fixes: #7422

This doesn't require the tests to run, as this script is only tested as part of the Operator CI.