### PR TITLE
kata-deploy: We need shim to an array, not a string

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -43,9 +43,9 @@ shims_s390x+=(
 
 arch=$(uname -m)
 if [[ "${arch}" == "x86_64" ]]; then
-	shims=${shims_x86_64[@]}
+	shims=(${shims_x86_64[@]})
 elif [[ "${arch}" == "s390x" ]]; then
-	shims=${shims_s390x[@]}
+	shims=(${shims_s390x[@]})
 else
 	die "${arch} is a not supported architecture"
 fi


### PR DESCRIPTION
In order to do so, we need the `()` around the `shim_{arch}`.

Fixes: #7422