### PR TITLE
Enable edk2 for arm64

### DIFF
--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -40,6 +40,7 @@ jobs:
           - kernel-dragonball-experimental
           - kernel-nvidia-gpu
           - nydus
+          - ovmf
           - qemu
           - stratovirt
           - virtiofsd

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -464,6 +464,13 @@ ifneq (,$(QEMUCMD))
     DEFSANDBOXCGROUPONLY_NV = true
     # The latest OVMF build should be good for both TDX and SNP
     FIRMWAREPATH_NV := $(PREFIXDEPS)/share/ovmf/OVMF.fd
+
+    ifneq (,$(QEMUFW))
+        FIRMWAREPATH := $(PREFIXDEPS)/share/ovmf/$(QEMUFW)
+    endif
+    ifneq (,$(QEMUFWVOL))
+        FIRMWAREVOLUMEPATH := $(PREFIXDEPS)/share/ovmf/$(QEMUFWVOL)
+    endif
 endif
 
 ifneq (,$(CLHCMD))

--- a/src/runtime/arch/arm64-options.mk
+++ b/src/runtime/arch/arm64-options.mk
@@ -11,6 +11,8 @@ MACHINEACCELERATORS :=
 CPUFEATURES := pmu=off
 
 QEMUCMD := qemu-system-aarch64
+QEMUFW := AAVMF_CODE.fd
+QEMUFWVOL := AAVMF_VARS.fd
 
 # Firecracker binary name
 FCCMD := firecracker

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -906,6 +906,10 @@ install_shimv2() {
 install_ovmf() {
 	ovmf_type="${1:-x86_64}"
 	tarball_name="${2:-edk2-x86_64.tar.gz}"
+	if [ "${ARCH}" == "aarch64" ]; then
+		ovmf_type="arm64"
+		tarball_name="edk2-arm64.tar.gz"
+	fi
 
 	local component_name="ovmf"
 	[ "${ovmf_type}" == "sev" ] && component_name="ovmf-sev"

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -41,6 +41,10 @@ elif [ "${ovmf_build}" == "tdx" ]; then
 	[ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps ".externals.ovmf.tdx.version")
 	[ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps ".externals.ovmf.tdx.package")
 	[ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps ".externals.ovmf.tdx.package_output_dir")
+elif [ "${ovmf_build}" == "arm64" ]; then
+	[ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps ".externals.ovmf.arm64.version")
+	[ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps ".externals.ovmf.arm64.package")
+	[ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps ".externals.ovmf.arm64.package_output_dir")
 fi
 
 [ -n "$ovmf_version" ] || die "failed to get ovmf version or commit"

--- a/versions.yaml
+++ b/versions.yaml
@@ -360,6 +360,11 @@ externals:
       version: "edk2-stable202411"
       package: "OvmfPkg/AmdSev/AmdSevX64.dsc"
       package_output_dir: "AmdSev"
+    arm64:
+      description: "UEFI for arm64 virtual machines."
+      version: "edk2-stable202411"
+      package: "ArmVirtPkg/ArmVirtQemu.dsc"
+      package_output_dir: "ArmVirtQemu-AARCH64"
 
   virtiofsd:
     description: "vhost-user virtio-fs device backend written in Rust"


### PR DESCRIPTION
This change enables building edk2 for arm64. The edk2 is required for memory hot plug on qemu for arm64. This is created as a smaller PR for only edk2 for arm64 changes from https://github.com/kata-containers/kata-containers/pull/11019.