### PR TITLE
runtime-rs: Enable share-rw=true when hotplug block device within qemu

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -634,6 +634,7 @@ impl Qmp {
             // add SCSI frontend device
             blkdev_add_args.insert("scsi-id".to_string(), scsi_id.into());
             blkdev_add_args.insert("lun".to_string(), lun.into());
+            blkdev_add_args.insert("share-rw".to_string(), true.into());
 
             self.qmp
                 .execute(&qmp::device_add {
@@ -654,6 +655,7 @@ impl Qmp {
         } else {
             let (bus, slot) = self.find_free_slot()?;
             blkdev_add_args.insert("addr".to_owned(), format!("{:02}", slot).into());
+            blkdev_add_args.insert("share-rw".to_string(), true.into());
 
             self.qmp
                 .execute(&qmp::device_add {


### PR DESCRIPTION
Support for the share-rw=true parameter has been added. While this parameter is essential for maintaining data consistency across multiple QEMU instances sharing a backend disk image, its implementation also serves to standardize parameters with the block device hotplug functionality in kata-runtime/qemu.

It mainly address such issue when we run nontee CI, which described as below:
```
failed to create containerd task: failed to create shim task: Others("failed to handle message create container\n\nCaused by:\n    0: do handle device\n    1: failed to add deivce\n    2: hotplug block device\n    3: blockdev-add backend Qapi(Error { class: GenericError, desc: \"Duplicate nodes with node-name='drive-1'\", id: None })\n\nStack backtrace:\n   0: anyhow::error::<impl anyhow::Error>::msg\n   1: hypervisor::qemu::qmp::Qmp::hotplug_block_device\n   2: hypervisor::qemu::inner::QemuInner::hotplug_device\n   3: <hypervisor::qemu::Qemu as hypervisor::Hypervisor>::add_device::{{closure}}\n   4: <hypervisor::device::driver::virtio_blk::BlockDevice as hypervisor::device::Device>::attach::{{closure}}\n   5: hypervisor::device::device_manager::do_handle_device::{{closure}}\n   6: virt_container::container_manager::container::Container::create::{{closure}}\n   7: <virt_container::container_manager::manager::VirtContainerManager as common::container_manager::ContainerManager>::create_container::{{closure}}\n   8: runtimes::manager::RuntimeHandlerManager::handler_task_message::{{closure}}::{{closure}}\n   9: runtimes::manager::RuntimeHandlerManager::handler_task_message::{{closure}}\n  10: <service::task_service::TaskService as containerd_shim_protos::shim::shim_ttrpc_async::Task>::create::{{closure}}\n  11: <containerd_shim_protos::shim::shim_ttrpc_async::CreateMethod as ttrpc::asynchronous::utils::MethodHandler>::handler::{{closure}}\n  12: <tokio::time::timeout::Timeout<T> as core::future::future::Future>::poll\n  13: ttrpc::asynchronous::server::HandlerContext::handle_msg::{{closure}}\n  14: <core::future::poll_fn::PollFn<F> as core::future::future::Future>::poll\n  15: <ttrpc::asynchronous::server::ServerReader as ttrpc::asynchronous::connection::ReaderDelegate>::handle_msg::{{closure}}::{{closure}}\n  16: tokio::runtime::task::core::Core<T,S>::poll\n  17: tokio::runtime::task::harness::Harness<T,S>::poll\n  18: tokio::runtime::scheduler::multi_thread::worker::Context::run_task\n  19: tokio::runtime::scheduler::multi_thread::worker::Context::run\n  20: tokio::runtime::context::runtime::enter_runtime\n  21: tokio::runtime::scheduler::multi_thread::worker::run\n  22: <tokio::runtime::blocking::task::BlockingTask<T> as core::future::future::Future>::poll\n  23: tokio::runtime::task::core::Core<T,S>::poll\n  24: tokio::runtime::task::harness::Harness<T,S>::poll\n  25: tokio::runtime::blocking::pool::Inner::run\n  26: std::sys::backtrace::__rust_begin_short_backtrace\n  27: core::ops::function::FnOnce::call_once{{vtable.shim}}\n  28: std::sys::pal::unix::thread::Thread::new::thread_start"): unknown
```