### PR TITLE
kata-deploy: Fix extraction of the containerd major version

### DIFF
--- a/tools/packaging/kata-deploy/scripts/kata-deploy.sh
+++ b/tools/packaging/kata-deploy/scripts/kata-deploy.sh
@@ -288,8 +288,8 @@ function is_containerd_capable_of_using_drop_in_files() {
 		return
 	fi
 
-	local version_major=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}' | grep -oE '[0-9]+\.[0-9]+' | cut -d'.' -f1)
-	if [ $version_major -lt 2 ]; then
+	local major_version=$(kubectl get node $NODE_NAME -o jsonpath='{.status.nodeInfo.containerRuntimeVersion}' | grep -oE '[0-9]+\.[0-9]+' | head -n1 | cut -d'.' -f1)
+	if [ $major_version -lt 2 ]; then
 		# Only containerd 2.0 does the merge of the plugins section from different snippets,
 		# instead of overwritting the whole section, which makes things considerably more
 		# complicated for us to deal with.


### PR DESCRIPTION
When deploying kata-containers using k3s the script fails with /opt/kata-artifacts/scripts/kata-deploy.sh: line 397: [: too many arguments

The script tries to extract the major version for containerd which is in the form containerd://2.1.5-k3s1.33

The current script extracts the major versions for both containerd (2) and k3s (1), hence the too many arguments error.

The fix simply extracts the first occurrence which is the one corresponding to containerd.

Perhaps, it could be simplified further, but this minor change works fine.
