### PR TITLE
TDX: Update QEMU to tdx-qemu-next-2023.9.21-v8.1.0 from https://github.com/intel/qemu-tdx

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -378,18 +378,6 @@ ifneq (,$(QEMUCMD))
     KERNELNAME = $(call MAKE_KERNEL_NAME,$(KERNELTYPE))
     KERNELPATH = $(KERNELDIR)/$(KERNELNAME)
 
-    KERNELSEVTYPE = compressed
-    KERNELSEVNAME = $(call MAKE_KERNEL_SEV_NAME,$(KERNELSEVTYPE))
-    KERNELSEVPATH = $(KERNELDIR)/$(KERNELSEVNAME)
-
-    KERNELTDXTYPE = compressed
-    KERNELTDXNAME = $(call MAKE_KERNEL_TDX_NAME,$(KERNELTDXTYPE))
-    KERNELTDXPATH = $(KERNELDIR)/$(KERNELTDXNAME)
-
-    KERNELSNPTYPE = compressed
-    KERNELSNPNAME = $(call MAKE_KERNEL_SNP_NAME,$(KERNELSNPTYPE))
-    KERNELSNPPATH = $(KERNELDIR)/$(KERNELSNPNAME)
-
     KERNELCONFIDENTIALTYPE = compressed
     KERNELCONFIDENTIALNAME = $(call MAKE_KERNEL_CONFIDENTIAL_NAME,$(KERNELCONFIDENTIALTYPE))
     KERNELCONFIDENTIALPATH = $(KERNELDIR)/$(KERNELCONFIDENTIALNAME)
@@ -590,9 +578,6 @@ USER_VARS += KERNELTYPE_CLH
 USER_VARS += KERNELPATH_ACRN
 USER_VARS += KERNELPATH
 USER_VARS += KERNELCONFIDENTIALPATH
-USER_VARS += KERNELSEVPATH
-USER_VARS += KERNELTDXPATH
-USER_VARS += KERNELSNPPATH
 USER_VARS += KERNELSEPATH
 USER_VARS += KERNELPATH_CLH
 USER_VARS += KERNELPATH_FC
@@ -776,19 +761,6 @@ endef
 
 define MAKE_KERNEL_VIRTIOFS_NAME
 $(if $(findstring uncompressed,$1),vmlinux-virtiofs.container,vmlinuz-virtiofs.container)
-endef
-
-define MAKE_KERNEL_SEV_NAME
-$(if $(findstring uncompressed,$1),vmlinux-sev.container,vmlinuz-sev.container)
-endef
-
-define MAKE_KERNEL_TDX_NAME
-$(if $(findstring uncompressed,$1),vmlinux-tdx.container,vmlinuz-tdx.container)
-endef
-
-# SNP configuration uses the SEV kernel
-define MAKE_KERNEL_SNP_NAME
-$(if $(findstring uncompressed,$1),vmlinux-sev.container,vmlinuz-sev.container)
 endef
 
 define MAKE_KERNEL_CONFIDENTIAL_NAME

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -390,6 +390,10 @@ ifneq (,$(QEMUCMD))
     KERNELSNPNAME = $(call MAKE_KERNEL_SNP_NAME,$(KERNELSNPTYPE))
     KERNELSNPPATH = $(KERNELDIR)/$(KERNELSNPNAME)
 
+    KERNELCONFIDENTIALTYPE = compressed
+    KERNELCONFIDENTIALNAME = $(call MAKE_KERNEL_CONFIDENTIAL_NAME,$(KERNELCONFIDENTIALTYPE))
+    KERNELCONFIDENTIALPATH = $(KERNELDIR)/$(KERNELCONFIDENTIALNAME)
+
     KERNELSENAME = kata-containers-se.img
     KERNELSEPATH = $(KERNELDIR)/$(KERNELSENAME)
 endif
@@ -585,6 +589,7 @@ USER_VARS += KERNELTYPE_ACRN
 USER_VARS += KERNELTYPE_CLH
 USER_VARS += KERNELPATH_ACRN
 USER_VARS += KERNELPATH
+USER_VARS += KERNELCONFIDENTIALPATH
 USER_VARS += KERNELSEVPATH
 USER_VARS += KERNELTDXPATH
 USER_VARS += KERNELSNPPATH
