### PR TITLE
ci: Require agent-ctl tests

### DIFF
--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -68,6 +68,7 @@ mapping:
       # - Kata Containers CI / kata-containers-ci-on-push / run-basic-amd64-tests / run-docker-tests (cloud-hypervisor)
       # - Kata Containers CI / kata-containers-ci-on-push / run-basic-amd64-tests / run-docker-tests (dragonball)
       # - Kata Containers CI / kata-containers-ci-on-push / run-basic-amd64-tests / run-docker-tests (qemu)
+      - Kata Containers CI / kata-containers-ci-on-push / run-basic-amd64-tests / run-kata-agent-apis
       - Kata Containers CI / kata-containers-ci-on-push / run-basic-amd64-tests / run-nerdctl-tests (cloud-hypervisor)
       - Kata Containers CI / kata-containers-ci-on-push / run-basic-amd64-tests / run-nerdctl-tests (dragonball)
       - Kata Containers CI / kata-containers-ci-on-push / run-basic-amd64-tests / run-nerdctl-tests (qemu)


### PR DESCRIPTION
This adds `run-kata-agent-apis` to the list of required tests.

Note the [dashboard](https://kata-containers.github.io/) shows 9 passing runs because last night's run had a failure before that test, but I expect tomorrow's to pass.

See also: https://github.com/kata-containers/kata-containers.github.io/pull/40