### PR TITLE
Kata-deploy: Add tolerations to daemonset and cleanup job

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -57,6 +57,10 @@ spec:
       nodeSelector:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{- toYaml . | nindent 8 }}
+{{- end }}
 {{- if index .Values "node-feature-discovery" "enabled" }}
       # When node-feature-discovery is managed by this chart (enabled: true), enforce virtualization requirements.
       # Kata Containers requires hardware virtualization support to function.

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/post-delete-job.yaml
@@ -98,6 +98,10 @@ spec:
       nodeSelector:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- with .Values.tolerations }}
+      tolerations:
+{{- toYaml . | nindent 8 }}
+{{- end }}
       hostPID: true
       containers:
       - name: kube-kata-cleanup

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -8,12 +8,17 @@ image:
 
 k8sDistribution: "k8s"  # k8s, k3s, rke2, k0s, microk8s
 
-# Node selector to control which nodes the kata-deploy daemonset runs on
-# Example:
+# Node selector and tolerations to control which nodes the kata-deploy daemonset runs on
+# Examples:
 # nodeSelector:
 #   kata-containers: "enabled"
 #   node-type: "worker"
+# tolerations:
+#   - key: "reservedFor"
+#     operator: "Exists"
+#     effect: "NoSchedule"
 nodeSelector: {}
+tolerations: []
 
 debug: false
 


### PR DESCRIPTION
Add tolerations value to kata-deploy, which allows the daemonset and cleanup job to run on tainted nodes.

fixes https://github.com/kata-containers/kata-containers/issues/12114

Signed-off-by: nheinemans-asml <nick.heinemans@asml.com>
Signed-off-by: Fabiano Fidêncio <ffidencio@nvidia.com>