### PR TITLE
nydus: Bump nydus snapshotter version to v0.13.7

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -551,7 +551,7 @@ function install_nydus_snapshotter() {
 	version="${1}"
 
 	project="containerd/nydus-snapshotter"
-	tarball_name="nydus-snapshotter-${version}-$(${repo_root_dir}/tests/kata-arch.sh).tgz"
+	tarball_name="nydus-snapshotter-${version}-$(uname -s| tr A-Z a-z)-$(${repo_root_dir}/tests/kata-arch.sh -g).tar.gz"
 
 	download_github_project_tarball "${project}" "${version}" "${tarball_name}"
 	sudo tar xfz "${tarball_name}" -C /usr/local/bin --strip-components=1

--- a/versions.yaml
+++ b/versions.yaml
@@ -303,7 +303,7 @@ externals:
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.12.0"
+    version: "v0.13.7"
 
   open-policy-agent:
     description: "Open Policy Agent"


### PR DESCRIPTION
Bump nydus snapshotter version to v0.13.7.

The new release name of nydus snapshotter is `nydus-snapshotter-v0.13.7-linux-amd64.tar.gz`, which differs from the version used by kata (`nydus-snapshotter-v0.12.0-x86_64.tgz`). Therefore, we need to update the script to obtain the correct nydus snapshotter name.

Fixes: #9044