### PR TITLE
CI: Introduce retry mechanism for kubectl in gha-run.sh

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -80,6 +80,22 @@ function handle_error() {
 }
 trap 'handle_error $LINENO' ERR
 
+# A wrapper function for kubectl with retry logic
+# runs the command up to 3 times with a 5-second interval
+# to ensure successful execution
+function kubectl_retry() {
+	local max_tries=3
+	local interval=5
+	local i=0
+	while true; do
+		kubectl $@ && return 0 || true
+		i=$((i + 1))
+		[ $i -lt $max_tries ] && echo "'kubectl $@' failed, retrying in $interval seconds" 1>&2 || break
+		sleep $interval
+	done
+	echo "'kubectl $@' failed after $max_tries tries" 1>&2 && return 1
+}
+
 function waitForProcess() {
 	wait_time="$1"
 	sleep_time="$2"


### PR DESCRIPTION
Frequent errors have been observed during k8s e2e tests:

- The connection to the server 127.0.0.1:6443 was refused - did you specify the right host or port?
- Error from server (ServiceUnavailable): the server is currently unable to handle the request
- Error from server (NotFound): the server could not find the requested resource

These errors can be resolved by retrying the kubectl command.

This commit introduces a wrapper function in common.sh that runs kubectl up to 3 times with a 5-second interval. Initially, this change only covers gha-run.sh for Kubernetes.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>