### PR TITLE
tests: Enforce qemu-coco-dev for experimental_force_guest_pull

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -137,6 +137,7 @@ jobs:
           - guest-pull
         include:
           - pull-type: experimental-force-guest-pull
+            vmm: qemu-coco-dev
             snapshotter: ""
     runs-on: ubuntu-22.04
     permissions:


### PR DESCRIPTION
The fact that we were not explicitly setting the VMM was leading to us testing with the default runtime class (qemu). :-/