### PR TITLE
workflows: adopting azure/setup-kubectl

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -107,7 +107,9 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-kata-tools kata-artifacts
 
       - name: Download Azure CLI
-        run: bash tests/integration/kubernetes/gha-run.sh install-azure-cli
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'latest'
 
       - name: Log into the Azure account
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
@@ -129,7 +131,9 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-bats
 
       - name: Install `kubectl`
-        run: bash tests/integration/kubernetes/gha-run.sh install-kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'latest'
 
       - name: Download credentials for the Kubernetes CLI to use them
         run: bash tests/integration/kubernetes/gha-run.sh get-cluster-credentials

--- a/.github/workflows/run-kata-coco-stability-tests.yaml
+++ b/.github/workflows/run-kata-coco-stability-tests.yaml
@@ -114,7 +114,9 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-bats
 
       - name: Install `kubectl`
-        run: bash tests/integration/kubernetes/gha-run.sh install-kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'latest'
 
       - name: Download credentials for the Kubernetes CLI to use them
         run: bash tests/integration/kubernetes/gha-run.sh get-cluster-credentials

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -292,7 +292,9 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-bats
 
       - name: Install `kubectl`
-        run: bash tests/integration/kubernetes/gha-run.sh install-kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'latest'
 
       - name: Download credentials for the Kubernetes CLI to use them
         run: bash tests/integration/kubernetes/gha-run.sh get-cluster-credentials

--- a/.github/workflows/run-kata-deploy-tests-on-aks.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-aks.yaml
@@ -95,7 +95,9 @@ jobs:
         run: bash tests/functional/kata-deploy/gha-run.sh install-bats
 
       - name: Install `kubectl`
-        run: bash tests/functional/kata-deploy/gha-run.sh install-kubectl
+        uses: azure/setup-kubectl@v4
+        with:
+          version: 'latest'
 
       - name: Download credentials for the Kubernetes CLI to use them
         run: bash tests/functional/kata-deploy/gha-run.sh get-cluster-credentials

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -135,10 +135,6 @@ function install_bats() {
 	sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
 }
 
-function install_kubectl() {
-	sudo az aks install-cli
-}
-
 # Install the kustomize tool in /usr/local/bin if it doesn't exist on
 # the system yet.
 #

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -576,7 +576,6 @@ function main() {
 		install-bats) install_bats ;;
 		install-kata-tools) install_kata_tools ;;
 		install-kbs-client) install_kbs_client ;;
-		install-kubectl) install_kubectl ;;
 		get-cluster-credentials) get_cluster_credentials "" ;;
 		deploy-csi-driver) return 0 ;;
 		deploy-kata) deploy_kata ;;

--- a/tests/stability/gha-stability-run.sh
+++ b/tests/stability/gha-stability-run.sh
@@ -32,7 +32,6 @@ function main() {
 		create-cluster) create_cluster ;;
 		install-bats) install_bats ;;
 		install-kata-tools) install_kata_tools ;;
-		install-kubectl) install_kubectl ;;
 		get-cluster-credentials) get_cluster_credentials ;;
 		deploy-snapshotter) deploy_snapshotter ;;
 		deploy-kata-aks) deploy_kata "aks" ;;


### PR DESCRIPTION
There are workflows that rely on `az aks install-cli` to get kubectl installed. There is a well-known problem on install-cli, related with API usage rate limit, that has recently caused the command to fail quite often.

This is replacing install-cli with the azure/setup-kubectl github action which has no such as rate limit problem.

While here, removed the install_cli() function from gha-run-k8s-common.sh so avoid developers using it by mistake in the future.

Fixes #11463

---

I've tested this change here:
 * https://github.com/kata-containers/kata-containers/actions/runs/16061390061
 * https://github.com/kata-containers/kata-containers/actions/runs/16075038260

`kubelogin`, which is downloaded by install-cli but not setup-kubectl, isn't used in our workflows. At least they didn't fail because of its lack.

setup-kubectl akin to install-cli is going to find and install latest kubectl version.