### PR TITLE
ci: Run Zizmor on pushes to any branch

### DIFF
--- a/.github/workflows/zizmor.yaml
+++ b/.github/workflows/zizmor.yaml
@@ -2,7 +2,6 @@ name: GHA security analysis
 
 on:
   push:
-    branches: ["main"]
   pull_request:
 
 permissions: {}


### PR DESCRIPTION
This runs Zizmor on pushes to any branch, not just main.

This is useful for:

 1. Testing changes in feature branches with the manually-triggered CI.
 2. Forked repos that may use a different name than "main" for their default branch.