### PR TITLE
Re-added hypervisor annotations

### DIFF
--- a/src/dragonball/Cargo.toml
+++ b/src/dragonball/Cargo.toml
@@ -27,7 +27,7 @@ kvm-bindings = "0.6.0"
 kvm-ioctls = "0.12.0"
 lazy_static = "1.2"
 libc = "0.2.39"
-linux-loader = "0.6.0"
+linux-loader = "0.8.0"
 log = "0.4.14"
 nix = "0.24.2"
 procfs = "0.12.0"
@@ -40,10 +40,10 @@ slog = "2.5.2"
 slog-scope = "4.4.0"
 thiserror = "1"
 vmm-sys-util = "0.11.0"
-virtio-queue = { version = "0.6.0", optional = true }
-vm-memory = { version = "0.9.0", features = ["backend-mmap"] }
+virtio-queue = { version = "0.7.0", optional = true }
+vm-memory = { version = "0.10.0", features = ["backend-mmap"] }
 crossbeam-channel = "0.5.6"
-fuse-backend-rs = "=0.10.4"
+fuse-backend-rs = "0.10.5"
 
 [dev-dependencies]
 slog-async = "2.7.0"

--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -358,7 +358,8 @@ impl VmmService {
             Some(ref path) => Some(File::open(path).map_err(|e| BootSource(InvalidInitrdPath(e)))?),
         };
 
-        let mut cmdline = linux_loader::cmdline::Cmdline::new(dbs_boot::layout::CMDLINE_MAX_SIZE);
+        let mut cmdline = linux_loader::cmdline::Cmdline::new(dbs_boot::layout::CMDLINE_MAX_SIZE)
+            .map_err(|err| BootSource(InvalidKernelCommandLine(err)))?;
         let boot_args = boot_source_config
             .boot_args
             .unwrap_or_else(|| String::from(DEFAULT_KERNEL_CMDLINE));

--- a/src/dragonball/src/dbs_address_space/Cargo.toml
+++ b/src/dragonball/src/dbs_address_space/Cargo.toml
@@ -17,4 +17,4 @@ nix = "0.23.1"
 lazy_static = "1"
 thiserror = "1"
 vmm-sys-util = "0.11.0"
-vm-memory = { version = "0.9", features = ["backend-mmap", "backend-atomic"] }
+vm-memory = { version = "0.10", features = ["backend-mmap", "backend-atomic"] }

--- a/src/dragonball/src/dbs_arch/Cargo.toml
+++ b/src/dragonball/src/dbs_arch/Cargo.toml
@@ -15,12 +15,12 @@ memoffset = "0.6"
 kvm-bindings = { version = "0.6.0", features = ["fam-wrappers"] }
 kvm-ioctls = "0.12.0"
 thiserror = "1"
-vm-memory = { version = "0.9" }
+vm-memory = { version = "0.10" }
 vmm-sys-util = "0.11.0"
 libc = ">=0.2.39"
 
 [dev-dependencies]
