### PR TITLE
tests: Use variable already defined in metrics common script for stability tests

### DIFF
--- a/tests/stability/agent_stability_test.sh
+++ b/tests/stability/agent_stability_test.sh
@@ -21,12 +21,12 @@ PAYLOAD_ARGS="${PAYLOAD_ARGS:-tail -f /dev/null}"
 
 function setup {
 	clean_env_ctr
-	sudo ctr image pull $IMAGE
-	sudo ctr run --runtime=$CTR_RUNTIME -d $IMAGE $CONTAINER_NAME sh -c $PAYLOAD_ARGS
+	sudo "${CTR_EXE}" image pull "${IMAGE}"
+	sudo "${CTR_EXE}" run --runtime="${CTR_RUNTIME}" -d "${IMAGE}" "${CONTAINER_NAME}" sh -c "${PAYLOAD_ARGS}"
 }
 
 function exec_loop {
-	cmd="sudo ctr t exec --exec-id $(random_name) $CONTAINER_NAME sh -c"
+	cmd="sudo $CTR_EXE t exec --exec-id $(random_name) $CONTAINER_NAME sh -c"
 	$cmd "echo 'hello world' > file"
 	$cmd "ls /file"
 	$cmd "rm -rf /file"

--- a/tests/stability/scability_test.sh
+++ b/tests/stability/scability_test.sh
@@ -40,13 +40,13 @@ function main() {
 	local not_started_count="${NUM_CONTAINERS}"
 
 	clean_env_ctr
-	sudo -E ctr i pull "${IMAGE}"
+	sudo -E "${CTR_EXE}" i pull "${IMAGE}"
 
 	info "Creating ${NUM_CONTAINERS} containers"
 
 	for ((i=1; i<= "${NUM_CONTAINERS}"; i++)); do
 		containers+=($(random_name))
-		sudo -E ctr run -d --runtime "${CTR_RUNTIME}" "${IMAGE}" "${containers[-1]}" sh -c "${PAYLOAD_ARGS}"
+		sudo -E "${CTR_EXE}" run -d --runtime "${CTR_RUNTIME}" "${IMAGE}" "${containers[-1]}" sh -c "${PAYLOAD_ARGS}"
 		((not_started_count--))
 		info "$not_started_count remaining containers"
 	done

--- a/tests/stability/soak_parallel_rm.sh
+++ b/tests/stability/soak_parallel_rm.sh
@@ -53,7 +53,7 @@ function check_vsock_active() {
 }
 
 function count_containers() {
-	sudo ctr c list -q | wc -l
+	sudo "${CTR_EXE}" c list -q | wc -l
 }
 
 function check_all_running() {
@@ -124,7 +124,7 @@ function go() {
 		local i
 		for ((i=1; i<= ${MAX_CONTAINERS}; i++)); do
 			containers+=($(random_name))
-			sudo ctr run --runtime=${CTR_RUNTIME} -d ${nginx_image} ${containers[-1]} sh -c ${COMMAND}
+			sudo "${CTR_EXE}" run --runtime="${CTR_RUNTIME}" -d "${nginx_image}" "${containers[-1]}" sh -c "${COMMAND}"
 			((how_many++))
 		done
 
@@ -177,7 +177,7 @@ function init() {
 	nginx_image="docker.io/library/nginx:$nginx_version"
 
 	# Pull nginx image
-	sudo ctr image pull ${nginx_image}
+	sudo "${CTR_EXE}" image pull "${nginx_image}"
 	if [ $? != 0 ]; then
 		die "Unable to retry docker image ${nginx_image}"
 	fi

--- a/tests/stability/stressng.sh
+++ b/tests/stability/stressng.sh
@@ -18,27 +18,27 @@ function main() {
 
 	init_env
 	check_cmds "${cmds[@]}"
-	sudo -E ctr run -d --runtime "${CTR_RUNTIME}" "${IMAGE}" "${CONTAINER_NAME}" sh -c "${PAYLOAD_ARGS}"
+	sudo -E "${CTR_EXE}" run -d --runtime "${CTR_RUNTIME}" "${IMAGE}" "${CONTAINER_NAME}" sh -c "${PAYLOAD_ARGS}"
 
 	# Run 1 iomix stressor (mix of I/O operations) for 20 seconds with verbose output
 	info "Running iomix stressor test"
 	IOMIX_CMD="stress-ng --iomix 1 -t 20 -v"
-	sudo -E ctr t exec --exec-id "$(random_name)" "${CONTAINER_NAME}" sh -c "${IOMIX_CMD}"
+	sudo -E "${CTR_EXE}" t exec --exec-id "$(random_name)" "${CONTAINER_NAME}" sh -c "${IOMIX_CMD}"
 
 	# Run cpu stressors and virtual memory stressors for 5 minutes
 	info "Running memory stressors for 5 minutes"
 	MEMORY_CMD="stress-ng --cpu 2 --vm 4 -t 5m"
-	sudo -E ctr t exec --exec-id "$(random_name)" "${CONTAINER_NAME}" sh -c "${MEMORY_CMD}"
+	sudo -E "${CTR_EXE}" t exec --exec-id "$(random_name)" "${CONTAINER_NAME}" sh -c "${MEMORY_CMD}"
 
 	# Test floating point on CPU for 60 seconds
 	info  "Running floating tests on CPU"
 	FLOAT_CMD="stress-ng --matrix 1 -t 1m"
-	sudo -E ctr t exec --exec-id "$(random_name)" "${CONTAINER_NAME}" sh -c "${FLOAT_CMD}"
+	sudo -E "${CTR_EXE}" t exec --exec-id "$(random_name)" "${CONTAINER_NAME}" sh -c "${FLOAT_CMD}"
 
 	# Runs two instances of the CPU stressors, one instance of the matrix
 	info "Running instances of the CPU stressors"
 	INSTANCE_CMD='stress-ng --cpu 2 --matrix 1 --mq 3 -t 3m'
-	sudo -E ctr t exec --exec-id "$(random_name)" "${CONTAINER_NAME}" sh -c "${INSTANCE_CMD}"
+	sudo -E "${CTR_EXE}" t exec --exec-id "$(random_name)" "${CONTAINER_NAME}" sh -c "${INSTANCE_CMD}"
 
 	clean_env_ctr
 }


### PR DESCRIPTION
This PR is for the use of the variable CTR_EXE which is already defined in the metrics common script and which is being used in the stabilty tests to have better uniformity.