### PR TITLE
ci: Fix shellcheck errors for kubernetes intergration tests

### DIFF
--- a/.github/workflows/shellcheck_required.yaml
+++ b/.github/workflows/shellcheck_required.yaml
@@ -28,8 +28,15 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Run ShellCheck
+      - name: Run ShellCheck (errors only)
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
         with:
           severity: error
           ignore_paths: "**/vendor/**"
+
+      - name: Run ShellCheck (all severities on clean directories)
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
+        with:
+          # Add any additional directories to be checked fully here
+          # to ensure that they remain clean.
+          scandir: "./tests/integration/kubernetes"

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -9,11 +9,11 @@
 set -e
 
 kubernetes_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck disable=1091
+# shellcheck disable=SC1091
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
-# shellcheck disable=1091
+# shellcheck disable=SC1091
 source "${kubernetes_dir}/../../../tests/common.bash"
-# shellcheck disable=1091
+# shellcheck disable=SC1091
 source "${kubernetes_dir}/../../../tools/packaging/guest-image/lib_se.sh"
 # For kata-runtime
 export PATH="${PATH}:/opt/kata/bin"
@@ -240,13 +240,13 @@ kbs_install_cli() {
 			local pkgs="build-essential pkg-config libssl-dev"
 
 			sudo apt-get update -y
-			# shellcheck disable=2086
+			# shellcheck disable=SC2086
 			sudo apt-get install -y ${pkgs}
 			;;
 		centos)
 			local pkgs="make"
 
-			# shellcheck disable=2086,2248
+			# shellcheck disable=SC2086,SC2248
 			sudo dnf install -y ${pkgs}
 			;;
 		*)
@@ -286,6 +286,7 @@ kbs_uninstall_cli() {
 ensure_sev_snp_measure() {
 	command -v sev-snp-measure >/dev/null && return
 
+	# shellcheck disable=SC1091
 	source "${HOME}"/.cicd/venv/bin/activate
 	pip install sev-snp-measure
 }
@@ -584,7 +585,7 @@ _ensure_rust() {
 	if ! command -v rustc >/dev/null; then
 		"${kubernetes_dir}/../../install_rust.sh" "${rust_version}"
 
-		# shellcheck disable=1091
+		# shellcheck disable=SC1091
 		source "${HOME}/.cargo/env"
 	else
 		[[ -z "${rust_version}" ]] && return

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -12,12 +12,10 @@ DEBUG="${DEBUG:-}"
 [[ -n "${DEBUG}" ]] && set -x
 
 kubernetes_dir="$(dirname "$(readlink -f "$0")")"
+# shellcheck disable=SC1091
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
-# shellcheck disable=1091
+# shellcheck disable=SC1091
 source "${kubernetes_dir}/confidential_kbs.sh"
-# shellcheck disable=2154
-tools_dir="${repo_root_dir}/tools"
-kata_tarball_dir="${2:-kata-artifacts}"
 
 export DOCKER_REGISTRY="${DOCKER_REGISTRY:-quay.io}"
 export DOCKER_REPO="${DOCKER_REPO:-kata-containers/kata-deploy-ci}"
@@ -580,7 +578,7 @@ function main() {
 		create-cluster-kcli) create_cluster_kcli ;;
 		configure-snapshotter) configure_snapshotter ;;
 		deploy-coco-kbs) deploy_coco_kbs ;;
-		deploy-k8s) deploy_k8s ${CONTAINER_ENGINE:-} ${CONTAINER_ENGINE_VERSION:-};;
+		deploy-k8s) deploy_k8s "${CONTAINER_ENGINE:-}" "${CONTAINER_ENGINE_VERSION:-}";;
 		install-bats) install_bats ;;
 		install-kata-tools) install_kata_tools "${2:-}" ;;
 		install-kbs-client) install_kbs_client ;;

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -8,13 +8,16 @@
 #
 set -euo pipefail
 
