### PR TITLE
ci: demote CoCo non-TEE to non-required from gatekeeper

### DIFF
--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -80,7 +80,6 @@ mapping:
       - Kata Containers CI / kata-containers-ci-on-push / run-basic-amd64-tests / run-nydus (lts, qemu)
       - Kata Containers CI / kata-containers-ci-on-push / run-basic-amd64-tests / run-nydus (lts, stratovirt)
       - Kata Containers CI / kata-containers-ci-on-push / run-cri-containerd-tests-s390x / run-cri-containerd (active, qemu)
-      - Kata Containers CI / kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-coco-nontee (qemu-coco-dev, nydus, guest-pull)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-arm64 / run-k8s-tests-on-arm64 (qemu, kubeadm)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-aks / run-k8s-tests (cbl-mariner, clh, normal, yes)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-aks / run-k8s-tests (cbl-mariner, clh, small, containerd, yes)


### PR DESCRIPTION
The CoCo non-TEE job has failed due the removal of an add-on from AKS, causing KBS to not get installed (see #11156).

The fix should be done in this repo as well as in trustee, which can take some time. We don't want to hold kata-containers PRs from getting merged anylonger, so removing the job from required list.