### PR TITLE
ci: retry genpolicy execution

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -207,8 +207,15 @@ auto_generate_policy() {
 
 	genpolicy_command+=" ${additional_flags}"
 
-	info "Executing: ${genpolicy_command}"
-	eval "${genpolicy_command}"
+	# Retry if genpolicy fails, because typical failures of this tool are caused by
+	# transient network errors.
+	for _ in {1..6}; do
+		info "Executing: ${genpolicy_command}"
+		eval "${genpolicy_command}" && return 0
+		info "Sleeping after command failed..."
+		sleep 10s
+	done
+	return 1
 }
 
 # Change genpolicy settings to allow "kubectl exec" to execute a command


### PR DESCRIPTION
`genpolicy` is sending more HTTPS requests than other components during CI so it's more likely to be affected by transient network errors similar to:

`ConnectError(
  "dns error",
  Custom {
     kind: Uncategorized,
     error: "failed to lookup address information: Try again",
  },
)`

Note that `genpolicy` is not the only component hitting network errors during CI. Recent example from a different component:

`"Message:  failed to create containerd task: failed to create shim task:
 failed to async pull blob stream HTTP status server error (502 Bad Gateway)"`

This CI change might help work around the `genpolicy` errors but not with the similar errors hit by other CI components.

Fixes: #11182