### PR TITLE
kata-types: Relax Mandatory source Field Check in Guest-Pull Mode

### DIFF
--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -9,6 +9,7 @@ use std::convert::TryFrom;
 use std::{collections::HashMap, fs, path::PathBuf};
 
 use crate::handler::HandlerManager;
+use crate::sl;
 
 /// Prefix to mark a volume as Kata special.
 pub const KATA_VOLUME_TYPE_PREFIX: &str = "kata:";
@@ -353,7 +354,7 @@ impl KataVirtualVolume {
             }
             KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL => {
                 if self.source.is_empty() {
-                    return Err(anyhow!("missing image reference for guest pulling volume"));
+                    warn!(sl!(), "missing image reference for guest pulling volume");
                 }
             }
             _ => {}


### PR DESCRIPTION
Previously, the source field was subject to mandatory checks. However, in guest-pull mode, this field doesn't consistently provide useful information. Our practical experience has shown that relying on this field for critical data isn't always necessary.

This commit relaxes the mandatory checks on the source field specifically for guest-pull mode, acknowledging its diminished utility in this context.

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>