### PR TITLE
runtime-rs: Enhancement of DirectVolume when using a dedicated CSI

### DIFF
--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -94,14 +94,18 @@ impl Mount {
 #[derive(Debug, Clone, Eq, PartialEq, Default, Serialize, Deserialize)]
 pub struct DirectVolumeMountInfo {
     /// The type of the volume (ie. block)
+    #[serde(rename = "volume-type")]
     pub volume_type: String,
     /// The device backing the volume.
     pub device: String,
     /// The filesystem type to be mounted on the volume.
+    #[serde(rename = "fstype")]
     pub fs_type: String,
     /// Additional metadata to pass to the agent regarding this volume.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub metadata: HashMap<String, String>,
     /// Additional mount options.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub options: Vec<String>,
 }
 

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/mod.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 
 use kata_types::mount::{
     get_volume_mount_info, join_path, DirectVolumeMountInfo, KATA_DIRECT_VOLUME_ROOT_PATH,
@@ -28,5 +28,12 @@ pub fn get_direct_volume_path(volume_path: &str) -> Result<String> {
     let volume_full_path =
         join_path(KATA_DIRECT_VOLUME_ROOT_PATH, volume_path).context("failed to join path.")?;
 
-    Ok(volume_full_path.display().to_string())
+    if volume_full_path.exists() {
+        Ok(volume_full_path.display().to_string())
+    } else {
+        Err(anyhow!(format!(
+            "direct volume path  {:?} Not Found",
+            &volume_full_path
+        )))
+    }
 }


### PR DESCRIPTION
(1) Enhancement of DirectVolume when using CSI.
  We use a matching direct-volume path to determine whether an OCI mount
  is a DirectVolume. However, we should handle the case where no match is
  found appropriately.
  This error will be defined as a non-DirectVolume type when judging the
  OCI mount but not failed.

(2) Add attribe serde rename to each field of DirectVolume.
  DirectVolume structure in runtime-rs is different from it in kata-runtime,
  which causes they has no unified handling method for DirectVolumeMountInfo
  and MountInfo.
  
  We should align the two by simply adding the attribute #[serde(rename="x")
  to each field in DirectVolumeMountInfo
  
  Fixes: #8619
    
Signed-off-by: alex.lyn <alex.lyn@antgroup.com>