### PR TITLE
dragonball: vcpu metrics change to be recorded per vcpu

### DIFF
--- a/src/dragonball/src/hypervisor_metrics.rs
+++ b/src/dragonball/src/hypervisor_metrics.rs
@@ -90,13 +90,15 @@ fn set_intgauge_vec_vcpu(icv: &prometheus::IntGaugeVec) {
 }
 
 fn set_intgauge_vec_seccomp(icv: &prometheus::IntGaugeVec) {
+    let metric_gurad = METRICS.read().unwrap();
     icv.with_label_values(&["num_faults"])
-        .set(METRICS.seccomp.num_faults.count() as i64);
+        .set(metric_gurad.seccomp.num_faults.count() as i64);
 }
 
 fn set_intgauge_vec_signals(icv: &prometheus::IntGaugeVec) {
+    let metric_gurad = METRICS.read().unwrap();
     icv.with_label_values(&["sigbus"])
-        .set(METRICS.signals.sigbus.count() as i64);
+        .set(metric_gurad.signals.sigbus.count() as i64);
     icv.with_label_values(&["sigsegv"])
-        .set(METRICS.signals.sigsegv.count() as i64);
+        .set(metric_gurad.signals.sigsegv.count() as i64);
 }

--- a/src/dragonball/src/metric.rs
+++ b/src/dragonball/src/metric.rs
@@ -2,14 +2,19 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use dbs_utils::metric::{IncMetric, SharedIncMetric};
+use dbs_utils::metric::SharedIncMetric;
 use lazy_static::lazy_static;
 use serde::Serialize;
 
 lazy_static! {
-    /// Static instance used for handling metrics.
+    /// # Static instance used for handling metrics.
+    ///
+    /// Using a big lock over the DragonballMetrics since we have various device metric types
+    /// and the write operation is only used when creating or removing devices, it has a low
+    /// competitive overhead.
     pub static ref METRICS: RwLock<DragonballMetrics> = RwLock::new(DragonballMetrics::default());
 }
 
