### PR TITLE
version: Add coco name and version for {image,initrd} for s390x

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -129,6 +129,9 @@ assets:
       s390x:
         name: *default-image-name
         version: *default-image-version
+        confidential:
+          name: *default-image-name
+          version: *default-image-version
       x86_64:
         name: *default-image-name
         version: *default-image-version
@@ -155,6 +158,9 @@ assets:
       s390x:
         name: *glibc-initrd-name
         version: *glibc-initrd-version
+        confidential:
+          name: *glibc-initrd-name
+          version: *glibc-initrd-version
       x86_64:
         name: *default-initrd-name
         version: *default-initrd-version


### PR DESCRIPTION
In order to build a coco {image,initrd}, it is required to specify its name and version in versions.yaml. This commit is to add the configuration for them, respectively.

Fixes: #9470

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>