### PR TITLE
docs: Update vexxhost instructions

### DIFF
--- a/docs/install/vexxhost-installation-guide.md
+++ b/docs/install/vexxhost-installation-guide.md
@@ -8,8 +8,8 @@ to remotely connect to your virtual machine (SSH).
 
 ## Create a new virtual machine with nesting support
 
-All regions support nested virtualization using the V2 flavors (those prefixed
-with v2).  The recommended machine type for container workloads is `v2-highcpu` range.
+All regions support nested virtualization.  The recommended machine type for
+container workloads is the `v3-standard` range.
 
 ## Set up with distribution specific quick start
 


### PR DESCRIPTION
Current machines use v3 rather than v2

Fixes https://github.com/kata-containers/kata-containers/issues/8263