### PR TITLE
tests: mariner: use KataVmIsolation

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -128,7 +128,7 @@ function create_cluster() {
 		--node-count 1 \
 		--generate-ssh-keys \
 		--tags "${tags[@]}" \
-		$([[ "${KATA_HOST_OS}" = "cbl-mariner" ]] && echo "--os-sku AzureLinux --workload-runtime KataMshvVmIsolation")
+		$([[ "${KATA_HOST_OS}" = "cbl-mariner" ]] && echo "--os-sku AzureLinux --workload-runtime KataVmIsolation")
 }
 
 function install_bats() {


### PR DESCRIPTION
The older KataMshvVmIsolation workload type name is being replaced with KataVmIsolation.