### PR TITLE
CI: Select jobs by touched code

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-cri-containerd:
@@ -30,31 +34,41 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/cri-containerd/gha-run.sh install-kata kata-artifacts
 
       - name: Run cri-containerd tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/cri-containerd/gha-run.sh run
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-containerd-stability:
     strategy:
@@ -69,31 +83,41 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/stability/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/stability/gha-run.sh install-kata kata-artifacts
 
       - name: Run containerd-stability tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 15
         run: bash tests/stability/gha-run.sh run
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-nydus:
     strategy:
@@ -111,31 +135,41 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/nydus/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/nydus/gha-run.sh install-kata kata-artifacts
 
       - name: Run nydus tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/nydus/gha-run.sh run
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-runk:
     runs-on: garm-ubuntu-2204-smaller
@@ -148,26 +182,35 @@ jobs:
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/runk/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/runk/gha-run.sh install-kata kata-artifacts
 
       - name: Run runk tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/runk/gha-run.sh run
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-tracing:
     strategy:
@@ -181,31 +224,41 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/tracing/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/tracing/gha-run.sh install-kata kata-artifacts
 
       - name: Run tracing tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 15
         run: bash tests/functional/tracing/gha-run.sh run
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-vfio:
     strategy:
@@ -218,28 +271,37 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/vfio/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Run vfio tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 15
         run: bash tests/functional/vfio/gha-run.sh run
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-docker-tests:
     strategy:
@@ -256,31 +318,41 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/docker/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/docker/gha-run.sh install-kata kata-artifacts
 
       - name: Run docker smoke test
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 5
         run: bash tests/integration/docker/gha-run.sh run
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-nerdctl-tests:
     strategy:
@@ -299,38 +371,50 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/nerdctl/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/nerdctl/gha-run.sh install-kata kata-artifacts
 
       - name: Run nerdctl smoke test
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 5
         run: bash tests/integration/nerdctl/gha-run.sh run
 
       - name: Collect artifacts ${{ matrix.vmm }}
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/nerdctl/gha-run.sh collect-artifacts
 
       - name: Archive artifacts ${{ matrix.vmm }}
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: nerdctl-tests-garm-${{ matrix.vmm }}
           path: /tmp/artifacts
           retention-days: 1
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -4,6 +4,10 @@ on:
       instance:
         required: true
         type: string
+      skip:
+        required: false
+        type: string
+        default: no
 
 name: Build checks
 jobs:
