### PR TITLE
kata-deploy: Support containerd configuration version 3

### DIFF
--- a/tools/packaging/kata-deploy/kata-deploy/overlays/k0s/mount_k0s_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-deploy/overlays/k0s/mount_k0s_conf.yaml
@@ -9,4 +9,4 @@ spec:
       volumes:
         - name: containerd-conf
           hostPath:
-            path: /etc/k0s/containerd.d/
+            path: /etc/k0s/

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -497,6 +497,10 @@ function configure_containerd_runtime() {
 		pluginid=\"io.containerd.grpc.v1.cri\"
 	fi
 
+	if grep -q "version = 3\>" $containerd_conf_file; then
+		pluginid=\"io.containerd.cri.v1.runtime\"
+	fi
+
 	local runtime_table=".plugins.${pluginid}.containerd.runtimes.\"${runtime}\""
 	local runtime_options_table="${runtime_table}.options"
 	local runtime_type=\"io.containerd."${runtime}".v2\"


### PR DESCRIPTION
As Ubuntu seems to already be shipping a containerd version that uses version 3 as its default version.