### PR TITLE
runtime-rs: Support and enable build on riscv64

### DIFF
--- a/.github/workflows/build-checks-preview-riscv64.yaml
+++ b/.github/workflows/build-checks-preview-riscv64.yaml
@@ -43,6 +43,10 @@ jobs:
               - rust
               - musl-tools
               - protobuf-compiler
+          - name: runtime-rs
+            path: src/runtime-rs
+            needs:
+              - rust
 
     steps:
       - name: Adjust a permission for repo

--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -277,6 +277,13 @@ pub fn available_guest_protection() -> Result<GuestProtection, ProtectionError> 
     Ok(GuestProtection::NoProtection)
 }
 
+#[cfg(target_arch = "riscv64")]
+#[allow(dead_code)]
+// Guest protection is not supported on RISC-V.
+pub fn available_guest_protection() -> Result<GuestProtection, ProtectionError> {
+    Ok(GuestProtection::NoProtection)
+}
+
 #[cfg(target_arch = "x86_64")]
 #[cfg(test)]
 mod tests {

--- a/src/runtime-rs/arch/riscv64gc-options.mk
+++ b/src/runtime-rs/arch/riscv64gc-options.mk
@@ -1,0 +1,13 @@
+# Copyright (c) 2025 Institute of Software, CAS.
+# Copyright (c) 2019-2022 Alibaba Cloud
+# Copyright (c) 2019-2022 Ant Group
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+MACHINETYPE := virt
+KERNELPARAMS := cgroup_no_v1=all systemd.unified_cgroup_hierarchy=1
+MACHINEACCELERATORS :=
+CPUFEATURES :=
+
+QEMUCMD := qemu-system-riscv64


### PR DESCRIPTION
- kata-sys-util: Set NoProtection for riscv64: `available_guets_protection` is required for `runtime-rs` to infer while building it on riscv64 platforms. Set it to `NoProtection` as riscv64 does not support guest protection for now.
- runtime-rs: Enable RISC-V build: Define `riscv64gc-options.mk` to enable `runtime-rs` to be built on RISC-V platforms.
- ci: Enable runtime-rs component build-check on riscv64: `runtime-rs` is now buildable and testable on riscv64 platforms, enable `build-check` on `runtime-rs`.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>