### PR TITLE
ci: Properly export node and node_start_time vars

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -48,6 +48,7 @@ ALLOW_ALL_POLICY="${ALLOW_ALL_POLICY:-$(base64 -w 0 "${K8S_TEST_DIR}/../../../sr
 setup_common() {
 	node=$(get_one_kata_node)
 	[ -n "$node" ]
+	export node=${node}
 	node_start_time=$(exec_host "$node" date +\"%Y-%m-%d %H:%M:%S\")
 	# If node_start_time is empty, try again 3 times with a 5 seconds sleep between each try.
 	count=0
@@ -58,7 +59,7 @@ setup_common() {
 		count=$((count + 1))
 	done
 	[ -n "$node_start_time" ]
-	export node node_start_time
+	export node_start_time=${node_start_time}
 
 	k8s_delete_all_pods_if_any_exists || true
 }


### PR DESCRIPTION
It seems we have overlooked how we export those two variables, which may be leading to some random failures on tests that are relying on journal content based on the node_start_time.