### PR TITLE
agent: fix the issue of setup sandbox pidns

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1750,7 +1750,7 @@ fn update_container_namespaces(
                 if !pidns.path.is_empty() {
                     pid_ns.set_path(Some(PathBuf::from(&pidns.path)));
                 }
-            } else {
+            } else if !sandbox.containers.is_empty() {
                 return Err(anyhow!(ERR_NO_SANDBOX_PIDNS));
             }
         }
@@ -2525,14 +2525,6 @@ mod tests {
                     .typ(LinuxNamespaceType::Pid)
                     .build()
                     .unwrap()],
-                ..Default::default()
-            },
-            TestData {
-                namespaces: vec![],
-                sandbox_pidns_path: None,
-                use_sandbox_pidns: true,
-                result: Err(anyhow!(ERR_NO_SANDBOX_PIDNS)),
-                expected_namespaces: vec![],
                 ..Default::default()
             },
             TestData {


### PR DESCRIPTION
When the sandbox api was enabled, the pasue container wouldn't be created, thus the shared sandbox pidns should be fallbacked to the first container's init process, instead of return any error here.