### PR TITLE
tests: Fix k8s test issues on s390x

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -7,6 +7,7 @@
 
 load "${BATS_TEST_DIRNAME}/lib.sh"
 load "${BATS_TEST_DIRNAME}/confidential_common.sh"
+load "${BATS_TEST_DIRNAME}/confidential_kbs.sh"
 
 setup() {
     if ! is_confidential_runtime_class; then

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -37,9 +37,11 @@ k8s_wait_pod_be_ready() {
 #
 # Parameters:
 #	$1 - the pod configuration file.
+#	$2 - wait time in seconds. Defaults to 120. (optional)
 #
 k8s_create_pod() {
 	local config_file="$1"
+	local wait_time="${2:-120}"
 	local pod_name=""
 
 	if [ ! -f "${config_file}" ]; then
@@ -53,11 +55,11 @@ k8s_create_pod() {
 		return 1
 	fi
 
-	if ! k8s_wait_pod_be_ready "$pod_name"; then
+	if ! k8s_wait_pod_be_ready "${pod_name}" "${wait_time}"; then
 		# TODO: run this command for debugging. Maybe it should be
 		#       guarded by DEBUG=true?
-		kubectl get pods "$pod_name"
-		kubectl describe pod "$pod_name"
+		kubectl get pods "${pod_name}"
+		kubectl describe pod "${pod_name}"
 		return 1
 	fi
 }


### PR DESCRIPTION
While resolving an issue for IBM SE after #9999 was merged, some test setups required patching.

This PR includes the following changes:

- Load confidential_kbs.sh in k8s-guest-pull-iamge.bats
- Introduce wait_time to k8s_create_pod()

Each commit message provides a detailed explanation for these changes.

 Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>