### PR TITLE
genpolicy: test more platforms

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -269,7 +269,8 @@
         ]
     },
     "kata_config": {
-        "confidential_guest": false
+        "confidential_guest": false,
+        "oci_version": "1.1.0-rc.1"
     },
     "cluster_config": {
         "default_namespace": "default",

--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -266,7 +266,8 @@
             "CAP_PERFMON",
             "CAP_BPF",
             "CAP_CHECKPOINT_RESTORE"
-        ]
+        ],
+        "bundle_path_prefix": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/"
     },
     "kata_config": {
         "confidential_guest": false,

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -66,8 +66,7 @@ CreateContainerRequest {
     p_oci := p_container.OCI
 
     print("CreateContainerRequest: p Version =", p_oci.Version, "i Version =", i_oci.Version)
-    # TODO: Reenable when the Mariner host is reinstated, see #9593.
-    # p_oci.Version == i_oci.Version
+    p_oci.Version == i_oci.Version
 
     print("CreateContainerRequest: p Readonly =", p_oci.Root.Readonly, "i Readonly =", i_oci.Root.Readonly)
     p_oci.Root.Readonly == i_oci.Root.Readonly

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -432,7 +432,7 @@ allow_by_bundle_or_sandbox_id(p_oci, i_oci, p_storages, i_storages) {
     print("allow_by_bundle_or_sandbox_id: start")
 
     bundle_path := i_oci.Annotations["io.katacontainers.pkg.oci.bundle_path"]
-    bundle_id := replace(bundle_path, "/run/containerd/io.containerd.runtime.v2.task/k8s.io/", "")
+    bundle_id := replace(bundle_path, policy_data.common.bundle_path_prefix, "")
 
     key := "io.kubernetes.cri.sandbox-id"
 
@@ -755,11 +755,12 @@ mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id) {
 mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id) {
     regex1 := p_mount.source
     regex2 := replace(regex1, "$(sfprefix)", policy_data.common.sfprefix)
-    regex3 := replace(regex2, "$(cpath)", policy_data.common.cpath)
+    regex3 := replace(regex2, "$(cpath)", "/run/kata-containers/shared/containers")
     regex4 := replace(regex3, "$(sandbox-id)", sandbox_id)
+    regex5 := replace(regex4, "$(bundle-id)", bundle_id)
 
-    print("mount_source_allows 2: regex4 =", regex4)
-    regex.match(regex4, i_mount.source)
+    print("mount_source_allows 2: regex5 =", regex5)
+    regex.match(regex5, i_mount.source)
 
     print("mount_source_allows 2: true")
 }

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -29,9 +29,6 @@ use std::collections::BTreeMap;
 use std::fs::read_to_string;
 use std::io::Write;
 
-// TODO: load this value from the settings file.
-const DEFAULT_OCI_VERSION: &str = "1.1.0-rc.1";
-
 /// Intermediary format of policy data.
 pub struct AgentPolicy {
     /// K8s resources described by the input YAML file.
@@ -73,7 +70,7 @@ pub struct PolicyData {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KataSpec {
     /// Version of the Open Container Initiative Runtime Specification with which the bundle complies.
-    #[serde(default = "version_default")]
+    #[serde(default)]
     pub Version: String,
 
     /// Process configures the container process.
@@ -98,10 +95,6 @@ pub struct KataSpec {
     /// Linux is platform-specific configuration for Linux based containers.
     #[serde(default)]
     pub Linux: KataLinux,
-}
-
-fn version_default() -> String {
-    DEFAULT_OCI_VERSION.to_string()
 }
 
 /// OCI container Process struct. This struct is very similar to the Process
@@ -565,7 +558,7 @@ impl AgentPolicy {
 
         ContainerPolicy {
             OCI: KataSpec {
-                Version: version_default(),
+                Version: self.config.settings.kata_config.oci_version.clone(),
                 Process: process,
                 Root: root,
                 Mounts: mounts,

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -350,6 +350,9 @@ pub struct CommonData {
 
     /// Default capabilities for a privileged container.
     pub privileged_caps: Vec<String>,
+
+    /// Prefix for bundled path
+    pub bundle_path_prefix: String,
 }
 
 /// Configuration from "kubectl config".

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -64,6 +64,7 @@ pub struct ConfigMapVolume {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KataConfig {
     pub confidential_guest: bool,
+    pub oci_version: String,
 }
 
 impl Settings {

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -12,9 +12,12 @@ DEBUG="${DEBUG:-}"
 [ -n "$DEBUG" ] && set -x
 
 kubernetes_dir="$(dirname "$(readlink -f "$0")")"
+# shellcheck disable=1091
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
 # shellcheck disable=1091
 source "${kubernetes_dir}/confidential_kbs.sh"
+# shellcheck disable=1091
+source "${kubernetes_dir}/tests_common.sh"
 # shellcheck disable=2154
 tools_dir="${repo_root_dir}/tools"
 kata_tarball_dir="${2:-kata-artifacts}"
@@ -268,7 +271,7 @@ function run_tests() {
 	# and enable cri plugin in containerd config.
 	# TODO: enable testing auto-generated policy for other types of hosts too.
 
-	if [ "${KATA_HOST_OS}" = "cbl-mariner" ]; then
+	if policy_tests_enabled; then
 
 		export AUTO_GENERATE_POLICY="yes"
 

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -4,6 +4,8 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+# shellcheck disable=1091
+
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -12,11 +14,8 @@ DEBUG="${DEBUG:-}"
 [ -n "$DEBUG" ] && set -x
 
 kubernetes_dir="$(dirname "$(readlink -f "$0")")"
-# shellcheck disable=1091
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
-# shellcheck disable=1091
 source "${kubernetes_dir}/confidential_kbs.sh"
-# shellcheck disable=1091
 source "${kubernetes_dir}/tests_common.sh"
 # shellcheck disable=2154
 tools_dir="${repo_root_dir}/tools"
@@ -274,11 +273,13 @@ function run_tests() {
 	if policy_tests_enabled; then
 
 		export AUTO_GENERATE_POLICY="yes"
-
-		# set default containerd config
-		sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
-		echo "containerd config has been set to default"
-		sudo systemctl restart containerd && sudo systemctl is-active containerd
+        
+		if [ "${GENPOLICY_PULL_METHOD}" = "containerd" ]; then
+			# set default containerd config
+			sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
+			echo "containerd config has been set to default"
+			sudo systemctl restart containerd && sudo systemctl is-active containerd
+		fi
 	fi
 
 	set_test_cluster_namespace

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -53,7 +53,7 @@ setup() {
 }
 
 @test "Successful pod with auto-generated policy and runtimeClassName filter" {
-	runtime_class_name=$(yq read "${testcase_pre_generate_pod_yaml}" "spec.runtimeClassName")
+	runtime_class_name=$(yq ".spec.runtimeClassName" < "${testcase_pre_generate_pod_yaml}" )
 
 	auto_generate_policy "${pod_config_dir}" "${testcase_pre_generate_pod_yaml}" "${testcase_pre_generate_configmap_yaml}" \
 		"--runtime-class-names=other-runtime-class-name --runtime-class-names=${runtime_class_name}" 
@@ -146,7 +146,7 @@ test_pod_policy_error() {
 
 @test "RuntimeClassName filter: no policy" {
 	# The policy should not be generated because the pod spec does not have a runtimeClassName.
-	runtime_class_name=$(yq read "${testcase_pre_generate_pod_yaml}" "spec.runtimeClassName")
+	runtime_class_name=$(yq ".spec.runtimeClassName" < "${testcase_pre_generate_pod_yaml}")
 
 	auto_generate_policy "${pod_config_dir}" "${testcase_pre_generate_pod_yaml}" "${testcase_pre_generate_configmap_yaml}" \
 		"--runtime-class-names=other-${runtime_class_name}"

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -140,16 +140,21 @@ create_common_genpolicy_settings() {
 
 	# TODO: Remove once the Mariner host is reinstated, see #9593.
 	# Set the OCI version to 1.1.0 for "Mariner" (temporary using Ubuntu instead) host.
-	[ "${KATA_HOST_OS}" = "cbl-mariner" ] && sudo sed -i 's|"oci_version": "1\.1\.0-rc\.1"|"oci_version": "1\.1\.0"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	[ "${KATA_HOST_OS}" = "cbl-mariner" ] && \
+	sudo sed -i 's|"oci_version": "1\.1\.0-rc\.1"|"oci_version": "1\.1\.0"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 
 	# Set the OCI version to 1.2.0 for "qemu-tdx" hypervisor.
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && sudo sed -i 's|"oci_version": "1\.1\.0-rc\.1"|"oci_version": "1\.2\.0"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && \
+	sudo sed -i 's|"oci_version": "1\.1\.0-rc\.1"|"oci_version": "1\.2\.0"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 
-	# Set cpath to /run/kata-containers for "qemu-sev" hypervisor.
-	[ "${KATA_HYPERVISOR}" = "qemu-sev" ] && sudo sed -i 's|"cpath": "/run/kata-containers/shared/containers"|"cpath": "/run/kata-containers"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
-
+	# Set cpath to /run/kata-containers, remove "watchable" from configmap mountpoint for "qemu-snp", "qemu-tdx, and ""qemu-sev" hypervisor.
+	{ [ "${KATA_HYPERVISOR}" = "qemu-snp" ] || [ "${KATA_HYPERVISOR}" = "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" = "qemu-sev" ]; } && \
+	sudo sed -i 's|"cpath": "/run/kata-containers/shared/containers"|"cpath": "/run/kata-containers"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json" && \
+	sudo sed -i 's|/watchable||g' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	
 	# update the bundle path prefix for k3s
-	[ "${KUBERNETES}" = "k3s" ] && sudo sed -i 's|"bundle_path_prefix": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/"|"bundle_path_prefix": "/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	[ "${KUBERNETES}" = "k3s" ] && \
+	sudo sed -i 's|"bundle_path_prefix": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/"|"bundle_path_prefix": "/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 	
 	cat "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 	

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -141,20 +141,19 @@ create_common_genpolicy_settings() {
 	# TODO: Remove once the Mariner host is reinstated, see #9593.
 	# Set the OCI version to 1.1.0 for "Mariner" (temporary using Ubuntu instead) host.
 	[ "${KATA_HOST_OS}" = "cbl-mariner" ] && \
-	sudo sed -i 's|"oci_version": "1\.1\.0-rc\.1"|"oci_version": "1\.1\.0"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	jq '.kata_config.oci_version = "1.1.0"' "${default_genpolicy_settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 
 	# Set the OCI version to 1.2.0 for "qemu-tdx" hypervisor.
 	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && \
-	sudo sed -i 's|"oci_version": "1\.1\.0-rc\.1"|"oci_version": "1\.2\.0"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	jq '.kata_config.oci_version = "1.2.0"' "${default_genpolicy_settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 
 	# Set cpath to /run/kata-containers, remove "watchable" from configmap mountpoint for "qemu-snp", "qemu-tdx, and ""qemu-sev" hypervisor.
 	{ [ "${KATA_HYPERVISOR}" = "qemu-snp" ] || [ "${KATA_HYPERVISOR}" = "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" = "qemu-sev" ]; } && \
-	sudo sed -i 's|"cpath": "/run/kata-containers/shared/containers"|"cpath": "/run/kata-containers"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json" && \
-	sudo sed -i 's|/watchable||g' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	jq '.common.cpath = "/run/kata-containers" | .volumes.configMap.mount_point = "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-"' "${default_genpolicy_settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 	
 	# update the bundle path prefix for k3s
 	[ "${KUBERNETES}" = "k3s" ] && \
-	sudo sed -i 's|"bundle_path_prefix": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/"|"bundle_path_prefix": "/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	jq '.common.bundle_path_prefix = "/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/"' "${default_genpolicy_settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 	
 	cat "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 	

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -138,14 +138,21 @@ create_common_genpolicy_settings() {
 
 	auto_generate_policy_enabled || return 0
 
+	# TODO: Remove once the Mariner host is reinstated, see #9593.
+	# Set the OCI version to 1.1.0 for "Mariner" (temporary using Ubuntu instead) host.
+	[ "${KATA_HOST_OS}" = "cbl-mariner" ] && sudo sed -i 's/"oci_version": "1\.1\.0-rc\.1"/"oci_version": "1\.1\.0"/' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+
+	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && sudo sed -i 's/"oci_version": "1\.1\.0-rc\.1"/"oci_version": "1\.2\.0"/' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 	cp "${default_genpolicy_settings_dir}/genpolicy-settings.json" "${genpolicy_settings_dir}"
 	cp "${default_genpolicy_settings_dir}/rules.rego" "${genpolicy_settings_dir}"
 
 	# Set the default namespace of Kata CI tests in the genpolicy settings.
 	set_namespace_to_policy_settings "${genpolicy_settings_dir}" "${TEST_CLUSTER_NAMESPACE}"
 
-	# allow genpolicy to access containerd without sudo
-	sudo chmod a+rw /var/run/containerd/containerd.sock
+	if [ "${GENPOLICY_PULL_METHOD}" == "containerd" ]; then
+		# allow genpolicy to access containerd without sudo
+		sudo chmod a+rw /var/run/containerd/containerd.sock
+	fi
 }
 
 # If auto-generated policy testing is enabled, make a copy of the common genpolicy settings

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -140,9 +140,19 @@ create_common_genpolicy_settings() {
 
 	# TODO: Remove once the Mariner host is reinstated, see #9593.
 	# Set the OCI version to 1.1.0 for "Mariner" (temporary using Ubuntu instead) host.
-	[ "${KATA_HOST_OS}" = "cbl-mariner" ] && sudo sed -i 's/"oci_version": "1\.1\.0-rc\.1"/"oci_version": "1\.1\.0"/' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	[ "${KATA_HOST_OS}" = "cbl-mariner" ] && sudo sed -i 's|"oci_version": "1\.1\.0-rc\.1"|"oci_version": "1\.1\.0"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
 
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && sudo sed -i 's/"oci_version": "1\.1\.0-rc\.1"/"oci_version": "1\.2\.0"/' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	# Set the OCI version to 1.2.0 for "qemu-tdx" hypervisor.
+	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && sudo sed -i 's|"oci_version": "1\.1\.0-rc\.1"|"oci_version": "1\.2\.0"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+
+	# Set cpath to /run/kata-containers for "qemu-sev" hypervisor.
+	[ "${KATA_HYPERVISOR}" = "qemu-sev" ] && sudo sed -i 's|"cpath": "/run/kata-containers/shared/containers"|"cpath": "/run/kata-containers"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+
+	# update the bundle path prefix for k3s
+	[ "${KUBERNETES}" = "k3s" ] && sudo sed -i 's|"bundle_path_prefix": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/"|"bundle_path_prefix": "/run/k3s/containerd/io.containerd.runtime.v2.task/k8s.io/"|' "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	
+	cat "${default_genpolicy_settings_dir}/genpolicy-settings.json"
+	
 	cp "${default_genpolicy_settings_dir}/genpolicy-settings.json" "${genpolicy_settings_dir}"
 	cp "${default_genpolicy_settings_dir}/rules.rego" "${genpolicy_settings_dir}"
 


### PR DESCRIPTION
- Enable genpolicy testing on sev, snp and tdx
- load oci version from settings. Set to default `1.1.0`
- reenable checking the OCI version in rules.rego
- added todo to modify oci version in genpolicy settings to `1.1.0-rc.1` for Mariner, once Mariner is reinstated as host (https://github.com/kata-containers/kata-containers/issues/9594)

Fixes: #9593