### PR TITLE
kata-deploy: Remove kata-cleanup unneeded vars

### DIFF
--- a/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/base/kata-cleanup.yaml
@@ -27,16 +27,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: DEBUG
-              value: "false"
-            - name: SHIMS
-              value: "clh cloud-hypervisor dragonball fc qemu-runtime-rs qemu-sev qemu-snp qemu-tdx qemu qemu-coco-dev stratovirt qemu-nvidia-gpu qemu-nvidia-gpu-snp qemu-nvidia-gpu-tdx"
-            - name: DEFAULT_SHIM
-              value: "qemu"
-            - name: CREATE_RUNTIMECLASSES
-              value: "false"
-            - name: CREATE_DEFAULT_RUNTIMECLASS
-              value: "false"
           securityContext:
             privileged: true
   updateStrategy:


### PR DESCRIPTION
As kata-cleanup will only call `reset_runtime()`, there's absolutely no need to export the other set of environment variables in its yaml file.