### PR TITLE
ci: Fix spell_check and improve header_check

### DIFF
--- a/tests/cmd/check-spelling/data/main.txt
+++ b/tests/cmd/check-spelling/data/main.txt
@@ -23,6 +23,7 @@ cryptoprocessor/AB
 DaemonSet/AB
 deliverable/AB
 dev
+devmapper/B
 devicemapper/B
 deploy
 dialer
@@ -98,6 +99,7 @@ runtime/AB
 scalability
 serverless
 signoff/A
+snapshotter/AB
 stalebot/B
 startup
 subdirectory/A

--- a/tests/cmd/check-spelling/kata-dictionary.dic
+++ b/tests/cmd/check-spelling/kata-dictionary.dic
@@ -1,4 +1,4 @@
-392
+394
 ACPI/AB
 ACS/AB
 API/AB
@@ -224,8 +224,8 @@ dbs
 deliverable/AB
 deploy
 dev
-devmapper/B
 devicemapper/B
+devmapper/B
 dialer
 dialog/A
 dind/B

--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -413,10 +413,21 @@ static_check_license_headers()
 
 	files=$(get_pr_changed_file_details || true)
 
-	# Strip off status
-	files=$(echo "$files"|awk '{print $NF}')
+	# Strip off status and convert to array
+	files=($(echo "$files"|awk '{print $NF}'))
 
-	# no files were changed
+	text_files=()
+	# Filter out non-text files
+	for file in "${files[@]}"; do
+		if [[ -f "$file" ]] && file --mime-type "$file" | grep -q "text/"; then
+			text_files+=("$file")
+		else
+			info "Ignoring non-text file: $file"
+		fi
+	done
+	files="${text_files[*]}"
+
+	# no text files were changed
 	[ -z "$files" ] && info "No files found" && popd && return
 
 	local header_check


### PR DESCRIPTION
- spell: Add missing entries for kata-spell-check:
  `kata-dictionary.dic` changes after running `kata-spell-check.sh make-dict`. This is due to someone forgot to first update entries in data and run `make-dict`, but directly updated `kata-dictionary.dic` instead.
   Add mssing entries to data and re-run `make-dict` to generate correct `kata-dictionary.dic`.
- header_check: Check header for changed text files:
   We are running `header_check` for non-text files like binary files, symbolic link files, image files (pictures) and etc., which does not make sense.
   Filter out non-text files and run `header_check` only for text files changed.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>
