### PR TITLE
gpu: QEMU SNP+TDX experimental updates

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -29,6 +29,7 @@ BASE_TARBALLS = serial-targets \
 	ovmf-sev-tarball \
 	ovmf-tarball \
 	qemu-snp-experimental-tarball \
+	qemu-tdx-experimental-tarball \
 	qemu-tarball \
 	stratovirt-tarball \
 	shim-v2-tarball \
@@ -144,6 +145,9 @@ ovmf-tarball:
 	${MAKE} $@-build
 
 qemu-snp-experimental-tarball:
+	${MAKE} $@-build
+
+qemu-tdx-experimental-tarball:
 	${MAKE} $@-build
 
 qemu-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -116,6 +116,7 @@ options:
 	ovmf-sev
 	qemu
 	qemu-snp-experimental
+	qemu-tdx-experimental
 	stratovirt
 	rootfs-image
 	rootfs-image-confidential
@@ -706,6 +707,17 @@ install_qemu_snp_experimental() {
 		"${qemu_experimental_builder}"
 }
 
+install_qemu_tdx_experimental() {
+	export qemu_suffix="tdx-experimental"
+	export qemu_tarball_name="kata-static-qemu-${qemu_suffix}.tar.gz"
+
+	install_qemu_helper \
+		"assets.hypervisor.qemu-${qemu_suffix}.url" \
+		"assets.hypervisor.qemu-${qemu_suffix}.tag" \
+		"qemu-${qemu_suffix}" \
+		"${qemu_experimental_builder}"
+}
+
 # Install static firecracker asset
 install_firecracker() {
 	local firecracker_version=$(get_from_kata_deps ".assets.hypervisor.firecracker.version")
@@ -1132,6 +1144,7 @@ handle_build() {
 		install_ovmf_sev
 		install_qemu
 		install_qemu_snp_experimental
+		install_qemu_tdx_experimental
 		install_stratovirt
 		install_runk
 		install_shimv2
@@ -1186,6 +1199,8 @@ handle_build() {
 	qemu) install_qemu ;;
 
 	qemu-snp-experimental) install_qemu_snp_experimental ;;
+
+	qemu-tdx-experimental) install_qemu_tdx_experimental ;;
 
 	stratovirt) install_stratovirt ;;
 

--- a/versions.yaml
+++ b/versions.yaml
@@ -100,9 +100,9 @@ assets:
         .*/v?(\d\S+)\.tar\.gz
 
     qemu-snp-experimental:
-      description: "QEMU with SNP support"
+      description: "QEMU with GPU+SNP support"
       url: "https://github.com/confidential-containers/qemu.git"
-      tag: "amd-snp-202402240000"
+      tag: "gpu-snp-20250211"
 
     stratovirt:
       description: "StratoVirt is an lightweight opensource VMM"

--- a/versions.yaml
+++ b/versions.yaml
@@ -104,6 +104,11 @@ assets:
       url: "https://github.com/confidential-containers/qemu.git"
       tag: "gpu-snp-20250211"
 
+    qemu-tdx-experimental:
+      description: "QEMU with GPU+TDX support"
+      url: "https://github.com/confidential-containers/qemu.git"
+      tag: "gpu-tdx-20250211"
+
     stratovirt:
       description: "StratoVirt is an lightweight opensource VMM"
       url: "https://github.com/openeuler-mirror/stratovirt"


### PR DESCRIPTION
Since SNP moved to upstream QEMU we're repurposing the experimental target for the GPU builds. The GPU related PRs are not yet fully upstream and merged in mainline QEMU. 

I am taking care of the branches on confidential-containers/qemu for SNP and TDX for the GPU work. 