### PR TITLE
ci-on-push: Make the CI also run for the stable-* branches

### DIFF
--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -3,6 +3,7 @@ on:
   pull_request_target:
     branches:
       - 'main'
+      - 'stable-*'
     types:
       # Adding 'labeled' to the list of activity types that trigger this event
       # (default: opened, synchronize, reopened) so that we can run this


### PR DESCRIPTION
As we only support one stable branch, it'll be used as part of the stable-3.2 and onwards.

Fixes: #7518