### PR TITLE
tests: Use variable definition for better uniformity

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -179,8 +179,8 @@ kbs_uninstall_cli() {
 function kbs_k8s_delete() {
 	pushd "$COCO_KBS_DIR"
 	kubectl delete -k config/kubernetes/overlays
-	# Verify that coco-tenant resources were properly deleted
-	cmd="kubectl get all -n coco-tenant 2>&1 | grep 'No resources found'"
+	# Verify that KBS namespace resources were properly deleted
+	cmd="kubectl get all -n $KBS_NS 2>&1 | grep 'No resources found'"
 	waitForProcess "120" "30" "$cmd"
 	popd
 }


### PR DESCRIPTION
This PR replaces the name to use a variable that is already defined to have a better uniformity across the general script.