### PR TITLE
runtime-rs: Separate init_config() from new() for struct VsockDevice

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -330,9 +330,11 @@ impl DeviceManager {
                 // No need to do find device for hybrid vsock device.
                 Arc::new(Mutex::new(HybridVsockDevice::new(&device_id, hvconfig)))
             }
-            DeviceConfig::VsockCfg(_vconfig) => {
+            DeviceConfig::VsockCfg(vconfig) => {
                 // No need to do find device for vsock device.
-                Arc::new(Mutex::new(VsockDevice::new(device_id.clone()).await?))
+                Arc::new(Mutex::new(
+                    VsockDevice::new(device_id.clone(), vconfig).await?,
+                ))
             }
             DeviceConfig::ShareFsCfg(config) => {
                 // Try to find the sharefs device. If found, just return matched device id.

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_vsock.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_vsock.rs
@@ -117,15 +117,19 @@ nix::ioctl_write_ptr!(
 const CID_RETRY_COUNT: u32 = 50;
 
 impl VsockDevice {
-    pub async fn new(id: String) -> Result<Self> {
-        let (guest_cid, _vhost_fd) = generate_vhost_vsock_cid()
-            .await
-            .context("generate vhost vsock cid failed")?;
-
+    pub async fn new(id: String, config: &VsockConfig) -> Result<Self> {
         Ok(Self {
             id,
-            config: VsockConfig { guest_cid },
+            config: config.clone(),
         })
+    }
+
+    pub async fn init_config(&mut self) -> Result<File> {
+        let (guest_cid, vhost_fd) = generate_vhost_vsock_cid()
+            .await
+            .context("generate vhost vsock cid failed")?;
+        self.config.guest_cid = guest_cid;
+        Ok(vhost_fd)
     }
 }
 


### PR DESCRIPTION
As a follow-up for #8516, guest_cid and vhost_fd are not necessarily initialised via new(). Instead, the fields should be initialised later when they are really used to construct hypervisor's parameters.
This commit is to separate init_config() from new() to initialise guest_cid and vhost_fd and leave only the assignment of id for the existing function.

Fixes: #8671

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>

