### PR TITLE
runtime-rs: fix a typo in shm

### DIFF
--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -68,7 +68,7 @@ impl VolumeResource {
         // handle mounts
         for m in oci_mounts {
             let read_only = m.options.iter().any(|opt| opt == "ro");
-            let volume: Arc<dyn Volume> = if shm_volume::is_shim_volume(m) {
+            let volume: Arc<dyn Volume> = if shm_volume::is_shm_volume(m) {
                 let shm_size = shm_volume::DEFAULT_SHM_SIZE;
                 Arc::new(
                     shm_volume::ShmVolume::new(m, shm_size)

--- a/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
@@ -112,6 +112,6 @@ impl Volume for ShmVolume {
     }
 }
 
-pub(crate) fn is_shim_volume(m: &oci::Mount) -> bool {
+pub(crate) fn is_shm_volume(m: &oci::Mount) -> bool {
     m.destination == "/dev/shm" && m.r#type != KATA_EPHEMERAL_DEV_TYPE
 }


### PR DESCRIPTION
is_shim_volume should be is_shm_volume in shm_volume mod.

fixes: #8168