### PR TITLE
gha: enable runtime-rs for ppc64le in CI

### DIFF
--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -233,7 +233,7 @@ jobs:
       matrix:
         asset:
           - shim-v2-go
-          # Add `shim-v2-rust` here once it builds on ppc64le.
+          - shim-v2-rust
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-ppc64le-${{ toJSON(matrix) }}
       cancel-in-progress: true

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -325,20 +325,29 @@ jobs:
           ./tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh kata-artifacts versions.yaml ppc64le
         env:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
-      - name: Check kata-go-static tarball size (GitHub release asset limit)
+      - name: Check kata tarball sizes (GitHub release asset limit)
         run: |
           # https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas
           GITHUB_ASSET_MAX_BYTES=2147483648
-          tarball_size=$(stat -c "%s" kata-go-static.tar.zst)
-          if [[ "${tarball_size}" -ge "${GITHUB_ASSET_MAX_BYTES}" ]]; then
-            echo "::error::kata-go-static.tar.zst size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
-            exit 1
-          fi
-          echo "kata-go-static.tar.zst size: ${tarball_size} bytes"
+          for tarball in kata-static.tar.zst kata-go-static.tar.zst; do
+            tarball_size=$(stat -c "%s" "${tarball}")
+            if [[ "${tarball_size}" -ge "${GITHUB_ASSET_MAX_BYTES}" ]]; then
+              echo "::error::${tarball} size (${tarball_size} bytes) >= GitHub release asset limit (${GITHUB_ASSET_MAX_BYTES} bytes)"
+              exit 1
+            fi
+            echo "${tarball} size: ${tarball_size} bytes"
+          done
+      - name: store runtime-rs artifacts
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: kata-static-tarball-ppc64le${{ inputs.tarball-suffix }}
+          path: kata-static.tar.zst
+          retention-days: 15
+          if-no-files-found: error
       - name: store Go runtime artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: kata-go-static-tarball-ppc64le${{ inputs.tarball-suffix }}
           path: kata-go-static.tar.zst
