### PR TITLE
security: gha: Run Zizmor in auditor mode

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -26,3 +26,5 @@ jobs:
 
       - name: Run zizmor
         uses: zizmorcore/zizmor-action@f52a838cfabf134edcbaa7c8b3677dde20045018 # v0.1.1
+        with:
+          persona: auditor


### PR DESCRIPTION
These are all the issues found in this PR with this mode:

https://github.com/kata-containers/kata-containers/security/code-scanning?page=1&query=is%3Aopen+tool%3Azizmor+pr%3A11615

I will fix those existing issues in separate PRs. In the meantime, any PR that introduces more such issues will be blocked and will have to be fixed.