### PR TITLE
ci: Fix Mariner rootfs build failure

### DIFF
--- a/tools/osbuilder/rootfs-builder/cbl-mariner/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/Dockerfile.in
@@ -11,6 +11,9 @@ RUN tdnf -y install \
     dnf \
     git \
     tar \
-    xz
+    xz \
+    # TODO: Remove when this issue is fixed:
+    # https://github.com/microsoft/azurelinux/issues/13971
+    --exclude=aznfs
 
 @INSTALL_RUST@


### PR DESCRIPTION
This implements a workaround for microsoft/azurelinux#13971 to unblock the CI.