### PR TITLE
libs,tests: fix typo disable_guest_seccomp in configuration-anno-1.toml

### DIFF
--- a/src/libs/kata-types/tests/texture/configuration-anno-1.toml
+++ b/src/libs/kata-types/tests/texture/configuration-anno-1.toml
@@ -72,7 +72,7 @@ container_pipe_size = 2
 [runtime]
 enable_debug = true
 internetworking_model="macvtap"
-pdisable_guest_seccomp=true
+disable_guest_seccomp=true
 enable_tracing = true
 jaeger_endpoint = "localhost:1234"
 jaeger_user = "user"


### PR DESCRIPTION
Change `pdisable_guest_seccomp` to `disable_guest_seccomp`

Fixes: #7727