### PR TITLE
dragonball: output virtio-net device metrics to runtime

### DIFF
--- a/src/dragonball/src/device_manager/virtio_net_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/virtio_net_dev_mgr.rs
@@ -22,6 +22,7 @@ use crate::config_manager::{
 };
 use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::get_bucket_update;
+use crate::metric::METRICS;
 
 use super::DbsMmioV2Device;
 
@@ -368,6 +369,11 @@ impl VirtioNetDeviceMgr {
             rx_rate_limiter,
             tx_rate_limiter,
         )?;
+        METRICS
+            .write()
+            .unwrap()
+            .net
+            .insert(cfg.host_dev_name.clone(), net_device.metrics());
 
         Ok(Box::new(net_device))
     }
@@ -380,6 +386,11 @@ impl VirtioNetDeviceMgr {
                 "remove virtio-net device: {}",
                 info.config.iface_id
             );
+            METRICS
+                .write()
+                .unwrap()
+                .net
+                .remove(info.config.host_dev_name.as_str());
             if let Some(device) = info.device.take() {
                 DeviceManager::destroy_mmio_virtio_device(device, ctx)?;
             }

--- a/src/dragonball/src/metric.rs
+++ b/src/dragonball/src/metric.rs
@@ -13,6 +13,8 @@ use dbs_legacy_devices::SerialDeviceMetrics;
 use dbs_utils::metric::SharedIncMetric;
 #[cfg(feature = "virtio-balloon")]
 use dbs_virtio_devices::balloon::BalloonDeviceMetrics;
+#[cfg(feature = "virtio-net")]
+use dbs_virtio_devices::net::NetDeviceMetrics;
 use lazy_static::lazy_static;
 use serde::Serialize;
 
@@ -77,6 +79,9 @@ pub struct DragonballMetrics {
     pub rtc: Arc<RTCDeviceMetrics>,
     /// Metrics related to serial device.
     pub serial: HashMap<String, Arc<SerialDeviceMetrics>>,
+    #[cfg(feature = "virtio-net")]
+    /// Metrics related to net device.
+    pub net: HashMap<String, Arc<NetDeviceMetrics>>,
     #[cfg(feature = "virtio-balloon")]
     /// Metrics related to balloon device.
     pub balloon: HashMap<String, Arc<BalloonDeviceMetrics>>,


### PR DESCRIPTION
Virtio-net device manager adds net device metrics to METRICS when a device is created and remove metrics when a device is dropped.

Fixes: #7248

Signed-off-by: lisongqian <mail@lisongqian.cn>