### PR TITLE
CI: Install KBS on k8s for attestation tests

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -94,6 +94,33 @@ function install_kubectl() {
     sudo az aks install-cli
 }
 
+# Install the kustomize tool in /usr/local/bin if it doesn't exist on
+# the system yet.
+#
+function install_kustomize() {
+	local arch
+	local checksum
+	local version
+
+	if command -v kustomize >/dev/null; then
+		return
+	fi
+
+	ensure_yq
+	version=$(get_from_kata_deps "externals.kustomize.version")
+	arch=$(arch_to_golang)
+	checksum=$(get_from_kata_deps "externals.kustomize.checksum.${arch}")
+
+	local tarball="kustomize_${version}_linux_${arch}.tar.gz"
+	curl -Lf -o "$tarball" "https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/${version}/${tarball}"
+
+	local rc=0
+	echo "${checksum} $tarball" | sha256sum -c || rc=$?
+	[ $rc -eq 0 ] && sudo tar -xvzf "${tarball}" -C /usr/local/bin || rc=$?
+	rm -f "$tarball"
+	[ $rc -eq 0 ]
+}
+
 function get_cluster_credentials() {
     test_type="${1:-k8s}"
 

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -27,11 +27,19 @@ function _print_instance_type() {
     esac
 }
 
+# Print the cluster name set by $AKS_NAME or generated out of runtime
+# metadata (e.g. pull request number, commit SHA, etc).
+#
 function _print_cluster_name() {
-    test_type="${1:-k8s}"
+    local test_type="${1:-k8s}"
+    local short_sha
 
-    short_sha="$(git rev-parse --short=12 HEAD)"
-    echo "${test_type}-${GH_PR_NUMBER}-${short_sha}-${KATA_HYPERVISOR}-${KATA_HOST_OS}-amd64-${K8S_TEST_HOST_TYPE:0:1}"
+    if [ -n "${AKS_NAME:-}" ]; then
+        echo "$AKS_NAME"
+    else
+        short_sha="$(git rev-parse --short=12 HEAD)"
+        echo "${test_type}-${GH_PR_NUMBER}-${short_sha}-${KATA_HYPERVISOR}-${KATA_HOST_OS}-amd64-${K8S_TEST_HOST_TYPE:0:1}"
+    fi
 }
 
 function _print_rg_name() {

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -40,6 +40,21 @@ function _print_rg_name() {
     echo "${AZ_RG:-"kataCI-$(_print_cluster_name ${test_type})"}"
 }
 
+# Enable the HTTP application routing add-on to AKS.
+# Use with ingress to expose a service API externally.
+#
+function enable_cluster_http_application_routing() {
+	local test_type="${1:-k8s}"
+	local cluster_name
+	local rg
+
+	rg="$(_print_rg_name "${test_type}")"
+	cluster_name="$(_print_cluster_name "${test_type}")"
+
+	az aks enable-addons -g "$rg" -n "$cluster_name" \
+		--addons http_application_routing
+}
+
 function install_azure_cli() {
     curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
     # The aks-preview extension is required while the Mariner Kata host is in preview.
@@ -127,6 +142,24 @@ function get_cluster_credentials() {
     az aks get-credentials \
         -g "$(_print_rg_name ${test_type})" \
         -n "$(_print_cluster_name ${test_type})"
+}
+
+
+# Get the AKS DNS zone name of HTTP application routing.
+#
+# Note: if the HTTP application routing add-on isn't installed in the cluster
+# then it will return an empty string.
+#
+function get_cluster_specific_dns_zone() {
+	local test_type="${1:-k8s}"
+	local cluster_name
+	local rg
+	local q="addonProfiles.httpApplicationRouting.config.HTTPApplicationRoutingZoneName"
+
+	rg="$(_print_rg_name "${test_type}")"
+	cluster_name="$(_print_cluster_name "${test_type}")"
+
+	az aks show -g "$rg" -n "$cluster_name" --query "$q" | tr -d \"
 }
 
 function delete_cluster() {

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Provides a library to deal with the CoCo KBS
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+kubernetes_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=1091
+source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
+
+# Where the kbs sources will be cloned
+readonly COCO_KBS_DIR="/tmp/kbs"
+# The k8s namespace where the kbs service is deployed
+readonly KBS_NS="coco-tenant"
+# The kbs service name
+readonly KBS_SVC_NAME="kbs"
+
+# Delete the kbs on Kubernetes
+#
+# Note: assume the kbs sources were cloned to $COCO_KBS_DIR
+#
+function kbs_k8s_delete() {
+	pushd "$COCO_KBS_DIR"
+	kubectl delete -k kbs/config/kubernetes/overlays
+	popd
+}
+
+# Deploy the kbs on Kubernetes
+#
+function kbs_k8s_deploy() {
+	local image
+	local image_tag
+	local repo
+	local kbs_ip
+	local kbs_port
+	local version
+
+	# yq is needed by get_from_kata_deps
+	ensure_yq
+
+	# Read from versions.yaml
+	repo=$(get_from_kata_deps "externals.coco-kbs.url")
+	version=$(get_from_kata_deps "externals.coco-kbs.version")
+	image=$(get_from_kata_deps "externals.coco-kbs.image")
+	image_tag=$(get_from_kata_deps "externals.coco-kbs.image_tag")
+
+	if [ -d "$COCO_KBS_DIR" ]; then
+		rm -rf "$COCO_KBS_DIR"
+	fi
+
+	echo "::group::Clone the kbs sources"
+	git clone --depth 1 "${repo}" "$COCO_KBS_DIR"
+	pushd "$COCO_KBS_DIR"
+	git fetch --depth=1 origin "${version}"
+	git checkout FETCH_HEAD -b kbs_$$
+	echo "::endgroup::"
+
+	pushd kbs/config/kubernetes/
+
+	# Tests should fill kbs resources later, however, the deployment
+	# expects at least one secret served at install time.
+	echo "somesecret" > overlays/key.bin
+
+	echo "::group::Update the kbs container image"
+	install_kustomize
+	pushd base
+	kustomize edit set image "kbs-container-image=${image}:${image_tag}"
+	popd
+	echo "::endgroup::"
+
+	echo "::group::Deploy the KBS"
+	./deploy-kbs.sh
+	popd
+	popd
+
+	if ! waitForProcess "120" "10" "kubectl -n \"$KBS_NS\" get pods | \
+		grep -q '^kbs-.*Running.*'"; then
+		echo "ERROR: KBS service pod isn't running"
+		echo "::group::DEBUG - describe kbs deployments"
+		kubectl -n "$KBS_NS" get deployments || true
+		echo "::endgroup::"
+		echo "::group::DEBUG - describe kbs pod"
+		kubectl -n "$KBS_NS" describe pod -l app=kbs || true
+		echo "::endgroup::"
+		return 1
+	fi
+	echo "::endgroup::"
+
+	# By default, the KBS service is reachable within the cluster only,
+	# thus the following healthy checker should run from a pod. So start a
+	# debug pod where it will try to get a response from the service. The
+	# expected response is '404 Not Found' because it will request an endpoint
+	# that does not exist.
+	#
+	echo "::group::Check the service healthy"
+	kbs_ip=$(kubectl get -o jsonpath='{.spec.clusterIP}' svc "$KBS_SVC_NAME" -n "$KBS_NS" 2>/dev/null)
+	kbs_port=$(kubectl get -o jsonpath='{.spec.ports[0].port}' svc "$KBS_SVC_NAME" -n "$KBS_NS" 2>/dev/null)
+	local pod=kbs-checker-$$
+	kubectl run "$pod" --image=quay.io/prometheus/busybox --restart=Never -- \
+		sh -c "wget -O- --timeout=5 \"${kbs_ip}:${kbs_port}\" || true"
+	if ! waitForProcess "60" "10" "kubectl logs \"$pod\" 2>/dev/null | grep -q \"404 Not Found\""; then
+		echo "ERROR: KBS service is not responding to requests"
+		echo "::group::DEBUG - kbs logs"
+		kubectl -n "$KBS_NS" logs -l app=kbs || true
+		echo "::endgroup::"
+		kubectl delete pod "$pod"
+		return 1
+	fi
+	kubectl delete pod "$pod"
+	echo "KBS service respond to requests"
+	echo "::endgroup::"
+}

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -111,8 +111,14 @@ function delete_coco_kbs() {
 	kbs_k8s_delete
 }
 
+# Deploy the CoCo KBS in Kubernetes
+#
+# Environment variables:
+#	KBS_INGRESS - (optional) specify the ingress implementation to expose the
+#	              service externally
+#
 function deploy_coco_kbs() {
-	kbs_k8s_deploy
+	kbs_k8s_deploy "$KBS_INGRESS"
 }
 
 function deploy_kata() {

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -13,6 +13,8 @@ DEBUG="${DEBUG:-}"
 
 kubernetes_dir="$(dirname "$(readlink -f "$0")")"
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
+# shellcheck disable=1091
+source "${kubernetes_dir}/confidential_kbs.sh"
 # shellcheck disable=2154
 tools_dir="${repo_root_dir}/tools"
 kata_tarball_dir="${2:-kata-artifacts}"
@@ -105,8 +107,12 @@ function configure_snapshotter() {
 	echo "::endgroup::"
 }
 
+function delete_coco_kbs() {
+	kbs_k8s_delete
+}
+
 function deploy_coco_kbs() {
-	echo "TODO: deploy https://github.com/confidential-containers/kbs"
+	kbs_k8s_deploy
 }
 
 function deploy_kata() {
@@ -389,6 +395,7 @@ function main() {
 		cleanup-garm) cleanup "garm" ;;
 		cleanup-zvsi) cleanup "zvsi" ;;
 		cleanup-snapshotter) cleanup_snapshotter ;;
+		delete-coco-kbs) delete_coco_kbs ;;
 		delete-cluster) cleanup "aks" ;;
 		delete-cluster-kcli) delete_cluster_kcli ;;
 		*) >&2 echo "Invalid argument"; exit 2 ;;

