### PR TITLE
workflow: add packages: write to csi-driver publish

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,9 @@ jobs:
 
   publish-csi-driver-amd64:
     needs: build-kata-static-tarball-amd64
+    permissions:
+      contents: read
+      packages: write
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code


### PR DESCRIPTION
This one was missed in the earlier PR