### PR TITLE
ci: Fix Docker publishing for CSI driver, 2nd try

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,7 +136,7 @@ jobs:
           file: tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
 
   publish-csi-driver-amd64:
-    needs: publish-kata-deploy-payload-amd64
+    needs: build-kata-static-tarball-amd64
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code
@@ -160,12 +160,11 @@ jobs:
       - name: Install tools
         run: bash tests/integration/kubernetes/gha-run.sh install-kata-tools kata-artifacts
 
-      - name: Link binary into Docker context
+      - name: Copy binary into Docker context
         run: |
+          # Copy to the location where the Dockerfile expects the binary.
           mkdir -p src/tools/csi-kata-directvolume/bin/
-          # Hard link (Docker doesn't follow symlinks) to the location
-          # where the Dockerfile expects to find the binary.
-          ln -f /opt/kata/bin/csi-kata-directvolume src/tools/csi-kata-directvolume/bin/directvolplugin
+          cp /opt/kata/bin/csi-kata-directvolume src/tools/csi-kata-directvolume/bin/directvolplugin
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
Follow-up to #10609 as it seems GHA doesn't allow hard links:

https://github.com/kata-containers/kata-containers/actions/runs/12144941404/job/33868901896?pr=10563#step:6:8

Note that I also updated the `needs` directive as we don't need the Kata payload container, just the tarball artifact.

Part of: #10560