### PR TITLE
CC | agent: support to manage verity devices

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -72,7 +72,7 @@ clap = { version = "3.0.1", features = ["derive"] }
 openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
-image-rs = { git = "https://github.com/confidential-containers/guest-components", tag = "v0.7.0", default-features = false, features = ["kata-cc-native-tls"] }
+image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "dc15fdc", default-features = false, features = ["kata-cc-native-tls"] }
 
 [patch.crates-io]
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -154,7 +154,7 @@ impl RefCountedObject<ObjectKind> {
     pub fn dec_ref(&mut self) -> Result<()> {
         self.ref_count -= 1;
         let name =  &self.name;
-        if self.is_zero() {
+        if self.get_count() == 0 {
             match self.ref_type {
                 ObjectKind::MountPoint => {
                     let mounts = vec![name.to_owned()];
@@ -170,10 +170,6 @@ impl RefCountedObject<ObjectKind> {
             }
         }
         Ok(())
-    }
-    #[inline]
-    pub fn is_zero(&self) -> bool {
-        self.ref_count == 0
     }
     #[inline]
     pub fn get_count(&self) -> u32 {
@@ -923,7 +919,7 @@ pub async fn add_storages(
 
         {
             let mut sb = sandbox.lock().await;
-            let new_storage = sb.set_sandbox_storage(&storage.mount_point);
+            let new_storage = sb.set_sandbox_storage(&storage.mount_point, ObjectKind::MountPoint);
             if !new_storage {
                 continue;
             }

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1914,10 +1914,10 @@ fn remove_container_resources(sandbox: &mut Sandbox, cid: &str) -> Result<()> {
     }
 
     for m in cmounts.iter() {
-        if let Err(err) = sandbox.unset_and_remove_sandbox_storage(m) {
+        if let Err(err) = sandbox.unset_sandbox_storage(m) {
             error!(
                 sl(),
-                "failed to unset_and_remove_sandbox_storage for container {}, error: {:?}",
+                "failed to unset_sandbox_storage for container {}, error: {:?}",
                 cid,
                 err
             );


### PR DESCRIPTION
To share image with integrity on the host with CoCo as described in https://github.com/confidential-containers/confidential-containers/issues/137,  we need to manage verity devices in the kata-agent. We can reuse the `Storages` in the Sandbox to manage both mountpoints and verity devices.

Fixes: #7561 