### PR TITLE
ci: Update AKS setup post Pod Sandboxing GA 

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -128,7 +128,7 @@ function create_cluster() {
 		--node-count 1 \
 		--generate-ssh-keys \
 		--tags "${tags[@]}" \
-		$([[ "${KATA_HOST_OS}" = "cbl-mariner" ]] && echo "--os-sku AzureLinux --workload-runtime KataMshvVmIsolation")
+		$([[ "${KATA_HOST_OS}" = "cbl-mariner" ]] && echo "--os-sku AzureLinux --workload-runtime KataVmIsolation")
 }
 
 function install_bats() {


### PR DESCRIPTION
Update `workload-runtime` value from `KataMshvVmIsolation` to the supported `KataVmIsolation` to align with current AKS Pod Sandboxing documentation.

fixes #12207 