### PR TITLE
metrics: Fix check results for tensorflow benchmark

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -73,26 +73,26 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
-name = "tensorflow"
+name = "tensorflow_nhwc"
 type = "json"
 description = "tensorflow resnet model"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall
 # within (inclusive)
-checkvar = ".\"tensorflow\".Results | .[] | .resnet.Result"
+checkvar = ".\"tensorflow_nhwc\".Results | .[] | .resnet.Result"
 checktype = "mean"
 midval = 3566.0
 minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
-name = "tensorflow"
+name = "tensorflow_nhwc"
 type = "json"
 description = "tensorflow alexnet model"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall
 # within (inclusive)
-checkvar = ".\"tensorflow\".Results | .[] | .alexnet.Result"
+checkvar = ".\"tensorflow_nhwc\".Results | .[] | .alexnet.Result"
 checktype = "mean"
 midval = 98.0
 minpercent = 20.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -73,26 +73,26 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
-name = "tensorflow"
+name = "tensorflow_nhwc"
 type = "json"
 description = "tensorflow resnet model"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall
 # within (inclusive)
-checkvar = ".\"tensorflow\".Results | .[] | .resnet.Result"
+checkvar = ".\"tensorflow_nhwc\".Results | .[] | .resnet.Result"
 checktype = "mean"
 midval = 3546.0
 minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
-name = "tensorflow"
+name = "tensorflow_nhwc"
 type = "json"
 description = "tensorflow alexnet model"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall
 # within (inclusive)
-checkvar = ".\"tensorflow\".Results | .[] | .alexnet.Result"
+checkvar = ".\"tensorflow_nhwc\".Results | .[] | .alexnet.Result"
 checktype = "mean"
 midval = 98.0
 minpercent = 20.0

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -80,7 +80,7 @@ function run_test_blogbench() {
 function run_test_tensorflow() {
 	info "Running TensorFlow test using ${KATA_HYPERVISOR} hypervisor"
 
-	bash tests/metrics/machine_learning/tensorflow.sh 1 20
+	bash tests/metrics/machine_learning/tensorflow_nhwc.sh 1 20
 
 	check_metrics
 }


### PR DESCRIPTION
This PR fixes the check results for tensorflow benchmark now that we change the name of the test.

Fixes #7684