### PR TITLE
Enable fio checkmetrics

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -190,13 +190,17 @@ function clean_env_ctr()
 
 # Kills running shim and hypervisor components
 function kill_kata_components() {
+	local ATTEMPTS=2
 	local TIMEOUT="30s"
 	local PID_NAMES=( "containerd-shim-kata-v2" "qemu-system-x86_64" "cloud-hypervisor" )
 
 	sudo systemctl stop containerd
 	# iterate over the list of kata components and stop them
-	for PID_NAME in "${PID_NAMES[@]}"; do
-		[[ ! -z "$(pidof ${PID_NAME})" ]] && sudo killall "${PID_NAME}" > /dev/null 2>&1 || true
+	for (( i=1; i<=ATTEMPTS; i++ )); do
+		for PID_NAME in "${PID_NAMES[@]}"; do
+			[[ ! -z "$(pidof ${PID_NAME})" ]] && sudo killall "${PID_NAME}" >/dev/null 2>&1 || true
+		done
+		sleep 1
 	done
 	sudo timeout -s SIGKILL "${TIMEOUT}" systemctl start containerd
 }

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -99,6 +99,58 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
+name = "fio"
+type = "json"
+description = "measure sequential read throughput using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = "[.\"fio\".\"Results sequential\"] | .[] | .[] | .read.bw | select( . != null )"
+checktype = "mean"
+midval = 312776
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure sequential write throughput using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = "[.\"fio\".\"Results sequential\"] | .[] | .[] | .write.bw | select( . != null )"
+checktype = "mean"
+midval = 307948
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure random read throughput using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = "[.\"fio\".\"Results random\"] | .[] | .[] | .randread.bw | select( . != null )"
+checktype = "mean"
+midval = 1351339
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure random write throughput using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = "[.\"fio\".\"Results random\"] | .[] | .[] | .randwrite.bw | select( . != null )"
+checktype = "mean"
+midval = 1440540.7
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
 name = "latency"
 type = "json"
 description = "measure container latency"

--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-qemu-kata-metric8.toml
@@ -99,6 +99,58 @@ minpercent = 20.0
 maxpercent = 20.0
 
 [[metric]]
+name = "fio"
+type = "json"
+description = "measure sequential read throughput using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = "[.\"fio\".\"Results sequential\"] | .[] | .[] | .read.bw | select( . != null )"
+checktype = "mean"
+midval = 327066.8
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure sequential write throughput using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = "[.\"fio\".\"Results sequential\"] | .[] | .[] | .write.bw | select( . != null )"
+checktype = "mean"
+midval = 309023.65
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure random read throughput using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = "[.\"fio\".\"Results random\"] | .[] | .[] | .randread.bw | select( . != null )"
+checktype = "mean"
+midval = 1301793.45
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
+name = "fio"
+type = "json"
+description = "measure random write throughput using fio"
+# Min and Max values to set a 'range' that
+# the median of the CSV Results data must fall
+# within (inclusive)
+checkvar = "[.\"fio\".\"Results random\"] | .[] | .[] | .randwrite.bw | select( . != null )"
+checktype = "mean"
+midval = 1457926.8
+minpercent = 20.0
+maxpercent = 20.0
+
+[[metric]]
 name = "latency"
 type = "json"
 description = "measure container latency"

--- a/tests/metrics/cmd/checkmetrics/json.go
+++ b/tests/metrics/cmd/checkmetrics/json.go
@@ -29,7 +29,7 @@ func (c *jsonRecord) load(filepath string, metric *metrics) error {
 
 	log.Debugf(" Run jq '%v' %s", metric.CheckVar, filepath)
 
-	out, err := exec.Command("jq", metric.CheckVar, filepath).Output()
+	out, err := exec.Command("jq", "-r", metric.CheckVar, filepath).Output()
 	if err != nil {
 		log.Warnf("Failed to run [jq %v %v][%v]", metric.CheckVar, filepath, err)
 		return err

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -84,9 +84,9 @@ function run_test_tensorflow() {
 }
 
 function run_test_fio() {
-	info "Skipping FIO test temporarily using ${KATA_HYPERVISOR} hypervisor"
+	info "Running FIO test using ${KATA_HYPERVISOR} hypervisor"
 
-	# bash tests/metrics/storage/fio-k8s/fio-test-ci.sh
+	bash tests/metrics/storage/fio_test.sh
 }
 
 function run_test_iperf() {

--- a/tests/metrics/lib/common.bash
+++ b/tests/metrics/lib/common.bash
@@ -201,8 +201,8 @@ function kill_processes_before_start()
 	CTR_PROCS=$(sudo "${CTR_EXE}" t list -q)
 	[[ -n "${CTR_PROCS}" ]] && clean_env_ctr
 
+	kill_kata_components && sleep 1
 	kill_kata_components
-
 	check_processes
 }
 

--- a/tests/metrics/storage/fio-dockerfile/workload/fio_bench.sh
+++ b/tests/metrics/storage/fio-dockerfile/workload/fio_bench.sh
@@ -71,7 +71,7 @@ function launch_workload() {
 	local test_name="${io_type}_${block_size}_nj-${num_jobs}_${rate_process}_iodepth-${iodepth}_io-direct-${disable_buffered}"
 
 	setup_workload
-	rm -f "${summary_file_local}" > /dev/null 2>&1
+	rm -f "${summary_file_local}" >/dev/null 2>&1
         fio \
 	--name="${test_name}" \
 	--output-format="json" \
@@ -88,12 +88,12 @@ function launch_workload() {
 	--iodepth="${iodepth}" \
 	--gtod_reduce="1" \
 	--randrepeat="1" \
-	| tee -a ${summary_file_local} > /dev/null 2>&1
+	--output "${summary_file_local}" >/dev/null 2>&1
 }
 
 function print_latest_results() {
 	[ ! -f "${summary_file_local}" ] && echo "Error: no results to display; you must run a test before requesting results display" && exit 1
-	echo "$(cat ${summary_file_local})"
+	cat "${summary_file_local}"
 }
 
 function delete_workload() {

--- a/tests/metrics/storage/fio-dockerfile/workload/fio_bench.sh
+++ b/tests/metrics/storage/fio-dockerfile/workload/fio_bench.sh
@@ -16,13 +16,13 @@ set -o pipefail
 # read, write, randread, randwrite, randrw, readwrite
 io_type="read"
 block_size="4k"
-num_jobs="2"
+num_jobs="4"
 
 # FIO default settings
 readonly ioengine="libaio"
 readonly rate_process="linear"
 readonly disable_buffered="1"
-readonly iodepth="2"
+readonly iodepth="8"
 readonly runtime="10s"
 # ramp time
 readonly rt="10s"

--- a/tests/metrics/storage/fio_test.sh
+++ b/tests/metrics/storage/fio_test.sh
@@ -18,6 +18,7 @@ IMAGE="docker.io/library/fio-bench:latest"
 DOCKERFILE="${SCRIPT_PATH}/fio-dockerfile/Dockerfile"
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 TEST_NAME="fio"
+REQUIRED_CMDS=("jq" "script")
 
 # Fio default number of jobs
 nj=4
@@ -34,7 +35,7 @@ trap release_resources EXIT
 function setup() {
 	info "setup fio test"
 	clean_env_ctr
-	check_cmds "${cmds[@]}"
+	check_cmds "${REQUIRED_CMDS[@]}"
 	check_ctr_images "$IMAGE" "$DOCKERFILE"
 	init_env
 
@@ -135,21 +136,21 @@ function main() {
 	# Collect bs=4K, num_jobs=4, io-direct, io-depth=2
 	info "Processing sequential type workload"
 	sudo -E "${CTR_EXE}" t exec --exec-id "${RANDOM}" ${CONTAINER_ID} sh -c "./fio_bench.sh run-read-4k ${nj}" >/dev/null 2>&1
-	local results_read_4K="$(sudo -E "${CTR_EXE}" t exec -t --exec-id "${RANDOM}" ${CONTAINER_ID} sh -c "./fio_bench.sh print-latest-results")"
+	local results_read_4K="$(script -qc "sudo -E ${CTR_EXE} t exec -t --exec-id ${RANDOM} ${CONTAINER_ID} sh -c './fio_bench.sh print-latest-results'")"
 
 	sleep 0.5
 	sudo -E "${CTR_EXE}" t exec --exec-id "${RANDOM}" ${CONTAINER_ID} sh -c "./fio_bench.sh run-write-4k ${nj}" >/dev/null 2>&1
-	local results_write_4K="$(sudo -E "${CTR_EXE}" t exec -t --exec-id "${RANDOM}" ${CONTAINER_ID} sh -c "./fio_bench.sh print-latest-results")"
+	local results_write_4K="$(script -qc "sudo -E ${CTR_EXE} t exec -t --exec-id ${RANDOM} ${CONTAINER_ID} sh -c './fio_bench.sh print-latest-results'")"
 
 	# Collect bs=64K, num_jobs=4, io-direct, io-depth=2
 	info "Processing random type workload"
 	sleep 0.5
 	sudo -E "${CTR_EXE}" t exec --exec-id "${RANDOM}" ${CONTAINER_ID} sh -c "./fio_bench.sh run-randread-64k ${nj}" >/dev/null 2>&1
-	local results_rand_read_64K="$(sudo -E "${CTR_EXE}" t exec -t --exec-id "${RANDOM}" ${CONTAINER_ID} sh -c "./fio_bench.sh print-latest-results")"
+	local results_rand_read_64K="$(script -qc "sudo -E ${CTR_EXE} t exec -t --exec-id ${RANDOM} ${CONTAINER_ID} sh -c './fio_bench.sh print-latest-results'")"
 
 	sleep 0.5
 	sudo -E "${CTR_EXE}" t exec --exec-id "${RANDOM}" ${CONTAINER_ID} sh -c "./fio_bench.sh run-randwrite-64k ${nj}" >/dev/null 2>&1
-	local results_rand_write_64K="$(sudo -E "${CTR_EXE}" t exec -t --exec-id "${RANDOM}" ${CONTAINER_ID} sh -c "./fio_bench.sh print-latest-results")"
+	local results_rand_write_64K="$(script -qc "sudo -E ${CTR_EXE} t exec -t --exec-id ${RANDOM} ${CONTAINER_ID} sh -c './fio_bench.sh print-latest-results'")"
 
 	# parse results
 	metrics_json_init


### PR DESCRIPTION
This PR enables the new FIO test based on the containerd client
which is used to track the I/O metrics in the kata-ci environment.

Fixes: #8199