### PR TITLE
Drop QEMU process privilege

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -144,6 +144,7 @@ impl QemuInner {
         info!(sl!(), "qemu args: {}", cmdline.build().await?.join(" "));
         let mut command = Command::new(&self.config.path);
         command.args(cmdline.build().await?);
+        command.uid(1000);
 
         info!(sl!(), "qemu cmd: {:?}", command);
 


### PR DESCRIPTION
Setting the effective UID to 1000 does the trick for the majority of Linuxes AFAIK
