### PR TITLE
[WIP] runtime-rs: support nydus v6 as rootfs of container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ src/agent/protocols/src/*.rs
 !src/agent/protocols/src/lib.rs
 build
 src/tools/log-parser/kata-log-parser
+.DS_Store

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_fs.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_fs.rs
@@ -15,6 +15,7 @@ pub enum ShareFsOperation {
 pub enum ShareFsMountType {
     PASSTHROUGH,
     RAFS,
+    BLOBFS,
 }
 
 /// ShareFsMountConfig: share fs mount config
@@ -40,6 +41,9 @@ pub struct ShareFsMountConfig {
 
     /// prefetch_list_path: path to file that contains file lists that should be prefetched by rafs
     pub prefetch_list_path: Option<String>,
+
+    /// What size file supports dax
+    pub dax_threshold_size_kb: Option<u64>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -369,6 +369,7 @@ impl DragonballInner {
         let fstype = match config.fstype {
             ShareFsMountType::PASSTHROUGH => "passthroughfs",
             ShareFsMountType::RAFS => "rafs",
+            ShareFsMountType::BLOBFS => "blobfs",
         };
 
         let cfg = FsMountConfigInfo {
@@ -379,7 +380,7 @@ impl DragonballInner {
             config: config.config.clone(),
             tag: config.tag.clone(),
             prefetch_list_path: config.prefetch_list_path.clone(),
-            dax_threshold_size_kb: None,
+            dax_threshold_size_kb: config.dax_threshold_size_kb.clone(),
         };
 
         self.vmm_instance.patch_fs(&cfg, config.op).map_err(|e| {

--- a/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
@@ -13,8 +13,8 @@ use crate::{
     rootfs::{HYBRID_ROOTFS_LOWER_DIR, ROOTFS},
     share_fs::{
         blobfs_mount, do_get_guest_path, do_get_guest_share_path, get_host_rw_shared_path,
-        passthrough_mount, rafs_mount, ShareFs, ShareFsRootfsConfig, BLOB_CACHE_DIR,
-        BLOB_CACHE_DIR, PASSTHROUGH_FS_DIR,
+        passthrough_mount, rafs_mount, ShareFs, ShareFsRootfsConfig, BLOB_CACHE_DIR, BOOTSTRAP_DIR,
+        PASSTHROUGH_FS_DIR,
     },
 };
 use agent::Storage;

--- a/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
@@ -3,6 +3,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+
+// TODO runtime-rs control logic
+
 use std::{fs, path::Path, sync::Arc};
 
 use super::{Rootfs, TYPE_OVERLAY_FS};

--- a/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
@@ -138,10 +138,11 @@ impl NydusRootfs {
                     h,
                     extra_options.source.clone(),
                     blobfs_mnt.clone(),
-                    &extra_options.config,
+                    extra_options.config,
                     Some(dax_threshold_size_kb),
                 )
-                .with_context(|| "failed to mount blob cache dir".to_string())?;
+                .await
+                .context("failed to mount blob cache dir")?;
 
                 let bootstrap_dir = {
                     let dir: &Path = extra_options.source.as_str().as_ref();
@@ -154,7 +155,8 @@ impl NydusRootfs {
                     passthroughfs_mnt.clone(),
                     Some(dax_threshold_size_kb),
                 )
-                .with_context(|| "failed to mount bootstrap dir".to_string())?;
+                .await
+                .context("failed to mount bootstrap dir")?;
 
                 // create rootfs under the share directory
                 let container_share_dir = get_host_rw_shared_path(sid)

--- a/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/nydus_rootfs.rs
@@ -151,7 +151,7 @@ impl NydusRootfs {
                 let passthroughfs_mnt = do_get_guest_path(BOOTSTRAP_DIR, cid, false, true);
                 passthrough_mount(
                     h,
-                    bootstrap_dir,
+                    bootstrap_dir.clone(),
                     passthroughfs_mnt.clone(),
                     Some(dax_threshold_size_kb),
                 )

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -5,6 +5,8 @@
 //
 
 mod share_virtio_fs;
+pub use share_virtio_fs::blobfs_mount;
+pub use share_virtio_fs::passthrough_mount;
 pub use share_virtio_fs::rafs_mount;
 mod share_virtio_fs_inline;
 use share_virtio_fs_inline::ShareVirtioFsInline;
@@ -40,6 +42,8 @@ const KATA_GUEST_SHARE_DIR: &str = "/run/kata-containers/shared/containers/";
 pub(crate) const DEFAULT_KATA_GUEST_SANDBOX_DIR: &str = "/run/kata-containers/sandbox/";
 
 pub const PASSTHROUGH_FS_DIR: &str = "passthrough";
+pub const BLOB_CACHE_DIR: &str = "blob_cache_dir";
+pub const BOOTSTRAP_DIR: &str = "bootstrap";
 const RAFS_DIR: &str = "rafs";
 
 #[async_trait]

--- a/tools/packaging/kernel/patches/5.19.x/0001-support-RAFS-v6-over-virtiofs.patch
+++ b/tools/packaging/kernel/patches/5.19.x/0001-support-RAFS-v6-over-virtiofs.patch
@@ -1,0 +1,1682 @@
+From c81f88bc52bfda7f80af90bb395aafa764b7f3d5 Mon Sep 17 00:00:00 2001
+From: Leospard <694963063@qq.com>
+Date: Wed, 6 Sep 2023 21:06:25 +0800
+Subject: [PATCH 1/3] support RAFS v6 over virtiofs
+
+---
+ .vscode/settings.json |   0
+ fs/erofs/data.c       | 154 ++++++++++++--------
+ fs/erofs/inode.c      | 317 ++++++++++++++++++++++++++++++++++++------
+ fs/erofs/internal.h   | 276 +++++++++++++++++++-----------------
+ fs/erofs/super.c      |  61 +++++++-
+ 5 files changed, 570 insertions(+), 238 deletions(-)
+ create mode 100644 .vscode/settings.json
+
+diff --git a/.vscode/settings.json b/.vscode/settings.json
+new file mode 100644
+index 000000000..e69de29bb
+diff --git a/fs/erofs/data.c b/fs/erofs/data.c
+index fbb037ba3..1fc53b2b8 100644
+--- a/fs/erofs/data.c
++++ b/fs/erofs/data.c
+@@ -30,7 +30,7 @@ void erofs_put_metabuf(struct erofs_buf *buf)
+ }
+ 
+ void *erofs_bread(struct erofs_buf *buf, struct inode *inode,
+-		  erofs_blk_t blkaddr, enum erofs_kmap_type type)
++				  erofs_blk_t blkaddr, enum erofs_kmap_type type)
+ {
+ 	struct address_space *const mapping = inode->i_mapping;
+ 	erofs_off_t offset = blknr_to_addr(blkaddr);
+@@ -39,7 +39,8 @@ void *erofs_bread(struct erofs_buf *buf, struct inode *inode,
+ 	struct folio *folio;
+ 	unsigned int nofs_flag;
+ 
+-	if (!page || page->index != index) {
++	if (!page || page->index != index)
++	{
+ 		erofs_put_metabuf(buf);
+ 
+ 		nofs_flag = memalloc_nofs_save();
+@@ -52,13 +53,16 @@ void *erofs_bread(struct erofs_buf *buf, struct inode *inode,
+ 		page = folio_file_page(folio, index);
+ 		buf->page = page;
+ 	}
+-	if (buf->kmap_type == EROFS_NO_KMAP) {
++	if (buf->kmap_type == EROFS_NO_KMAP)
++	{
+ 		if (type == EROFS_KMAP)
+ 			buf->base = kmap(page);
+ 		else if (type == EROFS_KMAP_ATOMIC)
+ 			buf->base = kmap_atomic(page);
+ 		buf->kmap_type = type;
+-	} else if (buf->kmap_type != type) {
++	}
++	else if (buf->kmap_type != type)
++	{
+ 		DBG_BUGON(1);
+ 		return ERR_PTR(-EFAULT);
+ 	}
+@@ -68,18 +72,20 @@ void *erofs_bread(struct erofs_buf *buf, struct inode *inode,
+ }
+ 
+ void *erofs_read_metabuf(struct erofs_buf *buf, struct super_block *sb,
+-			 erofs_blk_t blkaddr, enum erofs_kmap_type type)
++						 erofs_blk_t blkaddr, enum erofs_kmap_type type)
+ {
++	if (EROFS_SB(sb)->bootstrap)
++		return erofs_bread(buf, EROFS_SB(sb)->bootstrap->f_inode, blkaddr, type);
+ 	if (erofs_is_fscache_mode(sb))
+ 		return erofs_bread(buf, EROFS_SB(sb)->s_fscache->inode,
+-				   blkaddr, type);
++						   blkaddr, type);
+ 
+ 	return erofs_bread(buf, sb->s_bdev->bd_inode, blkaddr, type);
+ }
+ 
+ static int erofs_map_blocks_flatmode(struct inode *inode,
+-				     struct erofs_map_blocks *map,
+-				     int flags)
++									 struct erofs_map_blocks *map,
++									 int flags)
+ {
+ 	erofs_blk_t nblocks, lastblk;
+ 	u64 offset = map->m_la;
+@@ -91,30 +97,36 @@ static int erofs_map_blocks_flatmode(struct inode *inode,
+ 
+ 	/* there is no hole in flatmode */
+ 	map->m_flags = EROFS_MAP_MAPPED;
+-	if (offset < blknr_to_addr(lastblk)) {
++	if (offset < blknr_to_addr(lastblk))
++	{
+ 		map->m_pa = blknr_to_addr(vi->raw_blkaddr) + map->m_la;
+ 		map->m_plen = blknr_to_addr(lastblk) - offset;
+-	} else if (tailendpacking) {
++	}
++	else if (tailendpacking)
++	{
+ 		/* 2 - inode inline B: inode, [xattrs], inline last blk... */
+ 		struct erofs_sb_info *sbi = EROFS_SB(inode->i_sb);
+ 
+ 		map->m_pa = iloc(sbi, vi->nid) + vi->inode_isize +
+-			vi->xattr_isize + erofs_blkoff(map->m_la);
++					vi->xattr_isize + erofs_blkoff(map->m_la);
+ 		map->m_plen = inode->i_size - offset;
+ 
+ 		/* inline data should be located in the same meta block */
+-		if (erofs_blkoff(map->m_pa) + map->m_plen > EROFS_BLKSIZ) {
++		if (erofs_blkoff(map->m_pa) + map->m_plen > EROFS_BLKSIZ)
++		{
+ 			erofs_err(inode->i_sb,
+-				  "inline data cross block boundary @ nid %llu",
+-				  vi->nid);
++					  "inline data cross block boundary @ nid %llu",
++					  vi->nid);
+ 			DBG_BUGON(1);
+ 			return -EFSCORRUPTED;
+ 		}
+ 		map->m_flags |= EROFS_MAP_META;
+-	} else {
++	}
++	else
++	{
+ 		erofs_err(inode->i_sb,
+-			  "internal error @ nid: %llu (size %llu), m_la 0x%llx",
+-			  vi->nid, inode->i_size, map->m_la);
++				  "internal error @ nid: %llu (size %llu), m_la 0x%llx",
++				  vi->nid, inode->i_size, map->m_la);
+ 		DBG_BUGON(1);
+ 		return -EIO;
+ 	}
+@@ -122,7 +134,7 @@ static int erofs_map_blocks_flatmode(struct inode *inode,
+ }
+ 
+ int erofs_map_blocks(struct inode *inode,
+-		     struct erofs_map_blocks *map, int flags)
++					 struct erofs_map_blocks *map, int flags)
+ {
+ 	struct super_block *sb = inode->i_sb;
+ 	struct erofs_inode *vi = EROFS_I(inode);
+@@ -136,43 +148,52 @@ int erofs_map_blocks(struct inode *inode,
+ 
+ 	trace_erofs_map_blocks_enter(inode, map, flags);
+ 	map->m_deviceid = 0;
+-	if (map->m_la >= inode->i_size) {
++	if (map->m_la >= inode->i_size)
++	{
+ 		/* leave out-of-bound access unmapped */
+ 		map->m_flags = 0;
+ 		map->m_plen = 0;
+ 		goto out;
+ 	}
+ 
+-	if (vi->datalayout != EROFS_INODE_CHUNK_BASED) {
++	if (vi->datalayout != EROFS_INODE_CHUNK_BASED)
++	{
+ 		err = erofs_map_blocks_flatmode(inode, map, flags);
+ 		goto out;
+ 	}
+ 
+ 	if (vi->chunkformat & EROFS_CHUNK_FORMAT_INDEXES)
+-		unit = sizeof(*idx);			/* chunk index */
++		unit = sizeof(*idx); /* chunk index */
+ 	else
+-		unit = EROFS_BLOCK_MAP_ENTRY_SIZE;	/* block map */
++		unit = EROFS_BLOCK_MAP_ENTRY_SIZE; /* block map */
+ 
+ 	chunknr = map->m_la >> vi->chunkbits;
+ 	pos = ALIGN(iloc(EROFS_SB(sb), vi->nid) + vi->inode_isize +
+-		    vi->xattr_isize, unit) + unit * chunknr;
++					vi->xattr_isize,
++				unit) +
++		  unit * chunknr;
+ 
+ 	kaddr = erofs_read_metabuf(&buf, sb, erofs_blknr(pos), EROFS_KMAP);
+-	if (IS_ERR(kaddr)) {
++	if (IS_ERR(kaddr))
++	{
+ 		err = PTR_ERR(kaddr);
+ 		goto out;
+ 	}
+ 	map->m_la = chunknr << vi->chunkbits;
+ 	map->m_plen = min_t(erofs_off_t, 1UL << vi->chunkbits,
+-			    roundup(inode->i_size - map->m_la, EROFS_BLKSIZ));
++						roundup(inode->i_size - map->m_la, EROFS_BLKSIZ));
+ 
+ 	/* handle block map */
+-	if (!(vi->chunkformat & EROFS_CHUNK_FORMAT_INDEXES)) {
++	if (!(vi->chunkformat & EROFS_CHUNK_FORMAT_INDEXES))
++	{
+ 		__le32 *blkaddr = kaddr + erofs_blkoff(pos);
+ 
+-		if (le32_to_cpu(*blkaddr) == EROFS_NULL_ADDR) {
++		if (le32_to_cpu(*blkaddr) == EROFS_NULL_ADDR)
++		{
+ 			map->m_flags = 0;
+-		} else {
++		}
++		else
++		{
+ 			map->m_pa = blknr_to_addr(le32_to_cpu(*blkaddr));
+ 			map->m_flags = EROFS_MAP_MAPPED;
+ 		}
+@@ -180,13 +201,14 @@ int erofs_map_blocks(struct inode *inode,
+ 	}
+ 	/* parse chunk indexes */
+ 	idx = kaddr + erofs_blkoff(pos);
+-	switch (le32_to_cpu(idx->blkaddr)) {
++	switch (le32_to_cpu(idx->blkaddr))
++	{
+ 	case EROFS_NULL_ADDR:
+ 		map->m_flags = 0;
+ 		break;
+ 	default:
+ 		map->m_deviceid = le16_to_cpu(idx->device_id) &
+-			EROFS_SB(sb)->device_id_mask;
++						  EROFS_SB(sb)->device_id_mask;
+ 		map->m_pa = blknr_to_addr(le32_to_cpu(idx->blkaddr));
+ 		map->m_flags = EROFS_MAP_MAPPED;
+ 		break;
+@@ -208,14 +230,17 @@ int erofs_map_dev(struct super_block *sb, struct erofs_map_dev *map)
+ 
+ 	/* primary device by default */
+ 	map->m_bdev = sb->s_bdev;
++	mp->m_fp = EROFS_SB(sb)->bootstrap;
+ 	map->m_daxdev = EROFS_SB(sb)->dax_dev;
+ 	map->m_dax_part_off = EROFS_SB(sb)->dax_part_off;
+ 	map->m_fscache = EROFS_SB(sb)->s_fscache;
+ 
+-	if (map->m_deviceid) {
++	if (map->m_deviceid)
++	{
+ 		down_read(&devs->rwsem);
+ 		dif = idr_find(&devs->tree, map->m_deviceid - 1);
+-		if (!dif) {
++		if (!dif)
++		{
+ 			up_read(&devs->rwsem);
+ 			return -ENODEV;
+ 		}
+@@ -224,9 +249,12 @@ int erofs_map_dev(struct super_block *sb, struct erofs_map_dev *map)
+ 		map->m_dax_part_off = dif->dax_part_off;
+ 		map->m_fscache = dif->fscache;
+ 		up_read(&devs->rwsem);
+-	} else if (devs->extra_devices) {
++	}
++	else if (devs->extra_devices)
++	{
+ 		down_read(&devs->rwsem);
+-		idr_for_each_entry(&devs->tree, dif, id) {
++		idr_for_each_entry(&devs->tree, dif, id)
++		{
+ 			erofs_off_t startoff, length;
+ 
+ 			if (!dif->mapped_blkaddr)
+@@ -235,7 +263,8 @@ int erofs_map_dev(struct super_block *sb, struct erofs_map_dev *map)
+ 			length = blknr_to_addr(dif->blocks);
+ 
+ 			if (map->m_pa >= startoff &&
+-			    map->m_pa < startoff + length) {
++				map->m_pa < startoff + length)
++			{
+ 				map->m_pa -= startoff;
+ 				map->m_bdev = dif->bdev;
+ 				map->m_daxdev = dif->dax_dev;
+@@ -250,7 +279,7 @@ int erofs_map_dev(struct super_block *sb, struct erofs_map_dev *map)
+ }
+ 
+ static int erofs_iomap_begin(struct inode *inode, loff_t offset, loff_t length,
+-		unsigned int flags, struct iomap *iomap, struct iomap *srcmap)
++							 unsigned int flags, struct iomap *iomap, struct iomap *srcmap)
+ {
+ 	int ret;
+ 	struct erofs_map_blocks map;
+@@ -263,7 +292,7 @@ static int erofs_iomap_begin(struct inode *inode, loff_t offset, loff_t length,
+ 	if (ret < 0)
+ 		return ret;
+ 
+-	mdev = (struct erofs_map_dev) {
++	mdev = (struct erofs_map_dev){
+ 		.m_deviceid = map.m_deviceid,
+ 		.m_pa = map.m_pa,
+ 	};
+@@ -280,7 +309,8 @@ static int erofs_iomap_begin(struct inode *inode, loff_t offset, loff_t length,
+ 	iomap->flags = 0;
+ 	iomap->private = NULL;
+ 
+-	if (!(map.m_flags & EROFS_MAP_MAPPED)) {
++	if (!(map.m_flags & EROFS_MAP_MAPPED))
++	{
+ 		iomap->type = IOMAP_HOLE;
+ 		iomap->addr = IOMAP_NULL_ADDR;
+ 		if (!iomap->length)
+@@ -288,18 +318,21 @@ static int erofs_iomap_begin(struct inode *inode, loff_t offset, loff_t length,
+ 		return 0;
+ 	}
+ 
+-	if (map.m_flags & EROFS_MAP_META) {
++	if (map.m_flags & EROFS_MAP_META)
++	{
+ 		void *ptr;
+ 		struct erofs_buf buf = __EROFS_BUF_INITIALIZER;
+ 
+ 		iomap->type = IOMAP_INLINE;
+ 		ptr = erofs_read_metabuf(&buf, inode->i_sb,
+-					 erofs_blknr(mdev.m_pa), EROFS_KMAP);
++								 erofs_blknr(mdev.m_pa), EROFS_KMAP);
+ 		if (IS_ERR(ptr))
+ 			return PTR_ERR(ptr);
+ 		iomap->inline_data = ptr + erofs_blkoff(mdev.m_pa);
+ 		iomap->private = buf.base;
+-	} else {
++	}
++	else
++	{
+ 		iomap->type = IOMAP_MAPPED;
+ 		iomap->addr = mdev.m_pa;
+ 		if (flags & IOMAP_DAX)
+@@ -309,11 +342,12 @@ static int erofs_iomap_begin(struct inode *inode, loff_t offset, loff_t length,
+ }
+ 
+ static int erofs_iomap_end(struct inode *inode, loff_t pos, loff_t length,
+-		ssize_t written, unsigned int flags, struct iomap *iomap)
++						   ssize_t written, unsigned int flags, struct iomap *iomap)
+ {
+ 	void *ptr = iomap->private;
+ 
+-	if (ptr) {
++	if (ptr)
++	{
+ 		struct erofs_buf buf = {
+ 			.page = kmap_to_page(ptr),
+ 			.base = ptr,
+@@ -322,7 +356,9 @@ static int erofs_iomap_end(struct inode *inode, loff_t pos, loff_t length,
+ 
+ 		DBG_BUGON(iomap->type != IOMAP_INLINE);
+ 		erofs_put_metabuf(&buf);
+-	} else {
++	}
++	else
++	{
+ 		DBG_BUGON(iomap->type == IOMAP_INLINE);
+ 	}
+ 	return written;
+@@ -334,12 +370,13 @@ static const struct iomap_ops erofs_iomap_ops = {
+ };
+ 
+ int erofs_fiemap(struct inode *inode, struct fiemap_extent_info *fieinfo,
+-		 u64 start, u64 len)
++				 u64 start, u64 len)
+ {
+-	if (erofs_inode_is_data_compressed(EROFS_I(inode)->datalayout)) {
++	if (erofs_inode_is_data_compressed(EROFS_I(inode)->datalayout))
++	{
+ #ifdef CONFIG_EROFS_FS_ZIP
+ 		return iomap_fiemap(inode, fieinfo, start, len,
+-				    &z_erofs_iomap_report_ops);
++							&z_erofs_iomap_report_ops);
+ #else
+ 		return -EOPNOTSUPP;
+ #endif
+@@ -370,7 +407,7 @@ static int erofs_prepare_dio(struct kiocb *iocb, struct iov_iter *to)
+ {
+ 	struct inode *inode = file_inode(iocb->ki_filp);
+ 	loff_t align = iocb->ki_pos | iov_iter_count(to) |
+-		iov_iter_alignment(to);
++				   iov_iter_alignment(to);
+ 	struct block_device *bdev = inode->i_sb->s_bdev;
+ 	unsigned int blksize_mask;
+ 
+@@ -394,12 +431,13 @@ static ssize_t erofs_file_read_iter(struct kiocb *iocb, struct iov_iter *to)
+ 	if (IS_DAX(iocb->ki_filp->f_mapping->host))
+ 		return dax_iomap_rw(iocb, to, &erofs_iomap_ops);
+ #endif
+-	if (iocb->ki_flags & IOCB_DIRECT) {
++	if (iocb->ki_flags & IOCB_DIRECT)
++	{
+ 		int err = erofs_prepare_dio(iocb, to);
+ 
+ 		if (!err)
+ 			return iomap_dio_rw(iocb, to, &erofs_iomap_ops,
+-					    NULL, 0, NULL, 0);
++								NULL, 0, NULL, 0);
+ 		if (err < 0)
+ 			return err;
+ 	}
+@@ -416,7 +454,7 @@ const struct address_space_operations erofs_raw_access_aops = {
+ 
+ #ifdef CONFIG_FS_DAX
+ static vm_fault_t erofs_dax_huge_fault(struct vm_fault *vmf,
+-		enum page_entry_size pe_size)
++									   enum page_entry_size pe_size)
+ {
+ 	return dax_iomap_fault(vmf, pe_size, NULL, NULL, &erofs_iomap_ops);
+ }
+@@ -427,8 +465,8 @@ static vm_fault_t erofs_dax_fault(struct vm_fault *vmf)
+ }
+ 
+ static const struct vm_operations_struct erofs_dax_vm_ops = {
+-	.fault		= erofs_dax_fault,
+-	.huge_fault	= erofs_dax_huge_fault,
++	.fault = erofs_dax_fault,
++	.huge_fault = erofs_dax_huge_fault,
+ };
+ 
+ static int erofs_file_mmap(struct file *file, struct vm_area_struct *vma)
+@@ -444,12 +482,12 @@ static int erofs_file_mmap(struct file *file, struct vm_area_struct *vma)
+ 	return 0;
+ }
+ #else
+-#define erofs_file_mmap	generic_file_readonly_mmap
++#define erofs_file_mmap generic_file_readonly_mmap
+ #endif
+ 
+ const struct file_operations erofs_file_fops = {
+-	.llseek		= generic_file_llseek,
+-	.read_iter	= erofs_file_read_iter,
+-	.mmap		= erofs_file_mmap,
+-	.splice_read	= generic_file_splice_read,
++	.llseek = generic_file_llseek,
++	.read_iter = erofs_file_read_iter,
++	.mmap = erofs_file_mmap,
++	.splice_read = generic_file_splice_read,
+ };
+diff --git a/fs/erofs/inode.c b/fs/erofs/inode.c
+index 16cf9a283..524000b45 100644
+--- a/fs/erofs/inode.c
++++ b/fs/erofs/inode.c
+@@ -6,10 +6,14 @@
+  */
+ #include "xattr.h"
+ 
++#include <linux/uio.h>
+ #include <trace/events/erofs.h>
+ 
++const struct file_operations rafs_v6_file_ro_fops;
++const struct address_space_operations rafs_v6_aops;
++
+ static void *erofs_read_inode(struct erofs_buf *buf,
+-			      struct inode *inode, unsigned int *ofs)
++							  struct inode *inode, unsigned int *ofs)
+ {
+ 	struct super_block *sb = inode->i_sb;
+ 	struct erofs_sb_info *sbi = EROFS_SB(sb);
+@@ -27,54 +31,63 @@ static void *erofs_read_inode(struct erofs_buf *buf,
+ 	*ofs = erofs_blkoff(inode_loc);
+ 
+ 	erofs_dbg("%s, reading inode nid %llu at %u of blkaddr %u",
+-		  __func__, vi->nid, *ofs, blkaddr);
++			  __func__, vi->nid, *ofs, blkaddr);
+ 
+ 	kaddr = erofs_read_metabuf(buf, sb, blkaddr, EROFS_KMAP);
+-	if (IS_ERR(kaddr)) {
++	if (IS_ERR(kaddr))
++	{
+ 		erofs_err(sb, "failed to get inode (nid: %llu) page, err %ld",
+-			  vi->nid, PTR_ERR(kaddr));
++				  vi->nid, PTR_ERR(kaddr));
+ 		return kaddr;
+ 	}
+ 
+ 	dic = kaddr + *ofs;
+ 	ifmt = le16_to_cpu(dic->i_format);
+ 
+-	if (ifmt & ~EROFS_I_ALL) {
++	if (ifmt & ~EROFS_I_ALL)
++	{
+ 		erofs_err(inode->i_sb, "unsupported i_format %u of nid %llu",
+-			  ifmt, vi->nid);
++				  ifmt, vi->nid);
+ 		err = -EOPNOTSUPP;
+ 		goto err_out;
+ 	}
+ 
+ 	vi->datalayout = erofs_inode_datalayout(ifmt);
+-	if (vi->datalayout >= EROFS_INODE_DATALAYOUT_MAX) {
++	if (vi->datalayout >= EROFS_INODE_DATALAYOUT_MAX)
++	{
+ 		erofs_err(inode->i_sb, "unsupported datalayout %u of nid %llu",
+-			  vi->datalayout, vi->nid);
++				  vi->datalayout, vi->nid);
+ 		err = -EOPNOTSUPP;
+ 		goto err_out;
+ 	}
+ 
+-	switch (erofs_inode_version(ifmt)) {
++	switch (erofs_inode_version(ifmt))
++	{
+ 	case EROFS_INODE_LAYOUT_EXTENDED:
+ 		vi->inode_isize = sizeof(struct erofs_inode_extended);
+ 		/* check if the extended inode acrosses block boundary */
+-		if (*ofs + vi->inode_isize <= EROFS_BLKSIZ) {
++		if (*ofs + vi->inode_isize <= EROFS_BLKSIZ)
++		{
+ 			*ofs += vi->inode_isize;
+ 			die = (struct erofs_inode_extended *)dic;
+-		} else {
++		}
++		else
++		{
+ 			const unsigned int gotten = EROFS_BLKSIZ - *ofs;
+ 
+ 			copied = kmalloc(vi->inode_isize, GFP_NOFS);
+-			if (!copied) {
++			if (!copied)
++			{
+ 				err = -ENOMEM;
+ 				goto err_out;
+ 			}
+ 			memcpy(copied, dic, gotten);
+ 			kaddr = erofs_read_metabuf(buf, sb, blkaddr + 1,
+-						   EROFS_KMAP);
+-			if (IS_ERR(kaddr)) {
++									   EROFS_KMAP);
++			if (IS_ERR(kaddr))
++			{
+ 				erofs_err(sb, "failed to get inode payload block (nid: %llu), err %ld",
+-					  vi->nid, PTR_ERR(kaddr));
++						  vi->nid, PTR_ERR(kaddr));
+ 				kfree(copied);
+ 				return kaddr;
+ 			}
+@@ -85,7 +98,8 @@ static void *erofs_read_inode(struct erofs_buf *buf,
+ 		vi->xattr_isize = erofs_xattr_ibody_size(die->i_xattr_icount);
+ 
+ 		inode->i_mode = le16_to_cpu(die->i_mode);
+-		switch (inode->i_mode & S_IFMT) {
++		switch (inode->i_mode & S_IFMT)
++		{
+ 		case S_IFREG:
+ 		case S_IFDIR:
+ 		case S_IFLNK:
+@@ -128,7 +142,8 @@ static void *erofs_read_inode(struct erofs_buf *buf,
+ 		vi->xattr_isize = erofs_xattr_ibody_size(dic->i_xattr_icount);
+ 
+ 		inode->i_mode = le16_to_cpu(dic->i_mode);
+-		switch (inode->i_mode & S_IFMT) {
++		switch (inode->i_mode & S_IFMT)
++		{
+ 		case S_IFREG:
+ 		case S_IFDIR:
+ 		case S_IFLNK:
+@@ -162,22 +177,24 @@ static void *erofs_read_inode(struct erofs_buf *buf,
+ 		break;
+ 	default:
+ 		erofs_err(inode->i_sb,
+-			  "unsupported on-disk inode version %u of nid %llu",
+-			  erofs_inode_version(ifmt), vi->nid);
++				  "unsupported on-disk inode version %u of nid %llu",
++				  erofs_inode_version(ifmt), vi->nid);
+ 		err = -EOPNOTSUPP;
+ 		goto err_out;
+ 	}
+ 
+-	if (vi->datalayout == EROFS_INODE_CHUNK_BASED) {
+-		if (vi->chunkformat & ~EROFS_CHUNK_FORMAT_ALL) {
++	if (vi->datalayout == EROFS_INODE_CHUNK_BASED)
++	{
++		if (vi->chunkformat & ~EROFS_CHUNK_FORMAT_ALL)
++		{
+ 			erofs_err(inode->i_sb,
+-				  "unsupported chunk format %x of nid %llu",
+-				  vi->chunkformat, vi->nid);
++					  "unsupported chunk format %x of nid %llu",
++					  vi->chunkformat, vi->nid);
+ 			err = -EOPNOTSUPP;
+ 			goto err_out;
+ 		}
+ 		vi->chunkbits = LOG_BLOCK_SIZE +
+-			(vi->chunkformat & EROFS_CHUNK_FORMAT_BLKBITS_MASK);
++						(vi->chunkformat & EROFS_CHUNK_FORMAT_BLKBITS_MASK);
+ 	}
+ 	inode->i_mtime.tv_sec = inode->i_ctime.tv_sec;
+ 	inode->i_atime.tv_sec = inode->i_ctime.tv_sec;
+@@ -186,7 +203,7 @@ static void *erofs_read_inode(struct erofs_buf *buf,
+ 
+ 	inode->i_flags &= ~S_DAX;
+ 	if (test_opt(&sbi->opt, DAX_ALWAYS) && S_ISREG(inode->i_mode) &&
+-	    vi->datalayout == EROFS_INODE_FLAT_PLAIN)
++		vi->datalayout == EROFS_INODE_FLAT_PLAIN)
+ 		inode->i_flags |= S_DAX;
+ 	if (!nblks)
+ 		/* measure inode.i_blocks as generic filesystems */
+@@ -197,7 +214,7 @@ static void *erofs_read_inode(struct erofs_buf *buf,
+ 
+ bogusimode:
+ 	erofs_err(inode->i_sb, "bogus i_mode (%o) @ nid %llu",
+-		  inode->i_mode, vi->nid);
++			  inode->i_mode, vi->nid);
+ 	err = -EFSCORRUPTED;
+ err_out:
+ 	DBG_BUGON(1);
+@@ -207,14 +224,15 @@ err_out:
+ }
+ 
+ static int erofs_fill_symlink(struct inode *inode, void *kaddr,
+-			      unsigned int m_pofs)
++							  unsigned int m_pofs)
+ {
+ 	struct erofs_inode *vi = EROFS_I(inode);
+ 	char *lnk;
+ 
+ 	/* if it cannot be handled with fast symlink scheme */
+ 	if (vi->datalayout != EROFS_INODE_FLAT_INLINE ||
+-	    inode->i_size >= EROFS_BLKSIZ || inode->i_size < 0) {
++		inode->i_size >= EROFS_BLKSIZ || inode->i_size < 0)
++	{
+ 		inode->i_op = &erofs_symlink_iops;
+ 		return 0;
+ 	}
+@@ -225,11 +243,12 @@ static int erofs_fill_symlink(struct inode *inode, void *kaddr,
+ 
+ 	m_pofs += vi->xattr_isize;
+ 	/* inline symlink data shouldn't cross block boundary */
+-	if (m_pofs + inode->i_size > EROFS_BLKSIZ) {
++	if (m_pofs + inode->i_size > EROFS_BLKSIZ)
++	{
+ 		kfree(lnk);
+ 		erofs_err(inode->i_sb,
+-			  "inline data cross block boundary @ nid %llu",
+-			  vi->nid);
++				  "inline data cross block boundary @ nid %llu",
++				  vi->nid);
+ 		DBG_BUGON(1);
+ 		return -EFSCORRUPTED;
+ 	}
+@@ -245,6 +264,8 @@ static int erofs_fill_inode(struct inode *inode, int isdir)
+ {
+ 	struct erofs_inode *vi = EROFS_I(inode);
+ 	struct erofs_buf buf = __EROFS_BUF_INITIALIZER;
++	struct super_block *sb = inode->i_sb;
++	struct erofs_sb_info *sbi = EROFS_SB(sb);
+ 	void *kaddr;
+ 	unsigned int ofs;
+ 	int err = 0;
+@@ -257,13 +278,21 @@ static int erofs_fill_inode(struct inode *inode, int isdir)
+ 		return PTR_ERR(kaddr);
+ 
+ 	/* setup the new inode */
+-	switch (inode->i_mode & S_IFMT) {
++	switch (inode->i_mode & S_IFMT)
++	{
+ 	case S_IFREG:
+ 		inode->i_op = &erofs_generic_iops;
+ 		if (erofs_inode_is_data_compressed(vi->datalayout))
++		{
+ 			inode->i_fop = &generic_ro_fops;
++		}
+ 		else
+-			inode->i_fop = &erofs_file_fops;
++		{
++			if (sbi->bootstrap)
++				inode->i_fop = &rafs_v6_file_ro_fops;
++			else
++				inode->i_fop = &erofs_file_fops;
++		}
+ 		break;
+ 	case S_IFDIR:
+ 		inode->i_op = &erofs_dir_iops;
+@@ -287,18 +316,24 @@ static int erofs_fill_inode(struct inode *inode, int isdir)
+ 		goto out_unlock;
+ 	}
+ 
+-	if (erofs_inode_is_data_compressed(vi->datalayout)) {
++	if (erofs_inode_is_data_compressed(vi->datalayout))
++	{
+ 		if (!erofs_is_fscache_mode(inode->i_sb))
+ 			err = z_erofs_fill_inode(inode);
+ 		else
+ 			err = -EOPNOTSUPP;
+ 		goto out_unlock;
+ 	}
+-	inode->i_mapping->a_ops = &erofs_raw_access_aops;
++	if (sbi->bootstrap && !S_ISREG(inode->i_mode)) {
++		inode_nohighmem(inode);
++		inode->i_mapping->a_ops = &rafs_v6_aops;
++	} else if (inode->i_sb->s_bdev) {
++		inode->i_mapping->a_ops = &erofs_raw_access_aops;
+ #ifdef CONFIG_EROFS_FS_ONDEMAND
+-	if (erofs_is_fscache_mode(inode->i_sb))
++	} else if (erofs_is_fscache_mode(inode->i_sb)) {
+ 		inode->i_mapping->a_ops = &erofs_fscache_access_aops;
+ #endif
++	}
+ 
+ out_unlock:
+ 	erofs_put_metabuf(&buf);
+@@ -325,24 +360,25 @@ static int erofs_iget_set_actor(struct inode *inode, void *opaque)
+ }
+ 
+ static inline struct inode *erofs_iget_locked(struct super_block *sb,
+-					      erofs_nid_t nid)
++											  erofs_nid_t nid)
+ {
+ 	const unsigned long hashval = erofs_inode_hash(nid);
+ 
+ 	return iget5_locked(sb, hashval, erofs_ilookup_test_actor,
+-		erofs_iget_set_actor, &nid);
++						erofs_iget_set_actor, &nid);
+ }
+ 
+ struct inode *erofs_iget(struct super_block *sb,
+-			 erofs_nid_t nid,
+-			 bool isdir)
++						 erofs_nid_t nid,
++						 bool isdir)
+ {
+ 	struct inode *inode = erofs_iget_locked(sb, nid);
+ 
+ 	if (!inode)
+ 		return ERR_PTR(-ENOMEM);
+ 
+-	if (inode->i_state & I_NEW) {
++	if (inode->i_state & I_NEW)
++	{
+ 		int err;
+ 		struct erofs_inode *vi = EROFS_I(inode);
+ 
+@@ -351,7 +387,8 @@ struct inode *erofs_iget(struct super_block *sb,
+ 		err = erofs_fill_inode(inode, isdir);
+ 		if (!err)
+ 			unlock_new_inode(inode);
+-		else {
++		else
++		{
+ 			iget_failed(inode);
+ 			inode = ERR_PTR(err);
+ 		}
+@@ -360,8 +397,8 @@ struct inode *erofs_iget(struct super_block *sb,
+ }
+ 
+ int erofs_getattr(struct user_namespace *mnt_userns, const struct path *path,
+-		  struct kstat *stat, u32 request_mask,
+-		  unsigned int query_flags)
++				  struct kstat *stat, u32 request_mask,
++				  unsigned int query_flags)
+ {
+ 	struct inode *const inode = d_inode(path->dentry);
+ 
+@@ -370,7 +407,7 @@ int erofs_getattr(struct user_namespace *mnt_userns, const struct path *path,
+ 
+ 	stat->attributes |= STATX_ATTR_IMMUTABLE;
+ 	stat->attributes_mask |= (STATX_ATTR_COMPRESSED |
+-				  STATX_ATTR_IMMUTABLE);
++							  STATX_ATTR_IMMUTABLE);
+ 
+ 	generic_fillattr(mnt_userns, inode, stat);
+ 	return 0;
+@@ -396,3 +433,193 @@ const struct inode_operations erofs_fast_symlink_iops = {
+ 	.listxattr = erofs_listxattr,
+ 	.get_acl = erofs_get_acl,
+ };
++
++static ssize_t rafs_v6_read_chunk(struct super_block *sb,
++				  struct iov_iter *to, u64 off, u64 size,
++				  unsigned int device_id)
++{
++	struct iov_iter titer;
++	ssize_t read = 0;
++
++	do {
++		struct iovec iovec = iov_iter_iovec(to);
++		ssize_t ret;
++
++		if (iovec.iov_len > size)
++			iovec.iov_len = size;
++
++		pr_debug("%s: off %llu size %llu blob_index %u\n", __func__, off,
++			 size, device_id);
++
++		/* TODO async */
++		iov_iter_init(&titer, READ, &iovec, 1, iovec.iov_len);
++		ret = vfs_iter_read(EROFS_SB(sb)->bootstrap, &titer, &off, 0);
++		if (ret < 0) {
++			pr_err("%s: failed to read blob ret %ld\n", __func__, ret);
++			return ret;
++		} else if (ret < iovec.iov_len) {
++			return read;
++		}
++		iov_iter_advance(to, ret);
++		read += ret;
++	} while (read < size);
++
++	return read;
++}
++
++static ssize_t rafs_v6_file_read_iter(struct kiocb *iocb, struct iov_iter *to)
++{
++	struct inode *inode = file_inode(iocb->ki_filp);
++	struct erofs_map_blocks map = { 0 };
++	ssize_t bytes = 0;
++	u64 total = min_t(u64, iov_iter_count(to),
++			  inode->i_size - iocb->ki_pos);
++
++	while (total) {
++		erofs_off_t pos = iocb->ki_pos;
++		u64 delta, size;
++		ssize_t read;
++
++		if (map.m_la < pos || map.m_la + map.m_llen >= pos) {
++			int err;
++
++			map.m_la = pos;
++			err = erofs_map_blocks(inode, &map);
++			if (err)
++				return err;
++			if (map.m_la >= inode->i_size)
++				break;
++		}
++		delta = pos - map.m_la;
++		size = min_t(u64, map.m_llen - delta, total);
++		read = rafs_v6_read_chunk(inode->i_sb, to, map.m_pa + delta,
++					  size, map.m_deviceid);
++		if (read < size) {
++			erofs_err(inode->i_sb,
++				  "short read %ld pos %llu size %llu @ nid %llu",
++				  read, pos, size, EROFS_I(inode)->nid);
++			return -EIO;
++		}
++		iocb->ki_pos += read;
++		bytes += read;
++		total -= read;
++	}
++	return bytes;
++}
++
++static vm_fault_t rafs_v6_filemap_fault(struct vm_fault *vmf)
++{
++	struct vm_area_struct *vma = vmf->vma;
++	struct inode *inode = file_inode(vma->vm_file);
++	pgoff_t npages, orig_pgoff = vmf->pgoff;
++	erofs_off_t pos;
++	struct erofs_map_blocks map = {0};
++	struct vm_area_struct lower_vma;
++	int err;
++	vm_fault_t ret;
++
++	npages = DIV_ROUND_UP(i_size_read(inode), PAGE_SIZE);
++	if (unlikely(orig_pgoff >= npages))
++		return VM_FAULT_SIGBUS;
++
++	memcpy(&lower_vma, vmf->vma, sizeof(lower_vma));
++
++	/* TODO: check if chunk is available for us to read. */
++	map.m_la = orig_pgoff << PAGE_SHIFT;
++	pos = map.m_la;
++	err = erofs_map_blocks(inode, &map);
++	if (err)
++		return vmf_error(err);
++
++	lower_vma.vm_file = EROFS_I_SB(inode)->bootstrap;
++	vmf->pgoff = (map.m_pa + (pos - map.m_la)) >> PAGE_SHIFT;
++	vmf->vma = &lower_vma; /* override vma temporarily */
++	ret = EROFS_I(inode)->lower_vm_ops->fault(vmf);
++	vmf->vma = vma;
++	vmf->pgoff = orig_pgoff;
++	return ret;
++}
++
++static const struct vm_operations_struct rafs_v6_vm_ops = {
++	.fault	= rafs_v6_filemap_fault,
++};
++
++static int rafs_v6_file_mmap(struct file *file, struct vm_area_struct *vma)
++{
++	struct inode *inode = file_inode(file);
++	struct erofs_inode *vi = EROFS_I(inode);
++	const struct vm_operations_struct *lower_vm_ops;
++	int ret;
++
++	ret = call_mmap(EROFS_I_SB(inode)->bootstrap, vma);
++	if (ret) {
++		pr_err("%s: call_mmap failed ret %d\n", __func__, ret);
++		return ret;
++	}
++
++	/* set fs's vm_ops which is used in fault(). */
++	lower_vm_ops = vma->vm_ops;
++
++	if (vi->lower_vm_ops && vi->lower_vm_ops != lower_vm_ops) {
++		WARN_ON_ONCE(1);
++		return -EOPNOTSUPP;
++	}
++	/* fault() must exist in order to proceed. */
++	if (!lower_vm_ops || !lower_vm_ops->fault) {
++		WARN_ON_ONCE(1);
++		return -EOPNOTSUPP;
++	}
++	vi->lower_vm_ops = lower_vm_ops;
++	vma->vm_flags &= ~VM_HUGEPAGE;	/* dont use huge page */
++	vma->vm_ops = &rafs_v6_vm_ops;
++	return 0;
++}
++
++const struct file_operations rafs_v6_file_ro_fops = {
++	.llseek		= generic_file_llseek,
++	.read_iter	= rafs_v6_file_read_iter,
++	.mmap		= rafs_v6_file_mmap,
++//	.mmap		= generic_file_readonly_mmap,
++	.splice_read	= generic_file_splice_read,
++};
++
++static int rafs_v6_readpage(struct file *file, struct page *page) {
++	struct kvec iov = {
++		.iov_base	= page_address(page),
++	};
++	struct inode *inode = page->mapping->host;
++	struct super_block *sb = inode->i_sb;
++	erofs_off_t pos = page->index << PAGE_SHIFT;
++	struct erofs_map_blocks map = { .m_la = pos };
++	struct kiocb kiocb;
++	struct iov_iter iter;
++	int err;
++
++	err = erofs_map_blocks(inode, &map);
++	if (err)
++		goto err_out;
++
++	iov.iov_len = min_t(u64, PAGE_SIZE, map.m_plen - (pos - map.m_la));
++	init_sync_kiocb(&kiocb, EROFS_SB(sb)->bootstrap);
++	kiocb.ki_pos = map.m_pa + (pos - map.m_la);
++//	if (!(kiocb.ki_pos & ~PAGE_MASK) && iov.iov_len == PAGE_SIZE)
++//		kiocb.ki_flags |= IOCB_DIRECT;
++	iov_iter_kvec(&iter, READ, &iov, 1, iov.iov_len);
++	err = kiocb.ki_filp->f_op->read_iter(&kiocb, &iter);
++	if (err < iov.iov_len)
++		goto err_out;
++	if (iov.iov_len < PAGE_SIZE)
++		memset(iov.iov_base + iov.iov_len, 0,
++		       PAGE_SIZE - iov.iov_len);
++	SetPageUptodate(page);
++	unlock_page(page);
++	return 0;
++err_out:
++	SetPageError(page);
++	unlock_page(page);
++	return err;
++}
++
++const struct address_space_operations rafs_v6_aops = {
++	.readpage = rafs_v6_readpage,
++};
+\ No newline at end of file
+diff --git a/fs/erofs/internal.h b/fs/erofs/internal.h
+index a01cc8279..0710c3d71 100644
+--- a/fs/erofs/internal.h
++++ b/fs/erofs/internal.h
+@@ -24,23 +24,23 @@
+ #define pr_fmt(fmt) "erofs: " fmt
+ 
+ __printf(3, 4) void _erofs_err(struct super_block *sb,
+-			       const char *function, const char *fmt, ...);
+-#define erofs_err(sb, fmt, ...)	\
++							   const char *function, const char *fmt, ...);
++#define erofs_err(sb, fmt, ...) \
+ 	_erofs_err(sb, __func__, fmt "\n", ##__VA_ARGS__)
+ __printf(3, 4) void _erofs_info(struct super_block *sb,
+-			       const char *function, const char *fmt, ...);
++								const char *function, const char *fmt, ...);
+ #define erofs_info(sb, fmt, ...) \
+ 	_erofs_info(sb, __func__, fmt "\n", ##__VA_ARGS__)
+ #ifdef CONFIG_EROFS_FS_DEBUG
+-#define erofs_dbg(x, ...)       pr_debug(x "\n", ##__VA_ARGS__)
+-#define DBG_BUGON               BUG_ON
++#define erofs_dbg(x, ...) pr_debug(x "\n", ##__VA_ARGS__)
++#define DBG_BUGON BUG_ON
+ #else
+-#define erofs_dbg(x, ...)       ((void)0)
+-#define DBG_BUGON(x)            ((void)(x))
+-#endif	/* !CONFIG_EROFS_FS_DEBUG */
++#define erofs_dbg(x, ...) ((void)0)
++#define DBG_BUGON(x) ((void)(x))
++#endif /* !CONFIG_EROFS_FS_DEBUG */
+ 
+ /* EROFS_SUPER_MAGIC_V1 to represent the whole file system */
+-#define EROFS_SUPER_MAGIC   EROFS_SUPER_MAGIC_V1
++#define EROFS_SUPER_MAGIC EROFS_SUPER_MAGIC_V1
+ 
+ typedef u64 erofs_nid_t;
+ typedef u64 erofs_off_t;
+@@ -88,6 +88,7 @@ struct erofs_dev_context {
+ struct erofs_fs_context {
+ 	struct erofs_mount_opts opt;
+ 	struct erofs_dev_context *devs;
++	char *bootstrap_path;
+ };
+ 
+ /* all filesystem-wide lz4 configurations */
+@@ -104,7 +105,7 @@ struct erofs_fscache {
+ };
+ 
+ struct erofs_sb_info {
+-	struct erofs_mount_opts opt;	/* options */
++	struct erofs_mount_opts opt; /* options */
+ #ifdef CONFIG_EROFS_FS_ZIP
+ 	/* list for all registered superblocks, mainly for shrinker */
+ 	struct list_head list;
+@@ -120,7 +121,9 @@ struct erofs_sb_info {
+ 	struct inode *managed_cache;
+ 
+ 	struct erofs_sb_lz4_info lz4;
+-#endif	/* CONFIG_EROFS_FS_ZIP */
++#endif /* CONFIG_EROFS_FS_ZIP */
++	struct file *bootstrap;
++	char *bootstrap_path;
+ 	struct erofs_dev_context *devs;
+ 	struct dax_device *dax_dev;
+ 	u64 dax_part_off;
+@@ -131,12 +134,12 @@ struct erofs_sb_info {
+ #ifdef CONFIG_EROFS_FS_XATTR
+ 	u32 xattr_blkaddr;
+ #endif
+-	u16 device_id_mask;	/* valid bits of device id to be used */
++	u16 device_id_mask; /* valid bits of device id to be used */
+ 
+ 	/* inode slot unit size in bit shift */
+ 	unsigned char islotbits;
+ 
+-	u32 sb_size;			/* total superblock size */
++	u32 sb_size; /* total superblock size */
+ 	u32 build_time_nsec;
+ 	u64 build_time;
+ 
+@@ -145,13 +148,13 @@ struct erofs_sb_info {
+ 	/* used for statfs, f_files - f_favail */
+ 	u64 inos;
+ 
+-	u8 uuid[16];                    /* 128-bit uuid for volume */
+-	u8 volume_name[16];             /* volume name */
++	u8 uuid[16];		/* 128-bit uuid for volume */
++	u8 volume_name[16]; /* volume name */
+ 	u32 feature_compat;
+ 	u32 feature_incompat;
+ 
+ 	/* sysfs support */
+-	struct kobject s_kobj;		/* /sys/fs/erofs/<devname> */
++	struct kobject s_kobj; /* /sys/fs/erofs/<devname> */
+ 	struct completion s_kobj_unregister;
+ 
+ 	/* fscache support */
+@@ -163,17 +166,16 @@ struct erofs_sb_info {
+ #define EROFS_I_SB(inode) ((struct erofs_sb_info *)(inode)->i_sb->s_fs_info)
+ 
+ /* Mount flags set via mount options or defaults */
+-#define EROFS_MOUNT_XATTR_USER		0x00000010
+-#define EROFS_MOUNT_POSIX_ACL		0x00000020
+-#define EROFS_MOUNT_DAX_ALWAYS		0x00000040
+-#define EROFS_MOUNT_DAX_NEVER		0x00000080
++#define EROFS_MOUNT_XATTR_USER 0x00000010
++#define EROFS_MOUNT_POSIX_ACL 0x00000020
++#define EROFS_MOUNT_DAX_ALWAYS 0x00000040
++#define EROFS_MOUNT_DAX_NEVER 0x00000080
+ 
+-#define clear_opt(opt, option)	((opt)->mount_opt &= ~EROFS_MOUNT_##option)
+-#define set_opt(opt, option)	((opt)->mount_opt |= EROFS_MOUNT_##option)
+-#define test_opt(opt, option)	((opt)->mount_opt & EROFS_MOUNT_##option)
++#define clear_opt(opt, option) ((opt)->mount_opt &= ~EROFS_MOUNT_##option)
++#define set_opt(opt, option) ((opt)->mount_opt |= EROFS_MOUNT_##option)
++#define test_opt(opt, option) ((opt)->mount_opt & EROFS_MOUNT_##option)
+ 
+-static inline bool erofs_is_fscache_mode(struct super_block *sb)
+-{
++static inline bool erofs_is_fscache_mode(struct super_block *sb) {
+ 	return IS_ENABLED(CONFIG_EROFS_FS_ONDEMAND) && !sb->s_bdev;
+ }
+ 
+@@ -184,7 +186,7 @@ enum {
+ };
+ 
+ #ifdef CONFIG_EROFS_FS_ZIP
+-#define EROFS_LOCKED_MAGIC     (INT_MIN | 0xE0F510CCL)
++#define EROFS_LOCKED_MAGIC (INT_MIN | 0xE0F510CCL)
+ 
+ /* basic unit of the workstation of a super_block */
+ struct erofs_workgroup {
+@@ -196,8 +198,7 @@ struct erofs_workgroup {
+ };
+ 
+ static inline bool erofs_workgroup_try_to_freeze(struct erofs_workgroup *grp,
+-						 int val)
+-{
++												 int val) {
+ 	preempt_disable();
+ 	if (val != atomic_cmpxchg(&grp->refcount, val, EROFS_LOCKED_MAGIC)) {
+ 		preempt_enable();
+@@ -207,8 +208,7 @@ static inline bool erofs_workgroup_try_to_freeze(struct erofs_workgroup *grp,
+ }
+ 
+ static inline void erofs_workgroup_unfreeze(struct erofs_workgroup *grp,
+-					    int orig_val)
+-{
++											int orig_val) {
+ 	/*
+ 	 * other observers should notice all modifications
+ 	 * in the freezing period.
+@@ -218,32 +218,31 @@ static inline void erofs_workgroup_unfreeze(struct erofs_workgroup *grp,
+ 	preempt_enable();
+ }
+ 
+-static inline int erofs_wait_on_workgroup_freezed(struct erofs_workgroup *grp)
+-{
++static inline int erofs_wait_on_workgroup_freezed(struct erofs_workgroup *grp) {
+ 	return atomic_cond_read_relaxed(&grp->refcount,
+-					VAL != EROFS_LOCKED_MAGIC);
++									VAL != EROFS_LOCKED_MAGIC);
+ }
+-#endif	/* !CONFIG_EROFS_FS_ZIP */
++#endif /* !CONFIG_EROFS_FS_ZIP */
+ 
+ /* we strictly follow PAGE_SIZE and no buffer head yet */
+-#define LOG_BLOCK_SIZE		PAGE_SHIFT
++#define LOG_BLOCK_SIZE PAGE_SHIFT
+ 
+ #undef LOG_SECTORS_PER_BLOCK
+-#define LOG_SECTORS_PER_BLOCK	(PAGE_SHIFT - 9)
++#define LOG_SECTORS_PER_BLOCK (PAGE_SHIFT - 9)
+ 
+ #undef SECTORS_PER_BLOCK
+-#define SECTORS_PER_BLOCK	(1 << SECTORS_PER_BLOCK)
++#define SECTORS_PER_BLOCK (1 << SECTORS_PER_BLOCK)
+ 
+-#define EROFS_BLKSIZ		(1 << LOG_BLOCK_SIZE)
++#define EROFS_BLKSIZ (1 << LOG_BLOCK_SIZE)
+ 
+ #if (EROFS_BLKSIZ % 4096 || !EROFS_BLKSIZ)
+ #error erofs cannot be used in this platform
+ #endif
+ 
+ enum erofs_kmap_type {
+-	EROFS_NO_KMAP,		/* don't map the buffer */
+-	EROFS_KMAP,		/* use kmap() to map the buffer */
+-	EROFS_KMAP_ATOMIC,	/* use kmap_atomic() to map the buffer */
++	EROFS_NO_KMAP,	   /* don't map the buffer */
++	EROFS_KMAP,		   /* use kmap() to map the buffer */
++	EROFS_KMAP_ATOMIC, /* use kmap_atomic() to map the buffer */
+ };
+ 
+ struct erofs_buf {
+@@ -251,24 +250,23 @@ struct erofs_buf {
+ 	void *base;
+ 	enum erofs_kmap_type kmap_type;
+ };
+-#define __EROFS_BUF_INITIALIZER	((struct erofs_buf){ .page = NULL })
++#define __EROFS_BUF_INITIALIZER ((struct erofs_buf){.page = NULL})
+ 
+-#define ROOT_NID(sb)		((sb)->root_nid)
++#define ROOT_NID(sb) ((sb)->root_nid)
+ 
+-#define erofs_blknr(addr)       ((addr) / EROFS_BLKSIZ)
+-#define erofs_blkoff(addr)      ((addr) % EROFS_BLKSIZ)
+-#define blknr_to_addr(nr)       ((erofs_off_t)(nr) * EROFS_BLKSIZ)
++#define erofs_blknr(addr) ((addr) / EROFS_BLKSIZ)
++#define erofs_blkoff(addr) ((addr) % EROFS_BLKSIZ)
++#define blknr_to_addr(nr) ((erofs_off_t)(nr)*EROFS_BLKSIZ)
+ 
+-static inline erofs_off_t iloc(struct erofs_sb_info *sbi, erofs_nid_t nid)
+-{
++static inline erofs_off_t iloc(struct erofs_sb_info *sbi, erofs_nid_t nid) {
+ 	return blknr_to_addr(sbi->meta_blkaddr) + (nid << sbi->islotbits);
+ }
+ 
+-#define EROFS_FEATURE_FUNCS(name, compat, feature) \
+-static inline bool erofs_sb_has_##name(struct erofs_sb_info *sbi) \
+-{ \
+-	return sbi->feature_##compat & EROFS_FEATURE_##feature; \
+-}
++#define EROFS_FEATURE_FUNCS(name, compat, feature)                    \
++	static inline bool erofs_sb_has_##name(struct erofs_sb_info *sbi) \
++	{                                                                 \
++		return sbi->feature_##compat & EROFS_FEATURE_##feature;       \
++	}
+ 
+ EROFS_FEATURE_FUNCS(zero_padding, incompat, INCOMPAT_ZERO_PADDING)
+ EROFS_FEATURE_FUNCS(compr_cfgs, incompat, INCOMPAT_COMPR_CFGS)
+@@ -280,12 +278,12 @@ EROFS_FEATURE_FUNCS(ztailpacking, incompat, INCOMPAT_ZTAILPACKING)
+ EROFS_FEATURE_FUNCS(sb_chksum, compat, COMPAT_SB_CHKSUM)
+ 
+ /* atomic flag definitions */
+-#define EROFS_I_EA_INITED_BIT	0
+-#define EROFS_I_Z_INITED_BIT	1
++#define EROFS_I_EA_INITED_BIT 0
++#define EROFS_I_Z_INITED_BIT 1
+ 
+ /* bitlock definitions (arranged in reverse order) */
+-#define EROFS_I_BL_XATTR_BIT	(BITS_PER_LONG - 1)
+-#define EROFS_I_BL_Z_BIT	(BITS_PER_LONG - 2)
++#define EROFS_I_BL_XATTR_BIT (BITS_PER_LONG - 1)
++#define EROFS_I_BL_Z_BIT (BITS_PER_LONG - 2)
+ 
+ struct erofs_inode {
+ 	erofs_nid_t nid;
+@@ -299,68 +297,67 @@ struct erofs_inode {
+ 
+ 	unsigned int xattr_shared_count;
+ 	unsigned int *xattr_shared_xattrs;
+-
+-	union {
++	const struct vm_operations_struct *lower_vm_ops;
++	union
++	{
+ 		erofs_blk_t raw_blkaddr;
+-		struct {
+-			unsigned short	chunkformat;
+-			unsigned char	chunkbits;
++		struct
++		{
++			unsigned short chunkformat;
++			unsigned char chunkbits;
+ 		};
+ #ifdef CONFIG_EROFS_FS_ZIP
+-		struct {
++		struct
++		{
+ 			unsigned short z_advise;
+-			unsigned char  z_algorithmtype[2];
+-			unsigned char  z_logical_clusterbits;
+-			unsigned long  z_tailextent_headlcn;
+-			erofs_off_t    z_idataoff;
++			unsigned char z_algorithmtype[2];
++			unsigned char z_logical_clusterbits;
++			unsigned long z_tailextent_headlcn;
++			erofs_off_t z_idataoff;
+ 			unsigned short z_idata_size;
+ 		};
+-#endif	/* CONFIG_EROFS_FS_ZIP */
++#endif /* CONFIG_EROFS_FS_ZIP */
+ 	};
+ 	/* the corresponding vfs inode */
+ 	struct inode vfs_inode;
+ };
+ 
+-#define EROFS_I(ptr)	\
++#define EROFS_I(ptr) \
+ 	container_of(ptr, struct erofs_inode, vfs_inode)
+ 
+-static inline unsigned long erofs_inode_datablocks(struct inode *inode)
+-{
++static inline unsigned long erofs_inode_datablocks(struct inode *inode) {
+ 	/* since i_size cannot be changed */
+ 	return DIV_ROUND_UP(inode->i_size, EROFS_BLKSIZ);
+ }
+ 
+ static inline unsigned int erofs_bitrange(unsigned int value, unsigned int bit,
+-					  unsigned int bits)
+-{
++										  unsigned int bits) {
+ 
+ 	return (value >> bit) & ((1 << bits) - 1);
+ }
+ 
+-
+ static inline unsigned int erofs_inode_version(unsigned int value)
+ {
+ 	return erofs_bitrange(value, EROFS_I_VERSION_BIT,
+-			      EROFS_I_VERSION_BITS);
++						  EROFS_I_VERSION_BITS);
+ }
+ 
+ static inline unsigned int erofs_inode_datalayout(unsigned int value)
+ {
+ 	return erofs_bitrange(value, EROFS_I_DATALAYOUT_BIT,
+-			      EROFS_I_DATALAYOUT_BITS);
++						  EROFS_I_DATALAYOUT_BITS);
+ }
+ 
+ /*
+  * Different from grab_cache_page_nowait(), reclaiming is never triggered
+  * when allocating new pages.
+  */
+-static inline
+-struct page *erofs_grab_cache_page_nowait(struct address_space *mapping,
+-					  pgoff_t index)
++static inline struct page *erofs_grab_cache_page_nowait(struct address_space *mapping,
++														pgoff_t index)
+ {
+ 	return pagecache_get_page(mapping, index,
+-			FGP_LOCK|FGP_CREAT|FGP_NOFS|FGP_NOWAIT,
+-			readahead_gfp_mask(mapping) & ~__GFP_RECLAIM);
++							  FGP_LOCK | FGP_CREAT | FGP_NOFS | FGP_NOWAIT,
++							  readahead_gfp_mask(mapping) & ~__GFP_RECLAIM);
+ }
+ 
+ extern const struct super_operations erofs_sops;
+@@ -368,21 +365,23 @@ extern const struct super_operations erofs_sops;
+ extern const struct address_space_operations erofs_raw_access_aops;
+ extern const struct address_space_operations z_erofs_aops;
+ 
+-enum {
++enum
++{
+ 	BH_Encoded = BH_PrivateStart,
+ 	BH_FullMapped,
+ };
+ 
+ /* Has a disk mapping */
+-#define EROFS_MAP_MAPPED	(1 << BH_Mapped)
++#define EROFS_MAP_MAPPED (1 << BH_Mapped)
+ /* Located in metadata (could be copied from bd_inode) */
+-#define EROFS_MAP_META		(1 << BH_Meta)
++#define EROFS_MAP_META (1 << BH_Meta)
+ /* The extent is encoded */
+-#define EROFS_MAP_ENCODED	(1 << BH_Encoded)
++#define EROFS_MAP_ENCODED (1 << BH_Encoded)
+ /* The length of extent is full */
+-#define EROFS_MAP_FULL_MAPPED	(1 << BH_FullMapped)
++#define EROFS_MAP_FULL_MAPPED (1 << BH_FullMapped)
+ 
+-struct erofs_map_blocks {
++struct erofs_map_blocks
++{
+ 	struct erofs_buf buf;
+ 
+ 	erofs_off_t m_pa, m_la;
+@@ -394,18 +393,19 @@ struct erofs_map_blocks {
+ };
+ 
+ /* Flags used by erofs_map_blocks_flatmode() */
+-#define EROFS_GET_BLOCKS_RAW    0x0001
++#define EROFS_GET_BLOCKS_RAW 0x0001
+ /*
+  * Used to get the exact decompressed length, e.g. fiemap (consider lookback
+  * approach instead if possible since it's more metadata lightweight.)
+  */
+-#define EROFS_GET_BLOCKS_FIEMAP	0x0002
++#define EROFS_GET_BLOCKS_FIEMAP 0x0002
+ /* Used to map the whole extent if non-negligible data is requested for LZMA */
+-#define EROFS_GET_BLOCKS_READMORE	0x0004
++#define EROFS_GET_BLOCKS_READMORE 0x0004
+ /* Used to map tail extent for tailpacking inline pcluster */
+-#define EROFS_GET_BLOCKS_FINDTAIL	0x0008
++#define EROFS_GET_BLOCKS_FINDTAIL 0x0008
+ 
+-enum {
++enum
++{
+ 	Z_EROFS_COMPRESSION_SHIFTED = Z_EROFS_COMPRESSION_MAX,
+ 	Z_EROFS_COMPRESSION_RUNTIME_MAX
+ };
+@@ -416,21 +416,26 @@ extern const struct iomap_ops z_erofs_iomap_report_ops;
+ #ifdef CONFIG_EROFS_FS_ZIP
+ int z_erofs_fill_inode(struct inode *inode);
+ int z_erofs_map_blocks_iter(struct inode *inode,
+-			    struct erofs_map_blocks *map,
+-			    int flags);
++							struct erofs_map_blocks *map,
++							int flags);
+ #else
+-static inline int z_erofs_fill_inode(struct inode *inode) { return -EOPNOTSUPP; }
++static inline int z_erofs_fill_inode(struct inode *inode)
++{
++	return -EOPNOTSUPP;
++}
+ static inline int z_erofs_map_blocks_iter(struct inode *inode,
+-					  struct erofs_map_blocks *map,
+-					  int flags)
++										  struct erofs_map_blocks *map,
++										  int flags)
+ {
+ 	return -EOPNOTSUPP;
+ }
+-#endif	/* !CONFIG_EROFS_FS_ZIP */
++#endif /* !CONFIG_EROFS_FS_ZIP */
+ 
+-struct erofs_map_dev {
++struct erofs_map_dev
++{
+ 	struct erofs_fscache *m_fscache;
+ 	struct block_device *m_bdev;
++	struct file *m_fp;
+ 	struct dax_device *m_daxdev;
+ 	u64 m_dax_part_off;
+ 
+@@ -443,14 +448,14 @@ extern const struct file_operations erofs_file_fops;
+ void erofs_unmap_metabuf(struct erofs_buf *buf);
+ void erofs_put_metabuf(struct erofs_buf *buf);
+ void *erofs_bread(struct erofs_buf *buf, struct inode *inode,
+-		  erofs_blk_t blkaddr, enum erofs_kmap_type type);
++				  erofs_blk_t blkaddr, enum erofs_kmap_type type);
+ void *erofs_read_metabuf(struct erofs_buf *buf, struct super_block *sb,
+-			 erofs_blk_t blkaddr, enum erofs_kmap_type type);
++						 erofs_blk_t blkaddr, enum erofs_kmap_type type);
+ int erofs_map_dev(struct super_block *sb, struct erofs_map_dev *dev);
+ int erofs_fiemap(struct inode *inode, struct fiemap_extent_info *fieinfo,
+-		 u64 start, u64 len);
++				 u64 start, u64 len);
+ int erofs_map_blocks(struct inode *inode,
+-		     struct erofs_map_blocks *map, int flags);
++					 struct erofs_map_blocks *map, int flags);
+ 
+ /* inode.c */
+ static inline unsigned long erofs_inode_hash(erofs_nid_t nid)
+@@ -468,14 +473,14 @@ extern const struct inode_operations erofs_fast_symlink_iops;
+ 
+ struct inode *erofs_iget(struct super_block *sb, erofs_nid_t nid, bool dir);
+ int erofs_getattr(struct user_namespace *mnt_userns, const struct path *path,
+-		  struct kstat *stat, u32 request_mask,
+-		  unsigned int query_flags);
++				  struct kstat *stat, u32 request_mask,
++				  unsigned int query_flags);
+ 
+ /* namei.c */
+ extern const struct inode_operations erofs_dir_iops;
+ 
+ int erofs_namei(struct inode *dir, const struct qstr *name,
+-		erofs_nid_t *nid, unsigned int *d_type);
++				erofs_nid_t *nid, unsigned int *d_type);
+ 
+ /* dir.c */
+ extern const struct file_operations erofs_dir_fops;
+@@ -484,7 +489,8 @@ static inline void *erofs_vm_map_ram(struct page **pages, unsigned int count)
+ {
+ 	int retried = 0;
+ 
+-	while (1) {
++	while (1)
++	{
+ 		void *p = vm_map_ram(pages, count, -1);
+ 
+ 		/* retry two more times (totally 3 times) */
+@@ -511,7 +517,7 @@ void erofs_exit_sysfs(void);
+ /* utils.c / zdata.c */
+ struct page *erofs_allocpage(struct page **pagepool, gfp_t gfp);
+ static inline void erofs_pagepool_add(struct page **pagepool,
+-		struct page *page)
++									  struct page *page)
+ {
+ 	set_page_private(page, (unsigned long)*pagepool);
+ 	*pagepool = page;
+@@ -521,9 +527,9 @@ void erofs_release_pages(struct page **pagepool);
+ #ifdef CONFIG_EROFS_FS_ZIP
+ int erofs_workgroup_put(struct erofs_workgroup *grp);
+ struct erofs_workgroup *erofs_find_workgroup(struct super_block *sb,
+-					     pgoff_t index);
++											 pgoff_t index);
+ struct erofs_workgroup *erofs_insert_workgroup(struct super_block *sb,
+-					       struct erofs_workgroup *grp);
++											   struct erofs_workgroup *grp);
+ void erofs_workgroup_free_rcu(struct erofs_workgroup *grp);
+ void erofs_shrinker_register(struct super_block *sb);
+ void erofs_shrinker_unregister(struct super_block *sb);
+@@ -532,49 +538,57 @@ void erofs_exit_shrinker(void);
+ int __init z_erofs_init_zip_subsystem(void);
+ void z_erofs_exit_zip_subsystem(void);
+ int erofs_try_to_free_all_cached_pages(struct erofs_sb_info *sbi,
+-				       struct erofs_workgroup *egrp);
++									   struct erofs_workgroup *egrp);
+ int erofs_try_to_free_cached_page(struct page *page);
+ int z_erofs_load_lz4_config(struct super_block *sb,
+-			    struct erofs_super_block *dsb,
+-			    struct z_erofs_lz4_cfgs *lz4, int len);
++							struct erofs_super_block *dsb,
++							struct z_erofs_lz4_cfgs *lz4, int len);
+ #else
+-static inline void erofs_shrinker_register(struct super_block *sb) {}
++static inline void erofs_shrinker_register(struct super_block *sb)
++{
++}
+ static inline void erofs_shrinker_unregister(struct super_block *sb) {}
+ static inline int erofs_init_shrinker(void) { return 0; }
+ static inline void erofs_exit_shrinker(void) {}
+ static inline int z_erofs_init_zip_subsystem(void) { return 0; }
+ static inline void z_erofs_exit_zip_subsystem(void) {}
+ static inline int z_erofs_load_lz4_config(struct super_block *sb,
+-				  struct erofs_super_block *dsb,
+-				  struct z_erofs_lz4_cfgs *lz4, int len)
++										  struct erofs_super_block *dsb,
++										  struct z_erofs_lz4_cfgs *lz4, int len)
+ {
+-	if (lz4 || dsb->u1.lz4_max_distance) {
++	if (lz4 || dsb->u1.lz4_max_distance)
++	{
+ 		erofs_err(sb, "lz4 algorithm isn't enabled");
+ 		return -EINVAL;
+ 	}
+ 	return 0;
+ }
+-#endif	/* !CONFIG_EROFS_FS_ZIP */
++#endif /* !CONFIG_EROFS_FS_ZIP */
+ 
+ #ifdef CONFIG_EROFS_FS_ZIP_LZMA
+ int z_erofs_lzma_init(void);
+ void z_erofs_lzma_exit(void);
+ int z_erofs_load_lzma_config(struct super_block *sb,
+-			     struct erofs_super_block *dsb,
+-			     struct z_erofs_lzma_cfgs *lzma, int size);
++							 struct erofs_super_block *dsb,
++							 struct z_erofs_lzma_cfgs *lzma, int size);
+ #else
+-static inline int z_erofs_lzma_init(void) { return 0; }
++static inline int z_erofs_lzma_init(void)
++{
++	return 0;
++}
+ static inline int z_erofs_lzma_exit(void) { return 0; }
+ static inline int z_erofs_load_lzma_config(struct super_block *sb,
+-			     struct erofs_super_block *dsb,
+-			     struct z_erofs_lzma_cfgs *lzma, int size) {
+-	if (lzma) {
++										   struct erofs_super_block *dsb,
++										   struct z_erofs_lzma_cfgs *lzma, int size)
++{
++	if (lzma)
++	{
+ 		erofs_err(sb, "lzma algorithm isn't enabled");
+ 		return -EINVAL;
+ 	}
+ 	return 0;
+ }
+-#endif	/* !CONFIG_EROFS_FS_ZIP */
++#endif /* !CONFIG_EROFS_FS_ZIP */
+ 
+ /* fscache.c */
+ #ifdef CONFIG_EROFS_FS_ONDEMAND
+@@ -582,8 +596,8 @@ int erofs_fscache_register_fs(struct super_block *sb);
+ void erofs_fscache_unregister_fs(struct super_block *sb);
+ 
+ int erofs_fscache_register_cookie(struct super_block *sb,
+-				  struct erofs_fscache **fscache,
+-				  char *name, bool need_inode);
++								  struct erofs_fscache **fscache,
++								  char *name, bool need_inode);
+ void erofs_fscache_unregister_cookie(struct erofs_fscache **fscache);
+ 
+ extern const struct address_space_operations erofs_fscache_access_aops;
+@@ -595,8 +609,8 @@ static inline int erofs_fscache_register_fs(struct super_block *sb)
+ static inline void erofs_fscache_unregister_fs(struct super_block *sb) {}
+ 
+ static inline int erofs_fscache_register_cookie(struct super_block *sb,
+-						struct erofs_fscache **fscache,
+-						char *name, bool need_inode)
++												struct erofs_fscache **fscache,
++												char *name, bool need_inode)
+ {
+ 	return -EOPNOTSUPP;
+ }
+@@ -606,6 +620,6 @@ static inline void erofs_fscache_unregister_cookie(struct erofs_fscache **fscach
+ }
+ #endif
+ 
+-#define EFSCORRUPTED    EUCLEAN         /* Filesystem is corrupted */
++#define EFSCORRUPTED EUCLEAN /* Filesystem is corrupted */
+ 
+-#endif	/* __EROFS_INTERNAL_H */
++#endif /* __EROFS_INTERNAL_H */
+diff --git a/fs/erofs/super.c b/fs/erofs/super.c
+index ddf8f737c..bd43edf02 100644
+--- a/fs/erofs/super.c
++++ b/fs/erofs/super.c
+@@ -439,6 +439,7 @@ enum {
+ 	Opt_dax_enum,
+ 	Opt_device,
+ 	Opt_fsid,
++	Opt_bootstrap_path,
+ 	Opt_err
+ };
+ 
+@@ -464,6 +465,7 @@ static const struct fs_parameter_spec erofs_fs_parameters[] = {
+ 	fsparam_enum("dax",		Opt_dax_enum, erofs_dax_param_enums),
+ 	fsparam_string("device",	Opt_device),
+ 	fsparam_string("fsid",		Opt_fsid),
++	fsparam_string("bootstrap_path",	Opt_bootstrap_path),
+ 	{}
+ };
+ 
+@@ -559,6 +561,13 @@ static int erofs_fc_parse_param(struct fs_context *fc,
+ 		}
+ 		++ctx->devs->extra_devices;
+ 		break;
++	case Opt_bootstrap_path:
++		kfree(ctx->bootstrap_path);
++		ctx->bootstrap_path = kstrdup(param->string, GFP_KERNEL);
++		if (!ctx->bootstrap_path)
++			return -ENOMEM;
++		infofc(fc, "RAFS bootstrap_path %s", ctx->bootstrap_path);
++		break;
+ 	case Opt_fsid:
+ #ifdef CONFIG_EROFS_FS_ONDEMAND
+ 		kfree(ctx->opt.fsid);
+@@ -675,6 +684,22 @@ static const struct export_operations erofs_export_ops = {
+ 	.get_parent = erofs_get_parent,
+ };
+ 
++static int rafs_v6_fill_super(struct super_block *sb)
++{
++	struct erofs_sb_info *sbi = EROFS_SB(sb);
++
++	if (sbi->bootstrap_path) {
++		struct file *f;
++
++		f = filp_open(sbi->bootstrap_path, O_RDONLY, 0644);
++		if (IS_ERR(f))
++			return PTR_ERR(f);
++		sbi->bootstrap = f;
++	}
++	/* TODO: open each blobfiles */
++	return 0;
++}
++
+ static int erofs_fc_fill_super(struct super_block *sb, struct fs_context *fc)
+ {
+ 	struct inode *inode;
+@@ -696,6 +721,8 @@ static int erofs_fc_fill_super(struct super_block *sb, struct fs_context *fc)
+ 	ctx->opt.fsid = NULL;
+ 	sbi->devs = ctx->devs;
+ 	ctx->devs = NULL;
++	sbi->bootstrap_path = ctx->bootstrap_path;
++	ctx->bootstrap_path = NULL;
+ 
+ 	if (erofs_is_fscache_mode(sb)) {
+ 		sb->s_blocksize = EROFS_BLKSIZ;
+@@ -727,6 +754,25 @@ static int erofs_fc_fill_super(struct super_block *sb, struct fs_context *fc)
+ 	if (err)
+ 		return err;
+ 
++	if (sb->s_blocksize_bits != sbi->blkszbits) {
++		if (erofs_is_fscache_mode(sb)) {
++			errorfc(fc, "unsupported blksize for fscache mode");
++			return -EINVAL;
++		}
++		if (!sb_set_blocksize(sb, 1 << sbi->blkszbits)) {
++		if (sb->s_bdev && !sb_set_blocksize(sb, 1 << sbi->blkszbits)) {
++			errorfc(fc, "failed to set erofs blksize");
++			return -EINVAL;
++		} else {
++			sb->s_blocksize =  1 << sbi->blkszbits;
++			sb->s_blocksize_bits = sbi->blkszbits;
++		}
++	}
++
++	err = rafs_v6_fill_super(sb);
++	if (err)
++		return err;
++
+ 	if (test_opt(&sbi->opt, DAX_ALWAYS)) {
+ 		BUILD_BUG_ON(EROFS_BLKSIZ != PAGE_SIZE);
+ 
+@@ -786,6 +832,9 @@ static int erofs_fc_get_tree(struct fs_context *fc)
+ 	if (IS_ENABLED(CONFIG_EROFS_FS_ONDEMAND) && ctx->opt.fsid)
+ 		return get_tree_nodev(fc, erofs_fc_fill_super);
+ 
++	if (ctx->bootstrap_path)
++		return get_tree_nodev(fc, erofs_fc_fill_super);
++
+ 	return get_tree_bdev(fc, erofs_fc_fill_super);
+ }
+ 
+@@ -876,10 +925,10 @@ static void erofs_kill_sb(struct super_block *sb)
+ 
+ 	WARN_ON(sb->s_magic != EROFS_SUPER_MAGIC);
+ 
+-	if (erofs_is_fscache_mode(sb))
+-		kill_anon_super(sb);
+-	else
++	if (sb->s_bdev)
+ 		kill_block_super(sb);
++	else
++		kill_anon_super(sb);
+ 
+ 	sbi = EROFS_SB(sb);
+ 	if (!sbi)
+@@ -900,6 +949,10 @@ static void erofs_put_super(struct super_block *sb)
+ 	struct erofs_sb_info *const sbi = EROFS_SB(sb);
+ 
+ 	DBG_BUGON(!sbi);
++	
++	if (sbi->bootstrap)
++		filp_close(sbi->bootstrap, NULL);
++	kfree(sbi->bootstrap_path);
+ 
+ 	erofs_unregister_sysfs(sb);
+ 	erofs_shrinker_unregister(sb);
+@@ -993,7 +1046,7 @@ static int erofs_statfs(struct dentry *dentry, struct kstatfs *buf)
+ 	struct erofs_sb_info *sbi = EROFS_SB(sb);
+ 	u64 id = 0;
+ 
+-	if (!erofs_is_fscache_mode(sb))
++	if (sb->s_bdev)
+ 		id = huge_encode_dev(sb->s_bdev->bd_dev);
+ 
+ 	buf->f_type = sb->s_magic;
+-- 
+2.21.1 (Apple Git-122.3)
+

--- a/tools/packaging/kernel/patches/5.19.x/0002-support-blobfile-over-virtiofs.patch
+++ b/tools/packaging/kernel/patches/5.19.x/0002-support-blobfile-over-virtiofs.patch
@@ -1,0 +1,249 @@
+From 18bc7bf7bacfe082787befb7e841f16878902156 Mon Sep 17 00:00:00 2001
+From: Leospard <694963063@qq.com>
+Date: Wed, 6 Sep 2023 21:51:43 +0800
+Subject: [PATCH 2/3] support blobfile over virtiofs
+
+---
+ fs/erofs/inode.c | 109 +++++++++++++++++++++++++++++++----------------
+ 1 file changed, 73 insertions(+), 36 deletions(-)
+
+diff --git a/fs/erofs/inode.c b/fs/erofs/inode.c
+index 524000b45..045642b2d 100644
+--- a/fs/erofs/inode.c
++++ b/fs/erofs/inode.c
+@@ -324,13 +324,18 @@ static int erofs_fill_inode(struct inode *inode, int isdir)
+ 			err = -EOPNOTSUPP;
+ 		goto out_unlock;
+ 	}
+-	if (sbi->bootstrap && !S_ISREG(inode->i_mode)) {
++	if (sbi->bootstrap && !S_ISREG(inode->i_mode))
++	{
+ 		inode_nohighmem(inode);
+ 		inode->i_mapping->a_ops = &rafs_v6_aops;
+-	} else if (inode->i_sb->s_bdev) {
++	}
++	else if (inode->i_sb->s_bdev)
++	{
+ 		inode->i_mapping->a_ops = &erofs_raw_access_aops;
+ #ifdef CONFIG_EROFS_FS_ONDEMAND
+-	} else if (erofs_is_fscache_mode(inode->i_sb)) {
++	}
++	else if (erofs_is_fscache_mode(inode->i_sb))
++	{
+ 		inode->i_mapping->a_ops = &erofs_fscache_access_aops;
+ #endif
+ 	}
+@@ -435,13 +440,25 @@ const struct inode_operations erofs_fast_symlink_iops = {
+ };
+ 
+ static ssize_t rafs_v6_read_chunk(struct super_block *sb,
+-				  struct iov_iter *to, u64 off, u64 size,
+-				  unsigned int device_id)
++								  struct iov_iter *to, u64 off, u64 size,
++								  unsigned int device_id)
+ {
+ 	struct iov_iter titer;
+ 	ssize_t read = 0;
+ 
+-	do {
++	struct erofs_map_dev mdev = {
++		.m_deviceid = device_id,
++		.m_pa = off,
++	};
++	int err;
++
++	err = erofs_map_dev(sb, &mdev);
++	if (err)
++		return err;
++	off = mdev.m_pa;
++
++	do
++	{
+ 		struct iovec iovec = iov_iter_iovec(to);
+ 		ssize_t ret;
+ 
+@@ -449,15 +466,18 @@ static ssize_t rafs_v6_read_chunk(struct super_block *sb,
+ 			iovec.iov_len = size;
+ 
+ 		pr_debug("%s: off %llu size %llu blob_index %u\n", __func__, off,
+-			 size, device_id);
++				 size, device_id);
+ 
+ 		/* TODO async */
+ 		iov_iter_init(&titer, READ, &iovec, 1, iovec.iov_len);
+-		ret = vfs_iter_read(EROFS_SB(sb)->bootstrap, &titer, &off, 0);
+-		if (ret < 0) {
++		ret = vfs_iter_read(mdev.m_fp, &titer, &off, 0);
++		if (ret < 0)
++		{
+ 			pr_err("%s: failed to read blob ret %ld\n", __func__, ret);
+ 			return ret;
+-		} else if (ret < iovec.iov_len) {
++		}
++		else if (ret < iovec.iov_len)
++		{
+ 			return read;
+ 		}
+ 		iov_iter_advance(to, ret);
+@@ -470,17 +490,19 @@ static ssize_t rafs_v6_read_chunk(struct super_block *sb,
+ static ssize_t rafs_v6_file_read_iter(struct kiocb *iocb, struct iov_iter *to)
+ {
+ 	struct inode *inode = file_inode(iocb->ki_filp);
+-	struct erofs_map_blocks map = { 0 };
++	struct erofs_map_blocks map = {0};
+ 	ssize_t bytes = 0;
+ 	u64 total = min_t(u64, iov_iter_count(to),
+-			  inode->i_size - iocb->ki_pos);
++					  inode->i_size - iocb->ki_pos);
+ 
+-	while (total) {
++	while (total)
++	{
+ 		erofs_off_t pos = iocb->ki_pos;
+ 		u64 delta, size;
+ 		ssize_t read;
+ 
+-		if (map.m_la < pos || map.m_la + map.m_llen >= pos) {
++		if (map.m_la < pos || map.m_la + map.m_llen >= pos)
++		{
+ 			int err;
+ 
+ 			map.m_la = pos;
+@@ -493,11 +515,12 @@ static ssize_t rafs_v6_file_read_iter(struct kiocb *iocb, struct iov_iter *to)
+ 		delta = pos - map.m_la;
+ 		size = min_t(u64, map.m_llen - delta, total);
+ 		read = rafs_v6_read_chunk(inode->i_sb, to, map.m_pa + delta,
+-					  size, map.m_deviceid);
+-		if (read < size) {
++								  size, map.m_deviceid);
++		if (read < size)
++		{
+ 			erofs_err(inode->i_sb,
+-				  "short read %ld pos %llu size %llu @ nid %llu",
+-				  read, pos, size, EROFS_I(inode)->nid);
++					  "short read %ld pos %llu size %llu @ nid %llu",
++					  read, pos, size, EROFS_I(inode)->nid);
+ 			return -EIO;
+ 		}
+ 		iocb->ki_pos += read;
+@@ -514,6 +537,7 @@ static vm_fault_t rafs_v6_filemap_fault(struct vm_fault *vmf)
+ 	pgoff_t npages, orig_pgoff = vmf->pgoff;
+ 	erofs_off_t pos;
+ 	struct erofs_map_blocks map = {0};
++	struct erofs_map_dev mdev;
+ 	struct vm_area_struct lower_vma;
+ 	int err;
+ 	vm_fault_t ret;
+@@ -531,8 +555,17 @@ static vm_fault_t rafs_v6_filemap_fault(struct vm_fault *vmf)
+ 	if (err)
+ 		return vmf_error(err);
+ 
+-	lower_vma.vm_file = EROFS_I_SB(inode)->bootstrap;
+-	vmf->pgoff = (map.m_pa + (pos - map.m_la)) >> PAGE_SHIFT;
++	mdev = (struct erofs_map_dev){
++		.m_deviceid = map.m_deviceid,
++		.m_pa = map.m_pa,
++	};
++	err = erofs_map_dev(inode->i_sb, &mdev);
++	if (err)
++		return vmf_error(err);
++
++	lower_vma.vm_file = mdev.m_fp;
++	vmf->pgoff = (mdev.m_pa + (pos - map.m_la)) >> PAGE_SHIFT;
++
+ 	vmf->vma = &lower_vma; /* override vma temporarily */
+ 	ret = EROFS_I(inode)->lower_vm_ops->fault(vmf);
+ 	vmf->vma = vma;
+@@ -541,7 +574,7 @@ static vm_fault_t rafs_v6_filemap_fault(struct vm_fault *vmf)
+ }
+ 
+ static const struct vm_operations_struct rafs_v6_vm_ops = {
+-	.fault	= rafs_v6_filemap_fault,
++	.fault = rafs_v6_filemap_fault,
+ };
+ 
+ static int rafs_v6_file_mmap(struct file *file, struct vm_area_struct *vma)
+@@ -552,7 +585,8 @@ static int rafs_v6_file_mmap(struct file *file, struct vm_area_struct *vma)
+ 	int ret;
+ 
+ 	ret = call_mmap(EROFS_I_SB(inode)->bootstrap, vma);
+-	if (ret) {
++	if (ret)
++	{
+ 		pr_err("%s: call_mmap failed ret %d\n", __func__, ret);
+ 		return ret;
+ 	}
+@@ -560,37 +594,40 @@ static int rafs_v6_file_mmap(struct file *file, struct vm_area_struct *vma)
+ 	/* set fs's vm_ops which is used in fault(). */
+ 	lower_vm_ops = vma->vm_ops;
+ 
+-	if (vi->lower_vm_ops && vi->lower_vm_ops != lower_vm_ops) {
++	if (vi->lower_vm_ops && vi->lower_vm_ops != lower_vm_ops)
++	{
+ 		WARN_ON_ONCE(1);
+ 		return -EOPNOTSUPP;
+ 	}
+ 	/* fault() must exist in order to proceed. */
+-	if (!lower_vm_ops || !lower_vm_ops->fault) {
++	if (!lower_vm_ops || !lower_vm_ops->fault)
++	{
+ 		WARN_ON_ONCE(1);
+ 		return -EOPNOTSUPP;
+ 	}
+ 	vi->lower_vm_ops = lower_vm_ops;
+-	vma->vm_flags &= ~VM_HUGEPAGE;	/* dont use huge page */
++	vma->vm_flags &= ~VM_HUGEPAGE; /* dont use huge page */
+ 	vma->vm_ops = &rafs_v6_vm_ops;
+ 	return 0;
+ }
+ 
+ const struct file_operations rafs_v6_file_ro_fops = {
+-	.llseek		= generic_file_llseek,
+-	.read_iter	= rafs_v6_file_read_iter,
+-	.mmap		= rafs_v6_file_mmap,
+-//	.mmap		= generic_file_readonly_mmap,
+-	.splice_read	= generic_file_splice_read,
++	.llseek = generic_file_llseek,
++	.read_iter = rafs_v6_file_read_iter,
++	.mmap = rafs_v6_file_mmap,
++	//	.mmap		= generic_file_readonly_mmap,
++	.splice_read = generic_file_splice_read,
+ };
+ 
+-static int rafs_v6_readpage(struct file *file, struct page *page) {
++static int rafs_v6_readpage(struct file *file, struct page *page)
++{
+ 	struct kvec iov = {
+-		.iov_base	= page_address(page),
++		.iov_base = page_address(page),
+ 	};
+ 	struct inode *inode = page->mapping->host;
+ 	struct super_block *sb = inode->i_sb;
+ 	erofs_off_t pos = page->index << PAGE_SHIFT;
+-	struct erofs_map_blocks map = { .m_la = pos };
++	struct erofs_map_blocks map = {.m_la = pos};
+ 	struct kiocb kiocb;
+ 	struct iov_iter iter;
+ 	int err;
+@@ -602,15 +639,15 @@ static int rafs_v6_readpage(struct file *file, struct page *page) {
+ 	iov.iov_len = min_t(u64, PAGE_SIZE, map.m_plen - (pos - map.m_la));
+ 	init_sync_kiocb(&kiocb, EROFS_SB(sb)->bootstrap);
+ 	kiocb.ki_pos = map.m_pa + (pos - map.m_la);
+-//	if (!(kiocb.ki_pos & ~PAGE_MASK) && iov.iov_len == PAGE_SIZE)
+-//		kiocb.ki_flags |= IOCB_DIRECT;
++	//	if (!(kiocb.ki_pos & ~PAGE_MASK) && iov.iov_len == PAGE_SIZE)
++	//		kiocb.ki_flags |= IOCB_DIRECT;
+ 	iov_iter_kvec(&iter, READ, &iov, 1, iov.iov_len);
+ 	err = kiocb.ki_filp->f_op->read_iter(&kiocb, &iter);
+ 	if (err < iov.iov_len)
+ 		goto err_out;
+ 	if (iov.iov_len < PAGE_SIZE)
+ 		memset(iov.iov_base + iov.iov_len, 0,
+-		       PAGE_SIZE - iov.iov_len);
++			   PAGE_SIZE - iov.iov_len);
+ 	SetPageUptodate(page);
+ 	unlock_page(page);
+ 	return 0;
+-- 
+2.21.1 (Apple Git-122.3)
+

--- a/tools/packaging/kernel/patches/5.19.x/0003-introduce-blob_path_dir-mount-option.patch
+++ b/tools/packaging/kernel/patches/5.19.x/0003-introduce-blob_path_dir-mount-option.patch
@@ -1,0 +1,1496 @@
+From 26815825cf847f947dae14dab69b7f1311ff9b82 Mon Sep 17 00:00:00 2001
+From: Leospard <694963063@qq.com>
+Date: Mon, 25 Sep 2023 01:28:07 +0800
+Subject: [PATCH 3/3] introduce blob_path_dir mount option
+
+---
+ fs/erofs/data.c     |   2 +
+ fs/erofs/internal.h |  68 ++--
+ fs/erofs/super.c    | 837 ++++++++++++++++++++++++--------------------
+ 3 files changed, 516 insertions(+), 391 deletions(-)
+
+diff --git a/fs/erofs/data.c b/fs/erofs/data.c
+index 1fc53b2b8..1519ca65b 100644
+--- a/fs/erofs/data.c
++++ b/fs/erofs/data.c
+@@ -245,6 +245,7 @@ int erofs_map_dev(struct super_block *sb, struct erofs_map_dev *map)
+ 			return -ENODEV;
+ 		}
+ 		map->m_bdev = dif->bdev;
++		map->m_fp = dif->blobfile;
+ 		map->m_daxdev = dif->dax_dev;
+ 		map->m_dax_part_off = dif->dax_part_off;
+ 		map->m_fscache = dif->fscache;
+@@ -267,6 +268,7 @@ int erofs_map_dev(struct super_block *sb, struct erofs_map_dev *map)
+ 			{
+ 				map->m_pa -= startoff;
+ 				map->m_bdev = dif->bdev;
++				map->m_fp = dif->blobfile;
+ 				map->m_daxdev = dif->dax_dev;
+ 				map->m_dax_part_off = dif->dax_part_off;
+ 				map->m_fscache = dif->fscache;
+diff --git a/fs/erofs/internal.h b/fs/erofs/internal.h
+index 0710c3d71..f0244c3c9 100644
+--- a/fs/erofs/internal.h
++++ b/fs/erofs/internal.h
+@@ -47,10 +47,12 @@ typedef u64 erofs_off_t;
+ /* data type for filesystem-wide blocks number */
+ typedef u32 erofs_blk_t;
+ 
+-struct erofs_device_info {
++struct erofs_device_info
++{
+ 	char *path;
+ 	struct erofs_fscache *fscache;
+ 	struct block_device *bdev;
++	struct file *blobfile;
+ 	struct dax_device *dax_dev;
+ 	u64 dax_part_off;
+ 
+@@ -58,13 +60,15 @@ struct erofs_device_info {
+ 	u32 mapped_blkaddr;
+ };
+ 
+-enum {
++enum
++{
+ 	EROFS_SYNC_DECOMPRESS_AUTO,
+ 	EROFS_SYNC_DECOMPRESS_FORCE_ON,
+ 	EROFS_SYNC_DECOMPRESS_FORCE_OFF
+ };
+ 
+-struct erofs_mount_opts {
++struct erofs_mount_opts
++{
+ #ifdef CONFIG_EROFS_FS_ZIP
+ 	/* current strategy of how to use managed cache */
+ 	unsigned char cache_strategy;
+@@ -78,33 +82,39 @@ struct erofs_mount_opts {
+ 	char *fsid;
+ };
+ 
+-struct erofs_dev_context {
++struct erofs_dev_context
++{
+ 	struct idr tree;
+ 	struct rw_semaphore rwsem;
+ 
+ 	unsigned int extra_devices;
+ };
+ 
+-struct erofs_fs_context {
++struct erofs_fs_context
++{
+ 	struct erofs_mount_opts opt;
+ 	struct erofs_dev_context *devs;
+ 	char *bootstrap_path;
++	char *blob_dir_path;
+ };
+ 
+ /* all filesystem-wide lz4 configurations */
+-struct erofs_sb_lz4_info {
++struct erofs_sb_lz4_info
++{
+ 	/* # of pages needed for EROFS lz4 rolling decompression */
+ 	u16 max_distance_pages;
+ 	/* maximum possible blocks for pclusters in the filesystem */
+ 	u16 max_pclusterblks;
+ };
+ 
+-struct erofs_fscache {
++struct erofs_fscache
++{
+ 	struct fscache_cookie *cookie;
+ 	struct inode *inode;
+ };
+ 
+-struct erofs_sb_info {
++struct erofs_sb_info
++{
+ 	struct erofs_mount_opts opt; /* options */
+ #ifdef CONFIG_EROFS_FS_ZIP
+ 	/* list for all registered superblocks, mainly for shrinker */
+@@ -122,8 +132,11 @@ struct erofs_sb_info {
+ 
+ 	struct erofs_sb_lz4_info lz4;
+ #endif /* CONFIG_EROFS_FS_ZIP */
++	struct path blob_dir;
+ 	struct file *bootstrap;
++	char *blob_dir_path;
+ 	char *bootstrap_path;
++
+ 	struct erofs_dev_context *devs;
+ 	struct dax_device *dax_dev;
+ 	u64 dax_part_off;
+@@ -175,11 +188,13 @@ struct erofs_sb_info {
+ #define set_opt(opt, option) ((opt)->mount_opt |= EROFS_MOUNT_##option)
+ #define test_opt(opt, option) ((opt)->mount_opt & EROFS_MOUNT_##option)
+ 
+-static inline bool erofs_is_fscache_mode(struct super_block *sb) {
++static inline bool erofs_is_fscache_mode(struct super_block *sb)
++{
+ 	return IS_ENABLED(CONFIG_EROFS_FS_ONDEMAND) && !sb->s_bdev;
+ }
+ 
+-enum {
++enum
++{
+ 	EROFS_ZIP_CACHE_DISABLED,
+ 	EROFS_ZIP_CACHE_READAHEAD,
+ 	EROFS_ZIP_CACHE_READAROUND
+@@ -189,7 +204,8 @@ enum {
+ #define EROFS_LOCKED_MAGIC (INT_MIN | 0xE0F510CCL)
+ 
+ /* basic unit of the workstation of a super_block */
+-struct erofs_workgroup {
++struct erofs_workgroup
++{
+ 	/* the workgroup index in the workstation */
+ 	pgoff_t index;
+ 
+@@ -198,9 +214,11 @@ struct erofs_workgroup {
+ };
+ 
+ static inline bool erofs_workgroup_try_to_freeze(struct erofs_workgroup *grp,
+-												 int val) {
++												 int val)
++{
+ 	preempt_disable();
+-	if (val != atomic_cmpxchg(&grp->refcount, val, EROFS_LOCKED_MAGIC)) {
++	if (val != atomic_cmpxchg(&grp->refcount, val, EROFS_LOCKED_MAGIC))
++	{
+ 		preempt_enable();
+ 		return false;
+ 	}
+@@ -208,7 +226,8 @@ static inline bool erofs_workgroup_try_to_freeze(struct erofs_workgroup *grp,
+ }
+ 
+ static inline void erofs_workgroup_unfreeze(struct erofs_workgroup *grp,
+-											int orig_val) {
++											int orig_val)
++{
+ 	/*
+ 	 * other observers should notice all modifications
+ 	 * in the freezing period.
+@@ -218,7 +237,8 @@ static inline void erofs_workgroup_unfreeze(struct erofs_workgroup *grp,
+ 	preempt_enable();
+ }
+ 
+-static inline int erofs_wait_on_workgroup_freezed(struct erofs_workgroup *grp) {
++static inline int erofs_wait_on_workgroup_freezed(struct erofs_workgroup *grp)
++{
+ 	return atomic_cond_read_relaxed(&grp->refcount,
+ 									VAL != EROFS_LOCKED_MAGIC);
+ }
+@@ -239,13 +259,15 @@ static inline int erofs_wait_on_workgroup_freezed(struct erofs_workgroup *grp) {
+ #error erofs cannot be used in this platform
+ #endif
+ 
+-enum erofs_kmap_type {
++enum erofs_kmap_type
++{
+ 	EROFS_NO_KMAP,	   /* don't map the buffer */
+ 	EROFS_KMAP,		   /* use kmap() to map the buffer */
+ 	EROFS_KMAP_ATOMIC, /* use kmap_atomic() to map the buffer */
+ };
+ 
+-struct erofs_buf {
++struct erofs_buf
++{
+ 	struct page *page;
+ 	void *base;
+ 	enum erofs_kmap_type kmap_type;
+@@ -258,7 +280,8 @@ struct erofs_buf {
+ #define erofs_blkoff(addr) ((addr) % EROFS_BLKSIZ)
+ #define blknr_to_addr(nr) ((erofs_off_t)(nr)*EROFS_BLKSIZ)
+ 
+-static inline erofs_off_t iloc(struct erofs_sb_info *sbi, erofs_nid_t nid) {
++static inline erofs_off_t iloc(struct erofs_sb_info *sbi, erofs_nid_t nid)
++{
+ 	return blknr_to_addr(sbi->meta_blkaddr) + (nid << sbi->islotbits);
+ }
+ 
+@@ -285,7 +308,8 @@ EROFS_FEATURE_FUNCS(sb_chksum, compat, COMPAT_SB_CHKSUM)
+ #define EROFS_I_BL_XATTR_BIT (BITS_PER_LONG - 1)
+ #define EROFS_I_BL_Z_BIT (BITS_PER_LONG - 2)
+ 
+-struct erofs_inode {
++struct erofs_inode
++{
+ 	erofs_nid_t nid;
+ 
+ 	/* atomic flags (including bitlocks) */
+@@ -325,13 +349,15 @@ struct erofs_inode {
+ #define EROFS_I(ptr) \
+ 	container_of(ptr, struct erofs_inode, vfs_inode)
+ 
+-static inline unsigned long erofs_inode_datablocks(struct inode *inode) {
++static inline unsigned long erofs_inode_datablocks(struct inode *inode)
++{
+ 	/* since i_size cannot be changed */
+ 	return DIV_ROUND_UP(inode->i_size, EROFS_BLKSIZ);
+ }
+ 
+ static inline unsigned int erofs_bitrange(unsigned int value, unsigned int bit,
+-										  unsigned int bits) {
++										  unsigned int bits)
++{
+ 
+ 	return (value >> bit) & ((1 << bits) - 1);
+ }
+diff --git a/fs/erofs/super.c b/fs/erofs/super.c
+index bd43edf02..894fa16b5 100644
+--- a/fs/erofs/super.c
++++ b/fs/erofs/super.c
+@@ -6,6 +6,7 @@
+  */
+ #include <linux/module.h>
+ #include <linux/buffer_head.h>
++#include <linux/namei.h>
+ #include <linux/statfs.h>
+ #include <linux/parser.h>
+ #include <linux/seq_file.h>
+@@ -22,7 +23,7 @@
+ static struct kmem_cache *erofs_inode_cachep __read_mostly;
+ 
+ void _erofs_err(struct super_block *sb, const char *function,
+-		const char *fmt, ...)
++				const char *fmt, ...)
+ {
+ 	struct va_format vaf;
+ 	va_list args;
+@@ -37,7 +38,7 @@ void _erofs_err(struct super_block *sb, const char *function,
+ }
+ 
+ void _erofs_info(struct super_block *sb, const char *function,
+-		 const char *fmt, ...)
++				 const char *fmt, ...)
+ {
+ 	struct va_format vaf;
+ 	va_list args;
+@@ -57,7 +58,7 @@ static int erofs_superblock_csum_verify(struct super_block *sb, void *sbdata)
+ 	u32 expected_crc, crc;
+ 
+ 	dsb = kmemdup(sbdata + EROFS_SUPER_OFFSET,
+-		      EROFS_BLKSIZ - EROFS_SUPER_OFFSET, GFP_KERNEL);
++				  EROFS_BLKSIZ - EROFS_SUPER_OFFSET, GFP_KERNEL);
+ 	if (!dsb)
+ 		return -ENOMEM;
+ 
+@@ -67,9 +68,10 @@ static int erofs_superblock_csum_verify(struct super_block *sb, void *sbdata)
+ 	crc = crc32c(~0, dsb, EROFS_BLKSIZ - EROFS_SUPER_OFFSET);
+ 	kfree(dsb);
+ 
+-	if (crc != expected_crc) {
++	if (crc != expected_crc)
++	{
+ 		erofs_err(sb, "invalid checksum 0x%08x, 0x%08x expected",
+-			  crc, expected_crc);
++				  crc, expected_crc);
+ 		return -EBADMSG;
+ 	}
+ 	return 0;
+@@ -108,17 +110,18 @@ static void erofs_free_inode(struct inode *inode)
+ }
+ 
+ static bool check_layout_compatibility(struct super_block *sb,
+-				       struct erofs_super_block *dsb)
++									   struct erofs_super_block *dsb)
+ {
+ 	const unsigned int feature = le32_to_cpu(dsb->feature_incompat);
+ 
+ 	EROFS_SB(sb)->feature_incompat = feature;
+ 
+ 	/* check if current kernel meets all mandatory requirements */
+-	if (feature & (~EROFS_ALL_FEATURE_INCOMPAT)) {
++	if (feature & (~EROFS_ALL_FEATURE_INCOMPAT))
++	{
+ 		erofs_err(sb,
+-			  "unidentified incompatible feature %x, please upgrade kernel version",
+-			   feature & ~EROFS_ALL_FEATURE_INCOMPAT);
++				  "unidentified incompatible feature %x, please upgrade kernel version",
++				  feature & ~EROFS_ALL_FEATURE_INCOMPAT);
+ 		return false;
+ 	}
+ 	return true;
+@@ -127,7 +130,7 @@ static bool check_layout_compatibility(struct super_block *sb,
+ #ifdef CONFIG_EROFS_FS_ZIP
+ /* read variable-sized metadata, offset will be aligned by 4-byte */
+ static void *erofs_read_metadata(struct super_block *sb, struct erofs_buf *buf,
+-				 erofs_off_t *offset, int *lengthp)
++								 erofs_off_t *offset, int *lengthp)
+ {
+ 	u8 *buffer, *ptr;
+ 	int len, i, cnt;
+@@ -146,11 +149,13 @@ static void *erofs_read_metadata(struct super_block *sb, struct erofs_buf *buf,
+ 	*offset += sizeof(__le16);
+ 	*lengthp = len;
+ 
+-	for (i = 0; i < len; i += cnt) {
++	for (i = 0; i < len; i += cnt)
++	{
+ 		cnt = min(EROFS_BLKSIZ - (int)erofs_blkoff(*offset), len - i);
+ 		ptr = erofs_read_metabuf(buf, sb, erofs_blknr(*offset),
+-					 EROFS_KMAP);
+-		if (IS_ERR(ptr)) {
++								 EROFS_KMAP);
++		if (IS_ERR(ptr))
++		{
+ 			kfree(buffer);
+ 			return ptr;
+ 		}
+@@ -161,7 +166,7 @@ static void *erofs_read_metadata(struct super_block *sb, struct erofs_buf *buf,
+ }
+ 
+ static int erofs_load_compr_cfgs(struct super_block *sb,
+-				 struct erofs_super_block *dsb)
++								 struct erofs_super_block *dsb)
+ {
+ 	struct erofs_sb_info *sbi = EROFS_SB(sb);
+ 	struct erofs_buf buf = __EROFS_BUF_INITIALIZER;
+@@ -170,27 +175,31 @@ static int erofs_load_compr_cfgs(struct super_block *sb,
+ 	int size, ret = 0;
+ 
+ 	sbi->available_compr_algs = le16_to_cpu(dsb->u1.available_compr_algs);
+-	if (sbi->available_compr_algs & ~Z_EROFS_ALL_COMPR_ALGS) {
++	if (sbi->available_compr_algs & ~Z_EROFS_ALL_COMPR_ALGS)
++	{
+ 		erofs_err(sb, "try to load compressed fs with unsupported algorithms %x",
+-			  sbi->available_compr_algs & ~Z_EROFS_ALL_COMPR_ALGS);
++				  sbi->available_compr_algs & ~Z_EROFS_ALL_COMPR_ALGS);
+ 		return -EINVAL;
+ 	}
+ 
+ 	offset = EROFS_SUPER_OFFSET + sbi->sb_size;
+ 	alg = 0;
+-	for (algs = sbi->available_compr_algs; algs; algs >>= 1, ++alg) {
++	for (algs = sbi->available_compr_algs; algs; algs >>= 1, ++alg)
++	{
+ 		void *data;
+ 
+ 		if (!(algs & 1))
+ 			continue;
+ 
+ 		data = erofs_read_metadata(sb, &buf, &offset, &size);
+-		if (IS_ERR(data)) {
++		if (IS_ERR(data))
++		{
+ 			ret = PTR_ERR(data);
+ 			break;
+ 		}
+ 
+-		switch (alg) {
++		switch (alg)
++		{
+ 		case Z_EROFS_COMPRESSION_LZ4:
+ 			ret = z_erofs_load_lz4_config(sb, dsb, data, size);
+ 			break;
+@@ -210,9 +219,10 @@ static int erofs_load_compr_cfgs(struct super_block *sb,
+ }
+ #else
+ static int erofs_load_compr_cfgs(struct super_block *sb,
+-				 struct erofs_super_block *dsb)
++								 struct erofs_super_block *dsb)
+ {
+-	if (dsb->u1.available_compr_algs) {
++	if (dsb->u1.available_compr_algs)
++	{
+ 		erofs_err(sb, "try to load compressed fs when compression is disabled");
+ 		return -EINVAL;
+ 	}
+@@ -221,7 +231,7 @@ static int erofs_load_compr_cfgs(struct super_block *sb,
+ #endif
+ 
+ static int erofs_init_device(struct erofs_buf *buf, struct super_block *sb,
+-			     struct erofs_device_info *dif, erofs_off_t *pos)
++							 struct erofs_device_info *dif, erofs_off_t *pos)
+ {
+ 	struct erofs_sb_info *sbi = EROFS_SB(sb);
+ 	struct erofs_deviceslot *dis;
+@@ -234,8 +244,10 @@ static int erofs_init_device(struct erofs_buf *buf, struct super_block *sb,
+ 		return PTR_ERR(ptr);
+ 	dis = ptr + erofs_blkoff(*pos);
+ 
+-	if (!dif->path) {
+-		if (!dis->tag[0]) {
++	if (!dif->path)
++	{
++		if (!dis->tag[0])
++		{
+ 			erofs_err(sb, "empty device tag @ pos %llu", *pos);
+ 			return -EINVAL;
+ 		}
+@@ -244,14 +256,30 @@ static int erofs_init_device(struct erofs_buf *buf, struct super_block *sb,
+ 			return -ENOMEM;
+ 	}
+ 
+-	if (erofs_is_fscache_mode(sb)) {
++	if (erofs_is_fscache_mode(sb))
++	{
+ 		ret = erofs_fscache_register_cookie(sb, &dif->fscache,
+-				dif->path, false);
++											dif->path, false);
+ 		if (ret)
+ 			return ret;
+-	} else {
++	}
++	else if (sbi->blob_dir_path)
++	{
++		struct file *f;
++
++		f = file_open_root(sbi->blob_dir.dentry, sbi->blob_dir.mnt,
++						   dif->path, O_RDONLY | O_LARGEFILE, 0);
++		if (IS_ERR(f))
++		{
++			erofs_err(sb, "failed to open blob id %s", dif->path);
++			return PTR_ERR(f);
++		}
++		dif->blobfile = f;
++	}
++	else if (!sbi->devs->flatdev)
++	{
+ 		bdev = blkdev_get_by_path(dif->path, FMODE_READ | FMODE_EXCL,
+-					  sb->s_type);
++								  sb->s_type);
+ 		if (IS_ERR(bdev))
+ 			return PTR_ERR(bdev);
+ 		dif->bdev = bdev;
+@@ -266,7 +294,7 @@ static int erofs_init_device(struct erofs_buf *buf, struct super_block *sb,
+ }
+ 
+ static int erofs_scan_devices(struct super_block *sb,
+-			      struct erofs_super_block *dsb)
++							  struct erofs_super_block *dsb)
+ {
+ 	struct erofs_sb_info *sbi = EROFS_SB(sb);
+ 	unsigned int ondisk_extradevs;
+@@ -282,9 +310,10 @@ static int erofs_scan_devices(struct super_block *sb,
+ 		ondisk_extradevs = le16_to_cpu(dsb->extra_devices);
+ 
+ 	if (sbi->devs->extra_devices &&
+-	    ondisk_extradevs != sbi->devs->extra_devices) {
++		ondisk_extradevs != sbi->devs->extra_devices)
++	{
+ 		erofs_err(sb, "extra devices don't match (ondisk %u, given %u)",
+-			  ondisk_extradevs, sbi->devs->extra_devices);
++				  ondisk_extradevs, sbi->devs->extra_devices);
+ 		return -EINVAL;
+ 	}
+ 	if (!ondisk_extradevs)
+@@ -293,22 +322,29 @@ static int erofs_scan_devices(struct super_block *sb,
+ 	sbi->device_id_mask = roundup_pow_of_two(ondisk_extradevs + 1) - 1;
+ 	pos = le16_to_cpu(dsb->devt_slotoff) * EROFS_DEVT_SLOT_SIZE;
+ 	down_read(&sbi->devs->rwsem);
+-	if (sbi->devs->extra_devices) {
+-		idr_for_each_entry(&sbi->devs->tree, dif, id) {
++	if (sbi->devs->extra_devices)
++	{
++		idr_for_each_entry(&sbi->devs->tree, dif, id)
++		{
+ 			err = erofs_init_device(&buf, sb, dif, &pos);
+ 			if (err)
+ 				break;
+ 		}
+-	} else {
+-		for (id = 0; id < ondisk_extradevs; id++) {
++	}
++	else
++	{
++		for (id = 0; id < ondisk_extradevs; id++)
++		{
+ 			dif = kzalloc(sizeof(*dif), GFP_KERNEL);
+-			if (!dif) {
++			if (!dif)
++			{
+ 				err = -ENOMEM;
+ 				break;
+ 			}
+ 
+ 			err = idr_alloc(&sbi->devs->tree, dif, 0, 0, GFP_KERNEL);
+-			if (err < 0) {
++			if (err < 0)
++			{
+ 				kfree(dif);
+ 				break;
+ 			}
+@@ -334,7 +370,8 @@ static int erofs_read_superblock(struct super_block *sb)
+ 	int ret;
+ 
+ 	data = erofs_read_metabuf(&buf, sb, 0, EROFS_KMAP);
+-	if (IS_ERR(data)) {
++	if (IS_ERR(data))
++	{
+ 		erofs_err(sb, "cannot read erofs superblock");
+ 		return PTR_ERR(data);
+ 	}
+@@ -343,13 +380,15 @@ static int erofs_read_superblock(struct super_block *sb)
+ 	dsb = (struct erofs_super_block *)(data + EROFS_SUPER_OFFSET);
+ 
+ 	ret = -EINVAL;
+-	if (le32_to_cpu(dsb->magic) != EROFS_SUPER_MAGIC_V1) {
++	if (le32_to_cpu(dsb->magic) != EROFS_SUPER_MAGIC_V1)
++	{
+ 		erofs_err(sb, "cannot find valid erofs superblock");
+ 		goto out;
+ 	}
+ 
+ 	sbi->feature_compat = le32_to_cpu(dsb->feature_compat);
+-	if (erofs_sb_has_sb_chksum(sbi)) {
++	if (erofs_sb_has_sb_chksum(sbi))
++	{
+ 		ret = erofs_superblock_csum_verify(sb, data);
+ 		if (ret)
+ 			goto out;
+@@ -358,9 +397,10 @@ static int erofs_read_superblock(struct super_block *sb)
+ 	ret = -EINVAL;
+ 	blkszbits = dsb->blkszbits;
+ 	/* 9(512 bytes) + LOG_SECTORS_PER_BLOCK == LOG_BLOCK_SIZE */
+-	if (blkszbits != LOG_BLOCK_SIZE) {
++	if (blkszbits != LOG_BLOCK_SIZE)
++	{
+ 		erofs_err(sb, "blkszbits %u isn't supported on this platform",
+-			  blkszbits);
++				  blkszbits);
+ 		goto out;
+ 	}
+ 
+@@ -368,9 +408,10 @@ static int erofs_read_superblock(struct super_block *sb)
+ 		goto out;
+ 
+ 	sbi->sb_size = 128 + dsb->sb_extslots * EROFS_SB_EXTSLOT_SIZE;
+-	if (sbi->sb_size > EROFS_BLKSIZ) {
++	if (sbi->sb_size > EROFS_BLKSIZ)
++	{
+ 		erofs_err(sb, "invalid sb_extslots %u (more than a fs block)",
+-			  sbi->sb_size);
++				  sbi->sb_size);
+ 		goto out;
+ 	}
+ 	sbi->primarydevice_blocks = le32_to_cpu(dsb->blocks);
+@@ -388,8 +429,9 @@ static int erofs_read_superblock(struct super_block *sb)
+ 	memcpy(&sb->s_uuid, dsb->uuid, sizeof(dsb->uuid));
+ 
+ 	ret = strscpy(sbi->volume_name, dsb->volume_name,
+-		      sizeof(dsb->volume_name));
+-	if (ret < 0) {	/* -E2BIG */
++				  sizeof(dsb->volume_name));
++	if (ret < 0)
++	{ /* -E2BIG */
+ 		erofs_err(sb, "bad volume name without NIL terminator");
+ 		ret = -EFSCORRUPTED;
+ 		goto out;
+@@ -431,7 +473,8 @@ static void erofs_default_options(struct erofs_fs_context *ctx)
+ #endif
+ }
+ 
+-enum {
++enum
++{
+ 	Opt_user_xattr,
+ 	Opt_acl,
+ 	Opt_cache_strategy,
+@@ -440,41 +483,41 @@ enum {
+ 	Opt_device,
+ 	Opt_fsid,
+ 	Opt_bootstrap_path,
++	Opt_blob_dir_path,
+ 	Opt_err
+ };
+ 
+ static const struct constant_table erofs_param_cache_strategy[] = {
+-	{"disabled",	EROFS_ZIP_CACHE_DISABLED},
+-	{"readahead",	EROFS_ZIP_CACHE_READAHEAD},
+-	{"readaround",	EROFS_ZIP_CACHE_READAROUND},
+-	{}
+-};
++	{"disabled", EROFS_ZIP_CACHE_DISABLED},
++	{"readahead", EROFS_ZIP_CACHE_READAHEAD},
++	{"readaround", EROFS_ZIP_CACHE_READAROUND},
++	{}};
+ 
+ static const struct constant_table erofs_dax_param_enums[] = {
+-	{"always",	EROFS_MOUNT_DAX_ALWAYS},
+-	{"never",	EROFS_MOUNT_DAX_NEVER},
+-	{}
+-};
++	{"always", EROFS_MOUNT_DAX_ALWAYS},
++	{"never", EROFS_MOUNT_DAX_NEVER},
++	{}};
+ 
+ static const struct fs_parameter_spec erofs_fs_parameters[] = {
+-	fsparam_flag_no("user_xattr",	Opt_user_xattr),
+-	fsparam_flag_no("acl",		Opt_acl),
+-	fsparam_enum("cache_strategy",	Opt_cache_strategy,
+-		     erofs_param_cache_strategy),
+-	fsparam_flag("dax",             Opt_dax),
+-	fsparam_enum("dax",		Opt_dax_enum, erofs_dax_param_enums),
+-	fsparam_string("device",	Opt_device),
+-	fsparam_string("fsid",		Opt_fsid),
+-	fsparam_string("bootstrap_path",	Opt_bootstrap_path),
+-	{}
+-};
++	fsparam_flag_no("user_xattr", Opt_user_xattr),
++	fsparam_flag_no("acl", Opt_acl),
++	fsparam_enum("cache_strategy", Opt_cache_strategy,
++				 erofs_param_cache_strategy),
++	fsparam_flag("dax", Opt_dax),
++	fsparam_enum("dax", Opt_dax_enum, erofs_dax_param_enums),
++	fsparam_string("device", Opt_device),
++	fsparam_string("fsid", Opt_fsid),
++	fsparam_string("bootstrap_path", Opt_bootstrap_path),
++	fsparam_string("blob_dir_path", Opt_blob_dir_path),
++	{}};
+ 
+ static bool erofs_fc_set_dax_mode(struct fs_context *fc, unsigned int mode)
+ {
+ #ifdef CONFIG_FS_DAX
+ 	struct erofs_fs_context *ctx = fc->fs_private;
+ 
+-	switch (mode) {
++	switch (mode)
++	{
+ 	case EROFS_MOUNT_DAX_ALWAYS:
+ 		warnfc(fc, "DAX enabled. Warning: EXPERIMENTAL, use at your own risk");
+ 		set_opt(&ctx->opt, DAX_ALWAYS);
+@@ -495,7 +538,7 @@ static bool erofs_fc_set_dax_mode(struct fs_context *fc, unsigned int mode)
+ }
+ 
+ static int erofs_fc_parse_param(struct fs_context *fc,
+-				struct fs_parameter *param)
++								struct fs_parameter *param)
+ {
+ 	struct erofs_fs_context *ctx = fc->fs_private;
+ 	struct fs_parse_result result;
+@@ -506,7 +549,8 @@ static int erofs_fc_parse_param(struct fs_context *fc,
+ 	if (opt < 0)
+ 		return opt;
+ 
+-	switch (opt) {
++	switch (opt)
++	{
+ 	case Opt_user_xattr:
+ #ifdef CONFIG_EROFS_FS_XATTR
+ 		if (result.boolean)
+@@ -547,14 +591,16 @@ static int erofs_fc_parse_param(struct fs_context *fc,
+ 		if (!dif)
+ 			return -ENOMEM;
+ 		dif->path = kstrdup(param->string, GFP_KERNEL);
+-		if (!dif->path) {
++		if (!dif->path)
++		{
+ 			kfree(dif);
+ 			return -ENOMEM;
+ 		}
+ 		down_write(&ctx->devs->rwsem);
+ 		ret = idr_alloc(&ctx->devs->tree, dif, 0, 0, GFP_KERNEL);
+ 		up_write(&ctx->devs->rwsem);
+-		if (ret < 0) {
++		if (ret < 0)
++		{
+ 			kfree(dif->path);
+ 			kfree(dif);
+ 			return ret;
+@@ -568,6 +614,13 @@ static int erofs_fc_parse_param(struct fs_context *fc,
+ 			return -ENOMEM;
+ 		infofc(fc, "RAFS bootstrap_path %s", ctx->bootstrap_path);
+ 		break;
++	case Opt_blob_dir_path:
++		kfree(ctx->blob_dir_path);
++		ctx->blob_dir_path = kstrdup(param->string, GFP_KERNEL);
++		if (!ctx->blob_dir_path)
++			return -ENOMEM;
++		infofc(fc, "RAFS blob_dir_path %s", ctx->blob_dir_path);
++		break;
+ 	case Opt_fsid:
+ #ifdef CONFIG_EROFS_FS_ONDEMAND
+ 		kfree(ctx->opt.fsid);
+@@ -607,7 +660,7 @@ static bool erofs_managed_cache_release_folio(struct folio *folio, gfp_t gfp)
+  * We could introduce an extra locking instead but it seems unnecessary.
+  */
+ static void erofs_managed_cache_invalidate_folio(struct folio *folio,
+-					       size_t offset, size_t length)
++												 size_t offset, size_t length)
+ {
+ 	const size_t stop = length + offset;
+ 
+@@ -643,27 +696,30 @@ static int erofs_init_managed_cache(struct super_block *sb)
+ 	return 0;
+ }
+ #else
+-static int erofs_init_managed_cache(struct super_block *sb) { return 0; }
++static int erofs_init_managed_cache(struct super_block *sb)
++{
++	return 0;
++}
+ #endif
+ 
+ static struct inode *erofs_nfs_get_inode(struct super_block *sb,
+-					 u64 ino, u32 generation)
++										 u64 ino, u32 generation)
+ {
+ 	return erofs_iget(sb, ino, false);
+ }
+ 
+ static struct dentry *erofs_fh_to_dentry(struct super_block *sb,
+-		struct fid *fid, int fh_len, int fh_type)
++										 struct fid *fid, int fh_len, int fh_type)
+ {
+ 	return generic_fh_to_dentry(sb, fid, fh_len, fh_type,
+-				    erofs_nfs_get_inode);
++								erofs_nfs_get_inode);
+ }
+ 
+ static struct dentry *erofs_fh_to_parent(struct super_block *sb,
+-		struct fid *fid, int fh_len, int fh_type)
++										 struct fid *fid, int fh_len, int fh_type)
+ {
+ 	return generic_fh_to_parent(sb, fid, fh_len, fh_type,
+-				    erofs_nfs_get_inode);
++								erofs_nfs_get_inode);
+ }
+ 
+ static struct dentry *erofs_get_parent(struct dentry *child)
+@@ -688,7 +744,8 @@ static int rafs_v6_fill_super(struct super_block *sb)
+ {
+ 	struct erofs_sb_info *sbi = EROFS_SB(sb);
+ 
+-	if (sbi->bootstrap_path) {
++	if (sbi->bootstrap_path)
++	{
+ 		struct file *f;
+ 
+ 		f = filp_open(sbi->bootstrap_path, O_RDONLY, 0644);
+@@ -696,7 +753,19 @@ static int rafs_v6_fill_super(struct super_block *sb)
+ 			return PTR_ERR(f);
+ 		sbi->bootstrap = f;
+ 	}
+-	/* TODO: open each blobfiles */
++	if (sbi->blob_dir_path)
++	{
++		int ret = kern_path(sbi->blob_dir_path,
++							LOOKUP_FOLLOW | LOOKUP_DIRECTORY,
++							&sbi->blob_dir);
++
++		if (ret)
++		{
++			kfree(sbi->blob_dir_path);
++			sbi->blob_dir_path = NULL;
++			return ret;
++		}
++	}
+ 	return 0;
+ }
+ 
+@@ -723,8 +792,11 @@ static int erofs_fc_fill_super(struct super_block *sb, struct fs_context *fc)
+ 	ctx->devs = NULL;
+ 	sbi->bootstrap_path = ctx->bootstrap_path;
+ 	ctx->bootstrap_path = NULL;
++	sbi->blob_dir_path = ctx->blob_dir_path;
++	ctx->blob_dir_path = NULL;
+ 
+-	if (erofs_is_fscache_mode(sb)) {
++	if (erofs_is_fscache_mode(sb))
++	{
+ 		sb->s_blocksize = EROFS_BLKSIZ;
+ 		sb->s_blocksize_bits = LOG_BLOCK_SIZE;
+ 
+@@ -733,383 +805,408 @@ static int erofs_fc_fill_super(struct super_block *sb, struct fs_context *fc)
+ 			return err;
+ 
+ 		err = erofs_fscache_register_cookie(sb, &sbi->s_fscache,
+-						    sbi->opt.fsid, true);
++											sbi->opt.fsid, true);
+ 		if (err)
+ 			return err;
+ 
+ 		err = super_setup_bdi(sb);
+ 		if (err)
+ 			return err;
+-	} else {
+-		if (!sb_set_blocksize(sb, EROFS_BLKSIZ)) {
++	}
++	else
++	{
++		if (!sb_set_blocksize(sb, EROFS_BLKSIZ))
++		{
+ 			erofs_err(sb, "failed to set erofs blksize");
+ 			return -EINVAL;
+ 		}
+ 
+ 		sbi->dax_dev = fs_dax_get_by_bdev(sb->s_bdev,
+-						  &sbi->dax_part_off);
++										  &sbi->dax_part_off);
+ 	}
+ 
+ 	err = erofs_read_superblock(sb);
+ 	if (err)
+ 		return err;
+ 
+-	if (sb->s_blocksize_bits != sbi->blkszbits) {
+-		if (erofs_is_fscache_mode(sb)) {
++	if (sb->s_blocksize_bits != sbi->blkszbits)
++	{
++		if (erofs_is_fscache_mode(sb))
++		{
+ 			errorfc(fc, "unsupported blksize for fscache mode");
+ 			return -EINVAL;
+ 		}
+-		if (!sb_set_blocksize(sb, 1 << sbi->blkszbits)) {
+-		if (sb->s_bdev && !sb_set_blocksize(sb, 1 << sbi->blkszbits)) {
+-			errorfc(fc, "failed to set erofs blksize");
+-			return -EINVAL;
+-		} else {
+-			sb->s_blocksize =  1 << sbi->blkszbits;
+-			sb->s_blocksize_bits = sbi->blkszbits;
++		if (!sb_set_blocksize(sb, 1 << sbi->blkszbits))
++		{
++			if (sb->s_bdev && !sb_set_blocksize(sb, 1 << sbi->blkszbits))
++			{
++				errorfc(fc, "failed to set erofs blksize");
++				return -EINVAL;
++			}
++			else
++			{
++				sb->s_blocksize = 1 << sbi->blkszbits;
++				sb->s_blocksize_bits = sbi->blkszbits;
++			}
+ 		}
+-	}
+ 
+-	err = rafs_v6_fill_super(sb);
+-	if (err)
+-		return err;
++		err = rafs_v6_fill_super(sb);
++		if (err)
++			return err;
+ 
+-	if (test_opt(&sbi->opt, DAX_ALWAYS)) {
+-		BUILD_BUG_ON(EROFS_BLKSIZ != PAGE_SIZE);
++		if (test_opt(&sbi->opt, DAX_ALWAYS))
++		{
++			BUILD_BUG_ON(EROFS_BLKSIZ != PAGE_SIZE);
+ 
+-		if (!sbi->dax_dev) {
+-			errorfc(fc, "DAX unsupported by block device. Turning off DAX.");
+-			clear_opt(&sbi->opt, DAX_ALWAYS);
++			if (!sbi->dax_dev)
++			{
++				errorfc(fc, "DAX unsupported by block device. Turning off DAX.");
++				clear_opt(&sbi->opt, DAX_ALWAYS);
++			}
+ 		}
+-	}
+ 
+-	sb->s_time_gran = 1;
+-	sb->s_xattr = erofs_xattr_handlers;
+-	sb->s_export_op = &erofs_export_ops;
++		sb->s_time_gran = 1;
++		sb->s_xattr = erofs_xattr_handlers;
++		sb->s_export_op = &erofs_export_ops;
+ 
+-	if (test_opt(&sbi->opt, POSIX_ACL))
+-		sb->s_flags |= SB_POSIXACL;
+-	else
+-		sb->s_flags &= ~SB_POSIXACL;
++		if (test_opt(&sbi->opt, POSIX_ACL))
++			sb->s_flags |= SB_POSIXACL;
++		else
++			sb->s_flags &= ~SB_POSIXACL;
+ 
+ #ifdef CONFIG_EROFS_FS_ZIP
+-	xa_init(&sbi->managed_pslots);
++		xa_init(&sbi->managed_pslots);
+ #endif
+ 
+-	/* get the root inode */
+-	inode = erofs_iget(sb, ROOT_NID(sbi), true);
+-	if (IS_ERR(inode))
+-		return PTR_ERR(inode);
+-
+-	if (!S_ISDIR(inode->i_mode)) {
+-		erofs_err(sb, "rootino(nid %llu) is not a directory(i_mode %o)",
+-			  ROOT_NID(sbi), inode->i_mode);
+-		iput(inode);
+-		return -EINVAL;
+-	}
+-
+-	sb->s_root = d_make_root(inode);
+-	if (!sb->s_root)
+-		return -ENOMEM;
+-
+-	erofs_shrinker_register(sb);
+-	/* sb->s_umount is already locked, SB_ACTIVE and SB_BORN are not set */
+-	err = erofs_init_managed_cache(sb);
+-	if (err)
+-		return err;
++		/* get the root inode */
++		inode = erofs_iget(sb, ROOT_NID(sbi), true);
++		if (IS_ERR(inode))
++			return PTR_ERR(inode);
+ 
+-	err = erofs_register_sysfs(sb);
+-	if (err)
+-		return err;
++		if (!S_ISDIR(inode->i_mode))
++		{
++			erofs_err(sb, "rootino(nid %llu) is not a directory(i_mode %o)",
++					  ROOT_NID(sbi), inode->i_mode);
++			iput(inode);
++			return -EINVAL;
++		}
+ 
+-	erofs_info(sb, "mounted with root inode @ nid %llu.", ROOT_NID(sbi));
+-	return 0;
+-}
++		sb->s_root = d_make_root(inode);
++		if (!sb->s_root)
++			return -ENOMEM;
+ 
+-static int erofs_fc_get_tree(struct fs_context *fc)
+-{
+-	struct erofs_fs_context *ctx = fc->fs_private;
++		erofs_shrinker_register(sb);
++		/* sb->s_umount is already locked, SB_ACTIVE and SB_BORN are not set */
++		err = erofs_init_managed_cache(sb);
++		if (err)
++			return err;
+ 
+-	if (IS_ENABLED(CONFIG_EROFS_FS_ONDEMAND) && ctx->opt.fsid)
+-		return get_tree_nodev(fc, erofs_fc_fill_super);
++		err = erofs_register_sysfs(sb);
++		if (err)
++			return err;
+ 
+-	if (ctx->bootstrap_path)
+-		return get_tree_nodev(fc, erofs_fc_fill_super);
++		erofs_info(sb, "mounted with root inode @ nid %llu.", ROOT_NID(sbi));
++		return 0;
++	}
+ 
+-	return get_tree_bdev(fc, erofs_fc_fill_super);
+-}
++	static int erofs_fc_get_tree(struct fs_context * fc)
++	{
++		struct erofs_fs_context *ctx = fc->fs_private;
+ 
+-static int erofs_fc_reconfigure(struct fs_context *fc)
+-{
+-	struct super_block *sb = fc->root->d_sb;
+-	struct erofs_sb_info *sbi = EROFS_SB(sb);
+-	struct erofs_fs_context *ctx = fc->fs_private;
++		if (IS_ENABLED(CONFIG_EROFS_FS_ONDEMAND) && ctx->opt.fsid)
++			return get_tree_nodev(fc, erofs_fc_fill_super);
+ 
+-	DBG_BUGON(!sb_rdonly(sb));
++		if (ctx->bootstrap_path && ctx->blob_dir_path)
++			return get_tree_nodev(fc, erofs_fc_fill_super);
+ 
+-	if (test_opt(&ctx->opt, POSIX_ACL))
+-		fc->sb_flags |= SB_POSIXACL;
+-	else
+-		fc->sb_flags &= ~SB_POSIXACL;
++		return get_tree_bdev(fc, erofs_fc_fill_super);
++	}
+ 
+-	sbi->opt = ctx->opt;
++	static int erofs_fc_reconfigure(struct fs_context * fc)
++	{
++		struct super_block *sb = fc->root->d_sb;
++		struct erofs_sb_info *sbi = EROFS_SB(sb);
++		struct erofs_fs_context *ctx = fc->fs_private;
+ 
+-	fc->sb_flags |= SB_RDONLY;
+-	return 0;
+-}
++		DBG_BUGON(!sb_rdonly(sb));
+ 
+-static int erofs_release_device_info(int id, void *ptr, void *data)
+-{
+-	struct erofs_device_info *dif = ptr;
+-
+-	fs_put_dax(dif->dax_dev);
+-	if (dif->bdev)
+-		blkdev_put(dif->bdev, FMODE_READ | FMODE_EXCL);
+-	erofs_fscache_unregister_cookie(&dif->fscache);
+-	kfree(dif->path);
+-	kfree(dif);
+-	return 0;
+-}
++		if (test_opt(&ctx->opt, POSIX_ACL))
++			fc->sb_flags |= SB_POSIXACL;
++		else
++			fc->sb_flags &= ~SB_POSIXACL;
+ 
+-static void erofs_free_dev_context(struct erofs_dev_context *devs)
+-{
+-	if (!devs)
+-		return;
+-	idr_for_each(&devs->tree, &erofs_release_device_info, NULL);
+-	idr_destroy(&devs->tree);
+-	kfree(devs);
+-}
++		sbi->opt = ctx->opt;
+ 
+-static void erofs_fc_free(struct fs_context *fc)
+-{
+-	struct erofs_fs_context *ctx = fc->fs_private;
++		fc->sb_flags |= SB_RDONLY;
++		return 0;
++	}
+ 
+-	erofs_free_dev_context(ctx->devs);
+-	kfree(ctx->opt.fsid);
+-	kfree(ctx);
+-}
++	static int erofs_release_device_info(int id, void *ptr, void *data)
++	{
++		struct erofs_device_info *dif = ptr;
++
++		fs_put_dax(dif->dax_dev);
++		if (dif->bdev)
++			blkdev_put(dif->bdev, FMODE_READ | FMODE_EXCL);
++		if (dif->blobfile)
++			filp_close(dif->blobfile, NULL);
++		erofs_fscache_unregister_cookie(&dif->fscache);
++		kfree(dif->path);
++		kfree(dif);
++		return 0;
++	}
+ 
+-static const struct fs_context_operations erofs_context_ops = {
+-	.parse_param	= erofs_fc_parse_param,
+-	.get_tree       = erofs_fc_get_tree,
+-	.reconfigure    = erofs_fc_reconfigure,
+-	.free		= erofs_fc_free,
+-};
++	static void erofs_free_dev_context(struct erofs_dev_context * devs)
++	{
++		if (!devs)
++			return;
++		idr_for_each(&devs->tree, &erofs_release_device_info, NULL);
++		idr_destroy(&devs->tree);
++		kfree(devs);
++	}
+ 
+-static int erofs_init_fs_context(struct fs_context *fc)
+-{
+-	struct erofs_fs_context *ctx = kzalloc(sizeof(*ctx), GFP_KERNEL);
++	static void erofs_fc_free(struct fs_context * fc)
++	{
++		struct erofs_fs_context *ctx = fc->fs_private;
+ 
+-	if (!ctx)
+-		return -ENOMEM;
+-	ctx->devs = kzalloc(sizeof(struct erofs_dev_context), GFP_KERNEL);
+-	if (!ctx->devs) {
++		erofs_free_dev_context(ctx->devs);
++		kfree(ctx->opt.fsid);
+ 		kfree(ctx);
+-		return -ENOMEM;
+ 	}
+-	fc->fs_private = ctx;
+-
+-	idr_init(&ctx->devs->tree);
+-	init_rwsem(&ctx->devs->rwsem);
+-	erofs_default_options(ctx);
+-	fc->ops = &erofs_context_ops;
+-	return 0;
+-}
+ 
+-/*
+- * could be triggered after deactivate_locked_super()
+- * is called, thus including umount and failed to initialize.
+- */
+-static void erofs_kill_sb(struct super_block *sb)
+-{
+-	struct erofs_sb_info *sbi;
++	static const struct fs_context_operations erofs_context_ops = {
++		.parse_param = erofs_fc_parse_param,
++		.get_tree = erofs_fc_get_tree,
++		.reconfigure = erofs_fc_reconfigure,
++		.free = erofs_fc_free,
++	};
+ 
+-	WARN_ON(sb->s_magic != EROFS_SUPER_MAGIC);
++	static int erofs_init_fs_context(struct fs_context * fc)
++	{
++		struct erofs_fs_context *ctx = kzalloc(sizeof(*ctx), GFP_KERNEL);
+ 
+-	if (sb->s_bdev)
+-		kill_block_super(sb);
+-	else
+-		kill_anon_super(sb);
++		if (!ctx)
++			return -ENOMEM;
++		ctx->devs = kzalloc(sizeof(struct erofs_dev_context), GFP_KERNEL);
++		if (!ctx->devs)
++		{
++			kfree(ctx);
++			return -ENOMEM;
++		}
++		fc->fs_private = ctx;
+ 
+-	sbi = EROFS_SB(sb);
+-	if (!sbi)
+-		return;
+-
+-	erofs_free_dev_context(sbi->devs);
+-	fs_put_dax(sbi->dax_dev);
+-	erofs_fscache_unregister_cookie(&sbi->s_fscache);
+-	erofs_fscache_unregister_fs(sb);
+-	kfree(sbi->opt.fsid);
+-	kfree(sbi);
+-	sb->s_fs_info = NULL;
+-}
++		idr_init(&ctx->devs->tree);
++		init_rwsem(&ctx->devs->rwsem);
++		erofs_default_options(ctx);
++		fc->ops = &erofs_context_ops;
++		return 0;
++	}
+ 
+-/* called when ->s_root is non-NULL */
+-static void erofs_put_super(struct super_block *sb)
+-{
+-	struct erofs_sb_info *const sbi = EROFS_SB(sb);
++	/*
++	 * could be triggered after deactivate_locked_super()
++	 * is called, thus including umount and failed to initialize.
++	 */
++	static void erofs_kill_sb(struct super_block * sb)
++	{
++		struct erofs_sb_info *sbi;
+ 
+-	DBG_BUGON(!sbi);
+-	
+-	if (sbi->bootstrap)
+-		filp_close(sbi->bootstrap, NULL);
+-	kfree(sbi->bootstrap_path);
++		WARN_ON(sb->s_magic != EROFS_SUPER_MAGIC);
+ 
+-	erofs_unregister_sysfs(sb);
+-	erofs_shrinker_unregister(sb);
+-#ifdef CONFIG_EROFS_FS_ZIP
+-	iput(sbi->managed_cache);
+-	sbi->managed_cache = NULL;
+-#endif
+-	erofs_fscache_unregister_cookie(&sbi->s_fscache);
+-}
++		if (sb->s_bdev)
++			kill_block_super(sb);
++		else
++			kill_anon_super(sb);
++
++		sbi = EROFS_SB(sb);
++		if (!sbi)
++			return;
++
++		erofs_free_dev_context(sbi->devs);
++		if (sbi->bootstrap)
++			filp_close(sbi->bootstrap, NULL);
++		if (sbi->blob_dir_path)
++		{
++			path_put(&sbi->blob_dir);
++			kfree(sbi->blob_dir_path);
++		}
++		kfree(sbi->bootstrap_path);
++		fs_put_dax(sbi->dax_dev);
++		erofs_fscache_unregister_cookie(&sbi->s_fscache);
++		erofs_fscache_unregister_fs(sb);
++		kfree(sbi->opt.fsid);
++		kfree(sbi);
++		sb->s_fs_info = NULL;
++	}
+ 
+-static struct file_system_type erofs_fs_type = {
+-	.owner          = THIS_MODULE,
+-	.name           = "erofs",
+-	.init_fs_context = erofs_init_fs_context,
+-	.kill_sb        = erofs_kill_sb,
+-	.fs_flags       = FS_REQUIRES_DEV | FS_ALLOW_IDMAP,
+-};
+-MODULE_ALIAS_FS("erofs");
++	/* called when ->s_root is non-NULL */
++	static void erofs_put_super(struct super_block * sb)
++	{
++		struct erofs_sb_info *const sbi = EROFS_SB(sb);
+ 
+-static int __init erofs_module_init(void)
+-{
+-	int err;
++		DBG_BUGON(!sbi);
+ 
+-	erofs_check_ondisk_layout_definitions();
++		if (sbi->bootstrap)
++			filp_close(sbi->bootstrap, NULL);
++		kfree(sbi->bootstrap_path);
+ 
+-	erofs_inode_cachep = kmem_cache_create("erofs_inode",
+-					       sizeof(struct erofs_inode), 0,
+-					       SLAB_RECLAIM_ACCOUNT,
+-					       erofs_inode_init_once);
+-	if (!erofs_inode_cachep) {
+-		err = -ENOMEM;
+-		goto icache_err;
++		erofs_unregister_sysfs(sb);
++		erofs_shrinker_unregister(sb);
++#ifdef CONFIG_EROFS_FS_ZIP
++		iput(sbi->managed_cache);
++		sbi->managed_cache = NULL;
++#endif
++		erofs_fscache_unregister_cookie(&sbi->s_fscache);
+ 	}
+ 
+-	err = erofs_init_shrinker();
+-	if (err)
+-		goto shrinker_err;
++	static struct file_system_type erofs_fs_type = {
++		.owner = THIS_MODULE,
++		.name = "erofs",
++		.init_fs_context = erofs_init_fs_context,
++		.kill_sb = erofs_kill_sb,
++		.fs_flags = FS_REQUIRES_DEV | FS_ALLOW_IDMAP,
++	};
++	MODULE_ALIAS_FS("erofs");
++
++	static int __init erofs_module_init(void)
++	{
++		int err;
++
++		erofs_check_ondisk_layout_definitions();
++
++		erofs_inode_cachep = kmem_cache_create("erofs_inode",
++											   sizeof(struct erofs_inode), 0,
++											   SLAB_RECLAIM_ACCOUNT,
++											   erofs_inode_init_once);
++		if (!erofs_inode_cachep)
++		{
++			err = -ENOMEM;
++			goto icache_err;
++		}
+ 
+-	err = z_erofs_lzma_init();
+-	if (err)
+-		goto lzma_err;
++		err = erofs_init_shrinker();
++		if (err)
++			goto shrinker_err;
+ 
+-	erofs_pcpubuf_init();
+-	err = z_erofs_init_zip_subsystem();
+-	if (err)
+-		goto zip_err;
++		err = z_erofs_lzma_init();
++		if (err)
++			goto lzma_err;
+ 
+-	err = erofs_init_sysfs();
+-	if (err)
+-		goto sysfs_err;
++		erofs_pcpubuf_init();
++		err = z_erofs_init_zip_subsystem();
++		if (err)
++			goto zip_err;
+ 
+-	err = register_filesystem(&erofs_fs_type);
+-	if (err)
+-		goto fs_err;
++		err = erofs_init_sysfs();
++		if (err)
++			goto sysfs_err;
+ 
+-	return 0;
++		err = register_filesystem(&erofs_fs_type);
++		if (err)
++			goto fs_err;
+ 
+-fs_err:
+-	erofs_exit_sysfs();
+-sysfs_err:
+-	z_erofs_exit_zip_subsystem();
+-zip_err:
+-	z_erofs_lzma_exit();
+-lzma_err:
+-	erofs_exit_shrinker();
+-shrinker_err:
+-	kmem_cache_destroy(erofs_inode_cachep);
+-icache_err:
+-	return err;
+-}
++		return 0;
+ 
+-static void __exit erofs_module_exit(void)
+-{
+-	unregister_filesystem(&erofs_fs_type);
++	fs_err:
++		erofs_exit_sysfs();
++	sysfs_err:
++		z_erofs_exit_zip_subsystem();
++	zip_err:
++		z_erofs_lzma_exit();
++	lzma_err:
++		erofs_exit_shrinker();
++	shrinker_err:
++		kmem_cache_destroy(erofs_inode_cachep);
++	icache_err:
++		return err;
++	}
+ 
+-	/* Ensure all RCU free inodes / pclusters are safe to be destroyed. */
+-	rcu_barrier();
++	static void __exit erofs_module_exit(void)
++	{
++		unregister_filesystem(&erofs_fs_type);
+ 
+-	erofs_exit_sysfs();
+-	z_erofs_exit_zip_subsystem();
+-	z_erofs_lzma_exit();
+-	erofs_exit_shrinker();
+-	kmem_cache_destroy(erofs_inode_cachep);
+-	erofs_pcpubuf_exit();
+-}
++		/* Ensure all RCU free inodes / pclusters are safe to be destroyed. */
++		rcu_barrier();
+ 
+-/* get filesystem statistics */
+-static int erofs_statfs(struct dentry *dentry, struct kstatfs *buf)
+-{
+-	struct super_block *sb = dentry->d_sb;
+-	struct erofs_sb_info *sbi = EROFS_SB(sb);
+-	u64 id = 0;
++		erofs_exit_sysfs();
++		z_erofs_exit_zip_subsystem();
++		z_erofs_lzma_exit();
++		erofs_exit_shrinker();
++		kmem_cache_destroy(erofs_inode_cachep);
++		erofs_pcpubuf_exit();
++	}
+ 
+-	if (sb->s_bdev)
+-		id = huge_encode_dev(sb->s_bdev->bd_dev);
++	/* get filesystem statistics */
++	static int erofs_statfs(struct dentry * dentry, struct kstatfs * buf)
++	{
++		struct super_block *sb = dentry->d_sb;
++		struct erofs_sb_info *sbi = EROFS_SB(sb);
++		u64 id = 0;
+ 
+-	buf->f_type = sb->s_magic;
+-	buf->f_bsize = EROFS_BLKSIZ;
+-	buf->f_blocks = sbi->total_blocks;
+-	buf->f_bfree = buf->f_bavail = 0;
++		if (sb->s_bdev)
++			id = huge_encode_dev(sb->s_bdev->bd_dev);
+ 
+-	buf->f_files = ULLONG_MAX;
+-	buf->f_ffree = ULLONG_MAX - sbi->inos;
++		buf->f_type = sb->s_magic;
++		buf->f_bsize = EROFS_BLKSIZ;
++		buf->f_blocks = sbi->total_blocks;
++		buf->f_bfree = buf->f_bavail = 0;
+ 
+-	buf->f_namelen = EROFS_NAME_LEN;
++		buf->f_files = ULLONG_MAX;
++		buf->f_ffree = ULLONG_MAX - sbi->inos;
+ 
+-	buf->f_fsid    = u64_to_fsid(id);
+-	return 0;
+-}
++		buf->f_namelen = EROFS_NAME_LEN;
+ 
+-static int erofs_show_options(struct seq_file *seq, struct dentry *root)
+-{
+-	struct erofs_sb_info *sbi = EROFS_SB(root->d_sb);
+-	struct erofs_mount_opts *opt = &sbi->opt;
++		buf->f_fsid = u64_to_fsid(id);
++		return 0;
++	}
++
++	static int erofs_show_options(struct seq_file * seq, struct dentry * root)
++	{
++		struct erofs_sb_info *sbi = EROFS_SB(root->d_sb);
++		struct erofs_mount_opts *opt = &sbi->opt;
+ 
+ #ifdef CONFIG_EROFS_FS_XATTR
+-	if (test_opt(opt, XATTR_USER))
+-		seq_puts(seq, ",user_xattr");
+-	else
+-		seq_puts(seq, ",nouser_xattr");
++		if (test_opt(opt, XATTR_USER))
++			seq_puts(seq, ",user_xattr");
++		else
++			seq_puts(seq, ",nouser_xattr");
+ #endif
+ #ifdef CONFIG_EROFS_FS_POSIX_ACL
+-	if (test_opt(opt, POSIX_ACL))
+-		seq_puts(seq, ",acl");
+-	else
+-		seq_puts(seq, ",noacl");
++		if (test_opt(opt, POSIX_ACL))
++			seq_puts(seq, ",acl");
++		else
++			seq_puts(seq, ",noacl");
+ #endif
+ #ifdef CONFIG_EROFS_FS_ZIP
+-	if (opt->cache_strategy == EROFS_ZIP_CACHE_DISABLED)
+-		seq_puts(seq, ",cache_strategy=disabled");
+-	else if (opt->cache_strategy == EROFS_ZIP_CACHE_READAHEAD)
+-		seq_puts(seq, ",cache_strategy=readahead");
+-	else if (opt->cache_strategy == EROFS_ZIP_CACHE_READAROUND)
+-		seq_puts(seq, ",cache_strategy=readaround");
++		if (opt->cache_strategy == EROFS_ZIP_CACHE_DISABLED)
++			seq_puts(seq, ",cache_strategy=disabled");
++		else if (opt->cache_strategy == EROFS_ZIP_CACHE_READAHEAD)
++			seq_puts(seq, ",cache_strategy=readahead");
++		else if (opt->cache_strategy == EROFS_ZIP_CACHE_READAROUND)
++			seq_puts(seq, ",cache_strategy=readaround");
+ #endif
+-	if (test_opt(opt, DAX_ALWAYS))
+-		seq_puts(seq, ",dax=always");
+-	if (test_opt(opt, DAX_NEVER))
+-		seq_puts(seq, ",dax=never");
++		if (test_opt(opt, DAX_ALWAYS))
++			seq_puts(seq, ",dax=always");
++		if (test_opt(opt, DAX_NEVER))
++			seq_puts(seq, ",dax=never");
+ #ifdef CONFIG_EROFS_FS_ONDEMAND
+-	if (opt->fsid)
+-		seq_printf(seq, ",fsid=%s", opt->fsid);
++		if (opt->fsid)
++			seq_printf(seq, ",fsid=%s", opt->fsid);
+ #endif
+-	return 0;
+-}
++		return 0;
++	}
+ 
+-const struct super_operations erofs_sops = {
+-	.put_super = erofs_put_super,
+-	.alloc_inode = erofs_alloc_inode,
+-	.free_inode = erofs_free_inode,
+-	.statfs = erofs_statfs,
+-	.show_options = erofs_show_options,
+-};
++	const struct super_operations erofs_sops = {
++		.put_super = erofs_put_super,
++		.alloc_inode = erofs_alloc_inode,
++		.free_inode = erofs_free_inode,
++		.statfs = erofs_statfs,
++		.show_options = erofs_show_options,
++	};
+ 
+-module_init(erofs_module_init);
+-module_exit(erofs_module_exit);
++	module_init(erofs_module_init);
++	module_exit(erofs_module_exit);
+ 
+-MODULE_DESCRIPTION("Enhanced ROM File System");
+-MODULE_AUTHOR("Gao Xiang, Chao Yu, Miao Xie, CONSUMER BG, HUAWEI Inc.");
+-MODULE_LICENSE("GPL");
++	MODULE_DESCRIPTION("Enhanced ROM File System");
++	MODULE_AUTHOR("Gao Xiang, Chao Yu, Miao Xie, CONSUMER BG, HUAWEI Inc.");
++	MODULE_LICENSE("GPL");
++}
+-- 
+2.21.1 (Apple Git-122.3)
+


### PR DESCRIPTION
Depend on kernel patch where nydus v6 could also be handled by the guest kernel.
With that patch, bootstrap and blobs are shared with guest VM via passthroughfs and blobfs so that they can be mounted inside guest.