### PR TITLE
ci: Generalize `GITHUB_RUNNER_CI_ARM64`

### DIFF
--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -115,7 +115,7 @@ jobs:
       - name: Skip tests that depend on virtualization capable runners when needed
         if: ${{ endsWith(inputs.instance, '-arm') }}
         run: |
-          echo "GITHUB_RUNNER_CI_ARM64=true" >> "$GITHUB_ENV"
+          echo "GITHUB_RUNNER_CI_NON_VIRT=true" >> "$GITHUB_ENV"
       - name: Running `${{ matrix.command }}` for ${{ matrix.component.name }}
         run: |
           cd ${{ matrix.component.path }}

--- a/src/runtime/cmd/kata-runtime/kata-check_arm64_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-check_arm64_test.go
@@ -25,7 +25,7 @@ func setupCheckHostIsVMContainerCapable(assert *assert.Assertions, cpuInfoFile s
 }
 
 func TestCCCheckCLIFunction(t *testing.T) {
-	if os.Getenv("GITHUB_RUNNER_CI_ARM64") == "true" {
+	if os.Getenv("GITHUB_RUNNER_CI_NON_VIRT") == "true" {
 		t.Skip("Skipping the test as the GitHub self hosted runners for ARM64 do not support Virtualization")
 	}
 

--- a/src/runtime/cmd/kata-runtime/kata-env_arm64_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_arm64_test.go
@@ -18,7 +18,7 @@ func getExpectedHostDetails(tmpdir string) (HostInfo, error) {
 }
 
 func TestEnvGetEnvInfoSetsCPUType(t *testing.T) {
-	if os.Getenv("GITHUB_RUNNER_CI_ARM64") == "true" {
+	if os.Getenv("GITHUB_RUNNER_CI_NON_VIRT") == "true" {
 		t.Skip("Skipping the test as the GitHub self hosted runners for ARM64 do not support Virtualization")
 	}
 	testEnvGetEnvInfoSetsCPUTypeGeneric(t)

--- a/src/runtime/cmd/kata-runtime/kata-env_test.go
+++ b/src/runtime/cmd/kata-runtime/kata-env_test.go
@@ -375,7 +375,7 @@ func TestEnvGetMetaInfo(t *testing.T) {
 }
 
 func TestEnvGetHostInfo(t *testing.T) {
-	if os.Getenv("GITHUB_RUNNER_CI_ARM64") == "true" {
+	if os.Getenv("GITHUB_RUNNER_CI_NON_VIRT") == "true" {
 		t.Skip("Skipping the test as the GitHub self hosted runners for ARM64 do not support Virtualization")
 	}
 
@@ -439,7 +439,7 @@ func TestEnvGetHostInfoNoProcVersion(t *testing.T) {
 }
 
 func TestEnvGetEnvInfo(t *testing.T) {
-	if os.Getenv("GITHUB_RUNNER_CI_ARM64") == "true" {
+	if os.Getenv("GITHUB_RUNNER_CI_NON_VIRT") == "true" {
 		t.Skip("Skipping the test as the GitHub self hosted runners for ARM64 do not support Virtualization")
 	}
 
@@ -471,7 +471,7 @@ func TestEnvGetEnvInfo(t *testing.T) {
 }
 
 func TestEnvGetEnvInfoNoHypervisorVersion(t *testing.T) {
-	if os.Getenv("GITHUB_RUNNER_CI_ARM64") == "true" {
+	if os.Getenv("GITHUB_RUNNER_CI_NON_VIRT") == "true" {
 		t.Skip("Skipping the test as the GitHub self hosted runners for ARM64 do not support Virtualization")
 	}
 


### PR DESCRIPTION
`GITHUB_RUNNER_CI_ARM64` is turned on for self hosted runners without virtualization to skipped those tests depend on virtualization. This may happen to other archs/runners as well, let's generalize it to `GITHUB_RUNNER_CI_NON_VIRT` so we can reuse it on other archs.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>