### PR TITLE
config: update QEMU TDX configuration

### DIFF
--- a/src/runtime/arch/amd64-options.mk
+++ b/src/runtime/arch/amd64-options.mk
@@ -14,7 +14,7 @@ CPUFEATURES := pmu=off
 QEMUCMD := qemu-system-x86_64
 QEMUTDXCMD := qemu-system-x86_64-tdx-experimental
 QEMUSNPCMD := qemu-system-x86_64-snp-experimental
-TDXCPUFEATURES := -vmx-rdseed-exit,pmu=off
+TDXCPUFEATURES := pmu=off
 
 # Firecracker binary name
 FCCMD := firecracker


### PR DESCRIPTION
Drop '-vmx-rdseed-exit' from '-cpu host' QEMU options. The history of it is unknown but it's likely related to early TDX enablement.

TD pods start up fine without it (tested by manually editing the configuration file) and it's also not used elsewhere.

Keep TDXCPUFEATURES for now in case a need for it shows up later.