### PR TITLE
CC: Enable guest-pull tests on non-TEE for s390x

### DIFF
--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -31,10 +31,13 @@ jobs:
           - agent-opa
           - coco-guest-components
           - kernel
+          - kernel-confidential
           - pause-image
           - qemu
           - rootfs-image
+          - rootfs-image-confidential
           - rootfs-initrd
+          - rootfs-initrd-confidential
           - shim-v2
           - virtiofsd
         stage:

--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -31,18 +31,31 @@ jobs:
           - qemu
         snapshotter:
           - devmapper
+          - nydus
         k8s:
           - k3s
+        include:
+          - snapshotter: devmapper
+            pull-type: default
+            using-nfd: true
+            deploy-cmd: configure-snapshotter
+          - snapshotter: nydus
+            pull-type: guest-pull
+            using-nfd: false
+            deploy-cmd: deploy-snapshotter
     runs-on: s390x-large
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}
       DOCKER_TAG: ${{ inputs.tag }}
       PR_NUMBER: ${{ inputs.pr-number }}
+      GH_PR_NUMBER: ${{ inputs.pr-number }}
+      KATA_HOST_OS: "ubuntu"
       KATA_HYPERVISOR: ${{ matrix.vmm }}
       KUBERNETES: "k3s"
+      PULL_TYPE: ${{ matrix.pull-type }}
       SNAPSHOTTER: ${{ matrix.snapshotter }}
-      USING_NFD: "true"
+      USING_NFD: ${{ matrix.using-nfd }}
       TARGET_ARCH: "s390x"
     steps:
       - name: Take a pre-action for self-hosted runner
@@ -63,14 +76,14 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh deploy-k8s
 
       - name: Configure the ${{ matrix.snapshotter }} snapshotter
-        run: bash tests/integration/kubernetes/gha-run.sh configure-snapshotter
+        run: bash tests/integration/kubernetes/gha-run.sh ${{ matrix.deploy-cmd }}
 
       - name: Deploy Kata
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-zvsi
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Take a post-action

--- a/docs/how-to/how-to-run-kata-containers-with-SE-VMs.md
+++ b/docs/how-to/how-to-run-kata-containers-with-SE-VMs.md
@@ -62,17 +62,25 @@ $ export PATH="$PATH:/opt/kata/bin"
 $ ls -1 $(dirname $(kata-runtime env --json | jq -r '.Kernel.Path'))
 config-6.1.62-121
 kata-containers.img
+kata-containers-confidential.img
 kata-containers-initrd.img
+kata-containers-initrd-confidential.img
 kata-ubuntu-20.04.initrd
+kata-ubuntu-20.04-confidential.initrd
 kata-ubuntu-latest.image
+kata-ubuntu-latest-confidential.image
 vmlinux-6.1.62-121
+vmlinux-6.1.62-121-confidential
 vmlinux.container
+vmlinux-confidential.container
 vmlinuz-6.1.62-121
+vmlinuz-6.1.62-121-confidential
 vmlinuz.container
+vmlinuz-confidential.container
 ```
 
-The output indicates the deployment of the kernel (`vmlinux-6.1.62-121`, though the version
-may vary at the time of testing), rootfs-image (`kata-ubuntu-latest.image`), and rootfs-initrd (`kata-ubuntu-20.04.initrd`).
+The output indicates the deployment of the kernel (`vmlinux-6.1.62-121-confidential`, though the version
+may vary at the time of testing), rootfs-image (`kata-ubuntu-latest-confidential.image`), and rootfs-initrd (`kata-ubuntu-20.04-confidential.initrd`).
 In this scenario, the available kernel and initrd can be utilized for a secure image.
 However, if any of these components are absent, they must be built from the
 [project source](https://github.com/kata-containers/kata-containers) as follows:
@@ -80,19 +88,19 @@ However, if any of these components are absent, they must be built from the
 ```
 $ # Assume that the project is cloned at $GOPATH/src/github.com/kata-containers
 $ cd $GOPATH/src/github.com/kata-containers/kata-containers
