### PR TITLE
qemu: Disable features/devices per default

### DIFF
--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -377,9 +377,6 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-pixman)
 	qemu_options+=(size:--disable-relocatable)
 	qemu_options+=(size:--disable-rutabaga-gfx)
-	if ! gt_eq "${qemu_version}" "10.1.0" ; then
-		qemu_options+=(size:--disable-avx512bw)
-	fi
 	qemu_options+=(size:--disable-vpc)
 	qemu_options+=(size:--disable-vhdx)
 	qemu_options+=(size:--disable-hv-balloon)

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -268,6 +268,11 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-usb-redir)
 
 	# Disable TCG support
+	#
+	# aarch64 is deliberately left out: Kata only runs it with KVM, so TCG
+	# should be removable there as well, but neither the build nor the
+	# TCG-dependent QEMU paths have been audited on aarch64 yet.
+	# TODO: check with the aarch64 maintainers, then disable it here too.
 	case "${arch}" in
 	aarch64) ;;
 	x86_64) qemu_options+=(size:--disable-tcg) ;;
@@ -413,6 +418,19 @@ generate_qemu_options() {
 
 	#---------------------------------------------------------------------
 	# Enabled options
+
+	# Strip debug symbols from the installed binaries
+	qemu_options+=(size:--enable-strip)
+
+	# Link-Time Optimization drops the code that only becomes unreachable
+	# once everything is linked together, which is a lot with a device set
+	# this small: expect 15-25% off the binary, at 2-3x the build time.
+	#
+	# ppc64le is excluded: LTO turns a __builtin_memcpy bound check in
+	# qemu-system-ppc64 into a -Werror=stringop-overflow build failure.
+	if [[ "${arch}" != "ppc64le" ]]; then
+		qemu_options+=(size:--enable-lto)
+	fi
 
 	# Enable kernel Virtual Machine support.
 	# This is the default, but be explicit to avoid any future surprises

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -188,11 +188,10 @@ show_array() {
 		if [[ "${action}" = "dump" ]]; then
 			printf "%s\t\t%s\n" "${tags}" "${elem}"
 		elif [[ "${action}" = "multi" ]]; then
-			if [[ ${i} -eq ${size} ]]; then
+			if [[ "${i}" -eq "${size}" ]]; then
 				suffix=""
 			else
-				# shellcheck disable=SC1003
-				suffix=' \'
+				suffix=" \\"
 			fi
 
 			printf '%s%s\n' "${elem}" "${suffix}"
@@ -228,7 +227,7 @@ generate_qemu_options() {
 	# Disable graphical network access
 	qemu_options+=(size:--disable-vnc)
 	qemu_options+=(size:--disable-vnc-jpeg)
-	if ! gt_eq "${qemu_version}" "7.0.50" ; then
+	if ! gt_eq "${qemu_version}" "7.0.50"; then
 		qemu_options+=(size:--disable-vnc-png)
 	else
 		qemu_options+=(size:--disable-png)
@@ -274,8 +273,7 @@ generate_qemu_options() {
 
 	# Disable debug is always passed to the qemu binary so not required.
 	case "${arch}" in
-	aarch64)
-		;;
+	aarch64) ;;
 	x86_64)
 		qemu_options+=(size:--disable-debug-tcg)
 		qemu_options+=(size:--disable-tcg-interpreter)
@@ -316,9 +314,9 @@ generate_qemu_options() {
 	# of QEMU.
 	#
 	# qemu configure does not support virtiofsd if qemu version >= 8.0.0.
-        if ! gt_eq "${qemu_version}" "8.0.0" ; then
+	if ! gt_eq "${qemu_version}" "8.0.0"; then
 		qemu_options+=(functionality:--disable-virtiofsd)
-        fi
+	fi
 
 	qemu_options+=(functionality:--enable-virtfs)
 
@@ -333,7 +331,7 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-vde)
 
 	# Don't build other options which can't be depent on build server.
-	if ! gt_eq "${qemu_version}" "7.0.50" ; then
+	if ! gt_eq "${qemu_version}" "7.0.50"; then
 		qemu_options+=(size:--disable-xfsctl)
 		qemu_options+=(size:--disable-libxml2)
 	fi
@@ -382,7 +380,7 @@ generate_qemu_options() {
 	qemu_options+=(size:--disable-hv-balloon)
 
 	# Disable various features based on the qemu_version
-	if gt_eq "${qemu_version}" "9.1.0" ; then
+	if gt_eq "${qemu_version}" "9.1.0"; then
 		# Disable Query Processing Library support
 		qemu_options+=(size:--disable-qpl)
 		# Disable UADK Library support
@@ -437,7 +435,7 @@ generate_qemu_options() {
 
 	# AVX2 is enabled by default by x86_64, make sure it's enabled only
 	# for that architecture
-	if ! gt_eq "${qemu_version}" "10.1.0" ; then
+	if ! gt_eq "${qemu_version}" "10.1.0"; then
 		if [[ "${arch}" == x86_64 ]]; then
 			qemu_options+=(speed:--enable-avx2)
 			qemu_options+=(speed:--enable-avx512bw)
@@ -448,7 +446,7 @@ generate_qemu_options() {
 
 	# Disable passt support, as it'd bring glibc 2.40.x dependency,
 	# and it is only available on Ubuntu 25.04 or newer.
-	if gt_eq "${qemu_version}" "10.1.0" ; then
+	if gt_eq "${qemu_version}" "10.1.0"; then
 		qemu_options+=(functionality:--disable-passt)
 	fi
 
@@ -486,7 +484,7 @@ generate_qemu_options() {
 	# Improve code quality by assuming identical semantics for interposed
 	# synmbols.
 	# Only enable if gcc is 5.3 or newer
-	if gt_eq "${gcc_version}" "5.3.0" ; then
+	if gt_eq "${gcc_version}" "5.3.0"; then
 		_qemu_cflags+=" -fno-semantic-interposition"
 	fi
 
@@ -498,8 +496,7 @@ generate_qemu_options() {
 	_qemu_cflags+=" -D_FORTIFY_SOURCE=2"
 
 	# Set compile options
-	# shellcheck disable=SC2054
-	qemu_options+=(functionality,security,speed,size:"--extra-cflags=\"${_qemu_cflags}\"")
+	qemu_options+=("functionality,security,speed,size:--extra-cflags=\"${_qemu_cflags}\"")
 
 	unset _qemu_cflags
 
@@ -521,16 +518,16 @@ generate_qemu_options() {
 	unset _qemu_ldflags
 
 	# Where to install qemu helper binaries
-	qemu_options+=("misc:--prefix=${prefix}")
+	qemu_options+=(misc:--prefix="${prefix}")
 
 	# Where to install qemu libraries
-	qemu_options+=("arch:--libdir=${prefix}/lib/${hypervisor}")
+	qemu_options+=(arch:--libdir="${prefix}"/lib/"${hypervisor}")
 
 	# Where to install qemu helper binaries
-	qemu_options+=("misc:--libexecdir=${prefix}/libexec/${hypervisor}")
+	qemu_options+=(misc:--libexecdir="${prefix}"/libexec/"${hypervisor}")
 
 	# Where to install data files
-	qemu_options+=("misc:--datadir=${prefix}/share/${hypervisor}")
+	qemu_options+=(misc:--datadir="${prefix}"/share/"${hypervisor}")
 
 }
 
@@ -567,7 +564,7 @@ main() {
 	hypervisor="$1"
 
 	local qemu_version_file="VERSION"
-	[[ -f ${qemu_version_file} ]] || die "QEMU version file '${qemu_version_file}' not found"
+	[[ -f "${qemu_version_file}" ]] || die "QEMU version file '${qemu_version_file}' not found"
 
 	# Remove any pre-release identifier so that it returns the version on
 	# major.minor.patch format (e.g 5.2.0-rc4 becomes 5.2.0)
@@ -576,7 +573,7 @@ main() {
 	[[ -n "${qemu_version}" ]] ||
 		die "cannot determine qemu version from file ${qemu_version_file}"
 
-	if ! gt_eq "${qemu_version}" "6.1.0" ; then
+	if ! gt_eq "${qemu_version}" "6.1.0"; then
 		die "Kata requires QEMU >= 6.1.0"
 	fi
 
@@ -586,7 +583,7 @@ main() {
 		die "cannot determine gcc major version, please ensure it is installed"
 	# -dumpversion only returns the major version since GCC 7.0
 	local gcc_version_minor
-	if gt_eq "${gcc_version_major}" "7.0.0" ; then
+	if gt_eq "${gcc_version_major}" "7.0.0"; then
 		gcc_version_minor=$(gcc -dumpfullversion | cut -f2 -d.)
 	else
 		gcc_version_minor=$(gcc -dumpversion | cut -f2 -d.)

--- a/tools/packaging/scripts/configure-hypervisor.sh
+++ b/tools/packaging/scripts/configure-hypervisor.sh
@@ -208,6 +208,14 @@ show_array() {
 
 generate_qemu_options() {
 	#---------------------------------------------------------------------
+	# Start from nothing: allnoconfig semantics for both features and
+	# devices.  Every device Kata needs is allowlisted per architecture in
+	# static-build/qemu/build-qemu.sh (CONFIG_* entries in default.mak) and
+	# verified against the built binary before it is packaged.
+	qemu_options+=(minimal:--without-default-features)
+	qemu_options+=(minimal:--without-default-devices)
+
+	#---------------------------------------------------------------------
 	# Disabled options
 
 	# braille support not required
@@ -412,6 +420,13 @@ generate_qemu_options() {
 
 	# Required for fast network access
 	qemu_options+=(speed:--enable-vhost-net)
+
+	# vhost-kernel and vhost-user are "auto" features in meson, so
+	# --without-default-features turns them off.  Ask for them back
+	# explicitly: vhost-net needs the kernel backend, and virtiofsd and
+	# vhost-user-vsock need the vhost-user protocol.
+	qemu_options+=(speed:--enable-vhost-kernel)
+	qemu_options+=(functionality:--enable-vhost-user)
 
 	# Support Linux AIO (native)
 	qemu_options+=(size:--enable-linux-aio)

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -186,7 +186,13 @@ calc_qemu_files_sha256sum() {
 
 get_qemu_image_name() {
 	qemu_script_dir="${repo_root_dir}/tools/packaging/static-build/qemu"
-	echo "${BUILDER_REGISTRY}:qemu-$(get_last_modification "${qemu_script_dir}")-$(uname -m)"
+	qemu_configure_script="${repo_root_dir}/tools/packaging/scripts/configure-hypervisor.sh"
+
+	qemu_hash=$(merge_two_hashes \
+		"$(get_last_modification "${qemu_script_dir}")" \
+		"$(get_last_modification "${qemu_configure_script}")")
+
+	echo "${BUILDER_REGISTRY}:qemu-${qemu_hash}-$(uname -m)"
 }
 
 get_shim_v2_image_name() {

--- a/tools/packaging/static-build/qemu.blacklist
+++ b/tools/packaging/static-build/qemu.blacklist
@@ -33,3 +33,97 @@ qemu_black_list=(
 */share/*/u-boot*
 */share/*/vgabios*
 )
+
+# Firmware files not needed for this architecture.
+# Each platform uses a different firmware, ship only what's required:
+#   x86_64  -> edk2-x86_64-*.fd (OVMF)
+#   aarch64 -> edk2-aarch64-*.fd (AAVMF)
+#   s390x   -> s390-ccw.img (CCW BIOS)
+#   ppc64le -> slof.bin / vof.bin (Open Firmware)
+ARCH=${ARCH:-$(uname -m)}
+case "${ARCH}" in
+x86_64)
+    qemu_black_list+=(
+        */share/*/edk2-aarch64*
+        */share/*/edk2-arm*
+        */share/*/edk2-i386*
+        */share/*/edk2-loongarch64*
+        */share/*/edk2-riscv*
+        */share/*/firmware/60-edk2-aarch64.json
+        */share/*/firmware/60-edk2-arm.json
+        */share/*/firmware/60-edk2-i386.json
+        */share/*/firmware/60-edk2-loongarch64.json
+        */share/*/firmware/60-edk2-riscv64.json
+        */share/*/hppa-firmware*
+        */share/*/pnv-pnor.bin
+        */share/*/s390-ccw.img
+        */share/*/slof.bin
+        */share/*/vof*.bin
+        */share/*/ast27x0_bootrom.bin
+        */share/*/npcm8xx_bootrom.bin
+    )
+    ;;
+aarch64)
+    qemu_black_list+=(
+        */share/*/edk2-arm-*
+        */share/*/edk2-i386*
+        */share/*/edk2-loongarch64*
+        */share/*/edk2-riscv*
+        */share/*/edk2-x86_64*
+        */share/*/firmware/50-edk2-*
+        */share/*/firmware/60-edk2-arm.json
+        */share/*/firmware/60-edk2-i386.json
+        */share/*/firmware/60-edk2-loongarch64.json
+        */share/*/firmware/60-edk2-riscv64.json
+        */share/*/firmware/60-edk2-x86_64.json
+        */share/*/hppa-firmware*
+        */share/*/pnv-pnor.bin
+        */share/*/s390-ccw.img
+        */share/*/slof.bin
+        */share/*/vof*.bin
+        */share/*/ast27x0_bootrom.bin
+        */share/*/npcm8xx_bootrom.bin
+        */share/*/bios*.bin
+        */share/*/kvmvapic.bin
+        */share/*/linuxboot_dma.bin
+        */share/*/multiboot_dma.bin
+        */share/*/pvh.bin
+        */share/*/qboot.rom
+    )
+    ;;
+s390x)
+    qemu_black_list+=(
+        */share/*/edk2-*
+        */share/*/firmware
+        */share/*/hppa-firmware*
+        */share/*/pnv-pnor.bin
+        */share/*/slof.bin
+        */share/*/vof*.bin
+        */share/*/ast27x0_bootrom.bin
+        */share/*/npcm8xx_bootrom.bin
+        */share/*/bios*.bin
+        */share/*/kvmvapic.bin
+        */share/*/linuxboot_dma.bin
+        */share/*/multiboot_dma.bin
+        */share/*/pvh.bin
+        */share/*/qboot.rom
+    )
+    ;;
+ppc64le)
+    qemu_black_list+=(
+        */share/*/edk2-*
+        */share/*/firmware
+        */share/*/hppa-firmware*
+        */share/*/pnv-pnor.bin
+        */share/*/s390-ccw.img
+        */share/*/ast27x0_bootrom.bin
+        */share/*/npcm8xx_bootrom.bin
+        */share/*/bios*.bin
+        */share/*/kvmvapic.bin
+        */share/*/linuxboot_dma.bin
+        */share/*/multiboot_dma.bin
+        */share/*/pvh.bin
+        */share/*/qboot.rom
+    )
+    ;;
+esac

--- a/tools/packaging/static-build/qemu/build-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-qemu.sh
@@ -35,8 +35,189 @@ git fetch --depth=1 origin "${QEMU_VERSION_NUM}"
 git checkout FETCH_HEAD
 scripts/git-submodule.sh update meson capstone
 "${kata_packaging_scripts}/patch_qemu.sh" "${QEMU_VERSION_NUM}" "${kata_packaging_dir}/qemu/patches"
+
+# With --without-default-devices every machine type and every device with
+# "default y" is suppressed (allnoconfig semantics).  We must explicitly
+# list each CONFIG_* we need before ./configure so meson picks them up.
+# The post-build verify_devices check below fails the build if any device
+# Kata can emit is missing from the resulting binary.
+#
+# Transport-independent device models used by Kata on every architecture
+# (the PCI/CCW transport variant is built when the transport is enabled):
+#   VIRTIO_BLK  – rootfs / container block device
+#   VIRTIO_SCSI – SCSI block driver option (also selects SCSI for scsi-hd)
+#   VIRTIO_NET  – container networking (accelerated by vhost-kernel)
+#   VIRTIO_SERIAL / VIRTIO_CONSOLE – agent tty / console
+#   VIRTIO_RNG  – guest entropy source
+#   VIRTIO_BALLOON – memory pressure management
+#   VIRTIO_MEM  – memory hot-plug
+#   VHOST_USER_FS – virtiofsd shared filesystem (vhost-user)
+#   VHOST_USER_BLK – vhost-user block (SPDK and friends)
+#   VHOST_USER_SCSI – vhost-user SCSI
+#   VIRTIO_9P   – fallback 9P shared filesystem
+#   VHOST_VSOCK – VM↔host socket for the Kata agent (kernel vhost)
+
+_COMMON_DEVS='
+CONFIG_VIRTIO_BLK=y
+CONFIG_VIRTIO_SCSI=y
+CONFIG_VIRTIO_NET=y
+CONFIG_VIRTIO_SERIAL=y
+CONFIG_VIRTIO_RNG=y
+CONFIG_VIRTIO_BALLOON=y
+CONFIG_VIRTIO_MEM=y
+CONFIG_VHOST_USER_FS=y
+CONFIG_VHOST_USER_BLK=y
+CONFIG_VHOST_USER_SCSI=y
+CONFIG_VIRTIO_9P=y
+CONFIG_VHOST_VSOCK=y
+'
+
+# PCI transport plus the PCIe slot topology Kata builds for device
+# assignment (cold-plug root ports, switch ports, bridges, expander
+# bridges for NUMA-pinned GPU complexes):
+#   VIRTIO_PCI  – PCI transport for all virtio devices above
+#   VFIO_PCI    – GPU / NIC passthrough via VFIO (also selects VFIO)
+#   IOMMUFD     – modern VFIO backend (depends on VFIO)
+#   PCIE_PORT   – pcie-root-port (hot-plug slots, root-port topology)
+#   XIO3130     – x3130-upstream / xio3130-downstream (switch-port topology)
+#   PCI_BRIDGE  – pci-bridge (bridge-port topology)
+#   PCIE_PCI_BRIDGE – pcie-pci-bridge
+#   PXB         – pxb-pcie expander bridge (NUMA-pinned GPU root complexes)
+#   NVDIMM      – rootfs image as DAX-capable persistent memory
+
+_PCIE_DEVS='
+CONFIG_VIRTIO_PCI=y
+CONFIG_VFIO_PCI=y
+CONFIG_IOMMUFD=y
+CONFIG_PCIE_PORT=y
+CONFIG_XIO3130=y
+CONFIG_PCI_BRIDGE=y
+CONFIG_PCIE_PCI_BRIDGE=y
+CONFIG_PXB=y
+CONFIG_NVDIMM=y
+'
+
+if [[ "${ARCH}" == "x86_64" ]]; then
+	# VTD_ACCEL enables IOMMUFD-backed VT-d for high-performance passthrough.
+	# PVPANIC_ISA provides the pvpanic device (guest kernel panic reporting).
+	# CONFIG_CXL is required because CONFIG_PXB (in _PCIE_DEVS) links against
+	# CXL component symbols; omitting it produces undefined-reference link errors.
+	# TDX, SEV and SGX are only implied by CONFIG_PC, so allnoconfig drops them
+	# and the -object types the runtimes emit for confidential guests
+	# (tdx-guest, sev-snp-guest) and for SGX enclaves (memory-backend-epc)
+	# are gone from the binary.  CONFIG_SEV is QEMU's shared gate for both
+	# classic SEV and SEV-SNP; Kata only uses the SNP object.
+	printf 'CONFIG_Q35=y\n%s\n%s\nCONFIG_VTD=y\nCONFIG_VTD_ACCEL=y\nCONFIG_AMD_IOMMU=y\nCONFIG_PVPANIC_ISA=y\nCONFIG_CXL=y\nCONFIG_CXL_MEM_DEVICE=y\nCONFIG_TDX=y\nCONFIG_SEV=y\nCONFIG_SGX=y\n' \
+		"${_COMMON_DEVS}" "${_PCIE_DEVS}" \
+		>> configs/devices/i386-softmmu/default.mak
+elif [[ "${ARCH}" == "s390x" ]]; then
+	# s390x uses CCW bus (no PCI virtio); VIRTIO_CCW replaces VIRTIO_PCI and
+	# selects VIRTIO_MD_SUPPORTED.  Passthrough is via VFIO_CCW / VFIO_AP.
+	# VFIO_PCI is still required: the VFIO core references its symbols.
+	printf 'CONFIG_S390_CCW_VIRTIO=y\n%s\nCONFIG_VIRTIO_CCW=y\nCONFIG_VFIO_CCW=y\nCONFIG_VFIO_AP=y\nCONFIG_VFIO_PCI=y\n' \
+		"${_COMMON_DEVS}" \
+		>> configs/devices/s390x-softmmu/default.mak
+elif [[ "${ARCH}" == "aarch64" ]]; then
+	# CONFIG_CXL is required by CONFIG_ACPI_CXL (auto-selected by ARM_VIRT) for Rubin vCXL.
+	# CONFIG_PXB (in _PCIE_DEVS) is a dependency of CONFIG_CXL.
+	# arm-smmuv3 comes via ARM_VIRT (selects ARM_SMMUV3).
+	printf 'CONFIG_ARM_VIRT=y\nCONFIG_CXL=y\nCONFIG_CXL_MEM_DEVICE=y\n%s\n%s\n' \
+		"${_COMMON_DEVS}" "${_PCIE_DEVS}" \
+		>> configs/devices/aarch64-softmmu/default.mak
+elif [[ "${ARCH}" == "ppc64le" ]]; then
+	# VIRTIO_MEM depends on VIRTIO_MEM_SUPPORTED, which is only selected on
+	# arm/i386/s390x — ppc64 PSeries does not support virtio-mem.
+	# PSeries PHBs are conventional PCI: no PCIe root/switch ports, no PXB.
+	_PPC64_DEVS=$(printf '%s' "${_COMMON_DEVS}" | grep -v 'CONFIG_VIRTIO_MEM=')
+	printf 'CONFIG_PSERIES=y\n%s\nCONFIG_VIRTIO_PCI=y\nCONFIG_VFIO_PCI=y\nCONFIG_IOMMUFD=y\nCONFIG_PCI_BRIDGE=y\nCONFIG_NVDIMM=y\n' \
+		"${_PPC64_DEVS}" \
+		>> configs/devices/ppc64-softmmu/default.mak
+	unset _PPC64_DEVS
+fi
+unset _COMMON_DEVS _PCIE_DEVS
+
 PREFIX="${PREFIX}" "${kata_packaging_scripts}/configure-hypervisor.sh" -s "${HYPERVISOR_NAME}" "${ARCH}" | xargs ./configure  --with-pkgversion="${PKGVERSION}"
-make -j"$(nproc --ignore=1)"
+
+# Build only the system emulator, not tests or tools.
+# ppc64le uses a "ppc64" target name; all others match the arch.
+_qemu_target="${ARCH}"
+[[ "${ARCH}" == "ppc64le" ]] && _qemu_target="ppc64"
+make -j"$(nproc --ignore=1)" "qemu-system-${_qemu_target}"
+
+# Fail the build if any device Kata can emit is missing from the binary.
+# This is the completeness guarantee for the --without-default-devices
+# allowlist above: a gap fails here at build time, not at VM-start time.
+verify_devices() {
+	local qemu_binary="./build/qemu-system-${_qemu_target}"
+	local devices_help missing=()
+	devices_help=$("${qemu_binary}" -device help)
+	local dev
+	for dev in "$@"; do
+		if ! grep -q "name \"${dev}\"" <<< "${devices_help}"; then
+			missing+=("${dev}")
+		fi
+	done
+	if [[ "${#missing[@]}" -gt 0 ]]; then
+		echo "ERROR: required devices missing from ${qemu_binary}: ${missing[*]}" >&2
+		exit 1
+	fi
+	echo "verify_devices: all $# required devices present in ${qemu_binary}"
+}
+
+# Same guarantee for the user-creatable objects (-object) Kata emits: the
+# confidential-guest and SGX backends are objects, not devices, so they do
+# not show up in -device help.
+verify_objects() {
+	local qemu_binary="./build/qemu-system-${_qemu_target}"
+	local objects_help missing=()
+	objects_help=$("${qemu_binary}" -object help)
+	local obj
+	for obj in "$@"; do
+		if ! grep -q "^[[:space:]]*${obj}$" <<< "${objects_help}"; then
+			missing+=("${obj}")
+		fi
+	done
+	if [[ "${#missing[@]}" -gt 0 ]]; then
+		echo "ERROR: required objects missing from ${qemu_binary}: ${missing[*]}" >&2
+		exit 1
+	fi
+	echo "verify_objects: all $# required objects present in ${qemu_binary}"
+}
+
+_pci_devs=(
+	virtio-blk-pci virtio-scsi-pci scsi-hd virtio-net-pci
+	virtio-serial-pci virtconsole virtio-rng-pci virtio-balloon-pci
+	virtio-9p-pci vhost-vsock-pci vhost-user-fs-pci vhost-user-blk-pci
+	nvdimm vfio-pci pci-bridge
+)
+_pcie_topology=(
+	pcie-root-port x3130-upstream xio3130-downstream pcie-pci-bridge pxb-pcie
+	virtio-mem-pci
+)
+
+case "${ARCH}" in
+x86_64)
+	verify_devices "${_pci_devs[@]}" "${_pcie_topology[@]}" \
+		intel-iommu amd-iommu pvpanic
+	verify_objects tdx-guest sev-snp-guest
+	;;
+aarch64)
+	verify_devices "${_pci_devs[@]}" "${_pcie_topology[@]}" \
+		arm-smmuv3
+	;;
+ppc64le)
+	verify_devices "${_pci_devs[@]}"
+	;;
+s390x)
+	verify_devices \
+		virtio-blk-ccw virtio-scsi-ccw scsi-hd virtio-net-ccw \
+		virtio-serial-ccw virtconsole virtio-rng-ccw virtio-balloon-ccw \
+		virtio-9p-ccw vhost-vsock-ccw vhost-user-fs-ccw virtio-mem-ccw \
+		vfio-ccw vfio-ap
+	;;
+esac
+unset _pci_devs _pcie_topology _qemu_target
+
 make install DESTDIR="${QEMU_DESTDIR}"
 popd
 "${kata_static_build_scripts}/qemu-build-post.sh"

--- a/tools/packaging/static-build/qemu/build-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-qemu.sh
@@ -27,9 +27,10 @@ kata_static_build_scripts="${kata_static_build_dir}/scripts"
 
 ARCH=${ARCH:-$(uname -m)}
 
-rm -rf qemu
-git clone --depth=1 "${QEMU_REPO}" qemu
-pushd qemu
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+git clone --depth=1 "${QEMU_REPO}" "${workdir}/qemu"
+pushd "${workdir}/qemu"
 git fetch --depth=1 origin "${QEMU_VERSION_NUM}"
 git checkout FETCH_HEAD
 scripts/git-submodule.sh update meson capstone


### PR DESCRIPTION
We have a very long list of disable calls for QEMU that we can replace by using the configure script to disable all default features and default devices.
We enable selectively the features that we need.