### PR TITLE
CC | Add missing runtime classes

### DIFF
--- a/tools/packaging/kata-deploy/runtimeclasses/kata-clh-tdx.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-clh-tdx.yaml
@@ -1,0 +1,13 @@
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
+    name: kata-clh-tdx
+handler: kata-clh-tdx
+overhead:
+    podFixed:
+        memory: "2048Mi"
+        cpu: "1.0"
+scheduling:
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-se.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-se.yaml
@@ -1,0 +1,13 @@
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
+    name: kata-qemu-se
+handler: kata-qemu-se
+overhead:
+    podFixed:
+        memory: "2048Mi"
+        cpu: "1.0"
+scheduling:
+    nodeSelector:
+        katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-remote.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-remote.yaml
@@ -1,0 +1,13 @@
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
+    name: kata-remote
+handler: kata-remote
+overhead:
+    podFixed:
+        memory: "120Mi"
+        cpu: "250m"
+scheduling:
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -67,6 +67,19 @@ scheduling:
 kind: RuntimeClass
 apiVersion: node.k8s.io/v1
 metadata:
+    name: kata-qemu-se
+handler: kata-qemu-se
+overhead:
+    podFixed:
+        memory: "2048Mi"
+        cpu: "1.0"
+scheduling:
+    nodeSelector:
+        katacontainers.io/kata-runtime: "true"
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
     name: kata-qemu-sev
 handler: kata-qemu-sev
 overhead:

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -128,3 +128,16 @@ overhead:
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
+    name: kata-remote
+handler: kata-remote
+overhead:
+    podFixed:
+        memory: "120Mi"
+        cpu: "250m"
+scheduling:
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -2,6 +2,19 @@
 kind: RuntimeClass
 apiVersion: node.k8s.io/v1
 metadata:
+    name: kata-clh-tdx
+handler: kata-clh-tdx
+overhead:
+    podFixed:
+        memory: "2048Mi"
+        cpu: "1.0"
+scheduling:
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
     name: kata-clh
 handler: kata-clh
 overhead:


### PR DESCRIPTION
As the operator will be delegating the runtimeclass creation to the kata-deploy daemonset, let's add here the missing runtime classes that are not yet on main:
* kata-clh-tdx
* kata-qemu-se
* kata-remote