### PR TITLE
kata-manager: Support xz and zst suffixes for the kata tarball

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -219,7 +219,7 @@ github_get_release_file_url()
 
 	case "$url" in
 		*kata*)
-			regex="kata-static-${version}-${arch_regex}.tar.zst" ;;
+			regex="kata-static-${version}-${arch_regex}.tar.(xz|zst)" ;;
 		*nerdctl*)
 			# Keep this *always* before the containerd check, as it comes from
 			# the very same containerd organisation on GitHub.


### PR DESCRIPTION
We moved to `.zst`, but users still use the upstream kata-manager to download older versions of the project, thus we need to support both suffixes.

Fixes: #11714