### PR TITLE
runtime: use actual booleans for QMP `device_add` boolean options

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qmp.go
+++ b/src/runtime/pkg/govmm/qemu/qmp.go
@@ -869,7 +869,7 @@ func (q *QMP) ExecuteDeviceAdd(ctx context.Context, blockdevID, devID, driver, b
 	}
 
 	if shared {
-		args["share-rw"] = "on"
+		args["share-rw"] = true
 	}
 	if transport.isVirtioPCI(nil) {
 		args["romfile"] = romfile
@@ -923,7 +923,7 @@ func (q *QMP) ExecuteSCSIDeviceAdd(ctx context.Context, blockdevID, devID, drive
 		args["lun"] = lun
 	}
 	if shared {
-		args["share-rw"] = "on"
+		args["share-rw"] = true
 	}
 
 	return q.executeCommand(ctx, "device_add", args, nil)
@@ -1050,7 +1050,7 @@ func (q *QMP) ExecuteNetPCIDeviceAdd(ctx context.Context, netdevID, devID, macAd
 		// Clearlinux automatically sets up the queues properly
 		// The agent implementation should do this to ensure that it is
 		// always set
-		args["mq"] = "on"
+		args["mq"] = true
 		args["vectors"] = 2*queues + 2
 	}
 
@@ -1071,7 +1071,7 @@ func (q *QMP) ExecuteNetCCWDeviceAdd(ctx context.Context, netdevID, devID, macAd
 	}
 
 	if queues > 0 {
-		args["mq"] = "on"
+		args["mq"] = true
 	}
 
 	return q.executeCommand(ctx, "device_add", args, nil)
@@ -1113,7 +1113,7 @@ func (q *QMP) ExecutePCIDeviceAdd(ctx context.Context, blockdevID, devID, driver
 		args["bus"] = bus
 	}
 	if shared {
-		args["share-rw"] = "on"
+		args["share-rw"] = true
 	}
 	if queues > 0 {
 		args["num-queues"] = strconv.Itoa(queues)


### PR DESCRIPTION
Since https://github.com/qemu/qemu/commit/be93fd53723cbdca675bd9ed112dae5cabbe1e91, which is included in QEMU starting from version 9.2.0, the options for the `device_add` QMP command need to be typed correctly.

This makes it so that instead of `"on"`, the value is set to `true`, matching QEMU's expectations.

This has been tested on QEMU 9.2.0 and QEMU 9.1.2, so before and after the change.

The compatibility with incorrectly typed options  for the `device_add` command is deprecated since version 6.2.0 [^1].

[^1]:  https://qemu-project.gitlab.io/qemu/about/deprecated.html#incorrectly-typed-device-add-arguments-since-6-2