### PR TITLE
kata-deploy: Fix aarch64 image build

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -14,6 +14,7 @@ RUN \
 	apk --no-cache add bash curl && \
 	ARCH=$(uname -m) && \
 	if [ "${ARCH}" = "x86_64" ]; then ARCH=amd64; fi && \
+	if [ "${ARCH}" = "aarch64" ]; then ARCH=arm64; fi && \
 	curl -fL --progress-bar -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
 	chmod +x /usr/bin/kubectl && \
 	mkdir -p ${DESTINATION} && \

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -19,7 +19,8 @@ RUN \
 	chmod +x /usr/bin/kubectl && \
 	mkdir -p ${DESTINATION} && \
 	tar xvf ${WORKDIR}/${KATA_ARTIFACTS} -C ${DESTINATION} && \
-	rm -f ${WORKDIR}/${KATA_ARTIFACTS}
+	rm -f ${WORKDIR}/${KATA_ARTIFACTS} && \
+	apk del curl
 
 COPY scripts ${DESTINATION}/scripts
 COPY runtimeclasses ${DESTINATION}/runtimeclasses


### PR DESCRIPTION
Similarly to what's been done for x86_64 -> amd64, we need to do a
aarch64 -> arm64 change in order to be able to download the kubectl
binary.
