### PR TITLE
build: Fix compilation failure with Rust compiler version 1.80

### DIFF
--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
 
-#[cfg(any(target_arch = "s390x", target_arch = "powerpc64le"))]
+#[cfg(any(target_arch = "s390x", target_arch = "powerpc64"))]
 use nix::unistd::Uid;
 
 #[cfg(target_arch = "x86_64")]
@@ -234,7 +234,7 @@ pub fn available_guest_protection() -> Result<GuestProtection, ProtectionError> 
     Ok(GuestProtection::Se)
 }
 
-#[cfg(target_arch = "powerpc64le")]
+#[cfg(target_arch = "powerpc64")]
 pub fn available_guest_protection() -> Result<check::GuestProtection, check::ProtectionError> {
     if !Uid::effective().is_root() {
         return Err(check::ProtectionError::NoPerms);

--- a/src/tools/kata-ctl/src/arch/mod.rs
+++ b/src/tools/kata-ctl/src/arch/mod.rs
@@ -8,9 +8,9 @@ pub mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64 as arch_specific;
 
-#[cfg(target_arch = "powerpc64le")]
+#[cfg(all(target_arch = "powerpc64", target_endian = "little"))]
 pub mod powerpc64le;
-#[cfg(target_arch = "powerpc64le")]
+#[cfg(all(target_arch = "powerpc64", target_endian = "little"))]
 pub use powerpc64le as arch_specific;
 
 #[cfg(target_arch = "s390x")]

--- a/src/tools/kata-ctl/src/arch/powerpc64le/mod.rs
+++ b/src/tools/kata-ctl/src/arch/powerpc64le/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use crate::types::*;
-#[cfg(target_arch = "powerpc64le")]
+#[cfg(all(target_arch = "powerpc64", target_endian = "little"))]yyyyyy
 pub use arch_specific::*;
 
 mod arch_specific {


### PR DESCRIPTION
Starting with version 1.80, the Rust linter does not accept an invalid value for `target_arch` in configuration checks:

```
   Compiling kata-sys-util v0.1.0 (/home/ddd/Work/kata/kata-containers/src/libs/kata-sys-util)
error: unexpected `cfg` condition value: `powerpc64le`
  --> /home/ddd/Work/kata/kata-containers/src/libs/kata-sys-util/src/protection.rs:17:34
   |
17 | #[cfg(any(target_arch = "s390x", target_arch = "powerpc64le"))]
   |                                  ^^^^^^^^^^^^^^-------------
   |                                                |
   |                                                help: there is a expected value with a similar name: `"powerpc64"`
   |
   = note: expected values for `target_arch` are: `aarch64`, `arm`, `arm64ec`, `avr`, `bpf`, `csky`, `hexagon`, `loongarch64`, `m68k`, `mips`, `mips32r6`, `mips64`, `mips64r6`, `msp430`, `nvptx64`, `powerpc`, `powerpc64`, `riscv32`, `riscv64`, `s390x`, `sparc`, `sparc64`, `wasm32`, `wasm64`, `x86`, and `x86_64`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `-D unexpected-cfgs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unexpected_cfgs)]`
```

According [to GitHub user @Urgau][explain], this is a new warning introduced in Rust 1.80, but the problem exists before. The correct architecture name should be `powerpc64`, and the differentiation between `powerpc64le` and `powerpc64` should use the `target_endian = "little"` check.

[explain]: https://github.com/kata-containers/kata-containers/issues/10072#issuecomment-2251136045

Fixes: #10067
