### PR TITLE
gha: cri-containerd: Enable tests

### DIFF
--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -59,7 +59,8 @@ function install_dependencies() {
 function run() {
 	info "Running cri-containerd tests using ${KATA_HYPERVISOR} hypervisor"
 
-	return 0
+	enabling_hypervisor
+	bash -c ${cri_containerd_dir}/integration-tests.sh
 }
 
 function main() {

--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -130,10 +130,11 @@ trap cleanup EXIT
 function err_report() {
 	local log_file="${REPORT_DIR}/containerd.log"
 	if [ -f "$log_file" ]; then
-		echo "ERROR: containerd log :"
+		echo "::group::ERROR: containerd log :"
 		echo "-------------------------------------"
 		cat "${log_file}"
 		echo "-------------------------------------"
+		echo "::endgroup::"
 	fi
 }
 

--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -21,9 +21,9 @@ export PATH="$PATH:/usr/local/sbin"
 export PATH="$PATH:/usr/local/go/bin"
 
 # Runtime to be used for testing
-RUNTIME=${RUNTIME:-containerd-shim-kata-v2}
-FACTORY_TEST=${FACTORY_TEST:-""}
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+RUNTIME=${RUNTIME:-containerd-shim-kata-${KATA_HYPERVISOR}-v2}
+FACTORY_TEST=${FACTORY_TEST:-""}
 USE_DEVMAPPER="${USE_DEVMAPPER:-false}"
 ARCH=$(uname -m)
 

--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -136,6 +136,11 @@ function err_report() {
 		echo "-------------------------------------"
 		echo "::endgroup::"
 	fi
+	echo "::group::ERROR: Kata Containers logs : "
+	echo "-------------------------------------"
+	sudo journalctl -xe -t kata
+	echo "-------------------------------------"
+	echo "::endgroup::"
 }
 
 

--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -204,11 +204,11 @@ EOF
 
 function testContainerStop() {
 	info "show pod $podid"
-	sudo crictl pods --id $podid
+	sudo crictl --timeout=20s pods --id $podid
 	info "stop pod $podid"
-	sudo crictl stopp $podid
+	sudo crictl --timeout=20s stopp $podid
 	info "remove pod $podid"
-	sudo crictl rmp $podid
+	sudo crictl --timeout=20s rmp $podid
 
 	sudo cp "$default_containerd_config_backup" "$default_containerd_config"
 	restart_containerd_service

--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -203,6 +203,8 @@ EOF
 }
 
 function testContainerStop() {
+	info "show pod $podid"
+	sudo crictl pods --id $podid
 	info "stop pod $podid"
 	sudo crictl stopp $podid
 	info "remove pod $podid"


### PR DESCRIPTION
As the cri-containerd tests have been fully migrated to GHA, let's make sure we get them running.

Fixes: #6543