### PR TITLE
Fix a possible race condition in image service

### DIFF
--- a/src/agent/src/image_rpc.rs
+++ b/src/agent/src/image_rpc.rs
@@ -36,14 +36,20 @@ const KATA_CC_IMAGE_WORK_DIR: &str = "/run/image/";
 const KATA_CC_PAUSE_BUNDLE: &str = "/pause_bundle";
 const CONFIG_JSON: &str = "config.json";
 
+#[rustfmt::skip]
+lazy_static! {
+    pub static ref IMAGE_SERVICE: Mutex<Option<ImageService>> = Mutex::new(None);
+}
+
 // Convenience function to obtain the scope logger.
 fn sl() -> slog::Logger {
     slog_scope::logger().new(o!("subsystem" => "cgroups"))
 }
 
+#[derive(Clone)]
 pub struct ImageService {
     sandbox: Arc<Mutex<Sandbox>>,
-    attestation_agent_started: AtomicBool,
+    attestation_agent_started: Arc<AtomicBool>,
     image_client: Arc<Mutex<ImageClient>>,
     container_count: Arc<AtomicU16>,
 }
@@ -67,7 +73,7 @@ impl ImageService {
 
         Self {
             sandbox,
-            attestation_agent_started: AtomicBool::new(false),
+            attestation_agent_started: Arc::new(AtomicBool::new(false)),
             image_client: Arc::new(Mutex::new(image_client)),
             container_count: Arc::new(AtomicU16::new(0)),
         }

--- a/src/agent/src/image_rpc.rs
+++ b/src/agent/src/image_rpc.rs
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::path::Path;
@@ -12,7 +13,7 @@ use std::process::Command;
 use std::sync::atomic::{AtomicBool, AtomicU16, Ordering};
 use std::sync::Arc;
 
-use anyhow::{anyhow, Result};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use image_rs::image::ImageClient;
 use protocols::image;
@@ -20,8 +21,10 @@ use tokio::sync::Mutex;
 use ttrpc::{self, error::get_rpc_status as ttrpc_error};
 
 use crate::rpc::{verify_cid, CONTAINER_BASE};
-use crate::sandbox::Sandbox;
 use crate::AGENT_CONFIG;
+
+// A marker to merge container spec for images pulled inside guest.
+const ANNO_K8S_IMAGE_NAME: &str = "io.kubernetes.cri.image-name";
 
 const AA_PATH: &str = "/usr/local/bin/attestation-agent";
 
@@ -48,14 +51,14 @@ fn sl() -> slog::Logger {
 
 #[derive(Clone)]
 pub struct ImageService {
-    sandbox: Arc<Mutex<Sandbox>>,
     attestation_agent_started: Arc<AtomicBool>,
     image_client: Arc<Mutex<ImageClient>>,
+    images: Arc<Mutex<HashMap<String, String>>>,
     container_count: Arc<AtomicU16>,
 }
 
 impl ImageService {
-    pub fn new(sandbox: Arc<Mutex<Sandbox>>) -> Self {
+    pub fn new() -> Self {
         env::set_var("CC_IMAGE_WORK_DIR", KATA_CC_IMAGE_WORK_DIR);
 
         let mut image_client = ImageClient::default();
@@ -72,11 +75,20 @@ impl ImageService {
         }
 
         Self {
-            sandbox,
             attestation_agent_started: Arc::new(AtomicBool::new(false)),
             image_client: Arc::new(Mutex::new(image_client)),
+            images: Arc::new(Mutex::new(HashMap::new())),
             container_count: Arc::new(AtomicU16::new(0)),
         }
+    }
+
+    /// Get the singleton instance of image service.
+    pub async fn singleton() -> Result<ImageService> {
+        IMAGE_SERVICE
+            .lock()
+            .await
+            .clone()
+            .ok_or_else(|| anyhow!("image service is uninitialized"))
     }
 
     // pause image is packaged in rootfs for CC
@@ -171,9 +183,7 @@ impl ImageService {
         let image = req.image();
         if cid.starts_with("pause") {
             Self::unpack_pause_image(&cid)?;
-
-            let mut sandbox = self.sandbox.lock().await;
-            sandbox.images.insert(String::from(image), cid);
+            self.add_image(String::from(image), cid).await;
             return Ok(image.to_owned());
         }
 
@@ -240,9 +250,79 @@ impl ImageService {
             }
         };
 
-        let mut sandbox = self.sandbox.lock().await;
-        sandbox.images.insert(String::from(image), cid);
+        self.add_image(String::from(image), cid).await;
         Ok(image.to_owned())
+    }
+
+    async fn add_image(&self, image: String, cid: String) {
+        self.images.lock().await.insert(image, cid);
+    }
+
+    // When being passed an image name through a container annotation, merge its
+    // corresponding bundle OCI specification into the passed container creation one.
+    pub async fn merge_bundle_oci(&self, container_oci: &mut oci::Spec) -> Result<()> {
+        if let Some(image_name) = container_oci
+            .annotations
+            .get(&ANNO_K8S_IMAGE_NAME.to_string())
+        {
+            let images = self.images.lock().await;
+            if let Some(container_id) = images.get(image_name) {
+                let image_oci_config_path = Path::new(CONTAINER_BASE)
+                    .join(container_id)
+                    .join(CONFIG_JSON);
+                debug!(
+                    sl(),
+                    "Image bundle config path: {:?}", image_oci_config_path
+                );
+
+                let image_oci =
+                    oci::Spec::load(image_oci_config_path.to_str().ok_or_else(|| {
+                        anyhow!(
+                            "Invalid container image OCI config path {:?}",
+                            image_oci_config_path
+                        )
+                    })?)
+                    .context("load image bundle")?;
+
+                if let Some(container_root) = container_oci.root.as_mut() {
+                    if let Some(image_root) = image_oci.root.as_ref() {
+                        let root_path = Path::new(CONTAINER_BASE)
+                            .join(container_id)
+                            .join(image_root.path.clone());
+                        container_root.path =
+                            String::from(root_path.to_str().ok_or_else(|| {
+                                anyhow!("Invalid container image root path {:?}", root_path)
+                            })?);
+                    }
+                }
+
+                if let Some(container_process) = container_oci.process.as_mut() {
+                    if let Some(image_process) = image_oci.process.as_ref() {
+                        self.merge_oci_process(container_process, image_process);
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // Partially merge an OCI process specification into another one.
+    fn merge_oci_process(&self, target: &mut oci::Process, source: &oci::Process) {
+        if target.args.is_empty() && !source.args.is_empty() {
+            target.args.append(&mut source.args.clone());
+        }
+
+        if target.cwd == "/" && source.cwd != "/" {
+            target.cwd = String::from(&source.cwd);
+        }
+
+        for source_env in &source.env {
+            let variable_name: Vec<&str> = source_env.split('=').collect();
+            if !target.env.iter().any(|i| i.contains(variable_name[0])) {
+                target.env.push(source_env.to_string());
+            }
+        }
     }
 }
 

--- a/src/agent/src/image_rpc.rs
+++ b/src/agent/src/image_rpc.rs
@@ -255,52 +255,63 @@ impl ImageService {
     }
 
     async fn add_image(&self, image: String, cid: String) {
-        self.images.lock().await.insert(image, cid);
+        self.images.lock().await.insert(cid, image);
     }
 
     // When being passed an image name through a container annotation, merge its
     // corresponding bundle OCI specification into the passed container creation one.
-    pub async fn merge_bundle_oci(&self, container_oci: &mut oci::Spec) -> Result<()> {
-        if let Some(image_name) = container_oci
+    pub async fn merge_bundle_oci(&self, container_oci: &mut oci::Spec, cid: &str) -> Result<()> {
+        // Check marker for merging OCI spec inside guest.
+        let image_name = match container_oci
             .annotations
             .get(&ANNO_K8S_IMAGE_NAME.to_string())
         {
-            let images = self.images.lock().await;
-            if let Some(container_id) = images.get(image_name) {
-                let image_oci_config_path = Path::new(CONTAINER_BASE)
-                    .join(container_id)
-                    .join(CONFIG_JSON);
-                debug!(
-                    sl(),
-                    "Image bundle config path: {:?}", image_oci_config_path
-                );
+            Some(v) => v,
+            None => return Ok(()),
+        };
 
-                let image_oci =
-                    oci::Spec::load(image_oci_config_path.to_str().ok_or_else(|| {
-                        anyhow!(
-                            "Invalid container image OCI config path {:?}",
-                            image_oci_config_path
-                        )
-                    })?)
-                    .context("load image bundle")?;
+        let images = self.images.lock().await;
+        let image = match images.get(cid) {
+            Some(v) => v,
+            None => return Err(anyhow!("no image available for container {}", cid)),
+        };
 
-                if let Some(container_root) = container_oci.root.as_mut() {
-                    if let Some(image_root) = image_oci.root.as_ref() {
-                        let root_path = Path::new(CONTAINER_BASE)
-                            .join(container_id)
-                            .join(image_root.path.clone());
-                        container_root.path =
-                            String::from(root_path.to_str().ok_or_else(|| {
-                                anyhow!("Invalid container image root path {:?}", root_path)
-                            })?);
-                    }
-                }
+        if image_name != image {
+            warn!(
+                sl(),
+                "image name {} deosn't match expected {}", image_name, image
+            );
+        }
 
-                if let Some(container_process) = container_oci.process.as_mut() {
-                    if let Some(image_process) = image_oci.process.as_ref() {
-                        self.merge_oci_process(container_process, image_process);
-                    }
-                }
+        let image_oci_config_path = Path::new(CONTAINER_BASE).join(cid).join(CONFIG_JSON);
+        debug!(
+            sl(),
+            "Image bundle config path: {:?}", image_oci_config_path
+        );
+
+        let image_oci = oci::Spec::load(image_oci_config_path.to_str().ok_or_else(|| {
+            anyhow!(
+                "Invalid container image OCI config path {:?}",
+                image_oci_config_path
+            )
+        })?)
+        .context("load image bundle")?;
+
+        if let Some(container_root) = container_oci.root.as_mut() {
+            if let Some(image_root) = image_oci.root.as_ref() {
+                let root_path = Path::new(CONTAINER_BASE)
+                    .join(cid)
+                    .join(image_root.path.clone());
+                container_root.path =
+                    String::from(root_path.to_str().ok_or_else(|| {
+                        anyhow!("Invalid container image root path {:?}", root_path)
+                    })?);
+            }
+        }
+
+        if let Some(container_process) = container_oci.process.as_mut() {
+            if let Some(image_process) = image_oci.process.as_ref() {
+                self.merge_oci_process(container_process, image_process);
             }
         }
 
@@ -349,7 +360,6 @@ impl protocols::image_ttrpc_async::Image for ImageService {
 #[cfg(test)]
 mod tests {
     use super::ImageService;
-    use crate::sandbox::Sandbox;
     use protocols::image;
     use std::sync::Arc;
     use tokio::sync::Mutex;

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -191,7 +191,7 @@ impl AgentService {
         // In case of pulling image inside guest, we need to merge the image bundle OCI spec
         // into the container creation request OCI spec.
         let image_service = image_rpc::ImageService::singleton().await?;
-        image_service.merge_bundle_oci(&mut oci).await?;
+        image_service.merge_bundle_oci(&mut oci, &cid).await?;
 
         // Some devices need some extra processing (the ones invoked with
         // --device for instance), and that's what this call is doing. It

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1826,8 +1826,8 @@ pub async fn start(
     let health_service = Box::new(HealthService {}) as Box<dyn health_ttrpc::Health + Send + Sync>;
     let health_worker = Arc::new(health_service);
 
-    let image_service = Box::new(image_rpc::ImageService::new(s).await)
-        as Box<dyn image_ttrpc::Image + Send + Sync>;
+    let image_service =
+        Box::new(image_rpc::ImageService::new(s)) as Box<dyn image_ttrpc::Image + Send + Sync>;
 
     let aservice = agent_ttrpc::create_agent_service(agent_worker);
 

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -207,7 +207,8 @@ impl AgentService {
             "receive createcontainer, storages: {:?}", &req.storages
         );
 
-        // Merge the image bundle OCI spec into the container creation request OCI spec.
+        // In case of pulling image inside guest, we need to merge the image bundle OCI spec
+        // into the container creation request OCI spec.
         self.merge_bundle_oci(&mut oci).await?;
 
         // Some devices need some extra processing (the ones invoked with
@@ -1826,14 +1827,16 @@ pub async fn start(
     let health_service = Box::new(HealthService {}) as Box<dyn health_ttrpc::Health + Send + Sync>;
     let health_worker = Arc::new(health_service);
 
+    let image_service = image_rpc::ImageService::new(s);
+    *image_rpc::IMAGE_SERVICE.lock().await = Some(image_service.clone());
     let image_service =
-        Box::new(image_rpc::ImageService::new(s)) as Box<dyn image_ttrpc::Image + Send + Sync>;
+        Arc::new(Box::new(image_service) as Box<dyn image_ttrpc::Image + Send + Sync>);
 
     let aservice = agent_ttrpc::create_agent_service(agent_worker);
 
     let hservice = health_ttrpc::create_health(health_worker);
 
-    let iservice = image_ttrpc::create_image(Arc::new(image_service));
+    let iservice = image_ttrpc::create_image(image_service);
 
     let server = TtrpcServer::new()
         .bind(server_address)?

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -62,7 +62,6 @@ pub struct Sandbox {
     pub event_tx: Option<Sender<String>>,
     pub bind_watcher: BindWatcher,
     pub pcimap: HashMap<pci::Address, pci::Address>,
-    pub images: HashMap<String, String>,
 }
 
 impl Sandbox {
@@ -96,7 +95,6 @@ impl Sandbox {
             event_tx: Some(tx),
             bind_watcher: BindWatcher::new(),
             pcimap: HashMap::new(),
-            images: HashMap::new(),
         })
     }
 


### PR DESCRIPTION
Currently we use a HashMap<image_name, container_id> to maintain relationship between images and containers. If an image is used for multiple containers, it will conflicts and lost information.

Also refine the image service code to prepare for coming work.