### PR TITLE
runtime-rs & agent: Fix the issues with bind volumes

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -233,7 +233,7 @@ pub fn init_rootfs(
         // bind may be only specified in the oci spec options -> flags update r#type
         let m = &{
             let mut mbind = m.clone();
-            if mbind.typ().is_none() && flags & MsFlags::MS_BIND == MsFlags::MS_BIND {
+            if is_none_mount_type(mbind.typ()) && flags & MsFlags::MS_BIND == MsFlags::MS_BIND {
                 mbind.set_typ(Some("bind".to_string()));
             }
             mbind
@@ -395,6 +395,13 @@ fn mount_cgroups_v2(cfd_log: RawFd, m: &Mount, rootfs: &str, flags: MsFlags) -> 
     }
 
     Ok(())
+}
+
+fn is_none_mount_type(typ: &Option<String>) -> bool {
+    match typ {
+        Some(t) => t == "none",
+        None => true,
+    }
 }
 
 fn mount_cgroups(

--- a/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/virtio_fs_share_mount.rs
@@ -120,7 +120,7 @@ impl ShareFsMount for VirtiofsShareMount {
                 guest_path,
                 storages,
             });
-        } else if get_mount_type(config.mount.typ()).as_str() == mount::KATA_EPHEMERAL_VOLUME_TYPE {
+        } else if get_mount_type(&config.mount).as_str() == mount::KATA_EPHEMERAL_VOLUME_TYPE {
             // refer to the golang `handleEphemeralStorage` code at
             // https://github.com/kata-containers/kata-containers/blob/9516286f6dd5cfd6b138810e5d7c9e01cf6fc043/src/runtime/virtcontainers/kata_agent.go#L1354
 

--- a/src/runtime-rs/crates/resource/src/volume/direct_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volume.rs
@@ -98,7 +98,7 @@ pub(crate) async fn handle_direct_volume(
 }
 
 pub(crate) fn is_direct_volume(m: &oci::Mount) -> Result<bool> {
-    let mnt_type = get_mount_type(m.typ());
+    let mnt_type = get_mount_type(m);
     let mount_type = mnt_type.as_str();
 
     // Filter the non-bind volume and non-direct-vol volume

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
@@ -125,7 +125,7 @@ impl SPDKVolume {
             .context("generate host-guest shared path failed")?;
         storage.mount_point = guest_path.clone();
 
-        if get_mount_type(m.typ()).as_str() != "bind" {
+        if get_mount_type(m).as_str() != "bind" {
             storage.fs_type = mount_info.fs_type.clone();
         } else {
             storage.fs_type = DEFAULT_VOLUME_FS_TYPE.to_string();

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/vfio_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/vfio_volume.rs
@@ -80,7 +80,7 @@ impl VfioVolume {
             .context("generate host-guest shared path failed")?;
         storage.mount_point = guest_path.clone();
 
-        if get_mount_type(m.typ()).as_str() != "bind" {
+        if get_mount_type(m).as_str() != "bind" {
             storage.fs_type = mount_info.fs_type.clone();
         } else {
             storage.fs_type = DEFAULT_VOLUME_FS_TYPE.to_string();

--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -308,8 +308,8 @@ impl Volume for ShareFsVolume {
 }
 
 pub(crate) fn is_share_fs_volume(m: &oci::Mount) -> bool {
-    (get_mount_type(m.typ()).as_str() == "bind"
-        || get_mount_type(m.typ()).as_str() == mount::KATA_EPHEMERAL_VOLUME_TYPE)
+    let mount_type = get_mount_type(m);
+    (mount_type == "bind" || mount_type == mount::KATA_EPHEMERAL_VOLUME_TYPE)
         && !is_host_device(&get_mount_path(&Some(m.destination().clone())))
         && !is_system_mount(&get_mount_path(m.source()))
 }

--- a/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
@@ -115,5 +115,5 @@ impl Volume for ShmVolume {
 
 pub(crate) fn is_shm_volume(m: &oci::Mount) -> bool {
     get_mount_path(&Some(m.destination().clone())).as_str() == "/dev/shm"
-        && get_mount_type(m.typ()).as_str() != KATA_EPHEMERAL_DEV_TYPE
+        && get_mount_type(m).as_str() != KATA_EPHEMERAL_DEV_TYPE
 }


### PR DESCRIPTION
This path fixes the logic of getting the type of volume: when the type of
OCI mount is `Some("none")` and the options have "bind" or "rbind", the
type will be considered as "bind".

Fixes: #10642