### PR TITLE
ci: Fix rate limit error by migrating busybox_image

### DIFF
--- a/tests/integration/kubernetes/k8s-nginx-connectivity.bats
+++ b/tests/integration/kubernetes/k8s-nginx-connectivity.bats
@@ -11,7 +11,7 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 setup() {
 	nginx_version="${docker_images_nginx_version}"
 	nginx_image="nginx:$nginx_version"
-	busybox_image="busybox"
+	busybox_image="quay.io/prometheus/busybox:latest"
 	deployment="nginx-deployment"
 
 	get_pod_config_dir


### PR DESCRIPTION
Fixes Issue https://github.com/kata-containers/kata-containers/issues/10100

Changing the busybox_image from docker to quay to fix rate limit errors on k8s-nginx-connectivity.bats