### PR TITLE
kata-deploy: Fix merge-builds target

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -127,10 +127,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: kata-artifacts-amd64${{ inputs.tarball-suffix }}
-          path: kata-artifacts
+          path: build
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+          make merge-builds
       - name: store-artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -107,10 +107,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: kata-artifacts-arm64${{ inputs.tarball-suffix }}
-          path: kata-artifacts
+          path: build
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+          make merge-builds
       - name: store-artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -104,10 +104,10 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: kata-artifacts-s390x${{ inputs.tarball-suffix }}
-          path: kata-artifacts
+          path: build
       - name: merge-artifacts
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+          make merge-builds
       - name: store-artifacts
         uses: actions/upload-artifact@v3
         with:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -14,7 +14,7 @@ kata_build_dir=${1:-build}
 kata_versions_yaml_file=${2:-""}
 
 tar_path="${PWD}/kata-static.tar.xz"
-kata_versions_yaml_file_path="${PWD}/${kata_versions_yaml_file}"
+kata_versions_yaml_file_path="${kata_versions_yaml_file}"
 
 pushd "${kata_build_dir}"
 tarball_content_dir="${PWD}/kata-tarball-content"


### PR DESCRIPTION
`make merge-builds` has looked for `versions.yaml` at the wrong location as the called `kata-deploy-merge-builds.sh` script expects a path relative to the kata-containers root directory. This error was introduced on commit 59fdd69b8563572.

Fixes #7394
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>

---

I'm getting this error when running either `make kata-tarball` or `make merge-builds` from the project's root directory:
```
~/go/src/github.com/kata-containers/kata-containers/build/kata-tarball-content ~/go/src/github.com/kata-containers/kata-containers/build ~/go/src/github.com/kata-containers/kata-containers
cp: cannot stat '/home/wmoschet/go/src/github.com/kata-containers/kata-containers/../../../../versions.yaml': No such file or directory
make: *** [tools/packaging/kata-deploy/local-build/Makefile:143: merge-builds] Error 1
```