### PR TITLE
kata-deploy: fix deprecations on kustomization files

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/base/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - kata-cleanup.yaml

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_k3s_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_k3s_conf.yaml

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_rke2_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_rke2_conf.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/base/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - kata-deploy.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/k0s/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/k0s/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_k0s_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_k0s_conf.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/k3s/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/k3s/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_k3s_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_k3s_conf.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/rke2/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/rke2/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_rke2_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_rke2_conf.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/stable/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/stable/kustomization.yaml
@@ -1,4 +1,6 @@
-bases:
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
 - ../../base
 
 images:

--- a/tools/packaging/kata-deploy/kata-rbac/base/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-rbac/base/kustomization.yaml
@@ -1,2 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
 resources:
 - kata-rbac.yaml


### PR DESCRIPTION
By running `kustomize edit fix` on those files they have changed deprecated instructions ('bases' and 'patchesStrategicMerge') as well as 'apiVersion' and 'kind' were added.

Fixes #8268
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>