### PR TITLE
kata-deploy: accept 25.10 as supported distro for TDX

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -430,7 +430,7 @@ function install_artifacts() {
 			case ${ID} in
 				ubuntu)
 					case ${VERSION_ID} in
-						24.04|25.04)
+						24.04|25.04|25.10)
 							tdx_supported ${ID} ${VERSION_ID} ${kata_config_file}
 							;;
 						*)


### PR DESCRIPTION
Canonical TDX release is not needed for vanilla Ubuntu 25.10 but GRUB_CMDLINE_LINUX_DEFAULT needs to contain `nohibernate` and `kvm_intel.tdx=1`