### PR TITLE
Clean the config block_device_cache_direct of runtime-rs

### DIFF
--- a/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
+++ b/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
@@ -172,6 +172,11 @@ default_bridges = @DEFBRIDGES@
 # rootfs is backed by a block device.
 block_device_driver = "virtio-blk-pci"
 
+# Specifies cache-related options for block devices.
+# Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
+# Default false
+#block_device_cache_direct = true
+
 # Enable huge pages for VM RAM, default false
 # Enabling this will result in the VM memory
 # being allocated using huge pages.

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -204,6 +204,11 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are cached in guest and never expire.
 virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
+# Specifies cache-related options for block devices.
+# Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
+# Default false
+#block_device_cache_direct = true
+
 # Enable huge pages for VM RAM, default false
 # Enabling this will result in the VM memory
 # being allocated using huge pages.

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -122,11 +122,6 @@ block_device_driver = "@DEFBLOCKSTORAGEDRIVER_FC@"
 #block_device_cache_set = true
 
 # Specifies cache-related options for block devices.
-# Denotes whether use of O_DIRECT (bypass the host page cache) is enabled.
-# Default false
-#block_device_cache_direct = true
-
-# Specifies cache-related options for block devices.
 # Denotes whether flush requests for the device are ignored.
 # Default false
 #block_device_cache_noflush = true

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
@@ -27,7 +27,7 @@ pub struct CloudHypervisorInner {
     pub(crate) api_socket: Option<UnixStream>,
     pub(crate) extra_args: Option<Vec<String>>,
 
-    pub(crate) config: Option<HypervisorConfig>,
+    pub(crate) config: HypervisorConfig,
 
     pub(crate) process: Option<Child>,
     pub(crate) pid: Option<u32>,
@@ -101,7 +101,7 @@ impl CloudHypervisorInner {
             process: None,
             pid: None,
 
-            config: None,
+            config: Default::default(),
             state: VmmState::NotReady,
             timeout_secs: CH_DEFAULT_TIMEOUT_SECS as i32,
             id: String::default(),
@@ -124,11 +124,11 @@ impl CloudHypervisorInner {
     }
 
     pub fn set_hypervisor_config(&mut self, config: HypervisorConfig) {
-        self.config = Some(config);
+        self.config = config;
     }
 
     pub fn hypervisor_config(&self) -> HypervisorConfig {
-        self.config.clone().unwrap_or_default()
+        self.config.clone()
     }
 }
 
@@ -168,7 +168,7 @@ impl Persist for CloudHypervisorInner {
         let (tx, rx) = channel(true);
 
         let mut ch = Self {
-            config: Some(hypervisor_state.config),
+            config: hypervisor_state.config,
             state: VmmState::NotReady,
             id: hypervisor_state.id,
             vm_path: hypervisor_state.vm_path,

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -315,7 +315,8 @@ impl CloudHypervisorInner {
             .ok_or("missing socket")
             .map_err(|e| anyhow!(e))?;
 
-        let disk_config = DiskConfig::try_from(device.config)?;
+        let mut disk_config = DiskConfig::try_from(device.config.clone())?;
+        disk_config.direct = self.config.blockdev_info.block_device_cache_direct;
 
         let response = cloud_hypervisor_vm_blockdev_add(
             socket.try_clone().context("failed to clone socket")?,

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -117,11 +117,7 @@ impl CloudHypervisorInner {
     }
 
     async fn get_kernel_params(&self) -> Result<String> {
-        let cfg = self
-            .config
-            .as_ref()
-            .ok_or("no hypervisor config for CH")
-            .map_err(|e| anyhow!(e))?;
+        let cfg = &self.config;
 
         let enable_debug = cfg.debug_info.enable_debug;
 
@@ -200,15 +196,10 @@ impl CloudHypervisorInner {
 
         let vsock_socket_path = get_vsock_path(&self.id)?;
 
-        let hypervisor_config = self
-            .config
-            .as_ref()
-            .ok_or("no hypervisor config for CH")
-            .map_err(|e| anyhow!(e))?;
-
         debug!(
             sl!(),
-            "generic Hypervisor configuration: {:?}", hypervisor_config
+            "generic Hypervisor configuration: {:?}",
+            self.config.clone()
         );
 
         let kernel_params = self.get_kernel_params().await?;
@@ -217,7 +208,7 @@ impl CloudHypervisorInner {
             kernel_params,
             sandbox_path,
             vsock_socket_path,
-            cfg: hypervisor_config.clone(),
+            cfg: self.config.clone(),
             guest_protection_to_use: self.guest_protection_to_use.clone(),
             shared_fs_devices,
             network_devices,
@@ -324,11 +315,7 @@ impl CloudHypervisorInner {
     async fn cloud_hypervisor_launch(&mut self, _timeout_secs: i32) -> Result<()> {
         self.cloud_hypervisor_ensure_not_launched().await?;
 
-        let cfg = self
-            .config
-            .as_ref()
-            .ok_or("no hypervisor config for CH")
-            .map_err(|e| anyhow!(e))?;
+        let cfg = &self.config;
 
         let debug = cfg.debug_info.enable_debug;
 
@@ -338,13 +325,7 @@ impl CloudHypervisorInner {
 
         let _ = std::fs::remove_file(api_socket_path.clone());
 
-        let binary_path = self
-            .config
-            .as_ref()
-            .ok_or("no hypervisor config for CH")
-            .map_err(|e| anyhow!(e))?
-            .path
-            .to_string();
+        let binary_path = cfg.path.to_string();
 
         let path = Path::new(&binary_path).canonicalize()?;
 
@@ -567,11 +548,7 @@ impl CloudHypervisorInner {
     // call, if confidential_guest is set, a confidential
     // guest will be created.
     async fn handle_guest_protection(&mut self) -> Result<()> {
-        let cfg = self
-            .config
-            .as_ref()
-            .ok_or("missing hypervisor config")
-            .map_err(|e| anyhow!(e))?;
+        let cfg = &self.config;
 
         let confidential_guest = cfg.security_info.confidential_guest;
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -852,13 +852,13 @@ struct BlockBackend {
 }
 
 impl BlockBackend {
-    fn new(id: &str, path: &str) -> BlockBackend {
+    fn new(id: &str, path: &str, cache_direct: bool) -> BlockBackend {
         BlockBackend {
             driver: "file".to_owned(),
             id: id.to_owned(),
             path: path.to_owned(),
             aio: "threads".to_owned(),
-            cache_direct: true,
+            cache_direct,
             cache_no_flush: false,
             read_only: true,
         }
@@ -1959,9 +1959,9 @@ impl<'a> QemuCmdLine<'a> {
         Ok(())
     }
 
-    pub fn add_block_device(&mut self, device_id: &str, path: &str) -> Result<()> {
+    pub fn add_block_device(&mut self, device_id: &str, path: &str, is_direct: bool) -> Result<()> {
         self.devices
-            .push(Box::new(BlockBackend::new(device_id, path)));
+            .push(Box::new(BlockBackend::new(device_id, path, is_direct)));
         let devno = get_devno_ccw(&mut self.ccw_subchannel, device_id);
         self.devices.push(Box::new(DeviceVirtioBlk::new(
             device_id,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -109,6 +109,7 @@ impl QemuInner {
                         "ccw" => cmdline.add_block_device(
                             block_dev.device_id.as_str(),
                             &block_dev.config.path_on_host,
+                            self.config.blockdev_info.block_device_cache_direct,
                         )?,
                         unsupported => {
                             info!(sl!(), "unsupported block device driver: {}", unsupported)


### PR DESCRIPTION
The config block_device_cache_direct of runtime-rs is messy.

qemu and ch can support this config but doesn't have code for it.
db has this config support but its config file doesn't have this config.
fc cannot support this config but its config file has it.

This PR fixes the issues.