### PR TITLE
gha: Increase timeout to run CoCo TDX tests

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -82,7 +82,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 50
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Delete kata-deploy


### PR DESCRIPTION
This PR increases the timeout to run the CoCo TDX tests in order to avoid the random failures on TDX saying that
The action 'Run tests' has timed out after 30 minutes and making the GHA job fail.