### PR TITLE
kata-deploy: Create kata-static.tar with correct ownership

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -37,5 +37,5 @@ pushd ${tarball_content_dir}
 popd
 
 echo "create ${tar_path}"
-(cd "${tarball_content_dir}"; tar cvfJ "${tar_path}" .)
+(cd "${tarball_content_dir}"; tar cvfJ "${tar_path}" --owner=0 --group=0 .)
 popd


### PR DESCRIPTION
Pass --owner and --group to the tar invokation to prevent gihtub runner user from leaking into release artifacts.

Fixes: #7832