### PR TITLE
release: scripts: Accept KATA_TOOLS_STATIC_TARBALL env var

### DIFF
--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -40,6 +40,7 @@ function _check_required_env_var()
 		KATA_STATIC_TARBALL) env_var="${KATA_STATIC_TARBALL}" ;;
 		KATA_DEPLOY_IMAGE_TAGS) env_var="${KATA_DEPLOY_IMAGE_TAGS}" ;;
 		KATA_DEPLOY_REGISTRIES) env_var="${KATA_DEPLOY_REGISTRIES}" ;;
+		KATA_TOOLS_STATIC_TARBALL) env_var="${KATA_TOOLS_STATIC_TARBALL}" ;;
 		*) >&2 _die "Invalid environment variable \"${1}\"" ;;
 	esac
 


### PR DESCRIPTION
a2534e7bc8acba1de11b649479ebf75743c481c3 introduced the logic to also release a kata-tools tarball, but it missed allowing KATA_TOOLS_STATIC_TARBALL env var to be passed to the release script, leading to the following error during the release process:
```
ERROR: Invalid environment variable "KATA_TOOLS_STATIC_TARBALL"
```