### PR TITLE
tests: disable k8s-policy-job.bats on coco-dev

### DIFF
--- a/tests/integration/kubernetes/k8s-policy-job.bats
+++ b/tests/integration/kubernetes/k8s-policy-job.bats
@@ -9,6 +9,10 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+    if [ "${KATA_HYPERVISOR}" == "qemu-coco-dev" ]; then
+        skip "Test not stable on qemu-coco-dev. See issue #10616"
+    fi
+
     auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled."
 
     get_pod_config_dir
@@ -141,6 +145,10 @@ test_job_policy_error() {
 }
 
 teardown() {
+    if [ "${KATA_HYPERVISOR}" == "qemu-coco-dev" ]; then
+        skip "Test not stable on qemu-coco-dev. See issue #10616"
+    fi
+
     auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled."
 
     # Debugging information


### PR DESCRIPTION
k8s-policy-job is modeled after the older k8s-job, and it appears that both of them fail occasionally on coco-dev.