@@ -57,36 +61,38 @@ jobs:
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE $HOME
           sudo rm -rf $GITHUB_WORKSPACE/* && echo "GITHUB_WORKSPACE removed" || { sleep 10 && sudo rm -rf $GITHUB_WORKSPACE/*; }
           sudo rm -f /tmp/kata_hybrid*  # Sometime we got leftover from test_setup_hvsock_failed()
-        if: ${{ inputs.instance != 'ubuntu-20.04' }}
+        if: ${{ inputs.instance != 'ubuntu-20.04' && inputs.skip != 'yes' }}
 
       - name: Checkout the code
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install yq
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./ci/install_yq.sh
         env:
           INSTALL_IN_GOPATH: false
       - name: Install golang
-        if: ${{ matrix.component == 'runtime' }}
+        if: ${{ matrix.component == 'runtime' && inputs.skip != 'yes' }}
         run: |
           ./tests/install_go.sh -f -p
           echo "/usr/local/go/bin" >> $GITHUB_PATH
       - name: Install rust
-        if: ${{ matrix.component != 'runtime' }}
+        if: ${{ matrix.component != 'runtime' && inputs.skip != 'yes' }}
         run: |
           ./tests/install_rust.sh
           echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
       - name: Install musl-tools
-        if: ${{ matrix.component != 'runtime' }}
+        if: ${{ matrix.component != 'runtime' && inputs.skip != 'yes' }}
         run: sudo apt-get -y install musl-tools
       - name: Install devicemapper
-        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
+        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' && inputs.skip != 'yes' }}
         run: sudo apt-get -y install libdevmapper-dev
       - name: Install libseccomp
-        if: ${{ matrix.command != 'make vendor'  &&  matrix.command != 'make check' &&  matrix.install-libseccomp == 'yes' }}
+        if: ${{ matrix.command != 'make vendor'  &&  matrix.command != 'make check' &&  matrix.install-libseccomp == 'yes' && inputs.skip != 'yes' }}
         run: |
           libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
           gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)
@@ -95,19 +101,23 @@ jobs:
           echo "LIBSECCOMP_LINK_TYPE=static" >> $GITHUB_ENV
           echo "LIBSECCOMP_LIB_PATH=${libseccomp_install_dir}/lib" >> $GITHUB_ENV
       - name: Install protobuf-compiler
-        if: ${{ matrix.command != 'make vendor' && (matrix.component == 'agent' || matrix.component == 'runk') }}
+        if: ${{ matrix.command != 'make vendor' && (matrix.component == 'agent' || matrix.component == 'runk') && inputs.skip != 'yes' }}
         run: sudo apt-get -y install protobuf-compiler
       - name: Install clang
-        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
+        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' && inputs.skip != 'yes' }}
         run: sudo apt-get -y install clang
       - name: Setup XDG_RUNTIME_DIR for the `runtime` tests
-        if: ${{ matrix.command != 'make vendor' && matrix.command != 'make check' && matrix.component == 'runtime' }}
+        if: ${{ matrix.command != 'make vendor' && matrix.command != 'make check' && matrix.component == 'runtime' && inputs.skip != 'yes' }}
         run: |
           XDG_RUNTIME_DIR=$(mktemp -d /tmp/kata-tests-$USER.XXX | tee >(xargs chmod 0700))
           echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" >> $GITHUB_ENV
       - name: Running `${{ matrix.command }}` for ${{ matrix.component }}
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           cd ${{ matrix.component-path }}
           ${{ matrix.command }}
         env:
           RUST_BACKTRACE: "1"
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   build-asset:
@@ -75,7 +79,7 @@ jobs:
             stage: release
     steps:
       - name: Login to Kata Containers quay.io
-        if: ${{ inputs.push-to-registry == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' && inputs.skip != 'yes' }}
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -83,17 +87,20 @@ jobs:
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Build ${{ matrix.asset }}
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
@@ -109,6 +116,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: store-artifact ${{ matrix.asset }}
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-amd64-${{ matrix.asset }}${{ inputs.tarball-suffix }}
@@ -116,15 +124,21 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
+
   create-kata-tarball:
     runs-on: ubuntu-latest
     needs: build-asset
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
@@ -136,12 +150,18 @@ jobs:
           path: kata-artifacts
           merge-multiple: true
       - name: merge-artifacts
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz
           retention-days: 15
           if-no-files-found: error
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   build-asset:
@@ -38,16 +42,19 @@ jobs:
           - ${{ inputs.stage }}
     steps:
       - name: Adjust a permission for repo
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
       - name: Prepare the self-hosted runner
+        if: ${{ inputs.skip != 'yes' }}
         run: |
             ${HOME}/scripts/prepare_runner.sh
             sudo rm -rf $GITHUB_WORKSPACE/*
 
 
       - name: Login to Kata Containers quay.io
+        if: ${{ inputs.skip != 'yes' }}
         if: ${{ inputs.push-to-registry == 'yes' }}
         uses: docker/login-action@v3
         with:
@@ -56,17 +63,20 @@ jobs:
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Build ${{ matrix.asset }}
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
@@ -83,6 +93,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: store-artifact ${{ matrix.asset }}
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-ppc64le-${{ matrix.asset }}${{ inputs.tarball-suffix }}
@@ -90,36 +101,48 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
+
   create-kata-tarball:
     runs-on: ppc64le
     needs: build-asset
     steps:
       - name: Adjust a permission for repo
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
       - name: get-artifacts
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           pattern: kata-artifacts-ppc64le-*${{ inputs.tarball-suffix }}
           path: kata-artifacts
-          merge-multiple: true
       - name: merge-artifacts
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz
           retention-days: 1
           if-no-files-found: error
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -20,6 +20,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   build-asset:
@@ -46,10 +50,11 @@ jobs:
             stage: release
     steps:
       - name: Take a pre-action for self-hosted runner
+        if: ${{ inputs.skip != 'yes' }}
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - name: Login to Kata Containers quay.io
-        if: ${{ inputs.push-to-registry == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' && inputs.skip != 'yes' }}
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -57,17 +62,20 @@ jobs:
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0 # This is needed in order to keep the commit ids history
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Build ${{ matrix.asset }}
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
@@ -84,6 +92,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: store-artifact ${{ matrix.asset }}
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-s390x-${{ matrix.asset }}${{ inputs.tarball-suffix }}
@@ -91,16 +100,23 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
+
   build-asset-boot-image-se:
     runs-on: s390x
     needs: build-asset
     steps:
       - name: Take a pre-action for self-hosted runner
+        if: ${{ inputs.skip != 'yes' }}
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
 
       - name: get-artifacts
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           pattern: kata-artifacts-s390x-*${{ inputs.tarball-suffix }}
@@ -108,6 +124,7 @@ jobs:
           merge-multiple: true
 
       - name: Place a host key document
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           mkdir -p "host-key-document"
           cp "${CI_HKD_PATH}" "host-key-document"
@@ -115,6 +132,7 @@ jobs:
           CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
 
       - name: Build boot-image-se
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           base_dir=tools/packaging/kata-deploy/local-build/
           cp -r kata-artifacts ${base_dir}/build
@@ -129,6 +147,7 @@ jobs:
           HKD_PATH: "host-key-document"
 
       - name: store-artifact boot-image-se
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-s390x${{ inputs.tarball-suffix }}
@@ -136,35 +155,49 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
+
   create-kata-tarball:
     runs-on: s390x
     needs: [build-asset, build-asset-boot-image-se]
     steps:
       - name: Take a pre-action for self-hosted runner
+        if: ${{ inputs.skip != 'yes' }}
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
       - name: get-artifacts
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           pattern: kata-artifacts-s390x-*${{ inputs.tarball-suffix }}
           path: kata-artifacts
           merge-multiple: true
       - name: merge-artifacts
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
       - name: store-artifacts
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
           path: kata-static.tar.xz
           retention-days: 15
           if-no-files-found: error
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,15 +17,63 @@ on:
         default: ""
 
 jobs:
+  skipper:
+    runs-on: ubuntu-latest
+    outputs:
+      skip_build: ${{ steps.skipper.outputs.skip_build }}
+      skip_test: ${{ steps.skipper.outputs.skip_test }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+      - id: skipper
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+        run: |
+          #!/bin/bash -x
+          # NOTE: keep ALL_SKIPS and skipper.outputs in sync
+          ALL_SKIPS=( skip_build skip_test )
+          DISABLE_SKIPS=()
+          CHANGED_FILES=$(git diff --name-only "origin/${TARGET_BRANCH}")
+          echo "$CHANGED_FILES"
+          echo
+
+          # ci/* doesn't require any tests, just remove them
+          CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '^ci/')
+          # **/*.{rst,md} file require only build
+          echo "$CHANGED_FILES" | grep -e '\.rst$' -e '\.md$' -q && DISABLE_SKIPS+=( skip_build ) && CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v -e '\.rst$' -e '\.md$')
+          # Add more rules here; don't forget to remove treated CHANGED_FILES
+
+          if [ -n "$CHANGED_FILES" ]; then
+            # Remaining utreated files, run all tests
+            for SKIP in "${ALL_SKIPS[@]}"; do
+              echo "$SKIP=no" >> "$GITHUB_OUTPUT"
+            done
+          else
+            # Set DISABLE_SKIPS to no (don't want to skip them)
+            for SKIP in "${DISABLE_SKIPS[@]}"; do
+              echo "$SKIP=no" >> "$GITHUB_OUTPUT"
+            done
+            # Now SKIP all untreated checks
+            for SKIP in "${ALL_SKIPS[@]}"; do
+              grep "^$SKIP=" "$GITHUB_OUTPUT" || echo "$SKIP=yes" >> "$GITHUB_OUTPUT"
+            done
+          fi
+          echo "GH OUTPUT"
+          cat "$GITHUB_OUTPUT"
+        shell: /usr/bin/bash {0}
   build-kata-static-tarball-amd64:
