### PR TITLE
tests: Fix qemu-coc-dev skip

### DIFF
--- a/tests/integration/kubernetes/k8s-job.bats
+++ b/tests/integration/kubernetes/k8s-job.bats
@@ -9,7 +9,9 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" = "qemu-coco-dev" ] || skip "Test not stable on qemu-coco-dev. See issue #10616"
+	if [ "${KATA_HYPERVISOR}" == "qemu-coco-dev" ]; then
+		skip "Test not stable on qemu-coco-dev. See issue #10616"
+	fi
 
 	get_pod_config_dir
 	job_name="job-pi-test"
@@ -40,7 +42,9 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" = "qemu-coco-dev" ] || skip "Test not ready yet for ${KATA_HYPERVISOR}"
+	if [ "${KATA_HYPERVISOR}" == "qemu-coco-dev" ]; then
+		skip "Test not stable on qemu-coco-dev. See issue #10616"
+	fi
 
 	# Debugging information
 	kubectl describe pod "$pod_name"


### PR DESCRIPTION
Fix the logic to make the test skipped on qemu-coco-dev, rather than the opposite and update the syntax to make it clearer as it incorrectly got written and reviewed by three different people in it's prior form.