### PR TITLE
CC: kata-deploy: Set the snapshotter in the containerd runtime config

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -308,7 +308,6 @@ function configure_containerd_runtime() {
 		cat <<EOF | tee -a "$containerd_conf_file"
 [$runtime_table]
   runtime_type = "${runtime_type}"
-  cri_handler = "cc"
   snapshotter = "${SNAPSHOTTER}"
   privileged_without_host_devices = true
   pod_annotations = ["io.katacontainers.*"]

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -309,6 +309,7 @@ function configure_containerd_runtime() {
 [$runtime_table]
   runtime_type = "${runtime_type}"
   cri_handler = "cc"
+  snapshotter = "${SNAPSHOTTER}"
   privileged_without_host_devices = true
   pod_annotations = ["io.katacontainers.*"]
 EOF
@@ -414,6 +415,7 @@ function main() {
 	echo "* DEFAULT_SHIM: ${DEFAULT_SHIM}"
 	echo "* CREATE_RUNTIMECLASSES: ${CREATE_RUNTIMECLASSES}"
 	echo "* CREATE_DEFAULT_RUNTIMECLASS: ${CREATE_DEFAULT_RUNTIMECLASS}"
+	echo "* SNAPSHOTTER: ${SNAPSHOTTER}"
 
 	# script requires that user is root
 	euid=$(id -u)


### PR DESCRIPTION
This is a patch that should **NOT** be forward ported to main, as there we want to take a cleaner approach on configuring specific snapshotters for specific runtime handlers.

However, for CC, for the v0.8.0 release of CC, this is good enough as it is, and it'll allow us to set one snapshotter for all the deployments done with the CoCo Operator.

This is the Kata Containers counterpart of the work, and there's still work to be done on the Confidential Containers in order to make it work as expected, as:
* Confidential Containers Operator has to expose to the users which snapshotter will be configured
* Confidential Containers Opereator, specifically the pre-install hook, will have to take care of actually installing and configuring the snapshotter, so it can be used.