### PR TITLE
genpolicy: add topologySpreadConstraints support

### DIFF
--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -89,6 +89,9 @@ pub struct PodSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     dnsPolicy: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    topologySpreadConstraints: Option<Vec<TopologySpreadConstraint>>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
@@ -501,6 +504,29 @@ struct PodDNSConfigOption {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<String>,
+}
+
+/// See Reference / Kubernetes API / Workload Resources / Pod.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct TopologySpreadConstraint {
+    maxSkew: i32,
+    topologyKey: String,
+    whenUnsatisfiable: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    labelSelector: Option<yaml::LabelSelector>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    matchLabelKeys: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    minDomains: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nodeAffinityPolicy: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nodeTaintsPolicy: Option<String>,
 }
 
 impl Container {

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -27,3 +27,7 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+  topologySpreadConstraints:
+    - maxSkew: 2
+      topologyKey: kubernetes.io/hostname
+      whenUnsatisfiable: ScheduleAnyway


### PR DESCRIPTION
Allow genpolicy to process Pod YAML files including topologySpreadConstraints.