### PR TITLE
runtime: Make csi-directvolume-kata works well with runtime

### DIFF
--- a/src/runtime/pkg/resourcecontrol/utils.go
+++ b/src/runtime/pkg/resourcecontrol/utils.go
@@ -16,7 +16,9 @@ import (
 )
 
 var (
-	ErrCgroupMode = errors.New("cgroup controller type error")
+	ErrCgroupMode      = errors.New("cgroup controller type error")
+	VirtualDeviceMajor = 254
+	VirtualDeviceMinor = 254
 )
 
 func DeviceToCgroupDeviceRule(device string) (*devices.Rule, error) {
@@ -35,16 +37,19 @@ func DeviceToCgroupDeviceRule(device string) (*devices.Rule, error) {
 	switch devType {
 	case unix.S_IFCHR:
 		deviceRule.Type = 'c'
+		deviceRule.Major = int64(unix.Major(uint64(st.Rdev)))
+		deviceRule.Minor = int64(unix.Minor(uint64(st.Rdev)))
 	case unix.S_IFBLK:
 		deviceRule.Type = 'b'
+		deviceRule.Major = int64(unix.Major(uint64(st.Rdev)))
+		deviceRule.Minor = int64(unix.Minor(uint64(st.Rdev)))
+	case unix.S_IFREG:
+		deviceRule.Type = 'b'
+		deviceRule.Major = int64(VirtualDeviceMajor)
+		deviceRule.Minor = int64(VirtualDeviceMinor)
 	default:
-		return nil, fmt.Errorf("unsupported device type: %v", devType)
+		return nil, fmt.Errorf("unsupported type %v for device: %v", devType, device)
 	}
-
-	major := int64(unix.Major(uint64(st.Rdev)))
-	minor := int64(unix.Minor(uint64(st.Rdev)))
-	deviceRule.Major = major
-	deviceRule.Minor = minor
 
 	return &deviceRule, nil
 }

--- a/src/runtime/pkg/resourcecontrol/utils_linux_test.go
+++ b/src/runtime/pkg/resourcecontrol/utils_linux_test.go
@@ -126,10 +126,14 @@ func TestDeviceToCgroupDeviceRule(t *testing.T) {
 	assert.NoError(err)
 	f.Close()
 
-	// fail: regular file to device
+	// success: regular file to device
 	dev, err := DeviceToCgroupDeviceRule(f.Name())
-	assert.Error(err)
-	assert.Nil(dev)
+	assert.NoError(err)
+	assert.NotNil(dev)
+	assert.Equal(rune(dev.Type), 'b')
+	assert.Equal(dev.Major, int64(VirtualDeviceMajor))
+	assert.Equal(dev.Minor, int64(VirtualDeviceMinor))
+	assert.True(dev.Allow)
 
 	// fail: no such file
 	os.Remove(f.Name())

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -637,6 +637,12 @@ func (c *Container) createBlockDevices(ctx context.Context) error {
 				c.Logger().WithError(err).Error("error writing sandbox info")
 			}
 
+			// When using direct volume assignment, we assume the source file is a raw disk image even if it's a regular file.
+			fileInfo, err := os.Stat(mntInfo.Device)
+			if err == nil && fileInfo.Mode().IsRegular() {
+				isBlockFile = true
+			}
+
 			readonly := false
 			for _, flag := range mntInfo.Options {
 				if flag == "ro" {

--- a/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
@@ -98,7 +98,7 @@ func (dv *directVolume) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 	klog.Infof("target %v\nfstype %v\ndevice %v\nreadonly %v\nvolumeID %v\n",
 		targetPath, fsType, devicePath, readOnly, volumeID)
 
-	options := []string{"bind"}
+	options := []string{}
 	if readOnly {
 		options = append(options, "ro")
 	} else {


### PR DESCRIPTION
As csi-directvolume-kata will use raw file on the host as the backend of a virtio-blk block device, and it is treated as just a regular file, which cause runtime label it unsupported device type. To correct such case, this patch supports it.
Another important factor related to the issue #11296, as it said that, the Options with bind does cause it fail. But in my test with runtime-rs, it works well. So in this patch, I just remove the related Option assignment from the m.Option

Fixes #11296