### PR TITLE
chore(kata-deploy): allow to customize fs args in .toml configuration

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -72,6 +72,18 @@ spec:
         - name: HOST_OS
           value: {{ . | quote }}
 {{- end }}
+{{- with .Values.env.shared_fs }}
+        - name: SHARED_FS
+          value: {{ . | quote }}
+{{- end }}
+{{- with .Values.env.virtio_fs_daemon }}
+        - name: VIRTIO_FS_DAEMON
+          value: {{ . | quote }}
+{{- end }}
+{{- with .Values.env.virtio_fs_extra_args }}
+        - name: VIRTIO_FS_EXTRA_ARGS
+          value: {{ . | quote }}
+{{- end }}
         securityContext:
           privileged: true
         volumeMounts:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
@@ -129,6 +129,18 @@ spec:
         - name: HOST_OS
           value: {{ . | quote }}
 {{- end }}
+{{- with .Values.env.shared_fs }}
+        - name: SHARED_FS
+          value: {{ . | quote }}
+{{- end }}
+{{- with .Values.env.virtio_fs_daemon }}
+        - name: VIRTIO_FS_DAEMON
+          value: {{ . | quote }}
+{{- end }}
+{{- with .Values.env.virtio_fs_extra_args }}
+        - name: VIRTIO_FS_EXTRA_ARGS
+          value: {{ . | quote }}
+{{- end }}
         securityContext:
           privileged: true
         volumeMounts:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -19,3 +19,6 @@ env:
   installationPrefix: ""
   hostOS: ""
   multiInstallSuffix: ""
+  shared_fs: ""
+  virtio_fs_daemon: ""
+  virtio_fs_extra_args: ""

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -407,6 +407,21 @@ function install_artifacts() {
 			sed -i -e 's|^kernel_params = "\(.*\)"|kernel_params = "\1 agent.no_proxy='${AGENT_NO_PROXY}'"|g' "${kata_config_file}"
 		fi
 
+		# Shared file system type
+		if [[ -n "${SHARED_FS}" ]]; then
+			sed -i -e 's|^shared_fs = "\(.*\)"|shared_fs = '${SHARED_FS}'|g' "${kata_config_file}"
+		fi
+
+		# Path to vhost-user-fs daemon
+		if [[ -n "${VIRTIO_FS_DAEMON}" ]]; then
+			sed -i -e 's|^virtio_fs_daemon = "\(.*\)"|virtio_fs_daemon = '${VIRTIO_FS_DAEMON}'|g' "${kata_config_file}"
+		fi
+
+		# Extra args for virtiofsd daemon
+		if [[ -n "${VIRTIO_FS_EXTRA_ARGS}" ]]; then
+			sed -i -e 's|^virtio_fs_extra_args = "\(.*\)"|virtio_fs_extra_args = '${VIRTIO_FS_EXTRA_ARGS}'|g' "${kata_config_file}"
+		fi
+
 		# Allow enabling debug for Kata Containers
 		if [[ "${DEBUG}" == "true" ]]; then
 			sed -i -e 's/^#\(enable_debug\).*=.*$/\1 = true/g' "${kata_config_file}"


### PR DESCRIPTION
This will allow us to customize fs parameters from ENV vars, for example to set `shared_fs = "virtio-fs-nydus"`  to enable nydusd support https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/how-to-use-virtio-fs-nydus-with-kata.md


Signed-Off-By: lukas.mrtvy@gmail.com