### PR TITLE
ci: Add scheduled job to cleanup resources, pt. II

### DIFF
--- a/.github/workflows/cleanup-resources.yaml
+++ b/.github/workflows/cleanup-resources.yaml
@@ -9,5 +9,21 @@ jobs:
     runs-on: ubuntu-latest
     secrets: inherit
     steps:
+      - name: Log into Azure
+        env:
+          AZ_APPID: ${{ secrets.AZ_APPID }}
+          AZ_PASSWORD: ${{ secrets.AZ_PASSWORD }}
+          AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
+          AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+        run: bash tests/integration/kubernetes/gha-run.sh login-azure
+
+      - name: Install Python dependencies
+        run: |
+          pip3 install --user --upgrade \
+            azure-identity==1.16.0 \
+            azure-mgmt-resource==23.0.1
+
       - name: Cleanup resources
+        env:
+          AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
         run: python3 tests/cleanup_resources.py

--- a/.github/workflows/cleanup-resources.yaml
+++ b/.github/workflows/cleanup-resources.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   cleanup-resources:
     runs-on: ubuntu-latest
-    secrets: inherit
     steps:
       - name: Log into Azure
         env:


### PR DESCRIPTION
```
Follow-up to #9898.

This adapts the workflow to log into Azure, install Python dependencies
required to manage Azure resources, and pass the subscription which will
be required by the cleanup script. I tested that at least listing
resources works locally with the above.
```