### PR TITLE
bugfix and refactor device increate count

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -20,6 +20,7 @@ use crate::{
     device::{
         pci_path::PciPath,
         topology::{do_add_pcie_endpoint, PCIeTopology},
+        util::do_increase_count,
         Device, DeviceType, PCIeDevice,
     },
     register_pcie_device, unregister_pcie_device, update_pcie_device, Hypervisor as hypervisor,
@@ -522,18 +523,7 @@ impl Device for VfioDevice {
     }
 
     async fn increase_attach_count(&mut self) -> Result<bool> {
-        match self.attach_count {
-            0 => {
-                // do real attach
-                self.attach_count += 1;
-                Ok(false)
-            }
-            std::u64::MAX => Err(anyhow!("device was attached too many times")),
-            _ => {
-                self.attach_count += 1;
-                Ok(true)
-            }
-        }
+        do_increase_count(&mut self.attach_count)
     }
 
     async fn decrease_attach_count(&mut self) -> Result<bool> {

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -20,7 +20,7 @@ use crate::{
     device::{
         pci_path::PciPath,
         topology::{do_add_pcie_endpoint, PCIeTopology},
-        util::do_increase_count,
+        util::{do_decrease_count, do_increase_count},
         Device, DeviceType, PCIeDevice,
     },
     register_pcie_device, unregister_pcie_device, update_pcie_device, Hypervisor as hypervisor,
@@ -527,18 +527,7 @@ impl Device for VfioDevice {
     }
 
     async fn decrease_attach_count(&mut self) -> Result<bool> {
-        match self.attach_count {
-            0 => Err(anyhow!("detaching a device that wasn't attached")),
-            1 => {
-                // do real wrok
-                self.attach_count -= 1;
-                Ok(false)
-            }
-            _ => {
-                self.attach_count -= 1;
-                Ok(true)
-            }
-        }
+        do_decrease_count(&mut self.attach_count)
     }
 
     async fn get_device_info(&self) -> DeviceType {

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -456,7 +456,13 @@ impl Device for VfioDevice {
             .await
             .context("failed to increase attach count")?
         {
-            return Err(anyhow!("attach count increased failed as some reason."));
+            warn!(
+                sl!(),
+                "The device {:?} is not allowed to be attached more than one times.",
+                self.device_id
+            );
+
+            return Ok(());
         }
 
         // do add device for vfio deivce

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user_blk.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user_blk.rs
@@ -9,7 +9,7 @@ use async_trait::async_trait;
 
 use super::VhostUserConfig;
 use crate::{
-    device::{topology::PCIeTopology, Device, DeviceType},
+    device::{topology::PCIeTopology, util::do_increase_count, Device, DeviceType},
     Hypervisor as hypervisor,
 };
 
@@ -104,18 +104,7 @@ impl Device for VhostUserBlkDevice {
     }
 
     async fn increase_attach_count(&mut self) -> Result<bool> {
-        match self.attach_count {
-            0 => {
-                // do real attach
-                self.attach_count += 1;
-                Ok(false)
-            }
-            std::u64::MAX => Err(anyhow!("device was attached too many times")),
-            _ => {
-                self.attach_count += 1;
-                Ok(true)
-            }
-        }
+        do_increase_count(&mut self.attach_count)
     }
 
     async fn decrease_attach_count(&mut self) -> Result<bool> {

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user_blk.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user_blk.rs
@@ -4,12 +4,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 
 use super::VhostUserConfig;
 use crate::{
-    device::{topology::PCIeTopology, util::do_increase_count, Device, DeviceType},
+    device::{
+        topology::PCIeTopology,
+        util::{do_decrease_count, do_increase_count},
+        Device, DeviceType,
+    },
     Hypervisor as hypervisor,
 };
 
@@ -108,17 +112,6 @@ impl Device for VhostUserBlkDevice {
     }
 
     async fn decrease_attach_count(&mut self) -> Result<bool> {
-        match self.attach_count {
-            0 => Err(anyhow!("detaching a device that wasn't attached")),
-            1 => {
-                // do real wrok
-                self.attach_count -= 1;
-                Ok(false)
-            }
-            _ => {
-                self.attach_count -= 1;
-                Ok(true)
-            }
-        }
+        do_decrease_count(&mut self.attach_count)
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk.rs
@@ -6,11 +6,12 @@
 
 use crate::device::pci_path::PciPath;
 use crate::device::topology::PCIeTopology;
+use crate::device::util::do_decrease_count;
 use crate::device::util::do_increase_count;
 use crate::device::Device;
 use crate::device::DeviceType;
 use crate::Hypervisor as hypervisor;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result};
 use async_trait::async_trait;
 
 /// VIRTIO_BLOCK_PCI indicates block driver is virtio-pci based
@@ -140,17 +141,6 @@ impl Device for BlockDevice {
     }
 
     async fn decrease_attach_count(&mut self) -> Result<bool> {
-        match self.attach_count {
-            0 => Err(anyhow!("detaching a device that wasn't attached")),
-            1 => {
-                // do real wrok
-                self.attach_count -= 1;
-                Ok(false)
-            }
-            _ => {
-                self.attach_count -= 1;
-                Ok(true)
-            }
-        }
+        do_decrease_count(&mut self.attach_count)
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk.rs
@@ -6,6 +6,7 @@
 
 use crate::device::pci_path::PciPath;
 use crate::device::topology::PCIeTopology;
+use crate::device::util::do_increase_count;
 use crate::device::Device;
 use crate::device::DeviceType;
 use crate::Hypervisor as hypervisor;
@@ -135,18 +136,7 @@ impl Device for BlockDevice {
     }
 
     async fn increase_attach_count(&mut self) -> Result<bool> {
-        match self.attach_count {
-            0 => {
-                // do real attach
-                self.attach_count += 1;
-                Ok(false)
-            }
-            std::u64::MAX => Err(anyhow!("device was attached too many times")),
-            _ => {
-                self.attach_count += 1;
-                Ok(true)
-            }
-        }
+        do_increase_count(&mut self.attach_count)
     }
 
     async fn decrease_attach_count(&mut self) -> Result<bool> {


### PR DESCRIPTION
    runtime-rs: bugfix incorrect use of refcount before vfio attach
    
    When there's a pod with multiple containers, there may be case that
    attach point more than 2, we should not return Err in that case when
    we are doing attach ops, but just return Ok.

    runtime-rs: introduce dedicated function do_increase_count/do_decrease_count
    
    Since there are many implementations of reference counting in the
    drivers, all of which have the same implementation, we should try
    to reduce such duplicated code as much as possible. Therefore, a
    new function is introduced to solve the problem of duplicated code.

    runtime-rs: refactor increase_attach_count with do_increase_count/do_decrease_count
    
    Try to reduce duplicated code in increase_attach_count with public
    new function do_increase_count/do_decrease_count.

    Fixes: #8738