### PR TITLE
gha: azure: Set the correct subscription to the account

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -84,6 +84,7 @@ jobs:
           AZ_APPID: ${{ secrets.AZ_APPID }}
           AZ_PASSWORD: ${{ secrets.AZ_PASSWORD }}
           AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
+          AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
 
       - name: Create AKS cluster
         timeout-minutes: 10

--- a/.github/workflows/run-kata-deploy-tests-on-aks.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-aks.yaml
@@ -67,6 +67,7 @@ jobs:
           AZ_APPID: ${{ secrets.AZ_APPID }}
           AZ_PASSWORD: ${{ secrets.AZ_PASSWORD }}
           AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
+          AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
 
       - name: Create AKS cluster
         timeout-minutes: 10

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -52,6 +52,9 @@ function login_azure() {
         -u "${AZ_APPID}" \
         -p "${AZ_PASSWORD}" \
         --tenant "${AZ_TENANT_ID}"
+
+    # Switch to the Kata Containers subscription
+    az account set --subscription "${AZ_SUBSCRIPTION_ID}"
 }
 
 function create_cluster() {


### PR DESCRIPTION
Due to the changes done in the CI, we need to set the correct subscription to be used with the account from now on, otherwise we'd end up using CoCo subscription.