### PR TITLE
ci: nvidia: Install kata-artifacts

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -314,6 +314,7 @@ jobs:
     needs: publish-kata-deploy-payload-amd64
     uses: ./.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
     with:
+      tarball-suffix: -${{ inputs.tag }}
       registry: ghcr.io
       repo: ${{ github.repository_owner }}/kata-deploy-ci
       tag: ${{ inputs.tag }}-amd64

--- a/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
+++ b/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
@@ -2,6 +2,9 @@ name: CI | Run NVIDIA GPU kubernetes tests on amd64
 on:
   workflow_call:
     inputs:
+      tarball-suffix:
+        required: true
+        type: string
       registry:
         required: true
         type: string
@@ -58,6 +61,15 @@ jobs:
           ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: get-kata-tarball
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: kata-static-tarball-amd64${{ inputs.tarball-suffix }}
+          path: kata-artifacts
+
+      - name: Install kata
+        run: bash tests/integration/kubernetes/gha-run.sh install-kata-tools kata-artifacts
 
       - name: Uninstall previous `kbs-client`
         if: matrix.environment.name != 'nvidia-gpu'


### PR DESCRIPTION
In preparation for Kata agent security policy testing, installing Kata tools to provide genpolicy.

This will allow to run CI testing against the NVIDIA GPU handler for https://github.com/kata-containers/kata-containers/pull/12108/commits