### PR TITLE
build: Fix compilation failure with Rust compiler version 1.80

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -239,7 +239,7 @@ The agent is built with a statically linked `musl.` The default `libc` used is `
 ```bash
 $ export ARCH="$(uname -m)"
 $ if [ "$ARCH" = "ppc64le" -o "$ARCH" = "s390x" ]; then export LIBC=gnu; else export LIBC=musl; fi
-$ [ "${ARCH}" == "ppc64le" ] && export ARCH=powerpc64le
+$ [ "${ARCH}" == "ppc64le" ] && export ARCH=powerpc64
 $ rustup target add "${ARCH}-unknown-linux-${LIBC}"
 ```
 
@@ -268,7 +268,7 @@ to install `libseccomp` for the agent.
 
 ```bash
 $ mkdir -p ${seccomp_install_path} ${gperf_install_path}
-$ pushd kata-containers/ci 
+$ pushd kata-containers/ci
 $ script -fec 'sudo -E ./install_libseccomp.sh ${seccomp_install_path} ${gperf_install_path}"'
 $ export LIBSECCOMP_LIB_PATH="${seccomp_install_path}/lib"
 $ popd
@@ -415,11 +415,11 @@ $ script -fec 'sudo -E AGENT_INIT=yes USE_DOCKER=true SECCOMP=no ./rootfs.sh "${
 > - Check the [compatibility matrix](../tools/osbuilder/README.md#platform-distro-compatibility-matrix) before creating rootfs.
 
 Optionally, add your custom agent binary to the rootfs with the following commands. The default `$LIBC` used
-is `musl`, but on ppc64le and s390x, `gnu` should be used. Also, Rust refers to ppc64le as `powerpc64le`:
+is `musl`, but on ppc64le and s390x, `gnu` should be used. Also, Rust refers to ppc64le as `powerpc64`:
 ```bash
 $ export ARCH="$(uname -m)"
 $ [ "${ARCH}" == "ppc64le" ] || [ "${ARCH}" == "s390x" ] && export LIBC=gnu || export LIBC=musl
-$ [ "${ARCH}" == "ppc64le" ] && export ARCH=powerpc64le
+$ [ "${ARCH}" == "ppc64le" ] && export ARCH=powerpc64
 $ sudo install -o root -g root -m 0550 -T "${ROOTFS_DIR}/../../../../src/agent/target/${ARCH}-unknown-linux-${LIBC}/release/kata-agent" "${ROOTFS_DIR}/sbin/init"
 ```
 

--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -54,7 +54,7 @@ endif
 include ../../utils.mk
 
 ifeq ($(ARCH), ppc64le)
-    override ARCH = powerpc64le
+    override ARCH = powerpc64
 endif
 
 ##VAR STANDARD_OCI_RUNTIME=yes|no define if agent enables standard oci runtime feature

--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
 
-#[cfg(any(target_arch = "s390x", target_arch = "powerpc64le"))]
+#[cfg(any(target_arch = "s390x", target_arch = "powerpc64"))]
 use nix::unistd::Uid;
 
 #[cfg(target_arch = "x86_64")]
@@ -234,7 +234,7 @@ pub fn available_guest_protection() -> Result<GuestProtection, ProtectionError> 
     Ok(GuestProtection::Se)
 }
 
