### PR TITLE
CI: Correct rootfs ubuntu version and fix local (re)build

### DIFF
--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -93,6 +93,7 @@ rootfs-%: $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX)
 
 .PRECIOUS: $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX)
 $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX):: rootfs-builder/%
+	mkdir -p $(ROOTFS_BUILD_DEST)
 	$(call silent_run,Creating rootfs for "$*",$(ROOTFS_BUILDER) -o $(VERSION_COMMIT) -r $(ROOTFS_BUILD_DEST)/$*_rootfs $*)
 	@touch $@
 

--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -21,6 +21,7 @@ TARGET_ROOTFS         := $(ROOTFS_BUILD_DEST)/$(DISTRO)_rootfs
 TARGET_ROOTFS_MARKER  := $(ROOTFS_BUILD_DEST)/.$(DISTRO)$(ROOTFS_MARKER_SUFFIX)
 TARGET_IMAGE          := $(IMAGES_BUILD_DEST)/kata-containers.img
 TARGET_INITRD         := $(IMAGES_BUILD_DEST)/kata-containers-initrd.img
+ARTEFACT_VERSION      ?= none
 
 VERSION_FILE   := ./VERSION
 VERSION        := $(shell grep -v ^\# $(VERSION_FILE) 2>/dev/null || echo "unknown")
@@ -95,7 +96,7 @@ rootfs-%: $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX)
 $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX):: rootfs-builder/%
 	mkdir -p $(ROOTFS_BUILD_DEST)
 	$(call silent_run,Creating rootfs for "$*",$(ROOTFS_BUILDER) -o $(VERSION_COMMIT) -r $(ROOTFS_BUILD_DEST)/$*_rootfs $*)
-	@touch $@
+	@echo "$(ARTEFACT_VERSION)" >$@
 
 # To generate a dracut rootfs, we first generate a dracut initrd and then
 # extract it in a local folder.
@@ -106,7 +107,7 @@ ifeq (dracut,$(BUILD_METHOD))
 $(ROOTFS_BUILD_DEST)/.dracut$(ROOTFS_MARKER_SUFFIX): $(TARGET_INITRD)
 	mkdir -p $(TARGET_ROOTFS)
 	(cd $(TARGET_ROOTFS); cat $< | cpio --extract --preserve-modification-time --make-directories)
-	@touch $@
+	@echo "$(ARTEFACT_VERSION)" >$@
 endif
 
 image-%: $(IMAGES_BUILD_DEST)/kata-containers-image-%.img
@@ -125,6 +126,16 @@ $(IMAGES_BUILD_DEST)/kata-containers-initrd-%.img: rootfs-%
 
 .PHONY: rootfs
 rootfs: $(TARGET_ROOTFS_MARKER)
+
+# Invalidate rootfs unless artefact version is defined and matches to saved in marker
+.PHONY: invalidate-rootfs
+invalidate-rootfs:
+	@if [ "$(ARTEFACT_VERSION)" = "none" -o "$(ARTEFACT_VERSION)" != "$$(cat $(TARGET_ROOTFS_MARKER))" ] ; then \
+		echo "Invalidate rootfs $(TARGET_ROOTFS)" ; \
+		rm -f $(TARGET_ROOTFS_MARKER) ; \
+	else \
+		echo "Preserve rootfs $(TARGET_ROOTFS)" ; \
+	fi
 
 .PHONY: image
 image: $(TARGET_IMAGE)

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -398,12 +398,6 @@ build_rootfs_distro()
 		trap error_handler ERR
 	fi
 
