### PR TITLE
CC | osbuild: Reduce guest components binary size with strip

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -642,6 +642,7 @@ EOF
 		make clean
 		make LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP} SEALED_SECRET=${SEALED_SECRET}
 		make install DESTDIR="${ROOTFS_DIR}" LIBC=${LIBC} INIT=${AGENT_INIT}
+		strip ${ROOTFS_DIR}/usr/bin/kata-agent
 		if [ "${SECCOMP}" == "yes" ]; then
 			rm -rf "${libseccomp_install_dir}" "${gperf_install_dir}"
 		fi
@@ -701,16 +702,19 @@ EOF
 		( [ "${AA_KBC}" == "eaa_kbc" ] || [ "${AA_KBC}" == "cc_kbc_tdx" ] ) && [ "${ARCH}" == "x86_64" ] && LIBC="gnu"
 		make KBC=${AA_KBC} ttrpc=true
 		make install DESTDIR="${ROOTFS_DIR}/usr/local/bin/"
+		strip ${ROOTFS_DIR}/usr/local/bin/attestation-agent
 		popd
 
 		pushd guest-components/confidential-data-hub
 		make RESOURCE_PROVIDER=${CDH_RESOURCE_PROVIDER}
 		make install DESTDIR="${ROOTFS_DIR}/usr/local/bin/"
+		strip ${ROOTFS_DIR}/usr/local/bin/confidential-data-hub
 		popd
 
 		pushd guest-components/api-server-rest
 		make
 		make install DESTDIR="${ROOTFS_DIR}/usr/local/bin/"
+		strip ${ROOTFS_DIR}/usr/local/bin/api-server-rest
 		popd
 	fi
 


### PR DESCRIPTION
Guest rootfs will aligned to 128M, we may exceed the rootfs with several megabytes but the rootfs will add 128M.

Fixes: #8009