### PR TITLE
genpolicy: Switch to yaml_serde

### DIFF
--- a/src/tools/genpolicy/Cargo.lock
+++ b/src/tools/genpolicy/Cargo.lock
@@ -960,13 +960,13 @@ dependencies = [
  "serde-transcode",
  "serde_ignored",
  "serde_json",
- "serde_yaml",
  "slog",
  "tar",
  "tempfile",
  "tokio",
  "tonic",
  "tower 0.4.13",
+ "yaml_serde",
 ]
 
 [[package]]
@@ -1622,12 +1622,6 @@ name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
-
-[[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
@@ -2713,18 +2707,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.8.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
-dependencies = [
- "indexmap 1.9.2",
- "ryu",
- "serde",
- "yaml-rust",
-]
-
-[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,6 +3337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
 name = "url"
 version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3918,12 +3906,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "yaml-rust"
-version = "0.4.5"
+name = "yaml_serde"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+checksum = "4a7f5270edc6fab0529a772a772b3e505dfd883a8de5cc5b464e35fabe586411"
 dependencies = [
- "linked-hash-map",
+ "indexmap 2.10.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]

--- a/src/tools/genpolicy/Cargo.toml
+++ b/src/tools/genpolicy/Cargo.toml
@@ -23,18 +23,7 @@ base64 = "0.21.0"
 serde = { version = "1.0.159", features = ["derive"] }
 regex = "1.10.5"
 
-# Newer serde_yaml versions are using unsafe-libyaml instead of yaml-rust,
-# and incorrectly change on serialization:
-#
-# value: "yes"
-#
-# to:
-#
-# value: yes
-#
-# In YAML, the value yes without quotes is reserved for boolean,
-# and confuses kubectl, that expects a string value.
-serde_yaml = "0.8"
+serde_yaml = { package = "yaml_serde", version = "0.10" }
 
 # Container repository.
 anyhow = "1.0.32"

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -599,6 +599,7 @@ impl AgentPolicy {
         let mut yaml_string = String::new();
         for i in 0..self.resources.len() {
             let annotation = self.resources[i].generate_initdata_anno(self);
+            yaml_string += "---\n";
             yaml_string += &self.resources[i].serialize(&annotation);
         }
 


### PR DESCRIPTION
Although serde_yaml 0.9.34 is nearly two years old and unmaintained, bumping to lets us remove our dependency on the over 5 year old yaml-rust and remediates RUSTSEC-2024-0320

Sorry for the separate PRs for CVEs (which is annoying), but when I merged them all together the CI seemed unstable, so I'm separating them for problem isolation