### PR TITLE
genpolicy: prevent corruption of the layer cache file

### DIFF
--- a/src/tools/genpolicy/src/layers_cache.rs
+++ b/src/tools/genpolicy/src/layers_cache.rs
@@ -1,0 +1,97 @@
+// Copyright (c) 2025 Edgeless Systems GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use crate::registry::ImageLayer;
+
+use fs2::FileExt;
+use log::{debug, warn};
+use std::fs::OpenOptions;
+use std::sync::{Arc, Mutex};
+
+#[derive(Debug, Clone)]
+pub struct ImageLayersCache {
+    inner: Arc<Mutex<Vec<ImageLayer>>>,
+    filename: Option<String>,
+}
+
+impl ImageLayersCache {
+    pub fn new(layers_cache_file_path: &Option<String>) -> Self {
+        let layers = match ImageLayersCache::try_new(layers_cache_file_path) {
+            Ok(layers) => layers,
+            Err(e) => {
+                warn!("Could not read image layers cache: {e}");
+                Vec::new()
+            }
+        };
+        Self {
+            inner: Arc::new(Mutex::new(layers)),
+            filename: layers_cache_file_path.clone(),
+        }
+    }
+
+    fn try_new(layers_cache_file_path: &Option<String>) -> std::io::Result<Vec<ImageLayer>> {
+        match &layers_cache_file_path {
+            Some(filename) => {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .create(true)
+                    .truncate(false)
+                    .open(filename)?;
+                // Using try_lock_shared allows this genpolicy instance to make progress even if another concurrent instance holds a lock.
+                // In this case, the cache will simply not be used for this instance.
+                FileExt::try_lock_shared(&file)?;
+
+                let initial_state: Vec<ImageLayer> = match serde_json::from_reader(&file) {
+                    Ok(data) => data,
+                    Err(e) if e.is_eof() => Vec::new(), // empty file
+                    Err(e) => {
+                        FileExt::unlock(&file)?;
+                        return Err(e.into());
+                    }
+                };
+                FileExt::unlock(&file)?;
+                Ok(initial_state)
+            }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    pub fn get_layer(&self, diff_id: &str) -> Option<ImageLayer> {
+        let layers = self.inner.lock().unwrap();
+        layers
+            .iter()
+            .find(|layer| layer.diff_id == diff_id)
+            .cloned()
+    }
+
+    pub fn insert_layer(&self, layer: &ImageLayer) {
+        let mut layers = self.inner.lock().unwrap();
+        layers.push(layer.clone());
+    }
+
+    pub fn persist(&self) {
+        if let Err(e) = self.try_persist() {
+            warn!("Could not persist image layers cache: {e}");
+        }
+    }
+
+    fn try_persist(&self) -> std::io::Result<()> {
+        let Some(ref filename) = self.filename else {
+            return Ok(());
+        };
+        debug!("Persisting image layers cache...");
+        let layers = self.inner.lock().unwrap();
+        let file = OpenOptions::new()
+            .write(true)
+            .truncate(true)
+            .create(true)
+            .open(filename)?;
+        FileExt::try_lock_exclusive(&file)?;
+        serde_json::to_writer_pretty(&file, &*layers)?;
+        FileExt::unlock(&file)?;
+        Ok(())
+    }
+}

--- a/src/tools/genpolicy/src/lib.rs
+++ b/src/tools/genpolicy/src/lib.rs
@@ -9,6 +9,7 @@ pub mod cronjob;
 pub mod daemon_set;
 pub mod deployment;
 pub mod job;
+pub mod layers_cache;
 pub mod list;
 pub mod mount_and_storage;
 pub mod no_policy;

--- a/src/tools/genpolicy/src/main.rs
+++ b/src/tools/genpolicy/src/main.rs
@@ -11,6 +11,7 @@ mod cronjob;
 mod daemon_set;
 mod deployment;
 mod job;
+mod layers_cache;
 mod list;
 mod mount_and_storage;
 mod no_policy;
@@ -52,5 +53,6 @@ async fn main() {
 
     debug!("Exporting policy to yaml file...");
     policy.export_policy();
+    config.layers_cache.persist();
     info!("Success!");
 }

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use crate::layers_cache;
 use crate::settings;
 use clap::Parser;
 
@@ -123,7 +124,7 @@ pub struct Config {
     pub raw_out: bool,
     pub base64_out: bool,
     pub containerd_socket_path: Option<String>,
-    pub layers_cache_file_path: Option<String>,
+    pub layers_cache: layers_cache::ImageLayersCache,
     pub version: bool,
 }
 
@@ -161,7 +162,7 @@ impl Config {
             raw_out: args.raw_out,
             base64_out: args.base64_out,
             containerd_socket_path: args.containerd_socket_path,
-            layers_cache_file_path,
+            layers_cache: layers_cache::ImageLayersCache::new(&layers_cache_file_path),
             version: args.version,
         }
     }

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -73,7 +73,7 @@ mod tests {
             config_files: None,
             containerd_socket_path: None, // Some(String::from("/var/run/containerd/containerd.sock")),
             insecure_registries: Vec::new(),
-            layers_cache_file_path: None,
+            layers_cache: genpolicy::layers_cache::ImageLayersCache::new(&None),
             raw_out: false,
             rego_rules_path: workdir.join("rules.rego").to_str().unwrap().to_string(),
             runtime_class_names: Vec::new(),


### PR DESCRIPTION
We have been experiencing sporadic corruption of the layer cache file. Applying `genpolicy --use-cached-files` to this `deployment.yaml` and initial state of the layer cache `layers-cache.json`:

```yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: whatever
spec:
  template:
    spec:
      runtimeClassName: contrast-cc
      containers:
        - name: secret-service
          image: 'ghcr.io/edgelesssys/privatemode/secret-service:v1.17.0@sha256:e36c9f13932f46e2fd460c5469dd4ee22bcdbaefd4b576d985f9e9a435413d3b'
```

```json
[
  {
    "diff_id": "sha256:fa6a52ec54152fea01d1e53fa5b2447fcc2004d56414f23830fe4536b8b3f823",
    "verity_hash": "e25c3d85b5ef4fb029b338b0eef3c4d5f29ffabb7d0aa27a2a8130e06fdd8190",
    "passwd": "root:x:0:0:root:/root:/bin/ash\nbin:x:1:1:bin:/bin:/sbin/nologin\ndaemon:x:2:2:daemon:/sbin:/sbin/nologin\nadm:x:3:4:adm:/var/adm:/sbin/nologin\nlp:x:4:7:lp:/var/spool/lpd:/sbin/nologin\nsync:x:5:0:sync:/sbin:/bin/sync\nshutdown:x:6:0:shutdown:/sbin:/sbin/shutdown\nhalt:x:7:0:halt:/sbin:/sbin/halt\nmail:x:8:12:mail:/var/mail:/sbin/nologin\nnews:x:9:13:news:/usr/lib/news:/sbin/nologin\nuucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin\noperator:x:11:0:operator:/root:/sbin/nologin\nman:x:13:15:man:/usr/man:/sbin/nologin\npostmaster:x:14:12:postmaster:/var/mail:/sbin/nologin\ncron:x:16:16:cron:/var/spool/cron:/sbin/nologin\nftp:x:21:21::/var/lib/ftp:/sbin/nologin\nsshd:x:22:22:sshd:/dev/null:/sbin/nologin\nnobody:x:65534:65534:nobody:/:/sbin/nologin\nnonroot:x:65532:65532:Account created by apko:/home/nonroot:/bin/sh\nnotebook-user:x:1000:1000::/home/notebook-user:/bin/ash\n",
    "group": "root:x:0:root\nbin:x:1:root,bin,daemon\ndaemon:x:2:root,bin,daemon\nsys:x:3:root,bin,adm\nadm:x:4:root,adm,daemon\ntty:x:5:\ndisk:x:6:root,adm\nlp:x:7:lp\nmem:x:8:\nkmem:x:9:\nwheel:x:10:root\nfloppy:x:11:root\nmail:x:12:mail\nnews:x:13:news\nuucp:x:14:uucp\nman:x:15:man\ncron:x:16:cron\nconsole:x:17:\naudio:x:18:\ncdrom:x:19:\ndialout:x:20:root\nftp:x:21:\nsshd:x:22:\ninput:x:23:\nat:x:25:at\ntape:x:26:root\nvideo:x:27:root\nnetdev:x:28:\nreadproc:x:30:\nkvm:x:34:kvm\ngames:x:35:\nshadow:x:42:\ncdrw:x:80:\nusb:x:85:\nntp:x:123:\nnofiles:x:200:\nsmmsp:x:209:smmsp\nlocate:x:245:\nutmp:x:406:\nnogroup:x:65533:\nnobody:x:65534:\nnonroot:x:65532:\nnotebook-user:x:1000:notebook-user\n"
}
]
```

reproduces the error by generating this corrupted `layers-cache.json` in version `3.16.0` of `kata-containers`:

```json
[
  {
    "diff_id": "sha256:8f061a335e1d6c822399a78168ba847edc75ec8703a064418b21cbb2a8fbf867",
    "verity_hash": "18a84da98e284198dea7b85dd48d5622cd276bdcf4471cf5d4e37f582bfb2c17",
    "passwd": ""
  }
]
:0:root:/root:/bin/ash\nbin:x:1:1:bin:/bin:/sbin/nologin\ndaemon:x:2:2:daemon:/sbin:/sbin/nologin\nadm:x:3:4:adm:/var/adm:/sbin/nologin\nlp:x:4:7:lp:/var/spool/lpd:/sbin/nologin\nsync:x:5:0:sync:/sbin:/bin/sync\nshutdown:x:6:0:shutdown:/sbin:/sbin/shutdown\nhalt:x:7:0:halt:/sbin:/sbin/halt\nmail:x:8:12:mail:/var/mail:/sbin/nologin\nnews:x:9:13:news:/usr/lib/news:/sbin/nologin\nuucp:x:10:14:uucp:/var/spool/uucppublic:/sbin/nologin\noperator:x:11:0:operator:/root:/sbin/nologin\nman:x:13:15:man:/usr/man:/sbin/nologin\npostmaster:x:14:12:postmaster:/var/mail:/sbin/nologin\ncron:x:16:16:cron:/var/spool/cron:/sbin/nologin\nftp:x:21:21::/var/lib/ftp:/sbin/nologin\nsshd:x:22:22:sshd:/dev/null:/sbin/nologin\nnobody:x:65534:65534:nobody:/:/sbin/nologin\nnonroot:x:65532:65532:Account created by apko:/home/nonroot:/bin/sh\nnotebook-user:x:1000:1000::/home/notebook-user:/bin/ash\n"
  },
  {
    "diff_id": "sha256:e67c36428ee0de777e8ec5f7d73483f58854bd361026979b6937b631e2725f7a",
    "verity_hash": "e1fa97319b42f0f53fc07cbc2308e7a3d790aab2d35a2aa3820ec00b706e5efb",
    "passwd": ""
  }
]
loppy:x:11:root\nmail:x:12:mail\nnews:x:13:news\nuucp:x:14:uucp\nman:x:15:man\ncron:x:16:cron\nconsole:x:17:\naudio:x:18:\ncdrom:x:19:\ndialout:x:20:root\nftp:x:21:\nsshd:x:22:\ninput:x:23:\nat:x:25:at\ntape:x:26:root\nvideo:x:27:root\nnetdev:x:28:\nreadproc:x:30:\nkvm:x:34:kvm\ngames:x:35:\nshadow:x:42:\ncdrw:x:80:\nusb:x:85:\nntp:x:123:\nnofiles:x:200:\nsmmsp:x:209:smmsp\nlocate:x:245:\nutmp:x:406:\nnogroup:x:65533:\nnobody:x:65534:\nnonroot:x:65532:\nnotebook-user:x:1000:notebook-user\n"
}
```

Following 349ce8c33940cf95337857171fde900e7e6863b4 this example no longer exhibits the behavior. In the linked commit, the user and group parsing was refactored and improved.

However, for very long strings (in otherwise valid cache files), the same behavior can still be reproduced on the tip of main.

An (ugly) script to generate such a file:
```bash
USER_COUNT=7000  # 7k worked for me - depending on your machine, fewer might suffice or more ight be necessary
TMP_USERS=""

for i in $(seq 1 "$USER_COUNT"); do
    username="user-$i"
    uid=$((1000 + i))
    gid=$((1000 + i))

    passwd_entry="$username:x:$uid:$gid::/home/$username:/bin/ash\\n"
    group_entry="$username:x:$gid:$username\\n"

    user_json=$(jq -n \
        --arg user "$username" \
        --arg passwd "$passwd_entry" \
        --arg group "$group_entry" \
        '{username: $user, passwd: $passwd, group: $group}')

    TMP_USERS="${TMP_USERS}${user_json},"
done

final_json="[${TMP_USERS%,}]"
echo "$final_json" > test_users.json
```

The changes in this PR fix the issue. The root cause is that `fs2` only obtains a file lock during write. Since it's an exclusive lock, it should prevent concurrent writes; however, at other points in the code, no lock is acquired to read (or delete) the file. Since `fs2` implements advisory locks (through `flock` on UNIX systems), different threads/processes are still able to read/delete while the lock is supposed to be held elsewhere.

A large number of users and groups seems to take sufficient time to parse to reproduce this error reliably.

To be honest, I am not entirely certain how exactly the corruption of the file occurs, since only one concurrent write should be possible in the current implementation. Maybe someone here has deeper insight into this.
