### PR TITLE
agent: Fix non-guest-pull build

### DIFF
--- a/src/agent/src/cdh.rs
+++ b/src/agent/src/cdh.rs
@@ -184,6 +184,7 @@ pub async fn unseal_file(path: &str) -> Result<()> {
     Ok(())
 }
 
+#[cfg(feature = "guest-pull")]
 pub async fn secure_mount(
     volume_type: &str,
     options: &std::collections::HashMap<String, String>,

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -60,6 +60,7 @@ use crate::device::block_device_handler::get_virtio_blk_pci_device_name;
 use crate::device::network_device_handler::wait_for_net_interface;
 use crate::device::{add_devices, handle_cdi_devices, update_env_pci};
 use crate::features::get_build_features;
+#[cfg(feature = "guest-pull")]
 use crate::image::KATA_IMAGE_WORK_DIR;
 use crate::linux_abi::*;
 use crate::metrics::get_metrics;
@@ -106,6 +107,7 @@ use kata_types::k8s;
 
 pub const CONTAINER_BASE: &str = "/run/kata-containers";
 const MODPROBE_PATH: &str = "/sbin/modprobe";
+#[cfg(feature = "guest-pull")]
 const TRUSTED_IMAGE_STORAGE_DEVICE: &str = "/dev/trusted_store";
 /// the iptables seriers binaries could appear either in /sbin
 /// or /usr/sbin, we need to check both of them
@@ -2241,11 +2243,13 @@ async fn cdh_handler(oci: &mut Spec) -> Result<()> {
         }
     }
 
+    #[cfg(feature = "guest-pull")]
     let linux = oci
         .linux()
         .as_ref()
         .ok_or_else(|| anyhow!("Spec didn't contain linux field"))?;
 
+    #[cfg(feature = "guest-pull")]
     if let Some(devices) = linux.devices() {
         for specdev in devices.iter() {
             if specdev.path().as_path().to_str() == Some(TRUSTED_IMAGE_STORAGE_DEVICE) {


### PR DESCRIPTION
As the guest-pull is a very Confidental Containers specific feature, let's make sure we, at least, don't break folks who decide to build Kata Containers' agent without having this feature enabled (for instance, for the sake of the agent size).

This was tested by building the agent with the following patch:
```sh
diff --git a/src/agent/Cargo.toml b/src/agent/Cargo.toml
index 34a39b561..d746ad492 100644
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -99,7 +99,7 @@ lto = true
 
 [features]
 # The default-pull feature would support all pull types, including sharing images by virtio-fs and pulling images in the guest
-default-pull = ["guest-pull"]
+default-pull = []
 seccomp = ["rustjail/seccomp"]
 standard-oci-runtime = ["rustjail/standard-oci-runtime"]
 agent-policy = [ "kata-agent-policy" ]
```