### PR TITLE
runtime: reduce unnecessary loading of virtio-scsi

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -1362,7 +1362,7 @@ func SetKernelParams(runtimeConfig *oci.RuntimeConfig) error {
 	}
 
 	// set the scsi scan mode to none for virtio-scsi
-	if runtimeConfig.HypervisorConfig.BlockDeviceDriver == config.VirtioSCSI {
+	if runtimeConfig.HypervisorConfig.BlockDeviceDriver == config.VirtioSCSI && !runtimeConfig.HypervisorConfig.DisableBlockDeviceUse {
 		p := vc.Param{
 			Key:   "scsi_mod.scan",
 			Value: "none",

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -467,7 +467,7 @@ func (q *qemu) buildDevices(ctx context.Context, kernelPath string) ([]govmmQemu
 	}
 
 	var ioThread *govmmQemu.IOThread
-	if q.config.BlockDeviceDriver == config.VirtioSCSI {
+	if q.config.BlockDeviceDriver == config.VirtioSCSI && !q.config.DisableBlockDeviceUse {
 		devices, ioThread, err = q.arch.appendSCSIController(ctx, devices, q.config.EnableIOThreads)
 		if err != nil {
 			return nil, nil, nil, err


### PR DESCRIPTION
disable_block_device_use means
"disallow a block device from being used".

Therefore, when disable_block_device_use=true,
reduce unnecessary loading of virios-scsi.

Fixes: #11309