### PR TITLE
doc: Update how-to-run-kata-containers-with-SE-VMs.md

### DIFF
--- a/tools/packaging/guest-image/build_se_image.sh
+++ b/tools/packaging/guest-image/build_se_image.sh
@@ -37,6 +37,7 @@ Environment variables:
                   for information on how to retrieve and verify this document.
   SIGNING_KEY_CERT_PATH: a path for the IBM zSystem signing key certificate
   INTERMEDIATE_CA_CERT_PATH: a path for the intermediate CA certificate signed by the root CA
+  HOST_KEY_CRL_PATH: a path for the host key CRL
   DEBUG         : If set, display debug information.
 EOF
 	exit "${1:-0}"

--- a/tools/packaging/guest-image/lib_se.sh
+++ b/tools/packaging/guest-image/lib_se.sh
@@ -27,12 +27,16 @@ build_secure_image() {
 	install_dest_dir="${3:-}"
 	key_verify_option="--no-verify" # no verification for CI testing purposes
 
-	if [ -n "${SIGNING_KEY_CERT_PATH:-}" ] && [ -n "${INTERMEDIATE_CA_CERT_PATH:-}" ]; then
-		if [ -e "${SIGNING_KEY_CERT_PATH}" ] && [ -e "${INTERMEDIATE_CA_CERT_PATH}" ]; then
-			key_verify_option="--cert=${SIGNING_KEY_CERT_PATH} --cert=${INTERMEDIATE_CA_CERT_PATH}"
+	if [ -n "${SIGNING_KEY_CERT_PATH:-}" ] && [ -n "${INTERMEDIATE_CA_CERT_PATH:-}" ] && [ -n "${HOST_KEY_CRL_PATH:-}" ]; then
+		if [ -e "${SIGNING_KEY_CERT_PATH}" ] && [ -e "${INTERMEDIATE_CA_CERT_PATH}" ] && [ -e "${HOST_KEY_CRL_PATH}" ]; then
+			key_verify_option="--cert=${SIGNING_KEY_CERT_PATH} --cert=${INTERMEDIATE_CA_CERT_PATH} --crl=${HOST_KEY_CRL_PATH}"
 		else
 			die "Specified certificate(s) not found"
 		fi
+	elif [ -n "${SIGNING_KEY_CERT_PATH}" ] || [ -n "${INTERMEDIATE_CA_CERT_PATH}" ] || [ -n "${HOST_KEY_CRL_PATH}" ]; then
+		die "All of SIGNING_KEY_CERT_PATH, INTERMEDIATE_CA_CERT_PATH, and HOST_KEY_CRL_PATH must be specified"
+	else
+		echo "No certificate specified. Using --no-verify option"
 	fi
 
 	if [ ! -f "${install_src_dir}/vmlinuz-confidential.container" ] ||


### PR DESCRIPTION
This PR updates the documentation `how-to-run-kata-containers-with-SE-VMs.md` with the following changes:

- Update secure boot image verification for IBM SE
- Remove unnecessary `sudo`
- Add an error message where an incorrect host key document is used
- Add a missing artifact `kernel-confidential-modules`
- Make a variable `kernel_version` and replace it with relevant hits

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>