### PR TITLE
gpu: remove GHA target first then remove the obsoleted Makefile targets

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -42,8 +42,6 @@ jobs:
           - kernel-tdx-experimental
           - kernel-nvidia-gpu
           - kernel-nvidia-gpu-confidential
-          - kernel-nvidia-gpu-snp
-          - kernel-nvidia-gpu-tdx-experimental
           - nydus
           - ovmf
           - ovmf-sev


### PR DESCRIPTION
Lets remove the GHA target actions first so the the follow-up PR  https://github.com/kata-containers/kata-containers/pull/8874 tests are succeeding.