### PR TITLE
dragonball: Introduce `riscv64` architecture

### DIFF
--- a/src/dragonball/src/dbs_boot/src/lib.rs
+++ b/src/dragonball/src/dbs_boot/src/lib.rs
@@ -15,6 +15,11 @@ mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64::*;
 
+#[cfg(target_arch = "riscv64")]
+mod riscv64;
+#[cfg(target_arch = "riscv64")]
+pub use riscv64::*;
+
 /// Specialized [std::result::Result] for boot related operations.
 pub type Result<T> = std::result::Result<T, Error>;
 

--- a/src/dragonball/src/dbs_boot/src/riscv64/fdt.rs
+++ b/src/dragonball/src/dbs_boot/src/riscv64/fdt.rs
@@ -1,0 +1,153 @@
+// Copyright 2024 Alibaba Cloud. All Rights Reserved.
+// Copyright © 2024, Institute of Software, CAS. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Create Flatten Device Tree (FDT) for RISC-V 64-bit systems.
+
+use std::collections::HashMap;
+use std::fmt::Debug;
+
+use dbs_arch::aia::AIADevice;
+use dbs_arch::{DeviceInfoForFDT, DeviceType};
+
+use vm_fdt::FdtWriter;
+use vm_memory::GuestMemoryRegion;
+use vm_memory::{Address, Bytes, GuestAddress, GuestMemory};
+
+use super::fdt_utils::*;
+use super::Error;
+use crate::Result;
+
+const CPU_BASE_PHANDLE: u32 = 0x100;
+
+const AIA_APLIC_PHANDLE: u32 = 2;
+const AIA_IMSIC_PHANDLE: u32 = 3;
+const CPU_INTC_BASE_PHANDLE: u32 = 4;
+// Read the documentation specified when appending the root node to the FDT.
+const ADDRESS_CELLS: u32 = 0x2;
+const SIZE_CELLS: u32 = 0x2;
+
+/// Creates the flattened device tree for this riscv64 microVM.
+pub fn create_fdt<T>(
+    fdt_vm_info: FdtVmInfo,
+    fdt_device_info: FdtDeviceInfo<T>,
+) -> Result<Vec<u8>>
+where
+    T: DeviceInfoForFDT + Clone + Debug,
+{
+    // Allocate stuff necessary for storing the blob.
+    let mut fdt = FdtWriter::new()?;
+
+    // For an explanation why these nodes were introduced in the blob take a look at
+    // https://github.com/devicetree-org/devicetree-specification/releases/tag/v0.4
+    // In chapter 3.
+
+    // Header or the root node as per above mentioned documentation.
+    let root = fdt.begin_node("")?;
+    fdt.property_string("compatible", "linux,dummy-virt")?;
+    // For info on #address-cells and size-cells resort to Table 3.1 Root Node
+    // Properties
+    fdt.property_u32("#address-cells", ADDRESS_CELLS)?;
+    fdt.property_u32("#size-cells", SIZE_CELLS)?;
+    create_cpu_nodes(&mut fdt, &fdt_vm_info)?;
+    create_memory_node(&mut fdt, fdt_vm_info.get_guest_memory())?;
+    create_chosen_node(&mut fdt, &fdt_vm_info)?;
+    create_aia_node(&mut fdt, fdt_device_info.get_irqchip())?;
+    fdt_device_info
+        .get_mmio_device_info()
+        .map_or(Ok(()), |v| create_devices_node(&mut fdt, v))?;
+
+    // End Header node.
+    fdt.end_node(root)?;
+
+    // Allocate another buffer so we can format and then write fdt to guest.
+    let fdt_final = fdt.finish()?;
+
+    // Write FDT to memory.
+    let fdt_address = GuestAddress(super::get_fdt_addr(fdt_vm_info.get_guest_memory()));
+    fdt_vm_info
+        .get_guest_memory()
+        .write_slice(fdt_final.as_slice(), fdt_address)?;
+    Ok(fdt_final)
+}
+
+// Following are the auxiliary function for creating the different nodes that we append to our FDT.
+fn create_cpu_nodes(fdt: &mut FdtWriter, fdt_vm_info: &FdtVmInfo) -> Result<()> {
+    // See https://elixir.bootlin.com/linux/v6.10/source/Documentation/devicetree/bindings/riscv/cpus.yaml
+    let cpus = fdt.begin_node("cpus")?;
+    // As per documentation, on RISC-V 64-bit systems value should be set to 1.
+    fdt.property_u32("#address-cells", 0x01)?;
+    fdt.property_u32("#size-cells", 0x0)?;
+    // Retrieve CPU frequency from cpu timer regs
+    let timebase_frequency: u32 = 369999;
+    fdt.property_u32("timebase-frequency", timebase_frequency);
+
+    let num_cpus = fdt_vm_info.get_vcpu_num();
+    for cpu_index in 0..num_cpus {
+        let cpu = fdt.begin_node(&format!("cpu@{:x}", cpu_index))?;
+        fdt.property_string("device_type", "cpu")?;
+        fdt.property_string("compatible", "riscv")?;
+        fdt.property_string("mmy-type", "sv48")?;
+        fdt.property_string("riscv,isa", "rv64iafdcsu_smaia_ssaia")?;
+        fdt.property_string("status", "okay")?;
+        fdt.property_u64("reg", cpu_index as u64)?;
+        fdt.property_u32("phandle", CPU_BASE_PHANDLE + cpu_index)?;
+        fdt.end_node(cpu)?;
+
+        // interrupt controller node
+        let intc_node = fdt.begin_node("interrupt-controller")?;
+        fdt.property_string("compatible", "riscv,cpu-intc")?;
+        fdt.property_u32("#interrupt-cells", 1u32)?;
+        fdt.property_array_u32("interrupt-controller", &Vec::new())?;
+        fdt.property_u32("phandle", CPU_INTC_BASE_PHANDLE + cpu_index)?;
+        fdt.end_node(intc_node)?;
+    }
+    fdt.end_node(cpus)?;
+
+    Ok(())
+}
+
+fn create_memory_node<M: GuestMemory>(fdt: &mut FdtWriter, guest_mem: &M) -> Result<()> {
+    unimplemented!()
+}
+
+fn create_chosen_node(fdt: &mut FdtWriter, fdt_vm_info: &FdtVmInfo) -> Result<()> {
+    unimplemented!()
+}
+
+fn create_aia_node(fdt: &mut FdtWriter, aia_device: &dyn AIADevice) -> Result<()> {
+    unimplemented!()
+}
+
+fn create_virtio_node<T: DeviceInfoForFDT + Clone + Debug>(
+    fdt: &mut FdtWriter,
+    dev_info: &T,
+) -> Result<()> {
+    unimplemented!()
+}
+
+fn create_serial_node<T: DeviceInfoForFDT + Clone + Debug>(
+    fdt: &mut FdtWriter,
+    dev_info: &T,
+) -> Result<()> {
+    unimplemented!()
+}
+
+fn create_rtc_node<T: DeviceInfoForFDT + Clone + Debug>(
+    fdt: &mut FdtWriter,
+    dev_info: &T,
+) -> Result<()> {
+    unimplemented!()
+}
+
+fn create_devices_node<T: DeviceInfoForFDT + Clone + Debug>(
+    fdt: &mut FdtWriter,
+    dev_info: &HashMap<(DeviceType, String), T>,
+) -> Result<()> {
+    unimplemented!()
+}
+
+#[cfg(test)]
+mod tests {
+}

