### PR TITLE
runtime: oci: Use shares/cpuset for VM CPU sizing

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -17,7 +17,9 @@ use crate::config::TomlConfig;
 use crate::initdata::add_hypervisor_initdata_overrides;
 use crate::sl;
 
-use self::cri_containerd::{SANDBOX_CPU_PERIOD_KEY, SANDBOX_CPU_QUOTA_KEY, SANDBOX_MEM_KEY};
+use self::cri_containerd::{
+    SANDBOX_CPU_PERIOD_KEY, SANDBOX_CPU_QUOTA_KEY, SANDBOX_CPU_SHARE_KEY, SANDBOX_MEM_KEY,
+};
 
 /// CRI-containerd specific annotations.
 pub mod cri_containerd;
@@ -426,6 +428,14 @@ impl Annotation {
     pub fn get_sandbox_cpu_period(&self) -> u64 {
         let value = self
             .get_value::<u64>(SANDBOX_CPU_PERIOD_KEY)
+            .unwrap_or(Some(0));
+        value.unwrap_or(0)
+    }
+
+    /// Get the annotation of cpu shares for sandbox
+    pub fn get_sandbox_cpu_shares(&self) -> u64 {
+        let value = self
+            .get_value::<u64>(SANDBOX_CPU_SHARE_KEY)
             .unwrap_or(Some(0));
         value.unwrap_or(0)
     }

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -41,6 +41,7 @@ import (
 	exp "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/experimental"
 	vcAnnotations "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations"
 	dockershimAnnotations "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations/dockershim"
+	vcpuset "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/cpuset"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	vcutils "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
 )
@@ -1400,6 +1401,8 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32)
 	var memory, quota int64
 	var period uint64
 	var err error
+	var shares uint64
+	var cpuSet string
 
 	if spec == nil || spec.Annotations == nil {
 		return 0, 0
@@ -1429,6 +1432,15 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32)
 		}
 	}
 
+	annotation, ok = spec.Annotations[ctrAnnotations.SandboxCPUShares]
+	if ok {
+		shares, err = strconv.ParseUint(annotation, 10, 64)
+		if err != nil {
+			ociLog.Warningf("sandbox-sizing: failure to parse SandboxCPUShares: %s", annotation)
+			shares = 0
+		}
+	}
+
 	annotation, ok = spec.Annotations[ctrAnnotations.SandboxMem]
 	if ok {
 		memory, err = strconv.ParseInt(annotation, 10, 64)
@@ -1438,7 +1450,11 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32)
 		}
 	}
 
-	return calculateVMResources(period, quota, memory)
+	if spec.Linux != nil && spec.Linux.Resources != nil && spec.Linux.Resources.CPU != nil {
+		cpuSet = spec.Linux.Resources.CPU.Cpus
+	}
+
+	return calculateVMResources(period, quota, shares, cpuSet, memory)
 }
 
 // CalculateContainerSizing will calculate the number of CPUs and amount of memory that is needed
