### PR TITLE
kata-deploy: Allow users to set experimental_force_guest_pull

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -74,6 +74,8 @@ spec:
           value: {{ .Values.env.multiInstallSuffix | quote }}
         - name: EXPERIMENTAL_SETUP_SNAPSHOTTER
           value: {{ .Values.env._experimentalSetupSnapshotter | quote }}
+        - name: EXPERIMENTAL_FORCE_GUEST_PULL
+          value: {{ .Values.env._experimentalForceGuestPull | quote }}
 {{- with .Values.env.hostOS }}
         - name: HOST_OS
           value: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
@@ -127,6 +127,8 @@ spec:
           value: {{ .Values.env.multiInstallSuffix | quote }}
         - name: EXPERIMENTAL_SETUP_SNAPSHOTTER
           value: {{ .Values.env._experimentalSetupSnapshotter | quote }}
+        - name: EXPERIMENTAL_FORCE_GUEST_PULL
+          value: {{ .Values.env._experimentalForceGuestPull | quote }}
 {{- with .Values.env.hostOS }}
         - name: HOST_OS
           value: {{ . | quote }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -26,3 +26,4 @@ env:
   hostOS: ""
   multiInstallSuffix: ""
   _experimentalSetupSnapshotter: ""
+  _experimentalForceGuestPull: ""

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -65,6 +65,9 @@ IFS=',' read -a pull_types <<< "$PULL_TYPE_MAPPING"
 EXPERIMENTAL_SETUP_SNAPSHOTTER="${EXPERIMENTAL_SETUP_SNAPSHOTTER:-}"
 IFS=',' read -a experimental_setup_snapshotter <<< "${EXPERIMENTAL_SETUP_SNAPSHOTTER}"
 
+EXPERIMENTAL_FORCE_GUEST_PULL="${EXPERIMENTAL_FORCE_GUEST_PULL:-}"
+IFS="," read -a experimental_force_guest_pull <<< "${EXPERIMENTAL_FORCE_GUEST_PULL}"
+
 INSTALLATION_PREFIX="${INSTALLATION_PREFIX:-}"
 default_dest_dir="/opt/kata"
 dest_dir="${default_dest_dir}"
@@ -422,6 +425,10 @@ function install_artifacts() {
 
 		if [ -n "${allowed_hypervisor_annotations}" ]; then
 			sed -i -e "s/^enable_annotations = \[\(.*\)\]/enable_annotations = [\1, $allowed_hypervisor_annotations]/" "${kata_config_file}"
+		fi
+
+		if printf '%s\n' "${experimental_force_guest_pull[@]}" | grep -Fxq "${shim}"; then
+			sed -i -e 's/^\(experimental_force_guest_pull\).*=.*$/\1 = true/g' "${kata_config_file}"
 		fi
 
 		if grep -q "tdx" <<< "$shim"; then
@@ -958,6 +965,7 @@ function main() {
 	echo "* MULTI_INSTALL_SUFFIX: ${MULTI_INSTALL_SUFFIX}"
 	echo "* HELM_POST_DELETE_HOOK: ${HELM_POST_DELETE_HOOK}"
 	echo "* EXPERIMENTAL_SETUP_SNAPSHOTTER: ${EXPERIMENTAL_SETUP_SNAPSHOTTER}"
+	echo "* EXPERIMENTAL_FORCE_GUEST_PULL: ${EXPERIMENTAL_FORCE_GUEST_PULL}"
 
 	# script requires that user is root
 	euid=$(id -u)


### PR DESCRIPTION
For those who are not willing to use the nydus-snapshotter for pulling the image inside the guest, let's allow them setting the experimetal_force_guest_pull, introduced by Edgeless, as part of our helm-chart.

This option can be set as:
_experimentalForceGuestPull: "qemu-tdx,qemu-coco-dev"

Which would them ensure that the configuration for `qemu-tdx` and `qemu-coco-dev` would have the option enabled.