### PR TITLE
kata-deploy: disable provenance/SBOM for quay.io compatibility

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -23,20 +23,20 @@ pushd ${KATA_DEPLOY_DIR}
 
 arch=$(uname -m)
 [ "$arch" = "x86_64" ] && arch="amd64"
-# Single platform so each job pushes one architecture; attestations (provenance/SBOM)
-# are kept by default, making the tag an image index (manifest list).
+# Disable provenance and SBOM so each tag is a single image manifest. quay.io rejects
+# pushing multi-arch manifest lists that include attestation manifests ("manifest invalid").
 PLATFORM="linux/${arch}"
 IMAGE_TAG="${REGISTRY}:kata-containers-$(git rev-parse HEAD)-${arch}"
 
-echo "Building the image (with provenance and SBOM attestations)"
-docker buildx build --platform "${PLATFORM}" \
+echo "Building the image"
+docker buildx build --platform "${PLATFORM}" --provenance false --sbom false \
 	--tag "${IMAGE_TAG}" --push .
 
 if [ -n "${TAG}" ]; then
 	ADDITIONAL_TAG="${REGISTRY}:${TAG}"
 
 	echo "Building the ${ADDITIONAL_TAG} image"
-	docker buildx build --platform "${PLATFORM}" \
+	docker buildx build --platform "${PLATFORM}" --provenance false --sbom false \
 		--tag "${ADDITIONAL_TAG}" --push .
 fi
 

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -144,9 +144,10 @@ function _publish_multiarch_manifest()
 	_check_required_env_var "KATA_DEPLOY_IMAGE_TAGS"
 	_check_required_env_var "KATA_DEPLOY_REGISTRIES"
 
-	# Per-arch tags may be image indexes (image + attestations). Use buildx imagetools create
-	# so we can merge them; legacy "docker manifest create" rejects manifest list sources.
-	# imagetools create pushes the new manifest list to --tag by default (no separate push).
+	# Per-arch images are built without provenance/SBOM so each tag is a single image manifest;
+	# quay.io rejects pushing multi-arch manifest lists that include attestation manifests
+	# ("manifest invalid"), so we do not enable them for this workflow.
+	# imagetools create pushes to --tag by default.
 	for registry in "${REGISTRIES[@]}"; do
 		for tag in "${IMAGE_TAGS[@]}"; do
 			docker buildx imagetools create --tag "${registry}:${tag}" \


### PR DESCRIPTION
Disable provenance and SBOM when building per-arch kata-deploy images so each tag is a single image manifest. quay.io rejects pushing multi-arch manifest lists that include attestation manifests (400 manifest invalid). Add a note in the release script documenting this.