### PR TITLE
build: Add nvidia image rootfs builds

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -171,6 +171,8 @@ jobs:
           - rootfs-image
           - rootfs-image-confidential
           - rootfs-image-mariner
+          - rootfs-image-nvidia-gpu
+          - rootfs-image-nvidia-gpu-confidential
           - rootfs-initrd
           - rootfs-initrd-confidential
           - rootfs-initrd-nvidia-gpu

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -150,6 +150,7 @@ jobs:
       matrix:
         asset:
           - rootfs-image
+          - rootfs-image-nvidia-gpu
           - rootfs-initrd
           - rootfs-initrd-nvidia-gpu
     steps:

--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -208,6 +208,13 @@ check_rootfs() {
 	# check agent or systemd
 	case "${AGENT_INIT}" in
 		"no")
+			# Check if we have alternative init systems installed
+			# For now check if we have NVRC
+			if readlink "${rootfs}/sbin/init" | grep -q "NVRC"; then
+				OK "init is NVRC"
+				return 0
+			fi
+
 			for systemd_path in $candidate_systemd_paths; do
 				systemd="${rootfs}${systemd_path}"
 				if [ -x "${systemd}" ] || [ -L "${systemd}" ]; then


### PR DESCRIPTION
So far we've only been building the initrd for the nvidia rootfs. However, we're also interested on having the image beind used for a few use-cases.