### PR TITLE
runtime-rs: configuration-dragonball.toml.in: Remove duplication

### DIFF
--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -98,7 +98,7 @@ default_maxvcpus = @DEFMAXVCPUS_DB@
 # > 5                --> will be set to 5
 default_bridges = @DEFBRIDGES@
 
-# Enable balloon f_reporting, default false
+# Enable balloon f_reporting
 # Enabling this will result in the VM balloon device having f_reporting=on set
 #
 # Default false


### PR DESCRIPTION
Remove duplicated description of enable_balloon_f_reporting from configuration-dragonball.toml.in.

Fixes: #10281 