### PR TITLE
runtime: missing port type in the DeviceInfo

### DIFF
--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -100,6 +100,7 @@ func (endpoint *PhysicalEndpoint) Attach(ctx context.Context, s *Sandbox) error 
 		Major:         c.Major,
 		Minor:         c.Minor,
 		ColdPlug:      true,
+		Port:          s.config.HypervisorConfig.ColdPlugVFIO,
 	}
 
 	_, err = s.AddDevice(ctx, d)


### PR DESCRIPTION
Missing port type would cause error: port is not set.

https://github.com/kata-containers/kata-containers/blob/852021e4169df4d68d5e8b54894ee3c0585e6da3/src/runtime/pkg/device/drivers/vfio.go#L74-L78

Fix: #9014 