### PR TITLE
gha: Add cloud runtime rs tests as part of the kata CI

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -93,6 +93,50 @@ jobs:
       - name: Run containerd-stability tests
         run: bash tests/stability/gha-run.sh run
 
+  run-cloud-hypervisor-runtime-rs:
+    strategy:
+      fail-fast: false
+      matrix:
+        containerd_version: ['lts']
+        vmm: ['clh']
+    runs-on: garm-ubuntu-2204-smaller
+    env:
+      CONTAINERD_VERSION: ${{ matrix.containerd_version }}
+      GOPATH: ${{ github.workspace }}
+      KATA_HYPERVISOR: ${{ matrix.vmm }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Install dependencies
+        run: bash tests/cloud-hypervisor-rs/gha-run.sh install-dependencies
+
+      - name: get-kata-tarball
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          path: kata-artifacts
+
+      - name: Install kata
+        run: bash tests/cloud-hypervisor-rs/gha-run.sh install-kata kata-artifacts
+
+      - name: Install cloud hypervisor runtime rs
+        run: bash tests/cloud-hypervisor-rs/gha-run.sh install-cloud-hypervisor-rs
+
+      - name: Setup cloud hypervisor runtime rs
+        run: bash tests/cloud-hypervisor-rs/gha-run.sh setup-cloud-hypervisor-rs
+
+      - name: Run cloud hypervisor runtime rs tests
+        run: bash tests/integration/cloud-hypervisor-rs/gha-run.sh run
+
   run-nydus:
     strategy:
       # We can set this to true whenever we're 100% sure that

--- a/tests/integration/cloud-hypervisor-rs/gha-run.sh
+++ b/tests/integration/cloud-hypervisor-rs/gha-run.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+#
+# Copyright (c) 2023 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+kata_tarball_dir="${2:-kata-artifacts}"
+gral_dir="$(dirname "$(readlink -f "$0")")"
+source "${gral_dir}/../../common.bash"
+
+declare -r cloud_hypervisor_rs_dir="${gral_dir}/../../../src/runtime-rs"
+declare -r stability_dir="${gral_dir}/../../stability"
+
+function install_cloud_hypervisor_rs() {
+	info "Installing the cloud hypervisor runtime-rs"
+	pushd "${cloud_hypervisor_rs_dir}"
+	HYPERVISOR=cloud-hypervisor make
+	sudo make install
+	popd
+}
+
+function setup_cloud_hypervisor_rs() {
+	info "Verify that the shimv2 runtime-rs is installed"
+	/usr/local/bin/containerd-shim-kata-v2 --version | grep -i rust
+
+	info "Use the cloud hypervisor runtime-rs configuration"
+	sudo ln -sf /usr/shared/defaults/kata-containers/cloud-hypervisor-configuration.toml /usr/shared/defaults/kata-containers/configuration.toml
+	sudo systemctl daemon-reload
+
+	info "Verify cloud hypervisor runtime-rs configuration"
+	kata-ctl env
+}
+
+function install_dependencies() {
+	info "Installing the dependencies needed for running the tests"
+
+	declare -a system_deps=(
+		curl
+		gnupg
+		jq
+	)
+
+	sudo apt-get update
+	sudo apt-get -y install "${system_deps[@]}"
+
+	ensure_yq
+	install_docker
+}
+
+function run() {
+	# This will be enable once that the general setup and installation is done properly
+	info "Running soak parallel stability tests using ${KATA_HYPERVISOR} hypervisor"
+#	export ITERATIONS=2 MAX_CONTAINERS=20
+#	bash "${stability_dir}/soak_parallel_rm.sh"
+}
+
+function main() {
+	action="${1:-}"
+	case "${action}" in
+		install-dependencies) install_dependencies ;;
+		install-kata) install_kata ;;
+		install-cloud-hypervisor-rs) install_cloud_hypervisor_rs ;;
+		setup-cloud-hypervisor-rs) setup_cloud_hypervisor_rs ;;
+		run) run ;;
+		*) >&2 die "Invalid argument" ;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
This PR add the gha workflow in order to run the tests that we will have for cloud runtime rs.

Fixes #8462