### PR TITLE
genpolicy: add validation for storages

### DIFF
--- a/src/tools/genpolicy/.gitignore
+++ b/src/tools/genpolicy/.gitignore
@@ -1,1 +1,2 @@
 src/version.rs
+tests/**/layers-cache.json

--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -155,7 +155,7 @@
         "emptyDir": {
             "mount_type": "local",
             "mount_source": "^$(cpath)/$(sandbox-id)/rootfs/local/",
-            "mount_point": "^$(cpath)/$(sandbox-id)/local/",
+            "mount_point": "^$(cpath)/$(sandbox-id)/rootfs/local/",
             "driver": "local",
             "source": "local",
             "fstype": "local",
@@ -315,7 +315,8 @@
             "CAP_PERFMON",
             "CAP_BPF",
             "CAP_CHECKPOINT_RESTORE"
-        ]
+        ],
+        "image_layer_verification" : "none"
     },
     "kata_config": {
         "confidential_guest": false,

--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -165,8 +165,8 @@
         },
         "confidential_emptyDir": {
             "mount_type": "local",
-            "mount_source": "^$(cpath)/$(sandbox-id)/local/",
-            "mount_point": "^$(cpath)/$(sandbox-id)/local/",
+            "mount_source": "^$(cpath)/$(sandbox-id)/rootfs/local/",
+            "mount_point": "^$(cpath)/$(sandbox-id)/rootfs/local/",
             "driver": "local",
             "source": "local",
             "fstype": "local",

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1252,7 +1252,7 @@ allow_mount_point(p_storage, i_storage, bundle_id, sandbox_id, layer_ids) if {
     mount1 := p_storage.mount_point
     print("allow_mount_point 3: mount1 =", mount1)
 
-    mount2 := replace(mount1, "$(cpath)", policy_data.common.cpath)
+    mount2 := replace(mount1, "$(cpath)", policy_data.common.mount_source_cpath)
     print("allow_mount_point 3: mount2 =", mount2)
 
     mount3 := replace(mount2, "$(sandbox-id)", sandbox_id)

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1051,10 +1051,10 @@ allow_storages(p_storages, i_storages, bundle_id, sandbox_id) if {
 
 # Currently, Image Layer Integrity Verification through Policy is only required for Guest VMs
 # that use container image layers provided as dm-verity-protected block device images created on the Host.
-allow_container_image_storage(p_storages) = { "layer_ids": [], "root_hashes": [] } {
+allow_container_image_storage(p_storages) = { "layer_ids": [], "root_hashes": [] } if {
     policy_data.common.image_layer_verification != "host-tarfs-dm-verity"
 }
-allow_container_image_storage(p_storages) = { "layer_ids": layer_ids, "root_hashes": root_hashes } {
+allow_container_image_storage(p_storages) = { "layer_ids": layer_ids, "root_hashes": root_hashes } if {
     policy_data.common.image_layer_verification == "host-tarfs-dm-verity"
 
     some overlay_storage in p_storages
@@ -1082,7 +1082,7 @@ allow_storage(p_storages, i_storage, bundle_id, sandbox_id, layer_ids, root_hash
 
     print("allow_storage: true")
 }
-allow_storage(p_storages, i_storage, bundle_id, sandbox_id, layer_ids, root_hashes) {
+allow_storage(p_storages, i_storage, bundle_id, sandbox_id, layer_ids, root_hashes) if {
     i_storage.driver == "image_guest_pull"
     print("allow_storage with image_guest_pull: start")
     i_storage.fstype == "overlay"
@@ -1092,14 +1092,14 @@ allow_storage(p_storages, i_storage, bundle_id, sandbox_id, layer_ids, root_hash
     print("allow_storage with image_guest_pull: true")
 }
 
-allow_storage_source(p_storage, i_storage, bundle_id) {
+allow_storage_source(p_storage, i_storage, bundle_id) if {
     print("allow_storage_source 1: start")
 
     p_storage.source == i_storage.source
 
     print("allow_storage_source 1: true")
 }
-allow_storage_source(p_storage, i_storage, bundle_id) {
+allow_storage_source(p_storage, i_storage, bundle_id) if {
     print("allow_storage_source 2: start")
 
     source1 := p_storage.source
@@ -1112,7 +1112,7 @@ allow_storage_source(p_storage, i_storage, bundle_id) {
 
     print("allow_storage_source 2: true")
 }
-allow_storage_source(p_storage, i_storage, bundle_id) {
+allow_storage_source(p_storage, i_storage, bundle_id) if {
     print("allow_storage_source 3: start")
 
     p_storage.driver == "overlayfs"

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -671,8 +671,7 @@ allow_by_bundle_or_sandbox_id(p_oci, i_oci, p_storages, i_storages) if {
 
     count(p_matches) == count(input.OCI.Mounts)
 
-    # TODO: enable allow_storages() after fixing https://github.com/kata-containers/kata-containers/issues/8833
-    # allow_storages(p_storages, i_storages, bundle_id, sandbox_id)
+    allow_storages(p_storages, i_storages, bundle_id, sandbox_id)
 
     print("allow_by_bundle_or_sandbox_id: true")
 }
@@ -1038,23 +1037,32 @@ allow_storages(p_storages, i_storages, bundle_id, sandbox_id) if {
 
     p_count == i_count
 
-    # Get the container image layer IDs and verity root hashes, from the "overlayfs" storage.
-    some overlay_storage in p_storages
-    overlay_storage.driver == "overlayfs"
-    print("allow_storages: overlay_storage =", overlay_storage)
-    count(overlay_storage.options) == 2
-
-    layer_ids := split(overlay_storage.options[0], ":")
-    print("allow_storages: layer_ids =", layer_ids)
-
-    root_hashes := split(overlay_storage.options[1], ":")
-    print("allow_storages: root_hashes =", root_hashes)
+    image_info := allow_container_image_storage(p_storages)
+    layer_ids := image_info.layer_ids
+    root_hashes := image_info.root_hashes
 
     every i_storage in i_storages {
         allow_storage(p_storages, i_storage, bundle_id, sandbox_id, layer_ids, root_hashes)
     }
 
     print("allow_storages: true")
+}
+
+# Currently, Image Layer Integrity Verification through Policy is only required for Guest VMs
+# that use container image layers provided as dm-verity-protected block device images created on the Host.
+allow_container_image_storage(p_storages) = { "layer_ids": [], "root_hashes": [] } {
+    policy_data.common.image_layer_verification != "host-tarfs-dm-verity"
+}
+
+allow_container_image_storage(p_storages) = { "layer_ids": layer_ids, "root_hashes": root_hashes } {
+    policy_data.common.image_layer_verification == "host-tarfs-dm-verity"
+
+    some overlay_storage in p_storages
+    overlay_storage.driver == "overlayfs"
+    count(overlay_storage.options) == 2
+
+    layer_ids := split(overlay_storage.options[0], ":")
+    root_hashes := split(overlay_storage.options[1], ":")
 }
 
 allow_storage(p_storages, i_storage, bundle_id, sandbox_id, layer_ids, root_hashes) if {
@@ -1066,13 +1074,42 @@ allow_storage(p_storages, i_storage, bundle_id, sandbox_id, layer_ids, root_hash
     p_storage.driver           == i_storage.driver
     p_storage.driver_options   == i_storage.driver_options
     p_storage.fs_group         == i_storage.fs_group
+    p_storage.fstype           == i_storage.fstype
 
+    allow_storage_source(p_storage, i_storage, bundle_id)
     allow_storage_options(p_storage, i_storage, layer_ids, root_hashes)
     allow_mount_point(p_storage, i_storage, bundle_id, sandbox_id, layer_ids)
 
-    # TODO: validate the source field too.
-
     print("allow_storage: true")
+}
+
+allow_storage_source(p_storage, i_storage, bundle_id) {
+    print("allow_storage_source 1: start")
+
+    p_storage.source == i_storage.source
+
+    print("allow_storage_source 1: true")
+}
+allow_storage_source(p_storage, i_storage, bundle_id) {
+    print("allow_storage_source 2: start")
+
+    source1 := p_storage.source
+    source2 := replace(source1, "$(sfprefix)", policy_data.common.sfprefix)
+    source3 := replace(source2, "$(cpath)", policy_data.common.cpath)
+    source4 := replace(source3, "$(bundle-id)", bundle_id)
+    
+    print("allow_storage_source 2: source =", source4)
+    regex.match(source4, i_storage.source)
+
+    print("allow_storage_source 2: true")
+}
+allow_storage_source(p_storage, i_storage, bundle_id) {
+    print("allow_storage_source 3: start")
+
+    p_storage.driver == "overlayfs"
+    i_storage.source == "none"
+
+    print("allow_storage_source 3: true")
 }
 
 allow_storage_options(p_storage, i_storage, layer_ids, root_hashes) if {

--- a/src/tools/genpolicy/src/mount_and_storage.rs
+++ b/src/tools/genpolicy/src/mount_and_storage.rs
@@ -375,7 +375,6 @@ fn get_downward_api_mount(yaml_mount: &pod::VolumeMount, p_mounts: &mut Vec<poli
 pub fn get_image_mount_and_storage(
     settings: &settings::Settings,
     p_mounts: &mut Vec<policy::KataMount>,
-    storages: &mut Vec<agent::Storage>,
     destination: &str,
 ) {
     // https://github.com/kubernetes/examples/blob/master/cassandra/image/Dockerfile
@@ -403,17 +402,6 @@ pub fn get_image_mount_and_storage(
         "get_image_mount_and_storage: settings for container image volumes: {:?}",
         settings_image
     );
-
-    storages.push(agent::Storage {
-        driver: settings_image.driver.clone(),
-        driver_options: Vec::new(),
-        source: settings_image.source.clone(),
-        fstype: settings_image.fstype.clone(),
-        options: settings_image.options.clone(),
-        mount_point: destination_string.clone(),
-        fs_group: protobuf::MessageField::none(),
-        special_fields: ::protobuf::SpecialFields::new(),
-    });
 
     let file_name = Path::new(&destination_string).file_name().unwrap();
     let name = OsString::from(file_name).into_string().unwrap();

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -418,6 +418,9 @@ pub struct CommonData {
 
     /// Default capabilities for a privileged container.
     pub privileged_caps: Vec<String>,
+
+    /// Parse Container image as a storage object
+    pub image_layer_verification: String,
 }
 
 /// Configuration from "kubectl config".
@@ -615,7 +618,10 @@ impl AgentPolicy {
 
         let image_layers = yaml_container.registry.get_image_layers();
         let mut storages = Default::default();
-        get_image_layer_storages(&mut storages, &image_layers, &root);
+        const HOST_TARFS_DM_VERITY: &str = "host-tarfs-dm-verity";
+        if self.config.settings.common.image_layer_verification == HOST_TARFS_DM_VERITY {
+            get_image_layer_storages(&mut storages, &image_layers, &root);
+        }
         resource.get_container_mounts_and_storages(
             &mut mounts,
             &mut storages,

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -313,12 +313,7 @@ pub fn get_container_mounts_and_storages(
         for volume in volumes {
             debug!("get_container_mounts_and_storages: {:?}", &volume);
 
-            mount_and_storage::get_image_mount_and_storage(
-                settings,
-                policy_mounts,
-                storages,
-                volume.0,
-            );
+            mount_and_storage::get_image_mount_and_storage(settings, policy_mounts, volume.0);
         }
     }
 }

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -289,4 +289,9 @@ mod tests {
     async fn test_create_container_volumes_config_map() {
         runtests("createcontainer/volumes/config_map").await;
     }
+
+    #[tokio::test]
+    async fn test_create_container_volumes_container_image() {
+        runtests("createcontainer/volumes/container_image").await;
+    }
 }

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -63,14 +63,36 @@ mod tests {
     /// a JSON list of [TestCase] instances. Each instance will be of type enum TestRequest,
     /// with the tag `type` listing the exact type of request.
     async fn runtests(test_case_dir: &str) {
-        // Prepare temp dir for running genpolicy.
-        let (workdir, testdata_dir) = prepare_workdir(test_case_dir, &["pod.yaml"]);
+        // Check if config_map.yaml exists.
+        // If it does, we need to copy it to the workdir.
+        let is_config_map_file_present = path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/policy/testdata")
+            .join(test_case_dir)
+            .join("config_map.yaml")
+            .exists();
 
-        // Run the command and return the generated policy.
+        let files_to_copy = if is_config_map_file_present {
+            vec!["pod.yaml", "config_map.yaml"]
+        } else {
+            vec!["pod.yaml"]
+        };
+
+        // Prepare temp dir for running genpolicy.
+        let (workdir, testdata_dir) = prepare_workdir(test_case_dir, &files_to_copy);
+
+        let config_files = if is_config_map_file_present {
+            Some(vec![workdir
+                .join("config_map.yaml")
+                .to_str()
+                .unwrap()
+                .to_string()])
+        } else {
+            None
+        };
 
         let config = genpolicy::utils::Config {
             base64_out: false,
-            config_files: None,
+            config_files,
             containerd_socket_path: None, // Some(String::from("/var/run/containerd/containerd.sock")),
             insecure_registries: Vec::new(),
             layers_cache: genpolicy::layers_cache::ImageLayersCache::new(&None),

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -284,4 +284,9 @@ mod tests {
     async fn test_create_container_mounts() {
         runtests("createcontainer/volumes/emptydir").await;
     }
+
+    #[tokio::test]
+    async fn test_create_container_volumes_config_map() {
+        runtests("createcontainer/volumes/config_map").await;
+    }
 }

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -281,7 +281,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_create_container_mounts() {
+    async fn test_create_container_volumes_empty_dir() {
         runtests("createcontainer/volumes/emptydir").await;
     }
 

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/config_map.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/config_map.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config-map1
+data:
+  simple_value1: value1

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/pod.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+    - name: dummy
+      image: "registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+      volumeMounts:
+        - name: config
+          mountPath: /config
+          readOnly: true
+  volumes:
+    - name: config
+      configMap:
+        name: config-map1
+        items:
+          - key: simple_value1
+            path: simple_value1

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/testcases.json
@@ -1,0 +1,151 @@
+[
+  {
+    "description": "CreateContainer with config map volume",
+    "allowed": true,
+    "request": {
+      "type": "CreateContainer",
+      "OCI": {
+        "Version": "1.1.0",
+        "Annotations": {
+          "io.kubernetes.cri.sandbox-name": "dummy",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.container-type": "container",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
+          "io.kubernetes.cri.container-name": "dummy"
+        },
+        "Linux": {
+          "GIDMappings": [],
+          "MountLabel": "",
+          "Resources": {
+            "Devices": []
+          },
+          "RootfsPropagation": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            },
+            {
+              "Path": "/run/netns/podns",
+              "Type": "network"
+            }
+          ],
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/proc/scsi"
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ]
+        },
+        "Process": {
+          "SelinuxLabel": "",
+          "User": {
+            "Username": "",
+            "UID": 65535,
+            "AdditionalGids": [
+              0
+            ]
+          },
+          "Args": [
+            "/pause"
+          ],
+          "Cwd": "/",
+          "NoNewPrivileges": false,
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          }
+        },
+        "Root": {
+          "Readonly": false,
+          "Path": "/run/kata-containers/shared/containers/bundle-id/rootfs"
+        }
+      },
+      "storages": [
+        {
+          "driver": "watchable-bind",
+          "driver_options": [],
+          "source": "/run/kata-containers/shared/containers/bundle-id-a1b2c3d4e5f6g7h8-config",
+          "fstype": "bind",
+          "options": [
+            "rbind",
+            "rprivate",
+            "ro"
+          ],
+          "mount_point": "/run/kata-containers/shared/containers/watchable/bundle-id-a1b2c3d4e5f6g7h8-config",
+          "fs_group": null
+        }
+      ]
+    }
+  }
+]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/pod.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: redis
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+    - name: redis
+      image: quay.io/opstree/redis

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/testcases.json
@@ -1,0 +1,127 @@
+[
+  {
+    "description": "CreateContainer with a container image having volumes",
+    "allowed": true,
+    "request": {
+      "type": "CreateContainer",
+      "OCI": {
+        "Version": "1.1.0",
+        "Annotations": {
+          "io.kubernetes.cri.sandbox-name": "redis",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.container-type": "container",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
+          "io.kubernetes.cri.container-name": "redis"
+        },
+        "Linux": {
+          "GIDMappings": [],
+          "MountLabel": "",
+          "Resources": {
+            "Devices": []
+          },
+          "RootfsPropagation": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            },
+            {
+              "Path": "/run/netns/podns",
+              "Type": "network"
+            }
+          ],
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/proc/scsi"
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ]
+        },
+        "Process": {
+          "Args": [
+            "/usr/bin/entrypoint.sh"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "$(default_caps)"
+            ],
+            "Effective": [
+              "$(default_caps)"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "$(default_caps)"
+            ]
+          },
+          "Cwd": "/data",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "REDIS_PORT=6379",
+            "HOSTNAME=$(host-name)"
+          ],
+          "NoNewPrivileges": false,
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              1000
+            ],
+            "GID": 1000,
+            "UID": 1000,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Readonly": false,
+          "Path": "/run/kata-containers/shared/containers/bundle-id/rootfs"
+        },
+        "Mounts": [
+          {
+            "destination": "/data",
+            "source": "/run/kata-containers/shared/containers/bundle-id-a1b2c3d4e5f6g7h8-data",
+            "type_": "bind",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ]
+          },
+          {
+            "destination": "/node-conf",
+            "source": "/run/kata-containers/shared/containers/bundle-id-a1b2c3d4e5f6g7h8-node-conf",
+            "type_": "bind",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ]
+          }
+        ]
+      },
+      "storages": []
+    }
+  }
+]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
@@ -163,7 +163,53 @@
             ]
           }
         ]
-      }
+      },
+      "storages": [
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume2",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        }
+      ]
     }
   },
   {
@@ -310,7 +356,53 @@
             ]
           }
         ]
-      }
+      },
+      "storages": [
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume2",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        }
+      ]
     }
   },
   {
@@ -467,7 +559,53 @@
             ]
           }
         ]
