### PR TITLE
runtime-rs: Notify containerd when process exits

### DIFF
--- a/src/runtime-rs/crates/runtimes/common/src/message.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/message.rs
@@ -6,7 +6,8 @@
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use containerd_shim_protos::{events::task::TaskOOM, protobuf::Message as ProtobufMessage};
+use containerd_shim_protos::events::task::{TaskExit, TaskOOM};
+use containerd_shim_protos::protobuf::Message as ProtobufMessage;
 use tokio::sync::mpsc::{channel, Receiver, Sender};
 
 /// message receiver buffer size
@@ -47,7 +48,10 @@ impl Message {
 }
 
 const TASK_OOM_EVENT_TOPIC: &str = "/tasks/oom";
+const TASK_EXIT_EVENT_TOPIC: &str = "/tasks/exit";
+
 const TASK_OOM_EVENT_URL: &str = "containerd.events.TaskOOM";
+const TASK_EXIT_EVENT_URL: &str = "containerd.events.TaskExit";
 
 pub trait Event: std::fmt::Debug + Send {
     fn r#type(&self) -> String;
@@ -66,5 +70,19 @@ impl Event for TaskOOM {
 
     fn value(&self) -> Result<Vec<u8>> {
         self.write_to_bytes().context("get oom value")
+    }
+}
+
+impl Event for TaskExit {
+    fn r#type(&self) -> String {
+        TASK_EXIT_EVENT_TOPIC.to_string()
+    }
+
+    fn type_url(&self) -> String {
+        TASK_EXIT_EVENT_URL.to_string()
+    }
+
+    fn value(&self) -> Result<Vec<u8>> {
+        self.write_to_bytes().context("get exit value")
     }
 }

--- a/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
@@ -4,10 +4,12 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::{types::ContainerProcess, ContainerManager};
 use anyhow::Result;
 use async_trait::async_trait;
 use oci_spec::runtime as oci;
 use runtime_spec as spec;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct SandboxNetworkEnv {
@@ -43,6 +45,12 @@ pub trait Sandbox: Send + Sync {
     async fn direct_volume_stats(&self, volume_path: &str) -> Result<String>;
     async fn direct_volume_resize(&self, resize_req: agent::ResizeVolumeRequest) -> Result<()>;
     async fn agent_sock(&self) -> Result<String>;
+    async fn wait_process(
+        &self,
+        cm: Arc<dyn ContainerManager>,
+        process_id: ContainerProcess,
+        shim_pid: u32,
+    ) -> Result<()>;
 
     // metrics function
     async fn agent_metrics(&self) -> Result<String>;

--- a/src/runtime-rs/crates/runtimes/common/src/types/mod.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/mod.rs
@@ -8,6 +8,7 @@ mod trans_from_agent;
 mod trans_from_shim;
 mod trans_into_agent;
 mod trans_into_shim;
+pub mod utils;
 
 use std::fmt;
 

--- a/src/runtime-rs/crates/runtimes/common/src/types/trans_into_shim.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/trans_into_shim.rs
@@ -6,36 +6,15 @@
 
 use std::{
     any::type_name,
-    convert::{Into, TryFrom, TryInto},
-    time,
+    convert::{Into, TryFrom},
 };
 
 use anyhow::{anyhow, Result};
 use containerd_shim_protos::api;
 
+use super::utils::option_system_time_into;
 use super::{ProcessExitStatus, ProcessStateInfo, ProcessStatus, TaskResponse};
 use crate::error::Error;
-
-fn system_time_into(time: time::SystemTime) -> ::protobuf::well_known_types::timestamp::Timestamp {
-    let mut proto_time = ::protobuf::well_known_types::timestamp::Timestamp::new();
-    proto_time.seconds = time
-        .duration_since(time::UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_secs()
-        .try_into()
-        .unwrap_or_default();
-
-    proto_time
-}
-
-fn option_system_time_into(
-    time: Option<time::SystemTime>,
-) -> protobuf::MessageField<protobuf::well_known_types::timestamp::Timestamp> {
-    match time {
-        Some(v) => ::protobuf::MessageField::some(system_time_into(v)),
-        None => ::protobuf::MessageField::none(),
-    }
-}
 
 impl From<ProcessExitStatus> for api::WaitResponse {
     fn from(from: ProcessExitStatus) -> Self {

--- a/src/runtime-rs/crates/runtimes/common/src/types/utils.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/utils.rs
@@ -1,0 +1,28 @@
+// Copyright 2024 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::convert::TryInto;
+use std::time;
+
+fn system_time_into(time: time::SystemTime) -> ::protobuf::well_known_types::timestamp::Timestamp {
+    let mut proto_time = ::protobuf::well_known_types::timestamp::Timestamp::new();
+    proto_time.seconds = time
+        .duration_since(time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs()
+        .try_into()
+        .unwrap_or_default();
+
+    proto_time
+}
+
+pub fn option_system_time_into(
+    time: Option<time::SystemTime>,
+) -> protobuf::MessageField<protobuf::well_known_types::timestamp::Timestamp> {
+    match time {
+        Some(v) => ::protobuf::MessageField::some(system_time_into(v)),
+        None => ::protobuf::MessageField::none(),
+    }
+}


### PR DESCRIPTION
Docker cannot exit normally after the container process exits when used with runtime-rs since it doesn't receive the exit event. This commit enable runtime-rs to send TaskExit to containerd after process exits.

Also, it moves "system_time_into" and "option_system_time_into" from crates/runtimes/common/src/types/trans_into_shim.rs to a new utility mod.

Fixes #10288 

Signed-off-by: Sicheng Liu <lsc2001@outlook.com>