### PR TITLE
go-runtime: Add PCIe Expander Bus

### DIFF
--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -135,6 +135,8 @@ var SysBusPciDevicesPath = "/sys/bus/pci/devices"
 
 var getSysDevPath = getSysDevPathImpl
 
+const PCIeExpanderBusPrefix = "pxb"
+
 // PCIePortBusPrefix gives us the correct bus nameing dependeing on the port
 // used to hot(cold)-plug the device
 type PCIePortBusPrefix string

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -132,6 +132,9 @@ const (
 	// VHostVSockPCI is a generic Vsock vhost device with PCI transport.
 	VHostVSockPCI DeviceDriver = "vhost-vsock-pci"
 
+	// PCIeExpanderBus is a PCIe root complex with numa affinity
+	PCIeExpanderBus DeviceDriver = "pxb-pcie"
+
 	// PCIeRootPort is a PCIe Root Port, the PCIe device should be hotplugged to this port.
 	PCIeRootPort DeviceDriver = "pcie-root-port"
 
@@ -1736,6 +1739,37 @@ func (vhostuserDev VhostUserDevice) deviceName(config *Config) string {
 	default:
 		return ""
 	}
+}
+
+// PCIeExpanderBusDevice represents a root complex for a numa node
+type PCIeExpanderBusDevice struct {
+	ID       string
+	Bus      string
+	BusNr    string
+	NumaNode string
+}
+
+func (b PCIeExpanderBusDevice) QemuParams(config *Config) []string {
+	var qemuParams []string
+	var deviceParams []string
+	driver := PCIeExpanderBus
+
+	deviceParams = append(deviceParams, fmt.Sprintf("%s,id=%s", driver, b.ID))
+	deviceParams = append(deviceParams, fmt.Sprintf("bus=%s", b.Bus))
+	deviceParams = append(deviceParams, fmt.Sprintf("bus_nr=%s", b.BusNr))
+	deviceParams = append(deviceParams, fmt.Sprintf("numa_node=%s", b.NumaNode))
+
+	qemuParams = append(qemuParams, "-device")
+	qemuParams = append(qemuParams, strings.Join(deviceParams, ","))
+
+	return qemuParams
+}
+
+func (b PCIeExpanderBusDevice) Valid() bool {
+	if b.ID == "" || b.Bus == "" || b.BusNr == "" || b.NumaNode == "" {
+		return false
+	}
+	return true
 }
 
 // PCIeRootPortDevice represents a memory balloon device.

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -2612,6 +2612,51 @@ func genericMemoryTopology(memoryMb, hostMemoryMb uint64, slots uint8, memoryOff
 	return memory
 }
 
+func genericNUMAMemoryModles(memoryMb, memoryAlign uint64, numaNodes []types.NUMANode) []govmmQemu.MemoryModule {
+	if len(numaNodes) == 0 {
+		return nil
+	}
+
+	memoryModules := make([]govmmQemu.MemoryModule, 0, len(numaNodes))
+
+	// Divide memory among NUMA nodes.
+	memoryPerNode := memoryMb / uint64(len(numaNodes))
+	memoryPerNode -= memoryPerNode % memoryAlign
+
+	// First NUMA node gets more if memory is not divide evenly.
+	moduleSize := memoryMb - memoryPerNode*uint64(len(numaNodes)-1)
+
+	for nodeId, numaNode := range numaNodes {
+		memoryModules = append(memoryModules, govmmQemu.MemoryModule{
+			Size:         fmt.Sprintf("%dM", moduleSize),
+			NodeId:       uint32(nodeId),
+			HostNodes:    numaNode.HostNodes,
+			MemoryPolicy: "interleave",
+		})
+		moduleSize = memoryPerNode
+		if moduleSize == 0 {
+			break
+		}
+	}
+
+	return memoryModules
+}
+
+func genericAppendPCIeExpanderBus(devices []govmmQemu.Device, nodeId uint32, bus string, busNr uint32, machineType string) []govmmQemu.Device {
+	if machineType != QemuQ35 && machineType != QemuVirt {
+		return devices
+	}
+	devices = append(devices,
+		govmmQemu.PCIeExpanderBusDevice{
+			ID:       fmt.Sprintf("%s%d", config.PCIeExpanderBusPrefix, nodeId),
+			Bus:      bus,
+			BusNr:    fmt.Sprintf("%d", busNr),
+			NumaNode: fmt.Sprintf("%d", nodeId),
+		},
+	)
+	return devices
+}
+
 // genericAppendPCIeRootPort appends to devices the given pcie-root-port
 func genericAppendPCIeRootPort(devices []govmmQemu.Device, number uint32, machineType string, memSize32bit uint64, memSize64bit uint64) []govmmQemu.Device {
 	var (

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -152,6 +152,9 @@ type qemuArch interface {
 	// setIgnoreSharedMemoryMigrationCaps set bypass-shared-memory capability for migration
 	setIgnoreSharedMemoryMigrationCaps(context.Context, *govmmQemu.QMP) error
 
+	// apppendPCIeExpanderBus appends a new root complex for each NUMA node
+	appendPCIeExpanderBus(devices []govmmQemu.Device, nodeID uint32, bus string, busNr uint32) []govmmQemu.Device
+
 	// appendPCIeRootPortDevice appends a pcie-root-port device to pcie.0 bus
 	appendPCIeRootPortDevice(devices []govmmQemu.Device, number uint32, memSize32bit uint64, memSize64bit uint64) []govmmQemu.Device
 
@@ -862,6 +865,10 @@ func (q *qemuArchBase) setBridges(bridges []types.Bridge) {
 
 func (q *qemuArchBase) addBridge(b types.Bridge) {
 	q.Bridges = append(q.Bridges, b)
+}
+
+func (q *qemuArchBase) appendPCIeExpanderBus(devices []govmmQemu.Device, nodeID uint32, bus string, busNr uint32) []govmmQemu.Device {
+	return genericAppendPCIeExpanderBus(devices, nodeID, bus, busNr, q.qemuMachine.Type)
 }
 
 // appendPCIeRootPortDevice appends to devices the given pcie-root-port


### PR DESCRIPTION
The pxb-pcie is the only entity that is numa node affine. With that we can add PCIe Root and Switch Ports to our topology.