### PR TITLE
ci: use github.ref_name instead of $GITHUB_REF_NAME

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -15,5 +15,5 @@ jobs:
       commit-hash: ${{ github.sha }}
       pr-number: "nightly"
       tag: ${{ github.sha }}-nightly
-      target-branch: $GITHUB_REF_NAME
+      target-branch: ${{ github.ref_name }}
     secrets: inherit

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -15,7 +15,7 @@ jobs:
     with:
       commit-hash: ${{ github.sha }}
       push-to-registry: yes
-      target-branch: $GITHUB_REF_NAME
+      target-branch: ${{ github.ref_name }}
     secrets: inherit
 
   build-assets-arm64:
@@ -23,7 +23,7 @@ jobs:
     with:
       commit-hash: ${{ github.sha }}
       push-to-registry: yes
-      target-branch: $GITHUB_REF_NAME
+      target-branch: ${{ github.ref_name }}
     secrets: inherit
 
   build-assets-s390x:
@@ -31,7 +31,7 @@ jobs:
     with:
       commit-hash: ${{ github.sha }}
       push-to-registry: yes
-      target-branch: $GITHUB_REF_NAME
+      target-branch: ${{ github.ref_name }}
     secrets: inherit
 
   publish-kata-deploy-payload-amd64:
@@ -42,7 +42,7 @@ jobs:
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-amd64
-      target-branch: $GITHUB_REF_NAME
+      target-branch: ${{ github.ref_name }}
     secrets: inherit
 
   publish-kata-deploy-payload-arm64:
@@ -53,7 +53,7 @@ jobs:
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-arm64
-      target-branch: $GITHUB_REF_NAME
+      target-branch: ${{ github.ref_name }}
     secrets: inherit
 
   publish-kata-deploy-payload-s390x:
@@ -64,7 +64,7 @@ jobs:
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-s390x
-      target-branch: $GITHUB_REF_NAME
+      target-branch: ${{ github.ref_name }}
     secrets: inherit
 
   publish-manifest:


### PR DESCRIPTION
As, regardless of what's mentioned in the documentation, it seems that $GITHUB_REF_NAME is passed down as a literal string.

Fixes: #7414