### PR TITLE
ci: DEBUG=1 support in install_libseccomp.sh

### DIFF
--- a/ci/install_libseccomp.sh
+++ b/ci/install_libseccomp.sh
@@ -7,6 +7,8 @@
 
 set -o errexit
 
+[ -n "${DEBUG:-}" ] && set -o xtrace
+
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 script_name="$(basename "${BASH_SOURCE[0]}")"
 


### PR DESCRIPTION
Add DEBUG=1 support in install_libseccomp.sh, for easier debugging of this script.