### PR TITLE
DO NOT MERGE ci: use the prebuilt kbs-client

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -23,6 +23,8 @@ readonly KBS_NS="coco-tenant"
 readonly KBS_PRIVATE_KEY="${COCO_KBS_DIR}/config/kubernetes/base/kbs.key"
 # The kbs service name
 readonly KBS_SVC_NAME="kbs"
+# The install directory for kbs-client
+readonly KBS_CLIENT_INSTALL_DIR="/usr/local/bin"
 
 # Set "allow all" policy to resources.
 #
@@ -119,36 +121,27 @@ kbs_set_resource_from_file() {
 		--path "$path" --resource-file "$file"
 }
 
-# Build and install the kbs-client binary, unless it is already present.
+# Pull and install the kbs-client binary, unless it is already present.
+#
+# Note: Assumes (1) oras is installed, (2) this is an x86_64-linux-gnu machine,
+# and (3) staged-images/kbs-client:latest is a sample_only build for
+# this target triplet.
 #
 kbs_install_cli() {
 	command -v kbs-client >/dev/null && return
 
-	if ! command -v apt >/dev/null; then
-		>&2 echo "ERROR: running on unsupported distro"
+	if ! command -v oras >/dev/null; then
+		>&2 echo "ERROR: oras must be installed in order to pull kbs-client"
 		return 1
 	fi
+	if ! [[ "$(gcc -dumpmachine)" =~ "x86_64-linux-gnu" ]]; then
+		>&2 echo "ERROR: only x86_64-linux-gnu kbs-client currently supported"
+		return 2
+	fi
 
-	local pkgs="build-essential"
-
-	sudo apt-get update -y
-	# shellcheck disable=2086
-	sudo apt-get install -y $pkgs
-
-	# Mininum required version to build the client (read from versions.yaml)
-	local rust_version
-	ensure_yq
-	rust_version=$(get_from_kata_deps "externals.coco-kbs.toolchain")
-	# Currently kata version from version.yaml is 1.72.0
-	# which doesn't match the requirement, so let's pass
-	# the required version.
-	_ensure_rust "$rust_version"
-
-	pushd "${COCO_KBS_DIR}"
-	# Compile with sample features to bypass attestation.
-	make CLI_FEATURES=sample_only cli
-	sudo make install-cli
-	popd
+	oras pull ghcr.io/confidential-containers/staged-images/kbs-client:latest
+	sudo install -D -m0755 kbs-client ${KBS_CLIENT_INSTALL_DIR}
+	rm kbs-client
 }
 
 kbs_uninstall_cli() {


### PR DESCRIPTION
Rather than build the kbs-client from scratch, the CI can leverage the staged kbs-client images from ghcr.

We seem to be running this kbs-install-cli for [nontee](https://github.com/kata-containers/kata-containers/blob/6ca0f0971074fdc89fe12b0c6f685caaaeb0590a/.github/workflows/run-kata-coco-tests.yaml#L267) and (soon-to-be-merged) [tdx](https://github.com/kata-containers/kata-containers/pull/9452/files#diff-2e1776a4bdd1e4dadb74b49ede2126e8ef5ec99669ad7209242720d2b26ba97dR74) builds. The kbs-client:latest should work for these.

Note: The tdx self-hosted runner must have oras installed before this change is taken.

Fixes: #9493

DO NOT MERGE because this PR depends on #9452.