### PR TITLE
gha: Trigger CI on `issue_comment`

### DIFF
--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -4,14 +4,11 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
-  kata-containers-ci-on-push:
+  kata-containers-ci-nightly:
     uses: ./.github/workflows/ci.yaml
     with:
+      caller-workflow: ${{ github.workflow }}
       commit-hash: ${{ github.sha }}
       pr-number: "nightly"
       tag: ${{ github.sha }}-nightly

--- a/.github/workflows/ci-on-comment.yaml
+++ b/.github/workflows/ci-on-comment.yaml
@@ -1,0 +1,124 @@
+name: CI
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  kata-containers-ci-on-comment:
+    if: github.event.issue.pull_request
+    permissions:
+      actions: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check for /test-gha
+        id: test-command
+        run: |
+          comment_body=$(
+          cat <<'END_COMMENT'
+          ${{ github.event.comment.body }}
+          END_COMMENT
+          )
+          if echo "$comment_body" | sed 's/\r$//' | grep -xq '^/test-gha$'; then
+            echo "is_present=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Fetch PR info
+        id: pr-info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          pr_data="$(gh api repos/$GITHUB_REPOSITORY/pulls/${{ github.event.issue.number }})"
+          echo "base_ref=$(jq -r '.base.ref' <<< "$pr_data")" >> $GITHUB_OUTPUT
+          echo "head_ref=$(jq -r '.head.ref' <<< "$pr_data")" >> $GITHUB_OUTPUT
+          echo "head_sha=$(jq -r '.head.sha' <<< "$pr_data")" >> $GITHUB_OUTPUT
+
+      - name: Debug
+        run: |
+          echo "Is member/owner: ${{ contains(fromJSON('["MEMBER", "OWNER"]'), github.event.comment.author_association) }}"
+          echo "${{ github.event.comment.author_association }}"
+          echo "Is against main/stable-*: ${{ steps.pr-info.outputs.base_ref == 'main' || startsWith(steps.pr-info.outputs.base_ref, 'stable-') }}"
+          echo "${{ steps.pr-info.outputs.base_ref }}"
+          echo "Head commit: ${{ steps.pr-info.outputs.head_sha }}"
+          echo "Has /test-gha: ${{ steps.test-command.outputs.is_present == 'true' }}"
+
+      - name: Start CI
+        id: ci
+        if: |
+          contains(fromJSON('["MEMBER", "OWNER"]'), github.event.issue.author_association) &&
+          (steps.pr-info.outputs.base_ref == 'main' ||
+            startsWith(steps.pr-info.outputs.base_ref, 'stable-')) &&
+          steps.test-command.outputs.is_present == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "started-at=$(date +"%Y-%m-%dT%H:%M:%S%z")" >> $GITHUB_OUTPUT
+
+          gh workflow run ci.yaml \
+            -R "$GITHUB_REPOSITORY" \
+            -r ${{ steps.pr-info.outputs.head_ref }} \
+            -f commit-hash=${{ steps.pr-info.outputs.head_sha }} \
+            -f pr-number=${{ github.event.issue.number }} \
+            -f tag=${{ github.event.issue.number }}-${{ steps.pr-info.outputs.head_sha }} \
+            -f target-branch=${{ steps.pr-info.outputs.base_ref }}
+
+      # NOTE: There's a potential race condition here if another run was started
+      # right after the previous step. In any case, the concurrency directive of
+      # ci.yaml ensures that only one run prevails.
+      - name: Fetch CI run ID
+        id: ci-run
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        timeout-minutes: 1
+        run: |
+          get_run_id() {
+            created_query="$(printf %s '>=${{ steps.ci.outputs.started-at }}' | jq -Rr @uri)"
+            run_id="$( \
+              gh api "repos/$GITHUB_REPOSITORY/actions/workflows/ci.yaml/runs?created=$created_query&head_sha=${{ steps.pr-info.outputs.head_sha }}" \
+                --jq '.workflow_runs[0].id' \
+            )"
+          }
+
+          get_run_id
+          while [ -z "$run_id" ]; do
+            sleep 5
+            get_run_id
+          done
+
+          echo "id=$run_id" >> $GITHUB_OUTPUT
+
+      - name: Set initial PR status
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Possible commit statuses: error, failure, pending, success
+          gh api \
+            --method POST \
+            repos/$GITHUB_REPOSITORY/statuses/${{ steps.pr-info.outputs.head_sha }} \
+            -f state="pending" \
+            -f target_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/${{ steps.ci-run.outputs.id }}" \
+            -f context="Kata Containers CI"
+
+      - name: Wait for CI completion
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run watch --interval 15 "${{ steps.ci-run.outputs.id }}"
+
+      - name: Set final PR status
+        if: always()
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Possible commit statuses: error, failure, pending, success
+          # Possible run statuses: queued, in_progress, completed
+          # Possible run conclusions (if completed, otherwise null): success, failure, neutral, cancelled, skipped, timed_out, action_required
+          run_conclusion="$(gh api repos/$GITHUB_REPOSITORY/actions/runs/${{ steps.ci-run.outputs.id }} --jq '.conclusion')"
+          [[ "$run_conclusion" = "success" ]] && commit_status="success" || commit_status="error"
+
+          gh api \
+            --method POST \
+            repos/$GITHUB_REPOSITORY/statuses/${{ steps.pr-info.outputs.head_sha }} \
+            -f state="$commit_status" \
+            -f target_url="https://github.com/$GITHUB_REPOSITORY/actions/runs/${{ steps.ci-run.outputs.id }}" \
+            -f context="Kata Containers CI" \
+            -f description="$run_conclusion"

