### PR TITLE
versions: Update nydus-snapshotter to v0.13.11

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -307,7 +307,7 @@ externals:
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.13.8"
+    version: "v0.13.11"
 
   open-policy-agent:
     description: "Open Policy Agent"


### PR DESCRIPTION
This version brings in a fix for cleaning up k3s/rke2 environments, which directly impacts the TDX machine that's part of our CI.

Fixes: #9318