-          retention-days: 1
+          retention-days: 15
           if-no-files-found: error

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -548,6 +548,7 @@ jobs:
       matrix:
         params: [
           {containerd_version: latest, vmm: qemu},
+          {containerd_version: latest, vmm: qemu-runtime-rs},
         ]
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-cri-ppc64le-${{ toJSON(matrix) }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -223,6 +223,18 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ARCHITECTURE: s390x
 
+      - name: Download ppc64le artifacts
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: kata-static-tarball-ppc64le
+
+      - name: Upload ppc64le static tarball to GitHub
+        run: |
+          ./tools/packaging/release/release.sh upload-kata-static-tarball
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ARCHITECTURE: ppc64le
+
       - name: Download ppc64le Go runtime artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:

--- a/.github/workflows/run-k8s-tests-on-ppc64le.yaml
+++ b/.github/workflows/run-k8s-tests-on-ppc64le.yaml
@@ -36,6 +36,7 @@ jobs:
       matrix:
         vmm:
           - qemu
+          - qemu-runtime-rs
         k8s:
           - kubeadm
     concurrency:

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -1192,6 +1192,10 @@ install-runtime: runtime
 install-configs: $(CONFIGS)
 	$(foreach f,$(CONFIGS),$(call INSTALL_FILE,$f,$(dir $(CONFIG_PATH)))) \
 	ln -sf $(DEFAULT_HYPERVISOR_CONFIG) $(DESTDIR)/$(CONFIG_PATH)
+ifeq ($(ARCH),powerpc64le)
+	sed -i 's|^image = .*|initrd = "$(PREFIX)/share/kata-containers/kata-containers-initrd.img"|' \
+		$(DESTDIR)$(CONFIG_PATH_QEMU)
+endif
 
 .PHONY: \
 	help \

--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -1187,6 +1187,10 @@ install-runtime: runtime
 install-configs: $(CONFIGS)
 	$(foreach f,$(CONFIGS),$(call INSTALL_FILE,$f,$(dir $(CONFIG_PATH)))) \
 	ln -sf $(DEFAULT_HYPERVISOR_CONFIG) $(DESTDIR)/$(CONFIG_PATH)
+ifeq ($(ARCH),powerpc64le)
+	sed -i 's|^image = .*|initrd = "$(PREFIX)/share/kata-containers/kata-containers-initrd.img"|' \
+		$(DESTDIR)$(CONFIG_PATH_QEMU)
+endif
 
 .PHONY: \
 	help \

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -770,7 +770,7 @@ function helm_helper() {
 				# qemu-coco-dev-runtime-rs is checked explicitly because
 				# qemu-coco-dev (Go runtime) does not support arm64.
 				elif [[ "${shim}" == "qemu-runtime-rs" ]] || [[ "${shim}" == "qemu-coco-dev-runtime-rs" ]]; then
-					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\", \"s390x\"]" "${values_yaml}"
+					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\", \"s390x\", \"ppc64le\"]" "${values_yaml}"
 				elif is_non_tee_hypervisor "${shim}"; then
 					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"s390x\"]" "${values_yaml}"
 				elif is_nvidia_hypervisor "${shim}"; then

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -765,7 +765,9 @@ function helm_helper() {
 					yq -i ".shims.${shim}.supportedArches = [\"amd64\"]" "${values_yaml}"
 				# qemu-coco-dev-runtime-rs is checked explicitly because
 				# qemu-coco-dev (Go runtime) does not support arm64.
-				elif [[ "${shim}" == "qemu-runtime-rs" ]] || [[ "${shim}" == "qemu-coco-dev-runtime-rs" ]]; then
+				elif [[ "${shim}" == "qemu-runtime-rs" ]]; then
+					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\", \"s390x\", \"ppc64le\"]" "${values_yaml}"
+				elif [[ "${shim}" == "qemu-coco-dev-runtime-rs" ]]; then
 					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\", \"s390x\"]" "${values_yaml}"
 				elif is_non_tee_hypervisor "${shim}"; then
 					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"s390x\"]" "${values_yaml}"

--- a/tests/integration/kubernetes/filter_out_per_arch/ppc64le.yaml
+++ b/tests/integration/kubernetes/filter_out_per_arch/ppc64le.yaml
@@ -5,10 +5,13 @@
 
 kubernetes:
   - k8s-block-volume
+  - k8s-inotify
+  # Confidential Computing not supported
   - k8s-confidential-attestation
   - k8s-confidential
   - k8s-guest-pull-image
-  - k8s-inotify
+  # Memory limit <512MB not supported
   - k8s-limit-range
   - k8s-number-cpus
   - k8s-oom
+  - k8s-cpu-ns

--- a/tests/integration/kubernetes/filter_out_per_arch/ppc64le.yaml
+++ b/tests/integration/kubernetes/filter_out_per_arch/ppc64le.yaml
@@ -5,10 +5,14 @@
 
 kubernetes:
   - k8s-block-volume
+  - k8s-inotify
+  - k8s-memory
+  # Confidential Computing not supported
   - k8s-confidential-attestation
   - k8s-confidential
   - k8s-guest-pull-image
-  - k8s-inotify
+  # Memory limit <512MB not supported
   - k8s-limit-range
   - k8s-number-cpus
   - k8s-oom
+  - k8s-cpu-ns

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -1117,7 +1117,7 @@ fn get_default_shims_for_arch(arch: &str) -> &'static str {
         "x86_64" => "clh clh-runtime-rs dragonball fc qemu qemu-coco-dev qemu-coco-dev-runtime-rs qemu-runtime-rs qemu-nvidia-cpu qemu-nvidia-cpu-runtime-rs qemu-nvidia-gpu qemu-nvidia-gpu-runtime-rs qemu-nvidia-gpu-snp qemu-nvidia-gpu-snp-runtime-rs qemu-nvidia-gpu-tdx qemu-nvidia-gpu-tdx-runtime-rs qemu-snp qemu-snp-runtime-rs qemu-tdx qemu-tdx-runtime-rs",
         "aarch64" => "clh clh-runtime-rs dragonball fc qemu qemu-coco-dev-runtime-rs qemu-runtime-rs qemu-nvidia-cpu qemu-nvidia-cpu-runtime-rs qemu-nvidia-gpu",
         "s390x" => "qemu qemu-runtime-rs qemu-se qemu-se-runtime-rs qemu-coco-dev qemu-coco-dev-runtime-rs",
-        "ppc64le" => "qemu",
+        "ppc64le" => "qemu qemu-runtime-rs",
         _ => "qemu", // Fallback to qemu for unknown architectures
     }
 }
@@ -1126,13 +1126,11 @@ fn get_default_shims_for_arch(arch: &str) -> &'static str {
 ///
 /// Since the Kata Containers 4.0 release, the Rust runtime (runtime-rs,
 /// "qemu-runtime-rs") is the default wherever a runtime-rs build exists.
-/// ppc64le has no runtime-rs build yet, so it keeps the Go runtime ("qemu").
 /// This only acts as a fallback: the Helm chart normally provides DEFAULT_SHIM
 /// explicitly via values.yaml (`defaultShim`).
 fn get_default_shim_for_arch(arch: &str) -> &'static str {
     match arch {
-        "x86_64" | "aarch64" | "s390x" => "qemu-runtime-rs",
-        "ppc64le" => "qemu",
+        "x86_64" | "aarch64" | "s390x" | "ppc64le" => "qemu-runtime-rs",
         _ => "qemu", // Fallback to the Go runtime for unknown architectures
     }
 }
