### PR TITLE
runtime: log vm start error before cleanup

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1458,6 +1458,8 @@ func (s *Sandbox) startVM(ctx context.Context, prestartHookFunc func(context.Con
 
 	defer func() {
 		if err != nil {
+			// Log error, otherwise nobody might see it - StopVM could kill this process.
+			s.Logger().WithError(err).Error("Cannot start VM")
 			s.hypervisor.StopVM(ctx, false)
 		}
 	}()


### PR DESCRIPTION
Return of proper error to the initiator is not guaranteed.
Method StopVM could kill shim process together with VM pieces.

Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
