### PR TITLE
feat(hypervisor): implement VM startup from template in Rust runtime

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1221,6 +1221,23 @@ pub struct Hypervisor {
     /// Disable applying SELinux on the container process.
     #[serde(default = "yes")]
     pub disable_guest_selinux: bool,
+
+    /// Indicate whether the VM is being created as a template VM.
+    #[serde(default)]
+    pub boot_to_be_template: bool,
+
+    /// Indicate whether the VM should be created from an existing template VM.
+    #[serde(default = "yes")]
+    pub boot_from_template: bool,
+
+    /// Path to the device state file used for VM template migration.
+    /// Used when either `boot_to_be_template` or `boot_from_template` is true.
+    #[serde(default = "default_device_state_path")]
+    pub device_state_path: String,
+}
+
+fn default_device_state_path() -> String {
+    "/run/vc/vm/template/memory".to_string()
 }
 
 fn yes() -> bool {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2640,6 +2640,11 @@ impl<'a> QemuCmdLine<'a> {
 
         result.append(&mut self.knobs.qemu_params().await?);
 
+        if self.config.boot_from_template {
+            result.push("-incoming".to_string());
+            result.push("defer".to_string());
+        }
+        
         Ok(result)
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -26,11 +26,15 @@ use std::collections::HashMap;
 use std::convert::TryInto;
 use std::path::Path;
 use std::process::Stdio;
+use std::time::Duration;
 use tokio::sync::{mpsc, Mutex};
 use tokio::{
     io::{AsyncBufReadExt, BufReader},
     process::{Child, ChildStderr, Command},
 };
+
+use tokio::time::{sleep, timeout};
+use qapi_qmp::{MigrationStatus};
 
 const VSOCK_SCHEME: &str = "vsock";
 
@@ -224,7 +228,78 @@ impl QemuInner {
             }
         }
 
+        //Start the virtual machine by restoring it from a VM template if enabled.
+        if self.config.boot_from_template {
+            self.boot_from_template().await?;
+        }
+
         Ok(())
+    }
+
+    pub(crate) async fn boot_from_template(&mut self) -> Result<()> {
+        if let Some(ref mut qmp) = self.qmp {
+            info!(sl!(), "QemuInner::boot_from_template(): start");
+
+            // Set the migration capability to ignore shared memory regions during state restoration
+            if let Err(err) = qmp.set_ignore_shared_memory_capability() {
+                error!(sl!(), "QemuInner::set_ignore_shared_memory_capability(): {}", err);
+                return Err(err);
+            } else {
+                info!(sl!(), "QemuInner::set_ignore_shared_memory_capability() OK");
+            }
+
+            // Step 2: Build migration URI and execute migration
+            let uri = format!("exec:cat {}", self.config.device_state_path);
+            info!(sl!(), "QemuInner::device_state_path() = {}", uri);
+            
+            if let Err(err) = qmp.execute_migration_incoming(&uri) {
+                error!(sl!(), "QemuInner::execute_migration_incoming(): {}", err);
+                return Err(err);
+            } else {
+                info!(sl!(), "QemuInner::execute_migration_incoming() OK");
+            }
+
+            // Step 3: Wait for migration and check status
+            if let Err(err) = self.wait_for_migration().await {
+                error!(sl!(), "QemuInner::wait_for_migration() failed: {}", err);
+                return Err(err);
+            } else {
+                info!(sl!(), "QemuInner::wait_for_migration() OK");
+            }
+
+            Ok(())
+        } else {
+            warn!(sl!(), "QMP not initialized, skip boot_from_template()");
+            Ok(()) 
+        }
+    }
+
+    pub async fn wait_for_migration(&mut self) -> Result<()> {
+        let qmp = self.qmp.as_mut().ok_or_else(|| anyhow!("QMP not connected"))?;
+
+        let timeout_duration = Duration::from_secs(5);
+
+        let result = timeout(timeout_duration, async {
+            loop {
+                let status = qmp.query_migration()?;
+
+                if let Some(MigrationStatus::completed) = status.status {
+                    info!(sl!(), "QEMU migration completed");
+                    return Ok(());
+                } else if let Some(s) = status.status {
+                    info!(sl!(), "QEMU migration status: {:?}", s);
+                } else {
+                    info!(sl!(), "QEMU migration status: <unknown>");
+                }
+                sleep(Duration::from_millis(100)).await;
+            }
+        })
+        .await;
+
+        match result {
+            Ok(inner_result) => inner_result,
+            Err(_) => Err(anyhow!("Timed out waiting for QEMU migration")),
+        }
     }
 
     pub(crate) async fn stop_vm(&mut self) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -17,6 +17,9 @@ use std::time::Duration;
 
 use qapi::qmp;
 use qapi_qmp::{self, PciDeviceInfo};
