### PR TITLE
tests: k8s: GENPOLICY_PULL_METHOD clean-up

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -34,7 +34,7 @@ NO_PROXY="${NO_PROXY:-${no_proxy:-}}"
 PULL_TYPE="${PULL_TYPE:-default}"
 export AUTO_GENERATE_POLICY="${AUTO_GENERATE_POLICY:-no}"
 export TEST_CLUSTER_NAMESPACE="${TEST_CLUSTER_NAMESPACE:-kata-containers-k8s-tests}"
-export GENPOLICY_PULL_METHOD="${GENPOLICY_PULL_METHOD:-oci-distribution-client}"
+export GENPOLICY_PULL_METHOD="${GENPOLICY_PULL_METHOD:-oci-distribution}"
 
 function configure_devmapper() {
 	sudo mkdir -p /var/lib/containerd/devmapper

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -289,6 +289,12 @@ function run_tests() {
 		sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
 		echo "containerd config has been set to default"
 		sudo systemctl restart containerd && sudo systemctl is-active containerd
+
+		# Allow genpolicy to access the containerd image pull APIs without sudo.
+		local socket_wait_time=30
+		local socket_sleep_time=3
+		local cmd="sudo chmod a+rw /var/run/containerd/containerd.sock"
+		waitForProcess "${socket_wait_time}" "${socket_sleep_time}" "$cmd"
 	fi
 
 	set_test_cluster_namespace

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -70,6 +70,11 @@ else
 		"k8s-nginx-connectivity.bats" \
 	)
 
+	# When testing auto-generated policy, the genpolicy tool:
+	# - Is able to pull this older format container image by pulling through containerd.
+	# - Fails to pull the same container image by using the oci_distribution crate.
+	# Pulling through containerd might not be practical for all users, so both pulling
+	# methods are supported for most container images.
 	if [ "${GENPOLICY_PULL_METHOD}" == "containerd" ]; then
 		K8S_TEST_SMALL_HOST_UNION+=("k8s-pod-manifest-v1.bats")
 	fi

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -143,9 +143,6 @@ create_common_genpolicy_settings() {
 
 	# Set the default namespace of Kata CI tests in the genpolicy settings.
 	set_namespace_to_policy_settings "${genpolicy_settings_dir}" "${TEST_CLUSTER_NAMESPACE}"
-
-	# allow genpolicy to access containerd without sudo
-	sudo chmod a+rw /var/run/containerd/containerd.sock
 }
 
 # If auto-generated policy testing is enabled, make a copy of the common genpolicy settings


### PR DESCRIPTION
1. Avoid changing containerd settings in two different places.
2. Use GENPOLICY_PULL_METHOD=oci-distribution in gha-run.sh too, for consistency with other test files.
3. Add comment explaining why there are two different methods for pulling container images in genpolicy.
