### PR TITLE
versions: Update runc version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -281,7 +281,7 @@ externals:
     uscan-url: >-
       https://github.com/opencontainers/runc/tags
       .*/v?(\d\S+)\.tar\.gz
-    version: "v1.1.4"
+    version: "v1.1.11"
 
   nydus:
     description: "Nydus image acceleration service"


### PR DESCRIPTION
This PR updates the runc version to 1.1.11 which includes the following improvements

- Fix several issues with userns path handling.
- Support memory.peak and memory.swap.peak in cgroups v2. Add swapOnlyUsage in MemoryStats. This field reports swap-only usage. For cgroupv1, Usage and Failcnt are set by subtracting memory usage from memory+swap usage. For cgroupv2, Usage, Limit, and MaxUsage are set.
- build(deps): bump github.com/cyphar/filepath-securejoin.

Fixes #8795