### PR TITLE
virtiofsd: Update ubuntu to 22.04 for gnu target

### DIFF
--- a/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ARG RUST_TOOLCHAIN
 


### PR DESCRIPTION
With ubuntu 20.04 image, `virtiofsd` gnu target couldn't be built due to "unsupported ISA subset z" reported by "cc".

Updating to ubuntu 24.04 image addresses this problem.

Relates: #10739