### PR TITLE
rootfs: confidential: Install coco-guest-components

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -449,6 +449,11 @@ build_rootfs_distro()
 			engine_run_args+=" -v $(dirname ${AGENT_TARBALL}):$(dirname ${AGENT_TARBALL})"
 		fi
 
+		if [ -n "${COCO_GUEST_COMPONENTS_TARBALL}" ] ; then
+			engine_run_args+=" --env COCO_GUEST_COMPONENTS_TARBALL=${COCO_GUEST_COMPONENTS_TARBALL}"
+			engine_run_args+=" -v $(dirname ${COCO_GUEST_COMPONENTS_TARBALL}):$(dirname ${COCO_GUEST_COMPONENTS_TARBALL})"
+		fi
+
 		engine_run_args+=" -v ${GOPATH_LOCAL}:${GOPATH_LOCAL} --env GOPATH=${GOPATH_LOCAL}"
 
 		engine_run_args+=" $(docker_extra_args $distro)"

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -794,6 +794,7 @@ EOF
 	OK "init is installed"
 
 	if [ -n "${COCO_GUEST_COMPONENTS_TARBALL}" ] ; then
+		info "Installing the Confidential Containers guest components tarball"
 		tar xvJpf ${COCO_GUEST_COMPONENTS_TARBALL} -C ${ROOTFS_DIR}
 	fi
 

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -162,7 +162,7 @@ stratovirt-tarball:
 rootfs-image-tarball: agent-tarball
 	${MAKE} $@-build
 
-rootfs-image-confidential-tarball: agent-opa-tarball kernel-confidential-tarball
+rootfs-image-confidential-tarball: agent-opa-tarball coco-guest-components-tarball kernel-confidential-tarball
 	${MAKE} $@-build
 
 rootfs-image-tdx-tarball: agent-opa-tarball kernel-confidential-tarball
@@ -171,7 +171,7 @@ rootfs-image-tdx-tarball: agent-opa-tarball kernel-confidential-tarball
 rootfs-initrd-mariner-tarball: agent-opa-tarball
 	${MAKE} $@-build
 
