### PR TITLE
tests: k8s: log kubectl exec ouput

### DIFF
--- a/tests/integration/kubernetes/k8s-configmap.bats
+++ b/tests/integration/kubernetes/k8s-configmap.bats
@@ -40,8 +40,8 @@ setup() {
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Check env
-	kubectl exec $pod_name -- "${exec_command[@]}" | grep "KUBE_CONFIG_1=value-1"
-	kubectl exec $pod_name -- "${exec_command[@]}" | grep "KUBE_CONFIG_2=value-2"
+	grep_pod_exec_output "${pod_name}" "KUBE_CONFIG_1=value-1" "${exec_command[@]}"
+	grep_pod_exec_output "${pod_name}" "KUBE_CONFIG_2=value-2" "${exec_command[@]}"
 }
 
 teardown() {

--- a/tests/integration/kubernetes/k8s-env.bats
+++ b/tests/integration/kubernetes/k8s-env.bats
@@ -32,14 +32,14 @@ setup() {
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	# Print environment variables
-	kubectl exec $pod_name -- "${exec_command[@]}" | grep "MY_POD_NAME=$pod_name"
-	kubectl exec $pod_name -- "${exec_command[@]}" | \
-		grep "HOST_IP=\([0-9]\+\(\.\|$\)\)\{4\}"
+	grep_pod_exec_output "${pod_name}" "MY_POD_NAME=${pod_name}" "${exec_command[@]}"
+	grep_pod_exec_output "${pod_name}" "HOST_IP=\([0-9]\+\(\.\|$\)\)\{4\}" "${exec_command[@]}"
+
 	# Requested 32Mi of memory
-	kubectl exec $pod_name -- "${exec_command[@]}" | \
-		grep "MEMORY_REQUESTS=$((1024 * 1024 * 32))"
+	grep_pod_exec_output "${pod_name}" "MEMORY_REQUESTS=$((1024 * 1024 * 32))" "${exec_command[@]}"
+
 	# Memory limits allocated by the node
-	kubectl exec $pod_name -- "${exec_command[@]}" | grep "MEMORY_LIMITS=[1-9]\+"
+	grep_pod_exec_output "${pod_name}" "MEMORY_LIMITS=[1-9]\+" "${exec_command[@]}"
 }
 
 teardown() {

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -378,3 +378,21 @@ teardown_common() {
 		exec_host "${node}" journalctl -x -t "kata" --since '"'$node_start_time'"' || true
 	fi
 }
+
+# Invoke "kubectl exec", log its output, and check that a grep pattern is present in the output.
+#
+# Parameters:
+#	$1	- pod name
+#	$2	- the grep pattern
+#	$3+	- the command to execute using "kubectl exec"
+#
+grep_pod_exec_output() {
+	local -r pod_name="$1"
+	shift
+	local -r grep_arg="$1"
+	shift
+
+	local -r pod_env=$(kubectl exec "${pod_name}" -- "$@")
+	info "pod_env: ${pod_env}"
+	echo "${pod_env}" | grep "${grep_arg}"
+}


### PR DESCRIPTION
Log the "kubectl exec" ouput, just in case it helps investigate sporadic test errors like:


https://github.com/kata-containers/kata-containers/actions/runs/13724022494/job/38387329268?pr=10973

```not ok 1 ConfigMap for a pod
(in test file k8s-configmap.bats, line 44)
`kubectl exec $pod_name -- "${exec_command[@]}" | grep "KUBE_CONFIG_2=value-2"' failed
```

https://github.com/kata-containers/kata-containers/actions/runs/13724022494/job/38387329321?pr=10973

```not ok 1 Environment variables
(in test file k8s-env.bats, line 37)
 `grep "HOST_IP=\([0-9]\+\(\.\|$\)\)\{4\}"' failed
```