### PR TITLE
kata-deploy: Fix tdx_not_supported call

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -273,7 +273,7 @@ function install_artifacts() {
 					esac
 					;;
 				*)
-					tdx_not_supported_warning
+					tdx_not_supported ${ID} ${VERSION_ID}
 					;;
 			esac	
 		fi


### PR DESCRIPTION
the `tdx_not_supported_warning` function does not exists, the `tdx_not_supported` should be called instead.

Fixes: #9628