### PR TITLE
rootfs: Add libattest-tdx into the confidential rootfs

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -31,6 +31,7 @@ AGENT_POLICY=${AGENT_POLICY:-no}
 AGENT_SOURCE_BIN=${AGENT_SOURCE_BIN:-""}
 AGENT_TARBALL=${AGENT_TARBALL:-""}
 COCO_GUEST_COMPONENTS_TARBALL=${COCO_GUEST_COMPONENTS_TARBALL:-""}
+CONFIDENTIAL_GUEST="${CONFIDENTIAL_GUEST:-no}"
 
 lib_file="${script_dir}/../scripts/lib.sh"
 source "$lib_file"
@@ -450,6 +451,7 @@ build_rootfs_distro()
 		fi
 
 		if [ -n "${COCO_GUEST_COMPONENTS_TARBALL}" ] ; then
+			CONFIDENTIAL_GUEST="yes"
 			engine_run_args+=" --env COCO_GUEST_COMPONENTS_TARBALL=${COCO_GUEST_COMPONENTS_TARBALL}"
 			engine_run_args+=" -v $(dirname ${COCO_GUEST_COMPONENTS_TARBALL}):$(dirname ${COCO_GUEST_COMPONENTS_TARBALL})"
 		fi
@@ -500,6 +502,7 @@ build_rootfs_distro()
 			--env TARGET_ARCH="${TARGET_ARCH}" \
 			--env HOME="/root" \
 			--env AGENT_POLICY="${AGENT_POLICY}" \
+			--env CONFIDENTIAL_GUEST="${CONFIDENTIAL_GUEST}" \
 			-v "${repo_dir}":"/kata-containers" \
 			-v "${ROOTFS_DIR}":"/rootfs" \
 			-v "${script_dir}/../scripts":"/scripts" \

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -23,6 +23,7 @@ RUN apt-get update && \
          [ "$gcc_arch" = x86_64 ] && gcc_arch=x86-64 && libc_arch=amd64; \
          echo "gcc-$gcc_arch-linux-gnu libc6-dev-$libc_arch-cross")) \
     git \
+    gnupg2 \
     make \
     makedev \
     multistrap \

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -2,9 +2,10 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+source /etc/os-release
 OS_NAME=ubuntu
 # This should be Ubuntu's code name, e.g. "focal" (Focal Fossa) for 20.04
-OS_VERSION=${OS_VERSION:-focal}
+OS_VERSION=${OS_VERSION:-${UBUNTU_CODENAME}}
 PACKAGES="chrony iptables dbus"
 [ "$AGENT_INIT" = no ] && PACKAGES+=" init"
 [ "$MEASURED_ROOTFS" = yes ] && PACKAGES+=" cryptsetup-bin e2fsprogs"


### PR DESCRIPTION
This is required as the tdx-attest-rs crate, which is used as part of the guest components, has a runtime dependency on libattest-tdx.

Fixes: #9021 -- part II