### PR TITLE
tests: more k8s-exec-rejected debug output

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-exec-rejected.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-exec-rejected.yaml
@@ -1,0 +1,22 @@
+#
+# Copyright (c) 2023 Microsoft
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-exec-rejected
+spec:
+  terminationGracePeriodSeconds: 0
+  shareProcessNamespace: true
+  runtimeClassName: kata
+  containers:
+    - name: first-test-container
+      image: quay.io/prometheus/busybox:latest
+      env:
+        - name: CONTAINER_NAME
+          value: "first-test-container"
+      command:
+        - sleep
+        - "120"


### PR DESCRIPTION
Print more information useful for debugging. Also, use a separate YAML file for this test, instead of reusing someone else's file.

Fixes: #8270