### PR TITLE
build: cache: Ensure shim-v2-root_hash.txt is in "${workdir}"

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -1202,7 +1202,7 @@ handle_build() {
 					die "Building the shim-v2 with MEASURED_ROOTFS support requres a rootfs confidential image tarball built with MEASURED_ROOTFS support"
 				fi
 
-				mv root_hash.txt shim-v2-root_hash.txt
+				mv root_hash.txt ${workdir}/shim-v2-root_hash.txt
 			fi
 			;;
 	esac


### PR DESCRIPTION
All the oras push logic happens from inside `${workdir}`, while the root_hash.txt extraction and renaming was not taking this into consideration.

This was not caught during the manually triggered runs as those do not perform the oras push.