### PR TITLE
ci: stdio: Fix typo on getting the containerd version

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Run stdio tests
         timeout-minutes: 10
-        run: bash tests/integration/stdio/gha-run.sh
+        run: bash tests/integration/stdio/gha-run.sh run
 
   run-tracing:
     strategy:

--- a/tests/integration/stdio/gha-run.sh
+++ b/tests/integration/stdio/gha-run.sh
@@ -33,7 +33,7 @@ function install_dependencies() {
 	# - containerd
 	#   - cri-container-cni release tarball already includes CNI plugins
 	declare -a github_deps
-	github_deps[0]="cri_containerd:$(get_from_kata_deps "externals.containerd.${CONTAINERD_VERSION}")"
+	github_deps[0]="cri_containerd:$(get_from_kata_deps ".externals.containerd.${CONTAINERD_VERSION}")"
 
 	for github_dep in "${github_deps[@]}"; do
 		IFS=":" read -r -a dep <<< "${github_dep}"


### PR DESCRIPTION
I assume the PR that introduced this was based on an older version of yq, and as the test couldn't run before it got merged we never noticed the error.

However, this test has been failing for a reasonable amount of time, which makes me think that we either need a maintainer for it, or just remove it completely, but that's a discussion for another day.

For now, let's make it, at least, run.