### PR TITLE
k8s: Update negative confidential attestation k8s tests

### DIFF
--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -76,9 +76,7 @@ setup() {
 	sleep 5
 
 	kubectl logs aa-test-cc
-	cmd="kubectl logs aa-test-cc | grep -q aatest"
-	run $cmd
-	[ "$status" -eq 1 ]
+	kubectl logs aa-test-cc | grep -q "Failed to connect"
 }
 
 teardown() {


### PR DESCRIPTION
This PR updates the negative confidential attestation k8s test to look for a message when we are trying to retrieve the logs from the pod.