### PR TITLE
ci: tdx: Re-enable TDX CI

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -23,78 +23,78 @@ on:
         default: ""
 
 jobs:
-  #  run-k8s-tests-on-tdx:
-  #    strategy:
-  #      fail-fast: false
-  #      matrix:
-  #        vmm:
-  #          - qemu-tdx
-  #        snapshotter:
-  #          - nydus
-  #        pull-type:
-  #          - guest-pull
-  #    runs-on: tdx
-  #    env:
-  #      DOCKER_REGISTRY: ${{ inputs.registry }}
-  #      DOCKER_REPO: ${{ inputs.repo }}
-  #      DOCKER_TAG: ${{ inputs.tag }}
-  #      PR_NUMBER: ${{ inputs.pr-number }}
-  #      KATA_HYPERVISOR: ${{ matrix.vmm }}
-  #      KUBERNETES: "vanilla"
-  #      USING_NFD: "true"
-  #      KBS: "true"
-  #      K8S_TEST_HOST_TYPE: "baremetal"
-  #      KBS_INGRESS: "nodeport"
-  #      SNAPSHOTTER: ${{ matrix.snapshotter }}
-  #      PULL_TYPE: ${{ matrix.pull-type }}
-  #    steps:
-  #      - uses: actions/checkout@v4
-  #        with:
-  #          ref: ${{ inputs.commit-hash }}
-  #          fetch-depth: 0
-  #
-  #      - name: Rebase atop of the latest target branch
-  #        run: |
-  #          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
-  #        env:
-  #          TARGET_BRANCH: ${{ inputs.target-branch }}
-  #
-  #      - name: Deploy Snapshotter
-  #        timeout-minutes: 5
-  #        run: bash tests/integration/kubernetes/gha-run.sh deploy-snapshotter
-  #
-  #      - name: Deploy Kata
-  #        timeout-minutes: 10
-  #        run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-tdx
-  #
-  #      - name: Uninstall previous `kbs-client`
-  #        timeout-minutes: 10
-  #        run: bash tests/integration/kubernetes/gha-run.sh uninstall-kbs-client
-  #
-  #      - name: Deploy CoCo KBS
-  #        timeout-minutes: 10
-  #        run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
-  #
-  #      - name: Install `kbs-client`
-  #        timeout-minutes: 10
-  #        run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
-  #
-  #      - name: Run tests
-  #        timeout-minutes: 30
-  #        run: bash tests/integration/kubernetes/gha-run.sh run-tests
-  #
-  #      - name: Delete kata-deploy
-  #        if: always()
-  #        run: bash tests/integration/kubernetes/gha-run.sh cleanup-tdx
-  #
-  #      - name: Delete Snapshotter
-  #        if: always()
-  #        run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
-  #
-  #      - name: Delete CoCo KBS
-  #        if: always()
-  #        run: bash tests/integration/kubernetes/gha-run.sh delete-coco-kbs
-  #
+  run-k8s-tests-on-tdx:
+    strategy:
+      fail-fast: false
+      matrix:
+        vmm:
+          - qemu-tdx
+        snapshotter:
+          - nydus
+        pull-type:
+          - guest-pull
+    runs-on: tdx
+    env:
+      DOCKER_REGISTRY: ${{ inputs.registry }}
+      DOCKER_REPO: ${{ inputs.repo }}
+      DOCKER_TAG: ${{ inputs.tag }}
+      PR_NUMBER: ${{ inputs.pr-number }}
+      KATA_HYPERVISOR: ${{ matrix.vmm }}
+      KUBERNETES: "vanilla"
+      USING_NFD: "true"
+      KBS: "true"
+      K8S_TEST_HOST_TYPE: "baremetal"
+      KBS_INGRESS: "nodeport"
+      SNAPSHOTTER: ${{ matrix.snapshotter }}
+      PULL_TYPE: ${{ matrix.pull-type }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Deploy Snapshotter
+        timeout-minutes: 5
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-snapshotter
+
+      - name: Deploy Kata
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-tdx
+
+      - name: Uninstall previous `kbs-client`
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh uninstall-kbs-client
+
+      - name: Deploy CoCo KBS
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
+
+      - name: Install `kbs-client`
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
+
+      - name: Run tests
+        timeout-minutes: 30
+        run: bash tests/integration/kubernetes/gha-run.sh run-tests
+
+      - name: Delete kata-deploy
+        if: always()
+        run: bash tests/integration/kubernetes/gha-run.sh cleanup-tdx
+
+      - name: Delete Snapshotter
+        if: always()
+        run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
+
+      - name: Delete CoCo KBS
+        if: always()
+        run: bash tests/integration/kubernetes/gha-run.sh delete-coco-kbs
+
   run-k8s-tests-on-sev:
     strategy:
       fail-fast: false


### PR DESCRIPTION
Now, using vanilla kubernetes, let's re-enable the TDX CI and hope it becomes more stable than it used to be.

The cleanup-snapshotter is now taking ~4 minutes, and that matches with the other platforms, mainly considering there's a sum of 210 seconds sleep in the process.