### PR TITLE
ci: Temporarily remove arm64 builds -- part II

### DIFF
--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -142,7 +142,6 @@ function _publish_multiarch_manifest()
 		for tag in ${IMAGE_TAGS[@]}; do
 			docker manifest create ${registry}:${tag} \
 				--amend ${registry}:${tag}-amd64 \
-	#			--amend ${registry}:${tag}-arm64 \
 				--amend ${registry}:${tag}-s390x \
 				--amend ${registry}:${tag}-ppc64le
 


### PR DESCRIPTION
Let's remove what we commented out, as publish manifest complains:
```
Created manifest list quay.io/kata-containers/kata-deploy-ci:kata-containers-latest
./tools/packaging/release/release.sh: line 146: --amend: command not found
```