@@ -1446,6 +1462,8 @@ func CalculateSandboxSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32)
 func CalculateContainerSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint32) {
 	var memory, quota int64
 	var period uint64
+	var shares uint64
+	var cpuSet string
 
 	if spec == nil || spec.Linux == nil || spec.Linux.Resources == nil {
 		return 0, 0
@@ -1457,16 +1475,40 @@ func CalculateContainerSizing(spec *specs.Spec) (numCPU float32, memSizeMB uint3
 		quota = *resources.CPU.Quota
 		period = *resources.CPU.Period
 	}
+	if resources.CPU != nil {
+		cpuSet = resources.CPU.Cpus
+		if resources.CPU.Shares != nil {
+			shares = *resources.CPU.Shares
+		}
+	}
 
 	if resources.Memory != nil && resources.Memory.Limit != nil {
 		memory = *resources.Memory.Limit
 	}
 
-	return calculateVMResources(period, quota, memory)
+	return calculateVMResources(period, quota, shares, cpuSet, memory)
 }
 
-func calculateVMResources(period uint64, quota int64, memory int64) (numCPU float32, memSizeMB uint32) {
+func calculateVMResources(period uint64, quota int64, shares uint64, cpuSet string, memory int64) (numCPU float32, memSizeMB uint32) {
 	numCPU = vcutils.CalculateCPUsF(quota, period)
+	if numCPU == 0 {
+		// If quota is unconstrained and CPU shares are provided, use shares as an approximation
+		// of the requested CPUs. This avoids sizing the VM to the full shared/default CPUSet
+		// in best-effort/burstable cases.
+		if shares != 0 {
+			// Kubernetes uses a minimum share value of 2 for best-effort pods. Treat shares
+			// below 1 CPU as 0 for VM sizing, relying on the runtime's base CPU allocation.
+			// Without this, we'll be booting 2 vCPUs for a BestEffort pod.
+			if shares >= 1024 {
+				numCPU = float32(shares) / 1024
+			}
+		} else {
+			set, err := vcpuset.Parse(cpuSet)
+			if err == nil {
+				numCPU = float32(set.Size())
+			}
+		}
+	}
 
 	if memory < 0 {
 		// While spec allows for a negative value to indicate unconstrained, we don't

--- a/src/runtime/pkg/oci/utils_test.go
+++ b/src/runtime/pkg/oci/utils_test.go
@@ -1174,6 +1174,18 @@ func getCtrResourceSpec(memory, quota int64, period uint64) *specs.Spec {
 
 }
 
+func getCtrResourceSpecWithCPUSet(memory, quota int64, period uint64, cpuSet string) *specs.Spec {
+	spec := getCtrResourceSpec(memory, quota, period)
+	spec.Linux.Resources.CPU.Cpus = cpuSet
+	return spec
+}
+
+func getCtrResourceSpecWithShares(memory, quota int64, period uint64, shares uint64) *specs.Spec {
+	spec := getCtrResourceSpec(memory, quota, period)
+	spec.Linux.Resources.CPU.Shares = &shares
+	return spec
+}
+
 func makeSizingAnnotations(memory, quota, period string) *specs.Spec {
 	spec := specs.Spec{
 		Annotations: make(map[string]string),
@@ -1183,6 +1195,24 @@ func makeSizingAnnotations(memory, quota, period string) *specs.Spec {
 	spec.Annotations[ctrAnnotations.SandboxMem] = memory
 
 	return &spec
+}
+
+func makeSizingAnnotationsWithShares(memory, quota, period, shares string) *specs.Spec {
+	spec := makeSizingAnnotations(memory, quota, period)
+	spec.Annotations[ctrAnnotations.SandboxCPUShares] = shares
+	return spec
+}
+
+func makeSizingAnnotationsWithCPUSet(memory, quota, period, cpuSet string) *specs.Spec {
+	spec := makeSizingAnnotations(memory, quota, period)
+	spec.Linux = &specs.Linux{
+		Resources: &specs.LinuxResources{
+			CPU: &specs.LinuxCPU{
+				Cpus: cpuSet,
+			},
+		},
+	}
+	return spec
 }
 
 func TestCalculateContainerSizing(t *testing.T) {
@@ -1239,6 +1269,21 @@ func TestCalculateContainerSizing(t *testing.T) {
 			spec:        getCtrResourceSpec(-1, 10, 1),
 			expectedCPU: 10,
 			expectedMem: 0,
+		},
+		{
+			spec:        getCtrResourceSpecWithCPUSet(1024*1024, -1, 100000, "2-19,32-63"),
+			expectedCPU: 50,
+			expectedMem: 1,
+		},
+		{
+			spec:        getCtrResourceSpecWithShares(1024*1024, -1, 100000, 51200),
+			expectedCPU: 50,
+			expectedMem: 1,
+		},
+		{
+			spec:        getCtrResourceSpecWithShares(1024*1024, -1, 100000, 2),
+			expectedCPU: 0,
+			expectedMem: 1,
 		},
 	}
 
@@ -1297,6 +1342,21 @@ func TestCalculateSandboxSizing(t *testing.T) {
 			spec:        makeSizingAnnotations("4294967296", "400", "100"),
 			expectedCPU: 4,
 			expectedMem: 4096,
+		},
+		{
+			spec:        makeSizingAnnotationsWithCPUSet("1048576", "-1", "100000", "2-19,32-63"),
+			expectedCPU: 50,
+			expectedMem: 1,
+		},
+		{
+			spec:        makeSizingAnnotationsWithShares("1048576", "-1", "100000", "51200"),
+			expectedCPU: 50,
+			expectedMem: 1,
+		},
+		{
+			spec:        makeSizingAnnotationsWithShares("1048576", "-1", "100000", "2"),
+			expectedCPU: 0,
+			expectedMem: 1,
 		},
 	}
 


### PR DESCRIPTION
When cpu quota is unconstrained (usually, when quota=-1), Calculate{Sandbox,Container}Sizing returns 0 CPUs and static_sandbox_resource_mgmt can end up booting the VM with 1 vCPU, even when kubelet pins the workload to a large CPUSet (CPUManager static).

Prefer cpu.shares (1024 shares per CPU) to approximate requested CPUs, and fall back to counting CPUs in the CPUSet when shares are unavailable. Treat shares < 1024 as 0 to avoid oversizing best-effort pods.