### PR TITLE
gha: Switch KUBERNETES from k3s to kubeadm on s390x

### DIFF
--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -36,7 +36,7 @@ jobs:
           - qemu-runtime-rs
           - qemu-coco-dev
         k8s:
-          - k3s
+          - kubeadm
         include:
           - snapshotter: devmapper
             pull-type: default
@@ -96,9 +96,6 @@ jobs:
           echo "KBS=true" >> $GITHUB_ENV
           echo "KBS_INGRESS=nodeport" >> $GITHUB_ENV
         if: ${{ matrix.vmm == 'qemu-coco-dev' }}
-
-      - name: Deploy ${{ matrix.k8s }}
-        run: bash tests/integration/kubernetes/gha-run.sh deploy-k8s
 
       # qemu-runtime-rs only works with overlayfs
       # See: https://github.com/kata-containers/kata-containers/issues/10066


### PR DESCRIPTION
Last November, SUSE discontinued support for s390x, leaving `k3s` on this platform stuck at k8s version 1.28, while upstream k8s has since reached 1.31. Fortunately, `kubeadm` allows us to create a 1.30 Kubernetes cluster on s390x.

This PR switches the `KUBERNETES` option from `k3s` to `kubeadm` for s390x and removes a dedicated cluster creation step. It also includes a configuration option `kubeadm` for devmapper setup.
Now, cluster setup and teardown occur in `ACTIONS_RUNNER_HOOK_JOB_{STARTED,COMPLETED}` on the self-hosted runners.

For reviewers, the affected workflows are as follows:

- run-k8s-tests-on-zvsi / run-k8s-tests (devmapper, qemu, k3s)
- run-k8s-tests-on-zvsi / run-k8s-tests (overlayfs, qemu-runtime-rs, k3s)
- run-k8s-tests-on-zvsi / run-k8s-tests (nydus, qemu-coco-dev, k3s)

The change is verified at https://github.com/BbolroC/kata-containers/actions/runs/11406575283

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>