### PR TITLE
packaging: Fix pushing artefacts to the registry

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -999,7 +999,7 @@ handle_build() {
 					"kata-static-${build_target}-modules.tar.xz" \
 					${build_target}-version \
 					${build_target}-builder-image-version \
-					{build_target}-sha256sum
+					${build_target}-sha256sum
 				;;
 			*)
 				sudo oras push \
@@ -1007,7 +1007,7 @@ handle_build() {
 					${final_tarball_name} \
 					${build_target}-version \
 					${build_target}-builder-image-version \
-					{build_target}-sha256sum
+					${build_target}-sha256sum
 				;;
 		esac
 		sudo oras logout "${ARTEFACT_REGISTRY}"


### PR DESCRIPTION
This issues was introduced due to a typo not caught during reviews on e5bca90274f39608ecaf369df9ea2438461af22d.

Fixes: #6415 -- part II