### PR TITLE
gha: Increase timeout to run k8s tests on TDX

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -82,7 +82,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
 
       - name: Run tests
-        timeout-minutes: 50
+        timeout-minutes: 100
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Delete kata-deploy


### PR DESCRIPTION
This PR increases the timeout to run k8s tests for Kata CoCo TDX to avoid the random failures of timeout.