### PR TITLE
workflows: Add delete kata-deploy timeouts for crio tests

### DIFF
--- a/.github/workflows/run-k8s-tests-on-amd64.yaml
+++ b/.github/workflows/run-k8s-tests-on-amd64.yaml
@@ -105,4 +105,5 @@ jobs:
 
       - name: Delete kata-deploy
         if: always()
+        timeout-minutes: 5
         run: bash tests/integration/kubernetes/gha-run.sh cleanup


### PR DESCRIPTION
I've seen cases for the qemu, crio, k0s tests where Delete kata-deploy is still running for this test after 2 hours, and had to be manually cancelled, so let's try adding a 5m timeout to the kata-deploy delete to stop CI jobs hanging.