### PR TITLE
ci: create-confidential-image: Add dependent actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -33,6 +33,17 @@ jobs:
   build-and-publish-tee-confidential-unencrypted-image:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commit-hash }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Login to Kata Containers ghcr.io
         uses: docker/login-action@v2
         with:
@@ -40,13 +51,8 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ inputs.commit-hash }}
-
       - name: Docker build and push
-        uses: docker/build-and-push-action@v3
+        uses: docker/build-push-action@v4
         with:
           tags: ghcr.io/kata-containers/test-images:unencrypted-${{ inputs.pr-number }}
           push: true


### PR DESCRIPTION
Following the example on https://github.com/docker/build-push-action, it's clear that the actions to "Set up QEMU" and "Set up Docker Buildx" are missing.

Let's add them, and also take the advantage to bump the build-push-action to its v4, which, by the way, had a typo on its name (build-and-push-action does **NOT** exist, build-push-action does).

Fixes: #7595