### PR TITLE
build: Exclude tools from root workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,11 @@ exclude = [
     "src/tools",
     "src/libs",
     "src/runtime-rs",
+
+    # We are cloning and building rust packages under
+    # "tools/packaging/kata-deploy/local-build/build" folder, which may mislead
+    # those packages to think they are part of the kata root workspace
+    "tools/packaging/kata-deploy/local-build/build",
 ]
 
 [workspace.dependencies]


### PR DESCRIPTION
There are rust packages being cloned and built inside tools folder, which may mislead those packages to think they are part of the kata root workspace. Exclude tools to avoid that.

```shell
Cloning into 'virtiofsd'...
warning: redirecting to https://gitlab.com/virtio-fs/virtiofsd.git/
/home/runner/work/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/virtiofsd/builddir/virtiofsd /home/runner/work/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/virtiofsd/builddir
HEAD is now at 4f86ceb Merge branch 'release-1.13.1' into 'main'
error: current package believes it's in a workspace when it's not:
current:   /home/runner/work/kata-containers/kata-containers/tools/packaging/kata-deploy/local-build/build/virtiofsd/builddir/virtiofsd/Cargo.toml
workspace: /home/runner/work/kata-containers/kata-containers/Cargo.toml

this may be fixable by adding `tools/packaging/kata-deploy/local-build/build/virtiofsd/builddir/virtiofsd` to the `workspace.members` array of the manifest located at: /home/runner/work/kata-containers/kata-containers/Cargo.toml
Alternatively, to keep it out of the workspace, add the package to the `workspace.exclude` array, or add an empty `[workspace]` table to the package's manifest.
make[1]: *** [tools/packaging/kata-deploy/local-build/Makefile:93: virtiofsd-tarball-build] Error 101
make[1]: Leaving directory '/home/runner/work/kata-containers/kata-containers'
make: *** [tools/packaging/kata-deploy/local-build/Makefile:225: virtiofsd-tarball] Error 2
```