### PR TITLE
Add preliminary support for EROFS native rwlayers

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/intel-go/cpuid v0.0.0-20210602155658-5747e5cec0d9
 	github.com/mdlayher/vsock v1.2.1
+	github.com/moby/sys/mountinfo v0.7.2
 	github.com/moby/sys/userns v0.1.0
 	github.com/opencontainers/runc v1.2.8
 	github.com/opencontainers/runtime-spec v1.2.1
@@ -109,7 +110,6 @@ require (
 	github.com/mdlayher/socket v0.5.1 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/moby/locker v1.0.1 // indirect
-	github.com/moby/sys/mountinfo v0.7.2 // indirect
 	github.com/moby/sys/sequential v0.5.0 // indirect
 	github.com/moby/sys/signal v0.7.0 // indirect
 	github.com/moby/sys/symlink v0.2.0 // indirect

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -1328,7 +1328,7 @@ func TestKataAgentCreateContainerVFIODevices(t *testing.T) {
 			}
 
 			// Call createDevices which should trigger the full flow
-			err = container.createDevices(contConfig)
+			err = container.createDevices(context.Background(), contConfig)
 			assert.NoError(err)
 
 			// Find the device in device manager using the original device info


### PR DESCRIPTION
So that the writable data will be written to a seperate storage instead of tmpfs in the guest.

Note that a cleaner way should use new containerd custom mount type but I don't have time on this for now.

More details, see:
https://github.com/containerd/containerd/blob/v2.2.0/docs/snapshotters/erofs.md#quota-support

e.g. /etc/containerd/config.toml
```toml
[plugins."io.containerd.snapshotter.v1.erofs"]
  default_size = "5GB"
```
<img width="2188" height="310" alt="image" src="https://github.com/user-attachments/assets/d360fd5d-e1c6-41d1-ae6d-5219baf27583" />