### PR TITLE
kata-manager: Fix Docker install

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -906,8 +906,6 @@ handle_docker()
 		[ -e "$containerd_config" ] && sudo mv $containerd_config $containerd_config.system-$(date -Iseconds)
 	fi
 
-	containerd_installed
-
 	local filename='get-docker.sh'
 
 	local file


### PR DESCRIPTION
Fix the Docker install by removing the second (erroneous) call to `containerd_installed()` in `handle_docker()`.

Without this fix, installing using Docker (`-D`) will work *iff* you already have containerd installed. However, if you do not have containerd installed, the `containerd_installed()` function returns 1, which exits the script as we're running with `set -e`, leaving a broken Docker installation.

> **Note:** containerd is installed via Docker's `get-docker.sh` script.

Fixes: #9292.