### PR TITLE
packaging: do not install docker-compose-plugin for s390x|ppc64le

### DIFF
--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -19,7 +19,8 @@ RUN apt-get update && \
     apt-get clean && rm -rf /var/lib/apt/lists/ && \
     install_yq.sh && \
     curl -fsSL https://get.docker.com -o get-docker.sh && \
-    if uname -m | grep -Eq 's390x|ppc64le'; then export VERSION="v20.10"; fi && \
+    if uname -m | grep -Eq 's390x|ppc64le'; then export VERSION="v20.10" && \
+    sed -i 's/\<docker-compose-plugin\>//g' get-docker.sh; fi && \
     sh get-docker.sh
 
 ARG IMG_USER=kata-builder


### PR DESCRIPTION
This PR is to skip installing docker-compose-plugin while buiding a `build-kata-deploy` image for s390x|ppc64le. It is a temporary solution to fix current CI failures for s390x regarding `hash sum mismatch`.

Fixes: #7848
Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>