### PR TITLE
gha: Limit jobs to run after "ok-to-test¨ is set

### DIFF
--- a/.github/workflows/add-pr-sizing-label.yaml
+++ b/.github/workflows/add-pr-sizing-label.yaml
@@ -11,6 +11,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - labeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -18,6 +19,7 @@ concurrency:
 
 jobs:
   add-pr-size-label:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/auto-backport.yaml
+++ b/.github/workflows/auto-backport.yaml
@@ -9,6 +9,7 @@ concurrency:
 jobs:
   backport:
     name: Backport PR
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     runs-on: ubuntu-latest
     if: |
       github.event.pull_request.merged == true

--- a/.github/workflows/move-issues-to-in-progress.yaml
+++ b/.github/workflows/move-issues-to-in-progress.yaml
@@ -10,10 +10,12 @@ on:
     types:
       - opened
       - reopened
+      - labeled
 
 jobs:
   move-linked-issues-to-in-progress:
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     steps:
       - name: Install hub
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}

--- a/.github/workflows/require-pr-porting-labels.yaml
+++ b/.github/workflows/require-pr-porting-labels.yaml
@@ -11,7 +11,6 @@ on:
       - opened
       - reopened
       - labeled
-      - unlabeled
     branches:
       - main
 
@@ -22,6 +21,7 @@ concurrency:
 jobs:
   check-pr-porting-labels:
     runs-on: ubuntu-latest
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     steps:
       - name: Install hub
         if: ${{ !contains(github.event.pull_request.labels.*.name, 'force-skip-ci') }}

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -5,6 +5,7 @@ on:
       - edited
       - reopened
       - synchronize
+      - labeled
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -126,6 +127,7 @@ jobs:
           RUST_BACKTRACE: "1"
 
   build-checks-depending-on-kvm:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     runs-on: garm-ubuntu-2004-smaller
     strategy:
       fail-fast: false


### PR DESCRIPTION
Let's limit a variety of tests that are either using the `pull_request_target` event, or running on Azure instances, to only be triggered after an `okay-to-test` label is set.

This helps us to avoid leaking the GITHUB_TOKEN in case a malicious submitter tries to do so.

Fixes: #8805


Reported-by: Lukas Jokubauskas <sakul1234@proton.me>