### PR TITLE
CI: Append arch type to initramfs-cryptsetup image

### DIFF
--- a/tools/packaging/static-build/initramfs/build.sh
+++ b/tools/packaging/static-build/initramfs/build.sh
@@ -32,7 +32,7 @@ package_output_dir="${package_output_dir:-}"
 [ -n "${lvm2_repo}" ] || die "Failed to get lvm2 repo"
 [ -n "${lvm2_version}" ] || die "Failed to get lvm2 version"
 
-container_image="${BUILDER_REGISTRY}:initramfs-cryptsetup-${cryptsetup_version}-lvm2-${lvm2_version}-$(get_last_modification ${repo_root_dir} ${script_dir})"
+container_image="${BUILDER_REGISTRY}:initramfs-cryptsetup-${cryptsetup_version}-lvm2-${lvm2_version}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)"
 
 sudo docker pull ${container_image} || (sudo docker build \
 	--build-arg cryptsetup_repo="${cryptsetup_repo}" \


### PR DESCRIPTION
This PR is to append an arch type to the initramfs-cryptsetup image to prevent a wrong arch image from being pulled on a different arch host.

Fixes: #9654

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>