### PR TITLE
tools/osbuilder/tests: Add trap statement in test images script

### DIFF
--- a/tools/osbuilder/tests/test_images.sh
+++ b/tools/osbuilder/tests/test_images.sh
@@ -111,6 +111,7 @@ show_stats()
 	local sizes
 
 	local tmpfile=$(mktemp)
+	trap 'rm -f $tmpfile' EXIT
 
 	# images
 	for name in "${!built_images[@]}"
@@ -140,8 +141,6 @@ show_stats()
 		"Name"
 
 	sort -k1,1n -k3,3n "$tmpfile"
-
-	rm -f "${tmpfile}"
 }
 
 
@@ -326,13 +325,13 @@ get_distros_config()
 		fi
 
 		tmpfile=$(mktemp /tmp/osbuilder-$d-config.XXX)
+		trap 'rm -f $tmpfile' EXIT
 		${rootfs_builder} -t $d  > $tmpfile
 		# Get value of all keys in distroCfg
 		for k in ${!distroCfg[@]}; do
 			distroCfg[$k]="$(awk -v cfgKey=$k 'BEGIN{FS=":\t+"}{if ($1 == cfgKey) print $2}' $tmpfile)"
 			debug "distroCfg[$k]=${distroCfg[$k]}"
 		done
-		rm -f $tmpfile
 
 		machinePattern="\<${MACHINE_TYPE}\>"
 		if [[ "${distroCfg[ARCH_EXCLUDE_LIST]}" =~ $machinePattern ]]; then


### PR DESCRIPTION
This PR adds the trap statement in the test images script to clean up tmp files.