### PR TITLE
kata-ctl: Support using container short ID to enter guest.

### DIFF
--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -1473,6 +1473,7 @@ dependencies = [
  "anyhow",
  "hyper",
  "hyperlocal",
+ "kata-sys-util",
  "kata-types",
  "tokio",
 ]

--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -1475,6 +1475,9 @@ dependencies = [
  "hyperlocal",
  "kata-sys-util",
  "kata-types",
+ "nix 0.24.2",
+ "tempfile",
+ "test-utils",
  "tokio",
 ]
 

--- a/src/libs/shim-interface/Cargo.toml
+++ b/src/libs/shim-interface/Cargo.toml
@@ -13,8 +13,13 @@ edition = "2018"
 
 [dependencies]
 anyhow = "^1.0"
+nix = "0.24.0"
 tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 hyper = { version = "0.14.20", features = ["stream", "server", "http1"] }
 hyperlocal = "0.8"
 kata-types = { path = "../kata-types" }
 kata-sys-util = {path = "../kata-sys-util" }
+
+[dev-dependencies]
+tempfile = "3.2.0"
+test-utils = {path = "../test-utils"}

--- a/src/libs/shim-interface/Cargo.toml
+++ b/src/libs/shim-interface/Cargo.toml
@@ -17,3 +17,4 @@ tokio = { version = "1.8.0", features = ["rt-multi-thread"] }
 hyper = { version = "0.14.20", features = ["stream", "server", "http1"] }
 hyperlocal = "0.8"
 kata-types = { path = "../kata-types" }
+kata-sys-util = {path = "../kata-sys-util" }

--- a/src/libs/shim-interface/src/lib.rs
+++ b/src/libs/shim-interface/src/lib.rs
@@ -88,13 +88,119 @@ pub fn mgmt_socket_addr(sid: &str) -> Result<String> {
 mod tests {
     use super::*;
 
+    use std::path;
+    use tempfile::tempdir;
+
+    use test_utils::skip_if_not_root;
+
     #[test]
     fn test_mgmt_socket_addr() {
-        let sid = "414123";
-        let addr = mgmt_socket_addr(sid).unwrap();
-        assert_eq!(addr, "unix:///run/kata/414123/shim-monitor.sock");
+        // this test has to run as root, so has to manually cleanup afterwards
+        skip_if_not_root!();
 
+        let sid = "katatest";
+        let sandbox_test = path::Path::new(KATA_PATH).join("katatest98654sandboxpath1");
+        fs::create_dir_all(sandbox_test.as_path()).unwrap();
+        let addr = mgmt_socket_addr(sid).unwrap();
+        assert_eq!(
+            addr,
+            "unix:///run/kata/katatest98654sandboxpath1/shim-monitor.sock"
+        );
+        fs::remove_dir_all(sandbox_test).unwrap();
+    }
+
+    #[test]
+    fn test_mgmt_socket_addr_with_sid_empty() {
         let sid = "";
-        assert!(mgmt_socket_addr(sid).is_err());
+        let result = mgmt_socket_addr(sid);
+        assert!(result.is_err());
+        if let Err(err) = result {
+            let left = format!("{:?}", err.to_string());
+            let left_unquoted = &left[1..left.len() - 1];
+            let left_unescaped = left_unquoted.replace("\\\"", "\"");
+
+            assert_eq!(
+                left_unescaped,
+                format!("Empty sandbox id for acquiring socket address for shim_mgmt")
+            )
+        }
+    }
+
+    #[test]
+    fn test_get_uds_with_sid_ok() {
+        let run_path = tempdir().unwrap();
+        let dir1 = run_path.path().join("kata98654sandboxpath1");
+        let dir2 = run_path.path().join("aata98654dangboxpath1");
+        fs::create_dir_all(dir1.as_path()).unwrap();
+        fs::create_dir_all(dir2.as_path()).unwrap();
+
+        let result = get_uds_with_sid("kata", &run_path.path().display().to_string());
+        assert!(result.is_ok());
+        assert_eq!(
+            result.unwrap(),
+            format!(
+                "unix://{}",
+                run_path
+                    .path()
+                    .join("kata98654sandboxpath1")
+                    .join(SHIM_MGMT_SOCK_NAME)
+                    .display()
+            )
+        )
+    }
+
+    #[test]
+    fn test_get_uds_with_sid_with_zero() {
+        let result = get_uds_with_sid("acdsdfe", KATA_PATH);
+        assert!(result.is_err());
+        if let Err(err) = result {
+            let left = format!("{:?}", err.to_string());
+            let left_unquoted = &left[1..left.len() - 1];
+            let left_unescaped = left_unquoted.replace("\\\"", "\"");
+
+            assert_eq!(
+                left_unescaped,
+                format!(
+                    "sandbox with the provided prefix {:?} is not found",
+                    "acdsdfe"
+                )
+            )
+        }
+    }
+
+    #[test]
+    fn test_get_uds_with_sid_with_invalid() {
+        let result = get_uds_with_sid("^abcdse", KATA_PATH);
+        assert!(result.is_err());
+        if let Err(err) = result {
+            let left = format!("{:?}", err.to_string());
+            let left_unquoted = &left[1..left.len() - 1];
+            let left_unescaped = left_unquoted.replace("\\\"", "\"");
+            assert_eq!(
+                left_unescaped,
+                "The short id contains invalid characters.".to_owned()
+            );
+        }
+    }
+
+    #[test]
+    fn test_get_uds_with_sid_more_than_one() {
+        let run_path = tempdir().unwrap();
+
+        let dir1 = run_path.path().join("kata98654sandboxpath1");
+        let dir2 = run_path.path().join("kata98654dangboxpath1");
+        let dir3 = run_path.path().join("aata98654dangboxpath1");
+        fs::create_dir_all(dir1.as_path()).unwrap();
+        fs::create_dir_all(dir2.as_path()).unwrap();
+        fs::create_dir_all(dir3.as_path()).unwrap();
+
+        let result = get_uds_with_sid("kata", &run_path.path().display().to_string());
+        assert!(result.is_err());
+        if let Err(err) = result {
+            let left = format!("{:?}", err.to_string());
+            let left_unquoted = &left[1..left.len() - 1];
+            let left_unescaped = left_unquoted.replace("\\\"", "\"");
+            assert_eq!(left_unescaped, format!("more than one sandbox exists with the provided prefix {:?}, please provide a unique prefix", "kata"))
+        }
     }
 }

--- a/src/libs/shim-interface/src/lib.rs
+++ b/src/libs/shim-interface/src/lib.rs
@@ -1,4 +1,5 @@
 // Copyright (c) 2022 Alibaba Cloud
+// Copyright (c) 2024 Ant Group
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -3688,6 +3688,7 @@ dependencies = [
  "anyhow",
  "hyper",
  "hyperlocal",
+ "kata-sys-util",
  "kata-types",
  "tokio",
 ]


### PR DESCRIPTION
Fixes: #9189

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>