### PR TITLE
tests: Increase timeout to wait for soak stability test deployment

### DIFF
--- a/tests/stability/kubernetes_soak_test.sh
+++ b/tests/stability/kubernetes_soak_test.sh
@@ -27,7 +27,7 @@ function go() {
 
 function init() {
 	kubectl create -f "${SCRIPT_PATH}/runtimeclass_workloads/pod-deployment.yaml"
-	kubectl wait --for=condition=Available --timeout=30s deployment/"${deployment_name}"
+	kubectl wait --for=condition=Available --timeout=100s deployment/"${deployment_name}"
 }
 
 function main() {


### PR DESCRIPTION
This PR increases the timeout to wait that the deployment for the soak stability test is ready in order to avoid random failures saying that the deployment is not ready yet.