### PR TITLE
runtime-rs: align SELinux feature with runtime-go (#9866)

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -958,6 +958,10 @@ pub struct SecurityInfo {
     /// Another note: enabling this feature may reduce performance, you may enable
     /// /proc/sys/net/core/bpf_jit_enable to reduce the impact. see https://man7.org/linux/man-pages/man8/bpfc.8.html
     pub seccomp_sandbox: Option<String>,
+
+    /// selinux_label defines SELinux label for the guest
+    #[serde(default)]
+    pub selinux_label: Option<String>,
 }
 
 fn default_qgs_port() -> u32 {
@@ -1297,6 +1301,10 @@ pub struct Hypervisor {
     /// Disables applying SELinux on the container process within the guest.
     #[serde(default = "yes")]
     pub disable_guest_selinux: bool,
+
+    /// Disable applying SELinux on the VMM process.
+    #[serde(default)]
+    pub disable_selinux: bool,
 }
 
 fn yes() -> bool {

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -65,9 +65,10 @@ impl Hypervisor for CloudHypervisor {
         id: &str,
         netns: Option<String>,
         _annotations: &HashMap<String, String>,
+        selinux_label: Option<String>,
     ) -> Result<()> {
         let mut inner = self.inner.write().await;
-        inner.prepare_vm(id, netns).await
+        inner.prepare_vm(id, netns, selinux_label).await
     }
 
     async fn start_vm(&self, timeout: i32) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
@@ -19,13 +19,28 @@ use crate::{
 };
 
 impl DragonballInner {
-    pub(crate) async fn prepare_vm(&mut self, id: &str, netns: Option<String>) -> Result<()> {
+    pub(crate) async fn prepare_vm(
+        &mut self,
+        id: &str,
+        netns: Option<String>,
+        selinux_label: Option<String>,
+    ) -> Result<()> {
         self.id = id.to_string();
         self.state = VmmState::NotReady;
 
         self.vm_path = get_sandbox_path(id);
         self.jailer_root = get_jailer_root(id);
         self.netns = netns;
+
+        // Dragonball is a built-in VMM that runs as a thread inside the
+        // runtime. Because it is not a standalone process, Dragonball cannot
+        // independently set per-VM SELinux exec labels; any provided
+        // selinux_label will be ignored.
+        if selinux_label.is_some() {
+            warn!(sl!(),
+                    "SELinux label is provided for Dragonball VM, but Dragonball does not support SELinux; the label will be ignored",
+            );
+        }
 
         Ok(())
     }

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -75,9 +75,10 @@ impl Hypervisor for Dragonball {
         id: &str,
         netns: Option<String>,
         _annotations: &HashMap<String, String>,
+        selinux_label: Option<String>,
     ) -> Result<()> {
         let mut inner = self.inner.write().await;
-        inner.prepare_vm(id, netns).await
+        inner.prepare_vm(id, netns, selinux_label).await
     }
 
     #[instrument]

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
@@ -64,9 +64,10 @@ impl Hypervisor for Firecracker {
         id: &str,
         netns: Option<String>,
         _annotations: &HashMap<String, String>,
+        selinux_label: Option<String>,
     ) -> Result<()> {
         let mut inner = self.inner.write().await;
-        inner.prepare_vm(id, netns).await
+        inner.prepare_vm(id, netns, selinux_label).await
     }
 
     async fn start_vm(&self, timeout: i32) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -103,6 +103,7 @@ pub trait Hypervisor: std::fmt::Debug + Send + Sync {
         id: &str,
         netns: Option<String>,
         annotations: &HashMap<String, String>,
+        selinux_label: Option<String>,
     ) -> Result<()>;
     async fn start_vm(&self, timeout: i32) -> Result<()>;
     async fn stop_vm(&self) -> Result<()>;

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -19,6 +19,7 @@ pub mod firecracker;
 mod kernel_param;
 pub mod qemu;
 pub mod remote;
+pub mod selinux;
 pub use kernel_param::Param;
 pub mod utils;
 use std::collections::HashMap;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -7,8 +7,8 @@ use super::cmdline_generator::{get_network_device, QemuCmdLine, QMP_SOCKET_FILE}
 use super::qmp::Qmp;
 use crate::device::topology::PCIePort;
 use crate::{
-    device::driver::ProtectionDeviceConfig, hypervisor_persist::HypervisorState, HypervisorConfig,
-    MemoryConfig, VcpuThreadIds, VsockDevice, HYPERVISOR_QEMU,
+    device::driver::ProtectionDeviceConfig, hypervisor_persist::HypervisorState, selinux,
+    HypervisorConfig, MemoryConfig, VcpuThreadIds, VsockDevice, HYPERVISOR_QEMU,
 };
 
 use crate::utils::{bytes_to_megs, enter_netns, megs_to_bytes};
@@ -65,10 +65,22 @@ impl QemuInner {
         }
     }
 
-    pub(crate) async fn prepare_vm(&mut self, id: &str, netns: Option<String>) -> Result<()> {
+    pub(crate) async fn prepare_vm(
+        &mut self,
+        id: &str,
+        netns: Option<String>,
+        selinux_label: Option<String>,
+    ) -> Result<()> {
         info!(sl!(), "Preparing QEMU VM");
         self.id = id.to_string();
         self.netns = netns;
+
+        if !self.hypervisor_config().disable_selinux {
+            if let Some(label) = selinux_label.as_ref() {
+                self.config.security_info.selinux_label = Some(label.to_string());
+                selinux::set_exec_label(label).context("failed to set SELinux process label")?;
+            }
+        }
 
         let vm_path = [KATA_PATH, self.id.as_str()].join("/");
         std::fs::create_dir_all(vm_path)?;
@@ -196,11 +208,23 @@ impl QemuInner {
 
         info!(sl!(), "qemu cmd: {:?}", command);
 
-        // we need move the qemu process into Network Namespace.
+        // we need move the qemu process into Network Namespace and set SELinux label.
         unsafe {
+            let selinux_label = self.config.security_info.selinux_label.clone();
             let _pre_exec = command.pre_exec(move || {
                 let _ = enter_netns(&netns);
-
+                if let Some(label) = selinux_label.as_ref() {
+                    if let Err(e) = selinux::set_exec_label(label) {
+                        error!(sl!(), "Failed to set SELinux label in child process: {}", e);
+                        // Don't return error here to avoid breaking the process startup
+                        // Log the error and continue
+                    } else {
+                        info!(
+                            sl!(),
+                            "Successfully set SELinux label in child process: {}", &label
+                        );
+                    }
+                }
                 Ok(())
             });
         }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -58,9 +58,10 @@ impl Hypervisor for Qemu {
         id: &str,
         netns: Option<String>,
         _annotations: &HashMap<String, String>,
+        selinux_label: Option<String>,
     ) -> Result<()> {
         let mut inner = self.inner.write().await;
-        inner.prepare_vm(id, netns).await
+        inner.prepare_vm(id, netns, selinux_label).await
     }
 
     async fn start_vm(&self, timeout: i32) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -146,8 +146,16 @@ impl RemoteInner {
         id: &str,
         netns: Option<String>,
         annotations: &HashMap<String, String>,
+        selinux_label: Option<String>,
     ) -> Result<()> {
         info!(sl!(), "Preparing REMOTE VM");
+        // Remote does not support SELinux; any provided selinux_label will be ignored.
+        if selinux_label.is_some() {
+            warn!(sl!(),
+                    "SELinux label is provided for Remote VM, but Remote does not support SELinux; the label will be ignored",
+            );
+        }
+
         self.id = id.to_string();
 
         if let Some(netns_path) = &netns {

--- a/src/runtime-rs/crates/hypervisor/src/remote/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/mod.rs
@@ -48,9 +48,12 @@ impl Hypervisor for Remote {
         id: &str,
         netns: Option<String>,
         annotations: &HashMap<String, String>,
+        selinux_label: Option<String>,
     ) -> Result<()> {
         let mut inner = self.inner.write().await;
-        inner.prepare_vm(id, netns, annotations).await
+        inner
+            .prepare_vm(id, netns, annotations, selinux_label)
+            .await
     }
 
     async fn start_vm(&self, timeout: i32) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/selinux.rs
+++ b/src/runtime-rs/crates/hypervisor/src/selinux.rs
@@ -1,0 +1,65 @@
+// Copyright 2025 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::fs::{self, OpenOptions};
+use std::io::prelude::*;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use nix::unistd::gettid;
+
+/// Check if SELinux is enabled on the system
+pub fn is_selinux_enabled() -> bool {
+    fs::read_to_string("/proc/mounts")
+        .map(|buf| buf.contains("selinuxfs"))
+        .unwrap_or_default()
+}
+
+pub fn set_exec_label(label: &str) -> Result<()> {
+    let mut attr_path = Path::new("/proc/thread-self/attr/exec").to_path_buf();
+    if !attr_path.exists() {
+        // Fall back to the old convention
+        attr_path = Path::new("/proc/self/task")
+            .join(gettid().to_string())
+            .join("attr/exec")
+    }
+
+    let mut file = OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(attr_path)
+        .context("open attr path")?;
+
+    file.write_all(label.as_bytes())
+        .with_context(|| "failed to apply SELinux label")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_LABEL: &str = "system_u:system_r:unconfined_t:s0";
+
+    #[test]
+    fn test_set_exec_label() {
+        let ret = set_exec_label(TEST_LABEL);
+        if is_selinux_enabled() {
+            assert!(ret.is_ok(), "Expecting Ok, Got {:?}", ret);
+            // Check that the label was set correctly
+            let mut attr_path = std::path::Path::new("/proc/thread-self/attr/exec").to_path_buf();
+            if !attr_path.exists() {
+                attr_path = std::path::Path::new("/proc/self/task")
+                    .join(nix::unistd::gettid().to_string())
+                    .join("attr/exec");
+            }
+            let label = std::fs::read_to_string(attr_path).unwrap();
+            assert_eq!(label.trim_end_matches('\0'), TEST_LABEL);
+        } else {
+            assert!(ret.is_err(), "Expecting error, Got {:?}", ret);
+        }
+    }
+}

--- a/src/tools/agent-ctl/src/vm/vm_ops.rs
+++ b/src/tools/agent-ctl/src/vm/vm_ops.rs
@@ -113,7 +113,7 @@ pub(crate) async fn boot_vm(name: &str) -> Result<TestVm> {
     // we do not pass any network namesapce since we dont want any
     let empty_anno_map: HashMap<String, String> = HashMap::new();
     hypervisor
-        .prepare_vm(VM_NAME, None, &empty_anno_map)
+        .prepare_vm(VM_NAME, None, &empty_anno_map, None)
         .await
         .context(" prepare test vm")?;
 


### PR DESCRIPTION
# Description
Add SELinux label support for QEMU process in Kata Containers

This PR implements SELinux label support with the following changes:

1. Add SELinux configuration fields to hypervisor config:
   - Add `disable_selinux` flag

2. Set SELinux label for QEMU process:
   - Check if SELinux is enabled and enforcing
   - Apply the SELinux label to QEMU process before launching
   - Handle cases where SELinux is not enabled gracefully

3. Read SELinux label from OCI spec:
   - Extract SELinux label from container's OCI spec process configuration
   - Handle cases where spec or label is not available
   
 update: my latest results
   
   ```yaml
metadata:
  attempt: 1
  name: test-pod1
  namespace: default
  uid: hdishd83djaidwnduwk28bcsb
log_directory: /tmp
linux:
  security_context:
    selinux_options:  
      user: "system_u"
      role: "system_r"
      type: "container_t"
      level: "s0"
```

and below are my qemu test results:

<img width="916" height="105" alt="Pasted image 20250711154419" src="https://github.com/user-attachments/assets/cf4da569-1edf-4161-8428-b25bcf7ba1ec" />

clh result：
vboxuser@kata:Downloads$ sudo crictl runp -r kata sandbox.yaml
8469a21dec7d2d206c5b0b078f087a9984ff4a52a25bce9bf480ea4a5383f8be
vboxuser@kata:~/Downloads$ ps -eZ | grep container
system_u:system_r:container_t:s0 83496 ? 00:00:00 virtiofsd
system_u:system_r:container_t:s0 83499 ? 00:00:04 cloud-hypervisor

fc result:
vboxuser@kata:Downloads$ sudo crictl runp -r kata-fc sandbox.yaml
[sudo] password for vboxuser:
3ca833ceddb53774f1fa276386387ab5b5515a74cb72a16894de2f27b14ddbc5
vboxuser@kata:~/Downloads$ ps -eZ | grep container
system_u:system_r:initrc_t:s0 1113 ? 00:00:01 containerd
system_u:system_r:initrc_t:s0 13703 ? 00:00:00 containerd-shim
system_u:system_r:container_t:s0 13708 ? 00:00:04 firecracker

dragonball result:
         Dragonball is a built-in VMM that runs as a thread inside containerd-shim-kata-v2.Because it is not a standalone process, Dragonball cannot independently set per-VM SELinux exec labels; any provided selinux_label will be ignored.