### PR TITLE
agent: add feature flag to secure_mount method

### DIFF
--- a/src/agent/src/cdh.rs
+++ b/src/agent/src/cdh.rs
@@ -74,6 +74,7 @@ impl CDHClient {
         Ok(unsealed_secret.plaintext)
     }
 
+    #[cfg(feature = "guest-pull")]
     pub async fn secure_mount(
         &self,
         volume_type: &str,


### PR DESCRIPTION
This method is not used when guest-pull is not used. Add a flag that prevents a compile error when building with rust version > 1.84.0 and not using guest-pull.

Related to https://github.com/kata-containers/kata-containers/pull/10934