### PR TITLE
kata-manager: Ensure distro specific TDX config is set

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -833,6 +833,34 @@ install_kata()
 		sudo ln -sf "$from_path" "$link_dir"
 	done
 
+	local tdx_qemu_config="/opt/kata/share/defaults/kata-containers/configuration-qemu-tdx.toml"
+	local tdx_qemu_path_from_distro="NOT_SUPPORTED"
+	local tdx_ovmf_path_from_distro="NOT_SUPPORTED"
+	if [ -e $tdx_qemu_config ]; then
+		source /etc/os-release || source /usr/lib/os-release
+		case $ID in
+			ubuntu)
+				case $VERSION_ID in
+					24.04)
+						tdx_qemu_path_from_distro="/usr/bin/qemu-system-x86_64"
+						tdx_ovmf_path_from_distro="/usr/share/ovmf/OVMF.fd"
+						;;
+				esac
+				;;
+			centos)
+				case $VERSION_ID in
+					9)
+						tdx_qemu_path_from_distro="/usr/libexec/qemu-kvm"
+						tdx_ovmf_path_from_distro="/usr/share/edk2/ovmf/OVMF.inteltdx.fd"
+						;;
+				esac
+				;;
+		esac
+
+		sudo sed -i -e "s|PLACEHOLDER_FOR_DISTRO_QEMU_WITH_TDX_SUPPORT|$tdx_qemu_path_from_distro|g" $tdx_qemu_config
+		sudo sed -i -e "s|PLACEHOLDER_FOR_DISTRO_OVMF_WITH_TDX_SUPPORT|$tdx_ovmf_path_from_distro|g" $tdx_qemu_config
+	fi
+
 	info "$project installed\n"
 }
 


### PR DESCRIPTION
We've done something quite similar for kata-deploy, but I've noticed we forgot about the kata-manager counterpart.

Here you can find results (and how to test) without the patch and with the patch:
* without: https://gist.github.com/fidencio/b95fa4ea34e8f10e18dde4eabf18327d
* with: https://gist.github.com/fidencio/368211840813afe6ae41df60264e4f07

@GabyCT, @cmaf, @dborquez, could you give it a try on your TDX machines?