### PR TITLE
tests: Reduce KBS deployment check flakeness

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -393,7 +393,7 @@ function kbs_k8s_deploy() {
 
 	local pod=kbs-checker-$$
 	kubectl run "${pod}" --image=quay.io/prometheus/busybox --restart=Never -- \
-		sh -c "wget -O- --timeout=5 \"${kbs_ip}:${kbs_port}\" || true"
+		sh -c "wget -O- --timeout=60 \"${kbs_ip}:${kbs_port}\" || true"
 	if ! waitForProcess "60" "10" "kubectl logs \"${pod}\" 2>/dev/null | grep -q \"404 Not Found\""; then
 		echo "ERROR: KBS service is not responding to requests"
 		echo "::group::DEBUG - kbs logs"


### PR DESCRIPTION
We currently start a pod that does a `wget` to the KBS address, and fails after 5 seconds.

By the time it fails and reports back, we can see that KBS is actually running, but the workflow failed as the checker failed. :-/

Let's give it more time for the KBS to show up, and the flakeness should go away.