### PR TITLE
runtime: cleanup removed container when create failed

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1596,6 +1596,11 @@ func (s *Sandbox) CreateContainer(ctx context.Context, contConfig ContainerConfi
 
 			logger.Debug("Removing stopped container from sandbox store")
 			s.removeContainer(c.id)
+			// flush data to storage, cleanup removed container
+			// here can ignore the error
+			if errSave := s.Save(); errSave != nil {
+				logger.WithError(errSave).Warn("Failed to save sanbox to persist.json")
+			}
 		}
 	}()
 


### PR DESCRIPTION
In some scenarios, the container in the stopped state needs to be restarted in place. The residual data generated by restore may cause the startup to fail, such as ContainerDevices.