### PR TITLE
runtime-rs: Use bitwise or assign for bitflags

### DIFF
--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
@@ -170,7 +170,7 @@ fn generate_route(name: &str, route_msg: &RouteMessage) -> Result<Option<Route>>
 
     let mut flags: u32 = 0;
     for flag in &route_msg.header.flags {
-        flags += u32::from(*flag);
+        flags |= u32::from(*flag);
     }
 
     let mut route = Route {

--- a/src/runtime-rs/crates/resource/src/network/utils/address.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/address.rs
@@ -60,7 +60,7 @@ impl TryFrom<AddressMessage> for Address {
                     //thus here just implemeted a simple transformer.
                     let mut d: u32 = 0;
                     for flag in &f {
-                        d += u32::from(*flag);
+                        d |= u32::from(*flag);
                     }
                     addr.flags = d;
                 }

--- a/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/manager.rs
@@ -16,7 +16,7 @@ impl From<&VecLinkFlag> for u32 {
     fn from(v: &VecLinkFlag) -> u32 {
         let mut d: u32 = 0;
         for flag in &v.0 {
-            d += u32::from(*flag);
+            d |= u32::from(*flag);
         }
         d
     }


### PR DESCRIPTION
Use `|=` instead of `+=` while iterating through a vector of flags, which makes more sense and prevents situations like duplicated flags in vector would cause problems.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>