### PR TITLE
ci: Cleanup working dir when using self-hosted runners

### DIFF
--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -48,6 +48,12 @@ jobs:
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
+      # Cleanup current workspace dir
+      - name: Cleanup workspace
+        run: |
+          sudo rm -rf ${{ github.workspace }}/*
+          sudo rm -rf ${{ github.workspace }}/.??*
+
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}
@@ -88,6 +94,12 @@ jobs:
     runs-on: arm64-builder
     needs: build-asset
     steps:
+      # Cleanup current workspace dir
+      - name: Cleanup workspace
+        run: |
+          sudo rm -rf ${{ github.workspace }}/*
+          sudo rm -rf ${{ github.workspace }}/.??*
+
       - name: Adjust a permission for repo
         run: |
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -50,6 +50,12 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_DEPLOYER_USERNAME }}
           password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
+      
+      # Cleanup current workspace dir
+      - name: Cleanup workspace
+        run: |
+          sudo rm -rf ${{ github.workspace }}/*
+          sudo rm -rf ${{ github.workspace }}/.??*
 
       - uses: actions/checkout@v4
         with:
@@ -93,6 +99,12 @@ jobs:
     steps:
       - name: Take a pre-action for self-hosted runner
         run: ${HOME}/script/pre_action.sh ubuntu-2204
+
+      # Cleanup current workspace dir
+      - name: Cleanup workspace
+        run: |
+          sudo rm -rf ${{ github.workspace }}/*
+          sudo rm -rf ${{ github.workspace }}/.??*
 
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
We get permission issues when the current workspace directory is not clean. This is the case for self-hosted runners. This patch cleans the workspace dir before the checkout. An alternative would be to make sure we clean it as a last step of each job.