### PR TITLE
kata-deploy: build & ship the rust components from src/tools/

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -27,9 +27,11 @@ jobs:
     strategy:
       matrix:
         asset:
+          - agent-ctl
           - cloud-hypervisor
           - cloud-hypervisor-glibc
           - firecracker
+          - kata-ctl
           - kernel
           - kernel-sev
           - kernel-dragonball-experimental
@@ -37,6 +39,7 @@ jobs:
           - kernel-nvidia-gpu
           - kernel-nvidia-gpu-snp
           - kernel-nvidia-gpu-tdx-experimental
+          - log-parser-rs
           - nydus
           - ovmf
           - ovmf-sev
@@ -48,8 +51,10 @@ jobs:
           - rootfs-initrd
           - rootfs-initrd-mariner
           - rootfs-initrd-sev
+          - runk
           - shim-v2
           - tdvf
+          - trace-forwarder
           - virtiofsd
         stage:
           - ${{ inputs.stage }}

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -52,6 +52,9 @@ serial-targets:
 %-tarball-build: $(MK_DIR)/dockerbuild/install_yq.sh
 	$(call BUILD,$*)
 
+agent-ctl-tarball:
+	${MAKE} $@-build
+
 cloud-hypervisor-tarball:
 	${MAKE} $@-build
 
@@ -59,6 +62,9 @@ cloud-hypervisor-glibc-tarball:
 	${MAKE} $@-build
 
 firecracker-tarball:
+	${MAKE} $@-build
+
+kata-ctl-tarball:
 	${MAKE} $@-build
 
 kernel-dragonball-experimental-tarball:
@@ -80,6 +86,9 @@ kernel-tdx-experimental-tarball:
 	${MAKE} $@-build
 
 kernel-sev-tarball:
+	${MAKE} $@-build
+
+log-parser-rs-tarball:
 	${MAKE} $@-build
 
 nydus-tarball:
@@ -115,10 +124,16 @@ rootfs-initrd-sev-tarball: kernel-sev-tarball
 rootfs-initrd-tarball:
 	${MAKE} $@-build
 
+runk-tarball:
+	${MAKE} $@-build
+
 shim-v2-tarball:
 	${MAKE} $@-build
 
 tdvf-tarball:
+	${MAKE} $@-build
+
+trace-forwarder-tarball:
 	${MAKE} $@-build
 
 virtiofsd-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -32,8 +32,8 @@ readonly qemu_experimental_builder="${static_build_dir}/qemu/build-static-qemu-e
 readonly shimv2_builder="${static_build_dir}/shim-v2/build.sh"
 readonly virtiofsd_builder="${static_build_dir}/virtiofsd/build.sh"
 readonly nydus_builder="${static_build_dir}/nydus/build.sh"
-
 readonly rootfs_builder="${repo_root_dir}/tools/packaging/guest-image/build_image.sh"
+readonly tools_builder="${static_build_dir}/tools/build.sh"
 
 ARCH=${ARCH:-$(uname -m)}
 MEASURED_ROOTFS=${MEASURED_ROOTFS:-no}
@@ -81,9 +81,11 @@ options:
 -s             	      : Silent mode (produce output in case of failure only)
 --build=<asset>       :
 	all
+	agent-ctl
 	cloud-hypervisor
 	cloud-hypervisor-glibc
 	firecracker
+	kata-ctl
 	kernel
 	kernel-dragonball-experimental
 	kernel-experimental
@@ -92,6 +94,7 @@ options:
 	kernel-nvidia-gpu-tdx-experimental
 	kernel-sev-tarball
 	kernel-tdx-experimental
+	log-parser-rs
 	nydus
 	ovmf
 	ovmf-sev
@@ -103,8 +106,10 @@ options:
 	rootfs-initrd
 	rootfs-initrd-mariner
 	rootfs-initrd-sev
+	runk
 	shim-v2
 	tdvf
+	trace-forwarder
 	virtiofsd
 EOF
 
