### PR TITLE
CI: Fix "make kata-manager-tarball" after "make rootfs-image-tarball"

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -887,14 +887,7 @@ install_script_helper() {
 
 	local script_path
 
-	# If the script isn't specified as an absolute or relative path,
-	# find it.
-	if grep -q '/' <<< "$script"
-	then
-		script_path="$script"
-	else
-		script_path=$(find "${repo_root_dir}/" -type f -name "$script")
-	fi
+	script_path="${repo_root_dir}/$script"
 
 	local script_file
 	script_file=$(basename "$script_path")
@@ -977,7 +970,7 @@ install_kata_ctl() {
 }
 
 install_kata_manager() {
-	install_script_helper "kata-manager.sh"
+	install_script_helper "utils/kata-manager.sh"
 }
 
 install_runk() {


### PR DESCRIPTION
"make kata-manager-tarball" called by non-root fails when stumbles upon prebuild rootfs:

+ install_kata_manager
+ install_script_helper kata-manager.sh
+ local script=kata-manager.sh
+ '[' -n kata-manager.sh ']'
+ local script_path
+ grep -q /
++ find <_SRC_> -type f -name kata-manager.sh
find: '<_SRC_>/tools/packaging/kata-deploy/local-build/build/rootfs-image/builddir/rootfs-image/ubuntu_rootfs/root': Permission denied
+ script_path=<_SRC_>/utils/kata-manager.sh
make[1]: *** [tools/packaging/kata-deploy/local-build/Makefile:72: kata-manager-tarball-build] Error 1
make[1]: Leaving directory '<_SRC_>'
make: *** [tools/packaging/kata-deploy/local-build/Makefile:102: kata-manager-tarball] Error 2

Recursive lookup source file with certain name within own sources is a strange and fragile approach.
Let's use full path here. Helper "install_script_helper" is used only once.

Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
