### PR TITLE
workflows: Add timeout to some ppc64le steps

### DIFF
--- a/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
+++ b/.github/workflows/run-cri-containerd-tests-ppc64le.yaml
@@ -33,6 +33,7 @@ jobs:
         run: sudo chown -R "$USER":"$USER" "$GITHUB_WORKSPACE"
 
       - name: Prepare the self-hosted runner
+        timeout-minutes: 15
         run: |
           bash "${HOME}/scripts/prepare_runner.sh" cri-containerd
           sudo rm -rf "$GITHUB_WORKSPACE"/*
@@ -49,6 +50,7 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
+        timeout-minutes: 15
         run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
 
       - name: get-kata-tarball


### PR DESCRIPTION
In some runs e.g. https://github.com/kata-containers/kata-containers/actions/runs/12426384186/job/34697095588 and https://github.com/kata-containers/kata-containers/actions/runs/12422958889/job/34697016842 we've seen the Prepare the self-hosted runner
and Install dependencies steps get stuck for 5hours+. If they are working then it should take a few minutes, so let's add timeouts and not hold up whole the CI if they are stuck