### PR TITLE
genpolicy: validate input process fields for ExecProcessRequest

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -340,7 +340,8 @@
                 "^AZURE_CLIENT_ID=[A-Fa-f0-9-]*$",
                 "^AZURE_TENANT_ID=[A-Fa-f0-9-]*$",
                 "^AZURE_FEDERATED_TOKEN_FILE=/var/run/secrets/azure/tokens/azure-identity-token$",
-                "^AZURE_AUTHORITY_HOST=https://login\\.microsoftonline\\.com/$"
+                "^AZURE_AUTHORITY_HOST=https://login\\.microsoftonline\\.com/$",
+                "^TERM=xterm$"
             ]
         },
         "UpdateInterfaceRequest": {

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -292,7 +292,7 @@ allow_by_sandbox_name(p_oci, i_oci, p_storages, i_storages, s_name) {
 
     allow_by_container_types(p_oci, i_oci, s_name, i_namespace)
     allow_by_bundle_or_sandbox_id(p_oci, i_oci, p_storages, i_storages)
-    allow_process(p_oci, i_oci, s_name)
+    allow_process(p_oci.Process, i_oci.Process, s_name)
 
     print("allow_by_sandbox_name: true")
 }
@@ -668,10 +668,7 @@ allow_by_bundle_or_sandbox_id(p_oci, i_oci, p_storages, i_storages) {
     print("allow_by_bundle_or_sandbox_id: true")
 }
 
-allow_process(p_oci, i_oci, s_name) {
-    p_process := p_oci.Process
-    i_process := i_oci.Process
-
+allow_process(p_process, i_process, s_name) {
     print("allow_process: i terminal =", i_process.Terminal, "p terminal =", p_process.Terminal)
     p_process.Terminal == i_process.Terminal
 

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -686,6 +686,7 @@ allow_process_common(p_process, i_process, s_name) {
 allow_process(p_process, i_process, s_name) {
     print("allow_process: start")
 
+    allow_args(p_process, i_process, s_name)
     allow_process_common(p_process, i_process, s_name)
     allow_caps(p_process.Capabilities, i_process.Capabilities)
     p_process.Terminal == i_process.Terminal
@@ -697,7 +698,6 @@ allow_process(p_process, i_process, s_name) {
 allow_interactive_process(p_process, i_process, s_name) {
     print("allow_interactive_process: start")
 
-    allow_args(p_process, i_process, s_name)
     allow_process_common(p_process, i_process, s_name)
     allow_exec_caps(i_process.Capabilities)
 
@@ -705,6 +705,17 @@ allow_interactive_process(p_process, i_process, s_name) {
     # They can be executed interactively so allow them to use any value for i_process.Terminal.
 
     print("allow_interactive_process: true")
+}
+
+# Compare the OCI Process field of a policy container with the input process field from ExecProcessRequest
+allow_probe_process(p_process, i_process, s_name) {
+    print("allow_probe_process: start")
+
+    allow_process_common(p_process, i_process, s_name)
+    allow_exec_caps(i_process.Capabilities)
+    p_process.Terminal == i_process.Terminal
+
+    print("allow_probe_process: true")
 }
 
 allow_user(p_process, i_process) {

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -782,7 +782,13 @@ impl EnvVar {
                 let path: &str = &field_ref.fieldPath;
                 match path {
                     "metadata.name" => return "$(sandbox-name)".to_string(),
-                    "metadata.namespace" => return namespace.to_string(),
+                    "metadata.namespace" => {
+                        return if namespace.is_empty() {
+                            "$(sandbox-namespace)".to_string()
+                        } else {
+                            namespace.to_string()
+                        };
+                    }
                     "metadata.uid" => return "$(pod-uid)".to_string(),
                     "status.hostIP" => return "$(host-ip)".to_string(),
                     "status.podIP" => return "$(pod-ip)".to_string(),

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocess/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocess/testcases.json
@@ -768,6 +768,257 @@
     }
   },
   {
+    "description": "test exec process in first container with Terminal=true",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b300",
+      "string_user": null,
+      "process": {
+        "Terminal": true,
+        "ConsoleSize": null,
+        "User": {
+          "UID": 0,
+          "GID": 0,
+          "AdditionalGids": [
+            0,
+            10
+          ],
+          "Username": ""
+        },
+        "Args": [
+          "test1"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": ""
+      }
+    }
+  },
+  {
+    "description": "test exec process in first container with non-empty capabilities",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b302",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "User": {
+          "UID": 0,
+          "GID": 0,
+          "AdditionalGids": [
+            0,
+            10
+          ],
+          "Username": ""
+        },
+        "Args": [
+          "test1"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/",
+        "Capabilities": {
+          "Ambient": [],
+          "Bounding": [
+            "CAP_CHOWN"
+          ],
+          "Effective": [],
+          "Inheritable": [],
+          "Permitted": []
+        },
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": ""
+      }
+    }
+  },
+  {
+    "description": "test exec process in first container with different Cwd",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b303",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "User": {
+          "UID": 0,
+          "GID": 0,
+          "AdditionalGids": [
+            0,
+            10
+          ],
+          "Username": ""
+        },
+        "Args": [
+          "test1"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/tmp",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": ""
+      }
+    }
+  },
+  {
+    "description": "test exec process in first container with NoNewPrivileges=true",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b304",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "User": {
+          "UID": 0,
+          "GID": 0,
+          "AdditionalGids": [
+            0,
+            10
+          ],
+          "Username": ""
+        },
+        "Args": [
+          "test1"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": true,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": ""
+      }
+    }
+  },
+  {
+    "description": "test exec process in first container with non-null/different User",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b305",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "User": {
+          "UID": 1000,
+          "GID": 1000,
+          "AdditionalGids": [],
+          "Username": ""
+        },
+        "Args": [
+          "test1"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc"
+        ],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": ""
+      }
+    }
+  },
+  {
+    "description": "test exec process in first container with additional environment variables",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b306",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "User": {
+          "UID": 0,
+          "GID": 0,
+          "AdditionalGids": [
+            0,
+            10
+          ],
+          "Username": ""
+        },
+        "Args": [
+          "test1"
+        ],
+        "Env": [
+          "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+          "HOSTNAME=busybox-cc",
+          "TERM=xterm",
+          "PROBE_TYPE=liveness"
+        ],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": ""
+      }
+    }
+  },
+  {
+    "description": "test exec process in first container with multi-arg command",
+    "allowed": false,
+    "request": {
+      "type": "ExecProcess",
+      "container_id": "88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
+      "exec_id": "05e07bbb-d06c-402d-b9b7-e6386935b308",
+      "string_user": null,
+      "process": {
+        "Terminal": false,
+        "ConsoleSize": null,
+        "User": {
+          "UID": 0,
+          "GID": 0,
+          "AdditionalGids": [0, 10],
+          "Username": ""
+        },
+        "Args": ["test1", "--flag"],
+        "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"],
+        "Cwd": "/",
+        "Capabilities": null,
+        "Rlimits": [],
+        "NoNewPrivileges": false,
+        "OOMScoreAdj": 0,
+        "SelinuxLabel": ""
+      }
+    }
+  },
+  {
     "description": "test exec process in first container with non-null selinuxLabel",
     "allowed": false,
     "request": {


### PR DESCRIPTION
Validate more process fields for ExecProcessRequest and add test cases for each of those validations for input fields. These validations also hold true for k8s probe commands - e.g., livenessProbe, readinessProbe, etc.

Cherry-picked from:
- https://github.com/microsoft/kata-containers/commit/167e46577f24b856f6fc6957bcd7724e831adccb
- https://github.com/microsoft/kata-containers/commit/b78982693925f2cffc5a77102463d5307baa73f7
- https://github.com/microsoft/kata-containers/commit/12e16102de39cd7b1ed8d590ca98cc84095159d6
- https://github.com/microsoft/kata-containers/commit/577b154c0d7629a040f5155da5b74f27ae8e3aad

Fixes #11108 