### PR TITLE
libs: protection: x86_64: drop root requirement for querying

### DIFF
--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
 
-#[cfg(any(target_arch = "s390x", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "s390x", target_arch = "powerpc64le"))]
 use nix::unistd::Uid;
 
 #[cfg(target_arch = "x86_64")]
@@ -97,10 +97,6 @@ const TDX_MINOR_FILE: &str = "minor_version";
 
 #[cfg(target_arch = "x86_64")]
 pub fn available_guest_protection() -> Result<GuestProtection, ProtectionError> {
-    if !Uid::effective().is_root() {
-        return Err(ProtectionError::NoPerms);
-    }
-
     arch_guest_protection(
         TDX_SYS_FIRMWARE_DIR,
         SEV_KVM_PARAMETER_PATH,
@@ -262,22 +258,9 @@ pub fn available_guest_protection() -> Result<GuestProtection, ProtectionError> 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nix::unistd::Uid;
     use std::fs;
     use std::io::Write;
     use tempfile::tempdir;
-
-    #[test]
-    fn test_available_guest_protection_no_privileges() {
-        if !Uid::effective().is_root() {
-            let res = available_guest_protection();
-            assert!(res.is_err());
-            assert_eq!(
-                "No permission to check guest protection",
-                res.unwrap_err().to_string()
-            );
-        }
-    }
 
     #[test]
     fn test_arch_guest_protection_snp() {

--- a/src/tools/kata-ctl/src/ops/env_ops.rs
+++ b/src/tools/kata-ctl/src/ops/env_ops.rs
@@ -13,7 +13,6 @@ use kata_sys_util::protection;
 use kata_types::config::TomlConfig;
 
 use anyhow::{anyhow, Context, Result};
-use nix::unistd::Uid;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{self, Write};
@@ -473,10 +472,6 @@ pub fn get_env_info(toml_config: &TomlConfig) -> Result<EnvInfo> {
 }
 
 pub fn handle_env(env_args: EnvArgument) -> Result<()> {
-    if !Uid::effective().is_root() {
-        return Err(anyhow!("kata-ctl env command requires root privileges to get host information. Please run as root or use sudo"));
-    }
-
     let mut file: Box<dyn Write> = if let Some(path) = env_args.file {
         Box::new(
             File::create(path.as_str()).with_context(|| format!("Error creating file {}", path))?,


### PR DESCRIPTION
It is no longer necessary to be `root` to query the guest protection
(TDX) on `x86_64` systems, so drop the requirement.

Also update `kata-ctl` to remove the duplicate, and now redundant, root check.

Fixes: #8548.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>