### PR TITLE
runtime: Add Path for kata-deploy

### DIFF
--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -527,7 +527,7 @@ show_containerd_shimv2()
 {
 	start_section "Containerd shim v2"
 
-	local cmd="${containerd_shim_v2_name} --version"
+	local cmd="${containerd_shim_v2} --version"
 
 	msg "Containerd shim v2 is \`$containerd_shim_v2\`."
 
@@ -781,7 +781,7 @@ show_kata_monitor_version()
 {
 	start_section "Kata Monitor"
 
-	local cmd="${kata_monitor_name} --version"
+	local cmd="${kata_monitor} --version"
 
 	msg "Kata Monitor \`$kata_monitor_name\`."
 

--- a/src/runtime/data/kata-collect-data.sh.in
+++ b/src/runtime/data/kata-collect-data.sh.in
@@ -5,18 +5,22 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
+# kata-deploy installs binaries in /opt/kata/bin by default, which is not in the PATH.
+# We need to add it to PATH to ensure commands like kata-monitor and kata-runtime.
+SCRIPT_DIR="$(readlink -f "$(dirname "${BASH_SOURCE[0]}")")"
+
 typeset -r script_name=${0##*/}
 typeset -r runtime_name="@RUNTIME_NAME@"
-typeset -r runtime_path=$(command -v "$runtime_name" 2>/dev/null)
+typeset -r runtime_path=$(PATH="$SCRIPT_DIR:$PATH" command -v "$runtime_name" 2>/dev/null)
 typeset -r runtime_snap_name="kata-containers.runtime"
 typeset -r runtime_snap_path=$(command -v "$runtime_snap_name" 2>/dev/null)
 typeset -r runtime=${runtime_path:-"$runtime_snap_path"}
 
 typeset -r containerd_shim_v2_name="containerd-shim-kata-v2"
-typeset -r containerd_shim_v2=$(command -v "$containerd_shim_v2_name" 2>/dev/null)
+typeset -r containerd_shim_v2=$(PATH="$SCRIPT_DIR:$PATH" command -v "$containerd_shim_v2_name" 2>/dev/null)
 
 typeset -r kata_monitor_name="kata-monitor"
-typeset -r kata_monitor=$(command -v "$kata_monitor_name" 2>/dev/null)
+typeset -r kata_monitor=$(PATH="$SCRIPT_DIR:$PATH" command -v "$kata_monitor_name" 2>/dev/null)
 
 typeset -r issue_url="@PROJECT_BUG_URL@"
 typeset -r script_version="@VERSION@ (commit @COMMIT@)"


### PR DESCRIPTION
 When installing with kata-deploy,  usually `/opt/kata/bin` is not in the PATH.
 Therefore, it will fail to execute. so add it to the PATH.

The reason we don't use fixed values is because installation directory is customizable.(INSTALLATION_PREFIX etc)

Fixes: #11122