### PR TITLE
gha: Avoid "fail-fast" in tests that are known to be flaky

### DIFF
--- a/.github/workflows/run-cri-containerd-tests.yaml
+++ b/.github/workflows/run-cri-containerd-tests.yaml
@@ -12,7 +12,10 @@ on:
 jobs:
   run-cri-containerd:
     strategy:
-      fail-fast: true
+      # We can set this to true whenever we're 100% sure that
+      # the all the tests are not flaky, otherwise we'll fail
+      # all the tests due to a single flaky instance.
+      fail-fast: false
       matrix:
         containerd_version: ['lts', 'active']
         vmm: ['clh', 'qemu']

--- a/.github/workflows/run-metrics.yaml
+++ b/.github/workflows/run-metrics.yaml
@@ -32,7 +32,10 @@ jobs:
   run-metrics:
     needs: setup-kata
     strategy:
-      fail-fast: true
+      # We can set this to true whenever we're 100% sure that
+      # the all the tests are not flaky, otherwise we'll fail
+      # all the tests due to a single flaky instance.
+      fail-fast: false
       matrix:
         vmm: ['clh', 'qemu']
       max-parallel: 1

--- a/.github/workflows/run-nydus-tests.yaml
+++ b/.github/workflows/run-nydus-tests.yaml
@@ -12,7 +12,10 @@ on:
 jobs:
   run-nydus:
     strategy:
-      fail-fast: true
+      # We can set this to true whenever we're 100% sure that
+      # the all the tests are not flaky, otherwise we'll fail
+      # all the tests due to a single flaky instance.
+      fail-fast: false
       matrix:
         containerd_version: ['lts', 'active']
         vmm: ['clh', 'qemu', 'dragonball']

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -15,6 +15,10 @@ jobs:
   static-checks:
     runs-on: garm-ubuntu-2004
     strategy:
+      # We can set this to true whenever we're 100% sure that
+      # the all the tests are not flaky, otherwise we'll fail
+      # all the tests due to a single flaky instance.
+      fail-fast: false
       matrix:
         cmd:
           - "make vendor"


### PR DESCRIPTION
Otherwise we'll have to re-run all the tests due to a flaky behaviour in one of the parts.

Fixes: #7757