### PR TITLE
 ci: k8s: Add k8s devmapper tests (part 0)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,17 @@ jobs:
       pr-number: ${{ inputs.pr-number }}
     secrets: inherit
 
+  run-k8s-tests-on-garm:
+    needs: publish-kata-deploy-payload-amd64
+    uses: ./.github/workflows/run-k8s-tests-on-garm.yaml
+    with:
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-amd64
+      commit-hash: ${{ inputs.commit-hash }}
+      pr-number: ${{ inputs.pr-number }}
+    secrets: inherit
+
   run-k8s-tests-on-sev:
     needs: [publish-kata-deploy-payload-amd64, build-and-publish-tee-confidential-unencrypted-image]
     uses: ./.github/workflows/run-k8s-tests-on-sev.yaml

--- a/.github/workflows/run-k8s-tests-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-on-garm.yaml
@@ -1,0 +1,65 @@
+name: CI | Run kubernetes tests on GARM
+on:
+  workflow_call:
+    inputs:
+      registry:
+        required: true
+        type: string
+      repo:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      pr-number:
+        required: true
+        type: string
+      commit-hash:
+        required: false
+        type: string
+
+jobs:
+  run-k8s-tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        vmm:
+          - clh #cloud-hypervisor
+          - fc #firecracker
+          - qemu
+        snapshotter:
+          - devmapper
+        k8s:
+          - k3s
+    runs-on: garm-ubuntu-2204
+    env:
+      DOCKER_REGISTRY: ${{ inputs.registry }}
+      DOCKER_REPO: ${{ inputs.repo }}
+      DOCKER_TAG: ${{ inputs.tag }}
+      PR_NUMBER: ${{ inputs.pr-number }}
+      KATA_HYPERVISOR: ${{ matrix.vmm }}
+      KUBERNETES: ${{ matrix.k8s }}
+      SNAPSHOTTER: ${{ matrix.snapshotter }}
+      USING_NFD: "false"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.commit-hash }}
+
+      - name: Deploy ${{ matrix.k8s }}
+        run: bash tests/integrations/kubernetes/gha-run.sh deploy-k8s
+
+      - name: Configure the ${{ matrix.snapshotter }} snapshotter
+        run: bash tests/integrtion/kubernetes/gha-run.sh configure-snapshotter
+
+      - name: Deploy Kata
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-tdx
+  
+      - name: Run tests
+        timeout-minutes: 30
+        run: bash tests/integration/kubernetes/gha-run.sh run-tests
+  
+      - name: Delete kata-deploy
+        if: always()
+        run: bash tests/integration/kubernetes/gha-run.sh cleanup-tdx

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -68,6 +68,24 @@ function deploy_kata() {
     echo "::endgroup::"
 }
 
+function deploy_k3s() {
+	curl -sfL https://get.k3s.io | sh -
+
+	# This is an arbitrary value that came up from local tests
+	wait 240s
+}
+
+function deploy_k8s() {
+	echo "::group::Deploying ${KUBERNETES}"
+
+	case ${KUBERNETES} in
+		k3s) deploy_k3s ;;
+		*) >&2 echo "${KUBERNETES} flavour is not supported"; exit 2 ;;
+	esac
+
+	echo "::endgroup::"
+}
+
 function run_tests() {
     # Delete any spurious tests namespace that was left behind
     kubectl delete namespace kata-containers-k8s-tests &> /dev/null || true
@@ -138,6 +156,7 @@ function main() {
         install-azure-cli) install_azure_cli ;;
         login-azure) login_azure ;;
         create-cluster) create_cluster ;;
+        deploy-k8s) deploy_k8s ;;
         install-bats) install_bats ;;
         install-kubectl) install_kubectl ;;
         get-cluster-credentials) get_cluster_credentials ;;

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -12,6 +12,78 @@ kubernetes_dir="$(dirname "$(readlink -f "$0")")"
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
 tools_dir="${repo_root_dir}/tools"
 
+function configure_devmapper() {
+	sudo mkdir -p /var/lib/containerd/devmapper
+	sudo truncate --size 10G /var/lib/containerd/devmapper/data-disk.img
+	sudo truncate --size 10G /var/lib/containerd/devmapper/meta-disk.img
+
+	cat<<EOF | sudo tee /etc/systemd/system/containerd-devmapper.service
+[Unit]
+Description=Setup containerd devmapper device
+DefaultDependencies=no
+After=systemd-udev-settle.service
+Before=lvm2-activation-early.service
+Wants=systemd-udev-settle.service
+[Service]
+Type=oneshot
+RemainAfterExit=true
+ExecStart=-/sbin/losetup /dev/loop20 /var/lib/containerd/devmapper/data-disk.img
+ExecStart=-/sbin/losetup /dev/loop21 /var/lib/containerd/devmapper/meta-disk.img
+[Install]
+WantedBy=local-fs.target
+EOF
+
+	sudo systemctl daemon-reload
+	sudo systemctl enable --now containerd-devmapper
+
+	# Time to setup the thin pool for consumption.
+	# The table arguments are such.
+	# start block in the virtual device
+	# length of the segment (block device size in bytes / Sector size (512)
+	# metadata device
+	# block data device
+	# data_block_size Currently set it 512 (128KB)
+	# low_water_mark. Copied this from containerd snapshotter test setup
+	# no. of feature arguments
+	# Skip zeroing blocks for new volumes.
+	sudo dmsetup create contd-thin-pool \
+	        --table "0 20971520 thin-pool /dev/loop21 /dev/loop20 512 32768 1 skip_block_zeroing"
+	
+	case "${KUBERNETES}" in
+		k3s)
+			containerd_config_file="/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl"
+			sudo cp /var/lib/rancher/k3s/agent/etc/containerd/config.toml ${containerd_config_file}
+			;;
+		*) >&2 echo "${KUBERNETES} flavour is not supported"; exit 2 ;;
+	esac
+
+	# We're not using this with baremetal machines, so we're fine on cutting
+	# corners here and just append this to the configuration file.
+	cat<<EOF | sudo tee ${containerd_config_file}
+[plugins."io.containerd.snapshotter.v1.devmapper"]
+  pool_name = "contd-thin-pool"
+  base_image_size = "4096MB"
+EOF
+
+	case "${KUBERNETES}" in
+		k3s)
+			sudo sed -i -e 's/snapshotter = "overlayfs"/snapshotter = "devmapper"/g' ${containerd_config_file}
+			sudo systemctl restart k3s ;;
+		*) >&2 echo "${KUBERNETES} flavour is not supported"; exit 2 ;;
+	esac
+}
+
+function configure_snapshotter() {
+	echo "::group::Configuring ${SNAPSHOTTER}"
+
+	case ${SNAPSHOTTER} in
+		devmapper) configure_devmapper ;;
+		*) >&2 echo "${SNAPSHOTTER} flavour is not supported"; exit 2 ;;
+	esac
+
+	echo "::endgroup::"
+}
+
 function deploy_kata() {
     platform="${1}"
     ensure_yq
@@ -156,6 +228,7 @@ function main() {
         install-azure-cli) install_azure_cli ;;
         login-azure) login_azure ;;
         create-cluster) create_cluster ;;
+        configure-snapshotter) configure_snapshotter ;;
         deploy-k8s) deploy_k8s ;;
         install-bats) install_bats ;;
         install-kubectl) install_kubectl ;;


### PR DESCRIPTION
Let's enable the devmapper kubernetes tests to match exactly what's been
tested as part of the Jenkins CI.

Fixes: #6542