### PR TITLE
Revert "ci: azure: Workaround azure cli installation script"

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -62,14 +62,7 @@ function enable_cluster_http_application_routing() {
 }
 
 function install_azure_cli() {
-	# This is a workaround for https://github.com/Azure/azure-cli/issues/28984
-	# which ended up breaking our CI.
-	curl -sL https://aka.ms/InstallAzureCLIDeb -o installAzureCli.sh
-	sed -i '/curl -sLS https:\/\/packages.microsoft.com\/keys\/microsoft.asc |/d' installAzureCli.sh
-	sed -i '/gpg --dearmor -o \/etc\/apt\/keyrings\/microsoft.gpg/d' installAzureCli.sh
-	sed -i '/chmod go+r \/etc\/apt\/keyrings\/microsoft.gpg/d' installAzureCli.sh
-	sudo bash installAzureCli.sh
-
+	curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 	# The aks-preview extension is required while the Mariner Kata host is in preview.
 	az extension add --name aks-preview
 }


### PR DESCRIPTION
This reverts commit 5ff53e4d1cb94cef04477e36135b932edd28e077, as the script was fixed by MSFT, at least according to:
https://github.com/Azure/azure-cli/issues/28984