### PR TITLE
runtime-rs: Drop some useless QEMU arguments

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -363,10 +363,6 @@ struct Knobs {
     nodefaults: bool,
     nographic: bool,
     no_reboot: bool,
-    no_shutdown: bool,
-    daemonize: bool,
-    stopped: bool,
-
     vga: String,
 }
 
@@ -377,9 +373,6 @@ impl Knobs {
             nodefaults: true,
             nographic: true,
             no_reboot: true,
-            no_shutdown: false,
-            daemonize: false,
-            stopped: false,
             vga: "none".to_owned(),
         }
     }
@@ -402,15 +395,6 @@ impl ToQemuParams for Knobs {
         }
         if self.no_reboot {
             result.push("-no-reboot".to_owned());
-        }
-        if self.no_shutdown {
-            result.push("-no-shutdown".to_owned());
-        }
-        if self.daemonize {
-            result.push("-daemonize".to_owned());
-        }
-        if self.stopped {
-            result.push("-S".to_owned());
         }
         Ok(result)
     }


### PR DESCRIPTION
All these settings are hardcoded as `false` and result in no extra options on the QEMU command line, like the go runtime does. There actually not needed :
- we're never going to ask QEMU to survive a guest shutdown
- we're never going to run QEMU daemonized since it prevents log collection
- we're never going to ask QEMU to start with the guest stopped

No need to keep this code around then.