### PR TITLE
k8s: Rely on the USING_NFD environment variable passed by the jobs

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -40,6 +40,7 @@ jobs:
       GH_PR_NUMBER: ${{ inputs.pr-number }}
       KATA_HOST_OS: ${{ matrix.host_os }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
+      USING_NFD: "false"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/run-k8s-tests-on-sev.yaml
+++ b/.github/workflows/run-k8s-tests-on-sev.yaml
@@ -29,6 +29,7 @@ jobs:
       DOCKER_TAG: ${{ inputs.tag }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
       KUBECONFIG: /home/kata/.kube/config
+      USING_NFD: "false"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/run-k8s-tests-on-snp.yaml
+++ b/.github/workflows/run-k8s-tests-on-snp.yaml
@@ -29,6 +29,7 @@ jobs:
       DOCKER_TAG: ${{ inputs.tag }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
       KUBECONFIG: /home/kata/.kube/config
+      USING_NFD: "false"
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/run-k8s-tests-on-tdx.yaml
+++ b/.github/workflows/run-k8s-tests-on-tdx.yaml
@@ -28,6 +28,7 @@ jobs:
       DOCKER_REPO: ${{ inputs.repo }}
       DOCKER_TAG: ${{ inputs.tag }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
+      USING_NFD: "true"
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Let's make sure we can rely on the tests passing down whether they want to be tested using Node Feataure Discovery or not.

Right now, only the TDX job has this option set to "true", all the other jobs have this option set to "false".

We can and have to merge this one before merging the NFD related patches as:
1) It causes no harm in exporting this environment variable, but not
   having it used
2) It will allow us to test the NFD after this one is merged, as changes
   in the yaml file, in the case of the pull_request_target event,  are
   not taken into consideration before they're merged

Fixes: #7495