### PR TITLE
kata-deploy: Use host's systemctl

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -14,6 +14,7 @@ spec:
           name: kubelet-kata-cleanup
     spec:
       serviceAccountName: kata-deploy-sa
+      hostPID: true
       nodeSelector:
           katacontainers.io/kata-runtime: cleanup
       containers:
@@ -38,18 +39,6 @@ spec:
           value: "false"
         securityContext:
           privileged: true
-        volumeMounts:
-        - name: dbus
-          mountPath: /var/run/dbus/system_bus_socket
-        - name: systemd
-          mountPath: /run/systemd/system
-      volumes:
-        - name: dbus
-          hostPath:
-            path: /var/run/dbus/system_bus_socket
-        - name: systemd
-          hostPath:
-            path: /run/systemd/system
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -14,6 +14,7 @@ spec:
           name: kata-deploy
     spec:
       serviceAccountName: kata-deploy-sa
+      hostPID: true
       containers:
       - name: kube-kata
         image: quay.io/kata-containers/kata-deploy:latest
@@ -47,10 +48,6 @@ spec:
           mountPath: /etc/containerd/
         - name: kata-artifacts
           mountPath: /opt/kata/
-        - name: dbus
-          mountPath: /var/run/dbus/system_bus_socket
-        - name: systemd
-          mountPath: /run/systemd/system
         - name: local-bin
           mountPath: /usr/local/bin/
       volumes:
@@ -64,12 +61,6 @@ spec:
           hostPath:
             path: /opt/kata/
             type: DirectoryOrCreate
-        - name: dbus
-          hostPath:
-            path: /var/run/dbus/system_bus_socket
-        - name: systemd
-          hostPath:
-            path: /run/systemd/system
         - name: local-bin
           hostPath:
             path: /usr/local/bin/


### PR DESCRIPTION
when interacting with systemd. We have occasionally faced issues with compatibility between the systemctl version used inside the kata-deploy container and the systemd version on the host. Instead of using a containerized systemctl with bind mounted sockets, nsenter the host and run systemctl from there. This provides less coupling between the kata-deploy container and the host.

Fixes: #7511