### PR TITLE
runtime-rs: Add PCIe Expander Bus

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -50,7 +50,7 @@ const DEBUG_MONITOR_SOCKET: &str = "debug-monitor.sock";
 // instance is on stack which makes it necessary for QemuCmdLine to be
 // Send + Sync, and for that ToQemuParams has to be Send + Sync. :-(
 #[async_trait]
-trait ToQemuParams: Send + Sync {
+pub trait ToQemuParams: Send + Sync {
     // OsString could look as a better fit here, however since foreign strings
     // come to this code from the outside as Strings already and this code adds
     // nothing but UTF-8 (in fact probably just ASCII) switching to OsStrings
@@ -1995,7 +1995,6 @@ impl ToQemuParams for ObjectTdxGuest {
         Ok(vec!["-object".to_owned(), self.to_string()])
     }
 }
-
 /// PCIeRootPortDevice directly attached onto the root bus
 /// -device pcie-root-port,id=rp0,bus=pcie.0,chassis=0,slot=0,multifunction=off,pref64-reserve=<X>B,mem-reserve=<Y>B
 #[derive(Debug, Default)]
@@ -2184,7 +2183,7 @@ fn should_disable_modern() -> bool {
 
 pub struct QemuCmdLine<'a> {
     id: String,
-    config: &'a HypervisorConfig,
+    pub config: &'a HypervisorConfig,
 
     // In principle, all objects implementing ToQemuParams could be just stored
     // in the `devices` container.  However, there are several special cases
@@ -2204,7 +2203,7 @@ pub struct QemuCmdLine<'a> {
 
     knobs: Knobs,
 
-    devices: Vec<Box<dyn ToQemuParams>>,
+    pub devices: Vec<Box<dyn ToQemuParams>>,
     ccw_subchannel: Option<CcwSubChannel>,
 }
 
@@ -2591,27 +2590,28 @@ impl<'a> QemuCmdLine<'a> {
             .set_nvdimm(false);
     }
 
-    /// Note: add_pcie_root_port and add_pcie_switch_port follow kata-runtime's related implementations of vfio devices.
-    /// The design origins from https://github.com/qemu/qemu/blob/master/docs/pcie.txt
+    /// Note: add_pcie_root_port and add_pcie_switch_port follow kata-runtime's
+    /// related implementations of vfio devices. The design origins from
+    /// https://github.com/qemu/qemu/blob/master/docs/pcie.txt
     ///
     ///     pcie.0 bus
-    ///     ---------------------------------------------------------------------
-    ///          |                                         |
-    ///     -------------                            -------------
-    ///     | Root Port |                            | Root Port |
-    ///     ------------                             -------------
-    ///           |               -------------------------|------------------------
-    ///      ------------         |                 -----------------              |
-    ///      | PCIe Dev |         |    PCI Express  | Upstream Port |              |
-    ///      ------------         |      Switch     -----------------              |
-    ///                           |                  |            |                |
-    ///                           |    -------------------    -------------------  |
-    ///                           |    | Downstream Port |    | Downstream Port |  |
-    ///                           |    -------------------    -------------------  |
-    ///                           -------------|-----------------------|------------
-    ///                                  ------------
-    ///                                  | PCIe Dev |
-    ///                                  ------------
+    ///     --------------------------------------------------------------------
+    ///          |                                     |
+    ///     -------------                        -------------
+    ///     | Root Port |                        | Root Port |
+    ///     ------------                         -------------
+    ///           |           -------------------------|------------------------
+    ///      ------------     |                 -----------------              |
+    ///      | PCIe Dev |     |    PCI Express  | Upstream Port |              |
+    ///      ------------     |      Switch     -----------------              |
+    ///                       |                  |            |                |
+    ///                       |    -------------------    -------------------  |
+    ///                       |    | Downstream Port |    | Downstream Port |  |
+    ///                       |    -------------------    -------------------  |
+    ///                       -------------|-----------------------|------------
+    ///                              ------------
+    ///                              | PCIe Dev |
+    ///                              ------------
     ///  Using multi-function PCI Express Root Ports:
     ///     -device pcie-root-port,id=root_port1,multifunction=on,chassis=x,addr=z.0[,slot=y][,bus=pcie.0] \
     ///     -device pcie-root-port,id=root_port2,chassis=x1,addr=z.1[,slot=y1][,bus=pcie.0] \

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator_numa.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator_numa.rs
@@ -1,0 +1,93 @@
+// Copyright (c) NVIDIA Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+use crate::qemu::cmdline_generator::QemuCmdLine;
+use crate::qemu::cmdline_generator::ToQemuParams;
+use anyhow::Result;
+use async_trait::async_trait;
+
+/// NUMA Support with PCIe Expander Bus, each PXB represents a NUMA node.
+///
+///     pcie.0 bus
+///     --------------------------------------------------------------------
+///          |                                     |
+///          | numa_node=0                         | numa_node=1
+///          |                                     |
+///     -------------                        -------------
+///     |    PXB    |                        |    PXB    |
+///     ------------                         -------------
+///          |                                     |
+///          | pcie.1                              | pcie.2
+///          |                                     |
+///     -------------                        -------------
+///     | Root Port |                        | Root Port |
+///     ------------                         -------------
+///           |           -------------------------|------------------------
+///      ------------     |                 -----------------              |
+///      | PCIe Dev |     |    PCI Express  | Upstream Port |              |
+///      ------------     |      Switch     -----------------              |
+///                       |                  |            |                |
+///                       |    -------------------    -------------------  |
+///                       |    | Downstream Port |    | Downstream Port |  |
+///                       |    -------------------    -------------------  |
+///                       -------------|-----------------------|------------
+///                              ------------              ------------
+///                              | PCIe Dev |              | PCIe Dev |
+///                              ------------              ------------
+///
+
+/// PCIeExpanderBusDevice is the only entity that is numa node affine.
+/// -device pxb-pcie,id=pxb0,bus=pcie.1,bus_nr=20,numa_node=0
+#[derive(Debug, Default)]
+pub struct PCIeExpanderBusDevice {
+    id: String,
+    bus: String,
+    bus_nr: u32,
+    numa_node: u32,
+}
+
+impl PCIeExpanderBusDevice {
+    fn new(id: &str, bus: &str, bus_nr: u32, numa_node: u32) -> Self {
+        PCIeExpanderBusDevice {
+            id: id.to_owned(),
+            bus: bus.to_owned(),
+            bus_nr,
+            numa_node,
+        }
+    }
+}
+
+#[async_trait]
+impl ToQemuParams for PCIeExpanderBusDevice {
+    async fn qemu_params(&self) -> Result<Vec<String>> {
+        let mut device_params = Vec::new();
+        device_params.push(format!("{},id={}", "pxb-pcie", self.id));
+        device_params.push(format!("bus={}", self.bus));
+        device_params.push(format!("bus_nr={}", self.bus_nr));
+        device_params.push(format!("numa_node={}", self.numa_node));
+        Ok(vec!["-device".to_owned(), device_params.join(",")])
+    }
+}
+
+impl<'a> QemuCmdLine<'a> {
+    #[allow(dead_code)]
+    pub fn add_pcie_expander_bus(&mut self, id: &str, bus_nr: u32, numa_node: u32) -> Result<()> {
+        let machine_type: &str = &self.config.machine_info.machine_type;
+        let bus = match machine_type {
+            "q35" | "virt" => "pcie.0",
+            _ => {
+                info!(
+                    sl!(),
+                    "PCIe Expander Bus not supported for machine type: {}", machine_type
+                );
+                return Ok(());
+            }
+        };
+
+        let pxb_device = PCIeExpanderBusDevice::new(id, bus, bus_nr, numa_node);
+        self.devices.push(Box::new(pxb_device));
+
+        Ok(())
+    }
+}

--- a/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/mod.rs
@@ -4,6 +4,7 @@
 //
 
 mod cmdline_generator;
+mod cmdline_generator_numa;
 mod inner;
 mod qmp;
 


### PR DESCRIPTION
The pxb-pcie is the only entity that is numa node affine. With that we can add PCIe Root and Switch Ports to our topology.