### PR TITLE
gha: Make integration tests for s390x run on s390x-large runners

### DIFF
--- a/.github/workflows/run-cri-containerd-tests-s390x.yaml
+++ b/.github/workflows/run-cri-containerd-tests-s390x.yaml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         containerd_version: ['active']
         vmm: ['qemu', 'qemu-runtime-rs']
-    runs-on: s390x
+    runs-on: s390x-large
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -33,7 +33,7 @@ jobs:
           - devmapper
         k8s:
           - k3s
-    runs-on: s390x
+    runs-on: s390x-large
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}


### PR DESCRIPTION
This is to make a workflow `run-k8s-tests` and `run-cri-containerd` (s390x and zvsi) run only on the runners labeled by `s390x-large`.

FYI: here are the registered runners for s390x:

![image](https://github.com/kata-containers/kata-containers/assets/6759608/5b9aff8e-2f2e-4c37-92c0-a61f5e29aa5c)


Fixes: #9507

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>