### PR TITLE
runtime-rs: ch: Enable feature

### DIFF
--- a/src/runtime-rs/crates/hypervisor/README.md
+++ b/src/runtime-rs/crates/hypervisor/README.md
@@ -7,20 +7,6 @@ External hypervisor support is currently being developed.
 See [the main tracking issue](https://github.com/kata-containers/kata-containers/issues/4634)
 for further details.
 
-### Cloud Hypervisor
-
-A basic implementation currently exists for Cloud Hypervisor. However,
-since it is not yet fully functional, the feature is disabled by
-default. When the implementation matures, the feature will be enabled
-by default.
-
-> **Note:**
->
-> To enable the feature, follow the instructions on https://github.com/kata-containers/kata-containers/pull/6201.
-
-See the [Cloud Hypervisor tracking issue](https://github.com/kata-containers/kata-containers/issues/6263)
-for further details.
-
 Some key points for supporting multi-vmm in rust runtime.
 ## 1. Hypervisor Config
 

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -28,7 +28,7 @@ tracing = "0.1.36"
 
 agent = { path = "../../agent" }
 common = { path = "../common" }
-hypervisor = { path = "../../hypervisor" }
+hypervisor = { path = "../../hypervisor", features = ["cloud-hypervisor"] }
 kata-sys-util = { path = "../../../../libs/kata-sys-util" }
 kata-types = { path = "../../../../libs/kata-types" }
 logging = { path = "../../../../libs/logging"}
@@ -37,8 +37,7 @@ persist = { path = "../../persist"}
 resource = { path = "../../resource" }
 
 [features]
-default = []
+default = ["cloud-hypervisor"]
 
-# Feature is not yet complete, so not enabled by default.
-# See https://github.com/kata-containers/kata-containers/issues/6264.
+# Enable the Cloud Hypervisor driver
 cloud-hypervisor = []


### PR DESCRIPTION
Enable the Cloud Hypervisor driver (the `cloud-hypervisor` build feature) for the rust runtime.

Fixes: #6264.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>