### PR TITLE
tools/osbuilder/tests: Remove egrep in test images script

### DIFF
--- a/tools/osbuilder/tests/test_images.sh
+++ b/tools/osbuilder/tests/test_images.sh
@@ -209,7 +209,7 @@ exit_handler()
 	sudo -E kata-collect-data.sh >&2
 
 	info "processes:"
-	sudo -E ps -efwww | egrep "docker|kata" >&2
+	sudo -E ps -efwww | grep -E "docker|kata" >&2
 
 	# Restore the default image in config file
 	run_mgr configure-image


### PR DESCRIPTION
This PR removes egrep command as it has been deprecated and it replaces by grep in the test images script.