### PR TITLE
ci: Add integration tests for secret & configmap propagation

### DIFF
--- a/tests/integration/kubernetes/k8s-configmap.bats
+++ b/tests/integration/kubernetes/k8s-configmap.bats
@@ -10,47 +10,88 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	config_name="test-configmap"
+	pod_env_name="config-env-test-pod"
+	pod_volume_name="configmap-volume-test-pod"
+
 	setup_common || die "setup_common failed"
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
 
 	cmd="env"
 	exec_command=(sh -c "${cmd}")
 	add_exec_to_policy_settings "${policy_settings_dir}" "${exec_command[@]}"
+
+	# Add policy for volume mount test
+	check_config_cmd="cat /etc/config/data-1"
+	check_config_exec_command=(sh -c "${check_config_cmd}")
+	add_exec_to_policy_settings "${policy_settings_dir}" "${check_config_exec_command[@]}"
+
 	add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
 
 	configmap_yaml_file="${pod_config_dir}/configmap.yaml"
 	pod_yaml_file="${pod_config_dir}/pod-configmap.yaml"
+	pod_volume_yaml_file="${pod_config_dir}/pod-configmap-volume.yaml"
 
 	auto_generate_policy "${policy_settings_dir}" "${pod_yaml_file}" "${configmap_yaml_file}"
+	auto_generate_policy "${policy_settings_dir}" "${pod_volume_yaml_file}" "${configmap_yaml_file}"
 }
 
 @test "ConfigMap for a pod" {
-	config_name="test-configmap"
-	pod_name="config-env-test-pod"
-
 	# Create ConfigMap
 	kubectl create -f "${configmap_yaml_file}"
 
 	# View the values of the keys
-	kubectl get configmaps $config_name -o yaml | grep -q "data-"
+	kubectl get configmaps "${config_name}" -o yaml | grep -q "data-"
 
 	# Create a pod that consumes the ConfigMap
 	kubectl create -f "${pod_yaml_file}"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_env_name}"
 
 	# Check env
