### PR TITLE
WIP: cbl-mariner: use the guest rootfs-image format

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -50,6 +50,7 @@ jobs:
           - stratovirt
           - rootfs-image
           - rootfs-image-confidential
+          - rootfs-image-mariner
           - rootfs-initrd
           - rootfs-initrd-confidential
           - rootfs-initrd-mariner

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -35,6 +35,7 @@ BASE_TARBALLS = serial-targets \
 	virtiofsd-tarball
 BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-image-confidential-tarball \
+	rootfs-image-mariner-tarball \
 	rootfs-initrd-confidential-tarball \
 	rootfs-initrd-mariner-tarball \
 	rootfs-initrd-tarball \
@@ -144,6 +145,9 @@ rootfs-image-tarball: agent-tarball
 	${MAKE} $@-build
 
 rootfs-image-confidential-tarball: agent-tarball pause-image-tarball coco-guest-components-tarball kernel-confidential-tarball
+	${MAKE} $@-build
+
+rootfs-image-mariner-tarball: agent-tarball
 	${MAKE} $@-build
 
 rootfs-initrd-mariner-tarball: agent-tarball

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -340,6 +340,11 @@ install_image_confidential() {
 	install_image "confidential"
 }
 
+#Install guest image for Mariner
+install_image_mariner() {
+	install_image "mariner"
+}
+
 #Install guest initrd
 install_initrd() {
 	local variant="${1:-}"
@@ -989,6 +994,7 @@ handle_build() {
 		install_firecracker
 		install_image
 		install_image_confidential
+		install_image_mariner
 		install_initrd
 		install_initrd_confidential
 		install_initrd_mariner
@@ -1057,6 +1063,8 @@ handle_build() {
 	rootfs-image) install_image ;;
 
 	rootfs-image-confidential) install_image_confidential ;;
+
+	rootfs-image-mariner) install_image_mariner ;;
 
 	rootfs-initrd) install_initrd ;;
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -139,6 +139,9 @@ assets:
         confidential:
           name: *default-image-name
           version: *default-image-version
+        mariner:
+          name: "cbl-mariner"
+          version: "2.0"
         nvidia-gpu:
           name: *default-image-name
           version: "jammy"


### PR DESCRIPTION
Change the mariner Guest rootfs image from initrd to vanilla image.

This enables future CI testing for cbl-mariner Guests using:
- dm-verity protected rootfs images
- no initrd

AKS Confidential Containers are using that kind of Guest configuration, and the future Kata changes to enable it in the main branch are in https://github.com/kata-containers/kata-containers/pull/7988.

Expected side effects:

1. The io.katacontainers.config.hypervisor.initrd annotation will not be tested by CI anymore.
2. The io.katacontainers.config.hypervisor.image annotation will be tested.