### PR TITLE
local-build: add ability to build rootfs-image-mariner

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -50,6 +50,7 @@ jobs:
           - stratovirt
           - rootfs-image
           - rootfs-image-confidential
+          - rootfs-image-mariner
           - rootfs-initrd
           - rootfs-initrd-confidential
           - rootfs-initrd-mariner

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -35,6 +35,7 @@ BASE_TARBALLS = serial-targets \
 	virtiofsd-tarball
 BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-image-confidential-tarball \
+	rootfs-image-mariner-tarball \
 	rootfs-initrd-confidential-tarball \
 	rootfs-initrd-mariner-tarball \
 	rootfs-initrd-tarball \
@@ -147,6 +148,9 @@ rootfs-image-tarball: agent-tarball
 	${MAKE} $@-build
 
 rootfs-image-confidential-tarball: agent-tarball pause-image-tarball coco-guest-components-tarball kernel-confidential-tarball
+	${MAKE} $@-build
+
+rootfs-image-mariner-tarball: agent-tarball
 	${MAKE} $@-build
 
 rootfs-initrd-mariner-tarball: agent-tarball

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -118,6 +118,7 @@ options:
 	stratovirt
 	rootfs-image
 	rootfs-image-confidential
+	rootfs-image-mariner
 	rootfs-initrd
 	rootfs-initrd-confidential
 	rootfs-initrd-mariner
@@ -340,6 +341,11 @@ install_image_confidential() {
 	export MEASURED_ROOTFS=yes
 	export PULL_TYPE=default
 	install_image "confidential"
+}
+
+#Install cbl-mariner guest image
+install_image_mariner() {
+	install_image "mariner"
 }
 
 #Install guest initrd
@@ -1085,6 +1091,8 @@ handle_build() {
 	rootfs-image) install_image ;;
 
 	rootfs-image-confidential) install_image_confidential ;;
+
+	rootfs-image-mariner) install_image_mariner ;;
 
 	rootfs-initrd) install_initrd ;;
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -139,6 +139,9 @@ assets:
         confidential:
           name: *default-image-name
           version: *default-image-version
+        mariner:
+          name: "cbl-mariner"
+          version: "2.0"
         nvidia-gpu:
           name: *default-image-name
           version: "jammy"


### PR DESCRIPTION
Kata CI will start building and testing the new rootfs-image-mariner instead of the older rootfs-initrd-mariner image.

The "official" AKS images are moving from a rootfs-initrd-mariner image to the rootfs-image-mariner format. Making the same change in Kata CI is useful to keep this testing in sync with the AKS settings.