@@ -1286,7 +1284,7 @@ mod tests {
     #[case("x86_64", "qemu-runtime-rs")]
     #[case("aarch64", "qemu-runtime-rs")]
     #[case("s390x", "qemu-runtime-rs")]
-    #[case("ppc64le", "qemu")]
+    #[case("ppc64le", "qemu-runtime-rs")]
     #[case("riscv64", "qemu")]
     fn test_get_default_shim_for_arch(#[case] arch: &str, #[case] expected: &str) {
         assert_eq!(get_default_shim_for_arch(arch), expected);

--- a/tools/packaging/kata-deploy/binary/src/config.rs
+++ b/tools/packaging/kata-deploy/binary/src/config.rs
@@ -1048,7 +1048,7 @@ fn get_default_shims_for_arch(arch: &str) -> &'static str {
         "x86_64" => "clh clh-runtime-rs dragonball fc qemu qemu-coco-dev qemu-coco-dev-runtime-rs qemu-runtime-rs qemu-nvidia-cpu qemu-nvidia-cpu-runtime-rs qemu-nvidia-gpu qemu-nvidia-gpu-runtime-rs qemu-nvidia-gpu-snp qemu-nvidia-gpu-snp-runtime-rs qemu-nvidia-gpu-tdx qemu-nvidia-gpu-tdx-runtime-rs qemu-snp qemu-snp-runtime-rs qemu-tdx qemu-tdx-runtime-rs",
         "aarch64" => "clh clh-runtime-rs dragonball fc qemu qemu-coco-dev-runtime-rs qemu-runtime-rs qemu-nvidia-cpu qemu-nvidia-cpu-runtime-rs qemu-nvidia-gpu",
         "s390x" => "qemu qemu-runtime-rs qemu-se qemu-se-runtime-rs qemu-coco-dev qemu-coco-dev-runtime-rs",
-        "ppc64le" => "qemu",
+        "ppc64le" => "qemu qemu-runtime-rs",
         _ => "qemu", // Fallback to qemu for unknown architectures
     }
 }

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -582,6 +582,7 @@ shims:
       - amd64
       - arm64
       - s390x
+      - ppc64le
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
@@ -853,15 +854,14 @@ shims:
 #
 # Since the Kata Containers 4.0 release, the Rust runtime (runtime-rs,
 # "qemu-runtime-rs") is the default on every architecture that ships a