+# BATS_TEST_DIRNAME, BATS_FILE_TMPDIR, KATA_HYPERVISOR are set by BATS or the caller
+# shellcheck disable=SC2154
+
 wait_time=60
 sleep_time=3
 
 # Delete all pods if any exist, otherwise just return
 #
 k8s_delete_all_pods_if_any_exists() {
-	[ -z "$(kubectl get --no-headers pods)" ] || \
+	[[ -z "$(kubectl get --no-headers pods)" ]] || \
 		kubectl delete --all pods
 }
 
@@ -28,7 +31,7 @@ k8s_wait_pod_be_ready() {
 	local pod_name="$1"
 	local wait_time="${2:-120}"
 
-	kubectl wait --timeout="${wait_time}s" --for=condition=ready "pods/$pod_name"
+	kubectl wait --timeout="${wait_time}s" --for=condition=ready "pods/${pod_name}"
 }
 
 # Create a pod with a given number of retries if an output includes a timeout.
@@ -44,30 +47,30 @@ retry_kubectl_apply() {
     local func_name="${FUNCNAME[0]}"
 
     while true; do
-        output=$(kubectl apply -f "$file_path" 2>&1) || true
+        output=$(kubectl apply -f "${file_path}" 2>&1) || true
         echo ""
-        echo "$func_name: Attempt $attempt/$retries"
-        echo "$output"
+        echo "${func_name}: Attempt ${attempt}/${retries}"
+        echo "${output}"
 
         # Check for timeout and retry if needed
-        if echo "$output" | grep -iq "timed out"; then
-            if [ $attempt -ge $retries ]; then
-                echo "$func_name: Max ${retries} retries reached. Failed due to timeout."
+        if echo "${output}" | grep -iq "timed out"; then
+            if [[ ${attempt} -ge ${retries} ]]; then
+                echo "${func_name}: Max ${retries} retries reached. Failed due to timeout."
                 return 1
             fi
-            echo "$func_name: Timeout encountered, retrying in $delay seconds..."
-            sleep $delay
+            echo "${func_name}: Timeout encountered, retrying in ${delay} seconds..."
+            sleep "${delay}"
             attempt=$((attempt + 1))
             continue
         fi
 
         # Check for any other kind of error
-        if echo "$output" | grep -iq "error"; then
-            echo "$func_name: Error detected in kubectl output. Aborting."
+        if echo "${output}" | grep -iq "error"; then
+            echo "${func_name}: Error detected in kubectl output. Aborting."
             return 1
         fi
 
-        echo "$func_name: Resource created successfully."
+        echo "${func_name}: Resource created successfully."
         return 0
     done
 }
