### PR TITLE
runtime: add cause to CDI errors

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -123,7 +123,7 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 		if containerType == vc.SingleContainer {
 			_, err = config.WithCDI(ociSpec.Annotations, []string{}, ociSpec)
 			if err != nil {
-				return nil, fmt.Errorf("adding CDI devices failed")
+				return nil, fmt.Errorf("adding CDI devices failed: %w", err)
 			}
 		}
 

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -742,7 +742,7 @@ func (s *Sandbox) coldOrHotPlugVFIO(sandboxConfig *SandboxConfig) (bool, error) 
 			//
 			_, err := config.WithCDI(cdiSpec.Annotations, []string{}, cdiSpec)
 			if err != nil {
-				return coldPlugVFIO, fmt.Errorf("adding CDI devices failed")
+				return coldPlugVFIO, fmt.Errorf("adding CDI devices failed: %w", err)
 			}
 
 			for _, dev := range cdiSpec.Linux.Devices {


### PR DESCRIPTION
Adding devices by CDI annotation can fail for a variety of reasons. If that happens, it's helpful to know the root cause of the issue (CDI spec missing, malformatted, requested device not present, etc.).

This commit adds the root cause of the CDI device addition to the errors reported back to the caller. Since this error is bubbled up all the way back to the shimv2 task.Create handler, it will be visible in Kubernetes logs and enable fixing the root cause.

cc @zvonkok 