### PR TITLE
gha: stale: Remove the start-date

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -10,7 +10,6 @@ jobs:
     steps:
       - uses: actions/stale@v8
         with:
-          start-date: '2023-05-01T00:00:00Z'
           stale-pr-message: 'This PR has been opened without with no activity for 180 days. Comment on the issue otherwise it will be closed in 7 days'
           days-before-pr-stale: 180
           days-before-pr-close: 7


### PR DESCRIPTION
As documented in https://github.com/actions/stale?tab=readme-ov-file#start-date
> The start date is used to ignore the issues and pull requests created before the start date.
> Particularly useful when you wish to add this stale workflow on an existing repository
> and only wish to stale the new issues and pull requests.

As we don't want need to treat PRs older than May 2023 as a special case, then remove this option.

Fixes: #9502