### PR TITLE
ci: k8s: crio: Follow up patches to have CRI-O also working as part of our CI

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -225,6 +225,26 @@ function setup_crio() {
 	curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${os}/Release.key | sudo apt-key add -
 	sudo apt update
 	sudo apt install -y cri-o cri-o-runc
+
+	# We need to set the default capabilities to ensure our tests will pass
+	# See: https://github.com/kata-containers/kata-containers/issues/8034
+	sudo mkdir -p /etc/crio/crio.conf.d/
+	cat <<EOF | sudo tee /etc/crio/crio.conf.d/00-default-capabilities
+[crio.runtime]
+default_capabilities = [
+       "CHOWN",
+       "DAC_OVERRIDE",
+       "FSETID",
+       "FOWNER",
+       "SETGID",
+       "SETUID",
+       "SETPCAP",
+       "NET_BIND_SERVICE",
+       "KILL",
+       "SYS_CHROOT",
+]
+EOF
+
 	sudo systemctl enable --now crio
 }
 

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -224,7 +224,7 @@ function setup_crio() {
 	curl -L https://download.opensuse.org/repositories/devel:kubic:libcontainers:stable:cri-o:${crio_version}/${os}/Release.key | sudo apt-key add -
 	curl -L https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/stable/${os}/Release.key | sudo apt-key add -
 	sudo apt update
-	sudo apt install cri-o cri-o-runc
+	sudo apt install -y cri-o cri-o-runc
 	sudo systemctl enable --now crio
 }
 

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -44,7 +44,16 @@ exec_host() {
 	# `kubectl debug` always returns 0, so we hack it to return the right exit code.
 	command="$@"
 	command+='; echo -en \\n$?'
-	output="$(kubectl debug -qit "${node}" --image=alpine:latest -- chroot /host bash -c "${command}")"
+	# We're trailing the `\r` here due to: https://github.com/kata-containers/kata-containers/issues/8051
+	# tl;dr: When testing with CRI-O we're facing the foillowing error:
+	# ```
+	# (from function `exec_host' in file tests_common.sh, line 51,
+	# in test file k8s-file-volume.bats, line 25)
+	# `exec_host "echo "$file_body" > $tmp_file"' failed with status 127
+	# [bats-exec-test:38] INFO: k8s configured to use runtimeclass
+	# bash: line 1: $'\r': command not found
+	# ```
+	output="$(kubectl debug -qit "${node}" --image=alpine:latest -- chroot /host bash -c "${command}" | tr -d '\r')"
 	kubectl get pods -o name | grep node-debugger | xargs kubectl delete > /dev/null
 	exit_code="$(echo "${output}" | tail -1)"
 	echo "$(echo "${output}" | head -n -1)"

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -75,7 +75,9 @@ function get_container_runtime() {
                 die "invalid node name"
 	fi
 
-	if echo "$runtime" | grep -qE 'containerd.*-k3s'; then
+	if echo "$runtime" | grep -qE "cri-o"; then
+		echo "cri-o"
+	elif echo "$runtime" | grep -qE 'containerd.*-k3s'; then
 		if host_systemctl is-active --quiet rke2-agent; then
 			echo "rke2-agent"
 		elif host_systemctl is-active --quiet rke2-server; then


### PR DESCRIPTION
This is the last set of patches needed to get the CRI-O CI working as part of GHA.