### PR TITLE
runtime-rs: fix panic when hypervisor mismatches with configuration

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -479,8 +479,18 @@ impl Annotation {
         let u32_err = io::Error::new(io::ErrorKind::InvalidData, "parse u32 error".to_string());
         let u64_err = io::Error::new(io::ErrorKind::InvalidData, "parse u64 error".to_string());
         let i32_err = io::Error::new(io::ErrorKind::InvalidData, "parse i32 error".to_string());
-        let hv = config.hypervisor.get_mut(hypervisor_name).unwrap();
-        let ag = config.agent.get_mut(agent_name).unwrap();
+        let hv = config.hypervisor.get_mut(hypervisor_name).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Invalid hypervisor name {}", hypervisor_name),
+            )
+        })?;
+        let ag = config.agent.get_mut(agent_name).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("Invalid agent name {}", agent_name),
+            )
+        })?;
         for (key, value) in &self.annotations {
             if hv.security_info.is_annotation_enabled(key) {
                 match key.as_str() {


### PR DESCRIPTION
If a wrong configuration.toml file is used by accidentally, runtime-rs binary could run into panic because of unwrap().

This fixes the panic by returning errors instead of unwrap().

Fixes: #8565

--
v3:
* Rebased to the latest main branch(9d38f01c2fe3c7b9cc63904f7c961948e56ca128).

v2: 
* Added fixes label in the commit log.
* Updated the error msg to "hypervisor name" instead. 
