### PR TITLE
packaging: fix the broken usage help

### DIFF
--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -104,12 +104,12 @@ Usage:
 ${script_name} [options]
 
 Options:
- --osname=${os_name}
- --osversion=${os_version}
- --imagetype=${image_type}
- --prefix=${prefix}
- --destdir=${destdir}
- --image_initrd_suffix=${image_initrd_suffix}
+ --osname=\${os_name}
+ --osversion=\${os_version}
+ --imagetype=\${image_type}
+ --prefix=\${prefix}
+ --destdir=\${destdir}
+ --image_initrd_suffix=\${image_initrd_suffix}
 EOF
 
 	exit "${return_code}"

--- a/tools/packaging/guest-image/build_se_image.sh
+++ b/tools/packaging/guest-image/build_se_image.sh
@@ -27,8 +27,8 @@ Usage:
   ${script_name} [options]
 
 Options:
-  --builddir=${builddir}
-  --destdir=${destdir}
+  --builddir=\${builddir}
+  --destdir=\${destdir}
 
 Environment variables:
   HKD_PATH (required): a path for a directory which includes at least one host key document


### PR DESCRIPTION
Fix typos in usage and move the logic of valid check after usage help print.

Fixes: #9386