### PR TITLE
genpolicy: ignore volume configMap optional field

### DIFF
--- a/src/tools/genpolicy/src/volume.rs
+++ b/src/tools/genpolicy/src/volume.rs
@@ -71,6 +71,7 @@ pub struct PersistentVolumeClaimVolumeSource {
 pub struct ConfigMapVolumeSource {
     pub name: String,
     pub items: Option<Vec<KeyToPath>>,
+    optional: Option<bool>,
     // TODO: additional fields.
 }
 


### PR DESCRIPTION
The auto-generated Policy already allows these volumes to be mounted, regardless if they are:
- Present, or
- Missing and optional

Fixes: #8893