### PR TITLE
builds: ovmf: Workaround Zeex repo becoming private

### DIFF
--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -38,6 +38,9 @@ build_root=$(mktemp -d)
 pushd $build_root
 git clone --single-branch --depth 1 -b "${ovmf_version}" "${ovmf_repo}"
 cd "${ovmf_dir}"
+# TODO: Remove this line after bumping to a newer release of OVMF.
+# Reference: https://github.com/tianocore/edk2/pull/6402
+sed -i -e "s|https://github.com/Zeex/subhook.git|https://github.com/tianocore/edk2-subhook.git|g" .gitmodules
 git submodule init
 git submodule update
 


### PR DESCRIPTION
Let's just do a simple `sed` and **not** use the repo that became private.

This is not a backport of https://github.com/tianocore/edk2/pull/6402, but it's a similar approach that allows us to proceed without the need to pick up a newer version of edk2.