### PR TITLE
dragonball: fix noop-method-call warning

### DIFF
--- a/src/dragonball/src/dbs_virtio_devices/src/block/handler.rs
+++ b/src/dragonball/src/dbs_virtio_devices/src/block/handler.rs
@@ -94,7 +94,7 @@ impl<AS: DbsGuestAddressSpace, Q: QueueT> InnerBlockEpollHandler<AS, Q> {
                         data_descs,
                         iovecs,
                         &mut self.disk_image,
-                        mem.deref(),
+                        mem,
                     ) {
                         Ok(submited) => {
                             if submited {
@@ -104,7 +104,7 @@ impl<AS: DbsGuestAddressSpace, Q: QueueT> InnerBlockEpollHandler<AS, Q> {
                             // Else not Submited, fallback to synchronous processing
                         }
                         Err(_e) => {
-                            req.update_status(mem.deref(), VIRTIO_BLK_S_IOERR);
+                            req.update_status(mem, VIRTIO_BLK_S_IOERR);
                             used_desc_vec.push((index, 0));
                             continue 'next_desc;
                         }
@@ -118,7 +118,7 @@ impl<AS: DbsGuestAddressSpace, Q: QueueT> InnerBlockEpollHandler<AS, Q> {
                         &data_descs[..],
                         &mut self.disk_image,
                         &self.disk_image_id,
-                        mem.deref(),
+                        mem,
                     ) {
                         Ok(num_bytes_to_mem) => {
                             used_desc_vec.push((index, num_bytes_to_mem));
@@ -180,9 +180,9 @@ impl<AS: DbsGuestAddressSpace, Q: QueueT> InnerBlockEpollHandler<AS, Q> {
         disk_image_id: &[u8],
         mem: &M,
     ) -> std::result::Result<u32, ExecuteError> {
-        match req.execute(disk_image, mem.deref(), data_descs, disk_image_id) {
+        match req.execute(disk_image, mem, data_descs, disk_image_id) {
             Ok(l) => {
-                req.update_status(mem.deref(), VIRTIO_BLK_S_OK);
+                req.update_status(mem, VIRTIO_BLK_S_OK);
                 Ok(l)
             }
             Err(e) => {
@@ -229,7 +229,7 @@ impl<AS: DbsGuestAddressSpace, Q: QueueT> InnerBlockEpollHandler<AS, Q> {
                     }
                 };
 
-                req.update_status(mem.deref(), err_code);
+                req.update_status(mem, err_code);
                 Err(e)
             }
         }


### PR DESCRIPTION
The [`noop-method-call`](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#noop-method-call) is a rustc lint that has existed since [v1.52.0](https://github.com/rust-lang/rust/pull/80723).
This lint has been moved to the warn by default lint level since [v1.73.0](https://github.com/rust-lang/rust/pull/111916).
Therefore build is failing with this version and above.
This commit removes the unnecessary call to `<&T as Deref>::deref` on `T: !Deref`.

Fixes: #8586

Signed-off-by: Kvlil <kalil.pelissier@gmail.com>
