### PR TITLE
CC | policy: fix setting the policy path from agent config

### DIFF
--- a/src/agent/src/image_rpc.rs
+++ b/src/agent/src/image_rpc.rs
@@ -53,7 +53,7 @@ impl ImageService {
 
         let mut image_client = ImageClient::default();
         if !AGENT_CONFIG.image_policy_file.is_empty() {
-            image_client.config.file_paths.sigstore_config = AGENT_CONFIG.image_policy_file.clone();
+            image_client.config.file_paths.policy_path = AGENT_CONFIG.image_policy_file.clone();
         }
         if !AGENT_CONFIG.simple_signing_sigstore_config.is_empty() {
             image_client.config.file_paths.sigstore_config =


### PR DESCRIPTION
Fix setting the image service policy path when there is a policy path in the agent config.

Fixes https://github.com/kata-containers/kata-containers/issues/8049

Signed-off-by: Matthew Arnold <mattarno@uk.ibm.com>