### PR TITLE
runtime-rs: Fix the issues with stderr fifo

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/process.rs
@@ -128,11 +128,13 @@ impl Process {
 
     pub fn pre_fifos_open(&mut self) -> Result<()> {
         if let Some(ref stdout) = self.stdout {
-            self.stdout_r = Some(open_fifo_read(stdout)?);
+            self.stdout_r = Some(open_fifo_read(stdout).context("open stdout")?);
         }
 
-        if let Some(ref stderr) = self.stderr {
-            self.stderr_r = Some(open_fifo_read(stderr)?);
+        if !self.terminal {
+            if let Some(ref stderr) = self.stderr {
+                self.stderr_r = Some(open_fifo_read(stderr).context("open stderr")?);
+            }
         }
 
         Ok(())


### PR DESCRIPTION
When tty is enabled, stderr fifo should never be opened.

Fixes: #10637