### PR TITLE
runtime-rs: bugfix for GPU passthrough failed with InvalidOperation.

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -220,6 +220,7 @@ impl DragonballInner {
             max_vcpu_count: self.config.cpu_info.default_maxvcpus as u8,
             mem_type,
             mem_file_path,
+            pci_hotplug_enabled: true,
             ..Default::default()
         };
         info!(sl!(), "vm config: {:?}", vm_config);


### PR DESCRIPTION
    runtime-rs: bugfix for GPU passthrough failed with InvalidOperation.
    
    We need initailize the pci_hotplug_enabled with true before we do GPU
    passthrough with runtime-rs/dragonball. Otherwise it fails with error
    `InvalidOperation`.

Fixes: #9129

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>