### PR TITLE
sandbox: refactor the sandbox init process

### DIFF
--- a/src/runtime-rs/crates/runtimes/common/src/runtime_handler.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/runtime_handler.rs
@@ -6,7 +6,7 @@
 
 use std::sync::Arc;
 
-use crate::{message::Message, ContainerManager, Sandbox};
+use crate::{message::Message, types::SandboxConfig, ContainerManager, Sandbox};
 use anyhow::Result;
 use async_trait::async_trait;
 use kata_types::config::TomlConfig;
@@ -39,6 +39,7 @@ pub trait RuntimeHandler: Send + Sync {
         msg_sender: Sender<Message>,
         config: Arc<TomlConfig>,
         init_size_manager: InitialSizeManager,
+        sandbox_config: SandboxConfig,
     ) -> Result<RuntimeInstance>;
 
     fn cleanup(&self, id: &str) -> Result<()>;

--- a/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
@@ -7,8 +7,6 @@
 use crate::{types::ContainerProcess, ContainerManager};
 use anyhow::Result;
 use async_trait::async_trait;
-use oci_spec::runtime as oci;
-use runtime_spec as spec;
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -28,13 +26,7 @@ impl std::fmt::Debug for SandboxNetworkEnv {
 
 #[async_trait]
 pub trait Sandbox: Send + Sync {
-    async fn start(
-        &self,
-        dns: Vec<String>,
-        spec: &oci::Spec,
-        state: &spec::State,
-        network_env: SandboxNetworkEnv,
-    ) -> Result<()>;
+    async fn start(&self) -> Result<()>;
     async fn stop(&self) -> Result<()>;
     async fn cleanup(&self) -> Result<()>;
     async fn shutdown(&self) -> Result<()>;

--- a/src/runtime-rs/crates/runtimes/common/src/types/mod.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/mod.rs
@@ -10,11 +10,17 @@ mod trans_into_agent;
 mod trans_into_shim;
 pub mod utils;
 
-use std::fmt;
+use std::{
+    collections::{hash_map::RandomState, HashMap},
+    fmt,
+};
+
+use crate::SandboxNetworkEnv;
 
 use anyhow::{Context, Result};
 use kata_sys_util::validate;
 use kata_types::mount::Mount;
+use oci_spec::runtime as oci;
 use strum::Display;
 
 /// TaskRequest: TaskRequest from shim
@@ -133,6 +139,17 @@ pub struct ContainerConfig {
     pub stdin: Option<String>,
     pub stdout: Option<String>,
     pub stderr: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct SandboxConfig {
+    pub sandbox_id: String,
+    pub hostname: String,
+    pub dns: Vec<String>,
+    pub network_env: SandboxNetworkEnv,
+    pub annotations: HashMap<String, String, RandomState>,
+    pub hooks: Option<oci::Hooks>,
+    pub state: runtime_spec::State,
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime-rs/crates/runtimes/linux_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/linux_container/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use common::{message::Message, RuntimeHandler, RuntimeInstance};
+use common::{message::Message, types::SandboxConfig, RuntimeHandler, RuntimeInstance};
 use kata_types::config::TomlConfig;
 use resource::cpu_mem::initial_size::InitialSizeManager;
 use tokio::sync::mpsc::Sender;
@@ -34,6 +34,7 @@ impl RuntimeHandler for LinuxContainer {
         _msg_sender: Sender<Message>,
         _config: Arc<TomlConfig>,
         _init_size_manager: InitialSizeManager,
+        _sandbox_config: SandboxConfig,
     ) -> Result<RuntimeInstance> {
         todo!()
     }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 use agent::{kata::KataAgent, AGENT_KATA};
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
-use common::{message::Message, RuntimeHandler, RuntimeInstance};
+use common::{message::Message, types::SandboxConfig, RuntimeHandler, RuntimeInstance};
 use hypervisor::Hypervisor;
 #[cfg(not(target_arch = "s390x"))]
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
@@ -91,6 +91,7 @@ impl RuntimeHandler for VirtContainer {
         msg_sender: Sender<Message>,
         config: Arc<TomlConfig>,
         init_size_manager: InitialSizeManager,
+        sandbox_config: SandboxConfig,
     ) -> Result<RuntimeInstance> {
         let hypervisor = new_hypervisor(&config).await.context("new hypervisor")?;
 
@@ -114,6 +115,7 @@ impl RuntimeHandler for VirtContainer {
             agent.clone(),
             hypervisor.clone(),
             resource_manager.clone(),
+            sandbox_config,
         )
         .await
         .context("new virt sandbox")?;

--- a/src/runtime-rs/crates/runtimes/wasm_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/wasm_container/src/lib.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use async_trait::async_trait;
-use common::{message::Message, RuntimeHandler, RuntimeInstance};
+use common::{message::Message, types::SandboxConfig, RuntimeHandler, RuntimeInstance};
 use kata_types::config::TomlConfig;
 use resource::cpu_mem::initial_size::InitialSizeManager;
 use tokio::sync::mpsc::Sender;
@@ -33,6 +33,7 @@ impl RuntimeHandler for WasmContainer {
         _msg_sender: Sender<Message>,
         _config: Arc<TomlConfig>,
         _init_size_manager: InitialSizeManager,
+        _sandbox_config: SandboxConfig,
     ) -> Result<RuntimeInstance> {
         todo!()
     }


### PR DESCRIPTION
Inorder to support sandbox api, intorduce the sandbox_config struct and split the sandbox start stage from init process.