### PR TITLE
docs: Update Code PR advice document

### DIFF
--- a/docs/code-pr-advice.md
+++ b/docs/code-pr-advice.md
@@ -171,8 +171,7 @@ allows you to think about what types of value to test.
 
 ### Other categories of test
 
-Raised a GitHub issue in the
-[`tests`](https://github.com/kata-containers/tests) repository that
+Raised a GitHub issue in the Kata Containers repository that
 explains what sort of test is required along with as much detail as
 possible. Ensure the original issue is referenced on the `tests` issue.
 
@@ -229,13 +228,13 @@ maintenance issue.
 ### Markdown syntax
 
 Run the
-[markdown checker](https://github.com/kata-containers/tests/tree/main/cmd/check-markdown)
+[markdown checker](https://github.com/kata-containers/kata-containers/tree/main/tests/cmd/check-markdown)
 on your documentation changes.
 
 ### Spell check
 
 Run the
-[spell checker](https://github.com/kata-containers/tests/tree/main/cmd/check-spelling)
+[spell checker](https://github.com/kata-containers/kata-containers/tree/main/tests/cmd/check-spelling)
 on your documentation changes.
 
 ## Finally


### PR DESCRIPTION
This PR updates the code pr advice document to make the proper references now that we have move the test repository to the kata containers repository.

Fixes #9171