### PR TITLE
Upgrade to Cloud Hypervisor v36.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -415,6 +415,9 @@ components:
     VmmPingResponse:
       description: Virtual Machine Monitor information
       example:
+        features:
+        - features
+        - features
         build_version: build_version
         pid: 0
         version: version
@@ -426,19 +429,24 @@ components:
         pid:
           format: int64
           type: integer
+        features:
+          items:
+            type: string
+          type: array
       required:
       - version
       type: object
     VmInfo:
       description: Virtual Machine information
       example:
-        memory_actual_size: 7
+        memory_actual_size: 5
         state: Created
         config:
           console:
             mode: "false"
             file: file
             iommu: false
+            socket: socket
           balloon:
             size: 1
             deflate_on_oom: false
@@ -565,6 +573,9 @@ components:
               destination: 8
             - distance: 7
               destination: 8
+            pci_segments:
+            - 3
+            - 3
             cpus:
             - 4
             - 4
@@ -580,6 +591,9 @@ components:
               destination: 8
             - distance: 7
               destination: 8
+            pci_segments:
+            - 3
+            - 3
             cpus:
             - 4
             - 4
@@ -621,8 +635,8 @@ components:
             cid: 3
           platform:
             iommu_segments:
-            - 3
-            - 3
+            - 7
+            - 7
             num_pci_segments: 3
             oem_strings:
             - oem_strings
@@ -656,6 +670,7 @@ components:
             mode: "false"
             file: file
             iommu: false
+            socket: socket
           net:
           - tap: tap
             host_mac: host_mac
@@ -803,6 +818,7 @@ components:
           mode: "false"
           file: file
           iommu: false
+          socket: socket
         balloon:
           size: 1
           deflate_on_oom: false
@@ -929,6 +945,9 @@ components:
             destination: 8
           - distance: 7
             destination: 8
+          pci_segments:
+          - 3
+          - 3
           cpus:
           - 4
           - 4
@@ -944,6 +963,9 @@ components:
             destination: 8
           - distance: 7
             destination: 8
+          pci_segments:
+          - 3
+          - 3
           cpus:
           - 4
           - 4
@@ -985,8 +1007,8 @@ components:
           cid: 3
         platform:
           iommu_segments:
-          - 3
-          - 3
+          - 7
+          - 7
           num_pci_segments: 3
           oem_strings:
           - oem_strings
@@ -1020,6 +1042,7 @@ components:
           mode: "false"
           file: file
           iommu: false
+          socket: socket
         net:
         - tap: tap
           host_mac: host_mac
@@ -1220,8 +1243,8 @@ components:
     PlatformConfig:
       example:
         iommu_segments:
-        - 3
-        - 3
+        - 7
+        - 7
         num_pci_segments: 3
         oem_strings:
         - oem_strings
@@ -1643,8 +1666,11 @@ components:
         mode: "false"
         file: file
         iommu: false
+        socket: socket
       properties:
         file:
+          type: string
+        socket:
           type: string
         mode:
           enum:
@@ -1652,6 +1678,7 @@ components:
           - Pty
           - Tty
           - File
+          - Socket
           - null
           type: string
         iommu:
@@ -1782,6 +1809,9 @@ components:
           destination: 8
         - distance: 7
           destination: 8
+        pci_segments:
+        - 3
+        - 3
         cpus:
         - 4
         - 4
@@ -1812,6 +1842,11 @@ components:
         sgx_epc_sections:
           items:
             type: string
+          type: array
+        pci_segments:
+          items:
+            format: int32
+            type: integer
           type: array
       required:
       - guest_numa_id

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/ConsoleConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/ConsoleConfig.md
@@ -5,6 +5,7 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **File** | Pointer to **string** |  | [optional] 
+**Socket** | Pointer to **string** |  | [optional] 
 **Mode** | **string** |  | 
 **Iommu** | Pointer to **bool** |  | [optional] [default to false]
 
