### PR TITLE
genpolicy: temporarily disable allow_storages()

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -428,7 +428,8 @@ allow_by_bundle_or_sandbox_id(p_oci, i_oci, p_storages, i_storages) {
         allow_mount(p_oci, i_mount, bundle_id, sandbox_id)
     }
 
-    allow_storages(p_storages, i_storages, bundle_id, sandbox_id)
+    # TODO: enable allow_storages() after fixing https://github.com/kata-containers/kata-containers/issues/8833
+    # allow_storages(p_storages, i_storages, bundle_id, sandbox_id)
 
     print("allow_by_bundle_or_sandbox_id: true")
 }


### PR DESCRIPTION
Temporarily disable the allow_storages() rules, because they are based on tarfs snapshotter + container image integrity information that are not available yet in the main branch - see #8833.

Fixes: #8834