### PR TITLE
kata-deploy: Stop symlinking into /usr/local/bin

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -65,8 +65,6 @@ spec:
           mountPath: /etc/containerd/
         - name: kata-artifacts
           mountPath: /opt/kata/
-        - name: local-bin
-          mountPath: /usr/local/bin/
         - name: host
           mountPath: /host/
       volumes:
@@ -80,9 +78,6 @@ spec:
         hostPath:
           path: /opt/kata/
           type: DirectoryOrCreate
-      - name: local-bin
-        hostPath:
-          path: /usr/local/bin/
       - name: host
         hostPath:
           path: /

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -59,8 +59,6 @@ spec:
               mountPath: /etc/containerd/
             - name: kata-artifacts
               mountPath: /opt/kata/
-            - name: local-bin
-              mountPath: /usr/local/bin/
             - name: host
               mountPath: /host/
       volumes:
@@ -74,9 +72,6 @@ spec:
           hostPath:
             path: /opt/kata/
             type: DirectoryOrCreate
-        - name: local-bin
-          hostPath:
-            path: /usr/local/bin/
         - name: host
           hostPath:
             path: /

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -432,7 +432,7 @@ function configure_crio_runtime() {
 
 	local config_path=$(get_kata_containers_config_path "${shim}")
 
-	local kata_path="/usr/local/bin/containerd-shim-${runtime}-v2"
+	local kata_path=$(get_kata_containers_runtime_path "${shim}")
 	local kata_conf="crio.runtime.runtimes.${runtime}"
 	local kata_config_path="${config_path}/${configuration}.toml"
 

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -161,6 +161,22 @@ function get_kata_containers_config_path() {
 	echo "$config_path"
 }
 
+function get_kata_containers_runtime_path() {
+	local shim="$1"
+
+	local runtime_path
+	case "$shim" in
+		cloud-hypervisor | dragonball | qemu-runtime-rs)
+			runtime_path="/opt/kata/runtime-rs/bin/containerd-shim-kata-v2"
+			;;
+		*)
+			runtime_path="/opt/kata/bin/containerd-shim-kata-v2"
+			;;
+	esac
+
+	echo "$runtime_path"
+}
+
 function tdx_not_supported() {
 	distro="${1}"
 	version="${2}"
@@ -502,8 +518,10 @@ function configure_containerd_runtime() {
 	local runtime_options_table="${runtime_table}.options"
 	local runtime_type=\"io.containerd."${runtime}".v2\"
 	local runtime_config_path=\"$(get_kata_containers_config_path "${shim}")/${configuration}.toml\"
+	local runtime_path=\"$(get_kata_containers_runtime_path "${shim}")\"
 	
 	tomlq -i -t $(printf '%s.runtime_type=%s' ${runtime_table} ${runtime_type}) ${containerd_conf_file}
+	tomlq -i -t $(printf '%s.runtime_path=%s' ${runtime_table} ${runtime_path}) ${containerd_conf_file}
 	tomlq -i -t $(printf '%s.privileged_without_host_devices=true' ${runtime_table}) ${containerd_conf_file}
 	tomlq -i -t $(printf '%s.pod_annotations=["io.katacontainers.*"]' ${runtime_table}) ${containerd_conf_file}
 	tomlq -i -t $(printf '%s.ConfigPath=%s' ${runtime_options_table} ${runtime_config_path}) ${containerd_conf_file}

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -323,8 +323,6 @@ function wait_till_node_is_ready() {
 }
 
 function configure_cri_runtime() {
-	configure_different_shims_base
-
 	case $1 in
 	crio)
 		configure_crio
@@ -342,87 +340,6 @@ function configure_cri_runtime() {
 	fi
 
 	wait_till_node_is_ready
-}
-
-function backup_shim() {
-	local shim_file="$1"
-	local shim_backup="${shim_file}.bak"
-
-	if [ -f "${shim_file}" ]; then
-		echo "warning: ${shim_file} already exists" >&2
-		if [ ! -f "${shim_backup}" ]; then
-			mv "${shim_file}" "${shim_backup}"
-		else
-			rm -f "${shim_file}"
-		fi
-	fi
-}
-
-function configure_different_shims_base() {
-	# Currently containerd has an assumption on the location of the shimv2 implementation
-	# This forces kata-deploy to create files in a well-defined location that's part of
-	# the PATH, pointing to the containerd-shim-kata-v2 binary in /opt/kata/bin
-	# Issues:
-	#   https://github.com/containerd/containerd/issues/3073
-	#   https://github.com/containerd/containerd/issues/5006
-
-	local default_shim_file="/usr/local/bin/containerd-shim-kata-v2"
-
-	mkdir -p /usr/local/bin
-
-	for shim in "${shims[@]}"; do
-		local shim_binary="containerd-shim-kata-${shim}-v2"
-		local shim_file="/usr/local/bin/${shim_binary}"
-
-		backup_shim "${shim_file}"
-
-		# Map the runtime shim name to the appropriate
-		# containerd-shim-kata-v2 binary
-		case "$shim" in
-			cloud-hypervisor | dragonball | qemu-runtime-rs)
-				ln -sf /opt/kata/runtime-rs/bin/containerd-shim-kata-v2 "${shim_file}" ;;
-			*)
-				ln -sf /opt/kata/bin/containerd-shim-kata-v2 "${shim_file}" ;;
-		esac
-
-		chmod +x "$shim_file"
-
-		if [ "${shim}" == "${default_shim}" ]; then
-			backup_shim "${default_shim_file}"
-
-			echo "Creating the default shim-v2 binary"
-			ln -sf "${shim_file}" "${default_shim_file}"
-		fi
-	done
-}
-
-function restore_shim() {
-	local shim_file="$1"
-	local shim_backup="${shim_file}.bak"
-
-	if [ -f "${shim_backup}" ]; then
-		mv "$shim_backup" "$shim_file"
-	fi
-}
-
-function cleanup_different_shims_base() {
-	local default_shim_file="/usr/local/bin/containerd-shim-kata-v2"
-
-	for shim in "${shims[@]}"; do
-		local shim_binary="containerd-shim-kata-${shim}-v2"
-		local shim_file="/usr/local/bin/${shim_binary}"
-
-		rm  -f "${shim_file}"
-
-		restore_shim "${shim_file}"
-	done
-
-	rm  -f "${default_shim_file}"
-	restore_shim "${default_shim_file}"
-
-	if [[ "${CREATE_RUNTIMECLASSES}" == "true" ]]; then
-		delete_runtimeclasses
-	fi
 }
 
 function configure_crio_runtime() {
@@ -564,11 +481,13 @@ function configure_containerd() {
 function remove_artifacts() {
 	echo "deleting kata artifacts"
 	rm -rf /opt/kata/*
+
+	if [[ "${CREATE_RUNTIMECLASSES}" == "true" ]]; then
+		delete_runtimeclasses
+	fi
 }
 
 function cleanup_cri_runtime() {
-	cleanup_different_shims_base
-
 	case $1 in
 	crio)
 		cleanup_crio


### PR DESCRIPTION
All the supported versions of containerd and CRI-O do support setting the full runtime path via the `runtime_path` field.  Let's take advantage of that and avoid having to access `/usr/local/bin` and create symlinks there.