### PR TITLE
metrics: Skip metrics on stratovirt

### DIFF
--- a/.github/workflows/run-metrics.yaml
+++ b/.github/workflows/run-metrics.yaml
@@ -48,7 +48,7 @@ jobs:
       # all the tests due to a single flaky instance.
       fail-fast: false
       matrix:
-        vmm: ['clh', 'qemu', 'stratovirt']
+        vmm: ['clh', 'qemu']
       max-parallel: 1
     runs-on: metrics
     env:


### PR DESCRIPTION
As discussed on the AC call, we are lacking maintainers for the metrics tests. As a starting point for potentially phasing them out, we discussed starting with removing the test for stratovirt as a non-core hypervisor and a job that is problematic in leaving behind resources that need cleaning up.