### PR TITLE
 packaging: virtiofsd: Allow building a specific commit

### DIFF
--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -50,10 +50,10 @@ pull_virtiofsd_released_binary() {
 }
 
 build_virtiofsd_from_source() {
-	echo "build viriofsd from source"
+	echo "build virtiofsd from source"
 	. /etc/profile.d/rust.sh
 
-	git clone --depth 1 --branch main ${virtiofsd_repo} virtiofsd
+	git clone --branch main ${virtiofsd_repo} virtiofsd
 	pushd virtiofsd
 
 	git reset --hard ${virtiofsd_version}


### PR DESCRIPTION
#10714 added support for building a specific commit, but due to the clone only having `--depth=1`, we can only reset to a commit if it's the latest on the `main` branch, otherwise we will get:
```
+ git clone --depth 1 --branch main https://gitlab.com/virtio-fs/virtiofsd virtiofsd
Cloning into 'virtiofsd'...
warning: redirecting to https://gitlab.com/virtio-fs/virtiofsd.git/
+ pushd virtiofsd
+ git reset --hard cecc61bca981ab42aae6ec490dfd59965e79025e
...
fatal: Could not parse object 'cecc61bca981ab42aae6ec490dfd59965e79025e'.
```