### PR TITLE
runtime: fix comment to accurately reflect clh behavior

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1359,11 +1359,10 @@ func (clh *cloudHypervisor) launchClh() error {
 	if clh.config.Debug {
 		// Cloud hypervisor log levels
 		// 'v' occurrences increase the level
-		//0 =>  Error
-		//1 =>  Warn
-		//2 =>  Info
-		//3 =>  Debug
-		//4+ => Trace
+		//0 =>  Warn
+		//1 =>  Info
+		//2 =>  Debug
+		//3+ => Trace
 		// Use Info, the CI runs with debug enabled
 		// a high level of logging increases the boot time
 		// and in a nested environment this could increase


### PR DESCRIPTION
# Description of problem
Per the comment in clh.go pertaining to logging verbosity for CLH, we should only be getting 'WARN' messages from CLH when we configure clh.Config.Debug = true. This is not the case; we instead filter for messages up to an including the 'INFO' level. This appears to be due to the CLH implementation for logging verbosity getting out of sync with the comment/verbosity logic in clh.go.

clh.go comment: https://github.com/microsoft/kata-containers/blob/msft-main/src/runtime/virtcontainers/clh.go#L1437 
clh implementation logic: https://github.com/cloud-hypervisor/cloud-hypervisor/blob/main/src/main.rs#L556 

# Expected result

For a system configured with enable_debug=true for kata runtime, kernel, I expected only messages from CLH up to 'WARN'.

```
cat journal.txt | grep "cloud-hypervisor.*WARN"
time="2024-11-14T19:29:08.161716087Z" level=debug msg="reading guest console" console-protocol=pty console-url=/dev/pts/0 name=containerd-shim-v2 pid=1716822 sandbox=3495a5a94583c1c62985502f05da57228aa5803a93d495a97a5f8e9e13bb7ce5 source=virtcontainers subsystem=sandbox vmconsole="cloud-hypervisor: 674.660288ms: <vcpu0> WARN:devices/src/legacy/debug_port.rs:76 -- [Debug I/O port: Kernel code 0x40] 0.662356 seconds"
time="2024-11-14T19:29:13.379499593Z" level=debug msg="reading guest console" console-protocol=pty console-url=/dev/pts/0 name=containerd-shim-v2 pid=1716822 sandbox=3495a5a94583c1c62985502f05da57228aa5803a93d495a97a5f8e9e13bb7ce5 source=virtcontainers subsystem=sandbox vmconsole="cloud-hypervisor: 5.897750s: <vcpu0> WARN:devices/src/legacy/debug_port.rs:76 -- [Debug I/O port: Kernel code 0x41] 5.5885446 seconds"
cat journal.txt | grep "cloud-hypervisor.*INFO"

``` 

# Actual result

I am instead able to see messages up to 'INFO'

```
cat journal.txt | grep "cloud-hypervisor.*INFO"
time="2024-11-14T19:29:31.928024041Z" level=debug msg="reading guest console" console-protocol=pty console-url=/dev/pts/0 name=containerd-shim-v2 pid=1716822 sandbox=3495a5a94583c1c62985502f05da57228aa5803a93d495a97a5f8e9e13bb7ce5 source=virtcontainers subsystem=sandbox vmconsole="cloud-hypervisor: 24.446144s: <vmm> INFO:vmm/src/api/mod.rs:468 -- API request event: AddDisk DiskConfig { path: Some(\"/dev/loop0\"), readonly: false, direct: false, iommu: false, num_queues: 1, queue_size: 1024, vhost_user: false, vhost_socket: None, rate_limit_group: None, rate_limiter_config: None, id: None, disable_io_uring: false, disable_aio: false, pci_segment: 1, serial: None, queue_affinity: None }"
time="2024-11-14T19:29:31.92809644Z" level=debug msg="reading guest console" console-protocol=pty console-url=/dev/pts/0 name=containerd-shim-v2 pid=1716822 sandbox=3495a5a94583c1c62985502f05da57228aa5803a93d495a97a5f8e9e13bb7ce5 source=virtcontainers subsystem=sandbox vmconsole="cloud-hypervisor: 24.446209s: <vmm> INFO:vmm/src/device_manager.rs:2389 -- Creating virtio-block device: DiskConfig { path: Some(\"/dev/loop0\"), readonly: false, direct: false, iommu: false, num_queues: 1, queue_size: 1024, vhost_user: false, vhost_socket: None, rate_limit_group: None, rate_limiter_config: None, id: Some(\"_disk5\"), disable_io_uring: false, disable_aio: false, pci_segment: 1, serial: None, queue_affinity: None }"
``` 

Fix the CLH log levels description.

Update the comment to accurately reflect the actual logging level. Leave the debug option behavior as '-v', which enables clh logging up to 'INFO'. 

Addresses https://github.com/kata-containers/kata-containers/issues/10544 