### PR TITLE
gha: tests: Add kata-deploy functional tests -- Part 1

### DIFF
--- a/.github/workflows/run-kata-deploy-tests-on-aks.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-aks.yaml
@@ -1,0 +1,77 @@
+name: CI | Run kata-deploy tests on AKS
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: true
+        type: string
+      repo:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      pr-number:
+        required: true
+        type: string
+      commit-hash:
+        required: false
+        type: string
+
+jobs:
+  run-kata-deploy-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        host_os:
+          - ubuntu
+        vmm:
+          - clh
+          - dragonball
+          - qemu
+        include:
+          - host_os: cbl-mariner
+            vmm: clh
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: ${{ inputs.registry }}
+      DOCKER_REPO: ${{ inputs.repo }}
+      DOCKER_TAG: ${{ inputs.tag }}
+      GH_PR_NUMBER: ${{ inputs.pr-number }}
+      KATA_HOST_OS: ${{ matrix.host_os }}
+      KATA_HYPERVISOR: ${{ matrix.vmm }}
+      USING_NFD: "false"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commit-hash }}
+
+      - name: Download Azure CLI
+        run: bash tests/functional/kata-deploy/gha-run.sh install-azure-cli
+
+      - name: Log into the Azure account
+        run: bash tests/functional/kata-deploy/gha-run.sh login-azure
+        env:
+          AZ_APPID: ${{ secrets.AZ_APPID }}
+          AZ_PASSWORD: ${{ secrets.AZ_PASSWORD }}
+          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
+
+      - name: Create AKS cluster
+        timeout-minutes: 10
+        run: bash tests/functional/kata-deploy/gha-run.sh create-cluster
+
+      - name: Install `bats`
+        run: bash tests/functional/kata-deploy/gha-run.sh install-bats
+
+      - name: Install `kubectl`
+        run: bash tests/functional/kata-deploy/gha-run.sh install-kubectl
+
+      - name: Download credentials for the Kubernetes CLI to use them
+        run: bash tests/functional/kata-deploy/gha-run.sh get-cluster-credentials
+
+      - name: Run tests
+        run: bash tests/functional/kata-deploy/gha-run.sh run-tests
+      
+      - name: Delete AKS cluster
+        if: always()
+        run: bash tests/functional/kata-deploy/gha-run.sh delete-cluster

--- a/.github/workflows/run-kata-deploy-tests-on-tdx.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-tdx.yaml
@@ -1,0 +1,42 @@
+name: CI | Run kata-deploy tests on TDX
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: true
+        type: string
+      repo:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      pr-number:
+        required: true
+        type: string
+      commit-hash:
+        required: false
+        type: string
+
+jobs:
+  run-kata-deploy-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        vmm:
+          - qemu-tdx
+    runs-on: tdx
+    env:
+      DOCKER_REGISTRY: ${{ inputs.registry }}
+      DOCKER_REPO: ${{ inputs.repo }}
+      DOCKER_TAG: ${{ inputs.tag }}
+      PR_NUMBER: ${{ inputs.pr-number }}
+      KATA_HYPERVISOR: ${{ matrix.vmm }}
+      USING_NFD: "true"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commit-hash }}
+
+      - name: Run tests
+        run: bash tests/functional/kata-deploy/gha-run.sh run-tests

