### PR TITLE
gha: Fix `docs-url-alive-check` workflow

### DIFF
--- a/.github/workflows/docs-url-alive-check.yaml
+++ b/.github/workflows/docs-url-alive-check.yaml
@@ -1,6 +1,7 @@
 on:
   schedule:
     - cron:  '0 23 * * 0'
+  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
```
commit f4bb5e68089a1d306b0c9890abb15dd7c0bebac7 (HEAD -> sprt/remove-docs-url-check)
Author: Aurélien Bombo <abombo@microsoft.com>
Date:   Wed Oct 8 11:52:12 2025 -0500

    gha: Add `workflow_dispatch` trigger to `docs-url-alive-check`
    
    We can't test this PR because the workflow needs this trigger, so adding
    this will allow testing future PRs.
    
    Signed-off-by: Aurélien Bombo <abombo@microsoft.com>

commit 3aea814e7c3c55b57bd87d6e9d70755f8b5756a5
Author: Aurélien Bombo <abombo@microsoft.com>
Date:   Wed Oct 8 11:51:07 2025 -0500

    gha: Fix docs-url-alive-check workflow
    
    The Go installation step was broken because the checkout action was
    checking out the code in a subdirectory:
    
    https://github.com/kata-containers/kata-containers/actions/runs/18265538456/job/51999316919
    
    Signed-off-by: Aurélien Bombo <abombo@microsoft.com>
```