### PR TITLE
runtime: fix container launch fail on Arm64 platform

### DIFF
--- a/src/runtime-rs/arch/aarch64-options.mk
+++ b/src/runtime-rs/arch/aarch64-options.mk
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-MACHINETYPE :=
+MACHINETYPE := virt
 KERNELPARAMS := cgroup_no_v1=all systemd.unified_cgroup_hierarchy=1
 MACHINEACCELERATORS :=
 CPUFEATURES := pmu=off

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -544,6 +544,12 @@ impl ToQemuParams for Machine {
         if let Some(mem_backend) = &self.memory_backend {
             params.push(format!("memory-backend={}", mem_backend));
         }
+
+        #[cfg(target_arch = "aarch64")]
+        params.push(format!("usb=off"));
+        #[cfg(target_arch = "aarch64")]
+        params.push(format!("gic-version=3"));
+
         if !self.confidential_guest_support.is_empty() {
             params.push(format!(
                 "confidential-guest-support={}",
@@ -2492,6 +2498,11 @@ impl<'a> QemuCmdLine<'a> {
             }
         }
 
+        Ok(())
+    }
+
+    pub fn add_bios(&mut self, path: &str) ->  Result<()> {
+        self.devices.push(Box::new(Bios::new(path.to_string())));
         Ok(())
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -29,6 +29,7 @@ use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::{Child, ChildStderr, Command},
 };
+use tokio::time::{Duration,Instant};
 
 const VSOCK_SCHEME: &str = "vsock";
 
@@ -72,7 +73,7 @@ impl QemuInner {
         Ok(())
     }
 
-    pub(crate) async fn start_vm(&mut self, _timeout: i32) -> Result<()> {
+    pub(crate) async fn start_vm(&mut self, timeout: i32) -> Result<()> {
         info!(sl!(), "Starting QEMU VM");
         let netns = self.netns.clone().unwrap_or_default();
 
@@ -108,7 +109,7 @@ impl QemuInner {
                             &block_dev.config.path_on_host,
                             block_dev.config.is_readonly,
                         )?,
-                        "ccw" => cmdline.add_block_device(
+                        "blk" | "ccw" => cmdline.add_block_device(
                             block_dev.device_id.as_str(),
                             &block_dev.config.path_on_host,
                             block_dev
@@ -178,6 +179,10 @@ impl QemuInner {
         let console_socket_path = Path::new(&self.get_jailer_root().await?).join("console.sock");
         cmdline.add_console(console_socket_path.to_str().unwrap());
 
+        if !self.config.boot_info.firmware.is_empty() {
+            cmdline.add_bios(&self.config.boot_info.firmware)?;
+        }
+
         info!(sl!(), "qemu args: {}", cmdline.build().await?.join(" "));
         let mut command = Command::new(&self.config.path);
         command.args(cmdline.build().await?);
@@ -206,12 +211,21 @@ impl QemuInner {
 
         tokio::spawn(log_qemu_stderr(stderr, exit_notify));
 
-        match Qmp::new(QMP_SOCKET_FILE) {
-            Ok(qmp) => self.qmp = Some(qmp),
-            Err(e) => {
-                error!(sl!(), "couldn't initialise QMP: {:?}", e);
-                return Err(e);
+        let time_start = Instant::now();
+        loop {
+            match Qmp::new(QMP_SOCKET_FILE) {
+                Ok(qmp) => {
+                    self.qmp = Some(qmp);
+                    break;
+                }
+                Err(e) => {
+                    if time_start.elapsed() >= Duration::from_secs(timeout as u64)  {
+                        error!(sl!(), "Failed to couldn't initialise QMP(timeout {:?}s): {:?}", timeout, e);
+                        return Err(e);
+                    }
+                }
             }
+            tokio::time::sleep(Duration::from_millis(50)).await;
         }
 
         Ok(())
@@ -616,7 +630,8 @@ impl QemuInner {
                     network_device.config.guest_mac.clone().unwrap(),
                     &mut None,
                 )?;
-                qmp.hotplug_network_device(&netdev, &virtio_net_device)?
+                let machine_type = &self.config.machine_info.machine_type;
+                qmp.hotplug_network_device(&netdev, &virtio_net_device,machine_type)?
             }
             _ => info!(sl!(), "hotplugging of {:#?} is unsupported", device),
         }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -377,6 +377,7 @@ impl Qmp {
         &mut self,
         netdev: &Netdev,
         virtio_net_device: &DeviceVirtioNet,
+        machine_type: &String
     ) -> Result<()> {
         debug!(
             sl!(),
@@ -384,8 +385,6 @@ impl Qmp {
             virtio_net_device.get_netdev_id(),
             self.qmp.execute(&qapi_qmp::query_pci {})?
         );
-
-        let (bus, slot) = self.find_free_slot()?;
 
         let mut fd_names = vec![];
         for (idx, fd) in netdev.get_fds().iter().enumerate() {
@@ -438,6 +437,37 @@ impl Qmp {
             "netdev".to_owned(),
             virtio_net_device.get_netdev_id().clone().into(),
         );
+
+        if machine_type == "virt" {
+            let addr = 0;
+            let bus = String::from("rp0");
+            netdev_frontend_args.insert("addr".to_owned(), format!("{:02}", addr).into());
+            netdev_frontend_args.insert("mac".to_owned(), virtio_net_device.get_mac_addr().into());
+            if virtio_net_device.get_disable_modern() {
+                netdev_frontend_args.insert("disable-modern".to_owned(), true.into());
+            }
+            netdev_frontend_args.insert(
+                "vectors".to_owned(),
+                (2 * virtio_net_device.get_num_queues() + 2).into(),
+            );
+            netdev_frontend_args.insert("mq".to_owned(), "on".into());
+            netdev_frontend_args.insert("romfile".to_owned(), "".into());
+            self.qmp.execute(&qmp::device_add {
+                bus: Some(bus),
+                id: Some(format!("virtio-{}", virtio_net_device.get_netdev_id())),
+                driver: "virtio-net-pci".to_owned(),
+                arguments: netdev_frontend_args,
+            })?;
+            debug!(
+                 sl!(),
+                 "hotplug_network_device(): PCI after {}: {:#?}",
+                 virtio_net_device.get_netdev_id(),
+                 self.qmp.execute(&qapi_qmp::query_pci {})?
+             );
+            return Ok(());
+        }
+
+        let (bus, slot) = self.find_free_slot()?;
         netdev_frontend_args.insert("addr".to_owned(), format!("{:02}", slot).into());
         netdev_frontend_args.insert("mac".to_owned(), virtio_net_device.get_mac_addr().into());
         netdev_frontend_args.insert("mq".to_owned(), "on".into());


### PR DESCRIPTION
Support launching container on Arm64 with runtime-rs.

This PR add wait process just the same as runtime-go does just in case the container boot but the QMP socket is not started so quickly. 

Also add network work hotplug after the vm is started.