### PR TITLE
ci: disable k8s integration tests for cri-o

### DIFF
--- a/.github/workflows/run-k8s-tests-on-amd64.yaml
+++ b/.github/workflows/run-k8s-tests-on-amd64.yaml
@@ -39,11 +39,12 @@ jobs:
           - devmapper
         k8s:
           - k3s
-        include:
-          - vmm: qemu
-            container_runtime: crio
-            snapshotter: ""
-            k8s: k0s
+# Temporarily disable CRI-O jobs due https://github.com/kata-containers/kata-containers/issues/10861
+#        include:
+#          - vmm: qemu
+#            container_runtime: crio
+#            snapshotter: ""
+#            k8s: k0s
     runs-on: ubuntu-22.04
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}


### PR DESCRIPTION
The CI job for cri-o has failed consistently (10 last night executions failed). Let's withdraw the job to fix it.

Fixes: #10861