### PR TITLE
runtime-rs: Update readme to indicate cloud-hypervisor support

### DIFF
--- a/src/runtime-rs/README.md
+++ b/src/runtime-rs/README.md
@@ -87,7 +87,7 @@ Resources are classified into two types:
 
 For `VirtContainer`, there will be more hypervisors to choose.
 
-Currently, only built-in `Dragonball` has been implemented.
+Currently, built-in `Dragonball` has been implemented. We have also added initial support for `cloud-hypervisor` with CI being added next.
 
 ### agent
 


### PR DESCRIPTION
Since cloud-hypervisor is no longer built as an optional feature, lets mention cloud-hypervisor in the list of hypervisors supported by runtime-rs.

Fixes: 8587