### PR TITLE
genpolicy: avoid regorus warning

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -7,8 +7,6 @@ package agent_policy
 import future.keywords.in
 import future.keywords.every
 
-import input
-
 # Default values, returned by OPA when rules cannot be evaluated to true.
 default AddARPNeighborsRequest := false
 default AddSwapRequest := false


### PR DESCRIPTION
Avoid adding to the Guest console warnings about "agent_policy:10:8".

"import input" is unnecessary.