### PR TITLE
ppc64le: Introduce its own nightly tests

### DIFF
--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -20,9 +20,6 @@ on:
         required: false
         type: string
         default: ""
-    secrets:
-      QUAY_DEPLOYER_PASSWORD:
-        required: true
 
 permissions: {}
 
@@ -43,14 +40,6 @@ jobs:
         stage:
           - ${{ inputs.stage }}
     steps:
-      - name: Login to Kata Containers quay.io
-        if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: quay.io
-          username: ${{ vars.QUAY_DEPLOYER_USERNAME }}
-          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.commit-hash }}
@@ -84,7 +73,7 @@ jobs:
         with:
           name: kata-artifacts-ppc64le-${{ matrix.asset }}${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.zst
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error
 
   build-asset-rootfs:
@@ -101,14 +90,6 @@ jobs:
         stage:
           - ${{ inputs.stage }}
     steps:
-      - name: Login to Kata Containers quay.io
-        if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: quay.io
-          username: ${{ vars.QUAY_DEPLOYER_USERNAME }}
-          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.commit-hash }}
@@ -150,7 +131,7 @@ jobs:
         with:
           name: kata-artifacts-ppc64le-${{ matrix.asset }}${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-${{ matrix.asset }}.tar.zst
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error
 
   # We don't need the binaries installed in the rootfs as part of the release tarball, so can delete them now we've built the rootfs
@@ -176,14 +157,6 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Login to Kata Containers quay.io
-        if: ${{ inputs.push-to-registry == 'yes' }}
-        uses: docker/login-action@74a5d142397b4f367a81961eba4e8cd7edddf772 # v3.4.0
-        with:
-          registry: quay.io
-          username: ${{ vars.QUAY_DEPLOYER_USERNAME }}
-          password: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ inputs.commit-hash }}
@@ -225,7 +198,7 @@ jobs:
         with:
           name: kata-artifacts-ppc64le-shim-v2${{ inputs.tarball-suffix }}
           path: kata-build/kata-static-shim-v2.tar.zst
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error
 
   create-kata-tarball:
@@ -267,5 +240,5 @@ jobs:
         with:
           name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
           path: kata-static.tar.zst
-          retention-days: 1
+          retention-days: 3
           if-no-files-found: error

--- a/.github/workflows/ci-nightly-ppc64le.yaml
+++ b/.github/workflows/ci-nightly-ppc64le.yaml
@@ -1,0 +1,60 @@
+on:
+  schedule:
+    - cron: '0 5 * * *'
+
+name: Nightly CI for ppc64le
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  build-kata-static-tarball-ppc64le:
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
+    with:
+      tarball-suffix: -${{ github.sha }}
+      commit-hash: ${{ github.sha }}
+      target-branch: ${{ github.ref_name }}
+
+  publish-kata-deploy-payload-ppc64le:
+    needs: build-kata-static-tarball-ppc64le
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish-kata-deploy-payload.yaml
+    with:
+      tarball-suffix: -${{ github.sha }}
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ github.sha }}-ppc64le
+      commit-hash: ${{ github.sha }}
+      target-branch: ${{ github.ref_name }}
+      runner: ubuntu-24.04-ppc64le
+      arch: ppc64le
+
+  run-k8s-tests-on-ppc64le:
+    needs: publish-kata-deploy-payload-ppc64le
+    uses: ./.github/workflows/run-k8s-tests-on-ppc64le.yaml
+    with:
+      registry: ghcr.io
+      repo: ${{ github.repository_owner }}/kata-deploy-ci
+      tag: ${{ github.sha }}-ppc64le
+      commit-hash: ${{ github.sha }}
+      pr-number: ""
+      target-branch: ${{ github.ref_name }}
+
+  build-checks:
+    strategy:
+      fail-fast: false
+      matrix:
+        instance:
+          - "ubuntu-24.04-ppc64le"
+    uses: ./.github/workflows/build-checks.yaml
+    with:
+      instance: ${{ matrix.instance }}
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -129,18 +129,6 @@ jobs:
       CI_HKD_PATH: ${{ secrets.ci_hkd_path }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  build-kata-static-tarball-ppc64le:
-    permissions:
-      contents: read
-      packages: write
-    uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
-    with:
-      tarball-suffix: -${{ inputs.tag }}
-      commit-hash: ${{ inputs.commit-hash }}
-      target-branch: ${{ inputs.target-branch }}
-    secrets:
-      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
   publish-kata-deploy-payload-s390x:
     needs: build-kata-static-tarball-s390x
     permissions:
@@ -156,25 +144,6 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
       runner: ubuntu-24.04-s390x
       arch: s390x
-      build-type: ${{ inputs.build-type }}
-    secrets:
-      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
-  publish-kata-deploy-payload-ppc64le:
-    needs: build-kata-static-tarball-ppc64le
-    permissions:
-      contents: read
-      packages: write
-    uses: ./.github/workflows/publish-kata-deploy-payload.yaml
-    with:
-      tarball-suffix: -${{ inputs.tag }}
-      registry: ghcr.io
-      repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ inputs.tag }}-ppc64le
-      commit-hash: ${{ inputs.commit-hash }}
-      target-branch: ${{ inputs.target-branch }}
-      runner: ubuntu-24.04-ppc64le
-      arch: ppc64le
       build-type: ${{ inputs.build-type }}
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
@@ -373,18 +342,6 @@ jobs:
     secrets:
       AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
 
