### PR TITLE
runtime: fix reading cgroup stats of sandboxes

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1742,12 +1742,14 @@ func (s *Sandbox) Stats(ctx context.Context) (SandboxStats, error) {
 
 	// TODO Do we want to aggregate the overhead cgroup stats to the sandbox ones?
 	switch mt := metrics.(type) {
-	case v1.Metrics:
+	case *v1.Metrics:
 		stats.CgroupStats.CPUStats.CPUUsage.TotalUsage = mt.CPU.Usage.Total
 		stats.CgroupStats.MemoryStats.Usage.Usage = mt.Memory.Usage.Usage
-	case v2.Metrics:
+	case *v2.Metrics:
 		stats.CgroupStats.CPUStats.CPUUsage.TotalUsage = mt.CPU.UsageUsec
 		stats.CgroupStats.MemoryStats.Usage.Usage = mt.Memory.Usage
+	default:
+		return SandboxStats{}, fmt.Errorf("unknown metrics type %T", mt)
 	}
 
 	tids, err := s.hypervisor.GetThreadIDs(ctx)


### PR DESCRIPTION
The cgroup stats come from `resourcecontrol` package in the form of pointers to structs. The sandbox `Stat()` method incorrectly was expecting structs. This caused the cpu and memory stats to always be 0, which in turn caused incorrect pod overhead metrics.

Fixes #8035