### PR TITLE
Add option to manually set the number of queues for tap devices

### DIFF
--- a/docs/how-to/how-to-set-sandbox-config-kata.md
+++ b/docs/how-to/how-to-set-sandbox-config-kata.md
@@ -93,6 +93,7 @@ There are several kinds of Kata configurations and they are listed below.
 | `io.katacontainers.config.hypervisor.virtio_fs_extra_args` | string | extra options passed to `virtiofs` daemon |
 | `io.katacontainers.config.hypervisor.enable_guest_swap` | `boolean` | enable swap in the guest |
 | `io.katacontainers.config.hypervisor.use_legacy_serial` | `boolean` | uses legacy serial device for guest's console (QEMU) |
+| `io.katacontainers.config.hypervisor.network_queues` | uint32 | the default number of queues for the VM tap device |
 
 ## Container Options
 | Key | Value Type | Comments |

--- a/src/agent/src/random.rs
+++ b/src/agent/src/random.rs
@@ -10,6 +10,7 @@ use nix::sys::stat::Mode;
 use std::fs;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use tracing::instrument;
+use crate::util::IoctlRequestType;
 
 pub const RNGDEV: &str = "/dev/random";
 #[cfg(target_arch = "powerpc64")]
@@ -20,12 +21,6 @@ pub const RNDRESEEDCRNG: libc::c_int = 0x20005207;
 pub const RNDADDTOENTCNT: libc::c_int = 0x40045201;
 #[cfg(not(target_arch = "powerpc64"))]
 pub const RNDRESEEDCRNG: libc::c_int = 0x5207;
-
-// Handle the differing ioctl(2) request types for different targets
-#[cfg(target_env = "musl")]
-type IoctlRequestType = libc::c_int;
-#[cfg(target_env = "gnu")]
-type IoctlRequestType = libc::c_ulong;
 
 #[instrument]
 pub fn reseed_rng(data: &[u8]) -> Result<()> {

--- a/src/agent/src/util.rs
+++ b/src/agent/src/util.rs
@@ -13,6 +13,12 @@ use tokio::sync::watch::Receiver;
 use tokio_vsock::{Incoming, VsockListener, VsockStream};
 use tracing::instrument;
 
+// Handle the differing ioctl(2) request types for different targets
+#[cfg(target_env = "musl")]
+pub type IoctlRequestType = libc::c_int;
+#[cfg(target_env = "gnu")]
+pub type IoctlRequestType = libc::c_ulong;
+
 // Size of I/O read buffer
 const BUF_SIZE: usize = 8192;
 

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -467,6 +467,14 @@ disable_selinux=@DEFDISABLESELINUX@
 # (default: true)
 disable_guest_selinux=@DEFDISABLEGUESTSELINUX@
 
+# Default number of queues for the tap device.
+#  <= 0 will be set to the same value as default_vcpus
+#  > 0 will be set to the value
+#  > defaultMaxVCPUs will be set to default_vcpus
+#  Leaving it at default should yield the best performance in a multi-stream scenario.
+#  If your application is single-stream it's better to set it at 1.
+network_queues = 0
+
 
 [factory]
 # VM templating support. Once enabled, new VMs are created from template

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -432,6 +432,14 @@ disable_selinux=@DEFDISABLESELINUX@
 # (default: true)
 disable_guest_selinux=@DEFDISABLEGUESTSELINUX@
 
+# Default number of queues for the tap device.
+#  <= 0 will be set to the same value as default_vcpus
+#  > 0 will be set to the value
+#  > defaultMaxVCPUs will be set to default_vcpus
+#  Leaving it at default should yield the best performance in a multi-stream scenario.
+#  If your application is single-stream it's better to set it at 1.
+network_queues = 0
+
 
 [factory]
 # VM templating support. Once enabled, new VMs are created from template

--- a/src/runtime/config/configuration-qemu-sev.toml.in
+++ b/src/runtime/config/configuration-qemu-sev.toml.in
@@ -416,6 +416,15 @@ disable_selinux=@DEFDISABLESELINUX@
 # (default: true)
 disable_guest_selinux=@DEFDISABLEGUESTSELINUX@
 
+# Default number of queues for the tap device.
+#  <= 0 will be set to the same value as default_vcpus
+#  > 0 will be set to the value
+#  > defaultMaxVCPUs will be set to default_vcpus
+#  Leaving it at default should yield the best performance in a multi-stream scenario.
+#  If your application is single-stream it's better to set it at 1.
+network_queues = 0
+
+
 [factory]
 # VM templating support. Once enabled, new VMs are created from template
 # using vm cloning. They will share the same initial kernel, initramfs and

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -450,6 +450,14 @@ disable_selinux=@DEFDISABLESELINUX@
 # (default: true)
 disable_guest_selinux=@DEFDISABLEGUESTSELINUX@
 
+# Default number of queues for the tap device.
+#  <= 0 will be set to the same value as default_vcpus
+#  > 0 will be set to the value
+#  > defaultMaxVCPUs will be set to default_vcpus
+#  Leaving it at default should yield the best performance in a multi-stream scenario.
+#  If your application is single-stream it's better to set it at 1.
+network_queues = 0
+
 
 [factory]
 # VM templating support. Once enabled, new VMs are created from template

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -446,6 +446,14 @@ disable_selinux=@DEFDISABLESELINUX@
 # (default: true)
 disable_guest_selinux=@DEFDISABLEGUESTSELINUX@
 
+# Default number of queues for the tap device.
+#  <= 0 will be set to the same value as default_vcpus
+#  > 0 will be set to the value
+#  > defaultMaxVCPUs will be set to default_vcpus
+#  Leaving it at default should yield the best performance in a multi-stream scenario.
+#  If your application is single-stream it's better to set it at 1.
+network_queues = 0
+
 
 [factory]
 # VM templating support. Once enabled, new VMs are created from template

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -479,6 +479,14 @@ disable_selinux=@DEFDISABLESELINUX@
 # (default: true)
 disable_guest_selinux=@DEFDISABLEGUESTSELINUX@
 
+# Default number of queues for the tap device.
+#  <= 0 will be set to the same value as default_vcpus
+#  > 0 will be set to the value
+#  > defaultMaxVCPUs will be set to default_vcpus
+#  Leaving it at default should yield the best performance in a multi-stream scenario.
+#  If your application is single-stream it's better to set it at 1.
+network_queues = 0
+
 
 [factory]
 # VM templating support. Once enabled, new VMs are created from template

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -166,6 +166,7 @@ type hypervisor struct {
 	DisableGuestSeLinux            bool                      `toml:"disable_guest_selinux"`
 	LegacySerial                   bool                      `toml:"use_legacy_serial"`
 	ExtraMonitorSocket             govmmQemu.MonitorProtocol `toml:"extra_monitor_socket"`
+	NetworkQueues                  uint32                    `toml:"network_queues"`
 }
 
 type runtime struct {
@@ -664,6 +665,19 @@ func (h hypervisor) getRemoteHypervisorTimeout() uint32 {
 	return h.RemoteHypervisorTimeout
 }
 
+func (h hypervisor) getNetworkQueues() uint32 {
+	var queues uint32
+
+	queues = h.NetworkQueues
+	if queues <= 0 {
+		queues = uint32(h.defaultVCPUs())
+	} else if queues > h.defaultMaxVCPUs() {
+		queues = uint32(h.defaultMaxVCPUs())
+	}
+
+	return queues
+}
+
 func (a agent) debugConsoleEnabled() bool {
 	return a.DebugConsoleEnabled
 }
@@ -930,6 +944,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		DisableSeLinux:          h.DisableSeLinux,
 		DisableGuestSeLinux:     h.DisableGuestSeLinux,
 		ExtraMonitorSocket:      extraMonitorSocket,
+		NetworkQueues:           h.getNetworkQueues(),
 	}, nil
 }
 

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -845,6 +845,14 @@ func addHypervisorNetworkOverrides(ocispec specs.Spec, sbConfig *vc.SandboxConfi
 		return err
 	}
 
