### PR TITLE
runtime-rs: implement VMTemplate creation and startup in Rust runtime

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1281,6 +1281,34 @@ pub struct Hypervisor {
     /// Disables applying SELinux on the container process within the guest.
     #[serde(default = "yes")]
     pub disable_guest_selinux: bool,
+
+    /// Indicate whether the VM is being created as a template VM.
+    #[serde(default)]
+    pub boot_to_be_template: bool,
+
+    /// Indicate whether the VM should be created from an existing template VM.
+    #[serde(default)]
+    pub boot_from_template: bool,
+
+	/// MemoryPath is the memory file path of VM memory. Used when either BootToBeTemplate or BootFromTemplate is true.
+    #[serde(default)]
+    pub memory_path: String,
+
+    /// DevicesStatePath is the VM device state file path. Used when either BootToBeTemplate or BootFromTemplate is true.
+    #[serde(default)]
+    pub device_state_path: String,
+    
+    /// Path for filesystem sharing
+    #[serde(default)]
+	pub shared_path: String,
+
+    /// VMStorePath is the location on disk where VM information will persist
+    #[serde(default)]
+	pub vm_store_path: String,
+
+    /// VMStorePath is the location on disk where runtime information will persist
+    #[serde(default)]
+	pub run_store_path: String,
 }
 
 fn yes() -> bool {

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -100,6 +100,23 @@ pub trait ConfigObjectOps {
     }
 }
 
+/// Factory is a structure to set the VM factory configuration.
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+pub struct Factory {
+	/// TemplatePath specifies the path of template.
+    #[serde(default)]
+    pub template_path: String,
+    /// VMCacheEndpoint specifies the endpoint of transport VM from the VM cache server to runtime.
+    #[serde(default)]
+    pub vm_cache_endpoint: String,
+    /// VMCacheNumber specifies the the number of caches of VMCache.
+    #[serde(default)]
+    pub vm_cache_number: u32,
+    /// Template enables VM templating support in VM factory.
+    #[serde(default)]
+    pub template: bool,
+}
+
 /// Kata configuration information.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TomlConfig {
@@ -112,6 +129,9 @@ pub struct TomlConfig {
     /// Kata runtime configuration information.
     #[serde(default)]
     pub runtime: Runtime,
+    /// Factory configuration information.
+    #[serde(default)]
+    pub factory: Factory,
 }
 
 macro_rules! mem_agent_kv_insert {
@@ -162,7 +182,6 @@ impl TomlConfig {
             file_path.to_string_lossy()
         );
         let config = drop_in::load(&file_path)?;
-
         Ok((config, file_path))
     }
 

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -364,6 +364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,19 +1033,25 @@ name = "dbs-pci"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "dbs-address-space",
  "dbs-allocator",
  "dbs-boot",
  "dbs-device",
  "dbs-interrupt",
+ "dbs-utils",
+ "dbs-virtio-devices",
  "downcast-rs",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
  "log",
+ "serde",
  "thiserror 1.0.69",
  "vfio-bindings",
  "vfio-ioctls",
+ "virtio-queue",
  "vm-memory",
+ "vmm-sys-util 0.11.1",
 ]
 
 [[package]]
@@ -3647,11 +3659,11 @@ dependencies = [
 
 [[package]]
 name = "qapi-spec"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b360919a24ea5fc02fa762cb01bd8f43b643fee51c585f763257773b4dc5a9e8"
+checksum = "49e6bdbbe5d13015b21a49a778a29ae3cee9c450c3154e1648aed670d57fe5ba"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "serde",
  "serde_json",
 ]
