### PR TITLE
rootfs: Fix spurious error

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -40,6 +40,10 @@ packages=libtdx-attest=1.20\*
 EOF
 	fi
 
+	# This fixes the spurious error
+	# E: Can't find a source to download version '2021.03.26' of 'ubuntu-keyring:amd64'
+	apt update
+
 	if ! multistrap -a "$DEB_ARCH" -d "$rootfs_dir" -f "$multistrap_conf"; then
 		build_dbus $rootfs_dir
 	fi


### PR DESCRIPTION
 In some occassions multistrap is not able to find the ubuntu-keyring  package, e.g. CI system, DMZ'ed server etc. Run `apt pdate`  to have all repos up to date.