### PR TITLE
tests: Bump agnhost image to 2.40

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -12,7 +12,7 @@
 # Variables used by the kubernetes tests
 export docker_images_nginx_version="1.15-alpine"
 export container_images_agnhost_name="registry.k8s.io/e2e-test-images/agnhost"
-export container_images_agnhost_version="2.21"
+export container_images_agnhost_version="2.40"
 
 # Timeout options, mainly for use with waitForProcess(). Use them unless the
 # operation needs to wait longer.


### PR DESCRIPTION
The failure of tests might be caused by agnhost 2.21. Please refer to [#8715](https://github.com/kata-containers/kata-containers/issues/8715)
for more details. 

Fixes: #8715