### PR TITLE
metric: Upgrade blogbench to 1.2

### DIFF
--- a/tests/metrics/storage/blogbench_dockerfile/Dockerfile
+++ b/tests/metrics/storage/blogbench_dockerfile/Dockerfile
@@ -15,7 +15,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 # URL for blogbench test and blogbench version
 ENV BLOGBENCH_URL "https://download.pureftpd.org/pub/blogbench"
-ENV BLOGBENCH_VERSION 1.1
+ENV BLOGBENCH_VERSION 1.2
 
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends build-essential curl && \


### PR DESCRIPTION
Move to blogbench 1.2 version from 1.1.
This version includes an important fix for the read_score test which was reported to be broken in the previous version. It essentially fixes this issue here:
https://github.com/jedisct1/Blogbench/issues/4