### PR TITLE
Makefile: Use cargo build/test --workspace instead of --all

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -149,7 +149,7 @@ vendor:
 
 #TARGET test: run cargo tests
 test:
-	@cargo test --all --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
+	@cargo test --workspace --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
 
 ##TARGET check: run test
 check: $(GENERATED_FILES) standard_rust_check

--- a/src/libs/Makefile
+++ b/src/libs/Makefile
@@ -38,8 +38,8 @@ clean:
 # See the `test_logger_levels()` test for further information.
 test:
 	@echo "INFO: testing libraries for development build"
-	cargo test --all $(EXTRA_RUSTFEATURES) -- --nocapture $(EXTRA_TEST_FLAGS)
+	cargo test --workspace $(EXTRA_RUSTFEATURES) -- --nocapture $(EXTRA_TEST_FLAGS)
 	@echo "INFO: testing libraries for release build"
-	cargo test --release --all $(EXTRA_RUSTFEATURES) -- --nocapture $(EXTRA_TEST_FLAGS)
+	cargo test --release --workspace $(EXTRA_RUSTFEATURES) -- --nocapture $(EXTRA_TEST_FLAGS)
 
 .PHONY: install vendor

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -50,7 +50,7 @@ else
 default: runtime show-header
 ##TARGET test: run cargo tests
 test:
-	@cargo test --all --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
+	@cargo test --workspace --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
 install: install-runtime install-configs
 endif
 

--- a/src/tools/runk/Makefile
+++ b/src/tools/runk/Makefile
@@ -53,7 +53,7 @@ vendor:
 test: test-runk test-agent
 
 test-runk:
-	cargo test --all --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
+	cargo test --workspace --target $(TRIPLE) $(EXTRA_RUSTFEATURES) -- --nocapture
 
 test-agent:
 	make test -C $(AGENT_SOURCE_PATH) STANDARD_OCI_RUNTIME=yes

--- a/src/tools/trace-forwarder/Makefile
+++ b/src/tools/trace-forwarder/Makefile
@@ -25,7 +25,7 @@ vendor:
 	cargo vendor
 
 test:
-	@cargo test --all -- --nocapture
+	@cargo test --workspace -- --nocapture
 
 install:
 


### PR DESCRIPTION
Replace `--all` option with `--workspace` because the `--all` has been deprecated since cargo v1.39.

Fixes: #7730