### PR TITLE
ci: Use static checks from kata repo for lib functions

### DIFF
--- a/ci/lib.sh
+++ b/ci/lib.sh
@@ -5,6 +5,8 @@
 
 set -o nounset
 
+export kata_repo="github.com/kata-containers/kata-containers"
+export kata_repo_dir="$GOPATH/src/$kata_repo"
 export tests_repo="${tests_repo:-github.com/kata-containers/tests}"
 export tests_repo_dir="$GOPATH/src/$tests_repo"
 export branch="${target_branch:-main}"
@@ -39,20 +41,18 @@ clone_tests_repo()
 
 run_static_checks()
 {
-	clone_tests_repo
 	# Make sure we have the targeting branch
 	git remote set-branches --add origin "${branch}"
 	git fetch -a
-	bash "$tests_repo_dir/.ci/static-checks.sh" "$@"
+	bash "$kata_repo_dir/tests/static-checks.sh" "$@"
 }
 
 run_docs_url_alive_check()
 {
-	clone_tests_repo
 	# Make sure we have the targeting branch
 	git remote set-branches --add origin "${branch}"
 	git fetch -a
-	bash "$tests_repo_dir/.ci/static-checks.sh" --docs --all "github.com/kata-containers/kata-containers"
+	bash "$kata_repo_dir/tests/static-checks.sh" --docs --all "$kata_repo"
 }
 
 run_get_pr_changed_file_details()

--- a/docs/Licensing-strategy.md
+++ b/docs/Licensing-strategy.md
@@ -18,4 +18,4 @@ licensing and allows automated tooling to check the license of individual
 files.
 
 This SPDX licence identifier requirement is enforced by the
-[CI (Continuous Integration) system](https://github.com/kata-containers/tests/blob/main/.ci/static-checks.sh).
+[CI (Continuous Integration) system](https://github.com/kata-containers/kata-containers/blob/main/tests/static-checks.sh).

--- a/docs/presentations/unit-testing/kata-containers-unit-testing.md
+++ b/docs/presentations/unit-testing/kata-containers-unit-testing.md
@@ -213,7 +213,7 @@ If in doubt, look at the
   - As a non-privileged user.
   - As the `root` user (carefully!)
 
-- Run the [static checker](https://github.com/kata-containers/tests/blob/main/.ci/static-checks.sh)
+- Run the [static checker](https://github.com/kata-containers/kata-containers/blob/main/tests/static-checks.sh)
   on your changes.
 
   Checks formatting and many other things.


### PR DESCRIPTION
Change the two functions in lib.sh to use the static checks script from
the kata containers repo instead of tests. Remove cloning the repo from
these functions since we don't need it anymore. Leave these two
functions because the document checking one may be used locally and the
static checks one is called from the virtcontainers Makefile.
    
Fixes #8681
  
Signed-off-by: Chelsea Mafrica <chelsea.e.mafrica@intel.com>