### PR TITLE
genpolicy: add default peer pod network namespace

### DIFF
--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -993,5 +993,10 @@ pub fn get_kata_namespaces(
         Path: "".to_string(),
     });
 
+    namespaces.push(KataLinuxNamespace {
+        Type: "network".to_string(),
+        Path: "/run/netns/podns".to_string(),
+    });
+
     namespaces
 }


### PR DESCRIPTION
The CAA https://github.com/confidential-containers/cloud-api-adaptor starts conatiner inside the hardcoded network namespace `/run/netns/podns`. Therefore, we need to add this to the policy.


The way namespace are handled hasn't evolved since the initial genpolicy commit to this repo (https://github.com/kata-containers/kata-containers/commit/48829120b68526137249e86bf1b48ecda3a779f9). How do we generally handle sets of namespaces for different scenarios. I think the simplest solution right now would be to add some plumbing so that the constants that are currently defined in code can be defined in the genpolicy settings. 

I could implement such a solution either in this PR, if needed.
