### PR TITLE
docs: update virtiofs cache mode

### DIFF
--- a/src/runtime/config/configuration-qemu-cca.toml.in
+++ b/src/runtime/config/configuration-qemu-cca.toml.in
@@ -197,7 +197,7 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 
 # Cache mode:
 #
-#  - none
+#  - never
 #    Metadata, data, and pathname lookup are not cached in guest. They are
 #    always fetched from host and any changes are immediately pushed to host.
 #


### PR DESCRIPTION
Update virtiofs last outdated virtiofs cache mode documentation to use never instead of none

Fixes #10759

This is the last out of date documentation and the issue can be closed after this