### PR TITLE
Fix virtio-net-ccw

### DIFF
--- a/src/agent/src/ccw.rs
+++ b/src/agent/src/ccw.rs
@@ -15,7 +15,7 @@ use anyhow::anyhow;
 //   - <xxxx> is the device number (0000-ffff; leading zeroes can be omitted,
 //      e.g. 3 instead of 0003).
 // [1] https://www.ibm.com/docs/en/linuxonibm/pdf/lku4dd04.pdf
-// [2] https://qemu.readthedocs.io/en/latest/system/s390x/css.html
+// [2] https://qemu.readthedocs.io/en/master/system/s390x/css.html
 
 // Maximum subchannel set ID
 const SUBCHANNEL_SET_MAX: u8 = 3;

--- a/src/agent/src/device/network_device_handler.rs
+++ b/src/agent/src/device/network_device_handler.rs
@@ -3,35 +3,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
-use crate::device::pcipath_to_sysfs;
+#[cfg(target_arch = "s390x")]
+use crate::ccw;
 use crate::linux_abi::*;
-use crate::pci;
 use crate::sandbox::Sandbox;
 use crate::uevent::{wait_for_uevent, Uevent, UeventMatcher};
+#[cfg(not(target_arch = "s390x"))]
+use crate::{device::pcipath_to_sysfs, pci};
 use anyhow::{anyhow, Result};
 use regex::Regex;
 use std::fs;
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
-pub async fn wait_for_net_interface(
-    sandbox: &Arc<Mutex<Sandbox>>,
-    pcipath: &pci::Path,
-) -> Result<()> {
-    let root_bus_sysfs = format!("{}{}", SYSFS_DIR, create_pci_root_bus_path());
-    let sysfs_rel_path = pcipath_to_sysfs(&root_bus_sysfs, pcipath)?;
-
-    let matcher = NetPciMatcher::new(&sysfs_rel_path);
-
+fn check_existing(re: Regex) -> Result<bool> {
     // Check if the interface is already added in case network is cold-plugged
     // or the uevent loop is started before network is added.
-    // We check for the pci deive in the sysfs directory for network devices.
-    let pattern = format!(
-        r"[./]+{}/[a-z0-9/]*net/[a-z0-9/]*",
-        matcher.devpath.as_str()
-    );
-    let re = Regex::new(&pattern).expect("BUG: Failed to compile regex for NetPciMatcher");
-
+    // We check for the device in the sysfs directory for network devices.
     for entry in fs::read_dir(SYSFS_NET_PATH)? {
         let entry = entry?;
         let path = entry.path();
@@ -41,19 +29,41 @@ pub async fn wait_for_net_interface(
             .ok_or_else(|| anyhow!("Expected symlink in dir {}", SYSFS_NET_PATH))?;
 
         if re.is_match(target_path_str) {
-            return Ok(());
+            return Ok(true);
         }
     }
+    Ok(false)
+}
+
+#[cfg(not(target_arch = "s390x"))]
+pub async fn wait_for_pci_net_interface(
+    sandbox: &Arc<Mutex<Sandbox>>,
+    pcipath: &pci::Path,
+) -> Result<()> {
+    let root_bus_sysfs = format!("{}{}", SYSFS_DIR, create_pci_root_bus_path());
+    let sysfs_rel_path = pcipath_to_sysfs(&root_bus_sysfs, pcipath)?;
+    let matcher = NetPciMatcher::new(&sysfs_rel_path);
+    let pattern = format!(
+        r"[./]+{}/[a-z0-9/]*net/[a-z0-9/]*",
+        matcher.devpath.as_str()
+    );
+    let re = Regex::new(&pattern).expect("BUG: Failed to compile regex for NetPciMatcher");
+    if check_existing(re)? {
+        return Ok(());
+    }
+
     let _uev = wait_for_uevent(sandbox, matcher).await?;
 
     Ok(())
 }
 
+#[cfg(not(target_arch = "s390x"))]
 #[derive(Debug)]
 pub struct NetPciMatcher {
     devpath: String,
 }
 
+#[cfg(not(target_arch = "s390x"))]
 impl NetPciMatcher {
     pub fn new(relpath: &str) -> NetPciMatcher {
         let root_bus = create_pci_root_bus_path();
@@ -64,9 +74,52 @@ impl NetPciMatcher {
     }
 }
 
+#[cfg(not(target_arch = "s390x"))]
 impl UeventMatcher for NetPciMatcher {
     fn is_match(&self, uev: &Uevent) -> bool {
         uev.devpath.starts_with(self.devpath.as_str())
+            && uev.subsystem == "net"
+            && !uev.interface.is_empty()
+            && uev.action == "add"
+    }
+}
+
+#[cfg(target_arch = "s390x")]
+pub async fn wait_for_ccw_net_interface(
+    sandbox: &Arc<Mutex<Sandbox>>,
+    device: &ccw::Device,
+) -> Result<()> {
+    let matcher = NetCcwMatcher::new(CCW_ROOT_BUS_PATH, device);
+    if check_existing(matcher.re.clone())? {
+        return Ok(());
+    }
+    let _uev = wait_for_uevent(sandbox, matcher).await?;
+    Ok(())
+}
+
+#[cfg(target_arch = "s390x")]
+#[derive(Debug)]
+struct NetCcwMatcher {
+    re: Regex,
+}
+
+#[cfg(target_arch = "s390x")]
+impl NetCcwMatcher {
+    pub fn new(root_bus_path: &str, device: &ccw::Device) -> Self {
+        let re = format!(
+            r"{}/0\.[0-3]\.[0-9a-f]{{1,4}}/{}/virtio[0-9]+/net/",
+            root_bus_path, device
+        );
+        NetCcwMatcher {
+            re: Regex::new(&re).expect("BUG: failed to compile NetCCWMatcher regex"),
+        }
+    }
+}
+
+#[cfg(target_arch = "s390x")]
+impl UeventMatcher for NetCcwMatcher {
+    fn is_match(&self, uev: &Uevent) -> bool {
+        self.re.is_match(&uev.devpath)
             && uev.subsystem == "net"
             && !uev.interface.is_empty()
             && uev.action == "add"
@@ -77,6 +130,7 @@ impl UeventMatcher for NetPciMatcher {
 mod tests {
     use super::*;
 
+    #[cfg(not(target_arch = "s390x"))]
     #[tokio::test]
     #[allow(clippy::redundant_clone)]
     async fn test_net_pci_matcher() {
@@ -110,5 +164,35 @@ mod tests {
         assert!(matcher_c.is_match(&uev_c));
         assert!(!matcher_a.is_match(&uev_c));
         assert!(!matcher_b.is_match(&uev_c));
+    }
+
+    #[cfg(target_arch = "s390x")]
+    #[tokio::test]
+    async fn test_net_ccw_matcher() {
+        let dev_a = ccw::Device::new(0, 1).unwrap();
+        let dev_b = ccw::Device::new(1, 2).unwrap();
+
+        let mut uev_a = crate::uevent::Uevent::default();
+        uev_a.action = crate::linux_abi::U_EVENT_ACTION_ADD.to_string();
+        uev_a.subsystem = String::from("net");
+        uev_a.interface = String::from("eth0");
+        uev_a.devpath = format!(
+            "{}/0.0.0001/{}/virtio1/{}/{}",
+            CCW_ROOT_BUS_PATH, dev_a, uev_a.subsystem, uev_a.interface
+        );
+
+        let mut uev_b = uev_a.clone();
+        uev_b.devpath = format!(
+            "{}/0.0.0001/{}/virtio1/{}/{}",
+            CCW_ROOT_BUS_PATH, dev_b, uev_b.subsystem, uev_b.interface
+        );
+
+        let matcher_a = NetCcwMatcher::new(CCW_ROOT_BUS_PATH, &dev_a);
+        let matcher_b = NetCcwMatcher::new(CCW_ROOT_BUS_PATH, &dev_b);
+
+        assert!(matcher_a.is_match(&uev_a));
+        assert!(matcher_b.is_match(&uev_b));
+        assert!(!matcher_b.is_match(&uev_a));
+        assert!(!matcher_a.is_match(&uev_b));
     }
 }

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1002,8 +1002,8 @@ impl agent_ttrpc::AgentService for AgentService {
 
         // For network devices passed on the pci bus, check for the network interface
         // to be available first.
-        if !interface.pciPath.is_empty() {
-            let pcipath = pci::Path::from_str(&interface.pciPath)
+        if !interface.devicePath.is_empty() {
+            let pcipath = pci::Path::from_str(&interface.devicePath)
                 .map_ttrpc_err(|e| format!("Unexpected pci-path for network interface: {:?}", e))?;
 
             wait_for_net_interface(&self.sandbox, &pcipath)

--- a/src/libs/protocols/protos/types.proto
+++ b/src/libs/protocols/protos/types.proto
@@ -38,8 +38,10 @@ message Interface {
 	uint64 mtu = 4;
 	string hwAddr = 5;
 
-	// PCI path for the device (see the pci::Path (Rust) or types.PciPath (Go) type for format details)
-	string pciPath = 6;
+	// Path for the device (see the pci::Path (Rust) and types.PciPath
+	// (Go) or ccw::Device (Rust) types for format details, depending on
+	// architecture)
+	string devicePath = 6;
 
 	// Type defines the type of interface described by this structure.
 	// The expected values are the one that are defined by the netlink

--- a/src/libs/protocols/protos/types.proto
+++ b/src/libs/protocols/protos/types.proto
@@ -39,8 +39,8 @@ message Interface {
 	string hwAddr = 5;
 
 	// Path for the device (see the pci::Path (Rust) and types.PciPath
-	// (Go) or ccw::Device (Rust) types for format details, depending on
-	// architecture)
+	// (Go) or ccw::Device (Rust) and types.CcwDevice (Go) types for
+	// format details, depending on architecture)
 	string devicePath = 6;
 
 	// Type defines the type of interface described by this structure.

--- a/src/runtime-rs/crates/agent/src/kata/trans.rs
+++ b/src/runtime-rs/crates/agent/src/kata/trans.rs
@@ -188,7 +188,7 @@ impl From<Interface> for types::Interface {
             IPAddresses: trans_vec(from.ip_addresses),
             mtu: from.mtu,
             hwAddr: from.hw_addr,
-            pciPath: from.pci_addr,
+            devicePath: from.device_path,
             type_: from.field_type,
             raw_flags: from.raw_flags,
             ..Default::default()
@@ -204,7 +204,7 @@ impl From<types::Interface> for Interface {
             ip_addresses: trans_vec(src.IPAddresses),
             mtu: src.mtu,
             hw_addr: src.hwAddr,
-            pci_addr: src.pciPath,
+            device_path: src.devicePath,
             field_type: src.type_,
             raw_flags: src.raw_flags,
         }

--- a/src/runtime-rs/crates/agent/src/types.rs
+++ b/src/runtime-rs/crates/agent/src/types.rs
@@ -93,7 +93,7 @@ pub struct Interface {
     pub mtu: u64,
     pub hw_addr: String,
     #[serde(default)]
-    pub pci_addr: String,
+    pub device_path: String,
     #[serde(default)]
     pub field_type: String,
     #[serde(default)]

--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_dan.rs
@@ -53,7 +53,7 @@ impl NetworkInfoFromDan {
             ip_addresses,
             mtu: dan_device.network_info.interface.mtu,
             hw_addr: dan_device.guest_mac.clone(),
-            pci_addr: String::default(),
+            device_path: String::default(),
             field_type: dan_device.network_info.interface.ntype.clone(),
             raw_flags: dan_device.network_info.interface.flags & IFF_NOARP,
         };
@@ -181,7 +181,7 @@ mod tests {
             }],
             mtu: 1500,
             hw_addr: "xx:xx:xx:xx:xx".to_owned(),
-            pci_addr: String::default(),
+            device_path: String::default(),
             field_type: "tuntap".to_owned(),
             raw_flags: 0,
         };

--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
@@ -44,7 +44,7 @@ impl NetworkInfoFromLink {
                 ip_addresses: addrs.clone(),
                 mtu: attrs.mtu as u64,
                 hw_addr: hw_addr.to_string(),
-                pci_addr: Default::default(),
+                device_path: Default::default(),
                 field_type: link.r#type().to_string(),
                 raw_flags: attrs.flags & libc::IFF_NOARP as u32,
             },

--- a/src/runtime/virtcontainers/endpoint.go
+++ b/src/runtime/virtcontainers/endpoint.go
@@ -20,10 +20,12 @@ type Endpoint interface {
 	HardwareAddr() string
 	Type() EndpointType
 	PciPath() vcTypes.PciPath
+	CcwDevice() *vcTypes.CcwDevice
 	NetworkPair() *NetworkInterfacePair
 
 	SetProperties(NetworkInfo)
 	SetPciPath(vcTypes.PciPath)
+	SetCcwDevice(vcTypes.CcwDevice)
 	Attach(context.Context, *Sandbox) error
 	Detach(ctx context.Context, netNsCreated bool, netNsPath string) error
 	HotAttach(context.Context, *Sandbox) error

--- a/src/runtime/virtcontainers/ipvlan_endpoint.go
+++ b/src/runtime/virtcontainers/ipvlan_endpoint.go
@@ -22,6 +22,7 @@ var ipvlanTrace = getNetworkTrace(IPVlanEndpointType)
 type IPVlanEndpoint struct {
 	EndpointType       EndpointType
 	PCIPath            vcTypes.PciPath
+	CCWDevice          *vcTypes.CcwDevice
 	EndpointProperties NetworkInfo
 	NetPair            NetworkInterfacePair
 	RxRateLimiter      bool
@@ -86,6 +87,16 @@ func (endpoint *IPVlanEndpoint) PciPath() vcTypes.PciPath {
 // SetPciPath sets the PCI path of the endpoint.
 func (endpoint *IPVlanEndpoint) SetPciPath(pciPath vcTypes.PciPath) {
 	endpoint.PCIPath = pciPath
+}
+
+// CcwDevice returns the CCW device of the endpoint.
+func (endpoint *IPVlanEndpoint) CcwDevice() *vcTypes.CcwDevice {
+	return endpoint.CCWDevice
+}
+
+// SetCcwDevice sets the CCW device of the endpoint.
+func (endpoint *IPVlanEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
+	endpoint.CCWDevice = &ccwDev
 }
 
 // NetworkPair returns the network pair of the endpoint.

--- a/src/runtime/virtcontainers/macvlan_endpoint.go
+++ b/src/runtime/virtcontainers/macvlan_endpoint.go
@@ -22,6 +22,7 @@ var macvlanTrace = getNetworkTrace(MacvlanEndpointType)
 type MacvlanEndpoint struct {
 	EndpointType       EndpointType
 	PCIPath            vcTypes.PciPath
+	CCWDevice          *vcTypes.CcwDevice
 	EndpointProperties NetworkInfo
 	NetPair            NetworkInterfacePair
 	RxRateLimiter      bool
@@ -83,6 +84,16 @@ func (endpoint *MacvlanEndpoint) PciPath() vcTypes.PciPath {
 // SetPciPath sets the PCI path of the endpoint.
 func (endpoint *MacvlanEndpoint) SetPciPath(pciPath vcTypes.PciPath) {
 	endpoint.PCIPath = pciPath
+}
+
+// CcwDevice returns the CCW device of the endpoint.
+func (endpoint *MacvlanEndpoint) CcwDevice() *vcTypes.CcwDevice {
+	return endpoint.CCWDevice
+}
+
+// SetCcwDevice sets the CCW device of the endpoint.
+func (endpoint *MacvlanEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
+	endpoint.CCWDevice = &ccwDev
 }
 
 // NetworkPair returns the network pair of the endpoint.

--- a/src/runtime/virtcontainers/macvtap_endpoint.go
+++ b/src/runtime/virtcontainers/macvtap_endpoint.go
@@ -25,6 +25,7 @@ type MacvtapEndpoint struct {
 	VMFds              []*os.File
 	VhostFds           []*os.File
 	PCIPath            vcTypes.PciPath
+	CCWDevice          *vcTypes.CcwDevice
 	RxRateLimiter      bool
 	TxRateLimiter      bool
 }
@@ -110,6 +111,16 @@ func (endpoint *MacvtapEndpoint) PciPath() vcTypes.PciPath {
 // SetPciPath sets the PCI path of the endpoint.
 func (endpoint *MacvtapEndpoint) SetPciPath(pciPath vcTypes.PciPath) {
 	endpoint.PCIPath = pciPath
+}
+
+// CcwDevice returns the CCW device of the endpoint.
+func (endpoint *MacvtapEndpoint) CcwDevice() *vcTypes.CcwDevice {
+	return endpoint.CCWDevice
+}
+
+// SetCcwDevice sets the CCW device of the endpoint.
+func (endpoint *MacvtapEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
+	endpoint.CCWDevice = &ccwDev
 }
 
 // NetworkPair returns the network pair of the endpoint.

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -271,7 +271,7 @@ func generateVCNetworkStructures(ctx context.Context, endpoints []Endpoint) ([]*
 			Type:        string(endpoint.Type()),
 			RawFlags:    noarp,
 			HwAddr:      endpoint.HardwareAddr(),
-			PciPath:     endpoint.PciPath().String(),
+			DevicePath:  endpoint.PciPath().String(),
 		}
 
 		ifaces = append(ifaces, &ifc)

--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -34,6 +34,7 @@ type PhysicalEndpoint struct {
 	Driver             string
 	VendorDeviceID     string
 	PCIPath            vcTypes.PciPath
+	CCWDevice          *vcTypes.CcwDevice
 }
 
 // Properties returns the properties of the physical interface.
@@ -64,6 +65,16 @@ func (endpoint *PhysicalEndpoint) PciPath() vcTypes.PciPath {
 // SetPciPath sets the PCI path of the endpoint.
 func (endpoint *PhysicalEndpoint) SetPciPath(pciPath vcTypes.PciPath) {
 	endpoint.PCIPath = pciPath
+}
+
+// CcwDevice returns the CCW device of the endpoint.
+func (endpoint *PhysicalEndpoint) CcwDevice() *vcTypes.CcwDevice {
+	return endpoint.CCWDevice
+}
+
+// SetCcwDevice sets the CCW device of the endpoint.
+func (endpoint *PhysicalEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
+	endpoint.CCWDevice = &ccwDev
 }
 
 // SetProperties sets the properties of the physical endpoint.

--- a/src/runtime/virtcontainers/pkg/agent/protocols/types.pb.go
+++ b/src/runtime/virtcontainers/pkg/agent/protocols/types.pb.go
@@ -197,8 +197,8 @@ type Interface struct {
 	Mtu         uint64       `protobuf:"varint,4,opt,name=mtu,proto3" json:"mtu,omitempty"`
 	HwAddr      string       `protobuf:"bytes,5,opt,name=hwAddr,proto3" json:"hwAddr,omitempty"`
 	// Path for the device (see the pci::Path (Rust) and types.PciPath
-	// (Go) or ccw::Device (Rust) types for format details, depending on
-	// architecture)
+	// (Go) or ccw::Device (Rust) and types.CcwDevice (Go) types for
+	// format details, depending on architecture)
 	DevicePath string `protobuf:"bytes,6,opt,name=devicePath,proto3" json:"devicePath,omitempty"`
 	// Type defines the type of interface described by this structure.
 	// The expected values are the one that are defined by the netlink

--- a/src/runtime/virtcontainers/pkg/agent/protocols/types.pb.go
+++ b/src/runtime/virtcontainers/pkg/agent/protocols/types.pb.go
@@ -196,8 +196,10 @@ type Interface struct {
 	IPAddresses []*IPAddress `protobuf:"bytes,3,rep,name=IPAddresses,proto3" json:"IPAddresses,omitempty"`
 	Mtu         uint64       `protobuf:"varint,4,opt,name=mtu,proto3" json:"mtu,omitempty"`
 	HwAddr      string       `protobuf:"bytes,5,opt,name=hwAddr,proto3" json:"hwAddr,omitempty"`
-	// PCI path for the device (see the pci::Path (Rust) or types.PciPath (Go) type for format details)
-	PciPath string `protobuf:"bytes,6,opt,name=pciPath,proto3" json:"pciPath,omitempty"`
+	// Path for the device (see the pci::Path (Rust) and types.PciPath
+	// (Go) or ccw::Device (Rust) types for format details, depending on
+	// architecture)
+	DevicePath string `protobuf:"bytes,6,opt,name=devicePath,proto3" json:"devicePath,omitempty"`
 	// Type defines the type of interface described by this structure.
 	// The expected values are the one that are defined by the netlink
 	// library, regarding each type of link. Here is a non exhaustive
@@ -273,9 +275,9 @@ func (x *Interface) GetHwAddr() string {
 	return ""
 }
 
-func (x *Interface) GetPciPath() string {
+func (x *Interface) GetDevicePath() string {
 	if x != nil {
-		return x.PciPath
+		return x.DevicePath
 	}
 	return ""
 }

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1942,16 +1942,7 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op Opera
 			}
 		}()
 
-		bridgeSlot, err := types.PciSlotFromInt(bridge.Addr)
-		if err != nil {
-			return err
-		}
-		devSlot, err := types.PciSlotFromString(addr)
-		if err != nil {
-			return err
-		}
-		pciPath, err := types.PciPathFromSlots(bridgeSlot, devSlot)
-		endpoint.SetPciPath(pciPath)
+		q.arch.setEndpointDevicePath(endpoint, bridge.Addr, addr)
 
 		var machine govmmQemu.Machine
 		machine, err = q.getQemuMachine()

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1959,7 +1959,7 @@ func (q *qemu) hotplugNetDevice(ctx context.Context, endpoint Endpoint, op Opera
 			return err
 		}
 		if machine.Type == QemuCCWVirtio {
-			devNoHotplug := fmt.Sprintf("fe.%x.%x", bridge.Addr, addr)
+			devNoHotplug := fmt.Sprintf("fe.%x.%v", bridge.Addr, addr)
 			return q.qmpMonitorCh.qmp.ExecuteNetCCWDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), devNoHotplug, int(q.config.NumVCPUs()))
 		}
 		return q.qmpMonitorCh.qmp.ExecuteNetPCIDeviceAdd(q.qmpMonitorCh.ctx, tap.Name, devID, endpoint.HardwareAddr(), addr, bridge.ID, romFile, int(q.config.NumVCPUs()), defaultDisableModern)

--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -304,6 +304,15 @@ func (q *qemuS390x) appendIOMMU(devices []govmmQemu.Device) ([]govmmQemu.Device,
 	return devices, fmt.Errorf("S390x does not support appending a vIOMMU")
 }
 
+func (q *qemuS390x) setEndpointDevicePath(endpoint Endpoint, bridgeAddr int, devAddr string) error {
+	ccwDev, err := types.CcwDeviceFrom(bridgeAddr, devAddr)
+	if err != nil {
+		return err
+	}
+	endpoint.SetCcwDevice(ccwDev)
+	return nil
+}
+
 func (q *qemuS390x) addDeviceToBridge(ctx context.Context, ID string, t types.Type) (string, types.Bridge, error) {
 	addr, b, err := genericAddDeviceToBridge(ctx, q.Bridges, ID, types.CCW)
 	if err != nil {

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1172,7 +1172,7 @@ func (s *Sandbox) AddInterface(ctx context.Context, inf *pbTypes.Interface) (*pb
 	}()
 
 	// Add network for vm
-	inf.PciPath = endpoints[0].PciPath().String()
+	inf.DevicePath = endpoints[0].PciPath().String()
 	result, err := s.agent.updateInterface(ctx, inf)
 	if err != nil {
 		return nil, err

--- a/src/runtime/virtcontainers/tap_endpoint.go
+++ b/src/runtime/virtcontainers/tap_endpoint.go
@@ -27,6 +27,7 @@ type TapEndpoint struct {
 	EndpointProperties NetworkInfo
 	EndpointType       EndpointType
 	PCIPath            vcTypes.PciPath
+	CCWDevice          *vcTypes.CcwDevice
 	RxRateLimiter      bool
 	TxRateLimiter      bool
 }
@@ -64,6 +65,16 @@ func (endpoint *TapEndpoint) SetPciPath(pciPath vcTypes.PciPath) {
 // NetworkPair returns the network pair of the endpoint.
 func (endpoint *TapEndpoint) NetworkPair() *NetworkInterfacePair {
 	return nil
+}
+
+// CcwDevice returns the CCW device of the endpoint.
+func (endpoint *TapEndpoint) CcwDevice() *vcTypes.CcwDevice {
+	return endpoint.CCWDevice
+}
+
+// SetCcwDevice sets the CCW device of the endpoint.
+func (endpoint *TapEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
+	endpoint.CCWDevice = &ccwDev
 }
 
 // SetProperties sets the properties for the endpoint.

--- a/src/runtime/virtcontainers/tuntap_endpoint.go
+++ b/src/runtime/virtcontainers/tuntap_endpoint.go
@@ -26,6 +26,7 @@ var tuntapTrace = getNetworkTrace(TuntapEndpointType)
 type TuntapEndpoint struct {
 	EndpointType       EndpointType
 	PCIPath            vcTypes.PciPath
+	CCWDevice          *vcTypes.CcwDevice
 	TuntapInterface    TuntapInterface
 	EndpointProperties NetworkInfo
 	NetPair            NetworkInterfacePair
@@ -61,6 +62,16 @@ func (endpoint *TuntapEndpoint) PciPath() vcTypes.PciPath {
 // SetPciPath sets the PCI path of the endpoint.
 func (endpoint *TuntapEndpoint) SetPciPath(pciPath vcTypes.PciPath) {
 	endpoint.PCIPath = pciPath
+}
+
+// CcwDevice returns the CCW device of the endpoint.
+func (endpoint *TuntapEndpoint) CcwDevice() *vcTypes.CcwDevice {
+	return endpoint.CCWDevice
+}
+
+// SetCcwDevice sets the CCW device of the endpoint.
+func (endpoint *TuntapEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
+	endpoint.CCWDevice = &ccwDev
 }
 
 // NetworkPair returns the network pair of the endpoint.

--- a/src/runtime/virtcontainers/types/ccw.go
+++ b/src/runtime/virtcontainers/types/ccw.go
@@ -1,0 +1,42 @@
+// Copyright 2025 IBM
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package types
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// CCW bus ID follow the format <xx>.<d>.<xxxx> [1, p. 11], where
+//   - <xx> is the channel subsystem ID, which is always 0 from the guest side, but different from
+//     the host side, e.g. 0xfe for virtio-*-ccw [1, p. 435],
+//   - <d> is the subchannel set ID, which ranges from 0-3 [2], and
+//   - <xxxx> is the device number (0000-ffff; leading zeroes can be omitted,
+//     e.g. 3 instead of 0003).
+//
+// [1] https://www.ibm.com/docs/en/linuxonibm/pdf/lku4dd04.pdf
+// [2] https://qemu.readthedocs.io/en/master/system/s390x/css.html
+const subchannelSetMax = 3
+
+type CcwDevice struct {
+	ssid  uint8
+	devno uint16
+}
+
+func CcwDeviceFrom(ssid int, devno string) (CcwDevice, error) {
+	if ssid < 0 || ssid > subchannelSetMax {
+		return CcwDevice{}, fmt.Errorf("Subchannel set ID %d should be in range [0..%d]", ssid, subchannelSetMax)
+	}
+	v, err := strconv.ParseUint(devno, 16, 16)
+	if err != nil {
+		return CcwDevice{}, fmt.Errorf("Failed to parse 0x%v as CCW device number: %v", devno, err)
+	}
+	return CcwDevice{ssid: uint8(ssid), devno: uint16(v)}, nil
+}
+
+func (dev CcwDevice) String() string {
+	return fmt.Sprintf("0.%x.%04x", dev.ssid, dev.devno)
+}

--- a/src/runtime/virtcontainers/types/ccw_test.go
+++ b/src/runtime/virtcontainers/types/ccw_test.go
@@ -1,0 +1,39 @@
+// Copyright 2025 IBM
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package types
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPciDevice(t *testing.T) {
+	assert := assert.New(t)
+
+	// Valid devices
+	dev, err := CcwDeviceFrom(0, "0000")
+	assert.NoError(err)
+	assert.Equal(dev, CcwDevice{0, 0})
+	assert.Equal(dev.String(), "0.0.0000")
+
+	dev, err = CcwDeviceFrom(3, "ffff")
+	assert.NoError(err)
+	assert.Equal(dev, CcwDevice{3, 65535})
+	assert.Equal(dev.String(), "0.3.ffff")
+
+	// Invalid devices
+	_, err = CcwDeviceFrom(4, "0000")
+	assert.Error(err)
+
+	_, err = CcwDeviceFrom(-1, "0000")
+	assert.Error(err)
+
+	_, err = CcwDeviceFrom(-1, "10000")
+	assert.Error(err)
+
+	_, err = CcwDeviceFrom(-1, "NaN")
+	assert.Error(err)
+}

--- a/src/runtime/virtcontainers/veth_endpoint.go
+++ b/src/runtime/virtcontainers/veth_endpoint.go
@@ -22,6 +22,7 @@ var vethTrace = getNetworkTrace(VethEndpointType)
 type VethEndpoint struct {
 	EndpointType       EndpointType
 	PCIPath            vcTypes.PciPath
+	CCWDevice          *vcTypes.CcwDevice
 	EndpointProperties NetworkInfo
 	NetPair            NetworkInterfacePair
 	RxRateLimiter      bool
@@ -81,6 +82,16 @@ func (endpoint *VethEndpoint) PciPath() vcTypes.PciPath {
 // SetPciPath sets the PCI path of the endpoint.
 func (endpoint *VethEndpoint) SetPciPath(pciPath vcTypes.PciPath) {
 	endpoint.PCIPath = pciPath
+}
+
+// CcwDevice returns the CCW device of the endpoint.
+func (endpoint *VethEndpoint) CcwDevice() *vcTypes.CcwDevice {
+	return endpoint.CCWDevice
+}
+
+// SetCcwDevice sets the CCW device of the endpoint.
+func (endpoint *VethEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
+	endpoint.CCWDevice = &ccwDev
 }
 
 // NetworkPair returns the network pair of the endpoint.

--- a/src/runtime/virtcontainers/vfio_endpoint.go
+++ b/src/runtime/virtcontainers/vfio_endpoint.go
@@ -18,6 +18,7 @@ type VfioEndpoint struct {
 	EndpointType       EndpointType
 	HostBDF            string
 	PCIPath            vcTypes.PciPath
+	CCWDevice          *vcTypes.CcwDevice
 	Iface              NetworkInterface
 	EndpointProperties NetworkInfo
 }
@@ -62,6 +63,16 @@ func (endpoint *VfioEndpoint) SetProperties(info NetworkInfo) {
 // SetPciPath sets the PCI path of the endpoint.
 func (endpoint *VfioEndpoint) SetPciPath(path vcTypes.PciPath) {
 	endpoint.PCIPath = path
+}
+
+// CcwDevice returns the CCW device of the endpoint.
+func (endpoint *VfioEndpoint) CcwDevice() *vcTypes.CcwDevice {
+	return endpoint.CCWDevice
+}
+
+// SetCcwDevice sets the CCW device of the endpoint.
+func (endpoint *VfioEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
+	endpoint.CCWDevice = &ccwDev
 }
 
 // Attach for VFIO endpoint

--- a/src/runtime/virtcontainers/vhostuser_endpoint.go
+++ b/src/runtime/virtcontainers/vhostuser_endpoint.go
@@ -37,6 +37,7 @@ type VhostUserEndpoint struct {
 	EndpointProperties NetworkInfo
 	EndpointType       EndpointType
 	PCIPath            vcTypes.PciPath
+	CCWDevice          *vcTypes.CcwDevice
 }
 
 // Properties returns the properties of the interface.
@@ -72,6 +73,16 @@ func (endpoint *VhostUserEndpoint) PciPath() vcTypes.PciPath {
 // SetPciPath sets the PCI path of the endpoint.
 func (endpoint *VhostUserEndpoint) SetPciPath(pciPath vcTypes.PciPath) {
 	endpoint.PCIPath = pciPath
+}
+
+// CcwDevice returns the CCW device of the endpoint.
+func (endpoint *VhostUserEndpoint) CcwDevice() *vcTypes.CcwDevice {
+	return endpoint.CCWDevice
+}
+
+// SetCcwDevice sets the CCW device of the endpoint.
+func (endpoint *VhostUserEndpoint) SetCcwDevice(ccwDev vcTypes.CcwDevice) {
+	endpoint.CCWDevice = &ccwDev
 }
 
 // NetworkPair returns the network pair of the endpoint.


### PR DESCRIPTION
The s390x architecture uses `virtio-net-ccw` instead of `virtio-net-pci`.

- Device number was formatted wrong in virtcontainers. Fix, and implement device structure like for PCI.
- Find device (by uevent or already existing) in agent, using the appropriate path for PCI or CCW.

This re-enables e.g.
```
$ docker run --runtime io.containerd.run.kata.v2 --rm busybox ping -c1 katacontainers.io
PING katacontainers.io (75.2.60.5): 56 data bytes
64 bytes from 75.2.60.5: seq=0 ttl=229 time=9.398 ms

--- katacontainers.io ping statistics ---
1 packets transmitted, 1 packets received, 0% packet loss
round-trip min/avg/max = 9.398/9.398/9.398 ms
```
on s390x :)

cc @BbolroC @hbrueckner 

e: this definitely requires forward porting to runtime-rs, but from my first glance, the virtio-net implementation seems unfinished as of now.
e: sorry for the noise, lost some routine