@@ -784,6 +789,10 @@ endef
 # SNP configuration uses the SEV kernel
 define MAKE_KERNEL_SNP_NAME
 $(if $(findstring uncompressed,$1),vmlinux-sev.container,vmlinuz-sev.container)
+endef
+
+define MAKE_KERNEL_CONFIDENTIAL_NAME
+$(if $(findstring uncompressed,$1),vmlinux-confidential.container,vmlinuz-confidential.container)
 endef
 
 GENERATED_FILES += pkg/katautils/config-settings.go

--- a/src/runtime/config/configuration-qemu-sev.toml.in
+++ b/src/runtime/config/configuration-qemu-sev.toml.in
@@ -12,7 +12,7 @@
 
 [hypervisor.qemu]
 path = "@QEMUPATH@"
-kernel = "@KERNELSEVPATH@"
+kernel = "@KERNELCONFIDENTIALPATH@"
 initrd = "@INITRDSEVPATH@"
 machine_type = "@MACHINETYPE@"
 

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -14,7 +14,7 @@
 
 [hypervisor.qemu]
 path = "@QEMUSNPPATH@"
-kernel = "@KERNELSNPPATH@"
+kernel = "@KERNELCONFIDENTIALPATH@"
 #image = "@IMAGEPATH@"
 initrd = "@INITRDSEVPATH@"
 machine_type = "@MACHINETYPE@"

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -13,7 +13,7 @@
 
 [hypervisor.qemu]
 path = "@QEMUTDXPATH@"
