### PR TITLE
runtime, factory: fix resetHypervisorConfig

### DIFF
--- a/src/runtime/virtcontainers/factory/factory_linux.go
+++ b/src/runtime/virtcontainers/factory/factory_linux.go
@@ -80,6 +80,8 @@ func resetHypervisorConfig(config *vc.VMConfig) {
 	config.HypervisorConfig.SharedPath = ""
 	config.HypervisorConfig.VMStorePath = ""
 	config.HypervisorConfig.RunStorePath = ""
+	config.HypervisorConfig.SandboxName = ""
+	config.HypervisorConfig.SandboxNamespace = ""
 }
 
 // It's important that baseConfig and newConfig are passed by value!


### PR DESCRIPTION
With the support for the remote hypervisor type, new parameters in the hypervisor configs are added, namely SanboxName and SandboxNamespace. This makes the config comparison between the cached VM config and the one requested by the pod to always return false, and so the cached VM is never used.

This PR fixes this behavior resetting those parameter to an empty string for the comparison.

fixes #8488
