### PR TITLE
docs: Remove installation step in virtcontainers doc

### DIFF
--- a/src/runtime/virtcontainers/documentation/Developers.md
+++ b/src/runtime/virtcontainers/documentation/Developers.md
@@ -17,13 +17,6 @@ To build `virtcontainers`, at the top level directory run:
 
 Before testing `virtcontainers`, ensure you have met the [prerequisites](#prerequisites).
 
-Before testing you need to install virtcontainers. The following command will install
-`virtcontainers` into its own area (`/usr/bin/virtcontainers/bin/` by default).
-
-```
-# sudo -E PATH=$PATH make install
-```
-
 To test `virtcontainers`, at the top level run:
 
 ```


### PR DESCRIPTION
Remove the installation step in the virtcontainers doc because the virtcontainers install/uninstall targets have been removed by 86723b51ae131364e4efaa4d8818a6bac26a9dac and they are not used anymore.

Fixes: #7637