### PR TITLE
CI: Do not use cached artifacts if USE_CACHE=no

### DIFF
--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -115,6 +115,15 @@ get_last_modification() {
 	popd &> /dev/null
 }
 
+# $1 - The tag to be pulled from the registry
+pull_from_registry() {
+	local tag="${1}"
+
+	[ "${USE_CACHE:-"yes"}" != "yes" ] && return 1
+
+	docker pull "${tag}"
+}
+
 # $1 - The tag to be pushed to the registry
 # $2 - "yes" to use sudo, "no" otherwise
 push_to_registry() {

--- a/tools/packaging/static-build/agent/build.sh
+++ b/tools/packaging/static-build/agent/build.sh
@@ -16,7 +16,7 @@ source "${script_dir}/../../scripts/lib.sh"
 container_image="${AGENT_CONTAINER_BUILDER:-$(get_agent_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
-docker pull ${container_image} || \
+pull_from_registry ${container_image} || \
 	(docker $BUILDX build $PLATFORM \
 	    	--build-arg RUST_TOOLCHAIN="$(get_from_kata_deps ".languages.rust.meta.newest-version")" \
 		-t "${container_image}" "${script_dir}" && \

--- a/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
+++ b/tools/packaging/static-build/cloud-hypervisor/build-static-clh.sh
@@ -24,6 +24,10 @@ cloud_hypervisor_version="${cloud_hypervisor_version:-}"
 cloud_hypervisor_pr="${cloud_hypervisor_pr:-}"
 cloud_hypervisor_pull_ref_branch="${cloud_hypervisor_pull_ref_branch:-main}"
 
+if [ "${USE_CACHE:-"yes"}" != "yes" ]; then
+	force_build_from_source=true
+fi
+
 if [ -z "$cloud_hypervisor_repo" ]; then
 	info "Get cloud_hypervisor information from runtime versions.yaml"
 	cloud_hypervisor_url=$(get_from_kata_deps ".assets.hypervisor.cloud_hypervisor.url")
@@ -73,11 +77,16 @@ build_clh_from_source() {
 		git checkout "${cloud_hypervisor_version}"
 	fi
 
+	dev_options=""
+	if [ "${USE_CACHE:-"yes"}" != "yes" ]; then
+	    dev_options+=" --local"
+	fi
+
 	if [ -n "${features}" ]; then
 		info "Build cloud-hypervisor enabling the following features: ${features}"
-		./scripts/dev_cli.sh build --release --libc "${libc}" --features "${features}"
+		./scripts/dev_cli.sh ${dev_options} build --release --libc "${libc}" --features "${features}"
 	else
-		./scripts/dev_cli.sh build --release --libc "${libc}"
+		./scripts/dev_cli.sh ${dev_options} build --release --libc "${libc}"
 	fi
 	rm -f cloud-hypervisor
 	cp build/cargo_target/$(uname -m)-unknown-linux-${libc}/release/cloud-hypervisor .

--- a/tools/packaging/static-build/coco-guest-components/build.sh
+++ b/tools/packaging/static-build/coco-guest-components/build.sh
@@ -31,7 +31,7 @@ package_output_dir="${package_output_dir:-}"
 container_image="${COCO_GUEST_COMPONENTS_CONTAINER_BUILDER:-$(get_coco_guest_components_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
-docker pull ${container_image} || \
+pull_from_registry ${container_image} || \
 	(docker $BUILDX build $PLATFORM \
 	    	--build-arg RUST_TOOLCHAIN="${coco_guest_components_toolchain}" \
 		-t "${container_image}" "${script_dir}" && \

--- a/tools/packaging/static-build/initramfs/build.sh
+++ b/tools/packaging/static-build/initramfs/build.sh
@@ -34,7 +34,7 @@ package_output_dir="${package_output_dir:-}"
 
 container_image="${BUILDER_REGISTRY}:initramfs-cryptsetup-${cryptsetup_version}-lvm2-${lvm2_version}-$(get_last_modification ${repo_root_dir} ${script_dir})-$(uname -m)"
 
-docker pull ${container_image} || (docker build \
+pull_from_registry ${container_image} || (docker build \
 	--build-arg cryptsetup_repo="${cryptsetup_repo}" \
 	--build-arg cryptsetup_version="${cryptsetup_version}" \
 	--build-arg lvm2_repo="${lvm2_repo}" \

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -42,7 +42,7 @@ if [ "${CROSS_BUILD}" == "true" ]; then
        fi
 fi
 
-docker pull ${container_image} || \
+pull_from_registry ${container_image} || \
 	(docker ${BUILDX} build ${PLATFORM} \
 	--build-arg ARCH=${ARCH} -t "${container_image}" "${script_dir}" && \
 	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -47,7 +47,7 @@ fi
 [ -n "$ovmf_package" ] || die "failed to get ovmf package or commit"
 [ -n "$package_output_dir" ] || die "failed to get ovmf package or commit"
 
-docker pull ${container_image} || \
+pull_from_registry ${container_image} || \
 	(docker build -t "${container_image}" "${script_dir}" && \
 	# No-op unless PUSH_TO_REGISTRY is exported as "yes"
 	push_to_registry "${container_image}")

--- a/tools/packaging/static-build/pause-image/build.sh
+++ b/tools/packaging/static-build/pause-image/build.sh
@@ -28,7 +28,7 @@ package_output_dir="${package_output_dir:-}"
 container_image="${PAUSE_IMAGE_CONTAINER_BUILDER:-$(get_pause_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
-docker pull ${container_image} || \
+pull_from_registry ${container_image} || \
 	(docker $BUILDX build $PLATFORM \
 		-t "${container_image}" "${script_dir}" && \
 	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"

--- a/tools/packaging/static-build/qemu/build-base-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-base-qemu.sh
@@ -47,7 +47,7 @@ CACHE_TIMEOUT=$(date +"%Y-%m-%d")
 container_image="${QEMU_CONTAINER_BUILDER:-$(get_qemu_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
-${container_engine} pull ${container_image} || ("${container_engine}" build \
+[ "${USE_CACHE:-"yes"}" != "yes" ] && ${container_engine} pull ${container_image} || ("${container_engine}" build \
 	--build-arg CACHE_TIMEOUT="${CACHE_TIMEOUT}" \
 	--build-arg http_proxy="${http_proxy}" \
 	--build-arg https_proxy="${https_proxy}" \

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -37,7 +37,7 @@ if [ "${MEASURED_ROOTFS}" == "yes" ]; then
 	EXTRA_OPTS+=" ROOTMEASURECONFIG=\"${root_measure_config}\""
 fi
 
-docker pull ${container_image} || \
+pull_from_registry ${container_image} || \
 	(docker ${BUILDX} build ${PLATFORM}  \
 		--build-arg GO_VERSION="${GO_VERSION}" \
 		--build-arg RUST_VERSION="${RUST_VERSION}" \

--- a/tools/packaging/static-build/tools/build.sh
+++ b/tools/packaging/static-build/tools/build.sh
@@ -18,7 +18,7 @@ tool="${1}"
 container_image="${TOOLS_CONTAINER_BUILDER:-$(get_tools_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
-docker pull ${container_image} || \
+pull_from_registry ${container_image} || \
 	(docker $BUILDX build $PLATFORM \
 	    	--build-arg RUST_TOOLCHAIN="$(get_from_kata_deps ".languages.rust.meta.newest-version")" \
 		-t "${container_image}" "${script_dir}" && \

--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -24,12 +24,13 @@ virtiofsd_zip="${virtiofsd_zip:-}"
 [ -n "$virtiofsd_version" ] || die "failed to get virtiofsd version"
 [ -n "${virtiofsd_zip}" ] || die "failed to get virtiofsd binary URL"
 
-[ -d "virtiofsd" ] && rm -r virtiofsd
+[ -d "virtiofsd" ] && rm -rf virtiofsd
 
 pull_virtiofsd_released_binary() {
 	if [ "${ARCH}" != "x86_64" ]; then
 		info "Only x86_64 binaries are distributed as part of the virtiofsd releases" && return 1
 	fi
+	[ "${USE_CACHE:-"yes"}" != "yes" ] && return 1
 	info "Download virtiofsd version: ${virtiofsd_version}"
 
 	mkdir -p virtiofsd

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -60,6 +60,7 @@ pull_from_registry ${container_image} || \
 
 docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \
+	--env USE_CACHE="${USE_CACHE:-"yes"}" \
 	--env DESTDIR="${DESTDIR}" \
 	--env PREFIX="${PREFIX}" \
 	--env virtiofsd_repo="${virtiofsd_repo}" \

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -51,7 +51,7 @@ esac
 container_image="${VIRTIOFSD_CONTAINER_BUILDER:-$(get_virtiofsd_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
-docker pull ${container_image} || \
+pull_from_registry ${container_image} || \
 	(docker $BUILDX build $PLATFORM \
 		--build-arg RUST_TOOLCHAIN="${virtiofsd_toolchain}" \
 		-t "${container_image}" "${script_dir}/${libc}" && \


### PR DESCRIPTION
- CI: Do not pull builder docker images if USE_CACHE=no
  "make USE_CACHE=no kata-tarball" should build everything from scratch.
  
  Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
  
- CI: Build virtiofsd from source if USE_CACHE=no
  "make virtiofsd-tarball USE_CACHE=no" shouldn't use cached binaries.
  
  Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
  
- CI: Build cloud-hypervisor for source if USE_CACHE=no
  "make cloud-hypervisor-tarball USE_CACHE=no" shouldn't use cached binaries.
  
  Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
  
