### PR TITLE
tools: fix rootfs-builder when using dracut in a debian/ubuntu host os

### DIFF
--- a/tools/osbuilder/.gitignore
+++ b/tools/osbuilder/.gitignore
@@ -1,5 +1,6 @@
 **/*.tar.gz
 image-builder/nsdax
+dracut_overlay
 dracut/Dockerfile
 dracut/dracut.conf.d/15-extra-libs.conf
 /.*.done

--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -652,6 +652,9 @@ EOF
 			echo "I am ubuntu or debian"
 			chrony_conf_file="${ROOTFS_DIR}/etc/chrony/chrony.conf"
 			chrony_systemd_service="${ROOTFS_DIR}/lib/systemd/system/chrony.service"
+
+			info "Create ${ROOTFS_DIR}/etc/chrony
+			mkdir -p "${ROOTFS_DIR}/etc/chrony"
 			;;
 		"ubuntu")
 			# Fix for #4932 - Boot hang at: "A start job is running for /dev/ttyS0"


### PR DESCRIPTION
Closes #10918