### PR TITLE
runtime: skip CDI guest annotations for non-VFIO devices

### DIFF
--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1208,6 +1208,10 @@ func (c *Container) siblingAnnotation(devPath string, siblings []DeviceRelation)
 				// exit handling IOMMUFD device
 				return nil
 			}
+			// If we have a path of form /dev/vfio/devices/vfio<NUM>,
+			// the legacy VFIO codepath can't work with it, so rather
+			// than falling through, we should check the next sibling.
+			continue
 		}
 		// Legacy VFIO group device (/dev/vfio/<GROUP_NUM>), extract BDF from sysfs
 		vfioGroup := filepath.Base(devPath)

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -1004,7 +1004,9 @@ func (c *Container) createDevices(ctx context.Context, contConfig *ContainerConf
 
 	// If we're hot-plugging this will be a no-op because at this stage
 	// no devices are attached to the root-port or switch-port
-	c.annotateContainerWithVFIOMetadata(vfioColdPlugDevices)
+	if err := c.annotateContainerWithVFIOMetadata(vfioColdPlugDevices); err != nil {
+		return fmt.Errorf("annotating VFIO devices: %w", err)
+	}
 
 	return nil
 }
@@ -1117,6 +1119,10 @@ func (c *Container) annotateContainerWithVFIOMetadata(devices interface{}) error
 		// to the correct index
 		if devices, ok := devices.([]ContainerDevice); ok {
 			for _, dev := range devices {
+				if !strings.HasPrefix(dev.ContainerPath, "/dev/vfio") {
+					c.Logger().Infof("skipping guest annotations for non-VFIO device %q", dev.ContainerPath)
+					continue
+				}
 				if dev.ContainerPath == "/dev/vfio/vfio" {
 					c.Logger().Infof("skipping /dev/vfio/vfio for vfio_mode=guest-kernel")
 					continue
@@ -1130,6 +1136,10 @@ func (c *Container) annotateContainerWithVFIOMetadata(devices interface{}) error
 
 		if devices, ok := devices.([]config.DeviceInfo); ok {
 			for _, dev := range devices {
+				if !strings.HasPrefix(dev.ContainerPath, "/dev/vfio") {
+					c.Logger().Infof("skipping guest annotations for non-VFIO device %q", dev.ContainerPath)
+					continue
+				}
 				if dev.ContainerPath == "/dev/vfio/vfio" {
 					c.Logger().Infof("skipping /dev/vfio/vfio for vfio_mode=guest-kernel")
 					continue
@@ -1251,7 +1261,9 @@ func (c *Container) create(ctx context.Context) (err error) {
 		return
 	}
 
-	c.annotateContainerWithVFIOMetadata(c.devices)
+	if err = c.annotateContainerWithVFIOMetadata(c.devices); err != nil {
+		return
+	}
 
 	// Deduce additional system mount info that should be handled by the agent
 	// inside the VM


### PR DESCRIPTION
The `siblingAnnotation` function expects `devPath` to refer to a VFIO device. If that's not the case, the function will fail to find the sibling counterpart and return an error. This can be triggered by adding a block device to the container.

The reason why this did not cause immediate problems is that the error return was ignored on both call sites of
`annotateContainerWithVFIOMetadata`. This commit propagates the error correctly.

---

The siblingAnnotation function used to only check the first sibling candidate, because all sad paths led to a direct error return, instead of continuing with the next candidate. This becomes a problem when there
is more than one VFIO device cold-plugged into the pod.