### PR TITLE
versions: Update libseccomp to version v2.5.5

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -271,7 +271,7 @@ externals:
   libseccomp:
     description: "High level interface to Linux seccomp filter"
     url: "https://github.com/seccomp/libseccomp"
-    version: "2.5.4"
+    version: "2.5.5"
 
   runc:
     description: "OCI CLI reference runtime implementation"


### PR DESCRIPTION
This PR updates the libseccompt version to v2.5.5 which includes the following changes:
- Update the syscall table for Linux
- Fix minor issues with binary tree testing and with empty binary trees

Fixes #8883