### PR TITLE
runtime: Add -info flag support for containerd v2.0+

### DIFF
--- a/src/runtime/cmd/containerd-shim-kata-v2/main.go
+++ b/src/runtime/cmd/containerd-shim-kata-v2/main.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"os"
 
+	containerdtypes "github.com/containerd/containerd/api/types"
 	shimapi "github.com/containerd/containerd/runtime/v2/shim"
+	"google.golang.org/protobuf/proto"
 
 	shim "github.com/kata-containers/kata-containers/src/runtime/pkg/containerd-shim-v2"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils"
@@ -21,11 +23,34 @@ func shimConfig(config *shimapi.Config) {
 	config.NoSubreaper = true
 }
 
+func handleInfoFlag() {
+	info := &containerdtypes.RuntimeInfo{
+		Name: types.DefaultKataRuntimeName,
+		Version: &containerdtypes.RuntimeVersion{
+			Version:  katautils.VERSION,
+			Revision: katautils.COMMIT,
+		},
+	}
+
+	data, err := proto.Marshal(info)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "failed to marshal RuntimeInfo: %v\n", err)
+		os.Exit(1)
+	}
+
+	os.Stdout.Write(data)
+	os.Exit(0)
+}
+
 func main() {
 
 	if len(os.Args) == 2 && os.Args[1] == "--version" {
 		fmt.Printf("%s containerd shim (Golang): id: %q, version: %s, commit: %v\n", katautils.PROJECT, types.DefaultKataRuntimeName, katautils.VERSION, katautils.COMMIT)
 		os.Exit(0)
+	}
+
+	if len(os.Args) == 2 && os.Args[1] == "-info" {
+		handleInfoFlag()
 	}
 
 	shimapi.Run(types.DefaultKataRuntimeName, shim.New, shimConfig)


### PR DESCRIPTION
## Summary
- Add `-info` flag handling to containerd-shim-kata-v2
- Outputs RuntimeInfo protobuf (name, version, revision) to stdout
- Resolves error log: `flag provided but not defined: -info`

Fixes #12133

## Test plan
- [ ] Build passes on Linux
- [ ] `-info` flag outputs valid protobuf
- [ ] `--version` still works
- [ ] No error logs with containerd v2.2.0+