### PR TITLE
fix: Failed to clean up cgroup dir when deleting Pod

### DIFF
--- a/src/runtime/vendor/github.com/containerd/cgroups/cgroup.go
+++ b/src/runtime/vendor/github.com/containerd/cgroups/cgroup.go
@@ -231,6 +231,10 @@ func (c *cgroup) Delete() error {
 		// kernel prevents cgroups with running process from being removed, check the tree is empty
 		procs, err := c.processes(s.Name(), true, cgroupProcs)
 		if err != nil {
+			// if the control group does not exist within a subsystem, then proceed to the next subsystem
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
 			return err
 		}
 		if len(procs) > 0 {

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"time"
 
 	v1 "github.com/containerd/cgroups/stats/v1"
 	v2 "github.com/containerd/cgroups/v2/stats"
@@ -2611,8 +2612,15 @@ func (s *Sandbox) resourceControllerDelete() error {
 		return err
 	}
 
-	if err := sandboxController.Delete(); err != nil {
-		return err
+	delay := 1 * time.Second
+	maxDeletionAttempts := 5
+	for i := 0; i < maxDeletionAttempts; i++ {
+		if err := sandboxController.Delete(); err == nil {
+			break
+		} else if i == maxDeletionAttempts-1 {
+			return err
+		}
+		time.Sleep(delay)
 	}
 
 	if s.state.OverheadCgroupPath != "" {
@@ -2626,8 +2634,13 @@ func (s *Sandbox) resourceControllerDelete() error {
 			return err
 		}
 
-		if err := overheadController.Delete(); err != nil {
-			return err
+		for i := 0; i < maxDeletionAttempts; i++ {
+			if err := overheadController.Delete(); err == nil {
+				break
+			} else if i == maxDeletionAttempts-1 {
+				return err
+			}
+			time.Sleep(delay)
 		}
 	}
 


### PR DESCRIPTION
The Kata shim may not always be able to migrate the QEMU process to the parent cgroup during the MoveTo operation, which can lead to failure when deleting the cgroup.

Therefore, we should add retry logic when deleting the cgroup to ensure that the cgroup directory can be cleaned up properly.