### PR TITLE
do-not-merge: runtime: agent: verify the agent policy hash

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -248,6 +248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
+name = "bitfield"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46afbd2983a5d5a7bd740ccb198caf5b82f45c40c09c0eed36052d91cb92e719"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -522,6 +528,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "codicon"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12170080f3533d6f09a19f81596f836854d0fa4867dc32c8172b8474b4e9de61"
+
+[[package]]
 name = "common-path"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -721,6 +733,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
 name = "dirs-next"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -728,6 +749,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if 1.0.0",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1237,6 +1270,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "iocuddle"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8972d5be69940353d5347a1344cb375d9b457d6809b428b05bb1ca2fb9ce007"
+
+[[package]]
 name = "iovec"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1362,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "sev",
+ "sha2",
  "slog",
  "slog-scope",
  "slog-stdlog",
@@ -1337,6 +1378,7 @@ dependencies = [
  "tracing-opentelemetry",
  "tracing-subscriber",
  "ttrpc",
+ "vmm-sys-util",
  "vsock-exporter",
  "which",
 ]
@@ -1813,6 +1855,12 @@ dependencies = [
  "tokio",
  "tokio-stream",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-stream"
@@ -2616,6 +2664,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde-big-array"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11fc7cc2c76d73e0f27ee52abbd64eec84d46f370c88371120433196934e4b7f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde-enum-str"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2633,6 +2690,15 @@ name = "serde-rename-rule"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "794e44574226fc701e3be5c651feb7939038fc67fb73f6f4dd5c4ba90fd3be70"
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3c5113243e4a3a1c96587342d067f3e6b0f50790b6cf40d2868eb647a3eef0e"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "serde_derive"
@@ -2702,10 +2768,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "sev"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e9de97c6e3c65e4e67997d48ad506d258da10edc10894277093da679441f23"
+dependencies = [
+ "bincode",
+ "bitfield",
+ "bitflags",
+ "codicon",
+ "dirs",
+ "hex",
+ "iocuddle",
+ "lazy_static",
+ "libc",
+ "serde",
+ "serde-big-array",
+ "serde_bytes",
+ "static_assertions",
+ "uuid",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if 1.0.0",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if 1.0.0",
  "cpufeatures",
@@ -3358,6 +3457,9 @@ name = "uuid"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e395fcf16a7a3d8127ec99782007af141946b4795001f876d54fb0d55978560"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "valuable"
@@ -3376,6 +3478,16 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48b7b084231214f7427041e4220d77dfe726897a6d41fddee450696e66ff2a29"
+dependencies = [
+ "bitflags",
+ "libc",
+]
 
 [[package]]
 name = "vsock"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -73,6 +73,11 @@ reqwest = { version = "0.11.14", optional = true }
 # The "vendored" feature for openssl is required for musl build
 openssl = { version = "0.10.54", features = ["vendored"], optional = true }
 
+# Policy validation
+sha2 = { version = "0.10.6", optional = true }
+sev = { version = "2.0.2", default-features = false, features = ["snp"], optional = true }
+vmm-sys-util = { version = "0.11.0", optional = true }
+
 [dev-dependencies]
 tempfile = "3.1.0"
 test-utils = { path = "../libs/test-utils" }
@@ -89,7 +94,7 @@ lto = true
 [features]
 seccomp = ["rustjail/seccomp"]
 standard-oci-runtime = ["rustjail/standard-oci-runtime"]
-agent-policy = ["http", "openssl", "reqwest"]
+agent-policy = ["http", "openssl", "reqwest", "sev", "sha2", "vmm-sys-util"]
 
 [[bin]]
 name = "kata-agent"

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -76,6 +76,10 @@ mod tracer;
 
 #[cfg(feature = "agent-policy")]
 mod policy;
+#[cfg(feature = "agent-policy")]
+mod sev;
+#[cfg(feature = "agent-policy")]
+mod tdx;
 
 cfg_if! {
     if #[cfg(target_arch = "s390x")] {

--- a/src/agent/src/sev.rs
+++ b/src/agent/src/sev.rs
@@ -1,0 +1,19 @@
+// Copyright (c) 2023 Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::Result;
+
+pub fn get_snp_host_data() -> Result<Vec<u8>> {
+    match sev::firmware::guest::Firmware::open() {
+        Ok(mut firmware) => {
+            let report_data: [u8; 64] = [0; 64];
+            match firmware.get_report(None, Some(report_data), Some(0)) {
+                Ok(report) => Ok(report.host_data.to_vec()),
+                Err(e) => Err(e.into()),
+            }
+        }
+        Err(e) => Err(e.into()),
+    }
+}

--- a/src/agent/src/tdx.rs
+++ b/src/agent/src/tdx.rs
@@ -1,0 +1,194 @@
+// Copyright (c) 2023 Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::{bail, Result};
+use nix::fcntl::{self, OFlag};
+use nix::sys::stat::Mode;
+use std::os::fd::{AsRawFd, FromRawFd};
+use vmm_sys_util::ioctl::ioctl_with_val;
+use vmm_sys_util::{ioctl_ioc_nr, ioctl_iowr_nr};
+
+#[repr(C)]
+#[derive(Default)]
+/// Type header of TDREPORT_STRUCT.
+struct TdTransportType {
+    /// Type of the TDREPORT (0 - SGX, 81 - TDX, rest are reserved).
+    type_: u8,
+
+    /// Subtype of the TDREPORT (Default value is 0).
+    sub_type: u8,
+
+    /// TDREPORT version (Default value is 0).
+    version: u8,
+
+    /// Added for future extension.
+    reserved: u8,
+}
+
+#[repr(C)]
+/// TDX guest report data, MAC and TEE hashes.
+struct ReportMac {
+    /// TDREPORT type header.
+    type_: TdTransportType,
+
+    /// Reserved for future extension.
+    reserved1: [u8; 12],
+
+    /// CPU security version.
+    cpu_svn: [u8; 16],
+
+    /// SHA384 hash of TEE TCB INFO.
+    tee_tcb_info_hash: [u8; 48],
+
+    /// SHA384 hash of TDINFO_STRUCT.
+    tee_td_info_hash: [u8; 48],
+
+    /// User defined unique data passed in TDG.MR.REPORT request.
+    reportdata: [u8; 64],
+
+    /// Reserved for future extension.
+    reserved2: [u8; 32],
+
+    /// CPU MAC ID.
+    mac: [u8; 32],
+}
+
+impl Default for ReportMac {
+    fn default() -> Self {
+        Self {
+            type_: Default::default(),
+            reserved1: [0; 12],
+            cpu_svn: [0; 16],
+            tee_tcb_info_hash: [0; 48],
+            tee_td_info_hash: [0; 48],
+            reportdata: [0; 64],
+            reserved2: [0; 32],
+            mac: [0; 32],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Default)]
+/// TDX guest measurements and configuration.
+struct TdInfo {
+    /// TDX Guest attributes (like debug, spet_disable, etc).
+    attr: [u8; 8],
+
+    /// Extended features allowed mask.
+    xfam: u64,
+
+    /// Build time measurement register.
+    mrtd: [u64; 6],
+
+    /// Software-defined ID for non-owner-defined configuration of the guest - e.g., run-time or OS configuration.
+    mrconfigid: [u64; 6],
+
+    /// Software-defined ID for the guest owner.
+    mrowner: [u64; 6],
+
+    /// Software-defined ID for owner-defined configuration of the guest - e.g., specific to the workload.
+    mrownerconfig: [u64; 6],
+
+    /// Run time measurement registers.
+    rtmr: [u64; 24],
+
+    /// For future extension.
+    reserved: [u64; 14],
+}
+
+#[repr(C)]
+/// Output of TDCALL[TDG.MR.REPORT].
+struct TdReport {
+    /// Mac protected header of size 256 bytes.
+    report_mac: ReportMac,
+
+    /// Additional attestable elements in the TCB are not reflected in the report_mac.
+    tee_tcb_info: [u8; 239],
+
+    /// Added for future extension.
+    reserved: [u8; 17],
+
+    /// Measurements and configuration data of size 512 bytes.
+    tdinfo: TdInfo,
+}
+
+impl Default for TdReport {
+    fn default() -> Self {
+        Self {
+            report_mac: Default::default(),
+            tee_tcb_info: [0; 239],
+            reserved: [0; 17],
+            tdinfo: Default::default(),
+        }
+    }
+}
+
+#[repr(C)]
+/// Request struct for TDX_CMD_GET_REPORT0 IOCTL.
+struct TdxReportReq {
+    /// User buffer with REPORTDATA to be included into TDREPORT.
+    /// Typically it can be some nonce provided by attestation, service,
+    /// so the generated TDREPORT can be uniquely verified.
+    reportdata: [u8; 64],
+
+    /// User buffer to store TDREPORT output from TDCALL[TDG.MR.REPORT].
+    tdreport: TdReport,
+}
+
+impl Default for TdxReportReq {
+    fn default() -> Self {
+        Self {
+            reportdata: [0; 64],
+            tdreport: Default::default(),
+        }
+    }
+}
+
+// Get TDREPORT0 (a.k.a. TDREPORT subtype 0) using TDCALL[TDG.MR.REPORT].
+ioctl_iowr_nr!(
+    TDX_CMD_GET_REPORT0,
+    'T' as ::std::os::raw::c_uint,
+    1,
+    TdxReportReq
+);
+
+pub fn get_tdx_mrconfigid() -> Result<Vec<u8>> {
+    let fd = {
+        let raw_fd = fcntl::open(
+            "/dev/tdx_guest",
+            OFlag::O_CLOEXEC | OFlag::O_RDWR | OFlag::O_SYNC,
+            Mode::empty(),
+        )?;
+        unsafe { std::fs::File::from_raw_fd(raw_fd) }
+    };
+
+    let mut req = TdxReportReq {
+        reportdata: [0; 64],
+        tdreport: Default::default(),
+    };
+    let ret = unsafe {
+        ioctl_with_val(
+            &fd.as_raw_fd(),
+            TDX_CMD_GET_REPORT0(),
+            &mut req as *mut TdxReportReq as std::os::raw::c_ulong,
+        )
+    };
+    if ret < 0 {
+        bail!(
+            "TDX_CMD_GET_REPORT0 failed: {:?}",
+            std::io::Error::last_os_error(),
+        );
+    }
+
+    let mrconfigid: Vec<u8> = req
+        .tdreport
+        .tdinfo
+        .mrconfigid
+        .iter()
+        .flat_map(|val| val.to_le_bytes())
+        .collect();
+    Ok(mrconfigid)
+}

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -313,6 +313,11 @@ type Object struct {
 
 	// Prealloc enables memory preallocation
 	Prealloc bool
+
+	// TEEConfigData represents opaque binary data attached to a TEE and typically used
+	// for Guest attestation. This is only relevant for sev-snp-guest and tdx-guest
+	// objects and is encoded in the format expected by QEMU for each TEE type.
+	TEEConfigData string
 }
 
 // Valid returns true if the Object structure is valid and complete.
@@ -375,6 +380,9 @@ func (object Object) QemuParams(config *Config) []string {
 		if object.Debug {
 			objectParams = append(objectParams, "debug=on")
 		}
+		if len(object.TEEConfigData) > 0 {
+			objectParams = append(objectParams, fmt.Sprintf("mrconfigid=%s", object.TEEConfigData))
+		}
 		config.Bios = object.File
 	case SEVGuest:
 		fallthrough
@@ -386,6 +394,10 @@ func (object Object) QemuParams(config *Config) []string {
 
 		driveParams = append(driveParams, "if=pflash,format=raw,readonly=on")
 		driveParams = append(driveParams, fmt.Sprintf("file=%s", object.File))
+
+		if object.Type == SNPGuest && len(object.TEEConfigData) > 0 {
+			objectParams = append(objectParams, fmt.Sprintf("host-data=%s", object.TEEConfigData))
+		}
 	case SecExecGuest:
 		objectParams = append(objectParams, string(object.Type))
 		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -671,6 +671,10 @@ type HypervisorConfig struct {
 
 	// ExtraMonitorSocket allows to add an extra HMP or QMP socket when the VMM is Qemu
 	ExtraMonitorSocket govmmQemu.MonitorProtocol
+
+	// Policy text, for sandboxes created using a valid io.katacontainers.config.agent.policy
+	// annotation
+	AgentPolicy string
 }
 
 // vcpu mapping from vcpu number to thread number

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -698,7 +698,7 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
 		PidFile:        filepath.Join(q.config.VMStorePath, q.id, "pid"),
 	}
 
-	qemuConfig.Devices, qemuConfig.Bios, err = q.arch.appendProtectionDevice(qemuConfig.Devices, firmwarePath, firmwareVolumePath)
+	qemuConfig.Devices, qemuConfig.Bios, err = q.arch.appendProtectionDevice(qemuConfig.Devices, firmwarePath, firmwareVolumePath, q.config.AgentPolicy)
 	if err != nil {
 		return err
 	}

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -162,7 +162,7 @@ type qemuArch interface {
 	// This implementation is architecture specific, some archs may need
 	// a firmware, returns a string containing the path to the firmware that should
 	// be used with the -bios option, ommit -bios option if the path is empty.
-	appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error)
+	appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error)
 
 	// scans the PCIe space and returns the biggest BAR sizes for 32-bit
 	// and 64-bit addressable memory
@@ -897,7 +897,7 @@ func (q *qemuArchBase) setPFlash(p []string) {
 }
 
 // append protection device
-func (q *qemuArchBase) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
+func (q *qemuArchBase) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error) {
 	hvLogger.WithField("arch", runtime.GOARCH).Warnf("Confidential Computing has not been implemented for this architecture")
 	return devices, firmware, nil
 }

--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -154,7 +154,7 @@ func (q *qemuArm64) enableProtection() error {
 	return nil
 }
 
-func (q *qemuArm64) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
+func (q *qemuArm64) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error) {
 	err := q.enableProtection()
 	hvLogger.WithField("arch", runtime.GOARCH).Warnf("%v", err)
 	return devices, firmware, err

--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -182,42 +182,77 @@ func TestQemuArm64AppendProtectionDevice(t *testing.T) {
 	var err error
 
 	// no protection
-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "XYZ")
 	assert.Empty(devices)
 	assert.Empty(bios)
 	assert.NoError(err)
 
 	// PEF protection
 	arm64.(*qemuArm64).protection = pefProtection
-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "11111111111")
 	assert.Empty(devices)
 	assert.Empty(bios)
 	assert.NoError(err)
 
 	// Secure Execution protection
 	arm64.(*qemuArm64).protection = seProtection
-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "ABCD")
 	assert.Empty(devices)
 	assert.Empty(bios)
 	assert.NoError(err)
 
 	// SEV protection
 	arm64.(*qemuArm64).protection = sevProtection
-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
 	assert.Empty(devices)
 	assert.Empty(bios)
 	assert.NoError(err)
 
 	// SNP protection
 	arm64.(*qemuArm64).protection = snpProtection
-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
 	assert.Empty(devices)
 	assert.Empty(bios)
 	assert.NoError(err)
 
 	// TDX protection
 	arm64.(*qemuArm64).protection = tdxProtection
-	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "")
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "")
+	assert.Empty(devices)
+	assert.Empty(bios)
+	assert.NoError(err)
+
+	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", "123456789012345678901234567890123456789012345678")
 	assert.Empty(devices)
 	assert.Empty(bios)
 	assert.NoError(err)

