### PR TITLE
ci: gpu: Add SNP GPU job

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,6 +8,7 @@ self-hosted-runner:
   # Labels of self-hosted runner that linter should ignore
   labels:
     - amd64-nvidia-a100
+    - amd64-nvidia-h100-snp
     - arm64-k8s
     - containerd-v1.7-overlayfs
     - containerd-v2.0-overlayfs

--- a/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
+++ b/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
@@ -35,9 +35,15 @@ jobs:
       matrix:
         vmm:
           - qemu-nvidia-gpu
+          - qemu-nvidia-gpu-snp
         k8s:
           - kubeadm
-    runs-on: amd64-nvidia-a100
+        include:
+          - vmm: qemu-nvidia-gpu
+            runner: amd64-nvidia-a100
+          - vmm: qemu-nvidia-gpu-snp
+            runner: amd64-nvidia-h100-snp
+    runs-on: ${{ matrix.runner }}
     env:
       DOCKER_REGISTRY: ${{ inputs.registry }}
       DOCKER_REPO: ${{ inputs.repo }}
@@ -66,11 +72,12 @@ jobs:
       - name: Install `bats`
         run: bash tests/integration/kubernetes/gha-run.sh install-bats
 
-      - name: Run tests
+      - name: Run tests ${{ matrix.vmm }}
         timeout-minutes: 30
         run: bash tests/integration/kubernetes/gha-run.sh run-nv-tests
         env:
           NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+
       - name: Collect artifacts ${{ matrix.vmm }}
         if: always()
         run: bash tests/integration/kubernetes/gha-run.sh collect-artifacts

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -473,6 +473,8 @@ ifneq (,$(QEMUCMD))
     KERNELTDXPARAMS_NV += "authorize_allow_devs=pci:ALL"
 
     KERNELSNPPARAMS_NV = $(KERNELPARAMS_NV)
+    #TODO: temporary until the attestation agent activates the device after successful attestation
+    KERNELSNPPARAMS_NV = "nvrc.smi.srs=1"
 
     # Setting this to false can lead to cgroup leakages in the host
     # Best practice for production is to set this to true

--- a/tests/integration/kubernetes/k8s-nvidia-cuda.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-cuda.bats
@@ -15,6 +15,9 @@ export RUNTIME_CLASS_NAME
 POD_NAME_CUDA="cuda-vectoradd-kata"
 export POD_NAME_CUDA
 
