### PR TITLE
CI: fix the issue of ci failure on crio

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -620,6 +620,10 @@ function install_crio() {
 	# See: https://github.com/kata-containers/kata-containers/issues/8034
 	sudo mkdir -p /etc/crio/crio.conf.d/
 	cat <<EOF | sudo tee /etc/crio/crio.conf.d/00-default-capabilities
+[crio]
+storage_option = [
+	"overlay.skip_mount_home=true",
+]
 [crio.runtime]
 default_capabilities = [
        "CHOWN",


### PR DESCRIPTION
PR #8760 tentatively tried to have the shim to run in its own mount namespace for the sake of improving isolation between the sandbox and the host. Thus crio storage drivers shouldn't create a PRIVATE bind mount on their home directory. Otherwise, the container's rootfs mount wouldn't be propagated to kata runtime's mount namespace, and kata runtime couldn't access the container's rootfs files.

So, when kata cooperated with crio, crio should set skip_mount_home=true for its storage overlay.

Fixes: #9028