### PR TITLE
runtime-rs: Add default bus=pcie.0 to vhost,virtio PCI devices

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -851,6 +851,11 @@ impl ToQemuParams for DeviceVhostUserFs {
     async fn qemu_params(&self) -> Result<Vec<String>> {
         let mut params = Vec::new();
         params.push(format!("vhost-user-fs-{}", self.bus_type));
+        // Only valid for Q35 or VIRT machine types aka x86 or aarch64
+        // When NUMA is enabled we need to set the default bus to pcie.0
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        params.push(format!("bus=pcie.0"));
+
         params.push(format!("chardev={}", self.chardev));
         params.push(format!("tag={}", self.tag));
         if self.queue_size != 0 {
@@ -1065,6 +1070,11 @@ impl ToQemuParams for DeviceVirtioBlk {
     async fn qemu_params(&self) -> Result<Vec<String>> {
         let mut params = Vec::new();
         params.push(format!("virtio-blk-{}", self.bus_type));
+        // Only valid for Q35 or VIRT machine types aka x86 or aarch64
+        // When NUMA is enabled we need to set the default bus to pcie.0
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        params.push(format!("bus=pcie.0"));
+
         params.push(format!("drive=image-{}", self.id));
         if self.config_wce {
             params.push("config-wce=on".to_owned());
@@ -1126,6 +1136,11 @@ impl ToQemuParams for VhostVsock {
     async fn qemu_params(&self) -> Result<Vec<String>> {
         let mut params = Vec::new();
         params.push(format!("vhost-vsock-{}", self.bus_type));
+        // Only valid for Q35 or VIRT machine types aka x86 or aarch64
+        // When NUMA is enabled we need to set the default bus to pcie.0
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        params.push(format!("bus=pcie.0"));
+
         if self.disable_modern {
             params.push("disable-modern=true".to_owned());
         }
@@ -1353,6 +1368,10 @@ impl ToQemuParams for DeviceVirtioNet {
         //params.push(format!("driver={}", &self.device_driver.to_string()));
         params.push(self.device_driver.clone());
         params.push(format!("netdev={}", &self.netdev_id));
+        // Only valid for Q35 or VIRT machine types aka x86 or aarch64
+        // When NUMA is enabled we need to set the default bus to pcie.0
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        params.push(format!("bus=pcie.0"));
 
         params.push(format!("mac={:?}", self.mac_address));
 
@@ -1406,6 +1425,11 @@ impl ToQemuParams for DeviceVirtioSerial {
         let mut params = Vec::new();
         params.push(format!("virtio-serial-{}", self.bus_type));
         params.push(format!("id={}", self.id));
+        // Only valid for Q35 or VIRT machine types aka x86 or aarch64
+        // When NUMA is enabled we need to set the default bus to pcie.0
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        params.push(format!("bus=pcie.0"));
+
         if self.iommu_platform {
             params.push("iommu_platform=on".to_owned());
         }
@@ -1437,6 +1461,11 @@ impl ToQemuParams for DeviceVirtconsole {
         let mut params = Vec::new();
         params.push("virtconsole".to_owned());
         params.push(format!("id={}", self.id));
+        // Only valid for Q35 or VIRT machine types aka x86 or aarch64
+        // When NUMA is enabled we need to set the default bus to pcie.0
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        params.push(format!("bus=pcie.0"));
+
         params.push(format!("chardev={}", self.chardev));
         Ok(vec!["-device".to_owned(), params.join(",")])
     }
@@ -1541,12 +1570,16 @@ impl DeviceRng {
 #[async_trait]
 impl ToQemuParams for DeviceRng {
     async fn qemu_params(&self) -> Result<Vec<String>> {
-        let mut device_params = Vec::new();
+        let mut params = Vec::new();
 
-        device_params.push(self.transport.clone());
-        device_params.push(format!("rng={}", "rng0".to_owned()));
+        params.push(self.transport.clone());
+        params.push(format!("rng={}", "rng0".to_owned()));
+        // Only valid for Q35 or VIRT machine types aka x86 or aarch64
+        // When NUMA is enabled we need to set the default bus to pcie.0
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        params.push(format!("bus=pcie.0"));
 
-        Ok(vec!["-device".to_owned(), device_params.join(",")])
+        Ok(vec!["-device".to_owned(), params.join(",")])
     }
 }
 
@@ -1572,6 +1605,11 @@ impl ToQemuParams for DeviceIntelIommu {
     async fn qemu_params(&self) -> Result<Vec<String>> {
         let mut params = Vec::new();
         params.push("intel-iommu".to_owned());
+        // Only valid for Q35 aka x86
+        // When NUMA is enabled we need to set the default bus to pcie.0
+        #[cfg(target_arch = "x86_64")]
+        params.push(format!("bus=pcie.0"));
+
         let to_onoff = |b| if b { "on" } else { "off" };
         params.push(format!("intremap={}", to_onoff(self.intremap)));
         params.push(format!("device-iotlb={}", to_onoff(self.device_iotlb)));
@@ -1805,6 +1843,11 @@ impl ToQemuParams for DeviceVirtioScsi {
         let mut params = Vec::new();
         params.push(format!("virtio-scsi-{}", self.bus_type));
         params.push(format!("id={}", self.id));
+        // Only valid for Q35 or VIRT machine types aka x86 or aarch64
+        // When NUMA is enabled we need to set the default bus to pcie.0
+        #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+        params.push(format!("bus=pcie.0"));
+
         if self.disable_modern {
             params.push("disable-modern=true".to_owned());
         }


### PR DESCRIPTION
For NUMA enablemment and pxb-pcie we need to explicitly assign the PCI devices to the root bus otherwsie they will be added to the new root complex.

All vhosts/virtio devices need to go to pcie.0, see example:

```
[root@fbcf68455b32 /]# lspci -tv 
-+-[0000:00]-+-00.0  Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
 |           +-01.0  Red Hat, Inc. Virtio console
 |           +-02.0-[01]----01.0  Red Hat, Inc. Virtio network device
 |           +-03.0  Red Hat, Inc. Virtio SCSI
 |           +-04.0  Red Hat, Inc. Virtio RNG
 |           +-05.0  Red Hat, Inc. QEMU PCIe Expander bridge
 |           +-06.0  Red Hat, Inc. QEMU PCIe Expander bridge
 |           +-07.0  Red Hat, Inc. Virtio 1.0 socket
 |           +-08.0  Red Hat, Inc. Virtio file system
 |           +-1f.0  Intel Corporation 82801IB (ICH9) LPC Interface Controller
 |           +-1f.2  Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]
 |           \-1f.3  Intel Corporation 82801I (ICH9 Family) SMBus Controller
 +-[0000:20]-+-00.0-[21]----00.0  NVIDIA Corporation GH100 [H800]
 |           +-01.0-[22]--
 |           +-02.0-[23]--
 |           \-03.0-[24]--
 \-[0000:40]-+-00.0-[41]----00.0  NVIDIA Corporation GH100 [H800]
             +-01.0-[42]--
             +-02.0-[43]--
             \-03.0-[44]--
[root@fbcf68455b32 /]# 
```