### PR TITLE
versions: Bump golang version

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -18,7 +18,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.11
+        go-version: 1.23.7
     - name: Checkout code
       uses: actions/checkout@v4
     - name: Build utils

--- a/.github/workflows/docs-url-alive-check.yaml
+++ b/.github/workflows/docs-url-alive-check.yaml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.22.11
+        go-version: 1.23.7
       env:
         GOPATH: ${{ github.workspace }}/kata-containers
     - name: Set env

--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -1,6 +1,7 @@
 module github.com/kata-containers/kata-containers/src/runtime
 
-go 1.21
+// Keep in sync with version in versions.yaml
+go 1.23
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/src/tools/csi-kata-directvolume/go.mod
+++ b/src/tools/csi-kata-directvolume/go.mod
@@ -1,6 +1,7 @@
 module kata-containers/csi-kata-directvolume
 
-go 1.20
+// Keep in sync with version in versions.yaml
+go 1.23
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/src/tools/log-parser/go.mod
+++ b/src/tools/log-parser/go.mod
@@ -1,6 +1,7 @@
 module github.com/kata-containers/kata-containers/src/tools/log-parser
 
-go 1.19
+// Keep in sync with version in versions.yaml
+go 1.23
 
 require (
 	github.com/BurntSushi/toml v1.1.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,6 +1,7 @@
 module github.com/kata-containers/tests
 
-go 1.19
+// Keep in sync with version in versions.yaml
+go 1.23
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/tests/integration/cri-containerd/gha-run.sh
+++ b/tests/integration/cri-containerd/gha-run.sh
@@ -38,7 +38,7 @@ function install_dependencies() {
 	sudo apt-get -y install "${system_deps[@]}"
 
 	ensure_yq
-	. "${repo_root_dir}/tests/install_go.sh" -p -f
+	"${repo_root_dir}/tests/install_go.sh" -p -f
 
 	# Dependency list of projects that we can install them
 	# directly from their releases on GitHub:

--- a/tests/metrics/cmd/checkmetrics/go.mod
+++ b/tests/metrics/cmd/checkmetrics/go.mod
@@ -1,6 +1,7 @@
 module example.com/m
 
-go 1.19
+// Keep in sync with version in versions.yaml
+go 1.23
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/tools/testing/kata-webhook/go.mod
+++ b/tools/testing/kata-webhook/go.mod
@@ -1,6 +1,7 @@
 module module-path
 
-go 1.21
+// Keep in sync with version in versions.yaml
+go 1.23
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/versions.yaml
+++ b/versions.yaml
@@ -387,12 +387,12 @@ languages:
   golang:
     description: "Google's 'go' language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.22.11"
+    version: "1.23.7"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.22.11"
+      newest-version: "1.23.7"
 
   rust:
     description: "Rust language"

--- a/versions.yaml
+++ b/versions.yaml
@@ -409,12 +409,12 @@ languages:
     description: "golangci-lint"
     notes: "'version' is the default minimum version used by this project."
     url: "github.com/golangci/golangci-lint"
-    version: "1.57.2"
+    version: "1.64.8"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.57.2"
+      newest-version: "1.64.8"
 
 plugins:
   description: |


### PR DESCRIPTION
Bump golang version to the latest minor 1.23.x release now that 1.24 has been released and 1.22.x is no longer stable and receiving security fixes