### PR TITLE
local-build: Fix unbound variable issue for lib_se.sh

### DIFF
--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -90,6 +90,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
       - name: get-artifacts
         uses: actions/download-artifact@v4
         with:

--- a/tools/packaging/guest-image/lib_se.sh
+++ b/tools/packaging/guest-image/lib_se.sh
@@ -33,7 +33,7 @@ build_secure_image() {
 		else
 			die "Specified certificate(s) not found"
 		fi
-	elif [ -n "${SIGNING_KEY_CERT_PATH}" ] || [ -n "${INTERMEDIATE_CA_CERT_PATH}" ] || [ -n "${HOST_KEY_CRL_PATH}" ]; then
+	elif [ -n "${SIGNING_KEY_CERT_PATH:-}" ] || [ -n "${INTERMEDIATE_CA_CERT_PATH:-}" ] || [ -n "${HOST_KEY_CRL_PATH:-}" ]; then
 		die "All of SIGNING_KEY_CERT_PATH, INTERMEDIATE_CA_CERT_PATH, and HOST_KEY_CRL_PATH must be specified"
 	else
 		echo "No certificate specified. Using --no-verify option"


### PR DESCRIPTION
As #10315 introduced an `unbound variable` error, this PR is a hot-fix for it.

The job `build-asset-boot-image-se` https://github.com/kata-containers/kata-containers/blob/03cd02a00643ec4468e91cf59a34662b6aac68a5/.github/workflows/build-kata-static-tarball-s390x.yaml#L87 does not rebase itself atop of the latest target branch. It is why we let the error code sneak in the main. 

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>