### PR TITLE
metrics: Enable kata runtime in K8s for FIO test.

### DIFF
--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -87,10 +87,8 @@ function run_test_tensorflow() {
 
 function run_test_fio() {
 	info "Running FIO test using ${KATA_HYPERVISOR} hypervisor"
-        # ToDo: remove the exit once the metrics workflow is stable
-        exit 0
 
-	bash storage/fio-k8s/fio-test-ci.sh
+	bash tests/metrics/storage/fio-k8s/fio-test-ci.sh
 }
 
 function run_test_iperf() {

--- a/tests/metrics/storage/fio-k8s/Makefile
+++ b/tests/metrics/storage/fio-k8s/Makefile
@@ -24,5 +24,8 @@ test: build
 run: build
 	make -C $(MKFILE_DIR)/scripts/dax-compare-test/ run
 
-test-ci: build
-	make -C $(MKFILE_DIR)/cmd/fiotest/ runci
+test-qemu: build
+	make -C $(MKFILE_DIR)/cmd/fiotest/ run-qemu
+
+test-clh: build
+	make -C $(MKFILE_DIR)/cmd/fiotest/ run-clh

--- a/tests/metrics/storage/fio-k8s/cmd/fiotest/Makefile
+++ b/tests/metrics/storage/fio-k8s/cmd/fiotest/Makefile
@@ -20,5 +20,8 @@ gomod:
 	 go mod edit -replace=github.com/kata-containers/kata-containers/tests/metrics/env=../../pkg/env
 	 go mod tidy
 
-runci: build
-	$(MKFILE_DIR)/fio-k8s --debug --fio.size 10M --output-dir test-results --test-name kata $(MKFILE_DIR)/../../configs/example-config/
+run-qemu: build
+	$(MKFILE_DIR)/fio-k8s --debug --fio.size 10M --output-dir test-results --test-name kata --container-runtime kata-qemu $(MKFILE_DIR)/../../configs/example-config/
+
+run-clh: build
+	$(MKFILE_DIR)/fio-k8s --debug --fio.size 10M --output-dir test-results --test-name kata --container-runtime kata-clh $(MKFILE_DIR)/../../configs/example-config/

--- a/tests/metrics/storage/fio-k8s/configs/example-config/kata-clh.yaml
+++ b/tests/metrics/storage/fio-k8s/configs/example-config/kata-clh.yaml
@@ -1,0 +1,17 @@
+## Copyright (c) 2021 Intel Corporation
+#
+## SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: iometrics
+spec:
+  runtimeClassName: kata-clh
+  containers:
+  - args:
+    - sleep
+    - infinity
+    image: ubuntu:latest
+    name: iometrics
+    imagePullPolicy: Always

--- a/tests/metrics/storage/fio-k8s/configs/example-config/kata-qemu.yaml
+++ b/tests/metrics/storage/fio-k8s/configs/example-config/kata-qemu.yaml
@@ -1,0 +1,17 @@
+## Copyright (c) 2021 Intel Corporation
+#
+## SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: iometrics
+spec:
+  runtimeClassName: kata-qemu
+  containers:
+  - args:
+    - sleep
+    - infinity
+    image: ubuntu:latest
+    name: iometrics
+    imagePullPolicy: Always

--- a/tests/metrics/storage/fio-k8s/fio-test-ci.sh
+++ b/tests/metrics/storage/fio-k8s/fio-test-ci.sh
@@ -18,11 +18,12 @@ function main() {
 	check_processes
 	init_env
 
-	export KUBECONFIG="$HOME/.kube/config"
-
 	pushd "${FIO_PATH}"
-		echo "INFO: Running K8S FIO test"
-		make test-ci
+		[ -z "${KATA_HYPERVISOR}" ] && die "Hypervisor ID is missing."
+		[ "${KATA_HYPERVISOR}" != "qemu" ] && [ "${KATA_HYPERVISOR}" != "clh" ] && die "Hypervisor not recognized: ${KATA_HYPERVISOR}"
+
+		echo "INFO: Running K8S FIO test using ${KATA_HYPERVISOR} hypervisor"
+		make "test-${KATA_HYPERVISOR}"
 	popd
 
 	test_result_file="${FIO_PATH}/cmd/fiotest/test-results/kata/randrw-sync.job/output.json"
@@ -30,7 +31,7 @@ function main() {
 	metrics_json_init
 	local read_io=$(cat $test_result_file | grep io_bytes | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 	local read_bw=$(cat $test_result_file | grep bw_bytes | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
- 	local read_90_percentile=$(cat $test_result_file | grep 90.000000 | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
+	local read_90_percentile=$(cat $test_result_file | grep 90.000000 | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 	local read_95_percentile=$(cat $test_result_file | grep 95.000000 | head -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 	local write_io=$(cat $test_result_file | grep io_bytes | head -2 | tail -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')
 	local write_bw=$(cat $test_result_file | grep bw_bytes | head -2 | tail -1 | sed 's/[[:blank:]]//g' | cut -f2 -d ':' | cut -f1 -d ',')


### PR DESCRIPTION
This PR configures the corresponding kata runtime in K8s based on the tested hypervisor.

This PR also enables FIO metrics test in the kata metrics-ci.

Fixes: #7665