### PR TITLE
ci: security: Fix "commit hash does not point to a Git tag"

### DIFF
--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -41,7 +41,7 @@ jobs:
         filter_out_pattern: '^Revert "|^Reapply "'
 
     - name: DCO Check
-      uses: tim-actions/dco@2fd0504dc0d27b33f542867c300c60840c6dcb20 # master (2020-04-28)
+      uses: tim-actions/dco@f2279e6e62d5a7d9115b0cb8e837b777b1b02e21 # v1.1.0
       with:
         commits: ${{ steps.get-pr-commits.outputs.commits }}
 

--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -26,6 +26,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master (2024-06-20)
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
           ignore_paths: "**/vendor/**"

--- a/.github/workflows/shellcheck_required.yaml
+++ b/.github/workflows/shellcheck_required.yaml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Run ShellCheck
-        uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca # master (2024-06-20)
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
           severity: error
           ignore_paths: "**/vendor/**"


### PR DESCRIPTION
This fixes all such issues, ie.:

https://github.com/kata-containers/kata-containers/security/code-scanning/459
https://github.com/kata-containers/kata-containers/security/code-scanning/508
https://github.com/kata-containers/kata-containers/security/code-scanning/510