### PR TITLE
runtime-rs: Use console for log forwarder in QEMU

### DIFF
--- a/src/runtime-rs/crates/agent/src/kata/agent.rs
+++ b/src/runtime-rs/crates/agent/src/kata/agent.rs
@@ -32,12 +32,13 @@ impl AgentManager for KataAgent {
         self.set_console_address(console_address)
             .await
             .context("set console address")?;
-        self.connect_agent_server()
-            .await
-            .context("connect agent server")?;
+        // Log forwarder can start first to capture system logs streamed before kata agent starts
         self.start_log_forwarder()
             .await
             .context("connect log forwarder")?;
+        self.connect_agent_server()
+            .await
+            .context("connect agent server")?;
         Ok(())
     }
 

--- a/src/runtime-rs/crates/agent/src/kata/agent.rs
+++ b/src/runtime-rs/crates/agent/src/kata/agent.rs
@@ -24,11 +24,14 @@ fn new_ttrpc_ctx(timeout: i64) -> ttrpc_ctx::Context {
 #[async_trait]
 impl AgentManager for KataAgent {
     #[instrument]
-    async fn start(&self, address: &str) -> Result<()> {
-        info!(sl!(), "begin to connect agent {:?}", address);
-        self.set_socket_address(address)
+    async fn start(&self, socket_address: &str, console_address: &str) -> Result<()> {
+        info!(sl!(), "begin to connect agent {:?}", socket_address);
+        self.set_socket_address(socket_address)
             .await
             .context("set socket")?;
+        self.set_console_address(console_address)
+            .await
+            .context("set console address")?;
         self.connect_agent_server()
             .await
             .context("connect agent server")?;

--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -37,6 +37,9 @@ pub(crate) struct KataAgentInner {
     /// Unix domain socket address
     pub socket_address: String,
 
+    /// Unix domain console address
+    pub console_address: String,
+
     /// Agent config
     config: AgentConfig,
 
@@ -49,6 +52,7 @@ impl std::fmt::Debug for KataAgentInner {
         f.debug_struct("KataAgentInner")
             .field("client_fd", &self.client_fd)
             .field("socket_address", &self.socket_address)
+            .field("console_address", &self.console_address)
             .field("config", &self.config)
             .finish()
     }
@@ -68,6 +72,7 @@ impl KataAgent {
                 client: None,
                 client_fd: -1,
                 socket_address: "".to_string(),
+                console_address: "".to_string(),
                 config,
                 log_forwarder: LogForwarder::new(),
             })),
@@ -99,6 +104,12 @@ impl KataAgent {
     pub(crate) async fn set_socket_address(&self, address: &str) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner.socket_address = address.to_string();
+        Ok(())
+    }
+
+    pub(crate) async fn set_console_address(&self, address: &str) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.console_address = address.to_string();
         Ok(())
     }
 

--- a/src/runtime-rs/crates/agent/src/kata/mod.rs
+++ b/src/runtime-rs/crates/agent/src/kata/mod.rs
@@ -140,6 +140,10 @@ impl KataAgent {
 
     pub(crate) async fn start_log_forwarder(&self) -> Result<()> {
         let mut inner = self.inner.write().await;
+        if !inner.config.debug {
+            info!(sl!(), "debug is disabled, skip log forwarder");
+            return Ok(());
+        }
         let config = sock::ConnectConfig::new(
             inner.config.dial_timeout_ms as u64,
             inner.config.reconnect_timeout_ms as u64,

--- a/src/runtime-rs/crates/agent/src/lib.rs
+++ b/src/runtime-rs/crates/agent/src/lib.rs
@@ -37,7 +37,7 @@ pub const AGENT_KATA: &str = "kata";
 
 #[async_trait]
 pub trait AgentManager: Send + Sync {
-    async fn start(&self, address: &str) -> Result<()>;
+    async fn start(&self, socket_address: &str, console_address: &str) -> Result<()>;
     async fn stop(&self);
 
     async fn agent_sock(&self) -> Result<String>;

--- a/src/runtime-rs/crates/hypervisor/README.md
+++ b/src/runtime-rs/crates/hypervisor/README.md
@@ -87,6 +87,7 @@ pub trait Hypervisor: Send + Sync {
     
     // utils
     async fn get_agent_socket(&self) -> Result<String>;
+    async fn get_console_address(&self) -> Result<String>;
     async fn disconnect(&self);
     async fn hypervisor_config(&self) -> HypervisorConfig;
     async fn get_thread_ids(&self) -> Result<VcpuThreadIds>;

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -663,6 +663,10 @@ impl CloudHypervisorInner {
         Ok(uri)
     }
 
+    pub(crate) async fn get_console_address(&self) -> Result<String> {
+        Ok(String::new())
+    }
+
     pub(crate) async fn disconnect(&mut self) {
         self.state = VmmState::NotReady;
     }

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -125,6 +125,11 @@ impl Hypervisor for CloudHypervisor {
         inner.get_agent_socket().await
     }
 
+    async fn get_console_address(&self) -> Result<String> {
+        let inner = self.inner.write().await;
+        inner.get_console_address().await
+    }
+
     async fn disconnect(&self) {
         let mut inner = self.inner.write().await;
         inner.disconnect().await

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_hypervisor.rs
@@ -76,6 +76,10 @@ impl DragonballInner {
         ))
     }
 
+    pub(crate) async fn get_console_address(&self) -> Result<String> {
+        Ok(String::new())
+    }
+
     /// Get the address of agent vsock server used to init connections for io
     pub(crate) async fn get_passfd_listener_addr(&self) -> Result<(String, u32)> {
         if let Some(passfd_port) = self.passfd_listener_port {

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -160,6 +160,11 @@ impl Hypervisor for Dragonball {
         inner.get_agent_socket().await
     }
 
+    async fn get_console_address(&self) -> Result<String> {
+        let inner = self.inner.read().await;
+        inner.get_console_address().await
+    }
+
     async fn disconnect(&self) {
         let mut inner = self.inner.write().await;
         inner.disconnect().await

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/inner_hypervisor.rs
@@ -135,6 +135,10 @@ impl FcInner {
         Ok(format!("{}://{}", HYBRID_VSOCK_SCHEME, vsock_path))
     }
 
+    pub(crate) async fn get_console_address(&self) -> Result<String> {
+        Ok(String::new())
+    }
+
     pub(crate) async fn disconnect(&mut self) {
         warn!(sl(), "Disconnect: Not implemented");
     }

--- a/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/mod.rs
@@ -132,6 +132,11 @@ impl Hypervisor for Firecracker {
         inner.get_agent_socket().await
     }
 
+    async fn get_console_address(&self) -> Result<String> {
+        let inner = self.inner.read().await;
+        inner.get_console_address().await
+    }
+
     async fn disconnect(&self) {
         let mut inner = self.inner.write().await;
         inner.disconnect().await

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -120,6 +120,7 @@ pub trait Hypervisor: std::fmt::Debug + Send + Sync {
 
     // utils
     async fn get_agent_socket(&self) -> Result<String>;
+    async fn get_console_address(&self) -> Result<String>;
     async fn disconnect(&self);
     async fn hypervisor_config(&self) -> HypervisorConfig;
     async fn get_thread_ids(&self) -> Result<VcpuThreadIds>;

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -124,6 +124,11 @@ impl Hypervisor for Qemu {
         inner.get_agent_socket().await
     }
 
+    async fn get_console_address(&self) -> Result<String> {
+        let inner = self.inner.read().await;
+        inner.get_console_address().await
+    }
+
     async fn disconnect(&self) {
         let mut inner = self.inner.write().await;
         inner.disconnect().await

--- a/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/inner.rs
@@ -254,6 +254,10 @@ impl RemoteInner {
         Ok(format!("{}://{}", REMOTE_SCHEME, &self.agent_socket_path))
     }
 
+    pub(crate) async fn get_console_address(&self) -> Result<String> {
+        Ok(String::new())
+    }
+
     pub(crate) async fn disconnect(&mut self) {
         warn!(sl!(), "RemoteInner::disconnect(): NOT YET IMPLEMENTED");
         todo!()

--- a/src/runtime-rs/crates/hypervisor/src/remote/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/remote/mod.rs
@@ -103,6 +103,11 @@ impl Hypervisor for Remote {
         inner.get_agent_socket().await
     }
 
+    async fn get_console_address(&self) -> Result<String> {
+        let inner = self.inner.read().await;
+        inner.get_console_address().await
+    }
+
     async fn disconnect(&self) {
         let mut inner = self.inner.write().await;
         inner.disconnect().await

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -584,15 +584,20 @@ impl Sandbox for VirtSandbox {
 
         // connect agent
         // set agent socket
-        let address = self
+        let socket_address = self
             .hypervisor
             .get_agent_socket()
             .await
             .context("get agent socket")?;
-        self.agent
-            .start(&address)
+        let console_address = self
+            .hypervisor
+            .get_console_address()
             .await
-            .context(format!("connect to address {:?}", &address))?;
+            .context("get console address")?;
+        self.agent
+            .start(&socket_address, &console_address)
+            .await
+            .context(format!("connect to address {:?}", &socket_address))?;
 
         self.resource_manager
             .setup_after_start_vm()


### PR DESCRIPTION
The log forwarder now connects to the guest console for QEMU rather than using vsock.

See individual commit messages for details.

Fixes: #11588

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>