### PR TITLE
k8s-policy-pvc: use local PV/PVC when no default StorageClass exists

### DIFF
--- a/tests/integration/kubernetes/k8s-policy-pvc.bats
+++ b/tests/integration/kubernetes/k8s-policy-pvc.bats
@@ -11,14 +11,45 @@ load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
 	auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled."
-	[[ "${RUNS_ON_AKS}" == "true" ]] || skip "https://github.com/kata-containers/kata-containers/issues/9846"
 	setup_common || die "setup_common failed"
 	pod_name="policy-pod-pvc"
 	pvc_name="policy-dev"
+	volume_name="policy-dev-block-pv"
+	vol_capacity="10Mi"
 
 	correct_pod_yaml="${pod_config_dir}/k8s-policy-pod-pvc.yaml"
 	incorrect_pod_yaml="${pod_config_dir}/k8s-policy-pod-pvc-incorrect.yaml"
 	pvc_yaml="${pod_config_dir}/k8s-policy-pvc.yaml"
+
+	# On qemu-tdx / qemu-snp the cluster has no default StorageClass, so we create local block
+	# storage (loop device + StorageClass + PV) for the PVC to bind to.
+	node="$(get_one_kata_node)"
+	if [[ "${RUNS_ON_AKS:-false}" == "false" ]]; then
+		tmp_disk_image=$(exec_host "${node}" mktemp --tmpdir disk.XXXXXX.img | tr -d '\r\n')
+		exec_host "${node}" dd if=/dev/zero of="${tmp_disk_image}" bs=1M count=0 seek=10
+		loop_dev=$(exec_host "${node}" sudo losetup -f | tr -d '\r\n')
+		exec_host "${node}" sudo losetup "${loop_dev}" "${tmp_disk_image}"
+
+		kubectl apply -f - <<EOF
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: local-storage
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+EOF
+		kubectl delete pv "${volume_name}" --ignore-not-found=true || true
+		kubectl wait --for=delete "pv/${volume_name}" --timeout=30s 2>/dev/null || true
+		tmp_pv_yaml=$(mktemp --tmpdir block_persistent_vol.XXXXX.yaml)
+		sed -e "s|LOOP_DEVICE|${loop_dev}|" \
+			-e "s|HOSTNAME|${node}|g" \
+			-e "s|CAPACITY|${vol_capacity}|" \
+			-e "s|block-loop-pv|${volume_name}|" \
+			"${BATS_TEST_DIRNAME}/volume/block-loop-pv.yaml" > "${tmp_pv_yaml}"
+		kubectl create -f "${tmp_pv_yaml}"
+	fi
 
 	# Save some time by executing genpolicy a single time.
 	if [ "${BATS_TEST_NUMBER}" == "1" ]; then
@@ -26,8 +57,14 @@ setup() {
 		auto_generate_policy "${pod_config_dir}" "${correct_pod_yaml}"
 	fi
 
-    # Start each test case with a copy of the correct yaml files.
+	# Start each test case with a copy of the correct yaml files.
 	cp "${correct_pod_yaml}" "${incorrect_pod_yaml}"
+}
+
+# Ensure PVC is gone so this test can create it (idempotent; avoids AlreadyExists from previous test).
+delete_pvc_if_exists() {
+	kubectl delete pvc "${pvc_name}" --ignore-not-found=true || true
+	kubectl wait --for=delete "pvc/${pvc_name}" --timeout=60s 2>/dev/null || true
 }
 
 @test "Successful pod with auto-generated policy" {
@@ -58,15 +95,25 @@ test_pod_policy_error() {
 
 teardown() {
 	auto_generate_policy_enabled || skip "Auto-generated policy tests are disabled."
-	[[ "${RUNS_ON_AKS}" == "true" ]] || skip "https://github.com/kata-containers/kata-containers/issues/9846"
 
 	# Debugging information. Don't print the "Message:" line because it contains a truncated policy log.
 	kubectl describe pod "${pod_name}" | grep -v "Message:"
 
-	# Clean-up
-	kubectl delete -f "${correct_pod_yaml}"
-	kubectl delete -f "${pvc_yaml}"
+	# Clean-up: remove pod first so the PVC can be released, then remove PVC.
+	kubectl delete -f "${correct_pod_yaml}" --ignore-not-found=true || true
+	delete_pvc_if_exists
 	rm -f "${incorrect_pod_yaml}"
+
+	# Remove local block storage outside AKS (we created it in setup).
+	if [[ "${RUNS_ON_AKS:-false}" == "false" ]]; then
+		kubectl delete pv "${volume_name}" --ignore-not-found=true || true
+		kubectl delete storageclass local-storage --ignore-not-found=true || true
+		rm -f "${tmp_pv_yaml:-}"
+		if [ -n "${node:-}" ] && [ -n "${loop_dev:-}" ]; then
+			exec_host "${node}" sudo losetup -d "${loop_dev}" 2>/dev/null || true
+			exec_host "${node}" rm -f "${tmp_disk_image:-}" 2>/dev/null || true
+		fi
+	fi
 
 	teardown_common "${node}" "${node_start_time:-}"
 }


### PR DESCRIPTION
Create local block storage (loop device, StorageClass, PV) in the test only when the cluster has no default StorageClass, matching the approach used in k8s-volume.bats. Set our StorageClass as default so the PVC binds to our PV; tear it down after the test.

When a default already exists (e.g. AKS), skip creation and cleanup so we do not change the cluster's default storage class.

Fixes: #9846