### PR TITLE
runtime-rs: bring hybrid vsock devices in manager.

### DIFF
--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -1123,6 +1123,7 @@ dependencies = [
  "anyhow",
  "hyper",
  "hyperlocal",
+ "kata-types",
  "tokio",
 ]
 

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -34,6 +34,9 @@ pub use self::runtime::{Runtime, RuntimeVendor, RUNTIME_NAME_VIRTCONTAINER};
 
 pub use self::agent::AGENT_NAME_KATA;
 
+/// kata run dir
+pub const KATA_PATH: &str = "/run/kata";
+
 // TODO: let agent use the constants here for consistency
 /// Debug console enabled flag for agent
 pub const DEBUG_CONSOLE_FLAG: &str = "agent.debug_console";

--- a/src/libs/shim-interface/Cargo.toml
+++ b/src/libs/shim-interface/Cargo.toml
@@ -16,3 +16,4 @@ anyhow = "^1.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 hyper = { version = "0.14.20", features = ["stream", "server", "http1"] }
 hyperlocal = "0.8"
+kata-types = { path = "../kata-types" }

--- a/src/libs/shim-interface/src/lib.rs
+++ b/src/libs/shim-interface/src/lib.rs
@@ -21,7 +21,8 @@ use anyhow::{anyhow, Result};
 
 pub mod shim_mgmt;
 
