### PR TITLE
arm64: make agent-opa-tarball fix

### DIFF
--- a/tools/packaging/static-build/agent/Dockerfile
+++ b/tools/packaging/static-build/agent/Dockerfile
@@ -2,7 +2,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.18
+# BUILDPLATFORM - matches the current machine
+FROM --platform=$BUILDPLATFORM alpine:3.18 
+
 ARG RUST_TOOLCHAIN
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
@@ -19,3 +21,9 @@ RUN apk --no-cache add \
         openssl-libs-static \
         protoc && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+
+ARG TARGETARCH
+
+RUN if [ "${TARGETARCH}" = "arm64" ]; then \
+        ln -s /usr/bin/$(uname -m)-alpine-linux-musl-gcc /usr/bin/$(uname -m)-linux-musl-gcc; fi 
+

--- a/tools/packaging/static-build/agent/Dockerfile
+++ b/tools/packaging/static-build/agent/Dockerfile
@@ -25,5 +25,5 @@ RUN apk --no-cache add \
 ARG TARGETARCH
 
 RUN if [ "${TARGETARCH}" = "arm64" ]; then \
-        ln -s /usr/bin/$(uname -m)-alpine-linux-musl-gcc /usr/bin/$(uname -m)-linux-musl-gcc; fi 
+        ln -s "/usr/bin/$(uname -m)-alpine-linux-musl-gcc" "/usr/bin/$(uname -m)-linux-musl-gcc"; fi
 

--- a/tools/packaging/static-build/agent/build.sh
+++ b/tools/packaging/static-build/agent/build.sh
@@ -17,16 +17,16 @@ source "${script_dir}/../../scripts/lib.sh"
 container_image="${AGENT_CONTAINER_BUILDER:-$(get_agent_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
-sudo docker pull --platform=linux/${target_arch} ${container_image} || \
+sudo docker pull --platform=linux/"${target_arch}" "${container_image}" || \
 	(sudo docker $BUILDX build $PLATFORM \
 	    	--build-arg RUST_TOOLCHAIN="$(get_from_kata_deps "languages.rust.meta.newest-version")" \
 		-t "${container_image}" "${script_dir}" && \
 	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"
 	 push_to_registry "${container_image}")
-exit 1
+
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
-	--env DESTDIR=${DESTDIR} \
-	--env AGENT_POLICY=${AGENT_POLICY:-no} \
+	--env DESTDIR="${DESTDIR}" \
+	--env AGENT_POLICY="${AGENT_POLICY:-no}" \
 	-w "${repo_root_dir}" \
 	"${container_image}" \
 	bash -c "${agent_builder}"


### PR DESCRIPTION
Building the agent-opa-tarball fails on aarch64 and Alpine base container image PKG musl-dev installs /usr/bin/aarch64-alpine-linux-musl-gcc but we need "/usr/bin/$(uname -m)-linux-musl-gcc"

Fixes: #8371