### PR TITLE
gha: Remove docker and nerdctl tests from ci.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -73,22 +73,6 @@ jobs:
           platforms: linux/amd64, linux/s390x
           file: tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
 
-  run-docker-tests-on-garm:
-    needs: build-kata-static-tarball-amd64
-    uses: ./.github/workflows/run-docker-tests-on-garm.yaml
-    with:
-      tarball-suffix: -${{ inputs.tag }}
-      commit-hash: ${{ inputs.commit-hash }}
-      target-branch: ${{ inputs.target-branch }}
-
-  run-nerdctl-tests-on-garm:
-    needs: build-kata-static-tarball-amd64
-    uses: ./.github/workflows/run-nerdctl-tests-on-garm.yaml
-    with:
-      tarball-suffix: -${{ inputs.tag }}
-      commit-hash: ${{ inputs.commit-hash }}
-      target-branch: ${{ inputs.target-branch }}
-
   run-kata-deploy-tests-on-aks:
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-kata-deploy-tests-on-aks.yaml


### PR DESCRIPTION
> [!NOTE]  
> The latest main branch's `ci.yaml` rather than this patch's is used to perform the CI. Therefore, "kata-containers-ci-on-push/*" tests of this pull request still go failure.

Two workflows, run-nerdctl-tests-on-garm.yaml and
run-docker-tests-on-garm.yaml, are removed from commit b481d39. However,
they are referenced by CI workflow. It leads to the CI not working
properly. This patch is to remove those files from ci.yaml.

Fixes: #8433