### PR TITLE
misc: fix incorrect relative path in local-build makefile

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -194,7 +194,7 @@ virtiofsd-tarball:
 	${MAKE} $@-build
 
 merge-builds:
-	$(MK_DIR)/kata-deploy-merge-builds.sh build "$(MK_DIR)/../../../../versions.yaml"
+	$(MK_DIR)/kata-deploy-merge-builds.sh build "../../../../versions.yaml"
 
 install-tarball:
 	tar -xf ./kata-static.tar.xz -C /


### PR DESCRIPTION
When run make merge-builds, it's identified that the relative path `"$(MK_DIR)/../../../../versions.yaml"` is not correct, we should use `"../../../../versions.yaml"` instead.