### PR TITLE
gha: Add support to install KBS to k8s TDX GHA workflow

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -42,7 +42,9 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
       KUBERNETES: "k3s"
       USING_NFD: "true"
+      KBS: "true"
       K8S_TEST_HOST_TYPE: "baremetal"
+      KBS_INGRESS: "nodeport"
       SNAPSHOTTER: ${{ matrix.snapshotter }}
       PULL_TYPE: ${{ matrix.pull-type }}
     steps:
@@ -65,6 +67,14 @@ jobs:
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-tdx
 
+      - name: Deploy CoCo KBS
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
+
+      - name: Install `kbs-client`
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
+
       - name: Run tests
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
@@ -76,6 +86,10 @@ jobs:
       - name: Delete Snapshotter
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
+
+      - name: Delete CoCo KBS
+        if: always()
+        run: bash tests/integration/kubernetes/gha-run.sh delete-coco-kbs
 
   run-k8s-tests-on-sev:
     strategy:

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -67,6 +67,10 @@ jobs:
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-tdx
 
+      - name: Uninstall previous `kbs-client`
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh uninstall-kbs-client
+
       - name: Deploy CoCo KBS
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -131,7 +131,12 @@ function configure_snapshotter() {
 }
 
 function delete_coco_kbs() {
-	kbs_k8s_delete
+	if [ "${KATA_HYPERVISOR}" == "qemu-tdx" ]; then
+		echo "Skipping deleting coco kbs for ${KATA_HYPERVISOR}"
+		exit 0
+	else
+		kbs_k8s_delete
+	fi
 }
 
 # Deploy the CoCo KBS in Kubernetes
@@ -141,7 +146,12 @@ function delete_coco_kbs() {
 #	              service externally
 #
 function deploy_coco_kbs() {
-	kbs_k8s_deploy "$KBS_INGRESS"
+	if [ "${KATA_HYPERVISOR}" == "qemu-tdx" ]; then
+		echo "Skipping deploying coco kbs for ${KATA_HYPERVISOR}"
+		exit 0
+	else
+		kbs_k8s_deploy "$KBS_INGRESS"
+	fi
 }
 
 function deploy_kata() {
@@ -263,11 +273,21 @@ function deploy_kata() {
 }
 
 function install_kbs_client() {
-	kbs_install_cli
+	if [ "${KATA_HYPERVISOR}" == "qemu-tdx" ]; then
+		echo "Skipping install kbs client for ${KATA_HYPERVISOR}"
+		exit 0
+	else
+		kbs_install_cli
+	fi
 }
 
 function uninstall_kbs_client() {
-	kbs_uninstall_cli
+	if [ "${KATA_HYPERVISOR}" == "qemu-tdx" ]; then
+		echo "Skipping uninstall kbs client for ${KATA_HYPERVISOR}"
+		exit 0
+	else
+		kbs_uninstall_cli
+	fi
 }
 
 function run_tests() {

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -266,6 +266,10 @@ function install_kbs_client() {
 	kbs_install_cli
 }
 
+function uninstall_kbs_client() {
+	kbs_uninstall_cli
+}
+
 function run_tests() {
 	ensure_yq
 	platform="${1:-}"
@@ -594,6 +598,7 @@ function main() {
 		delete-coco-kbs) delete_coco_kbs ;;
 		delete-cluster) cleanup "aks" ;;
 		delete-cluster-kcli) delete_cluster_kcli ;;
+		uninstall-kbs-client) uninstall_kbs_client ;;
 		*) >&2 echo "Invalid argument"; exit 2 ;;
 	esac
 }


### PR DESCRIPTION
This PR adds support to install KBS to k8s TDX GHA workflow in order to run confidential attestation tests.

Fixes #9451