### PR TITLE
gha: Hardcode ubuntu-22.04 instead of latest

### DIFF
--- a/.github/workflows/ci-weekly.yaml
+++ b/.github/workflows/ci-weekly.yaml
@@ -37,7 +37,7 @@ jobs:
     secrets: inherit
 
   build-and-publish-tee-confidential-unencrypted-image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/gatekeeper-skipper.yaml
+++ b/.github/workflows/gatekeeper-skipper.yaml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   skipper:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       skip_build: ${{ steps.skipper.outputs.skip_build }}
       skip_test: ${{ steps.skipper.outputs.skip_test }}

--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   gatekeeper:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/run-kata-coco-stability-tests.yaml
+++ b/.github/workflows/run-kata-coco-stability-tests.yaml
@@ -34,7 +34,7 @@ jobs:
           - nydus
         pull-type:
           - guest-pull
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}

--- a/src/runtime/pkg/govmm/.github/workflows/main.yml
+++ b/src/runtime/pkg/govmm/.github/workflows/main.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.15.x, 1.16.x]
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go


### PR DESCRIPTION
GHA is migrating ubuntu-latest to Ubuntu 24 so let's hardcode the current 22.04 LTS.

https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/