### PR TITLE
CI: static-checks: Try multiple user agents 

### DIFF
--- a/docs/install/azure-installation-guide.md
+++ b/docs/install/azure-installation-guide.md
@@ -4,7 +4,7 @@ Kata Containers on Azure use nested virtualization to provide an identical insta
 experience to Kata on your preferred Linux distribution.
 
 This guide assumes you have an Azure account set up and tools to remotely login to your virtual
-machine (SSH). Instructions will use [Azure Portal](https://portal.azure.com/) to avoid
+machine (SSH). Instructions will use the Azure Portal to avoid
 local dependencies and setup.
 
 ## Create a new virtual machine with nesting support

--- a/docs/install/azure-installation-guide.md
+++ b/docs/install/azure-installation-guide.md
@@ -3,8 +3,8 @@
 Kata Containers on Azure use nested virtualization to provide an identical installation
 experience to Kata on your preferred Linux distribution.
 
-This guide assumes you have an Azure account set up and tools to remotely login to  your virtual
-machine (SSH).  Instructions will use [Azure Portal](https://portal.azure.com/) to avoid
+This guide assumes you have an Azure account set up and tools to remotely login to your virtual
+machine (SSH). Instructions will use [Azure Portal](https://portal.azure.com/) to avoid
 local dependencies and setup.
 
 ## Create a new virtual machine with nesting support

--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -500,13 +500,16 @@ check_url()
 	local invalid_urls_dir="${2:-}"
 	[ -n "$invalid_urls_dir" ] || die "need invalid URLs directory"
 
-	local curl_out=$(mktemp)
+	local curl_out
+	curl_out=$(mktemp)
+
 	files_to_remove+=("${curl_out}")
 
 	info "Checking URL $url"
 
 	# Process specific file to avoid out-of-order writes
-	local invalid_file=$(printf "%s/%d" "$invalid_urls_dir" "$$")
+	local invalid_file
+	invalid_file=$(printf "%s/%d" "$invalid_urls_dir" "$$")
 
 	local ret
 	local user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/103.0.0.0 Safari/537.36"

--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -811,7 +811,10 @@ static_check_docs()
 
 	popd
 
-	[ $docs_failed -eq 0 ] || die "spell check failed, See https://github.com/kata-containers/kata-containers/blob/main/docs/Documentation-Requirements.md#spelling for more information."
+	[ $docs_failed -eq 0 ] || {
+        url='https://github.com/kata-containers/kata-containers/blob/main/docs/Documentation-Requirements.md#spelling'
+        die "spell check failed, See $url for more information."
+    }
 }
 
 static_check_eof()

--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -647,7 +647,8 @@ static_check_docs()
 	# is necessary to guarantee that all docs are referenced.
 	md_docs_to_check="$all_docs"
 
-	(cd "${test_dir}" && make -C cmd/check-markdown)
+	command -v kata-check-markdown &>/dev/null ||\
+		(cd "${test_dir}" && make -C cmd/check-markdown)
 
 	command -v kata-check-markdown &>/dev/null || \
 		die 'kata-check-markdown command not found. Ensure that "$GOPATH/bin" is in your $PATH.'

--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -494,8 +494,11 @@ EOF
 
 check_url()
 {
-	local url="$1"
-	local invalid_urls_dir="$2"
+	local url="${1:-}"
+	[ -n "$url" ] || die "need URL to check"
+
+	local invalid_urls_dir="${2:-}"
+	[ -n "$invalid_urls_dir" ] || die "need invalid URLs directory"
 
 	local curl_out=$(mktemp)
 	files_to_remove+=("${curl_out}")


### PR DESCRIPTION
Make the URL checker cycle through a list of user agent values until we
hit one the remote server is happy with.

This is required since, unfortunately, we really, really want to check
these URLs, but some sites block clients based on their `User-Agent`
(UA) request header value. And of course, each site is different and can
change its behaviour at any time.

Our strategy therefore is to try various UA's until we find one the
server accepts:

- No explicit UA (use `curl`'s default)
- Explicitly no UA.
- A blank UA.
- Partial UA values for various CLI tools.
- Partial UA values for various console web browsers.
- Partial UA for Emacs's built-in browser.
- The existing UA which is used as a "last ditch" attempt where the UA implies multiple platforms and browser.

> **Notes:**
>
> - The "partial UA" values specify specify the UA "product" but not the
>   UA "product version": we specify `foo` and not `foo/1.2.3`). We do
>   this since most sites tested appear to not care about the version.
>   This is as expected given that the version is strictly optional (see `[*]`).
>
> - We now treat URLs that the server reports as HTTP 401, HTTP 402 or
>   HTTP 403 as *valid*. See the comments in the code.
>
> - We now log all errors and display a summary on error in addition to
>   the simple list of the URLs we believe to be invalid. This should make
>   future debugging simpler.

`[*]` - https://www.rfc-editor.org/rfc/rfc9110#section-10.1.5

Fixes: #8553.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>