### PR TITLE
kata-deploy: speficied the firmware got from qemu by default for aarch64

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -403,6 +403,12 @@ function install_artifacts() {
 			sed -i -e "s/^enable_annotations = \[\(.*\)\]/enable_annotations = [\1, $allowed_hypervisor_annotations]/" "${kata_config_file}"
 		fi
 
+		# Install firmware for Qemu on aarch64 as this is needed for memory hotplug
+		if [[ "${shim}" == "qemu" || $(uname -m) == "aarch64" ]]; then
+		  firmware="${dest_dir}/share/kata-qemu/qemu/edk2-aarch64-code.fd"
+		  sed -i -e 's|^firmware = "\(.*\)"|firmware = "'${firmware}'"|g' "${kata_config_file}"
+		fi
+
 		if grep -q "tdx" <<< "$shim"; then
   			VERSION_ID=version_unset # VERSION_ID may be unset, see https://www.freedesktop.org/software/systemd/man/latest/os-release.html#Notes
 			source /host/etc/os-release || source /host/usr/lib/os-release


### PR DESCRIPTION
Aarch64 needs to specify the firmware boot in order to get the memory hotplug(only hot add is supported): check the error: #10926 
In Qemu is has a build-in firmware edk2 already for each architecture, so that let's re-use this currently in kata-deploy.

