### PR TITLE
CC | payload-after-push: Bypass cache

### DIFF
--- a/.github/workflows/cc-payload-after-push-amd64.yaml
+++ b/.github/workflows/cc-payload-after-push-amd64.yaml
@@ -47,7 +47,7 @@ jobs:
           fetch-depth: 0 # This is needed in order to keep the commit ids history
       - name: Build ${{ matrix.asset }}
         run: |
-          make "${KATA_ASSET}-tarball"
+          USE_CACHE="no" make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           sudo cp -r "${build_dir}" "kata-build"
@@ -108,7 +108,7 @@ jobs:
 
       - name: Build cc-shim-v2
         run: |
-          make cc-shim-v2-tarball
+          USE_CACHE="no" make cc-shim-v2-tarball
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           sudo cp -r "${build_dir}" "kata-build"

--- a/.github/workflows/cc-payload-after-push-s390x.yaml
+++ b/.github/workflows/cc-payload-after-push-s390x.yaml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Build ${{ matrix.asset }}
         run: |
-          make "${KATA_ASSET}-tarball"
+          USE_CACHE="no" make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           sudo cp -r "${build_dir}" "kata-build"
@@ -92,7 +92,7 @@ jobs:
 
       - name: Build cc-shim-v2
         run: |
-          make cc-shim-v2-tarball
+          USE_CACHE="no" make cc-shim-v2-tarball
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           sudo cp -r "${build_dir}" "kata-build"
@@ -138,7 +138,7 @@ jobs:
           # Skip building dependant artifacts of cc-se-image-tarball
           # because we already have them from the previous build
           sed -i 's/\(^cc-se-image-tarball:\).*/\1/g' ${base_dir}/Makefile
-          make cc-se-image-tarball
+          USE_CACHE="no" make cc-se-image-tarball
           build_dir=$(readlink -f build)
           sudo cp -r "${build_dir}" "kata-build"
           sudo chown -R $(id -u):$(id -g) "kata-build"


### PR DESCRIPTION
We're facing errors in the operator CI, which are related to the measured rootfs.

For now, let's skip the cache builds (as those were dropped anyways for this branch) and ensure we do a clean build, and then check if the problem persists.