### PR TITLE
runtime-rs: ch: Fix TDX

### DIFF
--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1474,7 +1474,6 @@ dependencies = [
  "path-clean",
  "persist",
  "rand 0.8.5",
- "regex",
  "rust-ini",
  "safe-path 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "seccompiler",

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -16,7 +16,6 @@ go-flag = "0.1.0"
 libc = ">=0.2.39"
 nix = "0.24.2"
 persist = { path = "../persist" }
-regex = "1.10.2"
 rust-ini = "0.18.0"
 seccompiler = "0.2.0"
 serde = { version = "1.0.138", features = ["derive"] }


### PR DESCRIPTION
PR #8311 inadvertently broke the runtime-rs / Cloud Hypervisor TDX handling. It also introduced unrecoverable failure scenarios. Hence, replace slow, fallible regex matching in logging fast path with single pass non-failing multi-string log level matching.

Also, added a unit test for `parse_ch_log_level()`.

Fixes: #8418.