### PR TITLE
GHA: Use `runs-on` only for choosing proper runners

### DIFF
--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -12,7 +12,12 @@ name: Build checks
 jobs:
   check:
     name: check
-    runs-on: ${{ matrix.runner || inputs.instance }}
+    runs-on: >-
+      ${{
+        ( contains(inputs.instance, 's390x') && matrix.component.name == 'runtime' ) && 's390x' ||
+        ( contains(inputs.instance, 'ppc64le') && (matrix.component.name == 'runtime' || matrix.component.name == 'agent') ) && 'ppc64le' ||
+        inputs.instance
+      }}
     strategy:
       fail-fast: false
       matrix:
@@ -70,36 +75,6 @@ jobs:
               - protobuf-compiler
         instance:
           - ${{ inputs.instance }} 
-        include:
-          - component:
-              name: runtime
-              path: src/runtime
-              needs:
-                - golang
-                - XDG_RUNTIME_DIR
-            instance: ubuntu-24.04-s390x
-            runner: s390x
-          - component:
-              name: runtime
-              path: src/runtime
-              needs:
-                - golang
-                - XDG_RUNTIME_DIR
-            instance: ubuntu-24.04-ppc64le
-            runner: ppc64le
-          - component:
-              name: agent
-              path: src/agent
-              needs:
-                - rust
-                - libdevmapper
-                - libseccomp
-                - protobuf-compiler
-                - clang
-            instance: ubuntu-24.04-ppc64le
-            runner: ppc64le
-
-             
 
     steps:
       - name: Adjust a permission for repo


### PR DESCRIPTION
Fixes: #12123

`include` in #12069, introduced to choose a different runner based on component, leads to another set of redundant jobs where `matrix.command` is empty.
This PR gets back to the `runs-on` solution, but makes the condition human-readable.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>