### PR TITLE
osbuilder: Bump Fedora to 40

### DIFF
--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ARG IMAGE_REGISTRY=registry.fedoraproject.org
-FROM ${IMAGE_REGISTRY}/fedora:38
+FROM ${IMAGE_REGISTRY}/fedora:40
 
 RUN ([ -n "$http_proxy" ] && \
     sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true) && \


### PR DESCRIPTION
As Fedora 38 has reached EOL, we are encountering 404 errors for s390x, such as:

```
Status code: 404 for https://dl.fedoraproject.org/pub/fedora-secondary/updates/38/Everything/s390x/repodata/repomd.xml
```

Let's bump the OS to the latest version.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>