### PR TITLE
kata-runtime/kata-ctl: Add security details to output

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-env.go
+++ b/src/runtime/cmd/kata-runtime/kata-env.go
@@ -30,7 +30,7 @@ import (
 //
 // XXX: Increment for every change to the output format
 // (meaning any change to the EnvInfo type).
-const formatVersion = "1.0.26"
+const formatVersion = "1.0.27"
 
 // MetaInfo stores information on the format of the output itself
 type MetaInfo struct {
@@ -101,6 +101,14 @@ type RuntimeVersionInfo struct {
 	Version VersionInfo
 }
 
+type SecurityInfo struct {
+	Rootless          bool
+	DisableSeccomp    bool
+	GuestHookPath     string
+	EnableAnnotations []string
+	ConfidentialGuest bool
+}
+
 // HypervisorInfo stores hypervisor details
 type HypervisorInfo struct {
 	MachineType       string
@@ -116,6 +124,7 @@ type HypervisorInfo struct {
 	HotPlugVFIO       config.PCIePort
 	ColdPlugVFIO      config.PCIePort
 	Debug             bool
+	SecurityInfo      SecurityInfo
 }
 
 // AgentInfo stores agent details
@@ -284,6 +293,16 @@ func getAgentInfo(config oci.RuntimeConfig) (AgentInfo, error) {
 	return agent, nil
 }
 
+func getSecurityInfo(config vc.HypervisorConfig) SecurityInfo {
+	return SecurityInfo{
+		Rootless:          config.Rootless,
+		DisableSeccomp:    config.DisableSeccomp,
+		GuestHookPath:     config.GuestHookPath,
+		EnableAnnotations: config.EnableAnnotations,
+		ConfidentialGuest: config.ConfidentialGuest,
+	}
+}
+
 func getHypervisorInfo(config oci.RuntimeConfig) (HypervisorInfo, error) {
 	hypervisorPath := config.HypervisorConfig.HypervisorPath
 
@@ -305,6 +324,8 @@ func getHypervisorInfo(config oci.RuntimeConfig) (HypervisorInfo, error) {
 		}
 	}
 
+	securityInfo := getSecurityInfo(config.HypervisorConfig)
+
 	return HypervisorInfo{
 		Debug:             config.HypervisorConfig.Debug,
 		MachineType:       config.HypervisorConfig.HypervisorMachineType,
@@ -319,6 +340,7 @@ func getHypervisorInfo(config oci.RuntimeConfig) (HypervisorInfo, error) {
 		HotPlugVFIO:       config.HypervisorConfig.HotPlugVFIO,
 		ColdPlugVFIO:      config.HypervisorConfig.ColdPlugVFIO,
 		SocketPath:        socketPath,
+		SecurityInfo:      securityInfo,
 	}, nil
 }
 

--- a/src/tools/kata-ctl/Cargo.lock
+++ b/src/tools/kata-ctl/Cargo.lock
@@ -999,6 +999,7 @@ dependencies = [
  "oci",
  "once_cell",
  "rand",
+ "safe-path",
  "serde_json",
  "slog",
  "slog-scope",

--- a/src/tools/kata-ctl/src/ops/env_ops.rs
+++ b/src/tools/kata-ctl/src/ops/env_ops.rs
@@ -150,6 +150,21 @@ pub struct ImageInfo {
     path: String,
 }
 
+// SecurityInfo stores the hypervisor security details
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct SecurityInfo {
+    #[serde(default)]
+    rootless: bool,
+    #[serde(default)]
+    disable_seccomp: bool,
+    #[serde(default)]
+    guest_hook_path: String,
+    #[serde(default)]
+    enable_annotations: Vec<String>,
+    #[serde(default)]
+    confidential_guest: bool,
+}
+
 // HypervisorInfo stores hypervisor details
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct HypervisorInfo {
@@ -187,6 +202,8 @@ pub struct HypervisorInfo {
     default_vcpus: i32,
     #[serde(default)]
     cpu_features: String,
+    #[serde(default)]
+    security_info: SecurityInfo,
 }
 
 // EnvInfo collects all information that will be displayed by the
@@ -374,6 +391,14 @@ pub fn get_hypervisor_info(
     let version =
         get_command_version(&hypervisor_config.path).context("error getting hypervisor version")?;
 
+    let security_info = SecurityInfo {
+        rootless: hypervisor_config.security_info.rootless,
+        disable_seccomp: hypervisor_config.security_info.disable_seccomp,
+        guest_hook_path: hypervisor_config.security_info.guest_hook_path.clone(),
+        enable_annotations: hypervisor_config.security_info.enable_annotations.clone(),
+        confidential_guest: hypervisor_config.security_info.confidential_guest,
+    };
+
     let hypervisor_info = HypervisorInfo {
         machine_type: hypervisor_config.machine_info.machine_type.to_string(),
         machine_accelerators: hypervisor_config
@@ -402,6 +427,7 @@ pub fn get_hypervisor_info(
         enable_iommu_platform: hypervisor_config.device_info.enable_iommu_platform,
         default_vcpus: hypervisor_config.cpu_info.default_vcpus,
         cpu_features: hypervisor_config.cpu_info.cpu_features.to_string(),
+        security_info,
     };
 
     let image_info = ImageInfo {


### PR DESCRIPTION
Add the hypervisor security details to the output of the `kata-runtime env` and `kata-ctl env` commands so the user can see, amongst other things, the value of `confidential_guest`.

Fixes: #8313.