### PR TITLE
Revert "ci: Re-enable SNP CI"

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -188,6 +188,9 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
 
   run-k8s-tests-sev-snp:
+    # Skipping SNP tests to unblock the CI. 
+    # Will revert after issue is fixed.
+    if: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This reverts commit ef367d81f2e0580a410d95515952e27fe49fddd9.

SNP CI is not stable, nor online, and has been blocking jobs to finish for a reasonable amount of time, thus, let's just skip it.