### PR TITLE
tests: remove re-delcared local variable in k8s-empty-dirs.bats

### DIFF
--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -58,7 +58,6 @@ setup() {
 	local image
 	local logs
 	local pod_file
-	local pod_logs_file
 	local uid
 
 	[[ "${KATA_HYPERVISOR}" = qemu-se* ]] && \


### PR DESCRIPTION
Since #12204 was merged, the following error has been observed:

```
bats warning: Executed 1 instead of expected 2 tests
[run_kubernetes_tests.sh:162] ERROR: Tests FAILED from suites: k8s-empty-dirs.bats
```

The cause is that `pod_logs_file` is re-declared as a local variable in the second test before skipping, which makes it inaccessible in `teardown()` and leads to an error.

This PR removes the re-declaration of the variable.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>