### PR TITLE
dragonball: Remove a useless dead_code attribute

### DIFF
--- a/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/connection.rs
+++ b/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/connection.rs
@@ -201,9 +201,7 @@ impl Endpoint {
         Ok(Some(features))
     }
 
-    // TODO: Remove this after enabling vhost-user-fs on the runtime-rs. Issue:
-    // https://github.com/kata-containers/kata-containers/issues/8691
-    #[allow(dead_code)]
+    #[cfg(feature = "vhost-user-fs")]
     pub fn update_memory<AS: GuestAddressSpace>(&mut self, vm_as: &AS) -> VirtioResult<()> {
         let master = match self.conn.as_mut() {
             Some(conn) => conn,


### PR DESCRIPTION
The vhost-user-fs has been added to Dragonball, so we can remove
`update_memory`'s dead_code attribute.

Fixes: #8691