### PR TITLE
runtime-rs: Switch tempdir to tempfile

### DIFF
--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -1788,7 +1788,6 @@ dependencies = [
  "shim-interface",
  "slog",
  "slog-scope",
- "tempdir",
  "test-utils",
  "tests_utils",
  "thiserror 1.0.69",
@@ -3533,15 +3532,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4424,16 +4414,6 @@ dependencies = [
  "filetime",
  "libc",
  "xattr",
-]
-
-[[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
 ]
 
 [[package]]

--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -33,7 +33,6 @@ oci-spec = { workspace = true }
 futures = "0.3.25"
 safe-path = "0.1.0"
 crossbeam-channel = "0.5.6"
-tempdir = "0.3.7"
 qapi = { version = "0.14", features = ["qmp", "async-tokio-all"] }
 qapi-spec = "0.3.1"
 qapi-qmp = "0.14.0"
@@ -77,6 +76,7 @@ cloud-hypervisor = ["ch-config"]
 
 [dev-dependencies]
 serial_test = "2.0.0"
+tempfile = { workspace = true }
 
 # Local dev-dependencies
 # Force the CH tests to run, even when the feature is not enabled for

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -1093,7 +1093,7 @@ mod tests {
     use test_utils::{assert_result, skip_if_not_root};
 
     use std::fs::File;
-    use tempdir::TempDir;
+    use tempfile::Builder;
 
     fn set_fake_guest_protection(protection: Option<GuestProtection>) {
         let existing_ref = FAKE_GUEST_PROTECTION.clone();
@@ -1486,7 +1486,7 @@ mod tests {
         let path_dir = "/tmp/proc";
         let file_name = "1";
 
-        let tmp_dir = TempDir::new(path_dir).unwrap();
+        let tmp_dir = Builder::new().prefix("proc").tempdir().unwrap();
         let file_path = tmp_dir.path().join(file_name);
         let _tmp_file = File::create(file_path.as_os_str()).unwrap();
         let file_path_name = file_path.as_path().to_str().map(|s| s.to_string());


### PR DESCRIPTION
tempdir hasn't been updated for seven years and pulls in remove_dir_all@0.5.3 which has security advisory
GHSA-mc8h-8q98-g5hr, so replace this with using tempfile, which the crate got merged into and we use elsewhere in the project