### PR TITLE
build: mariner: Remove the ability to build the marine initrd

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -37,7 +37,6 @@ BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-image-confidential-tarball \
 	rootfs-image-mariner-tarball \
 	rootfs-initrd-confidential-tarball \
-	rootfs-initrd-mariner-tarball \
 	rootfs-initrd-tarball \
 	cloud-hypervisor-tarball \
 	cloud-hypervisor-glibc-tarball
@@ -151,9 +150,6 @@ rootfs-image-confidential-tarball: agent-tarball pause-image-tarball coco-guest-
 	${MAKE} $@-build
 
 rootfs-image-mariner-tarball: agent-tarball
-	${MAKE} $@-build
-
-rootfs-initrd-mariner-tarball: agent-tarball
 	${MAKE} $@-build
 
 rootfs-initrd-confidential-tarball: agent-tarball pause-image-tarball coco-guest-components-tarball kernel-confidential-tarball

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -121,7 +121,6 @@ options:
 	rootfs-image-mariner
 	rootfs-initrd
 	rootfs-initrd-confidential
-	rootfs-initrd-mariner
 	runk
 	shim-v2
 	trace-forwarder
@@ -416,11 +415,6 @@ install_initrd_confidential() {
 	export MEASURED_ROOTFS=yes
 	export PULL_TYPE=default
 	install_initrd "confidential"
-}
-
-#Install Mariner guest initrd
-install_initrd_mariner() {
-	install_initrd "mariner"
 }
 
 #Instal NVIDIA GPU image
@@ -1097,8 +1091,6 @@ handle_build() {
 	rootfs-initrd) install_initrd ;;
 
 	rootfs-initrd-confidential) install_initrd_confidential ;;
-
-	rootfs-initrd-mariner) install_initrd_mariner ;;
 
 	rootfs-nvidia-gpu-image) install_image_nvidia_gpu ;;
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -184,9 +184,6 @@ assets:
         confidential:
           name: *glibc-initrd-name
           version: *glibc-initrd-version
-        mariner:
-          name: "cbl-mariner"
-          version: "2.0"
         nvidia-gpu:
           name: *glibc-initrd-name
           version: "jammy"


### PR DESCRIPTION
As mariner has switched to using an image instead of an initrd, let's just drop the abiliy to build the initrd and avoid keeping something in the tree that won't be used.

--- 

This one depends on https://github.com/kata-containers/kata-containers/pull/10396 and will be kept as a draft till that one gets merged.