### PR TITLE
gpu: PPCIE support DGX like systems

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
@@ -198,13 +198,14 @@ prepare_distribution_drivers() {
 
 	eval "${APT_INSTALL}" nvidia-headless-no-dkms-"${driver_version}${driver_type}" \
 		nvidia-firmware-"${driver_version}"  \
-        nvidia-imex-"${driver_version}"      \
+		nvidia-imex-"${driver_version}"      \
 		libnvidia-cfg1-"${driver_version}"   \
-        libnvidia-gl-"${driver_version}"     \
-        libnvidia-extra-"${driver_version}"  \
-        libnvidia-decode-"${driver_version}" \
-        libnvidia-fbc1-"${driver_version}"   \
-        libnvidia-encode-"${driver_version}"
+		libnvidia-gl-"${driver_version}"     \
+		libnvidia-extra-"${driver_version}"  \
+		libnvidia-decode-"${driver_version}" \
+		libnvidia-fbc1-"${driver_version}"   \
+		libnvidia-encode-"${driver_version}" \
+		libnvidia-nscq-"${driver_version}"
 }
 
 prepare_nvidia_drivers() {

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -145,10 +145,24 @@ chisseled_iptables() {
 	cp -a "${stage_one}/${libdir}"/libxtables.so.12* lib/.
 }
 
+# <= NVLINK4 nv-fabrimanager
+# >= NVLINK5 nv-fabricmanager + nvlsm (TODO)
 chisseled_nvswitch() {
 	echo "nvidia: chisseling NVSwitch"
-	echo "nvidia: not implemented yet"
-	exit 1
+
+	mkdir -p usr/share/nvidia/nvswitch
+
+	cp -a "${stage_one}"/usr/bin/nv-fabricmanager 	bin/.
+	cp -a "${stage_one}"/usr/share/nvidia/nvswitch usr/share/nvidia/.
+
+	libdir=usr/lib/"${machine_arch}"-linux-gnu
+
+	cp -a "${stage_one}/${libdir}"/libnvidia-nscq.so.* lib/"${machine_arch}"-linux-gnu/.
+
+	# Logs will be redirected to console(stderr)
+	# if the specified log file can't be opened or the path is empty.
+	# LOG_FILE_NAME=/var/log/fabricmanager.log -> setting to empty for stderr -> kmsg
+	sed -i 's|^LOG_FILE_NAME=.*|LOG_FILE_NAME=|' usr/share/nvidia/nvswitch/fabricmanager.cfg
 }
 
 chisseled_dcgm() {


### PR DESCRIPTION
For DGX like systems we need additional binaries and libraries, enable the Kata AND CoCo use-case.