### PR TITLE
dragonball: kernel gpu dragonball 6.1.x

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -104,6 +104,9 @@ kata-ctl-tarball:
 kata-manager-tarball:
 	${MAKE} $@-build
 
+kernel-nvidia-gpu-dragonball-experimental-tarball:
+	${MAKE} $@-build
+
 kernel-dragonball-experimental-tarball:
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -549,6 +549,13 @@ install_kernel_dragonball_experimental() {
 		"-e -t dragonball"
 }
 
+install_kernel_nvidia_gpu_dragonball_experimental() {
+	install_kernel_helper \
+		"assets.kernel-dragonball-experimental.version" \
+		"kernel-dragonball-experimental" \
+		"-e -t dragonball -g nvidia -H deb"
+}
+
 #Install GPU enabled kernel asset
 install_kernel_nvidia_gpu() {
 	local kernel_url="$(get_from_kata_deps .assets.kernel.url)"
@@ -1055,6 +1062,7 @@ handle_build() {
 	kernel-confidential) install_kernel_confidential ;;
 
 	kernel-dragonball-experimental) install_kernel_dragonball_experimental ;;
+	kernel-nvidia-gpu-dragonball-experimental) install_kernel_nvidia_gpu_dragonball_experimental ;;
 
 	kernel-nvidia-gpu) install_kernel_nvidia_gpu ;;
 


### PR DESCRIPTION
Build a GPU flavoured dragonball kernel

Depends on: ~~#9967~~ 