### PR TITLE
ci: Actually enable the CRI-O tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -148,6 +148,18 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
     secrets: inherit
 
+  run-k8s-tests-with-crio-on-garm:
+    needs: publish-kata-deploy-payload-amd64
+    uses: ./.github/workflows/run-k8s-tests-with-crio-on-garm.yaml
+    with:
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-amd64
+      commit-hash: ${{ inputs.commit-hash }}
+      pr-number: ${{ inputs.pr-number }}
+      target-branch: ${{ inputs.target-branch }}
+    secrets: inherit
+
   run-k8s-tests-on-sev:
     needs: [publish-kata-deploy-payload-amd64, build-and-publish-tee-confidential-unencrypted-image]
     uses: ./.github/workflows/run-k8s-tests-on-sev.yaml


### PR DESCRIPTION
The test has been added to the repo, but we have to also add it to the
list of jobs to be executed.

Fixes: #8005
