### PR TITLE
Configure kernel to allow native overlay diff

### DIFF
--- a/tools/packaging/kernel/configs/fragments/common/fs.conf
+++ b/tools/packaging/kernel/configs/fragments/common/fs.conf
@@ -52,8 +52,6 @@ CONFIG_AIO=y
 # Docker in Docker support requires overlay
 CONFIG_OVERLAY_FS=y
 CONFIG_OVERLAY_FS_INDEX=y
-CONFIG_OVERLAY_FS_REDIRECT_DIR=y
-CONFIG_OVERLAY_FS_METACOPY=y
 CONFIG_OVERLAY_FS_XINO_AUTO=y
 
 # virtio-fs driver support:


### PR DESCRIPTION
For native overlay diff to work both `CONFIG_OVERLAY_FS_REDIRECT_DIR` and `CONFIG_OVERLAY_FS_METACOPY` must not be configured. This is the typical default in Host OSes used to run K8s and noticeably improves the performance of docker build.

Fixes: #8094

Signed-off-by: Simon Kaegi <simon.kaegi@gmail.com>