### PR TITLE
static-checks: Install clang in the ci environments

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -128,6 +128,9 @@ jobs:
       - name: Install protobuf-compiler
         if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
         run: sudo apt-get -y install protobuf-compiler
+      - name: Install clang
+        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
+        run: sudo apt-get -y install clang
       - name: Setup XDG_RUNTIME_DIR for the `runtime` tests
         if: ${{ matrix.command != 'make vendor' && matrix.command != 'make check' && matrix.component == 'runtime' }}
         run: |


### PR DESCRIPTION
To test PR #8484, the compilation process for the kata-agent relies on clang. There have been encountered failures on ARM, s390x, and ppc64le architectures: 
- ppc64le: https://github.com/kata-containers/kata-containers/actions/runs/7754082828/job/21146689026?pr=8484 
- s390x: https://github.com/kata-containers/kata-containers/actions/runs/7754082828/job/21146689401?pr=8484 
- arm: https://github.com/kata-containers/kata-containers/actions/runs/7754082828/job/21146689026?pr=8484

Fixed: #9004