### PR TITLE
osbuilder: Update image-builder base to f42

### DIFF
--- a/tools/osbuilder/image-builder/Dockerfile
+++ b/tools/osbuilder/image-builder/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ARG IMAGE_REGISTRY=registry.fedoraproject.org
-FROM ${IMAGE_REGISTRY}/fedora:40
+FROM ${IMAGE_REGISTRY}/fedora:42
 
 RUN ([ -n "$http_proxy" ] && \
     sed -i '$ a proxy='$http_proxy /etc/dnf/dnf.conf ; true) && \


### PR DESCRIPTION
Fedora 40 is EoL, and I've seen the registry pull fail a few times recently, so let's bump to fedora 42 which has 10 months of support left.