-$ sudo -E PATH=$PATH make kernel-tarball
-$ sudo -E PATH=$PATH make rootfs-initrd-tarball
-$ tar -tf build/kata-static-kernel.tar.xz | grep vmlinuz
-./opt/kata/share/kata-containers/vmlinuz.container
-./opt/kata/share/kata-containers/vmlinuz-6.1.62-121
-$ tar -tf build/kata-static-rootfs-initrd.tar.xz | grep initrd
-./opt/kata/share/kata-containers/kata-containers-initrd.img
-./opt/kata/share/kata-containers/kata-ubuntu-20.04.initrd
+$ sudo -E PATH=$PATH make kernel-confidential-tarball
+$ sudo -E PATH=$PATH make rootfs-initrd-confidential-tarball
+$ tar -tf build/kata-static-kernel-confidential.tar.xz | grep vmlinuz
+./opt/kata/share/kata-containers/vmlinuz-confidential.container
+./opt/kata/share/kata-containers/vmlinuz-6.1.62-121-confidential
+$ tar -tf build/kata-static-rootfs-initrd-confidential.tar.xz | grep initrd
+./opt/kata/share/kata-containers/kata-containers-initrd-confidential.img
+./opt/kata/share/kata-containers/kata-ubuntu-20.04-confidential.initrd
 $ mkdir artifacts
-$ tar -xvf build/kata-static-kernel.tar.xz -C artifacts ./opt/kata/share/kata-containers/vmlinuz-6.1.62-121
-$ tar -xvf build/kata-static-rootfs-initrd.tar.xz -C artifacts ./opt/kata/share/kata-containers/kata-ubuntu-20.04.initrd
+$ tar -xvf build/kata-static-kernel-confidential.tar.xz -C artifacts ./opt/kata/share/kata-containers/vmlinuz-6.1.62-121-confidential
+$ tar -xvf build/kata-static-rootfs-initrd-confidential.tar.xz -C artifacts ./opt/kata/share/kata-containers/kata-ubuntu-20.04-confidential.initrd
 $ ls artifacts/opt/kata/share/kata-containers/
