### PR TITLE
kata-deploy: Update `jq` as part of the kata-deploy daemonset

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -23,13 +23,17 @@ RUN \
 	ARCH=$(uname -m) && \
 	if [ "${ARCH}" = "x86_64" ]; then ARCH=amd64; fi && \
 	if [ "${ARCH}" = "aarch64" ]; then ARCH=arm64; fi && \
+	DEBIAN_ARCH=${ARCH} && \
+	if [ "${DEBIAN_ARCH}" = "ppc64le" ]; then DEBIAN_ARCH=ppc64el; fi && \
 	curl -fL --progress-bar -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
 	chmod +x /usr/bin/kubectl && \
+	curl -fL --progress-bar -o /usr/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${DEBIAN_ARCH} && \
+	chmod +x /usr/bin/jq && \
 	mkdir -p ${DESTINATION} && \
 	tar xvf ${WORKDIR}/${KATA_ARTIFACTS} -C ${DESTINATION} && \
 	rm -f ${WORKDIR}/${KATA_ARTIFACTS} && \
 	apk del curl && \
-	apk --no-cache add jq py3-pip && \
+	apk --no-cache add py3-pip && \
 	pip install --no-cache-dir yq==3.2.3
 
 COPY scripts ${DESTINATION}/scripts

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -94,8 +94,8 @@ function get_container_runtime() {
 		else
 			echo "k3s"
 		fi
-	# Note: we assumed you used a conventional k0s setup and k0s will generate a systemd entry k0scontroller.service and k0sworker.service respectively
-	# and it is impossible to run this script without a kubelet, so this k0s controller must also have worker mode enabled
+	# Note: we assumed you used a conventional k0s setup and k0s will generate a systemd entry k0scontroller.service and k0sworker.service respectively    
+	# and it is impossible to run this script without a kubelet, so this k0s controller must also have worker mode enabled 
 	elif host_systemctl is-active --quiet k0scontroller; then
 		echo "k0s-controller"
 	elif host_systemctl is-active --quiet k0sworker; then
@@ -344,48 +344,24 @@ function configure_containerd_runtime() {
 	local runtime="kata-${shim}"
 	local configuration="configuration-${shim}"
 	local pluginid=cri
-
+	
 	# if we are running k0s auto containerd.toml generation, the base template is by default version 2
 	# we can safely assume to reference the newer version of cri
 	if grep -q "version = 2\>" $containerd_conf_file || [ "$1" == "k0s-worker" ] || [ "$1" == "k0s-controller" ]; then
 		pluginid=\"io.containerd.grpc.v1.cri\"
 	fi
-	local runtime_table="plugins.${pluginid}.containerd.runtimes.$runtime"
-	local runtime_type="io.containerd.$runtime.v2"
-	local options_table="$runtime_table.options"
-	local config_path="$(get_kata_containers_config_path "${shim}")/$configuration.toml"
-	if grep -q "\[$runtime_table\]" $containerd_conf_file; then
-		echo "Configuration exists for $runtime_table, overwriting"
-		sed -i "/\[$runtime_table\]/,+1s#runtime_type.*#runtime_type = \"${runtime_type}\"#" $containerd_conf_file
-	else
-		cat <<EOF | tee -a "$containerd_conf_file"
-[$runtime_table]
-  runtime_type = "${runtime_type}"
-  privileged_without_host_devices = true
-  pod_annotations = ["io.katacontainers.*"]
-EOF
-	fi
-
-	if grep -q "\[$options_table\]" $containerd_conf_file; then
-		echo "Configuration exists for $options_table, overwriting"
-		sed -i "/\[$options_table\]/,+1s#ConfigPath.*#ConfigPath = \"${config_path}\"#" $containerd_conf_file
-	else
-		cat <<EOF | tee -a "$containerd_conf_file"
-  [$options_table]
-    ConfigPath = "${config_path}"
-EOF
-	fi
-
+	local runtime_table=".plugins.${pluginid}.containerd.runtimes.\"${runtime}\""
+	local runtime_options_table="${runtime_table}.options"
+	local runtime_type=\"io.containerd."${runtime}".v2\"
+	local runtime_config_path=\"$(get_kata_containers_config_path "${shim}")/${configuration}.toml\"
+	
+	tomlq -i -t $(printf '%s.runtime_type=%s' ${runtime_table} ${runtime_type}) ${containerd_conf_file}
+	tomlq -i -t $(printf '%s.privileged_without_host_devices=true' ${runtime_table}) ${containerd_conf_file}
+	tomlq -i -t $(printf '%s.pod_annotations=["io.katacontainers.*"]' ${runtime_table}) ${containerd_conf_file}
+	tomlq -i -t $(printf '%s.ConfigPath=%s' ${runtime_options_table} ${runtime_config_path}) ${containerd_conf_file}
+	
 	if [ "${DEBUG}" == "true" ]; then
-		if grep -q "\[debug\]" $containerd_conf_file; then
-			sed -i 's/level.*/level = \"debug\"/' $containerd_conf_file
-		else
-			cat <<EOF | tee -a "$containerd_conf_file"
-[debug]
-  level = "debug"
-EOF
-		fi
-
+		tomlq -i -t '.debug.level = "debug"' ${containerd_conf_file}
 	fi
 }
 
@@ -485,7 +461,7 @@ function main() {
 		containerd_conf_file="${containerd_conf_tmpl_file}"
 		containerd_conf_file_backup="${containerd_conf_file}.bak"
 	elif [ "$runtime" == "k0s-worker" ] || [ "$runtime" == "k0s-controller" ]; then
-		# From 1.27.1 onwards k0s enables dynamic configuration on containerd CRI runtimes.
+		# From 1.27.1 onwards k0s enables dynamic configuration on containerd CRI runtimes. 
 		# This works by k0s creating a special directory in /etc/k0s/containerd.d/ where user can drop-in partial containerd configuration snippets.
 		# k0s will automatically pick up these files and adds these in containerd configuration imports list.
 		containerd_conf_file="/etc/containerd/kata-containers.toml"


### PR DESCRIPTION
This is a follow-up from https://github.com/kata-containers/kata-containers/pull/8679#issuecomment-1864556280, where we've narrowed down the correct component that was causing the issue, and we can go ahead and unblock the snapshotter related work (and, consequently, the merge to main work).