### PR TITLE
tests: Fix cca test failure on arm64 and other architectures

### DIFF
--- a/src/runtime/virtcontainers/qemu_arm64_test.go
+++ b/src/runtime/virtcontainers/qemu_arm64_test.go
@@ -191,37 +191,32 @@ func TestQemuArm64AppendProtectionDevice(t *testing.T) {
 	// PEF protection
 	arm64.(*qemuArm64).protection = pefProtection
 	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", []byte(""))
-	assert.Empty(devices)
+	assert.Error(err)
 	assert.Empty(bios)
-	assert.NoError(err)
 
 	// Secure Execution protection
 	arm64.(*qemuArm64).protection = seProtection
 	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", []byte(""))
-	assert.Empty(devices)
+	assert.Error(err)
 	assert.Empty(bios)
-	assert.NoError(err)
 
 	// SEV protection
 	arm64.(*qemuArm64).protection = sevProtection
 	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", []byte(""))
-	assert.Empty(devices)
+	assert.Error(err)
 	assert.Empty(bios)
-	assert.NoError(err)
 
 	// SNP protection
 	arm64.(*qemuArm64).protection = snpProtection
 	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", []byte(""))
-	assert.Empty(devices)
+	assert.Error(err)
 	assert.Empty(bios)
-	assert.NoError(err)
 
 	// TDX protection
 	arm64.(*qemuArm64).protection = tdxProtection
 	devices, bios, err = arm64.appendProtectionDevice(devices, firmware, "", []byte(""))
-	assert.Empty(devices)
+	assert.Error(err)
 	assert.Empty(bios)
-	assert.NoError(err)
 
 	// CCA RME protection
 	arm64.(*qemuArm64).protection = ccaProtection

--- a/src/runtime/virtcontainers/qemu_ppc64le_test.go
+++ b/src/runtime/virtcontainers/qemu_ppc64le_test.go
@@ -92,7 +92,7 @@ func TestQemuPPC64leAppendProtectionDevice(t *testing.T) {
 
 	// CCA protection
 	ppc64le.(*qemuPPC64le).protection = ccaProtection
-	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "")
+	devices, bios, err = ppc64le.appendProtectionDevice(devices, firmware, "", []byte(nil))
 	assert.Error(err)
 	assert.Empty(bios)
 

--- a/src/runtime/virtcontainers/qemu_s390x_test.go
+++ b/src/runtime/virtcontainers/qemu_s390x_test.go
@@ -149,7 +149,7 @@ func TestQemuS390xAppendProtectionDevice(t *testing.T) {
 
 	// CCA protection
 	s390x.(*qemuS390x).protection = ccaProtection
-	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "")
+	devices, bios, err = s390x.appendProtectionDevice(devices, firmware, "", []byte(nil))
 	assert.Error(err)
 	assert.Empty(bios)
 


### PR DESCRIPTION
Fix the wrong test with appendProtectionDevice on arm64

Related with #10664 