### PR TITLE
cri-containerd: fix loop in TestContainerMemoryUpdate()

### DIFF
--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -259,7 +259,7 @@ function TestContainerMemoryUpdate() {
 		return
 	fi
 
-	for virtio_mem_enabled in {1, 0}; do
+	for virtio_mem_enabled in 1 0; do
 		PrepareContainerMemoryUpdate $virtio_mem_enabled
 		DoContainerMemoryUpdate $virtio_mem_enabled
 	done


### PR DESCRIPTION
The loop that generate test cases for virtio-mem enabled/disabled doesn't return the integers '1' and '0' as expected. Instead it returns the strings '{1,' and '0}'.

Fixes #9024
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>