### PR TITLE
genpolicy: implement default methods for K8sResource trait

### DIFF
--- a/src/tools/genpolicy/src/config_map.rs
+++ b/src/tools/genpolicy/src/config_map.rs
@@ -9,13 +9,11 @@
 use crate::obj_meta;
 use crate::pod;
 use crate::policy;
-use crate::settings;
 use crate::utils::Config;
 use crate::yaml;
 
 use async_trait::async_trait;
 use log::debug;
-use protocols::agent;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs::File;
@@ -87,16 +85,6 @@ impl yaml::K8sResource for ConfigMap {
         _silent_unsupported_fields: bool,
     ) {
         self.doc_mapping = doc_mapping.clone();
-    }
-
-    fn get_container_mounts_and_storages(
-        &self,
-        _policy_mounts: &mut Vec<policy::KataMount>,
-        _storages: &mut Vec<agent::Storage>,
-        _container: &pod::Container,
-        _settings: &settings::Settings,
-    ) {
-        panic!("Unsupported");
     }
 
     fn generate_policy(&self, _agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/config_map.rs
+++ b/src/tools/genpolicy/src/config_map.rs
@@ -95,10 +95,6 @@ impl yaml::K8sResource for ConfigMap {
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 
-    fn get_containers(&self) -> &Vec<pod::Container> {
-        panic!("Unsupported");
-    }
-
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
         &self.metadata.annotations
     }

--- a/src/tools/genpolicy/src/config_map.rs
+++ b/src/tools/genpolicy/src/config_map.rs
@@ -89,10 +89,6 @@ impl yaml::K8sResource for ConfigMap {
         self.doc_mapping = doc_mapping.clone();
     }
 
-    fn get_sandbox_name(&self) -> Option<String> {
-        panic!("Unsupported");
-    }
-
     fn get_container_mounts_and_storages(
         &self,
         _policy_mounts: &mut Vec<policy::KataMount>,

--- a/src/tools/genpolicy/src/config_map.rs
+++ b/src/tools/genpolicy/src/config_map.rs
@@ -99,10 +99,6 @@ impl yaml::K8sResource for ConfigMap {
         &self.metadata.annotations
     }
 
-    fn use_host_network(&self) -> bool {
-        panic!("Unsupported");
-    }
-
     fn use_sandbox_pidns(&self) -> bool {
         panic!("Unsupported");
     }

--- a/src/tools/genpolicy/src/config_map.rs
+++ b/src/tools/genpolicy/src/config_map.rs
@@ -98,8 +98,4 @@ impl yaml::K8sResource for ConfigMap {
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
         &self.metadata.annotations
     }
-
-    fn use_sandbox_pidns(&self) -> bool {
-        panic!("Unsupported");
-    }
 }

--- a/src/tools/genpolicy/src/list.rs
+++ b/src/tools/genpolicy/src/list.rs
@@ -49,10 +49,6 @@ impl yaml::K8sResource for List {
         }
     }
 
-    fn get_sandbox_name(&self) -> Option<String> {
-        panic!("Unsupported");
-    }
-
     fn get_container_mounts_and_storages(
         &self,
         _policy_mounts: &mut Vec<policy::KataMount>,

--- a/src/tools/genpolicy/src/list.rs
+++ b/src/tools/genpolicy/src/list.rs
@@ -81,10 +81,6 @@ impl yaml::K8sResource for List {
         serde_yaml::to_string(&self).unwrap()
     }
 
-    fn use_host_network(&self) -> bool {
-        panic!("Unsupported");
-    }
-
     fn use_sandbox_pidns(&self) -> bool {
         panic!("Unsupported");
     }

--- a/src/tools/genpolicy/src/list.rs
+++ b/src/tools/genpolicy/src/list.rs
@@ -81,10 +81,6 @@ impl yaml::K8sResource for List {
         serde_yaml::to_string(&self).unwrap()
     }
 
-    fn get_containers(&self) -> &Vec<pod::Container> {
-        panic!("Unsupported");
-    }
-
     fn use_host_network(&self) -> bool {
         panic!("Unsupported");
     }

--- a/src/tools/genpolicy/src/list.rs
+++ b/src/tools/genpolicy/src/list.rs
@@ -80,8 +80,4 @@ impl yaml::K8sResource for List {
         }
         serde_yaml::to_string(&self).unwrap()
     }
-
-    fn use_sandbox_pidns(&self) -> bool {
-        panic!("Unsupported");
-    }
 }

--- a/src/tools/genpolicy/src/list.rs
+++ b/src/tools/genpolicy/src/list.rs
@@ -18,7 +18,6 @@ use protocols::agent;
 use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 use std::boxed;
-use std::collections::BTreeMap;
 use std::marker::{Send, Sync};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -87,10 +86,6 @@ impl yaml::K8sResource for List {
     }
 
     fn get_containers(&self) -> &Vec<pod::Container> {
-        panic!("Unsupported");
-    }
-
-    fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
         panic!("Unsupported");
     }
 

--- a/src/tools/genpolicy/src/no_policy.rs
+++ b/src/tools/genpolicy/src/no_policy.rs
@@ -8,12 +8,10 @@
 
 use crate::pod;
 use crate::policy;
