### PR TITLE
docs: kata-manager: Update with latest details

### DIFF
--- a/utils/README.md
+++ b/utils/README.md
@@ -1,6 +1,6 @@
 # Utilities
 
-# Kata Manager
+## Kata Manager
 
 > **Notes:**
 >
@@ -31,7 +31,7 @@ containerd. However, be aware of the following before proceeding:
 If you still wish to continue, but prefer a manual installation, see
 [the containerd installation guide](/docs/install/container-manager/containerd/containerd-install.md).
 
-## Install a minimal Kata Containers system
+### Install a minimal Kata Containers system
 
 By default, the script will attempt to install Kata Containers and
 containerd, and then configure containerd to use Kata Containers. However,
@@ -55,7 +55,7 @@ behaviour.
 >   since: (a) it has been tested with the Kata Containers release you
 >   are using; and (b) it is simpler to run the command directly.
 
-### Show available options
+#### Show available options
 
 To show the available options without installing anything, run:
 
@@ -63,7 +63,7 @@ To show the available options without installing anything, run:
 $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh) -h"
 ```
 
-### To install Kata Containers only
+#### To install Kata Containers only
 
 If your system already has containerd installed, to install Kata Containers and only configure containerd, run:
 
@@ -71,7 +71,7 @@ If your system already has containerd installed, to install Kata Containers and 
 $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh) -o"
 ```
 
-### To install Kata Containers and containerd
+#### To install Kata Containers and containerd
 
 To install and configure a system with Kata Containers and containerd, run:
 
