### PR TITLE
ci: k8s: Second round of fix-ups with the devmapper CI

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -144,7 +144,7 @@ function deploy_k3s() {
 	curl -sfL https://get.k3s.io | sh -
 
 	# This is an arbitrary value that came up from local tests
-	wait 240s
+	sleep 240s
 }
 
 function deploy_k8s() {

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -141,7 +141,7 @@ function deploy_kata() {
 }
 
 function deploy_k3s() {
-	curl -sfL https://get.k3s.io | sh -
+	curl -sfL https://get.k3s.io | sh -s - --write-kubeconfig-mode 644
 
 	# This is an arbitrary value that came up from local tests
 	sleep 240s


### PR DESCRIPTION
This time we'll actually be able to run the tests, hopefully, and this PR will include all the needed fixes to get them green.