### PR TITLE
tests: runtimeclasses: Adjust gpu runtimeclasses

### DIFF
--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -71,8 +71,8 @@ metadata:
 handler: kata-qemu-nvidia-gpu-snp
 overhead:
     podFixed:
-        memory: "2048Mi"
-        cpu: "1.0"
+        memory: "4096Mi"
+        cpu: "1"
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"
@@ -84,8 +84,8 @@ metadata:
 handler: kata-qemu-nvidia-gpu-tdx
 overhead:
     podFixed:
-        memory: "2048Mi"
-        cpu: "1.0"
+        memory: "4096Mi"
+        cpu: "1"
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"
@@ -97,8 +97,8 @@ metadata:
 handler: kata-qemu-nvidia-gpu
 overhead:
     podFixed:
-        memory: "160Mi"
-        cpu: "250m"
+        memory: "4096Mi"
+        cpu: "1"
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"


### PR DESCRIPTION
679cc9d47c55dc77fc1e0a00cab370de1122eafc was merged and bumped the podoverhead for the gpu related runtimeclasses. However, the bump on the `kata-runtimeClasses.yaml` as overlooked, making our tests fail due to that discrepancy.

Let's just adjust the values here and move on.