### PR TITLE
genpolicy: deny UpdateEphemeralMountsRequest

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -316,6 +316,7 @@
         },
         "CloseStdinRequest": false,
         "ReadStreamRequest": false,
+        "UpdateEphemeralMountsRequest": false,
         "WriteStreamRequest": false
     }
 }

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -39,7 +39,7 @@ default StatsContainerRequest := true
 default StopTracingRequest := false
 default TtyWinResizeRequest := true
 default UpdateContainerRequest := false
-default UpdateEphemeralMountsRequest := true
+default UpdateEphemeralMountsRequest := false
 default UpdateInterfaceRequest := true
 default UpdateRoutesRequest := true
 default WaitProcessRequest := true
@@ -1167,6 +1167,10 @@ CloseStdinRequest {
 
 ReadStreamRequest {
     policy_data.request_defaults.ReadStreamRequest == true
+}
+
+UpdateEphemeralMountsRequest {
+    policy_data.request_defaults.UpdateEphemeralMountsRequest == true
 }
 
 WriteStreamRequest {

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -344,6 +344,9 @@ pub struct RequestDefaults {
     /// Allow Host reading from Guest containers stdout and stderr.
     pub ReadStreamRequest: bool,
 
+    /// Allow Host to update Guest mounts.
+    pub UpdateEphemeralMountsRequest: bool,
+
     /// Allow Host writing to Guest containers stdin.
     pub WriteStreamRequest: bool,
 }

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -153,6 +153,14 @@ adapt_common_policy_settings_for_sev() {
 	jq '.kata_config.oci_version = "1.1.0-rc.1" | .common.cpath = "/run/kata-containers" | .volumes.configMap.mount_point = "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-"' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
 }
 
+# adapt common policy settings for CBL-Mariner https://github.com/kata-containers/kata-containers/issues/10189
+adapt_common_policy_settings_for_cbl_mariner() {
+	local settings_dir=$1
+
+	info "Adapting common policy settings for CBL-Mariner"
+	jq '.request_defaults.UpdateEphemeralMountsRequest = true' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
+}
+
 # adapt common policy settings for various platforms
 adapt_common_policy_settings() {
 
@@ -164,6 +172,12 @@ adapt_common_policy_settings() {
 			;;
   		"qemu-sev")
 			adapt_common_policy_settings_for_sev "${settings_dir}"
+			;;
+	esac
+
+	case "${KATA_HOST_OS}" in
+		"cbl-mariner")
+			adapt_common_policy_settings_for_cbl_mariner "${settings_dir}"
 			;;
 	esac
 }


### PR DESCRIPTION
* genpolicy: deny UpdateEphemeralMountsRequest

Deny UpdateEphemeralMountsRequest by default, because paths to critical Guest components can be redirected using such request.

Upstreaming from https://github.com/microsoft/kata-containers/pull/126