### PR TITLE
versions: Upgrade to Cloud Hypervisor v45.0

### DIFF
--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -466,7 +466,7 @@ components:
     VmInfo:
       description: Virtual Machine information
       example:
-        memory_actual_size: 4
+        memory_actual_size: 7
         state: Created
         config:
           memory:
@@ -595,11 +595,13 @@ components:
             - 1
             - 1
             num_pci_segments: 4
+            iommu_address_width: 4
             oem_strings:
             - oem_strings
             - oem_strings
             tdx: false
             serial_number: serial_number
+            sev_snp: false
             uuid: uuid
           pmem:
           - pci_segment: 3
@@ -617,7 +619,9 @@ components:
           iommu: false
           payload:
             cmdline: cmdline
+            igvm: igvm
             kernel: kernel
+            host_data: host_data
             initramfs: initramfs
             firmware: firmware
           rate_limit_groups:
@@ -886,7 +890,9 @@ components:
       description: Payloads to boot in guest
       example:
         cmdline: cmdline
+        igvm: igvm
         kernel: kernel
+        host_data: host_data
         initramfs: initramfs
         firmware: firmware
       properties:
@@ -897,6 +903,10 @@ components:
         cmdline:
           type: string
         initramfs:
+          type: string
+        igvm:
+          type: string
+        host_data:
           type: string
       type: object
     VmConfig:
@@ -1028,11 +1038,13 @@ components:
           - 1
           - 1
           num_pci_segments: 4
+          iommu_address_width: 4
           oem_strings:
           - oem_strings
           - oem_strings
           tdx: false
           serial_number: serial_number
+          sev_snp: false
           uuid: uuid
         pmem:
         - pci_segment: 3
@@ -1050,7 +1062,9 @@ components:
         iommu: false
         payload:
           cmdline: cmdline
+          igvm: igvm
           kernel: kernel
+          host_data: host_data
           initramfs: initramfs
           firmware: firmware
         rate_limit_groups:
@@ -1431,11 +1445,13 @@ components:
         - 1
         - 1
         num_pci_segments: 4
+        iommu_address_width: 4
         oem_strings:
         - oem_strings
         - oem_strings
         tdx: false
         serial_number: serial_number
+        sev_snp: false
         uuid: uuid
       properties:
         num_pci_segments:
@@ -1446,6 +1462,9 @@ components:
             format: int16
             type: integer
           type: array
+        iommu_address_width:
+          format: uint8
+          type: integer
         serial_number:
           type: string
         uuid:
@@ -1455,6 +1474,9 @@ components:
             type: string
           type: array
         tdx:
+          default: false
+          type: boolean
+        sev_snp:
           default: false
           type: boolean
       type: object

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PayloadConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PayloadConfig.md
@@ -8,6 +8,8 @@ Name | Type | Description | Notes
 **Kernel** | Pointer to **string** |  | [optional] 
 **Cmdline** | Pointer to **string** |  | [optional] 
 **Initramfs** | Pointer to **string** |  | [optional] 
+**Igvm** | Pointer to **string** |  | [optional] 
+**HostData** | Pointer to **string** |  | [optional] 
 
 ## Methods
 
@@ -127,6 +129,56 @@ SetInitramfs sets Initramfs field to given value.
 `func (o *PayloadConfig) HasInitramfs() bool`
 
 HasInitramfs returns a boolean if a field has been set.
+
+### GetIgvm
+
+`func (o *PayloadConfig) GetIgvm() string`
+
+GetIgvm returns the Igvm field if non-nil, zero value otherwise.
+
+### GetIgvmOk
+
+`func (o *PayloadConfig) GetIgvmOk() (*string, bool)`
+
+GetIgvmOk returns a tuple with the Igvm field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetIgvm
+
+`func (o *PayloadConfig) SetIgvm(v string)`
+
+SetIgvm sets Igvm field to given value.
+
+### HasIgvm
+
+`func (o *PayloadConfig) HasIgvm() bool`
+
+HasIgvm returns a boolean if a field has been set.
+
+### GetHostData
+
+`func (o *PayloadConfig) GetHostData() string`
+
+GetHostData returns the HostData field if non-nil, zero value otherwise.
+
+### GetHostDataOk
+
+`func (o *PayloadConfig) GetHostDataOk() (*string, bool)`
+
+GetHostDataOk returns a tuple with the HostData field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetHostData
+
+`func (o *PayloadConfig) SetHostData(v string)`
+
+SetHostData sets HostData field to given value.
+
+### HasHostData
+
+`func (o *PayloadConfig) HasHostData() bool`
+
+HasHostData returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PlatformConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/PlatformConfig.md
@@ -6,10 +6,12 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **NumPciSegments** | Pointer to **int32** |  | [optional] 
 **IommuSegments** | Pointer to **[]int32** |  | [optional] 
