### PR TITLE
vc: adjust default and max CPUs after we move shim

### DIFF
--- a/src/runtime/virtcontainers/api.go
+++ b/src/runtime/virtcontainers/api.go
@@ -88,6 +88,14 @@ func createSandboxFromConfig(ctx context.Context, sandboxConfig SandboxConfig, f
 		return nil, err
 	}
 
+	// Now that we're in our 'final host cgroup' - let's make sure that the maximum number of
+	// CPUs reflects what is available to the shim.
+	currentMax := s.config.HypervisorConfig.DefaultMaxVCPUs
+	currentDefaultCPU := s.config.HypervisorConfig.NumVCPUs
+
+	s.config.HypervisorConfig.DefaultMaxVCPUs = adjustMaxVCPUs(currentMax)
+	s.config.HypervisorConfig.NumVCPUs = adjustDefaultVCPUs(s.config.HypervisorConfig.DefaultMaxVCPUs, currentDefaultCPU)
+
 	// Start the VM
 	if err = s.startVM(ctx, prestartHookFunc); err != nil {
 		return nil, err

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -1083,6 +1083,43 @@ func AvailableGuestProtections() (protections []string) {
 	return []string{gp.String()}
 }
 
+func adjustMaxVCPUs(currentMax uint32) uint32 {
+	availableCPUs := uint32(runtime.NumCPU())
+	maxCPUs := govmm.MaxVCPUs()
+	resultingCPUs := currentMax
+
+	if currentMax >= availableCPUs || resultingCPUs == 0 {
+		resultingCPUs = availableCPUs
+	}
+
+	if resultingCPUs > maxCPUs {
+		return maxCPUs
+	}
+
+	return resultingCPUs
+}
+
+const defaultCPU uint32 = 1
+
+func adjustDefaultVCPUs(max, currentDefault uint32) uint32 {
+	resultingCPUs := currentDefault
+	// available is lesser of available to the process and maximum
+	availableCPUs := uint32(runtime.NumCPU())
+	if availableCPUs > max {
+		availableCPUs = max
+	}
+
+	if resultingCPUs < 0 || resultingCPUs > availableCPUs {
+		return availableCPUs
+	}
+
+	if resultingCPUs == 0 {
+		return defaultCPU
+	}
+
+	return uint32(resultingCPUs)
+}
+
 // hypervisor is the virtcontainers hypervisor interface.
 // The default hypervisor implementation is Qemu.
 type Hypervisor interface {


### PR DESCRIPTION
We are setting up the runtime config earlier in configuration load and are validating the maximum CPU provided in the configuration file "makes sense" based on how many CPUs are available to the shim process. At this point in time, however, the shim is bound by how many CPUs its parent have.

In the event that the upper layer runtime (say containerd) is running within a constrained cpuset cgroup, this check will return however many CPUs the upper layer has available. Once the actual pod/sandbox is started, however, we'll no longer be in this cgroup and may have a different limitation (or no limitation).

Based on this unexpected behavior, let's make sure that we adjust the default and maximum number of vCPUs *after* we move into our own cgroup hierarchy.

Fixes: #9327