### PR TITLE
metrics: fix FIO test initialization

### DIFF
--- a/tests/metrics/storage/fio-k8s/fio-test-ci.sh
+++ b/tests/metrics/storage/fio-k8s/fio-test-ci.sh
@@ -15,8 +15,8 @@ TEST_NAME="${TEST_NAME:-fio}"
 function main() {
 	cmds=("bc" "jq")
 	check_cmds "${cmds[@]}"
-	check_processes
 	init_env
+	check_processes
 
 	pushd "${FIO_PATH}"
 		[ -z "${KATA_HYPERVISOR}" ] && die "Hypervisor ID is missing."


### PR DESCRIPTION
This PR changes the order in which the FIO test first cleans the environment and then checks if the environment is indeed clean.

Fixes: #7869