### PR TITLE
runtime-rs: fix the issue of the leak of dead shim

### DIFF
--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -128,13 +128,16 @@ impl RuntimeHandlerManagerInner {
             }
         }
 
+        let instance = Arc::new(runtime_instance);
+        self.runtime_instance = Some(instance.clone());
+
         // start sandbox
-        runtime_instance
+        instance
             .sandbox
             .start(dns, spec, state, network_env)
             .await
             .context("start sandbox")?;
-        self.runtime_instance = Some(Arc::new(runtime_instance));
+
         Ok(())
     }
 


### PR DESCRIPTION
We should init and asign the runtime instance to runtime handler, otherwise, if the pause container failed to start, which means the runtime instance failed to start, then the following delete & shutdown request wouldn't be run, thus the dead shim would be left.

Fixes: #9597