### PR TITLE
tests/k8s: enable policy tests for qemu-coco-dev

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -266,8 +266,9 @@ set_namespace_to_policy_settings() {
 policy_tests_enabled() {
 	# The Guest images for these platforms have been built using AGENT_POLICY=yes -
 	# see kata-deploy-binaries.sh.
-	[ "${KATA_HYPERVISOR}" == "qemu-sev" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
-		[ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HOST_OS}" == "cbl-mariner" ]
+	local enabled_hypervisors="qemu-coco-dev qemu-sev qemu-snp qemu-tdx"
+	[[ " $enabled_hypervisors " =~ " ${KATA_HYPERVISOR} " ]] || \
+		[ "${KATA_HOST_OS}" == "cbl-mariner" ]
 }
 
 add_allow_all_policy_to_yaml() {


### PR DESCRIPTION
So qemu-coco-dev is on pair with the TEE configurations.

Fixes: #9753