### PR TITLE
metrics: re-enable memory-usage initialization step

### DIFF
--- a/tests/metrics/density/memory_usage.sh
+++ b/tests/metrics/density/memory_usage.sh
@@ -361,7 +361,7 @@ function main(){
 
 	#Check for KSM before reporting test name, as it can modify it
 	check_for_ksm
-#	init_env
+	init_env
 	check_cmds "${SMEM_BIN}" bc
 	check_images "${IMAGE}"
 


### PR DESCRIPTION
This PR re-enables the initialization step disabled on 538c965c2b79053f0b4d8fe2855196307b72932b.

Fixes: #7804