### PR TITLE
gha: Add install kata tools as part of the stability workflow

### DIFF
--- a/.github/workflows/run-kata-coco-stability-tests.yaml
+++ b/.github/workflows/run-kata-coco-stability-tests.yaml
@@ -64,6 +64,9 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
+      - name: Install kata
+        run: bash tests/integration/kubernetes/gha-run.sh install-kata-tools
+
       - name: Download Azure CLI
         run: bash tests/integration/kubernetes/gha-run.sh install-azure-cli
 

--- a/tests/stability/gha-stability-run.sh
+++ b/tests/stability/gha-stability-run.sh
@@ -31,6 +31,7 @@ function main() {
 		login-azure) login_azure ;;
 		create-cluster) create_cluster ;;
 		install-bats) install_bats ;;
+		install-kata-tools) install_kata_tools ;;
 		install-kubectl) install_kubectl ;;
 		get-cluster-credentials) get_cluster_credentials ;;
 		deploy-snapshotter) deploy_snapshotter ;;


### PR DESCRIPTION
This PR adds the install kata tools step as part of the k8s stability workflow.