### PR TITLE
gitignore: ignore direnv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ src/agent/protocols/src/*.rs
 build
 src/tools/log-parser/kata-log-parser
 tools/packaging/static-build/agent/install_libseccomp.sh
+.envrc
+.direnv


### PR DESCRIPTION
This allows contributors to setup [direnv](https://direnv.net/) without having it detected by git.