### PR TITLE
Add NVIDIA CUDA vectoradd test and refactor NIM test

### DIFF
--- a/tests/integration/kubernetes/k8s-nvidia-cuda.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-cuda.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2025 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+RUNTIME_CLASS_NAME=${RUNTIME_CLASS_NAME:-kata-qemu-nvidia-gpu}
+export RUNTIME_CLASS_NAME
+
+POD_NAME_CUDA="cuda-vectoradd-kata"
+export POD_NAME_CUDA
+
+setup() {
+    setup_common
+    get_pod_config_dir
+
+    pod_name="${POD_NAME_CUDA}"
+    pod_yaml_in="${pod_config_dir}/nvidia-cuda-vectoradd.yaml.in"
+    pod_yaml="${pod_config_dir}/nvidia-cuda-vectoradd.yaml"
+
+    # Substitute environment variables in the YAML template
+    envsubst < "${pod_yaml_in}" > "${pod_yaml}"
+
+}
+
+@test "CUDA Vector Addition Test" {
+    # Create the CUDA pod
+    kubectl apply -f "${pod_yaml}"
+
+    # Wait for pod to complete successfully
+    kubectl wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s pod "${pod_name}"
+
+    # Get and verify the output contains expected CUDA success message
+    output=$(kubectl logs "${pod_name}")
+    echo "# CUDA Vector Add Output: ${output}" >&3
+
+    # The CUDA vectoradd sample outputs "Test PASSED" on success
+    [[ "${output}" =~ "Test PASSED" ]]
+}
+
+teardown() {
+    # Debugging information
+    kubectl describe pod "${pod_name}" || true
+    kubectl logs "${pod_name}" || true
+
+    teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -58,12 +58,6 @@ create_inference_embedqa_pods() {
     echo "# POD_IP_EMBEDQA=${POD_IP_EMBEDQA}" >&3
 }
 
-enable_nvrc_trace() {
-    if [[ ${RUNTIME_CLASS_NAME} == "kata-qemu-nvidia-gpu" ]]; then
-        config_file="/opt/kata/share/defaults/kata-containers/configuration-qemu-nvidia-gpu.toml"
-    fi
-    sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 nvrc.log=trace"/g' "${config_file}"
-}
 
 setup_file() {
     dpkg -s jq >/dev/null 2>&1 || sudo apt -y install jq
@@ -89,7 +83,6 @@ setup_file() {
     export POD_INSTRUCT_YAML="${pod_instruct_yaml}"
     export POD_EMBEDQA_YAML="${pod_embedqa_yaml}"
 
-    enable_nvrc_trace
 
     setup_langchain_flow
     create_inference_embedqa_pods
@@ -292,7 +285,7 @@ embedding_path = "./data/nv_embedding"
 docsearch = FAISS.load_local(folder_path=embedding_path, embeddings=embedding_model, allow_dangerous_deserialization=True)
 EOF
 
-    # shellcheck disable=SC2031  # Variables are used in heredoc, not subshell  
+    # shellcheck disable=SC2031  # Variables are used in heredoc, not subshell
     cat <<EOF >>"${HOME}"/.cicd/venv/langchain_nim_kata_rag.py
 llm = ChatNVIDIA(base_url="http://${POD_IP_INSTRUCT}:8000/v1", model="meta/llama3-8b-instruct", temperature=0.1, max_tokens=1000, top_p=1.0)
 

--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -18,6 +18,9 @@ export POD_NAME_EMBEDQA="nvidia-nim-llama-3-2-nv-embedqa-1b-v2"
 
 export LOCAL_NIM_CACHE="/opt/nim/.cache"
 
+SKIP_MULTI_GPU_TESTS=${SKIP_MULTI_GPU_TESTS:-false}
+export SKIP_MULTI_GPU_TESTS
+
 DOCKER_CONFIG_JSON=$(
     echo -n "{\"auths\":{\"nvcr.io\":{\"username\":\"\$oauthtoken\",\"password\":\"${NGC_API_KEY}\",\"auth\":\"$(echo -n "\$oauthtoken:${NGC_API_KEY}" | base64 -w0)\"}}}" |
         base64 -w0
@@ -36,29 +39,6 @@ setup_langchain_flow() {
     [[ "$(pip show beautifulsoup4 2>/dev/null | awk '/^Version:/{print $2}')" = "4.13.4" ]] || pip install beautifulsoup4==4.13.4
 }
 
-create_inference_embedqa_pods() {
-    kubectl apply -f "${POD_INSTRUCT_YAML}"
-    kubectl apply -f "${POD_EMBEDQA_YAML}"
-
-    kubectl wait --for=condition=Ready --timeout=500s pod "${POD_NAME_INSTRUCT}"
-    kubectl wait --for=condition=Ready --timeout=500s pod "${POD_NAME_EMBEDQA}"
-
-    # shellcheck disable=SC2030  # Variable is shared via file between BATS tests
-    POD_IP_INSTRUCT=$(kubectl get pod "${POD_NAME_INSTRUCT}" -o jsonpath='{.status.podIP}')
-    [[ -n "${POD_IP_INSTRUCT}" ]]
-
-    # shellcheck disable=SC2030  # Variable is shared via file between BATS tests
-    POD_IP_EMBEDQA=$(kubectl get pod "${POD_NAME_EMBEDQA}" -o jsonpath='{.status.podIP}')
-    [[ -n "${POD_IP_EMBEDQA}" ]]
-
-    echo "POD_IP_INSTRUCT=${POD_IP_INSTRUCT}" >"${BATS_SUITE_TMPDIR}/env"
-    echo "# POD_IP_INSTRUCT=${POD_IP_INSTRUCT}" >&3
-
-    echo "POD_IP_EMBEDQA=${POD_IP_EMBEDQA}" >>"${BATS_SUITE_TMPDIR}/env"
-    echo "# POD_IP_EMBEDQA=${POD_IP_EMBEDQA}" >&3
-}
-
-
 setup_file() {
     dpkg -s jq >/dev/null 2>&1 || sudo apt -y install jq
 
@@ -68,6 +48,8 @@ setup_file() {
 
     # shellcheck disable=SC1091  # Virtual environment will be created during test execution
     python3 -m venv "${HOME}"/.cicd/venv
+
+    setup_langchain_flow
 
     get_pod_config_dir
 
@@ -83,9 +65,19 @@ setup_file() {
     export POD_INSTRUCT_YAML="${pod_instruct_yaml}"
     export POD_EMBEDQA_YAML="${pod_embedqa_yaml}"
 
+    touch "${BATS_SUITE_TMPDIR}/env"
+}
 
-    setup_langchain_flow
-    create_inference_embedqa_pods
+@test "Create and verify instruct pod startup" {
+    kubectl apply -f "${POD_INSTRUCT_YAML}"
+    kubectl wait --for=condition=Ready --timeout=500s pod "${POD_NAME_INSTRUCT}"
+
+    # shellcheck disable=SC2030  # Variable is shared via file between BATS tests
+    POD_IP_INSTRUCT=$(kubectl get pod "${POD_NAME_INSTRUCT}" -o jsonpath='{.status.podIP}')
+    [[ -n "${POD_IP_INSTRUCT}" ]]
+
+    echo "POD_IP_INSTRUCT=${POD_IP_INSTRUCT}" >"${BATS_SUITE_TMPDIR}/env"
+    echo "# POD_IP_INSTRUCT=${POD_IP_INSTRUCT}" >&3
 }
 
 @test "List of models available for inference" {
@@ -165,7 +157,30 @@ EOF
     echo "# ANSWER: ${ANSWER}" >&3
 }
 
+@test "Create and verify embedqa pod startup" {
+    [ "${SKIP_MULTI_GPU_TESTS}" = "true" ] && skip "indicated to skip tests requiring multiple GPUs"
+
+    # shellcheck disable=SC1091  # File is created by previous test
+    source "${BATS_SUITE_TMPDIR}/env"
+    # shellcheck disable=SC2031  # Variables are shared via file between BATS tests
+    [[ -n "${POD_IP_EMBEDQA}" ]]
+    # shellcheck disable=SC2031  # Variables are shared via file between BATS tests
+    [[ -n "${POD_IP_INSTRUCT}" ]]
+
+    kubectl apply -f "${POD_EMBEDQA_YAML}"
+    kubectl wait --for=condition=Ready --timeout=500s pod "${POD_NAME_EMBEDQA}"
+
+    # shellcheck disable=SC2030  # Variable is shared via file between BATS tests
+    POD_IP_EMBEDQA=$(kubectl get pod "${POD_NAME_EMBEDQA}" -o jsonpath='{.status.podIP}')
+    [[ -n "${POD_IP_EMBEDQA}" ]]
+
+    echo "POD_IP_EMBEDQA=${POD_IP_EMBEDQA}" >>"${BATS_SUITE_TMPDIR}/env"
+    echo "# POD_IP_EMBEDQA=${POD_IP_EMBEDQA}" >&3
+}
+
 @test "Kata Documentation RAG" {
+    [ "${SKIP_MULTI_GPU_TESTS}" = "true" ] && skip "indicated to skip tests requiring multiple GPUs"
+
     # shellcheck disable=SC1091  # File is created by previous test
     source "${BATS_SUITE_TMPDIR}/env"
     # shellcheck disable=SC2031  # Variables are shared via file between BATS tests
@@ -325,6 +340,6 @@ EOF
 }
 
 teardown_file() {
-        kubectl delete -f "${POD_INSTRUCT_YAML}"
-        kubectl delete -f "${POD_EMBEDQA_YAML}"
+    kubectl delete -f "${POD_INSTRUCT_YAML}" --ignore-not-found=true
+    kubectl delete -f "${POD_EMBEDQA_YAML}" --ignore-not-found=true
 }

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-cuda-vectoradd.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-cuda-vectoradd.yaml.in
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2025 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${POD_NAME_CUDA}
+  labels:
+    app: ${POD_NAME_CUDA}
+spec:
+  runtimeClassName: ${RUNTIME_CLASS_NAME}
+  restartPolicy: Never
+  containers:
+  - name: cuda-vectoradd
+    image: "nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda11.7.1-ubuntu20.04"
+    resources:
+      limits:
+        nvidia.com/pgpu: "1"
+        memory: 16Gi


### PR DESCRIPTION
This PR adds a CUDA vectoradd test case, makes enabling NVRC tracing optional and idempotent.
Further, this PR changes the existing NVIDIA NIM bats file logic to allow skipping test cases which require multiple GPUs. This can be helpful for test clusters where there is only one node with a single GPU, or for local test environments with a single-node cluster with a single GPU.