### PR TITLE
runtime: runtime-rs: Use 'host' cpu model for AMD SEV-SNP guests

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -369,11 +369,6 @@ impl Cpu {
             cpu_features: config.cpu_info.cpu_features.clone(),
         }
     }
-
-    fn set_type(&mut self, cpu_type: &str) -> &mut Self {
-        self.r#type = cpu_type.to_owned();
-        self
-    }
 }
 
 #[async_trait]
@@ -2558,8 +2553,6 @@ impl<'a> QemuCmdLine<'a> {
         self.machine
             .set_confidential_guest_support("snp")
             .set_nvdimm(false);
-
-        self.cpu.set_type("EPYC-v4");
     }
 
     pub fn add_tdx_protection_device(

--- a/src/runtime/virtcontainers/qemu_amd64.go
+++ b/src/runtime/virtcontainers/qemu_amd64.go
@@ -186,18 +186,7 @@ func (q *qemuAmd64) bridges(number uint32) {
 }
 
 func (q *qemuAmd64) cpuModel() string {
-	var err error
-	cpuModel := defaultCPUModel
-
-	// Temporary until QEMU cpu model 'host' supports AMD SEV-SNP
-	protection, err := availableGuestProtection()
-	if err == nil {
-		if protection == snpProtection && q.snpGuest {
-			cpuModel = "EPYC-v4"
-		}
-	}
-
-	return cpuModel
+	return defaultCPUModel
 }
 
 func (q *qemuAmd64) memoryTopology(memoryMb, hostMemoryMb uint64, slots uint8) govmmQemu.Memory {

--- a/tests/integration/kubernetes/k8s-confidential-attestation.bats
+++ b/tests/integration/kubernetes/k8s-confidential-attestation.bats
@@ -156,10 +156,16 @@ setup() {
 	vcpu_count=$(echo "$qemu_cmd" | grep -oP -- '-smp \K\d+')
 	append=$(echo "$qemu_cmd" | sed -n 's/.*-append \(.*\) -bios.*/\1/p')
 
+	family=$(cpuid | grep -m 1 -oP -- '\(family synth\).*\(\K[^)]+')
+	stepping=$(cpuid | grep -m 1 -oP -- 'stepping id.*\(\K[^)]+')
+	model=$(cpuid | grep -m 1 -oP -- 'model.*\(\K[^)]+')
+
 	launch_measurement=$(PATH="${PATH}:${HOME}/.local/bin" sev-snp-measure \
 		--mode=snp \
 		--vcpus="${vcpu_count}" \
-		--vcpu-type=EPYC-v4 \
+		--vcpu-family="${family}" \
+		--vcpu-model="${model}" \
+		--vcpu-stepping="${stepping}" \
 		--output-format=base64 \
 		--ovmf="${firmware_path}" \
 		--kernel="${kernel_path}" \


### PR DESCRIPTION
Qemu supports cpu model 'host' for AMD SEV-SNP. Changing to 'host' exposes the correct CPUID. This is needed for SNP attestation to work correctly.

Fixes #12210