### PR TITLE
release: Don't ship the pause-image / coco-guest-components as part of the release artefacts

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -68,6 +68,8 @@ jobs:
             stage: release
           - asset: cloud-hypervisor-glibc
             stage: release
+          - asset: pause-image
+            stage: release
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -70,6 +70,8 @@ jobs:
             stage: release
           - asset: pause-image
             stage: release
+          - asset: coco-guest-components
+            stage: release
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -38,6 +38,9 @@ jobs:
           - virtiofsd
         stage:
           - ${{ inputs.stage }}
+        exclude:
+          - asset: pause-image
+            stage: release
     steps:
       - name: Take a pre-action for self-hosted runner
         run: ${HOME}/script/pre_action.sh ubuntu-2204

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -41,6 +41,8 @@ jobs:
         exclude:
           - asset: pause-image
             stage: release
+          - asset: coco-guest-components
+            stage: release
     steps:
       - name: Take a pre-action for self-hosted runner
         run: ${HOME}/script/pre_action.sh ubuntu-2204


### PR DESCRIPTION
It doesn't make sense to ship the pause-image / coco-guest-components themselves as an release artefact.

The reason we build and cache those is in order to use them inside the rootfs, and that's it, there's not need to ship them as part of the release, at all.

Fixes: #9032 -- part II
