### PR TITLE
runtime: preserve rootfs mount options for block devices

### DIFF
--- a/src/runtime/virtcontainers/fs_share_linux.go
+++ b/src/runtime/virtcontainers/fs_share_linux.go
@@ -689,8 +689,22 @@ func (f *FilesystemShare) ShareRootFilesystem(ctx context.Context, c *Container)
 		rootfsStorage.MountPoint = filepath.Join(kataGuestSharedDir(), c.id)
 		rootfsStorage.Fstype = c.state.Fstype
 
+		// Start with the original rootfs mount options
+		rootfsStorage.Options = c.rootFs.Options
+
+		// Add filesystem-specific options
 		if c.state.Fstype == "xfs" {
-			rootfsStorage.Options = []string{"nouuid"}
+			// Add nouuid to existing options if not already present
+			hasNouuid := false
+			for _, opt := range rootfsStorage.Options {
+				if opt == "nouuid" {
+					hasNouuid = true
+					break
+				}
+			}
+			if !hasNouuid {
+				rootfsStorage.Options = append(rootfsStorage.Options, "nouuid")
+			}
 		}
 
 		// Ensure container mount destination exists

--- a/src/runtime/virtcontainers/fs_share_linux_test.go
+++ b/src/runtime/virtcontainers/fs_share_linux_test.go
@@ -14,7 +14,10 @@ import (
 	"syscall"
 	"testing"
 
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/api"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/agent/protocols/grpc"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 )
@@ -165,6 +168,129 @@ func TestShareRootFilesystem(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		"block device rootfs with mount options": {
+			fsSharer: requireNewFilesystemShare(&Sandbox{
+				config: &SandboxConfig{
+					HypervisorConfig: HypervisorConfig{
+						BlockDeviceDriver: "virtio-scsi",
+					},
+				},
+				devManager: &mockDeviceManager{
+					devices: map[string]api.Device{
+						"block-device-123": &mockBlockDevice{
+							deviceInfo: &config.BlockDrive{
+								SCSIAddr: "0:0:0:0",
+							},
+						},
+					},
+				},
+			}),
+			container: &Container{
+				id:           "container-id-abc",
+				rootfsSuffix: "test-suffix",
+				rootFs: RootFs{
+					Source:  "/dev/sda1",
+					Type:    "ext4",
+					Options: []string{"rw", "discard", "noatime"},
+				},
+				state: types.ContainerState{
+					Fstype:        "ext4",
+					BlockDeviceID: "block-device-123",
+				},
+			},
+			wantSharedFile: &SharedFile{
+				containerStorages: []*grpc.Storage{{
+					MountPoint: "/run/kata-containers/shared/containers/container-id-abc",
+					Source:     "0:0:0:0",
+					Fstype:     "ext4",
+					Driver:     "scsi",
+					Options:    []string{"rw", "discard", "noatime"},
+				}},
+				guestPath: "/run/kata-containers/shared/containers/container-id-abc/test-suffix",
+			},
+		},
+		"xfs block device rootfs with nouuid": {
+			fsSharer: requireNewFilesystemShare(&Sandbox{
+				config: &SandboxConfig{
+					HypervisorConfig: HypervisorConfig{
+						BlockDeviceDriver: "virtio-scsi",
+					},
+				},
+				devManager: &mockDeviceManager{
+					devices: map[string]api.Device{
+						"block-device-456": &mockBlockDevice{
+							deviceInfo: &config.BlockDrive{
+								SCSIAddr: "0:0:0:1",
+							},
+						},
+					},
+				},
+			}),
+			container: &Container{
+				id:           "container-id-xyz",
+				rootfsSuffix: "test-suffix",
+				rootFs: RootFs{
+					Source:  "/dev/sdb1",
+					Type:    "xfs",
+					Options: []string{"rw", "noatime"},
+				},
+				state: types.ContainerState{
+					Fstype:        "xfs",
+					BlockDeviceID: "block-device-456",
+				},
+			},
+			wantSharedFile: &SharedFile{
+				containerStorages: []*grpc.Storage{{
+					MountPoint: "/run/kata-containers/shared/containers/container-id-xyz",
+					Source:     "0:0:0:1",
+					Fstype:     "xfs",
+					Driver:     "scsi",
+					Options:    []string{"rw", "noatime", "nouuid"},
+				}},
+				guestPath: "/run/kata-containers/shared/containers/container-id-xyz/test-suffix",
+			},
+		},
+		"xfs block device rootfs with existing nouuid": {
+			fsSharer: requireNewFilesystemShare(&Sandbox{
+				config: &SandboxConfig{
+					HypervisorConfig: HypervisorConfig{
+						BlockDeviceDriver: "virtio-scsi",
+					},
+				},
+				devManager: &mockDeviceManager{
+					devices: map[string]api.Device{
+						"block-device-789": &mockBlockDevice{
+							deviceInfo: &config.BlockDrive{
+								SCSIAddr: "0:0:0:2",
+							},
+						},
+					},
+				},
+			}),
+			container: &Container{
+				id:           "container-id-def",
+				rootfsSuffix: "test-suffix",
+				rootFs: RootFs{
+					Source:  "/dev/sdc1",
+					Type:    "xfs",
+					Options: []string{"rw", "nouuid", "noatime"},
+				},
+				state: types.ContainerState{
+					Fstype:        "xfs",
+					BlockDeviceID: "block-device-789",
+				},
+			},
+			wantSharedFile: &SharedFile{
+				containerStorages: []*grpc.Storage{{
+					MountPoint: "/run/kata-containers/shared/containers/container-id-def",
+					Source:     "0:0:0:2",
+					Fstype:     "xfs",
+					Driver:     "scsi",
+					Options:    []string{"rw", "nouuid", "noatime"},
+				}},
+				guestPath: "/run/kata-containers/shared/containers/container-id-def/test-suffix",
+			},
+		},
 	}
 
 	for name, tc := range testCases {
@@ -181,4 +307,96 @@ func TestShareRootFilesystem(t *testing.T) {
 			assert.Equal(tc.wantSharedFile, sharedFile)
 		})
 	}
