### PR TITLE
policy: validate pod generated name

### DIFF
--- a/src/tools/genpolicy/Cargo.lock
+++ b/src/tools/genpolicy/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "openssl",
  "protobuf 3.3.0",
  "protocols",
+ "regex",
  "serde",
  "serde-transcode",
  "serde_ignored",

--- a/src/tools/genpolicy/Cargo.toml
+++ b/src/tools/genpolicy/Cargo.toml
@@ -21,6 +21,7 @@ clap = { version = "4.1.8", features = ["derive"] }
 # YAML file serialization/deserialization.
 base64 = "0.21.0"
 serde = { version = "1.0.159", features = ["derive"] }
+regex = "1.10.5"
 
 # Newer serde_yaml versions are using unsafe-libyaml instead of yaml-rust,
 # and incorrectly change on serialization:

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -275,19 +275,10 @@ allow_by_sandbox_name(p_oci, i_oci, p_storages, i_storages, s_name) {
 }
 
 allow_sandbox_name(p_s_name, i_s_name) {
-    print("allow_sandbox_name 1: start")
+    print("allow_sandbox_name: start")
+    regex.match(p_s_name, i_s_name)
 
-    p_s_name == i_s_name
-
-    print("allow_sandbox_name 1: true")
-}
-allow_sandbox_name(p_s_name, i_s_name) {
-    print("allow_sandbox_name 2: start")
-
-    # TODO: should generated names be handled differently?
-    contains(p_s_name, "$(generated-name)")
-
-    print("allow_sandbox_name 2: true")
+    print("allow_sandbox_name: true")
 }
 
 # Check that the "io.kubernetes.cri.container-type" and

--- a/src/tools/genpolicy/src/obj_meta.rs
+++ b/src/tools/genpolicy/src/obj_meta.rs
@@ -34,9 +34,10 @@ pub struct ObjectMeta {
 impl ObjectMeta {
     pub fn get_name(&self) -> String {
         if let Some(name) = &self.name {
-            name.clone()
-        } else if self.generateName.is_some() {
-            "$(generated-name)".to_string()
+            format!("^{}$", regex::escape(name))
+        } else if let Some(generateName) = &self.generateName {
+            // https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names
+            format!("^{}[a-z0-9.-]*[a-z0-9]$", regex::escape(generateName))
         } else {
             String::new()
         }

--- a/src/tools/genpolicy/tests/main.rs
+++ b/src/tools/genpolicy/tests/main.rs
@@ -144,4 +144,9 @@ mod tests {
     async fn test_create_container_sysctls() {
         runtests::<CreateContainerRequest>("createcontainer/sysctls").await;
     }
+
+    #[tokio::test]
+    async fn test_create_container_generate_name() {
+        runtests::<CreateContainerRequest>("createcontainer/generate_name").await;
+    }
 }

--- a/src/tools/genpolicy/tests/testdata/createcontainer/generate_name/pod.yaml
+++ b/src/tools/genpolicy/tests/testdata/createcontainer/generate_name/pod.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  generateName: dummy
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+    - name: dummy
+      image: "registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"

--- a/src/tools/genpolicy/tests/testdata/createcontainer/generate_name/testcases.json
+++ b/src/tools/genpolicy/tests/testdata/createcontainer/generate_name/testcases.json
@@ -1,0 +1,264 @@
+[
+  {
+    "description": "generated name with valid prefix (dummyxyz)",
+    "allowed": true,
+    "request": {
+      "OCI": {
+        "Version": "1.1.0",
+        "Annotations": {
+          "io.kubernetes.cri.sandbox-name": "dummyxyz",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "nerdctl/network-namespace": "/var/run/netns/cni-00000000-0000-0000-0000-000000000000",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_dummyxyz_00000000-0000-0000-0000-000000000000",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "Linux": {
+          "GIDMappings": [],
+          "MountLabel": "",
+          "Resources": {
+            "Devices": []
+          },
+          "RootfsPropagation": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            },
+            {
+              "Path": "/run/netns/podns",
+              "Type": "network"
+            }
+          ],
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/proc/scsi"
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ]
+        },
+        "Process": {
+          "SelinuxLabel": "",
+          "User": {
+            "Username": "",
+            "UID": 65535
+          },
+          "Args": [
+            "/pause"
+          ],
+          "Cwd": "/",
+          "NoNewPrivileges": true,
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          }
+        },
+        "Root": {
+          "Readonly": true,
+          "Path": "/run/kata-containers/shared/containers/bundle-id/rootfs"
+        }
+      }
+    }
+  },
+  {
+    "description": "generated name with invalid prefix (xyzdummy)",
+    "allowed": false,
+    "request": {
+      "OCI": {
+        "Version": "1.1.0",
+        "Annotations": {
+          "io.kubernetes.cri.sandbox-name": "xyzdummy",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "nerdctl/network-namespace": "/var/run/netns/cni-00000000-0000-0000-0000-000000000000",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_xyzdummy_00000000-0000-0000-0000-000000000000",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "Linux": {
+          "GIDMappings": [],
+          "MountLabel": "",
+          "Resources": {
+            "Devices": []
+          },
+          "RootfsPropagation": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            },
+            {
+              "Path": "/run/netns/podns",
+              "Type": "network"
+            }
+          ],
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/proc/scsi"
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ]
+        },
+        "Process": {
+          "SelinuxLabel": "",
+          "User": {
+            "Username": "",
+            "UID": 65535
+          },
+          "Args": [
+            "/pause"
+          ],
+          "Cwd": "/",
+          "NoNewPrivileges": true,
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          }
+        },
+        "Root": {
+          "Readonly": true,
+          "Path": "/run/kata-containers/shared/containers/bundle-id/rootfs"
+        }
+      }
+    }
+  }
+]


### PR DESCRIPTION
Validate sandbox name using a regex. If the YAML specifies metadata.name, use a regex that exact matches.
If the YAML specifies metadata.generateName, use a regex that matches the prefix of the generated name.

Context: see generateName in https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta