### PR TITLE
rootfs: Install missing clang in Ubuntu docker image

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -39,6 +39,7 @@ RUN apt-get update && \
          echo "gcc-$gcc_arch-linux-gnu libc6-dev-$libc_arch-cross")) \
     git \
     gnupg2 \
+    libclang-dev \
     make \
     makedev \
     multistrap \


### PR DESCRIPTION
Without clang, the build of the kata-agent fails:
```
USE_PODMAN=true OS_VERSION=22.04 ./rootfs.sh ubuntu

...

   Compiling rsa v0.9.6
error: failed to run custom build command for `loopdev v0.5.0 (https://github.com/mdaffin/loopdev?rev=c9f91e8f0326ce8a3364ac911e81eb32328a5f27#c9f91e8f)`

Caused by:
  process didn't exit successfully: `/kata-containers/src/agent/target/release/build/loopdev-3dd7baed2e38b963/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at 'Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"', /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.63.0/./lib.rs:2338:31
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:137: target/x86_64-unknown-linux-musl/release/kata-agent] Error 101
Failed at 711: make LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP} AGENT_POLICY=${AGENT_POLICY} PULL_TYPE=${PULL_TYPE}

```