### PR TITLE
tests: Add check images as part of install dependencies

### DIFF
--- a/tests/stability/gha-run.sh
+++ b/tests/stability/gha-run.sh
@@ -12,6 +12,9 @@ set -o pipefail
 kata_tarball_dir="${2:-kata-artifacts}"
 stability_dir="$(dirname "$(readlink -f "$0")")"
 source "${stability_dir}/../common.bash"
+source "${stability_dir}/../metrics/lib/common.bash"
+DOCKERFILE="${stability_dir}/stressng_dockerfile/Dockerfile"
+IMAGE="docker.io/library/local-stressng:latest"
 
 function install_dependencies() {
 	info "Installing the dependencies needed for running the containerd-stability tests"
@@ -27,6 +30,7 @@ function install_dependencies() {
 
 	ensure_yq
 	install_docker
+	check_ctr_images "${IMAGE}" "${DOCKERFILE}"
 }
 
 function run() {


### PR DESCRIPTION
To avoid random failures while trying to build and install the stressng image, this PR moves that step as part of the install dependencies in order to move the stability tests and avoid timeouts.

Fixes #8787