### PR TITLE
runtime-go: fixes early closed stdout/err on exec w/o stdin option

### DIFF
--- a/src/runtime/virtcontainers/iostream.go
+++ b/src/runtime/virtcontainers/iostream.go
@@ -78,19 +78,11 @@ func (s *stdinStream) Close() error {
 }
 
 func (s *stdoutStream) Read(data []byte) (n int, err error) {
-	if s.closed {
-		return 0, errors.New("stream closed")
-	}
-
 	// can not pass context to Read(), so use background context
 	return s.sandbox.agent.readProcessStdout(context.Background(), s.container, s.process, data)
 }
 
 func (s *stderrStream) Read(data []byte) (n int, err error) {
-	if s.closed {
-		return 0, errors.New("stream closed")
-	}
-
 	// can not pass context to Read(), so use background context
 	return s.sandbox.agent.readProcessStderr(context.Background(), s.container, s.process, data)
 }

--- a/src/runtime/virtcontainers/iostream_test.go
+++ b/src/runtime/virtcontainers/iostream_test.go
@@ -47,10 +47,10 @@ func TestIOStream(t *testing.T) {
 	assert.NotNil(t, err, "stdin write closed should fail")
 
 	_, err = stdout.Read(buffer)
-	assert.NotNil(t, err, "stdout read closed should fail")
+	assert.Nil(t, err, "stdout read should succeed after stdin is closed")
 
 	_, err = stderr.Read(buffer)
-	assert.NotNil(t, err, "stderr read closed should fail")
+	assert.Nil(t, err, "stderr read should succeed after stdin is closed")
 
 	err = stdin.Close()
 	assert.NotNil(t, err, "stdin close closed should fail")

--- a/tests/integration/kubernetes/k8s-exec-websocket.bats
+++ b/tests/integration/kubernetes/k8s-exec-websocket.bats
@@ -1,0 +1,158 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2025 Kata Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Specific test for early closed stdio issue in kubectl exec via WebSocket
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+
+	setup_common || die "setup_common failed"
+	pod_name="wss-exec-pod"
+	container_name="container"
+
+	artifacts_dir="$(mktemp -d "${BATS_TEST_DIRNAME}/artifacts.XXXXXXXXXX")"
+
+	test_yaml_file="${pod_config_dir}/test-k8s-pod-wss.yaml"
+    cp "$pod_config_dir/k8s-pod-wss.yaml" "${test_yaml_file}"
+
+	info "Using existing test pod YAML file at ${test_yaml_file}"
+	# Use pre-existing test pod YAML with a simple busybox container a simple stdout/err script
+
+	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+
+	# Allow the exec command used by the WebSocket tests: sh -e test.sh
+	add_exec_to_policy_settings "${policy_settings_dir}" "sh" "-e" "test.sh"
+
+	allowed_requests=(
+		"CloseStdinRequest"
+		"ReadStreamRequest"
+		"WriteStreamRequest"
+	)
+	add_requests_to_policy_settings "${policy_settings_dir}" "${allowed_requests[@]}"
+
+	auto_generate_policy "${policy_settings_dir}" "${test_yaml_file}"
+
+	# Get current context's cluster & username
+	CURRENT_USER=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$(kubectl config current-context)\")].context.user}")
+	CURRENT_CLUSTER=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$(kubectl config current-context)\")].context.cluster}")
+	CURRENT_NAMESPACE=$(kubectl config view -o jsonpath="{.contexts[?(@.name==\"$(kubectl config current-context)\")].context.namespace}")
+	if [ -z "${CURRENT_NAMESPACE}" ]; then
+		CURRENT_NAMESPACE="kata-containers-k8s-tests"
+	fi
+
+	# Get that user's client-key-data
+	kubectl config view --raw -o jsonpath="{.users[?(@.name==\"${CURRENT_USER}\")].user.client-key-data}" | base64 --decode > "${artifacts_dir}/client.key"
+	kubectl config view --raw -o jsonpath="{.users[?(@.name==\"${CURRENT_USER}\")].user.client-certificate-data}" | base64 --decode > "${artifacts_dir}/client.crt"
+	kubectl config view --raw -o jsonpath="{.clusters[?(@.name==\"${CURRENT_CLUSTER}\")].cluster.certificate-authority-data}" | base64 --decode > "${artifacts_dir}/ca.crt"
+
+
+	CLUSTER_URL=$(kubectl config view --raw -o jsonpath="{.clusters[?(@.name==\"${CURRENT_CLUSTER}\")].cluster.server}")
+	CLUSTER_HOST_PORT="${CLUSTER_URL//https:\/\/}"
+}
+
+@test "TestWebsocketOutput" {
+
+	# Create the pod
+	kubectl create -f "${test_yaml_file}" -n "${CURRENT_NAMESPACE}"
+
+	# Wait for ready pod
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_name}" -n "${CURRENT_NAMESPACE}"
+
+	# Use curl to open WebSocket connection
+	curl \
+		-s --cacert "${artifacts_dir}/ca.crt" --cert "${artifacts_dir}/client.crt" --key "${artifacts_dir}/client.key" \
+		--connect-timeout 30 \
+		--max-time 30 \
+		--http1.1 \
+		--no-buffer \
+		--header "Connection: Upgrade" \
+		--header "Upgrade: websocket" \
+		--header "Host: ${CLUSTER_HOST_PORT}" \
+		--header "Origin: ${CLUSTER_URL}" \
+		--header "Sec-WebSocket-Version: 13" \
+		--header "Sec-WebSocket-Protocol: channel.k8s.io" \
+		--header "Sec-WebSocket-Key: MDEyMzQ1Njc4OWFiY2RlZg==" \
+		"https://${CLUSTER_HOST_PORT}/api/v1/namespaces/${CURRENT_NAMESPACE}/pods/${pod_name}/exec?stdout=true&stderr=true&command=sh&command=-e&command=test.sh" \
+		> "${artifacts_dir}/wss-output.log"
+
+	# Check for exactly 1 occurrence of each error1-error2-error3 and out1-out2-out3
+	for i in 1 2 3; do
+		error_count=$(LC_ALL="C" grep --text -c "error${i}" "${artifacts_dir}/wss-output.log" || true)
+		if [[ "${error_count}" -ne 1 ]]; then
+			info "✗ Test FAILED: Expected exactly 1 occurrence of 'error${i}', found ${error_count}" >&2
+			return 1
+		fi
+
+		out_count=$(LC_ALL="C" grep --text -c "out${i}" "${artifacts_dir}/wss-output.log" || true)
+		if [[ "${out_count}" -ne 1 ]]; then
+			info "✗ Test FAILED: Expected exactly 1 occurrence of 'out${i}', found ${out_count}" >&2
+			return 1
+		fi
+	done
+}
+
+@test "TestWebsocketOutputWithStdin" {
+
+	# Create the pod
+	kubectl create -f "${test_yaml_file}" -n "${CURRENT_NAMESPACE}"
+
+	# Wait for ready pod
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "${pod_name}" -n "${CURRENT_NAMESPACE}"
+
+	# Use curl to open WebSocket connection with stdin
+	curl \
+		-s --cacert "${artifacts_dir}/ca.crt" --cert "${artifacts_dir}/client.crt" --key "${artifacts_dir}/client.key" \
+		--connect-timeout 30 \
+		--max-time 30 \
+		--http1.1 \
+		--no-buffer \
+		--header "Connection: Upgrade" \
+		--header "Upgrade: websocket" \
+		--header "Host: ${CLUSTER_HOST_PORT}" \
+		--header "Origin: ${CLUSTER_URL}" \
+		--header "Sec-WebSocket-Version: 13" \
+		--header "Sec-WebSocket-Protocol: channel.k8s.io" \
+		--header "Sec-WebSocket-Key: MDEyMzQ1Njc4OWFiY2RlZg==" \
+		"https://${CLUSTER_HOST_PORT}/api/v1/namespaces/${CURRENT_NAMESPACE}/pods/${pod_name}/exec?stdin=true&stdout=true&stderr=true&command=sh&command=-e&command=test.sh" \
+		> "${artifacts_dir}/wss-output.log"
+
+	# Check for exactly 1 occurrence of each error1-error2-error3 and out1-out2-out3
+	for i in 1 2 3; do
+		error_count=$(LC_ALL="C" grep --text -c "error${i}" "${artifacts_dir}/wss-output.log" || true)
+		if [[ "${error_count}" -ne 1 ]]; then
+			info "✗ Test FAILED: Expected exactly 1 occurrence of 'error${i}', found ${error_count}" >&2
+			return 1
+		fi
+
+		out_count=$(LC_ALL="C" grep --text -c "out${i}" "${artifacts_dir}/wss-output.log" || true)
+		if [[ "${out_count}" -ne 1 ]]; then
+			info "✗ Test FAILED: Expected exactly 1 occurrence of 'out${i}', found ${out_count}" >&2
+			return 1
+		fi
+	done
+}
+
+
+teardown() {
+	# Show pod logs and status for debugging
+	kubectl describe pod "${pod_name}" -n "${CURRENT_NAMESPACE}" || true
+	kubectl logs "${pod_name}" -c "${container_name}" -n "${CURRENT_NAMESPACE}" || true
+	echo "### wss-output.log ###"
+	cat "${artifacts_dir}/wss-output.log" || true
+	echo "####################"
+
+	# Clean up
+	kubectl delete pod "${pod_name}" -n "${CURRENT_NAMESPACE}" || true
+
+	rm -rf "${artifacts_dir}"
+    rm "${test_yaml_file}"
+	delete_tmp_policy_settings_dir "${policy_settings_dir}"
+
+	teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/k8s-exec.bats
+++ b/tests/integration/kubernetes/k8s-exec.bats
@@ -76,6 +76,14 @@ EOF"
 	container_name=$(kubectl exec $pod_name -c $second_container_name -- $env_command | grep CONTAINER_NAME | tr -d '\r')
 	[ "$container_name" == "CONTAINER_NAME=$second_container_name" ]
 
+	## Case with background process
+	run bash -c "kubectl exec -i ${pod_name} -- "$sh_command" <<-EOF
+sleep 30s &
+exit
+EOF"
+	echo "run status: $status" 1>&2
+	echo "run output: $output" 1>&2
+	[ "$status" -eq 0 ]
 }
 
 teardown() {

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -75,6 +75,7 @@ else
 		"k8s-empty-dirs.bats" \
 		"k8s-env.bats" \
 		"k8s-exec.bats" \
+		"k8s-exec-websocket.bats" \
 		"k8s-file-volume.bats" \
 		"k8s-hostname.bats" \
 		"k8s-hostpath-volume.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-wss.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-wss.yaml
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2018 Intel Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: wss-exec-pod
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  shareProcessNamespace: true
+  containers:
+  - name: container
+    image: quay.io/prometheus/busybox:latest
+    command: ["/bin/sh"]
+    args:
+    - -c
+    - |
+      echo 'echo error1 1>&2 && sleep 1 && echo error2 1>&2  && sleep 1 && echo out1 && sleep 1 && echo out2 && sleep 1 && echo out3 && sleep 1 && echo error3 1>&2' > test.sh
+      chmod +x test.sh
+      sleep infinity


### PR DESCRIPTION
## Context 

When running an `exec` call through the API **without a stdin=true option**, the output of a running script may be lost at the first buffer read.
using the following kubernetes-context example :

Pod Example
___
```yaml
apiVersion: v1
kind: Pod
metadata:
  name: test
spec:
  runtimeClassName: kata
  containers:
  - name: busybox
    image: busybox
    command: ["/bin/sh"]
    args:
    - -c
    - |
      echo '>&2 echo "$(date) error1" && sleep 1 && >&2 echo "$(date) error2" && sleep 1 && echo "$(date) out1" && sleep 1 && echo out2 && echo out3 && echo error3 1>&2' > test.sh
      chmod +x test.sh
      sleep 600
```

Test Script 
___
```js
CLUSTER_URL = "wss://<kube-api-ip>:6443";
POD_NAME = "test";

const fs = require('fs');
const WebSocket = require('ws');

let url = `${CLUSTER_URL}/api/v1/namespaces/default/pods/${POD_NAME}/exec?command=sh&command=-e&command=test.sh&stderr=true&stdout=true`;

let sock = new WebSocket(url, 'channel.k8s.io', {
    // Cert only needed when using the wss:// scheme.
    ca: fs.readFileSync(`./ca.crt`),
    cert: fs.readFileSync(`./client.crt`),
    key: fs.readFileSync(`./client.key`),
});
sock.on('open', () => console.log('open'));
sock.on('message', x => console.log('message', JSON.stringify(x.toString())));
sock.on('close', () => console.log('close'));
```

Here is the ouput : 
```bash
open
message "\u0001"
message "\u0002Mon Jul  7 11:36:38 UTC 2025 error1\n"
message "\u0001Mon Jul  7 11:36:40 UTC 2025 out1\n"
close
node jstest  0.06s user 0.02s system 2% cpu 3.265 total
```

And here is some logs from `kata` that I generated from getting the err output from `io.CopyBuffer` call : 
```
Jul 07 11:36:40 ubuntu-test k0s[190241]: time="2025-07-07 11:36:40" level=info msg="time=\"2025-07-07T11:36:40.505381696Z\" level=error msg=\"**failed to copy stdout io stream**\" container=a7b30f206b0ad1acb38e8d8c1939e24dc06757b2437e7a135b017b04e4750a76 error=\"**stream closed**\" exec=ed206d46b27fa565996d0f19b72716ec56489fa7ab38a8d687b1bf6aab695c41 name=containerd-shim-v2 pid=749616 sandbox=1ff223bd5f882eca8437005c3306c64bf7f9713cbcbcbd5b5143bf5c0f99fcc9 source=containerd-kata-shim-v2" component=containerd stream=stderr
Jul 07 11:36:38 ubuntu-test k0s[190241]: time="2025-07-07 11:36:38" level=info msg="time=\"2025-07-07T11:36:38.467046356Z\" level=error msg=\"failed to copy stdout io stream\" container=a7b30f206b0ad1acb38e8d8c1939e24dc06757b2437e7a135b017b04e4750a76 error=\"stream closed\" exec=ed206d46b27fa565996d0f19b72716ec56489fa7ab38a8d687b1bf6aab695c41 name=containerd-shim-v2 pid=749616 sandbox=1ff223bd5f882eca8437005c3306c64bf7f9713cbcbcbd5b5143bf5c0f99fcc9 source=containerd-kata-shim-v2" component=containerd stream=stderr
```
Notice the `error=\"stream closed\"` message

---

## Resolution

As you can see the stream are getting closed before they reached the EOF, making the following global output not complete.
The channel closing call `close(stdinCloser)` is the one triggering a close on all io, calling it after all stdout & stderr process are done fixes the previous issue. 


Resolves #10387