### PR TITLE
runtime-rs: introduce VM template lifecycle and integration

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1297,6 +1297,34 @@ pub struct Hypervisor {
     /// Disables applying SELinux on the container process within the guest.
     #[serde(default = "yes")]
     pub disable_guest_selinux: bool,
+
+    /// Indicate whether the VM is being created as a template VM.
+    #[serde(default)]
+    pub boot_to_be_template: bool,
+
+    /// Indicate whether the VM should be created from an existing template VM.
+    #[serde(default)]
+    pub boot_from_template: bool,
+
+	/// MemoryPath is the memory file path of VM memory. Used when either BootToBeTemplate or BootFromTemplate is true.
+    #[serde(default)]
+    pub memory_path: String,
+
+    /// DevicesStatePath is the VM device state file path. Used when either BootToBeTemplate or BootFromTemplate is true.
+    #[serde(default)]
+    pub device_state_path: String,
+    
+    /// Path for filesystem sharing
+    #[serde(default)]
+	pub shared_path: String,
+
+    /// VMStorePath is the location on disk where VM information will persist
+    #[serde(default)]
+	pub vm_store_path: String,
+
+    /// VMStorePath is the location on disk where runtime information will persist
+    #[serde(default)]
+	pub run_store_path: String,
 }
 
 fn yes() -> bool {

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -100,6 +100,23 @@ pub trait ConfigObjectOps {
     }
 }
 
+/// Factory is a structure to set the VM factory configuration.
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+pub struct Factory {
+	/// TemplatePath specifies the path of template.
+    #[serde(default)]
+    pub template_path: String,
+    /// VMCacheEndpoint specifies the endpoint of transport VM from the VM cache server to runtime.
+    #[serde(default)]
+    pub vm_cache_endpoint: String,
+    /// VMCacheNumber specifies the the number of caches of VMCache.
+    #[serde(default)]
+    pub vm_cache_number: u32,
+    /// Template enables VM templating support in VM factory.
+    #[serde(default)]
+    pub template: bool,
+}
+
 /// Kata configuration information.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct TomlConfig {
@@ -112,6 +129,9 @@ pub struct TomlConfig {
     /// Kata runtime configuration information.
     #[serde(default)]
     pub runtime: Runtime,
+    /// Factory configuration information.
+    #[serde(default)]
+    pub factory: Factory,
 }
 
 macro_rules! mem_agent_kv_insert {
@@ -162,7 +182,6 @@ impl TomlConfig {
             file_path.to_string_lossy()
         );
         let config = drop_in::load(&file_path)?;
-
         Ok((config, file_path))
     }
 

--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -364,6 +364,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,19 +1033,25 @@ name = "dbs-pci"
 version = "0.1.0"
 dependencies = [
  "byteorder",
+ "dbs-address-space",
  "dbs-allocator",
  "dbs-boot",
  "dbs-device",
  "dbs-interrupt",
+ "dbs-utils",
+ "dbs-virtio-devices",
  "downcast-rs",
  "kvm-bindings",
  "kvm-ioctls",
  "libc",
  "log",
+ "serde",
  "thiserror 1.0.69",
  "vfio-bindings",
  "vfio-ioctls",
+ "virtio-queue",
  "vm-memory",
+ "vmm-sys-util 0.11.1",
 ]
 
 [[package]]
@@ -3647,11 +3659,11 @@ dependencies = [
 
 [[package]]
 name = "qapi-spec"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b360919a24ea5fc02fa762cb01bd8f43b643fee51c585f763257773b4dc5a9e8"
+checksum = "49e6bdbbe5d13015b21a49a778a29ae3cee9c450c3154e1648aed670d57fe5ba"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "serde",
  "serde_json",
 ]
@@ -5261,6 +5273,9 @@ name = "uuid"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+dependencies = [
+ "getrandom 0.3.2",
+]
 
 [[package]]
 name = "valuable"
