### PR TITLE
runtime: improve EROFS snapshotter support

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -315,7 +315,7 @@ func checkAndMount(s *service, r *taskAPI.CreateTaskRequest) (bool, error) {
 			return false, nil
 		}
 
-		if virtcontainers.HasErofsOptions(m.Options) {
+		if virtcontainers.IsErofsRootFS(virtcontainers.RootFs{Options: m.Options, Type: m.Type}) {
 			return false, nil
 		}
 

--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -130,7 +130,7 @@ func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec specs.Spec, runtimeCo
 	}
 
 	if !rootFs.Mounted && len(sandboxConfig.Containers) == 1 {
-		if rootFs.Source != "" && !vc.HasOptionPrefix(rootFs.Options, vc.VirtualVolumePrefix) && !vc.HasErofsOptions(rootFs.Options) {
+		if rootFs.Source != "" && !vc.HasOptionPrefix(rootFs.Options, vc.VirtualVolumePrefix) && !vc.IsErofsRootFS(rootFs) {
 			realPath, err := ResolvePath(rootFs.Source)
 			if err != nil {
 				return nil, vc.Process{}, err
@@ -244,7 +244,7 @@ func CreateContainer(ctx context.Context, sandbox vc.VCSandbox, ociSpec specs.Sp
 	}
 
 	if !rootFs.Mounted {
-		if rootFs.Source != "" && !vc.IsNydusRootFSType(rootFs.Type) && !vc.HasErofsOptions(rootFs.Options) {
+		if rootFs.Source != "" && !vc.IsNydusRootFSType(rootFs.Type) && !vc.IsErofsRootFS(rootFs) {
 			realPath, err := ResolvePath(rootFs.Source)
 			if err != nil {
 				return vc.Process{}, err

--- a/src/runtime/virtcontainers/fs_share_linux.go
+++ b/src/runtime/virtcontainers/fs_share_linux.go
@@ -626,7 +626,7 @@ func (f *FilesystemShare) ShareRootFilesystem(ctx context.Context, c *Container)
 		return f.shareRootFilesystemWithNydus(ctx, c)
 	}
 
-	if HasErofsOptions(c.rootFs.Options) {
+	if IsErofsRootFS(c.rootFs) {
 		return f.shareRootFilesystemWithErofs(ctx, c)
 	}
 

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -2703,9 +2703,13 @@ func IsNydusRootFSType(s string) bool {
 	return strings.HasPrefix(path.Base(s), "nydus-overlayfs")
 }
 
-// HasErofsOptions checks if any of the options contain io.containerd.snapshotter.v1.erofs path
-func HasErofsOptions(options []string) bool {
-	for _, opt := range options {
+// IsErofsRootFS checks if any of the options contain io.containerd.snapshotter.v1.erofs path
+func IsErofsRootFS(root RootFs) bool {
+	// TODO: support containerd mount manager: https://github.com/containerd/containerd/issues/11303
+	if root.Type != "overlay" {
+		return false
+	}
+	for _, opt := range root.Options {
 		if strings.Contains(opt, "io.containerd.snapshotter.v1.erofs") {
 			return true
 		}
@@ -2713,21 +2717,15 @@ func HasErofsOptions(options []string) bool {
 	return false
 }
 
-func parseRootFsOptions(options []string) []string {
+func parseErofsRootFsOptions(options []string) []string {
 	lowerdirs := []string{}
 
 	for _, opt := range options {
 		if strings.HasPrefix(opt, "lowerdir=") {
 			lowerdirValue := strings.TrimPrefix(opt, "lowerdir=")
 
-			paths := strings.Split(lowerdirValue, ":")
-
-			for _, path := range paths {
-				path = strings.TrimSuffix(path, "/fs")
-				lowerdirs = append(lowerdirs, path)
-			}
+			lowerdirs = append(lowerdirs, strings.Split(lowerdirValue, ":")...)
 		}
 	}
-
 	return lowerdirs
 }


### PR DESCRIPTION
To better support containerd 2.1 and later versions, remove the hardcoded `layer.erofs` and instead parse `/proc/mounts` to obtain the real mount source (and `/sys/block/loopX/loop/backing_file` if needed).

If the mount source doesn't end with `layer.erofs`, it should be marked as unsupported, as it may be a filesystem meta file generated by later containerd versions for the EROFS flattened filesystem feature.

Also check whether the filesystem type is `overlay` or not, since the containerd mount manager [1] may change it after being introduced.

[1] https://github.com/containerd/containerd/issues/11303