### PR TITLE
metrics: this PR skips the FIO test temprarily to fix issues

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -99,32 +99,6 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
-name = "fio"
-type = "json"
-description = "measure write 90 percentile using fio"
-# Min and Max values to set a 'range' that
-# the median of the CSV Results data must fall
-# within (inclusive)
-checkvar = ".\"fio\".Results | .[] | .write90percentile.Result"
-checktype = "mean"
-midval = 38656.0
-minpercent = 20.0
-maxpercent = 20.0
-
-[[metric]]
-name = "fio"
-type = "json"
-description = "measure write 95 percentile using fio"
-# Min and Max values to set a 'range' that
-# the median of the CSV Results data must fall
-# within (inclusive)
-checkvar = ".\"fio\".Results | .[] | .write95percentile.Result"
-checktype = "mean"
-midval = 33024.0
-minpercent = 20.0
-maxpercent = 20.0
-
-[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "iperf"

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -99,32 +99,6 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
-name = "fio"
-type = "json"
-description = "measure write 90 percentile using fio"
-# Min and Max values to set a 'range' that
-# the median of the CSV Results data must fall
-# within (inclusive)
-checkvar = ".\"fio\".Results | .[] | .write90percentile.Result"
-checktype = "mean"
-midval = 37120.0
-minpercent = 20.0
-maxpercent = 20.0
-
-[[metric]]
-name = "fio"
-type = "json"
-description = "measure write 95 percentile using fio"
-# Min and Max values to set a 'range' that
-# the median of the CSV Results data must fall
-# within (inclusive)
-checkvar = ".\"fio\".Results | .[] | .write95percentile.Result"
-checktype = "mean"
-midval = 43264.0
-minpercent = 20.0
-maxpercent = 20.0
-
-[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "iperf"

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -84,9 +84,9 @@ function run_test_tensorflow() {
 }
 
 function run_test_fio() {
-	info "Running FIO test using ${KATA_HYPERVISOR} hypervisor"
+	info "Skipping FIO test temporarily using ${KATA_HYPERVISOR} hypervisor"
 
-	bash tests/metrics/storage/fio-k8s/fio-test-ci.sh
+	# bash tests/metrics/storage/fio-k8s/fio-test-ci.sh
 }
 
 function run_test_iperf() {


### PR DESCRIPTION
FIO test is showing ongoing issues when running in k8s. Working on running FIO on the ctr client which has been shown to be stable.

Fixes: #7920