### PR TITLE
github: migrate k8s job to a different runner on ppc64le

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -19,10 +19,11 @@ self-hosted-runner:
     - garm-ubuntu-2304
     - garm-ubuntu-2304-smaller
     - garm-ubuntu-2204-smaller
-    - k8s-ppc64le
+    - ppc64le
+    - ppc64le-k8s
+    - ppc64le-small
     - ubuntu-24.04-ppc64le
     - metrics
-    - ppc64le
     - riscv-builder
     - sev-snp
     - s390x

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -179,7 +179,7 @@ jobs:
       tag: ${{ inputs.tag }}-ppc64le
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
-      runner: ppc64le
+      runner: ppc64le-small
       arch: ppc64le
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
@@ -495,7 +495,7 @@ jobs:
       tarball-suffix: -${{ inputs.tag }}
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
-      runner: ppc64le
+      runner: ppc64le-small
       arch: ppc64le
       containerd_version: ${{ matrix.params.containerd_version }}
       vmm: ${{ matrix.params.vmm }}

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -131,7 +131,7 @@ jobs:
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-latest-ppc64le
       target-branch: ${{ github.ref_name }}
-      runner: ppc64le
+      runner: ppc64le-small
       arch: ppc64le
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -31,7 +31,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    runs-on: ppc64le
+    runs-on: ppc64le-small
     steps:
       - name: Login to Kata Containers ghcr.io
         uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0

--- a/.github/workflows/run-k8s-tests-on-ppc64le.yaml
+++ b/.github/workflows/run-k8s-tests-on-ppc64le.yaml
@@ -34,7 +34,7 @@ jobs:
           - qemu
         k8s:
           - kubeadm
-    runs-on: k8s-ppc64le
+    runs-on: ppc64le-k8s
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}
@@ -63,11 +63,11 @@ jobs:
           ./tests/install_go.sh -f -p
           echo "/usr/local/go/bin" >> "$GITHUB_PATH"
 
-      - name: Prepare the runner for k8s cluster creation
-        run: bash "${HOME}/scripts/k8s_cluster_cleanup.sh"
+      - name: Prepare the runner for k8s test suite
+        run: bash "${HOME}/scripts/k8s_cluster_prepare.sh"
 
-      - name: Create k8s cluster using kubeadm
-        run: bash "${HOME}/scripts/k8s_cluster_create.sh"
+      - name: Check if cluster is healthy to run the tests
+        run: bash "${HOME}/scripts/k8s_cluster_check.sh"
 
       - name: Deploy Kata
         timeout-minutes: 10
@@ -76,6 +76,3 @@ jobs:
       - name: Run tests
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
-
-      - name: Delete cluster and post cleanup actions
-        run: bash "${HOME}/scripts/k8s_cluster_cleanup.sh"


### PR DESCRIPTION
1. Migrate the k8s job to a ppc64le-runner-02 and use a long running cluster instead of creating the cluster on every run.
2. Align all other jobs to run on runners with label ppc64le-small
