### PR TITLE
dragonball: add --all for fmt ci

### DIFF
--- a/src/dragonball/Makefile
+++ b/src/dragonball/Makefile
@@ -31,8 +31,9 @@ vendor:
 	@echo "INFO: vendor do nothing.."
 
 format:
-	@echo "INFO: cargo fmt..."
-	cargo fmt -- --check
+	@echo "INFO: rust fmt..."
+	# This is kinda dirty step here simply because cargo fmt --all will apply fmt to all dependencies of dragonball which will include /src/libs/protocols with some file generated during compilation time and could not be formatted when you use cargo fmt --all before building the whole project. In order to avoid this problem, we do fmt check in this following way. 
+	rustfmt --edition 2018 ./src/dbs_address_space/src/lib.rs ./src/dbs_allocator/src/lib.rs ./src/dbs_arch/src/lib.rs ./src/dbs_boot/src/lib.rs ./src/dbs_device/src/lib.rs ./src/dbs_interrupt/src/lib.rs ./src/dbs_legacy_devices/src/lib.rs ./src/dbs_pci/src/lib.rs ./src/dbs_upcall/src/lib.rs ./src/dbs_utils/src/lib.rs ./src/dbs_virtio_devices/src/lib.rs ./src/lib.rs --check
 
 clean:
 	cargo clean

--- a/src/dragonball/src/dbs_pci/src/bus.rs
+++ b/src/dragonball/src/dbs_pci/src/bus.rs
@@ -179,8 +179,7 @@ impl PciBus {
 
     /// Read from PCI device configuration space.
     pub fn read_config(&self, dev: u32, func: u32, offset: u32, data: &mut [u8]) {
-        if check_pci_cfg_valid(dev, func, offset, data.len())
-        {
+        if check_pci_cfg_valid(dev, func, offset, data.len()) {
             return fill_config_data(data);
         }
 
@@ -194,8 +193,7 @@ impl PciBus {
 
     /// Write to PCI device configuration space.
     pub fn write_config(&self, dev: u32, func: u32, offset: u32, data: &[u8]) {
-        if check_pci_cfg_valid(dev, func, offset, data.len())
-        {
+        if check_pci_cfg_valid(dev, func, offset, data.len()) {
             return;
         }
 
@@ -324,8 +322,8 @@ impl PartialEq for PciBus {
 
 #[inline]
 fn check_pci_cfg_valid(dev: u32, func: u32, offset: u32, data_len: usize) -> bool {
-    dev > 0x1f || func !=0 || offset >= 0x1000 || offset & (data_len - 1 ) as u32 & 0x3 != 0
-} 
+    dev > 0x1f || func != 0 || offset >= 0x1000 || offset & (data_len - 1) as u32 & 0x3 != 0
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/dragonball/src/dbs_pci/src/lib.rs
+++ b/src/dragonball/src/dbs_pci/src/lib.rs
@@ -30,6 +30,7 @@ mod bus;
 mod configuration;
 mod device;
 
+pub use self::bus::PciBus;
 pub use self::configuration::{
     BarProgrammingParams, PciBarConfiguration, PciBarPrefetchable, PciBarRegionType,
     PciBridgeSubclass, PciCapability, PciCapabilityID, PciClassCode, PciConfiguration,
@@ -37,7 +38,6 @@ pub use self::configuration::{
     PciNetworkControllerSubclass, PciProgrammingInterface, PciSerialBusSubClass, PciSubclass,
     NUM_BAR_REGS, NUM_CONFIGURATION_REGISTERS,
 };
-pub use self::bus::PciBus;
 pub use self::device::PciDevice;
 
 /// Error codes related to PCI root/bus/device operations.

--- a/src/dragonball/src/dbs_virtio_devices/src/lib.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/lib.rs
@@ -258,7 +258,7 @@ pub enum Error {
     #[cfg(feature = "virtio-balloon")]
     #[error("Virtio-balloon error: {0}")]
     VirtioBalloonError(#[from] balloon::BalloonError),
-    
+
     #[cfg(feature = "vhost")]
     /// Error from the vhost subsystem
     #[error("Vhost error: {0:?}")]

--- a/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_kern/net.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_kern/net.rs
@@ -290,7 +290,9 @@ where
                 "{}: Invalid virtio queue pairs, expected a value greater than 0, but got {}",
                 NET_DRIVER_NAME, self.vq_pairs
             );
-            return Err(VirtioError::ActivateError(Box::new(ActivateError::InvalidParam)));
+            return Err(VirtioError::ActivateError(Box::new(
+                ActivateError::InvalidParam,
+            )));
         }
 
         if self.handles.len() != self.vq_pairs || self.taps.len() != self.vq_pairs {
@@ -299,7 +301,9 @@ where
                 self.handles.len(),
                 self.taps.len(),
                 self.vq_pairs);
-            return Err(VirtioError::ActivateError(Box::new(ActivateError::InternalError)));
+            return Err(VirtioError::ActivateError(Box::new(
+                ActivateError::InternalError,
+            )));
         }
 
         for idx in 0..self.vq_pairs {

--- a/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_user/test_utils.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_user/test_utils.rs
@@ -7,7 +7,6 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use std::os::unix::net::UnixStream;
 use std::{mem, slice};
 
-use vmm_sys_util::tempfile::TempFile;
 use libc::{c_void, iovec};
 use vhost_rs::vhost_user::message::{
     VhostUserHeaderFlag, VhostUserInflight, VhostUserMemory, VhostUserMemoryRegion,
@@ -16,6 +15,7 @@ use vhost_rs::vhost_user::message::{
 };
 use vhost_rs::vhost_user::Error;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+use vmm_sys_util::tempfile::TempFile;
 
 pub const MAX_ATTACHED_FD_ENTRIES: usize = 32;
 


### PR DESCRIPTION
Right now, cargo fmt check in Dragonball only test with the default features but not all features. This will cause some code being untested by the fmt tool.

This PR adds --all option for the Dragonball CI and also fix some code that forgets to do cargo fmt --all.

fixes: #8598