-#[cfg(target_arch = "powerpc64le")]
+#[cfg(all(target_arch = "powerpc64"))]
 pub fn available_guest_protection() -> Result<check::GuestProtection, check::ProtectionError> {
     if !Uid::effective().is_root() {
         return Err(check::ProtectionError::NoPerms);

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -18,7 +18,7 @@ CONTAINERD_RUNTIME_NAME = io.containerd.kata.v2
 include ../../utils.mk
 
 ifeq ($(ARCH), ppc64le)
-    override ARCH = powerpc64le
+    override ARCH = powerpc64
 endif
 
 ARCH_DIR = arch
@@ -31,7 +31,7 @@ test:
 	@echo "s390x is not currently supported"
 	exit 0
 install: install-runtime install-configs
-else ifeq ($(ARCH), powerpc64le)
+else ifeq ($(ARCH), powerpc64)
 default:
 	@echo "PowerPC 64 LE is not currently supported"
 	exit 0

--- a/src/tools/agent-ctl/Makefile
+++ b/src/tools/agent-ctl/Makefile
@@ -6,7 +6,7 @@
 include ../../../utils.mk
 
 ifeq ($(ARCH), ppc64le)
-     override ARCH = powerpc64le
+     override ARCH = powerpc64
 endif
 
 .DEFAULT_GOAL := default

--- a/src/tools/genpolicy/Makefile
+++ b/src/tools/genpolicy/Makefile
@@ -7,7 +7,7 @@
 include ../../../utils.mk
 
 ifeq ($(ARCH), ppc64le)
-     override ARCH = powerpc64le
+     override ARCH = powerpc64
  endif
 
 COMMIT_HASH := $(shell git rev-parse HEAD 2>/dev/null || true)

--- a/src/tools/kata-ctl/Cross.toml
+++ b/src/tools/kata-ctl/Cross.toml
@@ -8,5 +8,5 @@ pre-build = ["dpkg --add-architecture arm64 && apt-get update && apt-get install
 pre-build = ["dpkg --add-architecture amd64 && apt-get update && apt-get install -y libssl-dev:amd64"]
 
 # Powerpc compile seems to be broken, due to `ring` crate not being supported on powerpc.
-[target.powerpc64le-unknown-linux-gnu]
+[target.powerpc64-unknown-linux-gnu]
 pre-build = ["dpkg --add-architecture ppc64le && apt-get update && apt-get install -y libssl-dev:ppc64le"]

--- a/src/tools/kata-ctl/src/arch/mod.rs
+++ b/src/tools/kata-ctl/src/arch/mod.rs
@@ -8,10 +8,10 @@ pub mod aarch64;
 #[cfg(target_arch = "aarch64")]
 pub use aarch64 as arch_specific;
 
-#[cfg(target_arch = "powerpc64le")]
-pub mod powerpc64le;
-#[cfg(target_arch = "powerpc64le")]
-pub use powerpc64le as arch_specific;
+#[cfg(all(target_arch = "powerpc64"))]
+pub mod powerpc64;
+#[cfg(all(target_arch = "powerpc64"))]
+pub use powerpc64 as arch_specific;
 
 #[cfg(target_arch = "s390x")]
 pub mod s390x;
@@ -25,7 +25,7 @@ pub use x86_64 as arch_specific;
 
 #[cfg(not(any(
     target_arch = "aarch64",
-    target_arch = "powerpc64le",
+    target_arch = "powerpc64",
     target_arch = "s390x",
     target_arch = "x86_64"
 )))]

--- a/src/tools/kata-ctl/src/arch/powerpc64/mod.rs
+++ b/src/tools/kata-ctl/src/arch/powerpc64/mod.rs
@@ -4,7 +4,7 @@
 //
 
 use crate::types::*;
-#[cfg(target_arch = "powerpc64le")]
+#[cfg(all(target_arch = "powerpc64"))]
 pub use arch_specific::*;
 
 mod arch_specific {
@@ -16,7 +16,7 @@ mod arch_specific {
     pub const ARCH_CPU_MODEL_FIELD: &str = "model";
 
     pub fn check() -> Result<()> {
-        unimplemented!("Check not implemented in powerpc64le");
+        unimplemented!("Check not implemented in powerpc64");
     }
 
     pub fn get_checks() -> Option<&'static [CheckItem<'static>]> {

--- a/src/tools/runk/Makefile
+++ b/src/tools/runk/Makefile
@@ -9,7 +9,7 @@ LIBC ?= gnu
 include ../../../utils.mk
 
 ifeq ($(ARCH), ppc64le)
-     override ARCH = powerpc64le
+     override ARCH = powerpc64
 endif
 
 TARGET = runk

--- a/src/tools/trace-forwarder/Makefile
+++ b/src/tools/trace-forwarder/Makefile
@@ -6,7 +6,7 @@
 include ../../../utils.mk
 
 ifeq ($(ARCH), ppc64le)
-     override ARCH = powerpc64le
+     override ARCH = powerpc64
 endif
 
 .DEFAULT_GOAL := default

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -595,7 +595,7 @@ function clone_cri_containerd() {
 # version: the version of the tarball that will be downloaded
 # tarball-name: the name of the tarball that will be downloaded
 function download_github_project_tarball() {
-	project="${1}" 
+	project="${1}"
 	version="${2}"
 	tarball_name="${3}"
 
@@ -746,7 +746,7 @@ function arch_to_rust() {
 
 	case "${arch}" in
 		aarch64) echo "${arch}";;
-		ppc64le) echo "powerpc64le";;
+		ppc64le) echo "powerpc64";;
 		x86_64) echo "${arch}";;
 		s390x) echo "${arch}";;
 		*) die "unsupported architecture: ${arch}";;

