### PR TITLE
ci: Use ubuntu for static building of kata tools.

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -57,7 +57,10 @@ endef
 kata-tarball: | all-parallel merge-builds
 
 copy-scripts-for-the-agent-build:
-	${MK_DIR}/kata-deploy-copy-libseccomp-installer.sh
+	${MK_DIR}/kata-deploy-copy-libseccomp-installer.sh "agent"
+
+copy-scripts-for-the-tools-build:
+	${MK_DIR}/kata-deploy-copy-libseccomp-installer.sh "tools"
 
 all-parallel:
 	${MAKE} -f $(MK_PATH) all -j $(shell nproc) V=
@@ -74,7 +77,7 @@ serial-targets:
 agent-tarball: copy-scripts-for-the-agent-build
 	${MAKE} $@-build
 
-agent-ctl-tarball:
+agent-ctl-tarball: copy-scripts-for-the-tools-build
 	${MAKE} $@-build
 
 busybox-tarball: 
@@ -92,13 +95,13 @@ cloud-hypervisor-glibc-tarball:
 firecracker-tarball:
 	${MAKE} $@-build
 
-genpolicy-tarball:
+genpolicy-tarball: copy-scripts-for-the-tools-build
 	${MAKE} $@-build
 
 pause-image-tarball:
 	${MAKE} $@-build
 
-kata-ctl-tarball:
+kata-ctl-tarball: copy-scripts-for-the-tools-build
 	${MAKE} $@-build
 
 kata-manager-tarball:
@@ -158,13 +161,13 @@ rootfs-initrd-confidential-tarball: agent-tarball pause-image-tarball coco-guest
 rootfs-initrd-tarball: agent-tarball
 	${MAKE} $@-build
 
-runk-tarball:
+runk-tarball: copy-scripts-for-the-tools-build
 	${MAKE} $@-build
 
 shim-v2-tarball:
 	${MAKE} $@-build
 
-trace-forwarder-tarball:
+trace-forwarder-tarball: copy-scripts-for-the-tools-build
 	${MAKE} $@-build
 
 virtiofsd-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -985,6 +985,10 @@ install_tools_helper() {
 		"${final_tarball_path}" \
 		&& return 0
 
+	export LIBSECCOMP_VERSION="$(get_from_kata_deps ".externals.libseccomp.version")"
+	export LIBSECCOMP_URL="$(get_from_kata_deps ".externals.libseccomp.url")"
+	export GPERF_VERSION="$(get_from_kata_deps ".externals.gperf.version")"
+	export GPERF_URL="$(get_from_kata_deps ".externals.gperf.url")"
 
 	info "build static ${tool}"
 	${tools_builder} ${tool}

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-copy-libseccomp-installer.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-copy-libseccomp-installer.sh
@@ -13,7 +13,7 @@ set -o errtrace
 
 script_dir=$(dirname "$(readlink -f "$0")")
 install_libseccomp_script_src="${script_dir}/../../../../ci/install_libseccomp.sh"
-install_libseccomp_script_dest="${script_dir}/../../static-build/agent/install_libseccomp.sh"
+install_libseccomp_script_dest="${script_dir}/../../static-build/$1/install_libseccomp.sh"
 
 cp "${install_libseccomp_script_src}" "${install_libseccomp_script_dest}"
 

--- a/tools/packaging/static-build/tools/Dockerfile
+++ b/tools/packaging/static-build/tools/Dockerfile
@@ -2,35 +2,49 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.18
+FROM ubuntu:20.04
 ARG GO_TOOLCHAIN
 ARG RUST_TOOLCHAIN
+
+COPY install_libseccomp.sh /usr/bin/install_libseccomp.sh
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 ENV RUSTUP_HOME="/opt/rustup"
 ENV CARGO_HOME="/opt/cargo"
 ENV PATH="/opt/cargo/bin/:${PATH}"
+ENV OPT_LIB="/opt/lib"
 
-ENV LIBC="musl"
 ENV LIBSECCOMP_LINK_TYPE=static
-ENV LIBSECCOMP_LIB_PATH=/usr/lib
+ENV LIBSECCOMP_LIB_PATH=${OPT_LIB}
 
-SHELL ["/bin/ash", "-o", "pipefail", "-c"]
+ENV PKG_CONFIG_PATH=${OPT_LIB}/pkgconfig:$PKG_CONFIG_PATH
 
-RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME} && chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN apk --no-cache add \
-        bash \
-        clang \
-        cmake \
-        curl \
-        gcc \
-        git \
-        libcap-ng-static \
-        libseccomp-static \
-        openssl-dev \
-        openssl-libs-static \
-        make \
-        musl-dev \
-        perl \
-        protoc && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME} && chmod -R a+rwX /opt
+
+RUN apt-get update && \
+	apt-get --no-install-recommends -y install \
+		ca-certificates \
+		clang \
+		cmake \
+		curl \
+		g++ \
+		gcc \
+		git \
+		libssl-dev \
+		make \
+		musl-tools \
+		perl \
+		protobuf-compiler && \
+	apt-get clean && rm -rf /var/lib/apt/lists/ && \
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+
+# Tools only build for x86_64
+RUN rustup target add x86_64-unknown-linux-musl
+
+# cmake looks for musl binutils
+# For setting CMAKE_AR, find_program searches for musl-ar.
+# Symlink to system ar.
+RUN ln -s "$(which ar)" /usr/bin/musl-ar

--- a/tools/packaging/static-build/tools/build-static-tools.sh
+++ b/tools/packaging/static-build/tools/build-static-tools.sh
@@ -12,17 +12,12 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 source "${script_dir}/../../scripts/lib.sh"
 
-init_env() {
-	source "$HOME/.cargo/env"
-
-	export LIBC=musl
-	export LIBSECCOMP_LINK_TYPE=static
-	export LIBSECCOMP_LIB_PATH=/usr/lib
-
-	extra_rust_flags=" -C link-self-contained=yes"
-}
-
 build_tool_from_source() {
+	RUSTFLAGS=" -C link-self-contained=yes"
+	export LIBC=musl
+
+	/usr/bin/install_libseccomp.sh /opt /opt
+
 	tool=${1}
 
 	echo "build ${tool} from source"

--- a/tools/packaging/static-build/tools/build.sh
+++ b/tools/packaging/static-build/tools/build.sh
@@ -26,6 +26,10 @@ docker pull ${container_image} || \
 	 push_to_registry "${container_image}")
 
 docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
+	--env LIBSECCOMP_VERSION=${LIBSECCOMP_VERSION} \
+	--env LIBSECCOMP_URL=${LIBSECCOMP_URL} \
+	--env GPERF_VERSION=${GPERF_VERSION} \
+	--env GPERF_URL=${GPERF_URL} \
 	-w "${repo_root_dir}" \
 	--user "$(id -u)":"$(id -g)" \
 	"${container_image}" \


### PR DESCRIPTION
This commit introduces changes to use ubuntu for statically building kata tools. In the existing CI setup, the tools currently build only for x86_64 architecture.

It also fixes the build error seen for agent-ctl PR#10395.

Fixes #10441