@@ -5355,6 +5370,7 @@ dependencies = [
  "toml 0.4.10",
  "tracing",
  "url",
+ "uuid 1.16.0",
 ]
 
 [[package]]

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2657,6 +2657,11 @@ impl<'a> QemuCmdLine<'a> {
 
         result.append(&mut self.knobs.qemu_params().await?);
 
+        if self.config.boot_from_template {
+            result.push("-incoming".to_string());
+            result.push("defer".to_string());
+        }
+
         Ok(result)
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -90,17 +90,17 @@ impl Hypervisor for Qemu {
     }
 
     async fn pause_vm(&self) -> Result<()> {
-        let inner = self.inner.read().await;
+        let mut inner = self.inner.write().await;
         inner.pause_vm()
     }
 
     async fn resume_vm(&self) -> Result<()> {
-        let inner = self.inner.read().await;
+        let mut inner = self.inner.write().await;
         inner.resume_vm()
     }
 
     async fn save_vm(&self) -> Result<()> {
-        let inner = self.inner.read().await;
+        let mut inner = self.inner.write().await;
         inner.save_vm().await
     }
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -10,6 +10,13 @@ use crate::VcpuThreadIds;
 use anyhow::{anyhow, Context, Result};
 use kata_types::config::hypervisor::VIRTIO_SCSI;
 use nix::sys::socket::{sendmsg, ControlMessage, MsgFlags};
+use qapi_qmp::{
+    self as qmp, BlockdevAioOptions, BlockdevOptions, BlockdevOptionsBase,
+    BlockdevOptionsGenericFormat, BlockdevOptionsRaw, BlockdevRef, PciDeviceInfo,
+};
+use qapi_qmp::{migrate, migrate_incoming, MigrationInfo};
+use qapi_qmp::{migrate_set_capabilities, MigrationCapability, MigrationCapabilityStatus};
+use qapi_qmp::{query_migrate};
 use std::collections::HashMap;
 use std::convert::TryFrom;
 use std::fmt::{Debug, Error, Formatter};
@@ -19,17 +26,12 @@ use std::os::unix::net::UnixStream;
 use std::str::FromStr;
 use std::time::Duration;
 
-use qapi_qmp::{
-    self as qmp, BlockdevAioOptions, BlockdevOptions, BlockdevOptionsBase,
-    BlockdevOptionsGenericFormat, BlockdevOptionsRaw, BlockdevRef, PciDeviceInfo,
-};
 use qapi_spec::Dictionary;
-
 /// default qmp connection read timeout
 const DEFAULT_QMP_READ_TIMEOUT: u64 = 250;
 
 pub struct Qmp {
-    qmp: qapi::Qmp<qapi::Stream<BufReader<UnixStream>, UnixStream>>,
+    pub qmp: qapi::Qmp<qapi::Stream<BufReader<UnixStream>, UnixStream>>,
 
     // This is basically the output of
     // `cat /sys/devices/system/memory/block_size_bytes`
@@ -78,6 +80,54 @@ impl Qmp {
         info!(sl!(), "QMP initialized: {:#?}", info);
 
         Ok(qmp)
+    }
+
+    pub fn set_ignore_shared_memory_capability(&mut self) -> Result<()> {
+        let cap = migrate_set_capabilities {
+            capabilities: vec![MigrationCapabilityStatus {
+                capability: MigrationCapability::x_ignore_shared,
+                state: true,
+            }],
+        };
+
+        self.qmp.execute(&cap)?;
+        Ok(())
+    }
+
+    pub fn execute_migration(&mut self, uri: &str) -> Result<()> {
+        let cmd = migrate {
+            detach: None,
+            resume: None,
+            // channels: None,
+            blk: None,
+            inc: None,
+            uri: uri.to_string(),
+        };
+        self.qmp.execute(&cmd)?;
+        Ok(())
+    }
+
+    pub fn execute_migration_incoming(&mut self, uri: &str) -> Result<()> {
+        let cmd = migrate_incoming {
+            uri: uri.to_string(),
+            // exit_on_error: None,
+            // channels:None,W
+        };
+        self.qmp.execute(&cmd)?;
+        Ok(())
+    }
+    #[allow(dead_code)]
+    pub fn query_migration(&mut self) -> Result<MigrationInfo> {
+
+        let cmd = query_migrate {};
+        info!(sl!(), "Qmp::query_migration(): will do execute");
+        let result = self.qmp.execute(&cmd)?;
+
+        info!(
+            sl!(),
+            "Qmp::query_migration(): query_migrate_result: {:#?}", result
+        );
+        Ok(result)
     }
 
     pub fn hotplug_vcpus(&mut self, vcpu_cnt: u32) -> Result<u32> {
@@ -227,6 +277,7 @@ impl Qmp {
                     x_use_canonical_path_for_ramblock_id: None,
                     size,
                 },
+                // rom:None,
                 align: None,
                 discard_data: None,
                 offset: None,
@@ -737,6 +788,19 @@ impl Qmp {
             .context("get device by qdev_id failed")?;
 
         Ok(Some(pci_path))
+    }
+
+    pub fn qmp_stop(&mut self) -> Result<()> {
+        let cmd = qmp::stop {};
+        self.qmp.execute(&cmd)?;
+        Ok(())
+    }
+
+    pub fn qmp_cont(&mut self) -> Result<()> {
+        let cmd = qmp::cont {};
+        let resp = self.qmp.execute(&cmd)?;
+        info!(sl!(), "qmp::qmp_cont(): qmp_cont resp = {:?}", resp);
+        Ok(())
     }
 
     /// Get vCPU thread IDs through QMP query_cpus_fast.

--- a/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/common/src/sandbox.rs
@@ -31,6 +31,7 @@ impl std::fmt::Debug for SandboxNetworkEnv {
 #[async_trait]
 pub trait Sandbox: Send + Sync {
     async fn start(&self) -> Result<()>;
+    async fn start_template(&self) -> Result<()>;
     async fn stop(&self) -> Result<()>;
     async fn cleanup(&self) -> Result<()>;
     async fn shutdown(&self) -> Result<()>;

--- a/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
+++ b/src/runtime-rs/crates/runtimes/virt_container/Cargo.toml
@@ -27,6 +27,7 @@ async-std = "1.12.0"
 tracing = { workspace = true }
 oci-spec = { workspace = true }
 strum = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
 
 # Local dependencies
 agent = { workspace = true }
@@ -38,7 +39,6 @@ logging = { workspace = true }
 runtime-spec = { workspace = true }
 persist = { workspace = true }
 resource = { workspace = true }
-
 [features]
 default = ["cloud-hypervisor"]
 

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/mod.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/mod.rs
@@ -1,0 +1,336 @@
+// Copyright 2025 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#![allow(unused_variables, unused_imports)]
+use anyhow::{anyhow, Context, Result};
+use containerd_shim_protos::ttrpc::asynchronous::shutdown::new;
+use hypervisor::firecracker::sl;
+use slog::{error, info};
+
+use serde::{Deserialize, Serialize};
+
+use kata_types::config::TomlConfig;
+
+use std::ffi::CString;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
+
+use crate::factory::template::Template;
+use crate::factory::vm::{VMConfig, VM};
+
+pub mod template;
+pub mod vm;
+
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "factory"))
+    };
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct FactoryConfig {
+    /// Path to the directory where VM templates are stored.
+    #[serde(default)]
+    pub template_path: String,
+
+    /// Endpoint used for communication with the VM cache server.
+    // #[serde(default)]
+    // pub vm_cache_endpoint: String,
+
+    /// Full configuration of the virtual machine to be used.
+    #[serde(default)]
+    pub vm_config: VMConfig,
+
+    /// Number of cached VMs to maintain.
+    #[serde(default)]
+    pub cache: u32,
+
+    /// Whether VM template feature is enabled.
+    #[serde(default)]
+    pub template: bool,
+
+    /// Whether VM cache feature is enabled.
+    #[serde(default)]
+    pub vm_cache: bool,
+}
+
+pub async fn init_factory_command() -> Result<()> {
+    // Load Kata config
+    let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+
+    // Build FactoryConfig
+    let mut factory_config = FactoryConfig {
+        template: toml_config.factory.template,
+        template_path: toml_config.factory.template_path.clone(),
+        cache: toml_config.factory.vm_cache_number,
+        vm_cache: toml_config.factory.vm_cache_number > 0,
+        vm_config: VMConfig {
+            hypervisor_name: toml_config.runtime.hypervisor_name.clone(),
+            agent_name: toml_config.runtime.agent_name.clone(),
+            hypervisor_config: toml_config
+                .hypervisor
+                .get(&toml_config.runtime.hypervisor_name)
+                .cloned()
+                .unwrap_or_default(),
+            agent_config: toml_config
+                .agent
+                .get(&toml_config.runtime.agent_name)
+                .cloned()
+                .unwrap_or_default(),
+        },
+    };
+
+    // Template
+    if toml_config.factory.template {
+        match new_factory(&mut factory_config, toml_config, false).await {
+            Ok(_) => {
+                info!(
+                    sl!(),
+                    "factory::init_factory_command(): create vm factory successfully"
+                );
+            }
+            Err(e) => {
+                error!(
+                    sl!(),
+                    "factory::init_factory_command(): create vm factory failed: {}", e
+                );
+                return Err(e);
+            }
+        }
+    } else {
+        let err_string = "vm factory or VMCache is not enabled";
+        error!(sl!(), "{}", err_string);
+    }
+
+    Ok(())
+}
+
+pub async fn destroy_factory_command() -> Result<()> {
+    println!("destroy_factory_command");
+    // Load Kata config
+    let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+
+    // Build FactoryConfig
+    let mut factory_config = FactoryConfig {
+        template: toml_config.factory.template,
+        template_path: toml_config.factory.template_path.clone(),
+        cache: toml_config.factory.vm_cache_number,
+        vm_cache: toml_config.factory.vm_cache_number > 0,
+        vm_config: VMConfig {
+            hypervisor_name: toml_config.runtime.hypervisor_name.clone(),
+            agent_name: toml_config.runtime.agent_name.clone(),
+            hypervisor_config: toml_config
+                .hypervisor
+                .get(&toml_config.runtime.hypervisor_name)
+                .cloned()
+                .unwrap_or_default(),
+            agent_config: toml_config
+                .agent
+                .get(&toml_config.runtime.agent_name)
+                .cloned()
+                .unwrap_or_default(),
+        },
+    };
+
+    // Template
+    if toml_config.factory.template {
+        if let Err(e) = new_factory(&mut factory_config, toml_config, true).await {
+            error!(sl!(), "load vm factory failed: {:?}", e);
+            return Err(e);
+        }
+
+        info!(sl!(), "begin destroy factory");
+
+        close_factory(&mut factory_config).map_err(|e| {
+            error!(sl!(), "Failed to close factory: {:?}", e);
+            anyhow!("Failed to close factory: {}", e)
+        })?;
+    } else {
+        let log_string = "vm factory is not enabled";
+        info!(sl!(), "{}", log_string);
+    }
+
+    info!(sl!(), "vm factory destroyed");
+    Ok(())
+}
+
+pub async fn status_factory_command() -> Result<()> {
+    println!("status_factory_command");
+    // Load Kata config
+    let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+
+    // Build FactoryConfig
+    let mut factory_config = FactoryConfig {
+        template: toml_config.factory.template,
+        template_path: toml_config.factory.template_path.clone(),
+        cache: toml_config.factory.vm_cache_number,
+        vm_cache: toml_config.factory.vm_cache_number > 0,
+        vm_config: VMConfig {
+            hypervisor_name: toml_config.runtime.hypervisor_name.clone(),
+            agent_name: toml_config.runtime.agent_name.clone(),
+            hypervisor_config: toml_config
+                .hypervisor
+                .get(&toml_config.runtime.hypervisor_name)
+                .cloned()
+                .unwrap_or_default(),
+            agent_config: toml_config
+                .agent
+                .get(&toml_config.runtime.agent_name)
+                .cloned()
+                .unwrap_or_default(),
+        },
+    };
+
+    // Template
+    if toml_config.factory.template {
+        match new_factory(&mut factory_config, toml_config, true).await {
+            Ok(_) => {
+                info!(sl!(), "vm factory is on");
+            }
+            Err(e) => {
+                info!(sl!(), "vm factory is off");
+            }
+        }
+    } else {
+        let log_string = "vm factory is not enabled";
+        info!(sl!(), "{}", log_string);
+    }
+
+    Ok(())
+}
+
+pub async fn new_factory(
+    config: &mut FactoryConfig,
+    toml_config: TomlConfig,
+    fetch_only: bool,
+) -> Result<()> {
+    // Validate VMConfig
+    config.vm_config.valid().map_err(|e| {
+        error!(
+            sl!(),
+            "factory::new_factory(): VMConfig validate failed {:#?}", e
+        );
+        e
+    })?;
+
+    info!(sl!(), "factory::new_factory(): VMConfig validate ok");
+
+    // template mode
+    if !config.template {
+        error!(sl!(), "factory::new_factory(): template must be enabled");
+    } else {
+        if fetch_only {
+            info!(sl!(), "factory::new_factory(): template fetch");
+            // Construct PathBuf
+            let path: PathBuf = config.template_path.clone().into();
+            let factory = match Template::fetch(config.vm_config.clone(), path) {
+                Ok(factory) => {
+                    // Successfully fetched the factory, proceed with the logic
+                    factory
+                }
+                Err(e) => {
+                    return Err(anyhow!(e)); // Return an error with a detailed message
+                }
+            };
+        } else {
+            info!(sl!(), "factory::new_factory(): template new");
+            // Construct PathBuf
+            let path: PathBuf = config.template_path.clone().into();
+            let factory = match Template::new(config.vm_config.clone(), toml_config, path).await {
+                Ok(factory) => factory,
+                Err(e) => {
+                    error!(sl!(), "Failed to create new Template factory: {}", e);
+                    return Err(e);
+                }
+            };
+        }
+    }
+
+    Ok(())
+}
+
+pub fn close_factory(config: &mut FactoryConfig) -> Result<()> {
+    let state_path = Path::new(&config.template_path); // Get the state path from the config
+    let c_state_path = CString::new(state_path.to_str().unwrap())?;
+    // Attempt to unmount the state path
+    let result = unsafe { libc::umount(c_state_path.as_ptr()) }; // Unmount the directory
+
+    if result != 0 {
+        // if umount false，try to use umount -f to force umount
+        let result_lazy = Command::new("umount")
+            .arg("-f")
+            .arg(state_path)
+            .output()
+            .context("Failed to execute umount command with -f")?;
+
+        if !result_lazy.status.success() {
+            let err = std::io::Error::last_os_error();
+            error!(
+                sl!(),
+                "Failed to force unmount {}: {}",
+                state_path.display(),
+                err
+            );
+            return Err(anyhow!(
+                "Failed to force unmount {}: {}",
+                state_path.display(),
+                err
+            ));
+        }
+    }
+
+    // Attempt to remove the directory and its contents
+    if let Err(e) = fs::remove_dir_all(&state_path) {
+        // Log an error if removing the directory fails
+        error!(sl(), "Failed to remove {}: {}", state_path.display(), e);
+        return Err(anyhow!("Failed to remove {}: {}", state_path.display(), e));
+    }
+
+    Ok(())
+}
+
+pub async fn get_vm(config: &mut VMConfig, template_path: PathBuf) -> Result<VM> {
+    info!(sl!(), "factory::get_vm(): start");
+
+    // Validate  VMConfig
+    if let Err(e) = config.valid() {
+        error!(sl!(), "{:#?}", e);
+        return Err(e);
+    } else {
+        info!(sl!(), "factory::get_vm(): VMConfig validate ok");
+    }
+
+    // Compare the VM template with the new VM template.
+    // If they do not match, directly start the VM instead
+    //todo vm.checkVMConfig() if true template; else direct
+
+    // Get template
+    // In Go, multiple VM types (cache, template, etc.) are accessed through the base interface.
+    // Here, we are currently implementing only the template.
+    let template = Template {
+        state_path: template_path,
+        config: config.clone(),
+    };
+    let vm = template.get_base_vm(config).await?;
+    info!(
+        sl!(),
+        "factory::get_vm(): vm: new_vm() VM id={}, cpu={}, memory={}", vm.id, vm.cpu, vm.memory
+    );
+
+    // Resume vm
+    vm.resume().await?;
+
+    // Re-inject a new seed into the guest kernel's RNG device to ensure that the cloned VM
+    // todo vm.ReseedRNG()
+
+    // Synchronize the guest internal clock with the host's current time to ensure the VM's time is accurate.
+    // todo vm.SyncTime()
+
+    //  After restoring the VM in the factory, perform "hotplug" processing for CPU and memory expansion.
+    // tofo vm.AddCPUs(); vm.AddMemory; vm.OnlineCPUMemory
+
+    Ok(vm)
+}

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/template/mod.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/template/mod.rs
@@ -1,0 +1,213 @@
+// Copyright 2025 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+#![allow(unused_variables, unused_imports)]
+use std::fmt::Debug;
+use std::fs::File;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use std::thread::sleep;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::{anyhow, Result};
+
+use async_trait::async_trait;
+use nix::mount::{mount, MsFlags};
+
+use crate::factory::vm::{VMConfig, VM};
+use kata_types::config::TomlConfig;
+
+#[allow(dead_code)]
+const TEMPLATE_WAIT_FOR_AGENT: Duration = Duration::from_secs(2);
+const TEMPLATE_DEVICE_STATE_SIZE_MB: u32 = 8; // as in Go templateDeviceStateSize
+use hypervisor::{qemu::Qemu, Hypervisor, HYPERVISOR_QEMU};
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "factory"))
+    };
+}
+
+pub trait FactoryBase: Debug {}
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub struct Template {
+    pub state_path: PathBuf,
+    pub config: VMConfig,
+}
+
+impl Template {
+    pub fn fetch(config: VMConfig, template_path: PathBuf) -> Result<Box<dyn FactoryBase>> {
+        let t = Template {
+            state_path: template_path,
+            config,
+        };
+
+        // Call check_template_vm to validate the template's files
+        if let Err(e) = t.check_template_vm() {
+            // If check_template_vm returns an error, log the error and return a detailed error message
+            return Err(anyhow!(e));
+        }
+
+        // If there is no error, return a Boxed instance of the Template
+        Ok(Box::new(t))
+    }
+
+    pub async fn new(
+        config: VMConfig,
+        toml_config: TomlConfig,
+        template_path: PathBuf,
+    ) -> Result<Box<dyn FactoryBase>> {
+        let t = Template {
+            state_path: template_path,
+            config,
+        };
+
+        match t.check_template_vm() {
+            Ok(_) => {
+                return Err(anyhow!(
+                    "There is already a VM template in {:?}",
+                    t.state_path
+                ));
+            }
+            Err(e) => {
+                info!(sl!(), "check_template_vm failed as expected: {}", e);
+            }
+        }
+
+        t.prepare_template_files()?;
+
+        if let Err(e) = t.create_template_vm(toml_config).await {
+            // t.close()?;
+            return Err(e);
+        }
+
+        Ok(Box::new(t))
+    }
+
+    pub fn check_template_vm(&self) -> Result<()> {
+        let memory_path = self.state_path.join("memory");
+        let state_path = self.state_path.join("state");
+
+        if !memory_path.exists() || !state_path.exists() {
+            info!(sl!(), "Template VM memory or state file missing");
+            return Err(anyhow!("template VM memory or state file missing"));
+        }
+
+        Ok(())
+    }
+
+    pub fn prepare_template_files(&self) -> Result<()> {
+        std::fs::create_dir_all(&self.state_path)?;
+        let opts = format!(
+            "size={}M",
+            self.config.hypervisor_config.memory_info.default_memory
+                + TEMPLATE_DEVICE_STATE_SIZE_MB
+        );
+        mount(
+            Some("tmpfs"),
+            &self.state_path,
+            Some("tmpfs"),
+            MsFlags::MS_NOSUID | MsFlags::MS_NODEV,
+            Some(opts.as_str()),
+        )?;
+
+        let memory_file = self.state_path.join("memory");
+        File::create(memory_file)?;
+
+        Ok(())
+    }
+
+    pub async fn create_template_vm(&self, toml_config: TomlConfig) -> Result<()> {
+        info!(sl!(), "template::create_template_vm: start(): start");
+        let mut config = self.config.clone();
+        config.hypervisor_config.boot_to_be_template = true;
+        config.hypervisor_config.boot_from_template = false;
+        config.hypervisor_config.memory_path =
+            self.state_path.join("memory").to_string_lossy().to_string();
+        config.hypervisor_config.device_state_path =
+            self.state_path.join("state").to_string_lossy().to_string();
+        // config.new_vm();
+        let vm = VM::new_vm(config, toml_config).await?;
+        info!(
+            sl!(),
+            "template::create_template_vm: new_vm() VM id={}, cpu={}, memory={}",
+            vm.id,
+            vm.cpu,
+            vm.memory
+        );
+
+        vm.disconnect().await?;
+        info!(sl!(), "template::create_template_vm: disconnect()");
+
+        // Sleep a bit to let the agent grpc server clean up
+        // When we close connection to the agent, it needs sometime to cleanup
+        // and restart listening on the communication( serial or vsock) port.
+        // That time can be saved if we sleep a bit to wait for the agent to
+        // come around and start listening again. The sleep is only done when
+        // creating new vm templates and saves time for every new vm that are
+        // created from template, so it worth the invest.
+        sleep(TEMPLATE_WAIT_FOR_AGENT);
+
+        vm.pause().await?;
+        info!(sl!(), "template::create_template_vm: pause()");
+
+        vm.save().await?;
+        info!(sl!(), "template::create_template_vm: save()");
+
+        // vm.stop().await?;
+        // info!(sl!(), "template::create_template_vm: stop()");
+
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    pub async fn create_from_template_vm(&self, new_config: &mut VMConfig) -> Result<VM> {
+        info!(sl!(), "template::create_from_template_vm: start(): start");
+
+        let mut config = self.config.clone();
+        config.hypervisor_config.boot_to_be_template = false;
+        config.hypervisor_config.boot_from_template = true;
+        config.hypervisor_config.memory_path =
+            self.state_path.join("memory").to_string_lossy().to_string();
+        config.hypervisor_config.device_state_path =
+            self.state_path.join("state").to_string_lossy().to_string();
+        config.hypervisor_config.shared_path = new_config.hypervisor_config.shared_path.clone();
+        config.hypervisor_config.vm_store_path = new_config.hypervisor_config.vm_store_path.clone();
+        config.hypervisor_config.run_store_path =
+            new_config.hypervisor_config.run_store_path.clone();
+
+        let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+
+        let vm = VM::new_vm(config, toml_config).await?;
+        info!(
+            sl!(),
+            "template::get_base_vm():  vm: new_vm() VM id={}, cpu={}, memory={}",
+            vm.id,
+            vm.cpu,
+            vm.memory
+        );
+        Ok(vm)
+    }
+
+    pub async fn get_base_vm(&self, config: &mut VMConfig) -> Result<VM> {
+        info!(sl!(), "template::get_base_vm(): start");
+        let vm = self.create_from_template_vm(config).await?;
+        info!(
+            sl!(),
+            "template::get_base_vm():  vm: new_vm() VM id={}, cpu={}, memory={}",
+            vm.id,
+            vm.cpu,
+            vm.memory
+        );
+        Ok(vm)
+    }
+}
+
+#[async_trait]
+impl FactoryBase for Template {
+
+}

--- a/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm/mod.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/factory/vm/mod.rs
@@ -1,0 +1,336 @@
+#![allow(unused_mut)]
+use anyhow::anyhow;
+use anyhow::Context;
+use anyhow::Result;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use kata_types::config::default;
+use kata_types::config::Agent as AgentConfig;
+use kata_types::config::Hypervisor as HypervisorConfig;
+use kata_types::config::TomlConfig;
+use serde::{Deserialize, Serialize};
+
+use agent::{kata::KataAgent, Agent, AGENT_KATA};
+use hypervisor::{qemu::Qemu, Hypervisor, HYPERVISOR_QEMU};
+use resource::{cpu_mem::initial_size::InitialSizeManager, ResourceManager};
+
+use crate::factory;
+use crate::sandbox::VirtSandbox;
+use common::{message::Message, types::SandboxConfig, Sandbox, SandboxNetworkEnv};
+use runtime_spec;
+use slog::error;
+use tokio::sync::mpsc::channel;
+use uuid::Uuid;
+macro_rules! sl {
+    () => {
+        slog_scope::logger().new(o!("subsystem" => "vm"))
+    };
+}
+
+/// VM is an abstraction of a virtual machine.
+#[allow(dead_code)]
+#[derive(Clone)]
+pub struct VM {
+    /// The hypervisor responsible for managing the virtual machine lifecycle.
+    pub hypervisor: Arc<dyn Hypervisor>,
+
+    /// The guest agent that communicates with the virtual machine.
+    pub agent: Arc<dyn Agent>,
+
+    // // / Persistent storage driver to save and restore VM state.
+    // pub store: Box<dyn PersistDriver>,
+    /// Unique identifier of the virtual machine.
+    pub id: String,
+
+    /// Number of vCPUs assigned to the VM.
+    pub cpu: f32,
+
+    /// Amount of memory (in MB) assigned to the VM.
+    pub memory: u32,
+
+    /// Tracks the difference in vCPU count since last update.
+    pub cpu_delta: i32,
+}
+
+/// VMConfig holds all configuration information required to start a new VM instance.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct VMConfig {
+    /// Type of hypervisor to be used (e.g., qemu, cloud-hypervisor).
+    #[serde(default)]
+    pub hypervisor_name: String,
+    #[serde(default)]
+    pub agent_name: String,
+    /// Configuration for the guest agent.
+    #[serde(default)]
+    pub agent_config: AgentConfig,
+
+    /// Configuration for the hypervisor.
+    #[serde(default)]
+    pub hypervisor_config: HypervisorConfig,
+}
+
+impl VMConfig {
+    pub fn valid(&mut self) -> Result<()> {
+        VMConfig::validate_hypervisor_config(&mut self.hypervisor_config)
+    }
+
+    pub fn validate_hypervisor_config(conf: &mut HypervisorConfig) -> Result<()> {
+        // remote_hypervisor_socket
+        if !conf.remote_info.hypervisor_socket.is_empty() {
+            return Ok(());
+        }
+
+        // kernel_path
+        if conf.boot_info.kernel.is_empty() {
+            let e = anyhow!("Missing kernel path");
+            error!(sl!(), "{:#?}", e);
+            return Err(e);
+        }
+
+        // In Secure Execution mode, the `image` and `initrd` settings are prohibited from being configured
+        if conf.security_info.confidential_guest
+            && conf.machine_info.machine_type == "s390-ccw-virtio"
+        // QemuCCWVirtio
+        {
+            if !conf.boot_info.image.is_empty() || !conf.boot_info.initrd.is_empty() {
+                let e = anyhow!("Neither the image or initrd path may be set for Secure Execution");
+                error!(sl!(), "{:#?}", e);
+                return Err(e);
+            }
+        } else if conf.boot_info.image.is_empty() && conf.boot_info.initrd.is_empty() {
+            let e = anyhow!("Missing image and initrd path");
+            error!(sl!(), "{:#?}", e);
+            return Err(e);
+        } else if !conf.boot_info.image.is_empty() && !conf.boot_info.initrd.is_empty() {
+            let e = anyhow!("Image and initrd path cannot be both set");
+            error!(sl!(), "{:#?}", e);
+            return Err(e);
+        }
+
+        // template valid todo 
+
+        // num_vcpus_f
+        if conf.cpu_info.default_vcpus == 0.0 {
+            conf.cpu_info.default_vcpus = default::DEFAULT_GUEST_VCPUS as f32;
+        }
+
+        // memory_size
+        if conf.memory_info.default_memory == 0 {
+            conf.memory_info.default_memory = default::DEFAULT_QEMU_MEMORY_SIZE_MB;
+        }
+
+        // default_bridges
+        if conf.device_info.default_bridges == 0 {
+            conf.device_info.default_bridges = default::DEFAULT_QEMU_PCI_BRIDGES;
+        }
+
+        // block_device_driver
+        if conf.blockdev_info.block_device_driver.is_empty() {
+            conf.blockdev_info.block_device_driver = default::DEFAULT_BLOCK_DEVICE_TYPE.to_string();
+        } else if conf.blockdev_info.block_device_driver == "virtio-blk"
+            && conf.machine_info.machine_type == "s390-ccw-virtio"
+        {
+            conf.blockdev_info.block_device_driver = "virtio-blk-ccw".to_string();
+        }
+
+        // default_maxvcpus
+        // let cpus = num_cpus::get() as u32;
+        if conf.cpu_info.default_maxvcpus == 0
+            || conf.cpu_info.default_maxvcpus > default::MAX_QEMU_VCPUS
+        {
+            conf.cpu_info.default_maxvcpus = default::MAX_QEMU_VCPUS;
+        }
+
+        // msize9p
+        if conf.shared_fs.shared_fs.as_deref() != Some("virtio-fs") && conf.shared_fs.msize_9p == 0
+        {
+            conf.shared_fs.msize_9p = default::MAX_SHARED_9PFS_SIZE_MB;
+        }
+
+        Ok(())
+    }
+}
+
+#[allow(dead_code)]
+impl VM {
+    // Initializes the QEMU hypervisor for Kata
+    // Refactored the function to support only QEMU, as access to the private function in `virt_container::lib::new_hypervisor()` is unavailable.
+    async fn new_hypervisor(config: &VMConfig) -> Result<Arc<dyn Hypervisor>> {
+        let hypervisor: Arc<dyn Hypervisor> = match config.hypervisor_name.as_str() {
+            HYPERVISOR_QEMU => {
+                let h = Qemu::new();
+                h.set_hypervisor_config(config.hypervisor_config.clone())
+                    .await;
+                Arc::new(h)
+            }
+            _ => return Err(anyhow!("Unsupported hypervisor {}", config.hypervisor_name)),
+        };
+        Ok(hypervisor)
+    }
+
+    // Initializes the Kata agent, handling necessary configurations and setup
+    // analogous to `virt_container::lib::new_agent()`.
+    fn new_agent(config: &VMConfig) -> Result<Arc<KataAgent>> {
+        let agent_name = &config.agent_name;
+        let agent_config = config.agent_config.clone();
+
+        match agent_name.as_str() {
+            AGENT_KATA => {
+                let agent = KataAgent::new(agent_config.clone());
+                Ok(Arc::new(agent))
+            }
+            _ => Err(anyhow!("Unsupported agent {}", &agent_name)),
+        }
+    }
+
+    // Create an empty `sandbox_config` structure
+    fn new_empty_sandbox_config() -> SandboxConfig {
+        SandboxConfig {
+            sandbox_id: String::new(),
+            hostname: String::new(),
+            dns: Vec::new(),
+            network_env: SandboxNetworkEnv {
+                netns: None,
+                network_created: false,
+            },
+            annotations: HashMap::default(),
+            hooks: None,
+            state: runtime_spec::State {
+                version: Default::default(),
+                id: String::new(),
+                status: runtime_spec::ContainerState::Creating,
+                pid: 0,
+                bundle: String::new(),
+                annotations: Default::default(),
+            },
+        }
+    }
+
+    // Creates a new VM based on the provided configuration.
+    #[allow(unused_variables)]
+    pub async fn new_vm(config: VMConfig, toml_config: TomlConfig) -> Result<Self> {
+        
+        let sid = Uuid::new_v4().to_string();
+        
+        // msg_sender
+        const MESSAGE_BUFFER_SIZE: usize = 8;
+        let (sender, _receiver) = channel::<Message>(MESSAGE_BUFFER_SIZE);
+
+        // hypervisor
+        let hypervisor = Self::new_hypervisor(&config)
+            .await
+            .context("new hypervisor")?;
+
+        // agent
+        // get uds from hypervisor and get config from toml_config
+        let agent = Self::new_agent(&config).context("new agent")?;
+
+        // sandbox_config
+        let sandbox_config = Self::new_empty_sandbox_config();
+
+        let mut initial_size_manager = InitialSizeManager::new_from(&sandbox_config.annotations)
+            .context("failed to construct static resource manager")?;
+
+        // We need to update the `toml_config` with runtime information, 
+        // but due to ownership issues with the variables, we cannot pass them as parameters.
+        // Therefore, for now, we directly set the `slot` and `maxmemory` values in the configuration file to non-zero.
+
+        // initial_size_manager
+        //     .setup_config(&mut toml_config)
+        //     .context("failed to setup static resource mgmt config")?;
+
+        let factory = toml_config.factory.clone();
+
+        let toml_config_arc = Arc::new(toml_config);
+
+        // resource_manager
+        let resource_manager = Arc::new(
+            ResourceManager::new(
+                &sid,
+                agent.clone(),
+                hypervisor.clone(),
+                toml_config_arc,
+                initial_size_manager,
+            )
+            .await?,
+        );
+
+        // sandbox_config
+        let sandbox = VirtSandbox::new(
+            &sid,
+            sender.clone(),
+            agent.clone(),
+            hypervisor.clone(),
+            resource_manager.clone(),
+            sandbox_config,
+            factory,
+        )
+        .await;
+
+        // info!(sl!(), "vm::new_vm"; "sandbox" => format!("{:?}", sandbox));
+
+        let sb = sandbox.unwrap();
+
+        match sb.start_template().await {
+            Ok(_) => {
+                info!(sl!(), "vm::new_vm():"; "sb" => format!("{:?}", sb));
+            }
+            Err(e) => {
+                error!(sl!(), "vm::new_vm(): sandbox start failed: {}", e);
+            }
+        }
+        info!(sl!(), "vm::new_vm(): VM start successfully");
+        let hypervisor_config = sb.hypervisor.hypervisor_config().await;
+        
+        let vm = VM {
+            id: sb.sid,
+            hypervisor: sb.hypervisor.clone(),
+            agent: sb.agent.clone(),
+            cpu: hypervisor_config.cpu_info.default_vcpus,
+            memory: hypervisor_config.memory_info.default_memory,
+            cpu_delta: 0,
+        };
+        Ok(vm)
+    }
+
+    pub async fn stop(&self) -> Result<()> {
+
+        // Stop qemu process
+        self.hypervisor
+            .stop_vm()
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to stop vm: {}", e))?;
+
+        // To be implemented: Remove the control resources from the cgroups, 
+        // similar to how it's done in `store.Destroy()` in Go.
+
+        Ok(())
+    }
+
+    // Disconnect the gRPC connection between the Kata agent and the VM
+    pub async fn disconnect(&self) -> Result<()> {
+        info!(sl!(), "vm::disconnect(): begin");
+        // To be implemented
+        Ok(())
+    }
+
+    // Pause a VM.
+    pub async fn pause(&self) -> Result<()> {
+        info!(sl!(), "vm::pause(): start");
+        self.hypervisor.pause_vm().await
+    }
+
+    // Save a VM to persistent disk.
+    pub async fn save(&self) -> Result<()> {
+        info!(sl!(), "vm::save(): start");
+        self.hypervisor.save_vm().await
+    }
+
+    // Resume resumes a paused VM.
+    pub async fn resume(&self) -> Result<()> {
+        info!(sl!(), "vm::resume(): start");
+        self.hypervisor.resume_vm().await
+    }
+}

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -1,19 +1,15 @@
-// Copyright (c) 2019-2022 Alibaba Cloud
-// Copyright (c) 2019-2022 Ant Group
-//
-// SPDX-License-Identifier: Apache-2.0
-//
-
 #[macro_use]
 extern crate slog;
 
 logging::logger_with_subsystem!(sl, "virt-container");
 
 mod container_manager;
