### PR TITLE
ci: re-enable arm CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,6 +36,25 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
     secrets: inherit
 
+  build-kata-static-tarball-arm64:
+    uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
+
+  publish-kata-deploy-payload-arm64:
+    needs: build-kata-static-tarball-arm64
+    uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
+    with:
+      tarball-suffix: -${{ inputs.tag }}
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-arm64
+      commit-hash: ${{ inputs.commit-hash }}
+      target-branch: ${{ inputs.target-branch }}
+    secrets: inherit
+
   build-kata-static-tarball-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -17,13 +17,13 @@ jobs:
       target-branch: ${{ github.ref_name }}
     secrets: inherit
 
-      #  build-assets-arm64:
-      #    uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
-      #    with:
-      #      commit-hash: ${{ github.sha }}
-      #      push-to-registry: yes
-      #      target-branch: ${{ github.ref_name }}
-      #    secrets: inherit
+  build-assets-arm64:
+    uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
+    with:
+      commit-hash: ${{ github.sha }}
+      push-to-registry: yes
+      target-branch: ${{ github.ref_name }}
+    secrets: inherit
 
   build-assets-s390x:
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -52,16 +52,16 @@ jobs:
       target-branch: ${{ github.ref_name }}
     secrets: inherit
 
-      #  publish-kata-deploy-payload-arm64:
-      #    needs: build-assets-arm64
-      #    uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
-      #    with:
-      #      commit-hash: ${{ github.sha }}
-      #      registry: quay.io
-      #      repo: kata-containers/kata-deploy-ci
-      #      tag: kata-containers-latest-arm64
-      #      target-branch: ${{ github.ref_name }}
-      #    secrets: inherit
+  publish-kata-deploy-payload-arm64:
+    needs: build-assets-arm64
+    uses: ./.github/workflows/publish-kata-deploy-payload-arm64.yaml
+    with:
+      commit-hash: ${{ github.sha }}
+      registry: quay.io
+      repo: kata-containers/kata-deploy-ci
+      tag: kata-containers-latest-arm64
+      target-branch: ${{ github.ref_name }}
+    secrets: inherit
 
   publish-kata-deploy-payload-s390x:
     needs: build-assets-s390x
@@ -87,8 +87,7 @@ jobs:
 
   publish-manifest:
     runs-on: ubuntu-latest
-      #      needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-arm64, publish-kata-deploy-payload-s390x, publish-kata-deploy-payload-ppc64le]
-    needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-s390x, publish-kata-deploy-payload-ppc64le]
+    needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-arm64, publish-kata-deploy-payload-s390x, publish-kata-deploy-payload-ppc64le]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -142,7 +142,7 @@ function _publish_multiarch_manifest()
 		for tag in ${IMAGE_TAGS[@]}; do
 			docker manifest create ${registry}:${tag} \
 				--amend ${registry}:${tag}-amd64 \
-	#			--amend ${registry}:${tag}-arm64 \
+				--amend ${registry}:${tag}-arm64 \
 				--amend ${registry}:${tag}-s390x \
 				--amend ${registry}:${tag}-ppc64le
 

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -142,6 +142,7 @@ function _publish_multiarch_manifest()
 		for tag in ${IMAGE_TAGS[@]}; do
 			docker manifest create ${registry}:${tag} \
 				--amend ${registry}:${tag}-amd64 \
+	#			--amend ${registry}:${tag}-arm64 \
 				--amend ${registry}:${tag}-s390x \
 				--amend ${registry}:${tag}-ppc64le
 


### PR DESCRIPTION
We're basically reverting c5dad991cecdeb3a3fe404694c636fc1ce1a282e and e9710332e74bca35a28f432bd4c9af1c353d5eb1, and enabling the builders to run on `pull_request_event`, avoiding then future breakages as those would be caught before content gets merged.

Right now 2 VMs have been added to the CI as builders (with 2 more to be added), and I'm assuming @ananos and @zvonkok will be the maintainers of those.