@@ -620,6 +625,55 @@ install_ovmf_sev() {
 	install_ovmf "sev" "edk2-sev.tar.gz"
 }
 
+install_tools_helper() {
+	tool=${1}
+
+	latest_artefact="$(git log -1 --pretty=format:"%h" ${repo_root_dir}/src/tools/${tool})"
+	latest_builder_image="$(get_tools_image_name)"
+
+	install_cached_tarball_component \
+		"${tool}" \
+		"${latest_artefact}" \
+		"${latest_builder_image}" \
+		"${final_tarball_name}" \
+		"${final_tarball_path}" \
+		&& return 0
+
+
+	info "build static ${tool}"
+	${tools_builder} ${tool}
+
+	tool_binary=${tool}
+	[ ${tool} = "agent-ctl" ] && tool_binary="kata-agent-ctl"
+	[ ${tool} = "log-parser-rs" ] && tool_binary="log-parser"
+	[ ${tool} = "trace-forwarder" ] && tool_binary="kata-trace-forwarder"
+	binary=$(find ${repo_root_dir}/src/tools/${tool}/ -type f -name ${tool_binary})
+
+	info "Install static ${tool_binary}"
+	mkdir -p "${destdir}/opt/kata/bin/"
+	sudo install -D --owner root --group root --mode 0744 ${binary} "${destdir}/opt/kata/bin/${tool_binary}"
+}
+
+install_agent_ctl() {
+	install_tools_helper "agent-ctl"
+}
+
+install_kata_ctl() {
+	install_tools_helper "kata-ctl"
+}
+
+install_log_parser_rs() {
+	install_tools_helper "log-parser-rs"
+}
+
+install_runk() {
+	install_tools_helper "runk"
+}
+
+install_trace_forwarder() {
+	install_tools_helper "trace-forwarder"
+}
+
 get_kata_version() {
 	local v
 	v=$(cat "${version_file}")
@@ -641,31 +695,40 @@ handle_build() {
 
 	case "${build_target}" in
 	all)
+		install_agent_ctl
 		install_clh
 		install_firecracker
 		install_image
 		install_initrd
 		install_initrd_mariner
 		install_initrd_sev
+		install_kata_ctl
 		install_kernel
 		install_kernel_dragonball_experimental
 		install_kernel_tdx_experimental
+		install_log_parser_rs
 		install_nydus
 		install_ovmf
 		install_ovmf_sev
 		install_qemu
 		install_qemu_snp_experimental
 		install_qemu_tdx_experimental
+		install_runk
 		install_shimv2
 		install_tdvf
+		install_trace_forwarder
 		install_virtiofsd
 		;;
+
+	agent-ctl) install_agent_ctl ;;
 
 	cloud-hypervisor) install_clh ;;
 
 	cloud-hypervisor-glibc) install_clh_glibc ;;
 
 	firecracker) install_firecracker ;;
+
+	kata-ctl) install_kata_ctl ;;
 
 	kernel) install_kernel ;;
 
@@ -680,6 +743,8 @@ handle_build() {
 	kernel-tdx-experimental) install_kernel_tdx_experimental ;;
 
 	kernel-sev) install_kernel_sev ;;
+
+	log-parser-rs) install_log_parser_rs ;;
 
 	nydus) install_nydus ;;
 
@@ -702,10 +767,14 @@ handle_build() {
 	rootfs-initrd-mariner) install_initrd_mariner ;;
 
 	rootfs-initrd-sev) install_initrd_sev ;;
+
+	runk) install_runk ;;
 	
 	shim-v2) install_shimv2 ;;
 
 	tdvf) install_tdvf ;;
+
+	trace-forwarder) install_trace_forwarder ;;
 
 	virtiofsd) install_virtiofsd ;;
 
