### PR TITLE
packaging: Fetch target commit before resetting to it for virtiofsd

### DIFF
--- a/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
+++ b/tools/packaging/static-build/virtiofsd/build-static-virtiofsd.sh
@@ -56,6 +56,10 @@ build_virtiofsd_from_source() {
 	git clone --branch main ${virtiofsd_repo} virtiofsd
 	pushd virtiofsd
 
+	# Fetch the specific version before resetting to it
+	# Sometimes it is necessary for a shallow clone:
+	# ${virtiofsd_version} is likely older than the single commit you cloned
+	git fetch $(git remote) ${virtiofsd_version}
 	git reset --hard ${virtiofsd_version}
 
 	export RUSTFLAGS='-C target-feature=+crt-static'${EXTRA_RUST_FLAGS}


### PR DESCRIPTION
Sometimes, we hit the following error during the static build for virtiofsd:

```
build viriofsd from source
+ git clone --depth 1 --branch main https://gitlab.com/virtio-fs/virtiofsd virtiofsd
Cloning into 'virtiofsd'...
warning: redirecting to https://gitlab.com/virtio-fs/virtiofsd.git/
fatal: Could not parse object 'cecc61bca981ab42aae6ec490dfd59965e79025e'.
```

For a shallow clone (e.g. `--depth 1`), a given commit hash is likely older than the cloned commit. Let's fetch it first.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>