### PR TITLE
runtime-rs: Remove InitData annotation from OCI Spec

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -18,7 +18,7 @@ use common::{
 };
 use kata_sys_util::k8s::update_ephemeral_storage_type;
 use kata_types::{
-    annotations::{BUNDLE_PATH_KEY, CONTAINER_TYPE_KEY},
+    annotations::{BUNDLE_PATH_KEY, CONTAINER_TYPE_KEY, KATA_ANNO_CFG_HYPERVISOR_INIT_DATA},
     container::{update_ocispec_annotations, POD_CONTAINER, POD_SANDBOX},
     k8s::{self, container_type},
 };
@@ -123,8 +123,11 @@ impl Container {
         };
 
         let bund_path_anno = (BUNDLE_PATH_KEY.to_string(), config.bundle.clone());
-        let updated_annotations =
-            update_ocispec_annotations(&annotations, &[], &[pod_type_anno, bund_path_anno]);
+        let updated_annotations = update_ocispec_annotations(
+            &annotations,
+            &[KATA_ANNO_CFG_HYPERVISOR_INIT_DATA],
+            &[pod_type_anno, bund_path_anno],
+        );
         spec.set_annotations(Some(updated_annotations.clone()));
 
         amend_spec(


### PR DESCRIPTION
This commit removes the InitData annotation from the OCI Spec's annotations.

Similar to the Policy annotation, InitData is now exclusively handled and transmitted to the guest via the sandbox's init data mechanism. Removing this redundant and potentially large annotation simplifies the OCI Spec and streamlines the guest initialization process.

This change aligns the handling of InitData with existing practices within runtime-go.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>