### PR TITLE
tests: fix list_routes test

### DIFF
--- a/src/agent/src/netlink.rs
+++ b/src/agent/src/netlink.rs
@@ -994,6 +994,7 @@ mod tests {
     #[tokio::test]
     #[serial(arp_neighbor_tests)]
     async fn list_routes() {
+        skip_if_not_root!();
         clean_env_for_test_add_one_arp_neighbor(TEST_DUMMY_INTERFACE, TEST_ARP_IP);
         let devices: Vec<Interface> = Handle::new().unwrap().list_interfaces().await.unwrap();
         let all = Handle::new()


### PR DESCRIPTION
subsystem: build

fix the list_routes test to skip when not root - add skip_if_not_root as mentioned in other tests

The test doesn't have the skip_if_not_root!() guard that other privileged tests in the same file use (like link_up, add_update_addresses, etc.)

Add skip_if_not_root!() macro to the list_routes test to prevent failures in unprivileged CI environments.

Signed-off-by: Liron Cohen <lironcohcoh@gmail.com>