### PR TITLE
genpolicy: use root path from cbl-mariner Guest VM

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -1,7 +1,7 @@
 {
     "pause_container": {
         "Root": {
-            "Path": "$(cpath)/$(bundle-id)",
+            "Path": "$(cpath)/$(bundle-id)/rootfs",
             "Readonly": true
         },
         "Mounts": [
@@ -62,7 +62,7 @@
     },
     "other_container": {
         "Root": {
-            "Path": "$(cpath)/$(bundle-id)"
+            "Path": "$(cpath)/$(bundle-id)/rootfs"
         },
         "Mounts": [
             {

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -700,8 +700,9 @@ is_ip_other_byte(component) {
 
 # OCI root.Path
 allow_root_path(p_oci, i_oci, bundle_id) {
+    i_path := i_oci.Root.Path
     p_path1 := p_oci.Root.Path
-    print("allow_root_path: p_path1 =", p_path1)
+    print("allow_root_path: i_path =", i_path, "p_path1 =", p_path1)
 
     p_path2 := replace(p_path1, "$(cpath)", policy_data.common.cpath)
     print("allow_root_path: p_path2 =", p_path2)
@@ -709,7 +710,7 @@ allow_root_path(p_oci, i_oci, bundle_id) {
     p_path3 := replace(p_path2, "$(bundle-id)", bundle_id)
     print("allow_root_path: p_path3 =", p_path3)
 
-    p_path3 == i_oci.Root.Path
+    p_path3 == i_path
 
     print("allow_root_path: true")
 }


### PR DESCRIPTION
Adjust genpolicy-settings.json to match the container root path from the main branch + cbl-mariner Guest VMs.

This configuration might have to be adjusted again when other types of Guest VMs will be tested during CI using genpolicy, in the future.

Also, improve logging from allow_root_path(), to easier debug these issues in the future.

Fixes: #8835