### PR TITLE
runtime: Ensure Confidential Guests use shared_fs=none

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -607,6 +607,10 @@ func (h hypervisor) extraMonitorSocket() (govmmQemu.MonitorProtocol, error) {
 func (h hypervisor) sharedFS() (string, error) {
 	supportedSharedFS := []string{config.Virtio9P, config.VirtioFS, config.VirtioFSNydus, config.NoSharedFS}
 
+	if h.ConfidentialGuest && h.SharedFS != config.NoSharedFS {
+		return "", fmt.Errorf("Confidential Guests must use `shared_fs=none`")
+	}
+
 	if h.SharedFS == "" {
 		return config.VirtioFS, nil
 	}


### PR DESCRIPTION
While we do have the option to, maybe, use virtio-9p for Confidential Guests, that basically means sharing content between host and guest.

Instead of allowing users to shoot themselves in the foot, let's enforce shared_fs=none is used for Confidential Guests, and it also brings in a little bit of extra security that if containerd and Kata Containers get maliciously misconfigured by an administrator we at least don't even start the Confidential Guest.

cc @kata-containers/architecture-committee, as this is a heavy handed decision from my side for now. :-)
cc @studychao from the Ali side
cc @ryansavino, @AdithyaKrishnan from the AMD side
cc @stevenhorsman @BbolroC @fitzthum from the IBM side
cc @danmihai1 @sprt from the MSFT side
cc @zvonkok from the NVIDIA side
cc @bpradipt @gkurz @wainersm from the Red Hat side