### PR TITLE
genpolicy: add --version flag

### DIFF
--- a/src/tools/genpolicy/.gitignore
+++ b/src/tools/genpolicy/.gitignore
@@ -1,0 +1,1 @@
+src/version.rs

--- a/src/tools/genpolicy/Cargo.toml
+++ b/src/tools/genpolicy/Cargo.toml
@@ -8,6 +8,7 @@ name = "genpolicy"
 version = "0.1.0"
 authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
 edition = "2021"
+license = "Apache-2.0"
 
 [dependencies]
 # Logging.

--- a/src/tools/genpolicy/Makefile
+++ b/src/tools/genpolicy/Makefile
@@ -1,4 +1,5 @@
 # Copyright (c) 2020 Intel Corporation
+# Portions Copyright (c) Microsoft Corporation.
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -9,10 +10,24 @@ ifeq ($(ARCH), ppc64le)
      override ARCH = powerpc64le
  endif
 
+COMMIT_HASH := $(shell git rev-parse HEAD 2>/dev/null || true)
+# appends '-dirty' to the commit hash if there are uncommitted changes
+COMMIT_INFO := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_HASH}-dirty,${COMMIT_HASH})
+
+GENERATED_CODE = src/version.rs
+
+GENERATED_REPLACEMENTS= COMMIT_INFO
+GENERATED_FILES :=
+
+GENERATED_FILES += $(GENERATED_CODE)
+
+$(GENERATED_FILES): %: %.in
+	sed $(foreach r,$(GENERATED_REPLACEMENTS),-e 's|@$r@|$($r)|g') "$<" > "$@"
+
 .DEFAULT_GOAL := default
 default: build
 
-build:
+build: $(GENERATED_FILES)
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE)
 
 static-checks-build:
@@ -20,16 +35,17 @@ static-checks-build:
 
 clean:
 	cargo clean
+	rm -f $(GENERATED_FILES)
 
 vendor:
 	cargo vendor
 
 test:
 
-install:
+install: $(GENERATED_FILES)
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --locked --target $(TRIPLE) --path .
 
-check: standard_rust_check
+check:  $(GENERATED_CODE) standard_rust_check
 
 .PHONY: \
 	build \

--- a/src/tools/genpolicy/src/main.rs
+++ b/src/tools/genpolicy/src/main.rs
@@ -27,6 +27,7 @@ mod settings;
 mod stateful_set;
 mod utils;
 mod verity;
+mod version;
 mod volume;
 mod yaml;
 
@@ -34,6 +35,16 @@ mod yaml;
 async fn main() {
     env_logger::init();
     let config = utils::Config::new();
+
+    if config.version {
+        println!(
+            "Kata Containers policy tool (Rust): id: {}, version: {}, commit: {}",
+            env!("CARGO_PKG_NAME"),
+            env!("CARGO_PKG_VERSION"),
+            version::COMMIT_INFO
+        );
+        return;
+    }
 
     debug!("Creating policy from yaml, settings, and rules.rego files...");
     let mut policy = policy::AgentPolicy::from_files(&config).await.unwrap();

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -96,6 +96,8 @@ struct CommandLineOptions {
         require_equals = true
     )]
     layers_cache_file_path: Option<String>,
+    #[clap(short, long, help = "Print version information and exit")]
+    version: bool,
 }
 
 /// Application configuration, derived from on command line parameters.
@@ -115,6 +117,7 @@ pub struct Config {
     pub base64_out: bool,
     pub containerd_socket_path: Option<String>,
     pub layers_cache_file_path: Option<String>,
+    pub version: bool,
 }
 
 impl Config {
@@ -153,6 +156,7 @@ impl Config {
             base64_out: args.base64_out,
             containerd_socket_path: args.containerd_socket_path,
             layers_cache_file_path,
+            version: args.version,
         }
     }
 }

--- a/src/tools/genpolicy/src/version.rs.in
+++ b/src/tools/genpolicy/src/version.rs.in
@@ -1,0 +1,12 @@
+// Copyright (c) 2020 Intel Corporation
+// Portions Copyright (c) Microsoft Corporation.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//
+// WARNING: This file is auto-generated - DO NOT EDIT!
+//
+
+#![allow(dead_code)]
+pub const COMMIT_INFO: &str = "@COMMIT_INFO@";


### PR DESCRIPTION
- Add --version flag to the genpolicy tool that prints the current version
- Add version.rs.in template to store the version information
- Update makefile to autogenerate version.rs from version.rs.in
- Add license to Cargo.toml

This follows a [similar patter used in the agent](https://github.com/kata-containers/kata-containers/blob/main/src/agent/src/main.rs#L332)

Cherry pick from https://github.com/microsoft/kata-containers/pull/176