### PR TITLE
runtime-rs: ch: Change state when VM stopped

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -110,8 +110,6 @@ impl CloudHypervisorInner {
             }
         }
 
-        self.state = VmmState::VmmServerReady;
-
         Ok(())
     }
 
@@ -246,8 +244,6 @@ impl CloudHypervisorInner {
         if let Some(detail) = response {
             debug!(sl!(), "vm start response: {:?}", detail);
         }
-
-        self.state = VmmState::VmRunning;
 
         Ok(())
     }
@@ -625,7 +621,11 @@ impl CloudHypervisorInner {
         self.timeout_secs = timeout_secs;
         self.start_hypervisor(self.timeout_secs).await?;
 
+        self.state = VmmState::VmmServerReady;
+
         self.boot_vm().await?;
+
+        self.state = VmmState::VmRunning;
 
         Ok(())
     }


### PR DESCRIPTION
Make the CH (Cloud Hypervisor) `stop_vm()` method check the VM state before attempting to stop the VM, and update the state once the VM has stopped.

This avoids the method failing if called multiple times which will happen if the workload exits before the container manager requests that the container stop.

This change ensures the CH driver finishes cleanly.

Fixes: #8629.