### PR TITLE
Runtime rs centralise workspace config

### DIFF
--- a/.github/workflows/build-checks-preview-riscv64.yaml
+++ b/.github/workflows/build-checks-preview-riscv64.yaml
@@ -116,4 +116,5 @@ jobs:
           ${{ matrix.command }}
         env:
           RUST_BACKTRACE: "1"
+          RUST_LIB_BACKTRACE: "0"
           SKIP_GO_VERSION_CHECK: "1"

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -122,4 +122,5 @@ jobs:
           ${{ matrix.command }}
         env:
           RUST_BACKTRACE: "1"
+          RUST_LIB_BACKTRACE: "0"
           SKIP_GO_VERSION_CHECK: "1"

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -87,6 +87,7 @@ jobs:
           ${{ matrix.command }}
         env:
           RUST_BACKTRACE: "1"
+          RUST_LIB_BACKTRACE: "0"
 
   static-checks:
     runs-on: ubuntu-22.04

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "actix-rt"
-version = "2.8.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15265b6b8e2347670eb363c47fc8c75208b4a4994b27192f345fcbe707804f3e"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
 dependencies = [
  "actix-macros",
  "futures-core",
@@ -68,7 +68,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom",
  "once_cell",
  "version_check",
 ]
@@ -105,9 +105,9 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anyhow"
-version = "1.0.72"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "api_client"
@@ -238,9 +238,9 @@ checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
 
 [[package]]
 name = "async-trait"
