### PR TITLE
k8s: Skip shared-volume relevant tests for IBM SE

### DIFF
--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -22,6 +22,8 @@ setup() {
 		skip "This test has failed for ${KATA_HYPERVISOR:-}"
 	[ "${KATA_HYPERVISOR:-}" = "qemu-coco-dev" ] && \
 		skip "This test has failed for ${KATA_HYPERVISOR:-}"
+	[ "${KATA_HYPERVISOR}" = "qemu-se" ] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	pod_name="sharevol-kata"
 	get_pod_config_dir
 	pod_logs_file=""
@@ -76,6 +78,8 @@ teardown() {
 		skip "This test has failed for ${KATA_HYPERVISOR:-}"
 	[ "${KATA_HYPERVISOR:-}" = "qemu-coco-dev" ] && \
 		skip "This test has failed for ${KATA_HYPERVISOR:-}"
+	[ "${KATA_HYPERVISOR}" = "qemu-se" ] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/tests/integration/kubernetes/k8s-shared-volume.bats
+++ b/tests/integration/kubernetes/k8s-shared-volume.bats
@@ -9,6 +9,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[ "${KATA_HYPERVISOR}" = "qemu-se" ] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	get_pod_config_dir
 }
 
@@ -65,6 +67,8 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR}" = "qemu-se" ] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	# Debugging information
 	kubectl describe "pod/$pod_name" || true
 


### PR DESCRIPTION
Currently, it is not viable to share a writable volume (e.g., emptyDir) between containers in a single pod for IBM SE.
The following tests are relevant:
  - pod-shared-volume.bats
  - k8s-empty-dirs.bats

(See: https://github.com/kata-containers/kata-containers/issues/10002)

This PR skips the tests until the issue is resolved.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>