### PR TITLE
tests: Add kubernetes stress-ng tests

### DIFF
--- a/tests/stability/kubernetes_stressng.sh
+++ b/tests/stability/kubernetes_stressng.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o pipefail
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../metrics/lib/common.bash"
+
+function main() {
+        # Check no processes are left behind
+        check_processes
+        # Create pod
+        kubectl create -f "${SCRIPT_PATH}/runtimeclass_workloads/stress-test.yaml"
+        # Verify pod is running
+        pod_name="stressng-test"
+        kubectl wait --for=condition=Ready --timeout=30s pod "${pod_name}"
+
+	echo "Running stress matrix test"
+        cmd1="stress-ng --matrix 0 -t 60m"
+        kubectl exec "${pod_name}" -- /bin/bash -c "${cmd1}"
+
+	echo "Running stress cpu test"
+        cmd2="stress-ng --cpu 0 --vm 2 -t 60m"
+        kubectl exec "${pod_name}" -- /bin/bash -c "${cmd2}"
+
+	echo "Running stress io test"
+        cmd3="stress-ng --io 2 -t 60m"
+        kubectl exec "${pod_name}" -- /bin/bash -c "${cmd3}"
+
+        kubectl delete -f "${SCRIPT_PATH}/runtimeclass_workloads/stress-test.yaml"
+        kubectl delete pod "${pod_name}"
+        check_processes
+}
+
+main "$@"

--- a/tests/stability/runtimeclass_workloads/stress-test.yaml
+++ b/tests/stability/runtimeclass_workloads/stress-test.yaml
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: stressng-test
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  containers:
+  - name: stress-test
+    image: quay.io/container-perf-tools/stress-ng
+    command: ["/bin/sh", "-c", "tail -f /dev/null"]


### PR DESCRIPTION
This PR adds kubernetes stress-ng tests as part of the stability testing for kata.