### PR TITLE
ci: reinstate Mariner host and guest kernel

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -96,7 +96,8 @@ function create_cluster() {
 		-n "$(_print_cluster_name ${test_type})" \
 		-s "$(_print_instance_type)" \
 		--node-count 1 \
-		--generate-ssh-keys
+		--generate-ssh-keys \
+		$([ "${KATA_HOST_OS}" = "cbl-mariner" ] && echo "--os-sku AzureLinux --workload-runtime KataMshvVmIsolation")
 }
 
 function install_bats() {

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -110,6 +110,7 @@ add_cbl_mariner_kernel_initrd_annotations() {
 
 		for K8S_TEST_YAML in runtimeclass_workloads_work/*.yaml
 		do
+			add_annotations_to_yaml "${K8S_TEST_YAML}" "${mariner_annotation_kernel}" "${mariner_kernel_path}"
 			add_annotations_to_yaml "${K8S_TEST_YAML}" "${mariner_annotation_initrd}" "${mariner_initrd_path}"
 		done
 	fi

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -159,6 +159,7 @@ adapt_common_policy_settings_for_cbl_mariner() {
 
 	info "Adapting common policy settings for CBL-Mariner"
 	jq '.request_defaults.UpdateEphemeralMountsRequest = true' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
+	jq '.kata_config.oci_version = "1.1.0-rc.1"' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
 }
 
 # adapt common policy settings for various platforms


### PR DESCRIPTION
GH-9592 addressed a bug in a previous version of the AKS Mariner host kernel that blocked the CH v39 upgrade. This bug has now been fixed so we undo that PR.

Fixes: #9594