### PR TITLE
runtime-rs/ch: Fix inverted vcpu/tid mapping in get_ch_vcpu_tids

### DIFF
--- a/tests/integration/kubernetes/k8s-sandbox-cgroup.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-cgroup.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 Chiranjeevi Uddanti
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	pod_name="sandbox-cgroup-pod"
+
+	setup_common || die "setup_common failed"
+
+	yaml_file="${pod_config_dir}/pod-sandbox-cgroup.yaml"
+	set_node "$yaml_file" "$node"
+
+	# Add policy to yaml
+	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+
+	add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
+	auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
+}
+
+# Regression test for https://github.com/kata-containers/kata-containers/issues/12479
+@test "Pod with sandbox_cgroup_only=false starts successfully" {
+	# Create pod
+	kubectl create -f "${yaml_file}"
+
+	# Wait for pod to be ready
+	kubectl wait --for=condition=Ready --timeout=$timeout pod "$pod_name"
+}
+
+teardown() {
+	delete_tmp_policy_settings_dir "${policy_settings_dir}"
+	teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -88,6 +88,7 @@ else
 		"k8s-privileged.bats" \
 		"k8s-projected-volume.bats" \
 		"k8s-replication.bats" \
+		"k8s-sandbox-cgroup.bats" \
 		"k8s-seccomp.bats" \
 		"k8s-sysctls.bats" \
 		"k8s-security-context.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-sandbox-cgroup.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-sandbox-cgroup.yaml
@@ -1,0 +1,18 @@
+#
+# Copyright (c) 2026 Chiranjeevi Uddanti
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sandbox-cgroup-pod
+  annotations:
+    io.katacontainers.config.runtime.sandbox_cgroup_only: "false"
+spec:
+  runtimeClassName: kata
+  restartPolicy: Never
+  containers:
+  - image: quay.io/prometheus/busybox:latest
+    name: sandbox-cgroup-test


### PR DESCRIPTION
## Problem

When using Cloud Hypervisor with `sandbox_cgroup_only=false`, pod creation fails with:
`failed to read /proc/0/status: No such file or directory (os error 2)`

## Root Cause

The `get_ch_vcpu_tids()` function was returning an inverted HashMap mapping `tid -> vcpu_id` instead of the expected `vcpu_id -> tid` format that `VcpuThreadIds` defines.

When `move_vcpus_to_sandbox_cgroup()` called `.values()` on this HashMap expecting thread IDs, it got vCPU IDs (0, 1, 2...) instead. This caused it to attempt reading `/proc/0/status` which doesn't exist.

## Fix

Swap the insert arguments from `vcpus.insert(tid, vcpu_id)` to `vcpus.insert(vcpu_id, tid)` to match the contract and all other hypervisor implementations (Dragonball, QEMU, Go runtime's CLH).

Fixes: #12479