### PR TITLE
clh: initialize clh pid before using it

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -708,11 +708,10 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
 		}
 	}()
 
-	pid, err := clh.launchClh()
+	err = clh.launchClh()
 	if err != nil {
 		return fmt.Errorf("failed to launch cloud-hypervisor: %q", err)
 	}
-	clh.state.PID = pid
 
 	bootTimeout := clh.getClhAPITimeout()
 	if bootTimeout < clhCreateAndBootVMMinimumTimeout {
@@ -1344,11 +1343,13 @@ func (clh *cloudHypervisor) clhPath() (string, error) {
 	return p, err
 }
 
-func (clh *cloudHypervisor) launchClh() (int, error) {
+func (clh *cloudHypervisor) launchClh() error {
+
+	clh.state.PID = -1
 
 	clhPath, err := clh.clhPath()
 	if err != nil {
-		return -1, err
+		return err
 	}
 
 	args := []string{cscAPIsocket, clh.state.apiSocket}
@@ -1406,15 +1407,17 @@ func (clh *cloudHypervisor) launchClh() (int, error) {
 
 	err = utils.StartCmd(cmdHypervisor)
 	if err != nil {
-		return -1, err
+		return err
 	}
+
+	clh.state.PID = cmdHypervisor.Process.Pid
 
 	if err := clh.waitVMM(clhTimeout); err != nil {
 		clh.Logger().WithError(err).Warn("cloud-hypervisor init failed")
-		return -1, err
+		return err
 	}
 
-	return cmdHypervisor.Process.Pid, nil
+	return nil
 }
 
 //###########################################################################


### PR DESCRIPTION
The PID needs to be initialized before calling isClhRunning. waitVMM() uses isClhRunning and is called by launchClh() just before returning from function.

Fixes: #9230