### PR TITLE
agent: reduce kata-agent binary size for release builds

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -94,6 +94,8 @@ members = ["rustjail"]
 
 [profile.release]
 lto = true
+codegen-units = 1
+opt-level = "s"
 
 [features]
 # The default-pull feature would support all pull types, including sharing images by virtio-fs and pulling images in the guest


### PR DESCRIPTION
This patch reduces kata-agent binary size from 21.05 MB to 14.78 MB.

Fixes: #9426