### PR TITLE
kata-deploy: Set a default value for ALLOWED_HYPERVISOR_ANNOTATIONS

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -16,6 +16,7 @@ containerd_conf_file_backup="${containerd_conf_file}.bak"
 
 IFS=' ' read -a shims <<< "$SHIMS"
 default_shim="$DEFAULT_SHIM"
+ALLOWED_HYPERVISOR_ANNOTATIONS="${ALLOWED_HYPERVISOR_ANNOTATIONS:-}"
 
 IFS=' ' read -a non_formatted_allowed_hypervisor_annotations <<< "$ALLOWED_HYPERVISOR_ANNOTATIONS"
 allowed_hypervisor_annotations=""


### PR DESCRIPTION
As a follow-up PR for #8404 (specifically https://github.com/kata-containers/kata-containers/commit/023c4a17cff82b547426932f4bc53e89c7817d03), this is to set a default value for an environment variable `ALLOWED_HYPERVISOR_ANNOTATIONS`. This will prevent a pod launching without an explicit configuration for the variable from getting into a `CrashLoop` state.

Fixes: #8477

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>