### PR TITLE
metrics: Add network nginx benchmark

### DIFF
--- a/tests/metrics/network/README.md
+++ b/tests/metrics/network/README.md
@@ -11,6 +11,7 @@ bandwidth, jitter, latency and parallel bandwidth.
 
 - `k8s-network-metrics-iperf3.sh` measures bandwidth which is the speed of the data transfer.
 - `latency-network.sh` measures network latency.
+- `nginx-network.sh` is a benchmark of the lightweight Nginx HTTPS web-server and measures the HTTP requests over a fixed period of time with a configurable number of concurrent clients/connections.
 
 ## Running the tests
 

--- a/tests/metrics/network/nginx_kubernetes/nginx-network.sh
+++ b/tests/metrics/network/nginx_kubernetes/nginx-network.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o pipefail
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+
+source "${SCRIPT_PATH}/../../lib/common.bash"
+nginx_file=$(mktemp nginxresults.XXXXXXXXXX)
+TEST_NAME="${TEST_NAME:-nginx}"
+
+function remove_tmp_file() {
+	rm -rf "${nginx_file}"
+}
+
+trap remove_tmp_file EXIT
+
+function main() {
+	init_env
+	cmds=("bc" "jq" "ab")
+	check_cmds "${cmds[@]}"
+
+	# Check no processes are left behind
+	check_processes
+
+	wait_time=20
+	sleep_time=2
+	timeout="20s"
+
+	deployment="nginx-deployment"
+	kubectl create -f "${SCRIPT_PATH}/runtimeclass_workloads/nginx-networking.yaml"
+	kubectl wait --for=condition=Available --timeout="${timeout}" deployment/"${deployment}"
+	kubectl expose deployment/"${deployment}"
+	ip=$(kubectl get service/nginx-deployment -o jsonpath='{.spec.clusterIP}')
+
+	ab -n 100000 -c 100 http://"${ip}":80/ > "${nginx_file}"
+	metrics_json_init
+ 	rps=$(cat "${nginx_file}" | grep "Requests" | awk '{print $4}')
+	echo "Requests per second: ${rps}"
+
+	metrics_json_start_array
+
+	local json="$(cat << EOF
+	{
+		"requests": {
+			"Result" : ${rps},
+			"Units": "rps"
+		}
+	}
+EOF
+)"
+
+	metrics_json_add_array_element "$json"
+	metrics_json_end_array "Results"
+	metrics_json_save
+
+	nginx_cleanup
+}
+
+function nginx_cleanup() {
+	kubectl delete deployment "${deployment}"
+	kubectl delete service "${deployment}"
+	check_processes
+}
+
+main "$@"

--- a/tests/metrics/network/nginx_kubernetes/runtimeclass_workloads/nginx-networking.yaml
+++ b/tests/metrics/network/nginx_kubernetes/runtimeclass_workloads/nginx-networking.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx-deployment
+spec:
+  selector:
+    matchLabels:
+      app: nginx
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      terminationGracePeriodSeconds: 0
+      runtimeClassName: kata
+      containers:
+      - name: nginx
+        image: nginx:1.14.2
+        ports:
+        - containerPort: 80


### PR DESCRIPTION
This PR adds the network nginx benchmark for kata metrics.

Fixes #7605