### PR TITLE
runtime: Add specific error message for gRPC request timeouts

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -171,7 +171,7 @@ setup() {
     # The pod should be failed because the default timeout of CreateContainerRequest is 60s
     assert_pod_fail "$pod_config"
     assert_logs_contain "$node" kata "$node_start_time" \
-		'context deadline exceeded'
+		'CreateContainerRequest timed out'
 }
 
 @test "Test we can pull a large image inside the guest with large createcontainer timeout" {


### PR DESCRIPTION
Improved error handling to provide clearer feedback on request failures.

Fixes: #10173 -- part II