### PR TITLE
CC | protocols: add support sealed_secret

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -23,6 +23,7 @@ regex = "1.5.6"
 serial_test = "0.5.1"
 kata-sys-util = { path = "../libs/kata-sys-util" }
 kata-types = { path = "../libs/kata-types" }
+const_format = "0.2.30"
 url = "2.2.2"
 
 # Async helpers

--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -33,6 +33,13 @@ ifeq ($(SECCOMP),yes)
     override EXTRA_RUSTFEATURES += seccomp
 endif
 
+SEALED_SECRET ?= no
+
+# Enable sealed-secret feature of rust build
+ifeq ($(SEALED_SECRET),yes)
+    override EXTRA_RUSTFEATURES += sealed-secret
+endif
+
 include ../../utils.mk
 
 ifeq ($(ARCH), ppc64le)

--- a/src/libs/protocols/Cargo.toml
+++ b/src/libs/protocols/Cargo.toml
@@ -9,6 +9,7 @@ license = "Apache-2.0"
 default = []
 with-serde = [ "serde", "serde_json" ]
 async = ["ttrpc/async", "async-trait"]
+sealed-secret = []
 
 [dependencies]
 ttrpc = { version = "0.7.1" }

--- a/src/libs/protocols/build.rs
+++ b/src/libs/protocols/build.rs
@@ -204,6 +204,8 @@ fn real_main() -> Result<(), std::io::Error> {
                 "protos/agent.proto",
                 "protos/health.proto",
                 "protos/image.proto",
+                #[cfg(feature = "sealed-secret")]
+                "protos/sealed_secret.proto",
             ],
             true,
         )?;
@@ -211,6 +213,11 @@ fn real_main() -> Result<(), std::io::Error> {
         fs::rename("src/agent_ttrpc.rs", "src/agent_ttrpc_async.rs")?;
         fs::rename("src/health_ttrpc.rs", "src/health_ttrpc_async.rs")?;
         fs::rename("src/image_ttrpc.rs", "src/image_ttrpc_async.rs")?;
+        #[cfg(feature = "sealed-secret")]
+        fs::rename(
+            "src/sealed_secret_ttrpc.rs",
+            "src/sealed_secret_ttrpc_async.rs",
+        )?;
     }
 
     codegen(
@@ -219,6 +226,8 @@ fn real_main() -> Result<(), std::io::Error> {
             "protos/agent.proto",
             "protos/health.proto",
             "protos/image.proto",
+            #[cfg(feature = "sealed-secret")]
+            "protos/sealed_secret.proto",
         ],
         false,
     )?;

--- a/src/libs/protocols/protos/sealed_secret.proto
+++ b/src/libs/protocols/protos/sealed_secret.proto
@@ -1,0 +1,27 @@
+syntax = "proto3";
+
+package api;
+
+message UnsealSecretInput {
+    bytes secret = 1;
+}
+
+message UnsealSecretOutput {
+    bytes plaintext = 1;
+}
+
+message GetResourceRequest {
+    string ResourcePath = 1;
+}
+
+message GetResourceResponse {
+    bytes Resource = 1;
+}
+
+service SealedSecretService {
+    rpc UnsealSecret(UnsealSecretInput) returns (UnsealSecretOutput) {};
+}
+
+service GetResourceService {
+    rpc GetResource(GetResourceRequest) returns (GetResourceResponse) {};
+}

--- a/src/libs/protocols/src/lib.rs
+++ b/src/libs/protocols/src/lib.rs
@@ -31,3 +31,10 @@ pub use serde_config::{
     deserialize_enum_or_unknown, deserialize_message_field, serialize_enum_or_unknown,
     serialize_message_field,
 };
+
+#[cfg(feature = "sealed-secret")]
+pub mod sealed_secret;
+#[cfg(feature = "sealed-secret")]
+pub mod sealed_secret_ttrpc;
+#[cfg(all(feature = "sealed-secret", feature = "async"))]
+pub mod sealed_secret_ttrpc_async;

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -28,6 +28,8 @@ LIBC=${LIBC:-musl}
 # The kata agent enables seccomp feature.
 # However, it is not enforced by default: you need to enable that in the main configuration file.
 SECCOMP=${SECCOMP:-"yes"}
+# The kata agent enables sealed-secret feature.
+SEALED_SECRET=${SEALED_SECRET:-"no"}
 SELINUX=${SELINUX:-"no"}
 
 lib_file="${script_dir}/../scripts/lib.sh"
@@ -155,6 +157,10 @@ ROOTFS_DIR          Path to the directory that is populated with the rootfs.
 
 SECCOMP             When set to "no", the kata-agent is built without seccomp capability.
                     Default value: "yes"
+
+SEALED_SECRET       When set to "yes", the kata-agent is built with sealed-secret
+                    capability.
+                    Default value: "no"
 
 SELINUX             When set to "yes", build the rootfs with the required packages to
                     enable SELinux in the VM.
@@ -469,6 +475,7 @@ build_rootfs_distro()
 			--env INSIDE_CONTAINER=1 \
 			--env AA_KBC="${AA_KBC}" \
 			--env SECCOMP="${SECCOMP}" \
+			--env SEALED_SECRET="${SEALED_SECRET}" \
 			--env SELINUX="${SELINUX}" \
 			--env DEBUG="${DEBUG}" \
 			--env HOME="/root" \
@@ -630,7 +637,7 @@ EOF
 			git checkout "${AGENT_VERSION}" && OK "git checkout successful" || die "checkout agent ${AGENT_VERSION} failed!"
 		fi
 		make clean
-		make LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP}
+		make LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP} SEALED_SECRET=${SEALED_SECRET}
 		make install DESTDIR="${ROOTFS_DIR}" LIBC=${LIBC} INIT=${AGENT_INIT}
 		if [ "${SECCOMP}" == "yes" ]; then
 			rm -rf "${libseccomp_install_dir}" "${gperf_install_dir}"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -30,6 +30,7 @@ LIBC=${LIBC:-musl}
 SECCOMP=${SECCOMP:-"yes"}
 # The kata agent enables sealed-secret feature.
 SEALED_SECRET=${SEALED_SECRET:-"no"}
+CDH_RESOURCE_PROVIDER=${CDH_RESOURCE_PROVIDER:-"kbs"}
 SELINUX=${SELINUX:-"no"}
 
 lib_file="${script_dir}/../scripts/lib.sh"
@@ -697,6 +698,10 @@ EOF
 		git checkout FETCH_HEAD
 		( [ "${AA_KBC}" == "eaa_kbc" ] || [ "${AA_KBC}" == "cc_kbc_tdx" ] ) && [ "${ARCH}" == "x86_64" ] && LIBC="gnu"
 		make KBC=${AA_KBC} ttrpc=true && make install DESTDIR="${ROOTFS_DIR}/usr/local/bin/"
+		popd
+
+		pushd guest-components/confidential-data-hub
+		make RESOURCE_PROVIDER=${CDH_RESOURCE_PROVIDER} && make install DESTDIR="${ROOTFS_DIR}/usr/local/bin/"
 		popd
 	fi
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -228,6 +228,7 @@ install_cc_image() {
 	export KATA_BUILD_CC=yes
 	export MEASURED_ROOTFS=yes
 	export DM_VERITY=yes
+	export SEALED_SECRET=yes
 	variant="${1:-}"
 
 	install_image "${variant}"


### PR DESCRIPTION
To call CDH ttrpc API, 'unseal_secret' for 'sealed_secret', add protocol file and generate ttrpc code.

Fixes: #7544