### PR TITLE
ci: kbs: Force delete the KBS pod

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -183,7 +183,15 @@ function kbs_k8s_delete() {
 	kubectl delete -k config/kubernetes/overlays
 	# Verify that KBS namespace resources were properly deleted
 	cmd="kubectl get all -n $KBS_NS 2>&1 | grep 'No resources found'"
-	waitForProcess "120" "30" "$cmd"
+	waitForProcess "90" "30" "$cmd"
+
+	# This is not ideal, but this will avoid runs getting stuck
+	# till we debug why it's actually happening.
+	if kubectl get pods -n $KBS_NS | grep -q Terminating; then
+		pod=$(kubectl get pods -n $KBS_NS -o NAME)
+		cmd="kubectl delete $pod -n $KBS_NS --force"
+		waitForProcess "60" "15" "$cmd"
+	fi
 	popd
 }
 


### PR DESCRIPTION
I've noticed that the KBS pod is getting stuck in "Terminating" state, which blocks the CI to finish.

This code path is only running on TDX for now, as the coco-qemu-dev runs do not clean up the KBS bits, so it may be a TDX machine issue or it may be a KBS issue.

Workarounds: #9885