### PR TITLE
Upgrade `ttrpc-codegen` and `protobuf` to kill `#![allow(box_pointers)]`

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -2701,7 +2701,7 @@ dependencies = [
  "tokio-util",
  "toml 0.8.22",
  "ttrpc",
- "ttrpc-codegen 0.5.0",
+ "ttrpc-codegen",
  "url",
  "walkdir",
  "xattr 1.5.0",
@@ -4940,7 +4940,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ttrpc",
- "ttrpc-codegen 0.4.2",
+ "ttrpc-codegen",
 ]
 
 [[package]]
@@ -6927,18 +6927,6 @@ dependencies = [
 
 [[package]]
 name = "ttrpc-codegen"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7f7631d7a9ebed715a47cd4cb6072cbc7ae1d4ec01598971bbec0024340c2"
-dependencies = [
- "protobuf 2.28.0",
- "protobuf-codegen 3.7.1",
- "protobuf-support",
- "ttrpc-compiler 0.6.2",
-]
-
-[[package]]
-name = "ttrpc-codegen"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdc0529f65223eca94fc5830e7d552d0d152ff42b74aff5c641edac39592f41f"
@@ -6947,22 +6935,7 @@ dependencies = [
  "protobuf 2.28.0",
  "protobuf-codegen 3.7.1",
  "protobuf-support",
- "ttrpc-compiler 0.7.0",
-]
-
-[[package]]
-name = "ttrpc-compiler"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0672eb06e5663ad190c7b93b2973f5d730259859b62e4e3381301a12a7441107"
-dependencies = [
- "derive-new",
- "prost",
- "prost-build",
- "prost-types",
- "protobuf 2.28.0",
- "protobuf-codegen 2.28.0",
- "tempfile",
+ "ttrpc-compiler",
 ]
 
 [[package]]

--- a/src/agent/src/cdh.rs
+++ b/src/agent/src/cdh.rs
@@ -270,9 +270,8 @@ mod tests {
 
     fn start_ttrpc_server(cdh_socket_uri: String) {
         tokio::spawn(async move {
-            let ss = Box::new(TestService {})
-                as Box<dyn confidential_data_hub_ttrpc_async::SealedSecretService + Send + Sync>;
-            let ss = Arc::new(ss);
+            let ss = Box::new(TestService {});
+            let ss = Arc::new(*ss);
             let ss_service = confidential_data_hub_ttrpc_async::create_sealed_secret_service(ss);
 
             remove_if_sock_exist(&cdh_socket_uri).unwrap();

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -1796,11 +1796,11 @@ pub async fn start(
         sandbox: s,
         init_mode,
         oma,
-    }) as Box<dyn agent_ttrpc::AgentService + Send + Sync>;
-    let aservice = agent_ttrpc::create_agent_service(Arc::new(agent_service));
+    });
+    let aservice = agent_ttrpc::create_agent_service(Arc::new(*agent_service));
 
-    let health_service = Box::new(HealthService {}) as Box<dyn health_ttrpc::Health + Send + Sync>;
-    let hservice = health_ttrpc::create_health(Arc::new(health_service));
+    let health_service = Box::new(HealthService {});
+    let hservice = health_ttrpc::create_health(Arc::new(*health_service));
 
     let server = TtrpcServer::new()
         .bind(server_address)?

--- a/src/libs/Cargo.lock
+++ b/src/libs/Cargo.lock
@@ -1435,9 +1435,9 @@ checksum = "cf7e6d18738ecd0902d30d1ad232c9125985a3422929b16c65517b38adc14f96"
 
 [[package]]
 name = "protobuf"
-version = "3.2.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55bad9126f378a853655831eb7363b7b01b81d19f8cb1218861086ca4a1a61e"
+checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
 dependencies = [
  "once_cell",
  "protobuf-support",
@@ -1455,13 +1455,13 @@ dependencies = [
 
 [[package]]
 name = "protobuf-codegen"
-version = "3.2.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd418ac3c91caa4032d37cb80ff0d44e2ebe637b2fb243b6234bf89cdac4901"
+checksum = "e26b833f144769a30e04b1db0146b2aaa53fd2fd83acf10a6b5f996606c18144"
 dependencies = [
  "anyhow",
  "once_cell",
- "protobuf 3.2.0",
+ "protobuf 3.7.1",
  "protobuf-parse",
  "regex",
  "tempfile",
@@ -1470,14 +1470,14 @@ dependencies = [
 
 [[package]]
 name = "protobuf-parse"
-version = "3.2.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d39b14605eaa1f6a340aec7f320b34064feb26c93aec35d6a9a2272a8ddfa49"
+checksum = "322330e133eab455718444b4e033ebfac7c6528972c784fcde28d2cc783c6257"
 dependencies = [
  "anyhow",
- "indexmap 1.8.1",
+ "indexmap 2.9.0",
  "log",
- "protobuf 3.2.0",
+ "protobuf 3.7.1",
  "protobuf-support",
  "tempfile",
  "thiserror",
@@ -1486,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "protobuf-support"
-version = "3.2.0"
+version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d4d7b8601c814cfb36bcebb79f0e61e45e1e93640cf778837833bbed05c372"
+checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
  "thiserror",
 ]
@@ -1499,7 +1499,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "oci-spec",
- "protobuf 3.2.0",
+ "protobuf 3.7.1",
  "serde",
  "serde_json",
  "ttrpc",
@@ -2244,8 +2244,8 @@ dependencies = [
  "libc",
  "log",
  "nix 0.26.4",
- "protobuf 3.2.0",
- "protobuf-codegen 3.2.0",
+ "protobuf 3.7.1",
+ "protobuf-codegen 3.7.1",
  "thiserror",
  "tokio",
  "tokio-vsock",
@@ -2254,23 +2254,25 @@ dependencies = [
 
 [[package]]
 name = "ttrpc-codegen"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d7f7631d7a9ebed715a47cd4cb6072cbc7ae1d4ec01598971bbec0024340c2"
+checksum = "cdc0529f65223eca94fc5830e7d552d0d152ff42b74aff5c641edac39592f41f"
 dependencies = [
+ "home",
  "protobuf 2.27.1",
- "protobuf-codegen 3.2.0",
+ "protobuf-codegen 3.7.1",
  "protobuf-support",
  "ttrpc-compiler",
 ]
 
 [[package]]
 name = "ttrpc-compiler"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec3cb5dbf1f0865a34fe3f722290fe776cacb16f50428610b779467b76ddf647"
+checksum = "9be3fb2fe509cb9c0099b3b5551b759ae714f2dde56dfc713f2a5bda8c16064a"
 dependencies = [
  "derive-new",
+ "home",
  "prost",
  "prost-build",
  "prost-types",

--- a/src/libs/protocols/Cargo.toml
+++ b/src/libs/protocols/Cargo.toml
@@ -13,11 +13,11 @@ async = ["ttrpc/async", "async-trait"]
 [dependencies]
 ttrpc = "0.8.4"
 async-trait = { version = "0.1.42", optional = true }
-protobuf = { version = "3.2.0" }
+protobuf = { version = "=3.7.1" }
 serde = { version = "1.0.130", features = ["derive"] }
 serde_json = "1.0.68"
 oci-spec = { version = "0.6.8", features = ["runtime"] }
 
 [build-dependencies]
-ttrpc-codegen = "0.4.2"
-protobuf = { version = "3.2.0" }
+ttrpc-codegen = "0.5.0"
+protobuf = { version = "=3.7.1" }


### PR DESCRIPTION
Previous version of `ttrpc-codegen` (v0.4.2) is generating rust code with `#![allow(box_pointers)]` which was deprecated and preventing us from bumping to Rust 1.85.1.

Bump `ttrpc-codegen` from v0.4.2 to v0.5.0 and `protobuf` from vx to v3.7.1 to get rid of this.

Relates: #11305 