### PR TITLE
WIP: runtime: Set disable_guest_empty_dir = true by default

### DIFF
--- a/src/runtime/Makefile
+++ b/src/runtime/Makefile
@@ -224,7 +224,7 @@ DEFBRIDGES := 1
 DEFENABLEANNOTATIONS := [\"enable_iommu\", \"virtio_fs_extra_args\", \"kernel_params\", \"kernel_verity_params\"]
 DEFENABLEANNOTATIONS_COCO := [\"enable_iommu\", \"virtio_fs_extra_args\", \"kernel_params\", \"kernel_verity_params\", \"default_vcpus\", \"default_memory\", \"cc_init_data\"]
 DEFDISABLEGUESTSECCOMP := true
-DEFDISABLEGUESTEMPTYDIR := false
+DEFDISABLEGUESTEMPTYDIR ?= true
 #Default experimental features enabled
 DEFAULTEXPFEATURES := []
 

--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -152,7 +152,7 @@
         }
     },
     "volumes": {
-        "emptyDir": {
+        "emptyDir_sandbox_local": {
             "mount_type": "local",
             "mount_source": "^$(cpath)/$(sandbox-id)/rootfs/local/",
             "mount_point": "^$(cpath)/$(sandbox-id)/rootfs/local/",
@@ -161,6 +161,19 @@
             "fstype": "local",
             "options": [
                 "mode=0777"
+            ]
+        },
+        "emptyDir_bundle_bind": {
+            "mount_type": "bind",
+            "mount_source": "$(sfprefix)",
+            "mount_point": "$(sfprefix)",
+            "driver": "local",
+            "source": "local",
+            "fstype": "bind",
+            "options": [
+                "rbind",
+                "rprivate",
+                "ro"
             ]
         },
         "emptyDir_memory": {
@@ -310,7 +323,8 @@
     },
     "kata_config": {
         "oci_version": "1.1.0",
-        "enable_configmap_secret_storages": false
+        "enable_configmap_secret_storages": false,
+        "emptydir_type": "sandbox-local"
     },
     "cluster_config": {
         "pause_container_image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",

--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -324,7 +324,7 @@
     "kata_config": {
         "oci_version": "1.1.0",
         "enable_configmap_secret_storages": false,
-        "emptydir_type": "sandbox-local"
+        "emptydir_type": "bundle-bind"
     },
     "cluster_config": {
         "pause_container_image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",

--- a/src/tools/genpolicy/src/mount_and_storage.rs
+++ b/src/tools/genpolicy/src/mount_and_storage.rs
@@ -114,16 +114,12 @@ pub fn get_mount_and_storage(
 
     if let Some(emptyDir) = &yaml_volume.emptyDir {
         let settings_volumes = &settings.volumes;
-        let mut volume: Option<&settings::EmptyDirVolume> = None;
+        let mut volume = &settings_volumes.emptyDir;
 
         if let Some(medium) = &emptyDir.medium {
             if medium == "Memory" {
-                volume = Some(&settings_volumes.emptyDir_memory);
+                volume = &settings_volumes.emptyDir_memory;
             }
-        }
-
-        if volume.is_none() {
-            volume = Some(&settings_volumes.emptyDir);
         }
 
         get_empty_dir_mount_and_storage(
@@ -131,7 +127,7 @@ pub fn get_mount_and_storage(
             p_mounts,
             storages,
             yaml_mount,
-            volume.unwrap(),
+            volume,
             pod_security_context,
         );
     } else if yaml_volume.persistentVolumeClaim.is_some() || yaml_volume.azureFile.is_some() {

--- a/src/tools/genpolicy/src/mount_and_storage.rs
+++ b/src/tools/genpolicy/src/mount_and_storage.rs
@@ -114,20 +114,45 @@ pub fn get_mount_and_storage(
 
     if let Some(emptyDir) = &yaml_volume.emptyDir {
         let settings_volumes = &settings.volumes;
-        let mut volume = &settings_volumes.emptyDir;
+        let emptydir_config = &settings.kata_config.emptydir_type;
+
+        let (mut settings_volume, mut mount_source_name, mut add_kata_storage) =
+            match emptydir_config.as_str() {
+                "sandbox-local" => {
+                    if yaml_mount.subPathExpr.is_some() {
+                        let volume = &settings_volumes.emptyDir_bundle_bind;
+                        let file_name = Path::new(&yaml_mount.mountPath).file_name().unwrap();
+                        let source_name = OsString::from(file_name).into_string().unwrap();
+                        (volume, source_name, false)
+                    } else {
+                        let volume = &settings_volumes.emptyDir_sandbox_local;
+                        (volume, yaml_mount.name.clone(), true)
+                    }
+                }
+                "bundle-bind" => {
+                    let volume = &settings_volumes.emptyDir_bundle_bind;
+                    let file_name = Path::new(&yaml_mount.mountPath).file_name().unwrap();
+                    let source_name = OsString::from(file_name).into_string().unwrap();
+                    (volume, source_name, false)
+                }
+                _ => panic!("Unsupported emptydir settings value: {emptydir_config}"),
+            };
 
         if let Some(medium) = &emptyDir.medium {
             if medium == "Memory" {
-                volume = &settings_volumes.emptyDir_memory;
+                settings_volume = &settings_volumes.emptyDir_memory;
+                mount_source_name = yaml_mount.name.clone();
+                add_kata_storage = true;
             }
         }
 
         get_empty_dir_mount_and_storage(
-            settings,
             p_mounts,
             storages,
             yaml_mount,
-            volume,
+            settings_volume,
+            &mount_source_name,
+            add_kata_storage,
             pod_security_context,
         );
     } else if yaml_volume.persistentVolumeClaim.is_some() || yaml_volume.azureFile.is_some() {
@@ -146,16 +171,17 @@ pub fn get_mount_and_storage(
 }
 
 fn get_empty_dir_mount_and_storage(
-    settings: &settings::Settings,
     p_mounts: &mut Vec<policy::KataMount>,
     storages: &mut Vec<agent::Storage>,
     yaml_mount: &pod::VolumeMount,
     settings_empty_dir: &settings::EmptyDirVolume,
+    mount_source_name: &str,
+    add_kata_storage: bool,
     pod_security_context: &Option<pod::PodSecurityContext>,
 ) {
     debug!("Settings emptyDir: {:?}", settings_empty_dir);
 
-    if yaml_mount.subPathExpr.is_none() {
+    if add_kata_storage {
         let mut options = settings_empty_dir.options.clone();
         if let Some(gid) = pod_security_context.as_ref().and_then(|sc| sc.fsGroup) {
             // This matches the runtime behavior of only setting the fsgid if the mountpoint GID is not 0.
@@ -176,20 +202,7 @@ fn get_empty_dir_mount_and_storage(
         });
     }
 
-    let source = if yaml_mount.subPathExpr.is_some() {
-        let file_name = Path::new(&yaml_mount.mountPath).file_name().unwrap();
-        let name = OsString::from(file_name).into_string().unwrap();
-        format!("{}{name}$", &settings.volumes.configMap.mount_source)
-    } else {
-        format!("{}{}$", &settings_empty_dir.mount_source, &yaml_mount.name)
-    };
-
-    let mount_type = if yaml_mount.subPathExpr.is_some() {
-        "bind"
-    } else {
-        &settings_empty_dir.mount_type
-    };
-
+    let source = format!("{}{mount_source_name}$", &settings_empty_dir.mount_source);
     let access = match yaml_mount.readOnly {
         Some(true) => {
             debug!("setting read only access for emptyDir mount");
@@ -200,7 +213,7 @@ fn get_empty_dir_mount_and_storage(
 
     p_mounts.push(policy::KataMount {
         destination: yaml_mount.mountPath.to_string(),
-        type_: mount_type.to_string(),
+        type_: settings_empty_dir.mount_type.to_string(),
         source,
         options: vec![
             "rbind".to_string(),

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -33,7 +33,8 @@ pub struct Settings {
 /// Volume settings loaded from genpolicy-settings.json.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Volumes {
-    pub emptyDir: EmptyDirVolume,
+    pub emptyDir_sandbox_local: EmptyDirVolume,
+    pub emptyDir_bundle_bind: EmptyDirVolume,
     pub emptyDir_memory: EmptyDirVolume,
     pub configMap: ConfigMapVolume,
     pub image_volume: ImageVolume,
@@ -79,6 +80,12 @@ pub struct ImageVolume {
 pub struct KataConfig {
     pub oci_version: String,
     pub enable_configmap_secret_storages: bool,
+
+    /// Supported values:
+    ///
+    /// "sandbox-local" - For Kata Containers using disable_guest_empty_dir = false.
+    /// "host-bundle" - For Kata Containers using disable_guest_empty_dir = true.
+    pub emptydir_type: String,
 }
 
 /// Drop-ins in genpolicy-settings.d/ must be RFC 6902 JSON Patch documents (JSON array of

--- a/tests/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
@@ -12,7 +12,8 @@ spec:
   initContainers:
   - name: first
     image: quay.io/prometheus/busybox:latest
-    command: [ "sh", "-c", "echo ${EPOCHREALTIME//.} > /volume/initContainer" ]
+    # TODO: remove this sleep command after fixing https://github.com/kata-containers/kata-containers/issues/12589
+    command: [ "sh", "-c", "sleep 1s ; echo ${EPOCHREALTIME//.} > /volume/initContainer" ]
     volumeMounts:
       - mountPath: /volume
         name: volume


### PR DESCRIPTION
This makes the runtime share the host Kubelet emptyDir folder with the guest instead of the agent creating an empty folder in the container rootfs. Doing so enables the Kubelet to track emptyDir usage and evict greedy pods.

In other words, with virtio-fs the container rootfs uses host storage whether this is true or false, however with true, Kata uses the k8s emptyDir folder so the sizeLimit is properly enforced by k8s.
