### PR TITLE
release: Copy the VERSION file to the tarball

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -343,6 +343,8 @@ jobs:
       - name: merge-artifacts
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+        env:
+          RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
       - name: store-artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -313,6 +313,8 @@ jobs:
       - name: merge-artifacts
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+        env:
+          RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
       - name: store-artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -256,6 +256,8 @@ jobs:
       - name: merge-artifacts
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+        env:
+          RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
       - name: store-artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -342,6 +342,8 @@ jobs:
       - name: merge-artifacts
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh kata-artifacts versions.yaml
+        env:
+          RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
       - name: store-artifacts
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-[ -z "${DEBUG}" ] || set -x
+[[ -z "${DEBUG}" ]] || set -x
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -26,13 +26,13 @@ mkdir "${tarball_content_dir}"
 
 for c in kata-static-*.tar.xz
 do
-	echo "untarring tarball "${c}" into ${tarball_content_dir}"
+	echo "untarring tarball \"${c}\" into ${tarball_content_dir}"
 	tar -xvf "${c}" -C "${tarball_content_dir}"
 done
 
-pushd ${tarball_content_dir}
+pushd "${tarball_content_dir}"
 	shim="containerd-shim-kata-v2"
-	shim_path=$(find . -name ${shim} | sort | head -1)
+	shim_path=$(find . -name "${shim}" | sort | head -1)
 	prefix=${shim_path%"bin/${shim}"}
 
 	if [[ "${RELEASE:-no}" == "yes" ]] && [[ -f "${repo_root_dir}/VERSION" ]]; then
@@ -40,9 +40,9 @@ pushd ${tarball_content_dir}
 		# thus we need to rely on the VERSION file.
 		cp "${repo_root_dir}/VERSION" "${prefix}/"
 	else
-		echo "$(git describe --tags)" > "${prefix}/VERSION"
+		git describe --tags > "${prefix}/VERSION"
 	fi
-	[[ -n "${kata_versions_yaml_file}" ]] && cp ${kata_versions_yaml_file_path} ${prefix}/
+	[[ -n "${kata_versions_yaml_file}" ]] && cp "${kata_versions_yaml_file_path}" "${prefix}/"
 popd
 
 echo "create ${tar_path}"


### PR DESCRIPTION
For the release itself, let's use the release version in the VERSION file.

To do so, we had to change the logic that merges the build, as at that point the tag is not yet pushed to the repo.