### PR TITLE
tests: k8s: auto-generate policy for additional tests

### DIFF
--- a/tests/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/tests/integration/kubernetes/k8s-credentials-secrets.bats
@@ -27,14 +27,14 @@ setup() {
 	auto_generate_policy "${pod_policy_settings_dir}" "${pod_yaml_file}"
 
 	# Add policy to pod-secret-env.yaml.
-	#
-	# TODO: auto-generate policy for this pod YAML after solving
-	# https://github.com/kata-containers/kata-containers/issues/10033
 	pod_env_yaml_file="${pod_config_dir}/pod-secret-env.yaml"
 	set_node "$pod_env_yaml_file" "$node"
 	pod_env_cmd="printenv"
 	pod_env_exec_command=(sh -c "${pod_env_cmd}")
-	add_allow_all_policy_to_yaml "${pod_env_yaml_file}"
+	pod_env_policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+	add_exec_to_policy_settings "${pod_env_policy_settings_dir}" "${pod_env_exec_command[@]}"
+	add_requests_to_policy_settings "${pod_env_policy_settings_dir}" "ReadStreamRequest"
+	auto_generate_policy "${pod_env_policy_settings_dir}" "${pod_env_yaml_file}" "${pod_config_dir}/inject_secret.yaml"
 }
 
 @test "Credentials using secrets" {
@@ -76,6 +76,7 @@ teardown() {
 	kubectl delete secret "$secret_name"
 
 	delete_tmp_policy_settings_dir "${pod_policy_settings_dir}"
+	delete_tmp_policy_settings_dir "${pod_env_policy_settings_dir}"
 
 	teardown_common "${node}" "${node_start_time:-}"
 }

--- a/tests/integration/kubernetes/k8s-liveness-probes.bats
+++ b/tests/integration/kubernetes/k8s-liveness-probes.bats
@@ -24,7 +24,7 @@ setup() {
 	yaml_file="${pod_config_dir}/probe-pod-liveness.yaml"
 	cp "${pod_config_dir}/pod-liveness.yaml" "${yaml_file}"
 	set_node "${yaml_file}" "$node"
-	add_allow_all_policy_to_yaml "${yaml_file}"
+	auto_generate_policy "${pod_config_dir}" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${yaml_file}"
@@ -49,7 +49,7 @@ setup() {
 	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
 		"${pod_config_dir}/pod-http-liveness.yaml" > "${yaml_file}"
 	set_node "${yaml_file}" "$node"
-	add_allow_all_policy_to_yaml "${yaml_file}"
+	auto_generate_policy "${pod_config_dir}" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${yaml_file}"
@@ -75,7 +75,7 @@ setup() {
 	sed -e "s#\${agnhost_image}#${agnhost_name}:${agnhost_version}#" \
 		"${pod_config_dir}/pod-tcp-liveness.yaml" > "${yaml_file}"
 	set_node "${yaml_file}" "$node"
-	add_allow_all_policy_to_yaml "${yaml_file}"
+	auto_generate_policy "${pod_config_dir}" "${yaml_file}"
 
 	# Create pod
 	kubectl create -f "${yaml_file}"

--- a/tests/integration/kubernetes/k8s-nginx-connectivity.bats
+++ b/tests/integration/kubernetes/k8s-nginx-connectivity.bats
@@ -24,7 +24,7 @@ setup() {
 	sed -e "s/\${nginx_version}/${nginx_image}/" \
 		"${pod_config_dir}/${deployment}.yaml" > "${yaml_file}"
 	
-	add_allow_all_policy_to_yaml "${yaml_file}"
+	auto_generate_policy "${pod_config_dir}" "${yaml_file}"
 }
 
 @test "Verify nginx connectivity between pods" {


### PR DESCRIPTION
Add auto-generated agent policy for:

k8s-credentials-secrets.bats
k8s-liveness-probes.bats
k8s-nginx-connectivity.bats

Most other k8s tests are already using auto-generated policy, for CoCo and cbl-mariner tests.
