### PR TITLE
ci: Stop building TDX specific QEMU and OVMF

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -47,7 +47,6 @@ jobs:
           - pause-image
           - qemu
           - qemu-snp-experimental
-          - qemu-tdx-experimental
           - stratovirt
           - rootfs-image
           - rootfs-image-confidential
@@ -56,7 +55,6 @@ jobs:
           - rootfs-initrd-mariner
           - runk
           - shim-v2
-          - tdvf
           - trace-forwarder
           - virtiofsd
         stage:


### PR DESCRIPTION
This is the first step of the work to start relying on the artefacts coming from the distros (CentOS 9 Stream, and Ubuntu) themselves.

Let's have this first one merged, as this will not run the CI due to the changes being on the yaml itself, and then follow-up with the changes needed on other parts of the project (kata-deploy, runtime, etc).

Fixes: #9590 -- part I