### PR TITLE
image-builder: fix udev error when using docker to build image

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -205,6 +205,7 @@ build_with_container() {
 		   --env DEBUG="${DEBUG}" \
 		   --env ARCH="${ARCH}" \
 		   --env TARGET_ARCH="${TARGET_ARCH}" \
+		   --env DM_VERITY="${DM_VERITY}" \
 		   -v /dev:/dev \
 		   -v "${script_dir}":"/osbuilder" \
 		   -v "${script_dir}/../scripts":"/scripts" \


### PR DESCRIPTION
Incorporate the `DM_VERITY` parameter when building the image with docker.
 
Fixes #7879