### PR TITLE
ci: install ORAS when needed

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -76,6 +76,10 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
+      - name: Install ORAS
+        run: |
+          ./tests/install_oras.sh
+
       - name: Build ${{ matrix.asset }}
         run: |
           make "${KATA_ASSET}-tarball"

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -63,6 +63,10 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
+      - name: Install ORAS
+        run: |
+          ./tests/install_oras.sh
+
       - name: Build ${{ matrix.asset }}
         run: |
           make "${KATA_ASSET}-tarball"

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -59,6 +59,10 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
+      - name: Install ORAS
+        run: |
+          ./tests/install_oras.sh
+
       - name: Build ${{ matrix.asset }}
         run: |
           make "${KATA_ASSET}-tarball"

--- a/tests/install_oras.sh
+++ b/tests/install_oras.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script_name="$(basename "${BASH_SOURCE[0]}")"
+
+source "${script_dir}/common.bash"
+
+install_dest="/usr/local/bin"
+
+function get_installed_oras_version() {
+	oras version | grep Version | sed -e s/Version:// | tr -d [:blank:]
+}
+
+ensure_yq
+
+oras_required_version=$(get_from_kata_deps "externals.oras.version")
+if command -v oras; then
+	if [[ "${oras_required_version}" == "v$(get_installed_oras_version)" ]]; then
+		info "ORAS is already installed in the system"
+		exit 0
+	fi
+
+	info "Proceeding to cleanup the previous installed version of ORAS, and install the version specified in the versions.yaml file"
+	oras_system_path=$(which oras)
+	sudo rm -f ${oras_system_path}
+fi
+
+goarch=$("${repo_root_dir}/tests/kata-arch.sh" --golang)
+oras_tarball="oras_${oras_required_version#v}_linux_${goarch}.tar.gz"
+oras_url=$(get_from_kata_deps "externals.oras.url")
+
+info "Downloading ORAS ${oras_required_version}"
+curl -OL ${oras_url}/releases/download/${oras_required_version}/${oras_tarball}
+
+info "Installing ORAS to ${install_dest}"
+sudo mkdir -p "${install_dest}"
+sudo tar -C "${install_dest}" -xzf "${oras_tarball}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -300,6 +300,12 @@ externals:
       # yamllint disable-line rule:line-length
       binary: "https://github.com/open-policy-agent/opa/releases/download/v0.55.0/opa_linux_amd64_static"
 
+  oras:
+    # yamllint disable-line rule:line-length
+    description: "Tools and libraries to enable leveraging OCI registries for arbitrary artifacts"
+    url: "https://github.com/oras-project/oras"
+    version: "v1.1.0"
+
   ovmf:
     description: "Firmware, implementation of UEFI for virtual machines."
     url: "https://github.com/tianocore/edk2"


### PR DESCRIPTION
ORAS (OCI Registry As Storage) will be used to cache the artefacts we build, in a way to reduce the usage of jenkins and lower the costs on Azure, as this can be done from the GHA, using the free machines.

For now the only thing we're doing is installing ORAS whenever it's needed, mostly targetting the baremetal machines (s390x and arm64), but also doing the same for x86_64 for the sake of consistency.

Fixes: #7834 -- with the caveat that this is only the first part of the
                of this work.