### PR TITLE
tests: Add common bats test runner function

### DIFF
--- a/.github/workflows/run-kata-deploy-tests.yaml
+++ b/.github/workflows/run-kata-deploy-tests.yaml
@@ -87,4 +87,4 @@ jobs:
 
       - name: Report tests
         if: always()
-        run: bash tests/integration/kubernetes/gha-run.sh report-tests
+        run: bash tests/functional/kata-deploy/gha-run.sh report-tests

--- a/tests/functional/kata-deploy/gha-run.sh
+++ b/tests/functional/kata-deploy/gha-run.sh
@@ -20,6 +20,10 @@ function run_tests() {
 	popd
 }
 
+function report_tests() {
+	report_bats_tests "${kata_deploy_dir}"
+}
+
 function cleanup_runtimeclasses() {
 	# Cleanup any runtime class that was left behind in the cluster, in
 	# case of a test failure, apart from the default one that comes from
@@ -59,6 +63,7 @@ function main() {
         install-kubectl) install_kubectl ;;
         get-cluster-credentials) get_cluster_credentials "kata-deploy" ;;
         run-tests) run_tests ;;
+        report-tests) report_tests ;;
         delete-cluster) cleanup "aks" "kata-deploy" ;;
         *) >&2 echo "Invalid argument"; exit 2 ;;
     esac

--- a/tests/functional/kata-deploy/run-kata-deploy-tests.sh
+++ b/tests/functional/kata-deploy/run-kata-deploy-tests.sh
@@ -6,9 +6,13 @@
 #
 
 set -e
+set -o pipefail
 
 kata_deploy_dir=$(dirname "$(readlink -f "$0")")
 source "${kata_deploy_dir}/../../common.bash"
+
+# Setting to "yes" enables fail fast, stopping execution at the first failed test.
+export BATS_TEST_FAIL_FAST="${BATS_TEST_FAIL_FAST:-no}"
 
 if [[ -n "${KATA_DEPLOY_TEST_UNION:-}" ]]; then
 	KATA_DEPLOY_TEST_UNION=("${KATA_DEPLOY_TEST_UNION}")
@@ -18,8 +22,4 @@ else
 	)
 fi
 
