### PR TITLE
qemu: enable TPM

### DIFF
--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -267,9 +267,6 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-lzo)
 	qemu_options+=(size:--disable-snappy)
 
-	# Disable unused security options
-	qemu_options+=(security:--disable-tpm)
-
 	# Disable userspace network access ("-net user")
 	qemu_options+=(size:--disable-slirp)
 


### PR DESCRIPTION
Several use-cases need a vTPM lets enable it for QEMU, a follow up patch will introduce the runtime config.

Fixes: #8902