### PR TITLE
kbs: ita: Ensure the proper image / image_tag is used for ITA

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -266,9 +266,8 @@ function kbs_k8s_deploy() {
 
 	# Image tag for TDX
 	if [ "${KATA_HYPERVISOR}" = "qemu-tdx" ]; then
-		# The ITA / ITTS images are named as:
-		# ita-as-${image_tag}
-		image_tag=$(echo ${image_tag} | sed 's/built-in/ita/g')
+		image=$(get_from_kata_deps ".externals.coco-trustee.ita_image")
+		image_tag=$(get_from_kata_deps ".externals.coco-trustee.ita_image_tag")
 	fi
 
 	# The ingress handler for AKS relies on the cluster's name which in turn

--- a/versions.yaml
+++ b/versions.yaml
@@ -238,8 +238,11 @@ externals:
     description: "Provides attestation and secret delivery components"
     url: "https://github.com/confidential-containers/trustee"
     version: "f287fcd60b0b3ddbef5546d646669813b9e68f8d"
+    # image / ita_image and image_tag / ita_image_tag must be in sync
     image: "ghcr.io/confidential-containers/staged-images/kbs"
     image_tag: "f287fcd60b0b3ddbef5546d646669813b9e68f8d"
+    ita_image: "ghcr.io/confidential-containers/staged-images/kbs-ita-as"
+    ita_image_tag: "f287fcd60b0b3ddbef5546d646669813b9e68f8d-x86_64"
     toolchain: "1.74.0"
 
   crio:


### PR DESCRIPTION
When dealing with a specific release, it was easier to just do some adjustments on the image that has to be used for ITA without actually adding a new entry in the versions.yaml.

However, it's been proven to be more complicated than that when it comes to dealing with staged images, and we better explicitly add (and update) those versions altogether to avoid CI issues.