### PR TITLE
tests: cri-containerd: Ensure Docker isn't present

### DIFF
--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -16,6 +16,9 @@ source "${cri_containerd_dir}/../../common.bash"
 function install_dependencies() {
 	info "Installing the dependencies needed for running the cri-containerd tests"
 
+	# Remove Docker if it's installed as it conflicts with podman-docker
+	sudo apt-get remove -y docker-ce-cli || true
+
 	# Dependency list of projects that we can rely on the system packages
 	# - build-essential
 	#   - Theoretically we only need `make`, but doesn't hurt to install


### PR DESCRIPTION
```
Following #9960 that transitioned this test to a free runner, we need to
ensure Docker isn't installed on the system as that will conflict with
the installation of Podman.

Example error:
https://github.com/kata-containers/kata-containers/actions/runs/9818218975/job/27177785716
```

Addresses #9940