### PR TITLE
helm: replace .Chart.Name with kata-deploy.name template helper

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-cleanup-rbac-job.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-cleanup-rbac-job.yaml
@@ -6,9 +6,9 @@ apiVersion: batch/v1
 kind: Job
 metadata:
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-rb-cleanup-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-rb-cleanup-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-rb-cleanup
+  name: {{ include "kata-deploy.name" . }}-rb-cleanup
 {{- end }}
   namespace: {{ .Release.Namespace }}
   annotations:
@@ -22,14 +22,14 @@ spec:
     metadata:
 {{- if .Values.env.multiInstallSuffix }}
       labels:
-        name: {{ .Chart.Name }}-rb-cleanup-{{ .Values.env.multiInstallSuffix }}
+        name: {{ include "kata-deploy.name" . }}-rb-cleanup-{{ .Values.env.multiInstallSuffix }}
 {{- end }}
     spec:
       restartPolicy: OnFailure
 {{- if .Values.env.multiInstallSuffix }}
-      serviceAccountName: {{ .Chart.Name }}-sa-cleanup-{{ .Values.env.multiInstallSuffix }}
+      serviceAccountName: {{ include "kata-deploy.name" . }}-sa-cleanup-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-      serviceAccountName: {{ .Chart.Name }}-sa-cleanup
+      serviceAccountName: {{ include "kata-deploy.name" . }}-sa-cleanup
 {{- end }}
       containers:
         - name: rb-cleanup
@@ -88,25 +88,25 @@ spec:
               value: {{ .Release.Namespace | quote }}
             - name: DAEMONSET_POD_LABEL
 {{- if .Values.env.multiInstallSuffix }}
-              value: "name={{ .Chart.Name }}-{{ .Values.env.multiInstallSuffix }}"
+              value: "name={{ include "kata-deploy.name" . }}-{{ .Values.env.multiInstallSuffix }}"
 {{- else }}
-              value: "name={{ .Chart.Name }}"
+              value: "name={{ include "kata-deploy.name" . }}"
 {{- end }}
             - name: CLUSTER_ROLE_BINDING_NAME
 {{- if .Values.env.multiInstallSuffix }}
-              value: {{ .Chart.Name }}-rb-{{ .Values.env.multiInstallSuffix }}
+              value: {{ include "kata-deploy.name" . }}-rb-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-              value: {{ .Chart.Name }}-rb
+              value: {{ include "kata-deploy.name" . }}-rb
 {{- end }}
             - name: CLUSTER_ROLE_NAME
 {{- if .Values.env.multiInstallSuffix }}
-              value: {{ .Chart.Name }}-role-{{ .Values.env.multiInstallSuffix }}
+              value: {{ include "kata-deploy.name" . }}-role-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-              value: {{ .Chart.Name }}-role
+              value: {{ include "kata-deploy.name" . }}-role
 {{- end }}
             - name: SERVICE_ACCOUNT_NAME
 {{- if .Values.env.multiInstallSuffix }}
-              value: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
+              value: {{ include "kata-deploy.name" . }}-sa-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-              value: {{ .Chart.Name }}-sa
+              value: {{ include "kata-deploy.name" . }}-sa
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -22,26 +22,26 @@ apiVersion: apps/v1
 kind: DaemonSet
 metadata:
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}
+  name: {{ include "kata-deploy.name" . }}
 {{- end }}
   namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
 {{- if .Values.env.multiInstallSuffix }}
-      name: {{ .Chart.Name }}-{{ .Values.env.multiInstallSuffix }}
+      name: {{ include "kata-deploy.name" . }}-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-      name: {{ .Chart.Name }}
+      name: {{ include "kata-deploy.name" . }}
 {{- end }}
   template:
     metadata:
       labels:
 {{- if .Values.env.multiInstallSuffix }}
