### PR TITLE
genpolicy: allow separate paths for rules and settings files

### DIFF
--- a/src/tools/genpolicy/genpolicy-advanced-command-line-parameters.md
+++ b/src/tools/genpolicy/genpolicy-advanced-command-line-parameters.md
@@ -83,10 +83,10 @@ $ genpolicy -j my-settings.json -y test.yaml
 
 # Use a custom path to `genpolicy` input files
 
-By default, the `genpolicy` input files [`rules.rego`](rules.rego) and [`genpolicy-settings.json`](genpolicy-settings.json) must be present in the current directory - otherwise `genpolicy` returns an error. Users can specify a different path to these two files, using the `-i` command line parameter - e.g.,
+By default, the `genpolicy` input files [`rules.rego`](rules.rego) and [`genpolicy-settings.json`](genpolicy-settings.json) must be present in the current directory - otherwise `genpolicy` returns an error. Users can specify different paths to these two files, using the `-p` and `-j` command line parameters - e.g.,
 
 ```bash
-$ genpolicy -i /tmp -y test.yaml
+$ genpolicy -p /tmp/rules.rego -j /tmp/genpolicy-settings.json -y test.yaml
 ```
 
 # Silently ignore unsupported input `YAML` fields

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -392,7 +392,7 @@ impl AgentPolicy {
             resources.push(resource);
         }
 
-        let settings = settings::Settings::new(&config.settings_file);
+        let settings = settings::Settings::new(&config.json_settings_path);
 
         if let Some(config_map_files) = &config.config_map_files {
             for file in config_map_files {
@@ -400,7 +400,7 @@ impl AgentPolicy {
             }
         }
 
-        if let Ok(rules) = read_to_string(&config.rules_file) {
+        if let Ok(rules) = read_to_string(&config.rego_rules_path) {
             Ok(AgentPolicy {
                 resources,
                 rules,
@@ -410,8 +410,8 @@ impl AgentPolicy {
                 config: config.clone(),
             })
         } else {
-            panic!("Cannot open file {}. Please copy it to the current directory or specify the path to it using the -i parameter.",
-                &config.rules_file);
+            panic!("Cannot open file {}. Please copy it to the current directory or specify the path to it using the -p parameter.",
+                &config.rego_rules_path);
         }
     }
 

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -65,15 +65,15 @@ pub struct KataConfig {
 }
 
 impl Settings {
-    pub fn new(settings_file: &str) -> Self {
+    pub fn new(json_settings_path: &str) -> Self {
         debug!("Loading settings file...");
-        if let Ok(file) = File::open(settings_file) {
+        if let Ok(file) = File::open(json_settings_path) {
             let settings: Self = serde_json::from_reader(file).unwrap();
             debug!("settings = {:?}", &settings);
             settings
         } else {
-            panic!("Cannot open file {}. Please copy it to the current directory or specify the path to it using the -i parameter.", 
-                settings_file);
+            panic!("Cannot open file {}. Please copy it to the current directory or specify the path to it using the -p parameter.",
+                json_settings_path);
         }
     }
 

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -4,7 +4,6 @@
 //
 
 use clap::Parser;
-use log::debug;
 
 #[derive(Debug, Parser)]
 struct CommandLineOptions {
@@ -23,20 +22,20 @@ struct CommandLineOptions {
     config_map_file: Option<String>,
 
     #[clap(
+        short = 'p',
+        long,
+        default_value_t = String::from("rules.rego"),
+        help = "Path to rego rules file"
+    )]
+    rego_rules_path: String,
+
+    #[clap(
         short = 'j',
         long,
         default_value_t = String::from("genpolicy-settings.json"),
-        help = "genpolicy settings file name"
+        help = "Path to genpolicy settings file"
     )]
-    settings_file_name: String,
-
-    #[clap(
-        short,
-        long,
-        default_value_t = String::from("."),
-        help = "Path to the rules.rego and settings input files"
-    )]
-    input_files_path: String,
+    json_settings_path: String,
 
     #[clap(
         short,
@@ -73,8 +72,8 @@ pub struct Config {
     pub use_cache: bool,
 
     pub yaml_file: Option<String>,
-    pub rules_file: String,
-    pub settings_file: String,
+    pub rego_rules_path: String,
+    pub json_settings_path: String,
     pub config_map_files: Option<Vec<String>>,
 
     pub silent_unsupported_fields: bool,
@@ -97,17 +96,11 @@ impl Config {
             None
         };
 
-        let rules_file = format!("{}/rules.rego", &args.input_files_path);
-        debug!("Rules file: {rules_file}");
-
-        let settings_file = format!("{}/{}", &args.input_files_path, &args.settings_file_name);
-        debug!("Settings file: {settings_file}");
-
         Self {
             use_cache: args.use_cached_files,
             yaml_file: args.yaml_file,
-            rules_file,
-            settings_file,
+            rego_rules_path: args.rego_rules_path,
+            json_settings_path: args.json_settings_path,
             config_map_files: cm_files,
             silent_unsupported_fields: args.silent_unsupported_fields,
             raw_out: args.raw_out,


### PR DESCRIPTION
Using custom input paths with -i is counter-intuitive. Simplify path handling with explicit flags for rules.rego and genpolicy-settings.json.

Fixes: #8568

I'm quite new here, but I think @danmihai1 might be a good person to review this.

<strike>Note: I couldn't come up with a good short flag for `--rules-file` (`--raw-out` is using `-r`). Suggestions are welcome.</strike>