### PR TITLE
tests: attestation: Restrict sample policy use

### DIFF
--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -47,7 +47,10 @@ setup() {
 }
 
 @test "Get CDH resource" {
-	kbs_set_allow_all_resources
+	if ! is_confidential_hardware; then
+		kbs_set_allow_all_resources
+	fi
+
 	kubectl apply -f "${K8S_TEST_YAML}"
 
 	# Retrieve pod name, wait for it to come up, retrieve pod ip


### PR DESCRIPTION
- We only want to enable the sample verifier in the KBS for non-TEE tests, so prevent an edge case where the TEE platform isn't set up correctly and we might fall back to the sample and get false positives. To prevent this we add guards around the sample policy enablement and only run it for non confidential hardware