### PR TITLE
tests/k8s: run for qemu-runtime-rs on AKS

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -36,6 +36,7 @@ jobs:
           - clh
           - dragonball
           - qemu
+          - qemu-runtime-rs
           - stratovirt
           - cloud-hypervisor
         instance-type:

--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -13,6 +13,7 @@ setup() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "test not working see: ${dragonball_limitations}"
 	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "https://github.com/kata-containers/kata-containers/issues/9039"
+	[ "${KATA_HYPERVISOR}" == "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
 		[ "${KATA_HYPERVISOR}" == "qemu-sev" ] || [ "${KATA_HYPERVISOR}" == "qemu-se" ] ) \
 		&& skip "TEEs do not support memory / CPU hotplug"
@@ -100,6 +101,7 @@ teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "test not working see: ${dragonball_limitations}"
+	[ "${KATA_HYPERVISOR}" == "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "https://github.com/kata-containers/kata-containers/issues/9039"
 	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
 		[ "${KATA_HYPERVISOR}" == "qemu-sev" ] || [ "${KATA_HYPERVISOR}" == "qemu-se" ] ) \

--- a/tests/integration/kubernetes/k8s-number-cpus.bats
+++ b/tests/integration/kubernetes/k8s-number-cpus.bats
@@ -9,7 +9,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]]&& skip "test not working https://github.com/kata-containers/kata-containers/issues/9039"
+	[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/9039"
+	[ "${KATA_HYPERVISOR}" = "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 	pod_name="cpu-test"
 	container_name="c1"
 	get_pod_config_dir
@@ -50,7 +51,8 @@ setup() {
 }
 
 teardown() {
-	[[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ]]&& skip "test not working https://github.com/kata-containers/kata-containers/issues/9039"
+	[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/9039"
+	[ "${KATA_HYPERVISOR}" = "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -9,8 +9,9 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" == "dragonball" ] || [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]&& \
+	[ "${KATA_HYPERVISOR}" == "dragonball" ] || [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && \
 		skip "runtime-rs is still using the old vcpus allocation algorithm, skipping the test see https://github.com/kata-containers/kata-containers/issues/8660"
+	[ "${KATA_HYPERVISOR}" = "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 
 	get_pod_config_dir
 	pods=( "vcpus-less-than-one-with-no-limits" "vcpus-less-than-one-with-limits" "vcpus-more-than-one-with-limits" )
@@ -36,6 +37,7 @@ setup() {
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] || [ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && \
 		skip "runtime-rs is still using the old vcpus allocation algorithm, skipping the test see https://github.com/kata-containers/kata-containers/issues/8660"
+	[ "${KATA_HYPERVISOR}" = "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 
 	for pod in "${pods[@]}"; do
 		kubectl logs ${pod}


### PR DESCRIPTION
The following tests are disabled because they fail (alike with dragonball):

- k8s-cpu-ns.bats
- k8s-number-cpus.bats
- k8s-sandbox-vcpus-allocation.bats

Fixes #9804 