### PR TITLE
cdi: Add Crate remove Github Hash

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -666,30 +666,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cdi"
-version = "0.1.0"
-source = "git+https://github.com/cncf-tags/container-device-interface-rs?rev=3b1e83dda5efcc83c7a4f134466ec006b37109c9#3b1e83dda5efcc83c7a4f134466ec006b37109c9"
-dependencies = [
- "anyhow",
- "clap",
- "const_format",
- "jsonschema",
- "lazy_static",
- "libc",
- "nix 0.24.3",
- "notify",
- "oci-spec",
- "once_cell",
- "path-clean",
- "regex",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "serde_yaml",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,6 +782,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "container-device-interface"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "653849f0c250f73d9afab4b2a9a6b07adaee1f34c44ffa6f2d2c3f9392002c1a"
+dependencies = [
+ "anyhow",
+ "clap",
+ "const_format",
+ "jsonschema",
+ "lazy_static",
+ "libc",
+ "nix 0.24.3",
+ "notify",
+ "oci-spec",
+ "once_cell",
+ "path-clean",
+ "regex",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_yaml",
 ]
 
 [[package]]
@@ -2049,11 +2050,11 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "capctl",
- "cdi",
  "cfg-if",
  "cgroups-rs",
  "clap",
  "const_format",
+ "container-device-interface",
  "derivative",
  "futures",
  "ipnetwork",

--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -167,9 +167,6 @@ clap.workspace = true
 strum.workspace = true
 strum_macros.workspace = true
 
-# Agent Policy
-cdi = { git = "https://github.com/cncf-tags/container-device-interface-rs", rev = "3b1e83dda5efcc83c7a4f134466ec006b37109c9" }
-
 # Local dependencies
 kata-agent-policy = { workspace = true, optional = true }
 mem-agent.workspace = true
@@ -188,6 +185,8 @@ vsock-exporter.workspace = true
 base64 = "0.22"
 sha2 = "0.10.8"
 async-compression = { version = "0.4.22", features = ["tokio", "gzip"] }
+
+container-device-interface = "0.1.0"
 
 [target.'cfg(target_arch = "s390x")'.dependencies]
 pv_core = { git = "https://github.com/ibm-s390-linux/s390-tools", rev = "4942504a9a2977d49989a5e5b7c1c8e07dc0fa41", package = "s390_pv_core" }

--- a/src/agent/src/device/mod.rs
+++ b/src/agent/src/device/mod.rs
@@ -15,6 +15,7 @@ use anyhow::{anyhow, Context, Result};
 use cdi::annotations::parse_annotations;
 use cdi::cache::{new_cache, with_auto_refresh, CdiOption};
 use cdi::spec_dirs::with_spec_dirs;
+use container_device_interface as cdi;
 use kata_types::device::DeviceHandlerManager;
 use nix::sys::stat;
 use oci::{LinuxDeviceCgroup, Spec};


### PR DESCRIPTION
Use CDI exclusively from crates.io and not from a GH repository. Cargo can easily check if a new version is available and we can far more easier bump it if needed.