### PR TITLE
dpu: add DPU support to nvidia gpu kernels

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -563,7 +563,7 @@ install_kernel_nvidia_gpu() {
 	install_kernel_helper \
 		"assets.kernel.version" \
 		"kernel-nvidia-gpu" \
-		"-g nvidia -u ${kernel_url} -H deb"
+		"-g nvidia -D nvidia -u ${kernel_url} -H deb"
 }
 
 #Install GPU and TEE enabled kernel asset
@@ -573,7 +573,7 @@ install_kernel_nvidia_gpu_confidential() {
 	install_kernel_helper \
 		"assets.kernel.confidential.version" \
 		"kernel-nvidia-gpu-confidential" \
-		"-x -g nvidia -u ${kernel_url} -H deb"
+		"-x -g nvidia -D nvidia -u ${kernel_url} -H deb"
 }
 
 install_qemu_helper() {


### PR DESCRIPTION
This is for allowing the VFIO device allocated from NVIDIA DPU being plugged into a guest VM.

The option `-D <vendor> 	: DPU/SmartNIC vendor, only nvidia.` was added by  PR https://github.com/kata-containers/kata-containers/pull/9620. 