### PR TITLE
ci: Refactor matrix for `build-checks`

### DIFF
--- a/.github/workflows/build-checks-preview-riscv64.yaml
+++ b/.github/workflows/build-checks-preview-riscv64.yaml
@@ -33,7 +33,6 @@ jobs:
             component-path: src/tools/agent-ctl
           - component: trace-forwarder
             component-path: src/tools/trace-forwarder
-          - install-libseccomp: no
           - component: genpolicy
             component-path: src/tools/genpolicy
     steps:
@@ -70,7 +69,7 @@ jobs:
         if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
         run: sudo apt-get -y install libdevmapper-dev
       - name: Install libseccomp
-        if: ${{ matrix.command != 'make vendor'  &&  matrix.command != 'make check' &&  matrix.install-libseccomp == 'yes' }}
+        if: ${{ matrix.command != 'make vendor' && matrix.command != 'make check' && matrix.component == 'agent' }}
         run: |
           libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
           gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)

--- a/.github/workflows/build-checks-preview-riscv64.yaml
+++ b/.github/workflows/build-checks-preview-riscv64.yaml
@@ -66,14 +66,14 @@ jobs:
         run: |
           ./tests/install_go.sh -f -p
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-      - name: Install rust
+      - name: Setup rust
         if: contains(matrix.component.needs, 'rust')
         run: |
           ./tests/install_rust.sh
           echo "${HOME}/.cargo/bin" >> "$GITHUB_PATH"
-      - name: Install musl-tools
-        if: contains(matrix.component.needs, 'musl-tools')
-        run: sudo apt-get -y install musl-tools
+          if [ "$(uname -m)" == "x86_64" ] || [ "$(uname -m)" == "aarch64" ]; then
+            sudo apt-get -y install musl-tools
+          fi
       - name: Install devicemapper
         if: contains(matrix.component.needs, 'libdevmapper') && matrix.command == 'make check'
         run: sudo apt-get -y install libdevmapper-dev

--- a/.github/workflows/build-checks-preview-riscv64.yaml
+++ b/.github/workflows/build-checks-preview-riscv64.yaml
@@ -19,22 +19,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component:
-          - agent-ctl
-          - trace-forwarder
-          - genpolicy
         command:
           - "make vendor"
           - "make check"
           - "make test"
           - "sudo -E PATH=\"$PATH\" make test"
-        include:
-          - component: agent-ctl
-            component-path: src/tools/agent-ctl
-          - component: trace-forwarder
-            component-path: src/tools/trace-forwarder
-          - component: genpolicy
-            component-path: src/tools/genpolicy
+        component:
+          - name: agent-ctl
+            path: src/tools/agent-ctl
+            needs:
+              - rust
+              - musl-tools
+              - protobuf-compiler
+              - clang
+          - name: trace-forwarder
+            path: src/tools/trace-forwarder
+            needs:
+              - rust
+              - musl-tools
+          - name: genpolicy
+            path: src/tools/genpolicy
+            needs:
+              - rust
+              - musl-tools
+              - protobuf-compiler
+
     steps:
       - name: Adjust a permission for repo
         run: |
@@ -53,23 +62,23 @@ jobs:
         env:
           INSTALL_IN_GOPATH: false
       - name: Install golang
-        if: ${{ matrix.component == 'runtime' }}
+        if: contains(matrix.component.needs, 'golang')
         run: |
           ./tests/install_go.sh -f -p
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
       - name: Install rust
-        if: ${{ matrix.component != 'runtime' }}
+        if: contains(matrix.component.needs, 'rust')
         run: |
           ./tests/install_rust.sh
           echo "${HOME}/.cargo/bin" >> "$GITHUB_PATH"
       - name: Install musl-tools
-        if: ${{ matrix.component != 'runtime' }}
+        if: contains(matrix.component.needs, 'musl-tools')
         run: sudo apt-get -y install musl-tools
       - name: Install devicemapper
-        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
+        if: contains(matrix.component.needs, 'libdevmapper') && matrix.command == 'make check'
         run: sudo apt-get -y install libdevmapper-dev
       - name: Install libseccomp
-        if: ${{ matrix.command != 'make vendor' && matrix.command != 'make check' && matrix.component == 'agent' }}
+        if: contains(matrix.component.needs, 'libseccomp') && matrix.command != 'make vendor' && matrix.command != 'make check'
         run: |
           libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
           gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)
@@ -78,19 +87,19 @@ jobs:
           echo "LIBSECCOMP_LINK_TYPE=static" >> "$GITHUB_ENV"
           echo "LIBSECCOMP_LIB_PATH=${libseccomp_install_dir}/lib" >> "$GITHUB_ENV"
       - name: Install protobuf-compiler
-        if: ${{ matrix.command != 'make vendor' && (matrix.component == 'agent' || matrix.component == 'genpolicy' || matrix.component == 'agent-ctl') }}
+        if: contains(matrix.component.needs, 'protobuf-compiler') && matrix.command != 'make vendor'
         run: sudo apt-get -y install protobuf-compiler
       - name: Install clang
