### PR TITLE
tests: Improve the kbs_k8s_delete function

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -158,6 +158,9 @@ kbs_install_cli() {
 function kbs_k8s_delete() {
 	pushd "$COCO_KBS_DIR"
 	kubectl delete -k config/kubernetes/overlays
+	# Verify that coco-tenant resources were properly deleted
+	cmd="kubectl get all -n coco-tenant 2>&1 | grep 'No resources found'"
+	waitForProcess "120" "30" "$cmd"
 	popd
 }
 


### PR DESCRIPTION
This PR improves the kbs_k8s_delete function to verify that the resources were properly deleted for baremetal environments.

Fixes #9379