### PR TITLE
docs: Remove jenkins reference from unit testing presentation

### DIFF
--- a/docs/presentations/unit-testing/kata-containers-unit-testing.md
+++ b/docs/presentations/unit-testing/kata-containers-unit-testing.md
@@ -202,11 +202,6 @@ attributes of each environment (local and CI):
 - The hardware architecture.
 - Number (and spec) of the CPUs.
 
-## Gotchas (part 3)
-
-If in doubt, look at the
-["test artifacts" attached to the failing CI test](http://jenkins.katacontainers.io).
-
 ## Before raising a PR
 
 - Remember to check that the test runs locally:


### PR DESCRIPTION
This PR removes the jenkins reference from unit testing presentation as this is not longer supported on the kata containers project.