### PR TITLE
tests: k8s: Adapt k8s-sandbox-vcpus-allocation.bats to kubernetes v1.29

### DIFF
--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -21,9 +21,11 @@ setup() {
 	# Create the pods
 	kubectl create -f "${pod_config_dir}/pod-sandbox-vcpus-allocation.yaml"
 
+	# Wait for completion
+	kubectl wait --for=jsonpath='{.status.conditions[0].reason}'=PodCompleted --timeout=$timeout pod --all
+
 	# Check the pods
 	for i in {0..2}; do
-		kubectl wait --for=jsonpath='{.status.conditions[0].reason}'=PodCompleted --timeout=$timeout pod ${pods[$i]}
 		[ `kubectl logs ${pods[$i]}` -eq ${expected_vcpus[$i]} ]
 	done
 }

--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -22,7 +22,7 @@ setup() {
 	kubectl create -f "${pod_config_dir}/pod-sandbox-vcpus-allocation.yaml"
 
 	# Wait for completion
-	kubectl wait --for=jsonpath='{.status.conditions[0].reason}'=PodCompleted --timeout=$timeout pod --all
+	kubectl wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=$timeout pod --all
 
 	# Check the pods
 	for i in {0..2}; do


### PR DESCRIPTION
Kubernetes v1.29 introduced a new [PodReadyToStartContainers](https://kubernetes.io/blog/2023/12/19/pod-ready-to-start-containers-condition-now-in-beta/) condition that breaks assumptions in `k8s-sandbox-vcpus-allocation.bats`.

Pass a less fragile condition to `kubectl wait`.

Fixes #9178