### PR TITLE
agent:cdh: Refactor CDHClient usage and initialization

### DIFF
--- a/src/agent/src/cdh.rs
+++ b/src/agent/src/cdh.rs
@@ -85,6 +85,11 @@ pub async fn init_cdh_client() -> Result<()> {
     Ok(())
 }
 
+/// Check if the CDH client is initialized
+pub async fn is_cdh_client_initialized() -> bool {
+    CDH_CLIENT.get().is_some() // Returns true if CDH_CLIENT is initialized, false otherwise
+}
+
 pub async fn unseal_env(env: &str) -> Result<String> {
     let cdh_client = CDH_CLIENT
         .get()


### PR DESCRIPTION
- Introduced a global `CDH_CLIENT` instance to hold the cdh client and implemented `init_cdh_client` function to initialize the cdh client if not already set.
- Move `unseal_env` and `secure_mount` functions on the global `CDH_CLIENT` instance to access the CDH client.
- Decouple the cdh client from AgentService and refactor cdh client usage and initialization in kata-agent.

Fixes: #10231 