### PR TITLE
kata-deploy: readlink in merge-builds

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -13,11 +13,11 @@ set -o errtrace
 kata_build_dir=${1:-build}
 kata_versions_yaml_file=${2:-""}
 
-tar_path="${PWD}/kata-static.tar.xz"
-kata_versions_yaml_file_path="${PWD}/${kata_versions_yaml_file}"
+tar_path=$(readlink -f kata-static.tar.xz)
+kata_versions_yaml_file_path=$(readlink -f "${kata_versions_yaml_file}")
 
 pushd "${kata_build_dir}"
-tarball_content_dir="${PWD}/kata-tarball-content"
+tarball_content_dir=$(readlink -f kata-tarball-content)
 rm -rf "${tarball_content_dir}"
 mkdir "${tarball_content_dir}"
 


### PR DESCRIPTION
Currently, kata-deploy-merge-builds.sh canonicalizes files by setting them relative to `${PWD}`, which will not work when called with an absolute path. The latter occurs e.g. when using `make kata-tarball`, invoking the `merge-builds` recipe from the kata-deploy Makefile. Use `readlink` instead.