### PR TITLE
local-build: Fix .docker ownership before build-payload

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -25,6 +25,8 @@ arch=$(uname -m)
 [ "$arch" = "x86_64" ] && arch="amd64"
 IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-${arch}"
 
+sudo chown -R $USER $HOME/.docker
+
 echo "Building the image"
 docker build --tag ${IMAGE_TAG} .
 


### PR DESCRIPTION
The permissions on .docker/buildx/activity/default are regularly broken by us passing docker.sock + $HOME/.docker to a container running as root and then using buildx inside. Fixup ownership before executing docker commands.

Fixes: #8027