### PR TITLE
build: Fix nvidia kernel breakage

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -1346,9 +1346,16 @@ handle_build() {
 				pushd "${kernel_headers_dir}"
 				find . -type f -name "*.${KERNEL_HEADERS_PKG_TYPE}" -exec tar -rvf kernel-headers.tar {} +
 				if [ -n "${KBUILD_SIGN_PIN}" ]; then
-					head -n1 kata-linux-*/certs/signing_key.pem | grep -q "ENCRYPTED PRIVATE KEY" || die "signing_key.pem is not encrypted"
-					mv kata-linux-*/certs/signing_key.pem .
-					mv kata-linux-*/certs/signing_key.x509 .
+					# For those 2 we can simply do a `|| true` as the signing_key.{pem,x509} are either:
+					# * already in ., as we're using a cached tarball
+					# * will be moved here, in case we had built the kernel
+					mv kata-linux-*/certs/signing_key.pem . || true
+					mv kata-linux-*/certs/signing_key.x509 . || true
+
+					# Then we can check for the key on ., as it should always be here on both cases
+					# (cached or built kernel).
+					head -n1 "signing_key.pem" | grep -q "ENCRYPTED PRIVATE KEY" || die "signing_key.pem is not encrypted"
+
 					tar -rvf kernel-headers.tar signing_key.pem signing_key.x509 --remove-files
 				fi
 				zstd -T0 kernel-headers.tar -o kernel-headers.tar.zst


### PR DESCRIPTION
On commit 9602ba6ccc5fb4f5a5f65849db96c3be6f83a600, from February this year, we've introduced a check to ensure that the files needed for signing the kernel build are present. However, we've noticed last week that there were a reasonable amount of wrong assumptions with the workflow. :-)

Zvonko fixed the majority of those, but this bit was left and it'd cause breakages when using kernel that was cached ... although passing when building new kernels.