### PR TITLE
tests: Add containerd-shim-kata-qemu-tdx-v2 in kill kata function

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -230,7 +230,7 @@ function clean_env_ctr()
 function kill_kata_components() {
 	local ATTEMPTS=2
 	local TIMEOUT="30s"
-	local PID_NAMES=( "containerd-shim-kata-v2" "qemu-system-x86_64" "qemu-system-x86_64-tdx-experimental" "cloud-hypervisor" )
+	local PID_NAMES=( "containerd-shim-kata-v2" "containerd-shim-kata-qemu-tdx-v2" "qemu-system-x86_64" "qemu-system-x86_64-tdx-experimental" "cloud-hypervisor" )
 
 	sudo systemctl stop containerd
 	# iterate over the list of kata components and stop them


### PR DESCRIPTION
This PR adds containerd-shim-kata-qemu-tdx-v2 as part of the kata components to kill to avoid leaving components running and make sure that the environment is clean.

Fixes #8841