### PR TITLE
version: Bump rtnetlink and netlink-packet-route

### DIFF
--- a/src/runtime-rs/Cargo.lock
+++ b/src/runtime-rs/Cargo.lock
@@ -2590,55 +2590,37 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.22.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0e7987b28514adf555dc1f9a5c30dfc3e50750bbaffb1aec41ca7b23dcd8e4"
+checksum = "9ea06a7cec15a9df94c58bddc472b1de04ca53bd32e72da7da2c5dd1c3885edc"
 dependencies = [
- "anyhow",
  "bitflags 2.9.0",
- "byteorder",
  "libc",
  "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.3"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b33524dc0968bfad349684447bfce6db937a9ac3332a1fe60c0c5a5ce63f21"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures 0.3.28",
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror 1.0.69",
- "tokio",
+ "thiserror 2.0.11",
 ]
 
 [[package]]
@@ -3948,18 +3930,18 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.16.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb5850b5aa2c9c0ae44f157694bbe85107a2e13d76eb3178d0e3ee96c410f57"
+checksum = "1f3ee907fdcec9200d13b9cdb64dfc8179cb4ac16ead6ae0ac76333dc41981fc"
 dependencies = [
- "futures 0.3.28",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
- "nix 0.29.0",
+ "nix 0.30.1",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/src/runtime-rs/crates/resource/Cargo.toml
+++ b/src/runtime-rs/crates/resource/Cargo.toml
@@ -40,9 +40,9 @@ tempfile = "3.19.1"
 hex = "0.4"
 
 ## Dependencies from `rust-netlink`
-netlink-packet-route = "0.22"
+netlink-packet-route = "0.26"
 netlink-sys = "0.8"
-rtnetlink = "0.16"
+rtnetlink = "0.19"
 
 # Local dependencies
 agent = { workspace = true }


### PR DESCRIPTION
It aims to upgrade rtnetlink to mitigate netlink log noise. This commit upgrades the `rtnetlink` dependency (and corresponding libraries like `netlink-packet-route`) to address excessive and unnecessary netlink-related logging during sandbox startup.

Problem:
The previously used `rtnetlink v0.16` (depending on `netlink-proto v0.11.3`) generates a high volume of DEBUG/INFO level netlink messages during sandbox initialization. This noise:
1.  Overloads the logging system, often leading to warnings like "slog-async: logger dropped messages due to channel overflow."
2.  Interferes with effective troubleshooting by distracting developers from legitimate Kata errors.

Solution:
We upgrade to `rtnetlink v0.19` (and `netlink-proto v0.12`), as testing confirms that the latest versions have correctly elevated the verbosity of these netlink internal events to the TRACE level.

This change significantly enhances the log analysis experience by suppressing unnecessary network-related logs during startup.

Current log info as below:
```
Dec 12 16:18:04 pek001 kata[1319592]: Preparing QEMU VM
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: prepare vm socket config for sandbox.
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: sandbox: available protection: NoProtection
Dec 12 16:18:04 pek001 kata[1319592]: No PCIe ports available for VM.
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::add_device() Vsock(VsockDevice { id: "4f6a22e951144b8", config: VsockConfig { guest_cid: 4294967295 } })
Dec 12 16:18:04 pek001 kata[1319592]: get network entity from config NetworkWithNetNsConfig { network_model: "tcfilter", netns_path: "/var/run/netns/cni-43dd0db3-3f2f-3d65-bf27-57064cc7869f", queues: 0, network_created: false } tid Pid(1319597)
Dec 12 16:18:04 pek001 kata[1319592]: set netns from old File { fd: 18, path: "net:[4026531840]", read: true, write: false } to new File { fd: 19, path: "/run/netns/cni-43dd0db3-3f2f-3d65-bf27-57064cc7869f", read: true, write: false } tid 1319597
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: Specified IFLA_INET6_ICMP6STATS NLA attribute holds more(most likely new kernel) data which is unknown to netlink-packet-route crate, expecting 48, got 56
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 1, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 1, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 1, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: Specified IFLA_INET6_ICMP6STATS NLA attribute holds more(most likely new kernel) data which is unknown to netlink-packet-route crate, expecting 48, got 56
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 1, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 1, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 1, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 1, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 1, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 1, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 2, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 2, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 2, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 2, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 2, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: set netns from old File { fd: 20, path: "net:[4026533196]", read: true, write: false } to new File { fd: 21, path: "/run/netns/cni-43dd0db3-3f2f-3d65-bf27-57064cc7869f", read: true, write: false } tid 1319597
Dec 12 16:18:04 pek001 kata[1319592]: veth network interface found: eth0
Dec 12 16:18:04 pek001 kata[1319592]: create link with fds [File { fd: 21, path: "/dev/net/tun", read: true, write: true }]
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: Specified IFLA_INET6_ICMP6STATS NLA attribute holds more(most likely new kernel) data which is unknown to netlink-packet-route crate, expecting 48, got 56
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 3, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 3, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 3, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: Specified IFLA_INET6_ICMP6STATS NLA attribute holds more(most likely new kernel) data which is unknown to netlink-packet-route crate, expecting 48, got 56
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 4, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 4, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 4, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 5, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 5, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 5, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 5, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 5, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 6, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 6, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 6, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 7, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 7, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 7, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 8, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 8, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 8, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 8, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 8, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 8, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 8, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 8, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 8, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 9, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 9, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 9, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 9, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 9, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 9, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 9, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 9, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 9, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 9, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 10, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 10, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 10, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 10, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 10, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 10, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: network info NetworkInfoFromLink { interface: Interface { device: "eth0", name: "eth0", ip_addresses: [IPAddress { family: V4, address: "10.244.0.236", mask: "24" }, IPAddress { family: V6, address: "fe80::d063:14ff:febf:ecc6", mask: "64" }], mtu: 1450, hw_addr: "d2:63:14:bf:ec:c6", device_path: "", field_type: "veth", raw_flags: 0 }, neighs: [ARPNeighbor { to_ip_address: Some(IPAddress { family: V6, address: "ff02::16", mask: "" }), device: "eth0", ll_addr: "33:33:00:00:00:16", state: 64, flags: 0 }, ARPNeighbor { to_ip_address: Some(IPAddress { family: V6, address: "ff02::2", mask: "" }), device: "eth0", ll_addr: "33:33:00:00:00:02", state: 64, flags: 0 }], routes: [Route { dest: "", gateway: "10.244.0.1", device: "eth0", source: "", scope: 0, family: V4, flags: 0, mtu: 0 }, Route { dest: "10.244.0.0", gateway: "10.244.0.1", device: "eth0", source: "", scope: 0, family: V4, flags: 0, mtu: 0 }] }
Dec 12 16:18:04 pek001 kata[1319592]: set netns to old 20
Dec 12 16:18:04 pek001 kata[1319592]: set netns to old 18
Dec 12 16:18:04 pek001 kata[1319592]: set netns from old File { fd: 18, path: "net:[4026531840]", read: true, write: false } to new File { fd: 20, path: "/run/netns/cni-43dd0db3-3f2f-3d65-bf27-57064cc7869f", read: true, write: false } tid 1319597
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: Specified IFLA_INET6_ICMP6STATS NLA attribute holds more(most likely new kernel) data which is unknown to netlink-packet-route crate, expecting 48, got 56
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 1, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 1, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 1, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: Specified IFLA_INET6_ICMP6STATS NLA attribute holds more(most likely new kernel) data which is unknown to netlink-packet-route crate, expecting 48, got 56
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 2, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 2, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 3, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 3, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 3, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 4, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 4, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 4, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 5, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 5, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handle: forwarding new request to connection
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: handling messages (request id = RequestId { sequence_number: 6, port: 0 })
Dec 12 16:18:04 pek001 kata[1319592]: handling response to request RequestId { sequence_number: 6, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: done handling response to request RequestId { sequence_number: 6, port: 0 }
Dec 12 16:18:04 pek001 kata[1319592]: NetlinkCodec: decoding next message
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::add_device() Network(NetworkDevice { device_id: "746ed83d8af29c13", config: NetworkConfig { index: 0, host_dev_name: "tap0_kata", virt_iface_name: "eth0", guest_mac: Some(d2:63:14:bf:ec:c6), queue_size: 0, queue_num: 0, use_shared_irq: None, use_generic_irq: None, allow_duplicate_mac: false } })
Dec 12 16:18:04 pek001 kata[1319592]: set netns to old 18
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::hypervisor_config()
Dec 12 16:18:04 pek001 kata[1319592]: QemuInner::add_device() Block(BlockDevice { device_id: "c23bb58860225058", attach_count: 1, config: BlockConfig { path_on_host: "/opt/kata/share/kata-containers/kata-ubuntu-noble-confidential.image", is_readonly: true, no_drop: false, is_direct: None, index: 0, blkdev_aio: IoUring, driver_option: "blk", virt_path: "/dev/vda", pci_path: None, scsi_addr: None, attach_count: 0, major: 0, minor: 0, queue_size: 0, num_queues: 0 } })
Dec 12 16:18:04 pek001 kata[1319592]: Starting QEMU VM
```
With this PR, when a kata starts up,the log as below:
```
Dec 12 19:29:37 pek001 kata[1727997]: Preparing QEMU VM
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: prepare vm socket config for sandbox.
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: sandbox: available protection: NoProtection
Dec 12 19:29:37 pek001 kata[1727997]: No PCIe ports available for VM.
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::add_device() Vsock(VsockDevice { id: "78d3b16fc4c36282", config: VsockConfig { guest_cid: 4294967295 } })
Dec 12 19:29:37 pek001 kata[1727997]: get network entity from config NetworkWithNetNsConfig { network_model: "tcfilter", netns_path: "/var/run/netns/cni-6eb6f678-fd42-e2b4-d97a-b461f901be51", queues: 0, network_created: false } tid Pid(1728002)
Dec 12 19:29:37 pek001 kata[1727997]: set netns from old File { fd: 18, path: "net:[4026531840]", read: true, write: false } to new File { fd: 19, path: "/run/netns/cni-6eb6f678-fd42-e2b4-d97a-b461f901be51", read: true, write: false } tid 1728002
Dec 12 19:29:37 pek001 kata[1727997]: set netns from old File { fd: 20, path: "net:[4026533196]", read: true, write: false } to new File { fd: 21, path: "/run/netns/cni-6eb6f678-fd42-e2b4-d97a-b461f901be51", read: true, write: false } tid 1728002
Dec 12 19:29:37 pek001 kata[1727997]: veth network interface found: eth0
Dec 12 19:29:37 pek001 kata[1727997]: create link with fds [File { fd: 21, path: "/dev/net/tun", read: true, write: true }]
Dec 12 19:29:37 pek001 kata[1727997]: network info NetworkInfoFromLink { interface: Interface { device: "eth0", name: "eth0", ip_addresses: [IPAddress { family: V4, address: "10.244.0.123", mask: "24" }, IPAddress { family: V6, address: "fe80::3086:2fff:fe93:a97d", mask: "64" }], mtu: 1450, hw_addr: "32:86:2f:93:a9:7d", device_path: "", field_type: "veth", raw_flags: 0 }, neighs: [ARPNeighbor { to_ip_address: Some(IPAddress { family: V6, address: "ff02::16", mask: "" }), device: "eth0", ll_addr: "33:33:00:00:00:16", state: 64, flags: 0 }, ARPNeighbor { to_ip_address: Some(IPAddress { family: V6, address: "ff02::2", mask: "" }), device: "eth0", ll_addr: "33:33:00:00:00:02", state: 64, flags: 0 }], routes: [Route { dest: "", gateway: "10.244.0.1", device: "eth0", source: "", scope: 0, family: V4, flags: 0, mtu: 0 }, Route { dest: "10.244.0.0", gateway: "10.244.0.1", device: "eth0", source: "", scope: 0, family: V4, flags: 0, mtu: 0 }] }
Dec 12 19:29:37 pek001 kata[1727997]: set netns to old 20
Dec 12 19:29:37 pek001 kata[1727997]: set netns to old 18
Dec 12 19:29:37 pek001 kata[1727997]: set netns from old File { fd: 18, path: "net:[4026531840]", read: true, write: false } to new File { fd: 20, path: "/run/netns/cni-6eb6f678-fd42-e2b4-d97a-b461f901be51", read: true, write: false } tid 1728002
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::add_device() Network(NetworkDevice { device_id: "df98b6b34e1e152b", config: NetworkConfig { index: 0, host_dev_name: "tap0_kata", virt_iface_name: "eth0", guest_mac: Some(32:86:2f:93:a9:7d), queue_size: 0, queue_num: 0, use_shared_irq: None, use_generic_irq: None, allow_duplicate_mac: false } })
Dec 12 19:29:37 pek001 kata[1727997]: set netns to old 18
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::hypervisor_config()
Dec 12 19:29:37 pek001 kata[1727997]: QemuInner::add_device() Block(BlockDevice { device_id: "e86fc94791c53ccc", attach_count: 1, config: BlockConfig { path_on_host: "/opt/kata/share/kata-containers/kata-ubuntu-noble-confidential.image", is_readonly: true, no_drop: false, is_direct: None, index: 0, blkdev_aio: IoUring, driver_option: "blk", virt_path: "/dev/vda", pci_path: None, scsi_addr: None, attach_count: 0, major: 0, minor: 0, queue_size: 0, num_queues: 0 } })
Dec 12 19:29:37 pek001 kata[1727997]: Starting QEMU VM
```
