### PR TITLE
tests: update container image for ci test

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-layered-sc-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-layered-sc-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         runAsGroup: 2000
       containers:
       - name: master
-        image: quay.io/opstree/redis@sha256:2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48
+        image: quay.io/opstree/redis:v7.2.7
         securityContext:
           runAsUser: 3000
         resources:

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-deployment.yaml
@@ -30,7 +30,7 @@ spec:
         runAsGroup: 2000
       containers:
       - name: master
-        image: quay.io/opstree/redis@sha256:2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48
+        image: quay.io/opstree/redis:v7.2.7
         resources:
           requests:
             cpu: 100m

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-nobodyupdate-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-nobodyupdate-deployment.yaml
@@ -29,7 +29,7 @@ spec:
         runAsUser: 65534
       containers:
       - name: master
-        image: quay.io/opstree/redis@sha256:2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48
+        image: quay.io/opstree/redis:v7.2.7
         resources:
           requests:
             cpu: 100m

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-supplementalgroups-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-supplementalgroups-deployment.yaml
@@ -34,7 +34,7 @@ spec:
           - 999
       containers:
       - name: master
-        image: quay.io/opstree/redis@sha256:2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48
+        image: quay.io/opstree/redis:v7.2.7
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
This patch updates the container image for the CI
test workloads:
- `k8s-layered-sc-deployment.yaml`
- `k8s-pod-sc-deployment.yaml`
- `k8s-pod-sc-nobodyupdate-deployment.yaml`
- `k8s-pod-sc-supplementalgroups-deployment.yaml`

This fixes tests failing due to image pull error
as the previous image version is not available in
the container registry.