### PR TITLE
ci: cleanup: introduce SkipAutoDeleteTill tag

### DIFF
--- a/tests/cleanup_resources.py
+++ b/tests/cleanup_resources.py
@@ -68,16 +68,10 @@ for resource in resources:
                 print(f"{resource.name}: resource group {rg_name} has tag SkipAutoDeleteTill={skip_delete_till}, skipping deletion")
                 continue
 
-    # XXX DANGER ZONE: Delete the resource. If it's the only resource
-    # in its resource group, the entire resource group is deleted.
-
-    num_rg_resources = len(list(client.resources.list_by_resource_group(rg_name)))
-    if num_rg_resources == 1:
-        client.resource_groups.begin_delete(rg_name)
-        print(f"{resource.name}: deleted resource group")
-    else:
-        client.resources.begin_delete_by_id(resource.id)
-        print(f"{resource.name}: deleted resource")
+    # XXX DANGER ZONE: Delete the resource. We don't delete dangling
+    # resource groups since they may have metadata that we may want to
+    # preserve (e.g. role assignments).
+    client.resources.begin_delete_by_id(resource.id)
 
     num_deleted += 1
 


### PR DESCRIPTION
This introduces a new tag `SkipAutoDeleteTill`, that can be added to resource groups to prevent them from being deleted until the specified date. This is the protect long-lived resources, such as the Prow instance that the BU students are currently experimenting with.

TODO: Reenable the cleanup workflow after this is merged
https://github.com/kata-containers/kata-containers/actions/workflows/cleanup-resources.yaml