@@ -143,7 +143,7 @@ one of the following on an installed system.
 > See the [configuration documentation](https://github.com/kata-containers/kata-containers#configuration)
 > for further information.
 
-#### Switch hypervisor
+### Switch hypervisor
 
 > **Note:**
 >
@@ -153,7 +153,7 @@ one of the following on an installed system.
 > the Kata configuration directory (`/etc/kata-containers/` and
 > sub-directories).
 
-##### To install Kata Containers and containerd and configure it for a specific hypervisor
+#### To install Kata Containers and containerd and configure it for a specific hypervisor
 
 To specify that Kata be installed and configured to use a specific
 hypervisor, use the `-H` option. For example, to select Cloud Hypervisor, run:
@@ -165,7 +165,7 @@ $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-c
 > **Note:** See the [List available hypervisors](#list-available-hypervisors) section
 > for details of how to obtain the list of available hypervisor names.
 
-##### To switch the locally installed hypervisor
+#### To switch the locally installed hypervisor
 
 To switch the local hypervisor config on an installed system use the
 `-S` option. For example, to switch to the Cloud Hypervisor hypervisor,
@@ -186,7 +186,7 @@ run one of the following commands on an installed system:
 > **Note:** See the [List available hypervisors](#list-available-hypervisors) section
 > for details of how to obtain the list of available hypervisor names.
 
-##### Switch to the default packaged hypervisor
+#### Switch to the default packaged hypervisor
 
 To undo your changes and switch back to the default Kata hypervisor,
 specify the hypervisor name as `default`. For example, run one of the following commands on an installed system:

--- a/utils/README.md
+++ b/utils/README.md
@@ -87,36 +87,20 @@ This means you can switch between hypervisors whenever you wish.
 
 #### List available hypervisors
 
-Run one of the following commands on an installed system.
+Run the following command on an installed system:
 
-- If you Kata Containers installation includes the `kata-manager.sh` script, run:
-
-  ```bash
-  $ kata-manager -L
-  ```
-
-- If your Kata Containers installation does not include the `kata-manager.sh` script, run:
-
-  ```bash
-  $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh) -L"
-  ```
+```bash
+$ kata-manager -L
+```
 
 #### Show the default packaged hypervisor
 
-To show the default packaged hypervisor, run one of the following
-commands on an installed system:
+To show the default packaged hypervisor, run the following
+command on an installed system:
 
-- If you Kata Containers installation includes the `kata-manager.sh` script, run:
-
-  ```bash
-  $ kata-manager -L | grep default
-  ```
-
-- If your Kata Containers installation does not include the `kata-manager.sh` script, run:
-
-  ```bash
-  $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh) -L | grep default"
-  ```
+```bash
+$ kata-manager -L | grep default
+```
 
 #### Show the locally configured hypervisor
 
@@ -124,19 +108,11 @@ commands on an installed system:
 file.
 
 To show details of the _local_ copy of the configuration files, run
-one of the following on an installed system.
+the following command on an installed system:
 
-- If you Kata Containers installation includes the `kata-manager.sh` script, run:
-
-  ```bash
-  $ kata-manager -e
-  ```
-
-- If your Kata Containers installation does not include the `kata-manager.sh` script, run:
-
-  ```bash
-  $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh) -e"
-  ```
+```bash
+$ kata-manager -e
+```
 
 > **Note:** This command can only be run once Kata has been installed.
 
@@ -169,19 +145,11 @@ $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-c
 
 To switch the local hypervisor config on an installed system use the
 `-S` option. For example, to switch to the Cloud Hypervisor hypervisor,
-run one of the following commands on an installed system:
+run the following command on an installed system:
 
-- If you Kata Containers installation includes the `kata-manager.sh` script, run:
-
-  ```bash
-  $ kata-manager -S clh
-  ```
-
-- If your Kata Containers installation does not include the `kata-manager.sh` script, run:
-
-  ```bash
-  $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh) -S clh"
-  ```
+```bash
+$ kata-manager -S clh
+```
 
 > **Note:** See the [List available hypervisors](#list-available-hypervisors) section
 > for details of how to obtain the list of available hypervisor names.
@@ -189,16 +157,8 @@ run one of the following commands on an installed system:
 #### Switch to the default packaged hypervisor
 
 To undo your changes and switch back to the default Kata hypervisor,
-specify the hypervisor name as `default`. For example, run one of the following commands on an installed system:
+specify the hypervisor name as `default`. For example, run the following command on an installed system:
 
-- If you Kata Containers installation includes the `kata-manager.sh` script, run:
-
-  ```bash
-  $ kata-manager -S default
-  ```
-
-- If your Kata Containers installation does not include the `kata-manager.sh` script, run:
-
-  ```bash
-  $ bash -c "$(curl -fsSL https://raw.githubusercontent.com/kata-containers/kata-containers/main/utils/kata-manager.sh) -S default"
-  ```
+```bash
+$ kata-manager -S default
+```

--- a/utils/README.md
+++ b/utils/README.md
@@ -9,6 +9,33 @@
 >
 > - These instructions only apply to the current default (golang) Kata runtime.
 >   See https://github.com/kata-containers/kata-containers/issues/9060 for further details.
+>
+> - If you get a "command not found" error when you try to run the `kata-manager` command,
+>   your version of Kata Containers is too old. Please consider
+>   [updating to version 3.3.0 or newer](https://github.com/kata-containers/kata-containers/releases).
+
+### Permissions
+
+The permissions of certain Kata binaries are currently overly
+restrictive. To allow you to call the `kata-manager` script directly
+as shown below, run the following command:
+
+```bash
+$ sudo chmod 755 /opt/kata/bin/kata-manager*
+```
+
+Alternatively, call the `kata-manager` script using `sudo(1)` by
+specifying its full path in all the examples below. For example,
+to show the usage statement:
+
+```bash
+$ sudo /opt/kata/bin/kata-manager -h
+```
+
+> **Note:**
+>
+> For further details, see:
+> https://github.com/kata-containers/kata-containers/issues/9373.
 
 The [`kata-manager.sh`](kata-manager.sh) script automatically installs and
 configures Kata Containers and a container manager (such as containerd, Docker and `nerdctl`).


### PR DESCRIPTION
Now that v3.3.0 has been released, simplify
the `kata-manager` documentation.

Fixes: #9227.