### PR TITLE
build: drop libtdx-attest

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -28,24 +28,6 @@ suite=$OS_VERSION
 packages=$PACKAGES $EXTRA_PKGS
 EOF
 
-	if [ "${CONFIDENTIAL_GUEST}" == "yes" ] && [ "${DEB_ARCH}" == "amd64" ]; then
-		mkdir -p $rootfs_dir/etc/apt/trusted.gpg.d/
-		curl -fsSL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key |
-			gpg --dearmour -o $rootfs_dir/etc/apt/trusted.gpg.d/intel-sgx-deb.gpg
-		sed -i -e "s/bootstrap=Ubuntu/bootstrap=Ubuntu intel-sgx/" $multistrap_conf
-		SUITE=$OS_VERSION
-		# Intel does not release sgx stuff for non-LTS, thus if using oracular (24.10),
-		# we need to enforce getting libtdx-attest from noble.
-		[ "$SUITE" = "oracular" ] && SUITE="noble"
-		cat >> $multistrap_conf << EOF
-
-[intel-sgx]
-source=https://download.01.org/intel-sgx/sgx_repo/ubuntu
-suite=$SUITE
-packages=libtdx-attest=1.22\*
-EOF
-	fi
-
 	# This fixes the spurious error
 	# E: Can't find a source to download version '2021.03.26' of 'ubuntu-keyring:amd64'
 	apt update

--- a/tools/packaging/static-build/coco-guest-components/Dockerfile
+++ b/tools/packaging/static-build/coco-guest-components/Dockerfile
@@ -12,7 +12,6 @@ ENV RUSTUP_HOME="/opt/rustup"
 ENV CARGO_HOME="/opt/cargo"
 ENV PATH="/opt/cargo/bin/:${PATH}"
 
-# Note - the TDX lib is only available on x86, so there is an arch check in the package install
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME} && chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
@@ -21,12 +20,6 @@ RUN apt-get update && \
 	apt-get --no-install-recommends install -y \
 	ca-certificates \
 	curl \
-	gnupg && \
-	if [ "$(uname -m)" == "x86_64" ]; then curl -sL https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | gpg --dearmor --output /usr/share/keyrings/intel-sgx.gpg && \
-	echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/intel-sgx.gpg] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
-	apt-get update && \
-	apt-get --no-install-recommends -y install libtdx-attest-dev; fi && \
-	apt-get --no-install-recommends -y install \
 	binutils \
 	clang \
 	g++ \


### PR DESCRIPTION
with the latest CoCo guest-components, tdx-attester no longer depends on libtdx attest. Stop installing it to the rootfs.