### PR TITLE
webhook: allow privileged containers

### DIFF
--- a/tools/testing/kata-webhook/main.go
+++ b/tools/testing/kata-webhook/main.go
@@ -57,15 +57,6 @@ func annotatePodMutator(_ context.Context, ar *kwhmodel.AdmissionReview, obj met
 		return &kwhmutating.MutatorResult{}, nil
 	}
 
-	for i := range pod.Spec.Containers {
-		if pod.Spec.Containers[i].SecurityContext != nil && pod.Spec.Containers[i].SecurityContext.Privileged != nil {
-			if *pod.Spec.Containers[i].SecurityContext.Privileged {
-				fmt.Println("privileged container: ", pod.GetNamespace(), pod.GetName())
-				return &kwhmutating.MutatorResult{}, nil
-			}
-		}
-	}
-
 	if pod.Spec.RuntimeClassName != nil {
 		fmt.Println("explicit runtime: ", pod.GetNamespace(), pod.GetName(), pod.Spec.RuntimeClassName)
 		return &kwhmutating.MutatorResult{}, nil


### PR DESCRIPTION
This allows us to test privileged containers when using the webhook.
We can do this because kata-deploy sets privileged_without_host_devices = true for kata runtime by default.