### PR TITLE
Fix | Support initdata for SNP

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -404,14 +404,6 @@ func (object Object) QemuParams(config *Config) []string {
 		driveParams = append(driveParams, "if=pflash,format=raw,readonly=on")
 		driveParams = append(driveParams, fmt.Sprintf("file=%s", object.File))
 	case SNPGuest:
-		if len(object.InitdataDigest) > 0 {
-			// due to https://github.com/confidential-containers/qemu/blob/amd-snp-202402240000/qapi/qom.json#L926-L929
-			// hostdata in SEV-SNP should be exactly 32 bytes
-			hostdataSlice := adjustProperLength(object.InitdataDigest, 32)
-			hostdata := base64.StdEncoding.EncodeToString(hostdataSlice)
-			objectParams = append(objectParams, fmt.Sprintf("host-data=%s", hostdata))
-		}
-
 		objectParams = append(objectParams, string(object.Type))
 		objectParams = append(objectParams, fmt.Sprintf("id=%s", object.ID))
 		objectParams = append(objectParams, fmt.Sprintf("cbitpos=%d", object.CBitPos))
@@ -422,6 +414,13 @@ func (object Object) QemuParams(config *Config) []string {
 		}
 		if object.SnpIdAuth != "" {
 			objectParams = append(objectParams, fmt.Sprintf("id-auth=%s", object.SnpIdAuth))
+		}
+		if len(object.InitdataDigest) > 0 {
+			// due to https://github.com/confidential-containers/qemu/blob/amd-snp-202402240000/qapi/qom.json#L926-L929
+			// hostdata in SEV-SNP should be exactly 32 bytes
+			hostdataSlice := adjustProperLength(object.InitdataDigest, 32)
+			hostdata := base64.StdEncoding.EncodeToString(hostdataSlice)
+			objectParams = append(objectParams, fmt.Sprintf("host-data=%s", hostdata))
 		}
 		config.Bios = object.File
 	case SecExecGuest:

--- a/tests/integration/kubernetes/k8s-initdata.bats
+++ b/tests/integration/kubernetes/k8s-initdata.bats
@@ -51,7 +51,7 @@ function setup_kbs_image_policy_for_initdata() {
 
     # TODO: Enable for more archs
     case "$KATA_HYPERVISOR" in
-        "qemu-tdx"|"qemu-coco-dev")
+        "qemu-tdx"|"qemu-coco-dev"|"qemu-snp")
             ;;
         *)
             skip "Test not supported for ${KATA_HYPERVISOR}."


### PR DESCRIPTION
This patch fixes the initdata support for SNP, and also turn on initdata test for CI.

Fixes #11300 