### PR TITLE
vfio-ap: Assign default string "0" for empty APID and APQI

### DIFF
--- a/tests/functional/vfio-ap/run.sh
+++ b/tests/functional/vfio-ap/run.sh
@@ -156,7 +156,9 @@ create_mediated_device() {
     _APID=${APQN//.*}
     _APQI=${APQN#*.}
     APID=$(echo ${_APID} | sed 's/^0*//')
+    APID=${APID:-0}
     APQI=$(echo ${_APQI} | sed 's/^0*//')
+    APQI=${APQI:-0}
 
     # Release the device from the host
     pushd ${sys_bus_base}


### PR DESCRIPTION
The current script logic assigns an empty string to APID and APQI when APQN consists entirely of zeros (e.g., "00.0000"). However, this behavior is incorrect, as "00" and "0000" are valid values and should be represented as "0".
This PR ensures that the script assigns the default string “0” to APID and APQI if their computed values are empty.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>