### PR TITLE
agent: Bump CDI-rs to latest

### DIFF
--- a/src/agent/Cargo.toml
+++ b/src/agent/Cargo.toml
@@ -186,7 +186,7 @@ base64 = "0.22"
 sha2 = "0.10.8"
 async-compression = { version = "0.4.22", features = ["tokio", "gzip"] }
 
-container-device-interface = "0.1.0"
+container-device-interface = "0.1.1"
 
 [target.'cfg(target_arch = "s390x")'.dependencies]
 pv_core = { git = "https://github.com/ibm-s390-linux/s390-tools", rev = "4942504a9a2977d49989a5e5b7c1c8e07dc0fa41", package = "s390_pv_core" }


### PR DESCRIPTION
Latest version of container-device-interface is v0.1.1