### PR TITLE
common: Add share fs information for dragonball

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -152,6 +152,7 @@ function extract_kata_env() {
 			hypervisor_path=".hypervisor.path"
 			virtio_fs_daemon_path=".hypervisor.virtio_fs_daemon"
 			initrd_path=".initrd.path"
+			shared_fs=".hypervisor.shared_fs"
 			;;
 		*)
 			cmd=kata-runtime


### PR DESCRIPTION
This PR adds the share fs information for dragonball using kata-ctl to avoid the failures in runk tests saying that shared_fs is an unbound variable.