### PR TITLE
tests: pull-image: Don't run on TEEs

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -9,7 +9,8 @@ load "${BATS_TEST_DIRNAME}/lib.sh"
 load "${BATS_TEST_DIRNAME}/confidential_common.sh"
 
 setup() {
-    confidential_setup || skip "Test not supported for ${KATA_HYPERVISOR}."
+    confidential_setup && skip "Due to issues related to pull-image integration skip tests for ${KATA_HYPERVISOR}."
+
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
     setup_common 
@@ -19,6 +20,8 @@ setup() {
 }
 
 @test "Test we can pull an unencrypted image outside the guest with runc and then inside the guest successfully" {
+    confidential_setup && skip "Due to issues related to pull-image integration skip tests for ${KATA_HYPERVISOR}."
+
     # 1. Create one runc pod with the $unencrypted_image_1 image
     # We want to have one runc pod, so we pass a fake runtimeclass "runc" and then delete the runtimeClassName,
     # because the runtimeclass is not optional in new_pod_config function.
@@ -213,7 +216,8 @@ setup() {
 }
 
 teardown() {
-    check_hypervisor_for_confidential_tests ${KATA_HYPERVISOR} || skip "Test not supported for ${KATA_HYPERVISOR}."
+    confidential_setup && skip "Due to issues related to pull-image integration skip tests for ${KATA_HYPERVISOR}."
+
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
     kubectl describe pod "$pod_name"


### PR DESCRIPTION
Let's skip those tests on TEEs as we've been facing a reasonable amount of issues, most likely on the containerd side, related to pulling the image on the guest.

Once we're able to fix the issues on containerd, we can get back and re-enable those by reverting this commit.

The decision of disabling the tests for TEEs is because the machines may end up in a state where human intervention is necessary to get them back to a functional state, and that's really not optimal for our CI.