### PR TITLE
gpu: rootfs ubuntu build expansion

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -437,6 +437,8 @@ build_rootfs_distro()
 			${engine_build_args} \
 			--build-arg http_proxy="${http_proxy}" \
 			--build-arg https_proxy="${https_proxy}" \
+			--build-arg RUST_TOOLCHAIN="$(get_package_version_from_kata_yaml  "languages.rust.meta.newest-version")" \
+			--build-arg GO_VERSION="$(get_package_version_from_kata_yaml  "languages.golang.version")" \
 			-t "${image_name}" "${distro_config_dir}"
 
 		# fake mapping if KERNEL_MODULES_DIR is unset

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -6,6 +6,22 @@ ARG IMAGE_REGISTRY=docker.io
 FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@
 @SET_PROXY@
 
+ENV GO_HOME="/opt"
+ENV GOCACHE="${GO_HOME}/.cache"
+ENV RUSTUP_HOME="/opt/rustup"
+ENV CARGO_HOME="/opt/cargo"
+ENV PATH="/opt/cargo/bin/:/opt/go/bin:${PATH}"
+
+ARG GO_VERSION
+ARG RUST_TOOLCHAIN
+ENV GO_HOME="/opt"
+ENV PATH="/opt/go/bin:${PATH}"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME} ${GOCACHE} && \
+    chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME} ${GO_HOME}
+
 # makedev tries to mknod from postinst
 RUN [ -x /usr/bin/systemd-detect-virt ] || ( echo "echo docker" >/usr/bin/systemd-detect-virt && chmod +x /usr/bin/systemd-detect-virt )
 # hadolint ignore=DL3009,SC2046
@@ -27,10 +43,45 @@ RUN apt-get update && \
     make \
     makedev \
     multistrap \
+    musl \
+    musl-dev \
     musl-tools \
     protobuf-compiler \
-    xz-utils
+    xz-utils \
+    pip \
+    python3-dev \
+    xz-utils \
+    zstd && \
+    apt-get clean && rm -rf /var/lib/apt/lists/&& \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+
+RUN ARCH=$(uname -m); \
+    goarch=""; \
+    kernelname=$(uname -s | tr '[:upper:]' '[:lower:]'); \
+    case "${ARCH}" in \
+        "aarch64") goarch="arm64" ;; \
+        "ppc64le") goarch=${ARCH} ;; \
+        "x86_64") goarch="amd64" ;; \
+        "s390x") goarch=${ARCH} ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+    esac; \
+    curl -OL "https://storage.googleapis.com/golang/go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
+    tar -C "${GO_HOME}" -xzf "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
+    rm "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz"
+
 # aarch64 requires this name -- link for all
 RUN if [ ! -f "/usr/bin/$(uname -m)-linux-musl-gcc" ]; then ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"; fi
 
-@INSTALL_RUST@
+RUN ARCH=$(uname -m); \
+	rust_arch=""; \
+    libc=""; \
+    case "${ARCH}" in \
+        "aarch64") rust_arch="${ARCH}"; libc="musl"; ;; \
+        "ppc64le") rust_arch="powerpc64le"; libc="gnu"; ;; \
+        "x86_64") rust_arch="${ARCH}"; libc="musl"; ;; \
+        "s390x") rust_arch="${ARCH}"; libc="gnu"; ;; \
+        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
+	esac; \
+    rustup target add "${rust_arch}-unknown-linux-${libc}"
+
+RUN pip install --no-cache-dir pyinstaller==6.9.0


### PR DESCRIPTION
For the GPU build we need go/rust and some other helpers to build the rootfs.