### PR TITLE
CI: Add dedicated expected error message for runtime-rs

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -178,6 +178,15 @@ setup() {
 
     # The pod should be failed because the image is too large to be pulled in the timeout
     assert_pod_fail "$pod_config"
+
+    # runtime-rs has its dedicated error message, we need handle it separately.
+    if [ "${KATA_HYPERVISOR}" == "qemu-coco-dev-runtime-rs" ]; then
+        pod_name="large-image-pod"
+        kubectl describe "pod/$pod_name" | grep "agent create container"
+        kubectl describe "pod/$pod_name" | grep "timeout"
+        return
+	fi
+
     assert_logs_contain "$node" kata "$node_start_time" 'createContainer failed'
     assert_logs_contain "$node" kata "$node_start_time" 'timeout'
 }


### PR DESCRIPTION
Runtime-rs has its dedicated error message, we need handle it separately when agent creates container with error timeout.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>