### PR TITLE
kata-manager: Handle zst unpacking

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -823,7 +823,11 @@ install_kata()
 		info "Installing $project release $version from $file"
 	fi
 
-	sudo tar -C / -xvf "${file}"
+	if [[ "${file}" == *.tar.zst ]]; then
+		sudo tar --zstd -xvf "${file}"
+	else
+		sudo tar -C / -xvf "${file}"
+	fi
 
 	[ -d "$from_dir" ] || die "$project does not exist in expected directory $from_dir"
 


### PR DESCRIPTION
On 63f6dcdeb9d5542fc6bf0c5a9461999ee13b30ff we added the support to download either a .xz or a .zst tarball file. However, we missed adding the code to properly unpack a .zst tarball file.