### PR TITLE
ci: Only use the Ubuntu TDX machine in the CI

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -21,5 +21,4 @@ self-hosted-runner:
     - sev-snp
     - s390x
     - s390x-large
-    - tdx-no-attestation
-    - tdx-attestation
+    - tdx

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -36,15 +36,7 @@ jobs:
           - nydus
         pull-type:
           - guest-pull
-        k8s-test-host-type:
-          - baremetal-attestation
-          - baremetal-no-attestation
-        include:
-          - k8s-test-host-type: baremetal-attestation
-            machine: tdx-attestation
-          - k8s-test-host-type: baremetal-no-attestation
-            machine: tdx-no-attestation
-    runs-on: ${{ matrix.machine }}
+    runs-on: tdx
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}
@@ -54,7 +46,7 @@ jobs:
       KUBERNETES: "vanilla"
       USING_NFD: "true"
       KBS: "true"
-      K8S_TEST_HOST_TYPE: ${{ matrix.k8s-test-host-type }}
+      K8S_TEST_HOST_TYPE: "baremetal"
       KBS_INGRESS: "nodeport"
       SNAPSHOTTER: ${{ matrix.snapshotter }}
       PULL_TYPE: ${{ matrix.pull-type }}
@@ -83,17 +75,14 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-tdx
 
       - name: Uninstall previous `kbs-client`
-        if: ${{ matrix.machine != 'tdx-no-attestation' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh uninstall-kbs-client
 
       - name: Deploy CoCo KBS
-        if: ${{ matrix.machine != 'tdx-no-attestation' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
 
       - name: Install `kbs-client`
-        if: ${{ matrix.machine != 'tdx-no-attestation' }}
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh install-kbs-client
 
@@ -114,7 +103,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
 
       - name: Delete CoCo KBS
-        if: ${{ always() && matrix.machine != 'tdx-no-attestation' }}
+        if: always()
         run: bash tests/integration/kubernetes/gha-run.sh delete-coco-kbs
 
       - name: Delete CSI driver


### PR DESCRIPTION
We've been hitting issues with the CentOS 9 Stream machine, which Intel doesn't have cycles to debug.

After raising this up in the Confidential Containers community meeting we got the green light from Red Hat (Ariel Adam) to just disable the CI based on CentOS 9 Stream for now.