### PR TITLE
runtime: fix no network when using Firecracker as VMM

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -1415,6 +1415,13 @@ func (s *Sandbox) startVM(ctx context.Context, prestartHookFunc func(context.Con
 		if err != nil {
 			return err
 		}
+		// If we want the network, scan the netns again to update the network
+		// configuration after the prestart hooks have run.
+		if !s.config.NetworkConfig.DisableNewNetwork {
+			if _, err := s.network.AddEndpoints(ctx, s, nil, false); err != nil {
+				return err
+			}
+		}
 	}
 
 	if err := s.network.Run(ctx, func() error {


### PR DESCRIPTION
Fix #11500 

In the function `func (s *Sandbox) startVM()`, it is distinguished whether the VMM supports network device hotplug: 

- When supported, there is no problem. 
  - it first start the VM 
  - call the prestart hook to initialize the network
  - then rescan the network namespace to update the network configuration in runtime
  - add network devices to the VMM via network hotplug.
- When unsupported, where the problem is.
  - it first call the prestart hook to initialize the network
  - **but did not rescan the network namespace to update the network configuration in runtime**
  - then just start the VM with the **uninitialized network configuration**, although the CNI plugins have initialized the network in the namespace.

Therefore, in the unsupported branch we need to resacn the network namespace after call the prestart hook to initialize the network.

