### PR TITLE
runtimeclasses: Fix nvidia-gpu podOverhead

### DIFF
--- a/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-qemu-nvidia-gpu.yaml
@@ -6,7 +6,7 @@ metadata:
 handler: kata-qemu-nvidia-gpu
 overhead:
     podFixed:
-        memory: "98304Mi"
+        memory: "4096Mi"
         cpu: "1"
 scheduling:
   nodeSelector:

--- a/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
+++ b/tools/packaging/kata-deploy/runtimeclasses/kata-runtimeClasses.yaml
@@ -123,7 +123,7 @@ metadata:
 handler: kata-qemu-nvidia-gpu
 overhead:
     podFixed:
-        memory: "98304Mi"
+        memory: "4096Mi"
         cpu: "1"
 scheduling:
   nodeSelector:


### PR DESCRIPTION
On 69c4fc4e762340ef097989ab0797e2afb8306728, I've mistakenly changed the nvidia-gpu podOverhead while I should only have changed the TEE nvidia-gpu ones.

Let's move it back to its original value.

Reported-by: Joji Mekkattuparamban