### PR TITLE
metrics: Fix iperf parallel bandwidth limit

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -198,7 +198,7 @@ description = "measure container parallel bandwidth using iperf3"
 # within (inclusive)
 checkvar = ".\"network-iperf3\".Results | .[] | .parallel.Result"
 checktype = "mean"
-midval = 47734838389.0
+midval = 57516472021.90
 minpercent = 20.0
 maxpercent = 20.0
 


### PR DESCRIPTION
This PR fixes the iperf parallel bandwidth limit for the kata metrics CI.

Fixes #8530