### PR TITLE
OVMF: deprecating SEV logic from OVMF

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -56,7 +56,7 @@ jobs:
           - kernel-nvidia-gpu-confidential
           - nydus
           - ovmf
-          - ovmf-sev
+          - ovmf-snp
           - pause-image
           - qemu
           - qemu-snp-experimental

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -26,7 +26,7 @@ BASE_TARBALLS = serial-targets \
 	kernel-nvidia-gpu-confidential-tarball \
 	kernel-tarball \
 	nydus-tarball \
-	ovmf-sev-tarball \
+	ovmf-snp-tarball \
 	ovmf-tarball \
 	qemu-snp-experimental-tarball \
 	qemu-tdx-experimental-tarball \
@@ -138,7 +138,7 @@ kernel-confidential-tarball:
 nydus-tarball:
 	${MAKE} $@-build
 
-ovmf-sev-tarball:
+ovmf-snp-tarball:
 	${MAKE} $@-build
 
 ovmf-tarball:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -120,7 +120,7 @@ options:
 	nydus
 	pause-image
 	ovmf
-	ovmf-sev
+	ovmf-snp
 	qemu
 	qemu-snp-experimental
 	qemu-tdx-experimental
@@ -937,7 +937,7 @@ install_ovmf() {
 	fi
 
 	local component_name="ovmf"
-	[ "${ovmf_type}" == "sev" ] && component_name="ovmf-sev"
+	[ "${ovmf_type}" == "sev" ] && component_name="ovmf-snp"
 
 	latest_artefact="$(get_from_kata_deps ".externals.ovmf.${ovmf_type}.version")"
 	latest_builder_image="$(get_ovmf_image_name)"
@@ -954,9 +954,9 @@ install_ovmf() {
 	tar xvf "${builddir}/${tarball_name}" -C "${destdir}"
 }
 
-# Install OVMF SEV
-install_ovmf_sev() {
-	install_ovmf "sev" "edk2-sev.tar.gz"
+# Install OVMF SNP
+install_ovmf_snp() {
+	install_ovmf "snp" "edk2-sev.tar.gz"
 }
 
 install_busybox() {
@@ -1192,7 +1192,7 @@ handle_build() {
 		install_log_parser_rs
 		install_nydus
 		install_ovmf
-		install_ovmf_sev
+		install_ovmf_snp
 		install_qemu
 		install_qemu_snp_experimental
 		install_qemu_tdx_experimental
@@ -1243,7 +1243,7 @@ handle_build() {
 
 	ovmf) install_ovmf ;;
 
-	ovmf-sev) install_ovmf_sev ;;
+	ovmf-snp) install_ovmf_snp ;;
 
 	pause-image) install_pause_image ;;
 

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -50,7 +50,7 @@ make -C BaseTools/
 info "Calling edksetup script"
 source edksetup.sh
 
-if [ "${ovmf_build}" == "sev" ]; then
+if [ "${ovmf_build}" == "snp" ]; then
 	info "Creating dummy grub file"
 	#required for building AmdSev package without grub
 	touch OvmfPkg/AmdSev/Grub/grub.efi
@@ -87,7 +87,7 @@ info "Install fd to destdir"
 install_dir="${DESTDIR}/${PREFIX}/share/ovmf"
 
 mkdir -p "${install_dir}"
-if [ "${ovmf_build}" == "sev" ]; then
+if [ "${ovmf_build}" == "snp" ]; then
 	install $build_root/$ovmf_dir/"${build_path_fv}"/OVMF.fd "${install_dir}/AMDSEV.fd"
 elif [ "${ovmf_build}" == "tdx" ]; then
 	install $build_root/$ovmf_dir/"${build_path_fv}"/OVMF.fd "${install_dir}"

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -33,10 +33,10 @@ if [ "${ovmf_build}" == "x86_64" ]; then
 	[ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps ".externals.ovmf.x86_64.version")
 	[ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps ".externals.ovmf.x86_64.package")
 	[ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps ".externals.ovmf.x86_64.package_output_dir")
-elif [ "${ovmf_build}" == "sev" ]; then
-	[ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps ".externals.ovmf.sev.version")
-	[ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps ".externals.ovmf.sev.package")
-	[ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps ".externals.ovmf.sev.package_output_dir")
+elif [ "${ovmf_build}" == "snp" ]; then
+	[ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps ".externals.ovmf.snp.version")
+	[ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps ".externals.ovmf.snp.package")
+	[ -n "$package_output_dir" ] || package_output_dir=$(get_from_kata_deps ".externals.ovmf.snp.package_output_dir")
 elif [ "${ovmf_build}" == "tdx" ]; then
 	[ -n "$ovmf_version" ] || ovmf_version=$(get_from_kata_deps ".externals.ovmf.tdx.version")
 	[ -n "$ovmf_package" ] || ovmf_package=$(get_from_kata_deps ".externals.ovmf.tdx.package")

--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -115,7 +115,7 @@ mapping:
       - Kata Containers CI / kata-containers-ci-on-push / build-kata-static-tarball-amd64 / build-asset (kernel-nvidia-gpu, test)
       - Kata Containers CI / kata-containers-ci-on-push / build-kata-static-tarball-amd64 / build-asset (kernel, test)
       - Kata Containers CI / kata-containers-ci-on-push / build-kata-static-tarball-amd64 / build-asset (nydus, test)
-      - Kata Containers CI / kata-containers-ci-on-push / build-kata-static-tarball-amd64 / build-asset (ovmf-sev, test)
+      - Kata Containers CI / kata-containers-ci-on-push / build-kata-static-tarball-amd64 / build-asset (ovmf-snp, test)
       - Kata Containers CI / kata-containers-ci-on-push / build-kata-static-tarball-amd64 / build-asset (ovmf, test)
       - Kata Containers CI / kata-containers-ci-on-push / build-kata-static-tarball-amd64 / build-asset (qemu-snp-experimental, test)
       - Kata Containers CI / kata-containers-ci-on-push / build-kata-static-tarball-amd64 / build-asset (qemu, test)

--- a/versions.yaml
+++ b/versions.yaml
@@ -362,8 +362,8 @@ externals:
       version: "edk2-stable202411"
       package: "OvmfPkg/OvmfPkgX64.dsc"
       package_output_dir: "OvmfX64"
-    sev:
-      description: "AmdSev build needed for SEV measured direct boot."
+    snp:
+      description: "AmdSev build needed for SNP measured direct boot."
       version: "edk2-stable202411"
       package: "OvmfPkg/AmdSev/AmdSevX64.dsc"
       package_output_dir: "AmdSev"


### PR DESCRIPTION
Follow up PR for PR #11380. Continuing deprecation of SEV from Kata by removing references from the
OVMF.