### PR TITLE
build: Build the shipped agent with policy enabled

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -28,7 +28,6 @@ jobs:
       matrix:
         asset:
           - agent
-          - agent-opa
           - agent-ctl
           - cloud-hypervisor
           - cloud-hypervisor-glibc
@@ -64,8 +63,6 @@ jobs:
           - ${{ inputs.stage }}
         exclude:
           - asset: agent
-            stage: release
-          - asset: agent-opa
             stage: release
           - asset: cloud-hypervisor-glibc
             stage: release

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -28,7 +28,6 @@ jobs:
       matrix:
         asset:
           - agent
-          - agent-opa
           - kernel
           - qemu
           - rootfs-initrd

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -28,7 +28,6 @@ jobs:
       matrix:
         asset:
           - agent
-          - agent-opa
           - coco-guest-components
           - kernel
           - kernel-confidential

--- a/docs/how-to/how-to-run-kata-containers-with-SE-VMs.md
+++ b/docs/how-to/how-to-run-kata-containers-with-SE-VMs.md
@@ -337,7 +337,7 @@ $ mkdir kata-artifacts
 $ build_dir=$(readlink -f build)
 $ cp -r $build_dir/*.tar.xz kata-artifacts
 $ ls -1 kata-artifacts
-kata-static-agent-opa.tar.xz
+kata-static-agent.tar.xz
 kata-static-boot-image-se.tar.xz
 kata-static-coco-guest-components.tar.xz
 kata-static-kernel-confidential.tar.xz

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -79,9 +79,6 @@ serial-targets:
 agent-tarball: copy-scripts-for-the-agent-build
 	${MAKE} $@-build
 
-agent-opa-tarball: copy-scripts-for-the-agent-build
-	${MAKE} $@-build
-
 agent-ctl-tarball:
 	${MAKE} $@-build
 
@@ -151,13 +148,13 @@ stratovirt-tarball:
 rootfs-image-tarball: agent-tarball
 	${MAKE} $@-build
 
-rootfs-image-confidential-tarball: agent-opa-tarball pause-image-tarball coco-guest-components-tarball kernel-confidential-tarball
+rootfs-image-confidential-tarball: agent-tarball pause-image-tarball coco-guest-components-tarball kernel-confidential-tarball
 	${MAKE} $@-build
 
-rootfs-initrd-mariner-tarball: agent-opa-tarball
+rootfs-initrd-mariner-tarball: agent-tarball
 	${MAKE} $@-build
 
-rootfs-initrd-confidential-tarball: agent-opa-tarball pause-image-tarball coco-guest-components-tarball kernel-confidential-tarball
+rootfs-initrd-confidential-tarball: agent-tarball pause-image-tarball coco-guest-components-tarball kernel-confidential-tarball
 	${MAKE} $@-build
 
 rootfs-initrd-tarball: agent-tarball

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -89,7 +89,6 @@ options:
 --build=<asset>       :
 	all
 	agent
-	agent-opa
 	agent-ctl
 	boot-image-se
 	coco-guest-components
@@ -217,9 +216,6 @@ install_cached_tarball_component() {
 get_agent_tarball_path() {
 	agent_local_build_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build"
 	agent_tarball_name="kata-static-agent.tar.xz"
-	if [ "${AGENT_POLICY:-no}" = "yes" ]; then
-		agent_tarball_name="kata-static-agent-opa.tar.xz"
-	fi
 
 	echo "${agent_local_build_dir}/${agent_tarball_name}"
 }
@@ -322,6 +318,7 @@ install_image() {
 	fi
 
 	export AGENT_TARBALL=$(get_agent_tarball_path)
+
 	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --imagetype=image --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
 }
 
@@ -391,6 +388,7 @@ install_initrd() {
 	fi
 
 	export AGENT_TARBALL=$(get_agent_tarball_path)
+
 	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --imagetype=initrd --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
 }
 
@@ -786,10 +784,6 @@ install_agent() {
 	DESTDIR="${destdir}" AGENT_POLICY="yes" PULL_TYPE=${PULL_TYPE} "${agent_builder}"
 }
 
-install_agent_opa() {
-	install_agent
-}
-
 install_coco_guest_components() {
 	latest_artefact="$(get_from_kata_deps "externals.coco-guest-components.version")-$(get_from_kata_deps "externals.coco-guest-components.toolchain")"
 	latest_builder_image="$(get_coco_guest_components_image_name)"
@@ -983,8 +977,6 @@ handle_build() {
 
 	agent) install_agent ;;
 
-	agent-opa) install_agent_opa ;;
-
 	agent-ctl) install_agent_ctl ;;
 
 	boot-image-se) install_se_image ;;
@@ -1134,7 +1126,6 @@ main() {
 	local silent
 	build_targets=(
 		agent
-		agent-opa
 		agent-ctl
 		cloud-hypervisor
 		coco-guest-components

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -765,9 +765,7 @@ install_ovmf_sev() {
 	install_ovmf "sev" "edk2-sev.tar.gz"
 }
 
-install_agent_helper() {
-	agent_policy="${1:-no}"
-
+install_agent() {
 	latest_artefact="$(git log -1 --pretty=format:"%h" ${repo_root_dir}/src/agent)"
 	latest_builder_image="$(get_agent_image_name)"
 
@@ -785,15 +783,11 @@ install_agent_helper() {
 	export GPERF_URL="$(get_from_kata_deps "externals.gperf.url")"
 
 	info "build static agent"
-	DESTDIR="${destdir}" AGENT_POLICY=${agent_policy} PULL_TYPE=${PULL_TYPE} "${agent_builder}"
-}
-
-install_agent() {
-	install_agent_helper
+	DESTDIR="${destdir}" AGENT_POLICY="yes" PULL_TYPE=${PULL_TYPE} "${agent_builder}"
 }
 
 install_agent_opa() {
-	install_agent_helper "yes"
+	install_agent
 }
 
 install_coco_guest_components() {


### PR DESCRIPTION

Now that the OPA binary is not required anymore, let's start shipping
the agent with the policy enabled by default.

The agent *without* policy enabled has 30MB, while it's 34MB *with* the
policy enabled.

This 4MB (~10%) increase is, IMHO, worth it in order to reduce the
amount of components we have to maintain and test, including the
possibility to also reduce the amount of possible rootfs / initrd
images.

Whoever wants to use the agent without policy enabled can simply do that
by building their own agent. :-)

/cc @stevenhorsman @danmihai1 