### PR TITLE
build: remove version suffix for imex, nscq

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
@@ -219,16 +219,19 @@ prepare_distribution_drivers() {
 
 	eval "${APT_INSTALL}" nvidia-utils-"${driver_version}"
 
+	# FIXME: the driver_version variable was removed from nvidia-imex and libnvidia-nscq
+	# because these packages in NVIDIA's repository do not contain the -580 version suffix
+	# despite currently being published in latest major version 580.
 	eval "${APT_INSTALL}" nvidia-headless-no-dkms-"${driver_version}${driver_type}" \
 		nvidia-firmware-"${driver_version}"  \
-		nvidia-imex-"${driver_version}"      \
+		nvidia-imex                          \
 		libnvidia-cfg1-"${driver_version}"   \
 		libnvidia-gl-"${driver_version}"     \
 		libnvidia-extra-"${driver_version}"  \
 		libnvidia-decode-"${driver_version}" \
 		libnvidia-fbc1-"${driver_version}"   \
 		libnvidia-encode-"${driver_version}" \
-		libnvidia-nscq-"${driver_version}"
+		libnvidia-nscq
 }
 
 prepare_nvidia_drivers() {


### PR DESCRIPTION
This change re-enables the broken NVIDIA GPU rootfs build, see currently failing CI runs: https://github.com/kata-containers/kata-containers/actions/runs/18594469030 as brought up by @stevenhorsman.

In this change, we temporarily remove the `driver_version` suffixes from the `nvidia-imex` and `libnvidia-nscq` packages to ensure we install these two packages from the NVIDIA repository. The NVIDIA repository does not publish these packages with a -580 version suffix (despite being published in major version 580), which made us fall back to the Ubuntu repository for exactly these two packages (a while ago already). Note, these packages are the only two packages we install which lack the -580 suffix.

These two packages were recently updated by Ubuntu to depend on `nvidia-kernel-common-580-server` (see the changes from `580.82.07-0ubuntu1` to `580.95.05-0ubuntu1`), which conflicts with `nvidia-kernel-common-580`. The latter package, however, gets already installed by `nvidia-headless-no-dkms-580-open`, thus causing a build failure.

Here is what NVIDIA publishes as of Oct 18th per: https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/Packages.gz

```
Package: libnvidia-nscq
Version: 580.95.05-1
Provides: libnvidia-nscq-580, nscq2
Maintainer: NVIDIA <cudatools@nvidia.com>

Package: nvidia-imex
Version: 580.95.05-1
Provides: nvidia-imex-580
Maintainer: NVIDIA <cudatools@nvidia.com>

Package: nvidia-utils-580
Version: 580.95.05-0ubuntu1
Maintainer: NVIDIA <cudatools@nvidia.com>
NOTE: The nvidia-utils package is not published in version -580 by Ubuntu!
```

Here is what Ubuntu publishes as of today per: http://us.archive.ubuntu.com/ubuntu/dists/noble-updates/multiverse/binary-amd64/Packages.gz
```
Package: nvidia-imex-580
Version: 580.95.05-0ubuntu0.24.04.2
Maintainer: Ubuntu Core Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Provides: nvidia-imex
Depends: nvidia-kernel-common-580-server (= 580.95.05-0ubuntu0.24.04.2)

Package: libnvidia-nscq-580
Version: 580.95.05-0ubuntu0.24.04.2
Maintainer: Ubuntu Core Developers <ubuntu-devel-discuss@lists.ubuntu.com>
Provides: libnvidia-nscq, nscq2
Depends: nvidia-kernel-common-580-server (= 580.95.05-0ubuntu0.24.04.2)
```

**Note:**
This change ensures we consistently keep using packages from the prioritized NVIDIA repository. If we do not want to take this version suffix removing change, we will need a change that allows us to re-enable build with Ubuntu's libnvidia-nscq-580 and nvidia-imex-580 packages. At the moment, this would require shifting to use Ubuntu's package repository for which I have a diff here: https://github.com/kata-containers/kata-containers/compare/main...manuelh-dev:kata-containers:mahuber/chroot-use-server?expand=1. This, from my current perspective, seems dissatisfying as well. A better way could be for NVIDIA to publish the "libnvidia-nscq-580" and "nvidia-imex-580" packages explicitly, assuming Ubuntu will not make a change on their end. We will be following up this and improve the situation.