### PR TITLE
gh: Fix released VERSION file

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -327,6 +327,7 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
       - name: Rebase atop of the latest target branch
         run: |

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -297,6 +297,7 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
       - name: Rebase atop of the latest target branch
         run: |

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -240,6 +240,7 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
       - name: Rebase atop of the latest target branch
         run: |

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -326,6 +326,7 @@ jobs:
         with:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
       - name: Rebase atop of the latest target branch
         run: |


### PR DESCRIPTION
The `/opt/kata/VERSION` file, which is created using `git describe --tags`, requires the newly released tag to be updated in order to be accurate.

To do so, let's add a `fetch-tags: true` to the checkout action used during the `create-kata-tarball` job.