### PR TITLE
runtime: clh: Add pci path for hotplugged network endpoints

### DIFF
--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -397,7 +397,7 @@ func TestCloudHypervisorBootVM(t *testing.T) {
 	clh.APIClient = &clhClientMock{}
 
 	savedVmAddNetPutRequestFunc := vmAddNetPutRequest
-	vmAddNetPutRequest = func(clh *cloudHypervisor) error { return nil }
+	vmAddNetPutRequest = func(clh *cloudHypervisor) ([]chclient.PciDeviceInfo, error) { return nil, nil }
 	defer func() {
 		vmAddNetPutRequest = savedVmAddNetPutRequestFunc
 	}()
@@ -526,7 +526,7 @@ func TestCloudHypervisorStartSandbox(t *testing.T) {
 	assert.NoError(err)
 
 	savedVmAddNetPutRequestFunc := vmAddNetPutRequest
-	vmAddNetPutRequest = func(clh *cloudHypervisor) error { return nil }
+	vmAddNetPutRequest = func(clh *cloudHypervisor) ([]chclient.PciDeviceInfo, error) { return nil, nil }
 	defer func() {
 		vmAddNetPutRequest = savedVmAddNetPutRequestFunc
 	}()


### PR DESCRIPTION
This commit introduces changes to parse the PciDeviceInfo received in response payload when adding a network device to the VM with cloud hypervisor. When hotplugging a network device for a given endpoint, it rightly sets the PciPath of the plugged-in device in the endpoint.

In calls like virtcontainers/sandbox.go:AddInterface, the later call to agent sends the pci info for uevents (instead of empty value) to rightly update the interfaces instead of failing with `Link not found`