### PR TITLE
runtime-rs: Add Configurable Compilation for Dragonball in Runtime-rs

### DIFF
--- a/docs/install/kata-containers-3.0-rust-runtime-installation-guide.md
+++ b/docs/install/kata-containers-3.0-rust-runtime-installation-guide.md
@@ -90,14 +90,14 @@ By default, runtime-rs includes the `Dragonball` VMM. To build without the built
 $ cd kata-containers/src/runtime-rs
 $ make USE_BUILDIN_DB=false
 ```
-After building, specify the desired hypervisor during installation using `DEFAULT_HYPERVISOR`. For example, to use `qemu` or `cloud-hypervisor`:
+After building, specify the desired hypervisor during installation using `HYPERVISOR`. For example, to use `qemu` or `cloud-hypervisor`:
 
 ```
-sudo make install DEFAULT_HYPERVISOR=qemu
+sudo make install HYPERVISOR=qemu
 ```
 or
 ```
-sudo make install DEFAULT_HYPERVISOR=cloud-hypervisor
+sudo make install HYPERVISOR=cloud-hypervisor
 ```
 
 ### Build Kata Containers Kernel

--- a/docs/install/kata-containers-3.0-rust-runtime-installation-guide.md
+++ b/docs/install/kata-containers-3.0-rust-runtime-installation-guide.md
@@ -83,6 +83,23 @@ $ make && sudo make install
 ```
 After running the command above, the default config file `configuration.toml` will be installed under `/usr/share/defaults/kata-containers/`,  the binary file `containerd-shim-kata-v2` will be installed under `/usr/local/bin/` .
 
+### Install Shim Without Builtin Dragonball VMM
+
+By default, runtime-rs includes the `Dragonball` VMM. To build without the built-in `Dragonball` hypervisor, use `make USE_BUILDIN_DB=false`:
+```bash
+$ cd kata-containers/src/runtime-rs
+$ make USE_BUILDIN_DB=false
+```
+After building, specify the desired hypervisor during installation using `DEFAULT_HYPERVISOR`. For example, to use `qemu` or `cloud-hypervisor`:
+
+```
+sudo make install DEFAULT_HYPERVISOR=qemu
+```
+or
+```
+sudo make install DEFAULT_HYPERVISOR=cloud-hypervisor
+```
+
 ### Build Kata Containers Kernel
 Follow the [Kernel installation guide](/tools/packaging/kernel/README.md).
 

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -88,6 +88,8 @@ HYPERVISOR_FC = firecracker
 HYPERVISOR_QEMU = qemu
 HYPERVISOR_CLH = cloud-hypervisor
 
+# When set to true, builds the built-in Dragonball hypervisor
+USE_BUILDIN_DB := true
 
 DEFAULT_HYPERVISOR ?= $(HYPERVISOR_DB)
 
@@ -185,8 +187,6 @@ VERSION := ${shell cat ./VERSION}
 CONFIGS =
 CONFIG_PATHS =
 SYSCONFIG_PATHS =
-# List of hypervisors known for the current architecture
-KNOWN_HYPERVISORS =
 # List of hypervisors known for the current architecture
 KNOWN_HYPERVISORS =
 
@@ -337,6 +337,7 @@ USER_VARS += CONFIG_PATH
 USER_VARS += CONFIG_QEMU_IN
 USER_VARS += DESTDIR
 USER_VARS += DEFAULT_HYPERVISOR
+USER_VARS += USE_BUILDIN_DB
 USER_VARS += DBCMD
 USER_VARS += DBCTLCMD
 USER_VARS += FCCTLCMD
@@ -474,6 +475,11 @@ COMMIT := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null |
 COMMIT_MSG = $(if $(COMMIT),$(COMMIT),unknown)
 
 EXTRA_RUSTFEATURES :=
+
+# if use dragonball hypervisor, add the feature to build dragonball in runtime
+ifeq ($(USE_BUILDIN_DB),true)
+    EXTRA_RUSTFEATURES +=  dragonball
+endif
 
 ifneq ($(EXTRA_RUSTFEATURES),)
     override EXTRA_RUSTFEATURES := --features $(EXTRA_RUSTFEATURES)

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -91,7 +91,7 @@ HYPERVISOR_CLH = cloud-hypervisor
 # When set to true, builds the built-in Dragonball hypervisor
 USE_BUILDIN_DB := true
 
-DEFAULT_HYPERVISOR ?= $(HYPERVISOR_DB)
+HYPERVISOR ?= $(HYPERVISOR_DB)
 
 ##VAR HYPERVISOR=<hypervisor_name> List of hypervisors this build system can generate configuration for.
 HYPERVISORS := $(HYPERVISOR_DB) $(HYPERVISOR_ACRN) $(HYPERVISOR_FC) $(HYPERVISOR_QEMU) $(HYPERVISOR_CLH)
