### PR TITLE
tests: fix ps command in k8s-security-context

### DIFF
--- a/tests/integration/kubernetes/k8s-security-context.bats
+++ b/tests/integration/kubernetes/k8s-security-context.bats
@@ -33,7 +33,7 @@ setup() {
 
 	# Check user
 	process="tail -f /dev/null"
-	kubectl exec $pod_name -- sh -c $cmd | grep "$process"
+	kubectl exec $pod_name -- sh -c "$cmd" | grep "$process"
 }
 
 teardown() {

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
@@ -14,5 +14,5 @@ spec:
     runAsUser: 1000
   containers:
   - name: sec-text
-    image: quay.io/prometheus/busybox:latest
+    image: quay.io/kata-containers/sysbench-kata:latest
     command: ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
1. Use a container image that supports "ps --user 1000 -f".
2. Execute that command using:

sh -c "ps --user 1000 -f"

instead of passing additional arguments to sh:

sh -c ps --user 1000 -f

Fixes: #10019