### PR TITLE
ci: Temporarily remove arm64 builds

### DIFF
--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -17,13 +17,13 @@ jobs:
       target-branch: ${{ github.ref_name }}
     secrets: inherit
 
-  build-assets-arm64:
-    uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
-    with:
-      commit-hash: ${{ github.sha }}
-      push-to-registry: yes
-      target-branch: ${{ github.ref_name }}
-    secrets: inherit
+      #  build-assets-arm64:
+      #    uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
+      #    with:
+      #      commit-hash: ${{ github.sha }}
+      #      push-to-registry: yes
+      #      target-branch: ${{ github.ref_name }}
+      #    secrets: inherit
 
   build-assets-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -52,16 +52,16 @@ jobs:
       target-branch: ${{ github.ref_name }}
     secrets: inherit
 
-  publish-kata-deploy-payload-arm64:
-    needs: build-assets-arm64
-    uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
-    with:
-      commit-hash: ${{ github.sha }}
-      registry: quay.io
-      repo: kata-containers/kata-deploy-ci
-      tag: kata-containers-latest-arm64
-      target-branch: ${{ github.ref_name }}
-    secrets: inherit
+      #  publish-kata-deploy-payload-arm64:
+      #    needs: build-assets-arm64
+      #    uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
+      #    with:
+      #      commit-hash: ${{ github.sha }}
+      #      registry: quay.io
+      #      repo: kata-containers/kata-deploy-ci
+      #      tag: kata-containers-latest-arm64
+      #      target-branch: ${{ github.ref_name }}
+      #    secrets: inherit
 
   publish-kata-deploy-payload-s390x:
     needs: build-assets-s390x
@@ -87,7 +87,8 @@ jobs:
 
   publish-manifest:
     runs-on: ubuntu-latest
-    needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-arm64, publish-kata-deploy-payload-s390x, publish-kata-deploy-payload-ppc64le]
+      #      needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-arm64, publish-kata-deploy-payload-s390x, publish-kata-deploy-payload-ppc64le]
+    needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-s390x, publish-kata-deploy-payload-ppc64le]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -142,7 +142,7 @@ function _publish_multiarch_manifest()
 		for tag in ${IMAGE_TAGS[@]}; do
 			docker manifest create ${registry}:${tag} \
 				--amend ${registry}:${tag}-amd64 \
-				--amend ${registry}:${tag}-arm64 \
+	#			--amend ${registry}:${tag}-arm64 \
 				--amend ${registry}:${tag}-s390x \
 				--amend ${registry}:${tag}-ppc64le
 


### PR DESCRIPTION
It's been a reasonable time that we're not able to even build arm64 artefacts.

For now I am removing the builds as it doesn't make sense to keep running failing builds, and those can be re-enabled once we have arm64 machines plugged in that can be used for building the stuff, and maintainers for those machines.

The `arm-jetson-xavier-nx-01` is also being removed from the runners.

Looped in @ananos  and @zvonkok  to make them aware of the situation.