### PR TITLE
genpolicy: fix settings path flag name

### DIFF
--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -74,7 +74,7 @@ impl Settings {
             debug!("settings = {:?}", &settings);
             settings
         } else {
-            panic!("Cannot open file {}. Please copy it to the current directory or specify the path to it using the -p parameter.",
+            panic!("Cannot open file {}. Please copy it to the current directory or specify the path to it using the -j parameter.",
                 json_settings_path);
         }
     }


### PR DESCRIPTION
This corrects the warning to point to the `-j` flag,
which is the correct flag for the JSON settings file.
Previously, the warning was confusing, as it pointed to
the `-p` flag, which specifies to the path for the Rego ruleset.