### PR TITLE
github: add workflows for building and publishing kata artefacts on ppc64le

### DIFF
--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -1,0 +1,116 @@
+name: CI | Build kata-static tarball for ppc64le
+on:
+  workflow_call:
+    inputs:
+      stage:
+        required: false
+        type: string
+        default: test
+      tarball-suffix:
+        required: false
+        type: string
+      push-to-registry:
+        required: false
+        type: string
+        default: no
+      commit-hash:
+        required: false
+        type: string
+      target-branch:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  build-asset:
+    runs-on: ppc64le
+    strategy:
+      matrix:
+        asset:
+          - kernel
+          - qemu
+          - rootfs-initrd
+          - shim-v2
+          - virtiofsd
+        stage:
+          - ${{ inputs.stage }}
+    steps:
+      - name: Adjust a permission for repo
+        run: |
+          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+
+      - name: Login to Kata Containers quay.io
+        if: ${{ inputs.push-to-registry == 'yes' }}
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
+          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0 # This is needed in order to keep the commit ids history
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Build ${{ matrix.asset }}
+        run: |
+          make "${KATA_ASSET}-tarball"
+          build_dir=$(readlink -f build)
+          # store-artifact does not work with symlink
+          sudo cp -r "${build_dir}" "kata-build"
+          sudo chown -R $(id -u):$(id -g) "kata-build"
+        env:
+          KATA_ASSET: ${{ matrix.asset }}
+          TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
+          PUSH_TO_REGISTRY: ${{ inputs.push-to-registry }}
+          ARTEFACT_REGISTRY: ghcr.io
+          ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
+          ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: store-artifact ${{ matrix.asset }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: kata-artifacts-ppc64le${{ inputs.tarball-suffix }}
+          path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
+          retention-days: 1
+          if-no-files-found: error
+
+  create-kata-tarball:
+    runs-on: ppc64le
+    needs: build-asset
+    steps:
+      - name: Adjust a permission for repo
+        run: |
+          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+      - name: get-artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-artifacts-ppc64le${{ inputs.tarball-suffix }}
+          path: kata-artifacts
+      - name: merge-artifacts
+        run: |
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+      - name: store-artifacts
+        uses: actions/upload-artifact@v3
+        with:
+          name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
+          path: kata-static.tar.xz
+          retention-days: 1
+          if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -42,6 +42,13 @@ jobs:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+  
+  build-kata-static-tarball-ppc64le:
+    uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
 
   publish-kata-deploy-payload-s390x:
     needs: build-kata-static-tarball-s390x
@@ -51,6 +58,18 @@ jobs:
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
       tag: ${{ inputs.tag }}-s390x
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
+    secrets: inherit
+  
+  publish-kata-deploy-payload-ppc64le:
+    needs: build-kata-static-tarball-ppc64le
+    uses: ./.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-ppc64le
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
     secrets: inherit

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -34,6 +34,14 @@ jobs:
       push-to-registry: yes
       target-branch: ${{ github.ref_name }}
     secrets: inherit
+  
+  build-assets-ppc64le:
+    uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
+    with:
+      commit-hash: ${{ github.sha }}
+      push-to-registry: yes
+      target-branch: ${{ github.ref_name }}
+    secrets: inherit
 
   publish-kata-deploy-payload-amd64:
     needs: build-assets-amd64
@@ -68,9 +76,20 @@ jobs:
       target-branch: ${{ github.ref_name }}
     secrets: inherit
 
+  publish-kata-deploy-payload-ppc64le:
+    needs: build-assets-ppc64le
+    uses: ./.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
+    with:
+      commit-hash: ${{ github.sha }}
+      registry: quay.io
+      repo: kata-containers/kata-deploy-ci
+      tag: kata-containers-ppc64le
+      target-branch: ${{ github.ref_name }}
+    secrets: inherit
+
   publish-manifest:
     runs-on: ubuntu-latest
-    needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-arm64, publish-kata-deploy-payload-s390x]
+    needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-arm64, publish-kata-deploy-payload-s390x, publish-kata-deploy-payload-ppc64le]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -87,5 +106,6 @@ jobs:
           docker manifest create quay.io/kata-containers/kata-deploy-ci:kata-containers-latest \
           --amend quay.io/kata-containers/kata-deploy-ci:kata-containers-amd64 \
           --amend quay.io/kata-containers/kata-deploy-ci:kata-containers-arm64 \
