### PR TITLE
tests: k8s: Retry output of kubectl exec in k8s-cpu-ns

### DIFF
--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -66,8 +66,18 @@ setup() {
 	# Check the total of cpus
 	for _ in $(seq 1 "$retries"); do
 		# Get number of cpus
-		total_cpus_container=$(kubectl exec pod/"$pod_name" -c "$container_name" \
+		# Retry "kubectl exec" several times in case it unexpectedly returns an empty output string,
+		# in an attempt to work around issues similar to https://github.com/kubernetes/kubernetes/issues/124571.
+		for _ in {1..10}; do
+			total_cpus_container=$(kubectl exec pod/"$pod_name" -c "$container_name" \
 			-- "${exec_num_cpus_cmd[@]}")
+			if [[ -n "${total_cpus_container}" ]]; then
+				break
+			fi
+			warn "Empty output from kubectl exec" >&2
+			sleep 1
+		done
+
 		# Verify number of cpus
 		[ "$total_cpus_container" -le "$total_cpus" ]
 		[ "$total_cpus_container" -eq "$total_cpus" ] && break
@@ -76,16 +86,29 @@ setup() {
 	[ "$total_cpus_container" -eq "$total_cpus" ]
 
 	# Check the total of requests
-	total_requests_container=$(kubectl exec $pod_name -c $container_name \
-		-- "${exec_weightsyspath_cmd[@]}")
+	for _ in {1..10}; do
+		total_requests_container=$(kubectl exec $pod_name -c $container_name \
+			-- "${exec_weightsyspath_cmd[@]}")
+		if [[ -n "${total_requests_container}" ]]; then
+			break
+		fi
+		warn "Empty output from kubectl exec" >&2
+		sleep 1
+	done
 	info "total_requests_container = $total_requests_container"
 
 	[ "$total_requests_container" -eq "$total_requests" ]
 
 	# Check the cpus inside the container
-
-	read total_cpu_quota total_cpu_period <<< $(kubectl exec $pod_name -c $container_name \
-		-- "${exec_maxsyspath_cmd[@]}")
+	for _ in {1..10}; do
+		maxsyspath=$(kubectl exec $pod_name -c $container_name -- "${exec_maxsyspath_cmd[@]}")
+		if [[ -n "${maxsyspath}" ]]; then
+			break
+		fi
+		warn "Empty output from kubectl exec" >&2
+		sleep 1
+	done
+	read total_cpu_quota total_cpu_period <<< ${maxsyspath}
 
 	division_quota_period=$(echo $((total_cpu_quota/total_cpu_period)))
 


### PR DESCRIPTION
We are seeing failures in this test, where the output of the kubectl exec command seems to be blank, so try retrying the exec like #11024

Fixes: #11133