### PR TITLE
build: Ensure MEASURED_ROOTFS is only used for images

### DIFF
--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -70,7 +70,7 @@ valid_hypervisor_paths = @QEMUVALIDHYPERVISORPATHS@
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
-kernel_params = "@KERNELPARAMS@"
+kernel_params = "@KERNELPARAMS@ init=/init"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -472,11 +472,7 @@ install_initrd() {
 
 #Install guest initrd for confidential guests
 install_initrd_confidential() {
-	if [ "${ARCH}" == "s390x" ]; then
-		export MEASURED_ROOTFS=no
-	else
-		export MEASURED_ROOTFS=yes
-	fi
+	export MEASURED_ROOTFS=no
 	export PULL_TYPE=default
 	install_initrd "confidential"
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -168,7 +168,7 @@ assets:
           version: "jammy"  # 22.04 LTS
         nvidia-gpu-confidential:
           name: "ubuntu"
-          version: "jammy"
+          version: "jammy"  # 22.04 LTS
       # Do not use Alpine on ppc64le & s390x, the agent cannot use musl because
       # there is no such Rust target
       ppc64le:

--- a/versions.yaml
+++ b/versions.yaml
@@ -185,7 +185,7 @@ assets:
         version: "3.18"
         confidential:
           name: "ubuntu"
-          version: "focal"  # 20.04 LTS
+          version: "oracular"  # 24.10
         nvidia-gpu:
           name: "ubuntu"
           version: "jammy"  # 22.04 LTS


### PR DESCRIPTION
We never ever tested MEASURED_ROOTFS with initrd, and I sincerely do not know why we've been setting that to "yes" in the initrd cases.

Let's drop it, as it may be causing issues with the jobs that rely on the rootfs-initrd-confidential.