@@ -5261,6 +5273,9 @@ name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "valuable"
@@ -5355,6 +5370,7 @@ dependencies = [
  "toml 0.4.10",
  "tracing",
  "url",
+ "uuid 1.16.0",
 ]
 
 [[package]]

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2657,6 +2657,11 @@ impl<'a> QemuCmdLine<'a> {
 
         result.append(&mut self.knobs.qemu_params().await?);
 
+        if self.config.boot_from_template {
+            result.push("-incoming".to_string());
+            result.push("defer".to_string());
+        }
+
         Ok(result)
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -90,17 +90,17 @@ impl Hypervisor for Qemu {
     }
 
     async fn pause_vm(&self) -> Result<()> {
-        let inner = self.inner.read().await;
+        let mut inner = self.inner.write().await;
         inner.pause_vm()
     }
 
     async fn resume_vm(&self) -> Result<()> {
-        let inner = self.inner.read().await;
+        let mut inner = self.inner.write().await;
         inner.resume_vm()
     }
 
     async fn save_vm(&self) -> Result<()> {
-        let inner = self.inner.read().await;
+        let mut inner = self.inner.write().await;
         inner.save_vm().await
     }
 

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -161,7 +161,6 @@ impl ResourceManagerInner {
                             )
                             .await
                             .context("setup share fs device before start vm")?;
-
                         // setup sandbox bind mounts: setup = true
                         self.handle_sandbox_bindmounts(true)
                             .await

--- a/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
@@ -31,6 +31,7 @@ impl std::fmt::Debug for SandboxNetworkEnv {
 #[async_trait]
 pub trait Sandbox: Send + Sync {
     async fn start(&self) -> Result<()>;
+    async fn start_template(&self) -> Result<()>;
     async fn stop(&self) -> Result<()>;
     async fn cleanup(&self) -> Result<()>;
     async fn shutdown(&self) -> Result<()>;

--- a/src/runtime-rs/crates/runtimes/src/manager.rs
+++ b/src/runtime-rs/crates/runtimes/src/manager.rs
@@ -354,7 +354,7 @@ impl RuntimeHandlerManager {
             netns,
             network_created,
         };
-
+        
         let sandbox_config = SandboxConfig {
             sandbox_id: inner.id.clone(),
             dns,

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -27,6 +27,7 @@ async-std = "1.12.0"
 tracing = { workspace = true }
 oci-spec = { workspace = true }
 strum = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
 
 # Local dependencies
 agent = { workspace = true }
@@ -38,7 +39,6 @@ logging = { workspace = true }
 runtime-spec = { workspace = true }
 persist = { workspace = true }
 resource = { workspace = true }
-
 [features]
 default = ["cloud-hypervisor"]
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/mod.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/mod.rs
@@ -1,0 +1,336 @@
+// Copyright 2025 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#![allow(unused_variables, unused_imports)]
+use anyhow::{anyhow, Context, Result};
+use containerd_shim_protos::ttrpc::asynchronous::shutdown::new;
+use hypervisor::firecracker::sl;
+use slog::{error, info};
+
+use serde::{Deserialize, Serialize};
+
+use kata_types::config::TomlConfig;
+
+use std::ffi::CString;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::factory::template::Template;
+use crate::factory::vm::{VMConfig, VM};
+
+pub mod template;
+pub mod vm;
+
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "factory"))
+    };
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FactoryConfig {
+    /// Path to the directory where VM templates are stored.
+    #[serde(default)]
+    pub template_path: String,
+
+    /// Endpoint used for communication with the VM cache server.
+    // #[serde(default)]
+    // pub vm_cache_endpoint: String,
+
+    /// Full configuration of the virtual machine to be used.
+    #[serde(default)]
+    pub vm_config: VMConfig,
+
+    /// Number of cached VMs to maintain.
+    #[serde(default)]
+    pub cache: u32,
+
+    /// Whether VM template feature is enabled.
+    #[serde(default)]
+    pub template: bool,
+
+    /// Whether VM cache feature is enabled.
+    #[serde(default)]
+    pub vm_cache: bool,
+}
+
+pub async fn init_factory_command() -> Result<()> {
+    // Load Kata config
+    let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+
+    // Build FactoryConfig
+    let mut factory_config = FactoryConfig {
+        template: toml_config.factory.template,
+        template_path: toml_config.factory.template_path.clone(),
+        cache: toml_config.factory.vm_cache_number,
+        vm_cache: toml_config.factory.vm_cache_number > 0,
+        vm_config: VMConfig {
+            hypervisor_name: toml_config.runtime.hypervisor_name.clone(),
+            agent_name: toml_config.runtime.agent_name.clone(),
+            hypervisor_config: toml_config
+                .hypervisor
+                .get(&toml_config.runtime.hypervisor_name)
+                .cloned()
+                .unwrap_or_default(),
+            agent_config: toml_config
+                .agent
+                .get(&toml_config.runtime.agent_name)
+                .cloned()
+                .unwrap_or_default(),
+        },
+    };
+
+    // Template
+    if toml_config.factory.template {
+        match new_factory(&mut factory_config, toml_config, false).await {
+            Ok(_) => {
+                info!(
+                    sl!(),
+                    "factory::init_factory_command(): create vm factory successfully"
+                );
+            }
+            Err(e) => {
+                error!(
+                    sl!(),
+                    "factory::init_factory_command(): create vm factory failed: {}", e
+                );
+                return Err(e);
+            }
+        }
+    } else {
+        let err_string = "vm factory or VMCache is not enabled";
+        error!(sl!(), "{}", err_string);
+    }
+
+    Ok(())
+}
+
+pub async fn destroy_factory_command() -> Result<()> {
+    println!("destroy_factory_command");
+    // Load Kata config
+    let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+
+    // Build FactoryConfig
+    let mut factory_config = FactoryConfig {
+        template: toml_config.factory.template,
+        template_path: toml_config.factory.template_path.clone(),
+        cache: toml_config.factory.vm_cache_number,
+        vm_cache: toml_config.factory.vm_cache_number > 0,
+        vm_config: VMConfig {
+            hypervisor_name: toml_config.runtime.hypervisor_name.clone(),
+            agent_name: toml_config.runtime.agent_name.clone(),
+            hypervisor_config: toml_config
+                .hypervisor
+                .get(&toml_config.runtime.hypervisor_name)
+                .cloned()
+                .unwrap_or_default(),
+            agent_config: toml_config
+                .agent
+                .get(&toml_config.runtime.agent_name)
+                .cloned()
+                .unwrap_or_default(),
+        },
+    };
+
+    // Template
+    if toml_config.factory.template {
+        if let Err(e) = new_factory(&mut factory_config, toml_config, true).await {
+            error!(sl!(), "load vm factory failed: {:?}", e);
+            return Err(e);
+        }
+
+        info!(sl!(), "begin destroy factory");
+
+        close_factory(&mut factory_config).map_err(|e| {
+            error!(sl!(), "Failed to close factory: {:?}", e);
+            anyhow!("Failed to close factory: {}", e)
+        })?;
+    } else {
+        let log_string = "vm factory is not enabled";
+        info!(sl!(), "{}", log_string);
+    }
+
+    info!(sl!(), "vm factory destroyed");
+    Ok(())
+}
+
+pub async fn status_factory_command() -> Result<()> {
+    println!("status_factory_command");
+    // Load Kata config
+    let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+
+    // Build FactoryConfig
+    let mut factory_config = FactoryConfig {
+        template: toml_config.factory.template,
+        template_path: toml_config.factory.template_path.clone(),
+        cache: toml_config.factory.vm_cache_number,
+        vm_cache: toml_config.factory.vm_cache_number > 0,
+        vm_config: VMConfig {
+            hypervisor_name: toml_config.runtime.hypervisor_name.clone(),
+            agent_name: toml_config.runtime.agent_name.clone(),
+            hypervisor_config: toml_config
+                .hypervisor
+                .get(&toml_config.runtime.hypervisor_name)
+                .cloned()
+                .unwrap_or_default(),
+            agent_config: toml_config
+                .agent
+                .get(&toml_config.runtime.agent_name)
+                .cloned()
+                .unwrap_or_default(),
+        },
+    };
+
+    // Template
+    if toml_config.factory.template {
+        match new_factory(&mut factory_config, toml_config, true).await {
+            Ok(_) => {
+                info!(sl!(), "vm factory is on");
+            }
+            Err(e) => {
+                info!(sl!(), "vm factory is off");
+            }
+        }
+    } else {
+        let log_string = "vm factory is not enabled";
+        info!(sl!(), "{}", log_string);
+    }
+
+    Ok(())
+}
+
+pub async fn new_factory(
+    config: &mut FactoryConfig,
+    toml_config: TomlConfig,
+    fetch_only: bool,
+) -> Result<()> {
+    // Validate VMConfig
+    config.vm_config.valid().map_err(|e| {
+        error!(
+            sl!(),
+            "factory::new_factory(): VMConfig validate failed {:#?}", e
+        );
+        e
+    })?;
+
+    info!(sl!(), "factory::new_factory(): VMConfig validate ok");
+
+    // template mode
+    if !config.template {
+        error!(sl!(), "factory::new_factory(): template must be enabled");
+    } else {
+        if fetch_only {
+            info!(sl!(), "factory::new_factory(): template fetch");
+            // Construct PathBuf
+            let path: PathBuf = config.template_path.clone().into();
+            let factory = match Template::fetch(config.vm_config.clone(), path) {
+                Ok(factory) => {
+                    // Successfully fetched the factory, proceed with the logic
+                    factory
+                }
+                Err(e) => {
+                    return Err(anyhow!(e)); // Return an error with a detailed message
+                }
+            };
+        } else {
+            info!(sl!(), "factory::new_factory(): template new");
+            // Construct PathBuf
+            let path: PathBuf = config.template_path.clone().into();
+            let factory = match Template::new(config.vm_config.clone(), toml_config, path).await {
+                Ok(factory) => factory,
+                Err(e) => {
+                    error!(sl!(), "Failed to create new Template factory: {}", e);
+                    return Err(e);
+                }
+            };
+        }
+    }
+
+    Ok(())
+}
+
+pub fn close_factory(config: &mut FactoryConfig) -> Result<()> {
+    let state_path = Path::new(&config.template_path); // Get the state path from the config
+    let c_state_path = CString::new(state_path.to_str().unwrap())?;
+    // Attempt to unmount the state path
+    let result = unsafe { libc::umount(c_state_path.as_ptr()) }; // Unmount the directory
+
+    if result != 0 {
+        // if umount false，try to use umount -f to force umount
+        let result_lazy = Command::new("umount")
+            .arg("-f")
+            .arg(state_path)
+            .output()
+            .context("Failed to execute umount command with -f")?;
+
+        if !result_lazy.status.success() {
+            let err = std::io::Error::last_os_error();
+            error!(
+                sl!(),
+                "Failed to force unmount {}: {}",
+                state_path.display(),
+                err
+            );
+            return Err(anyhow!(
+                "Failed to force unmount {}: {}",
+                state_path.display(),
+                err
+            ));
+        }
+    }
+
+    // Attempt to remove the directory and its contents
+    if let Err(e) = fs::remove_dir_all(&state_path) {
+        // Log an error if removing the directory fails
+        error!(sl(), "Failed to remove {}: {}", state_path.display(), e);
+        return Err(anyhow!("Failed to remove {}: {}", state_path.display(), e));
+    }
+
+    Ok(())
+}
+
+pub async fn get_vm(config: &mut VMConfig, template_path: PathBuf) -> Result<VM> {
+    info!(sl!(), "factory::get_vm(): start");
+
+    // Validate  VMConfig
+    if let Err(e) = config.valid() {
+        error!(sl!(), "{:#?}", e);
+        return Err(e);
+    } else {
+        info!(sl!(), "factory::get_vm(): VMConfig validate ok");
+    }
+
+    // Compare the VM template with the new VM template.
+    // If they do not match, directly start the VM instead
+    //todo vm.checkVMConfig() if true template; else direct
+
+    // Get template
+    // In Go, multiple VM types (cache, template, etc.) are accessed through the base interface.
+    // Here, we are currently implementing only the template.
+    let template = Template {
+        state_path: template_path,
+        config: config.clone(),
+    };
+    let vm = template.get_base_vm(config).await?;
+    info!(
+        sl!(),
+        "factory::get_vm(): vm: new_vm() VM id={}, cpu={}, memory={}", vm.id, vm.cpu, vm.memory
+    );
+
+    // Resume vm
+    vm.resume().await?;
+
+    // Re-inject a new seed into the guest kernel's RNG device to ensure that the cloned VM
+    // todo vm.ReseedRNG()
+
+    // Synchronize the guest internal clock with the host's current time to ensure the VM's time is accurate.
+    // todo vm.SyncTime()
+
+    //  After restoring the VM in the factory, perform "hotplug" processing for CPU and memory expansion.
+    // tofo vm.AddCPUs(); vm.AddMemory; vm.OnlineCPUMemory
+
+    Ok(vm)
+}

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/template/mod.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/template/mod.rs
@@ -1,0 +1,213 @@
+// Copyright 2025 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#![allow(unused_variables, unused_imports)]
+use std::fmt::Debug;
+use std::fs::File;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::{anyhow, Result};
+
+use async_trait::async_trait;
+use nix::mount::{mount, MsFlags};
+
+use crate::factory::vm::{VMConfig, VM};
+use kata_types::config::TomlConfig;
+
+#[allow(dead_code)]
+const TEMPLATE_WAIT_FOR_AGENT: Duration = Duration::from_secs(2);
+const TEMPLATE_DEVICE_STATE_SIZE_MB: u32 = 8; // as in Go templateDeviceStateSize
+use hypervisor::{qemu::Qemu, Hypervisor, HYPERVISOR_QEMU};
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "factory"))
+    };
+}
+
+pub trait FactoryBase: Debug {}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct Template {
+    pub state_path: PathBuf,
+    pub config: VMConfig,
+}
+
+impl Template {
+    pub fn fetch(config: VMConfig, template_path: PathBuf) -> Result<Box<dyn FactoryBase>> {
+        let t = Template {
+            state_path: template_path,
+            config,
+        };
+
+        // Call check_template_vm to validate the template's files
+        if let Err(e) = t.check_template_vm() {
+            // If check_template_vm returns an error, log the error and return a detailed error message
+            return Err(anyhow!(e));
+        }
+
+        // If there is no error, return a Boxed instance of the Template
+        Ok(Box::new(t))
+    }
+
+    pub async fn new(
+        config: VMConfig,
+        toml_config: TomlConfig,
+        template_path: PathBuf,
+    ) -> Result<Box<dyn FactoryBase>> {
+        let t = Template {
+            state_path: template_path,
+            config,
+        };
+
+        match t.check_template_vm() {
+            Ok(_) => {
+                return Err(anyhow!(
+                    "There is already a VM template in {:?}",
+                    t.state_path
+                ));
+            }
+            Err(e) => {
+                info!(sl!(), "check_template_vm failed as expected: {}", e);
+            }
+        }
+
+        t.prepare_template_files()?;
+
+        if let Err(e) = t.create_template_vm(toml_config).await {
+            // t.close()?;
+            return Err(e);
+        }
+
+        Ok(Box::new(t))
+    }
+
+    pub fn check_template_vm(&self) -> Result<()> {
+        let memory_path = self.state_path.join("memory");
+        let state_path = self.state_path.join("state");
+
+        if !memory_path.exists() || !state_path.exists() {
+            info!(sl!(), "Template VM memory or state file missing");
+            return Err(anyhow!("template VM memory or state file missing"));
+        }
+
+        Ok(())
+    }
+
+    pub fn prepare_template_files(&self) -> Result<()> {
+        std::fs::create_dir_all(&self.state_path)?;
+        let opts = format!(
+            "size={}M",
+            self.config.hypervisor_config.memory_info.default_memory
+                + TEMPLATE_DEVICE_STATE_SIZE_MB
+        );
+        mount(
+            Some("tmpfs"),
+            &self.state_path,
+            Some("tmpfs"),
+            MsFlags::MS_NOSUID | MsFlags::MS_NODEV,
+            Some(opts.as_str()),
+        )?;
+
+        let memory_file = self.state_path.join("memory");
+        File::create(memory_file)?;
+
+        Ok(())
+    }
+
+    pub async fn create_template_vm(&self, toml_config: TomlConfig) -> Result<()> {
+        info!(sl!(), "template::create_template_vm: start(): start");
+        let mut config = self.config.clone();
+        config.hypervisor_config.boot_to_be_template = true;
+        config.hypervisor_config.boot_from_template = false;
+        config.hypervisor_config.memory_path =
+            self.state_path.join("memory").to_string_lossy().to_string();
+        config.hypervisor_config.device_state_path =
+            self.state_path.join("state").to_string_lossy().to_string();
+        // config.new_vm();
+        let vm = VM::new_vm(config, toml_config).await?;
+        info!(
+            sl!(),
+            "template::create_template_vm: new_vm() VM id={}, cpu={}, memory={}",
+            vm.id,
+            vm.cpu,
+            vm.memory
+        );
+
+        vm.disconnect().await?;
+        info!(sl!(), "template::create_template_vm: disconnect()");
+
+        // Sleep a bit to let the agent grpc server clean up
+        // When we close connection to the agent, it needs sometime to cleanup
+        // and restart listening on the communication( serial or vsock) port.
+        // That time can be saved if we sleep a bit to wait for the agent to
+        // come around and start listening again. The sleep is only done when
+        // creating new vm templates and saves time for every new vm that are
+        // created from template, so it worth the invest.
+        sleep(TEMPLATE_WAIT_FOR_AGENT);
+
+        vm.pause().await?;
+        info!(sl!(), "template::create_template_vm: pause()");
+
+        vm.save().await?;
+        info!(sl!(), "template::create_template_vm: save()");
+
+        // vm.stop().await?;
+        // info!(sl!(), "template::create_template_vm: stop()");
+
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub async fn create_from_template_vm(&self, new_config: &mut VMConfig) -> Result<VM> {
+        info!(sl!(), "template::create_from_template_vm: start(): start");
+
+        let mut config = self.config.clone();
+        config.hypervisor_config.boot_to_be_template = false;
+        config.hypervisor_config.boot_from_template = true;
+        config.hypervisor_config.memory_path =
+            self.state_path.join("memory").to_string_lossy().to_string();
+        config.hypervisor_config.device_state_path =
+            self.state_path.join("state").to_string_lossy().to_string();
+        config.hypervisor_config.shared_path = new_config.hypervisor_config.shared_path.clone();
+        config.hypervisor_config.vm_store_path = new_config.hypervisor_config.vm_store_path.clone();
+        config.hypervisor_config.run_store_path =
+            new_config.hypervisor_config.run_store_path.clone();
+
+        let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+
+        let vm = VM::new_vm(config, toml_config).await?;
+        info!(
+            sl!(),
+            "template::get_base_vm():  vm: new_vm() VM id={}, cpu={}, memory={}",
+            vm.id,
+            vm.cpu,
+            vm.memory
+        );
+        Ok(vm)
+    }
+
+    pub async fn get_base_vm(&self, config: &mut VMConfig) -> Result<VM> {
+        info!(sl!(), "template::get_base_vm(): start");
+        let vm = self.create_from_template_vm(config).await?;
+        info!(
+            sl!(),
+            "template::get_base_vm():  vm: new_vm() VM id={}, cpu={}, memory={}",
+            vm.id,
+            vm.cpu,
+            vm.memory
+        );
+        Ok(vm)
+    }
+}
+
+#[async_trait]
+impl FactoryBase for Template {
+
+}

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm/mod.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm/mod.rs
@@ -1,0 +1,336 @@
+#![allow(unused_mut)]
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use kata_types::config::default;
+use kata_types::config::Agent as AgentConfig;
+use kata_types::config::Hypervisor as HypervisorConfig;
+use kata_types::config::TomlConfig;
+use serde::{Deserialize, Serialize};
+
+use agent::{kata::KataAgent, Agent, AGENT_KATA};
+use hypervisor::{qemu::Qemu, Hypervisor, HYPERVISOR_QEMU};
+use resource::{cpu_mem::initial_size::InitialSizeManager, ResourceManager};
+
+use crate::factory;
+use crate::sandbox::VirtSandbox;
+use common::{message::Message, types::SandboxConfig, Sandbox, SandboxNetworkEnv};
+use runtime_spec;
+use slog::error;
+use tokio::sync::mpsc::channel;
+use uuid::Uuid;
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "vm"))
+    };
+}
+
+/// VM is an abstraction of a virtual machine.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct VM {
+    /// The hypervisor responsible for managing the virtual machine lifecycle.
+    pub hypervisor: Arc<dyn Hypervisor>,
+
+    /// The guest agent that communicates with the virtual machine.
+    pub agent: Arc<dyn Agent>,
+
+    // // / Persistent storage driver to save and restore VM state.
+    // pub store: Box<dyn PersistDriver>,
+    /// Unique identifier of the virtual machine.
+    pub id: String,
+
+    /// Number of vCPUs assigned to the VM.
+    pub cpu: f32,
+
+    /// Amount of memory (in MB) assigned to the VM.
+    pub memory: u32,
+
+    /// Tracks the difference in vCPU count since last update.
+    pub cpu_delta: i32,
+}
+
+/// VMConfig holds all configuration information required to start a new VM instance.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct VMConfig {
+    /// Type of hypervisor to be used (e.g., qemu, cloud-hypervisor).
+    #[serde(default)]
+    pub hypervisor_name: String,
+    #[serde(default)]
+    pub agent_name: String,
+    /// Configuration for the guest agent.
+    #[serde(default)]
+    pub agent_config: AgentConfig,
+
+    /// Configuration for the hypervisor.
+    #[serde(default)]
+    pub hypervisor_config: HypervisorConfig,
+}
+
+impl VMConfig {
+    pub fn valid(&mut self) -> Result<()> {
+        VMConfig::validate_hypervisor_config(&mut self.hypervisor_config)
+    }
+
+    pub fn validate_hypervisor_config(conf: &mut HypervisorConfig) -> Result<()> {
+        // remote_hypervisor_socket
+        if !conf.remote_info.hypervisor_socket.is_empty() {
+            return Ok(());
+        }
+
+        // kernel_path
+        if conf.boot_info.kernel.is_empty() {
+            let e = anyhow!("Missing kernel path");
+            error!(sl!(), "{:#?}", e);
+            return Err(e);
+        }
+
+        // In Secure Execution mode, the `image` and `initrd` settings are prohibited from being configured
+        if conf.security_info.confidential_guest
+            && conf.machine_info.machine_type == "s390-ccw-virtio"
+        // QemuCCWVirtio
+        {
+            if !conf.boot_info.image.is_empty() || !conf.boot_info.initrd.is_empty() {
+                let e = anyhow!("Neither the image or initrd path may be set for Secure Execution");
+                error!(sl!(), "{:#?}", e);
+                return Err(e);
+            }
+        } else if conf.boot_info.image.is_empty() && conf.boot_info.initrd.is_empty() {
+            let e = anyhow!("Missing image and initrd path");
+            error!(sl!(), "{:#?}", e);
+            return Err(e);
+        } else if !conf.boot_info.image.is_empty() && !conf.boot_info.initrd.is_empty() {
+            let e = anyhow!("Image and initrd path cannot be both set");
+            error!(sl!(), "{:#?}", e);
+            return Err(e);
+        }
+
+        // template valid todo 
+
+        // num_vcpus_f
+        if conf.cpu_info.default_vcpus == 0.0 {
+            conf.cpu_info.default_vcpus = default::DEFAULT_GUEST_VCPUS as f32;
+        }
+
+        // memory_size
+        if conf.memory_info.default_memory == 0 {
+            conf.memory_info.default_memory = default::DEFAULT_QEMU_MEMORY_SIZE_MB;
+        }
+
+        // default_bridges
+        if conf.device_info.default_bridges == 0 {
+            conf.device_info.default_bridges = default::DEFAULT_QEMU_PCI_BRIDGES;
+        }
+
+        // block_device_driver
+        if conf.blockdev_info.block_device_driver.is_empty() {
+            conf.blockdev_info.block_device_driver = default::DEFAULT_BLOCK_DEVICE_TYPE.to_string();
+        } else if conf.blockdev_info.block_device_driver == "virtio-blk"
+            && conf.machine_info.machine_type == "s390-ccw-virtio"
+        {
+            conf.blockdev_info.block_device_driver = "virtio-blk-ccw".to_string();
+        }
+
+        // default_maxvcpus
+        // let cpus = num_cpus::get() as u32;
+        if conf.cpu_info.default_maxvcpus == 0
+            || conf.cpu_info.default_maxvcpus > default::MAX_QEMU_VCPUS
+        {
+            conf.cpu_info.default_maxvcpus = default::MAX_QEMU_VCPUS;
+        }
+
+        // msize9p
+        if conf.shared_fs.shared_fs.as_deref() != Some("virtio-fs") && conf.shared_fs.msize_9p == 0
+        {
+            conf.shared_fs.msize_9p = default::MAX_SHARED_9PFS_SIZE_MB;
+        }
+
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+impl VM {
+    // Initializes the QEMU hypervisor for Kata
+    // Refactored the function to support only QEMU, as access to the private function in `virt_container::lib::new_hypervisor()` is unavailable.
+    async fn new_hypervisor(config: &VMConfig) -> Result<Arc<dyn Hypervisor>> {
+        let hypervisor: Arc<dyn Hypervisor> = match config.hypervisor_name.as_str() {
+            HYPERVISOR_QEMU => {
+                let h = Qemu::new();
+                h.set_hypervisor_config(config.hypervisor_config.clone())
+                    .await;
+                Arc::new(h)
+            }
+            _ => return Err(anyhow!("Unsupported hypervisor {}", config.hypervisor_name)),
+        };
+        Ok(hypervisor)
+    }
+
+    // Initializes the Kata agent, handling necessary configurations and setup
+    // analogous to `virt_container::lib::new_agent()`.
+    fn new_agent(config: &VMConfig) -> Result<Arc<KataAgent>> {
+        let agent_name = &config.agent_name;
+        let agent_config = config.agent_config.clone();
+
+        match agent_name.as_str() {
+            AGENT_KATA => {
+                let agent = KataAgent::new(agent_config.clone());
+                Ok(Arc::new(agent))
+            }
+            _ => Err(anyhow!("Unsupported agent {}", &agent_name)),
+        }
+    }
+
+    // Create an empty `sandbox_config` structure
+    fn new_empty_sandbox_config() -> SandboxConfig {
+        SandboxConfig {
+            sandbox_id: String::new(),
+            hostname: String::new(),
+            dns: Vec::new(),
+            network_env: SandboxNetworkEnv {
+                netns: None,
+                network_created: false,
+            },
+            annotations: HashMap::default(),
+            hooks: None,
+            state: runtime_spec::State {
+                version: Default::default(),
+                id: String::new(),
+                status: runtime_spec::ContainerState::Creating,
+                pid: 0,
+                bundle: String::new(),
+                annotations: Default::default(),
+            },
+        }
+    }
+
+    // Creates a new VM based on the provided configuration.
+    #[allow(unused_variables)]
+    pub async fn new_vm(config: VMConfig, toml_config: TomlConfig) -> Result<Self> {
+        
+        let sid = Uuid::new_v4().to_string();
+        
+        // msg_sender
+        const MESSAGE_BUFFER_SIZE: usize = 8;
+        let (sender, _receiver) = channel::<Message>(MESSAGE_BUFFER_SIZE);
+
+        // hypervisor
+        let hypervisor = Self::new_hypervisor(&config)
+            .await
+            .context("new hypervisor")?;
+
+        // agent
+        // get uds from hypervisor and get config from toml_config
+        let agent = Self::new_agent(&config).context("new agent")?;
+
+        // sandbox_config
+        let sandbox_config = Self::new_empty_sandbox_config();
+
+        let mut initial_size_manager = InitialSizeManager::new_from(&sandbox_config.annotations)
+            .context("failed to construct static resource manager")?;
+
+        // We need to update the `toml_config` with runtime information, 
+        // but due to ownership issues with the variables, we cannot pass them as parameters.
+        // Therefore, for now, we directly set the `slot` and `maxmemory` values in the configuration file to non-zero.
+
+        // initial_size_manager
+        //     .setup_config(&mut toml_config)
+        //     .context("failed to setup static resource mgmt config")?;
+
+        let factory = toml_config.factory.clone();
+
+        let toml_config_arc = Arc::new(toml_config);
+
+        // resource_manager
+        let resource_manager = Arc::new(
+            ResourceManager::new(
+                &sid,
+                agent.clone(),
+                hypervisor.clone(),
+                toml_config_arc,
+                initial_size_manager,
+            )
+            .await?,
+        );
+
+        // sandbox_config
+        let sandbox = VirtSandbox::new(
+            &sid,
+            sender.clone(),
+            agent.clone(),
+            hypervisor.clone(),
+            resource_manager.clone(),
+            sandbox_config,
+            factory,
+        )
+        .await;
+
+        // info!(sl!(), "vm::new_vm"; "sandbox" => format!("{:?}", sandbox));
+
+        let sb = sandbox.unwrap();
+
+        match sb.start_template().await {
+            Ok(_) => {
+                info!(sl!(), "vm::new_vm():"; "sb" => format!("{:?}", sb));
+            }
+            Err(e) => {
+                error!(sl!(), "vm::new_vm(): sandbox start failed: {}", e);
+            }
+        }
+        info!(sl!(), "vm::new_vm(): VM start successfully");
+        let hypervisor_config = sb.hypervisor.hypervisor_config().await;
+        
+        let vm = VM {
+            id: sb.sid,
+            hypervisor: sb.hypervisor.clone(),
+            agent: sb.agent.clone(),
+            cpu: hypervisor_config.cpu_info.default_vcpus,
+            memory: hypervisor_config.memory_info.default_memory,
+            cpu_delta: 0,
+        };
+        Ok(vm)
+    }
+
+    pub async fn stop(&self) -> Result<()> {
+
+        // Stop qemu process
+        self.hypervisor
+            .stop_vm()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to stop vm: {}", e))?;
+
+        // To be implemented: Remove the control resources from the cgroups, 
+        // similar to how it's done in `store.Destroy()` in Go.
+
+        Ok(())
+    }
+
+    // Disconnect the gRPC connection between the Kata agent and the VM
+    pub async fn disconnect(&self) -> Result<()> {
+        info!(sl!(), "vm::disconnect(): begin");
+        // To be implemented
+        Ok(())
+    }
+
+    // Pause a VM.
+    pub async fn pause(&self) -> Result<()> {
+        info!(sl!(), "vm::pause(): start");
+        self.hypervisor.pause_vm().await
+    }
+
+    // Save a VM to persistent disk.
+    pub async fn save(&self) -> Result<()> {
+        info!(sl!(), "vm::save(): start");
+        self.hypervisor.save_vm().await
+    }
+
+    // Resume resumes a paused VM.
+    pub async fn resume(&self) -> Result<()> {
+        info!(sl!(), "vm::resume(): start");
+        self.hypervisor.resume_vm().await
+    }
+}

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -1,19 +1,15 @@
-// Copyright (c) 2019-2022 Alibaba Cloud
-// Copyright (c) 2019-2022 Ant Group
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-
 #[macro_use]
 extern crate slog;
 
 logging::logger_with_subsystem!(sl, "virt-container");
 
 mod container_manager;
+pub mod factory;
 pub mod health_check;
 pub mod sandbox;
 pub mod sandbox_persist;
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use agent::{kata::KataAgent, AGENT_KATA};
@@ -42,13 +38,17 @@ use hypervisor::ch::CloudHypervisor;
     any(target_arch = "x86_64", target_arch = "aarch64")
 ))]
 use kata_types::config::{hypervisor::HYPERVISOR_NAME_CH, CloudHypervisorConfig};
