### PR TITLE
kata-deploy: Allow users to set hypervisor annotations

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -119,6 +119,7 @@ function deploy_kata() {
     yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[5].value' --tag '!!str' "true"
 
     if [ "${KATA_HOST_OS}" = "cbl-mariner" ]; then
+        yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[6].value' "initrd kernel"
         yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[+].name' "HOST_OS"
         yq write -i "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" 'spec.template.spec.containers[0].env[-1].value' "${KATA_HOST_OS}"
     fi

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -39,6 +39,8 @@ spec:
               value: "false"
             - name: CREATE_DEFAULT_RUNTIMECLASS
               value: "false"
+            - name: ALLOWED_HYPERVISOR_ANNOTATIONS
+              value: ""
           securityContext:
             privileged: true
           volumeMounts:

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -130,7 +130,6 @@ function install_artifacts() {
 	if [ "${HOST_OS:-}" == "cbl-mariner" ]; then
 		config_path="/opt/kata/share/defaults/kata-containers/configuration-clh.toml"
 		clh_path="/opt/kata/bin/cloud-hypervisor-glibc"
-		sed -i -E 's|(enable_annotations) = .+|\1 = ["enable_iommu", "initrd", "kernel"]|' "${config_path}"
 		sed -i -E "s|(valid_hypervisor_paths) = .+|\1 = [\"${clh_path}\"]|" "${config_path}"
 		sed -i -E "s|(path) = \".+/cloud-hypervisor\"|\1 = \"${clh_path}\"|" "${config_path}"
 	fi


### PR DESCRIPTION
Currently the only way one can specify allowed hypervisor annotations is
during build time, which is a big issue for users grabbing kata-deploy
as we provide.

Fixes: #8403

---

Although a formal test for this is not provided, we're testing this as part of all the deployments / tests using CBL mariner, as we're set the extra "initrd" and "kernel" to the allowed list of hypervisor annotations.

@sprt, I'd appreciate a lot a review and tests from your side to make sure this is working as expected with CBL mariner.