### PR TITLE
metrics: Remove variable in sysbench that is not being used

### DIFF
--- a/tests/metrics/density/k8s-sysbench.sh
+++ b/tests/metrics/density/k8s-sysbench.sh
@@ -12,7 +12,6 @@ SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
 source "${SCRIPT_PATH}/../lib/common.bash"
 sysbench_file=$(mktemp sysbenchresults.XXXXXXXXXX)
 TEST_NAME="${TEST_NAME:-sysbench}"
-CI_JOB="${CI_JOB:-}"
 IMAGE="docker.io/library/local-sysbench:latest"
 DOCKERFILE="${SCRIPT_PATH}/sysbench-dockerfile/Dockerfile"
 


### PR DESCRIPTION
This PR removes the CI_JOB variable which previously was used but not longer being supported of the metrics sysbench test.