### PR TITLE
ci: Enable starting kata agent as local process

### DIFF
--- a/tests/functional/kata-agent-apis/gha-run.sh
+++ b/tests/functional/kata-agent-apis/gha-run.sh
@@ -11,6 +11,7 @@ set -o pipefail
 kata_tarball_dir="${2:-kata-artifacts}"
 kata_agent_apis_dir="$(dirname "$(readlink -f "$0")")"
 source "${kata_agent_apis_dir}/../../common.bash"
+source "${kata_agent_apis_dir}/../../gha-run-k8s-common.sh"
 
 function install_dependencies() {
 	info "Installing dependencies needed for testing individual agent apis using agent-ctl"
@@ -23,6 +24,9 @@ function install_dependencies() {
 
 	sudo apt-get update
 	sudo apt-get -y install "${deps[@]}"
+
+	info "Installing bats"
+	install_bats
 }
 
 function run() {

--- a/tests/functional/kata-agent-apis/run-agent-api-tests.sh
+++ b/tests/functional/kata-agent-apis/run-agent-api-tests.sh
@@ -48,6 +48,10 @@ main()
 
 	trap cleanup EXIT
 
+	install_policy_doc
+
+	try_and_remove_coco_attestation_procs
+
 	setup_agent
 
 	run_tests


### PR DESCRIPTION
The existing setup tries to start kata agent as local process.
Since a lot of dependent components which are part of the UVM rootfs are not used in this setup,
this commit works around the issues:
a. Install a local copy of a relaxed 'allow-all.rego' to initialize the agent policy.
b. Remove coco attestaion guest components from the installed kata artifacts so that agent does not try to start these processes.
c. Install bats.

This setup tries to start kata-agent in near vanilla mode with agent policy.

Fixes #10286