### PR TITLE
runtime.docs: Fixing s390 vfio-ap url

### DIFF
--- a/src/runtime/virtcontainers/README.md
+++ b/src/runtime/virtcontainers/README.md
@@ -24,7 +24,7 @@ or the [Kubernetes CRI][cri]) to the `virtcontainers` API.
 # Out of scope
 
 Implementing a container runtime is out of scope for this project. Any
-tools or executables in this repository are only provided for demonstration or
+tools or `executables` in this repository are only provided for demonstration or
 testing purposes.
 
 ## virtcontainers and Kubernetes CRI
@@ -232,7 +232,7 @@ is also supported in Kata. Pass-through happens separated by adapter and
 domain, i.e. a passable VFIO device has one or multiple adapter-domain
 combinations.
 
-1. You must follow the [kernel documentation for preparing VFIO-AP passthrough](https://www.kernel.org/doc/html/latest/s390/vfio-ap.html).
+1. You must follow the [kernel documentation for preparing VFIO-AP passthrough](https://www.kernel.org/doc/Documentation/s390/vfio-ap.txt).
 In short, your host kernel should have the following enabled or available as
 module (in case of modules, load the modules accordingly, e.g. through
 `modprobe`). If one is missing, you will have to update your kernel


### PR DESCRIPTION
make static-checks are failing due to this error.

Fixes #8078