### PR TITLE
gha: Update journal log names for kubernetes artifacts

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -291,7 +291,7 @@ function collect_artifacts() {
 	fi
 	mkdir -p "${artifacts_dir}"
 	info "Collecting artifacts using ${KATA_HYPERVISOR} hypervisor"
-	local journalctl_log_filename="journalctl.log"
+	local journalctl_log_filename="journalctl-$RANDOM.log"
 	local journalctl_log_path="${artifacts_dir}/${journalctl_log_filename}"
 	sudo journalctl --since="$start_time" > "${journalctl_log_path}"
 


### PR DESCRIPTION
This PR updates the journal log names for kubernetes artifacts in order to make sure that we have different names when we are running parallel GHA jobs.

Fixes #9308