### PR TITLE
docs: Fix trusted-image-storage reference

### DIFF
--- a/docs/how-to/how-to-pull-images-in-guest-with-kata.md
+++ b/docs/how-to/how-to-pull-images-in-guest-with-kata.md
@@ -256,7 +256,7 @@ spec:
             values:
             - NODE_NAME
   volumes:
-    - name: trusted-storage
+    - name: trusted-image-storage
       persistentVolumeClaim:
         claimName: trusted-pvc
   containers:


### PR DESCRIPTION
The sample uses a volume device name which does not exist, hence fix.