### PR TITLE
release: Skip --generate-notes for this release

### DIFF
--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -114,7 +114,7 @@ function _create_new_release()
 	_create_our_own_notes
 
 	gh release create ${RELEASE_VERSION} \
-		--generate-notes --title "Kata Containers ${RELEASE_VERSION}" \
+		--title "Kata Containers ${RELEASE_VERSION}" \
 		--notes-file "/tmp/our_notes_${RELEASE_VERSION}"
 }
 


### PR DESCRIPTION
This release is a special case, as we've slacked for 6 months and the release content is way too long ... long enough to exceed the allowed limit for the release notes.

With this in mind we'll just remove the `--generate-notes` for now, and then revert this commit as soon as the release is out, as releases should be happening every month and, ideally, we won't reach this situation never ever again.

Fixes: #9064 - part V