### PR TITLE
ci: arm64-non-k8s: temporarily skip the tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -474,7 +474,7 @@ jobs:
       vmm: ${{ matrix.params.vmm }}
 
   run-cri-containerd-tests-arm64:
-    if: ${{ inputs.skip-test != 'yes' }}
+    if: false
     needs: build-kata-static-tarball-arm64
     strategy:
       fail-fast: false


### PR DESCRIPTION
The runner is down for a few weeks. I may end up bringing in my personal runner, but I'm not confident I can easily do this before the holidays, thus I'm skipping the tests for now.