### PR TITLE
agent: do not close container io when init process exits

### DIFF
--- a/src/agent/src/signal.rs
+++ b/src/agent/src/signal.rs
@@ -77,10 +77,12 @@ async fn handle_sigchild(logger: Logger, sandbox: Arc<Mutex<Sandbox>>) -> Result
             p.exit_code = ret;
             let _ = p.exit_tx.take();
 
-            info!(logger, "notify term to close");
-            // close the socket file to notify readStdio to close terminal specifically
-            // in case this process's terminal has been inherited by its children.
-            p.notify_term_close();
+            if !p.init {
+                info!(logger, "notify term to close");
+                // close the socket file to notify readStdio to close terminal specifically
+                // in case this process's terminal has been inherited by its children.
+                p.notify_term_close();
+            }
         }
     }
 }


### PR DESCRIPTION
For container io, do_read_stream() can not be interrupted to prevent
loss container io when init process exists. 

Fixes: https://github.com/kata-containers/kata-containers/issues/9186