### PR TITLE
arm64: Update ptp.conf to correct time sync

### DIFF
--- a/tools/packaging/kernel/configs/fragments/arm64/ptp.conf
+++ b/tools/packaging/kernel/configs/fragments/arm64/ptp.conf
@@ -8,5 +8,5 @@
 # will change with time, we need update the patch again and again. For now, we
 # disable ptp_kvm to wait for the stable kernel version of virtio-fs or ptp_kvm
 # accept by upstream.
-#CONFIG_PTP_1588_CLOCK=y
-#CONFIG_PTP_1588_CLOCK_KVM=y
+CONFIG_PTP_1588_CLOCK=y
+CONFIG_PTP_1588_CLOCK_KVM=y


### PR DESCRIPTION
Given the patch has been merged in linux upstream, it's safe to enable these two options.