### PR TITLE
genpolicy: retry failed image pulls

### DIFF
--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -109,6 +109,15 @@ struct CommandLineOptions {
 
     #[clap(long, help = "Path to the initdata TOML file", require_equals = true)]
     initdata_path: Option<String>,
+
+    #[clap(
+        short,
+        long,
+        help = "Maximum amount of attempts for pulling manifests, config and image layers before giving up.",
+        default_value_t = 5,
+        require_equals = true
+    )]
+    max_pull_attempts: u8,
 }
 
 /// Application configuration, derived from on command line parameters.
@@ -131,6 +140,7 @@ pub struct Config {
     pub layers_cache: layers_cache::ImageLayersCache,
     pub version: bool,
     pub initdata: kata_types::initdata::InitData,
+    pub max_pull_attempts: u8,
 }
 
 impl Config {
@@ -182,6 +192,7 @@ impl Config {
             layers_cache: layers_cache::ImageLayersCache::new(&layers_cache_file_path),
             version: args.version,
             initdata,
+            max_pull_attempts: args.max_pull_attempts,
         }
     }
 }

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -121,6 +121,7 @@ mod tests {
             version: false,
             yaml_file: workdir.join("pod.yaml").to_str().map(|s| s.to_string()),
             initdata: kata_types::initdata::InitData::new("sha256", "0.1.0"),
+            max_pull_attempts: 1,
         };
 
         // The container repos/network calls can be unreliable, so retry


### PR DESCRIPTION
Prior to this commit, genpolicy immediately failed upon encountering an error while pulling the manifest and config, or the image layers.

Since the cause of these errors can often be a transient networking issue, this behavior leads to avoidable panics. This is especially unfortunate in CI environments, where entire runs might be aborted at an early stage due to a genpolicy error.

This commit introduces a retry mechanism with an exponential backoff. Users can specify the `max-pull-attempts` arg when calling genpolicy to specify how often failed pulls should be retried. The default is set at 5 pull attempts, and this pool is reset after each successful pull, i.e. the manifest and config pull is attempted up to `max-pull-attempts` times, and afterwards, the image layer pulls are again retried up to `max-pull-attempts` times.