### PR TITLE
tests: Improve assertion handling for runtime-rs hypervisor

### DIFF
--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -173,7 +173,7 @@ setup() {
     assert_pod_fail "$pod_config"
 
     # runtime-rs has its dedicated error message, we need handle it separately.
-    if [ "${KATA_HYPERVISOR}" == "qemu-coco-dev-runtime-rs" ]; then
+    if [[ "${KATA_HYPERVISOR}" == *-runtime-rs ]]; then
         pod_name="large-image-pod"
         kubectl describe "pod/$pod_name" | grep "agent create container"
         kubectl describe "pod/$pod_name" | grep "timeout"


### PR DESCRIPTION
Since runtime-rs added support for virtio-blk-ccw on s390x in #12531, the assertion in k8s-guest-pull-image.bats should be generalized to apply to all hypervisors ending with `-runtime-rs`.

This PR will fix a failing test on IBM SEL (`KATA_HYPERVISOR`="qemu-se-runtime-rs"): https://github.com/kata-containers/kata-containers/actions/runs/22337882259/job/64653856717#step:3:14141

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>