### PR TITLE
genpolicy: set confidential_guest default to true

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -301,7 +301,7 @@
         ]
     },
     "kata_config": {
-        "confidential_guest": false,
+        "confidential_guest": true,
         "oci_version": "1.1.0"
     },
     "cluster_config": {

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -85,7 +85,7 @@ adapt_common_policy_settings_coco() {
 	local settings_dir=$1
 
 	info "Adapting common policy settings for TDX, SNP, or the non-TEE development environment"
-	jq '.common.cpath = "/run/kata-containers" | .volumes.configMap.mount_point = "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-"' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
+	jq '.common.cpath = "/run/kata-containers"' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
 }
 
 # adapt common policy settings for qemu-sev
@@ -93,7 +93,7 @@ adapt_common_policy_settings_for_sev() {
 	local settings_dir=$1
 
 	info "Adapting common policy settings for SEV"
-	jq '.kata_config.oci_version = "1.1.0-rc.1" | .common.cpath = "/run/kata-containers" | .volumes.configMap.mount_point = "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-"' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
+	jq '.kata_config.oci_version = "1.1.0-rc.1" | .common.cpath = "/run/kata-containers"' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
 }
 
 # adapt common policy settings for pod VMs using "shared_fs = virtio-fs" (https://github.com/kata-containers/kata-containers/issues/10189)


### PR DESCRIPTION
The default for confidential_guest was changed in https://github.com/kata-containers/kata-containers/commit/60ac3048e9d94fb86344e9f1ae9510dc92da669c to unblock the testing CI during that time. We should now have the knobs in the CI setup to specifically turn the setting off when needed. This way we should also avoid the config map mount patch fixes in the CI.