### PR TITLE
tests: print debug msg on kata-deploy fail

### DIFF
--- a/tests/functional/kata-deploy/kata-deploy.bats
+++ b/tests/functional/kata-deploy/kata-deploy.bats
@@ -6,6 +6,7 @@
 #
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/lib.sh"
 
 setup() {
 	repo_root_dir="${BATS_TEST_DIRNAME}/../../../"
@@ -76,7 +77,7 @@ setup() {
 }
 
 teardown() {
-	kubectl get runtimeclasses -o name | grep -v "kata-mshv-vm-isolation"
+	debug_kata_deploy
 
 	if [ "${KUBERNETES}" = "k0s" ]; then
 		deploy_spec="-k \"${repo_root_dir}/tools/packaging/kata-deploy/kata-deploy/overlays/k0s\""

--- a/tests/functional/kata-deploy/lib.sh
+++ b/tests/functional/kata-deploy/lib.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2023 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Print useful information for debugging kata-deploy fails
+debug_kata_deploy() {
+	echo "::group::Describe kata-deploy pod"
+	kubectl -n kube-system describe pod -l name=kata-deploy || true
+	echo "::endgroup::"
+
+	echo "::group::Status of the k8s nodes"
+	kubectl get nodes || true
+	echo "::endgroup::"
+
+	echo "::group::List of runtimeclasses"
+	# When running on AKS "kata-mshv-vm-isolation" is added by the cloud
+	# provider, so it's noise and should be filtered out here.
+	kubectl get runtimeclasses -o name | grep -v "kata-mshv-vm-isolation" || true
+	echo "::endgroup::"
+}


### PR DESCRIPTION
This introduced the debug_kata_deploy() on
functional/kata-deploy/lib.sh that is now used by the k8s and kata-deploy tests to print debug information when kata-deploy fails to install.

Fixes #8272
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>