### PR TITLE
ci: Switch gatekeeper auth header

### DIFF
--- a/tools/testing/gatekeeper/jobs.py
+++ b/tools/testing/gatekeeper/jobs.py
@@ -35,7 +35,7 @@ RUNNING = 127
 
 _GH_HEADERS = {"Accept": "application/vnd.github.v3+json"}
 if os.environ.get("GITHUB_TOKEN"):
-    _GH_HEADERS["Authorization"] = f"token {os.environ['GITHUB_TOKEN']}"
+    _GH_HEADERS["Authorization"] = f"Bearer {os.environ['GITHUB_TOKEN']}"
 _GH_API_URL = f"https://api.github.com/repos/{os.environ['GITHUB_REPOSITORY']}"
 _GH_RUNS_URL = f"{_GH_API_URL}/actions/runs"
 if os.environ.get("DEBUG", "false") == "true":


### PR DESCRIPTION
The github API suggestions that `Authorization: Bearer <YOUR-TOKEN>` is the way to set the auth token, but it also mentioned that `token` should work, so it's unclear if this will help much, but it shouldn't harm.