### PR TITLE
runtime-rs: Block Device Rootfs Mount Options Lost During Storage Object Creation

### DIFF
--- a/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
@@ -69,7 +69,7 @@ impl BlockRootfs {
         let mut storage = Storage {
             fs_type: rootfs.fs_type.clone(),
             mount_point: container_path.clone(),
-            options: vec![],
+            options: rootfs.options.clone(),
             ..Default::default()
         };
 
@@ -77,7 +77,10 @@ impl BlockRootfs {
         // disk image is mounted across multiple VMs/containers.
         // This allows mounting XFS volumes that share the same UUID.
         if rootfs.fs_type == VM_ROOTFS_FILESYSTEM_XFS {
-            storage.options.push("nouuid".to_string());
+            // Add nouuid to existing options if not already present
+            if !storage.options.iter().any(|opt| opt == "nouuid") {
+                storage.options.push("nouuid".to_string());
+            }
         }
 
         let mut device_id: String = "".to_owned();


### PR DESCRIPTION
Init the storage options with original rootfs options.

Addition: XFS, append nouuid to the mount options if not exist.

Fixes: #11996 

Signed-off-by: shezhang.lau <shezhang.lau@antgroup.com>