### PR TITLE
gha: Bump various actions to use Node.js 20

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -44,7 +44,7 @@ jobs:
         run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
@@ -83,7 +83,7 @@ jobs:
         run: bash tests/stability/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
@@ -125,7 +125,7 @@ jobs:
         run: bash tests/integration/nydus/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
@@ -157,7 +157,7 @@ jobs:
         run: bash tests/integration/runk/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
@@ -195,7 +195,7 @@ jobs:
         run: bash tests/functional/tracing/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
@@ -232,7 +232,7 @@ jobs:
         run: bash tests/functional/vfio/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
@@ -270,7 +270,7 @@ jobs:
         run: bash tests/integration/docker/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
@@ -313,7 +313,7 @@ jobs:
         run: bash tests/integration/nerdctl/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
@@ -329,7 +329,7 @@ jobs:
         run: bash tests/integration/nerdctl/gha-run.sh collect-artifacts
 
       - name: Archive artifacts ${{ matrix.vmm }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: nerdctl-tests-garm-${{ matrix.vmm }}
           path: /tmp/artifacts

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -109,9 +109,9 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: store-artifact ${{ matrix.asset }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: kata-artifacts-amd64${{ inputs.tarball-suffix }}
+          name: kata-artifacts-amd64-${{ matrix.asset }}${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
           retention-days: 15
           if-no-files-found: error
@@ -130,15 +130,16 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
       - name: get-artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: kata-artifacts-amd64${{ inputs.tarball-suffix }}
+          pattern: kata-artifacts-amd64-*${{ inputs.tarball-suffix }}
           path: kata-artifacts
+          merge-multiple: true
       - name: merge-artifacts
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -81,9 +81,9 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: store-artifact ${{ matrix.asset }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: kata-artifacts-arm64${{ inputs.tarball-suffix }}
+          name: kata-artifacts-arm64-${{ matrix.asset }}${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
           retention-days: 15
           if-no-files-found: error
@@ -106,15 +106,16 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
       - name: get-artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: kata-artifacts-arm64${{ inputs.tarball-suffix }}
+          pattern: kata-artifacts-arm64-*${{ inputs.tarball-suffix }}
           path: kata-artifacts
+          merge-multiple: true
       - name: merge-artifacts
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kata-static-tarball-arm64${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -83,9 +83,9 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: store-artifact ${{ matrix.asset }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: kata-artifacts-ppc64le${{ inputs.tarball-suffix }}
+          name: kata-artifacts-ppc64le-${{ matrix.asset }}${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
           retention-days: 1
           if-no-files-found: error
@@ -108,15 +108,16 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
       - name: get-artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: kata-artifacts-ppc64le${{ inputs.tarball-suffix }}
+          pattern: kata-artifacts-ppc64le-*${{ inputs.tarball-suffix }}
           path: kata-artifacts
+          merge-multiple: true
       - name: merge-artifacts
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -98,7 +98,7 @@ jobs:
       - name: Take a pre-action for self-hosted runner
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: get-artifacts
         uses: actions/download-artifact@v3

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -84,9 +84,9 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: store-artifact ${{ matrix.asset }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: kata-artifacts-s390x${{ inputs.tarball-suffix }}
+          name: kata-artifacts-s390x-${{ matrix.asset }}${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.xz
           retention-days: 15
           if-no-files-found: error
@@ -101,10 +101,11 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: get-artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: kata-artifacts-s390x${{ inputs.tarball-suffix }}
+          pattern: kata-artifacts-s390x-*${{ inputs.tarball-suffix }}
           path: kata-artifacts
+          merge-multiple: true
 
       - name: Place a host key document
         run: |
@@ -128,7 +129,7 @@ jobs:
           HKD_PATH: "host-key-document"
 
       - name: store-artifact boot-image-se
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-s390x${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-boot-image-se.tar.xz
@@ -152,15 +153,16 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
       - name: get-artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: kata-artifacts-s390x${{ inputs.tarball-suffix }}
+          pattern: kata-artifacts-s390x-*${{ inputs.tarball-suffix }}
           path: kata-artifacts
+          merge-multiple: true
       - name: merge-artifacts
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -97,7 +97,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Kata Containers ghcr.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,7 +94,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Kata Containers ghcr.io
         uses: docker/login-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -104,7 +104,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker build and push
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v5
         with:
           tags: ghcr.io/kata-containers/test-images:unencrypted-${{ inputs.pr-number }}
           push: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -91,7 +91,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -93,7 +93,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Login to Kata Containers quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/publish-kata-deploy-payload-amd64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-amd64.yaml
@@ -38,7 +38,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
 

--- a/.github/workflows/publish-kata-deploy-payload-amd64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-amd64.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.registry == 'quay.io' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
@@ -52,7 +52,7 @@ jobs:
 
       - name: Login to Kata Containers ghcr.io
         if: ${{ inputs.registry == 'ghcr.io' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -42,7 +42,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-arm64${{ inputs.tarball-suffix }}
 

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.registry == 'quay.io' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
@@ -56,7 +56,7 @@ jobs:
 
       - name: Login to Kata Containers ghcr.io
         if: ${{ inputs.registry == 'ghcr.io' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
@@ -47,7 +47,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
 

--- a/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.registry == 'quay.io' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
@@ -61,7 +61,7 @@ jobs:
 
       - name: Login to Kata Containers ghcr.io
         if: ${{ inputs.registry == 'ghcr.io' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.registry == 'quay.io' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
@@ -55,7 +55,7 @@ jobs:
 
       - name: Login to Kata Containers ghcr.io
         if: ${{ inputs.registry == 'ghcr.io' }}
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -41,7 +41,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
 

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -17,13 +17,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Login to Kata Containers docker.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Kata Containers quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64
 

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-arm64
 

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -17,13 +17,13 @@ jobs:
     runs-on: arm64-builder
     steps:
       - name: Login to Kata Containers docker.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Kata Containers quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -22,13 +22,13 @@ jobs:
           sudo rm -rf $GITHUB_WORKSPACE/*
 
       - name: Login to Kata Containers docker.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Kata Containers quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-ppc64le
 

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -21,13 +21,13 @@ jobs:
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - name: Login to Kata Containers docker.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Kata Containers quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-s390x
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -89,7 +89,7 @@ jobs:
           echo "KATA_STATIC_TARBALL=${tarball}" >> "$GITHUB_ENV"
 
       - name: Download amd64 artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64
 
@@ -101,7 +101,7 @@ jobs:
           ARCHITECTURE: amd64
 
       - name: Download arm64 artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-arm64
 
@@ -113,7 +113,7 @@ jobs:
           ARCHITECTURE: arm64
 
       - name: Download s390x artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-s390x
 
@@ -125,7 +125,7 @@ jobs:
           ARCHITECTURE: s390x
 
       - name: Download ppc64le artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-ppc64le
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -53,13 +53,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Login to Kata Containers docker.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Login to Kata Containers quay.io
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}

--- a/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
+++ b/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
@@ -52,7 +52,7 @@ jobs:
         run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
           path: kata-artifacts

--- a/.github/workflows/run-cri-containerd-tests-s390x.yaml
+++ b/.github/workflows/run-cri-containerd-tests-s390x.yaml
@@ -47,7 +47,7 @@ jobs:
         run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
           path: kata-artifacts

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -82,7 +82,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts

--- a/.github/workflows/run-k8s-tests-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-on-garm.yaml
@@ -89,9 +89,9 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh collect-artifacts
 
       - name: Archive artifacts ${{ matrix.vmm }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: k8s-tests-garm-${{ matrix.vmm }}
+          name: k8s-tests-garm-${{ matrix.vmm }}-${{ matrix.snapshotter }}-${{ matrix.k8s }}-${{ matrix.instance }}-${{ inputs.tag }}
           path: /tmp/artifacts
           retention-days: 1
 

--- a/.github/workflows/run-kata-monitor-tests.yaml
+++ b/.github/workflows/run-kata-monitor-tests.yaml
@@ -47,7 +47,7 @@ jobs:
         run: bash tests/functional/kata-monitor/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts

--- a/.github/workflows/run-metrics.yaml
+++ b/.github/workflows/run-metrics.yaml
@@ -32,7 +32,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
@@ -86,7 +86,7 @@ jobs:
         run: bash tests/metrics/gha-run.sh make-tarball-results
 
       - name: archive metrics results ${{ matrix.vmm }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: metrics-artifacts-${{ matrix.vmm }}
           path: results-${{ matrix.vmm }}.tar.gz

--- a/.github/workflows/run-runk-tests.yaml
+++ b/.github/workflows/run-runk-tests.yaml
@@ -34,7 +34,7 @@ jobs:
         run: bash tests/integration/runk/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts


### PR DESCRIPTION
`Node.js 19` is deprecated. Bump to all impacted actions to new versions based on `Node.js 20`.

Fixes #9245 

