### PR TITLE
kata-deploy: Don't try to remove /opt/kata

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -357,7 +357,7 @@ function configure_containerd() {
 
 function remove_artifacts() {
 	echo "deleting kata artifacts"
-	rm -rf /opt/kata/
+	rm -rf /opt/kata/*
 }
 
 function cleanup_cri_runtime() {


### PR DESCRIPTION
The directory is a host path mount and cannot be removed from within the container.  What we actually want to remove is whatever is inside that directory.

This may raise errors like:
```
rm: cannot remove '/opt/kata/': Device or resource busy
```

Fixes: #7746