### PR TITLE
tests: use unique test name

### DIFF
--- a/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
+++ b/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
@@ -15,7 +15,7 @@ setup() {
 	get_pod_config_dir
 }
 
-@test "Check PID namespaces" {
+@test "Kill all processes in container" {
 	# Create the pod
 	kubectl create -f "${pod_config_dir}/initcontainer-shareprocesspid.yaml"
 


### PR DESCRIPTION
k8s-pid-ns.bats was already using the test name from k8s-kill-all-process-in-container.bats - probably a copy/paste bug.

Fixes: #7753