### PR TITLE
rootfs: nvidia: restore libcuda.so.1 symlink

### DIFF
--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -210,7 +210,16 @@ chisseled_compute() {
 
 	libdir=usr/lib/"${machine_arch}"-linux-gnu
 	cp -a "${stage_one}/${libdir}"/libnvidia-ml.so.*  lib/"${machine_arch}"-linux-gnu/.
-	cp -a "${stage_one}/${libdir}"/libcuda.so.*       lib/"${machine_arch}"-linux-gnu/.
+	# Copy libcuda.so.${driver_version} and link libcuda.so.1 to it
+	local driver_version="" libcuda_real="" libcuda_so_name="" dest_lib
+	dest_lib="lib/${machine_arch}-linux-gnu"
+	[[ "${NVIDIA_GPU_STACK}" =~ driver=([^,]+) ]] || die "NVIDIA_GPU_STACK must contain driver=VERSION (e.g. driver=550)"
+	driver_version="${BASH_REMATCH[1]}"
+	libcuda_real=$(find "${stage_one}/${libdir}" -maxdepth 1 -name "libcuda.so.${driver_version}*" -type f 2>/dev/null | head -1)
+	[[ -n "${libcuda_real}" ]] || die "could not find libcuda.so.${driver_version}* in ${stage_one}/${libdir}"
+	libcuda_so_name=$(basename "${libcuda_real}")
+	cp -a "${libcuda_real}" "${dest_lib}/."
+	ln -sf "${libcuda_so_name}" "${dest_lib}/libcuda.so.1"
 	cp -a "${stage_one}/${libdir}"/libnvidia-cfg.so.* lib/"${machine_arch}"-linux-gnu/.
 
 	# basic GPU admin tools


### PR DESCRIPTION
In kata-deploy 3.24.0 the GPU rootfs exposed libcuda.so.1 as a symlink to the versioned library (e.g. libcuda.so.580.95.05) under /usr/lib/x86_64-linux-gnu/, and clients could set LD_LIBRARY_PATH to that location and get the CUDA version matching the guest kernel driver.

From 3.25.0 onwards this symlink was no longer present, so CUDA apps fell back to the container image libcuda and failed; nvidia-smi from the rootfs was also affected.

Let's fix it by explicitly copying the real
libcuda.so.${driver_version}* from stage_one and creating libcuda.so.1 -> libcuda.so.${driver_version}.* in the chiselled rootfs.

Regression reported by Landon (@LandonTClipp).