### PR TITLE
agent: change secure_storage_integrity default

### DIFF
--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -269,7 +269,7 @@ impl Default for AgentConfig {
             no_proxy: String::from(""),
             guest_components_rest_api: GuestComponentsFeatures::default(),
             guest_components_procs: GuestComponentsProcs::default(),
-            secure_storage_integrity: false,
+            secure_storage_integrity: true,
             #[cfg(feature = "agent-policy")]
             policy_file: String::from(""),
             mem_agent: None,
@@ -911,7 +911,7 @@ mod tests {
                     no_proxy: "",
                     guest_components_rest_api: GuestComponentsFeatures::default(),
                     guest_components_procs: GuestComponentsProcs::default(),
-                    secure_storage_integrity: false,
+                    secure_storage_integrity: true,
                     #[cfg(feature = "agent-policy")]
                     policy_file: "",
                     mem_agent: None,
@@ -1364,7 +1364,7 @@ mod tests {
             },
             TestData {
                 contents: "",
-                secure_storage_integrity: false,
+                secure_storage_integrity: true,
                 ..Default::default()
             },
             TestData {

--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -116,11 +116,6 @@ setup() {
             "${create_container_timeout}"
     fi
 
-    # Enable dm-integrity in guest
-    set_metadata_annotation "${pod_config}" \
-        "io.katacontainers.config.hypervisor.kernel_params" \
-        "agent.secure_storage_integrity=true"
-
     # Set annotation to pull image in guest
     set_metadata_annotation "${pod_config}" \
         "io.containerd.cri.runtime-handler" \
@@ -160,11 +155,6 @@ setup() {
     set_metadata_annotation "$pod_config" \
         "io.katacontainers.config.runtime.create_container_timeout" \
         "${create_container_timeout}"
-
-    # Enable dm-integrity in guest
-    set_metadata_annotation "${pod_config}" \
-        "io.katacontainers.config.hypervisor.kernel_params" \
-        "agent.secure_storage_integrity=true"
 
     # Set annotation to pull image in guest
     set_metadata_annotation "${pod_config}" \
@@ -218,11 +208,6 @@ setup() {
     set_metadata_annotation "$pod_config" \
         "io.katacontainers.config.runtime.create_container_timeout" \
         "${create_container_timeout}"
-
-    # Enable dm-integrity in guest
-    set_metadata_annotation "${pod_config}" \
-        "io.katacontainers.config.hypervisor.kernel_params" \
-        "agent.secure_storage_integrity=true"
 
     # Set annotation to pull image in guest
     set_metadata_annotation "${pod_config}" \


### PR DESCRIPTION
Change the secure_storage_integrity option's default value to true. With this, integrity protection for encrypted block device contents will be requested from the confidential data hub by default, see the agent's cdh_handler_trusted_storage function in rpc.rs. This behavior can be disabled by explicitly setting the agent.secure_storage_integrity parameter to 0 or false via kernel command line parameters.

This will affect the trusted storage implementation for the guest-pull mechanism, and it will affect future implementations using this code path, such as implementations for ephemeral secure storage: https://github.com/kata-containers/kata-containers/pull/10559/files