### PR TITLE
versions: Bump guest-components

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -297,25 +297,6 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.59.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
-dependencies = [
- "bitflags",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
-]
-
-[[package]]
-name = "bindgen"
 version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36d860121800b2a9a94f9b5604b332d5cffb234ce17609ea479d723dbc9d3885"
@@ -1095,34 +1076,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "devicemapper"
-version = "0.33.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a9fd602a98d192f7662a1f4c4cf6920a1b454c3a9e724f6490cf8e30910114"
-dependencies = [
- "bitflags",
- "devicemapper-sys",
- "env_logger",
- "lazy_static",
- "log",
- "nix 0.26.2",
- "rand 0.8.5",
- "retry",
- "semver",
- "serde",
-]
-
-[[package]]
-name = "devicemapper-sys"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0b0f9d16560f830ae6e90b769017333c4561d2c84f39e7aa7d935d2e7bcbc4c"
-dependencies = [
- "bindgen 0.63.0",
- "nix 0.26.2",
-]
-
-[[package]]
 name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1360,19 +1313,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.28",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
 ]
 
 [[package]]
@@ -1858,12 +1798,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
-
-[[package]]
 name = "hyper"
 version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1953,14 +1887,13 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=3d8192f8d3efab041916ea4d60e32248ac6ec43d#3d8192f8d3efab041916ea4d60e32248ac6ec43d"
+source = "git+https://github.com/confidential-containers/guest-components?rev=53ddd632424432077e95d3901deb64727be0b4c1#53ddd632424432077e95d3901deb64727be0b4c1"
 dependencies = [
  "anyhow",
  "async-compression",
  "async-trait",
  "base64 0.21.2",
  "cfg-if 1.0.0",
- "devicemapper",
  "flate2",
  "futures",
  "futures-util",
@@ -2414,11 +2347,10 @@ dependencies = [
 
 [[package]]
 name = "loopdev"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bfa0855b04611e38acaff718542e9e809cddfc16535d39f9d9c694ab19f7388"
+version = "0.5.0"
+source = "git+https://github.com/mdaffin/loopdev?rev=c9f91e8f0326ce8a3364ac911e81eb32328a5f27#c9f91e8f0326ce8a3364ac911e81eb32328a5f27"
 dependencies = [
- "bindgen 0.59.2",
+ "bindgen",
  "errno 0.2.8",
  "libc",
 ]
@@ -2857,7 +2789,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=3d8192f8d3efab041916ea4d60e32248ac6ec43d#3d8192f8d3efab041916ea4d60e32248ac6ec43d"
+source = "git+https://github.com/confidential-containers/guest-components?rev=53ddd632424432077e95d3901deb64727be0b4c1#53ddd632424432077e95d3901deb64727be0b4c1"
 dependencies = [
  "aes 0.8.3",
  "anyhow",
@@ -3859,15 +3791,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "retry"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac95c60a949a63fd2822f4964939662d8f2c16c4fa0624fd954bc6e703b9a3f6"
-dependencies = [
- "rand 0.8.5",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4164,12 +4087,6 @@ dependencies = [
  "core-foundation-sys",
  "libc",
 ]
-
-[[package]]
-name = "semver"
-version = "1.0.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "sequoia-openpgp"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -34,7 +34,7 @@ futures = "0.3.28"
 tokio = { version = "1.28.1", features = ["full"] }
 tokio-vsock = "0.3.1"
 
-netlink-sys = { version = "0.7.0", features = ["tokio_socket",]}
+netlink-sys = { version = "0.7.0", features = ["tokio_socket"] }
 rtnetlink = "0.8.0"
 netlink-packet-utils = "0.4.1"
 ipnetwork = "0.17.0"
@@ -60,7 +60,7 @@ cgroups = { package = "cgroups-rs", version = "0.3.2" }
 tracing = "0.1.26"
 tracing-subscriber = "0.2.18"
 tracing-opentelemetry = "0.13.0"
-opentelemetry = { version = "0.14.0", features = ["rt-tokio-current-thread"]}
+opentelemetry = { version = "0.14.0", features = ["rt-tokio-current-thread"] }
 vsock-exporter = { path = "vsock-exporter" }
 
 # Configuration
@@ -72,7 +72,9 @@ clap = { version = "3.0.1", features = ["derive"] }
 openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
-image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "3d8192f8d3efab041916ea4d60e32248ac6ec43d", default-features = false, features = ["kata-cc-native-tls"] }
+image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "53ddd632424432077e95d3901deb64727be0b4c1", default-features = false, features = [
+    "kata-cc-native-tls",
+] }
 
 [patch.crates-io]
 oci-distribution = { git = "https://github.com/krustlet/oci-distribution.git", rev = "f44124c" }
@@ -84,9 +86,7 @@ which = "4.3.0"
 
 [workspace]
 resolver = "2"
-members = [
-    "rustjail",
-]
+members = ["rustjail"]
 
 [profile.release]
 lto = true

--- a/versions.yaml
+++ b/versions.yaml
@@ -200,7 +200,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/guest-components/"
-    version: "3d8192f8d3efab041916ea4d60e32248ac6ec43d"
+    version: "53ddd632424432077e95d3901deb64727be0b4c1"
 
   cni-plugins:
     description: "CNI network plugins"


### PR DESCRIPTION
Bump image-rs and attestation-agent to use the latest guest-components with the rust clap version fix

Fixes: #7580