### PR TITLE
network: Fix network hotplug for ipvlan and macvlan endpoints for qemu and add tests

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1895,9 +1895,8 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op Opera
 	var tap TapInterface
 
 	switch endpoint.Type() {
-	case VethEndpointType:
-		drive := endpoint.(*VethEndpoint)
-		tap = drive.NetPair.TapInterface
+	case VethEndpointType, IPVlanEndpointType, MacvlanEndpointType, TuntapEndpointType:
+		tap = endpoint.NetworkPair().TapInterface
 	case TapEndpointType:
 		drive := endpoint.(*TapEndpoint)
 		tap = drive.TapInterface

--- a/tests/integration/nerdctl/gha-run.sh
+++ b/tests/integration/nerdctl/gha-run.sh
@@ -78,6 +78,15 @@ function run() {
 
 	info "Running nerdctl with Kata Containers (${KATA_HYPERVISOR}) and ipvlan network"
 	sudo nerdctl run  --rm --net ${ipvlan_net_name}  --runtime io.containerd.kata-${KATA_HYPERVISOR}.v2 alpine ip a | grep "eth0"
+
+	# The following creates an ipvlan network with eth0 on host as parent.
+	macvlan_net_name="macvlan20"
+	info "Creating macvlan network with eth0 interface on host as parent"
+	sudo nerdctl network create ${macvlan_net_name=} --driver ipvlan --subnet=10.8.0.0/24 -o parent=${parent_interface}
+
+	info "Running nerdctl with Kata Containers (${KATA_HYPERVISOR}) and macvlan network"
+	sudo nerdctl run  --rm --net ${macvlan_net_name}  --runtime io.containerd.kata-${KATA_HYPERVISOR}.v2 alpine ip a | grep "eth0"
+
 }
 
 function main() {

--- a/tests/integration/nerdctl/gha-run.sh
+++ b/tests/integration/nerdctl/gha-run.sh
@@ -68,6 +68,16 @@ function run() {
 
 	info "Running nerdctl with Kata Containers (${KATA_HYPERVISOR})"
 	sudo nerdctl run --rm --runtime io.containerd.kata-${KATA_HYPERVISOR}.v2 --entrypoint nping instrumentisto/nmap --tcp-connect -c 2 -p 80 www.github.com
+
+	parent_interface="eth0"
+	# The following creates an ipvlan network with eth0 on host as parent. The test assumes
+	# that an interface called eth0 exists on the host.
+	ipvlan_net_name="ipvlan10"
+	info "Creating ipvlan network with eth0 interface on host as parent"
+	sudo nerdctl network create ${ipvlan_net_name=} --driver ipvlan --subnet=10.5.74.0/24 -o parent=${parent_interface}
+
+	info "Running nerdctl with Kata Containers (${KATA_HYPERVISOR}) and ipvlan network"
+	sudo nerdctl run  --rm --net ${ipvlan_net_name}  --runtime io.containerd.kata-${KATA_HYPERVISOR}.v2 alpine ip a | grep "eth0"
 }
 
 function main() {


### PR DESCRIPTION
network: Fix network hotplug for ipvlan and macvlan endpoints.
Since moving from network coldplug to hotplug, the only case verified
was veth endpoints. Support for network hotplug for ipvlan and macvlan was
broken/not added. Fix it.

Fixes: https://github.com/kata-containers/kata-containers/issues/8391

Add test to verify kata supports ipvlan networks.
This test can be bit tricky as it requires knowledge about host interfaces to be used as a master for the ipvlan network.
However, with github actions, we can assume interface called eth0 to be present on the host(VM) and functioning.

Fixes: #8366