### PR TITLE
runtime: nvidia: Use image and sanitize whitespaces

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -153,6 +153,8 @@ FIRMWARETDVFVOLUMEPATH :=
 FIRMWARESNPPATH := $(PREFIXDEPS)/share/ovmf/AMDSEV.fd
 
 ROOTMEASURECONFIG ?= ""
+ROOTMEASURECONFIG_NV ?= ""
+
 KERNELTDXPARAMS += $(ROOTMEASURECONFIG)
 KERNELQEMUCOCODEVPARAMS += $(ROOTMEASURECONFIG)
 
@@ -482,6 +484,7 @@ ifneq (,$(QEMUCMD))
     # using an image and /dev is already mounted.
     KERNELPARAMS_NV = "cgroup_no_v1=all"
     KERNELPARAMS_NV += "devtmpfs.mount=0"
+    KERNELPARAMS_NV += $(ROOTMEASURECONFIG_NV)
 
     # Setting this to false can lead to cgroup leakages in the host
     # Best practice for production is to set this to true

--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -154,6 +154,7 @@ FIRMWARESNPPATH := $(PREFIXDEPS)/share/ovmf/AMDSEV.fd
 
 ROOTMEASURECONFIG ?= ""
 ROOTMEASURECONFIG_NV ?= ""
+ROOTMEASURECONFIG_CONFIDENTIAL_NV ?= ""
 
 KERNELTDXPARAMS += $(ROOTMEASURECONFIG)
 KERNELQEMUCOCODEVPARAMS += $(ROOTMEASURECONFIG)
@@ -482,9 +483,14 @@ ifneq (,$(QEMUCMD))
     # Disable the devtmpfs mount in guest. NVRC does this, and later kata-agent
     # attempts this as well in a non-failing manner. Otherwise, NVRC fails when
     # using an image and /dev is already mounted.
-    KERNELPARAMS_NV = "cgroup_no_v1=all"
-    KERNELPARAMS_NV += "devtmpfs.mount=0"
+    KERNELPARAMS_NV_COMMON = "cgroup_no_v1=all"
+    KERNELPARAMS_NV_COMMON += "devtmpfs.mount=0"
+
+    KERNELPARAMS_NV = $(KERNELPARAMS_NV_COMMON)
     KERNELPARAMS_NV += $(ROOTMEASURECONFIG_NV)
+
+    KERNELPARAMS_CONFIDENTIAL_NV = $(KERNELPARAMS_NV_COMMON)
+    KERNELPARAMS_CONFIDENTIAL_NV += $(ROOTMEASURECONFIG_CONFIDENTIAL_NV)
 
     # Setting this to false can lead to cgroup leakages in the host
     # Best practice for production is to set this to true
@@ -662,6 +668,7 @@ USER_VARS += DEFAULTMEMORY_NV
 USER_VARS += DEFAULTVFIOPORT_NV
 USER_VARS += DEFAULTPCIEROOTPORT_NV
 USER_VARS += KERNELPARAMS_NV
+USER_VARS += KERNELPARAMS_CONFIDENTIAL_NV
 USER_VARS += DEFAULTTIMEOUT_NV
 USER_VARS += DEFSANDBOXCGROUPONLY_NV
 USER_VARS += DEFROOTFSTYPE

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -15,7 +15,7 @@
 [hypervisor.qemu]
 path = "@QEMUSNPPATH@"
 kernel = "@KERNELPATH_CONFIDENTIAL_NV@"
-initrd = "@INITRDPATH_CONFIDENTIAL_NV@"
+image = "@IMAGEPATH_CONFIDENTIAL_NV@"
 
 machine_type = "@MACHINETYPE@"
 
@@ -34,7 +34,7 @@ rootfs_type = @DEFROOTFSTYPE@
 #
 # Known limitations:
 # * Does not work by design:
-#   - CPU Hotplug 
+#   - CPU Hotplug
 #   - Memory Hotplug
 #   - NVDIMM devices
 #
