### PR TITLE
gpu: NVRC static build

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -49,8 +49,8 @@ setup_nvidia-nvrc() {
 
 	pushd "${PROJECT}" > /dev/null || exit 1
 
-	cargo build --release --target="${machine_arch}"-unknown-linux-gnu
-	cp target/"${machine_arch}"-unknown-linux-gnu/release/NVRC ../../destdir/bin/.
+	cargo build --release --target="${machine_arch}"-unknown-linux-musl
+	cp target/"${machine_arch}"-unknown-linux-musl/release/NVRC ../../destdir/bin/.
 
 	popd > /dev/null || exit 1
 


### PR DESCRIPTION
We had the proper config.toml configuration for static builds but were building the glibc  target and not the musl target.