### PR TITLE
ci: fix run-nydus tests

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -176,11 +176,6 @@ function extract_kata_env() {
 	RUNTIME_PATH="$(echo "${kata_env}" | jq -r ${runtime_path})"
 	SHARED_FS="$(echo "${kata_env}" | jq -r ${shared_fs})"
 
-	# get_kata_memory_and_vcpus() function measures the memory and the number of vcpus
-	# from a kata container, and saves these values ​​in the variables:
-	# 'MEASURED_CONTAINER_NUM_VCPUS' and 'MEASURED_CONTAINER_TOTAL_MEM'
-	get_kata_memory_and_vcpus
-
 	# get the requested memory and num of vcpus from the kata config file.
 	config_content="$(cat ${RUNTIME_CONFIG_PATH} | grep -vE "^#")"
 	REQ_MEMORY="$(echo "${config_content}" | grep -i default_memory | cut -d  "=" -f2 | awk '{print $1}')"

--- a/tests/metrics/lib/json.bash
+++ b/tests/metrics/lib/json.bash
@@ -43,6 +43,11 @@ function metrics_json_init() {
 	despaced_name="$(echo ${TEST_NAME} | sed 's/[ \/]/-/g')"
 	json_filename="${RESULT_DIR}/${despaced_name}.json"
 
+	# get_kata_memory_and_vcpus() function measures the memory and the number of vcpus
+	# from a kata container, and saves these values ​​in the variables:
+	# 'MEASURED_CONTAINER_NUM_VCPUS' and 'MEASURED_CONTAINER_TOTAL_MEM'
+	get_kata_memory_and_vcpus
+
 	local json="$(cat << EOF
 	"@timestamp" : $(timestamp_ms)
 EOF


### PR DESCRIPTION
```
GH-9973 introduced:

 * New function get_kata_memory_and_vcpus() in
   tests/metrics/lib/common.bash.
 * A call to get_kata_memory_and_vcpus() from extract_kata_env(), which
   is defined in tests/common.bash.

Because the nydus test only sources tests/common.bash, it can't find
get_kata_memory_and_vcpus() and errors out.

So we fix this by moving get_kata_memory_and_vcpus() to
tests/common.bash.
```

Related: #9940