### PR TITLE
runtime-rs: Log qemu's stderr in shim log

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -46,14 +46,14 @@ impl QemuInner {
         info!(sl!(), "Preparing QEMU VM");
         self.id = id.to_string();
 
+        let vm_path = [KATA_PATH, self.id.as_str()].join("/");
+        std::fs::create_dir_all(vm_path)?;
+
         Ok(())
     }
 
     pub(crate) async fn start_vm(&mut self, _timeout: i32) -> Result<()> {
         info!(sl!(), "Starting QEMU VM");
-
-        let vm_path = [KATA_PATH, self.id.as_str()].join("/");
-        std::fs::create_dir_all(vm_path)?;
 
         let mut cmdline = QemuCmdLine::new(&self.id, &self.config)?;
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -58,7 +58,7 @@ impl Hypervisor for Qemu {
 
     async fn stop_vm(&self) -> Result<()> {
         let mut inner = self.inner.write().await;
-        inner.stop_vm()
+        inner.stop_vm().await
     }
 
     async fn pause_vm(&self) -> Result<()> {


### PR DESCRIPTION
Having a ready access to qemu's stderr is immensely helpful in debugging qemu's launch failures.  Qemu's stderr output is now included in regular shim's log (look for lines prepended with "qemu stderr: ").

An unrelated small fix promised in review of PR #8185 is also included in this PR's initial commit.