### PR TITLE
kata-deploy: k0s: Fix drop-in path

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -12,7 +12,7 @@ Set the correct containerd conf path depending on the k8s distribution
 {{- else if eq .k8sDistribution "k3s" -}}
  /var/lib/rancher/k3s/agent/etc/containerd/
 {{- else if eq .k8sDistribution "k0s" -}}
-/etc/k0s/containerd.d/
+/etc/k0s/
 {{- else if eq .k8sDistribution "microk8s" -}}
 /var/snap/microk8s/current/args/
 {{- else -}}

--- a/tools/packaging/kata-deploy/kata-cleanup/overlays/k0s/mount_k0s_conf.yaml
+++ b/tools/packaging/kata-deploy/kata-cleanup/overlays/k0s/mount_k0s_conf.yaml
@@ -14,4 +14,4 @@ spec:
       volumes:
         - name: containerd-conf
           hostPath:
-            path: /etc/k0s/containerd.d/
+            path: /etc/k0s/


### PR DESCRIPTION
The drop-in path should be /etc/containerd (from the containers' perspective), which mounts to the host path /etc/k0s/containerd.d.

With what we had we ended up dropping the file under the /etc/k0s/containerd.d/containerd.d/, which is wrong.

This is a regression introduce by: 94b3348d3c