### PR TITLE
ci: add editorconfig checker

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.github/workflows/editorconfig-checker.yaml
+++ b/.github/workflows/editorconfig-checker.yaml
@@ -1,0 +1,29 @@
+name: EditorConfig checker
+
+on:
+  pull_request:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  editorconfig-checker:
+    name: editorconfig-checker
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up editorconfig-checker
+        uses: editorconfig-checker/action-editorconfig-checker@4b6cd6190d435e7e084fb35e36a096e98506f7b9 # v2.1.0
+        with:
+          version: v3.6.1
+
+      - name: Run editorconfig-checker
+        run: editorconfig-checker

--- a/tests/static-checks.sh
+++ b/tests/static-checks.sh
@@ -440,6 +440,7 @@ static_check_license_headers()
 
 		local missing=$(grep \
 			--exclude=".git/*" \
+			--exclude=".editorconfig" \
 			--exclude=".gitignore" \
 			--exclude=".dockerignore" \
 			--exclude="Gopkg.lock" \


### PR DESCRIPTION
This adds a basic configuration for editorconfig checker. The supplied configuration checks against trailing whitespaces and issues with newlines.
Example:
```
| tools/packaging/kernel/configs/fragments/x86_64/numa.conf:
|       Wrong line endings or no final newline
| tools/packaging/release/generate_vendor.sh:
|       44: Trailing whitespace
```

Some output:
```
EditorConfig checker/editorconfig-checker]   ❌  Failure - Main Run editorconfig-checker [4.034232778s]
[EditorConfig checker/editorconfig-checker] exitcode '1': failure
[EditorConfig checker/editorconfig-checker] ⭐ Run Complete job
[EditorConfig checker/editorconfig-checker]   ✅  Success - Complete job
[EditorConfig checker/editorconfig-checker] 🏁  Job failed
```

Ran locally with:
```
act pull_request -W .github/workflows/editorconfig-checker.yaml   -P ubuntu-24.04=ghcr.io/catthehacker/ubuntu:full-24.04
```