### PR TITLE
runtime-rs: Add the wait_vm support for hypervisors

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -64,6 +64,11 @@ impl Hypervisor for CloudHypervisor {
         inner.stop_vm()
     }
 
+    async fn wait_vm(&self) -> Result<i32> {
+        let inner = self.inner.read().await;
+        inner.wait_vm().await
+    }
+
     async fn pause_vm(&self) -> Result<()> {
         let inner = self.inner.write().await;
         inner.pause_vm()

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -29,6 +29,7 @@ use nix::mount::MsFlags;
 use persist::sandbox_persist::Persist;
 use std::cmp::Ordering;
 use std::{collections::HashSet, fs::create_dir_all};
+use tokio::sync::mpsc;
 
 const DRAGONBALL_KERNEL: &str = "vmlinux";
 const DRAGONBALL_INITRD: &str = "initrd";
@@ -88,7 +89,7 @@ pub struct DragonballInner {
 }
 
 impl DragonballInner {
-    pub fn new() -> DragonballInner {
+    pub fn new(exit_notify: mpsc::Sender<i32>) -> DragonballInner {
         let mut capabilities = Capabilities::new();
         capabilities.set(
             CapabilityBits::BlockDeviceSupport
@@ -106,7 +107,7 @@ impl DragonballInner {
             pending_devices: vec![],
             state: VmmState::NotReady,
             jailed: false,
-            vmm_instance: VmmInstance::new(""),
+            vmm_instance: VmmInstance::new("", exit_notify),
             run_dir: "".to_string(),
             cached_block_devices: Default::default(),
             capabilities,
@@ -498,7 +499,7 @@ impl DragonballInner {
 #[async_trait]
 impl Persist for DragonballInner {
     type State = HypervisorState;
-    type ConstructorArgs = ();
+    type ConstructorArgs = mpsc::Sender<i32>;
 
     /// Save a state of hypervisor
     async fn save(&self) -> Result<Self::State> {
@@ -519,7 +520,7 @@ impl Persist for DragonballInner {
 
     /// Restore hypervisor
     async fn restore(
-        _hypervisor_args: Self::ConstructorArgs,
+        hypervisor_args: Self::ConstructorArgs,
         hypervisor_state: Self::State,
     ) -> Result<Self> {
         Ok(DragonballInner {
@@ -530,7 +531,7 @@ impl Persist for DragonballInner {
             netns: hypervisor_state.netns,
             config: hypervisor_state.config,
             state: VmmState::NotReady,
-            vmm_instance: VmmInstance::new(""),
+            vmm_instance: VmmInstance::new("", hypervisor_args),
             run_dir: hypervisor_state.run_dir,
             pending_devices: vec![],
             cached_block_devices: hypervisor_state.cached_block_devices,

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -7,6 +7,13 @@
 use std::convert::TryFrom;
 use std::path::PathBuf;
 
+use super::{build_dragonball_network_config, DragonballInner};
+use crate::device::pci_path::PciPath;
+use crate::VhostUserConfig;
+use crate::{
+    device::DeviceType, HybridVsockConfig, NetworkConfig, ShareFsConfig, ShareFsMountConfig,
+    ShareFsMountOperation, ShareFsMountType, VfioDevice, VmmState, JAILER_ROOT,
+};
 use anyhow::{anyhow, Context, Result};
 use dbs_utils::net::MacAddr;
 use dragonball::api::v1::VhostUserConfig as DragonballVhostUserConfig;
@@ -17,14 +24,6 @@ use dragonball::api::v1::{
 use dragonball::device_manager::{
     blk_dev_mgr::BlockDeviceType,
     vfio_dev_mgr::{HostDeviceConfig, VfioPciDeviceConfig},
-};
-
-use super::{build_dragonball_network_config, DragonballInner};
-use crate::device::pci_path::PciPath;
-use crate::VhostUserConfig;
-use crate::{
-    device::DeviceType, HybridVsockConfig, NetworkConfig, ShareFsConfig, ShareFsMountConfig,
-    ShareFsMountOperation, ShareFsMountType, VfioDevice, VmmState, JAILER_ROOT,
 };
 
 const MB_TO_B: u32 = 1024 * 1024;
@@ -431,12 +430,14 @@ impl DragonballInner {
 #[cfg(test)]
 mod tests {
     use dragonball::api::v1::FsDeviceConfigInfo;
+    use tokio::sync::mpsc;
 
     use crate::dragonball::DragonballInner;
 
     #[test]
     fn test_parse_inline_virtiofs_args() {
-        let mut dragonball = DragonballInner::new();
+        let (tx, _) = mpsc::channel(1);
+        let mut dragonball = DragonballInner::new(tx);
         let mut fs_cfg = FsDeviceConfigInfo::default();
 
         // no_open and writeback_cache is the default, so test open and no_writeback_cache. "-d"

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -28,6 +28,7 @@ use dragonball::{
 };
 use nix::sched::{setns, CloneFlags};
 use seccompiler::BpfProgram;
+use tokio::sync::mpsc;
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::ShareFsMountOperation;
@@ -49,10 +50,11 @@ pub struct VmmInstance {
     to_vmm_fd: EventFd,
     seccomp: BpfProgram,
     vmm_thread: Option<thread::JoinHandle<Result<i32>>>,
+    exit_notify: Option<mpsc::Sender<i32>>,
 }
 
 impl VmmInstance {
-    pub fn new(id: &str) -> Self {
+    pub fn new(id: &str, exit_notify: mpsc::Sender<i32>) -> Self {
         let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo::new(
             String::from(id),
             DRAGONBALL_VERSION.to_string(),
@@ -68,6 +70,7 @@ impl VmmInstance {
             to_vmm_fd,
             seccomp: vec![],
             vmm_thread: None,
+            exit_notify: Some(exit_notify),
         }
     }
 
@@ -122,6 +125,7 @@ impl VmmInstance {
         )
         .expect("Failed to start vmm");
         let vmm_shared_info = self.get_shared_info();
+        let exit_notify = self.exit_notify.take().unwrap();
 
         self.vmm_thread = Some(
             thread::Builder::new()
@@ -141,6 +145,12 @@ impl VmmInstance {
                         }
                         let exit_code =
                             Vmm::run_vmm_event_loop(Arc::new(Mutex::new(vmm)), vmm_service);
+                        exit_notify
+                            .try_send(exit_code)
+                            .map_err(|e| {
+                                error!(sl!(), "vmm-master thread fail to send. {:?}", e);
+                            })
+                            .ok();
                         debug!(sl!(), "run vmm thread exited: {}", exit_code);
                         Ok(exit_code)
                     }()

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
@@ -67,6 +67,11 @@ impl Hypervisor for Firecracker {
         inner.stop_vm().await
     }
 
+    async fn wait_vm(&self) -> Result<i32> {
+        let inner = self.inner.read().await;
+        inner.wait_vm().await
+    }
+
     async fn pause_vm(&self) -> Result<()> {
         let inner = self.inner.read().await;
         inner.pause_vm()

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -96,6 +96,7 @@ pub trait Hypervisor: std::fmt::Debug + Send + Sync {
     async fn prepare_vm(&self, id: &str, netns: Option<String>) -> Result<()>;
     async fn start_vm(&self, timeout: i32) -> Result<()>;
     async fn stop_vm(&self) -> Result<()>;
+    async fn wait_vm(&self) -> Result<i32>;
     async fn pause_vm(&self) -> Result<()>;
     async fn save_vm(&self) -> Result<()>;
     async fn resume_vm(&self) -> Result<()>;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -62,6 +62,11 @@ impl Hypervisor for Qemu {
         inner.stop_vm().await
     }
 
+    async fn wait_vm(&self) -> Result<i32> {
+        let inner = self.inner.read().await;
+        inner.wait_vm().await
+    }
+
     async fn pause_vm(&self) -> Result<()> {
         let inner = self.inner.read().await;
         inner.pause_vm()


### PR DESCRIPTION
Add the wait_vm method for hypervisors. This is a
prerequisite for sandbox api support.

Fixes: #7043