### PR TITLE
build: Drop redundant ARCH override

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -53,10 +53,6 @@ endif
 
 include ../../utils.mk
 
-ifeq ($(ARCH), ppc64le)
-    override ARCH = powerpc64le
-endif
-
 ##VAR STANDARD_OCI_RUNTIME=yes|no define if agent enables standard oci runtime feature
 STANDARD_OCI_RUNTIME := no
 

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -17,10 +17,6 @@ CONTAINERD_RUNTIME_NAME = io.containerd.kata.v2
 
 include ../../utils.mk
 
-ifeq ($(ARCH), ppc64le)
-    override ARCH = powerpc64le
-endif
-
 ARCH_DIR = arch
 ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)

--- a/src/tools/agent-ctl/Makefile
+++ b/src/tools/agent-ctl/Makefile
@@ -5,10 +5,6 @@
 
 include ../../../utils.mk
 
-ifeq ($(ARCH), ppc64le)
-     override ARCH = powerpc64le
-endif
-
 .DEFAULT_GOAL := default
 default: build
 

--- a/src/tools/genpolicy/Makefile
+++ b/src/tools/genpolicy/Makefile
@@ -6,10 +6,6 @@
 
 include ../../../utils.mk
 
-ifeq ($(ARCH), ppc64le)
-     override ARCH = powerpc64le
- endif
-
 COMMIT_HASH := $(shell git rev-parse HEAD 2>/dev/null || true)
 # appends '-dirty' to the commit hash if there are uncommitted changes
 COMMIT_INFO := $(if $(shell git status --porcelain --untracked-files=no 2>/dev/null || true),${COMMIT_HASH}-dirty,${COMMIT_HASH})

--- a/src/tools/runk/Makefile
+++ b/src/tools/runk/Makefile
@@ -8,10 +8,6 @@ LIBC ?= gnu
 
 include ../../../utils.mk
 
-ifeq ($(ARCH), ppc64le)
-     override ARCH = powerpc64le
-endif
-
 TARGET = runk
 TARGET_PATH = target/$(TRIPLE)/$(BUILD_TYPE)/$(TARGET)
 AGENT_SOURCE_PATH = ../../agent

--- a/src/tools/trace-forwarder/Makefile
+++ b/src/tools/trace-forwarder/Makefile
@@ -5,10 +5,6 @@
 
 include ../../../utils.mk
 
-ifeq ($(ARCH), ppc64le)
-     override ARCH = powerpc64le
-endif
-
 .DEFAULT_GOAL := default
 default: build
 


### PR DESCRIPTION
There are many `override ARCH = powerpc64le` after where `utils.mk` is included, which are redundant.

Drop those redundant `override`s.