### PR TITLE
packaging: Add confidential image / initrd

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -49,8 +49,10 @@ jobs:
           - qemu-tdx-experimental
           - stratovirt
           - rootfs-image
+          - rootfs-image-confidential
           - rootfs-image-tdx
           - rootfs-initrd
+          - rootfs-initrd-confidential
           - rootfs-initrd-mariner
           - rootfs-initrd-sev
           - runk

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -39,7 +39,9 @@ BASE_TARBALLS = serial-targets \
 	tdvf-tarball \
 	virtiofsd-tarball
 BASE_SERIAL_TARBALLS = rootfs-image-tarball \
+	rootfs-image-confidential-tarball \
 	rootfs-image-tdx-tarball \
+	rootfs-initrd-confidential-tarball \
 	rootfs-initrd-mariner-tarball \
 	rootfs-initrd-sev-tarball \
 	rootfs-initrd-tarball \
@@ -160,10 +162,16 @@ stratovirt-tarball:
 rootfs-image-tarball: agent-tarball
 	${MAKE} $@-build
 
+rootfs-image-confidential-tarball: agent-opa-tarball kernel-confidential-tarball
+	${MAKE} $@-build
+
 rootfs-image-tdx-tarball: agent-opa-tarball kernel-confidential-tarball
 	${MAKE} $@-build
 
 rootfs-initrd-mariner-tarball: agent-opa-tarball
+	${MAKE} $@-build
+
+rootfs-initrd-confidential-tarball: agent-opa-tarball kernel-confidential-tarball
 	${MAKE} $@-build
 
 rootfs-initrd-sev-tarball: agent-opa-tarball kernel-confidential-tarball

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -112,8 +112,10 @@ options:
 	qemu-tdx-experimental
 	stratovirt
 	rootfs-image
+	rootfs-image-confidential
 	rootfs-image-tdx
 	rootfs-initrd
+	rootfs-initrd-confidential
 	rootfs-initrd-mariner
 	rootfs-initrd-sev
 	runk
@@ -284,6 +286,13 @@ install_image() {
 	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --imagetype=image --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
 }
 
+#Install guest image for confidential guests
+install_image_confidential() {
+	export AGENT_POLICY=yes
+	export MEASURED_ROOTFS=yes
+	install_image "confidential"
+}
+
 #Install guest image for tdx
 install_image_tdx() {
 	export AGENT_POLICY=yes
@@ -342,6 +351,13 @@ install_initrd() {
 
 	export AGENT_TARBALL=$(get_agent_tarball_path)
 	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --imagetype=initrd --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
+}
+
+#Install guest initrd for confidential guests
+install_initrd_confidential() {
+	export AGENT_POLICY=yes
+	export MEASURED_ROOTFS=yes
+	install_initrd "confidential"
 }
 
 #Install Mariner guest initrd
@@ -888,7 +904,9 @@ handle_build() {
 		install_clh
 		install_firecracker
 		install_image
+		install_image_confidential
 		install_initrd
+		install_initrd_confidential
 		install_initrd_mariner
 		install_initrd_sev
 		install_kata_ctl
@@ -965,9 +983,13 @@ handle_build() {
 
 	rootfs-image) install_image ;;
 
+	rootfs-image-confidential) install_image_confidential ;;
+
 	rootfs-image-tdx) install_image_tdx ;;
 
 	rootfs-initrd) install_initrd ;;
+
+	rootfs-initrd-confidential) install_initrd_confidential ;;
 
 	rootfs-initrd-mariner) install_initrd_mariner ;;
 
@@ -1081,7 +1103,9 @@ main() {
 		qemu
 		stratovirt
 		rootfs-image
+		rootfs-image-confidential
 		rootfs-initrd
+		rootfs-initrd-confidential
 		rootfs-initrd-mariner
 		runk
 		shim-v2

--- a/versions.yaml
+++ b/versions.yaml
@@ -133,6 +133,9 @@ assets:
       x86_64:
         name: *default-image-name
         version: *default-image-version
+        confidential:
+          name: *default-image-name
+          version: *default-image-version
         tdx:
           name: *default-image-name
           version: *default-image-version
@@ -159,6 +162,9 @@ assets:
       x86_64:
         name: *default-initrd-name
         version: *default-initrd-version
+        confidential:
+          name: *glibc-initrd-name
+          version: *glibc-initrd-version
         mariner:
           name: "cbl-mariner"
           version: "2.0"


### PR DESCRIPTION
Let's use a single rootfs image / initrd for confidential workloads,
instead of having those split for different TEEs.

We can easily do this now as the soon-to-be-added guest-components can
be built in a generic way.

Fixes: #8982

NOTE: This is rebased atop of #8978