### PR TITLE
agent: cdh: Update CDH and its API along with sealed secret tests

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -2317,8 +2317,13 @@ async fn cdh_handler_trusted_storage(oci: &mut Spec) -> Result<()> {
         for specdev in devices.iter() {
             if specdev.path().as_path().to_str() == Some(TRUSTED_IMAGE_STORAGE_DEVICE) {
                 let dev_major_minor = format!("{}:{}", specdev.major(), specdev.minor());
-                cdh_secure_mount("BlockDevice", &dev_major_minor, "LUKS", KATA_IMAGE_WORK_DIR)
-                    .await?;
+                cdh_secure_mount(
+                    "block-device",
+                    &dev_major_minor,
+                    "luks2",
+                    KATA_IMAGE_WORK_DIR,
+                )
+                .await?;
                 break;
             }
         }
@@ -2349,9 +2354,20 @@ pub(crate) async fn cdh_secure_mount(
 
     let options = std::collections::HashMap::from([
         ("deviceId".to_string(), device_id.to_string()),
-        ("encryptType".to_string(), encrypt_type.to_string()),
+        ("sourceType".to_string(), "empty".to_string()),
+        ("targetType".to_string(), "fileSystem".to_string()),
+        ("filesystemType".to_string(), "ext4".to_string()),
+        ("mkfsOpts".to_string(), "-E lazy_journal_init".to_string()),
+        ("encryptionType".to_string(), encrypt_type.to_string()),
         ("dataIntegrity".to_string(), integrity),
     ]);
+
+    std::fs::create_dir_all(mount_point).inspect_err(|e| {
+        error!(
+            sl(),
+            "Failed to create mount point directory {}: {:?}", mount_point, e
+        );
+    })?;
 
     confidential_data_hub::secure_mount(device_type, &options, vec![], mount_point).await?;
 

--- a/src/agent/src/storage/block_handler.rs
+++ b/src/agent/src/storage/block_handler.rs
@@ -59,7 +59,8 @@ async fn handle_block_storage(
         .contains(&"encryption_key=ephemeral".to_string());
 
     if has_ephemeral_encryption {
-        crate::rpc::cdh_secure_mount("BlockDevice", dev_num, "LUKS", &storage.mount_point).await?;
+        crate::rpc::cdh_secure_mount("block-device", dev_num, "luks2", &storage.mount_point)
+            .await?;
         set_ownership(logger, storage)?;
         new_device(storage.mount_point.clone())
     } else {

--- a/src/libs/protocols/protos/confidential_data_hub.proto
+++ b/src/libs/protocols/protos/confidential_data_hub.proto
@@ -24,9 +24,7 @@ message SecureMountRequest {
     string mount_point = 4;
 }
 
-message SecureMountResponse {
-    string mount_path = 1;
-}
+message SecureMountResponse {}
 
 message ImagePullRequest {
     // - `image_url`: The reference of the image to pull

--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -54,27 +54,8 @@ NGC_API_KEY_BASE64=$(
 )
 export NGC_API_KEY_BASE64
 
-# Sealed secret format for TEE pods (vault type pointing to KBS resource)
-# Format: sealed.<base64url JWS header>.<base64url payload>.<base64url signature>
-# IMPORTANT: JWS uses base64url encoding WITHOUT padding (no trailing '=')
-# We use tr to convert standard base64 (+/) to base64url (-_) and remove padding (=)
-# For vault type, header and signature can be placeholders since the payload
-# contains the KBS resource path where the actual secret is stored.
-#
-# Vault type sealed secret payload for instruct pod:
-# {
-#   "version": "0.1.0",
-#   "type": "vault",
-#   "name": "kbs:///default/ngc-api-key/instruct",
-#   "provider": "kbs",
-#   "provider_settings": {},
-#   "annotations": {}
-# }
-NGC_API_KEY_SEALED_SECRET_INSTRUCT_PAYLOAD=$(
-    echo -n '{"version":"0.1.0","type":"vault","name":"kbs:///default/ngc-api-key/instruct","provider":"kbs","provider_settings":{},"annotations":{}}' |
-    base64 -w0 | tr '+/' '-_' | tr -d '='
-)
-NGC_API_KEY_SEALED_SECRET_INSTRUCT="sealed.fakejwsheader.${NGC_API_KEY_SEALED_SECRET_INSTRUCT_PAYLOAD}.fakesignature"
+# pre-created signed sealed secrets for TEE pods (from confidential_common.sh)
+NGC_API_KEY_SEALED_SECRET_INSTRUCT="${SEALED_SECRET_PRECREATED_NIM_INSTRUCT}"
 export NGC_API_KEY_SEALED_SECRET_INSTRUCT
 
 # Base64 encode the sealed secret for use in Kubernetes Secret data field
@@ -82,20 +63,7 @@ export NGC_API_KEY_SEALED_SECRET_INSTRUCT
 NGC_API_KEY_SEALED_SECRET_INSTRUCT_BASE64=$(echo -n "${NGC_API_KEY_SEALED_SECRET_INSTRUCT}" | base64 -w0)
 export NGC_API_KEY_SEALED_SECRET_INSTRUCT_BASE64
 
-# Vault type sealed secret payload for embedqa pod:
-# {
-#   "version": "0.1.0",
-#   "type": "vault",
-#   "name": "kbs:///default/ngc-api-key/embedqa",
-#   "provider": "kbs",
-#   "provider_settings": {},
-#   "annotations": {}
-# }
-NGC_API_KEY_SEALED_SECRET_EMBEDQA_PAYLOAD=$(
-    echo -n '{"version":"0.1.0","type":"vault","name":"kbs:///default/ngc-api-key/embedqa","provider":"kbs","provider_settings":{},"annotations":{}}' |
-    base64 -w0 | tr '+/' '-_' | tr -d '='
-)
-NGC_API_KEY_SEALED_SECRET_EMBEDQA="sealed.fakejwsheader.${NGC_API_KEY_SEALED_SECRET_EMBEDQA_PAYLOAD}.fakesignature"
+NGC_API_KEY_SEALED_SECRET_EMBEDQA="${SEALED_SECRET_PRECREATED_NIM_EMBEDQA}"
 export NGC_API_KEY_SEALED_SECRET_EMBEDQA
 
 NGC_API_KEY_SEALED_SECRET_EMBEDQA_BASE64=$(echo -n "${NGC_API_KEY_SEALED_SECRET_EMBEDQA}" | base64 -w0)
@@ -223,6 +191,8 @@ setup_file() {
 
     if [ "${TEE}" = "true" ]; then
         setup_kbs_credentials
+        # provision signing public key to KBS so that CDH can verify pre-created, signed secret.
+        setup_sealed_secret_signing_public_key
         # Overwrite the empty default-initdata.toml with our CDH configuration.
         # This must happen AFTER create_tmp_policy_settings_dir() copies the empty
         # file and BEFORE auto_generate_policy() runs.

--- a/tests/integration/kubernetes/k8s-sealed-secret.bats
+++ b/tests/integration/kubernetes/k8s-sealed-secret.bats
@@ -48,25 +48,13 @@ setup() {
 		"${kernel_params_annotation}" \
 		"${kernel_params_value}"
 
+	# provision signing public key to KBS so that CDH can verify pre-created, signed secret.
+	setup_sealed_secret_signing_public_key
+
 	# Setup k8s secret
 	kubectl delete secret sealed-secret --ignore-not-found
 	kubectl delete secret not-sealed-secret --ignore-not-found
-
-	# Sealed secret format is defined at: https://github.com/confidential-containers/guest-components/blob/main/confidential-data-hub/docs/SEALED_SECRET.md#vault
-	# sealed.BASE64URL(UTF8(JWS Protected Header)) || '.
-	# || BASE64URL(JWS Payload) || '.'
-	# || BASE64URL(JWS Signature)
-	# test payload:
-	# {
-	# "version": "0.1.0",
-	# "type": "vault",
-	# "name": "kbs:///default/sealed-secret/test",
-	# "provider": "kbs",
-	# "provider_settings": {},
-	# "annotations": {}
-	# }
-	kubectl create secret generic sealed-secret --from-literal='secret=sealed.fakejwsheader.eyJ2ZXJzaW9uIjoiMC4xLjAiLCJ0eXBlIjoidmF1bHQiLCJuYW1lIjoia2JzOi8vL2RlZmF1bHQvc2VhbGVkLXNlY3JldC90ZXN0IiwicHJvdmlkZXIiOiJrYnMiLCJwcm92aWRlcl9zZXR0aW5ncyI6e30sImFubm90YXRpb25zIjp7fX0.fakesignature'
-
+	kubectl create secret generic sealed-secret --from-literal="secret=${SEALED_SECRET_PRECREATED_TEST}"
 	kubectl create secret generic not-sealed-secret --from-literal='secret=not_sealed_secret'
 
 	if ! is_confidential_hardware; then
@@ -79,10 +67,10 @@ setup() {
 @test "Cannot Unseal Env Secrets with CDH without key" {
 	k8s_create_pod "${K8S_TEST_ENV_YAML}"
 
-	kubectl logs secret-test-pod-cc
-	kubectl logs secret-test-pod-cc | grep -q "UNPROTECTED_SECRET = not_sealed_secret"
-	cmd="kubectl logs secret-test-pod-cc | grep -q \"PROTECTED_SECRET = unsealed_secret\""
-	run $cmd
+	logs=$(kubectl logs secret-test-pod-cc)
+	echo "$logs"
+	grep -q "UNPROTECTED_SECRET = not_sealed_secret" <<< "$logs"
+	run grep -q "PROTECTED_SECRET = unsealed_secret" <<< "$logs"
 	[ "$status" -eq 1 ]
 }
 
@@ -91,18 +79,20 @@ setup() {
 	kbs_set_resource "default" "sealed-secret" "test" "unsealed_secret"
 	k8s_create_pod "${K8S_TEST_ENV_YAML}"
 
-	kubectl logs secret-test-pod-cc
-	kubectl logs secret-test-pod-cc | grep -q "UNPROTECTED_SECRET = not_sealed_secret"
-	kubectl logs secret-test-pod-cc | grep -q "PROTECTED_SECRET = unsealed_secret"
+	logs=$(kubectl logs secret-test-pod-cc)
+	echo "$logs"
+	grep -q "UNPROTECTED_SECRET = not_sealed_secret" <<< "$logs"
+	grep -q "PROTECTED_SECRET = unsealed_secret" <<< "$logs"
 }
 
 @test "Unseal File Secrets with CDH" {
 	kbs_set_resource "default" "sealed-secret" "test" "unsealed_secret"
 	k8s_create_pod "${K8S_TEST_FILE_YAML}"
 
-	kubectl logs secret-test-pod-cc
-	kubectl logs secret-test-pod-cc | grep -q "UNPROTECTED_SECRET = not_sealed_secret"
-	kubectl logs secret-test-pod-cc | grep -q "PROTECTED_SECRET = unsealed_secret"
+	logs=$(kubectl logs secret-test-pod-cc)
+	echo "$logs"
+	grep -q "UNPROTECTED_SECRET = not_sealed_secret" <<< "$logs"
+	grep -q "PROTECTED_SECRET = unsealed_secret" <<< "$logs"
 }
 
 teardown() {

--- a/tests/integration/kubernetes/k8s-trusted-ephemeral-data-storage.bats
+++ b/tests/integration/kubernetes/k8s-trusted-ephemeral-data-storage.bats
@@ -19,6 +19,8 @@ setup() {
     mountpoint="/mnt/temp-encrypted"
 
     host_df="$(exec_host "${node}" df -PT -B1 "$(get_kubelet_data_dir)" | tail -n +2)"
+    info "host_df output:"
+    info "${host_df}"
     host_cap_bytes="$(echo "${host_df}" | awk '{print $3}')"
 
     yaml_file="${pod_config_dir}/pod-trusted-ephemeral-data-storage.yaml"
@@ -36,7 +38,7 @@ setup() {
 
     # With long device names, df adds line breaks by default, so we pass -P to prevent that.
     emptydir_df="$(kubectl exec "${pod_name}" -- df -PT -B1 "${mountpoint}" | tail -n +2)"
-    info "df output:"
+    info "emptydir_df output:"
     info "${emptydir_df}"
 
     dm_device="$(echo "${emptydir_df}" | awk '{print $1}')"
@@ -46,17 +48,18 @@ setup() {
 
     # The output of the cryptsetup command will contain something like this:
     #
-    #   /dev/mapper/encrypted_disk_N6PxO is active and is in use.
-    #     type:    LUKS2
-    #     cipher:  aes-xts-plain64
+    #   /dev/mapper/741ed4bf-3073-49ed-9b7a-d6fa7cce0db1 is active and is in use.
+    #     type:    n/a
+    #     cipher:  aes-xts-plain
     #     keysize: 768 bits
     #     key location: keyring
     #     integrity: hmac(sha256)
     #     integrity keysize: 256 bits
-    #     device:  /dev/vda
+    #     integrity tag size: 32 bytes
+    #     device:  /dev/sdd
     #     sector size:  4096
     #     offset:  0 sectors
-    #     size:    2031880 sectors
+    #     size:    300052568 sectors
     #     mode:    read/write
     crypt_status="$(kubectl exec "${pod_name}" -- cryptsetup status "${dm_device}")"
     info "cryptsetup status output:"
@@ -65,16 +68,15 @@ setup() {
     # Check filesystem type and capacity.
 
     [[ "${fs_type}" == "ext4" ]]
-    # Allow up to 7% LUKS metadata overhead.
-    (( emptydir_cap_bytes >= host_cap_bytes * 93 / 100 ))
-    # Allow up to 15% LUKS + ext4 metadata overhead.
-    (( emptydir_avail_bytes >= host_cap_bytes * 85 / 100 ))
+    # Allow up to 4% metadata overhead.
+    (( emptydir_cap_bytes >= host_cap_bytes * 96 / 100 ))
+    # Allow up to 10% metadata overhead.
+    (( emptydir_avail_bytes >= host_cap_bytes * 90 / 100 ))
 
     # Check encryption settings.
-
     grep -q "${dm_device} is active and is in use" <<< "${crypt_status}"
-    grep -Eq "type: +LUKS2" <<< "${crypt_status}"
-    grep -Eq "cipher: +aes-xts-plain64" <<< "${crypt_status}"
+    grep -Eq "type: +n/a" <<< "${crypt_status}" # The LUKS header is detached.
+    grep -Eq "cipher: +aes-xts-plain" <<< "${crypt_status}"
     grep -Eq "integrity: +hmac\(sha256\)" <<< "${crypt_status}"
 
     # Check I/O.

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_chroot.sh
@@ -67,6 +67,13 @@ install_userspace_components() {
 		libnvidia-cfg1 libnvidia-gl libnvidia-extra      \
 		libnvidia-decode libnvidia-fbc1 libnvidia-encode \
 		libnvidia-nscq libnvidia-compute nvidia-settings
+
+	# Needed for confidential-data-hub runtime dependencies
+	eval "${APT_INSTALL}" cryptsetup-bin dmsetup         \
+		libargon2-1 e2fsprogs
+
+	apt-mark hold cryptsetup-bin dmsetup libargon2-1     \
+		e2fsprogs
 }
 
 setup_apt_repositories() {

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -310,6 +310,44 @@ compress_rootfs() {
 	chmod +x "${libdir}"/ld-linux-*
 }
 
+copy_cdh_runtime_deps() {
+	local libdir="lib/${machine_arch}-linux-gnu"
+
+	# Shared libraries required by /usr/local/bin/confidential-data-hub.
+	# Note: libcryptsetup loads some optional helpers (e.g. libpopt/libssh) only
+	# when specific features are used. The current CDH path (LUKS2 + mkfs.ext4)
+	# does not require those optional libs.
+	cp -a "${stage_one}/${libdir}"/libcryptsetup.so.12*    "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libuuid.so.1*           "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libdevmapper.so.1.02.1* "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libselinux.so.1*        "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libpcre2-8.so.0*        "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libudev.so.1*           "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libcap.so.2*            "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libcrypto.so.3*         "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libz.so.1*              "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libzstd.so.1*           "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libjson-c.so.5*         "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libblkid.so.1*          "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libargon2.so.1*         "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libgcc_s.so.1*          "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libm.so.6*              "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libc.so.6*              "${libdir}/."
+
+	# e2fsprogs (mkfs.ext4) runtime libs
+	cp -a "${stage_one}/${libdir}"/libext2fs.so.2*         "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libe2p.so.2*            "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libss.so.2*             "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libcom_err.so.2*        "${libdir}/."
+
+	# mkfs.ext4 and dd are used by CDH secure_mount
+	mkdir -p sbin etc usr/bin bin
+	cp -a "${stage_one}/sbin/mke2fs" sbin/.
+	cp -a "${stage_one}/sbin/mkfs.ext4" sbin/.
+	cp -a "${stage_one}/etc/mke2fs.conf" etc/.
+	cp -a "${stage_one}/usr/bin/dd" bin/.
+}
+
 coco_guest_components() {
 	if [[ "${type}" != "confidential" ]]; then
 		return
@@ -331,6 +369,8 @@ coco_guest_components() {
 	mkdir -p "${pause_dir}/rootfs"
 	cp -a "${stage_one}/${pause_dir}"/config.json  "${pause_dir}/."
 	cp -a "${stage_one}/${pause_dir}"/rootfs/pause "${pause_dir}/rootfs/."
+
+	copy_cdh_runtime_deps
 }
 
 setup_nvidia_gpu_rootfs_stage_two() {

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -331,8 +331,6 @@ coco_guest_components() {
 	mkdir -p "${pause_dir}/rootfs"
 	cp -a "${stage_one}/${pause_dir}"/config.json  "${pause_dir}/."
 	cp -a "${stage_one}/${pause_dir}"/rootfs/pause "${pause_dir}/rootfs/."
-
-	info "TODO: nvidia: luks-encrypt-storage is a bash script, we do not have a shell!"
 }
 
 setup_nvidia_gpu_rootfs_stage_two() {

--- a/tools/packaging/static-build/coco-guest-components/Dockerfile
+++ b/tools/packaging/static-build/coco-guest-components/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update && \
 	g++ \
 	gcc \
 	git \
+	libcryptsetup-dev \
 	libssl-dev \
 	libtss2-dev \
 	make \

--- a/tools/packaging/static-build/coco-guest-components/build-static-coco-guest-components.sh
+++ b/tools/packaging/static-build/coco-guest-components/build-static-coco-guest-components.sh
@@ -34,7 +34,6 @@ build_coco_guest_components_from_source() {
 	strip "target/${RUST_ARCH}-unknown-linux-${LIBC}/release/api-server-rest"
 	DESTDIR="${DESTDIR}/usr/local/bin" TEE_PLATFORM=${TEE_PLATFORM} make install
 
-	install -D -m0755 "confidential-data-hub/hub/src/storage/scripts/luks-encrypt-storage" "${DESTDIR}/usr/local/bin/luks-encrypt-storage"
 	install -D -m0644 "confidential-data-hub/hub/src/image/ocicrypt_config.json" "${DESTDIR}/etc/ocicrypt_config.json"
 	popd
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -288,7 +288,7 @@ externals:
   coco-guest-components:
     description: "Provides attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/guest-components/"
-    version: "9aae2eae6a03ab97d6561bbe74f8b99843836bba"
+    version: "ab95914ac84c32a43102463cc0ae330710af47be"
     toolchain: "1.90.0"
 
   coco-trustee:


### PR DESCRIPTION
With the new CDH version, the secure_mount API changes. Further, the new CDH version no longer uses the luks-encrypt-storage script but utilizes libcryptsetup as well as mkfs.ext4 and dd. Hence, adapt some of the CDH and Kata components build steps. This change was caused by: https://github.com/confidential-containers/guest-components/pull/1052.

In addition, use pre-created signed sealed secrets (avoid having to run CI with disabling signature checks). This capability was introduced by: https://github.com/confidential-containers/guest-components/pull/1272.

This also enables container storage features for the NVIDIA GPU handlers. The size of the chiseled NVIDIA UVM rootfs grows by about 8MB due to including various required dependencies.