### PR TITLE
gha: Increase timeout to run CoCo tests

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -143,7 +143,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-sev
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 50
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Delete kata-deploy
@@ -214,7 +214,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 50
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Delete kata-deploy


### PR DESCRIPTION
This PR increases the timeout for running the CoCo tests to avoid random failures. These failures occur when the action `Run tests` times out after 30 minutes, causing the CI to fail.

Fixes: #10062