### PR TITLE
osbuilder: remove redundant env variable 

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -14,7 +14,6 @@ ENV PATH="/opt/cargo/bin/:/opt/go/bin:${PATH}"
 
 ARG GO_VERSION
 ARG RUST_TOOLCHAIN
-ENV GO_HOME="/opt"
 ENV PATH="/opt/go/bin:${PATH}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]


### PR DESCRIPTION
Remove unneeded second declaration of `GO_HOME` in rootfs-builder.