### PR TITLE
docs: install: Simplify instructions

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -15,10 +15,21 @@ The recommended way to create a development environment is to first
 to create a working system.
 
 The installation guide instructions will install all required Kata Containers
-components, plus *Docker*, the hypervisor, and the Kata Containers image and
-guest kernel.
+components, plus a container manager, the hypervisor, and the Kata
+Containers image and guest kernel.
+
+Alternatively, you can perform a
+[manual installation](install/container-manager/containerd/containerd-install.md),
+or continue with [the instructions below](#requirements-to-build-individual-components)
+to build the Kata Containers components from source.
 
 # Requirements to build individual components
+
+> **Note:**
+>
+> If you decide to build from sources, you should be aware of the
+> implications of using an unpackaged system which will not be automatically
+> updated as new [releases](Stable-Branch-Strategy.md) are made available.
 
 You need to install the following to build Kata Containers components:
 

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -10,18 +10,19 @@ Containers.
 
 ## Packaged installation methods
 
-Packaged installation methods uses your distribution's native package format (such as RPM or DEB).
+The packaged installation method uses your distribution's native package format (such as RPM or DEB).
 
-> **Note:** We encourage installation methods that provides automatic updates, it ensures security updates and bug fixes are
-> easily applied.
+> **Note:**
+>
+> We encourage you to select an installation method that provides
+> automatic updates, to ensure you get the latest security updates and
+> bug fixes.
 
 | Installation method                                  | Description                                                                                  | Automatic updates | Use case                                                                                      |
 |------------------------------------------------------|----------------------------------------------------------------------------------------------|-------------------|-----------------------------------------------------------------------------------------------|
-| [Using kata-deploy](#kata-deploy-installation)       | The preferred way to deploy the Kata Containers distributed binaries on a Kubernetes cluster | **No!**           | Best way to give it a try on kata-containers on an already up and running Kubernetes cluster. | 
 | [Using official distro packages](#official-packages) | Kata packages provided by Linux distributions official repositories                          | yes               | Recommended for most users.                                                                   |
 | [Automatic](#automatic-installation)                 | Run a single command to install a full system                                                | **No!**           | For those wanting the latest release quickly.                                                 |
-| [Manual](#manual-installation)                       | Follow a guide step-by-step to install a working system                                      | **No!**           | For those who want the latest release with more control.                                      |
-| [Build from source](#build-from-source-installation) | Build the software components manually                                                       | **No!**           | Power users and developers only.                                                              |
+| [Using kata-deploy](#kata-deploy-installation)       | The preferred way to deploy the Kata Containers distributed binaries on a Kubernetes cluster | **No!**           | Best way to give it a try on kata-containers on an already up and running Kubernetes cluster. |
 
 ### Kata Deploy Installation
 
@@ -44,20 +45,6 @@ Kata packages are provided by official distribution repositories for:
 ### Automatic Installation
 
 [Use `kata-manager`](/utils/README.md) to automatically install a working Kata Containers system.
-
-### Manual Installation
-
-Follow the [containerd installation guide](container-manager/containerd/containerd-install.md).
-
-## Build from source installation
-
-> **Note:** Power users who decide to build from sources should be aware of the
-> implications of using an unpackaged system which will not be automatically
-> updated as new [releases](../Stable-Branch-Strategy.md) are made available.
-
-[Building from sources](../Developer-Guide.md#initial-setup)  allows power users
-who are comfortable building software from source to use the latest component
-versions. This is not recommended for normal users.
 
 ## Installing on a Cloud Service Platform
 

--- a/tests/cmd/check-spelling/kata-spell-check.sh
+++ b/tests/cmd/check-spelling/kata-spell-check.sh
@@ -93,7 +93,7 @@ make_dictionary()
 	local dict
 
 	dict=$(cat "$fragment_dir"/*.txt |\
-		grep -v '^\#' |\
+		grep -v '^#' |\
 		grep -v '^$' |\
 		awk '{print $1}' |\
 		sort -u || true)
@@ -255,7 +255,7 @@ spell_check_file()
 	local near_misses
 
 	near_misses=$(echo "$final_results" | grep '^&' || true)
-	incorrects=$(echo "$final_results" | grep '^\#' | awk '{print $2}' || true)
+	incorrects=$(echo "$final_results" | grep '^#' | awk '{print $2}' || true)
 
 	local -i failed=0
 


### PR DESCRIPTION
Move the "build from source" and "manual installation" details to the
developer guide. This makes the installation landing page clearer for
users.

Fixes: #9234.

Also includes a fix for a `grep(1)` warning caused by the unnecessary escaping of the
hash/sharp symbol in the spell-checker.

Fixes: #9235.

Signed-off-by: James O. D. Hunt <james.o.hunt@intel.com>