### PR TITLE
gha: Add ita_key as a github secret

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -49,6 +49,7 @@ jobs:
       PULL_TYPE: ${{ matrix.pull-type }}
       AUTHENTICATED_IMAGE_USER: ${{ secrets.AUTHENTICATED_IMAGE_USER }}
       AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
+      ITA_KEY: ${{ secrets.ITA_KEY }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
This PR adds ita_key as a github secret at the kata coco tests yaml workflow.

This PR is not mine, it comes from Gaby! :-)

The reason I'm splitting this one as a different PR is because we need it to be merged to actually test the ITA changes.

There's no need to run CI on it.