### PR TITLE
policy: improve pod namespace validation

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -305,7 +305,6 @@
         "oci_version": "1.1.0"
     },
     "cluster_config": {
-        "default_namespace": "default",
         "pause_container_image": "mcr.microsoft.com/oss/kubernetes/pause:3.6"
     },
     "request_defaults": {

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -388,8 +388,6 @@ pub struct CommonData {
 /// Configuration from "kubectl config".
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ClusterConfig {
-    default_namespace: String,
-
     /// Pause container image reference.
     pub pause_container_image: String,
 }
@@ -532,15 +530,7 @@ impl AgentPolicy {
         let mut root = c_settings.Root.clone();
         root.Readonly = yaml_container.read_only_root_filesystem();
 
-        let namespace = match resource.get_namespace() {
-            Some(ns) if !ns.is_empty() => ns,
-            _ => self
-                .config
-                .settings
-                .cluster_config
-                .default_namespace
-                .clone(),
-        };
+        let namespace = resource.get_namespace().unwrap_or_default();
 
         let use_host_network = resource.use_host_network();
         let annotations = get_container_annotations(

--- a/tests/integration/kubernetes/k8s-limit-range.bats
+++ b/tests/integration/kubernetes/k8s-limit-range.bats
@@ -15,7 +15,6 @@ setup() {
 	pod_yaml="${pod_config_dir}/pod-cpu-defaults.yaml"
 
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
-	set_namespace_to_policy_settings "${policy_settings_dir}" "${namespace_name}"
 	auto_generate_policy "${policy_settings_dir}" "${pod_yaml}"
 }
 

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -155,9 +155,6 @@ create_common_genpolicy_settings() {
 
 	cp "${default_genpolicy_settings_dir}/genpolicy-settings.json" "${genpolicy_settings_dir}"
 	cp "${default_genpolicy_settings_dir}/rules.rego" "${genpolicy_settings_dir}"
-
-	# Set the default namespace of Kata CI tests in the genpolicy settings.
-	set_namespace_to_policy_settings "${genpolicy_settings_dir}" "${TEST_CLUSTER_NAMESPACE}"
 }
 
 # If auto-generated policy testing is enabled, make a copy of the common genpolicy settings
@@ -271,21 +268,6 @@ add_copy_from_guest_to_policy_settings() {
 
 	exec_command=(tar cf - "${copied_file}")
 	add_exec_to_policy_settings "${policy_settings_dir}" "${exec_command[@]}"
-}
-
-# Change genpolicy settings to use a pod namespace different than "default".
-set_namespace_to_policy_settings() {
-	local -r settings_dir="$1"
-	local -r namespace="$2"
-
-	auto_generate_policy_enabled || return 0
-
-	info "${settings_dir}/genpolicy-settings.json: namespace: ${namespace}"
-	jq --arg namespace "${namespace}" \
-		'.cluster_config.default_namespace |= $namespace' \
-		"${settings_dir}/genpolicy-settings.json" > \
-		"${settings_dir}/new-genpolicy-settings.json"
-	mv "${settings_dir}/new-genpolicy-settings.json" "${settings_dir}/genpolicy-settings.json"
 }
 
 hard_coded_policy_tests_enabled() {


### PR DESCRIPTION
- Remove the need for specifying `default_namespace` from settings
- Ensure container namespaces in a pod match each other in case no namespace is specified in the YAML