@@ -758,16 +827,21 @@ main() {
 	local build_targets
 	local silent
 	build_targets=(
+		agent-ctl
 		cloud-hypervisor
 		firecracker
+		kata-ctl
 		kernel
 		kernel-experimental
+		log-parser-rs
 		nydus
 		qemu
 		rootfs-image
 		rootfs-initrd
 		rootfs-initrd-mariner
+		runk
 		shim-v2
+		trace-forwarder
 		virtiofsd
 	)
 	silent=false

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -123,7 +123,7 @@ get_last_modification() {
 	dirty=""
 	[ $(git status --porcelain | grep "${file#${repo_root_dir}/}" | wc -l) -gt 0 ] && dirty="-dirty"
 
-	echo "$(git log -1 --pretty=format:"%H" ${file})${dirty}"
+	echo "$(git log -1 --pretty=format:"%h" ${file})${dirty}"
 	popd &> /dev/null
 }
 

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -218,3 +218,11 @@ get_virtiofsd_image_name() {
 	virtiofsd_script_dir="${repo_root_dir}/tools/packaging/static-build/virtiofsd"
 	echo "${BUILDER_REGISTRY}:virtiofsd-$(get_from_kata_deps "externals.virtiofsd.toolchain")-${libc}-$(get_last_modification ${virtiofsd_script_dir})-$(uname -m)"
 }
+
+get_tools_image_name() {
+	tools_dir="${repo_root_dir}/src/tools"
+	libs_dir="${repo_root_dir}/src/libs"
+	agent_dir="${repo_root_dir}/src/agent"
+
+	echo "${BUILDER_REGISTRY}:tools-$(get_last_modification ${tools_dir})-$(get_last_modification ${libs_dir})-$(get_last_modification ${agent_dir})"
+}

--- a/tools/packaging/static-build/tools/Dockerfile
+++ b/tools/packaging/static-build/tools/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright (c) 2023 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM alpine:3.18
+ARG GO_TOOLCHAIN
+ARG RUST_TOOLCHAIN
+
+SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+RUN apk --no-cache add \
+        bash \
+        curl \
+        gcc \
+        git \
+        libcap-ng-static \
+        libseccomp-static \
+        make \
+        musl-dev \
+        protoc && \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}

--- a/tools/packaging/static-build/tools/build-static-tools.sh
+++ b/tools/packaging/static-build/tools/build-static-tools.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+init_env() {
+	source "$HOME/.cargo/env"
+
+	export LIBC=musl
+	export LIBSECCOMP_LINK_TYPE=static
+	export LIBSECCOMP_LIB_PATH=/usr/lib
+
+	extra_rust_flags=" -C link-self-contained=yes"
+}
+
+build_tool_from_source() {
+	set -x
+	tool=${1}
+
+	echo "build ${tool} from source"
+	init_env
+
+	cd src/tools/${tool}
+	make
+}
+
+build_tool_from_source $@

--- a/tools/packaging/static-build/tools/build.sh
+++ b/tools/packaging/static-build/tools/build.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023 Intel
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly tools_builder="${script_dir}/build-static-tools.sh"
+
+source "${script_dir}/../../scripts/lib.sh"
+
+tool="${1}"
+
+container_image="${VIRTIOFSD_CONTAINER_BUILDER:-$(get_tools_image_name)}"
+[ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
+
+sudo docker pull ${container_image} || \
+	(sudo docker $BUILDX build $PLATFORM \
+	    	--build-arg RUST_TOOLCHAIN="$(get_from_kata_deps "languages.rust.meta.newest-version")" \
+		-t "${container_image}" "${script_dir}" && \
+	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"
+	 push_to_registry "${container_image}")
+
+sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	-w "${repo_root_dir}" \
+	"${container_image}" \
+	bash -c "${tools_builder} ${tool}"


### PR DESCRIPTION
We need those in order to start easily testing "tracing" and "runk".

This is focusing on "x86_64", and improvements for other arches are very much welcome **as follow-up PRs**.

Last but not least, to test this, run:
* make agent-ctl-tarball
* make kata-ctl-tarball
* make log-parser-rs-tarball
* make runk-tarball
* make trace-forwarder-tarball

Please, test it locally before approving!