### PR TITLE
agent: Remove unneeded 'async' keyword

### DIFF
--- a/src/agent/src/namespace.rs
+++ b/src/agent/src/namespace.rs
@@ -79,7 +79,7 @@ impl Namespace {
     // Note, pid namespaces cannot be persisted.
     #[instrument]
     #[allow(clippy::question_mark)]
-    pub async fn setup(mut self) -> Result<Self> {
+    pub fn setup(mut self) -> Result<Self> {
         fs::create_dir_all(&self.persistent_ns_dir)?;
 
         let ns_path = PathBuf::from(&self.persistent_ns_dir);
@@ -185,8 +185,8 @@ mod tests {
     use tempfile::Builder;
     use test_utils::skip_if_not_root;
 
-    #[tokio::test]
-    async fn test_setup_persistent_ns() {
+    #[test]
+    fn test_setup_persistent_ns() {
         skip_if_not_root!();
         // Create dummy logger and temp folder.
         let logger = slog::Logger::root(slog::Discard, o!());
@@ -195,8 +195,7 @@ mod tests {
         let ns_ipc = Namespace::new(&logger)
             .get_ipc()
             .set_root_dir(tmpdir.path().to_str().unwrap())
-            .setup()
-            .await;
+            .setup();
 
         assert!(ns_ipc.is_ok());
         assert!(remove_mounts(&[ns_ipc.unwrap().path]).is_ok());
@@ -207,8 +206,7 @@ mod tests {
         let ns_uts = Namespace::new(&logger)
             .get_uts("test_hostname")
             .set_root_dir(tmpdir.path().to_str().unwrap())
-            .setup()
-            .await;
+            .setup();
 
         assert!(ns_uts.is_ok());
         assert!(remove_mounts(&[ns_uts.unwrap().path]).is_ok());
@@ -220,8 +218,7 @@ mod tests {
         let ns_pid = Namespace::new(&logger)
             .get_pid()
             .set_root_dir(tmpdir.path().to_str().unwrap())
-            .setup()
-            .await;
+            .setup();
 
         assert!(ns_pid.is_err());
     }

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1188,7 +1188,7 @@ impl agent_ttrpc::AgentService for AgentService {
                 load_kernel_module(m).map_ttrpc_err(same)?;
             }
 
-            s.setup_shared_namespaces().await.map_ttrpc_err(same)?;
+            s.setup_shared_namespaces().map_ttrpc_err(same)?;
         }
 
         let m = add_storages(sl(), req.storages, &self.sandbox, None)

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -204,19 +204,17 @@ impl Sandbox {
     }
 
     #[instrument]
-    pub async fn setup_shared_namespaces(&mut self) -> Result<bool> {
+    pub fn setup_shared_namespaces(&mut self) -> Result<bool> {
         // Set up shared IPC namespace
         self.shared_ipcns = Namespace::new(&self.logger)
             .get_ipc()
             .setup()
-            .await
             .context("setup persistent IPC namespace")?;
 
         // // Set up shared UTS namespace
         self.shared_utsns = Namespace::new(&self.logger)
             .get_uts(self.hostname.as_str())
             .setup()
-            .await
             .context("setup persistent UTS namespace")?;
 
         Ok(true)


### PR DESCRIPTION
Remove unneeded the 'async' keyword of `Namespace::setup()` because it uses just a normal thread, not an asynchronous one. The `setup` function haven't used the tokio async thread since the https://github.com/kata-containers/kata-containers/commit/ea1a173854af892e92af95790b5726d64d04edf0 was introduced, so the `async` keyword is no longer needed.

Fixes: #7532