### PR TITLE
agent: Refresh `Cargo.lock`

### DIFF
--- a/src/agent/Cargo.lock
+++ b/src/agent/Cargo.lock
@@ -4305,6 +4305,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 name = "test-utils"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "nix 0.26.4",
 ]
 


### PR DESCRIPTION
Downstream builders at Red Hat complain that `Cargo.lock` doesn't match `Cargo.toml`.

Run `cargo check` to refresh `Cargo.lock`.

`git bisect` shows that https://github.com/kata-containers/kata-containers/commit/7cfb97d41b353f39955bedb4e9b5b24cd238313d is the first commit where `cargo check` has an effect in `src/agent`.
