### PR TITLE
tests/vfio: Extend test to cover cold-plug

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -200,6 +200,12 @@ block_device_driver = "virtio-blk"
 # The default setting is  "no-port"
 #hot_plug_vfio = "root-port"
 
+# In a confidential compute environment hot-plugging can compromise
+# security.
+# Enable cold-plugging of VFIO devices to a root-port.
+# The default setting is  "no-port", which means disabled.
+#cold_plug_vfio = "root-port"
+
 # Path to OCI hook binaries in the *guest rootfs*.
 # This does not affect host-side hooks which must instead be added to
 # the OCI spec passed to the runtime.

--- a/tests/functional/vfio/vfio_fedora_vm_wrapper.sh
+++ b/tests/functional/vfio/vfio_fedora_vm_wrapper.sh
@@ -182,6 +182,10 @@ ${environment}
     kata_tarball_dir="kata-artifacts"
     install_kata
 
+    if [ "\${KATA_HYPERVISOR}" = "clh" ]; then
+        export VFIO_CHECK_NUM_DEVICES=1
+        export VFIO_PORT=root-port
+    fi
     sudo /workspace/tests/functional/vfio/run.sh -s false -p \${KATA_HYPERVISOR} -m q35 -i image
     sudo /workspace/tests/functional/vfio/run.sh -s true -p \${KATA_HYPERVISOR} -m q35 -i image
 

--- a/tests/functional/vfio/vfio_fedora_vm_wrapper.sh
+++ b/tests/functional/vfio/vfio_fedora_vm_wrapper.sh
@@ -177,7 +177,6 @@ ${environment}
     cri_containerd=\$(get_from_kata_deps "externals.containerd.lts")
     cri_tools=\$(get_from_kata_deps "externals.critools.latest")
     install_cri_containerd \${cri_containerd}
-    install_cri_tools \${cri_tools}
 
     kata_tarball_dir="kata-artifacts"
     install_kata


### PR DESCRIPTION
This is a port of:
- https://github.com/kata-containers/tests/pull/5729

It allows testing cold-plug-vfio and makes the test more parametrized which makes it easier to test GPUs.