### PR TITLE
runtime-rs: update device pci info for vfio and virtio-blk devices

### DIFF
--- a/src/runtime-rs/crates/hypervisor/ch-config/src/ch_api.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/ch_api.rs
@@ -70,7 +70,7 @@ pub async fn cloud_hypervisor_vm_stop(mut socket: UnixStream) -> Result<Option<S
     .await?
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Deserialize, Debug)]
 pub struct PciDeviceInfo {
     pub id: String,
     pub bdf: String,

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -79,7 +79,7 @@ impl Hypervisor for CloudHypervisor {
         inner.save_vm().await
     }
 
-    async fn add_device(&self, device: DeviceType) -> Result<()> {
+    async fn add_device(&self, device: DeviceType) -> Result<DeviceType> {
         let mut inner = self.inner.write().await;
         inner.add_device(device).await
     }

--- a/src/runtime-rs/crates/hypervisor/src/device/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/mod.rs
@@ -10,7 +10,7 @@ use crate::device::driver::vhost_user_blk::VhostUserBlkDevice;
 use crate::{
     BlockConfig, BlockDevice, HybridVsockConfig, HybridVsockDevice, Hypervisor as hypervisor,
     NetworkConfig, NetworkDevice, ShareFsDevice, ShareFsDeviceConfig, ShareFsMountConfig,
-    ShareFsMountDevice, VfioConfig, VfioDevice, VhostUserConfig, VsockConfig, VsockDevice,
+    ShareFsMountDevice, VfioConfig, VfioDevice, VhostUserConfig, VsockConfig,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -31,7 +31,7 @@ pub enum DeviceConfig {
     HybridVsockCfg(HybridVsockConfig),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum DeviceType {
     Block(BlockDevice),
     VhostUserBlk(VhostUserBlkDevice),
@@ -40,7 +40,6 @@ pub enum DeviceType {
     ShareFs(ShareFsDevice),
     ShareFsMount(ShareFsMountDevice),
     HybridVsock(HybridVsockDevice),
-    Vsock(VsockDevice),
 }
 
 impl fmt::Display for DeviceType {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -74,9 +74,6 @@ impl DragonballInner {
             DeviceType::ShareFsMount(sharefs_mount) => self
                 .add_share_fs_mount(&sharefs_mount.config)
                 .context("add share fs mount"),
-            DeviceType::Vsock(_) => {
-                todo!()
-            }
         }
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -92,9 +92,12 @@ impl Hypervisor for Dragonball {
         inner.resize_vcpu(old_vcpus, new_vcpus).await
     }
 
-    async fn add_device(&self, device: DeviceType) -> Result<()> {
+    async fn add_device(&self, device: DeviceType) -> Result<DeviceType> {
         let mut inner = self.inner.write().await;
-        inner.add_device(device).await
+        match inner.add_device(device.clone()).await {
+            Ok(_) => Ok(device),
+            Err(err) => Err(err),
+        }
     }
 
     async fn remove_device(&self, device: DeviceType) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -85,7 +85,7 @@ pub trait Hypervisor: std::fmt::Debug + Send + Sync {
     async fn resize_vcpu(&self, old_vcpus: u32, new_vcpus: u32) -> Result<(u32, u32)>; // returns (old_vcpus, new_vcpus)
 
     // device manager
-    async fn add_device(&self, device: DeviceType) -> Result<()>;
+    async fn add_device(&self, device: DeviceType) -> Result<DeviceType>;
     async fn remove_device(&self, device: DeviceType) -> Result<()>;
 
     // utils

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -146,9 +146,9 @@ use crate::device::DeviceType;
 
 // device manager part of Hypervisor
 impl QemuInner {
-    pub(crate) async fn add_device(&mut self, device: DeviceType) -> Result<()> {
+    pub(crate) async fn add_device(&mut self, device: DeviceType) -> Result<DeviceType> {
         info!(sl!(), "QemuInner::add_device() {}", device);
-        todo!()
+        Ok(device)
     }
 
     pub(crate) async fn remove_device(&mut self, device: DeviceType) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -74,7 +74,7 @@ impl Hypervisor for Qemu {
         inner.save_vm().await
     }
 
-    async fn add_device(&self, device: DeviceType) -> Result<()> {
+    async fn add_device(&self, device: DeviceType) -> Result<DeviceType> {
         let mut inner = self.inner.write().await;
         inner.add_device(device).await
     }

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -297,8 +297,16 @@ impl ResourceManagerInner {
                     // create block device for kata agent,
                     // if driver is virtio-blk-pci, the id will be pci address.
                     if let DeviceType::Block(device) = device_info {
+                        // The following would work for drivers virtio-blk-pci and mmio.
+                        // Once scsi support is added, need to handle scsi identifiers.
+                        let id = if let Some(pci_path) = device.config.pci_path {
+                            pci_path.convert_to_string()
+                        } else {
+                            device.config.virt_path.clone()
+                        };
+
                         let agent_device = Device {
-                            id: device.config.virt_path.clone(),
+                            id,
                             container_path: d.path.clone(),
                             field_type: device.config.driver_option,
                             vm_path: device.config.virt_path,

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
@@ -89,9 +89,16 @@ pub(crate) async fn setup_inline_virtiofs(id: &str, h: &dyn Hypervisor) -> Resul
             prefetch_list_path: None,
         },
     };
-    h.add_device(DeviceType::ShareFsMount(virtio_fs))
+
+    let result = h
+        .add_device(DeviceType::ShareFsMount(virtio_fs))
         .await
-        .with_context(|| format!("fail to attach passthrough fs {:?}", source))
+        .with_context(|| format!("fail to attach passthrough fs {:?}", source));
+
+    match result {
+        Ok(_) => Ok(()),
+        Err(e) => Err(e),
+    }
 }
 
 pub async fn rafs_mount(


### PR DESCRIPTION
  runtime-rs: change hypervisor add_device trait to return device copy
    
 Block(virtio-blk) and vfio devices are currently not handled correctly
 by the agent as the agent is not provided with correct PCI paths for
 these devices.
    
 The PCI paths for these devices can be inferred from the PCI information
 provided by the hypervisor when the device is added.
 Hence changing the add_device trait function to return a device copy
 with PCI info potentially provided by the hypervisor. This can then be
 provided to the agent to correctly detect devices within the VM.
    
This commit includes implementation for PCI info update for
cloud-hupervisor for virtio-blk devices with stubs provided for other
hypervisors.

This PR fixes virtio-block device addition bug. The following works now:

```
$ sudo ctr run --runtime "io.containerd.kata.v2" --snapshotter devmapper --rm -t quay.io/prometheus/busybox:latest foo-dm /bin/true;echo $?
0
```
 as well as 
```
sudo ctr run --runtime "io.containerd.kata.v2" --device=/dev/block1 --rm -t quay.io/prometheus/busybox:latest foo-dm /bin/true;echo $?
0
```
The PR also fixes bugs around vfio device addition. End to end vfio device add now works:
```
sudo ctr run --runtime "io.containerd.kata.v2" --device=/dev/vfio/{vfio_group} --rm -t quay.io/prometheus/busybox:latest foo-dm /bin/true;echo $?
0
```


    
 Fixes: #8283
