### PR TITLE
WIP: runtime-rs: Add support for multi-virtiofs devices

### DIFF
--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -173,6 +173,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1039,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
@@ -1183,7 +1189,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.22",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -1302,10 +1308,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.22"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9e1b3cf1243ae005d9e74085d4d542f3125458f3a81af210d901dcd7411efd"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "itoa",
  "libc",
  "num_threads",
@@ -1322,9 +1329,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.9"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372950940a5f07bf38dbe211d7283c9e6d7327df53794992d293e534c733d09b"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]

--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -37,6 +37,9 @@ pub const DEFAULT_VHOST_USER_STORE_PATH: &str = "/var/run/vhost-user";
 pub const DEFAULT_BLOCK_NVDIMM_MEM_OFFSET: u64 = 0;
 
 pub const DEFAULT_SHARED_FS_TYPE: &str = "virtio-fs";
+
+pub const DEFAULT_VIRTIOFS_DEVICE: &str = "default";
+
 pub const DEFAULT_VIRTIO_FS_CACHE_MODE: &str = "never";
 pub const DEFAULT_VIRTIO_FS_DAX_SIZE_MB: u32 = 1024;
 pub const DEFAULT_SHARED_9PFS_SIZE_MB: u32 = 128 * 1024;

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -796,6 +796,13 @@ pub struct SharedFsInfo {
     #[serde(default)]
     pub virtio_fs_extra_args: Vec<String>,
 
+    /// The format of the extra virtiofs is as below:
+    /// <virtiofs name>:[parameter parameter];<virtiofs name>:[parameter parameter]
+    /// for example:
+    /// ["virtiofs1: -o xattr,no_open,writeback,trace,cache_symlinks --cache-mode=always", "virtiofs2: -o trace,cache_symlinks --thread-pool-size=1"]
+    #[serde(default)]
+    pub extra_virtiofs: Vec<String>,
+
     /// Cache mode:
     /// - never: Metadata, data, and pathname lookup are not cached in guest. They are always
     ///   fetched from host and any changes are immediately pushed to host.

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -9,7 +9,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
 dependencies = [
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -238,7 +238,7 @@ checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -310,7 +310,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78d456f91b4c1fdebf2698214e599fec3d7f8b46e3140fb254a9ea88c970ab0a"
 dependencies = [
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -416,11 +416,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "6c6b2562119bf28c3439f7f02db99faf0aa1a8cdfe5772a2ee155d32227239f0"
 dependencies = [
  "jobserver",
+ "libc",
 ]
 
 [[package]]
@@ -437,9 +438,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "cgroups-rs"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b098e7c3a70d03c288fa0a96ccf13e770eb3d78c4cc0e1549b3c13215d5f965"
+checksum = "1fb3af90c8d48ad5f432d8afb521b5b40c2a2fce46dd60e05912de51c47fba64"
 dependencies = [
  "libc",
  "log",
@@ -753,6 +754,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +835,7 @@ dependencies = [
  "dbs-upcall",
  "dbs-utils",
  "dbs-virtio-devices",
+ "fuse-backend-rs",
  "kvm-bindings",
  "kvm-ioctls",
  "lazy_static",
@@ -867,9 +875,9 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1091,7 +1099,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -1646,9 +1654,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "linux_container"
@@ -2075,14 +2083,14 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "openssl-src"
-version = "111.26.0+1.1.1u"
+version = "111.27.0+1.1.1v"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
+checksum = "06e8f197c82d7511c5b014030c9b1efeda40d7d5f99d23b4ceed3524a5e63f02"
 dependencies = [
  "cc",
 ]
@@ -2331,7 +2339,7 @@ checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -2726,9 +2734,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
+checksum = "b7b6d6190b7594385f61bd3911cd1be99dfddcfc365a4160cc2ab5bff4aed294"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2887,14 +2895,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "1ee020b1716f0a80e2ace9b03441a749e402e86712f15f16fe8a8f75afac732f"
 dependencies = [
  "bitflags 2.3.3",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.5",
  "windows-sys 0.48.0",
 ]
 
@@ -2958,22 +2966,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.177"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63ba2516aa6bf82e0b19ca8b50019d52df58455d3cf9bdaf6315225fdd0c560a"
+checksum = "6d3e73c93c3240c0bda063c239298e633114c69a888c3e37ca8bb33f343e9890"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.177"
+version = "1.0.181"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "401797fe7833d72109fedec6bfcbe67c0eed9b99772f26eb8afd261f0abc6fd3"
+checksum = "be02f6cb0cd3a5ec20bbcfbcbd749f57daddb1a0882dc2e46a6c236c90b977ed"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3172,7 +3180,7 @@ dependencies = [
  "serde",
  "serde_json",
  "slog",
- "time 0.3.23",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -3207,7 +3215,7 @@ dependencies = [
  "slog",
  "term",
  "thread_local",
- "time 0.3.23",
+ "time 0.3.25",
 ]
 
 [[package]]
@@ -3283,9 +3291,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.27"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b60f673f44a8255b9c8c657daf66a596d435f2da81a555b06dc644d080ba45e0"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3318,7 +3326,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.4",
+ "rustix 0.38.6",
  "windows-sys 0.48.0",
 ]
 
@@ -3364,7 +3372,7 @@ checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3412,10 +3420,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "itoa",
  "libc",
  "num_threads",
@@ -3432,9 +3441,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -3491,7 +3500,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3590,7 +3599,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
 ]
 
 [[package]]
@@ -3945,7 +3954,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
@@ -3979,7 +3988,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -100,7 +100,8 @@ impl ResourceManagerInner {
                         .await?
                         .is_fs_sharing_supported()
                     {
-                        let share_fs = share_fs::new(&self.sid, &c).context("new share fs")?;
+                        let share_fs =
+                            share_fs::new(&self.sid, &c, &self.config()).context("new share fs")?;
                         share_fs
                             .setup_device_before_start_vm(self.hypervisor.as_ref())
                             .await

--- a/src/runtime-rs/crates/resource/src/share_fs/sandbox_bind_mounts.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/sandbox_bind_mounts.rs
@@ -3,13 +3,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-// Note:
-// sandbox_bind_mounts supports kinds of mount patterns, for example:
-// (1) "/path/to", with default readonly mode.
-// (2) "/path/to:ro", same as (1).
-// (3) "/path/to:rw", with readwrite mode.
-//
-// sandbox_bind_mounts: ["/path/to", "/path/to:rw", "/mnt/to:ro"]
+
+// @extra-virtiofs Defination
+// @Annotation: io.katacontainers.config.hypervisor.extra_virtiofs
+// @ContentFormat:
+// <virtiofs_device_01>:<arg01,arg02,...>;<virtiofs_device_02>:<arg01,arg02,...>;...
+// @Example:
+// "virtiofs_device_01:-o no_open,cache=none --thread-pool-size=1;virtiofs_device_02:-o no_open,cache=always,writeback,cache_symlinks --thread-pool-size=10"
+
+// @sandbox_bind_mounts
+// @Annotation：io.katacontainers.config.runtime.sandbox_bind_mounts
+// @ContentFormat:
+// <virtiofs_device_01>:<host_path01:ro host_path02 ...>;<virtiofs_device_02>:<host_path03:rw host_path04 ...>; <host_path05:rw host_path06:ro ...>
+// @sandbox_bind_mounts with extra_virtiofs
+//    --annotation "io.katacontainers.config.hypervisor.extra_virtiofs=..." \
+//    --annotation "io.katacontainers.config.runtime.sandbox_bind_mounts=..."
 //
 
 use std::{
@@ -20,136 +28,164 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 
-use super::utils::{do_get_host_path, mkdir_with_permissions};
+use super::utils::mkdir_with_permissions;
+use crate::share_fs::utils::get_host_shared_subpath;
 use kata_sys_util::{fs::get_base_name, mount};
 use kata_types::mount::{SANDBOX_BIND_MOUNTS_DIR, SANDBOX_BIND_MOUNTS_RO, SANDBOX_BIND_MOUNTS_RW};
 use nix::mount::MsFlags;
 
 #[derive(Clone, Default, Debug)]
 pub struct SandboxBindMounts {
-    sid: String,
-    host_mounts_path: PathBuf,
+    sandbox_id: String,
     sandbox_bindmounts: Vec<String>,
 }
 
 impl SandboxBindMounts {
-    pub fn new(sid: String, sandbox_bindmounts: Vec<String>) -> Result<Self> {
-        // /run/kata-containers/shared/sandboxes/<sid>/rw/passthrough/sandbox-mounts
-        let bindmounts_path =
-            do_get_host_path(SANDBOX_BIND_MOUNTS_DIR, sid.as_str(), "", true, false);
-        let host_mounts_path = PathBuf::from(bindmounts_path);
-
+    pub fn new(sandbox_id: String, sandbox_bindmounts: Vec<String>) -> Result<Self> {
         Ok(SandboxBindMounts {
-            sid,
-            host_mounts_path,
+            sandbox_id,
             sandbox_bindmounts,
         })
     }
 
-    fn parse_sandbox_bind_mounts<'a>(&self, bindmnt_src: &'a str) -> Result<(&'a str, &'a str)> {
+    // return Result<(Option(virtiofs device), host path, r/w mode)>
+    fn parse_sandbox_bind_mounts<'a>(
+        &self,
+        sandbox_bindmount: &'a str,
+    ) -> Result<(Option<&'a str>, &'a str, &'a str)> {
         // get the bindmount's r/w mode
-        let bindmount_mode = if bindmnt_src.ends_with(SANDBOX_BIND_MOUNTS_RW) {
+        let bindmount_mode = if sandbox_bindmount.ends_with(SANDBOX_BIND_MOUNTS_RW) {
             SANDBOX_BIND_MOUNTS_RW
         } else {
             SANDBOX_BIND_MOUNTS_RO
         };
 
-        // get the true bindmount from the string
-        let bindmount = bindmnt_src.trim_end_matches(bindmount_mode);
-
-        Ok((bindmount_mode, bindmount))
+        // get the real bindmount from the string
+        // virtiofs_device:/path/to2@rw -> virtiofs_device:/path/to2
+        let dev_bindmount = sandbox_bindmount.trim_end_matches(bindmount_mode);
+        let dev_and_path: Vec<&str> = dev_bindmount.split(':').collect();
+        if dev_and_path.len() == 2 {
+            Ok((Some(dev_and_path[0]), dev_and_path[1], bindmount_mode))
+        } else {
+            Ok((None, dev_and_path[0], bindmount_mode))
+        }
     }
 
     pub fn setup_sandbox_bind_mounts(&self) -> Result<()> {
         let mut mounted_list: Vec<PathBuf> = Vec::new();
         let mut mounted_map: HashMap<String, bool> = HashMap::new();
+
         for src in &self.sandbox_bindmounts {
-            let (bindmount_mode, bindmount) = self
-                .parse_sandbox_bind_mounts(src)
-                .context("parse sandbox bind mounts failed")?;
+            // (Some(virtiofs1), /mnt/to, @rw)
+            let (virtiofs_dev, host_shared, bindmount_mode) =
+                self.parse_sandbox_bind_mounts(src)
+                    .context("parse sandbox bind mounts")?;
 
             // get the basename of the canonicalized mount path mnt_name: dirX
-            let mnt_name = get_base_name(bindmount)?
+            let mnt_name = get_base_name(host_shared)?
                 .into_string()
-                .map_err(|e| anyhow!("failed to get base name {:?}", e))?;
+                .map_err(|e| anyhow!("failed to convert to string{:?}", e))?;
 
             // if repeated mounted, do umount it and return error
             if mounted_map.insert(mnt_name.clone(), true).is_some() {
                 for p in &mounted_list {
-                    nix::mount::umount(p)
-                        .context("mounted_map insert one repeated mounted, do umount it")?;
+                    nix::mount::umount(p).context("one repeated mount, do umount it")?;
                 }
 
                 return Err(anyhow!(
                     "sandbox-bindmounts: path {} is already specified.",
-                    bindmount
+                    host_shared
                 ));
             }
 
-            // mount_dest: /run/kata-containers/shared/sandboxes/<sid>/rw/passthrough/sandbox-mounts/dirX
-            let mount_dest = self.host_mounts_path.clone().join(mnt_name.as_str());
-            mkdir_with_permissions(self.host_mounts_path.clone().to_path_buf(), 0o750).context(
-                format!(
-                    "create host mounts path {:?}",
-                    self.host_mounts_path.clone()
-                ),
-            )?;
+            // /run/kata-containers/shared/sandboxes/<sid>/<virtiofs_device>/rw/passthrough/sandbox-mounts/dirX
+            let host_mounts_target = get_host_shared_subpath(
+                self.sandbox_id.as_str(),
+                virtiofs_dev,
+                SANDBOX_BIND_MOUNTS_DIR,
+                false,
+            )
+            .join(&mnt_name);
+            mkdir_with_permissions(host_mounts_target.clone(), 0o750)
+                .context(format!("create host mounts path {:?}", host_mounts_target))?;
 
             info!(
                 sl!(),
-                "sandbox-bindmounts mount_src: {:?} => mount_dest: {:?}", bindmount, &mount_dest
+                "sandbox-bindmounts mount_src: {:?} => mount_dest: {:?}",
+                host_shared,
+                &host_mounts_target
             );
 
             // mount -o bind,ro host_shared mount_dest
             // host_shared: ${bindmount}
-            mount::bind_mount_unchecked(Path::new(bindmount), &mount_dest, true, MsFlags::MS_SLAVE)
-                .map_err(|e| {
-                    for p in &mounted_list {
-                        nix::mount::umount(p).unwrap_or_else(|x| {
-                            format!("do umount failed: {:?}", x);
-                        });
-                    }
-                    e
-                })?;
+            mount::bind_mount_unchecked(
+                Path::new(host_shared),
+                &host_mounts_target,
+                true,
+                MsFlags::MS_SLAVE,
+            )
+            .map_err(|e| {
+                for p in &mounted_list {
+                    nix::mount::umount(p).unwrap_or_else(|x| {
+                        format!("do umount failed: {:?}", x);
+                    });
+                }
+                e
+            })?;
 
             // default sandbox bind mounts mode is ro.
             if bindmount_mode == SANDBOX_BIND_MOUNTS_RO {
                 info!(sl!(), "sandbox readonly bind mount.");
-                // dest_ro: /run/kata-containers/shared/sandboxes/<sid>/ro/passthrough/sandbox-mounts
-                let mount_dest_ro =
-                    do_get_host_path(SANDBOX_BIND_MOUNTS_DIR, &self.sid, "", true, true);
-                let sandbox_bindmounts_ro = [mount_dest_ro, mnt_name.clone()].join("/");
+                // /run/kata-containers/shared/sandboxes/<sid>/<virtiofs_device>/ro/passthrough/sandbox-mounts/dirX
+                let bindmount_ro = get_host_shared_subpath(
+                    self.sandbox_id.as_str(),
+                    virtiofs_dev,
+                    SANDBOX_BIND_MOUNTS_DIR,
+                    true,
+                )
+                .join(mnt_name);
 
-                mount::bind_remount(sandbox_bindmounts_ro, true)
+                mount::bind_remount(&bindmount_ro, true)
                     .context("remount ro directory with ro permission")?;
             }
 
-            mounted_list.push(mount_dest);
+            mounted_list.push(host_mounts_target);
         }
 
         Ok(())
     }
 
     pub fn cleanup_sandbox_bind_mounts(&self) -> Result<()> {
+        let mut bindmounts_cleanup: Vec<PathBuf> = Vec::new();
         for src in &self.sandbox_bindmounts {
-            let parsed_mnts = self
+            // (Some(virtiofs1), /mnt/to, @rw)
+            let (virtiofs_dev, host_shared, _mode) = self
                 .parse_sandbox_bind_mounts(src)
                 .context("parse sandbox bind mounts")?;
 
-            let mnt_name = get_base_name(parsed_mnts.1)?
+            // get the basename of the canonicalized mount path mnt_name: dirX
+            let mnt_name = get_base_name(host_shared)?
                 .into_string()
                 .map_err(|e| anyhow!("failed to convert to string{:?}", e))?;
 
-            // /run/kata-containers/shared/sandboxes/<sid>/passthrough/rw/sandbox-mounts/dir
-            let mnt_dest = self.host_mounts_path.join(mnt_name.as_str());
-            mount::umount_timeout(mnt_dest, 0).context("umount bindmount failed")?;
+            // /run/kata-containers/shared/sandboxes/<sid>/<virtiofs_device>/rw/passthrough/sandbox-mounts/dirX
+            let host_sandbox_mounts = get_host_shared_subpath(
+                self.sandbox_id.as_str(),
+                virtiofs_dev,
+                SANDBOX_BIND_MOUNTS_DIR,
+                false,
+            );
+            bindmounts_cleanup.push(host_sandbox_mounts.clone());
+
+            let host_mounts_target = host_sandbox_mounts.join(&mnt_name);
+            mount::umount_timeout(&host_mounts_target, 0).context("umount bindmount failed")?;
         }
 
-        if fs::metadata(self.host_mounts_path.clone())?.is_dir() {
-            fs::remove_dir_all(self.host_mounts_path.clone()).context(format!(
-                "remove sandbox bindmount point {:?}.",
-                self.host_mounts_path.clone()
-            ))?;
+        for bindmount in bindmounts_cleanup.iter() {
+            if fs::metadata(bindmount)?.is_dir() {
+                fs::remove_dir_all(bindmount)
+                    .context(format!("remove sandbox bindmount point {:?}.", bindmount))?;
+            }
         }
 
         Ok(())

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_inline.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_inline.rs
@@ -4,20 +4,22 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
-use agent::Storage;
 use anyhow::{Context, Result};
 use async_trait::async_trait;
-use hypervisor::Hypervisor;
-use kata_types::config::hypervisor::SharedFsInfo;
 use tokio::sync::Mutex;
+
+use agent::Storage;
+use hypervisor::Hypervisor;
+use kata_types::config::{default::DEFAULT_VIRTIOFS_DEVICE, hypervisor::SharedFsInfo};
 
 use super::{
     share_virtio_fs::{
         prepare_virtiofs, setup_inline_virtiofs, FS_TYPE_VIRTIO_FS, KATA_VIRTIO_FS_DEV_TYPE,
         MOUNT_GUEST_TAG,
     },
+    utils::parse_sharefs_special_volumes,
     ShareFs, *,
 };
 
@@ -25,9 +27,42 @@ lazy_static! {
     pub(crate) static ref SHARED_DIR_VIRTIO_FS_OPTIONS: Vec::<String> = vec![String::from("nodev")];
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone, Debug, Default)]
 pub struct ShareVirtioFsInlineConfig {
-    pub id: String,
+    /// sandbox id
+    pub sandbox_id: String,
+
+    /// (virtiofs_device, extra_virtiofs_info)
+    pub multi_virtiofs: HashMap<String, Vec<String>>,
+}
+
+impl ShareVirtioFsInlineConfig {
+    // multi-virtiofs annotation: "virtiofs_device_01:arg01,arg02,...;virtiofs_device_02:arg01,arg02,..."
+    pub fn new(sid: &str, extra_virtiofs_devs: &Vec<String>) -> Result<ShareVirtioFsInlineConfig> {
+        let mut multi_virtiofs: HashMap<String, Vec<String>> = HashMap::new();
+        multi_virtiofs
+            .entry(DEFAULT_VIRTIOFS_DEVICE.to_string())
+            .or_insert(Vec::new());
+
+        for ex_vfs in extra_virtiofs_devs {
+            // virtiofs_device_01:arg01,arg02,...;
+            let ex_virtiofs: Vec<&str> = ex_vfs.split(':').collect();
+            if ex_virtiofs.len() != 2 {
+                return Err(anyhow!("invalid extra virtiofs formats: {}", ex_vfs));
+            }
+
+            // virtiofs_device_01
+            let virtiofs_name = String::from(ex_virtiofs[0]);
+            let extra_virtiofs_args = ex_virtiofs[1].split(',').map(String::from).collect();
+
+            multi_virtiofs.insert(virtiofs_name, extra_virtiofs_args);
+        }
+
+        Ok(ShareVirtioFsInlineConfig {
+            sandbox_id: sid.to_owned(),
+            multi_virtiofs,
+        })
+    }
 }
 
 pub struct ShareVirtioFsInline {
@@ -37,11 +72,21 @@ pub struct ShareVirtioFsInline {
 }
 
 impl ShareVirtioFsInline {
-    pub(crate) fn new(id: &str, _config: &SharedFsInfo) -> Result<Self> {
+    pub(crate) fn new(
+        id: &str,
+        config: &SharedFsInfo,
+        special_volumes: Vec<String>,
+    ) -> Result<Self> {
+        let config = ShareVirtioFsInlineConfig::new(id, &config.extra_virtiofs)
+            .context("parese extra virtiofs")?;
+        let devices: HashSet<&str> = config.multi_virtiofs.keys().map(|x| x.as_str()).collect();
+        let mountinfo_map = parse_sharefs_special_volumes(devices, special_volumes)
+            .context("parse special volumes failed.")?;
+
         Ok(Self {
-            config: ShareVirtioFsInlineConfig { id: id.to_string() },
+            config,
             share_fs_mount: Arc::new(VirtiofsShareMount::new(id)),
-            mounted_info_set: Arc::new(Mutex::new(HashMap::new())),
+            mounted_info_set: Arc::new(Mutex::new(mountinfo_map)),
         })
     }
 }
@@ -53,33 +98,81 @@ impl ShareFs for ShareVirtioFsInline {
     }
 
     async fn setup_device_before_start_vm(&self, h: &dyn Hypervisor) -> Result<()> {
-        prepare_virtiofs(h, INLINE_VIRTIO_FS, &self.config.id, "")
+        // do prepare for virtiofs, if not set, just skip it.
+        for (name, device) in self.config.multi_virtiofs.iter() {
+            let (virtiofs_args, virtiofs_dev) = if name != DEFAULT_VIRTIOFS_DEVICE {
+                (device.clone(), Some(name))
+            } else {
+                (Vec::new(), None)
+            };
+
+            prepare_virtiofs(
+                h,
+                INLINE_VIRTIO_FS,
+                &self.config.sandbox_id,
+                "",
+                virtiofs_args,
+                virtiofs_dev.as_ref().map(|s| s.as_str()),
+            )
             .await
-            .context("prepare virtiofs")?;
+            .context("prepare extra virtiofs")?;
+        }
+
         Ok(())
     }
 
     async fn setup_device_after_start_vm(&self, h: &dyn Hypervisor) -> Result<()> {
-        setup_inline_virtiofs(&self.config.id, h)
+        // do setup for default inline virtiofs
+        setup_inline_virtiofs(&self.config.sandbox_id, None, h)
             .await
-            .context("setup inline virtiofs")?;
+            .context("setup default inline virtiofs")?;
+
+        // do setup for extra virtiofs, if not set, just skip it.
+        for device in self.config.multi_virtiofs.keys() {
+            let virtiofs_dev = if device != DEFAULT_VIRTIOFS_DEVICE {
+                Some(device)
+            } else {
+                None
+            };
+
+            setup_inline_virtiofs(
+                &self.config.sandbox_id,
+                virtiofs_dev.as_ref().map(|s| s.as_str()),
+                h,
+            )
+            .await
+            .context("setup extra inline virtiofs")?;
+        }
+
         Ok(())
     }
+
     async fn get_storages(&self) -> Result<Vec<Storage>> {
         // setup storage
         let mut storages: Vec<Storage> = Vec::new();
 
-        let shared_volume: Storage = Storage {
-            driver: String::from(KATA_VIRTIO_FS_DEV_TYPE),
-            driver_options: Vec::new(),
-            source: String::from(MOUNT_GUEST_TAG),
-            fs_type: String::from(FS_TYPE_VIRTIO_FS),
-            fs_group: None,
-            options: SHARED_DIR_VIRTIO_FS_OPTIONS.clone(),
-            mount_point: String::from(KATA_GUEST_SHARE_DIR),
-        };
+        for (device_name, _device) in self.config.multi_virtiofs.iter() {
+            let mut shared_volume: Storage = Storage {
+                driver: String::from(KATA_VIRTIO_FS_DEV_TYPE),
+                driver_options: Vec::new(),
+                fs_type: String::from(FS_TYPE_VIRTIO_FS),
+                fs_group: None,
+                options: SHARED_DIR_VIRTIO_FS_OPTIONS.clone(),
+                ..Default::default()
+            };
 
-        storages.push(shared_volume);
+            if device_name == DEFAULT_VIRTIOFS_DEVICE {
+                shared_volume.source = String::from(MOUNT_GUEST_TAG);
+                shared_volume.mount_point = String::from(KATA_GUEST_SHARE_DIR);
+            } else {
+                // /run/kata-containers/shared/<device_name>/
+                shared_volume.source = String::from(device_name);
+                shared_volume.mount_point = format!("{}/{}", KATA_GUEST_SHARED, device_name);
+            }
+
+            storages.push(shared_volume);
+        }
+
         Ok(storages)
     }
 

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
@@ -173,9 +173,16 @@ impl ShareFs for ShareVirtioFsStandalone {
     }
 
     async fn setup_device_before_start_vm(&self, h: &dyn Hypervisor) -> Result<()> {
-        prepare_virtiofs(h, VIRTIO_FS, &self.config.id, &h.get_jailer_root().await?)
-            .await
-            .context("prepare virtiofs")?;
+        prepare_virtiofs(
+            h,
+            VIRTIO_FS,
+            &self.config.id,
+            &h.get_jailer_root().await?,
+            vec![],
+            None,
+        )
+        .await
+        .context("prepare virtiofs")?;
         self.setup_virtiofsd(h).await.context("setup virtiofsd")?;
         Ok(())
     }

--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -8,6 +8,7 @@ mod block_volume;
 mod default_volume;
 pub mod hugepage;
 mod share_fs_volume;
+mod sharefs_special_volume;
 mod shm_volume;
 pub mod utils;
 
@@ -109,6 +110,12 @@ impl VolumeResource {
                     share_fs_volume::ShareFsVolume::new(share_fs, m, cid, read_only, agent.clone())
                         .await
                         .with_context(|| format!("new share fs volume {:?}", m))?,
+                )
+            } else if sharefs_special_volume::is_sharefs_special_volume(share_fs, m).await {
+                Arc::new(
+                    sharefs_special_volume::ShareFsSpecialVolume::new(m, sid, cid, read_only)
+                        .await
+                        .with_context(|| format!("new share fs special volume {:?}", m))?,
                 )
             } else if is_skip_volume(m) {
                 info!(sl!(), "skip volume {:?}", m);

--- a/src/runtime-rs/crates/resource/src/volume/sharefs_special_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/sharefs_special_volume.rs
@@ -1,0 +1,299 @@
+// Copyright (c) 2023 Alibaba Cloud
+// Copyright (c) 2023 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// @extra-virtiofs Defination
+// @Annotation: io.katacontainers.config.hypervisor.extra_virtiofs
+// @ContentFormat:
+// <virtiofs_device_01>:<arg01,arg02,...>;<virtiofs_device_02>:<arg01,arg02,...>;...
+// @Example:
+// "virtiofs_device_01:-o no_open,cache=none --thread-pool-size=1;virtiofs_device_02:-o no_open,cache=always,writeback,cache_symlinks --thread-pool-size=10"
+// @Configuration.toml
+// [hypervisor.XXX]
+// extra_virtiofs = "virtiofs_device_01:-o no_open,cache=none --thread-pool-size=1;virtiofs_device_02: -o no_open,cache=always,writeback,cache_symlinks --thread-pool-size=10"
+
+// @special_volumes
+// @Annotation: io.katacontainers.config.runtime.special_volumes
+// @ContentFormat: <virtiofs_device_01>:<container_path01,container_path02,...>;<virtiofs_device_02>:<container_path03,container_path04,...>;...
+
+// @UseCase
+// @Special_volumes
+//    --annotation "io.katacontainers.config.hypervisor.extra_virtiofs=..." \
+//    --annotation "io.katacontainers.config.hypervisor.special_volumes=..." \
+//    --mount type=bind,src=host_path01,dst=container_path01,options=rbind:ro
+//
+// @default:
+// host mount path: /run/kata-containers/shared/sandboxes/<sid>/rw/passthrough/sharefs-special-volumes/dirX
+// guest mount path: /run/kata-containers/shared/containers/passthrough/sharefs-special-volumes/dirX
+// @extra_virtiofs:
+// host mount path: /run/kata-containers/shared/sandboxes/<sid>/<virtiofs_device>/rw/passthrough/sharefs-special-volumes/dirX
+// guest mount path: /run/kata-containers/shared/<virtiofs_device>/passthrough/sharefs-special-volumes/dirX
+// docker run -v src:dest --annotation extra_virtiofs ... --annotation special_volumes ...
+// sudo ctr run -t --rm --runtime io.containerd.kata.v2 \
+//     --mount type=bind,src=host_path01,dst=container_path01,options=rbind:ro \
+//     "$image" kata-v02 /bin/bash
+
+use std::{path::Path, sync::Arc};
+
+use anyhow::{anyhow, Context, Result};
+use async_trait::async_trait;
+use nix::mount::MsFlags;
+use tokio::sync::RwLock;
+
+use hypervisor::device::device_manager::DeviceManager;
+use kata_sys_util::mount::bind_mount_unchecked;
+
+use super::{Volume, BIND};
+use crate::share_fs::{
+    get_host_shared_subpath, ShareFs, KATA_GUEST_SHARED, KATA_GUEST_SHARE_DIR, MULTI_VIRTIOFS,
+    PASSTHROUGH_FS_DIR,
+};
+
+pub const SANDBOX_SPECIAL_VOLUMES: &str = "sharefs-special-volumes";
+pub const DEFAULT_VIRTIOFS_DEVICE: &str = "default";
+
+#[derive(Debug, Default)]
+pub struct SpecialVolume {
+    sandbox_id: String,
+}
+
+impl SpecialVolume {
+    pub fn new(sid: &str) -> Self {
+        Self {
+            sandbox_id: sid.to_owned(),
+        }
+    }
+
+    fn do_handle_sharefs_special_volumes(
+        &self,
+        source: &str,
+        container_path: &str,
+        virtiofs_device: &str,
+    ) -> Result<String> {
+        // bind mount secret/configmap source to guest as sandbox level volume with directory name `dirX`,
+        // host mount path: /run/kata-containers/shared/sandboxes/<sid>/rw/passthrough/sharefs-special-volumes
+        // guest mount path: /run/kata-containers/shared/containers/passthrough/sharefs-special-volumes
+        // host_mounts_target: /run/kata-containers/shared/sandboxes/<sid>/<virtiofs_device>/rw/passthrough/sharefs-special-volumes/dirX
+        let host_mount_target = get_host_shared_subpath(
+            self.sandbox_id.as_str(),
+            Some(virtiofs_device),
+            SANDBOX_SPECIAL_VOLUMES,
+            false,
+        )
+        .join(container_path);
+        if host_mount_target.exists() {
+            warn!(
+                sl!(),
+                "sharefs-special-mount: {:?}:{:?} has been mounted, no need to mount again",
+                virtiofs_device,
+                source
+            );
+
+            return Ok(String::new());
+        }
+
+        // default virtiofs, guest mount path:
+        // /run/kata-containers/shared/containers/passthrough/sharefs-special-volumes/dirX
+        // extra virtiofs, guest mount path:
+        // /run/kata-containers/shared/<virtiofs-device>/passthrough/sharefs-special-volumes/dirX
+        let guest_mount_path = match virtiofs_device {
+            DEFAULT_VIRTIOFS_DEVICE => {
+                format!(
+                    "{}/{}/{}/{}",
+                    KATA_GUEST_SHARE_DIR,
+                    PASSTHROUGH_FS_DIR,
+                    SANDBOX_SPECIAL_VOLUMES,
+                    container_path // dirX
+                )
+            }
+            _ => {
+                format!(
+                    "{}/{}/{}/{}/{}",
+                    KATA_GUEST_SHARED,
+                    virtiofs_device,
+                    PASSTHROUGH_FS_DIR,
+                    SANDBOX_SPECIAL_VOLUMES,
+                    container_path
+                )
+            }
+        };
+
+        debug!(
+            sl!(),
+            "sharefs-special_volumes: {:?} bind mount to {:?}, guest mount path: {:?}",
+            &source,
+            host_mount_target.display(),
+            guest_mount_path
+        );
+
+        bind_mount_unchecked(
+            Path::new(source),
+            &host_mount_target,
+            true,
+            MsFlags::MS_SLAVE,
+        )
+        .context("bind mount")?;
+
+        Ok(guest_mount_path)
+    }
+}
+
+#[derive(Debug, Default)]
+pub(crate) struct ShareFsSpecialVolume {
+    special_volume: SpecialVolume,
+    mount: oci::Mount,
+    storages: Option<agent::Storage>,
+}
+
+// --mount type=bind,src=host_path01,dst=container_path01,options=rbind:ro
+// setup for sandbox volume for sharefs_special_volumes, return whether this volume
+// should be mount into container
+// @source: mount.source, e.g. host_path
+// @destination: mount.destination, e.g. container_path
+// @fs_type: mount.fstype, e.g. bind
+impl ShareFsSpecialVolume {
+    pub async fn new(
+        // share_fs: &Option<Arc<dyn ShareFs>>,
+        m: &oci::Mount,
+        sid: &str,
+        _cid: &str,
+        _readonly: bool,
+    ) -> Result<Self> {
+        let mut sharefs_volume = ShareFsSpecialVolume {
+            special_volume: SpecialVolume::new(sid),
+            ..Default::default()
+        };
+
+        // let virtiofs_device = {
+        //     let mounted_info_guard = if let Some(sharefs) = share_fs.clone() {
+        //         sharefs.mounted_info_set()
+        //     } else {
+        //         return Ok(sharefs_volume);
+        //     };
+
+        //     let volume_devices = if let Some(mounted_info) = mounted_info_guard
+        //         .lock()
+        //         .await
+        //         .get(MULTI_VIRTIOFS)
+        //         .cloned()
+        //     {
+        //         mounted_info.volume_devices
+        //     } else {
+        //         return Err(anyhow!("volume devices is empty, something goes wrong."));
+        //     };
+
+        //     // It's safe to unwrap it here as the result of volume_devices is always OK here.
+        //     // And we get the virtiofs device with the destination given in mount.destination.
+        //     if let Some(device) = volume_devices.unwrap().get(&m.destination) {
+        //         device.clone()
+        //     } else {
+        //         return Err(anyhow!("virtiofs device not found."));
+        //     }
+        // };
+
+        // destination format <virtiofs_device@/container_path>,
+        // split it, get virtiofs device and specified container path
+        let tokens: Vec<&str> = m.destination.split('@').collect();
+        if tokens.len() != 2 {
+            return Err(anyhow!(
+                "special volume destination: {:?} is invalid",
+                m.destination
+            ));
+        }
+        let (virtiofs_device, container_path) = (tokens[0], tokens[1]);
+
+        // do check source path is valid
+        if !Path::new(&m.source).exists() {
+            return Err(anyhow!(
+                "special volume source: {:?} not exists.",
+                &m.source
+            ));
+        }
+
+        let guest_mount_path = sharefs_volume
+            .special_volume
+            .do_handle_sharefs_special_volumes(&m.source, container_path, virtiofs_device)?;
+        // .do_handle_sharefs_special_volumes(&m.source, &m.destination, &virtiofs_device)?;
+
+        sharefs_volume.mount = oci::Mount {
+            r#type: BIND.to_string(),
+            destination: m.destination.to_owned(),
+            source: guest_mount_path,
+            options: m.options.clone(),
+        };
+        sharefs_volume.storages = None;
+
+        Ok(sharefs_volume)
+    }
+}
+
+#[async_trait]
+impl Volume for ShareFsSpecialVolume {
+    fn get_volume_mount(&self) -> Result<Vec<oci::Mount>> {
+        Ok(vec![self.mount.clone()])
+    }
+
+    fn get_storage(&self) -> Result<Vec<agent::Storage>> {
+        let s = if let Some(s) = self.storages.as_ref() {
+            vec![s.clone()]
+        } else {
+            vec![]
+        };
+
+        Ok(s)
+    }
+
+    async fn cleanup(&self, _device_manager: &RwLock<DeviceManager>) -> Result<()> {
+        // TODO: implement it !
+        Ok(())
+    }
+
+    fn get_device_id(&self) -> Result<Option<String>> {
+        // TODO: virtiofs device needs to be managed by device manager.
+        Ok(None)
+    }
+}
+
+// --mount type=bind,src=host_path,dest=virtio_device01@container_path
+// (1) If mount.r#type is bind, mount.dest contains '@' and split it, getting only two parts;
+// (2) Do double check the container path in volume_devices, and its device is just the virtiofs device.
+// (3) Otherwise, it's false;
+pub(crate) async fn is_sharefs_special_volume(
+    share_fs: &Option<Arc<dyn ShareFs>>,
+    m: &oci::Mount,
+) -> bool {
+    if m.r#type.as_str() != BIND {
+        return false;
+    }
+
+    // destination format <virtiofs_device@/container_path>,
+    // split it, get virtiofs device and specified container path
+    let tokens: Vec<&str> = m.destination.split('@').collect();
+    if tokens.len() != 2 {
+        return false;
+    }
+    let (virtiofs_device, container_path) = (tokens[0], tokens[1]);
+
+    let mounted_info_guard = if let Some(sharefs) = share_fs.clone() {
+        sharefs.mounted_info_set()
+    } else {
+        return false;
+    };
+
+    let volume_devices =
+        if let Some(mounted_info) = mounted_info_guard.lock().await.get(MULTI_VIRTIOFS).cloned() {
+            mounted_info.volume_devices
+        } else {
+            return false;
+        };
+
+    // It's safe to unwrap it here as the result of volume_devices is always OK here.
+    // And we get the virtiofs device with the destination given in mount.destination.
+    if let Some(target_device) = volume_devices.unwrap().get(container_path) {
+        target_device.clone().as_str() == virtiofs_device
+    } else {
+        return false;
+    }
+}


### PR DESCRIPTION
Add multi-virtiofs solution to support isolated config for each virtiofs volume.

The current virtio-fs implementation only allows for one virtio-fs device per guest, and its config is limited to sandbox level(sandbox bind mounts). This makes it difficult to support different scenarios that require isolated config for special volume.

This solution would allow for multiple virtio-fs devices to be created in guest, each with its own config. It has the potential to improve virtiofs's flexibility and scalability.

It's still under development and not ready for users.

Fixes: #7380