### PR TITLE
ci: tdx: Adapt how we get the host IP

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -311,7 +311,7 @@ function kbs_k8s_deploy() {
 		echo "Setting up custom PCCS for TDX"
 		cat <<- EOF > "${COCO_KBS_DIR}/config/kubernetes/custom_pccs/sgx_default_qcnl.conf"
 {
- "pccs_url": "https://$(hostname -i):8081/sgx/certification/v4/",
+ "pccs_url": "https://$(hostname -i | grep -o "^[0-9.]*"):8081/sgx/certification/v4/",
 
  // To accept insecure HTTPS certificate, set this option to false
  "use_secure_cert": false


### PR DESCRIPTION
In the process of switching the TDX CI machine we've noticed that `hostname -i` in one of the machines returns an one and only IP address, while in another machine it returns a full list of IPs.

As we're only interested in the first one, let's adapt the code to always return the first one.