### PR TITLE
tests: k8s-inotify: pod termination polling

### DIFF
--- a/tests/integration/kubernetes/k8s-inotify.bats
+++ b/tests/integration/kubernetes/k8s-inotify.bats
@@ -32,8 +32,10 @@ setup() {
         # Update configmap
         kubectl apply -f "${pod_config_dir}"/inotify-updated-configmap.yaml
 
-        # Ideally we'd wait for the pod to complete...
-        sleep 120
+        # Wait for the pod to complete
+        command="kubectl describe pod ${pod_name} | grep \"State: \+Terminated\""
+        info "Waiting ${wait_time} seconds for: ${command}"
+        waitForProcess "${wait_time}" "$sleep_time" "${command}"
 
         # Verify we saw the update
         result=$(kubectl get pod "$pod_name" --output="jsonpath={.status.containerStatuses[]}")


### PR DESCRIPTION
Poll/wait for pod termination instead of sleeping 2 minutes. This change typically saves ~90 seconds in my test cluster.