### PR TITLE
tests: k8s: use newer yq command line format

### DIFF
--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -53,7 +53,7 @@ setup() {
 }
 
 @test "Successful pod with auto-generated policy and runtimeClassName filter" {
-	runtime_class_name=$(yq read "${testcase_pre_generate_pod_yaml}" "spec.runtimeClassName")
+	runtime_class_name=$(yq ".spec.runtimeClassName" < "${testcase_pre_generate_pod_yaml}")
 
 	auto_generate_policy "${pod_config_dir}" "${testcase_pre_generate_pod_yaml}" "${testcase_pre_generate_configmap_yaml}" \
 		"--runtime-class-names=other-runtime-class-name --runtime-class-names=${runtime_class_name}" 
@@ -145,8 +145,13 @@ test_pod_policy_error() {
 }
 
 @test "RuntimeClassName filter: no policy" {
+	# Solve a bats warning:
+	# BW02: Using flags on `run` requires at least BATS_VERSION=1.5.0.
+	# Use `bats_require_minimum_version 1.5.0` to fix this message.
+	bats_require_minimum_version 1.5.0
+
 	# The policy should not be generated because the pod spec does not have a runtimeClassName.
-	runtime_class_name=$(yq read "${testcase_pre_generate_pod_yaml}" "spec.runtimeClassName")
+	runtime_class_name=$(yq ".spec.runtimeClassName" < "${testcase_pre_generate_pod_yaml}")
 
 	auto_generate_policy "${pod_config_dir}" "${testcase_pre_generate_pod_yaml}" "${testcase_pre_generate_configmap_yaml}" \
 		"--runtime-class-names=other-${runtime_class_name}"


### PR DESCRIPTION
Fix the recent collision between:
- https://github.com/kata-containers/kata-containers/pull/9377
- https://github.com/kata-containers/kata-containers/pull/9725

One enabled a newer yq command line format and the other used the older format. Both passed CI because they were not tested together.

Fixes: #9789