### PR TITLE
genpolicy: add shareProcessNamespace support

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -45,8 +45,12 @@ CreateContainerRequest {
     some p_container in policy_data.containers
     print("======== CreateContainerRequest: trying next policy container")
 
+    p_pidns := p_container.sandbox_pidns
+    i_pidns := input.sandbox_pidns
+    print("CreateContainerRequest: p_pidns =", p_pidns, "i_pidns =", i_pidns)
+    p_pidns == i_pidns
+
     p_oci := p_container.OCI
-    p_storages := p_container.storages
 
     print("CreateContainerRequest: p Version =", p_oci.Version, "i Version =", i_oci.Version)
     p_oci.Version == i_oci.Version
@@ -55,7 +59,10 @@ CreateContainerRequest {
     p_oci.Root.Readonly == i_oci.Root.Readonly
 
     allow_anno(p_oci, i_oci)
+
+    p_storages := p_container.storages
     allow_by_anno(p_oci, i_oci, p_storages, i_storages)
+
     allow_linux(p_oci, i_oci)
 
     print("CreateContainerRequest: true")
@@ -1074,6 +1081,12 @@ CopyFileRequest {
     regex.match(regex2, input.path)
 
     print("CopyFileRequest: true")
+}
+
+CreateSandboxRequest {
+    i_pidns := input.sandbox_pidns
+    print("CreateSandboxRequest: i_pidns =", i_pidns)
+    i_pidns == false
 }
 
 ExecProcessRequest {

--- a/src/tools/genpolicy/src/config_map.rs
+++ b/src/tools/genpolicy/src/config_map.rs
@@ -125,4 +125,8 @@ impl yaml::K8sResource for ConfigMap {
     fn use_host_network(&self) -> bool {
         panic!("Unsupported");
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        panic!("Unsupported");
+    }
 }

--- a/src/tools/genpolicy/src/daemon_set.rs
+++ b/src/tools/genpolicy/src/daemon_set.rs
@@ -129,4 +129,11 @@ impl yaml::K8sResource for DaemonSet {
         }
         false
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        if let Some(shared) = self.spec.template.spec.shareProcessNamespace {
+            return shared;
+        }
+        false
+    }
 }

--- a/src/tools/genpolicy/src/deployment.rs
+++ b/src/tools/genpolicy/src/deployment.rs
@@ -127,4 +127,11 @@ impl yaml::K8sResource for Deployment {
         }
         false
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        if let Some(shared) = self.spec.template.spec.shareProcessNamespace {
+            return shared;
+        }
+        false
+    }
 }

--- a/src/tools/genpolicy/src/job.rs
+++ b/src/tools/genpolicy/src/job.rs
@@ -101,4 +101,11 @@ impl yaml::K8sResource for Job {
         }
         false
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        if let Some(shared) = self.spec.template.spec.shareProcessNamespace {
+            return shared;
+        }
+        false
+    }
 }

--- a/src/tools/genpolicy/src/list.rs
+++ b/src/tools/genpolicy/src/list.rs
@@ -100,4 +100,8 @@ impl yaml::K8sResource for List {
     fn use_host_network(&self) -> bool {
         panic!("Unsupported");
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        panic!("Unsupported");
+    }
 }

--- a/src/tools/genpolicy/src/no_policy.rs
+++ b/src/tools/genpolicy/src/no_policy.rs
@@ -67,4 +67,8 @@ impl yaml::K8sResource for NoPolicyResource {
     fn use_host_network(&self) -> bool {
         panic!("Unsupported");
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        panic!("Unsupported");
+    }
 }

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -78,6 +78,9 @@ pub struct PodSpec {
     pub hostNetwork: Option<bool>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub shareProcessNamespace: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     dnsConfig: Option<PodDNSConfig>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -734,6 +737,13 @@ impl yaml::K8sResource for Pod {
     fn use_host_network(&self) -> bool {
         if let Some(host_network) = self.spec.hostNetwork {
             return host_network;
+        }
+        false
+    }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        if let Some(shared) = self.spec.shareProcessNamespace {
+            return shared;
         }
         false
     }

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -256,6 +256,9 @@ pub struct ContainerPolicy {
     /// Data compared with req.storages for CreateContainerRequest calls.
     storages: Vec<agent::Storage>,
 
+    /// Data compared with req.sandbox_pidns for CreateContainerRequest calls.
+    sandbox_pidns: bool,
+
     /// Allow list of ommand lines that are allowed to be executed using
     /// ExecProcessRequest. By default, all ExecProcessRequest calls are blocked
     /// by the policy.
@@ -518,6 +521,11 @@ impl AgentPolicy {
             linux.ReadonlyPaths = c_settings.Linux.ReadonlyPaths.clone();
         }
 
+        let sandbox_pidns = if is_pause_container {
+            false
+        } else {
+            resource.use_sandbox_pidns()
+        };
         let exec_commands = yaml_container.get_exec_commands();
 
         ContainerPolicy {
@@ -531,6 +539,7 @@ impl AgentPolicy {
                 Linux: linux,
             },
             storages,
+            sandbox_pidns,
             exec_commands,
         }
     }

--- a/src/tools/genpolicy/src/replica_set.rs
+++ b/src/tools/genpolicy/src/replica_set.rs
@@ -99,4 +99,11 @@ impl yaml::K8sResource for ReplicaSet {
         }
         false
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        if let Some(shared) = self.spec.template.spec.shareProcessNamespace {
+            return shared;
+        }
+        false
+    }
 }

--- a/src/tools/genpolicy/src/replication_controller.rs
+++ b/src/tools/genpolicy/src/replication_controller.rs
@@ -101,4 +101,11 @@ impl yaml::K8sResource for ReplicationController {
         }
         false
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        if let Some(shared) = self.spec.template.spec.shareProcessNamespace {
+            return shared;
+        }
+        false
+    }
 }

--- a/src/tools/genpolicy/src/secret.rs
+++ b/src/tools/genpolicy/src/secret.rs
@@ -111,4 +111,8 @@ impl yaml::K8sResource for Secret {
     fn use_host_network(&self) -> bool {
         panic!("Unsupported");
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        panic!("Unsupported");
+    }
 }

--- a/src/tools/genpolicy/src/stateful_set.rs
+++ b/src/tools/genpolicy/src/stateful_set.rs
@@ -174,6 +174,13 @@ impl yaml::K8sResource for StatefulSet {
         }
         false
     }
+
+    fn use_sandbox_pidns(&self) -> bool {
+        if let Some(shared) = self.spec.template.spec.shareProcessNamespace {
+            return shared;
+        }
+        false
+    }
 }
 
 impl StatefulSet {

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -65,6 +65,7 @@ pub trait K8sResource {
     fn get_containers(&self) -> &Vec<pod::Container>;
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>>;
     fn use_host_network(&self) -> bool;
+    fn use_sandbox_pidns(&self) -> bool;
 }
 
 /// See Reference / Kubernetes API / Common Definitions / LabelSelector.


### PR DESCRIPTION
Validate the sandbox_pidns field value for CreateSandbox and CreateContainer.

For a simple, sanity test, using a Kata CI YAML file:

genpolicy -u -y busybox-pod.yaml

k apply -f busybox-pod.yaml

k get pods | grep busybox
busybox                                                 2/2     Running   0          29s

Fixes: #8868