### PR TITLE
ci.ocp: Use 0.0.0-dev tagged helm chart

### DIFF
--- a/ci/openshift-ci/cluster/install_kata.sh
+++ b/ci/openshift-ci/cluster/install_kata.sh
@@ -51,13 +51,13 @@ apply_kata_deploy() {
 
 	oc label --overwrite ns kube-system pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/warn=baseline pod-security.kubernetes.io/audit=baseline
 	local version chart
-	version=$(curl -sSL https://api.github.com/repos/kata-containers/kata-containers/releases/latest | jq .tag_name | tr -d '"')
+	version='0.0.0-dev'
 	chart="oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy"
 
 	# Ensure any potential leftover is cleaned up ... and this secret usually is not in case of previous failures
 	oc delete secret sh.helm.release.v1.kata-deploy.v1 -n kube-system || true
 
-	echo "Installing kata using helm ${chart} ${version}"
+	echo "Installing kata using helm ${chart} ${version} (sha printed in helm output)"
 	helm install kata-deploy --wait --namespace kube-system --set "image.reference=${KATA_DEPLOY_IMAGE%%:*},image.tag=${KATA_DEPLOY_IMAGE##*:}" "${chart}" --version "${version}"
 }
 


### PR DESCRIPTION
in CI we are testing the latest kata-deploy, which requires the latest helm chart. The previous query doesn't work anymore, but these days we should be able to rely on the "0.0.0-dev" tag and on helm to print the to-be-installed version into console.