### PR TITLE
ci: Enable kata agent API tests

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -366,7 +366,7 @@ jobs:
         run: bash tests/functional/kata-agent-apis/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
           path: kata-artifacts

--- a/tests/functional/kata-agent-apis/api-tests/dummy.bats
+++ b/tests/functional/kata-agent-apis/api-tests/dummy.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+# Copyright (c) 2024 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load "${BATS_TEST_DIRNAME}/../../../common.bash"
+load "${BATS_TEST_DIRNAME}/../setup_common.sh"
+
+setup_file() {
+    info "setup"
+}
+
+@test "Dummy test" {
+    info "placeholder"
+}
+
+teardown_file() {
+    info "teardown"
+}

--- a/tests/functional/kata-agent-apis/gha-run.sh
+++ b/tests/functional/kata-agent-apis/gha-run.sh
@@ -26,7 +26,7 @@ function install_dependencies() {
 }
 
 function run() {
-	exit 0
+	bash -c ${kata_agent_apis_dir}/run-agent-api-tests.sh
 }
 
 function main() {

--- a/tests/functional/kata-agent-apis/run-agent-api-tests.sh
+++ b/tests/functional/kata-agent-apis/run-agent-api-tests.sh
@@ -33,7 +33,9 @@ EOF
 }
 
 run_tests() {
-    info "placeholder: no tests"
+    info "Running agent API tests"
+
+    bats "${kata_agent_apis_dir}/api-tests"
 }
 
 main()


### PR DESCRIPTION
This commit enables running tests for kata agent apis. The 'api-tests' directory will contain bats test files for individual APIs.

Fixes #10269