### PR TITLE
kata-deploy: fix kata-deploy reset

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -663,7 +663,7 @@ function main() {
 		runtime="crio"
 	elif [ "$runtime" == "k3s" ] || [ "$runtime" == "k3s-agent" ] || [ "$runtime" == "rke2-agent" ] || [ "$runtime" == "rke2-server" ]; then
 		containerd_conf_tmpl_file="${containerd_conf_file}.tmpl"
-		if [ ! -f "$containerd_conf_tmpl_file" ]; then
+		if [ ! -f "$containerd_conf_tmpl_file" ] && [ -f "$containerd_conf_file" ]; then
 			cp "$containerd_conf_file" "$containerd_conf_tmpl_file"
 		fi
 


### PR DESCRIPTION
For the cases where containerd_conf_file does not exist, cp will fail and let the pod in Error state.