### PR TITLE
tests: fix nounset error with $GITHUB_ENV

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -213,7 +213,7 @@ function run_tests() {
 	# In case of running on Github workflow it needs to save the start time
 	# on the environment variables file so that the variable is exported on
 	# next workflow steps.
-	if [ -n "$GITHUB_ENV" ]; then
+	if [ -n "${GITHUB_ENV:-}" ]; then
 		start_time=$(date '+%Y-%m-%d %H:%M:%S')
 		export start_time
 		echo "start_time=${start_time}" >> "$GITHUB_ENV"

--- a/tests/integration/nerdctl/gha-run.sh
+++ b/tests/integration/nerdctl/gha-run.sh
@@ -95,7 +95,7 @@ function run() {
 
 	enabling_hypervisor
 
-	if [ -n "$GITHUB_ENV" ]; then
+	if [ -n "${GITHUB_ENV:-}" ]; then
 		start_time=$(date '+%Y-%m-%d %H:%M:%S')
 		export start_time
 		echo "start_time=${start_time}" >> "$GITHUB_ENV"


### PR DESCRIPTION
Initialize $GITHUB_ENV to avoid nounset error when running the scripts locally out of Github Actions.

Fixed commit 9ba5e3d2a8aeab8d1d868a1b6f8f1b2836cbfd0a

Fixes #9217
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>