### PR TITLE
genpolicy: ignore the nodeName field

### DIFF
--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -60,6 +60,9 @@ pub struct PodSpec {
     pub volumes: Option<Vec<volume::Volume>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    nodeName: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     serviceAccountName: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Validating the node name is currently outside the scope of the CoCo policy.

This change unblocks testing using Kata CI's test-pod-file-volume.yaml and pv-pod.yaml.

Fixes: #8888