### PR TITLE
metrics: Update TensorFlow ResNet50 Int8 Dockerfile

### DIFF
--- a/tests/metrics/machine_learning/resnet50_int8_dockerfile/Dockerfile
+++ b/tests/metrics/machine_learning/resnet50_int8_dockerfile/Dockerfile
@@ -12,10 +12,14 @@ LABEL DOCKERFILE_VERSION="1.0"
 
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends wget nano curl build-essential git && \
-	apt-get install -y python3.8  python3-pip && \
-	pip install --no-cache-dir intel-tensorflow-avx512==2.8.0 && \
-	pip install --no-cache-dir protobuf==3.20.* && \
 	wget -q https://storage.googleapis.com/intel-optimized-tensorflow/models/v1_8/resnet50_int8_pretrained_model.pb && \
-	git clone https://github.com/IntelAI/models.git
+	git clone https://github.com/IntelAI/models.git && \
+	wget -q https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz && \
+	tar xzf Python-3.8.10.tgz && \
+	cd Python-3.8.10 && \
+	./configure --enable-optimizations && make altinstall && make install && \
+	apt-get install -y python3-pip && \
+	pip install --no-cache-dir intel-tensorflow-avx512==2.8.0 && \
+	pip install --no-cache-dir protobuf==3.20.*
 
 CMD ["/bin/bash"]

--- a/tests/metrics/machine_learning/tensorflow_resnet50_int8.sh
+++ b/tests/metrics/machine_learning/tensorflow_resnet50_int8.sh
@@ -57,7 +57,7 @@ function create_start_script() {
 
 cat <<EOF >>"${script}"
 #!/bin/bash
-python3.8 models/benchmarks/launch_benchmark.py --benchmark-only --framework tensorflow --model-name resnet50  --precision int8 --mode inference --in-graph /resnet50_int8_pretrained_model.pb --batch-size 116 --num-intra-threads 16 >> results
+python3.10 models/benchmarks/launch_benchmark.py --benchmark-only --framework tensorflow --model-name resnet50  --precision int8 --mode inference --in-graph /resnet50_int8_pretrained_model.pb --batch-size 116 --num-intra-threads 16 >> results
 EOF
 	chmod +x "${script}"
 }


### PR DESCRIPTION
This PR updates the TensorFlow ResNet50 Int8 Dockerfile to use the proper python version for kata metrics.

Fixes #8643