### PR TITLE
genpolicy: allow RO and RW for sysfs with privileged container

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1133,6 +1133,20 @@ check_mount(p_mount, i_mount, bundle_id, sandbox_id) if {
 
     print("check_mount 2: true")
 }
+check_mount(p_mount, i_mount, bundle_id, sandbox_id) if {
+    # This check passes if the policy container has RW, the input container has
+    # RO and the volume type is sysfs, working around different handling of
+    # privileged containers after containerd 2.0.4.
+    i_mount.type_ == "sysfs"
+    p_mount.type_ == i_mount.type_
+    p_mount.destination == i_mount.destination
+    p_mount.source == i_mount.source
+
+    i_options := {x | x = i_mount.options[_]} | {"rw"}
+    p_options := {x | x = p_mount.options[_]} | {"ro"}
+    p_options == i_options
+    print("check_mount 3: true")
+}
 
 mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id) if {
     regex1 := p_mount.source

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -675,6 +675,9 @@ impl AgentPolicy {
         );
 
         let is_privileged = yaml_container.is_privileged();
+        let needs_privileged_mounts = is_privileged
+            || (is_pause_container && resource.get_containers().iter().any(|c| c.is_privileged()));
+
         let process = self.get_container_process(
             resource,
             yaml_container,
@@ -684,7 +687,7 @@ impl AgentPolicy {
             is_privileged,
         );
 
-        let mut mounts = containerd::get_mounts(is_pause_container, is_privileged);
+        let mut mounts = containerd::get_mounts(is_pause_container, needs_privileged_mounts);
         mount_and_storage::get_policy_mounts(
             &self.config.settings,
             &mut mounts,


### PR DESCRIPTION
After containerd 2.0.4, privileged containers handle sysfs mounts a bit differently, so we can end up with the policy expecting RO and the input having RW.

The sandbox needs to get privileged mounts when any container in the pod is privileged, not only when the pause container itself is marked privileged. So we now compute that and pass it into get_mounts.

One downside: we’re relaxing policy checks (accepting RO/RW mismatch for sysfs) and giving the pause container privileged mounts whenever the pod has any privileged workload. For Kata, that means a slightly broader attack surface for privileged pods—the pause container sees more than it strictly needs, and we’re being more permissive on sysfs.

It’s a trade-off for compatibility with newer containerd; if you need maximum isolation, you may want to avoid privileged pods or tighten policy elsewhere.

Fixes: #12532