### PR TITLE
ci: test dragonball stability and cri-containerd

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -417,6 +417,8 @@ function enabling_hypervisor() {
 	declare -r DEST_KATA_CONFIG="${CONFIG_DIR}/configuration.toml"
 
 	sudo ln -sf "${SRC_HYPERVISOR_CONFIG}" "${DEST_KATA_CONFIG}"
+
+	export KATA_CONFIG_PATH="${DEST_KATA_CONFIG}"
 }
 
 

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -61,11 +61,6 @@ function run() {
 
 	enabling_hypervisor
 
-	if [ "${KATA_HYPERVISOR}" = "dragonball" ]; then
-		echo "Skipping test for ${KATA_HYPERVISOR}"
-		return 0
-	fi
-
 	bash -c ${cri_containerd_dir}/integration-tests.sh
 }
 

--- a/tests/stability/gha-run.sh
+++ b/tests/stability/gha-run.sh
@@ -32,11 +32,6 @@ function install_dependencies() {
 function run() {
 	info "Running soak parallel stability tests using ${KATA_HYPERVISOR} hypervisor"
 
-	if [ "${KATA_HYPERVISOR}" = "dragonball" ]; then
-		echo "Skipping test for ${KATA_HYPERVISOR}"
-		return 0
-	fi
-
 	export ITERATIONS=2 MAX_CONTAINERS=20
 	bash "${stability_dir}/soak_parallel_rm.sh"
 


### PR DESCRIPTION
CI: make CI work for dragonball to test stability and cri-containerd
It needs to remove the skip setting, and make it work for dragonball.
bugfix when CI running cri-containerd

Fixes https://github.com/kata-containers/kata-containers/issues/8746