-# runtime-rs build. ppc64le has no runtime-rs build yet, so it stays on the
-# Go runtime ("qemu"). The Go runtime remains supported (no new features are
+# runtime-rs build. The Go runtime remains supported (no new features are
 # being added) and selectable (e.g. RuntimeClass "kata-qemu"); see the
 # deprecation notice in docs/migrating-config-go-runtime-to-runtime-rs.md.
 defaultShim:
   amd64: qemu-runtime-rs
   arm64: qemu-runtime-rs
   s390x: qemu-runtime-rs
-  ppc64le: qemu
+  ppc64le: qemu-runtime-rs
 
 runtimeClasses:
   enabled: true

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -494,6 +494,7 @@ shims:
       - amd64
       - arm64
       - s390x
+      - ppc64le
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -184,16 +184,11 @@ define DUMMY
 endef
 
 ifneq ($(filter $(ARCH),x86_64 aarch64 s390x ppc64le),)
-ifneq ($(ARCH), ppc64le)
 KATA_STATIC_FINAL_TARBALL_INPUTS := $(shell $(MK_DIR)/kata-release-tarball-inputs.sh kata-static $(ARCH) | tr '\n' ' ')
-endif
 KATA_GO_STATIC_FINAL_TARBALL_INPUTS := $(shell $(MK_DIR)/kata-release-tarball-inputs.sh kata-go-static $(ARCH) | tr '\n' ' ')
 endif
 
-ifeq ($(ARCH), ppc64le)
-kata-tarball:
-	@echo "kata-tarball: runtime-rs is unsupported on $(ARCH); use kata-go-static-tarball"; exit 1
-else ifneq ($(KATA_STATIC_FINAL_TARBALL_INPUTS),)
+ifneq ($(KATA_STATIC_FINAL_TARBALL_INPUTS),)
 kata-tarball: FINAL_TARBALL_INPUTS=$(KATA_STATIC_FINAL_TARBALL_INPUTS)
 kata-tarball: FINAL_TARBALL_NAME=kata-static.tar.zst
 kata-tarball: | all-parallel

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -183,16 +183,11 @@ define DUMMY
 endef
 
 ifneq ($(filter $(ARCH),x86_64 aarch64 s390x ppc64le),)
-ifneq ($(ARCH), ppc64le)
 KATA_STATIC_FINAL_TARBALL_INPUTS := $(shell $(MK_DIR)/kata-release-tarball-inputs.sh kata-static $(ARCH) | tr '\n' ' ')
-endif
 KATA_GO_STATIC_FINAL_TARBALL_INPUTS := $(shell $(MK_DIR)/kata-release-tarball-inputs.sh kata-go-static $(ARCH) | tr '\n' ' ')
 endif
 
-ifeq ($(ARCH), ppc64le)
-kata-tarball:
-	@echo "kata-tarball: runtime-rs is unsupported on $(ARCH); use kata-go-static-tarball"; exit 1
-else ifneq ($(KATA_STATIC_FINAL_TARBALL_INPUTS),)
+ifneq ($(KATA_STATIC_FINAL_TARBALL_INPUTS),)
 kata-tarball: FINAL_TARBALL_INPUTS=$(KATA_STATIC_FINAL_TARBALL_INPUTS)
 kata-tarball: FINAL_TARBALL_NAME=kata-static.tar.zst
 kata-tarball: | all-parallel

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh
@@ -33,10 +33,8 @@ merge_with_allowlist() {
 
 normalized_arch="$(normalize_arch "${arch}")"
 
-if [[ "${normalized_arch}" != "ppc64le" ]]; then
-	allowlist="$(kata_static_tarball_inputs "${arch}" | tr '\n' ' ')"
-	merge_with_allowlist "kata-static.tar.zst" "${allowlist}"
-fi
+allowlist="$(kata_static_tarball_inputs "${arch}" | tr '\n' ' ')"
+merge_with_allowlist "kata-static.tar.zst" "${allowlist}"
 
 allowlist="$(kata_go_tarball_inputs "${arch}" | tr '\n' ' ')"
 merge_with_allowlist "kata-go-static.tar.zst" "${allowlist}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-release-tarballs.sh
@@ -31,12 +31,8 @@ merge_with_allowlist() {
 		merge
 }
 
-normalized_arch="$(normalize_arch "${arch}")"
-
-if [[ "${normalized_arch}" != "ppc64le" ]]; then
-	allowlist="$(kata_static_tarball_inputs "${arch}" | tr '\n' ' ')"
-	merge_with_allowlist "kata-static.tar.zst" "${allowlist}"
-fi
+allowlist="$(kata_static_tarball_inputs "${arch}" | tr '\n' ' ')"
+merge_with_allowlist "kata-static.tar.zst" "${allowlist}"
 
 allowlist="$(kata_go_tarball_inputs "${arch}" | tr '\n' ' ')"
 merge_with_allowlist "kata-go-static.tar.zst" "${allowlist}"

--- a/tools/packaging/kata-deploy/local-build/kata-release-tarball-inputs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-release-tarball-inputs.sh
@@ -89,8 +89,13 @@ kata-static-virtiofsd.tar.zst
 EOF
 			;;
 		ppc64le)
