### PR TITLE
versions: Bump rust to 1.91

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 # Keep in sync with versions.yaml
-channel = "1.89"
+channel = "1.91"

--- a/versions.yaml
+++ b/versions.yaml
@@ -479,12 +479,12 @@ languages:
     description: "Rust language"
     notes: "'version' is the default minimum version used by this project."
     # Keep in sync with rust-toolchain.toml
-    version: "1.89"
+    version: "1.91"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.89"
+      newest-version: "1.91"
 
   golangci-lint:
     description: "golangci-lint"


### PR DESCRIPTION
Following the agreed toolchain policy - bump rust to the current (1.93)-2 releases.