### PR TITLE
ci: Temporarily skip SNP CI

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -161,6 +161,9 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
 
   run-k8s-tests-sev-snp:
+    # Skipping SNP tests to unblock the CI. 
+    # Will revert after issue is fixed.
+    if: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
As discussed in the CI working group,
we are temporarily skipping the SNP CI
to unblock the remaining workflow.
Will revert after fixing the SNP runner.