### PR TITLE
kata-deploy: Rework the logic a little bit

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -575,6 +575,15 @@ function snapshotter_handler_mapping_validation_check() {
 }
 
 function main() {
+	action=${1:-}
+	if [ -z "$action" ]; then
+		print_usage
+		die "invalid arguments"
+	fi
+
+	echo "Action:"
+	echo "* $action"
+	echo ""
 	echo "Environment variables passed to this script"
 	echo "* NODE_NAME: ${NODE_NAME}"
 	echo "* DEBUG: ${DEBUG}"
@@ -607,12 +616,6 @@ function main() {
 		# This works by k0s creating a special directory in /etc/k0s/containerd.d/ where user can drop-in partial containerd configuration snippets.
 		# k0s will automatically pick up these files and adds these in containerd configuration imports list.
 		containerd_conf_file="/etc/containerd/kata-containers.toml"
-	fi
-
-	action=${1:-}
-	if [ -z "$action" ]; then
-		print_usage
-		die "invalid arguments"
 	fi
 
 	# only install / remove / update if we are dealing with CRIO or containerd

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -598,7 +598,7 @@ function main() {
 	# CRI-O isn't consistent with the naming -- let's use crio to match the service file
 	if [ "$runtime" == "cri-o" ]; then
 		runtime="crio"
-	elif [ "$runtime" == "k3s" ] || [ "$runtime" == "k3s-agent" ] || [ "$runtime" == "rke2-agent" ] || [ "$runtime" == "rke2-server" ]; then
+	elif [[ "$runtime" =~ ^(k3s|k3s-agent|rke2-agent|rke2-server)$ ]]; then
 		containerd_conf_tmpl_file="${containerd_conf_file}.tmpl"
 		if [ ! -f "$containerd_conf_tmpl_file" ] && [ -f "$containerd_conf_file" ]; then
 			cp "$containerd_conf_file" "$containerd_conf_tmpl_file"
@@ -606,7 +606,7 @@ function main() {
 
 		containerd_conf_file="${containerd_conf_tmpl_file}"
 		containerd_conf_file_backup="${containerd_conf_file}.bak"
-	elif [ "$runtime" == "k0s-worker" ] || [ "$runtime" == "k0s-controller" ]; then
+	elif [[ "$runtime" =~ ^(k0s-worker|k0s-controller)$ ]]; then
 		# From 1.27.1 onwards k0s enables dynamic configuration on containerd CRI runtimes. 
 		# This works by k0s creating a special directory in /etc/k0s/containerd.d/ where user can drop-in partial containerd configuration snippets.
 		# k0s will automatically pick up these files and adds these in containerd configuration imports list.


### PR DESCRIPTION
In order to ensure that the cleanup action won't cause any harm or lead to a misconfiguration, let's re-work the "common to the actions" part of the script so file creations are only done during the specific actions.