### PR TITLE
build-checks: Install protoc in the ci environments

### DIFF
--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -95,7 +95,7 @@ jobs:
           echo "LIBSECCOMP_LINK_TYPE=static" >> $GITHUB_ENV
           echo "LIBSECCOMP_LIB_PATH=${libseccomp_install_dir}/lib" >> $GITHUB_ENV
       - name: Install protobuf-compiler
-        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
+        if: ${{ matrix.command != 'make vendor' && (matrix.component == 'agent' || matrix.component == 'runk') }}
         run: sudo apt-get -y install protobuf-compiler
       - name: Install clang
         if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}


### PR DESCRIPTION
To test PR #8484, the compilation process for the kata-agent relies on protoc:
https://github.com/kata-containers/kata-containers/actions/runs/8016317290/job/21898040849?pr=8484 https://github.com/kata-containers/kata-containers/actions/runs/8016534530/job/21898654435?pr=8484 

Fixes: #9141