### PR TITLE
Revert "release: Skip --generate-notes for this release"

### DIFF
--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -114,7 +114,7 @@ function _create_new_release()
 	_create_our_own_notes
 
 	gh release create ${RELEASE_VERSION} \
-		--title "Kata Containers ${RELEASE_VERSION}" \
+		--generate-notes --title "Kata Containers ${RELEASE_VERSION}" \
 		--notes-file "/tmp/our_notes_${RELEASE_VERSION}"
 }
 


### PR DESCRIPTION
This reverts commit 0fa59ff94bc405ea992e07ee5fda801caabb977b, as now we'll be able to use the `--generate-notes`, hopefully, without blowing the allowed limit.

Fixes: #9064 - part VI