-			echo "runtime-rs tarball is not produced on ppc64le" >&2
-			return 1
+			cat <<'EOF'
+kata-static-kernel.tar.zst
+kata-static-qemu.tar.zst
+kata-static-rootfs-initrd.tar.zst
+kata-static-shim-v2-rust.tar.zst
+kata-static-virtiofsd.tar.zst
+EOF
 			;;
 	esac
 }

--- a/tools/packaging/kata-deploy/local-build/kata-release-tarball-inputs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-release-tarball-inputs.sh
@@ -90,8 +90,13 @@ kata-static-virtiofsd.tar.zst
 EOF
 			;;
 		ppc64le)
-			echo "runtime-rs tarball is not produced on ppc64le" >&2
-			return 1
+			cat <<'EOF'
+kata-static-kernel.tar.zst
+kata-static-qemu.tar.zst
+kata-static-rootfs-initrd.tar.zst
+kata-static-shim-v2-rust.tar.zst
+kata-static-virtiofsd.tar.zst
+EOF
 			;;
 	esac
 }

--- a/tools/packaging/kata-deploy/shim-components.json
+++ b/tools/packaging/kata-deploy/shim-components.json
@@ -13,7 +13,8 @@
     "qemu-runtime-rs": {
       "x86_64":  ["shim-v2-rust", "qemu", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd"],
       "aarch64": ["shim-v2-rust", "qemu", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd", "ovmf"],
-      "s390x":   ["shim-v2-rust", "qemu", "virtiofsd", "kernel", "rootfs-image", "rootfs-initrd"]
+      "s390x":   ["shim-v2-rust", "qemu", "virtiofsd", "kernel", "rootfs-image", "rootfs-initrd"],
+      "ppc64le": ["shim-v2-rust", "qemu", "virtiofsd", "kernel", "rootfs-initrd"]
     },
     "qemu-snp": {
       "x86_64": ["shim-v2-go", "qemu", "kernel", "rootfs-image-confidential", "ovmf-sev"]


### PR DESCRIPTION
## Summary:
This PR enables qemu-runtime-rs support for ppc64le.
## Changes include:

- Add qemu-runtime-rs to the CI matrix
- Enable Kubernetes tests on ppc64le for qemu-runtime-rs
- Update the default shim configuration to include qemu-runtime-rs for ppc64le
- Extend Helm chart supportedArches to include ppc64le
- Enable shim-v2-rust support for ppc64le static tarball builds
- Add shim-v2-rust to the ppc64le shim component configuration
- Makefile changes to use initrd instead of image for ppc64le rust runtime
- Changes to enable ppc64le kata-static tarball generation and upload for runtime-rs
- k8s-cpu-ns enforces a 128 MB memory limit, below the 512 MB required for QEMU on Power , so skip these test.

### Reference: PR #12484