### PR TITLE
tools.kata-webhook: Specify runtime class using configMap

### DIFF
--- a/tools/testing/kata-webhook/deploy/webhook.yaml
+++ b/tools/testing/kata-webhook/deploy/webhook.yaml
@@ -67,3 +67,10 @@ spec:
     targetPort: 8080
   selector:
     app: pod-annotate-webhook
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kata-webhook
+data:
+  runtime_class: kata

--- a/tools/testing/kata-webhook/webhook-check.sh
+++ b/tools/testing/kata-webhook/webhook-check.sh
@@ -16,7 +16,7 @@ source "${webhook_dir}/common.bash"
 
 readonly hello_pod="hello-kata-webhook"
 # The Pod RuntimeClassName for Kata Containers.
-RUNTIME_CLASS="${RUNTIME_CLASS:-"kata"}"
+RUNTIME_CLASS="${RUNTIME_CLASS:-$(kubectl get configmap kata-webhook -o jsonpath='{.data.runtime_class}' 2>/dev/null || echo "kata")}"
 
 cleanup() {
 	{


### PR DESCRIPTION
The kata webhook requires a configmap to define what runtime class it should set for the newly created pods. Additionally, the configmap allows others to modify the default runtime class name we wish to set (in case the handler is kata but the name of the runtimeclass is different). 

Finally, this PR changes the webhook-check to compare the runtime of the newly created pod against the specific runtime class in the configmap, if said confimap doesn't exist, then it will default to "kata".
