### PR TITLE
CI|k8s: Skip vcpu allocation test for s390x

### DIFF
--- a/tests/integration/kubernetes/filter_out_per_arch/s390x.yaml
+++ b/tests/integration/kubernetes/filter_out_per_arch/s390x.yaml
@@ -6,3 +6,4 @@
 kubernetes:
   - k8s-caps
   - k8s-inotify
+  - k8s-sandbox-vcpus-allocation # see https://github.com/kata-containers/kata-containers/issues/9093


### PR DESCRIPTION
A test `vcpu allocation k8s test` exhibits different behavior on s390x For more details, please refer to issue #9093.
This commit is to make the test skipped until the issue is resolved on the platform.

Fixes: #9093

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>