### PR TITLE
ci: static-checks: add SECURITY.md to exclude list

### DIFF
--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -780,6 +780,7 @@ static_check_docs()
 
 	exclude_doc_regexs+=(^CODE_OF_CONDUCT\.md$)
 	exclude_doc_regexs+=(^CONTRIBUTING\.md$)
+	exclude_doc_regexs+=(^SECURITY\.md$)
 
 	# Magic github template files
 	exclude_doc_regexs+=(^\.github/.*\.md$)


### PR DESCRIPTION
This adds SECURITY.md to the list of GH-native files that should be excluded by the reference checker.

Today this is useful for downstreams who already have a SECURITY.md file for compliance reasons. When Kata onboards that file, this commit will also be required.