### PR TITLE
metrics: Add disk link to README

### DIFF
--- a/tests/metrics/README.md
+++ b/tests/metrics/README.md
@@ -78,6 +78,8 @@ For further details see the [storage tests documentation](storage).
 
 Test relating to measure reading and writing against clusters.
 
+For further details see the [disk tests documentation](disk).
+
 ### Machine Learning
 
 Tests relating with TensorFlow and Pytorch implementations of several popular


### PR DESCRIPTION
This PR adds disk link to README documentation for kata metrics.

Fixes #7721