### PR TITLE
metrics: Enable parallel bandwidth iperf limit

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -127,6 +127,19 @@ maxpercent = 20.0
 [[metric]]
 name = "network-iperf3"
 type = "json"
+description = "measure container parallel bandwidth using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3\".Results | .[] | .parallel.Result"
+checktype = "mean"
+midval = 61176889941.0
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "network-iperf3"
+type = "json"
 description = "iperf"
 # Min and Max values to set a 'range' that
 # the median of the CSV Results data must fall

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -133,7 +133,7 @@ description = "measure container parallel bandwidth using iperf3"
 # within (inclusive)
 checkvar = ".\"network-iperf3\".Results | .[] | .parallel.Result"
 checktype = "mean"
-midval = 61176889941.0
+midval = 47734838389.0
 minpercent = 20.0
 maxpercent = 20.0
 

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -120,7 +120,20 @@ description = "measure container bandwidth using iperf3"
 # within (inclusive)
 checkvar = ".\"network-iperf3\".Results | .[] | .bandwidth.Result"
 checktype = "mean"
-midval = 52644229340.91
+midval = 55344417086.81
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "network-iperf3"
+type = "json"
+description = "measure container parallel bandwidth using iperf3"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"network-iperf3\".Results | .[] | .parallel.Result"
+checktype = "mean"
+midval = 52644229340.0
 minpercent = 20.0
 maxpercent = 20.0
 


### PR DESCRIPTION
This PR enables the parallel bandwidth iperf limit for kata metrics.

Fixes #7989