### PR TITLE
kata-agent: optional bind flag

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -218,6 +218,17 @@ pub fn init_rootfs(
             ));
         }
 
+        // From https://github.com/opencontainers/runtime-spec/blob/main/config.md#mounts
+        // type (string, OPTIONAL) The type of the filesystem to be mounted.
+        // bind may be only specified in the oci spec options -> flags update r#type
+        let m = &{
+            let mut mbind = m.clone();
+            if mbind.r#type.is_empty() && flags & MsFlags::MS_BIND == MsFlags::MS_BIND {
+                mbind.r#type = "bind".to_string();
+            }
+            mbind
+        };
+
         if m.r#type == "cgroup" {
             mount_cgroups(cfd_log, m, rootfs, flags, &data, cpath, mounts)?;
         } else {


### PR DESCRIPTION
Fixes: #9269

From https://github.com/opencontainers/runtime-spec/blob/main/config.md#mounts type (string, OPTIONAL) The type of the filesystem to be mounted. bind may be only specified in the oci spec options -> flags update r#type The agent will ignore bind mounts if they are only specified in the OCI spec options and not in the flags.