### PR TITLE
metrics: Enable latency test in gha run script

### DIFF
--- a/.github/workflows/run-metrics.yaml
+++ b/.github/workflows/run-metrics.yaml
@@ -79,6 +79,9 @@ jobs:
       - name: run iperf test
         run:  bash tests/metrics/gha-run.sh run-test-iperf
 
+      - name: run latency test
+        run:  bash tests/metrics/gha-run.sh run-test-latency
+
       - name: make metrics tarball ${{ matrix.vmm }}
         run: bash tests/metrics/gha-run.sh make-tarball-results
 

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -97,6 +97,12 @@ function run_test_iperf() {
 	check_metrics
 }
 
+function run_test_latency() {
+	info "Running Latency test using ${KATA_HYPERVISOR} hypervisor"
+
+	bash tests/metrics/network/latency_kubernetes/latency-network.sh
+}
+
 function main() {
 	action="${1:-}"
 	case "${action}" in
@@ -110,6 +116,7 @@ function main() {
 		run-test-tensorflow) run_test_tensorflow ;;
 		run-test-fio) run_test_fio ;;
 		run-test-iperf) run_test_iperf ;;
+		run-test-latency) run_test_latency ;;
 		*) >&2 die "Invalid argument" ;;
 	esac
 }


### PR DESCRIPTION
This PR enables the latency test for gha run script for kata metrics.

Fixes #8037