### PR TITLE
CC | Agent: support to call image-rs to handle image block device

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -297,25 +297,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
@@ -1118,7 +1099,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b0f9d16560f830ae6e90b769017333c4561d2c84f39e7aa7d935d2e7bcbc4c"
 dependencies = [
- "bindgen 0.63.0",
+ "bindgen",
  "nix 0.26.2",
 ]
 
@@ -1953,7 +1934,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=3d8192f8d3efab041916ea4d60e32248ac6ec43d#3d8192f8d3efab041916ea4d60e32248ac6ec43d"
+source = "git+https://github.com/confidential-containers/guest-components?rev=5df1101#5df1101ba325993bb230981fe1efdf8570b84505"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2414,11 +2395,10 @@ dependencies = [
 
 [[package]]
 name = "loopdev"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bfa0855b04611e38acaff718542e9e809cddfc16535d39f9d9c694ab19f7388"
+version = "0.5.0"
+source = "git+https://github.com/mdaffin/loopdev?rev=c9f91e8f0326ce8a3364ac911e81eb32328a5f27#c9f91e8f0326ce8a3364ac911e81eb32328a5f27"
 dependencies = [
- "bindgen 0.59.2",
+ "bindgen",
  "errno 0.2.8",
  "libc",
 ]
@@ -2857,7 +2837,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=3d8192f8d3efab041916ea4d60e32248ac6ec43d#3d8192f8d3efab041916ea4d60e32248ac6ec43d"
+source = "git+https://github.com/confidential-containers/guest-components?rev=5df1101#5df1101ba325993bb230981fe1efdf8570b84505"
 dependencies = [
  "aes 0.8.3",
  "anyhow",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -72,7 +72,7 @@ clap = { version = "3.0.1", features = ["derive"] }
 openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
-image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "3d8192f8d3efab041916ea4d60e32248ac6ec43d", default-features = false, features = ["kata-cc-native-tls"] }
+image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "5df1101", default-features = false, features = ["kata-cc-native-tls","verity"] }
 
 [patch.crates-io]
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -22,6 +22,7 @@ use crate::linux_abi::*;
 
 pub const TYPE_ROOTFS: &str = "rootfs";
 pub const VERITY_DEVICE_MOUNT_PATH: &str = "/run/kata-containers/verity";
+pub const VERITY_DEVICE_MOUNT_OPTION: &str = "io.katacontainers.fs-opt.dm-verity";
 
 #[derive(Debug, PartialEq)]
 pub struct InitMount<'a> {

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -21,6 +21,7 @@ use crate::device::online_device;
 use crate::linux_abi::*;
 
 pub const TYPE_ROOTFS: &str = "rootfs";
+pub const VERITY_DEVICE_MOUNT_PATH: &str = "/run/kata-containers/verity";
 
 #[derive(Debug, PartialEq)]
 pub struct InitMount<'a> {
@@ -127,6 +128,15 @@ pub fn is_mounted(mount_point: &str) -> Result<bool> {
     let mount_point = mount_point.trim_end_matches('/');
     let found = fs::metadata(mount_point).is_ok() && get_linux_mount_info(mount_point).is_ok();
     Ok(found)
+}
+
+/// get device path of a mount point in the /proc/mounts.
+#[instrument]
+pub fn get_device_path_from_mount_point(mount_point: &str) -> Result<String> {
+    let mount_point = mount_point.trim_end_matches('/');
+    let mount_info = get_linux_mount_info(mount_point)
+        .map_err(|e| anyhow!("can not get mount info {}: {}", mount_point, e))?;
+    Ok(mount_info.device)
 }
 
 #[instrument]

--- a/src/agent/src/storage/block_handler.rs
+++ b/src/agent/src/storage/block_handler.rs
@@ -11,7 +11,9 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
-use kata_types::mount::StorageDevice;
+use kata_sys_util::mount::get_device_mounted_count;
+use kata_types::mount::{KataVirtualVolume, StorageDevice};
+use nix::mount::MsFlags;
 use protocols::agent::Storage;
 use tracing::instrument;
 
@@ -19,6 +21,7 @@ use crate::device::{
     get_scsi_device_name, get_virtio_blk_pci_device_name, get_virtio_mmio_device_name,
     wait_for_pmem_device,
 };
+use crate::mount::{VERITY_DEVICE_MOUNT_OPTION, VERITY_DEVICE_MOUNT_PATH};
 use crate::pci;
 use crate::storage::{common_storage_handler, new_device, StorageContext, StorageHandler};
 #[cfg(target_arch = "s390x")]
@@ -69,6 +72,54 @@ impl StorageHandler for VirtioBlkPciHandler {
             let pcipath = pci::Path::from_str(&storage.source)?;
             let dev_path = get_virtio_blk_pci_device_name(ctx.sandbox, &pcipath).await?;
             storage.source = dev_path;
+        }
+        let options = storage.options();
+        if options.contains(&VERITY_DEVICE_MOUNT_OPTION.to_string()) {
+            let logger = ctx.logger;
+            let cid = ctx
+                .cid
+                .clone()
+                .ok_or_else(|| anyhow!("No container id in rw overlay"))?;
+            let virt_volume_base64 = options[0].clone();
+            let virt_volume: KataVirtualVolume =
+                KataVirtualVolume::from_base64(&virt_volume_base64)?;
+
+            let mount_path = format!("{}/{}/{}", VERITY_DEVICE_MOUNT_PATH, cid, "lowerdir");
+            let mount_type = storage.fstype();
+            if fs::metadata(&mount_path).is_err() {
+                fs::create_dir_all(&mount_path)
+                    .map_err(anyhow::Error::from)
+                    .context("Could not create mountpath")?;
+            }
+
+            let verity_info = virt_volume
+                .dm_verity
+                .ok_or_else(|| anyhow!("failed to get dm verity info"))?;
+            info!(
+                logger,
+                "virtio_blk_storage_handler verity_info = {:?}", verity_info
+            );
+            let verity_device_name = &verity_info.hash;
+            let count =
+                get_device_mounted_count(&format!("{}/{}", "/dev/mapper", verity_device_name))?;
+            if count > 0 {
+                nix::mount::mount(
+                    Some(format!("/dev/mapper/{}", verity_device_name).as_str()),
+                    mount_path.as_str(),
+                    Some(mount_type),
+                    MsFlags::MS_RDONLY,
+                    None::<&str>,
+                )?;
+            } else {
+                let info_json = serde_json::to_string(&verity_info)?;
+                image_rs::verity::mount_image_block_with_integrity(
+                    info_json.as_str(),
+                    Path::new(&storage.source),
+                    Path::new(&mount_path),
+                    mount_type,
+                )?;
+            }
+            return new_device(mount_path);
         }
 
         let path = common_storage_handler(ctx.logger, &storage)?;

--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -424,6 +424,8 @@ pub fn parse_mount_options<T: AsRef<str>>(options: &[T]) -> Result<(MsFlags, Str
             return Err(Error::InvalidMountOption("loop".to_string()));
         } else if let Some(v) = parse_mount_flags(flags, opt.as_ref()) {
             flags = v;
+        } else if opt.as_ref().starts_with("io.katacontainers.") {
+            continue;
         } else {
             data.push(opt.as_ref().to_string());
         }


### PR DESCRIPTION
To share image with integrity on the host with CoCo as described in https://github.com/confidential-containers/confidential-containers/issues/137, we need to manage verity devices in the kata-agent. We can reuse the Storages in the Sandbox to manage both mountpoints and verity devices and to support calling image-rs to handle image block device.  
 
Fixes:  https://github.com/kata-containers/kata-containers/issues/7583