### PR TITLE
GHA: Fix kata-deploy-runtime-classes-check for kata-qemu-se

### DIFF
--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-se.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-se.yaml
@@ -1,0 +1,13 @@
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
+    name: kata-qemu-se
+handler: kata-qemu-se
+overhead:
+    podFixed:
+        memory: "2048Mi"
+        cpu: "1.0"
+scheduling:
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -67,6 +67,19 @@ scheduling:
 kind: RuntimeClass
 apiVersion: node.k8s.io/v1
 metadata:
+    name: kata-qemu-se
+handler: kata-qemu-se
+overhead:
+    podFixed:
+        memory: "2048Mi"
+        cpu: "1.0"
+scheduling:
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+---
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
     name: kata-qemu-sev
 handler: kata-qemu-sev
 overhead:
@@ -82,19 +95,6 @@ apiVersion: node.k8s.io/v1
 metadata:
     name: kata-qemu-snp
 handler: kata-qemu-snp
-overhead:
-    podFixed:
-        memory: "2048Mi"
-        cpu: "1.0"
-scheduling:
-  nodeSelector:
-    katacontainers.io/kata-runtime: "true"
----
-kind: RuntimeClass
-apiVersion: node.k8s.io/v1
-metadata:
-    name: kata-qemu-se
-handler: kata-qemu-se
 overhead:
     podFixed:
         memory: "2048Mi"


### PR DESCRIPTION
This is to fix an error on kata-deploy-runtime-classes-check for kata-qemu-se.

Fixes: #8623

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>