### PR TITLE
gpu: Add rootfs target amd64/arm64

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -147,6 +147,7 @@ jobs:
           - rootfs-image-mariner
           - rootfs-initrd
           - rootfs-initrd-confidential
+          - rootfs-nvidia-gpu-initrd
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -32,6 +32,7 @@ jobs:
           - firecracker
           - kernel
           - kernel-dragonball-experimental
+          - kernel-nvidia-gpu
           - nydus
           - qemu
           - stratovirt
@@ -88,6 +89,7 @@ jobs:
         asset:
           - rootfs-image
           - rootfs-initrd
+          - rootfs-nvidia-gpu-initrd
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}


### PR DESCRIPTION
Adding the initrd build first to get the rootfs on amd64. With that we can start to add tests.