+pub mod factory;
 pub mod health_check;
 pub mod sandbox;
 pub mod sandbox_persist;
 
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use agent::{kata::KataAgent, AGENT_KATA};
@@ -42,13 +38,17 @@ use hypervisor::ch::CloudHypervisor;
     any(target_arch = "x86_64", target_arch = "aarch64")
 ))]
 use kata_types::config::{hypervisor::HYPERVISOR_NAME_CH, CloudHypervisorConfig};
+#[allow(unused_imports)]
+use std::thread;
+#[allow(unused_imports)]
+use std::time::Duration;
 
+use crate::factory::vm::VMConfig;
 use resource::cpu_mem::initial_size::InitialSizeManager;
 use resource::ResourceManager;
 use sandbox::VIRTCONTAINER;
 use tokio::sync::mpsc::Sender;
 use tracing::instrument;
-
 unsafe impl Send for VirtContainer {}
 unsafe impl Sync for VirtContainer {}
 #[derive(Debug)]
@@ -104,10 +104,49 @@ impl RuntimeHandler for VirtContainer {
         init_size_manager: InitialSizeManager,
         sandbox_config: SandboxConfig,
     ) -> Result<RuntimeInstance> {
-        let hypervisor = new_hypervisor(&config).await.context("new hypervisor")?;
+        let factory = config.factory.clone();
+        let (hypervisor, agent);
+        // VMTemplate Mechanism
+        if factory.template {
+            let (toml_config, _) = TomlConfig::load_from_default().context("load toml config")?;
+            //Build VMConfig
+            let mut vm_config = VMConfig {
+                hypervisor_name: toml_config.runtime.hypervisor_name.clone(),
+                agent_name: toml_config.runtime.agent_name.clone(),
+                hypervisor_config: toml_config
+                    .hypervisor
+                    .get(&toml_config.runtime.hypervisor_name)
+                    .cloned()
+                    .unwrap_or_default(),
+                agent_config: toml_config
+                    .agent
+                    .get(&toml_config.runtime.agent_name)
+                    .cloned()
+                    .unwrap_or_default(),
+            };
+            let template_path = toml_config.factory.template_path.clone();
+            info!(
+                sl!(),
+                "lib::new_instance(): build VMConfig. VMConfig:{:?}", vm_config
+            );
+            let vm = factory::get_vm(&mut vm_config, PathBuf::from(template_path)).await?;
+
+            hypervisor = vm.hypervisor.clone();
+            
+            agent = vm.agent.clone();
+            
+            let addr = vm.hypervisor.get_agent_socket().await?;
+            info!(
+                sl!(),
+                "lib::new_instance(): template vm agent socket addr = {:?}", addr
+            );
+        } else {
+            hypervisor = new_hypervisor(&config).await.context("new hypervisor")?;
+            agent = new_agent(&config).context("new agent")?;
+        }
 
         // get uds from hypervisor and get config from toml_config
-        let agent = new_agent(&config).context("new agent")?;
+        // let agent = new_agent(&config).context("new agent")?;
         let resource_manager = Arc::new(
             ResourceManager::new(
                 sid,
@@ -119,7 +158,7 @@ impl RuntimeHandler for VirtContainer {
             .await?,
         );
         let pid = std::process::id();
-
+        info!(sl!(), "lib::new_instance(): sid={}", sid);
         let sandbox = sandbox::VirtSandbox::new(
             sid,
             msg_sender,
@@ -127,6 +166,7 @@ impl RuntimeHandler for VirtContainer {
             hypervisor.clone(),
             resource_manager.clone(),
             sandbox_config,
+            factory,
         )
         .await
         .context("new virt sandbox")?;
@@ -149,7 +189,11 @@ impl RuntimeHandler for VirtContainer {
     }
 }
 
-async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>> {
+// pub async fn p_new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>> {
+//     new_hypervisor(toml_config).await
+// }
+
+pub async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>> {
     let hypervisor_name = &toml_config.runtime.hypervisor_name;
     let hypervisor_config = toml_config
         .hypervisor
@@ -209,7 +253,7 @@ async fn new_hypervisor(toml_config: &TomlConfig) -> Result<Arc<dyn Hypervisor>>
     }
 }
 
-fn new_agent(toml_config: &TomlConfig) -> Result<Arc<KataAgent>> {
+pub fn new_agent(toml_config: &TomlConfig) -> Result<Arc<KataAgent>> {
     let agent_name = &toml_config.runtime.agent_name;
     let agent_config = toml_config
         .agent

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -39,7 +39,7 @@ use kata_sys_util::protection::{available_guest_protection, GuestProtection};
 use kata_types::capabilities::CapabilityBits;
 use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
 use kata_types::config::hypervisor::HYPERVISOR_NAME_CH;
-use kata_types::config::TomlConfig;
+use kata_types::config::{Factory, TomlConfig};
 use kata_types::initdata::{calculate_initdata_digest, ProtectedPlatform};
 use oci_spec::runtime as oci;
 use persist::{self, sandbox_persist::Persist};
@@ -54,12 +54,11 @@ use resource::{ResourceConfig, ResourceManager};
 use runtime_spec as spec;
 use std::path::Path;
 use std::sync::Arc;
+
 use strum::Display;
 use tokio::sync::{mpsc::Sender, Mutex, RwLock};
 use tracing::instrument;
-
 pub(crate) const VIRTCONTAINER: &str = "virt_container";
-
 pub struct SandboxRestoreArgs {
     pub sid: String,
     pub toml_config: TomlConfig,
@@ -73,7 +72,7 @@ pub enum SandboxState {
     Stopped,
 }
 
-struct SandboxInner {
+pub struct SandboxInner {
     state: SandboxState,
 }
 
@@ -85,17 +84,19 @@ impl SandboxInner {
     }
 }
 
+//VMTemplate::Todo
 #[derive(Clone)]
 pub struct VirtSandbox {
-    sid: String,
-    msg_sender: Arc<Mutex<Sender<Message>>>,
-    inner: Arc<RwLock<SandboxInner>>,
-    resource_manager: Arc<ResourceManager>,
-    agent: Arc<dyn Agent>,
-    hypervisor: Arc<dyn Hypervisor>,
-    monitor: Arc<HealthCheck>,
-    sandbox_config: Option<SandboxConfig>,
+    pub sid: String,
+    pub msg_sender: Arc<Mutex<Sender<Message>>>,
+    pub inner: Arc<RwLock<SandboxInner>>,
+    pub resource_manager: Arc<ResourceManager>,
+    pub agent: Arc<dyn Agent>,
+    pub hypervisor: Arc<dyn Hypervisor>,
+    pub monitor: Arc<HealthCheck>,
+    pub sandbox_config: Option<SandboxConfig>,
     shm_size: u64,
+    pub factory: Option<Factory>,
 }
 
 impl std::fmt::Debug for VirtSandbox {
@@ -103,6 +104,13 @@ impl std::fmt::Debug for VirtSandbox {
         f.debug_struct("VirtSandbox")
             .field("sid", &self.sid)
             .field("msg_sender", &self.msg_sender)
+            .field("inner", &"<SandboxInner>")
+            .field("resource_manager", &self.resource_manager)
+            .field("agent", &"<Agent>")
+            .field("hypervisor", &self.hypervisor)
+            .field("monitor", &"<HealthCheck>")
+            .field("sandbox_config", &self.sandbox_config)
+            .field("factory", &self.factory)
             .finish()
     }
 }
@@ -115,6 +123,7 @@ impl VirtSandbox {
         hypervisor: Arc<dyn Hypervisor>,
         resource_manager: Arc<ResourceManager>,
         sandbox_config: SandboxConfig,
+        factory: Factory,
     ) -> Result<Self> {
         let config = resource_manager.config().await;
         let keep_abnormal = config.runtime.keep_abnormal;
@@ -128,6 +137,7 @@ impl VirtSandbox {
             monitor: Arc::new(HealthCheck::new(true, keep_abnormal)),
             shm_size: sandbox_config.shm_size,
             sandbox_config: Some(sandbox_config),
+            factory: Some(factory),
         })
     }
 
@@ -501,6 +511,7 @@ impl VirtSandbox {
 impl Sandbox for VirtSandbox {
     #[instrument(name = "sb: start")]
     async fn start(&self) -> Result<()> {
+        info!(sl!(), "sandbox::start()"; "sandbox:" => format!("{:?}", self));
         let id = &self.sid;
 
         if self.sandbox_config.is_none() {
@@ -537,9 +548,15 @@ impl Sandbox for VirtSandbox {
             .await
             .context("set up device before start vm")?;
 
-        // start vm
-        self.hypervisor.start_vm(10_000).await.context("start vm")?;
-        info!(sl!(), "start vm");
+        if <std::option::Option<Factory> as Clone>::clone(&self.factory)
+            .unwrap()
+            .template
+        {
+            info!(sl!(), "sandbox::start(): start template vm");
+        } else {
+            self.hypervisor.start_vm(10_000).await.context("start vm")?;
+            info!(sl!(), "sandbox::start(): start normal vm");
+        }
 
         // execute pre-start hook functions, including Prestart Hooks and CreateRuntime Hooks
         let (prestart_hooks, create_runtime_hooks) =
@@ -594,6 +611,7 @@ impl Sandbox for VirtSandbox {
             .get_agent_socket()
             .await
             .context("get agent socket")?;
+        
         self.agent
             .start(&address)
             .await
@@ -673,6 +691,51 @@ impl Sandbox for VirtSandbox {
         });
         self.monitor.start(id, self.agent.clone());
         self.save().await.context("save state")?;
+        Ok(())
+    }
+    #[allow(unused_mut)]
+    async fn start_template(&self) -> Result<()> {
+        info!(sl!(), "sandbox::start_template()"; "sandbox:" => format!("{:?}", self));
+        let id = &self.sid;
+
+        if self.sandbox_config.is_none() {
+            return Err(anyhow!(
+                "sandbox::start_template(): sandbox config is missing"
+            ));
+        }
+        let sandbox_config = self.sandbox_config.as_ref().unwrap();
+
+        // if sandbox is not in SandboxState::Init then return,
+        // otherwise try to create sandbox
+
+        let mut inner = self.inner.write().await;
+        if inner.state != SandboxState::Init {
+            warn!(sl!(), "sandbox is started");
+            return Ok(());
+        }
+
+        self.hypervisor
+            .prepare_vm(
+                id,
+                sandbox_config.network_env.netns.clone(),
+                &sandbox_config.annotations,
+            )
+            .await
+            .context("prepare vm")?;
+
+        // generate device and setup before start vm
+        // should after hypervisor.prepare_vm
+        let resources = self
+            .prepare_for_start_sandbox(id, sandbox_config.network_env.clone())
+            .await?;
+
+        self.resource_manager
+            .prepare_before_start_vm(resources)
+            .await
+            .context("set up device before start vm")?;
+
+        self.hypervisor.start_vm(10_000).await.context("start vm")?;
+        info!(sl!(), "sandbox::start_template(): start vm");
         Ok(())
     }
 
@@ -929,6 +992,7 @@ impl Persist for VirtSandbox {
             monitor: Arc::new(HealthCheck::new(true, keep_abnormal)),
             sandbox_config: None,
             shm_size: DEFAULT_SHM_SIZE,
+            factory: None,
         })
     }
 }


### PR DESCRIPTION
Add VM template lifecycle with factory, template, and VM modules.
Implement VMTemplate creation and startup in Rust runtime.
Integrate template support in Sandbox, VirtContainer, and QEMU hypervisor.
Enable boot from template, migration handling, and backward compatibility.
Provide configuration via kata-types with factory and template options.

Fixes: #11413