### PR TITLE
kata-deploy: rust: Add list verb for runtimeclasses RBAC

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -23,7 +23,7 @@ rules:
   verbs: ["get", "patch"]
 - apiGroups: ["node.k8s.io"]
   resources: ["runtimeclasses"]
-  verbs: ["get", "patch"]
+  verbs: ["get", "list", "patch"]
 - apiGroups: ["apiextensions.k8s.io"]
   resources: ["customresourcedefinitions"]
   verbs: ["get", "list"]


### PR DESCRIPTION
The Rust kata-deploy binary calls list_runtimeclasses() during NFD setup, but the ClusterRole only granted get and patch permissions.

Add the list verb to the runtimeclasses resource permissions to fix the RBAC error:
  runtimeclasses.node.k8s.io is forbidden: User
  \"system:serviceaccount:kube-system:kata-deploy-sa\" cannot list
  resource \"runtimeclasses\" in API group \"node.k8s.io\" at the
  cluster scope