### PR TITLE
Disabling Nesting Check for SNP upstream

### DIFF
--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -330,7 +330,7 @@ pflashes = []
 # that it is running on top a VMM. This will result in the runtime
 # behaving as it would when running on bare metal.
 #
-#disable_nesting_checks = true
+disable_nesting_checks = true
 
 # This is the msize used for 9p shares. It is the number of bytes
 # used for 9p packet payload.


### PR DESCRIPTION
Adding disable nesting_checks for SNP config file upstream. This check isn't needed for majority of SNP deployments. Was brought up in a conversation by @jepio.