### PR TITLE
gha: add GOPATH env var to the ppc64le k8s workflow

### DIFF
--- a/.github/workflows/run-k8s-tests-on-ppc64le.yaml
+++ b/.github/workflows/run-k8s-tests-on-ppc64le.yaml
@@ -37,6 +37,7 @@ jobs:
       DOCKER_REPO: ${{ inputs.repo }}
       DOCKER_TAG: ${{ inputs.tag }}
       PR_NUMBER: ${{ inputs.pr-number }}
+      GOPATH: ${{ github.workspace }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
       KUBERNETES: ${{ matrix.k8s }}
       USING_NFD: "false"


### PR DESCRIPTION
The filtering of testing cases installs/uses yq and expects GOPATH to be present. Hence, add it to the workflow.

Fixes: #9018