### PR TITLE
shim-v2: Remove MEASURED_ROOTFS assignment for s390x

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -874,9 +874,6 @@ install_shimv2() {
 	export GO_VERSION
 	export RUST_VERSION
 	export MEASURED_ROOTFS
-	if [ "${ARCH}" == "s390x" ]; then
-		export MEASURED_ROOTFS=no
-	fi
 
 	DESTDIR="${destdir}" PREFIX="${prefix}" "${shimv2_builder}"
 }


### PR DESCRIPTION
As a follow-up for #10904, we do not need to set MEASURED_ROOTFS to no on s390x explicitly. The GHA workflow already exports this variable. This commit removes the redundant assignment.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>