### PR TITLE
ci.ocp: Switch base to centos-9

### DIFF
--- a/ci/openshift-ci/images/Dockerfile.buildroot
+++ b/ci/openshift-ci/images/Dockerfile.buildroot
@@ -4,7 +4,7 @@
 #
 # This is the build root image for Kata Containers on OpenShift CI.
 #
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 RUN yum -y update && \
     yum -y install \


### PR DESCRIPTION
Centos8 is EOL and repos are not available anymore https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/52655/rehearse-52655-pull-ci-kata-containers-kata-containers-main-images/1798289476254961664 Centos9 contains the same packages and should do well as a base for testing.