### PR TITLE
runtime: qemu: add support to use TDX QGS via Unix Domain Sockets

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -127,6 +127,27 @@ func TestAppendDeviceNVDIMM(t *testing.T) {
 	testAppend(object, deviceNVDIMMString, t)
 }
 
+var (
+	tdxObjectVsock = `-object {"qom-type":"tdx-guest","id":"tdx","quote-generation-socket":{"type":"vsock","cid":"2","port":"4050"}}`
+	tdxObjectUnix  = `-object {"qom-type":"tdx-guest","id":"tdx","quote-generation-socket":{"type":"unix","path":"/var/run/tdx-qgs/qgs.socket"}}`
+)
+
+func TestTdxQuoteSocket(t *testing.T) {
+	object := Object{
+		Type:     TDXGuest,
+		ID:       "tdx",
+		File:     "unused",
+		DeviceID: "unused",
+		QgsPort:  0,
+	}
+
+	testAppend(object, tdxObjectUnix, t)
+
+	object.QgsPort = 4050
+
+	testAppend(object, tdxObjectVsock, t)
+}
+
 var objectEPCString = "-object memory-backend-epc,id=epc0,size=65536,prealloc=on"
 
 func TestAppendEPCObject(t *testing.T) {


### PR DESCRIPTION
TDX Quote Generation Service (QGS) signs TDREPORT sent to it from Qemu (GetQuote hypercall). Qemu needs quote-generation-socket address configured for IPC.

Currently, Kata govmm only enables vsock based IPC for QGS but QGS supports Unix Domain Sockets too which works well for host process to process IPC (Qemu <-> QGS).

The QGS configuration to enable UDS is to run the service with "-port=0" parameter. The same works well here too: setting
"tdx_quote_generation_service_socket_port=0" lets users to enable UDS based IPC.

(unit tested only. this is an opt-in change so no change by default).