### PR TITLE
runtime-rs: Change default block device driver from virtio-scsi to virtio-blk-*

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -311,14 +311,15 @@ ifneq (,$(QEMUCMD))
     DEFSANDBOXCGROUPONLY_QEMU := false
 ifeq ($(ARCH), s390x)
     VMROOTFSDRIVER_QEMU := virtio-blk-ccw
+    DEFBLOCKSTORAGEDRIVER_QEMU := virtio-blk-ccw
 else
     VMROOTFSDRIVER_QEMU := virtio-pmem
+    DEFBLOCKSTORAGEDRIVER_QEMU := virtio-blk-pci
 endif
     DEFVCPUS_QEMU := 1
     DEFMAXVCPUS_QEMU := 0
     DEFSHAREDFS_QEMU_VIRTIOFS := virtio-fs
     DEFSHAREDFS_QEMU_SEL_VIRTIOFS := none
-    DEFBLOCKSTORAGEDRIVER_QEMU := virtio-scsi
     DEFBLOCKDEVICEAIO_QEMU := io_uring
     DEFNETWORKMODEL_QEMU := tcfilter
     DEFDISABLEGUESTSELINUX := true

--- a/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
+++ b/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
@@ -168,8 +168,9 @@ default_bridges = @DEFBRIDGES@
 # Default false
 #reclaim_guest_freed_memory = true
 
-# Block storage driver to be used for the hypervisor in case the container
-# rootfs is backed by a block device.
+# Block device driver to be used by the hypervisor when a container's storage
+# is backed by a block device or a file. This driver facilitates attaching the
+# storage directly to the guest VM.
 block_device_driver = "virtio-blk-pci"
 
 # Specifies cache-related options for block devices.

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -118,9 +118,11 @@ default_memory = @DEFMEMSZ@
 # > amount of physical RAM      --> will be set to the actual amount of physical RAM
 default_maxmemory = @DEFMAXMEMSZ@
 
-
-# Block storage driver to be used for the hypervisor in case the container
-# rootfs is backed by a block device. DB only supports virtio-blk.
+# Block device driver to be used by the hypervisor when a container's storage
+# is backed by a block device or a file. This driver facilitates attaching the
+# storage directly to the guest VM.
+#
+# DB only supports virtio-blk-mmio.
 block_device_driver = "@DEFBLOCKSTORAGEDRIVER_DB@"
 
 # This option changes the default hypervisor and kernel parameters

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -235,9 +235,15 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are cached in guest and never expire.
 virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
-# Block storage driver to be used for the hypervisor in case the container
-# rootfs is backed by a block device. This is virtio-scsi, virtio-blk
-# or nvdimm.
+# Block device driver to be used by the hypervisor when a container's
+# storage is backed by a block device or a file. This driver facilitates attaching
+# the storage directly to the guest VM.
+#
+# Examples include:
+# - virtio-blk-pci
+# - virtio-blk-ccw
+# - virtio-scsi
+# - nvidmm
 block_device_driver = "@DEFBLOCKSTORAGEDRIVER_QEMU@"
 
 # aio is the I/O mechanism used by qemu

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -211,9 +211,15 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are cached in guest and never expire.
 virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
-# Block storage driver to be used for the hypervisor in case the container
-# rootfs is backed by a block device. This is virtio-scsi, virtio-blk
-# or nvdimm.
+# Block device driver to be used by the hypervisor when a container's storage
+# is backed by a block device or a file. This driver facilitates attaching the
+# storage directly to the guest VM.
+#
+# Examples include:
+# - virtio-blk-pci
+# - virtio-blk-ccw
+# - virtio-scsi
+# - nvidmm
 block_device_driver = "@DEFBLOCKSTORAGEDRIVER_QEMU@"
 
 # aio is the I/O mechanism used by qemu

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -112,9 +112,11 @@ memory_slots = @DEFMEMSLOTS@
 # > amount of physical RAM      --> will be set to the actual amount of physical RAM
 default_maxmemory = @DEFMAXMEMSZ_FC@
 
-# Block storage driver to be used for the hypervisor in case the container
-# rootfs is backed by a block device. This is virtio-scsi, virtio-blk
-# or nvdimm.
+# Block device driver to be used by the hypervisor when a container's storage
+# is backed by a block device or a file. This driver facilitates attaching the
+# storage directly to the guest VM.
+#
+# FC only supports virtio-blk-mmio.
 block_device_driver = "@DEFBLOCKSTORAGEDRIVER_FC@"
 
 # Specifies cache-related options will be set to block devices or not.


### PR DESCRIPTION
runtime-rs: Change block device driver defualt with virtio-blk-* and update docs

When we run a kata pod with runtime-rs/qemu and with a default configuration toml,
it will fail with error "unsupported driver type virtio-scsi". 
As virtio-scsi within runtime-rs is not so popular, we set default block device driver with `virtio-blk-*`.

And as the previous description for the `block_device_driver` was inaccurate or
outdated. To make it clear for users, This PR also updates the documentation to
provide a more precise explanation of its function.

Fixes #11488

Signed-off-by: alex.lyn <alex.lyn@antgroup.com>