### PR TITLE
runtime: logging with file names instead of pointers

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -24,6 +24,8 @@ import (
 	"strconv"
 	"strings"
 	"syscall"
+
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/utils"
 )
 
 // Machine describes the machine type qemu will emulate.
@@ -3216,7 +3218,7 @@ func LaunchCustomQemu(ctx context.Context, path string, params []string, fds []*
 	/* #nosec */
 	cmd := exec.CommandContext(ctx, path, params...)
 	if len(fds) > 0 {
-		logger.Infof("Adding extra file %v", fds)
+		logger.Infof("Adding extra files %v", utils.ExpandFdsNames(fds))
 		cmd.ExtraFiles = fds
 	}
 

--- a/src/runtime/pkg/utils/utils.go
+++ b/src/runtime/pkg/utils/utils.go
@@ -155,3 +155,12 @@ func RemoveVmmUser(user string) error {
 	}
 	return err
 }
+
+// Expands fds to it's names for logging
+func ExpandFdsNames(fds []*os.File) []string {
+	names := make([]string, len(fds))
+	for i, fd := range fds {
+		names[i] = fd.Name()
+	}
+	return names
+}

--- a/src/runtime/virtcontainers/stratovirt.go
+++ b/src/runtime/virtcontainers/stratovirt.go
@@ -26,6 +26,7 @@ import (
 	govmmQemu "github.com/kata-containers/kata-containers/src/runtime/pkg/govmm/qemu"
 	hv "github.com/kata-containers/kata-containers/src/runtime/pkg/hypervisors"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils/katatrace"
+	pkgUtils "github.com/kata-containers/kata-containers/src/runtime/pkg/utils"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/uuid"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
@@ -981,7 +982,7 @@ func launchStratovirt(ctx context.Context, s *stratovirt) (*exec.Cmd, io.ReadClo
 	cmd := exec.CommandContext(ctx, s.path, params...)
 
 	if len(s.fds) > 0 {
-		s.Logger().Infof("Adding extra file %v", s.fds)
+		s.Logger().Infof("Adding extra files %v", pkgUtils.ExpandFdsNames(s.fds))
 		cmd.ExtraFiles = s.fds
 	}
 


### PR DESCRIPTION
Loging with pointers make no sense to users.
Because `String()` method is not implemented in `os.File`. So expand `fds` to name list

Logging output(before),
`"Adding extra file [0xc000128f58 0xc000128d40]"`

Logging output(now),
`"Adding extra files [unix:/run/vc/vm/bash1/qmp.sock-> /dev/vhost-vsock]"`

Fixes: #9333
