### PR TITLE
runtime: avoid panic on metrics gathering

### DIFF
--- a/src/runtime/virtcontainers/remote.go
+++ b/src/runtime/virtcontainers/remote.go
@@ -267,7 +267,7 @@ func (rh *remoteHypervisor) GetPids() []int {
 }
 
 func (rh *remoteHypervisor) GetVirtioFsPid() *int {
-	panic(notImplemented("GetVirtioFsPid"))
+	return nil
 }
 
 func (rh *remoteHypervisor) fromGrpc(ctx context.Context, hypervisorConfig *HypervisorConfig, j []byte) error {


### PR DESCRIPTION
While running with a remote hypervisor, whenever kata-monitor tries to access metrics from the shim, the shim does a "panic" and no metric can be gathered.

The function GetVirtioFsPid() is called on metrics gathering, and had a call to "panic()". Since there is no virtiofs process for remote hypervisor, the right implementation is to return nil. The caller expects that, and will skip metrics gathering for virtiofs.

Fixes: #9826