### PR TITLE
Revert "ci: Ensure the KBS resources are created"

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -218,15 +218,6 @@ kbs_set_resource_from_file() {
 	kbs-client --url "$(kbs_k8s_svc_http_addr)" config \
 		--auth-private-key "${KBS_PRIVATE_KEY}" set-resource \
 		--path "${path}" --resource-file "${file}"
-
-	kbs_pod=$(kubectl -n "${KBS_NS}" get pods -o NAME)
-	kbs_repo_path="/opt/confidential-containers/kbs/repository"
-	# Waiting for the resource to be created on the kbs pod
-	if ! kubectl -n "${KBS_NS}" exec -it "${kbs_pod}" -- bash -c "for i in {1..30}; do [ -e '${kbs_repo_path}/${path}' ] && exit 0; sleep 0.5; done; exit -1"; then
-		echo "ERROR: resource '${path}' not created in 15s"
-		kubectl -n "${KBS_NS}" exec -it "${kbs_pod}" -- bash -c "find ${kbs_repo_path}"
-		return 1
-	fi
 }
 
 # Build and install the kbs-client binary, unless it is already present.


### PR DESCRIPTION
This reverts commit c0d722219469dc80715af1185287070e365dbe4d.

Soon, guest components will switch to using a DB instead of storing resources in the filesystem. Further, I don't see any more indicators why kbs-client would struggle to set simple resources.