### PR TITLE
runtime-rs: container: fix the issue of missing cleanup container

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -546,6 +546,18 @@ impl Container {
     pub async fn spec(&self) -> oci::Spec {
         self.spec.clone()
     }
+
+    pub async fn cleanup(&mut self) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        let device_manager = self.resource_manager.get_device_manager().await;
+        inner
+            .cleanup_container(
+                self.container_id.container_id.as_str(),
+                true,
+                &device_manager,
+            )
+            .await
+    }
 }
 
 fn amend_spec(spec: &mut oci::Spec, disable_guest_seccomp: bool) -> Result<()> {

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container_inner.rs
@@ -177,7 +177,7 @@ impl ContainerInner {
         }
     }
 
-    async fn cleanup_container(
+    pub(crate) async fn cleanup_container(
         &mut self,
         cid: &str,
         force: bool,


### PR DESCRIPTION
When create container failed, it should cleanup the container thus there's no device/resource left.

Fixes: #10044