### PR TITLE
gha: release: Set inherit secrets on tarball builds

### DIFF
--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -12,6 +12,7 @@ jobs:
     with:
       push-to-registry: yes
       stage: release
+    secrets: inherit
 
   kata-deploy:
     needs: build-kata-static-tarball-amd64

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -12,6 +12,7 @@ jobs:
     with:
       push-to-registry: yes
       stage: release
+    secrets: inherit
 
   kata-deploy:
     needs: build-kata-static-tarball-arm64

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -12,6 +12,7 @@ jobs:
     with:
       push-to-registry: yes
       stage: release
+    secrets: inherit
 
   kata-deploy:
     needs: build-kata-static-tarball-ppc64le


### PR DESCRIPTION
Now we have updated the release builds to push artefacts to
our registry for the release, so we can cache the images, we need to set
`secrets: inherit` for all architecture's tarball builds so that we can log into quay.io and ghcr in those steps

This change was tested on release workflow https://github.com/kata-containers/kata-containers/actions/runs/9158766910/job/25179503476 which was green