### PR TITLE
ci: add workflow to push ORAS tarball cache

### DIFF
--- a/.github/workflows/push-oras-tarball-cache.yaml
+++ b/.github/workflows/push-oras-tarball-cache.yaml
@@ -1,0 +1,43 @@
+# Push gperf and busybox tarballs to the ORAS cache (ghcr.io) so that
+# download-with-oras-cache.sh can pull them instead of hitting upstream.
+# Runs when versions.yaml changes on main (e.g. after a PR merge) or manually.
+name: CI | Push ORAS tarball cache
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'versions.yaml'
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  push-oras-cache:
+    name: push-oras-cache
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install yq
+        run: ./ci/install_yq.sh
+
+      - name: Install ORAS
+        uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
+        with:
+          version: "1.2.0"
+
+      - name: Populate ORAS tarball cache
+        run: ./tools/packaging/scripts/populate-oras-tarball-cache.sh all
+        env:
+          ARTEFACT_REGISTRY: ghcr.io
+          ARTEFACT_REPOSITORY: kata-containers
+          ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
+          ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}

--- a/tools/packaging/scripts/download-with-oras-cache.sh
+++ b/tools/packaging/scripts/download-with-oras-cache.sh
@@ -343,9 +343,6 @@ download_with_cache() {
 		# Cache miss or verification failed - download from upstream
 		info "Downloading ${artifact_name} from upstream..."
 		download_upstream "${upstream_url}" "${tarball_path}" "${checksum_url}" "${gpg_sig_url}"
-
-		# Push to cache for future use (include verification files)
-		push_to_cache "${artifact_name}" "${version}" "${tarball_path}"
 	else
 		info "ORAS not available, downloading directly from upstream"
 		download_upstream "${upstream_url}" "${tarball_path}" "${checksum_url}" "${gpg_sig_url}"

--- a/tools/packaging/scripts/populate-oras-tarball-cache.sh
+++ b/tools/packaging/scripts/populate-oras-tarball-cache.sh
@@ -123,13 +123,16 @@ cache_component() {
 	trap "rm -rf ${tmpdir}" EXIT
 
 	info "Downloading ${component} from upstream using ORAS cache helper..."
-	export PUSH_TO_REGISTRY="yes"
 	local tarball_path
 	tarball_path=$(download_component "${component}" "${tmpdir}")
 
 	if [[ ! -f "${tarball_path}" ]]; then
 		die "Failed to download ${component}"
 	fi
+
+	info "Pushing ${component} ${version} to ORAS cache..."
+	export PUSH_TO_REGISTRY="yes"
+	push_to_cache "${component}" "${version}" "${tarball_path}"
 
 	info "Successfully cached ${component} version ${version}"
 }


### PR DESCRIPTION
Add push-oras-tarball-cache workflow that runs on push to main when versions.yaml changes (and on workflow_dispatch). It populates the ghcr.io ORAS cache with gperf and busybox tarballs from versions.yaml.

Remove the push_to_cache call from download-with-oras-cache.sh since it was never triggered in CI. Cache population is now done solely by the new workflow and by populate-oras-tarball-cache.sh when run manually.