### PR TITLE
genpolicy: default env if image doesn't have env

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -550,10 +550,9 @@ allow_env(p_process, i_process, s_name) {
     print("allow_env: p env =", p_process.Env)
     print("allow_env: i env =", i_process.Env)
 
-    # TODO: re-enable after fixing https://github.com/kata-containers/kata-containers/issues/9239.
-    # every i_var in i_process.Env {
-    #    allow_var(p_process, i_process, i_var, s_name)
-    # }
+    every i_var in i_process.Env {
+        allow_var(p_process, i_process, i_var, s_name)
+    }
 
     print("allow_env: true")
 }

--- a/src/tools/genpolicy/src/containerd.rs
+++ b/src/tools/genpolicy/src/containerd.rs
@@ -161,3 +161,10 @@ pub fn get_linux(privileged_container: bool) -> policy::KataLinux {
         }
     }
 }
+
+pub fn get_default_unix_env(env: &mut Vec<String>) {
+    assert!(env.is_empty());
+
+    // Return the value of defaultUnixEnv from containerd.
+    env.push("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin".to_string());
+}

--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -6,6 +6,7 @@
 // Allow Docker image config field names.
 #![allow(non_snake_case)]
 
+use crate::containerd;
 use crate::policy;
 use crate::verity;
 
@@ -159,10 +160,13 @@ impl Container {
             process.Terminal = false;
         }
 
+        assert!(process.Env.is_empty());
         if let Some(config_env) = &docker_config.Env {
             for env in config_env {
                 process.Env.push(env.clone());
             }
+        } else {
+            containerd::get_default_unix_env(&mut process.Env);
         }
 
         let policy_args = &mut process.Args;


### PR DESCRIPTION
Use containerd's default environment for container images that don't specify the Env field.

Also, re-enable policy env variable verification, now that these uncommon images are supported too.

Fixes: #9239