### PR TITLE
docs: update how-to-run-rooltess-vmm.md

### DIFF
--- a/docs/how-to/how-to-run-rootless-vmm.md
+++ b/docs/how-to/how-to-run-rootless-vmm.md
@@ -1,5 +1,5 @@
 ## Introduction
-To improve security, Kata Container supports running the VMM process (QEMU and cloud-hypervisor) as a non-`root` user. 
+To improve security, Kata Container supports running the VMM process (QEMU and cloud-hypervisor) as a non-`root` user, in both runtime-go and runtime-rs. 
 This document describes how to enable the rootless VMM mode and its limitations.
 
 ## Pre-requisites


### PR DESCRIPTION
Update documentation to reflect the implementation of non-root mode for QEMU and Cloud Hypervisor in runtime-rs, as done in PR #11678 and PR #11862.

Fixes: #11414