### PR TITLE
GHA: Turn off MEASURED_ROOTFS in build-kata-static-tarball-s390x

### DIFF
--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -279,7 +279,7 @@ jobs:
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
-          MEASURED_ROOTFS: yes
+          MEASURED_ROOTFS: no
 
       - name: store-artifact shim-v2
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
This is the first attempt to remove the following code:

```
if [ "${ARCH}" == "s390x" ]; then
    export MEASURED_ROOTFS=no
fi
```

from install_shimv2() in kata-deploy-binaries.sh.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>