### PR TITLE
workflows: Build agent-opa for more archs

### DIFF
--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         asset:
           - agent
+          - agent-opa
           - kernel
           - qemu
           - rootfs-initrd
@@ -39,7 +40,7 @@ jobs:
       - name: Adjust a permission for repo
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-      
+
       - name: Prepare the self-hosted runner
         run: |
             ${HOME}/scripts/prepare_runner.sh

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -28,6 +28,7 @@ jobs:
       matrix:
         asset:
           - agent
+          - agent-opa
           - coco-guest-components
           - kernel
           - pause-image


### PR DESCRIPTION
Since https://github.com/kata-containers/kata-containers/pull/7769, we support building the OPA binary into the ppc64le and s390x arch versions of the rootfs, so build the policy enabled agent to match for those architectures too.

Fixes: #9355