### PR TITLE
runtime-rs: Extend runtime-rs workspace and centralize local dependencies

### DIFF
--- a/src/runtime-rs/Cargo.toml
+++ b/src/runtime-rs/Cargo.toml
@@ -1,6 +1,13 @@
 [workspace]
 members = [
+    "crates/agent",
+    "crates/hypervisor",
+    "crates/persist",
+    "crates/resource",
+    "crates/runtimes",
+    "crates/service",
     "crates/shim",
     "crates/shim-ctl",
-]
 
+    "tests/utils",
+]

--- a/src/runtime-rs/Cargo.toml
+++ b/src/runtime-rs/Cargo.toml
@@ -11,3 +11,32 @@ members = [
 
     "tests/utils",
 ]
+
+[workspace.dependencies]
+agent = { path = "crates/agent" }
+hypervisor = { path = "crates/hypervisor" }
+persist = { path = "crates/persist"}
+resource = { path = "crates/resource" }
+runtimes = { path = "crates/runtimes" }
+service = { path = "crates/service" }
+tests_utils = { path = "tests/utils" }
+
+ch-config = { path = "crates/hypervisor/ch-config" }
+common = { path = "crates/runtimes/common" }
+linux_container = { path = "crates/runtimes/linux_container" }
+virt_container = { path = "crates/runtimes/virt_container" }
+wasm_container = { path = "crates/runtimes/wasm_container" }
+
+# Local dependencies from `src/libs`
+kata-sys-util = { path = "../libs/kata-sys-util"}
+kata-types = { path = "../libs/kata-types"}
+logging = { path = "../libs/logging"}
+protocols = { path = "../libs/protocols", features=["async"] }
+runtime-spec = { path = "../libs/runtime-spec" }
+safe-path = { path = "../libs/safe-path"}
+shim-interface = { path = "../libs/shim-interface" }
+test-utils = { path = "../libs/test-utils" }
+
+# Local dependencies from `src/dragonball`
+dragonball = { path = "../dragonball" }
+dbs-utils = { path = "../dragonball/dbs_utils" }

--- a/src/runtime-rs/crates/agent/Cargo.toml
+++ b/src/runtime-rs/crates/agent/Cargo.toml
@@ -22,10 +22,11 @@ tokio = { version = "1.38.0", features = ["fs", "rt"] }
 tracing = "0.1.36"
 url = "2.2.2"
 nix = "0.24.2"
+oci-spec = { version = "0.6.8", features = ["runtime"] }
 
+# Local dependencies
 kata-types = { path = "../../../libs/kata-types"}
 logging = { path = "../../../libs/logging"}
-oci-spec = { version = "0.6.8", features = ["runtime"] }
 protocols = { path = "../../../libs/protocols", features=["async"] }
 
 [features]

--- a/src/runtime-rs/crates/agent/Cargo.toml
+++ b/src/runtime-rs/crates/agent/Cargo.toml
@@ -25,9 +25,9 @@ nix = "0.24.2"
 oci-spec = { version = "0.6.8", features = ["runtime"] }
 
 # Local dependencies
-kata-types = { path = "../../../libs/kata-types"}
-logging = { path = "../../../libs/logging"}
-protocols = { path = "../../../libs/protocols", features=["async"] }
+kata-types = { workspace = true }
+logging = { workspace = true }
+protocols = { workspace = true, features=["async"] }
 
 [features]
 default = []

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -41,17 +41,17 @@ hyperlocal = "0.8.0"
 hyper = { version = "0.14.18", features = ["client"] }
 
 # Local dependencies
