### PR TITLE
Enhance block device AIO mode

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -8,7 +8,7 @@ use std::{collections::HashMap, sync::Arc};
 
 use anyhow::{anyhow, Context, Result};
 use kata_sys_util::rand::RandomBytes;
-use kata_types::config::hypervisor::{TopologyConfigInfo, VIRTIO_SCSI};
+use kata_types::config::hypervisor::{BlockDeviceInfo, TopologyConfigInfo, VIRTIO_SCSI};
 use tokio::sync::{Mutex, RwLock};
 
 use crate::{
@@ -117,12 +117,8 @@ impl DeviceManager {
         self.pcie_topology.clone()
     }
 
-    async fn get_block_driver(&self) -> String {
-        self.hypervisor
-            .hypervisor_config()
-            .await
-            .blockdev_info
-            .block_device_driver
+    async fn get_block_device_info(&self) -> BlockDeviceInfo {
+        self.hypervisor.hypervisor_config().await.blockdev_info
     }
 
     async fn try_add_device(&mut self, device_id: &str) -> Result<()> {
@@ -623,15 +619,15 @@ pub async fn do_update_device(
     Ok(())
 }
 
-pub async fn get_block_driver(d: &RwLock<DeviceManager>) -> String {
-    d.read().await.get_block_driver().await
+pub async fn get_block_device_info(d: &RwLock<DeviceManager>) -> BlockDeviceInfo {
+    d.read().await.get_block_device_info().await
 }
 
 #[cfg(test)]
 mod tests {
     use super::DeviceManager;
     use crate::{
-        device::{device_manager::get_block_driver, DeviceConfig, DeviceType},
+        device::{device_manager::get_block_device_info, DeviceConfig, DeviceType},
         qemu::Qemu,
         BlockConfig, KATA_BLK_DEV_TYPE,
     };
@@ -670,7 +666,7 @@ mod tests {
         assert!(dm.is_ok());
 
         let d = dm.unwrap();
-        let block_driver = get_block_driver(&d).await;
+        let block_driver = get_block_device_info(&d).await.block_device_driver;
         let dev_info = DeviceConfig::BlockCfg(BlockConfig {
             path_on_host: "/dev/dddzzz".to_string(),
             driver_option: block_driver,

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/mod.rs
@@ -24,9 +24,9 @@ pub use vfio::{
 pub use vhost_user::{VhostUserConfig, VhostUserDevice, VhostUserType};
 pub use vhost_user_net::VhostUserNetDevice;
 pub use virtio_blk::{
-    BlockConfig, BlockDevice, KATA_BLK_DEV_TYPE, KATA_CCW_DEV_TYPE, KATA_MMIO_BLK_DEV_TYPE,
-    KATA_NVDIMM_DEV_TYPE, KATA_SCSI_DEV_TYPE, VIRTIO_BLOCK_CCW, VIRTIO_BLOCK_MMIO,
-    VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
+    BlockConfig, BlockDevice, BlockDeviceAio, KATA_BLK_DEV_TYPE, KATA_CCW_DEV_TYPE,
+    KATA_MMIO_BLK_DEV_TYPE, KATA_NVDIMM_DEV_TYPE, KATA_SCSI_DEV_TYPE, VIRTIO_BLOCK_CCW,
+    VIRTIO_BLOCK_MMIO, VIRTIO_BLOCK_PCI, VIRTIO_PMEM,
 };
 pub use virtio_fs::{
     ShareFsConfig, ShareFsDevice, ShareFsMountConfig, ShareFsMountOperation, ShareFsMountType,

--- a/src/runtime-rs/crates/resource/src/cpu_mem/swap.rs
+++ b/src/runtime-rs/crates/resource/src/cpu_mem/swap.rs
@@ -7,7 +7,7 @@ use agent::Agent;
 use anyhow::{anyhow, Context, Error, Result};
 use hypervisor::{
     device::{
-        device_manager::{do_handle_device, get_block_driver, DeviceManager},
+        device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         DeviceConfig, DeviceType,
     },
     BlockConfig,
@@ -156,7 +156,9 @@ impl SwapTask {
         let swap_path = swap_path.to_string_lossy().to_string();
 
         // Add swap file to sandbox
-        let block_driver = get_block_driver(&self.device_manager).await;
+        let block_driver = get_block_device_info(&self.device_manager)
+            .await
+            .block_device_driver;
         let dev_info = DeviceConfig::BlockCfg(BlockConfig {
             path_on_host: swap_path.clone(),
             driver_option: block_driver,

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context, Ok, Result};
 use async_trait::async_trait;
 use hypervisor::{
     device::{
-        device_manager::{do_handle_device, get_block_driver, DeviceManager},
+        device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         util::{get_host_path, DEVICE_TYPE_CHAR},
         DeviceConfig, DeviceType,
     },
@@ -415,7 +415,9 @@ impl ResourceManagerInner {
         for d in linux_devices.iter() {
             match d.typ() {
                 LinuxDeviceType::B => {
-                    let block_driver = get_block_driver(&self.device_manager).await;
+                    let block_driver = get_block_device_info(&self.device_manager)
+                        .await
+                        .block_device_driver;
                     let dev_info = DeviceConfig::BlockCfg(BlockConfig {
                         major: d.major(),
                         minor: d.minor(),

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -15,7 +15,7 @@ use hypervisor::{
         util::{get_host_path, DEVICE_TYPE_CHAR},
         DeviceConfig, DeviceType,
     },
-    BlockConfig, Hypervisor, VfioConfig,
+    BlockConfig, BlockDeviceAio, Hypervisor, VfioConfig,
 };
 use kata_types::mount::{
     Mount, DEFAULT_KATA_GUEST_SANDBOX_DIR, KATA_EPHEMERAL_VOLUME_TYPE, SHM_DIR,
@@ -418,10 +418,14 @@ impl ResourceManagerInner {
                     let block_driver = get_block_device_info(&self.device_manager)
                         .await
                         .block_device_driver;
+                    let aio = get_block_device_info(&self.device_manager)
+                        .await
+                        .block_device_aio;
                     let dev_info = DeviceConfig::BlockCfg(BlockConfig {
                         major: d.major(),
                         minor: d.minor(),
                         driver_option: block_driver,
+                        blkdev_aio: BlockDeviceAio::new(&aio),
                         ..Default::default()
                     });
 

--- a/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
@@ -11,7 +11,7 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use hypervisor::{
     device::{
-        device_manager::{do_handle_device, get_block_driver, DeviceManager},
+        device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         DeviceConfig, DeviceType,
     },
     BlockConfig,
@@ -50,7 +50,7 @@ impl BlockRootfs {
         fs::create_dir_all(&host_path)
             .map_err(|e| anyhow!("failed to create rootfs dir {}: {:?}", host_path, e))?;
 
-        let block_driver = get_block_driver(d).await;
+        let block_driver = get_block_device_info(d).await.block_device_driver;
 
         let block_device_config = &mut BlockConfig {
             major: stat::major(dev_id) as i64,

--- a/src/runtime-rs/crates/resource/src/volume/block_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/block_volume.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use hypervisor::{
     device::{
-        device_manager::{do_handle_device, get_block_driver, DeviceManager},
+        device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         DeviceConfig,
     },
     BlockConfig,
@@ -39,7 +39,7 @@ impl BlockVolume {
             Some(path) => path,
             None => return Err(anyhow!("mount source path is empty")),
         };
-        let block_driver = get_block_driver(d).await;
+        let block_driver = get_block_device_info(d).await.block_device_driver;
         let fstat = stat::stat(mnt_src).context(format!("stat {}", mnt_src.display()))?;
         let block_device_config = BlockConfig {
             major: stat::major(fstat.st_rdev) as i64,

--- a/src/runtime-rs/crates/resource/src/volume/block_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/block_volume.rs
@@ -13,7 +13,7 @@ use hypervisor::{
         device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         DeviceConfig,
     },
-    BlockConfig,
+    BlockConfig, BlockDeviceAio,
 };
 use kata_sys_util::mount::get_mount_path;
 use nix::sys::{stat, stat::SFlag};
@@ -39,12 +39,14 @@ impl BlockVolume {
             Some(path) => path,
             None => return Err(anyhow!("mount source path is empty")),
         };
-        let block_driver = get_block_device_info(d).await.block_device_driver;
+
+        let blkdev_info = get_block_device_info(d).await;
         let fstat = stat::stat(mnt_src).context(format!("stat {}", mnt_src.display()))?;
         let block_device_config = BlockConfig {
             major: stat::major(fstat.st_rdev) as i64,
             minor: stat::minor(fstat.st_rdev) as i64,
-            driver_option: block_driver,
+            driver_option: blkdev_info.block_device_driver,
+            blkdev_aio: BlockDeviceAio::new(&blkdev_info.block_device_aio),
             ..Default::default()
         };
 

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/rawblock_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/rawblock_volume.rs
@@ -11,7 +11,7 @@ use hypervisor::{
         device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         DeviceConfig,
     },
-    BlockConfig,
+    BlockConfig, BlockDeviceAio,
 };
 use kata_types::mount::DirectVolumeMountInfo;
 use nix::sys::{stat, stat::SFlag};
@@ -36,7 +36,7 @@ impl RawblockVolume {
         read_only: bool,
         sid: &str,
     ) -> Result<Self> {
-        let block_driver = get_block_device_info(d).await.block_device_driver;
+        let blkdev_info = get_block_device_info(d).await;
 
         // check volume type
         if mount_info.volume_type != KATA_DIRECT_VOLUME_TYPE {
@@ -60,7 +60,8 @@ impl RawblockVolume {
 
         let block_config = BlockConfig {
             path_on_host: mount_info.device.clone(),
-            driver_option: block_driver,
+            driver_option: blkdev_info.block_device_driver,
+            blkdev_aio: BlockDeviceAio::new(&blkdev_info.block_device_aio),
             ..Default::default()
         };
 

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/rawblock_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/rawblock_volume.rs
@@ -8,7 +8,7 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use hypervisor::{
     device::{
-        device_manager::{do_handle_device, get_block_driver, DeviceManager},
+        device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         DeviceConfig,
     },
     BlockConfig,
@@ -36,7 +36,7 @@ impl RawblockVolume {
         read_only: bool,
         sid: &str,
     ) -> Result<Self> {
-        let block_driver = get_block_driver(d).await;
+        let block_driver = get_block_device_info(d).await.block_device_driver;
 
         // check volume type
         if mount_info.volume_type != KATA_DIRECT_VOLUME_TYPE {

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
@@ -10,7 +10,7 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use hypervisor::{
     device::{
-        device_manager::{do_handle_device, get_block_driver, DeviceManager},
+        device_manager::{do_handle_device, get_block_device_info, DeviceManager},
         DeviceConfig, DeviceType,
     },
     VhostUserConfig, VhostUserType,
@@ -74,7 +74,7 @@ impl SPDKVolume {
             }
         }
 
-        let block_driver = get_block_driver(d).await;
+        let block_driver = get_block_device_info(d).await.block_device_driver;
 
         let vhu_blk_config = &mut VhostUserConfig {
             socket_path: device,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -24,7 +24,6 @@ use common::{
 };
 
 use containerd_shim_protos::events::task::{TaskExit, TaskOOM};
-use hypervisor::PortDeviceConfig;
 use hypervisor::VsockConfig;
 use hypervisor::HYPERVISOR_FIRECRACKER;
 use hypervisor::HYPERVISOR_REMOTE;
@@ -33,6 +32,7 @@ use hypervisor::{dragonball::Dragonball, HYPERVISOR_DRAGONBALL};
 use hypervisor::{qemu::Qemu, HYPERVISOR_QEMU};
 use hypervisor::{utils::get_hvsock_path, HybridVsockConfig, DEFAULT_GUEST_VSOCK_CID};
 use hypervisor::{BlockConfig, Hypervisor};
+use hypervisor::{BlockDeviceAio, PortDeviceConfig};
 use hypervisor::{ProtectionDeviceConfig, SevSnpConfig, TdxConfig};
 use kata_sys_util::hooks::HookStates;
 use kata_sys_util::protection::{available_guest_protection, GuestProtection};
@@ -481,6 +481,7 @@ impl VirtSandbox {
             path_on_host: image_path.display().to_string(),
             is_readonly: true,
             driver_option: block_driver.clone(),
+            blkdev_aio: BlockDeviceAio::Native,
             ..Default::default()
         };
         let initdata_config = InitDataConfig(block_config, initdata_digest);


### PR DESCRIPTION
The commits introduce a new configuration option that allows users to specify the block device I/O mode on a per-device basis.

Previously, all block devices were configured to use a single, unified AIO mode (defaulting to `io_uring`). This change provides more granular control, enabling users to explicitly configure the AIO mode for each device through the configuration file.

This new feature improves flexibility and allows for more tailored performance tuning based on specific workload requirements.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>