### PR TITLE
CC | kata-deploy: Properly create default runtime class

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -339,6 +339,7 @@ function ensure_yq() {
     export GOPATH
     export PATH="${GOPATH}/bin:${PATH}"
     INSTALL_IN_GOPATH=true "${repo_root_dir}/ci/install_yq.sh"
+    hash -d yq # yq is preinstalled on GHA Ubuntu 22.04 runners so we clear Bash's PATH cache.
 }
 
 # dependency: What we want to get the version from the versions.yaml file

--- a/tests/integration/kubernetes/kata-deploy-ensure-runtimec-classes-created.bats
+++ b/tests/integration/kubernetes/kata-deploy-ensure-runtimec-classes-created.bats
@@ -14,13 +14,23 @@ setup() {
 	# * `kata-${KATA_HYPERVISOR}` is the other one
 	#    * As part of the tests we're only deploying the specific runtimeclass that will be used, instead of all of them.
 	expected_runtime_classes=2
+
+	# We expect both runtime classes to have the same handler: kata-${KATA_HYPERVISOR}
+	expected_handlers_re=( \
+		"kata\s+kata-${KATA_HYPERVISOR}" \
+		"kata-${KATA_HYPERVISOR}\s+kata-${KATA_HYPERVISOR}" \
+	)
 }
 
 @test "Test runtimeclasses are being properly created" {
 	# We filter `kata-mshv-vm-isolation` out as that's present on AKS clusters, but that's not coming from kata-deploy
 	current_runtime_classes=$(kubectl get runtimeclasses | grep -v "kata-mshv-vm-isolation" | grep "kata" | wc -l)
 	[[ ${current_runtime_classes} -eq ${expected_runtime_classes} ]]
-	[[ $(kubectl get runtimeclasses | grep -q "${KATA_HYPERVISOR}") -eq 0 ]]
+
+	for handler_re in ${expected_handlers_re[@]}
+	do
+		[[ $(kubectl get runtimeclass | grep -E "${handler_re}") ]]
+	done
 }
 
 teardown() {

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -18,18 +18,20 @@ reset_workloads_work_dir() {
 set_kernel_path() {
     if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
         mariner_kernel_path="/usr/share/cloud-hypervisor/vmlinux.bin"
-        find ${kubernetes_dir}/runtimeclass_workloads_work/*.yaml -exec yq write -i {} 'metadata.annotations[io.katacontainers.config.hypervisor.kernel]' "${mariner_kernel_path}" \;
+        # Not using find -exec as that still returns 0 on failure.
+        find ${kubernetes_dir}/runtimeclass_workloads_work/*.yaml -print0 | xargs -0 -I% yq write -i % 'metadata.annotations[io.katacontainers.config.hypervisor.kernel]' "${mariner_kernel_path}"
     fi
 }
 
 set_initrd_path() {
     if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
         initrd_path="/opt/kata/share/kata-containers/kata-containers-initrd-mariner.img"
-        find ${kubernetes_dir}/runtimeclass_workloads_work/*.yaml -exec yq write -i {} 'metadata.annotations[io.katacontainers.config.hypervisor.initrd]' "${initrd_path}" \;
+        find ${kubernetes_dir}/runtimeclass_workloads_work/*.yaml -print0 | xargs -0 -I% yq write -i % 'metadata.annotations[io.katacontainers.config.hypervisor.initrd]' "${initrd_path}"
     fi
 }
 
 main() {
+    ensure_yq
     reset_workloads_work_dir
     set_kernel_path
     set_initrd_path

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -44,7 +44,7 @@ function create_runtimeclasses() {
 	if [[ "${CREATE_DEFAULT_RUNTIMECLASS}" == "true" ]]; then
 		echo "Creating the kata runtime class for the default shim (an alias for kata-${default_shim})"
 		cp /opt/kata-artifacts/runtimeclasses/kata-${default_shim}.yaml /tmp/kata.yaml
-		sed -i -e 's/kata-'${default_shim}'/kata/g' /tmp/kata.yaml
+		sed -i -e 's/name: kata-'${default_shim}'/name: kata/g' /tmp/kata.yaml
 		kubectl apply -f /tmp/kata.yaml
 		rm -f /tmp/kata.yaml
 	fi
@@ -62,7 +62,7 @@ function delete_runtimeclasses() {
 	if [[ "${CREATE_DEFAULT_RUNTIMECLASS}" == "true" ]]; then
 		echo "Deleting the kata runtime class for the default shim (an alias for kata-${default_shim})"
 		cp /opt/kata-artifacts/runtimeclasses/kata-${default_shim}.yaml /tmp/kata.yaml
-		sed -i -e 's/kata-'${default_shim}'/kata/g' /tmp/kata.yaml
+		sed -i -e 's/name: kata-'${default_shim}'/name: kata/g' /tmp/kata.yaml
 		kubectl delete -f /tmp/kata.yaml
 		rm -f /tmp/kata.yaml
 	fi


### PR DESCRIPTION
The default `kata` runtime class would get created with the `kata`
handler instead of `kata-$KATA_HYPERVISOR`. This made Kata use the wrong
hypervisor and broke CI.

Fixes: https://github.com/kata-containers/kata-containers/issues/7681

Backport of #7654