### PR TITLE
gha: Force update before trying to install azure-cli

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -66,6 +66,7 @@ function enable_cluster_http_application_routing() {
 }
 
 function install_azure_cli() {
+    sudo apt update
 	curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 	# The aks-preview extension is required while the Mariner Kata host is in preview.
 	az extension add --name aks-preview


### PR DESCRIPTION
Let's see if this will lead to the same results as trying to install the azure-cli directly.