### PR TITLE
agent: clear log pipes if denied by policy

### DIFF
--- a/tests/integration/kubernetes/k8s-policy-logs.bats
+++ b/tests/integration/kubernetes/k8s-policy-logs.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+# Copyright (c) 2025 Microsoft Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/confidential_common.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+    auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled"
+
+    setup_common
+    get_pod_config_dir
+
+    pod_name="test-pod-hostname"
+    yaml_file="${pod_config_dir}/pod-hostname.yaml"
+    policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+
+    # Assert that ReadStreamRequest is indeed blocked.
+    [[ "$(jq .request_defaults.ReadStreamRequest "${policy_settings_dir}/genpolicy-settings.json")" == "false" ]]
+
+    auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
+}
+
+@test "Logs empty when ReadStreamRequest is blocked" {
+    kubectl apply -f "${yaml_file}"
+    kubectl wait --for jsonpath=status.phase=Succeeded --timeout=$timeout pod "$pod_name"
+
+    # Verify that (1) the logs are empty and (2) the container does not deadlock.
+    [[ "$(kubectl logs "${pod_name}")" == "" ]]
+}
+
+teardown() {
+    auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled"
+    teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -74,6 +74,7 @@ else
 		"k8s-policy-hard-coded.bats" \
 		"k8s-policy-deployment.bats" \
 		"k8s-policy-job.bats" \
+		"k8s-policy-logs.bats" \
 		"k8s-policy-pod.bats" \
 		"k8s-policy-pvc.bats" \
 		"k8s-policy-rc.bats" \


### PR DESCRIPTION
Container logs are forwarded to the agent through a unix pipe. These pipes have limited capacity and block the writer when full. If reading logs is blocked by policy, a common setup for confidential containers, the pipes fill up and eventually block the container.

This commit changes the implementation of `ReadStream` such that it returns empty log messages instead of a policy failure (in case reading log messages is forbidden by policy). As long as the runtime does not encounter a failure, it keeps pulling logs periodically. In turn, this triggers the agent to flush the pipes.

Fixes: #10680

---

#### Alternatives considered

* The agent could unconditionally pull from the pipe but still return a policy error, and the runtime could keep pulling in case of policy errors. This would arguably make the agent service correct, but would force the runtime to care about agent implementation details. I feel more strongly about the latter.
* The agent could spawn a pipe cleaning routine when it first sees a policy failure for `ReadStreamRequest`. I don't like the added agent complexity of this solution.

---

cc @sprt @gkurz @mythi 