### PR TITLE
tests: nerdctl: Enable nerdctl tests for cloud hypervisor runtime-rs

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -402,7 +402,7 @@ function enabling_hypervisor() {
 	declare -r CONTAINERD_SHIM_KATA="/usr/local/bin/containerd-shim-kata-${KATA_HYPERVISOR}-v2"
 
 	case "${KATA_HYPERVISOR}" in
-		dragonball)
+		dragonball | cloud-hypervisor)
 			sudo ln -sf "${KATA_DIR}/runtime-rs/bin/containerd-shim-kata-v2" "${CONTAINERD_SHIM_KATA}"
 			declare -r CONFIG_DIR="${KATA_DIR}/share/defaults/kata-containers/runtime-rs"
 			;;

--- a/tests/integration/nerdctl/gha-run.sh
+++ b/tests/integration/nerdctl/gha-run.sh
@@ -59,11 +59,6 @@ function install_dependencies() {
 }
 
 function run() {
-	if [ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]; then
-		echo "Skipping test for ${KATA_HYPERVISOR}"
-		return 0
-	fi
-
 	info "Running nerdctl smoke test tests using ${KATA_HYPERVISOR} hypervisor"
 
 	enabling_hypervisor


### PR DESCRIPTION
This PR enables the nerdctl tests for cloud hypervisor runtime-rs.

Fixes #8616