### PR TITLE
release: release-note.sh: Fix typos and reference to images

### DIFF
--- a/tools/packaging/release/release-notes.sh
+++ b/tools/packaging/release/release-notes.sh
@@ -141,18 +141,18 @@ build reproducibility we publish those container images, and when those are used
 of the projects listed as part of the "versions.yaml" file, users can get as close to the environment we
 used to build the release artefacts.
 * Kernel (on all its different flavours): $(get_kernel_image_name)
-* OVMF (on all its diferent flavours): $(get_ovmf_image_name)
+* OVMF (on all its different flavours): $(get_ovmf_image_name)
 * QEMU (on all its different flavurs): $(get_qemu_image_name)
 * shim-v2: $(get_shim_v2_image_name)
 * virtiofsd: $(get_virtiofsd_image_name)
 
 The users who want to rebuild the tarballs using exactly the same images can simply use the following environment
 variables:
-* `KERNEL_CONTAINER_BUILDER`
-* `OVMF_CONTAINER_BUILDER`
-* `QEMU_CONTAINER_BUILDER`
-* `SHIM_V2_CONTAINER_BUILDER`
-* `VIRTIOFSD_CONTAINER_BUILDER`
+* \`KERNEL_CONTAINER_BUILDER\`
+* \`OVMF_CONTAINER_BUILDER\`
+* \`QEMU_CONTAINER_BUILDER\`
+* \`SHIM_V2_CONTAINER_BUILDER\`
+* \`VIRTIOFSD_CONTAINER_BUILDER\`
 
 ## Kata Linux Containers Kernel
 Kata Containers ${runtime_version} suggest to use the Linux kernel [${kernel_version}][kernel]


### PR DESCRIPTION
diferent -> different

And also let's make sure we escape the backticks around the kata-deploy
environment variables, otherwise bash will try to interpret those.

Fixes: #7497