### PR TITLE
kata-manager: Avoid docker rate-limit

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -1035,7 +1035,7 @@ test_installation()
 
 	sudo kata-runtime check -v
 
-	local image="docker.io/library/busybox:latest"
+	local image="quay.io/prometheus/busybox:latest"
 	sudo $tool image pull "$image"
 
 	local container_name="${script_name/./-}-test-kata"


### PR DESCRIPTION
To do so, use a test image from quay.io instead of docker.io.