### PR TITLE
agent: Fix format issues

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -466,15 +466,15 @@ fn attestation_binaries_available(logger: &Logger, procs: &GuestComponentsProcs)
         _ => vec![],
     };
     for binary in binaries.iter() {
-        let exists = Path::new(binary).try_exists().unwrap_or_else(|error| {
-            match error.kind() {
+        let exists = Path::new(binary)
+            .try_exists()
+            .unwrap_or_else(|error| match error.kind() {
                 ErrorKind::NotFound => {
                     warn!(logger, "{} not found", binary);
                     false
-                },
-                _ => panic!("Path existence check failed for '{}': {}", binary, error)
-            }
-        });
+                }
+                _ => panic!("Path existence check failed for '{}': {}", binary, error),
+            });
 
         if !exists {
             return false;


### PR DESCRIPTION
In the previous commit we've added some code that broke `cargo fmt -- --check` without even noticing, as the code didn't go through the CI process (due to it being a security advisory).