### PR TITLE
ci: static-checks: Don't hardcode default repo branch

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -28,7 +28,7 @@ KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
 
 RUNTIME="${RUNTIME:-containerd-shim-kata-v2}"
 
-export branch="${target_branch:-main}"
+export branch="${target_branch:-"$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')"}"
 
 function die() {
 	local msg="$*"


### PR DESCRIPTION
This would cause weird issues for downstreams which default branch is not "main".

Tested downstream here: https://github.com/microsoft/kata-containers/actions/runs/16950865795/job/48043166346?pr=403