### PR TITLE
metrics: Increase containerd start timeout

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -288,8 +288,11 @@ jobs:
     needs: build-kata-static-tarball-amd64
     uses: ./.github/workflows/run-metrics.yaml
     with:
-      tarball-suffix: -${{ inputs.tag }}
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ inputs.tag }}-amd64
       commit-hash: ${{ inputs.commit-hash }}
+      pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
 
   run-basic-amd64-tests:

--- a/.github/workflows/run-metrics.yaml
+++ b/.github/workflows/run-metrics.yaml
@@ -2,8 +2,17 @@ name: CI | Run test metrics
 on:
   workflow_call:
     inputs:
-      tarball-suffix:
-        required: false
+      registry:
+        required: true
+        type: string
+      repo:
+        required: true
+        type: string
+      tag:
+        required: true
+        type: string
+      pr-number:
+        required: true
         type: string
       commit-hash:
         required: false
@@ -14,34 +23,7 @@ on:
         default: ""
 
 jobs:
-  setup-kata:
-    name: Kata Setup
-    runs-on: metrics
-    env:
-      GOPATH: ${{ github.workspace }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.commit-hash }}
-          fetch-depth: 0
-
-      - name: Rebase atop of the latest target branch
-        run: |
-          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
-        env:
-          TARGET_BRANCH: ${{ inputs.target-branch }}
-
-      - name: get-kata-tarball
-        uses: actions/download-artifact@v4
-        with:
-          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
-          path: kata-artifacts
-
-      - name: Install kata
-        run: bash tests/metrics/gha-run.sh install-kata kata-artifacts
-
   run-metrics:
-    needs: setup-kata
     strategy:
       # We can set this to true whenever we're 100% sure that
       # the all the tests are not flaky, otherwise we'll fail
@@ -54,7 +36,32 @@ jobs:
     env:
       GOPATH: ${{ github.workspace }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
+      DOCKER_REGISTRY: ${{ inputs.registry }}
+      DOCKER_REPO: ${{ inputs.repo }}
+      DOCKER_TAG: ${{ inputs.tag }}
+      GH_PR_NUMBER: ${{ inputs.pr-number }}
+      K8S_TEST_HOST_TYPE: "baremetal"
+      USING_NFD: "false"
+      KUBERNETES: kubeadm
     steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Deploy Kata
+        timeout-minutes: 10
+        run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-kubeadm
+
+      - name: Install check metrics
+        run: bash tests/metrics/gha-run.sh install-checkmetrics
+
       - name: enabling the hypervisor
         run: bash tests/metrics/gha-run.sh enabling-hypervisor
 
@@ -92,3 +99,7 @@ jobs:
           path: results-${{ matrix.vmm }}.tar.gz
           retention-days: 1
           if-no-files-found: error
+
+      - name: Delete kata-deploy
+        if: always()
+        run: bash tests/integration/kubernetes/gha-run.sh cleanup-kubeadm

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -298,23 +298,6 @@ function clean_env_ctr()
 	fi
 }
 
-# Kills running shim and hypervisor components
-function kill_kata_components() {
-	local ATTEMPTS=2
-	local TIMEOUT="30s"
-	local PID_NAMES=( "containerd-shim-kata-v2" "qemu-system-x86_64" "qemu-system-x86_64-tdx-experimental" "cloud-hypervisor" )
-
-	sudo systemctl stop containerd
-	# iterate over the list of kata components and stop them
-	for (( i=1; i<=ATTEMPTS; i++ )); do
-		for PID_NAME in "${PID_NAMES[@]}"; do
-			[[ ! -z "$(pidof ${PID_NAME})" ]] && sudo killall -w -s SIGKILL "${PID_NAME}" >/dev/null 2>&1 || true
-		done
-		sleep 1
-	done
-	sudo timeout -s SIGKILL "${TIMEOUT}" systemctl start containerd
-}
-
 # Restarts a systemd service while ensuring the start-limit-burst is set to 0.
 # Outputs warnings to stdio if something has gone wrong.
 #
@@ -601,7 +584,7 @@ function clone_cri_containerd() {
 # version: the version of the tarball that will be downloaded
 # tarball-name: the name of the tarball that will be downloaded
 function download_github_project_tarball() {
-	project="${1}" 
+	project="${1}"
 	version="${2}"
 	tarball_name="${3}"
 
@@ -731,7 +714,7 @@ OOMScoreAdjust=-999
 [Install]
 WantedBy=multi-user.target
 EOF
-	fi 
+	fi
 }
 
 # base_version: The version to be intalled in the ${major}.${minor} format

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -433,8 +433,8 @@ function cleanup() {
 		return
 	fi
 
-	# In case of canceling workflow manually, 'run_kubernetes_tests.sh' continues running and triggers new tests, 
-	# resulting in the CI being in an unexpected state. So we need kill all running test scripts before cleaning up the node. 
+	# In case of canceling workflow manually, 'run_kubernetes_tests.sh' continues running and triggers new tests,
+	# resulting in the CI being in an unexpected state. So we need kill all running test scripts before cleaning up the node.
 	# See issue https://github.com/kata-containers/kata-containers/issues/9980
 	delete_test_runners	|| true
 	# Switch back to the default namespace and delete the tests one
@@ -594,6 +594,7 @@ function main() {
 		collect-artifacts) collect_artifacts ;;
 		cleanup) cleanup ;;
 		cleanup-kcli) cleanup "kcli" ;;
+		cleanup-kubeadm) cleanup "kubeadm" ;;
 		cleanup-sev) cleanup "sev" ;;
 		cleanup-snp) cleanup "snp" ;;
 		cleanup-tdx) cleanup "tdx" ;;

