### PR TITLE
kata-deploy: remove the double "/"

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -229,7 +229,7 @@ function get_kata_containers_config_path() {
 	local shim="$1"
 
 	# Directory holding pristine configuration files for the current default golang runtime.
-	local golang_config_path="${dest_dir}/share/defaults/kata-containers/"
+	local golang_config_path="${dest_dir}/share/defaults/kata-containers"
 
 	# Directory holding pristine configuration files for the new rust runtime.
 	#


### PR DESCRIPTION
Currently, ConfigPath in containerd.toml is a double "/" as follows.

```
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-clh.options]
ConfigPath = "/opt/kata/share/defaults/kata-containers//configuration-clh.toml"
...
[plugins."io.containerd.grpc.v1.cri".containerd.runtimes.kata-cloud-hypervisor.options]
ConfigPath = "/opt/kata/share/defaults/kata-containers//runtime-rs/configuration-cloud-hypervisor.toml"
...
```

So, removed the double "/".

Fixes: #11099