### PR TITLE
CI: Fix handling path to versions file in "make kata-tarball"

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -14,7 +14,7 @@ kata_build_dir=${1:-build}
 kata_versions_yaml_file=${2:-""}
 
 tar_path="${PWD}/kata-static.tar.xz"
-kata_versions_yaml_file_path="${PWD}/${kata_versions_yaml_file}"
+[[ -n "${kata_versions_yaml_file}" ]] && kata_versions_yaml_file_path=$(realpath "${kata_versions_yaml_file}")
 
 pushd "${kata_build_dir}"
 tarball_content_dir="${PWD}/kata-tarball-content"


### PR DESCRIPTION
tools/packaging/kata-deploy/local-build/Makefile calls kata-deploy-merge-builds.sh with
absolute path to "versions.yaml" which is not handled well:

$  make DEBUG=yes kata-tarball
...
kata-deploy-merge-builds.sh build "<SRC>/tools/packaging/kata-deploy/local-build//../../../../versions.yaml"
...
+ kata_build_dir=build
+ kata_versions_yaml_file=<SRC>/tools/packaging/kata-deploy/local-build//../../../../versions.yaml
+ tar_path=/home/khlebnikov/src/kata-containers/kata-static.tar.xz
+ kata_versions_yaml_file_path=<SRC>//<SRC>/home/khlebnikov/src/kata-containers/tools/packaging/kata-deploy/local-build//../../../../versions.yaml
...
+ [[ -n <SRC>/tools/packaging/kata-deploy/local-build//../../../../versions.yaml ]]
+ cp <SRC>//<SRC>/tools/packaging/kata-deploy/local-build//../../../../versions.yaml ./opt/kata//
cp: cannot stat '<SRC>//<SRC>/tools/packaging/kata-deploy/local-build//../../../../versions.yaml': No such file or directory
make: *** [tools/packaging/kata-deploy/local-build/Makefile:168: merge-builds] Error 1

Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
