### PR TITLE
Support for direct-volume block devices backed by disk images (loop mounts)

### DIFF
--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -399,7 +399,9 @@ pub fn parse_mount_options<T: AsRef<str>>(options: &[T]) -> Result<(MsFlags, Str
     let mut data: Vec<String> = Vec::new();
 
     for opt in options.iter() {
-        if opt.as_ref() == "loop" {
+        if opt.as_ref().starts_with("io.katacontainers.") {
+            continue;
+        } else if opt.as_ref() == "loop" {
             return Err(Error::InvalidMountOption("loop".to_string()));
         } else if let Some(v) = parse_mount_flags(flags, opt.as_ref()) {
             flags = v;

--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -100,6 +100,7 @@ const (
 const (
 	// Define the string key for DriverOptions in DeviceInfo struct
 	BlockDriverOpt = "block-driver"
+	FormatOpt      = "format"
 
 	VhostUserReconnectTimeOutOpt = "vhost-user-reconnect-timeout"
 )
@@ -340,6 +341,9 @@ type BlockDrive struct {
 
 	// This block device is for swap
 	Swap bool
+
+	// The host path points to a regular file
+	RegularFile bool
 }
 
 // VFIOMode indicates e behaviour mode for handling devices in the VM

--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -44,6 +44,9 @@ const (
 	VhostUserFS = "vhost-user-fs-pci"
 )
 
+// Indicates that the device is backed by a host file
+const HostFileMajor int64 = -1
+
 const (
 	// VirtioMmio means use virtio-mmio for mmio based drives
 	VirtioMmio = "virtio-mmio"
@@ -116,6 +119,12 @@ const (
 	// qemu will delay this many seconds and then attempt to reconnect.  Zero
 	// disables reconnecting, and is the default.
 	DefaultVhostUserReconnectTimeOut = 0
+)
+
+// Define the values for the Format field specified in DeviceInfo
+const (
+	FormatRaw   = "raw"
+	FormatQcow2 = "qcow2"
 )
 
 // Defining these as a variable instead of a const, to allow
@@ -291,7 +300,7 @@ type BlockDrive struct {
 	// File is the path to the disk-image/device which will be used with this drive
 	File string
 
-	// Format of the drive
+	// Format of the drive (raw, qcow2)
 	Format string
 
 	// ID is used to identify this drive in the hypervisor options.
@@ -479,7 +488,7 @@ func GetHostPath(devInfo DeviceInfo, vhostUserStoreEnabled bool, vhostUserStoreP
 		return "", fmt.Errorf("Empty path provided for device")
 	}
 
-	if devInfo.Major == -1 {
+	if devInfo.Major == HostFileMajor {
 		return devInfo.HostPath, nil
 	}
 

--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -96,7 +96,6 @@ const (
 
 const (
 	// Define the string key for DriverOptions in DeviceInfo struct
-	FsTypeOpt      = "fstype"
 	BlockDriverOpt = "block-driver"
 
 	VhostUserReconnectTimeOutOpt = "vhost-user-reconnect-timeout"

--- a/src/runtime/pkg/device/drivers/block.go
+++ b/src/runtime/pkg/device/drivers/block.go
@@ -76,6 +76,13 @@ func (device *BlockDevice) Attach(ctx context.Context, devReceiver api.DeviceRec
 	}
 
 	customOptions := device.DeviceInfo.DriverOptions
+	if device.DeviceInfo.Major == config.HostFileMajor {
+		drive.RegularFile = true
+		if format, ok := customOptions[config.FormatOpt]; ok {
+			drive.Format = format
+		}
+	}
+
 	if customOptions == nil ||
 		customOptions[config.BlockDriverOpt] == config.VirtioSCSI {
 		// User has not chosen a specific block device type

--- a/src/runtime/pkg/device/drivers/block.go
+++ b/src/runtime/pkg/device/drivers/block.go
@@ -75,10 +75,6 @@ func (device *BlockDevice) Attach(ctx context.Context, devReceiver api.DeviceRec
 		ReadOnly: device.DeviceInfo.ReadOnly,
 	}
 
-	if fs, ok := device.DeviceInfo.DriverOptions[config.FsTypeOpt]; ok {
-		drive.Format = fs
-	}
-
 	customOptions := device.DeviceInfo.DriverOptions
 	if customOptions == nil ||
 		customOptions[config.BlockDriverOpt] == config.VirtioSCSI {

--- a/src/runtime/pkg/device/drivers/block.go
+++ b/src/runtime/pkg/device/drivers/block.go
@@ -68,7 +68,7 @@ func (device *BlockDevice) Attach(ctx context.Context, devReceiver api.DeviceRec
 
 	drive := &config.BlockDrive{
 		File:     device.DeviceInfo.HostPath,
-		Format:   "raw",
+		Format:   config.FormatRaw,
 		ID:       utils.MakeNameID("drive", device.DeviceInfo.ID, maxDevIDSize),
 		Index:    index,
 		Pmem:     device.DeviceInfo.Pmem,

--- a/src/runtime/pkg/device/manager/manager.go
+++ b/src/runtime/pkg/device/manager/manager.go
@@ -85,10 +85,10 @@ func NewDeviceManager(blockDriver string, vhostUserStoreEnabled bool, vhostUserS
 
 func (dm *deviceManager) findDevice(devInfo *config.DeviceInfo) api.Device {
 	// For devices with a major of -1, we use the host path to find existing instances.
-	if devInfo.Major == -1 {
+	if devInfo.Major == config.HostFileMajor {
 		for _, dev := range dm.devices {
 			dma, _ := dev.GetMajorMinor()
-			if dma == -1 && dev.GetHostPath() == devInfo.HostPath {
+			if dma == config.HostFileMajor && dev.GetHostPath() == devInfo.HostPath {
 				return dev
 			}
 		}

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -1171,6 +1171,8 @@ const (
 const (
 	// QCOW2 is the Qemu Copy On Write v2 image format.
 	QCOW2 BlockDeviceFormat = "qcow2"
+
+	RAW BlockDeviceFormat = "raw"
 )
 
 // BlockDevice represents a qemu block device.

--- a/src/runtime/pkg/govmm/qemu/qmp.go
+++ b/src/runtime/pkg/govmm/qemu/qmp.go
@@ -783,7 +783,7 @@ func (q *QMP) ExecuteQuit(ctx context.Context) error {
 
 func (q *QMP) blockdevAddBaseArgs(driver string, blockDevice *BlockDevice) map[string]interface{} {
 	blockdevArgs := map[string]interface{}{
-		"driver":    "raw",
+		"driver":    blockDevice.Format,
 		"read-only": blockDevice.ReadOnly,
 		"file": map[string]interface{}{
 			"driver":   driver,
@@ -802,12 +802,7 @@ func (q *QMP) blockdevAddBaseArgs(driver string, blockDevice *BlockDevice) map[s
 // used to name the device.  As this identifier will be passed directly to QMP,
 // it must obey QMP's naming rules, e,g., it must start with a letter.
 func (q *QMP) ExecuteBlockdevAdd(ctx context.Context, blockDevice *BlockDevice) error {
-	var args map[string]interface{}
-	if fi, err := os.Stat(blockDevice.File); err == nil && fi.Mode().IsRegular() {
-		args = q.blockdevAddBaseArgs("file", blockDevice)
-	} else {
-		args = q.blockdevAddBaseArgs("host_device", blockDevice)
-	}
+	args := q.blockdevAddBaseArgs("host_device", blockDevice)
 
 	return q.executeCommand(ctx, "blockdev-add", args, nil)
 }

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1568,7 +1568,6 @@ func handleBlockVolume(c *Container, device api.Device) (*grpc.Storage, error) {
 	case blockDrive.Pmem:
 		vol.Driver = kataNvdimmDevType
 		vol.Source = fmt.Sprintf("/dev/pmem%s", blockDrive.NvdimmID)
-		vol.Fstype = blockDrive.Format
 		vol.Options = []string{"dax"}
 	case c.sandbox.config.HypervisorConfig.BlockDeviceDriver == config.VirtioBlockCCW:
 		vol.Driver = kataBlkCCWDevType
@@ -1667,11 +1666,8 @@ func (k *kataAgent) handleDeviceBlockVolume(c *Container, m Mount, device api.De
 	}
 
 	vol.MountPoint = m.Destination
+	vol.Fstype = m.Type
 
-	// If no explicit FS Type or Options are being set, then let's use what is provided for the particular mount:
-	if vol.Fstype == "" {
-		vol.Fstype = m.Type
-	}
 	if len(vol.Options) == 0 {
 		vol.Options = m.Options
 	}

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1778,9 +1778,18 @@ func (k *kataAgent) handleBlkOCIMounts(c *Container, spec *specs.Spec) ([]*grpc.
 				"new-source":      path,
 			}).Debug("Replacing OCI mount source")
 			spec.Mounts[idx].Source = path
-			if HasOption(spec.Mounts[idx].Options, vcAnnotations.IsFileBlockDevice) {
-				// The device is already mounted, just bind to path in container.
-				spec.Mounts[idx].Options = []string{"bind"}
+
+			if isLoopMount(spec.Mounts[idx].Options) {
+				mountOptions := []string{"bind"}
+
+				for _, opt := range spec.Mounts[idx].Options {
+					if opt == "ro" {
+						mountOptions = append(mountOptions, "ro")
+					}
+				}
+
+				spec.Mounts[idx].Options = mountOptions
+				spec.Mounts[idx].Type = "bind"
 			}
 			break
 		}

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -245,7 +245,7 @@ func TestHandleDeviceBlockVolume(t *testing.T) {
 				BlockDrive: &config.BlockDrive{
 					Pmem:     true,
 					NvdimmID: testNvdimmID,
-					Format:   "raw",
+					Format:   config.FormatRaw,
 				},
 			},
 			inputMount: Mount{

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -245,10 +245,12 @@ func TestHandleDeviceBlockVolume(t *testing.T) {
 				BlockDrive: &config.BlockDrive{
 					Pmem:     true,
 					NvdimmID: testNvdimmID,
-					Format:   testBlkDriveFormat,
+					Format:   "raw",
 				},
 			},
-			inputMount: Mount{},
+			inputMount: Mount{
+				Type: testBlkDriveFormat,
+			},
 			resultVol: &pb.Storage{
 				Driver:  kataNvdimmDevType,
 				Source:  fmt.Sprintf("/dev/pmem%s", testNvdimmID),

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -425,11 +425,17 @@ func HasOption(options []string, option string) bool {
 	return false
 }
 
-func HasOptionPrefix(options []string, prefix string) bool {
+func GetOptionPrefix(options []string, prefix string) (string, bool) {
 	for _, o := range options {
 		if strings.HasPrefix(o, prefix) {
-			return true
+			return strings.TrimPrefix(o, prefix), true
 		}
 	}
-	return false
+	return "", false
+}
+
+func HasOptionPrefix(options []string, prefix string) bool {
+	_, found := GetOptionPrefix(options, prefix)
+
+	return found
 }

--- a/src/runtime/virtcontainers/mount_linux.go
+++ b/src/runtime/virtcontainers/mount_linux.go
@@ -13,6 +13,7 @@ import (
 
 	merr "github.com/hashicorp/go-multierror"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
+	vcAnnotations "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations"
 	"github.com/pkg/errors"
 	otelLabel "go.opentelemetry.io/otel/attribute"
 )
@@ -192,4 +193,17 @@ func bindUnmountAllRootfs(ctx context.Context, sharedDir string, sandbox *Sandbo
 		}
 	}
 	return errors.ErrorOrNil()
+}
+
+func isLoopMount(options []string) bool {
+	// a loop device can be associated with a regular file
+	// or another block device, this means a file
+	// block device annotation is a subset of the more general
+	// concept covered by the loop option
+	for _, o := range options {
+		if o == vcAnnotations.IsFileBlockDevice || o == "loop" {
+			return true
+		}
+	}
+	return false
 }

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -329,6 +329,8 @@ const (
 	// IsFileBlockDevice indicates that the annotated filesystem is mounted on a block device
 	// backed by a host file.
 	IsFileBlockDevice = kataAnnotFsOptPrefix + "block_device=file"
+
+	DriveFormat = kataAnnotFsOptPrefix + "format="
 )
 
 const (

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -411,7 +411,7 @@ func genericImage(path string) (config.BlockDrive, error) {
 
 	drive := config.BlockDrive{
 		File:     path,
-		Format:   "raw",
+		Format:   config.FormatRaw,
 		ID:       id,
 		ShareRW:  true,
 		ReadOnly: true,

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -322,7 +322,7 @@ func TestQemuArchBaseAppendImage(t *testing.T) {
 			ID:        drive.ID,
 			File:      image.Name(),
 			AIO:       govmmQemu.Threads,
-			Format:    "raw",
+			Format:    govmmQemu.RAW,
 			Interface: "none",
 			ShareRW:   true,
 			ReadOnly:  true,
@@ -415,7 +415,6 @@ func TestQemuArchBaseAppendSocket(t *testing.T) {
 func TestQemuArchBaseAppendBlockDevice(t *testing.T) {
 	id := "blockDevTest"
 	file := "/root"
-	format := "raw"
 
 	expectedOut := []govmmQemu.Device{
 		govmmQemu.BlockDevice{
@@ -423,14 +422,14 @@ func TestQemuArchBaseAppendBlockDevice(t *testing.T) {
 			ID:        id,
 			File:      "/root",
 			AIO:       govmmQemu.Threads,
-			Format:    govmmQemu.BlockDeviceFormat(format),
+			Format:    govmmQemu.RAW,
 			Interface: "none",
 		},
 	}
 
 	drive := config.BlockDrive{
 		File:   file,
-		Format: format,
+		Format: config.FormatRaw,
 		ID:     id,
 	}
 

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -2007,9 +2007,11 @@ func (s *Sandbox) HotplugAddDevice(ctx context.Context, device api.Device, devTy
 	defer span.End()
 
 	if s.sandboxController != nil {
-		if err := s.sandboxController.AddDevice(device.GetHostPath()); err != nil {
-			s.Logger().WithError(err).WithField("device", device).
-				Warnf("Could not add device to the %s controller", s.sandboxController)
+		if major, _ := device.GetMajorMinor(); major != config.HostFileMajor {
+			if err := s.sandboxController.AddDevice(device.GetHostPath()); err != nil {
+				s.Logger().WithError(err).WithField("device", device).
+					Warnf("Could not add device to the %s controller", s.sandboxController)
+			}
 		}
 	}
 
@@ -2060,9 +2062,11 @@ func (s *Sandbox) HotplugAddDevice(ctx context.Context, device api.Device, devTy
 func (s *Sandbox) HotplugRemoveDevice(ctx context.Context, device api.Device, devType config.DeviceType) error {
 	defer func() {
 		if s.sandboxController != nil {
-			if err := s.sandboxController.RemoveDevice(device.GetHostPath()); err != nil {
-				s.Logger().WithError(err).WithField("device", device).
-					Warnf("Could not add device to the %s controller", s.sandboxController)
+			if major, _ := device.GetMajorMinor(); major != config.HostFileMajor {
+				if err := s.sandboxController.RemoveDevice(device.GetHostPath()); err != nil {
+					s.Logger().WithError(err).WithField("device", device).
+						Warnf("Could not add device to the %s controller", s.sandboxController)
+				}
 			}
 		}
 	}()

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1280,7 +1280,7 @@ func (s *Sandbox) addSwap(ctx context.Context, swapID string, size int64) (*conf
 
 	blockDevice := &config.BlockDrive{
 		File:   swapFile,
-		Format: "raw",
+		Format: config.FormatRaw,
 		ID:     swapID,
 		Swap:   true,
 	}


### PR DESCRIPTION
This patch adds support for attaching direct-volumes where the source is a disk image file. It does so by using the loop (preferred) or io.katacontainers.fs-opt.block_device=file mount option. If the loop option is found, the file/device is attached as a block device to vm and kata-agent mounts it (without the loop option). 

The new `blockfile` snapshotter introduced in containerd 1.7.4 can also be supported using the loop mount option. I'll address this feature in another PR.

I fixed a few issues along the way:

1. There is a regression in kata agent when trying to use regular files as block devices 
2. In case the host path for the device points to a regular file on host the sandbox cgroup controller will generate an error
3. There is a hack where the Format field in BlockDrive is used for fstype. This field should be used for the format of the actual file/device on disk, not for the contents inside the drive. I removed the hack and documented what Format is actually supposed to mean.

Fixes: #7840 #7858 #7859