### PR TITLE
osbuilder: allow rootfs builds w/o git or version file deps

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -15,7 +15,7 @@ PROJECT_COMPONENT = kata-agent
 TARGET = $(PROJECT_COMPONENT)
 
 VERSION_FILE := ./VERSION
-VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+VERSION := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
 COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})
 COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -358,7 +358,7 @@ SOURCES := \
   Cargo.toml
 
 VERSION_FILE := ./VERSION
-VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+VERSION := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
 COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
 COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})
 COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)

--- a/src/tools/kata-ctl/Makefile
+++ b/src/tools/kata-ctl/Makefile
@@ -13,7 +13,7 @@ TARGET = $(PROJECT_COMPONENT)
 INSTALL_PATH = $(HOME)/.cargo
 
 VERSION_FILE := ./VERSION
-export VERSION := $(shell grep -v ^\# $(VERSION_FILE))
+export VERSION := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
 COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
 COMMIT_NO_SHORT := $(shell git rev-parse --short HEAD 2>/dev/null || true)
 export COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})

--- a/src/tools/log-parser/Makefile
+++ b/src/tools/log-parser/Makefile
@@ -7,9 +7,10 @@
 TARGET = kata-log-parser
 SOURCES = $(shell find . 2>&1 | grep -E '.*\.go$$')
 
-VERSION := ${shell cat ./VERSION}
-COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
-COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
+VERSION_FILE := ./VERSION
+VERSION := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
+COMMIT_NO := $(shell git rev-parse HEAD 2>/dev/null || true)
+COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 
 BINDIR := $(GOPATH)/bin
 DESTTARGET := $(abspath $(BINDIR)/$(TARGET))

--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -23,9 +23,9 @@ TARGET_IMAGE          := $(IMAGES_BUILD_DEST)/kata-containers.img
 TARGET_INITRD         := $(IMAGES_BUILD_DEST)/kata-containers-initrd.img
 
 VERSION_FILE   := ./VERSION
-VERSION        := $(shell grep -v ^\# $(VERSION_FILE))
-COMMIT_NO      := $(shell git rev-parse HEAD 2> /dev/null || true)
-COMMIT         := $(if $(shell git status --porcelain --untracked-files=no),${COMMIT_NO}-dirty,${COMMIT_NO})
+VERSION        := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
+COMMIT_NO      := $(shell git rev-parse HEAD 2>/dev/null || true)
+COMMIT         := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_NO}-dirty,${COMMIT_NO})
 VERSION_COMMIT := $(if $(COMMIT),$(VERSION)-$(COMMIT),$(VERSION))
 
 ifeq ($(filter $(BUILD_METHOD),$(BUILD_METHOD_LIST)),)

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -385,12 +385,6 @@ build_rootfs_distro()
 		mkdir -p ${ROOTFS_DIR}
 	fi
 
-	# need to detect rustc's version too?
-	detect_rust_version ||
-		die "Could not detect the required rust version for AGENT_VERSION='${AGENT_VERSION:-main}'."
-
-	echo "Required rust version: $RUST_VERSION"
-
 	if [ "${SELINUX}" == "yes" ]; then
 		if [ "${AGENT_INIT}" == "yes" ]; then
 			die "Guest SELinux with the agent init is not supported yet"

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -181,7 +181,8 @@ create_summary_file()
 	[ "$AGENT_INIT" = yes ] && agent="${init}"
 
 	local -r agentdir="${script_dir}/../../../"
-	local -r agent_version=$(cat ${agentdir}/VERSION)
+	local agent_version=$(cat ${agentdir}/VERSION 2> /dev/null)
+	[ -z "$agent_version" ] && agent_version="unknown"
 
 	cat >"$file"<<-EOF
 	---


### PR DESCRIPTION
This allows to call tooling like the rootfs builder outside of a git environment. Calculating the VERSION_COMMIT field without warnings/errors depends on the presence of a VERSION file and on a git environment. We set the VERSION_COMMIT field to 'unknown' if the version cannot be properly calculated. This not only prevents errors in the Makefile but also prevents from rootfs.sh being called with an empty -o parameter, thus the distro parameter from being parsed incorrectly.
The change also makes a rust version check optional for cases where we want to build the rootfs w/o building the agent and thus w/o the rust dependency

Fixes: 9824