### PR TITLE
gha: Restore cleanup-zvsi for s390x

### DIFF
--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -84,3 +84,7 @@ jobs:
       - name: Run tests
         timeout-minutes: 60
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
+
+      - name: Delete kata-deploy
+        if: always()
+        run: bash tests/integration/kubernetes/gha-run.sh cleanup-zvsi


### PR DESCRIPTION
In #10096, a cleanup step for kata-deploy is removed by mistake. This leads to a cleanup error in the following `Complete job` step.

This PR restores the removed step to resolve the current CI failure on s390x.

FYI: The error is being handled by a script triggered by ACTIONS_RUNNER_HOOK_JOB_COMPLETED.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>