### PR TITLE
sandbox: fix the issue of failed to get the vmm master tid

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -139,12 +139,11 @@ impl ContainerManager for VirtContainerManager {
                 // * should be run after the container is deleted but before delete operation returns
                 // * spec details: https://github.com/opencontainers/runtime-spec/blob/c1662686cff159595277b79322d0272f5182941b/config.md#poststop
                 let c_spec = c.spec().await;
-                let vmm_master_tid = self.hypervisor.get_vmm_master_tid().await?;
                 let state = oci::State {
                     version: c_spec.version.clone(),
                     id: c.container_id.to_string(),
                     status: oci::ContainerState::Stopped,
-                    pid: vmm_master_tid as i32,
+                    pid: self.pid as i32,
                     bundle: c.config().await.bundle,
                     annotations: c_spec.annotations.clone(),
                 };


### PR DESCRIPTION
For kata container, the container's pid is meaning less to containerd/crio since the container's pid is belonged to VM, and containerd/crio couldn't use it. Thus we just return any tid of kata shim or hypervisor. But since the hypervisor had been stopped before deleting the container, and it wouldn't get the hypervisor's tid for some supported hypervisor, thus we'd better to return the kata shim's pid instead of hypervisor's tid.

Fixes: #9777
Fixes: #9374