### PR TITLE
osbuilder: ubuntu: Add REPO_COMPONENTS setting

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -13,6 +13,7 @@ PACKAGES="chrony iptables dbus"
 [ "$MEASURED_ROOTFS" = yes ] && PACKAGES+=" cryptsetup-bin e2fsprogs"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp2"
 REPO_URL=http://ports.ubuntu.com
+REPO_COMPONENTS=${REPO_COMPONENTS:-main}
 
 case "$ARCH" in
 	aarch64) DEB_ARCH=arm64;;

--- a/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/rootfs_lib.sh
@@ -16,6 +16,7 @@ build_rootfs() {
 		EXTRA_PKGS=$(echo "$EXTRA_PKGS" | tr ' ' ',')
 	fi
 	if ! mmdebstrap --mode auto --arch "$DEB_ARCH" --variant required \
+			--components="$REPO_COMPONENTS" \
 			--include "$PACKAGES,$EXTRA_PKGS" "$OS_VERSION" "$rootfs_dir" "$REPO_URL"; then
 		echo "ERROR: mmdebstrap failed, cannot proceed" && exit 1
 	else


### PR DESCRIPTION
Added variable REPO_COMPONENTS (default: "main") which sets components used by mmdebstrap for rootfs building.
This is useful for custom image builders who want to include EXTRA_PKGS from components other than the default "main" (e.g. "universe").

Fixes: #11278