### PR TITLE
metrics: Add iperf udp information to README

### DIFF
--- a/tests/metrics/network/README.md
+++ b/tests/metrics/network/README.md
@@ -12,6 +12,7 @@ bandwidth, jitter, latency and parallel bandwidth.
 - `k8s-network-metrics-iperf3.sh` measures bandwidth which is the speed of the data transfer.
 - `latency-network.sh` measures network latency.
 - `nginx-network.sh` is a benchmark of the lightweight Nginx HTTPS web-server and measures the HTTP requests over a fixed period of time with a configurable number of concurrent clients/connections.
+- `k8s-network-metrics-iperf3-udp.sh` measures `UDP` bandwidth and parallel bandwidth which is the speed of the data transfer.
 
 ## Running the tests
 


### PR DESCRIPTION
This PR adds the iperf udp information to the network README for the kata metrics CI.

Fixes #8452