### PR TITLE
ci: add provenance attestation for agent artifact

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -24,6 +24,11 @@ on:
 jobs:
   build-asset:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         asset:
@@ -83,11 +88,16 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Build ${{ matrix.asset }}
+        id: build
         run: |
           make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           mkdir -p kata-build && cp "${build_dir}"/kata-static-${KATA_ASSET}*.tar.* kata-build/.
+          # export oci name and digest for attestation
+          oci_image="$(<"${build_dir}/${KATA_ASSET}-oci-image")"
+          echo "oci-name=${oci_image%@*}" >> $GITHUB_OUTPUT
+          echo "oci-digest=${oci_image#*@}" >> $GITHUB_OUTPUT
         env:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
@@ -97,6 +107,26 @@ jobs:
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
+
+      - uses: oras-project/setup-oras@v1
+        if: (matrix.asset == 'agent') && (inputs.push-to-registry == 'yes')
+        with:
+          version: "1.2.0"
+
+      # for pushing attestations to the registry
+      - uses: docker/login-action@v3
+        if: (matrix.asset == 'agent') && (inputs.push-to-registry == 'yes')
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/attest-build-provenance@v1
+        if: (matrix.asset == 'agent') && (inputs.push-to-registry == 'yes')
+        with:
+          subject-name: ${{ steps.build.outputs.oci-name }}
+          subject-digest: ${{ steps.build.outputs.oci-digest }}
+          push-to-registry: true
 
       - name: store-artifact ${{ matrix.asset }}
         if: ${{ matrix.stage != 'release' || (matrix.asset != 'agent' && matrix.asset != 'coco-guest-components' && matrix.asset != 'pause-image') }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -24,6 +24,11 @@ on:
 jobs:
   build-asset:
     runs-on: s390x
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     strategy:
       matrix:
         asset:
@@ -60,11 +65,16 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Build ${{ matrix.asset }}
+        id: build
         run: |
           make "${KATA_ASSET}-tarball"
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
           mkdir -p kata-build && cp "${build_dir}"/kata-static-${KATA_ASSET}*.tar.* kata-build/.
+          # export oci name and digest for attestation
+          oci_image="$(<"${build_dir}/${KATA_ASSET}-oci-image")"
+          echo "oci-name=${oci_image%@*}" >> $GITHUB_OUTPUT
+          echo "oci-digest=${oci_image#*@}" >> $GITHUB_OUTPUT
         env:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
@@ -74,6 +84,21 @@ jobs:
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
+
+      # for pushing attestations to the registry
+      - uses: docker/login-action@v3
+        if: (matrix.asset == 'agent') && (inputs.push-to-registry == 'yes')
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/attest-build-provenance@v1
+        if: (matrix.asset == 'agent') && (inputs.push-to-registry == 'yes')
+        with:
+          subject-name: ${{ steps.build.outputs.oci-name }}
+          subject-digest: ${{ steps.build.outputs.oci-digest }}
+          push-to-registry: true
 
       - name: store-artifact ${{ matrix.asset }}
         if: ${{ inputs.stage != 'release' || (matrix.asset != 'agent' && matrix.asset != 'coco-guest-components' && matrix.asset != 'pause-image') }}


### PR DESCRIPTION
This adds provenance attestation logic for agent binaries that are published to an oci registry via ORAS.

As a downstream consumer of the kata-agent binary the Peerpod project needs to verify that the artifact has been built on kata's CI. So far the provenance creation has been only enabled for agent builds on amd64 and xs390x.

To create an attestation we need to know the exact digest of the oci artifact, at the point when the artifact was pushed.

Therefore we record the full oci image as returned by oras push. The pushing and tagging logic have been slightly reworked to make this task less repetitive.

The oras cli accepts multiple tags separated by comma on pushes, so a push can be performed atomically instead of iterating through tags and pushing each individually. This removes the risk of partially successful push operations (think: rate limits on the oci registry).


## example

There is a [test run](https://github.com/mkulke/kata-containers/actions/runs/11383416140/job/31668982484) (on a mock build target) to illustrate. the respective verification:

```bash
$ gh attestation verify oci://ghcr.io/mkulke/kata-containers/cached-artefacts/mgns@sha256:89ad6a4b47012d6aa39acafbc23d5539c7ff2fec5c1abb1b851dcb4bc6b113f2 -R mkulke/kata-containers
Loaded digest sha256:89ad6a4b47012d6aa39acafbc23d5539c7ff2fec5c1abb1b851dcb4bc6b113f2 for oci://ghcr.io/mkulke/kata-containers/cached-artefacts/mgns@sha256:89ad6a4b47012d6aa39acafbc23d5539c7ff2fec5c1abb1b851dcb4bc6b113f2
Loaded 1 attestation from GitHub API
✓ Verification succeeded!

sha256:89ad6a4b47012d6aa39acafbc23d5539c7ff2fec5c1abb1b851dcb4bc6b113f2 was attested by:
REPO                    PREDICATE_TYPE                  WORKFLOW

mkulke/kata-containers  https://slsa.dev/provenance/v1  .github/workflows/build-kata-static-tarball-amd64.yaml@refs/heads/mkulke/add-provenance-attestation-for-agent-builds
```