### PR TITLE
genpolicy: add priorityClassName as a field in PodSpec interface

### DIFF
--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -95,6 +95,9 @@ pub struct PodSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     securityContext: Option<PodSecurityContext>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    priorityClassName: Option<String>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -13,6 +13,7 @@ setup() {
 
 	configmap_name="policy-configmap"
 	pod_name="policy-pod"
+	priority_class_name="test-high-priority"
 
 	get_pod_config_dir
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
@@ -27,10 +28,12 @@ setup() {
 	testcase_pre_generate_configmap_yaml="${pod_config_dir}/k8s-policy-configmap-testcase-pre-generation.yaml"
 
 	correct_pod_yaml="${pod_config_dir}/k8s-policy-pod.yaml"
+	priority_class_yaml="${pod_config_dir}/k8s-priority-class.yaml"
 	pre_generate_pod_yaml="${pod_config_dir}/k8s-policy-pod-pre-generation.yaml"
 	incorrect_pod_yaml="${pod_config_dir}/k8s-policy-pod-incorrect.yaml"
 	testcase_pre_generate_pod_yaml="${pod_config_dir}/k8s-policy-pod-testcase-pre-generation.yaml"
 
+	kubectl create -f "${priority_class_yaml}"
 
     # Save some time by executing genpolicy a single time.
     if [ "${BATS_TEST_NUMBER}" == "1" ]; then
@@ -233,6 +236,7 @@ teardown() {
 	# Clean-up
 	kubectl delete pod "${pod_name}"
 	kubectl delete configmap "${configmap_name}"
+	kubectl delete priorityClass "${priority_class_name}"
 	rm -f "${incorrect_pod_yaml}"
 	rm -f "${incorrect_configmap_yaml}"
 	rm -f "${testcase_pre_generate_pod_yaml}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -56,3 +56,4 @@ spec:
     - maxSkew: 2
       topologyKey: kubernetes.io/hostname
       whenUnsatisfiable: ScheduleAnyway
+  priorityClassName: test-high-priority

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-priority-class.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-priority-class.yaml
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2024 Microsoft
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: test-high-priority
+value: 1000000
+globalDefault: false

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -88,7 +88,7 @@ add_annotations_to_yaml() {
 		info "Issue #7765: adding annotations to ${resource_kind} from ${yaml_file} is not implemented yet"
 		;;
 
-	ConfigMap|LimitRange|Namespace|PersistentVolume|PersistentVolumeClaim|RuntimeClass|Secret|Service)
+	ConfigMap|LimitRange|Namespace|PersistentVolume|PersistentVolumeClaim|PriorityClass|RuntimeClass|Secret|Service)
 		info "Annotations are not required for ${resource_kind} from ${yaml_file}"
 		;;
 


### PR DESCRIPTION
This allows generation of policy for pods specifying priority classes.

Cherry pick from https://github.com/microsoft/kata-containers/pull/145