### PR TITLE
ci: Reduce the size of the AKS VMs

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -43,7 +43,7 @@ function create_cluster() {
     az aks create \
         -g "${AZ_RG}" \
         -n "$(_print_cluster_name ${test_type})" \
-        -s "Standard_D4s_v5" \
+        -s "Standard_D2s_v5" \
         --node-count 1 \
         --generate-ssh-keys \
         $([ "${KATA_HOST_OS}" = "cbl-mariner" ] && echo "--os-sku AzureLinux --workload-runtime KataMshvVmIsolation")

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -40,18 +40,15 @@ else
 		"k8s-liveness-probes.bats" \
 		"k8s-memory.bats" \
 		"k8s-nested-configmap-secret.bats" \
-		"k8s-number-cpus.bats" \
 		"k8s-oom.bats" \
 		"k8s-optional-empty-configmap.bats" \
 		"k8s-optional-empty-secret.bats" \
-		"k8s-parallel.bats" \
 		"k8s-pid-ns.bats" \
 		"k8s-pod-quota.bats" \
 		"k8s-port-forward.bats" \
 		"k8s-projected-volume.bats" \
 		"k8s-qos-pods.bats" \
 		"k8s-replication.bats" \
-		"k8s-scale-nginx.bats" \
 		"k8s-seccomp.bats" \
 		"k8s-sysctls.bats" \
 		"k8s-security-context.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/inotify-configmap-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/inotify-configmap-pod.yaml
@@ -16,10 +16,8 @@ spec:
     args: ["-c", "inotifywait --timeout 120 -r /config/ && [[ -L /config/config.toml ]] && echo success" ]
     resources:
       requests:
-        cpu: 1
         memory: 50Mi
       limits:
-        cpu: 1
         memory: 1024Mi
     volumeMounts:
       - name: config


### PR DESCRIPTION
We do **not** need a very powerful machine for our tests, as we're not building anything there.

The instance we switched to (Standard_D2s_v5) still has nested virt available, as shown here[0], but has half of the amount of vCPUs / Memory, which should be fine only for running the tests, costing us basically half of the price[1].

[0]:
https://learn.microsoft.com/en-us/azure/virtual-machines/dv5-dsv5-series [1]:
https://azure.microsoft.com/en-us/pricing/details/virtual-machines/linux/#pricing

Fixes: #7955