### PR TITLE
Made doc changes to remove deprecate --container-runtime flag

### DIFF
--- a/docs/how-to/how-to-use-k8s-with-containerd-and-kata.md
+++ b/docs/how-to/how-to-use-k8s-with-containerd-and-kata.md
@@ -45,7 +45,7 @@ In order to allow Kubelet to use containerd (using the CRI interface), configure
   $ sudo mkdir -p  /etc/systemd/system/kubelet.service.d/
   $ cat << EOF | sudo tee  /etc/systemd/system/kubelet.service.d/0-containerd.conf
   [Service]                                                 
-  Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+  Environment="KUBELET_EXTRA_ARGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
   EOF
   ```
 

--- a/docs/how-to/run-kata-with-k8s.md
+++ b/docs/how-to/run-kata-with-k8s.md
@@ -74,7 +74,7 @@ implementation you chose, and the Kubelet service has to be updated accordingly.
 `/etc/systemd/system/kubelet.service.d/0-crio.conf`
 ```
 [Service]
-Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///var/run/crio/crio.sock"
+Environment="KUBELET_EXTRA_ARGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///var/run/crio/crio.sock"
 ```
 
 ### Configure for containerd
@@ -82,7 +82,7 @@ Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-tim
 `/etc/systemd/system/kubelet.service.d/0-cri-containerd.conf`
 ```
 [Service]
-Environment="KUBELET_EXTRA_ARGS=--container-runtime=remote --runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
+Environment="KUBELET_EXTRA_ARGS=--runtime-request-timeout=15m --container-runtime-endpoint=unix:///run/containerd/containerd.sock"
 ```
 For more information about containerd see the "Configure Kubelet to use containerd"
 documentation [here](../how-to/how-to-use-k8s-with-containerd-and-kata.md#configure-kubelet-to-use-containerd).


### PR DESCRIPTION
Made doc changes to how-to-use-k8s-with-containerd-and-kata and run-kata-with-k8s. Removed deprecated --container-runtime flag