### PR TITLE
runtime-rs: make the resize_vcpu api support sync

### DIFF
--- a/src/dragonball/src/device_manager/vfio_dev_mgr/mod.rs
+++ b/src/dragonball/src/device_manager/vfio_dev_mgr/mod.rs
@@ -16,9 +16,9 @@ use std::collections::HashMap;
 use std::ops::Deref;
 use std::os::fd::RawFd;
 use std::path::Path;
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Weak};
 
-use crossbeam_channel::Sender;
 use dbs_device::resources::Resource::LegacyIrq;
 use dbs_device::resources::{DeviceResources, Resource, ResourceConstraint};
 use dbs_device::DeviceIo;

--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -832,7 +832,7 @@ impl Vm {
     pub fn resize_vcpu(
         &mut self,
         config: VcpuResizeInfo,
-        sync_tx: Option<Sender<bool>>,
+        sync_tx: Option<Sender<Option<i32>>>,
     ) -> std::result::Result<(), VcpuResizeError> {
         if self.upcall_client().is_none() {
             Err(VcpuResizeError::UpcallClientMissing)

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -28,7 +28,7 @@ use kata_types::{
 };
 use nix::mount::MsFlags;
 use persist::sandbox_persist::Persist;
-use std::cmp::Ordering;
+use std::{cmp::Ordering, time::Duration};
 use std::{collections::HashSet, fs::create_dir_all};
 use tokio::sync::mpsc;
 
@@ -37,6 +37,9 @@ const DRAGONBALL_INITRD: &str = "initrd";
 const DRAGONBALL_ROOT_FS: &str = "rootfs";
 const BALLOON_DEVICE_ID: &str = "balloon0";
 const MEM_DEVICE_ID: &str = "memmr0";
+/// default hotplug timeout
+const DEFAULT_HOTPLUG_TIMEOUT: u64 = 250;
+
 #[derive(Debug)]
 pub struct DragonballInner {
     /// sandbox id
@@ -391,7 +394,10 @@ impl DragonballInner {
             vcpu_count: Some(new_vcpus as u8),
         };
         self.vmm_instance
-            .resize_vcpu(&cpu_resize_info)
+            .resize_vcpu(
+                &cpu_resize_info,
+                Some(Duration::from_millis(DEFAULT_HOTPLUG_TIMEOUT)),
+            )
             .context(format!(
                 "failed to do_resize_vcpus on new_vcpus={:?}",
                 new_vcpus


### PR DESCRIPTION
This PR contains two patch:

This PR mainly consists of two parts, one is to add support for resize_vcpu synchronization capabilities to dragonball; the other is to support the synchronization capabilities of calling dragonball's resize_vcpu interface on runtime-rs.

When hot plugging vcpu in dragonball hypervisor, use the synchronization
   interface and wait until the hot plug cpu is executed in the guest
    before returning. This ensures that the subsequent device hot plug will
    not conflict with the previous call.