### PR TITLE
runtime-rs: fixup the of bridge vfio device between runtime-rs and dr…

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -137,13 +137,10 @@ impl DragonballInner {
             0
         };
 
-        let guest_dev_id = if let Some(pci_path) = primary_device.guest_pci_path {
-            // safe here, dragonball's pci device directly connects to root bus.
-            // usually, it has been assigned in vfio device manager.
-            pci_path.get_device_slot().unwrap().0
-        } else {
-            0
-        };
+        // It's safe to unwrap the guest_pci_path and get device slot,
+        // As it has been assigned in vfio device manager.
+        let pci_path = primary_device.guest_pci_path.unwrap();
+        let guest_dev_id = pci_path.get_device_slot().unwrap().0;
 
         info!(
             sl!(),

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -19,7 +19,10 @@ use dragonball::{
         InstanceInfo, InstanceState, NetworkInterfaceConfig, VcpuResizeInfo, VmmAction,
         VmmActionError, VmmData, VmmRequest, VmmResponse, VmmService, VsockDeviceConfigInfo,
     },
-    device_manager::{balloon_dev_mgr::BalloonDeviceConfigInfo, mem_dev_mgr::MemDeviceConfigInfo},
+    device_manager::{
+        balloon_dev_mgr::BalloonDeviceConfigInfo, mem_dev_mgr::MemDeviceConfigInfo,
+        vfio_dev_mgr::HostDeviceConfig,
+    },
     vm::VmConfigInfo,
     Vmm,
 };
@@ -192,6 +195,30 @@ impl VmmInstance {
             return Ok(vm_config);
         }
         Err(anyhow!("Failed to get machine info"))
+    }
+
+    pub fn insert_host_device(&self, device_cfg: HostDeviceConfig) -> Result<()> {
+        self.handle_request_with_retry(Request::Sync(VmmAction::InsertHostDevice(
+            device_cfg.clone(),
+        )))
+        .with_context(|| format!("Failed to insert host device {:?}", device_cfg))?;
+        Ok(())
+    }
+
+    pub fn prepare_remove_host_device(&self, id: &str) -> Result<()> {
+        info!(sl!(), "prepare to remove host device {}", id);
+        self.handle_request(Request::Sync(VmmAction::PrepareRemoveHostDevice(
+            id.to_string(),
+        )))
+        .with_context(|| format!("Prepare to remove host device {:?} failed", id))?;
+        Ok(())
+    }
+
+    pub fn remove_host_device(&self, id: &str) -> Result<()> {
+        info!(sl!(), "remove host device {}", id);
+        self.handle_request(Request::Sync(VmmAction::RemoveHostDevice(id.to_string())))
+            .with_context(|| format!("Failed to remove host device {:?}", id))?;
+        Ok(())
     }
 
     pub fn insert_block_device(&self, device_cfg: BlockDeviceConfigInfo) -> Result<()> {


### PR DESCRIPTION
runtime-rs: bridge the vfio device between runtime-rs and dragonball

Previously, Dragonball did not support PCI device hot-plugging or
VFIO device passthrough. Therefore, the runtime-rs support for
Dragonball was incomplete. it is time to complete it so that users
can use Dragonball's PCI hot-plugging and VFIO passthrough capabilities.

Fixes: #8748