### PR TITLE
k8s: confidential: Update cpuid to its latest release

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
+++ b/tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
@@ -16,9 +16,9 @@ RUN apk add --no-cache curl openssh-server
 RUN /bin/sh -c \
     'ARCH=$(uname -m) && \
     [[ "${ARCH}" == "x86_64" ]] && \
-    curl -LO https://github.com/klauspost/cpuid/releases/download/v2.2.5/cpuid-Linux_x86_64_2.2.5.tar.gz && \
-    tar -xvzf cpuid-Linux_x86_64_2.2.5.tar.gz  -C /usr/bin && \
-    rm -rf cpuid-Linux_x86_64_2.2.5.tar.gz && \
+    curl -LO https://github.com/klauspost/cpuid/releases/download/v2.2.7/cpuid-Linux_x86_64_2.2.7.tar.gz && \
+    tar -xvzf cpuid-Linux_x86_64_2.2.7.tar.gz  -C /usr/bin && \
+    rm -rf cpuid-Linux_x86_64_2.2.7.tar.gz && \
     rm -f /usr/bin/LICENSE' || true
 
 # This is done just to avoid the following error starting sshd


### PR DESCRIPTION
Since v2.2.6 it can detect TDX guests on Azure, so let's bump it even if Azure peer-pods are not currently used as part of our CI.

Fixes: #9348