### PR TITLE
gha: k8s: prepare AKS workflow to install the CoCo KBS

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -52,6 +52,10 @@ jobs:
       GH_PR_NUMBER: ${{ inputs.pr-number }}
       KATA_HOST_OS: ${{ matrix.host_os }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
+      # Set to install the KBS for attestation tests
+      KBS: ${{ (matrix.vmm == 'qemu' && matrix.host_os == 'ubuntu') && 'true' || 'false' }}
+      # Set the KBS ingress handler (empty string disables handling)
+      KBS_INGRESS: "aks"
       KUBERNETES: "vanilla"
       USING_NFD: "false"
       K8S_TEST_HOST_TYPE: ${{ matrix.instance-type }}
@@ -103,7 +107,17 @@ jobs:
       - name: Deploy Kata
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-aks
-      
+
+      - name: Deploy CoCo KBS
+        if: env.KBS == 'true'
+        timeout-minutes: 5
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
+
+      - name: Install `kbs-client`
+        if: env.KBS == 'true'
+        timeout-minutes: 5
+        run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
+
       - name: Run tests
         timeout-minutes: 60
         run: bash tests/integration/kubernetes/gha-run.sh run-tests

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -23,6 +23,8 @@ DOCKER_TAG=${DOCKER_TAG:-kata-containers-latest}
 KATA_DEPLOY_WAIT_TIMEOUT=${KATA_DEPLOY_WAIT_TIMEOUT:-10m}
 SNAPSHOTTER_DEPLOY_WAIT_TIMEOUT=${SNAPSHOTTER_DEPLOY_WAIT_TIMEOUT:-8m}
 KATA_HYPERVISOR=${KATA_HYPERVISOR:-qemu}
+KBS=${KBS:-false}
+KBS_INGRESS=${KBS_INGRESS:-}
 KUBERNETES="${KUBERNETES:-}"
 SNAPSHOTTER="${SNAPSHOTTER:-}"
 export AUTO_GENERATE_POLICY="${AUTO_GENERATE_POLICY:-no}"
@@ -103,6 +105,10 @@ function configure_snapshotter() {
 	echo "::endgroup::"
 }
 
+function deploy_coco_kbs() {
+	echo "TODO: deploy https://github.com/confidential-containers/kbs"
+}
+
 function deploy_kata() {
 	platform="${1}"
 	ensure_yq
@@ -168,6 +174,10 @@ function deploy_kata() {
 	echo "::group::Runtime classes"
 	kubectl get runtimeclass
 	echo "::endgroup::"
+}
+
+function install_kbs_client() {
+	echo "TODO: install kbs-client - https://github.com/kata-containers/kata-containers/pull/9114"
 }
 
 function run_tests() {
@@ -354,9 +364,11 @@ function main() {
 		create-cluster-kcli) create_cluster_kcli ;;
 		configure-snapshotter) configure_snapshotter ;;
 		setup-crio) setup_crio ;;
+		deploy-coco-kbs) deploy_coco_kbs ;;
 		deploy-k8s) deploy_k8s ;;
 		install-bats) install_bats ;;
 		install-kata-tools) install_kata_tools ;;
+		install-kbs-client) install_kbs_client ;;
 		install-kubectl) install_kubectl ;;
 		get-cluster-credentials) get_cluster_credentials ;;
 		deploy-kata-aks) deploy_kata "aks" ;;


### PR DESCRIPTION
Changed the "run k8s tests on AKS" workflows to get the CoCo KBS installed so that we can run attestation tests.

The plan is to run attestation tests only on a subset of non-TEE jobs initially, so this commit restricts to install KBS only on kata-qemu configuration. Actually at this point it is added only stubs commands to tests/integration/kubernetes/gha-run.sh that should be implemented in a future commit.

Fixes #9058
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>

---

This is a split of PR #9065. We merge this commit first to then allow to run CI on #9065.

@sprt @jodh-intel suggested on #9065 to move the logic about whether to install or not the KBS out of the workflow and into the shell script as this is easier for testing and future extending. However, talking with @fidencio today, despite agreeing with @sprt and @jodh-intel that it would be easier for testing; conceptually speaking it should be the workflow concerned about taking (or not) some action like install the kbs. So I moved the logic back to the workflow, however, unlike on the original version, this time I added the flag to enable/disable KBS installation on the matrix.

I ran the `actionlint` program on the new workflow file, so I can ensure it has no syntax errors :) 
    