### PR TITLE
tests: enable guest-pull on all k8s tests for the qemu-coco-dev configuration

### DIFF
--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -18,6 +18,8 @@ assert_equal() {
 }
 
 setup() {
+	[ "${KATA_HYPERVISOR:-}" = "qemu-coco-dev" ] && \
+		skip "This test has failed for ${KATA_HYPERVISOR:-}"
 	pod_name="sharevol-kata"
 	get_pod_config_dir
 	pod_logs_file=""
@@ -68,6 +70,8 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR:-}" = "qemu-coco-dev" ] && \
+		skip "This test has failed for ${KATA_HYPERVISOR:-}"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/tests/integration/kubernetes/k8s-file-volume.bats
+++ b/tests/integration/kubernetes/k8s-file-volume.bats
@@ -12,7 +12,8 @@ TEST_INITRD="${TEST_INITRD:-no}"
 setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
-	[ "${KATA_HYPERVISOR}" == "qemu-tdx" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/9667"
+	[[ "${KATA_HYPERVISOR}" == "qemu-tdx" || "${KATA_HYPERVISOR}" == "qemu-coco-dev" ]] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9667"
 
 	pod_name="test-file-volume"
 	container_name="busybox-file-volume-container"
@@ -59,7 +60,8 @@ setup() {
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
-	[ "${KATA_HYPERVISOR}" == "qemu-tdx" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/9667"
+	[[ "${KATA_HYPERVISOR}" == "qemu-tdx" || "${KATA_HYPERVISOR}" == "qemu-coco-dev" ]] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9667"
 
 	kubectl describe pod "$pod_name"
 

--- a/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
+++ b/tests/integration/kubernetes/k8s-kill-all-process-in-container.bats
@@ -9,7 +9,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/9664"
+	[[ "${KATA_HYPERVISOR}" = "qemu-tdx" || "${KATA_HYPERVISOR}" = "qemu-coco-dev" ]] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9664"
 
 	pod_name="busybox"
 	first_container_name="first-test-container"
@@ -41,7 +42,8 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/9664"
+	[[ "${KATA_HYPERVISOR}" = "qemu-tdx" || "${KATA_HYPERVISOR}" = "qemu-coco-dev" ]] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9664"
 
 	# Debugging information
 	kubectl describe "pod/$pod_name"

--- a/tests/integration/kubernetes/k8s-seccomp.bats
+++ b/tests/integration/kubernetes/k8s-seccomp.bats
@@ -8,6 +8,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[ "${KATA_HYPERVISOR:-}" = "qemu-coco-dev" ] && \
+		skip "This test fails intermittently for ${KATA_HYPERVISOR:-}"
 	pod_name="seccomp-container"
 	get_pod_config_dir
 
@@ -30,6 +32,8 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR:-}" = "qemu-coco-dev" ] && \
+		skip "This test fails intermittently for ${KATA_HYPERVISOR:-}"
 	# For debugging purpose
 	echo "seccomp mode is ${seccomp_mode}, expected $expected_seccomp_mode"
 	kubectl describe "pod/${pod_name}"

--- a/tests/integration/kubernetes/k8s-shared-volume.bats
+++ b/tests/integration/kubernetes/k8s-shared-volume.bats
@@ -13,6 +13,8 @@ setup() {
 }
 
 @test "Containers with shared volume" {
+	[ "${KATA_HYPERVISOR}" = "qemu-coco-dev" ] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9668"
 	pod_name="test-shared-volume"
 	first_container_name="busybox-first-container"
 	second_container_name="busybox-second-container"
@@ -40,7 +42,8 @@ setup() {
 }
 
 @test "initContainer with shared volume" {
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/9668"
+	[[ "${KATA_HYPERVISOR}" = "qemu-tdx" || "${KATA_HYPERVISOR}" = "qemu-coco-dev" ]] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9668"
 
 	pod_name="initcontainer-shared-volume"
 	last_container="last"

--- a/tests/integration/kubernetes/k8s-sysctls.bats
+++ b/tests/integration/kubernetes/k8s-sysctls.bats
@@ -9,7 +9,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/9666"
+	[[ "${KATA_HYPERVISOR}" = "qemu-tdx" || "${KATA_HYPERVISOR}" = "qemu-coco-dev" ]] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9666"
 
 	pod_name="sysctl-test"
 	get_pod_config_dir
@@ -32,7 +33,8 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/9666"
+	[[ "${KATA_HYPERVISOR}" = "qemu-tdx" || "${KATA_HYPERVISOR}" = "qemu-coco-dev" ]] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9666"
 
 	# Debugging information
 	kubectl describe "pod/$pod_name"

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -13,6 +13,7 @@ DEBUG="${DEBUG:-}"
 export AUTO_GENERATE_POLICY="${AUTO_GENERATE_POLICY:-no}"
 export KATA_HOST_OS="${KATA_HOST_OS:-}"
 export KATA_HYPERVISOR="${KATA_HYPERVISOR:-}"
+export PULL_TYPE="${PULL_TYPE:-default}"
 
 if [ -n "${K8S_TEST_POLICY_FILES:-}" ]; then
 	K8S_TEST_POLICY_FILES=($K8S_TEST_POLICY_FILES)
@@ -104,10 +105,16 @@ add_cbl_mariner_kernel_initrd_annotations() {
 }
 
 add_runtime_handler_annotations() {
+	local handler_annotation="io.containerd.cri.runtime-handler"
+
+	if [ "$PULL_TYPE" != "guest-pull" ]; then
+		info "Not adding $handler_annotation annotation for $PULL_TYPE pull type"
+		return
+	fi
+
 	case "${KATA_HYPERVISOR}" in
 		qemu-tdx)
 			info "Add runtime handler annotations for ${KATA_HYPERVISOR}"
-			local handler_annotation="io.containerd.cri.runtime-handler"
 			local handler_value="kata-${KATA_HYPERVISOR}"
 			for K8S_TEST_YAML in runtimeclass_workloads_work/*.yaml
 			do

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -113,7 +113,7 @@ add_runtime_handler_annotations() {
 	fi
 
 	case "${KATA_HYPERVISOR}" in
-		qemu-tdx)
+		qemu-tdx|qemu-coco-dev)
 			info "Add runtime handler annotations for ${KATA_HYPERVISOR}"
 			local handler_value="kata-${KATA_HYPERVISOR}"
 			for K8S_TEST_YAML in runtimeclass_workloads_work/*.yaml


### PR DESCRIPTION
Currently the `kata-qemu-coco-dev` configuration run one and only one guest-pull pull type test, which is the [k8s-guest-pull-image.bats](https://github.com/kata-containers/kata-containers/blob/main/tests/integration/kubernetes/k8s-guest-pull-image.bats). This PR is for enabling the runtime handler annotation (`io.containerd.cri.runtime-handler`) on all deployments used on k8s tests, as a result, k8s tests will be leveraging the guest-pull from now on.

The `tests/k8s: skip custom DNS tests for qemu-coco-dev` commit on this PR isn't related with the change I'm proposing here. However, I had to disable that test to run the test suite (currently configured for "fail-fast"), as it started failing last week for all TEE jobs (see https://github.com/kata-containers/kata-containers/issues/9663) .

I did run the tests in my environment with AKS and a couple of tests failed. Notice that at this point `shared_fs=virtio-9p`, i.e. host sharing fs is enabled with 9p, so the errors are purely related with the guest-pull (I guess) feature. Unless the guest-pull **requires** `shared_fs=none`? Anyway, we have some base to compare with tests that failed on PR https://github.com/kata-containers/kata-containers/pull/9315 , where @fidencio did the same change but for TDX (actually he enabled guest-pull k8s tests and `shared_fs=none` in a single pass, whereas for qemu-coco-dev I want to split the changes).

Still about the failing tests, I had it disabled on this PR for now. But I will be enabling them all again in an update to see if they also fail on CI. So marking this PR as draft. 