### PR TITLE
agent: fix the issue of parent writer pipe fd leak

### DIFF
--- a/src/agent/rustjail/src/container.rs
+++ b/src/agent/rustjail/src/container.rs
@@ -2081,8 +2081,8 @@ mod tests {
         });
     }
 
-    #[test]
-    fn test_linuxcontainer_get_process() {
+    #[tokio::test]
+    async fn test_linuxcontainer_get_process() {
         let _ = new_linux_container_and_then(|mut c: LinuxContainer| {
             c.processes.insert(
                 1,

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -2623,11 +2623,6 @@ mod tests {
                 }),
                 ..Default::default()
             },
-            TestData {
-                has_fd: false,
-                result: Err(anyhow!(ERR_CANNOT_GET_WRITER)),
-                ..Default::default()
-            },
         ];
 
         for (i, d) in tests.iter().enumerate() {


### PR DESCRIPTION
Sometimes, containers or execs do not use stdin, so there is no chance to add parent stdin to the process's writer hashmap, resulting in the parent stdin's fd not being closed when the process is cleaned up later.

Therefore, when creating a process, first explicitly add parent stdin to the wirter hashmap. Make sure that the parent stdin's fd can be closed when the process is cleaned up later.

Fixes: #11503