### PR TITLE
gha: move attestation tests to run-k8s-tests-coco-nontee

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -61,10 +61,6 @@ jobs:
       GH_PR_NUMBER: ${{ inputs.pr-number }}
       KATA_HOST_OS: ${{ matrix.host_os }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
-      # Set to install the KBS for attestation tests
-      KBS: ${{ (matrix.vmm == 'qemu' && matrix.host_os == 'ubuntu') && 'true' || 'false' }}
-      # Set the KBS ingress handler (empty string disables handling)
-      KBS_INGRESS: "aks"
       KUBERNETES: "vanilla"
       USING_NFD: "false"
       K8S_TEST_HOST_TYPE: ${{ matrix.instance-type }}
@@ -117,16 +113,6 @@ jobs:
       - name: Deploy Kata
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-aks
-
-      - name: Deploy CoCo KBS
-        if: env.KBS == 'true'
-        timeout-minutes: 10
-        run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
-
-      - name: Install `kbs-client`
-        if: env.KBS == 'true'
-        timeout-minutes: 10
-        run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
 
       - name: Run tests
         timeout-minutes: 60

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -206,6 +206,10 @@ jobs:
       GH_PR_NUMBER: ${{ inputs.pr-number }}
       KATA_HOST_OS: ${{ matrix.host_os }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
+      # Some tests rely on that variable to run (or not)
+      KBS: "true"
+      # Set the KBS ingress handler (empty string disables handling)
+      KBS_INGRESS: "aks"
       KUBERNETES: "vanilla"
       PULL_TYPE: ${{ matrix.pull-type }}
       SNAPSHOTTER: ${{ matrix.snapshotter }}
@@ -253,6 +257,14 @@ jobs:
       - name: Deploy Kata
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-aks
+
+      - name: Deploy CoCo KBS
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
+
+      - name: Install `kbs-client`
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
 
       - name: Run tests
         timeout-minutes: 60


### PR DESCRIPTION
The new run-k8s-tests-coco-nontee job should be the home of attestation tests.

Changed run-k8s-tests-coco-nontee to get KBS installed and by the time the KBS variable is exported in the environment then the attestation tests will kick in (likewise they will skip in run-k8s-tests-on-aks).

Fixes #9455
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>