### PR TITLE
tests: cbl-mariner: disable k8s-oom.bats

### DIFF
--- a/tests/integration/kubernetes/k8s-oom.bats
+++ b/tests/integration/kubernetes/k8s-oom.bats
@@ -9,6 +9,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[ "${KATA_HOST_OS}" == "cbl-mariner" ] && skip "test not working see: see #8821"
+
 	pod_name="pod-oom"
 	get_pod_config_dir
 }
@@ -29,6 +31,8 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HOST_OS}" == "cbl-mariner" ] && skip "test not working see: see #8821"
+
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 	kubectl get "pod/$pod_name" -o yaml


### PR DESCRIPTION
Disable k8s-oom.bats on cbl-mariner until it passes more often.

Fixes: #8824