### PR TITLE
genpolicy: add support for ignoring sandbox name

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -266,7 +266,8 @@
             "CAP_PERFMON",
             "CAP_BPF",
             "CAP_CHECKPOINT_RESTORE"
-        ]
+        ],
+        "ignore_sandbox_name": false
     },
     "kata_config": {
         "confidential_guest": false,


### PR DESCRIPTION
In some usecases, the workload that the policy is expected to apply to is generated dynamically. In other words, it may be impossible to determine, ahead of time, what the name of a pod will be. As a result, it is in turn also not possible to figure what the sandbox name will be.

Add an option that enables setting the expected sandbox name to be a generated name, so that any name is allowed.

Fixes #9956