@@ -51,6 +52,31 @@ SetFile sets File field to given value.
 `func (o *ConsoleConfig) HasFile() bool`
 
 HasFile returns a boolean if a field has been set.
+
+### GetSocket
+
+`func (o *ConsoleConfig) GetSocket() string`
+
+GetSocket returns the Socket field if non-nil, zero value otherwise.
+
+### GetSocketOk
+
+`func (o *ConsoleConfig) GetSocketOk() (*string, bool)`
+
+GetSocketOk returns a tuple with the Socket field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSocket
+
+`func (o *ConsoleConfig) SetSocket(v string)`
+
+SetSocket sets Socket field to given value.
+
+### HasSocket
+
+`func (o *ConsoleConfig) HasSocket() bool`
+
+HasSocket returns a boolean if a field has been set.
 
 ### GetMode
 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NumaConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NumaConfig.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **Distances** | Pointer to [**[]NumaDistance**](NumaDistance.md) |  | [optional] 
 **MemoryZones** | Pointer to **[]string** |  | [optional] 
 **SgxEpcSections** | Pointer to **[]string** |  | [optional] 
+**PciSegments** | Pointer to **[]int32** |  | [optional] 
 
 ## Methods
 
@@ -148,6 +149,31 @@ SetSgxEpcSections sets SgxEpcSections field to given value.
 `func (o *NumaConfig) HasSgxEpcSections() bool`
 
 HasSgxEpcSections returns a boolean if a field has been set.
+
+### GetPciSegments
+
+`func (o *NumaConfig) GetPciSegments() []int32`
+
+GetPciSegments returns the PciSegments field if non-nil, zero value otherwise.
+
+### GetPciSegmentsOk
+
+`func (o *NumaConfig) GetPciSegmentsOk() (*[]int32, bool)`
+
+GetPciSegmentsOk returns a tuple with the PciSegments field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetPciSegments
+
+`func (o *NumaConfig) SetPciSegments(v []int32)`
+
+SetPciSegments sets PciSegments field to given value.
+
+### HasPciSegments
+
+`func (o *NumaConfig) HasPciSegments() bool`
+
+HasPciSegments returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/VmmPingResponse.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/VmmPingResponse.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **BuildVersion** | Pointer to **string** |  | [optional] 
 **Version** | **string** |  | 
 **Pid** | Pointer to **int64** |  | [optional] 
+**Features** | Pointer to **[]string** |  | [optional] 
 
 ## Methods
 
@@ -96,6 +97,31 @@ SetPid sets Pid field to given value.
 `func (o *VmmPingResponse) HasPid() bool`
 
 HasPid returns a boolean if a field has been set.
