### PR TITLE
tests/kata-deploy: fix checker for kata-deploy running

### DIFF
--- a/tests/functional/kata-deploy/kata-deploy.bats
+++ b/tests/functional/kata-deploy/kata-deploy.bats
@@ -57,7 +57,9 @@ setup() {
 	else
 		kubectl apply -f "${repo_root_dir}/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
 	fi
-	kubectl -n kube-system wait --timeout=10m --for=condition=Ready -l name=kata-deploy pod
+
+	local cmd="kubectl -n kube-system get -l name=kata-deploy pod 2>/dev/null | grep '\<Running\>'"
+	waitForProcess 600 10 "$cmd"
 
 	# Give some time for the pod to finish what's doing and have the
 	# runtimeclasses properly created


### PR DESCRIPTION
Currently, the checking for kata-deploy is running assume that the daemonset scheduled at least one pod, however it might not had and the kubectl wait command fails due to "error: no matching resources found".

On CI I've observed that fail intermittently. I suspect the service account kata-deploy-sa take a while to show up then no kata-deploy is scheduled in meanwhile.

Changed the checker logic to use waitForProcess() to keep testing if it is already running, or hit the timeout (still 10m).

Fixes #9183
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>