### PR TITLE
gpu: Enable remote and local repo cuda builds

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -246,11 +246,34 @@ externals:
     url: "https://github.com/NVIDIA/nvrc/releases/download/"
 
   nvidia:
-    desc: "NVIDIA driver version"
+    desc: "NVIDIA compute stack"
     driver:
+      desc: "NVIDIA kernel driver"
       version: "590.48.01"
       # yamllint disable-line rule:line-length
       url: "https://github.com/NVIDIA/open-gpu-kernel-modules/archive/refs/tags/"
+    cuda:
+      desc: "NVIDIA CUDA repository"
+      repo:
+        x86_64:
+          # yamllint disable-line rule:line-length
+          url: "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/"
+          pkg: "cuda-keyring_1.1-1_all.deb"
+        aarch64:
+          # yamllint disable-line rule:line-length
+          url: "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/"
+          pkg: "cuda-keyring_1.1-1_all.deb"
+    tools:
+      desc: "NVIDIA container toolkit and tools repository"
+      repo:
+        x86_64:
+          # yamllint disable-line rule:line-length
+          url: "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/"
+          pkg: "cuda-keyring_1.1-1_all.deb"
+        aarch64:
+          # yamllint disable-line rule:line-length
+          url: "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/sbsa/"
+          pkg: "cuda-keyring_1.1-1_all.deb"
 
   busybox:
     desc: "The Swiss Army Knife of Embedded Linux"


### PR DESCRIPTION
 We want to enable local and remote CUDA repository builds. Moving the cuda and tools repo to versions.yaml with a unified build for both types.