### PR TITLE
kata-monitor: fix Dockerfile to build image

### DIFF
--- a/tools/packaging/kata-monitor/Dockerfile
+++ b/tools/packaging/kata-monitor/Dockerfile
@@ -1,12 +1,12 @@
 # Copyright (c) 2020 Eric Ernst
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.15-alpine AS builder
+FROM golang:1.19-alpine AS builder
 
-RUN apk add --no-cache bash curl git make
+RUN apk add --no-cache bash curl git make build-base
 WORKDIR /go/src/github.com/kata-containers/kata-containers/src/runtime
 COPY . /go/src/github.com/kata-containers/kata-containers
-RUN SKIP_GO_VERSION_CHECK=true make monitor
+RUN make SKIP_GO_VERSION_CHECK=true monitor
 
 FROM alpine:3.14
 COPY --from=builder /go/src/github.com/kata-containers/kata-containers/src/runtime/kata-monitor /usr/bin/kata-monitor


### PR DESCRIPTION
move `SKIP_GO_VERSION_CHECK` after `make` command to skip checking golang version.

And also upgrade golang to 1.19.

Fixes: #8728