### PR TITLE
gha: install containerd before installing kata

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -78,6 +78,9 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
+      - name: Install dependencies
+        run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
+
       - name: get-kata-tarball
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Otherwise we'll end up failing to create config.toml for containerd, and the tests are not supposed to runnable either.

Fixes: #8189

Running successfully at:
https://github.com/kata-containers/kata-containers/actions/runs/6464268136