### PR TITLE
tools: Support for building qemu with linux aio

### DIFF
--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -356,11 +356,6 @@ generate_qemu_options() {
 	# Disable XEN driver
 	qemu_options+=(size:--disable-xen)
 
-	# FIXME: why is this disabled?
-	# (for reference, it's explicitly enabled in Ubuntu 17.10 and
-	# implicitly enabled in Fedora 27).
-	qemu_options+=(size:--disable-linux-aio)
-
 	# Disable Capstone
 	qemu_options+=(size:--disable-capstone)
 
@@ -411,6 +406,9 @@ generate_qemu_options() {
 
 	# Required for fast network access
 	qemu_options+=(speed:--enable-vhost-net)
+
+	# Support Linux AIO (native)
+	qemu_options+=(size:--enable-linux-aio)
 
 	# Support Ceph RADOS Block Device (RBD)
 	[ -z "${static}" ] && qemu_options+=(functionality:--enable-rbd)

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get upgrade -y && \
 	    dpkg-dev \
 	    flex \
 	    gawk \
+	    libaio-dev${DPKG_ARCH} \
 	    libaudit-dev${DPKG_ARCH} \
 	    libblkid-dev${DPKG_ARCH} \
 	    libcap-dev${DPKG_ARCH} \


### PR DESCRIPTION
The kata containers hypervisior qemu configuration supports setting `block_device_aio="native"`, but the kata static build of qemu does not add the linux aio feature.

The `libaio-dev` library is a necessary dependency for building qemu with linux aio.

Fixes: #10130 