### PR TITLE
tests/k8s: Add uninstall kbs client command function

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -151,6 +151,12 @@ kbs_install_cli() {
 	popd
 }
 
+kbs_uninstall_cli() {
+	pushd "${COCO_KBS_DIR}"
+	sudo make uninstall
+	popd
+}
+
 # Delete the kbs on Kubernetes
 #
 # Note: assume the kbs sources were cloned to $COCO_TRUSTEE_DIR


### PR DESCRIPTION
This PR adds the function to uninstall kbs client command function specially when we are running with baremetal devices.

Fixes #9460