+
+### GetFeatures
+
+`func (o *VmmPingResponse) GetFeatures() []string`
+
+GetFeatures returns the Features field if non-nil, zero value otherwise.
+
+### GetFeaturesOk
+
+`func (o *VmmPingResponse) GetFeaturesOk() (*[]string, bool)`
+
+GetFeaturesOk returns a tuple with the Features field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetFeatures
+
+`func (o *VmmPingResponse) SetFeatures(v []string)`
+
+SetFeatures sets Features field to given value.
+
+### HasFeatures
+
+`func (o *VmmPingResponse) HasFeatures() bool`
+
+HasFeatures returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_console_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_console_config.go
@@ -16,9 +16,10 @@ import (
 
 // ConsoleConfig struct for ConsoleConfig
 type ConsoleConfig struct {
-	File  *string `json:"file,omitempty"`
-	Mode  string  `json:"mode"`
-	Iommu *bool   `json:"iommu,omitempty"`
+	File   *string `json:"file,omitempty"`
+	Socket *string `json:"socket,omitempty"`
+	Mode   string  `json:"mode"`
+	Iommu  *bool   `json:"iommu,omitempty"`
 }
 
 // NewConsoleConfig instantiates a new ConsoleConfig object
@@ -73,6 +74,38 @@ func (o *ConsoleConfig) HasFile() bool {
 // SetFile gets a reference to the given string and assigns it to the File field.
 func (o *ConsoleConfig) SetFile(v string) {
 	o.File = &v
+}
+
+// GetSocket returns the Socket field value if set, zero value otherwise.
+func (o *ConsoleConfig) GetSocket() string {
+	if o == nil || o.Socket == nil {
+		var ret string
+		return ret
+	}
+	return *o.Socket
+}
+
+// GetSocketOk returns a tuple with the Socket field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *ConsoleConfig) GetSocketOk() (*string, bool) {
+	if o == nil || o.Socket == nil {
+		return nil, false
+	}
+	return o.Socket, true
+}
+
+// HasSocket returns a boolean if a field has been set.
+func (o *ConsoleConfig) HasSocket() bool {
+	if o != nil && o.Socket != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSocket gets a reference to the given string and assigns it to the Socket field.
+func (o *ConsoleConfig) SetSocket(v string) {
+	o.Socket = &v
 }
 
 // GetMode returns the Mode field value
@@ -135,6 +168,9 @@ func (o ConsoleConfig) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.File != nil {
 		toSerialize["file"] = o.File
+	}
+	if o.Socket != nil {
+		toSerialize["socket"] = o.Socket
 	}
 	if true {
 		toSerialize["mode"] = o.Mode

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_numa_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_numa_config.go
@@ -21,6 +21,7 @@ type NumaConfig struct {
 	Distances      *[]NumaDistance `json:"distances,omitempty"`
 	MemoryZones    *[]string       `json:"memory_zones,omitempty"`
 	SgxEpcSections *[]string       `json:"sgx_epc_sections,omitempty"`
+	PciSegments    *[]int32        `json:"pci_segments,omitempty"`
 }
 
 // NewNumaConfig instantiates a new NumaConfig object
@@ -193,6 +194,38 @@ func (o *NumaConfig) SetSgxEpcSections(v []string) {
 	o.SgxEpcSections = &v
 }
 
+// GetPciSegments returns the PciSegments field value if set, zero value otherwise.
+func (o *NumaConfig) GetPciSegments() []int32 {
+	if o == nil || o.PciSegments == nil {
+		var ret []int32
+		return ret
+	}
+	return *o.PciSegments
+}
+
+// GetPciSegmentsOk returns a tuple with the PciSegments field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *NumaConfig) GetPciSegmentsOk() (*[]int32, bool) {
+	if o == nil || o.PciSegments == nil {
+		return nil, false
+	}
+	return o.PciSegments, true
+}
+
+// HasPciSegments returns a boolean if a field has been set.
+func (o *NumaConfig) HasPciSegments() bool {
+	if o != nil && o.PciSegments != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPciSegments gets a reference to the given []int32 and assigns it to the PciSegments field.
+func (o *NumaConfig) SetPciSegments(v []int32) {
+	o.PciSegments = &v
+}
+
 func (o NumaConfig) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if true {
@@ -209,6 +242,9 @@ func (o NumaConfig) MarshalJSON() ([]byte, error) {
 	}
 	if o.SgxEpcSections != nil {
 		toSerialize["sgx_epc_sections"] = o.SgxEpcSections
+	}
+	if o.PciSegments != nil {
+		toSerialize["pci_segments"] = o.PciSegments
 	}
 	return json.Marshal(toSerialize)
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vmm_ping_response.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_vmm_ping_response.go
@@ -16,9 +16,10 @@ import (
 
 // VmmPingResponse Virtual Machine Monitor information
 type VmmPingResponse struct {
-	BuildVersion *string `json:"build_version,omitempty"`
-	Version      string  `json:"version"`
-	Pid          *int64  `json:"pid,omitempty"`
+	BuildVersion *string   `json:"build_version,omitempty"`
+	Version      string    `json:"version"`
+	Pid          *int64    `json:"pid,omitempty"`
+	Features     *[]string `json:"features,omitempty"`
 }
 
 // NewVmmPingResponse instantiates a new VmmPingResponse object
@@ -127,6 +128,38 @@ func (o *VmmPingResponse) SetPid(v int64) {
 	o.Pid = &v
 }
 
+// GetFeatures returns the Features field value if set, zero value otherwise.
+func (o *VmmPingResponse) GetFeatures() []string {
+	if o == nil || o.Features == nil {
+		var ret []string
+		return ret
+	}
+	return *o.Features
+}
+
+// GetFeaturesOk returns a tuple with the Features field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *VmmPingResponse) GetFeaturesOk() (*[]string, bool) {
+	if o == nil || o.Features == nil {
+		return nil, false
+	}
+	return o.Features, true
+}
+
+// HasFeatures returns a boolean if a field has been set.
+func (o *VmmPingResponse) HasFeatures() bool {
+	if o != nil && o.Features != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetFeatures gets a reference to the given []string and assigns it to the Features field.
+func (o *VmmPingResponse) SetFeatures(v []string) {
+	o.Features = &v
+}
+
 func (o VmmPingResponse) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.BuildVersion != nil {
@@ -137,6 +170,9 @@ func (o VmmPingResponse) MarshalJSON() ([]byte, error) {
 	}
 	if o.Pid != nil {
 		toSerialize["pid"] = o.Pid
+	}
+	if o.Features != nil {
+		toSerialize["features"] = o.Features
 	}
 	return json.Marshal(toSerialize)
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -445,6 +445,10 @@ components:
         pid:
           type: integer
           format: int64
+        features:
+          type: array
+          items:
+            type: string
       description: Virtual Machine Monitor information
 
     VmInfo:
@@ -947,9 +951,11 @@ components:
       properties:
         file:
           type: string
+        socket:
+          type: string
         mode:
           type: string
-          enum: [Off, Pty, Tty, File, Null]
+          enum: [Off, Pty, Tty, File, Socket, Null]
         iommu:
           type: boolean
           default: false
@@ -1074,6 +1080,11 @@ components:
           type: array
           items:
             type: string
+        pci_segments:
+          type: array
+          items:
+            type: integer
+            format: int32
 
     VmResize:
       type: object

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v35.0"
+      version: "v36.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This release has been tracked in our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
v36.0. The following user visible changes have been made:

### Command Line Changes

We switched back to use the `clap` crate to create our command line,
since the `argh` crate is barely maintained. There were several syntax
changes:

* All `--option value` commands now are `--option=value`.
* The `--disk DISK1 --disk DISK2` command now is `--disk DISK1 DISK2`.
* The `-v -v -v`command now is `-vvv`.

Note: the released binary size increased around 0.3M due to this change.

### Enabled Features Reported via API Endpoint and CLI

Now the enabled (Cargo) features of the running Cloud Hypervisor
instance can be queried via API endpoint (`/vmm.ping`) and CLI
(`--version -v`).

### NUMA Support for PCI segments

The `--numa` command is augmented with a new option `pci_segment=`, so
that users can define the relationship between PCI segments and NUMA
nodes. Examples can be found from the memory documentation.

### CPU Topology Support on AMD Platforms

Now the CPU topology on x86_64 platforms supports multiple vendors.

### Unix Socket Backend for Serial Port

The `--serial` command is augmented with a new option `socket=`, allowing
users to access the serial port using a Unix socket.

### AIO Backend for Block Devices

An AIO backend is added for `virtio-block` devices to improve block
device performance when the `io_uring` feature is not supported by the
host Operating System.

### Documentation Improvements

* New documentation for collecting coverage data
* Various typo fixes

### Notable Bug Fixes

* Fix a deadlock when TDX is enabled
* Only advertise AMX feature bits to guest when the AMX cpu feature is
  enabled
* Correct default value for vCPU topology on AArch64

Details can be found here: https://github.com/cloud-hypervisor/cloud-hypervisor/releases/

Fixes: #8378