### PR TITLE
config: Enable guestHook for remote hyp

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1154,6 +1154,8 @@ func newRemoteHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		// No valid value so avoid to append block device to list in kata_agent.appendDevices
 		BlockDeviceDriver: "dummy",
 		EnableAnnotations: h.EnableAnnotations,
+		// Add GuestHookPath
+		GuestHookPath: h.guestHookPath(),
 	}, nil
 }
 


### PR DESCRIPTION
The guesthook config was missing which prevented handling of GPUs with remote hypervisor

Fixes: #8172