--- a/.github/workflows/ci-on-comment.yaml
+++ b/.github/workflows/ci-on-comment.yaml
@@ -56,6 +56,7 @@ jobs:
           gh workflow run ci.yaml \
             -R "$GITHUB_REPOSITORY" \
             -r ${{ steps.pr-info.outputs.head_ref }} \
+            -f caller-workflow=${{ github.workflow }} \
             -f commit-hash=${{ steps.pr-info.outputs.head_sha }} \
             -f pr-number=${{ github.event.issue.number }} \
             -f tag=${{ github.event.issue.number }}-${{ steps.pr-info.outputs.head_sha }} \

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -25,6 +25,7 @@ jobs:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     uses: ./.github/workflows/ci.yaml
     with:
+      caller-workflow: ${{ github.workflow }}
       commit-hash: ${{ github.event.pull_request.head.sha }}
       pr-number: ${{ github.event.pull_request.number }}
       tag: ${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,21 @@ on:
         required: false
         type: string
         default: ""
+  workflow_dispatch:
+    inputs:
+      commit-hash:
+        required: true
+        type: string
+      pr-number:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      target-branch:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-kata-static-tarball-amd64:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,6 +2,9 @@ name: Run the Kata Containers CI
 on:
   workflow_call:
     inputs:
+      caller-workflow:
+        required: true
+        type: string
       commit-hash:
         required: true
         type: string
@@ -17,6 +20,9 @@ on:
         default: ""
   workflow_dispatch:
     inputs:
+      caller-workflow:
+        required: true
+        type: string
       commit-hash:
         required: true
         type: string
@@ -30,6 +36,10 @@ on:
         required: false
         type: string
         default: ""
+
+concurrency:
+  group: ${{ inputs.caller-workflow }}-${{ inputs.pr-number }}
+  cancel-in-progress: true
 
 jobs:
   build-kata-static-tarball-amd64:


### PR DESCRIPTION
This is a rework of #8072 - since that one triggered CI via the `pull_request_review` event, it didn't have access to the repo secrets and thus couldn't create AKS clusters and so on.

This PR is similar with a few differences:

* The trigger event is `issue_comment`, meaning that the new `/test-gha` command works on regular PR comments, not PR review comments.
* I use the `gh workflow run` command to launch `ci.yaml`, rather than a `uses` block. Because `issue_comment` workflows also don't have access to the repo secrets, this launches the downstream jobs via the `workflow_dispatch` event, which gives access to secrets.
  * Upside: `ci.yaml` and downstream jobs are now executed from the base branch, making future YAML changes much easier to test.
  * **DOWNSIDE**: PR checks aren't created automatically for workflows run with `gh workflow run` - that's something we have to do manually via the API. Here I created a single "Kata Containers CI" check that accounts for all CI jobs, thus we lose granularity. In a future PR, we can create a wrapper workflow that takes a target workflow as argument and creates a check via the API.

Note that I'm keeping `ci-on-push.yaml` for now and will remove it in another PR once we've validated this works. One weird thing that I've seen in #8072 is that `github.event.issue.author_association` returns `CONTRIBUTOR` (instead of `MEMBER`) for me on this repo.

Tested working here: https://github.com/sprt/kata-containers/pull/5