+}
+
+// Mock types for testing block device rootfs functionality
+
+type mockDeviceManager struct {
+	devices map[string]api.Device
+}
+
+func (m *mockDeviceManager) NewDevice(config.DeviceInfo) (api.Device, error) {
+	return nil, nil
+}
+
+func (m *mockDeviceManager) RemoveDevice(string) error {
+	return nil
+}
+
+func (m *mockDeviceManager) AttachDevice(context.Context, string, api.DeviceReceiver) error {
+	return nil
+}
+
+func (m *mockDeviceManager) DetachDevice(context.Context, string, api.DeviceReceiver) error {
+	return nil
+}
+
+func (m *mockDeviceManager) IsDeviceAttached(string) bool {
+	return false
+}
+
+func (m *mockDeviceManager) GetDeviceByID(id string) api.Device {
+	return m.devices[id]
+}
+
+func (m *mockDeviceManager) GetAllDevices() []api.Device {
+	return nil
+}
+
+func (m *mockDeviceManager) LoadDevices([]config.DeviceState) {
+}
+
+func (m *mockDeviceManager) FindDevice(*config.DeviceInfo) api.Device {
+	return nil
+}
+
+type mockBlockDevice struct {
+	deviceInfo *config.BlockDrive
+}
+
+func (m *mockBlockDevice) DeviceID() string {
+	return "mock-device-id"
+}
+
+func (m *mockBlockDevice) DeviceType() config.DeviceType {
+	return config.DeviceBlock
+}
+
+func (m *mockBlockDevice) GetDeviceInfo() interface{} {
+	return m.deviceInfo
+}
+
+func (m *mockBlockDevice) Attach(context.Context, api.DeviceReceiver) error {
+	return nil
+}
+
+func (m *mockBlockDevice) Detach(context.Context, api.DeviceReceiver) error {
+	return nil
+}
+
+func (m *mockBlockDevice) GetMajorMinor() (int64, int64) {
+	return 8, 0
+}
+
+func (m *mockBlockDevice) GetHostPath() string {
+	return "/dev/mock"
+}
+
+func (m *mockBlockDevice) GetAttachCount() uint {
+	return 0
+}
+
+func (m *mockBlockDevice) Reference() uint {
+	return 0
+}
+
+func (m *mockBlockDevice) Dereference() uint {
+	return 0
+}
+
+func (m *mockBlockDevice) Save() config.DeviceState {
+	return config.DeviceState{}
+}
+
+func (m *mockBlockDevice) Load(config.DeviceState) {
 }


### PR DESCRIPTION
Fixes a bug where mount options from the original rootfs were being ignored when creating block device storage objects. Previously, only XFS filesystems got any mount options (hardcoded 'nouuid'), while all other filesystem types lost their original mount options entirely.

This fix preserves all original rootfs mount options for block devices, and maintains XFS-specific 'nouuid' option behavior.

Fixes: #11919