### PR TITLE
gha: make run-k8s-tests-on-zvsi inherit secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -43,7 +43,7 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
     secrets: inherit
-  
+
   build-kata-static-tarball-ppc64le:
     uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
     with:
@@ -62,7 +62,7 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
     secrets: inherit
-  
+
   publish-kata-deploy-payload-ppc64le:
     needs: build-kata-static-tarball-ppc64le
     uses: ./.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
@@ -203,7 +203,8 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
-      
+    secrets: inherit
+
   run-k8s-tests-on-ppc64le:
     needs: publish-kata-deploy-payload-ppc64le
     uses: ./.github/workflows/run-k8s-tests-on-ppc64le.yaml


### PR DESCRIPTION
run-k8s-tests-on-zvsi runs the coco tests and we've added new secrets to provide credentials for the authenticated image testing, so we need to let the zvsi job inherit these from the caller workflow like the rest of the coco tests (in https://github.com/kata-containers/kata-containers/pull/9479)