### PR TITLE
build: Allow users to build the go, rust, or both runtimes

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -108,6 +108,7 @@ KBUILD_SIGN_PIN=${KBUILD_SIGN_PIN:-}
 GUEST_HOOKS_TARBALL_NAME="${GUEST_HOOKS_TARBALL_NAME:-}"
 EXTRA_PKGS="${EXTRA_PKGS:-}"
 AGENT_POLICY="${AGENT_POLICY:-yes}"
+RUNTIME_CHOICE="${RUNTIME_CHOICE:-both}"
 
 docker run \
 	-v $HOME/.docker:/root/.docker \
@@ -143,6 +144,7 @@ docker run \
 	--env GUEST_HOOKS_TARBALL_NAME="${GUEST_HOOKS_TARBALL_NAME}" \
 	--env EXTRA_PKGS="${EXTRA_PKGS}" \
 	--env AGENT_POLICY="${AGENT_POLICY}" \
+	--env RUNTIME_CHOICE="${RUNTIME_CHOICE}" \
 	--env AA_KBC="${AA_KBC:-}" \
 	--env HKD_PATH="$(realpath "${HKD_PATH:-}" 2> /dev/null || true)" \
 	--env SE_KERNEL_PARAMS="${SE_KERNEL_PARAMS:-}" \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -57,6 +57,7 @@ PUSH_TO_REGISTRY="${PUSH_TO_REGISTRY:-}"
 KERNEL_HEADERS_PKG_TYPE="${KERNEL_HEADERS_PKG_TYPE:-deb}"
 RELEASE="${RELEASE:-"no"}"
 KBUILD_SIGN_PIN="${KBUILD_SIGN_PIN:-}"
+RUNTIME_CHOICE="${RUNTIME_CHOICE:-both}"
 
 workdir="${WORKDIR:-$PWD}"
 
@@ -897,6 +898,7 @@ install_shimv2() {
 	export GO_VERSION
 	export RUST_VERSION
 	export MEASURED_ROOTFS
+	export RUNTIME_CHOICE
 
 	DESTDIR="${destdir}" PREFIX="${prefix}" "${shimv2_builder}"
 }


### PR DESCRIPTION
Let's add a RUNTIME_CHOICE env var that can be passed to be build scripts, which allows the user to select whether they bulld the go runtime, the rust runtime, or both.