### PR TITLE
rootfs: agent: Policy support with AGENT_INIT=yes

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -229,27 +229,6 @@ async fn real_main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     let root_span = span!(tracing::Level::TRACE, "root-span");
 
-    #[cfg(feature = "agent-policy")]
-    {
-        let debug_policy =
-            config.log_level == slog::Level::Debug || config.log_level == slog::Level::Trace;
-        if let Err(e) = AGENT_POLICY
-            .lock()
-            .await
-            .initialize(
-                debug_policy,
-                "http://localhost:8181/v1",
-                "/agent_policy",
-                "/etc/kata-opa/default-policy.rego",
-            )
-            .await
-        {
-            error!(logger, "Failed to initialize agent policy: {:?}", e);
-            // Continuing execution without a security policy could be dangerous.
-            std::process::abort();
-        }
-    }
-
     // XXX: Start the root trace transaction.
     //
     // XXX: Note that *ALL* spans needs to start after this point!!
@@ -355,6 +334,19 @@ async fn start_sandbox(
         s.rtnl.handle_localhost().await?;
     }
 
+    // - When init_mode is true, enabling the localhost link during the
+    //   handle_localhost call above is required before starting OPA with the
+    //   initialize_policy call below.
+    // - When init_mode is false, the Policy could be initialized earlier,
+    //   because initialize_policy doesn't start OPA. OPA is started by
+    //   systemd after localhost has been enabled.
+    #[cfg(feature = "agent-policy")]
+    if let Err(e) = initialize_policy(init_mode).await {
+        error!(logger, "Failed to initialize agent policy: {:?}", e);
+        // Continuing execution without a security policy could be dangerous.
+        std::process::abort();
+    }
+
     let sandbox = Arc::new(Mutex::new(s));
 
     let signal_handler_task = tokio::spawn(setup_signal_handler(
@@ -414,6 +406,18 @@ fn init_agent_as_init(logger: &Logger, unified_cgroup_hierarchy: bool) -> Result
     }
 
     Ok(())
+}
+
+#[cfg(feature = "agent-policy")]
+async fn initialize_policy(init_mode: bool) -> Result<()> {
+    let opa_addr = "localhost:8181";
+    let agent_policy_path = "/agent_policy";
+    let default_agent_policy = "/etc/kata-opa/default-policy.rego";
+    AGENT_POLICY
+        .lock()
+        .await
+        .initialize(init_mode, opa_addr, agent_policy_path, default_agent_policy)
+        .await
 }
 
 // The Rust standard library had suppressed the default SIGPIPE behavior,


### PR DESCRIPTION
When building with AGENT_POLICY=yes and AGENT_INIT=yes:
1. Include OPA and the Policy settings in rootfs.
2. Start OPA from the kata agent.

Before these changes, building with both AGENT_POLICY=yes and AGENT_INIT=yes was unsupported.

Starting OPA from systemd (when AGENT_INIT=no) was already supported.

Fixes: #7615