### PR TITLE
kata-deploy: sa: Fix permissions for patching nodefeaturerules

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -29,7 +29,7 @@ rules:
   verbs: ["get", "list"]
 - apiGroups: ["nfd.k8s-sigs.io"]
   resources: ["nodefeaturerules"]
-  verbs: ["create", "get", "list", "watch"]
+  verbs: ["create", "get", "list", "patch", "update", "watch"]
 - apiGroups: ["apps"]
   resources: ["daemonsets"]
   verbs: ["get", "list", "watch"]


### PR DESCRIPTION
I've seen this happening with the GPU SNP CI every now and then, but I don't really understand how this was not caught by the TDX / SNP CI themselves before.

In any case, the error seen is:
```
  Error from server (Forbidden): error when applying patch:
  {"metadata":{"annotations":{"kubectl.kubernetes.io/last-applied-configuration":"{\"apiVersion\":\"nfd.k8s-sigs.io/v1alpha1\",\"kind\":\"NodeFeatureRule\",\"metadata\":{\"annotations\":{},\"name\":\"amd64-tee-keys\"},\"spec\":{\"rules\":[{\"extendedResources\":{\"sev-snp.amd.com/esids\":\"@cpu.security.sev.encrypted_state_ids\"},\"labels\":{\"amd.feature.node.kubernetes.io/snp\":\"true\"},\"matchFeatures\":[{\"feature\":\"cpu.security\",\"matchExpressions\":{\"sev.snp.enabled\":{\"op\":\"Exists\"}}}],\"name\":\"amd.sev-snp\"},{\"extendedResources\":{\"tdx.intel.com/keys\":\"@cpu.security.tdx.total_keys\"},\"labels\":{\"intel.feature.node.kubernetes.io/tdx\":\"true\"},\"matchFeatures\":[{\"feature\":\"cpu.security\",\"matchExpressions\":{\"tdx.enabled\":{\"op\":\"Exists\"}}}],\"name\":\"intel.tdx\"}]}}\n"}}}
  to:
  Resource: "nfd.k8s-sigs.io/v1alpha1, Resource=nodefeaturerules", GroupVersionKind: "nfd.k8s-sigs.io/v1alpha1, Kind=NodeFeatureRule"
  Name: "amd64-tee-keys", Namespace: ""
  for: "/opt/kata-artifacts/node-feature-rules/x86_64-tee-keys.yaml": error when patching "/opt/kata-artifacts/node-feature-rules/x86_64-tee-keys.yaml": nodefeaturerules.nfd.k8s-sigs.io "amd64-tee-keys" is forbidden: User "system:serviceaccount:kube-system:kata-deploy-sa" cannot patch resource "nodefeaturerules" in API group "nfd.k8s-sigs.io" at the cluster scope
```

And the fix is as simple as allowing patching and updating a nodefeaturerule in our service account RBAC.