### PR TITLE
gha: Cache the agent for non-x86_64 arches

### DIFF
--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -27,6 +27,7 @@ jobs:
     strategy:
       matrix:
         asset:
+          - agent
           - cloud-hypervisor
           - firecracker
           - kernel

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -27,6 +27,7 @@ jobs:
     strategy:
       matrix:
         asset:
+          - agent
           - kernel
           - qemu
           - rootfs-initrd

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -27,6 +27,7 @@ jobs:
     strategy:
       matrix:
         asset:
+          - agent
           - kernel
           - qemu
           - rootfs-image


### PR DESCRIPTION
Those are not yet being cached for no reason, and they better be as it'll allow us to save a considerable amount of time building the rootfs.

Fixes: #8917

NOTE: The agent-opa is not in the scope for this, and I will leave it for the maintainers of each specific architecture to do so, and to also add the dependency to their specific rootfs as done for this one in a previous commit.