### PR TITLE
gha: Enable cri-containerd tests for cloud hypervisor runtime-rs

### DIFF
--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -61,11 +61,7 @@ function run() {
 
 	enabling_hypervisor
 
-	if [[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]]; then
-		echo "Skipping cri-containerd tests for ${KATA_HYPERVISOR}"
-	else
-		bash -c "${cri_containerd_dir}/integration-tests.sh"
-	fi
+	bash -c "${cri_containerd_dir}/integration-tests.sh"
 }
 
 function main() {


### PR DESCRIPTION
This PR enables the cri-containerd tests for cloud hypervisor runtime-rs.

Fixes #9198