### PR TITLE
kata-deploy: fix qemu static build on ppc64le

### DIFF
--- a/src/runtime/virtcontainers/qemu_ppc64le.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le.go
@@ -26,7 +26,7 @@ const defaultQemuPath = "/usr/bin/qemu-system-ppc64"
 
 const defaultQemuMachineType = QemuPseries
 
-const defaultQemuMachineOptions = "accel=kvm,usb=off"
+const defaultQemuMachineOptions = "accel=kvm,usb=off,cap-ail-mode-3=off"
 
 const qmpMigrationWaitTimeout = 5 * time.Second
 

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -64,7 +64,6 @@ RUN apt-get update && apt-get upgrade -y && \
 	    rsync \
 	    zlib1g-dev${DPKG_ARCH} && \
     if [ "${ARCH}" != s390x ]; then apt-get install -y --no-install-recommends libpmem-dev${DPKG_ARCH}; fi && \
-	if [ "${ARCH}" == ppc64le ]; then apt-get install -y --no-install-recommends librados-dev librbd-dev; fi && \
     GCC_ARCH="${ARCH}" && if [ "${ARCH}" = "ppc64le" ]; then GCC_ARCH="powerpc64le"; fi && \
     if [ "${ARCH}" != "$(uname -m)" ]; then apt-get install --no-install-recommends -y gcc-"${GCC_ARCH}"-linux-gnu; fi && \
     apt-get clean && rm -rf /var/lib/apt/lists/


### PR DESCRIPTION
Do not install the packages librados-dev and librbd-dev as they are not needed for building static qemu.

Fixes: #9893