### PR TITLE
genpolicy: support fsGroup setting in pod security context

### DIFF
--- a/src/tools/genpolicy/src/cronjob.rs
+++ b/src/tools/genpolicy/src/cronjob.rs
@@ -100,7 +100,7 @@ impl yaml::K8sResource for CronJob {
             storages,
             container,
             settings,
-            &self.spec.jobTemplate.spec.template.spec.volumes,
+            &self.spec.jobTemplate.spec.template.spec,
         );
     }
 

--- a/src/tools/genpolicy/src/daemon_set.rs
+++ b/src/tools/genpolicy/src/daemon_set.rs
@@ -103,7 +103,7 @@ impl yaml::K8sResource for DaemonSet {
             storages,
             container,
             settings,
-            &self.spec.template.spec.volumes,
+            &self.spec.template.spec,
         );
     }
 

--- a/src/tools/genpolicy/src/deployment.rs
+++ b/src/tools/genpolicy/src/deployment.rs
@@ -114,7 +114,7 @@ impl yaml::K8sResource for Deployment {
             storages,
             container,
             settings,
-            &self.spec.template.spec.volumes,
+            &self.spec.template.spec,
         );
     }
 

--- a/src/tools/genpolicy/src/job.rs
+++ b/src/tools/genpolicy/src/job.rs
@@ -112,7 +112,7 @@ impl yaml::K8sResource for Job {
             storages,
             container,
             settings,
-            &self.spec.template.spec.volumes,
+            &self.spec.template.spec,
         );
     }
 

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -878,7 +878,7 @@ impl yaml::K8sResource for Pod {
             storages,
             container,
             settings,
-            &self.spec.volumes,
+            &self.spec,
         );
     }
 

--- a/src/tools/genpolicy/src/replica_set.rs
+++ b/src/tools/genpolicy/src/replica_set.rs
@@ -73,7 +73,7 @@ impl yaml::K8sResource for ReplicaSet {
             storages,
             container,
             settings,
-            &self.spec.template.spec.volumes,
+            &self.spec.template.spec,
         );
     }
 

--- a/src/tools/genpolicy/src/replication_controller.rs
+++ b/src/tools/genpolicy/src/replication_controller.rs
@@ -76,7 +76,7 @@ impl yaml::K8sResource for ReplicationController {
             storages,
             container,
             settings,
-            &self.spec.template.spec.volumes,
+            &self.spec.template.spec,
         );
     }
 

--- a/src/tools/genpolicy/src/stateful_set.rs
+++ b/src/tools/genpolicy/src/stateful_set.rs
@@ -147,7 +147,7 @@ impl yaml::K8sResource for StatefulSet {
             storages,
             container,
             settings,
-            &self.spec.template.spec.volumes,
+            &self.spec.template.spec,
         );
     }
 

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -23,7 +23,6 @@ use crate::secret;
 use crate::settings;
 use crate::stateful_set;
 use crate::utils::Config;
-use crate::volume;
 
 use async_trait::async_trait;
 use core::fmt::Debug;
