### PR TITLE
kata-deploy: return exit code for invalid argument

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -909,8 +909,8 @@ function main() {
 			reset_runtime $runtime
 			;;
 		*)
-			echo invalid arguments
 			print_usage
+			die "invalid arguments"
 			;;
 		esac
 	fi


### PR DESCRIPTION
It hangs when invalid arguments are specified.

```bash
kata-deploy-6sr2p:/# /opt/kata-artifacts/scripts/kata-deploy.sh xxx
Action:
* xxx
...
Usage: /opt/kata-artifacts/scripts/kata-deploy.sh [install/cleanup/reset]
ERROR: invalid arguments
...
^C <- hang
```

I changed it to behave the same as when there are no arguments.

```bash
kata-deploy-6sr2p:/# /opt/kata-artifacts/scripts/kata-deploy.sh
Usage: /opt/kata-artifacts/scripts/kata-deploy.sh [install/cleanup/reset]
ERROR: invalid arguments
kata-deploy-6sr2p:/# echo $?
1
```

Fixes: #11068