### PR TITLE
cc|osbuilder: Correct a typo in the initrd-image

### DIFF
--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -45,7 +45,7 @@ build_initrd() {
 		module_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/kernel-sev/builddir/kata-linux-${kernel_version}-${config_version}/lib/modules/${kernel_version}"
 		sudo -E PATH="$PATH" make rootfs AGENT_INIT=yes USE_DOCKER=1 ROOTFS_BUILD_DEST="${builddir}/initrd-image" KERNEL_MODULES_DIR="${module_dir}"
 	else
-		sudo -E PATH="$PATH" make rootfs AGENT_INIT=yes USE_DOCKER=1 ROOTFS_BUILD_DEST="${builddir}/intrd-image"
+		sudo -E PATH="$PATH" make rootfs AGENT_INIT=yes USE_DOCKER=1 ROOTFS_BUILD_DEST="${builddir}/initrd-image"
 	fi
 
 	if [ -n "${INCLUDE_ROOTFS:-}" ]; then


### PR DESCRIPTION
This PR is to prevent rootfs.sh from running twice for a target `make cc-rootfs-initrd` by fixing the typo `initrd-image`.

Fixes: #7980

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>