### PR TITLE
doc: update enabling full debug method

### DIFF
--- a/docs/Developer-Guide.md
+++ b/docs/Developer-Guide.md
@@ -125,7 +125,7 @@ If you want to enable SELinux in Permissive mode, add `enforcing=0` to the kerne
 Enable full debug as follows:
 
 ```bash
-$ sudo sed -i -e 's/^# *\(enable_debug\).*=.*$/\1 = true/g' /etc/kata-containers/configuration.toml
+$ sudo sed -i -E 's/^(\s*enable_debug\s*=\s*)false/\1true/' /etc/kata-containers/configuration.toml
 $ sudo sed -i -e 's/^kernel_params = "\(.*\)"/kernel_params = "\1 agent.log=debug initcall_debug"/g' /etc/kata-containers/configuration.toml
 ```
 


### PR DESCRIPTION
The enable_debug parameter was explicitly set to false rather than being commented out (e.g., # enable_debug = true). As the previous enabling method failed to account for this explicit setting, it was rendered invalid. This commit updates the matching logic to correctly handle and toggle the explicit false value.


```shell
# the original set as:
root@kata-dev001:/opt/kata/share/defaults/kata-containers/runtime-rs# cat configuration-qemu-snp-runtime-rs.toml |grep enable_debug
enable_debug = false
# This option allows to add an extra HMP or QMP socket when `enable_debug = true`
enable_debug = false
enable_debug = false

# the old method fails with the result:
root@kata-dev001:/opt/kata/share/defaults/kata-containers/runtime-rs# sed -i -e 's/^# *\(enable_debug\).*=.*$/\1 = true/g' configuration-qemu-snp-runtime-rs.toml
root@kata-dev001:/opt/kata/share/defaults/kata-containers/runtime-rs# cat configuration-qemu-snp-runtime-rs.toml |grep enable_debug
enable_debug = false
# This option allows to add an extra HMP or QMP socket when `enable_debug = true`
enable_debug = false
enable_debug = false

# the new method with the result:
root@kata-dev001:/opt/kata/share/defaults/kata-containers/runtime-rs# sed -i -E 's/^(\s*enable_debug\s*=\s*)false/\1true/' configuration-qemu-snp-runtime-rs.toml
root@kata-dev001:/opt/kata/share/defaults/kata-containers/runtime-rs# cat configuration-qemu-snp-runtime-rs.toml |grep enable_debug
enable_debug = true
# This option allows to add an extra HMP or QMP socket when `enable_debug = true`
enable_debug = true
enable_debug = true
root@kata-dev001:/opt/kata/share/defaults/kata-containers/runtime-rs# 


```

