### PR TITLE
kata-deploy: configuring CRI-O for guest-pull image pulling

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -215,6 +215,13 @@ function deploy_kata() {
 		  "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
 	fi
 
+	# Set the PULL_TYPE_MAPPING
+	if [ "${PULL_TYPE}" != "default" ]; then
+		yq -i \
+		  ".spec.template.spec.containers[0].env[10].value = \"${KATA_HYPERVISOR}:${PULL_TYPE}\"" \
+		  "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
+	fi
+
 	echo "::group::Final kata-deploy.yaml that is used in the test"
 	cat "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml"
 	grep "${DOCKER_REGISTRY}/${DOCKER_REPO}:${DOCKER_TAG}" "${tools_dir}/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml" || die "Failed to setup the tests image"

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -24,6 +24,7 @@ spec:
               exec:
                 command: ["bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh cleanup"]
           command: ["bash", "-c", "/opt/kata-artifacts/scripts/kata-deploy.sh install"]
+          # NOTE: Please don't change the order of the environment variables below.
           env:
             - name: NODE_NAME
               valueFrom:
@@ -46,6 +47,8 @@ spec:
             - name: AGENT_HTTPS_PROXY
               value: ""
             - name: AGENT_NO_PROXY
+              value: ""
+            - name: PULL_TYPE_MAPPING
               value: ""
           securityContext:
             privileged: true


### PR DESCRIPTION
This introduces a handler for PULL_TYPE variable to allow configuring CRI-O for guest-pull image pulling.

kata-deploy is going to append `runtime_pull_image = true` to each kata runtimeClass configuration created at `/etc/crio/crio.conf.d/99-kata-deploy` , when `PULL_TYPE=guest-pull`. For example:

```toml
[crio.runtime.runtimes.kata-qemu]
        runtime_path = "/usr/local/bin/containerd-shim-kata-qemu-v2"
        runtime_type = "vm"
        runtime_root = "/run/vc"
        runtime_config_path = "/opt/kata/share/defaults/kata-containers//configuration-qemu.toml"
        privileged_without_host_devices = true
        runtime_pull_image = true
```

Currently there aren't any CI jobs exercising this feature. I tested it in a fresh Ubuntu 22.04 VM by running the following script and checking  was as expected:

 ```bash
#!/bin/bash

set -o errexit
set -o pipefail
set -o nounset

export DOCKER_REGISTRY="quay.io"
export DOCKER_REPO="wainersm/kata-deploy"
export DOCKER_TAG="kata-containers-e15858616b0496fd5ca8659d4c9f46512e68cc51-amd64"
#PR_NUMBER: ${{ inputs.pr-number }}
export KATA_HYPERVISOR=qemu
export KUBERNETES=k0s
export KUBERNETES_EXTRA_PARAMS='--cri-socket remote:unix:///var/run/crio/crio.sock --kubelet-extra-args --cgroup-driver="systemd"'
#USING_NFD: "false"
export K8S_TEST_HOST_TYPE=small
export PULL_TYPE=guest-pull

echo "== SETUP CRIO"
./gha-run.sh setup-crio
echo "== DEPLOY K8S"
./gha-run.sh deploy-k8s

echo "== DEPLOY KATA"
./gha-run.sh deploy-kata-garm
#./gha-run.sh install-bats
#./gha-run.sh run-tests
 ```

ps: I didn't actually run a workload because I've faced issues with nested virt on my workstation.

(Partially) Fixes #9474