### PR TITLE
CI: change the containerd tarball name from cri-containerd-cni to containerd

### DIFF
--- a/tests/functional/kata-monitor/gha-run.sh
+++ b/tests/functional/kata-monitor/gha-run.sh
@@ -42,6 +42,8 @@ function install_dependencies() {
 	case "${CONTAINER_ENGINE}" in
 		containerd)
 			github_deps[1]="cri_containerd:$(get_from_kata_deps ".externals.containerd.${CONTAINERD_VERSION}")"
+			github_deps[2]="runc:$(get_from_kata_deps ".externals.runc.latest")"
+			github_deps[3]="cni_plugins:$(get_from_kata_deps ".externals.cni-plugins.version")"
 			;;
 		crio)
 			github_deps[1]="cni_plugins:$(get_from_kata_deps ".externals.cni-plugins.version")"

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -48,6 +48,8 @@ function install_dependencies() {
 	declare -a github_deps
 	github_deps[0]="cri_containerd:$(get_from_kata_deps ".externals.containerd.${CONTAINERD_VERSION}")"
 	github_deps[1]="cri_tools:$(get_from_kata_deps ".externals.critools.latest")"
+	github_deps[2]="runc:$(get_from_kata_deps ".externals.runc.latest")"
+	github_deps[3]="cni_plugins:$(get_from_kata_deps ".externals.cni-plugins.version")"
 
 	for github_dep in "${github_deps[@]}"; do
 		IFS=":" read -r -a dep <<< "${github_dep}"

--- a/tests/integration/nydus/gha-run.sh
+++ b/tests/integration/nydus/gha-run.sh
@@ -39,6 +39,8 @@ function install_dependencies() {
 	github_deps[1]="cri_tools:$(get_from_kata_deps ".externals.critools.latest")"
 	github_deps[2]="nydus:$(get_from_kata_deps ".externals.nydus.version")"
 	github_deps[3]="nydus_snapshotter:$(get_from_kata_deps ".externals.nydus-snapshotter.version")"
+	github_deps[4]="runc:$(get_from_kata_deps ".externals.runc.latest")"
+	github_deps[5]="cni_plugins:$(get_from_kata_deps ".externals.cni-plugins.version")"
 
 	for github_dep in "${github_deps[@]}"; do
 		IFS=":" read -r -a dep <<< "${github_dep}"

--- a/tests/integration/runk/gha-run.sh
+++ b/tests/integration/runk/gha-run.sh
@@ -34,6 +34,8 @@ function install_dependencies() {
 	#   - cri-container-cni release tarball already includes CNI plugins
 	declare -a github_deps
 	github_deps[0]="cri_containerd:$(get_from_kata_deps ".externals.containerd.${CONTAINERD_VERSION}")"
+	github_deps[1]="runc:$(get_from_kata_deps ".externals.runc.latest")"
+	github_deps[2]="cni_plugins:$(get_from_kata_deps ".externals.cni-plugins.version")"
 
 	for github_dep in "${github_deps[@]}"; do
 		IFS=":" read -r -a dep <<< "${github_dep}"

--- a/tests/integration/stdio/gha-run.sh
+++ b/tests/integration/stdio/gha-run.sh
@@ -34,6 +34,8 @@ function install_dependencies() {
 	#   - cri-container-cni release tarball already includes CNI plugins
 	declare -a github_deps
 	github_deps[0]="cri_containerd:$(get_from_kata_deps ".externals.containerd.${CONTAINERD_VERSION}")"
+	github_deps[1]="runc:$(get_from_kata_deps ".externals.runc.latest")"
+	github_deps[2]="cni_plugins:$(get_from_kata_deps ".externals.cni-plugins.version")"
 
 	for github_dep in "${github_deps[@]}"; do
 		IFS=":" read -r -a dep <<< "${github_dep}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -271,6 +271,11 @@ externals:
     # create a "latest" entry and use that for the GitHub actions tests.
     latest: "v1.29"
 
+  runc:
+    description: "CLI tool for spawning and running containers"
+    url: "https://github.com/opencontainers/runc"
+    latest: "v1.2"
+
   cryptsetup:
     description: "A utility used to setup disk encryption, integrity protection"
     url: "https://gitlab.com/cryptsetup/cryptsetup"


### PR DESCRIPTION
Since from https://github.com/containerd/containerd/pull/9096 containerd removed cri-containerd-*.tar.gz release bundles, thus we'd better change the tarball name to "containerd".

BTW, the containerd tarball containerd the follow files:

bin/
bin/containerd-shim
bin/ctr
bin/containerd-shim-runc-v1
bin/containerd-stress
bin/containerd
bin/containerd-shim-runc-v2

thus we should untar containerd into /usr/local directory instead of "/" to keep align with the cri-containerd.

In addition, there's no containerd.service file,runc binary and cni-plugin included, thus we should add a specific containerd.service file and install the runc binary and cni-plugin specifically.