### PR TITLE
runtime-rs Enable initdata IBM SEL

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -452,6 +452,7 @@ impl VirtSandbox {
             GuestProtection::Snp(_details) => {
                 calculate_initdata_digest(&initdata, ProtectedPlatform::Snp)?
             }
+            GuestProtection::Se => calculate_initdata_digest(&initdata, ProtectedPlatform::Se)?,
             // TODO: there's more `GuestProtection` types to be supported.
             _ => return Ok(None),
         };

--- a/tests/integration/kubernetes/k8s-initdata.bats
+++ b/tests/integration/kubernetes/k8s-initdata.bats
@@ -54,7 +54,7 @@ function setup_kbs_image_policy_for_initdata() {
     esac
 
     case "$KATA_HYPERVISOR" in
-        "qemu-tdx"|"qemu-coco-dev"|"qemu-snp"|"qemu-se")
+        "qemu-tdx"|"qemu-coco-dev"|"qemu-snp"|"qemu-se"|"qemu-se-runtime-rs")
             ;;
         *)
             skip "Test not supported for ${KATA_HYPERVISOR}."


### PR DESCRIPTION
This PR enables initdata for IBM SEL (s390x) and makes the relevant test for a new runtimeclass `qemu-se-runtime-rs`. 

For details, please look into each commit message.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>