### PR TITLE
add initial make target to generate json schema for helm values

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/Makefile
+++ b/tools/packaging/kata-deploy/helm-chart/Makefile
@@ -16,3 +16,9 @@ package: helm release
 
 clean:
 	rm kata-deploy-*.tgz
+
+schema: plugins
+	cd kata-deploy && helm schema -input values.yaml kata-deploy/values.schema.json && cd .. 
+
+plugins:
+	helm plugin install https://github.com/losisin/helm-values-schema-json.git || true

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.schema.json
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.schema.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "env": {
+            "properties": {
+                "agentHttpsProxy": {
+                    "type": "string"
+                },
+                "agentNoProxy": {
+                    "type": "string"
+                },
+                "allowedHypervisorAnnotations": {
+                    "type": "string"
+                },
+                "createDefaultRuntimeClass": {
+                    "description": "whether to create a default runtime class for kata",
+                    "type": "string"
+                },
+                "createRuntimeClasses": {
+                    "description": "whether to create runtime class objects by default",
+                    "type": "string"
+                },
+                "debug": {
+                    "description": "whether to enable debug mode",
+                    "enum": [
+                        "false",
+                        "true"
+                    ],
+                    "type": "string"
+                },
+                "defaultShim": {
+                    "description": "default shim to utilize",
+                    "type": "string"
+                },
+                "hostOS": {
+                    "type": "string"
+                },
+                "installationPrefix": {
+                    "type": "string"
+                },
+                "multiInstallSuffix": {
+                    "type": "string"
+                },
+                "pullTypeMapping": {
+                    "type": "string"
+                },
+                "shims": {
+                    "description": "space separated string containing supported shims",
+                    "type": "string"
+                },
+                "snapshotterHandlerMapping": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "debug",
+                "shims",
+                "defaultShim",
+                "createRuntimeClasses",
+                "createDefaultRuntimeClass"
+            ],
+            "type": "object"
+        },
+        "image": {
+            "properties": {
+                "reference": {
+                    "description": "image reference where kata-deploy is stored",
+                    "type": "string"
+                },
+                "tag": {
+                    "description": "tag to use for the kata-deploy image",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "reference"
+            ],
+            "type": "object"
+        },
+        "imagePullPolicy": {
+            "description": "sets deployment imagePullPolicy to determine when the image should be pulled",
+            "enum": [
+                "Always",
+                "IfNotPresent",
+                "Never"
+            ],
+            "type": "string"
+        },
+        "imagePullSecrets": {
+            "description": "a list of imagePullSecrets to utilize when pulling an image",
+            "type": "array"
+        },
+        "k8sDistribution": {
+            "description": "type of underlying kubernetes platform",
+            "enum": [
+                "k8s",
+                "k3s",
+                "rke2",
+                "k0s",
+                "microk8s"
+            ],
+            "type": "string"
+        }
+    },
+    "required": [
+        "imagePullPolicy",
+        "k8sDistribution"
+    ],
+    "type": "object"
+}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -1,21 +1,20 @@
-imagePullPolicy: Always
-imagePullSecrets: []
+imagePullPolicy: Always # @schema required:true ;enum:[Always,IfNotPresent,Never];description: sets deployment imagePullPolicy to determine when the image should be pulled
+imagePullSecrets: [] # @schema required:false;description: a list of imagePullSecrets to utilize when pulling an image
 image:
-  reference: quay.io/kata-containers/kata-deploy
-  tag: ""
-# k8s-dist can be k8s, k3s, rke2, k0s, microk8s
-k8sDistribution: "k8s"
+  reference: quay.io/kata-containers/kata-deploy # @schema required:true;description: image reference where kata-deploy is stored
+  tag: "" # @schema required:false; description: tag to use for the kata-deploy image
+k8sDistribution: "k8s" # @schema enum:[k8s,k3s,rke2,k0s,microk8s]; required:true; description: type of underlying kubernetes platform
 env:
-  debug: "false"
-  shims: "clh cloud-hypervisor dragonball fc qemu qemu-coco-dev qemu-runtime-rs qemu-se-runtime-rs qemu-sev qemu-snp qemu-tdx stratovirt qemu-nvidia-gpu qemu-nvidia-gpu-snp qemu-nvidia-gpu-tdx"
-  defaultShim: "qemu"
-  createRuntimeClasses: "true"
-  createDefaultRuntimeClass: "false"
-  allowedHypervisorAnnotations: ""
-  snapshotterHandlerMapping: ""
-  agentHttpsProxy: ""
-  agentNoProxy: ""
-  pullTypeMapping: ""
-  installationPrefix: ""
-  hostOS: ""
-  multiInstallSuffix: ""
+  debug: "false" # @schema required:true;enum:[false,true]; description: whether to enable debug mode
+  shims: "clh cloud-hypervisor dragonball fc qemu qemu-coco-dev qemu-runtime-rs qemu-se-runtime-rs qemu-sev qemu-snp qemu-tdx stratovirt qemu-nvidia-gpu qemu-nvidia-gpu-snp qemu-nvidia-gpu-tdx" # @schema required:true; description: space separated string containing supported shims
+  defaultShim: "qemu" # @schema required:true; description: default shim to utilize
+  createRuntimeClasses: "true" # @schema required:true;description: whether to create runtime class objects by default
+  createDefaultRuntimeClass: "false" # @schema required:true;description: whether to create a default runtime class for kata
+  allowedHypervisorAnnotations: "" # @schema required:false;
+  snapshotterHandlerMapping: "" # @schema required:false;
+  agentHttpsProxy: "" # @schema required:false;
+  agentNoProxy: "" # @schema required:false;
+  pullTypeMapping: "" # @schema required:false;
+  installationPrefix: "" # @schema required:false;
+  hostOS: "" # @schema required:false;
+  multiInstallSuffix: "" # @schema required:false;


### PR DESCRIPTION
Per comments [here](https://github.com/kata-containers/kata-containers/pull/11260#issuecomment-2916841959), adding a make target to the helm Makefile that will utilize a helm plugin to generate the json schema for the associated helm values.

Add initial descriptions, enums and required fields for existing values.