### PR TITLE
build: Switch all the docker images to quay.io

### DIFF
--- a/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
+++ b/tools/osbuilder/rootfs-builder/ubuntu/Dockerfile.in
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG IMAGE_REGISTRY=docker.io
+ARG IMAGE_REGISTRY=quay.io/kata-containers
 FROM ${IMAGE_REGISTRY}/ubuntu:@OS_VERSION@
 @SET_PROXY@
 

--- a/tools/packaging/kata-debug/Dockerfile
+++ b/tools/packaging/kata-debug/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 
 COPY debug.sh /usr/bin/debug.sh
 

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -2,13 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG BASE_IMAGE_NAME=alpine
+ARG BASE_IMAGE_NAME=quay.io/kata-containers/alpine
 ARG BASE_IMAGE_TAG=3.22
 FROM ${BASE_IMAGE_NAME}:${BASE_IMAGE_TAG} AS base
 
 #### Nydus snapshotter & nydus image
 
-FROM golang:1.24-alpine AS nydus-binary-downloader
+FROM quay.io/kata-containers/golang:1.24-alpine AS nydus-binary-downloader
 
 # Keep the version here aligned with "ndyus-snapshotter.version"
 # in versions.yaml

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ENV INSTALL_IN_GOPATH=false
 # Required for libxml2-dev

--- a/tools/packaging/kata-monitor/Dockerfile
+++ b/tools/packaging/kata-monitor/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2020 Eric Ernst
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.23-alpine AS builder
+FROM quay.io/kata-containers/golang:1.23-alpine AS builder
 
 RUN apk add --no-cache bash curl git make build-base
 WORKDIR /go/src/github.com/kata-containers/kata-containers/src/runtime

--- a/tools/packaging/static-build/busybox/Dockerfile
+++ b/tools/packaging/static-build/busybox/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.20.0
+FROM quay.io/kata-containers/alpine:3.20.0
 
 RUN apk update && apk --no-cache add gpg gpg-agent coreutils bash curl make \
  	gcc g++ pkgconf libselinux-dev gpg-agent

--- a/tools/packaging/static-build/coco-guest-components/Dockerfile
+++ b/tools/packaging/static-build/coco-guest-components/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:24.04
+FROM quay.io/kata-containers/ubuntu:24.04
 ARG RUST_TOOLCHAIN
 
 ENV DEBIAN_FRONTEND=noninteractive

--- a/tools/packaging/static-build/codegen/Dockerfile
+++ b/tools/packaging/static-build/codegen/Dockerfile
@@ -4,7 +4,7 @@
 
 ARG GO_VERSION=
 
-FROM busybox:1.37.0 AS resources
+FROM quay.io/kata-containers/busybox:1.37.0 AS resources
 
 WORKDIR /usr/local
 

--- a/tools/packaging/static-build/initramfs/Dockerfile
+++ b/tools/packaging/static-build/initramfs/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2022 Intel Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 ARG cryptsetup_repo=${cryptsetup_repo}

--- a/tools/packaging/static-build/kernel/Dockerfile
+++ b/tools/packaging/static-build/kernel/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 ARG ARCH

--- a/tools/packaging/static-build/ovmf/Dockerfile
+++ b/tools/packaging/static-build/ovmf/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \

--- a/tools/packaging/static-build/pause-image/Dockerfile
+++ b/tools/packaging/static-build/pause-image/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Intel
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -2,7 +2,7 @@
 # Copyright (c) 2020 Ant Group
 #
 # SPDX-License-Identifier: Apache-2.0
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 
 # CACHE_TIMEOUT: date to invalid cache, if the date changes the image will be rebuild
 # This is required to keep build dependencies with security fixes.

--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 ENV GO_HOME="/opt"

--- a/tools/packaging/static-build/tools/Dockerfile
+++ b/tools/packaging/static-build/tools/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 ARG GO_TOOLCHAIN
 ARG RUST_TOOLCHAIN
 

--- a/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM ubuntu:22.04
+FROM quay.io/kata-containers/ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ARG RUST_TOOLCHAIN
 

--- a/tools/packaging/static-build/virtiofsd/musl/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/musl/Dockerfile
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM alpine:3.16.2
+FROM quay.io/kata-containers/alpine:3.16.2
 ARG RUST_TOOLCHAIN
 
 ENV RUSTUP_HOME="/opt/rustup"


### PR DESCRIPTION
I haven't updated images, this is not the intent of this PR. I'm just switching the already used images to quay.io so we can avoid hitting docker's infamous rate limit in our runners.