### PR TITLE
workflows: Add extra permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,6 +66,8 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write
+      attestations: write
     uses: ./.github/workflows/release-ppc64le.yaml
     with:
       target-arch: ppc64le


### PR DESCRIPTION
Add permissions to the ppc release to match the other arches