### PR TITLE
tests: k8s: Add kubectl logs with retries

### DIFF
--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -42,7 +42,7 @@ setup() {
 		pod="${pods[$i]}"
 		bats_unbuffered_info "Getting log for pod: ${pod}"
 
-		log=$(kubectl logs "${pod}")
+		log=$(kubectl_logs_with_retries "${pod}")
 		bats_unbuffered_info "Log: ${log}"
 
 		[ "${log}" -eq "${expected_vcpus[$i]}" ]


### PR DESCRIPTION
We've had persistent issues with the k8s-sandbox-vcpus-allocation.bats test failing around 5% of the time. @danmihai1 has pointed out that sometimes we get empty output, in a way similar to how we do for kubectl exec, so suggested we try the retry approach.

Fixes: #12217