### PR TITLE
tests: k8s: Fix typo in authenticated tests

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
@@ -9,7 +9,7 @@ load "${BATS_TEST_DIRNAME}/confidential_common.sh"
 
 export KBS="${KBS:-false}"
 export SNAPSHOTTER="${SNAPSHOTTER:-}"
-export EXPERIMENTAL_FORCE_GUEST_PULL="{EXPERIMENTAL_FORCE_GUEST_PULL:-}"
+export EXPERIMENTAL_FORCE_GUEST_PULL="${EXPERIMENTAL_FORCE_GUEST_PULL:-}"
 
 setup() {
     if ! is_confidential_runtime_class; then


### PR DESCRIPTION
The person who introduced the check, someone named Fabiano Fidêncio,
forgot a `$` in a variable assignment.