### PR TITLE
metrics: Improve pod deletion for iperf benchmark

### DIFF
--- a/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+++ b/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
@@ -215,7 +215,8 @@ function iperf3_start_deployment() {
 
 function iperf3_deployment_cleanup() {
 	info "iperf: deleting deployments and services"
-	kubectl delete pod "${server_pod_name}" "${client_pod_name}"
+	kubectl delete pod "${server_pod_name}" -n default
+	kubectl delete pod "${client_pod_name}" -n default
 	kubectl delete -f "${IPERF_DAEMONSET}"
 	kubectl delete -f "${IPERF_DEPLOYMENT}"
 	kill_kata_components && sleep 1


### PR DESCRIPTION
To avoid failures when deleting a pod, this PR improves the way that is done for the iperf benchmark.

Fixes #8490