### PR TITLE
configuration: update comments for debug_console_enabled

### DIFF
--- a/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
+++ b/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
@@ -222,7 +222,7 @@ container_pipe_size=@PIPESIZE@
 # Enable debug console.
 
 # If enabled, user can connect guest OS running inside hypervisor
-# through "kata-runtime exec <sandbox-id>" command
+# through "kata-ctl exec <sandbox-id>" command
 
 #debug_console_enabled = true
 

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -235,7 +235,7 @@ container_pipe_size=@PIPESIZE@
 # Enable debug console.
 
 # If enabled, user can connect guest OS running inside hypervisor
-# through "kata-runtime exec <sandbox-id>" command
+# through "kata-ctl exec <sandbox-id>" command
 
 #debug_console_enabled = true
 


### PR DESCRIPTION
In terms of entering debug console, kata-runtime only works for runtime(golang), for runtime-rs, it's supposed to use kata-ctl.

fixes:  #8683

v2: 
* updated commit log.
* updated config for clh as well.