@@ -75,7 +75,7 @@ snp_id_auth = ""
 
 # SNP Guest Policy, the ‘POLICY’ parameter to the SNP_LAUNCH_START command.
 # If unset, the QEMU default policy (0x30000) will be used.
-# Notice that the guest policy is enforced at VM launch, and your pod VMs 
+# Notice that the guest policy is enforced at VM launch, and your pod VMs
 # won't start at all if the policy denys it. This will be indicated by a
 # 'SNP_LAUNCH_START' error.
 snp_guest_policy = 196608
@@ -388,10 +388,10 @@ disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM_NV@
 pcie_root_port = 0
 
 # In a confidential compute environment hot-plugging can compromise
-# security. 
-# Enable cold-plugging of VFIO devices to a bridge-port, 
-# root-port or switch-port. 
-# The default setting is  "no-port", which means disabled. 
+# security.
+# Enable cold-plugging of VFIO devices to a bridge-port,
+# root-port or switch-port.
+# The default setting is  "no-port", which means disabled.
 cold_plug_vfio = "@DEFAULTVFIOPORT_NV@"
 
 # If vhost-net backend for virtio-net is not desired, set to true. Default is false, which trades off
@@ -704,9 +704,9 @@ enable_pprof = false
 
 # Indicates the CreateContainer request timeout needed for the workload(s)
 # It using guest_pull this includes the time to pull the image inside the guest
-# Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)  
-# Note: The effective timeout is determined by the lesser of two values: runtime-request-timeout from kubelet config 
-# (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout) and create_container_timeout. 
+# Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)
+# Note: The effective timeout is determined by the lesser of two values: runtime-request-timeout from kubelet config
+# (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout) and create_container_timeout.
 # In essence, the timeout used for guest pull=runtime-request-timeout<create_container_timeout?runtime-request-timeout:create_container_timeout.
 create_container_timeout = @DEFAULTTIMEOUT_NV@
 

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -90,7 +90,7 @@ snp_guest_policy = 196608
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
-kernel_params = "@KERNELPARAMS_NV@"
+kernel_params = "@KERNELPARAMS_CONFIDENTIAL_NV@"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -14,7 +14,7 @@
 [hypervisor.qemu]
 path = "@QEMUTDXEXPERIMENTALPATH@"
 kernel = "@KERNELPATH_CONFIDENTIAL_NV@"
-initrd = "@INITRDPATH_CONFIDENTIAL_NV@"
+image = "@IMAGEPATH_CONFIDENTIAL_NV@"
 
 machine_type = "@MACHINETYPE@"
 tdx_quote_generation_service_socket_port = @QEMUTDXQUOTEGENERATIONSERVICESOCKETPORT@
@@ -34,7 +34,7 @@ rootfs_type = @DEFROOTFSTYPE@
 #
 # Known limitations:
 # * Does not work by design:
-#   - CPU Hotplug 
+#   - CPU Hotplug
 #   - Memory Hotplug
 #   - NVDIMM devices
 #
@@ -365,10 +365,10 @@ disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM_NV@
 pcie_root_port = 0
 
 # In a confidential compute environment hot-plugging can compromise
-# security. 
-# Enable cold-plugging of VFIO devices to a bridge-port, 
-# root-port or switch-port. 
-# The default setting is  "no-port", which means disabled. 
+# security.
+# Enable cold-plugging of VFIO devices to a bridge-port,
+# root-port or switch-port.
+# The default setting is  "no-port", which means disabled.
 cold_plug_vfio = "@DEFAULTVFIOPORT_NV@"
 
 # If vhost-net backend for virtio-net is not desired, set to true. Default is false, which trades off
@@ -681,9 +681,9 @@ enable_pprof = false
 
 # Indicates the CreateContainer request timeout needed for the workload(s)
 # It using guest_pull this includes the time to pull the image inside the guest
-# Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)  
-# Note: The effective timeout is determined by the lesser of two values: runtime-request-timeout from kubelet config 
-# (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout) and create_container_timeout. 
+# Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)
+# Note: The effective timeout is determined by the lesser of two values: runtime-request-timeout from kubelet config
+# (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout) and create_container_timeout.
 # In essence, the timeout used for guest pull=runtime-request-timeout<create_container_timeout?runtime-request-timeout:create_container_timeout.
 create_container_timeout = @DEFAULTTIMEOUT_NV@
 

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -67,7 +67,7 @@ valid_hypervisor_paths = @QEMUTDXEXPERIMENTALVALIDHYPERVISORPATHS@
 # may stop the virtual machine from booting.
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
-kernel_params = "@KERNELPARAMS_NV@"
+kernel_params = "@KERNELPARAMS_CONFIDENTIAL_NV@"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -14,7 +14,7 @@
 [hypervisor.qemu]
 path = "@QEMUPATH@"
 kernel = "@KERNELPATH_NV@"
-initrd = "@INITRDPATH_NV@"
+image = "@IMAGEPATH_NV@"
 machine_type = "@MACHINETYPE@"
 
 # rootfs filesystem type:
@@ -355,16 +355,16 @@ msize_9p = @DEFMSIZE9P@
 # nvdimm is not supported when `confidential_guest = true`.
 disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM_NV@
 
-# Enable hot-plugging of VFIO devices to a bridge-port, 
-# root-port or switch-port. 
+# Enable hot-plugging of VFIO devices to a bridge-port,
+# root-port or switch-port.
 # The default setting is  "no-port"
 hot_plug_vfio = "no-port"
 
 # In a confidential compute environment hot-plugging can compromise
-# security. 
-# Enable cold-plugging of VFIO devices to a bridge-port, 
-# root-port or switch-port. 
-# The default setting is  "no-port", which means disabled. 
+# security.
+# Enable cold-plugging of VFIO devices to a bridge-port,
+# root-port or switch-port.
+# The default setting is  "no-port", which means disabled.
 cold_plug_vfio = "@DEFAULTVFIOPORT_NV@"
 
 # Before hot plugging a PCIe device, you need to add a pcie_root_port device.
@@ -683,9 +683,9 @@ enable_pprof = false
 
 # Indicates the CreateContainer request timeout needed for the workload(s)
 # It using guest_pull this includes the time to pull the image inside the guest
-# Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)  
-# Note: The effective timeout is determined by the lesser of two values: runtime-request-timeout from kubelet config 
-# (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout) and create_container_timeout. 
+# Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)
+# Note: The effective timeout is determined by the lesser of two values: runtime-request-timeout from kubelet config
+# (https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet/#:~:text=runtime%2Drequest%2Dtimeout) and create_container_timeout.
 # In essence, the timeout used for guest pull=runtime-request-timeout<create_container_timeout?runtime-request-timeout:create_container_timeout.
 create_container_timeout = @DEFAULTTIMEOUT_NV@
 

--- a/tools/osbuilder/image-builder/image_builder.sh
+++ b/tools/osbuilder/image-builder/image_builder.sh
@@ -23,6 +23,7 @@ ARCH=${ARCH:-$(uname -m)}
 [ "${TARGET_ARCH}" == "aarch64" ] && TARGET_ARCH=arm64
 TARGET_OS=${TARGET_OS:-linux}
 [ "${CROSS_BUILD}" == "true" ] && BUILDX=buildx && PLATFORM="--platform=${TARGET_OS}/${TARGET_ARCH}"
+VARIANT=${VARIANT:-}
 
 readonly script_name="${0##*/}"
 readonly script_dir=$(dirname "$(readlink -f "$0")")
