### PR TITLE
docs: Document behavior of BlockDevice hostPath volumes 

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -166,6 +166,15 @@ moment.
 See [this issue](https://github.com/kata-containers/runtime/issues/2812) for more details.
 [Another issue](https://github.com/kata-containers/kata-containers/issues/1728) focuses on the case of `emptyDir`.
 
+### Kubernetes [hostPath][k8s-hostpath] volumes
+
+When the source path of a hostPath volume is under `/dev`, and the path
+either corresponds to a host device or is not accessible by the Kata
+shim, the Kata agent bind mounts the source path directly from the
+*guest* filesystem into the container.
+
+[k8s-hostpath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+
 ## Host resource sharing
 
 ### Privileged containers

--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -168,16 +168,22 @@ See [this issue](https://github.com/kata-containers/runtime/issues/2812) for mor
 
 ### Kubernetes [hostPath][k8s-hostpath] volumes
 
-When the source path of a hostPath volume is under `/dev`, and the path
-either corresponds to a host device or is not accessible by the Kata
-shim, the Kata agent bind mounts the source path directly from the
-*guest* filesystem into the container.
+In some cases, the behavior of hostPath volumes is different compared
+to `runc` containers:
+
+**Mounting guest devices**: When the source path of a hostPath volume is
+under `/dev`, and the path either corresponds to a host device or is not
+accessible by the Kata shim, the Kata agent bind mounts the source path
+directly from the *guest* filesystem into the container.
+
+**Mounting host block devices**: When a hostPath volume is of type
+[`BlockDevice`](k8s-blockdevice), Kata hotplugs the host block device
+into the guest and exposes it directly to the container.
 
 [k8s-hostpath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
+[k8s-blockdevice]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath-volume-types
 
-## Host resource sharing
-
-### Privileged containers
+## Privileged containers
 
 Privileged support in Kata is essentially different from `runc` containers.
 The container runs with elevated capabilities within the guest and is granted

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -469,8 +469,15 @@ func (c *Container) mountSharedDirMounts(ctx context.Context, sharedDirMounts, i
 
 		// Ignore /dev, directories and all other device files. We handle
 		// only regular files in /dev. It does not make sense to pass the host
-		// device nodes to the guest.
-		if isHostDevice(m.Destination) {
+		// device nodes to the guest. We also ignore inaccessible host
+		// devices in case we're mounting a device that is only
+		// accessible in the guest.
+		//
+		// Note: K8s/containerd seems to create the source path as a
+		// directory on the host if it does not already exist.
+		// isHostDevice() will still return true in that case, so the
+		// above contract holds.
+		if isDevice, err := isHostDevice(m.Source); isDevice || err != nil {
 			continue
 		}
 

--- a/src/runtime/virtcontainers/mount_linux_test.go
+++ b/src/runtime/virtcontainers/mount_linux_test.go
@@ -255,7 +255,7 @@ func TestIsHostDevice(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		result := isHostDevice(test.mnt)
+		result, _ := isHostDevice(test.mnt)
 		assert.Equal(result, test.expected)
 	}
 }

--- a/src/runtime/virtcontainers/mount_test.go
+++ b/src/runtime/virtcontainers/mount_test.go
@@ -65,7 +65,9 @@ func TestIsHostDeviceCreateFile(t *testing.T) {
 	assert.NoError(err)
 	f.Close()
 
-	assert.False(isHostDevice(path))
+	isDevice, err := isHostDevice(path)
+	assert.False(isDevice)
+	assert.NoError(err)
 	assert.NoError(os.Remove(path))
 }
 

--- a/tests/cmd/check-spelling/data/main.txt
+++ b/tests/cmd/check-spelling/data/main.txt
@@ -40,6 +40,7 @@ filesystem/AB
 freeform
 goroutine/AB
 hostname/AB
+hostPath
 hotplug/ACD
 howto/AB
 HugePage/AB

--- a/tests/cmd/check-spelling/kata-dictionary.dic
+++ b/tests/cmd/check-spelling/kata-dictionary.dic
@@ -89,7 +89,6 @@ MACVTAP/AB
 MDEV/AB
 MITRE/B
 MacOS/B
-MgLRU
 Mellanox/B
 Minikube/B
 MonitorTest/A
@@ -105,7 +104,6 @@ OVMF/AB
 OpenAPI
 OpenCensus/B
 OpenPGP/B
-OpenSSF/B
 OpenSSL/B
 OpenSUSE/B
 OpenShift/B
@@ -225,7 +223,6 @@ cpuset/AB
 cri-o/B
 crypto
 cryptoprocessor/AB
-ctl
 dbs
 deliverable/AB
 deploy
@@ -237,7 +234,6 @@ dialog/A
 dind/B
 distro/AB
 dracut/B
-dragonball
 emptydir/A
 enablement/AB
 entrypoint/AB
@@ -288,7 +284,6 @@ longterm
 loopback
 macOS/B
 mem/B
-memcg
 memcpy/A
 memdisk/B
 mergeable
@@ -312,7 +307,6 @@ openSUSE/B
 openshift/B
 osbuilder/B
 packagecloud/B
-pagetypeinfo
 parallelize/AC
 passthrough
 patchset/A
@@ -327,7 +321,6 @@ ppc64le/B
 pre
 prefetch/ACD
 prestart
-proc
 programmatically
 proxying
 ramdisk/A

--- a/tests/cmd/check-spelling/kata-dictionary.dic
+++ b/tests/cmd/check-spelling/kata-dictionary.dic
@@ -1,4 +1,4 @@
-401
+402
 ACPI/AB
 ACS/AB
 API/AB
@@ -250,6 +250,7 @@ gic
 golang/B
 goroutine/AB
 gpu
+hostPath
 hostname/AB
 hotplug/ACD
 howto/AB

--- a/tests/integration/kubernetes/k8s-hostpath-volume.bats
+++ b/tests/integration/kubernetes/k8s-hostpath-volume.bats
@@ -1,0 +1,57 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2025 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	setup_common
+	get_pod_config_dir
+
+    pod_name="hostpath-kmsg"
+	yaml_file="${pod_config_dir}/pod-hostpath-kmsg.yaml"
+
+	cmd_mountinfo=(sh -c "grep /dev/kmsg /proc/self/mountinfo")
+	cmd_stat=(sh -c "stat -c '%t,%T' /dev/kmsg")
+	cmd_head=(sh -c "head -10 /dev/kmsg")
+
+    policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+	add_exec_to_policy_settings "${policy_settings_dir}" "${cmd_mountinfo[@]}"
+	add_exec_to_policy_settings "${policy_settings_dir}" "${cmd_stat[@]}"
+	add_exec_to_policy_settings "${policy_settings_dir}" "${cmd_head[@]}"
+	add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
+	auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
+}
+
+@test "/dev hostPath volume bind mounts the guest device and skips virtio-fs" {
+	kubectl apply -f "${yaml_file}"
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_name}"
+
+	# Check the mount info.
+
+	mount_info="$(kubectl exec "${pod_name}" -- "${cmd_mountinfo[@]}")"
+	read root mountpoint fstype < <(awk '{print $4, $5, $9}' <<< "$mount_info")
+
+	[ "$root" == "/kmsg" ] # Would look like "/<CONTAINER_ID>-<RANDOM_ID>-kmsg" with virtio-fs.
+	[ "$mountpoint" == "/dev/kmsg" ]
+	[ "$fstype" == "devtmpfs" ] # Would be "virtiofs" with virtio-fs.
+
+	# Check the device major/minor.
+
+	majminor="$(kubectl exec "${pod_name}" -- "${cmd_stat[@]}")"
+	[ "$majminor" == "1,b" ]
+
+	# Check that the device is actually accessible.
+
+	kubectl exec "${pod_name}" -- "${cmd_head[@]}"
+}
+
+teardown() {
+	delete_tmp_policy_settings_dir "${policy_settings_dir}"
+	teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -60,6 +60,7 @@ else
 		"k8s-exec.bats" \
 		"k8s-file-volume.bats" \
 		"k8s-hostname.bats" \
+		"k8s-hostpath-volume.bats" \
 		"k8s-inotify.bats" \
 		"k8s-ip6tables.bats" \
 		"k8s-job.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-hostpath-kmsg.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-hostpath-kmsg.yaml
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2025 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hostpath-kmsg
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  restartPolicy: Never
+  volumes:
+  - name: dev-kmsg
+    hostPath:
+      path: /dev/kmsg
+  containers:
+  - image: quay.io/prometheus/busybox:latest 
+    name: container
+    volumeMounts:
+    - name: dev-kmsg
+      mountPath: /dev/kmsg


### PR DESCRIPTION
This is a follow-up to https://github.com/kata-containers/kata-containers/pull/11832.