### PR TITLE
virtiofsd: Update to its v1.13.0 ( + one patch) release :-)

### DIFF
--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -45,8 +45,6 @@ setup() {
 }
 
 @test "Empty dir volume when FSGroup is specified with non-root container" {
-	skip "See: https://github.com/kata-containers/kata-containers/issues/10706"
-
 	# This is a reproducer of k8s e2e "[sig-storage] EmptyDir volumes when FSGroup is specified [LinuxOnly] [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" test
 	pod_file="${pod_config_dir}/pod-empty-dir-fsgroup.yaml"
 	agnhost_name="${container_images_agnhost_name}"

--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -22,14 +22,19 @@ virtiofsd_zip="${virtiofsd_zip:-}"
 
 [ -n "$virtiofsd_repo" ] || die "failed to get virtiofsd repo"
 [ -n "$virtiofsd_version" ] || die "failed to get virtiofsd version"
-[ -n "${virtiofsd_zip}" ] || die "failed to get virtiofsd binary URL"
 
 [ -d "virtiofsd" ] && rm -r virtiofsd
 
 pull_virtiofsd_released_binary() {
+	if [ -z "${virtiofsd_zip}" ]; then
+		info "failed to get virtiofsd binary URL"
+		return 1
+	fi
+
 	if [ "${ARCH}" != "x86_64" ]; then
 		info "Only x86_64 binaries are distributed as part of the virtiofsd releases" && return 1
 	fi
+
 	info "Download virtiofsd version: ${virtiofsd_version}"
 
 	mkdir -p virtiofsd
@@ -48,8 +53,10 @@ build_virtiofsd_from_source() {
 	echo "build viriofsd from source"
 	. /etc/profile.d/rust.sh
 
-	git clone --depth 1 --branch ${virtiofsd_version} ${virtiofsd_repo} virtiofsd
+	git clone --depth 1 --branch main ${virtiofsd_repo} virtiofsd
 	pushd virtiofsd
+
+	git reset --hard ${virtiofsd_version}
 
 	export RUSTFLAGS='-C target-feature=+crt-static'${EXTRA_RUST_FLAGS}
 	export LIBSECCOMP_LINK_TYPE=static

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -31,7 +31,6 @@ package_output_dir="${package_output_dir:-}"
 [ -n "${virtiofsd_repo}" ] || die "Failed to get virtiofsd repo"
 [ -n "${virtiofsd_version}" ] || die "Failed to get virtiofsd version or commit"
 [ -n "${virtiofsd_toolchain}" ] || die "Failed to get the rust toolchain to build virtiofsd"
-[ -n "${virtiofsd_zip}" ] || die "Failed to get virtiofsd binary URL"
 
 case ${ARCH} in
 	"aarch64")

--- a/versions.yaml
+++ b/versions.yaml
@@ -354,14 +354,9 @@ externals:
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"
     url: "https://gitlab.com/virtio-fs/virtiofsd"
-    version: "v1.8.0"
-    toolchain: "1.72.0"
-    meta:
-      # From https://gitlab.com/virtio-fs/virtiofsd/-/releases/v1.8.0,
-      # this is the link labelled virtiofsd-v1.8.0.zip
-      #
-      # yamllint disable-line rule:line-length
-      binary: "https://gitlab.com/virtio-fs/virtiofsd/uploads/9ec473efd0203219d016e66aac4190aa/virtiofsd-v1.8.0.zip"
+    # v1.13.0 + seccomp patch allowing the tkill syscall
+    version: "cecc61bca981ab42aae6ec490dfd59965e79025e"
+    toolchain: "1.83.0"
 
   xurls:
     description: |


### PR DESCRIPTION
Together with the bump, let's also bump the rust version needed to build the package, with the caveat that virtiofsd doesn't actually use a pinned version as part of their CI, so we're bumping to whatever is the version on `alpine:rust` (which is used in their CI).