### PR TITLE
runtime: remove wrong qemu-system-x86_64 option

### DIFF
--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -73,10 +73,6 @@ var supportedQemuMachines = []govmmQemu.Machine{
 		Options: defaultQemuMachineOptions,
 	},
 	{
-		Type:    QemuVirt,
-		Options: defaultQemuMachineOptions,
-	},
-	{
 		Type:    QemuMicrovm,
 		Options: defaultQemuMachineOptions,
 	},
@@ -169,8 +165,7 @@ func newQemuArch(config HypervisorConfig) (qemuArch, error) {
 func (q *qemuAmd64) capabilities(hConfig HypervisorConfig) types.Capabilities {
 	var caps types.Capabilities
 
-	if q.qemuMachine.Type == QemuQ35 ||
-		q.qemuMachine.Type == QemuVirt {
+	if q.qemuMachine.Type == QemuQ35 {
 		caps.SetBlockDeviceHotplugSupport()
 		caps.SetNetworkDeviceHotplugSupported()
 	}

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -221,7 +221,7 @@ const (
 	// QemuMicrovm is the QEMU microvm machine type for amd64
 	QemuMicrovm = "microvm"
 
-	// QemuVirt is the QEMU virt machine type for aarch64 or amd64
+	// QemuVirt is the QEMU virt machine type for aarch64 or arm
 	QemuVirt = "virt"
 
 	// QemuPseries is a QEMU virt machine type for ppc64le


### PR DESCRIPTION
qemu-system-x86_64 does not support "-machine virt". (this is only supported by arm,aarch64)
<https://people.redhat.com/~cohuck/2022/01/05/qemu-machine-types.html>

no virt
```
$ /opt/kata/bin/qemu-system-x86_64 --machine help
Supported machines are:
microvm              microvm (i386)
pc                   Standard PC (i440FX + PIIX, 1996) (alias of pc-i440fx-9.1)
pc-i440fx-9.1        Standard PC (i440FX + PIIX, 1996) (default)
pc-i440fx-9.0        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-8.2        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-8.1        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-8.0        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-7.2        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-7.1        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-7.0        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-6.2        Standard PC (i440FX + PIIX, 1996)
pc-i440fx-6.1        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-6.0        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-5.2        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-5.1        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-5.0        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-4.2        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-4.1        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-4.0        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-3.1        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-3.0        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-2.9        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-2.8        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-2.7        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-2.6        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-2.5        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-2.4        Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-2.12       Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-2.11       Standard PC (i440FX + PIIX, 1996) (deprecated)
pc-i440fx-2.10       Standard PC (i440FX + PIIX, 1996) (deprecated)
q35                  Standard PC (Q35 + ICH9, 2009) (alias of pc-q35-9.1)
pc-q35-9.1           Standard PC (Q35 + ICH9, 2009)
pc-q35-9.0           Standard PC (Q35 + ICH9, 2009)
pc-q35-8.2           Standard PC (Q35 + ICH9, 2009)
pc-q35-8.1           Standard PC (Q35 + ICH9, 2009)
pc-q35-8.0           Standard PC (Q35 + ICH9, 2009)
pc-q35-7.2           Standard PC (Q35 + ICH9, 2009)
pc-q35-7.1           Standard PC (Q35 + ICH9, 2009)
pc-q35-7.0           Standard PC (Q35 + ICH9, 2009)
pc-q35-6.2           Standard PC (Q35 + ICH9, 2009)
pc-q35-6.1           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-6.0           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-5.2           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-5.1           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-5.0           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-4.2           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-4.1           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-4.0.1         Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-4.0           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-3.1           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-3.0           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-2.9           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-2.8           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-2.7           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-2.6           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-2.5           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-2.4           Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-2.12          Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-2.11          Standard PC (Q35 + ICH9, 2009) (deprecated)
pc-q35-2.10          Standard PC (Q35 + ICH9, 2009) (deprecated)
isapc                ISA-only PC
none                 empty machine
x-remote             Experimental remote machine
```

Fixes: #11229