### PR TITLE
gha: tag k8s tests on ppc64le to ppc64le-runner-01

### DIFF
--- a/.github/workflows/run-k8s-tests-on-ppc64le.yaml
+++ b/.github/workflows/run-k8s-tests-on-ppc64le.yaml
@@ -31,7 +31,7 @@ jobs:
           - qemu
         k8s:
           - kubeadm
-    runs-on: ppc64le
+    runs-on: k8s-ppc64le
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}


### PR DESCRIPTION
This PR aims at running the k8s tests to one runner on ppc64le.

Fixes: #9520