### PR TITLE
gha: cri-o: Bump runners to 22.04

### DIFF
--- a/.github/workflows/run-k8s-tests-with-crio-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-with-crio-on-garm.yaml
@@ -32,12 +32,12 @@ jobs:
         k8s:
           - k0s
         instance:
-          - garm-ubuntu-2004
-          - garm-ubuntu-2004-smaller
+          - garm-ubuntu-2204
+          - garm-ubuntu-2204-smaller
         include:
-          - instance: garm-ubuntu-2004
+          - instance: garm-ubuntu-2204
             instance-type: normal
-          - instance: garm-ubuntu-2004-smaller
+          - instance: garm-ubuntu-2204-smaller
             instance-type: small
           - k8s: k0s
             k8s-extra-params: '--cri-socket remote:unix:///var/run/crio/crio.sock --kubelet-extra-args --cgroup-driver="systemd"'


### PR DESCRIPTION
This will *not* solve the CRI-O CI breakage but will give us an environment where we could get it to run locally.

Fixes: #8935 -- part I

Thanks to Julien Ropé for trying to reproduce the issues I faced on https://github.com/kata-containers/kata-containers/issues/8935 in an Ubuntu 22.04 system.