### PR TITLE
runtime-rs: Skip test on RISC-V architecture

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -37,6 +37,11 @@ test:
 install:
 	@echo "PowerPC 64 LE is not currently supported"
 	exit 0
+else ifeq ($(ARCH), riscv64gc)
+default: runtime show-header
+test:
+	@echo "RISC-V 64 is not currently supported"
+	exit 0
 else
 ##TARGET default: build code
 default: runtime show-header


### PR DESCRIPTION
Full set test on RISC-V architecture is not yet supported, skip it for now.