### PR TITLE
tests:k8s: Update image in kubectl debug for the exec host function

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 #
 # Copyright (c) 2021 Red Hat, Inc.
 #
@@ -111,7 +112,7 @@ exec_host() {
 	# [bats-exec-test:38] INFO: k8s configured to use runtimeclass
 	# bash: line 1: $'\r': command not found
 	# ```
-	output="$(kubectl debug -qi "node/${node}" --image=ghcr.io/linuxcontainers/alpine:latest -- chroot /host bash -c "${command}" | tr -d '\r')"
+	output="$(kubectl debug -qi "node/${node}" --image=quay.io/bedrock/ubuntu:latest -- chroot /host bash -c "${command}" | tr -d '\r')"
 
 	# Get the updated list of debugger pods.
 	declare -a new_debugger_pods=( $(kubectl get pods -o name | grep node-debugger) )


### PR DESCRIPTION
This PR updates the image that we are using in the kubectl debug command as part of the exec host function, as the current alpine image does not allow to create a temporary file for example and creates random kubernetes failures.