### PR TITLE
kata-deploy: configure debugging for crio

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -351,7 +351,7 @@ function configure_crio() {
 
 	if [ "${DEBUG}" == "true" ]; then
 		cat <<EOF | tee $crio_drop_in_conf_file_debug
-[crio]
+[crio.runtime]
 log_level = "debug"
 EOF
 	fi


### PR DESCRIPTION
Fix the configuration for crio's log_level

Fixes: #9556