### PR TITLE
versions: Update alpine to its 3.18 version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -147,7 +147,7 @@ assets:
     architecture:
       aarch64:
         name: &default-initrd-name "alpine"
-        version: &default-initrd-version "3.15"
+        version: &default-initrd-version "3.18"
       # Do not use Alpine on ppc64le & s390x, the agent cannot use musl because
       # there is no such Rust target
       ppc64le:


### PR DESCRIPTION
3.15 will be out of life in 2 months from now.

Fixes: #7816