### PR TITLE
CCv0: runtime: fix k8s secret issue with remote hypervisor

### DIFF
--- a/src/runtime/virtcontainers/fs_share_linux.go
+++ b/src/runtime/virtcontainers/fs_share_linux.go
@@ -293,7 +293,7 @@ func (f *FilesystemShare) ShareFile(ctx context.Context, c *Container, m *Mount)
 
 			// Add fsNotify watcher for volume mounts
 			if strings.Contains(srcPath, "kubernetes.io~configmap") ||
-				strings.Contains(srcPath, "kubernetes.io~secrets") ||
+				strings.Contains(srcPath, "kubernetes.io~secret") ||
 				strings.Contains(srcPath, "kubernetes.io~projected") ||
 				strings.Contains(srcPath, "kubernetes.io~downward-api") {
 


### PR DESCRIPTION
kata-shim CCv0 does not propagate dynamically updated k8s secret values due to incorrect file name matching. This 
patch fixes the the wrong file name matching for k8s secret volume paths.

Note that this problem has already fixed in the main branch.
https://github.com/kata-containers/kata-containers/blob/538131ab449f85bc9533bb04ab8b2788e4d4e830/src/runtime/virtcontainers/fs_share_linux.go#L311

Fixes: #8208
