### PR TITLE
gha: add cri-containerd workflow for ppc64le

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -205,3 +205,11 @@ jobs:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+
+  run-cri-containerd-tests-ppc64le:
+    needs: build-kata-static-tarball-ppc64le
+    uses: ./.github/workflows/run-cri-containerd-tests-ppc64le.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}

--- a/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
+++ b/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
@@ -1,0 +1,59 @@
+name: CI | Run cri-containerd tests on ppc64le
+on:
+  workflow_call:
+    inputs:
+      tarball-suffix:
+        required: false
+        type: string
+      commit-hash:
+        required: false
+        type: string
+      target-branch:
+        required: false
+        type: string
+        default: ""
+
+jobs:
+  run-cri-containerd:
+    strategy:
+      # We can set this to true whenever we're 100% sure that
+      # the all the tests are not flaky, otherwise we'll fail
+      # all the tests due to a single flaky instance
+      fail-fast: false
+      matrix:
+        containerd_version: ['active']
+        vmm: ['qemu']
+    runs-on: ppc64le
+    env:
+      CONTAINERD_VERSION: ${{ matrix.containerd_version }}
+      GOPATH: ${{ github.workspace }}
+      KATA_HYPERVISOR: ${{ matrix.vmm }}
+    steps:
+      - name: Adjust a permission for repo
+        run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Install dependencies
+        run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
+
+      - name: get-kata-tarball
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
+          path: kata-artifacts
+
+      - name: Install kata
+        run: bash tests/integration/cri-containerd/gha-run.sh install-kata kata-artifacts
+
+      - name: Run cri-containerd tests
+        run: bash tests/integration/cri-containerd/gha-run.sh run

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -35,7 +35,7 @@ function install_dependencies() {
 	sudo apt-get -y install "${system_deps[@]}"
 
 	ensure_yq
-	${repo_root_dir}/tests/install_go.sh -p
+	${repo_root_dir}/tests/install_go.sh -p -f
 
 	# Dependency list of projects that we can install them
 	# directly from their releases on GitHub:

--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -630,8 +630,10 @@ function main() {
 		TestContainerMemoryUpdate 0
 	fi
 
-	TestKilledVmmCleanup
-	TestDeviceCgroup
+	if [[ "${ARCH}" != "ppc64le" ]]; then
+		TestKilledVmmCleanup
+		TestDeviceCgroup
+	fi
 
 	popd
 }


### PR DESCRIPTION
This PR adds workflow to run containerd tests on Power as a part of CI migration.

Fixes: #8500
