### PR TITLE
k8s:kbs: Add trap statement to clean up tmp files

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -85,12 +85,13 @@ kbs_set_resource_base64() {
 	fi
 
 	file=$(mktemp -t kbs-resource-XXXXX)
+	trap "rm -f $file" EXIT
+
 	echo "$data" | base64 -d > "$file"
 
 	kbs_set_resource_from_file "$repository" "$type" "$tag" "$file" || \
 		rc=$?
 
-	rm -f "$file"
 	return $rc
 }
 
@@ -116,12 +117,12 @@ kbs_set_resource() {
 	fi
 
 	file=$(mktemp -t kbs-resource-XXXXX)
+	trap "rm -f $file" EXIT
 	echo "$data" > "$file"
 
 	kbs_set_resource_from_file "$repository" "$type" "$tag" "$file" || \
 		rc=$?
 
-	rm -f "$file"
 	return $rc
 }
 


### PR DESCRIPTION
This PR adds the trap statement in the confidential kbs script to clean up temporary files and ensure we are leaving them.