### PR TITLE
genpolicy: allow multiple device types for NVIDIA VFIO GPUs

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -203,7 +203,10 @@
             "anno_key_regex": "^cdi\\.k8s\\.io/vfio[0-9]+$",
             "nvidia": {
                 "gpu_anno_value_regex": "^nvidia\\.com/gpu=[0-9]+$",
-                "gpu_gk_device_type": "vfio-pci-gk",
+                "gpu_device_types": [
+                    "vfio-pci-gk",
+                    "vfio-pci"
+                ],
                 "pgpu_resource_keys": [
                     "nvidia.com/pgpu"
                 ]

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -522,7 +522,9 @@ allow_vfio_device(p_vfio_devices, i_vfio_device) if {
 
     i_vfio_device.id == concat("", ["vfio", suffix])
 
-    i_vfio_device.type_ == p_device.type_
+    allowed_types := policy_data.devices.vfio.nvidia.gpu_device_types
+    some allowed_type in allowed_types
+    i_vfio_device.type_ == allowed_type
 
     i_vfio_device.vm_path == p_device.vm_path
 

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -504,7 +504,6 @@ pub struct VfioNvidiaDevices {
     /// depends on `vfio_mode` in `configuration.toml`:
     /// - `vfio_mode=guest-kernel` => `vfio-pci-gk`
     /// - `vfio_mode=vfio`         => `vfio-pci`
-    #[serde(default)]
     pub gpu_device_types: Vec<String>,
 
     /// Allowlist of K8s extended resource names that should be treated as NVIDIA
@@ -755,16 +754,6 @@ impl AgentPolicy {
             .get_nvidia_pgpu_count(&self.config.settings.devices.vfio.nvidia.pgpu_resource_keys)
         {
             if nvidia_pgpu_count > 0 {
-                let vfio_gpu_device_type = self
-                    .config
-                    .settings
-                    .devices
-                    .vfio
-                    .nvidia
-                    .gpu_device_types
-                    .first()
-                    .cloned()
-                    .unwrap_or_else(|| "vfio-pci-gk".to_string());
                 for _ in 0..nvidia_pgpu_count {
                     let mut device = agent::Device::new();
                     // The actual device number <device_path><device_number> is assigned at
@@ -774,7 +763,6 @@ impl AgentPolicy {
                     // number with the number from the provided CDI annotations.
                     device
                         .set_container_path(self.config.settings.devices.vfio.device_path.clone());
-                    device.set_type(vfio_gpu_device_type.clone());
                     device.set_vm_path("".to_string());
                     devices.push(device);
                 }

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -498,9 +498,14 @@ pub struct VfioNvidiaDevices {
     #[serde(skip_serializing)]
     pub gpu_anno_value_regex: String,
 
-    /// Device type for NVIDIA GPU VFIO devices (gk variant).
-    #[serde(skip_serializing)]
-    pub gpu_gk_device_type: String,
+    /// Allowed device types for NVIDIA GPU VFIO devices.
+    ///
+    /// Policy enforcement needs this allowlist because the agent device type
+    /// depends on `vfio_mode` in `configuration.toml`:
+    /// - `vfio_mode=guest-kernel` => `vfio-pci-gk`
+    /// - `vfio_mode=vfio`         => `vfio-pci`
+    #[serde(default)]
+    pub gpu_device_types: Vec<String>,
 
     /// Allowlist of K8s extended resource names that should be treated as NVIDIA
     /// passthrough GPU (pGPU) requests when generating policy.
@@ -750,6 +755,16 @@ impl AgentPolicy {
             .get_nvidia_pgpu_count(&self.config.settings.devices.vfio.nvidia.pgpu_resource_keys)
         {
             if nvidia_pgpu_count > 0 {
+                let vfio_gpu_device_type = self
+                    .config
+                    .settings
+                    .devices
+                    .vfio
+                    .nvidia
+                    .gpu_device_types
+                    .first()
+                    .cloned()
+                    .unwrap_or_else(|| "vfio-pci-gk".to_string());
                 for _ in 0..nvidia_pgpu_count {
                     let mut device = agent::Device::new();
                     // The actual device number <device_path><device_number> is assigned at
@@ -759,15 +774,7 @@ impl AgentPolicy {
                     // number with the number from the provided CDI annotations.
                     device
                         .set_container_path(self.config.settings.devices.vfio.device_path.clone());
-                    device.set_type(
-                        self.config
-                            .settings
-                            .devices
-                            .vfio
-                            .nvidia
-                            .gpu_gk_device_type
-                            .clone(),
-                    );
+                    device.set_type(vfio_gpu_device_type.clone());
                     device.set_vm_path("".to_string());
                     devices.push(device);
                 }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/testcases.json
@@ -1113,5 +1113,429 @@
       "storages": [],
       "string_user": null
     }
+  },
+  {
+    "description": "Valid: Hot-plug - 2 GPUs with properly correlated VFIO devices and CDI annotations (vfio-pci)",
+    "allowed": true,
+    "kind": "CreateContainerRequest",
+    "request": {
+      "type": "CreateContainer",
+      "OCI": {
+        "Annotations": {
+          "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
+          "cdi.k8s.io/vfio2": "nvidia.com/gpu=1",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.kubernetes.cri.container-name": "gpu-container",
+          "io.kubernetes.cri.container-type": "container",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db",
+          "io.kubernetes.cri.sandbox-id": "abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+          "io.kubernetes.cri.sandbox-name": "gpu-test-pod",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "12345678-1234-1234-1234-123456789012"
+        },
+        "Hooks": null,
+        "Hostname": "",
+        "Linux": {
+          "CgroupsPath": "kubepods-burstable-pod12345678_1234_1234_1234_123456789012.slice:cri-containerd:gpu-container",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": ["/proc/asound", "/proc/acpi", "/proc/kcore", "/proc/keys", "/proc/latency_stats", "/proc/timer_list", "/proc/timer_stats", "/proc/sched_debug", "/proc/scsi", "/sys/firmware", "/sys/devices/virtual/powercap"],
+          "MountLabel": "",
+          "Namespaces": [
+            {"Path": "", "Type": "ipc"},
+            {"Path": "", "Type": "uts"},
+            {"Path": "", "Type": "mount"}
+          ],
+          "ReadonlyPaths": ["/proc/bus", "/proc/fs", "/proc/irq", "/proc/sys", "/proc/sysrq-trigger"],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {"Cpus": "", "Mems": "", "Period": 100000, "Quota": 0, "RealtimePeriod": 0, "RealtimeRuntime": 0, "Shares": 2},
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": {"DisableOOMKiller": false, "Kernel": 0, "KernelTCP": 0, "Limit": 0, "Reservation": 0, "Swap": 0, "Swappiness": 0},
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {"destination": "/proc", "options": ["nosuid", "noexec", "nodev"], "source": "proc", "type_": "proc"},
+          {"destination": "/dev", "options": ["nosuid", "strictatime", "mode=755", "size=65536k"], "source": "tmpfs", "type_": "tmpfs"},
+          {"destination": "/dev/shm", "options": ["rbind"], "source": "/run/kata-containers/sandbox/shm", "type_": "bind"}
+        ],
+        "Process": {
+          "ApparmorProfile": "cri-containerd.apparmor.d",
+          "Args": ["/pause"],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"],
+            "Effective": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"],
+            "Inheritable": [],
+            "Permitted": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "HOSTNAME=gpu-test-pod"],
+          "NoNewPrivileges": false,
+          "OOMScoreAdj": 1000,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+        },
+        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "gpu-container",
+      "devices": [
+        {
+          "container_path": "/dev/vfio/devices/vfio1",
+          "id": "vfio1",
+          "options": ["0000:65:00.0=06/00"],
+          "type_": "vfio-pci",
+          "vm_path": ""
+        },
+        {
+          "container_path": "/dev/vfio/devices/vfio2",
+          "id": "vfio2",
+          "options": ["0000:66:00.0=06/00"],
+          "type_": "vfio-pci",
+          "vm_path": ""
+        }
+      ],
+      "exec_id": "gpu-container",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [],
+      "string_user": null
+    }
+  },
+  {
+    "description": "Invalid: Hot-plug - CDI annotation number doesn't match VFIO device number (vfio-pci)",
+    "allowed": false,
+    "kind": "CreateContainerRequest",
+    "request": {
+      "type": "CreateContainer",
+      "OCI": {
+        "Annotations": {
+          "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
+          "cdi.k8s.io/vfio3": "nvidia.com/gpu=2",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.kubernetes.cri.container-name": "gpu-container",
+          "io.kubernetes.cri.container-type": "container",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db",
+          "io.kubernetes.cri.sandbox-id": "abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+          "io.kubernetes.cri.sandbox-name": "gpu-test-pod",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "12345678-1234-1234-1234-123456789012"
+        },
+        "Hooks": null,
+        "Hostname": "",
+        "Linux": {
+          "CgroupsPath": "kubepods-burstable-pod12345678_1234_1234_1234_123456789012.slice:cri-containerd:gpu-container",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": ["/proc/asound", "/proc/acpi", "/proc/kcore", "/proc/keys", "/proc/latency_stats", "/proc/timer_list", "/proc/timer_stats", "/proc/sched_debug", "/proc/scsi", "/sys/firmware", "/sys/devices/virtual/powercap"],
+          "MountLabel": "",
+          "Namespaces": [
+            {"Path": "", "Type": "ipc"},
+            {"Path": "", "Type": "uts"},
+            {"Path": "", "Type": "mount"}
+          ],
+          "ReadonlyPaths": ["/proc/bus", "/proc/fs", "/proc/irq", "/proc/sys", "/proc/sysrq-trigger"],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {"Cpus": "", "Mems": "", "Period": 100000, "Quota": 0, "RealtimePeriod": 0, "RealtimeRuntime": 0, "Shares": 2},
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": {"DisableOOMKiller": false, "Kernel": 0, "KernelTCP": 0, "Limit": 0, "Reservation": 0, "Swap": 0, "Swappiness": 0},
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {"destination": "/proc", "options": ["nosuid", "noexec", "nodev"], "source": "proc", "type_": "proc"},
+          {"destination": "/dev", "options": ["nosuid", "strictatime", "mode=755", "size=65536k"], "source": "tmpfs", "type_": "tmpfs"},
+          {"destination": "/dev/shm", "options": ["rbind"], "source": "/run/kata-containers/sandbox/shm", "type_": "bind"}
+        ],
+        "Process": {
+          "ApparmorProfile": "cri-containerd.apparmor.d",
+          "Args": ["/pause"],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"],
+            "Effective": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"],
+            "Inheritable": [],
+            "Permitted": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "HOSTNAME=gpu-test-pod"],
+          "NoNewPrivileges": false,
+          "OOMScoreAdj": 1000,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+        },
+        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "gpu-container",
+      "devices": [
+        {
+          "container_path": "/dev/vfio/devices/vfio1",
+          "id": "vfio1",
+          "options": ["0000:65:00.0=06/00"],
+          "type_": "vfio-pci",
+          "vm_path": ""
+        },
+        {
+          "container_path": "/dev/vfio/devices/vfio2",
+          "id": "vfio2",
+          "options": ["0000:66:00.0=06/00"],
+          "type_": "vfio-pci",
+          "vm_path": ""
+        }
+      ],
+      "exec_id": "gpu-container",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [],
+      "string_user": null
+    }
+  },
+  {
+    "description": "Invalid: Hot-plug - CDI annotation with non-numeric suffix (vfio-pci)",
+    "allowed": false,
+    "kind": "CreateContainerRequest",
+    "request": {
+      "type": "CreateContainer",
+      "OCI": {
+        "Annotations": {
+          "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
+          "cdi.k8s.io/vfioABC": "nvidia.com/gpu=1",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.kubernetes.cri.container-name": "gpu-container",
+          "io.kubernetes.cri.container-type": "container",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db",
+          "io.kubernetes.cri.sandbox-id": "abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+          "io.kubernetes.cri.sandbox-name": "gpu-test-pod",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "12345678-1234-1234-1234-123456789012"
+        },
+        "Hooks": null,
+        "Hostname": "",
+        "Linux": {
+          "CgroupsPath": "kubepods-burstable-pod12345678_1234_1234_1234_123456789012.slice:cri-containerd:gpu-container",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": ["/proc/asound", "/proc/acpi", "/proc/kcore", "/proc/keys", "/proc/latency_stats", "/proc/timer_list", "/proc/timer_stats", "/proc/sched_debug", "/proc/scsi", "/sys/firmware", "/sys/devices/virtual/powercap"],
+          "MountLabel": "",
+          "Namespaces": [
+            {"Path": "", "Type": "ipc"},
+            {"Path": "", "Type": "uts"},
+            {"Path": "", "Type": "mount"}
+          ],
+          "ReadonlyPaths": ["/proc/bus", "/proc/fs", "/proc/irq", "/proc/sys", "/proc/sysrq-trigger"],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {"Cpus": "", "Mems": "", "Period": 100000, "Quota": 0, "RealtimePeriod": 0, "RealtimeRuntime": 0, "Shares": 2},
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": {"DisableOOMKiller": false, "Kernel": 0, "KernelTCP": 0, "Limit": 0, "Reservation": 0, "Swap": 0, "Swappiness": 0},
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {"destination": "/proc", "options": ["nosuid", "noexec", "nodev"], "source": "proc", "type_": "proc"},
+          {"destination": "/dev", "options": ["nosuid", "strictatime", "mode=755", "size=65536k"], "source": "tmpfs", "type_": "tmpfs"},
+          {"destination": "/dev/shm", "options": ["rbind"], "source": "/run/kata-containers/sandbox/shm", "type_": "bind"}
+        ],
+        "Process": {
+          "ApparmorProfile": "cri-containerd.apparmor.d",
+          "Args": ["/pause"],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"],
+            "Effective": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"],
+            "Inheritable": [],
+            "Permitted": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "HOSTNAME=gpu-test-pod"],
+          "NoNewPrivileges": false,
+          "OOMScoreAdj": 1000,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+        },
+        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "gpu-container",
+      "devices": [
+        {
+          "container_path": "/dev/vfio/devices/vfio1",
+          "id": "vfio1",
+          "options": ["0000:65:00.0=06/00"],
+          "type_": "vfio-pci",
+          "vm_path": ""
+        },
+        {
+          "container_path": "/dev/vfio/devices/vfio2",
+          "id": "vfio2",
+          "options": ["0000:66:00.0=06/00"],
+          "type_": "vfio-pci",
+          "vm_path": ""
+        }
+      ],
+      "exec_id": "gpu-container",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [],
+      "string_user": null
+    }
+  },
+  {
+    "description": "Invalid: Hot-plug - 2 GPUs with duplicate VFIO device numbers (same container_path) (vfio-pci)",
+    "allowed": false,
+    "kind": "CreateContainerRequest",
+    "request": {
+      "type": "CreateContainer",
+      "OCI": {
+        "Annotations": {
+          "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
+          "cdi.k8s.io/vfio2": "nvidia.com/gpu=1",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.kubernetes.cri.container-name": "gpu-container",
+          "io.kubernetes.cri.container-type": "container",
+          "io.kubernetes.cri.image-name": "registry.k8s.io/pause@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db",
+          "io.kubernetes.cri.sandbox-id": "abcd1234567890abcdef1234567890abcdef1234567890abcdef1234567890ab",
+          "io.kubernetes.cri.sandbox-name": "gpu-test-pod",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "12345678-1234-1234-1234-123456789012"
+        },
+        "Hooks": null,
+        "Hostname": "",
+        "Linux": {
+          "CgroupsPath": "kubepods-burstable-pod12345678_1234_1234_1234_123456789012.slice:cri-containerd:gpu-container",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": ["/proc/asound", "/proc/acpi", "/proc/kcore", "/proc/keys", "/proc/latency_stats", "/proc/timer_list", "/proc/timer_stats", "/proc/sched_debug", "/proc/scsi", "/sys/firmware", "/sys/devices/virtual/powercap"],
+          "MountLabel": "",
+          "Namespaces": [
+            {"Path": "", "Type": "ipc"},
+            {"Path": "", "Type": "uts"},
+            {"Path": "", "Type": "mount"}
+          ],
+          "ReadonlyPaths": ["/proc/bus", "/proc/fs", "/proc/irq", "/proc/sys", "/proc/sysrq-trigger"],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {"Cpus": "", "Mems": "", "Period": 100000, "Quota": 0, "RealtimePeriod": 0, "RealtimeRuntime": 0, "Shares": 2},
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": {"DisableOOMKiller": false, "Kernel": 0, "KernelTCP": 0, "Limit": 0, "Reservation": 0, "Swap": 0, "Swappiness": 0},
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {"destination": "/proc", "options": ["nosuid", "noexec", "nodev"], "source": "proc", "type_": "proc"},
+          {"destination": "/dev", "options": ["nosuid", "strictatime", "mode=755", "size=65536k"], "source": "tmpfs", "type_": "tmpfs"},
+          {"destination": "/dev/shm", "options": ["rbind"], "source": "/run/kata-containers/sandbox/shm", "type_": "bind"}
+        ],
+        "Process": {
+          "ApparmorProfile": "cri-containerd.apparmor.d",
+          "Args": ["/pause"],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"],
+            "Effective": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"],
+            "Inheritable": [],
+            "Permitted": ["CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD", "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP", "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "HOSTNAME=gpu-test-pod"],
+          "NoNewPrivileges": false,
+          "OOMScoreAdj": 1000,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+        },
+        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "gpu-container",
+      "devices": [
+        {
+          "container_path": "/dev/vfio/devices/vfio1",
+          "id": "vfio1",
+          "options": ["0000:65:00.0=06/00"],
+          "type_": "vfio-pci",
+          "vm_path": ""
+        },
+        {
+          "container_path": "/dev/vfio/devices/vfio1",
+          "id": "vfio1",
+          "options": ["0000:66:00.0=06/00"],
+          "type_": "vfio-pci",
+          "vm_path": ""
+        }
+      ],
+      "exec_id": "gpu-container",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [],
+      "string_user": null
+    }
   }
 ]


### PR DESCRIPTION
genpolicy-generated device policies for NVIDIA passthrough GPUs assume a fixed device type such as `vfio-pci-gk`. This breaks when Kata is configured with `vfio_mode=vfio`, where devices are typed as `vfio-pci`.

This PR adds a `gpu_device_types` allowlist (e.g. `["vfio-pci-gk", "vfio-pci"]`).

## Related Issue
Closes #12485