### PR TITLE
CC | agent: remove redundant implementation of verify_cid()

### DIFF
--- a/src/agent/src/image_rpc.rs
+++ b/src/agent/src/image_rpc.rs
@@ -18,7 +18,7 @@ use protocols::image;
 use tokio::sync::Mutex;
 use ttrpc::{self, error::get_rpc_status as ttrpc_error};
 
-use crate::rpc::{verify_cid, CONTAINER_BASE};
+use crate::rpc::CONTAINER_BASE;
 use crate::sandbox::Sandbox;
 use crate::AGENT_CONFIG;
 
@@ -149,7 +149,7 @@ impl ImageService {
         } else {
             return Err(anyhow!("Invalid image name. {}", req.image()));
         };
-        verify_cid(&cid)?;
+        kata_sys_util::validate::verify_id(&cid)?;
         Ok(cid)
     }
 

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -145,23 +145,6 @@ pub struct AgentService {
     init_mode: bool,
 }
 
-// A container ID must match this regex:
-//
-//     ^[a-zA-Z0-9][a-zA-Z0-9_.-]+$
-//
-pub fn verify_cid(id: &str) -> Result<()> {
-    let mut chars = id.chars();
-
-    let valid = matches!(chars.next(), Some(first) if first.is_alphanumeric()
-                && id.len() > 1
-                && chars.all(|c| c.is_alphanumeric() || ['.', '-', '_'].contains(&c)));
-
-    match valid {
-        true => Ok(()),
-        false => Err(anyhow!("invalid container ID: {:?}", id)),
-    }
-}
-
 // Partially merge an OCI process specification into another one.
 fn merge_oci_process(target: &mut oci::Process, source: &oci::Process) {
     if target.args.is_empty() && !source.args.is_empty() {


### PR DESCRIPTION
kata utils crate has an implementation of verify_cid(), so remove the version in agent.

Fixes: #7553