### PR TITLE
gha: capture additional kata-deploy output

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -60,7 +60,7 @@ function deploy_kata() {
     fi
 
     echo "::group::kata-deploy logs"
-    kubectl -n kube-system logs -l name=kata-deploy
+    kubectl -n kube-system logs --tail=100 -l name=kata-deploy
     echo "::endgroup::"
 
     echo "::group::Runtime classes"


### PR DESCRIPTION
10 lines can be insufficient for diagnostics.

Fixes: #7707