### PR TITLE
versions: Bump trustee to latest

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -237,12 +237,12 @@ externals:
   coco-trustee:
     description: "Provides attestation and secret delivery components"
     url: "https://github.com/confidential-containers/trustee"
-    version: "cc5738439964cd2bd0d11bb935b4f68e01b14cd7"
+    version: "68e2a8d25dbfa012b422ff464f31d18f3afa6677"
     # image / ita_image and image_tag / ita_image_tag must be in sync
     image: "ghcr.io/confidential-containers/staged-images/kbs"
-    image_tag: "cc5738439964cd2bd0d11bb935b4f68e01b14cd7"
+    image_tag: "68e2a8d25dbfa012b422ff464f31d18f3afa6677"
     ita_image: "ghcr.io/confidential-containers/staged-images/kbs-ita-as"
-    ita_image_tag: "cc5738439964cd2bd0d11bb935b4f68e01b14cd7-x86_64"
+    ita_image_tag: "68e2a8d25dbfa012b422ff464f31d18f3afa6677-x86_64"
     toolchain: "1.76.0"
 
   crio:


### PR DESCRIPTION
This update addresses an issue with token verification for SE and SNP introduced in the last update by #10541.
Bumping the project to the latest commit resolves the issue.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>