### PR TITLE
metrics: Update openVINO and oneDNN tests references

### DIFF
--- a/tests/metrics/machine_learning/onednn.sh
+++ b/tests/metrics/machine_learning/onednn.sh
@@ -6,7 +6,7 @@
 
 # Description of the test:
 # This test runs the 'onednn benchmark'
-# https://github.com/v8/web-tooling-benchmark
+# https://openbenchmarking.org/test/pts/onednn
 
 set -o pipefail
 

--- a/tests/metrics/machine_learning/openvino.sh
+++ b/tests/metrics/machine_learning/openvino.sh
@@ -6,7 +6,7 @@
 
 # Description of the test:
 # This test runs the 'openvino benchmark'
-# https://github.com/v8/web-tooling-benchmark
+# https://openbenchmarking.org/test/pts/openvino
 
 set -o pipefail
 


### PR DESCRIPTION
This PR updates the machine learning tests references or urls for the openVINO and oneDNN scripts as currently they are refering to a different performance benchmark.