### PR TITLE
ci: Adjust gatekeeper's job fetch

### DIFF
--- a/tools/testing/gatekeeper/jobs.py
+++ b/tools/testing/gatekeeper/jobs.py
@@ -178,7 +178,7 @@ class Checker:
         jobs = []
         page = 1
         while True:
-            url = f"{_GH_RUNS_URL}/{run_id}/jobs?per_page=100&page={page}"
+            url = f"{_GH_RUNS_URL}/{run_id}/jobs?per_page=30&page={page}"
             output = self.fetch_json_from_url(
                 url, f"get_jobs_for_workflow_run__{run_id}")
             jobs.extend(output["jobs"])


### PR DESCRIPTION
Try and reduce the page limit of each job request to avoid the chances of us tripping over github's 10s api limit.
All credit to @burgerdev for the investigation and suggestion!