### PR TITLE
gha: Place pre-action on s390x runner for kata-deploy during release

### DIFF
--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -17,6 +17,9 @@ jobs:
     needs: build-kata-static-tarball-s390x
     runs-on: s390x
     steps:
+      - name: Take a pre-action for self-hosted runner
+        run: ${HOME}/script/pre_action.sh ubuntu-2204
+
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
This is to place a pre-action step for the kata-deploy job in order to clean up the github workspace directory before checking out the repo.

Fixes: #9301

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>