### PR TITLE
tests: k8s: tests_common.sh shellcheck clean-up

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -539,10 +539,16 @@ container_exec_with_retries() {
 	for _ in {1..10}; do
 		if [[ -n "${container_name}" ]]; then
 			bats_unbuffered_info "Executing in pod ${pod_name}, container ${container_name}: $*"
-			cmd_out=$(kubectl exec "${pod_name}" -c "${container_name}" -- "$@") || (bats_unbuffered_info "kubectl exec failed" ; cmd_out="")
+			if ! cmd_out=$(kubectl exec "${pod_name}" -c "${container_name}" -- "$@"); then
+				bats_unbuffered_info "kubectl exec failed"
+				cmd_out=""
+			fi
 		else
 			bats_unbuffered_info "Executing in pod ${pod_name}: $*"
-			cmd_out=$(kubectl exec "${pod_name}" -- "$@") || (bats_unbuffered_info "kubectl exec failed" ; cmd_out="")
+			if ! cmd_out=$(kubectl exec "${pod_name}" -- "$@"); then
+				bats_unbuffered_info "kubectl exec failed"
+				cmd_out=""
+			fi
 		fi
 
 		if [[ -n "${cmd_out}" ]]; then


### PR DESCRIPTION
 Clean-up shellcheck warnings in tests_common.sh:

SC2250 (style): Prefer putting braces around variable references even when not strictly required.
SC2030 (info): Modification of cmd_out is local (to subshell caused by (..) group).
SC2031 (info): cmd_out was modified in a subshell. That change might be lost.
