### PR TITLE
deployment: kata-cleanup overlay, stable and latest components

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -2,23 +2,23 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kubelet-kata-cleanup
+  name: kata-cleanup
   namespace: kube-system
 spec:
   selector:
     matchLabels:
-      name: kubelet-kata-cleanup
+      name: kata-cleanup
   template:
     metadata:
       labels:
-        name: kubelet-kata-cleanup
+        name: kata-cleanup
     spec:
       serviceAccountName: kata-deploy-sa
       hostPID: true
       nodeSelector:
         katacontainers.io/kata-runtime: cleanup
       containers:
-        - name: kube-kata-cleanup
+        - name: kata-cleanup
           image: quay.io/kata-containers/kata-deploy:latest
           imagePullPolicy: Always
           command: ["bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh reset"]

--- a/tools/packaging/kata-deploy/kata-cleanup/base/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
 - kata-cleanup.yaml
+
+components:
+-  ../../kata-deploy/components/latest

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/k0s/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/k0s/kustomization.yaml
@@ -1,0 +1,6 @@
+bases: 
+- ../../base
+
+patchesStrategicMerge:
+- mount_k0s_conf.yaml
+

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/k0s/mount_k0s_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/k0s/mount_k0s_conf.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: kata-cleanup
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: containerd-conf
+          hostPath:
+            path: /etc/k0s/containerd.d/

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/mount_k3s_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/mount_k3s_conf.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kubelet-kata-cleanup
+  name: kata-cleanup
   namespace: kube-system
 spec:
   template:

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/mount_rke2_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/mount_rke2_conf.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: kubelet-kata-cleanup
+  name: kata-cleanup
   namespace: kube-system
 spec:
   template:

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/stable/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/stable/kustomization.yaml
@@ -1,0 +1,6 @@
+bases:
+- ../../base
+
+components: 
+- ../../../kata-deploy/components/stable
+

--- a/tools/packaging/kata-deploy/kata-deploy/base/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kustomization.yaml
@@ -1,2 +1,5 @@
 resources:
 - kata-deploy.yaml
+
+components:
+-  ../components/latest

--- a/tools/packaging/kata-deploy/kata-deploy/components/latest/env_latest_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/components/latest/env_latest_conf.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata: 
+  name: not-important
+  namespace: not-important
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-kata
+        env:
+          - name: SHIMS
+            value: "clh cloud-hypervisor dragonball fc qemu qemu-nvidia-gpu qemu-sev qemu-snp qemu-tdx stratovirt"

--- a/tools/packaging/kata-deploy/kata-deploy/components/latest/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/components/latest/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+images:
+- name: quay.io/kata-containers/kata-deploy
+  newTag: latest
+
+patches:
+- path: env_latest_conf.yaml
+  target:
+    kind: DaemonSet
+    namespace: kube-system

--- a/tools/packaging/kata-deploy/kata-deploy/components/stable/env_stable_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/components/stable/env_stable_conf.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata: 
-  name: kata-deploy
-  namespace: kube-system
+  name: not-important
+  namespace: not-important
 spec:
   template:
     spec:

--- a/tools/packaging/kata-deploy/kata-deploy/components/stable/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/components/stable/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+
+images:
+- name: quay.io/kata-containers/kata-deploy
+  newTag: stable
+
+patches:
+- path: env_stable_conf.yaml
+  target:
+    kind: DaemonSet
+    namespace: kube-system

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/stable/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/stable/kustomization.yaml
@@ -1,9 +1,5 @@
 bases:
 - ../../base
 
-images:
-- name: quay.io/kata-containers/kata-deploy
-  newTag: stable
-
-patches:
-- path: env_stable_conf.yaml
+components:
+- ../../components/stable


### PR DESCRIPTION
 kata-cleanup relies on a stable and latest SHIMS env var. We need to add components for stable and latest that we can use for any manifest.
 We may also need to rename the manifest to match kata-deploy naming
    