-	if [ -d "${ROOTFS_DIR}" ] && [ "${ROOTFS_DIR}" != "/" ]; then
-		rm -rf "${ROOTFS_DIR}"/*
-	else
-		mkdir -p ${ROOTFS_DIR}
-	fi
-
 	if [ "${SELINUX}" == "yes" ]; then
 		if [ "${AGENT_INIT}" == "yes" ]; then
 			die "Guest SELinux with the agent init is not supported yet"
@@ -414,6 +408,13 @@ build_rootfs_distro()
 	fi
 
 	if [ -z "${USE_DOCKER}" ] && [ -z "${USE_PODMAN}" ]; then
+
+		if [ -d "${ROOTFS_DIR}" ] && [ "${ROOTFS_DIR}" != "/" ]; then
+			rm -rf "${ROOTFS_DIR}"/*
+		else
+			mkdir -p ${ROOTFS_DIR}
+		fi
+
 		info "build directly"
 		build_rootfs ${ROOTFS_DIR}
 	else

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -36,7 +36,7 @@ build_initrd() {
 	info "Build initrd"
 	info "initrd os: $os_name"
 	info "initrd os version: $os_version"
-	make initrd \
+	make invalidate-rootfs initrd \
 		DISTRO="$os_name" \
 		DEBUG="${DEBUG:-}" \
 		OS_VERSION="${os_version}" \
@@ -46,6 +46,7 @@ build_initrd() {
 		AGENT_INIT="yes" \
 		AGENT_POLICY="${AGENT_POLICY:-}" \
 		PULL_TYPE="${PULL_TYPE:-default}" \
+		ARTEFACT_VERSION="${artefact_version}" \
 		COCO_GUEST_COMPONENTS_TARBALL="${COCO_GUEST_COMPONENTS_TARBALL:-}" \
 		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}"
 	mv "kata-containers-initrd.img" "${install_dir}/${artifact_name}"
@@ -59,7 +60,7 @@ build_image() {
 	info "Build image"
 	info "image os: $os_name"
 	info "image os version: $os_version"
-	make image \
+	make invalidate-rootfs image \
 		DISTRO="${os_name}" \
 		DEBUG="${DEBUG:-}" \
 		USE_DOCKER="1" \
@@ -68,6 +69,7 @@ build_image() {
 		AGENT_TARBALL="${AGENT_TARBALL}" \
 		AGENT_POLICY="${AGENT_POLICY:-}" \
 		PULL_TYPE="${PULL_TYPE:-default}" \
+		ARTEFACT_VERSION="${artefact_version}" \
 		COCO_GUEST_COMPONENTS_TARBALL="${COCO_GUEST_COMPONENTS_TARBALL:-}" \
 		PAUSE_IMAGE_TARBALL="${PAUSE_IMAGE_TARBALL:-}"
 	mv -f "kata-containers.img" "${install_dir}/${artifact_name}"
@@ -96,6 +98,7 @@ Options:
  --prefix=${prefix}
  --destdir=${destdir}
  --image_initrd_suffix=${image_initrd_suffix}
+ --artefact_version=${artefact_version}
 EOF
 
 	exit "${return_code}"
@@ -107,6 +110,7 @@ main() {
 	prefix="/opt/kata"
 	image_suffix=""
 	image_initrd_suffix=""
+	artefact_version=""
 	builddir="${PWD}"
 	while getopts "h-:" opt; do
 		case "$opt" in
@@ -126,6 +130,9 @@ main() {
 				;;
 			image_initrd_suffix=*)
 				image_initrd_suffix=${OPTARG#*=}
+				;;
+			artefact_version=*)
+				artefact_version=${OPTARG#*=}
 				;;
 			prefix=*)
 				prefix=${OPTARG#*=}

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -64,7 +64,7 @@ build_image() {
 		DISTRO="${os_name}" \
 		DEBUG="${DEBUG:-}" \
 		USE_DOCKER="1" \
-		IMG_OS_VERSION="${os_version}" \
+		OS_VERSION="${os_version}" \
 		ROOTFS_BUILD_DEST="${builddir}/rootfs-image" \
 		AGENT_TARBALL="${AGENT_TARBALL}" \
 		AGENT_POLICY="${AGENT_POLICY:-}" \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -299,9 +299,9 @@ install_image() {
 	if [ "${variant}" == "confidential" ]; then
 		# For the confidential image we depend on the kernel built in order to ensure that
 		# measured boot is used
-		latest_artefacts+="-$(get_latest_kernel_confidential_artefact_and_builder_image_version)"
-		latest_artefacts+="-$(get_latest_coco_guest_components_artefact_and_builder_image_version)"
-		latest_artefacts+="-$(get_latest_pause_image_artefact_and_builder_image_version)"
+		latest_artefact+="-$(get_latest_kernel_confidential_artefact_and_builder_image_version)"
+		latest_artefact+="-$(get_latest_coco_guest_components_artefact_and_builder_image_version)"
+		latest_artefact+="-$(get_latest_pause_image_artefact_and_builder_image_version)"
 	fi
 
 	latest_builder_image=""
@@ -367,9 +367,9 @@ install_initrd() {
 	if [ "${variant}" == "confidential" ]; then
 		# For the confidential initrd we depend on the kernel built in order to ensure that
 		# measured boot is used
-		latest_artefacts+="-$(get_latest_kernel_confidential_artefact_and_builder_image_version)"
-		latest_artefacts+="-$(get_latest_coco_guest_components_artefact_and_builder_image_version)"
-		latest_artefacts+="-$(get_latest_pause_image_artefact_and_builder_image_version)"
+		latest_artefact+="-$(get_latest_kernel_confidential_artefact_and_builder_image_version)"
+		latest_artefact+="-$(get_latest_coco_guest_components_artefact_and_builder_image_version)"
+		latest_artefact+="-$(get_latest_pause_image_artefact_and_builder_image_version)"
 	fi
 
 	latest_builder_image=""

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -332,7 +332,8 @@ install_image() {
 	export AGENT_TARBALL=$(get_agent_tarball_path)
 	export AGENT_POLICY=yes
 
-	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --imagetype=image --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
+	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --artefact_version="${latest_artefact}" \
+	    --imagetype=image --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
 }
 
 #Install guest image for confidential guests
@@ -402,7 +403,8 @@ install_initrd() {
 	export AGENT_TARBALL=$(get_agent_tarball_path)
 	export AGENT_POLICY=yes
 
-	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --imagetype=initrd --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
+	"${rootfs_builder}" --osname="${os_name}" --osversion="${os_version}" --artefact_version="${latest_artefact}" \
+	    --imagetype=initrd --prefix="${prefix}" --destdir="${destdir}" --image_initrd_suffix="${variant}"
 }
 
 #Install guest initrd for confidential guests

--- a/versions.yaml
+++ b/versions.yaml
@@ -117,7 +117,7 @@ assets:
     architecture:
       aarch64:
         name: &default-image-name "ubuntu"
-        version: &default-image-version "latest"
+        version: &default-image-version "focal"
         nvidia-gpu:
           name: *default-image-name
           version: "jammy"


### PR DESCRIPTION
Do osbuilder rootfs cleanup inside docker when it have root permissions.

Add osbuilder "invalidate-rootfs" makefile target to rebuild image from scratch.

Fix passing "OS_VERSION" and fix default in "versions.yaml".
It actually is "focal". Before ce82b5e3f5b9a0b26bb127ff4490233cafc67ba0
it was hardcoded in "tools/osbuilder/rootfs-builder/ubuntu/config.sh",
now in "tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile".

Actual "latest" ubuntu (noble) does not work - "init" is not installed in rootfs.

NB: update from "focal" to "jammy" changes default cgroup v1 to v2 in in guest.

I've tested this via "make rootfs-image-tarball".

Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
