### PR TITLE
tests: added consistency check for Cargo.toml and features.rs

### DIFF
--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -1395,7 +1395,11 @@ static_check_kata_agent_features()
 {
 	local cargo_toml="${repo_path}/src/agent/Cargo.toml"
 	local features_rs="${repo_path}/src/agent/src/features.rs"
+	
+	[ ! -f "$cargo_toml" ] && die "File $cargo_toml not found"
+	[ ! -f "$features_rs" ] && die "File $features_rs not found"
 
+	info "Checking consistency between $cargo_toml and $features_rs"
 
 	# Extract features from [features] section of Cargo.toml
 	local cargo_features=$(sed -n '/^\[features\]/,/^\[/p' "$cargo_toml" | grep '=' | cut -d= -f1)

--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -1395,14 +1395,14 @@ static_check_kata_agent_features()
 {
 	local cargo_toml="${repo_path}/src/agent/Cargo.toml"
 	local features_rs="${repo_path}/src/agent/src/features.rs"
-	
+
 	[ ! -f "$cargo_toml" ] && die "File $cargo_toml not found"
 	[ ! -f "$features_rs" ] && die "File $features_rs not found"
 
 	info "Checking consistency between $cargo_toml and $features_rs"
 
 	# Extract features from [features] section of Cargo.toml
-	local cargo_features=$(sed -n '/^\[features\]/,/^\[/p' "$cargo_toml" | grep '=' | cut -d= -f1)
+	local cargo_features=$(sed -n '/^\[features\]/,/^\[/p' "$cargo_toml" | grep '=' | cut -d= -f1 | tr -d ' ' | grep -v '^#' | sort)
 
 	# Extract features from features.rs
 	local rs_features=$(grep -E '^\s*".*",\s*$' "$features_rs" | tr -d ' ",' | sort)


### PR DESCRIPTION
Checks that the feature list defined in Cargo.toml matches the one declared in features.rs for the Kata agent. It extracts both sets of feature names, compares them, and exits with an error if there’s any mismatch.

Fixes #9319