### PR TITLE
CI: disable jobs that failed > 50% on nightly CI recently - part 1

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,24 @@
+# Copyright (c) 2024 Red Hat
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Configuration file with rules for the actionlint tool.
+#
+self-hosted-runner:
+  # Labels of self-hosted runner that linter should ignore
+  labels:
+    - arm64-builder
+    - garm-ubuntu-2004
+    - garm-ubuntu-2004-smaller
+    - garm-ubuntu-2204
+    - garm-ubuntu-2304
+    - garm-ubuntu-2304-smaller
+    - garm-ubuntu-2204-smaller
+    - k8s-ppc64le
+    - metrics
+    - ppc64le
+    - sev
+    - sev-snp
+    - s390x
+    - s390x-large
+    - tdx

--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -213,7 +213,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vmm: ['clh', 'qemu']
+        vmm:
+          - clh
+          - qemu
+        exclude:
+          # TODO: enable with clh when https://github.com/kata-containers/kata-containers/issues/9764 is fixed
+          - vmm: clh
     runs-on: garm-ubuntu-2304
     env:
       GOPATH: ${{ github.workspace }}

--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -176,6 +176,8 @@ jobs:
         vmm:
           - clh # cloud-hypervisor
           - qemu
+    # TODO: enable me when https://github.com/kata-containers/kata-containers/issues/9763 is fixed
+    if: false
     runs-on: garm-ubuntu-2204-smaller
     env:
       KATA_HYPERVISOR: ${{ matrix.vmm }}

--- a/.github/workflows/run-kata-monitor-tests.yaml
+++ b/.github/workflows/run-kata-monitor-tests.yaml
@@ -26,6 +26,10 @@ jobs:
         include:
           - container_engine: containerd
             containerd_version: lts
+        exclude:
+          # TODO: enable with containerd when https://github.com/kata-containers/kata-containers/issues/9761 is fixed
+          - container_engine: containerd
+            vmm: qemu
     runs-on: garm-ubuntu-2204-smaller
     env:
       CONTAINER_ENGINE: ${{ matrix.container_engine }}


### PR DESCRIPTION
I've made a python script to collect some statistics of the nightly CI jobs. This PR disables the **test** jobs that failed > 50% on the last 10 nights.

While I think that this script has bugs (e.g. I notice the filter regex isn't correct), I do believe that for the jobs I'm disabling here, the numbers are correct. I've observed those jobs for a while now and I only wanted an excuse :)

See the script and results here: https://github.com/kata-containers/kata-containers/issues/9506#issuecomment-2142990502