### PR TITLE
agent: fix permisssion according to runc

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -18,12 +18,13 @@ use std::collections::{HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::mem::MaybeUninit;
 use std::os::unix;
+use std::os::unix::fs::PermissionsExt;
 use std::os::unix::io::RawFd;
 use std::path::{Component, Path, PathBuf};
 
 use path_absolutize::*;
 use std::fs::File;
-use std::io::{BufRead, BufReader};
+use std::io::{BufRead, BufReader, ErrorKind};
 
 use crate::container::DEFAULT_DEVICES;
 use crate::selinux;
@@ -1010,18 +1011,24 @@ lazy_static! {
     };
 }
 
+fn permissions_from_path(path: &Path) -> Result<u32> {
+    match fs::metadata(path) {
+        Ok(metadata) => Ok(metadata.permissions().mode()),
+        Err(e) if e.kind() == ErrorKind::NotFound => Ok(0),
+        Err(e) => Err(e.into()),
+    }
+}
+
 fn mknod_dev(dev: &LinuxDevice, relpath: &Path) -> Result<()> {
     let f = match LINUXDEVICETYPE.get(dev.typ().as_str()) {
         Some(v) => v,
         None => return Err(anyhow!("invalid spec".to_string())),
     };
 
-    let file_mode = dev
-        .file_mode()
-        // drop the mode if it is 0
-        .filter(|&m| m != 0)
-        // fall back to 0o666
-        .unwrap_or(0o666);
+    let file_mode = match dev.file_mode().unwrap_or(0) {
+        0 => permissions_from_path(Path::new(dev.path()))?,
+        x => x,
+    };
 
     stat::mknod(
         relpath,


### PR DESCRIPTION
The previous PR mistakenly set all perms to 0o666 we should follow what runc does and fetch the permission from the guest aka host if the file_mode == 0. If we do not find the device on the guest aka host fallback to 0.