### PR TITLE
runtime: Extend the extraOption structure

### DIFF
--- a/src/runtime/virtcontainers/nydusd.go
+++ b/src/runtime/virtcontainers/nydusd.go
@@ -480,6 +480,8 @@ type extraOption struct {
 	Source      string `json:"source"`
 	Config      string `json:"config"`
 	Snapshotdir string `json:"snapshotdir"`
+	Version     string `json:"fs_version,omitempty"`
+	Verity      string `json:"verity,omitempty"`
 }
 
 const extraOptionKey = "extraoption="
@@ -495,7 +497,11 @@ func parseExtraOption(options []string) (*extraOption, error) {
 		return nil, errors.New("no extraoption found")
 	}
 
-	opt, err := base64.StdEncoding.DecodeString(extraOpt)
+	return decodeExtraOption(extraOpt)
+}
+func decodeExtraOption(extraoption string) (*extraOption, error) {
+
+	opt, err := base64.StdEncoding.DecodeString(extraoption)
 	if err != nil {
 		return nil, errors.Wrap(err, "base64 decoding err")
 	}

--- a/src/runtime/virtcontainers/nydusd_test.go
+++ b/src/runtime/virtcontainers/nydusd_test.go
@@ -160,8 +160,18 @@ func TestParseExtraOption(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "valid option",
+			name:    "valid option without version and verity",
 			option:  "extraoption=" + base64.StdEncoding.EncodeToString([]byte("{\"source\":\"/path/to/bootstrap\",\"config\":\"config content\",\"snapshotdir\":\"/path/to/snapshotdir\"}")),
+			wantErr: false,
+		},
+		{
+			name:    "valid option with version without verity",
+			option:  "extraoption=" + base64.StdEncoding.EncodeToString([]byte("{\"source\":\"/path/to/bootstrap\",\"config\":\"config content\",\"snapshotdir\":\"/path/to/snapshotdir\",\"version\":\"v5\"}")),
+			wantErr: false,
+		},
+		{
+			name:    "valid option with verity without version",
+			option:  "extraoption=" + base64.StdEncoding.EncodeToString([]byte("{\"source\":\"/path/to/bootstrap\",\"config\":\"config content\",\"snapshotdir\":\"/path/to/snapshotdir\",\"verity\":\"3865,1982464,sha256:f07fa2ae9f9177d17414ce4ca3348b51c0609b9cc0a24b8ef062d73143dc3193\"}")),
 			wantErr: false,
 		},
 		{


### PR DESCRIPTION
Add two fields in nydus extraOption. 
`Version`: Rafs version if not empty
`Verity`:  strings of block dm-verity info, including: data block number, offset and root hash, such as:`"1024,524288,sha256:9de18652fe74edfb9b805aaed72ae2aa48f94333f1ba5c452ac33b1c39325174"`

depends: https://github.com/containerd/nydus-snapshotter/pull/502, https://github.com/containerd/nydus-snapshotter/pull/499

Fixes https://github.com/kata-containers/kata-containers/issues/7687