### PR TITLE
gpu: rootfs/initrd build init

### DIFF
--- a/tools/osbuilder/initrd-builder/initrd_builder.sh
+++ b/tools/osbuilder/initrd-builder/initrd_builder.sh
@@ -72,8 +72,9 @@ OK "init is installed"
 	use AGENT_BIN env variable to change the expected agent binary name"
 OK "Agent is installed"
 
-# initramfs expects /init
-sudo ln -sf /sbin/init "${ROOTFS}/init"
+# initramfs expects /init, create symlink only if ${ROOTFS}/init does not exist
+# Init may be provided by other packages, e.g. systemd or GPU initrd/rootfs
+[ -x "${ROOTFS}/init" ] || [ -L "${ROOTFS}/init" ] || sudo ln -sf /sbin/init "${ROOTFS}/init"
 
 info "Creating ${IMAGE_DIR}/${IMAGE_NAME} based on rootfs at ${ROOTFS}"
 ( cd "${ROOTFS}" && sudo find . | sudo cpio -H newc -o | gzip -9 ) > "${IMAGE_DIR}"/"${IMAGE_NAME}"


### PR DESCRIPTION
Initramfs expects /init, create symlink only if ${ROOTFS}/init does not exist Init may be provided by other packages, e.g. systemd or GPU initrd/rootfs