### PR TITLE
tests: fix yq command line in k8s-policy-pvc

### DIFF
--- a/tests/integration/kubernetes/k8s-policy-pvc.bats
+++ b/tests/integration/kubernetes/k8s-policy-pvc.bats
@@ -45,10 +45,9 @@ test_pod_policy_error() {
 
 @test "Policy failure: unexpected device mount" {
 	# Changing the location of a mounted device after policy generation should fail the policy check.
-	yq write -i \
+	yq -i \
+		'.spec.containers[0].volumeDevices.[0].devicePath = "/dev/unexpected"' \
 		"${incorrect_pod_yaml}" \
-		"spec.containers[0].volumeDevices.[0].devicePath" \
-		"/dev/unexpected"
 
 	test_pod_policy_error
 }


### PR DESCRIPTION
Fix the collision between:
- https://github.com/kata-containers/kata-containers/pull/9377
- https://github.com/kata-containers/kata-containers/pull/9706

One enabled a newer yq command line format and the other used the older format. Both passed CI because they were not tested together.