### PR TITLE
shim: enforce iommufd for confidential guest vfio

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -861,6 +861,10 @@ func (q *qemu) createPCIeTopology(qemuConfig *govmmQemu.Config, hypervisorConfig
 				return fmt.Errorf("Cannot get VFIO device from IOMMUFD with device: %v err: %v", dev, err)
 			}
 		} else {
+			if q.config.ConfidentialGuest {
+				return fmt.Errorf("ConfidentialGuest needs IOMMUFD - cannot use %s", dev.HostPath)
+			}
+
 			vfioDevices, err = drivers.GetAllVFIODevicesFromIOMMUGroup(dev)
 			if err != nil {
 				return fmt.Errorf("Cannot get all VFIO devices from IOMMU group with device: %v err: %v", dev, err)


### PR DESCRIPTION
Confidential guests cannot use traditional IOMMU Group based VFIO. Instead, they need to use IMMUFD. This is mainly because the group abstraction is incompatible with a confidential device model. If traditional VFIO is specified for a confidential guest, detect the error and bail out early.

Addresses https://github.com/kata-containers/kata-containers/issues/12393