### PR TITLE
tests: nvidia: Update NIM/RAG samples

### DIFF
--- a/tests/integration/kubernetes/k8s-nvidia-cuda.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-cuda.bats
@@ -71,5 +71,5 @@ teardown() {
     # Clean up resources
     [ -f "${pod_yaml}" ] && kubectl delete -f "${pod_yaml}" --ignore-not-found=true
 
-    print_node_journal_since_test_start "${node}" "${node_start_time:-}" "${BATS_TEST_DIRNAME:-}"
+    print_node_journal_since_test_start "${node}" "${node_start_time:-}" "${BATS_TEST_COMPLETED:-}"
 }

--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -48,6 +48,12 @@ KBS_AUTH_CONFIG_JSON=$(
 )
 export KBS_AUTH_CONFIG_JSON
 
+# Base64 encoding for use as Kubernetes Secret in pod manifests
+NGC_API_KEY_BASE64=$(
+    echo -n "${NGC_API_KEY}" | base64 -w0
+)
+export NGC_API_KEY_BASE64
+
 setup_langchain_flow() {
     # shellcheck disable=SC1091  # Sourcing virtual environment activation script
     source "${HOME}"/.cicd/venv/bin/activate

--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -23,7 +23,7 @@ export TEE
 POD_NAME_EMBEDQA="nvidia-nim-llama-3-2-nv-embedqa-1b-v2"
 POD_NAME_INSTRUCT="nvidia-nim-llama-3-1-8b-instruct"
 POD_READY_TIMEOUT_EMBEDQA_PREDEFINED=500s
-POD_READY_TIMEOUT_INSTRUCT_PREDEFINED=500s
+POD_READY_TIMEOUT_INSTRUCT_PREDEFINED=600s
 if [[ "${TEE}" = "true" ]]; then
     POD_NAME_EMBEDQA="${POD_NAME_EMBEDQA}-tee"
     POD_NAME_INSTRUCT="${POD_NAME_INSTRUCT}-tee"
@@ -235,6 +235,8 @@ EOF
     [[ -n "${POD_IP_EMBEDQA}" ]]
     # shellcheck disable=SC2031  # Variables are shared via file between BATS tests
     [[ -n "${POD_IP_INSTRUCT}" ]]
+    # shellcheck disable=SC2031  # Variables are shared via file between BATS tests
+    [[ -n "${MODEL_NAME}" ]]
 
     # shellcheck disable=SC1091  # Sourcing virtual environment activation script
     source "${HOME}"/.cicd/venv/bin/activate
@@ -350,7 +352,7 @@ EOF
 
     # shellcheck disable=SC2031  # Variables are used in heredoc, not subshell
     cat <<EOF >>"${HOME}"/.cicd/venv/langchain_nim_kata_rag.py
-llm = ChatNVIDIA(base_url="http://${POD_IP_INSTRUCT}:8000/v1", model="meta/llama3-8b-instruct", temperature=0.1, max_tokens=1000, top_p=1.0)
+llm = ChatNVIDIA(base_url="http://${POD_IP_INSTRUCT}:8000/v1", model="${MODEL_NAME}", temperature=0.1, max_tokens=1000, top_p=1.0)
 
 memory = ConversationBufferMemory(memory_key="chat_history", return_messages=True)
 
@@ -412,5 +414,5 @@ teardown_file() {
         [ -f "${POD_EMBEDQA_YAML}" ] && kubectl delete -f "${POD_EMBEDQA_YAML}" --ignore-not-found=true
     fi
 
-    print_node_journal_since_test_start "${node}" "${node_start_time:-}" "${BATS_TEST_DIRNAME:-}"
+    print_node_journal_since_test_start "${node}" "${node_start_time:-}" "${BATS_TEST_COMPLETED:-}" >&3
 }

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
@@ -22,7 +22,7 @@ spec:
     fsGroup: 0
   containers:
   - name: ${POD_NAME_INSTRUCT}
-    image: nvcr.io/nim/meta/llama3-8b-instruct:1.0.0
+    image: nvcr.io/nim/meta/llama-3.1-8b-instruct:1.13.1
     # Ports exposed by the container:
     ports:
       - containerPort: 8000
@@ -31,41 +31,41 @@ spec:
       httpGet:
         path: /v1/health/live
         port: http-openai
-      initialDelaySeconds: 120
+      initialDelaySeconds: 15
       periodSeconds: 10
-      timeoutSeconds: 10
+      timeoutSeconds: 1
       successThreshold: 1
-      failureThreshold: 10
+      failureThreshold: 3
     readinessProbe:
       httpGet:
         path: /v1/health/ready
         port: http-openai
-      initialDelaySeconds: 120
+      initialDelaySeconds: 15
       periodSeconds: 10
-      timeoutSeconds: 10
+      timeoutSeconds: 1
       successThreshold: 1
-      failureThreshold: 10
+      failureThreshold: 3
     startupProbe:
       httpGet:
         path: /v1/health/ready
         port: http-openai
-      initialDelaySeconds: 180
+      initialDelaySeconds: 360
       periodSeconds: 10
-      timeoutSeconds: 10
+      timeoutSeconds: 1
       successThreshold: 1
-      failureThreshold: 300
+      failureThreshold: 30
     env:
       - name: NGC_API_KEY
         valueFrom:
           secretKeyRef:
             name: ngc-api-key-instruct
             key: api-key
-    # GPU resource request/limit (for NVIDIA GPU)
+    # GPU resource limit (for NVIDIA GPU)
     resources:
       limits:
         nvidia.com/pgpu: "1"
         cpu: "16"
-        memory: "64Gi"
+        memory: "128Gi"
 ---
 apiVersion: v1
 kind: Secret

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
@@ -54,10 +54,12 @@ spec:
       timeoutSeconds: 10
       successThreshold: 1
       failureThreshold: 300
-    # Environment variable for NGC_API_KEY. In production, use a Secret.
     env:
       - name: NGC_API_KEY
-        value: "${NGC_API_KEY}"
+        valueFrom:
+          secretKeyRef:
+            name: ngc-api-key-instruct
+            key: api-key
     # GPU resource request/limit (for NVIDIA GPU)
     resources:
       limits:
@@ -72,3 +74,11 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: ${DOCKER_CONFIG_JSON}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ngc-api-key-instruct
+type: Opaque
+data:
+  api-key: "${NGC_API_KEY_BASE64}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct.yaml.in
@@ -20,7 +20,7 @@ spec:
     fsGroup: 0
   containers:
   - name: ${POD_NAME_INSTRUCT}
-    image: nvcr.io/nim/meta/llama3-8b-instruct:1.0.0
+    image: nvcr.io/nim/meta/llama-3.1-8b-instruct:1.13.1
     # Ports exposed by the container:
     ports:
       - containerPort: 8000
@@ -47,26 +47,23 @@ spec:
       httpGet:
         path: /v1/health/ready
         port: http-openai
-      initialDelaySeconds: 40
+      initialDelaySeconds: 150
       periodSeconds: 10
       timeoutSeconds: 1
       successThreshold: 1
-      failureThreshold: 180
+      failureThreshold: 45
     env:
       - name: NGC_API_KEY
         valueFrom:
           secretKeyRef:
             name: ngc-api-key-instruct
             key: api-key
-    # GPU resource request/limit (for NVIDIA GPU)
+    # GPU resource limit (for NVIDIA GPU)
     resources:
-      requests:
-        cpu: "16"
-        memory: "32Gi"
       limits:
         nvidia.com/pgpu: "1"
         cpu: "16"
-        memory: "32Gi"
+        memory: "40Gi"
     # Mount the local .cache directory into the container
     volumeMounts:
       - name: nim-cache

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct.yaml.in
@@ -52,10 +52,12 @@ spec:
       timeoutSeconds: 1
       successThreshold: 1
       failureThreshold: 180
-    # Environment variable for NGC_API_KEY. In production, use a Secret.
     env:
       - name: NGC_API_KEY
-        value: "${NGC_API_KEY}"
+        valueFrom:
+          secretKeyRef:
+            name: ngc-api-key-instruct
+            key: api-key
     # GPU resource request/limit (for NVIDIA GPU)
     resources:
       requests:
@@ -85,3 +87,11 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: ${DOCKER_CONFIG_JSON}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ngc-api-key-instruct
+type: Opaque
+data:
+  api-key: "${NGC_API_KEY_BASE64}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
@@ -27,7 +27,10 @@ spec:
     imagePullPolicy: IfNotPresent
     env:
       - name: NGC_API_KEY
-        value: "${NGC_API_KEY}"
+        valueFrom:
+          secretKeyRef:
+            name: ngc-api-key-embedqa
+            key: api-key
       - name: NIM_HTTP_API_PORT
         value: "8000"
       - name: NIM_JSONL_LOGGING
@@ -81,3 +84,11 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: ${DOCKER_CONFIG_JSON}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ngc-api-key-embedqa
+type: Opaque
+data:
+  api-key: "${NGC_API_KEY_BASE64}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
@@ -23,7 +23,7 @@ spec:
     runAsUser: 0
   containers:
   - name: ${POD_NAME_EMBEDQA}
-    image: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.5.0
+    image: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.10.1
     imagePullPolicy: IfNotPresent
     env:
       - name: NGC_API_KEY
@@ -45,37 +45,37 @@ spec:
       httpGet:
         path: /v1/health/live
         port: 8000
-      initialDelaySeconds: 120
+      initialDelaySeconds: 15
       periodSeconds: 10
-      timeoutSeconds: 10
+      timeoutSeconds: 1
       successThreshold: 1
-      failureThreshold: 10
+      failureThreshold: 3
 
     readinessProbe:
       httpGet:
         path: /v1/health/ready
         port: 8000
-      initialDelaySeconds: 120
+      initialDelaySeconds: 15
       periodSeconds: 10
       timeoutSeconds: 10
       successThreshold: 1
-      failureThreshold: 10
+      failureThreshold: 3
 
     startupProbe:
       httpGet:
         path: /v1/health/ready
         port: 8000
-      initialDelaySeconds: 180
+      initialDelaySeconds: 60
       periodSeconds: 10
-      timeoutSeconds: 10
+      timeoutSeconds: 1
       successThreshold: 1
-      failureThreshold: 300
+      failureThreshold: 180
 
     resources:
       limits:
-        nvidia.com/pgpu: 1
+        nvidia.com/pgpu: "1"
         cpu: "16"
-        memory: "64Gi"
+        memory: "48Gi"
 ---
 apiVersion: v1
 kind: Secret

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2.yaml.in
@@ -27,7 +27,10 @@ spec:
       - name: NIM_CACHE_PATH
         value: "/opt/nim/.cache"
       - name: NGC_API_KEY
-        value: "${NGC_API_KEY}"
+        valueFrom:
+          secretKeyRef:
+            name: ngc-api-key-embedqa
+            key: api-key
       - name: NIM_HTTP_API_PORT
         value: "8000"
       - name: NIM_JSONL_LOGGING
@@ -91,3 +94,11 @@ metadata:
 type: kubernetes.io/dockerconfigjson
 data:
   .dockerconfigjson: ${DOCKER_CONFIG_JSON}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ngc-api-key-embedqa
+type: Opaque
+data:
+  api-key: "${NGC_API_KEY_BASE64}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2.yaml.in
@@ -21,7 +21,7 @@ spec:
     runAsUser: 0
   containers:
   - name: ${POD_NAME_EMBEDQA}
-    image: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.5.0
+    image: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.10.1
     imagePullPolicy: IfNotPresent
     env:
       - name: NIM_CACHE_PATH
@@ -73,7 +73,7 @@ spec:
 
     resources:
       limits:
-        nvidia.com/pgpu: 1
+        nvidia.com/pgpu: "1"
         cpu: "16"
         memory: "32Gi"
 


### PR DESCRIPTION
This PR updates the NIM/RAG image sample references to newer versions - and with this, the PR brings some required changes and additional improvements:
- `llama-3.1-8b-instruct` pod:
  - increase `POD_READY_TIMEOUT_INSTRUCT_PREDEFINED` by 100 seconds - the `llama-3.1-8b-instruct` image is around 6.3 GB larger, thus requires more time to pull, extract, ...
  - no need to increase the 1000s value for the TEE case - this one was already generously estimated (a more tight timeout value could be 850s).
  - with the increased image and model preparation size, increase the initial delay of the startup probe to 150s resp. 360s. On machines such as the ones being used for Kata CI, these are observed minimum times for a pod to be ready. This avoids various 'unhealty' warnings due to starting probing way too early.
  - increase the memory limit for the TEE scenario to 128GB. The container requires at least 54GB local rootfs storage, thus at least 108 GB of memory limit with 50% of memory being assigned to the container rootfs.
  - increase the memory limit for the non-TEE scenario to 40GB
- `llama-3.2-nv-embedqa-1b-v2` pod:
  - reduce initial startup probe and memory resource limits for the TEE case (the container image's size is actually by one GB smaller, around 2GB). This improves performance in CI by about two minutes.
  - adjust to use the proper model name (use `MODEL_NAME` variable instead of hard-coding)

Other changes:
- align probe values between TEE and non-TEE cases where possible and plausible (further fine tuning for these as well as for memory limits is a future exercise)
- fix wrong parameter passdown to `print_node_journal_since_test_start`
- remove obsolete resource requests and add quotation to some resource limits
- use a Kubernetes Secret for the `NGC_API_KEY`