### PR TITLE
runtime: Fix runtime/cdi panic with assignment to entry in nil map

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1010,6 +1010,9 @@ func (c *Container) siblingAnnotation(devPath string, siblings []DeviceRelation)
 			vfioNum := filepath.Base(devPath)
 			annoKey := fmt.Sprintf("cdi.k8s.io/vfio%s", vfioNum)
 			annoValue := fmt.Sprintf("nvidia.com/gpu=%d", sibling.Index)
+			if c.config.CustomSpec.Annotations == nil {
+				c.config.CustomSpec.Annotations = make(map[string]string)
+			}
 			c.config.CustomSpec.Annotations[annoKey] = annoValue
 			c.Logger().Infof("annotated container with %s: %s", annoKey, annoValue)
 		}


### PR DESCRIPTION
It will panic when users do GPU vfio passthrough with cdi in runtime. The root cause is that CustomSpec.Annotations is nil when new element added.
To address this issue, initialization is introduced when it's nil.

Fixes #10266