### PR TITLE
Improve logging control

### DIFF
--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -587,6 +587,8 @@ dependencies = [
 name = "logging"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
+ "lazy_static",
  "serde_json",
  "slog",
  "slog-async",

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -24,6 +24,10 @@ pub struct Agent {
     #[serde(default, rename = "enable_debug")]
     pub debug: bool,
 
+    /// The slog log level will be applied to agent.
+    #[serde(default)]
+    pub slog_level: String,
+
     /// Enable agent tracing.
     ///
     /// If enabled, the agent will generate OpenTelemetry trace spans.
@@ -88,6 +92,7 @@ impl std::default::Default for Agent {
     fn default() -> Self {
         Self {
             debug: true,
+            slog_level: "INFO".to_string(),
             enable_tracing: false,
             debug_console_enabled: false,
             server_port: DEFAULT_AGENT_VSOCK_PORT,

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -374,6 +374,10 @@ pub struct DebugInfo {
     #[serde(default)]
     pub enable_debug: bool,
 
+    /// The slog log level will be applied to hypervisor.
+    #[serde(default)]
+    pub slog_level: String,
+
     /// Enable dumping information about guest page structures if true.
     #[serde(default)]
     pub guest_memory_dump_paging: bool,

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -33,6 +33,9 @@ pub struct Runtime {
     #[serde(default, rename = "enable_debug")]
     pub debug: bool,
 
+    /// The slog level will be applied to runtimes.
+    #[serde(default)]
+    pub slog_level: String,
     /// Enabled experimental feature list, format: ["a", "b"].
     ///
     /// Experimental features are features not stable enough for production, they may break

--- a/src/libs/logging/Cargo.toml
+++ b/src/libs/logging/Cargo.toml
@@ -18,6 +18,8 @@ slog-json = "2.4.0"
 slog-term = "2.9.0"
 slog-async = "2.7.0"
 slog-scope = "4.4.0"
+lazy_static = "1.3.0"
+arc-swap = "1.5.0"
 
 [dev-dependencies]
 tempfile = "3.2.0"

--- a/src/libs/logging/src/lib.rs
+++ b/src/libs/logging/src/lib.rs
@@ -3,13 +3,17 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+#[macro_use]
+extern crate lazy_static;
+use arc_swap::ArcSwap;
 use slog::{o, record_static, BorrowedKV, Drain, Key, OwnedKV, OwnedKVList, Record, KV};
+
 use std::collections::HashMap;
 use std::io;
 use std::io::Write;
 use std::process;
 use std::result;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
 mod file_rotate;
 mod log_writer;
@@ -17,12 +21,56 @@ mod log_writer;
 pub use file_rotate::FileRotator;
 pub use log_writer::LogWriter;
 
+lazy_static! {
+    pub static ref FILTER_RULE: ArcSwap<HashMap<String, slog::Level>> =
+        ArcSwap::from(Arc::new(HashMap::from([
+            ("agent".to_string(), slog::Level::Info),
+            ("runtimes".to_string(), slog::Level::Info),
+            ("resource".to_string(), slog::Level::Info),
+            ("virt-container".to_string(), slog::Level::Info),
+            ("service".to_string(), slog::Level::Info),
+            ("shim".to_string(), slog::Level::Info),
+            ("hypervisor".to_string(), slog::Level::Info),
+            ("vmm-dragonball".to_string(), slog::Level::Info),
+        ])));
+
+    pub static ref AGENT_LOGGER: ArcSwap<slog::Logger> =
+        ArcSwap::from(Arc::new(slog::Logger::root(slog::Discard, o!())));
+    pub static ref RESOURCE_LOGGER: ArcSwap<slog::Logger> =
+        ArcSwap::from(Arc::new(slog::Logger::root(slog::Discard, o!())));
+    pub static ref RUNTIMES_LOGGER: ArcSwap<slog::Logger> =
+        ArcSwap::from(Arc::new(slog::Logger::root(slog::Discard, o!())));
+    pub static ref VIRT_CONTAINER_LOGGER: ArcSwap<slog::Logger> =
+        ArcSwap::from(Arc::new(slog::Logger::root(slog::Discard, o!())));
+    pub static ref SERVICE_LOGGER: ArcSwap<slog::Logger> =
+        ArcSwap::from(Arc::new(slog::Logger::root(slog::Discard, o!())));
+    pub static ref SHIM_LOGGER: ArcSwap<slog::Logger> =
+        ArcSwap::from(Arc::new(slog::Logger::root(slog::Discard, o!())));
+    
+    pub static ref VMM_LOGGER: ArcSwap<slog::Logger> =
+        ArcSwap::from(Arc::new(slog::Logger::root(slog::Discard, o!())));
+    pub static ref VMM_DRAGONBALL_LOGGER: ArcSwap<slog::Logger> =
+        ArcSwap::from(Arc::new(slog::Logger::root(slog::Discard, o!())));
+}
+
 #[macro_export]
 macro_rules! logger_with_subsystem {
     ($name: ident, $subsystem: expr) => {
         macro_rules! $name {
                             () => {
-                                    slog_scope::logger().new(slog::o!("subsystem" => $subsystem))
+                                match $subsystem {
+                                    // Loggers new()ed from slog_scope GLOBAL_LOGGER.
+                                    "agent" => Logger::clone(&AGENT_LOGGER.load()),
+                                    "resource" => Logger::clone(&RESOURCE_LOGGER.load()),
+                                    "runtimes" => Logger::clone(&RUNTIMES_LOGGER.load()),
+                                    "virt-container" => Logger::clone(&VIRT_CONTAINER_LOGGER.load()),
+                                    "service" => Logger::clone(&SERVICE_LOGGER.load()),
+                                    "shim" => Logger::clone(&SHIM_LOGGER.load()),
+                                    "hypervisor" => Logger::clone(&VMM_LOGGER.load()),
+                                    "vmm-dragonball" => Logger::clone(&VMM_DRAGONBALL_LOGGER.load()),
+
+                                    _ => slog_scope::logger().new(slog::o!("subsystem" => $subsystem)),
+                                }
                             };
                         }
     };
@@ -79,6 +127,19 @@ where
     // Ensure only a unique set of key/value fields is logged
     let unique_drain = UniqueDrain::new(json_drain).fuse();
 
+    if level == slog::Level::Debug {
+        FILTER_RULE.store(Arc::new(HashMap::from([
+            ("agent".to_string(), slog::Level::Debug),
+            ("runtimes".to_string(), slog::Level::Debug),
+            ("resource".to_string(), slog::Level::Debug),
+            ("virt-container".to_string(), slog::Level::Debug),
+            ("service".to_string(), slog::Level::Debug),
+            ("shim".to_string(), slog::Level::Debug),
+            ("hypervisor".to_string(), slog::Level::Debug),
+            ("vmm-dragonball".to_string(), slog::Level::Debug),
+        ])));
+    }
+
     // Allow runtime filtering of records by log level
     let filter_drain = RuntimeLevelFilter::new(unique_drain, level).fuse();
 
@@ -86,6 +147,7 @@ where
     let (async_drain, guard) = slog_async::Async::new(filter_drain)
         .thread_name("slog-async-logger".into())
         .build_with_guard();
+    let async_drain = async_drain.fuse();
 
     // Add some "standard" fields
     let logger = slog::Logger::root(
@@ -220,14 +282,14 @@ where
 // specified in the struct.
 struct RuntimeLevelFilter<D> {
     drain: D,
-    level: Mutex<slog::Level>,
+    _level: Mutex<slog::Level>,
 }
 
 impl<D> RuntimeLevelFilter<D> {
     fn new(drain: D, level: slog::Level) -> Self {
         RuntimeLevelFilter {
             drain,
-            level: Mutex::new(level),
+            _level: Mutex::new(level),
         }
     }
 }
@@ -244,9 +306,23 @@ where
         record: &slog::Record,
         values: &slog::OwnedKVList,
     ) -> result::Result<Self::Ok, Self::Err> {
-        let log_level = self.level.lock().unwrap();
+        let subsystem_level_config = FILTER_RULE.load();
 
-        if record.level().is_at_least(*log_level) {
+        let mut logger_serializer = HashSerializer::new();
+        values.serialize(record, &mut logger_serializer).unwrap();
+
+        let mut record_serializer = HashSerializer::new();
+        record.kv().serialize(record, &mut record_serializer).unwrap();
+
+        let mut subsystem = None;
+        for (k, v) in record_serializer.fields.iter().chain(logger_serializer.fields.iter()) {
+            if k == "subsystem" {
+                subsystem = Some(v.to_string());
+                break;
+            }
+        }
+        let according_level = subsystem_level_config.get(&subsystem.unwrap()).unwrap_or(&slog::Level::Info);
+        if record.level().is_at_least(*according_level) {
             self.drain.log(record, values)?;
         }
 

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1674,6 +1674,8 @@ dependencies = [
 name = "logging"
 version = "0.1.0"
 dependencies = [
+ "arc-swap",
+ "lazy_static",
  "serde_json",
  "slog",
  "slog-async",

--- a/src/runtime-rs/crates/agent/src/kata/agent.rs
+++ b/src/runtime-rs/crates/agent/src/kata/agent.rs
@@ -12,7 +12,11 @@ use ttrpc::context as ttrpc_ctx;
 use kata_types::config::Agent as AgentConfig;
 
 use crate::{kata::KataAgent, Agent, AgentManager, HealthService};
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 /// millisecond to nanosecond
 const MILLISECOND_TO_NANOSECOND: i64 = 1_000_000;
 

--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -19,7 +19,11 @@ use tokio::sync::RwLock;
 use ttrpc::asynchronous::Client;
 
 use crate::{log_forwarder::LogForwarder, sock};
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 // https://github.com/firecracker-microvm/firecracker/blob/master/docs/vsock.md
 #[derive(Debug, Default)]
 pub struct Vsock {

--- a/src/runtime-rs/crates/agent/src/log_forwarder.rs
+++ b/src/runtime-rs/crates/agent/src/log_forwarder.rs
@@ -8,7 +8,11 @@ use anyhow::Result;
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 use crate::sock;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 // https://github.com/slog-rs/slog/blob/master/src/lib.rs#L2082
 const LOG_LEVEL_TRACE: &str = "TRCE";
 const LOG_LEVEL_DEBUG: &str = "DEBG";

--- a/src/runtime-rs/crates/agent/src/sock/hybrid_vsock.rs
+++ b/src/runtime-rs/crates/agent/src/sock/hybrid_vsock.rs
@@ -14,7 +14,11 @@ use tokio::{
 };
 
 use super::{ConnectConfig, Sock, Stream};
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 #[derive(Debug, PartialEq)]
 pub struct HybridVsock {
     uds: String,

--- a/src/runtime-rs/crates/agent/src/sock/mod.rs
+++ b/src/runtime-rs/crates/agent/src/sock/mod.rs
@@ -7,6 +7,11 @@
 mod hybrid_vsock;
 pub use hybrid_vsock::HybridVsock;
 mod vsock;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 pub use vsock::Vsock;
 
 use std::{

--- a/src/runtime-rs/crates/agent/src/sock/vsock.rs
+++ b/src/runtime-rs/crates/agent/src/sock/vsock.rs
@@ -15,7 +15,11 @@ use nix::sys::socket::{connect, socket, AddressFamily, SockFlag, SockType, Vsock
 use tokio::net::UnixStream;
 
 use super::{ConnectConfig, Sock, Stream};
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 #[derive(Debug, PartialEq)]
 pub struct Vsock {
     vsock_cid: u32,

--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -10,16 +10,20 @@ use anyhow::{anyhow, Context, Result};
 use kata_sys_util::rand::RandomBytes;
 use tokio::sync::{Mutex, RwLock};
 
+use super::{
+    util::{get_host_path, get_virt_drive_name, DEVICE_TYPE_BLOCK},
+    Device, DeviceConfig, DeviceType,
+};
 use crate::{
     vhost_user_blk::VhostUserBlkDevice, BlockConfig, BlockDevice, Hypervisor, NetworkDevice,
     VfioDevice, VhostUserConfig, KATA_BLK_DEV_TYPE, KATA_MMIO_BLK_DEV_TYPE, KATA_NVDIMM_DEV_TYPE,
     VIRTIO_BLOCK_MMIO, VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
 };
-
-use super::{
-    util::{get_host_path, get_virt_drive_name, DEVICE_TYPE_BLOCK},
-    Device, DeviceConfig, DeviceType,
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
 };
+use slog::Logger;
 
 pub type ArcMutexDevice = Arc<Mutex<dyn Device>>;
 

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -25,7 +25,11 @@ use crate::{
     PciPath, PciSlot,
 };
 use kata_sys_util::fs::get_base_name;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 pub const SYS_BUS_PCI_DRIVER_PROBE: &str = "/sys/bus/pci/drivers_probe";
 pub const SYS_BUS_PCI_DEVICES: &str = "/sys/bus/pci/devices";
 pub const SYS_KERN_IOMMU_GROUPS: &str = "/sys/kernel/iommu_groups";

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
@@ -16,7 +16,12 @@ use super::inner::DragonballInner;
 use crate::{
     device::DeviceType, utils, HybridVsockConfig, HybridVsockDevice, VcpuThreadIds, VmmState,
 };
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use shim_interface::KATA_PATH;
+use slog::Logger;
 const DEFAULT_HYBRID_VSOCK_NAME: &str = "kata.hvsock";
 
 fn get_vsock_path(root: &str) -> String {
@@ -51,9 +56,9 @@ impl DragonballInner {
     pub(crate) async fn start_vm(&mut self, timeout: i32) -> Result<()> {
         self.run_vmm_server().context("start vmm server")?;
         self.cold_start_vm(timeout).await.map_err(|error| {
-            error!(sl!(), "start micro vm error {:?}", error);
+            error!(dl!(), "start micro vm error {:?}", error);
             if let Err(err) = self.stop_vm() {
-                error!(sl!(), "failed to call end err : {:?}", err);
+                error!(dl!(), "failed to call end err : {:?}", err);
             }
             error
         })?;
@@ -62,19 +67,19 @@ impl DragonballInner {
     }
 
     pub(crate) fn stop_vm(&mut self) -> Result<()> {
-        info!(sl!(), "Stopping dragonball VM");
+        info!(dl!(), "Stopping dragonball VM");
         self.vmm_instance.stop().context("stop")?;
         Ok(())
     }
 
     pub(crate) fn pause_vm(&self) -> Result<()> {
-        info!(sl!(), "do pause vm");
+        info!(dl!(), "do pause vm");
         self.vmm_instance.pause().context("pause vm")?;
         Ok(())
     }
 
     pub(crate) fn resume_vm(&self) -> Result<()> {
-        info!(sl!(), "do resume vm");
+        info!(dl!(), "do resume vm");
         self.vmm_instance.resume().context("resume vm")?;
         Ok(())
     }
@@ -93,7 +98,7 @@ impl DragonballInner {
     }
 
     pub(crate) async fn get_hypervisor_metrics(&self) -> Result<String> {
-        info!(sl!(), "get hypervisor metrics");
+        info!(dl!(), "get hypervisor metrics");
         self.vmm_instance.get_hypervisor_metrics()
     }
 
@@ -109,7 +114,7 @@ impl DragonballInner {
         for tid in self.vmm_instance.get_vcpu_tids() {
             vcpu_thread_ids.vcpus.insert(tid.0 as u32, tid.1);
         }
-        info!(sl!(), "get thread ids {:?}", vcpu_thread_ids);
+        info!(dl!(), "get thread ids {:?}", vcpu_thread_ids);
         Ok(vcpu_thread_ids)
     }
 
@@ -132,7 +137,7 @@ impl DragonballInner {
             pids.remove(&tid.1);
         }
 
-        info!(sl!(), "get pids {:?}", pids);
+        info!(dl!(), "get pids {:?}", pids);
         Ok(Vec::from_iter(pids.into_iter()))
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -21,6 +21,13 @@ use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 use tokio::sync::RwLock;
 use tracing::instrument;
 
+#[macro_export]
+macro_rules! sl {
+    () => {
+        Logger::clone(&VMM_DRAGONBALL_LOGGER.load())
+    };
+}
+
 use crate::{DeviceType, Hypervisor, VcpuThreadIds};
 
 pub struct Dragonball {

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -8,6 +8,8 @@
 extern crate slog;
 
 logging::logger_with_subsystem!(sl, "hypervisor");
+// Inside crate dragonball, the `dl!` macro should be used instead of `sl!`
+logging::logger_with_subsystem!(dl, "vmm-dragonball");
 
 pub mod device;
 pub mod hypervisor_persist;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -7,7 +7,11 @@ use anyhow::Result;
 
 use crate::{HypervisorConfig, VcpuThreadIds};
 use kata_types::capabilities::{Capabilities, CapabilityBits};
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 const VSOCK_SCHEME: &str = "vsock";
 const VSOCK_AGENT_CID: u32 = 3;
 const VSOCK_AGENT_PORT: u32 = 1024;

--- a/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/cpu.rs
@@ -19,7 +19,11 @@ use oci::LinuxCpu;
 use tokio::sync::RwLock;
 
 use crate::ResourceUpdateOp;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 #[derive(Default, Debug, Clone)]
 pub struct CpuResource {
     /// Current number of vCPUs

--- a/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/initial_size.rs
@@ -12,7 +12,11 @@ use kata_types::{
     annotations::Annotation, config::TomlConfig, container::ContainerType,
     cpu::LinuxContainerCpuResources, k8s::container_type,
 };
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 // initial resource that InitialSizeManager needs, this is the spec for the
 // sandbox/container's workload
 #[derive(Clone, Copy, Debug)]

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -34,7 +34,11 @@ use crate::{
     volume::{Volume, VolumeResource},
     ResourceConfig, ResourceUpdateOp,
 };
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 pub(crate) struct ResourceManagerInner {
     sid: String,
     toml_config: Arc<TomlConfig>,

--- a/src/runtime-rs/crates/resource/src/network/dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/dan.rs
@@ -36,7 +36,11 @@ use super::{EndpointState, NetnsGuard, Network};
 use crate::network::endpoint::TapEndpoint;
 use crate::network::network_info::network_info_from_dan::NetworkInfoFromDan;
 use crate::network::utils::generate_private_mac_addr;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 /// Directly attachable network
 pub struct Dan {
     inner: Arc<RwLock<DanInner>>,

--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
@@ -19,7 +19,11 @@ use crate::network::utils::{
     address::{parse_ip, Address},
     link::{self, LinkAttrs},
 };
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 #[derive(Debug)]
 pub(crate) struct NetworkInfoFromLink {
     interface: Interface,

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -31,7 +31,11 @@ use super::{
     Network,
 };
 use crate::network::NetworkInfo;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 #[derive(Debug)]
 pub struct NetworkWithNetNsConfig {
     pub network_model: String,

--- a/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/create.rs
@@ -15,7 +15,11 @@ use anyhow::{Context, Result};
 use nix::ioctl_write_ptr;
 
 use super::macros::{get_name, set_name};
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 type IfName = [u8; libc::IFNAMSIZ];
 
 #[derive(Copy, Clone, Debug)]

--- a/src/runtime-rs/crates/resource/src/network/utils/netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/netns.rs
@@ -7,9 +7,14 @@
 use std::{fs::File, os::unix::io::AsRawFd};
 
 use anyhow::{Context, Result};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use nix::sched::{setns, CloneFlags};
 use nix::unistd::{getpid, gettid};
 use rand::Rng;
+use slog::Logger;
 
 pub struct NetnsGuard {
     old_netns: Option<File>,

--- a/src/runtime-rs/crates/resource/src/rootfs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/mod.rs
@@ -15,9 +15,13 @@ use hypervisor::{device::device_manager::DeviceManager, Hypervisor};
 use std::{sync::Arc, vec::Vec};
 use tokio::sync::RwLock;
 
-use crate::share_fs::ShareFs;
-
 use self::{block_rootfs::is_block_rootfs, nydus_rootfs::NYDUS_ROOTFS_TYPE};
+use crate::share_fs::ShareFs;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 
 const ROOTFS: &str = "rootfs";
 const HYBRID_ROOTFS_LOWER_DIR: &str = "rootfs_lower";

--- a/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
@@ -18,6 +18,11 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use hypervisor::{device::device_manager::DeviceManager, Hypervisor};
 use kata_types::mount::{Mount, NydusExtraOptions};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 use tokio::sync::RwLock;
 
 // Used for nydus rootfs

--- a/src/runtime-rs/crates/resource/src/share_fs/sandbox_bind_mounts.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/sandbox_bind_mounts.rs
@@ -23,7 +23,12 @@ use anyhow::{anyhow, Context, Result};
 use super::utils::{do_get_host_path, mkdir_with_permissions};
 use kata_sys_util::{fs::get_base_name, mount};
 use kata_types::mount::{SANDBOX_BIND_MOUNTS_DIR, SANDBOX_BIND_MOUNTS_RO, SANDBOX_BIND_MOUNTS_RW};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use nix::mount::MsFlags;
+use slog::Logger;
 
 #[derive(Clone, Default, Debug)]
 pub struct SandboxBindMounts {

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
@@ -21,7 +21,11 @@ use kata_sys_util::mount;
 use nix::mount::MsFlags;
 
 use super::{utils, PASSTHROUGH_FS_DIR};
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 pub(crate) const MOUNT_GUEST_TAG: &str = "kataShared";
 
 pub(crate) const FS_TYPE_VIRTIO_FS: &str = "virtiofs";

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
@@ -28,7 +28,11 @@ use super::{
     share_virtio_fs::generate_sock_path, utils::ensure_dir_exist, utils::get_host_ro_shared_path,
     virtio_fs_share_mount::VirtiofsShareMount, MountedInfo, ShareFs, ShareFsMount,
 };
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 #[derive(Debug, Clone)]
 pub struct ShareVirtioFsStandaloneConfig {
     id: String,

--- a/src/runtime-rs/crates/resource/src/volume/default_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/default_volume.rs
@@ -11,7 +11,11 @@ use anyhow::Result;
 use async_trait::async_trait;
 
 use super::Volume;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 #[derive(Debug)]
 pub(crate) struct DefaultVolume {
     mount: oci::Mount,

--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -27,7 +27,11 @@ use self::hugepage::{get_huge_page_limits_map, get_huge_page_option};
 use crate::{share_fs::ShareFs, volume::block_volume::is_block_volume};
 use agent::Agent;
 use hypervisor::device::device_manager::DeviceManager;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 const BIND: &str = "bind";
 
 #[async_trait]

--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -20,11 +20,15 @@ use hypervisor::device::device_manager::DeviceManager;
 use tokio::sync::RwLock;
 
 use super::Volume;
-use crate::share_fs::{MountedInfo, ShareFs, ShareFsVolumeConfig};
-use kata_types::mount;
-
 use crate::share_fs::DEFAULT_KATA_GUEST_SANDBOX_DIR;
 use crate::share_fs::PASSTHROUGH_FS_DIR;
+use crate::share_fs::{MountedInfo, ShareFs, ShareFsVolumeConfig};
+use kata_types::mount;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 
 const SYS_MOUNT_PREFIX: [&str; 2] = ["/proc", "/sys"];
 

--- a/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
@@ -13,7 +13,11 @@ use tokio::sync::RwLock;
 
 use super::Volume;
 use crate::share_fs::DEFAULT_KATA_GUEST_SANDBOX_DIR;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 pub const SHM_DIR: &str = "shm";
 // DEFAULT_SHM_SIZE is the default shm size to be used in case host
 // IPC is used.

--- a/src/runtime-rs/crates/runtimes/src/shim_mgmt/handlers.rs
+++ b/src/runtime-rs/crates/runtimes/src/shim_mgmt/handlers.rs
@@ -12,13 +12,17 @@ use agent::ResizeVolumeRequest;
 use anyhow::{anyhow, Context, Result};
 use common::Sandbox;
 use hyper::{Body, Method, Request, Response, StatusCode};
-use std::sync::Arc;
-use url::Url;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use shim_interface::shim_mgmt::{
     AGENT_URL, DIRECT_VOLUME_PATH_KEY, DIRECT_VOLUME_RESIZE_URL, DIRECT_VOLUME_STATS_URL,
     IP6_TABLE_URL, IP_TABLE_URL, METRICS_URL,
 };
+use slog::Logger;
+use std::sync::Arc;
+use url::Url;
 
 // main router for response, this works as a multiplexer on
 // http arrival which invokes the corresponding handler function

--- a/src/runtime-rs/crates/runtimes/src/shim_mgmt/server.rs
+++ b/src/runtime-rs/crates/runtimes/src/shim_mgmt/server.rs
@@ -20,7 +20,11 @@ use shim_interface::{mgmt_socket_addr, shim_mgmt::ERR_NO_SHIM_SERVER};
 use tokio::net::UnixListener;
 
 use super::handlers::handler_mux;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 /// The shim management server instance
 pub struct MgmtServer {
     /// socket address(with prefix like hvsock://)

--- a/src/runtime-rs/crates/runtimes/src/tracer.rs
+++ b/src/runtime-rs/crates/runtimes/src/tracer.rs
@@ -9,8 +9,13 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use lazy_static::lazy_static;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use opentelemetry::global;
 use opentelemetry::runtime::Tokio;
+use slog::Logger;
 use tracing::{span, subscriber::NoSubscriber, Span, Subscriber};
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::Registry;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -17,9 +17,13 @@ use common::{
     },
 };
 use kata_sys_util::k8s::update_ephemeral_storage_type;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use oci::{LinuxResources, Process as OCIProcess};
 use resource::{ResourceManager, ResourceUpdateOp};
+use slog::Logger;
 use tokio::sync::RwLock;
 
 use super::{

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -13,9 +13,14 @@ use common::{
     types::{ContainerID, ContainerProcess, ProcessExitStatus, ProcessStatus, ProcessType},
 };
 use hypervisor::device::device_manager::DeviceManager;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use nix::sys::signal::Signal;
 use oci::LinuxResources;
 use resource::{rootfs::Rootfs, volume::Volume};
+use slog::Logger;
 use tokio::sync::RwLock;
 
 use crate::container_manager::logger_with_process;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/io/shim_io.rs
@@ -28,6 +28,11 @@ use tokio::{
 };
 use url::Url;
 
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 fn open_fifo(path: &str) -> Result<AsyncUnixStream> {
     let fd = fcntl::open(path, OFlag::O_RDWR, Mode::from_bits(0).unwrap())?;
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -29,7 +29,11 @@ use tracing::instrument;
 use kata_sys_util::hooks::HookStates;
 
 use super::{logger_with_process, Container};
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 pub struct VirtContainerManager {
     sid: String,
     pid: u32,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/mod.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/mod.rs
@@ -14,7 +14,11 @@ pub use manager::VirtContainerManager;
 mod process;
 
 use common::types::ContainerProcess;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 fn logger_with_process(container_process: &ContainerProcess) -> slog::Logger {
     sl!().new(o!("container_id" => container_process.container_id.container_id.clone(), "exec_id" => container_process.exec_id.clone()))
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/health_check.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/health_check.rs
@@ -8,6 +8,11 @@ use std::sync::Arc;
 
 use agent::Agent;
 use anyhow::Context;
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 use tokio::sync::{mpsc, Mutex};
 
 /// monitor check interval 30s

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -25,7 +25,11 @@ use tokio::sync::{mpsc::Sender, Mutex, RwLock};
 use tracing::instrument;
 
 use crate::health_check::HealthCheck;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 pub(crate) const VIRTCONTAINER: &str = "virt_container";
 pub struct SandboxRestoreArgs {
     pub sid: String,

--- a/src/runtime-rs/crates/service/src/manager.rs
+++ b/src/runtime-rs/crates/service/src/manager.rs
@@ -27,7 +27,11 @@ use tokio::{
 use ttrpc::asynchronous::Server;
 
 use crate::task_service::TaskService;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 /// message buffer size
 const MESSAGE_BUFFER_SIZE: usize = 8;
 

--- a/src/runtime-rs/crates/service/src/task_service.rs
+++ b/src/runtime-rs/crates/service/src/task_service.rs
@@ -14,7 +14,12 @@ use common::types::{Request, Response};
 use containerd_shim_protos::{api, shim_async};
 use ttrpc::{self, r#async::TtrpcContext};
 
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 use runtimes::RuntimeHandlerManager;
+use slog::Logger;
 
 pub(crate) struct TaskService {
     handler: Arc<RuntimeHandlerManager>,

--- a/src/runtime-rs/crates/shim/src/logger.rs
+++ b/src/runtime-rs/crates/shim/src/logger.rs
@@ -5,10 +5,14 @@
 //
 
 use std::os::unix::fs::OpenOptionsExt;
-
-use anyhow::{Context, Result};
+use std::sync::Arc;
 
 use crate::Error;
+use anyhow::{Context, Result};
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
 
 pub(crate) fn set_logger(path: &str, sid: &str, is_debug: bool) -> Result<slog_async::AsyncGuard> {
     let fifo = std::fs::OpenOptions::new()
@@ -36,6 +40,32 @@ pub(crate) fn set_logger(path: &str, sid: &str, is_debug: bool) -> Result<slog_a
         log::Level::Info
     };
     slog_stdlog::init_with_level(level).context(format!("init with level {}", level))?;
+
+    VMM_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "hypervisor")),
+    ));
+    VMM_DRAGONBALL_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "vmm-dragonball")),
+    ));
+
+    AGENT_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "agent")),
+    ));
+    RESOURCE_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "resource")),
+    ));
+    RUNTIMES_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "runtimes")),
+    ));
+    VIRT_CONTAINER_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "virt-container")),
+    ));
+    SERVICE_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "service")),
+    ));
+    SHIM_LOGGER.store(Arc::new(
+        slog_scope::logger().new(slog::o!("subsystem" => "shim")),
+    ));
 
     Ok(async_guard)
 }

--- a/src/runtime-rs/crates/shim/src/panic_hook.rs
+++ b/src/runtime-rs/crates/shim/src/panic_hook.rs
@@ -7,7 +7,11 @@
 use std::{boxed::Box, fs::OpenOptions, io::Write, ops::Deref};
 
 use backtrace::Backtrace;
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 const KMESG_DEVICE: &str = "/dev/kmsg";
 
 // TODO: the Kata 1.x runtime had a SIGUSR1 handler that would log a formatted backtrace on

--- a/src/runtime-rs/crates/shim/src/shim_delete.rs
+++ b/src/runtime-rs/crates/shim/src/shim_delete.rs
@@ -13,7 +13,11 @@ use protobuf::Message;
 use std::{fs, path::Path};
 
 use crate::{shim::ShimExecutor, Error};
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 impl ShimExecutor {
     pub async fn delete(&mut self) -> Result<()> {
         self.args.validate(true).context("validate")?;

--- a/src/runtime-rs/crates/shim/src/shim_run.rs
+++ b/src/runtime-rs/crates/shim/src/shim_run.rs
@@ -14,15 +14,20 @@ use crate::{
     shim::{ShimExecutor, ENV_KATA_RUNTIME_BIND_FD},
     Error,
 };
-
+use logging::{
+    AGENT_LOGGER, RESOURCE_LOGGER, RUNTIMES_LOGGER, SERVICE_LOGGER, SHIM_LOGGER,
+    VIRT_CONTAINER_LOGGER, VMM_DRAGONBALL_LOGGER, VMM_LOGGER,
+};
+use slog::Logger;
 impl ShimExecutor {
     pub async fn run(&mut self) -> Result<()> {
         crate::panic_hook::set_panic_hook();
         let sid = self.args.id.clone();
         let bundle_path = get_bundle_path().context("get bundle")?;
         let path = bundle_path.join("log");
-        let _logger_guard =
-            logger::set_logger(path.to_str().unwrap(), &sid, self.args.debug).context("set logger");
+        let _logger_guard = logger::set_logger(path.to_str().unwrap(), &sid, self.args.debug)
+            .context("set logger")
+            .unwrap();
         if try_core_sched().is_err() {
             warn!(
                 sl!(),

--- a/src/tools/kata-ctl/src/main.rs
+++ b/src/tools/kata-ctl/src/main.rs
@@ -41,10 +41,21 @@ macro_rules! sl {
 fn real_main() -> Result<()> {
     let args = KataCtlCli::parse();
 
-    let log_level = args.log_level.unwrap_or(slog::Level::Info);
+    let _log_level = args.log_level.unwrap_or(slog::Level::Info);
+
+    let subsystem_level_config: HashMap<String, slog::Level> = HashMap::from([
+        ("agent".to_string(), slog::Level::Info)
+        ("runtimes".to_string(), slog::Level::Info)
+        ("resource".to_string(), slog::Level::Info)
+        ("virt-container".to_string(), slog::Level::Info)
+        ("service".to_string(), slog::Level::Info)
+        ("shim".to_string(), slog::Level::Info)
+        ("hypervisor".to_string(), slog::Level::Info)
+        ("vmm-dragonball".to_string(), slog::Level::Info)
+    ]);
 
     let (logger, _guard) = if args.json_logging {
-        logging::create_logger(crate_name!(), crate_name!(), log_level, io::stdout())
+        logging::create_logger(crate_name!(), crate_name!(), subsystem_level_config, io::stdout())
     } else {
         logging::create_term_logger(log_level)
     };


### PR DESCRIPTION
By separating loggers used by dargonball vmm to improve logging control, enabling isolation of change effect of drains of loggers.