### PR TITLE
tests: k8s: Update bats

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -101,14 +101,11 @@ function create_cluster() {
 }
 
 function install_bats() {
-	# Installing bats from the lunar repo.
-	# This installs newer version of the bats which supports setup_file and teardown_file functions.
-	# These functions are helpful when adding new tests that require one time setup.
-
+	# Installing bats from the noble repo.
 	sudo apt install -y software-properties-common
-	sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ lunar universe'
+	sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
 	sudo apt install -y bats
-	sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ lunar universe'
+	sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
 }
 
 function install_kubectl() {

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -85,13 +85,12 @@ kbs_set_resource_base64() {
 	fi
 
 	file=$(mktemp -t kbs-resource-XXXXX)
-	trap "rm -f $file" EXIT
-
 	echo "$data" | base64 -d > "$file"
 
 	kbs_set_resource_from_file "$repository" "$type" "$tag" "$file" || \
 		rc=$?
 
+	rm -f "$file"
 	return $rc
 }
 
@@ -117,12 +116,12 @@ kbs_set_resource() {
 	fi
 
 	file=$(mktemp -t kbs-resource-XXXXX)
-	trap "rm -f $file" EXIT
 	echo "$data" > "$file"
 
 	kbs_set_resource_from_file "$repository" "$type" "$tag" "$file" || \
 		rc=$?
 
+	rm -f "$file"
 	return $rc
 }
 

--- a/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
@@ -16,7 +16,7 @@ setup() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    setup_common
+    setup_common || die "setup_common failed"
     AUTHENTICATED_IMAGE="${AUTHENTICATED_IMAGE:-quay.io/kata-containers/confidential-containers-auth:test}"
     AUTHENTICATED_IMAGE_USER=${AUTHENTICATED_IMAGE_USER:-}
     AUTHENTICATED_IMAGE_PASSWORD=${AUTHENTICATED_IMAGE_PASSWORD:-}

--- a/tests/integration/kubernetes/k8s-guest-pull-image-encrypted.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-encrypted.bats
@@ -20,7 +20,7 @@ setup() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    setup_common
+    setup_common || die "setup_common failed"
     ENCRYPTED_IMAGE="${ENCRYPTED_IMAGE:-ghcr.io/confidential-containers/test-container:multi-arch-encrypted}"
     DECRYPTION_KEY="${DECRYPTION_KEY:-HUlOu8NWz8si11OZUzUJMnjiq/iZyHBJZMSD3BaqgMc=}"
     DECRYPTION_KEY_ID="${DECRYPTION_KEY_ID:-ssh-demo}"

--- a/tests/integration/kubernetes/k8s-guest-pull-image-signature.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-signature.bats
@@ -22,7 +22,7 @@ setup() {
         tag_suffix="-$(uname -m)"
     fi
 
-    setup_common
+    setup_common || die "setup_common failed"
     UNSIGNED_UNPROTECTED_REGISTRY_IMAGE="quay.io/prometheus/busybox:latest"
     UNSIGNED_PROTECTED_REGISTRY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:unsigned${tag_suffix}"
     COSIGN_SIGNED_PROTECTED_REGISTRY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:cosign-signed${tag_suffix}"

--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -15,7 +15,7 @@ setup() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    setup_common
+    setup_common || die "setup_common failed"
     get_pod_config_dir
     unencrypted_image="quay.io/prometheus/busybox:latest"
     image_pulled_time_less_than_default_time="ghcr.io/confidential-containers/test-container:rust-1.79.0" # unpacked size: 1.41GB

--- a/tests/integration/kubernetes/k8s-liveness-probes.bats
+++ b/tests/integration/kubernetes/k8s-liveness-probes.bats
@@ -14,7 +14,7 @@ setup() {
 	agnhost_name="${container_images_agnhost_name}"
 	agnhost_version="${container_images_agnhost_version}"
 
-	setup_common
+	setup_common || die "setup_common failed"
 	get_pod_config_dir
 }
 

--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -22,7 +22,7 @@ check_and_skip() {
 
 setup() {
 	check_and_skip
-	setup_common
+	setup_common || die "setup_common failed"
 }
 
 @test "Test cannnot launch pod with measured boot enabled and incorrect hash" {

--- a/tests/integration/kubernetes/k8s-sealed-secret.bats
+++ b/tests/integration/kubernetes/k8s-sealed-secret.bats
@@ -21,7 +21,7 @@ setup() {
 		skip "Test skipped as KBS not setup"
 	fi
 
-	setup_common
+	setup_common || die "setup_common failed"
 	get_pod_config_dir
 
 	export K8S_TEST_ENV_YAML="${pod_config_dir}/pod-sealed-secret.yaml"

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -129,6 +129,8 @@ fi
 
 ensure_yq
 
+info "Running tests with bats version: $(bats --version)"
+
 tests_fail=()
 for K8S_TEST_ENTRY in ${K8S_TEST_UNION[@]}
 do


### PR DESCRIPTION
We've seen some issues with tests not being run in some of the Coco CI jobs (Issue #10451) and in the envrionments that are more stable we noticed that
they had a newer version of bats installed.

Try updating the version to 1.10+ and print out
the version for debug purposes