### PR TITLE
runtime: use custom initrd, not configured image

### DIFF
--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -705,6 +705,20 @@ func (conf *HypervisorConfig) assetPath(t types.AssetType) (string, error) {
 		return a.Path(), nil
 	}
 
+	if t == types.ImageAsset {
+		_, ok = conf.customAssets[types.InitrdAsset]
+		if ok {
+			// Use the initrd custom asset instead of the configured image.
+			return "", nil
+		}
+	} else if t == types.InitrdAsset {
+		_, ok = conf.customAssets[types.ImageAsset]
+		if ok {
+			// Use the image custom asset instead of the configured initrd.
+			return "", nil
+		}
+	}
+
 	// We could not find a custom asset for the given type, let's
 	// fall back to the configured ones.
 	switch t {


### PR DESCRIPTION
- Use a custom initrd asset instead of a configured image.
- Use a custom images asset instead of a configured initrd.

Fixes: #7705