### PR TITLE
tests: k8s: Adjust terminationGracePeriodSeconds to 1

### DIFF
--- a/tests/integration/kubernetes/k8s-liveness-probes.bats
+++ b/tests/integration/kubernetes/k8s-liveness-probes.bats
@@ -61,7 +61,9 @@ setup() {
 
 	# Sleep necessary to check liveness probe returns a failure code
 	sleep "$sleep_liveness"
-	kubectl describe pod "$pod_name" | grep "Started container"
+	# For k8s up to 1.34 we need to check for "Started container"
+	# For k8s 1.35 and onwards we need to check for "Container started"
+	kubectl describe pod "$pod_name" | grep -E "Started container|Container started" 
 }
 
 
@@ -87,7 +89,9 @@ setup() {
 
 	# Sleep necessary to check liveness probe returns a failure code
 	sleep "$sleep_liveness"
-	kubectl describe pod "$pod_name" | grep "Started container"
+	# For k8s up to 1.34 we need to check for "Started container"
+	# For k8s 1.35 and onwards we need to check for "Container started"
+	kubectl describe pod "$pod_name" | grep -E "Started container|Container started" 
 }
 
 teardown() {


### PR DESCRIPTION
Although I'm not exactly sure this is what's causing the issues with the livenessProbe tests when using k8s 1.35, the k8s documentation explicitly mentions:
```
terminationGracePeriodSeconds: configure a grace period for the kubelet
to wait between triggering a shut down of the failed container, and then
forcing the container runtime to stop that container. The default is to
inherit the Pod-level value for terminationGracePeriodSeconds (30
seconds if not specified), and the minimum value is 1.
```

With this in mind, let's adjust the values we're using and see if it makes any difference.

https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/#configure-probes