### PR TITLE
gpu: Remove the old SNP, TDX targets

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -24,8 +24,6 @@ BASE_TARBALLS = serial-targets \
 	kernel-dragonball-experimental-tarball \
 	kernel-nvidia-gpu-tarball \
 	kernel-nvidia-gpu-confidential-tarball \
-	kernel-nvidia-gpu-snp-tarball \
-	kernel-nvidia-gpu-tdx-experimental-tarball \
 	kernel-tarball \
 	kernel-tdx-experimental-tarball \
 	nydus-tarball \
@@ -116,12 +114,6 @@ kernel-nvidia-gpu-tarball:
 
 kernel-nvidia-gpu-confidential-tarball:
 	${MAKE} $@-build
-
-kernel-nvidia-gpu-snp-tarball:
-	${MAKE} $@-build
-
-kernel-nvidia-gpu-tdx-experimental-tarball:
-	${MAKE} $@-build	
 
 kernel-tarball:
 	${MAKE} $@-build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -99,8 +99,6 @@ options:
 	kernel-dragonball-experimental
 	kernel-experimental
 	kernel-nvidia-gpu
-	kernel-nvidia-gpu-snp
-	kernel-nvidia-gpu-tdx-experimental
 	kernel-nvidia-gpu-confidential
 	kernel-sev-tarball
 	kernel-tdx-experimental
@@ -480,26 +478,6 @@ install_kernel_nvidia_gpu_confidential() {
 		"assets.kernel.confidential.version" \
 		"kernel-nvidia-gpu-confidential" \
 		"-x confidential -g nvidia -u ${kernel_url} -H deb"
-}
-
-#Install GPU and SNP enabled kernel asset
-install_kernel_nvidia_gpu_snp() {
-	local kernel_url="$(get_from_kata_deps assets.kernel.sev.url)"
-
-	install_kernel_helper \
-		"assets.kernel.sev.version" \
-		"kernel-nvidia-gpu-snp" \
-		"-x sev -g nvidia -u ${kernel_url} -H deb"
-}
-
-#Install GPU and TDX experimental enabled kernel asset
-install_kernel_nvidia_gpu_tdx_experimental() {
-	local kernel_url="$(get_from_kata_deps assets.kernel-tdx-experimental.url)"
-
-	install_kernel_helper \
-		"assets.kernel-tdx-experimental.version" \
-		"kernel-nvidia-gpu-tdx-experimental" \
-		"-x tdx -g nvidia -u ${kernel_url} -H deb"
 }
 
 #Install experimental TDX kernel asset
@@ -958,10 +936,6 @@ handle_build() {
 	kernel-nvidia-gpu) install_kernel_nvidia_gpu ;;
 
 	kernel-nvidia-gpu-confidential) install_kernel_nvidia_gpu_confidential ;;
-
-	kernel-nvidia-gpu-snp) install_kernel_nvidia_gpu_snp;;
-
-	kernel-nvidia-gpu-tdx-experimental) install_kernel_nvidia_gpu_tdx_experimental;;
 
 	kernel-tdx-experimental) install_kernel_tdx_experimental ;;
 


### PR DESCRIPTION
Remove the old SNP, TDX GPU related targets we no rely on #8872

Fixes:  #8873