### PR TITLE
runtime: Failed to clean up resources when QEMU is terminated 

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1226,20 +1226,20 @@ func (q *qemu) StopVM(ctx context.Context, waitOnly bool) (err error) {
 		return errors.New("cannot determine QEMU PID")
 	}
 	pid := pids[0]
-
-	if waitOnly {
-		err := utils.WaitLocalProcess(pid, qemuStopSandboxTimeoutSecs, syscall.Signal(0), q.Logger())
-		if err != nil {
-			return err
-		}
-	} else {
-		err = syscall.Kill(pid, syscall.SIGKILL)
-		if err != nil {
-			q.Logger().WithError(err).Error("Fail to send SIGKILL to qemu")
-			return err
+	if pid > 0 {
+		if waitOnly {
+			err := utils.WaitLocalProcess(pid, qemuStopSandboxTimeoutSecs, syscall.Signal(0), q.Logger())
+			if err != nil {
+				return err
+			}
+		} else {
+			err = syscall.Kill(pid, syscall.SIGKILL)
+			if err != nil {
+				q.Logger().WithError(err).Error("Fail to send SIGKILL to qemu")
+				return err
+			}
 		}
 	}
-
 	if q.config.SharedFS == config.VirtioFS || q.config.SharedFS == config.VirtioFSNydus {
 		if err := q.stopVirtiofsDaemon(ctx); err != nil {
 			return err


### PR DESCRIPTION
When QEMU is terminated by signal 15, it deletes the PidFile. Upon detecting that QEMU has exited, the shim executes the stopVM function. If the PidFile is not found, the PID is set to 0. Subsequently, the shim executes kill -9 0, which terminates the current process group. This prevents any further logic from being executed, resulting in resources not being cleaned up.