### PR TITLE
workflows: gatekeeper: Update permissions

### DIFF
--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -19,6 +19,8 @@ concurrency:
 jobs:
   gatekeeper:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Restrict the permissions of gatekeeper flow to read contents only for better security