### PR TITLE
dragonball: metrics support for virtio-fs device

### DIFF
--- a/src/dragonball/src/device_manager/fs_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/fs_dev_mgr.rs
@@ -18,6 +18,7 @@ use crate::device_manager::{
     DbsMmioV2Device, DeviceManager, DeviceMgrError, DeviceOpContext, DeviceVirtioRegionHandler,
 };
 use crate::get_bucket_update;
+use crate::metric::METRICS;
 
 use super::DbsVirtioDevice;
 
@@ -423,7 +424,11 @@ impl FsDeviceMgr {
             )
             .map_err(FsDeviceError::CreateFsDevice)?,
         );
-
+        METRICS
+            .write()
+            .unwrap()
+            .fs
+            .insert(config.tag.clone(), device.metrics());
         Ok(device)
     }
 

--- a/src/dragonball/src/metric.rs
+++ b/src/dragonball/src/metric.rs
@@ -13,6 +13,8 @@ use dbs_legacy_devices::SerialDeviceMetrics;
 use dbs_utils::metric::SharedIncMetric;
 #[cfg(feature = "virtio-balloon")]
 use dbs_virtio_devices::balloon::BalloonDeviceMetrics;
+#[cfg(feature = "virtio-fs")]
+use dbs_virtio_devices::fs::FsDeviceMetrics;
 use lazy_static::lazy_static;
 use serde::Serialize;
 
@@ -77,6 +79,9 @@ pub struct DragonballMetrics {
     pub rtc: Arc<RTCDeviceMetrics>,
     /// Metrics related to serial device.
     pub serial: HashMap<String, Arc<SerialDeviceMetrics>>,
+    #[cfg(feature = "virtio-fs")]
+    /// Metrics related to virtio-fs devices.
+    pub fs: HashMap<String, Arc<FsDeviceMetrics>>,
     #[cfg(feature = "virtio-balloon")]
     /// Metrics related to balloon device.
     pub balloon: HashMap<String, Arc<BalloonDeviceMetrics>>,


### PR DESCRIPTION
This PR adds metrics support for virtio-fs device.

Fixes: #7248

Signed-off-by: Songqian Li <mail@lisongqian.cn>