### PR TITLE
ci: aks: switch from eastus2 to eastus region

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -66,12 +66,12 @@ function create_cluster() {
     local rg="$(_print_rg_name ${test_type})"
 
     az group create \
-        -l eastus2 \
+        -l eastus \
         -n "${rg}"
 
     az aks create \
         -g "${rg}" \
-	--node-resource-group "node-${rg}" \
+        --node-resource-group "node-${rg}" \
         -n "$(_print_cluster_name ${test_type})" \
         -s "$(_print_instance_type)" \
         --node-count 1 \


### PR DESCRIPTION
This addresses an internal AKS issue that intermittently prevents clusters from getting created. The fix has been rolled out to eastus but not yet eastus2, so we unblock the CI by switching. No downsides in general.

This supersedes #8990.

Fixes: #8989