### PR TITLE
runtime-rs: Add support for overhead cgroup on host

### DIFF
--- a/src/runtime-rs/crates/resource/src/cgroups/ops.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/ops.rs
@@ -1,0 +1,98 @@
+// Copyright (c) 2019-2025 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io;
+
+use anyhow::{anyhow, Context, Error, Result};
+use cgroups_rs::Cgroup;
+
+use crate::cgroups::CgroupsResource;
+
+pub(crate) fn delete_v1_cgroups(resource: &CgroupsResource) -> Result<()> {
+    move_tasks_to_root(&resource.cgroup_manager).context("move tasks in sandbox cgroup to root")?;
+    resource
+        .cgroup_manager
+        .delete()
+        .context("delete sandbox cgroup")?;
+
+    if let Some(overhead) = resource.overhead_cgroup_manager.as_ref() {
+        move_tasks_to_root(overhead).context("move tasks in overhead cgroup to root")?;
+        overhead.delete().context("delete overhead cgroup")?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn delete_v2_cgroups(resource: &CgroupsResource) -> Result<()> {
+    let mut cgroup = resource.cgroup_manager.clone();
+
+    // Move all threads from the sandbox and overhead to their parent,
+    // then delete them all, and back to their parent cgroup.
+    if resource.cgroup_config.threaded_mode() {
+        move_tasks_to_parent(&cgroup).context("move tasks in sandbox cgroup to parent")?;
+        cgroup.delete().context("delete sandbox cgroup")?;
+        if let Some(overhead) = resource.overhead_cgroup_manager.as_ref() {
+            move_tasks_to_parent(overhead).context("move tasks in overhead cgroup to parent")?;
+            overhead.delete().context("delete overhead cgroup")?;
+        }
+        // Go back to the parent
+        cgroup = cgroup.parent_control_group();
+    }
+
+    move_procs_to_root(&cgroup).context("move procs to root")?;
+    cgroup.delete().context("delete sandbox cgroup")?;
+
+    Ok(())
+}
+
+fn move_tasks_to_root(cgroup: &Cgroup) -> Result<()> {
+    for pid in cgroup.tasks() {
+        let pid_raw = pid.pid;
+        if let Err(err) = cgroup
+            .remove_task(pid)
+            .with_context(|| anyhow!("remove task {}", pid_raw))
+        {
+            ignore_esrch_error(err)?;
+        }
+    }
+    Ok(())
+}
+
+fn move_procs_to_root(cgroup: &Cgroup) -> Result<()> {
+    for tgid in cgroup.procs() {
+        let tgid_raw = tgid.pid;
+        if let Err(err) = cgroup
+            .remove_task_by_tgid(tgid)
+            .with_context(|| anyhow!("remove proc {}", tgid_raw))
+        {
+            ignore_esrch_error(err)?;
+        }
+    }
+    Ok(())
+}
+
+fn move_tasks_to_parent(cgroup: &Cgroup) -> Result<()> {
+    for pid in cgroup.tasks() {
+        let pid_raw = pid.pid;
+        if let Err(err) = cgroup
+            .move_task_to_parent(pid)
+            .with_context(|| anyhow!("remove task {} to parent", pid_raw))
+        {
+            ignore_esrch_error(err)?;
+        }
+    }
+    Ok(())
+}
+
+fn ignore_esrch_error(err: Error) -> Result<()> {
+    if let Some(err) = err.source() {
+        if let Some(io_err) = err.downcast_ref::<io::Error>() {
+            if io_err.raw_os_error() == Some(libc::ESRCH) {
+                return Ok(());
+            }
+        }
+    }
+    Err(err)
+}

--- a/src/runtime-rs/crates/resource/src/cgroups/utils.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/utils.rs
@@ -4,13 +4,46 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-// When the Kata overhead threads (I/O, VMM, etc) are not
-// placed in the sandbox resource controller (A cgroup on Linux),
-// they are moved to a specific, unconstrained resource controller.
-// On Linux, assuming the cgroup mount point is at /sys/fs/cgroup/,
-// on a cgroup v1 system, the Kata overhead memory cgroup will be at
-// /sys/fs/cgroup/memory/kata_overhead/$CGPATH where $CGPATH is
-// defined by the orchestrator.
-pub(crate) fn gen_overhead_path(path: &str) -> String {
-    format!("kata_overhead/{}", path.trim_start_matches('/'))
+use oci_spec::runtime::Spec;
+
+const SANDBOXED_CGROUP_PATH: &str = "kata_sandboxed_pod";
+
+/// Returns cgroup paths for sandbox and overhead, even though we don't
+/// need the overhead.
+///
+/// For cgroup v1
+/// - sandbox: "/sys/fs/cgroup/{subsystem}/{base}" (relative "{base}")
+/// - overhead: "/sys/fs/cgroup/{subsystem}/kata_overhead/{sid}" (relative
+///   "kata_overhead/{sid}")
+///
+/// For cgroup v2
+/// - sandbox: "/sys/fs/cgroup/{base}/sandbox" (relative "{base}/sandbox")
+/// - overhead: "/sys/fs/cgroup/{base}/overhead" (relative
+///   "{base}/overhead")
+///
+/// # Returns
+///  `(String, String)`: The first one is the sandbox cgroup path
+///  (relative), and the second one is the overhead cgroup path (relative).
+pub(crate) fn new_cgroup_paths(sid: &str, spec: Option<&Spec>, v2: bool) -> (String, String) {
+    let base = if let Some(spec) = spec {
+        spec.linux()
+            .clone()
+            .and_then(|linux| linux.cgroups_path().clone())
+            .map(|path| {
+                // The trim of '/' is important, because cgroup_path is a relative path.
+                path.display()
+                    .to_string()
+                    .trim_start_matches('/')
+                    .to_string()
+            })
+            .unwrap_or_default()
+    } else {
+        format!("{}/{}", SANDBOXED_CGROUP_PATH, sid)
+    };
+
+    if v2 {
+        (format!("{}/sandbox", base), format!("{}/overhead", base))
+    } else {
+        (base, format!("kata_overhead/{}", sid))
+    }
 }


### PR DESCRIPTION
Cgroup v2 introduces "threaded mode", which allows control of controllers
at the thread level. We can move non-user workloads, such as the shim, to
the overhead cgroup, and move user workloads to the sandbox cgroup. For
more information about the design of host cgroup, see [1].

Credit: The work builds upon the previous work [2] by @yaoyinnan.

1: https://github.com/kata-containers/kata-containers/blob/main/docs/design/host-cgroups.md
2: https://github.com/kata-containers/kata-containers/pull/5491

Fixes: #11356

Signed-off-by: yaoyinnan <yaoyinnan@foxmail.com>
Signed-off-by: Xuewei Niu <niuxuewei.nxw@antgroup.com>