### PR TITLE
gha: bump nydus snapshotter version to v0.13.8

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -288,7 +288,7 @@ externals:
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.13.7"
+    version: "v0.13.8"
 
   open-policy-agent:
     description: "Open Policy Agent"


### PR DESCRIPTION
Bump nydus snapshotter version to v0.13.8 to fix the bug in v0.13.7 : https://github.com/containerd/nydus-snapshotter/pull/582

Fixes: #9131