### PR TITLE
ci: k8s: Skip empty dir tests also for TDX

### DIFF
--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -18,6 +18,8 @@ assert_equal() {
 }
 
 setup() {
+	[ "${KATA_HYPERVISOR:-}" = "qemu-tdx" ] && \
+		skip "This test has failed for ${KATA_HYPERVISOR:-}"
 	[ "${KATA_HYPERVISOR:-}" = "qemu-coco-dev" ] && \
 		skip "This test has failed for ${KATA_HYPERVISOR:-}"
 	pod_name="sharevol-kata"
@@ -70,6 +72,8 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR:-}" = "qemu-tdx" ] && \
+		skip "This test has failed for ${KATA_HYPERVISOR:-}"
 	[ "${KATA_HYPERVISOR:-}" = "qemu-coco-dev" ] && \
 		skip "This test has failed for ${KATA_HYPERVISOR:-}"
 	# Debugging information


### PR DESCRIPTION
Wainer noticed this is failing for the coco-qemu-dev case, and decided to skip it, notifying me that he didn't fully understand why it was not failing on TDX.

Turns out, though, this is also failing on TDX, and we need to skip it there as well.