### PR TITLE
runtime-rs: Use add_task_by_tgid for constrain_hypervisor

### DIFF
--- a/src/runtime-rs/crates/resource/src/cgroups/mod.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/mod.rs
@@ -222,7 +222,7 @@ impl CgroupsResource {
         // All vCPU threads move to the sandbox controller.
         for tid in tids {
             self.cgroup_manager
-                .add_task(CgroupPid { pid: *tid as u64 })?
+                .add_task_by_tgid(CgroupPid { pid: *tid as u64 })?
         }
 
         Ok(())


### PR DESCRIPTION
runtime-rs `CgroupsResource.constrain_hypervisor` used `add_task` instead of `add_task_by_tgid` when adding the hypervisor threads to the cgroup.
This causes an issue due to the default type of the cgroup being `domain` instead of `threaded` or `domain threaded` and throws the error: `using method in wrong cgroup mode`.
CgroupsResource.new already uses `add_task_by_tgid` so this change should be fine

Fixes: #8245