### PR TITLE
ci: move the job publish kata payload after push to an alternate runner for ppc64le

### DIFF
--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -134,7 +134,7 @@ jobs:
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-latest-ppc64le
       target-branch: ${{ github.ref_name }}
-      runner: ppc64le-small
+      runner: ubuntu-24.04-ppc64le
       arch: ppc64le
       build-type: "" # Use script-based build (default)
     secrets:


### PR DESCRIPTION
To unlock the release, move the job publish kata payload after push to an alternate runner(IBM owned) for ppc64le.