### PR TITLE
tests: Support systemd unit files in /usr/lib as well as /lib

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -332,8 +332,8 @@ function restart_systemd_service_with_no_burst_limit() {
 		local unit_file=$(systemctl show "$service.service" -p FragmentPath | cut -d'=' -f2)
 		[ -f "$unit_file" ] || { warn "Can't find $service's unit file: $unit_file"; return 1; }
 
-		# If the unit file is in /lib, copy it to /etc
-		if [[ $unit_file == /lib* ]]; then
+		# If the unit file is in /lib or /usr/lib, copy it to /etc
+		if [[ $unit_file =~ ^/(usr/)?lib/ ]]; then
 			tmp_unit_file="/etc/${unit_file#*lib/}"
 			sudo cp "$unit_file" "$tmp_unit_file"
 			unit_file="$tmp_unit_file"


### PR DESCRIPTION
On Ubuntu 24.04, due to the `/usr` merge, system-provided unit files now reside in `/usr/lib/systemd/system/` instead of `/lib/systemd/system/`. For example, the command below now returns a different path:

```
$ systemctl show containerd.service -p FragmentPath
/usr/lib/systemd/system/containerd.service
```

Previously, on Ubuntu 22.04 and earlier, it returned:

```
/lib/systemd/system/containerd.service
```

The current pattern `if [[ $unit_file == /lib* ]]` fails to match the new path. To ensure compatibility across versions, we update the pattern to match both `/lib` and `/usr/lib` like:

```
if [[ $unit_file =~ ^/(usr/)?lib/ ]]
```

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>