### PR TITLE
gha: nerdctl: Enable cloud hypervisor runtime-rs for nerdctl CI

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -293,6 +293,7 @@ jobs:
           - clh
           - dragonball
           - qemu
+          - cloud-hypervisor
     runs-on: garm-ubuntu-2304-smaller
     env:
       KATA_HYPERVISOR: ${{ matrix.vmm }}

--- a/tests/integration/nerdctl/gha-run.sh
+++ b/tests/integration/nerdctl/gha-run.sh
@@ -59,6 +59,11 @@ function install_dependencies() {
 }
 
 function run() {
+	if [ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]; then
+		echo "Skipping test for ${KATA_HYPERVISOR}"
+		return 0
+	fi
+
 	info "Running nerdctl smoke test tests using ${KATA_HYPERVISOR} hypervisor"
 
 	enabling_hypervisor


### PR DESCRIPTION
This PR enables the cloud hypervisor runtime-rs for the nerdctl gha CI.

Fixes #8603