### PR TITLE
CI: Use kubectl for cleanup_nydus_snapshotter()

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -550,13 +550,13 @@ function cleanup_nydus_snapshotter() {
 	pushd "$nydus_snapshotter_install_dir"
 
 	if [ "${KUBERNETES}" = "k3s" ]; then
-		kubectl_retry delete --ignore-not-found -k "misc/snapshotter/overlays/k3s"
+		kubectl delete --ignore-not-found -k "misc/snapshotter/overlays/k3s"
 	else
-		kubectl_retry delete --ignore-not-found -f "misc/snapshotter/base/nydus-snapshotter.yaml"
+		kubectl delete --ignore-not-found -f "misc/snapshotter/base/nydus-snapshotter.yaml"
 	fi
 	sleep 180s
-	kubectl_retry delete --ignore-not-found -f "misc/snapshotter/nydus-snapshotter-rbac.yaml"
-	kubectl_retry get namespace nydus-system -o json | jq 'del(.spec.finalizers)' | kubectl_retry replace --raw "/api/v1/namespaces/nydus-system/finalize" -f - || true
+	kubectl delete --ignore-not-found -f "misc/snapshotter/nydus-snapshotter-rbac.yaml"
+	kubectl get namespace nydus-system -o json | jq 'del(.spec.finalizers)' | kubectl replace --raw "/api/v1/namespaces/nydus-system/finalize" -f - || true
 	popd
 	sleep 30s
 	echo "::endgroup::"


### PR DESCRIPTION
kubectl_retry() introduced unnecessary retries in cleanup_nydus_snapshotter(), leading to a timeout issue. Retrying is unnecessary for already deleted resources.

This PR makes cleanup_nydus_snapshotter() use kubectl again.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>