### PR TITLE
workflows: Remove rootfs binary artifacts

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -199,6 +199,21 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
+  # We don't need the binaries installed in the rootfs as part of the tarball, so can delete them now we've built the rootfs
+  remove-rootfs-binary-artifacts:
+    runs-on: ubuntu-22.04
+    needs: build-asset-rootfs
+    strategy:
+      matrix:
+        asset:
+          - agent
+          - coco-guest-components
+          - pause-image
+    steps:
+      - uses: geekyeggo/delete-artifact@v5
+        with:
+          name: kata-artifacts-amd64-${{ matrix.asset}}-*
+
   build-asset-shim-v2:
     runs-on: ubuntu-22.04
     needs: [build-asset, build-asset-rootfs]
@@ -258,7 +273,7 @@ jobs:
 
   create-kata-tarball:
     runs-on: ubuntu-22.04
-    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
+    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2, remove-rootfs-binary-artifacts]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -140,6 +140,19 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
+  # We don't need the binaries installed in the rootfs as part of the tarball, so can delete them now we've built the rootfs
+  remove-rootfs-binary-artifacts:
+    runs-on: ubuntu-22.04
+    needs: build-asset-rootfs
+    strategy:
+      matrix:
+        asset:
+          - agent
+    steps:
+      - uses: geekyeggo/delete-artifact@v5
+        with:
+          name: kata-artifacts-s390x-${{ matrix.asset}}-*
+
   build-asset-shim-v2:
     runs-on: arm64-builder
     needs: [build-asset, build-asset-rootfs]
@@ -197,7 +210,7 @@ jobs:
 
   create-kata-tarball:
     runs-on: arm64-builder
-    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
+    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2, remove-rootfs-binary-artifacts]
     steps:
       - name: Adjust a permission for repo
         run: |

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -148,6 +148,19 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # We don't need the binaries installed in the rootfs as part of the tarball, so can delete them now we've built the rootfs
+  remove-rootfs-binary-artifacts:
+    runs-on: ubuntu-22.04
+    needs: build-asset-rootfs
+    strategy:
+      matrix:
+        asset:
+          - agent
+    steps:
+      - uses: geekyeggo/delete-artifact@v5
+        with:
+          name: kata-artifacts-s390x-${{ matrix.asset}}-*
+
   build-asset-shim-v2:
     runs-on: ppc64le
     needs: [build-asset, build-asset-rootfs]
@@ -210,7 +223,7 @@ jobs:
 
   create-kata-tarball:
     runs-on: ppc64le
-    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
+    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2, remove-rootfs-binary-artifacts]
     steps:
       - name: Adjust a permission for repo
         run: |

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -216,6 +216,21 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  # We don't need the binaries installed in the rootfs as part of the tarball, so can delete them now we've built the rootfs
+  remove-rootfs-binary-artifacts:
+    runs-on: ubuntu-22.04
+    needs: build-asset-rootfs
+    strategy:
+      matrix:
+        asset:
+          - agent
+          - coco-guest-components
+          - pause-image
+    steps:
+      - uses: geekyeggo/delete-artifact@v5
+        with:
+          name: kata-artifacts-s390x-${{ matrix.asset}}-*
+
   build-asset-shim-v2:
     runs-on: s390x
     needs: [build-asset, build-asset-rootfs]
@@ -275,7 +290,12 @@ jobs:
 
   create-kata-tarball:
     runs-on: s390x
-    needs: [build-asset, build-asset-rootfs, build-asset-boot-image-se, build-asset-shim-v2]
+    needs:
+      - build-asset
+      - build-asset-rootfs
+      - build-asset-boot-image-se
+      - build-asset-shim-v2
+      - remove-rootfs-binary-artifacts
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
We need the publish certain artefacts for the rootfs, like the agent, guest-components, pause bundle etc as they are consumed in the `build-asset-rootfs` step. However after this point they aren't needed and probably shouldn't be included in the overall kata tarball, so delete them once they aren't needed any more to avoid them being included.

Fixes: #10575