### PR TITLE
genpolicy: Add support for envFrom

### DIFF
--- a/src/tools/genpolicy/src/config_map.rs
+++ b/src/tools/genpolicy/src/config_map.rs
@@ -64,12 +64,37 @@ impl ConfigMap {
 
         None
     }
+
+    pub fn get_key_value_pairs(&self) -> Option<Vec<String>> {
+        //eg ["key1=value1", "key2=value2"]
+        self.data
+            .as_ref()?
+            .keys()
+            .map(|key| {
+                let value = self.data.as_ref().unwrap().get(key).unwrap();
+                format!("{key}={value}")
+            })
+            .collect::<Vec<String>>()
+            .into()
+    }
 }
 
 pub fn get_value(value_from: &pod::EnvVarSource, config_maps: &Vec<ConfigMap>) -> Option<String> {
     for config_map in config_maps {
         if let Some(value) = config_map.get_value(value_from) {
             return Some(value);
+        }
+    }
+
+    None
+}
+
+pub fn get_values(config_map_name: &str, config_maps: &Vec<ConfigMap>) -> Option<Vec<String>> {
+    for config_map in config_maps {
+        if let Some(existing_configmap_name) = &config_map.metadata.name {
+            if config_map_name == existing_configmap_name {
+                return config_map.get_key_value_pairs();
+            }
         }
     }
 

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-configmap.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-configmap.yaml
@@ -10,3 +10,4 @@ metadata:
 data:
   data-1: value-1
   data-2: value-2
+  data-3: value-3

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -49,6 +49,9 @@ spec:
             - echo
             - startupProbe
             - test
+      envFrom:
+      - configMapRef:
+          name: policy-configmap
   topologySpreadConstraints:
     - maxSkew: 2
       topologyKey: kubernetes.io/hostname


### PR DESCRIPTION
This change adds support for the `envFrom` field in the `Pod` resource