### PR TITLE
tools: Change PACKAGES var for cbl-mariner

### DIFF
--- a/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
@@ -5,6 +5,6 @@
 OS_NAME=cbl-mariner
 OS_VERSION=${OS_VERSION:-2.0}
 LIBC="gnu"
-PACKAGES="core-packages-base-image ca-certificates"
+PACKAGES="kata-packages-uvm"
 [ "$AGENT_INIT" = no ] && PACKAGES+=" systemd"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp"


### PR DESCRIPTION
Outline: Change the PACKAGES variable for the cbl-mariner rootfs-builder to use the kata-packages-uvm meta package from packages.microsoft.com to define the set of packages to be contained in the UVM.
This aligns the UVM build for the Azure Linux distribution with the UVM build done for the Kata Containers offering on Azure Kubernetes Services (AKS).

The reasoning behind this change is to get to a more tailored selection of packages than before (e.g. a selection from core-packages-base-image) and to get more immediate control on the set of packages being included (for instance, this achieves a faster turnover when a third party has a use case for which a package is missing. In this case, no new fork/upstream release has to be cut in order to add the package to the UVM).

The kata-packages-uvm meta package can be found [here](https://github.com/microsoft/azurelinux/blob/main/SPECS/kata-packages-uvm/kata-packages-uvm.spec). Note, a kata-packages-uvm-coco meta package is defined as well to build the UVM with proper packages to support the AKS ConfPods offering.

