### PR TITLE
osbuild: Reduce guest components binary size with strip

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -619,6 +619,7 @@ EOF
 		make clean
 		make LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP} AGENT_POLICY=${AGENT_POLICY}
 		make install DESTDIR="${ROOTFS_DIR}" LIBC=${LIBC} INIT=${AGENT_INIT}
+		strip ${ROOTFS_DIR}/usr/bin/kata-agent
 		if [ "${SECCOMP}" == "yes" ]; then
 			rm -rf "${libseccomp_install_dir}" "${gperf_install_dir}"
 		fi
@@ -663,6 +664,7 @@ EOF
 			local opa_bin="${ROOTFS_DIR}${opa_bin_dir}/opa"
 			info "Installing OPA binary to ${opa_bin}"
 			install -D -o root -g root -m 0755 opa -T "${opa_bin}"
+			strip ${ROOTFS_DIR}${opa_bin_dir}/opa
 		else
 			info "OPA binary already exists in ${opa_bin_dir}"
 		fi


### PR DESCRIPTION
opa_linux_amd64_static 38M => 27M
kata-agent 30M => 23M

ls -alh opa_linux_amd64_static
-rw-rw-r-- 1 arron arron 38M Jul 28 01:59 opa_linux_amd64_static ➜ kata-containers git:(main) ✗ strip opa_linux_amd64_static ➜ kata-containers git:(main) ✗ ls -alh opa_linux_amd64_static -rw-rw-r-- 1 arron arron 27M Sep 20 16:12 opa_linux_amd64_static

ls -alh ./usr/bin/kata-agent
-rwxr-xr-x. 1 root root 30M Jul 30 23:41 ./usr/bin/kata-agent ls -alh ./usr/bin/kata-agent
-rwxr-xr-x. 1 root root 23M Sep 20 16:13 ./usr/bin/kata-agent

Fixes: #8011