### PR TITLE
ci: Enable encrypted image tests for TEEs

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image-encrypted.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-encrypted.bats
@@ -11,10 +11,6 @@ load "${BATS_TEST_DIRNAME}/confidential_kbs.sh"
 export KBS="${KBS:-false}"
 
 setup() {
-    if is_confidential_hardware; then
-        skip "Due to issues related to pull-image integration skip tests for ${KATA_HYPERVISOR}."
-    fi
-
     if ! is_confidential_runtime_class; then
         skip "Test not supported for ${KATA_HYPERVISOR}."
     fi
@@ -114,10 +110,6 @@ function create_pod_yaml_with_encrypted_image() {
 }
 
 teardown() {
-    if is_confidential_hardware; then
-        skip "Due to issues related to pull-image integration skip tests for ${KATA_HYPERVISOR}."
-    fi
-
     if ! is_confidential_runtime_class; then
         skip "Test not supported for ${KATA_HYPERVISOR}."
     fi


### PR DESCRIPTION
After experimenting a little bit with those tests, they seem to be passing on all the available TEE machines.

With this in mind, let's just enable them for those machines.