### PR TITLE
runtime: calculate total bar size for any VFIO device

### DIFF
--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -430,6 +430,9 @@ type VFIODev struct {
 	// HostPath is the path to the device on the host we need it as a reference
 	// to match a /dev/vfio/<num> device to a device in GK mode
 	HostPath string
+
+	// Total size of all declared bars in bytes
+	TotalBarSize uint64
 }
 
 // IOMMUFDID returns the IOMMUFD ID if the VFIO device is backed by IOMMUFD

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -812,7 +812,7 @@ func (q *qemu) createPCIeTopology(qemuConfig *govmmQemu.Config, hypervisorConfig
 	// For more details, please see https://github.com/qemu/qemu/blob/master/docs/pcie.txt
 
 	// Deduce the right values for mem-reserve and pref-64-reserve memory regions
-	memSize32bit, memSize64bit := q.arch.getBARsMaxAddressableMemory()
+	memSize32bit, memSize64bit := q.arch.getBARsMaxAddressableMemory(hypervisorConfig)
 
 	// The default OVMF MMIO aperture is too small for some PCIe devices
 	// with huge BARs so we need to increase it.


### PR DESCRIPTION
Currently the bar calculation only works for NVIDIA devices and it ignores the actual passed devices. If you pass a TPU that is not an NVIDIA device AND you have a NVIDIA device on your system.

You will STILL calculate the bar for that NVIDIA device.

This treats devices as agnostic VFIOs, and each bar is checked and summed.