### PR TITLE
kata-deploy: Fix binary find install_tools_helper

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -1186,6 +1186,13 @@ install_tools_helper() {
 	[ ${tool} = "trace-forwarder" ] && tool_binary="kata-trace-forwarder"
 	binary=$(find ${repo_root_dir}/src/tools/${tool}/ -type f -name ${tool_binary})
 
+	binary_count=$(echo "${binary}" | grep -c '^' || echo "0")
+	if [[ "${binary_count}" -eq 0 ]]; then
+		die "No binary found for ${tool} (expected: ${tool_binary})."
+	elif [[ "${binary_count}" -gt 1 ]]; then
+		die "Multiple binaries found for ${tool} (expected single ${tool_binary}). Found:"$'\n'"${binary}"
+	fi
+
 	if [[ "${tool}" == "genpolicy" ]]; then
 		defaults_path="${destdir}/opt/kata/share/defaults/kata-containers"
 		mkdir -p "${defaults_path}"


### PR DESCRIPTION
Using make tarball targets for tools locally, binaries may exist for both debug and release builds. In this case, cryptic errors are shown as we try to install multiple binaries.
This change require exactly one binary to be found and errors  out in other cases.

Example:
```
ERROR: Multiple binaries found for genpolicy (expected single genpolicy). Found:<...>/kata-containers/src/tools/genpolicy/target/debug/genpolicy
<...>/kata-containers/src/tools/genpolicy/target/x86_64-unknown-linux-musl/release/genpolicy.
```