### PR TITLE
kata-deploy: Add the ability to set up different snapshotters (nydus & erofs)

### DIFF
--- a/.github/workflows/nydus-snapshotter-version-in-sync.yaml
+++ b/.github/workflows/nydus-snapshotter-version-in-sync.yaml
@@ -1,0 +1,35 @@
+name: nydus-snapshotter-version-sync
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  nydus-snapshotter-version-check:
+    name: nydus-snapshotter-version-check
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        persist-credentials: false
+    - name: Ensure nydus-snapshotter-version is in sync inside our repo
+      run: |
+        dockerfile_version=$(grep "ARG NYDUS_SNAPSHOTTER_VERSION" tools/packaging/kata-deploy/Dockerfile | cut -f2 -d'=')
+        versions_version=$(yq ".externals.nydus-snapshotter.version | explode(.)" versions.yaml)
+        if [[ "${dockerfile_version}" != "${versions_version}" ]]; then
+          echo "nydus-snapshotter version must be the same in the following places: "
+          echo "- versions.yaml: ${versions_version}"
+          echo "- tools/packaging/kata-deploy/Dockerfile: ${dockerfile_version}"
+          exit 1
+        fi

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -242,6 +242,7 @@ jobs:
       AUTHENTICATED_IMAGE_USER: ${{ vars.AUTHENTICATED_IMAGE_USER }}
       AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
       SNAPSHOTTER: ${{ matrix.snapshotter }}
+      USE_EXPERIMENTAL_SETUP_SNAPSHOTTER: "true"
       # Caution: current ingress controller used to expose the KBS service
       # requires much vCPUs, lefting only a few for the tests. Depending on the
       # host type chose it will result on the creation of a cluster with
@@ -297,10 +298,6 @@ jobs:
 
       - name: Download credentials for the Kubernetes CLI to use them
         run: bash tests/integration/kubernetes/gha-run.sh get-cluster-credentials
-
-      - name: Deploy Snapshotter
-        timeout-minutes: 5
-        run: bash tests/integration/kubernetes/gha-run.sh deploy-snapshotter
 
       - name: Deploy Kata
         timeout-minutes: 10

