### PR TITLE
kata-deploy: Add support to multi-installation

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -1,22 +1,38 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
   name: {{ .Chart.Name }}
+{{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
+{{- if .Values.env.multiInstallSuffix }}
+      name: {{ .Chart.Name }}-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
       name: {{ .Chart.Name }}
+{{- end }}
   template:
     metadata:
       labels:
+{{- if .Values.env.multiInstallSuffix }}
+        name: {{ .Chart.Name }}-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
         name: {{ .Chart.Name }}
+{{- end }}
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
 {{- toYaml . | nindent 6 }}
 {{- end }}
+{{- if .Values.env.multiInstallSuffix }}
+      serviceAccountName: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
       serviceAccountName: {{ .Chart.Name }}-sa
+{{- end }}
       hostPID: true
       containers:
       - name: kube-kata
@@ -50,6 +66,8 @@ spec:
           value: {{ .Values.env.pullTypeMapping | quote }}
         - name: INSTALLATION_PREFIX
           value: {{ .Values.env.installationPrefix | quote }}
+        - name: MULTI_INSTALL_SUFFIX
+          value: {{ .Values.env.multiInstallSuffix | quote }}
 {{- with .Values.env.hostOS }}
         - name: HOST_OS
           value: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -2,13 +2,21 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
   name: {{ .Chart.Name }}-sa
+{{- end }}
   namespace: {{ .Release.Namespace }}
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-role-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
   name: {{ .Chart.Name }}-role
+{{- end }}
 rules:
 - apiGroups: [""]
   resources: ["nodes"]
@@ -20,12 +28,24 @@ rules:
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-rb-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
   name: {{ .Chart.Name }}-rb
+{{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-role-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
   name: {{ .Chart.Name }}-role
+{{- end }}
 subjects:
 - kind: ServiceAccount
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
+{{- else }}
   name: {{ .Chart.Name }}-sa
+{{- end }}
   namespace: {{ .Release.Namespace }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
@@ -90,6 +90,8 @@ spec:
           value: {{ .Values.env.pullTypeMapping | quote }}
         - name: HELM_POST_DELETE_HOOK
           value: "true"
+        - name: INSTALLATION_PREFIX
+          value: {{ .Values.env.installationPrefix | quote }}
 {{- with .Values.env.hostOS }}
         - name: HOST_OS
           value: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}-cleanup
+{{- else }}
   name: {{ .Chart.Name }}-sa-cleanup
+{{- end }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete
@@ -11,7 +15,11 @@ metadata:
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-role-{{ .Values.env.multiInstallSuffix }}-cleanup
+{{- else }}
   name: {{ .Chart.Name }}-role-cleanup
+{{- end }}
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-2"
@@ -23,11 +31,18 @@ rules:
 - apiGroups: ["node.k8s.io"]
   resources: ["runtimeclasses"]
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-rb-{{ .Values.env.multiInstallSuffix }}-cleanup
+{{- else }}
   name: {{ .Chart.Name }}-rb-cleanup
+{{- end }}
   annotations:
     "helm.sh/hook": post-delete
     "helm.sh/hook-weight": "-1"
@@ -35,16 +50,28 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-role-{{ .Values.env.multiInstallSuffix }}-cleanup
+{{- else }}
   name: {{ .Chart.Name }}-role-cleanup
+{{- end }}
 subjects:
 - kind: ServiceAccount
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}-cleanup
+{{- else }}
   name: {{ .Chart.Name }}-sa-cleanup
+{{- end }}
   namespace: {{ .Release.Namespace }}
 ---
 apiVersion: batch/v1
 kind: Job
 metadata:
+{{- if .Values.env.multiInstallSuffix }}
+  name: {{ .Chart.Name }}-{{ .Values.env.multiInstallSuffix }}-cleanup
+{{- else }}
   name: {{ .Chart.Name }}-cleanup
+{{- end }}
   namespace: {{ .Release.Namespace }}
   annotations:
     "helm.sh/hook": post-delete
@@ -56,7 +83,11 @@ spec:
       labels:
         role: cleanup
     spec:
+{{- if .Values.env.multiInstallSuffix }}
+      serviceAccountName: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}-cleanup
+{{- else }}
       serviceAccountName: {{ .Chart.Name }}-sa-cleanup
+{{- end }}
       hostPID: true
       containers:
       - name: kube-kata-cleanup
@@ -92,6 +123,8 @@ spec:
           value: "true"
         - name: INSTALLATION_PREFIX
           value: {{ .Values.env.installationPrefix | quote }}
+        - name: MULTI_INSTALL_SUFFIX
+          value: {{ .Values.env.multiInstallSuffix | quote }}
 {{- with .Values.env.hostOS }}
         - name: HOST_OS
           value: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -18,3 +18,4 @@ env:
   pullTypeMapping: ""
   installationPrefix: ""
   hostOS: ""
+  multiInstallSuffix: ""

--- a/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/base/kata-deploy.yaml
@@ -52,6 +52,8 @@ spec:
               value: ""
             - name: INSTALLATION_PREFIX
               value: ""
+            - name: MULTI_INSTALL_SUFFIX
+              value: ""
           securityContext:
             privileged: true
           volumeMounts:

--- a/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/kata-rbac/base/kata-rbac.yaml
@@ -16,6 +16,9 @@ rules:
 - apiGroups: ["node.k8s.io"]
   resources: ["runtimeclasses"]
   verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+- apiGroups: ["apps"]
+  resources: ["daemonsets"]
+  verbs: ["list"]
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -291,6 +291,10 @@ function adjust_qemu_cmdline() {
 	# ${dest_dir}/opt/kata/share/kata-qemu/qemu
 	# ${dest_dir}/opt/kata/share/kata-qemu-snp-experimnental/qemu
 	[[ "${shim}" =~ ^(qemu-snp|qemu-nvidia-snp)$ ]] && qemu_share=${shim}-experimental
+
+	# Both qemu and qemu-coco-dev use exactly the same QEMU, so we can adjust
+	# the shim on the qemu-coco-dev case to qemu
+	[[ "${shim}" =~ ^(qemu|qemu-coco-dev)$ ]] && qemu_share="qemu"
 		
 	qemu_binary=$(tomlq '.hypervisor.qemu.path' ${config_path} | tr -d \")
 	qemu_binary_script="${qemu_binary}-installation-prefix"
@@ -391,7 +395,7 @@ function install_artifacts() {
 			sed -i -e "s|${default_dest_dir}|${dest_dir}|g" "${kata_config_file}"
 
 			# Let's only adjust qemu_cmdline for the QEMUs that we build and ship ourselves
-			[[ "${shim}" =~ ^(qemu|qemu-snp|qemu-nvidia-gpu|qemu-nvidia-gpu-snp|qemu-sev|qemu-se)$ ]] && \
+			[[ "${shim}" =~ ^(qemu|qemu-snp|qemu-nvidia-gpu|qemu-nvidia-gpu-snp|qemu-sev|qemu-se|qemu-coco-dev)$ ]] && \
 				adjust_qemu_cmdline "${shim}" "${kata_config_file}"
 		fi
 	done


### PR DESCRIPTION
kata-deploy: Add support to multi-installation

This is super useful for development / debugging scenarios, mainly when
dealing with limited hardware availability, as this change allows
multiple people to develop into one single machine, while still using
kata-deploy.

Fixes: #10546
