### PR TITLE
tests: Enable k8s soak stability test for Kata CoCo CI

### DIFF
--- a/.github/workflows/run-kata-coco-stability-tests.yaml
+++ b/.github/workflows/run-kata-coco-stability-tests.yaml
@@ -105,7 +105,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
 
       - name: Run stability tests
-        timeout-minutes: 100
+        timeout-minutes: 300
         run: bash tests/stability/gha-stability-run.sh run-tests
 
       - name: Delete AKS cluster

--- a/tests/stability/gha-stability-run.sh
+++ b/tests/stability/gha-stability-run.sh
@@ -16,6 +16,9 @@ source "${stability_dir}/../metrics/lib/common.bash"
 function run_tests() {
 	info "Running scability test using ${KATA_HYPERVISOR} hypervisor"
 	bash "${stability_dir}/kubernetes_stability.sh"
+
+	info "Running soak stability test using ${KATA_HYPERVISOR} hypervisor"
+	bash "${stability_dir}/kubernetes_soak_test.sh"
 }
 
 function main() {


### PR DESCRIPTION
This PR enables the k8s soak stability test to run on the weekly Kata CoCo stability CI.