### PR TITLE
workflows: payload: do not remove AGENT_TOOLSDIRECTORY

### DIFF
--- a/.github/workflows/publish-kata-deploy-payload.yaml
+++ b/.github/workflows/publish-kata-deploy-payload.yaml
@@ -63,7 +63,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf /usr/lib/jvm
           sudo rm -rf /usr/share/swift
           sudo rm -rf /usr/local/share/powershell

--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -327,7 +327,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf /usr/lib/jvm
           sudo rm -rf /usr/share/swift
           sudo rm -rf /usr/local/share/powershell

--- a/.github/workflows/run-kata-deploy-tests.yaml
+++ b/.github/workflows/run-kata-deploy-tests.yaml
@@ -66,7 +66,6 @@ jobs:
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
           sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
           sudo rm -rf /usr/lib/jvm
           sudo rm -rf /usr/share/swift
           sudo rm -rf /usr/local/share/powershell


### PR DESCRIPTION
The workflow currently deletes $AGENT_TOOLSDIRECTORY. On GitHub-hosted runners
this is safe because the runners are ephemeral. On self-hosted runners,
$AGENT_TOOLSDIRECTORY points to /opt/hostedtoolcache, which is persistent
and shared. Removing it breaks subsequent jobs, forces tool re-downloads,
and causes permission errors.

Audit logs confirm the deletion happens via `rm -rf $AGENT_TOOLSDIRECTORY`
during workflow execution.

This PR removes that line to avoid destructive behavior on self-hosted runners.