### PR TITLE
runtime-rs: TEE support framework

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -825,6 +825,14 @@ pub struct SecurityInfo {
     #[serde(default)]
     pub confidential_guest: bool,
 
+    /// If false prefer SEV even if SEV-SNP is also available
+    #[serde(default)]
+    pub sev_snp_guest: bool,
+
+    /// Path to SNP certificates
+    #[serde(default)]
+    pub snp_certs_path: String,
+
     /// Path to OCI hook binaries in the *guest rootfs*.
     ///
     /// This does not affect host-side hooks which must instead be added to the OCI spec passed to

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -549,7 +549,7 @@ fn get_platform_cfg(guest_protection_to_use: GuestProtection) -> Option<Platform
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kata_sys_util::protection::TDXDetails;
+    use kata_sys_util::protection::{SevSnpDetails, TDXDetails};
     use kata_types::config::hypervisor::{
         BlockDeviceInfo, Hypervisor as HypervisorConfig, SecurityInfo,
     };
@@ -2180,6 +2180,8 @@ mod tests {
             minor_version: 0,
         };
 
+        let sev_snp_details = SevSnpDetails { cbitpos: 42 };
+
         #[derive(Debug)]
         struct TestData<'a> {
             use_image: bool,
@@ -2202,14 +2204,14 @@ mod tests {
                 use_image: true,
                 container_rootfs_driver: "container",
                 vm_rootfs_driver: "vm",
-                guest_protection_to_use: GuestProtection::Sev,
+                guest_protection_to_use: GuestProtection::Sev(sev_snp_details.clone()),
                 result: Ok(()),
             },
             TestData {
                 use_image: true,
                 container_rootfs_driver: "container",
                 vm_rootfs_driver: "vm",
-                guest_protection_to_use: GuestProtection::Snp,
+                guest_protection_to_use: GuestProtection::Snp(sev_snp_details.clone()),
                 result: Ok(()),
             },
             TestData {

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
@@ -508,7 +508,7 @@ pub fn guest_protection_is_tdx(guest_protection_to_use: GuestProtection) -> bool
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kata_sys_util::protection::TDXDetails;
+    use kata_sys_util::protection::{SevSnpDetails, TDXDetails};
 
     #[test]
     fn test_guest_protection_is_tdx() {
@@ -516,6 +516,8 @@ mod tests {
             major_version: 1,
             minor_version: 0,
         };
+
+        let sev_snp_details = SevSnpDetails { cbitpos: 42 };
 
         #[derive(Debug)]
         struct TestData {
@@ -537,11 +539,11 @@ mod tests {
                 result: false,
             },
             TestData {
-                protection: GuestProtection::Sev,
+                protection: GuestProtection::Sev(sev_snp_details.clone()),
                 result: false,
             },
             TestData {
-                protection: GuestProtection::Snp,
+                protection: GuestProtection::Snp(sev_snp_details.clone()),
                 result: false,
             },
             TestData {

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -956,7 +956,7 @@ fn get_ch_vcpu_tids(proc_path: &str) -> Result<HashMap<u32, u32>> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use kata_sys_util::protection::TDXDetails;
+    use kata_sys_util::protection::{SevSnpDetails, TDXDetails};
 
     #[cfg(target_arch = "x86_64")]
     use kata_sys_util::protection::TDX_SYS_FIRMWARE_DIR;
@@ -990,6 +990,8 @@ mod tests {
             minor_version: 0,
         };
 
+        let sev_snp_details = SevSnpDetails { cbitpos: 42 };
+
         #[derive(Debug)]
         struct TestData {
             value: Option<GuestProtection>,
@@ -1010,12 +1012,12 @@ mod tests {
                 result: Ok(GuestProtection::Se),
             },
             TestData {
-                value: Some(GuestProtection::Sev),
-                result: Ok(GuestProtection::Sev),
+                value: Some(GuestProtection::Sev(sev_snp_details.clone())),
+                result: Ok(GuestProtection::Sev(sev_snp_details.clone())),
             },
             TestData {
-                value: Some(GuestProtection::Snp),
-                result: Ok(GuestProtection::Snp),
+                value: Some(GuestProtection::Snp(sev_snp_details.clone())),
+                result: Ok(GuestProtection::Snp(sev_snp_details.clone())),
             },
             TestData {
                 value: Some(GuestProtection::Tdx(tdx_details.clone())),

--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -13,9 +13,9 @@ use tokio::sync::{Mutex, RwLock};
 
 use crate::{
     vhost_user_blk::VhostUserBlkDevice, BlockConfig, BlockDevice, HybridVsockDevice, Hypervisor,
-    NetworkDevice, ShareFsDevice, VfioDevice, VhostUserConfig, VhostUserNetDevice, VsockDevice,
-    KATA_BLK_DEV_TYPE, KATA_CCW_DEV_TYPE, KATA_MMIO_BLK_DEV_TYPE, KATA_NVDIMM_DEV_TYPE,
-    VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_MMIO, VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
+    NetworkDevice, ProtectionDevice, ShareFsDevice, VfioDevice, VhostUserConfig,
+    VhostUserNetDevice, VsockDevice, KATA_BLK_DEV_TYPE, KATA_CCW_DEV_TYPE, KATA_MMIO_BLK_DEV_TYPE,
+    KATA_NVDIMM_DEV_TYPE, VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_MMIO, VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
 };
 
 use super::{
@@ -250,7 +250,7 @@ impl DeviceManager {
                         return Some(device_id.to_string());
                     }
                 }
-                DeviceType::HybridVsock(_) | DeviceType::Vsock(_) => {
+                DeviceType::HybridVsock(_) | DeviceType::Vsock(_) | DeviceType::Protection(_) => {
                     continue;
                 }
             }
@@ -385,6 +385,13 @@ impl DeviceManager {
                 }
 
                 Arc::new(Mutex::new(ShareFsDevice::new(&device_id, config)))
+            }
+            DeviceConfig::ProtectionDevCfg(pconfig) => {
+                // No need to do find device for protection device.
+                Arc::new(Mutex::new(ProtectionDevice::new(
+                    device_id.clone(),
+                    pconfig,
+                )))
             }
         };
 

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+mod protection_device;
 mod vfio;
 mod vhost_user;
 pub mod vhost_user_blk;
@@ -13,6 +14,7 @@ mod virtio_fs;
 mod virtio_net;
 mod virtio_vsock;
 
+pub use protection_device::{ProtectionDevice, ProtectionDeviceConfig, SevSnpConfig};
 pub use vfio::{
     bind_device_to_host, bind_device_to_vfio, get_vfio_device, HostDevice, VfioBusMode, VfioConfig,
     VfioDevice,

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/protection_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/protection_device.rs
@@ -1,0 +1,80 @@
+// Copyright (c) 2025 Red Hat
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::{
+    device::{topology::PCIeTopology, Device, DeviceType},
+    Hypervisor as hypervisor,
+};
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+
+#[derive(Debug, Clone)]
+pub enum ProtectionDeviceConfig {
+    SevSnp(SevSnpConfig),
+}
+
+#[derive(Debug, Clone)]
+pub struct SevSnpConfig {
+    pub is_snp: bool,
+    pub cbitpos: u32,
+    pub firmware: String,
+    pub certs_path: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ProtectionDevice {
+    pub device_id: String,
+    pub config: ProtectionDeviceConfig,
+}
+
+impl ProtectionDevice {
+    pub fn new(device_id: String, config: &ProtectionDeviceConfig) -> Self {
+        Self {
+            device_id: device_id.clone(),
+            config: config.clone(),
+        }
+    }
+}
+
+#[async_trait]
+impl Device for ProtectionDevice {
+    async fn attach(
+        &mut self,
+        _pcie_topo: &mut Option<&mut PCIeTopology>,
+        h: &dyn hypervisor,
+    ) -> Result<()> {
+        h.add_device(DeviceType::Protection(self.clone()))
+            .await
+            .context("add protection device.")?;
+
+        return Ok(());
+    }
+
+    // Except for attach() and get_device_info(), the rest of Device operations
+    // don't seem to make sense for proctection device.
+    async fn detach(
+        &mut self,
+        _pcie_topo: &mut Option<&mut PCIeTopology>,
+        _h: &dyn hypervisor,
+    ) -> Result<Option<u64>> {
+        Ok(None)
+    }
+
+    async fn update(&mut self, _h: &dyn hypervisor) -> Result<()> {
+        Ok(())
+    }
+
+    async fn get_device_info(&self) -> DeviceType {
+        DeviceType::Protection(self.clone())
+    }
+
+    async fn increase_attach_count(&mut self) -> Result<bool> {
+        Ok(false)
+    }
+
+    async fn decrease_attach_count(&mut self) -> Result<bool> {
+        Ok(false)
+    }
+}

--- a/src/runtime-rs/crates/hypervisor/src/device/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/mod.rs
@@ -9,8 +9,9 @@ use std::fmt;
 use crate::device::driver::vhost_user_blk::VhostUserBlkDevice;
 use crate::{
     BlockConfig, BlockDevice, HybridVsockConfig, HybridVsockDevice, Hypervisor as hypervisor,
-    NetworkConfig, NetworkDevice, ShareFsConfig, ShareFsDevice, VfioConfig, VfioDevice,
-    VhostUserConfig, VhostUserNetDevice, VsockConfig, VsockDevice,
+    NetworkConfig, NetworkDevice, ProtectionDevice, ProtectionDeviceConfig, ShareFsConfig,
+    ShareFsDevice, VfioConfig, VfioDevice, VhostUserConfig, VhostUserNetDevice, VsockConfig,
+    VsockDevice,
 };
 use anyhow::Result;
 use async_trait::async_trait;
@@ -35,6 +36,7 @@ pub enum DeviceConfig {
     VfioCfg(VfioConfig),
     VsockCfg(VsockConfig),
     HybridVsockCfg(HybridVsockConfig),
+    ProtectionDevCfg(ProtectionDeviceConfig),
 }
 
 #[derive(Debug, Clone)]
@@ -47,6 +49,7 @@ pub enum DeviceType {
     ShareFs(ShareFsDevice),
     HybridVsock(HybridVsockDevice),
     Vsock(VsockDevice),
+    Protection(ProtectionDevice),
 }
 
 impl fmt::Display for DeviceType {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -96,7 +96,7 @@ impl DragonballInner {
                     .context("add vhost-user-net device")?;
                 Ok(DeviceType::VhostUserNetwork(dev))
             }
-            DeviceType::Vsock(_) => todo!(),
+            DeviceType::Vsock(_) | DeviceType::Protection(_) => todo!(),
         }
     }
 

--- a/src/runtime-rs/crates/resource/src/lib.rs
+++ b/src/runtime-rs/crates/resource/src/lib.rs
@@ -17,7 +17,7 @@ pub mod manager;
 mod manager_inner;
 pub mod network;
 pub mod resource_persist;
-use hypervisor::{BlockConfig, HybridVsockConfig, VsockConfig};
+use hypervisor::{BlockConfig, HybridVsockConfig, ProtectionDeviceConfig, VsockConfig};
 use network::NetworkConfig;
 pub mod rootfs;
 pub mod share_fs;
@@ -35,6 +35,7 @@ pub enum ResourceConfig {
     VmRootfs(BlockConfig),
     HybridVsock(HybridVsockConfig),
     Vsock(VsockConfig),
+    Protection(ProtectionDeviceConfig),
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -146,6 +146,11 @@ impl ResourceManagerInner {
                         .await
                         .context("do handle vsock device failed.")?;
                 }
+                ResourceConfig::Protection(p) => {
+                    do_handle_device(&self.device_manager, &DeviceConfig::ProtectionDevCfg(p))
+                        .await
+                        .context("do handle protection device failed.")?;
+                }
             };
         }
 


### PR DESCRIPTION
This PR adds `ProtectionDevice`, a new `DeviceType` to represent protection devices.

The implementation and handling of `ProtectionDevice` aims to be as similar as possible to other devices and to fit well into runtime-rs's device handling architecture.  I'd really appreciate review from @lifupan , @studychao or @Apokleos to verify that.

The PR might look like it also adds support for AMD's SEV/SEV-SNP TEEs but that's actually not a goal.  While a bulk of SEV/SEV-SNP support _is_ added parts are still missing and this work requires careful review and testing (@ryansavino ).  SEV/SEV-SNP was only used as a test case to make sure that the support framework I was creating made some sense, and I could obviously do no real testing (apart from faking detection of SEV or SEV-SNP and making sure an expected QEMU command line is emitted).

@fidencio Please take a look, I believe TDX support should be rather easy to add into this framework.