### PR TITLE
runtime: remove wrong xfs options

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
+++ b/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
@@ -76,11 +76,14 @@ impl KernelParams {
             VM_ROOTFS_DRIVER_PMEM => {
                 params.push(Param::new("root", VM_ROOTFS_ROOT_PMEM));
                 match rootfs_type {
-                    VM_ROOTFS_FILESYSTEM_EXT4 | VM_ROOTFS_FILESYSTEM_XFS => {
+                    VM_ROOTFS_FILESYSTEM_EXT4 => {
                         params.push(Param::new(
                             "rootflags",
                             "dax,data=ordered,errors=remount-ro ro",
                         ));
+                    }
+                    VM_ROOTFS_FILESYSTEM_XFS => {
+                        params.push(Param::new("rootflags", "dax ro"));
                     }
                     VM_ROOTFS_FILESYSTEM_EROFS => {
                         params.push(Param::new("rootflags", "dax ro"));
@@ -93,8 +96,11 @@ impl KernelParams {
             VM_ROOTFS_DRIVER_BLK | VM_ROOTFS_DRIVER_BLK_CCW | VM_ROOTFS_DRIVER_MMIO => {
                 params.push(Param::new("root", VM_ROOTFS_ROOT_BLK));
                 match rootfs_type {
-                    VM_ROOTFS_FILESYSTEM_EXT4 | VM_ROOTFS_FILESYSTEM_XFS => {
+                    VM_ROOTFS_FILESYSTEM_EXT4 => {
                         params.push(Param::new("rootflags", "data=ordered,errors=remount-ro ro"));
+                    }
+                    VM_ROOTFS_FILESYSTEM_XFS => {
+                        params.push(Param::new("rootflags", "ro"));
                     }
                     VM_ROOTFS_FILESYSTEM_EROFS => {
                         params.push(Param::new("rootflags", "ro"));
@@ -259,7 +265,7 @@ mod tests {
                 expect_params: KernelParams {
                     params: [
                         Param::new("root", VM_ROOTFS_ROOT_PMEM),
-                        Param::new("rootflags", "dax,data=ordered,errors=remount-ro ro"),
+                        Param::new("rootflags", "dax ro"),
                         Param::new("rootfstype", VM_ROOTFS_FILESYSTEM_XFS),
                     ]
                     .to_vec(),
@@ -272,7 +278,7 @@ mod tests {
                 expect_params: KernelParams {
                     params: [
                         Param::new("root", VM_ROOTFS_ROOT_BLK),
-                        Param::new("rootflags", "data=ordered,errors=remount-ro ro"),
+                        Param::new("rootflags", "ro"),
                         Param::new("rootfstype", VM_ROOTFS_FILESYSTEM_XFS),
                     ]
                     .to_vec(),

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -150,7 +150,11 @@ func GetKernelRootParams(rootfstype string, disableNvdimm bool, dax bool) ([]Par
 			kernelRootParams = append(kernelRootParams, Param{"rootflags", "ro"})
 		}
 	case XFS:
-		fallthrough
+		if dax {
+			kernelRootParams = append(kernelRootParams, Param{"rootflags", "dax ro"})
+		} else {
+			kernelRootParams = append(kernelRootParams, Param{"rootflags", "ro"})
+		}
 	// EXT4 filesystem is used by default.
 	case EXT4:
 		if dax {

--- a/src/runtime/virtcontainers/hypervisor_test.go
+++ b/src/runtime/virtcontainers/hypervisor_test.go
@@ -64,7 +64,7 @@ func TestGetKernelRootParams(t *testing.T) {
 			rootfstype: string(XFS),
 			expected: []Param{
 				{"root", string(Nvdimm)},
-				{"rootflags", "data=ordered,errors=remount-ro ro"},
+				{"rootflags", "ro"},
 				{"rootfstype", string(XFS)},
 			},
 			disableNvdimm: false,
@@ -75,7 +75,7 @@ func TestGetKernelRootParams(t *testing.T) {
 			rootfstype: string(XFS),
 			expected: []Param{
 				{"root", string(Nvdimm)},
-				{"rootflags", "dax,data=ordered,errors=remount-ro ro"},
+				{"rootflags", "dax ro"},
 				{"rootfstype", string(XFS)},
 			},
 			disableNvdimm: false,
@@ -86,7 +86,7 @@ func TestGetKernelRootParams(t *testing.T) {
 			rootfstype: string(XFS),
 			expected: []Param{
 				{"root", string(VirtioBlk)},
-				{"rootflags", "data=ordered,errors=remount-ro ro"},
+				{"rootflags", "ro"},
 				{"rootfstype", string(XFS)},
 			},
 			disableNvdimm: true,


### PR DESCRIPTION
 "data=ordered" and "errors=remount-ro" are wrong options in xfs.
 (they are ext4 options)
 <https://manpages.ubuntu.com/manpages/focal/man5/xfs.5.html>

Fixes: #11205
