### PR TITLE
docs: Update cri installation url link

### DIFF
--- a/docs/how-to/containerd-kata.md
+++ b/docs/how-to/containerd-kata.md
@@ -62,7 +62,7 @@ Follow the instructions to [install Kata Containers](../install/README.md).
 > You do not need to install `cri` if you have containerd 1.1 or above. Just remove the `cri` plugin from the list of
 > `disabled_plugins` in the containerd configuration file (`/etc/containerd/config.toml`).
 
-Follow the instructions from the [CRI installation guide](http://github.com/containerd/cri/blob/master/docs/installation.md).
+Follow the instructions from the [CRI installation guide](https://github.com/containerd/containerd/blob/main/docs/cri/installation.md).
 
 Then, check if `containerd` is now available:
 


### PR DESCRIPTION
This PR updates the cri installation url link for the containerd documentation.

Fixes #8539