### PR TITLE
tests: Delete test scripts forcely

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -364,3 +364,14 @@ function delete_test_cluster_namespace() {
 	set_default_cluster_namespace
 	kubectl delete namespace "${TEST_CLUSTER_NAMESPACE}"
 }
+
+function delete_test_scripts(){
+	echo "Delete test scripts"
+	local scripts_names=( "run_kubernetes_tests.sh" "bats" )
+	for script_name in "${scripts_names[@]}"; do
+		pids=$(pgrep -f ${script_name})
+		if [ -n "$pids" ]; then
+			echo "$pids" | xargs sudo kill -SIGKILL >/dev/null 2>&1 || true
+		fi
+	done
+}

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -450,6 +450,8 @@ function cleanup() {
 		return
 	fi
 
+	# Delete all test scripts
+	delete_test_scripts
 	# Switch back to the default namespace and delete the tests one
 	delete_test_cluster_namespace || true
 


### PR DESCRIPTION
Delete test scripts forcely in `Delete kata-deploy` step before deleting all kata pods.

Fixes: #9980