### PR TITLE
tests: k8s-sandbox-vcpus-allocation debug info

### DIFF
--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -26,6 +26,9 @@ setup() {
 }
 
 @test "Check the number vcpus are correctly allocated to the sandbox" {
+	local pod
+	local log
+
 	# Create the pods
 	kubectl create -f "${yaml_file}"
 
@@ -34,7 +37,13 @@ setup() {
 
 	# Check the pods
 	for i in {0..2}; do
-		[ `kubectl logs ${pods[$i]}` -eq ${expected_vcpus[$i]} ]
+		pod="${pods[$i]}"
+		bats_unbuffered_info "Getting log for pod: ${pod}"
+
+		log=$(kubectl logs "${pod}")
+		bats_unbuffered_info "Log: ${log}"
+
+		[ "${log}" -eq "${expected_vcpus[$i]}" ]
 	done
 }
 


### PR DESCRIPTION
Print more details about the behavior of "kubectl logs", trying to understand errors like:

https://github.com/kata-containers/kata-containers/actions/runs/16662887973/job/47164791712

not ok 1 Check the number vcpus are correctly allocated to the sandbox
 (in test file k8s-sandbox-vcpus-allocation.bats, line 37)
   `[ `kubectl logs ${pods[$i]}` -eq ${expected_vcpus[$i]} ]' failed with status 2
 No resources found in kata-containers-k8s-tests namespace.
...
 k8s-sandbox-vcpus-allocation.bats: line 37: [: -eq: unary operator expected