### PR TITLE
Use version 0.10.4 of `fuse-backend-rs`

### DIFF
--- a/src/dragonball/Cargo.toml
+++ b/src/dragonball/Cargo.toml
@@ -43,6 +43,7 @@ vmm-sys-util = "0.11.0"
 virtio-queue = { version = "0.6.0", optional = true }
 vm-memory = { version = "0.9.0", features = ["backend-mmap"] }
 crossbeam-channel = "0.5.6"
+fuse-backend-rs = "=0.10.4"
 
 [dev-dependencies]
 slog-async = "2.7.0"


### PR DESCRIPTION
Version 0.10.5, which was just released, breaks `nydus-storage`.

This is a workaround to fix the CI which is blocking other PRs.

Fixes: #7541