### PR TITLE
ci.ocp: Increase the MCP update time

### DIFF
--- a/ci/openshift-ci/cluster/install_kata.sh
+++ b/ci/openshift-ci/cluster/install_kata.sh
@@ -96,7 +96,7 @@ wait_for_reboot() {
 }
 
 wait_mcp_update() {
-	local delta="${1:-1200}"
+	local delta="${1:-3600}"
 	local sleep_time=30
 	# The machineconfigpool is fine when all the workers updated and are ready,
 	# and none are degraded.


### PR DESCRIPTION
updating the machine config takes even longer than 1200s, use 60m to be sure everything is updated.

Fixes: #9338