### PR TITLE
runtime: Files are not synced between host and guest VMs

### DIFF
--- a/src/runtime/virtcontainers/fs_share_linux.go
+++ b/src/runtime/virtcontainers/fs_share_linux.go
@@ -64,6 +64,14 @@ func resolveRootDir() string {
 		// Use the default root dir in case of any errors resolving the root dir symlink
 		return defaultKubernetesRootDir
 	}
+	// Make root dir an absolute path if needed
+	if !filepath.IsAbs(rootDir) {
+		rootDir, err = filepath.Abs(filepath.Join(filepath.Dir(defaultKubernetesRootDir), rootDir))
+		if err != nil {
+			// Use the default root dir in case of any errors resolving the root dir symlink
+			return defaultKubernetesRootDir
+		}
+	}
 	return rootDir
 }
 


### PR DESCRIPTION
This PR makes the root dir absolute after resolving the default root dir symlink.

Fixes: https://github.com/kata-containers/kata-containers/issues/10499