### PR TITLE
Tag component caches

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -102,6 +102,7 @@ jobs:
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
+          RELEASE: ${{ if inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -60,13 +60,7 @@ jobs:
         stage:
           - ${{ inputs.stage }}
         exclude:
-          - asset: agent
-            stage: release
           - asset: cloud-hypervisor-glibc
-            stage: release
-          - asset: pause-image
-            stage: release
-          - asset: coco-guest-components
             stage: release
     steps:
       - name: Login to Kata Containers quay.io
@@ -105,6 +99,7 @@ jobs:
           RELEASE: ${{ if inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact ${{ matrix.asset }}
+        if: ${{ matrix.stage != 'release' || (matrix.component != 'agent' && matrix.component != 'coco-guest-components' && matrix.component != 'pause-image') }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-amd64-${{ matrix.asset }}${{ inputs.tarball-suffix }}

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -79,6 +79,7 @@ jobs:
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
+          RELEASE: ${{ if inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -39,8 +39,6 @@ jobs:
           - rootfs-initrd
           - shim-v2
           - virtiofsd
-        stage:
-          - ${{ inputs.stage }}
     steps:
       - name: Adjust a permission for repo
         run: |
@@ -82,6 +80,7 @@ jobs:
           RELEASE: ${{ if inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact ${{ matrix.asset }}
+        if: ${{ inputs.stage != 'release' || matrix.component != 'agent' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-arm64-${{ matrix.asset }}${{ inputs.tarball-suffix }}

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -80,6 +80,7 @@ jobs:
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
+          RELEASE: ${{ if inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -83,6 +83,7 @@ jobs:
           RELEASE: ${{ if inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact ${{ matrix.asset }}
+        if: ${{ input.stage != 'release' || matrix.component != 'agent' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-ppc64le-${{ matrix.asset }}${{ inputs.tarball-suffix }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -39,13 +39,6 @@ jobs:
           - rootfs-initrd-confidential
           - shim-v2
           - virtiofsd
-        stage:
-          - ${{ inputs.stage }}
-        exclude:
-          - asset: pause-image
-            stage: release
-          - asset: coco-guest-components
-            stage: release
     steps:
       - name: Take a pre-action for self-hosted runner
         run: ${HOME}/script/pre_action.sh ubuntu-2204
@@ -87,6 +80,7 @@ jobs:
           RELEASE: ${{ if inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact ${{ matrix.asset }}
+        if: ${{ inputs.stage != 'release' || (matrix.component != 'agent' && matrix.component != 'coco-guest-components' && matrix.component != 'pause-image') }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-s390x-${{ matrix.asset }}${{ inputs.tarball-suffix }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -84,6 +84,7 @@ jobs:
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
+          RELEASE: ${{ if inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -10,6 +10,7 @@ jobs:
   build-kata-static-tarball-amd64:
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
+      push-to-registry: yes
       stage: release
 
   kata-deploy:

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -10,6 +10,7 @@ jobs:
   build-kata-static-tarball-arm64:
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
+      push-to-registry: yes
       stage: release
 
   kata-deploy:

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -10,6 +10,7 @@ jobs:
   build-kata-static-tarball-ppc64le:
     uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
     with:
+      push-to-registry: yes
       stage: release
 
   kata-deploy:

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -10,6 +10,7 @@ jobs:
   build-kata-static-tarball-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
+      push-to-registry: yes
       stage: release
     secrets: inherit
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -49,6 +49,7 @@ ARTEFACT_REGISTRY_PASSWORD="${ARTEFACT_REGISTRY_PASSWORD:-}"
 TARGET_BRANCH="${TARGET_BRANCH:-main}"
 PUSH_TO_REGISTRY="${PUSH_TO_REGISTRY:-}"
 KERNEL_HEADERS_PKG_TYPE="${KERNEL_HEADERS_PKG_TYPE:-deb}"
+RELEASE="${RELEASE:-"no"}"
 
 workdir="${WORKDIR:-$PWD}"
 
@@ -799,6 +800,7 @@ install_ovmf_sev() {
 
 install_agent() {
 	latest_artefact="$(git log -1 --abbrev=9 --pretty=format:"%h" ${repo_root_dir}/src/agent)"
+	artefact_tag="$(git log -1 --abbrev=9 --pretty=format:"%h" ${repo_root_dir})"
 	latest_builder_image="$(get_agent_image_name)"
 
 	install_cached_tarball_component \
@@ -820,6 +822,7 @@ install_agent() {
 
 install_coco_guest_components() {
 	latest_artefact="$(get_from_kata_deps "externals.coco-guest-components.version")-$(get_from_kata_deps "externals.coco-guest-components.toolchain")"
+	artefact_tag="$(get_from_kata_deps "externals.coco-guest-components.version")"
 	latest_builder_image="$(get_coco_guest_components_image_name)"
 
 	install_cached_tarball_component \
@@ -836,6 +839,7 @@ install_coco_guest_components() {
 
 install_pause_image() {
 	latest_artefact="$(get_from_kata_deps "externals.pause.repo")-$(get_from_kata_deps "externals.pause.version")"
+	artefact_tag=${latest_artefact}
 	latest_builder_image="$(get_pause_image_name)"
 
 	install_cached_tarball_component \
@@ -1063,8 +1067,8 @@ handle_build() {
 
 	rootfs-nvidia-gpu-image) install_image_nvidia_gpu ;;
 
-	rootfs-nvidia-gpu-initrd) install_initrd_nvidia_gpu ;;	
-	
+	rootfs-nvidia-gpu-initrd) install_initrd_nvidia_gpu ;;
+
 	rootfs-nvidia-gpu-confidential-image) install_image_nvidia_gpu_confidential ;;
 
 	rootfs-nvidia-gpu-confidential-initrd) install_initrd_nvidia_gpu_confidential ;;
@@ -1092,7 +1096,7 @@ handle_build() {
 		kernel-nvidia-gpu*)
 			local kernel_headers_final_tarball_path="${workdir}/kata-static-${build_target}-headers.tar.xz"
 			if [ ! -f "${kernel_headers_final_tarball_path}" ]; then
-				local kernel_headers_dir 
+				local kernel_headers_dir
 				kernel_headers_dir=$(get_kernel_headers_dir "${build_target}")
 
 				pushd "${kernel_headers_dir}"
@@ -1169,6 +1173,36 @@ handle_build() {
 					${build_target}-sha256sum
 				;;
 		esac
+
+		tags=(latest-${TARGET_BRANCH}-$(uname -m))
+		if [ -n "${artefact_tag}" ]; then
+			tags+=("${artefact_tag}")
+		fi
+		if [ "${RELEASE}" == "yes" ]; then
+			tags+=("$(cat "${version_file}")")
+		fi
+
+		for tag in "${tags[@]}"; do
+			case ${build_target} in
+				kernel*-confidential)
+					sudo oras push \
+						${ARTEFACT_REGISTRY}/kata-containers/cached-artefacts/${build_target}:${tag} \
+						${final_tarball_name} \
+						"kata-static-${build_target}-modules.tar.xz" \
+						${build_target}-version \
+						${build_target}-builder-image-version \
+						${build_target}-sha256sum
+					;;
+				*)
+					sudo oras push \
+						${ARTEFACT_REGISTRY}/kata-containers/cached-artefacts/${build_target}:${tag} \
+						${final_tarball_name} \
+						${build_target}-version \
+						${build_target}-builder-image-version \
+						${build_target}-sha256sum
+					;;
+			esac
+		done
 		sudo oras logout "${ARTEFACT_REGISTRY}"
 	fi
 


### PR DESCRIPTION
Add the ability to tag certain components in our ghcr cache, rather than just storing them all by digest. In particular the cloud-api-adaptor implementation of the remote-hypervisor wants to use the agent, agent-opa and guest-components