### PR TITLE
helm: Add missing documentation

### DIFF
--- a/tests/cmd/check-spelling/kata-dictionary.dic
+++ b/tests/cmd/check-spelling/kata-dictionary.dic
@@ -1,4 +1,4 @@
-402
+403
 ACPI/AB
 ACS/AB
 API/AB
@@ -33,6 +33,7 @@ Docker/B
 Dockerfile/AB
 Dragonball/B
 EulerOS/B
+erofs/A
 FS/AB
 FaaS/B
 Facebook/B
@@ -303,6 +304,7 @@ namespace/ABCD
 netlink
 netns/AB
 nvidia/A
+nydus/A
 onwards
 openSUSE/B
 openshift/B

--- a/tools/packaging/kata-deploy/helm-chart/README.md
+++ b/tools/packaging/kata-deploy/helm-chart/README.md
@@ -139,6 +139,8 @@ All values can be overridden with --set key=value or a custom `-f myvalues.yaml`
 | `env.installationPrefix` | Prefix where to install the Kata artifacts | `/opt/kata` |
 | `env.hostOS` | Provide host-OS setting, e.g. `cbl-mariner` to do additional configurations | `""` |
 | `env.multiInstallSuffix` | Enable multiple Kata installation on the same node with suffix e.g. `/opt/kata-PR12232` | `""` |
+| `env._experimentalSetupSnapshotter` | Deploys (nydus) and/or sets up (erofs, nydus) the snapshotter(s) specified as the value (supports multiple snapshotters, separated by commas; e.g., `nydus,erofs`) | `""` |
+| `env._experimentalForceGuestPull` | Enables `experimental_force_guest_pull` for the shim(s) specified as the value (supports multiple shims, separated by commas; e.g., `qemu-tdx,qemu-snp`) | `""` |
 
 ## Example: only `qemu` shim and debug enabled
 


### PR DESCRIPTION
We've recently added support for:
* deploying and setting up a snapshotter, via _experimentalSetupSnapshotter
* enabling experimental_force_guest_pull, via _experimentalForceGuestPull

However, we never updated the documentation for those, thus let's do it now.