### PR TITLE
tests: Remove terminationGracePeriod in manifests

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: busybox
 spec:
-  terminationGracePeriodSeconds: 0
   shareProcessNamespace: true
   runtimeClassName: kata
   containers:

--- a/tests/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: POD_NAME
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   shareProcessNamespace: true
   containers:

--- a/tests/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: initcontainer-shared-volume
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   initContainers:
   - name: first

--- a/tests/integration/kubernetes/runtimeclass_workloads/initcontainer-shareprocesspid.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/initcontainer-shareprocesspid.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: busybox
 spec:
-  terminationGracePeriodSeconds: 0
   shareProcessNamespace: true
   runtimeClassName: kata
   initContainers:

--- a/tests/integration/kubernetes/runtimeclass_workloads/job-template.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/job-template.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         jobgroup: jobtest
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: test

--- a/tests/integration/kubernetes/runtimeclass_workloads/job.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/job.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   template:
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: pi

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-layered-sc-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-layered-sc-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         role: master
         tier: backend
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       securityContext:
         runAsUser: 2000

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         role: master
         tier: backend
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       securityContext:
         runAsUser: 2000

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-nobodyupdate-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-nobodyupdate-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         role: master
         tier: backend
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       securityContext:
         runAsUser: 65534

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-supplementalgroups-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-supplementalgroups-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         role: master
         tier: backend
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       securityContext:
         runAsUser: 2000

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         role: master
         tier: backend
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       securityContext:
         runAsUser: 1000

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-hard-coded.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-hard-coded.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: hard-coded-policy-pod
 spec:
-  terminationGracePeriodSeconds: 0
   shareProcessNamespace: true
   runtimeClassName: kata
   containers:

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-job.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-job.yaml
@@ -10,7 +10,6 @@ metadata:
 spec:
   template:
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
         - name: hello

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod-pvc.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod-pvc.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: policy-pod-pvc
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: busybox

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -9,7 +9,6 @@ metadata:
   name: policy-pod
   uid: policy-pod-uid
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: prometheus

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-rc.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-rc.yaml
@@ -17,7 +17,6 @@ spec:
       labels:
         app: policy-nginx-rc
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: nginxtest

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-set-keys.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-set-keys.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: set-keys-test
 spec:
-  terminationGracePeriodSeconds: 0
   shareProcessNamespace: true
   runtimeClassName: kata
   containers:

--- a/tests/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/lifecycle-events.yaml
@@ -9,7 +9,6 @@ kind: Pod
 metadata:
   name: handlers
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: handlers-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nginx-deployment.yaml
@@ -17,7 +17,6 @@ spec:
       labels:
         app: nginx
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: nginx

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: besteffort-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: qos-besteffort

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-block-pv.yaml
@@ -3,7 +3,6 @@ kind: Pod
 metadata:
   name: pod-block-pv
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: my-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: burstable-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: qos-burstable

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-caps.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-caps.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: pod-caps
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: config-env-test-pod
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: default-cpu-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: default-cpu-demo-ctr

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-cpu.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-cpu.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: constraints-cpu-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: first-cpu-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-custom-dns.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: custom-dns-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: sharevol-kata
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: test

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: test-env
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-file-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-file-volume.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: test-file-volume
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   restartPolicy: Never
   nodeName: NODE

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-footloose.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-footloose.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: footubuntu
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   volumes:
   - name: runv

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: qos-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: qos-guaranteed

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-hostname.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-hostname.yaml
@@ -9,7 +9,6 @@ kind: Pod
 metadata:
   name: test-pod-hostname
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   restartPolicy: Never
   containers:

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-hostpath-kmsg.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-hostpath-kmsg.yaml
@@ -9,7 +9,6 @@ kind: Pod
 metadata:
   name: hostpath-kmsg
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   restartPolicy: Never
   volumes:

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
@@ -10,7 +10,6 @@ metadata:
     test: liveness-test
   name: liveness-http
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: liveness

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
@@ -10,7 +10,6 @@ metadata:
     test: liveness
   name: liveness-exec
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: liveness

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: memory-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: memory-test-ctr

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-nested-configmap-secret.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-nested-configmap-secret.yaml
@@ -23,7 +23,6 @@ kind: Pod
 metadata:
   name: nested-configmap-secret-pod
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: cpu-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: c1

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-configmap.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-configmap.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: optional-empty-config-test-pod
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-secret.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-secret.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: optional-empty-secret-test-pod
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-privileged.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-privileged.yaml
@@ -9,7 +9,6 @@ kind: Pod
 metadata:
   name: privileged
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   restartPolicy: Never
   containers:

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-projected-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-projected-volume.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: test-projected-volume
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: test-projected-volume

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
@@ -17,7 +17,6 @@ spec:
       labels:
         purpose: quota-demo
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: pod-quota-demo

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-readonly-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-readonly-volume.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: test-readonly-volume
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   restartPolicy: Never
   volumes:

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-seccomp.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-seccomp.yaml
@@ -11,7 +11,6 @@ metadata:
     io.katacontainers.config.runtime.disable_guest_seccomp: "false"
 spec:
   runtimeClassName: kata