-      }
+      },
+      "storages": [
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume2",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        }
+      ]
     }
   },
   {
@@ -608,7 +746,53 @@
             "source": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume"
           }
         ]
-      }
+      },
+      "storages": [
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume2",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        }
+      ]
     }
   },
   {
@@ -1109,7 +1293,53 @@
             ]
           }
         ]
-      }
+      },
+      "storages": [
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume2",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        }
+      ]
     }
   },
   {
@@ -1256,7 +1486,53 @@
             ]
           }
         ]
-      }
+      },
+      "storages": [
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume2",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        }
+      ]
     }
   },
   {
@@ -1403,7 +1679,53 @@
             ]
           }
         ]
-      }
+      },
+      "storages": [
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/0000000000000000000000000000000000000000000000000000000000000000/rootfs/local/test-volume2",
+          "options": [
+            "mode=0777"
+          ],
+          "source": "local"
+        }
+      ]
     }
   }
 ]

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocess/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocess/testcases.json
@@ -299,51 +299,7 @@
       "devices": [],
       "sandbox_pidns": false,
       "shared_mounts": [],
-      "storages": [
-        {
-          "driver": "blk",
-          "driver_options": [],
-          "source": "0001:00:02.0",
-          "fstype": "tar",
-          "options": [
-            "ro",
-            "io.katacontainers.fs-opt.block_device=file",
-            "io.katacontainers.fs-opt.is-layer",
-            "io.katacontainers.fs-opt.root-hash=75ed5e78d30374b9557d32c17ae6d2e1b4afdc5efd128812e6c99a0f60708dba"
-          ],
-          "mount_point": "/run/kata-containers/sandbox/layers/b1ef3d18661ad727a8ad01d462fffc63ec90420a938056bc0422822328f83ff7",
-          "fs_group": null
-        },
-        {
-          "driver": "blk",
-          "driver_options": [],
-          "source": "0001:00:03.0",
-          "fstype": "tar",
-          "options": [
-            "ro",
-            "io.katacontainers.fs-opt.block_device=file",
-            "io.katacontainers.fs-opt.is-layer",
-            "io.katacontainers.fs-opt.root-hash=2e52d86498030b4b99318650826d3f121bdfac5fe7bbbea9d18c546d48003aa0"
-          ],
-          "mount_point": "/run/kata-containers/sandbox/layers/a8650d4a279d4537d7fc43c582a264528a96f041b1327d41b503f368c301594f",
-          "fs_group": null
-        },
-        {
-          "driver": "overlayfs",
-          "driver_options": [],
-          "source": "none",
-          "fstype": "fuse3.kata-overlay",
-          "options": [
-            "io.katacontainers.fs-opt.layer-src-prefix=/var/lib/containerd/io.containerd.snapshotter.v1.tardev/layers",
-            "io.katacontainers.fs-opt.layer=YjFlZjNkMTg2NjFhZDcyN2E4YWQwMWQ0NjJmZmZjNjNlYzkwNDIwYTkzODA1NmJjMDQyMjgyMjMyOGY4M2ZmNyx0YXIscm8saW8ua2F0YWNvbnRhaW5lcnMuZnMtb3B0LmJsb2NrX2RldmljZT1maWxlLGlvLmthdGFjb250YWluZXJzLmZzLW9wdC5pcy1sYXllcixpby5rYXRhY29udGFpbmVycy5mcy1vcHQucm9vdC1oYXNoPTc1ZWQ1ZTc4ZDMwMzc0Yjk1NTdkMzJjMTdhZTZkMmUxYjRhZmRjNWVmZDEyODgxMmU2Yzk5YTBmNjA3MDhkYmE=",
-            "io.katacontainers.fs-opt.layer=YTg2NTBkNGEyNzlkNDUzN2Q3ZmM0M2M1ODJhMjY0NTI4YTk2ZjA0MWIxMzI3ZDQxYjUwM2YzNjhjMzAxNTk0Zix0YXIscm8saW8ua2F0YWNvbnRhaW5lcnMuZnMtb3B0LmJsb2NrX2RldmljZT1maWxlLGlvLmthdGFjb250YWluZXJzLmZzLW9wdC5pcy1sYXllcixpby5rYXRhY29udGFpbmVycy5mcy1vcHQucm9vdC1oYXNoPTJlNTJkODY0OTgwMzBiNGI5OTMxODY1MDgyNmQzZjEyMWJkZmFjNWZlN2JiYmVhOWQxOGM1NDZkNDgwMDNhYTA=",
-            "io.katacontainers.fs-opt.overlay-rw",
-            "lowerdir=b1ef3d18661ad727a8ad01d462fffc63ec90420a938056bc0422822328f83ff7:a8650d4a279d4537d7fc43c582a264528a96f041b1327d41b503f368c301594f"
-          ],
-          "mount_point": "/run/kata-containers/shared/containers/88941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
-          "fs_group": null
-        }
-      ],
+      "storages": [],
       "string_user": null
     }
   },
