### PR TITLE
tests: Update ubuntu image for stress Dockerfile

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/stress/Dockerfile
+++ b/tests/integration/kubernetes/runtimeclass_workloads/stress/Dockerfile
@@ -5,7 +5,7 @@
 
 # The image has only the 'latest' tag so it needs to ignore DL3007
 #hadolint ignore=DL3007
-FROM quay.io/libpod/ubuntu:latest
+FROM quay.io/bedrock/ubuntu:latest
 RUN apt-get -y update && \
     apt-get -y upgrade && \
     apt-get -y --no-install-recommends install stress && \


### PR DESCRIPTION
This PR updates the ubuntu image for stress Dockerfile. The main purpose is to have a more updated image compared with the one that is in libpod which has not been updated in a while.