### PR TITLE
ci: kata-deploy: Fix runner name

### DIFF
--- a/.github/workflows/run-kata-deploy-tests-on-garm.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-garm.yaml
@@ -34,7 +34,7 @@ jobs:
           - k0s
           - k3s
           - rke2
-    runs-on: garm-ubuntu-2004-small
+    runs-on: garm-ubuntu-2004-smaller
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}


### PR DESCRIPTION
It should be garm-ubuntu-2004-smaller instead of garm-ubuntu-2004-small.

Fixes: #7890