### PR TITLE
Remove shebang in non-executable completion script

### DIFF
--- a/src/runtime/data/completions/bash/kata-runtime
+++ b/src/runtime/data/completions/bash/kata-runtime
@@ -1,4 +1,3 @@
-#!/usr/bin/env bash
 #
 # Copyright (c) 2018 Intel Corporation
 #


### PR DESCRIPTION
Raised during package review [1] by rpmlint

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1590425#c8