### PR TITLE
CCv0: Set v0.8.0 tag for image-rs, AA and td-shim

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -2015,7 +2015,7 @@ dependencies = [
 [[package]]
 name = "image-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=615a46ff16ee8670014946d14e44e85cede82f01#615a46ff16ee8670014946d14e44e85cede82f01"
+source = "git+https://github.com/confidential-containers/guest-components?tag=v0.8.0#e849dc8921d2a48bec915f1a7c02f8988721022d"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -2921,7 +2921,7 @@ dependencies = [
 [[package]]
 name = "ocicrypt-rs"
 version = "0.1.0"
-source = "git+https://github.com/confidential-containers/guest-components?rev=615a46ff16ee8670014946d14e44e85cede82f01#615a46ff16ee8670014946d14e44e85cede82f01"
+source = "git+https://github.com/confidential-containers/guest-components?tag=v0.8.0#e849dc8921d2a48bec915f1a7c02f8988721022d"
 dependencies = [
  "aes 0.8.3",
  "anyhow",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -74,7 +74,7 @@ clap = { version = "3.0.1", features = ["derive"] }
 openssl = { version = "0.10.38", features = ["vendored"] }
 
 # Image pull/decrypt
-image-rs = { git = "https://github.com/confidential-containers/guest-components", rev = "615a46ff16ee8670014946d14e44e85cede82f01", default-features = false, features = [
+image-rs = { git = "https://github.com/confidential-containers/guest-components", tag = "v0.8.0", default-features = false, features = [
     "kata-cc-native-tls",
     "verity",
     "signature-simple-xrss",

--- a/versions.yaml
+++ b/versions.yaml
@@ -200,7 +200,7 @@ externals:
   attestation-agent:
     description: "Provide attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/guest-components/"
-    version: "615a46ff16ee8670014946d14e44e85cede82f01"
+    version: "v0.8.0"
 
   cni-plugins:
     description: "CNI network plugins"
@@ -332,7 +332,7 @@ externals:
     # yamllint disable-line rule:line-length
     description: "Confidential Containers Shim Firmware -- DO NOT TOUCH on main -> CCv0 merges"
     url: "https://github.com/confidential-containers/td-shim"
-    version: "3f18d9f3f51c9428c034cf01b45ab94bcd0d1622"
+    version: "v0.8.0"
     toolchain: "nightly-2023-08-28"
 
   virtiofsd:


### PR DESCRIPTION
Update toml and yaml files for v0.8.0 of image-rs, AA, and td-shim.

Fixes: [#8352](https://github.com/kata-containers/kata-containers/issues/8352)