-  terminationGracePeriodSeconds: 0
   restartPolicy: Never
   containers:
   - name: busybox

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: secret-envars-test-pod
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: envars-test-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: secret-test-pod
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: test-container

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-security-context.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: security-context-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   securityContext:
     runAsUser: 1000

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: test-shared-volume
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   restartPolicy: Never
   volumes:

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: sysctl-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   securityContext:
     sysctls:

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
@@ -10,7 +10,6 @@ metadata:
   labels:
     app: tcp-liveness
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: tcp-liveness

--- a/tests/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
@@ -8,7 +8,6 @@ apiVersion: v1
 metadata:
   name: pv-pod
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   nodeName: NODE
   volumes:

--- a/tests/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
@@ -23,7 +23,6 @@ spec:
         role: master
         tier: backend
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: master

--- a/tests/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/replication-controller.yaml
@@ -17,7 +17,6 @@ spec:
       labels:
         app: nginx-rc-test
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: nginxtest

--- a/tests/integration/kubernetes/runtimeclass_workloads/vfio.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/vfio.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: vfio
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: c1

--- a/tests/metrics/density/runtimeclass_workloads/sysbench-pod.yaml
+++ b/tests/metrics/density/runtimeclass_workloads/sysbench-pod.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: test-sysbench
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: test-sysbench

--- a/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-daemonset.yaml
+++ b/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-daemonset.yaml
@@ -26,4 +26,3 @@ spec:
       - name: iperf3-client
         image: networkstatic/iperf3
         command: ['/bin/sh', '-c', 'sleep infinity']
-      terminationGracePeriodSeconds: 0

--- a/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-deployment.yaml
+++ b/tests/metrics/network/iperf3_kubernetes/runtimeclass_workloads/iperf3-deployment.yaml
@@ -38,7 +38,6 @@ spec:
         ports:
         - containerPort: 5201
           name: server
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
 
 ---

--- a/tests/metrics/network/latency_kubernetes/latency-client.yaml
+++ b/tests/metrics/network/latency_kubernetes/latency-client.yaml
@@ -7,7 +7,6 @@ kind: Pod
 metadata:
   name: latency-client
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: client-container

--- a/tests/metrics/network/latency_kubernetes/latency-server.yaml
+++ b/tests/metrics/network/latency_kubernetes/latency-server.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: latency-server
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
     - name: server-container

--- a/tests/metrics/network/nginx_kubernetes/runtimeclass_workloads/nginx-networking.yaml
+++ b/tests/metrics/network/nginx_kubernetes/runtimeclass_workloads/nginx-networking.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         app: nginx
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: nginx

--- a/tests/stability/runtimeclass_workloads/pod-deployment.yaml
+++ b/tests/stability/runtimeclass_workloads/pod-deployment.yaml
@@ -16,7 +16,6 @@ spec:
       labels:
         purpose: pod-test
     spec:
-      terminationGracePeriodSeconds: 0
       runtimeClassName: kata
       containers:
       - name: pod-test

--- a/tests/stability/runtimeclass_workloads/stability-test.yaml
+++ b/tests/stability/runtimeclass_workloads/stability-test.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: stability-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: stability-test

--- a/tests/stability/runtimeclass_workloads/stress-test.yaml
+++ b/tests/stability/runtimeclass_workloads/stress-test.yaml
@@ -8,7 +8,6 @@ kind: Pod
 metadata:
   name: stressng-test
 spec:
-  terminationGracePeriodSeconds: 0
   runtimeClassName: kata
   containers:
   - name: stress-test


### PR DESCRIPTION
Do not kill containers immediately, instead use Kubernetes' default termination grace period.

Some of these manifests may intentionally use `terminationGracePeriod: 0`, for instance, to avoid longer pod teardown time, to explicitly test this specific setting, or because surrounding CI logic assumes immediate teardown.

On the other hand, this generally seems bad practice and there is no clue in commits/issues/manifests why these would need to be used. A possibility is previous issues in the code base, such as addressed by a recent cgroups fix for the go based shim where pod deletion would frequently hit the 30 seconds grace period (at least for manifests with VFIO passthrough): https://github.com/kata-containers/kata-containers/pull/12342
With this issue being fixed, and with potential other fixes in our code base, trying to remove `terminationGracePeriod: 0`.

Please do comment in the manifests for which you think this should be kept (maybe for metrics ones).

For failing manifests, we can assess whether there is more underlying issues with our pod termination behavior, and rather address these issues than keeping `terminationGracePeriod: 0`