### PR TITLE
release: Ensure the release-type is passed to workflows

### DIFF
--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -48,7 +48,7 @@ jobs:
       commit-hash: ${{ github.sha }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
-      tag: kata-containers-amd64
+      tag: kata-containers-latest-amd64
       target-branch: ${{ github.ref_name }}
     secrets: inherit
 
@@ -59,7 +59,7 @@ jobs:
       commit-hash: ${{ github.sha }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
-      tag: kata-containers-arm64
+      tag: kata-containers-latest-arm64
       target-branch: ${{ github.ref_name }}
     secrets: inherit
 
@@ -70,7 +70,7 @@ jobs:
       commit-hash: ${{ github.sha }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
-      tag: kata-containers-s390x
+      tag: kata-containers-latest-s390x
       target-branch: ${{ github.ref_name }}
     secrets: inherit
 
@@ -81,7 +81,7 @@ jobs:
       commit-hash: ${{ github.sha }}
       registry: quay.io
       repo: kata-containers/kata-deploy-ci
-      tag: kata-containers-ppc64le
+      tag: kata-containers-latest-ppc64le
       target-branch: ${{ github.ref_name }}
     secrets: inherit
 

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -5,6 +5,9 @@ on:
       target-arch:
         required: true
         type: string
+      release-type:
+        required: true
+        type: string
 
 jobs:
   build-kata-static-tarball-amd64:
@@ -42,7 +45,7 @@ jobs:
           # is "refs/tags/<tag>"
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           if [ "${tag}" = "main" ]; then
-              tag=$(./tools/packaging/release/release.sh next-release-version)
+              tag=$(RELEASE_TYPE=${{ inputs.release-type }} ./tools/packaging/release/release.sh next-release-version)
               tags=(${tag} "latest")
           else
               tags=(${tag})

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -5,6 +5,9 @@ on:
       target-arch:
         required: true
         type: string
+      release-type:
+        required: true
+        type: string
 
 jobs:
   build-kata-static-tarball-arm64:
@@ -42,7 +45,7 @@ jobs:
           # is "refs/tags/<tag>"
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           if [ "${tag}" = "main" ]; then
-              tag=$(./tools/packaging/release/release.sh next-release-version)
+              tag=$(RELEASE_TYPE=${{ inputs.release-type }} ./tools/packaging/release/release.sh next-release-version)
               tags=(${tag} "latest")
           else
               tags=(${tag})

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -5,6 +5,9 @@ on:
       target-arch:
         required: true
         type: string
+      release-type:
+        required: true
+        type: string
 
 jobs:
   build-kata-static-tarball-ppc64le:
@@ -42,7 +45,7 @@ jobs:
           # is "refs/tags/<tag>"
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           if [ "${tag}" = "main" ]; then
-              tag=$(./tools/packaging/release/release.sh next-release-version)
+              tag=$(RELEASE_TYPE=${{ inputs.release-type }} ./tools/packaging/release/release.sh next-release-version)
               tags=(${tag} "latest")
           else
               tags=(${tag})

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -5,6 +5,9 @@ on:
       target-arch:
         required: true
         type: string
+      release-type:
+        required: true 
+        type: string
 
 jobs:
   build-kata-static-tarball-s390x:
@@ -43,7 +46,7 @@ jobs:
           # is "refs/tags/<tag>"
           tag=$(echo $GITHUB_REF | cut -d/ -f3-)
           if [ "${tag}" = "main" ]; then
-              tag=$(./tools/packaging/release/release.sh next-release-version)
+              tag=$(RELEASE_TYPE=${{ inputs.release-type }} ./tools/packaging/release/release.sh next-release-version)
               tags=(${tag} "latest")
           else
               tags=(${tag})

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -6,12 +6,11 @@ on:
         required: true
         type: string
 
-env:
-  RELEASE_TYPE: ${{ inputs.release-type }}
-
 jobs:
   release:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TYPE: ${{ inputs.release-type }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -38,6 +37,7 @@ jobs:
     uses: ./.github/workflows/release-amd64.yaml
     with:
       target-arch: amd64
+      release-type: ${{ inputs.release-type }}
     secrets: inherit
 
   build-and-push-assets-arm64:
@@ -45,6 +45,7 @@ jobs:
     uses: ./.github/workflows/release-arm64.yaml
     with:
       target-arch: arm64
+      release-type: ${{ inputs.release-type }}
     secrets: inherit
 
   build-and-push-assets-s390x:
@@ -52,6 +53,7 @@ jobs:
     uses: ./.github/workflows/release-s390x.yaml
     with:
       target-arch: s390x
+      release-type: ${{ inputs.release-type }}
     secrets: inherit
 
   build-and-push-assets-ppc64le:
@@ -59,11 +61,14 @@ jobs:
     uses: ./.github/workflows/release-ppc64le.yaml
     with:
       target-arch: ppc64le
+      release-type: ${{ inputs.release-type }}
     secrets: inherit
 
   publish-multi-arch-images:
     runs-on: ubuntu-latest
     needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le]
+    env:
+      RELEASE_TYPE: ${{ inputs.release-type }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -95,6 +100,8 @@ jobs:
   upload-multi-arch-static-tarball:
     needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le]
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TYPE: ${{ inputs.release-type }}
     steps:
       - uses: actions/checkout@v4
 
@@ -150,6 +157,8 @@ jobs:
   upload-versions-yaml:
     needs: release
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TYPE: ${{ inputs.release-type }}
     steps:
       - uses: actions/checkout@v4
       - name: upload versions.yaml
@@ -161,6 +170,8 @@ jobs:
   upload-cargo-vendored-tarball:
     needs: release
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TYPE: ${{ inputs.release-type }}
     steps:
       - uses: actions/checkout@v4
       - name: generate-and-upload-tarball
@@ -172,6 +183,8 @@ jobs:
   upload-libseccomp-tarball:
     needs: release
     runs-on: ubuntu-latest
+    env:
+      RELEASE_TYPE: ${{ inputs.release-type }}
     steps:
       - uses: actions/checkout@v4
       - name: download-and-upload-tarball

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -22,7 +22,7 @@ IFS=' ' read -a REGISTRIES <<< "${KATA_DEPLOY_REGISTRIES}"
 GH_TOKEN="${GH_TOKEN:-}"
 ARCHITECTURE="${ARCHITECTURE:-}"
 KATA_STATIC_TARBALL="${KATA_STATIC_TARBALL:-}"
-RELEASE_TYPE="${RELEASE_TYPE:-minor}"
+RELEASE_TYPE="${RELEASE_TYPE:-}"
 
 function _die()
 {
@@ -35,6 +35,7 @@ function _check_required_env_var()
 	local env_var
 
 	case ${1} in
+		RELEASE_TYPE) env_var="${RELEASE_TYPE}" ;;
 		RELEASE_VERSION) env_var="${RELEASE_VERSION}" ;;
 		GH_TOKEN) env_var="${GH_TOKEN}" ;;
 		ARCHITECTURE) env_var="${ARCHITECTURE}" ;;
