### PR TITLE
runtime-rs: Support initdata within NonProtection scenarios

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -470,7 +470,7 @@ impl VirtSandbox {
             sl!(),
             "initdata push data into compressed block: {:?}", &image_path
         );
-        let block_driver = &hypervisor_config.boot_info.vm_rootfs_driver;
+        let block_driver = &hypervisor_config.blockdev_info.block_device_driver;
         let block_config = BlockConfig {
             path_on_host: image_path.display().to_string(),
             is_readonly: true,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -374,10 +374,6 @@ impl VirtSandbox {
         hypervisor_config: &HypervisorConfig,
         init_data: Option<String>,
     ) -> Result<Option<ProtectionDeviceConfig>> {
-        if !hypervisor_config.security_info.confidential_guest {
-            return Ok(None);
-        }
-
         let available_protection = available_guest_protection()?;
         info!(
             sl!(),
@@ -429,6 +425,7 @@ impl VirtSandbox {
                     debug: false,
                 })))
             },
+            GuestProtection::NoProtection => Ok(None),
             _ => Err(anyhow!("confidential_guest requested by configuration but no supported protection available"))
         }
     }
@@ -453,6 +450,9 @@ impl VirtSandbox {
                 calculate_initdata_digest(&initdata, ProtectedPlatform::Snp)?
             }
             GuestProtection::Se => calculate_initdata_digest(&initdata, ProtectedPlatform::Se)?,
+            GuestProtection::NoProtection => {
+                calculate_initdata_digest(&initdata, ProtectedPlatform::NoProtection)?
+            }
             // TODO: there's more `GuestProtection` types to be supported.
             _ => return Ok(None),
         };


### PR DESCRIPTION
we also need support initdat within nonprotection even though the platform is detected as NonProtection or usually is called nontee host. Within these cases, there's no need to validate the item of `confidential_guest=true`, we believe the result of the method `available_guest_protection()?`.

Fixes #11697