### PR TITLE
Revert "tests: Do not enable NFD on s390x"

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -509,8 +509,7 @@ function helm_helper() {
 	yq -i ".node-feature-discovery.enabled = true" "${values_yaml}"
 
 	# Do not enable on cbl-mariner yet, as the deployment is failing on those
-	# Do not enable on s390x yet, as the uninstall is failing on those
-	if [[ "${HELM_HOST_OS}" == "cbl-mariner" ]] || [[ "$(uname -m)" == "s390x" ]]; then
+	if [[ "${HELM_HOST_OS}" == "cbl-mariner" ]]; then
 		yq -i ".node-feature-discovery.enabled = false" "${values_yaml}"
 	fi
 


### PR DESCRIPTION
This reverts commit c75a46d17f800e1d825aca31c62c7bf3f44ca8b1, as NFD now publishes an s390x image (and also a ppc64le one).