### PR TITLE
genpolicy: support sysctls from PodSpec and environment defaults

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -39,6 +39,10 @@
             ]
         },
         "Linux": {
+            "Sysctl": {
+                "net.ipv4.ip_unprivileged_port_start": "0",
+                "net.ipv4.ping_group_range": "0 2147483647"
+            },
             "MaskedPaths": [
                 "/proc/acpi",
                 "/proc/asound",
@@ -132,6 +136,12 @@
             "io.kubernetes.cri.sandbox-id": "^[a-z0-9]{64}$",
             "io.katacontainers.pkg.oci.container_type": "pod_container",
             "io.kubernetes.cri.container-type": "container"
+        },
+        "Linux": {
+            "Sysctl": {
+                "net.ipv4.ip_unprivileged_port_start": "0",
+                "net.ipv4.ping_group_range": "0 2147483647"
+            }
         }
     },
     "volumes": {

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -132,7 +132,6 @@ allow_create_container_input {
     is_null(i_linux.Resources.Network)
     is_null(i_linux.Resources.Pids)
     is_null(i_linux.Seccomp)
-    i_linux.Sysctl == {}
 
     i_process := i_oci.Process
     count(i_process.SelinuxLabel) == 0
@@ -461,6 +460,7 @@ allow_linux(state_ops, p_oci, i_oci) := {"ops": ops, "allowed": true} {
     allow_masked_paths(p_oci, i_oci)
     allow_readonly_paths(p_oci, i_oci)
     allow_linux_devices(p_oci.Linux.Devices, i_oci.Linux.Devices)
+    allow_linux_sysctl(p_oci.Linux, i_oci.Linux)
     ret := allow_network_namespace_start(state_ops, p_oci, i_oci)
     ret.allowed
 
@@ -605,6 +605,23 @@ allow_linux_devices(p_devices, i_devices) {
         i_device.Path == p_device.Path
     }
     print("allow_linux_devices: true")
+}
+
+allow_linux_sysctl(p_linux, i_linux) {
+    print("allow_linux_sysctl 1: start")
+    not i_linux.Sysctl
+    print("allow_linux_sysctl 1: true")
+}
+
+allow_linux_sysctl(p_linux, i_linux) {
+    print("allow_linux_sysctl 2: start")
+    p_sysctl := p_linux.Sysctl
+    i_sysctl := i_linux.Sysctl
+    every i_name, i_val in i_sysctl {
+        print("allow_linux_sysctl 2: i_name =", i_name, "i_val =", i_val)
+        p_sysctl[i_name] == i_val
+    }
+    print("allow_linux_sysctl 2: true")
 }
 
 # Check the consistency of the input "io.katacontainers.pkg.oci.bundle_path"

--- a/src/tools/genpolicy/src/containerd.rs
+++ b/src/tools/genpolicy/src/containerd.rs
@@ -3,6 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::collections::BTreeMap;
+
 use crate::policy;
 
 // Default process field from containerd.
@@ -153,6 +155,7 @@ pub fn get_linux(privileged_container: bool) -> policy::KataLinux {
                 "/proc/sysrq-trigger".to_string(),
             ],
             Devices: vec![],
+            Sysctl: BTreeMap::new(),
         }
     } else {
         policy::KataLinux {
@@ -160,6 +163,7 @@ pub fn get_linux(privileged_container: bool) -> policy::KataLinux {
             MaskedPaths: vec![],
             ReadonlyPaths: vec![],
             Devices: vec![],
+            Sysctl: BTreeMap::new(),
         }
     }
 }

--- a/src/tools/genpolicy/src/cronjob.rs
+++ b/src/tools/genpolicy/src/cronjob.rs
@@ -154,4 +154,8 @@ impl yaml::K8sResource for CronJob {
             &self.spec.jobTemplate.spec.template.spec.securityContext,
         );
     }
+
+    fn get_sysctls(&self) -> Vec<pod::Sysctl> {
+        yaml::get_sysctls(&self.spec.jobTemplate.spec.template.spec.securityContext)
+    }
 }

--- a/src/tools/genpolicy/src/daemon_set.rs
+++ b/src/tools/genpolicy/src/daemon_set.rs
@@ -151,4 +151,8 @@ impl yaml::K8sResource for DaemonSet {
     fn get_process_fields(&self, process: &mut policy::KataProcess) {
         yaml::get_process_fields(process, &self.spec.template.spec.securityContext);
     }
+
+    fn get_sysctls(&self) -> Vec<pod::Sysctl> {
+        yaml::get_sysctls(&self.spec.template.spec.securityContext)
+    }
 }

