### PR TITLE
[WIP] Merge to main: Signed containers support

### DIFF
--- a/src/agent/src/image.rs
+++ b/src/agent/src/image.rs
@@ -59,6 +59,16 @@ impl ImageService {
         }
     }
 
+    fn get_security_config(&mut self) {
+        // Read enable signature verification from the agent config and set it in the image_client
+        let enable_signature_verification = &AGENT_CONFIG.enable_signature_verification;
+        info!(
+            sl(),
+            "enable_signature_verification set to: {}", enable_signature_verification
+        );
+        self.image_client.config.security_validate = *enable_signature_verification;
+    }
+
     /// pause image is packaged in rootfs
     fn unpack_pause_image(cid: &str) -> Result<String> {
         verify_id(cid).context("The guest pause image cid contains invalid characters.")?;
@@ -145,6 +155,8 @@ impl ImageService {
         let bundle_path = scoped_join(CONTAINER_BASE, cid)?;
         fs::create_dir_all(&bundle_path)?;
         info!(sl(), "pull image {image:?}, bundle path {bundle_path:?}");
+
+        self.get_security_config();
 
         let res = self
             .image_client

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -153,8 +153,8 @@ FIRMWARESNPPATH := $(PREFIXDEPS)/share/ovmf/AMDSEV.fd
 SNPCERTSPATH := /opt/snp/cert_chain.cert
 
 ROOTMEASURECONFIG ?= ""
-KERNELPARAMS += $(ROOTMEASURECONFIG)
-KERNELTDXPARAMS += $(ROOTMEASURECONFIG)
+KERNELPARAMS += $(ROOTMEASURECONFIG) agent.enable_signature_verification=false
+KERNELTDXPARAMS += $(ROOTMEASURECONFIG) agent.enable_signature_verification=false
 
 # Name of default configuration file the runtime will use.
 CONFIG_FILE = configuration.toml


### PR DESCRIPTION
This PR tries to complete #8120 work, pushing configuration changes for the runtime and agent.

The tasks that are included are:
- [X] agent: add enable_signature_verification config (from #5552)
- [X] agent: use the security_validate flag on image-rs client
- [X] runtime: add kernel parameters for the feature
- [ ] agent: add agent.image_policy_file (from https://github.com/kata-containers/kata-containers/commit/03d83914041fc8dc2bd7815414a619d94cbaf82c)
- [ ] New tests needed to validate the feature



