### PR TITLE
agent: add debug flag to initdata

### DIFF
--- a/src/agent/src/initdata.rs
+++ b/src/agent/src/initdata.rs
@@ -2,7 +2,7 @@
 //!
 //! This module will do the following things if a proper initdata device with initdata exists.
 //! 1. Parse the initdata block device and extract the config files to [`INITDATA_PATH`].
-//! 2. Return the initdata and the policy (if any).
+//! 2. Return the initdata, the policy (if any) and the guest components debug flag (defaults to `false`).
 
 // Copyright (c) 2025 Alibaba Cloud
 //
@@ -26,6 +26,7 @@ pub const INITDATA_PATH: &str = "/run/confidential-containers/initdata";
 const AA_CONFIG_KEY: &str = "aa.toml";
 const CDH_CONFIG_KEY: &str = "cdh.toml";
 const POLICY_KEY: &str = "policy.rego";
+const DEBUG_FLAG: &str = "debug";
 
 /// The path of initdata toml
 pub const INITDATA_TOML_PATH: &str = concatcp!(INITDATA_PATH, "/initdata.toml");
@@ -100,6 +101,7 @@ pub async fn read_initdata(device_path: &str) -> Result<Vec<u8>> {
 pub struct InitdataReturnValue {
     pub _digest: Vec<u8>,
     pub _policy: Option<String>,
+    pub debug: bool,
 }
 
 pub async fn initialize_initdata(logger: &Logger) -> Result<Option<InitdataReturnValue>> {
@@ -150,11 +152,17 @@ pub async fn initialize_initdata(logger: &Logger) -> Result<Option<InitdataRetur
         info!(logger, "write CDH config from initdata");
     }
 
+    let debug = initdata
+        .get_coco_data(DEBUG_FLAG)
+        .map(|s| s == "true")
+        .unwrap_or(false);
+
     debug!(logger, "Initdata digest: {}", STANDARD.encode(&_digest));
 
     let res = InitdataReturnValue {
         _digest,
         _policy: initdata.get_coco_data(POLICY_KEY).cloned(),
+        debug,
     };
 
     Ok(Some(res))

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -484,9 +484,13 @@ async fn launch_guest_component_procs(
 
     debug!(logger, "spawning attestation-agent process {}", AA_PATH);
     let mut aa_args = vec!["--attestation_sock", AA_ATTESTATION_URI];
-    if initdata_return_value.is_some() {
+    let mut log_level = "info";
+    if let Some(initdata_return_value) = initdata_return_value {
         aa_args.push("--initdata-toml");
         aa_args.push(initdata::INITDATA_TOML_PATH);
+        if initdata_return_value.debug {
+            log_level = "debug";
+        }
     }
 
     launch_process(
@@ -496,7 +500,7 @@ async fn launch_guest_component_procs(
         Some(AA_CONFIG_PATH),
         AA_ATTESTATION_SOCKET,
         DEFAULT_LAUNCH_PROCESS_TIMEOUT,
-        &[],
+        &[("RUST_LOG", log_level)],
     )
     .await
     .map_err(|e| anyhow!("launch_process {} failed: {:?}", AA_PATH, e))?;
@@ -518,7 +522,10 @@ async fn launch_guest_component_procs(
         Some(CDH_CONFIG_PATH),
         CDH_SOCKET,
         DEFAULT_LAUNCH_PROCESS_TIMEOUT,
-        &[("OCICRYPT_KEYPROVIDER_CONFIG", OCICRYPT_CONFIG_PATH)],
+        &[
+            ("OCICRYPT_KEYPROVIDER_CONFIG", OCICRYPT_CONFIG_PATH),
+            ("RUST_LOG", log_level),
+        ],
     )
     .await
     .map_err(|e| anyhow!("launch_process {} failed: {:?}", CDH_PATH, e))?;
@@ -540,7 +547,7 @@ async fn launch_guest_component_procs(
         None,
         "",
         0,
-        &[],
+        &[("RUST_LOG", log_level)],
     )
     .await
     .map_err(|e| anyhow!("launch_process {} failed: {:?}", API_SERVER_PATH, e))?;


### PR DESCRIPTION
The debug flag will be used to control guest-components log level for now, and in future it can have more abilities. As initdata is measured by attestation, the debug flag can be detected by the trustee side thus safe.

Fixes: #11587