### PR TITLE
Revert "ci: Fix Mariner rootfs build failure"

### DIFF
--- a/tools/osbuilder/rootfs-builder/cbl-mariner/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/Dockerfile.in
@@ -11,9 +11,6 @@ RUN tdnf -y install \
     dnf \
     git \
     tar \
-    xz \
-    # TODO: Remove when this issue is fixed:
-    # https://github.com/microsoft/azurelinux/issues/13971
-    --exclude=aznfs
+    xz
 
 @INSTALL_RUST@


### PR DESCRIPTION
This reverts commit dfa25a42ff956190387ae04764d1811d6f906d4d.

The original issue was fixed:

https://github.com/microsoft/azurelinux/issues/13971#issuecomment-2956384627