### PR TITLE
ci: Fix Docker publishing for CSI driver

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,13 @@ jobs:
       - name: Install tools
         run: bash tests/integration/kubernetes/gha-run.sh install-kata-tools kata-artifacts
 
+      - name: Link binary into Docker context
+        run: |
+          mkdir -p src/tools/csi-kata-directvolume/bin/
+          # Hard link (Docker doesn't follow symlinks) to the location
+          # where the Dockerfile expects to find the binary.
+          ln -f /opt/kata/bin/csi-kata-directvolume src/tools/csi-kata-directvolume/bin/directvolplugin
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -178,8 +185,6 @@ jobs:
           context: src/tools/csi-kata-directvolume/
           platforms: linux/amd64
           file: src/tools/csi-kata-directvolume/Dockerfile
-          build-args: |
-            binary=/opt/kata/bin/csi-kata-directvolume
 
   run-kata-monitor-tests:
     if: ${{ inputs.skip-test != 'yes' }}


### PR DESCRIPTION
The compilation succeeds, however Docker can't find the binary because we specify an absolute path. In Docker world, an absolute path is absolute to the Docker build context (here:
src/tools/csi-kata-directvolume).

To fix this, we link the binary into the build context, where the Dockerfile expects it.

Failure mode:
https://github.com/kata-containers/kata-containers/actions/runs/12068202642/job/33693101962?pr=10563#step:8:213

Note this does NOT affect any required jobs.

Part of: #10560