### PR TITLE
versions: migrate out of k8s.gcr.io

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -11,7 +11,7 @@
 
 # Variables used by the kubernetes tests
 export docker_images_nginx_version="1.15-alpine"
-export container_images_agnhost_name="k8s.gcr.io/e2e-test-images/agnhost"
+export container_images_agnhost_name="registry.k8s.io/e2e-test-images/agnhost"
 export container_images_agnhost_version="2.21"
 
 # Timeout options, mainly for use with waitForProcess(). Use them unless the

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-clh.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-clh.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       runtimeClassName: kata-clh
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-dragonball.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-dragonball.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       runtimeClassName: kata-dragonball
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-fc.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-fc.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       runtimeClassName: kata-fc
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-qemu.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-qemu.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       runtimeClassName: kata-qemu
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:

--- a/tools/packaging/kata-deploy/examples/test-deploy-runc.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-runc.yaml
@@ -15,7 +15,7 @@ spec:
         run: php-apache-runc
     spec:
       containers:
-      - image: k8s.gcr.io/hpa-example
+      - image: registry.k8s.io/hpa-example
         imagePullPolicy: Always
         name: php-apache
         ports:


### PR DESCRIPTION
The k8s.gcr.io is deprecated for a while now and has been redirected to registry.k8s.io. However on some bare-metal machines in our testing pools that redirection is not working, so let's just replace the registries.

Fixes #6461
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>
(cherry picked from commit b2c3bca558c38deff2117d5909d9071c23c05590)