### PR TITLE
workflows: Fix publish csi permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -193,6 +193,9 @@ jobs:
           file: tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
 
   publish-csi-driver-amd64:
+    permissions:
+      contents: read
+      packages: write
     needs: build-kata-static-tarball-amd64
     runs-on: ubuntu-22.04
     steps:


### PR DESCRIPTION
It must be:
content: read
packages: write

Otherwise we fail to publish the CSI, leading to CoCo tests not running.