### PR TITLE
virtiofsd: fix RUSTUP_HOME and CARGO_HOME permissions for non-root bu…

### DIFF
--- a/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
@@ -12,7 +12,7 @@ ENV PATH="/opt/cargo/bin/:${PATH}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME} && chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
+RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME}
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
@@ -24,7 +24,8 @@ RUN apt-get update && \
         libseccomp-dev \
         unzip && \
     apt-get clean && rm -rf /var/lib/lists/ && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
+    chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
 
 RUN ARCH=$(uname -m); \
     	rust_arch=""; \

--- a/tools/packaging/static-build/virtiofsd/musl/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/musl/Dockerfile
@@ -11,7 +11,7 @@ ENV PATH="/opt/cargo/bin/:${PATH}"
 
 SHELL ["/bin/ash", "-o", "pipefail", "-c"]
 
-RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME} && chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
+RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME}
 
 RUN apk --no-cache add \
         bash \
@@ -21,7 +21,8 @@ RUN apk --no-cache add \
         libcap-ng-static \
         libseccomp-static \
         musl-dev && \
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
+	chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
 
 RUN ARCH=$(uname -m); \
     	rust_arch=""; \


### PR DESCRIPTION
The following error was observed during virtiofsd static build:

```
error: could not create temp file /opt/rustup/tmp/p44enysfaxwdbvw4_file:
Permission denied (os error 13)
```

This occurs because RUSTUP_HOME and CARGO_HOME were initialized by the root user during `docker build`, but `cargo build` is executed as a non-root user via 'docker run --user'.

This PR ensures these directories are writable by adjusting the permission after the toolchain installation is complete.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>