### PR TITLE
tests: k8s: Allow passing rust-runtime env var to kata-deploy

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -27,6 +27,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        rust-runtime:
+          - false
         host_os:
           - ubuntu
         vmm:
@@ -40,6 +42,8 @@ jobs:
         include:
           - host_os: cbl-mariner
             vmm: clh
+          - dragonball:
+            rust-runtime: true
     runs-on: ubuntu-latest
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
@@ -51,6 +55,7 @@ jobs:
       KUBERNETES: "vanilla"
       USING_NFD: "false"
       K8S_TEST_HOST_TYPE: ${{ matrix.instance-type }}
+      RUST_RUNTIME: ${{ matrix.rust-runtime }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This will be used for selecting the correct runtimes and runtimeclasses to be deployed with kata-deploy.

Fixes: #8475