### PR TITLE
tests: Make sure /etc/containerd before writing config

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -368,7 +368,8 @@ function restart_crio_service() {
 # Configures containerd
 function overwrite_containerd_config() {
 	containerd_config="/etc/containerd/config.toml"
-	sudo rm -f "${containerd_config}"
+	base_config_dir=$(dirname "${containerd_config}")
+	sudo mkdir -p "${base_config_dir}"
 	sudo tee "${containerd_config}" << EOF
 version = 2
 


### PR DESCRIPTION
We get the following error while writing containerd config if a base dir `/etc/containerd` does not exist like:

```
sudo tee /etc/containerd/config.toml << EOF
...
EOF
tee: /etc/containerd/config.toml: No such file or directory
```

The PR makes sure a base directory for containerd before writing config and drops the config file deletion because a default behaviour of `tee` is overwriting.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>