-kernel = "@KERNELTDXPATH@"
+kernel = "@KERNELCONFIDENTIALPATH@"
 image = "@IMAGETDXPATH@"
 # initrd = "@INITRDPATH@"
 machine_type = "@MACHINETYPE@"

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -141,16 +141,9 @@ const (
 func isDimmSupported(config *Config) bool {
 	switch runtime.GOARCH {
 	case "amd64", "386", "ppc64le", "arm64":
-		if config != nil {
-			if config.Machine.Type == MachineTypeMicrovm {
-				// microvm does not support NUMA
-				return false
-			}
-			if config.Knobs.MemFDPrivate {
-				// TDX guests rely on MemFD Private, which
-				// does not have NUMA support yet
-				return false
-			}
+		if config != nil && config.Machine.Type == MachineTypeMicrovm {
+			// microvm does not support NUMA
+			return false
 		}
 		return true
 	default:
@@ -2653,9 +2646,6 @@ type Knobs struct {
 	// MemPrealloc will allocate all the RAM upfront
 	MemPrealloc bool
 
-	// Private Memory FD meant for private memory map/unmap.
-	MemFDPrivate bool
-
 	// FileBackedMem requires Memory.Size and Memory.Path of the VM to
 	// be set.
 	FileBackedMem bool
@@ -3025,13 +3015,10 @@ func (config *Config) appendMemoryKnobs() {
 		return
 	}
 	var objMemParam, numaMemParam string
-
 	dimmName := "dimm1"
 	if config.Knobs.HugePages {
 		objMemParam = "memory-backend-file,id=" + dimmName + ",size=" + config.Memory.Size + ",mem-path=/dev/hugepages"
 		numaMemParam = "node,memdev=" + dimmName
-	} else if config.Knobs.MemFDPrivate {
-		objMemParam = "memory-backend-memfd-private,id=" + dimmName + ",size=" + config.Memory.Size
 	} else if config.Knobs.FileBackedMem && config.Memory.Path != "" {
 		objMemParam = "memory-backend-file,id=" + dimmName + ",size=" + config.Memory.Size + ",mem-path=" + config.Memory.Path
 		numaMemParam = "node,memdev=" + dimmName
@@ -3040,6 +3027,9 @@ func (config *Config) appendMemoryKnobs() {
 		numaMemParam = "node,memdev=" + dimmName
 	}
 
+	if config.Knobs.Private {
+		objMemParam += ",private=on"
+	}
 	if config.Knobs.MemShared {
 		objMemParam += ",share=on"
 	}

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -2678,6 +2678,10 @@ type Knobs struct {
 
 	// IOMMUPlatform will enable IOMMU for supported devices
 	IOMMUPlatform bool
+
+	// Whether private memory should be used or not
+	// This is required by TDX, at least.
+	Private bool
 }
 
 // IOThread allows IO to be performed on a separate thread.

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -586,10 +586,11 @@ func TestAppendMemoryFileBackedMem(t *testing.T) {
 	knobs := Knobs{
 		FileBackedMem: true,
 		MemShared:     false,
+		Private:       false,
 	}
 	objMemString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=foobar"
 	numaMemString := "-numa node,memdev=dimm1"
-	memBackendString := "-machine memory-backend=dimm1"
+	memBackendString := "-machine memory-backend=dimm1,private=on"
 
 	knobsString := objMemString + " "
 	if isDimmSupported(nil) {
@@ -628,29 +629,6 @@ func TestAppendMemoryFileBackedMemPrealloc(t *testing.T) {
 	} else {
 		knobsString += memBackendString
 	}
-
-	testConfigAppend(conf, knobs, memString+" "+knobsString, t)
-}
-
-func TestAppendMemoryBackedMemFdPrivate(t *testing.T) {
-	conf := &Config{
-		Memory: Memory{
-			Size:  "1G",
-			Slots: 8,
-		},
-	}
-	memString := "-m 1G,slots=8"
-	testConfigAppend(conf, conf.Memory, memString, t)
-
-	knobs := Knobs{
-		MemFDPrivate: true,
-		MemShared:    false,
-	}
-	objMemString := "-object memory-backend-memfd-private,id=dimm1,size=1G"
-	memBackendString := "-machine memory-backend=dimm1"
-
-	knobsString := objMemString + " "
-	knobsString += memBackendString
 
 	testConfigAppend(conf, knobs, memString+" "+knobsString, t)
 }

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -629,13 +629,6 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
 			// headaches in the future.
 			knobs.FileBackedMem = false
 			knobs.MemShared = false
-
-			// SMP is currently broken with TDX 1.5, and
-			// we must ensure we use something like:
-			// `...,sockets=1,cores=numvcpus,threads=1,...`
-			smp.Sockets = 1
-			smp.Cores = q.config.NumVCPUs()
-			smp.Threads = 1
 		}
 	}
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -620,15 +620,9 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
 		// on the hypervisor specific code, as availableGuestProtection()
 		// has been called earlier and we know we have the value stored.
 		if q.arch.getProtection() == tdxProtection {
-			knobs.MemFDPrivate = true
 
-			// In case Nydus or VirtioFS is used, which may become a reality
-			// in the future, whenever we get those hardened for TDX, those
-			// knobs below would be automatically set.  Let's make sure we
-			// pre-emptively disable them, and with that we can avoid some
-			// headaches in the future.
-			knobs.FileBackedMem = false
-			knobs.MemShared = false
+			// TDX relies on ",private=on" passed to the memory object.
+			knobs.Private = true
 		}
 	}
 

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -26,7 +26,6 @@ BASE_TARBALLS = serial-targets \
 	kernel-nvidia-gpu-snp-tarball \
 	kernel-nvidia-gpu-tdx-experimental-tarball \
 	kernel-tarball \
-	kernel-tdx-experimental-tarball \
 	nydus-tarball \
 	ovmf-sev-tarball \
 	ovmf-tarball \
@@ -112,12 +111,6 @@ kernel-tarball:
 	${MAKE} $@-build
 
 kernel-confidential-tarball:
-	${MAKE} $@-build
-
-kernel-tdx-experimental-tarball:
-	${MAKE} $@-build
-
-kernel-sev-tarball:
 	${MAKE} $@-build
 
 nydus-tarball:

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -153,7 +153,7 @@ rootfs-image-tdx-tarball: kernel-tdx-experimental-tarball
 rootfs-initrd-mariner-tarball:
 	${MAKE} $@-build
 
-rootfs-initrd-sev-tarball: kernel-sev-tarball
+rootfs-initrd-sev-tarball: kernel-confidential-tarball
 	${MAKE} $@-build
 
 rootfs-initrd-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -98,8 +98,6 @@ options:
 	kernel-nvidia-gpu
 	kernel-nvidia-gpu-snp
 	kernel-nvidia-gpu-tdx-experimental
-	kernel-sev-tarball
-	kernel-tdx-experimental
 	nydus
 	ovmf
 	ovmf-sev
@@ -381,29 +379,6 @@ install_kernel_nvidia_gpu_tdx_experimental() {
 		"assets.kernel-tdx-experimental.version" \
 		"kernel-nvidia-gpu-tdx-experimental" \
 		"-x tdx -g nvidia -u ${kernel_url} -H deb"
-}
-
-#Install experimental TDX kernel asset
-install_kernel_tdx_experimental() {
-	local kernel_url="$(get_from_kata_deps assets.kernel-tdx-experimental.url)"
-
-	export MEASURED_ROOTFS=yes
-
-	install_kernel_helper \
-		"assets.kernel-tdx-experimental.version" \
-		"kernel-tdx-experimental" \
-		"-x tdx -u ${kernel_url}"
-}
-
-#Install sev kernel asset
-install_kernel_sev() {
-	info "build sev kernel"
-	local kernel_url="$(get_from_kata_deps assets.kernel.sev.url)"
-
-	install_kernel_helper \
-		"assets.kernel.sev.version" \
-		"kernel-sev" \
-		"-x sev -u ${kernel_url}"
 }
 
 install_qemu_helper() {
@@ -757,7 +732,6 @@ handle_build() {
 		install_kernel
 		install_kernel_confidential
 		install_kernel_dragonball_experimental
-		install_kernel_tdx_experimental
 		install_log_parser_rs
 		install_nydus
 		install_ovmf
@@ -800,10 +774,6 @@ handle_build() {
 	kernel-nvidia-gpu-snp) install_kernel_nvidia_gpu_snp;;
 
 	kernel-nvidia-gpu-tdx-experimental) install_kernel_nvidia_gpu_tdx_experimental;;
-
-	kernel-tdx-experimental) install_kernel_tdx_experimental ;;
-
-	kernel-sev) install_kernel_sev ;;
 
 	nydus) install_nydus ;;
 

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -322,17 +322,6 @@ generate_qemu_options() {
 	# Don't build the qemu-io, qemu-nbd and qemu-image tools
 	qemu_options+=(size:--disable-tools)
 
-	# Kata Containers may be configured to use the virtiofs daemon.
-	#
-	# But since QEMU 5.2 the daemon is built as part of the tools set
-	# (disabled with --disable-tools) thus it needs to be explicitely
-	# enabled.
-	#
-	# From Kata Containers 2.5.0-alpha2 all arches but powerpc have been
-	# using the new implementation of virtiofs daemon, which is not part
-	# of QEMU.
-	qemu_options+=(functionality:--disable-virtiofsd)
-
 	qemu_options+=(functionality:--enable-virtfs)
 
 	# Don't build linux-user bsd-user

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -58,8 +58,9 @@ RUN apt-get update && apt-get upgrade -y && \
 	    libseccomp-dev${DPKG_ARCH} \
 	    libseccomp2${DPKG_ARCH} \
 	    patch \
-	    python \
-	    python-dev \
+	    python3 \
+	    python3-dev \
+	    python3-venv \
 	    rsync \
 	    zlib1g-dev${DPKG_ARCH} && \
     if [ "${ARCH}" != s390x ]; then apt-get install -y --no-install-recommends libpmem-dev${DPKG_ARCH}; fi && \

--- a/versions.yaml
+++ b/versions.yaml
@@ -100,10 +100,9 @@ assets:
         .*/v?(\d\S+)\.tar\.gz
 
     qemu-tdx-experimental:
-      # yamllint disable-line rule:line-length
-      description: "QEMU with TDX support - based on https://github.com/intel/tdx-tools/releases/tag/2023ww15"
-      url: "https://github.com/kata-containers/qemu"
-      tag: "b67b00e6b4c7831a3f5bc684bc0df7a9bfd1bd56-plus-TDX-v1.10"
+      description: ¨QEMU with TDX support"
+      url: "https://github.com/intel/qemu-tdx"
+      tag: "tdx-qemu-next-2023.9.21-v8.1.0"
 
     qemu-snp-experimental:
       description: "QEMU with experimental SNP support (no UPM)"


### PR DESCRIPTION
qemu-tdx: Update to v8.1.0 + TDX patches

Let's update the QEMU to the one that's officially maintained by Intel
till all the TDX patches make their way upstream.

We've had to also update python to explicitly use python3 and add
python3-venv as part of the dependencies.

Fixes: #8810