### PR TITLE
ci/static-checks: use oras cache for regorus

### DIFF
--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -106,6 +106,9 @@ jobs:
           - "make static-checks"
     env:
       GOPATH: ${{ github.workspace }}
+    permissions:
+      contents: read  # for checkout
+      packages: write # for push to ghcr.io
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -132,6 +135,10 @@ jobs:
           cd "${GOPATH}/src/github.com/${{ github.repository }}"
           ./tests/install_opa.sh
       - name: Install regorus
+        env:
+          ARTEFACT_REPOSITORY: "${{ github.repository }}"
+          ARTEFACT_REGISTRY_USERNAME: "${{ github.actor }}"
+          ARTEFACT_REGISTRY_PASSWORD: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           "${GOPATH}/src/github.com/${{ github.repository }}/tests/install_regorus.sh"
       - name: Run check

--- a/tests/install_regorus.sh
+++ b/tests/install_regorus.sh
@@ -9,6 +9,73 @@
 test_dir=$(realpath "$(dirname "${BASH_SOURCE[0]}")")
 source "${test_dir}/common.bash"
 
+install_regorus_oras()
+{
+    local version
+    version=$1
+
+    if ! command -v oras &>/dev/null; then
+        warn "oras is not installed. Please install oras to install regorus."
+        return 1
+    fi
+
+    local image
+    image="${ARTEFACT_REGISTRY:-ghcr.io}/${ARTEFACT_REPOSITORY:-kata-containers/kata-containers}/cached-artefacts/regorus:${version}"
+
+    if ! oras pull "${image}" --no-tty; then
+        warn "Failed to pull regorus from oras cache"
+        return 1
+    fi
+    info "Successfully pulled regorus from oras cache"
+
+    if ! mv regorus "${HOME}/.cargo/bin/regorus"; then
+        warn "Failed to move regorus binary"
+        return 1
+    fi
+
+    if ! chmod +x "${HOME}/.cargo/bin/regorus"; then
+        warn "Failed to make regorus binary executable"
+        return 1
+    fi
+}
+
+install_regorus_cargo()
+{
+    local version
+    version=$1
+
+    if ! cargo install regorus --version "${version}" --example regorus --locked; then
+        warn "Failed to cargo install regorus"
+        return 1
+    fi
+    info "Successfully installed regorus using cargo"
+
+    # Cache the installed binary using oras, so we don't have to build it again.
+    if [[ -z "${ARTEFACT_REGISTRY_PASSWORD}" ]]; then
+        warn "ARTEFACT_REGISTRY_PASSWORD is not set. Skipping caching of regorus binary."
+        return 0
+    fi
+
+    if [[ -z "${ARTEFACT_REGISTRY_USERNAME}" ]]; then
+        warn "ARTEFACT_REGISTRY_USERNAME is not set. Skipping caching of regorus binary."
+        return 0
+    fi
+
+    if ! echo "${ARTEFACT_REGISTRY_PASSWORD}" | oras login "${ARTEFACT_REGISTRY:-ghcr.io}" -u "${ARTEFACT_REGISTRY_USERNAME}" --password-stdin; then
+        warn "Failed to login to oras registry"
+        return 1
+    fi
+
+    local image
+    image="${ARTEFACT_REGISTRY:-ghcr.io}/${ARTEFACT_REPOSITORY:-kata-containers/kata-containers}/cached-artefacts/regorus:${version}"
+
+    if ! (cd "${HOME}/.cargo/bin/" && oras push "${image}" --no-tty regorus); then
+        warn "Failed to push regorus binary to oras cache"
+        return 1
+    fi
+    info "Successfully pushed regorus binary to oras cache as ${image}"
+}
+
 install_regorus()
 {
     command -v cargo &>/dev/null \
@@ -16,17 +83,12 @@ install_regorus()
     command -v git &>/dev/null \
         || die "git is not installed. Please install git."
 
-    if regorus --version 2>/dev/null | grep -q "${version}"; then
-        info "regorus version ${version} is already installed"
-        return 0
-    fi
-
     # Get the regorus version from Cargo.toml of the agent policy crate instad of versions.yaml
     # so we test the version we are actually using.
     local cargo_toml="${test_dir}/../src/agent/policy/Cargo.toml"
     [[ -f "${cargo_toml}" ]] \
         || die "Cargo.toml not found at ${cargo_toml}"
-
+    local version
     version=$(
         cargo tree -i regorus --edges normal --prefix none --manifest-path "${cargo_toml}" |
             head -n1 |
@@ -34,12 +96,21 @@ install_regorus()
             sed 's/v//'
     ) || die "Failed to get regorus version from cargo.toml"
 
+    if regorus --version 2>/dev/null | grep -q "${version}"; then
+        info "regorus version ${version} is already installed"
+        return 0
+    fi
     info "Installing regorus version ${version}"
 
-    cargo install regorus --version "${version}" --example regorus \
-        || die "Failed to cargo install regorus"
+    if install_regorus_oras "${version}"; then
+        :
+    elif install_regorus_cargo "${version}"; then
+        :
+    else
+        die "Failed to install regorus"
+    fi
 
-    if ! echo "$PATH" | grep -q "${HOME}/.cargo/bin"; then
+    if ! echo "${PATH}" | grep -q "${HOME}/.cargo/bin"; then
         export PATH="${PATH}:${HOME}/.cargo/bin"
     fi
 


### PR DESCRIPTION
Instead of building it every time, we can store the regorus
binary in OCI registry using oras and download it from there.
This reduces the install time from ~1m40s to ~15s.