### PR TITLE
packaging(release): Properly handle version tag for the release bundle

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -32,7 +32,7 @@ pushd ${tarball_content_dir}
 	shim_path=$(find . -name ${shim} | sort | head -1)
 	prefix=${shim_path%"bin/${shim}"}
 
-	echo "$(git describe)" > ${prefix}/VERSION
+	echo "$(git describe --tags)" > ${prefix}/VERSION
 	[[ -n "${kata_versions_yaml_file}" ]] && cp ${kata_versions_yaml_file_path} ${prefix}/
 popd
 


### PR DESCRIPTION
The tags created automatically for published Github releases are probably not annotated, so by simply running `git describe` we are not getting the correct tag. Use a `git describe --tags` to allow git to look at all tags, not just annotated ones.