### PR TITLE
genpolicy: allow non-watchable ConfigMaps

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -229,7 +229,7 @@
     "common": {
         "cpath": "/run/kata-containers/shared/containers",
         "root_path": "/run/kata-containers/$(bundle-id)/rootfs",
-        "sfprefix": "^$(cpath)/$(bundle-id)-[a-z0-9]{16}-",
+        "sfprefix": "^$(cpath)/(watchable/)?$(bundle-id)-[a-z0-9]{16}-",
         "ip_p": "[0-9]{1,5}",
         "ipv4_a": "(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])",
         "svc_name_downward_env": "[A-Z](?:[A-Z0-9_]{0,61}[A-Z0-9])?",

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -111,7 +111,7 @@ adapt_common_policy_settings_for_non_coco() {
 	sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
 
 	# Using watchable binds for configMap volumes - instead of CopyFileRequest.
-	jq '.volumes.configMap.mount_point = "^$(cpath)/watchable/$(bundle-id)-[a-z0-9]{16}-" | .volumes.configMap.driver = "watchable-bind"' \
+	jq '.volumes.configMap.driver = "watchable-bind"' \
 		"${settings_dir}/genpolicy-settings.json" > temp.json
 	sudo mv temp.json "${settings_dir}/genpolicy-settings.json"
 


### PR DESCRIPTION
If a ConfigMap has more than 8 files it will not be mounted watchable [1]. However, genpolicy assumes that ConfigMaps are always mounted at a watchable path, so containers with large ConfigMap mounts fail verification.

This commit allows mounting ConfigMaps from watchable and non-watchable directories. ConfigMap mounts can't be meaningfully verified anyway, so the exact location of the data does not matter, except that we stay in the sandbox data dirs.

[1]: https://github.com/kata-containers/kata-containers/blob/0ce3f5fc6fd86c53d8b5e197d12887b712ce57d4/docs/design/inotify.md?plain=1#L11-L21

Fixes: #11777