### PR TITLE
rootfs: Bump rootfs-{image,initrd} to 24.04

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -12,6 +12,7 @@ PACKAGES="chrony iptables dbus"
 [ "$AGENT_INIT" = no ] && PACKAGES+=" init"
 [ "$MEASURED_ROOTFS" = yes ] && PACKAGES+=" cryptsetup-bin e2fsprogs"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp2"
+[ "$(uname -m)" = "s390x" ] && PACKAGES+=" libcurl4 libnghttp2-14"
 REPO_COMPONENTS=${REPO_COMPONENTS:-main}
 
 case "$ARCH" in

--- a/versions.yaml
+++ b/versions.yaml
@@ -122,25 +122,25 @@ assets:
     architecture:
       aarch64:
         name: "ubuntu"
-        version: "jammy"  # 22.04 LTS
+        version: "noble"  # 24.04 LTS
         nvidia-gpu:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
         nvidia-gpu-confidential:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
       ppc64le:
         name: "ubuntu"
-        version: "jammy"  # 22.04 LTS
+        version: "noble"  # 24.04 LTS
       s390x:
         name: "ubuntu"
-        version: "jammy"  # 22.04 LTS
+        version: "noble"  # 24.04 LTS
         confidential:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
       x86_64:
         name: "ubuntu"
-        version: "jammy"  # 22.04 lTS
+        version: "noble"  # 24.04 LTS
         confidential:
           name: "ubuntu"
           version: "noble"  # 24.04 LTS
@@ -149,10 +149,10 @@ assets:
           version: "3.0"
         nvidia-gpu:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
         nvidia-gpu-confidential:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
 
   initrd:
     description: |
@@ -165,21 +165,21 @@ assets:
         version: "3.18"
         nvidia-gpu:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
         nvidia-gpu-confidential:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
       # Do not use Alpine on ppc64le & s390x, the agent cannot use musl because
       # there is no such Rust target
       ppc64le:
         name: "ubuntu"
-        version: "jammy"  # 22.04 LTS
+        version: "noble"  # 24.04 LTS
       s390x:
         name: "ubuntu"
-        version: "jammy"  # 22.04 LTS
+        version: "noble"  # 24.04 LTS
         confidential:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
       x86_64:
         name: "alpine"
         version: "3.18"
@@ -188,10 +188,10 @@ assets:
           version: "noble"  # 24.04 LTS
         nvidia-gpu:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
         nvidia-gpu-confidential:
           name: "ubuntu"
-          version: "jammy"  # 22.04 LTS
+          version: "noble"  # 24.04 LTS
 
   kernel:
     description: "Linux kernel optimised for virtual machines"


### PR DESCRIPTION
Since #11197 was merged, all confidential k8s e2e tests for s390x have been failing with the following errors:

```
attestation-agent: error while loading shared libraries:
libcurl.so.4: cannot open shared object file
libnghttp2.so.14: cannot open shared object file
```

In line with the update on x86_64, we need to upgrade the OS used in rootfs-{image,initrd} on s390x.
This PR also bumps all 22.04 to 24.04 for all architectures.
For s390x, this ensures the  missing packages listed above are installed.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>