### PR TITLE
runtime-rs: Add TDX Support to runtime-rs for Confidential Containers (CoCo) 

### DIFF
--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -90,6 +90,8 @@ pub enum ProtectionError {
 #[cfg(target_arch = "x86_64")]
 pub const TDX_SYS_FIRMWARE_DIR: &str = "/sys/firmware/tdx/";
 #[cfg(target_arch = "x86_64")]
+pub const TDX_KVM_PARAMETER_PATH: &str = "/sys/module/kvm_intel/parameters/tdx";
+#[cfg(target_arch = "x86_64")]
 pub const SEV_KVM_PARAMETER_PATH: &str = "/sys/module/kvm_amd/parameters/sev";
 #[cfg(target_arch = "x86_64")]
 pub const SNP_KVM_PARAMETER_PATH: &str = "/sys/module/kvm_amd/parameters/sev_snp";
@@ -177,6 +179,19 @@ pub fn arch_guest_protection(
         };
 
         return Ok(GuestProtection::Tdx(details));
+    } else {
+        // Check if /sys/module/kvm_intel/parameters/tdx is set to 'Y'
+        if Path::new(TDX_KVM_PARAMETER_PATH).exists() {
+            if let Ok(content) = fs::read(TDX_KVM_PARAMETER_PATH) {
+                if !content.is_empty() && content[0] == b'Y' {
+                    // TODO: hardcode with tdx details(1.5) is acceptable ?
+                    return Ok(GuestProtection::Tdx(TDXDetails {
+                        major_version: 1_u32,
+                        minor_version: 5_u32,
+                    }));
+                }
+            }
+        }
     }
 
     let check_contents = |file_name: &str| -> Result<bool, ProtectionError> {

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
@@ -14,7 +14,7 @@ mod virtio_fs;
 mod virtio_net;
 mod virtio_vsock;
 
-pub use protection_device::{ProtectionDevice, ProtectionDeviceConfig, SevSnpConfig};
+pub use protection_device::{ProtectionDevice, ProtectionDeviceConfig, SevSnpConfig, TdxConfig};
 pub use vfio::{
     bind_device_to_host, bind_device_to_vfio, get_vfio_device, HostDevice, VfioBusMode, VfioConfig,
     VfioDevice,

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/protection_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/protection_device.rs
@@ -14,6 +14,7 @@ use async_trait::async_trait;
 pub enum ProtectionDeviceConfig {
     SevSnp(SevSnpConfig),
     Se,
+    Tdx(TdxConfig),
 }
 
 #[derive(Debug, Clone)]
@@ -21,6 +22,20 @@ pub struct SevSnpConfig {
     pub is_snp: bool,
     pub cbitpos: u32,
     pub firmware: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct TdxConfig {
+    // Object ID
+    pub id: String,
+    // Firmware path
+    pub firmware: String,
+    // Quote Qeneration Socket port
+    pub qgs_port: u32,
+    // mrconfigid
+    pub mrconfigid: Option<String>,
+    // Debug mode
+    pub debug: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -3,12 +3,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-use crate::utils::{clear_cloexec, create_vhost_net_fds, open_named_tuntap};
+use crate::utils::{clear_cloexec, create_vhost_net_fds, open_named_tuntap, SocketAddress};
 use crate::{kernel_param::KernelParams, Address, HypervisorConfig};
 
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use kata_types::config::hypervisor::VIRTIO_SCSI;
+use serde::{Deserialize, Serialize};
+use serde_json;
 use std::collections::HashMap;
 use std::fmt::Display;
 use std::fs::{read_to_string, File};
@@ -1824,6 +1826,85 @@ impl ToQemuParams for ObjectSevSnpGuest {
     }
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct ObjectTdxGuest {
+    // QOM Object type
+    qom_type: String,
+
+    // unique ID
+    id: String,
+
+    // The sept-ve-disable option prevents EPT violation conversions to #VE on guest TD
+    // accesses of PENDING pages, which is essential for certain guest OS compatibility,
+    // like Linux TD guests.
+    sept_ve_disable: bool,
+
+    // Base64 encoded sha348 digest. ID for non-owner-defined configuration of the guest TD,
+    // which identifies the guest TD's run-time/OS configuration via a SHA384 digest.
+    // Defaults to zero if unspecified.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mrconfigid: Option<String>,
+
+    // Base64 encoded sha348 digest. ID for the guest TD's owner. Defaults to all zeros.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mrowner: Option<String>,
+
+    // Base64 encoded sha348 digest. ID for owner-defined configuration of the guest TD,
+    // e.g., specific to the workload rather than the run-time or OS. Defaults to all zeros.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mrownerconfig: Option<String>,
+
+    // Quote generation socket.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    quote_generation_socket: Option<SocketAddress>,
+
+    // Debug mode
+    #[serde(skip_serializing_if = "Option::is_none")]
+    debug: Option<bool>,
+}
+
+impl std::fmt::Display for ObjectTdxGuest {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        serde_json::to_string(self)
+            .map_err(|_| std::fmt::Error)
+            .and_then(|s| write!(f, "{}", s))
+    }
+}
+
+#[allow(clippy::doc_lazy_continuation)]
+/// 1. Add property "quote-generation-socket" to tdx-guest
+/// https://lore.kernel.org/qemu-devel/Zv7dtghi20DZ9ozz@redhat.com/
+/// 2. Support user configurable mrconfigid/mrowner/mrownerconfig
+/// https://patchew.org/QEMU/20241105062408.3533704-1-xiaoyao.li@intel.com/20241105062408.3533704-15-xiaoyao.li@intel.com/
+/// 3. Add command line and validation for TDX type
+/// https://lists.libvirt.org/archives/list/devel@lists.libvirt.org/message/6N7KP5F5Z44NI3R5U7STSPWUYXK6QYUO/
+/// Example:
+/// -object { "qom-type": "tdx-guest","id": "tdx", "mrconfigid": "mrconfigid2", "debug":true,"sept-ve-disable":true, \
+/// "quote-generation-socket": { "type": "vsock","cid": "2","port": "4050" }}
+impl ObjectTdxGuest {
+    pub fn new(id: &str, mrconfigid: Option<String>, qgs_port: u32, debug: bool) -> Self {
+        let qgs_socket = SocketAddress::new("vsock", 2, qgs_port);
+        Self {
+            qom_type: "tdx-guest".to_owned(),
+            id: id.to_owned(),
+            mrconfigid,
+            mrowner: None,
+            mrownerconfig: None,
+            sept_ve_disable: true,
+            quote_generation_socket: Some(qgs_socket),
+            debug: if debug { Some(debug) } else { None },
+        }
+    }
+}
+
+#[async_trait]
+impl ToQemuParams for ObjectTdxGuest {
+    async fn qemu_params(&self) -> Result<Vec<String>> {
+        Ok(vec!["-object".to_owned(), self.to_string()])
+    }
+}
+
 fn is_running_in_vm() -> Result<bool> {
     let res = read_to_string("/proc/cpuinfo")?
         .lines()
@@ -2190,6 +2271,23 @@ impl<'a> QemuCmdLine<'a> {
             .set_nvdimm(false);
 
         self.cpu.set_type("EPYC-v4");
+    }
+
+    pub fn add_tdx_protection_device(
+        &mut self,
+        id: &str,
+        firmware: &str,
+        qgs_port: u32,
+        mrconfigid: &Option<String>,
+        debug: bool,
+    ) {
+        let tdx_object = ObjectTdxGuest::new(id, mrconfigid.clone(), qgs_port, debug);
+        self.devices.push(Box::new(tdx_object));
+        self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+
+        self.machine
+            .set_confidential_guest_support("tdx")
+            .set_nvdimm(false);
     }
 
     pub async fn build(&self) -> Result<Vec<String>> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -144,6 +144,13 @@ impl QemuInner {
                         }
                     }
                     ProtectionDeviceConfig::Se => cmdline.add_se_protection_device(),
+                    ProtectionDeviceConfig::Tdx(tdx_config) => cmdline.add_tdx_protection_device(
+                        &tdx_config.id,
+                        &tdx_config.firmware,
+                        tdx_config.qgs_port,
+                        &tdx_config.mrconfigid,
+                        tdx_config.debug,
+                    ),
                 },
                 _ => info!(sl!(), "qemu cmdline: unsupported device: {:?}", device),
             }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -107,7 +107,7 @@ impl QemuInner {
                             &block_dev.config.path_on_host,
                             block_dev.config.is_readonly,
                         )?,
-                        "ccw" => cmdline.add_block_device(
+                        "ccw" | "blk" => cmdline.add_block_device(
                             block_dev.device_id.as_str(),
                             &block_dev.config.path_on_host,
                             block_dev

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -358,7 +358,17 @@ impl QemuInner {
 
     pub(crate) async fn capabilities(&self) -> Result<Capabilities> {
         let mut caps = Capabilities::default();
-        caps.set(CapabilityBits::FsSharingSupport);
+
+        // Confidential Guest doesn't permit virtio-fs.
+        let flags = if self.hypervisor_config().security_info.confidential_guest {
+            CapabilityBits::BlockDeviceSupport | CapabilityBits::BlockDeviceHotplugSupport
+        } else {
+            CapabilityBits::BlockDeviceSupport
+                | CapabilityBits::BlockDeviceHotplugSupport
+                | CapabilityBits::FsSharingSupport
+        };
+        caps.set(flags);
+
         Ok(caps)
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/utils.rs
@@ -16,6 +16,8 @@ use nix::{
     fcntl,
     sched::{setns, CloneFlags},
 };
+use serde::{Deserialize, Serialize};
+use serde_json;
 
 use crate::device::Tap;
 
@@ -144,9 +146,37 @@ fn create_fds(device: &str, num_fds: usize) -> Result<Vec<File>> {
     Ok(fds)
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct SocketAddress {
+    #[serde(rename = "type")]
+    pub typ: String,
+    pub cid: String,
+    pub port: String,
+}
+
+impl SocketAddress {
+    pub fn new(typ: &str, cid: u32, port: u32) -> Self {
+        Self {
+            typ: typ.to_string(),
+            cid: cid.to_string(),
+            port: port.to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for SocketAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        serde_json::to_string(self)
+            .map_err(|_| std::fmt::Error)
+            .and_then(|s| write!(f, "{}", s))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::create_fds;
+    use super::SocketAddress;
 
     #[test]
     fn test_ctreate_fds() {
@@ -155,5 +185,39 @@ mod tests {
         let fds = create_fds(device, num_fds);
         assert!(fds.is_ok());
         assert_eq!(fds.unwrap().len(), num_fds);
+    }
+
+    #[test]
+    fn test_socket_address_new() {
+        let socket = SocketAddress::new("unix", 123, 8866);
+        assert_eq!(socket.typ, "unix");
+        assert_eq!(socket.cid, "123");
+        assert_eq!(socket.port, "8866");
+    }
+
+    #[test]
+    fn test_socket_address_display() {
+        let socket = SocketAddress::new("tcp", 456, 6688);
+        let expected_json = r#"{"type":"tcp","cid":"456","port":"6688"}"#;
+        assert_eq!(format!("{}", socket), expected_json);
+    }
+
+    #[test]
+    fn test_socket_address_serialize_deserialize() {
+        let socket = SocketAddress::new("unix", 789, 8686);
+        let serialized = serde_json::to_string(&socket).unwrap();
+        let deserialized: SocketAddress = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(socket.typ, deserialized.typ);
+        assert_eq!(socket.cid, deserialized.cid);
+        assert_eq!(socket.port, deserialized.port);
+    }
+
+    #[test]
+    fn test_socket_address_kebab_case() {
+        let socket = SocketAddress::new("unix", 101, 6868);
+        let serialized = serde_json::to_string(&socket).unwrap();
+        assert!(serialized.contains(r#""type":"#));
+        assert!(serialized.contains(r#""cid":"#));
+        assert!(serialized.contains(r#""port":"#));
     }
 }

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -28,7 +28,7 @@ use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{utils::get_hvsock_path, HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID};
 use hypervisor::{BlockConfig, Hypervisor};
-use hypervisor::{ProtectionDeviceConfig, SevSnpConfig};
+use hypervisor::{ProtectionDeviceConfig, SevSnpConfig, TdxConfig};
 use kata_sys_util::hooks::HookStates;
 use kata_sys_util::protection::{available_guest_protection, GuestProtection};
 use kata_types::capabilities::CapabilityBits;
@@ -365,6 +365,15 @@ impl VirtSandbox {
             GuestProtection::Se => {
                 Ok(Some(ProtectionDeviceConfig::Se))
             }
+            GuestProtection::Tdx(_details) => {
+                Ok(Some(ProtectionDeviceConfig::Tdx(TdxConfig {
+                    id: "tdx".to_owned(),
+                    firmware: hypervisor_config.boot_info.firmware.clone(),
+                    qgs_port: 4050,
+                    mrconfigid: None,
+                    debug: false,
+                })))
+            },
             _ => Err(anyhow!("confidential_guest requested by configuration but no supported protection available"))
         }
     }


### PR DESCRIPTION
  The Kata-runtime has already implemented support for Intel Trust Domain Extensions (TDX), enabling the creation of highly isolated and confidential containers. To ensure feature parity and further strengthen Kata's Confidential Computing capabilities, we need to extend TDX support to the runtime-rs.
  
  Implement the necessary functionality within runtime-rs to enable the creation and management of TDX-based CVM for containers.
  Ensure that the TDX implementation in runtime-rs aligns with the existing TDX support in the Kata-runtime(go).

 Fixes #11177
    
Signed-off-by: alex.lyn <alex.lyn@antgroup.com>