### PR TITLE
metrics: Ensure docker is running in init_env

### DIFF
--- a/tests/metrics/lib/common.bash
+++ b/tests/metrics/lib/common.bash
@@ -168,6 +168,8 @@ function init_env()
 
 	cmd=("docker" "ctr")
 
+	sudo systemctl restart docker
+
 	# check dependencies
 	check_cmds "${cmd[@]}"
 


### PR DESCRIPTION
This PR ensures that docker is running as part of the init_env function in kata metrics to avoid failures like docker is not running and making the kata metrics CI to fail.

Fixes #7898