### PR TITLE
gpu: TDX kernel cmdline  fixes

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -476,7 +476,6 @@ ifneq (,$(QEMUCMD))
     KERNELPARAMS_NV += "cgroup_no_v1=all"
 
     KERNELTDXPARAMS_NV = $(KERNELPARAMS_NV)
-    KERNELTDXPARAMS_NV += "clearcpuid=mtrr"
     KERNELTDXPARAMS_NV += "authorize_allow_devs=pci:ALL"
 
     KERNELSNPPARAMS_NV = $(KERNELPARAMS_NV)


### PR DESCRIPTION
This setting is not needed anymore with Ubuntu 25.10 and the newest QEMU releases for TDX by Ubuntu.
