### PR TITLE
GHA: Use qemu-coco-dev for k8s nydus test on s390x

### DIFF
--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -27,8 +27,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        vmm:
-          - qemu
         snapshotter:
           - devmapper
           - nydus
@@ -39,10 +37,12 @@ jobs:
             pull-type: default
             using-nfd: true
             deploy-cmd: configure-snapshotter
+            vmm: qemu
           - snapshotter: nydus
             pull-type: guest-pull
             using-nfd: false
             deploy-cmd: deploy-snapshotter
+            vmm: qemu-coco-dev
     runs-on: s390x-large
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -48,6 +48,14 @@ setup_common() {
 	node=$(get_one_kata_node)
 	[ -n "$node" ]
 	node_start_time=$(exec_host "$node" date +\"%Y-%m-%d %H:%M:%S\")
+	# If node_start_time is empty, try again 3 times with a 5 seconds sleep between each try.
+	count=0
+	while [ -z "$node_start_time" ] && [ $count -lt 3 ]; do
+		echo "node_start_time is empty, trying again..."
+		sleep 5
+		node_start_time=$(exec_host "$node" date +\"%Y-%m-%d %H:%M:%S\")
+		count=$((count + 1))
+	done
 	[ -n "$node_start_time" ]
 	export node node_start_time
 


### PR DESCRIPTION
 In line with the changes for x86_64, the k8s nydus test for s390x should also use `qemu-coco-dev` for `KATA_HYPERVISOR`.

Additionally, it was observed that the `node_start_time` value is sometimes empty, leading to a test failure.

This PR includes to make `setup_common()` retry fetching the value up to 3 times.

The changes have been tested 5 times internally, and all tests passed. 

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>