### PR TITLE
kata-deploy (rs): Remove unused dependency

### DIFF
--- a/tools/packaging/kata-deploy/binary/Cargo.lock
+++ b/tools/packaging/kata-deploy/binary/Cargo.lock
@@ -893,7 +893,6 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
- "toml",
  "toml_edit",
  "walkdir",
 ]
@@ -1726,15 +1725,6 @@ dependencies = [
  "pin-project-lite",
  "slab",
  "tokio",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]

--- a/tools/packaging/kata-deploy/binary/Cargo.toml
+++ b/tools/packaging/kata-deploy/binary/Cargo.toml
@@ -23,7 +23,6 @@ env_logger = "0.10"
 clap = { version = "4.5", features = ["derive"] }
 
 # TOML parsing and manipulation
-toml = "0.5.8"
 toml_edit = "0.22"
 
 # YAML parsing and manipulation


### PR DESCRIPTION
We're depending solely on toml_edit, thus we can safely remove the toml dependency.