@@ -647,51 +603,7 @@
       "devices": [],
       "sandbox_pidns": false,
       "shared_mounts": [],
-      "storages": [
-        {
-          "driver": "blk",
-          "driver_options": [],
-          "source": "0001:00:02.0",
-          "fstype": "tar",
-          "options": [
-            "ro",
-            "io.katacontainers.fs-opt.block_device=file",
-            "io.katacontainers.fs-opt.is-layer",
-            "io.katacontainers.fs-opt.root-hash=75ed5e78d30374b9557d32c17ae6d2e1b4afdc5efd128812e6c99a0f60708dba"
-          ],
-          "mount_point": "/run/kata-containers/sandbox/layers/b1ef3d18661ad727a8ad01d462fffc63ec90420a938056bc0422822328f83ff7",
-          "fs_group": null
-        },
-        {
-          "driver": "blk",
-          "driver_options": [],
-          "source": "0001:00:03.0",
-          "fstype": "tar",
-          "options": [
-            "ro",
-            "io.katacontainers.fs-opt.block_device=file",
-            "io.katacontainers.fs-opt.is-layer",
-            "io.katacontainers.fs-opt.root-hash=2e52d86498030b4b99318650826d3f121bdfac5fe7bbbea9d18c546d48003aa0"
-          ],
-          "mount_point": "/run/kata-containers/sandbox/layers/a8650d4a279d4537d7fc43c582a264528a96f041b1327d41b503f368c301594f",
-          "fs_group": null
-        },
-        {
-          "driver": "overlayfs",
-          "driver_options": [],
-          "source": "none",
-          "fstype": "fuse3.kata-overlay",
-          "options": [
-            "io.katacontainers.fs-opt.layer-src-prefix=/var/lib/containerd/io.containerd.snapshotter.v1.tardev/layers",
-            "io.katacontainers.fs-opt.layer=YjFlZjNkMTg2NjFhZDcyN2E4YWQwMWQ0NjJmZmZjNjNlYzkwNDIwYTkzODA1NmJjMDQyMjgyMjMyOGY4M2ZmNyx0YXIscm8saW8ua2F0YWNvbnRhaW5lcnMuZnMtb3B0LmJsb2NrX2RldmljZT1maWxlLGlvLmthdGFjb250YWluZXJzLmZzLW9wdC5pcy1sYXllcixpby5rYXRhY29udGFpbmVycy5mcy1vcHQucm9vdC1oYXNoPTc1ZWQ1ZTc4ZDMwMzc0Yjk1NTdkMzJjMTdhZTZkMmUxYjRhZmRjNWVmZDEyODgxMmU2Yzk5YTBmNjA3MDhkYmE=",
-            "io.katacontainers.fs-opt.layer=YTg2NTBkNGEyNzlkNDUzN2Q3ZmM0M2M1ODJhMjY0NTI4YTk2ZjA0MWIxMzI3ZDQxYjUwM2YzNjhjMzAxNTk0Zix0YXIscm8saW8ua2F0YWNvbnRhaW5lcnMuZnMtb3B0LmJsb2NrX2RldmljZT1maWxlLGlvLmthdGFjb250YWluZXJzLmZzLW9wdC5pcy1sYXllcixpby5rYXRhY29udGFpbmVycy5mcy1vcHQucm9vdC1oYXNoPTJlNTJkODY0OTgwMzBiNGI5OTMxODY1MDgyNmQzZjEyMWJkZmFjNWZlN2JiYmVhOWQxOGM1NDZkNDgwMDNhYTA=",
-            "io.katacontainers.fs-opt.overlay-rw",
-            "lowerdir=b1ef3d18661ad727a8ad01d462fffc63ec90420a938056bc0422822328f83ff7:a8650d4a279d4537d7fc43c582a264528a96f041b1327d41b503f368c301594f"
-          ],
-          "mount_point": "/run/kata-containers/shared/containers/22941c1e6546ae2aef276f738b162fc379e61467120544e13e5ca5bd204862b9",
-          "fs_group": null
-        }
-      ],
+      "storages": [],
       "string_user": null
     }
   },

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -90,7 +90,7 @@ adapt_common_policy_settings_for_tdx() {
 	local settings_dir=$1
 
 	info "Adapting common policy settings for TDX, SNP, or the non-TEE development environment"
-	jq '.common.cpath = "/run/kata-containers" | .volumes.configMap.mount_point = "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-"' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
+	jq '.kata_config.confidential_guest = true | .common.cpath = "/run/kata-containers" | .volumes.configMap.mount_point = "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-"' "${settings_dir}/genpolicy-settings.json" > temp.json && sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
 }
 
 # adapt common policy settings for qemu-sev


### PR DESCRIPTION
**Description**
This PR adds validation for storages in the genpolicy tool.
Test cases are added for: config map, and container images containing volumes
Test cases are improved for: empty_dir

