### PR TITLE
Updated Firecracker Version to 1.12.1

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -83,7 +83,7 @@ assets:
       uscan-url: >-
         https://github.com/firecracker-microvm/firecracker/tags
         .*/v?(\d\S+)\.tar\.gz
-      version: "v1.8.0"
+      version: "v1.12.1"
 
     qemu:
       description: "VMM that uses KVM"


### PR DESCRIPTION
This PR updates the Firecracker version bundled with Kata Containers from **v1.8.0** to the latest stable **v1.12.1**.

---

###  Summary of Changes

-  Updated `versions.yaml` to point to Firecracker **v1.12.1**

---

###  Verification & Testing on VPS

#### 🔧 Binary Version Check
```bash
/opt/kata/bin/firecracker --version
# Output:
Firecracker v1.12.1

/opt/kata/bin/jailer --version
# Output:
jailer v1.12.1

````

####  Functional Validation with Kubernetes On VPS

* Deployed **5 pods** using `kata-fc` runtime class and `gitpod/openvscode-server:latest` container.
* All pods launched successfully and were in `Running` state.
* Verified container access, resource allocation, and proper Firecracker usage.

```bash
kubectl get pods
# All pods showed STATUS=Running

kubectl exec -it vscode-kata-1 -- uname -a
# Output showed kernel running inside the microVM

ps aux | grep firecracker
# Verified that Firecracker process was running
```

####  Example Pod Description (vscode-kata-1)

* RuntimeClass: `kata-fc`
* Container image: `gitpod/openvscode-server:latest`
* Memory limit: `1Gi`, CPU: `1`
* Kernel: `Linux 6.12.36` inside microVM
* Pod scheduled and initialized correctly

-  Replaced both `firecracker` and `jailer` binaries under `/opt/kata/bin`
and tested if its able to create microvm 
---

###  Ready for Review

The Process is tested on a VPS and ready for review. Please let me know if you'd like any additional tests or modifications.

---

