### PR TITLE
osbuilder: add riscv64 support in rootfs-builder

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -36,6 +36,7 @@ RUN apt-get update && \
          [ "$gcc_arch" = aarch64 ] && libc_arch=arm64; \
          [ "$gcc_arch" = ppc64le ] && gcc_arch=powerpc64le && libc_arch=ppc64el; \
          [ "$gcc_arch" = s390x ] && gcc_arch=s390x && libc_arch=s390x; \
+         [ "$gcc_arch" = riscv64 ] && gcc_arch=riscv64 && libc_arch=riscv64; \
          [ "$gcc_arch" = x86_64 ] && gcc_arch=x86-64 && libc_arch=amd64; \
          echo "gcc-$gcc_arch-linux-gnu libc6-dev-$libc_arch-cross")) \
     git \
@@ -65,7 +66,7 @@ RUN ARCH=$(uname -m); \
         *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
     esac; \
     curl -OL "https://storage.googleapis.com/golang/go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
-    tar -C "${GO_HOME}" -xzf "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
+    tar --no-same-owner --no-same-permissions -C "${GO_HOME}" -xzf "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
     rm "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz"
 
 # aarch64 requires this name -- link for all
@@ -79,6 +80,7 @@ RUN ARCH=$(uname -m); \
         "ppc64le") rust_arch="powerpc64le"; libc="gnu"; ;; \
         "x86_64") rust_arch="${ARCH}"; libc="musl"; ;; \
         "s390x") rust_arch="${ARCH}"; libc="gnu"; ;; \
+        "riscv64") rust_arch="riscv64gc"; libc="gnu"; ;; \
         *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
 	esac; \
     rustup target add "${rust_arch}-unknown-linux-${libc}"

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -16,6 +16,7 @@ case "$ARCH" in
 	aarch64) DEB_ARCH=arm64;;
 	ppc64le) DEB_ARCH=ppc64el;;
 	s390x) DEB_ARCH="$ARCH";;
+	riscv64) DEB_ARCH="$ARCH";;
 	x86_64) DEB_ARCH=amd64; REPO_URL=http://archive.ubuntu.com/ubuntu;;
 	*) die "$ARCH not supported"
 esac


### PR DESCRIPTION
This commit adds riscv64 support for ubuntu target. Note that in order to be able to build the rootfs correctly without errors the command i used was `sudo -E AGENT_INIT=yes USE_DOCKER=false SECCOMP=no ./rootfs.sh ubuntu`

By setting `USE_DOCKER=true` I got several libclang errors, I think due to library incompatibilities. 

This PR depends on #10512.