### PR TITLE
tests: nvidia: cc: Remove nvrc.smi.srs=1 parameter

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -480,8 +480,6 @@ ifneq (,$(QEMUCMD))
     KERNELTDXPARAMS_NV += "authorize_allow_devs=pci:ALL"
 
     KERNELSNPPARAMS_NV = $(KERNELPARAMS_NV)
-    #TODO: temporary until the attestation agent activates the device after successful attestation
-    KERNELSNPPARAMS_NV += "nvrc.smi.srs=1"
 
     # Setting this to false can lead to cgroup leakages in the host
     # Best practice for production is to set this to true

--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -15,6 +15,7 @@ export LOCAL_NIM_CACHE="/opt/nim/.cache"
 
 SKIP_MULTI_GPU_TESTS=${SKIP_MULTI_GPU_TESTS:-false}
 
+# TODO: Replace with is_confidential_gpu_hardware() once available
 TEE=false
 [[ "${RUNTIME_CLASS_NAME}" = "kata-qemu-nvidia-gpu-snp" ]] && TEE=true
 [[ "${RUNTIME_CLASS_NAME}" = "kata-qemu-nvidia-gpu-tdx" ]] && TEE=true
@@ -65,6 +66,7 @@ setup_kbs_credentials() {
     export CC_KBS_ADDR="$(kbs_k8s_svc_http_addr)"
 
     # Set allow all resources policy (hardening will be done later)
+    # TODO: Replace with kbs_set_gpu_attestation_policy() once available
     kbs_set_allow_all_resources
 
     # Set up Kubernetes secret for the containerd metadata pull


### PR DESCRIPTION
Remove the nvrc.smi.srs=1 parameter from the kernel command line. In CC use cases, the attestation agent is expected to set the GPU ready state.

For the NIM tests, the attestation agent is already being leveraged. For the CUDA vectorAdd case where attestation agent is not being required and not used, we set the ready state by adding the kernel command line parameter through an annotation.