### PR TITLE
runtime-rs: add memory hotplugging support to qemu-rs

### DIFF
--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -289,7 +289,7 @@ impl TryFrom<(MemoryInfo, GuestProtection)> for MemoryConfig {
 // method is available in the rust language.
 //
 // See: https://github.com/rust-lang/rust/issues/88581
-fn checked_next_multiple_of(value: u64, multiple: u64) -> Option<u64> {
+pub fn checked_next_multiple_of(value: u64, multiple: u64) -> Option<u64> {
     match value.checked_rem(multiple) {
         None => Some(value),
         Some(r) => value.checked_add(multiple - r),

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -334,19 +334,31 @@ impl QemuInner {
         todo!()
     }
 
-    pub(crate) fn set_guest_memory_block_size(&mut self, _size: u32) {
-        warn!(
-            sl!(),
-            "QemuInner::set_guest_memory_block_size(): NOT YET IMPLEMENTED"
-        );
+    pub(crate) fn set_guest_memory_block_size(&mut self, size: u32) {
+        if let Some(ref mut qmp) = self.qmp {
+            info!(
+                sl!(),
+                "QemuInner::set_guest_memory_block_size(): block size set to {}", size
+            );
+            qmp.set_guest_memory_block_size(size.into());
+        } else {
+            warn!(
+                sl!(),
+                "QemuInner::set_guest_memory_block_size(): QMP not initialized"
+            );
+        }
     }
 
-    pub(crate) fn guest_memory_block_size_mb(&self) -> u32 {
-        warn!(
-            sl!(),
-            "QemuInner::guest_memory_block_size_mb(): NOT YET IMPLEMENTED"
-        );
-        0
+    pub(crate) fn guest_memory_block_size(&self) -> u32 {
+        if let Some(qmp) = &self.qmp {
+            qmp.guest_memory_block_size() as u32
+        } else {
+            warn!(
+                sl!(),
+                "QemuInner::guest_memory_block_size(): QMP not initialized"
+            );
+            0
+        }
     }
 
     pub(crate) fn resize_memory(&self, _new_mem_mb: u32) -> Result<(u32, MemoryConfig)> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -177,7 +177,7 @@ impl Hypervisor for Qemu {
     }
 
     async fn resize_memory(&self, new_mem_mb: u32) -> Result<(u32, MemoryConfig)> {
-        let inner = self.inner.read().await;
+        let mut inner = self.inner.write().await;
         inner.resize_memory(new_mem_mb)
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -173,7 +173,7 @@ impl Hypervisor for Qemu {
 
     async fn guest_memory_block_size(&self) -> u32 {
         let inner = self.inner.read().await;
-        inner.guest_memory_block_size_mb()
+        inner.guest_memory_block_size()
     }
 
     async fn resize_memory(&self, new_mem_mb: u32) -> Result<(u32, MemoryConfig)> {


### PR DESCRIPTION
A rather standard memory hotplugging implementation, the only slightly unusual thing about it is that it makes a best-effort attempt at hotunplugging, too.  While hotunplugging memory seems to fail generally I'd like to have it in the code base at least for a while for observation.  It does no harm either.