### PR TITLE
kata-ctl: direct-volume: Auto create KATA_DIRECT_VOLUME_ROOT_PATH

### DIFF
--- a/src/tools/kata-ctl/src/ops/volume_ops.rs
+++ b/src/tools/kata-ctl/src/ops/volume_ops.rs
@@ -100,6 +100,7 @@ async fn stats(volume_path: &str) -> Result<Option<String>> {
 
 // add writes the mount info (json string) of a direct volume into a filesystem path known to Kata Containers.
 pub fn add(volume_path: &str, mount_info: &str) -> Result<Option<String>> {
+    fs::create_dir_all(KATA_DIRECT_VOLUME_ROOT_PATH)?;
     let mount_info_dir_path = join_path(KATA_DIRECT_VOLUME_ROOT_PATH, volume_path)?;
 
     // create directory if missing


### PR DESCRIPTION
Got following issue:
kata-ctl direct-volume add /kubelet/kata-direct-vol-002/directvol002 "{\"device\": \"/home/t4/teawater/coco/t.img\", \"volume-type\": \"directvol\", \"fstype\": \"\", \"metadata\":"{}", \"options\": []}" subsystem: kata-ctl_main
 Dec 30 09:43:41.150 ERRO Os {
    code: 2,
    kind: NotFound,
    message: "No such file or directory",
}
The reason is KATA_DIRECT_VOLUME_ROOT_PATH is not exist.

This commit create_dir_all KATA_DIRECT_VOLUME_ROOT_PATH before join_path to handle this issue.

Fixes: #10695