### PR TITLE
tests: Only run devmapper tests with QEMU

### DIFF
--- a/.github/workflows/run-k8s-tests-on-amd64.yaml
+++ b/.github/workflows/run-k8s-tests-on-amd64.yaml
@@ -30,11 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         vmm:
-          - clh #cloud-hypervisor
-          - dragonball
-          - fc #firecracker
           - qemu
-          - cloud-hypervisor
         container_runtime:
           - containerd
         snapshotter:


### PR DESCRIPTION
devmapper tests have been failing for a while. It's been breaking on the kata-deploy deployment, which is most likely related to Disk Pressure.

Removing files was not enough to get the tests to run, so we'll just run those with QEMU as a way to test fixes.  Once we get the test working, we can re-enable the other VMMs, but for now let's just not waste resources for no reason.