### PR TITLE
stability: Add kubernetes parallel test

### DIFF
--- a/tests/stability/kubernetes_soak_test.sh
+++ b/tests/stability/kubernetes_soak_test.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+SCRIPT_PATH=$(dirname "$(readlink -f "$0")")
+source "${SCRIPT_PATH}/../metrics/lib/common.bash"
+
+set -x
+
+replicas="${replicas:-8}"
+deployment_name="${deployment_name:-deploymenttest}"
+# How many times will we run the test loop...
+iterations="${iterations:-20}"
+
+function delete_deployment() {
+	kubectl delete deployment "${deployment_name}"
+}
+
+function go() {
+	kubectl scale deployment/"${deployment_name}" --replicas="${replicas}"
+	cmd="kubectl get deployment/${deployment_name} -o yaml | grep 'availableReplicas: ${replicas}'"
+	waitForProcess "300" "30" "${cmd}"
+}
+
+function init() {
+	kubectl create -f "${SCRIPT_PATH}/runtimeclass_workloads/pod-deployment.yaml"
+	kubectl wait --for=condition=Available --timeout=30s deployment/"${deployment_name}"
+}
+
+function main() {
+	check_processes
+	local i=0
+	for (( i=1; i<="${iterations}"; i++ )); do
+		info "Start iteration $i of $iterations"
+		init
+		#spin them up
+		go
+		#shut them all down
+		delete_deployment
+	done
+}
+
+main "$@"

--- a/tests/stability/runtimeclass_workloads/pod-deployment.yaml
+++ b/tests/stability/runtimeclass_workloads/pod-deployment.yaml
@@ -1,4 +1,3 @@
-#
 # Copyright (c) 2024 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/stability/runtimeclass_workloads/pod-deployment.yaml
+++ b/tests/stability/runtimeclass_workloads/pod-deployment.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2024 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deploymenttest
+spec:
+  selector:
+    matchLabels:
+      purpose: pod-test
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        purpose: pod-test
+    spec:
+      terminationGracePeriodSeconds: 0
+      runtimeClassName: kata
+      containers:
+      - name: pod-test
+        image: quay.io/prometheus/busybox:latest
+        command: ["tail", "-f", "/dev/null"]


### PR DESCRIPTION
This PR adds a kubernetes parallel test that will launch multiple replicas from a kubernetes deployment and we will iterate this multiple times to verify that we are able to do this using CoCo Kata. This test will be part of the CoCo Kata stability CI.