### PR TITLE
version: add initrd, image NVIDIA sections

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -123,6 +123,12 @@ assets:
       aarch64:
         name: &default-image-name "ubuntu"
         version: &default-image-version "latest"
+        nvidia-gpu:
+          name: *default-image-name
+          version: "jammy"
+        nvidia-gpu-confidential:
+          name: *default-image-name
+          version: "jammy"
       ppc64le:
         name: *default-image-name
         version: *default-image-version
@@ -135,6 +141,13 @@ assets:
         confidential:
           name: *default-image-name
           version: *default-image-version
+        nvidia-gpu:
+          name: *default-image-name
+          version: "jammy"
+        nvidia-gpu-confidential:
+          name: *default-image-name
+          version: "jammy"
+
     meta:
       image-type: *default-image-name
 
@@ -147,6 +160,12 @@ assets:
       aarch64:
         name: &default-initrd-name "alpine"
         version: &default-initrd-version "3.18"
+        nvidia-gpu:
+          name: "ubuntu"
+          version: "jammy"
+        nvidia-gpu-confidential:
+          name: "ubuntu"
+          version: "jammy"
       # Do not use Alpine on ppc64le & s390x, the agent cannot use musl because
       # there is no such Rust target
       ppc64le:
@@ -164,6 +183,12 @@ assets:
         mariner:
           name: "cbl-mariner"
           version: "2.0"
+        nvidia-gpu:
+          name: *glibc-initrd-name
+          version: "jammy"
+        nvidia-gpu-confidential:
+          name: *glibc-initrd-name
+          version: "jammy"
 
   kernel:
     description: "Linux kernel optimised for virtual machines"


### PR DESCRIPTION
Fixes: #9472

For initrd and image, the related NVIDIA will not use the default targets and we will pin them to a specific release.