--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -157,7 +157,7 @@ func (q *qemuPPC64le) enableProtection() error {
 }
 
 // append protection device
-func (q *qemuPPC64le) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
+func (q *qemuPPC64le) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error) {
 	switch q.protection {
 	case pefProtection:
 		return append(devices,

--- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
@@ -60,39 +60,63 @@ func TestQemuPPC64leAppendProtectionDevice(t *testing.T) {
 	var devices []govmmQemu.Device
 	var bios, firmware string
 	var err error
-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
-	assert.NoError(err)
 
 	//no protection
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
+	assert.NoError(err)
+	assert.Empty(bios)
+
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "FOObar")
+	assert.NoError(err)
 	assert.Empty(bios)
 
 	//Secure Execution protection
 	ppc64le.(*qemuPPC64le).protection = seProtection
-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
+
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
+	assert.Error(err)
+	assert.Empty(bios)
+
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "adasawdq")
 	assert.Error(err)
 	assert.Empty(bios)
 
 	//SEV protection
 	ppc64le.(*qemuPPC64le).protection = sevProtection
-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
+
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
+	assert.Error(err)
+	assert.Empty(bios)
+
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
 	assert.Error(err)
 	assert.Empty(bios)
 
 	//SNP protection
 	ppc64le.(*qemuPPC64le).protection = snpProtection
-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
+
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
+	assert.Error(err)
+	assert.Empty(bios)
+
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "Fc+jr0/5HZMfG0uu54bbUsYuu8K0G7PXH8WNc4idAT8=")
 	assert.Error(err)
 	assert.Empty(bios)
 
 	//TDX protection
 	ppc64le.(*qemuPPC64le).protection = tdxProtection
-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
+
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
+	assert.Error(err)
+	assert.Empty(bios)
+
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "123456789012345678901234567890123456789012345678")
 	assert.Error(err)
 	assert.Empty(bios)
 
 	//PEF protection
 	ppc64le.(*qemuPPC64le).protection = pefProtection
