### PR TITLE
metrics: Fix memory inside limits for kata metrics

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -29,7 +29,7 @@ description = "measure memory usage"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 2518364.00
+midval = 127220.25
 minpercent = 20.0
 maxpercent = 20.0
 

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -29,7 +29,7 @@ description = "measure memory usage"
 # within (inclusive)
 checkvar = ".\"memory-footprint\".Results | .[] | .average.Result"
 checktype = "mean"
-midval = 2435844.00
+midval = 122832.40
 minpercent = 20.0
 maxpercent = 20.0
 


### PR DESCRIPTION
This PR fixes the memory inside limit for clh for kata metrics due to the recent changes that we had in the script which impacted in the performance measurement.