### PR TITLE
tests: nvidia: cc: Affirming attestation policy

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -64,7 +64,7 @@ kbs_set_gpu0_resource_policy() {
 		import rego.v1
 		default allow = false
 		allow if {
-		    input["submods"]["gpu0"]["ear.status"] != "contraindicated"
+		    input["submods"]["gpu0"]["ear.status"] == "affirming"
 		}
 	EOF
 


### PR DESCRIPTION
Set the attestation policy for GPU0 to affirming. This requires the GPU, for instance, to have production properties, such as properly signed VBIOS firmware.