### PR TITLE
versions: Update nydus-snapshotter to v0.15.9

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -12,7 +12,7 @@ FROM golang:1.24-alpine AS nydus-binary-downloader
 
 # Keep the version here aligned with "ndyus-snapshotter.version"
 # in versions.yaml
-ARG NYDUS_SNAPSHOTTER_VERSION=v0.15.2
+ARG NYDUS_SNAPSHOTTER_VERSION=v0.15.9
 ARG NYDUS_SNAPSHOTTER_REPO=https://github.com/containerd/nydus-snapshotter
 
 RUN \

--- a/versions.yaml
+++ b/versions.yaml
@@ -358,7 +358,7 @@ externals:
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.15.2"
+    version: "v0.15.9"
 
   opa:
     description: "Open Policy Agent"


### PR DESCRIPTION
We've missed a few bumps for patch releases in the past.