### PR TITLE
dragonball: Uniform the spelling of Virtio

### DIFF
--- a/src/dragonball/src/dbs_virtio_devices/src/block/device.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/block/device.rs
@@ -382,7 +382,7 @@ mod tests {
 
     use crate::epoll_helper::*;
     use crate::tests::{VirtQueue, VIRTQ_DESC_F_NEXT, VIRTQ_DESC_F_WRITE};
-    use crate::{Error as VirtIoError, VirtioQueueConfig};
+    use crate::{Error as VirtioError, VirtioQueueConfig};
 
     use super::*;
     use crate::block::*;
@@ -829,7 +829,7 @@ mod tests {
         .unwrap();
         assert!(matches!(
             req.execute(&mut disk, m, &data_descs, &disk_id),
-            Err(ExecuteError::BadRequest(VirtIoError::InvalidOffset))
+            Err(ExecuteError::BadRequest(VirtioError::InvalidOffset))
         ));
 
         let mut file = DummyFile::new();

--- a/src/dragonball/src/dbs_virtio_devices/src/fs/device.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/fs/device.rs
@@ -970,7 +970,7 @@ pub mod tests {
     use vm_memory::GuestMemoryRegion;
     use vm_memory::{GuestAddress, GuestMemoryMmap, GuestRegionMmap};
     use vmm_sys_util::tempfile::TempFile;
-    use Error as VirtIoError;
+    use Error as VirtioError;
 
     use super::*;
     use crate::device::VirtioRegionHandler;
@@ -996,7 +996,7 @@ pub mod tests {
         fn insert_region(
             &mut self,
             _region: Arc<GuestRegionMmap>,
-        ) -> std::result::Result<(), VirtIoError> {
+        ) -> std::result::Result<(), VirtioError> {
             Ok(())
         }
     }

--- a/src/dragonball/src/dbs_virtio_devices/src/vsock/epoll_handler.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/vsock/epoll_handler.rs
@@ -18,7 +18,7 @@ use super::defs;
 use super::muxer::{VsockGenericMuxer, VsockMuxer};
 use super::packet::VsockPacket;
 use crate::device::VirtioDeviceConfig;
-use crate::{DbsGuestAddressSpace, Result as VirtIoResult};
+use crate::{DbsGuestAddressSpace, Result as VirtioResult};
 
 const QUEUE_RX: usize = 0;
 const QUEUE_TX: usize = 1;
@@ -83,7 +83,7 @@ where
 
     /// Signal the guest driver that we've used some virtio buffers that it had
     /// previously made available.
-    pub(crate) fn signal_used_queue(&self, idx: usize) -> VirtIoResult<()> {
+    pub(crate) fn signal_used_queue(&self, idx: usize) -> VirtioResult<()> {
         trace!("{}: raising IRQ", self.id);
         self.config.queues[idx].notify().map_err(|e| {
             error!("{}: failed to signal used queue {}, {:?}", self.id, idx, e);

--- a/src/dragonball/src/device_manager/balloon_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/balloon_dev_mgr.rs
@@ -5,7 +5,7 @@ use dbs_virtio_devices as virtio;
 use serde_derive::{Deserialize, Serialize};
 use slog::{error, info};
 use virtio::balloon::{Balloon, BalloonConfig};
-use virtio::Error as VirtIoError;
+use virtio::Error as VirtioError;
 
 use crate::address_space_manager::GuestAddressSpaceImpl;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
@@ -51,7 +51,7 @@ pub enum BalloonDeviceError {
 
     /// resize balloon device error
     #[error("failure while resizing virtio-balloon device, {0}")]
-    ResizeFailed(#[source] VirtIoError),
+    ResizeFailed(#[source] VirtioError),
 
     /// The balloon device id doesn't exist.
     #[error("invalid balloon device id '{0}'")]

--- a/src/dragonball/src/device_manager/blk_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/blk_dev_mgr.rs
@@ -45,7 +45,7 @@ macro_rules! error(
     };
 );
 
-/// Default queue size for VirtIo block devices.
+/// Default queue size for Virtio block devices.
 pub const QUEUE_SIZE: u16 = 128;
 
 /// Errors associated with the operations allowed on a drive.

--- a/src/dragonball/src/device_manager/fs_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/fs_dev_mgr.rs
@@ -6,7 +6,7 @@
 use std::convert::TryInto;
 
 use dbs_utils::epoll_manager::EpollManager;
-use dbs_virtio_devices::{self as virtio, Error as VirtIoError};
+use dbs_virtio_devices::{self as virtio, Error as VirtioError};
 use serde_derive::{Deserialize, Serialize};
 use slog::{error, info};
 
@@ -77,7 +77,7 @@ pub enum FsDeviceError {
 
     /// Creating a shared-fs device fails (if the vhost-user socket cannot be open.)
     #[error("cannot create shared-fs device: {0}")]
-    CreateFsDevice(#[source] VirtIoError),
+    CreateFsDevice(#[source] VirtioError),
 
     /// Cannot initialize a shared-fs device or add a device to the MMIO Bus.
     #[error("failure while registering shared-fs device: {0}")]

--- a/src/dragonball/src/error.rs
+++ b/src/dragonball/src/error.rs
@@ -12,7 +12,7 @@
 #[cfg(target_arch = "aarch64")]
 use dbs_arch::pmu::PmuError;
 #[cfg(feature = "dbs-virtio-devices")]
-use dbs_virtio_devices::Error as VirtIoError;
+use dbs_virtio_devices::Error as VirtioError;
 
 use crate::{address_space_manager, device_manager, resource_manager, vcpu, vm};
 
@@ -149,7 +149,7 @@ pub enum StartMicroVmError {
     #[cfg(feature = "virtio-vsock")]
     /// Failed to create the vsock device.
     #[error("cannot create virtio-vsock device: {0}")]
-    CreateVsockDevice(#[source] VirtIoError),
+    CreateVsockDevice(#[source] VirtioError),
 
     #[cfg(feature = "virtio-vsock")]
     /// Cannot initialize a MMIO Vsock Device or add a device to the MMIO Bus.
@@ -241,5 +241,5 @@ pub enum EpollError {
     #[cfg(feature = "dbs-virtio-devices")]
     /// Errors from virtio devices.
     #[error("failed to manager Virtio device: {0}")]
-    VirtIoDevice(#[source] VirtIoError),
+    VirtioDevice(#[source] VirtioError),
 }


### PR DESCRIPTION
The changes are:

- VirtIoError -> VirtioError
- VirtIoResult -> VirtioResult
- VirtIoDevice -> VirtioDevice

Fixes: #8464