### PR TITLE
tests/k8s: Add set -euo pipefail to lib.sh

### DIFF
--- a/tests/integration/kubernetes/k8s-parallel.bats
+++ b/tests/integration/kubernetes/k8s-parallel.bats
@@ -54,7 +54,7 @@ teardown() {
 
 	delete_tmp_policy_settings_dir "${policy_settings_dir}"
 
-	teardown_common
+	teardown_common "${node}" "${node_start_time:-}"
 
 	# Delete jobs
 	kubectl delete jobs -l jobgroup=${job_name}

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -6,7 +6,7 @@
 #
 # This provides generic functions to use in the tests.
 #
-set -e
+set -euo pipefail
 
 wait_time=60
 sleep_time=3
@@ -17,8 +17,6 @@ k8s_delete_all_pods_if_any_exists() {
 	[ -z "$(kubectl get --no-headers pods)" ] || \
 		kubectl delete --all pods
 }
-
-FIXTURES_DIR="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 
 # Wait until the pod is not 'Ready'. Fail if it hits the timeout.
 #
@@ -258,6 +256,7 @@ assert_rootfs_count() {
 # 	directory.
 #
 new_pod_config() {
+	local FIXTURES_DIR="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	local base_config="${FIXTURES_DIR}/pod-config.yaml.in"
 	local image="$1"
 	local runtimeclass="$2"

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -325,7 +325,7 @@ add_allow_all_policy_to_yaml() {
 	# By default was changing only the first object.
 	# With yq>4 we need to make it explicit during the read and write.
 	local resource_kind
-	resource_kind=$(yq .kind "${yaml_file}" | head -1)
+	resource_kind=$(yq eval 'select(documentIndex == 0) | .kind' "${yaml_file}")
 
 	case "${resource_kind}" in
 	Pod)


### PR DESCRIPTION
```
-o pipefail in particular ensures that exec_host() returns the right exit
code.

-u is also added for good measure. Note that $BATS_TEST_DIRNAME is set by
bats so we move its usage inside the function.
```