### PR TITLE
metrics: Improve iperf3 cleanup

### DIFF
--- a/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+++ b/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
@@ -213,8 +213,10 @@ function iperf3_start_deployment() {
 function iperf3_deployment_cleanup() {
 	info "Iperf: deleting deployments and services"
 	rm -rf "${iperf_file}"
-	kubectl delete -f "${IPERF_DAEMONSET}"
-	kubectl delete -f "${IPERF_DEPLOYMENT}"
+	kubectl delete deployment iperf3-server-deployment
+	kubectl delete service iperf3-server
+	kubectl delete daemonset iperf3-clients
+	kubectl delete pods "${client_pod_name}"
 	kill_kata_components && sleep 1
 	kill_kata_components
 	check_processes


### PR DESCRIPTION
This PR improves the iperf3 cleanup to ensure all the components are being deleted properly to avoid the random failures of leaving the iperf3 clients on the kata metrics CI.

Fixes #8765