-        name: {{ .Chart.Name }}-{{ .Values.env.multiInstallSuffix }}
+        name: {{ include "kata-deploy.name" . }}-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-        name: {{ .Chart.Name }}
+        name: {{ include "kata-deploy.name" . }}
 {{- end }}
     spec:
 {{- with .Values.imagePullSecrets }}
@@ -49,9 +49,9 @@ spec:
 {{- toYaml . | nindent 6 }}
 {{- end }}
 {{- if .Values.env.multiInstallSuffix }}
-      serviceAccountName: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
+      serviceAccountName: {{ include "kata-deploy.name" . }}-sa-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-      serviceAccountName: {{ .Chart.Name }}-sa
+      serviceAccountName: {{ include "kata-deploy.name" . }}-sa
 {{- end }}
 {{- with .Values.nodeSelector }}
       nodeSelector:
@@ -323,9 +323,9 @@ spec:
       - name: custom-configs
         configMap:
 {{- if .Values.env.multiInstallSuffix }}
-          name: {{ .Chart.Name }}-custom-configs-{{ .Values.env.multiInstallSuffix }}
+          name: {{ include "kata-deploy.name" . }}-custom-configs-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-          name: {{ .Chart.Name }}-custom-configs
+          name: {{ include "kata-deploy.name" . }}-custom-configs
 {{- end }}
 {{- end }}
 {{- with .Values.updateStrategy }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-rbac.yaml
@@ -3,9 +3,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-sa-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-sa
+  name: {{ include "kata-deploy.name" . }}-sa
 {{- end }}
   namespace: {{ .Release.Namespace }}
   annotations:
@@ -16,9 +16,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-role-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-role-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-role
+  name: {{ include "kata-deploy.name" . }}-role
 {{- end }}
   annotations:
     helm.sh/resource-policy: keep
@@ -43,9 +43,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-rb-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-rb-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-rb
+  name: {{ include "kata-deploy.name" . }}-rb
 {{- end }}
   annotations:
     helm.sh/resource-policy: keep
@@ -53,16 +53,16 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-role-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-role-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-role
+  name: {{ include "kata-deploy.name" . }}-role
 {{- end }}
 subjects:
 - kind: ServiceAccount
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-sa-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-sa-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-sa
+  name: {{ include "kata-deploy.name" . }}-sa
 {{- end }}
   namespace: {{ .Release.Namespace }}
 ---
@@ -72,9 +72,9 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-sa-cleanup-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-sa-cleanup-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-sa-cleanup
+  name: {{ include "kata-deploy.name" . }}-sa-cleanup
 {{- end }}
   namespace: {{ .Release.Namespace }}
   annotations:
@@ -86,9 +86,9 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-cleanup-role-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-cleanup-role-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-cleanup-role
+  name: {{ include "kata-deploy.name" . }}-cleanup-role
 {{- end }}
   annotations:
     "helm.sh/hook": post-delete
@@ -106,9 +106,9 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-cleanup-rb-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-cleanup-rb-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-cleanup-rb
+  name: {{ include "kata-deploy.name" . }}-cleanup-rb
 {{- end }}
   annotations:
     "helm.sh/hook": post-delete
@@ -118,15 +118,15 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-cleanup-role-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-cleanup-role-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-cleanup-role
+  name: {{ include "kata-deploy.name" . }}-cleanup-role
 {{- end }}
 subjects:
 - kind: ServiceAccount
 {{- if .Values.env.multiInstallSuffix }}
-  name: {{ .Chart.Name }}-sa-cleanup-{{ .Values.env.multiInstallSuffix }}
+  name: {{ include "kata-deploy.name" . }}-sa-cleanup-{{ .Values.env.multiInstallSuffix }}
 {{- else }}
-  name: {{ .Chart.Name }}-sa-cleanup
+  name: {{ include "kata-deploy.name" . }}-sa-cleanup
 {{- end }}
   namespace: {{ .Release.Namespace }}


### PR DESCRIPTION
Use the kata-deploy.name include helper instead of hardcoded .Chart.Name to allow chart name override via nameOverride and fullnameOverride values.