### PR TITLE
osbuilder: Activate Debian guest rootfs

### DIFF
--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
@@ -1,5 +1,5 @@
-#
 # Copyright (c) 2018 SUSE
+# Copyright (c) 2023 Sony Group Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -7,34 +7,27 @@ ARG IMAGE_REGISTRY=docker.io
 # NOTE: OS_VERSION is set according to config.sh
 FROM ${IMAGE_REGISTRY}/debian:@OS_VERSION@
 
-# RUN commands
-RUN apt-get update && apt-get --no-install-recommends install -y \
-    apt-utils \
-    autoconf \
-    automake \
-    binutils \
-    build-essential \
+# makedev tries to mknod from postinst
+RUN [ -x /usr/bin/systemd-detect-virt ] || ( echo "echo docker" >/usr/bin/systemd-detect-virt && chmod +x /usr/bin/systemd-detect-virt )
+# hadolint ignore=DL3009,SC2046
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive \
+    apt-get --no-install-recommends -y install \
     ca-certificates \
-    chrony \
-    coreutils \
     curl \
-    debianutils \
-    debootstrap \
     g++ \
-    gcc \
+    $(gcc_arch="@ARCH@" && [ "$(uname -m)" != "$gcc_arch" ] && ( \
+         libc_arch="$gcc_arch" && \
+         [ "$gcc_arch" = aarch64 ] && libc_arch=arm64; \
+         [ "$gcc_arch" = ppc64le ] && gcc_arch=powerpc64le && libc_arch=ppc64el; \
+         [ "$gcc_arch" = s390x ] && gcc_arch=s390x && libc_arch=s390x; \
+         [ "$gcc_arch" = x86_64 ] && gcc_arch=x86-64 && libc_arch=amd64; \
+         echo "gcc-$gcc_arch-linux-gnu libc6-dev-$libc_arch-cross")) \
     git \
-    libc-dev \
-    libstdc++-8-dev \
-    m4 \
     make \
+    makedev \
+    multistrap \
     musl-tools \
-    sed \
-    systemd \
-    tar \
-    vim \
-    wget
-# aarch64 requires this name -- link for all
-RUN ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"
+    protobuf-compiler
 
-# This will install the proper packages to build Kata components
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/debian/config.sh
+++ b/tools/osbuilder/rootfs-builder/debian/config.sh
@@ -1,20 +1,14 @@
-#
 # Copyright (c) 2018 SUSE
+# Copyright (c) 2023 Sony Group Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
-OS_VERSION=${OS_VERSION:-10.11}
-
-# Set OS_NAME to the desired debian "codename"
-OS_NAME=${OS_NAME:-"stretch"}
-
-PACKAGES="systemd coreutils init iptables chrony kmod"
+OS_NAME=${OS_NAME:-"debian"}
+# This should be Debian's code name, e.g. "bookworm" for Debian 12.x
+OS_VERSION=${OS_VERSION:-bookworm}
 
 # NOTE: Re-using ubuntu rootfs configuration, see 'ubuntu' folder for full content.
 source $script_dir/ubuntu/$CONFIG_SH
 
-# Init process must be one of {systemd,kata-agent}
-INIT_PROCESS=systemd
-# List of zero or more architectures to exclude from build,
-# as reported by  `uname -m`
-ARCH_EXCLUDE_LIST=()
+REPO_URL="http://deb.debian.org/debian"
+KEYRING="debian-archive-keyring"

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -1,8 +1,9 @@
 # Copyright (c) 2018 Yash Jain, 2022 IBM Corp.
+# Copyright (c) 2023 Sony Group Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
-OS_NAME=ubuntu
+OS_NAME=${OS_NAME:-"ubuntu"}
 # This should be Ubuntu's code name, e.g. "focal" (Focal Fossa) for 20.04
 OS_VERSION=${OS_VERSION:-focal}
 PACKAGES="chrony iptables dbus"
@@ -10,6 +11,7 @@ PACKAGES="chrony iptables dbus"
 [ "$MEASURED_ROOTFS" = yes ] && PACKAGES+=" cryptsetup-bin e2fsprogs"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp2"
 REPO_URL=http://ports.ubuntu.com
+KEYRING="ubuntu-keyring"
 
 case "$ARCH" in
 	aarch64) DEB_ARCH=arm64;;

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -1,4 +1,5 @@
 # Copyright (c) 2018 Yash Jain, 2022 IBM Corp.
+# Copyright (c) 2023 Sony Group Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -16,13 +17,13 @@ build_rootfs() {
 	cat > "$multistrap_conf" << EOF
 [General]
 cleanup=true
-aptsources=Ubuntu
-bootstrap=Ubuntu
+aptsources=${OS_NAME^}
+bootstrap=${OS_NAME^}
 
-[Ubuntu]
+[${OS_NAME^}]
 source=$REPO_URL
-keyring=ubuntu-keyring
-suite=focal
+keyring=$KEYRING
+suite=$OS_VERSION
 packages=$PACKAGES $EXTRA_PKGS
 EOF
 	if ! multistrap -a "$DEB_ARCH" -d "$rootfs_dir" -f "$multistrap_conf"; then


### PR DESCRIPTION
Activate Debian guest rootfs for Kata using the multistrap. The created rootfs is `bookworm` which is the latest stable version of Debian and the `config.sh` for Debian reuses the one for Ubuntu because the installed packages inside the guest will be same as Ubuntu and this way can improve it's maintainability.

```sh
$ sudo -E kata-runtime exec <sandbox-id>
// Inside Kata VM
root@localhost:/# cat /etc/os-release
PRETTY_NAME="Debian GNU/Linux 12 (bookworm)"
NAME="Debian GNU/Linux"
VERSION_ID="12"
VERSION="12 (bookworm)"
VERSION_CODENAME=bookworm"
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
```

Fixes: #7828