### PR TITLE
Fix "libgcc_s.so.1" not found in the nvidia-gpu initrds

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -48,8 +48,8 @@ setup_nvidia-nvrc() {
 
 	pushd "${PROJECT}" > /dev/null || exit 1
 
-	cargo build --release --target="${machine_arch}"-unknown-linux-gnu
-	cp target/"${machine_arch}"-unknown-linux-gnu/release/NVRC ../../destdir/bin/.
+	cargo build --release --target="${machine_arch}"-unknown-linux-musl
+	cp target/"${machine_arch}"-unknown-linux-musl/release/NVRC ../../destdir/bin/.
 
 	popd > /dev/null || exit 1
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -518,7 +518,7 @@ install_image_nvidia_gpu_confidential() {
 	export AGENT_POLICY="yes"
 	export EXTRA_PKGS="apt"
 	# TODO: export MEASURED_ROOTFS=yes
-	NVIDIA_GPU_STACK=${NVIDIA_GPU_STACK:-"latest,compute"}
+	NVIDIA_GPU_STACK=${NVIDIA_GPU_STACK:-"latest,compute,dcgm"}
 	install_image "nvidia-gpu-confidential"
 }
 
@@ -527,7 +527,7 @@ install_initrd_nvidia_gpu_confidential() {
 	export AGENT_POLICY="yes"
 	export EXTRA_PKGS="apt"
 	# TODO: export MEASURED_ROOTFS=yes
-	NVIDIA_GPU_STACK=${NVIDIA_GPU_STACK:-"latest,compute"}
+	NVIDIA_GPU_STACK=${NVIDIA_GPU_STACK:-"latest,compute,dcgm"}
 	install_initrd "nvidia-gpu-confidential"
 }
 


### PR DESCRIPTION
In the nvidia-gpu initrds, the init points to the NVRC binary, but it is failing to run because it was not able to find the libgcc_s.so.1

```
Mar 03 22:04:16 ai-sandbox-srv121l-gpu crio[4109692]: time="2025-03-03T22:04:16.325850078Z" level=debug msg="reading guest console" console-protocol=unix console-url=/run/vc/vm/78455bb683f82687b661f97afb60e87b593abe6983eef2ccbdbc731ce0fb02b7/console.sock
 name=containerd-shim-v2 pid=690641 sandbox=78455bb683f82687b661f97afb60e87b593abe6983eef2ccbdbc731ce0fb02b7 source=virtcontainers subsystem=sandbox vmconsole="/init: error while loading shared libraries: libgcc_s.so.1: cannot open shared object file: No such file or directory"
```

This PR fixes that