### PR TITLE
tests/k8s: fix kbs installation on Azure AKS

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -222,6 +222,11 @@ jobs:
       AUTHENTICATED_IMAGE_USER: ${{ secrets.AUTHENTICATED_IMAGE_USER }}
       AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
       SNAPSHOTTER: ${{ matrix.snapshotter }}
+      # Caution: current ingress controller used to expose the KBS service
+      # requires much vCPUs, lefting only a few for the tests. Depending on the
+      # host type chose it will result on the creation of a cluster with
+      # insufficient resources.
+      K8S_TEST_HOST_TYPE: "all"
       USING_NFD: "false"
       AUTO_GENERATE_POLICY: "yes"
     steps:

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -75,10 +75,10 @@ function _print_rg_name() {
 	echo "${AZ_RG:-"kataCI-$(_print_cluster_name "${test_type}")"}"
 }
 
-# Enable the HTTP application routing add-on to AKS.
+# Enable the approuting routing add-on to AKS.
 # Use with ingress to expose a service API externally.
 #
-function enable_cluster_http_application_routing() {
+function enable_cluster_approuting() {
 	local test_type="${1:-k8s}"
 	local cluster_name
 	local rg
@@ -86,8 +86,7 @@ function enable_cluster_http_application_routing() {
 	rg="$(_print_rg_name "${test_type}")"
 	cluster_name="$(_print_cluster_name "${test_type}")"
 
-	az aks enable-addons -g "${rg}" -n "${cluster_name}" \
-		--addons http_application_routing
+	az aks approuting enable -g "${rg}" -n "${cluster_name}"
 }
 
 function install_azure_cli() {
@@ -192,24 +191,6 @@ function get_cluster_credentials() {
 		--overwrite-existing \
 		-g "$(_print_rg_name "${test_type}")" \
 		-n "$(_print_cluster_name "${test_type}")"
-}
-
-
-# Get the AKS DNS zone name of HTTP application routing.
-#
-# Note: if the HTTP application routing add-on isn't installed in the cluster
-# then it will return an empty string.
-#
-function get_cluster_specific_dns_zone() {
-	local test_type="${1:-k8s}"
-	local cluster_name
-	local rg
-	local q="addonProfiles.httpApplicationRouting.config.HTTPApplicationRoutingZoneName"
-
-	rg="$(_print_rg_name "${test_type}")"
-	cluster_name="$(_print_cluster_name "${test_type}")"
-
-	az aks show -g "${rg}" -n "${cluster_name}" --query "${q}" | tr -d \"
 }
 
 function delete_cluster() {

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -41,7 +41,7 @@ function _print_instance_type() {
 		small)
 			echo "Standard_D2s_v5"
 			;;
-		normal)
+		all|normal)
 			echo "Standard_D4s_v5"
 			;;
 		*)


### PR DESCRIPTION
The Azure AKS addon-http-application-routing add-on is deprecated and cannot be enabled on new clusters which has caused some CI jobs to fail.

Migrated our code to use approuting instead. Unlike addon-http-application-routing, this add-on doesn't configure a managed cluster DNS zone, but the created ingress has a public IP. To avoid having to deal with DNS setup, we will be using that address from now on. Thus, some functions no longer used are deleted.

Fixes #11156
Signed-off-by: Wainer dos Santos Moschetta <wainersm@redhat.com>

---

This is how I tested it locally:

```
$ export KBS_INGRESS=aks
$ ./tests/integration/kubernetes/gha-run.sh create-cluster
<output omitted>
$ ./tests/integration/kubernetes/gha-run.sh get-cluster-credentials
<output omitted>
$ ./tests/integration/kubernetes/gha-run.sh deploy-coco-kbs
<output omitted>
::endgroup::
/tmp/trustee/kbs/config/kubernetes/overlays /tmp/trustee/kbs/config/kubernetes ~/src/github.com/kata-containers/kata-containers
::group::/tmp/trustee/kbs/config/kubernetes/overlays/ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: kbs
  namespace: coco-tenant
  annotations:
    kubernetes.io/ingress.class: webapprouting.kubernetes.azure.com
spec:
  rules:
  - host: ""
    http:
      paths:
      - path: /
        pathType: Prefix
        backend:
          service:
            name: kbs
            port:
              number: 8080
::endgroup::
/tmp/trustee/kbs/config/kubernetes ~/src/github.com/kata-containers/kata-containers
::group::Deploy the KBS
namespace/coco-tenant created
configmap/kbs-config-d655m9k8gk created
configmap/policy-config-tf9h6d9bb2 created
secret/kbs-auth-public-key-t2f5fd6t89 created
secret/keys-gmf2g75547 created
service/kbs created
deployment.apps/kbs created
Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead
ingress.networking.k8s.io/kbs created
~/src/github.com/kata-containers/kata-containers
::endgroup::
::group::Check the service healthy
pod/kbs-checker-767919 created
pod "kbs-checker-767919" deleted
KBS service respond to requests
::endgroup::
::group::Check the kbs service is exposed
Trying to connect at http://51.8.197.252:80. Timeout=350
KBS service respond to requests at http://51.8.197.252:80
::endgroup::
```

The `Warning: annotation "kubernetes.io/ingress.class" is deprecated, please use 'spec.ingressClassName' instead` warning I've a fix that I will send to trustee. This doesn't break the installation, so we don't need to bump the kbs version used here.