### PR TITLE
Upgrade to Cloud Hypervisor v40.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -655,7 +655,7 @@ components:
             guest_numa_id: 3
           rng:
             iommu: false
-            src: /dev/urandom
+            src: src
           sgx_epc:
           - prefault: false
             size: 7
@@ -1082,7 +1082,7 @@ components:
           guest_numa_id: 3
         rng:
           iommu: false
-          src: /dev/urandom
+          src: src
         sgx_epc:
         - prefault: false
           size: 7
@@ -1366,11 +1366,9 @@ components:
           - 3
       properties:
         boot_vcpus:
-          default: 1
           minimum: 1
           type: integer
         max_vcpus:
-          default: 1
           minimum: 1
           type: integer
         topology:
@@ -1794,10 +1792,9 @@ components:
     RngConfig:
       example:
         iommu: false
-        src: /dev/urandom
+        src: src
       properties:
         src:
-          default: /dev/urandom
           type: string
         iommu:
           default: false

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/CpusConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/CpusConfig.md
@@ -4,8 +4,8 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**BootVcpus** | **int32** |  | [default to 1]
-**MaxVcpus** | **int32** |  | [default to 1]
+**BootVcpus** | **int32** |  | 
+**MaxVcpus** | **int32** |  | 
 **Topology** | Pointer to [**CpuTopology**](CpuTopology.md) |  | [optional] 
 **KvmHyperv** | Pointer to **bool** |  | [optional] [default to false]
 **MaxPhysBits** | Pointer to **int32** |  | [optional] 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/RngConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/RngConfig.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Src** | **string** |  | [default to "/dev/urandom"]
+**Src** | **string** |  | 
 **Iommu** | Pointer to **bool** |  | [optional] [default to false]
 
 ## Methods

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cpus_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_cpus_config.go
@@ -43,10 +43,6 @@ func NewCpusConfig(bootVcpus int32, maxVcpus int32) *CpusConfig {
 // but it doesn't guarantee that properties required by API are set
 func NewCpusConfigWithDefaults() *CpusConfig {
 	this := CpusConfig{}
-	var bootVcpus int32 = 1
-	this.BootVcpus = bootVcpus
-	var maxVcpus int32 = 1
-	this.MaxVcpus = maxVcpus
 	var kvmHyperv bool = false
 	this.KvmHyperv = &kvmHyperv
 	return &this

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_rng_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_rng_config.go
@@ -37,8 +37,6 @@ func NewRngConfig(src string) *RngConfig {
 // but it doesn't guarantee that properties required by API are set
 func NewRngConfigWithDefaults() *RngConfig {
 	this := RngConfig{}
-	var src string = "/dev/urandom"
-	this.Src = src
 	var iommu bool = false
 	this.Iommu = &iommu
 	return &this

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -667,11 +667,9 @@ components:
       properties:
         boot_vcpus:
           minimum: 1
-          default: 1
           type: integer
         max_vcpus:
           minimum: 1
-          default: 1
           type: integer
         topology:
           $ref: "#/components/schemas/CpuTopology"
@@ -736,7 +734,6 @@ components:
         size:
           type: integer
           format: int64
-          default: 512 MB
         file:
           type: string
         mergeable:
@@ -772,7 +769,6 @@ components:
         size:
           type: integer
           format: int64
-          default: 512 MB
         hotplug_size:
           type: integer
           format: int64
@@ -857,7 +853,7 @@ components:
           type: string
         rate_limiter_config:
           $ref: "#/components/schemas/RateLimiterConfig"
-    
+
     VirtQueueAffinity:
       required:
         - queue_index
@@ -963,7 +959,6 @@ components:
       properties:
         src:
           type: string
-          default: "/dev/urandom"
         iommu:
           type: boolean
           default: false

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v39.0"
+      version: "v40.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
This release has been tracked in our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6) as iteration
v40.0. The following user visible changes have been made:

### Support for Restoring File Descriptor Backed Network Devices

It is now possible to pass file descriptors over the HTTP API (and using
`ch-remote`) when restoring to update the file descriptors for network devices.
This enables snapshot & restore functionality for guests using `macvtap` or
other file descriptor backed network devices. 

### Notable Bug Fixes

* Default values have been removed from required fields in the OpenAPI metadata
* The help syntax of `ch-remote remove-device` has been improved
* A double close of file descriptors has been fixed when using `--serial`
* To prevent loops a limit on the nesting level for QCOW2 backing files has
  been introduced
* Boot time performance has been improved with multiple cores by avoiding
  `cpuid` instructions and by seeding the in kernel file descriptor table
* L1 cache details are more likely to be propagated into the guest
* The default topology for guests now uses multiple cores rather than sockets