### PR TITLE
runtime-rs: ch: Provide valid default value for NetConfig

### DIFF
--- a/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
@@ -267,8 +267,8 @@ impl Default for NetConfig {
     fn default() -> Self {
         NetConfig {
             tap: None,
-            ip: Ipv4Addr::new(0, 0, 0, 0),
-            mask: Ipv4Addr::new(0, 0, 0, 0),
+            ip: Ipv4Addr::new(192, 168, 249, 1),
+            mask: Ipv4Addr::new(255, 255, 255, 0),
             mac: MacAddr::default(),
             host_mac: None,
             mtu: None,


### PR DESCRIPTION
The current default value of IP `0.0.0.0` with mask `0.0.0.0` will cause ioctl error when being used to create and configure TAP device, with newer version of Cloud Hypervisor [1]. This patch replaces them with valid value that are the same as the Go-lang runtime [2].

[1] https://github.com/cloud-hypervisor/cloud-hypervisor/pull/5924
[2] https://github.com/kata-containers/kata-containers/blob/e3f78527388a22d0c1a4cfea66fe5c43ec041fea/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go#L40-L57

Fixes: #9254