### PR TITLE
gha: Enable install kbs and coco components for TDX, but still skip the CDH test

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -125,16 +125,26 @@ kbs_set_resource_from_file() {
 kbs_install_cli() {
 	command -v kbs-client >/dev/null && return
 
-	if ! command -v apt >/dev/null; then
-		>&2 echo "ERROR: running on unsupported distro"
-		return 1
-	fi
+	source /etc/os-release || source /usr/lib/os-release
+	case "${ID}" in
+		ubuntu)
+			local pkgs="build-essential"
 
-	local pkgs="build-essential"
+			sudo apt-get update -y
+			# shellcheck disable=2086
+			sudo apt-get install -y $pkgs
+			;;
+		centos)
+			local pkgs="make"
 
-	sudo apt-get update -y
-	# shellcheck disable=2086
-	sudo apt-get install -y $pkgs
+			# shellcheck disable=2086
+			sudo dnf install -y $pkgs
+			;;
+		*)
+			>&2 echo "ERROR: running on unsupported distro"
+			return 1
+			;;
+	esac
 
 	# Mininum required version to build the client (read from versions.yaml)
 	local rust_version

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -153,9 +153,13 @@ kbs_install_cli() {
 }
 
 kbs_uninstall_cli() {
-	pushd "${COCO_KBS_DIR}"
-	sudo make uninstall
-	popd
+	if [ -d "${COCO_KBS_DIR}" ]; then
+		pushd "${COCO_KBS_DIR}"
+		sudo make uninstall
+		popd
+	else
+		echo "${COCO_KBS_DIR} does not exist in the machine, skip uninstalling the kbs cli"
+	fi
 }
 
 # Delete the kbs on Kubernetes

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -238,6 +238,7 @@ function kbs_k8s_deploy() {
 
 	echo "::group::Deploy the KBS"
 	if [ "${KATA_HYPERVISOR}" = "qemu-tdx" ]; then
+		echo "Setting up custom PCCS for TDX"
 		cat <<- EOF > "${COCO_KBS_DIR}/config/kubernetes/custom_pccs/sgx_default_qcnl.conf"
 {
  "pccs_url": "https://localhost:8081/sgx/certification/v4/",

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -139,7 +139,7 @@ kbs_install_cli() {
 	# Mininum required version to build the client (read from versions.yaml)
 	local rust_version
 	ensure_yq
-	rust_version=$(get_from_kata_deps "externals.coco-kbs.toolchain")
+	rust_version=$(get_from_kata_deps "externals.coco-trustee.toolchain")
 	# Currently kata version from version.yaml is 1.72.0
 	# which doesn't match the requirement, so let's pass
 	# the required version.

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -131,12 +131,7 @@ function configure_snapshotter() {
 }
 
 function delete_coco_kbs() {
-	if [ "${KATA_HYPERVISOR}" == "qemu-tdx" ]; then
-		echo "Skipping deleting coco kbs for ${KATA_HYPERVISOR}"
-		exit 0
-	else
-		kbs_k8s_delete
-	fi
+	kbs_k8s_delete
 }
 
 # Deploy the CoCo KBS in Kubernetes
@@ -146,12 +141,7 @@ function delete_coco_kbs() {
 #	              service externally
 #
 function deploy_coco_kbs() {
-	if [ "${KATA_HYPERVISOR}" == "qemu-tdx" ]; then
-		echo "Skipping deploying coco kbs for ${KATA_HYPERVISOR}"
-		exit 0
-	else
-		kbs_k8s_deploy "$KBS_INGRESS"
-	fi
+	kbs_k8s_deploy "$KBS_INGRESS"
 }
 
 function deploy_kata() {
@@ -273,21 +263,11 @@ function deploy_kata() {
 }
 
 function install_kbs_client() {
-	if [ "${KATA_HYPERVISOR}" == "qemu-tdx" ]; then
-		echo "Skipping install kbs client for ${KATA_HYPERVISOR}"
-		exit 0
-	else
-		kbs_install_cli
-	fi
+	kbs_install_cli
 }
 
 function uninstall_kbs_client() {
-	if [ "${KATA_HYPERVISOR}" == "qemu-tdx" ]; then
-		echo "Skipping uninstall kbs client for ${KATA_HYPERVISOR}"
-		exit 0
-	else
-		kbs_uninstall_cli
-	fi
+	kbs_uninstall_cli
 }
 
 function run_tests() {

--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -15,6 +15,7 @@ export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 export AA_KBC="${AA_KBC:-cc_kbc}"
 
 setup() {
+	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "Test not ready yet for ${KATA_HYPERVISOR}"
 	is_confidential_runtime_class || skip "Test not supported for ${KATA_HYPERVISOR}."
 
 	if [ "${KBS}" = "false" ]; then
@@ -82,6 +83,7 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "Test not ready yet for ${KATA_HYPERVISOR}"
 	is_confidential_runtime_class || skip "Test not supported for ${KATA_HYPERVISOR}."
 
 	if [ "${KBS}" = "false" ]; then

--- a/versions.yaml
+++ b/versions.yaml
@@ -227,9 +227,9 @@ externals:
   coco-trustee:
     description: "Provides attestation and secret delivery components"
     url: "https://github.com/confidential-containers/trustee"
-    version: "18c8ee378c6d83446ee635a702d5dee389028d8f"
+    version: "6adb8383309cbb7279f1d8e1e4620556ac66481e"
     image: "ghcr.io/confidential-containers/staged-images/kbs"
-    image_tag: "18c8ee378c6d83446ee635a702d5dee389028d8f"
+    image_tag: "6adb8383309cbb7279f1d8e1e4620556ac66481e"
     toolchain: "1.74.0"
 
   crio:


### PR DESCRIPTION
This PR enables the installation and unistallation of the kbs client as well as general coco components needed for the TDX GHA CI.