### PR TITLE
rootfs: Add missing dependencies to clearlinux rootfs builder dockerfile

### DIFF
--- a/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/clearlinux/Dockerfile.in
@@ -11,10 +11,11 @@ FROM ${IMAGE_REGISTRY}/fedora:30
 RUN dnf -y update && dnf install -y \
     autoconf \
     automake \
+    bash \
     binutils \
     chrony \
+    clang \
     coreutils \
-    curl \
     curl \
     gcc \
     gcc-c++ \
@@ -28,6 +29,7 @@ RUN dnf -y update && dnf install -y \
     libstdc++-static \
     m4 \
     make \
+    musl-gcc \
     pkgconfig \
     sed \
     systemd \


### PR DESCRIPTION
I encountered three errors when building with the Clear Linux rootfs Dockerfile, which I resolved by adding three additional packages. I also removed a duplicate curl package. Below are the details of the errors and their respective fixes.

**Command to build:**
`USE_DOCKER=true ./rootfs-builder/rootfs.sh -r "${PWD}/clearlinux_rootfs" clearlinux`

**Docker Version:**
Docker version 27.2.1, build 9e34c9b

**Error 1**
```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "bash": executable file not found in $PATH: unknown.
```
**Fix**
Added `bash` package

**Error 2**
```
cargo:warning=Compiler family detection failed due to error: ToolNotFound: Failed to find tool. Is `musl-gcc` installed?

  --- stderr


  error occurred: Failed to find tool. Is `musl-gcc` installed?


warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:137: target/x86_64-unknown-linux-musl/release/kata-agent] Error 101
Failed at 686: make LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP} AGENT_POLICY=${AGENT_POLICY} PULL_TYPE=${PULL_TYPE}
```
**Fix** 
Added `musl-gcc` package

**Error 3**
```
error: failed to run custom build command for `loopdev v0.5.0 (https://github.com/mdaffin/loopdev?rev=c9f91e8f0326ce8a3364ac911e81eb32328a5f27#c9f91e8f)`

Caused by:
  process didn't exit successfully: `/kata-containers/src/agent/target/release/build/loopdev-61866741446c5cc7/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/bindgen-0.63.0/./lib.rs:2338:31:
  Unable to find libclang: "couldn't find any valid shared libraries matching: ['libclang.so', 'libclang-*.so', 'libclang.so.*', 'libclang-*.so.*'], set the `LIBCLANG_PATH` environment variable to a path where one of these files can be found (invalid: [])"
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
make: *** [Makefile:137: target/x86_64-unknown-linux-musl/release/kata-agent] Error 101
Failed at 686: make LIBC=${LIBC} INIT=${AGENT_INIT} SECCOMP=${SECCOMP} AGENT_POLICY=${AGENT_POLICY} PULL_TYPE=${PULL_TYPE}
```

**Fix**
Added `clang` package