### PR TITLE
gha: ensure that the self hosted runner is in desired state before running the workflow 

### DIFF
--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -39,6 +39,12 @@ jobs:
       - name: Adjust a permission for repo
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+      
+      - name: Prepare the self-hosted runner
+        run: |
+            ${HOME}/scripts/prepare_runner.sh
+            sudo rm -rf $GITHUB_WORKSPACE/*
+
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -52,9 +58,6 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
-      
-      - name: Prepare the self-hosted runner
-        run: ${HOME}/scripts/prepare_runner.sh
 
       - name: Rebase atop of the latest target branch
         run: |

--- a/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
@@ -26,6 +26,11 @@ jobs:
   kata-payload:
     runs-on: ppc64le
     steps:
+      - name: Prepare the self-hosted runner
+        run: |
+          ${HOME}/scripts/prepare_runner.sh
+          sudo rm -rf $GITHUB_WORKSPACE/*
+
       - name: Adjust a permission for repo
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -19,6 +19,11 @@ jobs:
     needs: build-kata-static-tarball-ppc64le
     runs-on: ppc64le
     steps:
+      - name: Prepare the self-hosted runner
+        run: |
+          bash ${HOME}/scripts/prepare_runner.sh
+          sudo rm -rf $GITHUB_WORKSPACE/*
+
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v2
         with:

--- a/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
+++ b/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
@@ -31,6 +31,11 @@ jobs:
     steps:
       - name: Adjust a permission for repo
         run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
+  
+      - name: Prepare the self-hosted runner
+        run: |
+          bash ${HOME}/scripts/prepare_runner.sh cri-containerd
+          sudo rm -rf $GITHUB_WORKSPACE/*
 
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/run-k8s-tests-on-ppc64le.yaml
+++ b/.github/workflows/run-k8s-tests-on-ppc64le.yaml
@@ -45,7 +45,7 @@ jobs:
     steps:
       - name: Prepare the self-hosted runner
         run: | 
-          bash ${HOME}/scripts/prepare_runner.sh
+          bash ${HOME}/scripts/prepare_runner.sh kubernetes
           sudo rm -rf $GITHUB_WORKSPACE/*
 
       - uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds a step to ensure that containerd is up and running before building the payload image on Power.

Fixes: #9262