### PR TITLE
ci: Bump ubuntu 20.04 runners to 22.04

### DIFF
--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -57,7 +57,6 @@ jobs:
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE $HOME
           sudo rm -rf $GITHUB_WORKSPACE/* && echo "GITHUB_WORKSPACE removed" || { sleep 10 && sudo rm -rf $GITHUB_WORKSPACE/*; }
           sudo rm -f /tmp/kata_hybrid*  # Sometime we got leftover from test_setup_hvsock_failed()
-        if: ${{ inputs.instance != 'ubuntu-20.04' }}
 
       - name: Checkout the code
         uses: actions/checkout@v4

--- a/.github/workflows/docs-url-alive-check.yaml
+++ b/.github/workflows/docs-url-alive-check.yaml
@@ -5,7 +5,7 @@ on:
 name: Docs URL Alive Check
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     # don't run this action on forks
     if: github.repository_owner == 'kata-containers'
     env:

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -37,7 +37,7 @@ jobs:
   build-checks:
     uses: ./.github/workflows/build-checks.yaml
     with:
-      instance: ubuntu-20.04
+      instance: ubuntu-22.04
 
   build-checks-depending-on-kvm:
     runs-on: ubuntu-22.04
@@ -77,7 +77,7 @@ jobs:
           RUST_BACKTRACE: "1"
 
   static-checks:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Azure internal mirrors for Ubuntu 20.04 have gone awry, leading to a situation where dependencies cannot be installed (such as libdevmapper-dev), blocking then our CI.

Let's bump the runners to 22.04 regardless, even knowing it'll cause an issue with the runk tests, as the agent check tests are considered more crucial to the project at this point.

Test run can be seen at: https://github.com/kata-containers/kata-containers/pull/10331