### PR TITLE
 runtime-rs: Add the memory and vcpu hotplug for cloud-hypervisor

### DIFF
--- a/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
@@ -500,6 +500,32 @@ pub struct NamedHypervisorConfig {
     pub guest_protection_to_use: GuestProtection,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, Default)]
+pub struct VmResize {
+    pub desired_vcpus: Option<u8>,
+    pub desired_ram: Option<u64>,
+    pub desired_balloon: Option<u64>,
+}
+
+/// VmInfo : Virtual Machine information
+#[derive(Clone, Default, Debug, Serialize, Deserialize)]
+pub struct VmInfo {
+    pub config: VmConfig,
+    pub state: State,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_actual_size: Option<u64>,
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum State {
+    #[default]
+    Created,
+    Running,
+    Shutdown,
+    Paused,
+}
+
 // Returns true if the enabled guest protection is Intel TDX.
 pub fn guest_protection_is_tdx(guest_protection_to_use: GuestProtection) -> bool {
     matches!(guest_protection_to_use, GuestProtection::Tdx)

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/net_util.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/net_util.rs
@@ -2,14 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use serde::{Deserialize, Serialize, Serializer};
+use anyhow::{anyhow, Result};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 
 pub const MAC_ADDR_LEN: usize = 6;
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Deserialize, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub struct MacAddr {
     pub bytes: [u8; MAC_ADDR_LEN],
+}
+
+impl MacAddr {
+    pub fn new(addr: [u8; MAC_ADDR_LEN]) -> MacAddr {
+        MacAddr { bytes: addr }
+    }
 }
 
 // Note: Implements ToString automatically.
@@ -28,5 +36,188 @@ impl fmt::Display for MacAddr {
 impl Serialize for MacAddr {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         self.to_string().serialize(serializer)
+    }
+}
+
+// Helper function: parse MAC address string to byte array
+fn parse_mac_address_str(s: &str) -> Result<[u8; MAC_ADDR_LEN]> {
+    let parts: Vec<&str> = s.split(':').collect();
+    if parts.len() != MAC_ADDR_LEN {
+        return Err(anyhow!(
+            "Invalid MAC address format: expected {} parts separated by ':', got {}",
+            MAC_ADDR_LEN,
+            parts.len()
+        ));
+    }
+
+    let mut bytes = [0u8; MAC_ADDR_LEN];
+    for (i, part) in parts.iter().enumerate() {
+        if part.len() != 2 {
+            return Err(anyhow!(
+                "Invalid MAC address part '{}': expected 2 hex digits",
+                part
+            ));
+        }
+        bytes[i] = u8::from_str_radix(part, 16)
+            .map_err(|e| anyhow!("Invalid hex digit in '{}': {}", part, e))?;
+    }
+    Ok(bytes)
+}
+
+// Customize Deserialize implementation, because the system's own one does not work.
+impl<'de> Deserialize<'de> for MacAddr {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        // We expect the deserializer to provide a string, so we use deserialize_string
+        deserializer.deserialize_string(MacAddrVisitor)
+    }
+}
+
+// MacAddrVisitor will handle the actual conversion from string to MacAddr
+struct MacAddrVisitor;
+
+impl Visitor<'_> for MacAddrVisitor {
+    type Value = MacAddr;
+
+    // When deserialization fails, Serde will call this method to get a description of the expected format
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str("a MAC address string in format \"XX:XX:XX:XX:XX:XX\"")
+    }
+
+    // Called when the deserializer provides a string slice
+    fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        // Use our auxiliary function to parse the string and convert it to MacAddr
+        parse_mac_address_str(v)
+            .map(MacAddr::new) // If the parsing is successful, create a MacAddr with a byte array
+            .map_err(de::Error::custom) // If parsing fails, convert the error to Serde's error type
+    }
+
+    // Called when the deserializer provides a String (usually delegated to visit_str)
+    fn visit_string<E>(self, v: String) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        self.visit_str(&v)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*; // Import parent module items, including MAC_ADDR_LEN and parse_mac_address_str
+
+    #[test]
+    fn test_parse_mac_address_str_valid() {
+        // Test a standard MAC address
+        let mac_str = "00:11:22:33:44:55";
+        let expected_bytes = [0x00, 0x11, 0x22, 0x33, 0x44, 0x55];
+        assert_eq!(parse_mac_address_str(mac_str).unwrap(), expected_bytes);
+
+        // Test a MAC address with uppercase letters
+        let mac_str_upper = "AA:BB:CC:DD:EE:FF";
+        let expected_bytes_upper = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+        assert_eq!(
+            parse_mac_address_str(mac_str_upper).unwrap(),
+            expected_bytes_upper
+        );
+
+        // Test a mixed-case MAC address
+        let mac_str_mixed = "aA:Bb:Cc:Dd:Ee:Ff";
+        let expected_bytes_mixed = [0xAA, 0xBB, 0xCC, 0xDD, 0xEE, 0xFF];
+        assert_eq!(
+            parse_mac_address_str(mac_str_mixed).unwrap(),
+            expected_bytes_mixed
+        );
+
+        // Test an all-zero MAC address
+        let mac_str_zero = "00:00:00:00:00:00";
+        let expected_bytes_zero = [0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
+        assert_eq!(
+            parse_mac_address_str(mac_str_zero).unwrap(),
+            expected_bytes_zero
+        );
+    }
+
+    #[test]
+    fn test_parse_mac_address_str_invalid_length() {
+        // MAC address with too few segments
+        let mac_str_short = "00:11:22:33:44";
+        let err = parse_mac_address_str(mac_str_short).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Invalid MAC address format: expected 6 parts separated by ':', got 5"));
+
+        // MAC address with too many segments
+        let mac_str_long = "00:11:22:33:44:55:66";
+        let err = parse_mac_address_str(mac_str_long).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Invalid MAC address format: expected 6 parts separated by ':', got 7"));
+
+        // Empty string
+        let mac_str_empty = "";
+        let err = parse_mac_address_str(mac_str_empty).unwrap_err();
+        // Note: split(':') on an empty string returns a Vec containing [""] if delimiter is not found,
+        // so its length will be 1.
+        assert!(err
+            .to_string()
+            .contains("Invalid MAC address format: expected 6 parts separated by ':', got 1"));
+    }
+
+    #[test]
+    fn test_parse_mac_address_str_invalid_part_length() {
+        // Part with insufficient length (1 digit)
+        let mac_str_part_short = "0:11:22:33:44:55";
+        let err = parse_mac_address_str(mac_str_part_short).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Invalid MAC address part '0': expected 2 hex digits"));
+
+        // Part with excessive length (3 digits)
+        let mac_str_part_long = "000:11:22:33:44:55";
+        let err = parse_mac_address_str(mac_str_part_long).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Invalid MAC address part '000': expected 2 hex digits"));
+    }
+
+    #[test]
+    fn test_parse_mac_address_str_invalid_chars() {
+        // Contains non-hexadecimal character (letter G)
+        let mac_str_invalid_char_g = "00:11:22:33:44:GG";
+        let err = parse_mac_address_str(mac_str_invalid_char_g).unwrap_err();
+        assert!(err.to_string().contains("Invalid hex digit in 'GG'"));
+
+        // Contains non-hexadecimal character (symbol @)
+        let mac_str_invalid_char_at = "00:11:22:33:44:@5";
+        let err = parse_mac_address_str(mac_str_invalid_char_at).unwrap_err();
+        assert!(err.to_string().contains("Invalid hex digit in '@5'"));
+
+        // Contains whitespace character
+        let mac_str_with_space = "00:11:22:33:44: 5";
+        let err = parse_mac_address_str(mac_str_with_space).unwrap_err();
+        assert!(err.to_string().contains("Invalid hex digit in ' 5'"));
+    }
+
+    #[test]
+    fn test_parse_mac_address_str_malformed_string() {
+        // String with only colons
+        let mac_str_colon_only = ":::::";
+        let err = parse_mac_address_str(mac_str_colon_only).unwrap_err();
+        // Each empty part will trigger the "expected 2 hex digits" error
+        assert!(err
+            .to_string()
+            .contains("Invalid MAC address part '': expected 2 hex digits"));
+
+        // String with trailing colon
+        let mac_str_trailing_colon = "00:11:22:33:44:55:";
+        let err = parse_mac_address_str(mac_str_trailing_colon).unwrap_err();
+        assert!(err
+            .to_string()
+            .contains("Invalid MAC address format: expected 6 parts separated by ':', got 7"));
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
@@ -74,8 +74,8 @@ pub struct CloudHypervisorInner {
     // None.
     pub(crate) ch_features: Option<Vec<String>>,
 
-    /// Size of memory block of guest OS in MB (currently unused)
-    pub(crate) _guest_memory_block_size_mb: u32,
+    /// Size of memory block of guest OS in MB
+    pub(crate) guest_memory_block_size_mb: u32,
 
     pub(crate) exit_notify: Option<mpsc::Sender<i32>>,
 }
@@ -117,7 +117,7 @@ impl CloudHypervisorInner {
             tasks: None,
             guest_protection_to_use: GuestProtection::NoProtection,
             ch_features: None,
-            _guest_memory_block_size_mb: 0,
+            guest_memory_block_size_mb: 0,
 
             exit_notify,
         }

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -206,7 +206,7 @@ impl Hypervisor for CloudHypervisor {
 
     async fn resize_memory(&self, new_mem_mb: u32) -> Result<(u32, MemoryConfig)> {
         let inner = self.inner.read().await;
-        inner.resize_memory(new_mem_mb)
+        inner.resize_memory(new_mem_mb).await
     }
 
     async fn get_passfd_listener_addr(&self) -> Result<(String, u32)> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -7,10 +7,12 @@ use super::cmdline_generator::{get_network_device, QemuCmdLine, QMP_SOCKET_FILE}
 use super::qmp::Qmp;
 use crate::device::topology::PCIePort;
 use crate::{
-    device::driver::ProtectionDeviceConfig, hypervisor_persist::HypervisorState,
-    utils::enter_netns, HypervisorConfig, MemoryConfig, VcpuThreadIds, VsockDevice,
-    HYPERVISOR_QEMU,
+    device::driver::ProtectionDeviceConfig, hypervisor_persist::HypervisorState, HypervisorConfig,
+    MemoryConfig, VcpuThreadIds, VsockDevice, HYPERVISOR_QEMU,
 };
+
+use crate::utils::{bytes_to_megs, enter_netns, megs_to_bytes};
+
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use kata_sys_util::netns::NetnsGuard;
@@ -452,15 +454,6 @@ impl QemuInner {
             sl!(),
             "QemuInner::resize_memory(): asked to resize memory to {} MB", new_total_mem_mb
         );
-
-        // stick to the apparent de facto convention and represent megabytes
-        // as u32 and bytes as u64
-        fn bytes_to_megs(bytes: u64) -> u32 {
-            (bytes / (1 << 20)) as u32
-        }
-        fn megs_to_bytes(bytes: u32) -> u64 {
-            bytes as u64 * (1 << 20)
-        }
 
         let qmp = match self.qmp {
             Some(ref mut qmp) => qmp,

--- a/src/runtime-rs/crates/hypervisor/src/utils.rs
+++ b/src/runtime-rs/crates/hypervisor/src/utils.rs
@@ -192,6 +192,14 @@ impl std::fmt::Display for SocketAddress {
     }
 }
 
+pub fn bytes_to_megs(bytes: u64) -> u32 {
+    (bytes / (1 << 20)) as u32
+}
+
+pub fn megs_to_bytes(bytes: u32) -> u64 {
+    bytes as u64 * (1 << 20)
+}
+
 #[cfg(test)]
 mod tests {
     use super::create_fds;


### PR DESCRIPTION
Add the memory and vcpu hotplug for the cloud-hypervisor.
    
For cloud-hypervisor, currently only hot plugging of memory is
supported, but hot unplugging of memory is not supported. In addition,
by default, cloud-hypervisor uses ACPI-based memory hot-plugging instead
of virtio-mem based memory hot-plugging.

For vcpu, it can support both of hotplug and hot unplug.
