### PR TITLE
build: fix the confusing build message if yq doesn't exist in GOPATH/bin

### DIFF
--- a/src/runtime/golang.mk
+++ b/src/runtime/golang.mk
@@ -21,7 +21,7 @@ endif
 ifeq (,$(not_check_version))
     have_yq=$(shell if [ -x "$(GOPATH)/bin/yq" ]; then echo "true"; else echo ""; fi)
     ifeq (,$(have_yq))
-        $(info INFO: yq was not found, installing it)
+        $(info INFO: yq was not found in GOPATH/bin, installing it)
         install_yq=$(shell ../../ci/install_yq.sh)
     endif
     ifneq (,$(install_yq))


### PR DESCRIPTION
The build message shows that yq was not found when I tried to build runtime binaries, but I've actually installed yq by yum install.