### PR TITLE
kata-types: remove default setting of guest_hook_path

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -951,9 +951,6 @@ fn default_qgs_port() -> u32 {
 impl SecurityInfo {
     /// Adjust the configuration information after loading from configuration file.
     pub fn adjust_config(&mut self) -> Result<()> {
-        if self.guest_hook_path.is_empty() {
-            self.guest_hook_path = default::DEFAULT_GUEST_HOOK_PATH.to_string();
-        }
         Ok(())
     }
 


### PR DESCRIPTION
To make it aligned with the setting of runtime-go, we should keep it as empty when users doesn't enable and set its specified path.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>