### PR TITLE
tests: arm64: Increase k8s tests timeout to 60 minutes

### DIFF
--- a/.github/workflows/run-k8s-tests-on-arm64.yaml
+++ b/.github/workflows/run-k8s-tests-on-arm64.yaml
@@ -65,7 +65,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-bats
 
       - name: Run tests
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Report tests


### PR DESCRIPTION
This allows adding different runners in case the powerful one goes down for one reason or another.