### PR TITLE
runtime: ensure socket file is removed after shim deletion

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/delete_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/delete_test.go
@@ -7,6 +7,9 @@
 package containerdshim
 
 import (
+	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
@@ -40,4 +43,99 @@ func TestDeleteContainerSuccessAndFail(t *testing.T) {
 	}
 	s.containers[testContainerID], err = newContainer(s, reqCreate, "", nil, true)
 	assert.NoError(err)
+}
+
+func TestCleanupPodContainerDoesNotRemoveSharedSocket(t *testing.T) {
+	assert := assert.New(t)
+
+	_, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
+	assert.NoError(err)
+
+	spec.Annotations = map[string]string{
+		testContainerTypeAnnotation: testContainerTypeContainer,
+		testSandboxIDAnnotation:     testSandboxID,
+	}
+	err = ktu.WriteOCIConfigFile(spec, ociConfigFile)
+	assert.NoError(err)
+
+	socketPath := filepath.Join(t.TempDir(), "shared.sock")
+	err = os.WriteFile(socketPath, nil, testFileMode)
+	assert.NoError(err)
+
+	err = os.WriteFile(filepath.Join(bundlePath, "address"), []byte("unix://"+socketPath), testFileMode)
+	assert.NoError(err)
+
+	oldWd, err := os.Getwd()
+	assert.NoError(err)
+	defer func() {
+		_ = os.Chdir(oldWd)
+	}()
+	err = os.Chdir(bundlePath)
+	assert.NoError(err)
+
+	testingImpl.CleanupContainerFunc = func(ctx context.Context, sandboxID, containerID string, force bool) error {
+		return nil
+	}
+	defer func() {
+		testingImpl.CleanupContainerFunc = nil
+	}()
+
+	s := &service{
+		id:      testContainerID,
+		rootCtx: context.Background(),
+	}
+
+	_, err = s.Cleanup(context.Background())
+	assert.NoError(err)
+
+	_, err = os.Stat(socketPath)
+	assert.NoError(err)
+}
+
+func TestCleanupSandboxRemovesSocket(t *testing.T) {
+	assert := assert.New(t)
+
+	_, bundlePath, ociConfigFile := ktu.SetupOCIConfigFile(t)
+	spec, err := compatoci.ParseConfigJSON(bundlePath)
+	assert.NoError(err)
+
+	spec.Annotations = map[string]string{
+		testContainerTypeAnnotation: testContainerTypeSandbox,
+	}
+	err = ktu.WriteOCIConfigFile(spec, ociConfigFile)
+	assert.NoError(err)
+
+	socketPath := filepath.Join(t.TempDir(), "sandbox.sock")
+	err = os.WriteFile(socketPath, nil, testFileMode)
+	assert.NoError(err)
+
+	err = os.WriteFile(filepath.Join(bundlePath, "address"), []byte("unix://"+socketPath), testFileMode)
+	assert.NoError(err)
+
+	oldWd, err := os.Getwd()
+	assert.NoError(err)
+	defer func() {
+		_ = os.Chdir(oldWd)
+	}()
+	err = os.Chdir(bundlePath)
+	assert.NoError(err)
+
+	testingImpl.CleanupContainerFunc = func(ctx context.Context, sandboxID, containerID string, force bool) error {
+		return nil
+	}
+	defer func() {
+		testingImpl.CleanupContainerFunc = nil
+	}()
+
+	s := &service{
+		id:      testSandboxID,
+		rootCtx: context.Background(),
+	}
+
+	_, err = s.Cleanup(context.Background())
+	assert.NoError(err)
+
+	_, err = os.Stat(socketPath)
+	assert.True(os.IsNotExist(err))
 }

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -242,7 +242,6 @@ func (s *service) StartShim(ctx context.Context, opts cdshim.StartOpts) (_ strin
 	}
 
 	socket, err := cdshim.NewSocket(address)
