### PR TITLE
tdx: Update QEMU version

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -3028,9 +3028,6 @@ func (config *Config) appendMemoryKnobs() {
 		numaMemParam = "node,memdev=" + dimmName
 	}
 
-	if config.Knobs.Private {
-		objMemParam += ",private=on"
-	}
 	if config.Knobs.MemShared {
 		objMemParam += ",share=on"
 	}

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -2664,10 +2664,6 @@ type Knobs struct {
 
 	// IOMMUPlatform will enable IOMMU for supported devices
 	IOMMUPlatform bool
-
-	// Whether private memory should be used or not
-	// This is required by TDX, at least.
-	Private bool
 }
 
 // IOThread allows IO to be performed on a separate thread.

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -586,43 +586,12 @@ func TestAppendMemoryFileBackedMem(t *testing.T) {
 	knobs := Knobs{
 		FileBackedMem: true,
 		MemShared:     false,
-		Private:       false,
 	}
 	objMemString := "-object memory-backend-file,id=dimm1,size=1G,mem-path=foobar"
 	numaMemString := "-numa node,memdev=dimm1"
 	memBackendString := "-machine memory-backend=dimm1"
 
 	knobsString := objMemString + " "
-	if isDimmSupported(nil) {
-		knobsString += numaMemString
-	} else {
-		knobsString += memBackendString
-	}
-
-	testConfigAppend(conf, knobs, memString+" "+knobsString, t)
-
-	// Reset the conf and memString values
-	conf = &Config{
-		Memory: Memory{
-			Size:   "1G",
-			Slots:  8,
-			MaxMem: "3G",
-			Path:   "foobar",
-		},
-	}
-	memString = "-m 1G,slots=8,maxmem=3G"
-	testConfigAppend(conf, conf.Memory, memString, t)
-
-	knobs = Knobs{
-		FileBackedMem: true,
-		MemShared:     false,
-		Private:       true,
-	}
-	objMemString = "-object memory-backend-file,id=dimm1,size=1G,mem-path=foobar,private=on"
-	numaMemString = "-numa node,memdev=dimm1"
-	memBackendString = "-machine memory-backend=dimm1"
-
-	knobsString = objMemString + " "
 	if isDimmSupported(nil) {
 		knobsString += numaMemString
 	} else {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -615,17 +615,6 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
 		return err
 	}
 
-	if q.config.ConfidentialGuest {
-		// At this point we're safe to just check for the protection field
-		// on the hypervisor specific code, as availableGuestProtection()
-		// has been called earlier and we know we have the value stored.
-		if q.arch.getProtection() == tdxProtection {
-
-			// TDX relies on ",private=on" passed to the memory object.
-			knobs.Private = true
-		}
-	}
-
 	kernelPath, err := q.config.KernelAssetPath()
 	if err != nil {
 		return err

--- a/versions.yaml
+++ b/versions.yaml
@@ -102,7 +102,7 @@ assets:
     qemu-tdx-experimental:
       description: ¨QEMU with TDX support"
       url: "https://github.com/intel/qemu-tdx"
-      tag: "tdx-qemu-next-2023.9.21-v8.1.0"
+      tag: "tdx-qemu-upstream-2024.03.27-v9.0.0-rc0"
 
     qemu-snp-experimental:
       description: "QEMU with SNP support"

--- a/versions.yaml
+++ b/versions.yaml
@@ -338,9 +338,8 @@ externals:
       package: "OvmfPkg/AmdSev/AmdSevX64.dsc"
       package_output_dir: "AmdSev"
     tdx:
-      # yamllint disable-line rule:line-length
-      description: "QEMU with TDX support - based on https://github.com/intel/tdx-tools/releases/tag/2023ww15"
-      version: "edk2-stable202302"
+      description: "OVMF with TDX support"
+      version: "edk2-stable202402"
       package: "OvmfPkg/IntelTdx/IntelTdxX64.dsc"
       package_output_dir: "IntelTdx"
 


### PR DESCRIPTION
Let's update QEMU to the -next-2024.03.27-v9.0.0-rc0, which has support for talking to the quote-generation-socket.