### PR TITLE
ci: k8s: adapt gha-run.sh to run locally

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -151,6 +151,11 @@ function deploy_kata() {
 }
 
 function run_tests() {
+    platform="${1:-}"
+
+    [ "$platform" = "kcli" ] && \
+        export KUBECONFIG="$HOME/.kcli/clusters/${CLUSTER_NAME:-kata-k8s}/auth/kubeconfig"
+
     # Delete any spurious tests namespace that was left behind
     kubectl delete namespace kata-containers-k8s-tests &> /dev/null || true
 
@@ -238,6 +243,7 @@ function main() {
         deploy-kata-tdx) deploy_kata "tdx" ;;
         deploy-kata-garm) deploy_kata "garm" ;;
         run-tests) run_tests ;;
+        run-tests-kcli) run_tests "kcli" ;;
         cleanup-kcli) cleanup "kcli" ;;
         cleanup-sev) cleanup "sev" ;;
         cleanup-snp) cleanup "snp" ;;

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -166,6 +166,9 @@ function cleanup() {
     test_type="${2:-k8s}"
     ensure_yq
 
+    [ "$platform" = "kcli" ] && \
+        export KUBECONFIG="$HOME/.kcli/clusters/${CLUSTER_NAME:-kata-k8s}/auth/kubeconfig"
+
     echo "Gather information about the nodes and pods before cleaning up the node"
     get_nodes_and_pods_info
 
@@ -231,6 +234,7 @@ function main() {
         deploy-kata-tdx) deploy_kata "tdx" ;;
         deploy-kata-garm) deploy_kata "garm" ;;
         run-tests) run_tests ;;
+        cleanup-kcli) cleanup "kcli" ;;
         cleanup-sev) cleanup "sev" ;;
         cleanup-snp) cleanup "snp" ;;
         cleanup-tdx) cleanup "tdx" ;;

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -18,6 +18,7 @@ DOCKER_REPO=${DOCKER_REPO:-kata-containers/kata-deploy-ci}
 DOCKER_TAG=${DOCKER_TAG:-kata-containers-latest}
 KATA_DEPLOY_WAIT_TIMEOUT=${KATA_DEPLOY_WAIT_TIMEOUT:-10m}
 KATA_HYPERVISOR=${KATA_HYPERVISOR:-qemu}
+KUBERNETES="${KUBERNETES:-}"
 
 function configure_devmapper() {
 	sudo mkdir -p /var/lib/containerd/devmapper

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -17,6 +17,7 @@ DOCKER_REGISTRY=${DOCKER_REGISTRY:-quay.io}
 DOCKER_REPO=${DOCKER_REPO:-kata-containers/kata-deploy-ci}
 DOCKER_TAG=${DOCKER_TAG:-kata-containers-latest}
 KATA_DEPLOY_WAIT_TIMEOUT=${KATA_DEPLOY_WAIT_TIMEOUT:-10m}
+KATA_HYPERVISOR=${KATA_HYPERVISOR:-qemu}
 
 function configure_devmapper() {
 	sudo mkdir -p /var/lib/containerd/devmapper

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -95,7 +95,10 @@ function deploy_kata() {
     platform="${1}"
     ensure_yq
 
-    # Emsure we're in the default namespace
+    [ "$platform" = "kcli" ] && \
+        export KUBECONFIG="$HOME/.kcli/clusters/${CLUSTER_NAME:-kata-k8s}/auth/kubeconfig"
+
+    # Ensure we're in the default namespace
     kubectl config set-context --current --namespace=default
 
     sed -i -e "s|quay.io/kata-containers/kata-deploy:latest|${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}|g" "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
@@ -229,6 +232,7 @@ function main() {
         install-kubectl) install_kubectl ;;
         get-cluster-credentials) get_cluster_credentials ;;
         deploy-kata-aks) deploy_kata "aks" ;;
+        deploy-kata-kcli) deploy_kata "kcli" ;;
         deploy-kata-sev) deploy_kata "sev" ;;
         deploy-kata-snp) deploy_kata "snp" ;;
         deploy-kata-tdx) deploy_kata "tdx" ;;

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -16,6 +16,7 @@ tools_dir="${repo_root_dir}/tools"
 DOCKER_REGISTRY=${DOCKER_REGISTRY:-quay.io}
 DOCKER_REPO=${DOCKER_REPO:-kata-containers/kata-deploy-ci}
 DOCKER_TAG=${DOCKER_TAG:-kata-containers-latest}