-pub const KATA_PATH: &str = "/run/kata";
+use kata_types::config::KATA_PATH;
+
 pub const SHIM_MGMT_SOCK_NAME: &str = "shim-monitor.sock";
 
 // return sandbox's storage path

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -3000,10 +3000,10 @@ dependencies = [
  "async-trait",
  "common",
  "containerd-shim-protos",
+ "kata-types",
  "logging",
  "persist",
  "runtimes",
- "shim-interface",
  "slog",
  "slog-scope",
  "tokio",
@@ -3107,6 +3107,7 @@ dependencies = [
  "anyhow",
  "hyper",
  "hyperlocal",
+ "kata-types",
  "tokio",
 ]
 

--- a/src/runtime-rs/crates/hypervisor/src/ch/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/utils.rs
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use shim_interface::KATA_PATH;
+
+use crate::utils::get_sandbox_path;
 
 // The socket used to connect to CH. This is used for CH API communications.
 const CH_API_SOCKET_NAME: &str = "ch-api.sock";
@@ -12,21 +13,11 @@ const CH_API_SOCKET_NAME: &str = "ch-api.sock";
 // Containers agent running inside the CH hosted VM.
 const CH_VM_SOCKET_NAME: &str = "ch-vm.sock";
 
-const CH_JAILER_DIR: &str = "root";
-
-// Return the path for a _hypothetical_ sandbox: the path does *not* exist
-// yet, and for this reason safe-path cannot be used.
-pub fn get_sandbox_path(id: &str) -> Result<String> {
-    let path = [KATA_PATH, id].join("/");
-
-    Ok(path)
-}
-
 // Return the path for a _hypothetical_ API socket path:
 // the path does *not* exist yet, and for this reason safe-path cannot be
 // used.
 pub fn get_api_socket_path(id: &str) -> Result<String> {
-    let sandbox_path = get_sandbox_path(id)?;
+    let sandbox_path = get_sandbox_path(id);
 
     let path = [&sandbox_path, CH_API_SOCKET_NAME].join("/");
 
@@ -37,17 +28,9 @@ pub fn get_api_socket_path(id: &str) -> Result<String> {
 // the path does *not* exist yet, and for this reason safe-path cannot be
 // used.
 pub fn get_vsock_path(id: &str) -> Result<String> {
-    let sandbox_path = get_sandbox_path(id)?;
+    let sandbox_path = get_sandbox_path(id);
 
     let path = [&sandbox_path, CH_VM_SOCKET_NAME].join("/");
-
-    Ok(path)
-}
-
-pub fn get_jailer_root(id: &str) -> Result<String> {
-    let sandbox_path = get_sandbox_path(id)?;
-
-    let path = [&sandbox_path, CH_JAILER_DIR].join("/");
 
     Ok(path)
 }

--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -11,9 +11,9 @@ use kata_sys_util::rand::RandomBytes;
 use tokio::sync::{Mutex, RwLock};
 
 use crate::{
-    vhost_user_blk::VhostUserBlkDevice, BlockConfig, BlockDevice, Hypervisor, NetworkDevice,
-    VfioDevice, VhostUserConfig, KATA_BLK_DEV_TYPE, KATA_MMIO_BLK_DEV_TYPE, KATA_NVDIMM_DEV_TYPE,
-    VIRTIO_BLOCK_MMIO, VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
+    vhost_user_blk::VhostUserBlkDevice, BlockConfig, BlockDevice, HybridVsockDevice, Hypervisor,
+    NetworkDevice, VfioDevice, VhostUserConfig, KATA_BLK_DEV_TYPE, KATA_MMIO_BLK_DEV_TYPE,
+    KATA_NVDIMM_DEV_TYPE, VIRTIO_BLOCK_MMIO, VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
 };
 
 use super::{
@@ -319,6 +319,10 @@ impl DeviceManager {
                 }
 
                 Arc::new(Mutex::new(NetworkDevice::new(device_id.clone(), config)))
+            }
+            DeviceConfig::HybridVsockCfg(hvconfig) => {
+                // No need to do find device for hybrid vsock device.
+                Arc::new(Mutex::new(HybridVsockDevice::new(&device_id, hvconfig)))
             }
             _ => {
                 return Err(anyhow!("invliad device type"));

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
@@ -24,7 +24,9 @@ pub use virtio_fs::{
     ShareFsOperation,
 };
 pub use virtio_net::{Address, NetworkConfig, NetworkDevice};
-pub use virtio_vsock::{HybridVsockConfig, HybridVsockDevice, VsockConfig, VsockDevice};
+pub use virtio_vsock::{
+    HybridVsockConfig, HybridVsockDevice, VsockConfig, VsockDevice, DEFAULT_GUEST_VSOCK_CID,
+};
 
 pub mod vhost_user_blk;
 pub use vhost_user::{VhostUserConfig, VhostUserDevice, VhostUserType};

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -19,11 +19,10 @@ use dragonball::{
 use kata_sys_util::mount;
 use kata_types::{
     capabilities::{Capabilities, CapabilityBits},
-    config::hypervisor::Hypervisor as HypervisorConfig,
+    config::{hypervisor::Hypervisor as HypervisorConfig, KATA_PATH},
 };
 use nix::mount::MsFlags;
 use persist::sandbox_persist::Persist;
-use shim_interface::KATA_PATH;
 use std::{collections::HashSet, fs::create_dir_all};
 
 const DRAGONBALL_KERNEL: &str = "vmlinux";

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -19,7 +19,7 @@ use dragonball::{
 use super::DragonballInner;
 use crate::{
     device::DeviceType, HybridVsockConfig, NetworkConfig, ShareFsDeviceConfig, ShareFsMountConfig,
-    ShareFsMountType, ShareFsOperation, VfioBusMode, VfioDevice, VmmState,
+    ShareFsMountType, ShareFsOperation, VfioBusMode, VfioDevice, VmmState, JAILER_ROOT,
 };
 
 const MB_TO_B: u32 = 1024 * 1024;
@@ -231,11 +231,12 @@ impl DragonballInner {
 
     fn add_hvsock(&mut self, config: &HybridVsockConfig) -> Result<()> {
         let vsock_cfg = VsockDeviceConfigInfo {
-            id: String::from("root"),
+            id: String::from(JAILER_ROOT),
             guest_cid: config.guest_cid,
             uds_path: Some(config.uds_path.clone()),
             ..Default::default()
         };
+        debug!(sl!(), "HybridVsock configure: {:?}", &vsock_cfg);
 
         self.vmm_instance
             .insert_vsock(vsock_cfg)

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -17,7 +17,7 @@ pub mod dragonball;
 mod kernel_param;
 pub mod qemu;
 pub use kernel_param::Param;
-mod utils;
+pub mod utils;
 use std::collections::HashMap;
 
 #[cfg(feature = "cloud-hypervisor")]
@@ -55,6 +55,9 @@ const SHMEM: &str = "shmem";
 
 pub const HYPERVISOR_DRAGONBALL: &str = "dragonball";
 pub const HYPERVISOR_QEMU: &str = "qemu";
+
+pub const DEFAULT_HYBRID_VSOCK_NAME: &str = "kata.hvsock";
+pub const JAILER_ROOT: &str = "root";
 
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) enum VmmState {

--- a/src/runtime-rs/crates/hypervisor/src/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/utils.rs
@@ -6,6 +6,10 @@
 
 use std::collections::HashSet;
 
+use kata_types::config::KATA_PATH;
+
+use crate::{DEFAULT_HYBRID_VSOCK_NAME, JAILER_ROOT};
+
 pub fn get_child_threads(pid: u32) -> HashSet<u32> {
     let mut result = HashSet::new();
     let path_name = format!("/proc/{}/task", pid);
@@ -24,4 +28,22 @@ pub fn get_child_threads(pid: u32) -> HashSet<u32> {
         }
     }
     result
+}
+
+// Return the path for a _hypothetical_ sandbox: the path does *not* exist
+// yet, and for this reason safe-path cannot be used.
+pub fn get_sandbox_path(sid: &str) -> String {
+    [KATA_PATH, sid].join("/")
+}
+
+pub fn get_hvsock_path(sid: &str) -> String {
+    let jailer_root_path = get_jailer_root(sid);
+
+    [jailer_root_path, DEFAULT_HYBRID_VSOCK_NAME.to_owned()].join("/")
+}
+
+pub fn get_jailer_root(sid: &str) -> String {
+    let sandbox_path = get_sandbox_path(sid);
+
+    [&sandbox_path, JAILER_ROOT].join("/")
 }

--- a/src/runtime-rs/crates/persist/src/lib.rs
+++ b/src/runtime-rs/crates/persist/src/lib.rs
@@ -6,8 +6,8 @@
 
 pub mod sandbox_persist;
 use anyhow::{anyhow, Context, Ok, Result};
+use kata_types::config::KATA_PATH;
 use serde::de;
-use shim_interface::KATA_PATH;
 use std::{fs::File, io::BufReader};
 
 pub const PERSIST_FILE: &str = "state.json";

--- a/src/runtime-rs/crates/resource/src/lib.rs
+++ b/src/runtime-rs/crates/resource/src/lib.rs
@@ -17,7 +17,7 @@ pub mod manager;
 mod manager_inner;
 pub mod network;
 pub mod resource_persist;
-use hypervisor::BlockConfig;
+use hypervisor::{BlockConfig, HybridVsockConfig};
 use network::NetworkConfig;
 pub mod rootfs;
 pub mod share_fs;
@@ -32,6 +32,7 @@ pub enum ResourceConfig {
     Network(NetworkConfig),
     ShareFs(SharedFsInfo),
     VmRootfs(BlockConfig),
+    HybridVsock(HybridVsockConfig),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -126,6 +126,11 @@ impl ResourceManagerInner {
                         .await
                         .context("do handle device failed.")?;
                 }
+                ResourceConfig::HybridVsock(hv) => {
+                    do_handle_device(&self.device_manager, &DeviceConfig::HybridVsockCfg(hv))
+                        .await
+                        .context("do handle hybrid-vsock device failed.")?;
+                }
             };
         }
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -15,6 +15,7 @@ use common::message::{Action, Message};
 use common::{Sandbox, SandboxNetworkEnv};
 use containerd_shim_protos::events::task::TaskOOM;
 use hypervisor::{dragonball::Dragonball, BlockConfig, Hypervisor, HYPERVISOR_DRAGONBALL};
+use hypervisor::{utils::get_hvsock_path, HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID};
 use kata_sys_util::hooks::HookStates;
 use kata_types::config::TomlConfig;
 use persist::{self, sandbox_persist::Persist};
@@ -100,6 +101,14 @@ impl VirtSandbox {
         network_env: SandboxNetworkEnv,
     ) -> Result<Vec<ResourceConfig>> {
         let mut resource_configs = vec![];
+
+        // Prepare VM hybrid vsock device config and add the hybrid vsock device first.
+        info!(sl!(), "prepare hybrid vsock resource for sandbox.");
+        let vm_hvsock = ResourceConfig::HybridVsock(HybridVsockConfig {
+            guest_cid: DEFAULT_GUEST_VSOCK_CID,
+            uds_path: get_hvsock_path(id),
+        });
+        resource_configs.push(vm_hvsock);
 
         // prepare network config
         if !network_env.network_created {

--- a/src/runtime-rs/crates/service/Cargo.toml
+++ b/src/runtime-rs/crates/service/Cargo.toml
@@ -17,6 +17,6 @@ ttrpc = { version = "0.7.1" }
 common = { path = "../runtimes/common" }
 containerd-shim-protos = { version = "0.3.0", features = ["async"]}
 logging = { path = "../../../libs/logging"}
-shim-interface = { path = "../../../libs/shim-interface" }
+kata-types = { path = "../../../libs/kata-types" }
 runtimes = { path = "../runtimes" }
 persist = { path = "../persist" }

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -17,8 +17,8 @@ use containerd_shim_protos::{
     protobuf::{well_known_types::any::Any, Message as ProtobufMessage},
     shim_async,
 };
+use kata_types::config::KATA_PATH;
 use runtimes::RuntimeHandlerManager;
-use shim_interface::KATA_PATH;
 use tokio::{
     io::AsyncWriteExt,
     process::Command,


### PR DESCRIPTION
Currently, virtio_vsock are still outside of the device manager. 
This causes some management issues,such as the inability to unify PCI address management.

Just do some work for hybrid vsock.

Fixes: #7655