@@ -292,9 +291,9 @@ pub fn get_container_mounts_and_storages(
     storages: &mut Vec<agent::Storage>,
     container: &pod::Container,
     settings: &settings::Settings,
-    volumes_option: &Option<Vec<volume::Volume>>,
+    podSpec: &pod::PodSpec,
 ) {
-    if let Some(volumes) = volumes_option {
+    if let Some(volumes) = &podSpec.volumes {
         if let Some(volume_mounts) = &container.volumeMounts {
             for volume in volumes {
                 for volume_mount in volume_mounts {
@@ -305,6 +304,7 @@ pub fn get_container_mounts_and_storages(
                             storages,
                             volume,
                             volume_mount,
+                            &podSpec.securityContext,
                         );
                     }
                 }

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -316,6 +316,11 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_container_security_context_fsgroup() {
+        runtests("createcontainer/security_context/fsgroup").await;
+    }
+
+    #[tokio::test]
     async fn test_create_container_volumes_empty_dir() {
         runtests("createcontainer/volumes/emptydir").await;
     }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+spec:
+  runtimeClassName: kata-cc-isolation
+  securityContext:
+    fsGroup: 1000
+  containers:
+  - name: dummy
+    image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    volumeMounts:
+    - name: tmp
+      mountPath: /mnt
+  volumes:
+  - name: tmp
+    emptyDir: {}

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/testcases.json
@@ -1,0 +1,358 @@
+[
+  {
+    "allowed": true,
+    "description": "a pod with PodSecurityContext.fsGroup set should be allowed",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.kubernetes.cri.container-name": "dummy",
+          "io.kubernetes.cri.container-type": "container",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db",
+          "io.kubernetes.cri.sandbox-id": "ba77faf442028eb9f3d849acb8ff55f3bc7e35d579dddcfec43fe75de2e7b2da",
+          "io.kubernetes.cri.sandbox-name": "dummy",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "d52808f4-575a-4036-b767-db84e7dcffee"
+        },
+        "Hooks": null,
+        "Hostname": "",
+        "Linux": {
+          "CgroupsPath": "kubepods-besteffort-podd52808f4_575a_4036_b767_db84e7dcffee.slice:cri-containerd:f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": [
+            "/proc/asound",
+            "/proc/acpi",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/proc/scsi",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {
+              "Cpus": "",
+              "Mems": "",
+              "Period": 100000,
+              "Quota": 0,
+              "RealtimePeriod": 0,
+              "RealtimeRuntime": 0,
+              "Shares": 2
+            },
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": {
+              "DisableOOMKiller": false,
+              "Kernel": 0,
+              "KernelTCP": 0,
+              "Limit": 0,
+              "Reservation": 0,
+              "Swap": 0,
+              "Swappiness": 0
+            },
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {
+            "destination": "/proc",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "proc",
+            "type_": "proc"
+          },
+          {
+            "destination": "/dev",
+            "options": [
+              "nosuid",
+              "strictatime",
+              "mode=755",
+              "size=65536k"
+            ],
+            "source": "tmpfs",
+            "type_": "tmpfs"
+          },
+          {
+            "destination": "/dev/pts",
+            "options": [
+              "nosuid",
+              "noexec",
+              "newinstance",
+              "ptmxmode=0666",
+              "mode=0620",
+              "gid=5"
+            ],
+            "source": "devpts",
+            "type_": "devpts"
+          },
+          {
+            "destination": "/dev/mqueue",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "mqueue",
+            "type_": "mqueue"
+          },
+          {
+            "destination": "/sys",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "ro"
+            ],
+            "source": "sysfs",
+            "type_": "sysfs"
+          },
+          {
+            "destination": "/sys/fs/cgroup",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "relatime",
+              "ro"
+            ],
+            "source": "cgroup",
+            "type_": "cgroup"
+          },
+          {
+            "destination": "/mnt",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/ba77faf442028eb9f3d849acb8ff55f3bc7e35d579dddcfec43fe75de2e7b2da/rootfs/local/tmp",
+            "type_": "local"
+          },
+          {
+            "destination": "/etc/hosts",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d-521df6f0b97ea722-hosts",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/termination-log",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d-8b3f5a9bcaeaa4e0-termination-log",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/hostname",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d-9f47d09f90943f8a-hostname",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/resolv.conf",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d-c9ef6ca2ae90bef8-resolv.conf",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/shm",
+            "options": [
+              "rbind"
+            ],
+            "source": "/run/kata-containers/sandbox/shm",
+            "type_": "bind"
+          },
+          {
+            "destination": "/var/run/secrets/kubernetes.io/serviceaccount",
+            "options": [
+              "rbind",
+              "rprivate",
+              "ro"
+            ],
+            "source": "/run/kata-containers/shared/containers/f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d-aae236b47a43d28a-serviceaccount",
+            "type_": "bind"
+          }
+        ],
+        "Process": {
+          "ApparmorProfile": "cri-containerd.apparmor.d",
+          "Args": [
+            "/pause"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HOSTNAME=dummy",
+            "KUBERNETES_SERVICE_PORT_HTTPS=443",
+            "KUBERNETES_PORT=tcp://10.0.0.1:443",
+            "KUBERNETES_PORT_443_TCP=tcp://10.0.0.1:443",
+            "KUBERNETES_PORT_443_TCP_PROTO=tcp",
+            "KUBERNETES_PORT_443_TCP_PORT=443",
+            "KUBERNETES_PORT_443_TCP_ADDR=10.0.0.1",
+            "KUBERNETES_SERVICE_HOST=10.0.0.1",
+            "KUBERNETES_SERVICE_PORT=443"
+          ],
+          "NoNewPrivileges": false,
+          "OOMScoreAdj": 1000,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              0,
+              1000
+            ],
+            "GID": 0,
+            "UID": 65535,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d/rootfs",
+          "Readonly": false
+        },
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d",
+      "devices": [],
+      "exec_id": "f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"dummy\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db\",\"io.kubernetes.cri.sandbox-id\":\"ba77faf442028eb9f3d849acb8ff55f3bc7e35d579dddcfec43fe75de2e7b2da\",\"io.kubernetes.cri.sandbox-name\":\"dummy\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"d52808f4-575a-4036-b767-db84e7dcffee\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/f86ec3cfa9c5e5a732744dbe844033126f0fdd84408df8809d19274b448e255d/rootfs",
+          "options": [],
+          "source": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+        },
+        {
+          "driver": "local",
+          "driver_options": [],
+          "fs_group": null,
+          "fstype": "local",
+          "mount_point": "/run/kata-containers/shared/containers/ba77faf442028eb9f3d849acb8ff55f3bc7e35d579dddcfec43fe75de2e7b2da/rootfs/local/tmp",
+          "options": [
+            "mode=0777",
+            "fsgid=1000"
+          ],
+          "source": "local"
+        }
+      ],
+      "string_user": null
+    }
+  }
+]


### PR DESCRIPTION
The runtime handles the `fsGroup` field of the pod security context by adding a mount option to the generated storage object. 

https://github.com/kata-containers/kata-containers/blob/0c6fcde198196580d02a34a6b27eb21376a4d95c/src/runtime/virtcontainers/kata_agent.go#L1620-L1625

This commit changes genpolicy to expect this option.

Instead of passing another side input to `yaml::get_container_mounts_and_storages`, we pass the entire `PodSpec`. This reduces the necessary changes in the pod-generating resources and allows for possible future use of other `PodSpec` fields.

Fixes: #11934