### PR TITLE
dragonball: Trigger unit tests of dbs_* subcrates by `make test`

### DIFF
--- a/src/dragonball/Makefile
+++ b/src/dragonball/Makefile
@@ -4,6 +4,8 @@
 
 include ../../utils.mk
 
+PROJECT_DIRS := $(shell find . -name Cargo.toml -printf '%h\n' | sort -u)
+
 ifeq ($(ARCH), s390x)
 default build check test clippy:
 	@echo "s390x not support currently"
@@ -40,7 +42,10 @@ clean:
 
 test:
 ifdef SUPPORT_VIRTUALIZATION
-	RUST_BACKTRACE=1 cargo test --all-features --target $(TRIPLE) -- --nocapture --test-threads=1
+	@set -e; \
+	for dir in $(PROJECT_DIRS); do \
+		bash -c "pushd $${dir} && RUST_BACKTRACE=1 cargo test --all-features --target $(TRIPLE) -- --nocapture --test-threads=1 && popd"; \
+	done
 else
 	@echo "INFO: skip testing dragonball, it need virtualization support."
 	exit 0

--- a/src/dragonball/src/dbs_legacy_devices/src/i8042.rs
+++ b/src/dragonball/src/dbs_legacy_devices/src/i8042.rs
@@ -86,7 +86,7 @@ mod tests {
     fn test_i8042_valid_ops() {
         let reset_evt = EventFdTrigger::new(EventFd::new(libc::EFD_NONBLOCK).unwrap());
         let metrics = Arc::new(I8042DeviceMetrics::default());
-        let mut i8042 = I8042Device::new(reset_evt.try_clone().unwrap(), metrics);
+        let mut i8042 = I8042Device::new(reset_evt.try_clone().unwrap());
 
         let mut v = [0x00u8; 1];
         i8042.pio_read(PioAddress(0), PioAddress(0), &mut v);
@@ -107,7 +107,7 @@ mod tests {
     fn test_i8042_invalid_ops() {
         let reset_evt = EventFdTrigger::new(EventFd::new(libc::EFD_NONBLOCK).unwrap());
         let metrics = Arc::new(I8042DeviceMetrics::default());
-        let mut i8042 = I8042Device::new(reset_evt.try_clone().unwrap(), metrics);
+        let mut i8042 = I8042Device::new(reset_evt.try_clone().unwrap());
 
         let mut v = [0x00u8; 2];
         i8042.pio_read(PioAddress(0), PioAddress(0), &mut v);
@@ -128,7 +128,7 @@ mod tests {
     fn test_i8042_reset_err() {
         let reset_evt = EventFdTrigger::new(unsafe { EventFd::from_raw_fd(i32::MAX) });
         let metrics = Arc::new(I8042DeviceMetrics::default());
-        let mut i8042 = I8042Device::new(reset_evt, metrics);
+        let mut i8042 = I8042Device::new(reset_evt);
         i8042.pio_write(
             PioAddress(0),
             PioAddress(COMMAND_OFFSET as u16),

--- a/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_user/fs.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_user/fs.rs
@@ -813,7 +813,7 @@ mod tests {
 
     #[test]
     fn test_vhost_user_fs_virtio_device_normal() {
-        let device_socket = "/var/tmp/vhost.1";
+        let device_socket = "/tmp/vhost.1";
         let tag = "test_fs";
 
         let handler = thread::spawn(move || {
@@ -882,7 +882,7 @@ mod tests {
 
     #[test]
     fn test_vhost_user_fs_virtio_device_activate() {
-        let device_socket = "/var/tmp/vhost.1";
+        let device_socket = "/tmp/vhost.1";
         let tag = "test_fs";
 
         let handler = thread::spawn(move || {


### PR DESCRIPTION
`make SUPPORT_VIRTUALIZATION=1 test` iterates through all subcrates and
does test. 

Plus, this patch fixes some issues about unit tests:

- Feed too much parameters to `I8042Device::new()`.
- Virtqueue checks have been introduced since `virtio-queue v0.7.0`.
- GHA might have no access to `/var/tmp` dir on runner.

Fixes: #8690