### PR TITLE
genpolicy: Reenable user gid policy

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -680,11 +680,8 @@ allow_user(p_process, i_process) {
     print("allow_user: input uid =", i_user.UID, "policy uid =", p_user.UID)
     p_user.UID == i_user.UID
 
-    # TODO: track down the reason for registry.k8s.io/pause:3.9 being
-    #       executed with gid = 0 despite having "65535:65535" in its container image
-    #       config.
-    #print("allow_user: input gid =", i_user.GID, "policy gid =", p_user.GID)
-    #p_user.GID == i_user.GID
+    print("allow_user: input gid =", i_user.GID, "policy gid =", p_user.GID)
+    p_user.GID == i_user.GID
 
     # TODO: compare the additionalGids field too after computing its value
     # based on /etc/passwd and /etc/group from the container image.


### PR DESCRIPTION
It doesn't seem significant that the pause container group id is omitted when explicitly included in the pod yaml. The GID is properly reflected in the implicit (injected) pause container. Attempt reenabling this check as in all other cases the field is properly populated. 