### PR TITLE
3.2 backport | kata-agent: use default filemode for block device when it is set to 0

### DIFF
--- a/src/agent/rustjail/src/lib.rs
+++ b/src/agent/rustjail/src/lib.rs
@@ -423,12 +423,18 @@ fn linux_grpc_to_oci(l: &grpc::Linux) -> oci::Linux {
         let mut r = Vec::new();
 
         for d in l.Devices.iter() {
+            // if the filemode for the device is 0 (unset), use a default value as runc does
+            let filemode = if d.FileMode != 0 {
+                Some(d.FileMode)
+            } else {
+                Some(0o666)
+            };
             r.push(oci::LinuxDevice {
                 path: d.Path.clone(),
                 r#type: d.Type.clone(),
                 major: d.Major,
                 minor: d.Minor,
-                file_mode: Some(d.FileMode),
+                file_mode: filemode,
                 uid: Some(d.UID),
                 gid: Some(d.GID),
             });


### PR DESCRIPTION
This is a backport of #7718 

When the FileMode field for the device is unset (0), use a default value instead to allow the use of the device from the container. This behaviour is seen from cri-o typically.

Note: this is what runc is doing, which is why regular containers don't have an issue. This change makes sure kata behaves the same as runc.