+    needs: skipper
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_build }}
 
   publish-kata-deploy-payload-amd64:
-    needs: build-kata-static-tarball-amd64
+    needs: [build-kata-static-tarball-amd64, skipper]
     uses: ./.github/workflows/publish-kata-deploy-payload-amd64.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -34,25 +82,30 @@ jobs:
       tag: ${{ inputs.tag }}-amd64
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_build }}
     secrets: inherit
 
   build-kata-static-tarball-s390x:
+    needs: skipper
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_build }}
     secrets: inherit
   
   build-kata-static-tarball-ppc64le:
+    needs: skipper
     uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_build }}
 
   publish-kata-deploy-payload-s390x:
-    needs: build-kata-static-tarball-s390x
+    needs: [skipper, build-kata-static-tarball-s390x]
     uses: ./.github/workflows/publish-kata-deploy-payload-s390x.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -61,10 +114,11 @@ jobs:
       tag: ${{ inputs.tag }}-s390x
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_build }}
     secrets: inherit
-  
+
   publish-kata-deploy-payload-ppc64le:
-    needs: build-kata-static-tarball-ppc64le
+    needs: [skipper, build-kata-static-tarball-ppc64le]
     uses: ./.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -73,30 +127,36 @@ jobs:
       tag: ${{ inputs.tag }}-ppc64le
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_build }}
     secrets: inherit
 
   build-and-publish-tee-confidential-unencrypted-image:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Set up QEMU
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Kata Containers ghcr.io
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -104,6 +164,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker build and push
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         uses: docker/build-push-action@v5
         with:
           tags: ghcr.io/kata-containers/test-images:unencrypted-${{ inputs.pr-number }}
@@ -112,8 +173,12 @@ jobs:
           platforms: linux/amd64, linux/s390x
           file: tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
 
+      - name: skip
+        if: ${{ needs.skipper.outputs.skip_build == 'yes' }}
+        run: echo "Skip this test"
+
   run-kata-deploy-tests-on-aks:
-    needs: publish-kata-deploy-payload-amd64
+    needs: [skipper, publish-kata-deploy-payload-amd64]
     uses: ./.github/workflows/run-kata-deploy-tests-on-aks.yaml
     with:
       registry: ghcr.io
@@ -122,10 +187,11 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
     secrets: inherit
 
   run-kata-deploy-tests-on-garm:
-    needs: publish-kata-deploy-payload-amd64
+    needs: [skipper, publish-kata-deploy-payload-amd64]
     uses: ./.github/workflows/run-kata-deploy-tests-on-garm.yaml
     with:
       registry: ghcr.io
@@ -134,18 +200,20 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
     secrets: inherit
 
   run-kata-monitor-tests:
-    needs: build-kata-static-tarball-amd64
+    needs: [skipper, build-kata-static-tarball-amd64]
     uses: ./.github/workflows/run-kata-monitor-tests.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
 
   run-k8s-tests-on-aks:
-    needs: publish-kata-deploy-payload-amd64
+    needs: [skipper, publish-kata-deploy-payload-amd64]
     uses: ./.github/workflows/run-k8s-tests-on-aks.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -155,10 +223,11 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
     secrets: inherit
 
   run-k8s-tests-on-garm:
-    needs: publish-kata-deploy-payload-amd64
+    needs: [skipper, publish-kata-deploy-payload-amd64]
     uses: ./.github/workflows/run-k8s-tests-on-garm.yaml
     with:
       registry: ghcr.io
