### PR TITLE
gha: Add workflow to close stale PRs

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,17 @@
+name: 'Automatically close stale PRs'
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: action/stale@v8
+        with:
+          start-date: '2023-05-01T00:00:00Z'
+          stale-pr-message: 'This PR has been opened without with no activity for 180 days. Comment on the issue otherwise it will be closed in 7 days'
+          days-before-pr-stale: 180
+          days-before-pr-close: 7
+          days-before-issue-stale: -1
+          days-before-issue-close: -1


### PR DESCRIPTION
Our goal. as discussed in the Architecture Committee meeting held on October 31st, 2023, is to take a more aggressive action on issues and PRs that have been opened for a long time.

This commit is the very first step, and it's **only** targetting **PRs**.  What this action will do is:
* Mark all the PRs that have no activity for more than 180 days, starting from May 1st, 2023, as stale.
  * A message will be added, letting the contributor know that they can simply comment on the PR in order to make it "not stale".
* If there's no activity on the PR for 7 days, the PR will be automatically closed.

Fixes: #8347