### PR TITLE
bugfix: kata-manager install wrong directory

### DIFF
--- a/utils/kata-manager.sh
+++ b/utils/kata-manager.sh
@@ -824,7 +824,7 @@ install_kata()
 	fi
 
 	if [[ "${file}" == *.tar.zst ]]; then
-		sudo tar --zstd -xvf "${file}"
+		sudo tar --zstd -C / -xvf "${file}"
 	else
 		sudo tar -C / -xvf "${file}"
 	fi


### PR DESCRIPTION
This pull request makes a minor change to the `install_kata()` function in `utils/kata-manager.sh` to ensure that `.tar.zst` archives are extracted to the root directory. This aligns the extraction behavior for `.tar.zst` files with other archive types.