### PR TITLE
gha: no policy for cbl-mariner during ci

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -59,16 +59,13 @@ jobs:
             vmm: clh
             instance-type: small
             genpolicy-pull-method: oci-distribution
-            auto-generate-policy: yes
           - host_os: cbl-mariner
             vmm: clh
             instance-type: small
             genpolicy-pull-method: containerd
-            auto-generate-policy: yes
           - host_os: cbl-mariner
             vmm: clh
             instance-type: normal
-            auto-generate-policy: yes
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -85,7 +82,6 @@ jobs:
       USING_NFD: "false"
       K8S_TEST_HOST_TYPE: ${{ matrix.instance-type }}
       GENPOLICY_PULL_METHOD: ${{ matrix.genpolicy-pull-method }}
-      AUTO_GENERATE_POLICY: ${{ matrix.auto-generate-policy }}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:


### PR DESCRIPTION
Temporarily disable the auto-generated Agent Policy on Mariner hosts, to work around the new test failures on these hosts.

When re-enabling auto-generated policy in the future, that would be better achieved with a tests/integration/kubernetes/gha-run.sh change. Those changes are easier to test compared with GHA YAML changes.