### PR TITLE
runtime: make kata-runtime check error more understandable when /dev/kvm doesn't exist

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-check.go
+++ b/src/runtime/cmd/kata-runtime/kata-check.go
@@ -471,15 +471,14 @@ func genericArchKernelParamHandler(onVMM bool, fields logrus.Fields, msg string)
 // genericKvmIsUsable determines if it will be possible to create a full virtual machine
 // by creating a minimal VM and then deleting it.
 func genericKvmIsUsable() error {
-	flags := syscall.O_RDWR | syscall.O_CLOEXEC
+	fieldLogger := kataLog.WithField("check-type", "full")
 
-	f, err := syscall.Open(kvmDevice, flags, 0)
+	f, err := syscall.Open(kvmDevice, syscall.O_RDWR|syscall.O_CLOEXEC, 0)
 	if err != nil {
+		fieldLogger.WithField("device", kvmDevice).Errorf("cannot open kvm device: %v", err)
 		return err
 	}
 	defer syscall.Close(f)
-
-	fieldLogger := kataLog.WithField("check-type", "full")
 
 	fieldLogger.WithField("device", kvmDevice).Info("device available")
 


### PR DESCRIPTION
If device /dev/kvm does not exist, kata-runtime check would fail with an ambiguous error messae 'no such file or directory'. I added a little more details to make it understandable and it will belike:

```
ERRO[0000] cannot open kvm device: no such file or directory  arch=arm64 check-type=full device=/dev/kvm name=kata-runtime pid=2849085 source=runtime
ERRO[0000] no such file or directory                          arch=arm64 name=kata-runtime pid=2849085 source=runtime
no such file or directory
```