### PR TITLE
metrics: install kata once and run multiple checks

### DIFF
--- a/.github/workflows/run-metrics.yaml
+++ b/.github/workflows/run-metrics.yaml
@@ -10,16 +10,11 @@ on:
         type: string
 
 jobs:
-  run-metrics:
-    strategy:
-      fail-fast: true
-      matrix:
-        vmm: ['clh', 'qemu']
-      max-parallel: 1
+  setup-kata:
+    name: Kata Setup
     runs-on: metrics
     env:
       GOPATH: ${{ github.workspace }}
-      KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v3
         with:
@@ -33,6 +28,21 @@ jobs:
 
       - name: Install kata
         run: bash tests/metrics/gha-run.sh install-kata kata-artifacts
+
+  run-metrics:
+    needs: setup-kata
+    strategy:
+      fail-fast: true
+      matrix:
+        vmm: ['clh', 'qemu']
+      max-parallel: 1
+    runs-on: metrics
+    env:
+      GOPATH: ${{ github.workspace }}
+      KATA_HYPERVISOR: ${{ matrix.vmm }}
+    steps:
+      - name: enabling the hypervisor
+        run: bash tests/metrics/gha-run.sh enabling-hypervisor
 
       - name: run launch times test
         run: bash tests/metrics/gha-run.sh run-test-launchtimes

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -295,17 +295,28 @@ function install_kata() {
 		sudo ln -sf "${b}" "${local_bin_dir}/$(basename $b)"
 	done
 
-	if [[ ${KATA_HYPERVISOR} == "dragonball" ]]; then
-		sudo ln -sf "${katadir}/runtime-rs/bin/containerd-shim-kata-v2" "${local_bin_dir}/containerd-shim-kata-${KATA_HYPERVISOR}-v2"
-	else
-		sudo ln -sf "${katadir}/bin/containerd-shim-kata-v2" "${local_bin_dir}/containerd-shim-kata-${KATA_HYPERVISOR}-v2"
-	fi
-
-	sudo ln -sf ${katadir}/share/defaults/kata-containers/configuration-${KATA_HYPERVISOR}.toml ${katadir}/share/defaults/kata-containers/configuration.toml 
-
 	check_containerd_config_for_kata
 	restart_containerd_service
 }
+
+# creates a new kata configuration.toml hard link that
+# points to the hypervisor passed by KATA_HYPERVISOR env var.
+function enabling_hypervisor() {
+	declare -r KATA_DIR="/opt/kata"
+	declare -r CONFIG_DIR="${KATA_DIR}/share/defaults/kata-containers"
+	declare -r SRC_HYPERVISOR_CONFIG="${CONFIG_DIR}/configuration-${KATA_HYPERVISOR}.toml"
+	declare -r DEST_KATA_CONFIG="${CONFIG_DIR}/configuration.toml"
+	declare -r CONTAINERD_SHIM_KATA="/usr/local/bin/containerd-shim-kata-${KATA_HYPERVISOR}-v2"
+
+	if [[ ${KATA_HYPERVISOR} == "dragonball" ]]; then
+		sudo ln -sf "${KATA_DIR}/runtime-rs/bin/containerd-shim-kata-v2" "${CONTAINERD_SHIM_KATA}"
+	else
+		sudo ln -sf "${KATA_DIR}/bin/containerd-shim-kata-v2" "${CONTAINERD_SHIM_KATA}"
+	fi
+
+	sudo ln -sf "${SRC_HYPERVISOR_CONFIG}" "${DEST_KATA_CONFIG}"
+}
+
 
 function check_containerd_config_for_kata() {
 	# check containerd config

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -105,6 +105,7 @@ function main() {
 	action="${1:-}"
 	case "${action}" in
 		install-kata) install_kata && install_checkmetrics ;;
+		enabling-hypervisor) enabling_hypervisor ;;
 		make-tarball-results) make_tarball_results ;;
 		run-test-launchtimes) run_test_launchtimes ;;
 		run-test-memory-usage) run_test_memory_usage ;;


### PR DESCRIPTION
This PR changes the metrics workflow in order to just install kata once, and run the checks for multiple hypervisor variations.

In this way we save time avoiding installing kata for each hypervisor to be tested.

Fixes: #7578