### PR TITLE
runtime-rs: Support shared fs with "none" on non-tee platforms

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -389,7 +389,9 @@ impl QemuInner {
         let mut caps = Capabilities::default();
 
         // Confidential Guest doesn't permit virtio-fs.
-        let flags = if self.hypervisor_config().security_info.confidential_guest {
+        let flags = if self.hypervisor_config().security_info.confidential_guest
+            || self.hypervisor_config().shared_fs.shared_fs.is_none()
+        {
             CapabilityBits::BlockDeviceSupport | CapabilityBits::BlockDeviceHotplugSupport
         } else {
             CapabilityBits::BlockDeviceSupport


### PR DESCRIPTION
This commit introduces the ability to run Pods without shared fs mechanism in Kata.

The default shared fs can lead to unnecessary resource consumption and security risks for certain use cases. Specifically, scenarios where files only need to be copied into the VM once at Pod creation (e.g., non-tee envs) and don't require dynamic updates make the shared fs redundant and inefficient.

By explicitly disabling shared fs functionality, we reduce resource overhead and shrink the attack surface. Users will need to employ alternative methods(e.g. guest-pull) to ensure container images are shared into the guest VM for these specific scenarios.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>