### PR TITLE
libs: protection: Fix typo in TDX output

### DIFF
--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -42,7 +42,7 @@ impl fmt::Display for GuestProtection {
         match self {
             GuestProtection::Tdx(details) => write!(
                 f,
-                "tdx (major_version: {}, minor_version: {}",
+                "tdx (major_version: {}, minor_version: {})",
                 details.major_version, details.minor_version
             ),
             GuestProtection::Sev => write!(f, "sev"),
@@ -363,12 +363,15 @@ mod tests {
 
         let result = result.unwrap();
 
-        let details = match result {
+        let details = match &result {
             GuestProtection::Tdx(details) => details,
             _ => panic!(),
         };
 
         assert_eq!(details.major_version, 1);
         assert_eq!(details.minor_version, 0);
+
+        let displayed_value = result.to_string();
+        assert_eq!(displayed_value, "tdx (major_version: 1, minor_version: 0)");
     }
 }


### PR DESCRIPTION
Add the missing closing bracket to the output of the TDX details, so rather than:

```bash
$ sudo kata-ctl env 2>/dev/null | grep available_guest_protection
available_guest_protection = "tdx (major_version: 1, minor_version: 0"
:                                                                    ^
:                                                           Missing ')' !
```

... we now have:

```bash
$ sudo kata-ctl env 2>/dev/null | grep available_guest_protection
available_guest_protection = "tdx (major_version: 1, minor_version: 0)"
:                                                                    ^
:                                                                   Aha!
```

Added a unit test for this scenario.

Fixes: #8257.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>