### PR TITLE
runtime-rs: Enable s390x nightly test for IBM SEL

### DIFF
--- a/.github/workflows/ci-nightly-s390x.yaml
+++ b/.github/workflows/ci-nightly-s390x.yaml
@@ -15,7 +15,8 @@ jobs:
         test_title:
           - kata-vfio-ap-e2e-tests
           - cc-vfio-ap-e2e-tests
-          - cc-se-e2e-tests
+          - cc-se-e2e-tests-go
+          - cc-se-e2e-tests-rs
     steps:
     - name: Fetch a test result for {{ matrix.test_title }}
       run: |

--- a/tests/integration/kubernetes/confidential_common.sh
+++ b/tests/integration/kubernetes/confidential_common.sh
@@ -10,7 +10,7 @@ source "${BATS_TEST_DIRNAME}/../../common.bash"
 
 load "${BATS_TEST_DIRNAME}/confidential_kbs.sh"
 
-SUPPORTED_TEE_HYPERVISORS=("qemu-snp" "qemu-tdx" "qemu-se")
+SUPPORTED_TEE_HYPERVISORS=("qemu-snp" "qemu-tdx" "qemu-se" "qemu-se-runtime-rs")
 SUPPORTED_NON_TEE_HYPERVISORS=("qemu-coco-dev")
 
 function setup_unencrypted_confidential_pod() {
@@ -35,6 +35,7 @@ function get_remote_command_per_hypervisor() {
 	REMOTE_COMMAND_PER_HYPERVISOR[qemu-snp]="dmesg | grep \"Memory Encryption Features active:.*SEV-SNP\""
 	REMOTE_COMMAND_PER_HYPERVISOR[qemu-tdx]="cpuid | grep TDX_GUEST"
 	REMOTE_COMMAND_PER_HYPERVISOR[qemu-se]="cd /sys/firmware/uv; cat prot_virt_guest | grep 1"
+	REMOTE_COMMAND_PER_HYPERVISOR[qemu-se-runtime-rs]="cd /sys/firmware/uv; cat prot_virt_guest | grep 1"
 
 	echo "${REMOTE_COMMAND_PER_HYPERVISOR[${KATA_HYPERVISOR}]}"
 }

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -234,7 +234,7 @@ function kbs_k8s_delete() {
 	pushd "${COCO_KBS_DIR}"
 	if [[ "${KATA_HYPERVISOR}" = "qemu-tdx" ]]; then
 		kubectl delete -k config/kubernetes/ita
-	elif [[ "${KATA_HYPERVISOR}" = "qemu-se" ]]; then
+	elif [[ "${KATA_HYPERVISOR}" = qemu-se* ]]; then
 		kubectl delete -k config/kubernetes/overlays/ibm-se
 	else
 		kubectl delete -k config/kubernetes/overlays/
@@ -304,8 +304,8 @@ function kbs_k8s_deploy() {
 	# expects at least one secret served at install time.
 	echo "somesecret" > overlays/key.bin
 
-	# For qemu-se runtime, prepare the necessary resources
-	if [[ "${KATA_HYPERVISOR}" == "qemu-se" ]]; then
+	# For qemu-se* runtime, prepare the necessary resources
+	if [[ "${KATA_HYPERVISOR}" == qemu-se* ]]; then
 		mv overlays/key.bin overlays/ibm-se/key.bin
 		prepare_credentials_for_qemu_se
 		# SE_SKIP_CERTS_VERIFICATION should be set to true

--- a/tests/integration/kubernetes/k8s-block-volume.bats
+++ b/tests/integration/kubernetes/k8s-block-volume.bats
@@ -11,7 +11,7 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	 case "${KATA_HYPERVISOR}" in
-	 	qemu-runtime-rs)
+		qemu-runtime-rs|qemu-se-runtime-rs)
 			skip "See: https://github.com/kata-containers/kata-containers/issues/10373" ;;
 		fc|stratovirt)
 			skip "See: https://github.com/kata-containers/kata-containers/issues/10873" ;;
@@ -73,7 +73,7 @@ setup() {
 
 teardown() {
 	case "${KATA_HYPERVISOR}" in
-	 	qemu-runtime-rs)
+		qemu-runtime-rs|qemu-se-runtime-rs)
 			skip "See: https://github.com/kata-containers/kata-containers/issues/10373" ;;
 		fc|stratovirt)
 			skip "See: https://github.com/kata-containers/kata-containers/issues/10873" ;;

