### PR TITLE
versions: Bump golang to 1.23.10

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.7
+        go-version: 1.23.10
     - name: Checkout code
       uses: actions/checkout@v4
       with:

--- a/.github/workflows/docs-url-alive-check.yaml
+++ b/.github/workflows/docs-url-alive-check.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@v5
       with:
-        go-version: 1.23.7
+        go-version: 1.23.10
       env:
         GOPATH: ${{ github.workspace }}/kata-containers
     - name: Set env

--- a/versions.yaml
+++ b/versions.yaml
@@ -397,12 +397,12 @@ languages:
   golang:
     description: "Google's 'go' language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.23.7"
+    version: "1.23.10"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.23.7"
+      newest-version: "1.23.10"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
Bump golang to fix CVEs GO-2025-3751
and GO-2025-3563