### PR TITLE
tests: Fix error with `kubectl debug`

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -111,7 +111,7 @@ exec_host() {
 	# [bats-exec-test:38] INFO: k8s configured to use runtimeclass
 	# bash: line 1: $'\r': command not found
 	# ```
-	output="$(kubectl debug -qit "node/${node}" --image=ghcr.io/linuxcontainers/alpine:latest -- chroot /host bash -c "${command}" | tr -d '\r')"
+	output="$(kubectl debug -qi "node/${node}" --image=ghcr.io/linuxcontainers/alpine:latest -- chroot /host bash -c "${command}" | tr -d '\r')"
 
 	# Get the updated list of debugger pods.
 	declare -a new_debugger_pods=( $(kubectl get pods -o name | grep node-debugger) )


### PR DESCRIPTION
The issue is similar to #10011.

The root cause is that tty and stderr are set to true at same time in containerd: #10031.

Fixes: #10081