### PR TITLE
docs/limitations: docker 22.06 is not a real version

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -64,10 +64,10 @@ Currently Kata Containers does not support Podman.
 
 See issue https://github.com/kata-containers/kata-containers/issues/722 for more information.
 
-Docker supports Kata Containers since 22.06:
+Docker supports Kata Containers since 23.0:
 
 ```bash
-$ sudo docker run --runtime io.containerd.kata.v2
+$ docker run --runtime io.containerd.kata.v2
 ```
 
 Kata Containers works perfectly with containerd, we recommend to use


### PR DESCRIPTION
We never released a version numbered 22.06, though there were betas; the final version was numbered 23.0.

Also remove an extraneous sudo as Unix permissions and not root are traditionally used to govern access to the Docker socket.