### PR TITLE
tests/k8s: print logs on fail only (k8s-confidential-attestation.bats)

### DIFF
--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -93,7 +93,7 @@ teardown() {
 	[ -n "${pod_name:-}" ] && kubectl describe "pod/${pod_name}" || true
 	[ -n "${pod_config_dir:-}" ] && kubectl delete -f "${K8S_TEST_YAML}" || true
 
-	if [ -n "${node_start_time}:-}" ]; then
+	if [[ -n "${node_start_time}:-}" && -z "$BATS_TEST_COMPLETED" ]]; then
 		echo "DEBUG: system logs of node '$node' since test start time ($node_start_time)"
 		print_node_journal "$node" "kata" --since "$node_start_time" || true
 	fi


### PR DESCRIPTION
Use the variable BATS_TEST_COMPLETED which is defined by the bats framework when the test finishes. `BATS_TEST_COMPLETED=` (empty) means the test failed, so the node syslogs will be printed only at that condition.

Fixes: #9750

---

First I created a function `has_test_failed()` (see below) that would be called from `teardown()`. It didn't work because `BATS_TEST_COMPLETED` is a local variable not visible from `has_test_failed()`, and I still don't know why. Any bash guru could help here? Then I decided to implement like in this PR.

```
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -118,6 +118,16 @@ exec_host() {
        return ${exit_code}
 }
 
+# Return true if current test failed.
+# Use in teardown() to conditionally take actions.
+has_test_failed() {
+       if [ -z "$BATS_TEST_COMPLETED" ]; then
+               return 0
+       fi
+
+       return 1
+}
+
```