### PR TITLE
genpolicy: allow specifying layer cache file

### DIFF
--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -88,6 +88,14 @@ struct CommandLineOptions {
         help = "If specified, resources that have a runtimeClassName field defined will only receive a policy if the parameter is a prefix one of the given runtime class names."
     )]
     runtime_class_names: Vec<String>,
+
+    #[clap(
+        long,
+        help = "Path to the layers cache file. This file is used to store the layers cache information. The default value is ./layers-cache.json.",
+        default_missing_value = "./layers-cache.json",
+        require_equals = true
+    )]
+    layers_cache_file_path: Option<String>,
 }
 
 /// Application configuration, derived from on command line parameters.
@@ -106,6 +114,7 @@ pub struct Config {
     pub raw_out: bool,
     pub base64_out: bool,
     pub containerd_socket_path: Option<String>,
+    pub layers_cache_file_path: Option<String>,
 }
 
 impl Config {
@@ -123,6 +132,12 @@ impl Config {
             None
         };
 
+        let mut layers_cache_file_path = args.layers_cache_file_path;
+        // preserve backwards compatibility for only using the `use_cached_files` flag
+        if args.use_cached_files && layers_cache_file_path.is_none() {
+            layers_cache_file_path = Some(String::from("./layers-cache.json"));
+        }
+
         let settings = settings::Settings::new(&args.json_settings_path);
 
         Self {
@@ -137,6 +152,7 @@ impl Config {
             raw_out: args.raw_out,
             base64_out: args.base64_out,
             containerd_socket_path: args.containerd_socket_path,
+            layers_cache_file_path,
         }
     }
 }

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -63,6 +63,20 @@ setup() {
 	kubectl wait --for=condition=Ready "--timeout=${timeout}" pod "${pod_name}"
 }
 
+@test "Successful pod with auto-generated policy and custom layers cache path" {
+	tmp_path=$(mktemp -d)
+
+	auto_generate_policy "${pod_config_dir}" "${testcase_pre_generate_pod_yaml}" "${testcase_pre_generate_configmap_yaml}" \
+		"--layers-cache-file-path=${tmp_path}/cache.json"
+
+	[ -f "${tmp_path}/cache.json" ]
+	rm -r "${tmp_path}"
+
+	kubectl create -f "${testcase_pre_generate_configmap_yaml}"
+	kubectl create -f "${testcase_pre_generate_pod_yaml}"
+	kubectl wait --for=condition=Ready "--timeout=${timeout}" pod "${pod_name}"
+}
+
 # Common function for several test cases from this bats script.
 test_pod_policy_error() {
 	kubectl create -f "${correct_configmap_yaml}"


### PR DESCRIPTION
Add --layers-cache-file-path flag to allow the user to specify where the cache file for the container layers is saved. This allows e.g. to have one cache file independent of the user's working directory.

In the actual logic, this replaces the `use_cached_files` variable. Note that the `use_cached_files` flag can still be used and the CLI retains the same behavior.

Current error behavior when specifying a path that does not exists:
```
[2024-06-17T20:34:25Z INFO  genpolicy::registry] ============================================
[2024-06-17T20:34:25Z INFO  genpolicy::registry] Pulling manifest and config for "ghcr.io/3u13r/contrast/openssl@sha256:2b75075a8c1273607fa9acbf30792b5d59c2a4b8519ceb8327226ac31d52633f"
[2024-06-17T20:34:26Z INFO  genpolicy::registry] read_verity_from_store: failed to open cache file: No such file or directory (os error 2)
[2024-06-17T20:34:26Z INFO  genpolicy::registry] Using cache file
[2024-06-17T20:34:26Z INFO  genpolicy::registry] dm-verity root hash: 
[2024-06-17T20:34:26Z INFO  genpolicy::registry] Pulling layer "sha256:763bf95122c1a0deac5651dda505097395c2269da607d6562b33f5ba759cb242"
[2024-06-17T20:34:27Z INFO  genpolicy::registry] Decompressing layer
[2024-06-17T20:34:28Z INFO  genpolicy::registry] Adding tarfs index to layer
[2024-06-17T20:34:29Z INFO  genpolicy::registry] Calculating dm-verity root hash
thread 'main' panicked at src/registry.rs:105:18:
called `Result::unwrap()` on an `Err` value: No such file or directory (os error 2)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```


cc: @danmihai1 
Fixes: #8567 