### PR TITLE
genpolicy: suppress YAML output when --{base64/raw}-out are used

### DIFF
--- a/src/tools/genpolicy/tests/generate/testdata/simple_pod.yaml
+++ b/src/tools/genpolicy/tests/generate/testdata/simple_pod.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: simple-pod
+spec:
+  restartPolicy: Never
+  runtimeClassName: kata-cc
+  containers:
+    - name: busybox
+      image: "quay.io/prometheus/busybox:latest"
+      command:
+        - /bin/sh
+      args:
+        - "-c"
+        - echo hello


### PR DESCRIPTION
this will suppress yaml output only if the input is passed via stdin. If {base64/raw}-out is passed in alongside a yaml file, the encoded annotation or the policy data respectively will be printed to stdout as before.

Fixes #12438