### PR TITLE
tools: agent-ctl: Fix unresolved ch import

### DIFF
--- a/src/tools/agent-ctl/Cargo.toml
+++ b/src/tools/agent-ctl/Cargo.toml
@@ -58,4 +58,10 @@ safe-path = { path = "../../libs/safe-path" }
 
 tokio = { version = "1.44.2", features = ["signal"] }
 
+[features]
+default = ["cloud-hypervisor"]
+
+# Enable the Cloud Hypervisor driver
+cloud-hypervisor = []
+
 [workspace]


### PR DESCRIPTION
agent-ctl's make check has been failing with:
```
    Checking kata-agent-ctl v0.0.1 (/home/ubuntu/runner/_layout/_work/kata-containers/kata-containers/src/tools/agent-ctl)
error[E0432]: unresolved import `hypervisor::ch`
  --> src/vm/vm_ops.rs:10:5
   |
10 |     ch::CloudHypervisor,
   |     ^^ could not find `ch` in `hypervisor`
   |
note: found an item that was configured out
  --> /home/ubuntu/runner/_layout/_work/kata-containers/kata-containers/src/runtime-rs/crates/hypervisor/src/lib.rs:30:9
   |
30 | pub mod ch;
   |         ^^
note: the item is gated here
  --> /home/ubuntu/runner/_layout/_work/kata-containers/kata-containers/src/runtime-rs/crates/hypervisor/src/lib.rs:26:1
   |
26 | / #[cfg(all(
27 | |     feature = "cloud-hypervisor",
28 | |     any(target_arch = "x86_64", target_arch = "aarch64")
29 | | ))]
   | |___^
```

Let's just make sure that we include ch conditionally as well.