### PR TITLE
fix: kata-deploy.sh VERSION_ID unbound-variable

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -250,6 +250,7 @@ function install_artifacts() {
 		fi
 
 		if grep -q "tdx" <<< "$shim"; then
+  			VERSION_ID=version_unset # VERSION_ID may be unset, see https://www.freedesktop.org/software/systemd/man/latest/os-release.html#Notes
 			source /host/etc/os-release || source /host/usr/lib/os-release
 			case ${ID} in
 				ubuntu)


### PR DESCRIPTION
fixes #9670

VERSION_ID is not guaranteed to be specified in os-release, this makes kaka-deploy breaks in rolling distros like arch linux and void linux.

> Note that operating system vendors may choose not to provide version information, for example to accommodate for rolling releases. In this case, VERSION and **VERSION_ID may be unset. Applications should not rely on these fields to be set.**