### PR TITLE
runtime-rs: Adjust path for sealed secret mount check

### DIFF
--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -38,7 +38,7 @@ const INLINE_VIRTIO_FS: &str = "inline-virtio-fs";
 const KATA_HOST_SHARED_DIR: &str = "/run/kata-containers/shared/sandboxes/";
 
 /// share fs (for example virtio-fs) mount path in the guest
-const KATA_GUEST_SHARE_DIR: &str = "/run/kata-containers/shared/containers/";
+pub const KATA_GUEST_SHARE_DIR: &str = "/run/kata-containers/shared/containers/";
 
 pub(crate) const DEFAULT_KATA_GUEST_SANDBOX_DIR: &str = "/run/kata-containers/sandbox/";
 

--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -31,8 +31,7 @@ use tokio::{
 use walkdir::WalkDir;
 
 use super::Volume;
-use crate::share_fs::DEFAULT_KATA_GUEST_SANDBOX_DIR;
-use crate::share_fs::PASSTHROUGH_FS_DIR;
+use crate::share_fs::KATA_GUEST_SHARE_DIR;
 use crate::share_fs::{MountedInfo, ShareFs, ShareFsVolumeConfig};
 use kata_types::{
     k8s::{is_configmap, is_downward_api, is_projected, is_secret},
@@ -286,12 +285,7 @@ impl ShareFsVolume {
                 // If the mount source is a file, we can copy it to the sandbox
                 if src.is_file() {
                     // This is where we set the value for the guest path
-                    let dest = [
-                        DEFAULT_KATA_GUEST_SANDBOX_DIR,
-                        PASSTHROUGH_FS_DIR,
-                        file_name.clone().as_str(),
-                    ]
-                    .join("/");
+                    let dest = [KATA_GUEST_SHARE_DIR, file_name.clone().as_str()].join("/");
 
                     debug!(
                         sl!(),
@@ -347,12 +341,7 @@ impl ShareFsVolume {
                     info!(sl!(), "copying directory {:?} to guest", &source_path);
 
                     // create target path in guest
-                    let dest_dir = [
-                        DEFAULT_KATA_GUEST_SANDBOX_DIR,
-                        PASSTHROUGH_FS_DIR,
-                        file_name.clone().as_str(),
-                    ]
-                    .join("/");
+                    let dest_dir = [KATA_GUEST_SHARE_DIR, file_name.clone().as_str()].join("/");
 
                     // create directory
                     let dir_metadata = std::fs::metadata(src.clone())


### PR DESCRIPTION
Mount validation for sealed secret https://github.com/kata-containers/kata-containers/blob/08d2ba19693f1e03ddb51b2a9c03a5917e0ba433/src/agent/src/rpc.rs#L2246-L2263

requires the base path to start with `/run/kata-containers/shared/containers`. Previously, it used `/run/kata-containers/sandbox/passthrough`, which caused test failures where volume mounts are used.

This PR renames the path to satisfy the validation check.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>