### PR TITLE
Add support for cloud hypervisor logging

### DIFF
--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1385,6 +1385,7 @@ dependencies = [
  "shim-interface",
  "slog",
  "slog-scope",
+ "termios",
  "tests_utils",
  "thiserror",
  "tokio",
@@ -3314,6 +3315,15 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -22,6 +22,7 @@ serde = { version = "1.0.138", features = ["derive"] }
 serde_json = ">=1.0.9"
 slog = "2.5.2"
 slog-scope = "4.4.0"
+termios = "0.3.3"
 thiserror = "1.0"
 tokio = { version = "1.28.1", features = ["sync", "fs"] }
 vmm-sys-util = "0.11.0"

--- a/src/runtime-rs/crates/hypervisor/src/ch/console_watcher.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/console_watcher.rs
@@ -1,0 +1,83 @@
+use std::path::Path;
+use std::fs::File;
+
+
+use std::boxed::Box;
+
+use anyhow::Result;
+use nix::fcntl::{OFlag, open};
+use nix::pty::{grantpt, posix_openpt, ptsname, unlockpt};
+use nix::sys::stat::Mode;
+use termios::Termios;
+
+fn new_pty() -> Result<(Termios, String)> {
+    // Open a new PTY master
+    let master_fd = posix_openpt(OFlag::O_RDWR)?;
+
+    // Allow a slave to be generated for it
+    grantpt(&master_fd)?;
+    unlockpt(&master_fd)?;
+
+    // Get the name of the slave
+    let slave_name = unsafe { ptsname(&master_fd) }?;
+
+    // Get the termios as the console to be used by cloud hypervisor
+    let termios = Termios::from_fd(fd)?;
+
+    // The termios will be used by ch, and the slave is the source of log
+    Ok((termios, slave_name))
+}
+
+fn get_vm_console() -> Result<String> {
+    // Log this behavior
+    // TODO
+
+    let (master, slave) = new_pty()?;
+
+    // Set the ch's console to master
+    // TODO
+
+    Ok(slave)
+}
+
+pub(crate) struct ConsoleWatcher {
+    console_url: String,
+    pty_console: Option<File>,
+}
+
+impl ConsoleWatcher {
+    fn new_console_watcher() -> Result<ConsoleWatcher> {
+        let console_url = get_vm_console()?;
+        Ok(ConsoleWatcher {
+            console_url,
+            pty_console: None,
+        })
+    }
+
+    fn console_watched(&self) -> bool {
+        self.pty_console.is_some()
+    }
+
+    fn start(&mut self) -> Result<()> {
+        // Log this behavior
+        // TODO
+        if console_watched() {
+            // Return an error
+        }
+
+        let f = File::open(self.console_url)?;
+        self.pty_console = Some(f);
+
+        // Read the content from pty_console
+        // TODO
+
+        Ok(())
+    }
+
+    fn stop(&mut self) {
+        if self.pty_console.is_some() {
+            self.pty_console.close();
+            self.pty_console = None;
+        }
+    }
+}

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -25,6 +25,7 @@ macro_rules! sl {
 mod inner;
 mod inner_device;
 mod inner_hypervisor;
+mod console_watcher;
 mod utils;
 
 use inner::CloudHypervisorInner;


### PR DESCRIPTION
Add `ConsoleWatcher`, a re-implementation did in the Go version of `kata runtime`, to support logging of cloud hypervisor.