### PR TITLE
Tests base image 20.04 -> 24.04 bump

### DIFF
--- a/tests/metrics/cpu/c-ray/Dockerfile
+++ b/tests/metrics/cpu/c-ray/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: FROM [image name]
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"

--- a/tests/metrics/density/sysbench-dockerfile/Dockerfile
+++ b/tests/metrics/density/sysbench-dockerfile/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: FROM [image name]
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"

--- a/tests/metrics/machine_learning/mobilenet_v1_bfloat16_fp32_dockerfile/Dockerfile
+++ b/tests/metrics/machine_learning/mobilenet_v1_bfloat16_fp32_dockerfile/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: FROM [image name]
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/tests/stability/stressng_dockerfile/Dockerfile
+++ b/tests/stability/stressng_dockerfile/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"


### PR DESCRIPTION
Bump metrics & stability test tools base images to not be on 20.04 whilst is EoL soon