### PR TITLE
Dragonball: fix unit test problems when switching to new virt github machine

### DIFF
--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -1429,11 +1429,7 @@ mod tests {
             Some(vm.vm_config().clone()),
             vm.shared_info().clone(),
         );
-        #[cfg(target_arch = "x86_64")]
-        let guest_addr = GuestAddress(0x200000000000);
-        // TODO: #7290 - https://github.com/kata-containers/kata-containers/issues/7290
-        #[cfg(target_arch = "aarch64")]
-        let guest_addr = GuestAddress(0xF800000000);
+        let guest_addr = GuestAddress(*dbs_boot::layout::GUEST_MEM_END);
 
         let cache_len = 1024 * 1024 * 1024;
         let mmap_region = MmapRegion::build(


### PR DESCRIPTION
fixes: #9207 

test_signal_handler: a) There is some unknown syscalls triggered in new github virt machine that would break the make test process with SIGSYS after applying SeccompFilter. In order to fix this, we change the allowlist in this unit test for seccompfileter into a blocklist to avoid meeting the unknown syscalls. b) lazy static METRICS is not fully initialize in the unit test and may lead to unstable result for this UT.

test_handler_insert_region: the mmap region start guest addr hard-code a value and later there would be check whether the mentioned addr is larger than or equal to mem_end (mem_end default to host_phy_mem >> 1) in order to satisfy the requirement for DaxMemory. Since github virt machine phy_mem is larger than previous CI machine we use, the hard-code value could no longer be worked. To fix this, we change the address to mem_end in unit test to avoid the influence of host machine change.