### PR TITLE
ci: Fix stalebot permissions

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -6,14 +6,21 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   stale:
     name: stale
     runs-on: ubuntu-22.04
+    permissions:
+      actions: write # Needed to manage caches for state persistence across runs
+      pull-requests: write # Needed to add/remove labels, post comments, or close PRs
     steps:
       - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
-          stale-pr-message: 'This PR has been opened without with no activity for 180 days. Comment on the issue otherwise it will be closed in 7 days'
+          stale-pr-message: 'This PR has been opened without activity for 180 days. Please comment on the issue or it will be closed in 7 days.'
           days-before-pr-stale: 180
           days-before-pr-close: 7
           days-before-issue-stale: -1


### PR DESCRIPTION
When looking into stale bot more for issues, I realised that our existing stale job would need permissions to work. Unfortunately the behaviour of the actions without these permissions is to log, but still finish as successful. This means it was hard to spot we had an issue.

Add the required permissions to get this working again and improve the message