### PR TITLE
metrics: Update memory tests to use grep -F

### DIFF
--- a/tests/metrics/density/fast_footprint.sh
+++ b/tests/metrics/density/fast_footprint.sh
@@ -179,7 +179,7 @@ EOF
 function grab_slab() {
 	# Grabbing slab total from meminfo is easier than doing the math
 	# on slabinfo
-	item=$(fgrep "Slab:" /proc/meminfo | awk '{print $2}')
+	item=$(grep -F "Slab:" /proc/meminfo | awk '{print $2}')
 	((item*=1024))
 
 	local json="$(cat << EOF
@@ -213,7 +213,7 @@ function grab_system() {
 	local free_decr=$((base_mem_free-item))
 
 	# Anon pages
-	local anon=$(fgrep "AnonPages:" /proc/meminfo | awk '{print $2}')
+	local anon=$(grep -F "AnonPages:" /proc/meminfo | awk '{print $2}')
 	((anon*=1024))
 
 	# Mapped pages

--- a/tests/metrics/density/footprint_data.sh
+++ b/tests/metrics/density/footprint_data.sh
@@ -163,7 +163,7 @@ EOF
 function grab_slab() {
 	# Grabbing slab total from meminfo is easier than doing the math
 	# on slabinfo
-	item=$(fgrep "Slab:" /proc/meminfo | awk '{print $2}')
+	item=$(grep -F "Slab:" /proc/meminfo | awk '{print $2}')
 	((item*=1024))
 
 	local json="$(cat << EOF
@@ -196,7 +196,7 @@ function grab_system() {
 	local free_decr=$((base_mem_free-item))
 
 	# Anon pages
-	local anon=$(fgrep "AnonPages:" /proc/meminfo | awk '{print $2}')
+	local anon=$(grep -F "AnonPages:" /proc/meminfo | awk '{print $2}')
 	((anon*=1024))
 
 	# Mapped pages


### PR DESCRIPTION
This PR updates the memory tests like fast footprint to use grep -F instead of fgrep as this command has been deprecated.