### PR TITLE
tests: k8s: minor policy tests clean-up

### DIFF
--- a/tests/integration/kubernetes/k8s-exec-rejected.bats
+++ b/tests/integration/kubernetes/k8s-exec-rejected.bats
@@ -9,7 +9,7 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	policy_tests_enabled || skip "Policy tests are disabled."
+	hard_coded_policy_tests_enabled || skip "Policy tests are disabled."
 
 	get_pod_config_dir
 	pod_name="policy-exec-rejected"
@@ -38,7 +38,7 @@ setup() {
 }
 
 teardown() {
-	policy_tests_enabled || skip "Policy tests are disabled."
+	hard_coded_policy_tests_enabled || skip "Policy tests are disabled."
 
 	# Debugging information
 	kubectl describe "pod/$pod_name"

--- a/tests/integration/kubernetes/k8s-policy-hard-coded.bats
+++ b/tests/integration/kubernetes/k8s-policy-hard-coded.bats
@@ -12,16 +12,16 @@ setup() {
 	hard_coded_policy_tests_enabled || skip "Policy tests are disabled."
 
 	get_pod_config_dir
-	pod_name="policy-exec-rejected"
-	pod_yaml="${pod_config_dir}/k8s-policy-exec-rejected.yaml"
-	allow_all_except_exec_policy=$(base64 -w 0 "${pod_config_dir}/allow-all-except-exec-process.rego")
+	pod_name="hard-coded-policy-pod"
+	pod_yaml="${pod_config_dir}/k8s-policy-hard-coded.yaml"
 }
 
 @test "Kubectl exec rejected by policy" {
 	# Add to the YAML file a policy that rejects ExecProcessRequest.
+	allow_all_except_exec_policy=$(base64 -w 0 "${pod_config_dir}/allow-all-except-exec-process.rego")
 	yq -i \
 		".metadata.annotations.\"io.katacontainers.config.agent.policy\" = \"${allow_all_except_exec_policy}\"" \
-  "${pod_yaml}"
+		"${pod_yaml}"
 
 	# Create the pod
 	kubectl create -f "${pod_yaml}"

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -64,7 +64,7 @@ wait_for_pod_ready() {
 
 @test "Able to read env variables sourced from configmap using envFrom" {
 	wait_for_pod_ready
-	expected_env_var=$(kubectl exec "${pod_name}" -- ${exec_command[@]})
+	expected_env_var=$(kubectl exec "${pod_name}" -- "${exec_command[@]}")
 	[ "$expected_env_var" = "value-3" ] || fail "expected_env_var is not equal to value-3"
 }
 

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -41,7 +41,6 @@ else
 		"k8s-empty-dirs.bats" \
 		"k8s-env.bats" \
 		"k8s-exec.bats" \
-		"k8s-exec-rejected.bats" \
 		"k8s-file-volume.bats" \
 		"k8s-inotify.bats" \
 		"k8s-job.bats" \
@@ -56,6 +55,7 @@ else
 		"k8s-optional-empty-secret.bats" \
 		"k8s-pid-ns.bats" \
 		"k8s-pod-quota.bats" \
+		"k8s-policy-hard-coded.bats" \
 		"k8s-policy-job.bats" \
 		"k8s-policy-pod.bats" \
 		"k8s-policy-pvc.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-hard-coded.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-hard-coded.yaml
@@ -6,7 +6,7 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  name: policy-exec-rejected
+  name: hard-coded-policy-pod
 spec:
   terminationGracePeriodSeconds: 0
   shareProcessNamespace: true

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -306,16 +306,18 @@ set_namespace_to_policy_settings() {
 	mv "${settings_dir}/new-genpolicy-settings.json" "${settings_dir}/genpolicy-settings.json"
 }
 
-policy_tests_enabled() {
-	# The Guest images for these platforms have been built using AGENT_POLICY=yes -
-	# see kata-deploy-binaries.sh.
+hard_coded_policy_tests_enabled() {
+	# CI is testing hard-coded policies just on a the platforms listed here. Outside of CI,
+	# users can enable testing of the same policies (plus the auto-generated policies) by
+	# specifying AUTO_GENERATE_POLICY=yes.
 	local enabled_hypervisors="qemu-coco-dev qemu-sev qemu-snp qemu-tdx"
 	[[ " $enabled_hypervisors " =~ " ${KATA_HYPERVISOR} " ]] || \
-		[ "${KATA_HOST_OS}" == "cbl-mariner" ]
+		[ "${KATA_HOST_OS}" == "cbl-mariner" ] || \
+		auto_generate_policy_enabled
 }
 
 add_allow_all_policy_to_yaml() {
-	policy_tests_enabled || return 0
+	hard_coded_policy_tests_enabled || return 0
 
 	local yaml_file="$1"
 	# Previous version of yq was not ready to handle multiple objects in a single yaml.


### PR DESCRIPTION
1. Avoid potential word splitting in k8s-policy-pod.bats.
2. Allow the users of AUTO_GENERATE_POLICY=yes to easily execute the hard-coded policy tests on any platform.
3. Rename k8s-exec-rejected.bats to k8s-policy-hard-coded.bats, thus getting ready to test in the future additional types of hard-coded policies by using the same test script.
