### PR TITLE
agent-ctl: Refactor CopyFile handler.

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -376,3 +376,34 @@ jobs:
           name: nerdctl-tests-garm-${{ matrix.vmm }}
           path: /tmp/artifacts
           retention-days: 1
+
+  run-test-agent-apis:
+    strategy:
+      fail-fast: false
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Install dependencies
+        run: bash tests/functional/test-agent-apis/gha-run.sh install-dependencies
+
+      - name: get-kata-tarball
+        uses: actions/download-artifact@v3
+        with:
+          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          path: kata-artifacts
+
+      - name: Install kata
+        run: bash tests/functional/test-agent-apis/gha-run.sh install-kata kata-artifacts
+
+      - name: Run test agent apis with agent-ctl
+        run: bash tests/functional/test-agent-apis/gha-run.sh run

--- a/src/tools/agent-ctl/src/types.rs
+++ b/src/tools/agent-ctl/src/types.rs
@@ -20,3 +20,10 @@ pub struct Config {
     pub ignore_errors: bool,
     pub no_auto_values: bool,
 }
+
+// CopyFile input struct
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct CopyFileInput {
+    pub src: String,
+    pub dest: String,
+}

--- a/tests/functional/test-agent-apis/gha-run.sh
+++ b/tests/functional/test-agent-apis/gha-run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Copyright (c) 2024 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+kata_tarball_dir="${2:-kata-artifacts}"
+test_agent_apis_dir="$(dirname "$(readlink -f "$0")")"
+source "${test_agent_apis_dir}/../../common.bash"
+
+function install_dependencies() {
+	info "Installing dependencies needed for testing individual agent apis using agent-ctl"
+
+	# Dependency list of projects that we can rely on the system packages
+	# - jq
+	declare -a deps=(
+		jq
+	)
+
+	sudo apt-get update
+	sudo apt-get -y install "${deps[@]}"
+}
+
+function run() {
+	info "Testing agent apis with agent-ctl."
+
+	bash -c ${test_agent_apis_dir}/run-agent-api-tests.sh
+}
+
+function main() {
+	action="${1:-}"
+	case "${action}" in
+		install-dependencies) install_dependencies ;;
+		install-kata) install_kata ;;
+		run) run ;;
+		*) >&2 die "Invalid argument" ;;
+	esac
+}
+
+main "$@"

--- a/tests/functional/test-agent-apis/run-agent-api-tests.sh
+++ b/tests/functional/test-agent-apis/run-agent-api-tests.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+test_agent_apis_dir="$(dirname "$(readlink -f "$0")")"
+source "${test_agent_apis_dir}/../../common.bash"
+source "${test_agent_apis_dir}/setup_common.sh"
+
+usage()
+{
+	cat <<EOF
+
+Usage: $script_name [<command>]
+
+Summary: Test agent ttrpc apis using agent-ctl tool.
+
+Description: Test agent exposed ttrpc api endpoints using agent-ctl tool.
+A number of variations of the inputs are used to test an inidividual api
+to validate success & failure code paths.
+
+Commands:
+
+  help   - Show usage.
+
+Notes:
+  - Currently, the script *does not support* running individual agent api tests.
+
+EOF
+}
+
+run_tests() {
+    info "Running tests."
+    bats "${test_agent_apis_dir}/test-agent-apis.bats"
+}
+
+main()
+{
+	local cmd="${1:-}"
+
+	case "$cmd" in
+		help|-h|-help|--help) usage; exit 0;;
+	esac
+
+	trap cleanup EXIT
+
+	setup_agent
+
+	run_tests
+}
+
+main "$@"

