### PR TITLE
workflows: Add explicit permissions for attestation

### DIFF
--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -23,6 +23,9 @@ on:
 
 jobs:
   build-asset:
+    permissions:
+      contents: read
+      packages: write
     runs-on: ppc64le
     strategy:
       matrix:

--- a/.github/workflows/ci-coco-stability.yaml
+++ b/.github/workflows/ci-coco-stability.yaml
@@ -10,6 +10,11 @@ concurrency:
 
 jobs:
   kata-containers-ci-on-push:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/ci-weekly.yaml
     with:
       commit-hash: ${{ github.sha }}

--- a/.github/workflows/ci-devel.yaml
+++ b/.github/workflows/ci-devel.yaml
@@ -4,6 +4,11 @@ on:
 
 jobs:
   kata-containers-ci-on-push:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/ci.yaml
     with:
       commit-hash: ${{ github.sha }}

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -9,6 +9,11 @@ concurrency:
 
 jobs:
   kata-containers-ci-on-push:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/ci.yaml
     with:
       commit-hash: ${{ github.sha }}

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -29,6 +29,11 @@ jobs:
   kata-containers-ci-on-push:
     needs: skipper
     if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/ci.yaml
     with:
       commit-hash: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -10,6 +10,11 @@ concurrency:
 
 jobs:
   build-assets-amd64:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -18,6 +23,11 @@ jobs:
     secrets: inherit
 
   build-assets-arm64:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -26,6 +36,11 @@ jobs:
     secrets: inherit
 
   build-assets-s390x:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -34,6 +49,9 @@ jobs:
     secrets: inherit
 
   build-assets-ppc64le:
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
     with:
       commit-hash: ${{ github.sha }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,11 @@ jobs:
 
   build-and-push-assets-amd64:
     needs: release
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release-amd64.yaml
     with:
       target-arch: amd64
@@ -26,6 +31,11 @@ jobs:
 
   build-and-push-assets-arm64:
     needs: release
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release-arm64.yaml
     with:
       target-arch: arm64
@@ -33,6 +43,11 @@ jobs:
 
   build-and-push-assets-s390x:
     needs: release
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release-s390x.yaml
     with:
       target-arch: s390x
@@ -40,6 +55,9 @@ jobs:
 
   build-and-push-assets-ppc64le:
     needs: release
+    permissions:
+      contents: read
+      packages: write
     uses: ./.github/workflows/release-ppc64le.yaml
     with:
       target-arch: ppc64le


### PR DESCRIPTION
We have a number of jobs that nest the build-static-tarball workflows later on. Due to these doing attest build provenance, and pushing to ghcr.io, t hey need write permissions on `packages`, `id-token` and `attestations`, so we need to set these permissions on the top-level jobs (along with `contents: read`), so they are not blocked.