### PR TITLE
nvidia-rootfs: only copy `kata-opa` if `AGENT_POLICY` is enabled

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -15,6 +15,7 @@ readonly SCRIPT_DIR="${script_dir}/nvidia"
 # This will control how much output the inird/image will produce
 DEBUG=""
 KBUILD_SIGN_PIN=${KBUILD_SIGN_PIN:-}
+AGENT_POLICY="${AGENT_POLICY:-no}"
 
 NVIDIA_GPU_STACK=${NVIDIA_GPU_STACK:?NVIDIA_GPU_STACK must be set}
 VARIANT=${VARIANT:?VARIANT must be set}
@@ -281,7 +282,9 @@ chisseled_init() {
 	ln -sf  /bin/NVRC sbin/init
 
 	cp -a "${stage_one}"/usr/bin/kata-agent   usr/bin/.
-	cp -a "${stage_one}"/etc/kata-opa         etc/.
+	if [[ "${AGENT_POLICY}" == "yes" ]]; then
+		cp -a "${stage_one}"/etc/kata-opa etc/.
+	fi
 	cp -a "${stage_one}"/etc/resolv.conf      etc/.
 	cp -a "${stage_one}"/supported-gpu.devids .
 


### PR DESCRIPTION
In the nvidia rootfs build, only copy in `kata-opa` if `AGENT_POLICY` is enabled. This fixes builds when `AGENT_POLICY` is disabled and opa is not built.