### PR TITLE
tests: add image check before running coco tests

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -493,6 +493,22 @@ function cleanup_snapshotter() {
 	echo "::endgroup::"
 }
 
+# Check existing images to ensure all content is available locally before running tests
+function image_check() {
+	local ctr_args="sudo ctr "
+	if [[ " k3s rke2 " =~ " ${KUBERNETES} " ]]; then
+		ctr_args+="--address /run/k3s/containerd/containerd.sock "
+	fi
+	ctr_args+="--namespace k8s.io "
+	local incomplete_images=$($ctr_args image check | grep "incomplete" | awk '{print $1}')
+	if [ -z "$incomplete_images" ]; then
+		return
+	fi
+	for incomplete_image in $incomplete_images; do
+		$ctr_args content fetch $incomplete_image || true
+	done
+}
+
 function deploy_nydus_snapshotter() {
 	echo "::group::deploy_nydus_snapshotter"
 	ensure_yq
@@ -555,6 +571,10 @@ function deploy_nydus_snapshotter() {
 	echo "::endgroup::"
 	echo "::group::nydus snapshotter describe"
 	kubectl_retry describe pod --selector=app=nydus-snapshotter -n nydus-system
+	echo "::endgroup::"
+
+	echo "::group::image check"
+	image_check
 	echo "::endgroup::"
 }
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -322,7 +322,7 @@ externals:
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.13.13"
+    version: "v0.13.14"
 
   ovmf:
     description: "Firmware, implementation of UEFI for virtual machines."


### PR DESCRIPTION
Currently, there are some issues with pulling images in CI, such as : https://github.com/kata-containers/kata-containers/actions/runs/10109747602/job/27959198585

This issue is caused by switching between different snapshotters for the same image in some scenarios. To resolve it, we can check existing images to ensure all content is available locally before running tests.

We also have some patches (https://github.com/containerd/nydus-snapshotter/pull/605, https://github.com/containerd/nydus-snapshotter/pull/609) in the nydus snapshotter to stabilize our CI. 

Fixes: #10029