### PR TITLE
tests: Add trap statement in kata doc script

### DIFF
--- a/tests/kata-doc-to-script.sh
+++ b/tests/kata-doc-to-script.sh
@@ -168,6 +168,7 @@ doc_to_script()
 
 	all=$(mktemp)
 	body=$(mktemp)
+	trap 'rm -f $body $all' EXIT
 
 	cat "$file" |\
 		sed -n "/^ *${bash_block_open}/,/^ *${block_close}/ p" |\
@@ -188,9 +189,6 @@ doc_to_script()
 
 	# create output file
 	[ "$check_only" = "no" ] && cp "$all" "$outfile"
-
-	# clean up
-	rm -f "$body" "$all"
 }
 
 main()


### PR DESCRIPTION
This PR adds the trap statement into the kata doc
script to clean up properly the temporary files.