### PR TITLE
kata-deploy: improving the runtimeclasses checker and documentation

### DIFF
--- a/.github/workflows/kata-runtime-classes-sync.yaml
+++ b/.github/workflows/kata-runtime-classes-sync.yaml
@@ -18,19 +18,4 @@ jobs:
       uses: actions/checkout@v4
     - name: Ensure the split out runtime classes match the all-in-one file
       run: |
-        pushd tools/packaging/kata-deploy/runtimeclasses/
-        echo "::group::Combine runtime classes"
-        for runtimeClass in `find . -type f \( -name "*.yaml" -and -not -name "kata-runtimeClasses.yaml" \) | sort`; do
-            echo "Adding ${runtimeClass} to the resultingRuntimeClasses.yaml"
-            cat ${runtimeClass} >> resultingRuntimeClasses.yaml;
-        done
-        echo "::endgroup::"
-        echo "::group::Displaying the content of resultingRuntimeClasses.yaml"
-        cat resultingRuntimeClasses.yaml
-        echo "::endgroup::"
-        echo ""
-        echo "::group::Displaying the content of kata-runtimeClasses.yaml"
-        cat kata-runtimeClasses.yaml
-        echo "::endgroup::"
-        echo ""
-        diff resultingRuntimeClasses.yaml kata-runtimeClasses.yaml
+        ./tools/packaging/kata-deploy/local-build/check-runtimeclasses.sh

--- a/.github/workflows/kata-runtime-classes-sync.yaml
+++ b/.github/workflows/kata-runtime-classes-sync.yaml
@@ -19,6 +19,13 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: Ensure the split out runtime classes match the all-in-one file
+
+    - name: Install yq
+      run: |
+        ./ci/install_yq.sh
+      env:
+        INSTALL_IN_GOPATH: false
+
+    - name: Run checker on runtime classes to ensure consistency
       run: |
         ./tools/packaging/kata-deploy/local-build/check-runtimeclasses.sh

--- a/.github/workflows/kata-runtime-classes-sync.yaml
+++ b/.github/workflows/kata-runtime-classes-sync.yaml
@@ -1,3 +1,5 @@
+name: Static checks
+
 on:
   pull_request:
     types:
@@ -5,7 +7,8 @@ on:
       - edited
       - reopened
       - synchronize
-
+    paths:
+      - 'tools/packaging/kata-deploy/runtimeclasses/**'
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true

--- a/tests/cmd/check-spelling/kata-dictionary.dic
+++ b/tests/cmd/check-spelling/kata-dictionary.dic
@@ -331,6 +331,7 @@ rootfs/AB
 runV/B
 runc/B
 runtime/AB
+runtimeClass
 rustlang/B
 s390x/B
 scalability

--- a/tools/packaging/kata-deploy/local-build/check-runtimeclasses.sh
+++ b/tools/packaging/kata-deploy/local-build/check-runtimeclasses.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2023-2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+pushd tools/packaging/kata-deploy/runtimeclasses/
+echo "::group::Combine runtime classes"
+for runtimeClass in `find . -type f \( -name "*.yaml" -and -not -name "kata-runtimeClasses.yaml" \) | sort`; do
+    echo "Adding ${runtimeClass} to the resultingRuntimeClasses.yaml"
+    cat ${runtimeClass} >> resultingRuntimeClasses.yaml;
+done
+echo "::endgroup::"
+echo "::group::Displaying the content of resultingRuntimeClasses.yaml"
+cat resultingRuntimeClasses.yaml
+echo "::endgroup::"
+echo ""
+echo "::group::Displaying the content of kata-runtimeClasses.yaml"
+cat kata-runtimeClasses.yaml
+echo "::endgroup::"
+echo ""
+diff resultingRuntimeClasses.yaml kata-runtimeClasses.yaml

--- a/tools/packaging/kata-deploy/local-build/check-runtimeclasses.sh
+++ b/tools/packaging/kata-deploy/local-build/check-runtimeclasses.sh
@@ -10,6 +10,10 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+# Explicitly export LC_ALL to ensure `sort` sorting is expected on
+# different environments.
+export LC_ALL=C
+
 pushd tools/packaging/kata-deploy/runtimeclasses/
 echo "::group::Combine runtime classes"
 for runtimeClass in `find . -type f \( -name "*.yaml" -and -not -name "kata-runtimeClasses.yaml" \) | sort`; do


### PR DESCRIPTION
While working on PR #9807 it was a little of a pain to pass the static checker for the runtimeClasses that kata-deploy deploys on the cluster. I realized that it wasn't the first time I had the same difficult to pass CI, likely because I wasn't able to run the checker locally. So here I am sending some improvements to allow devs to run the checker locally before submitting a PR. In particular, the `LC_ALL=C` trick was hurting my tentative to get the checker passing.

Taking that opportunity to also document how to add a new runtimeClass to kata-deploy.
