### PR TITLE
kata-agent: Change order of guest hook and bind mount processing

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1159,15 +1159,6 @@ impl agent_ttrpc::AgentService for AgentService {
             s.hostname = req.hostname.clone();
             s.running = true;
 
-            if !req.guest_hook_path.is_empty() {
-                let _ = s.add_hooks(&req.guest_hook_path).map_err(|e| {
-                    error!(
-                        sl(),
-                        "add guest hook {} failed: {:?}", req.guest_hook_path, e
-                    );
-                });
-            }
-
             if !req.sandbox_id.is_empty() {
                 s.id = req.sandbox_id.clone();
             }
@@ -1179,10 +1170,24 @@ impl agent_ttrpc::AgentService for AgentService {
             s.setup_shared_namespaces().await.map_ttrpc_err(same)?;
         }
 
-        let m = add_storages(sl(), req.storages, &self.sandbox, None)
+        let m = add_storages(sl(), req.storages.clone(), &self.sandbox, None)
             .await
             .map_ttrpc_err(same)?;
         self.sandbox.lock().await.mounts = m;
+
+        // Scan guest hooks upon creating new sandbox and append
+        // them to guest OCI spec before running containers.
+        {
+            let mut s = self.sandbox.lock().await;
+            if !req.guest_hook_path.is_empty() {
+                let _ = s.add_hooks(&req.guest_hook_path).map_err(|e| {
+                    error!(
+                        sl(),
+                        "add guest hook {} failed: {:?}", req.guest_hook_path, e
+                    );
+                });
+            }
+        }
 
         setup_guest_dns(sl(), &req.dns).map_ttrpc_err(same)?;
         {


### PR DESCRIPTION
The guest_hook_path item in configuration.toml allows OCI hook scripts to be executed within Kata's guest environment. Traditionally, these guest hook programs are pre-built and included in Kata's guest rootfs image at a fixed location.

While setting guest_hook_path = "/usr/share/oci/hooks" in configuration.toml works, it lacks flexibility. Not all guest hooks reside in the path /usr/share/oci/hooks, and users might have custom locations.

To address this, a more flexible and configurable approach is to be proposed that allows users to specify their desired path. This could include using a sandbox bind mount path for hooks specific to that particular container.

However, The current implementation of guest hooks and bind mounts in kata-agent has a reversed order of execution compared to the desired behavior. To achieve the intended functionality, we simply need to swap the order of their implementation.

Fixes: #9274