### PR TITLE
runtime-rs: Remove s390x conditional compilation

### DIFF
--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -50,7 +50,6 @@ qapi = { version = "0.14", features = ["qmp", "async-tokio-all"] }
 qapi-spec = "0.3.1"
 qapi-qmp = "0.14.0"
 
-[target.'cfg(not(target_arch = "s390x"))'.dependencies]
 dragonball = { path = "../../../dragonball", features = [
     "atomic-guest-memory",
     "virtio-vsock",

--- a/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
+++ b/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
@@ -118,7 +118,6 @@ impl KernelParams {
         self.params.append(&mut params.params);
     }
 
-    #[cfg(not(target_arch = "s390x"))]
     pub(crate) fn push(&mut self, new_param: Param) {
         self.params.push(new_param);
     }

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -13,9 +13,8 @@ pub mod device;
 pub mod hypervisor_persist;
 pub use device::driver::*;
 use device::DeviceType;
-#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+#[cfg(feature = "dragonball")]
 pub mod dragonball;
-#[cfg(not(target_arch = "s390x"))]
 pub mod firecracker;
 mod kernel_param;
 pub mod qemu;
@@ -24,7 +23,7 @@ pub use kernel_param::Param;
 pub mod utils;
 use std::collections::HashMap;
 
-#[cfg(all(feature = "cloud-hypervisor", not(target_arch = "s390x")))]
+#[cfg(feature = "cloud-hypervisor")]
 pub mod ch;
 
 use anyhow::Result;
@@ -55,13 +54,13 @@ const VM_ROOTFS_FILESYSTEM_EROFS: &str = "erofs";
 // mkdir -p /dev/hugepages
 // mount -t hugetlbfs none /dev/hugepages
 pub const HUGETLBFS: &str = "hugetlbfs";
-// Constants required for Dragonball VMM when enabled and not on s390x.
+// Constants required for Dragonball VMM when enabled
 // Not needed when the built-in VMM is not used.
-#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+#[cfg(feature = "dragonball")]
 const DEV_HUGEPAGES: &str = "/dev/hugepages";
-#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+#[cfg(feature = "dragonball")]
 const SHMEM: &str = "shmem";
-#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+#[cfg(feature = "dragonball")]
 const HUGE_SHMEM: &str = "hugeshmem";
 
 pub const HYPERVISOR_DRAGONBALL: &str = "dragonball";
@@ -72,7 +71,6 @@ pub const HYPERVISOR_REMOTE: &str = "remote";
 pub const DEFAULT_HYBRID_VSOCK_NAME: &str = "kata.hvsock";
 pub const JAILER_ROOT: &str = "root";
 
-#[cfg(not(target_arch = "s390x"))]
 #[derive(PartialEq, Debug, Clone)]
 pub(crate) enum VmmState {
     NotReady,

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -23,7 +23,10 @@ pub use kernel_param::Param;
 pub mod utils;
 use std::collections::HashMap;
 
-#[cfg(feature = "cloud-hypervisor")]
+#[cfg(all(
+    feature = "cloud-hypervisor",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 pub mod ch;
 
 use anyhow::Result;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -21,22 +21,20 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use common::{message::Message, types::SandboxConfig, RuntimeHandler, RuntimeInstance};
 use hypervisor::Hypervisor;
-#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+#[cfg(feature = "dragonball")]
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
-#[cfg(not(target_arch = "s390x"))]
 use hypervisor::{firecracker::Firecracker, HYPERVISOR_FIRECRACKER};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{remote::Remote, HYPERVISOR_REMOTE};
-#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+#[cfg(feature = "dragonball")]
 use kata_types::config::DragonballConfig;
-#[cfg(not(target_arch = "s390x"))]
 use kata_types::config::FirecrackerConfig;
 use kata_types::config::RemoteConfig;
 use kata_types::config::{hypervisor::register_hypervisor_plugin, QemuConfig, TomlConfig};
 
-#[cfg(all(feature = "cloud-hypervisor", not(target_arch = "s390x")))]
+#[cfg(feature = "cloud-hypervisor")]
 use hypervisor::ch::CloudHypervisor;
-#[cfg(all(feature = "cloud-hypervisor", not(target_arch = "s390x")))]
+#[cfg(feature = "cloud-hypervisor")]
 use kata_types::config::{hypervisor::HYPERVISOR_NAME_CH, CloudHypervisorConfig};
 
 use resource::cpu_mem::initial_size::InitialSizeManager;
@@ -57,21 +55,18 @@ impl RuntimeHandler for VirtContainer {
         logging::register_subsystem_logger("runtimes", "virt-container");
 
         // register
-        #[cfg(not(target_arch = "s390x"))]
-        {
-            #[cfg(feature = "dragonball")]
-            let dragonball_config = Arc::new(DragonballConfig::new());
-            #[cfg(feature = "dragonball")]
-            register_hypervisor_plugin("dragonball", dragonball_config);
+        #[cfg(feature = "dragonball")]
+        let dragonball_config = Arc::new(DragonballConfig::new());
+        #[cfg(feature = "dragonball")]
+        register_hypervisor_plugin("dragonball", dragonball_config);
 
-            let firecracker_config = Arc::new(FirecrackerConfig::new());
-            register_hypervisor_plugin("firecracker", firecracker_config);
-        }
+        let firecracker_config = Arc::new(FirecrackerConfig::new());
+        register_hypervisor_plugin("firecracker", firecracker_config);
 
         let qemu_config = Arc::new(QemuConfig::new());
         register_hypervisor_plugin("qemu", qemu_config);
 
-        #[cfg(all(feature = "cloud-hypervisor", not(target_arch = "s390x")))]
+        #[cfg(feature = "cloud-hypervisor")]
         {
             let ch_config = Arc::new(CloudHypervisorConfig::new());
             register_hypervisor_plugin(HYPERVISOR_NAME_CH, ch_config);
@@ -156,7 +151,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
     // TODO: support other hypervisor
     // issue: https://github.com/kata-containers/kata-containers/issues/4634
     match hypervisor_name.as_str() {
-        #[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+        #[cfg(feature = "dragonball")]
         HYPERVISOR_DRAGONBALL => {
             let hypervisor = Dragonball::new();
             hypervisor
@@ -176,7 +171,6 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
                 .await;
             Ok(Arc::new(hypervisor))
         }
-        #[cfg(not(target_arch = "s390x"))]
         HYPERVISOR_FIRECRACKER => {
             let hypervisor = Firecracker::new();
             hypervisor
@@ -184,7 +178,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
                 .await;
             Ok(Arc::new(hypervisor))
         }
-        #[cfg(all(feature = "cloud-hypervisor", not(target_arch = "s390x")))]
+        #[cfg(feature = "cloud-hypervisor")]
         HYPERVISOR_NAME_CH => {
             let hypervisor = CloudHypervisor::new();
             hypervisor

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -32,9 +32,15 @@ use kata_types::config::FirecrackerConfig;
 use kata_types::config::RemoteConfig;
 use kata_types::config::{hypervisor::register_hypervisor_plugin, QemuConfig, TomlConfig};
 
-#[cfg(feature = "cloud-hypervisor")]
+#[cfg(all(
+    feature = "cloud-hypervisor",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 use hypervisor::ch::CloudHypervisor;
-#[cfg(feature = "cloud-hypervisor")]
+#[cfg(all(
+    feature = "cloud-hypervisor",
+    any(target_arch = "x86_64", target_arch = "aarch64")
+))]
 use kata_types::config::{hypervisor::HYPERVISOR_NAME_CH, CloudHypervisorConfig};
 
 use resource::cpu_mem::initial_size::InitialSizeManager;
@@ -66,7 +72,10 @@ impl RuntimeHandler for VirtContainer {
         let qemu_config = Arc::new(QemuConfig::new());
         register_hypervisor_plugin("qemu", qemu_config);
 
-        #[cfg(feature = "cloud-hypervisor")]
+        #[cfg(all(
+            feature = "cloud-hypervisor",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ))]
         {
             let ch_config = Arc::new(CloudHypervisorConfig::new());
             register_hypervisor_plugin(HYPERVISOR_NAME_CH, ch_config);
@@ -178,7 +187,10 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
                 .await;
             Ok(Arc::new(hypervisor))
         }
-        #[cfg(feature = "cloud-hypervisor")]
+        #[cfg(all(
+            feature = "cloud-hypervisor",
+            any(target_arch = "x86_64", target_arch = "aarch64")
+        ))]
         HYPERVISOR_NAME_CH => {
             let hypervisor = CloudHypervisor::new();
             hypervisor

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -21,10 +21,9 @@ use common::{
 
 use containerd_shim_protos::events::task::{TaskExit, TaskOOM};
 use hypervisor::VsockConfig;
-#[cfg(not(target_arch = "s390x"))]
 use hypervisor::HYPERVISOR_FIRECRACKER;
 use hypervisor::HYPERVISOR_REMOTE;
-#[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+#[cfg(feature = "dragonball")]
 use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{utils::get_hvsock_path, HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID};
@@ -34,7 +33,6 @@ use kata_sys_util::hooks::HookStates;
 use kata_sys_util::protection::{available_guest_protection, GuestProtection};
 use kata_types::capabilities::CapabilityBits;
 use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
-#[cfg(not(target_arch = "s390x"))]
 use kata_types::config::hypervisor::HYPERVISOR_NAME_CH;
 use kata_types::config::TomlConfig;
 use oci_spec::runtime as oci;
@@ -743,11 +741,9 @@ impl Persist for VirtSandbox {
             resource: Some(self.resource_manager.save().await?),
             hypervisor: match hypervisor_state.hypervisor_type.as_str() {
                 // TODO support other hypervisors
-                #[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+                #[cfg(feature = "dragonball")]
                 HYPERVISOR_DRAGONBALL => Ok(Some(hypervisor_state)),
-                #[cfg(not(target_arch = "s390x"))]
                 HYPERVISOR_NAME_CH => Ok(Some(hypervisor_state)),
-                #[cfg(not(target_arch = "s390x"))]
                 HYPERVISOR_FIRECRACKER => Ok(Some(hypervisor_state)),
                 HYPERVISOR_QEMU => Ok(Some(hypervisor_state)),
                 HYPERVISOR_REMOTE => Ok(Some(hypervisor_state)),
@@ -783,7 +779,7 @@ impl Persist for VirtSandbox {
         let h = sandbox_state.hypervisor.unwrap_or_default();
         let hypervisor = match h.hypervisor_type.as_str() {
             // TODO support other hypervisors
-            #[cfg(all(feature = "dragonball", not(target_arch = "s390x")))]
+            #[cfg(feature = "dragonball")]
             HYPERVISOR_DRAGONBALL => {
                 let hypervisor = Arc::new(Dragonball::restore((), h).await?) as Arc<dyn Hypervisor>;
                 Ok(hypervisor)


### PR DESCRIPTION
- runtime-rs: Drop s390x target predicates: Drop `target_arch = "s390x"` all over `runtime-rs` since `dragonball` feature is not enabled.
- runtime-rs: Restrict cloud-hypervisor feature: Cloud-Hypervisor currently only supports `x86_64` and `aarch64`, this features should not be avaiable even if other architectures explicitly requires it.
  Restrict `cloud-hypervisor` feature to only `x86_64` and `aarch64`.