### PR TITLE
virtiofsd: Enable build for RISC-V

### DIFF
--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -67,6 +67,7 @@ arch_to_golang()
 	case "$arch" in
 		aarch64) echo "arm64";;
 		ppc64le) echo "$arch";;
+		riscv64) echo "$arch";;
 		x86_64) echo "amd64";;
 		s390x) echo "s390x";;
 		*) die "unsupported architecture: $arch";;
@@ -198,6 +199,9 @@ get_virtiofsd_image_name() {
 	                libc="musl"
 	                ;;
 	        "ppc64le")
+	                libc="gnu"
+	                ;;
+	        "riscv64")
 	                libc="gnu"
 	                ;;
 	        "s390x")

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -39,6 +39,9 @@ case ${ARCH} in
 	"ppc64le")
 		libc="gnu"
 		;;
+	"riscv64")
+		libc="gnu"
+		;;
 	"s390x")
 		libc="gnu"
 		;;

--- a/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
@@ -34,6 +34,7 @@ RUN ARCH=$(uname -m); \
        	case "${ARCH}" in \
             "aarch64") rust_arch="${ARCH}"; libc="musl"; arch_libc="" ;; \
             "ppc64le") rust_arch="powerpc64le"; libc="gnu"; arch_libc=${rust_arch}-linux-${libc}; extra_rust_flags="" ;; \
+            "riscv64") rust_arch="riscv64gc"; libc="gnu"; arch_libc=${ARCH}-linux-${libc}; extra_rust_flags="" ;; \
             "x86_64") rust_arch="${ARCH}"; libc="musl"; arch_libc="" ;; \
             "s390x") rust_arch="${ARCH}"; libc="gnu"; arch_libc=${rust_arch}-linux-${libc}; extra_rust_flags="" ;; \
             *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \


### PR DESCRIPTION
With this change, `virtiofsd` (gnu target) could be built and then to be used with other components.

Depends: #10741
Fixes: #10739