### PR TITLE
gha: arm64: Ensure the builder is arm64-builder

### DIFF
--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-asset:
-    runs-on: arm64
+    runs-on: arm64-builder
     strategy:
       matrix:
         asset:
@@ -87,7 +87,7 @@ jobs:
           if-no-files-found: error
 
   create-kata-tarball:
-    runs-on: arm64
+    runs-on: arm64-builder
     needs: build-asset
     steps:
       - name: Adjust a permission for repo

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   kata-payload:
-    runs-on: arm64
+    runs-on: arm64-builder
     steps:
       - name: Adjust a permission for repo
         run: |

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -14,7 +14,7 @@ jobs:
 
   kata-deploy:
     needs: build-kata-static-tarball-arm64
-    runs-on: arm64
+    runs-on: arm64-builder
     steps:
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v2


### PR DESCRIPTION
Otherwise we'll use any arm64 machine that's added as a runner, and whenever new machines are added those may end up being only used for running some specific set of the tests.

Fixes: #8109

![image](https://github.com/kata-containers/kata-containers/assets/112762/112dcddb-8819-47b4-8e8c-5f232ed17515)
