### PR TITLE
packaging:  Don't always build the kata-agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ src/agent/protocols/src/*.rs
 !src/agent/protocols/src/lib.rs
 build
 src/tools/log-parser/kata-log-parser
+tools/packaging/static-build/agent/install_libseccomp.sh

--- a/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/alpine/Dockerfile.in
@@ -25,6 +25,7 @@ RUN apk update && apk add --no-cache \
     musl \
     musl-dev \
     protoc \
-    tar
+    tar \
+    xz
 # aarch64 requires this name -- link for all
 RUN ln -s /usr/bin/gcc "/usr/bin/$(uname -m)-linux-musl-gcc"

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/Dockerfile.in
@@ -10,6 +10,7 @@ RUN tdnf -y install \
     build-essential \
     dnf \
     git \
-    tar
+    tar \
+    xz
 
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/centos/Dockerfile.in
@@ -13,6 +13,7 @@ RUN dnf -y update && \
     file \
     g++ \
     git \
-    protobuf-compiler
+    protobuf-compiler \
+    xz
 
 @INSTALL_RUST@

--- a/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/debian/Dockerfile.in
@@ -32,7 +32,8 @@ RUN apt-get update && apt-get --no-install-recommends install -y \
     systemd \
     tar \
     vim \
-    wget
+    wget \
+    xz-utils
 # aarch64 requires this name -- link for all
 RUN ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"
 

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -680,7 +680,6 @@ EOF
 		make clean
 		make LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP} AGENT_POLICY=${AGENT_POLICY}
 		make install DESTDIR="${ROOTFS_DIR}" LIBC=${LIBC} INIT=${AGENT_INIT}
-		${stripping_tool} ${ROOTFS_DIR}/usr/bin/kata-agent
 		if [ "${SECCOMP}" == "yes" ]; then
 			rm -rf "${libseccomp_install_dir}" "${gperf_install_dir}"
 		fi
@@ -692,6 +691,8 @@ EOF
 	else
 		tar xvJpf ${AGENT_TARBALL} -C ${ROOTFS_DIR}
 	fi
+
+	${stripping_tool} ${ROOTFS_DIR}/usr/bin/kata-agent
 
 	[ -x "${AGENT_DEST}" ] || die "${AGENT_DEST} is not installed in ${ROOTFS_DIR}"
 	OK "Agent installed"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -125,6 +125,14 @@ AGENT_INIT          When set to "yes", use ${AGENT_BIN} as init process in place
 
 AGENT_SOURCE_BIN    Path to the directory of agent binary.
                     If set, use the binary as agent but not build agent package.
+                    AGENT_SOURCE_BIN and AGENT_TARBALL should never be used toghether.
+                    Default value: <not set>
+
+AGENT_TARBALL       Path to the kata-agent.tar.xz tarball to be unpacked inside the
+                    rootfs.
+                    If set, this will take the priority and will be used instead of
+                    building the agent.
+                    AGENT_SOURCE_BIN and AGENT_TARBALL should never be used toghether.
                     Default value: <not set>
 
 AGENT_VERSION       Version of the agent to include in the rootfs.
@@ -419,13 +427,21 @@ build_rootfs_distro()
 		engine_run_args+=" --ulimit nofile=262144:262144"
 		engine_run_args+=" --runtime ${DOCKER_RUNTIME}"
 
-		if [ -z "${AGENT_SOURCE_BIN}" ] ; then
-			engine_run_args+=" -v ${GOPATH_LOCAL}:${GOPATH_LOCAL} --env GOPATH=${GOPATH_LOCAL}"
-		else
+		if [ -n "${AGENT_SOURCE_BIN}" ] && [ -n "${AGENT_TARBALL}" ]; then
+			die "AGENT_SOURCE_BIN and AGENT_TARBALL should never be used together!"
+		fi
+
+		if [ -n "${AGENT_SOURCE_BIN}" ] ; then
 			engine_run_args+=" --env AGENT_SOURCE_BIN=${AGENT_SOURCE_BIN}"
 			engine_run_args+=" -v ${AGENT_SOURCE_BIN}:${AGENT_SOURCE_BIN}"
-			engine_run_args+=" -v ${GOPATH_LOCAL}:${GOPATH_LOCAL} --env GOPATH=${GOPATH_LOCAL}"
 		fi
