### PR TITLE
osbuilder: create parent directory for rootfs image with normal permissions

### DIFF
--- a/tools/osbuilder/Makefile
+++ b/tools/osbuilder/Makefile
@@ -93,6 +93,7 @@ rootfs-%: $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX)
 
 .PRECIOUS: $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX)
 $(ROOTFS_BUILD_DEST)/.%$(ROOTFS_MARKER_SUFFIX):: rootfs-builder/%
+	mkdir -p $(ROOTFS_BUILD_DEST)
 	$(call silent_run,Creating rootfs for "$*",$(ROOTFS_BUILDER) -o $(VERSION_COMMIT) -r $(ROOTFS_BUILD_DEST)/$*_rootfs $*)
 	@touch $@
 


### PR DESCRIPTION
"tools/packaging/kata-deploy/local-build/build/rootfs-image/builddir/rootfs-image"
should be owned by origin user to create here mark file from makefile.

Should not be owned by root:
ls -ld tools/packaging/kata-deploy/local-build/build/rootfs-image/builddir/rootfs-image
drwxr-xr-x 3 root root 4096 Jul  4 10:40 tools/packaging/kata-deploy/local-build/build/rootfs-image/builddir/rootfs-image

Otherwise "make rootfs-image-tarball" fails:
INFO: Created summary file '/var/lib/osbuilder/osbuilder.yaml' inside rootfs
/bin/sh: 1: cannot create /home/khlebnikov/src/containers/kata-containers/tools/packaging/kata-deploy/local-build/build/rootfs-image/builddir/rootfs-image/.ubuntu_rootfs.done: Permission denied
make: *** [Makefile:98: /home/khlebnikov/src/containers/kata-containers/tools/packaging/kata-deploy/local-build/build/rootfs-image/builddir/rootfs-image/.ubuntu_rootfs.done] Error 2
make[1]: *** [tools/packaging/kata-deploy/local-build/Makefile:72: rootfs-image-tarball-build] Error 2
