### PR TITLE
gha: Add cloud-hypervisor (runtime-rs) support to cri-containerd tests

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         containerd_version: ['lts', 'active']
-        vmm: ['clh', 'dragonball', 'qemu', 'stratovirt']
+        vmm: ['clh', 'dragonball', 'qemu', 'stratovirt', 'cloud-hypervisor']
     runs-on: garm-ubuntu-2204-smaller
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -10,7 +10,7 @@ set -o nounset
 set -o pipefail
 
 kata_tarball_dir="${2:-kata-artifacts}"
-cri_containerd_dir="$(dirname "$(readlink -f "$0")")" 
+cri_containerd_dir="$(dirname "$(readlink -f "$0")")"
 source "${cri_containerd_dir}/../../common.bash"
 
 function install_dependencies() {
@@ -35,7 +35,7 @@ function install_dependencies() {
 	sudo apt-get -y install "${system_deps[@]}"
 
 	ensure_yq
-	${repo_root_dir}/tests/install_go.sh -p -f
+	"${repo_root_dir}"/tests/install_go.sh -p -f
 
 	# Dependency list of projects that we can install them
 	# directly from their releases on GitHub:
@@ -48,7 +48,7 @@ function install_dependencies() {
 
 	for github_dep in "${github_deps[@]}"; do
 		IFS=":" read -r -a dep <<< "${github_dep}"
-		install_${dep[0]} "${dep[1]}"
+		install_"${dep[0]}" "${dep[1]}"
 	done
 
 	# Clone containerd as we'll need to build it in order to run the tests
@@ -64,7 +64,7 @@ function run() {
 	if [[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]]; then
 		echo "Skipping cri-containerd tests for ${KATA_HYPERVISOR}"
 	else
-		bash -c ${cri_containerd_dir}/integration-tests.sh
+		bash -c "${cri_containerd_dir}/integration-tests.sh"
 	fi
 }
 

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -61,7 +61,11 @@ function run() {
 
 	enabling_hypervisor
 
-	bash -c ${cri_containerd_dir}/integration-tests.sh
+	if [[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]]; then
+		echo "Skipping cri-containerd tests for ${KATA_HYPERVISOR}"
+	else
+		bash -c ${cri_containerd_dir}/integration-tests.sh
+	fi
 }
 
 function main() {

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -35,7 +35,7 @@ function install_dependencies() {
 	sudo apt-get -y install "${system_deps[@]}"
 
 	ensure_yq
-	"${repo_root_dir}"/tests/install_go.sh -p -f
+	. "${repo_root_dir}/tests/install_go.sh" -p -f
 
 	# Dependency list of projects that we can install them
 	# directly from their releases on GitHub:
@@ -48,7 +48,7 @@ function install_dependencies() {
 
 	for github_dep in "${github_deps[@]}"; do
 		IFS=":" read -r -a dep <<< "${github_dep}"
-		install_"${dep[0]}" "${dep[1]}"
+		"install_${dep[0]}" "${dep[1]}"
 	done
 
 	# Clone containerd as we'll need to build it in order to run the tests


### PR DESCRIPTION
This PR adds the Cloud Hypervisor driver, integrated with the runtime-rs, as part of the cri-containerd tests.

Fixes #9181