### PR TITLE
runtime: fix corner-case qemu with zero-size virtio-mem hotplug

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -908,8 +908,10 @@ func (q *qemu) getMemArgs() (bool, string, string, error) {
 }
 
 func (q *qemu) setupVirtioMem(ctx context.Context) error {
-	// backend memory size must be multiple of 4Mib
-	sizeMB := (int(q.config.DefaultMaxMemorySize) - int(q.config.MemorySize)) >> 2 << 2
+	sizeMB := int(q.getMaxHotplugMemoryMB())
+	if sizeMB == 0 {
+		return nil
+	}
 
 	share, target, memoryBack, err := q.getMemArgs()
 	if err != nil {
@@ -2354,6 +2356,15 @@ func (q *qemu) GetTotalMemoryMB(ctx context.Context) uint32 {
 	return q.config.MemorySize + uint32(q.state.HotpluggedMemory)
 }
 
+func (q *qemu) getMaxHotplugMemoryMB() uint32 {
+	maxHotplugMemorySize := uint32(q.config.DefaultMaxMemorySize) - q.config.MemorySize
+	if q.config.VirtioMem {
+		// backend memory size must be multiple of 4Mib
+		maxHotplugMemorySize -= maxHotplugMemorySize % 4
+	}
+	return maxHotplugMemorySize
+}
+
 // ResizeMemory gets a request to update the VM memory to reqMemMB
 // Memory update is managed with two approaches
 // Add memory to VM:
@@ -2370,6 +2381,10 @@ func (q *qemu) ResizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSiz
 	currentMemory := q.GetTotalMemoryMB(ctx)
 	if err := q.qmpSetup(); err != nil {
 		return 0, MemoryDevice{}, err
+	}
+	maxHotplugMemory := q.getMaxHotplugMemoryMB()
+	if reqMemMB > q.config.MemorySize+maxHotplugMemory {
+		reqMemMB = q.config.MemorySize + maxHotplugMemory
 	}
 	var addMemDevice MemoryDevice
 	if q.config.VirtioMem && currentMemory != reqMemMB {
@@ -2388,10 +2403,6 @@ func (q *qemu) ResizeMemory(ctx context.Context, reqMemMB uint32, memoryBlockSiz
 	case currentMemory < reqMemMB:
 		//hotplug
 		addMemMB := reqMemMB - currentMemory
-
-		if currentMemory+addMemMB > uint32(q.config.DefaultMaxMemorySize) {
-			addMemMB = uint32(q.config.DefaultMaxMemorySize) - currentMemory
-		}
 
 		memHotplugMB, err := calcHotplugMemMiBSize(addMemMB, memoryBlockSizeMB)
 		if err != nil {


### PR DESCRIPTION
- runtime: do not add zero-size virtio-mem device to qemu
  Adding zero-size devices fails in qemu:
  "Add 0MB virtio-mem-pci fail QMP command failed:
  property 'size' of memory-backend-file doesn't take value '0'
  
  Handle memory resize up to possible limit, including alignment.
  
  Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
  
- runtime: fix infinite loop at memory hotplug beyond max memory size
  If QEMU VM has virtio-mem and default_maxmemory == default_memory then loop in
  Sandbox.updateResources() never ends because "maxhotPluggableMemoryMB" is zero.
  
  Non virtio-mem setup ignores memory resize beyond maxmemory,
  virtio-mem should do the same.
  
  Signed-off-by: Konstantin Khlebnikov <koct9i@gmail.com>
  
