### PR TITLE
gha: Remove k8s-cri-containerd-rhel9-e2e-tests for s390x

### DIFF
--- a/.github/workflows/ci-nightly-s390x.yaml
+++ b/.github/workflows/ci-nightly-s390x.yaml
@@ -19,25 +19,3 @@ jobs:
         /home/${USER}/script/handle_test_log.sh download $file_name
       env:
         TEST_TITLE: ${{ matrix.test_title }}
-
-  k8s-cri-containerd-rhel9-e2e-tests:
-    runs-on: s390x-rhel9
-    steps:
-    - name: Take a pre-action for self-hosted runner
-      run: |
-        ${HOME}/script/pre_action.sh rhel9-nightly
-
-    - name: Run k8s/cri-containerd e2e tests on RHEL9
-      run: |
-        export WORKSPACE=$GITHUB_WORKSPACE
-        export GITHUB_ACTION=""
-        bash ci_crio_entry_point.sh
-      env:
-        BAREMETAL: "true"
-        REPO_OWNER: "cri-o"
-        REPO_NAME: "cri-o"
-    
-    - name: Take a post-action for self-hosted runner
-      if: always()
-      run: |
-        ${HOME}/script/post_action.sh rhel9-nightly


### PR DESCRIPTION
This commit is simply to remove a CI workflow `k8s-cri-containerd-rhel9-e2e-tests`.

Fixes: #9504

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>