### PR TITLE
dragonball: Put local dependencies into workspace

### DIFF
--- a/src/dragonball/Cargo.toml
+++ b/src/dragonball/Cargo.toml
@@ -27,8 +27,8 @@ members = [
 ]
 resolver = "2"
 
-# Rust-VMM crates
 [workspace.dependencies]
+# Rust-VMM crates
 event-manager = "0.2.1"
 kvm-bindings = "0.6.0"
 kvm-ioctls = "0.12.0"
@@ -43,23 +43,41 @@ vm-memory = "0.10.0"
 vm-superio = "0.5.0"
 vmm-sys-util = "0.11.0"
 
-[dependencies]
-anyhow = "1.0.32"
-arc-swap = "1.5.0"
-bytes = "1.1.0"
+# Local dependencies from Dragonball Sandbox crates
+dbs-acpi = { path = "dbs_acpi" }
 dbs-address-space = { path = "dbs_address_space" }
 dbs-allocator = { path = "dbs_allocator" }
 dbs-arch = { path = "dbs_arch" }
 dbs-boot = { path = "dbs_boot" }
 dbs-device = { path = "dbs_device" }
-dbs-interrupt = { path = "dbs_interrupt", features = ["kvm-irq"] }
+dbs-interrupt = { path = "dbs_interrupt" }
 dbs-legacy-devices = { path = "dbs_legacy_devices" }
-dbs-upcall = { path = "dbs_upcall", optional = true }
+dbs-pci = { path = "dbs_pci" }
+dbs-tdx = { path = "dbs_tdx" }
+dbs-upcall = { path = "dbs_upcall" }
 dbs-utils = { path = "dbs_utils" }
