### PR TITLE
metrics: Fix README for pytorch

### DIFF
--- a/tests/metrics/machine_learning/README.md
+++ b/tests/metrics/machine_learning/README.md
@@ -14,7 +14,7 @@ Individual tests can be run by hand, for example:
 
 ```
 $ cd metrics/machine_learning
-$ ./tensorflow.sh 25 60
+$ ./tensorflow_nhwc.sh 25 60
 ```
 # Kata Containers Pytorch Metrics
 
@@ -28,7 +28,7 @@ Individual tests can be run by hand, for example:
 
 ```
 $ cd metrics/machine_learning
-$ ./tensorflow.sh 40 100
+$ ./pytorch.sh 40 100
 ```
 # Kata Containers TensorFlow `MobileNet` Metrics
 


### PR DESCRIPTION
This PR fixes the pytorch reference in the README file.

Fixes #7689