### PR TITLE
versions: Upgrade to Cloud Hypervisor v47.0

### DIFF
--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -594,7 +594,8 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 
 	if assetType == types.ImageAsset {
 		if clh.config.DisableImageNvdimm || clh.config.ConfidentialGuest {
-			disk := chclient.NewDiskConfig(assetPath)
+			disk := chclient.NewDiskConfig()
+			disk.Path = &assetPath
 			disk.SetReadonly(true)
 
 			diskRateLimiterConfig := clh.getDiskRateLimiterConfig()
@@ -886,7 +887,8 @@ func (clh *cloudHypervisor) hotplugAddBlockDevice(drive *config.BlockDrive) erro
 	}
 
 	// Create the clh disk config via the constructor to ensure default values are properly assigned
-	clhDisk := *chclient.NewDiskConfig(drive.File)
+	clhDisk := *chclient.NewDiskConfig()
+	clhDisk.Path = &drive.File
 	clhDisk.Readonly = &drive.ReadOnly
 	clhDisk.VhostUser = func(b bool) *bool { return &b }(false)
 	if clh.config.BlockDeviceCacheSet {

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/api/openapi.yaml
@@ -149,6 +149,9 @@ paths:
           description: The VM instance was successfully resized.
         "404":
           description: The VM instance could not be resized because it is not created.
+        "429":
+          description: The VM instance could not be resized because a cpu removal
+            is still pending.
       summary: Resize the VM
   /vm.resize-zone:
     put:
@@ -1762,8 +1765,6 @@ components:
           items:
             $ref: '#/components/schemas/VirtQueueAffinity'
           type: array
-      required:
-      - path
       type: object
     NetConfig:
       example:
@@ -1795,9 +1796,12 @@ components:
           type: string
         ip:
           default: 192.168.249.1
+          description: IPv4 or IPv6 address
           type: string
         mask:
           default: 255.255.255.0
+          description: Must be a valid IPv4 netmask if ip is an IPv4 address or a
+            valid IPv6 netmask if ip is an IPv6 address.
           type: string
         mac:
           type: string

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/DefaultApi.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/DefaultApi.md
@@ -637,7 +637,7 @@ import (
 )
 
 func main() {
-    diskConfig := *openapiclient.NewDiskConfig("Path_example") // DiskConfig | The details of the new disk
+    diskConfig := *openapiclient.NewDiskConfig() // DiskConfig | The details of the new disk
 
     configuration := openapiclient.NewConfiguration()
     api_client := openapiclient.NewAPIClient(configuration)

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/DiskConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/DiskConfig.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Path** | **string** |  | 
+**Path** | Pointer to **string** |  | [optional] 
 **Readonly** | Pointer to **bool** |  | [optional] [default to false]
 **Direct** | Pointer to **bool** |  | [optional] [default to false]
 **Iommu** | Pointer to **bool** |  | [optional] [default to false]
@@ -23,7 +23,7 @@ Name | Type | Description | Notes
 
 ### NewDiskConfig
 
-`func NewDiskConfig(path string, ) *DiskConfig`
+`func NewDiskConfig() *DiskConfig`
 
 NewDiskConfig instantiates a new DiskConfig object
 This constructor will assign default values to properties that have it defined,
@@ -57,6 +57,11 @@ and a boolean to check if the value has been set.
 
 SetPath sets Path field to given value.
 
+### HasPath
+
+`func (o *DiskConfig) HasPath() bool`
+
+HasPath returns a boolean if a field has been set.
 
 ### GetReadonly
 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/docs/NetConfig.md
@@ -5,8 +5,8 @@
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **Tap** | Pointer to **string** |  | [optional] 
-**Ip** | Pointer to **string** |  | [optional] [default to "192.168.249.1"]
-**Mask** | Pointer to **string** |  | [optional] [default to "255.255.255.0"]
+**Ip** | Pointer to **string** | IPv4 or IPv6 address | [optional] [default to "192.168.249.1"]
+**Mask** | Pointer to **string** | Must be a valid IPv4 netmask if ip is an IPv4 address or a valid IPv6 netmask if ip is an IPv6 address. | [optional] [default to "255.255.255.0"]
 **Mac** | Pointer to **string** |  | [optional] 
 **HostMac** | Pointer to **string** |  | [optional] 
 **Mtu** | Pointer to **int32** |  | [optional] 

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_disk_config.go
@@ -16,7 +16,7 @@ import (
 
 // DiskConfig struct for DiskConfig
 type DiskConfig struct {
-	Path              string               `json:"path"`
+	Path              *string              `json:"path,omitempty"`
 	Readonly          *bool                `json:"readonly,omitempty"`
 	Direct            *bool                `json:"direct,omitempty"`
 	Iommu             *bool                `json:"iommu,omitempty"`
@@ -36,9 +36,8 @@ type DiskConfig struct {
 // This constructor will assign default values to properties that have it defined,
 // and makes sure properties required by API are set, but the set of arguments
 // will change when the set of required properties is changed
-func NewDiskConfig(path string) *DiskConfig {
+func NewDiskConfig() *DiskConfig {
 	this := DiskConfig{}
-	this.Path = path
 	var readonly bool = false
 	this.Readonly = &readonly
 	var direct bool = false
@@ -74,28 +73,36 @@ func NewDiskConfigWithDefaults() *DiskConfig {
 	return &this
 }
 
-// GetPath returns the Path field value
+// GetPath returns the Path field value if set, zero value otherwise.
 func (o *DiskConfig) GetPath() string {
-	if o == nil {
+	if o == nil || o.Path == nil {
 		var ret string
 		return ret
 	}
-
-	return o.Path
+	return *o.Path
 }
 
-// GetPathOk returns a tuple with the Path field value
+// GetPathOk returns a tuple with the Path field value if set, nil otherwise
 // and a boolean to check if the value has been set.
 func (o *DiskConfig) GetPathOk() (*string, bool) {
-	if o == nil {
+	if o == nil || o.Path == nil {
 		return nil, false
 	}
-	return &o.Path, true
+	return o.Path, true
 }
 
-// SetPath sets field value
+// HasPath returns a boolean if a field has been set.
+func (o *DiskConfig) HasPath() bool {
+	if o != nil && o.Path != nil {
+		return true
+	}
+
+	return false
+}
+
+// SetPath gets a reference to the given string and assigns it to the Path field.
 func (o *DiskConfig) SetPath(v string) {
-	o.Path = v
+	o.Path = &v
 }
 
 // GetReadonly returns the Readonly field value if set, zero value otherwise.
@@ -516,7 +523,7 @@ func (o *DiskConfig) SetQueueAffinity(v []VirtQueueAffinity) {
 
 func (o DiskConfig) MarshalJSON() ([]byte, error) {
 	toSerialize := map[string]interface{}{}
-	if true {
+	if o.Path != nil {
 		toSerialize["path"] = o.Path
 	}
 	if o.Readonly != nil {

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/client/model_net_config.go
@@ -16,8 +16,10 @@ import (
 
 // NetConfig struct for NetConfig
 type NetConfig struct {
-	Tap               *string            `json:"tap,omitempty"`
-	Ip                *string            `json:"ip,omitempty"`
+	Tap *string `json:"tap,omitempty"`
+	// IPv4 or IPv6 address
+	Ip *string `json:"ip,omitempty"`
+	// Must be a valid IPv4 netmask if ip is an IPv4 address or a valid IPv6 netmask if ip is an IPv6 address.
 	Mask              *string            `json:"mask,omitempty"`
 	Mac               *string            `json:"mac,omitempty"`
 	HostMac           *string            `json:"host_mac,omitempty"`

--- a/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
+++ b/src/runtime/virtcontainers/pkg/cloud-hypervisor/cloud-hypervisor.yaml
@@ -160,6 +160,8 @@ paths:
           description: The VM instance was successfully resized.
         404:
           description: The VM instance could not be resized because it is not created.
+        429:
+          description: The VM instance could not be resized because a cpu removal is still pending.
 
   /vm.resize-zone:
     put:
@@ -885,8 +887,6 @@ components:
             type: integer
 
     DiskConfig:
-      required:
-        - path
       type: object
       properties:
         path:
@@ -935,9 +935,11 @@ components:
         ip:
           type: string
           default: "192.168.249.1"
+          description: IPv4 or IPv6 address
         mask:
           type: string
           default: "255.255.255.0"
+          description: Must be a valid IPv4 netmask if ip is an IPv4 address or a valid IPv6 netmask if ip is an IPv6 address.
         mac:
           type: string
         host_mac:

--- a/versions.yaml
+++ b/versions.yaml
@@ -75,7 +75,7 @@ assets:
       url: "https://github.com/cloud-hypervisor/cloud-hypervisor"
       uscan-url: >-
         https://github.com/cloud-hypervisor/cloud-hypervisor/tags.*/v?(\d\S+)\.tar\.gz
-      version: "v45.0"
+      version: "v47.0"
 
     firecracker:
       description: "Firecracker micro-VMM"


### PR DESCRIPTION
## v47.0

### Block Device Error Reporting to the Guest

Instead of exiting on I/O errors, the `virtio-block` device now reports
errors to the guest using `VIRTIO_BLK_S_IOERR`. It improves the user
experience particularly when the guest rootfs is not backed by the
affected block device.

### Nice Error Messages on Exit

We now have the chain of errors being reported and printed nicely, when
Cloud Hypervisor or ch-remote exits on errors.

### Alphabetically Sorted CLI Options for ch-remote

To improve readability, ch-remote now prints help information in
alphabetical order.

### Notable Bug Fixes

* Error out early when block device serial is too long
* Fix partial commands being discarded for `virtio-vsock`
* Disable the broken interrupt support for the `rtc_pl031` device to
  prevent spurious guest interrupts

### Deprecations

* A default IP (`192.168.249.1`) and mask (`255.255.255.0`) are
 currently assigned  to the `virtio-net` device if no value is specified
 by users. Such behavior is now deprecated.  Users of this behavior will
 receive a warning message and should make adjustments. The behavior
 will be removed in two release cycles (v49.0).

## v46.0

### File-level Locking Support with `--disk`

Now file-level locking is enforced for disk images, provided by users
with `--disk`. This ensures that only a single Cloud Hypervisor instance
can obtain write access to a given disk image at any time, preventing
misconfiguration and avoiding potential data corruption.

### Improved Error Reporting with VM Resizing

Instead of returning a generic error `400` (e.g. `BadRequest`), users
now get a more specific error `429` (e.g. `TooManyRequests`) when a
pending VM resizing is not completed. This allows users to better handle
different errors, say retrying the request when applicable.

### IPv6 Address Support with `--net`

It is now possible to specify an IPv6 address and mask when creating a
network interface with `--net`.

### Experimental AArch64 Support with the MSHV Hypervisor

It is now possible to start VMs on AArch64 platforms when using MSHV
hypervisor.

### Deprecated SGX Support

The SGX support now is deprecated with a warning message if it being
used, with the intention to remove its support from our code base in two
release cycles (e.g. v48.0).

### Notable Bug Fixes

* Remove `path` as required for `DiskConfig` from the OpenAPI spec file
* Properly parse PCI capabilities
* Reprogram PCI device BAR when its MSE bit is set
* Update IOMMU mappings of MMIO regions with BAR reprogram for VFIO
  devices
* Avoid resizing VMs to zero vCPUs
* Fix extended topology enumeration leaf exposed to the guest