@@ -50,9 +55,121 @@ pub struct SignalMetrics {
 #[derive(Default, Serialize)]
 pub struct DragonballMetrics {
     /// Metrics related to a vcpu's functioning.
-    pub vcpu: VcpuMetrics,
+    pub vcpu: HashMap<u32, Arc<VcpuMetrics>>,
     /// Metrics related to seccomp filtering.
     pub seccomp: SeccompMetrics,
     /// Metrics related to signals.
     pub signals: SignalMetrics,
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::thread;
+
+    use dbs_utils::metric::IncMetric;
+
+    use crate::metric::{VcpuMetrics, METRICS};
+
+    #[test]
+    fn test_read_map() {
+        let metrics = Arc::new(VcpuMetrics::default());
+        let vcpu_id: u32 = u32::MIN;
+        METRICS
+            .write()
+            .unwrap()
+            .vcpu
+            .insert(vcpu_id, metrics.clone());
+        metrics.failures.inc();
+        assert_eq!(
+            METRICS
+                .read()
+                .unwrap()
+                .vcpu
+                .get(&vcpu_id)
+                .unwrap()
+                .failures
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn test_metrics_count() {
+        let metrics = Arc::new(VcpuMetrics::default());
+        let vcpu_id: u32 = 65535;
+        METRICS
+            .write()
+            .unwrap()
+            .vcpu
+            .insert(vcpu_id, metrics.clone());
+
+        let metrics1 = metrics.clone();
+        let thread1 = thread::spawn(move || {
+            for _i in 0..10 {
+                metrics1.exit_io_in.inc();
+            }
+        });
+
+        let metrics2 = metrics.clone();
+        let thread2 = thread::spawn(move || {
+            for _i in 0..10 {
+                metrics2.exit_io_in.inc();
+            }
+        });
+        thread1.join().unwrap();
+        thread2.join().unwrap();
+        assert_eq!(
+            METRICS
+                .read()
+                .unwrap()
+                .vcpu
+                .get(&vcpu_id)
+                .unwrap()
+                .exit_io_in
+                .count(),
+            20
+        );
+    }
+
+    #[test]
+    fn test_rw_lock() {
+        let metrics = Arc::new(VcpuMetrics::default());
+        let vcpu_id: u32 = u32::MAX;
+        METRICS
+            .write()
+            .unwrap()
+            .vcpu
+            .insert(vcpu_id, metrics.clone());
+
+        let write_thread = thread::spawn(move || {
+            for _ in 0..10 {
+                let metrics = Arc::new(VcpuMetrics::default());
+                let vcpu_id: u32 = 128;
+                METRICS
+                    .write()
+                    .unwrap()
+                    .vcpu
+                    .insert(vcpu_id, metrics.clone());
+            }
+        });
+
+        let read_thread = thread::spawn(move || {
+            for _ in 0..10 {
+                assert_eq!(
+                    METRICS
+                        .read()
+                        .unwrap()
+                        .vcpu
+                        .get(&vcpu_id)
+                        .unwrap()
+                        .failures
+                        .count(),
+                    0
+                );
+            }
+        });
+        write_thread.join().unwrap();
+        read_thread.join().unwrap();
+    }
 }

--- a/src/dragonball/src/metric.rs
+++ b/src/dragonball/src/metric.rs
@@ -2,15 +2,15 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dbs_utils::metric::SharedIncMetric;
+use std::sync::{Arc, RwLock};
+
+use dbs_utils::metric::{IncMetric, SharedIncMetric};
 use lazy_static::lazy_static;
 use serde::Serialize;
 
-pub use dbs_utils::metric::IncMetric;
-
 lazy_static! {
     /// Static instance used for handling metrics.
-    pub static ref METRICS: DragonballMetrics = DragonballMetrics::default();
+    pub static ref METRICS: RwLock<DragonballMetrics> = RwLock::new(DragonballMetrics::default());
 }
 
 /// Metrics specific to VCPUs' mode of functioning.

--- a/src/dragonball/src/signal_handler.rs
+++ b/src/dragonball/src/signal_handler.rs
@@ -1,11 +1,12 @@
 // Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use dbs_utils::metric::IncMetric;
 use libc::{_exit, c_int, c_void, siginfo_t, SIGBUS, SIGSEGV, SIGSYS};
 use log::error;
 use vmm_sys_util::signal::register_signal_handler;
 
-use crate::metric::{IncMetric, METRICS};
+use crate::metric::METRICS;
 
 // The offset of `si_syscall` (offending syscall identifier) within the siginfo structure
 // expressed as an `(u)int*`.
@@ -51,7 +52,7 @@ extern "C" fn sigsys_handler(num: c_int, info: *mut siginfo_t, _unused: *mut c_v
     let syscall = unsafe { *(info as *const i32).offset(SI_OFF_SYSCALL) as usize };
     // SIGSYS is triggered when bad syscalls are detected. num_faults is only added when SIGSYS is detected
     // so it actually only collects the count for bad syscalls.
-    METRICS.seccomp.num_faults.inc();
+    METRICS.read().unwrap().seccomp.num_faults.inc();
     error!(
         "Shutting down VM after intercepting a bad syscall ({}).",
         syscall
@@ -82,8 +83,8 @@ extern "C" fn sigbus_sigsegv_handler(num: c_int, info: *mut siginfo_t, _unused: 
     // Other signals which might do async unsafe things incompatible with the rest of this
     // function are blocked due to the sa_mask used when registering the signal handler.
     match si_signo {
-        SIGBUS => METRICS.signals.sigbus.inc(),
-        SIGSEGV => METRICS.signals.sigsegv.inc(),
+        SIGBUS => METRICS.read().unwrap().signals.sigbus.inc(),
+        SIGSEGV => METRICS.read().unwrap().signals.sigsegv.inc(),
         _ => (),
     }
 
@@ -182,19 +183,19 @@ mod tests {
             .unwrap();
 
             assert!(apply_filter(&TryInto::<BpfProgram>::try_into(filter).unwrap()).is_ok());
-            assert_eq!(METRICS.seccomp.num_faults.count(), 0);
+            assert_eq!(METRICS.read().unwrap().seccomp.num_faults.count(), 0);
 
             // Call the blacklisted `SYS_mkdirat`.
             unsafe { syscall(libc::SYS_mkdirat, "/foo/bar\0") };
 
             // Call SIGBUS signal handler.
-            assert_eq!(METRICS.signals.sigbus.count(), 0);
+            assert_eq!(METRICS.read().unwrap().signals.sigbus.count(), 0);
             unsafe {
                 syscall(libc::SYS_kill, process::id(), SIGBUS);
             }
 
             // Call SIGSEGV signal handler.
-            assert_eq!(METRICS.signals.sigsegv.count(), 0);
+            assert_eq!(METRICS.read().unwrap().signals.sigsegv.count(), 0);
             unsafe {
                 syscall(libc::SYS_kill, process::id(), SIGSEGV);
             }
@@ -211,9 +212,9 @@ mod tests {
         // tests, so we use this as an heuristic to decide if we check the assertion.
         if cpu_count() > 1 {
             // The signal handler should let the program continue during unit tests.
-            assert!(METRICS.seccomp.num_faults.count() >= 1);
+            assert!(METRICS.read().unwrap().seccomp.num_faults.count() >= 1);
         }
-        assert!(METRICS.signals.sigbus.count() >= 1);
-        assert!(METRICS.signals.sigsegv.count() >= 1);
+        assert!(METRICS.read().unwrap().signals.sigbus.count() >= 1);
+        assert!(METRICS.read().unwrap().signals.sigsegv.count() >= 1);
     }
 }

--- a/src/dragonball/src/vcpu/aarch64.rs
+++ b/src/dragonball/src/vcpu/aarch64.rs
@@ -10,7 +10,6 @@ use std::ops::Deref;
 use std::sync::mpsc::{channel, Sender};
 use std::sync::Arc;
 
-use crate::IoManagerCached;
 use dbs_arch::{regs, VpmuFeatureLevel};
 use dbs_boot::get_fdt_addr;
 use dbs_utils::time::TimestampUs;
@@ -19,8 +18,10 @@ use vm_memory::{Address, GuestAddress, GuestAddressSpace};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::address_space_manager::GuestAddressSpaceImpl;
+use crate::metric::VcpuMetrics;
 use crate::vcpu::vcpu_impl::{Result, Vcpu, VcpuError, VcpuStateEvent};
 use crate::vcpu::VcpuConfig;
+use crate::IoManagerCached;
 
 #[allow(unused)]
 impl Vcpu {
@@ -67,6 +68,7 @@ impl Vcpu {
             support_immediate_exit,
             mpidr: 0,
             exit_evt,
+            metrics: Arc::new(VcpuMetrics::default()),
         })
     }
 

--- a/src/dragonball/src/vcpu/vcpu_manager.rs
+++ b/src/dragonball/src/vcpu/vcpu_manager.rs
@@ -29,6 +29,7 @@ use vmm_sys_util::eventfd::EventFd;
 use crate::address_space_manager::GuestAddressSpaceImpl;
 use crate::api::v1::InstanceInfo;
 use crate::kvm_context::KvmContext;
+use crate::metric::METRICS;
 use crate::vcpu::vcpu_impl::{
     Vcpu, VcpuError, VcpuEvent, VcpuHandle, VcpuResizeResult, VcpuResponse, VcpuStateEvent,
 };
@@ -555,6 +556,11 @@ impl VcpuManager {
         };
 
         let mut vcpu = self.create_vcpu_arch(cpu_index, kvm_vcpu, request_ts)?;
+        METRICS
+            .write()
+            .unwrap()
+            .vcpu
+            .insert(cpu_index as u32, vcpu.metrics());
         self.configure_single_vcpu(entry_addr, &mut vcpu)
             .map_err(VcpuManagerError::Vcpu)?;
         self.vcpu_infos[cpu_index as usize].vcpu = Some(vcpu);


### PR DESCRIPTION
In this PR, the vcpu metrics in Dragonball will be changed to record per-vcpu.

Fixes: #7248

Signed-off-by: lisongqian <mail@lisongqian.cn>