-vm-memory = { version = "0.9", features = ["backend-mmap"] }
+vm-memory = { version = "0.10", features = ["backend-mmap"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/dragonball/src/dbs_boot/Cargo.toml
+++ b/src/dragonball/src/dbs_boot/Cargo.toml
@@ -17,10 +17,10 @@ kvm-ioctls = "0.12.0"
 lazy_static = "1"
 libc = "0.2.39"
 thiserror = "1"
-vm-memory = "0.9.0"
+vm-memory = "0.10.0"
 vm-fdt = "0.2.0"
 
 [dev-dependencies]
-vm-memory = { version = "0.9.0", features = ["backend-mmap"] }
+vm-memory = { version = "0.10.0", features = ["backend-mmap"] }
 device_tree = ">=1.1.0"
 dbs-device = { path = "../dbs_device" }

--- a/src/dragonball/src/dbs_virtio_devices/Cargo.toml
+++ b/src/dragonball/src/dbs_virtio_devices/Cargo.toml
@@ -18,28 +18,28 @@ dbs-interrupt = { path = "../dbs_interrupt", features = ["kvm-legacy-irq", "kvm-
 dbs-utils = { path = "../dbs_utils" }
 epoll = ">=4.3.1, <4.3.2"
 io-uring = "0.5.2"
-fuse-backend-rs = { version = "0.10.0", optional = true }
+fuse-backend-rs = { version = "0.10.5", optional = true }
 kvm-bindings = "0.6.0"
 kvm-ioctls = "0.12.0"
 libc = "0.2.119"
 log = "0.4.14"
 nix = "0.24.3"
-nydus-api = "0.3.0"
-nydus-rafs = "0.3.1"
-nydus-storage = "0.6.3"
+nydus-api = "0.3.1"
+nydus-rafs = "0.3.2"
+nydus-storage = "0.6.4"
 rlimit = "0.7.0"
 serde = "1.0.27"
 serde_json = "1.0.9"
 thiserror = "1"
 threadpool = "1"
 virtio-bindings = "0.1.0"
-virtio-queue = "0.6.0"
+virtio-queue = "0.7.0"
 vmm-sys-util = "0.11.0"
-vm-memory = { version = "0.9.0", features = [ "backend-mmap" ] }
+vm-memory = { version = "0.10.0", features = [ "backend-mmap" ] }
 sendfd = "0.4.3"
 
 [dev-dependencies]
-vm-memory = { version = "0.9.0", features = [ "backend-mmap", "backend-atomic" ] }
+vm-memory = { version = "0.10.0", features = [ "backend-mmap", "backend-atomic" ] }
 
 [features]
 virtio-mmio = []

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -1195,7 +1195,7 @@ mod tests {
         let mut cmdline = crate::vm::KernelConfigInfo::new(
             kernel_file,
             None,
-            linux_loader::cmdline::Cmdline::new(0x1000),
+            linux_loader::cmdline::Cmdline::new(0x1000).unwrap(),
         );
 
         let address_space = vm.vm_address_space().cloned();

--- a/src/dragonball/src/test_utils.rs
+++ b/src/dragonball/src/test_utils.rs
@@ -17,7 +17,7 @@ pub mod tests {
         let epoll_manager = EpollManager::default();
         let mut vm = Vm::new(None, instance_info, epoll_manager).unwrap();
         let kernel_file = TempFile::new().unwrap();
-        let cmd_line = Cmdline::new(64);
+        let cmd_line = Cmdline::new(64).unwrap();
         vm.set_kernel_config(KernelConfigInfo::new(
             kernel_file.into_file(),
             None,

--- a/src/dragonball/src/vm/kernel_config.rs
+++ b/src/dragonball/src/vm/kernel_config.rs
@@ -62,7 +62,7 @@ mod tests {
     fn test_kernel_config_info() {
         let kernel = TempFile::new().unwrap();
         let initrd = TempFile::new().unwrap();
-        let mut cmdline = linux_loader::cmdline::Cmdline::new(1024);
+        let mut cmdline = linux_loader::cmdline::Cmdline::new(1024).unwrap();
         cmdline.insert_str("ro").unwrap();
         let mut info = KernelConfigInfo::new(kernel.into_file(), Some(initrd.into_file()), cmdline);
 

--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -1055,7 +1055,7 @@ pub mod tests {
         );
 
         let kernel_file = TempFile::new().unwrap();
-        let cmd_line = Cmdline::new(64);
+        let cmd_line = Cmdline::new(64).unwrap();
 
         vm.set_kernel_config(KernelConfigInfo::new(
             kernel_file.into_file(),

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -828,6 +828,7 @@ dependencies = [
  "dbs-upcall",
  "dbs-utils",
  "dbs-virtio-devices",
+ "fuse-backend-rs",
  "kvm-bindings",
  "kvm-ioctls",
  "lazy_static",
@@ -995,9 +996,9 @@ checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc24820b14267bec37fa87f5c2a32b5f1c5405b8c60cc3aa77afd481bd2628a6"
+checksum = "f85357722be4bf3d0b7548bedf7499686c77628c2c61cb99c6519463f7a9e5f0"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",
@@ -1008,10 +1009,9 @@ dependencies = [
  "log",
  "mio",
  "nix 0.24.3",
- "tokio-uring",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util 0.10.0",
+ "vmm-sys-util 0.11.1",
 ]
 
 [[package]]
@@ -1594,17 +1594,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
-name = "leaky-bucket"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e8b256cabb5f5c7affd490acbb12f951d725385971fa602dedb11e09c896b6d"
-dependencies = [
- "parking_lot 0.12.1",
- "tokio",
- "tracing",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1625,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "linux-loader"
-version = "0.6.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62a2f912deca034ec34b0a43a390059ea98daac40e440ebe8bea88f3315fe168"
+checksum = "b9259ddbfbb52cc918f6bbc60390004ddd0228cf1d85f402009ff2b3d95de83f"
 dependencies = [
  "vm-memory",
 ]
@@ -1938,11 +1927,10 @@ dependencies = [
 
 [[package]]
 name = "nydus-api"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33a6ca41dd10813e3d29397550fbb0f15ad149381f312e04659d39e0adcf2002"
+checksum = "c64c62d8a36c10b654b87246a39861b2c05f68e96ab3b2f002f5a54f406d5e0e"
 dependencies = [
- "backtrace",
  "libc",
  "log",
  "serde",
@@ -1952,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "nydus-rafs"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed21e44a99472850d2afc4fb07427ed46d4e6a8b1cce28b42bd689319e45076d"
+checksum = "adde865ef71c91c5f139c4c05ca5aedb6fbd53f530d646b13409ac5220b85467"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1974,16 +1962,15 @@ dependencies = [
 
 [[package]]
 name = "nydus-storage"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9591fbee1875895bf1f765656695d0be6887fe65372fbf4924b8b3959bd61375"
+checksum = "4023f15303dbbda47797d07e9acd2045862ce82c7e28cd66f70b09bda5584cbb"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",
  "fuse-backend-rs",
  "hex",
  "lazy_static",
- "leaky-bucket",
  "libc",
  "log",
  "nix 0.24.3",
@@ -1998,9 +1985,9 @@ dependencies = [
 
 [[package]]
 name = "nydus-utils"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8b9269e3a370682f272a1b2cac4bdaf6d6657f3f6966560c4fedab36548362"
+checksum = "c1f7bcde0f3906cf49101f2d40e485b0155eee97e3358eefd4783448c4f69c96"
 dependencies = [
  "blake3",
  "flate2",
@@ -2927,12 +2914,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3506,20 +3487,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-uring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5e02bb137e030b3a547c65a3bd2f1836d66a97369fdcc69034002b10e155ef"
-dependencies = [
- "io-uring",
- "libc",
- "scoped-tls",
- "slab",
- "socket2",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3828,14 +3795,14 @@ checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
 name = "virtio-queue"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435dd49c7b38419729afd43675850c7b5dc4728f2fabd70c7a9079a331e4f8c6"
+checksum = "3ba81e2bcc21c0d2fc5e6683e79367e26ad219197423a498df801d79d5ba77bd"
 dependencies = [
  "log",
  "virtio-bindings",
  "vm-memory",
- "vmm-sys-util 0.10.0",
+ "vmm-sys-util 0.11.1",
 ]
 
 [[package]]
@@ -3846,9 +3813,9 @@ checksum = "f43fb5a6bd1a7d423ad72802801036719b7546cf847a103f8fe4575f5b0d45a6"
 
 [[package]]
 name = "vm-memory"
-version = "0.9.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "583f213899e8a5eea23d9c507252d4bed5bc88f0ecbe0783262f80034630744b"
+checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
 dependencies = [
  "arc-swap",
  "libc",


### PR DESCRIPTION
- Add support for setting the sandbox name and namespace in the hypervisor config, which is needed in the remote hypervisor implementation to get the pod name and namespace for the remote pod create request
- Also cherry-pick in the nydus version bump to attempt to stop the dragonball errors

Fixes: #7588