### PR TITLE
gha: add dependencies for spell checker

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -187,7 +187,7 @@ jobs:
           echo "/usr/local/go/bin" >> $GITHUB_PATH
       - name: Install system dependencies
         run: |
-          sudo apt-get -y install moreutils hunspell pandoc
+          sudo apt-get -y install moreutils hunspell hunspell-en-gb hunspell-en-us pandoc
       - name: Run check
         run: |
           export PATH=${PATH}:${GOPATH}/bin


### PR DESCRIPTION
In the migration from the tests repo to the kata containers repo we missed two huspell dictionaries for static checks; add them.

Fixes #8315