### PR TITLE
runtime-rs: add the sandbox's shm volume support

### DIFF
--- a/src/libs/kata-sys-util/src/k8s.rs
+++ b/src/libs/kata-sys-util/src/k8s.rs
@@ -11,7 +11,6 @@
 
 use kata_types::mount;
 use oci_spec::runtime::{Mount, Spec};
-use std::path::Path;
 
 use crate::mount::get_linux_mount_info;
 
@@ -34,9 +33,8 @@ pub fn is_ephemeral_volume(mount: &Mount) -> bool {
             mount.destination(),
 
         ),
-        (Some("bind"), Some(source), dest) if get_linux_mount_info(source).is_ok_and(|info| info.fs_type == "tmpfs") &&
-            (is_empty_dir(source) || dest.as_path() == Path::new("/dev/shm"))
-    )
+        (Some("bind"), Some(source), _dest) if get_linux_mount_info(source).is_ok_and(|info| info.fs_type == "tmpfs") &&
+            is_empty_dir(source))
 }
 
 /// Check whether the given path is a kubernetes empty-dir volume of medium "default".

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -68,6 +68,12 @@ pub const KATA_VIRTUAL_VOLUME_LAYER_NYDUS_FS: &str = "layer_nydus_fs";
 pub const KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL: &str = "image_guest_pull";
 /// In CoCo scenario, we support force_guest_pull to enforce container image guest pull without remote snapshotter.
 pub const KATA_IMAGE_FORCE_GUEST_PULL: &str = "force_guest_pull";
+/// kata default guest sandbox dir.
+pub const DEFAULT_KATA_GUEST_SANDBOX_DIR: &str = "/run/kata-containers/sandbox/";
+/// default shm directory name.
+pub const SHM_DIR: &str = "shm";
+/// shm device path.
+pub const SHM_DEVICE: &str = "/dev/shm";
 
 /// Manager to manage registered storage device handlers.
 pub type StorageHandlerManager<H> = HandlerManager<H>;

--- a/src/runtime-rs/crates/resource/src/manager.rs
+++ b/src/runtime-rs/crates/resource/src/manager.rs
@@ -90,9 +90,9 @@ impl ResourceManager {
         inner.setup_after_start_vm().await
     }
 
