### PR TITLE
workflows: setup environment to run auth registry tests on s390x

### DIFF
--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -61,7 +61,8 @@ jobs:
       AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
     steps:
       - name: Take a pre-action for self-hosted runner
-        run: ${HOME}/script/pre_action.sh ubuntu-2204
+        run: |
+          "${HOME}/script/pre_action.sh" ubuntu-2204
 
       - uses: actions/checkout@v4
         with:
@@ -92,4 +93,4 @@ jobs:
         if: always()
         run: |
           bash tests/integration/kubernetes/gha-run.sh cleanup-zvsi || true
-          ${HOME}/script/post_action.sh ubuntu-2204
+          "${HOME}/script/post_action.sh" ubuntu-2204

--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -57,6 +57,8 @@ jobs:
       SNAPSHOTTER: ${{ matrix.snapshotter }}
       USING_NFD: ${{ matrix.using-nfd }}
       TARGET_ARCH: "s390x"
+      AUTHENTICATED_IMAGE_USER: ${{ secrets.AUTHENTICATED_IMAGE_USER }}
+      AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
     steps:
       - name: Take a pre-action for self-hosted runner
         run: ${HOME}/script/pre_action.sh ubuntu-2204


### PR DESCRIPTION
We missed to apply the changes of commit d8961cbd4a in the IBM SE workflow and then getting https://github.com/kata-containers/kata-containers/pull/9904 not passing CI. As this is a required change on the workflow we need to have it in a separated PR.

While here, I delinted the run-k8s-tests-on-zvsi.yaml and ran `actionlint` to ensure I'm not introducing any (obvious) bug. 