### PR TITLE
tools.kata-webhook: Fix lib path

### DIFF
--- a/tools/testing/kata-webhook/webhook-check.sh
+++ b/tools/testing/kata-webhook/webhook-check.sh
@@ -11,7 +11,7 @@ set -o nounset
 set -o pipefail
 
 webhook_dir=$(dirname $0)
-source "${webhook_dir}/../lib/common.bash"
+source "${webhook_dir}/../../../tests/common.bash"
 source "${webhook_dir}/common.bash"
 
 readonly hello_pod="hello-kata-webhook"


### PR DESCRIPTION
When moving the webhook we skipped the common.bash as (close-enough) version is already in `/tests` but we forgot to update the source path, fixing it here.