### PR TITLE
genpolicy: add support for runAsUser

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -540,11 +540,8 @@ allow_user(p_process, i_process) {
     p_user := p_process.User
     i_user := i_process.User
 
-    # TODO: track down the reason for mcr.microsoft.com/oss/bitnami/redis:6.0.8 being
-    #       executed with uid = 0 despite having "User": "1001" in its container image
-    #       config.
-    #print("allow_user: input uid =", i_user.UID, "policy uid =", p_user.UID)
-    #p_user.UID == i_user.UID
+    print("allow_user: input uid =", i_user.UID, "policy uid =", p_user.UID)
+    p_user.UID == i_user.UID
 
     # TODO: track down the reason for registry.k8s.io/pause:3.9 being
     #       executed with gid = 0 despite having "65535:65535" in its container image

--- a/src/tools/genpolicy/src/containerd.rs
+++ b/src/tools/genpolicy/src/containerd.rs
@@ -32,7 +32,7 @@ pub fn get_process(privileged_container: bool, common: &policy::CommonData) -> p
         Env: Vec::new(),
         Cwd: "/".to_string(),
         Capabilities: capabilities,
-        NoNewPrivileges: true,
+        NoNewPrivileges: false,
     }
 }
 

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -657,8 +657,10 @@ impl AgentPolicy {
 
         substitute_env_variables(&mut process.Env);
         substitute_args_env_variables(&mut process.Args, &process.Env);
+
         c_settings.get_process_fields(&mut process);
-        process.NoNewPrivileges = !yaml_container.allow_privilege_escalation();
+        resource.get_process_fields(&mut process);
+        yaml_container.get_process_fields(&mut process);
 
         process
     }

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -94,6 +94,11 @@ pub trait K8sResource {
     fn get_runtime_class_name(&self) -> Option<String> {
         None
     }
+
+    fn get_process_fields(&self, _process: &mut policy::KataProcess) {
+        // Just Pods can have a PodSecurityContext field, so the other
+        // resources can use this default get_process_fields implementation.
+    }
 }
 
 /// See Reference / Kubernetes API / Common Definitions / LabelSelector.

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -27,3 +27,5 @@ spec:
       securityContext:
         seccompProfile:
           type: RuntimeDefault
+  securityContext:
+    runAsUser: 1000


### PR DESCRIPTION
Add policy support for SecurityContext and PodSecurityContext runAsUser.

Also, remove outdated UID rule workaround.

Fixes: #8879

Downstream PR https://github.com/microsoft/kata-containers/pull/153