-        if: ${{ matrix.command == 'make check' && (matrix.component == 'agent' || matrix.component == 'agent-ctl') }}
+        if: contains(matrix.component.needs, 'clang') && matrix.command == 'make check'
         run: sudo apt-get -y install clang
-      - name: Setup XDG_RUNTIME_DIR for the `runtime` tests
-        if: ${{ matrix.command != 'make vendor' && matrix.command != 'make check' && matrix.component == 'runtime' }}
+      - name: Setup XDG_RUNTIME_DIR
+        if: contains(matrix.component.needs, 'XDG_RUNTIME_DIR') && matrix.command != 'make check'
         run: |
           XDG_RUNTIME_DIR=$(mktemp -d "/tmp/kata-tests-$USER.XXX" | tee >(xargs chmod 0700))
           echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" >> "$GITHUB_ENV"
-      - name: Running `${{ matrix.command }}` for ${{ matrix.component }}
+      - name: Running `${{ matrix.command }}` for ${{ matrix.component.name }}
         run: |
-          cd ${{ matrix.component-path }}
+          cd ${{ matrix.component.path }}
           ${{ matrix.command }}
         env:
           RUST_BACKTRACE: "1"

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -22,7 +22,6 @@ jobs:
             path: src/agent
             needs:
               - rust
-              - musl-tools
               - libdevmapper
               - libseccomp
               - protobuf-compiler
@@ -31,7 +30,6 @@ jobs:
             path: src/dragonball
             needs:
               - rust
-              - musl-tools
           - name: runtime
             path: src/runtime
             needs:
@@ -41,29 +39,24 @@ jobs:
             path: src/runtime-rs
             needs:
               - rust
-              - musl-tools
           - name: agent-ctl
             path: src/tools/agent-ctl
             needs:
               - rust
-              - musl-tools
               - protobuf-compiler
               - clang
           - name: kata-ctl
             path: src/tools/kata-ctl
             needs:
               - rust
-              - musl-tools
           - name: trace-forwarder
             path: src/tools/trace-forwarder
             needs:
               - rust
-              - musl-tools
           - name: genpolicy
             path: src/tools/genpolicy
             needs:
               - rust
-              - musl-tools
               - protobuf-compiler
 
     steps:
@@ -88,14 +81,14 @@ jobs:
         run: |
           ./tests/install_go.sh -f -p
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-      - name: Install rust
+      - name: Setup rust
         if: contains(matrix.component.needs, 'rust')
         run: |
           ./tests/install_rust.sh
           echo "${HOME}/.cargo/bin" >> "$GITHUB_PATH"
-      - name: Install musl-tools
-        if: contains(matrix.component.needs, 'musl-tools')
-        run: sudo apt-get -y install musl-tools
+          if [ "$(uname -m)" == "x86_64" ] || [ "$(uname -m)" == "aarch64" ]; then
+            sudo apt-get -y install musl-tools
+          fi
       - name: Install devicemapper
         if: contains(matrix.component.needs, 'libdevmapper') && matrix.command == 'make check'
         run: sudo apt-get -y install libdevmapper-dev

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -12,37 +12,60 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        component:
-          - agent
-          - dragonball
-          - runtime
-          - runtime-rs
-          - agent-ctl
-          - kata-ctl
-          - trace-forwarder
-          - genpolicy
         command:
           - "make vendor"
           - "make check"
           - "make test"
           - "sudo -E PATH=\"$PATH\" make test"
-        include:
-          - component: agent
-            component-path: src/agent
-          - component: dragonball
-            component-path: src/dragonball
-          - component: runtime
-            component-path: src/runtime
-          - component: runtime-rs
-            component-path: src/runtime-rs
-          - component: agent-ctl
-            component-path: src/tools/agent-ctl
-          - component: kata-ctl
-            component-path: src/tools/kata-ctl
-          - component: trace-forwarder
-            component-path: src/tools/trace-forwarder
-          - component: genpolicy
-            component-path: src/tools/genpolicy
+        component:
+          - name: agent
+            path: src/agent
+            needs:
+              - rust
+              - musl-tools
+              - libdevmapper
+              - libseccomp
+              - protobuf-compiler
+              - clang
+          - name: dragonball
+            path: src/dragonball
+            needs:
+              - rust
+              - musl-tools
+          - name: runtime
+            path: src/runtime
+            needs:
+              - golang
+              - XDG_RUNTIME_DIR
+          - name: runtime-rs
+            path: src/runtime-rs
+            needs:
+              - rust
+              - musl-tools
+          - name: agent-ctl
+            path: src/tools/agent-ctl
+            needs:
+              - rust
+              - musl-tools
+              - protobuf-compiler
+              - clang
+          - name: kata-ctl
+            path: src/tools/kata-ctl
+            needs:
+              - rust
+              - musl-tools
+          - name: trace-forwarder
+            path: src/tools/trace-forwarder
+            needs:
+              - rust
+              - musl-tools
+          - name: genpolicy
+            path: src/tools/genpolicy
+            needs:
+              - rust
+              - musl-tools
+              - protobuf-compiler
+
     steps:
       - name: Adjust a permission for repo
         run: |
