### PR TITLE
gpu: Handle VFIO and IOMMUFD

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1095,7 +1095,13 @@ func (c *Container) annotateContainerWithVFIOMetadata(devices interface{}) {
 func (c *Container) siblingAnnotation(devPath string, siblings []DeviceRelation) {
 	for _, sibling := range siblings {
 		if sibling.Path == devPath {
-			vfioNum := filepath.Base(devPath)
+			// We have here either /dev/vfio/<num> or /dev/vfio/devices/vfio<num>
+			baseName := filepath.Base(devPath)
+			vfioNum := baseName
+			// For IOMMUFD format /dev/vfio/devices/vfio<num>, strip "vfio" prefix
+			if strings.HasPrefix(baseName, "vfio") {
+				vfioNum = strings.TrimPrefix(baseName, "vfio")
+			}
 			annoKey := fmt.Sprintf("cdi.k8s.io/vfio%s", vfioNum)
 			annoValue := fmt.Sprintf("nvidia.com/gpu=%d", sibling.Index)
 			if c.config.CustomSpec.Annotations == nil {


### PR DESCRIPTION
We have here either /dev/vfio/<num> or /dev/vfio/devices/vfio<num>, for IOMMUFD format /dev/vfio/devices/vfio<num>, strip "vfio" prefix
```
/dev/vfio/123 - basename "123" - vfioNum = "123" - cdi.k8s.io/vfio123 
/dev/vfio/devices/vfio123 - basename "vfio123" - strip - vfioNum = "123" - cdi.k8s.io/vfio123
```

The problem is that today if we have an IOMMUFD device the inner CDI annotations is created as follows: 

```
/dev/vfio/devices/vfio123 - basename -> "vfio123" = cdi.k8s.io/vfiovfio123
```
The `cdi.k8s.io/vfiovfio123` is technically not wrong since annotations do not have semantics, but we want to keep it readable; it needs to be `cdi.k8s.io/vfiov123`, the same as in the case when a `/dev/vfio/123` device is being passed-through. 


