### PR TITLE
workflows: Swap our go install for setup-go

### DIFF
--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -94,13 +94,19 @@ jobs:
           ./ci/install_yq.sh
         env:
           INSTALL_IN_GOPATH: false
-      - name: Install golang
+      - name: Read properties from versions.yaml
         if: contains(matrix.component.needs, 'golang')
         run: |
-          if ! command -v go; then
-            ./tests/install_go.sh -f -p
-            echo "/usr/local/go/bin" >> "$GITHUB_PATH"
-          fi
+          go_version="$(yq '.languages.golang.version' versions.yaml)"
+          [ -n "$go_version" ]
+          echo "GO_VERSION=${go_version}" >> "$GITHUB_ENV"
+      - name: Setup Golang version ${{ env.GO_VERSION }}
+        if: contains(matrix.component.needs, 'golang')
+        uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          # Setup-go doesn't work properly with ppc64le: https://github.com/actions/setup-go/issues/648
+          architecture: ${{ contains(inputs.instance, 'ppc64le') && 'ppc64le' || '' }}
       - name: Setup rust
         if: contains(matrix.component.needs, 'rust')
         run: |


### PR DESCRIPTION
Unfortunately, due to golang/go#75031, there is an issue that results in `go: no such tool "covdata"`
with a automatically installed 1.25 toolchain, so
the approach to skip the install_go.sh script (which causes double install problems) didn't work. Try the alternative approach of using setup-go action, which should do a more comprehensive job