### PR TITLE
workflows: Add fail-fast: false to cri-containerd tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -419,6 +419,7 @@ jobs:
     if: ${{ inputs.skip-test != 'yes' }}
     needs: build-kata-static-tarball-amd64
     strategy:
+      fail-fast: false
       matrix:
         params: [
           { containerd_version: lts,    vmm: clh              },
@@ -448,6 +449,7 @@ jobs:
     if: ${{ inputs.skip-test != 'yes' }}
     needs: build-kata-static-tarball-s390x
     strategy:
+      fail-fast: false
       matrix:
         params: [
           { containerd_version: active, vmm: qemu            },
@@ -467,6 +469,7 @@ jobs:
     if: ${{ inputs.skip-test != 'yes' }}
     needs: build-kata-static-tarball-ppc64le
     strategy:
+      fail-fast: false
       matrix:
         params: [
           { containerd_version: active, vmm: qemu },
@@ -485,6 +488,7 @@ jobs:
     if: ${{ inputs.skip-test != 'yes' }}
     needs: build-kata-static-tarball-arm64
     strategy:
+      fail-fast: false
       matrix:
         params: [
           { containerd_version: active, vmm: qemu },


### PR DESCRIPTION
At the moment if any of the tests in the matric fails then the rest of the jobs are cancelled, so we have to re-run everything. Add `fail-fast: false` to stop this behaviour.