### PR TITLE
tests: Extend fail timeout for failure test

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -170,7 +170,10 @@ setup() {
     cat $pod_config
 
     # The pod should be failed because the image is too large to be pulled in the timeout
-    assert_pod_fail "$pod_config"
+    local fail_timeout=120
+    # In this case, the host pulls first. Sometimes pull times spike, so allow longer to observe the failure
+    [[ -n "${EXPERIMENTAL_FORCE_GUEST_PULL}" ]] && fail_timeout=360
+    assert_pod_fail "$pod_config" "$fail_timeout"
 
     # runtime-rs has its dedicated error message, we need handle it separately.
     if [ "${KATA_HYPERVISOR}" == "qemu-coco-dev-runtime-rs" ]; then


### PR DESCRIPTION
Extend the timeout for the assert_pod_fail function call for the test case "Test we cannot pull a large image that pull time exceeds createcontainer timeout inside the guest" when the experimental force guest-pull method is being used. In this method, the image is first pulled on the host before creating the pod sandbox. While image pull times can suddenly spike, we already time out in the assert_pod_fail function before the image is even pulled on the host.

Example: `kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-coco-nontee (qemu-coco-dev, experimental-force-guest-pull)` - such as https://github.com/kata-containers/kata-containers/actions/runs/22253055088/job/64380538661?pr=12555

We see:
```
not ok 4 Test we cannot pull a large image that pull time exceeds createcontainer timeout inside the guest in 140273ms
# (from function `assert_pod_fail' in file lib.sh, line 213,
#  in test file k8s-guest-pull-image.bats, line 173)
#   `assert_pod_fail "$pod_config"' failed
```

From `kubectl describe` you see the almost two minute host-pull time:
```
# Events: 
# Type Reason Age From Message 
# ---- ------ ---- ---- ------- 
# Normal Scheduled 2m6s default-scheduler Successfully assigned kata-containers-k8s-tests/large-image-pod to runnervmwffz4 
# Normal SuccessfulMountVolume 2m6s kubelet MapVolume.MapPodDevice succeeded for volume "trusted-block-pv" globalMapPath "/var/lib/kubelet/plugins/kubernetes.io~local-volume/volumeDevices/trusted-block-pv" 
# Normal SuccessfulMountVolume 2m6s kubelet MapVolume.MapPodDevice succeeded for volume "trusted-block-pv" volumeMapPath "/var/lib/kubelet/pods/bd1c2768-eb13-416f-81fd-71bd8f22796c/volumeDevices/kubernetes.io~local-volume" 
# Normal Pulling 2m3s kubelet spec.containers{app-container}: Pulling image "quay.io/confidential-containers/test-images:largeimage" 
# Normal Pulled 8s kubelet spec.containers{app-container}: Successfully pulled image "quay.io/confidential-containers/test-images:largeimage" in 1m54.345s (1m54.345s including waiting). Image size: 2151531235 bytes. 
# Normal Created 8s kubelet spec.containers{app-container}: Container created
```