### PR TITLE
ci: Always refresh OIDC token before cluster deletion

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -149,6 +149,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Refresh OIDC token in case access token expired
+        if: always()
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZ_APPID }}

--- a/.github/workflows/run-kata-coco-stability-tests.yaml
+++ b/.github/workflows/run-kata-coco-stability-tests.yaml
@@ -141,6 +141,7 @@ jobs:
         run: bash tests/stability/gha-stability-run.sh run-tests
 
       - name: Refresh OIDC token in case access token expired
+        if: always()
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZ_APPID }}

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -242,6 +242,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh report-tests
 
       - name: Refresh OIDC token in case access token expired
+        if: always()
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZ_APPID }}

--- a/.github/workflows/run-kata-deploy-tests-on-aks.yaml
+++ b/.github/workflows/run-kata-deploy-tests-on-aks.yaml
@@ -104,6 +104,7 @@ jobs:
         run: bash tests/functional/kata-deploy/gha-run.sh run-tests
 
       - name: Refresh OIDC token in case access token expired
+        if: always()
         uses: azure/login@a457da9ea143d694b1b9c7c869ebb04ebe844ef5 # v2.3.0
         with:
           client-id: ${{ secrets.AZ_APPID }}


### PR DESCRIPTION
This forces OIDC token refresh even if the tests step failed, so that we also have proper credentials to delete the cluster in that case.

I first noticed the original issue here:
https://github.com/kata-containers/kata-containers/actions/runs/18659064688/job/53215379040?pr=11950