### PR TITLE
Kill some dead runtime code

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -2684,9 +2684,6 @@ type Knobs struct {
 	// NoGraphic completely disables graphic output.
 	NoGraphic bool
 
-	// Daemonize will turn the qemu process into a daemon
-	Daemonize bool
-
 	// Both HugePages and MemPrealloc require the Memory.Size of the VM
 	// to be set, as they need to reserve the memory upfront in order
 	// for the VM to boot without errors.
@@ -3123,10 +3120,6 @@ func (config *Config) appendKnobs() {
 
 	if config.Knobs.NoShutdown {
 		config.qemuParams = append(config.qemuParams, "--no-shutdown")
-	}
-
-	if config.Knobs.Daemonize {
-		config.qemuParams = append(config.qemuParams, "-daemonize")
 	}
 
 	config.appendMemoryKnobs()

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -2714,9 +2714,6 @@ type Knobs struct {
 	// Prevents QEMU from rebooting in the event of a Triple Fault.
 	NoReboot bool
 
-	// Don’t exit QEMU on guest shutdown, but instead only stop the emulation.
-	NoShutdown bool
-
 	// IOMMUPlatform will enable IOMMU for supported devices
 	IOMMUPlatform bool
 }
@@ -3116,10 +3113,6 @@ func (config *Config) appendKnobs() {
 
 	if config.Knobs.NoReboot {
 		config.qemuParams = append(config.qemuParams, "--no-reboot")
-	}
-
-	if config.Knobs.NoShutdown {
-		config.qemuParams = append(config.qemuParams, "--no-shutdown")
 	}
 
 	config.appendMemoryKnobs()

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -445,13 +445,12 @@ func TestAppendEmptyDevice(t *testing.T) {
 }
 
 func TestAppendKnobsAllTrue(t *testing.T) {
-	var knobsString = "-no-user-config -nodefaults -nographic --no-reboot -daemonize -overcommit mem-lock=on -S"
+	var knobsString = "-no-user-config -nodefaults -nographic --no-reboot -overcommit mem-lock=on -S"
 	knobs := Knobs{
 		NoUserConfig:  true,
 		NoDefaults:    true,
 		NoGraphic:     true,
 		NoReboot:      true,
-		Daemonize:     true,
 		MemPrealloc:   true,
 		FileBackedMem: true,
 		MemShared:     true,

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -569,7 +569,6 @@ func (q *qemu) CreateVM(ctx context.Context, id string, network Network, hypervi
 		NoDefaults:    true,
 		NoGraphic:     true,
 		NoReboot:      true,
-		Daemonize:     false,
 		MemPrealloc:   q.config.MemPrealloc,
 		HugePages:     q.config.HugePages,
 		IOMMUPlatform: q.config.IOMMUPlatform,
@@ -1105,16 +1104,10 @@ func (q *qemu) StartVM(ctx context.Context, timeout int) error {
 		q.Logger().WithError(err).Error("failed to launch qemu")
 		return fmt.Errorf("failed to launch qemu: %s", err)
 	}
-	if q.qemuConfig.Knobs.Daemonize {
-		// LaunchQemu returns a handle on the upper QEMU process.
-		// Wait for it to exit to assume that the QEMU daemon was
-		// actually started.
-		qemuCmd.Wait()
-	} else {
-		// Log QEMU errors and ensure the QEMU process is reaped after
-		// termination.
-		go q.LogAndWait(qemuCmd, reader)
-	}
+
+	// Log QEMU errors and ensure the QEMU process is reaped after
+	// termination.
+	go q.LogAndWait(qemuCmd, reader)
 
 	err = q.waitVM(ctx, qmpConn, timeout)
 	if err != nil {


### PR DESCRIPTION
As said in https://github.com/kata-containers/kata-containers/pull/9642#issuecomment-2122399707, this is back-porting a code simplification from the rust shim : remove the code for the options that are not to be ever passed to QEMU.
