### PR TITLE
ci: aks: Refresh OIDC token in case access token expired

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -147,6 +147,13 @@ jobs:
         timeout-minutes: 60
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
+      - name: Refresh OIDC token in case access token expired
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZ_APPID }}
+          tenant-id: ${{ secrets.AZ_TENANT_ID }}
+          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+
       - name: Delete AKS cluster
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh delete-cluster

--- a/.github/workflows/run-kata-coco-stability-tests.yaml
+++ b/.github/workflows/run-kata-coco-stability-tests.yaml
@@ -139,6 +139,13 @@ jobs:
         timeout-minutes: 300
         run: bash tests/stability/gha-stability-run.sh run-tests
 
+      - name: Refresh OIDC token in case access token expired
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZ_APPID }}
+          tenant-id: ${{ secrets.AZ_TENANT_ID }}
+          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+
       - name: Delete AKS cluster
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh delete-cluster

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -323,6 +323,13 @@ jobs:
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh report-tests
 
+      - name: Refresh OIDC token in case access token expired
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZ_APPID }}
+          tenant-id: ${{ secrets.AZ_TENANT_ID }}
+          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+
       - name: Delete AKS cluster
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh delete-cluster

--- a/.github/workflows/run-kata-deploy-tests-on-aks.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-aks.yaml
@@ -102,6 +102,13 @@ jobs:
       - name: Run tests
         run: bash tests/functional/kata-deploy/gha-run.sh run-tests
 
+      - name: Refresh OIDC token in case access token expired
+        uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
+        with:
+          client-id: ${{ secrets.AZ_APPID }}
+          tenant-id: ${{ secrets.AZ_TENANT_ID }}
+          subscription-id: ${{ secrets.AZ_SUBSCRIPTION_ID }}
+
       - name: Delete AKS cluster
         if: always()
         run: bash tests/functional/kata-deploy/gha-run.sh delete-cluster


### PR DESCRIPTION
It's possible that tests take a long time to run and hence that the access token expires before we delete the cluster. In this case `az cli` will try to refresh the access token using the OIDC token (which will have definitely also expired because its lifetime is ~5 minutes).

To address this we refresh the OIDC token manually instead. Automatic refresh isn't supported per Azure/azure-cli#28708.

Fixes: #11758

---

Test run: https://github.com/kata-containers/kata-containers/actions/workflows/ci-devel.yaml?query=branch%3Asprt%2Foidc-fix