### PR TITLE
cgroups: Fix "." parent cgroup special case

### DIFF
--- a/src/runtime/pkg/resourcecontrol/cgroups.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups.go
@@ -31,7 +31,7 @@ const (
 )
 
 func RenameCgroupPath(path string) (string, error) {
-	if path == "" {
+	if path == "" || path == "." {
 		path = DefaultResourceControllerID
 	}
 

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -2546,10 +2546,8 @@ func (s *Sandbox) resourceControllerDelete() error {
 	}
 
 	resCtrlParent := sandboxController.Parent()
-	if resCtrlParent != "." {
-		if err := sandboxController.MoveTo(resCtrlParent); err != nil {
-			return err
-		}
+	if err := sandboxController.MoveTo(resCtrlParent); err != nil {
+		return err
 	}
 
 	if err := sandboxController.Delete(); err != nil {


### PR DESCRIPTION
ef642fe8900fb1ee1daae6501bbd6bae3aa50d3a added a special case to avoid
moving cgroups that are on the "default" slice in case of deletion.

However, this special check should be done in the Parent() method
instead, which ensures that the default resource controller ID is
returned, instead of ".".

Fixes: #11599
