### PR TITLE
cri-containerd: Skip virtio-mem on aarch64

### DIFF
--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -280,7 +280,7 @@ function PrepareContainerMemoryUpdate() {
 	test_virtio_mem=$1
 
 	if [ $test_virtio_mem -eq 1 ]; then
-		if [[ "$ARCH" != "x86_64" ]] && [[ "$ARCH" != "aarch64" ]]; then
+		if [[ "$ARCH" != "x86_64" ]]; then
 			return
 		fi
 		info "Test container memory update with virtio-mem"


### PR DESCRIPTION
I am not sure why it's breaking with the new HW. For now we're disabling it, and we'll re-enable it after investigating / finding a fix.