### PR TITLE
kata-ctl: fix outdated comments

### DIFF
--- a/src/tools/kata-ctl/src/ops/exec_ops.rs
+++ b/src/tools/kata-ctl/src/ops/exec_ops.rs
@@ -358,7 +358,6 @@ fn get_server_socket(sandbox_id: &str) -> anyhow::Result<String> {
 }
 
 fn do_run_exec(sandbox_id: &str, dbg_console_vport: u32) -> anyhow::Result<()> {
-    // sandbox_id MUST be a long ID.
     let server_url = get_server_socket(sandbox_id).context("get debug console socket URL")?;
     if server_url.is_empty() {
         return Err(anyhow!("server url is empty."));


### PR DESCRIPTION
MgmnClient can also tolerate short sandbox id.

Signed-off-by: Liu Bo <liub.liubo@gmail.com>