### PR TITLE
local-build: Do not build measured rootfs on s390x

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -89,6 +89,7 @@ setup() {
 }
 
 @test "Test we can pull an image inside the guest using trusted storage" {
+	[ "$(uname -m)" == "s390x" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/10838"
     # The image pulled in the guest will be downloaded and unpacked in the `/run/kata-containers/image` directory.
     # The tests will use `cryptsetup` to encrypt a block device and mount it at `/run/kata-containers/image`.
 
@@ -136,6 +137,7 @@ setup() {
 }
 
 @test "Test we cannot pull a large image that pull time exceeds createcontainer timeout inside the guest" {
+	[ "$(uname -m)" == "s390x" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/10838"
 
     storage_config=$(mktemp "${BATS_FILE_TMPDIR}/$(basename "${storage_config_template}").XXX")
     local_device=$(create_loop_device)
@@ -178,6 +180,7 @@ setup() {
 }
 
 @test "Test we can pull a large image inside the guest with large createcontainer timeout" {
+	[ "$(uname -m)" == "s390x" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/10838"
 
     if [ "${KATA_HYPERVISOR}" = "qemu-coco-dev" ] && [ "${KBS_INGRESS}" = "aks" ]; then
         skip "skip this specific one due to issue https://github.com/kata-containers/kata-containers/issues/10299"

--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -12,6 +12,9 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 check_and_skip() {
 	case "${KATA_HYPERVISOR}" in
 		qemu-tdx|qemu-coco-dev)
+			if [ "$(uname -m)" == "s390x" ]; then
+				skip "measured rootfs tests not implemented for s390x"
+			fi
 			return
 			;;
 		*)

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -389,7 +389,11 @@ install_image() {
 
 #Install guest image for confidential guests
 install_image_confidential() {
-	export MEASURED_ROOTFS=yes
+	if [ "${ARCH}" == "s390x" ]; then
+		export MEASURED_ROOTFS=no
+	else
+		export MEASURED_ROOTFS=yes
+	fi
 	export PULL_TYPE=default
 	install_image "confidential"
 }
@@ -467,7 +471,11 @@ install_initrd() {
 
 #Install guest initrd for confidential guests
 install_initrd_confidential() {
-	export MEASURED_ROOTFS=yes
+	if [ "${ARCH}" == "s390x" ]; then
+		export MEASURED_ROOTFS=no
+	else
+		export MEASURED_ROOTFS=yes
+	fi
 	export PULL_TYPE=default
 	install_initrd "confidential"
 }
@@ -610,7 +618,11 @@ install_kernel() {
 }
 
 install_kernel_confidential() {
-	export MEASURED_ROOTFS=yes
+	if [ "${ARCH}" == "s390x" ]; then
+		export MEASURED_ROOTFS=no
+	else
+		export MEASURED_ROOTFS=yes
+	fi
 
 	install_kernel_helper \
 		"assets.kernel.confidential" \
@@ -850,6 +862,9 @@ install_shimv2() {
 	export GO_VERSION
 	export RUST_VERSION
 	export MEASURED_ROOTFS
+	if [ "${ARCH}" == "s390x" ]; then
+		export MEASURED_ROOTFS=no
+	fi
 
 	DESTDIR="${destdir}" PREFIX="${prefix}" "${shimv2_builder}"
 }


### PR DESCRIPTION
IBM SE has encountered a boot failure issue since the guest OS was upgraded to Ubuntu 22.04. We identified that the issue is caused by the initramfs, which is built for the measured rootfs scenario. IBM SE ensures that the initrd is measured by genprotimg and verified by the ultravisor. To address this, let’s skip building the measured rootfs on s390x. This PR also skips end-to-end tests for trusted storage for IBM SE.

For reviewers: the changes are already verified at https://github.com/kata-containers/kata-containers/actions/runs/13150558902/job/36740406368

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>

FYI: @hbrueckner 

