### PR TITLE
runtime: virtio-fs: Support "metadata" cache mode

### DIFF
--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -163,6 +163,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -212,6 +212,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -221,6 +221,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -205,6 +205,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -210,6 +210,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -196,6 +196,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -221,6 +221,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -206,6 +206,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -211,6 +211,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/config/configuration-stratovirt.toml.in
+++ b/src/runtime/config/configuration-stratovirt.toml.in
@@ -144,6 +144,10 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #
+#  - metadata
+#    Metadata and pathname lookup are cached in guest and never expire.
+#    Data is never cached in guest.
+#
 #  - auto
 #    Metadata and pathname lookup cache expires after a configured amount of
 #    time (default is 1 second). Data is cached while the file is open (close

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -877,10 +877,10 @@ func setupStorages(ctx context.Context, sandbox *Sandbox) []*grpc.Storage {
 		if sharedFS == config.VirtioFS || sharedFS == config.VirtioFSNydus {
 			// If virtio-fs uses either of the two cache options 'auto, always',
 			// the guest directory can be mounted with option 'dax' allowing it to
-			// directly map contents from the host. When set to 'never', the mount
+			// directly map contents from the host. Otherwise, the mount
 			// options should not contain 'dax' lest the virtio-fs daemon crashing
 			// with an invalid address reference.
-			if sandbox.config.HypervisorConfig.VirtioFSCache != typeVirtioFSCacheModeNever {
+			if sandbox.config.HypervisorConfig.VirtioFSCache != typeVirtioFSCacheModeNever && sandbox.config.HypervisorConfig.VirtioFSCache != typeVirtioFSCacheModeMetadata {
 				// If virtio_fs_cache_size = 0, dax should not be used.
 				if sandbox.config.HypervisorConfig.VirtioFSCacheSize != 0 {
 					sharedDirVirtioFSOptions = append(sharedDirVirtioFSOptions, sharedDirVirtioFSDaxOptions)

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -38,9 +38,10 @@ var (
 )
 
 const (
-	typeVirtioFSCacheModeNever  = "never"
-	typeVirtioFSCacheModeAlways = "always"
-	typeVirtioFSCacheModeAuto   = "auto"
+	typeVirtioFSCacheModeNever    = "never"
+	typeVirtioFSCacheModeMetadata = "metadata"
+	typeVirtioFSCacheModeAlways   = "always"
+	typeVirtioFSCacheModeAuto     = "auto"
 )
 
 type VirtiofsDaemon interface {
@@ -216,9 +217,16 @@ func (v *virtiofsd) valid() error {
 		return errVirtiofsdSourceNotAvailable
 	}
 
-	if v.cache == "" {
+	switch v.cache {
+	case "":
 		v.cache = typeVirtioFSCacheModeAuto
-	} else if v.cache != typeVirtioFSCacheModeAuto && v.cache != typeVirtioFSCacheModeAlways && v.cache != typeVirtioFSCacheModeNever {
+	case
+		typeVirtioFSCacheModeAuto,
+		typeVirtioFSCacheModeAlways,
+		typeVirtioFSCacheModeMetadata,
+		typeVirtioFSCacheModeNever:
+		// No-op, accepted
+	default:
 		return errVirtiofsdInvalidVirtiofsCacheMode(v.cache)
 	}
 

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -133,6 +133,9 @@ func TestValid(t *testing.T) {
 		{"invalid cache mode", func(v *virtiofsd) {
 			v.cache = "foo"
 		}, errVirtiofsdInvalidVirtiofsCacheMode("foo"), nil},
+		{"valid metadata cache mode", func(v *virtiofsd) {
+			v.cache = typeVirtioFSCacheModeMetadata
+		}, nil, nil},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
The Rust virtiofsd supports a "metadata" cache mode [1] that wasn't present in the C version [2], so this PR adds support for that.

 [1] https://gitlab.com/virtio-fs/virtiofsd
 [2] https://qemu.weilnetz.de/doc/5.1/tools/virtiofsd.html#cmdoption-virtiofsd-cache