### PR TITLE
gha: Fix k0s deployment

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -128,7 +128,7 @@ function deploy_k0s() {
 	if [ "${ARCH}" = "x86_64" ]; then
 		ARCH=amd64
 	fi
-	kubectl_version=$(sudo k0s kubectl version --short 2>/dev/null | grep "Client Version" | sed -e 's/Client Version: //')
+	kubectl_version=$(sudo k0s kubectl version 2>/dev/null | grep "Client Version" | sed -e 's/Client Version: //')
 	sudo curl -fL --progress-bar -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/${ARCH}/kubectl
 	sudo chmod +x /usr/bin/kubectl
 


### PR DESCRIPTION
The tests are failing when setting up k0s, and that happens because we download a kubectl binary matching the kubernetes version k0s is using, and we do that by:
```
sudo k0s kubectl version --short 2>/dev/null | ...
```

With kubectl 1.28, which is now the default on k0s, `kubectl version --short` has been removed, leading us to an empty stringm causing then the error in the CI.

Fixes: #8105