### PR TITLE
ci: Update gatekeeper tests for md files

### DIFF
--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -18,10 +18,8 @@ paths:
   - "^\\.github/workflows/static-checks": ["static"]
   - "^\\.github/workflows/": []
   - "^tools/testing/gatekeeper/required-tests.yaml": []
+  - "\\.md$": ["static"]
   # TODO: Expand filters
-  # Documentation
-  #- "\\.rst$": ["build"]
-  #- "\\.md$": ["build"]
   # Sources
   #- "^src/": ["static", "build", "test"]
 


### PR DESCRIPTION
Update the required-tests.yaml so that .md files only trigger the static tests, not the build, or CI tests