### PR TITLE
agent: Handle EINVAL error when umounting container rootfs

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1306,7 +1306,14 @@ impl BaseContainer for LinuxContainer {
                 .to_string()
                 .as_str(),
             MntFlags::MNT_DETACH,
-        )?;
+        )
+        .or_else(|e| {
+            if e.ne(&nix::Error::EINVAL) {
+                return Err(anyhow!(e));
+            }
+            warn!(self.logger, "rootfs not mounted");
+            Ok(())
+        })?;
         fs::remove_dir_all(&self.root)?;
 
         let cgm = self.cgroup_manager.as_mut();


### PR DESCRIPTION
Container/Sandbox clean up should not fail if root FS is not mounted for some reason.

Fixes: https://github.com/kata-containers/kata-containers/issues/10166

When running the remote hypervisor, the sandbox is not properly stopped since there are errors destroying the pause container. These errors happen because pause container root fs is not mounted (see [line](https://github.com/kata-containers/kata-containers/blob/3.7.0/src/agent/src/image.rs#L146)).  This PR handles EINVAL errors when umount2 is called.

```
024/08/13 17:54:54 [adaptor/proxy] StartContainer: containerID:3f363c9b05624badc5eb1adbf8b79d2125acb5b80dd93063f5bec942d69db139
2024/08/13 17:56:36 [adaptor/proxy] RemoveContainer: containerID:3f363c9b05624badc5eb1adbf8b79d2125acb5b80dd93063f5bec942d69db139
2024/08/13 17:56:36 [adaptor/proxy] RemoveContainer: containerID:7ed44ed560387f623343a12f15586a007ca751186a445466e27e3462979d7b53
2024/08/13 17:56:36 [adaptor/proxy] RemoveContainer fails: rpc error: code = Internal desc = EINVAL: Invalid argument

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: <rustjail::container::LinuxContainer as rustjail::container::BaseContainer>::destroy::{{closure}}
   2: <kata_agent::rpc::AgentService as protocols::agent_ttrpc_async::AgentService>::remove_container::{{closure}}
   3: <protocols::agent_ttrpc_async::RemoveContainerMethod as ttrpc::asynchronous::utils::MethodHandler>::handler::{{closure}}
   4: ttrpc::asynchronous::server::HandlerContext::handle_msg::{{closure}}
   5: <ttrpc::asynchronous::server::ServerReader as ttrpc::asynchronous::connection::ReaderDelegate>::handle_msg::{{closure}}::{{closure}}
   6: tokio::runtime::task::raw::poll
   7: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
   8: tokio::runtime::task::raw::poll
   9: std::sys_common::backtrace::__rust_begin_short_backtrace
  10: core::ops::function::FnOnce::call_once{{vtable.shim}}
  11: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  12: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  13: std::sys::unix::thread::Thread::new::thread_start
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys/unix/thread.rs:108:17
  14: start_thread
  15: clone
2024/08/13 17:56:36 [adaptor/proxy] DestroySandbox
2024/08/13 17:56:36 [adaptor/proxy] DestroySandbox fails: rpc error: code = Internal desc = EINVAL: Invalid argument

Stack backtrace:
   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
   1: <rustjail::container::LinuxContainer as rustjail::container::BaseContainer>::destroy::{{closure}}
   2: <kata_agent::rpc::AgentService as protocols::agent_ttrpc_async::AgentService>::destroy_sandbox::{{closure}}
   3: <protocols::agent_ttrpc_async::DestroySandboxMethod as ttrpc::asynchronous::utils::MethodHandler>::handler::{{closure}}
   4: ttrpc::asynchronous::server::HandlerContext::handle_msg::{{closure}}
   5: <ttrpc::asynchronous::server::ServerReader as ttrpc::asynchronous::connection::ReaderDelegate>::handle_msg::{{closure}}::{{closure}}
   6: tokio::runtime::task::raw::poll
   7: tokio::runtime::scheduler::multi_thread::worker::Context::run_task
   8: tokio::runtime::task::raw::poll
   9: std::sys_common::backtrace::__rust_begin_short_backtrace
  10: core::ops::function::FnOnce::call_once{{vtable.shim}}
  11: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  12: <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/alloc/src/boxed.rs:2007:9
  13: std::sys::unix::thread::Thread::new::thread_start
             at ./rustc/82e1608dfa6e0b5569232559e3d385fea5a93112/library/std/src/sys/unix/thread.rs:108:17
  14: start_thread
  15: clone
```

