### PR TITLE
gha: release: `stage` must be defined for arm64 / s390x yamls

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -51,7 +51,7 @@ jobs:
           - ${{ inputs.stage }}
         exclude:
           - asset: cloud-hypervisor-glibc
-            stage: "release"
+            stage: release
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -2,6 +2,10 @@ name: CI | Build kata-static tarball for arm64
 on:
   workflow_call:
     inputs:
+      stage:
+        required: false
+        type: string
+        default: test
       tarball-suffix:
         required: false
         type: string
@@ -29,6 +33,8 @@ jobs:
           - rootfs-initrd
           - shim-v2
           - virtiofsd
+        stage:
+          - ${{ inputs.stage }}
     steps:
       - name: Adjust a permission for repo
         run: |

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -2,6 +2,10 @@ name: CI | Build kata-static tarball for s390x
 on:
   workflow_call:
     inputs:
+      stage:
+        required: false
+        type: string
+        default: test
       tarball-suffix:
         required: false
         type: string
@@ -25,6 +29,8 @@ jobs:
           - rootfs-initrd
           - shim-v2
           - virtiofsd
+        stage:
+          - ${{ inputs.stage }}
     steps:
       - name: Adjust a permission for repo
         run: |

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -10,7 +10,7 @@ jobs:
   build-kata-static-tarball-amd64:
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
-      stage: "release"
+      stage: release
 
   kata-deploy:
     needs: build-kata-static-tarball-amd64

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -10,7 +10,7 @@ jobs:
   build-kata-static-tarball-arm64:
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
-      stage: "release"
+      stage: release
 
   kata-deploy:
     needs: build-kata-static-tarball-arm64

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -10,7 +10,7 @@ jobs:
   build-kata-static-tarball-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
-      stage: "release"
+      stage: release
 
   kata-deploy:
     needs: build-kata-static-tarball-s390x


### PR DESCRIPTION
`stage`  has been added, but only hooked up to the amd64 logic, leaving
arm64 and s390x behind.

Let's fix this right now, and make sure no error occurs when passing
this down to the yaml files.

Fixes: #7497
