### PR TITLE
genpolicy: mount source for non-confidential guest

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -137,6 +137,17 @@
     "volumes": {
         "emptyDir": {
             "mount_type": "local",
+            "mount_source": "^$(cpath)/$(sandbox-id)/rootfs/local/",
+            "mount_point": "^$(cpath)/$(sandbox-id)/local/",
+            "driver": "local",
+            "source": "local",
+            "fstype": "local",
+            "options": [
+                "mode=0777"
+            ]
+        },
+        "confidential_emptyDir": {
+            "mount_type": "local",
             "mount_source": "^$(cpath)/$(sandbox-id)/local/",
             "mount_point": "^$(cpath)/$(sandbox-id)/local/",
             "driver": "local",

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -30,6 +30,7 @@ pub struct Settings {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Volumes {
     pub emptyDir: EmptyDirVolume,
+    pub confidential_emptyDir: EmptyDirVolume,
     pub emptyDir_memory: EmptyDirVolume,
     pub configMap: ConfigMapVolume,
     pub confidential_configMap: ConfigMapVolume,


### PR DESCRIPTION
The emergent Kata CI tests for Policy use confidential_guest = false in genpolicy-settings.json. That value is inconsistent with the following mount settings:

        "emptyDir": {
            "mount_type": "local",
            "mount_source": "^$(cpath)/$(sandbox-id)/local/",
            "mount_point": "^$(cpath)/$(sandbox-id)/local/",
            "driver": "local",
            "source": "local",
            "fstype": "local",
            "options": [
                "mode=0777"
            ]
        },

We need to keep those settings for confidential_guest = true, and change confidential_guest = false to use:

        "emptyDir": {
            "mount_type": "local",
            "mount_source": "^$(cpath)/$(sandbox-id)/rootfs/local/",
            "mount_point": "^$(cpath)/$(sandbox-id)/local/",
            "driver": "local",
            "source": "local",
            "fstype": "local",
            "options": [
                "mode=0777"
            ]
        },

The value of the mount_source field is different.

This change unblocks testing using Kata CI's pod-empty-dir.yaml:

genpolicy -u -y pod-empty-dir.yaml

kubectl apply -f pod-empty-dir.yaml

k get pod sharevol-kata
NAME            READY   STATUS    RESTARTS   AGE
sharevol-kata   1/1     Running   0          53s

Fixes: #8887