### PR TITLE
runtime-rs: Bugfix for kata virtual volume overlay fstype

### DIFF
--- a/src/runtime-rs/crates/resource/src/rootfs/virtual_volume.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/virtual_volume.rs
@@ -24,7 +24,7 @@ use kata_types::{
 /// Image guest-pull related consts
 const KUBERNETES_CRI_IMAGE_NAME: &str = "io.kubernetes.cri.image-name";
 const KUBERNETES_CRIO_IMAGE_NAME: &str = "io.kubernetes.cri-o.ImageName";
-const KATA_VIRTUAL_VOLUME_TYPE_OVERLAY_FS: &str = "overlayfs";
+const KATA_VIRTUAL_VOLUME_TYPE_OVERLAY_FS: &str = "overlay";
 const KATA_GUEST_ROOT_SHARED_FS: &str = "/run/kata-containers/";
 
 const CRI_CONTAINER_TYPE_KEY_LIST: &[&str] = &[


### PR DESCRIPTION
As prvious configure with overlayfs is incorrect, which causes the agent policy validation failure. And it's also different with runtime-go's configuration. In this patch, we'll correct its fstype with overlay and align with runtime on this matter.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>