### PR TITLE
CI: switch static-checks-dragonball CI machines to Azure

### DIFF
--- a/.github/workflows/static-checks-dragonball.yaml
+++ b/.github/workflows/static-checks-dragonball.yaml
@@ -14,7 +14,7 @@ concurrency:
 name: Static checks dragonball
 jobs:
   test-dragonball:
-    runs-on: dragonball
+    runs-on: garm-ubuntu-2004
     env:
       RUST_BACKTRACE: "1"
     steps:
@@ -23,6 +23,10 @@ jobs:
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |
           echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential haveged
       - name: Install Rust
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}
         run: |


### PR DESCRIPTION
Previously, static-checks-dragonball is using machines from Alibaba Cloud to run all the CI jobs.

Currently, we are going through an internal process to apply for the new machines for Dragonball CI. Before the internal process is over, we will temporarily use Azure VM to run static-checks-dragonball jobs.

fixes: #7838