### PR TITLE
kata-types: Optimize memory adjuesting by only gathering memory info

### DIFF
--- a/src/libs/kata-types/Cargo.toml
+++ b/src/libs/kata-types/Cargo.toml
@@ -26,7 +26,7 @@ serde_json = "1.0.73"
 thiserror = "1.0"
 toml = "0.5.8"
 serde-enum-str = "0.4"
-sysinfo = "0.30.5"
+sysinfo = "0.34.2"
 
 oci-spec = { version = "0.6.8", features = ["runtime"] }
 safe-path = { path = "../safe-path" }

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -33,7 +33,7 @@ use std::collections::HashMap;
 use std::io::{self, Result};
 use std::path::Path;
 use std::sync::{Arc, Mutex};
-use sysinfo::System;
+use sysinfo::{MemoryRefreshKind, RefreshKind, System};
 
 mod dragonball;
 pub use self::dragonball::{DragonballConfig, HYPERVISOR_NAME_DRAGONBALL};
@@ -751,7 +751,9 @@ impl MemoryInfo {
             "Memory backend file {} is invalid: {}"
         )?;
         if self.default_maxmemory == 0 {
-            let s = System::new_all();
+            let s = System::new_with_specifics(
+                RefreshKind::nothing().with_memory(MemoryRefreshKind::everything()),
+            );
             self.default_maxmemory = Byte::from_u64(s.total_memory())
                 .get_adjusted_unit(Unit::MiB)
                 .get_value() as u32;

--- a/src/libs/kata-types/src/config/hypervisor/qemu.rs
+++ b/src/libs/kata-types/src/config/hypervisor/qemu.rs
@@ -119,7 +119,9 @@ impl ConfigPlugin for QemuConfig {
             }
             if qemu.boot_info.image.is_empty() && qemu.boot_info.initrd.is_empty() {
                 // IBM SE (CCW + confidential guest) does not require neither image nor initrd.
-                if !(qemu.boot_info.vm_rootfs_driver.ends_with("ccw") && qemu.security_info.confidential_guest) {
+                if !(qemu.boot_info.vm_rootfs_driver.ends_with("ccw")
+                    && qemu.security_info.confidential_guest)
+                {
                     return Err(eother!(
                         "Both guest boot image and initrd for qemu are empty"
                     ));
@@ -151,9 +153,7 @@ impl ConfigPlugin for QemuConfig {
             }
 
             if qemu.memory_info.enable_guest_swap {
-                return Err(eother!(
-                    "Qemu hypervisor doesn't support enable_guest_swap"
-                ));
+                return Err(eother!("Qemu hypervisor doesn't support enable_guest_swap"));
             }
         }
 

--- a/src/libs/kata-types/src/config/hypervisor/remote.rs
+++ b/src/libs/kata-types/src/config/hypervisor/remote.rs
@@ -13,7 +13,9 @@ use crate::{
     config::{
         default::{self, MAX_REMOTE_VCPUS, MIN_REMOTE_MEMORY_SIZE_MB},
         ConfigPlugin,
-    }, device::DRIVER_NVDIMM_TYPE, eother, resolve_path
+    },
+    device::DRIVER_NVDIMM_TYPE,
+    eother, resolve_path,
 };
 
 use super::register_hypervisor_plugin;

--- a/src/libs/kata-types/src/device.rs
+++ b/src/libs/kata-types/src/device.rs
@@ -15,7 +15,7 @@ pub const DRIVER_BLK_MMIO_TYPE: &str = "mmioblk";
 pub const DRIVER_SCSI_TYPE: &str = "scsi";
 /// DRIVER_NVDIMM_TYPE is the device driver for nvdimm
 pub const DRIVER_NVDIMM_TYPE: &str = "nvdimm";
-/// DRIVER_VFIO_PCI_GK_TYPE is the device driver for vfio-pci 
+/// DRIVER_VFIO_PCI_GK_TYPE is the device driver for vfio-pci
 /// while the device will be bound to a guest kernel driver
 pub const DRIVER_VFIO_PCI_GK_TYPE: &str = "vfio-pci-gk";
 /// DRIVER_VFIO_PCI_TYPE is the device driver for vfio-pci

--- a/src/libs/kata-types/src/handler.rs
+++ b/src/libs/kata-types/src/handler.rs
@@ -3,16 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use std::collections::HashMap;
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 
 /// Generic manager to manage registered handlers.
 pub struct HandlerManager<H> {
     handlers: HashMap<String, H>,
 }
 
-impl<H> Default for HandlerManager<H> 
+impl<H> Default for HandlerManager<H>
 where
     H: Clone,
 {
@@ -21,7 +21,7 @@ where
     }
 }
 
-impl<H> HandlerManager<H> 
+impl<H> HandlerManager<H>
 where
     H: Clone,
 {


### PR DESCRIPTION

    The Coniguration initialization was observed to be significantly slow
    due to the extensive system information gathering performed by
    `sysinfo::System::new_all()`. This function collects data on CPU,
    memory, disks, and network, most of which is unnecessary for Kata's
    memory adjusting config phase, where only the total system memory is
    required.
    
    This commit optimizes the initialization process by implementing a more
    targeted approach to retrieve only the total system memory. This avoids
    the overhead of collecting a large amount of irrelevant data, resulting
    in a noticeable performance improvement.
    
Fixes #11165
    
Signed-off-by: alex.lyn <alex.lyn@antgroup.com>