### PR TITLE
runitme-rs/bugfix: kata pod with multi-containers sharing one direct volume

### DIFF
--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -77,7 +77,7 @@ impl VolumeResource {
             } else if is_block_volume(m).context("block volume type")? {
                 // handle block volume
                 Arc::new(
-                    block_volume::BlockVolume::new(d, m, read_only, cid, sid)
+                    block_volume::BlockVolume::new(d, m, read_only, sid)
                         .await
                         .with_context(|| format!("new share fs volume {:?}", m))?,
                 )

--- a/src/runtime-rs/crates/resource/src/volume/utils.rs
+++ b/src/runtime-rs/crates/resource/src/volume/utils.rs
@@ -57,13 +57,13 @@ pub fn get_file_name<P: AsRef<Path>>(src: P) -> Result<String> {
 pub(crate) async fn generate_shared_path(
     dest: String,
     read_only: bool,
-    cid: &str,
+    device_id: &str,
     sid: &str,
 ) -> Result<String> {
     let file_name = get_file_name(&dest).context("failed to get file name.")?;
-    let mount_name = generate_mount_path(cid, file_name.as_str());
-    let guest_path = do_get_guest_path(&mount_name, cid, true, false);
-    let host_path = do_get_host_path(&mount_name, sid, cid, true, read_only);
+    let mount_name = generate_mount_path(device_id, file_name.as_str());
+    let guest_path = do_get_guest_path(&mount_name, device_id, true, false);
+    let host_path = do_get_host_path(&mount_name, sid, device_id, true, read_only);
 
     if dest.starts_with("/dev") {
         fs::File::create(&host_path).context(format!("failed to create file {:?}", &host_path))?;


### PR DESCRIPTION


When multiple containers in a kata pod share one direct volume, it's important to make sure that the corresponding block device is only mounted once in the guest. This means that there should be only one mount entry for the device in the mount information.

Fixes: #8328