### PR TITLE
agent: mounts: Mount configfs into the container

### DIFF
--- a/src/agent/README.md
+++ b/src/agent/README.md
@@ -125,6 +125,7 @@ The kata agent has the ability to configure agent options in guest kernel comman
 | `agent.debug_console` | Debug console flag | Allow to connect guest OS running inside hypervisor Connect using `kata-runtime exec <sandbox-id>` | boolean | `false` |
 | `agent.debug_console_vport` | Debug console port | Allow to specify the `vsock` port to connect the debugging console | integer | `0` |
 | `agent.devmode` | Developer mode | Allow the agent process to coredump | boolean | `false` |
+| `agent.expose_configfs` | `expose-configs` configuration | Whether `/sys/kernel/config` is exposed to the container | boolean | `false` |
 | `agent.guest_components_rest_api` | `api-server-rest` configuration | Select the features that the API Server Rest attestation component will run with. Valid values are `all`, `attestation`, `resource` | string | `resource` |
 | `agent.guest_components_procs` | guest-components processes | Attestation-related processes that should be spawned as children of the guest. Valid values are `none`, `attestation-agent`, `confidential-data-hub` (implies `attestation-agent`), `api-server-rest` (implies `attestation-agent` and `confidential-data-hub`) | string | `api-server-rest` |
 | `agent.hotplug_timeout` | Hotplug timeout | Allow to configure hotplug timeout(seconds) of block devices | integer | `3` |

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -346,7 +346,7 @@ fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
 
     if let Some(SubCommand::Init {}) = args.subcmd {
         reset_sigpipe();
-        rustjail::container::init_child();
+        rustjail::container::init_child(AGENT_CONFIG.expose_configfs);
         exit(0);
     }
 


### PR DESCRIPTION
configfs is used to get a quote generated, and having this information available from inside the container (in case the container itself wants to attest something) is a must.

It's important to note that this is not really needed by Confidential Containers as that implies the guest-components are being used. However, that's not the only use-case we should support, and we've seen other companies already having to maintain a downstream patch (a version of this very same patch) to have configfs exposed to their attestation agents.