### PR TITLE
ci: tdx: Use vanilla k8s instead of k3s

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -40,7 +40,7 @@ jobs:
   #      DOCKER_TAG: ${{ inputs.tag }}
   #      PR_NUMBER: ${{ inputs.pr-number }}
   #      KATA_HYPERVISOR: ${{ matrix.vmm }}
-  #      KUBERNETES: "k3s"
+  #      KUBERNETES: "vanilla"
   #      USING_NFD: "true"
   #      KBS: "true"
   #      K8S_TEST_HOST_TYPE: "baremetal"


### PR DESCRIPTION
We've noticed a bunch of issues related to deploying and deleting the nydus-snapshotter.  As we don't see the same issues on other machines using vanilla kubernetes, let's avoid using k3s for now follow the flow.

NOTE: This test should **NOT** run as the TDX CI is not enabled right now.