### PR TITLE
runtime: snp: enable CoCo annotations

### DIFF
--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -52,7 +52,7 @@ sev_snp_guest = true
 # List of valid annotation names for the hypervisor
 # Each member of the list is a regular expression, which is the base name
 # of the annotation, e.g. "path" for io.katacontainers.config.hypervisor.path"
-enable_annotations = @DEFENABLEANNOTATIONS@
+enable_annotations = @DEFENABLEANNOTATIONS_COCO@
 
 # List of valid annotations values for the hypervisor
 # Each member of the list is a path pattern as described by glob(3).


### PR DESCRIPTION
Use @DEFENABLEANNOTATIONS_COCO@ in configuration-qemu-snp.toml, for consistency with the tdx and coco-dev configuration files.

k8s-initdata.bats was failing during CI on SNP without this change, because the cc_init_data annotation was disabled.