### PR TITLE
WIP tests: pull image as a test dependency for kata monitor

### DIFF
--- a/tests/functional/kata-monitor/gha-run.sh
+++ b/tests/functional/kata-monitor/gha-run.sh
@@ -56,6 +56,14 @@ function install_dependencies() {
 	if [ "${CONTAINER_ENGINE}" = "crio" ]; then
 		install_crio ${cri_tools_version#v}
 	fi
+
+	if [ "${CONTAINER_ENGINE}" == "containerd" ]; then
+		#sudo systemctl status containerd
+		sudo systemctl restart containerd
+	fi
+
+	info "pull the image to be used for the test"
+	sudo crictl pull busybox
 }
 
 function run() {

--- a/tests/functional/kata-monitor/kata-monitor-tests.sh
+++ b/tests/functional/kata-monitor/kata-monitor-tests.sh
@@ -14,6 +14,7 @@
 set -o errexit
 set -o nounset
 set -o pipefail
+set -x
 
 source "/etc/os-release" || source "/usr/lib/os-release"
 
@@ -218,11 +219,11 @@ main() {
 	echo_ok "$CURRENT_TASK"
 
 	###########################
-	title "pull the image to be used"
-	sudo crictl pull busybox
-
-	###########################
 	title "create workloads"
+
+	crictl pods
+	crictl images
+	cat /etc/crictl.yaml
 
 	CURRENT_TASK="start workload (runc)"
 	start_workload


### PR DESCRIPTION
This PR pull the image that is going to be used for kata monitory tests to avoid the random failures of timeouts when this is being done and avoid the random failures in the test.

Fixes #8991