### PR TITLE
workflows: Build components with MEASURED_ROOTFS=yes

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -31,6 +31,8 @@ jobs:
       attestations: write
     strategy:
       matrix:
+        measured-rootfs:
+          - no
         asset:
           - agent
           - agent-ctl
@@ -41,8 +43,6 @@ jobs:
           - genpolicy
           - kata-ctl
           - kata-manager
-          - kernel
-          - kernel-confidential
           - kernel-dragonball-experimental
           - kernel-nvidia-gpu
           - kernel-nvidia-gpu-confidential
@@ -53,14 +53,21 @@ jobs:
           - qemu
           - qemu-snp-experimental
           - stratovirt
-          - rootfs-image
-          - rootfs-image-confidential
           - rootfs-image-mariner
           - rootfs-initrd
           - rootfs-initrd-confidential
           - runk
           - trace-forwarder
           - virtiofsd
+        include:
+          - measured-rootfs: yes
+            asset: kernel
+          - measured-rootfs: yes
+            asset: kernel-confidential
+          - measured-rootfs: yes
+            asset: rootfs-image
+          - measured-rootfs: yes
+            asset: rootfs-image-confidential
         stage:
           - ${{ inputs.stage }}
         exclude:
@@ -104,6 +111,7 @@ jobs:
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
+          MEASURED_ROOTFS: ${{ matrix.measured-rootfs }}
 
       - name: Parse OCI image name and digest
         id: parse-oci-segments
@@ -181,6 +189,7 @@ jobs:
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
+          MEASURED_ROOTFS: yes
 
       - name: store-artifact shim-v2
         if: ${{ matrix.stage != 'release' }}

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -26,18 +26,23 @@ jobs:
     runs-on: arm64-builder
     strategy:
       matrix:
+        measured-rootfs:
+          - no
         asset:
           - agent
           - cloud-hypervisor
           - firecracker
-          - kernel
           - kernel-dragonball-experimental
           - nydus
           - qemu
           - stratovirt
-          - rootfs-image
           - rootfs-initrd
           - virtiofsd
+        include:
+          - measured-rootfs: yes
+            asset: kernel
+          - measured-rootfs: yes
+            asset: rootfs-image
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -73,6 +78,7 @@ jobs:
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
+          MEASURED_ROOTFS: ${{ matrix.measured-rootfs }}
 
       - name: store-artifact ${{ matrix.asset }}
         if: ${{ inputs.stage != 'release' || matrix.asset != 'agent' }}
@@ -121,6 +127,7 @@ jobs:
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
+          MEASURED_ROOTFS: yes
 
       - name: store-artifact shim-v2
         if: ${{ inputs.stage != 'release' }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -31,18 +31,25 @@ jobs:
       attestations: write
     strategy:
       matrix:
+        measured-rootfs:
+          - no
         asset:
           - agent
           - coco-guest-components
-          - kernel
-          - kernel-confidential
           - pause-image
           - qemu
-          - rootfs-image
-          - rootfs-image-confidential
           - rootfs-initrd
           - rootfs-initrd-confidential
           - virtiofsd
+        include:
+          - measured-rootfs: yes
+            asset: kernel
+          - measured-rootfs: yes
+            asset: kernel-confidential
+          - measured-rootfs: yes
+            asset: rootfs-image
+          - measured-rootfs: yes
+            asset: rootfs-image-confidential
     env:
       PERFORM_ATTESTATION: ${{ matrix.asset == 'agent' && inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
     steps:
@@ -81,6 +88,7 @@ jobs:
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
+          MEASURED_ROOTFS: ${{ matrix.measured-rootfs }}
 
       - name: Parse OCI image name and digest
         id: parse-oci-segments
@@ -201,6 +209,7 @@ jobs:
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
+          MEASURED_ROOTFS: yes
 
       - name: store-artifact shim-v2
         if: ${{ inputs.stage != 'release' }}


### PR DESCRIPTION
This is the second step in order to get measured rootfs back in place.

This used to be set in the good and old `CCv0` branch, but when we did the `merge-to-main` effort it ended up not being brought in.

In the `CCv0` branch this was done only for `x86_64` architectures, but it doesn't hurt to be done for all the support architectures, as done as part of this commit.