@@ -318,14 +318,14 @@ ifneq (,$(FCCMD))
     DEFSTATICRESOURCEMGMT_FC := true
 endif
 
-ifeq ($(DEFAULT_HYPERVISOR),$(HYPERVISOR_DB))
+ifeq ($(HYPERVISOR),$(HYPERVISOR_DB))
     DEFAULT_HYPERVISOR_CONFIG = $(CONFIG_FILE_DB)
 endif
 
-ifeq ($(DEFAULT_HYPERVISOR),$(HYPERVISOR_QEMU))
+ifeq ($(HYPERVISOR),$(HYPERVISOR_QEMU))
     DEFAULT_HYPERVISOR_CONFIG = $(CONFIG_FILE_QEMU)
 endif
-ifeq ($(DEFAULT_HYPERVISOR),$(HYPERVISOR_FC))
+ifeq ($(HYPERVISOR),$(HYPERVISOR_FC))
     DEFAULT_HYPERVISOR_CONFIG = $(CONFIG_FILE_FC)
 endif
 # list of variables the user may wish to override
@@ -336,7 +336,7 @@ USER_VARS += CONFIG_FC_IN
 USER_VARS += CONFIG_PATH
 USER_VARS += CONFIG_QEMU_IN
 USER_VARS += DESTDIR
-USER_VARS += DEFAULT_HYPERVISOR
+USER_VARS += HYPERVISOR
 USER_VARS += USE_BUILDIN_DB
 USER_VARS += DBCMD
 USER_VARS += DBCTLCMD
@@ -620,7 +620,7 @@ show-summary: show-header
 	@printf "  %s\n" "$(call get_toolchain_version)"
 	@printf "\n"
 	@printf "• Hypervisors:\n"
-	@printf "\tDefault: $(DEFAULT_HYPERVISOR)\n"
+	@printf "\tDefault: $(HYPERVISOR)\n"
 	@printf "\tKnown: $(sort $(HYPERVISORS))\n"
 	@printf "\tAvailable for this architecture: $(sort $(KNOWN_HYPERVISORS))\n"
 	@printf "\n"
@@ -640,7 +640,7 @@ show-summary: show-header
 	@printf "\talternate config paths (SYSCONFIG_PATHS) : %s\n"
 	@printf \
 	  "$(foreach c,$(sort $(SYSCONFIG_PATHS)),$(shell printf "\\t - $(c)\\\n"))"
-	@printf "\tdefault install path for $(DEFAULT_HYPERVISOR) (CONFIG_PATH) : %s\n" $(abspath $(CONFIG_PATH))
+	@printf "\tdefault install path for $(HYPERVISOR) (CONFIG_PATH) : %s\n" $(abspath $(CONFIG_PATH))
 	@printf "\tdefault alternate config path (SYSCONFIG) : %s\n" $(abspath $(SYSCONFIG))
 ifneq (,$(findstring $(HYPERVISOR_QEMU),$(KNOWN_HYPERVISORS)))
 	@printf "\t$(HYPERVISOR_QEMU) hypervisor path (QEMUPATH) : %s\n" $(abspath $(QEMUPATH))

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -48,7 +48,7 @@ qapi-spec = "0.3.1"
 qapi-qmp = "0.14.0"
 
 [target.'cfg(not(target_arch = "s390x"))'.dependencies]
-dragonball = { path = "../../../dragonball", features = ["atomic-guest-memory", "virtio-vsock", "hotplug", "virtio-blk", "virtio-net", "virtio-fs", "vhost-net", "dbs-upcall", "virtio-mem", "virtio-balloon", "vhost-user-net", "host-device"] }
+dragonball = { path = "../../../dragonball", features = ["atomic-guest-memory", "virtio-vsock", "hotplug", "virtio-blk", "virtio-net", "virtio-fs", "vhost-net", "dbs-upcall", "virtio-mem", "virtio-balloon", "vhost-user-net", "host-device"], optional = true }
 dbs-utils = { path = "../../../dragonball/src/dbs_utils" }
 hyperlocal = "0.8.0"
 hyper = {version = "0.14.18", features = ["client"]}
@@ -56,6 +56,7 @@ hyper = {version = "0.14.18", features = ["client"]}
 [features]
 default = []
 
+dragonball = ["dep:dragonball"]
 # Feature is not yet complete, so not enabled by default.
 # See https://github.com/kata-containers/kata-containers/issues/6264.
 cloud-hypervisor = ["ch-config"]

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -13,7 +13,7 @@ pub mod device;
 pub mod hypervisor_persist;
 pub use device::driver::*;
 use device::DeviceType;