-rootfs-initrd-confidential-tarball: agent-opa-tarball kernel-confidential-tarball
+rootfs-initrd-confidential-tarball: agent-opa-tarball coco-guest-components-tarball kernel-confidential-tarball
 	${MAKE} $@-build
 
 rootfs-initrd-sev-tarball: agent-opa-tarball kernel-confidential-tarball

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -818,7 +818,7 @@ install_coco_guest_components() {
 		&& return 0
 
 	info "build static coco-guest-components"
-	"${coco_guest_components_builder}"
+	DESTDIR="${destdir}" "${coco_guest_components_builder}"
 }
 
 install_tools_helper() {

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -224,6 +224,22 @@ get_agent_tarball_path() {
 	echo "${agent_local_build_dir}/${agent_tarball_name}"
 }
 
+get_coco_guest_components_tarball_path() {
+	coco_guest_components_local_build_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build"
+	coco_guest_components_tarball_name="kata-static-coco-guest-components.tar.xz"
+
+	echo "${coco_guest_components_local_build_dir}/${coco_guest_components_tarball_name}"
+}
+
+get_latest_coco_guest_components_artefact_and_builder_image_version() {
+	local coco_guest_components_version=$(get_from_kata_deps "externals.coco-guest-components.version")
+	local coco_guest_components_toolchain=$(get_from_kata_deps "externals.coco-guest-components.toolchain")
+	local latest_coco_guest_components_artefact="${coco_guest_components_version}-${coco_guest_components_toolchain}"
+	local latest_coco_guest_components_builder_image="$(get_coco_guest_components_image_name)"
+
+	echo "${latest_coco_guest_components_artefact}-${latest_coco_guest_components_builder_image}"
+}
+
 get_latest_kernel_confidential_artefact_and_builder_image_version() {
 		local kernel_version=$(get_from_kata_deps "assets.kernel.confidential.version")
 		local kernel_kata_config_version="$(cat ${repo_root_dir}/tools/packaging/kernel/kata_config_version)"
@@ -256,10 +272,11 @@ install_image() {
 
 
 	latest_artefact="${osbuilder_last_commit}-${guest_image_last_commit}-${agent_last_commit}-${libs_last_commit}-${gperf_version}-${libseccomp_version}-${rust_version}-${image_type}"
-	if [ "${variant}" == "tdx" ]; then
-		# For the TDX image we depend on the kernel built in order to ensure that
+	if [ "${variant}" == "confidential" ]; then
+		# For the confidential image we depend on the kernel built in order to ensure that
 		# measured boot is used
 		latest_artefacts+="-$(get_latest_kernel_confidential_artefact_and_builder_image_version)"
+		latest_artefacts+="-$(get_latest_coco_guest_components_artefact_and_builder_image_version)"
 	fi
 
 	latest_builder_image=""
@@ -277,6 +294,10 @@ install_image() {
 	if [ -n "${variant}" ]; then
 		os_name="$(get_from_kata_deps "assets.image.architecture.${ARCH}.${variant}.name")"
 		os_version="$(get_from_kata_deps "assets.image.architecture.${ARCH}.${variant}.version")"
+
+		if [ "${variant}" == "confidential" ]; then
+			export COCO_GUEST_COMPONENTS_TARBALL="$(get_coco_guest_components_tarball_path)"
+		fi
 	else
 		os_name="$(get_from_kata_deps "assets.image.architecture.${ARCH}.name")"
 		os_version="$(get_from_kata_deps "assets.image.architecture.${ARCH}.version")"
@@ -321,10 +342,11 @@ install_initrd() {
 		"$(get_last_modification "${repo_root_dir}/tools/packaging/static-build/agent")")
 
 	latest_artefact="${osbuilder_last_commit}-${guest_image_last_commit}-${agent_last_commit}-${libs_last_commit}-${gperf_version}-${libseccomp_version}-${rust_version}-${initrd_type}"
-	if [ "${variant}" == "tdx" ]; then
-		# For the TDX image we depend on the kernel built in order to ensure that
+	if [ "${variant}" == "confidential" ]; then
+		# For the confidential initrd we depend on the kernel built in order to ensure that
 		# measured boot is used
 		latest_artefacts+="-$(get_latest_kernel_confidential_artefact_and_builder_image_version)"
+		latest_artefacts+="-$(get_latest_coco_guest_components_artefact_and_builder_image_version)"
 	fi
 
 	latest_builder_image=""
@@ -344,6 +366,10 @@ install_initrd() {
 	if [ -n "${variant}" ]; then
 		os_name="$(get_from_kata_deps "assets.initrd.architecture.${ARCH}.${variant}.name")"
 		os_version="$(get_from_kata_deps "assets.initrd.architecture.${ARCH}.${variant}.version")"
+
+		if [ "${variant}" == "confidential" ]; then
+			export COCO_GUEST_COMPONENTS_TARBALL="$(get_coco_guest_components_tarball_path)"
+		fi
 	else
 		os_name="$(get_from_kata_deps "assets.initrd.architecture.${ARCH}.name")"
 		os_version="$(get_from_kata_deps "assets.initrd.architecture.${ARCH}.version")"

--- a/tools/packaging/static-build/coco-guest-components/build-static-coco-guest-components.sh
+++ b/tools/packaging/static-build/coco-guest-components/build-static-coco-guest-components.sh
@@ -52,11 +52,11 @@ build_coco_guest_components_from_source() {
 	git fetch --depth=1 origin "${coco_guest_components_version}"
 	git checkout FETCH_HEAD
 
-	TEE_PLATFORM=${TEE_PLATFORM} make build
+	DESTDIR="${DESTDIR}/usr/local/bin" TEE_PLATFORM=${TEE_PLATFORM} make build
 	strip target/${rust_arch}-unknown-linux-${LIBC}/release/confidential-data-hub
 	strip target/${rust_arch}-unknown-linux-${LIBC}/release/attestation-agent
 	strip target/${rust_arch}-unknown-linux-${LIBC}/release/api-server-rest
-	TEE_PLATFORM=${TEE_PLATFORM} make install
+	DESTDIR="${DESTDIR}/usr/local/bin" TEE_PLATFORM=${TEE_PLATFORM} make install
 	popd
 }
 

--- a/tools/packaging/static-build/coco-guest-components/build.sh
+++ b/tools/packaging/static-build/coco-guest-components/build.sh
@@ -13,6 +13,8 @@ readonly coco_guest_components_builder="${script_dir}/build-static-coco-guest-co
 
 source "${script_dir}/../../scripts/lib.sh"
 
+DESTDIR=${DESTDIR:-${PWD}}
+
 coco_guest_components_repo="${coco_guest_components_repo:-}"
 coco_guest_components_version="${coco_guest_components_version:-}"
 coco_guest_components_toolchain="${coco_guest_components_toolchain:-}"
@@ -38,6 +40,7 @@ sudo docker pull ${container_image} || \
 
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \
+	--env DESTDIR="${DESTDIR}" \
 	--env TEE_PLATFORM=${TEE_PLATFORM:-all} \
 	--env coco_guest_components_repo="${coco_guest_components_repo}" \
 	--env coco_guest_components_version="${coco_guest_components_version}" \


### PR DESCRIPTION
Let's install the coco-guest-components into the confidential rootfs image and initrd.

Fixes: #9021