--- a/tests/common.bash
+++ b/tests/common.bash
@@ -568,7 +568,7 @@ function get_latest_patch_release_from_a_github_project() {
         base_version="${2}"
 
         curl \
-          --header "Authorization: Bearer "${GH_TOKEN:-}"" \
+          ${GH_TOKEN:+--header "Authorization: Bearer ${GH_TOKEN:-}"} \
           --fail-with-body \
           --show-error \
           --silent \

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -26,6 +26,7 @@ HELM_K8S_DISTRIBUTION="${HELM_K8S_DISTRIBUTION:-}"
 HELM_PULL_TYPE_MAPPING="${HELM_PULL_TYPE_MAPPING:-}"
 HELM_SHIMS="${HELM_SHIMS:-}"
 HELM_SNAPSHOTTER_HANDLER_MAPPING="${HELM_SNAPSHOTTER_HANDLER_MAPPING:-}"
+HELM_EXPERIMENTAL_SETUP_SNAPSHOTTER="${HELM_EXPERIMENTAL_SETUP_SNAPSHOTTER:-}"
 KATA_DEPLOY_WAIT_TIMEOUT="${KATA_DEPLOY_WAIT_TIMEOUT:-600}"
 KATA_HOST_OS="${KATA_HOST_OS:-}"
 KUBERNETES="${KUBERNETES:-}"
@@ -445,6 +446,7 @@ function helm_helper() {
 		[[ -n "${HELM_AGENT_NO_PROXY}" ]] && yq -i ".env.agentNoProxy = \"${HELM_AGENT_NO_PROXY}\"" "${values_yaml}"
 		[[ -n "${HELM_PULL_TYPE_MAPPING}" ]] && yq -i ".env.pullTypeMapping = \"${HELM_PULL_TYPE_MAPPING}\"" "${values_yaml}"
 		[[ -n "${HELM_HOST_OS}" ]] && yq -i ".env.hostOS=\"${HELM_HOST_OS}\"" "${values_yaml}"
+		[[ -n "${HELM_EXPERIMENTAL_SETUP_SNAPSHOTTER}" ]] && yq -i ".env._experimentalSetupSnapshotter=\"${HELM_EXPERIMENTAL_SETUP_SNAPSHOTTER}\"" "${values_yaml}"
 	fi
 
 	echo "::group::Final kata-deploy manifests used in the test"

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -196,6 +196,23 @@ function deploy_kata() {
 		HOST_OS="${KATA_HOST_OS}"
 	fi
 
+	EXPERIMENTAL_SETUP_SNAPSHOTTER=""
+	if [[ "${USE_EXPERIMENTAL_SETUP_SNAPSHOTTER:-false}" == "true" ]]; then
+		case "${SNAPSHOTTER}" in
+			nydus|erofs)
+				ARCH="$(uname -m)"
+				# We only want to tests this for the qemu-coco-dev runtime class
+				# as it's running on a GitHub runner (and not on a BM machine),
+				# and there the snapshotter is deployed on every run (rather than
+				# deployed when the machine is configured, as on the BM machines).
+				if [[ "${KATA_HYPERVISOR}" == "qemu-coco-dev" ]] && [[ ${ARCH} == "x86_64" ]]; then
+					EXPERIMENTAL_SETUP_SNAPSHOTTER="${SNAPSHOTTER}"
+				fi
+				;;
+			*) ;;
+		esac
+	fi
+
 	export HELM_K8S_DISTRIBUTION="${KUBERNETES}"
 	export HELM_IMAGE_REFERENCE="${DOCKER_REGISTRY}/${DOCKER_REPO}"
 	export HELM_IMAGE_TAG="${DOCKER_TAG}"
@@ -208,6 +225,7 @@ function deploy_kata() {
 	export HELM_AGENT_HTTPS_PROXY="${HTTPS_PROXY}"
 	export HELM_AGENT_NO_PROXY="${NO_PROXY}"
 	export HELM_PULL_TYPE_MAPPING="${PULL_TYPE_MAPPING}"
+	export HELM_EXPERIMENTAL_SETUP_SNAPSHOTTER="${EXPERIMENTAL_SETUP_SNAPSHOTTER}"
 	export HELM_HOST_OS="${HOST_OS}"
 	helm_helper
 }

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -4,11 +4,37 @@
 
 ARG BASE_IMAGE_NAME=alpine
 ARG BASE_IMAGE_TAG=3.22
-FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
+FROM ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG} AS base
+
+#### Nydus snapshotter & nydus image
+
+FROM golang:1.24-alpine AS nydus-binary-downloader
+
+# Keep the version here aligned with "ndyus-snapshotter.version"
+# in versions.yaml
+ARG NYDUS_SNAPSHOTTER_VERSION=v0.15.2
+ARG NYDUS_SNAPSHOTTER_REPO=https://github.com/containerd/nydus-snapshotter
+
+RUN \
+	mkdir -p /opt/nydus-snapshotter && \
+	ARCH=$(uname -m) && \
+	if [[ "${ARCH}" == "x86_64" ]]; then ARCH=amd64 ; fi && \
+	if [[ "${ARCH}" == "aarch64" ]]; then ARCH=arm64; fi && \
+	apk add --no-cache curl && \
+	curl -fOL --progress-bar ${NYDUS_SNAPSHOTTER_REPO}/releases/download/${NYDUS_SNAPSHOTTER_VERSION}/nydus-snapshotter-${NYDUS_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz && \
+	tar xvzpf nydus-snapshotter-${NYDUS_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz -C /opt/nydus-snapshotter && \
+	rm nydus-snapshotter-${NYDUS_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz
+
+
+#### kata-deploy main image
+
+# kata-deploy args
+FROM base
+
 ARG KATA_ARTIFACTS=./kata-static.tar.zst
 ARG DESTINATION=/opt/kata-artifacts
 
-COPY ${KATA_ARTIFACTS} ${WORKDIR}
+COPY ${KATA_ARTIFACTS} /
 
 # I understand that in order to be on the safer side, it'd
 # be good to have the alpine packages pointing to a very
@@ -37,4 +63,7 @@ RUN \
 	pip install --no-cache-dir yq==3.2.3 --break-system-packages
 
 COPY scripts ${DESTINATION}/scripts
+COPY nydus-snapshotter ${DESTINATION}/nydus-snapshotter
+COPY --from=nydus-binary-downloader /opt/nydus-snapshotter/bin/containerd-nydus-grpc ${DESTINATION}/nydus-snapshotter/
+COPY --from=nydus-binary-downloader /opt/nydus-snapshotter/bin/nydus-overlayfs ${DESTINATION}/nydus-snapshotter/
 COPY runtimeclasses ${DESTINATION}/runtimeclasses

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -72,6 +72,8 @@ spec:
           value: {{ .Values.env.installationPrefix | quote }}
         - name: MULTI_INSTALL_SUFFIX
           value: {{ .Values.env.multiInstallSuffix | quote }}
+        - name: EXPERIMENTAL_SETUP_SNAPSHOTTER
+          value: {{ .Values.env._experimentalSetupSnapshotter | quote }}
 {{- with .Values.env.hostOS }}
         - name: HOST_OS
           value: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
@@ -125,6 +125,8 @@ spec:
           value: {{ .Values.env.installationPrefix | quote }}
         - name: MULTI_INSTALL_SUFFIX
           value: {{ .Values.env.multiInstallSuffix | quote }}
+        - name: EXPERIMENTAL_SETUP_SNAPSHOTTER
+          value: {{ .Values.env._experimentalSetupSnapshotter | quote }}
 {{- with .Values.env.hostOS }}
         - name: HOST_OS
           value: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -25,3 +25,4 @@ env:
   installationPrefix: ""
   hostOS: ""
   multiInstallSuffix: ""
+  _experimentalSetupSnapshotter: ""

--- a/tools/packaging/kata-deploy/nydus-snapshotter/config-guest-pulling.toml
+++ b/tools/packaging/kata-deploy/nydus-snapshotter/config-guest-pulling.toml
@@ -1,0 +1,15 @@
+version = 1
+
+# Snapshotter's own home directory where it stores and creates necessary resources
+root = "/var/lib/containerd-nydus"
+
+# The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
+address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+
+[daemon]
+# Enable proxy mode
+fs_driver = "proxy"
+
+[snapshot]
+# Insert Kata volume information to `Mount.Options`
+enable_kata_volume = true

--- a/tools/packaging/kata-deploy/nydus-snapshotter/nydus-snapshotter.service
+++ b/tools/packaging/kata-deploy/nydus-snapshotter/nydus-snapshotter.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nydus snapshotter
+After=network.target local-fs.target
+Before=containerd.service
+
+[Service]
+ExecStart=/usr/local/bin/containerd-nydus-grpc --config /etc/nydus-snapshotter/config-guest-pulling.toml --log-to-stdout
+
+[Install]
+RequiredBy=containerd.service

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -673,7 +673,9 @@ function configure_containerd() {
 	fi
 
 	if [ $use_containerd_drop_in_conf_file = "true" ]; then
-		tomlq -i -t $(printf '.imports|=.+["%s"]' ${containerd_drop_in_conf_file}) ${containerd_conf_file}
+		if ! grep -q "${containerd_drop_in_conf_file}" ${containerd_conf_file}; then
+			tomlq -i -t $(printf '.imports|=.+["%s"]' ${containerd_drop_in_conf_file}) ${containerd_conf_file}
+		fi
 	fi
 
 	for shim in "${shims[@]}"; do

--- a/versions.yaml
+++ b/versions.yaml
@@ -344,6 +344,8 @@ externals:
     url: "https://github.com/dragonflyoss/image-service"
     version: "v2.2.3"
 
+  # Keep the version here aligned with the NYDUS_SNAPSHOTTER_VERSION
+  # on tools/packaging/kata-deploy/Dockerfile
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"


### PR DESCRIPTION
Please, see each commit message for a better explanation of what each commit does.