### PR TITLE
 tests/k8s: better tests reporting for CI

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -303,6 +303,10 @@ jobs:
         timeout-minutes: 80
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
+      - name: Report tests
+        if: always()
+        run: bash tests/integration/kubernetes/gha-run.sh report-tests
+
       - name: Delete AKS cluster
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh delete-cluster

--- a/tests/integration/kubernetes/.gitignore
+++ b/tests/integration/kubernetes/.gitignore
@@ -1,0 +1,1 @@
+reports/

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -6,6 +6,7 @@
 #
 
 set -e
+set -o pipefail
 
 kubernetes_dir=$(dirname "$(readlink -f "$0")")
 source "${kubernetes_dir}/../../common.bash"
@@ -131,7 +132,10 @@ fi
 
 ensure_yq
 
-info "Running tests with bats version: $(bats --version)"
+report_dir="${kubernetes_dir}/reports/$(date +'%F-%T')"
+mkdir -p "${report_dir}"
+
+info "Running tests with bats version: $(bats --version). Save outputs to ${report_dir}"
 
 tests_fail=()
 for K8S_TEST_ENTRY in "${K8S_TEST_UNION[@]}"
@@ -139,9 +143,14 @@ do
 	K8S_TEST_ENTRY=$(echo "$K8S_TEST_ENTRY" | tr -d '[:space:][:cntrl:]')
 	info "$(kubectl get pods --all-namespaces 2>&1)"
 	info "Executing ${K8S_TEST_ENTRY}"
-	if ! bats --show-output-of-passing-tests "${K8S_TEST_ENTRY}"; then
+	# Output file will be prefixed with "ok" or "not_ok" based on the result
+	out_file="${report_dir}/${K8S_TEST_ENTRY}.out"
+	if ! bats --show-output-of-passing-tests "${K8S_TEST_ENTRY}" | tee "${out_file}"; then
 		tests_fail+=("${K8S_TEST_ENTRY}")
+		mv "${out_file}" "$(dirname "${out_file}")/not_ok-$(basename "${out_file}")"
 		[ "${K8S_TEST_FAIL_FAST}" = "yes" ] && break
+	else
+		mv "${out_file}" "$(dirname "${out_file}")/ok-$(basename "${out_file}")"
 	fi
 done
 


### PR DESCRIPTION
This is a spin off of https://github.com/kata-containers/kata-containers/pull/10901 where I removed the mechanism to re-trigger tests, leaving only the improvements for better reporting tests results in CI.

I changed the test runner to send the output of the bats executions to stdout and individual files too; and added a command to gha.sh where a report with a summary and detailed sections is printed. I hope it helps to speed up time to spot a bad test.

