### PR TITLE
runtime-rs: Enhance TDX in qemu

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2610,6 +2610,7 @@ impl<'a> QemuCmdLine<'a> {
         self.devices.push(Box::new(Bios::new(firmware.to_owned())));
 
         self.machine
+            .set_kernel_irqchip("split")
             .set_confidential_guest_support("tdx")
             .set_nvdimm(false);
     }


### PR DESCRIPTION
Add `kernel_irqchip=split` within qemu `-machine`
```
-machine q35,accel=kvm,kernel_irqchip=split,confidential-guest-support=tdx \
-object {"qom-type":"tdx-guest","id":"0","sept-ve-disable":true,"quote-generation-socket":{"type":"vsock","cid":"2","port":"4050"}}
```