### PR TITLE
tests: k8s-job: wait for job successful create

### DIFF
--- a/tests/integration/kubernetes/k8s-job.bats
+++ b/tests/integration/kubernetes/k8s-job.bats
@@ -23,7 +23,7 @@ setup() {
 	kubectl apply -f "${yaml_file}"
 
 	# Verify job
-	kubectl describe jobs/"$job_name" | grep "SuccessfulCreate"
+	waitForProcess "$wait_time" "$sleep_time" "kubectl describe job $job_name | grep SuccessfulCreate"
 
 	# List pods that belong to the job
 	pod_name=$(kubectl get pods --selector=job-name=$job_name --output=jsonpath='{.items[*].metadata.name}')


### PR DESCRIPTION
Don't just verify SuccessfulCreate - wait for it if needed.

Fixes: #9138