+KATA_DEPLOY_WAIT_TIMEOUT=${KATA_DEPLOY_WAIT_TIMEOUT:-10m}
 
 function configure_devmapper() {
 	sudo mkdir -p /var/lib/containerd/devmapper
@@ -131,7 +132,7 @@ function deploy_kata() {
     else
         kubectl apply -f "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
     fi
-    kubectl -n kube-system wait --timeout=10m --for=condition=Ready -l name=kata-deploy pod
+    kubectl -n kube-system wait --timeout="${KATA_DEPLOY_WAIT_TIMEOUT}" --for=condition=Ready -l name=kata-deploy pod
 
     # This is needed as the kata-deploy pod will be set to "Ready" when it starts running,
     # which may cause issues like not having the node properly labeled or the artefacts

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -12,6 +12,10 @@ kubernetes_dir="$(dirname "$(readlink -f "$0")")"
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
 tools_dir="${repo_root_dir}/tools"
 
+DOCKER_REGISTRY=${DOCKER_REGISTRY:-quay.io}
+DOCKER_REPO=${DOCKER_REPO:-kata-containers/kata-deploy-ci}
+DOCKER_TAG=${DOCKER_TAG:-kata-containers-latest}
+
 function configure_devmapper() {
 	sudo mkdir -p /var/lib/containerd/devmapper
 	sudo truncate --size 10G /var/lib/containerd/devmapper/data-disk.img

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -214,6 +214,7 @@ function main() {
         install-azure-cli) install_azure_cli ;;
         login-azure) login_azure ;;
         create-cluster) create_cluster ;;
+        create-cluster-kcli) create_cluster_kcli ;;
         configure-snapshotter) configure_snapshotter ;;
         setup-crio) setup_crio ;;
         deploy-k8s) deploy_k8s ;;
@@ -231,6 +232,7 @@ function main() {
         cleanup-tdx) cleanup "tdx" ;;
         cleanup-garm) cleanup "garm" ;;
         delete-cluster) cleanup "aks" ;;
+        delete-cluster-kcli) delete_cluster_kcli ;;
         *) >&2 echo "Invalid argument"; exit 2 ;;
     esac
 }

--- a/tests/integration/kubernetes/k8s-file-volume.bats
+++ b/tests/integration/kubernetes/k8s-file-volume.bats
@@ -14,7 +14,8 @@ setup() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	pod_name="test-file-volume"
 	container_name="busybox-file-volume-container"
-	tmp_file=$(exec_host mktemp /tmp/file-volume-test-foo.XXXXX)
+	node="$(get_one_kata_node)"
+	tmp_file=$(exec_host "$node" mktemp /tmp/file-volume-test-foo.XXXXX)
 	mount_path="/tmp/foo.txt"
 	file_body="test"
 	get_pod_config_dir
