### PR TITLE
disabling SEV and SNP job for nydus install

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -122,6 +122,9 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh delete-csi-driver
 
   run-k8s-tests-on-sev:
+    #Skipping the test
+    #to install nydus permanently
+    if: false
     strategy:
       fail-fast: false
       matrix:
@@ -188,6 +191,9 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
 
   run-k8s-tests-sev-snp:
+    #skipping the test to 
+    #install nydus permanently
+    if: false
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Disabling the SEV and SNP job to install nydus permanently on the AMD node.