### PR TITLE
tests: Enable attestation e2e tests for IBM SE

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -180,7 +180,7 @@ kbs_uninstall_cli() {
 #
 function kbs_k8s_delete() {
 	pushd "$COCO_KBS_DIR"
-	kubectl delete -k config/kubernetes/overlays
+	kubectl delete -k config/kubernetes/overlays/$(uname -m)
 	# Verify that KBS namespace resources were properly deleted
 	cmd="kubectl get all -n $KBS_NS 2>&1 | grep 'No resources found'"
 	waitForProcess "120" "30" "$cmd"
@@ -237,7 +237,7 @@ function kbs_k8s_deploy() {
 
 	# Tests should fill kbs resources later, however, the deployment
 	# expects at least one secret served at install time.
-	echo "somesecret" > overlays/key.bin
+	echo "somesecret" > overlays/$(uname -m)/key.bin
 
 	echo "::group::Update the kbs container image"
 	install_kustomize
@@ -437,7 +437,7 @@ _handle_ingress_aks() {
 		return 1
 	fi
 
-	pushd "${COCO_KBS_DIR}/config/kubernetes/overlays"
+	pushd "${COCO_KBS_DIR}/config/kubernetes/overlays/common"
 
 	echo "::group::$(pwd)/ingress.yaml"
 	KBS_INGRESS_CLASS="addon-http-application-routing" \

--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -47,6 +47,15 @@ setup() {
 	set_metadata_annotation "${K8S_TEST_YAML}" \
 		"${kernel_params_annotation}" \
 		"${kernel_params_value}"
+
+	# A secure boot image for IBM SE should be rebuilt according to the KBS configuration.
+	if [ "${KATA_HYPERVISOR}" == "qemu-se" ]; then
+		if [ -z "${IBM_SE_CREDS_DIR:-}" ]; then
+			>&2 echo "ERROR: IBM_SE_CREDS_DIR is empty"
+			return 1
+		fi
+		repack_secure_image "${kernel_params_value}" "${IBM_SE_CREDS_DIR}" "true"
+	fi
 }
 
 @test "Get CDH resource" {

--- a/tools/packaging/guest-image/build_se_image.sh
+++ b/tools/packaging/guest-image/build_se_image.sh
@@ -9,27 +9,18 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-readonly script_name="$(basename "${BASH_SOURCE[0]}")"
-readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-readonly packaging_root_dir="$(cd "${script_dir}/../" && pwd)"
-readonly kata_root_dir="$(cd "${packaging_root_dir}/../../" && pwd)"
+script_name="$(basename "${BASH_SOURCE[0]}")"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+packaging_root_dir="$(cd "${script_dir}/../" && pwd)"
+kata_root_dir="$(cd "${packaging_root_dir}/../../" && pwd)"
 
-source "$kata_root_dir/tests/common.bash"
 source "${packaging_root_dir}/scripts/lib.sh"
+source "${script_dir}/lib_se.sh"
 
 ARCH=${ARCH:-$(uname -m)}
 if [ $(uname -m) == "${ARCH}" ]; then
 	[ "${ARCH}" == "s390x" ] || die "Building a Secure Execution image is currently only supported on s390x."
 fi
-
-finish() {
-	if [ -e "${parmfile}" ]; then
-		rm -f "${parmfile}"
-	fi
-}
-
-trap finish EXIT
-
 usage() {
 	cat >&2 << EOF
 Usage:
@@ -49,76 +40,6 @@ Environment variables:
   DEBUG         : If set, display debug information.
 EOF
 	exit "${1:-0}"
-}
-
-# Build a IBM zSystem secure execution (SE) image
-#
-# Parameters:
-#	$1	- kernel_parameters
-#	$2	- a source directory where kernel and initrd are located
-#	$3	- a destination directory where a SE image is built
-#
-# Return:
-# 	0 if the image is successfully built
-#	1 otherwise
-build_secure_image() {
-	kernel_params="${1:-}"
-	install_src_dir="${2:-}"
-	install_dest_dir="${3:-}"
-	key_verify_option="--no-verify" # no verification for CI testing purposes
-
-	if [ -n "${SIGNING_KEY_CERT_PATH:-}" ] && [ -n "${INTERMEDIATE_CA_CERT_PATH:-}" ]; then
-		if [ -e "${SIGNING_KEY_CERT_PATH}" ] && [ -e "${INTERMEDIATE_CA_CERT_PATH}" ]; then
-			key_verify_option="--cert=${SIGNING_KEY_CERT_PATH} --cert=${INTERMEDIATE_CA_CERT_PATH}"
-		else
-			die "Specified certificate(s) not found"
-		fi
-	fi
-
-	if [ ! -f "${install_src_dir}/vmlinuz-confidential.container" ] ||
-		[ ! -f "${install_src_dir}/kata-containers-initrd-confidential.img" ]; then
-		cat << EOF >&2
-Either kernel or initrd does not exist or is mistakenly named
-A file name for kernel must be vmlinuz-confidential.container (raw binary)
-A file name for initrd must be kata-containers-initrd-confidential.img
-EOF
-		return 1
-	fi
-
-	cmdline="${kernel_params} panic=1 scsi_mod.scan=none swiotlb=262144"
-	parmfile="$(mktemp --suffix=-cmdline)"
-	echo "${cmdline}" > "${parmfile}"
-	chmod 600 "${parmfile}"
-
-	[ -n "${HKD_PATH:-}" ] || (echo >&2 "No host key document specified." && return 1)
-	cert_list=($(ls -1 $HKD_PATH))
-	declare hkd_options
-	eval "for cert in ${cert_list[*]}; do
-		hkd_options+=\"--host-key-document=\\\"\$HKD_PATH/\$cert\\\" \"
-	done"
-
-	command -v genprotimg > /dev/null 2>&1 || die "A package s390-tools is not installed."
-	extra_arguments=""
-	genprotimg_version=$(genprotimg --version | grep -Po '(?<=version )[^-]+')
-	if ! version_greater_than_equal "${genprotimg_version}" "2.17.0"; then
-		extra_arguments="--x-pcf '0xe0'"
-	fi
-
-	eval genprotimg \
-		"${extra_arguments}" \
-		"${hkd_options}" \
-		--output="${install_dest_dir}/kata-containers-se.img" \
-		--image="${install_src_dir}/vmlinuz-confidential.container" \
-		--ramdisk="${install_src_dir}/kata-containers-initrd-confidential.img" \
-		--parmfile="${parmfile}" \
-		"${key_verify_option}"
-
-	build_result=$?
-	if [ $build_result -eq 0 ]; then
-		return 0
-	else
-		return 1
-	fi
 }
 
 build_image() {

--- a/tools/packaging/guest-image/lib_se.sh
+++ b/tools/packaging/guest-image/lib_se.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Copyright (c) 2024 IBM Corp.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+set -o nounset
+
+readonly script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly packaging_root_dir="$(cd "${script_dir}/../" && pwd)"
+readonly kata_root_dir="$(cd "${packaging_root_dir}/../../" && pwd)"
+
+source "$kata_root_dir/tests/common.bash"
+
+# Build a IBM zSystem secure execution (SE) image
+#
+# Parameters:
+#	$1	- kernel_parameters
+#	$2	- a source directory where kernel and initrd are located
+#	$3	- a destination directory where a SE image is built
+#
+# Return:
+# 	0 if the image is successfully built
+#	1 otherwise
+build_secure_image() {
+	kernel_params="${1:-}"
+	install_src_dir="${2:-}"
+	install_dest_dir="${3:-}"
+	key_verify_option="--no-verify" # no verification for CI testing purposes
+
+	if [ -n "${SIGNING_KEY_CERT_PATH:-}" ] && [ -n "${INTERMEDIATE_CA_CERT_PATH:-}" ]; then
+		if [ -e "${SIGNING_KEY_CERT_PATH}" ] && [ -e "${INTERMEDIATE_CA_CERT_PATH}" ]; then
+			key_verify_option="--cert=${SIGNING_KEY_CERT_PATH} --cert=${INTERMEDIATE_CA_CERT_PATH}"
+		else
+			die "Specified certificate(s) not found"
+		fi
+	fi
+
+	if [ ! -f "${install_src_dir}/vmlinuz-confidential.container" ] ||
+		[ ! -f "${install_src_dir}/kata-containers-initrd-confidential.img" ]; then
+		cat << EOF >&2
+Either kernel or initrd does not exist or is mistakenly named
+A file name for kernel must be vmlinuz-confidential.container (raw binary)
+A file name for initrd must be kata-containers-initrd-confidential.img
+EOF
+		return 1
+	fi
+
+	cmdline="${kernel_params} panic=1 scsi_mod.scan=none swiotlb=262144 agent.debug_console agent.debug_console_vport=1026"
+	parmfile="$(mktemp --suffix=-cmdline)"
+	echo "${cmdline}" > "${parmfile}"
+	chmod 600 "${parmfile}"
+
+	[ -n "${HKD_PATH:-}" ] || (echo >&2 "No host key document specified." && return 1)
+	cert_list=($(ls -1 $HKD_PATH/HKD-*.crt | xargs -n 1 basename))
+	declare hkd_options
+	eval "for cert in ${cert_list[*]}; do
+		hkd_options+=\"--host-key-document=\\\"\$HKD_PATH/\$cert\\\" \"
+	done"
+
+	command -v genprotimg > /dev/null 2>&1 || die "A package s390-tools is not installed."
+	extra_arguments=""
+	genprotimg_version=$(genprotimg --version | grep -Po '(?<=version )[^-]+')
+	if ! version_greater_than_equal "${genprotimg_version}" "2.17.0"; then
+		extra_arguments="--x-pcf '0xe0'"
+	fi
+
+	eval genprotimg \
+		"${extra_arguments}" \
+		"${hkd_options}" \
+		--output="${install_dest_dir}/kata-containers-se.img" \
+		--image="${install_src_dir}/vmlinuz-confidential.container" \
+		--ramdisk="${install_src_dir}/kata-containers-initrd-confidential.img" \
+		--parmfile="${parmfile}" \
+		"${key_verify_option}"
+
+	build_result=$?
+	rm -f "${parmfile}"
+	if [ $build_result -eq 0 ]; then
+		return 0
+	else
+		return 1
+	fi
+}

--- a/tools/packaging/static-build/coco-guest-components/build.sh
+++ b/tools/packaging/static-build/coco-guest-components/build.sh
@@ -41,9 +41,13 @@ docker pull ${container_image} || \
 # Temp settings until we have a matching TEE_PLATFORM
 TEE_PLATFORM=""
 RESOURCE_PROVIDER="kbs,sev"
-ATTESTER="none"
 # snp-attester and tdx-attester crates require packages only available on x86
-[ "$(uname -m)" == "x86_64" ] && ATTESTER="snp-attester,tdx-attester"
+# se-attester crate requires packages only available on s390x
+case "$(uname -m)" in
+	x86_64) ATTESTER="snp-attester,tdx-attester" ;;
+	s390x) ATTESTER="se-attester" ;;
+	*) ATTESTER="none" ;;
+esac
 
 docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \

--- a/versions.yaml
+++ b/versions.yaml
@@ -227,9 +227,9 @@ externals:
   coco-trustee:
     description: "Provides attestation and secret delivery components"
     url: "https://github.com/confidential-containers/trustee"
-    version: "v0.9.0"
-    image: "ghcr.io/confidential-containers/key-broker-service"
-    image_tag: "built-in-as-v0.9.0"
+    version: "e890fc90c384207668fa3a4d6a2f2a2d652797ee"
+    image: "ghcr.io/confidential-containers/staged-images/kbs"
+    image_tag: "e890fc90c384207668fa3a4d6a2f2a2d652797ee"
     toolchain: "1.74.0"
 
   crio:


### PR DESCRIPTION
This PR enables [k8s-confidential-attestation.bats](https://github.com/kata-containers/kata-containers/blob/main/tests/integration/kubernetes/k8s-confidential-attestation.bats) for s390x. Detailed explanation can be found in each commit message.

Fixes: #9933

For reviewers: the tests have been passing since the 27th of June at https://github.com/kata-containers/kata-containers/actions/workflows/ci-nightly-s390x.yaml

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>