### PR TITLE
docs: Fix paths to build kernel in SNP VMs documentation

### DIFF
--- a/docs/how-to/how-to-run-kata-containers-with-SNP-VMs.md
+++ b/docs/how-to/how-to-run-kata-containers-with-SNP-VMs.md
@@ -28,10 +28,10 @@ __Steps from the Developer Guide:__
 __SNP-specific steps:__
 - Build the SNP-specific kernel as shown below (see this [guide](../../tools/packaging/kernel/README.md#build-kata-containers-kernel) for more information)
 ```bash
-$ pushd kata-containers/tools/packaging/kernel/
-$ ./build-kernel.sh -a x86_64 -x snp setup
-$ ./build-kernel.sh -a x86_64 -x snp build
-$ sudo -E PATH="${PATH}" ./build-kernel.sh -x snp install
+$ pushd kata-containers/tools/packaging/
+$ ./kernel/build-kernel.sh -a x86_64 -x snp setup
+$ ./kernel/build-kernel.sh -a x86_64 -x snp build
+$ sudo -E PATH="${PATH}" ./kernel/build-kernel.sh -x snp install
 $ popd
 ```
 - Build a current OVMF capable of SEV-SNP:


### PR DESCRIPTION
This PR fixes the correct path to setup, build and install properly the kernel for snp.

Fixes #8156