### PR TITLE
gpu: Fix rootfs build

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -60,7 +60,7 @@ setup_nvidia-gpu-admin-tools() {
 
 	rm -rf dist
 	# Installed via pipx local python environment
-	"${HOME}"/local/bin/pyinstaller -s -F gpu-admin-tools/nvidia_gpu_tools.py
+	/usr/local/bin/pyinstaller -s -F gpu-admin-tools/nvidia_gpu_tools.py
 
 	cp dist/nvidia_gpu_tools ../destdir/sbin/.
 


### PR DESCRIPTION
The pyinstaller is located per default under /usr/local/bin some prior versions were installing it to ${HOME}.