### PR TITLE
metrics: Remove unused remove img var in common script

### DIFF
--- a/tests/metrics/lib/common.bash
+++ b/tests/metrics/lib/common.bash
@@ -526,7 +526,6 @@ function get_kata_memory_and_vcpus() {
 	local busybox_img="quay.io/prometheus/busybox:latest"
 	local container_name="kata-busybox_${RANDOM}"
 	local PAYLOAD_ARGS="tail -f /dev/null"
-	local remove_img=1
 
 	IMG_EXIST="$(sudo ctr i list | grep -c $busybox_img)" || true
 


### PR DESCRIPTION
This PR removes the remove_img variable in the metrics common script as it is not being used.