### PR TITLE
genpolicy: read binaryData value as String

### DIFF
--- a/src/tools/genpolicy/src/config_map.rs
+++ b/src/tools/genpolicy/src/config_map.rs
@@ -28,8 +28,10 @@ pub struct ConfigMap {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub data: Option<BTreeMap<String, String>>,
 
+    // When parsing a YAML file, binaryData is encoded as base64.
+    // Therefore, this is a BTreeMap<String, String> instead of BTreeMap<String, Vec<u8>>.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub binaryData: Option<BTreeMap<String, Vec<u8>>>,
+    pub binaryData: Option<BTreeMap<String, String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     immutable: Option<bool>,

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-configmap.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-configmap.yaml
@@ -11,3 +11,7 @@ data:
   data-1: value-1
   data-2: value-2
   data-3: value-3
+binaryData:
+  bin-data-1: YmluLXZhbHVlLTE=
+  bin-data-2: YmluLXZhbHVlLTI=
+  bin-data-3: YmluLXZhbHVlLTM=


### PR DESCRIPTION
While Kubernetes defines `binaryData` as `[]byte`, when defined in a YAML file the raw bytes are
base64 encoded. Therefore, we need to read the YAML value as `String` and not as `Vec<u8>`.

Fixes: #10410