### PR TITLE
metrics: Add read 95 percentile for FIO metrics

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -125,6 +125,19 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
+name = "fio"
+type = "json"
+description = "measure read 95 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .read95percentile.Result"
+checktype = "mean"
+midval = 67072.0
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "iperf"

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -133,7 +133,7 @@ description = "measure read 95 percentile using fio"
 # within (inclusive)
 checkvar = ".\"fio\".Results | .[] | .read95percentile.Result"
 checktype = "mean"
-midval = 67072.0
+midval = 41216.0
 minpercent = 20.0
 maxpercent = 20.0
 

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -125,6 +125,19 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
+name = "fio"
+type = "json"
+description = "measure read 95 percentile using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"fio\".Results | .[] | .read95percentile.Result"
+checktype = "mean"
+midval = 72192.0
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "iperf"

--- a/tests/metrics/storage/fio-k8s/fio-test-ci.sh
+++ b/tests/metrics/storage/fio-k8s/fio-test-ci.sh
@@ -15,6 +15,7 @@ TEST_NAME="${TEST_NAME:-fio}"
 function main() {
 	cmds=("bc" "jq")
 	check_cmds "${cmds[@]}"
+	sudo modprobe vhost_iotlb
 	init_env
 
 	pushd "${FIO_PATH}"

--- a/tests/metrics/storage/fio-k8s/fio-test-ci.sh
+++ b/tests/metrics/storage/fio-k8s/fio-test-ci.sh
@@ -16,7 +16,6 @@ function main() {
 	cmds=("bc" "jq")
 	check_cmds "${cmds[@]}"
 	init_env
-	check_processes
 
 	pushd "${FIO_PATH}"
 		[ -z "${KATA_HYPERVISOR}" ] && die "Hypervisor ID is missing."
@@ -79,8 +78,6 @@ EOF
 	metrics_json_add_array_element "$json"
 	metrics_json_end_array "Results"
 	metrics_json_save
-
-	check_processes
 }
 
 main "$@"


### PR DESCRIPTION
This PR adds the read 95 percentile limit value for FIO metrics for kata metrics.

Fixes #7855