### PR TITLE
CC: run guest-pull tests on non-TEE jobs

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -186,3 +186,78 @@ jobs:
       - name: Delete Snapshotter
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
+
+  # Generate jobs for testing CoCo on non-TEE environments
+  run-k8s-tests-coco-nontee:
+    strategy:
+      fail-fast: false
+      matrix:
+        vmm:
+          - qemu
+        snapshotter:
+          - nydus
+        pull-type:
+          - guest-pull
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_REGISTRY: ${{ inputs.registry }}
+      DOCKER_REPO: ${{ inputs.repo }}
+      DOCKER_TAG: ${{ inputs.tag }}
+      GH_PR_NUMBER: ${{ inputs.pr-number }}
+      KATA_HOST_OS: ${{ matrix.host_os }}
+      KATA_HYPERVISOR: ${{ matrix.vmm }}
+      KUBERNETES: "vanilla"
+      PULL_TYPE: ${{ matrix.pull-type }}
+      SNAPSHOTTER: ${{ matrix.snapshotter }}
+      USING_NFD: "false"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Download Azure CLI
+        run: bash tests/integration/kubernetes/gha-run.sh install-azure-cli
+
+      - name: Log into the Azure account
+        run: bash tests/integration/kubernetes/gha-run.sh login-azure
+        env:
+          AZ_APPID: ${{ secrets.AZ_APPID }}
+          AZ_PASSWORD: ${{ secrets.AZ_PASSWORD }}
+          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
+          AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+
+      - name: Create AKS cluster
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh create-cluster
+
+      - name: Install `bats`
+        run: bash tests/integration/kubernetes/gha-run.sh install-bats
+
+      - name: Install `kubectl`
+        run: bash tests/integration/kubernetes/gha-run.sh install-kubectl
+
+      - name: Download credentials for the Kubernetes CLI to use them
+        run: bash tests/integration/kubernetes/gha-run.sh get-cluster-credentials
+
+      - name: Deploy Snapshotter
+        timeout-minutes: 5
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-snapshotter
+
+      - name: Deploy Kata
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-aks
+
+      - name: Run tests
+        timeout-minutes: 60
+        run: bash tests/integration/kubernetes/gha-run.sh run-tests
+
+      - name: Delete AKS cluster
+        if: always()
+        run: bash tests/integration/kubernetes/gha-run.sh delete-cluster

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -146,6 +146,7 @@ function get_cluster_credentials() {
     test_type="${1:-k8s}"
 
     az aks get-credentials \
+        --overwrite-existing \
         -g "$(_print_rg_name ${test_type})" \
         -n "$(_print_cluster_name ${test_type})"
 }

--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -47,6 +47,11 @@ setup() {
         "io.containerd.cri.runtime-handler" \
         "kata-${KATA_HYPERVISOR}"
 
+    [[ " ${SUPPORTED_NON_TEE_HYPERVISORS} " =~ " ${KATA_HYPERVISOR} " ]] && \
+        set_metadata_annotation "$kata_pod_with_nydus_config" \
+            "io.katacontainers.config.hypervisor.image" \
+            "/opt/kata/share/kata-containers/kata-containers-confidential.img"
+
     # For debug sake
     echo "Pod $kata_pod_with_nydus_config file:"
     cat $kata_pod_with_nydus_config
@@ -111,6 +116,11 @@ setup() {
     set_metadata_annotation "$kata_pod_with_nydus_config" \
         "io.containerd.cri.runtime-handler" \
         "kata-${KATA_HYPERVISOR}"
+
+    [[ " ${SUPPORTED_NON_TEE_HYPERVISORS} " =~ " ${KATA_HYPERVISOR} " ]] && \
+        set_metadata_annotation "$kata_pod_with_nydus_config" \
+            "io.katacontainers.config.hypervisor.image" \
+            "/opt/kata/share/kata-containers/kata-containers-confidential.img"
 
     # For debug sake
     echo "Pod $kata_pod_with_nydus_config file:"
@@ -189,6 +199,11 @@ setup() {
     set_metadata_annotation "$kata_pod_with_nydus_config" \
         "io.containerd.cri.runtime-handler" \
         "kata-${KATA_HYPERVISOR}"
+
+    [[ " ${SUPPORTED_NON_TEE_HYPERVISORS} " =~ " ${KATA_HYPERVISOR} " ]] && \
+        set_metadata_annotation "$kata_pod_with_nydus_config" \
+            "io.katacontainers.config.hypervisor.image" \
+            "/opt/kata/share/kata-containers/kata-containers-confidential.img"
 
     # For debug sake
     echo "Pod $kata_pod_with_nydus_config file:"


### PR DESCRIPTION
This is for running the existing guest-pull tests on non-TEE environment for the CoCo 0.9.0 release.

I could have introduced a new column to the current k8s jobs matrix (`.github/workflows/run-k8s-tests-on-aks.yaml`) but this would have created some issues as I described in https://github.com/kata-containers/kata-containers/issues/9410. So instead this is going to create a new matrix of jobs (`run-k8s-tests-coco-nontee`) alongside the TEE jobs in `.github/workflows/run-kata-coco-tests.yaml` for running the CoCo tests on non-TEE.

Initially it is going to run only the guest-pull tests but in the future I envision it being used for all CoCo's non-TEE tests, that's why I made it generic.

Talking about the guest-pull tests, because I  they are now running on non-CoCo runtimeclasses, i.e., when `KATA_HYPERVISOR=qemu`, I had to add a new guard to ensure the tests are executed only on environments that have a snapshotter installed. This way the tests won't get executed on the `run-k8s-tests-on-aks` jobs, for example.

"Simulated" these changes with the following script running from `./tests/integration/kubernetes`:
```bash
#!/bin/bash

set -o errexit
set -o nounset
set -o pipefail

export AZ_RG="wmoschet-ci-tests"
export AKS_NAME="wmoschet-aks-ci-test"

#export DOCKER_REGISTRY=
#export DOCKER_REPO=
#export DOCKER_TAG=
#export GH_PR_NUMBER=
export KATA_HOST_OS=ubuntu
export KATA_HYPERVISOR=qemu
export KUBERNETES=vanilla
export K8S_TEST_HOST_TYPE=small
#export K8S_TEST_UNION="k8s-guest-pull-image.bats"
export PULL_TYPE=guest-pull
export SNAPSHOTTER=nydus
export USING_NFD="false"

prep_env() {
    echo "== CREATE CLUSTER =="
    ./gha-run.sh create-cluster
    echo "== GET CREDENTIALS =="
    ./gha-run.sh get-cluster-credentials
    echo "== DEPLOY SNAPSHOTTER =="
    ./gha-run.sh deploy-snapshotter
    echo "== DEPLOY KATA =="
    ./gha-run.sh deploy-kata-aks
}

teardown_env() {
    echo "== DESTROY CLUSTER =="
    ./gha-run.sh delete-cluster
}

run_tests() {
    echo "== RUN TESTS =="
    ./gha-run.sh run-tests
}

prep_env
run_tests
teardown_env
```
