### PR TITLE
tests: Call repack_secure_image() in set_metadata_annotation()

### DIFF
--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -44,15 +44,6 @@ setup() {
 	set_metadata_annotation "${K8S_TEST_YAML}" \
 		"${kernel_params_annotation}" \
 		"${kernel_params_value}"
-
-	# A secure boot image for IBM SE should be rebuilt according to the KBS configuration.
-	if [ "${KATA_HYPERVISOR}" == "qemu-se" ]; then
-		if [ -z "${IBM_SE_CREDS_DIR:-}" ]; then
-			>&2 echo "ERROR: IBM_SE_CREDS_DIR is empty"
-			return 1
-		fi
-		repack_secure_image "${kernel_params_value}" "${IBM_SE_CREDS_DIR}" "true"
-	fi
 }
 
 @test "Get CDH resource" {

--- a/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
@@ -90,15 +90,6 @@ function create_pod_yaml_with_private_image() {
         "${kernel_params_annotation}" \
         "${kernel_params_value}"
 
-    # A secure boot image for IBM SE should be rebuilt according to the KBS configuration.
-    if [ "${KATA_HYPERVISOR}" == "qemu-se" ]; then
-        if [ -z "${IBM_SE_CREDS_DIR:-}" ]; then
-            >&2 echo "ERROR: IBM_SE_CREDS_DIR is empty"
-            return 1
-        fi
-        repack_secure_image "${kernel_params_value} agent.log=debug" "${IBM_SE_CREDS_DIR}" "true"
-    fi
-
     # Set annotation to pull image in guest
     set_metadata_annotation "${kata_pod_with_private_image}" \
         "io.containerd.cri.runtime-handler" \

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -191,6 +191,15 @@ set_metadata_annotation() {
 	# yq set annotations in yaml. Quoting the key because it can have
 	# dots.
 	yq -i ".${annotation_key} = \"${value}\"" "${yaml}"
+
+	if [[ "${key}" =~ kernel_params ]] && [[ "${KATA_HYPERVISOR}" == "qemu-se" ]]; then
+		# A secure boot image for IBM SE should be rebuilt according to the KBS configuration.
+		if [ -z "${IBM_SE_CREDS_DIR:-}" ]; then
+			>&2 echo "ERROR: IBM_SE_CREDS_DIR is empty"
+			return 1
+		fi
+		repack_secure_image "${value}" "${IBM_SE_CREDS_DIR}" "true"
+	fi
 }
 
 # Set the command for container spec.


### PR DESCRIPTION
It is not good practice to call repack_secure_image() from a bats file because the test code might not consider cases where `qemu-se` is used as `KATA_HYPERVISOR`.

This PR moves the function call to set_metadata_annotation() if a key includes `kernel_params` and `KATA_HYPERVISOR` is set to `qemu-se`, allowing developers to focus on the test scenario itself.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>