### PR TITLE
runtime-rs: Fix state_process to return stopped state for terminated …

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/manager.rs
@@ -371,7 +371,27 @@ impl ContainerManager for VirtContainerManager {
                 exited_at: None,
             })
         } else {
-            Err(Error::ContainerNotFound(container_id.clone()).into())
+            // Container not found in HashMap - this can happen during normal operation
+            // when containerd queries state during/after container deletion.
+            // Return a synthetic "stopped" state
+            warn!(
+                sl!(),
+                "Container not found in state query, returning stopped state";
+                "container_id" => container_id
+            );
+            Ok(ProcessStateInfo {
+                container_id: container_id.clone(),
+                exec_id: process.exec_id.clone(),
+                pid: PID { pid: 0 },
+                bundle: String::new(),
+                stdin: None,
+                stdout: None,
+                stderr: None,
+                terminal: false,
+                status: ProcessStatus::Stopped,
+                exit_status: 0,
+                exited_at: None,
+            })
         }
     }
 


### PR DESCRIPTION
…containers

When containerd queries container state during/after deletion, runtime-rs throws "failed to find container" errors. This is a race condition where state_process() is called after the container has already been removed from the internal HashMap.

This causes containerd to interpret the error as a temporary failure and enter a retry loop, preventing task cleanup and generating log spam.

Return a synthetic "stopped" state instead of an error when a container is not found in the HashMap

This fix aligns with the **containerd Shim v2 Protocol** ([shim.proto](https://github.com/containerd/containerd/blob/main/api/runtime/task/v2/shim.proto)).

The `State` RPC is expected to return a `StateResponse` with a valid `Status` enum (CREATED, RUNNING, STOPPED, PAUSED):
-  Returning `Status: STOPPED` → Containerd accepts this as valid and proceeds with cleanup
-  Returning an error (e.g., "Not Found") → Containerd assumes the shim is broken and enters a retry loop

By returning a synthetic "stopped" state instead of an error, we maintain the protocol contract and allow containerd to complete the deletion workflow normally.
Fixes: #12336