### PR TITLE
agent/config: Make CDH_API_TIMEOUT configurable

### DIFF
--- a/docs/how-to/how-to-set-sandbox-config-kata.md
+++ b/docs/how-to/how-to-set-sandbox-config-kata.md
@@ -35,6 +35,7 @@ There are several kinds of Kata configurations and they are listed below.
 | `io.katacontainers.config.agent.enable_tracing` | `boolean` | enable tracing for the agent |
 | `io.katacontainers.config.agent.container_pipe_size` | uint32 | specify the size of the std(in/out) pipes created for containers |
 | `io.katacontainers.config.agent.kernel_modules` | string | the list of kernel modules and their parameters that will be loaded in the guest kernel. Semicolon separated list of kernel modules and their parameters. These modules will be loaded in the guest kernel using `modprobe`(8). E.g., `e1000e InterruptThrottleRate=3000,3000,3000 EEE=1; i915 enable_ppgtt=0` |
+| `io.katacontainers.config.agent.cdh_api_timeout` | uint32 | timeout in second for Confidential Data Hub (CDH) API service, default is `50` |
 
 ## Hypervisor Options
 | Key | Value Type | Comments |

--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -128,6 +128,7 @@ The kata agent has the ability to configure agent options in guest kernel comman
 | `agent.guest_components_rest_api` | `api-server-rest` configuration | Select the features that the API Server Rest attestation component will run with. Valid values are `all`, `attestation`, `resource` | string | `resource` |
 | `agent.guest_components_procs` | guest-components processes | Attestation-related processes that should be spawned as children of the guest. Valid values are `none`, `attestation-agent`, `confidential-data-hub` (implies `attestation-agent`), `api-server-rest` (implies `attestation-agent` and `confidential-data-hub`) | string | `api-server-rest` |
 | `agent.hotplug_timeout` | Hotplug timeout | Allow to configure hotplug timeout(seconds) of block devices | integer | `3` |
+| `agent.cdh_api_timeout` | Confidential Data Hub (CDH) API timeout | Allow to configure CDH API timeout(seconds) | integer | `50` |
 | `agent.https_proxy` | HTTPS proxy | Allow to configure `https_proxy` in the guest | string | `""` |
 | `agent.image_registry_auth` | Image registry credential URI | The URI to where image-rs can find the credentials for pulling images from private registries e.g. `file:///root/.docker/config.json` to read from a file in the guest image, or `kbs:///default/credentials/test` to get the file from the KBS| string | `""` |
 | `agent.log` | Log level | Allow the agent log level to be changed (produces more or less output) | string | `"info"` |
@@ -145,7 +146,7 @@ The kata agent has the ability to configure agent options in guest kernel comman
 >    The agent will fail to start if the configuration file is not present,
 >    or if it can't be parsed properly.
 >  - `agent.devmode`: true | false
->  - `agent.hotplug_timeout`: a whole number of seconds
+>  - `agent.hotplug_timeout` and `agent.cdh_api_timeout`: a whole number of seconds
 >  - `agent.log`:   "critical"("fatal" | "panic") | "error" | "warn"("warning") | "info" | "debug"
 >  - `agent.server_addr`: "{VSOCK_ADDR}:{VSOCK_PORT}"
 >  - `agent.trace`: true | false

--- a/src/agent/src/cdh.rs
+++ b/src/agent/src/cdh.rs
@@ -14,10 +14,13 @@ use protocols::{
     confidential_data_hub_ttrpc_async::{SealedSecretServiceClient, SecureMountServiceClient},
 };
 
+use crate::AGENT_CONFIG;
 use crate::CDH_SOCKET_URI;
 
 // Nanoseconds
-const CDH_API_TIMEOUT: i64 = 50 * 1000 * 1000 * 1000;
+lazy_static! {
+    static ref CDH_API_TIMEOUT: i64 = AGENT_CONFIG.cdh_api_timeout.as_nanos() as i64;
+}
 const SEALED_SECRET_PREFIX: &str = "sealed.";
 
 #[derive(Derivative)]
@@ -48,7 +51,7 @@ impl CDHClient {
 
         let unsealed_secret = self
             .sealed_secret_client
-            .unseal_secret(ttrpc::context::with_timeout(CDH_API_TIMEOUT), &input)
+            .unseal_secret(ttrpc::context::with_timeout(*CDH_API_TIMEOUT), &input)
             .await?;
         Ok(unsealed_secret.plaintext)
     }
@@ -81,7 +84,7 @@ impl CDHClient {
             ..Default::default()
         };
         self.secure_mount_client
