### PR TITLE
runtime-rs: fix QMP 'mq' parameter type in netdev_add to boolean

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -488,7 +488,7 @@ impl Qmp {
         );
         netdev_frontend_args.insert("addr".to_owned(), format!("{:02}", slot).into());
         netdev_frontend_args.insert("mac".to_owned(), virtio_net_device.get_mac_addr().into());
-        netdev_frontend_args.insert("mq".to_owned(), "on".into());
+        netdev_frontend_args.insert("mq".to_owned(), true.into());
         // As the golang runtime documents the vectors computation, it's
         // 2N+2 vectors, N for tx queues, N for rx queues, 1 for config, and one for possible control vq
         netdev_frontend_args.insert(


### PR DESCRIPTION
QEMU netdev_add QMP command requires the 'mq' (multi-queue) argument to be of boolean type (`true` / `false`). In runtime-rs the virtio-net device hotplug logic currently passes a string value (e.g. "on"/"off"), which causes QEMU to reject the command:
```
    Invalid parameter type for 'mq', expected: boolean
```
This patch modifies `hotplug_network_device` to insert 'mq' as a proper boolean value of `true . This fixes sandbox startup failures when multi-queue is enabled.

Fixes #12136