### PR TITLE
tests: Enable AUTO_GENERATE_POLICY for qemu-coco-dev-runtime-rs

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -595,7 +595,7 @@ function main() {
 	if [[ -z "${AUTO_GENERATE_POLICY}" ]]; then
 		if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
 			AUTO_GENERATE_POLICY="yes"
-		elif [[ "${KATA_HYPERVISOR}" = "qemu-coco-dev" && \
+		elif [[ "${KATA_HYPERVISOR}" = qemu-coco-dev* && \
 		        "${TARGET_ARCH}" = "x86_64" && \
 		        "${PULL_TYPE}" != "experimental-force-guest-pull" ]]; then
 			AUTO_GENERATE_POLICY="yes"


### PR DESCRIPTION
Enable auto-generate policy on cbl-mariner Hosts for qemu-coco-dev-runtime-rs if the user didn't specify an AUTO_GENERATE_POLICY value.

Signed-off-by: Alex Lyn <alex.lyn@antgroup.com>