### PR TITLE
tools: kata-monitor: update go version used to build in Dockerfile

### DIFF
--- a/tools/packaging/kata-monitor/Dockerfile
+++ b/tools/packaging/kata-monitor/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Eric Ernst
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.19-alpine AS builder
+FROM golang:1.23-alpine AS builder
 
 RUN apk add --no-cache bash curl git make build-base
 WORKDIR /go/src/github.com/kata-containers/kata-containers/src/runtime


### PR DESCRIPTION
Current Dockerfile fails when trying to build from the root of the repo docker build -t kata-monitor -f tools/packaging/kata-monitor/Dockerfile . with "invalid go version '1.23.0': must match format 1.23"

Using go 1.23 in the Dockerfile fixes the build error