### PR TITLE
agent: fix typo on getting EphemeralHandler size option

### DIFF
--- a/src/agent/src/storage/ephemeral_handler.rs
+++ b/src/agent/src/storage/ephemeral_handler.rs
@@ -170,7 +170,7 @@ impl EphemeralHandler {
         let size = size_str
             .unwrap()
             .parse::<u64>()
-            .context(format!("parse size: {:?}", &pagesize_str))?;
+            .context(format!("parse size: {:?}", &size_str))?;
 
         Ok((pagesize, size))
     }


### PR DESCRIPTION
Most likely this was overlooked during the development / review, but we're actually interested on the size rather than on the pagesize of the hugepages.


cc @liubin @bpradipt, as this as introduced as part of 36c3fc12ce6813763538ada66334a3d8a28845f0

Please, let me know if this is not actually a typo, and why it's not a typo. as I came across this one while debugging something completely unrelated.