-          --amend quay.io/kata-containers/kata-deploy-ci:kata-containers-s390x
+          --amend quay.io/kata-containers/kata-deploy-ci:kata-containers-s390x \
+          --amend quay.io/kata-containers/kata-deploy-ci:kata-containers-ppc64le
           docker manifest push quay.io/kata-containers/kata-deploy-ci:kata-containers-latest

--- a/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
@@ -1,0 +1,73 @@
+name: CI | Publish kata-deploy payload for ppc64le
+on:
+  workflow_call:
+    inputs:
+      tarball-suffix:
+        required: false
+        type: string
+      registry:
+        required: true
+        type: string
+      repo:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      commit-hash:
+        required: false
+        type: string
+      target-branch:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  kata-payload:
+    runs-on: ppc64le
+    steps:
+      - name: Adjust a permission for repo
+        run: |
+          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+
+      - name: Prepare the self-hosted runner
+        run: ${HOME}/scripts/prepare_runner.sh
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: get-kata-tarball
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
+
+      - name: Login to Kata Containers quay.io
+        if: ${{ inputs.registry == 'quay.io' }}
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
+          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+
+      - name: Login to Kata Containers ghcr.io
+        if: ${{ inputs.registry == 'ghcr.io' }}
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: build-and-push-kata-payload
+        id: build-and-push-kata-payload
+        run: |
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+          $(pwd)/kata-static.tar.xz \
+          ${{ inputs.registry }}/${{ inputs.repo }} ${{ inputs.tag }}

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -1,0 +1,53 @@
+name: Publish Kata release artifacts for ppc64le
+on:
+  workflow_call:
+    inputs:
+      target-arch:
+        required: true
+        type: string
+
+jobs:
+  build-kata-static-tarball-ppc64le:
+    uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
+    with:
+      stage: release
+
+  kata-deploy:
+    needs: build-kata-static-tarball-ppc64le
+    runs-on: ppc64le
+    steps:
+      - name: Login to Kata Containers docker.io
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Login to Kata Containers quay.io
+        uses: docker/login-action@v2
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
+          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+
+      - uses: actions/checkout@v4
+      - name: get-kata-tarball
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-static-tarball-ppc64le
+
+      - name: build-and-push-kata-deploy-ci-ppc64le
+        id: build-and-push-kata-deploy-ci-ppc64le
+        run: |
+          # We need to do such trick here as the format of the $GITHUB_REF 
+          # is "refs/tags/<tag>"
+          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+          tags=($tag)
+          tags+=($([[ "$tag" =~ "alpha"|"rc" ]] && echo "latest" || echo "stable"))
+          for tag in ${tags[@]}; do
+              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+                  $(pwd)/kata-static.tar.xz "docker.io/katadocker/kata-deploy" \
+                  "${tag}-${{ inputs.target-arch }}"
+              ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
+                  $(pwd)/kata-static.tar.xz "quay.io/kata-containers/kata-deploy" \
+                  "${tag}-${{ inputs.target-arch }}"
+          done

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,9 +27,15 @@ jobs:
       target-arch: s390x
     secrets: inherit
 
+  build-and-push-assets-ppc64le:
+    uses: ./.github/workflows/release-ppc64le.yaml
+    with:
+      target-arch: ppc64le
+    secrets: inherit
+
   publish-multi-arch-images:
     runs-on: ubuntu-latest
-    needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x]
+    needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,12 +64,14 @@ jobs:
             docker manifest create quay.io/kata-containers/kata-deploy:${tag} \
               --amend quay.io/kata-containers/kata-deploy:${tag}-amd64 \
               --amend quay.io/kata-containers/kata-deploy:${tag}-arm64 \
-              --amend quay.io/kata-containers/kata-deploy:${tag}-s390x
+              --amend quay.io/kata-containers/kata-deploy:${tag}-s390x \
+              --amend quay.io/kata-containers/kata-deploy:${tag}-ppc64le
 
             docker manifest create docker.io/katadocker/kata-deploy:${tag} \
               --amend docker.io/katadocker/kata-deploy:${tag}-amd64 \
               --amend docker.io/katadocker/kata-deploy:${tag}-arm64 \
-              --amend docker.io/katadocker/kata-deploy:${tag}-s390x
+              --amend docker.io/katadocker/kata-deploy:${tag}-s390x \
+              --amend docker.io/katadocker/kata-deploy:${tag}-ppc64le
 
             docker manifest push quay.io/kata-containers/kata-deploy:${tag}
             docker manifest push docker.io/katadocker/kata-deploy:${tag}
