### PR TITLE
scripts: use temporary GPG home when verifying cached gperf tarball

### DIFF
--- a/tools/packaging/static-build/tools/Dockerfile
+++ b/tools/packaging/static-build/tools/Dockerfile
@@ -36,6 +36,7 @@ RUN apt-get update && \
 		g++ \
 		gcc \
 		git \
+		gnupg \
 		libssl-dev \
 		make \
 		musl-tools \


### PR DESCRIPTION
In CI the default GPG keyring is often read-only or missing, so 'gpg --import' of the cached keyring fails and verification cannot succeed. Use a temporary GNUPGHOME for import and verify so cached gperf can be verified without writing to the system keyring.