### PR TITLE
Reapply "runtime: confidential: Do not set the max_vcpu to cpu"

### DIFF
--- a/src/runtime/virtcontainers/hypervisor_config_linux.go
+++ b/src/runtime/virtcontainers/hypervisor_config_linux.go
@@ -58,11 +58,6 @@ func validateHypervisorConfig(conf *HypervisorConfig) error {
 		conf.DefaultMaxVCPUs = defaultMaxVCPUs
 	}
 
-	if conf.ConfidentialGuest && conf.NumVCPUs() != conf.DefaultMaxVCPUs {
-		hvLogger.Warnf("Confidential guests do not support hotplugging of vCPUs. Setting DefaultMaxVCPUs to NumVCPUs (%d)", conf.NumVCPUs())
-		conf.DefaultMaxVCPUs = conf.NumVCPUs()
-	}
-
 	if conf.Msize9p == 0 && conf.SharedFS != config.VirtioFS {
 		conf.Msize9p = defaultMsize9p
 	}


### PR DESCRIPTION
This reverts commit f15e16b69229c5aafde14072eb05f971d80a3c2e, as we don't have to do this since we're relying on the
`static_sandbox_resource_mgmt` feature, which gives us the correct amount of memory and CPUs to be allocated.