### PR TITLE
docs: Add oneDNN benchmark information to metrics README

### DIFF
--- a/tests/metrics/machine_learning/README.md
+++ b/tests/metrics/machine_learning/README.md
@@ -73,3 +73,16 @@ Individual test can be run by hand, for example:
 $ cd metrics/machine_learning
 $ ./openvino.sh
 ```
+
+# Kata Containers `oneDNN` Benchmark
+
+This is a test of the Intel `oneDNN` as an Intel optimized library for Deep Neural Networks
+and making use of its built-in `benchdnn` functionality.
+
+## Running the `oneDNN` test
+Individual test can be run by hand, for example:
+
+```
+$ cd metrics/machine_learning
+$ ./onednn.sh
+```


### PR DESCRIPTION
This PR adds the oneDNN benchmark information to the machine learning metrics README.