### PR TITLE
runtime: Add block device resize support

### DIFF
--- a/src/runtime/cmd/kata-runtime/kata-block_device.go
+++ b/src/runtime/cmd/kata-runtime/kata-block_device.go
@@ -1,0 +1,87 @@
+// Copyright (c) 2022 Databricks Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+
+	containerdshim "github.com/kata-containers/kata-containers/src/runtime/pkg/containerd-shim-v2"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/utils/shimclient"
+
+	"github.com/urfave/cli"
+)
+
+var (
+	blockDevice string
+)
+
+var blockDeviceSubCmds = []cli.Command{
+	resizeBlockDeviceCommand,
+}
+
+var kataBlockDeviceCommand = cli.Command{
+	Name:        "block-device",
+	Usage:       "manage raw block device assignment for Kata Containers",
+	Description: "Operations for raw block device management in Kata Containers",
+	Subcommands: blockDeviceSubCmds,
+	Action: func(context *cli.Context) {
+		cli.ShowSubcommandHelp(context)
+	},
+}
+
+var resizeBlockDeviceCommand = cli.Command{
+	Name:      "resize",
+	Usage:     "resize a raw block device",
+	ArgsUsage: "[options]",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:        "sandbox-id, s",
+			Usage:       "the sandbox id of the Kata container",
+			Required:    true,
+			Destination: &sandboxID,
+		},
+		cli.StringFlag{
+			Name:        "block-device, b",
+			Usage:       "host path to the raw block device",
+			Required:    true,
+			Destination: &blockDevice,
+		},
+		cli.Uint64Flag{
+			Name:        "size",
+			Usage:       "the new size of the raw block device in bytes",
+			Required:    true,
+			Destination: &size,
+		},
+	},
+	Action: func(c *cli.Context) error {
+		if err := ResizeDevice(sandboxID, blockDevice, size); err != nil {
+			return cli.NewExitError(fmt.Sprintf("Failed to resize device: %v", err), 1)
+		}
+
+		return nil
+	},
+}
+
+// ResizeDevice resizes a direct volume inside the guest.
+func ResizeDevice(sandboxID string, blockDevice string, size uint64) error {
+
+	resizeReq := containerdshim.BlockResizeRequest{
+		BlockDevice: blockDevice,
+		Size:        size,
+	}
+
+	encoded, err := json.Marshal(resizeReq)
+	if err != nil {
+		return fmt.Errorf("failed to marshal resize request: %v", err)
+	}
+
+	if err := shimclient.DoPost(sandboxID, defaultTimeout, containerdshim.BlockDeviceResizeUrl, "application/json", encoded); err != nil {
+		return fmt.Errorf("shim client request failed: %v", err)
+	}
+
+	return nil
+}

--- a/src/runtime/cmd/kata-runtime/main.go
+++ b/src/runtime/cmd/kata-runtime/main.go
@@ -127,6 +127,7 @@ var runtimeCommands = []cli.Command{
 	kataVolumeCommand,
 	kataIPTablesCommand,
 	kataPolicyCommand,
+	kataBlockDeviceCommand,
 }
 
 // runtimeBeforeSubcommands is the function to run before command-line

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -79,7 +79,7 @@ type VCSandbox interface {
 
 	GuestVolumeStats(ctx context.Context, volumePath string) ([]byte, error)
 	ResizeGuestVolume(ctx context.Context, volumePath string, size uint64) error
-
+	ResizeBlockDevice(ctx context.Context, blockDevice string, size uint64) error
 	GetIPTables(ctx context.Context, isIPv6 bool) ([]byte, error)
 	SetIPTables(ctx context.Context, isIPv6 bool, data []byte) error
 	SetPolicy(ctx context.Context, policy string) error


### PR DESCRIPTION
Add support for resizing raw block devices in Kata Containers through:
- New CLI command `kata-runtime block-device resize`
- Shim API endpoint `/block-device/resize`
- Sandbox implementation with device lookup and resize handling
- Hypervisor integration for the resize operation