### PR TITLE
runtime-rs : fix the issue of stop sandbox

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -275,6 +275,10 @@ impl ContainerInner {
         signal: u32,
         all: bool,
     ) -> Result<()> {
+        if self.check_state(vec![ProcessStatus::Stopped]).await.is_ok() {
+            return Ok(());
+        }
+
         let mut process_id: agent::ContainerProcessID = process.clone().into();
         if all {
             // force signal init process

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -471,8 +471,15 @@ impl Sandbox for VirtSandbox {
     }
 
     async fn stop(&self) -> Result<()> {
-        info!(sl!(), "begin stop sandbox");
-        self.hypervisor.stop_vm().await.context("stop vm")?;
+        let mut sandbox_inner = self.inner.write().await;
+
+        if sandbox_inner.state != SandboxState::Stopped {
+            info!(sl!(), "begin stop sandbox");
+            self.hypervisor.stop_vm().await.context("stop vm")?;
+            sandbox_inner.state = SandboxState::Stopped;
+            info!(sl!(), "sandbox stopped");
+        }
+
         Ok(())
     }
 


### PR DESCRIPTION
Since stop sandbox would be called in multi path,
thus it's better to set and check the sandbox's state.