### PR TITLE
rootfs: Add missing libclang dependency in Ubuntu Dockerfile

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -40,6 +40,7 @@ RUN apt-get update && \
          echo "gcc-$gcc_arch-linux-gnu libc6-dev-$libc_arch-cross")) \
     git \
     gnupg2 \
+    libclang1-6.0 \
     make \
     makedev \
     multistrap \


### PR DESCRIPTION
### What
Running the make command to create the rootfs within an Ubuntu machine as such
```
sudo -E PATH=$PATH make USE_DOCKER=true rootfs
```

Results in the following error
```
error: failed to run custom build command for `loopdev v0.5.0 (https://github.com/mdaffin/loopdev?rev=c9f91e8f0326ce8a3364ac911e81eb32328a5f27#c9f91e8f)`

Caused by:
  process didn't exit successfully: `/kata-containers/src/agent/target/release/build/loopdev-61866741446c5cc7/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at /opt/cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.63.0/./lib.rs:2338:31:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:137: target/x86_64-unknown-linux-musl/release/kata-agent] Error 101
Failed at 683: make LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP} AGENT_POLICY=${AGENT_POLICY} PULL_TYPE=${PULL_TYPE}
make: *** [Makefile:96: /home/ubuntu/kata-containers/tools/osbuilder/.ubuntu_rootfs.done] Error 2
```

### Fix
There seem to be a missing dependency within `kata-containers/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in` and adding `libclang-6.0` fixes the issue.