### PR TITLE
dragonball: Remove unused definition

### DIFF
--- a/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_user/connection.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/vhost/vhost_user/connection.rs
@@ -25,8 +25,6 @@ use crate::{Error as VirtioError, Result as VirtioResult};
 
 enum EndpointProtocolFlags {
     ProtocolMq = 1,
-    #[cfg(feature = "vhost-user-blk")]
-    ProtocolBackend = 2,
 }
 
 pub(super) struct Listener {


### PR DESCRIPTION
`EndpointProtocolFlags::ProtocolBackend` is removed due to no reference.

Fixes: #8745