### PR TITLE
tests: fixes permission denied when running test

### DIFF
--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -444,7 +444,7 @@ function main() {
 	pushd "containerd"
 
 	# Make sure the right artifacts are going to be built
-	make clean
+	sudo make clean
 
 	check_daemon_setup
 


### PR DESCRIPTION
After running cri-containerd/integration-tests twice we receive permission denied during containerd clean.

Fixes: #8216