### PR TITLE
metrics: Update packages needed for ResNet50 FP32 Dockerfile

### DIFF
--- a/tests/metrics/machine_learning/resnet50_fp32_dockerfile/Dockerfile
+++ b/tests/metrics/machine_learning/resnet50_fp32_dockerfile/Dockerfile
@@ -11,7 +11,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 LABEL DOCKERFILE_VERSION="1.0"
 
 RUN apt-get update && \
-	apt-get install -y --no-install-recommends wget nano curl build-essential git && \
+	apt-get install -y --no-install-recommends wget nano curl build-essential git zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev libbz2-dev && \
 	wget -q https://storage.googleapis.com/intel-optimized-tensorflow/models/v1_8/resnet50_fp32_pretrained_model.pb && \
 	git clone https://github.com/IntelAI/models.git && \
 	wget -q https://www.python.org/ftp/python/3.8.10/Python-3.8.10.tgz && \


### PR DESCRIPTION
This PR updates the packages necessary to build the ResNet50 fp32 Dockerfile to run properly the benchmark.

Fixes #8875