### PR TITLE
clh: Direct IO support for block devices 

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -176,6 +176,15 @@ virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 # rootfs is backed by a block device. This is virtio-blk.
 block_device_driver = "virtio-blk"
 
+# Specifies cache-related options will be set to block devices or not.
+# Default false
+#block_device_cache_set = true
+
+# Specifies cache-related options for block devices.
+# Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
+# Default false
+#block_device_cache_direct = true
+
 # Enable huge pages for VM RAM, default false
 # Enabling this will result in the VM memory
 # being allocated using huge pages.

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -127,11 +127,6 @@ block_device_driver = "@DEFBLOCKSTORAGEDRIVER_FC@"
 #block_device_cache_set = true
 
 # Specifies cache-related options for block devices.
-# Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
-# Default false
-#block_device_cache_direct = true
-
-# Specifies cache-related options for block devices.
 # Denotes whether flush requests for the device are ignored.
 # Default false
 #block_device_cache_noflush = true

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1082,7 +1082,6 @@ func newClhHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		BlockDeviceDriver:              blockDriver,
 		BlockDeviceCacheSet:            h.BlockDeviceCacheSet,
 		BlockDeviceCacheDirect:         h.BlockDeviceCacheDirect,
-		BlockDeviceCacheNoflush:        h.BlockDeviceCacheNoflush,
 		EnableIOThreads:                h.EnableIOThreads,
 		Msize9p:                        h.msize9p(),
 		ColdPlugVFIO:                   h.coldPlugVFIO(),

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -851,6 +851,9 @@ func (clh *cloudHypervisor) hotplugAddBlockDevice(drive *config.BlockDrive) erro
 	clhDisk := *chclient.NewDiskConfig(drive.File)
 	clhDisk.Readonly = &drive.ReadOnly
 	clhDisk.VhostUser = func(b bool) *bool { return &b }(false)
+	if clh.config.BlockDeviceCacheSet {
+		clhDisk.Direct = &clh.config.BlockDeviceCacheDirect
+	}
 
 	queues := int32(clh.config.NumVCPUs)
 	queueSize := int32(1024)

--- a/src/runtime/virtcontainers/fc.go
+++ b/src/runtime/virtcontainers/fc.go
@@ -835,6 +835,17 @@ func (fc *firecracker) createDiskPool(ctx context.Context) error {
 			PathOnHost:   &jailedDrive,
 		}
 
+		if fc.config.BlockDeviceCacheSet {
+			var cacheOption string
+			if fc.config.BlockDeviceCacheNoflush {
+				cacheOption = models.DriveCacheTypeUnsafe
+			} else {
+				cacheOption = models.DriveCacheTypeWriteback
+			}
+
+			drive.CacheType = &cacheOption
+		}
+
 		fc.fcConfig.Drives = append(fc.fcConfig.Drives, drive)
 	}
 


### PR DESCRIPTION
Cloud hypervisor has support for direct i/o, this patch adds support for enabling it in kata. It doesn't know about noflush, removed it from the list of valid options for clh.
Firecracker supports noflush semantic via Unsafe cache type.
There is no support for direct i/o in firecracker, I removed it from config file.

Fixes: #7798 #7823