### PR TITLE
genpolicy: hardening some agent requests

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -296,7 +296,7 @@
             ]
         },
         "CopyFileRequest": [
-            "^$(cpath)/"
+            "$(sfprefix)"
         ],
         "ExecProcessRequest": {
             "allowed_commands": [],

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1092,12 +1092,23 @@ match_caps(p_caps, i_caps) {
 }
 
 ######################################################################
+
+check_directory_traversal(i_path) {
+    not regex.match("(^|/)..($|/)", i_path)
+}
+
 CopyFileRequest {
     print("CopyFileRequest: input.path =", input.path)
 
+    check_directory_traversal(input.path)
+
     some regex1 in policy_data.request_defaults.CopyFileRequest
-    regex2 := replace(regex1, "$(cpath)", policy_data.common.cpath)
-    regex.match(regex2, input.path)
+    regex2 := replace(regex1, "$(sfprefix)", policy_data.common.sfprefix)
+    regex3 := replace(regex2, "$(cpath)", policy_data.common.mount_source_cpath)
+    regex4 := replace(regex3, "$(bundle-id)", "[a-z0-9]{64}")
+    print("CopyFileRequest: regex4 =", regex4)
+
+    regex.match(regex4, input.path)
 
     print("CopyFileRequest: true")
 }

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -15,7 +15,7 @@ default AddSwapRequest := false
 default CloseStdinRequest := false
 default CopyFileRequest := false
 default CreateContainerRequest := false
-default CreateSandboxRequest := true
+default CreateSandboxRequest := false
 default DestroySandboxRequest := true
 default ExecProcessRequest := false
 default GetOOMEventRequest := true
@@ -1116,6 +1116,9 @@ CopyFileRequest {
 CreateSandboxRequest {
     print("CreateSandboxRequest: input.guest_hook_path =", input.guest_hook_path)
     count(input.guest_hook_path) == 0
+
+    print("CreateSandboxRequest: input.kernel_modules =", input.kernel_modules)
+    count(input.kernel_modules) == 0
 
     i_pidns := input.sandbox_pidns
     print("CreateSandboxRequest: i_pidns =", i_pidns)

--- a/src/tools/genpolicy/tests/testdata/copyfile/testcases.json
+++ b/src/tools/genpolicy/tests/testdata/copyfile/testcases.json
@@ -7,10 +7,59 @@
     }
   },
   {
+    "description": "a dirname can have trailing dots",
+    "allowed": true,
+    "request": {
+      "path": "/run/kata-containers/shared/containers/81e5f43bc8599c5661e66f959ac28df5bfb30da23c5d583f2dcc6f9e0c5186dc-ce23cfeb91e75aaa-foo../bar"
+    }
+  },
+  {
     "description": "attempt to copy outside of container root",
     "allowed": false,
     "request": {
       "path": "/etc/ssl/cert.pem"
+    }
+  },
+  {
+    "description": "attempt to write into container root",
+    "allowed": false,
+    "request": {
+      "path": "/run/kata-containers/shared/containers/81e5f43bc8599c5661e66f959ac28df5bfb30da23c5d583f2dcc6f9e0c5186dc/rootfs/bin/sh"
+    }
+  },
+  {
+    "description": "attempt to write into container root - guest pull",
+    "allowed": false,
+    "request": {
+      "path": "/run/kata-containers/81e5f43bc8599c5661e66f959ac28df5bfb30da23c5d583f2dcc6f9e0c5186dc/rootfs/bin/sh"
+    }
+  },
+  {
+    "description": "attempted directory traversal",
+    "allowed": false,
+    "request": {
+      "path": "/run/kata-containers/shared/containers/81e5f43bc8599c5661e66f959ac28df5bfb30da23c5d583f2dcc6f9e0c5186dc-ce23cfeb91e75aaa-foo/../../../../../etc/ssl/cert.pem"
+    }
+  },
+  {
+    "description": "attempted directory traversal - parent directory",
+    "allowed": false,
+    "request": {
+      "path": "/run/kata-containers/shared/containers/81e5f43bc8599c5661e66f959ac28df5bfb30da23c5d583f2dcc6f9e0c5186dc-ce23cfeb91e75aaa-foo/.."
+    }
+  },
+  {
+    "description": "relative path",
+    "allowed": false,
+    "request": {
+      "path": "etc/ssl/cert.pem"
+    }
+  },
+  {
+    "description": "relative path - parent directory",
+    "allowed": false,
+    "request": {
+      "path": ".."
     }
   }
 ]

--- a/src/tools/genpolicy/tests/testdata/createsandbox/testcases.json
+++ b/src/tools/genpolicy/tests/testdata/createsandbox/testcases.json
@@ -5,5 +5,28 @@
     "request": {
       "sandbox_pidns": false
     }
+  },
+  {
+    "description": "pidns",
+    "allowed": false,
+    "request": {
+      "sandbox_pidns": true
+    }
+  },
+  {
+    "description": "kernel modules",
+    "allowed": false,
+    "request": {
+      "sandbox_pidns": false,
+      "kernel_modules": [{"name": "evil.ko"}]
+    }
+  },
+  {
+    "description": "guest hooks",
+    "allowed": false,
+    "request": {
+      "sandbox_pidns": false,
+      "guest_hook_path": "/attacker/controlled/path"
+    }
   }
 ]


### PR DESCRIPTION
This PR backports the commits mentioned in #10046, except for the symlink source (which I don't quite understand yet) and the sandbox storage checks (which are likely blocked by #8833). The commit messages each have a rationale for why this hardening makes sense.

cc @danmihai1 