### PR TITLE
workflows: Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,52 @@ updates:
       - dependency-name: "virtio-vsock"
       - dependency-name: "vm-memory"
       - dependency-name: "vmm-sys-util"
+    # As we often have up to 8/9 components that need the same versions bumps
+    # create groups for common dependencies, so they can all go in a single PR
+    # We can extend this as we see more frequent groups
+    groups:
+      atty:
+        patterns:
+          - atty
+      bit-vec:
+        patterns:
+          - bit-vec
+      bumpalo:
+        patterns:
+          - bumpalo
+      clap:
+        patterns:
+          - clap
+      crossbeam:
+        patterns:
+          - crossbeam
+      h2:
+        patterns:
+          - h2
+      idna:
+        patterns:
+          - idna
+      openssl:
+        patterns:
+          - openssl
+      protobuf:
+        patterns:
+          - protobuf
+      rsa:
+        patterns:
+          - rsa
+      rustix:
+        patterns:
+          - rustix
+      time:
+        patterns:
+          - time
+      tokio:
+        patterns:
+          - tokio
+      tracing:
+        patterns:
+          - tracing
 
   - package-ecosystem: "gomod"
     directories:


### PR DESCRIPTION
The default dependabot config isn't working
due to dragonball workspace crates with:
```
Handled error whilst updating thiserror: dependency_file_not_resolvable
{:message=>"error: failed to parse manifest at
`dependabot_tmp_dir/src/dragonball/dbs_pci/Cargo.toml`\n\nCaused by:\n
error inheriting `kvm-bindings` from workspace root manifest's
`workspace.dependencies.kvm-bindings`\n\nCaused by:\n
failed to find a workspace root"}
```
so create a custom config that skips those crates to allow us to progress