### PR TITLE
kata-deploy: Allow setting up snapshotters per runtime handler

### DIFF
--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -41,6 +41,8 @@ spec:
               value: "false"
             - name: ALLOWED_HYPERVISOR_ANNOTATIONS
               value: ""
+            - name: SNAPSHOTTER_HANDLER_MAPPING
+              value: ""
           securityContext:
             privileged: true
           volumeMounts:


### PR DESCRIPTION
Since containerd 1.7.0 we can easily set a specific snapshotter to be used with a runtime handler, and we should take advantage of this, mostly as it'll help setting up any runtime using devmapper or nydus snapshotters.

This implementation here has a few caveats:
* The format expected for the SNAPSHOTTER_HANDLER_MAPPING is: `shim:snapshotter,shim:snapshotter,...`
* It only works with containerd 1.7 or newer
* We **never** change the default containerd snapshotter
* We don't do any check on our side to verify whether the snapshotter required is properly deployed
* Users will have to add an annotation to their pods, in order to use the snapshotter set up per runtime handler
  * Example: ``` metadata: ... annotations: io.containerd.cri.runtime-handler: kata-fc ```

Fixes: #8615

**NOTE**: Due to the lack of time from my side, as I'm vanishing for a few weeks, I've opted for not yet change the tests related to devmapper to use this new "feature".  Together with this decision comes a head's up that this is not tested anywhere yet, but it'll help us to unblock @ChengyuZhu6's series.