--- a/tests/install_rust.sh
+++ b/tests/install_rust.sh
@@ -35,7 +35,7 @@ export PATH="${PATH}:${HOME}/.cargo/bin"
 ## this command will not take too long to run.
 rustup toolchain install ${version}
 rustup default ${version}
-if [ "${rustarch}" == "powerpc64le" ] || [ "${rustarch}" == "s390x" ] ; then
+if [ "${rustarch}" == "powerpc64" ] || [ "${rustarch}" == "s390x" ] ; then
 	rustup target add ${rustarch}-unknown-linux-gnu
 else
 	rustup target add ${rustarch}-unknown-linux-musl

--- a/tests/kata-arch.sh
+++ b/tests/kata-arch.sh
@@ -46,7 +46,7 @@ function arch_to_rust() {
 	local arch="$1"
 
 	if [ "${arch}" == "ppc64le" ]; then
-		arch="powerpc64le"
+		arch="powerpc64"
 	fi
 
 	echo "${arch}"

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -34,7 +34,7 @@ RUN apt-get update && \
     $(gcc_arch="@ARCH@" && [ "$(uname -m)" != "$gcc_arch" ] && ( \
          libc_arch="$gcc_arch" && \
          [ "$gcc_arch" = aarch64 ] && libc_arch=arm64; \
-         [ "$gcc_arch" = ppc64le ] && gcc_arch=powerpc64le && libc_arch=ppc64el; \
+         [ "$gcc_arch" = ppc64le ] && gcc_arch=powerpc64 && libc_arch=ppc64el; \
          [ "$gcc_arch" = s390x ] && gcc_arch=s390x && libc_arch=s390x; \
          [ "$gcc_arch" = x86_64 ] && gcc_arch=x86-64 && libc_arch=amd64; \
          echo "gcc-$gcc_arch-linux-gnu libc6-dev-$libc_arch-cross")) \
@@ -76,7 +76,7 @@ RUN ARCH=$(uname -m); \
     libc=""; \
     case "${ARCH}" in \
         "aarch64") rust_arch="${ARCH}"; libc="musl"; ;; \
-        "ppc64le") rust_arch="powerpc64le"; libc="gnu"; ;; \
+        "ppc64le") rust_arch="powerpc64"; libc="gnu"; ;; \
         "x86_64") rust_arch="${ARCH}"; libc="musl"; ;; \
         "s390x") rust_arch="${ARCH}"; libc="gnu"; ;; \
         *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -22,7 +22,7 @@ esac
 
 if [ "$(uname -m)" != "$ARCH" ]; then
 	case "$ARCH" in
-		ppc64le) cc_arch=powerpc64le;;
+		ppc64le) cc_arch=powerpc64;;
 		x86_64) cc_arch=x86-64;;
 		*) cc_arch="$ARCH"
 	esac

--- a/tools/osbuilder/scripts/lib.sh
+++ b/tools/osbuilder/scripts/lib.sh
@@ -221,7 +221,7 @@ generate_dockerfile()
 	[ -d "${dir}" ] || die "${dir}: not a directory"
 
 	local rustarch="$ARCH"
-	[ "$ARCH" = ppc64le ] && rustarch=powerpc64le
+	[ "$ARCH" = ppc64le ] && rustarch=powerpc64
 
 	[ -n "${http_proxy:-}" ] && readonly set_proxy="RUN sed -i '$ a proxy="${http_proxy:-}"' /etc/dnf/dnf.conf /etc/yum.conf; true"
 

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -213,7 +213,7 @@ generate_qemu_options() {
 	if [ $arch != $host ];then
 		case $arch in
 			aarch64) qemu_options+=(size:--cross-prefix=aarch64-linux-gnu-);;
-			ppc64le) qemu_options+=(size:--cross-prefix=powerpc64le-linux-gnu-);;
+			ppc64le) qemu_options+=(size:--cross-prefix=powerpc64-linux-gnu-);;
 			s390x) exit;;
 			x86_64);;
 			*) exit;;

--- a/tools/packaging/static-build/agent/Dockerfile
+++ b/tools/packaging/static-build/agent/Dockerfile
@@ -45,7 +45,7 @@ RUN ARCH=$(uname -m); \
 	libc=""; \
     	case "${ARCH}" in \
 	        "aarch64") rust_arch="${ARCH}"; libc="musl" ;; \
