### PR TITLE
runtime-rs: fix assert error in `make check`

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
@@ -215,7 +215,7 @@ mod tests {
         assert_eq!(state.vm_path, clh.vm_path);
         assert_eq!(state.run_dir, clh.run_dir);
         assert_eq!(state.guest_protection_to_use, clh.guest_protection_to_use);
-        assert_eq!(state.jailed, false);
+        assert!(!state.jailed);
         assert_eq!(state.hypervisor_type, HYPERVISOR_NAME_CH.to_string());
 
         let clh = CloudHypervisorInner::restore((), state.clone())


### PR DESCRIPTION
Fix assert error:
```
error: used `assert_eq!` with a literal bool
   --> crates/hypervisor/src/ch/inner.rs:218:9
    |
218 |         assert_eq!(state.jailed, false);
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#bool_assert_comparison
    = note: `-D clippy::bool-assert-comparison` implied by `-D warnings`
```
Fixes: #9042