### PR TITLE
gha: docker: Pull docker image as part of the dependencies

### DIFF
--- a/tests/integration/docker/gha-run.sh
+++ b/tests/integration/docker/gha-run.sh
@@ -12,11 +12,14 @@ set -o pipefail
 kata_tarball_dir="${2:-kata-artifacts}"
 docker_dir="$(dirname "$(readlink -f "$0")")"
 source "${docker_dir}/../../common.bash"
+image="${image:-instrumentisto/nmap:latest}"
 
 function install_dependencies() {
 	info "Installing the dependencies needed for running the docker smoke test"
 
 	install_docker
+
+	sudo -E docker pull "${image}"
 }
 
 function run() {
@@ -25,10 +28,10 @@ function run() {
 	enabling_hypervisor
 
 	info "Running docker with runc"
-	sudo docker run --rm --entrypoint nping instrumentisto/nmap --tcp-connect -c 2 -p 80 www.github.com
+	sudo docker run --rm --entrypoint nping "${image}" --tcp-connect -c 2 -p 80 www.github.com
 
 	info "Running docker with Kata Containers (${KATA_HYPERVISOR})"
-	sudo docker run --rm --runtime io.containerd.kata-${KATA_HYPERVISOR}.v2 --entrypoint nping instrumentisto/nmap --tcp-connect -c 2 -p 80 www.github.com
+	sudo docker run --rm --runtime io.containerd.kata-${KATA_HYPERVISOR}.v2 --entrypoint nping "${image}" --tcp-connect -c 2 -p 80 www.github.com
 }
 
 function main() {


### PR DESCRIPTION
This PR pulls the docker image needed for the test as part of the dependencies in order to avoid failures of timeouts mainly because the image was not properly download it and it is unable to find it.

Fixes #9089