### PR TITLE
docs: Update CI link into the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ The table below lists the remaining parts of the project:
 | [`kata-ctl`](src/tools/kata-ctl) | utility | Tool that provides advanced commands and debug facilities. |
 | [`trace-forwarder`](src/tools/trace-forwarder) | utility | Agent tracing helper. |
 | [`runk`](src/tools/runk) | utility | Standard OCI container runtime based on the agent. |
-| [`ci`](https://github.com/kata-containers/ci) | CI | Continuous Integration configuration files and scripts. |
+| [`ci`](.github/workflows) | CI | Continuous Integration configuration files and scripts. |
 | [`katacontainers.io`](https://github.com/kata-containers/www.katacontainers.io) | Source for the [`katacontainers.io`](https://www.katacontainers.io) site. |
 | [`Webhook`](tools/testing/kata-webhook/README.md) | utility | Example of a simple admission controller webhook to annotate pods with the Kata runtime class |
 


### PR DESCRIPTION
This PR updates the CI link into the README as currently we are using GHA workflows and they are now part of the kata containers repository.

Fixes #9078