### PR TITLE
gpu: Add libgcc for RUST libc=gnu builds

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -245,6 +245,10 @@ chisseled_init() {
 
 	ln -sf ../run var/run
 
+	# Needed for various RUST static builds with LIBC=gnu
+	libdir=lib/"${machine_arch}"-linux-gnu
+	cp -a "${stage_one}"/"${libdir}"/libgcc_s.so.1*    "${libdir}"/.
+
 	tar xvf "${BUILD_DIR}"/kata-static-nvidia-nvrc.tar.zst -C .
 	# make sure NVRC is the init process for the initrd and image case
 	ln -sf  /bin/NVRC init


### PR DESCRIPTION
Since we cannot build all components with libc=musl and
static RUSTFLAG we still need to ship libcc for AA or other guest
components.