### PR TITLE
csi-kata-directvolume: Add basic SPDK volume support

### DIFF
--- a/src/tools/csi-kata-directvolume/README.md
+++ b/src/tools/csi-kata-directvolume/README.md
@@ -20,6 +20,8 @@ The driver can provision volumes based on direct block devices, eliminating the 
 
 [Deployment for K8S 1.20+](docs/deploy-csi-kata-directvol.md)
 
+[SPDK Usage Guide](docs/spdk-usage.md)
+
 ## Building the Binary
 
 If you want to build the driver yourself, you can do so with the following command from `csi-kata-directvolume` path:

--- a/src/tools/csi-kata-directvolume/cmd/directvolplugin/main.go
+++ b/src/tools/csi-kata-directvolume/cmd/directvolplugin/main.go
@@ -10,8 +10,10 @@ package main
 import (
 	"flag"
 	"kata-containers/csi-kata-directvolume/pkg/directvolume"
+	"kata-containers/csi-kata-directvolume/pkg/spdkrpc"
 	"os"
 	"path"
+	"time"
 
 	"k8s.io/klog/v2"
 )
@@ -40,6 +42,10 @@ func main() {
 	flag.Var(&cfg.Capacity, "capacity", "Simulate storage capacity. The parameter is <kind>=<quantity> where <kind> is the value of a 'kind' storage class parameter and <quantity> is the total amount of bytes for that kind. The flag may be used multiple times to configure different kinds.")
 	flag.Int64Var(&cfg.MaxVolumeSize, "max-volume-size", 1024*1024*1024*1024, "maximum size of volumes in bytes (inclusive)")
 	flag.BoolVar(&cfg.EnableTopology, "enable-topology", true, "Enables PluginCapability_Service_VOLUME_ACCESSIBILITY_CONSTRAINTS capability.")
+	flag.DurationVar(&cfg.SpdkRPCTimeout, "spdk-rpc-timeout", 10*time.Second,
+		"timeout for SPDK JSON-RPC requests")
+	flag.StringVar(&cfg.SpdkRawPath, "spdk-rawpath", "", "path for spdk rawdisk backing files")
+	flag.StringVar(&cfg.SpdkVhostPath, "spdk-vhostpath", "", "path for spdk vhost controller sockets")
 
 	showVersion := flag.Bool("version", false, "Show version.")
 
@@ -50,6 +56,8 @@ func main() {
 		klog.Infof(baseName, version)
 		return
 	}
+
+	spdkrpc.Init(cfg.SpdkRPCTimeout)
 
 	driver, err := directvolume.NewDirectVolumeDriver(cfg)
 	if err != nil {

--- a/src/tools/csi-kata-directvolume/deploy/kata-directvolume/csi-directvol-plugin.yaml
+++ b/src/tools/csi-kata-directvolume/deploy/kata-directvolume/csi-directvol-plugin.yaml
@@ -87,7 +87,7 @@ spec:
 
         - name: kata-directvolume
           # build and push it into registry
-          image: localhost/kata-directvolume:v1.0.18
+          image: localhost/kata-directvolume:v1.0.19
           args:
             - --drivername=directvolume.csi.katacontainers.io
             - --v=5
@@ -95,6 +95,9 @@ spec:
             - --statedir=$(STATE_DIR)
             - --storagepath=$(STORAGE_POOL)
             - --nodeid=$(KUBE_NODE_NAME)
+            - --spdk-rawpath=$(RAW_DISKS)
+            - --spdk-vhostpath=$(VHU_UDS_PATH)
+            - --spdk-rpc-timeout=10s
           env:
             - name: CSI_ENDPOINT
               value: unix:///csi/csi.sock
@@ -107,6 +110,10 @@ spec:
                 fieldRef:
                   apiVersion: v1
                   fieldPath: spec.nodeName
+            - name: RAW_DISKS
+              value: /var/lib/spdk/rawdisks
+            - name: VHU_UDS_PATH
+              value: /var/lib/spdk/vhost
           securityContext:
             privileged: true
           ports:
@@ -140,6 +147,15 @@ spec:
             # direct volume mountInfo.json stored at shared-directvols
             - mountPath: /run/kata-containers/shared/direct-volumes
               name: shared-directvols
+            # vhost-user socket
+            - mountPath: /var/lib/spdk/vhost
+              name: vhost-dir
+            # rawdisks
+            - mountPath: /var/lib/spdk/rawdisks
+              name: rawdisks-dir
+            # spdk socket
+            - mountPath: /var/tmp
+              name: spdk-dir
 
         - name: liveness-probe
           volumeMounts:
@@ -149,7 +165,6 @@ spec:
           args:
           - --csi-address=/csi/csi.sock
           - --health-port=9898
-
       volumes:
         - hostPath:
             path: /var/lib/kubelet/plugins/csi-kata-directvolume
@@ -187,4 +202,20 @@ spec:
             path: /run/kata-containers/shared/direct-volumes/
             type: DirectoryOrCreate
           name: shared-directvols
+        # vhost there.
+        - hostPath:
+            path: /var/lib/spdk/vhost
+            type: Directory
+          name: vhost-dir
+        # rawdisk there.
+        - hostPath:
+            path: /var/lib/spdk/rawdisks
+            type: DirectoryOrCreate
+          name: rawdisks-dir
+        # spdk socket stored there.
+        - hostPath:
+            path: /var/tmp
+            type: Directory
+          name: spdk-dir
+
 

--- a/src/tools/csi-kata-directvolume/docs/spdk-usage.md
+++ b/src/tools/csi-kata-directvolume/docs/spdk-usage.md
@@ -1,0 +1,114 @@
+# User Guide: SPDK Volume CSI Driver
+
+## 1. Prerequisites
+* A running **Kubernetes cluster with Kata Containers (Dragonball)** enabled.
+* The `csi-kata-directvolume` is deployed.
+* **SPDK** is built and `spdk_tgt` is available.
+
+## 2. Start the SPDK Service
+
+```sh
+# Environment variables
+# By default, the driver uses `/var/lib/spdk/vhost` and `/var/lib/spdk/rawdisks` 
+# you need to set your own paths according to your environment.
+export SPDK_DEVEL=<path-to-your-spdk>
+export VHU_UDS_PATH=<your_vhost_path>
+export RAW_DISKS=<your_rawdisk_path>
+
+# Stop existing process
+sudo pkill spdk_tgt || true
+
+# Reset and allocate hugepages
+cd $SPDK_DEVEL
+sudo ./scripts/setup.sh reset
+sudo sysctl -w vm.nr_hugepages=2048
+sudo HUGEMEM=4096 ./scripts/setup.sh
+
+# Start SPDK vhost target
+sudo mkdir -p $VHU_UDS_PATH
+sudo $SPDK_DEVEL/build/bin/spdk_tgt -S $VHU_UDS_PATH -s 1024 -m 0x3 &
+```
+
+> Notes:
+>
+> * `-s 1024`: size of the hugepage memory pool in MB.
+> * `-m 0x3`: CPU mask specifying which cores SPDK will use.
+
+## 3. Deploy Kubernetes Resources
+
+Run the example script:
+
+```sh
+cd kata-containers/src/tools/csi-kata-directvolume/examples/pod-with-spdkvol
+kubectl apply -f csi-storageclass.yaml
+kubectl apply -f csi-pvc.yaml
+kubectl apply -f csi-app.yaml
+```
+
+This creates:
+
+* Storage Class `spdk-test-adapted`
+* PVC `kata-spdk-directvolume-pvc`
+* Pod `spdk-pod-test`
+
+## 4. Verify the Volume Inside the Pod
+
+Check the mounted block device:
+
+```sh
+$ kubectl exec -it spdk-pod-test -- /bin/sh
+
+$ lsblk
+NAME   MAJ:MIN RM  SIZE RO TYPE MOUNTPOINTS
+vda    254:0    0  256M  1 disk 
+`-vda1 254:1    0  253M  1 part 
+vdb    254:16   0    2G  0 disk /data
+
+$ echo "hello spdk" > /data/test.txt
+$ cat /data/test.txt
+hello spdk
+```
+
+The SPDK-backed volume `/dev/vdb` is mounted to `/data` inside the container.
+
+## 5. Verify Data on the Host
+
+On the host, inspect the raw backing file:
+
+```sh
+# Locate the raw file
+ls /var/lib/spdk/rawdisks
+
+# Attach it as a loop device
+sudo losetup -fP /var/lib/spdk/rawdisks/pvc-xxxx.raw
+
+# List loop devices
+sudo losetup -a
+
+# Mount and check data
+sudo mkdir -p /mnt/testvol
+sudo mount /dev/loopX /mnt/testvol
+ls /mnt/testvol
+cat /mnt/testvol/test.txt
+hello spdk
+
+# Cleanup
+sudo umount /mnt/testvol
+sudo losetup -d /dev/loopX
+```
+
+## 6. Cleanup
+
+```sh
+kubectl delete -f csi-app.yaml
+kubectl delete -f csi-pvc.yaml
+kubectl delete -f csi-storageclass.yaml
+```
+
+---
+
+## Notes
+* The SPDK CSI driver exposes **SPDK-managed volumes via vhost-user-blk** into Kata containers.
+* Usage is the same as regular PVCs — specify `volumetype=spdkvol` in the Storage Class.
+
+

--- a/src/tools/csi-kata-directvolume/examples/pod-with-spdkvol/csi-app.yaml
+++ b/src/tools/csi-kata-directvolume/examples/pod-with-spdkvol/csi-app.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: spdk-pod-test
+spec:
+  runtimeClassName: kata  
+  containers:
+  - name: app
+    image: docker.io/library/ubuntu:22.04
+    command: ["sleep", "3600"]
+    volumeMounts:
+    - name: data
+      mountPath: /data
+  volumes:
+  - name: data
+    persistentVolumeClaim:
+      claimName: kata-spdk-directvolume-pvc

--- a/src/tools/csi-kata-directvolume/examples/pod-with-spdkvol/csi-pvc.yaml
+++ b/src/tools/csi-kata-directvolume/examples/pod-with-spdkvol/csi-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kata-spdk-directvolume-pvc
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: spdk-test-adapted  
+  resources:
+    requests:
+      storage: 2Gi

--- a/src/tools/csi-kata-directvolume/examples/pod-with-spdkvol/csi-storageclass.yaml
+++ b/src/tools/csi-kata-directvolume/examples/pod-with-spdkvol/csi-storageclass.yaml
@@ -1,0 +1,9 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: spdk-test-adapted
+provisioner: directvolume.csi.katacontainers.io  
+parameters:
+  katacontainers.direct.volume/volumetype: spdkvol  
+reclaimPolicy: Delete
+volumeBindingMode: Immediate

--- a/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver_test.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver_test.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2025 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package directvolume
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+
+	"kata-containers/csi-kata-directvolume/pkg/spdkrpc"
+	"kata-containers/csi-kata-directvolume/pkg/utils"
+)
+
+type call struct {
+	method string
+	params map[string]any
+}
+type fakeSpdk struct {
+	calls []call
+	ret   map[string]any
+	err   map[string]error
+}
+
+func newFakeSpdk() *fakeSpdk {
+	return &fakeSpdk{
+		ret: map[string]any{},
+		err: map[string]error{},
+	}
+}
+func (f *fakeSpdk) fn(method string, params map[string]any) (any, error) {
+	f.calls = append(f.calls, call{method, params})
+	if e := f.err[method]; e != nil {
+		return nil, e
+	}
+	return f.ret[method], nil
+}
+
+func mountCap() *csi.VolumeCapability {
+	return &csi.VolumeCapability{
+		AccessType: &csi.VolumeCapability_Mount{
+			Mount: &csi.VolumeCapability_MountVolume{},
+		},
+	}
+}
+
+func TestSPDKVolume(t *testing.T) {
+	tmp := t.TempDir()
+
+	oldDir := utils.SpdkRawDiskDir
+	utils.SpdkRawDiskDir = filepath.Join(tmp, "rawdisks")
+	defer func() { utils.SpdkRawDiskDir = oldDir }()
+	require.NoError(t, os.MkdirAll(utils.SpdkRawDiskDir, 0o750))
+
+	oldCall := spdkrpc.Call
+	fs := newFakeSpdk()
+	spdkrpc.Call = fs.fn
+	defer func() { spdkrpc.Call = oldCall }()
+
+	cfg := Config{
+		DriverName:    "directvolume.csi.katacontainers.io",
+		Endpoint:      "unix:///tmp/fake.sock",
+		NodeID:        "node-test",
+		StoragePath:   filepath.Join(tmp, "stor"),
+		StateDir:      filepath.Join(tmp, "st"),
+		MaxVolumeSize: 1 << 40,
+		SpdkRawPath:   filepath.Join(tmp, "spdk-raw"),
+		SpdkVhostPath: filepath.Join(tmp, "spdk-vhost"),
+	}
+	dv, err := NewDirectVolumeDriver(cfg)
+	require.NoError(t, err)
+
+	req := &csi.CreateVolumeRequest{
+		Name: "vol-spdk",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 1 << 20,
+		},
+		Parameters: map[string]string{
+			utils.KataContainersDirectVolumeType: utils.SpdkVolumeTypeName,
+			utils.KataContainersDirectFsType:     "ext4",
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{mountCap()},
+	}
+	resp, err := dv.CreateVolume(context.TODO(), req)
+	require.NoError(t, err)
+	require.NotNil(t, resp.GetVolume())
+	volID := resp.GetVolume().GetVolumeId()
+	require.NotEmpty(t, volID)
+
+	backing := filepath.Join(utils.SpdkRawDiskDir, "vol-spdk.raw")
+	info, statErr := os.Stat(backing)
+	require.NoError(t, statErr, "backing file should exist")
+	require.EqualValues(t, 1<<20, info.Size())
+
+	require.NotEmpty(t, fs.calls)
+	foundCreate := false
+	for _, c := range fs.calls {
+		if c.method == "bdev_aio_create" {
+			foundCreate = true
+			require.Equal(t, backing, c.params["filename"])
+			require.Equal(t, "bdev-vol-spdk", c.params["name"])
+		}
+	}
+	require.True(t, foundCreate, "should call bdev_aio_create")
+
+	_, err = dv.DeleteVolume(context.TODO(), &csi.DeleteVolumeRequest{VolumeId: volID})
+	require.NoError(t, err)
+
+	foundDelete := false
+	for _, c := range fs.calls {
+		if c.method == "bdev_aio_delete" {
+			foundDelete = true
+			require.Equal(t, "bdev-vol-spdk", c.params["name"])
+		}
+	}
+	require.True(t, foundDelete, "should call bdev_aio_delete")
+
+	_, err = os.Stat(backing)
+	require.True(t, os.IsNotExist(err), "backing file should be removed after DeleteVolume")
+
+	_, err = dv.DeleteVolume(context.TODO(), &csi.DeleteVolumeRequest{VolumeId: volID})
+	require.NoError(t, err)
+}

--- a/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver_test.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver_test.go
@@ -1,0 +1,194 @@
+// Copyright (c) 2025 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package directvolume
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/net/context"
+
+	"kata-containers/csi-kata-directvolume/pkg/spdkrpc"
+	"kata-containers/csi-kata-directvolume/pkg/utils"
+)
+
+type nsCall struct {
+	method string
+	params map[string]any
+}
+
+type fakeSpdkNS struct {
+	calls     []nsCall
+	ret       map[string]any
+	err       map[string]error
+	lastCtrlr string
+}
+
+func newFakeSpdkNS() *fakeSpdkNS {
+	return &fakeSpdkNS{
+		ret: map[string]any{},
+		err: map[string]error{},
+	}
+}
+
+func (f *fakeSpdkNS) fn(method string, params map[string]any) (any, error) {
+	f.calls = append(f.calls, nsCall{method, params})
+
+	switch method {
+	case "vhost_get_controllers":
+		if f.lastCtrlr != "" {
+			return []interface{}{
+				map[string]interface{}{"ctrlr": f.lastCtrlr},
+			}, nil
+		}
+		return []interface{}{}, nil
+	case "vhost_create_blk_controller":
+		if ctrlr, _ := params["ctrlr"].(string); ctrlr != "" {
+			f.lastCtrlr = ctrlr
+			f.ret["vhost_get_controllers"] = []map[string]any{
+				{"ctrlr": ctrlr},
+			}
+		}
+	case "vhost_delete_controller":
+		if f.lastCtrlr != "" {
+			f.ret["vhost_get_controllers"] = []map[string]any{}
+		}
+	}
+
+	if e := f.err[method]; e != nil {
+		return nil, e
+	}
+	return f.ret[method], nil
+}
+
+func TestSPDKStage(t *testing.T) {
+	tmp := t.TempDir()
+
+	oldRaw := utils.SpdkRawDiskDir
+	utils.SpdkRawDiskDir = filepath.Join(tmp, "rawdisks")
+	defer func() { utils.SpdkRawDiskDir = oldRaw }()
+	require.NoError(t, os.MkdirAll(utils.SpdkRawDiskDir, 0o750))
+
+	oldCall := spdkrpc.Call
+	fs := newFakeSpdkNS()
+	spdkrpc.Call = fs.fn
+	defer func() { spdkrpc.Call = oldCall }()
+
+	cfg := Config{
+		DriverName:    "directvolume.csi.katacontainers.io",
+		Endpoint:      "unix:///tmp/fake.sock",
+		NodeID:        "node-test",
+		StoragePath:   filepath.Join(tmp, "stor"),
+		StateDir:      filepath.Join(tmp, "st"),
+		MaxVolumeSize: 1 << 40,
+		SpdkRawPath:   filepath.Join(tmp, "spdk-raw"),
+		SpdkVhostPath: filepath.Join(tmp, "spdk-vhost"),
+	}
+	dv, err := NewDirectVolumeDriver(cfg)
+	require.NoError(t, err)
+
+	createResp, err := dv.CreateVolume(context.TODO(), &csi.CreateVolumeRequest{
+		Name: "vol-spdk",
+		CapacityRange: &csi.CapacityRange{
+			RequiredBytes: 8 << 20,
+		},
+		Parameters: map[string]string{
+			utils.KataContainersDirectVolumeType: utils.SpdkVolumeTypeName,
+			utils.KataContainersDirectFsType:     "ext4",
+		},
+		VolumeCapabilities: []*csi.VolumeCapability{mountCap()},
+	})
+	require.NoError(t, err)
+	volID := createResp.GetVolume().GetVolumeId()
+	require.NotEmpty(t, volID)
+	volCtx := createResp.GetVolume().GetVolumeContext()
+
+	stagePath := filepath.Join(tmp, "stage", volID)
+	require.NoError(t, os.MkdirAll(stagePath, 0o750))
+
+	_, err = dv.NodeStageVolume(context.TODO(), &csi.NodeStageVolumeRequest{
+		VolumeId:          volID,
+		StagingTargetPath: stagePath,
+		VolumeCapability:  mountCap(),
+		VolumeContext:     volCtx,
+	})
+	require.NoError(t, err)
+
+	foundCreate := false
+	var createdCtrlrName string
+	for _, c := range fs.calls {
+		if c.method == "vhost_create_blk_controller" {
+			foundCreate = true
+			if ctrlr, ok := c.params["ctrlr"].(string); ok {
+				createdCtrlrName = ctrlr
+			}
+			_, hasDev := c.params["dev_name"]
+			require.True(t, hasDev, "vhost_create_blk_controller should have dev_name")
+		}
+	}
+	require.True(t, foundCreate, "should call vhost_create_blk_controller at NodeStage")
+
+	stateFile := filepath.Join(cfg.StateDir, "state.json")
+	data, readErr := os.ReadFile(stateFile)
+	require.NoError(t, readErr, "state.json should exist after NodeStage")
+	require.Contains(t, string(data), `"devicePath"`, "devicePath should be recorded in state")
+	require.Contains(t, string(data), volID, "state should include this volume")
+
+	_, err = dv.NodeStageVolume(context.TODO(), &csi.NodeStageVolumeRequest{
+		VolumeId:          volID,
+		StagingTargetPath: stagePath,
+		VolumeCapability:  mountCap(),
+		VolumeContext:     volCtx,
+	})
+	require.NoError(t, err)
+
+	_, err = dv.NodeUnstageVolume(context.TODO(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          volID,
+		StagingTargetPath: stagePath,
+	})
+	require.NoError(t, err)
+
+	foundDelete := false
+	for _, c := range fs.calls {
+		if c.method == "vhost_delete_controller" {
+			foundDelete = true
+			if createdCtrlrName != "" {
+				require.Equal(t, createdCtrlrName, c.params["ctrlr"])
+			} else {
+				_, has := c.params["ctrlr"]
+				require.True(t, has, "vhost_delete_controller should have ctrlr")
+			}
+		}
+	}
+	require.True(t, foundDelete, "should call vhost_delete_controller at NodeUnstage")
+
+	_, err = dv.NodeUnstageVolume(context.TODO(), &csi.NodeUnstageVolumeRequest{
+		VolumeId:          volID,
+		StagingTargetPath: stagePath,
+	})
+	if err != nil {
+		require.Contains(t, err.Error(), "file does not exist")
+	}
+
+	_, err = dv.DeleteVolume(context.TODO(), &csi.DeleteVolumeRequest{VolumeId: volID})
+	require.NoError(t, err)
+
+	backing := filepath.Join(utils.SpdkRawDiskDir, "vol-spdk.raw")
+	_, statErr := os.Stat(backing)
+	require.True(t, os.IsNotExist(statErr), "backing file should be removed after DeleteVolume")
+
+	var callsJoined strings.Builder
+	for _, c := range fs.calls {
+		callsJoined.WriteString(c.method)
+		callsJoined.WriteString("|")
+	}
+	require.Contains(t, callsJoined.String(), "vhost_get_controllers",
+		"should call vhost_get_controllers at least once")
+}

--- a/src/tools/csi-kata-directvolume/pkg/spdkrpc/jsonrpc.go
+++ b/src/tools/csi-kata-directvolume/pkg/spdkrpc/jsonrpc.go
@@ -1,0 +1,103 @@
+// Copyright (c) 2025 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package spdkrpc
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+const SpdkErrNoDevice = -int(unix.ENODEV)
+
+var Call = CallSPDK
+
+type JsonRPCRequest struct {
+	Method  string                 `json:"method"`
+	Params  map[string]interface{} `json:"params"`
+	ID      int                    `json:"id"`
+	Jsonrpc string                 `json:"jsonrpc"`
+}
+
+type JsonRPCResponse struct {
+	Result interface{} `json:"result"`
+	Error  interface{} `json:"error"`
+	ID     int         `json:"id"`
+}
+
+type SpdkError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+var (
+	requestID  = 1
+	RPCTimeout = 10 * time.Second
+)
+
+func Init(timeout time.Duration) {
+	if timeout > 0 {
+		RPCTimeout = timeout
+	}
+}
+
+func (e *SpdkError) Error() string {
+	return fmt.Sprintf("SPDK error %d: %s", e.Code, e.Message)
+}
+
+func CallSPDK(method string, params map[string]interface{}) (interface{}, error) {
+	req := JsonRPCRequest{
+		Method:  method,
+		Params:  params,
+		ID:      requestID,
+		Jsonrpc: "2.0",
+	}
+	requestID++
+
+	data, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	conn, err := net.Dial("unix", "/var/tmp/spdk.sock")
+	if err != nil {
+		return "", fmt.Errorf("failed to connect to spdk.sock: %w", err)
+	}
+	defer conn.Close()
+
+	_, err = conn.Write(data)
+	if err != nil {
+		return "", fmt.Errorf("failed to write to spdk.sock: %w", err)
+	}
+
+	conn.SetReadDeadline(time.Now().Add(RPCTimeout))
+
+	buf := make([]byte, 8192)
+	n, err := conn.Read(buf)
+	if err != nil {
+		return "", fmt.Errorf("failed to read from spdk.sock: %w", err)
+	}
+
+	var resp JsonRPCResponse
+	if err := json.Unmarshal(buf[:n], &resp); err != nil {
+		return "", fmt.Errorf("failed to unmarshal response: %w", err)
+	}
+
+	if resp.Error != nil {
+		errBytes, _ := json.Marshal(resp.Error)
+		var spdkErr SpdkError
+		if json.Unmarshal(errBytes, &spdkErr) == nil && spdkErr.Code != 0 {
+			return "", &spdkErr
+		}
+		return "", fmt.Errorf("SPDK returned error: %v", resp.Error)
+	}
+
+	// return fmt.Sprintf("%v", resp.Result), nil
+	return resp.Result, nil
+}

--- a/src/tools/csi-kata-directvolume/pkg/state/state.go
+++ b/src/tools/csi-kata-directvolume/pkg/state/state.go
@@ -37,6 +37,8 @@ type Volume struct {
 	// Published contains the target paths where the volume
 	// was published.
 	Published Strings
+
+	Metadata map[string]string
 }
 
 // State is the interface that the rest of the code has to use to

--- a/src/tools/csi-kata-directvolume/pkg/utils/utils.go
+++ b/src/tools/csi-kata-directvolume/pkg/utils/utils.go
@@ -27,6 +27,7 @@ const (
 	KataContainersDirectVolumeType = "katacontainers.direct.volume/volumetype"
 	KataContainersDirectFsType     = "katacontainers.direct.volume/fstype"
 	DirectVolumeTypeName           = "directvol"
+	SpdkVolumeTypeName             = "spdkvol"
 	IsDirectVolume                 = "is_directvolume"
 )
 
@@ -45,6 +46,11 @@ const (
 	GiB100 int64 = GiB * 100
 	TiB    int64 = GiB * 1024
 	TiB100 int64 = TiB * 100
+)
+
+var (
+	SpdkRawDiskDir string
+	SpdkVhostDir   string
 )
 
 func AddDirectVolume(targetPath string, mountInfo MountInfo) error {


### PR DESCRIPTION
## Description

Introduce initial implementation for SPDK-backed CSI volumes, allowing basic create and delete operations with vhost-user-blk integration.

Fixes: #9704

## TODO
- [x] Improve recovery mechanism
- [x] Improve basic documentation and examples

