### PR TITLE
workflows: devel: Follow-up on the manually triggered jobs

### DIFF
--- a/.github/workflows/ci-devel.yaml
+++ b/.github/workflows/ci-devel.yaml
@@ -2,10 +2,6 @@ name: Kata Containers CI (manually triggered)
 on:
   workflow_dispatch:
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   kata-containers-ci-on-push:
     uses: ./.github/workflows/ci.yaml

--- a/.github/workflows/ci-devel.yaml
+++ b/.github/workflows/ci-devel.yaml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/ci.yaml
     with:
       commit-hash: ${{ github.sha }}
-      pr-number: "manually-triggered"
-      tag: ${{ github.sha }}-manually-triggered
+      pr-number: "dev"
+      tag: ${{ github.sha }}-dev
       target-branch: ${{ github.ref_name }}
     secrets: inherit


### PR DESCRIPTION
Stop using "manually-triggered" as it's too long to create AKS clusters, and use "dev" instead.
Also, let's allow this to run in parallel in case two or more developers want to test things at the same time.