### PR TITLE
metrics: Fix minvalue for boot time

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -16,7 +16,7 @@ description = "measure container lifecycle timings"
 # within (inclusive)
 checkvar = ".\"boot-times\".Results | .[] | .\"to-workload\".Result"
 checktype = "mean"
-midval = 0.69
+midval = 0.39
 minpercent = 40.0
 maxpercent = 30.0
 


### PR DESCRIPTION
This PR fixes the minvalue for boot time to avoid the random failures of the GHA CI.