### PR TITLE
osbuilder: ubuntu: Switch from multistrap to mmdebstrap

### DIFF
--- a/tools/osbuilder/rootfs-builder/rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/rootfs.sh
@@ -700,6 +700,10 @@ EOF
 		       -e '/^\[Unit\]/a ConditionPathExists=\/dev\/ptp0' \
 		       -e 's/^ReadWritePaths=\(.\+\) \/var\/lib\/chrony \(.\+\)$/ReadWritePaths=\1 -\/var\/lib\/chrony \2/m' \
 		       ${chrony_systemd_service}
+		# Disable automatic directory creation
+		sed -i -e 's/^\(StateDirectory=\)/#\1/g' \
+		       -e 's/^\(LogsDirectory=\)/#\1/g' \
+		       ${chrony_systemd_service}
 	fi
 
 	AGENT_DIR="${ROOTFS_DIR}/usr/bin"

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -42,7 +42,7 @@ RUN apt-get update && \
     libclang-dev \
     make \
     makedev \
-    multistrap \
+    mmdebstrap \
     musl \
     musl-dev \
     musl-tools \

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -4,43 +4,22 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-build_dbus() {
-	local rootfs_dir=$1
-	ln -sf /lib/systemd/system/dbus.service $rootfs_dir/etc/systemd/system/dbus.service
-	ln -sf /lib/systemd/system/dbus.socket $rootfs_dir/etc/systemd/system/dbus.socket
-}
-
 build_rootfs() {
 	local rootfs_dir=$1
-	local multistrap_conf=multistrap.conf
-
-	# For simplicity's sake, use multistrap for foreign and native bootstraps.
-	cat > "$multistrap_conf" << EOF
-[General]
-cleanup=true
-aptsources=Ubuntu
-bootstrap=Ubuntu
-
-[Ubuntu]
-source=$REPO_URL
-keyring=ubuntu-keyring
-suite=$OS_VERSION
-packages=$PACKAGES $EXTRA_PKGS
-EOF
 
 	# This fixes the spurious error
 	# E: Can't find a source to download version '2021.03.26' of 'ubuntu-keyring:amd64'
 	apt update
-
-	if ! multistrap -a "$DEB_ARCH" -d "$rootfs_dir" -f "$multistrap_conf"; then
-		if [ "$OS_VERSION" = "focal" ]; then
-			echo "WARN: multistrap failed, proceed with hack for Ubuntu 20.04"
-			build_dbus $rootfs_dir
-		else
-			echo "ERROR: multistrap failed, cannot proceed" && exit 1
-		fi
+	# focal version of mmdebstrap only supports comma separated package lists
+	if [ "$OS_VERSION" = "focal" ]; then
+		PACKAGES=$(echo "$PACKAGES" | tr ' ' ',')
+		EXTRA_PKGS=$(echo "$EXTRA_PKGS" | tr ' ' ',')
+	fi
+	if ! mmdebstrap --mode auto --arch "$DEB_ARCH" --variant required \
+			--include "$PACKAGES,$EXTRA_PKGS" "$OS_VERSION" "$rootfs_dir" "$REPO_URL"; then
+		echo "ERROR: mmdebstrap failed, cannot proceed" && exit 1
 	else
-		echo "INFO: multistrap succeeded"
+		echo "INFO: mmdebstrap succeeded"
 	fi
 	rm -rf "$rootfs_dir/var/run"
 	ln -s /run "$rootfs_dir/var/run"


### PR DESCRIPTION
Multistrap requires usrmerge package which was dropped in Ubuntu 24.04 (Noble). Based on details from [0], the rootfs build process was switched to mmdebstrap.

Some additional minor tweaks were needed around chrony as the version from Noble has very strict systemd sandboxing configured and it doesn't work with readonly root by default.

[0] https://lists.debian.org/debian-dpkg/2023/05/msg00080.html

Fixes: #11245