### PR TITLE
ci: Remove DL3007 ignore comment for base image

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
+++ b/tests/integration/kubernetes/runtimeclass_workloads/confidential/unencrypted/Dockerfile
@@ -2,8 +2,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# We know that using latest is error prone, we're taking the risk here.
-# hadolint ignore=DL3007
 # alpine:3.20
 FROM alpine@sha256:b3119ef930faabb6b7b976780c0c7a9c1aa24d0c75e9179ac10e6bc9ac080d0d
 


### PR DESCRIPTION
The Hadolint warning DL3007 (pin the version explicitly) is no longer applicable.

We have updated the base image to use a specific version digest, which satisfies the linter's requirement for reproducible builds. This PR removes the corresponding inline ignore comment.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>