### PR TITLE
stable-3.2 | gha: Keep kata tarballs for 15 days

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -104,7 +104,7 @@ jobs:
         with:
           name: kata-artifacts-amd64${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
-          retention-days: 1
+          retention-days: 15
           if-no-files-found: error
 
   create-kata-tarball:
@@ -133,5 +133,5 @@ jobs:
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz
-          retention-days: 1
+          retention-days: 15
           if-no-files-found: error

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -83,7 +83,7 @@ jobs:
         with:
           name: kata-artifacts-arm64${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
-          retention-days: 1
+          retention-days: 15
           if-no-files-found: error
 
   create-kata-tarball:
@@ -116,5 +116,5 @@ jobs:
         with:
           name: kata-static-tarball-arm64${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz
-          retention-days: 1
+          retention-days: 15
           if-no-files-found: error

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -80,7 +80,7 @@ jobs:
         with:
           name: kata-artifacts-s390x${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
-          retention-days: 1
+          retention-days: 15
           if-no-files-found: error
 
   create-kata-tarball:
@@ -113,5 +113,5 @@ jobs:
         with:
           name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz
-          retention-days: 1
+          retention-days: 15
           if-no-files-found: error


### PR DESCRIPTION
these tarballs are useful for debugging and re-running jobs, keep them for 15 days.

Fixes: #8000
Backport of: #8460