### PR TITLE
kata-deploy: Fix for merge-builds Makefile target

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -14,7 +14,7 @@ kata_build_dir=${1:-build}
 kata_versions_yaml_file=${2:-""}
 
 tar_path="${PWD}/kata-static.tar.xz"
-kata_versions_yaml_file_path="${PWD}/${kata_versions_yaml_file}"
+kata_versions_yaml_file_path=$(realpath "${kata_versions_yaml_file}")
 
 pushd "${kata_build_dir}"
 tarball_content_dir="${PWD}/kata-tarball-content"


### PR DESCRIPTION
Makefile sends the path to versions.yaml as an absolute path. Adding ${PWD} as prefix breaks the build. I switched to realpath instead, it works for both absolute (Makefile) and relative (GitHub Actions) paths.

Fixes: #9276