### PR TITLE
WIP: tests: really use initrd for testing on mariner

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -60,7 +60,7 @@ function deploy_kata() {
     fi
 
     echo "::group::kata-deploy logs"
-    kubectl -n kube-system logs -l name=kata-deploy
+    kubectl -n kube-system logs --tail=100 -l name=kata-deploy
     echo "::endgroup::"
 
     echo "::group::Runtime classes"

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -120,6 +120,10 @@ function install_artifacts() {
 		sed -i -E 's|(enable_annotations) = .+|\1 = ["enable_iommu", "initrd", "kernel"]|' "${config_path}"
 		sed -i -E "s|(valid_hypervisor_paths) = .+|\1 = [\"${clh_path}\"]|" "${config_path}"
 		sed -i -E "s|(path) = \".+/cloud-hypervisor\"|\1 = \"${clh_path}\"|" "${config_path}"
+
+		# TODO: remove this debugging hack.
+		local incorrect_image="/opt/kata/share/kata-containers/kata-containers.img"
+		[ -f "${incorrect_image}" ] && echo "kata-deploy.sh hack: deleting ${incorrect_image}" && rm "${incorrect_image}"
 	fi
 
 	if [[ "${CREATE_RUNTIMECLASSES}" == "true" ]]; then


### PR DESCRIPTION
The k8s tests are using kata-containers.img instead of 
kata-containers-initrd-mariner.img.
