### PR TITLE
rust: Update cgroups-rs to its v0.3.5 release

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -981,9 +981,8 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgroups-rs"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db7c2f5545da4c12c5701455d9471da5f07db52e49b9cccb4f5512226dd0836"
+version = "0.3.5"
+source = "git+https://github.com/kata-containers/cgroups-rs?rev=v0.3.5#de9625ff57d156967b5b2a637c2c41bb2366e39b"
 dependencies = [
  "libc",
  "log",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -54,7 +54,7 @@ procfs = "0.12.0"
 
 anyhow = "1"
 
-cgroups = { package = "cgroups-rs", version = "0.3.3" }
+cgroups = { package = "cgroups-rs", git = "https://github.com/kata-containers/cgroups-rs", rev = "v0.3.5" }
 
 # Tracing
 tracing = "0.1.26"

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -511,6 +511,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "cgroups-rs"
+version = "0.3.5"
+source = "git+https://github.com/kata-containers/cgroups-rs?rev=v0.3.5#de9625ff57d156967b5b2a637c2c41bb2366e39b"
+dependencies = [
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "regex",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "ch-config"
 version = "0.1.0"
 dependencies = [
@@ -614,7 +626,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063d0e137d508846210c2f8b6c6dc3db9f1abd4c20b0a9aecdb962385dcb7899"
 dependencies = [
  "async-trait",
- "cgroups-rs",
+ "cgroups-rs 0.3.4",
  "command-fds",
  "containerd-shim-protos",
  "futures 0.3.28",
@@ -3594,7 +3606,7 @@ dependencies = [
  "async-trait",
  "bitflags 2.9.0",
  "byte-unit",
- "cgroups-rs",
+ "cgroups-rs 0.3.5",
  "futures 0.3.28",
  "hypervisor",
  "inotify",

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -17,7 +17,7 @@ anyhow = { workspace = true }
 async-trait = { workspace = true }
 bitflags = "2.9.0"
 byte-unit = "5.1.6"
-cgroups-rs = "0.3.2"
+cgroups-rs = { git = "https://github.com/kata-containers/cgroups-rs", rev = "v0.3.5" }
 futures = "0.3.11"
 lazy_static = { workspace = true }
 libc = { workspace = true }

--- a/src/tools/runk/Cargo.lock
+++ b/src/tools/runk/Cargo.lock
@@ -483,9 +483,8 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "cgroups-rs"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db7c2f5545da4c12c5701455d9471da5f07db52e49b9cccb4f5512226dd0836"
+version = "0.3.5"
+source = "git+https://github.com/kata-containers/cgroups-rs?rev=v0.3.5#de9625ff57d156967b5b2a637c2c41bb2366e39b"
 dependencies = [
  "libc",
  "log",
@@ -2539,6 +2538,7 @@ dependencies = [
  "regex",
  "rlimit",
  "runtime-spec",
+ "safe-path",
  "scan_fmt",
  "scopeguard",
  "serde",

--- a/src/tools/runk/libcontainer/Cargo.toml
+++ b/src/tools/runk/libcontainer/Cargo.toml
@@ -21,7 +21,7 @@ chrono = { version = "0.4.19", features = ["serde"] }
 serde = { version = "1.0.133", features = ["derive"] }
 serde_json = "1.0.74"
 scopeguard = "1.1.0"
-cgroups = { package = "cgroups-rs", version = "0.3.2" }
+cgroups = { package = "cgroups-rs", git = "https://github.com/kata-containers/cgroups-rs", rev = "v0.3.5" }
 procfs = "0.14.0"
 
 [dev-dependencies]


### PR DESCRIPTION
We're switching to using a rev as it may take some time for the package to be updated on crates.io.