-	        "ppc64le") rust_arch="powerpc64le"; libc="gnu" ;; \
+	        "ppc64le") rust_arch="powerpc64"; libc="gnu" ;; \
 	        "x86_64") rust_arch="${ARCH}"; libc="musl" ;; \
 	        "s390x") rust_arch="${ARCH}"; libc="gnu" ;; \
 	        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \

--- a/tools/packaging/static-build/coco-guest-components/Dockerfile
+++ b/tools/packaging/static-build/coco-guest-components/Dockerfile
@@ -48,7 +48,7 @@ RUN ARCH=$(uname -m); \
 	rust_arch=""; \
     	case "${ARCH}" in \
 	        "aarch64") rust_arch="${ARCH}" ;; \
-	        "ppc64le") rust_arch="powerpc64le" ;; \
+	        "ppc64le") rust_arch="powerpc64" ;; \
 	        "x86_64") rust_arch="${ARCH}" ;; \
 	        "s390x") rust_arch="${ARCH}" ;; \
 	        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -65,14 +65,14 @@ RUN apt-get update && apt-get upgrade -y && \
 	    rsync \
 	    zlib1g-dev${DPKG_ARCH} && \
     if [ "${ARCH}" != s390x ]; then apt-get install -y --no-install-recommends libpmem-dev${DPKG_ARCH}; fi && \
-    GCC_ARCH="${ARCH}" && if [ "${ARCH}" = "ppc64le" ]; then GCC_ARCH="powerpc64le"; fi && \
+    GCC_ARCH="${ARCH}" && if [ "${ARCH}" = "ppc64le" ]; then GCC_ARCH="powerpc64"; fi && \
     if [ "${ARCH}" != "$(uname -m)" ]; then apt-get install --no-install-recommends -y gcc-"${GCC_ARCH}"-linux-gnu; fi && \
     apt-get clean && rm -rf /var/lib/apt/lists/
 
 RUN git clone  https://github.com/axboe/liburing/ ~/liburing && \
     cd ~/liburing && \
     git checkout tags/liburing-2.1 && \
-    GCC_ARCH="${ARCH}" && if [ "${ARCH}" = "ppc64le" ]; then GCC_ARCH="powerpc64le"; fi && \
+    GCC_ARCH="${ARCH}" && if [ "${ARCH}" = "ppc64le" ]; then GCC_ARCH="powerpc64"; fi && \
     if [ "${ARCH}" != "$(uname -m)" ]; then PREFIX="${GCC_ARCH}-linux-gnu"; fi && \
     ./configure --cc=${GCC_ARCH}-linux-gnu-gcc --cxx=${GCC_ARCH}-linux-gnu-cpp --prefix=/usr/${PREFIX}/ && \
     make && make install && ldconfig

--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:20.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 ENV GO_HOME="/opt"
-ENV GOCACHE="${GO_HOME}/.cache" 
+ENV GOCACHE="${GO_HOME}/.cache"
 ENV RUSTUP_HOME="/opt/rustup"
 ENV CARGO_HOME="/opt/cargo"
 ENV PATH="/opt/cargo/bin/:/opt/go/bin:${PATH}"
@@ -32,19 +32,19 @@ RUN apt-get update && \
         sudo && \
         apt-get clean && rm -rf /var/lib/apt/lists/&& \
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION}
-    
+
 RUN ARCH=$(uname -m); \
    	rust_arch=""; \
    	libc=""; \
    	case "${ARCH}" in \
         "aarch64") rust_arch="${ARCH}"; libc="musl"; ;; \
-        "ppc64le") rust_arch="powerpc64le"; libc="gnu"; ;; \
+        "ppc64le") rust_arch="powerpc64"; libc="gnu"; ;; \
         "x86_64") rust_arch="${ARCH}"; libc="musl"; ;; \
         "s390x") rust_arch="${ARCH}"; libc="gnu"; ;; \
         *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
   	esac; \
-   	rustup target add "${rust_arch}-unknown-linux-${libc}" 
-        
+   	rustup target add "${rust_arch}-unknown-linux-${libc}"
+
 RUN ARCH=$(uname -m); \
     goarch=""; \
     kernelname=$(uname -s | tr '[:upper:]' '[:lower:]'); \
@@ -58,6 +58,6 @@ RUN ARCH=$(uname -m); \
     curl -OL "https://storage.googleapis.com/golang/go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
     tar -C "${GO_HOME}" -xzf "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
     rm "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz"
-        
+
 # aarch64 requires this name -- link for all
 RUN ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -48,7 +48,7 @@ docker pull ${container_image} || \
 arch=${ARCH:-$(uname -m)}
 GCC_ARCH=${arch}
 if [ ${arch} = "ppc64le" ]; then
