### PR TITLE
GHA: Enable static check for s390x, aarch64 and ppc64le

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -35,7 +35,6 @@ jobs:
           fi
 
   build-checks:
-    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:
@@ -78,7 +77,18 @@ jobs:
             install-libseccomp: yes
           - component: genpolicy
             component-path: src/tools/genpolicy
+        instance:
+          - "ubuntu-20.04"
+          - "arm-no-k8s"
+    runs-on: ${{ matrix.instance }}
+
     steps:
+      - name: Adjust a permission for repo
+        run: |
+          sudo chown -R $USER:$USER $GITHUB_WORKSPACE $HOME
+          sudo rm -rf $GITHUB_WORKSPACE/*
+        if: ${{ matrix.instance == 'arm-no-k8s' }}
+
       - name: Checkout the code
         uses: actions/checkout@v4
         with:

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -87,6 +87,7 @@ jobs:
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE $HOME
           sudo rm -rf $GITHUB_WORKSPACE/*
+          sudo rm -f /tmp/kata_hybrid*  # Sometime we got leftover from test_setup_hvsock_failed()
         if: ${{ matrix.instance != 'ubuntu-20.04' }}
 
       - name: Checkout the code

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -80,14 +80,14 @@ jobs:
         instance:
           - "ubuntu-20.04"
           - "arm-no-k8s"
+          - "s390x"
     runs-on: ${{ matrix.instance }}
-
     steps:
       - name: Adjust a permission for repo
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE $HOME
           sudo rm -rf $GITHUB_WORKSPACE/*
-        if: ${{ matrix.instance == 'arm-no-k8s' }}
+        if: ${{ matrix.instance != 'ubuntu-20.04' }}
 
       - name: Checkout the code
         uses: actions/checkout@v4

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -81,6 +81,7 @@ jobs:
           - "ubuntu-20.04"
           - "arm-no-k8s"
           - "s390x"
+          - "ppc64le"
     runs-on: ${{ matrix.instance }}
     steps:
       - name: Adjust a permission for repo

--- a/ci/install_yq.sh
+++ b/ci/install_yq.sh
@@ -17,6 +17,7 @@ die() {
 function install_yq() {
 	local yq_pkg="github.com/mikefarah/yq"
 	local yq_version=3.4.1
+	local precmd=""
 	INSTALL_IN_GOPATH=${INSTALL_IN_GOPATH:-true}
 
 	if [ "${INSTALL_IN_GOPATH}"  == "true" ];then
@@ -25,6 +26,15 @@ function install_yq() {
 		local yq_path="${GOPATH}/bin/yq"
 	else
 		yq_path="/usr/local/bin/yq"
+		# Check if we need sudo to install yq
+		if [ ! -w "/usr/local/bin" ]; then
+			# Check if we have sudo privileges
+			if ! sudo -n true 2>/dev/null; then
+				die "Please provide sudo privileges to install yq"
+			else
+				precmd="sudo"
+			fi
+		fi
 	fi
 	[ -x  "${yq_path}" ] && [ "`${yq_path} --version`"X == "yq version ${yq_version}"X ] && return
 
@@ -75,9 +85,9 @@ function install_yq() {
 
 	## NOTE: ${var,,} => gives lowercase value of var
 	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos}_${goarch}"
-	curl -o "${yq_path}" -LSsf "${yq_url}"
+	${precmd} curl -o "${yq_path}" -LSsf "${yq_url}"
 	[ $? -ne 0 ] && die "Download ${yq_url} failed"
-	chmod +x "${yq_path}"
+	${precmd} chmod +x "${yq_path}"
 
 	if ! command -v "${yq_path}" >/dev/null; then
 		die "Cannot not get ${yq_path} executable"

--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -1400,6 +1400,20 @@ mod tests {
     fn test_new_fs_manager() {
         skip_if_not_root!();
 
+        let output = Command::new("stat")
+            .arg("-f")
+            .arg("-c")
+            .arg("%T")
+            .arg("/sys/fs/cgroup/")
+            .output()
+            .unwrap();
+        let output_str = String::from_utf8(output.stdout).unwrap();
+        let cgroup_version = output_str.strip_suffix("\n").unwrap();
+        if cgroup_version.eq("cgroup2fs") {
+            println!("INFO: Skipping the test as cgroups v2 is used by default");
+            return;
+        }
+
         struct TestCase {
             cpath: Vec<String>,
             devices: Vec<Vec<LinuxDeviceCgroup>>,

--- a/src/agent/src/device.rs
+++ b/src/agent/src/device.rs
@@ -1563,7 +1563,7 @@ mod tests {
 
         // Valid path
         let device = ccw::Device::from_str(relpath).unwrap();
-        let matcher = VirtioBlkCCWMatcher::new(&root_bus, &device);
+        let matcher = VirtioBlkCCWMatcher::new(root_bus, &device);
         assert!(matcher.is_match(&uev));
 
         // Invalid paths
@@ -1794,12 +1794,7 @@ mod tests {
         assert!(!matcher.is_match(&uev_remove));
 
         let mut uev_other_device = uev.clone();
-        uev_other_device.devpath = format!(
-            "{}/card{}/{}",
-            AP_ROOT_BUS_PATH,
-            card,
-            format!("{}.0002", card)
-        );
+        uev_other_device.devpath = format!("{}/card{}/{}.0002", AP_ROOT_BUS_PATH, card, card);
         assert!(!matcher.is_match(&uev_other_device));
     }
 }

--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -320,7 +320,9 @@ impl Handle {
                 route.device = self.find_link(LinkFilter::Index(index)).await?.name();
             }
 
-            result.push(route);
+            if !route.dest.is_empty() {
+                result.push(route);
+            }
         }
 
         Ok(result)

--- a/src/agent/src/random.rs
+++ b/src/agent/src/random.rs
@@ -12,7 +12,13 @@ use std::os::unix::io::{AsRawFd, FromRawFd};
 use tracing::instrument;
 
 pub const RNGDEV: &str = "/dev/random";
+#[cfg(target_arch = "powerpc64")]
+pub const RNDADDTOENTCNT: libc::c_uint = 0x80045201;
+#[cfg(target_arch = "powerpc64")]
+pub const RNDRESEEDCRNG: libc::c_int = 0x20005207;
+#[cfg(not(target_arch = "powerpc64"))]
 pub const RNDADDTOENTCNT: libc::c_int = 0x40045201;
+#[cfg(not(target_arch = "powerpc64"))]
 pub const RNDRESEEDCRNG: libc::c_int = 0x5207;
 
 // Handle the differing ioctl(2) request types for different targets

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -655,6 +655,8 @@ fn onlined_cpus() -> Result<i32> {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
+#[allow(unused_imports)]
 mod tests {
     use super::*;
     use crate::mount::baremount;
@@ -924,6 +926,7 @@ mod tests {
 
     #[tokio::test]
     #[serial]
+    #[cfg(not(target_arch = "powerpc64"))]
     async fn add_and_get_container() {
         skip_if_not_root!();
 
@@ -989,6 +992,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_arch = "powerpc64"))]
     async fn test_find_container_process() {
         skip_if_not_root!();
 
@@ -1036,6 +1040,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[cfg(not(target_arch = "powerpc64"))]
     async fn test_find_process() {
         skip_if_not_root!();
 

--- a/src/dragonball/Makefile
+++ b/src/dragonball/Makefile
@@ -7,7 +7,7 @@ include ../../utils.mk
 PROJECT_DIRS := $(shell find . -name Cargo.toml -printf '%h\n' | sort -u)
 
 ifeq ($(ARCH), s390x)
-default build check test clippy:
+default build check test clippy vendor:
 	@echo "s390x not support currently"
 	exit 0
 else

--- a/src/dragonball/Makefile
+++ b/src/dragonball/Makefile
@@ -6,9 +6,9 @@ include ../../utils.mk
 
 PROJECT_DIRS := $(shell find . -name Cargo.toml -printf '%h\n' | sort -u)
 
-ifeq ($(ARCH), s390x)
+ifeq ($(ARCH), $(filter $(ARCH), s390x ppc64le))
 default build check test clippy vendor:
-	@echo "s390x not support currently"
+	@echo "$(ARCH) is not support currently"
 	exit 0
 else
 

--- a/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_user/connection.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_user/connection.rs
@@ -25,6 +25,9 @@ use crate::{Error as VirtioError, Result as VirtioResult};
 
 enum EndpointProtocolFlags {
     ProtocolMq = 1,
+    #[allow(dead_code)]
+    #[cfg(feature = "vhost-user-blk")]
+    ProtocolBackend = 2,
 }
 
 pub(super) struct Listener {

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -1038,9 +1038,7 @@ impl DeviceManager {
     pub fn get_pci_bus_resources(&self) -> Option<PciBusResources> {
         let mut vfio_dev_mgr = self.vfio_manager.lock().unwrap();
         let vfio_pci_mgr = vfio_dev_mgr.get_pci_manager();
-        if vfio_pci_mgr.is_none() {
-            return None;
-        }
+        vfio_pci_mgr.as_ref()?;
         let pci_manager = vfio_pci_mgr.unwrap();
         let ecam_space = pci_manager.get_ecam_space();
         let bar_space = pci_manager.get_bar_space();

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -467,8 +467,14 @@ clean-generated-files:
 vendor:
 	@cargo vendor
 
+ifeq ($(ARCH),x86_64)
 ##TARGET check: run test
 check: $(GENERATED_FILES) standard_rust_check
+else
+check:
+	@echo "$(ARCH) is not currently supported"
+	exit 0
+endif
 
 ##TARGET run: build and run agent
 run:

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -918,6 +918,7 @@ mod tests {
 
     use kata_types::config::hypervisor::{Hypervisor as HypervisorConfig, SecurityInfo};
     use serial_test::serial;
+    #[cfg(target_arch = "x86_64")]
     use std::path::PathBuf;
     use test_utils::{assert_result, skip_if_not_root};
 

--- a/src/runtime/cmd/kata-runtime/kata-env_ppc64le_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_ppc64le_test.go
@@ -9,7 +9,7 @@ import "testing"
 
 func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 	expectedVendor := ""
-	expectedModel := "POWER8"
+	expectedModel := "POWER9"
 	expectedVMContainerCapable := true
 	return genericGetExpectedHostDetails(tmpdir, expectedVendor, expectedModel, expectedVMContainerCapable)
 }

--- a/src/tools/agent-ctl/Makefile
+++ b/src/tools/agent-ctl/Makefile
@@ -7,7 +7,7 @@ include ../../../utils.mk
 
 ifeq ($(ARCH), ppc64le)
      override ARCH = powerpc64le
- endif
+endif
 
 .DEFAULT_GOAL := default
 default: build

--- a/src/tools/kata-ctl/Makefile
+++ b/src/tools/kata-ctl/Makefile
@@ -32,6 +32,12 @@ GENERATED_FILES := $(GENERATED_CODE)
 
 .DEFAULT_GOAL := default
 
+ifeq ($(ARCH), ppc64le)
+default build check test vendor:
+	@echo "Building kata-ctl on $(ARCH) is currently being skipped"
+	exit 0
+else
+
 default: $(TARGET) build
 
 $(TARGET): $(GENERATED_CODE)
@@ -59,6 +65,8 @@ install:
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --locked --target $(TRIPLE) --path . --root $(INSTALL_PATH)
 
 check: $(GENERATED_CODE) standard_rust_check
+
+endif
 
 .PHONY: \
 	build \

--- a/src/tools/kata-ctl/src/arch/s390x/mod.rs
+++ b/src/tools/kata-ctl/src/arch/s390x/mod.rs
@@ -104,11 +104,11 @@ mod arch_specific {
 
         let check_fn = if search_values.is_empty() {
             |param: &str, search_param: &str, _search_values: &[&str]| {
-                return param.eq_ignore_ascii_case(search_param);
+                param.eq_ignore_ascii_case(search_param)
             }
         } else {
             |param: &str, search_param: &str, search_values: &[&str]| {
-                let split: Vec<&str> = param.splitn(2, "=").collect();
+                let split: Vec<&str> = param.splitn(2, '=').collect();
                 if split.len() < 2 || split[0] != search_param {
                     return false;
                 }

--- a/src/tools/runk/Makefile
+++ b/src/tools/runk/Makefile
@@ -10,7 +10,7 @@ include ../../../utils.mk
 
 ifeq ($(ARCH), ppc64le)
      override ARCH = powerpc64le
- endif
+endif
 
 TARGET = runk
 TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)

--- a/src/tools/runk/libcontainer/src/init_builder.rs
+++ b/src/tools/runk/libcontainer/src/init_builder.rs
@@ -95,6 +95,7 @@ mod tests {
     use std::fs::{create_dir, File};
     use std::path::Path;
     use tempfile::tempdir;
+    use test_utils::skip_if_not_root;
 
     #[test]
     fn test_init_container_validate() {
@@ -113,6 +114,8 @@ mod tests {
 
     #[test]
     fn test_init_container_create_launcher() {
+        #[cfg(target_arch = "powerpc64")]
+        skip_if_not_root!();
         let logger = slog::Logger::root(slog::Discard, o!());
         let root_dir = tempdir().unwrap();
         let bundle_dir = tempdir().unwrap();

--- a/src/tools/trace-forwarder/Makefile
+++ b/src/tools/trace-forwarder/Makefile
@@ -7,7 +7,7 @@ include ../../../utils.mk
 
 ifeq ($(ARCH), ppc64le)
      override ARCH = powerpc64le
- endif
+endif
 
 .DEFAULT_GOAL := default
 default: build


### PR DESCRIPTION
This is to enable the static check (including a unit test) for s390x by incorporating it with the existing one for `x86_64`.
Once this PR is merged and the relevant workflows settle down, it will replace a Jenkins CI  http://jenkins.katacontainers.io/job/kata-containers-2.0-ubuntu-s390x-unit-PR/.


Fixes: #8482

Test result: https://github.com/BbolroC/kata-containers/actions/runs/6945353895/job/18894516175 (all failing tests are for `x86_64` and they have nothing to do with the change for this PR)

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
Signed-off-by: Jianyong Wu <jianyong.wu@arm.com>
Signed-off-by: Amulyam24 <amulmek1@in.ibm.com>