### PR TITLE
Revert "runtime: confidential: Do not set the max_vcpu to cpu"

### DIFF
--- a/src/runtime/virtcontainers/hypervisor_config_linux.go
+++ b/src/runtime/virtcontainers/hypervisor_config_linux.go
@@ -58,6 +58,11 @@ func validateHypervisorConfig(conf *HypervisorConfig) error {
 		conf.DefaultMaxVCPUs = defaultMaxVCPUs
 	}
 
+	if conf.ConfidentialGuest && conf.NumVCPUs() != conf.DefaultMaxVCPUs {
+		hvLogger.Warnf("Confidential guests do not support hotplugging of vCPUs. Setting DefaultMaxVCPUs to NumVCPUs (%d)", conf.NumVCPUs())
+		conf.DefaultMaxVCPUs = conf.NumVCPUs()
+	}
+
 	if conf.Msize9p == 0 && conf.SharedFS != config.VirtioFS {
 		conf.Msize9p = defaultMsize9p
 	}


### PR DESCRIPTION
This reverts commit b0157ad73a41b7e23d3c3ca7a761e27eab29ae29.
```
commit b0157ad73a41b7e23d3c3ca7a761e27eab29ae29
Refs: 3.3.0-alpha0-124-gb0157ad73
Author:     Fabiano Fidêncio <fabiano.fidencio@intel.com>
AuthorDate: Fri Aug 11 14:55:11 2023 +0200
Commit:     Fabiano Fidêncio <fabiano.fidencio@intel.com>
CommitDate: Fri Nov 10 12:58:20 2023 +0100

    runtime: confidential: Do not set the max_vcpu to cpu

    We don't have to do this since we're relying on the
    `static_sandbox_resource_mgmt` feature, which gives us the correct
    amount of memory and CPUs to be allocated.

    Signed-off-by: Fabiano Fidêncio <fabiano.fidencio@intel.com>
```

This commit was removing a requirement that was made previously, but due to the SMP issue we're facing with the QEMU used for TDX (see commit d1b54ede290e95762099fff4e0bcdad10f816126*), QEMU will fail to start due to:
```
Invalid CPU topology: product of the hierarchy must match maxcpus:
sockets (1) * dies (1) * cores (1) * threads (1) != maxcpus (240)"
```

This has no affect on the SEV / SNP workflow and hopefully we'll be able to re-revet this soon enough, when this gets solved on te QEMU side.

Fixes: #8532