### PR TITLE
runtime: Fix cold-plug CDI device naming

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/device_cold_plug.go
+++ b/src/runtime/pkg/containerd-shim-v2/device_cold_plug.go
@@ -124,21 +124,11 @@ func getDeviceSpec(ctx context.Context, socket string, ann map[string]string) ([
 		for _, d := range container.Devices {
 			shimLog.WithField("container", container.Name).Debugf("Pod Resources Device: %s = %v\n",
 				d.ResourceName, d.DeviceIds)
-			cdiDevs := formatCDIDevIDs(d.ResourceName, d.DeviceIds)
-			devices = append(devices, cdiDevs...)
+			devices = append(devices, d.DeviceIds...)
 		}
 	}
 
 	return devices, nil
-}
-
-// formatCDIDevIDs formats the way CDI package expects
-func formatCDIDevIDs(specName string, devIDs []string) []string {
-	var result []string
-	for _, id := range devIDs {
-		result = append(result, fmt.Sprintf("%s=%s", specName, id))
-	}
-	return result
 }
 
 func debugPodID(ann map[string]string) string {


### PR DESCRIPTION
The device names coming from the Pod Resources API were incorrectly handled, leading to CDI names like `nvidia.com/gpu=nvidia.com/gpu=5`. The name normalization function seems to have been unnecessary, so we remove that and instead use the device ID coming directly from the Pod Resources API, which is the correct fully-qualified Device ID.

Example pod.yaml:

```yaml
apiVersion: v1
kind: Pod
metadata:
  name: kata-test
  annotations:
    io.katacontainers.config.hypervisor.default_memory: "10240"
    io.katacontainers.config.hypervisor.enable_hugepages: "true"
spec:
  runtimeClassName: kata-qemu-nvidia-gpu
  restartPolicy: Never
  containers:
  - name: kata-test
    image: ubuntu:22.04
    resources:
      limits:
        nvidia.com/gpu: 7
        cpu: 500m
        memory: 100Gi
        hugepages-1Gi: 125Gi
      requests:
        nvidia.com/gpu: 7
        cpu: 500m
        memory: 100Gi
        hugepages-1Gi: 125Gi
    command:
      - /bin/bash
      - -lc
      - sleep 9999
```

Refs:
- https://github.com/kata-containers/kata-containers/pull/12087