### PR TITLE
packaging: Don't build the confidential / sev kernel twice -- part III

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -402,7 +402,7 @@ install_kernel_confidential() {
 
 	install_kernel_helper \
 		"assets.kernel.confidential.version" \
-		"kernel" \
+		"kernel-confidential" \
 		"-x confidential -u ${kernel_url}"
 }
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -197,7 +197,7 @@ install_cached_tarball_component() {
 	IFS=' ' read -a mapping <<< "${extra_tarballs}"
 	for m in ${mapping[@]}; do
 		local extra_tarball_name=${m%:*}
-		local extra_tarball_path=${m#&:}
+		local extra_tarball_path=${m#*:}
 
 		mv ${extra_tarball_name} ${extra_tarball_path}
 	done

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -351,7 +351,7 @@ install_cached_kernel_tarball_component() {
 		return 0
 	fi
 
-	local modules_dir=$(get_kernel_modules_dir ${kernel_version} ${kernel_kata_config_version})
+	local modules_dir=$(get_kernel_modules_dir ${kernel_version} ${kernel_kata_config_version} ${build_target})
 	mkdir -p "${modules_dir}" || true
 	tar xvf "${workdir}/kata-static-${kernel_name}-modules.tar.xz" -C  "${modules_dir}" && return 0
 
@@ -965,7 +965,7 @@ handle_build() {
 		kernel*-confidential|kernel-sev)
 			local modules_final_tarball_path="${workdir}/kata-static-${build_target}-modules.tar.xz"
 			if [ ! -f "${modules_final_tarball_path}" ]; then
-				local modules_dir=$(get_kernel_modules_dir ${kernel_version} ${kernel_kata_config_version})
+				local modules_dir=$(get_kernel_modules_dir ${kernel_version} ${kernel_kata_config_version} ${build_target})
 
 				pushd "${modules_dir}"
 				sudo rm -f build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -344,7 +344,7 @@ install_cached_kernel_tarball_component() {
 		"${latest_builder_image}" \
 		"${final_tarball_name}" \
 		"${final_tarball_path}" \
-		"${extra_tarballs} " \
+		"${extra_tarballs}" \
 		|| return 1
 	
 	if [[ "${kernel_name}" != "kernel-sev" ]] && [[ "${kernel_name}" != "kernel"*"-confidential" ]]; then


### PR DESCRIPTION
Those are fix ups to ensure that the work merged as part of #8987 works correctly.

Here are the local tests with these patches in:
```bash
⋊> kata-containers on topic/fix-cache-for-confidential-kernel-part-III ≡ make kernel-tarball
make kernel-tarball-build
make[1]: Entering directory '/home/ffidenci/src/upstream/kata-containers/kata-containers'
/home/ffidenci/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build//kata-deploy-binaries-in-docker.sh  --build=kernel
sha256:17f85480ef404c1533f7fe4d1dc1ccf371df074f33e0894dfb5c8983e6feb268
Build kata version 3.3.0-alpha0: kernel
INFO: DESTDIR /home/ffidenci/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/kernel/destdir
Downloading 8f71e2b0fe63 kernel-builder-image-version
Downloading 107f76619e2a kata-static-kernel.tar.xz
Downloading 216843ea6ed0 kernel-version
Downloaded  8f71e2b0fe63 kernel-builder-image-version
Downloading efd423ff12dc kernel-sha256sum
Downloaded  216843ea6ed0 kernel-version
Downloaded  efd423ff12dc kernel-sha256sum
Downloaded  107f76619e2a kata-static-kernel.tar.xz
Pulled [registry] ghcr.io/kata-containers/cached-artefacts/kernel:latest-main-x86_64
Digest: sha256:a770d0debba8026f81700841f5e64f3877735a6657d9236583f9c9a21db0ccb6
kata-static-kernel.tar.xz: OK
INFO: Using cached tarball of kernel
drwxr-xr-x runner/runner     0 2024-02-02 09:28 ./
drwxr-xr-x root/root         0 2024-02-02 09:28 ./opt/
drwxr-xr-x root/root         0 2024-02-02 09:28 ./opt/kata/
drwxr-xr-x root/root         0 2024-02-02 09:28 ./opt/kata/share/
drwxr-xr-x root/root         0 2024-02-02 09:28 ./opt/kata/share/kata-containers/
-rw-r--r-- root/root   6702032 2024-02-02 09:28 ./opt/kata/share/kata-containers/vmlinuz-6.1.62-123
lrwxrwxrwx root/root         0 2024-02-02 09:28 ./opt/kata/share/kata-containers/vmlinux.container -> vmlinux-6.1.62-123
-rw-r--r-- root/root     76921 2024-02-02 09:28 ./opt/kata/share/kata-containers/config-6.1.62-123
lrwxrwxrwx root/root         0 2024-02-02 09:28 ./opt/kata/share/kata-containers/vmlinuz.container -> vmlinuz-6.1.62-123
-rw-r--r-- root/root  44796144 2024-02-02 09:28 ./opt/kata/share/kata-containers/vmlinux-6.1.62-123
~/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build ~/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/kernel/builddir
~/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/kernel/builddir
make[1]: Leaving directory '/home/ffidenci/src/upstream/kata-containers/kata-containers'
```

```bash
⋊> kata-containers on topic/fix-cache-for-confidential-kernel-part-III ≡ make kernel-confidential-tarball
make kernel-confidential-tarball-build
make[1]: Entering directory '/home/ffidenci/src/upstream/kata-containers/kata-containers'
/home/ffidenci/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build//kata-deploy-binaries-in-docker.sh  --build=kernel-confidential
sha256:2fce5fdc714a0f688b2d4266a29c5d6e18ca3b2f1a74da077736d128db405fba
Build kata version 3.3.0-alpha0: kernel-confidential
INFO: DESTDIR /home/ffidenci/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/kernel-confidential/destdir
Downloading 7602529452de kernel-confidential-version
Downloading 09117eec91c7 kata-static-kernel-confidential-modules.tar.xz
Downloading 8f71e2b0fe63 kernel-confidential-builder-image-version
Downloaded  8f71e2b0fe63 kernel-confidential-builder-image-version
Downloading 98ddaeaddd71 kernel-confidential-sha256sum
Downloaded  7602529452de kernel-confidential-version
Downloaded  98ddaeaddd71 kernel-confidential-sha256sum
Downloaded  09117eec91c7 kata-static-kernel-confidential-modules.tar.xz
Restored    09117eec91c7 kata-static-kernel-confidential.tar.xz
Pulled [registry] ghcr.io/kata-containers/cached-artefacts/kernel-confidential:latest-main-x86_64
Digest: sha256:9301b7cb9dddd66e0fbea53a8b7d8d0250cc92a70595b71a2665faa95d3cf2eb
kata-static-kernel-confidential.tar.xz: OK
INFO: Using cached tarball of kernel-confidential
./
./opt/
./opt/kata/
./opt/kata/share/
./opt/kata/share/kata-containers/
./opt/kata/share/kata-containers/config-6.7-123-confidential
./opt/kata/share/kata-containers/vmlinux-confidential.container
./opt/kata/share/kata-containers/vmlinuz-6.7-123-confidential
./opt/kata/share/kata-containers/vmlinux-6.7-123-confidential
./opt/kata/share/kata-containers/vmlinuz-confidential.container
drwxr-xr-x runner/runner     0 2024-02-02 09:29 ./
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/share/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/
-rw-r--r-- root/root     85597 2024-02-02 09:29 ./opt/kata/share/kata-containers/config-6.7-123-confidential
lrwxrwxrwx root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinux-confidential.container -> vmlinux-6.7-123-confidential
-rw-r--r-- root/root   7380992 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinuz-6.7-123-confidential
-rw-r--r-- root/root  41283984 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinux-6.7-123-confidential
lrwxrwxrwx root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinuz-confidential.container -> vmlinuz-6.7-123-confidential
drwxr-xr-x runner/runner     0 2024-02-02 09:29 ./
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/share/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/
-rw-r--r-- root/root     85597 2024-02-02 09:29 ./opt/kata/share/kata-containers/config-6.7-123-confidential
lrwxrwxrwx root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinux-confidential.container -> vmlinux-6.7-123-confidential
-rw-r--r-- root/root   7380992 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinuz-6.7-123-confidential
-rw-r--r-- root/root  41283984 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinux-6.7-123-confidential
lrwxrwxrwx root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinuz-confidential.container -> vmlinuz-6.7-123-confidential
~/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build ~/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/kernel-confidential/builddir
~/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/kernel-confidential/builddir
make[1]: Leaving directory '/home/ffidenci/src/upstream/kata-containers/kata-containers'
```

```bash
⋊> kata-containers on topic/fix-cache-for-confidential-kernel-part-III ≡ make kernel-sev-tarball
make kernel-sev-tarball-build
make[1]: Entering directory '/home/ffidenci/src/upstream/kata-containers/kata-containers'
/home/ffidenci/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build//kata-deploy-copy-yq-installer.sh
/home/ffidenci/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build//kata-deploy-binaries-in-docker.sh  --build=kernel-sev
sha256:17f85480ef404c1533f7fe4d1dc1ccf371df074f33e0894dfb5c8983e6feb268
Build kata version 3.3.0-alpha0: kernel-sev
INFO: DESTDIR /home/ffidenci/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/kernel-sev/destdir
INFO: build sev kernel
Downloading 66ac785c4bbb kata-static-kernel-sev-modules.tar.xz
Downloading e693f4bbb23b kernel-sev-version
Downloading 8f71e2b0fe63 kernel-sev-builder-image-version
Downloaded  8f71e2b0fe63 kernel-sev-builder-image-version
Downloading 038e470ffe03 kernel-sev-sha256sum
Downloaded  e693f4bbb23b kernel-sev-version
Downloaded  038e470ffe03 kernel-sev-sha256sum
Downloaded  66ac785c4bbb kata-static-kernel-sev-modules.tar.xz
Restored    66ac785c4bbb kata-static-kernel-sev.tar.xz
Pulled [registry] ghcr.io/kata-containers/cached-artefacts/kernel-sev:latest-main-x86_64
Digest: sha256:c63df7f1d95ab52af48bdb3ee248de5b3b9f59df128d9dd2a6ceba56cd6a3547
kata-static-kernel-sev.tar.xz: OK
INFO: Using cached tarball of kernel-sev
./
./opt/
./opt/kata/
./opt/kata/share/
./opt/kata/share/kata-containers/
./opt/kata/share/kata-containers/vmlinux-sev.container
./opt/kata/share/kata-containers/vmlinuz-5.19.2-123-sev
./opt/kata/share/kata-containers/vmlinuz-sev.container
./opt/kata/share/kata-containers/config-5.19.2-123-sev
./opt/kata/share/kata-containers/vmlinux-5.19.2-123-sev
drwxr-xr-x runner/runner     0 2024-02-02 09:29 ./
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/share/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/
lrwxrwxrwx root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinux-sev.container -> vmlinux-5.19.2-123-sev
-rw-r--r-- root/root   6820288 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinuz-5.19.2-123-sev
lrwxrwxrwx root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinuz-sev.container -> vmlinuz-5.19.2-123-sev
-rw-r--r-- root/root     79027 2024-02-02 09:29 ./opt/kata/share/kata-containers/config-5.19.2-123-sev
-rw-r--r-- root/root  56129552 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinux-5.19.2-123-sev
drwxr-xr-x runner/runner     0 2024-02-02 09:29 ./
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/share/
drwxr-xr-x root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/
lrwxrwxrwx root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinux-sev.container -> vmlinux-5.19.2-123-sev
-rw-r--r-- root/root   6820288 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinuz-5.19.2-123-sev
lrwxrwxrwx root/root         0 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinuz-sev.container -> vmlinuz-5.19.2-123-sev
-rw-r--r-- root/root     79027 2024-02-02 09:29 ./opt/kata/share/kata-containers/config-5.19.2-123-sev
-rw-r--r-- root/root  56129552 2024-02-02 09:29 ./opt/kata/share/kata-containers/vmlinux-5.19.2-123-sev
~/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build ~/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/kernel-sev/builddir
~/src/upstream/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/kernel-sev/builddir
make[1]: Leaving directory '/home/ffidenci/src/upstream/kata-containers/kata-containers'
```