### PR TITLE
ci: unencrypted-image: Fix build context

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -56,7 +56,7 @@ jobs:
         with:
           tags: ghcr.io/kata-containers/test-images:unencrypted-${{ inputs.pr-number }}
           push: true
-          context: .
+          context: tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/
           platforms: linux/amd64, linux/s390x
           file: tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
 

--- a/tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
+++ b/tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
@@ -19,7 +19,7 @@ RUN /bin/sh -c \
     curl -LO https://github.com/klauspost/cpuid/releases/download/v2.2.5/cpuid-Linux_x86_64_2.2.5.tar.gz && \
     tar -xvzf cpuid-Linux_x86_64_2.2.5.tar.gz  -C /usr/bin && \
     rm -rf cpuid-Linux_x86_64_2.2.5.tar.gz && \
-    rm -f /usr/bin/LICENSE'
+    rm -f /usr/bin/LICENSE' || true
 
 # This is done just to avoid the following error starting sshd
 # `sshd: no hostkeys available -- exiting.`


### PR DESCRIPTION
The build context should be the folder where the Dockerfile is present,
otherwise the files copied into the image won't be found.

Fixes: #7595