### PR TITLE
runtime: fix freeze when kata fails to connect to agent the first time

### DIFF
--- a/src/runtime/virtcontainers/pkg/agent/protocols/client/client.go
+++ b/src/runtime/virtcontainers/pkg/agent/protocols/client/client.go
@@ -345,7 +345,7 @@ func commonDialer(timeout time.Duration, dialFunc func() (net.Conn, error), time
 			return nil, timeoutErrMsg
 		}
 	case <-t.C:
-		cancel <- true
+		close(cancel)
 		return nil, timeoutErrMsg
 	}
 


### PR DESCRIPTION
The cancel channel is blocking, writing to it after the dialer goroutine has exited generates a freeze because there is no one that reads from it. I closed the channel instead of writing to it.

Fixes: #8150