### PR TITLE
runk: support containerd integration test

### DIFF
--- a/tests/integration/runk/.gitignore
+++ b/tests/integration/runk/.gitignore
@@ -1,0 +1,1 @@
+containerd

--- a/tests/integration/runk/gha-run.sh
+++ b/tests/integration/runk/gha-run.sh
@@ -19,14 +19,21 @@ function install_dependencies() {
 
 	# Dependency list of projects that we can rely on the system packages
 	# - jq
+	# - make
+		# - make is required to run containerd integration test.
+	# - gcc
+		# - gcc is required to run containerd integration test.
 	declare -a system_deps=(
 		jq
+		make
+		gcc
 	)
 
 	sudo apt-get update
 	sudo apt-get -y install "${system_deps[@]}"
 
 	ensure_yq
+	${repo_root_dir}/tests/install_go.sh -p -f
 
 	# Dependency list of projects that we can install them
 	# directly from their releases on GitHub:

--- a/versions.yaml
+++ b/versions.yaml
@@ -371,7 +371,7 @@ languages:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.19.3"
+      newest-version: "1.20"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
## Background
- Issue: https://github.com/kata-containers/kata-containers/issues/9035
- support containerd integration test along with ctr test.
  - currently `TestUserNamespaces, TestTaskUpdate, TestContentClient` are skipped
- `TestUserNamespaces and TestTaskUpdate` are not supported in `runk` yet.
- `TestContentClient` is flaky for containerd v1.6.8.


## How to execute containerd integration test
- containerd integration test is updated in `runk-tests.sh`
```
$ cd tests/integration/runk/
$ sudo ./runk-tests.sh 
```
- Log: TODO