### PR TITLE
runtime-rs: fix the issue of wrong vcpu number

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -233,7 +233,7 @@ impl DragonballInner {
         let vm_config = VmConfigInfo {
             serial_path: Some(serial_path),
             mem_size_mib: self.config.memory_info.default_memory as usize,
-            vcpu_count: self.config.cpu_info.default_vcpus as u8,
+            vcpu_count: self.config.cpu_info.default_vcpus.ceil() as u8,
             max_vcpu_count: self.config.cpu_info.default_maxvcpus as u8,
             mem_type,
             mem_file_path,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -335,7 +335,7 @@ struct Smp {
 impl Smp {
     fn new(config: &HypervisorConfig) -> Smp {
         Smp {
-            num_vcpus: config.cpu_info.default_vcpus as u32,
+            num_vcpus: config.cpu_info.default_vcpus.ceil() as u32,
             max_num_vcpus: config.cpu_info.default_maxvcpus,
         }
     }


### PR DESCRIPTION
In commit 1f95d9401b7b065aeb8181ded6b0f674cc948e16 runtime-rs: change representation of default_vcpus from i32 to f32,

When the vCPU number is less than 1.0, directly converting an integer to a floating-point number will automatically convert it to 0. Therefore, it needs to be rounded up before converting it back to an integer.