### PR TITLE
runtime: Don't error out about SNP cert path on non SNP platforms

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -299,6 +299,16 @@ func (h hypervisor) firmware() (string, error) {
 }
 
 func (h hypervisor) snpCertsPath() (string, error) {
+	// snpCertsPath only matter when using Confidential Guests
+	if !h.ConfidentialGuest {
+		return "", nil
+	}
+
+	// snpCertsPath only matter for SNP guests
+	if !h.SevSnpGuest {
+		return "", nil
+	}
+
 	p := h.SnpCertsPath
 
 	if p == "" {


### PR DESCRIPTION
This error is specific to SNP platforms, so let's make sure we only error this out when an SNP platform is used.