### PR TITLE
gha: Define GH_PR_NUMBER variable in gha run k8s common script

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -12,6 +12,7 @@ tests_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${tests_dir}/common.bash"
 
 K8S_TEST_HOST_TYPE="${K8S_TEST_HOST_TYPE:-small}"
+GH_PR_NUMBER="${GH_PR_NUMBER:-}"
 
 function _print_instance_type() {
     case ${K8S_TEST_HOST_TYPE} in


### PR DESCRIPTION
This PR defines the GH_PR_NUMBER variable in gha run k8s common script to avoid failures like unbound variable when running locally the scripts just like the GHA CI.

Fixes #9408