### PR TITLE
tests/git-helper: cancel any previous rebase left halfway

### DIFF
--- a/tests/git-helper.sh
+++ b/tests/git-helper.sh
@@ -19,6 +19,8 @@ function add_kata_bot_info() {
 function rebase_atop_of_the_latest_target_branch() {
 	if [ -n "${TARGET_BRANCH}" ]; then
 		echo "Rebasing atop of the latest ${TARGET_BRANCH}"
+		# Recover from any previous rebase left halfway
+		git rebase --abort 2> /dev/null || true
 		git rebase origin/${TARGET_BRANCH}
 	fi
 }


### PR DESCRIPTION
In bare-metal machines the git tree might get on unstable state with the previous rebase left halfway. So let's attempt to abort any rebase before.

Fixes #8318
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>