### PR TITLE
agent: Fix default linux device permissions

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -1016,10 +1016,17 @@ fn mknod_dev(dev: &LinuxDevice, relpath: &Path) -> Result<()> {
         None => return Err(anyhow!("invalid spec".to_string())),
     };
 
+    let file_mode = dev
+        .file_mode()
+        // drop the mode if it is 0
+        .filter(|&m| m != 0)
+        // fall back to 0o666
+        .unwrap_or(0o666);
+
     stat::mknod(
         relpath,
         *f,
-        Mode::from_bits_truncate(dev.file_mode().unwrap_or(0)),
+        Mode::from_bits_truncate(file_mode),
         nix::sys::stat::makedev(dev.major() as u64, dev.minor() as u64),
     )?;
 


### PR DESCRIPTION
We had the default permissions set to 0o000 if the file_mode was not present, for most container devices this is the wrong default. Since those devices are meant also to be accessed by users and others add a sane default of 0o666 to devices that do not have any permissions set.

Otherwise only root can acess those and we cannot run containers as a user.