### PR TITLE
ci: nydus: Treat the snapshotter as a dependency

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -415,6 +415,11 @@ function cleanup() {
 }
 
 function deploy_snapshotter() {
+	if [[ "${KATA_HYPERVISOR}" == "qemu-tdx" ]]; then
+	       echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
+	       return
+	fi
+
 	echo "::group::Deploying ${SNAPSHOTTER}"
 	case ${SNAPSHOTTER} in
 		nydus) deploy_nydus_snapshotter ;;
@@ -424,6 +429,11 @@ function deploy_snapshotter() {
 }
 
 function cleanup_snapshotter() {
+	if [[ "${KATA_HYPERVISOR}" == "qemu-tdx" ]]; then
+	       echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
+	       return
+	fi
+
 	echo "::group::Cleanuping ${SNAPSHOTTER}"
 	case ${SNAPSHOTTER} in
 		nydus) cleanup_nydus_snapshotter ;;


### PR DESCRIPTION
Instead of deploying and removing the snapshotter on every single run, let's make sure the snapshotter is always deploy on the TDX case.

We're doing this as an experiment, in order to see if we'll be able to reduce the failures we've been facing with the nydus snapshotter.