### PR TITLE
static-build: Bump Ubuntu to 22.04 for the payloads builders

### DIFF
--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV INSTALL_IN_GOPATH=false
 # Required for libxml2-dev

--- a/tools/packaging/static-build/agent/Dockerfile
+++ b/tools/packaging/static-build/agent/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG RUST_TOOLCHAIN
 
 COPY install_libseccomp.sh /usr/bin/install_libseccomp.sh
@@ -51,6 +51,3 @@ RUN ARCH=$(uname -m); \
 	        *) echo "Unsupported architecture: ${ARCH}" && exit 1 ;; \
     	esac; \
 	rustup target add "${rust_arch}-unknown-linux-${libc}"
-
-# aarch64 requires this name -- link for all
-RUN ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"

--- a/tools/packaging/static-build/coco-guest-components/Dockerfile
+++ b/tools/packaging/static-build/coco-guest-components/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG RUST_TOOLCHAIN
 
 ENV DEBIAN_FRONTEND=noninteractive
@@ -55,6 +55,3 @@ RUN ARCH=$(uname -m); \
     	esac; \
     	echo "RUST_ARCH=${rust_arch}" > /etc/profile.d/rust.sh; \
 	rustup target add "${rust_arch}-unknown-linux-${LIBC}"
-
-# aarch64 requires this name -- link for all
-RUN ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"

--- a/tools/packaging/static-build/initramfs/Dockerfile
+++ b/tools/packaging/static-build/initramfs/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG cryptsetup_repo=${cryptsetup_repo}
@@ -13,9 +13,6 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV TZ=UTC
 RUN apt-get update &&\
-    apt-get --no-install-recommends install -y software-properties-common &&\
-    add-apt-repository ppa:git-core/ppa -y &&\
-    apt-get update && apt-get upgrade -y && \
     apt-get --no-install-recommends install -y \
 	    apt-utils \
 	    asciidoctor \

--- a/tools/packaging/static-build/ovmf/Dockerfile
+++ b/tools/packaging/static-build/ovmf/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
@@ -14,15 +14,9 @@ RUN apt-get update && \
         git \
         iasl  \
         make \
-        python \
+        nasm \
         python3 \
         python3-distutils \
+        python-is-python3 \
         uuid-dev && \
-    apt-get clean && rm -rf /var/lib/lists/ && \
-    cd /tmp && curl -fsLO https://www.nasm.us/pub/nasm/releasebuilds/2.15.05/nasm-2.15.05.tar.gz && \
-    tar xf nasm-2.15.05.tar.gz && \
-    cd nasm-2.15.05 && \
-    ./configure && \
-    make -j"$(nproc)" && \
-    make install && \
-    cd /tmp && rm -r nasm-2.15.05*
+    apt-get clean && rm -rf /var/lib/lists/

--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 ENV GO_HOME="/opt"
@@ -58,6 +58,3 @@ RUN ARCH=$(uname -m); \
     curl -OL "https://storage.googleapis.com/golang/go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
     tar -C "${GO_HOME}" -xzf "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz" && \
     rm "go${GO_VERSION}.${kernelname}-${goarch}.tar.gz"
-        
-# aarch64 requires this name -- link for all
-RUN ln -s /usr/bin/musl-gcc "/usr/bin/$(uname -m)-linux-musl-gcc"

--- a/tools/packaging/static-build/tools/Dockerfile
+++ b/tools/packaging/static-build/tools/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 ARG GO_TOOLCHAIN
 ARG RUST_TOOLCHAIN
 


### PR DESCRIPTION
As Ubuntu 20.04 will reach its EOL in April, let's start moving away from it as soon as possible.