### PR TITLE
agent: Show features enabled at build time

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -1357,6 +1357,7 @@ dependencies = [
  "chrono",
  "common-path",
  "fail",
+ "hex",
  "kata-types",
  "lazy_static",
  "libc",

--- a/src/agent/src/features.rs
+++ b/src/agent/src/features.rs
@@ -1,0 +1,22 @@
+// Copyright (c) 2024 Intel Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+// Returns a sorted list of optional features enabled at agent build time.
+pub fn get_build_features() -> Vec<String> {
+    let features: Vec<&str> = vec![
+        #[cfg(feature = "agent-policy")]
+        "agent-policy",
+        #[cfg(feature = "seccomp")]
+        "seccomp",
+        #[cfg(feature = "standard-oci-runtime")]
+        "standard-oci-runtime",
+    ];
+
+    let mut sorted: Vec<String> = features.into_iter().map(String::from).collect();
+
+    sorted.sort();
+
+    sorted
+}

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -38,6 +38,7 @@ use tracing::{instrument, span};
 mod config;
 mod console;
 mod device;
+mod features;
 mod linux_abi;
 mod metrics;
 mod mount;
@@ -121,11 +122,14 @@ enum SubCommand {
 
 #[instrument]
 fn announce(logger: &Logger, config: &AgentConfig) {
+    let extra_features = features::get_build_features();
+
     info!(logger, "announce";
     "agent-commit" => version::VERSION_COMMIT,
     "agent-version" =>  version::AGENT_VERSION,
     "api-version" => version::API_VERSION,
     "config" => format!("{:?}", config),
+    "extra-features" => format!("{extra_features:?}"),
     );
 }
 
@@ -293,8 +297,10 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let args = AgentOpts::parse();
 
     if args.version {
+        let extra_features = features::get_build_features();
+
         println!(
-            "{} version {} (api version: {}, commit version: {}, type: rust)",
+            "{} version {} (api version: {}, commit version: {}, type: rust, extra-features: {extra_features:?})",
             NAME,
             version::AGENT_VERSION,
             version::API_VERSION,

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -53,6 +53,7 @@ use nix::unistd::{self, Pid};
 use rustjail::process::ProcessOperations;
 
 use crate::device::{add_devices, get_virtio_blk_pci_device_name, update_env_pci};
+use crate::features::get_build_features;
 use crate::linux_abi::*;
 use crate::metrics::get_metrics;
 use crate::mount::baremount;
@@ -1563,6 +1564,7 @@ fn get_agent_details() -> AgentDetails {
 
     detail.device_handlers = Vec::new();
     detail.storage_handlers = STORAGE_HANDLERS.get_handlers();
+    detail.extra_features = get_build_features();
 
     detail
 }

--- a/src/libs/protocols/protos/agent.proto
+++ b/src/libs/protocols/protos/agent.proto
@@ -417,6 +417,9 @@ message AgentDetails {
 	// Set only if the agent is built with seccomp support and the guest
 	// environment supports seccomp.
 	bool supports_seccomp = 5;
+
+	// List of additional features enabled at agent build time.
+	repeated string extra_features = 6;
 }
 
 message GuestDetailsRequest {

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -3690,6 +3690,7 @@ dependencies = [
  "hyperlocal",
  "kata-sys-util",
  "kata-types",
+ "nix 0.24.3",
  "tokio",
 ]
 

--- a/src/runtime-rs/crates/agent/src/kata/trans.rs
+++ b/src/runtime-rs/crates/agent/src/kata/trans.rs
@@ -747,6 +747,7 @@ impl From<agent::AgentDetails> for AgentDetails {
             device_handlers: trans_vec(src.device_handlers),
             storage_handlers: trans_vec(src.storage_handlers),
             supports_seccomp: src.supports_seccomp,
+            extra_features: trans_vec(src.extra_features),
         }
     }
 }

--- a/src/runtime-rs/crates/agent/src/types.rs
+++ b/src/runtime-rs/crates/agent/src/types.rs
@@ -527,6 +527,7 @@ pub struct AgentDetails {
     pub device_handlers: Vec<String>,
     pub storage_handlers: Vec<std::string::String>,
     pub supports_seccomp: bool,
+    pub extra_features: Vec<std::string::String>,
 }
 
 #[derive(PartialEq, Clone, Default)]


### PR DESCRIPTION
The agent now has a number of optional build-time features that can be enabled.

Add details of these features to the following areas:

- Version output (`kata-agent --version`)
- Announce message (so that the details are always added to the journal at agent startup).
- The response message returned by the ttRPC `GetGuestDetails()` API.

Fixes: #9285.