### PR TITLE
kata-manager: Update config.toml version

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -687,6 +687,9 @@ configure_containerd()
 	sudo test -e "$containerd_config" || {
 		sudo touch "$containerd_config"
 		info "Created $containerd_config"
+		cat <<-EOF | sudo tee -a "$containerd_config"
+		version = 2
+		EOF
 	}
 
 	local original


### PR DESCRIPTION
Containerd's config.toml version 1 is deprecated.
<https://github.com/containerd/containerd/blob/main/RELEASES.md#daemon-configuration>

Fixes: #11033