### PR TITLE
workflows: Remove potential timing issues with artifacts

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -217,7 +217,7 @@ jobs:
 
   build-asset-shim-v2:
     runs-on: ubuntu-22.04
-    needs: [build-asset, build-asset-rootfs]
+    needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -274,7 +274,7 @@ jobs:
 
   create-kata-tarball:
     runs-on: ubuntu-22.04
-    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2, remove-rootfs-binary-artifacts]
+    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -200,7 +200,7 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
-  # We don't need the binaries installed in the rootfs as part of the tarball, so can delete them now we've built the rootfs
+  # We don't need the binaries installed in the rootfs as part of the release tarball, so can delete them now we've built the rootfs
   remove-rootfs-binary-artifacts:
     runs-on: ubuntu-22.04
     needs: build-asset-rootfs
@@ -212,6 +212,7 @@ jobs:
           - pause-image
     steps:
       - uses: geekyeggo/delete-artifact@v5
+        if: ${{ inputs.stage == 'release' }}
         with:
           name: kata-artifacts-amd64-${{ matrix.asset}}${{ inputs.tarball-suffix }}
 

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -155,7 +155,7 @@ jobs:
 
   build-asset-shim-v2:
     runs-on: arm64-builder
-    needs: [build-asset, build-asset-rootfs]
+    needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -210,7 +210,7 @@ jobs:
 
   create-kata-tarball:
     runs-on: arm64-builder
-    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2, remove-rootfs-binary-artifacts]
+    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
     steps:
       - name: Adjust a permission for repo
         run: |

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -140,7 +140,7 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
-  # We don't need the binaries installed in the rootfs as part of the tarball, so can delete them now we've built the rootfs
+  # We don't need the binaries installed in the rootfs as part of the release tarball, so can delete them now we've built the rootfs
   remove-rootfs-binary-artifacts:
     runs-on: ubuntu-22.04
     needs: build-asset-rootfs
@@ -150,6 +150,7 @@ jobs:
           - agent
     steps:
       - uses: geekyeggo/delete-artifact@v5
+        if: ${{ inputs.stage == 'release' }}
         with:
           name: kata-artifacts-arm64-${{ matrix.asset}}${{ inputs.tarball-suffix }}
 

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -148,7 +148,7 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # We don't need the binaries installed in the rootfs as part of the tarball, so can delete them now we've built the rootfs
+  # We don't need the binaries installed in the rootfs as part of the release tarball, so can delete them now we've built the rootfs
   remove-rootfs-binary-artifacts:
     runs-on: ubuntu-22.04
     needs: build-asset-rootfs
@@ -158,6 +158,7 @@ jobs:
           - agent
     steps:
       - uses: geekyeggo/delete-artifact@v5
+        if: ${{ inputs.stage == 'release' }}
         with:
           name: kata-artifacts-ppc64le-${{ matrix.asset}}${{ inputs.tarball-suffix }}
 

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -163,7 +163,7 @@ jobs:
 
   build-asset-shim-v2:
     runs-on: ppc64le
-    needs: [build-asset, build-asset-rootfs]
+    needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     steps:
       - name: Prepare the self-hosted runner
         run: |
@@ -223,7 +223,7 @@ jobs:
 
   create-kata-tarball:
     runs-on: ppc64le
-    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2, remove-rootfs-binary-artifacts]
+    needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
     steps:
       - name: Adjust a permission for repo
         run: |

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -219,7 +219,7 @@ jobs:
   # We don't need the binaries installed in the rootfs as part of the tarball, so can delete them now we've built the rootfs
   remove-rootfs-binary-artifacts:
     runs-on: ubuntu-22.04
-    needs: build-asset-rootfs
+    needs: [build-asset-rootfs, build-asset-boot-image-se]
     strategy:
       matrix:
         asset:
@@ -233,7 +233,7 @@ jobs:
 
   build-asset-shim-v2:
     runs-on: s390x
-    needs: [build-asset, build-asset-rootfs]
+    needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -295,7 +295,6 @@ jobs:
       - build-asset-rootfs
       - build-asset-boot-image-se
       - build-asset-shim-v2
-      - remove-rootfs-binary-artifacts
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -216,7 +216,7 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
-  # We don't need the binaries installed in the rootfs as part of the tarball, so can delete them now we've built the rootfs
+  # We don't need the binaries installed in the rootfs as part of the release tarball, so can delete them now we've built the rootfs
   remove-rootfs-binary-artifacts:
     runs-on: ubuntu-22.04
     needs: [build-asset-rootfs, build-asset-boot-image-se]
@@ -228,6 +228,7 @@ jobs:
           - pause-image
     steps:
       - uses: geekyeggo/delete-artifact@v5
+        if: ${{ inputs.stage == 'release' }}
         with:
           name: kata-artifacts-s390x-${{ matrix.asset}}${{ inputs.tarball-suffix }}
 


### PR DESCRIPTION
With the code I originally did I think there is potentially a case where we can get a failure due to timing of steps. Before this change the `build-asset-shim-v2`
job could start the `get-artifacts` step and concurrently `remove-rootfs-binary-artifacts` could run and delete the artifact during the download and result in the error. In this commit, I try to resolve this by making sure that the shim build waits for the artifact deletes to complete before starting.