### PR TITLE
tests: start auto-generating the policy

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -751,6 +751,9 @@ function auto_generate_policy() {
 		if [ ! -z "${config_map_yaml_file}" ]; then
 			genpolicy_command+=" -c ${config_map_yaml_file}"
 		fi
+
+		find /opt/kata/ -ls
+
 		info "Executing: ${genpolicy_command}"
 		eval "${genpolicy_command}"
 	fi

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -12,6 +12,7 @@ kubernetes_dir="$(dirname "$(readlink -f "$0")")"
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
 # shellcheck disable=2154
 tools_dir="${repo_root_dir}/tools"
+kata_tarball_dir="${2:-kata-artifacts}"
 
 DOCKER_REGISTRY=${DOCKER_REGISTRY:-quay.io}
 DOCKER_REPO=${DOCKER_REPO:-kata-containers/kata-deploy-ci}
@@ -236,11 +237,6 @@ function cleanup() {
 	kubectl delete -f "${tools_dir}/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml"
 }
 
-install_kata_tools_placeholder() {
-	echo "Kata tools will be installed (for the genpolicy app)"\
-		"after CI picks up the gha yaml changes required to test that installation."
-}
-
 function main() {
 	export KATA_HOST_OS="${KATA_HOST_OS:-}"
 	export K8S_TEST_HOST_TYPE="${K8S_TEST_HOST_TYPE:-}"
@@ -256,7 +252,7 @@ function main() {
 		setup-crio) setup_crio ;;
 		deploy-k8s) deploy_k8s ;;
 		install-bats) install_bats ;;
-		install-kata-tools) install_kata_tools_placeholder ;;
+		install-kata-tools) install_kata_tools ;;
 		install-kubectl) install_kubectl ;;
 		get-cluster-credentials) get_cluster_credentials ;;
 		deploy-kata-aks) deploy_kata "aks" ;;

--- a/tests/integration/kubernetes/k8s-attach-handlers.bats
+++ b/tests/integration/kubernetes/k8s-attach-handlers.bats
@@ -16,16 +16,19 @@ setup() {
 
 	get_pod_config_dir
 	yaml_file="${pod_config_dir}/test-lifecycle-events.yaml"
-}
 
-@test "Running with postStart and preStop handlers" {
 	# Create yaml
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/lifecycle-events.yaml" > "${yaml_file}"
 
-	# TODO: disabled due to #8850
-	# auto_generate_policy "${yaml_file}"
+	# Add policy to yaml
+	display_message="cat /usr/share/message"
+	exec_command="sh -c ${display_message}"
+	test_settings_dir="$(enable_exec_in_policy "${exec_command}")"
+	auto_generate_policy "${test_settings_dir}" "${yaml_file}"
+}
 
