### PR TITLE
libs: Fix the test_parse_mount_options failure on ppc64le

### DIFF
--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -1088,7 +1088,7 @@ mod tests {
         assert!(parse_mount_options(&options).is_err());
 
         let idx = options.len() - 1;
-        options[idx] = " ".repeat(4097);
+        options[idx] = " ".repeat(*MAX_MOUNT_PARAM_SIZE+1);
         assert!(parse_mount_options(&options).is_err());
     }
 


### PR DESCRIPTION
- Test was failing on ppc64le due to larger system page size (e.g., 65536 bytes)
- Original test used a hardcoded 4097-byte string assuming 4KB page size
- Replaced with *MAX_MOUNT_PARAM_SIZE + 1 to reflect actual system limit
- Ensures test fails correctly across all architectures

Fixes: #11852

Signed-off-by: shwetha-s-poojary <shwetha.s-poojary@ibm.com>