### PR TITLE
tests/k8s: delint confidential_kbs.sh

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -59,14 +59,14 @@ kbs_set_deny_all_resources() {
 kbs_set_resources_policy() {
 	local file="${1:-}"
 
-	if [ ! -f "$file" ]; then
-		>&2 echo "ERROR: policy file '$file' does not exist"
+	if [[ ! -f "${file}" ]]; then
+		>&2 echo "ERROR: policy file '${file}' does not exist"
 		return 1
 	fi
 
 	kbs-client --url "$(kbs_k8s_svc_http_addr)" config \
-		--auth-private-key "$KBS_PRIVATE_KEY" set-resource-policy \
-		--policy-file "$file"
+		--auth-private-key "${KBS_PRIVATE_KEY}" set-resource-policy \
+		--policy-file "${file}"
 }
 
 # Set resource data in base64 encoded.
@@ -85,19 +85,19 @@ kbs_set_resource_base64() {
 	local file
 	local rc=0
 
-	if [ -z "$data" ]; then
+	if [[ -z "${data}" ]]; then
 		>&2 echo "ERROR: missing data parameter"
 		return 1
 	fi
 
 	file=$(mktemp -t kbs-resource-XXXXX)
-	echo "$data" | base64 -d > "$file"
+	echo "${data}" | base64 -d > "${file}"
 
-	kbs_set_resource_from_file "$repository" "$type" "$tag" "$file" || \
+	kbs_set_resource_from_file "${repository}" "${type}" "${tag}" "${file}" || \
 		rc=$?
 
-	rm -f "$file"
-	return $rc
+	rm -f "${file}"
+	return "${rc}"
 }
 
 # Set resource data.
@@ -116,19 +116,19 @@ kbs_set_resource() {
 	local file
 	local rc=0
 
-	if [ -z "$data" ]; then
+	if [[ -z "${data}" ]]; then
 		>&2 echo "ERROR: missing data parameter"
 		return 1
 	fi
 
 	file=$(mktemp -t kbs-resource-XXXXX)
-	echo "$data" > "$file"
+	echo "${data}" > "${file}"
 
-	kbs_set_resource_from_file "$repository" "$type" "$tag" "$file" || \
+	kbs_set_resource_from_file "${repository}" "${type}" "${tag}" "${file}" || \
 		rc=$?
 
-	rm -f "$file"
-	return $rc
+	rm -f "${file}"
+	return "${rc}"
 }
 
 # Set resource, read data from file.
@@ -145,29 +145,29 @@ kbs_set_resource_from_file() {
 	local tag="${3:-}"
 	local file="${4:-}"
 
-	if [[ -z "$type" || -z "$tag" ]]; then
-		>&2 echo "ERROR: missing type='$type' and/or tag='$tag' parameters"
+	if [[ -z "${type}" || -z "${tag}" ]]; then
+		>&2 echo "ERROR: missing type='${type}' and/or tag='${tag}' parameters"
 		return 1
-	elif [ ! -f "$file" ]; then
-		>&2 echo "ERROR: resource file '$file' does not exist"
+	elif [[ ! -f "${file}" ]]; then
+		>&2 echo "ERROR: resource file '${file}' does not exist"
 		return 1
 	fi
 
 	local path=""
-	[ -n "$repository" ] && path+="${repository}/"
+	[[ -n "${repository}" ]] && path+="${repository}/"
 	path+="${type}/"
 	path+="${tag}"
 
 	kbs-client --url "$(kbs_k8s_svc_http_addr)" config \
-		--auth-private-key "$KBS_PRIVATE_KEY" set-resource \
-		--path "$path" --resource-file "$file"
+		--auth-private-key "${KBS_PRIVATE_KEY}" set-resource \
+		--path "${path}" --resource-file "${file}"
 
-	kbs_pod=$(kubectl -n $KBS_NS get pods -o NAME)
+	kbs_pod=$(kubectl -n "${KBS_NS}" get pods -o NAME)
 	kbs_repo_path="/opt/confidential-containers/kbs/repository"
 	# Waiting for the resource to be created on the kbs pod
-	if ! kubectl -n $KBS_NS exec -it "$kbs_pod" -- bash -c "for i in {1..30}; do [ -e '$kbs_repo_path/$path' ] && exit 0; sleep 0.5; done; exit -1"; then
-		echo "ERROR: resource '$path' not created in 15s"
-		kubectl -n $KBS_NS exec -it "$kbs_pod" -- bash -c "find $kbs_repo_path"
+	if ! kubectl -n "${KBS_NS}" exec -it "${kbs_pod}" -- bash -c "for i in {1..30}; do [ -e '${kbs_repo_path}/${path}' ] && exit 0; sleep 0.5; done; exit -1"; then
+		echo "ERROR: resource '${path}' not created in 15s"
+		kubectl -n "${KBS_NS}" exec -it "${kbs_pod}" -- bash -c "find ${kbs_repo_path}"
 		return 1
 	fi
 }
@@ -184,13 +184,13 @@ kbs_install_cli() {
 
 			sudo apt-get update -y
 			# shellcheck disable=2086
-			sudo apt-get install -y $pkgs
+			sudo apt-get install -y ${pkgs}
 			;;
 		centos)
 			local pkgs="make"
 
-			# shellcheck disable=2086
-			sudo dnf install -y $pkgs
+			# shellcheck disable=2086,2248
+			sudo dnf install -y ${pkgs}
 			;;
 		*)
 			>&2 echo "ERROR: running on unsupported distro"
