### PR TITLE
metrics: Update container name in blogbench test

### DIFF
--- a/tests/metrics/storage/blogbench.sh
+++ b/tests/metrics/storage/blogbench.sh
@@ -40,7 +40,7 @@ function main() {
 	metrics_json_init
 
 	info "Running Blogbench test"
-	local output=$(sudo -E ${CTR_EXE} run --rm --runtime=${CTR_RUNTIME} ${IMAGE} test ${CMD})
+	local output=$(sudo -E ${CTR_EXE} run --rm --runtime=${CTR_RUNTIME} ${IMAGE} $(random_name) ${CMD})
 
 	# Save configuration
 	metrics_json_start_array


### PR DESCRIPTION
This PR updates the container name to put a random name instead of using a hard coded name.