### PR TITLE
packaging: Use Ubuntu 20.04 for building an agent

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -181,11 +181,13 @@ install_image() {
 
 	local osbuilder_last_commit="$(get_last_modification "${repo_root_dir}/tools/osbuilder")"
 	local guest_image_last_commit="$(get_last_modification "${repo_root_dir}/tools/packaging/guest-image")"
-	local agent_last_commit="$(get_last_modification "${repo_root_dir}/src/agent")"
 	local libs_last_commit="$(get_last_modification "${repo_root_dir}/src/libs")"
 	local gperf_version="$(get_from_kata_deps "externals.gperf.version")"
 	local libseccomp_version="$(get_from_kata_deps "externals.libseccomp.version")"
 	local rust_version="$(get_from_kata_deps "languages.rust.meta.newest-version")"
+	local agent_last_commit=$(merge_two_hashes \
+		"$(get_last_modification "${repo_root_dir}/src/agent")" \
+		"$(get_last_modification "${repo_root_dir}/tools/packaging/static-build/agent")")
 
 	latest_artefact="${osbuilder_last_commit}-${guest_image_last_commit}-${agent_last_commit}-${libs_last_commit}-${gperf_version}-${libseccomp_version}-${rust_version}-${image_type}"
 	latest_builder_image=""
@@ -231,11 +233,13 @@ install_initrd() {
 
 	local osbuilder_last_commit="$(get_last_modification "${repo_root_dir}/tools/osbuilder")"
 	local guest_image_last_commit="$(get_last_modification "${repo_root_dir}/tools/packaging/guest-image")"
-	local agent_last_commit="$(get_last_modification "${repo_root_dir}/src/agent")"
 	local libs_last_commit="$(get_last_modification "${repo_root_dir}/src/libs")"
 	local gperf_version="$(get_from_kata_deps "externals.gperf.version")"
 	local libseccomp_version="$(get_from_kata_deps "externals.libseccomp.version")"
 	local rust_version="$(get_from_kata_deps "languages.rust.meta.newest-version")"
+	local agent_last_commit=$(merge_two_hashes \
+		"$(get_last_modification "${repo_root_dir}/src/agent")" \
+		"$(get_last_modification "${repo_root_dir}/tools/packaging/static-build/agent")")
 
 	latest_artefact="${osbuilder_last_commit}-${guest_image_last_commit}-${agent_last_commit}-${libs_last_commit}-${gperf_version}-${libseccomp_version}-${rust_version}-${initrd_type}"
 	latest_builder_image=""

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -95,6 +95,13 @@ get_kata_hash() {
 	git ls-remote --heads --tags "https://github.com/${project}/${repo}.git" | grep "${ref}" | awk '{print $1}'
 }
 
+merge_two_hashes() {
+	local hash1="${1}"
+	local hash2="${2}"
+
+	echo "${hash1}${hash2}" | sha256sum | cut -c1-9
+}
+
 # $1 - The file we're looking for the last modification
 get_last_modification() {
 	local file="${1}"
@@ -211,10 +218,12 @@ get_tools_image_name() {
 }
 
 get_agent_image_name() {
-	libs_dir="${repo_root_dir}/src/libs"
-	agent_dir="${repo_root_dir}/src/agent"
+	libseccomp_hash=$(merge_two_hashes \
+		"$(get_last_modification "${repo_root_dir}/ci/install_libseccomp.sh")" \
+		"$(get_last_modification "${repo_root_dir}/tools/packaging/kata-deploy/local-build/kata-deploy-copy-libseccomp-installer.sh")")
+	agent_dir="${repo_root_dir}/tools/packaging/static-build/agent"
 
-	echo "${BUILDER_REGISTRY}:agent-$(get_last_modification ${libs_dir})-$(get_last_modification ${agent_dir})-$(uname -m)"
+	echo "${BUILDER_REGISTRY}:agent-${libseccomp_hash}-$(get_last_modification ${agent_dir})-$(uname -m)"
 }
 
 get_coco_guest_components_image_name() {

--- a/tools/packaging/static-build/agent/Dockerfile
+++ b/tools/packaging/static-build/agent/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:22.04
+FROM ubuntu:20.04
 ARG RUST_TOOLCHAIN
 
 COPY install_libseccomp.sh /usr/bin/install_libseccomp.sh
@@ -24,3 +24,6 @@ RUN apt-get update && \
 		protobuf-compiler && \
 	apt-get clean && rm -rf /var/lib/apt/lists/ && \
     	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+
+# aarch64 requires this name -- link for all
+RUN ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"


### PR DESCRIPTION
This involves using Ubuntu 20.04 as a build environment for an agent to match with a runtime environment.

Fixes: #8955

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>