### PR TITLE
agent: avoid possible leakage of storage device

### DIFF
--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -71,6 +71,10 @@ impl StorageState {
         }
     }
 
+    pub fn path(&self) -> &str {
+        self.device.path()
+    }
+
     pub async fn ref_count(&self) -> u32 {
         self.count.load(Ordering::Relaxed)
     }

--- a/src/agent/src/storage/mod.rs
+++ b/src/agent/src/storage/mod.rs
@@ -103,6 +103,10 @@ pub async fn add_storages(
         let path = storage.mount_point.clone();
         let state = sandbox.lock().await.add_sandbox_storage(&path).await;
         if state.ref_count().await > 1 {
+            let path = state.path();
+            if !path.is_empty() {
+                mount_list.push(path.to_string());
+            }
             // The device already exists.
             continue;
         }


### PR DESCRIPTION
When a storage device is used by more than one container, the second and forth instances will cause storage device reference count leakage, thus cause storage device leakage. The reason is:
add_storages() will increase reference count of existing storage device, but forget to add the device to the `mount_list` array, thus leak the reference count.

Fixes: #7820