### PR TITLE
genpolicy: enable container image parsing for coco-dev

### DIFF
--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -125,7 +125,7 @@ const GROUP_FILE_WHITEOUT_TAR_PATH: &str = "etc/.wh.group";
 pub const WHITEOUT_MARKER: &str = "WHITEOUT";
 
 impl Container {
-    pub async fn new(config: &Config, image: &str, is_pause_container: bool) -> Result<Self> {
+    pub async fn new(config: &Config, image: &str, _is_pause_container: bool) -> Result<Self> {
         info!("============================================");
         info!("Pulling manifest and config for {image}");
         let image_string = image.to_string();
@@ -169,7 +169,7 @@ impl Container {
         // Nydus/guest_pull doesn't make available passwd/group files from layers properly.
         // See issue https://github.com/kata-containers/kata-containers/issues/11162
         let v1_policy = config.settings.cluster_config.pause_container_id_policy == "v1";
-        if config.settings.cluster_config.guest_pull && (v1_policy || !is_pause_container) {
+        if config.settings.cluster_config.guest_pull && v1_policy {
             info!("Guest pull is enabled, skipping passwd/group file parsing");
         } else {
             let image_layers = get_image_layers(
@@ -185,7 +185,10 @@ impl Container {
             // Find the last layer with an /etc/* file, respecting whiteouts.
             info!("Parsing users and groups in image layers");
             for layer in &image_layers {
+                debug!("Container:new: parsing layer diff_id = {}", &layer.diff_id);
+
                 if layer.passwd == WHITEOUT_MARKER {
+                    debug!("Container:new: found {WHITEOUT_MARKER} for passwd");
                     passwd = String::new();
                 } else if !layer.passwd.is_empty() {
                     passwd = layer.passwd.clone();
@@ -193,6 +196,7 @@ impl Container {
                 }
 
                 if layer.group == WHITEOUT_MARKER {
+                    debug!("Container:new: found {WHITEOUT_MARKER} for group");
                     group = String::new();
                 } else if !layer.group.is_empty() {
                     group = layer.group.clone();

--- a/tests/integration/kubernetes/k8s-openvpn.bats
+++ b/tests/integration/kubernetes/k8s-openvpn.bats
@@ -35,17 +35,10 @@ setup() {
     client_secret_template_yaml="${pod_config_dir}/openvpn/openvpn-client-secret.yaml.in"
     client_secret_instance_yaml="${pod_config_dir}/openvpn/openvpn-client-secret-instance.yaml"
 
-    # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-    # other references to this issue in the genpolicy source folder.
-    if [[ "${SNAPSHOTTER:-}" == "nydus" ]]; then
-        add_allow_all_policy_to_yaml "$server_pod_yaml"
-        add_allow_all_policy_to_yaml "$client_pod_yaml"
-    else
-        policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
-        add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
-        auto_generate_policy "${policy_settings_dir}" "$server_pod_yaml" "$server_configmap_yaml" "--config-file $server_secret_template_yaml"
-        auto_generate_policy "${policy_settings_dir}" "$client_pod_yaml" "$client_configmap_yaml" "--config-file $client_secret_template_yaml"
-    fi
+    policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+    add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
+    auto_generate_policy "${policy_settings_dir}" "$server_pod_yaml" "$server_configmap_yaml" "--config-file $server_secret_template_yaml"
+    auto_generate_policy "${policy_settings_dir}" "$client_pod_yaml" "$client_configmap_yaml" "--config-file $client_secret_template_yaml"
 }
 
 @test "Pods establishing a VPN connection using openvpn" {

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -462,12 +462,6 @@ teardown_common() {
 
 	kubectl describe pods
 	k8s_delete_all_pods_if_any_exists || true
-
-	# Print the node journal since the test start time if a bats test is not completed
-	if [[ -n "${node_start_time}" && -z "${BATS_TEST_COMPLETED}" ]]; then
-		echo "DEBUG: system logs of node '${node}' since test start time (${node_start_time})"
-		exec_host "${node}" journalctl -x -t "kata" --since '"'"${node_start_time}"'"' || true
-	fi
 }
 
 # Execute a command in a pod and grep kubectl's output.

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -234,7 +234,7 @@ auto_generate_policy_no_added_flags() {
 	declare -r additional_flags="${4:-""}"
 
 	auto_generate_policy_enabled || return 0
-	local genpolicy_command="RUST_LOG=info /opt/kata/bin/genpolicy -u -y ${yaml_file}"
+	local genpolicy_command="RUST_LOG=debug /opt/kata/bin/genpolicy -u -y ${yaml_file}"
 	genpolicy_command+=" -p ${settings_dir}/rules.rego"
 	genpolicy_command+=" -j ${settings_dir}/genpolicy-settings.json"
 


### PR DESCRIPTION
Disable the guest_pull workaround on coco-dev and keep it just for the SNP and TDX CI tests.
