### PR TITLE
genpolicy: support non-default namespace name

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -260,6 +260,9 @@
     "kata_config": {
         "confidential_guest": false
     },
+    "cluster_config": {
+        "default_namespace": "default"
+    },
     "request_defaults": {
         "CreateContainerRequest": {
             "allow_env_regex": [

--- a/src/tools/genpolicy/src/config_map.rs
+++ b/src/tools/genpolicy/src/config_map.rs
@@ -92,10 +92,6 @@ impl yaml::K8sResource for ConfigMap {
         panic!("Unsupported");
     }
 
-    fn get_namespace(&self) -> String {
-        panic!("Unsupported");
-    }
-
     fn get_container_mounts_and_storages(
         &self,
         _policy_mounts: &mut Vec<policy::KataMount>,

--- a/src/tools/genpolicy/src/daemon_set.rs
+++ b/src/tools/genpolicy/src/daemon_set.rs
@@ -84,7 +84,7 @@ impl yaml::K8sResource for DaemonSet {
         None
     }
 
-    fn get_namespace(&self) -> String {
+    fn get_namespace(&self) -> Option<String> {
         self.metadata.get_namespace()
     }
 

--- a/src/tools/genpolicy/src/deployment.rs
+++ b/src/tools/genpolicy/src/deployment.rs
@@ -82,7 +82,7 @@ impl yaml::K8sResource for Deployment {
         None
     }
 
-    fn get_namespace(&self) -> String {
+    fn get_namespace(&self) -> Option<String> {
         self.metadata.get_namespace()
     }
 

--- a/src/tools/genpolicy/src/job.rs
+++ b/src/tools/genpolicy/src/job.rs
@@ -56,7 +56,7 @@ impl yaml::K8sResource for Job {
         None
     }
 
-    fn get_namespace(&self) -> String {
+    fn get_namespace(&self) -> Option<String> {
         self.metadata.get_namespace()
     }
 

--- a/src/tools/genpolicy/src/list.rs
+++ b/src/tools/genpolicy/src/list.rs
@@ -53,10 +53,6 @@ impl yaml::K8sResource for List {
         panic!("Unsupported");
     }
 
-    fn get_namespace(&self) -> String {
-        panic!("Unsupported");
-    }
-
     fn get_container_mounts_and_storages(
         &self,
         _policy_mounts: &mut Vec<policy::KataMount>,

--- a/src/tools/genpolicy/src/no_policy.rs
+++ b/src/tools/genpolicy/src/no_policy.rs
@@ -34,10 +34,6 @@ impl yaml::K8sResource for NoPolicyResource {
         panic!("Unsupported");
     }
 
-    fn get_namespace(&self) -> String {
-        panic!("Unsupported");
-    }
-
     fn get_container_mounts_and_storages(
         &self,
         _policy_mounts: &mut Vec<policy::KataMount>,

--- a/src/tools/genpolicy/src/obj_meta.rs
+++ b/src/tools/genpolicy/src/obj_meta.rs
@@ -33,17 +33,13 @@ impl ObjectMeta {
         if let Some(name) = &self.name {
             name.clone()
         } else if self.generateName.is_some() {
-            return "$(generated-name)".to_string();
+            "$(generated-name)".to_string()
         } else {
             String::new()
         }
     }
 
-    pub fn get_namespace(&self) -> String {
-        if let Some(namespace) = &self.namespace {
-            namespace.clone()
-        } else {
-            "default".to_string()
-        }
+    pub fn get_namespace(&self) -> Option<String> {
+        self.namespace.as_ref().cloned()
     }
 }

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -698,7 +698,7 @@ impl yaml::K8sResource for Pod {
         panic!("No pod name.");
     }
 
-    fn get_namespace(&self) -> String {
+    fn get_namespace(&self) -> Option<String> {
         self.metadata.get_namespace()
     }
 

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -359,6 +359,12 @@ pub struct CommonData {
     pub privileged_caps: Vec<String>,
 }
 
+/// Configuration from "kubectl config".
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ClusterConfig {
+    default_namespace: String,
+}
+
 impl AgentPolicy {
     pub async fn from_files(config: &utils::Config) -> Result<AgentPolicy> {
         let mut config_maps = Vec::new();
@@ -472,7 +478,12 @@ impl AgentPolicy {
         let mut root = c_settings.Root.clone();
         root.Readonly = yaml_container.read_only_root_filesystem();
 
-        let namespace = resource.get_namespace();
+        let namespace = if let Some(ns) = resource.get_namespace() {
+            ns
+        } else {
+            self.settings.cluster_config.default_namespace.clone()
+        };
+
         let use_host_network = resource.use_host_network();
         let annotations = get_container_annotations(
             resource,

--- a/src/tools/genpolicy/src/replica_set.rs
+++ b/src/tools/genpolicy/src/replica_set.rs
@@ -54,7 +54,7 @@ impl yaml::K8sResource for ReplicaSet {
         None
     }
 
-    fn get_namespace(&self) -> String {
+    fn get_namespace(&self) -> Option<String> {
         self.metadata.get_namespace()
     }
 

--- a/src/tools/genpolicy/src/replication_controller.rs
+++ b/src/tools/genpolicy/src/replication_controller.rs
@@ -56,7 +56,7 @@ impl yaml::K8sResource for ReplicationController {
         None
     }
 
-    fn get_namespace(&self) -> String {
+    fn get_namespace(&self) -> Option<String> {
         self.metadata.get_namespace()
     }
 

--- a/src/tools/genpolicy/src/secret.rs
+++ b/src/tools/genpolicy/src/secret.rs
@@ -81,10 +81,6 @@ impl yaml::K8sResource for Secret {
         panic!("Unsupported");
     }
 
-    fn get_namespace(&self) -> String {
-        panic!("Unsupported");
-    }
-
     fn get_container_mounts_and_storages(
         &self,
         _policy_mounts: &mut Vec<policy::KataMount>,

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -20,6 +20,7 @@ pub struct Settings {
     pub other_container: policy::KataSpec,
     pub volumes: Volumes,
     pub kata_config: KataConfig,
+    pub cluster_config: policy::ClusterConfig,
     pub request_defaults: policy::RequestDefaults,
     pub common: policy::CommonData,
     pub mount_destinations: Vec<String>,

--- a/src/tools/genpolicy/src/stateful_set.rs
+++ b/src/tools/genpolicy/src/stateful_set.rs
@@ -104,7 +104,7 @@ impl yaml::K8sResource for StatefulSet {
         None
     }
 
-    fn get_namespace(&self) -> String {
+    fn get_namespace(&self) -> Option<String> {
         self.metadata.get_namespace()
     }
 

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -52,7 +52,9 @@ pub trait K8sResource {
     fn serialize(&mut self, policy: &str) -> String;
 
     fn get_sandbox_name(&self) -> Option<String>;
-    fn get_namespace(&self) -> String;
+    fn get_namespace(&self) -> Option<String> {
+        panic!("Unsupported");
+    }
 
     fn get_container_mounts_and_storages(
         &self,


### PR DESCRIPTION
Allow users to specify in genpolicy-settings.json a default cluster namespace other than "default". For example, Kata CI uses as default namespace: "kata-containers-k8s-tests".

Fixes: #8976