### PR TITLE
runtime: Normalize IOMMUFD device IDs in CDI coldplug

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/device_cold_plug.go
+++ b/src/runtime/pkg/containerd-shim-v2/device_cold_plug.go
@@ -136,7 +136,9 @@ func getDeviceSpec(ctx context.Context, socket string, ann map[string]string) ([
 func formatCDIDevIDs(specName string, devIDs []string) []string {
 	var result []string
 	for _, id := range devIDs {
-		result = append(result, fmt.Sprintf("%s=%s", specName, id))
+		// Normalize IOMMUFD device IDs: vfio5 -> 5
+		cleanID := strings.TrimPrefix(id, "vfio")
+		result = append(result, fmt.Sprintf("%s=%s", specName, cleanID))
 	}
 	return result
 }


### PR DESCRIPTION
When using IOMMUFD, device plugins report device IDs like "vfio5" (matching the device node /dev/vfio/devices/vfio5), but CDI specs define devices with just the numeric ID (e.g., "5").

This caused CDI device injection to fail with:
  "unresolvable CDI devices nvidia.com/pgpu=vfio5"

Add normalization to strip the "vfio" prefix from device IDs in formatCDIDevIDs(), consistent with existing normalization in VFIODeviceInfo.DevNo() and createCDIAnnotation().

Fixes: nvidia.com/pgpu=vfio5 -> nvidia.com/pgpu=5