### PR TITLE
runtime: Properly set default hyp loglevel to 1

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -521,7 +521,9 @@ func (h hypervisor) defaultBridges() uint32 {
 }
 
 func (h hypervisor) defaultHypervisorLoglevel() uint32 {
-	if h.HypervisorLoglevel > maxHypervisorLoglevel {
+	if h.HypervisorLoglevel == 0 {
+		return defaultHypervisorLoglevel
+	} else if h.HypervisorLoglevel > maxHypervisorLoglevel {
 		return maxHypervisorLoglevel
 	}
 

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -184,6 +184,7 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (testConfig testRuntime
 		GuestHookPath:         defaultGuestHookPath,
 		VhostUserStorePath:    defaultVhostUserStorePath,
 		SharedFS:              sharedFS,
+		HypervisorLoglevel:    defaultHypervisorLoglevel,
 		VirtioFSDaemon:        virtioFSdaemon,
 		VirtioFSCache:         defaultVirtioFSCacheMode,
 		PFlash:                []string{},


### PR DESCRIPTION
The documented behavior was that the clh loglevel was set to 1 if unspecified. This was in actuality 0; properly fix the default logic to reflect the documented/expected result.