### PR TITLE
genpolicy: validate each exec command line arg

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -299,7 +299,7 @@
             "^$(cpath)/"
         ],
         "ExecProcessRequest": {
-            "commands": [],
+            "allowed_commands": [],
             "regex": []
         },
         "CloseStdinRequest": false,

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1111,12 +1111,9 @@ CreateSandboxRequest {
 ExecProcessRequest {
     print("ExecProcessRequest 1: input =", input)
 
-    i_command = concat(" ", input.process.Args)
-    print("ExecProcessRequest 1: i_command =", i_command)
-
-    some p_command in policy_data.request_defaults.ExecProcessRequest.commands
+    some p_command in policy_data.request_defaults.ExecProcessRequest.allowed_commands
     print("ExecProcessRequest 1: p_command =", p_command)
-    p_command == i_command
+    p_command == input.process.Args
 
     print("ExecProcessRequest 1: true")
 }

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -313,8 +313,12 @@ pub struct CreateContainerRequestDefaults {
 /// ExecProcessRequest settings from genpolicy-settings.json.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ExecProcessRequestDefaults {
+    /// Allow these commands to be executed. This field has been deprecated - use allowed_commands instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub commands: Option<Vec<String>>,
+
     /// Allow these commands to be executed.
-    commands: Vec<String>,
+    pub allowed_commands: Vec<Vec<String>>,
 
     /// Allow commands matching these regexes to be executed.
     regex: Vec<String>,

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -73,6 +73,7 @@ impl Settings {
         if let Ok(file) = File::open(json_settings_path) {
             let settings: Self = serde_json::from_reader(file).unwrap();
             debug!("settings = {:?}", &settings);
+            Self::validate_settings(&settings);
             settings
         } else {
             panic!("Cannot open file {}. Please copy it to the current directory or specify the path to it using the -j parameter.",
@@ -85,6 +86,15 @@ impl Settings {
             &self.pause_container
         } else {
             &self.other_container
+        }
+    }
+
+    fn validate_settings(settings: &Self) {
+        if let Some(commands) = &settings.request_defaults.ExecProcessRequest.commands {
+            if !commands.is_empty() {
+                panic!("The settings field <request_defaults.ExecProcessRequest.commands> has been deprecated. \
+                    Please use <request_defaults.ExecProcessRequest.allowed_commands> instead.");
+            }
         }
     }
 }

--- a/tests/integration/kubernetes/k8s-exec.bats
+++ b/tests/integration/kubernetes/k8s-exec.bats
@@ -60,7 +60,7 @@ EOF
 
 	## Case for return value
 	### Command return non-zero code
-	run bash -c "kubectl exec -i $pod_name -- sh <<-EOF
+	run bash -c "kubectl exec -i $pod_name -- "$sh_command" <<-EOF
 exit 123
 EOF"
 	echo "run status: $status" 1>&2

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -17,8 +17,8 @@ setup() {
 	get_pod_config_dir
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
 	
-	exec_command="printenv data-3"
-	add_exec_to_policy_settings "${policy_settings_dir}" "${exec_command}"
+	exec_command=(printenv data-3)
+	add_exec_to_policy_settings "${policy_settings_dir}" "${exec_command[@]}"
 	add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
 
 	correct_configmap_yaml="${pod_config_dir}/k8s-policy-configmap.yaml"
@@ -63,10 +63,8 @@ wait_for_pod_ready() {
 }
 
 @test "Able to read env variables sourced from configmap using envFrom" {
-	kubectl create -f "${correct_configmap_yaml}"
-	kubectl create -f "${correct_pod_yaml}"
-	kubectl wait --for=condition=Ready "--timeout=${timeout}" pod "${pod_name}"
-	expected_env_var=$(kubectl exec "${pod_name}" -- printenv data-3)
+	wait_for_pod_ready
+	expected_env_var=$(kubectl exec "${pod_name}" -- ${exec_command[@]})
 	[ "$expected_env_var" = "value-3" ] || fail "expected_env_var is not equal to value-3"
 }
 


### PR DESCRIPTION
Generate policy that validates each exec command line argument, instead of joining those args and validating the resulting string. Joining the args ignored the fact that some of the args might include space characters.

The older format from genpolicy-settings.json was similar to:

    "ExecProcessRequest": {
      "commands": [
		"sh -c cat /proc/self/status"
        ],
      "regex": []
    },

That format will not be supported anymore. genpolicy will detect if its users are trying to use the older "commands" field and will exit with a relevant error message in that case.

The new settings format is:

    "ExecProcessRequest": {
      "allowed_commands": [
        [
          "sh",
          "-c",
          "cat /proc/self/status"
        ]
      ],
      "regex": []
    },