### PR TITLE
dragonball: Use vhost-net device by default

### DIFF
--- a/src/dragonball/src/api/v1/virtio_net.rs
+++ b/src/dragonball/src/api/v1/virtio_net.rs
@@ -128,9 +128,23 @@ impl From<&NetworkInterfaceConfig> for VhostNetDeviceConfigInfo {
     fn from(value: &NetworkInterfaceConfig) -> Self {
         let num_queues = value
             .num_queues
+            .map(|nq| {
+                if nq == 0 {
+                    vhost_net_dev_mgr::DEFAULT_NUM_QUEUES
+                } else {
+                    nq
+                }
+            })
             .unwrap_or(vhost_net_dev_mgr::DEFAULT_NUM_QUEUES);
         let queue_size = value
             .queue_size
+            .map(|qs| {
+                if qs == 0 {
+                    vhost_net_dev_mgr::DEFAULT_QUEUE_SIZE
+                } else {
+                    qs
+                }
+            })
             .unwrap_or(vhost_net_dev_mgr::DEFAULT_QUEUE_SIZE);
 
         // It is safe because we tested the type of config before.

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -475,7 +475,7 @@ impl TryFrom<ShareFsSettings> for FsConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Address, Backend};
+    use crate::Address;
 
     #[test]
     fn test_networkconfig_to_netconfig() {
@@ -489,7 +489,6 @@ mod tests {
             allow_duplicate_mac: false,
             use_generic_irq: None,
             use_shared_irq: None,
-            backend: Backend::default(),
         };
 
         let net = NetConfig::try_from(cfg.clone());

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
@@ -22,7 +22,7 @@ pub use virtio_blk::{
 pub use virtio_fs::{
     ShareFsConfig, ShareFsDevice, ShareFsMountConfig, ShareFsMountOperation, ShareFsMountType,
 };
-pub use virtio_net::{Address, Backend, NetworkConfig, NetworkDevice};
+pub use virtio_net::{Address, NetworkConfig, NetworkDevice};
 pub use virtio_vsock::{
     HybridVsockConfig, HybridVsockDevice, VsockConfig, VsockDevice, DEFAULT_GUEST_VSOCK_CID,
 };

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_net.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_net.rs
@@ -27,19 +27,10 @@ impl fmt::Debug for Address {
 }
 
 #[derive(Clone, Debug, Default)]
-pub enum Backend {
-    #[default]
-    Virtio,
-    Vhost,
-}
-
-#[derive(Clone, Debug, Default)]
 pub struct NetworkConfig {
     /// for detach, now it's default value 0.
     pub index: u64,
 
-    /// Network device backend
-    pub backend: Backend,
     /// Host level path for the guest network interface.
     pub host_dev_name: String,
     /// Guest iface name for the guest network interface.

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -12,7 +12,7 @@ use dragonball::api::v1::{
 };
 use dragonball::device_manager::blk_dev_mgr::BlockDeviceType;
 
-use super::DragonballInner;
+use super::{build_dragonball_network_config, DragonballInner};
 use crate::{
     device::DeviceType, HybridVsockConfig, NetworkConfig, ShareFsConfig, ShareFsMountConfig,
     ShareFsMountOperation, ShareFsMountType, VfioBusMode, VfioDevice, VmmState, JAILER_ROOT,
@@ -210,8 +210,9 @@ impl DragonballInner {
     }
 
     fn add_net_device(&mut self, config: &NetworkConfig) -> Result<()> {
+        let net_cfg = build_dragonball_network_config(&self.config, config);
         self.vmm_instance
-            .insert_network_device(config.into())
+            .insert_network_device(net_cfg)
             .context("insert network device")
     }
 

--- a/src/runtime-rs/crates/resource/src/network/endpoint/ipvlan_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/ipvlan_endpoint.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use hypervisor::device::device_manager::{do_handle_device, DeviceManager};
 use hypervisor::device::driver::NetworkConfig;
 use hypervisor::device::{DeviceConfig, DeviceType};
-use hypervisor::{Backend, Hypervisor, NetworkDevice};
+use hypervisor::{Hypervisor, NetworkDevice};
 use tokio::sync::RwLock;
 
 use super::endpoint_persist::{EndpointState, IpVlanEndpointState};
@@ -57,7 +57,6 @@ impl IPVlanEndpoint {
         Ok(NetworkConfig {
             host_dev_name: iface.name.clone(),
             virt_iface_name: self.net_pair.virt_iface.name.clone(),
-            backend: Backend::Virtio,
             guest_mac: Some(guest_mac),
             ..Default::default()
         })

--- a/src/runtime-rs/crates/resource/src/network/endpoint/macvlan_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/macvlan_endpoint.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use hypervisor::device::device_manager::{do_handle_device, DeviceManager};
 use hypervisor::device::driver::NetworkConfig;
 use hypervisor::device::{DeviceConfig, DeviceType};
-use hypervisor::{Backend, Hypervisor, NetworkDevice};
+use hypervisor::{Hypervisor, NetworkDevice};
 use tokio::sync::RwLock;
 
 use super::endpoint_persist::{EndpointState, MacvlanEndpointState};
@@ -56,7 +56,6 @@ impl MacVlanEndpoint {
         Ok(NetworkConfig {
             host_dev_name: iface.name.clone(),
             virt_iface_name: self.net_pair.virt_iface.name.clone(),
-            backend: Backend::Virtio,
             guest_mac: Some(guest_mac),
             ..Default::default()
         })

--- a/src/runtime-rs/crates/resource/src/network/endpoint/tap_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/tap_endpoint.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use hypervisor::device::device_manager::{do_handle_device, DeviceManager};
 use hypervisor::device::{DeviceConfig, DeviceType};
-use hypervisor::{Backend, Hypervisor, NetworkConfig, NetworkDevice};
+use hypervisor::{Hypervisor, NetworkConfig, NetworkDevice};
 use tokio::sync::RwLock;
 
 use super::endpoint_persist::TapEndpointState;
@@ -76,7 +76,6 @@ impl TapEndpoint {
         Ok(NetworkConfig {
             host_dev_name: self.tap_iface.name.clone(),
             virt_iface_name: self.name.clone(),
-            backend: Backend::Virtio,
             guest_mac: Some(guest_mac),
             queue_num: self.queue_num,
             queue_size: self.queue_size,

--- a/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use hypervisor::device::device_manager::{do_handle_device, DeviceManager};
 use hypervisor::device::driver::NetworkConfig;
 use hypervisor::device::{DeviceConfig, DeviceType};
-use hypervisor::{Backend, Hypervisor, NetworkDevice};
+use hypervisor::{Hypervisor, NetworkDevice};
 use tokio::sync::RwLock;
 
 use super::endpoint_persist::{EndpointState, VethEndpointState};
@@ -56,7 +56,6 @@ impl VethEndpoint {
         Ok(NetworkConfig {
             host_dev_name: iface.name.clone(),
             virt_iface_name: self.net_pair.virt_iface.name.clone(),
-            backend: Backend::Virtio,
             guest_mac: Some(guest_mac),
             ..Default::default()
         })

--- a/src/runtime-rs/crates/resource/src/network/endpoint/vlan_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/vlan_endpoint.rs
@@ -12,7 +12,7 @@ use async_trait::async_trait;
 use hypervisor::device::device_manager::{do_handle_device, DeviceManager};
 use hypervisor::device::driver::NetworkConfig;
 use hypervisor::device::{DeviceConfig, DeviceType};
-use hypervisor::{Backend, Hypervisor, NetworkDevice};
+use hypervisor::{Hypervisor, NetworkDevice};
 use tokio::sync::RwLock;
 
 use super::endpoint_persist::{EndpointState, VlanEndpointState};
@@ -56,7 +56,6 @@ impl VlanEndpoint {
         Ok(NetworkConfig {
             host_dev_name: iface.name.clone(),
             virt_iface_name: self.net_pair.virt_iface.name.clone(),
-            backend: Backend::Virtio,
             guest_mac: Some(guest_mac),
             ..Default::default()
         })


### PR DESCRIPTION
This patch set vhost-net as default backend of networking. It allows users
to set `disable_vhost_net` to `true` to reenable virtio-net backend.
Plus, which backend to use is a matter of hypervisor, runtime-rs will no
longer need to know that.

Fixes: #8608