### PR TITLE
packaging: release notes: Don't show shortlist by default, and add survey link

### DIFF
--- a/tools/packaging/release/release-notes.sh
+++ b/tools/packaging/release/release-notes.sh
@@ -75,9 +75,19 @@ changes() {
 	echo "**FIXME - message this section by hand to produce a summary please**"
 
 	echo "### Shortlog"
+
+	echo "<details>"
+	echo "<summary>Click the icon to show the list of commits included in this release</summary>"
+
+	# XXX: Essential to have at least one blank line here. It forces
+	# GitHub to show each commit on a separate line.
+	echo
+
 	for cr in $(git log --merges "${previous_release}".."${new_release}" | grep 'Merge:' | awk '{print $2".."$3}'); do
 		git log --oneline "$cr"
 	done
+
+	echo "</details>"
 }
 
 print_release_notes() {

--- a/tools/packaging/release/release-notes.sh
+++ b/tools/packaging/release/release-notes.sh
@@ -104,6 +104,17 @@ EOF
 ## ${repo} Changes
 $(changes)
 
+## Survey
+
+Please take the Kata Containers survey:
+
+- https://openinfrafoundation.formstack.com/forms/kata_containers_user_survey
+
+This will help the Kata Containers community understand:
+
+- how you use Kata Containers
+- what features and improvements you would like to see in Kata Containers
+
 EOF
 		popd >>/dev/null
 		rm -rf "${tmp_dir}/${repo}"


### PR DESCRIPTION
Add a link in the release notes to the Kata Container survey, to
advertise it, and hopefully encourage users to take the survey.

Add a "twistie" / arrow (`▶`) that the user can click on to see the full
list of commits _if they want to_.

This way, the release notes become easier to read and we can display
information below the shortlog which would (probably) normally not be
seen due to the huge long list of commits.

Fixes: #9075.
Fixes: #9074.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>