### PR TITLE
gha: ci: Remove incorrect secrets line

### DIFF
--- a/.github/workflows/cleanup-resources.yaml
+++ b/.github/workflows/cleanup-resources.yaml
@@ -7,7 +7,6 @@ on:
 jobs:
   cleanup-resources:
     runs-on: ubuntu-latest
-    secrets: inherit
     steps:
       - name: Cleanup resources
         run: python3 tests/cleanup_resources.py


### PR DESCRIPTION
The CI is failing in https://github.com/kata-containers/kata-containers/actions/runs/9723935611 with:
```
Invalid workflow file: .github/workflows/cleanup-resources.yaml#L10
The workflow is not valid. .github/workflows/cleanup-resources.yaml (Line: 10, Col: 5): Unexpected value 'secrets'
```
I think this is because `secrets: inherit` is only applicable when re-using a workflow, not for a standalone job like we have here.