### PR TITLE
metrics: Add write 95 percentile FIO value

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -112,6 +112,20 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
+name = "fio"
+type = "json"
+description = "measure write 95 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .write95percentile.Result"
+checktype = "mean"
+midval = 823296.0
+minpercent = 20.0
+maxpercent = 20.0
+
+
+[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "iperf"

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -120,10 +120,9 @@ description = "measure write 95 percentile using fio"
 # within (inclusive)
 checkvar = ".\"fio\".Results | .[] | .write95percentile.Result"
 checktype = "mean"
-midval = 823296.0
+midval = 33024.0
 minpercent = 20.0
 maxpercent = 20.0
-
 
 [[metric]]
 name = "network-iperf3"

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -112,6 +112,19 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
+name = "fio"
+type = "json"
+description = "measure write 95 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .write95percentile.Result"
+checktype = "mean"
+midval = 43264.0
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "iperf"


### PR DESCRIPTION
This PR adds the write 95 percentile FIO value for checkmetrics for kata metrics.

Fixes #7842