### PR TITLE
gha: Get artifacts when installing kata tools in stability workflow

### DIFF
--- a/.github/workflows/run-kata-coco-stability-tests.yaml
+++ b/.github/workflows/run-kata-coco-stability-tests.yaml
@@ -64,8 +64,14 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
+      - name: get-kata-tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          path: kata-artifacts
+
       - name: Install kata
-        run: bash tests/integration/kubernetes/gha-run.sh install-kata-tools
+        run: bash tests/integration/kubernetes/gha-run.sh install-kata-tools kata-artifacts
 
       - name: Download Azure CLI
         run: bash tests/integration/kubernetes/gha-run.sh install-azure-cli

--- a/tests/stability/gha-stability-run.sh
+++ b/tests/stability/gha-stability-run.sh
@@ -12,6 +12,7 @@ set -o pipefail
 stability_dir="$(dirname "$(readlink -f "$0")")"
 source "${stability_dir}/../metrics/lib/common.bash"
 source "${stability_dir}/../gha-run-k8s-common.sh"
+kata_tarball_dir="${2:-kata-artifacts}"
 
 function run_tests() {
 	info "Running scability test using ${KATA_HYPERVISOR} hypervisor"


### PR DESCRIPTION
This PR adds the get artifacts which are needed when installing kata tools in stability workflow to avoid failures saying that artifacts are missing.