-
 	if err != nil {
 		if !cdshim.SocketEaddrinuse(err) {
 			return "", err
@@ -349,10 +348,10 @@ func (s *service) Cleanup(ctx context.Context) (_ *taskAPI.DeleteResponse, err e
 	span, spanCtx := katatrace.Trace(s.rootCtx, shimLog, "Cleanup", shimTracingTags)
 	defer span.End()
 
-	//Since the binary cleanup will return the DeleteResponse from stdout to
-	//containerd, thus we must make sure there is no any outputs in stdout except
-	//the returned response, thus here redirect the log to stderr in case there's
-	//any log output to stdout.
+	// Since the binary cleanup will return the DeleteResponse from stdout to
+	// containerd, thus we must make sure there is no any outputs in stdout except
+	// the returned response, thus here redirect the log to stderr in case there's
+	// any log output to stdout.
 	logrus.SetOutput(os.Stderr)
 
 	defer func() {
@@ -376,6 +375,13 @@ func (s *service) Cleanup(ctx context.Context) (_ *taskAPI.DeleteResponse, err e
 	containerType, err := oci.ContainerType(ociSpec)
 	if err != nil {
 		return nil, err
+	}
+	if containerType != vc.PodContainer {
+		defer func() {
+			if address, addrErr := cdshim.ReadAddress("address"); addrErr == nil {
+				_ = cdshim.RemoveSocket(address)
+			}
+		}()
 	}
 
 	switch containerType {
@@ -486,7 +492,7 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (_ *taskAP
 	s.eventSendMu.Lock()
 	defer s.eventSendMu.Unlock()
 
-	//start a container
+	// start a container
 	if r.ExecID == "" {
 		err = startContainer(spanCtx, s, c)
 		if err != nil {
@@ -497,7 +503,7 @@ func (s *service) Start(ctx context.Context, r *taskAPI.StartRequest) (_ *taskAP
 			Pid:         s.hpid,
 		})
 	} else {
-		//start an exec
+		// start an exec
 		_, err = startExec(spanCtx, s, r.ID, r.ExecID)
 		if err != nil {
 			return nil, errdefs.ToGRPC(err)
@@ -553,7 +559,7 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 			Pid:        s.hpid,
 		}, nil
 	}
-	//deal with the exec case
+	// deal with the exec case
 	execs, err := c.getExec(r.ExecID)
 	if err != nil {
 		return nil, err
@@ -685,7 +691,7 @@ func (s *service) State(ctx context.Context, r *taskAPI.StateRequest) (_ *taskAP
 		}, nil
 	}
 
-	//deal with exec case
+	// deal with exec case
 	execs, err := c.getExec(r.ExecID)
 	if err != nil {
 		return nil, err
@@ -952,7 +958,7 @@ func (s *service) Connect(ctx context.Context, r *taskAPI.ConnectRequest) (_ *ta
 
 	return &taskAPI.ConnectResponse{
 		ShimPid: s.pid,
-		//Since kata cannot get the container's pid in VM, thus only return the hypervisor's pid.
+		// Since kata cannot get the container's pid in VM, thus only return the hypervisor's pid.
 		TaskPid: s.hpid,
 	}, nil
 }
@@ -1090,14 +1096,14 @@ func (s *service) Wait(ctx context.Context, r *taskAPI.WaitRequest) (_ *taskAPI.
 		return nil, err
 	}
 
-	//wait for container
+	// wait for container
 	if r.ExecID == "" {
 		ret = <-c.exitCh
 
 		// refill the exitCh with the container process's exit code in case
 		// there were other waits on this process.
 		c.exitCh <- ret
-	} else { //wait for exec
+	} else { // wait for exec
 		execs, err := c.getExec(r.ExecID)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Problem

We recently encountered an issue where hundreds of thousands of socket files were leaked under `/run/containerd/s/`.

These socket files are created by kata-shim during `StartShim` and are expected to be cleaned up when the shim process exits normally. 

However, in our environment, the shim processes exited abnormally due to missing dependent packages, which caused the socket files to remain on disk

<img width="910" height="112" alt="image" src="https://github.com/user-attachments/assets/5d7277e4-193c-4f83-832f-7720484bc046" />
<img width="217" height="21" alt="image" src="https://github.com/user-attachments/assets/3497e94d-d61b-4113-a9ad-2c05a34dcc78" />

## Fix

This PR ensures that the socket file is removed when `shim delete` is called, preventing resource leakage even if the shim exits unexpectedly.