### PR TITLE
agent: Fix errors in `make check`

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -569,7 +569,7 @@ pub fn parse_mount_table(mountinfo_path: &str) -> Result<Vec<Info>> {
     let reader = BufReader::new(file);
     let mut infos = Vec::new();
 
-    for (_index, line) in reader.lines().enumerate() {
+    for line in reader.lines() {
         let line = line?;
 
         //Example mountinfo format:

--- a/src/agent/src/mount.rs
+++ b/src/agent/src/mount.rs
@@ -180,7 +180,7 @@ pub fn get_mount_fs_type_from_file(mount_file: &str, mount_point: &str) -> Resul
     let re = Regex::new(format!("device .+ mounted on {} with fstype (.+)", mount_point).as_str())?;
 
     // Read the file line by line using the lines() iterator from std::io::BufRead.
-    for (_index, line) in content.lines().enumerate() {
+    for line in content.lines() {
         if let Some(capes) = re.captures(line) {
             if capes.len() > 1 {
                 return Ok(capes[1].to_string());
@@ -225,7 +225,7 @@ pub fn get_cgroup_mounts(
 
     // #subsys_name    hierarchy       num_cgroups     enabled
     // fields[0]       fields[1]       fields[2]       fields[3]
-    'outer: for (_, line) in reader.lines().enumerate() {
+    'outer: for line in reader.lines() {
         let line = line?;
 
         let fields: Vec<&str> = line.split('\t').collect();

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1746,7 +1746,7 @@ fn is_signal_handled(proc_status_file: &str, signum: u32) -> bool {
     // read lines start with SigBlk/SigIgn/SigCgt and check any match the signal mask
     reader
         .lines()
-        .flatten()
+        .map_while(Result::ok)
         .filter(|line| {
             line.starts_with("SigBlk:")
                 || line.starts_with("SigIgn:")

--- a/src/agent/src/signal.rs
+++ b/src/agent/src/signal.rs
@@ -144,15 +144,12 @@ mod tests {
 
         tx.send(true).expect("failed to request shutdown");
 
-        loop {
-            select! {
-                _ = handle => {
-                    println!("INFO: task completed");
-                    break;
-                },
-                _ = &mut timeout => {
-                    panic!("signal thread failed to stop");
-                }
+        select! {
+            _ = handle => {
+                println!("INFO: task completed");
+            },
+            _ = &mut timeout => {
+                panic!("signal thread failed to stop");
             }
         }
     }


### PR DESCRIPTION
Running `make check` in the `src/agent` directory shows a variety of lint-level errors, outlined in the three commits in this PR. With the proposed fixes, `make check` is clean (at least on my machine).