@@ -83,7 +86,7 @@ k8s_create_pod() {
 	local wait_time="${2:-120}"
 	local pod_name=""
 
-	if [ ! -f "${config_file}" ]; then
+	if [[ ! -f "${config_file}" ]]; then
 		echo "Pod config file '${config_file}' does not exist"
 		return 1
 	fi
@@ -115,9 +118,10 @@ exec_host() {
 		die "A given node ${node} is not valid"
 	fi
 	# `kubectl debug` always returns 0, so we hack it to return the right exit code.
-	local command="${@:2}"
+	local command="${*:2}"
 	# Make 7 character hash from the node name
-	local pod_name="custom-node-debugger-$(echo -n "$node" | sha1sum | cut -c1-7)"
+	local pod_name
+	pod_name="custom-node-debugger-$(echo -n "${node}" | sha1sum | cut -c1-7)"
 
 	# Run a debug pod
 	# Check if there is an existing node debugger pod and reuse it
@@ -126,11 +130,10 @@ exec_host() {
 		POD_NAME="${pod_name}" NODE_NAME="${node}" envsubst < runtimeclass_workloads/custom-node-debugger.yaml | \
 			kubectl apply -n kube-system -f - > /dev/null
 		# Wait for the newly created pod to be ready
-		kubectl wait pod -n kube-system --timeout="30s" --for=condition=ready "${pod_name}" > /dev/null
-		# Manually check the exit status of the previous command to handle errors explicitly
+		# Manually check the exit status of the kubectl wait command to handle errors explicitly
 		# since `set -e` is not enabled, allowing subsequent commands to run if needed.
-		if [ $? -ne 0 ]; then
-			return $?
+		if ! kubectl wait pod -n kube-system --timeout="30s" --for=condition=ready "${pod_name}" > /dev/null; then
+			return 1
 		fi
 	fi
 
@@ -162,7 +165,7 @@ assert_logs_contain() {
 	local message="$4"
 
 	# Note: with image-rs we get more than the default 1000 lines of logs
-	exec_host "${node}" journalctl -x -t $log_id --since '"'$datetime'"' | grep "$message"
+	exec_host "${node}" journalctl -x -t "${log_id}" --since '"'"${datetime}"'"' | grep "${message}"
 }
 
 # Create a pod then assert it fails to run. Use in tests that you expect the
@@ -179,7 +182,7 @@ assert_pod_fail() {
 	local container_config="$1"
 	local duration="${2:-120}"
 
-	echo "In assert_pod_fail: $container_config"
+	echo "In assert_pod_fail: ${container_config}"
 	echo "Attempt to create the container but it should fail"
 
 	retry_kubectl_apply "${container_config}"
@@ -192,13 +195,13 @@ assert_pod_fail() {
 	local sleep_time=5
 	while true; do
 		echo "Waiting for a container to fail"
-		sleep ${sleep_time}
+		sleep "${sleep_time}"
 		elapsed_time=$((elapsed_time+sleep_time))
 		if [[ $(kubectl get pod "${pod_name}" \
 			-o jsonpath='{.status.containerStatuses[0].state.waiting.reason}') = *BackOff* ]]; then
 			return 0
 		fi
-		if [ $elapsed_time -gt $duration ]; then
+		if [[ "${elapsed_time}" -gt "${duration}" ]]; then
 			echo "The container does not get into a failing state" >&2
 			break
 		fi
@@ -223,24 +226,24 @@ assert_rootfs_count() {
 	# verify that the sandbox_id is not empty;
 	# otherwise, the command $(exec_host $node "find /run/kata-containers/shared/sandboxes/${sandbox_id} -name rootfs -type d")
 	# may yield an unexpected count of rootfs.
-	if [ -z "$sandbox_id" ]; then
+	if [[ -z "${sandbox_id}" ]]; then
 		return 1
 	fi
 
 	# Max loop 3 times to get all pulled rootfs for given sandbox_id
 	for _ in {1..3}
 	do
-		allrootfs=$(exec_host $node "find /run/kata-containers/shared/sandboxes/${sandbox_id} -name rootfs -type d")
-		if [ -n "$allrootfs" ]; then
+		allrootfs=$(exec_host "${node}" "find /run/kata-containers/shared/sandboxes/${sandbox_id} -name rootfs -type d")
+		if [[ -n "${allrootfs}" ]]; then
 			break
 		else
 			sleep 1
 		fi
 	done
-	echo "allrootfs is: $allrootfs"
-	count=$(echo $allrootfs | grep -o "rootfs" | wc -l)
-	echo "count of container rootfs in host is: $count, expect count is less than, or equal to: $expect_count"
-	[ $expect_count -ge $count ]
+	echo "allrootfs is: ${allrootfs}"
+	count=$(echo "${allrootfs}" | grep -o "rootfs" | wc -l)
+	echo "count of container rootfs in host is: ${count}, expect count is less than, or equal to: ${expect_count}"
+	[[ "${expect_count}" -ge "${count}" ]]
 }
 
 # Create a pod configuration out of a template file.
@@ -256,6 +259,7 @@ assert_rootfs_count() {
 # 	directory.
 #
 new_pod_config() {
+	# shellcheck disable=SC2154 # BATS_TEST_DIRNAME set by BATS
 	local FIXTURES_DIR="${BATS_TEST_DIRNAME}/runtimeclass_workloads"
 	local base_config="${FIXTURES_DIR}/pod-config.yaml.in"
 	local image="$1"
@@ -263,12 +267,13 @@ new_pod_config() {
 	local new_config
 
 	# The runtimeclass is not optional.
-	[ -n "$runtimeclass" ] || return 1
+	[[ -n "${runtimeclass}" ]] || return 1
 
+	# shellcheck disable=SC2154 # BATS_FILE_TMPDIR set by BATS
 	new_config=$(mktemp "${BATS_FILE_TMPDIR}/pod-config.XXXXXX.yaml")
-	IMAGE="$image" RUNTIMECLASS="$runtimeclass" envsubst < "$base_config" > "$new_config"
+	IMAGE="${image}" RUNTIMECLASS="${runtimeclass}" envsubst < "${base_config}" > "${new_config}"
 
-	echo "$new_config"
+	echo "${new_config}"
 }
 
 # Set an annotation on configuration metadata.
@@ -291,19 +296,20 @@ set_metadata_annotation() {
 	local metadata_path="${4:-}"
 	local annotation_key=""
 
-	[ -n "$metadata_path" ] && annotation_key+="${metadata_path}."
+	[[ -n "${metadata_path}" ]] && annotation_key+="${metadata_path}."
 
 	# yaml annotation key name.
 	annotation_key+="metadata.annotations.\"${key}\""
 
-	echo "$annotation_key"
+	echo "${annotation_key}"
 	# yq set annotations in yaml. Quoting the key because it can have
 	# dots.
 	yq -i ".${annotation_key} = \"${value}\"" "${yaml}"
 
+	# shellcheck disable=SC2154 # KATA_HYPERVISOR set by caller
 	if [[ "${key}" =~ kernel_params ]] && [[ "${KATA_HYPERVISOR}" == qemu-se* ]]; then
 		# A secure boot image for IBM SE should be rebuilt according to the KBS configuration.
-		if [ -z "${IBM_SE_CREDS_DIR:-}" ]; then
+		if [[ -z "${IBM_SE_CREDS_DIR:-}" ]]; then
 			>&2 echo "ERROR: IBM_SE_CREDS_DIR is empty"
 			return 1
 		fi
@@ -342,7 +348,7 @@ set_node() {
 	local node="$2"
 	local kind
 	local spec
-	[ -n "$node" ] || return 1
+	[[ -n "${node}" ]] || return 1
 
 	kind="$(yq -r '.kind' "${yaml}")"
 	if [[ "${kind}" = "Job" ]]; then
@@ -352,7 +358,7 @@ set_node() {
 	fi
 
   yq -i \
-    "${spec} = \"$node\"" \
+    "${spec} = \"${node}\"" \
     "${yaml}"
 }
 
@@ -366,19 +372,19 @@ get_node_kata_sandbox_id() {
 	local kata_sandbox_id=""
 	local local_wait_time="${wait_time}"
 	# Max loop 3 times to get kata_sandbox_id
-	while [ "$local_wait_time" -gt 0 ];
+	while [[ "${local_wait_time}" -gt 0 ]];
 	do
-		kata_sandbox_id=$(exec_host $node "ps -ef |\
+		kata_sandbox_id=$(exec_host "${node}" "ps -ef |\
 		  grep containerd-shim-kata-v2" |\
 		  grep -oP '(?<=-id\s)[a-f0-9]+' |\
 		  tail -1)
-		if [ -n "$kata_sandbox_id" ]; then
+		if [[ -n "${kata_sandbox_id}" ]]; then
 			break
 		else
 			sleep "${sleep_time}"
 			local_wait_time=$((local_wait_time-sleep_time))
 		fi
 	done
-	echo $kata_sandbox_id
+	echo "${kata_sandbox_id}"
 }
 

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -9,13 +9,14 @@ set -e
 set -o pipefail
 
 kubernetes_dir=$(dirname "$(readlink -f "$0")")
+# shellcheck disable=SC1091
 source "${kubernetes_dir}/../../common.bash"
 
 cleanup() {
-	# Clean up all node debugger pods whose name starts with `custom-node-debugger` if pods exist
-	pods_to_be_deleted=$(kubectl get pods -n kube-system --no-headers -o custom-columns=:metadata.name \
-		| grep '^custom-node-debugger' || true)
-	[ -n "$pods_to_be_deleted" ] && kubectl delete pod -n kube-system $pods_to_be_deleted || true
+	# Clean up all node debugger pods whose name starts with `custom-node-debugger`
+	kubectl get pods -n kube-system --no-headers -o custom-columns=:metadata.name \
+		| grep '^custom-node-debugger' \
+		| xargs -r kubectl delete pod -n kube-system || true
 }
 
 trap cleanup EXIT
@@ -27,8 +28,8 @@ K8S_TEST_HOST_TYPE="${K8S_TEST_HOST_TYPE:-small}"
 # Setting to "yes" enables fail fast, stopping execution at the first failed test.
 K8S_TEST_FAIL_FAST="${K8S_TEST_FAIL_FAST:-no}"
 
-if [ -n "${K8S_TEST_UNION:-}" ]; then
-	K8S_TEST_UNION=($K8S_TEST_UNION)
+if [[ -n "${K8S_TEST_UNION:-}" ]]; then
+	read -ra K8S_TEST_UNION <<< "${K8S_TEST_UNION}"
 else
 	# Before we use containerd 2.0 with 'image pull per runtime class' feature
 	# we need run k8s-guest-pull-image.bats test first, otherwise the test result will be affected
@@ -105,19 +106,19 @@ else
 
 	case ${K8S_TEST_HOST_TYPE} in
 		small)
-			K8S_TEST_UNION=(${K8S_TEST_SMALL_HOST_ATTESTATION_REQUIRED_UNION[@]} ${K8S_TEST_SMALL_HOST_UNION[@]})
+			K8S_TEST_UNION=("${K8S_TEST_SMALL_HOST_ATTESTATION_REQUIRED_UNION[@]}" "${K8S_TEST_SMALL_HOST_UNION[@]}")
 			;;
 		normal)
-			K8S_TEST_UNION=(${K8S_TEST_NORMAL_HOST_UNION[@]})
+			K8S_TEST_UNION=("${K8S_TEST_NORMAL_HOST_UNION[@]}")
 			;;
 		all|baremetal)
-			K8S_TEST_UNION=(${K8S_TEST_SMALL_HOST_ATTESTATION_REQUIRED_UNION[@]} ${K8S_TEST_SMALL_HOST_UNION[@]} ${K8S_TEST_NORMAL_HOST_UNION[@]})
+			K8S_TEST_UNION=("${K8S_TEST_SMALL_HOST_ATTESTATION_REQUIRED_UNION[@]}" "${K8S_TEST_SMALL_HOST_UNION[@]}" "${K8S_TEST_NORMAL_HOST_UNION[@]}")
 			;;
 		baremetal-attestation)
-			K8S_TEST_UNION=(${K8S_TEST_SMALL_HOST_ATTESTATION_REQUIRED_UNION[@]})
+			K8S_TEST_UNION=("${K8S_TEST_SMALL_HOST_ATTESTATION_REQUIRED_UNION[@]}")
 			;;
 		baremetal-no-attestation)
-			K8S_TEST_UNION=(${K8S_TEST_SMALL_HOST_UNION[@]} ${K8S_TEST_NORMAL_HOST_UNION[@]})
+			K8S_TEST_UNION=("${K8S_TEST_SMALL_HOST_UNION[@]}" "${K8S_TEST_NORMAL_HOST_UNION[@]}")
 			;;
 		*)
 			echo "${K8S_TEST_HOST_TYPE} is an invalid K8S_TEST_HOST_TYPE option. Valid options are: small | normal | all | baremetal"
@@ -128,8 +129,8 @@ fi
 
 # we may need to skip a few test cases when running on non-x86_64 arch
 arch_config_file="${kubernetes_dir}/filter_out_per_arch/${TARGET_ARCH}.yaml"
-if [ -f "${arch_config_file}" ]; then
-	arch_k8s_test_union=$(${kubernetes_dir}/filter_k8s_test.sh ${arch_config_file} "${K8S_TEST_UNION[*]}")
+if [[ -f "${arch_config_file}" ]]; then
+	arch_k8s_test_union=$("${kubernetes_dir}/filter_k8s_test.sh" "${arch_config_file}" "${K8S_TEST_UNION[*]}")
 	mapfile -d " " -t K8S_TEST_UNION <<< "${arch_k8s_test_union}"
 fi
 

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -8,22 +8,25 @@ set -o nounset
 set -o pipefail
 
 DEBUG="${DEBUG:-}"
-[ -n "$DEBUG" ] && set -x
+[[ -n "${DEBUG}" ]] && set -x
 
 export AUTO_GENERATE_POLICY="${AUTO_GENERATE_POLICY:-no}"
 export KATA_HOST_OS="${KATA_HOST_OS:-}"
 export KATA_HYPERVISOR="${KATA_HYPERVISOR:-}"
 export PULL_TYPE="${PULL_TYPE:-default}"
 
-declare -r kubernetes_dir=$(dirname "$(readlink -f "$0")")
+kubernetes_dir=$(dirname "$(readlink -f "$0")")
+declare -r kubernetes_dir
 declare -r runtimeclass_workloads_work_dir="${kubernetes_dir}/runtimeclass_workloads_work"
 declare -r runtimeclass_workloads_dir="${kubernetes_dir}/runtimeclass_workloads"
 declare -r kata_opa_dir="${kubernetes_dir}/../../../src/kata-opa"
+# shellcheck disable=SC1091
 source "${kubernetes_dir}/../../common.bash"
+# shellcheck disable=SC1091
 source "${kubernetes_dir}/tests_common.sh"
 
 
-if [ -n "${K8S_TEST_POLICY_FILES:-}" ]; then
+if [[ -n "${K8S_TEST_POLICY_FILES:-}" ]]; then
 	K8S_TEST_POLICY_FILES=("${K8S_TEST_POLICY_FILES}")
 else
 	K8S_TEST_POLICY_FILES=( \
@@ -59,7 +62,8 @@ add_annotations_to_yaml() {
 	# Previous version of yq was not ready to handle multiple objects in a single yaml.
 	# By default was changing only the first object.
 	# With yq>4 we need to make it explicit during the read and write.
-	local resource_kind="$(yq .kind ${yaml_file} | head -1)"
+	local resource_kind
+	resource_kind="$(yq .kind "${yaml_file}" | head -1)"
 
 	case "${resource_kind}" in
 
@@ -123,8 +127,8 @@ add_cbl_mariner_specific_annotations() {
 add_runtime_handler_annotations() {
 	local handler_annotation="io.containerd.cri.runtime-handler"
 
-	if [ "$PULL_TYPE" != "guest-pull" ]; then
-		info "Not adding $handler_annotation annotation for $PULL_TYPE pull type"
+	if [[ "${PULL_TYPE}" != "guest-pull" ]]; then
+		info "Not adding ${handler_annotation} annotation for ${PULL_TYPE} pull type"
 		return
 	fi
 


### PR DESCRIPTION
`shellcheck` fails all the time in CI and this is an attempt to get to a clean state. This PR is scoped only to fix issues under `tests/integration/kubernetes`.

Before the PR: ~108 shellcheck issues
After the PR: 0 shellcheck issues

#### Validation
`shellcheck tests/integration/kubernetes/*.sh` exits cleanly with no output.