### PR TITLE
genpolicy: panic when we see a volume mount subpath

### DIFF
--- a/src/tools/genpolicy/src/mount_and_storage.rs
+++ b/src/tools/genpolicy/src/mount_and_storage.rs
@@ -23,6 +23,14 @@ pub fn get_policy_mounts(
     yaml_container: &pod::Container,
     is_pause_container: bool,
 ) {
+    if let Some(volumeMounts) = &yaml_container.volumeMounts {
+        for volumeMount in volumeMounts {
+            if volumeMount.subPath.is_some() {
+                panic!("Kata Containers doesn't support volumeMounts.subPath - see https://github.com/kata-containers/runtime/issues/2812");
+            }
+        }
+    }
+
     let c_settings = settings.get_container_settings(is_pause_container);
     let settings_mounts = &c_settings.Mounts;
     let rootfs_access = if yaml_container.read_only_root_filesystem() {

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -412,6 +412,9 @@ pub struct VolumeMount {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub readOnly: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subPath: Option<String>,
     // TODO: additional fields.
 }
 


### PR DESCRIPTION
Make tool panic when we find a yaml that has a volume mount subpath defined.

Fixes: https://github.com/kata-containers/kata-containers/issues/9145