### PR TITLE
agent: failed experiment with more recent anyhow

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.58"
+version = "1.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb07d2053ccdbe10e2af2995a2f116c1330396493dc1269f6a91d0ae82e19704"
+checksum = "c9d19de80eff169429ac1e9f48fffb163916b448a44e8e046186232046d9e1f9"
 
 [[package]]
 name = "arc-swap"

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -56,7 +56,23 @@ log = "0.4.11"
 cfg-if = "1.0.0"
 prometheus = { version = "0.13.0", features = ["process"] }
 procfs = "0.12.0"
-anyhow = "1.0.32"
+
+# Failed experiment with more recent version of the anyhow crate:
+# - "make test" passes for the Kata Agent when using anyhow 1.0.76 or older
+# - "make test" fails when using anyhow 1.0.77 or newer
+#
+# failures:
+#    config::tests::test_get_container_pipe_size
+#    config::tests::test_get_guest_components_features_value
+#    config::tests::test_get_hotplug_timeout
+#    config::tests::test_get_log_level
+#    config::tests::test_get_string_value
+#    config::tests::test_logrus_to_slog_level
+#    rpc::tests::test_do_write_stream
+#    rpc::tests::test_get_memory_info
+#    rpc::tests::test_update_container_namespaces
+anyhow = "=1.0.77"
+
 cgroups = { package = "cgroups-rs", version = "0.3.3" }
 
 # Tracing


### PR DESCRIPTION
Failed experiment with more recent version of the anyhow crate:
- "make test" passes for the Kata Agent when using anyhow 1.0.76 or older
- "make test" fails when using anyhow 1.0.77 or newer

failures:
   config::tests::test_get_container_pipe_size
   config::tests::test_get_guest_components_features_value
   config::tests::test_get_hotplug_timeout
   config::tests::test_get_log_level
   config::tests::test_get_string_value
   config::tests::test_logrus_to_slog_level
   rpc::tests::test_do_write_stream
   rpc::tests::test_get_memory_info
   rpc::tests::test_update_container_namespaces'