### PR TITLE
runtime-rs: ch: Unbreak CH driver

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
@@ -73,6 +73,9 @@ pub struct CloudHypervisorInner {
     // If the version of CH does not provide these details, the value will be
     // None.
     pub(crate) ch_features: Option<Vec<String>>,
+
+    /// Size of memory block of guest OS in MB (currently unused)
+    pub(crate) _guest_memory_block_size_mb: u32,
 }
 
 const CH_DEFAULT_TIMEOUT_SECS: u32 = 10;
@@ -112,6 +115,7 @@ impl CloudHypervisorInner {
             tasks: None,
             guest_protection_to_use: GuestProtection::NoProtection,
             ch_features: None,
+            _guest_memory_block_size_mb: 0,
         }
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -744,20 +744,24 @@ impl CloudHypervisorInner {
         Err(anyhow!("CH hypervisor metrics not implemented - see https://github.com/kata-containers/kata-containers/issues/8800"))
     }
 
-    pub(crate) fn set_capabilities(&mut self, _flag: CapabilityBits) {
-        todo!()
+    pub(crate) fn set_capabilities(&mut self, flag: CapabilityBits) {
+        let mut caps = Capabilities::default();
+
+        caps.set(flag)
     }
 
-    pub(crate) fn set_guest_memory_block_size(&mut self, _size: u32) {
-        todo!()
+    pub(crate) fn set_guest_memory_block_size(&mut self, size: u32) {
+        self._guest_memory_block_size_mb = size;
     }
 
     pub(crate) fn guest_memory_block_size_mb(&self) -> u32 {
-        todo!()
+        self._guest_memory_block_size_mb
     }
 
     pub(crate) fn resize_memory(&self, _new_mem_mb: u32) -> Result<(u32, MemoryConfig)> {
-        todo!()
+        warn!(sl!(), "CH memory resize not implemented - see https://github.com/kata-containers/kata-containers/issues/8801");
+
+        Ok((0, MemoryConfig::default()))
     }
 }
 

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -741,7 +741,7 @@ impl CloudHypervisorInner {
     }
 
     pub(crate) async fn get_hypervisor_metrics(&self) -> Result<String> {
-        todo!()
+        Err(anyhow!("CH hypervisor metrics not implemented - see https://github.com/kata-containers/kata-containers/issues/8800"))
     }
 
     pub(crate) fn set_capabilities(&mut self, _flag: CapabilityBits) {


### PR DESCRIPTION
Unfortunately, PR #6876 broke running runtime-rs with Cloud Hypervisor so add minimal implementations of the new APIs to allow CH to be used with runtime-rs.

Full implementations will be added later on issues #8800, #8801, and #8802.