### PR TITLE
ci: add genpolicy build for Darwin

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -18,6 +18,14 @@ jobs:
     name: test
     runs-on: macos-latest
     steps:
+    - name: Install Protoc
+      run: |
+        f=$(mktemp)
+        curl -sSLo "$f" https://github.com/protocolbuffers/protobuf/releases/download/v28.2/protoc-28.2-osx-aarch_64.zip
+        mkdir -p "$HOME/.local"
+        unzip -d "$HOME/.local" "$f"
+        echo "$HOME/.local/bin" >> "${GITHUB_PATH}"
+
     - name: Checkout code
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       with:
@@ -27,6 +35,9 @@ jobs:
       run: |
         ./tests/install_go.sh -f -p
         echo "/usr/local/go/bin" >> "${GITHUB_PATH}"
+
+    - name: Install Rust
+      run: ./tests/install_rust.sh
 
     - name: Build utils
       run: ./ci/darwin-test.sh

--- a/ci/darwin-test.sh
+++ b/ci/darwin-test.sh
@@ -8,6 +8,7 @@ set -e
 
 cidir=$(dirname "$0")
 runtimedir=${cidir}/../src/runtime
+genpolicydir=${cidir}/../src/tools/genpolicy
 
 build_working_packages() {
 	# working packages:
@@ -40,3 +41,11 @@ build_working_packages() {
 }
 
 build_working_packages
+
+build_genpolicy() {
+	echo "building genpolicy"
+	pushd "${genpolicydir}" &>/dev/null
+	make TRIPLE=aarch64-apple-darwin build
+}
+
+build_genpolicy

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -88,7 +88,7 @@ vsock-exporter = { path = "vsock-exporter" }
 mem-agent = { path = "../mem-agent", package = "mem-agent-lib" }
 
 kata-sys-util = { path = "../libs/kata-sys-util" }
-kata-types = { path = "../libs/kata-types" }
+kata-types = { path = "../libs/kata-types", features = ["safe-path"] }
 # Note: this crate sets the slog 'max_*' features which allows the log level
 # to be modified at runtime.
 logging = { path = "../libs/logging" }

--- a/src/libs/kata-types/Cargo.toml
+++ b/src/libs/kata-types/Cargo.toml
@@ -32,7 +32,8 @@ flate2 = { version = "1.0", features = ["zlib"] }
 hex = "0.4"
 
 oci-spec = { version = "0.8.1", features = ["runtime"] }
-safe-path = { path = "../safe-path" }
+
+safe-path = { path = "../safe-path", optional = true }
 
 [dev-dependencies]
 tempfile = "3.19.1"
@@ -42,3 +43,4 @@ nix = "0.26.4"
 [features]
 default = []
 enable-vendor = []
+safe-path = ["dep:safe-path"] # safe-path is platform-specific

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -6,7 +6,7 @@
 
 use anyhow::{anyhow, Context, Error, Result};
 use std::convert::TryFrom;
-use std::{collections::HashMap, fs, path::PathBuf};
+use std::{collections::HashMap, path::PathBuf};
 
 use crate::build_path;
 use crate::handler::HandlerManager;
@@ -483,6 +483,8 @@ pub trait StorageDevice: Send + Sync {
 /// Joins a user-provided volume path with the Kata direct-volume root path.
 ///
 /// The `volume_path` is base64-url-encoded and then safely joined to the `prefix`.
+/// `safe_path` is OS-specific.
+#[cfg(feature = "safe-path")]
 pub fn join_path(prefix: &str, volume_path: &str) -> Result<PathBuf> {
     if volume_path.is_empty() {
         return Err(anyhow!(std::io::ErrorKind::NotFound));
@@ -493,10 +495,12 @@ pub fn join_path(prefix: &str, volume_path: &str) -> Result<PathBuf> {
 }
 
 /// Gets `DirectVolumeMountInfo` from `mountinfo.json`.
+/// `safe_path` is OS-specific.
+#[cfg(feature = "safe-path")]
 pub fn get_volume_mount_info(volume_path: &str) -> Result<DirectVolumeMountInfo> {
     let volume_path = join_path(kata_direct_volume_root_path().as_str(), volume_path)?;
     let mount_info_file_path = volume_path.join(KATA_MOUNT_INFO_FILE_NAME);
-    let mount_info_file = fs::read_to_string(mount_info_file_path)?;
+    let mount_info_file = std::fs::read_to_string(mount_info_file_path)?;
     let mount_info: DirectVolumeMountInfo = serde_json::from_str(&mount_info_file)?;
 
     Ok(mount_info)

--- a/src/runtime-rs/Cargo.toml
+++ b/src/runtime-rs/Cargo.toml
@@ -34,7 +34,7 @@ wasm_container = { path = "crates/runtimes/wasm_container" }
 
 # Local dependencies from `src/libs`
 kata-sys-util = { path = "../libs/kata-sys-util" }
-kata-types = { path = "../libs/kata-types" }
+kata-types = { path = "../libs/kata-types", features = ["safe-path"] }
 logging = { path = "../libs/logging" }
 protocols = { path = "../libs/protocols", features = ["async"] }
 runtime-spec = { path = "../libs/runtime-spec" }

--- a/src/tools/genpolicy/Cargo.lock
+++ b/src/tools/genpolicy/Cargo.lock
@@ -1612,7 +1612,6 @@ dependencies = [
  "num_cpus",
  "oci-spec",
  "regex",
- "safe-path",
  "serde",
  "serde-enum-str",
  "serde_json",
@@ -2588,13 +2587,6 @@ name = "ryu"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "safe-path"
-version = "0.1.0"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "schannel"

--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -29,7 +29,7 @@ toml = "0.5.8"
 sys-info = "0.9.1"
 
 shim-interface = { path = "../../libs/shim-interface" }
-kata-types = { path = "../../libs/kata-types" }
+kata-types = { path = "../../libs/kata-types", features = ["safe-path"] }
 kata-sys-util = { path = "../../../src/libs/kata-sys-util/" }
 safe-path = { path = "../../libs/safe-path" }
 agent = { path = "../../runtime-rs/crates/agent" }

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -822,7 +822,7 @@ function install_docker() {
 
 # Convert architecture to the name used by golang
 function arch_to_golang() {
-	local arch="$(uname -m)"
+	local -r arch="$(uname -m)"
 
 	case "${arch}" in
 		aarch64|arm64) echo "arm64";;
@@ -839,7 +839,7 @@ function arch_to_rust() {
 	local -r arch="$(uname -m)"
 
 	case "${arch}" in
-		aarch64) echo "${arch}";;
+		aarch64|arm64) echo "aarch64";;
 		ppc64le) echo "powerpc64le";;
 		riscv64) echo "riscv64gc";;
 		x86_64) echo "${arch}";;
@@ -853,7 +853,7 @@ function arch_to_kernel() {
 	local -r arch="$(uname -m)"
 
 	case "${arch}" in
-		aarch64) echo "arm64";;
+		aarch64|arm64) echo "arm64";;
 		ppc64le) echo "powerpc";;
 		x86_64) echo "${arch}";;
 		s390x) echo "s390x";;

