### PR TITLE
packaging: Delete pause_bundle dir before unpack

### DIFF
--- a/tools/packaging/static-build/pause-image/build-static-pause-image.sh
+++ b/tools/packaging/static-build/pause-image/build-static-pause-image.sh
@@ -19,6 +19,7 @@ pull_pause_image_from_remote() {
 	echo "pull pause image from remote"
 
 	skopeo copy "${pause_image_repo}":"${pause_image_version}" oci:pause:"${pause_image_version}"
+	rm -rf "${DESTDIR}/pause_bundle"
 	umoci unpack --rootless --image pause:"${pause_image_version}"  "${DESTDIR}/pause_bundle"
 	rm "${DESTDIR}/pause_bundle/umoci.json"
 }


### PR DESCRIPTION
Delete the pause_bundle directory before running the umoci unpack operation. This will make builds more idempotent and not fail with errors like "create runtime bundle: config.json already exists in .../build/pause-image/destdir/pause_bundle". This will make life better when building locally.