### PR TITLE
tests: Use selector rather than pod name for kubectl logs/describe

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -532,9 +532,10 @@ function deploy_nydus_snapshotter() {
 
 	echo "::endgroup::"
 	echo "::group::nydus snapshotter logs"
-	pods_name=$(kubectl_retry get pods --selector=app=nydus-snapshotter -n nydus-system -o=jsonpath='{.items[*].metadata.name}')
-	kubectl_retry logs "${pods_name}" -n nydus-system
-	kubectl_retry describe pod "${pods_name}" -n nydus-system
+	kubectl_retry logs --selector=app=nydus-snapshotter -n nydus-system
+	echo "::endgroup::"
+	echo "::group::nydus snapshotter describe"
+	kubectl_retry describe pod --selector=app=nydus-snapshotter -n nydus-system
 	echo "::endgroup::"
 }
 


### PR DESCRIPTION
Since #9785 was introduced, the following error was observed during the deployment of nydus snapshotter:

```
Error from server (NotFound):
the server could not find the requested resource ( pods/log nydus-snapshotter-5v82v)
  'kubectl logs nydus-snapshotter-5v82v -n nydus-system' failed after 3 tries
    Error: Process completed with exit code 1.
```

This error can occur when a pod is re-created by a daemonset during the retry interval.
This commit addresses the issue by using `--selector` rather than the pod name
for `kubectl logs/describe`.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>