### PR TITLE
ci.ocp: Use the official python:3 container for sanity

### DIFF
--- a/ci/openshift-ci/smoke/http-server.yaml.in
+++ b/ci/openshift-ci/smoke/http-server.yaml.in
@@ -13,7 +13,7 @@ metadata:
 spec:
   containers:
     - name: http-server
-      image: registry.fedoraproject.org/fedora
+      image: docker.io/library/python:3
       ports:
         - containerPort: 8080
       command: ["python3"]


### PR DESCRIPTION
Fedora F40 removed python3 from the base container, to avoid such issues let's rely on the latest and greates official python container.

Fixes: #10497