### PR TITLE
agent: add support to provide default agent policy via env

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -600,11 +600,7 @@ fn init_agent_as_init(logger: &Logger, unified_cgroup_hierarchy: bool) -> Result
 
 #[cfg(feature = "agent-policy")]
 async fn initialize_policy() -> Result<()> {
-    AGENT_POLICY
-        .lock()
-        .await
-        .initialize("/etc/kata-opa/default-policy.rego")
-        .await
+    AGENT_POLICY.lock().await.initialize().await
 }
 
 // The Rust standard library had suppressed the default SIGPIPE behavior,

--- a/tests/functional/kata-agent-apis/setup_common.sh
+++ b/tests/functional/kata-agent-apis/setup_common.sh
@@ -33,7 +33,6 @@ agent_log_level="debug"
 keep_logs=false
 
 local_policy_file="/opt/kata/test.rego"
-policy_file="/etc/kata-opa/default-policy.rego"
 
 cleanup()
 {
@@ -43,9 +42,7 @@ cleanup()
 
 	stop_agent
 
-	sudo unlink $policy_file
 	sudo rm $local_policy_file
-	sudo rm -rf $(dirname ${policy_file})
 
 	local sandbox_dir="/run/sandbox-ns/"
 	sudo umount -f "${sandbox_dir}/uts" "${sandbox_dir}/ipc" &>/dev/null || true
@@ -166,6 +163,7 @@ start_agent()
 			RUST_BACKTRACE=full \
 			KATA_AGENT_LOG_LEVEL=${agent_log_level} \
 			KATA_AGENT_SERVER_ADDR=${local_agent_server_addr} \
+			KATA_AGENT_POLICY_FILE=${local_policy_file} \
 			${agent_binary} \
 			&> ${log_file} \
 			&
@@ -191,12 +189,7 @@ install_policy_doc()
 	allow_all_rego_file="${repo_root_dir}/src/kata-opa/allow-all.rego"
 	[ ! -f $allow_all_rego_file ] && die "Failed to locate allow-all.rego file"
 
-	local policy_dir=$(dirname ${policy_file})
-	[ ! -d $policy_dir ] && sudo mkdir -p $policy_dir || true
-
 	sudo cp $allow_all_rego_file $local_policy_file
-
-	[ ! -f $policy_file ] && sudo ln -s $local_policy_file $policy_file || die "Failed to setup local policy file, exists: $policy_file"
 }
 
 # Same reason as above, we do not have the necessary components to start the coco processes


### PR DESCRIPTION
agent built with policy feature initializes the policy engine using a
policy document from a default path, which is installed & linked during
UVM rootfs build. This commit adds support to provide a default agent
policy as environment variable.

This targets development/testing scenarios where kata-agent
is wanted to be started as a local process.

Fixes #10301