### PR TITLE
metrics: Fix static-checks error for markdown reference

### DIFF
--- a/tests/metrics/storage/README.md
+++ b/tests/metrics/storage/README.md
@@ -21,7 +21,3 @@ to perform measurements upon a single test file.
 
 The test configuration used by the script can be modified by setting a number of
 environment variables to change or over-ride the test defaults.
-
-## DAX `virtio-fs` `fio` Kubernetes tests
-
-[Test](fio-k8s/README.md) to compare the use of DAX option in `virtio-fs`.


### PR DESCRIPTION
Fix static-checks error for markdown reference.  The failed CI as seen: https://github.com/kata-containers/kata-containers/actions/runs/6429506360/job/17485032319?pr=7505

Fixes: #8163

Signed-off-by: lisongqian <mail@lisongqian.cn>