### PR TITLE
ci: cri-containerd: add 5s timeout for creating sanbox with crictl

### DIFF
--- a/tests/integration/cri-containerd/integration-tests.sh
+++ b/tests/integration/cri-containerd/integration-tests.sh
@@ -211,7 +211,7 @@ EOF
 	restart_containerd_service
 
 	sudo crictl pull $image
-	podid=$(sudo crictl runp $pod_yaml)
+	podid=$(sudo crictl --timeout=5s runp $pod_yaml)
 	cid=$(sudo crictl create $podid $container_yaml $pod_yaml)
 	sudo crictl start $cid
 }
@@ -537,7 +537,7 @@ EOF
 	restart_containerd_service
 
 	sudo crictl pull $image
-	podid=$(sudo crictl runp $pod_yaml)
+	podid=$(sudo crictl --timeout=5s runp $pod_yaml)
 	cid1=$(sudo crictl create $podid $container1_yaml $pod_yaml)
 	cid2=$(sudo crictl create $podid $container2_yaml $pod_yaml)
 	sudo crictl start $cid1


### PR DESCRIPTION
After moving Arm64 CI nodes to new `not powerful` one, we do faced an interesting issue for timeout when it executes the command with `crictl runp`,  the error is usally: code = DeadlineExceeded 

Closes: #11662 