### PR TITLE
tests: Reduce AKS cluster length

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -35,7 +35,7 @@ function _print_cluster_name() {
 	if [ -n "${AKS_NAME:-}" ]; then
 		echo "$AKS_NAME"
 	else
-		short_sha="$(git rev-parse --short=12 HEAD)"
+		short_sha="$(git rev-parse --short=8 HEAD)"
 		echo "${test_type}-${GH_PR_NUMBER}-${short_sha}-${KATA_HYPERVISOR}-${KATA_HOST_OS}-amd64-${K8S_TEST_HOST_TYPE:0:1}-${GENPOLICY_PULL_METHOD:0:1}"
 	fi
 }


### PR DESCRIPTION
For the last 30+ days the cloud-hypervisor and
qemu-runtime-rs hypervisor AKS tests have failed with:
```
Error: The action 'Create AKS cluster' has timed out after 10 minutes.
```
e.g. https://github.com/kata-containers/kata-containers/actions/runs/12624156638/job/35174371454 
Although the error is not at all helpful I spotted that the cluster names `kataCI-k8s-nightly-<12 char sha>-qemu-runtime-rs-ubuntu-amd64-s-o` and `kataCI-k8s-nightly-<12 char sha>-cloud-hypervisor-ubuntu-amd64-s-o` are 64 and 65 characters and the limit is 63 chars, so only take the first 8 chars of the sha, not the first 12. This is somewhat temporary, so it would still be good to understand if we can get a proper output from the `az` cli.