### PR TITLE
image: bump mariner guest version to 3.0

### DIFF
--- a/tools/osbuilder/rootfs-builder/cbl-mariner/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/Dockerfile.in
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ARG IMAGE_REGISTRY=mcr.microsoft.com
-FROM ${IMAGE_REGISTRY}/cbl-mariner/base/core:@OS_VERSION@
+FROM ${IMAGE_REGISTRY}/azurelinux/base/core:@OS_VERSION@
 
 RUN tdnf -y install \
     ca-certificates \

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 OS_NAME=cbl-mariner
-OS_VERSION=${OS_VERSION:-2.0}
+OS_VERSION=${OS_VERSION:-3.0}
 LIBC="gnu"
 PACKAGES="kata-packages-uvm"
 [ "$AGENT_INIT" = no ] && PACKAGES+=" systemd"

--- a/versions.yaml
+++ b/versions.yaml
@@ -141,7 +141,7 @@ assets:
           version: *default-image-version
         mariner:
           name: "cbl-mariner"
-          version: "2.0"
+          version: "3.0"
         nvidia-gpu:
           name: *default-image-name
           version: "jammy"


### PR DESCRIPTION
Use Mariner 3.0 (a.k.a., Azure Linux 3.0) as the Guest CI image.