-dbs-virtio-devices = { path = "dbs_virtio_devices", optional = true, features = [
+dbs-virtio-devices = { path = "dbs_virtio_devices" }
+
+# Local dependencies from `src/lib`
+test-utils = { path = "../libs/test-utils" }
+
+[dependencies]
+anyhow = "1.0.32"
+arc-swap = "1.5.0"
+bytes = "1.1.0"
+dbs-address-space = { workspace = true }
+dbs-allocator = { workspace = true }
+dbs-arch = { workspace = true }
+dbs-boot = { workspace = true }
+dbs-device = { workspace = true }
+dbs-interrupt = { workspace = true, features = ["kvm-irq"] }
+dbs-legacy-devices = { workspace = true }
+dbs-upcall = { workspace = true, optional = true }
+dbs-utils = { workspace = true }
+dbs-virtio-devices = { workspace = true, optional = true, features = [
   "virtio-mmio",
 ] }
-dbs-pci = { path = "dbs_pci", optional = true }
+dbs-pci = { workspace = true, optional = true }
 derivative = "2.2.0"
 kvm-bindings = { workspace = true }
 kvm-ioctls = { workspace = true }
@@ -89,7 +107,7 @@ vfio-ioctls = { workspace = true, optional = true }
 [dev-dependencies]
 slog-async = "2.7.0"
 slog-term = "2.9.0"
-test-utils = { path = "../libs/test-utils" }
+test-utils = { workspace = true }
 
 [features]
 acpi = []

--- a/src/dragonball/dbs_boot/Cargo.toml
+++ b/src/dragonball/dbs_boot/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["dragonball", "boot", "VMM"]
 readme = "README.md"
 
 [dependencies]
-dbs-arch = { path = "../dbs_arch" }
+dbs-arch = { workspace = true }
 kvm-bindings = { workspace = true, features = ["fam-wrappers"] }
 kvm-ioctls = {workspace = true}
 lazy_static = "1"
@@ -23,4 +23,4 @@ vm-fdt = {workspace= true}
 [dev-dependencies]
 vm-memory = { workspace = true, features = ["backend-mmap"] }
 device_tree = ">=1.1.0"
-dbs-device = { path = "../dbs_device" }
+dbs-device = { workspace = true }

--- a/src/dragonball/dbs_interrupt/Cargo.toml
+++ b/src/dragonball/dbs_interrupt/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["dragonball", "secure-sandbox", "device", "interrupt"]
 readme = "README.md"
 
 [dependencies]
-dbs-device = { path = "../dbs_device" }
-dbs-arch = { path = "../dbs_arch" }
+dbs-device = { workspace = true }
+dbs-arch = { workspace = true }
 kvm-bindings = { workspace = true, optional = true }
 kvm-ioctls = { workspace = true, optional = true }
 libc = "0.2"

--- a/src/dragonball/dbs_legacy_devices/Cargo.toml
+++ b/src/dragonball/dbs_legacy_devices/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["dragonball", "secure-sandbox", "devices", "legacy"]
 readme = "README.md"
 
 [dependencies]
-dbs-device = { path = "../dbs_device" }
-dbs-utils = { path = "../dbs_utils" }
+dbs-device = { workspace = true }
+dbs-utils = { workspace = true }
 libc = "0.2.39"
 log = "0.4.14"
 serde = { version = "1.0.27", features = ["derive", "rc"] }

--- a/src/dragonball/dbs_pci/Cargo.toml
+++ b/src/dragonball/dbs_pci/Cargo.toml
@@ -13,10 +13,10 @@ readme = "README.md"
 [dependencies]
 log = "0.4.14"
 thiserror = "1"
-dbs-allocator = { path = "../dbs_allocator" }
-dbs-boot = { path = "../dbs_boot" }
-dbs-device = { path = "../dbs_device" }
-dbs-interrupt = { path = "../dbs_interrupt", features = [
+dbs-allocator = { workspace = true }
+dbs-boot = { workspace = true }
+dbs-device = { workspace = true }
+dbs-interrupt = { workspace = true, features = [
     "kvm-irq",
     "kvm-legacy-irq",
     "kvm-msi-irq",
@@ -31,7 +31,7 @@ vfio-bindings = {workspace = true}
 libc = "0.2.39"
 
 [dev-dependencies]
-dbs-arch = { path = "../dbs_arch" }
+dbs-arch = { workspace = true }
 kvm-ioctls = {workspace = true}
 
 [lints.rust]

--- a/src/dragonball/dbs_upcall/Cargo.toml
+++ b/src/dragonball/dbs_upcall/Cargo.toml
@@ -16,5 +16,5 @@ log = "0.4.14"
 thiserror = "1"
 timerfd = "1.2.0"
 
-dbs-utils = { path = "../dbs_utils" }
-dbs-virtio-devices = { path = "../dbs_virtio_devices", features = ["virtio-vsock"] }
+dbs-utils = { workspace = true }
+dbs-virtio-devices = { workspace = true, features = ["virtio-vsock"] }

--- a/src/dragonball/dbs_virtio_devices/Cargo.toml
+++ b/src/dragonball/dbs_virtio_devices/Cargo.toml
@@ -13,14 +13,14 @@ readme = "README.md"
 [dependencies]
 byteorder = "1.4.3"
 caps = "0.5.3"
-dbs-device = { path = "../dbs_device" }
-dbs-interrupt = { path = "../dbs_interrupt", features = [
+dbs-device = { workspace = true }
+dbs-interrupt = { workspace = true, features = [
     "kvm-legacy-irq",
     "kvm-msi-irq",
 ] }
-dbs-utils = { path = "../dbs_utils" }
-dbs-address-space = { path = "../dbs_address_space" }
-dbs-boot = { path = "../dbs_boot" }
+dbs-utils = { workspace = true }
+dbs-address-space = { workspace = true }
+dbs-boot = { workspace = true }
 epoll = ">=4.3.1, <4.3.2"
 io-uring = "0.5.2"
 fuse-backend-rs = { version = "0.10.5", optional = true }


### PR DESCRIPTION
Put local dependencies (mostly `dbs` crates) into workspace to avoid complex path dependencies all over the workspace. Simplify path dependency referencing.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>