@@ -22,11 +23,12 @@ setup() {
 
 @test "Test readonly volume for pods" {
 	# Write test body to temp file
-	exec_host "echo "$file_body" > $tmp_file"
+	exec_host "$node" "echo "$file_body" > $tmp_file"
 
 	# Create test yaml
 	sed -e "s|HOST_FILE|$tmp_file|" ${pod_config_dir}/pod-file-volume.yaml > ${pod_config_dir}/test-pod-file-volume.yaml
 	sed -i "s|MOUNT_PATH|$mount_path|" ${pod_config_dir}/test-pod-file-volume.yaml
+	sed -i "s|NODE|$node|" ${pod_config_dir}/test-pod-file-volume.yaml
 
 	# Create pod
 	kubectl create -f "${pod_config_dir}/test-pod-file-volume.yaml"
@@ -43,6 +45,6 @@ teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	kubectl delete pod "$pod_name"
-	exec_host rm -f $tmp_file
+	exec_host "$node" rm -f $tmp_file
 	rm -f ${pod_config_dir}/test-pod-file-volume.yaml.yaml
 }

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-file-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-file-volume.yaml
@@ -11,6 +11,7 @@ spec:
   terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   restartPolicy: Never
+  nodeName: NODE
   volumes:
   - name: shared-file
     hostPath:

--- a/tests/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   runtimeClassName: kata
+  nodeName: NODE
   volumes:
     - name: pv-storage
       persistentVolumeClaim:

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -38,6 +38,14 @@ get_pod_config_dir() {
 	info "k8s configured to use runtimeclass"
 }
 
+# Return the first worker found that is kata-runtime labeled.
+get_one_kata_node() {
+	local resource_name
+	resource_name="$(kubectl get node -l katacontainers.io/kata-runtime=true -o name | head -1)"
+	# Remove leading "/node"
+	echo "${resource_name/"node/"}"
+}
+
 # Runs a command in the host filesystem.
 exec_host() {
 	node="$(kubectl get node -o name)"

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -47,10 +47,14 @@ get_one_kata_node() {
 }
 
 # Runs a command in the host filesystem.
+#
+# Parameters:
+#	$1 - the node name
+#
 exec_host() {
-	node="$(kubectl get node -o name)"
+	node="$1"
 	# `kubectl debug` always returns 0, so we hack it to return the right exit code.
-	command="$@"
+	command="${@:2}"
 	command+='; echo -en \\n$?'
 	# We're trailing the `\r` here due to: https://github.com/kata-containers/kata-containers/issues/8051
 	# tl;dr: When testing with CRI-O we're facing the foillowing error:
@@ -61,7 +65,7 @@ exec_host() {
 	# [bats-exec-test:38] INFO: k8s configured to use runtimeclass
 	# bash: line 1: $'\r': command not found
 	# ```
-	output="$(kubectl debug -qit "${node}" --image=alpine:latest -- chroot /host bash -c "${command}" | tr -d '\r')"
+	output="$(kubectl debug -qit "node/${node}" --image=alpine:latest -- chroot /host bash -c "${command}" | tr -d '\r')"
 	kubectl get pods -o name | grep node-debugger | xargs kubectl delete > /dev/null
 	exit_code="$(echo "${output}" | tail -1)"
 	echo "$(echo "${output}" | head -n -1)"

--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -6,39 +6,39 @@ metadata:
   namespace: kube-system
 spec:
   selector:
-      matchLabels:
-        name: kubelet-kata-cleanup
+    matchLabels:
+      name: kubelet-kata-cleanup
   template:
     metadata:
-        labels:
-          name: kubelet-kata-cleanup
+      labels:
+        name: kubelet-kata-cleanup
     spec:
       serviceAccountName: kata-deploy-sa
       hostPID: true
       nodeSelector:
-          katacontainers.io/kata-runtime: cleanup
+        katacontainers.io/kata-runtime: cleanup
       containers:
-      - name: kube-kata-cleanup
-        image: quay.io/kata-containers/kata-deploy:latest
-        imagePullPolicy: Always
-        command: [ "bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh reset" ]
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: DEBUG
-          value: "false"
-        - name: SHIMS
-          value: "clh dragonball fc qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx qemu"
-        - name: DEFAULT_SHIM
-          value: "qemu"
-        - name: CREATE_RUNTIMECLASSES
-          value: "false"
-        - name: CREATE_DEFAULT_RUNTIMECLASS
-          value: "false"
-        securityContext:
-          privileged: true
+        - name: kube-kata-cleanup
+          image: quay.io/kata-containers/kata-deploy:latest
+          imagePullPolicy: Always
+          command: ["bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh reset"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEBUG
+              value: "false"
+            - name: SHIMS
+              value: "clh dragonball fc qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx qemu"
+            - name: DEFAULT_SHIM
+              value: "qemu"
+            - name: CREATE_RUNTIMECLASSES
+              value: "false"
+            - name: CREATE_DEFAULT_RUNTIMECLASS
+              value: "false"
+          securityContext:
+            privileged: true
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -6,50 +6,50 @@ metadata:
   namespace: kube-system
 spec:
   selector:
-      matchLabels:
-        name: kata-deploy
+    matchLabels:
+      name: kata-deploy
   template:
     metadata:
-        labels:
-          name: kata-deploy
+      labels:
+        name: kata-deploy
     spec:
       serviceAccountName: kata-deploy-sa
       hostPID: true
       containers:
-      - name: kube-kata
-        image: quay.io/kata-containers/kata-deploy:latest
-        imagePullPolicy: Always
-        lifecycle:
-          preStop:
-            exec:
-              command: ["bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh cleanup"]
-        command: [ "bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh install" ]
-        env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
-        - name: DEBUG
-          value: "false"
-        - name: SHIMS
-          value: "clh dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx"
-        - name: DEFAULT_SHIM
-          value: "qemu"
-        - name: CREATE_RUNTIMECLASSES
-          value: "false"
-        - name: CREATE_DEFAULT_RUNTIMECLASS
-          value: "false"
-        securityContext:
-          privileged: true
-        volumeMounts:
-        - name: crio-conf
-          mountPath: /etc/crio/
-        - name: containerd-conf
-          mountPath: /etc/containerd/
-        - name: kata-artifacts
-          mountPath: /opt/kata/
-        - name: local-bin
-          mountPath: /usr/local/bin/
+        - name: kube-kata
+          image: quay.io/kata-containers/kata-deploy:latest
+          imagePullPolicy: Always
+          lifecycle:
+            preStop:
+              exec:
+                command: ["bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh cleanup"]
+          command: ["bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh install"]
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+            - name: DEBUG
+              value: "false"
+            - name: SHIMS
+              value: "clh dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx"
+            - name: DEFAULT_SHIM
+              value: "qemu"
+            - name: CREATE_RUNTIMECLASSES
+              value: "false"
+            - name: CREATE_DEFAULT_RUNTIMECLASS
+              value: "false"
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - name: crio-conf
+              mountPath: /etc/crio/
+            - name: containerd-conf
+              mountPath: /etc/containerd/
+            - name: kata-artifacts
+              mountPath: /opt/kata/
+            - name: local-bin
+              mountPath: /usr/local/bin/
       volumes:
         - name: crio-conf
           hostPath:


### PR DESCRIPTION
My first version of https://github.com/kata-containers/kata-containers/pull/7600 I simply didn't test locally, instead I let the CI run. Unfortunately CI failed and it took a good amount of time to give me a feedback. Other than that, I don't need the kata-deploy payload rebuilt as I am just changing tests files. Ok, so I decided to look if I could make `gha-run.sh` (which basically implements the CI workflow) to run locally, and here is this PR. I hope it helps to speed up the process to migrate testing code from CCv0 -> main.

I chose to deploy and managed a k8s locally with kcli (https://github.com/karmab/kcli) because it is a tool that I use almost everyday (so I know it quite well). I know that @fidencio used to use it, and I suspect others on the community use too.

kcli will be running with one control node and one worker. Two tests are failing on this configuration because they expect a single-node cluster. I fixed both tests. 

Here is how I run the tests:

```
$ ./gha-run.sh create-cluster-kcli
$ ./gha-run.sh deploy-kata-kcli
$ ./gha-run.sh run-tests-kcli
```

If I need to re-deploy kata for some reason I run `./gha-run.sh cleanup-kcli && ./gha-run.sh deploy-kata-kcli`. Finally I can delete the cluster entirely with a `./gha-run.sh delete-cluster-kcli`

Fixes https://github.com/kata-containers/kata-containers/issues/7620