### PR TITLE
workflows: Add apt update before install

### DIFF
--- a/.github/workflows/add-pr-sizing-label.yaml
+++ b/.github/workflows/add-pr-sizing-label.yaml
@@ -48,6 +48,6 @@ jobs:
           pr=${{ github.event.number }}
           # Removing man-db, workflow kept failing, fixes: #4480
           sudo apt -y remove --purge man-db
-          sudo apt -y install diffstat patchutils
+          sudo apt update && sudo apt -y install diffstat patchutils
 
           pr-add-size-label.sh -p "$pr"

--- a/.github/workflows/build-checks-preview-riscv64.yaml
+++ b/.github/workflows/build-checks-preview-riscv64.yaml
@@ -81,11 +81,11 @@ jobs:
           ./tests/install_rust.sh
           echo "${HOME}/.cargo/bin" >> "$GITHUB_PATH"
           if [ "$(uname -m)" == "x86_64" ] || [ "$(uname -m)" == "aarch64" ]; then
-            sudo apt-get -y install musl-tools
+            sudo apt-get update && sudo apt-get -y install musl-tools
           fi
       - name: Install devicemapper
         if: contains(matrix.component.needs, 'libdevmapper') && matrix.command == 'make check'
-        run: sudo apt-get -y install libdevmapper-dev
+        run: sudo apt-get update && sudo apt-get -y install libdevmapper-dev
       - name: Install libseccomp
         if: contains(matrix.component.needs, 'libseccomp') && matrix.command != 'make vendor' && matrix.command != 'make check'
         run: |
@@ -97,10 +97,10 @@ jobs:
           echo "LIBSECCOMP_LIB_PATH=${libseccomp_install_dir}/lib" >> "$GITHUB_ENV"
       - name: Install protobuf-compiler
         if: contains(matrix.component.needs, 'protobuf-compiler') && matrix.command != 'make vendor'
-        run: sudo apt-get -y install protobuf-compiler
+        run: sudo apt-get update && sudo apt-get -y install protobuf-compiler
       - name: Install clang
         if: contains(matrix.component.needs, 'clang') && matrix.command == 'make check'
-        run: sudo apt-get -y install clang
+        run: sudo apt-get update && sudo apt-get -y install clang
       - name: Setup XDG_RUNTIME_DIR
         if: contains(matrix.component.needs, 'XDG_RUNTIME_DIR') && matrix.command != 'make check'
         run: |

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -87,11 +87,11 @@ jobs:
           ./tests/install_rust.sh
           echo "${HOME}/.cargo/bin" >> "$GITHUB_PATH"
           if [ "$(uname -m)" == "x86_64" ] || [ "$(uname -m)" == "aarch64" ]; then
-            sudo apt-get -y install musl-tools
+            sudo apt-get update && sudo apt-get -y install musl-tools
           fi
       - name: Install devicemapper
         if: contains(matrix.component.needs, 'libdevmapper') && matrix.command == 'make check'
-        run: sudo apt-get -y install libdevmapper-dev
+        run: sudo apt-get update && sudo apt-get -y install libdevmapper-dev
       - name: Install libseccomp
         if: contains(matrix.component.needs, 'libseccomp') && matrix.command != 'make vendor' && matrix.command != 'make check'
         run: |
@@ -103,10 +103,10 @@ jobs:
           echo "LIBSECCOMP_LIB_PATH=${libseccomp_install_dir}/lib" >> "$GITHUB_ENV"
       - name: Install protobuf-compiler
         if: contains(matrix.component.needs, 'protobuf-compiler') && matrix.command != 'make vendor'
-        run: sudo apt-get -y install protobuf-compiler
+        run: sudo apt-get update && sudo apt-get -y install protobuf-compiler
       - name: Install clang
         if: contains(matrix.component.needs, 'clang') && matrix.command == 'make check'
-        run: sudo apt-get -y install clang
+        run: sudo apt-get update && sudo apt-get -y install clang
       - name: Setup XDG_RUNTIME_DIR
         if: contains(matrix.component.needs, 'XDG_RUNTIME_DIR') && matrix.command != 'make check'
         run: |

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -70,7 +70,7 @@ jobs:
           fetch-depth: 0
       - name: Install system deps
         run: |
-          sudo apt-get install -y build-essential musl-tools
+          sudo apt-get update && sudo apt-get install -y build-essential musl-tools
       - name: Install yq
         run: |
           sudo -E ./ci/install_yq.sh
@@ -118,7 +118,7 @@ jobs:
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
       - name: Install system dependencies
         run: |
-          sudo apt-get -y install moreutils hunspell hunspell-en-gb hunspell-en-us pandoc
+          sudo apt-get update && sudo apt-get -y install moreutils hunspell hunspell-en-gb hunspell-en-us pandoc
       - name: Run check
         run: |
           export PATH="${PATH}:${GOPATH}/bin"


### PR DESCRIPTION
Add apt/apt-get updates before we do
apt/apt-get installs to try and help with
issues where we fail to fetch packages