### PR TITLE
ci: k8s: Fix checks used to skip confidential tests

### DIFF
--- a/tests/integration/kubernetes/k8s-confidential.bats
+++ b/tests/integration/kubernetes/k8s-confidential.bats
@@ -15,11 +15,11 @@ setup() {
 
 	# This check must be done with "<SPACE>${KATA_HYPERVISOR}<SPACE>" to avoid
 	# having substrings, like qemu, being matched with qemu-$something.
-	if ! [[ " ${KATA_HYPERVISOR} " =~ " ${SUPPORTED_TEE_HYPERVISORS[@]} " ]] && ! [[ " ${KATA_HYPERVISOR} " =~ " ${SUPPORTED_NON_TEE_HYPERVISORS} " ]]; then
+	if ! [[ " ${SUPPORTED_TEE_HYPERVISORS[@]} " =~ " ${KATA_HYPERVISOR} " ]] && ! [[ " ${SUPPORTED_NON_TEE_HYPERVISORS} " =~ " ${KATA_HYPERVISOR} " ]]; then
 		skip "Test not supported for ${KATA_HYPERVISOR}."
 	fi
 
-	if [[ " ${KATA_HYPERVISOR} " =~ " ${SUPPORTED_NON_TEE_HYPERVISORS} " ]]; then
+	if [[ " ${SUPPORTED_NON_TEE_HYPERVISORS} " =~ " ${KATA_HYPERVISOR} " ]]; then
 		info "Need to apply image annotations"
 	else
 		get_pod_config_dir
@@ -28,7 +28,7 @@ setup() {
 }
 
 @test "Test unencrypted confidential container launch success and verify that we are running in a secure enclave." {
-	[[ " ${KATA_HYPERVISOR} " =~ " ${SUPPORTED_NON_TEE_HYPERVISORS} " ]] &&  skip "Test not supported for ${KATA_HYPERVISOR}."
+	[[ " ${SUPPORTED_NON_TEE_HYPERVISORS} " =~ " ${KATA_HYPERVISOR} " ]] && skip "Test not supported for ${KATA_HYPERVISOR}."
 	# Start the service/deployment/pod
 	kubectl apply -f "${pod_config_dir}/pod-confidential-unencrypted.yaml"
 
@@ -54,7 +54,7 @@ setup() {
 }
 
 teardown() {
-	if ! [[ " ${KATA_HYPERVISOR} " =~ " ${SUPPORTED_TEE_HYPERVISORS[@]} " ]] && ! [[ " ${KATA_HYPERVISOR} " =~ " ${SUPPORTED_NON_TEE_HYPERVISORS} " ]]; then
+	if ! [[ " ${SUPPORTED_TEE_HYPERVISORS[@]} " =~ " ${KATA_HYPERVISOR} " ]] && ! [[ " ${SUPPORTED_NON_TEE_HYPERVISORS} " =~ " ${KATA_HYPERVISOR} " ]]; then
 		skip "Test not supported for ${KATA_HYPERVISOR}."
 	fi
 


### PR DESCRIPTION
This has been introduced by 53bc4a432bc9782272fb7fd1fe3113e006172294, where the condition was changed.

The correct condition is:
* If the list of supported tees does not contain the kata hypervisor and the list of supported non tees does not contain the kata hypervisor.

The error is that we were checking whether kata-hypervisor would contain the list of supported tees, and that would almost always be false (unless in the case where the list had an one and only one element).

Fixes: #9055 -- part II