### PR TITLE
runtime-rs: check peer close in log_forwarder

### DIFF
--- a/src/runtime-rs/crates/agent/src/log_forwarder.rs
+++ b/src/runtime-rs/crates/agent/src/log_forwarder.rs
@@ -64,16 +64,14 @@ impl LogForwarder {
                     Ok(stream) => {
                         let stream = BufReader::new(stream);
                         let mut lines = stream.lines();
-                        while let Ok(line) = lines.next_line().await {
-                            if let Some(l) = line {
-                                match parse_agent_log_level(&l) {
-                                    LOG_LEVEL_TRACE => trace!(sl!(), "{}", l),
-                                    LOG_LEVEL_DEBUG => debug!(sl!(), "{}", l),
-                                    LOG_LEVEL_WARNING => warn!(sl!(), "{}", l),
-                                    LOG_LEVEL_ERROR => error!(sl!(), "{}", l),
-                                    LOG_LEVEL_CRITICAL => crit!(sl!(), "{}", l),
-                                    _ => info!(sl!(), "{}", l),
-                                }
+                        while let Ok(Some(l)) = lines.next_line().await {
+                            match parse_agent_log_level(&l) {
+                                LOG_LEVEL_TRACE => trace!(sl!(), "{}", l),
+                                LOG_LEVEL_DEBUG => debug!(sl!(), "{}", l),
+                                LOG_LEVEL_WARNING => warn!(sl!(), "{}", l),
+                                LOG_LEVEL_ERROR => error!(sl!(), "{}", l),
+                                LOG_LEVEL_CRITICAL => crit!(sl!(), "{}", l),
+                                _ => info!(sl!(), "{}", l),
                             }
                         }
                     }


### PR DESCRIPTION
The log_forwarder task does not check if the peer has closed, causing a meaningless loop during the period of “kata vm exit”, when the peer closed, and “ShutdownContainer RPC received” that aborts the log forwarder.

This patch fixes the problem.

Fixed: #7741