### PR TITLE
kata-ctl: Fix failures when kata-ctl exec with short id

### DIFF
--- a/src/libs/shim-interface/src/lib.rs
+++ b/src/libs/shim-interface/src/lib.rs
@@ -37,11 +37,6 @@ fn get_uds_with_sid(short_id: &str, path: &str) -> Result<String> {
         return Ok(format!("unix://{}", p.display()));
     }
 
-    let _ = fs::create_dir_all(kata_run_path.join(short_id)).context(format!(
-        "failed to create directory {:?}",
-        kata_run_path.join(short_id)
-    ));
-
     let target_ids: Vec<String> = fs::read_dir(&kata_run_path)?
         .filter_map(|e| {
             let x = e.ok()?.file_name().to_string_lossy().into_owned();

--- a/src/libs/shim-interface/src/lib.rs
+++ b/src/libs/shim-interface/src/lib.rs
@@ -73,11 +73,8 @@ fn get_uds_with_sid(short_id: &str, path: &str) -> Result<String> {
 }
 
 // return sandbox's storage path
-pub fn sb_storage_path() -> Result<&'static str> {
-    //make sure the path existed
-    std::fs::create_dir_all(KATA_PATH).context(format!("failed to create dir: {KATA_PATH}"))?;
-
-    Ok(KATA_PATH)
+pub fn sb_storage_path() -> &'static str {
+    KATA_PATH
 }
 
 // returns the address of the unix domain socket(UDS) for communication with shim
@@ -90,7 +87,7 @@ pub fn mgmt_socket_addr(sid: &str) -> Result<String> {
         ));
     }
 
-    get_uds_with_sid(sid, sb_storage_path()?)
+    get_uds_with_sid(sid, sb_storage_path())
 }
 
 #[cfg(test)]

--- a/src/libs/shim-interface/src/lib.rs
+++ b/src/libs/shim-interface/src/lib.rs
@@ -130,7 +130,7 @@ mod tests {
     #[test]
     fn test_get_uds_with_sid_ok() {
         let run_path = tempdir().unwrap();
-        let dir = run_path.path().join("aata98654dangboxpath1");
+        let dir = run_path.path().join("kata98654sandboxpath1");
         fs::create_dir_all(dir.as_path()).unwrap();
 
         let result = get_uds_with_sid("kata", &run_path.path().display().to_string());
@@ -141,7 +141,7 @@ mod tests {
                 "unix://{}",
                 run_path
                     .path()
-                    .join("kata")
+                    .join("kata98654sandboxpath1")
                     .join(SHIM_MGMT_SOCK_NAME)
                     .display()
             )
@@ -152,18 +152,9 @@ mod tests {
     fn test_get_uds_with_sid_with_zero() {
         let run_path = tempdir().unwrap();
         let result = get_uds_with_sid("acdsdfe", &run_path.path().display().to_string());
-        assert!(result.is_ok());
-        assert_eq!(
-            result.unwrap(),
-            format!(
-                "unix://{}",
-                run_path
-                    .path()
-                    .join("acdsdfe")
-                    .join(SHIM_MGMT_SOCK_NAME)
-                    .display()
-            )
-        )
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(err_msg.contains("is not found"));
     }
 
     #[test]

--- a/src/runtime-rs/crates/runtimes/src/shim_mgmt/server.rs
+++ b/src/runtime-rs/crates/runtimes/src/shim_mgmt/server.rs
@@ -16,7 +16,7 @@ use std::{fs, path::Path, sync::Arc};
 use anyhow::{Context, Result};
 use common::Sandbox;
 use hyper::{server::conn::Http, service::service_fn};
-use shim_interface::{mgmt_socket_addr, shim_mgmt::ERR_NO_SHIM_SERVER};
+use shim_interface::{sb_storage_path, SHIM_MGMT_SOCK_NAME};
 use tokio::net::UnixListener;
 
 use super::handlers::handler_mux;
@@ -33,10 +33,14 @@ pub struct MgmtServer {
 impl MgmtServer {
     /// construct a new management server
     pub fn new(sid: &str, sandbox: Arc<dyn Sandbox>) -> Result<Self> {
-        Ok(Self {
-            s_addr: mgmt_socket_addr(sid).context(ERR_NO_SHIM_SERVER)?,
-            sandbox,
-        })
+        // make sure the storage path exists, and the socket file will be created in that path
+        let kata_path = sb_storage_path();
+        fs::create_dir_all(kata_path)
+            .context(format!("failed to create kata path directory {kata_path}"))?;
+
+        let s_addr = format!("unix://{kata_path}/{sid}/{SHIM_MGMT_SOCK_NAME}");
+
+        Ok(Self { s_addr, sandbox })
     }
 
     // TODO(when metrics is supported): write metric addresses to fs


### PR DESCRIPTION
When running kata-ctl exec <short-id>, kata-ctl may fail with:

"more than one sandbox exists with the provided prefix "ed07", please provide a unique prefix".

At the same time, a new subdirectory named <short-id> is incorrectly created under /runkata/. This is wrong behavior: a short ID should be used only to match an existing sandbox by prefix, and must not trigger creation of a new sandbox directory when lookup fails or is ambiguous.

Update the exec path to perform prefix matching and return an error on no match or non-unique matches, without creating any new directories.

Signeduoff-by: Alex Lyn <alex.lyn@antgroup.com>