### PR TITLE
runtime: display accurate error msg to avoid misleading users.

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/shim_management.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_management.go
@@ -338,12 +338,16 @@ func ServerSocketAddress(id string) string {
 // shim management endpoint
 // NOTE: this code allows various go clients, e.g. kata-runtime or kata-monitor commands, to
 // connect to the rust shim management implementation.
-func ClientSocketAddress(id string) string {
+func ClientSocketAddress(id string) (string, error) {
 	// get the go runtime uds path
 	socketPath := SocketPathGo(id)
 	// if the path not exist, use the rust runtime uds path instead
 	if _, err := os.Stat(socketPath); err != nil {
 		socketPath = SocketPathRust(id)
+		if _, err := os.Stat(socketPath); err != nil {
+			return "", fmt.Errorf("It fails to stat both %s and %s with error %v.", SocketPathGo(id), SocketPathRust(id), err)
+		}
 	}
-	return fmt.Sprintf("unix://%s", socketPath)
+
+	return fmt.Sprintf("unix://%s", socketPath), nil
 }

--- a/src/runtime/pkg/kata-monitor/pprof.go
+++ b/src/runtime/pkg/kata-monitor/pprof.go
@@ -32,7 +32,7 @@ func (km *KataMonitor) composeSocketAddress(r *http.Request) (string, error) {
 		return "", err
 	}
 
-	return shim.ClientSocketAddress(sandbox), nil
+	return shim.ClientSocketAddress(sandbox)
 }
 
 func (km *KataMonitor) proxyRequest(w http.ResponseWriter, r *http.Request,

--- a/src/runtime/pkg/utils/shimclient/shim_management_client.go
+++ b/src/runtime/pkg/utils/shimclient/shim_management_client.go
@@ -19,7 +19,12 @@ import (
 
 // BuildShimClient builds and returns an http client for communicating with the provided sandbox
 func BuildShimClient(sandboxID string, timeout time.Duration) (*http.Client, error) {
-	return buildUnixSocketClient(shim.ClientSocketAddress(sandboxID), timeout)
+	socketAddress, err := shim.ClientSocketAddress(sandboxID)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildUnixSocketClient(socketAddress, timeout)
 }
 
 // buildUnixSocketClient build http client for Unix socket


### PR DESCRIPTION
    runtime: display accurate error msg to avoid misleading users.
    
    The original handling method does not reach user expectations.
    When the ClientSocketAddress method stats the corresponding
    path of runtime-rs and has not found it yet, we should return
    an error message here that includes the reason for the failure
    (which should be an error display indicating that both runtime-go
    and runtime-rs were not found). Instead of simply displaying the
    corresponding path of runtime-rs as the final error message to
    users.
    It is also necessary to return the error promptly to the caller
    for further error handling.
    
    Fixes: #8999

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>