### PR TITLE
Add `sudo` explicitly as a dependency for platforms that do not ship …

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -428,6 +428,7 @@ check_deps()
 	elems+=("git:git")
 	elems+=("jq:jq")
 	elems+=("tar:tar")
+	elems+=("sudo:sudo")
 
 	local pkgs_to_install=()
 


### PR DESCRIPTION
…it by default (e.g. Alpine)

Sudo needs to be installed and correctly configured, even if running as root.