### PR TITLE
kata-manager: Copy cni files under /opt/cni

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -584,6 +584,14 @@ install_nerdctl()
 		done
 
 	info "$project installed\n"
+
+	sudo mkdir -p /opt/cni/bin
+
+	# nerdctl requires cni plugins to be installed in /opt/cni/bin
+	# Copy extracted tarball cni files under /usr/local/libexec
+	sudo cp /usr/local/libexec/cni/* /opt/cni/bin/
+
+	info "cni plugins installed under /opt/cni/bin"
 }
 
 configure_containerd()


### PR DESCRIPTION
nerdctl requires cni plugins to be installed in /opt/cni/bin
Without bridge plugin installed, it is not possible to run a
container with nerdctl.
The downloaded nerdctl tarball contains cni plugin files, but are
extracted under /usr/local/libexec.
Copy extracted tarball cni files under /usr/local/libexec
to /opt/cni/bin

Signed-off-by: Archana Shinde <archana.m.shinde@intel.com>