### PR TITLE
tests: Use "Failed" consistently for both runtimes

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -84,7 +84,7 @@ setup() {
 
     # The pod should be failed because the unpacked image size is larger than the memory size in the guest.
     assert_pod_fail "$pod_config"
-    assert_logs_contain "$node" kata "$node_start_time" "failed to pull image"
+    assert_logs_contain "$node" kata "$node_start_time" "Failed to pull image"
 }
 
 @test "Test we can pull an image inside the guest using trusted storage" {


### PR DESCRIPTION
In k8s-guest-pull-image.bats, `failed to pull image` is not caught by assert_logs_contain() for runtime-rs. 
To ensure consistency, this PR changes `failed` to `Failed`, which works for both runtimes.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>