### PR TITLE
tests/k8s: increase wait time of KBS service ingress

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -429,11 +429,12 @@ function kbs_k8s_deploy() {
 kbs_k8s_svc_host() {
 	if kubectl get ingress -n "$KBS_NS" 2>/dev/null | grep -q kbs; then
 		local host
+		local timeout=50
 		# The ingress IP address can take a while to show up.
 		SECONDS=0
 		while true; do
 			host=$(kubectl get ingress "${KBS_INGRESS_NAME}" -n "${KBS_NS}" -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-			[[ -z "${host}" && ${SECONDS} -lt 30 ]] || break
+			[[ -z "${host}" && ${SECONDS} -lt "${timeout}" ]] || break
 			sleep 5
 		done
 		echo "${host}"


### PR DESCRIPTION
kbs_k8s_svc_host() returns the ingress IP when the KBS service is exposed via an ingress. In Azure AKS the ingress can time a while to be fully ready and recently we have noticed on CI that kbs_k8s_svc_host() has returned empty value. Maybe the problem is on current timeout being too low, so let's increase it to 50 seconds to see if the situation improves.