### PR TITLE
genpolicy: optional PodTemplateSpec metadata field

### DIFF
--- a/src/tools/genpolicy/src/daemon_set.rs
+++ b/src/tools/genpolicy/src/daemon_set.rs
@@ -111,7 +111,7 @@ impl yaml::K8sResource for DaemonSet {
     }
 
     fn serialize(&mut self, policy: &str) -> String {
-        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template.metadata", policy);
+        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template", policy);
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 
@@ -120,7 +120,10 @@ impl yaml::K8sResource for DaemonSet {
     }
 
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
-        &self.spec.template.metadata.annotations
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.annotations;
+        }
+        &None
     }
 
     fn use_host_network(&self) -> bool {

--- a/src/tools/genpolicy/src/deployment.rs
+++ b/src/tools/genpolicy/src/deployment.rs
@@ -109,7 +109,7 @@ impl yaml::K8sResource for Deployment {
     }
 
     fn serialize(&mut self, policy: &str) -> String {
-        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template.metadata", policy);
+        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template", policy);
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 
@@ -118,7 +118,10 @@ impl yaml::K8sResource for Deployment {
     }
 
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
-        &self.spec.template.metadata.annotations
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.annotations;
+        }
+        &None
     }
 
     fn use_host_network(&self) -> bool {

--- a/src/tools/genpolicy/src/job.rs
+++ b/src/tools/genpolicy/src/job.rs
@@ -83,7 +83,7 @@ impl yaml::K8sResource for Job {
     }
 
     fn serialize(&mut self, policy: &str) -> String {
-        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template.metadata", policy);
+        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template", policy);
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 
@@ -92,7 +92,10 @@ impl yaml::K8sResource for Job {
     }
 
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
-        &self.spec.template.metadata.annotations
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.annotations;
+        }
+        &None
     }
 
     fn use_host_network(&self) -> bool {

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -719,7 +719,7 @@ impl yaml::K8sResource for Pod {
     }
 
     fn serialize(&mut self, policy: &str) -> String {
-        yaml::add_policy_annotation(&mut self.doc_mapping, "metadata", policy);
+        yaml::add_policy_annotation(&mut self.doc_mapping, "", policy);
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 

--- a/src/tools/genpolicy/src/pod_template.rs
+++ b/src/tools/genpolicy/src/pod_template.rs
@@ -23,6 +23,8 @@ pub struct PodTemplate {
 /// Reference / Kubernetes API / Workload /  Resources / PodTemplate.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PodTemplateSpec {
-    pub metadata: obj_meta::ObjectMeta,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<obj_meta::ObjectMeta>,
+
     pub spec: pod::PodSpec,
 }

--- a/src/tools/genpolicy/src/replica_set.rs
+++ b/src/tools/genpolicy/src/replica_set.rs
@@ -81,7 +81,7 @@ impl yaml::K8sResource for ReplicaSet {
     }
 
     fn serialize(&mut self, policy: &str) -> String {
-        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template.metadata", policy);
+        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template", policy);
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 
@@ -90,7 +90,10 @@ impl yaml::K8sResource for ReplicaSet {
     }
 
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
-        &self.spec.template.metadata.annotations
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.annotations;
+        }
+        &None
     }
 
     fn use_host_network(&self) -> bool {

--- a/src/tools/genpolicy/src/replication_controller.rs
+++ b/src/tools/genpolicy/src/replication_controller.rs
@@ -83,7 +83,7 @@ impl yaml::K8sResource for ReplicationController {
     }
 
     fn serialize(&mut self, policy: &str) -> String {
-        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template.metadata", policy);
+        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template", policy);
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 
@@ -92,7 +92,10 @@ impl yaml::K8sResource for ReplicationController {
     }
 
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
-        &self.spec.template.metadata.annotations
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.annotations;
+        }
+        &None
     }
 
     fn use_host_network(&self) -> bool {

--- a/src/tools/genpolicy/src/stateful_set.rs
+++ b/src/tools/genpolicy/src/stateful_set.rs
@@ -156,7 +156,7 @@ impl yaml::K8sResource for StatefulSet {
     }
 
     fn serialize(&mut self, policy: &str) -> String {
-        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template.metadata", policy);
+        yaml::add_policy_annotation(&mut self.doc_mapping, "spec.template", policy);
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 
@@ -165,7 +165,10 @@ impl yaml::K8sResource for StatefulSet {
     }
 
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
-        &self.spec.template.metadata.annotations
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.annotations;
+        }
+        &None
     }
 
     fn use_host_network(&self) -> bool {

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -264,10 +264,23 @@ pub fn add_policy_annotation(
     let policy_key = serde_yaml::Value::String("io.katacontainers.config.agent.policy".to_string());
     let policy_value = serde_yaml::Value::String(policy.to_string());
 
-    let path_components = metadata_path.split('.');
-    for name in path_components {
-        ancestor = ancestor.get_mut(name).unwrap();
+    if !metadata_path.is_empty() {
+        let path_components = metadata_path.split('.');
+        for name in path_components {
+            ancestor = ancestor.get_mut(name).unwrap();
+        }
     }
+
+    // Add metadata to the output if the input YAML didn't include it.
+    let metadata = "metadata";
+    if ancestor.get(metadata).is_none() {
+        let new_mapping = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+        ancestor
+            .as_mapping_mut()
+            .unwrap()
+            .insert(serde_yaml::Value::String(metadata.to_string()), new_mapping);
+    }
+    ancestor = ancestor.get_mut(metadata).unwrap();
 
     if let Some(annotations) = ancestor.get_mut(&annotations_key) {
         if let Some(annotation) = annotations.get_mut(&policy_key) {


### PR DESCRIPTION
Add metadata containing the Policy annotation if the user didn't provide any metadata in the input yaml file.

For a simple sanity test using a Kata CI YAML file:

genpolicy -u -y job.yaml

kubectl apply -f job.yaml

kubectl get pods | grep job
job-pi-test-64dxs 0/1     Completed   0          14s

Fixes: #8891