--- a/src/dragonball/src/dbs_boot/src/riscv64/fdt_utils.rs
+++ b/src/dragonball/src/dbs_boot/src/riscv64/fdt_utils.rs
@@ -1,0 +1,164 @@
+// Copyright 2024 Alibaba Cloud. All Rights Reserved.
+// Copyright © 2024, Institute of Software, CAS. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module abstract some structs for constructing fdt. Instead of using
+//! multiple parameters.
+
+use std::collections::HashMap;
+
+use dbs_arch::{aia::AIADevice, DeviceInfoForFDT, DeviceType};
+use vm_memory::mmap::GuestMemoryMmap;
+
+use crate::InitrdConfig;
+
+/// Struct to save vcpu information
+pub struct FdtVcpuInfo {
+    /// number of vcpu
+    vcpu_num: u32,
+}
+
+impl FdtVcpuInfo {
+    /// Generate FdtVcpuInfo
+    pub fn new(
+        vcpu_num: u32,
+    ) -> Self {
+        FdtVcpuInfo {
+            vcpu_num,
+        }
+    }
+}
+
+/// Struct to save vm information.
+pub struct FdtVmInfo<'a> {
+    /// guest meory
+    guest_memory: &'a GuestMemoryMmap,
+    /// command line
+    cmdline: &'a str,
+    /// initrd config
+    initrd_config: Option<&'a InitrdConfig>,
+    /// vcpu information
+    vcpu_info: FdtVcpuInfo,
+}
+
+impl FdtVmInfo<'_> {
+    /// Generate FdtVmInfo.
+    pub fn new<'a>(
+        guest_memory: &'a GuestMemoryMmap,
+        cmdline: &'a str,
+        initrd_config: Option<&'a InitrdConfig>,
+        vcpu_info: FdtVcpuInfo,
+    ) -> FdtVmInfo<'a> {
+        FdtVmInfo {
+            guest_memory,
+            cmdline,
+            initrd_config,
+            vcpu_info,
+        }
+    }
+
+    /// Get guest_memory.
+    pub fn get_guest_memory(&self) -> &GuestMemoryMmap {
+        self.guest_memory
+    }
+
+    /// Get cmdline.
+    pub fn get_cmdline(&self) -> &str {
+        self.cmdline
+    }
+
+    /// Get initrd_config.
+    pub fn get_initrd_config(&self) -> Option<&InitrdConfig> {
+        self.initrd_config
+    }
+
+    /// Get number of vcpu.
+    pub fn get_vcpu_num(&self) -> u32 {
+        self.vcpu_info.vcpu_num
+    }
+}
+
+/// Struct to save device information.
+pub struct FdtDeviceInfo<'a, T: DeviceInfoForFDT> {
+    /// mmio device information
+    mmio_device_info: Option<&'a HashMap<(DeviceType, String), T>>,
+    /// interrupt controller
+    irq_chip: &'a dyn AIADevice,
+}
+
+impl<T: DeviceInfoForFDT> FdtDeviceInfo<'_, T> {
+    /// Generate FdtDeviceInfo.
+    pub fn new<'a>(
+        mmio_device_info: Option<&'a HashMap<(DeviceType, String), T>>,
+        irq_chip: &'a dyn AIADevice,
+    ) -> FdtDeviceInfo<'a, T> {
+        FdtDeviceInfo {
+            mmio_device_info,
+            irq_chip,
+        }
+    }
+
+    /// Get mmio device information.
+    pub fn get_mmio_device_info(&self) -> Option<&HashMap<(DeviceType, String), T>> {
+        self.mmio_device_info
+    }
+
+    /// Get interrupt controller.
+    pub fn get_irqchip(&self) -> &dyn AIADevice {
+        self.irq_chip
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use dbs_arch::aia::create_aia;
+    use vm_memory::{GuestAddress, GuestMemory};
+
+    const CMDLINE: &str = "console=tty0";
+    const INITRD_CONFIG: InitrdConfig = InitrdConfig {
+        address: GuestAddress(0x10000000),
+        size: 0x1000,
+    };
+    const VCPU_NUM: u32 = 1;
+
+    #[inline]
+    fn helper_generate_fdt_vm_info(guest_memory: &GuestMemoryMmap) -> FdtVmInfo<'_> {
+        FdtVmInfo::new(
+            guest_memory,
+            CMDLINE,
+            Some(&INITRD_CONFIG),
+            FdtVcpuInfo::new(
+                VCPU_NUM
+            ),
+        )
+    }
+
+    #[test]
+    fn test_fdtutils_fdt_vm_info() {
+        let ranges = vec![(GuestAddress(0x80000000), 0x40000)];
+        let guest_memory: GuestMemoryMmap<()> =
+            GuestMemoryMmap::<()>::from_ranges(ranges.as_slice())
+                .expect("Cannot initialize memory");
+        let vm_info = helper_generate_fdt_vm_info(&guest_memory);
+
+        assert_eq!(
+            guest_memory.check_address(GuestAddress(0x80001000)),
+            Some(GuestAddress(0x80001000))
+        );
+        assert_eq!(guest_memory.check_address(GuestAddress(0x80050000)), None);
+        assert!(guest_memory.check_range(GuestAddress(0x80000000), 0x40000));
+        assert_eq!(vm_info.get_cmdline(), CMDLINE);
+        assert_eq!(
+            vm_info.get_initrd_config().unwrap().address,
+            INITRD_CONFIG.address
+        );
+        assert_eq!(
+            vm_info.get_initrd_config().unwrap().size,
+            INITRD_CONFIG.size
+        );
+        assert_eq!(vm_info.get_vcpu_num(), VCPU_NUM);
+    }
+}

