### PR TITLE
runtime-rs: add base qmp framework

### DIFF
--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1644,6 +1644,9 @@ dependencies = [
  "nix 0.24.3",
  "path-clean",
  "persist",
+ "qapi",
+ "qapi-qmp",
+ "qapi-spec",
  "rand 0.8.5",
  "rust-ini",
  "safe-path 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2957,6 +2960,65 @@ dependencies = [
  "protobuf 3.2.0",
  "ttrpc",
  "ttrpc-codegen",
+]
+
+[[package]]
+name = "qapi"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6412bdd014ebee03ddbbe79ac03a0b622cce4d80ba45254f6357c847f06fa38"
+dependencies = [
+ "bytes",
+ "futures 0.3.28",
+ "log",
+ "memchr",
+ "qapi-qmp",
+ "qapi-spec",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "qapi-codegen"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ba4de731473de4c8bd508ddb38a9049e999b8a7429f3c052ba8735a178ff68c"
+dependencies = [
+ "qapi-parser",
+]
+
+[[package]]
+name = "qapi-parser"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80044db145aa2953ef5803d0376dcbca50f2763242547e856b7f37507adca677"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "qapi-qmp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b944db7e544d2fa97595e9a000a6ba5c62c426fa185e7e00aabe4b5640b538"
+dependencies = [
+ "qapi-codegen",
+ "qapi-spec",
+ "serde",
+]
+
+[[package]]
+name = "qapi-spec"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b360919a24ea5fc02fa762cb01bd8f43b643fee51c585f763257773b4dc5a9e8"
+dependencies = [
+ "base64 0.13.1",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -43,6 +43,10 @@ safe-path = "0.1.0"
 crossbeam-channel = "0.5.6"
 tempdir = "0.3.7"
 
+qapi = { version = "0.14", features = [ "qmp", "async-tokio-all" ] }
+qapi-spec = "0.3.1"
+qapi-qmp = "0.14.0"
+
 [target.'cfg(not(target_arch = "s390x"))'.dependencies]
 dragonball = { path = "../../../dragonball", features = ["atomic-guest-memory", "virtio-vsock", "hotplug", "virtio-blk", "virtio-net", "virtio-fs", "vhost-net", "dbs-upcall", "virtio-mem", "virtio-balloon", "vhost-user-net", "host-device"] }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -21,7 +21,7 @@ use tokio;
 const MI_B: u64 = 1024 * 1024;
 const GI_B: u64 = 1024 * MI_B;
 
-const QMP_SOCKET_FILE: &str = "qmp.sock";
+pub const QMP_SOCKET_FILE: &str = "qmp.sock";
 const DEBUG_MONITOR_SOCKET: &str = "debug-monitor.sock";
 
 // The approach taken here is inspired by govmm.  We build structs, each

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -5,6 +5,7 @@
 
 mod cmdline_generator;
 mod inner;
+mod qmp;
 
 use crate::device::DeviceType;
 use crate::hypervisor_persist::HypervisorState;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -128,7 +128,7 @@ impl Hypervisor for Qemu {
     }
 
     async fn resize_vcpu(&self, old_vcpus: u32, new_vcpus: u32) -> Result<(u32, u32)> {
-        let inner = self.inner.read().await;
+        let mut inner = self.inner.write().await;
         inner.resize_vcpu(old_vcpus, new_vcpus).await
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -4,12 +4,22 @@
 //
 
 use anyhow::Result;
+use std::fmt::{Debug, Error, Formatter};
 use std::io::BufReader;
 use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
 pub struct Qmp {
     qmp: qapi::Qmp<qapi::Stream<BufReader<UnixStream>, UnixStream>>,
+}
+
+// We have to implement Debug since the Hypervisor trait requires it and Qmp
+// is ultimately stored in one of Hypervisor's implementations (Qemu).
+// We can't do it automatically since the type of Qmp::qmp isn't Debug.
+impl Debug for Qmp {
+    fn fmt(&self, _f: &mut Formatter<'_>) -> Result<(), Error> {
+        Ok(())
+    }
 }
 
 impl Qmp {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -1,0 +1,40 @@
+// Copyright (c) 2024 Red Hat
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::Result;
+use std::io::BufReader;
+use std::os::unix::net::UnixStream;
+use std::time::Duration;
+
+pub struct Qmp {
+    qmp: qapi::Qmp<qapi::Stream<BufReader<UnixStream>, UnixStream>>,
+}
+
+impl Qmp {
+    pub fn new(qmp_sock_path: &str) -> Result<Self> {
+        let stream = UnixStream::connect(qmp_sock_path)?;
+
+        // Set the read timeout to protect runtime-rs from blocking forever
+        // trying to set up QMP connection if qemu fails to launch.  The exact
+        // value is a matter of judegement.  Setting it too long would risk
+        // being ineffective since container runtime would timeout first anyway
+        // (containerd's task creation timeout is 2 s by default).  OTOH
+        // setting it too short would risk interfering with a normal launch,
+        // perhaps just seeing some delay due to a heavily loaded host.
+        stream.set_read_timeout(Some(Duration::from_millis(250)))?;
+
+        let mut qmp = Qmp {
+            qmp: qapi::Qmp::new(qapi::Stream::new(
+                BufReader::new(stream.try_clone()?),
+                stream,
+            )),
+        };
+
+        let info = qmp.qmp.handshake()?;
+        info!(sl!(), "QMP initialized: {:#?}", info);
+
+        Ok(qmp)
+    }
+}

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -9,6 +9,9 @@ use std::io::BufReader;
 use std::os::unix::net::UnixStream;
 use std::time::Duration;
 
+use qapi::qmp;
+use qapi_spec::Dictionary;
+
 pub struct Qmp {
     qmp: qapi::Qmp<qapi::Stream<BufReader<UnixStream>, UnixStream>>,
 }
@@ -47,4 +50,86 @@ impl Qmp {
 
         Ok(qmp)
     }
+
+    pub fn hotplug_vcpus(&mut self, vcpu_cnt: u32) -> Result<u32> {
+        let hotpluggable_cpus = self.qmp.execute(&qmp::query_hotpluggable_cpus {})?;
+        //info!(sl!(), "hotpluggable CPUs: {:#?}", hotpluggable_cpus);
+
+        let mut hotplugged = 0;
+        for vcpu in &hotpluggable_cpus {
+            if hotplugged >= vcpu_cnt {
+                break;
+            }
+            let core_id = match vcpu.props.core_id {
+                Some(id) => id,
+                None => continue,
+            };
+            if vcpu.qom_path.is_some() {
+                info!(sl!(), "hotpluggable vcpu {} hotplugged already", core_id);
+                continue;
+            }
+            let socket_id = match vcpu.props.socket_id {
+                Some(id) => id,
+                None => continue,
+            };
+            let thread_id = match vcpu.props.thread_id {
+                Some(id) => id,
+                None => continue,
+            };
+
+            let mut cpu_args = Dictionary::new();
+            cpu_args.insert("socket-id".to_owned(), socket_id.into());
+            cpu_args.insert("core-id".to_owned(), core_id.into());
+            cpu_args.insert("thread-id".to_owned(), thread_id.into());
+            self.qmp.execute(&qmp::device_add {
+                bus: None,
+                id: Some(vcpu_id_from_core_id(core_id)),
+                driver: hotpluggable_cpus[0].type_.clone(),
+                arguments: cpu_args,
+            })?;
+
+            hotplugged += 1;
+        }
+
+        info!(
+            sl!(),
+            "Qmp::hotplug_vcpus(): hotplugged {}/{} vcpus", hotplugged, vcpu_cnt
+        );
+
+        Ok(hotplugged)
+    }
+
+    pub fn hotunplug_vcpus(&mut self, vcpu_cnt: u32) -> Result<u32> {
+        let hotpluggable_cpus = self.qmp.execute(&qmp::query_hotpluggable_cpus {})?;
+
+        let mut hotunplugged = 0;
+        for vcpu in &hotpluggable_cpus {
+            if hotunplugged >= vcpu_cnt {
+                break;
+            }
+            let core_id = match vcpu.props.core_id {
+                Some(id) => id,
+                None => continue,
+            };
+            if vcpu.qom_path.is_none() {
+                info!(sl!(), "hotpluggable vcpu {} not hotplugged yet", core_id);
+                continue;
+            }
+            self.qmp.execute(&qmp::device_del {
+                id: vcpu_id_from_core_id(core_id),
+            })?;
+            hotunplugged += 1;
+        }
+
+        info!(
+            sl!(),
+            "Qmp::hotunplug_vcpus(): hotunplugged {}/{} vcpus", hotunplugged, vcpu_cnt
+        );
+
+        Ok(hotunplugged)
+    }
+}
+
+fn vcpu_id_from_core_id(core_id: i64) -> String {
+    format!("cpu-{}", core_id)
 }


### PR DESCRIPTION
This PR creates a base framework for QMP functionality.  The idea of the new `Qmp` object is similar to the one of `QemuCmdLine` - encapsulate implementation details of QMP handling while offering `QemuInner` an interface that matches its needs.

The `qapi-rs` library is used to handle the QMP low-level details.  Its documentation isn't great but the library itself is close enough to QMP to be actually quite easy to use (so far at least ;-)).

We also add support for hotplugging vCPUs, basically as a test case for the newly added infrastructure. :-)