### PR TITLE
policy: ignore optional metadata uid field

### DIFF
--- a/src/tools/genpolicy/src/obj_meta.rs
+++ b/src/tools/genpolicy/src/obj_meta.rs
@@ -26,6 +26,9 @@ pub struct ObjectMeta {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub namespace: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uid: Option<String>,
 }
 
 impl ObjectMeta {

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: policy-pod
+  uid: policy-pod-uid
 spec:
   terminationGracePeriodSeconds: 0
   runtimeClassName: kata


### PR DESCRIPTION
This prevents a deserialization error when uid is specified

More context on uid: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids