### PR TITLE
build: Allow dummy builds (for when adding a new target)

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -54,6 +54,11 @@ define BUILD
 	$(MK_DIR)/kata-deploy-binaries-in-docker.sh $(if $(V),,-s) --build=$1
 endef
 
+define DUMMY
+	$(call BUILD,"dummy")
+	mv $(MK_DIR)/build/kata-static-dummy.tar.xz $(MK_DIR)/build/kata-static-$(patsubst %-tarball,%,$1).tar.xz
+endef
+
 kata-tarball: | all-parallel merge-builds
 
 copy-scripts-for-the-agent-build:
@@ -94,7 +99,7 @@ cloud-hypervisor-glibc-tarball:
 	${MAKE} $@-build
 
 csi-kata-directvolume-tarball: copy-scripts-for-the-tools-build
-	exit 0
+	$(call DUMMY,$@)
 
 firecracker-tarball:
 	${MAKE} $@-build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -1191,6 +1191,10 @@ handle_build() {
 
 	virtiofsd) install_virtiofsd ;;
 
+	dummy)
+		tar cvfJ ${final_tarball_path} --files-from /dev/null
+	       	;;
+
 	*)
 		die "Invalid build target ${build_target}"
 		;;
@@ -1365,6 +1369,7 @@ main() {
 		shim-v2
 		trace-forwarder
 		virtiofsd
+		dummy
 	)
 	silent=false
 	while getopts "hs-:" opt; do


### PR DESCRIPTION
This will help us to simply allow a new dummy build whenever a new component is added.

As long as the format `$(call DUMMY,$@)` is followed, we should be good to go without taking the risk of breaking the CI.