### PR TITLE
CI: Deprecate SEV

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -110,72 +110,7 @@ jobs:
         timeout-minutes: 5
         run: bash tests/integration/kubernetes/gha-run.sh delete-csi-driver
 
-  run-k8s-tests-on-sev:
-    strategy:
-      fail-fast: false
-      matrix:
-        vmm:
-          - qemu-sev
-        snapshotter:
-          - nydus
-        pull-type:
-          - guest-pull
-    runs-on: sev
-    env:
-      DOCKER_REGISTRY: ${{ inputs.registry }}
-      DOCKER_REPO: ${{ inputs.repo }}
-      DOCKER_TAG: ${{ inputs.tag }}
-      GH_PR_NUMBER: ${{ inputs.pr-number }}
-      KATA_HYPERVISOR: ${{ matrix.vmm }}
-      KUBECONFIG: /home/kata/.kube/config
-      KUBERNETES: "vanilla"
-      USING_NFD: "false"
-      K8S_TEST_HOST_TYPE: "baremetal"
-      SNAPSHOTTER: ${{ matrix.snapshotter }}
-      PULL_TYPE: ${{ matrix.pull-type }}
-      AUTHENTICATED_IMAGE_USER: ${{ secrets.AUTHENTICATED_IMAGE_USER }}
-      AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
-      AUTO_GENERATE_POLICY: "yes"
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.commit-hash }}
-          fetch-depth: 0
-
-      - name: Rebase atop of the latest target branch
-        run: |
-          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
-        env:
-          TARGET_BRANCH: ${{ inputs.target-branch }}
-
-      - name: Deploy Snapshotter
-        timeout-minutes: 5
-        run: bash tests/integration/kubernetes/gha-run.sh deploy-snapshotter
-
-      - name: Deploy Kata
-        timeout-minutes: 10
-        run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-sev
-
-      - name: Deploy CSI driver
-        timeout-minutes: 5
-        run: bash tests/integration/kubernetes/gha-run.sh deploy-csi-driver
-
-      - name: Run tests
-        timeout-minutes: 50
-        run: bash tests/integration/kubernetes/gha-run.sh run-tests
-
-      - name: Delete CSI driver
-        timeout-minutes: 5
-        run: bash tests/integration/kubernetes/gha-run.sh delete-csi-driver
-
-      - name: Delete kata-deploy
-        if: always()
-        run: bash tests/integration/kubernetes/gha-run.sh cleanup-sev
-
-      - name: Delete Snapshotter
-        if: always()
-        run: bash tests/integration/kubernetes/gha-run.sh cleanup-snapshotter
-
+  # AMD has deprecated SEV support on Kata and henceforth SNP will be the only feature supported for Kata Containers.
   run-k8s-tests-sev-snp:
     strategy:
       fail-fast: false


### PR DESCRIPTION
Phase 1 of Issue #10840

AMD has deprecated SEV support on
Kata Containers, and going forward,
SNP will be the only AMD feature
supported. As a first step in this
deprecation process, we are removing
the SEV CI workflow from the test suite
to unblock the CI.

Will be adding future commits to
remove redundant SEV code paths.