### PR TITLE
workflows: Temporarily stop building OVMF (revert me ASAP)

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -47,8 +47,6 @@ jobs:
           - kernel-nvidia-gpu
           - kernel-nvidia-gpu-confidential
           - nydus
-          - ovmf
-          - ovmf-sev
           - pause-image
           - qemu
           - qemu-snp-experimental


### PR DESCRIPTION
OVMF / OVMF-SEV are failing to build due to a dependency that was made private.  Those 2 packages are only used by the SNP (uses OVMF) and SEV (uses OVMF SEV) respectively, and should be taken care by the respective CI owners.

For now, in order to avoid blocking the upstream development, let's just not build those and we can revert this PR as soon as the OVMF situation is solved.