### PR TITLE
kata-deploy: Temporarily comment GPU specific labels

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -117,8 +117,9 @@ shims:
     runtimeClass:
       # This label is automatically added by gpu-operator. Override it
       # if you want to use a different label.
-      nodeSelector:
-        nvidia.com/cc.ready.state: "false"
+      # Uncomment once GPU Operator v26.3 is out
+      # nodeSelector:
+        # nvidia.com/cc.ready.state: "false"
 
   qemu-nvidia-gpu-snp:
     enabled: ~
@@ -139,7 +140,8 @@ shims:
       # If you don't have NFD, you need to add the snp label by other
       # means to your SNP nodes.
       nodeSelector:
-        nvidia.com/cc.ready.state: "true"
+        # Uncomment once GPU Operator v26.3 is out
+        # nvidia.com/cc.ready.state: "true"
         amd.feature.node.kubernetes.io/snp: "true"
 
   qemu-nvidia-gpu-tdx:
@@ -161,7 +163,8 @@ shims:
       # If you don't have NFD, you need to add the tdx label by other
       # means to your TDX nodes.
       nodeSelector:
-        nvidia.com/cc.ready.state: "true"
+        # Uncomment once GPU Operator v26.3 is out
+        # nvidia.com/cc.ready.state: "true"
         intel.feature.node.kubernetes.io/tdx: "true"
 
   qemu-snp:


### PR DESCRIPTION
We depend on GPU Operator v26.3 release, which is not out yet. Although we have been testing with it, it's not yet publicly available, which would break anyone actually trying to use the GPU runtime classes.