### PR TITLE
runtime: Remove console=ttysclp0 for s390x

### DIFF
--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -114,8 +114,6 @@ func (q *qemuS390x) appendConsole(ctx context.Context, devices []govmmQemu.Devic
 		return devices, fmt.Errorf("Failed to append console %v", err)
 	}
 
-	q.kernelParams = append(q.kernelParams, Param{"console", "ttysclp0"})
-
 	serial := govmmQemu.SerialDevice{
 		Driver:        virtioSerialCCW,
 		ID:            id,


### PR DESCRIPTION
After the introduction of the following kernel parameters on s390x (see #6163):

```
CONFIG_SCLP_VT220_TTY=y
CONFIG_SCLP_VT220_CONSOLE=y
```

the system log for Kata components (e.g., the agent) no longer appeared on the SCLP console (i.e., /dev/ttysclp0).
Let's switch to the default fallback console (likely /dev/console) for logging on the platform.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>