### PR TITLE
kata-types: Support create_container_timeout set within configuration

### DIFF
--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use serde::{Deserialize, Deserializer};
 use std::io::Result;
 
 use crate::config::{ConfigOps, TomlConfig};
@@ -117,7 +118,8 @@ pub struct Agent {
     /// have sufficient time to complete.
     #[serde(
         default = "default_request_timeout",
-        rename = "create_container_timeout"
+        rename = "create_container_timeout",
+        deserialize_with = "deserialize_secs_to_millis"
     )]
     pub request_timeout_ms: u32,
 
@@ -146,6 +148,15 @@ pub struct Agent {
     /// Memory agent configuration
     #[serde(default)]
     pub mem_agent: MemAgent,
+}
+
+fn deserialize_secs_to_millis<'de, D>(deserializer: D) -> std::result::Result<u32, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    let secs = u32::deserialize(deserializer)?;
+
+    Ok(secs.saturating_mul(1000))
 }
 
 impl std::default::Default for Agent {

--- a/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
+++ b/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
@@ -387,7 +387,7 @@ container_pipe_size=@PIPESIZE@
 #
 # Effective Timeout Determination:
 # The effective timeout for a CreateContainerRequest is determined by taking the minimum of the following two values:
-# - create_container_timeout: The timeout value configured for creating containers (default: 30,000 milliseconds).
+# - create_container_timeout: The timeout value configured for creating containers (default: 30 seconds).
 # - runtime-request-timeout: The timeout value specified in the Kubelet configuration described as the link below:
 # (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout)
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -294,7 +294,7 @@ container_pipe_size=@PIPESIZE@
 #
 # Effective Timeout Determination:
 # The effective timeout for a CreateContainerRequest is determined by taking the minimum of the following two values:
-# - create_container_timeout: The timeout value configured for creating containers (default: 30,000 milliseconds).
+# - create_container_timeout: The timeout value configured for creating containers (default: 30 seconds).
 # - runtime-request-timeout: The timeout value specified in the Kubelet configuration described as the link below:
 # (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout)
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -707,7 +707,7 @@ kernel_modules=[]
 #
 # Effective Timeout Determination:
 # The effective timeout for a CreateContainerRequest is determined by taking the minimum of the following two values:
-# - create_container_timeout: The timeout value configured for creating containers (default: 30,000 milliseconds).
+# - create_container_timeout: The timeout value configured for creating containers (default: 30 seconds).
 # - runtime-request-timeout: The timeout value specified in the Kubelet configuration described as the link below:
 # (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout)
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -559,7 +559,7 @@ reconnect_timeout_ms = 5000
 #
 # Effective Timeout Determination:
 # The effective timeout for a CreateContainerRequest is determined by taking the minimum of the following two values:
-# - create_container_timeout: The timeout value configured for creating containers (default: 30,000 milliseconds).
+# - create_container_timeout: The timeout value configured for creating containers (default: 30 seconds).
 # - runtime-request-timeout: The timeout value specified in the Kubelet configuration described as the link below:
 # (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout)
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -178,7 +178,7 @@ disable_guest_selinux = true
 #
 # Effective Timeout Determination:
 # The effective timeout for a CreateContainerRequest is determined by taking the minimum of the following two values:
-# - create_container_timeout: The timeout value configured for creating containers (default: 30,000 milliseconds).
+# - create_container_timeout: The timeout value configured for creating containers (default: 30 seconds).
 # - runtime-request-timeout: The timeout value specified in the Kubelet configuration described as the link below:
 # (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout)
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -293,7 +293,7 @@ dial_timeout = 45
 #
 # Effective Timeout Determination:
 # The effective timeout for a CreateContainerRequest is determined by taking the minimum of the following two values:
-# - create_container_timeout: The timeout value configured for creating containers (default: 30,000 milliseconds).
+# - create_container_timeout: The timeout value configured for creating containers (default: 30 seconds).
 # - runtime-request-timeout: The timeout value specified in the Kubelet configuration described as the link below:
 # (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout)
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)


### PR DESCRIPTION
Since it aligns with the create_container_timeout definition in runtime-go, we need to set the value in configuration.toml in seconds, not milliseconds. We must also convert it to milliseconds when the configuration is loaded for request_timeout_ms.

Signed-off-by: Alex Lyn [alex.lyn@antgroup.com](mailto:alex.lyn@antgroup.com)