### PR TITLE
ci: cache: Filter out non-printable characters from tag

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -1148,8 +1148,9 @@ handle_build() {
 		echo "Pushing ${build_target} with tags: ${tags[*]}"
 
 		for tag in "${tags[@]}"; do
-			# tags can only contain lowercase and uppercase letters, digits, underscores, periods, and hyphens
-			tag=("$(echo ${tag} | tr -c '[a-zA-Z0-9\_\.\-]' _)")
+			# tags can only contain lowercase and uppercase letters, digits, underscores, periods, and hyphens, so
+			# filter out non-printable characers and then replace invalid printable characters with underscode
+			tag=("$(echo ${tag} | tr -dc '[:print:]' | tr -c '[a-zA-Z0-9\_\.\-]' _)")
 			case ${build_target} in
 				kernel-nvidia-gpu)
 					sudo oras push \


### PR DESCRIPTION
- The tags have a trailing non-printable character, which results in our cache tags having a trailing underscore e.g. `ghcr.io/kata-containers/cached-artefacts/agent:ce24e9835_` For ease of use of these cached components, we should strip off the trailing underscore.