### PR TITLE
kata-deploy: Fix shim check for snapshotter configuration

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -481,7 +481,7 @@ function snapshotter_handler_mapping_validation_check() {
 			die "The snapshotter must follow the \"shim:snapshotter,shim:snapshotter,...\" format, but at least one snapshotter is empty"
 		fi
 
-		if ! grep -q " $shim " <<< " $shims "; then
+		if ! grep -q " $shim " <<< " $SHIMS "; then
 			die "\"$shim\" is not part of \"$SHIMS\""
 		fi
 

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -377,7 +377,7 @@ function configure_containerd_runtime() {
 			fi
 
 			value="${m#*$snapshotters_delimiter}"
-			tomlq -i -t $(printf '%s.snapshotter=%s' ${shim} ${value}) ${containerd_conf_file}
+			tomlq -i -t $(printf '%s.snapshotter=%s' ${runtime_table} ${value}) ${containerd_conf_file}
 			break
 		done
 	fi

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -377,7 +377,7 @@ function configure_containerd_runtime() {
 			fi
 
 			value="${m#*$snapshotters_delimiter}"
-			tomlq -i -t $(printf '%s.snapshotter=%s' ${runtime_table} ${value}) ${containerd_conf_file}
+			tomlq -i -t $(printf '%s.snapshotter="%s"' ${runtime_table} ${value}) ${containerd_conf_file}
 			break
 		done
 	fi


### PR DESCRIPTION
We want to check whether the shim is part of the "plain text" shims passed to the daemonset (meaning, checking against `$SHIMS`).  Before this fix we were checking against `$shims`, which is an array of shims instead of a string, resulting on a broken check.

Fixes: #8732