### PR TITLE
ci: k8s: arm: Enable skipped tests

### DIFF
--- a/tests/integration/kubernetes/k8s-memory.bats
+++ b/tests/integration/kubernetes/k8s-memory.bats
@@ -40,8 +40,6 @@ setup_yaml() {
 }
 
 @test "Running within memory constraints" {
-	[ "$(uname -m)" == "aarch64" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/10926"
-
 	memory_limit_size="600Mi"
 	allocated_size="150M"
 

--- a/tests/integration/kubernetes/k8s-pod-quota.bats
+++ b/tests/integration/kubernetes/k8s-pod-quota.bats
@@ -9,7 +9,6 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: https://github.com/kata-containers/kata-containers/issues/7873"
-	[ "$(uname -m)" == "aarch64" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/10927"
 
 	get_pod_config_dir
 
@@ -38,7 +37,6 @@ setup() {
 
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: https://github.com/kata-containers/kata-containers/issues/7873"
-	[ "$(uname -m)" == "aarch64" ] && skip "See: https://github.com/kata-containers/kata-containers/issues/10927"
 
 	# Debugging information
 	kubectl describe deployment ${deployment_name}


### PR DESCRIPTION
Now that memory hotplug should work, as we're using a firmware that supports that, let's re-enable the tests that rely on hotplug.

Fixes: #10926, #10927, #10928