### PR TITLE
runtime: nvidia: change kernel parameters

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -476,13 +476,11 @@ ifneq (,$(QEMUCMD))
     DEFAULTVFIOPORT_NV = root-port
     DEFAULTPCIEROOTPORT_NV = 8
 
-    KERNELPARAMS_NV =  "agent.hotplug_timeout=20"
-    KERNELPARAMS_NV += "cgroup_no_v1=all"
-
-    KERNELTDXPARAMS_NV = $(KERNELPARAMS_NV)
-    KERNELTDXPARAMS_NV += "authorize_allow_devs=pci:ALL"
-
-    KERNELSNPPARAMS_NV = $(KERNELPARAMS_NV)
+    # Disable the devtmpfs mount in guest. NVRC does this, and later kata-agent
+    # attempts this as well in a non-failing manner. Otherwise, NVRC fails when
+    # using an image and /dev is already mounted.
+    KERNELPARAMS_NV = "cgroup_no_v1=all"
+    KERNELPARAMS_NV += "devtmpfs.mount=0"
 
     # Setting this to false can lead to cgroup leakages in the host
     # Best practice for production is to set this to true
@@ -660,8 +658,6 @@ USER_VARS += DEFAULTMEMORY_NV
 USER_VARS += DEFAULTVFIOPORT_NV
 USER_VARS += DEFAULTPCIEROOTPORT_NV
 USER_VARS += KERNELPARAMS_NV
-USER_VARS += KERNELTDXPARAMS_NV
-USER_VARS += KERNELSNPPARAMS_NV
 USER_VARS += DEFAULTTIMEOUT_NV
 USER_VARS += DEFSANDBOXCGROUPONLY_NV
 USER_VARS += DEFROOTFSTYPE

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -90,7 +90,7 @@ snp_guest_policy = 196608
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
-kernel_params = "@KERNELSNPPARAMS_NV@"
+kernel_params = "@KERNELPARAMS_NV@"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -67,7 +67,7 @@ valid_hypervisor_paths = @QEMUTDXEXPERIMENTALVALIDHYPERVISORPATHS@
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
-kernel_params = "@KERNELTDXPARAMS_NV@"
+kernel_params = "@KERNELPARAMS_NV@"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty


### PR DESCRIPTION
This PR makes various changes to the default NVIDIA kernel parameters.
1. Remove the agent hotplug timeout parameter from the kernel command line. Having shifted to VFIO cold-plug, this parameter is no longer needed. This shift was previously done in [PR #12550](https://github.com/kata-containers/kata-containers/pull/12250)
2. Remove the no longer required parameter for TDX and thus align the SNP and TDX configurations.
3. Add a parameter to avoid the kernel to mount the /dev tmpfs. NVRC and later on kata-agent attempt this. While kata-agent does not panic when mounting /dev fails, NVRC makes mounting /dev a hard requirement.