### PR TITLE
Improve the way to clean up storage devices for sandbox

### DIFF
--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -32,7 +32,7 @@ use tokio::sync::Mutex;
 use tracing::instrument;
 
 use crate::linux_abi::*;
-use crate::mount::{get_mount_fs_type, is_mounted, remove_mounts, TYPE_ROOTFS};
+use crate::mount::{get_mount_fs_type, TYPE_ROOTFS};
 use crate::namespace::Namespace;
 use crate::netlink::Handle;
 use crate::network::Network;
@@ -61,7 +61,7 @@ impl StorageState {
     fn new() -> Self {
         StorageState {
             count: Arc::new(AtomicU32::new(1)),
-            device: Arc::new(StorageDeviceGeneric::new("".to_string())),
+            device: Arc::new(StorageDeviceGeneric::default()),
         }
     }
 
@@ -183,30 +183,6 @@ impl Sandbox {
         Ok(state.device)
     }
 
-    // Clean mount and directory of a mountpoint.
-    // This is actually StorageDeviceGeneric::cleanup(), kept here due to dependency chain.
-    #[instrument]
-    fn cleanup_sandbox_storage(&mut self, path: &str) -> Result<()> {
-        if path.is_empty() {
-            return Err(anyhow!("mountpoint path is empty"));
-        } else if !Path::new(path).exists() {
-            return Ok(());
-        }
-
-        if matches!(is_mounted(path), Ok(true)) {
-            let mounts = vec![path.to_string()];
-            remove_mounts(&mounts)?;
-        }
-
-        // "remove_dir" will fail if the mount point is backed by a read-only filesystem.
-        // This is the case with the device mapper snapshotter, where we mount the block device directly
-        // at the underlying sandbox path which was provided from the base RO kataShared path from the host.
-        if let Err(err) = fs::remove_dir(path) {
-            warn!(self.logger, "failed to remove dir {}, {:?}", path, err);
-        }
-        Ok(())
-    }
-
     /// Decrease reference count and destroy the storage object if reference count reaches zero.
     /// Returns `Ok(true)` if the reference count has reached zero and the storage object has been
     /// removed.
@@ -216,8 +192,9 @@ impl Sandbox {
             None => Err(anyhow!("Sandbox storage with path {} not found", path)),
             Some(state) => {
                 if state.dec_and_test_ref_count().await {
-                    self.storages.remove(path);
-                    self.cleanup_sandbox_storage(path)?;
+                    if let Some(storage) = self.storages.remove(path) {
+                        storage.device.cleanup()?;
+                    }
                     Ok(true)
                 } else {
                     Ok(false)
@@ -577,50 +554,6 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn remove_sandbox_storage() {
-        skip_if_not_root!();
-
-        let logger = slog::Logger::root(slog::Discard, o!());
-        let mut s = Sandbox::new(&logger).unwrap();
-
-        let tmpdir = Builder::new().tempdir().unwrap();
-        let tmpdir_path = tmpdir.path().to_str().unwrap();
-
-        let srcdir = Builder::new()
-            .prefix("src")
-            .tempdir_in(tmpdir_path)
-            .unwrap();
-        let srcdir_path = srcdir.path().to_str().unwrap();
-
-        let destdir = Builder::new()
-            .prefix("dest")
-            .tempdir_in(tmpdir_path)
-            .unwrap();
-        let destdir_path = destdir.path().to_str().unwrap();
-
-        let emptydir = Builder::new()
-            .prefix("empty")
-            .tempdir_in(tmpdir_path)
-            .unwrap();
-
-        assert!(s.cleanup_sandbox_storage("").is_err());
-
-        let invalid_dir = emptydir.path().join("invalid");
-
-        assert!(s
-            .cleanup_sandbox_storage(invalid_dir.to_str().unwrap())
-            .is_ok());
-
-        assert!(bind_mount(srcdir_path, destdir_path, &logger).is_ok());
-
-        assert!(s.cleanup_sandbox_storage(destdir_path).is_ok());
-
-        // remove a directory without umount
-        s.cleanup_sandbox_storage(srcdir_path).unwrap();
-    }
-
-    #[tokio::test]
-    #[serial]
     async fn unset_and_remove_sandbox_storage() {
         skip_if_not_root!();
 
@@ -650,6 +583,10 @@ mod tests {
         assert!(bind_mount(srcdir_path, destdir_path, &logger).is_ok());
 
         s.add_sandbox_storage(destdir_path).await;
+        let storage = StorageDeviceGeneric::new(destdir_path.to_string());
+        assert!(s
+            .update_sandbox_storage(destdir_path, Arc::new(storage))
+            .is_ok());
         assert!(s.remove_sandbox_storage(destdir_path).await.is_ok());
 
         let other_dir_str;
@@ -664,6 +601,10 @@ mod tests {
             other_dir_str = other_dir_path.to_string();
 
             s.add_sandbox_storage(other_dir_path).await;
+            let storage = StorageDeviceGeneric::new(other_dir_path.to_string());
+            assert!(s
+                .update_sandbox_storage(other_dir_path, Arc::new(storage))
+                .is_ok());
         }
 
         assert!(s.remove_sandbox_storage(&other_dir_str).await.is_ok());

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -16,7 +16,7 @@ use std::{thread, time};
 
 use anyhow::{anyhow, Context, Result};
 use kata_types::cpu::CpuSet;
-use kata_types::mount::{StorageDevice, StorageDeviceGeneric};
+use kata_types::mount::StorageDevice;
 use libc::pid_t;
 use oci::{Hook, Hooks};
 use protocols::agent::OnlineCPUMemRequest;
@@ -37,6 +37,7 @@ use crate::namespace::Namespace;
 use crate::netlink::Handle;
 use crate::network::Network;
 use crate::pci;
+use crate::storage::StorageDeviceGeneric;
 use crate::uevent::{Uevent, UeventMatcher};
 use crate::watcher::BindWatcher;
 

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -72,7 +72,7 @@ impl StorageState {
         }
     }
 
-    pub fn path(&self) -> &str {
+    pub fn path(&self) -> Option<&str> {
         self.device.path()
     }
 

--- a/src/agent/src/storage/mod.rs
+++ b/src/agent/src/storage/mod.rs
@@ -5,6 +5,7 @@
 //
 
 use std::collections::HashMap;
+use std::fmt::Formatter;
 use std::fs;
 use std::os::unix::fs::{MetadataExt, PermissionsExt};
 use std::path::Path;
@@ -12,9 +13,7 @@ use std::sync::Arc;
 
 use anyhow::{anyhow, Context, Result};
 use kata_sys_util::mount::{create_mount_destination, parse_mount_options};
-use kata_types::mount::{
-    StorageDevice, StorageDeviceGeneric, StorageHandlerManager, KATA_SHAREDFS_GUEST_PREMOUNT_TAG,
-};
+use kata_types::mount::{StorageDevice, StorageHandlerManager, KATA_SHAREDFS_GUEST_PREMOUNT_TAG};
 use nix::unistd::{Gid, Uid};
 use protocols::agent::Storage;
 use protocols::types::FSGroupChangePolicy;
@@ -53,6 +52,34 @@ pub struct StorageContext<'a> {
     cid: &'a Option<String>,
     logger: &'a Logger,
     sandbox: &'a Arc<Mutex<Sandbox>>,
+}
+
+/// An implementation of generic storage device.
+pub struct StorageDeviceGeneric {
+    path: String,
+}
+
+impl std::fmt::Debug for StorageDeviceGeneric {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StorageDeviceGeneric")
+            .field("path", &self.path)
+            .finish()
+    }
+}
+
+impl StorageDeviceGeneric {
+    /// Create a new instance of `StorageStateCommon`.
+    pub fn new(path: String) -> Self {
+        StorageDeviceGeneric { path }
+    }
+}
+
+impl StorageDevice for StorageDeviceGeneric {
+    fn path(&self) -> &str {
+        &self.path
+    }
+
+    fn cleanup(&self) {}
 }
 
 /// Trait object to handle storage device.

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -7,7 +7,6 @@
 use anyhow::{anyhow, Context, Error, Result};
 use std::collections::hash_map::Entry;
 use std::convert::TryFrom;
-use std::fmt::Formatter;
 use std::{collections::HashMap, fs, path::PathBuf};
 
 /// Prefix to mark a volume as Kata special.
@@ -427,34 +426,6 @@ impl TryFrom<&NydusExtraOptions> for KataVirtualVolume {
             ..Default::default()
         })
     }
-}
-
-/// An implementation of generic storage device.
-pub struct StorageDeviceGeneric {
-    path: String,
-}
-
-impl std::fmt::Debug for StorageDeviceGeneric {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("StorageState")
-            .field("path", &self.path)
-            .finish()
-    }
-}
-
-impl StorageDeviceGeneric {
-    /// Create a new instance of `StorageStateCommon`.
-    pub fn new(path: String) -> Self {
-        StorageDeviceGeneric { path }
-    }
-}
-
-impl StorageDevice for StorageDeviceGeneric {
-    fn path(&self) -> &str {
-        &self.path
-    }
-
-    fn cleanup(&self) {}
 }
 
 /// Trait object for storage device.

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -431,10 +431,10 @@ impl TryFrom<&NydusExtraOptions> for KataVirtualVolume {
 /// Trait object for storage device.
 pub trait StorageDevice: Send + Sync {
     /// Path
-    fn path(&self) -> &str;
+    fn path(&self) -> Option<&str>;
 
     /// Clean up resources related to the storage device.
-    fn cleanup(&self);
+    fn cleanup(&self) -> Result<()>;
 }
 
 /// Manager to manage registered storage device handlers.


### PR DESCRIPTION
Currently there's no way to return error when cleaning up storage devices for sandbox. So add a way to return error and refine the logic to clean up resources.