### PR TITLE
runtime: remove stream copy infinite loop

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/stream.go
+++ b/src/runtime/pkg/containerd-shim-v2/stream.go
@@ -10,9 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"strings"
 	"sync"
-	"time"
 
 	"github.com/sirupsen/logrus"
 )
@@ -127,20 +125,7 @@ func ioCopy(shimLog *logrus.Entry, exitch, stdinCloser chan struct{}, tty *ttyIO
 			shimLog.Debug("stdout io stream copy started")
 			p := bufPool.Get().(*[]byte)
 			defer bufPool.Put(p)
-
-			for {
-				var _, err = io.CopyBuffer(tty.io.Stdout(), stdoutPipe, *p)
-				if err != nil {
-					shimLog.Debug("stdout io stream copy error happens: error = %w", err.Error())
-					if !strings.Contains(err.Error(), "blocked by policy") {
-						break
-					}
-					time.Sleep(1 * time.Second)
-				} else {
-					break
-				}
-			}
-
+			io.CopyBuffer(tty.io.Stdout(), stdoutPipe, *p)
 			if tty.io.Stdin() != nil {
 				// close stdin to make the other routine stop
 				tty.io.Stdin().Close()


### PR DESCRIPTION
This reverts commit 1c5693be86be4dcfee83d2d5ff2ec68dcfd18df4.

Avoid apparent infinite loop when ReadStreamRequest is blocked by policy - for some of the pods.

When running the k8s-limit-range.bats test with Policy enabled, the Shim + VMM never get terminated on my cluster. Not sure why the sandbox clean-up works better for other tests, but the k8s-limit-range test pod gets stuck in an infinite loop:

```
stdout io stream copy error happens: error = %wrpc error: code =
PermissionDenied desc = \"ReadStreamRequest is blocked by policy

...

policy check: ReadStreamRequest

...

stdout io stream copy error happens: error = %wrpc error: code =
PermissionDenied desc = \"ReadStreamRequest is blocked by policy

...

policy check: ReadStreamRequest

...
```

Fixes: #9380