### PR TITLE
CI|k8s: Handle skipped tests with a comment for filter_out_per_arch

### DIFF
--- a/tests/integration/kubernetes/filter_k8s_test.sh
+++ b/tests/integration/kubernetes/filter_k8s_test.sh
@@ -35,7 +35,19 @@ main()
 		local flag="false"
 		for SKIP_ENTRY in "${_K8S_SKIP_UNION[@]}"
 		do
-			SKIP_ENTRY="${SKIP_ENTRY#- }.bats"
+			# Remove '- ' from the beginning of the string
+			# Example: "- test.bats" -> "test.bats"
+			SKIP_ENTRY="${SKIP_ENTRY#- }"
+			# Remove a comment if it exists
+			# Example: "test.bats # comment" -> "test.bats "
+			SKIP_ENTRY="${SKIP_ENTRY%#*}"
+			# Strip trailing spaces if it exists
+			# Example: "test.bats " -> "test.bats"
+			# Explanation for parameter expansion:
+			# A="${SKIP_ENTRY##*[![:space:]]}" - get spaces after the last non-space character
+			# SKIP_ENTRY="${SKIP_ENTRY%"${A}"}" - remove the spaces from the string
+			SKIP_ENTRY="${SKIP_ENTRY%"${SKIP_ENTRY##*[![:space:]]}"}"
+			SKIP_ENTRY="${SKIP_ENTRY}.bats"
 			[ "$SKIP_ENTRY" == "$TEST_ENTRY" ] && flag="true"
 		done
 		[ "$flag" == "false" ] && result+=("$TEST_ENTRY")


### PR DESCRIPTION
This commit updates `filter_k8s_test.sh` to handle skipped tests that include comments. In addition to the existing parameter expansion, the following expansions have been added:

- Removal of a comment
- Stripping of trailing spaces

Fixes: #9304

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>