### PR TITLE
ci: nvidia: remove kubectl_retry calls

### DIFF
--- a/tests/integration/kubernetes/k8s-nvidia-cuda.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-cuda.bats
@@ -46,10 +46,10 @@ setup() {
     kubectl apply -f "${pod_yaml}"
 
     # Wait for pod to complete successfully (with retry)
-    kubectl_retry 10 30 wait --for=jsonpath='{.status.phase}'=Succeeded --timeout="${POD_WAIT_TIMEOUT}" pod "${POD_NAME_CUDA}"
+    kubectl wait --for=jsonpath='{.status.phase}'=Succeeded --timeout="${POD_WAIT_TIMEOUT}" pod "${POD_NAME_CUDA}"
 
     # Get and verify the output contains expected CUDA success message
-    kubectl_retry 10 30 logs "${POD_NAME_CUDA}"
+    kubectl logs "${POD_NAME_CUDA}"
     output=$(kubectl logs "${POD_NAME_CUDA}")
     echo "# CUDA Vector Add Output: ${output}" >&3
 

--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -82,10 +82,10 @@ create_inference_pod() {
     add_allow_all_policy_to_yaml "${POD_INSTRUCT_YAML}"
 
     kubectl apply -f "${POD_INSTRUCT_YAML}"
-    kubectl_retry 10 30 wait --for=condition=Ready --timeout="${POD_READY_TIMEOUT_INSTRUCT}" pod "${POD_NAME_INSTRUCT}"
+    kubectl wait --for=condition=Ready --timeout="${POD_READY_TIMEOUT_INSTRUCT}" pod "${POD_NAME_INSTRUCT}"
 
     # shellcheck disable=SC2030  # Variable is shared via file between BATS tests
-    kubectl_retry 10 30 get pod "${POD_NAME_INSTRUCT}" -o jsonpath='{.status.podIP}'
+    kubectl get pod "${POD_NAME_INSTRUCT}" -o jsonpath='{.status.podIP}'
     POD_IP_INSTRUCT=$(kubectl get pod "${POD_NAME_INSTRUCT}" -o jsonpath='{.status.podIP}')
     [[ -n "${POD_IP_INSTRUCT}" ]]
 
@@ -98,10 +98,10 @@ create_embedqa_pod() {
     add_allow_all_policy_to_yaml "${POD_EMBEDQA_YAML}"
 
     kubectl apply -f "${POD_EMBEDQA_YAML}"
-    kubectl_retry 10 30 wait --for=condition=Ready --timeout="${POD_READY_TIMEOUT_EMBEDQA}" pod "${POD_NAME_EMBEDQA}"
+    kubectl wait --for=condition=Ready --timeout="${POD_READY_TIMEOUT_EMBEDQA}" pod "${POD_NAME_EMBEDQA}"
 
     # shellcheck disable=SC2030  # Variable is shared via file between BATS tests
-    kubectl_retry 10 30 get pod "${POD_NAME_EMBEDQA}" -o jsonpath='{.status.podIP}'
+    kubectl get pod "${POD_NAME_EMBEDQA}" -o jsonpath='{.status.podIP}'
     POD_IP_EMBEDQA=$(kubectl get pod "${POD_NAME_EMBEDQA}" -o jsonpath='{.status.podIP}')
 
     [[ -n "${POD_IP_EMBEDQA}" ]]


### PR DESCRIPTION
When tests regress, the CI wait time can increase significantly with the current kubectly_retry attempt logic. Thus, align with other tests and remove kubectl_retry invocations. Instead, rely on proper timeouts.