### PR TITLE
Merging confidential kata tests to main - Part 1

### DIFF
--- a/tests/integration/kubernetes/k8s-attach-handlers.bats
+++ b/tests/integration/kubernetes/k8s-attach-handlers.bats
@@ -24,10 +24,7 @@ setup() {
 		"${pod_config_dir}/lifecycle-events.yaml" > "${pod_config_dir}/test-lifecycle-events.yaml"
 
 	# Create the pod with postStart and preStop handlers
-	kubectl create -f "${pod_config_dir}/test-lifecycle-events.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/test-lifecycle-events.yaml" "$pod_name"
 
 	# Check postStart message
 	display_message="cat /usr/share/message"

--- a/tests/integration/kubernetes/k8s-attach-handlers.bats
+++ b/tests/integration/kubernetes/k8s-attach-handlers.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	nginx_version="${docker_images_nginx_version}"
@@ -26,7 +27,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/test-lifecycle-events.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check postStart message
 	display_message="cat /usr/share/message"

--- a/tests/integration/kubernetes/k8s-caps.bats
+++ b/tests/integration/kubernetes/k8s-caps.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
         pod_name="pod-caps"
@@ -31,7 +32,7 @@ setup() {
         # Create pod
         kubectl create -f "${pod_config_dir}/pod-caps.yaml"
         # Check pod creation
-        kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+        wait_pod_to_be_ready "$pod_name"
 
         # Verify expected capabilities for the running container. Add retry to ensure
         # that the container had time to execute:

--- a/tests/integration/kubernetes/k8s-caps.bats
+++ b/tests/integration/kubernetes/k8s-caps.bats
@@ -30,9 +30,7 @@ setup() {
 
 @test "Check capabilities of pod" {
         # Create pod
-        kubectl create -f "${pod_config_dir}/pod-caps.yaml"
-        # Check pod creation
-        wait_pod_to_be_ready "$pod_name"
+        create_pod_and_wait "${pod_config_dir}/pod-caps.yaml" "$pod_name"
 
         # Verify expected capabilities for the running container. Add retry to ensure
         # that the container had time to execute:

--- a/tests/integration/kubernetes/k8s-configmap.bats
+++ b/tests/integration/kubernetes/k8s-configmap.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	get_pod_config_dir
@@ -26,7 +27,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-configmap.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check env
 	cmd="env"

--- a/tests/integration/kubernetes/k8s-configmap.bats
+++ b/tests/integration/kubernetes/k8s-configmap.bats
@@ -24,10 +24,7 @@ setup() {
 	kubectl get configmaps $config_name -o yaml | grep -q "data-"
 
 	# Create a pod that consumes the ConfigMap
-	kubectl create -f "${pod_config_dir}/pod-configmap.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-configmap.yaml" "$pod_name"
 
 	# Check env
 	cmd="env"

--- a/tests/integration/kubernetes/k8s-copy-file.bats
+++ b/tests/integration/kubernetes/k8s-copy-file.bats
@@ -50,10 +50,7 @@ setup() {
 	sed -i "s/POD_NAME/$pod_name/" "$pod_config"
 	sed -i "s/CTR_NAME/$ctr_name/" "$pod_config"
 
-	kubectl create -f "${pod_config}"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config}" "$pod_name"
 
 	kubectl logs "$pod_name" || true
 	kubectl describe pod "$pod_name" || true

--- a/tests/integration/kubernetes/k8s-copy-file.bats
+++ b/tests/integration/kubernetes/k8s-copy-file.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	get_pod_config_dir
@@ -27,7 +28,7 @@ setup() {
 	kubectl create -f "${pod_config}"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+	wait_pod_to_be_ready "$pod_name"
 
 	# Create a file
 	echo "$content" > "$file_name"
@@ -52,7 +53,7 @@ setup() {
 	kubectl create -f "${pod_config}"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+	wait_pod_to_be_ready "$pod_name"
 
 	kubectl logs "$pod_name" || true
 	kubectl describe pod "$pod_name" || true

--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
@@ -38,7 +39,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-cpu.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	retries="10"
 

--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -36,10 +36,7 @@ setup() {
 
 
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/pod-cpu.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-cpu.yaml" "$pod_name"
 
 	retries="10"
 

--- a/tests/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/tests/integration/kubernetes/k8s-credentials-secrets.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
@@ -31,7 +32,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-secret.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# List the files
 	cmd="ls /tmp/secret-volume"
@@ -42,7 +43,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-secret-env.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$second_pod_name"
+	wait_pod_to_be_ready "$second_pod_name"
 
 	# Display environment variables
 	second_cmd="printenv"

--- a/tests/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/tests/integration/kubernetes/k8s-credentials-secrets.bats
@@ -29,10 +29,7 @@ setup() {
 	kubectl get secret "${secret_name}" -o yaml | grep "type: Opaque"
 
 	# Create a pod that has access to the secret through a volume
-	kubectl create -f "${pod_config_dir}/pod-secret.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-secret.yaml" "$pod_name"
 
 	# List the files
 	cmd="ls /tmp/secret-volume"
@@ -40,10 +37,7 @@ setup() {
 	kubectl exec $pod_name -- sh -c "$cmd" | grep -w "username"
 
 	# Create a pod that has access to the secret data through environment variables
-	kubectl create -f "${pod_config_dir}/pod-secret-env.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$second_pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-secret-env.yaml" "$second_pod_name"
 
 	# Display environment variables
 	second_cmd="printenv"

--- a/tests/integration/kubernetes/k8s-custom-dns.bats
+++ b/tests/integration/kubernetes/k8s-custom-dns.bats
@@ -17,10 +17,7 @@ setup() {
 
 @test "Check custom dns" {
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/pod-custom-dns.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-custom-dns.yaml" "$pod_name"
 
 	# Check dns config at /etc/resolv.conf
 	kubectl exec "$pod_name" -- cat "$file_name" | grep -q "nameserver 1.2.3.4"

--- a/tests/integration/kubernetes/k8s-custom-dns.bats
+++ b/tests/integration/kubernetes/k8s-custom-dns.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	pod_name="custom-dns-test"
@@ -19,7 +20,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-custom-dns.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check dns config at /etc/resolv.conf
 	kubectl exec "$pod_name" -- cat "$file_name" | grep -q "nameserver 1.2.3.4"

--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 assert_equal() {
 	local expected=$1
@@ -28,7 +29,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-empty-dir.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check volume mounts
 	cmd="mount | grep cache"

--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -26,10 +26,7 @@ setup() {
 
 @test "Empty dir volumes" {
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/pod-empty-dir.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-empty-dir.yaml" "$pod_name"
 
 	# Check volume mounts
 	cmd="mount | grep cache"

--- a/tests/integration/kubernetes/k8s-env.bats
+++ b/tests/integration/kubernetes/k8s-env.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	pod_name="test-env"
@@ -18,7 +19,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-env.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Print environment variables
 	cmd="printenv"

--- a/tests/integration/kubernetes/k8s-env.bats
+++ b/tests/integration/kubernetes/k8s-env.bats
@@ -16,10 +16,7 @@ setup() {
 
 @test "Environment variables" {
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-env.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-env.yaml" "$pod_name"
 
 	# Print environment variables
 	cmd="printenv"

--- a/tests/integration/kubernetes/k8s-exec.bats
+++ b/tests/integration/kubernetes/k8s-exec.bats
@@ -18,10 +18,7 @@ setup() {
 
 @test "Kubectl exec" {
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
-
-	# Get pod specification
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/busybox-pod.yaml" "$pod_name"
 
 	# Run commands in Pod
 	## Cases for -it options

--- a/tests/integration/kubernetes/k8s-exec.bats
+++ b/tests/integration/kubernetes/k8s-exec.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	get_pod_config_dir
@@ -20,7 +21,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
 
 	# Get pod specification
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Run commands in Pod
 	## Cases for -it options

--- a/tests/integration/kubernetes/k8s-file-volume.bats
+++ b/tests/integration/kubernetes/k8s-file-volume.bats
@@ -30,10 +30,7 @@ setup() {
 	sed -i "s|MOUNT_PATH|$mount_path|" ${pod_config_dir}/test-pod-file-volume.yaml
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/test-pod-file-volume.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/test-pod-file-volume.yaml" "$pod_name"
 
 	# Validate file volume body inside the pod
 	file_in_container=$(kubectl exec $pod_name -- cat $mount_path)

--- a/tests/integration/kubernetes/k8s-file-volume.bats
+++ b/tests/integration/kubernetes/k8s-file-volume.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 TEST_INITRD="${TEST_INITRD:-no}"
 
 setup() {
@@ -32,7 +33,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/test-pod-file-volume.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Validate file volume body inside the pod
 	file_in_container=$(kubectl exec $pod_name -- cat $mount_path)

--- a/tests/integration/kubernetes/k8s-footloose.bats
+++ b/tests/integration/kubernetes/k8s-footloose.bats
@@ -34,10 +34,7 @@ setup() {
 	kubectl create -f "$configmap_yaml"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-footloose.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-footloose.yaml" "$pod_name"
 
 	# Get pod ip
 	pod_ip=$(kubectl get pod $pod_name --template={{.status.podIP}})

--- a/tests/integration/kubernetes/k8s-footloose.bats
+++ b/tests/integration/kubernetes/k8s-footloose.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	pod_name="footubuntu"
@@ -36,7 +37,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-footloose.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Get pod ip
 	pod_ip=$(kubectl get pod $pod_name --template={{.status.podIP}})

--- a/tests/integration/kubernetes/k8s-inotify.bats
+++ b/tests/integration/kubernetes/k8s-inotify.bats
@@ -21,8 +21,7 @@ setup() {
         kubectl apply -f "${pod_config_dir}"/inotify-configmap.yaml
 
         # Create deployment that expects identity-certs
-        kubectl apply -f "${pod_config_dir}"/inotify-configmap-pod.yaml
-        wait_pod_to_be_ready "$pod_name"
+        create_pod_and_wait "${pod_config_dir}"/inotify-configmap-pod.yaml "$pod_name"
 
         # Update configmap
         kubectl apply -f "${pod_config_dir}"/inotify-updated-configmap.yaml

--- a/tests/integration/kubernetes/k8s-inotify.bats
+++ b/tests/integration/kubernetes/k8s-inotify.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
@@ -21,7 +22,7 @@ setup() {
 
         # Create deployment that expects identity-certs
         kubectl apply -f "${pod_config_dir}"/inotify-configmap-pod.yaml
-        kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+        wait_pod_to_be_ready "$pod_name"
 
         # Update configmap
         kubectl apply -f "${pod_config_dir}"/inotify-updated-configmap.yaml

--- a/tests/integration/kubernetes/k8s-job.bats
+++ b/tests/integration/kubernetes/k8s-job.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	get_pod_config_dir

--- a/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
+++ b/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	pod_name="busybox"
@@ -20,7 +21,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/initcontainer-shareprocesspid.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check PID from first container
 	first_pid_container=$(kubectl exec $pod_name -c $first_container_name \

--- a/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
+++ b/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
@@ -18,10 +18,7 @@ setup() {
 
 @test "Check PID namespaces" {
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/initcontainer-shareprocesspid.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/initcontainer-shareprocesspid.yaml" "$pod_name"
 
 	# Check PID from first container
 	first_pid_container=$(kubectl exec $pod_name -c $first_container_name \

--- a/tests/integration/kubernetes/k8s-limit-range.bats
+++ b/tests/integration/kubernetes/k8s-limit-range.bats
@@ -25,7 +25,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-cpu-defaults.yaml" --namespace=${namespace_name}
 
 	# Get pod specification
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name" --namespace="$namespace_name"
+	kubectl wait --for=condition=Ready --timeout=90s pod "$pod_name" --namespace="$namespace_name"
 
 	# Check limits
 	# Find the 500 millicpus specified at the yaml

--- a/tests/integration/kubernetes/k8s-liveness-probes.bats
+++ b/tests/integration/kubernetes/k8s-liveness-probes.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	sleep_liveness=20
@@ -23,7 +24,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-liveness.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check liveness probe returns a success code
 	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
@@ -42,7 +43,7 @@ setup() {
 		kubectl create -f -
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check liveness probe returns a success code
 	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"
@@ -62,7 +63,7 @@ setup() {
 		kubectl create -f -
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check liveness probe returns a success code
 	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"

--- a/tests/integration/kubernetes/k8s-liveness-probes.bats
+++ b/tests/integration/kubernetes/k8s-liveness-probes.bats
@@ -21,10 +21,7 @@ setup() {
 	pod_name="liveness-exec"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-liveness.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-liveness.yaml" "$pod_name"
 
 	# Check liveness probe returns a success code
 	kubectl describe pod "$pod_name" | grep -E "Liveness|#success=1"

--- a/tests/integration/kubernetes/k8s-memory.bats
+++ b/tests/integration/kubernetes/k8s-memory.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	pod_name="memory-test"
@@ -44,7 +45,7 @@ setup_yaml() {
 	kubectl create -f "${pod_config_dir}/test_within_memory.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	rm -f "${pod_config_dir}/test_within_memory.yaml"
 	kubectl delete pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-memory.bats
+++ b/tests/integration/kubernetes/k8s-memory.bats
@@ -42,10 +42,7 @@ setup_yaml() {
 	setup_yaml > "${pod_config_dir}/test_within_memory.yaml"
 
 	# Create the pod within memory constraints
-	kubectl create -f "${pod_config_dir}/test_within_memory.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/test_within_memory.yaml" "$pod_name"
 
 	rm -f "${pod_config_dir}/test_within_memory.yaml"
 	kubectl delete pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-nested-configmap-secret.bats
+++ b/tests/integration/kubernetes/k8s-nested-configmap-secret.bats
@@ -19,10 +19,7 @@ setup() {
 
 @test "Nested mount of a secret volume in a configmap volume for a pod" {
 	# Creates a configmap, secret and pod that mounts the secret inside the configmap
-	kubectl create -f "${pod_config_dir}/pod-nested-configmap-secret.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-nested-configmap-secret.yaml" "$pod_name"
 
 	# Check config/secret value are correct
 	[ "myconfig" == $(kubectl exec $pod_name -- cat /config/config_key) ]

--- a/tests/integration/kubernetes/k8s-nested-configmap-secret.bats
+++ b/tests/integration/kubernetes/k8s-nested-configmap-secret.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
@@ -21,7 +22,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-nested-configmap-secret.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check config/secret value are correct
 	[ "myconfig" == $(kubectl exec $pod_name -- cat /config/config_key) ]

--- a/tests/integration/kubernetes/k8s-nginx-connectivity.bats
+++ b/tests/integration/kubernetes/k8s-nginx-connectivity.bats
@@ -24,7 +24,7 @@ setup() {
 		"${pod_config_dir}/${deployment}.yaml" > "${pod_config_dir}/test-${deployment}.yaml"
 
 	kubectl create -f "${pod_config_dir}/test-${deployment}.yaml"
-	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment}
+	kubectl wait --for=condition=Available --timeout=90s deployment/${deployment}
 	kubectl expose deployment/${deployment}
 
 	busybox_pod="test-nginx"

--- a/tests/integration/kubernetes/k8s-number-cpus.bats
+++ b/tests/integration/kubernetes/k8s-number-cpus.bats
@@ -18,10 +18,7 @@ setup() {
 # Skip on aarch64 due to missing cpu hotplug related functionality.
 @test "Check number of cpus" {
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-number-cpu.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-number-cpu.yaml" "$pod_name"
 
 	retries="10"
 	max_number_cpus="3"

--- a/tests/integration/kubernetes/k8s-number-cpus.bats
+++ b/tests/integration/kubernetes/k8s-number-cpus.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	pod_name="cpu-test"
@@ -20,7 +21,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-number-cpu.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	retries="10"
 	max_number_cpus="3"

--- a/tests/integration/kubernetes/k8s-oom.bats
+++ b/tests/integration/kubernetes/k8s-oom.bats
@@ -16,10 +16,7 @@ setup() {
 
 @test "Test OOM events for pods" {
 	# Create pod
-	kubectl create -f "${pod_config_dir}/$pod_name.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/$pod_name.yaml" "$pod_name"
 
 	# Check if OOMKilled
 	cmd="kubectl get pods "$pod_name" -o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' | grep OOMKilled"

--- a/tests/integration/kubernetes/k8s-oom.bats
+++ b/tests/integration/kubernetes/k8s-oom.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	pod_name="pod-oom"
@@ -18,7 +19,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/$pod_name.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check if OOMKilled
 	cmd="kubectl get pods "$pod_name" -o jsonpath='{.status.containerStatuses[0].state.terminated.reason}' | grep OOMKilled"

--- a/tests/integration/kubernetes/k8s-optional-empty-configmap.bats
+++ b/tests/integration/kubernetes/k8s-optional-empty-configmap.bats
@@ -21,10 +21,7 @@ setup() {
 	kubectl create configmap "$config_name"
 
 	# Create a pod that consumes the "empty-config" and "optional-missing-config" ConfigMaps as volumes
-	kubectl create -f "${pod_config_dir}/pod-optional-empty-configmap.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-optional-empty-configmap.yaml" "$pod_name"
 
 	# Check configmap folders exist
 	kubectl exec $pod_name -- sh -c ls /empty-config

--- a/tests/integration/kubernetes/k8s-optional-empty-configmap.bats
+++ b/tests/integration/kubernetes/k8s-optional-empty-configmap.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	get_pod_config_dir
@@ -23,7 +24,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-optional-empty-configmap.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check configmap folders exist
 	kubectl exec $pod_name -- sh -c ls /empty-config

--- a/tests/integration/kubernetes/k8s-optional-empty-secret.bats
+++ b/tests/integration/kubernetes/k8s-optional-empty-secret.bats
@@ -21,10 +21,7 @@ setup() {
 	kubectl create secret generic "$secret_name"
 
 	# Create a pod that consumes the "empty-secret" and "optional-missing-secret" Secrets as volumes
-	kubectl create -f "${pod_config_dir}/pod-optional-empty-secret.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-optional-empty-secret.yaml" "$pod_name"
 
 	# Check secret folders exist
 	kubectl exec $pod_name -- sh -c ls /empty-secret

--- a/tests/integration/kubernetes/k8s-optional-empty-secret.bats
+++ b/tests/integration/kubernetes/k8s-optional-empty-secret.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	get_pod_config_dir
@@ -23,7 +24,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-optional-empty-secret.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check secret folders exist
 	kubectl exec $pod_name -- sh -c ls /empty-secret

--- a/tests/integration/kubernetes/k8s-parallel.bats
+++ b/tests/integration/kubernetes/k8s-parallel.bats
@@ -29,7 +29,7 @@ setup() {
 	kubectl get jobs -l jobgroup=${job_name}
 
 	# Check the pods
-	kubectl wait --for=condition=Ready --timeout=$timeout pod -l jobgroup=${job_name}
+	kubectl wait --for=condition=Ready --timeout=90s pod -l jobgroup=${job_name}
 
 	# Check output of the jobs
 	for i in $(kubectl get pods -l jobgroup=${job_name} -o name); do

--- a/tests/integration/kubernetes/k8s-pid-ns.bats
+++ b/tests/integration/kubernetes/k8s-pid-ns.bats
@@ -19,10 +19,7 @@ setup() {
 
 @test "Check PID namespaces" {
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/busybox-pod.yaml" "$pod_name"
 
 	# Check PID from first container
 	first_pid_container=$(kubectl exec $pod_name -c $first_container_name \

--- a/tests/integration/kubernetes/k8s-pid-ns.bats
+++ b/tests/integration/kubernetes/k8s-pid-ns.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	pod_name="busybox"
@@ -21,7 +22,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check PID from first container
 	first_pid_container=$(kubectl exec $pod_name -c $first_container_name \

--- a/tests/integration/kubernetes/k8s-pod-quota.bats
+++ b/tests/integration/kubernetes/k8s-pod-quota.bats
@@ -26,7 +26,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-quota-deployment.yaml"
 
 	# View deployment
-	kubectl wait --for=condition=Available --timeout=$timeout \
+	kubectl wait --for=condition=Available --timeout=90s \
 		deployment/${deployment_name}
 }
 

--- a/tests/integration/kubernetes/k8s-port-forward.bats
+++ b/tests/integration/kubernetes/k8s-port-forward.bats
@@ -6,6 +6,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 source "/etc/os-release" || source "/usr/lib/os-release"
 
 issue="https://github.com/kata-containers/runtime/issues/1834"
@@ -23,12 +24,12 @@ setup() {
 	kubectl apply -f "${pod_config_dir}/redis-master-deployment.yaml"
 
 	# Check deployment
-	kubectl wait --for=condition=Available --timeout=$timeout deployment/"$deployment_name"
+	kubectl wait --for=condition=Available --timeout=90s deployment/"$deployment_name"
 	kubectl expose deployment/"$deployment_name"
 
 	# Get pod name
 	pod_name=$(kubectl get pods --output=jsonpath={.items..metadata.name})
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# View replicaset
 	kubectl get rs

--- a/tests/integration/kubernetes/k8s-projected-volume.bats
+++ b/tests/integration/kubernetes/k8s-projected-volume.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
@@ -36,7 +37,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-projected-volume.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check that the projected sources exists
 	cmd="ls /projected-volume | grep username"

--- a/tests/integration/kubernetes/k8s-projected-volume.bats
+++ b/tests/integration/kubernetes/k8s-projected-volume.bats
@@ -34,10 +34,7 @@ setup() {
 	kubectl create secret generic pass --from-file=$SECOND_TMP_FILE
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-projected-volume.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-projected-volume.yaml" "$pod_name"
 
 	# Check that the projected sources exists
 	cmd="ls /projected-volume | grep username"

--- a/tests/integration/kubernetes/k8s-qos-pods.bats
+++ b/tests/integration/kubernetes/k8s-qos-pods.bats
@@ -19,10 +19,7 @@ setup() {
 	pod_name="qos-test"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-guaranteed.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-guaranteed.yaml" "$pod_name"
 
 	# Check pod class
 	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: Guaranteed"

--- a/tests/integration/kubernetes/k8s-qos-pods.bats
+++ b/tests/integration/kubernetes/k8s-qos-pods.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 TEST_INITRD="${TEST_INITRD:-no}"
 
 # Not working on ARM CI see https://github.com/kata-containers/tests/issues/4727  
@@ -21,7 +22,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-guaranteed.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check pod class
 	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: Guaranteed"
@@ -34,7 +35,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-burstable.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check pod class
 	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: Burstable"
@@ -47,7 +48,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-besteffort.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check pod class
 	kubectl get pod "$pod_name" --output=yaml | grep "qosClass: BestEffort"

--- a/tests/integration/kubernetes/k8s-replication.bats
+++ b/tests/integration/kubernetes/k8s-replication.bats
@@ -48,7 +48,7 @@ setup() {
 
 	# Check pod creation
 	for pod_name in ${launched_pods[@]}; do
-		cmd="kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name"
+		cmd="kubectl wait --for=condition=Ready --timeout=90s pod $pod_name"
 		waitForProcess "$wait_time" "$sleep_time" "$cmd"
 	done
 }

--- a/tests/integration/kubernetes/k8s-scale-nginx.bats
+++ b/tests/integration/kubernetes/k8s-scale-nginx.bats
@@ -22,7 +22,7 @@ setup() {
 		"${pod_config_dir}/${deployment}.yaml" > "${pod_config_dir}/test-${deployment}.yaml"
 
 	kubectl create -f "${pod_config_dir}/test-${deployment}.yaml"
-	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment}
+	kubectl wait --for=condition=Available --timeout=90s deployment/${deployment}
 	kubectl expose deployment/${deployment}
 	kubectl scale deployment/${deployment} --replicas=${replicas}
 	cmd="kubectl get deployment/${deployment} -o yaml | grep 'availableReplicas: ${replicas}'"

--- a/tests/integration/kubernetes/k8s-security-context.bats
+++ b/tests/integration/kubernetes/k8s-security-context.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	get_pod_config_dir
@@ -19,7 +20,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-security-context.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check user
 	cmd="ps --user 1000 -f"

--- a/tests/integration/kubernetes/k8s-security-context.bats
+++ b/tests/integration/kubernetes/k8s-security-context.bats
@@ -17,10 +17,7 @@ setup() {
 	pod_name="security-context-test"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-security-context.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-security-context.yaml" "$pod_name"
 
 	# Check user
 	cmd="ps --user 1000 -f"

--- a/tests/integration/kubernetes/k8s-shared-volume.bats
+++ b/tests/integration/kubernetes/k8s-shared-volume.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	get_pod_config_dir
@@ -21,7 +22,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-shared-volume.yaml"
 
 	# Check pods
-	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+	wait_pod_to_be_ready "$pod_name"
 
 	# Communicate containers
 	cmd="cat /tmp/pod-data"
@@ -37,7 +38,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/initContainer-shared-volume.yaml"
 
 	# Check pods
-	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+	wait_pod_to_be_ready "$pod_name"
 
 	cmd='test $(cat /volume/initContainer) -lt $(cat /volume/container)'
 	kubectl exec "$pod_name" -c "$last_container" -- sh -c "$cmd"

--- a/tests/integration/kubernetes/k8s-shared-volume.bats
+++ b/tests/integration/kubernetes/k8s-shared-volume.bats
@@ -19,10 +19,7 @@ setup() {
 	second_container_name="busybox-second-container"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-shared-volume.yaml"
-
-	# Check pods
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-shared-volume.yaml" "$pod_name"
 
 	# Communicate containers
 	cmd="cat /tmp/pod-data"
@@ -35,10 +32,7 @@ setup() {
 	last_container="last"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/initContainer-shared-volume.yaml"
-
-	# Check pods
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/initContainer-shared-volume.yaml" "$pod_name"
 
 	cmd='test $(cat /volume/initContainer) -lt $(cat /volume/container)'
 	kubectl exec "$pod_name" -c "$last_container" -- sh -c "$cmd"

--- a/tests/integration/kubernetes/k8s-sysctls.bats
+++ b/tests/integration/kubernetes/k8s-sysctls.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	pod_name="sysctl-test"
@@ -18,7 +19,7 @@ setup() {
 	kubectl apply -f "${pod_config_dir}/pod-sysctl.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
+	wait_pod_to_be_ready "$pod_name"
 
 	# Check sysctl configuration
 	cmd="cat /proc/sys/kernel/shm_rmid_forced"

--- a/tests/integration/kubernetes/k8s-sysctls.bats
+++ b/tests/integration/kubernetes/k8s-sysctls.bats
@@ -16,10 +16,7 @@ setup() {
 
 @test "Setting sysctl" {
 	# Create pod
-	kubectl apply -f "${pod_config_dir}/pod-sysctl.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pod-sysctl.yaml" "$pod_name"
 
 	# Check sysctl configuration
 	cmd="cat /proc/sys/kernel/shm_rmid_forced"

--- a/tests/integration/kubernetes/k8s-volume.bats
+++ b/tests/integration/kubernetes/k8s-volume.bats
@@ -45,10 +45,7 @@ setup() {
 	waitForProcess "$wait_time" "$sleep_time" "$cmd"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pv-pod.yaml"
-
-	# Check pod creation
-	wait_pod_to_be_ready "$pod_name"
+	create_pod_and_wait "${pod_config_dir}/pv-pod.yaml" "$pod_name"
 
 	cmd="cat /mnt/index.html"
 	kubectl exec $pod_name -- sh -c "$cmd" | grep "$msg"

--- a/tests/integration/kubernetes/k8s-volume.bats
+++ b/tests/integration/kubernetes/k8s-volume.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 TEST_INITRD="${TEST_INITRD:-no}"
 
 setup() {
@@ -47,7 +48,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pv-pod.yaml"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	wait_pod_to_be_ready "$pod_name"
 
 	cmd="cat /mnt/index.html"
 	kubectl exec $pod_name -- sh -c "$cmd" | grep "$msg"

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Copyright (c) 2021, 2022 IBM Corporation
+# Copyright (c) 2022, 2023 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# This provides generic functions to use in the tests.
+#
+
+# Wait until the pod is not 'Ready'. Fail if it hits the timeout.
+#
+# Parameters:
+#	$1 - the pod name
+#	$2 - wait time in seconds. Defaults to 90. (optional)
+#
+wait_pod_to_be_ready() {
+	local pod_name="$1"
+	local wait_time="${2:-90}"
+
+	kubectl wait --timeout="${wait_time}s" --for=condition=ready "pods/$pod_name"
+}

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -19,10 +19,6 @@ export container_images_agnhost_version="2.21"
 wait_time=90
 sleep_time=3
 
-# Timeout for use with `kubectl wait`, unless it needs to wait longer.
-# Note: try to keep timeout and wait_time equal.
-timeout=90s
-
 # issues that can't test yet.
 fc_limitations="https://github.com/kata-containers/documentation/issues/351"
 dragonball_limitations="https://github.com/kata-containers/kata-containers/issues/6621"


### PR DESCRIPTION
I'm starting the CCv0 -> main merging of the tests. In this first PR I am looking for utilities functions that were introduced on CCv0`s tests that can be re-used on` main`.