### PR TITLE
runtime-rs: ch: implement full hypervisor metrics method

### DIFF
--- a/docs/design/kata-metrics-in-runtime-rs.md
+++ b/docs/design/kata-metrics-in-runtime-rs.md
@@ -40,6 +40,8 @@ Here are listed all the metrics gathered by `runtime-rs`.
 
 Different from golang runtime, hypervisor and shim in runtime-rs belong to the **same process**, so all previous metrics for hypervisor and shim only need to be gathered once. Thus, we currently only collect previous metrics in kata shim.
 
+#### Dragonball
+
 At the same time, we added the interface(`VmmAction::GetHypervisorMetrics`) to gather hypervisor metrics, in case we design tailor-made metrics for hypervisor in the future. Here're metrics exposed from [src/dragonball/src/metric.rs](https://github.com/kata-containers/kata-containers/blob/main/src/dragonball/src/metric.rs).
 
 | Metric name                                                  | Type       | Units | Labels                                                       |
@@ -48,3 +50,11 @@ At the same time, we added the interface(`VmmAction::GetHypervisorMetrics`) to g
 | `kata_hypervisor_vcpu`: <br>Hypervisor metrics specific to VCPUs' mode of functioning. | `IntGauge` |       | <ul><li>`item`<ul><li>`exit_io_in`</li><li>`exit_io_out`</li><li>`exit_mmio_read`</li><li>`exit_mmio_write`</li><li>`failures`</li><li>`filter_cpuid`</li></ul></li><li>`sandbox_id`</li></ul> |
 | `kata_hypervisor_seccomp`: <br> Hypervisor metrics for the seccomp filtering. | `IntGauge` |       | <ul><li>`item`<ul><li>`num_faults`</li></ul></li><li>`sandbox_id`</li></ul> |
 | `kata_hypervisor_seccomp`: <br> Hypervisor metrics for the seccomp filtering. | `IntGauge` |       | <ul><li>`item`<ul><li>`sigbus`</li><li>`sigsegv`</li></ul></li><li>`sandbox_id`</li></ul> |
+
+#### CloudHypervisor
+
+| Metric name                                                  | Type       | Units | Labels                                                       |
+| ------------------------------------------------------------ | ---------- | ----- | ------------------------------------------------------------ |
+| `kata_hypervisor_scrape_count`: <br> Metrics scrape count    | `COUNTER`  |       | <ul><li>`sandbox_id`</li></ul>                               |
+| `kata_hypervisor_netdev`: <br> Kata container guest network devices statistics. | `GAUGE`     |                | <ul><li>`device` (network device name)</li><li>`item`<ul><li>`rx_bytes`</li><li>`rx_frames`</li><li>`tx_bytes`</li><li>`tx_frames`</li></ul></li><li>`sandbox_id`</li></ul> |
+| `kata_hypervisor_blockdev`: <br> Kata container guest block devices statistics. | `GAUGE`     |                | <ul><li>`device` (network device name)</li><li>`item`<ul><li>`read_bytes`</li><li>`read_latency_avg`</li><li>`read_latency_max`</li><li>`read_latency_min`</li><li>`read_ops`</li><li>`read_bytes`</li><li>`read_latency_avg`</li><li>`read_latency_max`</li><li>`read_latency_min`</li><li>`read_ops`</li></ul></li><li>`sandbox_id`</li></ul> |

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/ch_api.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/ch_api.rs
@@ -20,6 +20,17 @@ pub async fn cloud_hypervisor_vmm_ping(mut socket: UnixStream) -> Result<Option<
     .await?
 }
 
+pub async fn cloud_hypervisor_vm_counters(mut socket: UnixStream) -> Result<Option<String>> {
+    task::spawn_blocking(move || -> Result<Option<String>> {
+        let response =
+            simple_api_full_command_and_response(&mut socket, "GET", "vm.counters", None)
+                .map_err(|e| anyhow!(e))?;
+
+        Ok(response)
+    })
+    .await?
+}
+
 pub async fn cloud_hypervisor_vmm_shutdown(mut socket: UnixStream) -> Result<Option<String>> {
     task::spawn_blocking(move || -> Result<Option<String>> {
         let response =


### PR DESCRIPTION
Implement a full/fuller version of the `get_hypervisor_metrics()` API.
Use CH [`VmCounters`](https://github.com/cloud-hypervisor/cloud-hypervisor/blob/7c4ca2bcf97c792936abe2a5e2fb64ca6b5c0ff1/vmm/src/api/openapi/cloud-hypervisor.yaml#L44) API to gather metrics.

Fixes: #8800 

Signed-off-by: Kvlil <kalil.pelissier@gmail.com>
