### PR TITLE
tools: Enable avx as an option for QEMU

### DIFF
--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -426,6 +426,7 @@ generate_qemu_options() {
 	# AVX2 is enabled by default by x86_64, make sure it's enabled only
 	# for that architecture
 	if [ "$arch" == x86_64 ]; then
+		qemu_options+=(speed:--enable-avx)
 		qemu_options+=(speed:--enable-avx2)
 		qemu_options+=(speed:--enable-avx512f)
 		# According to QEMU's nvdimm documentation: When 'pmem' is 'on' and QEMU is


### PR DESCRIPTION
This PR enables avx as well as an option for QEMU with the main purpose that certain AI performance benchmarks are able to run without issues of not having it avx enabled.