### PR TITLE
metrics: Add iperf bandwidth value for kata metrics

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -101,6 +101,19 @@ maxpercent = 20.0
 [[metric]]
 name = "network-iperf3"
 type = "json"
+description = "measure container bandwidth using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3\".Results | .[] | .bandwidth.Result"
+checktype = "mean"
+midval = 55302925246.02
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "network-iperf3"
+type = "json"
 description = "iperf"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -121,5 +121,5 @@ description = "iperf"
 checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
 midval = 0.044
-minpercent = 30.0
-maxpercent = 30.0
+minpercent = 35.0
+maxpercent = 35.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -121,5 +121,5 @@ description = "iperf"
 checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
 midval = 0.044
-minpercent = 35.0
-maxpercent = 35.0
+minpercent = 40.0
+maxpercent = 40.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -107,7 +107,7 @@ description = "measure container bandwidth using iperf3"
 # within (inclusive)
 checkvar = ".\"network-iperf3\".Results | .[] | .bandwidth.Result"
 checktype = "mean"
-midval = 55302925246.02
+midval = 61176889941.19
 minpercent = 20.0
 maxpercent = 20.0
 

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -101,6 +101,19 @@ maxpercent = 20.0
 [[metric]]
 name = "network-iperf3"
 type = "json"
+description = "measure container bandwidth using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3\".Results | .[] | .bandwidth.Result"
+checktype = "mean"
+midval = 52644229340.91
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "network-iperf3"
+type = "json"
 description = "iperf"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -121,5 +121,5 @@ description = "iperf"
 checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
 midval = 0.041
-minpercent = 30.0
-maxpercent = 30.0
+minpercent = 40.0
+maxpercent = 40.0


### PR DESCRIPTION
This PR adds the iperf bandwidth value for kata metrics.

Fixes #7924