### PR TITLE
tests: Switch nginx test image ref to digest

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -562,9 +562,9 @@ set_nginx_image() {
 	output_yaml=$2
 
 	ensure_yq
-	nginx_version=$(get_from_kata_deps ".docker_images.nginx.version")
 	nginx_registry=$(get_from_kata_deps ".docker_images.nginx.registry")
-	nginx_image="${nginx_registry}:${nginx_version}"
+	nginx_digest=$(get_from_kata_deps ".docker_images.nginx.digest")
+	nginx_image="${nginx_registry}@${nginx_digest}"
 
 	NGINX_IMAGE="${nginx_image}" envsubst < "${input_yaml}" > "${output_yaml}"
 }

--- a/tests/stability/soak_parallel_rm.sh
+++ b/tests/stability/soak_parallel_rm.sh
@@ -174,8 +174,8 @@ function init() {
 
 	versions_file="${cidir}/../../versions.yaml"
 	nginx_registry=$("${GOPATH}/bin/yq" ".docker_images.nginx.registry" "${versions_file}")
-	nginx_version=$("${GOPATH}/bin/yq" ".docker_images.nginx.version" "${versions_file}")
-	nginx_image="${nginx_registry}:${nginx_version}"
+	nginx_digest=$("${GOPATH}/bin/yq" ".docker_images.nginx.digest" "${versions_file}")
+	nginx_image="${nginx_registry}@${nginx_digest}"
 
 	# Pull nginx image
 	sudo "${CTR_EXE}" image pull "${nginx_image}"

--- a/versions.yaml
+++ b/versions.yaml
@@ -480,4 +480,5 @@ docker_images:
   nginx:
     description: "Proxy server for HTTP, HTTPS, SMTP, POP3 and IMAP protocols"
     registry: "quay.io/kata-containers/nginx"
-    version: "1.15-alpine"
+    # yamllint disable-line rule:line-length
+    digest: "sha256:a905609e0f9adc2607f06da2f76893c6da07caa396c41f2806fee162064cfb4b" # 1.15-alpine


### PR DESCRIPTION
As tags are mutable and digests are not, lets pin our image by digest to give our CI a better chance of stability