### PR TITLE
runtime: Fix more virtiofs args

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -513,7 +513,7 @@ func (q *qemu) createVirtiofsDaemon(sharedPath string) (VirtiofsDaemon, error) {
 	// in virtiofs if SELinux on the guest side is enabled.
 	if !q.config.DisableGuestSeLinux {
 		q.Logger().Info("Set the xattr option for virtiofsd")
-		q.config.VirtioFSExtraArgs = append(q.config.VirtioFSExtraArgs, "-o", "xattr")
+		q.config.VirtioFSExtraArgs = append(q.config.VirtioFSExtraArgs, "--xattr")
 	}
 
 	// default use virtiofsd

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -39,7 +39,6 @@ var (
 
 const (
 	typeVirtioFSCacheModeNever  = "never"
-	typeVirtioFSCacheModeNone   = "none"
 	typeVirtioFSCacheModeAlways = "always"
 	typeVirtioFSCacheModeAuto   = "auto"
 )
@@ -219,9 +218,6 @@ func (v *virtiofsd) valid() error {
 
 	if v.cache == "" {
 		v.cache = typeVirtioFSCacheModeAuto
-	} else if v.cache == typeVirtioFSCacheModeNone {
-		v.Logger().Warn("virtio-fs cache mode `none` is deprecated since Kata Containers 2.5.0 and will be removed in the future release, please use `never` instead. For more details please refer to https://github.com/kata-containers/kata-containers/issues/4234.")
-		v.cache = typeVirtioFSCacheModeNever
 	} else if v.cache != typeVirtioFSCacheModeAuto && v.cache != typeVirtioFSCacheModeAlways && v.cache != typeVirtioFSCacheModeNever {
 		return errVirtiofsdInvalidVirtiofsCacheMode(v.cache)
 	}

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -76,15 +76,15 @@ func TestVirtiofsdArgs(t *testing.T) {
 	v := &virtiofsd{
 		path:       "/usr/bin/virtiofsd",
 		sourcePath: "/run/kata-shared/foo",
-		cache:      "none",
+		cache:      "never",
 	}
 
-	expected := "--syslog --cache=none --shared-dir=/run/kata-shared/foo --fd=123"
+	expected := "--syslog --cache=never --shared-dir=/run/kata-shared/foo --fd=123"
 	args, err := v.args(123)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))
 
-	expected = "--syslog --cache=none --shared-dir=/run/kata-shared/foo --fd=456"
+	expected = "--syslog --cache=never --shared-dir=/run/kata-shared/foo --fd=456"
 	args, err = v.args(456)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))
@@ -130,12 +130,7 @@ func TestValid(t *testing.T) {
 		{"source is not available", func(v *virtiofsd) {
 			v.sourcePath = "/foo/bar"
 		}, errVirtiofsdSourceNotAvailable, nil},
-		{"replace cache mode none by never", func(v *virtiofsd) {
-			v.cache = "none"
-		}, nil, func(name string, a *assert.Assertions, v *virtiofsd) {
-			a.Equal("never", v.cache, "test case %+s, cache mode none should be replaced by never", name)
-		}},
-		{"invald cache mode: replace none by never", func(v *virtiofsd) {
+		{"invalid cache mode", func(v *virtiofsd) {
 			v.cache = "foo"
 		}, errVirtiofsdInvalidVirtiofsCacheMode("foo"), nil},
 	}


### PR DESCRIPTION
Update some more virtiofsd arguments from the legacy syntax of the C implementation to the new syntax used by the rust implementation.
