### PR TITLE
CC | kata-deploy: Use different shim arrays for different arches

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -13,7 +13,7 @@ crio_drop_in_conf_file="${crio_drop_in_conf_dir}/99-kata-deploy"
 containerd_conf_file="/etc/containerd/config.toml"
 containerd_conf_file_backup="${containerd_conf_file}.bak"
 
-shims=(
+shims_x86_64=(
 	"fc"
 	"qemu"
 	"qemu-nvidia-gpu"
@@ -25,11 +25,30 @@ shims=(
 )
 
 # THOSE ARE NOT YET ON MAIN, PLEASE, MOVE THEM TO THE UPPDER LIST WHENEVER THEY MAKE THEIR WAY IN.
-shims+=(
+shims_x86_64+=(
 	"remote"
-	"qemu-se"
 	"clh-tdx"
 )
+
+shims_s390x=(
+	"qemu"
+)
+
+
+# THOSE ARE NOT YET ON MAIN, PLEASE, MOVE THEM TO THE UPPDER LIST WHENEVER THEY MAKE THEIR WAY IN.
+shims_s390x+=(
+	"remote"
+	"qemu-se"
+)
+
+arch=$(uname -m)
+if [[ "${arch}" == "x86_64" ]]; then
+	shims=${shims_x86_64[@]}
+else if [[ "${arch}" == "s390x" ]]; then
+	shims=${shims_s390x[@]}
+else
+	die "${arch} is a not supported architecture"
+fi
 
 default_shim="qemu"
 


### PR DESCRIPTION
On main we will not have this problem as we can easily configure which
shims will be installed according to an environment variable passed to
the kata-deploy.yaml file.

However, on CCV0, at least for now, we better keep the list of shims
separated by architecture, as we've found out that s390x CoCo Operator
CI is breaking because we try to install a shim that's not even built
for that architecture (dragonball).