### PR TITLE
dragonball: add metrics support for legacy device

### DIFF
--- a/src/dragonball/src/dbs_legacy_devices/src/i8042.rs
+++ b/src/dragonball/src/dbs_legacy_devices/src/i8042.rs
@@ -30,16 +30,20 @@ pub struct I8042DeviceMetrics {
 pub type I8042Device = I8042Wrapper<EventFdTrigger>;
 
 pub struct I8042Wrapper<T: Trigger> {
-    pub device: I8042Dev<T>,
-    pub metrics: Arc<I8042DeviceMetrics>,
+    device: I8042Dev<T>,
+    metrics: Arc<I8042DeviceMetrics>,
 }
 
 impl I8042Device {
-    pub fn new(event: EventFdTrigger, metrics: Arc<I8042DeviceMetrics>) -> Self {
+    pub fn new(event: EventFdTrigger) -> Self {
         Self {
             device: I8042Dev::new(event),
-            metrics,
+            metrics: Arc::new(I8042DeviceMetrics::default()),
         }
+    }
+
+    pub fn metrics(&self) -> Arc<I8042DeviceMetrics> {
+        self.metrics.clone()
     }
 }
 

--- a/src/dragonball/src/dbs_legacy_devices/src/serial.rs
+++ b/src/dragonball/src/dbs_legacy_devices/src/serial.rs
@@ -96,6 +96,10 @@ impl SerialDevice {
             out,
         }
     }
+
+    pub fn metrics(&mut self) -> Arc<SerialDeviceMetrics> {
+        self.serial.events().metrics.clone()
+    }
 }
 
 pub struct SerialWrapper<T: Trigger, EV: SerialEvents> {

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -60,7 +60,7 @@ mod legacy;
 pub use self::legacy::{Error as LegacyDeviceError, LegacyDeviceManager};
 
 #[cfg(target_arch = "aarch64")]
-pub use self::legacy::aarch64::{COM1, COM2, RTC};
+pub use self::legacy::aarch64::{COM1_NAME, COM2_NAME, RTC_NAME};
 
 #[cfg(feature = "virtio-vsock")]
 /// Device manager for user-space vsock devices.
@@ -823,9 +823,9 @@ impl DeviceManager {
     ) -> std::result::Result<HashMap<String, DeviceResources>, StartMicroVmError> {
         let mut resources = HashMap::new();
         let legacy_devices = vec![
-            (DeviceType::Serial, String::from(COM1)),
-            (DeviceType::Serial, String::from(COM2)),
-            (DeviceType::RTC, String::from(RTC)),
+            (DeviceType::Serial, String::from(COM1_NAME)),
+            (DeviceType::Serial, String::from(COM2_NAME)),
+            (DeviceType::RTC, String::from(RTC_NAME)),
         ];
 
         for (device_type, device_id) in legacy_devices {

--- a/src/dragonball/src/metric.rs
+++ b/src/dragonball/src/metric.rs
@@ -5,6 +5,11 @@
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
+#[cfg(target_arch = "x86_64")]
+use dbs_legacy_devices::I8042DeviceMetrics;
+#[cfg(target_arch = "aarch64")]
+use dbs_legacy_devices::RTCDeviceMetrics;
+use dbs_legacy_devices::SerialDeviceMetrics;
 use dbs_utils::metric::SharedIncMetric;
 #[cfg(feature = "virtio-balloon")]
 use dbs_virtio_devices::balloon::BalloonDeviceMetrics;
@@ -64,6 +69,14 @@ pub struct DragonballMetrics {
     pub seccomp: SeccompMetrics,
     /// Metrics related to signals.
     pub signals: SignalMetrics,
+    /// Metrics related to i8032 device.
+    #[cfg(target_arch = "x86_64")]
+    pub i8042: Arc<I8042DeviceMetrics>,
+    /// Metrics related to rtc device.
+    #[cfg(target_arch = "aarch64")]
+    pub rtc: Arc<RTCDeviceMetrics>,
+    /// Metrics related to serial device.
+    pub serial: HashMap<String, Arc<SerialDeviceMetrics>>,
     #[cfg(feature = "virtio-balloon")]
     /// Metrics related to balloon device.
     pub balloon: HashMap<String, Arc<BalloonDeviceMetrics>>,


### PR DESCRIPTION
This PR unifies the legacy device metrics interface and outputs the metrics to runtime.

Fixes: #7248

Signed-off-by: lisongqian <mail@lisongqian.cn>