### PR TITLE
runtime: nvidia: Disable NVDIMM

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -234,7 +234,7 @@ DEFDISABLESELINUX := false
 DEFDISABLEGUESTSELINUX := true
 # Default is empty string "" to match the default golang (when commented out in config).
 # Most users will want to set this to "system_u:system_r:container_t" for SELinux support.
-DEFGUESTSELINUXLABEL := 
+DEFGUESTSELINUXLABEL :=
 
 #Default SeccomSandbox param
 #The same default policy is used by libvirt
@@ -291,6 +291,7 @@ DEFSTATICRESOURCEMGMT_TEE = true
 DEFSTATICRESOURCEMGMT_NV = true
 
 DEFDISABLEIMAGENVDIMM ?= false
+DEFDISABLEIMAGENVDIMM_NV = true
 
 DEFBINDMOUNTS := []
 
@@ -784,6 +785,7 @@ USER_VARS += DEFVFIOMODE
 USER_VARS += DEFVFIOMODE_SE
 USER_VARS += BUILDFLAGS
 USER_VARS += DEFDISABLEIMAGENVDIMM
+USER_VARS += DEFDISABLEIMAGENVDIMM_NV
 USER_VARS += DEFCCAMEASUREMENTALGO
 USER_VARS += DEFSHAREDFS_QEMU_CCA_VIRTIOFS
 USER_VARS += DEFPODRESOURCEAPISOCK

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -379,7 +379,7 @@ msize_9p = @DEFMSIZE9P@
 # Otherwise virtio-block device is used.
 #
 # nvdimm is not supported when `confidential_guest = true`.
-disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM@
+disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM_NV@
 
 # Before hot plugging a PCIe device, you need to add a pcie_root_port device.
 # Use this parameter when using some large PCI bar devices, such as Nvidia GPU

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -356,7 +356,7 @@ msize_9p = @DEFMSIZE9P@
 # Otherwise virtio-block device is used.
 #
 # nvdimm is not supported when `confidential_guest = true`.
-disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM@
+disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM_NV@
 
 # Before hot plugging a PCIe device, you need to add a pcie_root_port device.
 # Use this parameter when using some large PCI bar devices, such as Nvidia GPU

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -353,7 +353,7 @@ msize_9p = @DEFMSIZE9P@
 # Otherwise virtio-block device is used.
 #
 # nvdimm is not supported when `confidential_guest = true`.
-disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM@
+disable_image_nvdimm = @DEFDISABLEIMAGENVDIMM_NV@
 
 # Enable hot-plugging of VFIO devices to a bridge-port, 
 # root-port or switch-port. 


### PR DESCRIPTION
Disable NVDIMM. When using GPU passthrough, using NVDIMM would create a r/o file-backed memory region. When using a GPU, QEMU tries to DMA- map guest memory for the device, resulting in a mapping error: memory listener initialization failed: Region mem0: vfio_container_dma_map ... -22 (Invalid argument). For the CC configs, NVDIMM is disabled by default in qemu_amd64.go with a warning, but we also explicitly disable the setting in the shim configuration file.

The change also cleans up a trailing whitespace.