### PR TITLE
tests: Clean up superfluous GPU annotation

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-attestable-gpu.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-attestable-gpu.yaml.in
@@ -7,8 +7,6 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: aa-test-cc
-  annotations:
-    cdi.k8s.io/gpu: "nvidia.com/pgpu=0"
 spec:
   runtimeClassName: ${RUNTIME_CLASS_NAME}
   containers:


### PR DESCRIPTION
This annotation was required for GPU cold-plug before using a newer device plugin and before querying the pod resources API. As this annotation is no longer required, cleaning it up.