### PR TITLE
Add a specific workflow for testing the CI, without messing up with the "nightly" weather

### DIFF
--- a/.github/workflows/ci-devel.yaml
+++ b/.github/workflows/ci-devel.yaml
@@ -1,0 +1,17 @@
+name: Kata Containers CI (manually triggered)
+on:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  kata-containers-ci-on-push:
+    uses: ./.github/workflows/ci.yaml
+    with:
+      commit-hash: ${{ github.sha }}
+      pr-number: "manually-triggered"
+      tag: ${{ github.sha }}-manually-triggered
+      target-branch: ${{ github.ref_name }}
+    secrets: inherit

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -2,7 +2,6 @@ name: Kata Containers Nightly CI
 on:
   schedule:
     - cron: '0 0 * * *'
-  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
```
workflows: Add a manually trigger "devel" workflow for the CI

This workflow is intended to replace the `workflow_dispatch` trigger
currently present as part of the `ci-nightly.yaml`.

The reasoning behind having this done in this way is because of our good
and old GHA behaviour for `pull_request_target`, which requires a PR to
be merged in order to check the changes in the workflow itself, which
leads to:
* when a change in a workflow is done, developers (should) do:
  * push their branch to the kata-containers repo
  * manually trigger the "nightly" CI in order to ensure the changes
    don't break anything
    * this can result in the "nightly" CI weather being polluted
      * we don't have the guarantee / assurance about the last n nightly
	runs anymore
```

---


```
workflows: Remove the possibility to manually trigger the nightly CI

As a new workflow was added for the cases where developers want to test
their changes in the workflow itself, let's make sure we stop allowing
manual triggers on this workflow, which can lead to a polluted /
misleading weather of the CI.
```