### PR TITLE
runtime-rs: make compilation for QEMU on s390x

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -26,15 +26,11 @@ ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
 
 ifeq ($(ARCH), s390x)
-default:
-	@echo "s390x is not currently supported"
-	exit 0
+default: runtime show-header
 test:
 	@echo "s390x is not currently supported"
 	exit 0
-install:
-	@echo "s390x is not currently supported"
-	exit 0
+install: install-runtime install-configs
 else ifeq ($(ARCH), powerpc64le)
 default:
 	@echo "PowerPC 64 LE is not currently supported"

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -11,7 +11,6 @@ license = "Apache-2.0"
 actix-rt = "2.7.0"
 anyhow = "^1.0"
 async-trait = "0.1.48"
-dbs-utils = { path = "../../../dragonball/src/dbs_utils" }
 go-flag = "0.1.0"
 libc = ">=0.2.39"
 nix = "0.24.2"
@@ -35,14 +34,16 @@ kata-types = { path = "../../../libs/kata-types" }
 logging = { path = "../../../libs/logging" }
 shim-interface = { path = "../../../libs/shim-interface" }
 
-dragonball = { path = "../../../dragonball", features = ["atomic-guest-memory", "virtio-vsock", "hotplug", "virtio-blk", "virtio-net", "virtio-fs", "vhost-net", "dbs-upcall", "virtio-mem", "virtio-balloon", "vhost-user-net", "host-device"] }
-
 ch-config = { path = "ch-config", optional = true }
 tests_utils = { path = "../../tests/utils" }
 
 futures = "0.3.25"
 safe-path = "0.1.0"
 crossbeam-channel = "0.5.6"
+
+[target.'cfg(not(target_arch = "s390x"))'.dependencies]
+dragonball = { path = "../../../dragonball", features = ["atomic-guest-memory", "virtio-vsock", "hotplug", "virtio-blk", "virtio-net", "virtio-fs", "vhost-net", "dbs-upcall", "virtio-mem", "virtio-balloon", "vhost-user-net", "host-device"] }
+dbs-utils = { path = "../../../dragonball/src/dbs_utils" }
 
 [features]
 default = []

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -13,6 +13,7 @@ pub mod device;
 pub mod hypervisor_persist;
 pub use device::driver::*;
 use device::DeviceType;
+#[cfg(not(target_arch = "s390x"))]
 pub mod dragonball;
 mod kernel_param;
 pub mod qemu;
@@ -20,7 +21,7 @@ pub use kernel_param::Param;
 pub mod utils;
 use std::collections::HashMap;
 
-#[cfg(feature = "cloud-hypervisor")]
+#[cfg(all(feature = "cloud-hypervisor", not(target_arch = "s390x")))]
 pub mod ch;
 
 use anyhow::Result;
@@ -49,9 +50,12 @@ const VM_ROOTFS_FILESYSTEM_EROFS: &str = "erofs";
 // /dev/hugepages will be the mount point
 // mkdir -p /dev/hugepages
 // mount -t hugetlbfs none /dev/hugepages
+#[cfg(not(target_arch = "s390x"))]
 const DEV_HUGEPAGES: &str = "/dev/hugepages";
 pub const HUGETLBFS: &str = "hugetlbfs";
+#[cfg(not(target_arch = "s390x"))]
 const SHMEM: &str = "shmem";
+#[cfg(not(target_arch = "s390x"))]
 const HUGE_SHMEM: &str = "hugeshmem";
 
 pub const HYPERVISOR_DRAGONBALL: &str = "dragonball";
@@ -60,6 +64,7 @@ pub const HYPERVISOR_QEMU: &str = "qemu";
 pub const DEFAULT_HYBRID_VSOCK_NAME: &str = "kata.hvsock";
 pub const JAILER_ROOT: &str = "root";
 
+#[cfg(not(target_arch = "s390x"))]
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) enum VmmState {
     NotReady,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -17,7 +17,9 @@ use common::message::{Action, Message};
 use common::{Sandbox, SandboxNetworkEnv};
 use containerd_shim_protos::events::task::TaskOOM;
 use hypervisor::VsockConfig;
-use hypervisor::{dragonball::Dragonball, BlockConfig, Hypervisor, HYPERVISOR_DRAGONBALL};
+use hypervisor::{BlockConfig, Hypervisor};
+#[cfg(not(target_arch = "s390x"))]
+use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 use hypervisor::{utils::get_hvsock_path, HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID};
 use kata_sys_util::hooks::HookStates;
 use kata_types::capabilities::CapabilityBits;
@@ -585,6 +587,7 @@ impl Persist for VirtSandbox {
         let h = sandbox_state.hypervisor.unwrap_or_default();
         let hypervisor = match h.hypervisor_type.as_str() {
             // TODO support other hypervisors
+            #[cfg(not(target_arch = "s390x"))]
             HYPERVISOR_DRAGONBALL => Ok(Arc::new(Dragonball::restore((), h).await?)),
             _ => Err(anyhow!("Unsupported hypervisor {}", &h.hypervisor_type)),
         }?;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -17,10 +17,11 @@ use common::message::{Action, Message};
 use common::{Sandbox, SandboxNetworkEnv};
 use containerd_shim_protos::events::task::TaskOOM;
 use hypervisor::VsockConfig;
-use hypervisor::{BlockConfig, Hypervisor};
 #[cfg(not(target_arch = "s390x"))]
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
+use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{utils::get_hvsock_path, HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID};
+use hypervisor::{BlockConfig, Hypervisor};
 use kata_sys_util::hooks::HookStates;
 use kata_types::capabilities::CapabilityBits;
 use kata_types::config::TomlConfig;
@@ -588,7 +589,14 @@ impl Persist for VirtSandbox {
         let hypervisor = match h.hypervisor_type.as_str() {
             // TODO support other hypervisors
             #[cfg(not(target_arch = "s390x"))]
-            HYPERVISOR_DRAGONBALL => Ok(Arc::new(Dragonball::restore((), h).await?)),
+            HYPERVISOR_DRAGONBALL => {
+                let hypervisor = Arc::new(Dragonball::restore((), h).await?) as Arc<dyn Hypervisor>;
+                Ok(hypervisor)
+            }
+            HYPERVISOR_QEMU => {
+                let hypervisor = Arc::new(Qemu::restore((), h).await?) as Arc<dyn Hypervisor>;
+                Ok(hypervisor)
+            }
             _ => Err(anyhow!("Unsupported hypervisor {}", &h.hypervisor_type)),
         }?;
         let agent = Arc::new(KataAgent::new(kata_types::config::Agent::default()));


### PR DESCRIPTION
This PR is to make `runtime-rs` compilable with QEMU on s390x. This is just a base work for the s390x enablement. There must be a few more steps (implementation for s390x-specific) to run a container with runtime-rs.

Fixes: #8446

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>