-version = "0.1.72"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc6dde6e4ed435a4c1ee4e73592f5ba9da2151af10076cc04858746af9352d09"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -418,7 +418,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190baaad529bcfbde9e1a19022c42781bdb6ff9de25721abdb8fd98c0807730b"
 dependencies = [
  "libc",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -452,7 +452,7 @@ dependencies = [
  "log",
  "nix 0.25.1",
  "regex",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -466,7 +466,7 @@ dependencies = [
  "nix 0.26.2",
  "serde",
  "serde_json",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -501,7 +501,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f190f3c954f7bca3c6296d0ec561c739bdbe6c7e990294ed168d415f6e1b5b01"
 dependencies = [
  "nix 0.27.1",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -526,7 +526,7 @@ dependencies = [
  "slog",
  "slog-scope",
  "strum 0.24.1",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "tokio",
  "ttrpc",
 ]
@@ -567,7 +567,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "nix 0.27.1",
  "oci-spec",
  "os_pipe",
@@ -577,7 +577,7 @@ dependencies = [
  "serde_json",
  "signal-hook",
  "signal-hook-tokio",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "time 0.3.37",
  "tokio",
  "windows-sys 0.48.0",
@@ -802,7 +802,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "nix 0.23.2",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "vm-memory",
  "vmm-sys-util 0.11.1",
 ]
@@ -811,7 +811,7 @@ dependencies = [
 name = "dbs-allocator"
 version = "0.1.1"
 dependencies = [
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -822,7 +822,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "memoffset 0.6.5",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "vm-memory",
  "vmm-sys-util 0.11.1",
 ]
@@ -836,7 +836,7 @@ dependencies = [
  "kvm-ioctls",
  "lazy_static",
  "libc",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "vm-fdt",
  "vm-memory",
 ]
@@ -845,7 +845,7 @@ dependencies = [
 name = "dbs-device"
 version = "0.2.0"
 dependencies = [
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -887,7 +887,7 @@ dependencies = [
  "kvm-ioctls",
  "libc",
  "log",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "vfio-bindings",
  "vfio-ioctls",
  "vm-memory",
@@ -901,7 +901,7 @@ dependencies = [
  "dbs-utils",
  "dbs-virtio-devices",
  "log",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "timerfd",
 ]
 
@@ -914,7 +914,7 @@ dependencies = [
  "libc",
  "log",
  "serde",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "timerfd",
  "vmm-sys-util 0.11.1",
 ]
@@ -945,7 +945,7 @@ dependencies = [
  "sendfd",
  "serde",
  "serde_json",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "threadpool",
  "timerfd",
  "vhost",
@@ -1113,7 +1113,7 @@ dependencies = [
  "serde_json",
  "slog",
  "slog-scope",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "tracing",
  "vfio-bindings",
  "vfio-ioctls",
@@ -1300,7 +1300,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "log",
- "mio",
+ "mio 0.8.11",
  "nix 0.24.3",
  "virtio-queue",
  "vm-memory",
@@ -1429,17 +1429,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
@@ -1496,9 +1485,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.20"
+version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
 dependencies = [
  "bytes",
  "fnv",
@@ -1506,7 +1495,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 1.9.3",
+ "indexmap 2.8.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1655,9 +1644,9 @@ checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
 
 [[package]]
 name = "hyper"
-version = "0.14.27"
+version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1746,7 +1735,7 @@ dependencies = [
  "tempdir",
  "test-utils",
  "tests_utils",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "ttrpc",
@@ -1914,7 +1903,7 @@ dependencies = [
  "slog",
  "slog-scope",
  "subprocess",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1937,7 +1926,7 @@ dependencies = [
  "slog",
  "slog-scope",
  "sysinfo",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "toml 0.5.11",
 ]
 
@@ -1972,9 +1961,9 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
@@ -2018,9 +2007,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.3"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux_container"
@@ -2046,9 +2035,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.25"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 dependencies = [
  "value-bag",
 ]
@@ -2154,6 +2143,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+dependencies = [
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "mockall"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2237,7 +2237,7 @@ dependencies = [
  "anyhow",
  "byteorder",
  "paste",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2251,7 +2251,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -2275,7 +2275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23541694f1d7d18cd1a0da3a1352a6ea48b01cbb4a8e7a6e547963823fd5276e"
 dependencies = [
  "nix 0.23.2",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2527,7 +2527,7 @@ dependencies = [
  "serde_json",
  "strum 0.26.3",
  "strum_macros 0.26.4",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2636,7 +2636,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-semantic-conventions",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "thrift",
  "tokio",
 ]
@@ -2663,7 +2663,7 @@ dependencies = [
  "js-sys",
  "once_cell",
  "pin-project-lite",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -2683,7 +2683,7 @@ dependencies = [
  "opentelemetry_api",
  "percent-encoding",
  "rand 0.8.5",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
 ]
@@ -2954,7 +2954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
  "libc",
- "nix 0.27.1",
+ "nix 0.25.1",
 ]
 
 [[package]]
@@ -3058,7 +3058,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "procfs 0.14.2",
  "protobuf 2.28.0",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3126,7 +3126,7 @@ checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
 dependencies = [
  "once_cell",
  "protobuf-support",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3150,7 +3150,7 @@ dependencies = [
  "protobuf-parse",
  "regex",
  "tempfile",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3165,7 +3165,7 @@ dependencies = [
  "protobuf 3.7.1",
  "protobuf-support",
  "tempfile",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "which",
 ]
 
@@ -3175,7 +3175,7 @@ version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3284,36 +3284,13 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha 0.3.1",
+ "rand_chacha",
  "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -3343,29 +3320,11 @@ checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
-]
-
-[[package]]
-name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.10",
-]
-
-[[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
+ "getrandom",
 ]
 
 [[package]]
@@ -3396,14 +3355,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+dependencies = [
+ "bitflags 1.3.2",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
 dependencies = [
- "getrandom 0.2.10",
+ "getrandom",
  "redox_syscall 0.2.16",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -3505,7 +3473,7 @@ dependencies = [
  "nix 0.24.3",
  "oci-spec",
  "persist",
- "rand 0.7.3",
+ "rand 0.8.5",
  "rtnetlink",
  "scopeguard",
  "serde",
@@ -3543,7 +3511,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "nix 0.27.1",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "tokio",
 ]
 
@@ -3651,14 +3619,14 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.4"
+version = "0.38.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+checksum = "dc99bc2d4f1fed22595588a013687477aedf3cdcfb26558c559edb67b4d9b22e"
 dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.3",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.48.0",
 ]
 
@@ -3749,9 +3717,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.194"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b114498256798c94a0689e1a15fec6005dee8ac1f41de56404b67afc2a4b773"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -3788,9 +3756,9 @@ checksum = "794e44574226fc701e3be5c651feb7939038fc67fb73f6f4dd5c4ba90fd3be70"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.194"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3385e45322e8f9931410f01b3031ec534c3947d0e94c18049af4d9f9907d4e0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3799,11 +3767,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.104"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -3959,7 +3928,7 @@ dependencies = [
  "slog-stdlog",
  "tempfile",
  "tests_utils",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tracing-opentelemetry",
@@ -4260,14 +4229,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.7.0"
+version = "3.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5486094ee78b2e5038a6382ed7645bc084dc2ec433426ca4c3cb61e2007b8998"
+checksum = "7ef1adac450ad7f4b3c28589471ade84f25f731a7a0fe30d71dfa9f60fd808e5"
 dependencies = [
  "cfg-if 1.0.0",
  "fastrand 2.0.0",
- "redox_syscall 0.3.5",
- "rustix 0.38.4",
+ "redox_syscall 0.4.1",
+ "rustix 0.38.25",
  "windows-sys 0.48.0",
 ]
 
@@ -4306,11 +4275,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.44"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "611040a08a0439f8248d1990b111c95baa9c704c805fa1f62104b39655fd7f90"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl 1.0.44",
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -4324,9 +4293,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.44"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090198534930841fab3a5d1bb637cde49e339654e606195f8d9c76eeb081dc96"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4446,28 +4415,27 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.2"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68722da18b0fc4a05fdc1120b302b82051265792a1e1b399086e9b204b10ad3d"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
  "libc",
- "mio",
- "num_cpus",
+ "mio 1.0.3",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.5.7",
  "tokio-macros",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "tokio-macros"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f5ae998a069d4b5aba8ee9dad856af7d520c3699e6159b185c2acd48155d39a"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4548,11 +4516,10 @@ checksum = "b6bc1c9ce2b5135ac7f93c72918fc37feb872bdc6a5533a8b85eb4b86bfdae52"
 
 [[package]]
 name = "tracing"
-version = "0.1.37"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ce8c33a8d48bd45d624a6e523445fd21ec13d3653cd51f681abf67418f54eb8"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "cfg-if 1.0.0",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4560,9 +4527,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.26"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4571,9 +4538,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.31"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -4640,7 +4607,7 @@ dependencies = [
  "nix 0.26.2",
  "protobuf 3.7.1",
  "protobuf-codegen 3.7.1",
- "thiserror 1.0.44",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-vsock",
  "windows-sys 0.48.0",
@@ -4717,9 +4684,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -4826,7 +4793,6 @@ dependencies = [
  "runtime-spec",
  "sendfd",
  "serde",
- "serde_derive",
  "serde_json",
  "slog",
  "slog-scope",
@@ -4922,12 +4888,6 @@ checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
  "try-lock",
 ]
-
-[[package]]
-name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
 
 [[package]]
 name = "wasi"

--- a/src/runtime-rs/Cargo.toml
+++ b/src/runtime-rs/Cargo.toml
@@ -12,10 +12,15 @@ members = [
     "tests/utils",
 ]
 
+[workspace.package]
+authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
+edition = "2018"
+license = "Apache-2.0"
+
 [workspace.dependencies]
 agent = { path = "crates/agent" }
 hypervisor = { path = "crates/hypervisor" }
-persist = { path = "crates/persist"}
+persist = { path = "crates/persist" }
 resource = { path = "crates/resource" }
 runtimes = { path = "crates/runtimes" }
 service = { path = "crates/service" }
@@ -28,15 +33,44 @@ virt_container = { path = "crates/runtimes/virt_container" }
 wasm_container = { path = "crates/runtimes/wasm_container" }
 
 # Local dependencies from `src/libs`
-kata-sys-util = { path = "../libs/kata-sys-util"}
-kata-types = { path = "../libs/kata-types"}
-logging = { path = "../libs/logging"}
-protocols = { path = "../libs/protocols", features=["async"] }
+kata-sys-util = { path = "../libs/kata-sys-util" }
+kata-types = { path = "../libs/kata-types" }
+logging = { path = "../libs/logging" }
+protocols = { path = "../libs/protocols", features = ["async"] }
 runtime-spec = { path = "../libs/runtime-spec" }
-safe-path = { path = "../libs/safe-path"}
+safe-path = { path = "../libs/safe-path" }
 shim-interface = { path = "../libs/shim-interface" }
 test-utils = { path = "../libs/test-utils" }
 
 # Local dependencies from `src/dragonball`
 dragonball = { path = "../dragonball" }
 dbs-utils = { path = "../dragonball/dbs_utils" }
+
+actix-rt = "2.7.0"
+anyhow = "1.0"
+async-trait = "0.1.48"
+containerd-shim = { version = "0.6.0", features = ["async"] }
+containerd-shim-protos = { version = "0.6.0", features = ["async"] }
+go-flag = "0.1.0"
+hyper = "0.14.20"
+hyperlocal = "0.8.0"
+lazy_static = "1.4"
+libc = "0.2"
+log = "0.4.14"
+netns-rs = "0.1.0"
+nix = "0.24.2"
+oci-spec = { version = "0.6.8", features = ["runtime"] }
+protobuf = "=3.7.1"
+rand = "0.8.4"
+serde = { version = "1.0.145", features = ["derive"] }
+serde_json = "1.0.91"
+slog = "2.5.2"
+slog-scope = "4.4.0"
+strum = { version = "0.24.0", features = ["derive"] }
+tempfile = "3.2.0"
+thiserror = "1.0"
+tokio = "1.38.2"
+tracing = "0.1.36"
+tracing-opentelemetry = "0.18.0"
+ttrpc = "0.8.4"
+url = "2.3.1"

--- a/src/runtime-rs/crates/agent/Cargo.toml
+++ b/src/runtime-rs/crates/agent/Cargo.toml
@@ -1,33 +1,33 @@
 [package]
 name = "agent"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
-license = "Apache-2.0"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dev-dependencies]
 futures = "0.1.27"
 
 [dependencies]
-anyhow = "1.0.26"
-async-trait = "0.1.48"
-log = "0.4.14"
-protobuf = "=3.7.1"
-serde = { version = "^1.0", features = ["derive"] }
-serde_json = ">=1.0.9"
-slog = "2.5.2"
-slog-scope = "4.4.0"
-ttrpc = "0.8.4"
-tokio = { version = "1.38.2", features = ["fs", "rt"] }
-tracing = "0.1.36"
-url = "2.2.2"
-nix = "0.24.2"
-oci-spec = { version = "0.6.8", features = ["runtime"] }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+log = { workspace = true }
+protobuf = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+slog = { workspace = true }
+slog-scope = { workspace = true }
+ttrpc = { workspace = true }
+tokio = { workspace = true, features = ["fs", "rt"] }
+tracing = { workspace = true }
+url = { workspace = true }
+nix = { workspace = true }
+oci-spec = { workspace = true }
 
 # Local dependencies
 kata-types = { workspace = true }
 logging = { workspace = true }
-protocols = { workspace = true, features=["async"] }
+protocols = { workspace = true, features = ["async"] }
 
 [features]
 default = []

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -1,35 +1,35 @@
 [package]
 name = "hypervisor"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
-license = "Apache-2.0"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-actix-rt = "2.7.0"
-anyhow = "^1.0"
-async-trait = "0.1.48"
-go-flag = "0.1.0"
-libc = ">=0.2.39"
-nix = "0.24.2"
+actix-rt = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+go-flag = { workspace = true }
+libc = { workspace = true }
+nix = { workspace = true }
 rust-ini = "0.18.0"
 seccompiler = "0.2.0"
-serde = { version = "1.0.138", features = ["derive"] }
-serde_json = ">=1.0.9"
-slog = "2.5.2"
-slog-scope = "4.4.0"
-thiserror = "1.0"
-tokio = { version = "1.38.2", features = ["sync", "fs", "process", "io-util"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+slog = { workspace = true }
+slog-scope = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["sync", "fs", "process", "io-util"] }
 vmm-sys-util = "0.11.0"
-rand = "0.8.4"
+rand = { workspace = true }
 path-clean = "1.0.1"
-lazy_static = "1.4"
-tracing = "0.1.36"
-ttrpc = { version = "0.8.4", features = ["async"] }
-protobuf = "=3.7.1"
-oci-spec = { version = "0.6.8", features = ["runtime"] }
+lazy_static = { workspace = true }
+tracing = { workspace = true }
+ttrpc = { workspace = true, features = ["async"] }
+protobuf = { workspace = true }
+oci-spec = { workspace = true }
 futures = "0.3.25"
 safe-path = "0.1.0"
 crossbeam-channel = "0.5.6"
@@ -37,8 +37,8 @@ tempdir = "0.3.7"
 qapi = { version = "0.14", features = ["qmp", "async-tokio-all"] }
 qapi-spec = "0.3.1"
 qapi-qmp = "0.14.0"
-hyperlocal = "0.8.0"
-hyper = { version = "0.14.18", features = ["client"] }
+hyperlocal = { workspace = true }
+hyper = { workspace = true, features = ["client"] }
 
 # Local dependencies
 kata-sys-util = { workspace = true }

--- a/src/runtime-rs/crates/hypervisor/ch-config/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/ch-config/Cargo.toml
@@ -5,17 +5,17 @@
 [package]
 name = "ch-config"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.68"
-serde = { version = "1.0.145", features = ["rc", "derive"] }
-serde_json = "1.0.91"
-tokio = { version = "1.38.0", features = ["sync", "rt"] }
+anyhow = { workspace = true }
+serde = { workspace = true, features = ["rc", "derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync", "rt"] }
 nix = "0.26.2"
-thiserror = "1.0.38"
+thiserror = { workspace = true }
 
 # Cloud Hypervisor public HTTP API functions
 # Note that the version specified is not necessarily the version of CH

--- a/src/runtime-rs/crates/persist/Cargo.toml
+++ b/src/runtime-rs/crates/persist/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "persist"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
-license = "Apache-2.0"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-async-trait = "0.1.48"
-anyhow = "^1.0"
-libc = "0.2"
-serde = { version = "1.0.138", features = ["derive"] }
-serde_json = "1.0.82"
+async-trait = { workspace = true }
+anyhow = { workspace = true }
+libc = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Local dependencies
 kata-sys-util = { workspace = true }

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -1,41 +1,41 @@
 [package]
 name = "resource"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
-license = "Apache-2.0"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.2.0"
+tempfile = { workspace = true }
 
 # Local dev-dependencies
 test-utils = { workspace = true }
 
 [dependencies]
-anyhow = "^1.0"
-actix-rt = "2.7.0"
-async-trait = "0.1.48"
+actix-rt = { workspace = true }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 bitflags = "1.2.1"
 byte-unit = "4.0.14"
 cgroups-rs = "0.3.2"
 futures = "0.3.11"
-lazy_static = "1.4.0"
-libc = ">=0.2.39"
-netns-rs = "0.1.0"
+lazy_static = { workspace = true }
+libc = { workspace = true }
+netns-rs = { workspace = true }
 netlink-sys = "0.8.3"
 netlink-packet-route = "0.19.0"
-nix = "0.24.2"
-rand = "^0.7.2"
+nix = { workspace = true }
+rand = { workspace = true }
 rtnetlink = "0.14.0"
 scopeguard = "1.0.0"
-serde = { version = "1.0.138", features = ["derive"] }
-serde_json = "1.0.82"
-slog = "2.5.2"
-slog-scope = "4.4.0"
-tokio = { version = "1.38.2", features = ["process"] }
-tracing = "0.1.36"
+serde = { workspace = true }
+serde_json = { workspace = true }
+slog = { workspace = true }
+slog-scope = { workspace = true }
+tokio = { workspace = true, features = ["process"] }
+tracing = { workspace = true }
 uuid = { version = "0.4", features = ["v4"] }
-oci-spec = { version = "0.6.8", features = ["runtime"] }
+oci-spec = { workspace = true }
 
 # Local dependencies
 agent = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/Cargo.toml
@@ -1,30 +1,38 @@
 [package]
 name = "runtimes"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
-license = "Apache-2.0"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-anyhow = "^1.0"
-lazy_static = "1.4.0"
-netns-rs = "0.1.0"
-slog = "2.5.2"
-slog-scope = "4.4.0"
-tokio = { version = "1.38.2", features = ["rt-multi-thread"] }
-tracing = "0.1.36"
-tracing-opentelemetry = "0.18.0"
-opentelemetry = { version = "0.18.0", features = ["rt-tokio-current-thread", "trace", "rt-tokio"] }
-opentelemetry-jaeger = { version = "0.17.0", features = ["rt-tokio", "hyper_collector_client", "collector_client"] }
+anyhow = { workspace = true }
+lazy_static = { workspace = true }
+netns-rs = { workspace = true }
+slog = { workspace = true }
+slog-scope = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+opentelemetry = { version = "0.18.0", features = [
+    "rt-tokio-current-thread",
+    "trace",
+    "rt-tokio",
+] }
+opentelemetry-jaeger = { version = "0.17.0", features = [
+    "rt-tokio",
+    "hyper_collector_client",
+    "collector_client",
+] }
 tracing-subscriber = { version = "0.3", features = ["registry", "std"] }
-hyper = { version = "0.14.20", features = ["stream", "server", "http1"] }
-hyperlocal = "0.8"
-serde_json = "1.0.88"
+hyper = { workspace = true, features = ["stream", "server", "http1"] }
+hyperlocal = { workspace = true }
+serde_json = { workspace = true }
 nix = "0.25.0"
-url = "2.3.1"
+url = { workspace = true }
 procfs = "0.12.0"
 prometheus = { version = "0.13.0", features = ["process"] }
-oci-spec = { version = "0.6.8", features = ["runtime"] }
+oci-spec = { workspace = true }
 
 # Local dependencies
 agent = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/common/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/common/Cargo.toml
@@ -1,27 +1,27 @@
 [package]
 name = "common"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
-license = "Apache-2.0"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "^1.0"
-async-trait = "0.1.48"
-containerd-shim-protos = { version = "0.6.0", features = ["async"] }
-lazy_static = "1.4.0"
-nix = "0.24.2"
-protobuf = "=3.7.1"
-serde_json = "1.0.39"
-slog = "2.5.2"
-slog-scope = "4.4.0"
-strum = { version = "0.24.0", features = ["derive"] }
-thiserror = "^1.0"
-tokio = { version = "1.38.0", features = ["rt-multi-thread", "process", "fs"] }
-ttrpc = "0.8.4" 
-oci-spec = { version = "0.6.8", features = ["runtime"] }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+containerd-shim-protos = { workspace = true }
+lazy_static = { workspace = true }
+nix = { workspace = true }
+protobuf = { workspace = true }
+serde_json = { workspace = true }
+slog = { workspace = true }
+slog-scope = { workspace = true }
+strum = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread", "process", "fs"] }
+ttrpc = { workspace = true }
+oci-spec = { workspace = true }
 
 # Local dependencies
 persist = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/linux_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/linux_container/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "linux_container"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-anyhow = "^1.0"
-async-trait = "0.1.48"
-tokio = { version = "1.38.0" }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
 
 # Local dependencies
 common = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -1,33 +1,32 @@
 [package]
 name = "virt_container"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
-license = "Apache-2.0"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-anyhow = "^1.0"
-async-trait = "0.1.48"
+anyhow = { workspace = true }
+async-trait = { workspace = true }
 awaitgroup = "0.6.0"
-containerd-shim-protos = { version = "0.6.0", features = ["async"] }
+containerd-shim-protos = { workspace = true }
 futures = "0.3.19"
-lazy_static = "1.4.0"
-libc = ">=0.2.39"
-nix = "0.24.2"
-protobuf = "=3.7.1"
+lazy_static = { workspace = true }
+libc = { workspace = true }
+nix = { workspace = true }
+protobuf = { workspace = true }
 sendfd = { version = "0.4.3", features = ["tokio"] }
-serde = { version = "1.0.100", features = ["derive"] }
-serde_derive = "1.0.27"
-serde_json = "1.0.82"
-slog = "2.5.2"
-slog-scope = "4.4.0"
-tokio = { version = "1.38.0" }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+slog = { workspace = true }
+slog-scope = { workspace = true }
+tokio = { workspace = true }
 toml = "0.4.2"
-url = "2.1.1"
+url = { workspace = true }
 async-std = "1.12.0"
-tracing = "0.1.36"
-oci-spec = { version = "0.6.8", features = ["runtime"] }
-strum = { version = "0.24.0", features = ["derive"] }
+tracing = { workspace = true }
+oci-spec = { workspace = true }
+strum = { workspace = true }
 
 # Local dependencies
 agent = { workspace = true }

--- a/src/runtime-rs/crates/runtimes/wasm_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/wasm_container/Cargo.toml
@@ -1,13 +1,14 @@
 [package]
 name = "wasm_container"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-anyhow = "^1.0"
-async-trait = "0.1.48"
-tokio = { version = "1.38.0" }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
 
 # Local dependencies
 common = { workspace = true }

--- a/src/runtime-rs/crates/service/Cargo.toml
+++ b/src/runtime-rs/crates/service/Cargo.toml
@@ -1,20 +1,20 @@
 [package]
 name = "service"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
-edition = "2018"
-license = "Apache-2.0"
+authors = { workspace = true }
+edition = { workspace = true }
+license = { workspace = true }
 
 [dependencies]
-anyhow = "^1.0"
-async-trait = "0.1.48"
-slog = "2.5.2"
-slog-scope = "4.4.0"
-tokio = { version = "1.38.2", features = ["rt-multi-thread"] }
-tracing = "0.1.36"
-ttrpc = "0.8.4"
-containerd-shim-protos = { version = "0.6.0", features = ["async", "sandbox"] }
-containerd-shim = { version = "0.6.0", features = ["async"] }
+anyhow = { workspace = true }
+async-trait = { workspace = true }
+slog = { workspace = true }
+slog-scope = { workspace = true }
+tokio = { workspace = true, features = ["rt-multi-thread"] }
+tracing = { workspace = true }
+ttrpc = { workspace = true }
+containerd-shim-protos = { workspace = true, features = ["async", "sandbox"] }
+containerd-shim = { workspace = true }
 
 # Local dependencies
 common = { workspace = true }

--- a/src/runtime-rs/crates/shim-ctl/Cargo.toml
+++ b/src/runtime-rs/crates/shim-ctl/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
 name = "shim-ctl"
 version = "0.1.0"
-edition = "2021"
+edition = { workspace = true }
+authors = { workspace = true }
+license = { workspace = true }
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "^1.0"
-tokio = { version = "1.38.2", features = [ "rt", "rt-multi-thread" ] }
+anyhow = { workspace = true }
+tokio = { workspace = true, features = [ "rt", "rt-multi-thread" ] }
 
 # Local dependencies
 common = { workspace = true }

--- a/src/runtime-rs/crates/shim/Cargo.toml
+++ b/src/runtime-rs/crates/shim/Cargo.toml
@@ -1,37 +1,37 @@
 [package]
 name = "shim"
 version = "0.1.0"
-authors = ["The Kata Containers community <kata-dev@lists.katacontainers.io>"]
+authors = { workspace = true }
 description = "Containerd shim runtime for Kata Containers"
 keywords = ["kata-containers", "shim"]
 repository = "https://github.com/kata-containers/kata-containers.git"
-license = "Apache-2.0"
-edition = "2018"
+license  = { workspace = true }
+edition = { workspace = true }
 
 [[bin]]
 name = "containerd-shim-kata-v2"
 path = "src/bin/main.rs"
 
 [dependencies]
-anyhow = "^1.0"
+anyhow = { workspace = true }
 backtrace = {version = ">=0.3.35", features = ["libunwind", "libbacktrace", "std"], default-features = false}
-containerd-shim-protos = { version = "0.6.0", features = ["async"]}
-go-flag = "0.1.0"
-libc = "0.2.108"
-log = "0.4.14"
-nix = "0.24.2"
-protobuf = "=3.7.1"
+containerd-shim-protos = { workspace = true }
+go-flag = { workspace = true }
+libc = { workspace = true }
+log = { workspace = true }
+nix  = { workspace = true }
+protobuf = { workspace = true }
 sha2 = "=0.9.3"
-slog = {version = "2.5.2", features = ["std", "release_max_level_trace", "max_level_trace"]}
+slog = {workspace = true, features = ["std", "release_max_level_trace", "max_level_trace"]}
 slog-async = "2.5.2"
-slog-scope = "4.4.0"
+slog-scope = { workspace = true }
 slog-stdlog = "4.1.0"
-thiserror = "1.0.30"
-tokio = { version = "1.38.2", features = [ "rt", "rt-multi-thread" ] }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = [ "rt", "rt-multi-thread" ] }
 unix_socket2 = "0.5.4"
-tracing = "0.1.36"
-tracing-opentelemetry = "0.18.0"
-oci-spec = { version = "0.6.8", features = ["runtime"] }
+tracing = { workspace = true }
+tracing-opentelemetry = { workspace = true }
+oci-spec = { workspace = true }
 
 # Local dependencies
 kata-types = { workspace = true }
@@ -42,8 +42,8 @@ service = { workspace = true }
 runtimes = { workspace = true }
 
 [dev-dependencies]
-tempfile = "3.2.0"
-rand = "0.8.4"
+tempfile = { workspace = true }
+rand = { workspace = true }
 serial_test = "0.5.1"
 
 # Local dev-dependencies

--- a/src/runtime-rs/tests/utils/Cargo.toml
+++ b/src/runtime-rs/tests/utils/Cargo.toml
@@ -8,8 +8,8 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "^1.0"
-rand = "0.8.4"
+anyhow = { workspace = true }
+rand = { workspace = true }
 
 # Local dependencies
 kata-types = { workspace = true }


### PR DESCRIPTION
Update the runtime-rs workspace packages to
use workspace package versions where applicable
to centralise the config and reduce maintenance
when updating these