### PR TITLE
temp: ci: Fix AKS cluster creation

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -92,8 +92,10 @@ function enable_cluster_http_application_routing() {
 
 function install_azure_cli() {
 	curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
-	# The aks-preview extension is required while the Mariner Kata host is in preview.
-	az extension add --name aks-preview
+
+	# TODO: Remove the version spec when this bug is fixed:
+	# https://github.com/Azure/azure-cli/issues/31345
+	az extension add --name aks-preview --version 14.0.0b3
 }
 
 function login_azure() {


### PR DESCRIPTION
The AKS CLI recently introduced a regression that prevents using aks-preview extensions (Azure/azure-cli#31345), and hence create CI clusters.

To address this, we temporarily hardcode the last known good version of aks-preview.

Note that I removed the comment about this being a Mariner requirement, as aks-preview is also a requirement of AKS App Routing, which will be introduced soon in #11164.