@@ -167,10 +236,11 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
     secrets: inherit
 
   run-k8s-tests-with-crio-on-garm:
-    needs: publish-kata-deploy-payload-amd64
+    needs: [skipper, publish-kata-deploy-payload-amd64]
     uses: ./.github/workflows/run-k8s-tests-with-crio-on-garm.yaml
     with:
       registry: ghcr.io
@@ -179,10 +249,11 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
     secrets: inherit
 
   run-kata-coco-tests:
-    needs: [publish-kata-deploy-payload-amd64, build-and-publish-tee-confidential-unencrypted-image]
+    needs: [skipper, publish-kata-deploy-payload-amd64, build-and-publish-tee-confidential-unencrypted-image]
     uses: ./.github/workflows/run-kata-coco-tests.yaml
     with:
       registry: ghcr.io
@@ -191,9 +262,10 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
 
   run-k8s-tests-on-zvsi:
-    needs: [publish-kata-deploy-payload-s390x, build-and-publish-tee-confidential-unencrypted-image]
+    needs: [skipper, publish-kata-deploy-payload-s390x, build-and-publish-tee-confidential-unencrypted-image]
     uses: ./.github/workflows/run-k8s-tests-on-zvsi.yaml
     with:
       registry: ghcr.io
@@ -202,9 +274,10 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
-      
+      skip: ${{ needs.skipper.outputs.skip_test }}
+
   run-k8s-tests-on-ppc64le:
-    needs: publish-kata-deploy-payload-ppc64le
+    needs: [skipper, publish-kata-deploy-payload-ppc64le]
     uses: ./.github/workflows/run-k8s-tests-on-ppc64le.yaml
     with:
       registry: ghcr.io
@@ -213,35 +286,40 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
 
   run-metrics-tests:
-    needs: build-kata-static-tarball-amd64
+    needs: [skipper, build-kata-static-tarball-amd64]
     uses: ./.github/workflows/run-metrics.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
 
   run-basic-amd64-tests:
-    needs: build-kata-static-tarball-amd64
+    needs: [skipper, build-kata-static-tarball-amd64]
     uses: ./.github/workflows/basic-ci-amd64.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
 
   run-cri-containerd-tests-s390x:
-    needs: build-kata-static-tarball-s390x
+    needs: [skipper, build-kata-static-tarball-s390x]
     uses: ./.github/workflows/run-cri-containerd-tests-s390x.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}
 
   run-cri-containerd-tests-ppc64le:
-    needs: build-kata-static-tarball-ppc64le
+    needs: [skipper, build-kata-static-tarball-ppc64le]
     uses: ./.github/workflows/run-cri-containerd-tests-ppc64le.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
+      skip: ${{ needs.skipper.outputs.skip_test }}

--- a/.github/workflows/publish-kata-deploy-payload-amd64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-amd64.yaml
@@ -21,29 +21,36 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   kata-payload:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
 
       - name: Login to Kata Containers quay.io
-        if: ${{ inputs.registry == 'quay.io' }}
+        if: ${{ inputs.registry == 'quay.io' && inputs.skip != 'yes' }}
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -51,7 +58,7 @@ jobs:
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
       - name: Login to Kata Containers ghcr.io
