### PR TITLE
workflows: shellcheck: Expand vendor ignore

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -27,4 +27,4 @@ jobs:
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@master
         with:
-          ignore_paths: ./src/runtime/vendor/**
+          ignore_paths: "**/vendor/**"

--- a/.github/workflows/shellcheck_required.yaml
+++ b/.github/workflows/shellcheck_required.yaml
@@ -16,7 +16,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  shellcheck:
+  shellcheck-required:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout the code
@@ -29,4 +29,4 @@ jobs:
         uses: ludeeus/action-shellcheck@master
         with:
           severity: error
-          ignore_paths: ./src/runtime/vendor/**
+          ignore_paths: "**/vendor/**"


### PR DESCRIPTION
- In the previous PR I only skipped the runtime/vendor directory, but errors are showing up in other vendor packages, so try a wildcard skip
- Also update the job step was we can distinguish between the required and non-required versions