### PR TITLE
runtime-rs: support IOMMU in qemu VMs

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -1278,7 +1278,7 @@ impl<'a> QemuCmdLine<'a> {
 
         let mut virtiofs_device = DeviceVhostUserFs::new(chardev_name, mount_tag, self.bus_type());
         virtiofs_device.set_queue_size(queue_size);
-        if self.config.device_info.enable_iommu_platform {
+        if self.config.device_info.enable_iommu_platform && self.bus_type() == VirtioBusType::Ccw {
             virtiofs_device.set_iommu_platform(true);
         }
         self.devices.push(Box::new(virtiofs_device));

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -282,6 +282,7 @@ struct Machine {
     accel: String,
     options: String,
     nvdimm: bool,
+    kernel_irqchip: Option<String>,
 
     is_nvdimm_supported: bool,
     memory_backend: Option<String>,
@@ -309,6 +310,7 @@ impl Machine {
             accel: "kvm".to_owned(),
             options: config.machine_info.machine_accelerators.clone(),
             nvdimm: false,
+            kernel_irqchip: None,
             is_nvdimm_supported,
             memory_backend: None,
         }
@@ -326,6 +328,11 @@ impl Machine {
         self.memory_backend = Some(mem_backend.to_owned());
         self
     }
+
+    fn set_kernel_irqchip(&mut self, kernel_irqchip: &str) -> &mut Self {
+        self.kernel_irqchip = Some(kernel_irqchip.to_owned());
+        self
+    }
 }
 
 #[async_trait]
@@ -339,6 +346,9 @@ impl ToQemuParams for Machine {
         }
         if self.nvdimm {
             params.push("nvdimm=on".to_owned());
+        }
+        if let Some(kernel_irqchip) = &self.kernel_irqchip {
+            params.push(format!("kernel_irqchip={}", kernel_irqchip));
         }
         if let Some(mem_backend) = &self.memory_backend {
             params.push(format!("memory-backend={}", mem_backend));

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -1118,6 +1118,36 @@ impl ToQemuParams for Rtc {
     }
 }
 
+#[derive(Debug)]
+struct DeviceIntelIommu {
+    intremap: bool,
+    device_iotlb: bool,
+    caching_mode: bool,
+}
+
+impl DeviceIntelIommu {
+    fn new() -> DeviceIntelIommu {
+        DeviceIntelIommu {
+            intremap: true,
+            device_iotlb: true,
+            caching_mode: true,
+        }
+    }
+}
+
+#[async_trait]
+impl ToQemuParams for DeviceIntelIommu {
+    async fn qemu_params(&self) -> Result<Vec<String>> {
+        let mut params = Vec::new();
+        params.push("intel-iommu".to_owned());
+        let to_onoff = |b| if b { "on" } else { "off" };
+        params.push(format!("intremap={}", to_onoff(self.intremap)));
+        params.push(format!("device-iotlb={}", to_onoff(self.device_iotlb)));
+        params.push(format!("caching-mode={}", to_onoff(self.caching_mode)));
+        Ok(vec!["-device".to_owned(), params.join(",")])
+    }
+}
+
 fn is_running_in_vm() -> Result<bool> {
     let res = read_to_string("/proc/cpuinfo")?
         .lines()

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -997,6 +997,7 @@ pub struct DeviceVirtioNet {
     disable_modern: bool,
 
     num_queues: u32,
+    iommu_platform: bool,
 }
 
 impl DeviceVirtioNet {
@@ -1007,6 +1008,7 @@ impl DeviceVirtioNet {
             mac_address,
             disable_modern: false,
             num_queues: 1,
+            iommu_platform: false,
         }
     }
 
@@ -1017,6 +1019,11 @@ impl DeviceVirtioNet {
 
     fn set_num_queues(&mut self, num_queues: u32) -> &mut Self {
         self.num_queues = num_queues;
+        self
+    }
+
+    fn set_iommu_platform(&mut self, iommu_platform: bool) -> &mut Self {
+        self.iommu_platform = iommu_platform;
         self
     }
 }
@@ -1034,6 +1041,9 @@ impl ToQemuParams for DeviceVirtioNet {
 
         if self.disable_modern {
             params.push("disable-modern=true".to_owned());
+        }
+        if self.iommu_platform {
+            params.push("iommu_platform=on".to_owned());
         }
 
         params.push("mq=on".to_owned());
@@ -1377,6 +1387,9 @@ impl<'a> QemuCmdLine<'a> {
 
         if should_disable_modern() {
             virtio_net_device.set_disable_modern(true);
+        }
+        if self.config.device_info.enable_iommu_platform && self.bus_type() == VirtioBusType::Ccw {
+            virtio_net_device.set_iommu_platform(true);
         }
         if self.config.network_info.network_queues > 1 {
             virtio_net_device.set_num_queues(self.config.network_info.network_queues);


### PR DESCRIPTION
This PR adds support for the IOMMU device and `iommu_platforms` device param to runtime-rs qemu driver.  It can be also viewed as implementing support for `configuration.toml`'s `enable_iommu` and `enable_iommu_platform` settings.