### PR TITLE
agent: mounts: Mount configfs into the container

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -276,6 +276,24 @@ pub fn init_rootfs(
         }
     }
 
+    spec.annotations.iter().for_each(|(k, v)| {
+        if k == "io.katacontainers.pkg.oci.container_type" && v != "pod_sandbox" {
+            let err = mount(
+                Some("configfs"),
+                format!("{}/sys/kernel/config", rootfs).as_str(),
+                Some("configfs"),
+                MsFlags::MS_NODEV | MsFlags::MS_NOSUID | MsFlags::MS_NOEXEC | MsFlags::MS_RELATIME,
+                None::<&str>,
+            );        
+            match err {
+                Ok(_) => (),
+                Err(e) => {
+                    log_child!(cfd_log, "mount /sys/kernel/config configs error: {}", e.to_string());
+                }
+            }
+        }
+    });
+
     let olddir = unistd::getcwd()?;
     unistd::chdir(rootfs)?;
 


### PR DESCRIPTION
configfs is used to get a quote generated, and having this information available from inside the container (in case the container itself wants to attest something) is a must.

It's important to note that this is not really needed by Confidential Containers, as the attestation-agent (which is running on the pod sandbox VM) has access to this and is able to get the quote generated on the guest without any kind of issue.  However, this is still reasonable to have exposed to the container, as it may and will help doing some simpler tests.