### PR TITLE
GHA: Pin Alpine to 3.20 for tee-unencrypted image

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
+++ b/tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
@@ -4,7 +4,8 @@
 
 # We know that using latest is error prone, we're taking the risk here.
 # hadolint ignore=DL3007
-FROM alpine:latest
+# alpine:3.20
+FROM alpine@sha256:b3119ef930faabb6b7b976780c0c7a9c1aa24d0c75e9179ac10e6bc9ac080d0d
 
 # We don't need a specific version of those packages
 # hadolint ignore=DL3018


### PR DESCRIPTION
We recently hit the following error during build:

```
RUN ssh-keygen -t ed25519 -f /etc/ssh/ssh_host_ed25519_key -P ""
OpenSSL version mismatch. Built against 3050003f, you have 30500010
```

This happened because `alpine:latest` moved forward and the `ssh-keygen` binary in the base image was compiled against a newer OpenSSL version that is not available at runtime.
Pinning the base image to the stable release (3.20) avoids the mismatch and ensures consistent builds.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>