### PR TITLE
runtime-rs: Remove unneeded `mut` from `new_hypervisor()`

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -46,7 +46,7 @@ impl CloudHypervisor {
         }
     }
 
-    pub async fn set_hypervisor_config(&mut self, config: HypervisorConfig) {
+    pub async fn set_hypervisor_config(&self, config: HypervisorConfig) {
         let mut inner = self.inner.write().await;
         inner.set_hypervisor_config(config)
     }

--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -629,7 +629,7 @@ mod tests {
             .get(hypervisor_name)
             .ok_or_else(|| anyhow!("failed to get hypervisor for {}", &hypervisor_name))?;
 
-        let mut hypervisor = Qemu::new();
+        let hypervisor = Qemu::new();
         hypervisor
             .set_hypervisor_config(hypervisor_config.clone())
             .await;

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -56,12 +56,12 @@ impl Dragonball {
         }
     }
 
-    pub async fn set_hypervisor_config(&mut self, config: HypervisorConfig) {
+    pub async fn set_hypervisor_config(&self, config: HypervisorConfig) {
         let mut inner = self.inner.write().await;
         inner.set_hypervisor_config(config)
     }
 
-    pub async fn set_passfd_listener_port(&mut self, port: u32) {
+    pub async fn set_passfd_listener_port(&self, port: u32) {
         let mut inner = self.inner.write().await;
         inner.set_passfd_listener_port(port)
     }

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
@@ -51,7 +51,7 @@ impl Firecracker {
         }
     }
 
-    pub async fn set_hypervisor_config(&mut self, config: HypervisorConfig) {
+    pub async fn set_hypervisor_config(&self, config: HypervisorConfig) {
         let mut inner = self.inner.write().await;
         inner.set_hypervisor_config(config)
     }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -45,7 +45,7 @@ impl Qemu {
         }
     }
 
-    pub async fn set_hypervisor_config(&mut self, config: HypervisorConfig) {
+    pub async fn set_hypervisor_config(&self, config: HypervisorConfig) {
         let mut inner = self.inner.write().await;
         inner.set_hypervisor_config(config)
     }

--- a/src/runtime-rs/crates/hypervisor/src/remote/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/mod.rs
@@ -35,7 +35,7 @@ impl Remote {
         }
     }
 
-    pub async fn set_hypervisor_config(&mut self, config: HypervisorConfig) {
+    pub async fn set_hypervisor_config(&self, config: HypervisorConfig) {
         let mut inner = self.inner.write().await;
         inner.set_hypervisor_config(config)
     }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/endpoints_test.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/endpoints_test.rs
@@ -36,7 +36,7 @@ mod tests {
             .get(hypervisor_name)
             .ok_or_else(|| anyhow!("failed to get hypervisor for {}", &hypervisor_name))?;
 
-        let mut hypervisor = Qemu::new();
+        let hypervisor = Qemu::new();
         hypervisor
             .set_hypervisor_config(hypervisor_config.clone())
             .await;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -158,7 +158,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
     match hypervisor_name.as_str() {
         #[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
         HYPERVISOR_DRAGONBALL => {
-            let mut hypervisor = Dragonball::new();
+            let hypervisor = Dragonball::new();
             hypervisor
                 .set_hypervisor_config(hypervisor_config.clone())
                 .await;
@@ -170,7 +170,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
             Ok(Arc::new(hypervisor))
         }
         HYPERVISOR_QEMU => {
-            let mut hypervisor = Qemu::new();
+            let hypervisor = Qemu::new();
             hypervisor
                 .set_hypervisor_config(hypervisor_config.clone())
                 .await;
@@ -178,7 +178,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
         }
         #[cfg(not(target_arch = "s390x"))]
         HYPERVISOR_FIRECRACKER => {
-            let mut hypervisor = Firecracker::new();
+            let hypervisor = Firecracker::new();
             hypervisor
                 .set_hypervisor_config(hypervisor_config.clone())
                 .await;
@@ -186,16 +186,14 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
         }
         #[cfg(all(feature = "cloud-hypervisor", not(target_arch = "s390x")))]
         HYPERVISOR_NAME_CH => {
-            let mut hypervisor = CloudHypervisor::new();
-
+            let hypervisor = CloudHypervisor::new();
             hypervisor
                 .set_hypervisor_config(hypervisor_config.clone())
                 .await;
-
             Ok(Arc::new(hypervisor))
         }
         HYPERVISOR_REMOTE => {
-            let mut hypervisor = Remote::new();
+            let hypervisor = Remote::new();
             hypervisor
                 .set_hypervisor_config(hypervisor_config.clone())
                 .await;


### PR DESCRIPTION
`set_hypervisor_config()` and `set_passfd_listener_port()` acquire inner
lock, so that `mut` for `hypervisor` is unneeded.

Fixes: #10682