### PR TITLE
tests: delete k8s deployment at the test's end

### DIFF
--- a/tests/integration/kubernetes/k8s-pod-quota.bats
+++ b/tests/integration/kubernetes/k8s-pod-quota.bats
@@ -31,5 +31,6 @@ setup() {
 }
 
 teardown() {
+	kubectl delete -f "${pod_config_dir}/pod-quota-deployment.yaml"
 	kubectl delete -f "${pod_config_dir}/resource-quota.yaml"
 }


### PR DESCRIPTION
At the end of k8s-kill-all-process-in-container.bats, delete the deployment it created.

Fixes: #7752