### PR TITLE
kata-deploy: new build-and-push-kata-payload target

### DIFF
--- a/.github/workflows/publish-kata-deploy-payload-amd64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-amd64.yaml
@@ -61,6 +61,8 @@ jobs:
       - name: build-and-push-kata-payload
         id: build-and-push-kata-payload
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-          $(pwd)/kata-static.tar.xz \
-          ${{ inputs.registry }}/${{ inputs.repo }} ${{ inputs.tag }}
+          export KATA_TARBALL="$(pwd)/kata-static.tar.xz"
+          export KATA_PAYLOAD="${{ inputs.registry }}/${{ inputs.repo }}"
+          export KATA_PAYLOAD_TAG="${{ inputs.tag }}"
+
+          make build-and-push-kata-payload

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -65,7 +65,8 @@ jobs:
       - name: build-and-push-kata-payload
         id: build-and-push-kata-payload
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-          $(pwd)/kata-static.tar.xz \
-          ${{ inputs.registry }}/${{ inputs.repo }} ${{ inputs.tag }}
+          export KATA_TARBALL="$(pwd)/kata-static.tar.xz"
+          export KATA_PAYLOAD="${{ inputs.registry }}/${{ inputs.repo }}"
+          export KATA_PAYLOAD_TAG="${{ inputs.tag }}"
 
+          make build-and-push-kata-payload

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -65,6 +65,8 @@ jobs:
       - name: build-and-push-kata-payload
         id: build-and-push-kata-payload
         run: |
-          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-          $(pwd)/kata-static.tar.xz \
-          ${{ inputs.registry }}/${{ inputs.repo }} ${{ inputs.tag }}
+          export KATA_TARBALL="$(pwd)/kata-static.tar.xz"
+          export KATA_PAYLOAD="${{ inputs.registry }}/${{ inputs.repo }}"
+          export KATA_PAYLOAD_TAG="${{ inputs.tag }}"
+
+          make build-and-push-kata-payload

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -43,11 +43,13 @@ jobs:
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           tags=($tag)
           tags+=($([[ "$tag" =~ "alpha"|"rc" ]] && echo "latest" || echo "stable"))
+          export KATA_TARBALL="$(pwd)/kata-static.tar.xz"
           for tag in ${tags[@]}; do
-              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy" \
-                  "${tag}-${{ inputs.target-arch }}"
-              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy" \
-                  "${tag}-${{ inputs.target-arch }}"
+              for img in "docker.io/katadocker/kata-deploy" \
+                         "quay.io/kata-containers/kata-deploy"; do
+                  export KATA_PAYLOAD="${img}"
+                  export KATA_PAYLOAD_TAG="${tag}-${{ inputs.target-arch }}"
+
+                  make build-and-push-kata-payload
+              done
           done

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -44,10 +44,11 @@ jobs:
           tags=($tag)
           tags+=($([[ "$tag" =~ "alpha"|"rc" ]] && echo "latest" || echo "stable"))
           for tag in ${tags[@]}; do
-              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy" \
-                  "${tag}-${{ inputs.target-arch }}"
-              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy" \
-                  "${tag}-${{ inputs.target-arch }}"
+              for img in "docker.io/katadocker/kata-deploy" \
+                         "quay.io/kata-containers/kata-deploy"; do
+                  export KATA_PAYLOAD="${img}"
+                  export KATA_PAYLOAD_TAG="${tag}-${{ inputs.target-arch }}"
+
+                  make build-and-push-kata-payload
+              done
           done

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -44,10 +44,11 @@ jobs:
           tags=($tag)
           tags+=($([[ "$tag" =~ "alpha"|"rc" ]] && echo "latest" || echo "stable"))
           for tag in ${tags[@]}; do
-              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy" \
-                  "${tag}-${{ inputs.target-arch }}"
-              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy" \
-                  "${tag}-${{ inputs.target-arch }}"
+              for img in "docker.io/katadocker/kata-deploy" \
+                         "quay.io/kata-containers/kata-deploy"; do
+                  export KATA_PAYLOAD="${img}"
+                  export KATA_PAYLOAD_TAG="${tag}-${{ inputs.target-arch }}"
+
+                  make build-and-push-kata-payload
+              done
           done

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -9,6 +9,13 @@ MK_DIR := $(dir $(MK_PATH))
 # Verbose build
 V := 1
 
+# Path to the artifacts tarball
+KATA_TARBALL ?= $(abspath $(MK_DIR)/../../../../kata-static.tar.xz)
+# Payload container image
+KATA_PAYLOAD ?= "quay.io/kata-containers/kata-deploy"
+# An optional payload container image tag
+KATA_PAYLOAD_TAG ?=
+
 define BUILD
 	$(MK_DIR)/kata-deploy-binaries-in-docker.sh $(if $(V),,-s) --build=$1
 endef
@@ -149,4 +156,8 @@ merge-builds:
 	$(MK_DIR)/kata-deploy-merge-builds.sh build "$(MK_DIR)/../../../../versions.yaml"
 
 install-tarball:
-	tar -xf ./kata-static.tar.xz -C /
+	tar -xf "$(KATA_TARBALL)" -C /
+
+build-and-push-kata-payload:
+	$(MK_DIR)kata-deploy-build-and-upload-payload.sh \
+		"$(KATA_TARBALL)" "$(KATA_PAYLOAD)" "$(KATA_PAYLOAD_TAG)"


### PR DESCRIPTION
Added the build-and-push-kata-payload make target to replace the calls to the script directly by the workflows. Also it should be the main interface for devels to build the payload locally.

Fixes #8298
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>