### PR TITLE
runtime-rs: Adjust VSOCK timeouts for IBM SEL

### DIFF
--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -541,7 +541,7 @@ kernel_modules=[]
 
 # Agent dial timeout in millisecond.
 # (default: 10)
-dial_timeout_ms = 30
+dial_timeout_ms = 90
 
 # Agent reconnect timeout in millisecond.
 # Retry times = reconnect_timeout_ms / dial_timeout_ms (default: 300)
@@ -550,7 +550,7 @@ dial_timeout_ms = 30
 # You'd better not change the value of dial_timeout_ms, unless you have an
 # idea of what you are doing.
 # (default: 3000)
-#reconnect_timeout_ms = 3000
+reconnect_timeout_ms = 5000
 
 # Create Container Request Timeout
 # This timeout value is used to set the maximum duration for the agent to process a CreateContainerRequest.


### PR DESCRIPTION
The default `reconnect_timeout` (3 seconds) was found to be insufficient for IBM SEL when using VSOCK, which led to the following:

```
# Events:
#   Type     Reason                  Age   From               Message
#   ----     ------                  ----  ----               -------
#   Normal   Scheduled               22s   default-scheduler  Successfully assigned kata-containers-k8s-tests/busybox to a46lp22.lnxne.boe
#   Warning  FailedCreatePodSandBox  18s   kubelet            Failed to create pod sandbox: rpc error: code = Unknown desc = failed to create containerd task: failed to create shim task: Others("failed to handle message start sandbox in task handler\n\nCaused by:\n    0
: connect to address \"vsock://2057012271\"\n    1: connect agent server\n    2: connect\n    3: cannot connect vsock to agent ttrpc server ConnectConfig { dial_timeout_ms: 30, reconnect_timeout_ms: 3000 }\n\nStack backtrace:\n   0: <agent::sock::vsock::Vsock as agent::
sock::Sock>::connect::{{closure}}\n   1: agent::kata::agent::<impl agent::AgentManager for agent::kata::KataAgent>::start::{{closure}}\n   2: <virt_container::sandbox::VirtSandbox as common::sandbox::Sandbox>::start::{{closure}}::{{closure}}\n   3: <virt_container::sand
box::VirtSandbox as common::sandbox::Sandbox>::start::{{closure}}\n   4: runtimes::manager::RuntimeHandlerManager::handler_task_message::{{closure}}\n   5: <service::task_service::TaskService as containerd_shim_protos::shim::shim_ttrpc_async::Task>::create::{{closure}}\
n   6: <containerd_shim_protos::shim::shim_ttrpc_async::CreateMethod as ttrpc::asynchronous::utils::MethodHandler>::handler::{{closure}}\n   7: ttrpc::asynchronous::server::HandlerContext::handle_msg::{{closure}}\n   8: <core::future::poll_fn::PollFn<F> as core::future:
:future::Future>::poll\n   9: <ttrpc::asynchronous::server::ServerReader as ttrpc::asynchronous::connection::ReaderDelegate>::handle_msg::{{closure}}::{{closure}}\n  10: tokio::runtime::task::core::Core<T,S>::poll\n  11: std::panicking::try::do_call\n  12: __rust_try.ll
vm.2988112330843742391\n  13: tokio::runtime::task::harness::Harness<T,S>::poll\n  14: tokio::runtime::scheduler::multi_thread::worker::Context::run_task\n  15: tokio::runtime::scheduler::multi_thread::worker::Context::run\n  16: tokio::runtime::context::set_scheduler\n
  17: tokio::runtime::context::runtime::enter_runtime\n  18: tokio::runtime::scheduler::multi_thread::worker::run\n  19: tokio::runtime::task::core::Core<T,S>::poll\n  20: std::panicking::try::do_call\n  21: __rust_try.llvm.8598346620275421969\n  22: tokio::runtime::tas
k::harness::Harness<T,S>::poll\n  23: tokio::runtime::blocking::pool::Inner::run\n  24: std::sys_common::backtrace::__rust_begin_short_backtrace\n  25: std::panicking::try::do_call\n  26: __rust_try.llvm.8598346620275421969\n  27: core::ops::function::FnOnce::call_once{
{vtable.shim}}\n  28: std::sys::pal::unix::thread::Thread::new::thread_start\n  29: <unknown>\n  30: <unknown>"): unknown
```

This PR updates the timeouts as follows:

- `dial_timeout_ms`: Set to 90ms to match the value used in go-runtime for IBM SEL
- `reconnect_timeout_ms`: Increased to 5000ms based on empirical testing

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>