### PR TITLE
Support hot-plug block device in qemu-rs with QMP

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -618,6 +618,20 @@ impl QemuInner {
                 )?;
                 qmp.hotplug_network_device(&netdev, &virtio_net_device)?
             }
+            DeviceType::Block(mut block_device) => {
+                block_device.config.pci_path = qmp
+                    .hotplug_block_device(
+                        &self.config.blockdev_info.block_device_driver,
+                        &block_device.device_id,
+                        &block_device.config.path_on_host,
+                        block_device.config.is_direct,
+                        block_device.config.is_readonly,
+                        block_device.config.no_drop,
+                    )
+                    .context("hotplug block device")?;
+
+                return Ok(DeviceType::Block(block_device));
+            }
             _ => info!(sl!(), "hotplugging of {:#?} is unsupported", device),
         }
         Ok(device)


### PR DESCRIPTION
    runtime-rs: Add hotplug block device type with QMP
    
    There's several cases that block device plays very import roles:
    
    1. Direct Volume:
    In Kata cases, to achieve high-performance I/O, raw files on the host
    are typically passed directly to the Guest via virtio-blk, and then
    bond/mounted within the Guest for container usage.
    
    2. Trusted Storage
    In CoCo scenarios, particularly in Guest image pull mode, images are
    typically pulled directly from the registry within the Guest. However,
    due to constrained memory resources (prioritized for containers), CoCo
    leverages externally attached encrypted storage to store images,
    requiring hot-plug capability for block devices.
    
    and as other vmms, like dragonball and cloud-hypervisor in runtime-rs or
    qemu in kata-runtime have already supported such capabilities, we need
    support block device with hot-plug method (QMP) in qemu-rs. Let's do it.

Fixes #11143
    
Signed-off-by: alex.lyn <alex.lyn@antgroup.com>