### PR TITLE
tests: k0s: Always use latest version, apart from CRI-O tests

### DIFF
--- a/.github/workflows/run-k8s-tests-on-amd64.yaml
+++ b/.github/workflows/run-k8s-tests-on-amd64.yaml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Deploy ${{ matrix.k8s }}
         run: bash tests/integration/kubernetes/gha-run.sh deploy-k8s
+        env:
+          CONTAINER_RUNTIME: ${{ matrix.container_runtime }}
 
       - name: Configure the ${{ matrix.snapshotter }} snapshotter
         if: matrix.snapshotter != ''

--- a/tests/functional/kata-deploy/kata-deploy.bats
+++ b/tests/functional/kata-deploy/kata-deploy.bats
@@ -91,7 +91,7 @@ setup() {
 teardown() {
 	pushd "${repo_root_dir}"
 
-	helm uninstall --namespace=kube-system kata-deploy --wait
+	helm uninstall --namespace=kube-system kata-deploy
 	kubectl -n kube-system wait --timeout=10m --for=delete -l name=kata-deploy pod
 
 	popd

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -31,6 +31,7 @@ KATA_HOST_OS="${KATA_HOST_OS:-}"
 KUBERNETES="${KUBERNETES:-}"
 K8S_TEST_HOST_TYPE="${K8S_TEST_HOST_TYPE:-small}"
 TEST_CLUSTER_NAMESPACE="${TEST_CLUSTER_NAMESPACE:-}"
+CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-containerd}"
 
 function _print_instance_type() {
 	case "${K8S_TEST_HOST_TYPE}" in
@@ -192,15 +193,19 @@ function get_nodes_and_pods_info() {
 }
 
 function deploy_k0s() {
-	url=$(get_from_kata_deps ".externals.k0s.url")
-
-	k0s_version_param=""
-	version=$(get_from_kata_deps ".externals.k0s.version")
-	if [[ -n "${version}" ]]; then
-		k0s_version_param="K0S_VERSION=${version}"
+	if [[ "${CONTAINER_RUNTIME}" == "crio" ]]; then
+		url=$(get_from_kata_deps ".externals.k0s.url")
+	
+		k0s_version_param=""
+		version=$(get_from_kata_deps ".externals.k0s.version")
+		if [[ -n "${version}" ]]; then
+			k0s_version_param="K0S_VERSION=${version}"
+		fi
+	
+		curl -sSLf "${url}" | sudo "${k0s_version_param}" sh
+	else
+		curl -sSLf -sSLf https://get.k0s.sh | sudo sh
 	fi
-
-	curl -sSLf "${url}" | sudo "${k0s_version_param}" sh
 
 	# In this case we explicitly want word splitting when calling k0s
 	# with extra parameters.

--- a/versions.yaml
+++ b/versions.yaml
@@ -301,6 +301,8 @@ externals:
     url: "https://github.com/lvmteam/lvm2"
     version: "v2_03_16"
 
+  # This is only used for CRI-O.
+  # kata-deploy tests rely on the latest version of k0s.
   k0s:
     description: "K0s Kubernetes distribution, used in cri-o testing"
     url: "https://get.k0s.sh"


### PR DESCRIPTION
We've been pinning a specific version of k0s for CRI-O tests, which may make sense for CRI-O, but doesn't make sense at all when it comes to testing that we can install kata-deploy on latest k0s (and currently our test for that is broken).

Let's bump to the latest, and from this point we start debugging, instead of debugging on an ancient version of the project.