### PR TITLE
Fix PR #8284

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -57,8 +57,8 @@ impl CloudHypervisorInner {
             // - Network details need to be saved for later application.
             //
             match device {
-                DeviceType::ShareFs(_) => self.pending_devices.insert(0, device.clone()),
-                DeviceType::Network(_) => self.pending_devices.insert(0, device.clone()),
+                DeviceType::ShareFs(_) => self.pending_devices.insert(0, device.try_clone()?),
+                DeviceType::Network(_) => self.pending_devices.insert(0, device.try_clone()?),
                 _ => {
                     debug!(
                         sl!(),

--- a/src/runtime-rs/crates/hypervisor/src/device/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/mod.rs
@@ -10,9 +10,9 @@ use crate::device::driver::vhost_user_blk::VhostUserBlkDevice;
 use crate::{
     BlockConfig, BlockDevice, HybridVsockConfig, HybridVsockDevice, Hypervisor as hypervisor,
     NetworkConfig, NetworkDevice, ShareFsDevice, ShareFsDeviceConfig, ShareFsMountConfig,
-    ShareFsMountDevice, VfioConfig, VfioDevice, VhostUserConfig, VsockConfig,
+    ShareFsMountDevice, VfioConfig, VfioDevice, VhostUserConfig, VsockConfig, VsockDevice,
 };
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 
 pub mod device_manager;
@@ -31,7 +31,7 @@ pub enum DeviceConfig {
     HybridVsockCfg(HybridVsockConfig),
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub enum DeviceType {
     Block(BlockDevice),
     VhostUserBlk(VhostUserBlkDevice),
@@ -40,6 +40,7 @@ pub enum DeviceType {
     ShareFs(ShareFsDevice),
     ShareFsMount(ShareFsMountDevice),
     HybridVsock(HybridVsockDevice),
+    Vsock(VsockDevice),
 }
 
 impl DeviceType {
@@ -56,6 +57,7 @@ impl DeviceType {
                 Ok(DeviceType::ShareFsMount(share_fs_mount.clone()))
             }
             DeviceType::HybridVsock(hvsock) => Ok(DeviceType::HybridVsock(hvsock.clone())),
+            DeviceType::Vsock(_) => Err(anyhow!("DeviceType::Vsock cannot be cloned")),
         }
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/device/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/mod.rs
@@ -42,6 +42,24 @@ pub enum DeviceType {
     HybridVsock(HybridVsockDevice),
 }
 
+impl DeviceType {
+    pub fn try_clone(&self) -> Result<DeviceType> {
+        match self {
+            DeviceType::Block(block) => Ok(DeviceType::Block(block.clone())),
+            DeviceType::VhostUserBlk(vhost_user_blk) => {
+                Ok(DeviceType::VhostUserBlk(vhost_user_blk.clone()))
+            }
+            DeviceType::Vfio(vfio) => Ok(DeviceType::Vfio(vfio.clone())),
+            DeviceType::Network(network) => Ok(DeviceType::Network(network.clone())),
+            DeviceType::ShareFs(share_fs) => Ok(DeviceType::ShareFs(share_fs.clone())),
+            DeviceType::ShareFsMount(share_fs_mount) => {
+                Ok(DeviceType::ShareFsMount(share_fs_mount.clone()))
+            }
+            DeviceType::HybridVsock(hvsock) => Ok(DeviceType::HybridVsock(hvsock.clone())),
+        }
+    }
+}
+
 impl fmt::Display for DeviceType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:?}", self)

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -85,6 +85,9 @@ impl DragonballInner {
                 .add_share_fs_mount(&sharefs_mount.config)
                 .map(|_ok| device)
                 .context("add share fs mount"),
+            DeviceType::Vsock(_) => {
+                todo!()
+            }
         }
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -94,10 +94,7 @@ impl Hypervisor for Dragonball {
 
     async fn add_device(&self, device: DeviceType) -> Result<DeviceType> {
         let mut inner = self.inner.write().await;
-        match inner.add_device(device.clone()).await {
-            Ok(_) => Ok(device),
-            Err(err) => Err(err),
-        }
+        inner.add_device(device).await
     }
 
     async fn remove_device(&self, device: DeviceType) -> Result<()> {


### PR DESCRIPTION
PR #8284 removed `DeviceType::Vsock` which broke PR #8185.  The removal (and thus breakage) doesn't seem necessary to achieve PR #8284's goals and this PR proposes a solution.  It is based on observation that while PR #8284 imposes the requirement of cloneability on all `DeviceType` variants, the requirement is arguably unnecessarily strong since fallible cloneability (try_clone() functionality) should be enough.

NB I couldn't test this change properly.  Since this is an emergency fix of another PR I take the liberty of relying on reviewers' help to verify the change.

NB This PR cannot and does not address potential technical design flaws in PR #8284. Most importantly, it's not clear whether adding a `DeviceType` return value to `add_device()` is the best way of achieving PR #8284's goals.  The resulting signature incorrectly suggests that `add_device()` could take a `DeviceType` and return a completely unrelated one.  Another solution, maybe passing a mutable reference to `add_device()`, could have communicated the `add_device()` contract better.

Fixes: #8413

@Apokleos @bergwolf @amshinde 