### PR TITLE
docs: require explicit User/Group/AdditionalID

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -226,6 +226,35 @@ Importantly, the default behavior to pass the host devices to a
 privileged container is not supported in Kata Containers and needs to be
 disabled, see [Privileged Kata Containers](how-to/privileged.md).
 
+## Guest pulled container images
+
+When using features like **nydus guest-pull**, set user/group IDs explicitly in the pod spec.
+If the ID values are omitted:
+
+- Your workload might be executed with unexpected user/group ID values, because image layers
+  may be unavailable to containerd, so image config (including user/group) is not applied.
+- If using policy or genpolicy, the generated policy may detect these unexpected values and
+  reject the creation of workload containers.
+
+Set `securityContext` explicitly. Use **pod-level** `spec.securityContext` (for Pods) or
+`spec.template.spec.securityContext` (for controllers like Deployments) and/or **container-level**
+`spec.containers[].securityContext`. Include at least:
+- `runAsUser` — primary user ID
+- `runAsGroup` — primary group ID
+- `fsGroup` — volume group ownership (often reflected as a supplemental group)
+- `supplementalGroups` — list of additional group IDs (if needed)
+
+Example:
+
+ ```yaml
+ # Explicit user/group/supplementary groups to support nydus guest-pull
+ securityContext:
+   runAsUser: 0
+   runAsGroup: 0
+   fsGroup: 0
+   supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
+ ```
+
 # Appendices
 
 ## The constraints challenge

--- a/docs/how-to/how-to-use-the-kata-agent-policy.md
+++ b/docs/how-to/how-to-use-the-kata-agent-policy.md
@@ -99,6 +99,9 @@ The [`genpolicy`](../../src/tools/genpolicy/) application can be used to generat
 
 **Warning** Users should review carefully the automatically-generated Policy, and modify the Policy file if needed to match better their use case, before using this Policy.
 
+**Important — User / Group / Supplemental groups for Policy and genpolicy**
+When using features like **nydus guest-pull**, set user/group IDs explicitly in the pod spec, as described in [Limitations](../Limitations.md#guest-pulled-container-images).
+
 See the [`genpolicy` documentation](../../src/tools/genpolicy/README.md) and the [Policy contents examples](#policy-contents) for additional information.
 
 ## Policy contents

--- a/tests/cmd/check-spelling/data/projects.txt
+++ b/tests/cmd/check-spelling/data/projects.txt
@@ -61,6 +61,7 @@ Minikube/B
 MITRE/B
 musl/B
 Netlify/B
+nydus/B		# Nydus image, container image format (e.g. guest-pull)
 Nginx/B
 OpenCensus/B
 OpenPGP/B

--- a/tests/cmd/check-spelling/kata-dictionary.dic
+++ b/tests/cmd/check-spelling/kata-dictionary.dic
@@ -1,4 +1,4 @@
-417
+418
 ACPI/AB
 ACS/AB
 API/AB
@@ -316,6 +316,7 @@ nodeSelector/B
 nodeSelectors/B
 nv/AB
 nvidia/A
+nydus/B
 onwards
 openSUSE/B
 openshift/B


### PR DESCRIPTION
Add a nydus guest-pull limitation explaining that specifying runAsUser, runAsGroup, and supplementalGroups is required.