### PR TITLE
tests: Install Go from reliable mirror

### DIFF
--- a/tests/install_go.sh
+++ b/tests/install_go.sh
@@ -93,7 +93,7 @@ goarch=$(arch_to_golang)
 
 info "Download go version ${go_version}"
 kernel_name=$(uname -s | tr '[:upper:]' '[:lower:]')
-curl -OL "https://storage.googleapis.com/golang/go${go_version}.${kernel_name}-${goarch}.tar.gz"
+curl -OL  -w "http status: %{http_code}\n" "https://go.dev/dl/go${go_version}.${kernel_name}-${goarch}.tar.gz"
 info "Install go"
 mkdir -p "${install_dest}"
 sudo tar -C "${install_dest}" -xzf "go${go_version}.${kernel_name}-${goarch}.tar.gz"


### PR DESCRIPTION
```
Downloading Go from storage.googleapis.com fails intermittently with a 403 (see error below) so we switch to go.dev as referenced at https://go.dev/dl/.

/tmp/install-go-tmp.Rw5Q4thEWr ~/work/kata-containers/kata-containers /usr/bin/go
[install_go.sh:85] INFO: removing go version go1.24.9 linux/amd64 [install_go.sh:94] INFO: Download go version 1.24.6
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed

  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
100   298  100   298    0     0   2610      0 --:--:-- --:--:-- --:--:--  2614
[install_go.sh:97] INFO: Install go

gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
[install_go.sh:99] ERROR: sudo tar -C /usr/local/ -xzf go1.24.6.linux-amd64.tar.gz

https://github.com/kata-containers/kata-containers/actions/runs/18602801597/job/53045072109?pr=11947#step:5:17
```