### PR TITLE
runtime: don't use machtype default for remote-hyp

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1341,7 +1341,10 @@ func newStratovirtHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 }
 
 func newRemoteHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
-	machineType := h.machineType()
+	// the default machine type doesn't make sense for remote hypervisor,
+	// since the remote component owns the infrastructure, so we do not
+	// use the generic default (e.g. "q35" here)
+	machineType := h.MachineType
 
 	return vc.HypervisorConfig{
 		RemoteHypervisorSocket:  h.getRemoteHypervisorSocket(),


### PR DESCRIPTION
The host's default machine type doesn't make sense for remote hypervisor, since the remote component defines the machines. In Cloud API Adaptor this is causing problems, since it defines it's own default which gets overridden by a "q35" machinetype annotation from the host. We don't want to overwrite the CAA default with a runtime default value.