### PR TITLE
runtime: config: allow TDX QGS port=0

### DIFF
--- a/src/runtime/pkg/katautils/config-settings.go.in
+++ b/src/runtime/pkg/katautils/config-settings.go.in
@@ -57,7 +57,6 @@ var systemdUnitName = "kata-containers.target"
 
 const defaultKernelParams = ""
 const defaultMachineType = "q35"
-const defaultQgsPort = 4050
 
 const defaultVCPUCount uint32 = 1
 const defaultMaxVCPUCount uint32 = 0

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -393,10 +393,8 @@ func (h hypervisor) machineType() string {
 }
 
 func (h hypervisor) qgsPort() uint32 {
-	if h.QgsPort == 0 {
-		return defaultQgsPort
-	}
-
+	// TOML parser guarantees that only integers >= 0 are accepted. Any
+	// value from the parser is OK, including 0.
 	return h.QgsPort
 }
 

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -189,7 +189,6 @@ func createAllRuntimeConfigFiles(dir, hypervisor string) (testConfig testRuntime
 		VirtioFSCache:         defaultVirtioFSCacheMode,
 		PFlash:                []string{},
 		SGXEPCSize:            epcSize,
-		QgsPort:               defaultQgsPort,
 	}
 
 	if goruntime.GOARCH == "arm64" && len(hypervisorConfig.PFlash) == 0 && hypervisorConfig.FirmwarePath == "" {


### PR DESCRIPTION
85f3391bc added the support for TDX QGS port=0 but missed defaultQgsPort in the default config. defaultQgsPort overrides user provided tdx_quote_generation_service_socket_port=0.

After this change, defaultQgsPort is not needed anymore since there's no default: any positive integer is OK and negative or unset value becomes a parse error.

QEMUTDXQUOTEGENERATIONSERVICESOCKETPORT in the Makefile is used to provide a sane default when tdx_quote_generation_service_socket_port gets set in the configuration.