### PR TITLE
tests: Fix missing log on TDX

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
@@ -11,11 +11,6 @@ load "${BATS_TEST_DIRNAME}/confidential_kbs.sh"
 export KBS="${KBS:-false}"
 
 setup() {
-    # Log checking not working on TDX
-    if [ "${KATA_HYPERVISOR}" = "qemu-tdx" ]; then
-	    skip "Test skipped on ${KATA_HYPERVISOR}, see https://github.com/kata-containers/kata-containers/issues/10011"
-    fi
-
     if ! is_confidential_runtime_class; then
         skip "Test not supported for ${KATA_HYPERVISOR}."
     fi
@@ -138,10 +133,6 @@ function create_pod_yaml_with_private_image() {
 }
 
 teardown() {
-    if [ "${KATA_HYPERVISOR}" = "qemu-tdx" ]; then
-	    skip "Test skipped on ${KATA_HYPERVISOR}, see https://github.com/kata-containers/kata-containers/issues/10011"
-    fi
-
     if ! is_confidential_runtime_class; then
         skip "Test not supported for ${KATA_HYPERVISOR}."
     fi

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -77,8 +77,7 @@ assert_logs_contain() {
 	local message="$4"
 
 	# Note: with image-rs we get more than the default 1000 lines of logs
-	print_node_journal "$node" "$log_id" --since "$datetime" -n 100000 \
-		| grep "$message"
+	print_node_journal "$node" "$log_id" --since "$datetime" | grep "$message"
 }
 
 # Create a pod then assert it fails to run. Use in tests that you expect the
@@ -241,7 +240,7 @@ print_node_journal() {
 	shift 2
 	local img="quay.io/prometheus/busybox"
 
-	kubectl debug --image "$img" -q -it "node/${node}" \
+	kubectl debug --image "$img" -q -i "node/${node}" \
 		-- chroot /host journalctl -x -t "$id" --no-pager "$@"
 	# Delete the debugger pod
 	kubectl get pods -o name | grep "node-debugger-${node}" | \


### PR DESCRIPTION
Currently, we have found that `assert_logs_contain` does not work on TDX. We manually located the specific log, but it fails to get the log using `kubectl debug`. The error found in CI is:
```
warning: couldn't attach to pod/node-debugger-984fee00bd70.jf.intel.com-pdgsj,
falling back to streaming logs: error stream protocol error: unknown error
```

Upon debugging the TDX CI machine, we found an error in containerd:
```
Attach container from runtime service failed" err="rpc error: code = InvalidArgument desc = tty and stderr cannot both be true"
containerID="abc8c7a546c5fede4aae53a6ff2f4382ff35da331bfc5fd3843b0c8b231728bf"
```

We believe this is the root cause of the test failures in TDX CI. Therefore, we need to ensure that tty and stderr are not set to true at same time.

Fixes: #10011