### PR TITLE
runtime: Set maxvcpus equal to vcpus for the static resources case

### DIFF
--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -1100,6 +1100,8 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid st
 		sandboxConfig.HypervisorConfig.NumVCPUsF += sandboxConfig.SandboxResources.WorkloadCPUs
 		sandboxConfig.HypervisorConfig.MemorySize += sandboxConfig.SandboxResources.WorkloadMemMB
 
+		sandboxConfig.HypervisorConfig.DefaultMaxVCPUs = sandboxConfig.HypervisorConfig.NumVCPUs()
+
 		ociLog.WithFields(logrus.Fields{
 			"workload cpu":       sandboxConfig.SandboxResources.WorkloadCPUs,
 			"default cpu":        sandboxConfig.SandboxResources.BaseCPUs,


### PR DESCRIPTION
This patch sets maxvcpus equal to vcpus for the static sandbox resources management case. The value can safely be set to the actual number of vCPUs that the VM will use since CPU hotplugging will be no op when static_sandbox_resources_mgmt is set to true. The value gets passed down to the kernel when using clh/qemu. Booting with a high number of max vCPUs is a bit slower compared to a lower number.

Fixes: #9194