### PR TITLE
genpolicy: support ephemeral volume source

### DIFF
--- a/src/tools/genpolicy/src/mount_and_storage.rs
+++ b/src/tools/genpolicy/src/mount_and_storage.rs
@@ -130,7 +130,7 @@ pub fn get_mount_and_storage(
         }
 
         get_empty_dir_mount_and_storage(settings, p_mounts, storages, yaml_mount, volume.unwrap());
-    } else if yaml_volume.persistentVolumeClaim.is_some() || yaml_volume.azureFile.is_some() {
+    } else if yaml_volume.persistentVolumeClaim.is_some() || yaml_volume.azureFile.is_some() || yaml_volume.ephemeral.is_some() {
         get_shared_bind_mount(yaml_mount, p_mounts, "rprivate", "rw");
     } else if yaml_volume.hostPath.is_some() {
         get_host_path_mount(yaml_mount, yaml_volume, p_mounts);

--- a/src/tools/genpolicy/src/volume.rs
+++ b/src/tools/genpolicy/src/volume.rs
@@ -6,7 +6,7 @@
 // Allow K8s YAML field names.
 #![allow(non_snake_case)]
 
-use crate::pod;
+use crate::{persistent_volume_claim, pod};
 
 use serde::{Deserialize, Serialize};
 
@@ -23,6 +23,9 @@ pub struct Volume {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub persistentVolumeClaim: Option<PersistentVolumeClaimVolumeSource>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ephemeral: Option<EphemeralVolumeSource>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub configMap: Option<ConfigMapVolumeSource>,
@@ -64,6 +67,13 @@ pub struct EmptyDirVolumeSource {
 pub struct PersistentVolumeClaimVolumeSource {
     pub claimName: String,
     // TODO: additional fields.
+}
+
+/// See Reference / Kubernetes API / Config and Storage Resources / Volume.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct EphemeralVolumeSource {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub volumeClaimTemplate: Option<persistent_volume_claim::PersistentVolumeClaim>,
 }
 
 /// See Reference / Kubernetes API / Config and Storage Resources / Volume.

--- a/tests/integration/kubernetes/k8s-policy-pvc.bats
+++ b/tests/integration/kubernetes/k8s-policy-pvc.bats
@@ -53,6 +53,15 @@ test_pod_policy_error() {
 	test_pod_policy_error
 }
 
+@test "Policy failure: unexpected volume mount" {
+	# Changing the location of a mounted device after policy generation should fail the policy check.
+	yq -i \
+		'.spec.containers[0].volumeMounts.[0].mountPath = "/usr/bin"' \
+		"${incorrect_pod_yaml}" \
+
+	test_pod_policy_error
+}
+
 teardown() {
 	auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled."
 	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-sev" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] ) && skip "https://github.com/kata-containers/kata-containers/issues/9846"

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod-pvc.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod-pvc.yaml
@@ -16,7 +16,21 @@ spec:
       volumeDevices:
         - name: dev
           devicePath: /dev/csi0
+      volumeMounts:
+        - name: ephemeral
+          mountPath: /state
   volumes:
     - name: dev
       persistentVolumeClaim:
         claimName: policy-dev
+    - name: ephemeral
+      ephemeral:
+        volumeClaimTemplate:
+          metadata:
+            labels:
+              type: some-type
+          spec:
+            accessModes: [ "ReadWriteOnce" ]
+            resources:
+              requests:
+                storage: 1Mi


### PR DESCRIPTION
The Ephemeral volume type is more or less a managed version of the PersitentVolumeClaim volume type. Therefore, it can be supported with the rules for PVCs, and only needs deserialization support.

---

The use case is close enough that I decided to just add fields to the existing PVC policy test, instead of creating a new test file.

cc @Redent0r @danmihai1 

---

Btw, I noticed that `get_shared_bind_mount` has `access` and `propagation` both in the `yaml_mount` as well as in explicit arguments, but only the latter are used (and those are hard-coded). Is that WAI?