### PR TITLE
runtime: Reduce the mount points with namespace isolation

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -191,6 +191,27 @@ func newCommand(ctx context.Context, id, containerdBinary, containerdAddress str
 	return cmd, nil
 }
 
+func setupMntNs() error {
+	err := unix.Unshare(unix.CLONE_NEWNS)
+	if err != nil {
+		return err
+	}
+
+	err = unix.Mount("", "/", "", unix.MS_REC|unix.MS_SLAVE, "")
+	if err != nil {
+		err = fmt.Errorf("failed to mount with slave: %v", err)
+		return err
+	}
+
+	err = unix.Mount("", "/", "", unix.MS_REC|unix.MS_SHARED, "")
+	if err != nil {
+		err = fmt.Errorf("failed to mount with shared: %v", err)
+		return err
+	}
+
+	return nil
+}
+
 // StartShim is a binary call that starts a kata shimv2 service which will
 // implement the ShimV2 APIs such as create/start/update etc containers.
 func (s *service) StartShim(ctx context.Context, opts cdshim.StartOpts) (_ string, retErr error) {
@@ -253,6 +274,10 @@ func (s *service) StartShim(ctx context.Context, opts cdshim.StartOpts) (_ strin
 		if err := utils.Create(utils.ProcessGroup); err != nil {
 			return "", errors.Wrap(err, "enable sched core support")
 		}
+	}
+
+	if err := setupMntNs(); err != nil {
+		return "", err
 	}
 
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
We notice a 100% CPU load `systemd` process in the `host` when deploying more than 400 Kata Containers Pods (using go runtime) through k8s in one node, as described in issue #8758 .

Inspired by rust runtime, we add the mount namespace isolation to go runtime, and it can prevent the `systemd` process from seeing more mounts, thereby reducing the burden on the `systemd`, making it faster to deploy more Pods.

Considering the runtime-rs VMMs are under heavy developments, adding such isolation is still useful for many user-cases.

Fixes: #8758