### PR TITLE
policy: Add missing input validations for ExecProcessRequest

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1276,6 +1276,7 @@ CreateSandboxRequest {
 
 ExecProcessRequest {
     print("ExecProcessRequest 1: input =", input)
+    allow_exec_process_input
 
     some p_command in policy_data.request_defaults.ExecProcessRequest.allowed_commands
     print("ExecProcessRequest 1: p_command =", p_command)
@@ -1285,6 +1286,7 @@ ExecProcessRequest {
 }
 ExecProcessRequest {
     print("ExecProcessRequest 2: input =", input)
+    allow_exec_process_input
 
     # TODO: match input container ID with its corresponding container.exec_commands.
     some container in policy_data.containers
@@ -1298,6 +1300,7 @@ ExecProcessRequest {
 }
 ExecProcessRequest {
     print("ExecProcessRequest 3: input =", input)
+    allow_exec_process_input
 
     i_command = concat(" ", input.process.Args)
     print("ExecProcessRequest 3: i_command =", i_command)
@@ -1308,6 +1311,16 @@ ExecProcessRequest {
     regex.match(p_regex, i_command)
 
     print("ExecProcessRequest 3: true")
+}
+
+allow_exec_process_input {
+    is_null(input.string_user)
+
+    i_process := input.process
+    count(i_process.SelinuxLabel) == 0
+    count(i_process.ApparmorProfile) == 0
+
+    print("allow_exec_process_input: true")
 }
 
 UpdateRoutesRequest {

--- a/src/tools/genpolicy/tests/main.rs
+++ b/src/tools/genpolicy/tests/main.rs
@@ -12,8 +12,8 @@ mod tests {
     use std::str;
 
     use protocols::agent::{
-        CopyFileRequest, CreateContainerRequest, CreateSandboxRequest, UpdateInterfaceRequest,
-        UpdateRoutesRequest,
+        CopyFileRequest, CreateContainerRequest, CreateSandboxRequest, ExecProcessRequest,
+        UpdateInterfaceRequest, UpdateRoutesRequest,
     };
     use serde::{Deserialize, Serialize};
 
@@ -29,6 +29,7 @@ mod tests {
         CreateSandbox(CreateSandboxRequest),
         UpdateInterface(UpdateInterfaceRequest),
         UpdateRoutes(UpdateRoutesRequest),
+        ExecProcess(ExecProcessRequest),
     }
 
     impl Display for TestRequest {
@@ -39,6 +40,7 @@ mod tests {
                 TestRequest::CreateSandbox(_) => write!(f, "CreateSandboxRequest"),
                 TestRequest::UpdateInterface(_) => write!(f, "UpdateInterfaceRequest"),
                 TestRequest::UpdateRoutes(_) => write!(f, "UpdateRoutesRequest"),
+                TestRequest::ExecProcess(_) => write!(f, "ExecProcessRequest"),
             }
         }
     }
@@ -182,5 +184,10 @@ mod tests {
     #[tokio::test]
     async fn test_create_container_generate_name() {
         runtests("createcontainer/generate_name").await;
+    }
+
+    #[tokio::test]
+    async fn test_exec_process() {
+        runtests("execprocess").await;
     }
 }

--- a/src/tools/genpolicy/tests/testdata/execprocess/pod.yaml
+++ b/src/tools/genpolicy/tests/testdata/execprocess/pod.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+spec:
+  runtimeClassName: kata-cc
+  containers:
+    - name: first-test-container
+      image: "quay.io/prometheus/busybox:latest"
+      env:
+        - name: CONTAINER_NAME
+          value: first-test-container
+      command:
+        - sleep
+        - "3600"
+      livenessProbe:
+        exec:
+          command:
+            - echo
+            - test

--- a/src/tools/genpolicy/tests/testdata/execprocess/testcases.json
+++ b/src/tools/genpolicy/tests/testdata/execprocess/testcases.json
@@ -1,0 +1,139 @@
+[
+  {
+    "description": "test exec process with correct args",
+    "allowed": true,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b200",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "Args": [
+          "echo",
+          "test"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": "",
+        "ApparmorProfile": ""
+      }
+    }
+  },
+  {
+    "description": "test exec process with incorrect args",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b200",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "Args": [],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": "",
+        "ApparmorProfile": ""
+      }
+    }
+  },
+  {
+    "description": "test exec process with non-null selinuxLabel",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b200",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "Args": [],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": "system_u:system_r:container_t",
+        "ApparmorProfile": ""
+      }
+    }
+  },
+  {
+    "description": "test exec process with random ApparmorProfile",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b200",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "Args": [],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": "",
+        "ApparmorProfile": "localhost/root-user"
+      }
+    }
+  },
+  {
+    "description": "test exec process with random string_user",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b200",
+      "string_user": {
+        "uid": "0",
+        "gid": "12",
+        "additional_gids": []
+      },
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "Args": [],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": "",
+        "ApparmorProfile": ""
+      }
+    }
+  }
+]


### PR DESCRIPTION
#### Summary: 

This PR introduces validation for additional input fields in ExecProcessRequest. for hardening the security policy. Here are the enforcements - 
-  `string_user` : Enforced to be null to disallow any root privileges using this field
- `selinuxLabel`: Disallowed for any custom label
- `ApparmorProfile` : Disallowed for any custom profiles

#### Changelog: 
- Update rules.rego to add null/empty field enforcements for String_user, SelinuxLabel and ApparmorProfile
- Introduce unit tests for ExecProcessRequest for each of the validations

#### Testing Methodology: 
- Local testing using `cargo tests`

Fixes #11108 