### PR TITLE
rust: Add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+# Keep in sync with versions.yaml
+channel = "1.80.0"

--- a/versions.yaml
+++ b/versions.yaml
@@ -392,6 +392,7 @@ languages:
   rust:
     description: "Rust language"
     notes: "'version' is the default minimum version used by this project."
+    # Keep in sync with rust-toolchain.toml
     version: "1.80.0"
     meta:
       description: |


### PR DESCRIPTION
Add a top-level rust-toolchain.toml with the version that matches version.yaml to ensure that we stay in sync