### PR TITLE
kata-ctl: Add tests and fix experimental features formatting

### DIFF
--- a/src/runtime-rs/README.md
+++ b/src/runtime-rs/README.md
@@ -120,6 +120,24 @@ See the
 See the
 [debugging section of the developer guide](../../docs/Developer-Guide.md#troubleshoot-kata-containers).
 
+For diagnosing runtime configuration, use the `kata-ctl env` command:
+
+```bash
+# Display the currently applied Kata configuration in JSON format
+kata-ctl env --json
+
+# Display configuration details in TOML format
+kata-ctl env
+
+# Save configuration to a file for analysis
+kata-ctl env --json --file /tmp/kata-config.json
+```
+
+The `kata-ctl env` command provides comprehensive information about the active runtime,
+hypervisor, agent, and host system configuration, which is invaluable for troubleshooting
+and understanding the execution context. See the [`kata-ctl` README](../../tools/kata-ctl/README.md#the-env-command)
+for more details.
+
 An [experimental alternative binary](crates/shim-ctl/README.md) is available that removes containerd dependencies and makes it easier to run the shim proper outside of the runtime's usual deployment environment (i.e. on a developer machine).
 
 ## Limitations

--- a/src/tools/kata-ctl/README.md
+++ b/src/tools/kata-ctl/README.md
@@ -45,6 +45,27 @@ Containers, run:
 $ kata-ctl check all
 ```
 
+### The `env` command
+
+The `env` command displays comprehensive information about the currently applied Kata
+configuration, including details about the host system, runtime, hypervisor, agent,
+and kernel configuration. This is useful for troubleshooting and understanding the
+execution context.
+
+Usage:
+```bash
+# Display environment info in TOML format (default)
+$ kata-ctl env
+
+# Display environment info in JSON format
+$ kata-ctl env --json
+
+# Save environment info to a file
+$ kata-ctl env --json --file /tmp/kata-env.json
+```
+
+The kata-ctl env command provides equivalent functionality to the legacy kata-runtime env command, displaying configuration for the Rust-based runtime-rs.
+
 ### Full details
 
 For a usage statement, run:


### PR DESCRIPTION
- Add comprehensive unit tests for env command
- Fix experimental features to use Debug format
- Improve module documentation