### PR TITLE
runtime-rs: enhance debug info for agent connect.

### DIFF
--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -113,7 +113,13 @@ impl KataAgent {
             sock::new(&inner.socket_address, inner.config.server_port).context("new sock")?;
         let stream = sock.connect(&config).await.context("connect")?;
         let fd = stream.into_raw_fd();
-        info!(sl!(), "get stream raw fd {:?}", fd);
+        info!(
+            sl!(),
+            "get stream raw fd {:?} with socket address: {:?} and server_port {:?}",
+            fd,
+            &inner.socket_address,
+            inner.config.server_port
+        );
         let c = Client::new(fd);
         inner.client = Some(c);
         inner.client_fd = fd;

--- a/src/runtime-rs/crates/agent/src/sock/vsock.rs
+++ b/src/runtime-rs/crates/agent/src/sock/vsock.rs
@@ -69,11 +69,15 @@ impl Sock for Vsock {
                     );
                     return Ok(Stream::Vsock(stream));
                 }
-                Err(_) => {
+                Err(e) => {
+                    debug!(sl!(), "retry after {} ms: failed to connect to agent via vsock at {} attempts: {:?}", config.dial_timeout_ms, i, e);
                     tokio::time::sleep(Duration::from_millis(config.dial_timeout_ms)).await;
                 }
             }
         }
-        Err(anyhow!("cannot connect to agent ttrpc server {:?}", config))
+        Err(anyhow!(
+            "cannot connect vsock to agent ttrpc server {:?}",
+            config
+        ))
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -382,7 +382,10 @@ impl Sandbox for VirtSandbox {
             .get_agent_socket()
             .await
             .context("get agent socket")?;
-        self.agent.start(&address).await.context("connect")?;
+        self.agent
+            .start(&address)
+            .await
+            .context(format!("connect to address {:?}", &address))?;
 
         self.resource_manager
             .setup_after_start_vm()


### PR DESCRIPTION
we need more friendly logs for debugging agent conntion cases when kata pods fail.

Fixes #10057