### PR TITLE
tests: kbs: Add missing dependencies to install kbs cli

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -164,7 +164,7 @@ kbs_install_cli() {
 	source /etc/os-release || source /usr/lib/os-release
 	case "${ID}" in
 		ubuntu)
-			local pkgs="build-essential"
+			local pkgs="build-essential pkg-config libssl-dev"
 
 			sudo apt-get update -y
 			# shellcheck disable=2086


### PR DESCRIPTION
This PR adds missing packages depenencies to install kbs cli in a fresh new baremetal environment. This will avoid to have a failure when trying to run install-kbs-client.