### PR TITLE
tests: Enable sealed secrets for all TEEs

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -39,6 +39,11 @@ kbs_set_allow_all_resources() {
 		"${COCO_KBS_DIR}/sample_policies/allow_all.rego"
 }
 
+kbs_set_default_policy() {
+	kbs_set_resources_policy \
+		"${COCO_KBS_DIR}/src/policy_engine/opa/default_policy.rego"
+}
+
 # Set "deny all" policy to resources.
 #
 kbs_set_deny_all_resources() {

--- a/tests/integration/kubernetes/k8s-sealed-secret.bats
+++ b/tests/integration/kubernetes/k8s-sealed-secret.bats
@@ -70,6 +70,8 @@ setup() {
 
 	if ! is_confidential_hardware; then
 		kbs_set_allow_all_resources
+	else
+		kbs_set_default_policy
 	fi
 }
 

--- a/tests/integration/kubernetes/k8s-sealed-secret.bats
+++ b/tests/integration/kubernetes/k8s-sealed-secret.bats
@@ -15,7 +15,9 @@ export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 export AA_KBC="${AA_KBC:-cc_kbc}"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" = "qemu-coco-dev" ] || skip "Test not ready yet for ${KATA_HYPERVISOR}"
+	if ! is_confidential_runtime_class; then
+		skip "Test not supported for ${KATA_HYPERVISOR}."
+	fi
 
 	if [ "${KBS}" = "false" ]; then
 		skip "Test skipped as KBS not setup"
@@ -105,7 +107,9 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" = "qemu-coco-dev" ] || skip "Test not ready yet for ${KATA_HYPERVISOR}"
+	if ! is_confidential_runtime_class; then
+		skip "Test not supported for ${KATA_HYPERVISOR}."
+	fi
 
 	if [ "${KBS}" = "false" ]; then
 		skip "Test skipped as KBS not setup"


### PR DESCRIPTION
This PR allows all TEEs to run the sealed secret test. In order to make it happen, the followings are made:

- Call `cdh_handler()` for sealed secrets after `add_storage()` in kata agent
- Introduce `kbs_set_default_policy()` and add it to `setup()` in `k8s-sealed-secrets.bats` for CoCo

Please check out each commit message for details.

The tests pass for IBM SE: https://github.com/kata-containers/kata-containers/actions/runs/14075853927/job/39418620980#step:3:18102

Fixes: #11011 

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>