### PR TITLE
osbuilder: Remove duplicated arch variable definition

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -71,7 +71,6 @@ handle_error() {
 trap 'handle_error $LINENO' ERR
 
 # Default architecture
-export ARCH=${ARCH:-$(uname -m)}
 if [ "$ARCH" == "ppc64le" ] || [ "$ARCH" == "s390x" ]; then
 	LIBC=gnu
 	echo "WARNING: Forcing LIBC=gnu because $ARCH has no musl Rust target"
@@ -650,7 +649,7 @@ EOF
 
 	if [ -z "${AGENT_SOURCE_BIN}" ] && [ -z "${AGENT_TARBALL}" ] ; then
 		test -r "${HOME}/.cargo/env" && source "${HOME}/.cargo/env"
-		# rust agent needs ${arch}-unknown-linux-${LIBC}
+		# rust agent needs ${ARCH}-unknown-linux-${LIBC}
 		if ! (rustup show | grep -v linux-${LIBC} > /dev/null); then
 			if [ "$RUST_VERSION" == "null" ]; then
 				detect_rust_version || \
@@ -782,7 +781,6 @@ parse_arguments()
 
 	shift $(($OPTIND - 1))
 	distro="$1"
-	arch=$(uname -m)
 }
 
 detect_host_distro()


### PR DESCRIPTION
This PR removes duplicated arch variable definition in the rootfs script as this variable and its value is already defined at the top of the script.