### PR TITLE
gha: static-checks: Switch to using GHA for KVM tests

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -141,7 +141,7 @@ jobs:
           RUST_BACKTRACE: "1"
 
   build-checks-depending-on-kvm:
-    runs-on: garm-ubuntu-2004-smaller
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This may be possible as the new runners may have virtualisation enabled. Let's see ...