### PR TITLE
riscv: Introduce its own nightly tests

### DIFF
--- a/.github/workflows/build-kata-static-tarball-riscv64.yaml
+++ b/.github/workflows/build-kata-static-tarball-riscv64.yaml
@@ -20,9 +20,6 @@ on:
         required: false
         type: string
         default: ""
-    secrets:
-      QUAY_DEPLOYER_PASSWORD:
-        required: true
 
 permissions: {}
 
@@ -41,14 +38,6 @@ jobs:
           - kernel
           - virtiofsd
     steps:
-      - name: Login to Kata Containers quay.io
-        if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: quay.io
-          username: ${{ vars.QUAY_DEPLOYER_USERNAME }}
-          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.commit-hash }}
@@ -82,5 +71,5 @@ jobs:
         with:
           name: kata-artifacts-riscv64-${{ matrix.asset }}${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.zst
-          retention-days: 15
+          retention-days: 3
           if-no-files-found: error

--- a/.github/workflows/ci-nightly-riscv.yaml
+++ b/.github/workflows/ci-nightly-riscv.yaml
@@ -1,0 +1,34 @@
+on:
+  schedule:
+    - cron: '0 5 * * *'
+
+name: Nightly CI for RISC-V
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build-kata-static-tarball-riscv:
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+      attestations: write
+    uses: ./.github/workflows/build-kata-static-tarball-riscv64.yaml
+    with:
+      tarball-suffix: -${{ github.sha }}
+      commit-hash: ${{ github.sha }}
+      target-branch: ${{ github.ref_name }}
+
+  build-checks-preview:
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - "riscv-builder"
+    uses: ./.github/workflows/build-checks-preview-riscv64.yaml
+    with:
+      instance: ${{ matrix.instance }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,20 +134,6 @@ jobs:
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  build-kata-static-tarball-riscv64:
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    uses: ./.github/workflows/build-kata-static-tarball-riscv64.yaml
-    with:
-      tarball-suffix: -${{ inputs.tag }}
-      commit-hash: ${{ inputs.commit-hash }}
-      target-branch: ${{ inputs.target-branch }}
-    secrets:
-      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
   publish-kata-deploy-payload-s390x:
     needs: build-kata-static-tarball-s390x
     permissions:

--- a/.github/workflows/static-checks-self-hosted.yaml
+++ b/.github/workflows/static-checks-self-hosted.yaml
@@ -34,15 +34,3 @@ jobs:
     uses: ./.github/workflows/build-checks.yaml
     with:
       instance: ${{ matrix.instance }}
-
-  build-checks-preview:
-    needs: skipper
-    if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        instance:
-          - "riscv-builder"
-    uses: ./.github/workflows/build-checks-preview-riscv64.yaml
-    with:
-      instance: ${{ matrix.instance }}


### PR DESCRIPTION
By doing this, the ones interested on RISC-V support can still have a ood visibility of its state, without the extra noise in our CI.