### PR TITLE
rootfs: minor systemd file deletion cleanup

### DIFF
--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -49,30 +49,6 @@ readonly dax_header_sz=2
 # [2] - https://nvdimm.wiki.kernel.org/2mib_fs_dax
 readonly dax_alignment=2
 
-# The list of systemd units and files that are not needed in Kata Containers
-readonly -a systemd_units=(
-	"systemd-coredump@"
-	"systemd-journald"
-	"systemd-journald-dev-log"
-	"systemd-journal-flush"
-	"systemd-random-seed"
-	"systemd-timesyncd"
-	"systemd-tmpfiles-setup"
-	"systemd-udevd"
-	"systemd-udevd-control"
-	"systemd-udevd-kernel"
-	"systemd-udev-trigger"
-	"systemd-update-utmp"
-)
-
-readonly -a systemd_files=(
-	"systemd-bless-boot-generator"
-	"systemd-fstab-generator"
-	"systemd-getty-generator"
-	"systemd-gpt-auto-generator"
-	"systemd-tmpfiles-cleanup.timer"
-)
-
 # Set a default value
 AGENT_INIT=${AGENT_INIT:-no}
 SELINUX=${SELINUX:-no}
@@ -455,21 +431,6 @@ setup_selinux() {
 }
 
 setup_systemd() {
-		local mount_dir="$1"
-
-		info "Removing unneeded systemd services and sockets"
-		for u in "${systemd_units[@]}"; do
-			find "${mount_dir}" -type f \( \
-				 -name "${u}.service" -o \
-				 -name "${u}.socket" \) \
-				 -exec rm -f {} \;
-		done
-
-		info "Removing unneeded systemd files"
-		for u in "${systemd_files[@]}"; do
-			find "${mount_dir}" -type f -name "${u}" -exec rm -f {} \;
-		done
-
 		info "Creating empty machine-id to allow systemd to bind-mount it"
 		touch "${mount_dir}/etc/machine-id"
 }

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -837,7 +837,7 @@ delete_unnecessary_files()
 	info "Removing unneeded systemd services and sockets"
 	for u in "${systemd_units[@]}"; do
 		find "${ROOTFS_DIR}" \
-			-type f \
+			\( -type f -o -type l \) \
 			\( -name "${u}.service" -o -name "${u}.socket" \) \
 			-exec echo "deleting {}" \; \
 			-exec rm -f {} \;
@@ -846,7 +846,7 @@ delete_unnecessary_files()
 	info "Removing unneeded systemd files"
 	for u in "${systemd_files[@]}"; do
 		find "${ROOTFS_DIR}" \
-			-type f \
+			\( -type f -o -type l \) \
 			-name "${u}" \
 			-exec echo "deleting {}" \; \
 			-exec rm -f {} \;

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -839,6 +839,7 @@ delete_unnecessary_files()
 		find "${ROOTFS_DIR}" \
 			-type f \
 			\( -name "${u}.service" -o -name "${u}.socket" \) \
+			-exec echo "deleting {}" \; \
 			-exec rm -f {} \;
 	done
 
@@ -847,6 +848,7 @@ delete_unnecessary_files()
 		find "${ROOTFS_DIR}" \
 			-type f \
 			-name "${u}" \
+			-exec echo "deleting {}" \; \
 			-exec rm -f {} \;
 	done
 }

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -66,6 +66,29 @@ if [ "${CROSS_BUILD}" == "true" ]; then
 	fi
 fi
 
+# The list of systemd units and files that are not needed in Kata Containers
+readonly -a systemd_units=(
+	"systemd-coredump@"
+	"systemd-journald"
+	"systemd-journald-dev-log"
+	"systemd-journal-flush"
+	"systemd-random-seed"
+	"systemd-timesyncd"
+	"systemd-tmpfiles-setup"
+	"systemd-udevd"
+	"systemd-udevd-control"
+	"systemd-udevd-kernel"
+	"systemd-udev-trigger"
+	"systemd-update-utmp"
+)
+
+readonly -a systemd_files=(
+	"systemd-bless-boot-generator"
+	"systemd-fstab-generator"
+	"systemd-getty-generator"
+	"systemd-gpt-auto-generator"
+	"systemd-tmpfiles-cleanup.timer"
+)
 
 handle_error() {
 	local exit_code="${?}"
@@ -768,6 +791,8 @@ EOF
 	info "Create /etc/resolv.conf file in rootfs if not exist"
 	touch "$dns_file"
 
+	delete_unnecessary_files
+
 	info "Creating summary file"
 	create_summary_file "${ROOTFS_DIR}"
 }
@@ -805,6 +830,25 @@ detect_host_distro()
 			distro="$ID"
 			;;
 	esac
+}
+
+delete_unnecessary_files()
+{
+	info "Removing unneeded systemd services and sockets"
+	for u in "${systemd_units[@]}"; do
+		find "${ROOTFS_DIR}" \
+			-type f \
+			\( -name "${u}.service" -o -name "${u}.socket" \) \
+			-exec rm -f {} \;
+	done
+
+	info "Removing unneeded systemd files"
+	for u in "${systemd_files[@]}"; do
+		find "${ROOTFS_DIR}" \
+			-type f \
+			-name "${u}" \
+			-exec rm -f {} \;
+	done
 }
 
 main()


### PR DESCRIPTION
1. Move the deletion of systemd units and files from image_builder.sh into rootfs.sh. 

- This allows other image file formats to benefit from the deletion of unnecessary systemd units and files, not just the rootfs-image format created by image_builder.sh.
- Also, image_builder.sh was deleting these files *after* it calculated the size of the rootfs files, thus missing out on the opportunity to possibly create a smaller image file.

2. Delete symbolic links to files being deleted.
