### PR TITLE
runtime-rs:  refactor and fix the implementation of guest-pull

### DIFF
--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -47,6 +47,9 @@ pub const SANDBOX_BIND_MOUNTS_RO: &str = ":ro";
 /// SANDBOX_BIND_MOUNTS_RO is for sandbox bindmounts with readwrite
 pub const SANDBOX_BIND_MOUNTS_RW: &str = ":rw";
 
+/// KATA_VIRTUAL_VOLUME_PREFIX is for container image guest pull
+pub const KATA_VIRTUAL_VOLUME_PREFIX: &str = "io.katacontainers.volume=";
+
 /// Directly assign a block volume to vm and mount it inside guest.
 pub const KATA_VIRTUAL_VOLUME_DIRECT_BLOCK: &str = "direct_block";
 /// Present a container image as a generic block device.
@@ -532,7 +535,7 @@ pub fn adjust_rootfs_mounts() -> Result<Vec<Mount>> {
     // Create a new Vec<Mount> with a single Mount entry.
     // This Mount's options will contain the base64-encoded virtual volume.
     Ok(vec![Mount {
-        options: vec![format!("{}={}", "io.katacontainers.volume", b64_vol)],
+        options: vec![format!("{}{}", KATA_VIRTUAL_VOLUME_PREFIX, b64_vol)],
         ..Default::default() // Use default values for other Mount fields
     }])
 }

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -387,7 +387,15 @@ impl KataVirtualVolume {
     pub fn from_base64(value: &str) -> Result<Self> {
         let json = base64::decode(value)?;
         let volume: KataVirtualVolume = serde_json::from_slice(&json)?;
+
+        Ok(volume)
+    }
+
+    /// Decode and deserialize a virtual volume object from base64 encoded json string and validate it.
+    pub fn from_base64_and_validate(value: &str) -> Result<Self> {
+        let volume = Self::from_base64(value)?;
         volume.validate()?;
+
         Ok(volume)
     }
 }
@@ -650,7 +658,8 @@ mod tests {
         volume.direct_volume = Some(DirectAssignedVolume { metadata });
 
         let value = volume.to_base64().unwrap();
-        let volume2: KataVirtualVolume = KataVirtualVolume::from_base64(value.as_str()).unwrap();
+        let volume2: KataVirtualVolume =
+            KataVirtualVolume::from_base64_and_validate(value.as_str()).unwrap();
         assert_eq!(volume.volume_type, volume2.volume_type);
         assert_eq!(volume.source, volume2.source);
         assert_eq!(volume.fs_type, volume2.fs_type);

--- a/src/runtime-rs/crates/resource/src/rootfs/virtual_volume.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/virtual_volume.rs
@@ -17,13 +17,12 @@ use hypervisor::device::device_manager::DeviceManager;
 use kata_types::{
     annotations,
     container::ContainerType,
-    mount::{KataVirtualVolume, KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL},
+    mount::{KataVirtualVolume, KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL, KATA_VIRTUAL_VOLUME_PREFIX},
 };
 
 /// Image guest-pull related consts
 const KUBERNETES_CRI_IMAGE_NAME: &str = "io.kubernetes.cri.image-name";
 const KUBERNETES_CRIO_IMAGE_NAME: &str = "io.kubernetes.cri-o.ImageName";
-const KATA_VIRTUAL_VOLUME_PREFIX: &str = "io.katacontainers.volume=";
 const KATA_VIRTUAL_VOLUME_TYPE_OVERLAY_FS: &str = "overlayfs";
 const KATA_GUEST_ROOT_SHARED_FS: &str = "/run/kata-containers/";
 


### PR DESCRIPTION
When we do force guest pull with the setting in configuration.toml:
```
...
# If enabled, the runtime will not create Kubernetes emptyDir mounts on the guest filesystem. Instead, emptyDir mounts will
# be created on the host and shared via virtio-fs. This is potentially slower, but allows sharing of files from host to guest.
disable_guest_empty_dir=false

# Enabled experimental feature list, format: ["a", "b"].
# Experimental features are features not stable enough for production,
# they may break compatibility, and are prepared for a big version bump.
# Supported experimental features:
# (default: [])
experimental=["force_guest_pull"] # add experimental feature here

# If enabled, user can run pprof tools with shim v2 process through kata-monitor.
# (default: false)
# enable_pprof = true
...
```

(1) Refactor its implementation by adding public constant values; 
(2) Fix force guest pull implementation
    - add default value for source to pass the validation.
    - Initialize image_pull with Some(xxx) to prevent skipping when serializing.




Signed-off-by: alex.lyn <alex.lyn@antgroup.com>