### PR TITLE
tests: k8s: Enable tests for cloud hypervisor runtime-rs without devicemapper

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -174,6 +174,7 @@ function run_tests() {
 	pushd "${kubernetes_dir}"
 	bash setup.sh
 	if [[ "${KATA_HYPERVISOR}" = "dragonball" ]] && [[ "${SNAPSHOTTER}" = "devmapper" ]] || [[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]] && [[ "${SNAPSHOTTER}" = "devmapper" ]]; then
+		# cloud-hypervisor runtime-rs issue is https://github.com/kata-containers/kata-containers/issues/9034
 		echo "Skipping tests for $KATA_HYPERVISOR using devmapper"
 	else
 		bash run_kubernetes_tests.sh

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -173,10 +173,8 @@ function run_tests() {
 
 	pushd "${kubernetes_dir}"
 	bash setup.sh
-	if [[ "${KATA_HYPERVISOR}" = "dragonball" ]] && [[ "${SNAPSHOTTER}" = "devmapper" ]]; then
-		echo "Skipping tests for dragonball using devmapper"
-	elif [[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]]; then
-		echo "Skipping tests for ${KATA_HYPERVISOR}"
+	if [[ "${KATA_HYPERVISOR}" = "dragonball" ]] && [[ "${SNAPSHOTTER}" = "devmapper" ]] || [[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]] && [[ "${SNAPSHOTTER}" = "devmapper" ]]; then
+		echo "Skipping tests for $KATA_HYPERVISOR using devmapper"
 	else
 		bash run_kubernetes_tests.sh
 	fi

--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -10,6 +10,7 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/8965"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "test not working see: ${dragonball_limitations}"
 	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
@@ -30,6 +31,7 @@ setup() {
 }
 
 @test "Check CPU constraints" {
+	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/8965"
 	# Create the pod
 	kubectl create -f "${pod_config_dir}/pod-cpu.yaml"
 
@@ -72,6 +74,7 @@ setup() {
 
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
+	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/8965"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "test not working see: ${dragonball_limitations}"
 	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \

--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -10,9 +10,9 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
-	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/8965"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "test not working see: ${dragonball_limitations}"
+	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "https://github.com/kata-containers/kata-containers/issues/9039"
 	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
 		[ "${KATA_HYPERVISOR}" == "qemu-sev" ] || [ "${KATA_HYPERVISOR}" == "qemu-se" ] ) \
 		&& skip "TEEs do not support memory / CPU hotplug"
@@ -31,7 +31,6 @@ setup() {
 }
 
 @test "Check CPU constraints" {
-	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/8965"
 	# Create the pod
 	kubectl create -f "${pod_config_dir}/pod-cpu.yaml"
 
@@ -74,9 +73,9 @@ setup() {
 
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
-	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/8965"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "test not working see: ${dragonball_limitations}"
+	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "https://github.com/kata-containers/kata-containers/issues/9039"
 	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
 		[ "${KATA_HYPERVISOR}" == "qemu-sev" ] || [ "${KATA_HYPERVISOR}" == "qemu-se" ] ) \
 		&& skip "TEEs do not support memory / CPU hotplug"

--- a/tests/integration/kubernetes/k8s-number-cpus.bats
+++ b/tests/integration/kubernetes/k8s-number-cpus.bats
@@ -9,6 +9,7 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]]&& skip "test not working https://github.com/kata-containers/kata-containers/issues/9039"
 	pod_name="cpu-test"
 	container_name="c1"
 	get_pod_config_dir
@@ -40,6 +41,7 @@ setup() {
 }
 
 teardown() {
+	[[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]]&& skip "test not working https://github.com/kata-containers/kata-containers/issues/9039"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -9,7 +9,7 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" == "dragonball" ] && \
+	[ "${KATA_HYPERVISOR}" == "dragonball" ] || [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]&& \
 		skip "runtime-rs is still using the old vcpus allocation algorithm, skipping the test"
 
 	get_pod_config_dir
@@ -29,7 +29,7 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" == "dragonball" ] && \
+	[ "${KATA_HYPERVISOR}" == "dragonball" ] || [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && \
 		skip "runtime-rs is still using the old vcpus allocation algorithm, skipping the test"
 
 	for pod in "${pods[@]}"; do

--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -10,7 +10,7 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] || [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]&& \
-		skip "runtime-rs is still using the old vcpus allocation algorithm, skipping the test"
+		skip "runtime-rs is still using the old vcpus allocation algorithm, skipping the test see https://github.com/kata-containers/kata-containers/issues/8660"
 
 	get_pod_config_dir
 	pods=( "vcpus-less-than-one-with-no-limits" "vcpus-less-than-one-with-limits" "vcpus-more-than-one-with-limits" )
@@ -30,7 +30,7 @@ setup() {
 
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] || [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && \
-		skip "runtime-rs is still using the old vcpus allocation algorithm, skipping the test"
+		skip "runtime-rs is still using the old vcpus allocation algorithm, skipping the test see https://github.com/kata-containers/kata-containers/issues/8660"
 
 	for pod in "${pods[@]}"; do
 		kubectl logs ${pod}

--- a/tests/integration/kubernetes/k8s-scale-nginx.bats
+++ b/tests/integration/kubernetes/k8s-scale-nginx.bats
@@ -17,6 +17,7 @@ setup() {
 }
 
 @test "Scale nginx deployment" {
+
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/${deployment}.yaml" > "${pod_config_dir}/test-${deployment}.yaml"
 

--- a/tests/integration/kubernetes/k8s-scale-nginx.bats
+++ b/tests/integration/kubernetes/k8s-scale-nginx.bats
@@ -17,7 +17,6 @@ setup() {
 }
 
 @test "Scale nginx deployment" {
-
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/${deployment}.yaml" > "${pod_config_dir}/test-${deployment}.yaml"
 


### PR DESCRIPTION
This PR enable the k8s tests for cloud hypervisor runtime-rs without devicemapper.

Fixes #8627