### PR TITLE
version: Bump nydus snapshotter to v0.13.13

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -317,7 +317,7 @@ externals:
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.13.11"
+    version: "v0.13.13"
 
   ovmf:
     description: "Firmware, implementation of UEFI for virtual machines."


### PR DESCRIPTION
Bump nydus snapshotter to v0.13.13 to fix the gap when switching different snapshotters in guest pull.

Fixes: #8407