### PR TITLE
metrics: Add latency value limits for kata CI

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -160,5 +160,5 @@ description = "iperf"
 checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
 midval = 0.044
-minpercent = 40.0
-maxpercent = 40.0
+minpercent = 50.0
+maxpercent = 50.0

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -99,6 +99,19 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
+name = "latency"
+type = "json"
+description = "measure container latency"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"latency\".Results | .[] | .latency.Result"
+checktype = "mean"
+midval = 0.75
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "measure container cpu utilization using iperf3"

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -99,6 +99,19 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
+name = "latency"
+type = "json"
+description = "measure container latency"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = ".\"latency\".Results | .[] | .latency.Result"
+checktype = "mean"
+midval = 0.70
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
 name = "network-iperf3"
 type = "json"
 description = "measure container cpu utilization using iperf3"

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -160,5 +160,5 @@ description = "iperf"
 checkvar = ".\"network-iperf3\".Results | .[] | .jitter.Result"
 checktype = "mean"
 midval = 0.041
-minpercent = 40.0
-maxpercent = 40.0
+minpercent = 50.0
+maxpercent = 50.0

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -93,14 +93,14 @@ function run_test_iperf() {
 	info "Running Iperf test using ${KATA_HYPERVISOR} hypervisor"
 
 	bash tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh -a
-
-	check_metrics
 }
 
 function run_test_latency() {
 	info "Running Latency test using ${KATA_HYPERVISOR} hypervisor"
 
 	bash tests/metrics/network/latency_kubernetes/latency-network.sh
+
+	check_metrics
 }
 
 function main() {


### PR DESCRIPTION
This PR adds latency value limits for kata CI.

Fixes #8067