--- a/versions.yaml
+++ b/versions.yaml
@@ -260,6 +260,17 @@ externals:
       .*/v?([\d\.]+)\.tar\.gz
     version: "1.23.1-00"
 
+  kustomize:
+    description: "Kubernetes native configuration management"
+    url: "https://github.com/kubernetes-sigs/kustomize"
+    version: "v5.3.0"
+    checksum:
+      amd64: "3ab32f92360d752a2a53e56be073b649abc1e7351b912c0fb32b960d1def854c"
+      arm64: "a1ec622d4adeb483e3cdabd70f0d66058b1e4bcec013c4f74f370666e1e045d8"
+      # yamllint disable-line rule:line-length
+      ppc64le: "946b1aa9325e7234157881fe2098e59c05c6834e56205bf6ec0a9a5fc83c9cc4"
+      s390x: "0b1a00f0e33efa2ecaa6cda9eeb63141ddccf97a912425974d6b65e66cf96cd4"
+
   libseccomp:
     description: "High level interface to Linux seccomp filter"
     url: "https://github.com/seccomp/libseccomp"

--- a/versions.yaml
+++ b/versions.yaml
@@ -199,6 +199,13 @@ externals:
     version: "42b7c9687ecd0907ef70da31cf290a60ee8432cd"
     toolchain: "1.72.0"
 
