### PR TITLE
tests: Increase interval and max_tries for kubectl_retry

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -81,11 +81,11 @@ function handle_error() {
 trap 'handle_error $LINENO' ERR
 
 # A wrapper function for kubectl with retry logic
-# runs the command up to 3 times with a 5-second interval
+# runs the command up to 5 times with a 15-second interval
 # to ensure successful execution
 function kubectl_retry() {
-	local max_tries=3
-	local interval=5
+	local max_tries=5
+	local interval=15
 	local i=0
 	while true; do
 		kubectl $@ && return 0 || true


### PR DESCRIPTION
Observed instability in the API server after deploying kata-deploy caused test failures. (see: https://github.com/kata-containers/kata-containers/actions/runs/9681494440/job/26743286861) Specifically, `kubectl_retry logs` failed before the API server could respond properly.

This commit increases the interval and max_tries for kubectl_retry(), allowing sufficient time to handle this situation.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>