### PR TITLE
agent: Allow clippy::redundant_clone in the unit tests

### DIFF
--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -1467,6 +1467,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::redundant_clone)]
     async fn test_virtio_blk_matcher() {
         let root_bus = create_pci_root_bus_path();
         let devname = "vda";
@@ -1551,6 +1552,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::redundant_clone)]
     async fn test_scsi_block_matcher() {
         let root_bus = create_pci_root_bus_path();
         let devname = "sda";
@@ -1581,6 +1583,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::redundant_clone)]
     async fn test_vfio_matcher() {
         let grpa = IommuGroup(1);
         let grpb = IommuGroup(22);
@@ -1602,6 +1605,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[allow(clippy::redundant_clone)]
     async fn test_mmio_block_matcher() {
         let devname_a = "vda";
         let devname_b = "vdb";


### PR DESCRIPTION
Allow `clippy::redundant_clone` in the agent's unit tests because rustc>=1.70 shows the errors as false-negatives. These `clone()` are required because the following codes refer to the variable, but the clippy analyzes them by mistake, using the conservative and limited approach.
Ref. https://rust-lang.github.io/rust-clippy/master/index.html#/redundant_clone

Fixes: #7534