### PR TITLE
github-actions: Remove ignore paths for required CI checks

### DIFF
--- a/.github/workflows/cargo-deny-runner.yaml
+++ b/.github/workflows/cargo-deny-runner.yaml
@@ -6,7 +6,6 @@ on:
       - edited
       - reopened
       - synchronize
-    paths-ignore: [ '**.md', '**.png', '**.jpg', '**.jpeg', '**.svg', '/docs/**' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -13,8 +13,6 @@ on:
       - synchronize
       - reopened
       - labeled
-    paths-ignore:
-      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -5,7 +5,6 @@ on:
       - edited
       - reopened
       - synchronize
-    paths-ignore: [ '**.md', '**.png', '**.jpg', '**.jpeg', '**.svg', '/docs/**' ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
If a PR contains files from the ignore-paths, these actions do not run as intended. However, the actions are make as required. And there does not seem to be a way to mark these as non-required in that case. As a result a PR containing the files from the ignore-paths remains stalled.
Hence remove the ignore-paths until github provides a way to mark actions that are skipped due to ignore-paths as non-required/passed.

Fixes: #8663