### PR TITLE
tests: enable policy for openvpn on nydus

### DIFF
--- a/tests/integration/kubernetes/k8s-openvpn.bats
+++ b/tests/integration/kubernetes/k8s-openvpn.bats
@@ -34,17 +34,10 @@ setup() {
     client_secret_template_yaml="${pod_config_dir}/openvpn/openvpn-client-secret.yaml.in"
     client_secret_instance_yaml="${pod_config_dir}/openvpn/openvpn-client-secret-instance.yaml"
 
-    # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-    # other references to this issue in the genpolicy source folder.
-    if [[ "${SNAPSHOTTER:-}" == "nydus" ]]; then
-        add_allow_all_policy_to_yaml "$server_pod_yaml"
-        add_allow_all_policy_to_yaml "$client_pod_yaml"
-    else
-        policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
-        add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
-        auto_generate_policy "${policy_settings_dir}" "$server_pod_yaml" "$server_configmap_yaml" "--config-file $server_secret_template_yaml"
-        auto_generate_policy "${policy_settings_dir}" "$client_pod_yaml" "$client_configmap_yaml" "--config-file $client_secret_template_yaml"
-    fi
+    policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+    add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
+    auto_generate_policy "${policy_settings_dir}" "$server_pod_yaml" "$server_configmap_yaml" "--config-file $server_secret_template_yaml"
+    auto_generate_policy "${policy_settings_dir}" "$client_pod_yaml" "$client_configmap_yaml" "--config-file $client_secret_template_yaml"
 }
 
 @test "Pods establishing a VPN connection using openvpn" {
@@ -92,9 +85,7 @@ teardown() {
     echo "=== OpenVPN Client Pod Logs ==="
     kubectl logs "$client_pod_name" || true
 
-    if [[ "${SNAPSHOTTER:-}" != "nydus" ]]; then
-        delete_tmp_policy_settings_dir "${policy_settings_dir}"
-    fi
+    delete_tmp_policy_settings_dir "${policy_settings_dir}"
     teardown_common "${node}" "${node_start_time:-}"
 
     # teardown cleans up pods, but not other resources

--- a/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-client-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-client-pod.yaml
@@ -11,6 +11,13 @@ metadata:
   labels:
     app: openvpn-client
 spec:
+  # Explicit user/group/supplementary groups to support nydus guest-pull.
+  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
+  # other references to this issue in the genpolicy source folder.
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
   containers:
   - name: openvpn-client
     image: quay.io/kata-containers/alpine:3.22.1-openvpn

--- a/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-server-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-server-pod.yaml
@@ -11,6 +11,13 @@ metadata:
   labels:
     app: openvpn-server
 spec:
+  # Explicit user/group/supplementary groups to support nydus guest-pull.
+  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
+  # other references to this issue in the genpolicy source folder.
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
   containers:
   - name: openvpn-server
     image: quay.io/kata-containers/alpine:3.22.1-openvpn


### PR DESCRIPTION
Specify runAsUser, runAsGroup, supplementalGroups values embedded
in the image's /etc/group file explicitly in the security context.
With this, both genpolicy and containerd, which in case of using
nydus guest-pull lack image introspection capabilities, will use the
same values for user/group/additionalG IDs at policy generation
time and at runtime when the OCI spec is passed.