### PR TITLE
kata-deploy: Fix if-elif-else-statement

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -44,7 +44,7 @@ shims_s390x+=(
 arch=$(uname -m)
 if [[ "${arch}" == "x86_64" ]]; then
 	shims=${shims_x86_64[@]}
-else if [[ "${arch}" == "s390x" ]]; then
+elif [[ "${arch}" == "s390x" ]]; then
 	shims=${shims_s390x[@]}
 else
 	die "${arch} is a not supported architecture"


### PR DESCRIPTION
We were doing "if - else  if - else", while bash expects "if - elif - else", and that should never have happened in the first place, but it happend as part of b8b73939ea98086e1359f5cb4d5a71d940e960dc

Fixes: #7422

Again, no tests are needed to run as it will only be tested on the operator side.