### PR TITLE
runtime: failed to delete sandbox when container was StartError

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -470,6 +470,9 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (_ *taskAP
 
 	start := time.Now()
 	defer func() {
+		if err != nil {
+			shimLog.WithField("container", r.ID).WithError(err).Error("Start container failed")
+		}
 		err = toGRPC(err)
 		rpcDurationsHistogram.WithLabelValues("start").Observe(float64(time.Since(start).Nanoseconds() / int64(time.Millisecond)))
 	}()

--- a/src/runtime/pkg/containerd-shim-v2/start.go
+++ b/src/runtime/pkg/containerd-shim-v2/start.go
@@ -20,6 +20,7 @@ func startContainer(ctx context.Context, s *service, c *container) (retErr error
 	defer func() {
 		if retErr != nil {
 			// notify the wait goroutine to continue
+			c.status = task.StatusStopped
 			c.exitCh <- exitCode255
 		}
 	}()


### PR DESCRIPTION
1. shimv2-delete execution failed, return error "/run/vs/sbs/xxx: no such file or directory"
because of the sandbox store may be destroyed when the monitor watches that sandbox
stopped unexpectedly

2. failed to delete containerd task, return error "Container not ready, running or paused, ..."
because of the containerd task was CREATED status and pid>0. in the world of containerd, this state cannot be deleted.