### PR TITLE
revert: Enable new ibm runners for s390x

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -30,4 +30,3 @@ self-hosted-runner:
     - s390x-large
     - tdx
     - ubuntu-22.04-arm
-    - ubuntu-24.04-s390x

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -32,7 +32,7 @@ permissions: {}
 jobs:
   build-asset:
     name: build-asset
-    runs-on: ubuntu-24.04-s390x
+    runs-on: s390x
     permissions:
       contents: read
       packages: write
@@ -257,7 +257,7 @@ jobs:
 
   build-asset-shim-v2:
     name: build-asset-shim-v2
-    runs-on: ubuntu-24.04-s390x
+    runs-on: s390x
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     permissions:
       contents: read
@@ -319,7 +319,7 @@ jobs:
 
   create-kata-tarball:
     name: create-kata-tarball
-    runs-on: ubuntu-24.04-s390x
+    runs-on: s390x
     needs:
       - build-asset
       - build-asset-rootfs

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -161,7 +161,7 @@ jobs:
       tag: ${{ inputs.tag }}-s390x
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
-      runner: ubuntu-24.04-s390x
+      runner: s390x
       arch: s390x
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}

--- a/.github/workflows/static-checks-self-hosted.yaml
+++ b/.github/workflows/static-checks-self-hosted.yaml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         instance:
           - "ubuntu-22.04-arm"
-          - "ubuntu-24.04-s390x"
+          - "s390x"
           - "ubuntu-24.04-ppc64le"
     uses: ./.github/workflows/build-checks.yaml
     with:


### PR DESCRIPTION
This partially reverts 8dcd91c for the s390x because the CI jobs are currently blocking the release. The new runners will be re-introduced once they are stable and no longer impact critical paths.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>