### PR TITLE
Kbs deploy overlays update

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -240,9 +240,9 @@ externals:
   coco-trustee:
     description: "Provides attestation and secret delivery components"
     url: "https://github.com/confidential-containers/trustee"
-    version: "v0.10.1"
-    image: "ghcr.io/confidential-containers/key-broker-service"
-    image_tag: "built-in-as-v0.10.1"
+    version: "f287fcd60b0b3ddbef5546d646669813b9e68f8d"
+    image: "ghcr.io/confidential-containers/staged-images/kbs"
+    image_tag: "f287fcd60b0b3ddbef5546d646669813b9e68f8d"
     toolchain: "1.74.0"
 
   crio:


### PR DESCRIPTION
In https://github.com/confidential-containers/trustee/pull/521
the overlays logic was modified to add sample
s390x support and simplify non-ibm-se platforms.
We need to update the logic in `kbs_k8s_deploy`
to match and can remove the dummying of `IBM_SE_CREDS_DIR`
for non-SE flows now.

Signed-off-by: stevenhorsman <steven@uk.ibm.com>