### PR TITLE
go-runtime: Add default bus=pcie.0 to vhost,virtio PCI devices

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -1487,6 +1487,7 @@ func (dev LoaderDevice) QemuParams(config *Config) []string {
 // in to the guest
 // nolint: govet
 type VhostUserDevice struct {
+	Bus           string
 	SocketPath    string //path to vhostuser socket on host
 	CharDevID     string
 	TypeDevID     string //variable QEMU parameter based on value of VhostUserType
@@ -1658,6 +1659,9 @@ func (vhostuserDev VhostUserDevice) QemuFSParams(config *Config) []string {
 	}
 
 	deviceParams = append(deviceParams, driver)
+	if vhostuserDev.Bus != "" {
+		deviceParams = append(deviceParams, fmt.Sprintf("bus=%s", vhostuserDev.Bus))
+	}
 	deviceParams = append(deviceParams, fmt.Sprintf("chardev=%s", vhostuserDev.CharDevID))
 	deviceParams = append(deviceParams, fmt.Sprintf("tag=%s", vhostuserDev.Tag))
 	queueSize := uint32(1024)
@@ -2245,6 +2249,8 @@ func (bridgeDev BridgeDevice) QemuParams(config *Config) []string {
 type VSOCKDevice struct {
 	ID string
 
+	Bus string
+
 	ContextID uint64
 
 	// VHostFD vhost file descriptor that holds the ContextID
@@ -2308,6 +2314,9 @@ func (vsock VSOCKDevice) QemuParams(config *Config) []string {
 		deviceParams = append(deviceParams, fmt.Sprintf("vhostfd=%d", qemuFDs[0]))
 	}
 	deviceParams = append(deviceParams, fmt.Sprintf("id=%s", vsock.ID))
+	if vsock.Bus != "" {
+		deviceParams = append(deviceParams, fmt.Sprintf("bus=%s", vsock.Bus))
+	}
 	deviceParams = append(deviceParams, fmt.Sprintf("%s=%d", VSOCKGuestCID, vsock.ContextID))
 
 	if vsock.Transport.isVirtioPCI(config) && vsock.ROMFile != "" {

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -2324,7 +2324,7 @@ func (q *qemu) AddDevice(ctx context.Context, devInfo interface{}, devType Devic
 			vhostDev.SocketPath = sockPath
 			vhostDev.DevID = id
 
-			q.qemuConfig.Devices, err = q.arch.appendVhostUserDevice(ctx, q.qemuConfig.Devices, vhostDev)
+			q.qemuConfig.Devices, err = q.arch.appendVhostUserDevice(ctx, q.qemuConfig.Devices, q.qemuConfig.Machine.Type, vhostDev)
 		} else {
 			q.Logger().WithField("volume-type", "virtio-9p").Info("adding volume")
 			q.qemuConfig.Devices, err = q.arch.append9PVolume(ctx, q.qemuConfig.Devices, v)
@@ -2333,13 +2333,13 @@ func (q *qemu) AddDevice(ctx context.Context, devInfo interface{}, devType Devic
 		q.qemuConfig.Devices = q.arch.appendSocket(q.qemuConfig.Devices, v)
 	case types.VSock:
 		q.fds = append(q.fds, v.VhostFd)
-		q.qemuConfig.Devices, err = q.arch.appendVSock(ctx, q.qemuConfig.Devices, v)
+		q.qemuConfig.Devices, err = q.arch.appendVSock(ctx, q.qemuConfig.Devices, q.qemuConfig.Machine.Type, v)
 	case Endpoint:
 		q.qemuConfig.Devices, err = q.arch.appendNetwork(ctx, q.qemuConfig.Devices, v)
 	case config.BlockDrive:
 		q.qemuConfig.Devices, err = q.arch.appendBlockDevice(ctx, q.qemuConfig.Devices, v)
 	case config.VhostUserDeviceAttrs:
-		q.qemuConfig.Devices, err = q.arch.appendVhostUserDevice(ctx, q.qemuConfig.Devices, v)
+		q.qemuConfig.Devices, err = q.arch.appendVhostUserDevice(ctx, q.qemuConfig.Devices, q.qemuConfig.Machine.Type, v)
 	case config.VFIODev:
 		q.qemuConfig.Devices = q.arch.appendVFIODevice(q.qemuConfig.Devices, v)
 	default:

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -99,7 +99,7 @@ type qemuArch interface {
 	appendSocket(devices []govmmQemu.Device, socket types.Socket) []govmmQemu.Device
 
 	// appendVSock appends a vsock PCI to devices
-	appendVSock(ctx context.Context, devices []govmmQemu.Device, vsock types.VSock) ([]govmmQemu.Device, error)
+	appendVSock(ctx context.Context, devices []govmmQemu.Device, machineType string, vsock types.VSock) ([]govmmQemu.Device, error)
 
 	// appendNetwork appends a endpoint device to devices
 	appendNetwork(ctx context.Context, devices []govmmQemu.Device, endpoint Endpoint) ([]govmmQemu.Device, error)
@@ -108,7 +108,7 @@ type qemuArch interface {
 	appendBlockDevice(ctx context.Context, devices []govmmQemu.Device, drive config.BlockDrive) ([]govmmQemu.Device, error)
 
 	// appendVhostUserDevice appends a vhost user device to devices
-	appendVhostUserDevice(ctx context.Context, devices []govmmQemu.Device, drive config.VhostUserDeviceAttrs) ([]govmmQemu.Device, error)
+	appendVhostUserDevice(ctx context.Context, devices []govmmQemu.Device, machineType string, drive config.VhostUserDeviceAttrs) ([]govmmQemu.Device, error)
 
 	// appendVFIODevice appends a VFIO device to devices
 	appendVFIODevice(devices []govmmQemu.Device, vfioDevice config.VFIODev) []govmmQemu.Device
@@ -561,10 +561,16 @@ func (q *qemuArchBase) appendSocket(devices []govmmQemu.Device, socket types.Soc
 	return devices
 }
 
-func (q *qemuArchBase) appendVSock(_ context.Context, devices []govmmQemu.Device, vsock types.VSock) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) appendVSock(_ context.Context, devices []govmmQemu.Device, machineType string, vsock types.VSock) ([]govmmQemu.Device, error) {
+
+	bus := "" // empty for other architectures
+	if machineType == QemuQ35 || machineType == QemuVirt {
+		bus = "pcie.0"
+	}
 	devices = append(devices,
 		govmmQemu.VSOCKDevice{
 			ID:            fmt.Sprintf("vsock-%d", vsock.ContextID),
+			Bus:           bus,
 			ContextID:     vsock.ContextID,
 			VHostFD:       vsock.VhostFd,
 			DisableModern: q.nestedRun,
@@ -680,8 +686,13 @@ func (q *qemuArchBase) appendBlockDevice(_ context.Context, devices []govmmQemu.
 	return devices, nil
 }
 
-func (q *qemuArchBase) appendVhostUserDevice(ctx context.Context, devices []govmmQemu.Device, attr config.VhostUserDeviceAttrs) ([]govmmQemu.Device, error) {
+func (q *qemuArchBase) appendVhostUserDevice(ctx context.Context, devices []govmmQemu.Device, machineType string, attr config.VhostUserDeviceAttrs) ([]govmmQemu.Device, error) {
 	qemuVhostUserDevice := govmmQemu.VhostUserDevice{}
+
+	qemuVhostUserDevice.Bus = "" // all other architecture empty bus
+	if machineType == QemuQ35 || machineType == QemuVirt {
+		qemuVhostUserDevice.Bus = "pcie.0"
+	}
 
 	switch attr.Type {
 	case config.VhostUserNet:

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -233,7 +233,7 @@ func testQemuArchBaseAppend(t *testing.T, structure interface{}, expected []govm
 	case config.VFIODev:
 		devices = qemuArchBase.appendVFIODevice(devices, s)
 	case config.VhostUserDeviceAttrs:
-		devices, err = qemuArchBase.appendVhostUserDevice(context.Background(), devices, s)
+		devices, err = qemuArchBase.appendVhostUserDevice(context.Background(), devices, "QemuQ35", s)
 	}
 
 	assert.NoError(err)


### PR DESCRIPTION
For numa enablement and pxb-pcie, we need to assign the PCI devices to the root bus explicitly; otherwise, they will be added to the new root complex.

All vhosts/virtio devices need to go to `pcie.0`, see example: 
```
[root@fbcf68455b32 /]# lspci -tv 
-+-[0000:00]-+-00.0  Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
 |           +-01.0  Red Hat, Inc. Virtio console
 |           +-02.0-[01]----01.0  Red Hat, Inc. Virtio network device
 |           +-03.0  Red Hat, Inc. Virtio SCSI
 |           +-04.0  Red Hat, Inc. Virtio RNG
 |           +-05.0  Red Hat, Inc. QEMU PCIe Expander bridge
 |           +-06.0  Red Hat, Inc. QEMU PCIe Expander bridge
 |           +-07.0  Red Hat, Inc. Virtio 1.0 socket
 |           +-08.0  Red Hat, Inc. Virtio file system
 |           +-1f.0  Intel Corporation 82801IB (ICH9) LPC Interface Controller
 |           +-1f.2  Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]
 |           \-1f.3  Intel Corporation 82801I (ICH9 Family) SMBus Controller
 +-[0000:20]-+-00.0-[21]----00.0  NVIDIA Corporation GH100 [H800]
 |           +-01.0-[22]--
 |           +-02.0-[23]--
 |           \-03.0-[24]--
 \-[0000:40]-+-00.0-[41]----00.0  NVIDIA Corporation GH100 [H800]
             +-01.0-[42]--
             +-02.0-[43]--
             \-03.0-[44]--
[root@fbcf68455b32 /]# 
```