### PR TITLE
runtime-rs: bugfix for root bus slot allocation

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/device/topology.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/topology.rs
@@ -244,7 +244,7 @@ impl PCIeTopology {
         let to_string = |v: u32| -> String { to_pcipath(v).to_string() };
 
         // find the first available index as the allocated slot.
-        let allocated_slot = (0..PCIE_ROOT_BUS_SLOTS_CAPACITY).find(|&i| {
+        let allocated_slot = (1..PCIE_ROOT_BUS_SLOTS_CAPACITY).find(|&i| {
             !self
                 .root_complex
                 .root_bus_devices


### PR DESCRIPTION
There's no point that allocating root bus slot
starting from zero. This is used to correct the
starting index with 1 replacing original 0.

Fixes #9813