### PR TITLE
kata-deploy: add INSTALLATION_PREFIX validation

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -16,6 +16,23 @@ containerd_conf_file_backup="${containerd_conf_file}.bak"
 containerd_conf_tmpl_file=""
 use_containerd_drop_in_conf_file="false"
 
+# If we fail for any reason a message will be displayed
+die() {
+        msg="$*"
+        echo "ERROR: $msg" >&2
+        exit 1
+}
+
+warn() {
+        msg="$*"
+        echo "WARN: $msg" >&2
+}
+
+info() {
+	msg="$*"
+	echo "INFO: $msg" >&2
+}
+
 DEBUG="${DEBUG:-"false"}"
 
 SHIMS="${SHIMS:-"clh cloud-hypervisor dragonball fc qemu qemu-coco-dev qemu-runtime-rs qemu-se-runtime-rs qemu-sev qemu-snp qemu-tdx stratovirt qemu-nvidia-gpu qemu-nvidia-gpu-snp qemu-nvidia-gpu-tdx"}"
@@ -66,23 +83,6 @@ containerd_drop_in_conf_file="${dest_dir}/containerd/config.d/kata-deploy.toml"
 host_install_dir="/host${dest_dir}"
 
 HELM_POST_DELETE_HOOK="${HELM_POST_DELETE_HOOK:-"false"}"
-
-# If we fail for any reason a message will be displayed
-die() {
-        msg="$*"
-        echo "ERROR: $msg" >&2
-        exit 1
-}
-
-warn() {
-        msg="$*"
-        echo "WARN: $msg" >&2
-}
-
-info() {
-	msg="$*"
-	echo "INFO: $msg" >&2
-}
 
 function host_systemctl() {
 	nsenter --target 1 --mount systemctl "${@}"

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -66,6 +66,9 @@ INSTALLATION_PREFIX="${INSTALLATION_PREFIX:-}"
 default_dest_dir="/opt/kata"
 dest_dir="${default_dest_dir}"
 if [ -n "${INSTALLATION_PREFIX}" ]; then
+	if [[ "${INSTALLATION_PREFIX:0:1}" != "/" ]]; then
+		die 'INSTALLATION_PREFIX must begin with a "/"(ex. /hoge/fuga)'
+	fi
 	# There's no `/` in between ${INSTALLATION_PREFIX} and ${default_dest_dir}
 	# as, otherwise, we'd have it doubled there, as: `/foo/bar//opt/kata`
 	dest_dir="${INSTALLATION_PREFIX}${default_dest_dir}"


### PR DESCRIPTION
INSTALLATION_PREFIX needs to start with a "/"
because it is being concatenated with /host.

If there is no /, it will be added, making it more robust.

Fixes: #11096