### PR TITLE
tests: Enable auto-generated policies for experimental_force_guest_pull

### DIFF
--- a/.github/workflows/run-kata-coco-tests.yaml
+++ b/.github/workflows/run-kata-coco-tests.yaml
@@ -165,6 +165,7 @@ jobs:
       AUTHENTICATED_IMAGE_PASSWORD: ${{ secrets.AUTHENTICATED_IMAGE_PASSWORD }}
       SNAPSHOTTER: ${{ matrix.environment.snapshotter }}
       EXPERIMENTAL_FORCE_GUEST_PULL: ${{ matrix.environment.pull_type == 'experimental-force-guest-pull' && matrix.environment.vmm || '' }}
+      AUTO_GENERATE_POLICY: "yes"
       K8S_TEST_HOST_TYPE: "all"
       CONTAINER_ENGINE: "containerd"
       CONTAINER_ENGINE_VERSION: "active"
@@ -221,7 +222,6 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata
         env:
           USE_EXPERIMENTAL_SETUP_SNAPSHOTTER: ${{ matrix.environment.snapshotter == 'nydus' }}
-          AUTO_GENERATE_POLICY: ${{ matrix.environment.pull_type == 'experimental-force-guest-pull' && 'no' || 'yes' }}
 
       - name: Deploy CoCo KBS
         timeout-minutes: 10

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -180,6 +180,15 @@ adapt_common_policy_settings_for_containerd_version() {
 	jq '.kata_config.oci_version = "1.3.0"' "${settings_dir}/genpolicy-settings.json" > temp.json && mv temp.json "${settings_dir}/genpolicy-settings.json"
 }
 
+# When using experimental-force-guest-pull, genpolicy must not use guest_pull (we pull via oci-distribution for policy generation).
+adapt_common_policy_settings_for_experimental_force_guest_pull() {
+	local settings_dir=$1
+
+	info "Adapting common policy settings for experimental-force-guest-pull: disable guest_pull"
+	jq '.cluster_config.guest_pull = false' "${settings_dir}/genpolicy-settings.json" > temp.json
+	mv temp.json "${settings_dir}/genpolicy-settings.json"
+}
+
 # adapt common policy settings for various platforms
 adapt_common_policy_settings() {
 	local settings_dir=$1
@@ -188,6 +197,7 @@ adapt_common_policy_settings() {
 	is_aks_cluster && adapt_common_policy_settings_for_aks "${settings_dir}"
 	is_nvidia_gpu_platform && adapt_common_policy_settings_for_nvidia_gpu "${settings_dir}"
 	[[ -n "${CONTAINER_ENGINE_VERSION:-}" ]] && adapt_common_policy_settings_for_containerd_version "${settings_dir}"
+	[[ "${PULL_TYPE:-}" == "experimental-force-guest-pull" ]] && adapt_common_policy_settings_for_experimental_force_guest_pull "${settings_dir}"
 
 	case "${KATA_HOST_OS}" in
 		"cbl-mariner")


### PR DESCRIPTION
We want to run with auto-generated policies when using experimental_force_guest_pull.