### PR TITLE
osbuilder: Update api-server-rest

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=e9944577d1f61060c51d48890359a5467d519a29#e9944577d1f61060c51d48890359a5467d519a29"
+source = "git+https://github.com/confidential-containers/guest-components?rev=b01062b8a9eef0a5e7cc83eeb36f818991826fb4#b01062b8a9eef0a5e7cc83eeb36f818991826fb4"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2920,7 +2920,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=e9944577d1f61060c51d48890359a5467d519a29#e9944577d1f61060c51d48890359a5467d519a29"
+source = "git+https://github.com/confidential-containers/guest-components?rev=b01062b8a9eef0a5e7cc83eeb36f818991826fb4#b01062b8a9eef0a5e7cc83eeb36f818991826fb4"
 dependencies = [
  "aes 0.8.3",
  "anyhow",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -74,8 +74,9 @@ clap = { version = "3.0.1", features = ["derive"] }
 openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
-image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "e9944577d1f61060c51d48890359a5467d519a29", default-features = false, features = [
-    "kata-cc-native-tls", "verity",
+image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "b01062b8a9eef0a5e7cc83eeb36f818991826fb4", default-features = false, features = [
+    "kata-cc-native-tls",
+    "verity",
 ] }
 
 [patch.crates-io]

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -709,8 +709,8 @@ EOF
 		popd
 
 		pushd guest-components/api-server-rest
-		cargo build --release --target-dir ./target
-		install -D -m0755 ./target/release/api-server-rest ${ROOTFS_DIR}/usr/local/bin/
+		make
+		make install DESTDIR="${ROOTFS_DIR}/usr/local/bin/"
 		popd
 	fi
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -200,7 +200,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/guest-components/"
-    version: "29086ca22583f0dcfa6548866e9bf2a5e07881e9"
+    version: "b01062b8a9eef0a5e7cc83eeb36f818991826fb4"
 
   cni-plugins:
     description: "CNI network plugins"


### PR DESCRIPTION
- Switch api-server-rest to use the Makefile rather than directly calling cargo for multi-platform support and decoupling

Fixes: #7947