+**IommuAddressWidth** | Pointer to **int32** |  | [optional] 
 **SerialNumber** | Pointer to **string** |  | [optional] 
 **Uuid** | Pointer to **string** |  | [optional] 
 **OemStrings** | Pointer to **[]string** |  | [optional] 
 **Tdx** | Pointer to **bool** |  | [optional] [default to false]
+**SevSnp** | Pointer to **bool** |  | [optional] [default to false]
 
 ## Methods
 
@@ -79,6 +81,31 @@ SetIommuSegments sets IommuSegments field to given value.
 `func (o *PlatformConfig) HasIommuSegments() bool`
 
 HasIommuSegments returns a boolean if a field has been set.
+
+### GetIommuAddressWidth
+
+`func (o *PlatformConfig) GetIommuAddressWidth() int32`
+
+GetIommuAddressWidth returns the IommuAddressWidth field if non-nil, zero value otherwise.
+
+### GetIommuAddressWidthOk
+
+`func (o *PlatformConfig) GetIommuAddressWidthOk() (*int32, bool)`
+
+GetIommuAddressWidthOk returns a tuple with the IommuAddressWidth field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetIommuAddressWidth
+
+`func (o *PlatformConfig) SetIommuAddressWidth(v int32)`
+
+SetIommuAddressWidth sets IommuAddressWidth field to given value.
+
+### HasIommuAddressWidth
+
+`func (o *PlatformConfig) HasIommuAddressWidth() bool`
+
+HasIommuAddressWidth returns a boolean if a field has been set.
 
 ### GetSerialNumber
 
@@ -179,6 +206,31 @@ SetTdx sets Tdx field to given value.
 `func (o *PlatformConfig) HasTdx() bool`
 
 HasTdx returns a boolean if a field has been set.
+
+### GetSevSnp
+
+`func (o *PlatformConfig) GetSevSnp() bool`
+
+GetSevSnp returns the SevSnp field if non-nil, zero value otherwise.
+
+### GetSevSnpOk
+
+`func (o *PlatformConfig) GetSevSnpOk() (*bool, bool)`
+
+GetSevSnpOk returns a tuple with the SevSnp field if it's non-nil, zero value otherwise
+and a boolean to check if the value has been set.
+
+### SetSevSnp
+
+`func (o *PlatformConfig) SetSevSnp(v bool)`
+
+SetSevSnp sets SevSnp field to given value.
+
+### HasSevSnp
+
+`func (o *PlatformConfig) HasSevSnp() bool`
+
+HasSevSnp returns a boolean if a field has been set.
 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_payload_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_payload_config.go
@@ -20,6 +20,8 @@ type PayloadConfig struct {
 	Kernel    *string `json:"kernel,omitempty"`
 	Cmdline   *string `json:"cmdline,omitempty"`
 	Initramfs *string `json:"initramfs,omitempty"`
+	Igvm      *string `json:"igvm,omitempty"`
+	HostData  *string `json:"host_data,omitempty"`
 }
 
 // NewPayloadConfig instantiates a new PayloadConfig object
@@ -167,6 +169,70 @@ func (o *PayloadConfig) SetInitramfs(v string) {
 	o.Initramfs = &v
 }
 
