### PR TITLE
docs: Add reminder to update features.rs when adding new feature

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -97,6 +97,7 @@ members = ["rustjail"]
 [profile.release]
 lto = true
 
+# Update /src/agent/src/features.rs when adding a new feature
 [features]
 # The default-pull feature would support all pull types, including sharing images by virtio-fs and pulling images in the guest
 default-pull = ["guest-pull"]


### PR DESCRIPTION
Leave a comment reminder in `Cargo.toml` to update features vec in `/src/agent/src/features.rs` when devs are adding a new feature. This line should be removed when #9319 is implemented.

Fixes #9320