### PR TITLE
runtime: add the mtu support for updating routes

### DIFF
--- a/src/libs/protocols/protos/types.proto
+++ b/src/libs/protocols/protos/types.proto
@@ -59,6 +59,7 @@ message Route {
 	uint32 scope = 5;
 	IPFamily family = 6;
 	uint32 flags = 7;
+	uint32 mtu = 8;
 }
 
 message ARPNeighbor {

--- a/src/runtime-rs/crates/agent/src/kata/trans.rs
+++ b/src/runtime-rs/crates/agent/src/kata/trans.rs
@@ -230,6 +230,7 @@ impl From<Route> for types::Route {
             scope: from.scope,
             family: protobuf::EnumOrUnknown::new(from.family.into()),
             flags: from.flags,
+            mtu: from.mtu,
             ..Default::default()
         }
     }
@@ -245,6 +246,7 @@ impl From<types::Route> for Route {
             scope: src.scope,
             family: src.family.unwrap().into(),
             flags: src.flags,
+            mtu: src.mtu,
         }
     }
 }

--- a/src/runtime-rs/crates/agent/src/types.rs
+++ b/src/runtime-rs/crates/agent/src/types.rs
@@ -114,6 +114,7 @@ pub struct Route {
     pub scope: u32,
     pub family: IPFamily,
     pub flags: u32,
+    pub mtu: u32,
 }
 
 #[derive(Deserialize, Debug, PartialEq, Clone, Default)]

--- a/src/runtime-rs/crates/resource/src/network/dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/dan.rs
@@ -292,6 +292,8 @@ pub(crate) struct Route {
     pub scope: u32,
     #[serde(default)]
     pub flags: u32,
+    #[serde(default)]
+    pub mtu: u32,
 }
 
 impl Route {
@@ -369,7 +371,8 @@ mod tests {
                     "source": "172.18.0.1",
                     "gateway": "172.18.31.1",
                     "scope": 0,
-                    "flags": 0
+                    "flags": 0,
+                    "mtu": 1450
                 }],
                 "neighbors": [{
                     "ip_address": "192.168.0.3/16",
@@ -402,6 +405,7 @@ mod tests {
                     gateway: "172.18.31.1".to_owned(),
                     scope: 0,
                     flags: 0,
+                    mtu: 1450,
                 }],
                 neighbors: vec![ARPNeighbor {
                     ip_address: Some("192.168.0.3/16".to_owned()),

--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_dan.rs
@@ -75,6 +75,7 @@ impl NetworkInfoFromDan {
                     scope: route.scope,
                     family,
                     flags: route.flags,
+                    mtu: route.mtu,
                 })
             })
             .collect();
@@ -161,6 +162,7 @@ mod tests {
                     gateway: "172.18.31.1".to_owned(),
                     scope: 0,
                     flags: 0,
+                    mtu: 1450,
                 }],
                 neighbors: vec![DanARPNeighbor {
                     ip_address: Some("192.168.0.3/16".to_owned()),
@@ -197,6 +199,7 @@ mod tests {
             scope: 0,
             family: IPFamily::V4,
             flags: 0,
+            mtu: 1450,
         }];
         assert_eq!(routes, network_info.routes().await.unwrap());
 

--- a/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_info/network_info_from_link.rs
@@ -13,7 +13,7 @@ use futures::stream::TryStreamExt;
 use netlink_packet_route::{
     self,
     neighbour::{NeighbourAddress, NeighbourAttribute, NeighbourMessage},
-    route::{RouteAddress, RouteAttribute, RouteMessage},
+    route::{RouteAddress, RouteAttribute, RouteMessage, RouteMetric},
 };
 
 use super::NetworkInfo;
@@ -200,6 +200,14 @@ fn generate_route(name: &str, route_msg: &RouteMessage) -> Result<Option<Route>>
                 let dest = parse_route_addr(s)?;
 
                 route.source = dest.to_string();
+            }
+            RouteAttribute::Metrics(metrics) => {
+                for m in metrics {
+                    if let RouteMetric::Mtu(mtu) = m {
+                        route.mtu = *mtu;
+                        break;
+                    }
+                }
             }
             _ => {}
         }

--- a/src/runtime/virtcontainers/network.go
+++ b/src/runtime/virtcontainers/network.go
@@ -310,6 +310,8 @@ func generateVCNetworkStructures(ctx context.Context, endpoints []Endpoint) ([]*
 			r.Scope = uint32(route.Scope)
 			r.Family = utils.ConvertAddressFamily((int32)(route.Family))
 			r.Flags = uint32(route.Flags)
+			r.Mtu = uint32(route.MTU)
+
 			routes = append(routes, &r)
 		}
 

--- a/src/runtime/virtcontainers/pkg/agent/protocols/types.pb.go
+++ b/src/runtime/virtcontainers/pkg/agent/protocols/types.pb.go
@@ -308,6 +308,7 @@ type Route struct {
 	Scope   uint32   `protobuf:"varint,5,opt,name=scope,proto3" json:"scope,omitempty"`
 	Family  IPFamily `protobuf:"varint,6,opt,name=family,proto3,enum=types.IPFamily" json:"family,omitempty"`
 	Flags   uint32   `protobuf:"varint,7,opt,name=flags,proto3" json:"flags,omitempty"`
+	Mtu     uint32   `protobuf:"varint,8,opt,name=mtu,proto3" json:"mtu,omitempty"`
 }
 
 func (x *Route) Reset() {


### PR DESCRIPTION
Some cni plugins will set the MTU of some routes, such as cilium will modify the MTU of the default route. If the mtu of the route is not set correctly, it may cause excessive fragmentation or even packet loss of network packets. Therefore, this PR adds the setting of the MTU of the route. First, when obtaining the route, if the MTU is set, the MTU will also be obtained and set to the route in the guest.

Fixes:https://github.com/kata-containers/kata-containers/pull/11135