+#[allow(unused_imports)]
+use std::thread;
+#[allow(unused_imports)]
+use std::time::Duration;
 
+use crate::factory::vm::VMConfig;
 use resource::cpu_mem::initial_size::InitialSizeManager;
 use resource::ResourceManager;
 use sandbox::VIRTCONTAINER;
 use tokio::sync::mpsc::Sender;
 use tracing::instrument;
-
 unsafe impl Send for VirtContainer {}
 unsafe impl Sync for VirtContainer {}
 #[derive(Debug)]
@@ -104,10 +104,49 @@ impl RuntimeHandler for VirtContainer {
         init_size_manager: InitialSizeManager,
         sandbox_config: SandboxConfig,
     ) -> Result<RuntimeInstance> {
-        let hypervisor = new_hypervisor(&config).await.context("new hypervisor")?;
+        let factory = config.factory.clone();
+        let (hypervisor, agent);
+        // VMTemplate Mechanism
+        if factory.template {
+            let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+            //Build VMConfig
+            let mut vm_config = VMConfig {
+                hypervisor_name: toml_config.runtime.hypervisor_name.clone(),
+                agent_name: toml_config.runtime.agent_name.clone(),
+                hypervisor_config: toml_config
+                    .hypervisor
+                    .get(&toml_config.runtime.hypervisor_name)
+                    .cloned()
+                    .unwrap_or_default(),
+                agent_config: toml_config
+                    .agent
+                    .get(&toml_config.runtime.agent_name)
+                    .cloned()
+                    .unwrap_or_default(),
+            };
+            let template_path = toml_config.factory.template_path.clone();
+            info!(
+                sl!(),
+                "lib::new_instance(): build VMConfig. VMConfig:{:?}", vm_config
+            );
+            let vm = factory::get_vm(&mut vm_config, PathBuf::from(template_path)).await?;
+
+            hypervisor = vm.hypervisor.clone();
+            
+            agent = vm.agent.clone();
+            
+            let addr = vm.hypervisor.get_agent_socket().await?;
+            info!(
+                sl!(),
+                "lib::new_instance(): template vm agent socket addr = {:?}", addr
+            );
+        } else {
+            hypervisor = new_hypervisor(&config).await.context("new hypervisor")?;
+            agent = new_agent(&config).context("new agent")?;
+        }
 
         // get uds from hypervisor and get config from toml_config
-        let agent = new_agent(&config).context("new agent")?;
+        // let agent = new_agent(&config).context("new agent")?;
         let resource_manager = Arc::new(
             ResourceManager::new(
                 sid,
@@ -119,7 +158,7 @@ impl RuntimeHandler for VirtContainer {
             .await?,
         );
         let pid = std::process::id();
-
+        info!(sl!(), "lib::new_instance(): sid={}", sid);
         let sandbox = sandbox::VirtSandbox::new(
             sid,
             msg_sender,
@@ -127,6 +166,7 @@ impl RuntimeHandler for VirtContainer {
             hypervisor.clone(),
             resource_manager.clone(),
             sandbox_config,
+            factory,
         )
         .await
         .context("new virt sandbox")?;
@@ -149,7 +189,11 @@ impl RuntimeHandler for VirtContainer {
     }
 }
 
-async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>> {
+// pub async fn p_new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>> {
+//     new_hypervisor(toml_config).await
+// }
+
+pub async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>> {
     let hypervisor_name = &toml_config.runtime.hypervisor_name;
     let hypervisor_config = toml_config
         .hypervisor
@@ -209,7 +253,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
     }
 }
 
-fn new_agent(toml_config: &TomlConfig) -> Result<Arc<KataAgent>> {
+pub fn new_agent(toml_config: &TomlConfig) -> Result<Arc<KataAgent>> {
     let agent_name = &toml_config.runtime.agent_name;
     let agent_config = toml_config
         .agent

--- a/src/tools/kata-ctl/Cargo.lock
+++ b/src/tools/kata-ctl/Cargo.lock
@@ -3,6 +3,27 @@
 version = 4
 
 [[package]]
+name = "actix-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01ed3140b2f8d422c68afa1ed2e85d996ea619c988ac834d255db32138655cb"
+dependencies = [
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "actix-rt"
+version = "2.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24eda4e2a6e042aa4e55ac438a2ae052d3b5da0ecf83d7411e1a368946925208"
+dependencies = [
+ "actix-macros",
+ "futures-core",
+ "tokio",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,6 +153,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "api_client"
+version = "0.1.0"
+source = "git+https://github.com/cloud-hypervisor/cloud-hypervisor?tag=v27.0#2ba6a9bfcfd79629aecf77504fa554ab821d138e"
+dependencies = [
+ "vmm-sys-util 0.10.0",
+]
+
+[[package]]
 name = "arc-swap"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -144,10 +173,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
-name = "async-trait"
-version = "0.1.74"
+name = "async-broadcast"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.0",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb812ffb58524bdd10860d7d974e2f01cc0950c2438a74ee5ec2e2280c6c4ffa"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19634d6336019ef220f09fd31168ce5c184b295cbf80345437cc36094ef223ca"
+dependencies = [
+ "async-lock",
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.0.7",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener 5.4.0",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65daa13722ad51e6ab1a1b9c01299142bc75135b337923cfa10e79bbbd669f00"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if 1.0.0",
+ "event-listener 5.4.0",
+ "futures-lite",
+ "rustix 1.0.7",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -155,10 +295,83 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-signal"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f567af260ef69e1d52c2b560ce0ea230763e6fbb9214a85d768760a920e3e3c1"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if 1.0.0",
+ "futures-core",
+ "futures-io",
+ "rustix 1.0.7",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "730294c1c08c2e0f85759590518f6333f0d5a0a766a27d519c1b244c3dfd8a24"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "awaitgroup"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc17ab023b4091c10ff099f9deebaeeb59b5189df07e554c4fef042b70745d68"
 
 [[package]]
 name = "backtrace"
@@ -168,7 +381,7 @@ checksum = "2089b7e3f35b9dd2d0ed921ead4f6d318c27680d4a5bd167b3ee120edb105837"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "miniz_oxide",
  "object",
@@ -186,6 +399,18 @@ name = "base64"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35636a1494ede3b646cc98f74f8e62c773a38a659ebc777a2cf26b9b74171df9"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
 
 [[package]]
 name = "bitflags"
@@ -240,6 +465,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -327,6 +565,12 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -336,6 +580,36 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "cgroups-rs"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879433e90a9bf3c38e4e854ad36bd14507751dbd3a0df15429283ff5c10ff0e4"
+dependencies = [
+ "bit-vec",
+ "libc",
+ "log",
+ "nix 0.25.1",
+ "oci-spec",
+ "thiserror 1.0.50",
+ "zbus",
+]
+
+[[package]]
+name = "ch-config"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "api_client",
+ "kata-sys-util",
+ "kata-types",
+ "nix 0.26.4",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.50",
+ "tokio",
+]
 
 [[package]]
 name = "chrono"
@@ -399,10 +673,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "common"
+version = "0.1.0"
+dependencies = [
+ "agent",
+ "anyhow",
+ "async-trait",
+ "containerd-shim-protos",
+ "kata-sys-util",
+ "kata-types",
+ "lazy_static",
+ "nix 0.26.4",
+ "oci-spec",
+ "persist",
+ "protobuf",
+ "protocols",
+ "resource",
+ "runtime-spec",
+ "serde_json",
+ "slog",
+ "slog-scope",
+ "strum 0.24.1",
+ "thiserror 1.0.50",
+ "tokio",
+ "ttrpc",
+]
+
+[[package]]
 name = "common-path"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2382f75942f4b3be3690fe4f86365e9c853c1587d6ee58212cebf6e2a9ccd101"
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
 
 [[package]]
 name = "const_format"
@@ -422,6 +732,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "containerd-shim-protos"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de174e763d62b6b1aaed7d9ec7f21369e18d4f4098ae1f11f2ea1a3eb4a31c61"
+dependencies = [
+ "async-trait",
+ "protobuf",
+ "ttrpc",
+ "ttrpc-codegen",
 ]
 
 [[package]]
@@ -455,7 +777,7 @@ version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -630,11 +952,25 @@ version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "hashbrown 0.14.3",
  "lock_api",
  "once_cell",
  "parking_lot_core",
+]
+
+[[package]]
+name = "dbs-utils"
+version = "0.2.1"
+dependencies = [
+ "anyhow",
+ "event-manager",
+ "libc",
+ "log",
+ "serde",
+ "thiserror 1.0.50",
+ "timerfd",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
@@ -714,7 +1050,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "dirs-sys-next",
 ]
 
@@ -741,6 +1077,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dlv-list"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,7 +1100,34 @@ version = "0.8.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7268b386296a025e474d5140678f75d6de9493ae55a5d709eeb9dd08149945e1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -788,6 +1157,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.0",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-manager"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377fa591135fbe23396a18e2655a6d5481bf7c5823cdfa3cc81b01a229cbe640"
+dependencies = [
+ "libc",
+ "vmm-sys-util 0.11.2",
+]
+
+[[package]]
 name = "fail"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -795,7 +1201,7 @@ checksum = "fe5e43d0f78a42ad591453aedb1d7ae631ce7ee445c7643691055a9ed8d3b01c"
 dependencies = [
  "log",
  "once_cell",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -858,6 +1264,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -890,9 +1302,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.29"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb1d22c66e66d9d72e1758f0bd7d4fd0bee04cad842ee34587d68c07e45d088c"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -910,6 +1322,19 @@ name = "futures-io"
 version = "0.3.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf34a163b5c4c52d0478a4d757da8fb65cabef42ba90515efee0f6f9fa45aaa"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5edaec856126859abb19ed65f39e90fea3a9574b9707f13539acf4abf7eb532"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -968,7 +1393,7 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9006bed769170c11f845cf00c7c1e9092aeb3f268e007c3e760ac68008070f"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
 ]
@@ -979,7 +1404,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
@@ -1010,6 +1435,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "go-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b4a40c9ca507513f573aabaf6a8558173a1ac9aa1363d8de30c7f89b34f8d2b"
+dependencies = [
+ "cfg-if 0.1.10",
+]
+
+[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1021,7 +1467,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.1.0",
+ "indexmap 2.11.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1042,6 +1488,12 @@ name = "hashbrown"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -1200,6 +1652,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "hypervisor"
+version = "0.1.0"
+dependencies = [
+ "actix-rt",
+ "anyhow",
+ "async-trait",
+ "ch-config",
+ "crossbeam-channel",
+ "dbs-utils",
+ "futures",
+ "go-flag",
+ "hyper",
+ "hyperlocal",
+ "kata-sys-util",
+ "kata-types",
+ "lazy_static",
+ "libc",
+ "logging",
+ "nix 0.26.4",
+ "oci-spec",
+ "path-clean",
+ "persist",
+ "protobuf",
+ "protocols",
+ "qapi",
+ "qapi-qmp",
+ "qapi-spec",
+ "rand 0.8.5",
+ "rust-ini",
+ "safe-path 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "seccompiler",
+ "serde",
+ "serde_json",
+ "shim-interface",
+ "slog",
+ "slog-scope",
+ "tests_utils",
+ "thiserror 1.0.50",
+ "tokio",
+ "tracing",
+ "ttrpc",
+ "ttrpc-codegen",
+ "vmm-sys-util 0.11.2",
+]
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1348,12 +1846,34 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.1.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d530e1a18b1cb4c484e6e34556a0d948706958449fca0cab753d649f2bce3d1f"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.3",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.0",
+ "futures-core",
+ "inotify-sys",
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1363,7 +1883,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
 dependencies = [
  "bitflags 2.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
 ]
 
@@ -1420,13 +1940,16 @@ version = "0.0.1"
 dependencies = [
  "agent",
  "anyhow",
+ "async-trait",
  "base64 0.13.1",
  "chrono",
  "clap",
+ "containerd-shim-protos",
  "csv",
  "epoll",
  "futures",
  "hyper",
+ "hypervisor",
  "kata-sys-util",
  "kata-types",
  "lazy_static",
@@ -1440,7 +1963,7 @@ dependencies = [
  "quick-xml",
  "reqwest",
  "ron",
- "safe-path",
+ "safe-path 0.1.0",
  "semver",
  "serde",
  "serde_json",
@@ -1457,10 +1980,11 @@ dependencies = [
  "test-utils",
  "thiserror 1.0.50",
  "tokio",
- "toml",
+ "toml 0.5.11",
  "ttrpc",
  "url",
- "vmm-sys-util",
+ "virt_container",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
@@ -1481,9 +2005,9 @@ dependencies = [
  "oci-spec",
  "once_cell",
  "pci-ids",
- "rand",
+ "rand 0.8.5",
  "runtime-spec",
- "safe-path",
+ "safe-path 0.1.0",
  "serde",
  "serde_json",
  "slog",
@@ -1507,7 +2031,7 @@ dependencies = [
  "num_cpus",
  "oci-spec",
  "regex",
- "safe-path",
+ "safe-path 0.1.0",
  "serde",
  "serde-enum-str",
  "serde_json",
@@ -1516,7 +2040,16 @@ dependencies = [
  "slog-scope",
  "sysinfo",
  "thiserror 1.0.50",
- "toml",
+ "toml 0.5.11",
+]
+
+[[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1603,6 +2136,9 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "logging"
@@ -1644,12 +2180,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "micro_http"
 version = "0.1.0"
 source = "git+https://github.com/firecracker-microvm/micro-http?branch=main#a4d632f2c5ea45712c0d2002dc909a63879e85c3"
 dependencies = [
  "libc",
- "vmm-sys-util",
+ "vmm-sys-util 0.11.2",
 ]
 
 [[package]]
@@ -1690,7 +2235,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39a6bfcc6c8c7eed5ee98b9c3e33adc726054389233e201c95dab2d41a3839d2"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "downcast",
  "fragile",
  "mockall_derive",
@@ -1704,7 +2249,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ca3004c2efe9011bd4e461bd8256445052b9615405b4f7ea43fc8ca5c20898"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -1735,6 +2280,81 @@ dependencies = [
 ]
 
 [[package]]
+name = "netlink-packet-core"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
+dependencies = [
+ "anyhow",
+ "bitflags 2.9.0",
+ "byteorder",
+ "libc",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-utils",
+]
+
+[[package]]
+name = "netlink-packet-utils"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
+dependencies = [
+ "anyhow",
+ "byteorder",
+ "paste",
+ "thiserror 1.0.50",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-sys",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416060d346fbaf1f23f9512963e3e878f1a78e707cb699ba9215761754244307"
+dependencies = [
+ "bytes",
+ "futures",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "netns-rs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23541694f1d7d18cd1a0da3a1352a6ea48b01cbb4a8e7a6e547963823fd5276e"
+dependencies = [
+ "nix 0.23.2",
+ "thiserror 1.0.50",
+]
+
+[[package]]
 name = "nix"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1742,7 +2362,7 @@ checksum = "8f3790c00a0150112de0f4cd161e3d7fc4b2d8a5542ffc35f099a2562aecb35c"
 dependencies = [
  "bitflags 1.3.2",
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -1754,7 +2374,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
 ]
@@ -1767,7 +2387,7 @@ checksum = "f346ff70e7dbfd675fe90590b92d59ef2de15a8779ae305ebcbfd3f0caf59be4"
 dependencies = [
  "autocfg",
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.6.5",
  "pin-utils",
@@ -1780,10 +2400,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if 1.0.0",
+ "cfg_aliases",
+ "libc",
+ "memoffset 0.9.1",
 ]
 
 [[package]]
@@ -1890,7 +2535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "foreign-types",
  "libc",
  "once_cell",
@@ -1928,6 +2573,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-multimap"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+dependencies = [
+ "dlv-list",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1943,12 +2614,24 @@ version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "libc",
  "redox_syscall",
  "smallvec",
  "windows-targets 0.48.5",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
 
 [[package]]
 name = "pci-ids"
@@ -1968,6 +2651,21 @@ name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+
+[[package]]
+name = "persist"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "kata-sys-util",
+ "kata-types",
+ "libc",
+ "safe-path 0.1.0",
+ "serde",
+ "serde_json",
+ "shim-interface",
+]
 
 [[package]]
 name = "petgraph"
@@ -2005,7 +2703,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -2050,10 +2748,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
+name = "polling"
+version = "3.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee9b2fa7a4517d2c91ff5bc6c297a427a96749d15f98fcdbb22c05571a4d4b7"
+dependencies = [
+ "cfg-if 1.0.0",
+ "concurrent-queue",
+ "hermit-abi 0.5.2",
+ "pin-project-lite",
+ "rustix 1.0.7",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "potential_utf"
@@ -2114,9 +2837,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
@@ -2195,7 +2918,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "fnv",
  "lazy_static",
  "libc",
@@ -2290,7 +3013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
- "indexmap 2.1.0",
+ "indexmap 2.11.0",
  "log",
  "protobuf",
  "protobuf-support",
@@ -2342,6 +3065,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "qapi"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6412bdd014ebee03ddbbe79ac03a0b622cce4d80ba45254f6357c847f06fa38"
+dependencies = [
+ "bytes",
+ "futures",
+ "log",
+ "memchr",
+ "qapi-qmp",
+ "qapi-spec",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+]
+
+[[package]]
+name = "qapi-codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb959fed63a69baa2e3ae57224d885e686bc3f56c9bb3b03406969980ea57a44"
+dependencies = [
+ "qapi-parser",
+]
+
+[[package]]
+name = "qapi-parser"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b37f643cfdf67a409a9323334138a11636a5db5d56cedcc780d7a82a7fb7659"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "qapi-qmp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b944db7e544d2fa97595e9a000a6ba5c62c426fa185e7e00aabe4b5640b538"
+dependencies = [
+ "qapi-codegen",
+ "qapi-spec",
+ "serde",
+]
+
+[[package]]
+name = "qapi-spec"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e6bdbbe5d13015b21a49a778a29ae3cee9c450c3154e1648aed670d57fe5ba"
+dependencies = [
+ "base64 0.22.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "quick-xml"
 version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2374,13 +3156,36 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ac302d8f83c0c1974bf758f6b041c6c8ada916fbb44a609158ca8b064cc76c"
+dependencies = [
+ "libc",
+ "rand 0.4.6",
+]
+
+[[package]]
+name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2390,8 +3195,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -2400,6 +3220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.11",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -2505,13 +3334,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "resource"
+version = "0.1.0"
+dependencies = [
+ "actix-rt",
+ "agent",
+ "anyhow",
+ "async-trait",
+ "bitflags 2.9.0",
+ "byte-unit",
+ "cgroups-rs",
+ "flate2",
+ "futures",
+ "hypervisor",
+ "inotify",
+ "kata-sys-util",
+ "kata-types",
+ "lazy_static",
+ "libc",
+ "logging",
+ "netlink-packet-route",
+ "netlink-sys",
+ "netns-rs",
+ "nix 0.26.4",
+ "oci-spec",
+ "persist",
+ "rand 0.8.5",
+ "rtnetlink",
+ "scopeguard",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-scope",
+ "tempfile",
+ "tests_utils",
+ "tokio",
+ "tracing",
+ "uuid 0.4.0",
+ "walkdir",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
- "cfg-if",
+ "cfg-if 1.0.0",
  "getrandom 0.2.11",
  "libc",
  "untrusted",
@@ -2560,6 +3430,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "rtnetlink"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cb5850b5aa2c9c0ae44f157694bbe85107a2e13d76eb3178d0e3ee96c410f57"
+dependencies = [
+ "futures",
+ "log",
+ "netlink-packet-core",
+ "netlink-packet-route",
+ "netlink-packet-utils",
+ "netlink-proto",
+ "netlink-sys",
+ "nix 0.29.0",
+ "thiserror 1.0.50",
+ "tokio",
+]
+
+[[package]]
 name = "runtime-spec"
 version = "0.1.0"
 dependencies = [
@@ -2567,6 +3455,16 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+]
+
+[[package]]
+name = "rust-ini"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+dependencies = [
+ "cfg-if 1.0.0",
+ "ordered-multimap",
 ]
 
 [[package]]
@@ -2579,7 +3477,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -2668,6 +3566,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe-path"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980abdd3220aa19b67ca3ea07b173ca36383f18ae48cde696d90c8af39447ffb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2699,6 +3615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "seccompiler"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01d1292a1131b22ccea49f30bd106f1238b5ddeec1a98d39268dcc31d540e68"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2728,10 +3653,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "836fa6a3e1e547f9a2c4040802ec865b5d85f4014efe00555d7090a3dcaa1090"
 
 [[package]]
-name = "serde"
-version = "1.0.193"
+name = "sendfd"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
+checksum = "b183bfd5b1bc64ab0c1ef3ee06b008a9ef1b68a7d3a99ba566fbfe7a7c6d745b"
+dependencies = [
+ "libc",
+ "tokio",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.219"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
@@ -2768,9 +3703,9 @@ checksum = "794e44574226fc701e3be5c651feb7939038fc67fb73f6f4dd5c4ba90fd3be70"
 
 [[package]]
 name = "serde_derive"
-version = "1.0.193"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2786,6 +3721,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2834,7 +3780,7 @@ version = "0.9.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cc7a1570e38322cfe4154732e5110f887ea57e22b76f4bfd32b5bdd3368666c"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.11.0",
  "itoa",
  "ryu",
  "serde",
@@ -2873,7 +3819,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
@@ -2885,7 +3831,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "cpufeatures",
  "digest 0.10.7",
 ]
@@ -3023,6 +3969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3033,6 +3985,9 @@ name = "strum"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+dependencies = [
+ "strum_macros 0.24.3",
+]
 
 [[package]]
 name = "strum"
@@ -3215,6 +4170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tests_utils"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "kata-types",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3260,7 +4224,7 @@ version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdd6f064ccff2d6567adcb3873ca630700f00b5ad3f060c25b5dcfd9a4ce152"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "once_cell",
 ]
 
@@ -3293,6 +4257,15 @@ checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "timerfd"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84e482e368cf7efa2c8b570f476e5b9fd9fd5e9b9219fc567832b05f13511091"
+dependencies = [
+ "rustix 0.38.25",
 ]
 
 [[package]]
@@ -3331,6 +4304,7 @@ dependencies = [
  "io-uring",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
@@ -3399,6 +4373,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758664fc71a3a69038656bee8b6be6477d2a6c315a6b81f7081f591bffa4111f"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml"
 version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
@@ -3408,17 +4391,17 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.6"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4badfd56924ae69bcc9039335b2e017639ce3f9b001c393c1b2d1ef846ce2cbf"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 
 [[package]]
 name = "toml_edit"
-version = "0.21.1"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.1.0",
+ "indexmap 2.11.0",
  "toml_datetime",
  "winnow",
 ]
@@ -3522,6 +4505,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
+name = "uds_windows"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89daebc3e6fd160ac4aa9fc8b3bf71e1f74fbf92367ae71fb83a037e8bf164b9"
+dependencies = [
+ "memoffset 0.9.1",
+ "tempfile",
+ "winapi",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3582,6 +4576,15 @@ checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cfec50b0842181ba6e713151b72f4ec84a6a7e2c9c8a8a3ffc37bb1cd16b231"
+dependencies = [
+ "rand 0.3.23",
+]
+
+[[package]]
+name = "uuid"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
@@ -3594,6 +4597,15 @@ name = "uuid"
 version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de17fd2f7da591098415cff336e12965a28061ddace43b59cb3c430179c9439"
+dependencies = [
+ "getrandom 0.2.11",
+]
+
+[[package]]
+name = "value-bag"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "943ce29a8a743eb10d6082545d861b24f9d1b160b7d741e0f2cdf726bec909c5"
 
 [[package]]
 name = "vcpkg"
@@ -3606,6 +4618,53 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "virt_container"
+version = "0.1.0"
+dependencies = [
+ "agent",
+ "anyhow",
+ "async-std",
+ "async-trait",
+ "awaitgroup",
+ "common",
+ "containerd-shim-protos",
+ "futures",
+ "hypervisor",
+ "kata-sys-util",
+ "kata-types",
+ "lazy_static",
+ "libc",
+ "logging",
+ "nix 0.26.4",
+ "oci-spec",
+ "persist",
+ "protobuf",
+ "resource",
+ "runtime-spec",
+ "sendfd",
+ "serde",
+ "serde_json",
+ "slog",
+ "slog-scope",
+ "strum 0.24.1",
+ "tokio",
+ "toml 0.4.10",
+ "tracing",
+ "url",
+ "uuid 1.9.1",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
 
 [[package]]
 name = "vmm-sys-util"
@@ -3625,6 +4684,16 @@ checksum = "4c8e1df0bf1e1b28095c24564d1b90acae64ca69b097ed73896e342fa6649c57"
 dependencies = [
  "libc",
  "nix 0.24.3",
+]
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
 ]
 
 [[package]]
@@ -3657,7 +4726,7 @@ version = "0.2.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ed0d4f68a3015cc185aff4db9506a015f4b96f95303897bfa23f846db54064e"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "wasm-bindgen-macro",
 ]
 
@@ -3682,7 +4751,7 @@ version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac36a15a220124ac510204aec1c3e5db8a22ab06fd6706d881dc6149f8ed9a12"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "js-sys",
  "wasm-bindgen",
  "web-sys",
@@ -3762,6 +4831,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+dependencies = [
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3821,6 +4899,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-result"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3857,6 +4941,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.3",
+]
+
+[[package]]
 name = "windows-targets"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3880,11 +4973,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -3900,6 +5010,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3910,6 +5026,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3924,10 +5046,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3942,6 +5076,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3952,6 +5092,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3966,6 +5112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3978,10 +5130,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.5.40"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -3992,7 +5150,7 @@ version = "0.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "windows-sys 0.48.0",
 ]
 
@@ -4042,6 +5200,66 @@ dependencies = [
  "quote",
  "syn 2.0.87",
  "synstructure",
+]
+
+[[package]]
+name = "zbus"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a073be99ace1adc48af593701c8015cd9817df372e14a1a6b0ee8f8bf043be"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener 5.4.0",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "nix 0.30.1",
+ "ordered-stream",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.60.2",
+ "winnow",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e80cd713a45a49859dcb648053f63265f4f2851b6420d47a958e5697c68b131"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7be68e64bf6ce8db94f63e72f0c7eb9a60d733f7e0499e628dfab0f84d6bcb97"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "winnow",
+ "zvariant",
 ]
 
 [[package]]
@@ -4096,4 +5314,44 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.87",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "999dd3be73c52b1fccd109a4a81e4fcd20fab1d3599c8121b38d04e1419498db"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6643fd0b26a46d226bd90d3f07c1b5321fe9bb7f04673cb37ac6d6883885b68e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6949d142f89f6916deca2232cf26a8afacf2b9fdc35ce766105e104478be599"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.87",
+ "winnow",
 ]

--- a/src/tools/kata-ctl/Cargo.toml
+++ b/src/tools/kata-ctl/Cargo.toml
@@ -27,16 +27,21 @@ futures = "0.3.24"
 base64 = "0.13.0"
 toml = "0.5.8"
 sys-info = "0.9.1"
+async-trait = "0.1"
+containerd-shim-protos = { version = "0.10.0", features = ["sandbox"] }
 
 shim-interface = { path = "../../libs/shim-interface" }
 kata-types = { path = "../../libs/kata-types" }
 kata-sys-util = { path = "../../../src/libs/kata-sys-util/" }
 safe-path = { path = "../../libs/safe-path" }
 agent = { path = "../../runtime-rs/crates/agent" }
+hypervisor = { path = "../../runtime-rs/crates/hypervisor", features = ["cloud-hypervisor"] }
+virt_container = { path = "../../runtime-rs/crates/runtimes/virt_container" }
 serial_test = "0.10.0"
 vmm-sys-util = "0.11.0"
 epoll = "4.0.1"
 libc = "0.2.138"
+
 
 # Note: this crate sets the slog 'max_*' features which allows the log level
 # to be modified at runtime.
@@ -72,6 +77,7 @@ reqwest = { version = "0.11", default-features = false, features = [
     "blocking",
     "rustls-tls",
 ] }
+
 
 [dev-dependencies]
 semver = "1.0.12"

--- a/src/tools/kata-ctl/src/args.rs
+++ b/src/tools/kata-ctl/src/args.rs
@@ -59,7 +59,7 @@ pub enum Commands {
     Exec(ExecArguments),
 
     /// Manage VM factory
-    Factory,
+    Factory(FactoryArgs),
 
     /// Manage guest VM iptables
     Iptables(IptablesCommand),
@@ -104,6 +104,25 @@ pub enum CheckSubCommand {
     /// List all available checks
     List,
 }
+
+#[derive(Parser, Debug)]
+pub struct FactoryArgs {
+    #[command(subcommand)]
+    pub command: FactorySubCommand,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum FactorySubCommand {
+    /// Initialize a VM factory based on kata-runtime configuration
+    Init,
+
+    /// Destroy the VM factory
+    Destroy,
+
+    /// Query the status of VM factory
+    Status,
+}
+
 
 #[derive(Debug, Args)]
 pub struct EnvArgument {

--- a/src/tools/kata-ctl/src/ops.rs
+++ b/src/tools/kata-ctl/src/ops.rs
@@ -8,3 +8,4 @@ pub mod env_ops;
 pub mod exec_ops;
 pub mod version;
 pub mod volume_ops;
+pub mod factory_ops;

--- a/src/tools/kata-ctl/src/ops/check_ops.rs
+++ b/src/tools/kata-ctl/src/ops/check_ops.rs
@@ -119,10 +119,6 @@ pub fn handle_check(checkcmd: CheckArgument) -> Result<()> {
     Ok(())
 }
 
-pub fn handle_factory() -> Result<()> {
-    Ok(())
-}
-
 pub fn handle_iptables(_args: IptablesCommand) -> Result<()> {
     Ok(())
 }

--- a/src/tools/kata-ctl/src/ops/env_ops.rs
+++ b/src/tools/kata-ctl/src/ops/env_ops.rs
@@ -467,7 +467,6 @@ pub fn get_env_info(toml_config: &TomlConfig) -> Result<EnvInfo> {
         host: host_info,
         agent: agent_info,
     };
-
     Ok(env_info)
 }
 

--- a/src/tools/kata-ctl/src/ops/factory_ops.rs
+++ b/src/tools/kata-ctl/src/ops/factory_ops.rs
@@ -1,0 +1,35 @@
+use anyhow::Result;
+
+use crate::args::{FactoryArgs, FactorySubCommand};
+use virt_container::factory;
+
+use slog::info;
+
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "factory_ops"))
+    };
+}
+
+pub async fn handle_factory(factory_args: FactoryArgs) -> Result<()> {
+    info!(sl!(), "handle_factory");
+    match &factory_args.command {
+        FactorySubCommand::Init => {
+            if let Err(e) = factory::init_factory_command().await {
+                error!(sl!(), "Failed to initialize factory command: {}", e);
+            }
+        }
+        FactorySubCommand::Destroy => {
+            if let Err(e) = factory::destroy_factory_command().await {
+                error!(sl!(), "Failed to destory factory: {}", e);
+            }
+        }
+        FactorySubCommand::Status => {
+            if let Err(e) = factory::status_factory_command().await {
+                error!(sl!(), "Failed to status factory: {}", e);
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Added factory subcommands (init, status, destroy) to kata-ctl for managing VM template factories. Implemented Factory, Template, and VM modules: Factory handles initialization, validation, status checks, and destroy of template resources. Template manages VM template creation, file preparation, and cloning of new VMs. VM defines the structure and lifecycle of virtual machines, covering creation, resource allocation, pausing, resuming, and stopping. Added execution logic and configuration for starting VMs from templates with reliable validation.

Fixes: #11413