### PR TITLE
runtime-rs: bugfix for non-filtered dev-vfio-vfio

### DIFF
--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -336,7 +336,7 @@ impl ResourceManagerInner {
                     let host_path = get_host_path(DEVICE_TYPE_CHAR, d.major(), d.minor())
                         .context("get host path failed")?;
                     // First of all, filter vfio devices.
-                    if !host_path.starts_with("/dev/vfio") {
+                    if !host_path.starts_with("/dev/vfio") || host_path == "/dev/vfio/vfio" {
                         continue;
                     }
 


### PR DESCRIPTION
The kata will fail when running vfio device passthrough with /dev/vfio/vfio which is not filtered.
We need to enhance the filtering criteria in order to make passthrough fine.

Fixes: #10094