### PR TITLE
CI: change the directory for Arm64 firmware

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -460,10 +460,10 @@ ifneq (,$(QEMUCMD))
     FIRMWAREPATH_NV := $(PREFIXDEPS)/share/ovmf/OVMF.fd
 
     ifneq (,$(QEMUFW))
-        FIRMWAREPATH := $(PREFIXDEPS)/share/ovmf/$(QEMUFW)
+        FIRMWAREPATH := $(PREFIXDEPS)/share/aavmf/$(QEMUFW)
     endif
     ifneq (,$(QEMUFWVOL))
-        FIRMWAREVOLUMEPATH := $(PREFIXDEPS)/share/ovmf/$(QEMUFWVOL)
+        FIRMWAREVOLUMEPATH := $(PREFIXDEPS)/share/aavmf/$(QEMUFWVOL)
     endif
 endif
 

--- a/tools/packaging/static-build/ovmf/build-ovmf.sh
+++ b/tools/packaging/static-build/ovmf/build-ovmf.sh
@@ -84,7 +84,11 @@ fi
 popd
 
 info "Install fd to destdir"
+if [ "${ovmf_build}" == "arm64" ]; then
+install_dir="${DESTDIR}/${PREFIX}/share/aavmf"
+else
 install_dir="${DESTDIR}/${PREFIX}/share/ovmf"
+fi
 
 mkdir -p "${install_dir}"
 if [ "${ovmf_build}" == "sev" ]; then


### PR DESCRIPTION
Previouly it is reusing the ovmf, which will enter some issue for path checking, so move to aavmf as it should be.

https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/qemu.go#L879 will only check the directory which contains `ovmf`, and this is a really x86_64 directory, so we need to move the Arm64 specified directory to aavmf to avoid add redundant parameters.