### PR TITLE
versions: Bump virtiofsd to v1.8.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -329,14 +329,14 @@ externals:
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"
     url: "https://gitlab.com/virtio-fs/virtiofsd"
-    version: "v1.6.1"
-    toolchain: "1.66.0"
+    version: "v1.8.0"
+    toolchain: "1.72.0"
     meta:
-      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.7.0,
-      # this is the link labelled virtiofsd-v1.7.0.zip
+      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.8.0,
+      # this is the link labelled virtiofsd-v1.8.0.zip
       #
       # yamllint disable-line rule:line-length
-      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/dc56ecbf86ce1226bdc31f946cfded75/virtiofsd-v1.7.0.zip"
+      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/9ec473efd0203219d016e66aac4190aa/virtiofsd-v1.8.0.zip"
 
 languages:
   description: |


### PR DESCRIPTION
https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.8.0 was released two weeks ago. We have fully tested and are using this version.

Fixes: #7960

Signed-off-by: Simon Kaegi <simon.kaegi@gmail.com>