### PR TITLE
CC | github: add workflow for publishing runtime-payload for ppc64le

### DIFF
--- a/.github/workflows/cc-payload-ppc64le.yaml
+++ b/.github/workflows/cc-payload-ppc64le.yaml
@@ -1,0 +1,74 @@
+name: Publish Kata Containers payload for Confidential Containers (ppc64le)
+on:
+  workflow_call:
+    inputs:
+      target-arch:
+        required: true
+        type: string
+
+jobs:
+  build-asset-cc-shim-v2:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build cc-shim-v2
+        run: |
+          make CROSS_BUILD=true ARCH=${{ inputs.target-arch }} TARGET_ARCH=${{ inputs.target-arch }} cc-shim-v2-tarball
+          build_dir=$(readlink -f build)
+          # store-artifact does not work with symlink
+          sudo cp -r "${build_dir}" "kata-build"
+
+      - name: store-artifact cc-shim-v2
+        uses: actions/upload-artifact@v3
+        with:
+          name: kata-artifacts-ppc64le
+          path: kata-build/kata-static-cc-shim-v2.tar.xz
+          retention-days: 1
+          if-no-files-found: error
+
+  create-kata-tarball:
+    runs-on: ubuntu-latest
+    needs: build-asset-cc-shim-v2
+    steps:
+      - uses: actions/checkout@v3
+      - name: get-artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-artifacts-ppc64le
+          path: kata-artifacts
+      - name: merge-artifacts
+        run: |
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts
+      - name: store-artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: kata-static-tarball-ppc64le
+          path: kata-static.tar.xz
+          retention-days: 1
+          if-no-files-found: error
+
+  kata-payload:
+    needs: create-kata-tarball
+    runs-on: ubuntu-latest
+    steps:
+      - name: Login to quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.COCO_QUAY_DEPLOYER_USERNAME }}
+          password: ${{ secrets.COCO_QUAY_DEPLOYER_PASSWORD }}
+
+      - uses: actions/checkout@v3
+      - name: get-kata-tarball
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-static-tarball-ppc64le
+
+      - name: build-and-push-kata-payload
+        id: build-and-push-kata-payload
+        run: |
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+          $(pwd)/kata-static.tar.xz \
+          "quay.io/confidential-containers/runtime-payload" \
+          "kata-containers-${{ inputs.target-arch }}" \
+          cross-build ${{ inputs.target-arch }}

--- a/.github/workflows/cc-payload.yaml
+++ b/.github/workflows/cc-payload.yaml
@@ -16,10 +16,16 @@ jobs:
     with:
       target-arch: s390x
     secrets: inherit
+    
+  build-assets-ppc64le:
+    uses: ./.github/workflows/cc-payload-ppc64le.yaml
+    with:
+      target-arch: ppc64le
+    secrets: inherit
 
   publish:
     runs-on: ubuntu-latest
-    needs: [build-assets-amd64, build-assets-s390x]
+    needs: [build-assets-amd64, build-assets-s390x, build-assets-ppc64le]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -35,12 +41,14 @@ jobs:
         run: |
           docker manifest create quay.io/confidential-containers/runtime-payload:kata-containers-${GITHUB_SHA} \
           --amend quay.io/confidential-containers/runtime-payload:kata-containers-${GITHUB_SHA}-amd64 \
-          --amend quay.io/confidential-containers/runtime-payload:kata-containers-${GITHUB_SHA}-s390x
+          --amend quay.io/confidential-containers/runtime-payload:kata-containers-${GITHUB_SHA}-s390x \
+          --amend quay.io/confidential-containers/runtime-payload:kata-containers-${GITHUB_SHA}-ppc64le
           docker manifest push quay.io/confidential-containers/runtime-payload:kata-containers-${GITHUB_SHA}
 
       - name: Push latest multi-arch manifest
         run: |
           docker manifest create quay.io/confidential-containers/runtime-payload:kata-containers-latest \
           --amend quay.io/confidential-containers/runtime-payload:kata-containers-amd64 \
-          --amend quay.io/confidential-containers/runtime-payload:kata-containers-s390x
+          --amend quay.io/confidential-containers/runtime-payload:kata-containers-s390x \
+          --amend quay.io/confidential-containers/runtime-payload:kata-containers-ppc64le
           docker manifest push quay.io/confidential-containers/runtime-payload:kata-containers-latest

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -113,7 +113,7 @@ options:
 	cc-rootfs-initrd
 	cc-sev-rootfs-initrd
 	cc-se-image
