### PR TITLE
ci.ocp: Set mcp update timeout explicitly

### DIFF
--- a/ci/openshift-ci/cluster/install_kata.sh
+++ b/ci/openshift-ci/cluster/install_kata.sh
@@ -138,7 +138,7 @@ enable_sandboxedcontainers_extension() {
 	oc apply -f ${deployment_file}
 	oc get -f ${deployment_file} || \
 		die "Sandboxed Containers extension machineconfig not found"
-	wait_mcp_update || die "Failed to update the machineconfigpool"
+	wait_mcp_update 1200 || die "Failed to update the machineconfigpool"
 }
 
 # Print useful information for debugging.


### PR DESCRIPTION
the "delta" variable is apparently set in the CI pipeline, let's set the timeout explicitly when calling the mcp update.

Fixes: #9338