### PR TITLE
genpolicy: support AddARPNeighbors

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -347,6 +347,14 @@
                 "^127\\.(?:[0-9]{1,3}\\.){2}[0-9]{1,3}$"
             ]
         },
+        "AddARPNeighborsRequest": {
+            "forbidden_device_names": [
+                "lo"
+            ],
+            "forbidden_cidrs_regex": [
+                "^127\\.(?:[0-9]{1,3}\\.){2}[0-9]{1,3}$"
+            ]
+        },
         "CloseStdinRequest": false,
         "ReadStreamRequest": false,
         "UpdateEphemeralMountsRequest": false,

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1400,6 +1400,25 @@ UpdateInterfaceRequest if {
     print("UpdateInterfaceRequest: true")
 }
 
+AddARPNeighborsRequest if {
+    p_defaults := policy_data.request_defaults.AddARPNeighborsRequest
+    print("AddARPNeighborsRequest: policy =", p_defaults)
+
+    every i_neigh in input.neighbors.ARPNeighbors {
+        print("AddARPNeighborsRequest: i_neigh =", i_neigh)
+
+        not i_neigh.device in p_defaults.forbidden_device_names
+        i_neigh.toIPAddress.mask == ""
+        every p_cidr in p_defaults.forbidden_cidrs_regex {
+            not regex.match(p_cidr, i_neigh.toIPAddress.address)
+        }
+        i_neigh.state == 128
+        bits.or(i_neigh.flags, 136) == 136
+    }
+
+    print("AddARPNeighborsRequest: true")
+}
+
 CloseStdinRequest if {
     policy_data.request_defaults.CloseStdinRequest == true
 }

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -355,6 +355,16 @@ pub struct UpdateInterfaceRequestDefaults {
     forbidden_hw_addrs: Vec<String>,
 }
 
+/// UpdateInterfaceRequest settings from genpolicy-settings.json.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AddARPNeighborsRequestDefaults {
+    /// Explicitly blocked interface names. Intent is to block changes to loopback interface.
+    forbidden_device_names: Vec<String>,
+    /// Explicitly blocked IP address ranges.
+    /// Should include loopback addresses and other CIDRs that should not be routed outside the VM.
+    forbidden_cidrs_regex: Vec<String>,
+}
+
 /// Settings specific to each kata agent endpoint, loaded from
 /// genpolicy-settings.json.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -373,6 +383,9 @@ pub struct RequestDefaults {
 
     /// Allow the host to configure only used raw_flags and reject names/mac addresses of the loopback.
     pub UpdateInterfaceRequest: UpdateInterfaceRequestDefaults,
+
+    /// Allow the host to configure only used raw_flags and reject names/mac addresses of the loopback.
+    pub AddARPNeighborsRequest: AddARPNeighborsRequestDefaults,
 
     /// Allow the Host to close stdin for a container. Typically used with WriteStreamRequest.
     pub CloseStdinRequest: bool,

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -13,8 +13,8 @@ mod tests {
     use std::str;
 
     use protocols::agent::{
-        CopyFileRequest, CreateContainerRequest, CreateSandboxRequest, ExecProcessRequest,
-        RemoveContainerRequest, UpdateInterfaceRequest, UpdateRoutesRequest,
+        AddARPNeighborsRequest, CopyFileRequest, CreateContainerRequest, CreateSandboxRequest,
+        ExecProcessRequest, RemoveContainerRequest, UpdateInterfaceRequest, UpdateRoutesRequest,
     };
     use serde::{Deserialize, Serialize};
 
@@ -32,6 +32,7 @@ mod tests {
         RemoveContainer(RemoveContainerRequest),
         UpdateInterface(UpdateInterfaceRequest),
         UpdateRoutes(UpdateRoutesRequest),
+        AddARPNeighbors(AddARPNeighborsRequest),
     }
 
     impl Display for TestRequest {
@@ -44,6 +45,7 @@ mod tests {
                 TestRequest::RemoveContainer(_) => write!(f, "RemoveContainerRequest"),
                 TestRequest::UpdateInterface(_) => write!(f, "UpdateInterfaceRequest"),
                 TestRequest::UpdateRoutes(_) => write!(f, "UpdateRoutesRequest"),
+                TestRequest::AddARPNeighbors(_) => write!(f, "AddARPNeighborsRequest"),
             }
         }
     }
