### PR TITLE
metrics: Enable iperf benchmark on gha for kata metrics

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -111,14 +111,15 @@ midval = 38656.0
 minpercent = 20.0
 maxpercent = 20.0
 
-name = "iperf"
+[[metric]]
+name = "network-iperf3"
 type = "json"
 description = "iperf"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall
 # within (inclusive)
-checkvar = ".\"iperf\".Results | .[] | .jitter.Result"
+checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
-midval = 0.039
-minpercent = 20.0
-maxpercent = 20.0
+midval = 0.044
+minpercent = 30.0
+maxpercent = 30.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -110,3 +110,15 @@ checktype = "mean"
 midval = 38656.0
 minpercent = 20.0
 maxpercent = 20.0
+
+name = "iperf"
+type = "json"
+description = "iperf"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"iperf\".Results | .[] | .jitter.Result"
+checktype = "mean"
+midval = 0.039
+minpercent = 20.0
+maxpercent = 20.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -108,5 +108,15 @@ description = "measure write 90 percentile using fio"
 checkvar = ".\"fio\".Results | .[] | .write90percentile.Result"
 checktype = "mean"
 midval = 37120.0
+
+name = "iperf"
+type = "json"
+description = "iperf"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"iperf\".Results | .[] | .jitter.Result"
+checktype = "mean"
+midval = 0.50
 minpercent = 20.0
 maxpercent = 20.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -108,15 +108,18 @@ description = "measure write 90 percentile using fio"
 checkvar = ".\"fio\".Results | .[] | .write90percentile.Result"
 checktype = "mean"
 midval = 37120.0
+minpercent = 20.0
+maxpercent = 20.0
 
-name = "iperf"
+[[metric]]
+name = "network-iperf3"
 type = "json"
 description = "iperf"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall
 # within (inclusive)
-checkvar = ".\"iperf\".Results | .[] | .jitter.Result"
+checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
-midval = 0.50
-minpercent = 20.0
-maxpercent = 20.0
+midval = 0.041
+minpercent = 30.0
+maxpercent = 30.0

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -94,7 +94,7 @@ function run_test_fio() {
 function run_test_iperf() {
 	info "Running Iperf test using ${KATA_HYPERVISOR} hypervisor"
 
-	bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+	bash tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -a
 }
 
 function main() {

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -93,8 +93,6 @@ function run_test_fio() {
 
 function run_test_iperf() {
 	info "Running Iperf test using ${KATA_HYPERVISOR} hypervisor"
-	# ToDo: remove the exit once the metrics workflow is stable
-	exit 0
 
 	bash network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
 }

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -87,14 +87,14 @@ function run_test_fio() {
 	info "Running FIO test using ${KATA_HYPERVISOR} hypervisor"
 
 	bash tests/metrics/storage/fio-k8s/fio-test-ci.sh
-
-	check_metrics
 }
 
 function run_test_iperf() {
 	info "Running Iperf test using ${KATA_HYPERVISOR} hypervisor"
 
 	bash tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -a
+
+	check_metrics
 }
 
 function main() {

--- a/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+++ b/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
@@ -18,6 +18,8 @@
 # case 2"
 #  container-server <----> host-client
 
+set -x
+
 set -o pipefail
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")

--- a/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+++ b/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
@@ -18,8 +18,6 @@
 # case 2"
 #  container-server <----> host-client
 
-set -x
-
 set -o pipefail
 
 SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
@@ -178,6 +176,8 @@ EOF
 function iperf3_start_deployment() {
 	cmds=("bc" "jq")
 	check_cmds "${cmds[@]}"
+
+	init_env
 
 	# Check no processes are left behind
 	check_processes


### PR DESCRIPTION
This PR enables the iperf benchmark to run on the gha for kata metrics.

Fixes #7575