### PR TITLE
tests: Stop testing on stratovirt

### DIFF
--- a/.github/workflows/basic-ci-amd64.yaml
+++ b/.github/workflows/basic-ci-amd64.yaml
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         containerd_version: ['lts', 'active']
-        vmm: ['clh', 'cloud-hypervisor', 'dragonball', 'qemu', 'stratovirt']
+        vmm: ['clh', 'cloud-hypervisor', 'dragonball', 'qemu']
     runs-on: ubuntu-22.04
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}
@@ -117,7 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         containerd_version: ['lts', 'active']
-        vmm: ['clh', 'qemu', 'dragonball', 'stratovirt']
+        vmm: ['clh', 'qemu', 'dragonball']
     runs-on: ubuntu-22.04
     env:
       CONTAINERD_VERSION: ${{ matrix.containerd_version }}

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -63,7 +63,6 @@ jobs:
           - qemu
           - qemu-snp-experimental
           - qemu-tdx-experimental
-          - stratovirt
           - trace-forwarder
           - virtiofsd
         stage:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -51,7 +51,6 @@ jobs:
           - nydus
           - ovmf
           - qemu
-          - stratovirt
           - virtiofsd
     env:
       PERFORM_ATTESTATION: ${{ matrix.asset == 'agent' && inputs.push-to-registry == 'yes' && 'yes' || 'no' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -429,13 +429,11 @@ jobs:
           { containerd_version: lts,    vmm: clh              },
           { containerd_version: lts,    vmm: dragonball       },
           { containerd_version: lts,    vmm: qemu             },
-          { containerd_version: lts,    vmm: stratovirt       },
           { containerd_version: lts,    vmm: cloud-hypervisor },
           { containerd_version: lts,    vmm: qemu-runtime-rs  },
           { containerd_version: active, vmm: clh              },
           { containerd_version: active, vmm: dragonball       },
           { containerd_version: active, vmm: qemu             },
-          { containerd_version: active, vmm: stratovirt       },
           { containerd_version: active, vmm: cloud-hypervisor },
           { containerd_version: active, vmm: qemu-runtime-rs  },
          ]

--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -49,7 +49,6 @@ jobs:
           - dragonball
           - qemu
           - qemu-runtime-rs
-          - stratovirt
           - cloud-hypervisor
         instance-type:
           - small


### PR DESCRIPTION
Stratovirt has been failing for a considerable amount of time, with no sign of someone watching it and being actively working on a fix.

With this we also stop building and shipping stratovirt as part of our release as we cannot test it.