### PR TITLE
gha: Storing artifacts for logs of k8s tests garm

### DIFF
--- a/.github/workflows/run-k8s-tests-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-on-garm.yaml
@@ -94,7 +94,6 @@ jobs:
           name: k8s-tests-garm-${{ matrix.vmm }}
           path: /tmp/artifacts
           retention-days: 1
-          if-no-files-found: error
 
       - name: Delete kata-deploy
         if: always()

--- a/.github/workflows/run-k8s-tests-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-on-garm.yaml
@@ -85,6 +85,17 @@ jobs:
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
   
+      - name: Make artifacts tarball ${{ matrix.vmm }}
+        run: bash tests/integration/kubernetes/gha-run.sh make-tarball-artifacts
+
+      - name: Archive artifacts ${{ matrix.vmm }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: k8s-tests-garm-${{ matrix.vmm }}
+          path: artifacts-${{ matrix.vmm }}.tar.gz
+          retention-days: 1
+          if-no-files-found: error
+
       - name: Delete kata-deploy
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-garm

--- a/.github/workflows/run-k8s-tests-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-on-garm.yaml
@@ -85,14 +85,14 @@ jobs:
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
   
-      - name: Collect artifacts
+      - name: Collect artifacts ${{ matrix.vmm }}
         run: bash tests/integration/kubernetes/gha-run.sh collect-artifacts
 
-      - name: Archive artifacts
+      - name: Archive artifacts ${{ matrix.vmm }}
         uses: actions/upload-artifact@v3
         with:
           name: k8s-tests-garm-${{ matrix.vmm }}
-          path: artifacts-${{ matrix.vmm }}.tar.gz
+          path: /tmp/artifacts
           retention-days: 1
           if-no-files-found: error
 

--- a/.github/workflows/run-k8s-tests-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-on-garm.yaml
@@ -85,10 +85,10 @@ jobs:
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
   
-      - name: Make artifacts tarball ${{ matrix.vmm }}
-        run: bash tests/integration/kubernetes/gha-run.sh make-tarball-artifacts
+      - name: Collect artifacts
+        run: bash tests/integration/kubernetes/gha-run.sh collect-artifacts
 
-      - name: Archive artifacts ${{ matrix.vmm }}
+      - name: Archive artifacts
         uses: actions/upload-artifact@v3
         with:
           name: k8s-tests-garm-${{ matrix.vmm }}

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -70,14 +70,14 @@ EOF
 	case "${KUBERNETES}" in
 		k3s)
 			containerd_config_file="/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl"
-			sudo cp /var/lib/rancher/k3s/agent/etc/containerd/config.toml ${containerd_config_file}
+			sudo cp /var/lib/rancher/k3s/agent/etc/containerd/config.toml "${containerd_config_file}"
 			;;
 		*) >&2 echo "${KUBERNETES} flavour is not supported"; exit 2 ;;
 	esac
 
 	# We're not using this with baremetal machines, so we're fine on cutting
 	# corners here and just append this to the configuration file.
-	cat<<EOF | sudo tee -a ${containerd_config_file}
+	cat<<EOF | sudo tee -a "${containerd_config_file}"
 [plugins."io.containerd.snapshotter.v1.devmapper"]
   pool_name = "contd-thin-pool"
   base_image_size = "4096MB"
@@ -85,19 +85,19 @@ EOF
 
 	case "${KUBERNETES}" in
 		k3s)
-			sudo sed -i -e 's/snapshotter = "overlayfs"/snapshotter = "devmapper"/g' ${containerd_config_file}
+			sudo sed -i -e 's/snapshotter = "overlayfs"/snapshotter = "devmapper"/g' "${containerd_config_file}"
 			sudo systemctl restart k3s ;;
 		*) >&2 echo "${KUBERNETES} flavour is not supported"; exit 2 ;;
 	esac
 
 	sleep 60s
-	sudo cat ${containerd_config_file}
+	sudo cat "${containerd_config_file}"
 }
 
 function configure_snapshotter() {
 	echo "::group::Configuring ${SNAPSHOTTER}"
 
-	case ${SNAPSHOTTER} in
+	case "${SNAPSHOTTER}" in
 		devmapper) configure_devmapper ;;
 		*) >&2 echo "${SNAPSHOTTER} flavour is not supported"; exit 2 ;;
 	esac
@@ -265,7 +265,7 @@ function cleanup() {
 	get_nodes_and_pods_info
 
 	if [ "${platform}" = "aks" ]; then
-		delete_cluster ${test_type}
+		delete_cluster "${test_type}"
 		return
 	fi
 
@@ -336,8 +336,8 @@ function deploy_nydus_snapshotter() {
 	echo "::endgroup::"
 	echo "::group::nydus snapshotter logs"
 	pods_name=$(kubectl get pods --selector=app=nydus-snapshotter -n nydus-system -o=jsonpath='{.items[*].metadata.name}')
-	kubectl logs ${pods_name} -n nydus-system
-	kubectl describe pod ${pods_name} -n nydus-system
+	kubectl logs "${pods_name}" -n nydus-system
+	kubectl describe pod "${pods_name}" -n nydus-system
 	echo "::endgroup::"
 }
 

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -195,6 +195,7 @@ function run_tests() {
 
 	pushd "${kubernetes_dir}"
 	bash setup.sh
+	export start_time=$(date '+%Y-%m-%d %H:%M:%S')
 	if [[ "${KATA_HYPERVISOR}" = "dragonball" ]] && [[ "${SNAPSHOTTER}" = "devmapper" ]] || [[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]] && [[ "${SNAPSHOTTER}" = "devmapper" ]]; then
 		# cloud-hypervisor runtime-rs issue is https://github.com/kata-containers/kata-containers/issues/9034
 		echo "Skipping tests for $KATA_HYPERVISOR using devmapper"
@@ -210,8 +211,10 @@ function collect_artifacts() {
 		rm -rf "${artifacts_dir}"
 	fi
 	mkdir -p "${artifacts_dir}"
-	info "Running teardown script to collect artifacts using ${KATA_HYPERVISOR} hypervisor"
-	bash "${kubernetes_dir}/../../../ci/teardown.sh" "${artifacts_dir}"
+	info "Collecting artifacts using ${KATA_HYPERVISOR} hypervisor"
+	local journalctl_log_filename="journalctl.log"
+	local journalctl_log_path="${artifacts_dir}/${journalctl_log_filename}"
+	sudo journalctl --since="$start_time" > "${journalctl_log_path}"
 }
 
 function cleanup_kata_deploy() {


### PR DESCRIPTION
This PR helps to store the artifacts for different logs for k8s tests on garm. This includes changes in the workflow to install the dependencies required as well as saving the artifacts files, the introduction of the teardown script which will help to collect kata env details as well as logs from the different components.

Fixes #9103