### PR TITLE
runtime-rs: enable sandbox feature for containerd-shim-protos

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,7 +112,7 @@ actix-rt = "2.7.0"
 anyhow = "1.0"
 async-trait = "0.1.48"
 containerd-shim = { version = "0.10.0", features = ["async"] }
-containerd-shim-protos = { version = "0.10.0", features = ["async"] }
+containerd-shim-protos = { version = "0.10.0", features = ["async", "sandbox"] }
 go-flag = "0.1.0"
 hyper = "0.14.20"
 hyperlocal = "0.8.0"


### PR DESCRIPTION
The containerd-shim-protos dependency in the root Cargo.toml was missing the sandbox feature. This caused build failures in clean environments because the sandbox and sandbox_async modules were not being compiled, leading to unresolved import errors in crates that rely on sandbox_api.

This patch explicitly adds sandbox to the workspace dependency features.