### PR TITLE
tests: Fixes TEE timeout issue

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -556,7 +556,6 @@ function cleanup_nydus_snapshotter() {
 	fi
 	sleep 180s
 	kubectl_retry delete --ignore-not-found -f "misc/snapshotter/nydus-snapshotter-rbac.yaml"
-	kubectl_retry get namespace nydus-system -o json | jq 'del(.spec.finalizers)' | kubectl_retry replace --raw "/api/v1/namespaces/nydus-system/finalize" -f - || true
 	popd
 	sleep 30s
 	echo "::endgroup::"


### PR DESCRIPTION
tests: remove unnecessary sleeps that slow down tests
The modifications to kubectl_retry from #9923 in combination with extensive sleep times in the nydus cleanup is causing various TEE environment timeouts and test failures.
Fixes: #9942

tests: delete the nydus directory at the end of cleanup
The nydus cleanup is skipped if the directory does not exist.
The directory was not being deleted.

Signed-Off-By: Adithya Krishnan Kannan <AdithyaKrishnan.Kannan@amd.com>