### PR TITLE
build: kernel: Do not expect a modules tarball for vanilla kernel

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -143,7 +143,7 @@ jobs:
           if-no-files-found: error
 
       - name: store-extratarballs-artifact ${{ matrix.asset }}
-        if: ${{ matrix.asset == 'kernel' || startsWith(matrix.asset, 'kernel-nvidia-gpu') }}
+        if: ${{ startsWith(matrix.asset, 'kernel-nvidia-gpu') }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: kata-artifacts-amd64-${{ matrix.asset }}-modules${{ inputs.tarball-suffix }}
@@ -235,7 +235,6 @@ jobs:
         asset:
           - busybox
           - coco-guest-components
-          - kernel-modules
           - kernel-nvidia-gpu-modules
           - pause-image
     steps:

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -120,15 +120,6 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
-      - name: store-extratarballs-artifact ${{ matrix.asset }}
-        if: ${{ matrix.asset == 'kernel' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: kata-artifacts-s390x-${{ matrix.asset }}-modules${{ inputs.tarball-suffix }}
-          path: kata-build/kata-static-${{ matrix.asset }}-modules.tar.zst
-          retention-days: 15
-          if-no-files-found: error
-
   build-asset-rootfs:
     name: build-asset-rootfs
     runs-on: s390x

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -656,14 +656,6 @@ install_cached_kernel_tarball_component() {
 		|| return 1
 
 	case ${kernel_name} in
-		"kernel")
-			if [[ "${ARCH}" == "x86_64" || "${ARCH}" == "s390x" ]]; then
-				local modules_dir
-				modules_dir=$(get_kernel_modules_dir "${kernel_version}" "${kernel_kata_config_version}" "${build_target}")
-				mkdir -p "${modules_dir}" || true
-				tar --strip-components=1 --zstd -xvf "${workdir}/kata-static-${kernel_name}-modules.tar.zst" -C "${modules_dir}" || return 1
-			fi
-			;;
 		"kernel-nvidia-gpu"*"")
 			local modules_dir
 			modules_dir=$(get_kernel_modules_dir "${kernel_version}" "${kernel_kata_config_version}" "${build_target}")
@@ -699,14 +691,6 @@ install_kernel_helper() {
 	fi
 
 	case ${kernel_name} in
-		kernel)
-			# Main kernel on x86_64/s390x is built with -x (TEE); produce modules tarball for rootfs
-			if [[ "${ARCH}" == "x86_64" || "${ARCH}" == "s390x" ]]; then
-				local kernel_modules_tarball_name="kata-static-${kernel_name}-modules.tar.zst"
-				local kernel_modules_tarball_path="${workdir}/${kernel_modules_tarball_name}"
-				extra_tarballs="${kernel_modules_tarball_name}:${kernel_modules_tarball_path}"
-			fi
-			;;
 		kernel-nvidia-gpu|kernel-nvidia-gpu-dragonball-experimental|kernel*-confidential)
 			local kernel_modules_tarball_name="kata-static-${kernel_name}-modules.tar.zst"
 			local kernel_modules_tarball_path="${workdir}/${kernel_modules_tarball_name}"
@@ -1419,22 +1403,6 @@ handle_build() {
 	tar --zstd -tvf "${final_tarball_path}"
 
 	case ${build_target} in
-		kernel)
-			if [[ "${ARCH}" == "x86_64" || "${ARCH}" == "s390x" ]]; then
-				local modules_final_tarball_path="${workdir}/kata-static-${build_target}-modules.tar.zst"
-				if [[ ! -f "${modules_final_tarball_path}" ]]; then
-					local modules_dir
-					modules_dir=$(get_kernel_modules_dir "${kernel_version}" "${kernel_kata_config_version}" "${build_target}")
-					parent_dir=$(dirname "${modules_dir}")
-					parent_dir_basename=$(basename "${parent_dir}")
-					pushd "${parent_dir}"
-					rm -f "${parent_dir_basename}"/build
-					tar --zstd -cvf "${modules_final_tarball_path}" "."
-					popd
-				fi
-				tar --zstd -tvf "${modules_final_tarball_path}"
-			fi
-			;;
 		kernel-nvidia-gpu|kernel-nvidia-gpu-dragonball-experimental)
 			local modules_final_tarball_path="${workdir}/kata-static-${build_target}-modules.tar.zst"
 			if [[ ! -f "${modules_final_tarball_path}" ]]; then


### PR DESCRIPTION
When I added this I had in mind the period that we still relied on the SEV module being generated, which we don't do for quite a long time.

This wrong assumption caused the cache to **ALWAYS** fail, increasing our build time considerably for no reason.