### PR TITLE
workflows: Possibly fix the release workflow

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -183,7 +183,6 @@ jobs:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact shim-v2
-        if: ${{ matrix.stage != 'release' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-amd64-shim-v2${{ inputs.tarball-suffix }}

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -123,7 +123,6 @@ jobs:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact shim-v2
-        if: ${{ inputs.stage != 'release' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-arm64-shim-v2${{ inputs.tarball-suffix }}

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -129,7 +129,6 @@ jobs:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact shim-v2
-        if: ${{ inputs.stage != 'release' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-ppc64le-shim-v2${{ inputs.tarball-suffix }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -203,7 +203,6 @@ jobs:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 
       - name: store-artifact shim-v2
-        if: ${{ inputs.stage != 'release' }}
         uses: actions/upload-artifact@v4
         with:
           name: kata-artifacts-s390x-shim-v2${{ inputs.tarball-suffix }}


### PR DESCRIPTION
The only reason we had this one passing for amd64 is because the check was done using the wrong variable (`matrix.stage`, while in the other workflows the variable used is `inputs.stage`).

The commit that broke the release process is 67a8665f51d78e1138c, which blindly copy & pasted the logic from the matrix assets.