### PR TITLE
ci.ocp: Use helm to install kata

### DIFF
--- a/ci/openshift-ci/cluster/install_kata.sh
+++ b/ci/openshift-ci/cluster/install_kata.sh
@@ -173,13 +173,13 @@ wait_for_app_pods_message() {
 	local namespace="$5"
 	[[ -z "${pod_count}" ]] && pod_count=1
 	[[ -z "${timeout}" ]] && timeout=60
-	[[ -n "${namespace}" ]] && namespace=" -n ${namespace} "
+	[[ -n "${namespace}" ]] && namespace=("-n" "${namespace}")
 	local pod
 	local pods
 	local i
 	SECONDS=0
 	while :; do
-		mapfile -t pods < <(oc get pods -l app="${app}" --no-headers=true "${namespace}" | awk '{print $1}')
+		mapfile -t pods < <(oc get pods -l app="${app}" --no-headers=true "${namespace[@]}" | awk '{print $1}')
 		[[ "${#pods}" -ge "${pod_count}" ]] && break
 		if [[ "${SECONDS}" -gt "${timeout}" ]]; then
 			printf "Unable to find ${pod_count} pods for '-l app=\"${app}\"' in ${SECONDS}s (%s)" "${pods[@]}"
@@ -189,7 +189,7 @@ wait_for_app_pods_message() {
 	local log
 	for pod in "${pods[@]}"; do
 		while :; do
-			log=$(oc logs "${namespace}" "${pod}")
+			log=$(oc logs "${namespace[@]}" "${pod}")
 			echo "${log}" | grep "${message}" -q && echo "Found $(echo "${log}" | grep "${message}") in ${pod}'s log (${SECONDS})" && break;
 			if [[ "${SECONDS}" -gt "${timeout}" ]]; then
 				echo -n "Message '${message}' not present in '${pod}' pod of the '-l app=\"${app}\"' "


### PR DESCRIPTION
Upstream moved towards helm to deploy kata-containers, updating the OCP ci pipeline script to reflect that.

The second commit originates here https://github.com/kata-containers/kata-containers/pull/11648 the only extra change is a missing `[@]` in `namespaces`.