-kata-sys-util = { path = "../../../libs/kata-sys-util" }
-kata-types = { path = "../../../libs/kata-types" }
-logging = { path = "../../../libs/logging" }
-protocols = { path = "../../../libs/protocols", features = ["async"] }
-shim-interface = { path = "../../../libs/shim-interface" }
-persist = { path = "../persist" }
-ch-config = { path = "ch-config", optional = true }
-tests_utils = { path = "../../tests/utils" }
+kata-sys-util = { workspace = true }
+kata-types = { workspace = true }
+logging = { workspace = true }
+protocols = { workspace = true, features = ["async"] }
+shim-interface = { workspace = true }
+persist = { workspace = true }
+ch-config = { workspace = true, optional = true }
+tests_utils = { workspace = true }
 
 # Local dependencies: Dragonball
-dragonball = { path = "../../../dragonball", features = [
+dragonball = { workspace = true, features = [
     "atomic-guest-memory",
     "virtio-vsock",
     "hotplug",
@@ -65,7 +65,7 @@ dragonball = { path = "../../../dragonball", features = [
     "vhost-user-net",
     "host-device",
 ], optional = true }
-dbs-utils = { path = "../../../dragonball/dbs_utils" }
+dbs-utils = { workspace = true }
 
 [features]
 default = []
@@ -81,8 +81,8 @@ serial_test = "2.0.0"
 # Local dev-dependencies
 # Force the CH tests to run, even when the feature is not enabled for
 # a normal build.
-hypervisor = { path = ".", features = ["cloud-hypervisor"] }
-test-utils = { path = "../../../libs/test-utils" }
+hypervisor = { workspace = true, features = ["cloud-hypervisor"] }
+test-utils = { workspace = true }
 
 [build-dependencies]
 ttrpc-codegen = "0.4.2"

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -14,7 +14,6 @@ async-trait = "0.1.48"
 go-flag = "0.1.0"
 libc = ">=0.2.39"
 nix = "0.24.2"
-persist = { path = "../persist" }
 rust-ini = "0.18.0"
 seccompiler = "0.2.0"
 serde = { version = "1.0.138", features = ["derive"] }
@@ -30,26 +29,28 @@ lazy_static = "1.4"
 tracing = "0.1.36"
 ttrpc = { version = "0.8.4", features = ["async"] }
 protobuf = "=3.7.1"
+oci-spec = { version = "0.6.8", features = ["runtime"] }
+futures = "0.3.25"
+safe-path = "0.1.0"
+crossbeam-channel = "0.5.6"
+tempdir = "0.3.7"
+qapi = { version = "0.14", features = ["qmp", "async-tokio-all"] }
+qapi-spec = "0.3.1"
+qapi-qmp = "0.14.0"
+hyperlocal = "0.8.0"
+hyper = { version = "0.14.18", features = ["client"] }
 
+# Local dependencies
 kata-sys-util = { path = "../../../libs/kata-sys-util" }
 kata-types = { path = "../../../libs/kata-types" }
 logging = { path = "../../../libs/logging" }
 protocols = { path = "../../../libs/protocols", features = ["async"] }
 shim-interface = { path = "../../../libs/shim-interface" }
-oci-spec = { version = "0.6.8", features = ["runtime"] }
-
+persist = { path = "../persist" }
 ch-config = { path = "ch-config", optional = true }
 tests_utils = { path = "../../tests/utils" }
 
-futures = "0.3.25"
-safe-path = "0.1.0"
-crossbeam-channel = "0.5.6"
-tempdir = "0.3.7"
-
-qapi = { version = "0.14", features = ["qmp", "async-tokio-all"] }
-qapi-spec = "0.3.1"
-qapi-qmp = "0.14.0"
-
+# Local dependencies: Dragonball
 dragonball = { path = "../../../dragonball", features = [
     "atomic-guest-memory",
     "virtio-vsock",
@@ -65,8 +66,6 @@ dragonball = { path = "../../../dragonball", features = [
     "host-device",
 ], optional = true }
 dbs-utils = { path = "../../../dragonball/dbs_utils" }
-hyperlocal = "0.8.0"
-hyper = { version = "0.14.18", features = ["client"] }
 
 [features]
 default = []
@@ -77,14 +76,13 @@ dragonball = ["dep:dragonball"]
 cloud-hypervisor = ["ch-config"]
 
 [dev-dependencies]
+serial_test = "2.0.0"
+
+# Local dev-dependencies
 # Force the CH tests to run, even when the feature is not enabled for
 # a normal build.
 hypervisor = { path = ".", features = ["cloud-hypervisor"] }
-
 test-utils = { path = "../../../libs/test-utils" }
-
-serial_test = "2.0.0"
-
 
 [build-dependencies]
 ttrpc-codegen = "0.4.2"

--- a/src/runtime-rs/crates/hypervisor/ch-config/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/ch-config/Cargo.toml
@@ -14,6 +14,8 @@ anyhow = "1.0.68"
 serde = { version = "1.0.145", features = ["rc", "derive"] }
 serde_json = "1.0.91"
 tokio = { version = "1.38.0", features = ["sync", "rt"] }
+nix = "0.26.2"
+thiserror = "1.0.38"
 
 # Cloud Hypervisor public HTTP API functions
 # Note that the version specified is not necessarily the version of CH
@@ -21,7 +23,6 @@ tokio = { version = "1.38.0", features = ["sync", "rt"] }
 # which is relatively static.
 api_client = { git = "https://github.com/cloud-hypervisor/cloud-hypervisor", crate = "api_client", tag = "v27.0" }
 
+# Local dependencies
 kata-types = { path = "../../../../libs/kata-types"}
 kata-sys-util = { path = "../../../../libs/kata-sys-util"}
-nix = "0.26.2"
-thiserror = "1.0.38"

--- a/src/runtime-rs/crates/hypervisor/ch-config/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/ch-config/Cargo.toml
@@ -24,5 +24,5 @@ thiserror = "1.0.38"
 api_client = { git = "https://github.com/cloud-hypervisor/cloud-hypervisor", crate = "api_client", tag = "v27.0" }
 
 # Local dependencies
-kata-types = { path = "../../../../libs/kata-types"}
-kata-sys-util = { path = "../../../../libs/kata-sys-util"}
+kata-types = { workspace = true }
+kata-sys-util = { workspace = true }

--- a/src/runtime-rs/crates/persist/Cargo.toml
+++ b/src/runtime-rs/crates/persist/Cargo.toml
@@ -8,10 +8,12 @@ license = "Apache-2.0"
 [dependencies]
 async-trait = "0.1.48"
 anyhow = "^1.0"
-kata-sys-util = { path = "../../../libs/kata-sys-util"}
-kata-types = { path = "../../../libs/kata-types" }
-shim-interface = { path = "../../../libs/shim-interface" }
 libc = "0.2"
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.82"
+
+# Local dependencies
+kata-sys-util = { path = "../../../libs/kata-sys-util"}
+kata-types = { path = "../../../libs/kata-types" }
+shim-interface = { path = "../../../libs/shim-interface" }
 safe-path = { path = "../../../libs/safe-path"}

--- a/src/runtime-rs/crates/persist/Cargo.toml
+++ b/src/runtime-rs/crates/persist/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0.138", features = ["derive"] }
 serde_json = "1.0.82"
 
 # Local dependencies
-kata-sys-util = { path = "../../../libs/kata-sys-util"}
-kata-types = { path = "../../../libs/kata-types" }
-shim-interface = { path = "../../../libs/shim-interface" }
-safe-path = { path = "../../../libs/safe-path"}
+kata-sys-util = { workspace = true }
+kata-types = { workspace = true }
+shim-interface = { workspace = true }
+safe-path = { workspace = true }

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -9,7 +9,7 @@ license = "Apache-2.0"
 tempfile = "3.2.0"
 
 # Local dev-dependencies
-test-utils = { path = "../../../libs/test-utils" }
+test-utils = { workspace = true }
 
 [dependencies]
 anyhow = "^1.0"
@@ -38,12 +38,12 @@ uuid = { version = "0.4", features = ["v4"] }
 oci-spec = { version = "0.6.8", features = ["runtime"] }
 
 # Local dependencies
-agent = { path = "../agent" }
-hypervisor = { path = "../hypervisor" }
-kata-types = { path = "../../../libs/kata-types" }
-kata-sys-util = { path = "../../../libs/kata-sys-util" }
-logging = { path = "../../../libs/logging" }
-persist = { path = "../persist"}
-tests_utils = { path = "../../tests/utils" }
+agent = { workspace = true }
+hypervisor = { workspace = true }
+kata-types = { workspace = true }
+kata-sys-util = { workspace = true }
+logging = { workspace = true }
+persist = { workspace = true }
+tests_utils = { workspace = true }
 
 [features]

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -6,8 +6,10 @@ edition = "2018"
 license = "Apache-2.0"
 
 [dev-dependencies]
-test-utils = { path = "../../../libs/test-utils" }
 tempfile = "3.2.0"
+
+# Local dev-dependencies
+test-utils = { path = "../../../libs/test-utils" }
 
 [dependencies]
 anyhow = "^1.0"
@@ -33,13 +35,14 @@ slog-scope = "4.4.0"
 tokio = { version = "1.38.0", features = ["process"] }
 tracing = "0.1.36"
 uuid = { version = "0.4", features = ["v4"] }
+oci-spec = { version = "0.6.8", features = ["runtime"] }
 
+# Local dependencies
 agent = { path = "../agent" }
 hypervisor = { path = "../hypervisor" }
 kata-types = { path = "../../../libs/kata-types" }
 kata-sys-util = { path = "../../../libs/kata-sys-util" }
 logging = { path = "../../../libs/logging" }
-oci-spec = { version = "0.6.8", features = ["runtime"] }
 persist = { path = "../persist"}
 tests_utils = { path = "../../tests/utils" }
 

--- a/src/runtime-rs/crates/runtimes/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/Cargo.toml
@@ -24,20 +24,21 @@ nix = "0.25.0"
 url = "2.3.1"
 procfs = "0.12.0"
 prometheus = { version = "0.13.0", features = ["process"] }
+oci-spec = { version = "0.6.8", features = ["runtime"] }
 
+# Local dependencies
 agent = { path = "../agent" }
 common = { path = "./common" }
 kata-types = { path = "../../../libs/kata-types" }
 kata-sys-util = { path = "../../../libs/kata-sys-util" }
 logging = { path = "../../../libs/logging"}
 runtime-spec = { path = "../../../libs/runtime-spec" }
-oci-spec = { version = "0.6.8", features = ["runtime"] }
 shim-interface = { path = "../../../libs/shim-interface" }
 persist = { path = "../persist" }
 hypervisor = { path = "../hypervisor" }
 resource = { path = "../resource" }
 
-# runtime handler
+# Local dependencies: runtime handler
 linux_container = { path = "./linux_container", optional = true }
 virt_container = { path = "./virt_container", optional = true }
 wasm_container = { path = "./wasm_container", optional = true }

--- a/src/runtime-rs/crates/runtimes/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/Cargo.toml
@@ -27,21 +27,21 @@ prometheus = { version = "0.13.0", features = ["process"] }
 oci-spec = { version = "0.6.8", features = ["runtime"] }
 
 # Local dependencies
-agent = { path = "../agent" }
-common = { path = "./common" }
-kata-types = { path = "../../../libs/kata-types" }
-kata-sys-util = { path = "../../../libs/kata-sys-util" }
-logging = { path = "../../../libs/logging"}
-runtime-spec = { path = "../../../libs/runtime-spec" }
-shim-interface = { path = "../../../libs/shim-interface" }
-persist = { path = "../persist" }
-hypervisor = { path = "../hypervisor" }
-resource = { path = "../resource" }
+agent = { workspace = true }
+common = { workspace = true }
+kata-types = { workspace = true }
+kata-sys-util = { workspace = true }
+logging = { workspace = true }
+runtime-spec = { workspace = true }
+shim-interface = { workspace = true }
+persist = { workspace = true }
+hypervisor = { workspace = true }
+resource = { workspace = true }
 
 # Local dependencies: runtime handler
-linux_container = { path = "./linux_container", optional = true }
-virt_container = { path = "./virt_container", optional = true }
-wasm_container = { path = "./wasm_container", optional = true }
+linux_container = { workspace = true, optional = true }
+virt_container = { workspace = true, optional = true }
+wasm_container = { workspace = true, optional = true }
 
 [features]
 default = ["virt"]

--- a/src/runtime-rs/crates/runtimes/common/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/common/Cargo.toml
@@ -24,10 +24,10 @@ ttrpc = "0.8.4"
 oci-spec = { version = "0.6.8", features = ["runtime"] }
 
 # Local dependencies
-persist = { path = "../../persist" }
-agent = { path = "../../agent" }
-kata-sys-util = { path = "../../../../libs/kata-sys-util" }
-kata-types = { path = "../../../../libs/kata-types" }
-runtime-spec = { path = "../../../../libs/runtime-spec" }
-resource = { path = "../../resource" }
-protocols = { path = "../../../../libs/protocols"}
+persist = { workspace = true }
+agent = { workspace = true }
+kata-sys-util = { workspace = true }
+kata-types = { workspace = true }
+runtime-spec = { workspace = true }
+resource = { workspace = true }
+protocols = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/common/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/common/Cargo.toml
@@ -21,11 +21,13 @@ strum = { version = "0.24.0", features = ["derive"] }
 thiserror = "^1.0"
 tokio = { version = "1.38.0", features = ["rt-multi-thread", "process", "fs"] }
 ttrpc = "0.8.4" 
+oci-spec = { version = "0.6.8", features = ["runtime"] }
+
+# Local dependencies
 persist = { path = "../../persist" }
 agent = { path = "../../agent" }
 kata-sys-util = { path = "../../../../libs/kata-sys-util" }
 kata-types = { path = "../../../../libs/kata-types" }
 runtime-spec = { path = "../../../../libs/runtime-spec" }
-oci-spec = { version = "0.6.8", features = ["runtime"] }
 resource = { path = "../../resource" }
 protocols = { path = "../../../../libs/protocols"}

--- a/src/runtime-rs/crates/runtimes/linux_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/linux_container/Cargo.toml
@@ -10,6 +10,6 @@ async-trait = "0.1.48"
 tokio = { version = "1.38.0" }
 
 # Local dependencies
-common = { path = "../common" }
-kata-types = { path = "../../../../libs/kata-types" }
-resource = { path = "../../resource" }
+common = { workspace = true }
+kata-types = { workspace = true }
+resource = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/linux_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/linux_container/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "^1.0"
 async-trait = "0.1.48"
 tokio = { version = "1.38.0" }
 
+# Local dependencies
 common = { path = "../common" }
 kata-types = { path = "../../../../libs/kata-types" }
 resource = { path = "../../resource" }

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -30,15 +30,15 @@ oci-spec = { version = "0.6.8", features = ["runtime"] }
 strum = { version = "0.24.0", features = ["derive"] }
 
 # Local dependencies
-agent = { path = "../../agent" }
-common = { path = "../common" }
-hypervisor = { path = "../../hypervisor", features = ["cloud-hypervisor"] }
-kata-sys-util = { path = "../../../../libs/kata-sys-util" }
-kata-types = { path = "../../../../libs/kata-types" }
-logging = { path = "../../../../libs/logging"}
-runtime-spec = { path = "../../../../libs/runtime-spec" }
-persist = { path = "../../persist"}
-resource = { path = "../../resource" }
+agent = { workspace = true }
+common = { workspace = true }
+hypervisor = { workspace = true, features = ["cloud-hypervisor"] }
+kata-sys-util = { workspace = true }
+kata-types = { workspace = true }
+logging = { workspace = true }
+runtime-spec = { workspace = true }
+persist = { workspace = true }
+resource = { workspace = true }
 
 [features]
 default = ["cloud-hypervisor"]

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -26,7 +26,10 @@ toml = "0.4.2"
 url = "2.1.1"
 async-std = "1.12.0"
 tracing = "0.1.36"
+oci-spec = { version = "0.6.8", features = ["runtime"] }
+strum = { version = "0.24.0", features = ["derive"] }
 
+# Local dependencies
 agent = { path = "../../agent" }
 common = { path = "../common" }
 hypervisor = { path = "../../hypervisor", features = ["cloud-hypervisor"] }
@@ -34,10 +37,8 @@ kata-sys-util = { path = "../../../../libs/kata-sys-util" }
 kata-types = { path = "../../../../libs/kata-types" }
 logging = { path = "../../../../libs/logging"}
 runtime-spec = { path = "../../../../libs/runtime-spec" }
-oci-spec = { version = "0.6.8", features = ["runtime"] }
 persist = { path = "../../persist"}
 resource = { path = "../../resource" }
-strum = { version = "0.24.0", features = ["derive"] }
 
 [features]
 default = ["cloud-hypervisor"]

--- a/src/runtime-rs/crates/runtimes/wasm_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/wasm_container/Cargo.toml
@@ -10,6 +10,6 @@ async-trait = "0.1.48"
 tokio = { version = "1.38.0" }
 
 # Local dependencies
-common = { path = "../common" }
-kata-types = { path = "../../../../libs/kata-types" }
-resource = { path = "../../resource" }
+common = { workspace = true }
+kata-types = { workspace = true }
+resource = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/wasm_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/wasm_container/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = "^1.0"
 async-trait = "0.1.48"
 tokio = { version = "1.38.0" }
 
+# Local dependencies
 common = { path = "../common" }
 kata-types = { path = "../../../../libs/kata-types" }
 resource = { path = "../../resource" }

--- a/src/runtime-rs/crates/service/Cargo.toml
+++ b/src/runtime-rs/crates/service/Cargo.toml
@@ -17,8 +17,8 @@ containerd-shim-protos = { version = "0.6.0", features = ["async", "sandbox"] }
 containerd-shim = { version = "0.6.0", features = ["async"] }
 
 # Local dependencies
-common = { path = "../runtimes/common" }
-logging = { path = "../../../libs/logging" }
-kata-types = { path = "../../../libs/kata-types" }
-runtimes = { path = "../runtimes" }
-persist = { path = "../persist" }
+common = { workspace = true }
+logging = { workspace = true }
+kata-types = { workspace = true }
+runtimes = { workspace = true }
+persist = { workspace = true }

--- a/src/runtime-rs/crates/service/Cargo.toml
+++ b/src/runtime-rs/crates/service/Cargo.toml
@@ -13,10 +13,11 @@ slog-scope = "4.4.0"
 tokio = { version = "1.38.0", features = ["rt-multi-thread"] }
 tracing = "0.1.36"
 ttrpc = "0.8.4"
-
-common = { path = "../runtimes/common" }
 containerd-shim-protos = { version = "0.6.0", features = ["async", "sandbox"] }
 containerd-shim = { version = "0.6.0", features = ["async"] }
+
+# Local dependencies
+common = { path = "../runtimes/common" }
 logging = { path = "../../../libs/logging" }
 kata-types = { path = "../../../libs/kata-types" }
 runtimes = { path = "../runtimes" }

--- a/src/runtime-rs/crates/shim-ctl/Cargo.toml
+++ b/src/runtime-rs/crates/shim-ctl/Cargo.toml
@@ -10,6 +10,6 @@ anyhow = "^1.0"
 tokio = { version = "1.38.0", features = [ "rt", "rt-multi-thread" ] }
 
 # Local dependencies
-common = { path = "../runtimes/common" }
-logging = { path = "../../../libs/logging"}
-runtimes = { path = "../runtimes" }
+common = { workspace = true }
+logging = { workspace = true }
+runtimes = { workspace = true }

--- a/src/runtime-rs/crates/shim-ctl/Cargo.toml
+++ b/src/runtime-rs/crates/shim-ctl/Cargo.toml
@@ -7,8 +7,9 @@ edition = "2021"
 
 [dependencies]
 anyhow = "^1.0"
+tokio = { version = "1.38.0", features = [ "rt", "rt-multi-thread" ] }
+
+# Local dependencies
 common = { path = "../runtimes/common" }
 logging = { path = "../../../libs/logging"}
 runtimes = { path = "../runtimes" }
-tokio = { version = "1.38.0", features = [ "rt", "rt-multi-thread" ] }
-

--- a/src/runtime-rs/crates/shim/Cargo.toml
+++ b/src/runtime-rs/crates/shim/Cargo.toml
@@ -34,12 +34,12 @@ tracing-opentelemetry = "0.18.0"
 oci-spec = { version = "0.6.8", features = ["runtime"] }
 
 # Local dependencies
-kata-types = { path = "../../../libs/kata-types"}
-kata-sys-util = { path = "../../../libs/kata-sys-util"}
-logging = { path = "../../../libs/logging"}
-runtime-spec = { path = "../../../libs/runtime-spec" }
-service = { path = "../service" }
-runtimes = { path = "../runtimes" }
+kata-types = { workspace = true }
+kata-sys-util = { workspace = true }
+logging = { workspace = true }
+runtime-spec = { workspace = true }
+service = { workspace = true }
+runtimes = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.2.0"
@@ -47,4 +47,4 @@ rand = "0.8.4"
 serial_test = "0.5.1"
 
 # Local dev-dependencies
-tests_utils = { path = "../../tests/utils"}
+tests_utils = { workspace = true }

--- a/src/runtime-rs/crates/shim/Cargo.toml
+++ b/src/runtime-rs/crates/shim/Cargo.toml
@@ -31,12 +31,13 @@ tokio = { version = "1.38.0", features = [ "rt", "rt-multi-thread" ] }
 unix_socket2 = "0.5.4"
 tracing = "0.1.36"
 tracing-opentelemetry = "0.18.0"
+oci-spec = { version = "0.6.8", features = ["runtime"] }
 
+# Local dependencies
 kata-types = { path = "../../../libs/kata-types"}
 kata-sys-util = { path = "../../../libs/kata-sys-util"}
 logging = { path = "../../../libs/logging"}
 runtime-spec = { path = "../../../libs/runtime-spec" }
-oci-spec = { version = "0.6.8", features = ["runtime"] }
 service = { path = "../service" }
 runtimes = { path = "../runtimes" }
 
@@ -44,4 +45,6 @@ runtimes = { path = "../runtimes" }
 tempfile = "3.2.0"
 rand = "0.8.4"
 serial_test = "0.5.1"
+
+# Local dev-dependencies
 tests_utils = { path = "../../tests/utils"}

--- a/src/runtime-rs/tests/utils/Cargo.toml
+++ b/src/runtime-rs/tests/utils/Cargo.toml
@@ -10,4 +10,6 @@ license = "Apache-2.0"
 [dependencies]
 anyhow = "^1.0"
 rand = "0.8.4"
+
+# Local dependencies
 kata-types = { path = "../../../libs/kata-types" }

--- a/src/runtime-rs/tests/utils/Cargo.toml
+++ b/src/runtime-rs/tests/utils/Cargo.toml
@@ -12,4 +12,4 @@ anyhow = "^1.0"
 rand = "0.8.4"
 
 # Local dependencies
-kata-types = { path = "../../../libs/kata-types" }
+kata-types = { workspace = true }


### PR DESCRIPTION
- runtime-rs: Extend workspace to cover all crates
- runtime-rs: Group local dependencies
- runtime-rs: Put local dependencies into workspace

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>