### PR TITLE
GHA: Implement secondary GITHUB_WORKSPACE cleanup on 1st failure

### DIFF
--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Adjust a permission for repo
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE $HOME
-          sudo rm -rf $GITHUB_WORKSPACE/*
+          sudo rm -rf $GITHUB_WORKSPACE/* && echo "GITHUB_WORKSPACE removed" || { sleep 10 && sudo rm -rf $GITHUB_WORKSPACE/*; }
           sudo rm -f /tmp/kata_hybrid*  # Sometime we got leftover from test_setup_hvsock_failed()
         if: ${{ inputs.instance != 'ubuntu-20.04' }}
 


### PR DESCRIPTION
Occasionally, the removal of GITHUB_WORKSPACE fails for self-hosted runners because one of the subdirectories is not empty. This is likely due to another process occupying the directory at the time.
Implementing a secondary cleanup resolves this issue. This commit focuses on the implementation for the secondary cleanup.

Fixes: #9317

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>