### PR TITLE
ci: Temporarily disable kata-deploy and GARM tests

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   run-cri-containerd:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     strategy:
       # We can set this to true whenever we're 100% sure that
       # the all the tests are not flaky, otherwise we'll fail
@@ -57,6 +59,8 @@ jobs:
         run: bash tests/integration/cri-containerd/gha-run.sh run
 
   run-containerd-stability:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -96,6 +100,8 @@ jobs:
         run: bash tests/stability/gha-run.sh run
 
   run-nydus:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     strategy:
       # We can set this to true whenever we're 100% sure that
       # the all the tests are not flaky, otherwise we'll fail
@@ -138,6 +144,8 @@ jobs:
         run: bash tests/integration/nydus/gha-run.sh run
 
   run-runk:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     runs-on: garm-ubuntu-2204-smaller
     env:
       CONTAINERD_VERSION: lts
@@ -177,6 +185,7 @@ jobs:
           - clh # cloud-hypervisor
           - qemu
     # TODO: enable me when https://github.com/kata-containers/kata-containers/issues/9763 is fixed
+    # TODO: Transition to free runner (see #9940).
     if: false
     runs-on: garm-ubuntu-2204-smaller
     env:
@@ -218,6 +227,7 @@ jobs:
           - qemu
     # TODO: enable with clh when https://github.com/kata-containers/kata-containers/issues/9764 is fixed
     # TODO: enable with qemu when https://github.com/kata-containers/kata-containers/issues/9851 is fixed
+    # TODO: Transition to free runner (see #9940).
     if: false
     runs-on: garm-ubuntu-2304
     env:
@@ -249,6 +259,8 @@ jobs:
         run: bash tests/functional/vfio/gha-run.sh run
 
   run-docker-tests:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     strategy:
       # We can set this to true whenever we're 100% sure that
       # all the tests are not flaky, otherwise we'll fail them
@@ -290,6 +302,8 @@ jobs:
         run: bash tests/integration/docker/gha-run.sh run
 
   run-nerdctl-tests:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     strategy:
       # We can set this to true whenever we're 100% sure that
       # all the tests are not flaky, otherwise we'll fail them

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -113,6 +113,8 @@ jobs:
           file: tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
 
   run-kata-deploy-tests-on-aks:
+    # TODO: Reenable when Azure CI budget is secured (see #9939).
+    if: false
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-kata-deploy-tests-on-aks.yaml
     with:
@@ -125,6 +127,8 @@ jobs:
     secrets: inherit
 
   run-kata-deploy-tests-on-garm:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-kata-deploy-tests-on-garm.yaml
     with:

--- a/.github/workflows/run-kata-deploy-tests-on-garm.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-garm.yaml
@@ -36,6 +36,7 @@ jobs:
           - rke2
     # TODO: There are a couple of vmm/k8s combination failing (https://github.com/kata-containers/kata-containers/issues/9854)
     # and we will put the entire kata-deploy-tests on GARM on maintenance.
+    # TODO: Transition to free runner (see #9940).
     if: false
     runs-on: garm-ubuntu-2004-smaller
     env:

--- a/.github/workflows/run-kata-monitor-tests.yaml
+++ b/.github/workflows/run-kata-monitor-tests.yaml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   run-monitor:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/run-runk-tests.yaml
+++ b/.github/workflows/run-runk-tests.yaml
@@ -15,6 +15,8 @@ on:
 
 jobs:
   run-runk:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     runs-on: garm-ubuntu-2204-smaller
     env:
       CONTAINERD_VERSION: lts

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -40,6 +40,8 @@ jobs:
       instance: ubuntu-20.04
 
   build-checks-depending-on-kvm:
+    # TODO: Transition to free runner (see #9940).
+    if: false
     runs-on: garm-ubuntu-2004-smaller
     strategy:
       fail-fast: false


### PR DESCRIPTION
```
Per the decision taken in the 6/27 AC meeting, this PR temporarily
disables kata-deploy and GARM tests until we secure further Azure CI
funding.

In the meantime, I'll transition the GARM tests to free runners and
reenable them to regain that coverage without affecting spending (see
#9940). If it turns out the free runners are too slow, we'll switch back
to GARM.

After funding is secured, we'll reenable the kata-deploy tests (see
#9939).
```