### PR TITLE
workflow: Update actionlint workflows

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -28,3 +28,9 @@ self-hosted-runner:
     - s390x-large
     - tdx
     - ubuntu-24.04-arm
+
+paths:
+  .github/workflows/**/*.{yml,yaml}:
+    ignore:
+      # We use if: false to "temporarily" skip jobs with issues
+      - 'constant expression "false" in condition'

--- a/.github/workflows/actionlint.yaml
+++ b/.github/workflows/actionlint.yaml
@@ -13,18 +13,13 @@ concurrency:
 jobs:
   run-actionlint:
     name: run-actionlint
-    env:
-      GH_TOKEN: ${{ github.token }}
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout the code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Install actionlint gh extension
-        run: gh extension install https://github.com/cschleiden/gh-actionlint
-
       - name: Run actionlint
-        run:  gh actionlint
+        uses: raven-actions/actionlint@e01d1ea33dd6a5ed517d95b4c0c357560ac6f518  # v2.1.1


### PR DESCRIPTION
The actionlint gh extension is outdated and the wrapping seems unnecessary when there is a github action that seems to be maintained, so let's update to use that