-use crate::settings;
 use crate::utils::Config;
 use crate::yaml;
 
 use async_trait::async_trait;
-use protocols::agent;
 
 #[derive(Clone, Debug)]
 pub struct NoPolicyResource {
@@ -28,16 +26,6 @@ impl yaml::K8sResource for NoPolicyResource {
         _doc_mapping: &serde_yaml::Value,
         _silent_unsupported_fields: bool,
     ) {
-    }
-
-    fn get_container_mounts_and_storages(
-        &self,
-        _policy_mounts: &mut Vec<policy::KataMount>,
-        _storages: &mut Vec<agent::Storage>,
-        _container: &pod::Container,
-        _settings: &settings::Settings,
-    ) {
-        panic!("Unsupported");
     }
 
     fn generate_policy(&self, _agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/no_policy.rs
+++ b/src/tools/genpolicy/src/no_policy.rs
@@ -6,7 +6,6 @@
 // Allow K8s YAML field names.
 #![allow(non_snake_case)]
 
-use crate::pod;
 use crate::policy;
 use crate::utils::Config;
 use crate::yaml;
@@ -34,10 +33,6 @@ impl yaml::K8sResource for NoPolicyResource {
 
     fn serialize(&mut self, _policy: &str) -> String {
         self.yaml.clone()
-    }
-
-    fn get_containers(&self) -> &Vec<pod::Container> {
-        panic!("Unsupported");
     }
 
     fn use_host_network(&self) -> bool {

--- a/src/tools/genpolicy/src/no_policy.rs
+++ b/src/tools/genpolicy/src/no_policy.rs
@@ -30,10 +30,6 @@ impl yaml::K8sResource for NoPolicyResource {
     ) {
     }
 
-    fn get_sandbox_name(&self) -> Option<String> {
-        panic!("Unsupported");
-    }
-
     fn get_container_mounts_and_storages(
         &self,
         _policy_mounts: &mut Vec<policy::KataMount>,

--- a/src/tools/genpolicy/src/no_policy.rs
+++ b/src/tools/genpolicy/src/no_policy.rs
@@ -14,7 +14,6 @@ use crate::yaml;
 
 use async_trait::async_trait;
 use protocols::agent;
-use std::collections::BTreeMap;
 
 #[derive(Clone, Debug)]
 pub struct NoPolicyResource {
@@ -54,10 +53,6 @@ impl yaml::K8sResource for NoPolicyResource {
     }
 
     fn get_containers(&self) -> &Vec<pod::Container> {
-        panic!("Unsupported");
-    }
-
-    fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
         panic!("Unsupported");
     }
 

--- a/src/tools/genpolicy/src/no_policy.rs
+++ b/src/tools/genpolicy/src/no_policy.rs
@@ -35,10 +35,6 @@ impl yaml::K8sResource for NoPolicyResource {
         self.yaml.clone()
     }
 
-    fn use_host_network(&self) -> bool {
-        panic!("Unsupported");
-    }
-
     fn use_sandbox_pidns(&self) -> bool {
         panic!("Unsupported");
     }

--- a/src/tools/genpolicy/src/no_policy.rs
+++ b/src/tools/genpolicy/src/no_policy.rs
@@ -34,8 +34,4 @@ impl yaml::K8sResource for NoPolicyResource {
     fn serialize(&mut self, _policy: &str) -> String {
         self.yaml.clone()
     }
-
-    fn use_sandbox_pidns(&self) -> bool {
-        panic!("Unsupported");
-    }
 }

--- a/src/tools/genpolicy/src/secret.rs
+++ b/src/tools/genpolicy/src/secret.rs
@@ -84,10 +84,6 @@ impl yaml::K8sResource for Secret {
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 
-    fn use_host_network(&self) -> bool {
-        panic!("Unsupported");
-    }
-
     fn use_sandbox_pidns(&self) -> bool {
         panic!("Unsupported");
     }

--- a/src/tools/genpolicy/src/secret.rs
+++ b/src/tools/genpolicy/src/secret.rs
@@ -104,10 +104,6 @@ impl yaml::K8sResource for Secret {
         panic!("Unsupported");
     }
 
-    fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
-        panic!("Unsupported");
-    }
-
     fn use_host_network(&self) -> bool {
         panic!("Unsupported");
     }

--- a/src/tools/genpolicy/src/secret.rs
+++ b/src/tools/genpolicy/src/secret.rs
@@ -78,10 +78,6 @@ impl yaml::K8sResource for Secret {
         self.doc_mapping = doc_mapping.clone();
     }
 
-    fn get_sandbox_name(&self) -> Option<String> {
-        panic!("Unsupported");
-    }
-
     fn get_container_mounts_and_storages(
         &self,
         _policy_mounts: &mut Vec<policy::KataMount>,

--- a/src/tools/genpolicy/src/secret.rs
+++ b/src/tools/genpolicy/src/secret.rs
@@ -84,10 +84,6 @@ impl yaml::K8sResource for Secret {
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
 
-    fn get_containers(&self) -> &Vec<pod::Container> {
-        panic!("Unsupported");
-    }
-
     fn use_host_network(&self) -> bool {
         panic!("Unsupported");
     }

--- a/src/tools/genpolicy/src/secret.rs
+++ b/src/tools/genpolicy/src/secret.rs
@@ -9,13 +9,11 @@
 use crate::obj_meta;
 use crate::pod;
 use crate::policy;
-use crate::settings;
 use crate::utils::Config;
 use crate::yaml;
 
 use async_trait::async_trait;
 use base64::{engine::general_purpose, Engine as _};
-use protocols::agent;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
@@ -76,16 +74,6 @@ pub fn get_value(value_from: &pod::EnvVarSource, secrets: &Vec<Secret>) -> Optio
 impl yaml::K8sResource for Secret {
     async fn init(&mut self, _config: &Config, doc_mapping: &serde_yaml::Value, _silent: bool) {
         self.doc_mapping = doc_mapping.clone();
-    }
-
-    fn get_container_mounts_and_storages(
-        &self,
-        _policy_mounts: &mut Vec<policy::KataMount>,
-        _storages: &mut Vec<agent::Storage>,
-        _container: &pod::Container,
-        _settings: &settings::Settings,
-    ) {
-        panic!("Unsupported");
     }
 
     fn generate_policy(&self, _agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/secret.rs
+++ b/src/tools/genpolicy/src/secret.rs
@@ -83,8 +83,4 @@ impl yaml::K8sResource for Secret {
     fn serialize(&mut self, _policy: &str) -> String {
         serde_yaml::to_string(&self.doc_mapping).unwrap()
     }
-
-    fn use_sandbox_pidns(&self) -> bool {
-        panic!("Unsupported");
-    }
 }

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -70,7 +70,10 @@ pub trait K8sResource {
         panic!("Unsupported");
     }
 
-    fn get_containers(&self) -> &Vec<pod::Container>;
+    fn get_containers(&self) -> &Vec<pod::Container> {
+        panic!("Unsupported");
+    }
+
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
         panic!("Unsupported");
     }

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -78,7 +78,10 @@ pub trait K8sResource {
         panic!("Unsupported");
     }
 
-    fn use_host_network(&self) -> bool;
+    fn use_host_network(&self) -> bool {
+        panic!("Unsupported");
+    }
+
     fn use_sandbox_pidns(&self) -> bool;
 }
 

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -66,7 +66,10 @@ pub trait K8sResource {
     );
 
     fn get_containers(&self) -> &Vec<pod::Container>;
-    fn get_annotations(&self) -> &Option<BTreeMap<String, String>>;
+    fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {
+        panic!("Unsupported");
+    }
+
     fn use_host_network(&self) -> bool;
     fn use_sandbox_pidns(&self) -> bool;
 }

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -49,8 +49,13 @@ pub trait K8sResource {
         silent_unsupported_fields: bool,
     );
 
-    fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String;
-    fn serialize(&mut self, policy: &str) -> String;
+    fn generate_policy(&self, _agent_policy: &policy::AgentPolicy) -> String {
+        panic!("Unsupported");
+    }
+
+    fn serialize(&mut self, _policy: &str) -> String {
+        panic!("Unsupported");
+    }
 
     fn get_sandbox_name(&self) -> Option<String> {
         panic!("Unsupported");

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -52,7 +52,10 @@ pub trait K8sResource {
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String;
     fn serialize(&mut self, policy: &str) -> String;
 
-    fn get_sandbox_name(&self) -> Option<String>;
+    fn get_sandbox_name(&self) -> Option<String> {
+        panic!("Unsupported");
+    }
+
     fn get_namespace(&self) -> Option<String> {
         panic!("Unsupported");
     }

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -62,11 +62,13 @@ pub trait K8sResource {
 
     fn get_container_mounts_and_storages(
         &self,
-        policy_mounts: &mut Vec<policy::KataMount>,
-        storages: &mut Vec<agent::Storage>,
-        container: &pod::Container,
-        settings: &settings::Settings,
-    );
+        _policy_mounts: &mut Vec<policy::KataMount>,
+        _storages: &mut Vec<agent::Storage>,
+        _container: &pod::Container,
+        _settings: &settings::Settings,
+    ) {
+        panic!("Unsupported");
+    }
 
     fn get_containers(&self) -> &Vec<pod::Container>;
     fn get_annotations(&self) -> &Option<BTreeMap<String, String>> {

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -82,7 +82,9 @@ pub trait K8sResource {
         panic!("Unsupported");
     }
 
-    fn use_sandbox_pidns(&self) -> bool;
+    fn use_sandbox_pidns(&self) -> bool {
+        panic!("Unsupported");
+    }
 }
 
 /// See Reference / Kubernetes API / Common Definitions / LabelSelector.


### PR DESCRIPTION
This PR adds default implementations for the following methods of K8sResource trait:
- generate_policy
- serialize
- use_sandbox_pidns
- use_host_network
- get_containers
- get_container_mounts_and_storages
- get_sandbox_name
- get_annotations

Fixes: #8960