### PR TITLE
kata-deploy: enable kata-remote for ppc64le

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -275,6 +275,7 @@ shims:
     enabled: false
     supportedArches:
       - amd64
+      - ppc64le
       - s390x
     allowedHypervisorAnnotations: []
     containerd:


### PR DESCRIPTION
When kata-deploy is deployed with cloud-api-adaptor, shim defaults to qemu for ppc64le instead of configuring the remote shim. Support ppc64le to enable it correctly when shims.remote.enabled=true