### PR TITLE
Cleanup network to make sure physical interfaces are restores back to original host driver.

### DIFF
--- a/src/runtime/virtcontainers/api.go
+++ b/src/runtime/virtcontainers/api.go
@@ -70,17 +70,18 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 		}
 	}()
 
+	// network rollback
+	defer func() {
+		if err != nil {
+			virtLog.Info("Removing network after failure in createSandbox")
+			s.removeNetwork(ctx)
+		}
+	}()
+
 	// Create the sandbox network
 	if err = s.createNetwork(ctx); err != nil {
 		return nil, err
 	}
-
-	// network rollback
-	defer func() {
-		if err != nil {
-			s.removeNetwork(ctx)
-		}
-	}()
 
 	// Set the sandbox host cgroups.
 	if err := s.setupResourceController(); err != nil {

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -437,7 +437,12 @@ func (n *LinuxNetwork) RemoveEndpoints(ctx context.Context, s *Sandbox, endpoint
 		}
 
 		if err := n.removeSingleEndpoint(ctx, s, ep, hotplug); err != nil {
-			return err
+			// Log the error instead of returning right away
+			// Proceed to remove the next endpoint so as to clean the network setup as
+			// much as possible.
+			// This is crucial for physical endpoints as we want to bind back the physical
+			// interface to its original host driver.
+			networkLogger().Warnf("Error removing endpoint %v : %v", ep.Name(), err)
 		}
 	}
 


### PR DESCRIPTION
 network: Move up defer block to cleanup network
    
 Move the defer for cleaning up network before the call to add network.
 This way if any change made by add network is reverted by in case of
 failure. This is particulary important for physical network interfaces
 as with this step we make sure that driver for the physical interface is
 reverted back to the original host driver. Without this the physical
 network iterface will remain bound to vfio.
    
 Fixes: #8646