-	grep_pod_exec_output "${pod_name}" "KUBE_CONFIG_1=value-1" "${exec_command[@]}"
-	grep_pod_exec_output "${pod_name}" "KUBE_CONFIG_2=value-2" "${exec_command[@]}"
+	grep_pod_exec_output "${pod_env_name}" "KUBE_CONFIG_1=value-1" "${exec_command[@]}"
+	grep_pod_exec_output "${pod_env_name}" "KUBE_CONFIG_2=value-2" "${exec_command[@]}"
+}
+
+@test "ConfigMap propagation to volume-mounted pod" {
+	original_value="value-1"
+	updated_value="updated-value-1"
+
+	# Create ConfigMap
+	kubectl create -f "${configmap_yaml_file}"
+
+	# Create a pod that consumes the ConfigMap via volume mount
+	kubectl create -f "${pod_volume_yaml_file}"
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_volume_name}"
+
+	# Verify initial value from volume
+	grep_pod_exec_output "${pod_volume_name}" "${original_value}" "${check_config_exec_command[@]}"
+
+	# Update ConfigMap to test propagation
+	kubectl patch configmap "${config_name}" -p "{\"data\":{\"data-1\":\"${updated_value}\"}}"
+
+	# Wait for propagation (kubelet sync period ~60s, but allow extra time for slow clusters)
+	info "Waiting for ConfigMap propagation to volume-mounted pod"
+	propagation_wait_time=180
+
+	# Define check function for waitForProcess
+	check_configmap_propagated() {
+		pod_exec "${pod_volume_name}" "${check_config_exec_command[@]}" | grep -q "${updated_value}"
+	}
+
+	if waitForProcess "${propagation_wait_time}" "${sleep_time}" check_configmap_propagated; then
+		info "ConfigMap successfully propagated to volume"
+	else
+		info "ConfigMap propagation test failed after ${propagation_wait_time} seconds"
+		return 1
+	fi
 }
 
 teardown() {
-	# Debugging information
-	kubectl describe "pod/$pod_name"
-
-	kubectl delete pod "$pod_name"
-	kubectl delete configmap "$config_name"
+	kubectl delete pod "${pod_env_name}" --ignore-not-found=true
+	kubectl delete pod "${pod_volume_name}" --ignore-not-found=true
+	kubectl delete configmap "${config_name}" --ignore-not-found=true
 
 	delete_tmp_policy_settings_dir "${policy_settings_dir}"
 	teardown_common "${node}" "${node_start_time:-}"

--- a/tests/integration/kubernetes/k8s-credentials-secrets.bats
+++ b/tests/integration/kubernetes/k8s-credentials-secrets.bats
@@ -13,21 +13,31 @@ setup() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 
+	secret_name="test-secret"
+	pod_name="secret-test-pod"
+	second_pod_name="secret-envars-test-pod"
+
 	setup_common || die "setup_common failed"
 
 	# Add policy to pod-secret.yaml.
 	pod_yaml_file="${pod_config_dir}/pod-secret.yaml"
-	set_node "$pod_yaml_file" "$node"
+	set_node "${pod_yaml_file}" "${node}"
 	pod_cmd="ls /tmp/secret-volume"
 	pod_exec_command=(sh -c "${pod_cmd}")
+
+	# Also add policy for reading secret content (for propagation test)
+	check_secret_cmd="cat /tmp/secret-volume/username"
+	check_secret_exec_command=(sh -c "${check_secret_cmd}")
+
 	pod_policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
 	add_exec_to_policy_settings "${pod_policy_settings_dir}" "${pod_exec_command[@]}"
+	add_exec_to_policy_settings "${pod_policy_settings_dir}" "${check_secret_exec_command[@]}"
 	add_requests_to_policy_settings "${pod_policy_settings_dir}" "ReadStreamRequest"
-	auto_generate_policy "${pod_policy_settings_dir}" "${pod_yaml_file}"
+	auto_generate_policy "${pod_policy_settings_dir}" "${pod_yaml_file}" "${pod_config_dir}/inject_secret.yaml"
 
 	# Add policy to pod-secret-env.yaml.
 	pod_env_yaml_file="${pod_config_dir}/pod-secret-env.yaml"
-	set_node "$pod_env_yaml_file" "$node"
+	set_node "${pod_env_yaml_file}" "${node}"
 	pod_env_cmd="printenv"
 	pod_env_exec_command=(sh -c "${pod_env_cmd}")
 	pod_env_policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
@@ -37,10 +47,6 @@ setup() {
 }
 
 @test "Credentials using secrets" {
-	secret_name="test-secret"
-	pod_name="secret-test-pod"
-	second_pod_name="secret-envars-test-pod"
-
 	# Create the secret
 	kubectl create -f "${pod_config_dir}/inject_secret.yaml"
 
@@ -51,7 +57,7 @@ setup() {
 	kubectl create -f "${pod_yaml_file}"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_name}"
 
 	# List the files
 	pod_exec "${pod_name}" "${pod_exec_command[@]}" | grep -w "password"
@@ -61,18 +67,54 @@ setup() {
 	kubectl create -f "${pod_env_yaml_file}"
 
 	# Check pod creation
-	kubectl wait --for=condition=Ready --timeout=$timeout pod "$second_pod_name"
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${second_pod_name}"
 
 	# Display environment variables
 	pod_exec "${second_pod_name}" "${pod_env_exec_command[@]}" | grep -w "SECRET_USERNAME"
 	pod_exec "${second_pod_name}" "${pod_env_exec_command[@]}" | grep -w "SECRET_PASSWORD"
 }
 
+@test "Secret propagation to volume-mounted pod" {
+	original_username="my-app"
+	updated_username="updated-username"
+
+	# Create the secret
+	kubectl create -f "${pod_config_dir}/inject_secret.yaml"
+
+	# Create a pod that has access to the secret through a volume
+	kubectl create -f "${pod_yaml_file}"
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_name}"
+
+	# Verify initial secret value
+	grep_pod_exec_output "${pod_name}" "${original_username}" "${check_secret_exec_command[@]}"
+
+	# Update Secret to test propagation
+	kubectl patch secret "${secret_name}" -p "{\"stringData\":{\"username\":\"${updated_username}\"}}"
+
+	# Wait for propagation (kubelet sync period ~60s, but allow extra time for slow clusters)
+	info "Waiting for Secret propagation to volume-mounted pod"
+	propagation_wait_time=180
+
+	# Define check function for waitForProcess
+	check_secret_propagated() {
+		pod_exec "${pod_name}" "${check_secret_exec_command[@]}" | grep -q "${updated_username}"
+	}
+
+	if waitForProcess "${propagation_wait_time}" "${sleep_time}" check_secret_propagated; then
+		info "Secret successfully propagated to volume"
+	else
+		info "Secret propagation test failed after ${propagation_wait_time} seconds"
+		return 1
+	fi
+}
+
 teardown() {
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 
-	kubectl delete secret "$secret_name"
+	kubectl delete pod "${pod_name}" --ignore-not-found=true
+	kubectl delete pod "${second_pod_name}" --ignore-not-found=true
+	kubectl delete secret "${secret_name}" --ignore-not-found=true
 
 	delete_tmp_policy_settings_dir "${pod_policy_settings_dir}"
 	delete_tmp_policy_settings_dir "${pod_env_policy_settings_dir}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-configmap-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-configmap-volume.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2026 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: configmap-volume-test-pod
+spec:
+  terminationGracePeriodSeconds: 0
+  runtimeClassName: kata
+  containers:
+  - name: test-container
+    image: quay.io/prometheus/busybox:latest
+    command: ["sh", "-c", "while true; do sleep 10; done"]
+    volumeMounts:
+    - name: config-volume
+      mountPath: /etc/config
+      readOnly: true
+  volumes:
+  - name: config-volume
+    configMap:
+      name: test-configmap
+  restartPolicy: Never


### PR DESCRIPTION
Enhanced `k8s-configmap.bats` and `k8s-credentials-secrets.bats` to verify that ConfigMap and Secret updates propagate to volume-mounted pods.

Changes:
- `k8s-configmap.bats`: Added volume mount test and propagation verification
- `k8s-credentials-secrets.bats`: Added propagation verification
- Improved cleanup by moving resource deletion to `teardown()`

Tests use retry logic to validate propagation within kubelet sync period and maximize reuse of existing YAML resources.

Fixes #8015 