@@ -61,23 +84,23 @@ jobs:
         env:
           INSTALL_IN_GOPATH: false
       - name: Install golang
-        if: ${{ matrix.component == 'runtime' }}
+        if: contains(matrix.component.needs, 'golang')
         run: |
           ./tests/install_go.sh -f -p
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
       - name: Install rust
-        if: ${{ matrix.component != 'runtime' }}
+        if: contains(matrix.component.needs, 'rust')
         run: |
           ./tests/install_rust.sh
           echo "${HOME}/.cargo/bin" >> "$GITHUB_PATH"
       - name: Install musl-tools
-        if: ${{ matrix.component != 'runtime' }}
+        if: contains(matrix.component.needs, 'musl-tools')
         run: sudo apt-get -y install musl-tools
       - name: Install devicemapper
-        if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
+        if: contains(matrix.component.needs, 'libdevmapper') && matrix.command == 'make check'
         run: sudo apt-get -y install libdevmapper-dev
       - name: Install libseccomp
-        if: ${{ matrix.command != 'make vendor' && matrix.command != 'make check' && matrix.component == 'agent' }}
+        if: contains(matrix.component.needs, 'libseccomp') && matrix.command != 'make vendor' && matrix.command != 'make check'
         run: |
           libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
           gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)
@@ -86,13 +109,13 @@ jobs:
           echo "LIBSECCOMP_LINK_TYPE=static" >> "$GITHUB_ENV"
           echo "LIBSECCOMP_LIB_PATH=${libseccomp_install_dir}/lib" >> "$GITHUB_ENV"
       - name: Install protobuf-compiler
-        if: ${{ matrix.command != 'make vendor' && (matrix.component == 'agent' || matrix.component == 'genpolicy' || matrix.component == 'agent-ctl') }}
+        if: contains(matrix.component.needs, 'protobuf-compiler') && matrix.command != 'make vendor'
         run: sudo apt-get -y install protobuf-compiler
       - name: Install clang
-        if: ${{ matrix.command == 'make check' && (matrix.component == 'agent' || matrix.component == 'agent-ctl') }}
+        if: contains(matrix.component.needs, 'clang') && matrix.command == 'make check'
         run: sudo apt-get -y install clang
-      - name: Setup XDG_RUNTIME_DIR for the `runtime` tests
-        if: ${{ matrix.command != 'make vendor' && matrix.command != 'make check' && matrix.component == 'runtime' }}
+      - name: Setup XDG_RUNTIME_DIR
+        if: contains(matrix.component.needs, 'XDG_RUNTIME_DIR') && matrix.command != 'make check'
         run: |
           XDG_RUNTIME_DIR=$(mktemp -d "/tmp/kata-tests-$USER.XXX" | tee >(xargs chmod 0700))
           echo "XDG_RUNTIME_DIR=${XDG_RUNTIME_DIR}" >> "$GITHUB_ENV"
@@ -100,9 +123,9 @@ jobs:
         if: ${{ endsWith(inputs.instance, '-arm') }}
         run: |
           echo "GITHUB_RUNNER_CI_ARM64=true" >> "$GITHUB_ENV"
-      - name: Running `${{ matrix.command }}` for ${{ matrix.component }}
+      - name: Running `${{ matrix.command }}` for ${{ matrix.component.name }}
         run: |
-          cd ${{ matrix.component-path }}
+          cd ${{ matrix.component.path }}
           ${{ matrix.command }}
         env:
           RUST_BACKTRACE: "1"

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -41,9 +41,6 @@ jobs:
             component-path: src/tools/kata-ctl
           - component: trace-forwarder
             component-path: src/tools/trace-forwarder
-          - install-libseccomp: no
-          - component: agent
-            install-libseccomp: yes
           - component: genpolicy
             component-path: src/tools/genpolicy
     steps:
@@ -80,7 +77,7 @@ jobs:
         if: ${{ matrix.command == 'make check' && matrix.component == 'agent' }}
         run: sudo apt-get -y install libdevmapper-dev
       - name: Install libseccomp
-        if: ${{ matrix.command != 'make vendor'  &&  matrix.command != 'make check' &&  matrix.install-libseccomp == 'yes' }}
+        if: ${{ matrix.command != 'make vendor' && matrix.command != 'make check' && matrix.component == 'agent' }}
         run: |
           libseccomp_install_dir=$(mktemp -d -t libseccomp.XXXXXXXXXX)
           gperf_install_dir=$(mktemp -d -t gperf.XXXXXXXXXX)


### PR DESCRIPTION
- ci: Drop install-libseccomp matrix variant
  `install-libseccomp` is applied only for `agent` component, and we are already combining matrix with `if`s in steps, drop `install-libseccomp` in matrix to reduce complexity.
- ci: Refactor build-checks workflow
  Refator matrix setup and according dependencies installation logic in`build-checks.yaml` and `build-checks-preview-riscv64.yaml` to provide better readability and maintainability.
- ci: Move musl-tools installation into Setup rust
  `musl-tools` is only needed when a component needs `rust`, and the `instance` running is of `x86_64` or `aarch64`.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>