### PR TITLE
WIP GHA: downgrade action/checkout to v3 for s390x

### DIFF
--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -48,7 +48,7 @@ jobs:
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
@@ -91,7 +91,7 @@ jobs:
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -29,7 +29,7 @@ jobs:
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: get-kata-tarball
         uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
This PR is to downgrade `action/checkout` to v3 again for s390x.

Fixes: #8296

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>