### PR TITLE
Stable-3.2 | Upgrade to Cloud Hypervisor v35.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -485,6 +485,7 @@ components:
             iommu: false
             queue_size: 5
             vhost_socket: vhost_socket
+            serial: serial
             vhost_user: false
             direct: false
             rate_limiter_config:
@@ -504,6 +505,7 @@ components:
             iommu: false
             queue_size: 5
             vhost_socket: vhost_socket
+            serial: serial
             vhost_user: false
             direct: false
             rate_limiter_config:
@@ -847,6 +849,7 @@ components:
           iommu: false
           queue_size: 5
           vhost_socket: vhost_socket
+          serial: serial
           vhost_user: false
           direct: false
           rate_limiter_config:
@@ -866,6 +869,7 @@ components:
           iommu: false
           queue_size: 5
           vhost_socket: vhost_socket
+          serial: serial
           vhost_user: false
           direct: false
           rate_limiter_config:
@@ -1429,6 +1433,7 @@ components:
         iommu: false
         queue_size: 5
         vhost_socket: vhost_socket
+        serial: serial
         vhost_user: false
         direct: false
         rate_limiter_config:
@@ -1470,6 +1475,8 @@ components:
           format: int16
           type: integer
         id:
+          type: string
+        serial:
           type: string
       required:
       - path

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/DiskConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/DiskConfig.md
@@ -15,6 +15,7 @@ Name | Type | Description | Notes
 **RateLimiterConfig** | Pointer to [**RateLimiterConfig**](RateLimiterConfig.md) |  | [optional] 
 **PciSegment** | Pointer to **int32** |  | [optional] 
 **Id** | Pointer to **string** |  | [optional] 
+**Serial** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
@@ -304,6 +305,31 @@ SetId sets Id field to given value.
 `func (o *DiskConfig) HasId() bool`
 
 HasId returns a boolean if a field has been set.
+
+### GetSerial
+
+`func (o *DiskConfig) GetSerial() string`
+
+GetSerial returns the Serial field if non-nil, zero value otherwise.
+
+### GetSerialOk
+
+`func (o *DiskConfig) GetSerialOk() (*string, bool)`
+
+GetSerialOk returns a tuple with the Serial field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSerial
+
+`func (o *DiskConfig) SetSerial(v string)`
+
+SetSerial sets Serial field to given value.
+
+### HasSerial
+
+`func (o *DiskConfig) HasSerial() bool`
+
+HasSerial returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
@@ -27,6 +27,7 @@ type DiskConfig struct {
 	RateLimiterConfig *RateLimiterConfig `json:"rate_limiter_config,omitempty"`
 	PciSegment        *int32             `json:"pci_segment,omitempty"`
 	Id                *string            `json:"id,omitempty"`
+	Serial            *string            `json:"serial,omitempty"`
 }
 
 // NewDiskConfig instantiates a new DiskConfig object
@@ -415,6 +416,38 @@ func (o *DiskConfig) SetId(v string) {
 	o.Id = &v
 }
 
+// GetSerial returns the Serial field value if set, zero value otherwise.
+func (o *DiskConfig) GetSerial() string {
+	if o == nil || o.Serial == nil {
+		var ret string
+		return ret
+	}
+	return *o.Serial
+}
+
+// GetSerialOk returns a tuple with the Serial field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *DiskConfig) GetSerialOk() (*string, bool) {
+	if o == nil || o.Serial == nil {
+		return nil, false
+	}
+	return o.Serial, true
+}
+
+// HasSerial returns a boolean if a field has been set.
+func (o *DiskConfig) HasSerial() bool {
+	if o != nil && o.Serial != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSerial gets a reference to the given string and assigns it to the Serial field.
+func (o *DiskConfig) SetSerial(v string) {
+	o.Serial = &v
+}
+
 func (o DiskConfig) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
@@ -449,6 +482,9 @@ func (o DiskConfig) MarshalJSON() ([]byte, error) {
 	}
 	if o.Id != nil {
 		toSerialize["id"] = o.Id
+	}
+	if o.Serial != nil {
+		toSerialize["serial"] = o.Serial
 	}
 	return json.Marshal(toSerialize)
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -820,6 +820,8 @@ components:
           format: int16
         id:
           type: string
+        serial:
+          type: string
 
     NetConfig:
       type: object

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v33.0"
+      version: "v35.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This patch is backporting #8058 to the Stable-3.2 branch mainly due to the recent security advisory published from the `vm-memory` crate (https://github.com/advisories/GHSA-49hh-fprx-m68g).

See: https://github.com/kata-containers/kata-containers/issues/8057#issuecomment-1764962600
