### PR TITLE
tools: Stop building / shipping log-parser-rs

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -41,7 +41,6 @@ jobs:
           - kernel-nvidia-gpu
           - kernel-nvidia-gpu-snp
           - kernel-nvidia-gpu-tdx-experimental
-          - log-parser-rs
           - nydus
           - ovmf
           - ovmf-sev

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -46,7 +46,6 @@ jobs:
           - runtime-rs
           - agent-ctl
           - kata-ctl
-          - log-parser-rs
           - runk
           - trace-forwarder
         command:
@@ -67,8 +66,6 @@ jobs:
             component-path: src/tools/agent-ctl
           - component: kata-ctl
             component-path: src/tools/kata-ctl
-          - component: log-parser-rs
-            component-path: src/tools/log-parser-rs
           - component: runk
             component-path: src/tools/runk
           - component: trace-forwarder


### PR DESCRIPTION
This is a commit that's a pre-req for #6826, as that PR will merge log-parser-rs into kata-ctl, but that will result in a CI breakage.

So, let's deal with the CI changes here, thanks to GHA and our favourite `pull_request_target` event, unblocking that PR to be merged.

Fixes: #6797 (not really, but related).