### PR TITLE
helm: Provide kata-remote runtime class

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/README.md
+++ b/tools/packaging/kata-deploy/helm-chart/README.md
@@ -269,6 +269,7 @@ This includes all available Kata Containers shims:
 - Standard shims: `qemu`, `qemu-runtime-rs`, `clh`, `cloud-hypervisor`, `dragonball`, `fc`
 - TEE shims: `qemu-snp`, `qemu-tdx`, `qemu-se`, `qemu-se-runtime-rs`, `qemu-cca`, `qemu-coco-dev`, `qemu-coco-dev-runtime-rs`
 - NVIDIA GPU shims: `qemu-nvidia-gpu`, `qemu-nvidia-gpu-snp`, `qemu-nvidia-gpu-tdx`
+- Remote shims: `remote` (for `peer-pods`/`cloud-api-adaptor`, disabled by default)
 
 To enable only specific shims, you can override the configuration:
 
@@ -411,6 +412,8 @@ shims:
   qemu-coco-dev:
     enabled: false
   qemu-coco-dev-runtime-rs:
+    enabled: false
+  remote:
     enabled: false
 ```
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -220,6 +220,20 @@ shims:
       httpsProxy: ""
       noProxy: ""
 
+  remote:
+    enabled: false
+    supportedArches:
+      - amd64
+      - s390x
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: "nydus"
+    crio:
+      guestPull: true
+    agent:
+      httpsProxy: ""
+      noProxy: ""
+
 # Default shim per architecture
 defaultShim:
   amd64: qemu


### PR DESCRIPTION
kata-remote is a runtime class that cloud-api-adaptor relies on to work.

kata-remote by itself does nothing, and that's the reason it's disabled by default. We're only adding it here so cloud-api-adaptor charts can simply do something like `--set shims.remote.enabled=true`.