### PR TITLE
agent: Enable VFIO and initContainers

### DIFF
--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -95,6 +95,8 @@ impl StorageState {
     }
 }
 
+pub type PciHostGuestMapping = HashMap<pci::Address, pci::Address>;
+
 #[derive(Debug)]
 pub struct Sandbox {
     pub logger: Logger,
@@ -118,7 +120,7 @@ pub struct Sandbox {
     pub event_rx: Arc<Mutex<Receiver<String>>>,
     pub event_tx: Option<Sender<String>>,
     pub bind_watcher: BindWatcher,
-    pub pcimap: HashMap<pci::Address, pci::Address>,
+    pub pcimap: HashMap<String, PciHostGuestMapping>,
     pub devcg_info: Arc<RwLock<DevicesCgroupInfo>>,
 }
 


### PR DESCRIPTION
We had a static mapping of host guest PCI addresses, which prevented to use VFIO devices in initContainers. We're tracking now the host-guest mapping per container and removing this mapping if a container is removed.

We do not properly support VFIO with initContainers or containers in a Pod with different life-cycles (with pass-through devices), In the outer runtime we allocate a root-port slot and deallocate a root-port slot when  creating a container and stopping deleting a container. The kata-agent only does a sb.pcimap.insert(host, guest) but never deallocates the mapping, which needs to be done during stop/delete container to free up the mapping.
```
create initContainer - bind GPU -> alloc: root-port slot 0000:02.0 - agent.pcimap.insert (host, guest)
stop   initContainer - unbind GPU -> dealloc: root-port slot 0000:02.0 - .... bug .... 
create container - bind GPU -> alloc: root-port slot 0000:02.0 - agent.pcimap.insert(host, guest) !?!? ERROR Conflicting guest address 
```

