### PR TITLE
cc: gha: kernel-snp-experimental is not a valid tag

### DIFF
--- a/.github/workflows/cc-payload-amd64.yaml
+++ b/.github/workflows/cc-payload-amd64.yaml
@@ -18,7 +18,6 @@ jobs:
           - qemu
           - virtiofsd
           - kernel-sev
-          - kernel-snp-experimental
           - ovmf-sev
           - ovmf
           - qemu-snp-experimental


### PR DESCRIPTION
We fixed this as part of the after-push PR, but we forgot to have this one fixed.