### PR TITLE
 tests: k8s-inotify.bats improvements

### DIFF
--- a/tests/integration/kubernetes/k8s-inotify.bats
+++ b/tests/integration/kubernetes/k8s-inotify.bats
@@ -40,8 +40,6 @@ setup() {
         # Verify we saw the update
         result=$(kubectl get pod "$pod_name" --output="jsonpath={.status.containerStatuses[]}")
         echo $result | grep -vq Error
-
-        kubectl delete configmap cm
 }
 
 teardown() {
@@ -49,7 +47,10 @@ teardown() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	issue_url="https://github.com/kata-containers/kata-containers/issues/8906"
 	[ "${KATA_HYPERVISOR}" == "qemu-se" ] && skip "test not working for IBM Z LPAR (see ${issue_url})"
+
 	# Debugging information
 	kubectl describe "pod/$pod_name"
+
 	kubectl delete pod "$pod_name"
+	kubectl delete configmap cm
 }

--- a/tests/integration/kubernetes/k8s-inotify.bats
+++ b/tests/integration/kubernetes/k8s-inotify.bats
@@ -32,10 +32,14 @@ setup() {
         # Update configmap
         kubectl apply -f "${pod_config_dir}"/inotify-updated-configmap.yaml
 
+        # inotify-configmap-pod.yaml is using: "inotifywait --timeout 120", so wait for
+        # up to 180 seconds for the pod termination to be reported.
+        pod_termination_wait_time=180
+
         # Wait for the pod to complete
         command="kubectl describe pod ${pod_name} | grep \"State: \+Terminated\""
-        info "Waiting ${wait_time} seconds for: ${command}"
-        waitForProcess "${wait_time}" "$sleep_time" "${command}"
+        info "Waiting ${pod_termination_wait_time} seconds for: ${command}"
+        waitForProcess "${pod_termination_wait_time}" "$sleep_time" "${command}"
 
         # Verify we saw the update
         result=$(kubectl get pod "$pod_name" --output="jsonpath={.status.containerStatuses[]}")


### PR DESCRIPTION
- Don't leak configmap if the test fails.
- Wait for pod termination up to a longer time (180 sec) than the timeout specified in the pod yaml (120 sec). Before these changes, the 90 sec wait might have timed out before the pod got a chance to finish its work.
