### PR TITLE
tests: confidential: Add KBS logging

### DIFF
--- a/tests/integration/kubernetes/confidential_common.sh
+++ b/tests/integration/kubernetes/confidential_common.sh
@@ -207,3 +207,16 @@ function create_coco_pod_yaml_with_annotations() {
 		set_node "${kata_pod}" "$node"
 	fi
 }
+
+confidential_teardown_common() {
+	local node="$1"
+	local node_start_time="$2"
+
+	# Run common teardown
+	teardown_common "${node}" ${node_start_time}
+
+	# Also try and print the kbs logs on failure
+	if [[ -n "${node_start_time}" && -z "${BATS_TEST_COMPLETED}" ]]; then
+		kbs_k8s_print_logs "${node_start_time}"
+	fi
+}

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -328,7 +328,7 @@ function kbs_k8s_deploy() {
 			# ITA/ITTS specific configuration
 			sed -i -e "s/tBfd5kKX2x9ahbodKV1.../${ITA_KEY}/g" kbs-config.toml
 		popd
-		
+
 		if [ -n "${HTTPS_PROXY}" ]; then
 			# Ideally this should be something kustomizable on trustee side.
 			#
@@ -337,7 +337,7 @@ function kbs_k8s_deploy() {
 			# solved.
 			pushd "${COCO_KBS_DIR}/config/kubernetes/base/"
 				ensure_yq
-				
+
 				yq e ".spec.template.spec.containers[0].env += [{\"name\": \"https_proxy\", \"value\": \"$HTTPS_PROXY\"}]" -i deployment.yaml
 			popd
 		fi
@@ -461,6 +461,18 @@ kbs_k8s_svc_http_addr() {
 	port=$(kbs_k8s_svc_port)
 
 	echo "http://${host}:${port}"
+}
+
+kbs_k8s_print_logs() {
+	local start_time="$1"
+
+	# Convert to iso time for kubectl
+	local iso_start_time
+	iso_start_time=$(date -d "${start_time}" --iso-8601=seconds)
+
+	echo "::group::DEBUG - kbs logs since ${start_time}"
+	kubectl -n "${KBS_NS}" logs -l app=kbs --since-time="${iso_start_time}" --timestamps=true || true
+	echo "::endgroup::"
 }
 
 # Ensure rust is installed in the host.

--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -90,5 +90,5 @@ teardown() {
 		skip "Test skipped as KBS not setup"
 	fi
 
-	teardown_common "${node}" "${node_start_time:-}"
+	confidential_teardown_common "${node}" "${node_start_time:-}"
 }

--- a/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
@@ -110,6 +110,6 @@ teardown() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    teardown_common "${node}" "${node_start_time:-}"
+    confidential_teardown_common "${node}" "${node_start_time:-}"
     kubectl delete secret cococred --ignore-not-found
 }

--- a/tests/integration/kubernetes/k8s-guest-pull-image-encrypted.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-encrypted.bats
@@ -95,5 +95,5 @@ teardown() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    teardown_common "${node}" "${node_start_time:-}"
+    confidential_teardown_common "${node}" "${node_start_time:-}"
 }

--- a/tests/integration/kubernetes/k8s-sealed-secret.bats
+++ b/tests/integration/kubernetes/k8s-sealed-secret.bats
@@ -115,7 +115,7 @@ teardown() {
 		skip "Test skipped as KBS not setup"
 	fi
 
-	teardown_common "${node}" "${node_start_time:-}"
+	confidential_teardown_common "${node}" "${node_start_time:-}"
 	kubectl delete secret sealed-secret --ignore-not-found
 	kubectl delete secret not-sealed-secret --ignore-not-found
 }


### PR DESCRIPTION
For help with debugging, add logging of the KBS,
like the container system logs if the confidential test fails

Signed-off-by: stevenhorsman <steven@uk.ibm.com>