-  run-k8s-tests-on-ppc64le:
-    if: ${{ inputs.skip-test != 'yes' }}
-    needs: publish-kata-deploy-payload-ppc64le
-    uses: ./.github/workflows/run-k8s-tests-on-ppc64le.yaml
-    with:
-      registry: ghcr.io
-      repo: ${{ github.repository_owner }}/kata-deploy-ci
-      tag: ${{ inputs.tag }}-ppc64le${{ inputs.build-type == 'rust' && '-rust' || '' }}
-      commit-hash: ${{ inputs.commit-hash }}
-      pr-number: ${{ inputs.pr-number }}
-      target-branch: ${{ inputs.target-branch }}
-
   run-kata-deploy-tests:
     if: ${{ inputs.skip-test != 'yes' }}
     needs: [publish-kata-deploy-payload-amd64]
@@ -460,25 +417,6 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
       runner: s390x-large
       arch: s390x
-      containerd_version: ${{ matrix.params.containerd_version }}
-      vmm: ${{ matrix.params.vmm }}
-
-  run-cri-containerd-tests-ppc64le:
-    if: ${{ inputs.skip-test != 'yes' }}
-    needs: build-kata-static-tarball-ppc64le
-    strategy:
-      fail-fast: false
-      matrix:
-        params: [
-          { containerd_version: active, vmm: qemu },
-         ]
-    uses: ./.github/workflows/run-cri-containerd-tests.yaml
-    with:
-      tarball-suffix: -${{ inputs.tag }}
-      commit-hash: ${{ inputs.commit-hash }}
-      target-branch: ${{ inputs.target-branch }}
-      runner: ppc64le-small
-      arch: ppc64le
       containerd_version: ${{ matrix.params.containerd_version }}
       vmm: ${{ matrix.params.vmm }}
 

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -56,18 +56,6 @@ jobs:
       CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  build-assets-ppc64le:
-    permissions:
-      contents: read
-      packages: write
-    uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
-    with:
-      commit-hash: ${{ github.sha }}
-      push-to-registry: yes
-      target-branch: ${{ github.ref_name }}
-    secrets:
-      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
   publish-kata-deploy-payload-amd64:
     needs: build-assets-amd64
     permissions:
@@ -122,31 +110,13 @@ jobs:
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  publish-kata-deploy-payload-ppc64le:
-    needs: build-assets-ppc64le
-    permissions:
-      contents: read
-      packages: write
-    uses: ./.github/workflows/publish-kata-deploy-payload.yaml
-    with:
-      commit-hash: ${{ github.sha }}
-      registry: quay.io
-      repo: kata-containers/kata-deploy-ci
-      tag: kata-containers-latest-ppc64le
-      target-branch: ${{ github.ref_name }}
-      runner: ppc64le-small
-      arch: ppc64le
-      build-type: "" # Use script-based build (default)
-    secrets:
-      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
   publish-manifest:
     name: publish-manifest
     runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
-    needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-arm64, publish-kata-deploy-payload-s390x, publish-kata-deploy-payload-ppc64le]
+    needs: [publish-kata-deploy-payload-amd64, publish-kata-deploy-payload-arm64, publish-kata-deploy-payload-s390x]
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -65,23 +65,10 @@ jobs:
       CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
-  build-and-push-assets-ppc64le:
-    needs: release
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
-    uses: ./.github/workflows/release-ppc64le.yaml
-    with:
-      target-arch: ppc64le
-    secrets:
-      QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
-
   publish-multi-arch-images:
     name: publish-multi-arch-images
     runs-on: ubuntu-22.04
-    needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le]
+    needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x]
     permissions:
       contents: write # needed for the `gh release` commands
       packages: write # needed to push the multi-arch manifest to ghcr.io
@@ -118,7 +105,7 @@ jobs:
 
   upload-multi-arch-static-tarball:
     name: upload-multi-arch-static-tarball
-    needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le]
+    needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x]
     permissions:
       contents: write # needed for the `gh release` commands
     runs-on: ubuntu-22.04
@@ -168,18 +155,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ARCHITECTURE: s390x
-
-      - name: Download ppc64le artifacts
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
-        with:
-          name: kata-static-tarball-ppc64le
-
-      - name: Upload ppc64le static tarball to GitHub
-        run: |
-          ./tools/packaging/release/release.sh upload-kata-static-tarball
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ARCHITECTURE: ppc64le
 
       - name: Set KATA_TOOLS_STATIC_TARBALL env var
         run: |
@@ -292,7 +267,7 @@ jobs:
 
   publish-release:
     name: publish-release
-    needs: [ build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le, publish-multi-arch-images, upload-multi-arch-static-tarball, upload-versions-yaml, upload-cargo-vendored-tarball, upload-libseccomp-tarball ]
+    needs: [ build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, publish-multi-arch-images, upload-multi-arch-static-tarball, upload-versions-yaml, upload-cargo-vendored-tarball, upload-libseccomp-tarball ]
     runs-on: ubuntu-22.04
     permissions:
       contents: write # needed for the `gh release` commands

--- a/.github/workflows/static-checks-self-hosted.yaml
+++ b/.github/workflows/static-checks-self-hosted.yaml
@@ -30,7 +30,6 @@ jobs:
         instance:
           - "ubuntu-24.04-arm"
           - "ubuntu-24.04-s390x"
-          - "ubuntu-24.04-ppc64le"
     uses: ./.github/workflows/build-checks.yaml
     with:
       instance: ${{ matrix.instance }}


### PR DESCRIPTION
The ppc64le CI has been a huge hit or miss, either it works well for a few PRs or does not work at all.  This makes super hard to have reliable nightly CIs and / or payloads generated after the build ... thus, let's move it away to its own nightly, as done for RISC-V, which was in a very similar situation.

By doing this, the ones interested on ppc64le support can still have a good visibility of its state, without the extra noise in our CI.