+@test "Running with postStart and preStop handlers" {
 	# Create the pod with postStart and preStop handlers
 	kubectl create -f "${yaml_file}"
 
@@ -33,8 +36,9 @@ setup() {
 	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	# Check postStart message
-	display_message="cat /usr/share/message"
-	check_postStart=$(kubectl exec $pod_name -- sh -c "$display_message" | grep "Hello from the postStart handler")
+	check_postStart=$(kubectl exec $pod_name -- sh -c "$display_message")
+	echo "check_postStart=$check_postStart"
+	echo "$check_postStart" | grep "Hello from the postStart handler"
 }
 
 teardown(){
@@ -43,4 +47,8 @@ teardown(){
 
 	rm -f "${yaml_file}"
 	kubectl delete pod "$pod_name"
+
+	if [ -d "${test_settings_dir}" ]; then
+		rm -rf "${test_settings_dir}"
+	fi
 }

--- a/tests/integration/kubernetes/k8s-attach-handlers.bats
+++ b/tests/integration/kubernetes/k8s-attach-handlers.bats
@@ -15,15 +15,19 @@ setup() {
 	pod_name="handlers"
 
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/test-lifecycle-events.yaml"
 }
 
 @test "Running with postStart and preStop handlers" {
 	# Create yaml
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
-		"${pod_config_dir}/lifecycle-events.yaml" > "${pod_config_dir}/test-lifecycle-events.yaml"
+		"${pod_config_dir}/lifecycle-events.yaml" > "${yaml_file}"
+
+	# TODO: disabled due to #8850
+	# auto_generate_policy "${yaml_file}"
 
 	# Create the pod with postStart and preStop handlers
-	kubectl create -f "${pod_config_dir}/test-lifecycle-events.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
@@ -37,6 +41,6 @@ teardown(){
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 
-	rm -f "${pod_config_dir}/test-lifecycle-events.yaml"
+	rm -f "${yaml_file}"
 	kubectl delete pod "$pod_name"
 }

--- a/tests/integration/kubernetes/k8s-caps.bats
+++ b/tests/integration/kubernetes/k8s-caps.bats
@@ -11,6 +11,8 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 setup() {
         pod_name="pod-caps"
         get_pod_config_dir
+        yaml_file="${pod_config_dir}/${pod_name}.yaml"
+
 # We expect the capabilities mask to very per distribution, runtime
 # configuration. Even for this, we should expect a few common items to
 # not be set in the mask unless we are failing to apply capabilities. If
@@ -28,8 +30,11 @@ setup() {
 }
 
 @test "Check capabilities of pod" {
+        # TODO: disabled due to #8850
+        # auto_generate_policy "${yaml_file}"
+
         # Create pod
-        kubectl create -f "${pod_config_dir}/pod-caps.yaml"
+        kubectl create -f "${yaml_file}"
         # Check pod creation
         kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 

--- a/tests/integration/kubernetes/k8s-confidential.bats
+++ b/tests/integration/kubernetes/k8s-confidential.bats
@@ -18,11 +18,14 @@ setup() {
 
 	get_pod_config_dir
 	setup_unencrypted_confidential_pod
+	yaml_file="${pod_config_dir}/pod-confidential-unencrypted.yaml"
 }
 
 @test "Test unencrypted confidential container launch success and verify that we are running in a secure enclave." {
+	auto_generate_policy "${yaml_file}"
+
 	# Start the service/deployment/pod
-	kubectl apply -f "${pod_config_dir}/pod-confidential-unencrypted.yaml"
+	kubectl apply -f "${yaml_file}"
 
 	# Retrieve pod name, wait for it to come up, retrieve pod ip
 	pod_name=$(kubectl get pod -o wide | grep "confidential-unencrypted" | awk '{print $1;}')
@@ -49,5 +52,5 @@ teardown() {
 	[[ " ${SUPPORTED_HYPERVISORS[*]} " =~  " ${KATA_HYPERVISOR} " ]] ||  skip "Test not supported for ${KATA_HYPERVISOR}."
 
 	kubectl describe "pod/${pod_name}" || true
-	kubectl delete -f "${pod_config_dir}/pod-confidential-unencrypted.yaml" || true
+	kubectl delete -f "${yaml_file}" || true
 }

--- a/tests/integration/kubernetes/k8s-confidential.bats
+++ b/tests/integration/kubernetes/k8s-confidential.bats
@@ -22,7 +22,7 @@ setup() {
 }
 
 @test "Test unencrypted confidential container launch success and verify that we are running in a secure enclave." {
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Start the service/deployment/pod
 	kubectl apply -f "${yaml_file}"

--- a/tests/integration/kubernetes/k8s-configmap.bats
+++ b/tests/integration/kubernetes/k8s-configmap.bats
@@ -10,20 +10,25 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	get_pod_config_dir
+	configmap_yaml_file="${pod_config_dir}/configmap.yaml"
+	pod_yaml_file="${pod_config_dir}/pod-configmap.yaml"
 }
 
 @test "ConfigMap for a pod" {
 	config_name="test-configmap"
 	pod_name="config-env-test-pod"
 
+	# TODO: disabled due to #8850
+	# auto_generate_policy "${pod_yaml_file}" "${configmap_yaml_file}"
+
 	# Create ConfigMap
-	kubectl create -f "${pod_config_dir}/configmap.yaml"
+	kubectl create -f "${configmap_yaml_file}"
 
 	# View the values of the keys
 	kubectl get configmaps $config_name -o yaml | grep -q "data-"
 
 	# Create a pod that consumes the ConfigMap
-	kubectl create -f "${pod_config_dir}/pod-configmap.yaml"
+	kubectl create -f "${pod_yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-copy-file.bats
+++ b/tests/integration/kubernetes/k8s-copy-file.bats
@@ -24,6 +24,9 @@ setup() {
 	sed -i "s/POD_NAME/$pod_name/" "$pod_config"
 	sed -i "s/CTR_NAME/$ctr_name/" "$pod_config"
 
+	# TODO: disabled due to #8868
+	# auto_generate_policy "$pod_config"
+
 	kubectl create -f "${pod_config}"
 
 	# Check pod creation
@@ -48,6 +51,9 @@ setup() {
 	cp "$pod_config_dir/busybox-template.yaml" "$pod_config"
 	sed -i "s/POD_NAME/$pod_name/" "$pod_config"
 	sed -i "s/CTR_NAME/$ctr_name/" "$pod_config"
+
+	# TODO: disabled due to #8868
+	# auto_generate_policy "$pod_config"
 
 	kubectl create -f "${pod_config}"
 

--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -26,11 +26,15 @@ setup() {
 	total_cpu_container=1
 
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/pod-cpu.yaml"
 }
 
 @test "Check CPU constraints" {
+	# TODO: disabled due to #8850
+	# auto_generate_policy "${yaml_file}"
+
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/pod-cpu.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/tests/integration/kubernetes/k8s-credentials-secrets.bats
@@ -13,6 +13,7 @@ setup() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 
 	get_pod_config_dir
+	pod_yaml_file="${pod_config_dir}/pod-secret.yaml"
 }
 
 @test "Credentials using secrets" {
@@ -26,8 +27,11 @@ setup() {
 	# View information about the secret
 	kubectl get secret "${secret_name}" -o yaml | grep "type: Opaque"
 
+	# TODO: disabled due to #8886
+	# auto_generate_policy "${pod_yaml_file}"
+
 	# Create a pod that has access to the secret through a volume
-	kubectl create -f "${pod_config_dir}/pod-secret.yaml"
+	kubectl create -f "${pod_yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-custom-dns.bats
+++ b/tests/integration/kubernetes/k8s-custom-dns.bats
@@ -12,11 +12,15 @@ setup() {
 	pod_name="custom-dns-test"
 	file_name="/etc/resolv.conf"
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/pod-custom-dns.yaml"
 }
 
 @test "Check custom dns" {
+	# TODO: disabled due to #8850
+	# auto_generate_policy "${yaml_file}"
+
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/pod-custom-dns.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name

--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -24,8 +24,13 @@ setup() {
 }
 
 @test "Empty dir volumes" {
+	pod_file="${pod_config_dir}/pod-empty-dir.yaml"
+
+	# TODO: disabled due to #8887
+	# auto_generate_policy "${pod_file}"
+
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/pod-empty-dir.yaml"
+	kubectl create -f "${pod_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -45,6 +50,8 @@ setup() {
 	agnhost_name="${container_images_agnhost_name}"
 	agnhost_version="${container_images_agnhost_version}"
 	image="${agnhost_name}:${agnhost_version}"
+
+	# TODO: auto-generate policy for this yaml file - see #8887
 
 	# Try to avoid timeout by prefetching the image.
 	sed -e "s#\${agnhost_image}#${image}#" "$pod_file" |\

--- a/tests/integration/kubernetes/k8s-env.bats
+++ b/tests/integration/kubernetes/k8s-env.bats
@@ -11,11 +11,15 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 setup() {
 	pod_name="test-env"
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/pod-env.yaml"
 }
 
 @test "Environment variables" {
+	# TODO: disabled due to #8850
+	# auto_generate_policy "${yaml_file}"
+
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-env.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-exec.bats
+++ b/tests/integration/kubernetes/k8s-exec.bats
@@ -13,11 +13,15 @@ setup() {
 	pod_name="busybox"
 	first_container_name="first-test-container"
 	second_container_name="second-test-container"
+	yaml_file="${pod_config_dir}/busybox-pod.yaml"
 }
 
 @test "Kubectl exec" {
+	# TODO: disabled due to 8868
+	# auto_generate_policy "${yaml_file}"
+
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Get pod specification
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-file-volume.bats
+++ b/tests/integration/kubernetes/k8s-file-volume.bats
@@ -19,6 +19,7 @@ setup() {
 	mount_path="/tmp/foo.txt"
 	file_body="test"
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/test-pod-file-volume.yaml"
 }
 
 @test "Test readonly volume for pods" {
@@ -26,12 +27,15 @@ setup() {
 	exec_host "$node" "echo "$file_body" > $tmp_file"
 
 	# Create test yaml
-	sed -e "s|HOST_FILE|$tmp_file|" ${pod_config_dir}/pod-file-volume.yaml > ${pod_config_dir}/test-pod-file-volume.yaml
-	sed -i "s|MOUNT_PATH|$mount_path|" ${pod_config_dir}/test-pod-file-volume.yaml
-	sed -i "s|NODE|$node|" ${pod_config_dir}/test-pod-file-volume.yaml
+	sed -e "s|HOST_FILE|$tmp_file|" ${pod_config_dir}/pod-file-volume.yaml > "${yaml_file}"
+	sed -i "s|MOUNT_PATH|$mount_path|" "${yaml_file}"
+	sed -i "s|NODE|$node|" "${yaml_file}"
+
+	# TODO: disabled due to #8888
+	# auto_generate_policy "${yaml_file}"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/test-pod-file-volume.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -46,5 +50,5 @@ teardown() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	kubectl delete pod "$pod_name"
 	exec_host "$node" rm -f $tmp_file
-	rm -f ${pod_config_dir}/test-pod-file-volume.yaml.yaml
+	rm -f "${yaml_file}"
 }

--- a/tests/integration/kubernetes/k8s-footloose.bats
+++ b/tests/integration/kubernetes/k8s-footloose.bats
@@ -23,17 +23,22 @@ setup() {
 	sed -e "/\${ssh_key}/r ${public_key_path}" -e "/\${ssh_key}/d" \
 		"${pod_config_dir}/footloose-configmap.yaml" > "$configmap_yaml"
 	sed -i 's/ssh-rsa/      ssh-rsa/' "$configmap_yaml"
+
+	pod_yaml="${pod_config_dir}/pod-footloose.yaml"
 }
 
 @test "Footloose pod" {
 	cmd="uname -r"
 	sleep_connect="10"
 
+	# TODO: disabled due to #8850
+	# auto_generate_policy "${pod_yaml}" "${configmap_yaml}"
+
 	# Create ConfigMap
 	kubectl create -f "$configmap_yaml"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-footloose.yaml"
+	kubectl create -f "${pod_yaml}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-inotify.bats
+++ b/tests/integration/kubernetes/k8s-inotify.bats
@@ -12,16 +12,21 @@ setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	get_pod_config_dir
+	configmap_yaml_file="${pod_config_dir}/inotify-configmap.yaml"
+	pod_yaml_file="${pod_config_dir}/inotify-configmap-pod.yaml"
 }
 
 @test "configmap update works, and preserves symlinks" {
         pod_name="inotify-configmap-testing"
 
+        # TODO: disabled due to #8889
+        # auto_generate_policy "${pod_yaml_file}" "${configmap_yaml_file}"
+
         # Create configmap for my deployment
-        kubectl apply -f "${pod_config_dir}"/inotify-configmap.yaml
+        kubectl apply -f "${configmap_yaml_file}"
 
         # Create deployment that expects identity-certs
-        kubectl apply -f "${pod_config_dir}"/inotify-configmap-pod.yaml
+        kubectl apply -f "${pod_yaml_file}"
         kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
         # Update configmap
@@ -33,8 +38,6 @@ setup() {
         # Verify we saw the update
         result=$(kubectl get pod "$pod_name" --output="jsonpath={.status.containerStatuses[]}")
         echo $result | grep -vq Error
-
-        kubectl delete configmap cm
 }
 
 
@@ -45,4 +48,5 @@ teardown() {
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 	kubectl delete pod "$pod_name"
+	kubectl delete configmap cm
 }

--- a/tests/integration/kubernetes/k8s-job.bats
+++ b/tests/integration/kubernetes/k8s-job.bats
@@ -10,13 +10,17 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/job.yaml"
 }
 
 @test "Run a job to completion" {
 	job_name="job-pi-test"
+	
+	# TODO: disabled due to #8891
+	# auto_generate_policy "${yaml_file}"
 
 	# Create job
-	kubectl apply -f "${pod_config_dir}/job.yaml"
+	kubectl apply -f "${yaml_file}"
 
 	# Verify job
 	kubectl describe jobs/"$job_name" | grep "SuccessfulCreate"

--- a/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
+++ b/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
@@ -13,11 +13,15 @@ setup() {
 	first_container_name="first-test-container"
 
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/initcontainer-shareprocesspid.yaml"
 }
 
 @test "Kill all processes in container" {
+	# TODO: disabled due to #8868
+	# auto_generate_policy "${yaml_file}"
+
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/initcontainer-shareprocesspid.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name

--- a/tests/integration/kubernetes/k8s-limit-range.bats
+++ b/tests/integration/kubernetes/k8s-limit-range.bats
@@ -12,9 +12,12 @@ setup() {
 	get_pod_config_dir
 	namespace_name="default-cpu-example"
 	pod_name="default-cpu-test"
+	pod_yaml_file="${pod_config_dir}/pod-cpu-defaults.yaml"
 }
 
 @test "Limit range for storage" {
+	auto_generate_policy "${pod_yaml_file}"
+
 	# Create namespace
 	kubectl create namespace "$namespace_name"
 
@@ -22,7 +25,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/limit-range.yaml" --namespace=${namespace_name}
 
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/pod-cpu-defaults.yaml" --namespace=${namespace_name}
+	kubectl create -f "${pod_yaml_file}" --namespace=${namespace_name}
 
 	# Get pod specification
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name" --namespace="$namespace_name"

--- a/tests/integration/kubernetes/k8s-limit-range.bats
+++ b/tests/integration/kubernetes/k8s-limit-range.bats
@@ -13,11 +13,10 @@ setup() {
 	namespace_name="default-cpu-example"
 	pod_name="default-cpu-test"
 	pod_yaml_file="${pod_config_dir}/pod-cpu-defaults.yaml"
+	auto_generate_policy "" "${pod_yaml_file}"
 }
 
 @test "Limit range for storage" {
-	auto_generate_policy "${pod_yaml_file}"
-
 	# Create namespace
 	kubectl create namespace "$namespace_name"
 

--- a/tests/integration/kubernetes/k8s-liveness-probes.bats
+++ b/tests/integration/kubernetes/k8s-liveness-probes.bats
@@ -20,7 +20,7 @@ setup() {
 	pod_name="liveness-exec"
 	yaml_file="${pod_config_dir}/pod-liveness.yaml"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-liveness.yaml"
@@ -43,7 +43,7 @@ setup() {
 	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
 		"${pod_config_dir}/pod-http-liveness.yaml" > "${yaml_file}"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${yaml_file}"
@@ -67,7 +67,7 @@ setup() {
 	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
 		"${pod_config_dir}/pod-tcp-liveness.yaml" > "${yaml_file}"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${yaml_file}"

--- a/tests/integration/kubernetes/k8s-liveness-probes.bats
+++ b/tests/integration/kubernetes/k8s-liveness-probes.bats
@@ -18,6 +18,9 @@ setup() {
 
 @test "Liveness probe" {
 	pod_name="liveness-exec"
+	yaml_file="${pod_config_dir}/pod-liveness.yaml"
+
+	auto_generate_policy "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${pod_config_dir}/pod-liveness.yaml"
@@ -35,11 +38,15 @@ setup() {
 
 @test "Liveness http probe" {
 	pod_name="liveness-http"
+	yaml_file="${pod_config_dir}/pod-http-liveness-test.yaml"
+
+	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
+		"${pod_config_dir}/pod-http-liveness.yaml" > "${yaml_file}"
+
+	auto_generate_policy "${yaml_file}"
 
 	# Create pod
-	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
-		"${pod_config_dir}/pod-http-liveness.yaml" |\
-		kubectl create -f -
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -55,11 +62,15 @@ setup() {
 
 @test "Liveness tcp probe" {
 	pod_name="tcptest"
+	yaml_file="${pod_config_dir}/pod-tcp-liveness-test.yaml"
+
+	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
+		"${pod_config_dir}/pod-tcp-liveness.yaml" > "${yaml_file}"
+
+	auto_generate_policy "${yaml_file}"
 
 	# Create pod
-	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
-		"${pod_config_dir}/pod-tcp-liveness.yaml" |\
-		kubectl create -f -
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -77,4 +88,6 @@ teardown() {
 	kubectl describe "pod/$pod_name"
 
 	kubectl delete pod "$pod_name"
+	rm -f ${pod_config_dir}/pod-http-liveness-test.yaml
+	rm -f ${pod_config_dir}/pod-tcp-liveness-test.yaml
 }

--- a/tests/integration/kubernetes/k8s-memory.bats
+++ b/tests/integration/kubernetes/k8s-memory.bats
@@ -24,29 +24,37 @@ setup_yaml() {
 @test "Exceeding memory constraints" {
 	memory_limit_size="50Mi"
 	allocated_size="250M"
+	yaml_file="${pod_config_dir}/test_exceed_memory.yaml"
+
 	# Create test .yaml
-	setup_yaml > "${pod_config_dir}/test_exceed_memory.yaml"
+	setup_yaml > "${yaml_file}"
+
+	auto_generate_policy "${yaml_file}"
 
 	# Create the pod exceeding memory constraints
-	run kubectl create -f "${pod_config_dir}/test_exceed_memory.yaml"
+	run kubectl create -f "${yaml_file}"
 	[ "$status" -ne 0 ]
 
-	rm -f "${pod_config_dir}/test_exceed_memory.yaml"
+	rm -f "${yaml_file}"
 }
 
 @test "Running within memory constraints" {
 	memory_limit_size="600Mi"
 	allocated_size="150M"
+	yaml_file="${pod_config_dir}/test_within_memory.yaml"
+
 	# Create test .yaml
-	setup_yaml > "${pod_config_dir}/test_within_memory.yaml"
+	setup_yaml > "${yaml_file}"
+
+	auto_generate_policy "${yaml_file}"
 
 	# Create the pod within memory constraints
-	kubectl create -f "${pod_config_dir}/test_within_memory.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
-	rm -f "${pod_config_dir}/test_within_memory.yaml"
+	rm -f "${yaml_file}"
 	kubectl delete pod "$pod_name"
 }
 

--- a/tests/integration/kubernetes/k8s-memory.bats
+++ b/tests/integration/kubernetes/k8s-memory.bats
@@ -29,7 +29,7 @@ setup_yaml() {
 	# Create test .yaml
 	setup_yaml > "${yaml_file}"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create the pod exceeding memory constraints
 	run kubectl create -f "${yaml_file}"
@@ -46,7 +46,7 @@ setup_yaml() {
 	# Create test .yaml
 	setup_yaml > "${yaml_file}"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create the pod within memory constraints
 	kubectl create -f "${yaml_file}"

--- a/tests/integration/kubernetes/k8s-nested-configmap-secret.bats
+++ b/tests/integration/kubernetes/k8s-nested-configmap-secret.bats
@@ -15,11 +15,15 @@ setup() {
 	get_pod_config_dir
 
 	pod_name="nested-configmap-secret-pod"
+	yaml_file="${pod_config_dir}/pod-nested-configmap-secret.yaml"
 }
 
 @test "Nested mount of a secret volume in a configmap volume for a pod" {
+	# TODO: disabled due to #8892
+	# auto_generate_policy "${yaml_file}"
+
 	# Creates a configmap, secret and pod that mounts the secret inside the configmap
-	kubectl create -f "${pod_config_dir}/pod-nested-configmap-secret.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -37,5 +41,5 @@ teardown() {
 	kubectl describe "pod/$pod_name"
 
 	# Delete the configmap, secret, and pod used for testing
-	kubectl delete -f "${pod_config_dir}/pod-nested-configmap-secret.yaml"
+	kubectl delete -f "${yaml_file}"
 }

--- a/tests/integration/kubernetes/k8s-nginx-connectivity.bats
+++ b/tests/integration/kubernetes/k8s-nginx-connectivity.bats
@@ -15,15 +15,18 @@ setup() {
 	deployment="nginx-deployment"
 
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/test-${deployment}.yaml"
 }
 
 @test "Verify nginx connectivity between pods" {
 
 	# Create test .yaml
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
-		"${pod_config_dir}/${deployment}.yaml" > "${pod_config_dir}/test-${deployment}.yaml"
+		"${pod_config_dir}/${deployment}.yaml" > "${yaml_file}"
 
-	kubectl create -f "${pod_config_dir}/test-${deployment}.yaml"
+	auto_generate_policy "${yaml_file}"
+
+	kubectl create -f "${yaml_file}"
 	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment}
 	kubectl expose deployment/${deployment}
 
@@ -46,7 +49,7 @@ teardown() {
 	kubectl get service/${deployment} -o yaml
 	kubectl get endpoints/${deployment} -o yaml
 
-	rm -f "${pod_config_dir}/test-${deployment}.yaml"
+	rm -f "${yaml_file}"
 	kubectl delete deployment "$deployment"
 	kubectl delete service "$deployment"
 	kubectl delete pod "$busybox_pod"

--- a/tests/integration/kubernetes/k8s-nginx-connectivity.bats
+++ b/tests/integration/kubernetes/k8s-nginx-connectivity.bats
@@ -24,7 +24,7 @@ setup() {
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/${deployment}.yaml" > "${yaml_file}"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	kubectl create -f "${yaml_file}"
 	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment}

--- a/tests/integration/kubernetes/k8s-number-cpus.bats
+++ b/tests/integration/kubernetes/k8s-number-cpus.bats
@@ -12,12 +12,16 @@ setup() {
 	pod_name="cpu-test"
 	container_name="c1"
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/pod-number-cpu.yaml"
 }
 
 # Skip on aarch64 due to missing cpu hotplug related functionality.
 @test "Check number of cpus" {
+	# TODO: disabled due to #8850
+	# auto_generate_policy "${yaml_file}"
+
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-number-cpu.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-oom.bats
+++ b/tests/integration/kubernetes/k8s-oom.bats
@@ -17,7 +17,7 @@ setup() {
 }
 
 @test "Test OOM events for pods" {
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${yaml_file}"

--- a/tests/integration/kubernetes/k8s-oom.bats
+++ b/tests/integration/kubernetes/k8s-oom.bats
@@ -13,11 +13,14 @@ setup() {
 
 	pod_name="pod-oom"
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/$pod_name.yaml"
 }
 
 @test "Test OOM events for pods" {
+	auto_generate_policy "${yaml_file}"
+
 	# Create pod
-	kubectl create -f "${pod_config_dir}/$pod_name.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-optional-empty-configmap.bats
+++ b/tests/integration/kubernetes/k8s-optional-empty-configmap.bats
@@ -10,17 +10,21 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/pod-optional-empty-configmap.yaml"
 }
 
 @test "Optional and Empty ConfigMap Volume for a pod" {
 	config_name="empty-config"
 	pod_name="optional-empty-config-test-pod"
 
+	# TODO: disabled due to #8893
+	# auto_generate_policy "${yaml_file}"
+
 	# Create Empty ConfigMap
 	kubectl create configmap "$config_name"
 
 	# Create a pod that consumes the "empty-config" and "optional-missing-config" ConfigMaps as volumes
-	kubectl create -f "${pod_config_dir}/pod-optional-empty-configmap.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-parallel.bats
+++ b/tests/integration/kubernetes/k8s-parallel.bats
@@ -17,7 +17,9 @@ setup() {
 @test "Parallel jobs" {
 	# Create yaml files
 	for i in "${names[@]}"; do
-		sed "s/\$ITEM/$i/" ${pod_config_dir}/job-template.yaml > ${pod_config_dir}/job-$i.yaml
+		yaml_file="${pod_config_dir}/job-$i.yaml"
+		sed "s/\$ITEM/$i/" ${pod_config_dir}/job-template.yaml > "${yaml_file}"
+		auto_generate_policy "${yaml_file}"
 	done
 
 	# Create the jobs

--- a/tests/integration/kubernetes/k8s-parallel.bats
+++ b/tests/integration/kubernetes/k8s-parallel.bats
@@ -19,7 +19,7 @@ setup() {
 	for i in "${names[@]}"; do
 		yaml_file="${pod_config_dir}/job-$i.yaml"
 		sed "s/\$ITEM/$i/" ${pod_config_dir}/job-template.yaml > "${yaml_file}"
-		auto_generate_policy "${yaml_file}"
+		auto_generate_policy "" "${yaml_file}"
 	done
 
 	# Create the jobs

--- a/tests/integration/kubernetes/k8s-pid-ns.bats
+++ b/tests/integration/kubernetes/k8s-pid-ns.bats
@@ -14,11 +14,15 @@ setup() {
 	second_container_name="second-test-container"
 
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/busybox-pod.yaml"
 }
 
 @test "Check PID namespaces" {
+	# TODO: disabled due to #8850
+	# auto_generate_policy "${yaml_file}"
+
 	# Create the pod
-	kubectl create -f "${pod_config_dir}/busybox-pod.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name

--- a/tests/integration/kubernetes/k8s-pod-quota.bats
+++ b/tests/integration/kubernetes/k8s-pod-quota.bats
@@ -11,11 +11,14 @@ setup() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: https://github.com/kata-containers/kata-containers/issues/7873"
 
 	get_pod_config_dir
+	deployment_yaml_file="${pod_config_dir}/pod-quota-deployment.yaml"
 }
 
 @test "Pod quota" {
 	resource_name="pod-quota"
 	deployment_name="deploymenttest"
+
+	auto_generate_policy "${deployment_yaml_file}"
 
 	# Create the resourcequota
 	kubectl create -f "${pod_config_dir}/resource-quota.yaml"
@@ -25,7 +28,7 @@ setup() {
 		--output=yaml | grep 'pods: "2"'
 
 	# Create deployment
-	kubectl create -f "${pod_config_dir}/pod-quota-deployment.yaml"
+	kubectl create -f "${deployment_yaml_file}"
 
 	# View deployment
 	kubectl wait --for=condition=Available --timeout=$timeout \
@@ -39,6 +42,6 @@ teardown() {
 	kubectl describe deployment ${deployment_name}
 
 	# Clean-up
-	kubectl delete -f "${pod_config_dir}/pod-quota-deployment.yaml"
+	kubectl delete -f "${deployment_yaml_file}"
 	kubectl delete -f "${pod_config_dir}/resource-quota.yaml"
 }

--- a/tests/integration/kubernetes/k8s-pod-quota.bats
+++ b/tests/integration/kubernetes/k8s-pod-quota.bats
@@ -18,7 +18,7 @@ setup() {
 	resource_name="pod-quota"
 	deployment_name="deploymenttest"
 
-	auto_generate_policy "${deployment_yaml_file}"
+	auto_generate_policy "" "${deployment_yaml_file}"
 
 	# Create the resourcequota
 	kubectl create -f "${pod_config_dir}/resource-quota.yaml"

--- a/tests/integration/kubernetes/k8s-port-forward.bats
+++ b/tests/integration/kubernetes/k8s-port-forward.bats
@@ -13,14 +13,17 @@ issue="https://github.com/kata-containers/runtime/issues/1834"
 setup() {
 	skip "test not working see: ${issue}"
 	get_pod_config_dir
+	deployment_yaml_file="${pod_config_dir}/redis-master-deployment.yaml"
 }
 
 @test "Port forwarding" {
 	skip "test not working see: ${issue}"
 	deployment_name="redis-master"
 
+	auto_generate_policy "${deployment_yaml_file}"
+
 	# Create deployment
-	kubectl apply -f "${pod_config_dir}/redis-master-deployment.yaml"
+	kubectl apply -f "${deployment_yaml_file}"
 
 	# Check deployment
 	kubectl wait --for=condition=Available --timeout=$timeout deployment/"$deployment_name"
@@ -66,6 +69,6 @@ setup() {
 
 teardown() {
 	skip "test not working see: ${issue}"
-	kubectl delete -f "${pod_config_dir}/redis-master-deployment.yaml"
+	kubectl delete -f "${deployment_yaml_file}"
 	kubectl delete -f "${pod_config_dir}/redis-master-service.yaml"
 }

--- a/tests/integration/kubernetes/k8s-port-forward.bats
+++ b/tests/integration/kubernetes/k8s-port-forward.bats
@@ -20,7 +20,7 @@ setup() {
 	skip "test not working see: ${issue}"
 	deployment_name="redis-master"
 
-	auto_generate_policy "${deployment_yaml_file}"
+	auto_generate_policy "" "${deployment_yaml_file}"
 
 	# Create deployment
 	kubectl apply -f "${deployment_yaml_file}"

--- a/tests/integration/kubernetes/k8s-projected-volume.bats
+++ b/tests/integration/kubernetes/k8s-projected-volume.bats
@@ -13,12 +13,16 @@ setup() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/pod-projected-volume.yaml"
 }
 
 @test "Projected volume" {
 	password="1f2d1e2e67df"
 	username="admin"
 	pod_name="test-projected-volume"
+
+	# TODO: disabled due to #8894
+	# auto_generate_policy "${yaml_file}"
 
 	TMP_FILE=$(mktemp username.XXXX)
 	SECOND_TMP_FILE=$(mktemp password.XXXX)
@@ -32,7 +36,7 @@ setup() {
 	kubectl create secret generic pass --from-file=$SECOND_TMP_FILE
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-projected-volume.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-qos-pods.bats
+++ b/tests/integration/kubernetes/k8s-qos-pods.bats
@@ -16,9 +16,12 @@ setup() {
 
 @test "Guaranteed QoS" {
 	pod_name="qos-test"
+	yaml_file="${pod_config_dir}/pod-guaranteed.yaml"
+
+	auto_generate_policy "${yaml_file}"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-guaranteed.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -29,9 +32,12 @@ setup() {
 
 @test "Burstable QoS" {
 	pod_name="burstable-test"
+	yaml_file="${pod_config_dir}/pod-burstable.yaml"
+
+	auto_generate_policy "${yaml_file}"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-burstable.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
@@ -42,9 +48,12 @@ setup() {
 
 @test "BestEffort QoS" {
 	pod_name="besteffort-test"
+	yaml_file="${pod_config_dir}/pod-besteffort.yaml"
+
+	auto_generate_policy "${yaml_file}"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-besteffort.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-qos-pods.bats
+++ b/tests/integration/kubernetes/k8s-qos-pods.bats
@@ -18,7 +18,7 @@ setup() {
 	pod_name="qos-test"
 	yaml_file="${pod_config_dir}/pod-guaranteed.yaml"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${yaml_file}"
@@ -34,7 +34,7 @@ setup() {
 	pod_name="burstable-test"
 	yaml_file="${pod_config_dir}/pod-burstable.yaml"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${yaml_file}"
@@ -50,7 +50,7 @@ setup() {
 	pod_name="besteffort-test"
 	yaml_file="${pod_config_dir}/pod-besteffort.yaml"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${yaml_file}"

--- a/tests/integration/kubernetes/k8s-replication.bats
+++ b/tests/integration/kubernetes/k8s-replication.bats
@@ -13,6 +13,7 @@ setup() {
 	nginx_image="nginx:$nginx_version"
 
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/test-replication-controller.yaml"
 }
 
 @test "Replication controller" {
@@ -20,10 +21,12 @@ setup() {
 
 	# Create yaml
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
-		"${pod_config_dir}/replication-controller.yaml" > "${pod_config_dir}/test-replication-controller.yaml"
+		"${pod_config_dir}/replication-controller.yaml" > "${yaml_file}"
+
+	auto_generate_policy "${yaml_file}"
 
 	# Create replication controller
-	kubectl create -f "${pod_config_dir}/test-replication-controller.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check replication controller
 	local cmd="kubectl describe replicationcontrollers/$replication_name | grep replication-controller"
@@ -57,6 +60,6 @@ teardown() {
 	# Debugging information
 	kubectl describe replicationcontrollers/"$replication_name"
 
-	rm -f "${pod_config_dir}/test-replication-controller.yaml"
+	rm -f "${yaml_file}"
 	kubectl delete rc "$replication_name"
 }

--- a/tests/integration/kubernetes/k8s-replication.bats
+++ b/tests/integration/kubernetes/k8s-replication.bats
@@ -23,7 +23,7 @@ setup() {
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/replication-controller.yaml" > "${yaml_file}"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	# Create replication controller
 	kubectl create -f "${yaml_file}"

--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -13,13 +13,18 @@ setup() {
 		skip "runtime-rs is still using the old vcpus allocation algorithm, skipping the test"
 
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/pod-sandbox-vcpus-allocation.yaml"
+
 	pods=( "vcpus-less-than-one-with-no-limits" "vcpus-less-than-one-with-limits" "vcpus-more-than-one-with-limits" )
 	expected_vcpus=( 1 1 2 )
 }
 
 @test "Check the number vcpus are correctly allocated to the sandbox" {
+	# TODO: disabled due to #8895
+	# auto_generate_policy "${yaml_file}"
+
 	# Create the pods
-	kubectl create -f "${pod_config_dir}/pod-sandbox-vcpus-allocation.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check the pods
 	for i in {0..2}; do
@@ -36,5 +41,5 @@ teardown() {
 		kubectl logs ${pod}
 	done
 
-	kubectl delete -f "${pod_config_dir}/pod-sandbox-vcpus-allocation.yaml"
+	kubectl delete -f "${yaml_file}"
 }

--- a/tests/integration/kubernetes/k8s-scale-nginx.bats
+++ b/tests/integration/kubernetes/k8s-scale-nginx.bats
@@ -22,7 +22,7 @@ setup() {
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/${deployment}.yaml" > "${yaml_file}"
 
-	auto_generate_policy "${yaml_file}"
+	auto_generate_policy "" "${yaml_file}"
 
 	kubectl create -f "${yaml_file}"
 	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment}

--- a/tests/integration/kubernetes/k8s-scale-nginx.bats
+++ b/tests/integration/kubernetes/k8s-scale-nginx.bats
@@ -14,14 +14,17 @@ setup() {
 	replicas="3"
 	deployment="nginx-deployment"
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/test-${deployment}.yaml"
 }
 
 @test "Scale nginx deployment" {
 
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
-		"${pod_config_dir}/${deployment}.yaml" > "${pod_config_dir}/test-${deployment}.yaml"
+		"${pod_config_dir}/${deployment}.yaml" > "${yaml_file}"
 
-	kubectl create -f "${pod_config_dir}/test-${deployment}.yaml"
+	auto_generate_policy "${yaml_file}"
+
+	kubectl create -f "${yaml_file}"
 	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment}
 	kubectl expose deployment/${deployment}
 	kubectl scale deployment/${deployment} --replicas=${replicas}
@@ -30,7 +33,7 @@ setup() {
 }
 
 teardown() {
-	rm -f "${pod_config_dir}/test-${deployment}.yaml"
+	rm -f "${yaml_file}"
 	kubectl delete deployment "$deployment"
 	kubectl delete service "$deployment"
 }

--- a/tests/integration/kubernetes/k8s-security-context.bats
+++ b/tests/integration/kubernetes/k8s-security-context.bats
@@ -10,13 +10,17 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/pod-security-context.yaml"
 }
 
 @test "Security context" {
 	pod_name="security-context-test"
 
+	# TODO: disabled due to #8879
+	# auto_generate_policy "${yaml_file}"
+
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-security-context.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"

--- a/tests/integration/kubernetes/k8s-shared-volume.bats
+++ b/tests/integration/kubernetes/k8s-shared-volume.bats
@@ -16,9 +16,13 @@ setup() {
 	pod_name="test-shared-volume"
 	first_container_name="busybox-first-container"
 	second_container_name="busybox-second-container"
+	yaml_file="${pod_config_dir}/pod-shared-volume.yaml"
+
+	# TODO: disabled due to #8896
+	# auto_generate_policy "${yaml_file}"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/pod-shared-volume.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pods
 	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
@@ -32,9 +36,13 @@ setup() {
 @test "initContainer with shared volume" {
 	pod_name="initcontainer-shared-volume"
 	last_container="last"
+	yaml_file="${pod_config_dir}/initContainer-shared-volume.yaml"
+
+	# TODO: disabled due to #8896
+	# auto_generate_policy "${yaml_file}"
 
 	# Create pod
-	kubectl create -f "${pod_config_dir}/initContainer-shared-volume.yaml"
+	kubectl create -f "${yaml_file}"
 
 	# Check pods
 	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name

--- a/tests/integration/kubernetes/k8s-sysctls.bats
+++ b/tests/integration/kubernetes/k8s-sysctls.bats
@@ -11,11 +11,15 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 setup() {
 	pod_name="sysctl-test"
 	get_pod_config_dir
+	yaml_file="${pod_config_dir}/pod-sysctl.yaml"
 }
 
 @test "Setting sysctl" {
+	# TODO: disabled due to #8879
+	# auto_generate_policy "${yaml_file}"
+
 	# Create pod
-	kubectl apply -f "${pod_config_dir}/pod-sysctl.yaml"
+	kubectl apply -f "${yaml_file}"
 
 	# Check pod creation
 	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name

--- a/tests/integration/kubernetes/k8s-volume.bats
+++ b/tests/integration/kubernetes/k8s-volume.bats
@@ -34,6 +34,9 @@ setup() {
 	volume_name="pv-volume"
 	volume_claim="pv-claim"
 
+	# TODO: disabled due to #8888
+	# auto_generate_policy "$pod_yaml"
+
 	# Create the persistent volume
 	kubectl create -f "$pv_yaml"
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -716,16 +716,19 @@ install_tools_helper() {
 	[ ${tool} = "trace-forwarder" ] && tool_binary="kata-trace-forwarder"
 	binary=$(find ${repo_root_dir}/src/tools/${tool}/ -type f -name ${tool_binary})
 
-	info "Install static ${tool_binary}"
-	mkdir -p "${destdir}/opt/kata/bin/"
-	sudo install -D --owner root --group root --mode 0744 ${binary} "${destdir}/opt/kata/bin/${tool_binary}"
-
 	if [[ "${tool}" == "genpolicy" ]]; then
 		defaults_path="${destdir}/opt/kata/share/defaults/kata-containers"
 		mkdir -p "${defaults_path}"
 		sudo install -D --owner root --group root --mode 0644 ${repo_root_dir}/src/tools/${tool}/rules.rego "${defaults_path}/rules.rego"
 		sudo install -D --owner root --group root --mode 0644 ${repo_root_dir}/src/tools/${tool}/genpolicy-settings.json "${defaults_path}/genpolicy-settings.json"
+		binary_permissions="0755"
+	else
+		binary_permissions="0744"
 	fi
+
+	info "Install static ${tool_binary}"
+	mkdir -p "${destdir}/opt/kata/bin/"
+	sudo install -D --owner root --group root --mode ${binary_permissions} ${binary} "${destdir}/opt/kata/bin/${tool_binary}"
 }
 
 install_agent_ctl() {


### PR DESCRIPTION
Start auto-generating CoCo policy for kubernetes integration tests.

Policy gets auto-generated just for cbl-mariner Hosts for now. Auto-generated policy will be enabled for other Hosts too, after
testing these Hosts. For now, the other Hosts continue to use the allow-all.rego policy.

Some of the tests are still using the allow-all policy even on cbl-mariner Hosts, until the auto-generated policy will start working for these tests too.

Fixes: #8851