### PR TITLE
Nginx test image unification

### DIFF
--- a/tests/integration/kubernetes/k8s-attach-handlers.bats
+++ b/tests/integration/kubernetes/k8s-attach-handlers.bats
@@ -9,25 +9,21 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	nginx_version="${docker_images_nginx_version}"
-	nginx_image="nginx:$nginx_version"
-
 	pod_name="handlers"
 
 	get_pod_config_dir
 	yaml_file="${pod_config_dir}/test-lifecycle-events.yaml"
 
 	# Create yaml
-	sed -e "s/\${nginx_version}/${nginx_image}/" \
-		"${pod_config_dir}/lifecycle-events.yaml" > "${yaml_file}"
+	set_nginx_image "${pod_config_dir}/lifecycle-events.yaml" "${yaml_file}"
 
 	# Add policy to yaml
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
-	
+
 	display_message="cat /usr/share/message"
 	exec_command=(sh -c "${display_message}")
 	add_exec_to_policy_settings "${policy_settings_dir}" "${exec_command[@]}"
-	
+
 	add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
 	auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
 }

--- a/tests/integration/kubernetes/k8s-nginx-connectivity.bats
+++ b/tests/integration/kubernetes/k8s-nginx-connectivity.bats
@@ -11,8 +11,6 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 setup() {
 	[ "${CONTAINER_RUNTIME}" == "crio" ] && skip "test not working see: https://github.com/kata-containers/kata-containers/issues/10414"
 
-	nginx_version="${docker_images_nginx_version}"
-	nginx_image="nginx:$nginx_version"
 	busybox_image="quay.io/prometheus/busybox:latest"
 	deployment="nginx-deployment"
 
@@ -20,10 +18,8 @@ setup() {
 
 	# Create test .yaml
 	yaml_file="${pod_config_dir}/test-${deployment}.yaml"
+	set_nginx_image "${pod_config_dir}/${deployment}.yaml" "${yaml_file}"
 
-	sed -e "s/\${nginx_version}/${nginx_image}/" \
-		"${pod_config_dir}/${deployment}.yaml" > "${yaml_file}"
-	
 	auto_generate_policy "${pod_config_dir}" "${yaml_file}"
 }
 

--- a/tests/integration/kubernetes/k8s-policy-rc.bats
+++ b/tests/integration/kubernetes/k8s-policy-rc.bats
@@ -22,11 +22,7 @@ setup() {
     # Save some time by executing genpolicy a single time.
     if [ "${BATS_TEST_NUMBER}" == "1" ]; then
         # Create the correct yaml file
-        nginx_version="${docker_images_nginx_version}"
-        nginx_image="nginx:$nginx_version"
-
-        sed -e "s/\${nginx_version}/${nginx_image}/" \
-            "${pod_config_dir}/k8s-policy-rc.yaml" > "${correct_yaml}"
+        set_nginx_image "${pod_config_dir}/k8s-policy-rc.yaml" "${correct_yaml}"
 
         # Add policy to the correct yaml file
         policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"

--- a/tests/integration/kubernetes/k8s-replication.bats
+++ b/tests/integration/kubernetes/k8s-replication.bats
@@ -9,15 +9,11 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	nginx_version="${docker_images_nginx_version}"
-	nginx_image="nginx:$nginx_version"
-
 	get_pod_config_dir
 
 	# Create yaml
 	test_yaml="${pod_config_dir}/test-replication-controller.yaml"
-	sed -e "s/\${nginx_version}/${nginx_image}/" \
-		"${pod_config_dir}/replication-controller.yaml" > "${test_yaml}"
+	set_nginx_image "${pod_config_dir}/replication-controller.yaml" "${test_yaml}"
 
 	# Add policy to the yaml file
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"

--- a/tests/integration/kubernetes/k8s-scale-nginx.bats
+++ b/tests/integration/kubernetes/k8s-scale-nginx.bats
@@ -9,16 +9,13 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	nginx_version="${docker_images_nginx_version}"
-	nginx_image="nginx:$nginx_version"
 	replicas="3"
 	deployment="nginx-deployment"
 	get_pod_config_dir
 
 	# Create the yaml file
 	test_yaml="${pod_config_dir}/test-${deployment}.yaml"
-	sed -e "s/\${nginx_version}/${nginx_image}/" \
-		"${pod_config_dir}/${deployment}.yaml" > "${test_yaml}"
+	set_nginx_image "${pod_config_dir}/${deployment}.yaml" "${test_yaml}"
 
 	# Add policy to the yaml file
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-rc.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-rc.yaml
@@ -21,7 +21,7 @@ spec:
       runtimeClassName: kata
       containers:
       - name: nginxtest
-        image: quay.io/fidencio/${nginx_version}
+        image: ${NGINX_IMAGE}
         ports:
         - containerPort: 80
         volumeMounts:

--- a/tests/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
@@ -13,7 +13,8 @@ spec:
   runtimeClassName: kata
   containers:
   - name: handlers-container
-    image: quay.io/fidencio/${nginx_version}
+    image: ${NGINX_IMAGE}
+    imagePullPolicy: Always
     lifecycle:
       postStart:
         exec:

--- a/tests/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
@@ -21,6 +21,7 @@ spec:
       runtimeClassName: kata
       containers:
       - name: nginx
-        image: quay.io/fidencio/${nginx_version}
+        image: ${NGINX_IMAGE}
+        imagePullPolicy: Always
         ports:
         - containerPort: 80

--- a/tests/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
@@ -21,6 +21,6 @@ spec:
       runtimeClassName: kata
       containers:
       - name: nginxtest
-        image: quay.io/fidencio/${nginx_version}
+        image: ${NGINX_IMAGE}
         ports:
         - containerPort: 80

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -11,7 +11,6 @@
 # This contains variables and functions common to all e2e tests.
 
 # Variables used by the kubernetes tests
-export docker_images_nginx_version="1.15-alpine"
 export container_images_agnhost_name="registry.k8s.io/e2e-test-images/agnhost"
 export container_images_agnhost_version="2.21"
 
@@ -556,4 +555,16 @@ container_exec_with_retries() {
 	done
 
 	echo "${cmd_out}"
+}
+
+set_nginx_image() {
+	input_yaml=$1
+	output_yaml=$2
+
+	ensure_yq
+	nginx_version=$(get_from_kata_deps ".docker_images.nginx.version")
+	nginx_registry=$(get_from_kata_deps ".docker_images.nginx.registry")
+	nginx_image="${nginx_registry}:${nginx_version}"
+
+	NGINX_IMAGE="${nginx_image}" envsubst < "${input_yaml}" > "${output_yaml}"
 }

--- a/tests/stability/soak_parallel_rm.sh
+++ b/tests/stability/soak_parallel_rm.sh
@@ -173,8 +173,9 @@ function init() {
 	fi
 
 	versions_file="${cidir}/../../versions.yaml"
-	nginx_version=$("${GOPATH}/bin/yq" ".docker_images.nginx.version" "$versions_file")
-	nginx_image="docker.io/library/nginx:$nginx_version"
+	nginx_registry=$("${GOPATH}/bin/yq" ".docker_images.nginx.registry" "${versions_file}")
+	nginx_version=$("${GOPATH}/bin/yq" ".docker_images.nginx.version" "${versions_file}")
+	nginx_image="${nginx_registry}:${nginx_version}"
 
 	# Pull nginx image
 	sudo "${CTR_EXE}" image pull "${nginx_image}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -475,9 +475,9 @@ plugins:
     version: "b7f6d3e0679796e907ecca88cfab0e32e326850d"
 
 docker_images:
-  description: "Docker hub images used for testing"
+  description: "Docker images used for testing"
 
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
-    url: "https://hub.docker.com/_/nginx/"
+    registry: "quay.io/kata-containers/nginx"
     version: "1.15-alpine"


### PR DESCRIPTION
tests: Switch nginx images to use version.yaml details

- Swap out the hard-coded nginx registry and verisons for reading
the test image details for version.yaml
which can also ensure that the quay.io mirror is used
rather than the docker hub versions which can hit pull limits