### PR TITLE
metrics: Increase minval range for blogbench test

### DIFF
--- a/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
+++ b/tests/metrics/cmd/checkmetrics/ci_worker/checkmetrics-json-clh-kata-metric8.toml
@@ -56,7 +56,7 @@ description = "measure container average of blogbench write"
 checkvar = ".\"blogbench\".Results | .[] | .write.Result"
 checktype = "mean"
 midval = 2087.0
-minpercent = 20.0
+minpercent = 25.0
 maxpercent = 20.0
 
 [[metric]]


### PR DESCRIPTION
In the last couple of days I've seen the blogbench metrics write latency test on clh fail a few times e.g. https://github.com/kata-containers/kata-containers/actions/runs/12931225043/job/36067164331?pr=10779 because the latency was too low, so adjust the minimum range to tolerate quicker finishes.