### PR TITLE
build: coco-guest-components: Fix TEE_PLATFORM support

### DIFF
--- a/tools/packaging/static-build/coco-guest-components/build.sh
+++ b/tools/packaging/static-build/coco-guest-components/build.sh
@@ -48,7 +48,7 @@ ATTESTER="none"
 sudo docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \
 	--env DESTDIR="${DESTDIR}" \
-	--env TEE_PLATFORM=${TEE_PLATFORM:+"all"} \
+	--env TEE_PLATFORM=${TEE_PLATFORM:-"all"} \
 	--env RESOURCE_PROVIDER=${RESOURCE_PROVIDER:-} \
 	--env ATTESTER=${ATTESTER:-} \
 	--env coco_guest_components_repo="${coco_guest_components_repo}" \


### PR DESCRIPTION
We want to build with support for *all* the TEE_PLATFORM, however, we've been passing the wrong value to the TEE_PLATFORM env var, as using ${TEE_PLATFORM:+"all"} results in an empty string, and what we really want to use is ${TEE_PLATFORM:-"all"} instead.

/cc @bpradipt @stevenhorsman @mythi 