### PR TITLE
qemu: don't emit scsi parameter

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -820,7 +820,6 @@ impl ToQemuParams for BlockBackend {
 struct DeviceVirtioBlk {
     bus_type: VirtioBusType,
     id: String,
-    scsi: bool,
     config_wce: bool,
     share_rw: bool,
 }
@@ -830,16 +829,9 @@ impl DeviceVirtioBlk {
         DeviceVirtioBlk {
             bus_type,
             id: id.to_owned(),
-            scsi: false,
             config_wce: false,
             share_rw: true,
         }
-    }
-
-    #[allow(dead_code)]
-    fn set_scsi(&mut self, scsi: bool) -> &mut Self {
-        self.scsi = scsi;
-        self
     }
 
     #[allow(dead_code)]
@@ -861,11 +853,6 @@ impl ToQemuParams for DeviceVirtioBlk {
         let mut params = Vec::new();
         params.push(format!("virtio-blk-{}", self.bus_type));
         params.push(format!("drive=image-{}", self.id));
-        if self.scsi {
-            params.push("scsi=on".to_owned());
-        } else {
-            params.push("scsi=off".to_owned());
-        }
         if self.config_wce {
             params.push("config-wce=on".to_owned());
         } else {

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -1298,10 +1298,6 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 		deviceParams = append(deviceParams, s)
 	}
 	deviceParams = append(deviceParams, fmt.Sprintf("drive=%s", blkdev.ID))
-	if !blkdev.SCSI {
-		deviceParams = append(deviceParams, "scsi=off")
-	}
-
 	if !blkdev.WCE {
 		deviceParams = append(deviceParams, "config-wce=off")
 	}

--- a/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
@@ -25,7 +25,7 @@ var (
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0,disable-modern=true,iothread=iothread1,romfile=efi-virtio.rom"
 	deviceVhostUserSCSIString      = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -device vhost-user-scsi-pci,id=scsi1,chardev=char1,romfile=efi-virtio.rom"
 	deviceVhostUserBlkString       = "-chardev socket,id=char2,path=/tmp/nonexistentsocket.socket -device vhost-user-blk-pci,logical_block_size=4096,size=512M,chardev=char2,romfile=efi-virtio.rom"
-	deviceBlockString              = "-device virtio-blk-pci,disable-modern=true,drive=hd0,scsi=off,config-wce=off,romfile=efi-virtio.rom,share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly=on"
+	deviceBlockString              = "-device virtio-blk-pci,disable-modern=true,drive=hd0,config-wce=off,romfile=efi-virtio.rom,share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly=on"
 	devicePCIBridgeString          = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=on,addr=ff,romfile=efi-virtio.rom"
 	devicePCIBridgeStringReserved  = "-device pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,chassis_nr=5,shpc=off,addr=ff,romfile=efi-virtio.rom,io-reserve=4k,mem-reserve=1m,pref64-reserve=1m"
 	devicePCIEBridgeString         = "-device pcie-pci-bridge,bus=/pci-bus/pcie.0,id=mybridge,addr=ff,romfile=efi-virtio.rom"

--- a/src/runtime/pkg/govmm/qemu/qemu_s390x_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_s390x_test.go
@@ -19,7 +19,7 @@ var (
 	deviceVFIOString               = "-device vfio-ccw,host=02:10.0,devno=" + DevNo
 	deviceSCSIControllerStr        = "-device virtio-scsi-ccw,id=foo,devno=" + DevNo
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-ccw,id=foo,bus=pci.0,addr=00:04.0,iothread=iothread1,devno=" + DevNo
-	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,scsi=off,config-wce=off,devno=" + DevNo + ",share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly=on"
+	deviceBlockString              = "-device virtio-blk-ccw,drive=hd0,config-wce=off,devno=" + DevNo + ",share-rw=on,serial=hd0 -drive id=hd0,file=/var/lib/vm.img,aio=threads,format=qcow2,if=none,readonly=on"
 	romfile                        = ""
 )
 

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -281,7 +281,6 @@ func TestAppendDeviceBlock(t *testing.T) {
 		AIO:           Threads,
 		Format:        QCOW2,
 		Interface:     NoInterface,
-		SCSI:          false,
 		WCE:           false,
 		DisableModern: true,
 		ROMFile:       romfile,


### PR DESCRIPTION
This parameter has been deprecated for a long time and QEMU 9.1.0 finally removes it.

Fixes: #10112