### PR TITLE
runtime-rs: Remove redundant empty line

### DIFF
--- a/src/runtime-rs/crates/runtimes/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/src/lib.rs
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-
 #[macro_use(lazy_static)]
 extern crate lazy_static;
 


### PR DESCRIPTION
While running `cargo fmt -- --check` in `src/runtime-rs` directory, it errors out and suggesting these is an redundant empty line, which prevents `make check` of `runtime-rs` component from passing, see https://github.com/kata-containers/kata-containers/actions/runs/14156708226/job/39659572004?pr=11100.

Remove redundant empty line to fix this.