### PR TITLE
gpu: Update runtimeClasses for correct podoverhead

### DIFF
--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu-snp.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu-snp.yaml
@@ -6,8 +6,8 @@ metadata:
 handler: kata-qemu-nvidia-gpu-snp
 overhead:
     podFixed:
-        memory: "2048Mi"
-        cpu: "1.0"
+        memory: "4096Mi"
+        cpu: "1"
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu-tdx.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu-tdx.yaml
@@ -6,8 +6,8 @@ metadata:
 handler: kata-qemu-nvidia-gpu-tdx
 overhead:
     podFixed:
-        memory: "2048Mi"
-        cpu: "1.0"
+        memory: "4096Mi"
+        cpu: "1"
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu.yaml
@@ -6,8 +6,8 @@ metadata:
 handler: kata-qemu-nvidia-gpu
 overhead:
     podFixed:
-        memory: "160Mi"
-        cpu: "250m"
+        memory: "4096Mi"
+        cpu: "1"
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"


### PR DESCRIPTION
We cannot only rely only on default_cpu and default_memory in the config, default is 1 and 2Gi but we need some overhead for QEMU and the other related binaries running as the pod overhead. Especially when QEMU is hot-plugging GPUs, CPUs, and memory it can consume more memory.