### PR TITLE
CC | runtime: merge metadata and annotation in imagepullvolume

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1589,7 +1589,11 @@ func handleImageGuestPullBlockVolume(c *Container, virtualVolumeInfo *types.Kata
 			}
 		}
 		virtualVolumeInfo.Source = image_ref
-		virtualVolumeInfo.ImagePull.Metadata = container_annotations
+
+		//merge virtualVolumeInfo.ImagePull.Metadata and container_annotations
+		for k, v := range container_annotations {
+			virtualVolumeInfo.ImagePull.Metadata[k] = v
+		}
 	}
 
 	no, err := json.Marshal(virtualVolumeInfo.ImagePull)


### PR DESCRIPTION
merge metadata and annotation in `imagepullvolume`.