### PR TITLE
gha: increase timeout of KBS steps

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -110,12 +110,12 @@ jobs:
 
       - name: Deploy CoCo KBS
         if: env.KBS == 'true'
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
 
       - name: Install `kbs-client`
         if: env.KBS == 'true'
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
 
       - name: Run tests


### PR DESCRIPTION
The step to deploy KBS on run-k8s-tests-on-aks workflow should be increased so that there is enough time for checking the service is healthy and exposed. Likewise the step that builds the kbs-client which requires enough time to build the executable.

Fixes #9058
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>