+POD_WAIT_TIMEOUT=${POD_WAIT_TIMEOUT:-300s}
+export POD_WAIT_TIMEOUT
+
 setup() {
     setup_common
     get_pod_config_dir
@@ -33,7 +36,7 @@ setup() {
     kubectl apply -f "${pod_yaml}"
 
     # Wait for pod to complete successfully
-    kubectl wait --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s pod "${pod_name}"
+    kubectl wait --for=jsonpath='{.status.phase}'=Succeeded --timeout="${POD_WAIT_TIMEOUT}" pod "${pod_name}"
 
     # Get and verify the output contains expected CUDA success message
     output=$(kubectl logs "${pod_name}")

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-cuda-vectoradd.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-cuda-vectoradd.yaml.in
@@ -9,6 +9,8 @@ metadata:
   name: ${POD_NAME_CUDA}
   labels:
     app: ${POD_NAME_CUDA}
+  annotations:
+    cdi.k8s.io/gpu: "nvidia.com/pgpu=0"
 spec:
   runtimeClassName: ${RUNTIME_CLASS_NAME}
   restartPolicy: Never

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct.yaml.in
@@ -17,6 +17,8 @@ metadata:
   name: ${POD_NAME_INSTRUCT}
   labels:
     app: ${POD_NAME_INSTRUCT}
+  annotations:
+    cdi.k8s.io/gpu: "nvidia.com/pgpu=0"
 spec:
   restartPolicy: Never
   runtimeClassName: "${RUNTIME_CLASS_NAME}"
@@ -85,4 +87,3 @@ spec:
     hostPath:
       path: "${LOCAL_NIM_CACHE}"
       type: DirectoryOrCreate
-

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2.yaml.in
@@ -17,6 +17,8 @@ metadata:
   name: nvidia-nim-llama-3-2-nv-embedqa-1b-v2
   labels:
     app: nvidia-nim-llama-3-2-nv-embedqa-1b-v2
+  annotations:
+    cdi.k8s.io/gpu: "nvidia.com/pgpu=1"
 spec:
   restartPolicy: Always
   runtimeClassName: "${RUNTIME_CLASS_NAME}"

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -21,7 +21,7 @@
   "qemu-snp" (dict "memory" "2048Mi" "cpu" "1.0")
   "qemu-tdx" (dict "memory" "2048Mi" "cpu" "1.0")
   "qemu-nvidia-gpu" (dict "memory" "4096Mi" "cpu" "1.0")
-  "qemu-nvidia-gpu-snp" (dict "memory" "4096Mi" "cpu" "1.0")
+  "qemu-nvidia-gpu-snp" (dict "memory" "16384Mi" "cpu" "1.0")
   "qemu-nvidia-gpu-tdx" (dict "memory" "4096Mi" "cpu" "1.0")
   "qemu-cca" (dict "memory" "2048Mi" "cpu" "1.0")
   "stratovirt" (dict "memory" "130Mi" "cpu" "250m")
@@ -76,4 +76,3 @@ scheduling:
 {{- end }}
 {{- end }}
 {{- end }}
-

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu-snp.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu-snp.yaml
@@ -6,7 +6,7 @@ metadata:
 handler: kata-qemu-nvidia-gpu-snp
 overhead:
     podFixed:
-        memory: "4096Mi"
+        memory: "16384Mi"
         cpu: "1"
 scheduling:
   nodeSelector:

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -84,7 +84,7 @@ metadata:
 handler: kata-qemu-nvidia-gpu-snp
 overhead:
     podFixed:
-        memory: "4096Mi"
+        memory: "16384Mi"
         cpu: "1"
 scheduling:
   nodeSelector:

--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -320,7 +320,7 @@ function is_containerd_capable_of_using_drop_in_files() {
 		echo "false"
 		return
 	fi
- 
+
 	local version_major=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}' | grep -oE '[0-9]+\.[0-9]+' | cut -d'.' -f1)
 	if [ $version_major -lt 2 ]; then
 		# Only containerd 2.0 does the merge of the plugins section from different snippets,
@@ -557,6 +557,13 @@ function install_artifacts() {
 			esac
 		fi
 
+		# TODO: this is a temporary change aiming to facilitate execution of CC-enabled GPU workloads in CI
+		# Next steps are to disable filesystem sharing and to use nydus guest pull for this handler.
+		# This will require adjustments to the pod manifest and deployment configuration.
+		if [[ "${shim}" == "qemu-nvidia-gpu-snp" ]]; then
+			sed -i -e 's/^shared_fs = "none"/shared_fs = "virtio-9p"/' "${kata_config_file}"
+		fi
+
 		if [ "${dest_dir}" != "${default_dest_dir}" ]; then
 			hypervisor="${shim}"
 			[[ "${shim}" == "qemu"* ]] && hypervisor="qemu"
@@ -766,7 +773,14 @@ function configure_containerd_runtime() {
 	tomlq -i -t $(printf '%s.runtime_type=%s' ${runtime_table} ${runtime_type}) ${configuration_file}
 	tomlq -i -t $(printf '%s.runtime_path=%s' ${runtime_table} ${runtime_path}) ${configuration_file}
 	tomlq -i -t $(printf '%s.privileged_without_host_devices=true' ${runtime_table}) ${configuration_file}
-	tomlq -i -t $(printf '%s.pod_annotations=["io.katacontainers.*"]' ${runtime_table}) ${configuration_file}
+
+	# Add CDI annotation for NVIDIA GPU SNP runtime class
+	if [[ "${shim}" == *"nvidia-gpu-snp"* ]]; then
+		tomlq -i -t $(printf '%s.pod_annotations=["io.katacontainers.*","cdi.k8s.io/*"]' ${runtime_table}) ${configuration_file}
+	else
+		tomlq -i -t $(printf '%s.pod_annotations=["io.katacontainers.*"]' ${runtime_table}) ${configuration_file}
+	fi
+
 	tomlq -i -t $(printf '%s.ConfigPath=%s' ${runtime_options_table} ${runtime_config_path}) ${configuration_file}
 
 	if [ "${DEBUG}" == "true" ]; then
@@ -1043,7 +1057,7 @@ function install_nydus_snapshotter() {
 
 	local config_guest_pulling="/opt/kata-artifacts/nydus-snapshotter/config-guest-pulling.toml"
 	local nydus_snapshotter_service="/opt/kata-artifacts/nydus-snapshotter/nydus-snapshotter.service"
-	
+
 	# Adjust the paths for the config-guest-pulling.toml and nydus-snapshotter.service
 	sed -i -e "s|@SNAPSHOTTER_ROOT_DIR@|/var/lib/${nydus_snapshotter}|g" "${config_guest_pulling}"
 	sed -i -e "s|@SNAPSHOTTER_GRPC_SOCKET_ADDRESS@|/run/${nydus_snapshotter}/containerd-nydus-grpc.sock|g" "${config_guest_pulling}"
@@ -1070,7 +1084,7 @@ function uninstall_nydus_snapshotter() {
 	if [[ -n "${MULTI_INSTALL_SUFFIX}" ]]; then
 		nydus_snapshotter="${nydus_snapshotter}-${MULTI_INSTALL_SUFFIX}"
 	fi
-	
+
 	host_systemctl disable --now "${nydus_snapshotter}.service"
 
 	rm -f "/host/etc/systemd/system/${nydus_snapshotter}.service"


### PR DESCRIPTION
This PR introduces a new SNP GPU job validating CC-enabled NVIDIA GPU deployment using the existing Kata GPU CI test cases and using a new, self-hosted CI runner.

While the primary goal of this change is to detect regressions to the NVIDIA SNP GPU scenario, various improvements to reflect a more realistic CC setting are planned in subsequent changes, such as:
1. moving away from the overlayfs snapshotter
2. disabling filesystem sharing
3. applying a pod security policy
4. activating the GPUs only after attestation
5. using a refined approach for GPU cold-plugging without requiring annotations
6. revisiting pod timeout and overhead parameters (the `podOverhead` value was increased due to CUDA vectorAdd requiring about 6Gi of podOverhead, as well as the inference and embedqa requiring at least 12Gi, respectively, 14Gi of podOverhead to run without invoking the host's oom-killer. We will revisit this aspect after addressing points 1. and 2.)