### PR TITLE
logging: genpolicy: do not log entire policy annotation in 'debug' mode

### DIFF
--- a/src/tools/genpolicy/src/obj_meta.rs
+++ b/src/tools/genpolicy/src/obj_meta.rs
@@ -8,9 +8,10 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
+use std::fmt;
 
 /// See ObjectMeta in the Kubernetes API reference.
-#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+#[derive(Clone, Default, Serialize, Deserialize)]
 pub struct ObjectMeta {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
@@ -44,5 +45,42 @@ impl ObjectMeta {
 
     pub fn get_namespace(&self) -> Option<String> {
         self.namespace.as_ref().cloned()
+    }
+}
+
+impl fmt::Debug for ObjectMeta {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug_struct = f.debug_struct("ObjectMeta");
+
+        if let Some(ref name) = self.name {
+            debug_struct.field("name", name);
+        }
+        if let Some(ref generate_name) = self.generateName {
+            debug_struct.field("generateName", generate_name);
+        }
+        if let Some(ref labels) = self.labels {
+            debug_struct.field("labels", labels);
+        }
+        if let Some(ref annotations) = self.annotations {
+            let truncated_annotations: BTreeMap<_, _> = annotations
+                .iter()
+                .map(|(key, value)| {
+                    if value.len() > 4096 {
+                        (
+                            key,
+                            format!("{}<... truncated ...>", &value[..4096].to_string()),
+                        )
+                    } else {
+                        (key, value.to_string())
+                    }
+                })
+                .collect();
+            debug_struct.field("annotations", &truncated_annotations);
+        }
+        if let Some(ref namespace) = self.namespace {
+            debug_struct.field("namespace", namespace);
+        }
+
+        debug_struct.finish()
     }
 }


### PR DESCRIPTION
When RUST_LOG=debug the genpolicy tool logs the entire deployment including existing policy annotations. However the size of the policy annotation especially introduces complications when embedding the genpolicy binary and parsing debug logs, because they may exceed limited buffer sizes. Further it worsens the reading-flow and interpretation of debug logs in general usage of genpolicy.
As the policy annotation is base64 encoded, logging them does not provide human-readable information. To still reference the existing annotation and thus allow checking the recreation of a fresh policy annotation, the debug logs of annotations are limited to 4096 characters, truncating the rest of the annotation.

No upstream issue, just suggesting.