### PR TITLE
genpolicy: add bind mounts for image volumes

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -189,6 +189,18 @@
                 "rprivate",
                 "ro"
             ]
+        },
+        "image_volume": {
+            "mount_type": "bind",
+            "mount_source": "$(sfprefix)",
+            "driver": "local",
+            "source": "local",
+            "fstype": "bind",
+            "options": [
+                "rbind",
+                "rprivate",
+                "rw"
+            ]
         }
     },
     "mount_destinations": [

--- a/src/tools/genpolicy/src/cronjob.rs
+++ b/src/tools/genpolicy/src/cronjob.rs
@@ -94,15 +94,13 @@ impl yaml::K8sResource for CronJob {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.jobTemplate.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            container,
+            settings,
+            &self.spec.jobTemplate.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/daemon_set.rs
+++ b/src/tools/genpolicy/src/daemon_set.rs
@@ -96,15 +96,13 @@ impl yaml::K8sResource for DaemonSet {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                container,
-                settings,
-                volumes,
-            )
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/deployment.rs
+++ b/src/tools/genpolicy/src/deployment.rs
@@ -94,15 +94,13 @@ impl yaml::K8sResource for Deployment {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/job.rs
+++ b/src/tools/genpolicy/src/job.rs
@@ -68,15 +68,13 @@ impl yaml::K8sResource for Job {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -842,15 +842,13 @@ impl yaml::K8sResource for Pod {
         container: &Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            container,
+            settings,
+            &self.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/registry_containerd.rs
+++ b/src/tools/genpolicy/src/registry_containerd.rs
@@ -46,7 +46,8 @@ impl Container {
         let ctrd_client = containerd_client::Client::from(containerd_channel.clone());
         let k8_cri_image_client = ImageServiceClient::new(containerd_channel);
 
-        let image_ref: Reference = image.to_string().parse().unwrap();
+        let image_str = image.to_string();
+        let image_ref: Reference = image_str.parse().unwrap();
 
         info!("Pulling image: {:?}", image_ref);
 
@@ -67,6 +68,7 @@ impl Container {
         .await?;
 
         Ok(Container {
+            image: image_str,
             config_layer,
             image_layers,
         })

--- a/src/tools/genpolicy/src/replica_set.rs
+++ b/src/tools/genpolicy/src/replica_set.rs
@@ -66,15 +66,13 @@ impl yaml::K8sResource for ReplicaSet {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/replication_controller.rs
+++ b/src/tools/genpolicy/src/replication_controller.rs
@@ -68,15 +68,13 @@ impl yaml::K8sResource for ReplicationController {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                container,
-                settings,
-                volumes,
-            );
-        }
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -34,6 +34,7 @@ pub struct Volumes {
     pub emptyDir_memory: EmptyDirVolume,
     pub configMap: ConfigMapVolume,
     pub confidential_configMap: ConfigMapVolume,
+    pub image_volume: ImageVolume,
 }
 
 /// EmptyDir volume settings loaded from genpolicy-settings.json.
@@ -55,6 +56,17 @@ pub struct ConfigMapVolume {
     pub mount_source: String,
     pub mount_point: String,
     pub driver: String,
+    pub fstype: String,
+    pub options: Vec<String>,
+}
+
+/// Container image volume settings loaded from genpolicy-settings.json.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ImageVolume {
+    pub mount_type: String,
+    pub mount_source: String,
+    pub driver: String,
+    pub source: String,
     pub fstype: String,
     pub options: Vec<String>,
 }

--- a/src/tools/genpolicy/src/stateful_set.rs
+++ b/src/tools/genpolicy/src/stateful_set.rs
@@ -116,16 +116,6 @@ impl yaml::K8sResource for StatefulSet {
         container: &pod::Container,
         settings: &settings::Settings,
     ) {
-        if let Some(volumes) = &self.spec.template.spec.volumes {
-            yaml::get_container_mounts_and_storages(
-                policy_mounts,
-                storages,
-                container,
-                settings,
-                volumes,
-            );
-        }
-
         // Example:
         //
         // containers:
@@ -150,6 +140,14 @@ impl yaml::K8sResource for StatefulSet {
                 StatefulSet::get_mounts_and_storages(policy_mounts, volume_mounts, claims);
             }
         }
+
+        yaml::get_container_mounts_and_storages(
+            policy_mounts,
+            storages,
+            container,
+            settings,
+            &self.spec.template.spec.volumes,
+        );
     }
 
     fn generate_policy(&self, agent_policy: &policy::AgentPolicy) -> String {

--- a/tests/integration/kubernetes/k8s-policy-deployment.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2024 Microsoft.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+    auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled."
+
+    get_pod_config_dir
+
+    deployment_name="policy-redis-deployment"
+    deployment_yaml="${pod_config_dir}/k8s-policy-deployment.yaml"
+
+    # Add an appropriate policy to the correct YAML file.
+    policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+    add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
+    auto_generate_policy "${policy_settings_dir}" "${deployment_yaml}"
+}
+
+@test "Successful deployment with auto-generated policy and container image volumes" {
+    # Initiate deployment
+    kubectl apply -f "${deployment_yaml}"
+
+    # Wait for the deployment to be created
+    cmd="kubectl rollout status --timeout=1s deployment/${deployment_name} | grep 'successfully rolled out'"
+    info "Waiting for: ${cmd}"
+    waitForProcess "${wait_time}" "${sleep_time}" "${cmd}"
+}
+
+teardown() {
+    auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled."
+
+    # Debugging information
+    info "Deployment ${deployment_name}:"
+    kubectl describe deployment "${deployment_name}"
+    kubectl rollout status deployment/${deployment_name}
+
+    # Clean-up
+    kubectl delete deployment "${deployment_name}"
+
+    delete_tmp_policy_settings_dir "${policy_settings_dir}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -57,6 +57,7 @@ else
 		"k8s-pid-ns.bats" \
 		"k8s-pod-quota.bats" \
 		"k8s-policy-hard-coded.bats" \
+		"k8s-policy-deployment.bats" \
 		"k8s-policy-job.bats" \
 		"k8s-policy-pod.bats" \
 		"k8s-policy-pvc.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-deployment.yaml
@@ -1,0 +1,36 @@
+#
+# Copyright (c) 2024 Microsoft
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: policy-redis-deployment
+  labels:
+    app: policyredis
+spec:
+  selector:
+    matchLabels:
+      app: policyredis
+      role: master
+      tier: backend
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: policyredis
+        role: master
+        tier: backend
+    spec:
+      terminationGracePeriodSeconds: 0
+      runtimeClassName: kata
+      containers:
+      - name: master
+        image: quay.io/opstree/redis
+        resources:
+          requests:
+            cpu: 100m
+            memory: 100Mi
+        ports:
+        - containerPort: 6379


### PR DESCRIPTION
Add bind mounts for volumes defined by docker container images, unless those mounts have been defined in the input K8s YAML file too.

For example, quay.io/opstree/redis defines two mounts:
/data
/node-conf
Before these changes, if these mounts were not defined in the YAML file too, the auto-generated policy did not allow this container image to start.
