### PR TITLE
metrics: Remove unused variable in openvino script

### DIFF
--- a/tests/metrics/machine_learning/openvino.sh
+++ b/tests/metrics/machine_learning/openvino.sh
@@ -62,7 +62,6 @@ EOF
 }
 
 function main() {
-	local i=0
 	local cmds=("docker")
 	local RES_DIR="/var/lib/phoronix-test-suite/test-results"
 


### PR DESCRIPTION
This PR removes an unused variable in the openvino script for kata metrics.