### PR TITLE
qemu: log exit code after failure

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1098,8 +1098,10 @@ func (q *qemu) LogAndWait(qemuCmd *exec.Cmd, reader io.ReadCloser) {
 			q.Logger().WithField("qemuPid", pid).Error(text)
 		}
 	}
-	q.Logger().Infof("Stop logging QEMU (qemuPid=%d)", pid)
-	qemuCmd.Wait()
+	q.Logger().WithField("qemuPid", pid).Infof("Stop logging QEMU")
+	if err := qemuCmd.Wait(); err != nil {
+		q.Logger().WithField("qemuPid", pid).WithField("error", err).Warn("QEMU exited with an error")
+	}
 }
 
 // StartVM will start the Sandbox's VM.


### PR DESCRIPTION
When qemu exits prematurely, we usually see a message like

```
msg="Cannot start VM" error="exiting QMP loop, command cancelled"
```

This is an indirect hint, caused by the QMP server shutting down. It takes experience to understand what it even means, and it still does not show what's actually the problem.

With this commit, we're taking the error return from the qemu subprocess and surface it in the logs, if it's not nil. This means we automatically capture any non-zero exit codes in the logs.

---

This change helped me understand an issue after I tried a qemu update recently. The qemu version I targeted was segfaulting pretty early, and with the change I get logs like

```
level=warning msg="QEMU exited with an error" error="signal: segmentation fault (core dumped)" name=containerd-shim-v2 pid=1557022 qemuPid=1557031 sandbox=fbec3e571533e1001c779ad9bba6b4466c677f2d1e518f3c6d48c5b8127f0951 source=virtcontainers/hypervisor subsystem=qemu
```

On a normal pod termination, we just see the "end of logging" message.