### PR TITLE
runtime: Allow machine_type in kata config for remote hypervisors

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1341,11 +1341,13 @@ func newStratovirtHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 }
 
 func newRemoteHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
+	machineType := h.machineType()
 
 	return vc.HypervisorConfig{
 		RemoteHypervisorSocket:  h.getRemoteHypervisorSocket(),
 		RemoteHypervisorTimeout: h.getRemoteHypervisorTimeout(),
 		DisableGuestSeLinux:     true, // The remote hypervisor has a different guest, so Guest SELinux config doesn't work
+		HypervisorMachineType:   machineType,
 		SharedFS:                config.NoSharedFS,
 
 		// No valid value so avoid to append block device to list in kata_agent.appendDevices


### PR DESCRIPTION
Fixes: #10211