### PR TITLE
rootfs: add sudo

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -439,7 +439,7 @@ build_rootfs_distro()
 	fi
 
 	if [ -d "${ROOTFS_DIR}" ] && [ "${ROOTFS_DIR}" != "/" ]; then
-		rm -rf "${ROOTFS_DIR}"/*
+		sudo rm -rf "${ROOTFS_DIR}"/*
 	else
 		mkdir -p ${ROOTFS_DIR}
 	fi

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -50,6 +50,7 @@ RUN apt-get update && \
     xz-utils \
     pip \
     python3-dev \
+    sudo \
     libclang-dev \
     zstd && \
     apt-get clean && rm -rf /var/lib/apt/lists/&& \


### PR DESCRIPTION
Consecutive runs of make rootfs-* failed because one needs sudo right to remove the root files from a rootfs.