### PR TITLE
WIP: Ubuntu kata guest selinux rfc

### DIFF
--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1018,33 +1018,32 @@ func (k *kataAgent) constrainGRPCSpec(grpcSpec *grpc.Spec, passSeccomp bool, dis
 	}
 
 	// Pass SELinux label for the container process to the agent.
-	if grpcSpec.Process.SelinuxLabel != "" {
-		if !disableGuestSeLinux {
-			k.Logger().Info("SELinux label will be applied to the container process inside guest")
+	if !disableGuestSeLinux {
 
-			var label string
-			if guestSeLinuxLabel != "" {
-				label = guestSeLinuxLabel
-			} else {
-				label = grpcSpec.Process.SelinuxLabel
-			}
-
-			processContext, err := selinux.NewContext(label)
-			if err != nil {
-				return err
-			}
-
-			// Change the type from KVM to container because the type passed from the high-level
-			// runtime is for KVM process.
-			if guestSeLinuxLabel == "" {
-				processContext["type"] = defaultSeLinuxContainerType
-			}
-			grpcSpec.Process.SelinuxLabel = processContext.Get()
+		var label string
+		if guestSeLinuxLabel != "" {
+			label = guestSeLinuxLabel
 		} else {
-			k.Logger().Info("Empty SELinux label for the process and the mount because guest SELinux is disabled")
-			grpcSpec.Process.SelinuxLabel = ""
-			grpcSpec.Linux.MountLabel = ""
+			label = grpcSpec.Process.SelinuxLabel
 		}
+
+		processContext, err := selinux.NewContext(label)
+		if err != nil {
+			return err
+		}
+
+		// Change the type from KVM to container because the type passed from the high-level
+		// runtime is for KVM process.
+		if guestSeLinuxLabel == "" {
+			processContext["type"] = defaultSeLinuxContainerType
+		}
+		grpcSpec.Process.SelinuxLabel = processContext.Get()
+		k.Logger().Info("SELinux label will be applied to the container process inside guest: ",
+			grpcSpec.Process.SelinuxLabel)
+	} else {
+		k.Logger().Info("Empty SELinux label for the process and the mount because guest SELinux is disabled")
+		grpcSpec.Process.SelinuxLabel = ""
+		grpcSpec.Linux.MountLabel = ""
 	}
 
 	// By now only CPU constraints are supported
@@ -1472,10 +1471,6 @@ func (k *kataAgent) createContainer(ctx context.Context, sandbox *Sandbox, c *Co
 
 	passSeccomp := !sandbox.config.DisableGuestSeccomp && sandbox.seccompSupported
 
-	// Currently, guest SELinux can be enabled only when SELinux is enabled on the host side.
-	if !sandbox.config.HypervisorConfig.DisableGuestSeLinux && !selinux.GetEnabled() {
-		return nil, fmt.Errorf("Guest SELinux is enabled, but SELinux is disabled on the host side")
-	}
 	if sandbox.config.HypervisorConfig.DisableGuestSeLinux && sandbox.config.GuestSeLinuxLabel != "" {
 		return nil, fmt.Errorf("Custom SELinux security policy is provided, but guest SELinux is disabled")
 	}

--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -54,6 +54,7 @@ readonly dax_alignment=2
 AGENT_INIT=${AGENT_INIT:-no}
 SELINUX=${SELINUX:-no}
 SELINUXFS="/sys/fs/selinux"
+SELINUX_ENFORCING=${SELINUX_ENFORCING:-yes}
 
 # shellcheck source=../scripts/lib.sh
 source "${lib_file}"
@@ -84,6 +85,10 @@ Extra environment variables:
 	                Make sure that selinuxfs is mounted to /sys/fs/selinux on the host
 	                and the rootfs is built with SELINUX=yes.
 	                DEFAULT value: "no"
+	SELINUX_ENFORCING:
+					If set to "yes", the image will be configured to enforce SELinux.
+					If set to "no", permissive (non-enforcing but logging) mode will be set.
+					DEFAULT value: "yes"
 
 Following diagram shows how the resulting image will look like
 
@@ -171,6 +176,7 @@ build_with_container() {
 		   --env NSDAX_BIN="${nsdax_bin}" \
 		   --env MEASURED_ROOTFS="${MEASURED_ROOTFS}" \
 		   --env SELINUX="${SELINUX}" \
+		   --env SELINUX_ENFORCING="${SELINUX_ENFORCING}" \
 		   --env DEBUG="${DEBUG}" \
 		   --env ARCH="${ARCH}" \
 		   --env TARGET_ARCH="${TARGET_ARCH}" \
@@ -412,6 +418,17 @@ create_disk() {
 	OK "Partitions created"
 }
 
+setup_selinux_agent() {
+	local mount_dir="$1"
+	# need to check the distro since policies vary
+	if [ -f ${mount_dir}/etc/os-release ]; then
+		local DISTRO=`sed -n 's/^NAME=\(.*\)$/\1/p' < ${mount_dir}/etc/os-release`
+		if [ "${DISTRO}" == "\"Ubuntu\"" ]; then
+			chroot "${mount_dir}" /usr/bin/chcon "system_u:system_r:dockerd_t:s0" /usr/bin/kata-agent
+		fi
+	fi
+}
+
 setup_selinux() {
 		local mount_dir="$1"
 		local agent_bin="$2"
@@ -424,14 +441,21 @@ setup_selinux() {
 			info "Labeling rootfs for SELinux"
 			selinuxfs_path="${mount_dir}${SELINUXFS}"
 			mkdir -p "$selinuxfs_path"
-			if mountpoint $SELINUXFS > /dev/null && \
-				chroot "${mount_dir}" command -v restorecon > /dev/null; then
+			if mountpoint $SELINUXFS > /dev/null; then
 				mount -t selinuxfs selinuxfs "$selinuxfs_path"
-				chroot "${mount_dir}" restorecon -RF -e ${SELINUXFS} /
+				chroot "${mount_dir}" /usr/sbin/restorecon -RF -e ${SELINUXFS} /
+				setup_selinux_agent ${mount_dir}
 				umount "${selinuxfs_path}"
 			else
 				die "Could not label the rootfs. Make sure that SELinux is enabled on the host \
   and the rootfs is built with SELINUX=yes"
+			fi
+			if [ "${SELINUX_ENFORCING}" == "yes" ]; then
+				info "Setting SELinux to enforcing"
+				sed -i 's/^SELINUX=permissive$/SELINUX=enforcing/' ${mount_dir}/etc/selinux/config
+			else
+				info "WARNING: Setting SELinux to permissive"
+				sed -i 's/^SELINUX=enforcing$/SELINUX=permissive/' ${mount_dir}/etc/selinux/config
 			fi
 		fi
 }

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -52,6 +52,9 @@ RUN apt-get update && \
     python3-dev \
     libclang-dev \
     file \
+    semodule-utils \
+    policycoreutils \
+    checkpolicy \
     zstd && \
     apt-get clean && rm -rf /var/lib/apt/lists/&& \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}

--- a/tools/osbuilder/rootfs-builder/ubuntu/config.sh
+++ b/tools/osbuilder/rootfs-builder/ubuntu/config.sh
@@ -13,7 +13,9 @@ PACKAGES="chrony iptables dbus"
 [ "$MEASURED_ROOTFS" = yes ] && PACKAGES+=" cryptsetup-bin e2fsprogs"
 [ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp2"
 [ "$(uname -m)" = "s390x" ] && PACKAGES+=" libcurl4 libnghttp2-14"
+[ "$SELINUX" = yes ] && PACKAGES+=" selinux-basics selinux-policy-default"
 REPO_COMPONENTS=${REPO_COMPONENTS:-main}
+[ "$SELINUX" = yes ] && REPO_COMPONENTS+=" universe"
 
 case "$ARCH" in
 	aarch64) DEB_ARCH=arm64;;

--- a/tools/osbuilder/rootfs-builder/ubuntu/kata-guest.te
+++ b/tools/osbuilder/rootfs-builder/ubuntu/kata-guest.te
@@ -1,0 +1,71 @@
+module kata-guest 1.0;
+#============= +++++++++ ==============
+# SELinux module for Ubuntu Kata guest
+# Provides allow rules for base OS,
+# kata-agent and basic workload.
+#============= +++++++++ ==============
+
+require {
+	type chronyd_t;
+	type container_t;
+	type debugfs_t;
+	type device_t;
+	type devpts_t;
+	type dmesg_t;
+	type dockerd_t;
+	type init_t;
+	type locale_t;
+	type mount_t;
+	type systemd_sysctl_t;
+	type systemd_binfmt_t;
+	type systemd_tmpfiles_t;
+	type tmp_t;
+	type tmpfs_t;
+	type unlabeled_t;
+	class capability sys_rawio;
+	class blk_file getattr;
+	class chr_file { create getattr ioctl open read write };
+	class dir { add_name create getattr mounton open read relabelto search write };
+	class file { entrypoint execute execute_no_trans getattr map open read relabelfrom relabelto };
+	class filesystem { associate mount relabelfrom relabelto };
+	class lnk_file { create getattr read };
+	class system start;
+	class process transition;
+}
+
+#============= chronyd_t ==============
+allow chronyd_t debugfs_t:dir search;
+#============= container_t ==============
+allow container_t devpts_t:chr_file { getattr ioctl read write };
+allow container_t container_t:chr_file { open read write };
+allow container_t self:filesystem associate;
+# without mount labeling, /dev falls under tmpfs_t
+allow container_t tmpfs_t:chr_file { getattr open read write };
+allow container_t tmpfs_t:filesystem associate;
+allow container_t tmpfs_t:lnk_file read;
+# workload rootfs may not be labeled, so allow unlabeled
+# this carries the risk of exposing anything else not properly labeled
+allow container_t unlabeled_t:dir { open getattr read search };
+allow container_t unlabeled_t:file { entrypoint execute execute_no_trans getattr map open read };
+allow container_t unlabeled_t:lnk_file { getattr read };
+#============= dmesg_t ==============
+# necessary for dmesg to function
+allow dmesg_t devpts_t:chr_file { read write };
+#============= init_t ==============
+allow init_t container_t:chr_file { create write };
+allow init_t container_t:dir { add_name create mounton relabelto write };
+allow init_t container_t:filesystem { mount relabelfrom relabelto };
+allow init_t container_t:lnk_file create;
+allow init_t container_t:process transition;
+allow init_t dockerd_t:file { execute execute_no_trans map };
+allow init_t self:system start;
+#============= mount_t ==============
+allow mount_t device_t:blk_file getattr;
+#============= systemd_binfmt_t ==============
+allow systemd_binfmt_t locale_t:dir { getattr open read search };
+allow systemd_binfmt_t locale_t:file { read open getattr map };
+#============= systemd_sysctl_t ==============
+allow systemd_sysctl_t self:capability sys_rawio;
+#============= systemd_tmpfiles_t ==============
+allow systemd_tmpfiles_t locale_t:file { read map };
+allow systemd_tmpfiles_t tmp_t:lnk_file read;


### PR DESCRIPTION
### Elements of this PR
- Changes to osbuilder to build Ubuntu images which have SELinux enforcement support enabled, including policy module coverage of Kata customizations of the guest OS, the kata-agent and minimal workload function.
- A change to runtime to enable sending an SELinux label to the agent when SELinux is not active on the host.
Question: should these be split into 2 PRs?

### Progress
- [x] tools/osbuilder/rootfs-builder: Enable building of Ubuntu guest images with SELinux enabled, with the necessary packages included.
- [x] tools/osbuilder/image-builder: Allow controlling whether SELinux is enforced, to enable debugging.
- [x] runtime: Allow launching an SELinux-enabled guest without host SELinux, passing a label to be applied to the workload container inside the guest.
- [x] Adapt the distro-provided SELinux policy to the kata guest image contents.
- [x] Understand and manage the size of the resulting image file.
- [x]  Ensure all Ubuntu-specific code is conditionalized.
- [x]  Document the SELinux policy allow rule origins.
- [ ]  Address Copilot review comments.
- [ ] Implement workload mount labeling in some fashion and remove unlabeled rules.

Work in progress for feedback.

### Limitations of current work
- Currently there is no change to runtime for transmitting mount label instructions to the agent. At least in my testing, this results in the workload mounts being unlabeled. The workload SELinux rules therefore give access to unlabeled files to the workload container_t type, which is not fail-secure in the event of other failures to label files. #11789
- One potentially important workflow for using this would be the various stages the life-cycle of workload-specific policies. There are several ways this might be supported that doesn't involve directly modifying the osbuilder inputs, generating custom images and inspection of the results, within the constraints of read-only guest rootfs. For example, it might be nice to be able to use a tool like https://github.com/containers/udica to generate a policy that would apply inside the guest, which might need adapting to the kata context.
- One likely important concern for SELinux guest usage is the ability to detect violation of policy. I.e. some way of delivering the AVC logs generated in the guest system components where they can be inspected for security response and debugging. #11778
- The SELinux policy isn't modularized between base OS, kata-agent and workload. Theoretically, some portion of the base OS rules might be eligible for upstream (in Ubuntu). I believe the question of how Kata should distribute kata-specific policies has been discussed for host-side confinement extensively - this looks similar. Workload-specific policy seems largely separate, assuming the packages policy provides reasonable defaults.
- All tools for administering SELinux policy are deployed as part of the guest image, which will be inert since they can't operate on the immutable filesystem. This increases the image size by ~90 MB purely from package installation, and approximately 130MB in final image size. Building the policy files and deploying them into the image from the builder containers could perhaps address this.