### PR TITLE
Dragonballl: introduce MTRR regs support

### DIFF
--- a/src/dragonball/src/dbs_arch/src/x86_64/regs.rs
+++ b/src/dragonball/src/dbs_arch/src/x86_64/regs.rs
@@ -31,6 +31,11 @@ pub const X86_CR0_PG: u64 = 0x8000_0000;
 /// Physical Address Extension bit in CR4.
 pub const X86_CR4_PAE: u64 = 0x20;
 
+// MTRR constants.
+const MTRR_ENABLED: u64 = 0x0800; // IA32_MTRR_DEF_TYPE MSR: E (MTRRs enabled) flag, bit 11
+const MTRR_FIXED_RANGE_ENABLE: u64 = 0x0400;
+const MTRR_MEM_TYPE_WB: u64 = 0x6;
+
 /// Errors thrown while setting up x86_64 registers.
 #[derive(Debug)]
 pub enum Error {
@@ -213,6 +218,11 @@ fn create_msr_entries() -> Vec<kvm_msr_entry> {
     entries.push(kvm_msr_entry {
         index: msr::MSR_IA32_SYSENTER_EIP,
         data: 0x0,
+        ..Default::default()
+    });
+    entries.push(kvm_msr_entry {
+        index: msr::MSR_MTRRdefType,
+        data: MTRR_ENABLED | MTRR_FIXED_RANGE_ENABLE | MTRR_MEM_TYPE_WB,
         ..Default::default()
     });
     // x86_64 specific msrs, we only run on x86_64 not x86.


### PR DESCRIPTION
MTRR, or Memory-Type Range Registers are a group of x86 MSRs providing a way to control acces s and cacheability of physical memory regions.
During our test in runtime-rs + Dragonball, we found out that this register support is a must for passthrough GPU running CUDA application, GPU needs that information to properly use GPU memory.

fixes: #9310