### PR TITLE
cargo: Agent cargo.lock updated

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1202,6 +1202,7 @@ dependencies = [
  "oci",
  "once_cell",
  "rand",
+ "safe-path",
  "serde_json",
  "slog",
  "slog-scope",


### PR DESCRIPTION
The Cargo.lock for agent needs to be updated to include "safe-path" dependency.

Fixes: #8350