### PR TITLE
genpolicy: ignore pod DNS settings

### DIFF
--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -76,6 +76,12 @@ pub struct PodSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hostNetwork: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dnsConfig: Option<PodDNSConfig>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    dnsPolicy: Option<String>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
@@ -437,6 +443,28 @@ struct Toleration {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct LocalObjectReference {
     name: String,
+}
+
+/// See Reference / Kubernetes API / Workload Resources / Pod.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct PodDNSConfig {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nameservers: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    options: Option<Vec<PodDNSConfigOption>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    searches: Option<Vec<String>>,
+}
+
+/// See Reference / Kubernetes API / Workload Resources / Pod.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct PodDNSConfigOption {
+    name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    value: Option<String>,
 }
 
 impl Container {


### PR DESCRIPTION
Ignore pod DNS settings because policing the network traffic is currently outside the scope of the Agent Policy.

Example from Kata CI: pod-custom-dns.yaml

Fixes: #8832