@@ -177,6 +178,7 @@ build_with_container() {
 		   --env USER="$(id -u)" \
 		   --env GROUP="$(id -g)" \
 		   --env IMAGE_SIZE_ALIGNMENT_MB="${IMAGE_SIZE_ALIGNMENT_MB}" \
+		   --env VARIANT="${VARIANT}" \
 		   -v /dev:/dev \
 		   -v "${script_dir}":"/osbuilder" \
 		   -v "${script_dir}/../scripts":"/scripts" \
@@ -487,7 +489,8 @@ create_rootfs_image() {
 	if [ "${MEASURED_ROOTFS}" == "yes" ] && [ -b "${device}p2" ]; then
 		info "veritysetup format rootfs device: ${device}p1, hash device: ${device}p2"
 		local image_dir=$(dirname "${image}")
-		veritysetup format "${device}p1" "${device}p2" > "${image_dir}"/root_hash.txt 2>&1
+		veritysetup format "${device}p1" "${device}p2" > "${image_dir}"/root_hash_${VARIANT}.txt 2>&1
+		OK "Root hash file created for variant: ${VARIANT}"
 	fi
 
 	losetup -d "${device}"

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -86,8 +86,8 @@ build_image() {
 	fi
 
 	mv -f "kata-containers.img" "${install_dir}/${artifact_name}"
-	info "Copying root hash file for variant: ${image_initrd_suffix} $PWD"
 	if [ -e "root_hash_${image_initrd_suffix}.txt" ]; then
+		info "Copying root hash file for variant: ${image_initrd_suffix} $PWD"
 		cp "root_hash_${image_initrd_suffix}.txt" "${install_dir}/"
 	fi
 	(

--- a/tools/packaging/guest-image/build_image.sh
+++ b/tools/packaging/guest-image/build_image.sh
@@ -86,8 +86,9 @@ build_image() {
 	fi
 
 	mv -f "kata-containers.img" "${install_dir}/${artifact_name}"
-	if [ -e "root_hash.txt" ]; then
-	    cp root_hash.txt "${install_dir}/"
+	info "Copying root hash file for variant: ${image_initrd_suffix} $PWD"
+	if [ -e "root_hash_${image_initrd_suffix}.txt" ]; then
+		cp "root_hash_${image_initrd_suffix}.txt" "${install_dir}/"
 	fi
 	(
 		cd "${install_dir}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -185,7 +185,7 @@ get_kernel_modules_dir() {
 }
 
 cleanup_and_fail_shim_v2_specifics() {
-	for variant in confidential nvidia-gpu-confidential; do
+	for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
 		local root_hash_file="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/shim-v2-root_hash_${variant}.txt"
 		[ -f "${root_hash_file}" ] && rm -f "${root_hash_file}"
 	done
@@ -220,7 +220,7 @@ install_cached_shim_v2_tarball_get_root_hash() {
 	local root_hash_basedir="./opt/kata/share/kata-containers/"
 	local found_any=""
 
-	for variant in confidential nvidia-gpu-confidential; do
+	for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
 		local image_conf_tarball="kata-static-rootfs-image-${variant}.tar.zst"
 		local tarball_path="${tarball_dir}/${image_conf_tarball}"
 
@@ -245,7 +245,7 @@ install_cached_shim_v2_tarball_compare_root_hashes() {
 	local found_any=""
 	local tarball_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build"
 
-	for variant in confidential nvidia-gpu-confidential; do
+	for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
 		# skip if one or the other does not exist
 		[ ! -f "${tarball_dir}/root_hash_${variant}.txt" ] && continue
 
@@ -629,6 +629,7 @@ install_initrd_confidential() {
 # Install NVIDIA GPU image
 install_image_nvidia_gpu() {
 	export AGENT_POLICY
+	export MEASURED_ROOTFS=yes
 	local version=$(get_from_kata_deps .externals.nvidia.driver.version)
 	EXTRA_PKGS="apt curl ${EXTRA_PKGS}"
 	NVIDIA_GPU_STACK=${NVIDIA_GPU_STACK:-"driver=${version},compute,dcgm"}
@@ -798,6 +799,7 @@ install_kernel_nvidia_gpu_dragonball_experimental() {
 
 #Install GPU enabled kernel asset
 install_kernel_nvidia_gpu() {
+	export MEASURED_ROOTFS=yes
 	install_kernel_helper \
 		"assets.kernel.nvidia" \
 		"kernel-nvidia-gpu" \
@@ -1041,7 +1043,7 @@ install_shimv2() {
 
 	if [ "${MEASURED_ROOTFS}" = "yes" ]; then
 		local found_any=""
-		for variant in confidential nvidia-gpu-confidential; do
+		for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
 			local image_conf_tarball="$(find "${workdir}" -name "kata-static-rootfs-image-${variant}.tar.zst" 2>/dev/null | head -n 1)"
 			# only one variant may be built at a time so we need to
 			# skip one or the other if not available
@@ -1488,7 +1490,7 @@ handle_build() {
 			;;
 		shim-v2)
 			if [ "${MEASURED_ROOTFS}" = "yes" ]; then
-				for variant in confidential nvidia-gpu-confidential; do
+				for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
 					[ -f "${workdir}/root_hash_${variant}.txt" ] && mv "${workdir}/root_hash_${variant}.txt" "${workdir}/shim-v2-root_hash_${variant}.txt"
 				done
 			fi
@@ -1550,7 +1552,7 @@ handle_build() {
 			shim-v2)
 				if [ "${MEASURED_ROOTFS}" = "yes" ]; then
 					local found_any=""
-					for variant in confidential nvidia-gpu-confidential; do
+					for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
 						# The variants could be built independently we need to check if
 						# they exist and then push them to the registry
 						[ -f "${workdir}/shim-v2-root_hash_${variant}.txt" ] && files_to_push+=("shim-v2-root_hash_${variant}.txt")

--- a/tools/packaging/static-build/initramfs/init.sh
+++ b/tools/packaging/static-build/initramfs/init.sh
@@ -17,6 +17,11 @@ mount -t proc -o nodev,noexec,nosuid proc /proc
 echo "/sbin/mdev" > /proc/sys/kernel/hotplug
 mdev -s
 
+log() {
+	local msg="initramfs: $*"
+	printf '%s\n' "$msg" > /dev/kmsg
+}
+
 get_option() {
 	local value
 	value=" $(cat /proc/cmdline) "
@@ -34,24 +39,24 @@ hash_device=${root_device%?}2
 # just mounted when verification is disabled.
 if [ ! -e "${root_device}" ]
 then
-	echo "No root device ${root_device} found"
+	log "No root device ${root_device} found"
 	exit 1
 fi
 
 if [ "${rootfs_verifier}" = "dm-verity" ]
 then
-	echo "Verify the root device with ${rootfs_verifier}"
+	log "Verify the root device with ${rootfs_verifier}"
 
 	if [ ! -e "${hash_device}" ]
 	then
-		echo "No hash device ${hash_device} found. Cannot verify the root device"
+		log "No hash device ${hash_device} found. Cannot verify the root device"
 		exit 1
 	fi
 
 	veritysetup open --panic-on-corruption "${root_device}" root "${hash_device}" "${rootfs_hash}"
 	mount /dev/mapper/root /mnt
 else
-	echo "No LUKS device found"
+	log "No LUKS device found"
 	mount "${root_device}" /mnt
 fi
 

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -32,7 +32,7 @@ kernel_builder_args="-a ${ARCH:-} $*"
 KERNEL_DEBUG_ENABLED=${KERNEL_DEBUG_ENABLED:-"no"}
 
 if [[ "${MEASURED_ROOTFS}" == "yes" ]]; then
-	info "build initramfs for cc kernel"
+	info "build initramfs for kernel with measured rootfs support"
 	"${initramfs_builder}"
 	# Turn on the flag to build the kernel with support to
 	# measured rootfs.

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -39,14 +39,26 @@ esac
 if [ "${MEASURED_ROOTFS}" == "yes" ]; then
 	info "Enable rootfs measurement config"
 
-	root_hash_file="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/root_hash.txt"
+	# Two VARIANTS (targets) that build a measured rootfs as of now are:
+	# - rootfs-image-confidential
+	# - rootfs-image-nvidia-gpu-confidential
+	#
+	found_any=""
+	for variant in confidential nvidia-gpu-confidential; do
+		root_hash_file="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/root_hash_${variant}.txt"
+		[ -f "$root_hash_file" ] || \
+			die "Root hash file for measured rootfs ${variant} not found at ${root_hash_file}"
 
-	[ -f "$root_hash_file" ] || \
-		die "Root hash file for measured rootfs not found at ${root_hash_file}"
+		found_any="yes"
 
-	root_hash=$(sed -e 's/Root hash:\s*//g;t;d' "${root_hash_file}")
-	root_measure_config="rootfs_verity.scheme=dm-verity rootfs_verity.hash=${root_hash}"
-	EXTRA_OPTS+=" ROOTMEASURECONFIG=\"${root_measure_config}\""
+		root_hash=$(sed -e 's/Root hash:\s*//g;t;d' "${root_hash_file}")
+		root_measure_config="rootfs_verity.scheme=dm-verity rootfs_verity.hash=${root_hash}"
+
+		[ "${variant}" == "confidential" ] && EXTRA_OPTS+=" ROOTMEASURECONFIG=\"${root_measure_config}\""
+		[ "${variant}" == "nvidia-gpu-confidential" ] && EXTRA_OPTS+=" ROOTMEASURECONFIG_NV=\"${root_measure_config}\""
+
+	done
+	[ -z "${found_any}" ] && die "No root hash files found for shim-v2 with MEASURED_ROOTFS support, needs a rootfs with MEASURED_ROOTFS support"
 fi
 
 docker pull ${container_image} || \

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -39,12 +39,13 @@ esac
 if [ "${MEASURED_ROOTFS}" == "yes" ]; then
 	info "Enable rootfs measurement config"
 
-	# Two VARIANTS (targets) that build a measured rootfs as of now are:
+	# Variants (targets) that build a measured rootfs as of now are:
 	# - rootfs-image-confidential
+	# - rootfs-image-nvidia-gpu
 	# - rootfs-image-nvidia-gpu-confidential
 	#
 	found_any=""
-	for variant in confidential nvidia-gpu-confidential; do
+	for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
 		root_hash_file="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/root_hash_${variant}.txt"
 		[ -f "$root_hash_file" ] || \
 			die "Root hash file for measured rootfs ${variant} not found at ${root_hash_file}"
@@ -55,7 +56,8 @@ if [ "${MEASURED_ROOTFS}" == "yes" ]; then
 		root_measure_config="rootfs_verity.scheme=dm-verity rootfs_verity.hash=${root_hash}"
 
 		[ "${variant}" == "confidential" ] && EXTRA_OPTS+=" ROOTMEASURECONFIG=\"${root_measure_config}\""
-		[ "${variant}" == "nvidia-gpu-confidential" ] && EXTRA_OPTS+=" ROOTMEASURECONFIG_NV=\"${root_measure_config}\""
+		[ "${variant}" == "nvidia-gpu" ] && EXTRA_OPTS+=" ROOTMEASURECONFIG_NV=\"${root_measure_config}\""
+		[ "${variant}" == "nvidia-gpu-confidential" ] && EXTRA_OPTS+=" ROOTMEASURECONFIG_CONFIDENTIAL_NV=\"${root_measure_config}\""
 
 	done
 	[ -z "${found_any}" ] && die "No root hash files found for shim-v2 with MEASURED_ROOTFS support, needs a rootfs with MEASURED_ROOTFS support"


### PR DESCRIPTION
Shift NVIDIA shim configurations to use an image instead of an initrd, and remove trailing whitespaces from the configs. This, for instance, prepares for dm-verity protected r/o rootfs protection using the image format.

DO NOT MERGE/TEST: the commit for dm-verity based r/o protection of the image does not work yet