### PR TITLE
versions: Update runc version to 1.1.12

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -297,7 +297,7 @@ externals:
     uscan-url: >-
       https://github.com/opencontainers/runc/tags
       .*/v?(\d\S+)\.tar\.gz
-    version: "v1.1.11"
+    version: "v1.1.12"
 
   nydus:
     description: "Nydus image acceleration service"


### PR DESCRIPTION
This PR updates the runc version to 1.1.12 which includes the following changes
- Fix CVE-2024-21626, a container breakout attack that took advantage of a file descriptor that was leaked internally within runc (but never leaked to the container process).
In addition to fixing the leak, several strict hardening measures were added to ensure that future internal leaks could not be used to break out in this manner again.

Fixes #9361