### PR TITLE
runtime: Update dial_timeout and enable_annotations for gpu

### DIFF
--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -553,8 +553,8 @@ kernel_modules=[]
 #debug_console_enabled = true
 
 # Agent connection dialing timeout value in seconds
-# (default: 90)
-dial_timeout = 90
+# (default: @DEFAULTTIMEOUT_NV@)
+dial_timeout = @DEFAULTTIMEOUT_NV@
 
 [runtime]
 # If enabled, the runtime will log additional debug messages to the

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -537,8 +537,8 @@ kernel_modules=[]
 #debug_console_enabled = true
 
 # Agent connection dialing timeout value in seconds
-# (default: 90)
-dial_timeout = 90
+# (default: @DEFAULTTIMEOUT_NV@)
+dial_timeout = @DEFAULTTIMEOUT_NV@
 
 [runtime]
 # If enabled, the runtime will log additional debug messages to the

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -562,8 +562,8 @@ kernel_modules=[]
 #debug_console_enabled = true
 
 # Agent connection dialing timeout value in seconds
-# (default: 90)
-dial_timeout = 90
+# (default: @DEFAULTTIMEOUT_NV@)
+dial_timeout = @DEFAULTTIMEOUT_NV@
 
 [runtime]
 # If enabled, the runtime will log additional debug messages to the


### PR DESCRIPTION
kata configuration changes in this PR:
- Set dial_timeout back to @DEFAULTTIMEOUT_NV@ (which is 500 seconds). Currently, the 90 seconds is not enough to create a PodSandBox that has GPUs and so kubelet reports a timeout exceeded
- Allow users to set default_{vcpus,memory} via annotation since they may need to accomodate big workloads inside the guest.