### PR TITLE
versions: Switch gperf mirror

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -288,7 +288,7 @@ externals:
 
   gperf:
     description: "GNU gperf is a perfect hash function generator"
-    url: "http://ftp.gnu.org/pub/gnu/gperf/"
+    url: "http://ftpmirror.gnu.org/gperf/"
     version: "3.1"
 
   hadolint:


### PR DESCRIPTION
Every so often the main gnu site has an outage, so we can't download gperf. GNU providesthe generic URL https://ftpmirror.gnu.org to automatically choose a nearby and up-to-date mirror, so switch to this to help avoid this problem