### PR TITLE
tests: fix kernel and initrd annotations

### DIFF
--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -82,14 +82,10 @@ add_policy_to_yaml() {
 		;;
 
 	Deployment|Job|ReplicationController)
-		if [ "${KATA_HOST_OS}" == "cbl-mariner" ]; then
-			echo "Issue #7764: using policy for ${resource_kind} from ${yaml_file} is blocked on ${KATA_HOST_OS}"
-		else
-			echo "Adding policy to ${resource_kind} from ${yaml_file}"
-			ALLOW_ALL_POLICY="${ALLOW_ALL_POLICY}" yq write -i "${K8S_TEST_YAML}" \
-				'spec.template.metadata.annotations."io.katacontainers.config.agent.policy"' \
-				"${ALLOW_ALL_POLICY}"
-		fi
+		echo "Adding policy to ${resource_kind} from ${yaml_file}"
+		ALLOW_ALL_POLICY="${ALLOW_ALL_POLICY}" yq write -i "${K8S_TEST_YAML}" \
+			'spec.template.metadata.annotations."io.katacontainers.config.agent.policy"' \
+			"${ALLOW_ALL_POLICY}"
 		;;
 
 	List)

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -15,26 +15,56 @@ reset_workloads_work_dir() {
     cp -R ${kubernetes_dir}/runtimeclass_workloads ${kubernetes_dir}/runtimeclass_workloads_work
 }
 
-set_kernel_path() {
-    if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
-        mariner_kernel_path="/usr/share/cloud-hypervisor/vmlinux.bin"
-        # Not using find -exec as that still returns 0 on failure.
-        find ${kubernetes_dir}/runtimeclass_workloads_work/*.yaml -print0 | xargs -0 -I% yq write -i % 'metadata.annotations[io.katacontainers.config.hypervisor.kernel]' "${mariner_kernel_path}"
-    fi
+add_kernel_initrd_annotations_to_yaml() {
+    local yaml_file="$1"
+    local mariner_kernel_path="/usr/share/cloud-hypervisor/vmlinux.bin"
+    local mariner_initrd_path="/opt/kata/share/kata-containers/kata-containers-initrd-mariner.img"
+    local resource_kind="$(yq read ${yaml_file} kind)"
+
+    case "${resource_kind}" in
+
+    Pod)
+        echo "Adding kernel and initrd annotations to ${resource_kind} from ${yaml_file}"
+        yq write -i "${K8S_TEST_YAML}" 'metadata.annotations[io.katacontainers.config.hypervisor.kernel]' "${mariner_kernel_path}"
+        yq write -i "${K8S_TEST_YAML}" 'metadata.annotations[io.katacontainers.config.hypervisor.initrd]' "${mariner_initrd_path}"
+        ;;
+
+    Deployment|Job|ReplicationController)
+        echo "Adding kernel and initrd annotations to ${resource_kind} from ${yaml_file}"
+        yq write -i "${K8S_TEST_YAML}" 'spec.template.metadata.annotations[io.katacontainers.config.hypervisor.kernel]' "${mariner_kernel_path}"
+        yq write -i "${K8S_TEST_YAML}" 'spec.template.metadata.annotations[io.katacontainers.config.hypervisor.initrd]' "${mariner_initrd_path}"
+        ;;
+
+    List)
+        echo "Issue #7765: adding kernel and initrd annotations to ${resource_kind} from ${yaml_file} is not implemented yet"
+        ;;
+
+    ConfigMap|LimitRange|Namespace|PersistentVolume|PersistentVolumeClaim|RuntimeClass|Secret|Service)
+        echo "Kernel and initrd annotations are not required for ${resource_kind} from ${yaml_file}"
+        ;;
+
+    *)
+        echo "k8s resource type ${resource_kind} from ${yaml_file} is not yet supported for kernel and initrd annotations testing"
+        return 1
+        ;;
+
+	esac
 }
 
-set_initrd_path() {
+add_kernel_initrd_annotations() {
     if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
-        initrd_path="/opt/kata/share/kata-containers/kata-containers-initrd-mariner.img"
-        find ${kubernetes_dir}/runtimeclass_workloads_work/*.yaml -print0 | xargs -0 -I% yq write -i % 'metadata.annotations[io.katacontainers.config.hypervisor.initrd]' "${initrd_path}"
+        info "Add kernel and initrd annotations"
+        for K8S_TEST_YAML in runtimeclass_workloads_work/*.yaml
+        do
+            add_kernel_initrd_annotations_to_yaml "${K8S_TEST_YAML}"
+        done
     fi
 }
 
 main() {
     ensure_yq
     reset_workloads_work_dir
-    set_kernel_path
-    set_initrd_path
+    add_kernel_initrd_annotations
 }
 
 main "$@"


### PR DESCRIPTION
Fix kernel and initrd annotations in the k8s tests on Mariner. These annotations must be applied to the spec.template for Deployment, Job and ReplicationController resources.

Fixes: #7764