### PR TITLE
workflows: Move arm static checks runner

### DIFF
--- a/.github/workflows/static-checks-self-hosted.yaml
+++ b/.github/workflows/static-checks-self-hosted.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         instance:
-          - "arm-no-k8s"
+          - "ubuntu-22.04-arm"
           - "s390x"
           - "ppc64le"
     uses: ./.github/workflows/build-checks.yaml

--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -14,6 +14,7 @@ paths:
   # Mapping of path (python) regexps to set-of-tests (sort by order of importance)
   # CI
   - "^ci/openshift-ci/": []
+  - "^\\.github/workflows/static-checks": ["static"]
   - "^\\.github/workflows/": []
   # TODO: Expand filters
   # Documentation


### PR DESCRIPTION
Now we have the build-assets running on the gh-hosted runners, try the same approach for the static-checks