--- a/tests/install_rust.sh
+++ b/tests/install_rust.sh
@@ -9,21 +9,20 @@ set -o nounset
 set -o pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-script_name="$(basename "${BASH_SOURCE[0]}")"
 
 source "${script_dir}/common.bash"
 
 rustarch=$(arch_to_rust)
 
 version="${1:-""}"
-if [ -z "${version}" ]; then
+if [[ -z "${version}" ]]; then
 	version=$(get_from_kata_deps ".languages.rust.meta.newest-version")
 fi
 
 echo "Install rust ${version}"
 
 if ! command -v rustup > /dev/null; then
-	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${version}
+	curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain "${version}"
 fi
 
 export PATH="${PATH}:${HOME}/.cargo/bin"
@@ -33,13 +32,13 @@ export PATH="${PATH}:${HOME}/.cargo/bin"
 ## with a different version toolchain.
 ## Even though the target version toolchain has been installed,
 ## this command will not take too long to run.
-rustup toolchain install ${version}
-rustup default ${version}
-if [ "${rustarch}" == "x86_64" ] || [ "${rustarch}" == "aarch64" ] ; then
-	rustup target add ${rustarch}-unknown-linux-musl
-	$([ "$(whoami)" != "root" ] && echo sudo) ln -sf /usr/bin/g++ /bin/musl-g++
+rustup toolchain install "${version}"
+rustup default "${version}"
+if [[ "${rustarch}" == "x86_64" || "${rustarch}" == "aarch64" ]] ; then
+	rustup target add "${rustarch}-unknown-linux-musl"
+	$([[ "$(whoami)" != "root" ]] && echo sudo) ln -sf /usr/bin/g++ /bin/musl-g++
 else
-	rustup target add ${rustarch}-unknown-linux-gnu
+	rustup target add "${rustarch}-unknown-linux-gnu"
 fi
 rustup component add rustfmt
 rustup component add clippy

--- a/tests/install_rust.sh
+++ b/tests/install_rust.sh
@@ -35,8 +35,10 @@ export PATH="${PATH}:${HOME}/.cargo/bin"
 rustup toolchain install "${version}"
 rustup default "${version}"
 if [[ "${rustarch}" == "x86_64" || "${rustarch}" == "aarch64" ]] ; then
-	rustup target add "${rustarch}-unknown-linux-musl"
-	$([[ "$(whoami)" != "root" ]] && echo sudo) ln -sf /usr/bin/g++ /bin/musl-g++
+	if [[ "$(uname -s)" != "Darwin" ]]; then
+		rustup target add "${rustarch}-unknown-linux-musl"
+		$([[ "$(whoami)" != "root" ]] && echo sudo) ln -sf /usr/bin/g++ /bin/musl-g++
+	fi
 else
 	rustup target add "${rustarch}-unknown-linux-gnu"
 fi


### PR DESCRIPTION
Overall, the goal is to build the genpolicy package in CI (eventually as required job), such that we learn of darwin support regressions in the tool. This PR adds the build to the existing, non-required darwin CI job, so that we can monitor its stability.  

Prerequisite: allow using `kata-types` on non-Linux
Drive-by: fix shellcheck issues in install_rust.sh

Fixes: #11635