### PR TITLE
tests: Add k8s negative policy test

### DIFF
--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -32,25 +32,22 @@ setup() {
 	set_node "$K8S_TEST_YAML" "$node"
 
 	kbs_set_resource "default" "aa" "key" "$test_key"
-	kbs_set_allow_all_resources
-}
-
-@test "Get CDH resource" {
 	local CC_KBS_ADDR
 	export CC_KBS_ADDR=$(kbs_k8s_svc_http_addr)
 	kernel_params_annotation="io.katacontainers.config.hypervisor.kernel_params"
 	kernel_params_value="agent.guest_components_rest_api=resource"
-
 	# Based on current config we still need to pass the agent.aa_kbc_params, but this might change
 	# as the CDH/Attestaiton-agent config gets updated
 	if [ "${AA_KBC}" = "cc_kbc" ]; then
 		kernel_params_value+=" agent.aa_kbc_params=cc_kbc::${CC_KBS_ADDR}"
 	fi
-
 	set_metadata_annotation "${K8S_TEST_YAML}" \
-			"${kernel_params_annotation}" \
-			"${kernel_params_value}"
+		"${kernel_params_annotation}" \
+		"${kernel_params_value}"
+}
 
+@test "Get CDH resource" {
+	kbs_set_allow_all_resources
 	kubectl apply -f "${K8S_TEST_YAML}"
 
 	# Retrieve pod name, wait for it to come up, retrieve pod ip
@@ -64,6 +61,24 @@ setup() {
 
 	kubectl logs aa-test-cc
 	kubectl logs aa-test-cc | grep -q "aatest"
+}
+
+@test "Cannot get CDH resource when deny-all policy is set" {
+	kbs_set_deny_all_resources
+	kubectl apply -f "${K8S_TEST_YAML}"
+
+	# Retrieve pod name, wait for it to come up, retrieve pod ip
+	export pod_name=$(kubectl get pod -o wide | grep "aa-test-cc" | awk '{print $1;}')
+
+	# Check pod creation
+	kubectl wait --for=condition=Ready --timeout="$timeout" pod "${pod_name}"
+
+	sleep 5
+
+	kubectl logs aa-test-cc
+	cmd="kubectl logs aa-test-cc | grep -q aatest"
+	run $cmd
+	[ "$status" -eq 1 ]
 }
 
 teardown() {


### PR DESCRIPTION
This PR adds a k8s negative policy test to the confidential attestation bats test.

Fixes #9437