### PR TITLE
ci: rootfs-image build-asset is failing

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -94,6 +94,8 @@ VIRTIOFSD_CONTAINER_BUILDER="${VIRTIOFSD_CONTAINER_BUILDER:-}"
 MEASURED_ROOTFS="${MEASURED_ROOTFS:-}"
 USE_CACHE="${USE_CACHE:-}"
 
+sudo chown -R ${USER}:${USER} ${HOME}/.docker
+
 docker run \
 	-v $HOME/.docker:/root/.docker \
 	-v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
Fixes: #8027

This PR and [PR 8030](https://github.com/kata-containers/kata-containers/pull/8030) are two different attempts to solve the current CI failure. Example failure [here](https://github.com/kata-containers/kata-containers/actions/runs/6257676526/job/16990382096).