### PR TITLE
gpu: introduce a new devkit build flag to produce a rootfs for developers

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
@@ -4,7 +4,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#!/bin/bash
 set -euo pipefail
 [[ -n "${DEBUG}" ]] && set -x
 
@@ -164,6 +163,10 @@ build_nvidia_drivers() {
 		# went wroing make sure the signing_key.pem is removed
 		[[ -e "${signing_key}" ]] && rm -f "${signing_key}"
 	done
+
+	# Save the modules for later so that a linux-image purge does not remove them
+	tar cvfa /lib/modules.save_from_purge.tar.zst /lib/modules
+
 	popd >> /dev/null
 }
 
@@ -373,6 +376,65 @@ install_nvidia_dcgm() {
 		datacenter-gpu-manager-exporter
 }
 
+cleanup_rootfs() {
+	echo "chroot: Cleanup NVIDIA GPU rootfs"
+
+	apt-mark hold libstdc++6 libzstd1 libgnutls30t64 pciutils
+
+	if [[ -n "${driver_version}" ]]; then
+		apt-mark hold libnvidia-cfg1-"${driver_version}"-server \
+			nvidia-utils-"${driver_version}"-server         \
+			nvidia-kernel-common-"${driver_version}"-server \
+			nvidia-imex-"${driver_version}"                 \
+			nvidia-compute-utils-"${driver_version}"-server \
+			libnvidia-compute-"${driver_version}"-server    \
+			libnvidia-gl-"${driver_version}"-server         \
+			libnvidia-extra-"${driver_version}"-server      \
+			libnvidia-decode-"${driver_version}"-server     \
+			libnvidia-fbc1-"${driver_version}"-server       \
+			libnvidia-encode-"${driver_version}"-server     \
+			libnvidia-nscq-"${driver_version}"              \
+			linuxptp libnftnl11
+	fi
+
+	kernel_headers=$(dpkg --get-selections | cut -f1 | grep linux-headers)
+	linux_images=$(dpkg --get-selections | cut -f1 | grep linux-image)
+	for i in ${kernel_headers} ${linux_images}; do
+		apt purge -yqq "${i}"
+	done
+
+	apt purge -yqq jq make gcc xz-utils linux-libc-dev
+
+	if [[ -n "${driver_version}" ]]; then
+		apt purge -yqq nvidia-headless-no-dkms-"${driver_version}"-server"${driver_type}" \
+			nvidia-kernel-source-"${driver_version}"-server"${driver_type}"
+	fi
+
+	apt autoremove -yqq
+
+	apt clean
+	apt autoclean
+
+	for modules_version in /lib/modules/*; do
+		ln -sf "${modules_version}" /lib/modules/"$(uname -r)"
+		touch  "${modules_version}"/modules.order
+		touch  "${modules_version}"/modules.builtin
+		depmod -a
+	done
+
+	rm -rf /var/lib/apt/lists/* /var/cache/apt/* /var/log/apt /var/cache/debconf
+	rm -f /etc/apt/sources.list
+	rm -f /usr/bin/nvidia-ngx-updater /usr/bin/nvidia-container-runtime
+	rm -f /var/log/{nvidia-installer.log,dpkg.log,alternatives.log}
+
+	# Clear and regenerate the ld cache
+	rm -f /etc/ld.so.cache
+	ldconfig
+
+	tar xvf /lib/modules.save_from_purge.tar.zst -C /
+	rm -f /lib/modules.save_from_purge.tar.zst
+}
+
 # Start of script
 echo "chroot: Setup NVIDIA GPU rootfs stage one"
 
@@ -387,3 +449,4 @@ install_nvidia_fabricmanager
 install_nvidia_ctk
 export_driver_version
 install_nvidia_dcgm
+cleanup_rootfs

--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -51,6 +51,7 @@ RUN apt-get update && \
     pip \
     python3-dev \
     libclang-dev \
+    file \
     zstd && \
     apt-get clean && rm -rf /var/lib/apt/lists/&& \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -570,13 +570,16 @@ install_initrd_confidential() {
 #              -> use the latest and greatest driver,
 #                 lts release or e.g. version=550.127.1
 # driver       -> enable open or closed drivers
-# debug        -> enable debugging support
 # compute      -> enable the compute GPU stack, includes utility
 # graphics     -> enable the graphics GPU stack, includes compute
 # dcgm         -> enable the DCGM stack + DGCM exporter
 # nvswitch     -> enable DGX like systems
 # gpudirect    -> enable use-cases like GPUDirect RDMA, GPUDirect GDS
 # dragonball   -> enable dragonball support
+# devkit       -> builds a developer kit image, resulting in a larger
+#                 rootfs size. May require incrementing the
+#                 default_memory allocation and with this, potentially
+#                 podOverhead. Experimental. Not for use in production
 #
 # The full stack can be enabled by setting all the options like:
 #


### PR DESCRIPTION
Introduce a new devkit parameter which will produce a rootfs without chisselling. This results in a larger rootfs with various packages and binaries being included, for instance, enabling the use of the debug console.

Enabling the debug console, end users can chose to install packages, for instance, using a `tmpfs` based `overlayfs` on top of the r/o `rootfs`, or, in scenarios where possible, remounting the `rootfs` in read-write mode. Various apt sources are defined under `/etc/apt/sources.list.d/` which can be adjusted.

As this is a utility intended for developers, I am not adding deployment or test CI. Those who aim to make use of a debug console will need to build the devkit type rootfs locally.

The initrd file size is currently 523M (non-confidential), resp., 533MB (confidential) while the rootfs decompressed by the kernel is about ~1.3 GB, thus requiring to increment the `default_memory` value (and possibly `podOverhead`) when making use of the devkit rootfs in combination with the initrd.