### PR TITLE
runtime-rs: Fix panic issue with 'enable-debug' option on Cloud Hypervisor

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -761,13 +761,16 @@ async fn cloud_hypervisor_log_output(mut child: Child, mut shutdown: Receiver<bo
 }
 
 pub fn parse_ch_log_level(line: &str) -> &str {
-    let re = Regex::new(r"cloud-hypervisor: [0-9]*[.][0-9]+ms: <\w+> (?<level>\w+)").unwrap();
-    let level = re
-        .captures(line)
-        .expect("There should be a match for level")
-        .name("level")
-        .expect("Level should be found in record")
-        .as_str();
+    let re = Regex::new(r"cloud-hypervisor: [0-9]*[.][0-9]+.s: <\w+> (?<clh_level>\w+)").unwrap();
+
+    let mut level = "INFO";
+
+    if let Some(captures) = re.captures(line) {
+        if let Some(clh_level) = captures.name("clh_level") {
+            level = clh_level.as_str();
+        }
+    }
+
     match level {
         "TRACE" => LOG_LEVEL_TRACE,
         "DEBUG" => LOG_LEVEL_DEBUG,


### PR DESCRIPTION
Fixes a problem where parse_ch_log_level() fails to work correctly when the "enable-debug" option is turned on in the configuration.toml.

Root Cause of Panic:
Parsing certain logs,
such as "[0.000000] Booting Linux on physical CPU 0x0000000000 [0x411fd0c0]"
        "cloud-hypervisor: 1.302s: <vcpu0> INFO:.."
can triggers the following panic:
{"msg":"A panic occurred at crates/hypervisor/src/ch/inner_hypervisor.rs:768: There should be a match for level\r\n"...

Fixes: #8416