### PR TITLE
tests: Ensure exec_host() consistently captures command output

### DIFF
--- a/tests/integration/kubernetes/k8s-file-volume.bats
+++ b/tests/integration/kubernetes/k8s-file-volume.bats
@@ -8,10 +8,8 @@
 load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 TEST_INITRD="${TEST_INITRD:-no}"
-issue="https://github.com/kata-containers/kata-containers/issues/10081"
 
 setup() {
-	skip "test not working see: ${issue}"
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 
@@ -46,7 +44,6 @@ setup() {
 }
 
 @test "Test readonly volume for pods" {
-	skip "test not working see: ${issue}"
 	# Create pod
 	kubectl create -f "${test_yaml}"
 
@@ -59,7 +56,6 @@ setup() {
 }
 
 teardown() {
-	skip "test not working see: ${issue}"
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 


### PR DESCRIPTION
The `exec_host()` function often fails to capture the output of a given command because the node debugger pod is prematurely terminated. To address this issue, the function has been refactored to ensure consistent output capture by adjusting the `kubectl debug` process as follows:

- Keep the node debugger pod running
- Wait until the pod is fully ready
- Execute the command using `kubectl exec`
- Capture the output and terminate the pod

This PR refactors `exec_host()` to implement the above steps, improving its reliability. And it reverts #10156 as well.

Fixes: #10081

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>