### PR TITLE
CI: Use multi-arch image for alpine-bash-curl

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-attestable.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-attestable.yaml
@@ -10,7 +10,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: bash-curl
-      image: storytel/alpine-bash-curl:latest
+      image: quay.io/kata-containers/alpine-bash-curl:latest
       imagePullPolicy: Always
       command:
         - sh


### PR DESCRIPTION
A multi-arch image for `alpine-bash-curl` has been pushed to and available at `quay.io/kata-containers`.
This PR switches the test image to `quay.io/kata-containers/alpine-bash-curl`.

Fixes: #9935

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>