### PR TITLE
runtime: remove kata_shim_netdev metric

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/shim_metrics.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_metrics.go
@@ -49,14 +49,6 @@ var (
 		[]string{"item"},
 	)
 
-	katashimNetdev = prometheus.NewGaugeVec(prometheus.GaugeOpts{
-		Namespace: namespaceKatashim,
-		Name:      "netdev",
-		Help:      "Kata containerd shim v2 network devices statistics.",
-	},
-		[]string{"interface", "item"},
-	)
-
 	katashimIOStat = prometheus.NewGaugeVec(prometheus.GaugeOpts{
 		Namespace: namespaceKatashim,
 		Name:      "io_stat",
@@ -89,7 +81,6 @@ func registerMetrics() {
 	prometheus.MustRegister(katashimThreads)
 	prometheus.MustRegister(katashimProcStatus)
 	prometheus.MustRegister(katashimProcStat)
-	prometheus.MustRegister(katashimNetdev)
 	prometheus.MustRegister(katashimIOStat)
 	prometheus.MustRegister(katashimOpenFDs)
 	prometheus.MustRegister(katashimPodOverheadCPU)
@@ -106,14 +97,6 @@ func updateShimMetrics() error {
 	// metrics about open FDs
 	if fds, err := proc.FileDescriptorsLen(); err == nil {
 		katashimOpenFDs.Set(float64(fds))
-	}
-
-	// network device metrics
-	if netdev, err := proc.NetDev(); err == nil {
-		// netdev: map[string]NetDevLine
-		for _, v := range netdev {
-			mutils.SetGaugeVecNetDev(katashimNetdev, v)
-		}
 	}
 
 	// proc stat


### PR DESCRIPTION
Following discussion on #5738 - I think the `kata_shim_netdev` metrics is unneeded.
It is not only using too much memory (causing Prometheus pods to be OOM-killed in some installations), but it also reports data from interfaces that are unrelated to kata (no namespace isolation allowing the reporting of host-wide metrics).

The shim network usage is not giving any useful insight anyway - we already have hypervisor and agent metrics for that.
So rather than trying to fix the memory/namespace question, I'm suggesting to just remove the shim netdev metrics.

I'm also doing it on the rust implementation, even if it's not impacted by the initial bug as far as I can tell: In the rutime-rs case, the metrics are isolated (not verified, but that's my understanding at this point). Also it seems we don't have hypervisor netdev metrics coming from runtime-rs, but we still have the agent's network metrics.
I feel it's worth removing anyway, if only for consistency, but I'm making it in a separate commit in case reviewers ask to keep it as it is.