### PR TITLE
genpolicy: load OCI version from settings

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -269,7 +269,8 @@
         ]
     },
     "kata_config": {
-        "confidential_guest": false
+        "confidential_guest": false,
+        "oci_version": "1.1.0"
     },
     "cluster_config": {
         "default_namespace": "default",

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -66,8 +66,7 @@ CreateContainerRequest {
     p_oci := p_container.OCI
 
     print("CreateContainerRequest: p Version =", p_oci.Version, "i Version =", i_oci.Version)
-    # TODO: Reenable when the Mariner host is reinstated, see #9593.
-    # p_oci.Version == i_oci.Version
+    p_oci.Version == i_oci.Version
 
     print("CreateContainerRequest: p Readonly =", p_oci.Root.Readonly, "i Readonly =", i_oci.Root.Readonly)
     p_oci.Root.Readonly == i_oci.Root.Readonly

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -29,9 +29,6 @@ use std::collections::BTreeMap;
 use std::fs::read_to_string;
 use std::io::Write;
 
-// TODO: load this value from the settings file.
-const DEFAULT_OCI_VERSION: &str = "1.1.0-rc.1";
-
 /// Intermediary format of policy data.
 pub struct AgentPolicy {
     /// K8s resources described by the input YAML file.
@@ -73,7 +70,7 @@ pub struct PolicyData {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct KataSpec {
     /// Version of the Open Container Initiative Runtime Specification with which the bundle complies.
-    #[serde(default = "version_default")]
+    #[serde(default)]
     pub Version: String,
 
     /// Process configures the container process.
@@ -98,10 +95,6 @@ pub struct KataSpec {
     /// Linux is platform-specific configuration for Linux based containers.
     #[serde(default)]
     pub Linux: KataLinux,
-}
-
-fn version_default() -> String {
-    DEFAULT_OCI_VERSION.to_string()
 }
 
 /// OCI container Process struct. This struct is very similar to the Process
@@ -565,7 +558,7 @@ impl AgentPolicy {
 
         ContainerPolicy {
             OCI: KataSpec {
-                Version: version_default(),
+                Version: self.config.settings.kata_config.oci_version.clone(),
                 Process: process,
                 Root: root,
                 Mounts: mounts,

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -64,6 +64,7 @@ pub struct ConfigMapVolume {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct KataConfig {
     pub confidential_guest: bool,
+    pub oci_version: String,
 }
 
 impl Settings {


### PR DESCRIPTION
Load OCI version from genpolicy-settings.json and validate it in rules.rego

Fixes: #9593