### PR TITLE
Enables block device and disable virtio-fs

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -108,7 +108,7 @@ impl QemuInner {
                             &block_dev.config.path_on_host,
                             block_dev.config.is_readonly,
                         )?,
-                        "ccw" => cmdline.add_block_device(
+                        "ccw" | "blk" => cmdline.add_block_device(
                             block_dev.device_id.as_str(),
                             &block_dev.config.path_on_host,
                             block_dev

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -379,7 +379,17 @@ impl QemuInner {
 
     pub(crate) async fn capabilities(&self) -> Result<Capabilities> {
         let mut caps = Capabilities::default();
-        caps.set(CapabilityBits::FsSharingSupport);
+
+        // Confidential Guest doesn't permit virtio-fs.
+        let flags = if self.hypervisor_config().security_info.confidential_guest {
+            CapabilityBits::BlockDeviceSupport | CapabilityBits::BlockDeviceHotplugSupport
+        } else {
+            CapabilityBits::BlockDeviceSupport
+                | CapabilityBits::BlockDeviceHotplugSupport
+                | CapabilityBits::FsSharingSupport
+        };
+        caps.set(flags);
+
         Ok(caps)
     }
 


### PR DESCRIPTION
- Support cold plug of block devices via virtio-blk for Qemu
- Enables block device and disable virtio-fs via capabilities

Fixes #11341

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>