### PR TITLE
tests: nerdctl: Fix variables names and remove network

### DIFF
--- a/tests/integration/nerdctl/gha-run.sh
+++ b/tests/integration/nerdctl/gha-run.sh
@@ -86,12 +86,12 @@ function run() {
 	# that an interface called eth0 exists on the host.
 	local ipvlan_net_name="ipvlan10"
 	info "Creating ipvlan network with eth0 interface on host as parent"
-	sudo nerdctl network create ${ipvlan_net_name=} --driver ipvlan --subnet=10.5.74.0/24 -o parent=${parent_interface}
+	sudo nerdctl network create ${ipvlan_net_name} --driver ipvlan --subnet=10.5.74.0/24 -o parent=${parent_interface}
 
 	# The following creates an ipvlan network with eth0 on host as parent.
 	local macvlan_net_name="macvlan20"
 	info "Creating macvlan network with eth0 interface on host as parent"
-	sudo nerdctl network create ${macvlan_net_name=} --driver ipvlan --subnet=10.8.0.0/24 -o parent=${parent_interface}
+	sudo nerdctl network create ${macvlan_net_name} --driver ipvlan --subnet=10.8.0.0/24 -o parent=${parent_interface}
 
 	enabling_hypervisor
 
@@ -111,6 +111,9 @@ function run() {
 
 	info "Running nerdctl with Kata Containers (${KATA_HYPERVISOR}) and macvlan network"
 	sudo nerdctl run  --rm --net ${macvlan_net_name}  --runtime io.containerd.kata-${KATA_HYPERVISOR}.v2 alpine ip a | grep "eth0"
+
+	info "Removing networks"
+	sudo nerdctl network rm ${macvlan_net_name} ${ipvlan_net_name}
 }
 
 function main() {


### PR DESCRIPTION
This PR fixes the variables names for the network that was created as well removes the network that were created for the tests to ensure a clean environment when running all the tests and avoid failures specially on baremental environments that network already exists.