@@ -115,6 +123,20 @@ jobs:
           pushd $GITHUB_WORKSPACE
           echo "uploading asset '${tarball}' for tag: ${tag}"
           GITHUB_TOKEN=${{ secrets.GIT_UPLOAD_TOKEN }} gh release upload "${tag}" "${tarball}"
+          popd
+
+      - name: download-artifacts-ppc64le
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-static-tarball-ppc64le
+      - name: push ppc64le static tarball to github
+        run: |
+          tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+          tarball="kata-static-$tag-ppc64le.tar.xz"
+          mv kata-static.tar.xz "$GITHUB_WORKSPACE/${tarball}"
+          pushd $GITHUB_WORKSPACE
+          echo "uploading asset '${tarball}' for tag: ${tag}"
+          GITHUB_TOKEN=${{ secrets.GIT_UPLOAD_TOKEN }} hub release edit -m "" -a "${tarball}" "${tag}"
           popd
 
   upload-versions-yaml:

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -16,6 +16,9 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         curl \
+        make \
+        git \
+        wget \
         sudo && \
     apt-get clean && rm -rf /var/lib/apt/lists/ && \
     install_yq.sh && \
@@ -43,10 +46,7 @@ RUN apt-get update && \
   build-essential \
   cpio \
   gcc \
-  git \
-  make \
   unzip \
-  wget \
   xz-utils && \
   apt-get clean && rm -rf /var/lib/apt/lists
 

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/install_oras.sh
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/install_oras.sh
@@ -29,9 +29,21 @@ fi
 
 arch=$(uname -m)
 if [ "${arch}" = "ppc64le" ]; then
-	echo "An ORAS release for ppc64le is not available yet."
-	exit 0
-fi
+ 	echo "Building oras from source"
+	go_version="go1.21.3"
+ 	# Install go
+ 	wget https://go.dev/dl/${go_version}.linux-ppc64le.tar.gz
+ 	rm -rf /usr/local/go && tar -C /usr/local -xzf ${go_version}.linux-ppc64le.tar.gz
+ 	export PATH=$PATH:/usr/local/go/bin
+ 	go version
+
+ 	git clone https://github.com/oras-project/oras.git
+ 	pushd oras 
+	make build-linux-ppc64le
+ 	cp bin/linux/ppc64le/oras ${install_dest}
+ 	popd 
+ 	exit 0
+ fi
 if [ "${arch}" = "x86_64" ]; then
 	arch="amd64"
 fi

--- a/tools/packaging/static-build/qemu.blacklist
+++ b/tools/packaging/static-build/qemu.blacklist
@@ -29,7 +29,6 @@ qemu_black_list=(
 */share/*/qemu_vga.ndrv
 */share/*/sgabios.bin
 */share/*/skiboot.lid
-*/share/*/slof.bin
 */share/*/trace-events-all
 */share/*/u-boot*
 */share/*/vgabios*

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -63,6 +63,7 @@ RUN apt-get update && apt-get upgrade -y && \
 	    rsync \
 	    zlib1g-dev${DPKG_ARCH} && \
     if [ "${ARCH}" != s390x ]; then apt-get install -y --no-install-recommends libpmem-dev${DPKG_ARCH}; fi && \
+	if [ "${ARCH}" == ppc64le ]; then apt-get install -y --no-install-recommends librados-dev librbd-dev; fi && \
     GCC_ARCH="${ARCH}" && if [ "${ARCH}" = "ppc64le" ]; then GCC_ARCH="powerpc64le"; fi && \
     if [ "${ARCH}" != "$(uname -m)" ]; then apt-get install --no-install-recommends -y gcc-"${GCC_ARCH}"-linux-gnu; fi && \
     apt-get clean && rm -rf /var/lib/apt/lists/

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -74,7 +74,12 @@ sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 for vmm in ${VMM_CONFIGS}; do
 	config_file="${DESTDIR}/${PREFIX}/share/defaults/kata-containers/configuration-${vmm}.toml"
 	if [ -f ${config_file} ]; then
-		sudo sed -i -e '/^initrd =/d' ${config_file}
+		if [ ${ARCH} == "ppc64le" ]; then
+ 			sudo sed -i -e '/^image =/d' ${config_file}
+ 			sudo sed -i 's/^# \(initrd =.*\)/\1/g' ${config_file}
+ 		else
+ 			sudo sed -i -e '/^initrd =/d' ${config_file}
+ 		fi
 	fi
 done
 


### PR DESCRIPTION
This is the first step of the migration of jobs from Jenkins to GHA. 

Fixes: #8458 