--- a/tests/metrics/gha-run.sh
+++ b/tests/metrics/gha-run.sh
@@ -121,7 +121,7 @@ function run_test_latency() {
 function main() {
 	action="${1:-}"
 	case "${action}" in
-		install-kata) install_kata && install_checkmetrics ;;
+		install-checkmetrics) install_checkmetrics ;;
 		enabling-hypervisor) enabling_hypervisor ;;
 		make-tarball-results) make_tarball_results ;;
 		run-test-launchtimes) run_test_launchtimes ;;
@@ -132,7 +132,7 @@ function main() {
 		run-test-fio) run_test_fio ;;
 		run-test-iperf) run_test_iperf ;;
 		run-test-latency) run_test_latency ;;
-		*) >&2 die "Invalid argument" ;;
+		*) >&2 die "Invalid argument: ${action}" ;;
 	esac
 }
 

--- a/tests/metrics/lib/common.bash
+++ b/tests/metrics/lib/common.bash
@@ -181,6 +181,8 @@ function test_banner()
 # minimal steps for metrics/tests execution.
 function init_env()
 {
+	set -x
+	echo "Before init Pods: $(kubectl get pods -A)"
 	test_banner "${TEST_NAME}"
 
 	cmd=("docker" "ctr")
@@ -200,6 +202,8 @@ function init_env()
 	kill_processes_before_start
 	check_processes
 	info "init environment complete"
+	echo "Post init Pods: $(kubectl get pods -A)"
+	set +x
 }
 
 # This function checks if there are containers or

--- a/tests/metrics/lib/common.bash
+++ b/tests/metrics/lib/common.bash
@@ -224,6 +224,23 @@ function kill_processes_before_start()
 	kill_kata_components
 }
 
+# Kills running shim and hypervisor components
+function kill_kata_components() {
+	local ATTEMPTS=2
+	local TIMEOUT="300s"
+	local PID_NAMES=( "containerd-shim-kata-v2" "qemu-system-x86_64" "qemu-system-x86_64-tdx-experimental" "cloud-hypervisor" )
+
+	sudo systemctl stop containerd
+	# iterate over the list of kata components and stop them
+	for (( i=1; i<=ATTEMPTS; i++ )); do
+		for PID_NAME in "${PID_NAMES[@]}"; do
+			[[ ! -z "$(pidof ${PID_NAME})" ]] && sudo killall -w -s SIGKILL "${PID_NAME}" >/dev/null 2>&1 || true
+		done
+		sleep 1
+	done
+	sudo timeout -s SIGKILL "${TIMEOUT}" systemctl start containerd
+}
+
 # Generate a random name - generally used when creating containers, but can
 # be used for any other appropriate purpose
 function random_name()
@@ -513,7 +530,7 @@ function get_current_kata_config_file() {
 	current_config_file="${KATA_CONFIG_FNAME}"
 }
 
-# This function checks if the current session is runnin as root, 
+# This function checks if the current session is runnin as root,
 # if that is not the case, the function exits with an error message.
 function check_if_root() {
 	[ "$EUID" -ne 0 ] && die "Please run as root or use sudo."

--- a/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
+++ b/tests/metrics/network/iperf3_kubernetes/k8s-network-metrics-iperf3.sh
@@ -179,7 +179,7 @@ function iperf3_start_deployment() {
 	# Check no processes are left behind
 	check_processes
 
-	wait_time=20
+	wait_time=180
 	sleep_time=2
 
 	# Create deployment

--- a/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-daemonset.yaml
+++ b/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-daemonset.yaml
@@ -19,7 +19,7 @@ spec:
         app: iperf3-client
     spec:
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-deployment.yaml
+++ b/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-deployment.yaml
@@ -25,12 +25,10 @@ spec:
           - weight: 1
             preference:
               matchExpressions:
-              - key: kubernetes.io/role
-                operator: In
-                values:
-                - master
+              - key: node-role.kubernetes.io/control-plane
+                operator: Exists
       tolerations:
-        - key: node-role.kubernetes.io/master
+        - key: node-role.kubernetes.io/control-plane
           operator: Exists
           effect: NoSchedule
       containers:

--- a/tests/metrics/network/latency_kubernetes/latency-network.sh
+++ b/tests/metrics/network/latency_kubernetes/latency-network.sh
@@ -33,8 +33,6 @@ function main() {
 	cmds=("bc" "jq")
 	check_cmds "${cmds[@]}"
 
-	init_env
-
 	# Check no processes are left behind
 	check_processes
 

--- a/tests/metrics/network/latency_kubernetes/latency-network.sh
+++ b/tests/metrics/network/latency_kubernetes/latency-network.sh
@@ -36,7 +36,7 @@ function main() {
 	# Check no processes are left behind
 	check_processes
 
-	wait_time=20
+	wait_time=180
 	sleep_time=2
 
 	# Create server

--- a/tests/metrics/network/latency_kubernetes/latency-network.sh
+++ b/tests/metrics/network/latency_kubernetes/latency-network.sh
@@ -36,6 +36,8 @@ function main() {
 	# Check no processes are left behind
 	check_processes
 
+	kubectl get pods -A
+
 	wait_time=180
 	sleep_time=2
 


### PR DESCRIPTION
- Move `kill_kata_components` from common.bash into the metrics code base as the only user of it
- Increase the timeout on the start of containerd as the last 10 nightlies metric tests have failed with:
```
223478 Killed                  sudo timeout -s SIGKILL "${TIMEOUT}" systemctl start containerd
```