### PR TITLE
runtime-rs: Add GPU annotations for remote hypervisor

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -276,6 +276,14 @@ pub const KATA_ANNO_CFG_HYPERVISOR_MSIZE_9P: &str = "io.katacontainers.config.hy
 pub const KATA_ANNO_CFG_HYPERVISOR_INIT_DATA: &str =
     "io.katacontainers.config.hypervisor.cc_init_data";
 
+/// GPU specific annotations for remote hypervisor to help with instance selection
+/// It's for minimum number of GPUs required for the VM.
+pub const KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPUS: &str =
+    "io.katacontainers.config.hypervisor.default_gpus";
+/// It's for the GPU model(tesla, h100, a100, radeon etc.) required for the VM.
+pub const KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPU_MODEL: &str =
+    "io.katacontainers.config.hypervisor.default_gpu_model";
+
 // Runtime related annotations
 /// Prefix for Runtime configurations.
 pub const KATA_ANNO_CFG_RUNTIME_PREFIX: &str = "io.katacontainers.config.runtime.";
@@ -887,6 +895,17 @@ impl Annotation {
                     KATA_ANNO_CFG_HYPERVISOR_INIT_DATA => {
                         hv.security_info.initdata =
                             add_hypervisor_initdata_overrides(value).unwrap();
+                    }
+                    KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPUS => match self.get_value::<u32>(key) {
+                        Ok(r) => {
+                            hv.remote_info.default_gpus = r.unwrap_or_default();
+                        }
+                        Err(_e) => {
+                            return Err(u32_err);
+                        }
+                    },
+                    KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPU_MODEL => {
+                        hv.remote_info.default_gpu_model = value.to_string();
                     }
                     KATA_ANNO_CFG_HYPERVISOR_ENABLE_ROOTLESS_HYPERVISOR => {
                         match self.get_value::<bool>(key) {

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1110,6 +1110,14 @@ pub struct RemoteInfo {
     /// Remote hyperisor timeout of creating (in seconds)
     #[serde(default)]
     pub hypervisor_timeout: i32,
+
+    /// GPU specific annotations (currently only applicable for Remote Hypervisor)
+    /// default_gpus specifies the number of GPUs required for the Kata VM
+    #[serde(default)]
+    pub default_gpus: u32,
+    /// default_gpu_model specifies GPU model like tesla, h100, a100, readeon etc.
+    #[serde(default)]
+    pub default_gpu_model: String,
 }
 
 /// Common configuration information for hypervisors.

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -41,7 +41,7 @@ remote_hypervisor_timeout = 600
 # Each member of the list is a regular expression, which is the base name
 # of the annotation, e.g. "path" for io.katacontainers.config.hypervisor.path"
 # Note: Remote hypervisor is only handling the following annotations
-enable_annotations = ["machine_type", "default_memory", "default_vcpus"]
+enable_annotations = ["machine_type", "default_memory", "default_vcpus", "default_gpus", "default_gpu_model"]
 
 # Optional space-separated list of options to pass to the guest kernel.
 # For example, use `kernel_params = "vsyscall=emulate"` if you are having

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -12,6 +12,7 @@ use async_trait::async_trait;
 use kata_types::{
     annotations::{
         cri_containerd::{SANDBOX_NAMESPACE_LABEL_KEY, SANDBOX_NAME_LABEL_KEY},
+        KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPUS, KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPU_MODEL,
         KATA_ANNO_CFG_HYPERVISOR_DEFAULT_MEMORY, KATA_ANNO_CFG_HYPERVISOR_DEFAULT_VCPUS,
         KATA_ANNO_CFG_HYPERVISOR_IMAGE_PATH, KATA_ANNO_CFG_HYPERVISOR_MACHINE_TYPE,
     },
@@ -123,6 +124,14 @@ impl RemoteInner {
         annotations.insert(
             KATA_ANNO_CFG_HYPERVISOR_IMAGE_PATH.to_string(),
             config.boot_info.image.to_string(),
+        );
+        annotations.insert(
+            KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPUS.to_string(),
+            config.remote_info.default_gpus.to_string(),
+        );
+        annotations.insert(
+            KATA_ANNO_CFG_HYPERVISOR_DEFAULT_GPU_MODEL.to_string(),
+            config.remote_info.default_gpu_model.to_string(),
         );
         annotations
     }


### PR DESCRIPTION
We're introducing `default_gpus` and `default_gpu_model` as GPU annotations for kata VM configurations to improve instance selection on remote hypervisors.
By adding these annotations:
- default_gpus: Allows us to specify the minimum number of GPUs a VM requires. This ensures that the remote hypervisor selects an instance with at least that many GPUs, preventing resource under-provisioning.
- default_gpu_model: Lets us define the specific GPU model needed for the VM. This is crucial for workloads that depend on particular GPU architectures or features, ensuring compatibility and optimal performance.
Essentially, these new fields provide the remote hypervisor with the necessary intelligence to select the most appropriate instance for a given GPU VM.

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>