### PR TITLE
gha: delete azure RG only if it exists

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -104,10 +104,12 @@ function get_cluster_credentials() {
 
 function delete_cluster() {
     test_type="${1:-k8s}"
+    local rg
+    rg="$(_print_rg_name ${test_type})"
 
-    az group delete \
-        -g "$(_print_rg_name ${test_type})" \
-        --yes
+    if [ "$(az group exists -g "${rg}")" == "true" ]; then
+        az group delete -g "${rg}" --yes
+    fi
 }
 
 function delete_cluster_kcli() {


### PR DESCRIPTION
delete_cluster() has tried to delete the az resources group regardless if it exists. In some cases the result of that operation is ignored, i.e., fail to resource group not found, but the log messages get a little dirty. Let's delete the RG only if it exists then.

Fixes #8989
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>

---

Split of https://github.com/kata-containers/kata-containers/pull/8990