### PR TITLE
workflows: Add more ppc64le timeouts

### DIFF
--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -35,6 +35,7 @@ jobs:
           - ${{ inputs.stage }}
     steps:
       - name: Prepare the self-hosted runner
+        timeout-minutes: 15
         run: |
             "${HOME}/scripts/prepare_runner.sh"
             sudo rm -rf "$GITHUB_WORKSPACE"/*
@@ -93,6 +94,7 @@ jobs:
           - ${{ inputs.stage }}
     steps:
       - name: Prepare the self-hosted runner
+        timeout-minutes: 15
         run: |
             "${HOME}/scripts/prepare_runner.sh"
             sudo rm -rf "$GITHUB_WORKSPACE"/*
@@ -167,6 +169,7 @@ jobs:
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     steps:
       - name: Prepare the self-hosted runner
+        timeout-minutes: 15
         run: |
             "${HOME}/scripts/prepare_runner.sh"
             sudo rm -rf "$GITHUB_WORKSPACE"/*

--- a/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-ppc64le.yaml
@@ -27,6 +27,7 @@ jobs:
     runs-on: ppc64le
     steps:
       - name: Prepare the self-hosted runner
+        timeout-minutes: 15
         run: |
           "${HOME}/scripts/prepare_runner.sh"
           sudo rm -rf "$GITHUB_WORKSPACE"/*

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ppc64le
     steps:
       - name: Prepare the self-hosted runner
+        timeout-minutes: 15
         run: |
           bash "${HOME}/scripts/prepare_runner.sh"
           sudo rm -rf "$GITHUB_WORKSPACE"/*

--- a/.github/workflows/run-k8s-tests-on-ppc64le.yaml
+++ b/.github/workflows/run-k8s-tests-on-ppc64le.yaml
@@ -44,6 +44,7 @@ jobs:
       TARGET_ARCH: "ppc64le"
     steps:
       - name: Prepare the self-hosted runner
+        timeout-minutes: 15
         run: |
           bash "${HOME}/scripts/prepare_runner.sh" kubernetes
           sudo rm -rf "$GITHUB_WORKSPACE"/*


### PR DESCRIPTION
Unsurprisingly now we've got passed the containerd test hangs on the ppc64le, we are hitting others  in the "Prepare the self-hosted runner" stage, so add timeouts to all of them to avoid CI blockages.