### PR TITLE
GHA: Put all the preliminary steps into pre-action for s390x

### DIFF
--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -36,9 +36,8 @@ jobs:
         stage:
           - ${{ inputs.stage }}
     steps:
-      - name: Adjust a permission for repo
-        run: |
-          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+      - name: Take a pre-action for self-hosted runner
+        run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -87,9 +86,9 @@ jobs:
     runs-on: s390x
     needs: build-asset
     steps:
-      - name: Adjust a permission for repo
-        run: |
-          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+      - name: Take a pre-action for self-hosted runner
+        run: ${HOME}/script/pre_action.sh ubuntu-2204
+
       - uses: actions/checkout@v3
 
       - name: get-artifacts
@@ -131,9 +130,8 @@ jobs:
     runs-on: s390x
     needs: [build-asset, build-asset-boot-image-se]
     steps:
-      - name: Adjust a permission for repo
-        run: |
-          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+      - name: Take a pre-action for self-hosted runner
+        run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-nightly-s390x.yaml
+++ b/.github/workflows/ci-nightly-s390x.yaml
@@ -22,11 +22,6 @@ jobs:
   k8s-cri-containerd-rhel9-e2e-tests:
     runs-on: s390x-rhel9
     steps:
-    - name: Delete the existing files
-      run: |
-        sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-        sudo rm -rf $GITHUB_WORKSPACE/*
-
     - name: Take a pre-action for self-hosted runner
       run: |
         ${HOME}/script/pre_action.sh rhel9-nightly

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -26,9 +26,8 @@ jobs:
   kata-payload:
     runs-on: s390x
     steps:
-      - name: Adjust a permission for repo
-        run: |
-          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+      - name: Take a pre-action for self-hosted runner
+        run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/run-cri-containerd-tests-s390x.yaml
+++ b/.github/workflows/run-cri-containerd-tests-s390x.yaml
@@ -29,9 +29,6 @@ jobs:
       GOPATH: ${{ github.workspace }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
-      - name: Adjust a permission for repo
-        run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-
       - name: Take a pre-action for self-hosted runner
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 

--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -45,9 +45,6 @@ jobs:
       USING_NFD: "true"
       TARGET_ARCH: "s390x"
     steps:
-      - name: Adjust a permission for repo
-        run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-
       - name: Take a pre-action for self-hosted runner
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 


### PR DESCRIPTION
This is to introduce a pre-action to all the workflows for building artifacts. The action could take care of tasks such as cleaning up files and reinstalling packages, which prevents a workflow from getting affected by the environment.

This also includes the removal of the step `Adjust a permission for repo`, because it could be incorporated into the action.

Fixes: #8648

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>