### PR TITLE
tests: Correct unexpected capability for policy failure test

### DIFF
--- a/tests/integration/kubernetes/k8s-policy-rc.bats
+++ b/tests/integration/kubernetes/k8s-policy-rc.bats
@@ -147,7 +147,7 @@ test_rc_policy() {
 @test "Policy failure: unexpected capability" {
     # Changing the template spec after generating its policy will cause CreateContainer to be denied.
     yq -i \
-      '.spec.template.spec.containers[0].securityContext.capabilities.add += ["CAP_SYS_CHROOT"]' \
+      '.spec.template.spec.containers[0].securityContext.capabilities.add += ["SYS_NICE"]' \
       "${incorrect_yaml}"
 
     test_rc_policy true


### PR DESCRIPTION
The test case designed to verify policy failures due to an "unexpected capability" was misconfigured. It was using "CAP_SYS_CHROOT" as the unexpected capability to be added.

This configuration was flawed for two main reasons: 

1. Incorrect Syntax: Kubernetes Pod specs expect capability names without the "CAP_" prefix (e.g., "SYS_CHROOT", not "CAP_SYS_CHROOT"). This made the test case's premise incorrect from a K8s API perspective. 
2. Part of Default Set: "SYS_CHROOT" is already included in the `default_caps` list for a standard container. Therefore, adding it would not trigger a policy violation, defeating the purpose of the "unexpected capability" test.

Furthermore, a related issue was observed where a malformed capability like "CAP_CAP_SYS_CHROOT" was being generated, causing parsing failures in the `oci-spec-rs` library. This was a symptom of incorrect string manipulation when handling capabilities.

This commit corrects the test by selecting "SYS_NICE" as the unexpected capability. "SYS_NICE" is a more suitable choice because:
- It is a valid Linux capability.
- It is relatively harmless.
- It is **not** part of the default capability set defined in `genpolicy-settings.json`.

By using "SYS_NICE", the test now accurately simulates a scenario where a Pod requests a legitimate but non-default capability, which the policy (generated from a baseline Pod without this capability) should correctly reject. This change fixes the test's logic and also resolves the downstream `oci-spec-rs` parsing error by ensuring only valid capability names are processed.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>