### PR TITLE
agent: fix clippy static analysis error

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -560,11 +560,7 @@ fn build_blk_io_device_throttle_resource(
 }
 
 fn linux_device_cgroup_to_device_resource(d: &LinuxDeviceCgroup) -> Option<DeviceResource> {
-    let dev_type = match DeviceType::from_char(d.typ().unwrap_or_default().as_str().chars().next())
-    {
-        Some(t) => t,
-        None => return None,
-    };
+    let dev_type = DeviceType::from_char(d.typ().unwrap_or_default().as_str().chars().next())?;
 
     let mut permissions: Vec<DevicePermissions> = vec![];
     for p in d
@@ -1324,10 +1320,7 @@ fn default_allowed_devices() -> Vec<DeviceResource> {
 
 /// Convert LinuxDevice to DeviceResource.
 fn linux_device_to_device_resource(d: &LinuxDevice) -> Option<DeviceResource> {
-    let dev_type = match DeviceType::from_char(d.typ().as_str().chars().next()) {
-        Some(t) => t,
-        None => return None,
-    };
+    let dev_type = DeviceType::from_char(d.typ().as_str().chars().next())?;
 
     let permissions = vec![
         DevicePermissions::Read,

--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -481,7 +481,7 @@ fn mount_cgroups(
 
         if key != base {
             let src = format!("{}/{}", &mount_dest, key);
-            unix::fs::symlink(destination.as_str(), &src[1..]).map_err(|e| {
+            unix::fs::symlink(destination.as_str(), &src[1..]).inspect_err(|e| {
                 log_child!(
                     cfd_log,
                     "symlink: {} {} err: {}",
@@ -489,8 +489,6 @@ fn mount_cgroups(
                     destination.as_str(),
                     e.to_string()
                 );
-
-                e
             })?;
         }
     }
@@ -793,14 +791,13 @@ fn mount_from(
             Path::new(&dest).parent().unwrap()
         };
 
-        fs::create_dir_all(dir).map_err(|e| {
+        fs::create_dir_all(dir).inspect_err(|e| {
             log_child!(
                 cfd_log,
                 "create dir {}: {}",
                 dir.to_str().unwrap(),
                 e.to_string()
             );
-            e
         })?;
 
         // make sure file exists so we can bind over it
@@ -830,9 +827,8 @@ fn mount_from(
         }
     };
 
-    let _ = stat::stat(dest.as_str()).map_err(|e| {
+    let _ = stat::stat(dest.as_str()).inspect_err(|e| {
         log_child!(cfd_log, "dest stat error. {}: {:?}", dest.as_str(), e);
-        e
     })?;
 
     // Set the SELinux context for the mounts
@@ -878,9 +874,8 @@ fn mount_from(
         flags,
         Some(d.as_str()),
     )
-    .map_err(|e| {
+    .inspect_err(|e| {
         log_child!(cfd_log, "mount error: {:?}", e);
-        e
     })?;
 
     if !label.is_empty() && selinux::is_enabled()? && use_xattr {
@@ -904,9 +899,8 @@ fn mount_from(
             flags | MsFlags::MS_REMOUNT,
             None::<&str>,
         )
-        .map_err(|e| {
+        .inspect_err(|e| {
             log_child!(cfd_log, "remout {}: {:?}", dest.as_str(), e);
-            e
         })?;
     }
     Ok(())

--- a/src/agent/src/image.rs
+++ b/src/agent/src/image.rs
@@ -238,13 +238,10 @@ pub fn get_process(
         }
     }
     if guest_pull {
-        match oci.annotations() {
-            Some(a) => {
-                if ImageService::is_sandbox(a) {
-                    return ImageService::get_pause_image_process();
-                }
+        if let Some(a) = oci.annotations() {
+            if ImageService::is_sandbox(a) {
+                return ImageService::get_pause_image_process();
             }
-            None => {}
         }
     }
     Ok(ocip.clone())

--- a/src/agent/src/pci.rs
+++ b/src/agent/src/pci.rs
@@ -51,7 +51,7 @@ impl SlotFn {
             }
         };
 
-        Ok(SlotFn(ss8 << FUNCTION_BITS | f8))
+        Ok(SlotFn((ss8 << FUNCTION_BITS) | f8))
     }
 
     pub fn slot(self) -> u8 {

--- a/src/agent/src/sandbox.rs
+++ b/src/agent/src/sandbox.rs
@@ -428,13 +428,10 @@ impl Sandbox {
     pub fn setup_shared_mounts(&self, c: &LinuxContainer, mounts: &Vec<SharedMount>) -> Result<()> {
         let mut src_ctrs: HashMap<String, i32> = HashMap::new();
         for shared_mount in mounts {
-            match src_ctrs.get(&shared_mount.src_ctr) {
-                None => {
-                    if let Some(c) = self.find_container_by_name(&shared_mount.src_ctr) {
-                        src_ctrs.insert(shared_mount.src_ctr.clone(), c.init_process_pid);
-                    }
+            if !src_ctrs.contains_key(&shared_mount.src_ctr) {
+                if let Some(c) = self.find_container_by_name(&shared_mount.src_ctr) {
+                    src_ctrs.insert(shared_mount.src_ctr.clone(), c.init_process_pid);
                 }
-                Some(_) => {}
             }
         }
 

--- a/src/agent/src/storage/mod.rs
+++ b/src/agent/src/storage/mod.rs
@@ -321,12 +321,11 @@ pub fn set_ownership(logger: &Logger, storage: &Storage) -> Result<()> {
     let fs_group = storage.fs_group();
     let read_only = storage.options.contains(&String::from("ro"));
     let mount_path = Path::new(&storage.mount_point);
-    let metadata = mount_path.metadata().map_err(|err| {
+    let metadata = mount_path.metadata().inspect_err(|err| {
         error!(logger, "failed to obtain metadata for mount path";
             "mount-path" => mount_path.to_str(),
             "error" => err.to_string(),
         );
-        err
     })?;
 
     if fs_group.group_change_policy == FSGroupChangePolicy::OnRootMismatch.into()


### PR DESCRIPTION
This patch addresses various clippy lints (found by cargo 1.85) by using more idiomatic Rust patterns: replacing match-Some-None patterns with the ? operator, using inspect_err instead of map_err for side effects, and adding operator precedence parentheses for clarity.