### PR TITLE
runtime-rs: set the default block driver as virtio-scsi for qemu

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -315,7 +315,7 @@ ifeq ($(ARCH), s390x)
     DEFBLOCKSTORAGEDRIVER_QEMU := virtio-blk-ccw
 else
     VMROOTFSDRIVER_QEMU := virtio-pmem
-    DEFBLOCKSTORAGEDRIVER_QEMU := virtio-blk-pci
+    DEFBLOCKSTORAGEDRIVER_QEMU := virtio-scsi
 endif
     DEFVCPUS_QEMU := 1
     DEFMAXVCPUS_QEMU := 0


### PR DESCRIPTION
Change the default block driver to virtio-scsi.

Since the latest qemu's commit:
https://gitlab.com/qemu-project/qemu/-/commit/
984a32f17e8dab0dc3d2328c46cb3e0c0a472a73

brings a bug for virtio-blk-pci with io_uring mode at line: https://gitlab.com/qemu-project/qemu/-/commit/984a32f17e8dab0dc3d2328c46cb3e0c0a472a73#ce8eeb01f8b84f8cb8d3c35684d473fe1ee670f9_345_352

In order to avoid this issue, change the default block driver to virtio-scsi.