### PR TITLE
tests: Do not use `kubectl -it` for nginx-connectivity test

### DIFF
--- a/tests/integration/kubernetes/k8s-nginx-connectivity.bats
+++ b/tests/integration/kubernetes/k8s-nginx-connectivity.bats
@@ -34,8 +34,10 @@ setup() {
 	kubectl expose deployment/${deployment}
 
 	busybox_pod="test-nginx"
-	kubectl run $busybox_pod --restart=Never -it --image="$busybox_image" \
+	kubectl run $busybox_pod --restart=Never --image="$busybox_image" \
 		-- sh -c 'i=1; while [ $i -le '"$wait_time"' ]; do wget --timeout=5 '"$deployment"' && break; sleep 1; i=$(expr $i + 1); done'
+	# `kubectl run` without -i flag doesn't wait for the pod to be ready, so we need to wait for it manually
+	kubectl wait --for=condition=Ready pod/$busybox_pod --timeout=30s
 
 	# check pod's status, it should be Succeeded.
 	# or {.status.containerStatuses[0].state.terminated.reason} = "Completed"


### PR DESCRIPTION
The following error was observed on the s390x runners:

```
Unable to use a TTY - input is not a terminal or the right kind of file
If you don't see a command prompt, try pressing enter.
```

This can happen when running in a GitHub Actions runner or other non-interactive environment. This PR prevents a test from using an `-it` option for kubectl for nginx-connectivity test.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>