### PR TITLE
ci: Fix tools builder images

### DIFF
--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -210,11 +210,12 @@ get_virtiofsd_image_name() {
 }
 
 get_tools_image_name() {
+	tools_script_dir="${repo_root_dir}/tools/packaging/static-build/tools"
 	tools_dir="${repo_root_dir}/src/tools"
 	libs_dir="${repo_root_dir}/src/libs"
 	agent_dir="${repo_root_dir}/src/agent"
 
-	echo "${BUILDER_REGISTRY}:tools-$(get_last_modification ${tools_dir})-$(get_last_modification ${libs_dir})-$(get_last_modification ${agent_dir})-$(uname -m)"
+	echo "${BUILDER_REGISTRY}:tools-$(get_last_modification ${tools_dir})-$(get_last_modification ${libs_dir})-$(get_last_modification ${agent_dir})-$(get_last_modification ${tools_script_dir})-$(uname -m)"
 }
 
 get_agent_image_name() {


### PR DESCRIPTION
We weren't considering changes of the tools script dir adding a fourth hash to accomodate this