### PR TITLE
versions: Bump golang to 1.23.12

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -415,12 +415,12 @@ languages:
   golang:
     description: "Google's 'go' language"
     notes: "'version' is the default minimum version used by this project."
-    version: "1.23.10"
+    version: "1.23.12"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.23.10"
+      newest-version: "1.23.12"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
Bump go version to remediate vuln GO-2025-3849