### PR TITLE
tests: Rebuild secure boot image for guest-pull-image-authenticated for IBM SE

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
@@ -90,6 +90,15 @@ function create_pod_yaml_with_private_image() {
         "${kernel_params_annotation}" \
         "${kernel_params_value}"
 
+    # A secure boot image for IBM SE should be rebuilt according to the KBS configuration.
+    if [ "${KATA_HYPERVISOR}" == "qemu-se" ]; then
+        if [ -z "${IBM_SE_CREDS_DIR:-}" ]; then
+            >&2 echo "ERROR: IBM_SE_CREDS_DIR is empty"
+            return 1
+        fi
+        repack_secure_image "${kernel_params_value} agent.log=debug" "${IBM_SE_CREDS_DIR}" "true"
+    fi
+
     # Set annotation to pull image in guest
     set_metadata_annotation "${kata_pod_with_private_image}" \
         "io.containerd.cri.runtime-handler" \


### PR DESCRIPTION
Since #9904 was merged, newly introduced tests for `k8s-guest-pull-image-authenticated.bats` have been failing on IBM SE (s390x). The agent fails to start because a kernel parameter cannot pass to the guest VM via annotation. To fix this, the boot image must be rebuilt with updated parameters.

This PR adds the rebuilding step in `create_pod_yaml_with_private_image()` for `qemu-se`.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>