### PR TITLE
tests: k8s: test default_vcpus > 1

### DIFF
--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -16,8 +16,8 @@ setup() {
 
 	setup_common
 	get_pod_config_dir
-	pods=( "vcpus-less-than-one-with-no-limits" "vcpus-less-than-one-with-limits" "vcpus-more-than-one-with-limits" )
-	expected_vcpus=( 1 1 2 )
+	pods=( "vcpus-less-than-one-with-no-limits" "vcpus-less-than-one-with-limits" "vcpus-more-than-one-with-limits" "vcpus-default-more-than-one" )
+	expected_vcpus=( 1 1 2 4 )
 
 	yaml_file="${pod_config_dir}/pod-sandbox-vcpus-allocation.yaml"
 	set_node "$yaml_file" "$node"
@@ -35,7 +35,7 @@ setup() {
 	kubectl wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=$timeout pod --all
 
 	# Check the pods
-	for i in {0..2}; do
+	for i in {0..3}; do
 		pod="${pods[$i]}"
 		bats_unbuffered_info "Getting log for pod: ${pod}"
 

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-sandbox-vcpus-allocation.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-sandbox-vcpus-allocation.yaml
@@ -51,3 +51,17 @@ spec:
         cpu: "1.2"
     command: ['nproc', '--all']
   restartPolicy: Never
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vcpus-default-more-than-one
+  annotations:
+    io.katacontainers.config.hypervisor.default_vcpus: "4"
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: vcpus-default-more-than-one
+    image: quay.io/prometheus/busybox:latest
+    command: ['nproc', '--all']
+  restartPolicy: Never


### PR DESCRIPTION
Add simple test for default_vcpus = 4, in an attempt to expose possible issues related to Kata Shim variables similar to:

queues := int(q.config.NumVCPUs())

Other CI tests are executed with just 1 vCPU.