### PR TITLE
runtime-rs: ch: Detect Intel TDX version

### DIFF
--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -558,6 +558,7 @@ dependencies = [
  "oci",
  "once_cell",
  "rand",
+ "safe-path",
  "serde_json",
  "serial_test",
  "slog",

--- a/src/libs/kata-sys-util/Cargo.toml
+++ b/src/libs/kata-sys-util/Cargo.toml
@@ -30,6 +30,7 @@ thiserror = "1.0.30"
 
 kata-types = { path = "../kata-types" }
 oci = { path = "../oci" }
+safe-path = { path = "../safe-path" }
 
 [dev-dependencies]
 num_cpus = "1.13.1"

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1574,6 +1574,7 @@ dependencies = [
  "oci",
  "once_cell",
  "rand 0.8.5",
+ "safe-path 0.1.0",
  "serde_json",
  "slog",
  "slog-scope",

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -580,6 +580,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kata_sys_util::protection::TDXDetails;
     use kata_types::config::hypervisor::{
         BlockDeviceInfo, Hypervisor as HypervisorConfig, SecurityInfo,
     };
@@ -755,6 +756,11 @@ mod tests {
 
     #[test]
     fn test_get_serial_cfg() {
+        let tdx_details = TDXDetails {
+            major_version: 1,
+            minor_version: 0,
+        };
+
         #[derive(Debug)]
         struct TestData {
             debug: bool,
@@ -783,7 +789,7 @@ mod tests {
             },
             TestData {
                 debug: false,
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: ConsoleConfig {
                     file: None,
                     mode: ConsoleOutputMode::Off,
@@ -792,7 +798,7 @@ mod tests {
             },
             TestData {
                 debug: true,
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: ConsoleConfig {
                     file: None,
                     mode: ConsoleOutputMode::Off,
@@ -838,6 +844,11 @@ mod tests {
 
     #[test]
     fn test_get_console_cfg() {
+        let tdx_details = TDXDetails {
+            major_version: 1,
+            minor_version: 0,
+        };
+
         #[derive(Debug)]
         struct TestData {
             debug: bool,
@@ -866,7 +877,7 @@ mod tests {
             },
             TestData {
                 debug: false,
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: ConsoleConfig {
                     file: None,
                     mode: ConsoleOutputMode::Off,
@@ -875,7 +886,7 @@ mod tests {
             },
             TestData {
                 debug: true,
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: ConsoleConfig {
                     file: None,
                     mode: ConsoleOutputMode::Tty,
@@ -919,6 +930,11 @@ mod tests {
 
     #[test]
     fn test_get_platform_cfg() {
+        let tdx_details = TDXDetails {
+            major_version: 1,
+            minor_version: 0,
+        };
+
         #[derive(Debug)]
         struct TestData {
             guest_protection: GuestProtection,
@@ -931,7 +947,7 @@ mod tests {
                 result: None,
             },
             TestData {
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: Some(PlatformConfig {
                     tdx: true,
                     num_pci_segments: DEFAULT_NUM_PCI_SEGMENTS,
@@ -1168,6 +1184,11 @@ mod tests {
 
     #[test]
     fn test_cpuinfo_to_cpusconfig() {
+        let tdx_details = TDXDetails {
+            major_version: 1,
+            minor_version: 0,
+        };
+
         #[derive(Debug)]
         struct TestData {
             cpu_info: CpuInfo,
@@ -1258,7 +1279,7 @@ mod tests {
                     default_maxvcpus: 13,
                     ..Default::default()
                 },
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(CpusConfig {
                     boot_vcpus: 1,
                     max_vcpus: 1,
@@ -1304,6 +1325,11 @@ mod tests {
 
     #[test]
     fn test_bootinfo_to_payloadconfig() {
+        let tdx_details = TDXDetails {
+            major_version: 1,
+            minor_version: 0,
+        };
+
         #[derive(Debug)]
         struct TestData {
             boot_info: BootInfo,
@@ -1409,19 +1435,19 @@ mod tests {
                     ..Default::default()
                 },
                 cmdline: None,
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(PayloadConfigError::TDXFirmwareMissing),
             },
             TestData {
                 boot_info: boot_info_with_initrd,
                 cmdline: Some(cmdline.to_string()),
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(payload_config_with_initrd),
             },
             TestData {
                 boot_info: boot_info_without_initrd,
                 cmdline: Some(cmdline.to_string()),
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(payload_config_without_initrd),
             },
         ];
@@ -1460,6 +1486,11 @@ mod tests {
 
     #[test]
     fn test_memoryinfo_to_memoryconfig() {
+        let tdx_details = TDXDetails {
+            major_version: 1,
+            minor_version: 0,
+        };
+
         #[derive(Debug)]
         struct TestData {
             mem_info: MemoryInfo,
@@ -1494,7 +1525,7 @@ mod tests {
 
                     ..Default::default()
                 },
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(MemoryConfig {
                     size: (17 * MIB),
                     shared: true,
@@ -1509,7 +1540,7 @@ mod tests {
 
                     ..Default::default()
                 },
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(MemoryConfig {
                     size: usable_max_mem_bytes,
                     shared: true,
@@ -1524,7 +1555,7 @@ mod tests {
 
                     ..Default::default()
                 },
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(MemoryConfigError::DefaultMemSizeTooBig),
             },
             TestData {
@@ -1552,7 +1583,7 @@ mod tests {
             },
             TestData {
                 mem_info: mem_info_confidential_guest,
-                guest_protection: GuestProtection::Tdx,
+                guest_protection: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(mem_cfg_confidential_guest),
             },
         ];
@@ -1642,6 +1673,11 @@ mod tests {
 
     #[test]
     fn test_named_hypervisor_config_to_vmconfig() {
+        let tdx_details = TDXDetails {
+            major_version: 1,
+            minor_version: 0,
+        };
+
         #[derive(Debug)]
         struct TestData {
             cfg: NamedHypervisorConfig,
@@ -1813,7 +1849,7 @@ mod tests {
             ..Default::default()
         };
 
-        let platform_config_tdx = get_platform_cfg(GuestProtection::Tdx);
+        let platform_config_tdx = get_platform_cfg(GuestProtection::Tdx(tdx_details.clone()));
 
         let vmconfig_tdx_image = VmConfig {
             cpus: cpus_config_tdx.clone(),
@@ -1922,7 +1958,7 @@ mod tests {
             vsock_socket_path: vsock_socket_path.into(),
 
             cfg: hypervisor_cfg_tdx_image,
-            guest_protection_to_use: GuestProtection::Tdx,
+            guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
 
             ..Default::default()
         };
@@ -1932,7 +1968,7 @@ mod tests {
             vsock_socket_path: vsock_socket_path.into(),
 
             cfg: hypervisor_cfg_tdx_initrd,
-            guest_protection_to_use: GuestProtection::Tdx,
+            guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
 
             ..Default::default()
         };
@@ -2169,6 +2205,11 @@ mod tests {
 
     #[test]
     fn test_check_tdx_rootfs_settings() {
+        let tdx_details = TDXDetails {
+            major_version: 1,
+            minor_version: 0,
+        };
+
         #[derive(Debug)]
         struct TestData<'a> {
             use_image: bool,
@@ -2220,7 +2261,7 @@ mod tests {
                 use_image: true,
                 container_rootfs_driver: "container",
                 vm_rootfs_driver: "vm",
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(VmConfigError::TDXContainerRootfsNotVirtioBlk),
             },
             // Partially correct
@@ -2228,28 +2269,28 @@ mod tests {
                 use_image: true,
                 container_rootfs_driver: VIRTIO_BLK_PCI,
                 vm_rootfs_driver: "vm",
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(VmConfigError::TDXVMRootfsNotVirtioBlk),
             },
             TestData {
                 use_image: true,
                 container_rootfs_driver: VIRTIO_BLK_MMIO,
                 vm_rootfs_driver: "vm",
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(VmConfigError::TDXVMRootfsNotVirtioBlk),
             },
             TestData {
                 use_image: true,
                 container_rootfs_driver: "container",
                 vm_rootfs_driver: VIRTIO_BLK_PCI,
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(VmConfigError::TDXContainerRootfsNotVirtioBlk),
             },
             TestData {
                 use_image: true,
                 container_rootfs_driver: "container",
                 vm_rootfs_driver: VIRTIO_BLK_MMIO,
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(VmConfigError::TDXContainerRootfsNotVirtioBlk),
             },
             // Same types
@@ -2257,14 +2298,14 @@ mod tests {
                 use_image: true,
                 container_rootfs_driver: VIRTIO_BLK_MMIO,
                 vm_rootfs_driver: VIRTIO_BLK_MMIO,
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(()),
             },
             TestData {
                 use_image: true,
                 container_rootfs_driver: VIRTIO_BLK_PCI,
                 vm_rootfs_driver: VIRTIO_BLK_PCI,
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(()),
             },
             // Alternate types
@@ -2272,14 +2313,14 @@ mod tests {
                 use_image: true,
                 container_rootfs_driver: VIRTIO_BLK_MMIO,
                 vm_rootfs_driver: VIRTIO_BLK_PCI,
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(()),
             },
             TestData {
                 use_image: true,
                 container_rootfs_driver: VIRTIO_BLK_PCI,
                 vm_rootfs_driver: VIRTIO_BLK_MMIO,
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Ok(()),
             },
             // Using an initrd (not currently supported)
@@ -2287,28 +2328,28 @@ mod tests {
                 use_image: false,
                 container_rootfs_driver: VIRTIO_BLK_PCI,
                 vm_rootfs_driver: VIRTIO_BLK_PCI,
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(VmConfigError::TDXDisallowsInitrd),
             },
             TestData {
                 use_image: false,
                 container_rootfs_driver: "container",
                 vm_rootfs_driver: "vm",
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(VmConfigError::TDXDisallowsInitrd),
             },
             TestData {
                 use_image: false,
                 container_rootfs_driver: VIRTIO_BLK_PCI,
                 vm_rootfs_driver: "vm",
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(VmConfigError::TDXDisallowsInitrd),
             },
             TestData {
                 use_image: false,
                 container_rootfs_driver: VIRTIO_BLK_MMIO,
                 vm_rootfs_driver: "vm",
-                guest_protection_to_use: GuestProtection::Tdx,
+                guest_protection_to_use: GuestProtection::Tdx(tdx_details.clone()),
                 result: Err(VmConfigError::TDXDisallowsInitrd),
             },
         ];

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
@@ -504,15 +504,21 @@ pub struct NamedHypervisorConfig {
 
 // Returns true if the enabled guest protection is Intel TDX.
 pub fn guest_protection_is_tdx(guest_protection_to_use: GuestProtection) -> bool {
-    matches!(guest_protection_to_use, GuestProtection::Tdx)
+    matches!(guest_protection_to_use, GuestProtection::Tdx(_))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use kata_sys_util::protection::TDXDetails;
 
     #[test]
     fn test_guest_protection_is_tdx() {
+        let tdx_details = TDXDetails {
+            major_version: 1,
+            minor_version: 0,
+        };
+
         #[derive(Debug)]
         struct TestData {
             protection: GuestProtection,
@@ -541,7 +547,7 @@ mod tests {
                 result: false,
             },
             TestData {
-                protection: GuestProtection::Tdx,
+                protection: GuestProtection::Tdx(tdx_details),
                 result: true,
             },
         ];


### PR DESCRIPTION
Improve the `GuestProtection` handling to detect the version of Intel TDX available.

The TDX version is now logged by the Cloud Hypervisor driver.

Fixes: #8147.