### PR TITLE
tests: Adjust install_bats()

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -132,11 +132,20 @@ function create_cluster() {
 }
 
 function install_bats() {
-	# Installing bats from the noble repo.
-	sudo apt install -y software-properties-common
-	sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
-	sudo apt install -y bats
-	sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
+	source /etc/os-release
+	case "${ID}" in
+		ubuntu)
+			# Installing bats from the noble repo.
+			sudo apt install -y software-properties-common
+			sudo add-apt-repository 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
+			sudo apt install -y bats
+			sudo add-apt-repository --remove 'deb http://archive.ubuntu.com/ubuntu/ noble universe'
+			;;
+		*)
+			echo "${ID} is not a supported distro, install bats manually"
+			;;
+	esac
+
 }
 
 # Install the kustomize tool in /usr/local/bin if it doesn't exist on


### PR DESCRIPTION
The function assumes that the runner is a Ubuntu machine, which so far has been true as part of our CI.

However, the new ARM runner is running on Debian, and those mirror additions would simply break.

With this in mind, for any distro that's not ubuntu, let's just make sure to inform the owner of the system to have bats already installed as part of the environment provided.