### PR TITLE
runtime-rs: Reduce the number of duplicate log entries being printed

### DIFF
--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -111,6 +111,7 @@ impl KataAgent {
         );
         let sock =
             sock::new(&inner.socket_address, inner.config.server_port).context("new sock")?;
+        info!(sl!(), "try to connect agent server through {:?}", sock);
         let stream = sock.connect(&config).await.context("connect")?;
         let fd = stream.into_raw_fd();
         info!(

--- a/src/runtime-rs/crates/agent/src/sock/hybrid_vsock.rs
+++ b/src/runtime-rs/crates/agent/src/sock/hybrid_vsock.rs
@@ -4,8 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::os::unix::prelude::AsRawFd;
-
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use tokio::{
@@ -33,32 +31,43 @@ impl HybridVsock {
 #[async_trait]
 impl Sock for HybridVsock {
     async fn connect(&self, config: &ConnectConfig) -> Result<Stream> {
+        let mut last_err = None;
         let retry_times = config.reconnect_timeout_ms / config.dial_timeout_ms;
+
         for i in 0..retry_times {
             match connect_helper(&self.uds, self.port).await {
                 Ok(stream) => {
-                    info!(
-                        sl!(),
-                        "connect success on {} current client fd {}",
-                        i,
-                        stream.as_raw_fd()
-                    );
+                    info!(sl!(), "hybrid vsock: connected to {:?}", self);
                     return Ok(Stream::Unix(stream));
                 }
                 Err(err) => {
-                    debug!(sl!(), "connect on {} err : {:?}", i, err);
+                    trace!(
+                        sl!(),
+                        "hybrid vsock: failed to connect to {:?}, err {:?}, attempts {}, will retry after {} ms",
+                        self,
+                        err,
+                        i,
+                        config.dial_timeout_ms,
+                    );
+                    last_err = Some(err);
                     tokio::time::sleep(std::time::Duration::from_millis(config.dial_timeout_ms))
                         .await;
                     continue;
                 }
             }
         }
-        Err(anyhow!("cannot connect to agent ttrpc server {:?}", config))
+
+        // Safe to unwrap the last_err, as this line will be unreachable if
+        // no errors occurred.
+        Err(anyhow!(
+            "hybrid vsock: failed to connect to {:?}, err {:?}",
+            self,
+            last_err.unwrap()
+        ))
     }
 }
 
 async fn connect_helper(uds: &str, port: u32) -> Result<UnixStream> {
-    info!(sl!(), "connect uds {:?} port {}", &uds, port);
     let mut stream = UnixStream::connect(&uds).await.context("connect")?;
     stream
         .write_all(format!("connect {}\n", port).as_bytes())

--- a/src/runtime-rs/crates/agent/src/sock/mod.rs
+++ b/src/runtime-rs/crates/agent/src/sock/mod.rs
@@ -105,7 +105,7 @@ enum SockType {
 }
 
 #[async_trait]
-pub trait Sock: Send + Sync {
+pub trait Sock: Send + Sync + std::fmt::Debug {
     async fn connect(&self, config: &ConnectConfig) -> Result<Stream>;
 }
 


### PR DESCRIPTION
When connecting to guest through vsock, a log is printed for each failure.
The failure comes from two main reasons: (1) the guest is not ready or (2)
some real errors happen. Printing logs for the first case leads to log
clutter, and your logs will like this:

```
Feb 07 02:47:24 ubuntu containerd[520]: {"msg":"connect uds \"/run/kata/...
Feb 07 02:47:24 ubuntu containerd[520]: {"msg":"connect uds \"/run/kata/...
Feb 07 02:47:24 ubuntu containerd[520]: {"msg":"connect uds \"/run/kata/...
Feb 07 02:47:24 ubuntu containerd[520]: {"msg":"connect uds \"/run/kata/...
Feb 07 02:47:24 ubuntu containerd[520]: {"msg":"connect uds \"/run/kata/...
```

To avoid this, the sock implmentations save the last error and return it
after all retries are exhausted. Users are able to check all errors by
setting the log level to trace.

Reorganize the log format to "{sock type}: {message}" to make it clearer.
Apart from that, errors return by the socks use `self`, instead of
`ConnectConfig`, since the `ConnectConfig` doesn't provide any useful
information.

Disable infinite loop for the log forwarder. There is retry logic in the
sock implmentations. We can consider the agent-log unavailable if
`sock.connect()` encounters an error.

Fixes: #10847