-            .secure_mount(ttrpc::context::with_timeout(CDH_API_TIMEOUT), &req)
+            .secure_mount(ttrpc::context::with_timeout(*CDH_API_TIMEOUT), &req)
             .await?;
         Ok(())
     }

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -282,6 +282,10 @@ kernel_modules=[]
 # (default: 45)
 dial_timeout = 45 
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+#cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/config/configuration-acrn.toml.in
+++ b/src/runtime/config/configuration-acrn.toml.in
@@ -157,6 +157,10 @@ disable_selinux=@DEFDISABLESELINUX@
 # (default: 45)
 dial_timeout = 45
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+#cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -328,6 +328,10 @@ block_device_driver = "virtio-blk"
 # (default: 45)
 dial_timeout = 45
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+#cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -282,6 +282,10 @@ kernel_modules=[]
 # (default: 45)
 dial_timeout = 45
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+#cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -567,6 +567,10 @@ kernel_modules=[]
 # (default: 45)
 dial_timeout = 45
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+#cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -566,6 +566,10 @@ kernel_modules=[]
 # (default: 45)
 dial_timeout = 45
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+#cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/config/configuration-stratovirt.toml.in
+++ b/src/runtime/config/configuration-stratovirt.toml.in
@@ -294,6 +294,10 @@ kernel_modules = []
 # (default: 45)
 dial_timeout = 45
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+#cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -198,6 +198,7 @@ type agent struct {
 	Tracing             bool     `toml:"enable_tracing"`
 	DebugConsoleEnabled bool     `toml:"debug_console_enabled"`
 	DialTimeout         uint32   `toml:"dial_timeout"`
+	CdhApiTimeout       uint32   `toml:"cdh_api_timeout"`
 }
 
 func (orig *tomlConfig) Clone() tomlConfig {
@@ -734,6 +735,10 @@ func (a agent) debugConsoleEnabled() bool {
 
 func (a agent) dialTimout() uint32 {
 	return a.DialTimeout
+}
+
+func (a agent) cdhApiTimout() uint32 {
+	return a.CdhApiTimeout
 }
 
 func (a agent) debug() bool {
@@ -1415,6 +1420,7 @@ func updateRuntimeConfigAgent(configPath string, tomlConf tomlConfig, config *oc
 			KernelModules:      agent.kernelModules(),
 			EnableDebugConsole: agent.debugConsoleEnabled(),
 			DialTimeout:        agent.dialTimout(),
+			CdhApiTimeout:      agent.cdhApiTimout(),
 		}
 	}
 

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -283,6 +283,7 @@ type KataAgentConfig struct {
 	KernelModules      []string
 	ContainerPipeSize  uint32
 	DialTimeout        uint32
+	CdhApiTimeout      uint32
 	LongLiveConn       bool
 	Debug              bool
 	Trace              bool
@@ -346,6 +347,11 @@ func KataAgentKernelParams(config KataAgentConfig) []Param {
 	if config.EnableDebugConsole {
 		params = append(params, Param{Key: kernelParamDebugConsole, Value: ""})
 		params = append(params, Param{Key: kernelParamDebugConsoleVPort, Value: kernelParamDebugConsoleVPortValue})
+	}
+
+	if config.CdhApiTimeout > 0 {
+		cdhApiTimeout := strconv.FormatUint(uint64(config.CdhApiTimeout), 10)
+		params = append(params, Param{Key: vcAnnotations.CdhApiTimeoutKernelParam, Value: cdhApiTimeout})
 	}
 
 	return params

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -309,6 +309,8 @@ const (
 	AgentContainerPipeSize       = kataAnnotAgentPrefix + ContainerPipeSizeOption
 	ContainerPipeSizeOption      = "container_pipe_size"
 	ContainerPipeSizeKernelParam = "agent." + ContainerPipeSizeOption
+	CdhApiTimeoutOption          = "cdh_api_timeout"
+	CdhApiTimeoutKernelParam     = "agent." + CdhApiTimeoutOption
 
 	// Policy is an annotation containing the contents of an agent policy file, base64 encoded.
 	Policy = kataAnnotAgentPrefix + "policy"


### PR DESCRIPTION
In `k8s-guest-pull-image.bats`, a container sometimes fails to start due to the following error:

```
Message:   failed to create containerd task: failed to create shim task: ttrpc err: Receive packet timeout Elapsed(())
```

This issue occurs when fulfilling volume mounts for a large image (https://github.com/kata-containers/kata-containers/actions/runs/10465537902/job/28980940906). 

It was identified that CDH_API_TIMEOUT (default: 50s) influences this situation. 
This PR makes the variable configurable so that the timeout can be adjusted on the fly via annotations.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>