### PR TITLE
runtime-rs: Empty block-rootfs Storage.options and align with Go runtime

### DIFF
--- a/src/libs/kata-types/src/fs.rs
+++ b/src/libs/kata-types/src/fs.rs
@@ -1,0 +1,15 @@
+// Copyright 2025 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+//! Filesystem-related constants shared across Kata components.
+
+/// Root filesystem type: ext4
+pub const VM_ROOTFS_FILESYSTEM_EXT4: &str = "ext4";
+
+/// Root filesystem type: xfs
+pub const VM_ROOTFS_FILESYSTEM_XFS: &str = "xfs";
+
+/// Root filesystem type: erofs
+pub const VM_ROOTFS_FILESYSTEM_EROFS: &str = "erofs";

--- a/src/libs/kata-types/src/lib.rs
+++ b/src/libs/kata-types/src/lib.rs
@@ -40,6 +40,9 @@ pub(crate) mod utils;
 /// hypervisor capabilities
 pub mod capabilities;
 
+/// Filesystem-related constants
+pub mod fs;
+
 /// The Initdata specification defines the key data structures and algorithms for injecting
 /// any well-defined data from an untrusted host into a TEE (Trusted Execution Environment).
 pub mod initdata;

--- a/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
+++ b/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
@@ -8,10 +8,12 @@ use anyhow::{anyhow, Result};
 
 use crate::{
     VM_ROOTFS_DRIVER_BLK, VM_ROOTFS_DRIVER_BLK_CCW, VM_ROOTFS_DRIVER_MMIO, VM_ROOTFS_DRIVER_PMEM,
-    VM_ROOTFS_FILESYSTEM_EROFS, VM_ROOTFS_FILESYSTEM_EXT4, VM_ROOTFS_FILESYSTEM_XFS,
     VM_ROOTFS_ROOT_BLK, VM_ROOTFS_ROOT_PMEM,
 };
 use kata_types::config::LOG_VPORT_OPTION;
+use kata_types::fs::{
+    VM_ROOTFS_FILESYSTEM_EROFS, VM_ROOTFS_FILESYSTEM_EXT4, VM_ROOTFS_FILESYSTEM_XFS,
+};
 
 // Port where the agent will send the logs. Logs are sent through the vsock in cases
 // where the hypervisor has no console.sock, i.e dragonball
@@ -179,9 +181,10 @@ mod tests {
     use super::*;
 
     use crate::{
-        VM_ROOTFS_DRIVER_BLK, VM_ROOTFS_DRIVER_PMEM, VM_ROOTFS_FILESYSTEM_EROFS,
-        VM_ROOTFS_FILESYSTEM_EXT4, VM_ROOTFS_FILESYSTEM_XFS, VM_ROOTFS_ROOT_BLK,
-        VM_ROOTFS_ROOT_PMEM,
+        VM_ROOTFS_DRIVER_BLK, VM_ROOTFS_DRIVER_PMEM, VM_ROOTFS_ROOT_BLK, VM_ROOTFS_ROOT_PMEM,
+    };
+    use kata_types::fs::{
+        VM_ROOTFS_FILESYSTEM_EROFS, VM_ROOTFS_FILESYSTEM_EXT4, VM_ROOTFS_FILESYSTEM_XFS,
     };
 
     #[test]

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -47,11 +47,6 @@ const VM_ROOTFS_DRIVER_MMIO: &str = "virtio-blk-mmio";
 const VM_ROOTFS_ROOT_BLK: &str = "/dev/vda1";
 const VM_ROOTFS_ROOT_PMEM: &str = "/dev/pmem0p1";
 
-// Config which filesystem to use as rootfs type
-const VM_ROOTFS_FILESYSTEM_EXT4: &str = "ext4";
-const VM_ROOTFS_FILESYSTEM_XFS: &str = "xfs";
-const VM_ROOTFS_FILESYSTEM_EROFS: &str = "erofs";
-
 // before using hugepages for VM, we need to mount hugetlbfs
 // /dev/hugepages will be the mount point
 // mkdir -p /dev/hugepages


### PR DESCRIPTION
- Set guest Storage.options for block rootfs to empty (do not propagate host mount options).
- Align behavior with Go runtime: only add xfs "nouuid" when needed.

Fixes #11688