### PR TITLE
versions: bump ovmf edk2 version

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -359,18 +359,18 @@ externals:
     url: "https://github.com/tianocore/edk2"
     x86_64:
       description: "Vanilla firmware build"
-      version: "edk2-stable202411"
+      version: "edk2-stable202508"
       package: "OvmfPkg/OvmfPkgX64.dsc"
       package_output_dir: "OvmfX64"
     sev:
       # Used by AMD SEV-SNP for measured direct boot
       description: "AmdSev build needed for SEV measured direct boot."
-      version: "edk2-stable202411"
+      version: "edk2-stable202508"
       package: "OvmfPkg/AmdSev/AmdSevX64.dsc"
       package_output_dir: "AmdSev"
     arm64:
       description: "UEFI for arm64 virtual machines."
-      version: "edk2-stable202411"
+      version: "edk2-stable202508"
       package: "ArmVirtPkg/ArmVirtQemu.dsc"
       package_output_dir: "ArmVirtQemu-AARCH64"
 


### PR DESCRIPTION
Update ovmf to latest release. Includes CVE-2024-38805 fix.

EDK2 changelogs for releases since edk2-stable202411: https://github.com/tianocore/edk2/releases/tag/edk2-stable202508 https://github.com/tianocore/edk2/releases/tag/edk2-stable202505 https://github.com/tianocore/edk2/releases/tag/edk2-stable202502