### PR TITLE
kata-agent: mount.rs: Fix warning of test

### DIFF
--- a/src/agent/rustjail/src/mount.rs
+++ b/src/agent/rustjail/src/mount.rs
@@ -1144,7 +1144,6 @@ mod tests {
     use std::fs::remove_dir_all;
     use std::fs::remove_file;
     use std::io;
-    use std::os::unix::fs;
     use std::os::unix::io::AsRawFd;
     use tempfile::tempdir;
     use test_utils::assert_result;


### PR DESCRIPTION
Got follow warning with make test of kata-agent:
   Compiling rustjail v0.1.0 (/data/teawater/kata-containers/src/agent/rustjail)
   Compiling kata-agent v0.1.0 (/data/teawater/kata-containers/src/agent)
warning: unused import: `std::os::unix::fs`
    --> rustjail/src/mount.rs:1147:9
     |
1147 |     use std::os::unix::fs;
     |         ^^^^^^^^^^^^^^^^^
     |
     = note: `#[warn(unused_imports)]` on by default

This commit fixes it.

Fixes: #11508