### PR TITLE
GHA: Add VFIO-AP to s390x nightly tests for CoCo

### DIFF
--- a/.github/workflows/ci-nightly-s390x.yaml
+++ b/.github/workflows/ci-nightly-s390x.yaml
@@ -11,6 +11,7 @@ jobs:
       matrix:
         test_title:
           - kata-vfio-ap-e2e-tests
+          - cc-vfio-ap-e2e-tests
           - cc-se-e2e-tests
     steps:
     - name: Fetch a test result for {{ matrix.test_title }}


### PR DESCRIPTION
As #11076 introduces VFIO-AP bind/associate funtions for IBM Secure Execution (SEL), a new internal nightly test has been established. 
This PR adds a new entry `cc-vfio-ap-e2e-tests` to the existing matrix to share the test result.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>