### PR TITLE
genpolicy: align state path getter and setter

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -154,7 +154,8 @@ get_state() = state {
 }
 
 get_state_path(key) = path {
-    path := concat("/", ["", key]) # prepend "/" to key
+    # prepend "/pstate/" to key
+    path := concat("/", ["/pstate", key])
 }
 
 # Helper functions to conditionally concatenate if op is not null


### PR DESCRIPTION
Before this patch there was a mismatch between the JSON path under which the state of the rule evaluation is set in comparison to under which it is retrieved.

This resulted in the behavior that each time the policy was evaluated, it thought it was the _first_ time the policy was evaluated.
This also means that the consistency check for the `sandbox_name` was ineffective.

Also use `sprintf` instead of concat since it is more straightforward to understand.


Note (not included in commit message):
I found this when implementing https://github.com/kata-containers/kata-containers/issues/10529. This necessitates larger refactoring of rust code though. I hope I can a create a draft PR for those changes tomorrow, we can then discuss with concrete proposal in that PR.