### PR TITLE
Install Nydus-snapshotter permanently on amd nodes

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -444,7 +444,7 @@ function cleanup() {
 }
 
 function deploy_snapshotter() {
-	if [[ "${KATA_HYPERVISOR}" == "qemu-tdx" ]]; then
+	if [[ "${KATA_HYPERVISOR}" == "qemu-tdx" ]] || [[ "${KATA_HYPERVISOR}" == "qemu-sev"]] || [[ "${KATA_HYPERVISOR}" == "qemu-snp"]]; then
 	       echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
 	       return
 	fi
@@ -458,7 +458,7 @@ function deploy_snapshotter() {
 }
 
 function cleanup_snapshotter() {
-	if [[ "${KATA_HYPERVISOR}" == "qemu-tdx" ]]; then
+	if [[ "${KATA_HYPERVISOR}" == "qemu-tdx" ]] || [[ "${KATA_HYPERVISOR}" == "qemu-sev"]] || [[ "${KATA_HYPERVISOR}" == "qemu-snp"]]; then
 	       echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
 	       return
 	fi


### PR DESCRIPTION
Making skips to the deploy and cleanup snapshotter functions to exclude the amd boxes from getting affected after installing nydus-snapshotter permanently on amd nodes.

