### PR TITLE
release: Fully migrate from hub to gh

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,9 +167,6 @@ jobs:
           asc="${tarball}.asc"
           curl -sSLO "${download_url}/${tarball}"
           curl -sSLO "${download_url}/${asc}"
-          # "-m" option should be empty to re-use the existing release title
-          # without opening a text editor.
-          # For the details, check https://hub.github.com/hub-release.1.html.
           gh release upload "${tag}" "${tarball}"
           gh release upload "${tag}" "${asc}"
           popd

--- a/tools/packaging/release/README.md
+++ b/tools/packaging/release/README.md
@@ -14,7 +14,7 @@ See [the release documentation](../../../docs/Release-Process.md).
 ### `update-repository-version.sh`
 
 This script creates a GitHub pull request (a.k.a PR) to change the version in
-all the Kata repositories.
+the Kata repository.
 
 For more information on using the script, run the following:
 

--- a/tools/packaging/release/README.md
+++ b/tools/packaging/release/README.md
@@ -43,7 +43,4 @@ After Kata Containers repository is updated with a new version, it needs to be
 tagged.
 
 The `tag_repos.sh` script is used to create tags for the Kata Containers repository.
-The script creates an **annotated tag** for the new release version for the
-following repositories:
-
-- kata-containers
+The script creates an **annotated tag** for the new release version.

--- a/tools/packaging/release/update-repository-version.sh
+++ b/tools/packaging/release/update-repository-version.sh
@@ -13,7 +13,8 @@ readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly script_name="$(basename "${BASH_SOURCE[0]}")"
 
 readonly tmp_dir=$(mktemp -t -d pr-bump.XXXX)
-readonly organization="kata-containers"
+OWNER="${OWNER:-kata-containers}"
+readonly organization="$OWNER"
 PUSH="false"
 GOPATH=${GOPATH:-${HOME}/go}
 

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -15,7 +15,6 @@ export repo_root_dir="$(cd "${this_script_dir}/../../../" && pwd)"
 
 short_commit_length=10
 
-hub_bin="hub-bin"
 gh_cli="gh-cli"
 
 #for cross build
@@ -58,26 +57,6 @@ get_repo_hash() {
 	[ -d "${repo_dir}" ] || die "${repo_dir} is not a directory"
 	pushd "${repo_dir}" >>/dev/null
 	git rev-parse --verify HEAD
-	popd >>/dev/null
-}
-
-build_hub() {
-	info "Get hub"
-
-	if cmd=$(command -v hub); then
-		hub_bin="${cmd}"
-		return
-	else
-		hub_bin="${tmp_dir:-/tmp}/hub-bin"
-	fi
-
-	local hub_repo="github.com/github/hub"
-	local hub_repo_dir="${GOPATH}/src/${hub_repo}"
-	[ -d "${hub_repo_dir}" ] || git clone --quiet --depth 1 "https://${hub_repo}.git" "${hub_repo_dir}"
-	pushd "${hub_repo_dir}" >>/dev/null
-	git checkout master
-	git pull
-	./script/build -o "${hub_bin}"
 	popd >>/dev/null
 }
 

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -16,6 +16,7 @@ export repo_root_dir="$(cd "${this_script_dir}/../../../" && pwd)"
 short_commit_length=10
 
 hub_bin="hub-bin"
+gh_cli="gh-cli"
 
 #for cross build
 CROSS_BUILD=${CROSS_BUILD-:}
@@ -91,6 +92,22 @@ arch_to_golang()
 		s390x) echo "s390x";;
 		*) die "unsupported architecture: $arch";;
 	esac
+}
+
+get_gh() {
+	info "Get gh"
+
+	if cmd=$(command -v gh); then
+		gh_cli="${cmd}"
+		return
+	else
+		gh_cli="${tmp_dir:-/tmp}/gh-cli"
+	fi
+
+	local goarch=$(arch_to_golang $(uname -m))
+	curl -sSL https://github.com/cli/cli/releases/download/v2.37.0/gh_2.37.0_linux_${goarch}.tar.gz | tar -xz
+	mv gh_2.37.0_linux_${goarch}/bin/gh "${gh_cli}"
+	rm -rf gh_2.37.0_linux_amd64
 }
 
 get_kata_hash() {


### PR DESCRIPTION
The hub tool is deprecated. Convert the release scripts to use the official GitHub CLI gh instead.

Fixes #8303

EDIT: this also fixes this old issue

Fixes #3083

Same digits being used in both issue numbers is pure coincidence :smile:

Signed-off-by: Greg Kurz <groug@kaod.org>