+use qapi_qmp::{migrate_set_capabilities, MigrationCapability,MigrationCapabilityStatus};
+use qapi_qmp::migrate_incoming;
+use qapi_qmp::{query_migrate, MigrationInfo};
 use qapi_spec::Dictionary;
 
 /// default qmp connection read timeout
@@ -72,6 +75,34 @@ impl Qmp {
         info!(sl!(), "QMP initialized: {:#?}", info);
 
         Ok(qmp)
+    }
+
+    pub fn set_ignore_shared_memory_capability(&mut self) -> Result<()> {
+        let cap = migrate_set_capabilities {
+            capabilities: vec![
+                MigrationCapabilityStatus {
+                    capability: MigrationCapability::x_ignore_shared,
+                    state: true,
+                }
+            ],
+        };
+
+        self.qmp.execute(&cap)?;
+        Ok(())
+    }
+
+    pub fn execute_migration_incoming(&mut self, uri: &str) -> Result<()> {
+        let cmd = migrate_incoming {
+            uri: uri.to_string(),
+        };
+        self.qmp.execute(&cmd)?;
+        Ok(())
+    }   
+
+    pub fn query_migration(&mut self) -> Result<MigrationInfo> {
+        let cmd = query_migrate {};
+        let result = self.qmp.execute(&cmd)?;
+        Ok(result)
     }
 
     pub fn hotplug_vcpus(&mut self, vcpu_cnt: u32) -> Result<u32> {


### PR DESCRIPTION
##  Summary

This PR introduces initial support for booting QEMU virtual machines from a VM template in runtime-rs. It modifies both configuration structures and QEMU-related logic to support template-based startup. 
> Note: Since the VM template has not yet been created, this functionality has not been fully verified. The current implementation lays the groundwork for future template-based startup once the template generation is complete.

##  Changes

### Added three new configuration fields:
  * `boot_to_be_template: bool` : Indicate whether the VM is being created as a template VM.
  * `boot_from_template: bool` : Indicate whether the VM should be created from an existing template VM.
  * `device_state_path: Option<String>` : The VM device state file path. Used when either BootToBeTemplate or boot_from_template is true.

### Added QMP commands in  `runtime-rs/crates/hypervisor/src/qemu/qmp.rs`
  * `set_ignore_shared_memory_capability()`
  * `execute_migration_incoming()`
  * `query_migration()`

### Updated `QemuCmdLine::build()` 
Append `-incoming defer` when `boot_from_template` is true. Current logic is simplistic and will be refactored in the future.

###  Implemented `boot_from_template()` function.
* Checks if QMP is initialized; if not, skips the template boot process.
* Sets the migration capability to ignore shared memory regions.
* Builds the migration URI and executes incoming migration using the device state path.
* Waits for the migration process to complete successfully.
---

##  TODO / Follow-up

* Refactor the `incoming` parameter handling to follow the Go version's `addIncoming()` pattern.
* Add test coverage for VM template boot scenarios.
