### PR TITLE
Remove shebang from kata-runtime bash completion file

### DIFF
--- a/src/runtime/data/completions/bash/kata-runtime
+++ b/src/runtime/data/completions/bash/kata-runtime
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Intel Corporation
 #


### PR DESCRIPTION
Completion file shouldn't have a shebang

https://bugzilla.redhat.com/show_bug.cgi?id=1590425#c8