### PR TITLE
build: Update golang version to 1.22.2

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19.3
+        go-version: 1.22.2
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Build utils

--- a/.github/workflows/docs-url-alive-check.yaml
+++ b/.github/workflows/docs-url-alive-check.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.19.3
+        go-version: 1.22.2
       env:
         GOPATH: ${{ runner.workspace }}/kata-containers
     - name: Set env

--- a/tests/.golangci.yml
+++ b/tests/.golangci.yml
@@ -5,10 +5,11 @@
 run:
   concurrency: 4
   deadline: 600s
-  skip-dirs:
+
+issues:
+  exclude-dirs:
     - vendor
-# Ignore auto-generated protobuf code.
-  skip-files:
+  exclude-files:
     - ".*\\.pb\\.go$"
 
 linters:

--- a/versions.yaml
+++ b/versions.yaml
@@ -381,12 +381,12 @@ languages:
   golang:
     description: "Google's 'go' language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.19.3"
+    version: "1.22.2"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.19.3"
+      newest-version: "1.22.2"
 
   rust:
     description: "Rust language"
@@ -402,12 +402,12 @@ languages:
     description: "golangci-lint"
     notes: "'version' is the default minimum version used by this project."
     url: "github.com/golangci/golangci-lint"
-    version: "1.50.1"
+    version: "1.57.2"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.50.1"
+      newest-version: "1.57.2"
 
 specs:
   description: "Details of important specifications"


### PR DESCRIPTION
As we have the following issue with a golang version for `run-cri-containerd`, it is required to bump the language:

```
go build  -gcflags=-trimpath=/home/runner/actions-runner/_work/kata-containers/kata-containers/src -buildmode=pie  -o bin/containerd -ldflags '-X github.com/containerd/containerd/version.Version=v1.7.16 -X github.com/containerd/containerd/version.Revision=83031836b2cf55637d7abf847b17134c51b38e53 -X github.com/containerd/containerd/version.Package=github.com/containerd/containerd -s -w ' -tags "no_btrfs"  ./cmd/containerd
# tags.cncf.io/container-device-interface/internal/validation/k8s
vendor/tags.cncf.io/container-device-interface/internal/validation/k8s/objectmeta.go:43:16: undefined: errors.Join
note: module requires Go 1.20
```

CI example: https://github.com/kata-containers/kata-containers/actions/runs/8844120756/job/24285892891