### PR TITLE
Ignore Empty Values for Environment Variables with PCIDEVICE_ Prefix

### DIFF
--- a/src/agent/src/device/mod.rs
+++ b/src/agent/src/device/mod.rs
@@ -416,7 +416,7 @@ pub fn update_env_pci(
         let (name, eqval) = envvar.split_at(eqpos);
         let val = &eqval[1..];
 
-        if !name.starts_with("PCIDEVICE_") || name.ends_with("_INFO") {
+        if !name.starts_with("PCIDEVICE_") || name.ends_with("_INFO") || val.is_empty() {
             continue;
         }
 


### PR DESCRIPTION
Fixes #11195