### PR TITLE
ci: aks: also run tests in normal instance for Mariner

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -44,6 +44,10 @@ jobs:
         include:
           - host_os: cbl-mariner
             vmm: clh
+            instance-type: small
+          - host_os: cbl-mariner
+            vmm: clh
+            instance-type: normal
     runs-on: ubuntu-latest
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}


### PR DESCRIPTION
Currently we're only running the small instance tests. This adds the normal instance tests as well.

Fixes: #9298