### PR TITLE
workflow: Update gatekeeper permissions

### DIFF
--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -20,7 +20,9 @@ jobs:
   gatekeeper:
     runs-on: ubuntu-22.04
     permissions:
+      actions: read
       contents: read
+      issues: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
I shortsightedly forgot that gatekeeper would need
to read more than just the commit content in it's
python scripts, so add read permissions to actions issues which it uses in it's processing