### PR TITLE
cc|rootfs: Define SEALED_SECRET for cc-rootfs-initrd-tarball

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -481,6 +481,7 @@ install_cached_kernel_tarball_component() {
 
 install_cc_initrd() {
 	export AA_KBC="${AA_KBC:-offline_fs_kbc}"
+	export SEALED_SECRET=yes
 	info "Create CC initrd configured with AA_KBC=${AA_KBC}"
 	install_initrd
 }


### PR DESCRIPTION
This is to define `SEALED_SECRET` as yes for a make target `cc-rootfs-initrd-tarball`, which makes a service `confidential-data-hub` available with an initrd-based VM creation.

Fixes: #8210

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>