### PR TITLE
docs/howto/docker: remove incompatibility warning

### DIFF
--- a/docs/how-to/how-to-run-docker-with-kata.md
+++ b/docs/how-to/how-to-run-docker-with-kata.md
@@ -2,8 +2,6 @@
 
 This document describes the why and how behind running Docker in a Kata Container.
 
-> **Note:** While in other environments this might be described as "Docker in Docker", the new architecture of Kata 2.x means [Docker can no longer be used to create containers using a Kata Containers runtime](https://github.com/kata-containers/kata-containers/issues/722).
-
 ## Requirements
 
 - A working Kata Containers installation


### PR DESCRIPTION
Docker 23.0+ fully supports Kata Containers v2.