@@ -205,7 +205,7 @@ kbs_install_cli() {
 	# Currently kata version from version.yaml is 1.72.0
 	# which doesn't match the requirement, so let's pass
 	# the required version.
-	_ensure_rust "$rust_version"
+	_ensure_rust "${rust_version}"
 
 	pushd "${COCO_KBS_DIR}"
 	# Compile with sample features to bypass attestation.
@@ -215,7 +215,7 @@ kbs_install_cli() {
 }
 
 kbs_uninstall_cli() {
-	if [ -d "${COCO_KBS_DIR}" ]; then
+	if [[ -d "${COCO_KBS_DIR}" ]]; then
 		pushd "${COCO_KBS_DIR}"
 		sudo make uninstall
 		popd
@@ -229,18 +229,18 @@ kbs_uninstall_cli() {
 # Note: assume the kbs sources were cloned to $COCO_TRUSTEE_DIR
 #
 function kbs_k8s_delete() {
-	pushd "$COCO_KBS_DIR"
-	if [ "${KATA_HYPERVISOR}" = "qemu-tdx" ]; then
+	pushd "${COCO_KBS_DIR}"
+	if [[ "${KATA_HYPERVISOR}" = "qemu-tdx" ]]; then
 		kubectl delete -k config/kubernetes/ita
-	elif [ "${KATA_HYPERVISOR}" = "qemu-se" ]; then
+	elif [[ "${KATA_HYPERVISOR}" = "qemu-se" ]]; then
 		kubectl delete -k config/kubernetes/overlays/ibm-se
 	else
 		kubectl delete -k config/kubernetes/overlays/
 	fi
 
 	# Verify that KBS namespace resources were properly deleted
-	cmd="kubectl get all -n $KBS_NS 2>&1 | grep 'No resources found'"
-	waitForProcess "120" "30" "$cmd"
+	cmd="kubectl get all -n ${KBS_NS} 2>&1 | grep 'No resources found'"
+	waitForProcess "120" "30" "${cmd}"
 	popd
 }
 
@@ -270,7 +270,7 @@ function kbs_k8s_deploy() {
 	image_tag=$(get_from_kata_deps ".externals.coco-trustee.image_tag")
 
 	# Image tag for TDX
-	if [ "${KATA_HYPERVISOR}" = "qemu-tdx" ]; then
+	if [[ "${KATA_HYPERVISOR}" = "qemu-tdx" ]]; then
 		image=$(get_from_kata_deps ".externals.coco-trustee.ita_image")
 		image_tag=$(get_from_kata_deps ".externals.coco-trustee.ita_image_tag")
 	fi
@@ -279,18 +279,18 @@ function kbs_k8s_deploy() {
 	# contain the HEAD commit of the kata-containers repository (supposedly the
 	# current directory). It will be needed to save the cluster's name before
 	# it switches to the kbs repository and get a wrong HEAD commit.
-	if [ -z "${AKS_NAME:-}" ]; then
+	if [[ -z "${AKS_NAME:-}" ]]; then
 		AKS_NAME=$(_print_cluster_name)
 		export AKS_NAME
 	fi
 
-	if [ -d "$COCO_TRUSTEE_DIR" ]; then
-		rm -rf "$COCO_TRUSTEE_DIR"
+	if [[ -d "${COCO_TRUSTEE_DIR}" ]]; then
+		rm -rf "${COCO_TRUSTEE_DIR}"
 	fi
 
 	echo "::group::Clone the kbs sources"
-	git clone --depth 1 "${repo}" "$COCO_TRUSTEE_DIR"
-	pushd "$COCO_TRUSTEE_DIR"
+	git clone --depth 1 "${repo}" "${COCO_TRUSTEE_DIR}"
+	pushd "${COCO_TRUSTEE_DIR}"
 	git fetch --depth=1 origin "${version}"
 	git checkout FETCH_HEAD -b kbs_$$
 	popd
@@ -303,7 +303,7 @@ function kbs_k8s_deploy() {
 	echo "somesecret" > overlays/key.bin
 
 	# For qemu-se runtime, prepare the necessary resources
-	if [ "${KATA_HYPERVISOR}" == "qemu-se" ]; then
+	if [[ "${KATA_HYPERVISOR}" == "qemu-se" ]]; then
 		mv overlays/key.bin overlays/ibm-se/key.bin
 		prepare_credentials_for_qemu_se
 		# SE_SKIP_CERTS_VERIFICATION should be set to true
@@ -317,10 +317,10 @@ function kbs_k8s_deploy() {
 	kustomize edit set image "kbs-container-image=${image}:${image_tag}"
 	popd
 	echo "::endgroup::"
-	[ -n "$ingress" ] && _handle_ingress "$ingress"
+	[[ -n "${ingress}" ]] && _handle_ingress "${ingress}"
 
 	echo "::group::Deploy the KBS"
-	if [ "${KATA_HYPERVISOR}" = "qemu-tdx" ]; then
+	if [[ "${KATA_HYPERVISOR}" = "qemu-tdx" ]]; then
 		echo "::group::Setting up ITA/ITTS for TDX"
 		pushd "${COCO_KBS_DIR}/config/kubernetes/ita/"
 			# Let's replace the "tBfd5kKX2x9ahbodKV1..." sample
@@ -329,7 +329,7 @@ function kbs_k8s_deploy() {
 			sed -i -e "s/tBfd5kKX2x9ahbodKV1.../${ITA_KEY}/g" kbs-config.toml
 		popd
 
-		if [ -n "${HTTPS_PROXY}" ]; then
+		if [[ -n "${HTTPS_PROXY}" ]]; then
 			# Ideally this should be something kustomizable on trustee side.
 			#
 			# However, for now let's take the bullet and do it here, and revert this as
@@ -338,7 +338,7 @@ function kbs_k8s_deploy() {
 			pushd "${COCO_KBS_DIR}/config/kubernetes/base/"
 				ensure_yq
 
-				yq e ".spec.template.spec.containers[0].env += [{\"name\": \"https_proxy\", \"value\": \"$HTTPS_PROXY\"}]" -i deployment.yaml
+				yq e ".spec.template.spec.containers[0].env += [{\"name\": \"https_proxy\", \"value\": \"${HTTPS_PROXY}\"}]" -i deployment.yaml
 			popd
 		fi
 
@@ -350,23 +350,23 @@ function kbs_k8s_deploy() {
 	# Check the private key used to install the KBS exist and save it in a
 	# well-known location. That's the access key used by the kbs-client.
 	local install_key="${PWD}/base/kbs.key"
-	if [ ! -f "$install_key" ]; then
+	if [[ ! -f "${install_key}" ]]; then
 		echo "ERROR: KBS private key not found at ${install_key}"
 		return 1
 	fi
-	sudo mkdir -p "$(dirname "$KBS_PRIVATE_KEY")"
-	sudo cp -f "${install_key}" "$KBS_PRIVATE_KEY"
+	sudo mkdir -p "$(dirname "${KBS_PRIVATE_KEY}")"
+	sudo cp -f "${install_key}" "${KBS_PRIVATE_KEY}"
 
 	popd
 
-	if ! waitForProcess "120" "10" "kubectl -n \"$KBS_NS\" get pods | \
+	if ! waitForProcess "120" "10" "kubectl -n \"${KBS_NS}\" get pods | \
 		grep -q '^kbs-.*Running.*'"; then
 		echo "ERROR: KBS service pod isn't running"
 		echo "::group::DEBUG - describe kbs deployments"
-		kubectl -n "$KBS_NS" get deployments || true
+		kubectl -n "${KBS_NS}" get deployments || true
 		echo "::endgroup::"
 		echo "::group::DEBUG - describe kbs pod"
-		kubectl -n "$KBS_NS" describe pod -l app=kbs || true
+		kubectl -n "${KBS_NS}" describe pod -l app=kbs || true
 		echo "::endgroup::"
 		return 1
 	fi
@@ -383,28 +383,28 @@ function kbs_k8s_deploy() {
 	# that does not exist.
 	#
 	echo "::group::Check the service healthy"
-	kbs_ip=$(kubectl get -o jsonpath='{.spec.clusterIP}' svc "$KBS_SVC_NAME" -n "$KBS_NS" 2>/dev/null)
-	kbs_port=$(kubectl get -o jsonpath='{.spec.ports[0].port}' svc "$KBS_SVC_NAME" -n "$KBS_NS" 2>/dev/null)
+	kbs_ip=$(kubectl get -o jsonpath='{.spec.clusterIP}' svc "${KBS_SVC_NAME}" -n "${KBS_NS}" 2>/dev/null)
+	kbs_port=$(kubectl get -o jsonpath='{.spec.ports[0].port}' svc "${KBS_SVC_NAME}" -n "${KBS_NS}" 2>/dev/null)
 
 	local pod=kbs-checker-$$
-	kubectl run "$pod" --image=quay.io/prometheus/busybox --restart=Never -- \
+	kubectl run "${pod}" --image=quay.io/prometheus/busybox --restart=Never -- \
 		sh -c "wget -O- --timeout=5 \"${kbs_ip}:${kbs_port}\" || true"
-	if ! waitForProcess "60" "10" "kubectl logs \"$pod\" 2>/dev/null | grep -q \"404 Not Found\""; then
+	if ! waitForProcess "60" "10" "kubectl logs \"${pod}\" 2>/dev/null | grep -q \"404 Not Found\""; then
 		echo "ERROR: KBS service is not responding to requests"
 		echo "::group::DEBUG - kbs logs"
-		kubectl -n "$KBS_NS" logs -l app=kbs || true
+		kubectl -n "${KBS_NS}" logs -l app=kbs || true
 		echo "::endgroup::"
-		kubectl delete pod "$pod"
+		kubectl delete pod "${pod}"
 		return 1
 	fi
-	kubectl delete pod "$pod"
+	kubectl delete pod "${pod}"
 	echo "KBS service respond to requests"
 	echo "::endgroup::"
 
-	if [ -n "$ingress" ]; then
+	if [[ -n "${ingress}" ]]; then
 		echo "::group::Check the kbs service is exposed"
 		svc_host=$(kbs_k8s_svc_http_addr)
-		if [ -z "$svc_host" ]; then
+		if [[ -z "${svc_host}" ]]; then
 			echo "ERROR: service host not found"
 			return 1
 		fi
@@ -412,13 +412,13 @@ function kbs_k8s_deploy() {
 		# AZ DNS can take several minutes to update its records so that
 		# the host name will take a while to start resolving.
 		timeout=350
-		echo "Trying to connect at $svc_host. Timeout=$timeout"
-		if ! waitForProcess "$timeout" "30" "curl -s -I \"$svc_host\" | grep -q \"404 Not Found\""; then
-			echo "ERROR: service seems to not respond on $svc_host host"
-			curl -I "$svc_host"
+		echo "Trying to connect at ${svc_host}. Timeout=${timeout}"
+		if ! waitForProcess "${timeout}" "30" "curl -s -I \"${svc_host}\" | grep -q \"404 Not Found\""; then
+			echo "ERROR: service seems to not respond on ${svc_host} host"
+			curl -I "${svc_host}"
 			return 1
 		fi
-		echo "KBS service respond to requests at $svc_host"
+		echo "KBS service respond to requests at ${svc_host}"
 		echo "::endgroup::"
 	fi
 }
@@ -427,7 +427,7 @@ function kbs_k8s_deploy() {
 # otherwise the cluster IP.
 #
 kbs_k8s_svc_host() {
-	if kubectl get ingress -n "$KBS_NS" 2>/dev/null | grep -q kbs; then
+	if kubectl get ingress -n "${KBS_NS}" 2>/dev/null | grep -q kbs; then
 		local host
 		# The ingress IP address can take a while to show up.
 		SECONDS=0
@@ -437,12 +437,12 @@ kbs_k8s_svc_host() {
 			sleep 5
 		done
 		echo "${host}"
-	elif kubectl get svc "$KBS_SVC_NAME" -n "$KBS_NS" &>/dev/null; then
+	elif kubectl get svc "${KBS_SVC_NAME}" -n "${KBS_NS}" &>/dev/null; then
 			local host
-			host=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' -n "$KBS_NS")
-			echo "$host"
+			host=$(kubectl get nodes -o jsonpath='{.items[0].status.addresses[?(@.type=="InternalIP")].address}' -n "${KBS_NS}")
+			echo "${host}"
 	else
-		kubectl get svc "$KBS_SVC_NAME" -n "$KBS_NS" \
+		kubectl get svc "${KBS_SVC_NAME}" -n "${KBS_NS}" \
 			-o jsonpath='{.spec.clusterIP}' 2>/dev/null
 	fi
 }
@@ -451,13 +451,13 @@ kbs_k8s_svc_host() {
 # it will return "80", otherwise the pod's service port.
 #
 kbs_k8s_svc_port() {
-	if kubectl get ingress -n "$KBS_NS" 2>/dev/null | grep -q kbs; then
+	if kubectl get ingress -n "${KBS_NS}" 2>/dev/null | grep -q kbs; then
 		# Assume served on default HTTP port 80
 		echo "80"
-	elif kubectl get svc "$KBS_SVC_NAME" -n "$KBS_NS" &>/dev/null; then
-		kubectl get svc "$KBS_SVC_NAME" -n "$KBS_NS" -o jsonpath='{.spec.ports[0].nodePort}'
+	elif kubectl get svc "${KBS_SVC_NAME}" -n "${KBS_NS}" &>/dev/null; then
+		kubectl get svc "${KBS_SVC_NAME}" -n "${KBS_NS}" -o jsonpath='{.spec.ports[0].nodePort}'
 	else
-		kubectl get svc "$KBS_SVC_NAME" -n "$KBS_NS" \
+		kubectl get svc "${KBS_SVC_NAME}" -n "${KBS_NS}" \
 			-o jsonpath='{.spec.ports[0].port}' 2>/dev/null
 	fi
 }
@@ -499,9 +499,9 @@ _ensure_rust() {
 		"${kubernetes_dir}/../../install_rust.sh" "${rust_version}"
 
 		# shellcheck disable=1091
-		source "$HOME/.cargo/env"
+		source "${HOME}/.cargo/env"
 	else
-		[ -z "$rust_version" ] && return
+		[[ -z "${rust_version}" ]] && return
 
 		# We don't want to mess with installation on bare-metal so
 		# if rust is installed then just check it's >= the required
@@ -511,7 +511,7 @@ _ensure_rust() {
 		current_rust_version="$(rustc --version | cut -d' ' -f2)"
 		if ! version_greater_than_equal "${current_rust_version}" \
 			"${rust_version}"; then
-			>&2 echo "ERROR: installed rust $current_rust_version < $rust_version (required)"
+			>&2 echo "ERROR: installed rust ${current_rust_version} < ${rust_version} (required)"
 			return 1
 		fi
 	fi
@@ -526,12 +526,12 @@ _ensure_rust() {
 _handle_ingress() {
 	local ingress="$1"
 
-	type -a "_handle_ingress_$ingress" &>/dev/null || {
-		echo "ERROR: ingress '$ingress' handler not implemented";
+	type -a "_handle_ingress_${ingress}" &>/dev/null || {
+		echo "ERROR: ingress '${ingress}' handler not implemented";
 		return 1;
 	}
 
-	"_handle_ingress_$ingress"
+	"_handle_ingress_${ingress}"
 }
 
 # Implement the ingress handler for AKS.
@@ -584,13 +584,13 @@ _post_deploy() {
 # Documentation: https://github.com/confidential-containers/trustee/tree/main/attestation-service/verifier/src/se
 prepare_credentials_for_qemu_se() {
 	echo "::group::Prepare credentials for qemu-se runtime"
-	if [ -z "${IBM_SE_CREDS_DIR:-}" ]; then
+	if [[ -z "${IBM_SE_CREDS_DIR:-}" ]]; then
 		>&2 echo "ERROR: IBM_SE_CREDS_DIR is empty"
 		return 1
 	fi
 	config_file_path="/opt/kata/share/defaults/kata-containers/configuration-qemu-se.toml"
-	kata_base_dir=$(dirname $(kata-runtime --config ${config_file_path} env --json | jq -r '.Kernel.Path'))
-	if [ ! -d ${HKD_PATH} ]; then
+	kata_base_dir=$(dirname "$(kata-runtime --config "${config_file_path}" env --json | jq -r '.Kernel.Path')")
+	if [[ ! -d "${HKD_PATH}" ]]; then
 		>&2 echo "ERROR: HKD_PATH is not set"
 		return 1
 	fi
@@ -599,11 +599,11 @@ prepare_credentials_for_qemu_se() {
 	openssl genrsa -aes256 -passout pass:test1234 -out encrypt_key-psw.pem 4096
 	openssl rsa -in encrypt_key-psw.pem -passin pass:test1234 -pubout -out rsa/encrypt_key.pub
 	openssl rsa -in encrypt_key-psw.pem -passin pass:test1234 -out rsa/encrypt_key.pem
-	cp ${kata_base_dir}/kata-containers-se.img hdr/hdr.bin
-	cp ${HKD_PATH}/HKD-*.crt hkds/
-	cp ${HKD_PATH}/ibm-z-host-key-gen2.crl crls/
-	cp ${HKD_PATH}/DigiCertCA.crt ${HKD_PATH}/ibm-z-host-key-signing-gen2.crt certs/
+	cp "${kata_base_dir}/kata-containers-se.img" hdr/hdr.bin
+	cp "${HKD_PATH}"/HKD-*.crt hkds/
+	cp "${HKD_PATH}/ibm-z-host-key-gen2.crl" crls/
+	cp "${HKD_PATH}/DigiCertCA.crt" "${HKD_PATH}/ibm-z-host-key-signing-gen2.crt" certs/
 	popd
-	ls -R ${IBM_SE_CREDS_DIR}
+	ls -R "${IBM_SE_CREDS_DIR}"
 	echo "::endgroup::"
 }

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -591,7 +591,7 @@ prepare_credentials_for_qemu_se() {
 	fi
 	config_file_path="/opt/kata/share/defaults/kata-containers/configuration-qemu-se.toml"
 	kata_base_dir=$(dirname "$(kata-runtime --config "${config_file_path}" env --json | jq -r '.Kernel.Path')")
-	if [[ ! -d "${HKD_PATH}" ]]; then
+	if [[ -z "${HKD_PATH:-}" || ! -d "${HKD_PATH}" ]]; then
 		>&2 echo "ERROR: HKD_PATH is not set"
 		return 1
 	fi

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -13,6 +13,7 @@ kubernetes_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
 # shellcheck disable=1091
 source "${kubernetes_dir}/../../../tests/common.bash"
+# shellcheck disable=1091
 source "${kubernetes_dir}/../../../tools/packaging/guest-image/lib_se.sh"
 # For kata-runtime
 export PATH="${PATH}:/opt/kata/bin"

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -6,6 +6,7 @@
 #
 # Provides a library to deal with the CoCo KBS
 #
+set -e
 
 kubernetes_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=1091


### PR DESCRIPTION
Addressed the following shellcheck advices:

SC2046 (warning): Quote this to prevent word splitting.
SC2248 (style): Prefer double quoting even when variables don't contain special characters
SC2250 (style): Prefer putting braces around variable references even when not strictly required.
SC2292 (style): Prefer [[ ]] over [ ] for tests in Bash/Ksh

Resulting in a free of warning/info/style file.

---

I have fixed some stuffs on that file recently and seeing the shellcheck advices was making me sick, hence this PR that I hope doesn't introduce unintentional bugs (always are a risk).