### PR TITLE
helm: release: Publish our helm charts to the OCI registries

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -192,6 +192,19 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
 
+      - name: Login to the OCI registries
+        run: |
+          echo "${{ secrets.QUAY_DEPLOYER_PASSWORD }}" | helm registry login quay.io --username "${{ secrets.QUAY_DEPLOYER_USERNAME }}" --password-stdin
+          echo "${{ secrets.DOCKER_PASSWORD }}" | helm registry login docker.io --username "${{ secrets.DOCKER_USERNAME }}" --password-stdin
+          echo "${{ github.token }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
+
+      - name: Push helm chart to the OCI registries
+        run: |
+          release_version=$(./tools/packaging/release/release.sh release-version)
+          helm push "kata-deploy-${release_version}.tgz" oci://quay.io/kata-containers/kata-deploy-charts
+          helm push "kata-deploy-${release-version}.tgz" oci://docker.io/katadocker/kata-deploy-charts
+          helm push "kata-deploy-${release-version}.tgz" oci://ghcr.io/kata-containers/kata-deploy-charts
+
   publish-release:
     needs: [ build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le, publish-multi-arch-images, upload-multi-arch-static-tarball, upload-versions-yaml, upload-cargo-vendored-tarball, upload-libseccomp-tarball ]
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Let's take advantage that helm take and OCI registry as the charts, and upload our charts to the OCI registries we've been using so far.

**NOTE**: I'd like to ask someone from the @kata-containers/architecture-committee on what's the best way to try this out before the release, before it gets merged.. :-)