### PR TITLE
tests: tests/metrics/cpu/c-ray Dockerfile is outdated

### DIFF
--- a/tests/metrics/cpu/c-ray/Dockerfile
+++ b/tests/metrics/cpu/c-ray/Dockerfile
@@ -11,7 +11,7 @@ LABEL DOCKERFILE_VERSION="1.0"
 ENV DEBIAN_FRONTEND=noninteractive
 
 # URL for c-ray benchmark
-ENV CRAY_URL "http://www.phoronix-test-suite.com/benchmark-files/c-ray-1.1.tar.gz"
+ENV CRAY_URL="http://www.phoronix-test-suite.com/benchmark-files/c-ray-1.1.tar.gz"
 
 RUN apt-get update && \
 	apt-get install -y --no-install-recommends build-essential gcc curl && \

--- a/tests/metrics/cpu/c-ray/Dockerfile
+++ b/tests/metrics/cpu/c-ray/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 # Usage: FROM [image name]
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 
 # Version of the Dockerfile
 LABEL DOCKERFILE_VERSION="1.0"


### PR DESCRIPTION
tests/metrics/cpu/c-ray is tested on Ubuntu 20.04.

But 20.04 is approaching its EOL.Therefore, I have migrated to Ubuntu 24.04 LTS.

> Ubuntu 20.04 LTS, this support will last until 31 May 2025. 
>    <https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare>

https://github.com/kata-containers/kata-containers/blob/7a704453b6f426b76e141086bffd1379d89501b8/tests/metrics/cpu/c-ray/Dockerfile#L6



The Dockerfile syntax is outdated.Therefore, I fixed(my docker version is 28.0.2)

```
$ ./cray.sh
[cray.sh:177] INFO: -e
===== starting test [cray] =====
[cray.sh:65] INFO: command: docker: yes
[cray.sh:65] INFO: command: ctr: yes
[cray.sh:307] INFO: restart containerd service
[cray.sh:202] INFO: init environment complete
[cray.sh:65] INFO: command: awk: yes
[cray.sh:65] INFO: command: docker: yes
...
 1 warning found (use docker --debug to expand):
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 14)
unpacking docker.io/library/cray:latest (sha256:019bf0ddcdfdf975d48e928a116cae338ec7e2841eb84b1be3554fda711f83f1)...done
```