### PR TITLE
ci.gatekeeper: Update existing results

### DIFF
--- a/tools/testing/gatekeeper/jobs.py
+++ b/tools/testing/gatekeeper/jobs.py
@@ -80,9 +80,7 @@ class Checker:
             else:
                 # Not a required job
                 return
-        # TODO: Check if multiple re-runs use the same "run_id". If so use
-        #       job['run_attempt'] in case of matching "run_id".
-        elif job['run_id'] <= self.results[job_name]['run_id']:
+        elif job['run_id'] < self.results[job_name]['run_id']:
             # Newer results already stored
             print(f"older {job_name} - {job['status']} {job['conclusion']} "
                   f"{job['id']}", file=sys.stderr)

--- a/tools/testing/gatekeeper/jobs.py
+++ b/tools/testing/gatekeeper/jobs.py
@@ -83,7 +83,7 @@ class Checker:
         elif job['run_id'] < self.results[job_name]['run_id']:
             # Newer results already stored
             print(f"older {job_name} - {job['status']} {job['conclusion']} "
-                  f"{job['id']}", file=sys.stderr)
+                  f"{job['id']} (newer_id={self.results[job_name]['id']})", file=sys.stderr)
             return
         print(f"{job_name} - {job['status']} {job['conclusion']} {job['id']}",
               file=sys.stderr)

--- a/tools/testing/gatekeeper/jobs.py
+++ b/tools/testing/gatekeeper/jobs.py
@@ -178,7 +178,7 @@ class Checker:
         )
         response.raise_for_status()
         workflow_runs = response.json()["workflow_runs"]
-        for i, run in enumerate(workflow_runs):
+        for run in workflow_runs:
             jobs = self.get_jobs_for_workflow_run(run["id"])
             for job in jobs:
                 self.record(run["name"], job)


### PR DESCRIPTION
In https://github.com/kata-containers/kata-containers/pull/10447 we stumbled across the situation where previously recorded "running" job was never reported as "finished" because they had the same run_id (which makes sense). While on it also improve the message and remove unused variable.