+
+		if [ -n "${AGENT_TARBALL}" ] ; then
+			engine_run_args+=" --env AGENT_TARBALL=${AGENT_TARBALL}"
+			engine_run_args+=" -v $(dirname ${AGENT_TARBALL}):$(dirname ${AGENT_TARBALL})"
+		fi
+
+		engine_run_args+=" -v ${GOPATH_LOCAL}:${GOPATH_LOCAL} --env GOPATH=${GOPATH_LOCAL}"
 
 		engine_run_args+=" $(docker_extra_args $distro)"
 
@@ -630,7 +646,7 @@ EOF
 	AGENT_DIR="${ROOTFS_DIR}/usr/bin"
 	AGENT_DEST="${AGENT_DIR}/${AGENT_BIN}"
 
-	if [ -z "${AGENT_SOURCE_BIN}" ] ; then
+	if [ -z "${AGENT_SOURCE_BIN}" ] && [ -z "${AGENT_TARBALL}" ] ; then
 		test -r "${HOME}/.cargo/env" && source "${HOME}/.cargo/env"
 		# rust agent needs ${arch}-unknown-linux-${LIBC}
 		if ! (rustup show | grep -v linux-${LIBC} > /dev/null); then
@@ -669,10 +685,12 @@ EOF
 			rm -rf "${libseccomp_install_dir}" "${gperf_install_dir}"
 		fi
 		popd
-	else
+	elif [ "${AGENT_SOURCE_BIN}" ]; then
 		mkdir -p ${AGENT_DIR}
 		cp ${AGENT_SOURCE_BIN} ${AGENT_DEST}
 		OK "cp ${AGENT_SOURCE_BIN} ${AGENT_DEST}"
+	else
+		tar xvJpf ${AGENT_TARBALL} -C ${ROOTFS_DIR}
 	fi
 
 	[ -x "${AGENT_DEST}" ] || die "${AGENT_DEST} is not installed in ${ROOTFS_DIR}"

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -27,7 +27,8 @@ RUN apt-get update && \
     makedev \
     multistrap \
     musl-tools \
-    protobuf-compiler
+    protobuf-compiler \
+    xz-utils
 # aarch64 requires this name -- link for all
 RUN ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"
 

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -20,6 +20,7 @@ source "${packaging_root_dir}/scripts/lib.sh"
 readonly osbuilder_dir="$(cd "${repo_root_dir}/tools/osbuilder" && pwd)"
 
 export GOPATH=${GOPATH:-${HOME}/go}
+export AGENT_TARBALL=${AGENT_TARBALL:-}
 
 ARCH=${ARCH:-$(uname -m)}
 if [ $(uname -m) == "${ARCH}" ]; then