-        if: ${{ inputs.registry == 'ghcr.io' }}
+        if: ${{ inputs.registry == 'ghcr.io' && inputs.skip != 'yes' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -59,8 +66,12 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build-and-push-kata-payload
+        if: ${{ inputs.skip != 'yes' }}
         id: build-and-push-kata-payload
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
           $(pwd)/kata-static.tar.xz \
           ${{ inputs.registry }}/${{ inputs.repo }} ${{ inputs.tag }}
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skipping this test"

--- a/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
@@ -21,38 +21,47 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   kata-payload:
     runs-on: ppc64le
     steps:
       - name: Prepare the self-hosted runner
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ${HOME}/scripts/prepare_runner.sh
           sudo rm -rf $GITHUB_WORKSPACE/*
 
       - name: Adjust a permission for repo
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
 
       - name: Login to Kata Containers quay.io
-        if: ${{ inputs.registry == 'quay.io' }}
+        if: ${{ inputs.registry == 'quay.io' && inputs.skip != 'yes' }}
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -60,7 +69,7 @@ jobs:
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
       - name: Login to Kata Containers ghcr.io
-        if: ${{ inputs.registry == 'ghcr.io' }}
+        if: ${{ inputs.registry == 'ghcr.io' && inputs.skip != 'yes' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -68,8 +77,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build-and-push-kata-payload
+        if: ${{ inputs.skip != 'yes' }}
         id: build-and-push-kata-payload
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
           $(pwd)/kata-static.tar.xz \
           ${{ inputs.registry }}/${{ inputs.repo }} ${{ inputs.tag }}
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -21,32 +21,40 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   kata-payload:
     runs-on: s390x
     steps:
       - name: Take a pre-action for self-hosted runner
+        if: ${{ inputs.skip != 'yes' }}
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
 
       - name: Login to Kata Containers quay.io
-        if: ${{ inputs.registry == 'quay.io' }}
+        if: ${{ inputs.registry == 'quay.io' && inputs.skip != 'yes' }}
         uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -54,7 +62,7 @@ jobs:
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
       - name: Login to Kata Containers ghcr.io
-        if: ${{ inputs.registry == 'ghcr.io' }}
+        if: ${{ inputs.registry == 'ghcr.io' && inputs.skip != 'yes' }}
         uses: docker/login-action@v3
         with:
           registry: ghcr.io
@@ -62,8 +70,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: build-and-push-kata-payload
+        if: ${{ inputs.skip != 'yes' }}
         id: build-and-push-kata-payload
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
           $(pwd)/kata-static.tar.xz \
           ${{ inputs.registry }}/${{ inputs.repo }} ${{ inputs.tag }}
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
+++ b/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-cri-containerd:
@@ -30,38 +34,51 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - name: Adjust a permission for repo
+        if: ${{ inputs.skip != 'yes' }}
         run: sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-  
+
       - name: Prepare the self-hosted runner
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           bash ${HOME}/scripts/prepare_runner.sh cri-containerd
           sudo rm -rf $GITHUB_WORKSPACE/*
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/cri-containerd/gha-run.sh install-kata kata-artifacts
 
       - name: Run cri-containerd tests
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/cri-containerd/gha-run.sh run
-      
+
       - name: Cleanup actions for the self hosted runner
+        if: ${{ inputs.skip != 'yes' }}
         run: ${HOME}/scripts/cleanup_runner.sh
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-cri-containerd-tests-s390x.yaml
+++ b/.github/workflows/run-cri-containerd-tests-s390x.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-cri-containerd:
@@ -29,35 +33,46 @@ jobs:
       GOPATH: ${{ github.workspace }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
+      if: ${{ inputs.skip != 'yes' }}
       - name: Take a pre-action for self-hosted runner
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-s390x${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/cri-containerd/gha-run.sh install-kata kata-artifacts
 
       - name: Run cri-containerd tests
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/cri-containerd/gha-run.sh run
 
       - name: Take a post-action for self-hosted runner
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: ${HOME}/script/post_action.sh ubuntu-2204
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -24,6 +24,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-k8s-tests:
@@ -71,29 +75,35 @@ jobs:
       GENPOLICY_PULL_METHOD: ${{ matrix.genpolicy-pull-method }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh install-kata-tools kata-artifacts
 
       - name: Download Azure CLI
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh install-azure-cli
 
       - name: Log into the Azure account
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh login-azure
         env:
           AZ_APPID: ${{ secrets.AZ_APPID }}
@@ -102,36 +112,46 @@ jobs:
           AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
 
       - name: Create AKS cluster
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh create-cluster
 
       - name: Install `bats`
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh install-bats
 
       - name: Install `kubectl`
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh install-kubectl
 
       - name: Download credentials for the Kubernetes CLI to use them
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh get-cluster-credentials
 
       - name: Deploy Kata
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-aks
 
       - name: Deploy CoCo KBS
-        if: env.KBS == 'true'
+        if: env.KBS == 'true' && ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
 
       - name: Install `kbs-client`
-        if: env.KBS == 'true'
+        if: env.KBS == 'true' && ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
 
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 60
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Delete AKS cluster
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh delete-cluster
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-k8s-tests-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-on-garm.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-k8s-tests:
@@ -58,37 +62,46 @@ jobs:
       K8S_TEST_HOST_TYPE: ${{ matrix.instance-type }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Deploy ${{ matrix.k8s }}
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh deploy-k8s
 
       - name: Configure the ${{ matrix.snapshotter }} snapshotter
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh configure-snapshotter
 
       - name: Deploy Kata
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-garm
 
       - name: Install `bats`
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh install-bats
   
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
   
       - name: Collect artifacts ${{ matrix.vmm }}
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh collect-artifacts
 
       - name: Archive artifacts ${{ matrix.vmm }}
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: k8s-tests-garm-${{ matrix.vmm }}-${{ matrix.snapshotter }}-${{ matrix.k8s }}-${{ matrix.instance }}-${{ inputs.tag }}
@@ -96,5 +109,9 @@ jobs:
           retention-days: 1
 
       - name: Delete kata-deploy
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-garm
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-k8s-tests-on-ppc64le.yaml
+++ b/.github/workflows/run-k8s-tests-on-ppc64le.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-k8s-tests:
@@ -44,39 +48,52 @@ jobs:
       TARGET_ARCH: "ppc64le"
     steps:
       - name: Prepare the self-hosted runner
-        run: | 
+        if: ${{ inputs.skip != 'yes' }}
+        run: |
           bash ${HOME}/scripts/prepare_runner.sh kubernetes
           sudo rm -rf $GITHUB_WORKSPACE/*
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install golang
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/install_go.sh -f -p
           echo "/usr/local/go/bin" >> $GITHUB_PATH
 
       - name: Prepare the runner for k8s cluster creation
+        if: ${{ inputs.skip != 'yes' }}
         run: bash ${HOME}/scripts/k8s_cluster_cleanup.sh
 
       - name: Create k8s cluster using kubeadm
+        if: ${{ inputs.skip != 'yes' }}
         run: bash ${HOME}/scripts/k8s_cluster_create.sh
 
       - name: Deploy Kata
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-kubeadm
 
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Delete cluster and post cleanup actions
+        if: ${{ inputs.skip != 'yes' }}
         run: bash ${HOME}/scripts/k8s_cluster_cleanup.sh
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-k8s-tests:
@@ -46,35 +50,46 @@ jobs:
       TARGET_ARCH: "s390x"
     steps:
       - name: Take a pre-action for self-hosted runner
+        if: ${{ inputs.skip != 'yes' }}
         run: ${HOME}/script/pre_action.sh ubuntu-2204
 
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Deploy ${{ matrix.k8s }}
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh deploy-k8s
 
       - name: Configure the ${{ matrix.snapshotter }} snapshotter
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh configure-snapshotter
 
       - name: Deploy Kata
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-zvsi
 
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Take a post-action
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: |
           bash tests/integration/kubernetes/gha-run.sh cleanup-zvsi || true
           ${HOME}/script/post_action.sh ubuntu-2204
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-k8s-tests-with-crio-on-garm.yaml
+++ b/.github/workflows/run-k8s-tests-with-crio-on-garm.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-k8s-tests:
@@ -54,33 +58,44 @@ jobs:
       K8S_TEST_HOST_TYPE: ${{ matrix.instance-type }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Configure CRI-O
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh setup-crio
 
       - name: Deploy ${{ matrix.k8s }}
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh deploy-k8s
 
       - name: Deploy Kata
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-garm
 
       - name: Install `bats`
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh install-bats
   
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
   
       - name: Delete kata-deploy
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-garm
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-k8s-tests-on-tdx:
@@ -47,35 +51,44 @@ jobs:
       PULL_TYPE: ${{ matrix.pull-type }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Deploy Snapshotter
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 5
         run: bash tests/integration/kubernetes/gha-run.sh deploy-snapshotter
 
       - name: Deploy Kata
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-tdx
 
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Delete kata-deploy
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-tdx
 
       - name: Delete Snapshotter
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-k8s-tests-on-sev:
     strategy:
@@ -102,35 +115,44 @@ jobs:
       PULL_TYPE: ${{ matrix.pull-type }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Deploy Snapshotter
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 5
         run: bash tests/integration/kubernetes/gha-run.sh deploy-snapshotter
 
       - name: Deploy Kata
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-sev
 
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Delete kata-deploy
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-sev
 
       - name: Delete Snapshotter
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-k8s-tests-sev-snp:
     strategy:
@@ -157,32 +179,41 @@ jobs:
       PULL_TYPE: ${{ matrix.pull-type }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Deploy Snapshotter
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 5
         run: bash tests/integration/kubernetes/gha-run.sh deploy-snapshotter
 
       - name: Deploy Kata
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-snp
 
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Delete kata-deploy
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snp
 
       - name: Delete Snapshotter
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-kata-deploy-tests-on-aks.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-aks.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-kata-deploy-tests:
@@ -48,20 +52,24 @@ jobs:
       USING_NFD: "false"
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Download Azure CLI
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-deploy/gha-run.sh install-azure-cli
 
       - name: Log into the Azure account
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-deploy/gha-run.sh login-azure
         env:
           AZ_APPID: ${{ secrets.AZ_APPID }}
@@ -70,21 +78,30 @@ jobs:
           AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
 
       - name: Create AKS cluster
+        if: ${{ inputs.skip != 'yes' }}
         timeout-minutes: 10
         run: bash tests/functional/kata-deploy/gha-run.sh create-cluster
 
       - name: Install `bats`
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-deploy/gha-run.sh install-bats
 
       - name: Install `kubectl`
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-deploy/gha-run.sh install-kubectl
 
       - name: Download credentials for the Kubernetes CLI to use them
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-deploy/gha-run.sh get-cluster-credentials
 
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-deploy/gha-run.sh run-tests
-      
+
       - name: Delete AKS cluster
-        if: always()
+        if: always() && ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-deploy/gha-run.sh delete-cluster
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-kata-deploy-tests-on-garm.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-garm.yaml
@@ -21,6 +21,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-kata-deploy-tests:
@@ -45,21 +49,30 @@ jobs:
       USING_NFD: "false"
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Deploy ${{ matrix.k8s }}
+        if: ${{ inputs.skip != 'yes' }}
         run:  bash tests/functional/kata-deploy/gha-run.sh deploy-k8s
 
       - name: Install `bats`
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-deploy/gha-run.sh install-bats
 
       - name: Run tests
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-deploy/gha-run.sh run-tests
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-kata-monitor-tests.yaml
+++ b/.github/workflows/run-kata-monitor-tests.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   run-monitor:
@@ -33,27 +37,37 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-monitor/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-monitor/gha-run.sh install-kata kata-artifacts
 
       - name: Run kata-monitor tests
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/functional/kata-monitor/gha-run.sh run
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/run-metrics.yaml
+++ b/.github/workflows/run-metrics.yaml
@@ -12,6 +12,10 @@ on:
         required: false
         type: string
         default: ""
+      skip:
+        required: false
+        type: string
+        default: no
 
 jobs:
   setup-kata:
@@ -21,24 +25,32 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - uses: actions/checkout@v4
+        if: ${{ inputs.skip != 'yes' }}
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
 
       - name: Rebase atop of the latest target branch
+        if: ${{ inputs.skip != 'yes' }}
         run: |
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: get-kata-tarball
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts
 
       - name: Install kata
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/metrics/gha-run.sh install-kata kata-artifacts
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"
 
   run-metrics:
     needs: setup-kata
@@ -56,39 +68,54 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
       - name: enabling the hypervisor
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/metrics/gha-run.sh enabling-hypervisor
 
       - name: run launch times test
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/metrics/gha-run.sh run-test-launchtimes
 
       - name: run memory foot print test
+        if: ${{ inputs.skip != 'yes' }}
         run:  bash tests/metrics/gha-run.sh run-test-memory-usage
 
       - name: run memory usage inside container test
+        if: ${{ inputs.skip != 'yes' }}
         run:  bash tests/metrics/gha-run.sh run-test-memory-usage-inside-container
 
       - name: run blogbench test
+        if: ${{ inputs.skip != 'yes' }}
         run:  bash tests/metrics/gha-run.sh run-test-blogbench
 
       - name: run tensorflow test
+        if: ${{ inputs.skip != 'yes' }}
         run:  bash tests/metrics/gha-run.sh run-test-tensorflow
 
       - name: run fio test
+        if: ${{ inputs.skip != 'yes' }}
         run:  bash tests/metrics/gha-run.sh run-test-fio
 
       - name: run iperf test
+        if: ${{ inputs.skip != 'yes' }}
         run:  bash tests/metrics/gha-run.sh run-test-iperf
 
       - name: run latency test
+        if: ${{ inputs.skip != 'yes' }}
         run:  bash tests/metrics/gha-run.sh run-test-latency
 
       - name: make metrics tarball ${{ matrix.vmm }}
+        if: ${{ inputs.skip != 'yes' }}
         run: bash tests/metrics/gha-run.sh make-tarball-results
 
       - name: archive metrics results ${{ matrix.vmm }}
+        if: ${{ inputs.skip != 'yes' }}
         uses: actions/upload-artifact@v4
         with:
           name: metrics-artifacts-${{ matrix.vmm }}
           path: results-${{ matrix.vmm }}.tar.gz
           retention-days: 1
           if-no-files-found: error
+
+      - name: skip
+        if: ${{ inputs.skip == 'yes' }}
+        run: echo "Skip this test"

--- a/.github/workflows/static-checks-self-hosted.yaml
+++ b/.github/workflows/static-checks-self-hosted.yaml
@@ -12,7 +12,57 @@ concurrency:
 
 name: Static checks self-hosted
 jobs:
+name: Static checks
+jobs:
+  skipper:
+    runs-on: ubuntu-latest
+    outputs:
+      skip_build: ${{ steps.skipper.outputs.skip_build }}
+      skip_test: ${{ steps.skipper.outputs.skip_test }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+      - id: skipper
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+        run: |
+          #!/bin/bash -x
+          # NOTE: keep ALL_SKIPS and skipper.outputs in sync
+          ALL_SKIPS=( skip_build skip_test )
+          DISABLE_SKIPS=()
+          CHANGED_FILES=$(git diff --name-only "origin/${TARGET_BRANCH}")
+          echo "$CHANGED_FILES"
+          echo
+
+          # ci/* doesn't require any tests, just remove them
+          CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '^ci/')
+          # **/*.{rst,md} file require only build
+          echo "$CHANGED_FILES" | grep -e '\.rst$' -e '\.md$' -q && DISABLE_SKIPS+=( skip_build ) && CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v -e '\.rst$' -e '\.md$')
+          # Add more rules here; don't forget to remove treated CHANGED_FILES
+
+          if [ -n "$CHANGED_FILES" ]; then
+            # Remaining utreated files, run all tests
+            for SKIP in "${ALL_SKIPS[@]}"; do
+              echo "$SKIP=no" >> "$GITHUB_OUTPUT"
+            done
+          else
+            # Set DISABLE_SKIPS to no (don't want to skip them)
+            for SKIP in "${DISABLE_SKIPS[@]}"; do
+              echo "$SKIP=no" >> "$GITHUB_OUTPUT"
+            done
+            # Now SKIP all untreated checks
+            for SKIP in "${ALL_SKIPS[@]}"; do
+              grep "^$SKIP=" "$GITHUB_OUTPUT" || echo "$SKIP=yes" >> "$GITHUB_OUTPUT"
+            done
+          fi
+          echo "GH OUTPUT"
+          cat "$GITHUB_OUTPUT"
+        shell: /usr/bin/bash {0}
+
   build-checks:
+    needs: skipper
     if: ${{ contains(github.event.pull_request.labels.*.name, 'ok-to-test') }}
     strategy:
       fail-fast: false
@@ -24,3 +74,4 @@ jobs:
     uses: ./.github/workflows/build-checks.yaml
     with:
       instance: ${{ matrix.instance }}
+      skip: ${{ needs.skipper.outputs.skip_build }}

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -12,14 +12,64 @@ concurrency:
 
 name: Static checks
 jobs:
+  skipper:
+    runs-on: ubuntu-latest
+    outputs:
+      skip_build: ${{ steps.skipper.outputs.skip_build }}
+      skip_test: ${{ steps.skipper.outputs.skip_test }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+      - id: skipper
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+        run: |
+          #!/bin/bash -x
+          # NOTE: keep ALL_SKIPS and skipper.outputs in sync
+          ALL_SKIPS=( skip_build skip_test )
+          DISABLE_SKIPS=()
+          CHANGED_FILES=$(git diff --name-only "origin/${TARGET_BRANCH}")
+          echo "$CHANGED_FILES"
+          echo
+
+          # ci/* doesn't require any tests, just remove them
+          CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v '^ci/')
+          # **/*.{rst,md} file require only build
+          echo "$CHANGED_FILES" | grep -e '\.rst$' -e '\.md$' -q && DISABLE_SKIPS+=( skip_build ) && CHANGED_FILES=$(echo "$CHANGED_FILES" | grep -v -e '\.rst$' -e '\.md$')
+          # Add more rules here; don't forget to remove treated CHANGED_FILES
+
+          if [ -n "$CHANGED_FILES" ]; then
+            # Remaining utreated files, run all tests
+            for SKIP in "${ALL_SKIPS[@]}"; do
+              echo "$SKIP=no" >> "$GITHUB_OUTPUT"
+            done
+          else
+            # Set DISABLE_SKIPS to no (don't want to skip them)
+            for SKIP in "${DISABLE_SKIPS[@]}"; do
+              echo "$SKIP=no" >> "$GITHUB_OUTPUT"
+            done
+            # Now SKIP all untreated checks
+            for SKIP in "${ALL_SKIPS[@]}"; do
+              grep "^$SKIP=" "$GITHUB_OUTPUT" || echo "$SKIP=yes" >> "$GITHUB_OUTPUT"
+            done
+          fi
+          echo "GH OUTPUT"
+          cat "$GITHUB_OUTPUT"
+        shell: /usr/bin/bash {0}
+
   check-kernel-config-version:
     runs-on: ubuntu-latest
+    needs: skipper
     steps:
       - name: Checkout the code
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Ensure the kernel config version has been updated
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           kernel_dir="tools/packaging/kernel/"
           kernel_version_file="${kernel_dir}kata_config_version"
@@ -34,10 +84,16 @@ jobs:
             echo "Check passed"
           fi
 
+      - name: skip
+        if: ${{ needs.skipper.outputs.skip_build == 'yes' }}
+        run: echo "Skip this test"
+
   build-checks:
+    needs: skipper
     uses: ./.github/workflows/build-checks.yaml
     with:
       instance: ubuntu-20.04
+      skip: ${{ needs.skipper.outputs.skip_build }}
 
   build-checks-depending-on-kvm:
     runs-on: garm-ubuntu-2004-smaller
@@ -53,28 +109,36 @@ jobs:
             component-path: src/dragonball
     steps:
       - name: Checkout the code
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - name: Install system deps
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           sudo apt-get install -y build-essential musl-tools
       - name: Install yq
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           sudo -E ./ci/install_yq.sh
         env:
           INSTALL_IN_GOPATH: false
       - name: Install rust
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           export PATH="$PATH:/usr/local/bin"
           ./tests/install_rust.sh
       - name: Running `${{ matrix.command }}` for ${{ matrix.component }}
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           export PATH="$PATH:${HOME}/.cargo/bin"
           cd ${{ matrix.component-path }}
           ${{ matrix.command }}
         env:
           RUST_BACKTRACE: "1"
+      - name: skip
+        if: ${{ needs.skipper.outputs.skip_build == 'yes' }}
+        run: echo "Skip this test"
 
   static-checks:
     runs-on: ubuntu-20.04
@@ -87,25 +151,33 @@ jobs:
       GOPATH: ${{ github.workspace }}
     steps:
       - name: Checkout code
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           path: ./src/github.com/${{ github.repository }}
       - name: Install yq
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           cd ${GOPATH}/src/github.com/${{ github.repository }}
           ./ci/install_yq.sh
         env:
           INSTALL_IN_GOPATH: false
       - name: Install golang
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           cd ${GOPATH}/src/github.com/${{ github.repository }}
           ./tests/install_go.sh -f -p
           echo "/usr/local/go/bin" >> $GITHUB_PATH
       - name: Install system dependencies
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           sudo apt-get -y install moreutils hunspell hunspell-en-gb hunspell-en-us pandoc
       - name: Run check
+        if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
         run: |
           export PATH=${PATH}:${GOPATH}/bin
           cd ${GOPATH}/src/github.com/${{ github.repository }} && ${{ matrix.cmd }}
+      - name: skip
+        if: ${{ needs.skipper.outputs.skip_build == 'yes' }}
+        run: echo "Skip this test"


### PR DESCRIPTION
to allow test selection while reporting status of all jobs let's add a "selector" job to check what subsystems were touched and then trigger all jobs using the subsystem-skips to either run the test or run a fake "skip" job. This way the (required) job reports status while not utilizing the workers (that much).

Fixes: #9237

I have tested this approach on (simplified) repo here: https://github.com/ldoktor/gh-actions-test

you can see 3 examples

* https://github.com/ldoktor/gh-actions-test/pull/2
* https://github.com/ldoktor/gh-actions-test/pull/3
* https://github.com/ldoktor/gh-actions-test/pull/4

Consider this dirty PoC to discuss whether such approach would be acceptable.

**NOTE: It still uses the target runners, which is something I will need to take care of. Still the current version should be sufficient to start the discussion. Example with skipped build checks is available here: https://github.com/ldoktor/kata-containers/pull/2 - https://github.com/ldoktor/kata-containers/actions/runs/8616244995/job/23613454144?pr=2**