### PR TITLE
kata-types: remove trailing slash from DEFAULT_KATA_GUEST_SANDBOX_DIR

### DIFF
--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -69,7 +69,7 @@ pub const KATA_VIRTUAL_VOLUME_IMAGE_GUEST_PULL: &str = "image_guest_pull";
 /// In CoCo scenario, we support force_guest_pull to enforce container image guest pull without remote snapshotter.
 pub const KATA_IMAGE_FORCE_GUEST_PULL: &str = "force_guest_pull";
 /// kata default guest sandbox dir.
-pub const DEFAULT_KATA_GUEST_SANDBOX_DIR: &str = "/run/kata-containers/sandbox/";
+pub const DEFAULT_KATA_GUEST_SANDBOX_DIR: &str = "/run/kata-containers/sandbox";
 /// default shm directory name.
 pub const SHM_DIR: &str = "shm";
 /// shm device path.


### PR DESCRIPTION
Trailing slash in DEFAULT_KATA_GUEST_SANDBOX_DIR caused double slashes in mount_point (e.g. "/run/kata-containers/sandbox//shm"), which failed OPA strict equality checks against policy mount_point. Removing it aligns generated paths with policy and fixes CreateSandboxRequest denial.

The related error message:
```
allow_sandbox_storages: i_storages = [{\\\\\\\"driver\\\\\\\": \\\\\\\"ephemeral\\\\\\\", \\\\\\\"driver_options\\\\\\\": [], \\\\\\\"fs_group\\\\\\\": null, \\\\\\\"fstype\\\\\\\": \\\\\\\"tmpfs\\\\\\\", \\\\\\\"mount_point\\\\\\\": \\\\\\\"/run/kata-containers/sandbox//shm\\\\\\\", \\\\\\\"options\\\\\\\": [\\\\\\\"noexec\\\\\\\", \\\\\\\"nosuid\\\\\\\", \\\\\\\"nodev\\\\\\\", \\\\\\\"mode=1777\\\\\\\", \\\\\\\"size=67108864\\\\\\\"], \\\\\\\"source\\\\\\\": \\\\\\\"shm\\\\\\\"}] 
```