### PR TITLE
agent: support running command in nesting cgroup v2

### DIFF
--- a/src/agent/rustjail/src/cgroups/mod.rs
+++ b/src/agent/rustjail/src/cgroups/mod.rs
@@ -30,6 +30,10 @@ pub trait Manager {
         Err(anyhow!("not supported!".to_string()))
     }
 
+    fn set_init_pid(&mut self, _pid: i32) -> Result<()> {
+        Err(anyhow!("not supported!"))
+    }
+
     fn get_pids(&self) -> Result<Vec<i32>> {
         Err(anyhow!("not supported!"))
     }

--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -1216,7 +1216,7 @@ impl BaseContainer for LinuxContainer {
             &logger,
             spec,
             &p,
-            self.cgroup_manager.as_ref(),
+            self.cgroup_manager.as_mut(),
             self.config.use_systemd_cgroup,
             &st,
             &mut pipe_w,
@@ -1517,7 +1517,7 @@ async fn join_namespaces(
     logger: &Logger,
     spec: &Spec,
     p: &Process,
-    cm: &(dyn Manager + Send + Sync),
+    cm: &mut (dyn Manager + Send + Sync),
     use_systemd_cgroup: bool,
     st: &OCIState,
     pipe_w: &mut PipeStream,
@@ -1583,6 +1583,8 @@ async fn join_namespaces(
     }
 
     if p.init && res.is_some() {
+        info!(logger, "set init pid {} for {:p}", p.pid, cm);
+        cm.set_init_pid(p.pid)?;
         info!(logger, "set properties to cgroups!");
         cm.set(res.unwrap(), false)?;
     }


### PR DESCRIPTION
When running systemd in container, processes should be attached to "init.scope". systemd fixedly use "init.scope" as delegate sub-cgroup name, and the name cannot be changed.

This is a supplement for PR #10845.

Fixes #10733