### PR TITLE
runtime-rs: ch: Enable main driver

### DIFF
--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -51,6 +51,10 @@ default = []
 # See https://github.com/kata-containers/kata-containers/issues/6264.
 cloud-hypervisor = ["ch-config"]
 
+# Feature is not yet ready for general use, so not enabled by default.
+# See https://github.com/kata-containers/kata-containers/issues/8112
+cloud-hypervisor-tdx = []
+
 [dev-dependencies]
 # Force the CH tests to run, even when the feature is not enabled for
 # a normal build.

--- a/src/runtime-rs/crates/hypervisor/README.md
+++ b/src/runtime-rs/crates/hypervisor/README.md
@@ -7,6 +7,16 @@ External hypervisor support is currently being developed.
 See [the main tracking issue](https://github.com/kata-containers/kata-containers/issues/4634)
 for further details.
 
+### Cloud Hypervisor with Intel TDX
+
+The Cloud Hypervisor driver provides Intel TDX functionality. However,
+this feature is currently disabled by default. To enable it, you need to enable
+[the `cloud-hypervisor-tdx` build feature](https://github.com/kata-containers/kata-containers/issues/8112).
+
+See https://github.com/kata-containers/kata-containers/issues/8113 and the
+[Cloud Hypervisor tracking issue](https://github.com/kata-containers/kata-containers/issues/6263)
+for further details.
+
 Some key points for supporting multi-vmm in rust runtime.
 ## 1. Hypervisor Config
 

--- a/src/runtime-rs/crates/hypervisor/README.md
+++ b/src/runtime-rs/crates/hypervisor/README.md
@@ -7,20 +7,6 @@ External hypervisor support is currently being developed.
 See [the main tracking issue](https://github.com/kata-containers/kata-containers/issues/4634)
 for further details.
 
-### Cloud Hypervisor
-
-A basic implementation currently exists for Cloud Hypervisor. However,
-since it is not yet fully functional, the feature is disabled by
-default. When the implementation matures, the feature will be enabled
-by default.
-
-> **Note:**
->
-> To enable the feature, follow the instructions on https://github.com/kata-containers/kata-containers/pull/6201.
-
-See the [Cloud Hypervisor tracking issue](https://github.com/kata-containers/kata-containers/issues/6263)
-for further details.
-
 Some key points for supporting multi-vmm in rust runtime.
 ## 1. Hypervisor Config
 

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -28,7 +28,7 @@ tracing = "0.1.36"
 
 agent = { path = "../../agent" }
 common = { path = "../common" }
-hypervisor = { path = "../../hypervisor" }
+hypervisor = { path = "../../hypervisor", features = ["cloud-hypervisor"] }
 kata-sys-util = { path = "../../../../libs/kata-sys-util" }
 kata-types = { path = "../../../../libs/kata-types" }
 logging = { path = "../../../../libs/logging"}
@@ -37,8 +37,7 @@ persist = { path = "../../persist"}
 resource = { path = "../../resource" }
 
 [features]
-default = []
+default = ["cloud-hypervisor"]
 
-# Feature is not yet complete, so not enabled by default.
-# See https://github.com/kata-containers/kata-containers/issues/6264.
+# Enable the Cloud Hypervisor driver
 cloud-hypervisor = []


### PR DESCRIPTION
Enable the Cloud Hypervisor runtime-rs driver by default, but do not enable TDX functionality by default.

Fixes: #6264.
Fixes: #8112.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>