### PR TITLE
kata-deploy: Add missing runtimeClasses

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -13,6 +13,7 @@
   "cloud-hypervisor" (dict "memory" "130Mi" "cpu" "250m")
   "dragonball" (dict "memory" "130Mi" "cpu" "250m")
   "fc" (dict "memory" "130Mi" "cpu" "250m")
+  "firecracker" (dict "memory" "130Mi" "cpu" "250m")
   "qemu" (dict "memory" "160Mi" "cpu" "250m")
   "qemu-coco-dev" (dict "memory" "160Mi" "cpu" "250m")
   "qemu-runtime-rs" (dict "memory" "160Mi" "cpu" "250m")


### PR DESCRIPTION
When the runtimeClasses were added, as part of 7cfa82680420e31f, the firecracker and qemu-coco-dev-runtime-rs runtimeClasses ended up missing from the dictionary.