### PR TITLE
dragonball: Fix warnings in default build

### DIFF
--- a/src/dragonball/dbs_utils/src/net/mac.rs
+++ b/src/dragonball/dbs_utils/src/net/mac.rs
@@ -146,7 +146,6 @@ mod tests {
         assert!(MacAddr::from_bytes(&src3[..]).is_err());
     }
 
-    #[cfg(feature = "with-serde")]
     #[test]
     fn test_mac_addr_serialization_and_deserialization() {
         let mac: MacAddr =

--- a/src/dragonball/dbs_virtio_devices/src/vsock/mod.rs
+++ b/src/dragonball/dbs_virtio_devices/src/vsock/mod.rs
@@ -313,8 +313,8 @@ mod tests {
     pub struct TestContext {
         pub cid: u64,
         pub mem: GuestMemoryMmap,
-        pub mem_size: usize,
-        pub epoll_manager: EpollManager,
+        pub _mem_size: usize,
+        pub _epoll_manager: EpollManager,
         pub device: Vsock<Arc<GuestMemoryMmap>, TestMuxer>,
     }
 
@@ -327,8 +327,8 @@ mod tests {
             Self {
                 cid: CID,
                 mem,
-                mem_size: MEM_SIZE,
-                epoll_manager: epoll_manager.clone(),
+                _mem_size: MEM_SIZE,
+                _epoll_manager: epoll_manager.clone(),
                 device: Vsock::new_with_muxer(
                     CID,
                     Arc::new(defs::QUEUE_SIZES.to_vec()),
@@ -394,7 +394,7 @@ mod tests {
             EventHandlerContext {
                 guest_rxvq,
                 guest_txvq,
-                guest_evvq,
+                _guest_evvq: guest_evvq,
                 queues,
                 epoll_handler: None,
                 device: Vsock::new_with_muxer(
@@ -422,7 +422,7 @@ mod tests {
         pub queues: Vec<VirtioQueueConfig<QueueSync>>,
         pub guest_rxvq: GuestQ<'a>,
         pub guest_txvq: GuestQ<'a>,
-        pub guest_evvq: GuestQ<'a>,
+        pub _guest_evvq: GuestQ<'a>,
         pub mem: Arc<GuestMemoryMmap>,
     }
 

--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -17,7 +17,6 @@ use tracing::instrument;
 use crate::error::{Result, StartMicroVmError, StopMicrovmError};
 use crate::event_manager::EventManager;
 use crate::tracer::{DragonballTracer, TraceError, TraceInfo};
-use crate::vcpu::VcpuManagerError;
 use crate::vm::{CpuTopology, KernelConfigInfo, VmConfigInfo};
 use crate::vmm::Vmm;
 
@@ -55,6 +54,8 @@ pub use crate::device_manager::virtio_net_dev_mgr::{
 };
 #[cfg(feature = "virtio-vsock")]
 pub use crate::device_manager::vsock_dev_mgr::{VsockDeviceConfigInfo, VsockDeviceError};
+#[cfg(feature = "host-device")]
+use crate::vcpu::VcpuManagerError;
 #[cfg(feature = "hotplug")]
 pub use crate::vcpu::{VcpuResizeError, VcpuResizeInfo};
 

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -879,7 +879,7 @@ impl DeviceManager {
     /// Start all registered devices when booting the associated virtual machine.
     pub fn start_devices(
         &mut self,
-        vm_as: &GuestAddressSpaceImpl,
+        #[allow(unused)] vm_as: &GuestAddressSpaceImpl,
     ) -> std::result::Result<(), StartMicroVmError> {
         // It is safe because we don't expect poison lock.
         #[cfg(feature = "host-device")]
@@ -899,6 +899,7 @@ impl DeviceManager {
         address_space: Option<&AddressSpace>,
     ) -> Result<()> {
         // create context for removing devices
+        #[allow(unused)]
         let mut ctx = DeviceOpContext::new(
             Some(epoll_mgr),
             self,

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -1276,7 +1276,9 @@ mod tests {
     use dbs_address_space::{AddressSpaceLayout, AddressSpaceRegion, AddressSpaceRegionType};
     use kvm_ioctls::Kvm;
     use test_utils::skip_if_not_root;
-    use vm_memory::{GuestAddress, GuestUsize, MmapRegion};
+    #[cfg(feature = "virtio-fs")]
+    use vm_memory::MmapRegion;
+    use vm_memory::{GuestAddress, GuestUsize};
 
     use super::*;
     #[cfg(target_arch = "x86_64")]


### PR DESCRIPTION
We always compile dragonball with `make` command, which enables `all-features` by default in our makefile. This leave some warning in default `cargo build` unnoticed.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>