### PR TITLE
gha: k8s: Add cloud-hypervisor (runtime-rs) support

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -37,6 +37,7 @@ jobs:
           - dragonball
           - qemu
           - stratovirt
+          - cloud-hypervisor
         instance-type:
           - small
           - normal


### PR DESCRIPTION
This PR adds the Cloud Hypervisor driver, integrated with the runtime-rs, as part of the kubernetes tests different without devmapper.

Fixes #8995