### PR TITLE
ci: Add more target-branch related fixes

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -15,4 +15,5 @@ jobs:
       commit-hash: ${{ github.sha }}
       pr-number: "nightly"
       tag: ${{ github.sha }}-nightly
+      target-branch: $GITHUB_REF_NAME
     secrets: inherit

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -15,6 +15,7 @@ jobs:
     with:
       commit-hash: ${{ github.sha }}
       push-to-registry: yes
+      target-branch: $GITHUB_REF_NAME
     secrets: inherit
 
   build-assets-arm64:
@@ -22,6 +23,7 @@ jobs:
     with:
       commit-hash: ${{ github.sha }}
       push-to-registry: yes
+      target-branch: $GITHUB_REF_NAME
     secrets: inherit
 
   build-assets-s390x:
@@ -29,6 +31,7 @@ jobs:
     with:
       commit-hash: ${{ github.sha }}
       push-to-registry: yes
+      target-branch: $GITHUB_REF_NAME
     secrets: inherit
 
   publish-kata-deploy-payload-amd64:
@@ -39,6 +42,7 @@ jobs:
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-amd64
+      target-branch: $GITHUB_REF_NAME
     secrets: inherit
 
   publish-kata-deploy-payload-arm64:
@@ -49,6 +53,7 @@ jobs:
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-arm64
+      target-branch: $GITHUB_REF_NAME
     secrets: inherit
 
   publish-kata-deploy-payload-s390x:
@@ -59,6 +64,7 @@ jobs:
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-s390x
+      target-branch: $GITHUB_REF_NAME
     secrets: inherit
 
   publish-manifest:

--- a/.github/workflows/publish-kata-deploy-payload-amd64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-amd64.yaml
@@ -17,6 +17,10 @@ on:
       commit-hash:
         required: false
         type: string
+      target-branch:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   kata-payload:

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -17,6 +17,10 @@ on:
       commit-hash:
         required: false
         type: string
+      target-branch:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   kata-payload:
@@ -29,6 +33,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -17,6 +17,10 @@ on:
       commit-hash:
         required: false
         type: string
+      target-branch:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   kata-payload:
@@ -29,6 +33,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@v3


### PR DESCRIPTION
The ones for the payload-after-push.yamland ci-nightly.yaml are not that much important right now, but they're needed for when we start running those on stable branches as well.

The other ones were missed during
bd24afcf737f94481992e2d88b27e66cfae64df8.

Fixes: #7414