### PR TITLE
WIP: quay.io/prometheus/prometheus experiment

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-hard-coded.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-hard-coded.yaml
@@ -13,7 +13,7 @@ spec:
   runtimeClassName: kata
   containers:
     - name: first-test-container
-      image: quay.io/prometheus/busybox:latest
+      image: quay.io/prometheus/prometheus:latest
       env:
         - name: CONTAINER_NAME
           value: "first-test-container"


### PR DESCRIPTION
Experiment with using quay.io/prometheus/prometheus instead of quay.io/prometheus/busybox. Testing if the prometheus image is supported by all Kata CI test setups.