### PR TITLE
kata-deploy: Fix kustomization warnings

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/base/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - kata-cleanup.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/k3s/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_k3s_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_k3s_conf.yaml

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/rke2/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_rke2_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_rke2_conf.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/base/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - kata-deploy.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/k0s/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/k0s/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_k0s_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_k0s_conf.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/k3s/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/k3s/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_k3s_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_k3s_conf.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/rke2/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/rke2/kustomization.yaml
@@ -1,5 +1,7 @@
-bases:
-- ../../base
 
-patchesStrategicMerge:
-- mount_rke2_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base
+patches:
+- path: mount_rke2_conf.yaml

--- a/tools/packaging/kata-deploy/kata-deploy/overlays/stable/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/stable/kustomization.yaml
@@ -1,5 +1,3 @@
-bases:
-- ../../base
 
 images:
 - name: quay.io/kata-containers/kata-deploy
@@ -7,3 +5,7 @@ images:
 
 patches:
 - path: env_stable_conf.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+- ../../base

--- a/tools/packaging/kata-deploy/kata-rbac/base/kustomization.yaml
+++ b/tools/packaging/kata-deploy/kata-rbac/base/kustomization.yaml
@@ -1,2 +1,4 @@
 resources:
 - kata-rbac.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization


### PR DESCRIPTION
Fix the following warnings:
```
 # Warning: 'bases' is deprecated. Please use 'resources' instead. Run
 'kustomize edit fix' to update your Kustomization automatically.

 # Warning: 'patchesStrategicMerge' is deprecated. Please use 'patches'
 instead. Run 'kustomize edit fix' to update your Kustomization
 automatically.
```

Fixes: #8979