### PR TITLE
tests: Skip k8s-block-volume.bats for qemu-runtime-rs

### DIFF
--- a/tests/integration/kubernetes/k8s-block-volume.bats
+++ b/tests/integration/kubernetes/k8s-block-volume.bats
@@ -10,6 +10,7 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[ "${KATA_HYPERVISOR}" == "qemu-runtime-rs" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/10373"
 	get_pod_config_dir
 
 	node="$(get_one_kata_node)"
@@ -65,6 +66,7 @@ setup() {
 }
 
 teardown() {
+	[ "${KATA_HYPERVISOR}" == "qemu-runtime-rs" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/10373"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 


### PR DESCRIPTION
Currently, `qemu-runtime-rs` does not support `virtio-scsi`, which causes the `k8s-block-volume.bats` test to fail (for details, please check out #10373).
This PR skips the test until `virtio-scsi` is supported by the runtime.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>

FYI: @sprt 