+// GetIgvm returns the Igvm field value if set, zero value otherwise.
+func (o *PayloadConfig) GetIgvm() string {
+	if o == nil || o.Igvm == nil {
+		var ret string
+		return ret
+	}
+	return *o.Igvm
+}
+
+// GetIgvmOk returns a tuple with the Igvm field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PayloadConfig) GetIgvmOk() (*string, bool) {
+	if o == nil || o.Igvm == nil {
+		return nil, false
+	}
+	return o.Igvm, true
+}
+
+// HasIgvm returns a boolean if a field has been set.
+func (o *PayloadConfig) HasIgvm() bool {
+	if o != nil && o.Igvm != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIgvm gets a reference to the given string and assigns it to the Igvm field.
+func (o *PayloadConfig) SetIgvm(v string) {
+	o.Igvm = &v
+}
+
+// GetHostData returns the HostData field value if set, zero value otherwise.
+func (o *PayloadConfig) GetHostData() string {
+	if o == nil || o.HostData == nil {
+		var ret string
+		return ret
+	}
+	return *o.HostData
+}
+
+// GetHostDataOk returns a tuple with the HostData field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PayloadConfig) GetHostDataOk() (*string, bool) {
+	if o == nil || o.HostData == nil {
+		return nil, false
+	}
+	return o.HostData, true
+}
+
+// HasHostData returns a boolean if a field has been set.
+func (o *PayloadConfig) HasHostData() bool {
+	if o != nil && o.HostData != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetHostData gets a reference to the given string and assigns it to the HostData field.
+func (o *PayloadConfig) SetHostData(v string) {
+	o.HostData = &v
+}
+
 func (o PayloadConfig) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.Firmware != nil {
@@ -180,6 +246,12 @@ func (o PayloadConfig) MarshalJSON() ([]byte, error) {
 	}
 	if o.Initramfs != nil {
 		toSerialize["initramfs"] = o.Initramfs
+	}
+	if o.Igvm != nil {
+		toSerialize["igvm"] = o.Igvm
+	}
+	if o.HostData != nil {
+		toSerialize["host_data"] = o.HostData
 	}
 	return json.Marshal(toSerialize)
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_platform_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_platform_config.go
@@ -16,12 +16,14 @@ import (
 
 // PlatformConfig struct for PlatformConfig
 type PlatformConfig struct {
-	NumPciSegments *int32    `json:"num_pci_segments,omitempty"`
-	IommuSegments  *[]int32  `json:"iommu_segments,omitempty"`
-	SerialNumber   *string   `json:"serial_number,omitempty"`
-	Uuid           *string   `json:"uuid,omitempty"`
-	OemStrings     *[]string `json:"oem_strings,omitempty"`
-	Tdx            *bool     `json:"tdx,omitempty"`
+	NumPciSegments    *int32    `json:"num_pci_segments,omitempty"`
+	IommuSegments     *[]int32  `json:"iommu_segments,omitempty"`
+	IommuAddressWidth *int32    `json:"iommu_address_width,omitempty"`
+	SerialNumber      *string   `json:"serial_number,omitempty"`
+	Uuid              *string   `json:"uuid,omitempty"`
+	OemStrings        *[]string `json:"oem_strings,omitempty"`
+	Tdx               *bool     `json:"tdx,omitempty"`
+	SevSnp            *bool     `json:"sev_snp,omitempty"`
 }
 
 // NewPlatformConfig instantiates a new PlatformConfig object
@@ -32,6 +34,8 @@ func NewPlatformConfig() *PlatformConfig {
 	this := PlatformConfig{}
 	var tdx bool = false
 	this.Tdx = &tdx
+	var sevSnp bool = false
+	this.SevSnp = &sevSnp
 	return &this
 }
 
@@ -42,6 +46,8 @@ func NewPlatformConfigWithDefaults() *PlatformConfig {
 	this := PlatformConfig{}
 	var tdx bool = false
 	this.Tdx = &tdx
+	var sevSnp bool = false
+	this.SevSnp = &sevSnp
 	return &this
 }
 
@@ -107,6 +113,38 @@ func (o *PlatformConfig) HasIommuSegments() bool {
 // SetIommuSegments gets a reference to the given []int32 and assigns it to the IommuSegments field.
 func (o *PlatformConfig) SetIommuSegments(v []int32) {
 	o.IommuSegments = &v
+}
+
+// GetIommuAddressWidth returns the IommuAddressWidth field value if set, zero value otherwise.
+func (o *PlatformConfig) GetIommuAddressWidth() int32 {
+	if o == nil || o.IommuAddressWidth == nil {
+		var ret int32
+		return ret
+	}
+	return *o.IommuAddressWidth
+}
+
+// GetIommuAddressWidthOk returns a tuple with the IommuAddressWidth field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PlatformConfig) GetIommuAddressWidthOk() (*int32, bool) {
+	if o == nil || o.IommuAddressWidth == nil {
+		return nil, false
+	}
+	return o.IommuAddressWidth, true
+}
+
+// HasIommuAddressWidth returns a boolean if a field has been set.
+func (o *PlatformConfig) HasIommuAddressWidth() bool {
+	if o != nil && o.IommuAddressWidth != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetIommuAddressWidth gets a reference to the given int32 and assigns it to the IommuAddressWidth field.
+func (o *PlatformConfig) SetIommuAddressWidth(v int32) {
+	o.IommuAddressWidth = &v
 }
 
 // GetSerialNumber returns the SerialNumber field value if set, zero value otherwise.
@@ -237,6 +275,38 @@ func (o *PlatformConfig) SetTdx(v bool) {
 	o.Tdx = &v
 }
 
+// GetSevSnp returns the SevSnp field value if set, zero value otherwise.
+func (o *PlatformConfig) GetSevSnp() bool {
+	if o == nil || o.SevSnp == nil {
+		var ret bool
+		return ret
+	}
+	return *o.SevSnp
+}
+
+// GetSevSnpOk returns a tuple with the SevSnp field value if set, nil otherwise
+// and a boolean to check if the value has been set.
+func (o *PlatformConfig) GetSevSnpOk() (*bool, bool) {
+	if o == nil || o.SevSnp == nil {
+		return nil, false
+	}
+	return o.SevSnp, true
+}
+
+// HasSevSnp returns a boolean if a field has been set.
+func (o *PlatformConfig) HasSevSnp() bool {
+	if o != nil && o.SevSnp != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetSevSnp gets a reference to the given bool and assigns it to the SevSnp field.
+func (o *PlatformConfig) SetSevSnp(v bool) {
+	o.SevSnp = &v
+}
+
 func (o PlatformConfig) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
 	if o.NumPciSegments != nil {
@@ -244,6 +314,9 @@ func (o PlatformConfig) MarshalJSON() ([]byte, error) {
 	}
 	if o.IommuSegments != nil {
 		toSerialize["iommu_segments"] = o.IommuSegments
+	}
+	if o.IommuAddressWidth != nil {
+		toSerialize["iommu_address_width"] = o.IommuAddressWidth
 	}
 	if o.SerialNumber != nil {
 		toSerialize["serial_number"] = o.SerialNumber
@@ -256,6 +329,9 @@ func (o PlatformConfig) MarshalJSON() ([]byte, error) {
 	}
 	if o.Tdx != nil {
 		toSerialize["tdx"] = o.Tdx
+	}
+	if o.SevSnp != nil {
+		toSerialize["sev_snp"] = o.SevSnp
 	}
 	return json.Marshal(toSerialize)
 }

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -548,6 +548,10 @@ components:
           type: string
         initramfs:
           type: string
+        igvm:
+          type: string
+        host_data:
+          type: string
       description: Payloads to boot in guest
 
     VmConfig:
@@ -718,6 +722,9 @@ components:
           items:
             type: integer
             format: int16
+        iommu_address_width:
+          type: integer
+          format: uint8
         serial_number:
           type: string
         uuid:
@@ -727,6 +734,9 @@ components:
           items:
             type: string
         tdx:
+          type: boolean
+          default: false
+        sev_snp:
           type: boolean
           default: false
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v41.0"
+      version: "v45.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
## v45.0

### Experimental `riscv64` Architecture Support

Cloud Hypervisor now has experimental `riscv64` architecture
support. Details can be found from the [riscv
documentation](docs/riscv.md).

### Alphabetically Sorted CLI Options

To improve the readability of CLI options, the output of the `--help`
now is alphabetically sorted. 

### Improved Downtime of VM Live Migration

The downtime of VM live migration is reduced via delaying some of the
tearing down process of the source VM after the destination VM is up and
running. 

### Notable Bug Fixes

* Fix seccomp filters related to http-api thread
* Handle cross-page access in the emulator for mshv 

## v44.0

This release has been tracked in [v44.0
group](https://github.com/orgs/cloud-hypervisor/projects/6/views/4?filterQuery=release%3A%22Release+v44.0%22)
of our [roadmap project](https://github.com/orgs/cloud-hypervisor/projects/6/).

### Configurable `virtio-iommu` Address Width

The `iommu_address_width` option has been added to `--platform` to allow users
to limit the `virtio-iommu` address space in the guest. 

### Notable Performance Improvements

The `VIRTIO_BLK_F_SEG_MAX` feature has been enabled for `virtio-block` devices,
which brings significant performance improvements on throughput. 

The `io_uring` entries are no longer forced to use async helper workers,
delegating the decision to the kernel. This change resolved the issue of having
excessive amount of worker threads when `io_uring` is being used, which is
expected to improve performance, such as reducing memory usage and reduce CPU
contention.

### New Fuzzers

Our continuous fuzzing infrastructure is augmented with two new fuzzers to cover
x86 instruction emulator and `virtio-vsock`.

### Notable Bug Fixes

* Fix short read and short write that impact QCOW and VHDX support. 
* Various bug fixes on VHDX support. 

## v43.0

### Live Migration over TCP Connections
Support has been added to enable direct live migration from two hosts via TCP
connections. This supplements the existing support for migrating over a UNIX
socket which can then be tunnelled as desired. The documentation has been
updated. 

### Notable Performance Improvements
The VIRTIO_RING_F_INDIRECT_DESC feature has been enabled for virtio-block
devices. This significantly increases the throughput of the devices with a
small negative impact on latency. 

### Notable Bug Fixes
* Cloud Hypervisor now accepts VFIO devices that use I/O PCI BARs on non x86-64
architectures. Whether they function depends on the host PCI host bridge
support - previously they would be rejected even if the driver did not use
these BARs. 
* Command line groups were adjusted to ensure that at least one payload
parameter was provided if any other VM parameters provided. 

## v42.0

### SVE/SVE2 Support on AArch64
The SVE and SVE2 feature bits are now propagated through to the guest on
AArch64. 

### Notable Bug Fixes
* Reduce latency notification when rate limited
* Fix virtio-console resizing
* Fix resizing when console uses TTY
* Avoid deadlock in PCI BAR reprogramming that can occur when adding a new
virtio device to a VM that has been restored
* Fix console resizing after VM restore 
* Fix memory resize error due to incorrect bounds checks

Fixes: #10723