### PR TITLE
metrics: Update fast footprint script to use grep

### DIFF
--- a/tests/metrics/density/fast_footprint.sh
+++ b/tests/metrics/density/fast_footprint.sh
@@ -217,7 +217,7 @@ function grab_system() {
 	((anon*=1024))
 
 	# Mapped pages
-	local mapped=$(egrep "^Mapped:" /proc/meminfo | awk '{print $2}')
+	local mapped=$(grep "^Mapped:" /proc/meminfo | awk '{print $2}')
 	((mapped*=1024))
 
 	# Cached


### PR DESCRIPTION
This PR updates the fast footprint script to remove the use of egrep as this command has been deprecated and change it to use grep command.