### PR TITLE
runtime-rs: fix the issue return the wrong volume

### DIFF
--- a/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
@@ -150,7 +150,7 @@ pub(crate) fn is_block_rootfs(m: &Mount) -> Option<(u64, Mount)> {
                 //clear the volume resource thus the block device will use the dev_id
                 //to find the device's host path;
                 volume.source = String::new();
-                return Some((dev_id, m.clone()));
+                return Some((dev_id, volume));
             }
 
             if SFlag::from_bits_truncate(fstat.st_mode) == SFlag::S_IFREG


### PR DESCRIPTION
In the pre commit:74eccc54e7b31cc4c9abd8b6e4007c3a4c1d4dd4, it missed return the right rootfs volume.

In the is_block_rootfs fn, if the rootfs is based on a block device such as devicemapper, it should clear the volume's source and let the device_manager to use the dev_id to get the device's host path.