### PR TITLE
runtime: Set maxmem to initialmem on s390x when memory hotplug is disabled

### DIFF
--- a/src/runtime/virtcontainers/qemu_s390x.go
+++ b/src/runtime/virtcontainers/qemu_s390x.go
@@ -424,3 +424,21 @@ func (q *qemuS390x) qomGetPciPath(qemuID string, qmpCh *qmpChannel) (types.PciPa
 	hvLogger.Warnf("qomGetPciPath not implemented for s390x")
 	return types.PciPath{}, nil
 }
+
+func (q *qemuS390x) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory {
+	// For no hotplug memory, set hostMemoryMb to memoryMb, otherwise will cause
+	// `invalid value of maxmem: maximum memory size (0x0) must be at least the initial memory size`
+	if hostMemoryMb == 0 {
+		hostMemoryMb = memoryMb
+	}
+
+	memMax := fmt.Sprintf("%dM", hostMemoryMb)
+	mem := fmt.Sprintf("%dM", memoryMb)
+	memory := govmmQemu.Memory{
+		Size:   mem,
+		Slots:  slots,
+		MaxMem: memMax,
+	}
+
+	return memory
+}

--- a/src/runtime/virtcontainers/qemu_s390x_test.go
+++ b/src/runtime/virtcontainers/qemu_s390x_test.go
@@ -56,6 +56,12 @@ func TestQemuS390xMemoryTopology(t *testing.T) {
 
 	m := s390x.memoryTopology(mem, hostMem, slots)
 	assert.Equal(expectedMemory, m)
+
+	// test when hostMem is set to 0 (no hotplug memory)
+	hostMem = 0
+	expectedMemory.MaxMem = fmt.Sprintf("%dM", mem)
+	m = s390x.memoryTopology(mem, hostMem, slots)
+	assert.Equal(expectedMemory, m)
 }
 
 func TestQemuS390xAppendVhostUserDevice(t *testing.T) {


### PR DESCRIPTION
On s390x, QEMU fails if maxmem is set to 0 (#11681):

```
invalid value of maxmem: maximum memory size (0x0) must be at least the initial memory size
```

This PR sets maxmem to the initial memory size for s390x when hotplug is disabled, resolving the error while still ensuring that memory hotplug remains off.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>