### PR TITLE
virtcontainers: allow specifying nydus-overlayfs binary by path

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -318,7 +318,7 @@ func checkAndMount(s *service, r *taskAPI.CreateTaskRequest) (bool, error) {
 			return false, nil
 		}
 
-		if m.Type == vc.NydusRootFSType {
+		if vc.IsNydusRootFSType(m.Type) {
 			// if kata + nydus, do not mount
 			return false, nil
 		}

--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -244,7 +244,7 @@ func CreateContainer(ctx context.Context, sandbox vc.VCSandbox, ociSpec specs.Sp
 	}
 
 	if !rootFs.Mounted {
-		if rootFs.Source != "" && rootFs.Type != vc.NydusRootFSType {
+		if rootFs.Source != "" && !vc.IsNydusRootFSType(rootFs.Type) {
 			realPath, err := ResolvePath(rootFs.Source)
 			if err != nil {
 				return vc.Process{}, err

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -904,7 +904,7 @@ func (c *Container) rollbackFailingContainerCreation(ctx context.Context) {
 		c.Logger().WithError(err).Error("rollback failed unmountHostMounts()")
 	}
 
-	if c.rootFs.Type == NydusRootFSType {
+	if IsNydusRootFSType(c.rootFs.Type) {
 		if err := nydusContainerCleanup(ctx, getMountPath(c.sandbox.id), c); err != nil {
 			c.Logger().WithError(err).Error("rollback failed nydusContainerCleanup()")
 		}
@@ -1028,7 +1028,7 @@ func (c *Container) create(ctx context.Context) (err error) {
 		}
 	}()
 
-	if c.checkBlockDeviceSupport(ctx) && c.rootFs.Type != NydusRootFSType {
+	if c.checkBlockDeviceSupport(ctx) && !IsNydusRootFSType(c.rootFs.Type) {
 		// If the rootfs is backed by a block device, go ahead and hotplug it to the guest
 		if err = c.hotplugDrive(ctx); err != nil {
 			return
@@ -1178,7 +1178,7 @@ func (c *Container) stop(ctx context.Context, force bool) error {
 		return err
 	}
 
-	if c.rootFs.Type == NydusRootFSType {
+	if IsNydusRootFSType(c.rootFs.Type) {
 		if err := nydusContainerCleanup(ctx, getMountPath(c.sandbox.id), c); err != nil && !force {
 			return err
 		}

--- a/src/runtime/virtcontainers/fs_share_linux.go
+++ b/src/runtime/virtcontainers/fs_share_linux.go
@@ -541,7 +541,7 @@ func (f *FilesystemShare) ShareRootFilesystem(ctx context.Context, c *Container)
 		return f.shareRootFilesystemWithVirtualVolume(ctx, c)
 	}
 
-	if c.rootFs.Type == NydusRootFSType {
+	if IsNydusRootFSType(c.rootFs.Type) {
 		return f.shareRootFilesystemWithNydus(ctx, c)
 	}
 	rootfsGuestPath := filepath.Join(kataGuestSharedDir(), c.id, c.rootfsSuffix)
@@ -641,7 +641,7 @@ func (f *FilesystemShare) ShareRootFilesystem(ctx context.Context, c *Container)
 }
 
 func (f *FilesystemShare) UnshareRootFilesystem(ctx context.Context, c *Container) error {
-	if c.rootFs.Type == NydusRootFSType {
+	if IsNydusRootFSType(c.rootFs.Type) {
 		if err2 := nydusContainerCleanup(ctx, getMountPath(c.sandbox.id), c); err2 != nil {
 			f.Logger().WithError(err2).Error("rollback failed nydusContainerCleanup")
 		}

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -68,8 +69,6 @@ const (
 
 	// path to vfio devices
 	vfioPath = "/dev/vfio/"
-
-	NydusRootFSType = "fuse.nydus-overlayfs"
 
 	VirtualVolumePrefix = "io.katacontainers.volume="
 
@@ -2625,4 +2624,19 @@ func (k *kataAgent) setPolicy(ctx context.Context, policy string) error {
 		return status.Errorf(codes.DeadlineExceeded, "SetPolicyRequest timed out")
 	}
 	return err
+}
+
+// IsNydusRootFSType checks if the given mount type indicates Nydus is used.
+// By default, Nydus will use "fuse.nydus-overlayfs" as the mount type, but
+// we also accept binaries which have "nydus-overlayfs" prefix, so you can,
+// for example, place a nydus-overlayfs-abcde binary in the PATH and use
+// "fuse.nydus-overlayfs-abcde" as the mount type.
+// Further, we allow passing the full path to a Nydus binary as the mount type,
+// so "fuse./usr/local/bin/nydus-overlayfs" is also recognized.
+func IsNydusRootFSType(s string) bool {
+	if !strings.HasPrefix(s, "fuse.") {
+		return false
+	}
+	s = strings.TrimPrefix(s, "fuse.")
+	return strings.HasPrefix(path.Base(s), "nydus-overlayfs")
 }

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -1202,3 +1202,19 @@ func TestKataAgentDirs(t *testing.T) {
 	expected := "/rafs/123/lowerdir"
 	assert.Equal(rafsMountPath(cid), expected)
 }
+
+func TestIsNydusRootFSType(t *testing.T) {
+	testCases := map[string]bool{
+		"nydus":                               false,
+		"nydus-overlayfs":                     false,
+		"fuse.nydus-overlayfs":                true,
+		"fuse./usr/local/bin/nydus-overlayfs": true,
+		"fuse.nydus-overlayfs-e0ae398a2":      true,
+	}
+
+	for test, exp := range testCases {
+		t.Run(test, func(t *testing.T) {
+			assert.Equal(t, exp, IsNydusRootFSType(test))
+		})
+	}
+}

--- a/src/runtime/virtcontainers/mount_linux.go
+++ b/src/runtime/virtcontainers/mount_linux.go
@@ -184,7 +184,7 @@ func bindUnmountAllRootfs(ctx context.Context, sharedDir string, sandbox *Sandbo
 		if c.state.Fstype == "" {
 			// even if error found, don't break out of loop until all mounts attempted
 			// to be unmounted, and collect all errors
-			if c.rootFs.Type == NydusRootFSType {
+			if IsNydusRootFSType(c.state.Fstype) {
 				errors = merr.Append(errors, nydusContainerCleanup(ctx, sharedDir, c))
 			} else {
 				errors = merr.Append(errors, bindUnmountContainerRootfs(ctx, sharedDir, c.id))


### PR DESCRIPTION
...or by using a binary with additional suffix.

This allows having multiple verisons of nydus-overlayfs installed on the host, telling nydus-snapshotter which one to use while still detecting Nydus is used.

