### PR TITLE
runtime-rs: Add -info flag support for containerd v2.0+

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4005,6 +4005,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "common",
+ "containerd-shim-protos",
  "go-flag",
  "logging",
  "nix 0.26.4",

--- a/src/runtime-rs/Cargo.toml
+++ b/src/runtime-rs/Cargo.toml
@@ -22,6 +22,7 @@ cloud-hypervisor = ["runtimes/cloud-hypervisor"]
 
 [dependencies]
 anyhow = { workspace = true }
+containerd-shim-protos = { workspace = true }
 go-flag = { workspace = true }
 nix = { workspace = true }
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }


### PR DESCRIPTION
## Summary
- Add `-info` flag handling to containerd-shim-kata-v2 (Rust version)
- Outputs RuntimeInfo protobuf (name, version, revision) to stdout
- Resolves error log: `flag provided but not defined: -info`

This is the Rust equivalent of #12366 (Go version).

Fixes #12133

## Test plan
- [ ] Build passes on Linux
- [ ] `-info` flag outputs valid protobuf
- [ ] `--version` still works
- [ ] No error logs with containerd v2.2.0+