### PR TITLE
protocols: Fix the noise caused by non-formatted codes in protocols

### DIFF
--- a/src/libs/protocols/src/lib.rs
+++ b/src/libs/protocols/src/lib.rs
@@ -9,6 +9,7 @@ pub mod agent;
 pub mod agent_ttrpc;
 #[cfg(feature = "async")]
 pub mod agent_ttrpc_async;
+pub mod api;
 pub mod csi;
 pub mod empty;
 mod gogo;
@@ -17,15 +18,14 @@ pub mod health_ttrpc;
 #[cfg(feature = "async")]
 pub mod health_ttrpc_async;
 pub mod oci;
-#[cfg(feature = "with-serde")]
-mod serde_config;
-pub mod trans;
-pub mod types;
 pub mod remote;
 pub mod remote_ttrpc;
 #[cfg(feature = "async")]
 pub mod remote_ttrpc_async;
-pub mod api;
+#[cfg(feature = "with-serde")]
+mod serde_config;
+pub mod trans;
+pub mod types;
 
 #[cfg(feature = "with-serde")]
 pub use serde_config::{

--- a/src/libs/protocols/src/trans.rs
+++ b/src/libs/protocols/src/trans.rs
@@ -42,7 +42,9 @@ fn cap_vec2hashset(caps: Vec<String>) -> HashSet<oci::Capability> {
         .map(|cap: &String| {
             // cap might be JSON-encoded
             let decoded: &str = serde_json::from_str(cap).unwrap_or(cap);
-            decoded.strip_prefix("CAP_").unwrap_or(decoded)
+            decoded
+                .strip_prefix("CAP_")
+                .unwrap_or(decoded)
                 .parse::<oci::Capability>()
                 .unwrap_or_else(|_| panic!("Failed to parse {:?} to Enum Capability", cap))
         })
@@ -1318,8 +1320,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_cap_vec2hashset_bad() {
-        cap_vec2hashset(vec![
-            "CAP_DOES_NOT_EXIST".to_string(),
-        ]);
+        cap_vec2hashset(vec!["CAP_DOES_NOT_EXIST".to_string()]);
     }
 }


### PR DESCRIPTION
We always encount such noising warnings which makes us not happy. I think it's time to wipe it out
```
-            decoded.strip_prefix("CAP_").unwrap_or(decoded)
+            decoded
+                .strip_prefix("CAP_")
+                .unwrap_or(decoded)
                 .parse::<oci::Capability>()
                 .unwrap_or_else(|_| panic!("Failed to parse {:?} to
Enum Capability", cap))
         })
@@ -1318,8 +1320,6 @@ mod tests {
     #[test]
     #[should_panic]
     fn test_cap_vec2hashset_bad() {
-        cap_vec2hashset(vec![
-            "CAP_DOES_NOT_EXIST".to_string(),
-        ]);
+        cap_vec2hashset(vec!["CAP_DOES_NOT_EXIST".to_string()]);
```