### PR TITLE
ci: k8s: Use kbs-client from inside a container

### DIFF
--- a/tests/integration/kubernetes/Dockerfile.kbs-client
+++ b/tests/integration/kubernetes/Dockerfile.kbs-client
@@ -1,0 +1,70 @@
+# Copyright (c) 2024 Intel
+# Copyright (c) 2024 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM ubuntu:22.04
+ARG RUST_TOOLCHAIN
+ARG TRUSTEE_VERSION
+ARG CLI_FEATURES
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV RUSTUP_HOME="/opt/rustup"
+ENV CARGO_HOME="/opt/cargo"
+ENV PATH="/opt/cargo/bin/:${PATH}"
+
+# Note - the TDX lib is only available on x86, so there is an arch check in the package install
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME} && chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
+
+RUN apt-get update && \
+	apt-get --no-install-recommends install -y \
+	ca-certificates \
+	curl \
+	gnupg && \
+	if [ "$(uname -m)" == "x86_64" ]; then curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
+	echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+	apt-get update && \
+	apt-get --no-install-recommends -y install libtdx-attest-dev; fi && \
+	apt-get --no-install-recommends -y install \
+	binutils \
+	clang \
+	g++ \
+	gcc \
+	git \
+	libssl-dev \
+	libtss2-dev \
+	make \
+	musl-tools \
+	openssl \
+	perl \
+	pkg-config \
+	protobuf-compiler && \
+	apt-get clean && rm -rf /var/lib/apt/lists/ && \
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+
+ENV LIBC="gnu"
+RUN ARCH=$(uname -m); \
+	rust_arch=""; \
+    	case "${ARCH}" in \
+	        "aarch64") rust_arch="${ARCH}" ;; \
+	        "ppc64le") rust_arch="powerpc64le" ;; \
+	        "x86_64") rust_arch="${ARCH}" ;; \
+	        "s390x") rust_arch="${ARCH}" ;; \
+	        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    	esac; \
+    	echo "RUST_ARCH=${rust_arch}" > /etc/profile.d/rust.sh; \
+	rustup target add "${rust_arch}-unknown-linux-${LIBC}"
+
+# clone and build the kbs-client
+RUN git clone --depth 1 https://github.com/confidential-containers/trustee && \
+	pushd trustee && \
+	git fetch --depth=1 origin "${TRUSTEE_VERSION}" && \
+	git checkout FETCH_HEAD -b kbs_$$ && \
+	popd && \
+	pushd trustee/kbs && \
+	make CLI_FEATURES=${CLI_FEATURES} cli && \
+	make install-cli && \
+	popd

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -26,6 +26,10 @@ readonly KBS_PRIVATE_KEY="${COCO_KBS_DIR}/config/kubernetes/base/kbs.key"
 readonly KBS_SVC_NAME="kbs"
 # The features to enable in the kbs client
 KBS_CLI_FEATURES="sample_only"
+if [ "${KATA_HYPERVISOR}" == "qemu-tdx" ]; then
+       echo "Set KBS_CLI_FEATURES=default for ${KATA_HYPERVISOR}"
+       KBS_CLI_FEATURES="default"
+fi
 
 # Set "allow all" policy to resources.
 #

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -265,12 +265,13 @@ function deploy_kata() {
 	echo "::endgroup::"
 }
 
-function install_kbs_client() {
-	kbs_install_cli
+function pull_kbs_client_container() {
+	kbs_pull_cli_container
 }
 
 function uninstall_kbs_client() {
-	kbs_uninstall_cli
+	# no-op, just left behind for backward compatibility with the CI
+	return 0
 }
 
 function run_tests() {
@@ -596,7 +597,7 @@ function main() {
 		deploy-k8s) deploy_k8s ;;
 		install-bats) install_bats ;;
 		install-kata-tools) install_kata_tools ;;
-		install-kbs-client) install_kbs_client ;;
+		install-kbs-client) pull_kbs_client_container ;;
 		install-kubectl) install_kubectl ;;
 		get-cluster-credentials) get_cluster_credentials ;;
 		deploy-kata-aks) deploy_kata "aks" ;;

--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -15,7 +15,6 @@ export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 export AA_KBC="${AA_KBC:-cc_kbc}"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "Test not ready yet for ${KATA_HYPERVISOR}"
 	is_confidential_runtime_class || skip "Test not supported for ${KATA_HYPERVISOR}."
 
 	if [ "${KBS}" = "false" ]; then
@@ -83,7 +82,6 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" = "qemu-tdx" ] && skip "Test not ready yet for ${KATA_HYPERVISOR}"
 	is_confidential_runtime_class || skip "Test not supported for ${KATA_HYPERVISOR}."
 
 	if [ "${KBS}" = "false" ]; then


### PR DESCRIPTION
There's absolutely no need to build and use it from the host, if we can just build it and run it from a privileged container instead.