### PR TITLE
ci.ocp: Backport service-up detection fixes

### DIFF
--- a/ci/openshift-ci/run_smoke_test.sh
+++ b/ci/openshift-ci/run_smoke_test.sh
@@ -57,16 +57,26 @@ else
 fi
 
 info "Wait for the HTTP server to respond"
-rm -f hello_msg.txt
-waitForProcess 60 1 "curl '${host}:${port}${hello_file}' -s -o hello_msg.txt"
-
-grep "${hello_msg}" hello_msg.txt > /dev/null
-test_status=$?
-if [ $test_status -eq 0 ]; then
-	info "HTTP server is working"
+tempfile=$(mktemp)
+check_cmd="curl -vvv '${host}:${port}${hello_file}' 2>&1 | tee -a '$tempfile' | grep -q '$hello_msg'"
+if waitForProcess 60 1 "${check_cmd}"; then
+    test_status=0
+    info "HTTP server is working"
 else
-	info "HTTP server is unreachable"
+    test_status=1
+    echo "::error:: HTTP server not working"
+    echo "::group::Output of the \"curl -vvv '${host}:${port}${hello_file}'\""
+    cat "${tempfile}"
+    echo "::endgroup::"
+    echo "::group::Describe kube-system namespace"
+    oc describe -n kube-system all
+    echo "::endgroup::"
+    echo "::group::Descibe current namespace"
+    oc describe all
+    echo "::endgroup::"
+    info "HTTP server is unreachable"
 fi
+rm -f "$tempfile"
 
 # Delete the resources.
 #


### PR DESCRIPTION
This backports the:

9060e930caf2d20f413df07778d3ab497493161c

    ci.ocp: Add debug output on HTTP service failure

    these logs are vital to analyze a setup failure.

a10a1e2c9cbc21afc1e80f22b0fb8634d27cbd8d

    ci.ocp: Improve the service-up detection

    waiting for the first response is not sufficient as OCP returns html
    page without error even when the route is not yet established describing
    the issue (why it doesn't reply with 500?). Waiting for the correct
    output should do better.

commits from the kata-containers/tests repo.

Fixes: #8653