### PR TITLE
gha: make run-kata-coco-tests inherit secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,7 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
+    secrets: inherit
 
   run-k8s-tests-on-zvsi:
     needs: [publish-kata-deploy-payload-s390x, build-and-publish-tee-confidential-unencrypted-image]


### PR DESCRIPTION
The new CoCo non-tee job introduced on commit 0d5399ba923a17f need to read secrets like AZ_TENANT_ID, so run-kata-coco-tests workflow should inherit the secrets from the caller workflow.

Fixes #9477
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>