--- a/src/dragonball/src/dbs_boot/src/riscv64/layout.rs
+++ b/src/dragonball/src/dbs_boot/src/riscv64/layout.rs
@@ -1,0 +1,79 @@
+// Copyright © 2024, Institute of Software, CAS. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//
+// Memory layout of riscv64 guest:
+//
+// RAM end    +---------------------------------------------------------------+
+// (dynamic,  |                                                               |
+// including  |                                                               |
+// hotplug    ~                   ~                       ~                   ~
+// memory)    |                                                               |
+//            |                            DRAM                               |
+//            ~                   ~                       ~                   ~
+//            |                                                               |
+//            |                                                               |
+// 0x80000000 +---------------------------------------------------------------+
+//            |                             ...                               |
+// 0x08100000 +---------------------------------------------------------------+
+//            |                                                               |
+//            |                           VIRTIO (0x1000)                     |
+//            |                                                               |
+// 0x08002000 +---------------------------------------------------------------+
+//            |                             RTC (0x1000)                      |
+// 0x08001000 +---------------------------------------------------------------|
+//            |                            UART (0x100)                       |
+// 0x08000000 +---------------------------------------------------------------+
+//            |                                                               |
+//  (64M)     |                           IMSICs                              |
+//            |                                                               |
+// 0x04000000 +---------------------------------------------------------------+
+//            |                                                               |
+//  (64M)     |                           APLICs                              |
+//            |                                                               |
+// 0 GB       +---------------------------------------------------------------+
+//
+
+/// Start of RAM.
+pub const DRAM_MEM_START: u64 = 0x8000_0000; // 2 GB.
+
+pub const SYSTEM_MEM_START: u64 = 0;
+
+/// Kernel command line maximum size on RISC-V.
+/// See https://elixir.bootlin.com/linux/v6.10/source/arch/riscv/include/uapi/asm/setup.h
+pub const CMDLINE_MAX_SIZE: usize = 1024;
+
+pub const FDT_MAX_SIZE: usize = 0x1_0000;
+
+/// First usable interrupt on riscv64.
+pub const IRQ_BASE: u32 = dbs_arch::aia::IRQ_BASE;
+
+/// 0x0800_2000 ~ 0x0810_0000 is reserved for VIRTIO devices.
+pub const VIRTIO_START: u64 = 0x0800_2000;
+pub const VIRTIO_SIZE: u64 = 0x1000;
+
+/// 0x0800_1000 ~ 0x0800_2000 is reserved for RTC devices.
+pub const RTC_START: u64 = 0x0800_1000;
+pub const RTC_SIZE: u64 = 0x1000;
+
+/// 0x0800_0000 ~ 0x0800_1000 is reserved for UART devices.
+pub const UART_START: u64 = 0x0800_0000;
+pub const UART_SIZE: u64 = 0x0100;
+
+/// AIA related devices
+/// See https://elixir.bootlin.com/linux/v6.10/source/arch/riscv/include/uapi/asm/kvm.h
+/// 0x0400_0000 ~ 0x0800_0000 (64 MiB) resides IMSICs
+pub const IMSIC_START: u64 = 0x0400_0000;
+pub const IMSIC_SIZE: u64 = 0x0400_0000;
+
+/// 0x0 ~ 0x0400_0000 (64 MiB) resides APLICs
+pub const APLIC_START: u64 = 0;
+pub const APLIC_SIZE: u64 = 0x0400_0000;
+
+/// Kernel start with a 2MiB shift.
+pub const KERNEL_OFFSET: u64 = 0x20_0000;
+
+pub const INITRD_ALIGN: u64 = 8;
+pub const FDT_ALIGN: u64 = 0x40_0000;

