### PR TITLE
Test https://github.com/kata-containers/kata-containers/pull/9637 (take 2)

### DIFF
--- a/ci/openshift-ci/run_smoke_test.sh
+++ b/ci/openshift-ci/run_smoke_test.sh
@@ -6,6 +6,8 @@
 #
 # Run a smoke test.
 #
+# CHANGE
+#
 
 script_dir=$(dirname $0)
 source ${script_dir}/lib.sh


### PR DESCRIPTION
This replays https://github.com/ldoktor/kata-containers/pull/6 on top of https://github.com/kata-containers/kata-containers/tree/selective-ci which contains the changes from https://github.com/kata-containers/kata-containers/pull/9637 .

Previous tentative to test at https://github.com/kata-containers/kata-containers/pull/9961 got auto-merged. Likely a mistake from my side : I forgot to commit the test patch after rebasing and I force-pushed to the PR an exact copy of the target branch.
