### PR TITLE
qemu: upgrade to 8.2.4

### DIFF
--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -387,6 +387,21 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-dmg)
 	qemu_options+=(size:--disable-parallels)
 
+	# Disable new available features from 8.2.4
+	qemu_options+=(size:--disable-colo-proxy)
+	qemu_options+=(size:--disable-debug-graph-lock)
+	qemu_options+=(size:--disable-hexagon-idef-parser)
+	qemu_options+=(size:--disable-libdw)
+	qemu_options+=(size:--disable-pipewire)
+	qemu_options+=(size:--disable-pixman)
+	qemu_options+=(size:--disable-relocatable)
+	qemu_options+=(size:--disable-rutabaga-gfx)
+	qemu_options+=(size:--disable-vmdk)
+	qemu_options+=(size:--disable-avx512bw)
+	qemu_options+=(size:--disable-vpc)
+	qemu_options+=(size:--disable-vhdx)
+	qemu_options+=(size:--disable-hv-balloon)
+
 	#---------------------------------------------------------------------
 	# Enabled options
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -88,8 +88,8 @@ assets:
     qemu:
       description: "VMM that uses KVM"
       url: "https://github.com/qemu/qemu"
-      version: "v7.2.0"
-      tag: "v7.2.0"
+      version: "v8.2.4"
+      tag: "v8.2.4"
       # Do not include any non-full release versions
       # Break the line *without CR or space being appended*, to appease
       # yamllint, and note the deliberate ' ' at the end of the expression.


### PR DESCRIPTION
There is a known issue in qemu 7.2.0 that causes kernel-hashes to fail the verification of the launch binaries for the SEV legacy use case.

Fixes: #9148