### PR TITLE
agent: Refactor storage handler registration

### DIFF
--- a/src/agent/src/storage/bind_watcher_handler.rs
+++ b/src/agent/src/storage/bind_watcher_handler.rs
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::device::DRIVER_WATCHABLE_BIND_TYPE;
+use crate::storage::{new_device, StorageContext, StorageHandler};
 use anyhow::Result;
 use kata_types::mount::StorageDevice;
 use protocols::agent::Storage;
@@ -11,13 +13,16 @@ use std::iter;
 use std::sync::Arc;
 use tracing::instrument;
 
-use crate::storage::{new_device, StorageContext, StorageHandler};
-
 #[derive(Debug)]
 pub struct BindWatcherHandler {}
 
 #[async_trait::async_trait]
 impl StorageHandler for BindWatcherHandler {
+    #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_WATCHABLE_BIND_TYPE]
+    }
+
     #[instrument]
     async fn create_device(
         &self,

--- a/src/agent/src/storage/block_handler.rs
+++ b/src/agent/src/storage/block_handler.rs
@@ -10,6 +10,10 @@ use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
 
+use crate::device::{
+    DRIVER_BLK_CCW_TYPE, DRIVER_BLK_MMIO_TYPE, DRIVER_BLK_PCI_TYPE, DRIVER_NVDIMM_TYPE,
+    DRIVER_SCSI_TYPE,
+};
 use anyhow::{anyhow, Context, Result};
 use kata_types::mount::StorageDevice;
 use protocols::agent::Storage;
@@ -29,6 +33,11 @@ pub struct VirtioBlkMmioHandler {}
 
 #[async_trait::async_trait]
 impl StorageHandler for VirtioBlkMmioHandler {
+    #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_BLK_MMIO_TYPE]
+    }
+
     #[instrument]
     async fn create_device(
         &self,
@@ -50,6 +59,11 @@ pub struct VirtioBlkPciHandler {}
 
 #[async_trait::async_trait]
 impl StorageHandler for VirtioBlkPciHandler {
+    #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_BLK_PCI_TYPE]
+    }
+
     #[instrument]
     async fn create_device(
         &self,
@@ -81,6 +95,11 @@ pub struct VirtioBlkCcwHandler {}
 
 #[async_trait::async_trait]
 impl StorageHandler for VirtioBlkCcwHandler {
+    #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_BLK_CCW_TYPE]
+    }
+
     #[cfg(target_arch = "s390x")]
     #[instrument]
     async fn create_device(
@@ -112,6 +131,11 @@ pub struct ScsiHandler {}
 #[async_trait::async_trait]
 impl StorageHandler for ScsiHandler {
     #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_SCSI_TYPE]
+    }
+
+    #[instrument]
     async fn create_device(
         &self,
         mut storage: Storage,
@@ -131,6 +155,11 @@ pub struct PmemHandler {}
 
 #[async_trait::async_trait]
 impl StorageHandler for PmemHandler {
+    #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_NVDIMM_TYPE]
+    }
+
     #[instrument]
     async fn create_device(
         &self,

--- a/src/agent/src/storage/ephemeral_handler.rs
+++ b/src/agent/src/storage/ephemeral_handler.rs
@@ -36,6 +36,11 @@ pub struct EphemeralHandler {}
 #[async_trait::async_trait]
 impl StorageHandler for EphemeralHandler {
     #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_EPHEMERAL_TYPE]
+    }
+
+    #[instrument]
     async fn create_device(
         &self,
         mut storage: Storage,

--- a/src/agent/src/storage/fs_handler.rs
+++ b/src/agent/src/storage/fs_handler.rs
@@ -8,18 +8,23 @@ use std::fs;
 use std::path::Path;
 use std::sync::Arc;
 
+use crate::device::{DRIVER_9P_TYPE, DRIVER_OVERLAYFS_TYPE, DRIVER_VIRTIOFS_TYPE};
+use crate::storage::{common_storage_handler, new_device, StorageContext, StorageHandler};
 use anyhow::{anyhow, Context, Result};
 use kata_types::mount::StorageDevice;
 use protocols::agent::Storage;
 use tracing::instrument;
-
-use crate::storage::{common_storage_handler, new_device, StorageContext, StorageHandler};
 
 #[derive(Debug)]
 pub struct OverlayfsHandler {}
 
 #[async_trait::async_trait]
 impl StorageHandler for OverlayfsHandler {
+    #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_OVERLAYFS_TYPE]
+    }
+
     #[instrument]
     async fn create_device(
         &self,
@@ -62,6 +67,11 @@ pub struct Virtio9pHandler {}
 #[async_trait::async_trait]
 impl StorageHandler for Virtio9pHandler {
     #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_9P_TYPE]
+    }
+
+    #[instrument]
     async fn create_device(
         &self,
         storage: Storage,
@@ -77,6 +87,11 @@ pub struct VirtioFsHandler {}
 
 #[async_trait::async_trait]
 impl StorageHandler for VirtioFsHandler {
+    #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_VIRTIOFS_TYPE]
+    }
+
     #[instrument]
     async fn create_device(
         &self,

--- a/src/agent/src/storage/image_pull_handler.rs
+++ b/src/agent/src/storage/image_pull_handler.rs
@@ -33,6 +33,11 @@ impl ImagePullHandler {
 #[async_trait::async_trait]
 impl StorageHandler for ImagePullHandler {
     #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL]
+    }
+
+    #[instrument]
     async fn create_device(
         &self,
         storage: Storage,

--- a/src/agent/src/storage/local_handler.rs
+++ b/src/agent/src/storage/local_handler.rs
@@ -8,6 +8,7 @@ use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::sync::Arc;
 
+use crate::device::DRIVER_LOCAL_TYPE;
 use anyhow::{Context, Result};
 use kata_types::mount::{StorageDevice, KATA_MOUNT_OPTION_FS_GID};
 use nix::unistd::Gid;
@@ -21,6 +22,11 @@ pub struct LocalHandler {}
 
 #[async_trait::async_trait]
 impl StorageHandler for LocalHandler {
+    #[instrument]
+    fn driver_types(&self) -> &[&str] {
+        &[DRIVER_LOCAL_TYPE]
+    }
+
     #[instrument]
     async fn create_device(
         &self,

--- a/src/agent/src/storage/mod.rs
+++ b/src/agent/src/storage/mod.rs
@@ -139,20 +139,20 @@ pub trait StorageHandler: Send + Sync {
 lazy_static! {
     pub static ref STORAGE_HANDLERS: StorageHandlerManager<Arc<dyn StorageHandler>> = {
         let mut manager: StorageHandlerManager<Arc<dyn StorageHandler>> = StorageHandlerManager::new();
-        manager.add_handler(DRIVER_9P_TYPE, Arc::new(Virtio9pHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_9P_TYPE], Arc::new(Virtio9pHandler{})).unwrap();
         #[cfg(target_arch = "s390x")]
-        manager.add_handler(crate::device::DRIVER_BLK_CCW_TYPE, Arc::new(self::block_handler::VirtioBlkCcwHandler{})).unwrap();
-        manager.add_handler(DRIVER_BLK_MMIO_TYPE, Arc::new(VirtioBlkMmioHandler{})).unwrap();
-        manager.add_handler(DRIVER_BLK_PCI_TYPE, Arc::new(VirtioBlkPciHandler{})).unwrap();
-        manager.add_handler(DRIVER_EPHEMERAL_TYPE, Arc::new(EphemeralHandler{})).unwrap();
-        manager.add_handler(DRIVER_LOCAL_TYPE, Arc::new(LocalHandler{})).unwrap();
-        manager.add_handler(DRIVER_NVDIMM_TYPE, Arc::new(PmemHandler{})).unwrap();
-        manager.add_handler(DRIVER_OVERLAYFS_TYPE, Arc::new(OverlayfsHandler{})).unwrap();
-        manager.add_handler(DRIVER_SCSI_TYPE, Arc::new(ScsiHandler{})).unwrap();
-        manager.add_handler(DRIVER_VIRTIOFS_TYPE, Arc::new(VirtioFsHandler{})).unwrap();
-        manager.add_handler(DRIVER_WATCHABLE_BIND_TYPE, Arc::new(BindWatcherHandler{})).unwrap();
+        manager.add_handler(&[crate::device::DRIVER_BLK_CCW_TYPE], Arc::new(self::block_handler::VirtioBlkCcwHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_BLK_MMIO_TYPE], Arc::new(VirtioBlkMmioHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_BLK_PCI_TYPE], Arc::new(VirtioBlkPciHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_EPHEMERAL_TYPE], Arc::new(EphemeralHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_LOCAL_TYPE], Arc::new(LocalHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_NVDIMM_TYPE], Arc::new(PmemHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_OVERLAYFS_TYPE], Arc::new(OverlayfsHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_SCSI_TYPE], Arc::new(ScsiHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_VIRTIOFS_TYPE], Arc::new(VirtioFsHandler{})).unwrap();
+        manager.add_handler(&[DRIVER_WATCHABLE_BIND_TYPE], Arc::new(BindWatcherHandler{})).unwrap();
         #[cfg(feature = "guest-pull")]
-        manager.add_handler(KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL, Arc::new(ImagePullHandler{})).unwrap();
+        manager.add_handler(&[KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL], Arc::new(ImagePullHandler{})).unwrap();
         manager
     };
 }

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -446,13 +446,19 @@ pub struct StorageHandlerManager<H> {
     handlers: HashMap<String, H>,
 }
 
-impl<H> Default for StorageHandlerManager<H> {
+impl<H> Default for StorageHandlerManager<H> 
+where
+    H: Clone,
+{
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl<H> StorageHandlerManager<H> {
+impl<H> StorageHandlerManager<H> 
+where
+    H: Clone,
+{
     /// Create a new instance of `StorageHandlerManager`.
     pub fn new() -> Self {
         Self {
@@ -461,14 +467,18 @@ impl<H> StorageHandlerManager<H> {
     }
 
     /// Register a storage device handler.
-    pub fn add_handler(&mut self, id: &str, handler: H) -> Result<()> {
-        match self.handlers.entry(id.to_string()) {
-            Entry::Occupied(_) => Err(anyhow!("storage handler for {} already exists", id)),
-            Entry::Vacant(entry) => {
-                entry.insert(handler);
-                Ok(())
+    pub fn add_handler(&mut self, ids: &[&str], handler: H) -> Result<()> {
+        for &id in ids {
+            match self.handlers.entry(id.to_string()) {
+                Entry::Occupied(_) => {
+                    return Err(anyhow!("storage handler for {} already exists", id));
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(handler.clone());
+                }
             }
         }
+        Ok(())
     }
 
     /// Get storage handler with specified `id`.


### PR DESCRIPTION
Support registering multiple IDs to a single handler and Refactor storage handler registration. That's the pre-PR for the trusted data storage feature in CoCo.

Fixes: https://github.com/kata-containers/kata-containers/issues/10242