### PR TITLE
metrics: Enable FIO limits for kata metrics

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -97,3 +97,16 @@ checktype = "mean"
 midval = 98.0
 minpercent = 20.0
 maxpercent = 20.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure write 90 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .write90percentile.Result"
+checktype = "mean"
+midval = 38656.0
+minpercent = 20.0
+maxpercent = 20.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -97,3 +97,16 @@ checktype = "mean"
 midval = 98.0
 minpercent = 20.0
 maxpercent = 20.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure write 90 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .write90percentile.Result"
+checktype = "mean"
+midval = 37120.0
+minpercent = 20.0
+maxpercent = 20.0

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -81,14 +81,14 @@ function run_test_tensorflow() {
 	info "Running TensorFlow test using ${KATA_HYPERVISOR} hypervisor"
 
 	bash tests/metrics/machine_learning/tensorflow_nhwc.sh 1 20
-
-	check_metrics
 }
 
 function run_test_fio() {
 	info "Running FIO test using ${KATA_HYPERVISOR} hypervisor"
 
 	bash tests/metrics/storage/fio-k8s/fio-test-ci.sh
+
+	check_metrics
 }
 
 function run_test_iperf() {


### PR DESCRIPTION
This PR enables the FIO limits for kata metrics.

Fixes #7771