### PR TITLE
qemu: the error is logged only when it occurs

### DIFF
--- a/src/runtime/virtcontainers/qemu_arm64.go
+++ b/src/runtime/virtcontainers/qemu_arm64.go
@@ -156,6 +156,8 @@ func (q *qemuArm64) enableProtection() error {
 
 func (q *qemuArm64) appendProtectionDevice(devices []govmmQemu.Device, firmware, firmwareVolume string) ([]govmmQemu.Device, string, error) {
 	err := q.enableProtection()
-	hvLogger.WithField("arch", runtime.GOARCH).Warnf("%v", err)
+	if err != nil {
+		hvLogger.WithField("arch", runtime.GOARCH).Error(err)
+	}
 	return devices, firmware, err
 }


### PR DESCRIPTION
Everytime I create contianer on arm64 machine, containerd/kata logs a redundant warning as follows:

``` shell
time="2024-05-07" level=warning msg="<nil>" arch=arm64 name=containerd-shim-v2 pid=xxx sandbox=fdd1f05 source=virtcontainers/hypervisor
```

I added an error statement so that the error would be logged when it occurs.