### PR TITLE
genpolicy: add get_process_fields to CronJob

### DIFF
--- a/src/tools/genpolicy/src/cronjob.rs
+++ b/src/tools/genpolicy/src/cronjob.rs
@@ -147,4 +147,11 @@ impl yaml::K8sResource for CronJob {
         }
         false
     }
+
+    fn get_process_fields(&self, process: &mut policy::KataProcess) {
+        yaml::get_process_fields(
+            process,
+            &self.spec.jobTemplate.spec.template.spec.securityContext,
+        );
+    }
 }


### PR DESCRIPTION
This function was accidentally left unimplemented for `CronJob`, resulting in `runAsUser` not being supported there.

Fixes: #10653

---

cc @Redent0r 