### PR TITLE
gha: Update journal log names for nerdctl artifacts

### DIFF
--- a/tests/integration/nerdctl/gha-run.sh
+++ b/tests/integration/nerdctl/gha-run.sh
@@ -70,7 +70,7 @@ function collect_artifacts() {
 	fi
 	mkdir -p "${artifacts_dir}"
 	info "Collecting artifacts using ${KATA_HYPERVISOR} hypervisor"
-	local journalctl_log_filename="journalctl.log"
+	local journalctl_log_filename="journalctl-$RANDOM.log"
 	local journalctl_log_path="${artifacts_dir}/${journalctl_log_filename}"
 	sudo journalctl --since="$start_time" > "${journalctl_log_path}"
 }


### PR DESCRIPTION
This PR updates the journal log name for nerdctl artifacts to make sure that we have different names in case we add a parallel GHA job.

Fixes #9357