--- a/src/tools/genpolicy/src/deployment.rs
+++ b/src/tools/genpolicy/src/deployment.rs
@@ -149,4 +149,8 @@ impl yaml::K8sResource for Deployment {
     fn get_process_fields(&self, process: &mut policy::KataProcess) {
         yaml::get_process_fields(process, &self.spec.template.spec.securityContext);
     }
+
+    fn get_sysctls(&self) -> Vec<pod::Sysctl> {
+        yaml::get_sysctls(&self.spec.template.spec.securityContext)
+    }
 }

--- a/src/tools/genpolicy/src/job.rs
+++ b/src/tools/genpolicy/src/job.rs
@@ -114,4 +114,8 @@ impl yaml::K8sResource for Job {
     fn get_process_fields(&self, process: &mut policy::KataProcess) {
         yaml::get_process_fields(process, &self.spec.template.spec.securityContext);
     }
+
+    fn get_sysctls(&self) -> Vec<pod::Sysctl> {
+        yaml::get_sysctls(&self.spec.template.spec.securityContext)
+    }
 }

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -315,7 +315,17 @@ struct SeccompProfile {
 pub struct PodSecurityContext {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runAsUser: Option<i64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sysctls: Option<Vec<Sysctl>>,
     // TODO: additional fields.
+}
+
+/// See Reference / Kubernetes API / Workload Resources / Pod.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Sysctl {
+    pub name: String,
+    pub value: String,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
@@ -894,6 +904,10 @@ impl yaml::K8sResource for Pod {
 
     fn get_process_fields(&self, process: &mut policy::KataProcess) {
         yaml::get_process_fields(process, &self.spec.securityContext);
+    }
+
+    fn get_sysctls(&self) -> Vec<Sysctl> {
+        yaml::get_sysctls(&self.spec.securityContext)
     }
 }
 

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -180,14 +180,20 @@ pub struct KataLinux {
     pub Namespaces: Vec<KataLinuxNamespace>,
 
     /// MaskedPaths masks over the provided paths inside the container.
+    #[serde(default)]
     pub MaskedPaths: Vec<String>,
 
     /// ReadonlyPaths sets the provided paths as RO inside the container.
+    #[serde(default)]
     pub ReadonlyPaths: Vec<String>,
 
     /// Devices contains devices to be created inside the container.
     #[serde(default)]
     pub Devices: Vec<KataLinuxDevice>,
+
+    /// Sysctls contains sysctls to be applied inside the container.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub Sysctl: BTreeMap<String, String>,
 }
 
 /// OCI container LinuxNamespace struct. This struct is similar to the LinuxNamespace
@@ -604,6 +610,11 @@ impl AgentPolicy {
         }
         for default_device in &c_settings.Linux.Devices {
             linux.Devices.push(default_device.clone())
+        }
+
+        linux.Sysctl.extend(c_settings.Linux.Sysctl.clone());
+        for sysctl in resource.get_sysctls() {
+            linux.Sysctl.insert(sysctl.name, sysctl.value);
         }
 
         ContainerPolicy {

--- a/src/tools/genpolicy/src/replica_set.rs
+++ b/src/tools/genpolicy/src/replica_set.rs
@@ -112,4 +112,8 @@ impl yaml::K8sResource for ReplicaSet {
     fn get_process_fields(&self, process: &mut policy::KataProcess) {
         yaml::get_process_fields(process, &self.spec.template.spec.securityContext);
     }
+
+    fn get_sysctls(&self) -> Vec<pod::Sysctl> {
+        yaml::get_sysctls(&self.spec.template.spec.securityContext)
+    }
 }

--- a/src/tools/genpolicy/src/replication_controller.rs
+++ b/src/tools/genpolicy/src/replication_controller.rs
@@ -114,4 +114,8 @@ impl yaml::K8sResource for ReplicationController {
     fn get_process_fields(&self, process: &mut policy::KataProcess) {
         yaml::get_process_fields(process, &self.spec.template.spec.securityContext);
     }
+
+    fn get_sysctls(&self) -> Vec<pod::Sysctl> {
+        yaml::get_sysctls(&self.spec.template.spec.securityContext)
+    }
 }

--- a/src/tools/genpolicy/src/stateful_set.rs
+++ b/src/tools/genpolicy/src/stateful_set.rs
@@ -196,6 +196,10 @@ impl yaml::K8sResource for StatefulSet {
     fn get_process_fields(&self, process: &mut policy::KataProcess) {
         yaml::get_process_fields(process, &self.spec.template.spec.securityContext);
     }
+
+    fn get_sysctls(&self) -> Vec<pod::Sysctl> {
+        yaml::get_sysctls(&self.spec.template.spec.securityContext)
+    }
 }
 
 impl StatefulSet {

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -100,6 +100,10 @@ pub trait K8sResource {
         // No need to implement support for securityContext or similar fields
         // for some of the K8s resource types.
     }
+
+    fn get_sysctls(&self) -> Vec<pod::Sysctl> {
+        vec![]
+    }
 }
 
 /// See Reference / Kubernetes API / Common Definitions / LabelSelector.
@@ -388,4 +392,13 @@ pub fn get_process_fields(
             process.User.UID = uid.try_into().unwrap();
         }
     }
+}
+
+pub fn get_sysctls(security_context: &Option<pod::PodSecurityContext>) -> Vec<pod::Sysctl> {
+    if let Some(context) = security_context {
+        if let Some(ref sysctls) = context.sysctls {
+            return sysctls.clone();
+        }
+    }
+    vec![]
 }

