### PR TITLE
genpolicy: Make cpath compatible with both runtime-rs and runtime-go

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -227,7 +227,7 @@
         ]
     },
     "common": {
-        "cpath": "/run/kata-containers/shared/containers",
+        "cpath": "/run/kata-containers/shared/containers(?:/passthrough)?",
         "root_path": "/run/kata-containers/$(bundle-id)/rootfs",
         "sfprefix": "^$(cpath)/(watchable/)?$(bundle-id)-[a-z0-9]{16}-",
         "ip_p": "[0-9]{1,5}",


### PR DESCRIPTION
Update the `cpath` variable in the policy template to support the optional `/passthrough` subpath used by runtime-rs. This ensures that mount source path validation works correctly for both runtime implementations.

By changing `cpath` to include the `(?:/passthrough)?` regular expression fragment, we make the `/passthrough` segment optional. The updated `cpath`:
`/run/kata-containers/shared/containers(?:/passthrough)?`

This single regex pattern now correctly matches both: 1.`/run/kata-containers/shared/containers/<sandbox-id>/...` (runtime-go)
2.`/run/kata-containers/shared/containers/passthrough/<sandbox-id>/...` (runtime-rs)

This elegantly resolves the compatibility issue without needing to add separate or conditional logic to the policy rules, making the policy more robust and maintainable.

Fixes: #12063

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>