### PR TITLE
build/kata-deploy: Move rust runtime config files to runtime-rs directory

### DIFF
--- a/src/libs/kata-types/src/config/default.rs
+++ b/src/libs/kata-types/src/config/default.rs
@@ -14,6 +14,12 @@ use lazy_static::lazy_static;
 lazy_static! {
     /// Default configuration file paths, vendor may extend the list
     pub static ref DEFAULT_RUNTIME_CONFIGURATIONS: Vec::<&'static str> = vec![
+        // The rust runtime specific paths
+        "/etc/kata-containers/runtime-rs/configuration.toml",
+        "/usr/share/defaults/kata-containers/runtime-rs/configuration.toml",
+        "/opt/kata/share/defaults/kata-containers/runtime-rs/configuration.toml",
+
+        // The traditional golang paths
         "/etc/kata-containers/configuration.toml",
         "/usr/share/defaults/kata-containers/configuration.toml",
         "/opt/kata/share/defaults/kata-containers/configuration.toml",

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -189,7 +189,7 @@ KNOWN_HYPERVISORS =
 # List of hypervisors known for the current architecture
 KNOWN_HYPERVISORS =
 
-CONFDIR := $(DEFAULTSDIR)/$(PROJECT_DIR)
+CONFDIR := $(DEFAULTSDIR)/$(PROJECT_DIR)/runtime-rs
 SYSCONFDIR := $(SYSCONFDIR)/$(PROJECT_DIR)
 ##VAR CONFIG_PATH=<path> Main configuration file location for stateless systems
 CONFIG_PATH := $(abspath $(CONFDIR)/$(CONFIG_FILE))

--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -30,7 +30,7 @@ spec:
             - name: DEBUG
               value: "false"
             - name: SHIMS
-              value: "clh dragonball fc qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx qemu"
+              value: "clh cloud-hypervisor dragonball fc qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx qemu"
             - name: DEFAULT_SHIM
               value: "qemu"
             - name: CREATE_RUNTIMECLASSES

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy-stable.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy-stable.yaml
@@ -32,7 +32,7 @@ spec:
             - name: DEBUG
               value: "false"
             - name: SHIMS
-              value: "clh dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx"
+              value: "clh cloud-hypervisor dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx"
             - name: DEFAULT_SHIM
               value: "qemu"
             - name: CREATE_RUNTIMECLASSES

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -32,7 +32,7 @@ spec:
             - name: DEBUG
               value: "false"
             - name: SHIMS
-              value: "clh dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx"
+              value: "clh cloud-hypervisor dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx"
             - name: DEFAULT_SHIM
               value: "qemu"
             - name: CREATE_RUNTIMECLASSES


### PR DESCRIPTION
Install the rust runtime configuration files to a `runtime-rs/`
directory to distinguish them from the golang config files (which may
have a different syntax).

The default values mean that the rust config files are now installed to
`/opt/kata/share/defaults/kata-containers/runtime-rs/` rather than
`/opt/kata/share/defaults/kata-containers/`.

See: https://github.com/kata-containers/kata-containers/issues/6020

Also:

- Updates `kata-deploy` to include the rust runtime CH config file and als to make use of the `runtime-rs/` directory for all rust runtime config files.
- Updates the rust runtime to look in the `runtime-rs/` directories before looking for config files in the "traditional" (golang runtime) locations.

Fixes: #8444.