### PR TITLE
ci: cache: Fix unbound variable

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -1177,7 +1177,7 @@ handle_build() {
 		esac
 
 		tags=(latest-${TARGET_BRANCH}-$(uname -m))
-		if [ -n "${artefact_tag}" ]; then
+		if [ -n "${artefact_tag:-}" ]; then
 			tags+=("${artefact_tag}")
 		fi
 		if [ "${RELEASE}" == "yes" ]; then


### PR DESCRIPTION
Now we have the workflow updated and can test the changes in caching we've hit an error:
```
line 1180: artefact_tag: unbound variable
```
so we need to fix that up. Sorry for missing this before.