### PR TITLE
runtime-rs: add seccomp support for cloud hypervisor and firecracker

### DIFF
--- a/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
+++ b/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
@@ -195,6 +195,9 @@ block_device_driver = "virtio-blk-pci"
 # result in memory pre allocation
 #enable_hugepages = true
 
+# Disable the 'seccomp' feature from Cloud Hypervisor or firecracker, default false
+# disable_seccomp = true
+
 # This option changes the default hypervisor and kernel parameters
 # to enable debug output where available.
 #

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -145,6 +145,9 @@ block_device_driver = "@DEFBLOCKSTORAGEDRIVER_FC@"
 # result in memory pre allocation
 #enable_hugepages = true
 
+# Disable the 'seccomp' feature from Cloud Hypervisor or firecracker, default false
+# disable_seccomp = true
+
 # Enable vIOMMU, default false
 # Enabling this will result in the VM having a vIOMMU device
 # This will also add the following options to the kernel's

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/inner.rs
@@ -103,6 +103,9 @@ impl FcInner {
                 cmd.args(["--api-sock", &self.asock_path]);
             }
         }
+        if self.config.security_info.disable_seccomp {
+            cmd.arg("--no-seccomp");
+        }
         debug!(sl(), "Exec: {:?}", cmd);
 
         // Make sure we're in the correct Network Namespace


### PR DESCRIPTION
The seccomp feature for Cloud Hypervisor and Firecracker is enabled by default. This commit introduces an option to disable seccomp for both and updates the built-in configuration.toml file accordingly.

Fixes: #11535