--- a/src/tools/genpolicy/tests/main.rs
+++ b/src/tools/genpolicy/tests/main.rs
@@ -139,4 +139,9 @@ mod tests {
     async fn test_create_container_network_namespace() {
         runtests::<CreateContainerRequest>("createcontainer/network_namespace").await;
     }
+
+    #[tokio::test]
+    async fn test_create_container_sysctls() {
+        runtests::<CreateContainerRequest>("createcontainer/sysctls").await;
+    }
 }

--- a/src/tools/genpolicy/tests/testdata/createcontainer/sysctls/pod.yaml
+++ b/src/tools/genpolicy/tests/testdata/createcontainer/sysctls/pod.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-redis-deployment-6674f9448-xjrzf
+spec:
+  runtimeClassName: kata-cc-isolation
+  securityContext:
+    sysctls:
+    - name: net.ipv4.ip_forward
+      value: 1
+  containers:
+  - name: redis
+    image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db

--- a/src/tools/genpolicy/tests/testdata/createcontainer/sysctls/testcases.json
+++ b/src/tools/genpolicy/tests/testdata/createcontainer/sysctls/testcases.json
@@ -1,0 +1,552 @@
+[
+  {
+    "description": "sysctls listed in yaml or settings",
+    "allowed": true,
+    "state": {"sandbox_name": "policy-redis-deployment-6674f9448-xjrzf"},
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.kubernetes.cri.podsandbox.image-name": "registry.k8s.io/pause:3.10",
+          "io.kubernetes.cri.sandbox-cpu-period": "100000",
+          "io.kubernetes.cri.sandbox-cpu-quota": "0",
+          "io.kubernetes.cri.sandbox-cpu-shares": "102",
+          "io.kubernetes.cri.sandbox-id": "4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_policy-redis-deployment-6674f9448-xjrzf_9c64c5bf-298f-46c4-ad63-e2270a2ff44c",
+          "io.kubernetes.cri.sandbox-memory": "0",
+          "io.kubernetes.cri.sandbox-name": "policy-redis-deployment-6674f9448-xjrzf",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "9c64c5bf-298f-46c4-ad63-e2270a2ff44c",
+          "nerdctl/network-namespace": "/var/run/netns/cni-22190131-6f68-2878-6d7b-418baf176cdf"
+        },
+        "Hooks": null,
+        "Hostname": "policy-redis-deployment-6674f9448-xjrzf",
+        "Linux": {
+          "CgroupsPath": "/kubepods/burstable/pod9c64c5bf-298f-46c4-ad63-e2270a2ff44c/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap",
+            "/proc/scsi"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {
+              "Cpus": "",
+              "Mems": "",
+              "Period": 0,
+              "Quota": 0,
+              "RealtimePeriod": 0,
+              "RealtimeRuntime": 0,
+              "Shares": 2
+            },
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": null,
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {
+            "net.ipv4.ip_unprivileged_port_start": "0",
+            "net.ipv4.ping_group_range": "0 2147483647",
+            "net.ipv4.ip_forward": "1"
+          },
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {
+            "destination": "/proc",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "proc",
+            "type_": "proc"
+          },
+          {
+            "destination": "/dev",
+            "options": [
+              "nosuid",
+              "strictatime",
+              "mode=755",
+              "size=65536k"
+            ],
+            "source": "tmpfs",
+            "type_": "tmpfs"
+          },
+          {
+            "destination": "/dev/pts",
+            "options": [
+              "nosuid",
+              "noexec",
+              "newinstance",
+              "ptmxmode=0666",
+              "mode=0620",
+              "gid=5"
+            ],
+            "source": "devpts",
+            "type_": "devpts"
+          },
+          {
+            "destination": "/dev/mqueue",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "mqueue",
+            "type_": "mqueue"
+          },
+          {
+            "destination": "/sys",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "ro"
+            ],
+            "source": "sysfs",
+            "type_": "sysfs"
+          },
+          {
+            "destination": "/dev/shm",
+            "options": [
+              "rbind"
+            ],
+            "source": "/run/kata-containers/sandbox/shm",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/resolv.conf",
+            "options": [
+              "rbind",
+              "ro",
+              "nosuid",
+              "nodev",
+              "noexec"
+            ],
+            "source": "/run/kata-containers/shared/containers/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12-b3930b9af7125931-resolv.conf",
+            "type_": "bind"
+          }
+        ],
+        "Process": {
+          "ApparmorProfile": "",
+          "Args": [
+            "/pause"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          ],
+          "NoNewPrivileges": true,
+          "OOMScoreAdj": -998,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              0
+            ],
+            "GID": 0,
+            "UID": 65535,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/shared/containers/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12/rootfs",
+          "Readonly": true
+        },
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+      "devices": [],
+      "exec_id": "4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.podsandbox.image-name\":\"registry.k8s.io/pause:3.10\",\"io.kubernetes.cri.sandbox-cpu-period\":\"100000\",\"io.kubernetes.cri.sandbox-cpu-quota\":\"0\",\"io.kubernetes.cri.sandbox-cpu-shares\":\"102\",\"io.kubernetes.cri.sandbox-id\":\"4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_policy-redis-deployment-6674f9448-xjrzf_9c64c5bf-298f-46c4-ad63-e2270a2ff44c\",\"io.kubernetes.cri.sandbox-memory\":\"0\",\"io.kubernetes.cri.sandbox-name\":\"policy-redis-deployment-6674f9448-xjrzf\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"9c64c5bf-298f-46c4-ad63-e2270a2ff44c\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-22190131-6f68-2878-6d7b-418baf176cdf\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/shared/containers/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ],
+      "string_user": null
+    }
+  },
+  {
+    "description": "sysctl not listed in yaml or settings",
+    "allowed": false,
+    "state": {"sandbox_name": "policy-redis-deployment-6674f9448-xjrzf"},
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.kubernetes.cri.podsandbox.image-name": "registry.k8s.io/pause:3.10",
+          "io.kubernetes.cri.sandbox-cpu-period": "100000",
+          "io.kubernetes.cri.sandbox-cpu-quota": "0",
+          "io.kubernetes.cri.sandbox-cpu-shares": "102",
+          "io.kubernetes.cri.sandbox-id": "4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_policy-redis-deployment-6674f9448-xjrzf_9c64c5bf-298f-46c4-ad63-e2270a2ff44c",
+          "io.kubernetes.cri.sandbox-memory": "0",
+          "io.kubernetes.cri.sandbox-name": "policy-redis-deployment-6674f9448-xjrzf",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "9c64c5bf-298f-46c4-ad63-e2270a2ff44c",
+          "nerdctl/network-namespace": "/var/run/netns/cni-22190131-6f68-2878-6d7b-418baf176cdf"
+        },
+        "Hooks": null,
+        "Hostname": "policy-redis-deployment-6674f9448-xjrzf",
+        "Linux": {
+          "CgroupsPath": "/kubepods/burstable/pod9c64c5bf-298f-46c4-ad63-e2270a2ff44c/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap",
+            "/proc/scsi"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {
+              "Cpus": "",
+              "Mems": "",
+              "Period": 0,
+              "Quota": 0,
+              "RealtimePeriod": 0,
+              "RealtimeRuntime": 0,
+              "Shares": 2
+            },
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": null,
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {
+            "net.ipv4.ip_unprivileged_port_start": "0",
+            "net.ipv4.ping_group_range": "0 2147483647",
+            "net.ipv4.conf.all.src_valid_mark": "1"
+          },
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {
+            "destination": "/proc",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "proc",
+            "type_": "proc"
+          },
+          {
+            "destination": "/dev",
+            "options": [
+              "nosuid",
+              "strictatime",
+              "mode=755",
+              "size=65536k"
+            ],
+            "source": "tmpfs",
+            "type_": "tmpfs"
+          },
+          {
+            "destination": "/dev/pts",
+            "options": [
+              "nosuid",
+              "noexec",
+              "newinstance",
+              "ptmxmode=0666",
+              "mode=0620",
+              "gid=5"
+            ],
+            "source": "devpts",
+            "type_": "devpts"
+          },
+          {
+            "destination": "/dev/mqueue",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "mqueue",
+            "type_": "mqueue"
+          },
+          {
+            "destination": "/sys",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "ro"
+            ],
+            "source": "sysfs",
+            "type_": "sysfs"
+          },
+          {
+            "destination": "/dev/shm",
+            "options": [
+              "rbind"
+            ],
+            "source": "/run/kata-containers/sandbox/shm",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/resolv.conf",
+            "options": [
+              "rbind",
+              "ro",
+              "nosuid",
+              "nodev",
+              "noexec"
+            ],
+            "source": "/run/kata-containers/shared/containers/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12-b3930b9af7125931-resolv.conf",
+            "type_": "bind"
+          }
+        ],
+        "Process": {
+          "ApparmorProfile": "",
+          "Args": [
+            "/pause"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          ],
+          "NoNewPrivileges": true,
+          "OOMScoreAdj": -998,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              0
+            ],
+            "GID": 0,
+            "UID": 65535,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/shared/containers/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12/rootfs",
+          "Readonly": true
+        },
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+      "devices": [],
+      "exec_id": "4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.podsandbox.image-name\":\"registry.k8s.io/pause:3.10\",\"io.kubernetes.cri.sandbox-cpu-period\":\"100000\",\"io.kubernetes.cri.sandbox-cpu-quota\":\"0\",\"io.kubernetes.cri.sandbox-cpu-shares\":\"102\",\"io.kubernetes.cri.sandbox-id\":\"4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_policy-redis-deployment-6674f9448-xjrzf_9c64c5bf-298f-46c4-ad63-e2270a2ff44c\",\"io.kubernetes.cri.sandbox-memory\":\"0\",\"io.kubernetes.cri.sandbox-name\":\"policy-redis-deployment-6674f9448-xjrzf\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"9c64c5bf-298f-46c4-ad63-e2270a2ff44c\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-22190131-6f68-2878-6d7b-418baf176cdf\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/shared/containers/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ],
+      "string_user": null
+    }
+  }
+]


