### PR TITLE
Revert "ci: add reset_runtime to cleanup"

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -706,7 +706,6 @@ function main() {
 			cleanup_cri_runtime "$runtime"
 			kubectl label node "$NODE_NAME" --overwrite katacontainers.io/kata-runtime=cleanup
 			remove_artifacts
-			reset_runtime "$runtime"
 			;;
 		reset)
 			reset_runtime $runtime


### PR DESCRIPTION
This reverts commit 8d9bec2e015f20126a84bc474e35ecf748f53d98, as it causes issues in the operator and kata-deploy itself, leading to the node to be NotReady.