### PR TITLE
tools: Fix container image build warning

### DIFF
--- a/tools/osbuilder/dracut/Dockerfile.in
+++ b/tools/osbuilder/dracut/Dockerfile.in
@@ -5,7 +5,7 @@
 
 # openSUSE Tumbleweed image has only 'latest' tag so ignore DL3006 rule.
 # hadolint ignore=DL3006
-from opensuse/tumbleweed
+FROM opensuse/tumbleweed
 
 # zypper -y or --non-interactive can be used interchangeably here so ignore
 # DL3034 rule.

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) 2020 Ant Group
 #
 # SPDX-License-Identifier: Apache-2.0
-from ubuntu:20.04
+FROM ubuntu:20.04
 
 # CACHE_TIMEOUT: date to invalid cache, if the date changes the image will be rebuild
 # This is required to keep build dependencies with security fixes.


### PR DESCRIPTION
docker prints warning when building QEMU builder image.

```
 1 warning found (use docker --debug to expand):
 - ConsistentInstructionCasing: Command 'from' should match the case of the command majority (uppercase) (line 5)
```

All commands within the Dockerfile should use the same casing (either upper or lower).

Docker build checks doc: https://docs.docker.com/reference/build-checks/consistent-instruction-casing/