### PR TITLE
CI: Fix race condition in kernel configuration

### DIFF
--- a/tools/packaging/kernel/build-kernel.sh
+++ b/tools/packaging/kernel/build-kernel.sh
@@ -232,7 +232,7 @@ get_kernel_frag_path() {
 	local kernel_path="$2"
 	local arch="$3"
 	local cmdpath="${kernel_path}/scripts/kconfig/merge_config.sh"
-	local config_path="${arch_path}/.config"
+	local config_path="${kernel_path}/config-${config_version}-${arch}"
 
 	local arch_configs="$(ls ${arch_path}/*.conf)"
 	# Exclude configs if they have !$arch tag in the header


### PR DESCRIPTION
Currently kernel configs are generated into single file:
"tools/packaging/kernel/configs/fragments/x86_64/.config".

This cause race when several kernel flavors builds runs in parallel.
For 64-cpu machine this happens every time.

Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
