### PR TITLE
versions: Bump go to 1.25.7

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -1,7 +1,7 @@
 module github.com/kata-containers/kata-containers/src/runtime
 
 // Keep in sync with version in versions.yaml
-go 1.24.13
+go 1.25.7
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/src/tools/csi-kata-directvolume/go.mod
+++ b/src/tools/csi-kata-directvolume/go.mod
@@ -1,7 +1,7 @@
 module kata-containers/csi-kata-directvolume
 
 // Keep in sync with version in versions.yaml
-go 1.24.13
+go 1.25.7
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/src/tools/log-parser/go.mod
+++ b/src/tools/log-parser/go.mod
@@ -1,7 +1,7 @@
 module github.com/kata-containers/kata-containers/src/tools/log-parser
 
 // Keep in sync with version in versions.yaml
-go 1.24.13
+go 1.25.7
 
 require (
 	github.com/BurntSushi/toml v1.1.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,7 +1,7 @@
 module github.com/kata-containers/tests
 
 // Keep in sync with version in versions.yaml
-go 1.24.13
+go 1.25.7
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/tests/metrics/cmd/checkmetrics/go.mod
+++ b/tests/metrics/cmd/checkmetrics/go.mod
@@ -1,7 +1,7 @@
 module example.com/m
 
 // Keep in sync with version in versions.yaml
-go 1.24.13
+go 1.25.7
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/tools/testing/kata-webhook/go.mod
+++ b/tools/testing/kata-webhook/go.mod
@@ -1,7 +1,7 @@
 module module-path
 
 // Keep in sync with version in versions.yaml
-go 1.24.13
+go 1.25.7
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/versions.yaml
+++ b/versions.yaml
@@ -465,12 +465,12 @@ languages:
     description: "Google's 'go' language"
     notes: "'version' is the default minimum version used by this project."
     # When updating this, also update in go.mod files.
-    version: "1.24.13"
+    version: "1.25.7"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.24.13"
+      newest-version: "1.25.7"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
Now that go 1.26 is out, 1.24 is not supported, so bump to 1.25 as per our policy.