### PR TITLE
ci.ocp: Install helm in local dir

### DIFF
--- a/ci/openshift-ci/cluster/install_kata.sh
+++ b/ci/openshift-ci/cluster/install_kata.sh
@@ -44,8 +44,9 @@ WORKAROUND_9206_CRIO=${WORKAROUND_9206_CRIO:-no}
 #
 apply_kata_deploy() {
 	if ! command -v helm &>/dev/null; then
-		echo "Helm not installed, installing..."
-		curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+		echo "Helm not installed, installing in current location..."
+		PATH=".:${PATH}"
+		curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | HELM_INSTALL_DIR='.' bash -s -- --no-sudo
 	fi
 
 	oc label --overwrite ns kube-system pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/warn=baseline pod-security.kubernetes.io/audit=baseline


### PR DESCRIPTION
in CI helm is not yet installed and we don't have root access. Let's use the current dir, which should be writable, and --no-sudo option to install it.

Note when helm is installed it should not change anything and simply use the syste-wide installation.

Related failure: https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-kata-containers-kata-containers-main-e2e-tests/1978359226262622208