### PR TITLE
runtime: Add missing check in ResizeMemory for CH

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1042,11 +1042,14 @@ func (clh *cloudHypervisor) ResizeMemory(ctx context.Context, reqMemMB uint32, m
 		newMem = alignedRequest
 	}
 
-	// Check if memory is the same as requested, a second Check is done
-	// to consider the memory request now that is updated to be memory aligned
+	// Post-alignment checks
 	if currentMem == newMem {
 		clh.Logger().WithFields(log.Fields{"current-memory": currentMem, "new-memory": newMem}).Debug("VM already has requested memory(after alignment)")
 		return uint32(currentMem.ToMiB()), MemoryDevice{}, nil
+	}
+	// Check for aligned memory exceeding max hotplug size
+	if newMem > (utils.MemUnit(uint32(maxHotplugSize.ToMiB())) * utils.MiB) {
+		newMem = utils.MemUnit(uint32(maxHotplugSize.ToMiB())) * utils.MiB
 	}
 
 	cl := clh.client()


### PR DESCRIPTION
ResizeMemory for Cloud Hypervisor is missing a check for the new requested memory being greater than the max hotplug size after alignment. Add the check, and since an earlier check for this setsrequested memory to the max hotplug size, do the same in the post-alignment check.

Fixes #9640