### PR TITLE
Revert "version: bump trustee version"

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -237,9 +237,9 @@ externals:
   coco-trustee:
     description: "Provides attestation and secret delivery components"
     url: "https://github.com/confidential-containers/trustee"
-    version: "4a83e3b99ceb7cb6e8ce523d2ca1762eec7b7239"
+    version: "e890fc90c384207668fa3a4d6a2f2a2d652797ee"
     image: "ghcr.io/confidential-containers/staged-images/kbs"
-    image_tag: "4a83e3b99ceb7cb6e8ce523d2ca1762eec7b7239"
+    image_tag: "e890fc90c384207668fa3a4d6a2f2a2d652797ee"
     toolchain: "1.74.0"
 
   crio:


### PR DESCRIPTION
This reverts commit d35320472c9db9e706979289d36e53fcbc60e8d8.

Although the commit in question does solve an issue related to the usage of busybox from docker.io, as it's reasonably easy to hit the rate limit, the commit also brings in functionalities that are causing issues in, at least, the TDX CI, such as:
```sh
[2024-08-16T16:03:52Z INFO  actix_web::middleware::logger] 10.244.0.1 "POST /kbs/v0/attest HTTP/1.1" 401 259 "-" "attestation-agent-kbs-client/0.1.0" 0.065266
[2024-08-16T16:03:53Z INFO  kbs::http::attest] Auth API called.
[2024-08-16T16:03:53Z INFO  actix_web::middleware::logger] 10.244.0.1 "POST /kbs/v0/auth HTTP/1.1" 200 74 "-" "attestation-agent-kbs-client/0.1.0" 0.000169
[2024-08-16T16:03:54Z INFO  kbs::http::attest] Attest API called.
[2024-08-16T16:03:54Z INFO  verifier::tdx] Quote DCAP check succeeded.
[2024-08-16T16:03:54Z INFO  verifier::tdx] MRCONFIGID check succeeded.
[2024-08-16T16:03:54Z INFO  verifier::tdx] CCEL integrity check succeeded.
[2024-08-16T16:03:54Z ERROR kbs::http::error] Attestation failed: Verifier evaluate failed: TDX Verifier: failed to parse AA Eventlog from evidence

    Caused by:
        at least one line should be included in AAEL
```

Let's revert this for now, and then once we get this one fixed on trustee side we'll update again.