### PR TITLE
image: Add suffix to image or initrd depending on the NVIDIA driver version

### DIFF
--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -37,6 +37,7 @@ build_initrd() {
 	info "initrd os: $os_name"
 	info "initrd os version: $os_version"
 	make initrd \
+		VARIANT="${image_initrd_suffix}" \
 		DISTRO="$os_name" \
 		DEBUG="${DEBUG:-}" \
 		OS_VERSION="${os_version}" \
@@ -49,7 +50,7 @@ build_initrd() {
 		COCO_GUEST_COMPONENTS_TARBALL="${COCO_GUEST_COMPONENTS_TARBALL:-}" \
 		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}"
 
-	if [[ "$artifact_name" == *"nvidia-gpu"* ]]; then
+	if [[ "${image_initrd_suffix}" == "nvidia-gpu"* ]]; then
 		nvidia_driver_version=$(cat "${builddir}"/initrd-image/*/nvidia_driver_version)
 		artifact_name=${artifact_name/.initrd/"-${nvidia_driver_version}".initrd}
 	fi
@@ -66,6 +67,7 @@ build_image() {
 	info "image os: $os_name"
 	info "image os version: $os_version"
 	make image \
+		VARIANT="${image_initrd_suffix}" \
 		DISTRO="${os_name}" \
 		DEBUG="${DEBUG:-}" \
 		USE_DOCKER="1" \
@@ -77,9 +79,9 @@ build_image() {
 		COCO_GUEST_COMPONENTS_TARBALL="${COCO_GUEST_COMPONENTS_TARBALL:-}" \
 		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}"
 
-	if [[ "$artifact_name" == *"nvidia-gpu"* ]]; then
+	if [[ "${image_initrd_suffix}" == "nvidia-gpu"* ]]; then
 		nvidia_driver_version=$(cat "${builddir}"/rootfs-image/*/nvidia_driver_version)
-		artifact_name=${artifact_name/.img/"-${nvidia_driver_version}".img}
+		artifact_name=${artifact_name/.image/"-${nvidia_driver_version}".image}
 	fi
 
 	mv -f "kata-containers.img" "${install_dir}/${artifact_name}"

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -48,6 +48,12 @@ build_initrd() {
 		PULL_TYPE="${PULL_TYPE:-default}" \
 		COCO_GUEST_COMPONENTS_TARBALL="${COCO_GUEST_COMPONENTS_TARBALL:-}" \
 		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}"
+
+	if [[ "$artifact_name" == *"nvidia-gpu"* ]]; then
+		nvidia_driver_version=$(cat "${builddir}"/initrd-image/*/nvidia_driver_version)
+		artifact_name=${artifact_name/.initrd/"-${nvidia_driver_version}".initrd}
+	fi
+
 	mv "kata-containers-initrd.img" "${install_dir}/${artifact_name}"
 	(
 		cd "${install_dir}"
@@ -70,6 +76,12 @@ build_image() {
 		PULL_TYPE="${PULL_TYPE:-default}" \
 		COCO_GUEST_COMPONENTS_TARBALL="${COCO_GUEST_COMPONENTS_TARBALL:-}" \
 		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}"
+
+	if [[ "$artifact_name" == *"nvidia-gpu"* ]]; then
+		nvidia_driver_version=$(cat "${builddir}"/rootfs-image/*/nvidia_driver_version)
+		artifact_name=${artifact_name/.img/"-${nvidia_driver_version}".img}
+	fi
+
 	mv -f "kata-containers.img" "${install_dir}/${artifact_name}"
 	if [ -e "root_hash.txt" ]; then
 	    cp root_hash.txt "${install_dir}/"

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -54,7 +54,7 @@ build_initrd() {
 		artifact_name=${artifact_name/.initrd/"-${nvidia_driver_version}".initrd}
 	fi
 
-	mv "kata-containers-initrd.img" "${install_dir}/${artifact_name}"
+	mv -f "kata-containers-initrd.img" "${install_dir}/${artifact_name}"
 	(
 		cd "${install_dir}"
 		ln -sf "${artifact_name}" "${final_artifact_name}${image_initrd_extension}"


### PR DESCRIPTION
Add suffix to image or initrd depending on the NVIDIA driver version 

Fixes: #9478

We want to keep track of the driver versions build during initrd/image build so update the artifact_name after the fact.