### PR TITLE
tests/k8s: skip custom DNS tests on confidential jobs

### DIFF
--- a/tests/integration/kubernetes/k8s-custom-dns.bats
+++ b/tests/integration/kubernetes/k8s-custom-dns.bats
@@ -7,9 +7,11 @@
 
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
+load "${BATS_TEST_DIRNAME}/confidential_common.sh"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/9663"
+	is_confidential_runtime_class && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9663"
 
 	pod_name="custom-dns-test"
 	file_name="/etc/resolv.conf"
@@ -39,7 +41,8 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/9663"
+	is_confidential_runtime_class && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/9663"
 
 	# Debugging information
 	kubectl describe "pod/$pod_name"


### PR DESCRIPTION
This test has failed in confidential runtime jobs. Skip it until we don't have a fix.

Fixes: #9663