### PR TITLE
versions: Bump sha2 crate version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -771,12 +771,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpuid-bool"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8aebca1129a03dc6dc2b127edd729435bbc4a37e1d5f4d7513165089ceb02634"
-
-[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2378,7 +2372,7 @@ dependencies = [
  "nix 0.23.2",
  "once_cell",
  "serde",
- "sha2 0.9.3",
+ "sha2 0.9.9",
  "thiserror 1.0.48",
  "uuid 0.8.2",
 ]
@@ -4430,13 +4424,13 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.9.3"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa827a14b29ab7f44778d14a88d3cb76e949c45083f7dbfa507d0cb699dc12de"
+checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
 dependencies = [
  "block-buffer 0.9.0",
  "cfg-if 1.0.0",
- "cpuid-bool",
+ "cpufeatures",
  "digest 0.9.0",
  "opaque-debug",
 ]
@@ -4482,7 +4476,7 @@ dependencies = [
  "runtimes",
  "serial_test 0.10.0",
  "service",
- "sha2 0.9.3",
+ "sha2 0.10.9",
  "slog",
  "slog-async",
  "slog-scope",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,6 +127,7 @@ protobuf = "3.7.2"
 rand = "0.8.4"
 serde = { version = "1.0.145", features = ["derive"] }
 serde_json = "1.0.91"
+sha2 = "0.10.9"
 slog = "2.5.2"
 slog-scope = "4.4.0"
 strum = { version = "0.24.0", features = ["derive"] }

--- a/src/runtime-rs/crates/shim/Cargo.toml
+++ b/src/runtime-rs/crates/shim/Cargo.toml
@@ -24,7 +24,7 @@ libc = { workspace = true }
 log = { workspace = true }
 nix = { workspace = true }
 protobuf = { workspace = true }
-sha2 = "=0.9.3"
+sha2 = { workspace = true }
 slog = { workspace = true, features = [
     "std",
     "release_max_level_trace",


### PR DESCRIPTION
sha2 0.9.3 includes the use of cpuid-bool, which was renamed to cpufeatures around 5 years ago. Try moving to a workspace dependency of sha2 and bumping to the latest version to remediate RUSTSEC-2021-0064