### PR TITLE
virtcontainers: fix nydus cleanup on rootfs unmount

### DIFF
--- a/src/runtime/virtcontainers/mount_linux.go
+++ b/src/runtime/virtcontainers/mount_linux.go
@@ -184,7 +184,7 @@ func bindUnmountAllRootfs(ctx context.Context, sharedDir string, sandbox *Sandbo
 		if c.state.Fstype == "" {
 			// even if error found, don't break out of loop until all mounts attempted
 			// to be unmounted, and collect all errors
-			if IsNydusRootFSType(c.state.Fstype) {
+			if IsNydusRootFSType(c.rootFs.Type) {
 				errors = merr.Append(errors, nydusContainerCleanup(ctx, sharedDir, c))
 			} else {
 				errors = merr.Append(errors, bindUnmountContainerRootfs(ctx, sharedDir, c.id))


### PR DESCRIPTION
This was discovered by @sprt in https://github.com/kata-containers/kata-containers/pull/10243#discussion_r2373709407. Checking for state.Fstype makes no sense as we know it is empty.