### PR DESCRIPTION
Sysctls may be added to a container by the Kubernetes pod definition or by containerd configuration. The main commit adds support for the corresponding PodSecurityContext field and an option to specify environment-dependent sysctls in the settings file.

The sysctls requested in a `CreateContainerRequest` are checked against the sysctls in the pod definition, or if not defined there in the defaults in genpolicy-settings.json. There is no check for the presence of expected sysctls, though, because Kubernetes might legitimately omit unsafe syscalls itself and because default sysctls might not apply to all containers.

---

Notes to reviewers (@Redent0r, @danmihai1) : 

1. I'm leaving this as draft until #10613 is merged and I can test with that. Feel free to ignore the test cases for now.
2. We can debate whether sysctls should be exactly as specified. While I think that this may be too restrictive, I cannot possibly rule out that there is a combination of sysctls that is safe, but leaving one out leads to a vulnerability. If we want to go for an exact match, I'd propose two settings fields: `sysctls` and `optional_sysctls`.

---

@fidencio: while the test case is mostly faithful to your pod from #10648, I needed to make adjustments to make tests pass. #10632 (or something similar) is still needed to make the OCI version flexible enough, and the default cpath  [needs adjustment](https://github.com/kata-containers/kata-containers/blob/7b0c1d0a8c45ffdf09e0f93c5df7e194021406c9/tests/integration/kubernetes/tests_common.sh#L88).