### PR TITLE
ci: Run post action script on AMD SEV/SNP nodes

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -154,6 +154,13 @@ jobs:
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
 
+      - name: Take a post-action
+        if: always()
+        run:
+          if [ -f ${HOME}/script/post_action.sh ]; then
+            ${HOME}/script/post_action.sh sev
+          fi
+
   run-k8s-tests-sev-snp:
     strategy:
       fail-fast: false
@@ -228,6 +235,13 @@ jobs:
       - name: Delete CoCo KBS
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh delete-coco-kbs
+
+      - name: Take a post-action
+        if: always()
+        run:
+          if [ -f ${HOME}/script/post_action.sh ]; then
+            ${HOME}/script/post_action.sh sev-snp
+          fi
 
   # Generate jobs for testing CoCo on non-TEE environments
   run-k8s-tests-coco-nontee:


### PR DESCRIPTION
ci: Fixes Issue #10085
Currently, the CI does not have the capability to run a post action script on the self-hosted runners.
This feature would greatly simplify debugging and clean-up to stabilize the nodes after a test run.