--- a/tests/functional/kata-deploy/gha-run.sh
+++ b/tests/functional/kata-deploy/gha-run.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2023 Microsoft Corporation
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+kata_deploy_dir="$(dirname "$(readlink -f "$0")")"
+source "$kata_deploy_dir}/../../gha-run-k8s-common.sh"
+tools_dir="${repo_root_dir}/tools"
+
+function run_tests() {
+	return 0
+}
+
+function main() {
+    export KATA_HOST_OS="${KATA_HOST_OS:-}"
+
+    action="${1:-}"
+
+    case "${action}" in
+        install-azure-cli) install_azure_cli ;;
+        login-azure) login_azure ;;
+        create-cluster) create_cluster ;;
+        install-bats) install_bats ;;
+        install-kubectl) install_kubectl ;;
+        get-cluster-credentials) get_cluster_credentials ;;
+        run-tests) run_tests ;;
+        delete-cluster) cleanup "aks" ;;
+        *) >&2 echo "Invalid argument"; exit 2 ;;
+    esac
+}
+
+main "$@"

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2023 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+tests_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${tests_dir}/common.bash"
+
+AZ_RG="${AZ_RG:-kataCI}"
+
+function _print_cluster_name() {
+    short_sha="$(git rev-parse --short=12 HEAD)"
+    echo "${GH_PR_NUMBER}-${short_sha}-${KATA_HYPERVISOR}-${KATA_HOST_OS}-amd64"
+}
+
+function install_azure_cli() {
+    curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+    # The aks-preview extension is required while the Mariner Kata host is in preview.
+    az extension add --name aks-preview
+}
+
+function login_azure() {
+    az login \
+        --service-principal \
+        -u "${AZ_APPID}" \
+        -p "${AZ_PASSWORD}" \
+        --tenant "${AZ_TENANT_ID}"
+}
+
+function create_cluster() {
+    # First, ensure that the cluster didn't fail to get cleaned up from a previous run.
+    delete_cluster || true
+
+    az aks create \
+        -g "${AZ_RG}" \
+        -n "$(_print_cluster_name)" \
+        -s "Standard_D4s_v5" \
+        --node-count 1 \
+        --generate-ssh-keys \
+        $([ "${KATA_HOST_OS}" = "cbl-mariner" ] && echo "--os-sku AzureLinux --workload-runtime KataMshvVmIsolation")
+}
+
+function install_bats() {
+    # Installing bats from the lunar repo.
+    # This installs newer version of the bats which supports setup_file and teardown_file functions.
+    # These functions are helpful when adding new tests that require one time setup.
+
+    sudo apt install -y software-properties-common
+    sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ lunar universe'
+    sudo apt install -y bats
+    sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ lunar universe'
+}
+
+function install_kubectl() {
+    sudo az aks install-cli
+}
+
+function get_cluster_credentials() {
+    az aks get-credentials \
+        -g "${AZ_RG}" \
+        -n "$(_print_cluster_name)"
+}
+
+function delete_cluster() {
+    az aks delete \
+        -g "${AZ_RG}" \
+        -n "$(_print_cluster_name)" \
+        --yes
+}
+
+function get_nodes_and_pods_info() {
+    kubectl debug $(kubectl get nodes -o name) -it --image=quay.io/kata-containers/kata-debug:latest || true
+    kubectl get pods -o name | grep node-debugger | xargs kubectl delete || true
+}

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -9,63 +9,8 @@ set -o nounset
 set -o pipefail
 
 kubernetes_dir="$(dirname "$(readlink -f "$0")")"
-source "${kubernetes_dir}/../../common.bash"
+source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
 tools_dir="${repo_root_dir}/tools"
-
-AZ_RG="${AZ_RG:-kataCI}"
-
-function _print_cluster_name() {
-    short_sha="$(git rev-parse --short=12 HEAD)"
-    echo "${GH_PR_NUMBER}-${short_sha}-${KATA_HYPERVISOR}-${KATA_HOST_OS}-amd64"
-}
-
-function install_azure_cli() {
-    curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-    # The aks-preview extension is required while the Mariner Kata host is in preview.
-    az extension add --name aks-preview
-}
-
-function login_azure() {
-    az login \
-        --service-principal \
-        -u "${AZ_APPID}" \
-        -p "${AZ_PASSWORD}" \
-        --tenant "${AZ_TENANT_ID}"
-}
-
-function create_cluster() {
-    # First, ensure that the cluster didn't fail to get cleaned up from a previous run.
-    delete_cluster || true
-
-    az aks create \
-        -g "${AZ_RG}" \
-        -n "$(_print_cluster_name)" \
-        -s "Standard_D4s_v5" \
-        --node-count 1 \
-        --generate-ssh-keys \
-        $([ "${KATA_HOST_OS}" = "cbl-mariner" ] && echo "--os-sku AzureLinux --workload-runtime KataMshvVmIsolation")
-}
-
-function install_bats() {
-    # Installing bats from the lunar repo.
-    # This installs newer version of the bats which supports setup_file and teardown_file functions.
-    # These functions are helpful when adding new tests that require one time setup.
-
-    sudo apt install -y software-properties-common
-    sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ lunar universe'
-    sudo apt install -y bats
-    sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ lunar universe'
-}
-
-function install_kubectl() {
-    sudo az aks install-cli
-}
-
-function get_cluster_credentials() {
-    az aks get-credentials \
-        -g "${AZ_RG}" \
-        -n "$(_print_cluster_name)"
-}
 
 function deploy_kata() {
     platform="${1}"
@@ -181,18 +126,6 @@ function cleanup() {
 
     kubectl delete ${cleanup_spec}
     kubectl delete -f "${tools_dir}/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml"
-}
-
-function delete_cluster() {
-    az aks delete \
-        -g "${AZ_RG}" \
-        -n "$(_print_cluster_name)" \
-        --yes
-}
-
-function get_nodes_and_pods_info() {
-    kubectl debug $(kubectl get nodes -o name) -it --image=quay.io/kata-containers/kata-debug:latest || true
-    kubectl get pods -o name | grep node-debugger | xargs kubectl delete || true
 }
 
 function main() {


### PR DESCRIPTION
This first part does:
* Splits gha-run.sh from the `integration/kubernetes`  dir, so it can be reused for the `functional/kata-deploy`  tests that will come in the future
* Add the aks / tdx tests, as those are the ones I will be touching
  * sev / snp tests are also welcome but I'll leave this to AMD to play with
* Add a basic placeholder for the gha-run.sh, which will be used by the `functional/kata-deploy` tests.