### PR TITLE
gha: release: `stage` must be a string

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -51,7 +51,7 @@ jobs:
           - ${{ inputs.stage }}
         exclude:
           - asset: cloud-hypervisor-glibc
-            stage: release
+            stage: "release"
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -10,7 +10,7 @@ jobs:
   build-kata-static-tarball-amd64:
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
-      stage: release
+      stage: "release"
 
   kata-deploy:
     needs: build-kata-static-tarball-amd64

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -10,7 +10,7 @@ jobs:
   build-kata-static-tarball-arm64:
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
-      stage: release
+      stage: "release"
 
   kata-deploy:
     needs: build-kata-static-tarball-arm64

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -10,7 +10,7 @@ jobs:
   build-kata-static-tarball-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
-      stage: release
+      stage: "release"
 
   kata-deploy:
     needs: build-kata-static-tarball-s390x


### PR DESCRIPTION
Otherwise we'll face the following error as part of our GHA:
```
The workflow is not valid.
kata-containers/kata-containers/.github/workflows/release-$foo.yaml
(Line: 13, Col: 14): Invalid input, stage is not defined in the
referenced workflow.
```

Fixes: #7497

NOTE: I'm adding the `force-skip-ci` label as the changes here are only touching the yaml file used for the release, and it can only be tested after being merged.  Running the tests here would be a waste of resource, and they would **NOT** test anything related to this PR.