### PR TITLE
kata-manager: Add symlinks for runc and slirp4netns

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -588,7 +588,9 @@ install_nerdctl()
 	for file in \
 		/usr/local/bin/containerd \
 		/usr/local/bin/ctr \
-		/usr/local/bin/nerdctl
+		/usr/local/bin/nerdctl \
+		/usr/local/bin/runc \
+		/usr/local/bin/slirp4netns
 		do
 			sudo ln -sf "$file" "${link_dir}"
 		done


### PR DESCRIPTION
For nerdctl install, add symlinks for runc and slirp4netns in the binary install path.
runc link comes in handy for running runc containers with nerdctl fir quick tests.
slirp4netns allows for running containers with user mode networking useful in case of rootless containers.