### PR TITLE
tests: nvidia: cc: Use sealed secrets for NGC_API_KEY

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
@@ -10,7 +10,11 @@ metadata:
   labels:
     app: ${POD_NAME_INSTRUCT}
   annotations:
-    io.katacontainers.config.hypervisor.kernel_params: "agent.image_registry_auth=kbs:///default/credentials/nvcr agent.aa_kbc_params=cc_kbc::${CC_KBS_ADDR}"
+    # Start CDH process and configure AA for KBS communication
+    # aa_kbc_params tells the Attestation Agent where KBS is located
+    io.katacontainers.config.hypervisor.kernel_params: "agent.guest_components_procs=confidential-data-hub agent.aa_kbc_params=cc_kbc::${CC_KBS_ADDR}"
+    # cc_init_data annotation will be added by genpolicy with CDH configuration
+    # from the custom default-initdata.toml created by create_nim_initdata_file()
 spec:
   restartPolicy: Never
   runtimeClassName: kata
@@ -58,7 +62,7 @@ spec:
       - name: NGC_API_KEY
         valueFrom:
           secretKeyRef:
-            name: ngc-api-key-instruct
+            name: ngc-api-key-sealed-instruct
             key: api-key
     # GPU resource limit (for NVIDIA GPU)
     resources:
@@ -78,7 +82,9 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ngc-api-key-instruct
+  name: ngc-api-key-sealed-instruct
 type: Opaque
 data:
-  api-key: "${NGC_API_KEY_BASE64}"
+  # Sealed secret pointing to kbs:///default/ngc-api-key/instruct
+  # CDH will unseal this by fetching the actual key from KBS
+  api-key: "${NGC_API_KEY_SEALED_SECRET_INSTRUCT_BASE64}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
@@ -10,7 +10,11 @@ metadata:
   labels:
     app: ${POD_NAME_EMBEDQA}
   annotations:
-    io.katacontainers.config.hypervisor.kernel_params: "agent.image_registry_auth=kbs:///default/credentials/nvcr agent.aa_kbc_params=cc_kbc::${CC_KBS_ADDR}"
+    # Start CDH process and configure AA for KBS communication
+    # aa_kbc_params tells the Attestation Agent where KBS is located
+    io.katacontainers.config.hypervisor.kernel_params: "agent.guest_components_procs=confidential-data-hub agent.aa_kbc_params=cc_kbc::${CC_KBS_ADDR}"
+    # cc_init_data annotation will be added by genpolicy with CDH configuration
+    # from the custom default-initdata.toml created by create_nim_initdata_file()
 spec:
   restartPolicy: Always
   runtimeClassName: kata
@@ -29,7 +33,7 @@ spec:
       - name: NGC_API_KEY
         valueFrom:
           secretKeyRef:
-            name: ngc-api-key-embedqa
+            name: ngc-api-key-sealed-embedqa
             key: api-key
       - name: NIM_HTTP_API_PORT
         value: "8000"
@@ -88,7 +92,9 @@ data:
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ngc-api-key-embedqa
+  name: ngc-api-key-sealed-embedqa
 type: Opaque
 data:
-  api-key: "${NGC_API_KEY_BASE64}"
+  # Sealed secret pointing to kbs:///default/ngc-api-key/embedqa
+  # CDH will unseal this by fetching the actual key from KBS
+  api-key: "${NGC_API_KEY_SEALED_SECRET_EMBEDQA_BASE64}"


### PR DESCRIPTION
Use sealed secrets for the NGC_API_KEY environment variable in TEE mode.
This ensures the API key is protected and only accessible inside the
confidential guest VM after attestation.

The sealed secret uses the vault type format pointing to KBS resources:
- kbs:///default/ngc-api-key/instruct for the instruct pod
- kbs:///default/ngc-api-key/embedqa for the embedqa pod

The actual NGC_API_KEY is stored in KBS and the CDH (Confidential Data
Hub) unseals the secret inside the guest by fetching it from KBS.