### PR TITLE
version: bump trustee version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -232,9 +232,9 @@ externals:
   coco-trustee:
     description: "Provides attestation and secret delivery components"
     url: "https://github.com/confidential-containers/trustee"
-    version: "e890fc90c384207668fa3a4d6a2f2a2d652797ee"
+    version: "4a83e3b99ceb7cb6e8ce523d2ca1762eec7b7239"
     image: "ghcr.io/confidential-containers/staged-images/kbs"
-    image_tag: "e890fc90c384207668fa3a4d6a2f2a2d652797ee"
+    image_tag: "4a83e3b99ceb7cb6e8ce523d2ca1762eec7b7239"
     toolchain: "1.74.0"
 
   crio:


### PR DESCRIPTION
Bump trustee to the latest to fix error with pulling busybox from dockerhub.

related PR in trustee: https://github.com/confidential-containers/trustee/pull/452

Fixes: #10109