+  coco-kbs:
+    description: "Provides attestation and secret Management services"
+    url: "https://github.com/confidential-containers/kbs"
+    version: "18c8ee378c6d83446ee635a702d5dee389028d8f"
+    image: "ghcr.io/confidential-containers/staged-images/kbs"
+    image_tag: "18c8ee378c6d83446ee635a702d5dee389028d8f"
+
   conmon:
     description: "An OCI container runtime monitor"
     url: "https://github.com/containers/conmon"


### PR DESCRIPTION
## Introduction

This introduces the building blocks to install the [CoCo KBS](https://github.com/confidential-containers/kbs) on Kubernetes to be used on the upcoming attestation tests (see https://github.com/kata-containers/kata-containers/issues/9058).

It is added the commands `deploy-coco-kbs` and `delete-coco-kbs` to the `tests/integration/kubernetes/gha.sh` script to install and uninstall the KBS on Kubernetes.

I tested those new commands on a kubeadm cluster as:

```
$ ./tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
::group::Clone the kbs sources
Cloning into '/tmp/kbs'...
remote: Enumerating objects: 283, done.
remote: Counting objects: 100% (283/283), done.
remote: Compressing objects: 100% (256/256), done.
remote: Total 283 (delta 24), reused 185 (delta 8), pack-reused 0
Receiving objects: 100% (283/283), 261.03 KiB | 1.16 MiB/s, done.
Resolving deltas: 100% (24/24), done.
/tmp/kbs ~/go/src/github.com/kata-containers/kata-containers
remote: Total 0 (delta 0), reused 0 (delta 0), pack-reused 0
From https://github.com/confidential-containers/kbs
 * branch            112018371d38c73eba8998f4f6b81ebe00b41556 -> FETCH_HEAD
Switched to a new branch 'kbs_126625'
::endgroup::
/tmp/kbs/kbs/config/kubernetes /tmp/kbs ~/go/src/github.com/kata-containers/kata-containers
::group::Update the kbs container image
/tmp/kbs/kbs/config/kubernetes/base /tmp/kbs/kbs/config/kubernetes /tmp/kbs ~/go/src/github.com/kata-containers/kata-containers
/tmp/kbs/kbs/config/kubernetes /tmp/kbs ~/go/src/github.com/kata-containers/kata-containers
::endgroup::
::group::Deploy the KBS
namespace/coco-tenant created
configmap/kbs-config-k5gm89bk2b created
secret/kbs-auth-public-key-26bb2m572t created
secret/keys-gmf2g75547 created
service/kbs created
deployment.apps/kbs created
/tmp/kbs ~/go/src/github.com/kata-containers/kata-containers
~/go/src/github.com/kata-containers/kata-containers
pod/kbs-598c4bfd-qrs26 condition met
::endgroup::
::group::Check the service healthy
pod/kbs-checker-126625 created
wget: server returned error: HTTP/1.1 404 Not Found
KBS service respond to requests
::endgroup::
``` 

And to delete:

```
$ ./tests/integration/kubernetes/gha-run.sh delete-coco-kbs
/tmp/kbs ~/go/src/github.com/kata-containers/kata-containers
namespace "coco-tenant" deleted
configmap "kbs-config-k5gm89bk2b" deleted
secret "kbs-auth-public-key-26bb2m572t" deleted
secret "keys-gmf2g75547" deleted
service "kbs" deleted
deployment.apps "kbs" deleted
~/go/src/github.com/kata-containers/kata-containers
```

As agreed on the CoCo CI meeting we will pursued to run the attestation tests on both TEE and non-TEE jobs. Initially I've changed the non-TEE [run-kata-deploy-tests-on-aks.yaml](https://github.com/kata-containers/kata-containers/blob/main/.github/workflows/run-kata-deploy-tests-on-aks.yaml) workflow to get KBS installed, but only for the kata-qemu configuration. Further workflows should be addressed on follow up PRs.

Fixes #9056

## Notes

 * As mentioned the code was tested on a kubeadm (not exposing the service) and AKS clusters, ~I hope to run the CI to see if it works for AKS (in theory it should)~. For other cluster types, e.g., k3s, we will need to test it too but hopefully only when it comes the time to run attestation tests on workflows that use those "alternative" k8s clusters
 * ~Currently the KBS service is reachable only within the cluster (as one can note on the "healthy checker")~. Depending on how we gonna feed the KBS with data for the tests, we might need to expose the service with a public IP. For example, suppose that we want to use the [KBS client](https://github.com/confidential-containers/kbs/tree/main/kbs/tools/client) from within the Github Actions runner, then it will be required to expose the service externally from AKS. Other questions will derive from this, for example, how/where to install the client, how to get access to the authentication key...etc @GabyCT @fitzthum something we will need to sync'up
 * The first commit of this series, that changes the workflow, should be merged before and in another PR. I leaving it here to receive the initial reviews as well as show how it all integrate