-#[cfg(not(target_arch = "s390x"))]
+#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
 pub mod dragonball;
 #[cfg(not(target_arch = "s390x"))]
 pub mod firecracker;
@@ -53,12 +53,14 @@ const VM_ROOTFS_FILESYSTEM_EROFS: &str = "erofs";
 // /dev/hugepages will be the mount point
 // mkdir -p /dev/hugepages
 // mount -t hugetlbfs none /dev/hugepages
-#[cfg(not(target_arch = "s390x"))]
-const DEV_HUGEPAGES: &str = "/dev/hugepages";
 pub const HUGETLBFS: &str = "hugetlbfs";
-#[cfg(not(target_arch = "s390x"))]
+// Constants required for Dragonball VMM when enabled and not on s390x.
+// Not needed when the built-in VMM is not used.
+#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+const DEV_HUGEPAGES: &str = "/dev/hugepages";
+#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
 const SHMEM: &str = "shmem";
-#[cfg(not(target_arch = "s390x"))]
+#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
 const HUGE_SHMEM: &str = "hugeshmem";
 
 pub const HYPERVISOR_DRAGONBALL: &str = "dragonball";

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -43,3 +43,6 @@ default = ["cloud-hypervisor"]
 
 # Enable the Cloud Hypervisor driver
 cloud-hypervisor = []
+
+# Enable the build-in VMM Dragtonball
+dragonball = []

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -21,12 +21,12 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use common::{message::Message, RuntimeHandler, RuntimeInstance};
 use hypervisor::Hypervisor;
-#[cfg(not(target_arch = "s390x"))]
+#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 #[cfg(not(target_arch = "s390x"))]
 use hypervisor::{firecracker::Firecracker, HYPERVISOR_FIRECRACKER};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
-#[cfg(not(target_arch = "s390x"))]
+#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
 use kata_types::config::DragonballConfig;
 #[cfg(not(target_arch = "s390x"))]
 use kata_types::config::FirecrackerConfig;
@@ -57,7 +57,9 @@ impl RuntimeHandler for VirtContainer {
         // register
         #[cfg(not(target_arch = "s390x"))]
         {
+            #[cfg(feature = "dragonball")]
             let dragonball_config = Arc::new(DragonballConfig::new());
+            #[cfg(feature = "dragonball")]
             register_hypervisor_plugin("dragonball", dragonball_config);
 
             let firecracker_config = Arc::new(FirecrackerConfig::new());
@@ -147,7 +149,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
     // TODO: support other hypervisor
     // issue: https://github.com/kata-containers/kata-containers/issues/4634
     match hypervisor_name.as_str() {
-        #[cfg(not(target_arch = "s390x"))]
+        #[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
         HYPERVISOR_DRAGONBALL => {
             let mut hypervisor = Dragonball::new();
             hypervisor

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -16,7 +16,9 @@ use common::{Sandbox, SandboxNetworkEnv};
 use containerd_shim_protos::events::task::TaskOOM;
 use hypervisor::VsockConfig;
 #[cfg(not(target_arch = "s390x"))]
-use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL, HYPERVISOR_FIRECRACKER};
+use hypervisor::HYPERVISOR_FIRECRACKER;
+#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{utils::get_hvsock_path, HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID};
 use hypervisor::{BlockConfig, Hypervisor};
@@ -591,7 +593,7 @@ impl Persist for VirtSandbox {
             resource: Some(self.resource_manager.save().await?),
             hypervisor: match hypervisor_state.hypervisor_type.as_str() {
                 // TODO support other hypervisors
-                #[cfg(not(target_arch = "s390x"))]
+                #[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
                 HYPERVISOR_DRAGONBALL => Ok(Some(hypervisor_state)),
                 #[cfg(not(target_arch = "s390x"))]
                 HYPERVISOR_NAME_CH => Ok(Some(hypervisor_state)),
@@ -630,7 +632,7 @@ impl Persist for VirtSandbox {
         let h = sandbox_state.hypervisor.unwrap_or_default();
         let hypervisor = match h.hypervisor_type.as_str() {
             // TODO support other hypervisors
-            #[cfg(not(target_arch = "s390x"))]
+            #[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
             HYPERVISOR_DRAGONBALL => {
                 let hypervisor = Arc::new(Dragonball::restore((), h).await?) as Arc<dyn Hypervisor>;
                 Ok(hypervisor)


### PR DESCRIPTION
This PR introduces support for selectively compiling Dragonball in runtime-rs. By default, Dragonball will continue to be compiled into the containerd-shim-kata-v2 executable, but users now have the option to disable Dragonball compilation. When Dragonball is not compiled, the default runtime will switch to Qemu.

Fixes #10310

Signed-off-by: sidney chang <2190206983@qq.com>