-	cc-shimv2
+	cc-shim-v2
 EOF
 
 	exit "${return_code}"
@@ -173,8 +173,8 @@ install_cached_cc_shim_v2() {
 	local root_hash_vanilla="${repo_root_dir}/tools/osbuilder/root_hash_vanilla.txt"
 	local root_hash_tdx="${repo_root_dir}/tools/osbuilder/root_hash_tdx.txt"
 
-	local rootfs_image_cached_root_hash="${jenkins_url}/job/kata-containers-2.0-rootfs-image-cc-$(uname -m)/${cached_artifacts_path}/root_hash_vanilla.txt"
-	local tdx_rootfs_image_cached_root_hash="${jenkins_url}/job/kata-containers-2.0-rootfs-image-tdx-cc-$(uname -m)/${cached_artifacts_path}/root_hash_tdx.txt"
+	local rootfs_image_cached_root_hash="${jenkins_url}/job/kata-containers-2.0-rootfs-image-cc-${ARCH}/${cached_artifacts_path}/root_hash_vanilla.txt"
+	local tdx_rootfs_image_cached_root_hash="${jenkins_url}/job/kata-containers-2.0-rootfs-image-tdx-cc-${ARCH}/${cached_artifacts_path}/root_hash_tdx.txt"
 
 
 	wget "${rootfs_image_cached_root_hash}" -O "rootfs_root_hash_vanilla.txt" || return 1
@@ -256,7 +256,7 @@ install_cc_shimv2() {
 
 	install_cached_cc_shim_v2 \
 		"shim-v2" \
-		"${jenkins_url}/job/kata-containers-2.0-shim-v2-cc-$(uname -m)/${cached_artifacts_path}" \
+		"${jenkins_url}/job/kata-containers-2.0-shim-v2-cc-${ARCH}/${cached_artifacts_path}" \
 		"${shim_v2_version}" \
 		"$(get_shim_v2_image_name)" \
 		"${final_tarball_name}" \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -15,6 +15,10 @@ KATA_DEPLOY_DIR="`dirname ${0}`/../../kata-deploy"
 KATA_DEPLOY_ARTIFACT="${1:-"kata-static.tar.xz"}"
 REGISTRY="${2:-"quay.io/confidential-containers/runtime-payload"}"
 TAG="${3:-}"
+CROSS_BUILD="${4:-}"
+TARGET_ARCH="${5:-}"
+BUILDX=
+PLATFORM=
 
 echo "Copying ${KATA_DEPLOY_ARTIFACT} to ${KATA_DEPLOY_DIR}"
 cp ${KATA_DEPLOY_ARTIFACT} ${KATA_DEPLOY_DIR}
@@ -23,19 +27,27 @@ pushd ${KATA_DEPLOY_DIR}
 
 arch=$(uname -m)
 [ "$arch" = "x86_64" ] && arch="amd64"
-IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-${arch}"
+IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)"
+
+if [ -n "${CROSS_BUILD}" ]; then
+	# TAG the image, build and push it
+	arch=${TARGET_ARCH}
+	BUILDX=buildx
+	PLATFORM="--platform=linux/${arch}"
+fi
+
 
 echo "Building the image"
-docker build --tag ${IMAGE_TAG} .
+docker ${BUILDX} build ${PLATFORM} --tag ${IMAGE_TAG}-${arch} .
 
 echo "Pushing the image to the registry"
-docker push ${IMAGE_TAG}
+docker push ${IMAGE_TAG}-${arch}
 
 if [ -n "${TAG}" ]; then
 	ADDITIONAL_TAG="${REGISTRY}:${TAG}"
 
 	echo "Building the ${ADDITIONAL_TAG} image"
-	docker build --tag ${ADDITIONAL_TAG} .
+	docker ${BUILDX} build ${PLATFORM} --tag ${ADDITIONAL_TAG} .
 
 	echo "Pushing the image ${ADDITIONAL_TAG} to the registry"
 	docker push ${ADDITIONAL_TAG}


### PR DESCRIPTION
This PR adds
* support for building and publishing runtime-payload image for `ppc64le`
* Leverages docker buildx to build `cc-shim-v2` and the final paylaod image to support the platform `ppc64le`

Fixes:https://github.com/kata-containers/kata-containers/issues/7759

Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>