### PR TITLE
ci: Run some of the GARM tests in smaller instances

### DIFF
--- a/.github/workflows/run-cri-containerd-tests.yaml
+++ b/.github/workflows/run-cri-containerd-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         containerd_version: ['lts', 'active']
         vmm: ['clh', 'qemu']
-    runs-on: garm-ubuntu-2204
+    runs-on: garm-ubuntu-2204-smaller
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/run-docker-tests-on-garm.yaml
+++ b/.github/workflows/run-docker-tests-on-garm.yaml
@@ -24,7 +24,7 @@ jobs:
         vmm:
           - clh
           - qemu
-    runs-on: garm-ubuntu-2304
+    runs-on: garm-ubuntu-2304-smaller
     env:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:

--- a/.github/workflows/run-k8s-tests-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-on-garm.yaml
@@ -35,7 +35,7 @@ jobs:
           - devmapper
         k8s:
           - k3s
-    runs-on: garm-ubuntu-2004
+    runs-on: garm-ubuntu-2004-smaller
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}

--- a/.github/workflows/run-nerdctl-tests-on-garm.yaml
+++ b/.github/workflows/run-nerdctl-tests-on-garm.yaml
@@ -25,7 +25,7 @@ jobs:
           - clh
           - dragonball
           - qemu
-    runs-on: garm-ubuntu-2304
+    runs-on: garm-ubuntu-2304-smaller
     env:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:

--- a/.github/workflows/run-nydus-tests.yaml
+++ b/.github/workflows/run-nydus-tests.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         containerd_version: ['lts', 'active']
         vmm: ['clh', 'qemu', 'dragonball']
-    runs-on: garm-ubuntu-2204
+    runs-on: garm-ubuntu-2204-smaller
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}


### PR DESCRIPTION
With the idea of reducing the costs, let's make sure we run the following jobs in smaller instances:
* docker
* nerdctl
* cri-containerd
* nydus
* k8s - devmapper