### PR TITLE
gpu: fix init symlinks

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -275,7 +275,8 @@ chisseled_init() {
 	ln -sf ../run var/run
 
 	tar xvf "${BUILD_DIR}"/kata-static-nvidia-nvrc.tar.zst -C .
-
+	# make sure NVRC is the init process for the initrd and image case
+	ln -sf  /bin/NVRC init
 	ln -sf  /bin/NVRC sbin/init
 
 	cp -a "${stage_one}"/usr/bin/kata-agent   usr/bin/.


### PR DESCRIPTION
With the recent changes we need to make sure NVRC is symlinked for init and sbin/init