### PR TITLE
gha: add a post cleanup script for cri-containerd ppc64le workflow

### DIFF
--- a/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
+++ b/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
@@ -57,3 +57,6 @@ jobs:
 
       - name: Run cri-containerd tests
         run: bash tests/integration/cri-containerd/gha-run.sh run
+      
+      - name: Cleanup actions for the self hosted runner
+        run: ${HOME}/scripts/cleanup_runner.sh


### PR DESCRIPTION
This PR identifies and adds an action to cleanup the ppc64le self hosted runner.

Fixes: #8666