### PR TITLE
metrics: Remove iperf3 server protocol

### DIFF
--- a/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-deployment.yaml
+++ b/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-deployment.yaml
@@ -53,6 +53,5 @@ spec:
   selector:
     app: iperf3-server
   ports:
-  - protocol: TCP
-    port: 5201
+  - port: 5201
     targetPort: server


### PR DESCRIPTION
This PR removes the iperf3 server protocol as this server definition is also used for the UDP iperf3 benchmarks to avoid duplication of the same yaml files.

Fixes #8829