### PR TITLE
ci: Try passing api token into githubh api call

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -49,6 +49,8 @@ jobs:
 
       - name: Install dependencies
         run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -89,6 +91,8 @@ jobs:
 
       - name: Install dependencies
         run: bash tests/stability/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -132,6 +136,8 @@ jobs:
 
       - name: Install dependencies
         run: bash tests/integration/nydus/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -209,6 +215,8 @@ jobs:
 
       - name: Install dependencies
         run: bash tests/functional/tracing/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -253,6 +261,8 @@ jobs:
 
       - name: Install dependencies
         run: bash tests/functional/vfio/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -294,6 +304,8 @@ jobs:
 
       - name: Install dependencies
         run: bash tests/integration/docker/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -339,6 +351,7 @@ jobs:
       - name: Install dependencies
         env:
           GITHUB_API_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.token }}
         run: bash tests/integration/nerdctl/gha-run.sh install-dependencies
 
       - name: get-kata-tarball
@@ -383,6 +396,8 @@ jobs:
 
       - name: Install dependencies
         run: bash tests/functional/kata-agent-apis/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/basic-ci-s390x.yaml
+++ b/.github/workflows/basic-ci-s390x.yaml
@@ -48,7 +48,9 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
       - name: Install dependencies
-        run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
+        run: bash tests/integration/cri-containerd/gha-run.sh
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/run-cri-containerd-tests.yaml
+++ b/.github/workflows/run-cri-containerd-tests.yaml
@@ -59,6 +59,8 @@ jobs:
       - name: Install dependencies
         timeout-minutes: 15
         run: bash tests/integration/cri-containerd/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball for ${{ inputs.arch }}
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/run-kata-monitor-tests.yaml
+++ b/.github/workflows/run-kata-monitor-tests.yaml
@@ -54,6 +54,8 @@ jobs:
 
       - name: Install dependencies
         run: bash tests/functional/kata-monitor/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/run-runk-tests.yaml
+++ b/.github/workflows/run-runk-tests.yaml
@@ -38,6 +38,8 @@ jobs:
 
       - name: Install dependencies
         run: bash tests/integration/runk/gha-run.sh install-dependencies
+        env:
+          GH_TOKEN: ${{ github.token }}
 
       - name: get-kata-tarball
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -564,10 +564,10 @@ function get_from_kata_deps() {
 # project: org/repo format
 # base_version: ${major}.${minor}
 function get_latest_patch_release_from_a_github_project() {
-       project="${1}"
-       base_version="${2}"
+        project="${1}"
+        base_version="${2}"
 
-       curl --silent https://api.github.com/repos/${project}/releases | jq -r .[].tag_name | grep "^${base_version}.[0-9]*$" -m1
+        curl --header \"Authorization: Bearer "${GH_TOKEN:-}"\" --silent https://api.github.com/repos/${project}/releases | jq -r .[].tag_name | grep "^${base_version}.[0-9]*$" -m1
 }
 
 # base_version: The version to be intalled in the ${major}.${minor} format


### PR DESCRIPTION
Our CI keeps on getting
```
jq: error (at <stdin>:1): Cannot index string with string "tag_name"
```
during the install dependencies phase, which I suspect might be due to github rate limits being reduced, so try to pass through the `GH_TOKEN` env and use it in the auth header.