### PR TITLE
tests: cri-o: Use packages from pkgs.k8s.io

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -248,7 +248,7 @@ externals:
     version: "1.23.0"
     # As we don't want to disrupt what we have on the `tests` repo, let's
     # create a "latest" entry and use that for the GitHub actions tests.
-    latest: "v1.27"
+    latest: "v1.29"
 
   cryptsetup:
     description: "A utility used to setup disk encryption, integrity protection"


### PR DESCRIPTION
CRI-O has moved, for a long time, towards pkgs.k8s.io, see:
https://kubernetes.io/blog/2023/10/10/cri-o-community-package-infrastructure/

With this the OBS repo won't be used anymore.

Fixes: #8935