### PR TITLE
gha: Add cloud runtime rs as part of the stability tests

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         containerd_version: ['lts', 'active']
-        vmm: ['clh', 'qemu', 'stratovirt']
+        vmm: ['clh', 'cloud-hypervisor', 'qemu', 'stratovirt']
     runs-on: garm-ubuntu-2204-smaller
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}


### PR DESCRIPTION
This PR adds the cloud runtime rs as part of the containerd stability tests.

Fixes #8462