### PR TITLE
utils: kata-manager: Add option to list versions

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -27,6 +27,10 @@ readonly kata_releases_url="https://api.github.com/repos/${kata_slug}/releases"
 readonly containerd_releases_url="https://api.github.com/repos/${containerd_slug}/releases"
 readonly containerd_io_releases_url="https://raw.githubusercontent.com/containerd/containerd.io/main/content/releases.md"
 
+readonly docker_slug="moby/moby"
+readonly docker_project="Docker (moby)"
+readonly docker_releases_url="https://api.github.com/repos/${docker_slug}/releases"
+
 # Directory created when unpacking a binary release archive downloaded from
 # $kata_releases_url.
 readonly kata_install_dir="${kata_install_dir:-/opt/kata}"
@@ -896,6 +900,10 @@ list_versions()
 	installed_containerd=$(containerd --version 2>/dev/null ||\
 		echo "$not_installed")
 
+	local installed_docker
+	installed_docker=$(docker --version 2>/dev/null ||\
+		echo "$not_installed")
+
 	local latest_kata
 	latest_kata=$(github_get_latest_release "$kata_releases_url" || true)
 	[ -z "$latest_kata" ] && \
@@ -906,6 +914,11 @@ list_versions()
 	[ -z "$latest_containerd" ] && \
 		die "cannot determine latest version of $containerd_project"
 
+	local latest_docker
+	latest_docker=$(github_get_latest_release "$docker_releases_url" || true)
+	[ -z "$latest_docker" ] && \
+		die "cannot determine latest version of $docker_project"
+
 	info "$kata_project: installed version: $installed_kata"
 	info "$kata_project: latest version: $latest_kata"
 
@@ -913,6 +926,11 @@ list_versions()
 
 	info "$containerd_project: installed version: $installed_containerd"
 	info "$containerd_project: latest version: $latest_containerd"
+
+	echo
+
+	info "$docker_project: installed version: $installed_docker"
+	info "$docker_project: latest version: $latest_docker"
 }
 
 handle_args()

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -270,9 +270,11 @@ $warnings
 
 Advice:
 
-- You can check the latest version of Kata Containers by running:
+- You can check the latest version of Kata Containers by running
+  one of the following:
 
   $ kata-runtime check --only-list-releases
+  $ kata-ctl check only-list-releases
 
 EOF
 }

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -109,7 +109,7 @@ github_get_latest_release()
 	local latest
 	latest=$(curl -sL "$url" |\
 		jq -r '.[].tag_name | select(contains("-") | not)' |\
-		sort -t "." -k1,1n -k2,2n -k3,3n |\
+		sort -t '.' -V |\
 		tail -1 || true)
 
 	[ -z "$latest" ] && die "Cannot determine latest release from $url"

--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -765,7 +765,7 @@ test_installation()
 	local image="docker.io/library/busybox:latest"
 	sudo $tool image pull "$image"
 
-	local container_name="test-kata"
+	local container_name="${script_name/./-}-test-kata"
 
 	# Used to prove that the kernel in the container
 	# is different to the host kernel.


### PR DESCRIPTION
Add a command-line option to list the installed and available versions
of Kata, containerd and Docker.

Also contains a few extra code improvements.

Fixes: #8355.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>