-kata-ubuntu-20.04.initrd  vmlinuz-6.1.62-121
+kata-ubuntu-20.04-confidential.initrd  vmlinuz-6.1.62-121-confidential
 ```
 
 3. Secure Image Generation Tool
@@ -131,7 +139,6 @@ These files will be used for verification during secure image construction in th
 
 ### Build a Secure Image
 
-
 Assuming you have placed a host key document at `$HOME/host-key-document`:
 
 - Host key document as `HKD-0000-0000000.crt`
@@ -147,8 +154,8 @@ you can construct a secure image using the following procedure:
 $ # Change a directory to the project root
 $ cd $GOPATH/src/github.com/kata-containers/kata-containers
 $ host_key_document=$HOME/host-key-document/HKD-0000-0000000.crt
-$ kernel_image=artifacts/opt/kata/share/kata-containers/vmlinuz-6.1.62-121
-$ initrd_image=artifacts/opt/kata/share/kata-containers/kata-ubuntu-20.04.initrd
+$ kernel_image=artifacts/opt/kata/share/kata-containers/vmlinuz-6.1.62-121-confidential
+$ initrd_image=artifacts/opt/kata/share/kata-containers/kata-ubuntu-20.04-confidential.initrd
 $ echo "panic=1 scsi_mod.scan=none swiotlb=262144 agent.log=debug" > parmfile
 $ genprotimg --host-key-document=${host_key_document} \
 --output=kata-containers-se.img --image=${kernel_image} --ramdisk=${initrd_image} \
@@ -319,7 +326,7 @@ for confidential containers.
 $ cd $GOPATH/src/github.com/kata-containers/kata-containers
 $ host_key_document=$HOME/host-key-document/HKD-0000-0000000.crt
 $ mkdir hkd_dir && cp $host_key_document hkd_dir
-$ # kernel and rootfs-initrd are built automactially by the command below
+$ # kernel-confidential and rootfs-initrd-confidential are built automactially by the command below
 $ sudo -E PATH=$PATH HKD_PATH=hkd_dir SE_KERNEL_PARAMS="agent.log=debug" \
 make boot-image-se-tarball
 $ sudo -E PATH=$PATH make qemu-tarball
@@ -330,10 +337,13 @@ $ mkdir kata-artifacts
 $ build_dir=$(readlink -f build)
 $ cp -r $build_dir/*.tar.xz kata-artifacts
 $ ls -1 kata-artifacts
+kata-static-agent-opa.tar.xz
 kata-static-boot-image-se.tar.xz
-kata-static-kernel.tar.xz
+kata-static-coco-guest-components.tar.xz
+kata-static-kernel-confidential.tar.xz
+kata-static-pause-image.tar.xz
 kata-static-qemu.tar.xz
-kata-static-rootfs-initrd.tar.xz
+kata-static-rootfs-initrd-confidential.tar.xz
 kata-static-shim-v2.tar.xz
 kata-static-virtiofsd.tar.xz
 $ ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts

--- a/tools/packaging/guest-image/build_se_image.sh
+++ b/tools/packaging/guest-image/build_se_image.sh
@@ -75,12 +75,12 @@ build_secure_image() {
 		fi
 	fi
 
-	if [ ! -f "${install_src_dir}/vmlinuz.container" ] ||
-		[ ! -f "${install_src_dir}/kata-containers-initrd.img" ]; then
+	if [ ! -f "${install_src_dir}/vmlinuz-confidential.container" ] ||
+		[ ! -f "${install_src_dir}/kata-containers-initrd-confidential.img" ]; then
 		cat << EOF >&2
 Either kernel or initrd does not exist or is mistakenly named
-A file name for kernel must be vmlinuz.container (raw binary)
-A file name for initrd must be kata-containers-initrd.img
+A file name for kernel must be vmlinuz-confidential.container (raw binary)
+A file name for initrd must be kata-containers-initrd-confidential.img
 EOF
 		return 1
 	fi
@@ -108,8 +108,8 @@ EOF
 		"${extra_arguments}" \
 		"${hkd_options}" \
 		--output="${install_dest_dir}/kata-containers-se.img" \
-		--image="${install_src_dir}/vmlinuz.container" \
-		--ramdisk="${install_src_dir}/kata-containers-initrd.img" \
+		--image="${install_src_dir}/vmlinuz-confidential.container" \
+		--ramdisk="${install_src_dir}/kata-containers-initrd-confidential.img" \
 		--parmfile="${parmfile}" \
 		"${key_verify_option}"
 
@@ -125,7 +125,7 @@ build_image() {
 	image_source_dir="${builddir}/secure-image"
 	mkdir -p "${image_source_dir}"
 	pushd "${tarball_dir}"
-	for tarball_id in kernel rootfs-initrd; do
+	for tarball_id in kernel-confidential rootfs-initrd-confidential; do
 		tar xvf kata-static-${tarball_id}.tar.xz -C "${image_source_dir}"
 	done
 	popd
@@ -167,7 +167,7 @@ main() {
 	readonly destdir
 	readonly builddir
 
-	info "Build IBM zSystems & LinuxONE SE image"
+	info "Build IBM zSystems & LinuxONE Secure Execution(SE) image"
 
 	install_dir="${destdir}${prefix}/share/kata-containers"
 	readonly install_dir

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -139,7 +139,7 @@ qemu-snp-experimental-tarball:
 qemu-tarball:
 	${MAKE} $@-build
 
-boot-image-se-tarball: kernel-tarball rootfs-initrd-tarball
+boot-image-se-tarball: kernel-confidential-tarball rootfs-initrd-confidential-tarball
 	${MAKE} $@-build
 
 qemu-tdx-experimental-tarball:


### PR DESCRIPTION
This commit is to add a new CI job to run-k8s-tests-on-zvsi.yaml.
Why the job is not configured in run-kata-coco-tests.yaml by having it integrated with `run-k8s-tests-coco-nontee` is:

- It uses k3s instead of AKS
- It runs on a self-hosted runner

These differences make the integrated job not easy to read and maintain when it comes to incorporating other platforms in the near future.

The verification for non-TEE has been done via a private self-hosted runner at https://github.com/BbolroC/kata-containers/actions/runs/8782763328

This PR also includes an adjustment of the build procedure for `boot-image-se` and updates the document accordingly. The verification for TEE (Secure Execution) from the internal test is at https://github.com/kata-containers/kata-containers/actions/runs/8795055047/job/24144779614

Fixes: #9467

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>

**IMPORTANT NOTE**: This PR should not be merged before #9489.