### PR TITLE
tests: Re-enable oom tests for mariner

### DIFF
--- a/tests/integration/kubernetes/k8s-oom.bats
+++ b/tests/integration/kubernetes/k8s-oom.bats
@@ -9,8 +9,6 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[ "${KATA_HOST_OS}" == "cbl-mariner" ] && skip "test not working see: see #8821"
-
 	pod_name="pod-oom"
 	get_pod_config_dir
 
@@ -34,8 +32,6 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HOST_OS}" == "cbl-mariner" ] && skip "test not working see: see #8821"
-
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 	kubectl get "pod/$pod_name" -o yaml


### PR DESCRIPTION
Since we bumped to the 6.12.x LTS kernel, we've also adjusted the aggressivity of the OOM test, which may be enough to allow us to re-enable it for mariner.

Fixes: #8821