### PR TITLE
katautils: fix panic on tracing.

### DIFF
--- a/src/runtime/pkg/katautils/katatrace/tracing.go
+++ b/src/runtime/pkg/katautils/katatrace/tracing.go
@@ -90,7 +90,7 @@ func CreateTracer(name string, config *JaegerConfig) (*sdktrace.TracerProvider, 
 	}
 
 	// build tracer provider, that combining both jaeger exporter and kata exporter.
-	tp := sdktrace.NewTracerProvider(
+	tp = sdktrace.NewTracerProvider(
 		sdktrace.WithSampler(sdktrace.AlwaysSample()),
 		sdktrace.WithSyncer(kataExporter),
 		sdktrace.WithSyncer(jaegerExporter),


### PR DESCRIPTION
This fixes a panic on tracing on container exit.

The root cause is that global var needs to be set by "=" instead of ":=".

Fixes: #9102