### PR TITLE
ci: Enable static-checks on riscv64

### DIFF
--- a/.github/workflows/static-checks-self-hosted.yaml
+++ b/.github/workflows/static-checks-self-hosted.yaml
@@ -29,6 +29,7 @@ jobs:
           - "ubuntu-22.04-arm"
           - "s390x"
           - "ppc64le"
+          - "riscv64"
     uses: ./.github/workflows/build-checks.yaml
     with:
       instance: ${{ matrix.instance }}


### PR DESCRIPTION
Draft, this requires Github Action Runners on riscv64 system to be connected as self-hosted runners and properly labled.

We will enable component by component until it can just use `build-check.yaml` directly.

We have some QEMU emulated Ubuntu 24.04.1 RISC-V instances which are capable of connecting to kata community, await AC to agree on this as a temporary solution before we get hold on hardwares are capable of running these build/test.