### PR TITLE
kata-agent: fixing bug of unable setting hostname correctly.

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1679,13 +1679,19 @@ fn update_container_namespaces(
     if let Some(namespaces) = linux.namespaces_mut() {
         for namespace in namespaces.iter_mut() {
             if namespace.typ().to_string() == NSTYPEIPC {
-                namespace.set_path(Some(PathBuf::from(&sandbox.shared_ipcns.path.clone())));
-                namespace.set_path(None);
+                namespace.set_path(if !sandbox.shared_ipcns.path.is_empty() {
+                    Some(PathBuf::from(&sandbox.shared_ipcns.path))
+                } else {
+                    None
+                });
                 continue;
             }
             if namespace.typ().to_string() == NSTYPEUTS {
-                namespace.set_path(Some(PathBuf::from(&sandbox.shared_utsns.path.clone())));
-                namespace.set_path(None);
+                namespace.set_path(if !sandbox.shared_utsns.path.is_empty() {
+                    Some(PathBuf::from(&sandbox.shared_utsns.path))
+                } else {
+                    None
+                });
                 continue;
             }
         }

--- a/tests/integration/kubernetes/k8s-hostname.bats
+++ b/tests/integration/kubernetes/k8s-hostname.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2024 Ant Group
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	pod_name="test-pod-hostname"
+	get_pod_config_dir
+
+	yaml_file="${pod_config_dir}/pod-hostname.yaml"
+	add_allow_all_policy_to_yaml "${yaml_file}"
+
+	expected_name=$pod_name
+}
+
+@test "Validate Pod hostname" {
+	# Create pod
+	kubectl apply -f "${yaml_file}"
+
+	kubectl wait --for jsonpath=status.phase=Succeeded --timeout=$timeout pod "$pod_name"
+
+	# Validate the pod hostname
+	result=$(kubectl logs $pod_name)
+	[ "$pod_name" == "$result" ]
+}
+
+teardown() {
+	# Debugging information
+	kubectl describe "pod/$pod_name"
+
+	kubectl delete pod "$pod_name"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -54,6 +54,7 @@ else
 		"k8s-env.bats" \
 		"k8s-exec.bats" \
 		"k8s-file-volume.bats" \
+		"k8s-hostname.bats" \
 		"k8s-inotify.bats" \
 		"k8s-job.bats" \
 		"k8s-kill-all-process-in-container.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-hostname.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-hostname.yaml
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2024 Ant Group.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod-hostname
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  restartPolicy: Never
+  containers:
+  - image: quay.io/prometheus/busybox:latest 
+    name: pod-hostname-c01
+    command: ["sh"]
+    args: ["-c", "hostname"]


### PR DESCRIPTION
When do update_container_namespaces updating namespaces, setting all UTS(and IPC) namespace paths to None resulted in hostnames set prior to the update becoming ineffective. This was primarily due to an error made while aligning with the oci spec: in an attempt to match empty strings with None values in oci-spec-rs, all paths were incorrectly set to None.

Fixes #10325

Related PR #10423