### PR TITLE
workflows: Release permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # needed for the `gh release create` command
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -77,6 +79,8 @@ jobs:
   publish-multi-arch-images:
     runs-on: ubuntu-22.04
     needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le]
+    permissions:
+      contents: write # needed for the `gh release` commands
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -110,6 +114,8 @@ jobs:
 
   upload-multi-arch-static-tarball:
     needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le]
+    permissions:
+      contents: write # needed for the `gh release` commands
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
@@ -173,6 +179,8 @@ jobs:
   upload-versions-yaml:
     needs: release
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # needed for the `gh release` commands
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -188,6 +196,8 @@ jobs:
   upload-cargo-vendored-tarball:
     needs: release
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # needed for the `gh release` commands
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -203,6 +213,8 @@ jobs:
   upload-libseccomp-tarball:
     needs: release
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # needed for the `gh release` commands
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -218,6 +230,9 @@ jobs:
   upload-helm-chart-tarball:
     needs: release
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # needed for the `gh release` commands
+      packages: write # needed to push the helm chart to ghcr.io
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -248,6 +263,8 @@ jobs:
   publish-release:
     needs: [ build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le, publish-multi-arch-images, upload-multi-arch-static-tarball, upload-versions-yaml, upload-cargo-vendored-tarball, upload-libseccomp-tarball ]
     runs-on: ubuntu-22.04
+    permissions:
+      contents: write # needed for the `gh release` commands
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
Add more permissions to the release workflow
in order to enable `gh release` commands to run