### PR TITLE
runtime: Add validation for hot-pluggable memory limit

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -2358,6 +2358,12 @@ func (s *Sandbox) updateResources(ctx context.Context) error {
 
 	hconfig := s.hypervisor.HypervisorConfig()
 
+	if finalMemoryMB > uint32(hconfig.DefaultMaxMemorySize) {
+		s.Logger().Errorf("Requested hot-pluggable memory to %d MB exceeds the default max memory %d MB. Current memory allocation is invalid.", finalMemoryMB, hconfig.DefaultMaxMemorySize)
+		return fmt.Errorf("could not update the memory to %d MB: requested memory exceeds the default max memory limit of %d MB",
+			finalMemoryMB, hconfig.DefaultMaxMemorySize)
+	}
+
 	for {
 		currentMemoryMB := s.hypervisor.GetTotalMemoryMB(ctx)
 


### PR DESCRIPTION
Added validation logic to prevent deadlock when updating memory beyond the maximum hot-pluggable limit. If the requested memory exceeds the limit, log an error and return an appropriate error message. This ensures that invalid memory updates are blocked, maintaining system stability and avoiding infinite loops.