### PR TITLE
docs: Update config containerd url link

### DIFF
--- a/docs/how-to/containerd-kata.md
+++ b/docs/how-to/containerd-kata.md
@@ -185,7 +185,7 @@ and then, run an untrusted workload with Kata Containers:
       runtime_type = "io.containerd.kata.v2"
 ```
 
-You can find more information on the [Containerd config documentation](https://github.com/containerd/cri/blob/master/docs/config.md)
+You can find more information on the [Containerd config documentation](https://github.com/containerd/containerd/blob/main/docs/cri/config.md)
 
 #### Kata Containers as the default runtime
 


### PR DESCRIPTION
This PR updates the config containerd url link in the containerd kata documentation.

Fixes #8577