### PR TITLE
dragonball: Use unique name for vhost path

### DIFF
--- a/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/block.rs
+++ b/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/block.rs
@@ -631,7 +631,7 @@ mod tests {
 
     #[test]
     fn test_vhost_user_block_virtio_device_spdk() {
-        let socket_path = "/tmp/vhost.1";
+        let socket_path = concat!("vhost.", line!());
 
         let handler = thread::spawn(move || {
             let listener = Listener::new(socket_path, true).unwrap();
@@ -692,7 +692,7 @@ mod tests {
 
     #[test]
     fn test_vhost_user_block_virtio_device_activate_spdk() {
-        let socket_path = "/tmp/vhost.2";
+        let socket_path = concat!("vhost.", line!());
 
         let handler = thread::spawn(move || {
             // create vhost user block device

--- a/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/fs.rs
+++ b/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/fs.rs
@@ -810,7 +810,7 @@ mod tests {
 
     #[test]
     fn test_vhost_user_fs_virtio_device_normal() {
-        let device_socket = "/tmp/vhost.1";
+        let device_socket = concat!("vhost.", line!());
         let tag = "test_fs";
 
         let handler = thread::spawn(move || {
@@ -879,7 +879,7 @@ mod tests {
 
     #[test]
     fn test_vhost_user_fs_virtio_device_activate() {
-        let device_socket = "/tmp/vhost.1";
+        let device_socket = concat!("vhost.", line!());
         let tag = "test_fs";
 
         let handler = thread::spawn(move || {

--- a/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/net.rs
+++ b/src/dragonball/dbs_virtio_devices/src/vhost/vhost_user/net.rs
@@ -648,7 +648,7 @@ mod tests {
 
     #[test]
     fn test_vhost_user_net_virtio_device_normal() {
-        let device_socket = "/tmp/vhost.1";
+        let device_socket = concat!("vhost.", line!());
         let queue_sizes = Arc::new(vec![128]);
         let epoll_mgr = EpollManager::default();
         let handler = thread::spawn(move || {
@@ -699,7 +699,7 @@ mod tests {
     #[test]
     fn test_vhost_user_net_virtio_device_activate() {
         skip_if_not_root!();
-        let device_socket = "/tmp/vhost.1";
+        let device_socket = concat!("vhost.", line!());
         let queue_sizes = Arc::new(vec![128]);
         let epoll_mgr = EpollManager::default();
         let handler = thread::spawn(move || {


### PR DESCRIPTION
The five tests are set to the same vhost socket path, which could lead to racing with one another. Use unique name to avoid this.

Signed-off-by: Ruoqing He <heruoqing@iscas.ac.cn>