### PR TITLE
runtime: Add heartbeat check parameters to the configuration file.

### DIFF
--- a/src/runtime/config/configuration-acrn.toml.in
+++ b/src/runtime/config/configuration-acrn.toml.in
@@ -261,3 +261,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -469,3 +469,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -388,3 +388,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -713,3 +713,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -686,3 +686,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -682,3 +682,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -707,3 +707,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -661,3 +661,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-qemu-sev.toml.in
+++ b/src/runtime/config/configuration-qemu-sev.toml.in
@@ -639,3 +639,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -684,3 +684,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -676,3 +676,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -712,3 +712,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-remote.toml.in
+++ b/src/runtime/config/configuration-remote.toml.in
@@ -305,3 +305,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/config/configuration-stratovirt.toml.in
+++ b/src/runtime/config/configuration-stratovirt.toml.in
@@ -413,3 +413,10 @@ create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
+
+# The heartbeat check interval between kata-shim and kata-agent. unit: seconds
+# If heartbeat_check_interval is set to 0, it means that no heartbeat check will be performed.
+heartbeat_check_interval = 5
+# The timeout for sending gRPC checkrequest. unit: seconds.
+# If heartbeat_check_interval is set to 0, this parameter does not take effect.
+heartbeat_check_timeout = 30

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -190,6 +190,8 @@ type runtime struct {
 	DisableGuestEmptyDir      bool     `toml:"disable_guest_empty_dir"`
 	CreateContainerTimeout    uint64   `toml:"create_container_timeout"`
 	DanConf                   string   `toml:"dan_conf"`
+	HeartbeatCheckInterval    uint64   `toml:"heartbeat_check_interval"`
+	HeartbeatCheckTimeout     uint64   `toml:"heartbeat_check_timeout"`
 }
 
 type agent struct {
@@ -1657,6 +1659,8 @@ func LoadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 	config.JaegerUser = tomlConf.Runtime.JaegerUser
 	config.JaegerPassword = tomlConf.Runtime.JaegerPassword
 	config.CreateContainerTimeout = tomlConf.Runtime.CreateContainerTimeout
+	config.HeartbeatCheckInterval = tomlConf.Runtime.HeartbeatCheckInterval
+	config.HeartbeatCheckTimeout = tomlConf.Runtime.HeartbeatCheckTimeout
 	for _, f := range tomlConf.Runtime.Experimental {
 		feature := exp.Get(f)
 		if feature == nil {

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -164,6 +164,9 @@ type RuntimeConfig struct {
 
 	// Base directory of directly attachable network config
 	DanConfig string
+
+	HeartbeatCheckInterval uint64
+	HeartbeatCheckTimeout  uint64
 }
 
 // AddKernelParam allows the addition of new kernel parameters to an existing
@@ -1067,6 +1070,10 @@ func SandboxConfig(ocispec specs.Spec, runtime RuntimeConfig, bundlePath, cid st
 		Experimental: runtime.Experimental,
 
 		CreateContainerTimeout: runtime.CreateContainerTimeout,
+
+		HeartbeatCheckInterval: runtime.HeartbeatCheckInterval,
+
+		HeartbeatCheckTimeout: runtime.HeartbeatCheckTimeout,
 	}
 
 	if err := addAnnotations(ocispec, &sandboxConfig, runtime); err != nil {

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -384,6 +384,8 @@ func (k *kataAgent) init(ctx context.Context, sandbox *Sandbox, config KataAgent
 	k.dialTimout = config.DialTimeout
 
 	createContainerRequestTimeout = time.Duration(sandbox.config.CreateContainerTimeout) * time.Second
+	checkRequestTimeout = time.Duration(sandbox.config.HeartbeatCheckTimeout) * time.Second
+
 	k.Logger().WithFields(logrus.Fields{
 		"createContainerRequestTimeout": fmt.Sprintf("%+v", createContainerRequestTimeout),
 	}).Info("The createContainerRequestTimeout has been set ")

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -186,6 +186,9 @@ type SandboxConfig struct {
 	// Create container timeout which, if provided, indicates the create container timeout
 	// needed for the workload(s)
 	CreateContainerTimeout uint64
+
+	HeartbeatCheckInterval uint64
+	HeartbeatCheckTimeout  uint64
 }
 
 // valid checks that the sandbox configuration is valid.


### PR DESCRIPTION
The code I submitted is useful in the following two situations:
1. In some scenarios, such as when the load in the kata container is very high, the default 30-second timeout may exceed the timeout.
2. In addition, in some development environments, it is not desirable to perform heartbeat detection, but to retain the problematic container to analyze and locate the problem.