### PR TITLE
runtime-rs: Remove default value of Linux.Resources.Devices and correctly set Hooks in OCI Spec to meet with Agent Policy requirements

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -18,7 +18,7 @@ use common::{
 };
 use kata_sys_util::k8s::update_ephemeral_storage_type;
 use kata_types::k8s;
-use oci_spec::runtime as oci;
+use oci_spec::runtime::{self as oci, LinuxDeviceCgroup};
 
 use oci::{LinuxResources, Process as OCIProcess};
 use resource::{
@@ -602,13 +602,33 @@ fn amend_spec(
     // special process K8s ephemeral volumes.
     update_ephemeral_storage_type(spec);
 
-    if let Some(linux) = spec.linux_mut() {
+    if let Some(linux) = &mut spec.linux_mut() {
         if disable_guest_seccomp {
             linux.set_seccomp(None);
         }
 
-        if let Some(_resource) = linux.resources_mut() {
-            LinuxResources::default();
+        // In certain scenarios, particularly under CoCo/Agent Policy enforcement, the default initial value of `Linux.Resources.Devices`
+        // is considered non-compliant, leading to container creation failures. To address this issue and ensure consistency with the behavior
+        // in `runtime-go`, the default value of `Linux.Resources.Devices` from the OCI Spec should be removed.
+        if let Some(resources) = linux.resources_mut() {
+            if let Some(devices) = resources.devices_mut().take() {
+                let cleaned_devices: Vec<LinuxDeviceCgroup> = devices
+                    .into_iter()
+                    .filter(|device| {
+                        !(!device.allow()
+                            && device.typ().is_none()
+                            && device.major().is_none()
+                            && device.minor().is_none()
+                            && device.access().as_deref() == Some("rwm"))
+                    })
+                    .collect();
+
+                resources.set_devices(if cleaned_devices.is_empty() {
+                    None
+                } else {
+                    Some(cleaned_devices)
+                });
+            }
         }
 
         // Host pidns path does not make sense in kata. Let's just align it with

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -593,15 +593,11 @@ fn amend_spec(
     disable_guest_selinux: bool,
 ) -> Result<()> {
     // Only the StartContainer hook needs to be reserved for execution in the guest
-    let start_container_hooks = if let Some(hooks) = spec.hooks().as_ref() {
-        hooks.start_container().clone()
-    } else {
-        None
-    };
-
-    let mut oci_hooks = oci::Hooks::default();
-    oci_hooks.set_start_container(start_container_hooks);
-    spec.set_hooks(Some(oci_hooks));
+    if let Some(hooks) = spec.hooks().as_ref() {
+        let mut oci_hooks = oci::Hooks::default();
+        oci_hooks.set_start_container(hooks.start_container().clone());
+        spec.set_hooks(Some(oci_hooks));
+    }
 
     // special process K8s ephemeral volumes.
     update_ephemeral_storage_type(spec);


### PR DESCRIPTION
In certain scenarios, particularly under CoCo/Agent Policy enforcement, the default initial value of `Linux.Resources.Devices` is considered non-compliant, leading to container creation failures. 

To address this issue and ensure consistency with the behavior in `runtime-go`, this commit removes the default value of `Linux.Resources.Devices` from the OCI Spec. 

This cleanup ensures that the OCI Spec aligns with runtime expectations and prevents policy violations during container creation.

And we also need ensure the setting of hooks when OCI Hooks is existing. Only the StartContainer hook needs to be reserved for execution in the guest, but we also make sure that the setting happens only when the OCI Hooks does exist, otherwise we do nothing.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>