### PR TITLE
gha: Add pandoc as a dependency for static checks

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -187,7 +187,7 @@ jobs:
           echo "/usr/local/go/bin" >> $GITHUB_PATH
       - name: Install system dependencies
         run: |
-          sudo apt-get -y install moreutils hunspell
+          sudo apt-get -y install moreutils hunspell pandoc
       - name: Run check
         run: |
           export PATH=${PATH}:${GOPATH}/bin


### PR DESCRIPTION
To avoid the failure of not finding pandoc command this PR adds that package as a dependency for static checks.

Fixes #8041