### PR TITLE
tests: Remove kata-deploy-tdx test and ensure kata-deploy is always cleaned up before starting the tests

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -23,42 +23,6 @@ on:
         default: ""
 
 jobs:
-  run-kata-deploy-tests-on-tdx:
-    strategy:
-      fail-fast: false
-      matrix:
-        vmm:
-          - qemu-tdx
-        snapshotter:
-          - nydus
-        pull-type:
-          - guest-pull
-    runs-on: tdx
-    env:
-      DOCKER_REGISTRY: ${{ inputs.registry }}
-      DOCKER_REPO: ${{ inputs.repo }}
-      DOCKER_TAG: ${{ inputs.tag }}
-      PR_NUMBER: ${{ inputs.pr-number }}
-      KATA_HYPERVISOR: ${{ matrix.vmm }}
-      KUBERNETES: "k3s"
-      USING_NFD: "true"
-      SNAPSHOTTER: ${{ matrix.snapshotter }}
-      PULL_TYPE: ${{ matrix.pull-type }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.commit-hash }}
-          fetch-depth: 0
-
-      - name: Rebase atop of the latest target branch
-        run: |
-          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
-        env:
-          TARGET_BRANCH: ${{ inputs.target-branch }}
-
-      - name: Run tests
-        run: bash tests/functional/kata-deploy/gha-run.sh run-tests
-
   run-k8s-tests-on-tdx:
     strategy:
       fail-fast: false


### PR DESCRIPTION
---

ci: Clean up kata-deploy ds before starting the tests

This will ensure no leftovers are in the node, which has been cause the
TDX CI to fail every now and then.

Fixes: #9081

---

gha: tdx: Stop running kata-deploy tests on TDX

We only have one TDX machine, let's not make it busier than needed.

---