### PR TITLE
genpolicy: support insecure registries and custom pause containers

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -272,7 +272,8 @@
         "confidential_guest": false
     },
     "cluster_config": {
-        "default_namespace": "default"
+        "default_namespace": "default",
+        "pause_container_image": "mcr.microsoft.com/oss/kubernetes/pause:3.6"
     },
     "request_defaults": {
         "CreateContainerRequest": {

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -834,9 +834,7 @@ fn compress_capabilities(capabilities: &mut Vec<String>, defaults: &policy::Comm
 pub async fn add_pause_container(containers: &mut Vec<Container>, config: &Config) {
     debug!("Adding pause container...");
     let mut pause_container = Container {
-        // TODO: load this path from the settings file.
-        image: "mcr.microsoft.com/oss/kubernetes/pause:3.6".to_string(),
-
+        image: config.settings.cluster_config.pause_container_image.clone(),
         name: String::new(),
         imagePullPolicy: None,
         securityContext: Some(SecurityContext {

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -362,6 +362,9 @@ pub struct CommonData {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClusterConfig {
     default_namespace: String,
+
+    /// Pause container image reference.
+    pub pause_container_image: String,
 }
 
 impl AgentPolicy {

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -14,7 +14,7 @@ use std::fs::File;
 use std::str;
 
 /// Policy settings loaded from genpolicy-settings.json.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Settings {
     pub pause_container: policy::KataSpec,
     pub other_container: policy::KataSpec,

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::settings;
 use clap::Parser;
 
 #[derive(Debug, Parser)]
@@ -84,7 +85,7 @@ pub struct Config {
 
     pub yaml_file: Option<String>,
     pub rego_rules_path: String,
-    pub json_settings_path: String,
+    pub settings: settings::Settings,
     pub config_map_files: Option<Vec<String>>,
 
     pub silent_unsupported_fields: bool,
@@ -108,11 +109,13 @@ impl Config {
             None
         };
 
+        let settings = settings::Settings::new(&args.json_settings_path);
+
         Self {
             use_cache: args.use_cached_files,
             yaml_file: args.yaml_file,
             rego_rules_path: args.rego_rules_path,
-            json_settings_path: args.json_settings_path,
+            settings,
             config_map_files: cm_files,
             silent_unsupported_fields: args.silent_unsupported_fields,
             raw_out: args.raw_out,

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -76,12 +76,19 @@ struct CommandLineOptions {
         require_equals= true
     )]
     containerd_socket_path: Option<String>,
+
+    #[clap(
+        long,
+        help = "Registry that uses plain HTTP. Can be passed more than once to configure multiple insecure registries."
+    )]
+    insecure_registry: Vec<String>,
 }
 
 /// Application configuration, derived from on command line parameters.
 #[derive(Clone, Debug)]
 pub struct Config {
     pub use_cache: bool,
+    pub insecure_registries: Vec<String>,
 
     pub yaml_file: Option<String>,
     pub rego_rules_path: String,
@@ -113,6 +120,7 @@ impl Config {
 
         Self {
             use_cache: args.use_cached_files,
+            insecure_registries: args.insecure_registry,
             yaml_file: args.yaml_file,
             rego_rules_path: args.rego_rules_path,
             settings,


### PR DESCRIPTION
This PR adds support for a few registry options that allow running genpolicy in hermetic environments (e.g. build systems). Instead of adding more arguments to the individual function calls, I decided to pass around an options struct that holds the currently required options: `use_cache`, `pause_container_image` and `insecure_registries`. 

I think the right place to obtain the pause container image from is the settings file, because this is where other implementation details of the CRI currently live (such as default env vars, capabilities, etc.). The `cluster_config` section seemed like a good idea, but I'm open to alternatives. Although there already is a `pause_container` section, that one is parsed as a `KataSpec`, where putting an image reference does not make sense. 

Insecure registries are something specific to the environment where genpolicy  is run, not the container runtime environment. Since the settings file deals with settings for the latter, I decided not to put them there but rather make them arguments to the CLI.

Fixes: #9008 