### PR TITLE
gha: vfio: Run on Ubuntu 23.04 runner

### DIFF
--- a/.github/workflows/run-vfio-tests.yaml
+++ b/.github/workflows/run-vfio-tests.yaml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         vmm: ['clh', 'qemu']
-    runs-on: garm-ubuntu-2204
+    runs-on: garm-ubuntu-2304
     env:
       GOPATH: ${{ github.workspace }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}


### PR DESCRIPTION
Move the test to run on Ubuntu 23.04, which already ships kernel v6.2. We need this to get L3 virtualization to work.

To be merged before #7704 so that the other PR can make use of it (thanks GHA...).