### PR TITLE
docs: Update iperf3 network documentation

### DIFF
--- a/tests/metrics/network/README.md
+++ b/tests/metrics/network/README.md
@@ -5,7 +5,7 @@ bandwidth, jitter, latency and parallel bandwidth.
 
 ## Performance tools
 
-- `iperf3` measures bandwidth, jitter, CPU usage and the quality of a network link.
+- `iperf3` measures bandwidth, jitter, CPU usage, parallel bandwidth and the quality of a network link.
 
 ## Networking tests
 


### PR DESCRIPTION
This PR updates the iperf3 network documentation to include the parallel bandwidth.

Fixes #8523