### PR TITLE
ci: Add two extra gatekeeper triggers

### DIFF
--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -10,7 +10,9 @@ on:
       - opened
       - synchronize
       - reopened
+      - edited
       - labeled
+      - unlabeled
 
 permissions: {}
 


### PR DESCRIPTION
We hit a case that gatekeeper was failing due to thinking the WIP check had failed, but since it ran the PR had been edited to remove that from the title. We should listen to edits and unlabels of the PR to ensure that gatekeeper doesn't get outdated in situations like this.