### PR TITLE
ci: cri-containerd: upgrade the LTS / Active versions for containerd

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -63,15 +63,13 @@ jobs:
       # all the tests due to a single flaky instance.
       fail-fast: false
       matrix:
-        containerd_version: ['latest']
+        containerd_version: ['active']
         vmm: ['dragonball', 'cloud-hypervisor', 'qemu-runtime-rs']
     runs-on: ubuntu-22.04
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
       GOPATH: ${{ github.workspace }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
-      #the latest containerd from 2.0 need to set the CGROUP_DRIVER for e2e testing
-      CGROUP_DRIVER: ""
       SANDBOXER: "shim"
     steps:
       - uses: actions/checkout@v4

--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -20,6 +20,9 @@ export PATH="$PATH:/usr/local/sbin"
 # golang is installed in /usr/local/go/bin/ add that path
 export PATH="$PATH:/usr/local/go/bin"
 
+#the latest containerd from 2.0 need to set the CGROUP_DRIVER for e2e testing
+export CGROUP_DRIVER=""
+
 # Runtime to be used for testing
 KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 RUNTIME=${RUNTIME:-containerd-shim-kata-${KATA_HYPERVISOR}-v2}

--- a/versions.yaml
+++ b/versions.yaml
@@ -261,10 +261,11 @@ externals:
     # containerd from v1.5.0 used the path unix socket
     # instead of abstract socket, thus kata wouldn's support the containerd's
     # version older than them.
-    version: "v1.6.8"
-    lts: "v1.6"
-    active: "v1.7"
-    # add containerd 2.0.0 for sandbox api test
+    version: "v1.7.25"
+    lts: "v1.7"
+    active: "v2.0"
+    # keep the latest version to make the current PR ci work, once it was
+    # merged,we can remove the latest version.
     latest: "v2.0"
 
   critools:


### PR DESCRIPTION
As we're testing against the LTS and the Active versions of containers, let's upgrade the lts version from 1.6 to 1.7 and active version from 1.7 to 2.0 to cover the sandboxapi tests.