### PR TITLE
workflows: Switch to github-hosted arm runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,7 +7,7 @@
 self-hosted-runner:
   # Labels of self-hosted runner that linter should ignore
   labels:
-    - arm64-builder
+    - ubuntu-22.04-arm
     - garm-ubuntu-2004
     - garm-ubuntu-2004-smaller
     - garm-ubuntu-2204

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -23,7 +23,7 @@ on:
 
 jobs:
   build-asset:
-    runs-on: arm64-builder
+    runs-on: ubuntu-22.04-arm
     strategy:
       matrix:
         asset:
@@ -81,7 +81,7 @@ jobs:
           if-no-files-found: error
 
   build-asset-rootfs:
-    runs-on: arm64-builder
+    runs-on: ubuntu-22.04-arm
     needs: build-asset
     strategy:
       matrix:
@@ -155,7 +155,7 @@ jobs:
           name: kata-artifacts-arm64-${{ matrix.asset}}${{ inputs.tarball-suffix }}
 
   build-asset-shim-v2:
-    runs-on: arm64-builder
+    runs-on: ubuntu-22.04-arm
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     steps:
       - name: Login to Kata Containers quay.io
@@ -210,13 +210,9 @@ jobs:
           if-no-files-found: error
 
   create-kata-tarball:
-    runs-on: arm64-builder
+    runs-on: ubuntu-22.04-arm
     needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
     steps:
-      - name: Adjust a permission for repo
-        run: |
-          sudo chown -R "$USER":"$USER" "$GITHUB_WORKSPACE"
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}

--- a/.github/workflows/publish-kata-deploy-payload-arm64.yaml
+++ b/.github/workflows/publish-kata-deploy-payload-arm64.yaml
@@ -24,12 +24,8 @@ on:
 
 jobs:
   kata-payload:
-    runs-on: arm64-builder
+    runs-on: ubuntu-22.04-arm
     steps:
-      - name: Adjust a permission for repo
-        run: |
-          sudo chown -R "$USER":"$USER" "$GITHUB_WORKSPACE"
-
       - uses: actions/checkout@v4
         with:
           ref: ${{ inputs.commit-hash }}

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -16,7 +16,7 @@ jobs:
 
   kata-deploy:
     needs: build-kata-static-tarball-arm64
-    runs-on: arm64-builder
+    runs-on: ubuntu-22.04-arm
     steps:
       - name: Login to Kata Containers docker.io
         uses: docker/login-action@v3


### PR DESCRIPTION
Now that gituhb have hosted arm runners
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/ we should try and switch our arm64 builder jobs to run on these.