### PR TITLE
virtcontainers: calculate exact PCI root port size

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -812,7 +812,7 @@ func (q *qemu) createPCIeTopology(qemuConfig *govmmQemu.Config, hypervisorConfig
 	// For more details, please see https://github.com/qemu/qemu/blob/master/docs/pcie.txt
 
 	// Deduce the right values for mem-reserve and pref-64-reserve memory regions
-	memSize32bit, memSize64bit := q.arch.getBARsMaxAddressableMemory()
+	memSize32bit, memSize64bit := q.arch.getBARsMaxAddressableMemory(hypervisorConfig.VFIODevices)
 
 	// The default OVMF MMIO aperture is too small for some PCIe devices
 	// with huge BARs so we need to increase it.


### PR DESCRIPTION
This changes the PCI root port size calculation to support cold-plugging multiple GPUs. Instead of using the maximum BAR size of any of the attached GPUs, the attached GPUs' sizes are now summed up and returned. To my understanding, the previous approach didn't support hot-plugging multiple GPUs either. This patch does not address this issue. A simple way would certainly be to just unconditionally sum all GPU BAR sizes on the node for every UVM, but I'm unsure about what other implications this might have.

Fixes #12289