### PR TITLE
Revert "gha: Build and ship SEV OVMF"

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -50,7 +50,6 @@ jobs:
           - kernel-nvidia-gpu-confidential
           - nydus
           - ovmf
-          - ovmf-sev
           - pause-image
           - qemu
           - qemu-snp-experimental


### PR DESCRIPTION
SEV has been deprecated, so remove the OVMF-SEV workflow build target

This reverts commit 45fa36692688d8b419a5136001c8d9284d79b5b4.