### PR TITLE
genpolicy: fix ConfigMap volume mount paths

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -258,7 +258,7 @@
         ]
     },
     "kata_config": {
-        "confidential_guest": true
+        "confidential_guest": false
     },
     "request_defaults": {
         "CreateContainerRequest": {

--- a/src/tools/genpolicy/src/secret.rs
+++ b/src/tools/genpolicy/src/secret.rs
@@ -33,6 +33,9 @@ pub struct Secret {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     immutable: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    r#type: Option<String>,
     // TODO: additional fields.
 }
 


### PR DESCRIPTION
Allow Kata CI's pod-nested-configmap-secret.yaml to work with
genpolicy and current cbl-mariner images:

1. Ignore the optional type field of Secret input YAML files.

    It's possible that CoCo will need a more sophisticated Policy
    for Secrets, but this change at least unblocks CI testing for
    already-existing genpolicy features.

2. Adapt the value of the settings field below to fit current CI
    images for testing on cbl-mariner Hosts:

    "kata_config": {
        "confidential_guest": false
    },

    Switching this value from true to false instructs genpolicy to
    expect ConfigMap volume mounts similar to:

        "configMap": {
            "mount_type": "bind",
            "mount_source": "$(sfprefix)",
            "mount_point": "^$(cpath)/watchable/$(bundle-id)-[a-z0-9]{16}-",
            "driver": "watchable-bind",
            "fstype": "bind",
            "options": [
                "rbind",
                "rprivate",
                "ro"
            ]
        },

    instead of:

        "confidential_configMap": {
            "mount_type": "bind",
            "mount_source": "$(sfprefix)",
            "mount_point": "$(sfprefix)",
            "driver": "local",
            "fstype": "bind",
            "options": [
                "rbind",
                "rprivate",
                "ro"
            ]
        }
    },

    This settings change unblocks CI testing for ConfigMaps.

Simple sanity testing for these changes:

genpolicy -u -y pod-nested-configmap-secret.yaml

kubectl apply -f pod-nested-configmap-secret.yaml

kubectl get pods | grep config
nested-configmap-secret-pod 1/1     Running   0          26s

Fixes: #8892
