### PR TITLE
gha: always delete workspace on rebase error

### DIFF
--- a/tests/git-helper.sh
+++ b/tests/git-helper.sh
@@ -17,10 +17,10 @@ function add_kata_bot_info() {
 }
 
 function rebase_atop_of_the_latest_target_branch() {
-	if [ -n "${TARGET_BRANCH}" ]; then
+	if [[ -n "${TARGET_BRANCH}" ]]; then
 		echo "Rebasing atop of the latest ${TARGET_BRANCH}"
-		if ! git rebase origin/${TARGET_BRANCH}; then
-			if [ -n "${GITHUB_WORKSPACE}" ] ; then
+		if ! git rebase "origin/${TARGET_BRANCH}"; then
+			if [[ -n "${GITHUB_WORKSPACE}" ]] ; then
 				echo "Rebase failed, cleaning up the local repository and exiting"
 				cd "${GITHUB_WORKSPACE}"/..
 				sudo rm -rf "${GITHUB_WORKSPACE}"

--- a/tests/git-helper.sh
+++ b/tests/git-helper.sh
@@ -19,13 +19,9 @@ function add_kata_bot_info() {
 function rebase_atop_of_the_latest_target_branch() {
 	if [ -n "${TARGET_BRANCH}" ]; then
 		echo "Rebasing atop of the latest ${TARGET_BRANCH}"
-		# Recover from any previous rebase left halfway
-		git rebase --abort 2> /dev/null || true
 		if ! git rebase origin/${TARGET_BRANCH}; then
-			# if GITHUB_WORKSPACE is defined and an architecture is not equal to x86_64
-			# (mostly self-hosted runners), then remove the repository
-			if [ -n "${GITHUB_WORKSPACE}" ] && [ "$(uname -m)" != "x86_64" ]; then
-				echo "Rebase failed, cleaning up a repository for self-hosted runners and exiting"
+			if [ -n "${GITHUB_WORKSPACE}" ] ; then
+				echo "Rebase failed, cleaning up the local repository and exiting"
 				cd "${GITHUB_WORKSPACE}"/..
 				sudo rm -rf "${GITHUB_WORKSPACE}"
 			else


### PR DESCRIPTION
The workplace was already being deleted on non-x86_64 platforms, but x86_64 can be affected by the same problem too. That might have been the case with the SNP and TDX test runs from:

https://github.com/kata-containers/kata-containers/actions/runs/13687511270/job/38313758751?pr=10973
https://github.com/kata-containers/kata-containers/actions/runs/13687511270/job/38313760086?pr=10973

Rebase worked fine for the same PR #10973 on other platforms - but not on these two x86_64 platforms.

TDX might have recovered successfully using this git-helper.sh change - here:

https://github.com/kata-containers/kata-containers/actions/runs/13705989000/job/38332494333?pr=10973

```
Adding user name and email to the local git repo
Rebasing atop of the latest main
fatal: It seems that there is already a rebase-merge directory, and
I wonder if you are in the middle of another rebase.  If that is the
case, please try
	git rebase (--continue | --abort | --skip)
If that is not the case, please
	rm -fr ".git/rebase-merge"
and run me again.  I am stopping in case you still have something
valuable there.

Rebase failed, cleaning up the local repository and exiting <<<<<<<<<<<<<
##[error]Process completed with exit code 1.
##[group]Run bash tests/integration/kubernetes/gha-run.sh cleanup-tdx
```

Also, fix git-helper issues reported by shellcheck.
