### PR TITLE
genpolicy: Correct caps matcher for runtime-rs

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1213,7 +1213,9 @@ allow_caps(p_caps, i_caps) if {
 match_caps(p_caps, i_caps) if {
     print("match_caps 1: start")
 
-    p_caps == i_caps
+    norm_p_caps := { strip_cap_prefix(c) | c := p_caps[_] }
+    norm_i_caps := { strip_cap_prefix(c) | c := i_caps[_] }
+    norm_p_caps == norm_i_caps
 
     print("match_caps 1: true")
 }


### PR DESCRIPTION
As Caps in runtime-rs usually have no prefix with 'CAP_', we need support such caps without prefix  'CAP_' in match_caps(p_caps, i_caps).

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>