### PR TITLE
agent: Support both virtio-blk and virtio-scsi block devices for initdata

### DIFF
--- a/src/agent/src/initdata.rs
+++ b/src/agent/src/initdata.rs
@@ -39,6 +39,12 @@ pub const CDH_CONFIG_PATH: &str = concatcp!(INITDATA_PATH, "/cdh.toml");
 /// Magic number of initdata device
 pub const INITDATA_MAGIC_NUMBER: &[u8] = b"initdata";
 
+/// initdata device with disk type 'vd*'
+const INITDATA_PREFIX_DISK_VDX: &str = "vd";
+
+/// initdata device with disk type 'sd*'
+const INITDATA_PREFIX_DISK_SDX: &str = "sd";
+
 async fn detect_initdata_device(logger: &Logger) -> Result<Option<String>> {
     let dev_dir = Path::new("/dev");
     let mut read_dir = tokio::fs::read_dir(dev_dir).await?;
@@ -46,9 +52,15 @@ async fn detect_initdata_device(logger: &Logger) -> Result<Option<String>> {
         let filename = entry.file_name();
         let filename = filename.to_string_lossy();
         debug!(logger, "Initdata check device `{filename}`");
-        if !filename.starts_with("vd") {
+
+        // Currently there're two disk types supported:
+        // virtio-blk (vd*) and virtio-scsi (sd*)
+        if !filename.starts_with(INITDATA_PREFIX_DISK_VDX)
+            && !filename.starts_with(INITDATA_PREFIX_DISK_SDX)
+        {
             continue;
         }
+
         let path = entry.path();
 
         debug!(logger, "Initdata find potential device: `{path:?}`");


### PR DESCRIPTION
Currently, the initdata module only detects virtio-blk devices (/dev/vd*) when searching for the initdata block device. However, when using virtio-scsi, the devices appear as /dev/sd* in the guest, causing the initdata detection to fail.

This commit extends the device detection logic to support both device types:
- virtio-blk devices: /dev/vda, /dev/vdb, etc.
- virtio-scsi devices: /dev/sda, /dev/sdb, etc.

This commits aims to address issue of theinitdata device not being found when using virtio-scsi.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>