@@ -238,6 +240,11 @@ mod tests {
     #[tokio::test]
     async fn test_update_interface() {
         runtests("updateinterface").await;
+    }
+
+    #[tokio::test]
+    async fn test_add_arp_neighbors() {
+        runtests("addarpneighbors").await;
     }
 
     #[tokio::test]

--- a/src/tools/genpolicy/tests/policy/testdata/addarpneighbors/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/addarpneighbors/pod.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+  - name: dummy
+    image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db

--- a/src/tools/genpolicy/tests/policy/testdata/addarpneighbors/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/addarpneighbors/testcases.json
@@ -1,0 +1,156 @@
+[
+  {
+    "description": "compliant neighbors",
+    "allowed": true,
+    "request": {
+      "type": "AddARPNeighbors",
+      "neighbors": {
+        "ARPNeighbors": [
+          {
+            "toIPAddress": {
+              "family": 0,
+              "address": "10.0.0.1",
+              "mask": ""
+            },
+            "device": "eth0",
+            "lladdr": "00:00:5e:00:53:01",
+            "state": 128,
+            "flags": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "description": "allowed flags: NTF_PROXY",
+    "allowed": true,
+    "request": {
+      "type": "AddARPNeighbors",
+      "neighbors": {
+        "ARPNeighbors": [
+          {
+            "toIPAddress": {
+              "family": 0,
+              "address": "10.0.0.1",
+              "mask": ""
+            },
+            "device": "eth0",
+            "lladdr": "00:00:5e:00:53:01",
+            "state": 128,
+            "flags": 8
+          }
+        ]
+      }
+    }
+  },
+  {
+    "description": "allowed flags: NTF_ROUTER",
+    "allowed": true,
+    "request": {
+      "type": "AddARPNeighbors",
+      "neighbors": {
+        "ARPNeighbors": [
+          {
+            "toIPAddress": {
+              "family": 0,
+              "address": "10.0.0.1",
+              "mask": ""
+            },
+            "device": "eth0",
+            "lladdr": "00:00:5e:00:53:01",
+            "state": 128,
+            "flags": 128
+          }
+        ]
+      }
+    }
+  },
+  {
+    "description": "bad interface",
+    "allowed": false,
+    "request": {
+      "type": "AddARPNeighbors",
+      "neighbors": {
+        "ARPNeighbors": [
+          {
+            "toIPAddress": {
+              "family": 0,
+              "address": "10.0.0.1",
+              "mask": ""
+            },
+            "device": "lo",
+            "lladdr": "00:00:5e:00:53:01",
+            "state": 128,
+            "flags": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "description": "bad IP",
+    "allowed": false,
+    "request": {
+      "type": "AddARPNeighbors",
+      "neighbors": {
+        "ARPNeighbors": [
+          {
+            "toIPAddress": {
+              "family": 0,
+              "address": "127.1.2.3",
+              "mask": ""
+            },
+            "device": "eth0",
+            "lladdr": "00:00:5e:00:53:01",
+            "state": 128,
+            "flags": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "description": "bad state",
+    "allowed": false,
+    "request": {
+      "type": "AddARPNeighbors",
+      "neighbors": {
+        "ARPNeighbors": [
+          {
+            "toIPAddress": {
+              "family": 0,
+              "address": "10.0.0.1",
+              "mask": ""
+            },
+            "device": "eth0",
+            "lladdr": "00:00:5e:00:53:01",
+            "state": 0,
+            "flags": 0
+          }
+        ]
+      }
+    }
+  },
+  {
+    "description": "bad flags",
+    "allowed": false,
+    "request": {
+      "type": "AddARPNeighbors",
+      "neighbors": {
+        "ARPNeighbors": [
+          {
+            "toIPAddress": {
+              "family": 0,
+              "address": "10.0.0.1",
+              "mask": ""
+            },
+            "device": "eth0",
+            "lladdr": "00:00:5e:00:53:01",
+            "state": 128,
+            "flags": 5
+          }
+        ]
+      }
+    }
+  }
+]


### PR DESCRIPTION
When the network interface provisioned by the CNI has static ARP table entries, the runtime calls `AddARPNeighbor` to propagate these to the agent. As of today, these calls are simply rejected.

In order to allow the calls, we do some sanity checks on the arguments.

We must ensure that we don't unexpectedly route traffic to the host that was not intended to leave the VM. In a first approximation, this applies to loopback IPs and devices. However, there may be other sensitive ranges (for example, VPNs between VMs), so there should be some flexibility for users to restrict this further. This is why we introduce a setting, similar to `UpdateRoutes`, that allows restricting the neighbor IPs further. Note that reverting back to the existing "deny all ARP neighbours" behaviour is as simple as forbidding IP `.*`.

Forbidding ARP entries for loopback IPs is mostly defence-in-depth - these should be rejected/ignored by the kernel!

The only valid state of an ARP neighbor entry is `NUD_PERMANENT`, which [has a value of `128`](https://github.com/torvalds/linux/blob/479058002c32b77acac43e883b92174e22c4be2d/include/uapi/linux/neighbour.h#L72). This is already [enforced by the runtime](https://github.com/kata-containers/kata-containers/blob/af01434226d1f6cecb344d6f1841025e40255c29/src/runtime/virtcontainers/network_linux.go#L1617-L1620).

According to `rtnetlink(7)`:

```
              Valid ndm_flags are:
              NTF_PROXY    a proxy arp entry
              NTF_ROUTER   an IPv6 router
```

These values [are 8 and 128, respectively](https://github.com/torvalds/linux/blob/479058002c32b77acac43e883b92174e22c4be2d/include/uapi/linux/neighbour.h#L49C20-L53), thus we allow any combination of these (`128 | 8 == 136`). 