### PR TITLE
versions: SNP qemu updated to stable coco tagged version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -106,9 +106,9 @@ assets:
       tag: "b67b00e6b4c7831a3f5bc684bc0df7a9bfd1bd56-plus-TDX-v1.10"
 
     qemu-snp-experimental:
-      description: "QEMU with experimental SNP support"
-      url: "https://github.com/AMDESE/qemu"
-      tag: "b6ee1218e6c9b98a556841615dd10d094e648393"
+      description: "QEMU with SNP support"
+      url: "https://github.com/confidential-containers/qemu.git"
+      tag: "amd-snp-202402240000"
 
     stratovirt:
       description: "StratoVirt is an lightweight opensource VMM"


### PR DESCRIPTION
New qemu fork of AMDESE created in confidential-containers project. SNP qemu version now pointed to stable tag at:
https://github.com/confidential-containers/qemu/tree/amd-snp-202402240000

Fixes: #9173

Forks of AMDESE repositories have been created in the confidential-containers project:
[amdese-amdsev](https://github.com/confidential-containers/amdese-amdsev/tree/amd-snp)
[linux](https://github.com/confidential-containers/linux)
[qemu](https://github.com/confidential-containers/qemu)
[edk2](https://github.com/confidential-containers/edk2)

Pointing to the tagged version here will allow users to generate host kernels for stable SNP testing environments with the specified version of qemu above.