-info "Run tests"
-for KATA_DEPLOY_TEST_ENTRY in "${KATA_DEPLOY_TEST_UNION[@]}"
-do
-	bats --show-output-of-passing-tests "${KATA_DEPLOY_TEST_ENTRY}"
-done
+run_bats_tests "${kata_deploy_dir}" KATA_DEPLOY_TEST_UNION

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -326,41 +326,7 @@ function run_tests() {
 # directory.
 #
 function report_tests() {
-	local reports_dir="${kubernetes_dir}/reports"
-	local ok
-	local not_ok
-	local status
-
-	if [[ ! -d "${reports_dir}" ]]; then
-		info "no reports directory found: ${reports_dir}"
-		return
-	fi
-
-	for report_dir in "${reports_dir}"/*; do
-		mapfile -t ok < <(find "${report_dir}" -name "ok-*.out")
-		mapfile -t not_ok < <(find "${report_dir}" -name "not_ok-*.out")
-
-		cat <<-EOF
-		SUMMARY ($(basename "${report_dir}")):
-		 Pass:  ${#ok[*]}
-		 Fail:  ${#not_ok[*]}
-		EOF
-
-		echo -e "\nSTATUSES:"
-		for out in "${not_ok[@]}" "${ok[@]}"; do
-			status=$(basename "${out}" | cut -d '-' -f1)
-			bats=$(basename "${out}" | cut -d '-' -f2- | sed 's/.out$//')
-			echo " ${status} ${bats}"
-		done
-
-		echo -e "\nOUTPUTS:"
-		for out in "${not_ok[@]}" "${ok[@]}"; do
-			bats=$(basename "${out}" | cut -d '-' -f2- | sed 's/.out$//')
-			echo "::group::${bats}"
-			cat "${out}"
-			echo "::endgroup::"
-		done
-	done
+	report_bats_tests "${kubernetes_dir}"
 }
 
 function collect_artifacts() {

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -54,28 +54,6 @@ if [[ "${ENABLE_NVRC_TRACE:-true}" == "true" ]]; then
 	enable_nvrc_trace
 fi
 
-report_dir="${kubernetes_dir}/reports/$(date +'%F-%T')"
-mkdir -p "${report_dir}"
-
-info "Running tests with bats version: $(bats --version). Save outputs to ${report_dir}"
-
-tests_fail=()
-for K8S_TEST_ENTRY in "${K8S_TEST_NV[@]}"
-do
-	K8S_TEST_ENTRY=$(echo "${K8S_TEST_ENTRY}" | tr -d '[:space:][:cntrl:]')
-	time info "$(kubectl get pods --all-namespaces 2>&1)"
-	info "Executing ${K8S_TEST_ENTRY}"
-	# Output file will be prefixed with "ok" or "not_ok" based on the result
-	out_file="${report_dir}/${K8S_TEST_ENTRY}.out"
-	if ! bats --timing --show-output-of-passing-tests "${K8S_TEST_ENTRY}" | tee "${out_file}"; then
-		tests_fail+=("${K8S_TEST_ENTRY}")
-		mv "${out_file}" "$(dirname "${out_file}")/not_ok-$(basename "${out_file}")"
-		[[ "${K8S_TEST_FAIL_FAST}" = "yes" ]] && break
-	else
-		mv "${out_file}" "$(dirname "${out_file}")/ok-$(basename "${out_file}")"
-	fi
-done
-
-[[ ${#tests_fail[@]} -ne 0 ]] && die "Tests FAILED from suites: ${tests_fail[*]}"
-
-info "All tests SUCCEEDED"
+# Use common bats test runner with proper reporting
+export BATS_TEST_FAIL_FAST="${K8S_TEST_FAIL_FAST}"
+run_bats_tests "${kubernetes_dir}" K8S_TEST_NV

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -135,28 +135,6 @@ fi
 
 ensure_yq
 
-report_dir="${kubernetes_dir}/reports/$(date +'%F-%T')"
-mkdir -p "${report_dir}"
-
-info "Running tests with bats version: $(bats --version). Save outputs to ${report_dir}"
-
-tests_fail=()
-for K8S_TEST_ENTRY in "${K8S_TEST_UNION[@]}"
-do
-	K8S_TEST_ENTRY=$(echo "$K8S_TEST_ENTRY" | tr -d '[:space:][:cntrl:]')
-	time info "$(kubectl get pods --all-namespaces 2>&1)"
-	info "Executing ${K8S_TEST_ENTRY}"
-	# Output file will be prefixed with "ok" or "not_ok" based on the result
-	out_file="${report_dir}/${K8S_TEST_ENTRY}.out"
-	if ! bats --timing --show-output-of-passing-tests "${K8S_TEST_ENTRY}" | tee "${out_file}"; then
-		tests_fail+=("${K8S_TEST_ENTRY}")
-		mv "${out_file}" "$(dirname "${out_file}")/not_ok-$(basename "${out_file}")"
-		[ "${K8S_TEST_FAIL_FAST}" = "yes" ] && break
-	else
-		mv "${out_file}" "$(dirname "${out_file}")/ok-$(basename "${out_file}")"
-	fi
-done
-
-[ ${#tests_fail[@]} -ne 0 ] && die "Tests FAILED from suites: ${tests_fail[*]}"
-
-info "All tests SUCCEEDED"
+# Use common bats test runner with proper reporting
+export BATS_TEST_FAIL_FAST="${K8S_TEST_FAIL_FAST}"
+run_bats_tests "${kubernetes_dir}" K8S_TEST_UNION


### PR DESCRIPTION
Add run_bats_tests() function to common.bash that provides consistent test execution and reporting across all test suites (k8s, nvidia, kata-deploy).

This removes duplicated test runner code from run_kubernetes_tests.sh, run_kubernetes_nv_tests.sh, and run-kata-deploy-tests.sh.

Internal run (as it changes kata-deploy's workflow): https://github.com/kata-containers/kata-containers/actions/runs/21151969583/job/60832191528