-    pub async fn get_storage_for_sandbox(&self) -> Result<Vec<Storage>> {
+    pub async fn get_storage_for_sandbox(&self, shm_size: u64) -> Result<Vec<Storage>> {
         let inner = self.inner.read().await;
-        inner.get_storage_for_sandbox().await
+        inner.get_storage_for_sandbox(shm_size).await
     }
 
     pub async fn handler_rootfs(

--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -40,8 +40,6 @@ const KATA_HOST_SHARED_DIR: &str = "/run/kata-containers/shared/sandboxes/";
 /// share fs (for example virtio-fs) mount path in the guest
 pub const KATA_GUEST_SHARE_DIR: &str = "/run/kata-containers/shared/containers/";
 
-pub(crate) const DEFAULT_KATA_GUEST_SANDBOX_DIR: &str = "/run/kata-containers/sandbox/";
-
 pub const PASSTHROUGH_FS_DIR: &str = "passthrough";
 const RAFS_DIR: &str = "rafs";
 

--- a/src/runtime-rs/crates/resource/src/volume/ephemeral_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/ephemeral_volume.rs
@@ -7,11 +7,11 @@
 use std::path::{Path, PathBuf};
 
 use super::Volume;
-use crate::share_fs::DEFAULT_KATA_GUEST_SANDBOX_DIR;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use hypervisor::device::device_manager::DeviceManager;
 use kata_sys_util::mount::{get_mount_path, get_mount_type};
+use kata_types::mount::DEFAULT_KATA_GUEST_SANDBOX_DIR;
 use kata_types::mount::KATA_EPHEMERAL_VOLUME_TYPE;
 use nix::sys::stat::stat;
 use oci_spec::runtime as oci;

--- a/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/shm_volume.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2019-2022 Alibaba Cloud
+// Copyright (c) 2019-2022 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::path::PathBuf;
+
+use super::Volume;
+use anyhow::Result;
+use async_trait::async_trait;
+use hypervisor::device::device_manager::DeviceManager;
+use kata_sys_util::mount::{get_mount_path, get_mount_type};
+use kata_types::mount::{
+    DEFAULT_KATA_GUEST_SANDBOX_DIR, KATA_EPHEMERAL_VOLUME_TYPE, SHM_DEVICE, SHM_DIR,
+};
+use oci_spec::runtime as oci;
+use tokio::sync::RwLock;
+
+#[derive(Debug)]
+pub(crate) struct ShmVolume {
+    mount: oci::Mount,
+}
+
+impl ShmVolume {
+    pub(crate) fn new(m: &oci::Mount) -> Result<Self> {
+        let mut mount = oci::Mount::default();
+        mount.set_destination(m.destination().clone());
+        mount.set_typ(Some("bind".to_string()));
+        mount.set_source(Some(
+            PathBuf::from(DEFAULT_KATA_GUEST_SANDBOX_DIR).join(SHM_DIR),
+        ));
+        mount.set_options(Some(vec!["rbind".to_string()]));
+
+        Ok(Self { mount })
+    }
+}
+
+#[async_trait]
+impl Volume for ShmVolume {
+    fn get_volume_mount(&self) -> anyhow::Result<Vec<oci::Mount>> {
+        Ok(vec![self.mount.clone()])
+    }
+
+    fn get_storage(&self) -> Result<Vec<agent::Storage>> {
+        Ok(vec![])
+    }
+
+    async fn cleanup(&self, _device_manager: &RwLock<DeviceManager>) -> Result<()> {
+        // No cleanup is required for ShmVolume because it is a mount in guest which
+        // does not require explicit unmounting or deletion in host side.
+        Ok(())
+    }
+
+    fn get_device_id(&self) -> Result<Option<String>> {
+        Ok(None)
+    }
+}
+
+pub(crate) fn is_shm_volume(m: &oci::Mount) -> bool {
+    get_mount_path(&Some(m.destination().clone())).as_str() == SHM_DEVICE
+        && get_mount_type(m).as_str() != KATA_EPHEMERAL_VOLUME_TYPE
+}

--- a/src/runtime-rs/crates/runtimes/common/src/types/mod.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/mod.rs
@@ -23,6 +23,10 @@ use kata_types::mount::Mount;
 use oci_spec::runtime as oci;
 use strum::Display;
 
+// DEFAULT_SHM_SIZE is the default shm size to be used in case host
+// IPC is used.
+pub const DEFAULT_SHM_SIZE: u64 = 65536 * 1024;
+
 /// TaskRequest: TaskRequest from shim
 /// TaskRequest and TaskResponse messages need to be paired
 #[derive(Debug, Clone, Display)]
@@ -176,6 +180,7 @@ pub struct SandboxConfig {
     pub annotations: HashMap<String, String, RandomState>,
     pub hooks: Option<oci::Hooks>,
     pub state: runtime_spec::State,
+    pub shm_size: u64,
 }
 
 #[derive(Clone, Debug)]

--- a/src/runtime-rs/crates/runtimes/common/src/types/trans_from_shim.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/types/trans_from_shim.rs
@@ -8,6 +8,7 @@ use super::{
     ContainerConfig, ContainerID, ContainerProcess, ExecProcessRequest, KillRequest,
     ResizePTYRequest, SandboxConfig, SandboxID, SandboxNetworkEnv, SandboxRequest,
     SandboxStatusRequest, ShutdownRequest, StopSandboxRequest, TaskRequest, UpdateRequest,
+    DEFAULT_SHM_SIZE,
 };
 
 use kata_types::mount::Mount;
@@ -84,6 +85,7 @@ impl TryFrom<sandbox_api::CreateSandboxRequest> for SandboxRequest {
                 bundle: from.bundle_path,
                 annotations: config.annotations,
             },
+            shm_size: DEFAULT_SHM_SIZE,
         })))
     }
 }


### PR DESCRIPTION
Docker containers support specifying the shm size using the --shm-size option and support sandbox-level shm volumes, so we've added support for shm volumes. Since Kubernetes doesn't support specifying the shm size, it typically uses a memory-based emptydir as the container's shm, and its size can be specified.