### PR TITLE
kata-deploy: always copy ci/install_yq.sh

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -56,13 +56,10 @@ endef
 
 kata-tarball: | all-parallel merge-builds
 
-$(MK_DIR)/dockerbuild/install_yq.sh:
-	$(MK_DIR)/kata-deploy-copy-yq-installer.sh
-
 copy-scripts-for-the-agent-build:
 	${MK_DIR}/kata-deploy-copy-libseccomp-installer.sh
 
-all-parallel: $(MK_DIR)/dockerbuild/install_yq.sh
+all-parallel:
 	${MAKE} -f $(MK_PATH) all -j $(shell nproc ${CI:+--ignore 1}) V=
 
 all: ${BASE_TARBALLS}
@@ -71,7 +68,7 @@ serial-targets:
 	${MAKE} -f $(MK_PATH) -j 1 V= \
 	${BASE_SERIAL_TARBALLS}
 
-%-tarball-build: $(MK_DIR)/dockerbuild/install_yq.sh
+%-tarball-build:
 	$(call BUILD,$*)
 
 agent-tarball: copy-scripts-for-the-agent-build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -68,6 +68,7 @@ if [ ! -d "$HOME/.docker" ]; then
 	remove_dot_docker_dir=true
 fi
 
+"${script_dir}"/kata-deploy-copy-yq-installer.sh
 docker build -q -t build-kata-deploy \
 	--build-arg IMG_USER="${USER}" \
 	--build-arg UID=${uid} \


### PR DESCRIPTION
To build the build-kata-deploy image, it should be copied ci/install_yq.sh to tools/packaging/kata-deploy/local-build/dockerbuild as this script will install yq within the image. Currently, if
tools/packaging/kata-deploy/local-build/dockerbuild/install_yq.sh exists then make won't copy it again. This can raise problems as, for example, the current update of yq version (commit c99ba42d) in ci/install_yq.sh won't force the rebuild of the build-kata-deploy image.

Note: this isn't a problem on a fresh dev or CI environment.