-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "")
 	assert.NoError(err)
 	assert.Empty(bios)
 
@@ -107,4 +131,19 @@ func TestQemuPPC64leAppendProtectionDevice(t *testing.T) {
 	}
 	assert.Equal(expectedOut, devices)
 
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", "abc")
+	assert.NoError(err)
+	assert.Empty(bios)
+
+	expectedOut = append(expectedOut,
+		govmmQemu.Object{
+			Driver:   govmmQemu.SpaprTPMProxy,
+			Type:     govmmQemu.PEFGuest,
+			ID:       pefID,
+			DeviceID: tpmID,
+			File:     tpmHostPath,
+		},
+	)
+
+	assert.Equal(expectedOut, devices)
 }

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -337,7 +337,7 @@ func (q *qemuS390x) enableProtection() error {
 
 // appendProtectionDevice appends a QEMU object for Secure Execution.
 // Takes devices and returns updated version. Takes BIOS and returns it (no modification on s390x).
-func (q *qemuS390x) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
+func (q *qemuS390x) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string, agentPolicy string) ([]govmmQemu.Device, string, error) {
 	switch q.protection {
 	case seProtection:
 		return append(devices,

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -592,6 +592,7 @@ func newSandbox(ctx context.Context, sandboxConfig SandboxConfig, factory Factor
 
 	sandboxConfig.HypervisorConfig.VMStorePath = s.store.RunVMStoragePath()
 	sandboxConfig.HypervisorConfig.RunStorePath = s.store.RunStoragePath()
+	sandboxConfig.HypervisorConfig.AgentPolicy = sandboxConfig.AgentConfig.Policy
 
 	spec := s.GetPatchedOCISpec()
 	if spec != nil && spec.Process.SelinuxLabel != "" {


### PR DESCRIPTION
Attach the policy hash to SEV-SNP VMs and verify the value of the hash from SetPolicy.

Fixes: #7668