### PR TITLE
libs: remove creation for path kata_run_path in get_uds_with_sid

### DIFF
--- a/src/libs/shim-interface/src/lib.rs
+++ b/src/libs/shim-interface/src/lib.rs
@@ -37,9 +37,6 @@ fn get_uds_with_sid(short_id: &str, path: &str) -> Result<String> {
         return Ok(format!("unix://{}", p.display()));
     }
 
-    let _ = fs::create_dir_all(kata_run_path.join(short_id))
-            .context(format!("failed to create directory {:?}", kata_run_path.join(short_id)));
-
     let target_ids: Vec<String> = fs::read_dir(&kata_run_path)?
         .filter_map(|e| {
             let x = e.ok()?.file_name().to_string_lossy().into_owned();

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/inner_hypervisor.rs
@@ -23,6 +23,10 @@ impl FcInner {
         debug!(sl(), "Preparing Firecracker");
 
         self.id = id.to_string();
+        let vm_path = [KATA_PATH, &self.id].join("/");
+        fs::create_dir_all(&vm_path)
+            .await
+            .context(format!("failed to create vm path {:?}", &vm_path))?;
 
         if !self.config.jailer_path.is_empty() {
             debug!(sl(), "Running jailed");
@@ -40,7 +44,7 @@ impl FcInner {
             debug!(sl(), "Rundir: {:?}", self.run_dir);
             let _ = self.remount_jailer_with_exec().await;
         } else {
-            self.vm_path = [KATA_PATH.to_string(), id.to_string()].join("/");
+            self.vm_path = vm_path;
             debug!(sl(), "VM Path: {:?}", self.vm_path);
             self.run_dir = [self.vm_path.clone(), "run".to_string()].join("/");
             debug!(sl(), "Rundir: {:?}", self.run_dir);


### PR DESCRIPTION
In fact, the function get_uds_with_sid works based on immutable existing kata_run_path. There's no point that do create_dir_all(kata_run_path). With this reason, I propose to remove the create_dir_all

Fixes #10055