### PR TITLE
metrics: Add OpenVINO general information into README

### DIFF
--- a/tests/metrics/machine_learning/README.md
+++ b/tests/metrics/machine_learning/README.md
@@ -60,3 +60,16 @@ Individual test can be run by hand, for example:
 $ cd metrics/machine_learning
 $ ./tensorflow_resnet50_int8.sh 25 60
 ```
+
+# Kata Containers OpenVINO Benchmark
+
+This is a toolkit around neural networks using its built-in benchmarking support
+and analyzing the throughput and latency for various models.
+
+## Running the `OpenVINO` test
+Individual test can be run by hand, for example:
+
+```
+$ cd metrics/machine_learning
+$ ./openvino.sh
+```


### PR DESCRIPTION
This PR adds the OpenVINO benchmark general information into the machine learning README metrics information.