### PR TITLE
genpolicy: add support for runAsUser fields

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -540,9 +540,7 @@ allow_user(p_process, i_process) {
     p_user := p_process.User
     i_user := i_process.User
 
-    # TODO: track down the reason for mcr.microsoft.com/oss/bitnami/redis:6.0.8 being
-    #       executed with uid = 0 despite having "User": "1001" in its container image
-    #       config.
+    # TODO: remove this workaround when fixing https://github.com/kata-containers/kata-containers/issues/9928.
     #print("allow_user: input uid =", i_user.UID, "policy uid =", p_user.UID)
     #p_user.UID == i_user.UID
 

--- a/src/tools/genpolicy/src/containerd.rs
+++ b/src/tools/genpolicy/src/containerd.rs
@@ -32,7 +32,7 @@ pub fn get_process(privileged_container: bool, common: &policy::CommonData) -> p
         Env: Vec::new(),
         Cwd: "/".to_string(),
         Capabilities: capabilities,
-        NoNewPrivileges: true,
+        NoNewPrivileges: false,
     }
 }
 

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -92,6 +92,9 @@ pub struct PodSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     topologySpreadConstraints: Option<Vec<TopologySpreadConstraint>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    securityContext: Option<PodSecurityContext>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
@@ -231,7 +234,7 @@ struct Probe {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     tcpSocket: Option<TCPSocketAction>,
-    // TODO: additional fiels.
+    // TODO: additional fields.
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
@@ -259,7 +262,7 @@ struct HTTPGetAction {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     httpHeaders: Option<Vec<HTTPHeader>>,
-    // TODO: additional fiels.
+    // TODO: additional fields.
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
@@ -303,6 +306,14 @@ struct SeccompProfile {
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
 #[derive(Clone, Debug, Serialize, Deserialize)]
+struct PodSecurityContext {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    runAsUser: Option<i64>,
+    // TODO: additional fields.
+}
+
+/// See Reference / Kubernetes API / Workload Resources / Pod.
+#[derive(Clone, Debug, Serialize, Deserialize)]
 struct Lifecycle {
     #[serde(skip_serializing_if = "Option::is_none")]
     postStart: Option<LifecycleHandler>,
@@ -316,7 +327,7 @@ struct Lifecycle {
 struct LifecycleHandler {
     #[serde(skip_serializing_if = "Option::is_none")]
     exec: Option<ExecAction>,
-    // TODO: additional fiels.
+    // TODO: additional fields.
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
@@ -571,15 +582,6 @@ impl Container {
         false
     }
 
-    pub fn allow_privilege_escalation(&self) -> bool {
-        if let Some(context) = &self.securityContext {
-            if let Some(allow) = context.allowPrivilegeEscalation {
-                return allow;
-            }
-        }
-        true
-    }
-
     pub fn read_only_root_filesystem(&self) -> bool {
         if let Some(context) = &self.securityContext {
             if let Some(read_only) = context.readOnlyRootFilesystem {
@@ -811,6 +813,14 @@ impl yaml::K8sResource for Pod {
             .clone()
             .or_else(|| Some(String::new()))
     }
+
+    fn get_process_fields(&self, process: &mut policy::KataProcess) {
+        if let Some(context) = &self.spec.securityContext {
+            if let Some(uid) = context.runAsUser {
+                process.User.UID = uid.try_into().unwrap();
+            }
+        }
+    }
 }
 
 impl Container {
@@ -857,6 +867,17 @@ impl Container {
             }
         }
         compress_default_capabilities(capabilities, defaults);
+    }
+
+    pub fn get_process_fields(&self, process: &mut policy::KataProcess) {
+        if let Some(context) = &self.securityContext {
+            if let Some(uid) = context.runAsUser {
+                process.User.UID = uid.try_into().unwrap();
+            }
+            if let Some(allow) = context.allowPrivilegeEscalation {
+                process.NoNewPrivileges = !allow
+            }
+        }
     }
 }
 

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -657,8 +657,10 @@ impl AgentPolicy {
 
         substitute_env_variables(&mut process.Env);
         substitute_args_env_variables(&mut process.Args, &process.Env);
+
         c_settings.get_process_fields(&mut process);
-        process.NoNewPrivileges = !yaml_container.allow_privilege_escalation();
+        resource.get_process_fields(&mut process);
+        yaml_container.get_process_fields(&mut process);
 
         process
     }

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -94,6 +94,11 @@ pub trait K8sResource {
     fn get_runtime_class_name(&self) -> Option<String> {
         None
     }
+
+    fn get_process_fields(&self, _process: &mut policy::KataProcess) {
+        // Just Pods can have a PodSecurityContext field, so the other
+        // resources can use this default get_process_fields implementation.
+    }
 }
 
 /// See Reference / Kubernetes API / Common Definitions / LabelSelector.

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -25,6 +25,7 @@ spec:
               name: policy-configmap
               key: data-2
       securityContext:
+        runAsUser: 1000
         seccompProfile:
           type: RuntimeDefault
   topologySpreadConstraints:


### PR DESCRIPTION
1. Explain better the reason for already-existing workaround in rules.rego.
2. Add genpolicy ability to create policy based on the SecurityContext.runAsUser and PodSecurityContext.runAsUser fields.
3. Add basic tests for genpolicy + these two fields.

Fixes: #8879
