### PR TITLE
tests: upgrade bats version

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -47,8 +47,14 @@ function create_cluster() {
 }
 
 function install_bats() {
-    sudo apt-get update
-    sudo apt-get -y install bats
+    # Installing bats from the lunar repo.
+    # This installs newer version of the bats which supports setup_file and teardown_file functions.
+    # These functions are helpful when adding new tests that require one time setup.
+
+    sudo apt install -y software-properties-common
+    sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ lunar universe'
+    sudo apt install -y bats
+    sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ lunar universe'
 }
 
 function install_kubectl() {


### PR DESCRIPTION
Instead of using package manager to install bats, building this from source. This gives us the updated version of bats which supports functions such as setup_file and
teardown_file.
We can use these functions into our current tests.

Fixes: #7597