### PR TITLE
rootfs: Make OPA build working in docker for s390x and pp…

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -553,10 +553,9 @@ build_opa_from_source()
 	local opa_repo_url=$1
 	opa_version="$(get_package_version_from_kata_yaml externals.open-policy-agent.version)"
 
-	if [ ${CROSS_BUILD} == "yes" ]; then
-		export GOOS="${TARGET_OS}"
-		export GOARCH="${TARGET_ARCH}}"
-	fi
+	export PATH="$PATH:/usr/local/go/bin"
+	export GOOS="${TARGET_OS}"
+	[ ${CROSS_BUILD} == "yes" ] && export GOARCH="${TARGET_ARCH}" || export GOARCH="$(uname -m)"
 
 	current_dir="$(pwd)"
 	pushd $(mktemp -d) &>/dev/null
@@ -565,7 +564,7 @@ build_opa_from_source()
 		cd opa
 		export WASM_ENABLED=0
 		export DOCKER_RUNNING=0
-		make ci-go-ci-build-linux-static || return 1
+		make ci-build-linux-static || return 1
 
 		info "Copy OPA binary to ${current_dir}/opa"
 		binary_name="_release/${opa_version##v}/opa_${GOOS}_${GOARCH}_static"

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -6,6 +6,7 @@ ARG IMAGE_REGISTRY=docker.io
 FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@
 @SET_PROXY@
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # makedev tries to mknod from postinst
 RUN [ -x /usr/bin/systemd-detect-virt ] || ( echo "echo docker" >/usr/bin/systemd-detect-virt && chmod +x /usr/bin/systemd-detect-virt )
 # hadolint ignore=DL3009,SC2046
@@ -29,7 +30,9 @@ RUN apt-get update && \
     multistrap \
     musl-tools \
     protobuf-compiler \
-    xz-utils
+    xz-utils && \
+    ( go_version="@GO_VERSION@" && [ "${go_version}" = "" ] || ( \
+    echo "Installing go @GO_VERSION@" && curl -sSL "https://golang.org/dl/go@GO_VERSION@.linux-@ARCH@.tar.gz" | tar -xz -C /usr/local ))
 # aarch64 requires this name -- link for all
 RUN if [ ! -f "/usr/bin/$(uname -m)-linux-musl-gcc" ]; then ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"; fi
 

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -237,6 +237,7 @@ RUN . /root/.cargo/env; cargo install cargo-when
 	sed \
 		-e "s#@OS_VERSION@#${OS_VERSION:-}#g" \
 		-e "s#@ARCH@#$ARCH#g" \
+		-e "s#@GO_VERSION@#$GO_VERSION#g" \
 		-e "s#@INSTALL_RUST@#${install_rust//$'\n'/\\n}#g" \
 		-e "s#@SET_PROXY@#${set_proxy:-}#g" \
 		Dockerfile.in > Dockerfile

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -47,7 +47,8 @@ build_initrd() {
 		AGENT_POLICY="${AGENT_POLICY:-}" \
 		PULL_TYPE="${PULL_TYPE:-default}" \
 		COCO_GUEST_COMPONENTS_TARBALL="${COCO_GUEST_COMPONENTS_TARBALL:-}" \
-		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}"
+		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}" \
+		GO_VERSION="${GO_VERSION:-}"
 	mv "kata-containers-initrd.img" "${install_dir}/${artifact_name}"
 	(
 		cd "${install_dir}"
@@ -69,7 +70,8 @@ build_image() {
 		AGENT_POLICY="${AGENT_POLICY:-}" \
 		PULL_TYPE="${PULL_TYPE:-default}" \
 		COCO_GUEST_COMPONENTS_TARBALL="${COCO_GUEST_COMPONENTS_TARBALL:-}" \
-		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}"
+		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}" \
+		GO_VERSION="${GO_VERSION:-}"
 	mv -f "kata-containers.img" "${install_dir}/${artifact_name}"
 	if [ -e "root_hash.txt" ]; then
 	    cp root_hash.txt "${install_dir}/"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -315,6 +315,11 @@ install_image() {
 		if [ "${variant}" == "confidential" ]; then
 			export COCO_GUEST_COMPONENTS_TARBALL="$(get_coco_guest_components_tarball_path)"
 			export PAUSE_IMAGE_TARBALL="$(get_pause_image_tarball_path)"
+			# GO_VERSION should be exported to install the package in ubuntu-rootfs-osbuilder
+			# This is necessary for installing opa from the source for s390x and ppc64le
+			if [ "${AGENT_POLICY}" == "yes" ] && [ "${ARCH}" == "s390x" -o "${ARCH}" == "ppc64le" ]; then
+				export GO_VERSION=$(get_from_kata_deps "languages.golang.meta.newest-version")
+			fi
 		fi
 	else
 		os_name="$(get_from_kata_deps "assets.image.architecture.${ARCH}.name")"
@@ -384,6 +389,11 @@ install_initrd() {
 		if [ "${variant}" == "confidential" ]; then
 			export COCO_GUEST_COMPONENTS_TARBALL="$(get_coco_guest_components_tarball_path)"
 			export PAUSE_IMAGE_TARBALL="$(get_pause_image_tarball_path)"
+			# GO_VERSION should be exported to install the package in ubuntu-rootfs-osbuilder
+			# This is necessary for installing opa from the source for s390x and ppc64le
+			if [ "${AGENT_POLICY}" == "yes" ] && [ "${ARCH}" == "s390x" -o "${ARCH}" == "ppc64le" ]; then
+				export GO_VERSION=$(get_from_kata_deps "languages.golang.meta.newest-version")
+			fi
 		fi
 	else
 		os_name="$(get_from_kata_deps "assets.initrd.architecture.${ARCH}.name")"


### PR DESCRIPTION
The PR is to make the OPA build from source working in a docker builder `ubuntu-rootfs-osbuilder`. 
To achieve the goal, the configuration is changed as follows:

- Switch the make target to `ci-build-linux-static` not triggering docker-in-docker build
- Install go in the builder image for s390x and ppc64le

Fixes: #9466

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>