### PR TITLE
build: cleanup: Don't fail deleting file that doesn't exist

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -167,7 +167,7 @@ get_kernel_modules_dir() {
 }
 
 cleanup_and_fail_shim_v2_specifics() {
-	rm -f "${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/shim-v2-root_hash.txt"
+	rm -f "${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/shim-v2-root_hash.txt" || true
 
 	return $(cleanup_and_fail "${1:-}" "${2:-}")
 }


### PR DESCRIPTION
Let's just add a `|| true` when deleting the shim-v2-root_hash.txt as the first time the shim will be built it won't have the file there.