--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -14,6 +14,7 @@ setup() {
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "test not working see: ${dragonball_limitations}"
 	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "https://github.com/kata-containers/kata-containers/issues/9039"
 	[ "${KATA_HYPERVISOR}" == "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
+	[ "${KATA_HYPERVISOR}" == "qemu-se-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
 		[ "${KATA_HYPERVISOR}" == "qemu-se" ] ) \
 		&& skip "TEEs do not support memory / CPU hotplug"
@@ -120,6 +121,7 @@ teardown() {
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "dragonball" ] && skip "test not working see: ${dragonball_limitations}"
 	[ "${KATA_HYPERVISOR}" == "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
+	[ "${KATA_HYPERVISOR}" == "qemu-se-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 	[ "${KATA_HYPERVISOR}" == "cloud-hypervisor" ] && skip "https://github.com/kata-containers/kata-containers/issues/9039"
 	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
 		[ "${KATA_HYPERVISOR}" == "qemu-se" ] ) \

--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -18,8 +18,6 @@ assert_equal() {
 }
 
 setup() {
-	[ "${KATA_HYPERVISOR}" = "qemu-se" ] && \
-		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	pod_name="sharevol-kata"
 	get_pod_config_dir
 	pod_logs_file=""
@@ -45,6 +43,8 @@ setup() {
 }
 
 @test "Empty dir volume when FSGroup is specified with non-root container" {
+	[[ "${KATA_HYPERVISOR}" = qemu-se* ]] && \
+		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	# This is a reproducer of k8s e2e "[sig-storage] EmptyDir volumes when FSGroup is specified [LinuxOnly] [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" test
 	pod_file="${pod_config_dir}/pod-empty-dir-fsgroup.yaml"
 	agnhost_name="${container_images_agnhost_name}"
@@ -70,8 +70,6 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" = "qemu-se" ] && \
-		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/tests/integration/kubernetes/k8s-inotify.bats
+++ b/tests/integration/kubernetes/k8s-inotify.bats
@@ -12,7 +12,7 @@ setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	issue_url="https://github.com/kata-containers/kata-containers/issues/8906"
-	[ "${KATA_HYPERVISOR}" == "qemu-se" ] && skip "test not working for IBM Z LPAR (see ${issue_url})"
+        [[ "${KATA_HYPERVISOR}" == qemu-se* ]] && skip "test not working for IBM Z LPAR (see ${issue_url})"
 	get_pod_config_dir
 
 	pod_yaml="${pod_config_dir}"/inotify-configmap-pod.yaml
@@ -50,7 +50,7 @@ teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	issue_url="https://github.com/kata-containers/kata-containers/issues/8906"
-	[ "${KATA_HYPERVISOR}" == "qemu-se" ] && skip "test not working for IBM Z LPAR (see ${issue_url})"
+        [[ "${KATA_HYPERVISOR}" == qemu-se* ]] && skip "test not working for IBM Z LPAR (see ${issue_url})"
 
 	# Debugging information
 	kubectl describe "pod/$pod_name"

--- a/tests/integration/kubernetes/k8s-number-cpus.bats
+++ b/tests/integration/kubernetes/k8s-number-cpus.bats
@@ -11,6 +11,7 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 setup() {
 	[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/9039"
 	[ "${KATA_HYPERVISOR}" = "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
+	[ "${KATA_HYPERVISOR}" = "qemu-se-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 	pod_name="cpu-test"
 	container_name="c1"
 	get_pod_config_dir
@@ -53,6 +54,7 @@ setup() {
 teardown() {
 	[ "${KATA_HYPERVISOR}" = "cloud-hypervisor" ] && skip "test not working https://github.com/kata-containers/kata-containers/issues/9039"
 	[ "${KATA_HYPERVISOR}" = "qemu-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
+	[ "${KATA_HYPERVISOR}" = "qemu-se-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/tests/integration/kubernetes/k8s-shared-volume.bats
+++ b/tests/integration/kubernetes/k8s-shared-volume.bats
@@ -9,7 +9,7 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" = "qemu-se" ] && \
+	[[ "${KATA_HYPERVISOR}" == qemu-se* ]] && \
 		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	get_pod_config_dir
 }
@@ -67,7 +67,7 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" = "qemu-se" ] && \
+	[[ "${KATA_HYPERVISOR}" == qemu-se* ]] && \
 		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	# Debugging information
 	kubectl describe "pod/$pod_name" || true

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -302,7 +302,7 @@ set_metadata_annotation() {
 	# dots.
 	yq -i ".${annotation_key} = \"${value}\"" "${yaml}"
 
-	if [[ "${key}" =~ kernel_params ]] && [[ "${KATA_HYPERVISOR}" == "qemu-se" ]]; then
+	if [[ "${key}" =~ kernel_params ]] && [[ "${KATA_HYPERVISOR}" == qemu-se* ]]; then
 		# A secure boot image for IBM SE should be rebuilt according to the KBS configuration.
 		if [ -z "${IBM_SE_CREDS_DIR:-}" ]; then
 			>&2 echo "ERROR: IBM_SE_CREDS_DIR is empty"


### PR DESCRIPTION
This PR skips the following k8s tests:

Tests skipped because tests for `qemu-se` are skipped:
- k8s-empty-dirs.bats
- k8s-inotify.bats
- k8s-shared-volume.bats

Tests skipped because tests for `qemu-runtime-rs` are skipped:

- k8s-block-volume.bats
- k8s-cpu-ns.bats
- k8s-number-cpus.bats

and adds a new test entry `cc-se-e2e-tests-rs` to the existing matrix and renames the existing entry `cc-se-e2e-tests` to `cc-se-e2e-tests-go`.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>