+	if err := newAnnotationConfiguration(ocispec, vcAnnotations.NetworkQueues).setUint(func(NetworkQueues uint64) {
+		if NetworkQueues > 0 {
+			sbConfig.HypervisorConfig.NetworkQueues = uint32(NetworkQueues)
+		}
+	}); err != nil {
+		return err
+	}
+
 	return newAnnotationConfiguration(ocispec, vcAnnotations.TxRateLimiterMaxRate).setUint(func(txRateLimiterMaxRate uint64) {
 		sbConfig.HypervisorConfig.TxRateLimiterMaxRate = txRateLimiterMaxRate
 	})

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -574,6 +574,9 @@ type HypervisorConfig struct {
 	// Size of virtqueues
 	VirtioFSQueueSize uint32
 
+	// Numbmer of queues for the tap interface
+	NetworkQueues uint32
+
 	// User ID.
 	Uid uint32
 

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -597,7 +597,7 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) err
 	queues := 0
 	caps := h.Capabilities(ctx)
 	if caps.IsMultiQueueSupported() {
-		queues = int(h.HypervisorConfig().NumVCPUs())
+		queues = int(h.HypervisorConfig().NetworkQueues)
 	}
 
 	disableVhostNet := h.HypervisorConfig().DisableVhostNet

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -142,7 +142,7 @@ const (
 	// DefaultVCPUs is a sandbox annotation for passing the default vcpus assigned for a VM by the hypervisor.
 	DefaultVCPUs = kataAnnotHypervisorPrefix + "default_vcpus"
 
-	// DefaultVCPUs is a sandbox annotation that specifies the maximum number of vCPUs allocated for the VM by the hypervisor.
+	// DefaultMaxVCPUs is a sandbox annotation that specifies the maximum number of vCPUs allocated for the VM by the hypervisor.
 	DefaultMaxVCPUs = kataAnnotHypervisorPrefix + "default_max_vcpus"
 
 	//

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -237,6 +237,9 @@ const (
 
 	// EnableRootlessHypervisor is a sandbox annotation to enable rootless hypervisor (only supported in QEMU currently).
 	EnableRootlessHypervisor = kataAnnotHypervisorPrefix + "rootless"
+
+	// NetworkQueues is a sandbox annotation for passing the default number of queues assigned for the tap interface by the hypervisor.
+	NetworkQueues = kataAnnotHypervisorPrefix + "network_queues"
 )
 
 // Runtime related annotations


### PR DESCRIPTION
As described in issue #9290 , it's useful sometimes to set the number of queues of a tap device to a specific values. This patchset allows doing that.

Patch 1-2 are changes in the agent, ensuring that the software fully utilized all the queues available on interface link update.

Patch 3-4 are changes in the runtime, allowing to set the number of queues via toml file or annotation

Patch 5 is a typo fix that I discovered while adding this feature.

I briefly talked to @fidencio about this in one of the Confidential Computers Community meetings.