### PR TITLE
agent-ctl: Add SetPolicy support

### DIFF
--- a/src/tools/agent-ctl/src/client.rs
+++ b/src/tools/agent-ctl/src/client.rs
@@ -5,7 +5,7 @@
 
 // Description: Client side of ttRPC comms
 
-use crate::types::{Config, CopyFileInput, Options};
+use crate::types::{Config, CopyFileInput, Options, SetPolicyInput};
 use crate::utils;
 use anyhow::{anyhow, Result};
 use byteorder::ByteOrder;
@@ -287,6 +287,11 @@ static AGENT_CMDS: &[AgentCmd] = &[
         name: "WriteStdin",
         st: ServiceType::Agent,
         fp: agent_cmd_container_write_stdin,
+    },
+    AgentCmd {
+        name: "SetPolicy",
+        st: ServiceType::Agent,
+        fp: agent_cmd_sandbox_set_policy,
     },
 ];
 
@@ -2109,6 +2114,31 @@ fn agent_cmd_sandbox_add_swap(
 
     // FIXME: Implement 'AddSwap' fully.
     eprintln!("FIXME: 'AddSwap' not fully implemented");
+
+    info!(sl!(), "response received";
+        "response" => format!("{:?}", reply));
+
+    Ok(())
+}
+
+fn agent_cmd_sandbox_set_policy(
+    ctx: &Context,
+    client: &AgentServiceClient,
+    _health: &HealthClient,
+    _options: &mut Options,
+    args: &str,
+) -> Result<()> {
+    let input: SetPolicyInput = utils::make_request(args)?;
+
+    let req = utils::make_set_policy_request(&input)?;
+
+    let ctx = clone_context(ctx);
+
+    info!(sl!(), "sending request"; "request" => format!("{:?}", req));
+
+    let reply = client
+        .set_policy(ctx, &req)
+        .map_err(|e| anyhow!("{:?}", e).context(ERR_API_FAILED))?;
 
     info!(sl!(), "response received";
         "response" => format!("{:?}", reply));

--- a/src/tools/agent-ctl/src/types.rs
+++ b/src/tools/agent-ctl/src/types.rs
@@ -27,3 +27,9 @@ pub struct CopyFileInput {
     pub src: String,
     pub dest: String,
 }
+
+// SetPolicy input request
+#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+pub struct SetPolicyInput {
+    pub policy_file: String,
+}

--- a/tests/functional/kata-agent-apis/api-tests/test_set_policy.bats
+++ b/tests/functional/kata-agent-apis/api-tests/test_set_policy.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+
+# Copyright (c) 2024 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+load "${BATS_TEST_DIRNAME}/../../../common.bash"
+load "${BATS_TEST_DIRNAME}/../setup_common.sh"
+
+setup_file() {
+    info "setup"
+}
+
+@test "Test SetPolicy API: Set allow all policy" {
+    info "Upload policy document from under src/kata-opa"
+    repo_root_dir="${BATS_TEST_DIRNAME}/../../../../"
+    policy_dir="${repo_root_dir}/src/kata-opa"
+    policy_file="${policy_dir}/allow-all.rego"
+    local cmds=()
+    cmds+=("-c 'SetPolicy json://{\"policy_file\": \"$policy_file\"}'")
+    run_agent_ctl "${cmds[@]}"
+}
+
+@test "Test SetPolicy API: Block CopyFile in policy" {
+    policy_file=$(mktemp)
+    deny_single_api_in_policy ${policy_file} "CopyFileRequest"
+    local cmds=()
+    cmds+=("-c 'SetPolicy json://{\"policy_file\": \"$policy_file\"}'")
+    run_agent_ctl "${cmds[@]}"
+
+    src_file=$(mktemp)
+    local cmds=()
+    cmds+=("-c 'CopyFile json://{\"src\": \"$src_file\", \"dest\":\"/run/kata-containers/foo\"}'")
+    run run_agent_ctl "${cmds[@]}"
+    [ "$status" -ne 0 ]
+
+    rm $src_file
+    rm $policy_file
+}
+
+teardown_file() {
+    info "teardown"
+    sudo rm -r /run/kata-containers/ || echo "Failed to clean /run/kata-containers"
+}

--- a/tests/functional/kata-agent-apis/setup_common.sh
+++ b/tests/functional/kata-agent-apis/setup_common.sh
@@ -205,3 +205,16 @@ try_and_remove_coco_attestation_procs()
 		[ -f "${procs_path}${i}" ] && sudo mv "${procs_path}${i}" /tmp || true
 	done
 }
+
+deny_single_api_in_policy()
+{
+	info "Setting default deny for single API in policy"
+	local pol_file=$1
+	local deny_req=$2
+
+	[ ! -f $local_policy_file ] && install_policy_doc
+
+	info "Not allowing ${deny_req}"
+	sudo cp $local_policy_file $pol_file
+	sed -i "s/\(.*$deny_req.*:= \)\(.*\)/\1false/" $pol_file
+}


### PR DESCRIPTION
This patch adds support to call kata agents SetPolicy API. Also adds tests for SetPolicy API using agent-ctl.

Fixes #9711