### PR TITLE
tests: Only run docker tests with one VMM

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -281,10 +281,7 @@ jobs:
       fail-fast: false
       matrix:
         vmm:
-          - clh
           - qemu
-          - dragonball
-          - cloud-hypervisor
     runs-on: ubuntu-22.04
     env:
       KATA_HYPERVISOR: ${{ matrix.vmm }}


### PR DESCRIPTION
Docker tests have been broken for a while and should be removed if we cannot maintain those.

For now, though, let's limit it to run only with one hypervisor and avoid wasting resources for no reason.