### PR TITLE
versions: Switch gperf mirror again

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -331,7 +331,7 @@ externals:
 
   gperf:
     description: "GNU gperf is a perfect hash function generator"
-    url: "http://ftpmirror.gnu.org/gperf/"
+    url: "https://ftp.gnu.org.uk/gnu/gperf/"
     version: "3.3"
 
   hadolint:


### PR DESCRIPTION
The mirror introduced by #11178 still breaks quite often so apply this as a quick fix.

A proper solution would probably be to load balance like in #12453.