### PR TITLE
Revert "tests: add image check before running coco tests"

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -514,22 +514,6 @@ function cleanup_snapshotter() {
 	echo "::endgroup::"
 }
 
-# Check existing images to ensure all content is available locally before running tests
-function image_check() {
-	local ctr_args="sudo ctr "
-	if [[ " k3s rke2 " =~ " ${KUBERNETES} " ]]; then
-		ctr_args+="--address /run/k3s/containerd/containerd.sock "
-	fi
-	ctr_args+="--namespace k8s.io "
-	local incomplete_images=$($ctr_args image check | grep "incomplete" | awk '{print $1}')
-	if [ -z "$incomplete_images" ]; then
-		return
-	fi
-	for incomplete_image in $incomplete_images; do
-		$ctr_args content fetch $incomplete_image || true
-	done
-}
-
 function deploy_nydus_snapshotter() {
 	echo "::group::deploy_nydus_snapshotter"
 	ensure_yq
@@ -592,10 +576,6 @@ function deploy_nydus_snapshotter() {
 	echo "::endgroup::"
 	echo "::group::nydus snapshotter describe"
 	kubectl_retry describe pod --selector=app=nydus-snapshotter -n nydus-system
-	echo "::endgroup::"
-
-	echo "::group::image check"
-	image_check
 	echo "::endgroup::"
 }
 


### PR DESCRIPTION
This reverts commit 41b7577f08da85a7507d106de7068121019c42e2.

We were seeing a lot of issues in the TDX CI of the nature:

"Error: failed to create containerd container: create instance
470: object with key "470" already exists: unknown"

With the TDX CI, we moved to having the nydus snapsotter pre-installed. Essentially the `deploy-snapshotter` step was performed once before any actual CI runs.
We were seeing failures related to the error message above.

On reverting this change, we are no longer seeing errors related to "key exists" with the TDX CI passing now.

The change reverted here is related to downloading incomplete images, but this seems to be messing up TDX CI.
It is possible to pass --snapshotter to `ctr image check` but that does not seem to have any effect on the data set returned.