### PR TITLE
genpolicy: better parsing of mount path

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1017,10 +1017,15 @@ check_mount(p_mount, i_mount, bundle_id, sandbox_id) if {
 
 mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id) if {
     regex1 := p_mount.source
-    regex2 := replace(regex1, "$(sfprefix)", policy_data.common.sfprefix)
-    regex3 := replace(regex2, "$(cpath)", policy_data.common.cpath)
-    regex4 := replace(regex3, "$(bundle-id)", bundle_id)
+    print("mount_source_allows 1: regex1 =", regex1)
 
+    regex2 := replace(regex1, "$(sfprefix)", policy_data.common.sfprefix)
+    print("mount_source_allows 1: regex2 =", regex2)
+
+    regex3 := replace(regex2, "$(cpath)", policy_data.common.cpath)
+    print("mount_source_allows 1: regex3 =", regex3)
+
+    regex4 := replace(regex3, "$(bundle-id)", bundle_id)
     print("mount_source_allows 1: regex4 =", regex4)
     regex.match(regex4, i_mount.source)
 
@@ -1028,10 +1033,15 @@ mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id) if {
 }
 mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id) if {
     regex1 := p_mount.source
-    regex2 := replace(regex1, "$(sfprefix)", policy_data.common.sfprefix)
-    regex3 := replace(regex2, "$(cpath)", policy_data.common.cpath)
-    regex4 := replace(regex3, "$(sandbox-id)", sandbox_id)
+    print("mount_source_allows 2: regex1 =", regex1)
 
+    regex2 := replace(regex1, "$(sfprefix)", policy_data.common.sfprefix)
+    print("mount_source_allows 2: regex2 =", regex2)
+
+    regex3 := replace(regex2, "$(cpath)", policy_data.common.cpath)
+    print("mount_source_allows 2: regex3 =", regex3)
+
+    regex4 := replace(regex3, "$(sandbox-id)", sandbox_id)
     print("mount_source_allows 2: regex4 =", regex4)
     regex.match(regex4, i_mount.source)
 

--- a/src/tools/genpolicy/src/mount_and_storage.rs
+++ b/src/tools/genpolicy/src/mount_and_storage.rs
@@ -301,11 +301,12 @@ fn get_shared_bind_mount(
     propagation: &str,
     access: &str,
 ) {
-    let mount_path = if let Some(byte_index) = str::rfind(&yaml_mount.mountPath, '/') {
-        str::from_utf8(&yaml_mount.mountPath.as_bytes()[byte_index + 1..]).unwrap()
-    } else {
-        &yaml_mount.mountPath
-    };
+    // The Kata Shim filepath.Base() to extract the last element of this path, in
+    // https://github.com/kata-containers/kata-containers/blob/5e46f814dd79ab6b34588a83825260413839735a/src/runtime/virtcontainers/fs_share_linux.go#L305
+    // In Rust, Path::file_name() has a similar behavior.
+    let path = Path::new(&yaml_mount.mountPath);
+    let mount_path = path.file_name().unwrap().to_str().unwrap();
+
     let source = format!("$(sfprefix){mount_path}$");
 
     let dest = yaml_mount.mountPath.clone();

--- a/tests/integration/kubernetes/k8s-volume.bats
+++ b/tests/integration/kubernetes/k8s-volume.bats
@@ -58,7 +58,7 @@ setup() {
 	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
 
 	cmd="cat /mnt/index.html"
-	kubectl exec $pod_name -- sh -c "$cmd" | grep "$msg"
+	grep_pod_exec_output "$pod_name" "$msg" sh -c "$cmd"
 }
 
 teardown() {


### PR DESCRIPTION
Mount paths ending in '/' were not parsed correctly.

Also, auto-generate policy from k8s-volume.bats - the test that exposed this genpolicy bug by using the "/mnt/" path.
