### PR TITLE
metrics: Remove unused variable in oneDNN benchmark

### DIFF
--- a/tests/metrics/machine_learning/onednn.sh
+++ b/tests/metrics/machine_learning/onednn.sh
@@ -62,7 +62,6 @@ EOF
 }
 
 function main() {
-	local i=0
 	local cmds=("docker")
 	local RES_DIR="/var/lib/phoronix-test-suite/test-results"
 


### PR DESCRIPTION
This PR removes an unused variable in oneDNN metrics benchmark.