@@ -41,6 +42,7 @@ build_initrd() {
 		OS_VERSION="${os_version}" \
 		ROOTFS_BUILD_DEST="${builddir}/initrd-image" \
 		USE_DOCKER=1 \
+		AGENT_TARBALL="${AGENT_TARBALL}" \
 		AGENT_INIT="yes" \
 		AGENT_POLICY="${AGENT_POLICY:-}"
 	mv "kata-containers-initrd.img" "${install_dir}/${artifact_name}"
@@ -60,6 +62,7 @@ build_image() {
 		USE_DOCKER="1" \
 		IMG_OS_VERSION="${os_version}" \
 		ROOTFS_BUILD_DEST="${builddir}/rootfs-image" \
+		AGENT_TARBALL="${AGENT_TARBALL}" \
 		AGENT_POLICY="${AGENT_POLICY:-}"
 	mv -f "kata-containers.img" "${install_dir}/${artifact_name}"
 	if [ -e "root_hash.txt" ]; then

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -154,19 +154,19 @@ qemu-tdx-experimental-tarball:
 stratovirt-tarball:
 	${MAKE} $@-build
 
-rootfs-image-tarball:
+rootfs-image-tarball: agent-tarball
 	${MAKE} $@-build
 
-rootfs-image-tdx-tarball: kernel-tdx-experimental-tarball
+rootfs-image-tdx-tarball: agent-opa-tarball kernel-tdx-experimental-tarball
 	${MAKE} $@-build
 
-rootfs-initrd-mariner-tarball:
+rootfs-initrd-mariner-tarball: agent-opa-tarball
 	${MAKE} $@-build
 
-rootfs-initrd-sev-tarball: kernel-sev-tarball
+rootfs-initrd-sev-tarball: agent-opa-tarball kernel-sev-tarball
 	${MAKE} $@-build
 
-rootfs-initrd-tarball:
+rootfs-initrd-tarball: agent-tarball
 	${MAKE} $@-build
 
 runk-tarball:

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -64,6 +64,9 @@ kata-tarball: | all-parallel merge-builds
 $(MK_DIR)/dockerbuild/install_yq.sh:
 	$(MK_DIR)/kata-deploy-copy-yq-installer.sh
 
+copy-scripts-for-the-agent-build:
+	${MK_DIR}/kata-deploy-copy-libseccomp-installer.sh
+
 all-parallel: $(MK_DIR)/dockerbuild/install_yq.sh
 	${MAKE} -f $(MK_PATH) all -j $(shell nproc ${CI:+--ignore 1}) V=
 
@@ -76,10 +79,10 @@ serial-targets:
 %-tarball-build: $(MK_DIR)/dockerbuild/install_yq.sh
 	$(call BUILD,$*)
 
-agent-tarball:
+agent-tarball: copy-scripts-for-the-agent-build
 	${MAKE} $@-build
 
-agent-opa-tarball:
+agent-opa-tarball: copy-scripts-for-the-agent-build
 	${MAKE} $@-build
 
 agent-ctl-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -681,6 +681,11 @@ install_agent_helper() {
 		"${final_tarball_path}" \
 		&& return 0
 
+	export LIBSECCOMP_VERSION="$(get_from_kata_deps "externals.libseccomp.version")"
+	export LIBSECCOMP_URL="$(get_from_kata_deps "externals.libseccomp.url")"
+	export GPERF_VERSION="$(get_from_kata_deps "externals.gperf.version")"
+	export GPERF_URL="$(get_from_kata_deps "externals.gperf.url")"
+
 	info "build static agent"
 	DESTDIR="${destdir}" AGENT_POLICY=${agent_policy} "${agent_builder}"
 }

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -140,7 +140,7 @@ install_cached_tarball_component() {
 	local component_tarball_name="${4}"
 	local component_tarball_path="${5}"
 
-	sudo oras pull ${ARTEFACT_REGISTRY}/kata-containers/cached-artefacts/${build_target}:latest-${TARGET_BRANCH}-$(uname -m)
+	sudo oras pull ${ARTEFACT_REGISTRY}/kata-containers/cached-artefacts/${build_target}:latest-${TARGET_BRANCH}-$(uname -m) || return 1
 
 	cached_version="$(cat ${component}-version)"
 	cached_image_version="$(cat ${component}-builder-image-version)"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -156,6 +156,16 @@ install_cached_tarball_component() {
 	mv "${component_tarball_name}" "${component_tarball_path}"
 }
 
+get_agent_tarball_path() {
+	agent_local_build_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build"
+	agent_tarball_name="kata-static-agent.tar.xz"
+	if [ "${AGENT_POLICY:-no}" = "yes" ]; then
+		agent_tarball_name="kata-static-agent-opa.tar.xz"
+	fi
+
+	echo "${agent_local_build_dir}/${agent_tarball_name}"
+}
+
 #Install guest image
 install_image() {
 	local variant="${1:-}"
@@ -195,7 +205,8 @@ install_image() {
 		os_name="$(get_from_kata_deps "assets.image.architecture.${ARCH}.name")"
 		os_version="$(get_from_kata_deps "assets.image.architecture.${ARCH}.version")"
 	fi
-	
+
+	export AGENT_TARBALL=$(get_agent_tarball_path)
 	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --imagetype=image --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
 }
 
@@ -247,6 +258,7 @@ install_initrd() {
 		os_version="$(get_from_kata_deps "assets.initrd.architecture.${ARCH}.version")"
 	fi
 
+	export AGENT_TARBALL=$(get_agent_tarball_path)
 	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --imagetype=initrd --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
 }
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -929,6 +929,8 @@ silent_mode_error_trap() {
 }
 
 main() {
+	git config --global --add safe.directory ${repo_root_dir}
+
 	local build_targets
 	local silent
 	build_targets=(

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-copy-libseccomp-installer.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-copy-libseccomp-installer.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[ -z "${DEBUG}" ] || set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+script_dir=$(dirname "$(readlink -f "$0")")
+install_libseccomp_script_src="${script_dir}/../../../../ci/install_libseccomp.sh"
+install_libseccomp_script_dest="${script_dir}/../../static-build/agent/install_libseccomp.sh"
+
+cp "${install_libseccomp_script_src}" "${install_libseccomp_script_dest}"
+
+# We don't have to import any other file, as we're passing
+# the env vars needed for installing libseccomp and gperf.
+sed -i -e '/^source.*$/d' ${install_libseccomp_script_dest}

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -214,5 +214,5 @@ get_agent_image_name() {
 	libs_dir="${repo_root_dir}/src/libs"
 	agent_dir="${repo_root_dir}/src/agent"
 
-	echo "${BUILDER_REGISTRY}:agent-$(get_last_modification ${libs_dir})-$(get_last_modification ${agent_dir})"
+	echo "${BUILDER_REGISTRY}:agent-$(get_last_modification ${libs_dir})-$(get_last_modification ${agent_dir})-$(uname -m)"
 }

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -207,7 +207,7 @@ get_tools_image_name() {
 	libs_dir="${repo_root_dir}/src/libs"
 	agent_dir="${repo_root_dir}/src/agent"
 
-	echo "${BUILDER_REGISTRY}:tools-$(get_last_modification ${tools_dir})-$(get_last_modification ${libs_dir})-$(get_last_modification ${agent_dir})"
+	echo "${BUILDER_REGISTRY}:tools-$(get_last_modification ${tools_dir})-$(get_last_modification ${libs_dir})-$(get_last_modification ${agent_dir})-$(uname -m)"
 }
 
 get_agent_image_name() {

--- a/tools/packaging/static-build/agent/Dockerfile
+++ b/tools/packaging/static-build/agent/Dockerfile
@@ -2,20 +2,25 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.18
+FROM ubuntu:22.04
 ARG RUST_TOOLCHAIN
 
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
-RUN apk --no-cache add \
-        bash \
-        curl \
-        gcc \
-        git \
-        libcap-ng-static \
-        libseccomp-static \
-        make \
-        musl-dev \
-        openssl-dev \
-        openssl-libs-static \
-        protoc && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+COPY install_libseccomp.sh /usr/bin/install_libseccomp.sh
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN apt-get update && \
+	apt-get --no-install-recommends -y install \
+		ca-certificates \
+		curl \
+		g++ \
+		gcc \
+		libssl-dev \
+		make \
+		musl-tools \
+		openssl \
+		perl \
+		protobuf-compiler && \
+	apt-get clean && rm -rf /var/lib/apt/lists/ && \
+    	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}

--- a/tools/packaging/static-build/agent/build-static-agent.sh
+++ b/tools/packaging/static-build/agent/build-static-agent.sh
@@ -15,19 +15,38 @@ source "${script_dir}/../../scripts/lib.sh"
 init_env() {
 	source "$HOME/.cargo/env"
 
-	export LIBC=musl
+	ARCH=$(uname -m)
+	rust_arch=""
+	case ${ARCH} in
+		"aarch64")
+			export LIBC=musl
+			rust_arch=${ARCH}
+			;;
+		"ppc64le")
+			export LIBC=gnu
+			rust_arch="powerpc64le"
+			;;
+		"x86_64")
+			export LIBC=musl
+			rust_arch=${ARCH}
+			;;
+		"s390x")
+			export LIBC=gnu
+			rust_arch=${ARCH}
+			;;
+	esac
+	rustup target add ${rust_arch}-unknown-linux-${LIBC}
+
 	export LIBSECCOMP_LINK_TYPE=static
 	export LIBSECCOMP_LIB_PATH=/usr/lib
-
-	# This is needed to workaround
-	# https://github.com/sfackler/rust-openssl/issues/1624
-	export OPENSSL_NO_VENDOR=Y
 }
 
 build_agent_from_source() {
 	echo "build agent from source"
 
 	init_env
+
+	/usr/bin/install_libseccomp.sh /usr /usr
 
 	cd src/agent
 	DESTDIR=${DESTDIR} AGENT_POLICY=${AGENT_POLICY} make

--- a/tools/packaging/static-build/agent/build.sh
+++ b/tools/packaging/static-build/agent/build.sh
@@ -26,6 +26,10 @@ sudo docker pull ${container_image} || \
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	--env DESTDIR=${DESTDIR} \
 	--env AGENT_POLICY=${AGENT_POLICY:-no} \
+	--env LIBSECCOMP_VERSION=${LIBSECCOMP_VERSION} \
+	--env LIBSECCOMP_URL=${LIBSECCOMP_URL} \
+	--env GPERF_VERSION=${GPERF_VERSION} \
+	--env GPERF_URL=${GPERF_URL} \
 	-w "${repo_root_dir}" \
 	"${container_image}" \
 	bash -c "${agent_builder}"


### PR DESCRIPTION
There's absolutely no need to always build the Kata Containers agent when building the rootfs. We already have the agent being built / packaged on every PR, and we can rely on that to simply be unpacked into the rootfs, unless there's a change in the agent.

Please, see each commit for more info.