@@ -52,6 +53,8 @@ function _check_required_env_var()
 
 function _next_release_version()
 {
+	_check_required_env_var "RELEASE_TYPE"
+
 	local current_release=$(cat "${repo_root_dir}/VERSION")
 	local current_major
 	local current_everything_else

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -133,14 +133,8 @@ statically linked with the following [GNU LGPL-2.1][lgpl-2.1] licensed libseccom
 The \`kata-agent\` uses the libseccomp v${libseccomp_version} which is not modified from the upstream version.
 However, in order to comply with the LGPL-2.1 (§6(a)), we attach the complete source code for the library.
 
-If you want to use the \`kata-agent\` which is not statically linked with the library, you can build
-a custom \`kata-agent\` that does not use the library from sources.
-
 ## Kata Containers builder images
-The majority of the components of the project were built using containers.  In order to do a step towards
-build reproducibility we publish those container images, and when those are used combined with the version
-of the projects listed as part of the "versions.yaml" file, users can get as close to the environment we
-used to build the release artefacts.
+
 * agent (on all its different flavours): $(get_agent_image_name)
 * Kernel (on all its different flavours): $(get_kernel_image_name)
 * OVMF (on all its different flavours): $(get_ovmf_image_name)
@@ -149,29 +143,12 @@ used to build the release artefacts.
 * tools: $(get_tools_image_name)
 * virtiofsd: $(get_virtiofsd_image_name)
 
-The users who want to rebuild the tarballs using exactly the same images can simply use the following environment
-variables:
-* \`AGENT_CONTAINER_BUILDER\`
-* \`COCO_GUEST_COMPONENTS_CONTAINER_BUILDER\`
-* \`KERNEL_CONTAINER_BUILDER\`
-* \`OVMF_CONTAINER_BUILDER\`
-* \`PAUSE_IMAGE_CONTAINER_BUILDER\`
-* \`QEMU_CONTAINER_BUILDER\`
-* \`SHIM_V2_CONTAINER_BUILDER\`
-* \`TOOLS_CONTAINER_BUILDER\`
-* \`VIRTIOFSD_CONTAINER_BUILDER\`
-
 ## Installation
 
 Follow the Kata [installation instructions][installation].
 
-## Issues & limitations
-
-More information [Limitations][limitations]
-
 [libseccomp]: ${libseccomp_url}
 [lgpl-2.1]: https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html
-[limitations]: https://github.com/kata-containers/kata-containers/blob/${RELEASE_VERSION}/docs/Limitations.md
 [installation]: https://github.com/kata-containers/kata-containers/blob/${RELEASE_VERSION}/docs/install
 EOF
 


### PR DESCRIPTION
We need to ensure the release type is passed down to workflows, otherwise we'll fail to get the correct release version for tagging the daemonset images.

Fixes: #9064 - part III