### PR TITLE
ci.ocp: Override default runtimeclass CPU resources

### DIFF
--- a/ci/openshift-ci/test.sh
+++ b/ci/openshift-ci/test.sh
@@ -26,6 +26,9 @@ info "Install and configure kata into the test cluster"
 export SELINUX_PERMISSIVE="no"
 "${script_dir}/cluster/install_kata.sh" || die "Failed to install kata-containers"
 
+info "Overriding KATA_RUNTIME cpu resources"
+oc patch "runtimeclass/${KATA_RUNTIME}" -p '{"overhead": {"podFixed": {"cpu": "50m"}}}'
+
 info "Run test suite: ${suite}"
 test_status='PASS'
 "${script_dir}/run_${suite}_test.sh" || test_status='FAIL'


### PR DESCRIPTION
some of the e2e tests spawn a lot of workers which are mainly idle, but the scheduler fails to schedule them due to cpu resource overcommit. For our testing we are more focused on having actual pods running than the speed of the scheduled pods so let's increase the amount of schedulable pods by decreasing the default cpu requests.