### PR TITLE
ci: Delete policy settings directory in teardown_common()

### DIFF
--- a/tests/integration/kubernetes/confidential_common.sh
+++ b/tests/integration/kubernetes/confidential_common.sh
@@ -210,9 +210,10 @@ function create_coco_pod_yaml_with_annotations() {
 confidential_teardown_common() {
 	local node="$1"
 	local node_start_time="$2"
+	local policy_settings_dir="$3"
 
 	# Run common teardown
-	teardown_common "${node}" ${node_start_time}
+	teardown_common "${node}" ${node_start_time} "${policy_settings_dir}"
 
 	# Also try and print the kbs logs on failure
 	if [[ -n "${node_start_time}" && -z "${BATS_TEST_COMPLETED}" ]]; then

--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -90,5 +90,5 @@ teardown() {
 		skip "Test skipped as KBS not setup"
 	fi
 
-	confidential_teardown_common "${node}" "${node_start_time:-}"
+	confidential_teardown_common "${node}" "${node_start_time:-}" ""
 }

--- a/tests/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/tests/integration/kubernetes/k8s-credentials-secrets.bats
@@ -75,7 +75,5 @@ teardown() {
 
 	kubectl delete secret "$secret_name"
 
-	delete_tmp_policy_settings_dir "${pod_policy_settings_dir}"
-
-	teardown_common "${node}" "${node_start_time:-}"
+	teardown_common "${node}" "${node_start_time:-}" "${pod_policy_settings_dir}"
 }

--- a/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
@@ -110,6 +110,6 @@ teardown() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    confidential_teardown_common "${node}" "${node_start_time:-}"
+    confidential_teardown_common "${node}" "${node_start_time:-}" ""
     kubectl delete secret cococred --ignore-not-found
 }

--- a/tests/integration/kubernetes/k8s-guest-pull-image-encrypted.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-encrypted.bats
@@ -93,5 +93,5 @@ teardown() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    confidential_teardown_common "${node}" "${node_start_time:-}"
+    confidential_teardown_common "${node}" "${node_start_time:-}" ""
 }

--- a/tests/integration/kubernetes/k8s-guest-pull-image-signature.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-signature.bats
@@ -146,5 +146,5 @@ teardown() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    teardown_common "${node}" "${node_start_time:-}"
+    teardown_common "${node}" "${node_start_time:-}" ""
 }

--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -238,7 +238,7 @@ teardown() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    teardown_common "${node}" "${node_start_time:-}"
+    teardown_common "${node}" "${node_start_time:-}" ""
     kubectl delete --ignore-not-found pvc trusted-pvc
     kubectl delete --ignore-not-found pv trusted-block-pv
     kubectl delete --ignore-not-found storageclass local-storage

--- a/tests/integration/kubernetes/k8s-initdata.bats
+++ b/tests/integration/kubernetes/k8s-initdata.bats
@@ -192,5 +192,5 @@ teardown() {
 
     [ "${SNAPSHOTTER:-}" = "nydus" ] || skip "None snapshotter was found but this test requires one"
 
-    teardown_common "${node}" "${node_start_time:-}"
+    teardown_common "${node}" "${node_start_time:-}" ""
 }

--- a/tests/integration/kubernetes/k8s-ip6tables.bats
+++ b/tests/integration/kubernetes/k8s-ip6tables.bats
@@ -42,6 +42,5 @@ teardown() {
 	# Debugging information
 	kubectl logs "$pod_name"
 
-	delete_tmp_policy_settings_dir "${policy_settings_dir}"
-	teardown_common "${node}" "${node_start_time:-}"
+	teardown_common "${node}" "${node_start_time:-}" "${policy_settings_dir}"
 }

--- a/tests/integration/kubernetes/k8s-liveness-probes.bats
+++ b/tests/integration/kubernetes/k8s-liveness-probes.bats
@@ -95,5 +95,5 @@ teardown() {
 	# Debugging information
 	rm -f "${yaml_file}"
 
-	teardown_common "${node}" "${node_start_time:-}"
+	teardown_common "${node}" "${node_start_time:-}" ""
 }

--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -58,5 +58,5 @@ setup() {
 teardown() {
 	check_and_skip
 
-	teardown_common "${node}" "${node_start_time:-}"
+	teardown_common "${node}" "${node_start_time:-}" ""
 }

--- a/tests/integration/kubernetes/k8s-parallel.bats
+++ b/tests/integration/kubernetes/k8s-parallel.bats
@@ -52,9 +52,7 @@ teardown() {
 		rm -f ${pod_config_dir}/job-$i.yaml
 	done
 
-	delete_tmp_policy_settings_dir "${policy_settings_dir}"
-
-	teardown_common
+	teardown_common "${node}" "${node_start_time:-}" "${policy_settings_dir}"
 
 	# Delete jobs
 	kubectl delete jobs -l jobgroup=${job_name}

--- a/tests/integration/kubernetes/k8s-policy-logs.bats
+++ b/tests/integration/kubernetes/k8s-policy-logs.bats
@@ -33,5 +33,5 @@ setup() {
 
 teardown() {
     auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled"
-    teardown_common "${node}" "${node_start_time:-}"
+    teardown_common "${node}" "${node_start_time:-}" "${policy_settings_dir}"
 }

--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -55,5 +55,5 @@ teardown() {
 		kubectl logs ${pod}
 	done
 
-	teardown_common "${node}" "${node_start_time:-}"
+	teardown_common "${node}" "${node_start_time:-}" ""
 }

--- a/tests/integration/kubernetes/k8s-sealed-secret.bats
+++ b/tests/integration/kubernetes/k8s-sealed-secret.bats
@@ -115,7 +115,7 @@ teardown() {
 		skip "Test skipped as KBS not setup"
 	fi
 
-	confidential_teardown_common "${node}" "${node_start_time:-}"
+	confidential_teardown_common "${node}" "${node_start_time:-}" ""
 	kubectl delete secret sealed-secret --ignore-not-found
 	kubectl delete secret not-sealed-secret --ignore-not-found
 }

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -379,13 +379,16 @@ pod_exec_blocked_command() {
 # Parameters:
 #	$1	- node name where kata is installed
 #	$2	- start time at the node for the sake of fetching logs
+#   $3  - policy settings dir (can be empty)
 #
 teardown_common() {
 	local node="$1"
 	local node_start_time="$2"
+	local policy_settings_dir="$3"
 
 	kubectl describe pods
 	k8s_delete_all_pods_if_any_exists || true
+	delete_tmp_policy_settings_dir "${policy_settings_dir}"
 
 	# Print the node journal since the test start time if a bats test is not completed
 	if [[ -n "${node_start_time}" && -z "${BATS_TEST_COMPLETED}" ]]; then


### PR DESCRIPTION
This calls delete_tmp_policy_settings_dir() from teardown_common() and removes delete_tmp_policy_settings_dir() calls from tests when teardown_common() is already called.