### PR TITLE
runtime: Allow no initrd path for IBM Z Secure Execution

### DIFF
--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -747,6 +747,12 @@ func (conf *HypervisorConfig) ImageOrInitrdAssetPath() (string, types.AssetType,
 			return initrd, types.InitrdAsset, nil
 		}
 
+		// Even if neither image nor initrd are set, we still need to return
+		// if we are running a confidential guest on QemuCCWVirtio. (IBM Z Secure Execution)
+		if conf.ConfidentialGuest && conf.HypervisorMachineType == QemuCCWVirtio {
+			return "", types.SecureBootAsset, nil
+		}
+
 		return "", types.UnkownAsset, fmt.Errorf("one of image and initrd must be set")
 	}
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -422,9 +422,13 @@ func (q *qemu) buildDevices(ctx context.Context, kernelPath string) ([]govmmQemu
 		if err != nil {
 			return nil, nil, nil, err
 		}
-	} else {
+	} else if assetType == types.InitrdAsset {
 		// InitrdAsset, need to set kernel initrd path
 		kernel.InitrdPath = assetPath
+	} else if assetType == types.SecureBootAsset {
+		// SecureBootAsset, no need to set image or initrd path
+		q.Logger().Info("For IBM Z Secure Execution, initrd path should not be set")
+		kernel.InitrdPath = ""
 	}
 
 	if q.config.IOMMU {

--- a/src/runtime/virtcontainers/types/asset.go
+++ b/src/runtime/virtcontainers/types/asset.go
@@ -28,6 +28,10 @@ const (
 	// InitrdAsset is an initrd asset.
 	InitrdAsset AssetType = "initrd"
 
+	// SecureBootAsset is a secure boot asset.
+	// (IBM Z Secure Execution only)
+	SecureBootAsset AssetType = "secure_boot"
+
 	// HypervisorAsset is an hypervisor asset.
 	HypervisorAsset AssetType = "hypervisor"
 


### PR DESCRIPTION
This is to reintroduce a configuration rule for IBM Z Secure Execution, where no initrd path should be configured. For the TEE of interest, only a kernel image should be specified with `confidential_guest=true`.

Fixes: #8692

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>


Test result:

```
$ ps -ef | grep qemu | grep kernel
root      415937  415926  3 14:51 ?        00:00:02 /opt/kata/bin/qemu-system-s390x -name sandbox-217c61c958d255f517cacfe2cbb1cde84eb58a0f6af7f2a04ce98a1035c072c8 -uuid 3d1d57e4-48c4-436e-9350-2fcd2c1466d5 -machine s390-ccw-virtio,accel=kvm,confidential-guest-support=pv0 -cpu host, -qmp unix:fd=3,server=on,wait=off -m 2048M,slots=10,maxmem=15923M -device virtio-serial-ccw,id=serial0,devno=fe.0.0001 -device virtconsole,chardev=charconsole0,id=console0 -chardev socket,id=charconsole0,path=/run/vc/vm/217c61c958d255f517cacfe2cbb1cde84eb58a0f6af7f2a04ce98a1035c072c8/console.sock,server=on,wait=off -device virtio-scsi-ccw,id=scsi0,devno=fe.0.0002 -object s390-pv-guest,id=pv0 -device vhost-vsock-ccw,vhostfd=4,id=vsock-826465042,guest-cid=826465042,devno=fe.0.0003 -chardev socket,id=char-94dc2772c2c7eaec,path=/run/vc/vm/217c61c958d255f517cacfe2cbb1cde84eb58a0f6af7f2a04ce98a1035c072c8/vhost-fs.sock -device vhost-user-fs-ccw,chardev=char-94dc2772c2c7eaec,tag=kataShared,queue-size=1024,devno=fe.0.0004 -netdev tap,id=network-0,fds=5 -device driver=virtio-net-ccw,netdev=network-0,mac=ce:58:f6:92:c5:07,mq=on,devno=fe.0.0005 -rtc base=utc,driftfix=slew,clock=host -global kvm-pit.lost_tick_policy=discard -vga none -no-user-config -nodefaults -nographic --no-reboot -object memory-backend-file,id=dimm1,size=2048M,mem-path=/dev/shm,share=on -machine memory-backend=dimm1 -kernel /opt/kata/share/kata-containers/kata-containers-se.img -append console=ttysclp0 quiet panic=1 nr_cpus=1 selinux=0 scsi_mod.scan=none -pidfile /run/vc/vm/217c61c958d255f517cacfe2cbb1cde84eb58a0f6af7f2a04ce98a1035c072c8/pid -smp 1,cores=1,threads=1,sockets=1,maxcpus=1
$ ps -ef | grep qemu | grep initrd
$ kubectl get po
NAME                                   READY   STATUS    RESTARTS   AGE
php-apache-kata-qemu-5f5fc68bd-9jmbx   1/1     Running   0          37m
```

For a normal kata configuration with initrd, a qemu argument `-initrd` should be specified to run a container like:

```
$ ps -ef | grep qemu | grep initrd
root      435056  435046  4 16:44 ?        00:00:00 /opt/kata/bin/qemu-system-s390x -name sandbox-73f231f408a3cf15b3b6b9182ad4e8ebc5751857907436fe3c6d5039ecb7eecf -uuid 3132e80b-ba75-4f2d-a50b-e8883280c2cd -machine s390-ccw-virtio,accel=kvm -cpu host, -qmp unix:fd=3,server=on,wait=off -m 2048M,slots=10,maxmem=15923M -device virtio-serial-ccw,id=serial0,devno=fe.0.0001 -device virtconsole,chardev=charconsole0,id=console0 -chardev socket,id=charconsole0,path=/run/vc/vm/73f231f408a3cf15b3b6b9182ad4e8ebc5751857907436fe3c6d5039ecb7eecf/console.sock,server=on,wait=off -device virtio-scsi-ccw,id=scsi0,devno=fe.0.0002 -device vhost-vsock-ccw,vhostfd=4,id=vsock-3232324942,guest-cid=3232324942,devno=fe.0.0003 -chardev socket,id=char-baa771172eab7fe6,path=/run/vc/vm/73f231f408a3cf15b3b6b9182ad4e8ebc5751857907436fe3c6d5039ecb7eecf/vhost-fs.sock -device vhost-user-fs-ccw,chardev=char-baa771172eab7fe6,tag=kataShared,queue-size=1024,devno=fe.0.0004 -netdev tap,id=network-0,fds=5 -device driver=virtio-net-ccw,netdev=network-0,mac=62:00:92:d6:bf:7a,mq=on,devno=fe.0.0005 -rtc base=utc,driftfix=slew,clock=host -global kvm-pit.lost_tick_policy=discard -vga none -no-user-config -nodefaults -nographic --no-reboot -object memory-backend-file,id=dimm1,size=2048M,mem-path=/dev/shm,share=on -machine memory-backend=dimm1 -kernel /opt/kata/share/kata-containers/vmlinux-6.1.52-116 -initrd /opt/kata/share/kata-containers/kata-ubuntu-20.04.initrd -append console=ttysclp0 quiet panic=1 nr_cpus=16 selinux=0 scsi_mod.scan=none -pidfile /run/vc/vm/73f231f408a3cf15b3b6b9182ad4e8ebc5751857907436fe3c6d5039ecb7eecf/pid -smp 1,cores=1,threads=1,sockets=16,maxcpus=16
```