-	GCC_ARCH="powerpc64le"
+	GCC_ARCH="powerpc64"
 	arch="ppc64"
 fi
 

--- a/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
@@ -33,7 +33,7 @@ RUN ARCH=$(uname -m); \
     	extra_rust_flags=" -C link-self-contained=yes"; \
        	case "${ARCH}" in \
             "aarch64") rust_arch="${ARCH}"; libc="musl"; arch_libc="" ;; \
-            "ppc64le") rust_arch="powerpc64le"; libc="gnu"; arch_libc=${rust_arch}-linux-${libc}; extra_rust_flags="" ;; \
+            "ppc64le") rust_arch="powerpc64"; libc="gnu"; arch_libc=${rust_arch}-linux-${libc}; extra_rust_flags="" ;; \
             "x86_64") rust_arch="${ARCH}"; libc="musl"; arch_libc="" ;; \
             "s390x") rust_arch="${ARCH}"; libc="gnu"; arch_libc=${rust_arch}-linux-${libc}; extra_rust_flags="" ;; \
             *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \

--- a/tools/packaging/static-build/virtiofsd/musl/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/musl/Dockerfile
@@ -30,7 +30,7 @@ RUN ARCH=$(uname -m); \
     	extra_rust_flags=" -C link-self-contained=yes"; \
         	case "${ARCH}" in \
     	        "aarch64") rust_arch="${ARCH}"; libc="musl"; arch_libc="" ;; \
-    	        "ppc64le") rust_arch="powerpc64le"; libc="gnu"; arch_libc=${rust_arch}-linux-${libc}; extra_rust_flags="" ;; \
+    	        "ppc64le") rust_arch="powerpc64"; libc="gnu"; arch_libc=${rust_arch}-linux-${libc}; extra_rust_flags="" ;; \
     	        "x86_64") rust_arch="${ARCH}"; libc="musl"; arch_libc="" ;; \
     	        "s390x") rust_arch="${ARCH}"; libc="gnu"; arch_libc=${rust_arch}-linux-${libc}; extra_rust_flags="" ;; \
     	        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \

--- a/utils.mk
+++ b/utils.mk
@@ -147,7 +147,7 @@ endif
 
 ifeq ($(ARCH), ppc64le)
     override LIBC = gnu
-    $(warning "WARNING: powerpc64le-unknown-linux-musl target is unavailable")
+    $(warning "WARNING: powerpc64-unknown-linux-musl target is unavailable")
 endif
 
 ifeq ($(ARCH), s390x)


### PR DESCRIPTION
build: Fix compilation failure with Rust compiler version 1.80

Starting with version 1.80, the Rust linter does not accept an invalid
value for `target_arch` in configuration checks:

```
   Compiling kata-sys-util v0.1.0 (/home/ddd/Work/kata/kata-containers/src/libs/kata-sys-util)
error: unexpected `cfg` condition value: `powerpc64le`

  --> /home/ddd/Work/kata/kata-containers/src/libs/kata-sys-util/src/protection.rs:17:34
   |
17 | #[cfg(any(target_arch = "s390x", target_arch = "powerpc64le"))]
   |                                  ^^^^^^^^^^^^^^-------------
   |                                                |
   |                                                help: there is a expected value with a similar name: `"powerpc64"`
   |
   = note: expected values for `target_arch` are: `aarch64`, `arm`, `arm64ec`, `avr`, `bpf`, `csky`, `hexagon`, `loongarch64`, `m68k`, `mips`, `mips32r6`, `mips64`, `mips64r6`, `msp430`, `nvptx64`, `powerpc`, `powerpc64`, `riscv32`, `riscv64`, `s390x`, `sparc`, `sparc64`, `wasm32`, `wasm64`, `x86`, and `x86_64`
   = note: see <https://doc.rust-lang.org/nightly/rustc/check-cfg/cargo-specifics.html> for more information about checking conditional configuration
   = note: `-D unexpected-cfgs` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(unexpected_cfgs)]`
```

According [to GitHub user @Urgau][explain], this is a new warning
introduced in Rust 1.80, but the problem exists before. The correct
architecture name should be `powerpc64`, and the differentiation
between `powerpc64le` and `powerpc64` should use the `target_endian =
"little"` check.

[explain]: #10072 (comment)

Fixes: #10067

Signed-off-by: Christophe de Dinechin <dinechin@redhat.com>
[emlima: fix some more occurences and typos]
Signed-off-by: Emanuel Lima <emlima@redhat.com>