### PR TITLE
ci: Enable new ibm runners

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -7,8 +7,8 @@
 self-hosted-runner:
   # Labels of self-hosted runner that linter should ignore
   labels:
+    - amd64-nvidia-a100
     - arm64-k8s
-    - ubuntu-22.04-arm
     - garm-ubuntu-2004
     - garm-ubuntu-2004-smaller
     - garm-ubuntu-2204
@@ -16,6 +16,7 @@ self-hosted-runner:
     - garm-ubuntu-2304-smaller
     - garm-ubuntu-2204-smaller
     - k8s-ppc64le
+    - ubuntu-24.04-ppc64le
     - metrics
     - ppc64le
     - riscv-builder
@@ -23,4 +24,5 @@ self-hosted-runner:
     - s390x
     - s390x-large
     - tdx
-    - amd64-nvidia-a100
+    - ubuntu-22.04-arm
+    - ubuntu-24.04-s390x

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -32,7 +32,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ppc64le
+    runs-on: ubuntu-24.04-ppc64le
     strategy:
       matrix:
         asset:
@@ -89,7 +89,7 @@ jobs:
 
   build-asset-rootfs:
     name: build-asset-rootfs
-    runs-on: ppc64le
+    runs-on: ubuntu-24.04-ppc64le
     needs: build-asset
     permissions:
       contents: read
@@ -170,7 +170,7 @@ jobs:
 
   build-asset-shim-v2:
     name: build-asset-shim-v2
-    runs-on: ppc64le
+    runs-on: ubuntu-24.04-ppc64le
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     permissions:
       contents: read
@@ -230,7 +230,7 @@ jobs:
 
   create-kata-tarball:
     name: create-kata-tarball
-    runs-on: ppc64le
+    runs-on: ubuntu-24.04-ppc64le
     needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
     permissions:
       contents: read

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -32,7 +32,7 @@ permissions: {}
 jobs:
   build-asset:
     name: build-asset
-    runs-on: s390x
+    runs-on: ubuntu-24.04-s390x
     permissions:
       contents: read
       packages: write
@@ -257,7 +257,7 @@ jobs:
 
   build-asset-shim-v2:
     name: build-asset-shim-v2
-    runs-on: s390x
+    runs-on: ubuntu-24.04-s390x
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     permissions:
       contents: read
@@ -319,7 +319,7 @@ jobs:
 
   create-kata-tarball:
     name: create-kata-tarball
-    runs-on: s390x
+    runs-on: ubuntu-24.04-s390x
     needs:
       - build-asset
       - build-asset-rootfs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -159,7 +159,7 @@ jobs:
       tag: ${{ inputs.tag }}-s390x
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
-      runner: s390x
+      runner: ubuntu-24.04-s390x
       arch: s390x
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}

--- a/.github/workflows/static-checks-self-hosted.yaml
+++ b/.github/workflows/static-checks-self-hosted.yaml
@@ -29,8 +29,8 @@ jobs:
       matrix:
         instance:
           - "ubuntu-22.04-arm"
-          - "s390x"
-          - "ppc64le"
+          - "ubuntu-24.04-s390x"
+          - "ubuntu-24.04-ppc64le"
     uses: ./.github/workflows/build-checks.yaml
     with:
       instance: ${{ matrix.instance }}


### PR DESCRIPTION
We have some scalable s390x and ppc runners, so start to use them for build and test, to improve the throughput of our CI

Some CI tested in https://github.com/kata-containers/kata-containers/actions/runs/18375732270, but we don't have a way to test the "self-hosted" static checks at the moment, so we might hit issues with them and be quick to fix/remove them from required.