### PR TITLE
ci.ocp: Ensure we smoke-test with the right runtime class

### DIFF
--- a/ci/openshift-ci/run_smoke_test.sh
+++ b/ci/openshift-ci/run_smoke_test.sh
@@ -15,7 +15,9 @@ pod='http-server'
 # Create a pod.
 #
 info "Creating the ${pod} pod"
-oc apply -f ${script_dir}/smoke/${pod}.yaml || \
+[ -z "$KATA_RUNTIME" ] && die "Please set the KATA_RUNTIME first"
+envsubst < "${script_dir}/smoke/${pod}.yaml.in" | \
+	oc apply -f - || \
 	die "failed to create ${pod} pod"
 
 # Check it eventually goes to 'running'

--- a/ci/openshift-ci/smoke/http-server.yaml.in
+++ b/ci/openshift-ci/smoke/http-server.yaml.in
@@ -27,4 +27,4 @@ spec:
         runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
-  runtimeClassName: kata-qemu
+  runtimeClassName: ${KATA_RUNTIME}

--- a/ci/openshift-ci/test.sh
+++ b/ci/openshift-ci/test.sh
@@ -5,6 +5,9 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# The kata shim to be used
+export KATA_RUNTIME=${KATA_RUNTIME:-kata-qemu}
+
 script_dir=$(dirname $0)
 source ${script_dir}/lib.sh
 


### PR DESCRIPTION
we do encourage people to set the KATA_RUNTIME, but it is only used by the webhook. Let's define it in the main `test.sh` and use it in the smoke test to ensure the user-defined runtime is smoke-tested rather than hard-coded kata-qemu one.

Related to: #9804