### PR TITLE
tests: Add check images as part of the install dependencies function for stability tests

### DIFF
--- a/tests/stability/gha-run.sh
+++ b/tests/stability/gha-run.sh
@@ -12,6 +12,8 @@ set -o pipefail
 kata_tarball_dir="${2:-kata-artifacts}"
 stability_dir="$(dirname "$(readlink -f "$0")")"
 source "${stability_dir}/../common.bash"
+DOCKERFILE="${SCRIPT_PATH}/stressng_dockerfile/Dockerfile"
+IMAGE="docker.io/library/local-stressng:latest"
 
 function install_dependencies() {
 	info "Installing the dependencies needed for running the containerd-stability tests"
@@ -27,6 +29,7 @@ function install_dependencies() {
 
 	ensure_yq
 	install_docker
+	check_ctr_images "${IMAGE}" "${DOCKERFILE}"
 }
 
 function run() {

--- a/tests/stability/gha-run.sh
+++ b/tests/stability/gha-run.sh
@@ -12,7 +12,8 @@ set -o pipefail
 kata_tarball_dir="${2:-kata-artifacts}"
 stability_dir="$(dirname "$(readlink -f "$0")")"
 source "${stability_dir}/../common.bash"
-DOCKERFILE="${SCRIPT_PATH}/stressng_dockerfile/Dockerfile"
+source "${stability_dir}/../metrics/lib/common.bash"
+DOCKERFILE="${stability_dir}/stressng_dockerfile/Dockerfile"
 IMAGE="docker.io/library/local-stressng:latest"
 
 function install_dependencies() {

--- a/tests/stability/stressng.sh
+++ b/tests/stability/stressng.sh
@@ -11,8 +11,6 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../metrics/lib/common.bash"
 
 PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
-DOCKERFILE="${SCRIPT_PATH}/stressng_dockerfile/Dockerfile"
-IMAGE="docker.io/library/local-stressng:latest"
 CONTAINER_NAME="${CONTAINER_NAME:-stressng_test}"
 
 function main() {
@@ -20,7 +18,6 @@ function main() {
 
 	init_env
 	check_cmds "${cmds[@]}"
-	check_ctr_images "${IMAGE}" "${DOCKERFILE}"
 	sudo -E ctr run -d --runtime "${CTR_RUNTIME}" "${IMAGE}" "${CONTAINER_NAME}" sh -c "${PAYLOAD_ARGS}"
 
 	# Run 1 iomix stressor (mix of I/O operations) for 20 seconds with verbose output


### PR DESCRIPTION
This PR adds the check images as part of the install dependencies function for stability tests in order to avoid random failures due to timeouts when trying to install and build the image for stress-ng test.