### PR TITLE
versions: Bump nydus and nydus-snapshotter to its latest release

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -12,7 +12,7 @@ FROM golang:1.24-alpine AS nydus-binary-downloader
 
 # Keep the version here aligned with "ndyus-snapshotter.version"
 # in versions.yaml
-ARG NYDUS_SNAPSHOTTER_VERSION=v0.15.2
+ARG NYDUS_SNAPSHOTTER_VERSION=v0.15.7
 ARG NYDUS_SNAPSHOTTER_REPO=https://github.com/containerd/nydus-snapshotter
 
 RUN \

--- a/versions.yaml
+++ b/versions.yaml
@@ -351,14 +351,14 @@ externals:
   nydus:
     description: "Nydus image acceleration service"
     url: "https://github.com/dragonflyoss/image-service"
-    version: "v2.2.3"
+    version: "v2.3.9"
 
   # Keep the version here aligned with the NYDUS_SNAPSHOTTER_VERSION
   # on tools/packaging/kata-deploy/Dockerfile
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.15.2"
+    version: "v0.15.7"
 
   opa:
     description: "Open Policy Agent"


### PR DESCRIPTION
The nydus tests have started failing and the snapshotter still causes issues, so try bumping to the latest version to see if that helps