### PR TITLE
genpolicy: add restartPolicy to container struct

### DIFF
--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -137,6 +137,9 @@ pub struct Container {
     startupProbe: Option<Probe>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    restartPolicy: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub serviceAccountName: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This adds support for sidecar container introduced in Kubernetes 1.28.

Fixes: #9220

I tested this for our use-case and it worked well.