### PR TITLE
runtime-rs: Implement resize memory for CH

### DIFF
--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -289,7 +289,7 @@ impl TryFrom<(MemoryInfo, GuestProtection)> for MemoryConfig {
 // method is available in the rust language.
 //
 // See: https://github.com/rust-lang/rust/issues/88581
-fn checked_next_multiple_of(value: u64, multiple: u64) -> Option<u64> {
+pub fn checked_next_multiple_of(value: u64, multiple: u64) -> Option<u64> {
     match value.checked_rem(multiple) {
         None => Some(value),
         Some(r) => value.checked_add(multiple - r),

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
@@ -48,7 +48,7 @@ pub struct CloudHypervisorInner {
     /// List of devices that will be added to the VM once it boots
     pub(crate) pending_devices: Vec<DeviceType>,
 
-    pub(crate) _capabilities: Capabilities,
+    pub(crate) capabilities: Capabilities,
 
     pub(crate) shutdown_tx: Option<Sender<bool>>,
     pub(crate) shutdown_rx: Option<Receiver<bool>>,
@@ -74,16 +74,18 @@ pub struct CloudHypervisorInner {
     // None.
     pub(crate) ch_features: Option<Vec<String>>,
 
-    /// Size of memory block of guest OS in MB (currently unused)
-    pub(crate) _guest_memory_block_size_mb: u32,
+    // hotplug memory size
+    pub(crate) mem_hotplug_size_mb: u32,
+    /// Size of memory block of guest OS in MB
+    pub(crate) guest_memory_block_size_mb: u32,
 }
 
 const CH_DEFAULT_TIMEOUT_SECS: u32 = 10;
 
 impl CloudHypervisorInner {
     pub fn new() -> Self {
-        let mut capabilities = Capabilities::new();
-        capabilities.set(
+        let mut caps = Capabilities::new();
+        caps.set(
             CapabilityBits::BlockDeviceSupport
                 | CapabilityBits::BlockDeviceHotplugSupport
                 | CapabilityBits::FsSharingSupport
@@ -109,13 +111,14 @@ impl CloudHypervisorInner {
             netns: None,
             pending_devices: vec![],
             device_ids: HashMap::<String, String>::new(),
-            _capabilities: capabilities,
+            capabilities: caps,
             shutdown_tx: Some(tx),
             shutdown_rx: Some(rx),
             tasks: None,
             guest_protection_to_use: GuestProtection::NoProtection,
             ch_features: None,
-            _guest_memory_block_size_mb: 0,
+            mem_hotplug_size_mb: 0,
+            guest_memory_block_size_mb: 0,
         }
     }
 
@@ -183,7 +186,7 @@ impl Persist for CloudHypervisorInner {
 
             ..Default::default()
         };
-        ch._capabilities = ch.capabilities().await?;
+        ch.capabilities = ch.capabilities().await?;
 
         Ok(ch)
     }

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -179,8 +179,8 @@ impl Hypervisor for CloudHypervisor {
     }
 
     async fn resize_memory(&self, new_mem_mb: u32) -> Result<(u32, MemoryConfig)> {
-        let inner = self.inner.read().await;
-        inner.resize_memory(new_mem_mb)
+        let mut inner = self.inner.write().await;
+        inner.resize_memory(new_mem_mb).await
     }
 
     async fn get_passfd_listener_addr(&self) -> Result<(String, u32)> {


### PR DESCRIPTION
Add resize_memory for Cloud Hypervisor and cloud_hypervisor_vm_resize for the call to the VM. Write unit tests checking failure cases.

Fixes #8801