### PR TITLE
kata-deploy: Switch Kubernetes URL

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -217,7 +217,7 @@ function deploy_k0s() {
 		ARCH=amd64
 	fi
 	kubectl_version=$(sudo k0s kubectl version 2>/dev/null | grep "Client Version" | sed -e 's/Client Version: //')
-	sudo curl -fL --progress-bar -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/${ARCH}/kubectl
+	sudo curl -fL --progress-bar -o /usr/bin/kubectl https://dl.k8s.io/release/${kubectl_version}/bin/linux/${ARCH}/kubectl
 	sudo chmod +x /usr/bin/kubectl
 
 	mkdir -p ~/.kube
@@ -245,7 +245,7 @@ function deploy_k3s() {
 		ARCH=amd64
 	fi
 	kubectl_version=$(/usr/local/bin/k3s kubectl version --client=true 2>/dev/null | grep "Client Version" | sed -e 's/Client Version: //' -e 's/+k3s[0-9]\+//')
-	sudo curl -fL --progress-bar -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${kubectl_version}/bin/linux/${ARCH}/kubectl
+	sudo curl -fL --progress-bar -o /usr/bin/kubectl https://dl.k8s.io/release/${kubectl_version}/bin/linux/${ARCH}/kubectl
 	sudo chmod +x /usr/bin/kubectl
 	sudo rm -rf /usr/local/bin/kubectl
 

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -25,7 +25,7 @@ RUN \
 	if [ "${ARCH}" = "aarch64" ]; then ARCH=arm64; fi && \
 	DEBIAN_ARCH=${ARCH} && \
 	if [ "${DEBIAN_ARCH}" = "ppc64le" ]; then DEBIAN_ARCH=ppc64el; fi && \
-	curl -fL --progress-bar -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
+	curl -fL --progress-bar -o /usr/bin/kubectl https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && \
 	chmod +x /usr/bin/kubectl && \
 	curl -fL --progress-bar -o /usr/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${DEBIAN_ARCH} && \
 	chmod +x /usr/bin/jq && \

--- a/tools/packaging/kata-deploy/action/Dockerfile
+++ b/tools/packaging/kata-deploy/action/Dockerfile
@@ -16,7 +16,7 @@ ENV GITHUB_ACTION_NAME="Test kata-deploy in an AKS cluster"
 # PKG_SHA environment variable
 ENV PKG_SHA=HEAD
 
-RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${ARCH}/kubectl" \
+RUN curl -LO "https://dl.k8s.io/release/$(curl -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl" \
   && chmod +x ./kubectl \
   && mv ./kubectl /usr/local/bin/kubectl
 


### PR DESCRIPTION
The payload build is failing with:
```
ERROR: failed to solve: process "/bin/sh -c apk --no-cache add bash curl && \tARCH=$(uname -m) && \tif [ \"${ARCH}\" = \"x86_64\" ]; then ARCH=amd64; fi && \tif [ \"${ARCH}\" = \"aarch64\" ]; then ARCH=arm64; fi && \tDEBIAN_ARCH=${ARCH} && \tif [ \"${DEBIAN_ARCH}\" = \"ppc64le\" ]; then DEBIAN_ARCH=ppc64el; fi && \tcurl -fL --progress-bar -o /usr/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/${ARCH}/kubectl && \tchmod +x /usr/bin/kubectl && \tcurl -fL --progress-bar -o /usr/bin/jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-${DEBIAN_ARCH} && \tchmod +x /usr/bin/jq && \tmkdir -p ${DESTINATION} && \ttar xvf ${WORKDIR}/${KATA_ARTIFACTS} -C ${DESTINATION} && \trm -f ${WORKDIR}/${KATA_ARTIFACTS} && \tapk del curl && \tapk --no-cache add py3-pip && \tpip install --no-cache-dir yq==3.2.3" did not complete successfully: exit code: 22
```

Looking into this, the problem is that
https://storage.googleapis.com/kubernetes-release/release/v1.31.1/bin/linux/amd64/kubectl doesn't exist. The [kubectl install doc](https://kubernetes.io/docs/tasks/tools/install-kubectl-linux/#install-kubectl-on-linux) recommends the `dl.k8s.io` site, so let's switch to this.

**Note:** I've not updated the URLS of the kubectl install in `deploy_k0s` and `deploy_k3s` yet as I'm not sure if the dl.k8s.io has all the back level versions, but we should look at this soon once our builds are unblocked