--- a/src/dragonball/src/dbs_boot/src/riscv64/mod.rs
+++ b/src/dragonball/src/dbs_boot/src/riscv64/mod.rs
@@ -1,0 +1,103 @@
+// Copyright 2021 Alibaba Cloud. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! VM boot related constants and utilities for `riscv64` architecture.
+
+use vm_fdt::Error as VmFdtError;
+use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryError};
+
+// /// Magic addresses externally used to lay out riscv64 VMs.
+// pub mod layout;
+
+/// FDT is used to inform the guest kernel of device tree information.
+pub mod fdt;
+
+/// Helper structs for constructing  fdt.
+pub mod fdt_utils;
+
+/// Default (smallest) memory page size for the supported architectures.
+pub const PAGE_SIZE: usize = 4096;
+
+/// Errors thrown while configuring the Flattened Device Tree for aarch64.
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Failure in creating FDT
+    #[error("create fdt fail: {0}")]
+    CreateFdt(#[from] VmFdtError),
+    /// Failure in writing FDT in memory.
+    #[error("write fdt to memory fail: {0}")]
+    WriteFDTToMemory(#[from] GuestMemoryError),
+    /// Failed to compute the initrd address.
+    #[error("Failed to compute the initrd address.")]
+    InitrdAddress,
+    /// Invalid arguments
+    #[error("invalid arguments")]
+    InvalidArguments,
+}
+
+/// Returns the memory address where the kernel could be loaded.
+pub fn get_kernel_start() -> u64 {
+    layout::DRAM_MEM_START
+}
+
+/// Auxiliary function to get the address where the device tree blob is loaded.
+pub fn get_fdt_addr<M: GuestMemory>(mem: &M) -> u64 {
+    // If the memory allocated is smaller than the size allocated for the FDT,
+    // we return the start of the DRAM so that
+    // we allow the code to try and load the FDT.
+    if let Some(offset) = mem.last_addr().checked_sub(layout::FDT_MAX_SIZE as u64 - 1) {
+        if mem.address_in_range(offset) {
+            return offset.raw_value();
+        }
+    }
+    layout::DRAM_MEM_START
+}
+
+/// Returns the memory address where the initrd could be loaded.
+pub fn initrd_load_addr<M: GuestMemory>(guest_mem: &M, initrd_size: u64) -> super::Result<u64> {
+    let round_to_pagesize = |size| (size + (PAGE_SIZE as u64 - 1)) & !(PAGE_SIZE as u64 - 1);
+    match GuestAddress(get_fdt_addr(guest_mem)).checked_sub(round_to_pagesize(initrd_size)) {
+        Some(offset) => {
+            if guest_mem.address_in_range(offset) {
+                Ok(offset.raw_value())
+            } else {
+                Err(Error::InitrdAddress)
+            }
+        }
+        None => Err(Error::InitrdAddress),
+    }
+}
+
+#[cfg(test)]
+pub mod tests {
+    use dbs_arch::{DeviceInfoForFDT, Error as ArchError};
+
+    const LEN: u64 = 4096;
+
+    #[derive(Clone, Debug, PartialEq)]
+    pub struct MMIODeviceInfo {
+        addr: u64,
+        irq: u32,
+    }
+
+    impl MMIODeviceInfo {
+        pub fn new(addr: u64, irq: u32) -> Self {
+            MMIODeviceInfo { addr, irq }
+        }
+    }
+
+    impl DeviceInfoForFDT for MMIODeviceInfo {
+        fn addr(&self) -> u64 {
+            self.addr
+        }
+        fn irq(&self) -> std::result::Result<u32, ArchError> {
+            Ok(self.irq)
+        }
+        fn length(&self) -> u64 {
+            LEN
+        }
+        fn get_device_id(&self) -> Option<u32> {
+            None
+        }
+    }
+}

--- a/src/dragonball/src/dbs_boot/src/riscv64/mod.rs
+++ b/src/dragonball/src/dbs_boot/src/riscv64/mod.rs
@@ -1,4 +1,6 @@
-// Copyright 2021 Alibaba Cloud. All Rights Reserved.
+// Copyright 2024 Alibaba Cloud. All Rights Reserved.
+// Copyright © 2024, Institute of Software, CAS. All rights reserved.
+//
 // SPDX-License-Identifier: Apache-2.0
 
 //! VM boot related constants and utilities for `riscv64` architecture.
@@ -6,8 +8,8 @@
 use vm_fdt::Error as VmFdtError;
 use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryError};
 
-// /// Magic addresses externally used to lay out riscv64 VMs.
-// pub mod layout;
+/// Magic addresses externally used to lay out riscv64 VMs.
+pub mod layout;
 
 /// FDT is used to inform the guest kernel of device tree information.
 pub mod fdt;


### PR DESCRIPTION
Introduce `riscv64` architecture support to dragonball.

Fixes: #10226

Depends: #10531