### PR TITLE
metrics: Add iperf value for cpu utilization

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -107,7 +107,7 @@ description = "measure container cpu utilization using iperf3"
 # within (inclusive)
 checkvar = ".\"network-iperf3\".Results | .[] | .cpu.Result"
 checktype = "mean"
-midval = 99.0
+midval = 85.60
 minpercent = 20.0
 maxpercent = 20.0
 

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -101,6 +101,19 @@ maxpercent = 20.0
 [[metric]]
 name = "network-iperf3"
 type = "json"
+description = "measure container cpu utilization using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3\".Results | .[] | .cpu.Result"
+checktype = "mean"
+midval = 99.0
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "network-iperf3"
+type = "json"
 description = "measure container bandwidth using iperf3"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -101,6 +101,19 @@ maxpercent = 20.0
 [[metric]]
 name = "network-iperf3"
 type = "json"
+description = "measure container cpu utilization using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3\".Results | .[] | .cpu.Result"
+checktype = "mean"
+midval = 99.86
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "network-iperf3"
+type = "json"
 description = "measure container bandwidth using iperf3"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall


### PR DESCRIPTION
This PR adds the iperf value for cpu utilization for kata metrics.

Fixes #7936