### PR TITLE
doc: Update crictl pod-config

### DIFF
--- a/docs/how-to/how-to-setup-swap-devices-in-guest-kernel.md
+++ b/docs/how-to/how-to-setup-swap-devices-in-guest-kernel.md
@@ -27,6 +27,8 @@ $ image="quay.io/prometheus/busybox:latest"
 $ cat << EOF > "${pod_yaml}"
 metadata:
   name: busybox-sandbox1
+  uid: $(uuidgen)
+  namespace: default
 EOF
 $ cat << EOF > "${container_yaml}"
 metadata:

--- a/docs/how-to/how-to-use-virtio-fs-nydus-with-kata.md
+++ b/docs/how-to/how-to-use-virtio-fs-nydus-with-kata.md
@@ -32,6 +32,7 @@ The `nydus-sandbox.yaml` looks like below:
 metadata:
   attempt: 1
   name: nydus-sandbox
+  uid: nydus-uid
   namespace: default
 log_directory: /tmp
 linux:

--- a/docs/how-to/how-to-use-virtio-mem-with-kata.md
+++ b/docs/how-to/how-to-use-virtio-mem-with-kata.md
@@ -29,7 +29,7 @@ Then you can build and install the guest kernel image as shown [here](../../tool
 
 ## Run a Kata Container utilizing `virtio-mem`
 
-Use following command to enable memory overcommitment of a Linux kernel.  Because QEMU `virtio-mem` device need to allocate a lot of memory.
+Use following command to enable memory over-commitment of a Linux kernel.  Because QEMU `virtio-mem` device need to allocate a lot of memory.
 ```
 $ echo 1 | sudo tee /proc/sys/vm/overcommit_memory
 ```

--- a/docs/how-to/how-to-use-virtio-mem-with-kata.md
+++ b/docs/how-to/how-to-use-virtio-mem-with-kata.md
@@ -42,6 +42,8 @@ $ image="quay.io/prometheus/busybox:latest"
 $ cat << EOF > "${pod_yaml}"
 metadata:
   name: busybox-sandbox1
+  uid: $(uuidgen)
+  namespace: default
 EOF
 $ cat << EOF > "${container_yaml}"
 metadata:


### PR DESCRIPTION
- Ensure that our documented crictl pod config file contents have uid  and namespace fields for compatibility with crictl 1.24+

This avoids a user potentially hitting the error:
```
getting sandbox status of pod "d3af2db414ce8": metadata.Name,
metadata.Namespace or metadata.Uid is not in metadata
"&PodSandboxMetadata{Name:nydus-sandbox,Uid:,Namespace:default,Attempt:1,}"

getting sandbox status of pod "-A": rpc error: code = NotFound desc = an
error occurred when try to find sandbox: not found
```

Fixes: #8092
Signed-off-by: stevenhorsman <steven@uk.ibm.com>
(cherry picked from commit 8f8c2215)