### PR TITLE
runtime-rs: ch: Add TDX CH features check

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
@@ -67,6 +67,12 @@ pub struct CloudHypervisorInner {
     // The cloud-hypervisor device-id is later looked up and used while
     // removing the device.
     pub(crate) device_ids: HashMap<String, String>,
+
+    // List of Cloud Hypervisor features enabled at Cloud Hypervisor build-time.
+    //
+    // If the version of CH does not provide these details, the value will be
+    // None.
+    pub(crate) ch_features: Option<Vec<String>>,
 }
 
 const CH_DEFAULT_TIMEOUT_SECS: u32 = 10;
@@ -104,6 +110,7 @@ impl CloudHypervisorInner {
             shutdown_rx: Some(rx),
             tasks: None,
             guest_protection_to_use: GuestProtection::NoProtection,
+            ch_features: None,
         }
     }
 


### PR DESCRIPTION
If you attempt to create a container (a TD) on a TDX system using a
custom build of Cloud Hypervisor (CH) that was not built with the `tdx`
CH feature, Kata will report the following, somewhat cryptic, CH error:

```
ApiError(VmBoot(InvalidPayload))
```

Newer versions of CH now report their build-time features in the ping
API response message so we now use that, if available, to detect this
scenario and generate a user-friendly error message instead.

Also adds a commit to check for TDX as this is the only expected guest
protection for CH for now.

Fixes: #8152.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>