### PR TITLE
runtime-rs: add NVIDIA GPUDirect clique_id support

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vfio.rs
@@ -198,6 +198,9 @@ pub struct VfioConfig {
     /// outside of the container mount namespace
     /// virt_path: Option<(index, virt_path_name)>
     pub virt_path: Option<(u64, String)>,
+
+    /// NVIDIA GPUs within the same clique ID are capable of direct P2P
+    pub clique_id: Option<u8>,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -141,24 +141,27 @@ impl DragonballInner {
         // As it has been assigned in vfio device manager.
         let pci_path = primary_device.guest_pci_path.unwrap();
         let guest_dev_id = pci_path.get_device_slot().unwrap().0;
-
+        let clique_id = vfio_device.config.clique_id;
         info!(
             sl!(),
             "insert host device. 
             host device id: {:?}, 
             bus_slot_func: {:?}, 
             guest device id: {:?}, 
-            vendor/device id: {:?}",
+            vendor/device id: {:?},
+            nvidia gpudirect clique id: {:?}",
             primary_device.hostdev_id,
             primary_device.bus_slot_func,
             guest_dev_id,
             vendor_device_id,
+            clique_id,
         );
 
         let vfio_dev_config = VfioPciDeviceConfig {
             bus_slot_func: primary_device.bus_slot_func,
             vendor_device_id,
             guest_dev_id: Some(guest_dev_id),
+            clique_id,
             ..Default::default()
         };
         let host_dev_config = HostDeviceConfig {

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -14,7 +14,7 @@ use hypervisor::device::device_manager::DeviceManager;
 use hypervisor::Hypervisor;
 use kata_types::config::TomlConfig;
 use kata_types::mount::Mount;
-use oci::{Linux, LinuxResources};
+use oci::LinuxResources;
 use persist::sandbox_persist::Persist;
 use tokio::sync::RwLock;
 use tracing::instrument;
@@ -115,9 +115,9 @@ impl ResourceManager {
         inner.handler_volumes(cid, spec).await
     }
 
-    pub async fn handler_devices(&self, cid: &str, linux: &Linux) -> Result<Vec<Device>> {
+    pub async fn handler_devices(&self, cid: &str, spec: &oci::Spec) -> Result<Vec<Device>> {
         let inner = self.inner.read().await;
-        inner.handler_devices(cid, linux).await
+        inner.handler_devices(cid, spec).await
     }
 
     pub async fn dump(&self) {

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -149,14 +149,9 @@ impl Container {
         }
         spec.mounts = oci_mounts;
 
-        let linux = spec
-            .linux
-            .as_ref()
-            .context("OCI spec missing linux field")?;
-
         let devices_agent = self
             .resource_manager
-            .handler_devices(&config.container_id, linux)
+            .handler_devices(&config.container_id, &spec)
             .await?;
 
         // update vcpus, mems and host cgroups


### PR DESCRIPTION
In GPUDirect, NVIDIA defines "cliques" to enable p2p DMA. Devices within a clique (sharing the same ID) can directly access each other's memory. we need support such feature to allow more than GPU devices passed throug in guest within the same clique ID are capable of direct P2P.

Fixes: #9526 
