### PR TITLE
genpolicy: disable env variable verification

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -550,9 +550,10 @@ allow_env(p_process, i_process, s_name) {
     print("allow_env: p env =", p_process.Env)
     print("allow_env: i env =", i_process.Env)
 
-    every i_var in i_process.Env {
-        allow_var(p_process, i_process, i_var, s_name)
-    }
+    # TODO: re-enable after fixing https://github.com/kata-containers/kata-containers/issues/9239.
+    # every i_var in i_process.Env {
+    #    allow_var(p_process, i_process, i_var, s_name)
+    # }
 
     print("allow_env: true")
 }

--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -41,7 +41,7 @@ struct DockerConfigLayer {
 struct DockerImageConfig {
     User: Option<String>,
     Tty: Option<bool>,
-    Env: Vec<String>,
+    Env: Option<Vec<String>>,
     Cmd: Option<Vec<String>>,
     WorkingDir: Option<String>,
     Entrypoint: Option<Vec<String>>,
@@ -159,8 +159,10 @@ impl Container {
             process.Terminal = false;
         }
 
-        for env in &docker_config.Env {
-            process.Env.push(env.clone());
+        if let Some(config_env) = &docker_config.Env {
+            for env in config_env {
+                process.Env.push(env.clone());
+            }
         }
 
         let policy_args = &mut process.Args;


### PR DESCRIPTION
Disable env variable verification to unblock CI, until container images that don't specify the Env variables will be handled correctly (see #9239).

Also, mark the image config Env field as optional, thus allowing policy generation for these container images.

Fixes: #9240