### PR TITLE
metrics: Use TensorFlow optimized image

### DIFF
--- a/tests/metrics/machine_learning/resnet50_fp32_dockerfile/Dockerfile
+++ b/tests/metrics/machine_learning/resnet50_fp32_dockerfile/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: FROM [image name]
-FROM ubuntu:20.04
+FROM intel/intel-optimized-tensorflow:2.9.1
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/tests/metrics/machine_learning/resnet50_int8_dockerfile/Dockerfile
+++ b/tests/metrics/machine_learning/resnet50_int8_dockerfile/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: FROM [image name]
-FROM ubuntu:20.04
+FROM intel/intel-optimized-tensorflow:2.9.1
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This PR replaces the ubuntu image for one which has TensorFlow optimized for kata metrics.

Fixes #7866