### PR TITLE
tests: remove the assert_pod_container_creating function

### DIFF
--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -55,7 +55,7 @@ setup() {
 	echo "Pod $pod_config file:"
 	cat $pod_config
 
-	assert_pod_container_creating "$pod_config"
+	assert_pod_fail "$pod_config"
 	assert_logs_contain "$node" kata "${node_start_time}" "verity: .* metadata block .* is corrupted"
 }
 

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -205,6 +205,23 @@ assert_pod_fail() {
 		if [[ "${terminated_reason}" == "StartError" ]] || [[ "${terminated_reason}" == "Error" ]]; then
 			return 0
 		fi
+		# Sandbox failure (e.g. kernel or early init crash): pod stays Pending, failure only in events.
+		# Only treat events as failure when the pod is still Pending (e.g. ContainerCreating).
+		local pod_phase
+		pod_phase=$(kubectl get pod "${pod_name}" -o jsonpath='{.status.phase}' 2>/dev/null || true)
+		if [[ "${pod_phase}" == "Pending" ]]; then
+			local namespace
+			namespace=$(kubectl get pod "${pod_name}" -o jsonpath='{.metadata.namespace}' 2>/dev/null || true)
+			if [[ -n "${namespace}" ]]; then
+				local events_reasons
+				events_reasons=$(kubectl get events -n "${namespace}" \
+					--field-selector "involvedObject.name=${pod_name},involvedObject.kind=Pod" \
+					-o jsonpath='{.items[*].reason}' 2>/dev/null || true)
+				if echo "${events_reasons}" | grep -qE "FailedCreatePodSandBox|Killing"; then
+					return 0
+				fi
+			fi
+		fi
 		if [[ "${elapsed_time}" -gt "${duration}" ]]; then
 			echo "The container does not get into a failing state" >&2
 			break


### PR DESCRIPTION
Remove the function `assert_pod_container_creating`. This function was used for the test `Test cannot launch pod with measured boot enabled and incorrect hash`. While the container remains in container creating state for this test case, the container is actually exhibiting a fault status, which the reworked `assert_pod_fail` function now detects.