--- a/tests/functional/test-agent-apis/setup_common.sh
+++ b/tests/functional/test-agent-apis/setup_common.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+
+# Copyright (c) 2024 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+# 1. Setup: start kata-agent as an individual process listening on the default port
+# 2. Use a bats script to run all tests
+# 3. Collect logs if possible (look into this to validate success/failures)
+# 4. handle errors/exit in cleanup to remove all mounts, etc.
+# IMP: Look at how to assert tests.
+# The agent process runs locally as a standalone process for now.
+
+agent_binary="/usr/bin/kata-agent"
+agent_ctl_path="/opt/kata/bin/kata-agent-ctl"
+
+# Name of socket file used by a local agent.
+agent_socket_file="/tmp/kata-agent.socket"
+
+# Kata Agent socket URI.
+local_agent_server_addr="unix://@${agent_socket_file}"
+
+# Log file that contains agent ctl output
+ctl_log_file="${PWD}/agent-ctl.log"
+# Log file that contains agent output.
+agent_log_file="${PWD}/kata-agent.log"
+
+agent_log_level="debug"
+keep_logs=false
+
+cleanup()
+{
+	info "cleaning resources..."
+
+	local failure_ret="$?"
+
+	stop_agent
+
+	local sandbox_dir="/run/sandbox-ns/"
+	sudo umount -f "${sandbox_dir}/uts" "${sandbox_dir}/ipc" &>/dev/null || true
+	sudo rm -rf "${sandbox_dir}" &>/dev/null || true
+
+	if [ "$failure_ret" -eq 0 ] && [ "$keep_logs" = 'true' ]
+	then
+		info "SUCCESS: Test passed, but leaving logs:"
+		info ""
+		info "agent log file       : ${agent_log_file}"
+		info "agent-ctl log file   : ${ctl_log_file}"
+		return 0
+	fi
+
+	if [ $failure_ret -ne 0 ]; then
+		warn "ERROR: Test failed"
+		warn ""
+		warn "Not cleaning up to help debug failure:"
+		warn ""
+
+		info "agent-ctl log file   : ${ctl_log_file}"
+		info "agent log file       : ${agent_log_file}"
+		return 0
+	fi
+
+	sudo rm -f \
+		"$agent_log_file" \
+		"$ctl_log_file"
+}
+
+run_agent_ctl()
+{
+	local cmds="${1:-}"
+
+	[ -n "$cmds" ] || die "need commands for agent control tool"
+
+	local redirect="&>\"${ctl_log_file}\""
+
+	local server_address="--server-address ${local_agent_server_addr}"
+
+	eval \
+		sudo \
+		RUST_BACKTRACE=full \
+		"${agent_ctl_path}" \
+		-l debug \
+		connect \
+		--no-auto-values \
+		${server_address} \
+		${cmds} \
+		${redirect}
+}
+
+get_agent_pid()
+{
+	local pids
+
+	local name
+	name=$(basename "$agent_binary")
+
+	pids=$(pgrep "$name" || true)
+	[ -z "$pids" ] && return 0
+
+	local count
+	count=$(echo "$pids"|wc -l)
+
+	[ "$count" -gt 1 ] && \
+		die "too many agent processes running ($count, '$pids')"
+
+	echo $pids
+}
+
+check_agent_alive()
+{
+	local cmds=()
+
+	cmds+=("-c Check")
+
+	run_agent_ctl \
+		"${cmds[@]}"
+}
+
+wait_for_agent_to_start()
+{
+	local cmd="check_agent_alive"
+
+	local wait_time_secs=20
+	local sleep_time_secs=1
+
+	info "Waiting for agent process to start.."
+
+	waitForProcess \
+		"$wait_time_secs" \
+		"$sleep_time_secs" \
+		"$cmd"
+
+	info "Kata agent process running."
+}
+
+stop_agent() {
+	info "Stopping agent"
+	local cmds=()
+	cmds+=("-c DestroySandbox")
+	run_agent_ctl \
+		"${cmds[@]}"
+}
+
+start_agent()
+{
+	local log_file="${1:-}"
+	[ -z "$log_file" ] && die "need agent log file"
+
+	local running
+	running=$(get_agent_pid || true)
+
+	[ -n "$running" ] && die "agent already running: '$running'"
+
+	eval \
+		sudo \
+			RUST_BACKTRACE=full \
+			KATA_AGENT_LOG_LEVEL=${agent_log_level} \
+			KATA_AGENT_SERVER_ADDR=${local_agent_server_addr} \
+			${agent_binary} \
+			&> ${log_file} \
+			&
+
+    wait_for_agent_to_start
+}
+
+setup_agent() {
+	info "Starting a single kata agent process."
+
+	start_agent $agent_log_file
+
+	info "Setup done."
+}

--- a/tests/functional/test-agent-apis/test-agent-apis.bats
+++ b/tests/functional/test-agent-apis/test-agent-apis.bats
@@ -1,0 +1,67 @@
+#!/usr/bin/env bats
+
+# Copyright (c) 2024 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/setup_common.sh"
+
+setup_file() {
+    info "setup"
+}
+
+@test "Test CopyFile API: Copy a file to /run/kata-containers" {
+    info "Copy file to /run/kata-containers"
+    src_file=$(mktemp)
+    local cmds=()
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/foo\"}'")
+    run_agent_ctl "${cmds[@]}"
+    rm $src_file
+}
+
+@test "Test CopyFile API: Copy a symlink to /run/kata-containers" {
+    info "Copy symlink to /run/kata-containers"
+    src_file=$(mktemp)
+    link_file="/tmp/link"
+    ln -s $src_file $link_file
+    local cmds=()
+    cmds+=("-c 'CopyFile json://{\"src\": \"$link_file\", \"dest\":\"/run/kata-containers/link\"}'")
+    run_agent_ctl "${cmds[@]}"
+    unlink $link_file
+    rm $src_file
+}
+
+@test "Test CopyFile API: Copy a directory to /run/kata-containers" {
+    info "Copy directory to /run/kata-containers"
+    src_dir=$(mktemp -d)
+    local cmds=()
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_dir\", \"dest\":\"/run/kata-containers/dir\"}'")
+    run_agent_ctl "${cmds[@]}"
+    rmdir $src_dir
+}
+
+@test "Test CopyFile API: Copy a file to an unallowed destination" {
+    info "Copy file to /tmp"
+    src_file=$(mktemp)
+    local cmds=()
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/tmp/foo\"}'")
+    run run_agent_ctl "${cmds[@]}"
+    [ "$status" -ne 0 ]
+    rm $src_file
+}
+
+@test "Test CopyFile API: Copy a large file to /run/kata-containers" {
+    info "Copy large file to /run/kata-containers"
+    src_file="/tmp/large_file_2M.txt"
+    truncate -s 2M $src_file
+    local cmds=()
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/large_file_2M.txt\"}'")
+    run_agent_ctl "${cmds[@]}"
+    rm $src_file
+}
+
+teardown_file() {
+    info "teardown"
+    sudo rm -r /run/kata-containers/
+}


### PR DESCRIPTION
In the existing implementation for the CopyFile subcommand,
- cmd line argument list is too long, including various metadata information.
- in case of a regular file, passing the actual data as bytes stream adds to the size and complexity of the input.
- the copy request will fail when the file size exceeds that of the allowed ttrpc max data length limit of 4Mb.

This change refactors the CopyFile handler and modifies the input to a known 'source' 'destination' syntax.

Fixes #9689