### PR TITLE
runtime-rs: Only QEMU supports templating

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/ch.rs
+++ b/src/libs/kata-types/src/config/hypervisor/ch.rs
@@ -85,11 +85,6 @@ impl ConfigPlugin for CloudHypervisorConfig {
             if ch.memory_info.memory_slots == 0 {
                 ch.memory_info.memory_slots = default::DEFAULT_CH_MEMORY_SLOTS;
             }
-
-            // Apply factory defaults
-            if ch.factory.template_path.is_empty() {
-                ch.factory.template_path = default::DEFAULT_TEMPLATE_PATH.to_string();
-            }
         }
 
         Ok(())

--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -79,11 +79,6 @@ impl ConfigPlugin for DragonballConfig {
             if db.memory_info.memory_slots == 0 {
                 db.memory_info.memory_slots = default::DEFAULT_DRAGONBALL_MEMORY_SLOTS;
             }
-
-            // Apply factory defaults
-            if db.factory.template_path.is_empty() {
-                db.factory.template_path = default::DEFAULT_TEMPLATE_PATH.to_string();
-            }
         }
         Ok(())
     }

--- a/src/libs/kata-types/src/config/hypervisor/firecracker.rs
+++ b/src/libs/kata-types/src/config/hypervisor/firecracker.rs
@@ -69,11 +69,6 @@ impl ConfigPlugin for FirecrackerConfig {
                 firecracker.memory_info.default_memory =
                     default::DEFAULT_FIRECRACKER_MEMORY_SIZE_MB;
             }
-
-            // Apply factory defaults
-            if firecracker.factory.template_path.is_empty() {
-                firecracker.factory.template_path = default::DEFAULT_TEMPLATE_PATH.to_string();
-            }
         }
 
         Ok(())

--- a/src/libs/kata-types/src/config/hypervisor/qemu.rs
+++ b/src/libs/kata-types/src/config/hypervisor/qemu.rs
@@ -92,7 +92,6 @@ impl ConfigPlugin for QemuConfig {
                 qemu.memory_info.memory_slots = default::DEFAULT_QEMU_MEMORY_SLOTS;
             }
 
-            // Apply factory defaults
             if qemu.factory.template_path.is_empty() {
                 qemu.factory.template_path = default::DEFAULT_TEMPLATE_PATH.to_string();
             }

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -263,20 +263,6 @@ tx_rate_limiter_max_rate = 0
 # disable applying SELinux on the VMM process (default false)
 disable_selinux = @DEFDISABLESELINUX@
 
-[factory]
-# VM templating support. Once enabled, new VMs are created from template
-# using vm cloning. They will share the same initial kernel, initramfs and
-# agent memory by mapping it readonly. It helps speeding up new container
-# creation and saves a lot of memory if there are many kata containers running
-# on the same host.
-#
-# When disabled, new VMs are created from scratch.
-#
-# Note: Requires "initrd=" to be set ("image=" is not supported).
-#
-# Default false
-enable_template = false
-
 [agent.@PROJECT_TYPE@]
 # If enabled, make the agent display debug-level messages.
 # (default: disabled)


### PR DESCRIPTION
We can remove the checks and default values attribution from all other shims.