### PR TITLE
runtime: support SizeLimit for tmpfs emptyDir volume

### DIFF
--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -437,3 +437,19 @@ func HasOptionPrefix(options []string, prefix string) bool {
 	}
 	return false
 }
+
+// GetMountSize returns the mount size specified in the size options 
+// for this mount. The return value is a string that includes both 
+// the numeric value and the unit (e.g., "512M", "2G").
+func (mount *Mount) GetMountSize() (string, error) {
+	for _, opt := range mount.Options {
+		if strings.HasPrefix(opt, "size") {
+			// Get the size mount option
+			sizeOptionSlice := strings.Split(opt, "=")
+			sizeValueIdx := 1
+			size := sizeOptionSlice[sizeValueIdx]
+			return size, nil
+		}
+	}
+	return "", nil
+}

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -191,6 +191,7 @@ func TestPrepareEphemeralMounts(t *testing.T) {
 					Options: []string{
 						"rw",
 						"relatime",
+						"size=512M",
 					},
 					Source: "/tmp",
 				},
@@ -203,17 +204,6 @@ func TestPrepareEphemeralMounts(t *testing.T) {
 					},
 					Source: "/tmp",
 				},
-				{
-					// should be ignored because it is sizeLimited
-					Type: KataLocalDevType,
-					Options: []string{
-						"rw",
-						"relatime",
-						"size=1M",
-					},
-					Source: "/tmp",
-				},
-			},
 		},
 	}
 
@@ -225,7 +215,7 @@ func TestPrepareEphemeralMounts(t *testing.T) {
 		assert.Equal(t, s.Source, "tmpfs")
 		assert.Equal(t, s.Fstype, "tmpfs")
 		assert.Equal(t, s.MountPoint, filepath.Join(ephemeralPath(), "tmp"))
-		assert.Equal(t, len(s.Options), 2) // remount, size=1024M
+		assert.Equal(t, len(s.Options), 2) // remount, size=512M
 
 		validSet := map[string]struct{}{
 			"remount":    {},


### PR DESCRIPTION
Adding support for limiting tmpfs volumes according to the 'SizeLimit field
Signed-off-by: Gilad Sid <gsid@redhat.com>