### PR TITLE
ci: remove sudo from kata-static-arm64 build

### DIFF
--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -88,10 +88,6 @@ jobs:
     runs-on: arm64-builder
     needs: build-asset
     steps:
-      - name: Adjust a permission for repo
-        run: |
-          sudo chown -R $USER:$USER $GITHUB_WORKSPACE
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}


### PR DESCRIPTION
We do not need it in the amd64 case and we've made all artifacts owned by USER this is not needed anymore.