### PR TITLE
kata-deploy: Ensure we cover SHIMS / DEFAULT_SHIM as part of our tests

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -72,8 +72,14 @@ function deploy_kata() {
 
     # Enable debug for Kata Containers
     yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[1].value' --tag '!!str' "true"
+    # Create the runtime class only for the shim that's being tested
+    yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[2].value' "${KATA_HYPERVISOR}"
+    # Set the tested hypervisor as the default `kata` shim
+    yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[3].value' "${KATA_HYPERVISOR}"
     # Let the `kata-deploy` script take care of the runtime class creation / removal
     yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[4].value' --tag '!!str' "true"
+    # Let the `kata-deploy` create the default `kata` runtime class
+    yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[5].value' --tag '!!str' "true"
 
     if [ "${KATA_HOST_OS}" = "cbl-mariner" ]; then
         yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[+].name' "HOST_OS"
@@ -154,6 +160,12 @@ function cleanup() {
 
     # Let the `kata-deploy` script take care of the runtime class creation / removal
     yq write -i "${tools_dir}/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml" 'spec.template.spec.containers[0].env[4].value' --tag '!!str' "true"
+    # Create the runtime class only for the shim that's being tested
+    yq write -i "${tools_dir}/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml" 'spec.template.spec.containers[0].env[2].value' "${KATA_HYPERVISOR}"
+    # Set the tested hypervisor as the default `kata` shim
+    yq write -i "${tools_dir}/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml" 'spec.template.spec.containers[0].env[3].value' "${KATA_HYPERVISOR}"
+    # Let the `kata-deploy` create the default `kata` runtime class
+    yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[5].value' --tag '!!str' "true"
 
     sed -i -e "s|quay.io/kata-containers/kata-deploy:latest|${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}|g" "${tools_dir}/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml"
     cat "${tools_dir}/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml"

--- a/tests/integration/kubernetes/kata-deploy-ensure-runtimec-classes-created.bats
+++ b/tests/integration/kubernetes/kata-deploy-ensure-runtimec-classes-created.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	# We expect 2 runtime classes because:
+	# * `kata` is the default runtimeclass created, basically an alias for `kata-${KATA_HYPERVISOR}`.
+	# * `kata-${KATA_HYPERVISOR}` is the other one
+	#    * As part of the tests we're only deploying the specific runtimeclass that will be used, instead of all of them.
+	expected_runtime_classes=2
+}
+
+@test "Test runtimeclasses are being properly created" {
+	# We filter `kata-mshv-vm-isolation` out as that's present on AKS clusters, but that's not coming from kata-deploy
+	current_runtime_classes=$(kubectl get runtimeclasses | grep -v "kata-mshv-vm-isolation" | grep "kata" | wc -l)
+	[[ ${current_runtime_classes} -eq ${expected_runtime_classes} ]]
+	[[ $(kubectl get runtimeclasses | grep -q "${KATA_HYPERVISOR}") -eq 0 ]]
+}
+
+teardown() {
+	kubectl get runtimeclasses
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -18,6 +18,7 @@ if [ -n "${K8S_TEST_UNION:-}" ]; then
 	K8S_TEST_UNION=($K8S_TEST_UNION)
 else
 	K8S_TEST_UNION=( \
+		"kata-deploy-ensure-runtimec-classes-created.bats" \
 		"k8s-attach-handlers.bats" \
 		"k8s-caps.bats" \
 		"k8s-configmap.bats" \

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -15,10 +15,6 @@ reset_workloads_work_dir() {
     cp -R ${kubernetes_dir}/runtimeclass_workloads ${kubernetes_dir}/runtimeclass_workloads_work
 }
 
-set_runtime_class() {
-    sed -i -e "s|runtimeClassName: kata|runtimeClassName: kata-${KATA_HYPERVISOR}|" ${kubernetes_dir}/runtimeclass_workloads_work/*.yaml
-}
-
 set_kernel_path() {
     if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
         mariner_kernel_path="/usr/share/cloud-hypervisor/vmlinux.bin"
@@ -35,7 +31,6 @@ set_initrd_path() {
 
 main() {
     reset_workloads_work_dir
-    set_runtime_class
     set_kernel_path
     set_initrd_path
 }


### PR DESCRIPTION
---

k8s: tests: Take advantage of `SHIMS` and `DEFAULT_SHIM` env vars

We don't have to do any sed to replace the runtimeclass being used by
the moment we start taking advantage of the `DEFAULT_SHIM` environment
variable exposed merged in the previous commits.

---

tests: k8s: Ensure the runtime classes are properly created

With these 2 simple checks we can ensure that we do not regress on the
behaviour of allowing the runtime classes / default runtime class to be
created by the kata-deploy payload.

---