### PR TITLE
runtime-rs: remove snp certs path support from qemu-rs

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -829,10 +829,6 @@ pub struct SecurityInfo {
     #[serde(default)]
     pub sev_snp_guest: bool,
 
-    /// Path to SNP certificates
-    #[serde(default)]
-    pub snp_certs_path: String,
-
     /// Path to OCI hook binaries in the *guest rootfs*.
     ///
     /// This does not affect host-side hooks which must instead be added to the OCI spec passed to

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/protection_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/protection_device.rs
@@ -20,7 +20,6 @@ pub struct SevSnpConfig {
     pub is_snp: bool,
     pub cbitpos: u32,
     pub firmware: String,
-    pub certs_path: String,
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -1748,7 +1748,6 @@ struct ObjectSevSnpGuest {
     kernel_hashes: bool,
 
     is_snp: bool,
-    certs_path: String,
 }
 
 impl ObjectSevSnpGuest {
@@ -1759,13 +1758,7 @@ impl ObjectSevSnpGuest {
             reduced_phys_bits: 1,
             kernel_hashes: true,
             is_snp,
-            certs_path: "".to_owned(),
         }
-    }
-
-    fn set_certs_path(&mut self, certs_path: &str) -> &mut Self {
-        self.certs_path = certs_path.to_owned();
-        self
     }
 }
 
@@ -1789,9 +1782,6 @@ impl ToQemuParams for ObjectSevSnpGuest {
                 "kernel-hashes={}",
                 if self.kernel_hashes { "on" } else { "off" }
             ));
-            if !self.certs_path.is_empty() {
-                params.push(format!("certs-path={}", self.certs_path));
-            }
         }
         Ok(vec!["-object".to_owned(), params.join(",")])
     }
@@ -2124,14 +2114,8 @@ impl<'a> QemuCmdLine<'a> {
             .set_nvdimm(false);
     }
 
-    pub fn add_sev_snp_protection_device(
-        &mut self,
-        cbitpos: u32,
-        firmware: &str,
-        certs_path: &str,
-    ) {
-        let mut sev_snp_object = ObjectSevSnpGuest::new(true, cbitpos);
-        sev_snp_object.set_certs_path(certs_path);
+    pub fn add_sev_snp_protection_device(&mut self, cbitpos: u32, firmware: &str) {
+        let sev_snp_object = ObjectSevSnpGuest::new(true, cbitpos);
         self.devices.push(Box::new(sev_snp_object));
 
         self.devices.push(Box::new(Bios::new(firmware.to_owned())));

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -132,7 +132,6 @@ impl QemuInner {
                             cmdline.add_sev_snp_protection_device(
                                 sev_snp_cfg.cbitpos,
                                 &sev_snp_cfg.firmware,
-                                &sev_snp_cfg.certs_path,
                             )
                         } else {
                             cmdline.add_sev_protection_device(

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -338,7 +338,6 @@ impl VirtSandbox {
                     is_snp: false,
                     cbitpos: details.cbitpos,
                     firmware: hypervisor_config.boot_info.firmware.clone(),
-                    certs_path: "".to_owned(),
                 })))
             }
             GuestProtection::Snp(details) => {
@@ -354,17 +353,10 @@ impl VirtSandbox {
                     info!(sl!(), "reverting to SEV even though SEV-SNP is available as requested by 'sev_snp_guest'");
                 }
 
-                let certs_path = if is_snp {
-                    hypervisor_config.security_info.snp_certs_path.clone()
-                } else {
-                    "".to_owned()
-                };
-
                 Ok(Some(ProtectionDeviceConfig::SevSnp(SevSnpConfig {
                     is_snp,
                     cbitpos: details.cbitpos,
                     firmware: hypervisor_config.boot_info.firmware.clone(),
-                    certs_path,
                 })))
             }
             _ => Err(anyhow!("confidential_guest requested by configuration but no supported protection available"))


### PR DESCRIPTION
An almost trivial PR to remove support of the obsolete `snp_certs_path` setting.