### PR TITLE
runtime-rs: Show config files attempted on config load failure

### DIFF
--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -216,6 +216,14 @@ impl TomlConfig {
 
         Err(io::Error::from(io::ErrorKind::NotFound))
     }
+
+    /// Return a list of default config file paths.
+    pub fn get_default_config_file_list() -> Vec<PathBuf> {
+        default::DEFAULT_RUNTIME_CONFIGURATIONS
+            .iter()
+            .map(|s| PathBuf::from(*s))
+            .collect()
+    }
 }
 
 /// Validate the `path` matches one of the pattern in `patterns`.

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -489,8 +489,10 @@ fn load_config(spec: &oci::Spec, option: &Option<Vec<u8>>) -> Result<TomlConfig>
     let logger = slog::Logger::clone(&slog_scope::logger());
 
     info!(logger, "get config path {:?}", &config_path);
-    let (mut toml_config, _) =
-        TomlConfig::load_from_file(&config_path).context("load toml config")?;
+    let (mut toml_config, _) = TomlConfig::load_from_file(&config_path).context(format!(
+        "load TOML config failed (tried {:?})",
+        TomlConfig::get_default_config_file_list()
+    ))?;
     annotation.update_config_by_annotation(&mut toml_config)?;
     update_agent_kernel_params(&mut toml_config)?;
 

--- a/src/runtime-rs/crates/service/src/task_service.rs
+++ b/src/runtime-rs/crates/service/src/task_service.rs
@@ -43,7 +43,7 @@ impl TaskService {
         debug!(logger, "====> task service {:?}", &r);
         let resp =
             self.handler.handler_message(r).await.map_err(|err| {
-                ttrpc::Error::Others(format!("failed to handler message {:?}", err))
+                ttrpc::Error::Others(format!("failed to handle message {:?}", err))
             })?;
         debug!(logger, "<==== task service {:?}", &resp);
         resp.try_into()


### PR DESCRIPTION
PR #8483 changed the location of the rust runtime config files to
`/etc/kata-containers/runtime-rs/`. However, if you haven't updated your
system to create that directory, attempting to create a container using
the rust runtime was giving the following cryptic message
(formatted for easier reading):

```
failed to handler message try init runtime instance

Caused by:
    0: load config
    1: load toml config
    2: entity not found
```

Now, the message is as follows (again, reformatted for easier reading):

```
failed to handle message try init runtime instance

Caused by:
    0: load config
    1: load TOML config failed (tried [
        \"/etc/kata-containers/runtime-rs/configuration.toml\",
        \"/usr/share/defaults/kata-containers/runtime-rs/configuration.toml\",
        \"/opt/kata/share/defaults/kata-containers/runtime-rs/configuration.toml\"
    ])
```

Fixes: #8557.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>