### PR TITLE
ci: Use shell option to enable tty in gha

### DIFF
--- a/.github/workflows/run-k8s-tests-on-amd64.yaml
+++ b/.github/workflows/run-k8s-tests-on-amd64.yaml
@@ -89,6 +89,7 @@ jobs:
 
       - name: Run tests
         timeout-minutes: 30
+        shell: 'script -q -e -c "bash {0}"'
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Collect artifacts ${{ matrix.vmm }}


### PR DESCRIPTION
A tty is required for testing the debug console

GHA containers don't support a TTY by default. For issue/explanation, see:
https://github.com/actions/runner/issues/241

This GHA workflow change is needed for the debug console test PR: #11138 

Can't test this without the GHA workflow change pushed first. Manual test runs of #11138 are passing, but the GHA flow is failing due to above (I believe). Hopefully this resolves the issue. If not, I will open a subsequent PR to revert this change.