### PR TITLE
gha: Eradicate {pre,post}-action steps for s390x runners

### DIFF
--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -40,9 +40,6 @@ jobs:
           - shim-v2
           - virtiofsd
     steps:
-      - name: Take a pre-action for self-hosted runner
-        run: ${HOME}/script/pre_action.sh ubuntu-2204
-
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
         uses: docker/login-action@v3
@@ -91,9 +88,6 @@ jobs:
     runs-on: s390x
     needs: build-asset
     steps:
-      - name: Take a pre-action for self-hosted runner
-        run: ${HOME}/script/pre_action.sh ubuntu-2204
-
       - uses: actions/checkout@v4
 
       - name: get-artifacts
@@ -136,9 +130,6 @@ jobs:
     runs-on: s390x
     needs: [build-asset, build-asset-boot-image-se]
     steps:
-      - name: Take a pre-action for self-hosted runner
-        run: ${HOME}/script/pre_action.sh ubuntu-2204
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}

--- a/.github/workflows/publish-kata-deploy-payload-s390x.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-s390x.yaml
@@ -26,9 +26,6 @@ jobs:
   kata-payload:
     runs-on: s390x
     steps:
-      - name: Take a pre-action for self-hosted runner
-        run: ${HOME}/script/pre_action.sh ubuntu-2204
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -18,9 +18,6 @@ jobs:
     needs: build-kata-static-tarball-s390x
     runs-on: s390x
     steps:
-      - name: Take a pre-action for self-hosted runner
-        run: ${HOME}/script/pre_action.sh ubuntu-2204
-
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/run-cri-containerd-tests-s390x.yaml
+++ b/.github/workflows/run-cri-containerd-tests-s390x.yaml
@@ -29,9 +29,6 @@ jobs:
       GOPATH: ${{ github.workspace }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
     steps:
-      - name: Take a pre-action for self-hosted runner
-        run: ${HOME}/script/pre_action.sh ubuntu-2204
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}
@@ -57,7 +54,3 @@ jobs:
 
       - name: Run cri-containerd tests
         run: bash tests/integration/cri-containerd/gha-run.sh run
-
-      - name: Take a post-action for self-hosted runner
-        if: always()
-        run: ${HOME}/script/post_action.sh ubuntu-2204

--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -60,10 +60,6 @@ jobs:
       AUTHENTICATED_IMAGE_USER: ${{ secrets.AUTHENTICATED_IMAGE_USER }}
       AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
     steps:
-      - name: Take a pre-action for self-hosted runner
-        run: |
-          "${HOME}/script/pre_action.sh" ubuntu-2204
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}
@@ -88,9 +84,3 @@ jobs:
       - name: Run tests
         timeout-minutes: 60
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
-
-      - name: Take a post-action
-        if: always()
-        run: |
-          bash tests/integration/kubernetes/gha-run.sh cleanup-zvsi || true
-          "${HOME}/script/post_action.sh" ubuntu-2204


### PR DESCRIPTION
As suggested in #9934, the following hooks have been introduced for s390x runners:

- ACTIONS_RUNNER_HOOK_JOB_STARTED
- ACTIONS_RUNNER_HOOK_JOB_COMPLETED

These hooks will perfectly replace the existing {pre,post}-action scripts. This commit wipes out all GHA steps for s390x where the actions are triggered.

Verification result: https://github.com/BbolroC/kata-containers/actions/runs/10163515657

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>