### PR TITLE
runtime: Clear outer CDI annotations

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -62,6 +62,7 @@ require (
 	google.golang.org/protobuf v1.36.6
 	k8s.io/apimachinery v0.33.0
 	k8s.io/cri-api v0.33.0
+	tags.cncf.io/container-device-interface v1.0.1
 )
 
 require (
@@ -137,7 +138,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	sigs.k8s.io/yaml v1.4.0 // indirect
-	tags.cncf.io/container-device-interface v1.0.1 // indirect
 	tags.cncf.io/container-device-interface/specs-go v1.0.0 // indirect
 )
 

--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/oci"
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/compatoci"
+	"tags.cncf.io/container-device-interface/pkg/cdi"
 )
 
 type startManagementServerFunc func(s *service, ctx context.Context, ociSpec *specs.Spec)
@@ -184,6 +185,13 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 			}
 		}
 
+		// config.WithCDI() has used the CDI annotations to inject
+		// host-side devices. As these annotations reference device kinds
+		// that don't exist in the guest (e.g., nvidia.com/pgpu), we
+		// remove them before creating the sandbox and the containers
+		// within it.
+		removeCDIAnnotations(ociSpec.Annotations)
+
 		// Pass service's context instead of local ctx to CreateSandbox(), since local
 		// ctx will be canceled after this rpc service call, but the sandbox will live
 		// across multiple rpc service calls.
@@ -222,6 +230,12 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 				}
 			}
 		}()
+
+		// CDI annotations have been processed during PodSandbox creation
+		// and cold-plug. CDI annotations referencing device kinds that
+		// exist in the guest (e.g., nvidia.com/gpu) will be generated
+		// during device attachment.
+		removeCDIAnnotations(ociSpec.Annotations)
 
 		_, err = katautils.CreateContainer(ctx, s.sandbox, *ociSpec, rootFs, r.ID, bundlePath, disableOutput, runtimeConfig.DisableGuestEmptyDir)
 		if err != nil {
@@ -432,4 +446,17 @@ func configureNonRootHypervisor(runtimeConfig *oci.RuntimeConfig, sandboxId stri
 		return nil
 	}
 	return fmt.Errorf("failed to get the gid of /dev/kvm")
+}
+
+func removeCDIAnnotations(annotations map[string]string) {
+	if annotations == nil {
+		return
+	}
+
+	for key := range annotations {
+		if strings.HasPrefix(key, cdi.AnnotationPrefix) {
+			shimLog.Debugf("removing CDI annotation: %s=%s", key, annotations[key])
+			delete(annotations, key)
+		}
+	}
 }

--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -705,14 +705,7 @@ func WithCDI(annotations map[string]string, cdiSpecDirs []string, spec *specs.Sp
 	if _, err := registry.InjectDevices(spec, devsFromAnnotations...); err != nil {
 		return nil, fmt.Errorf("CDI device injection failed: %w", err)
 	}
-	// Once we injected the device into the ociSpec we do not need to CDI
-	// device annotation from the outer runtime. The runtime will create the
-	// appropriate inner runtime CDI annotation dependent on the device.
-	for key := range spec.Annotations {
-		if strings.HasPrefix(key, cdi.AnnotationPrefix) {
-			delete(spec.Annotations, key)
-		}
-	}
+
 	// One crucial thing to keep in mind is that CDI device injection
 	// might add OCI Spec environment variables, hooks, and mounts as
 	// well. Therefore it is important that none of the corresponding


### PR DESCRIPTION
Pod annotations from the outer runtime are being used for cold-plugging CDI devices. We need to ensure that these annotations don't leak into the inner runtime for which specific container (sibling) annotations are being created. Without this change, the inner runtime receives both annotations, leading to failing CDI injection as an outer runtime annotation observed in the guest translates to an unresolvable CDI device, for example, cdi.k8s.io/gpu: "nvidia.com/pgpu=0".

This will unblock the GPU-CC scenario for which we aim to add SNP GPU CI soon.