### PR TITLE
Revert "tests: k8s-policy-rc: add unexpected UID

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-rc.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-rc.yaml
@@ -17,8 +17,6 @@ spec:
       labels:
         app: policy-nginx-rc
     spec:
-      securityContext:
-        runAsUser: 123
       terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:


### PR DESCRIPTION
This reverts commit https://github.com/microsoft/kata-containers/commit/5777869cf4097ef1596dc5bbd1646f22bbab0bba.
We believe this commit is causing the tests to timeout sometimes on
sev and sev-snp, due to k8s-policy-rc.bats taking too long or getting
stuck.

Example of current sev timeout: https://github.com/kata-containers/kata-containers/actions/runs/11051555048/job/30702164729

What I suspect introduced the timeout: https://github.com/kata-containers/kata-containers/pull/10306/files#diff-adfa666381d0bcec3478867a7f5ae04e894d89c8f66353366a78b0b81985646bR64-R72