### PR TITLE
gha: Install hunspell for static checks

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -187,7 +187,7 @@ jobs:
           echo "/usr/local/go/bin" >> $GITHUB_PATH
       - name: Install system dependencies
         run: |
-          sudo apt-get -y install moreutils
+          sudo apt-get -y install moreutils hunspell
       - name: Run check
         run: |
           export PATH=${PATH}:${GOPATH}/bin


### PR DESCRIPTION
Seems like the static checks are failing due the missing of the hunspell package this PR fixes that.

Fixes #8019