### PR TITLE
osbuilder: fix typo in ubuntu rootfs depends

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -50,7 +50,6 @@ RUN apt-get update && \
     xz-utils \
     pip \
     python3-dev \
-    xz-utils \
     zstd && \
     apt-get clean && rm -rf /var/lib/apt/lists/&& \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}


### PR DESCRIPTION
Remove the duplicate package "xz-utils".