### PR TITLE
agent-genpolicy: read bundle-id from OCI spec rootfs

### DIFF
--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/generate_name/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/generate_name/testcases.json
@@ -6,7 +6,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
           "io.kubernetes.cri.container-type": "sandbox",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -128,7 +128,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": true
         },
         "Version": "1.1.0"
@@ -142,7 +142,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
           "io.kubernetes.cri.container-type": "sandbox",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -264,7 +264,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": true
         },
         "Version": "1.1.0"

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/testcases.json
@@ -9,7 +9,7 @@
         "Annotations": {
           "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
           "cdi.k8s.io/vfio2": "nvidia.com/gpu=1",
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -73,7 +73,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -115,7 +115,7 @@
         "Annotations": {
           "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
           "cdi.k8s.io/vfio3": "nvidia.com/gpu=2",
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -179,7 +179,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -219,7 +219,7 @@
       "type": "CreateContainer",
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -283,7 +283,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -325,7 +325,7 @@
         "Annotations": {
           "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
           "cdi.k8s.io/vfioABC": "nvidia.com/gpu=1",
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -389,7 +389,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -431,7 +431,7 @@
         "Annotations": {
           "cdi.k8s.io/vfio1": "invalid-format",
           "cdi.k8s.io/vfio2": "nvidia.com/gpu=1",
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -495,7 +495,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -536,7 +536,7 @@
       "OCI": {
         "Annotations": {
           "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -600,7 +600,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -642,7 +642,7 @@
         "Annotations": {
           "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
           "cdi.k8s.io/vfio3": "nvidia.com/gpu=1",
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -706,7 +706,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -748,7 +748,7 @@
         "Annotations": {
           "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
           "cdi.k8s.io/vfio2": "nvidia.com/gpu=1",
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -812,7 +812,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -854,7 +854,7 @@
         "Annotations": {
           "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
           "cdi.k8s.io/vfio2": "nvidia.com/gpu=1",
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -918,7 +918,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -944,7 +944,7 @@
       "OCI": {
         "Annotations": {
           "cdi.k8s.io/vfio1": "nvidia.com/gpu=0",
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -1008,7 +1008,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null
@@ -1033,7 +1033,7 @@
       "type": "CreateContainer",
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gpu-container",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "gpu-container",
           "io.kubernetes.cri.container-type": "container",
@@ -1097,7 +1097,7 @@
           "Terminal": false,
           "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
         },
-        "Root": {"Path": "/run/kata-containers/gpu-container/rootfs", "Readonly": false},
+        "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
         "Version": "1.1.0",
         "Windows": null

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/network_namespace/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/network_namespace/testcases.json
@@ -6,7 +6,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
           "io.kubernetes.cri.container-type": "sandbox",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -128,7 +128,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": true
         },
         "Version": "1.1.0"
@@ -142,7 +142,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
           "io.kubernetes.cri.container-type": "sandbox",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -264,7 +264,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": true
         },
         "Version": "1.1.0"
@@ -278,7 +278,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
           "io.kubernetes.cri.container-type": "sandbox",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -396,7 +396,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": true
         },
         "Version": "1.1.0"
@@ -410,7 +410,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
           "io.kubernetes.cri.container-type": "sandbox",
           "io.kubernetes.cri.sandbox-id": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -532,7 +532,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": true
         },
         "Version": "1.1.0"

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/runas/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/runas/testcases.json
@@ -254,7 +254,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/dummy",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -411,7 +411,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-c26fcab88aa5d50b-data",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-c26fcab88aa5d50b-data",
             "type_": "bind"
           },
           {
@@ -421,7 +421,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-d62fcc4f2e8b5659-node-conf",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-d62fcc4f2e8b5659-node-conf",
             "type_": "bind"
           },
           {
@@ -431,7 +431,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-dc49e1ba3ec278c5-hosts",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-dc49e1ba3ec278c5-hosts",
             "type_": "bind"
           },
           {
@@ -441,7 +441,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-2e8b2725e7ce6844-termination-log",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-2e8b2725e7ce6844-termination-log",
             "type_": "bind"
           },
           {
@@ -451,7 +451,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-717ad4c50963e851-hostname",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-717ad4c50963e851-hostname",
             "type_": "bind"
           },
           {
@@ -461,7 +461,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-d8f5f7c88a297469-resolv.conf",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-d8f5f7c88a297469-resolv.conf",
             "type_": "bind"
           },
           {
@@ -479,7 +479,7 @@
               "rprivate",
               "ro"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-4db7c43db401ed9e-serviceaccount",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-4db7c43db401ed9e-serviceaccount",
             "type_": "bind"
           }
         ],
@@ -570,7 +570,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/dummy/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Solaris": null,

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/supplemental_groups/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/supplemental_groups/testcases.json
@@ -6,7 +6,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/dummy",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -163,7 +163,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-c26fcab88aa5d50b-data",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-c26fcab88aa5d50b-data",
             "type_": "bind"
           },
           {
@@ -173,7 +173,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-d62fcc4f2e8b5659-node-conf",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-d62fcc4f2e8b5659-node-conf",
             "type_": "bind"
           },
           {
@@ -183,7 +183,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-dc49e1ba3ec278c5-hosts",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-dc49e1ba3ec278c5-hosts",
             "type_": "bind"
           },
           {
@@ -193,7 +193,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-2e8b2725e7ce6844-termination-log",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-2e8b2725e7ce6844-termination-log",
             "type_": "bind"
           },
           {
@@ -203,7 +203,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-717ad4c50963e851-hostname",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-717ad4c50963e851-hostname",
             "type_": "bind"
           },
           {
@@ -213,7 +213,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-d8f5f7c88a297469-resolv.conf",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-d8f5f7c88a297469-resolv.conf",
             "type_": "bind"
           },
           {
@@ -231,7 +231,7 @@
               "rprivate",
               "ro"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-4db7c43db401ed9e-serviceaccount",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-4db7c43db401ed9e-serviceaccount",
             "type_": "bind"
           }
         ],
@@ -324,7 +324,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/dummy/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Solaris": null,
@@ -340,7 +340,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/dummy",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -497,7 +497,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-c26fcab88aa5d50b-data",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-c26fcab88aa5d50b-data",
             "type_": "bind"
           },
           {
@@ -507,7 +507,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-d62fcc4f2e8b5659-node-conf",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-d62fcc4f2e8b5659-node-conf",
             "type_": "bind"
           },
           {
@@ -517,7 +517,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-dc49e1ba3ec278c5-hosts",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-dc49e1ba3ec278c5-hosts",
             "type_": "bind"
           },
           {
@@ -527,7 +527,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-2e8b2725e7ce6844-termination-log",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-2e8b2725e7ce6844-termination-log",
             "type_": "bind"
           },
           {
@@ -537,7 +537,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-717ad4c50963e851-hostname",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-717ad4c50963e851-hostname",
             "type_": "bind"
           },
           {
@@ -547,7 +547,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-d8f5f7c88a297469-resolv.conf",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-d8f5f7c88a297469-resolv.conf",
             "type_": "bind"
           },
           {
@@ -565,7 +565,7 @@
               "rprivate",
               "ro"
             ],
-            "source": "/run/kata-containers/shared/containers/dummy-4db7c43db401ed9e-serviceaccount",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-4db7c43db401ed9e-serviceaccount",
             "type_": "bind"
           }
         ],
@@ -659,7 +659,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/dummy/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Solaris": null,

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/testcases.json
@@ -6,7 +6,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -126,7 +126,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/testcases.json
@@ -6,7 +6,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "redis",
           "io.kubernetes.cri.container-type": "container",
@@ -67,7 +67,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/bundle-id-a1b2c3d4e5f6g7h8-data",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-a1b2c3d4e5f6g7h8-data",
             "type_": "bind"
           },
           {
@@ -77,7 +77,7 @@
               "rprivate",
               "rw"
             ],
-            "source": "/run/kata-containers/shared/containers/bundle-id-a1b2c3d4e5f6g7h8-node-conf",
+            "source": "/run/kata-containers/shared/containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855-a1b2c3d4e5f6g7h8-node-conf",
             "type_": "bind"
           }
         ],
@@ -116,7 +116,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
@@ -6,7 +6,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -159,7 +159,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"
@@ -219,7 +219,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -352,7 +352,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"
@@ -412,7 +412,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -555,7 +555,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"
@@ -615,7 +615,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -742,7 +742,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"
@@ -802,7 +802,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -945,7 +945,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"
@@ -959,7 +959,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -1102,7 +1102,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"
@@ -1116,7 +1116,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -1289,7 +1289,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"
@@ -1349,7 +1349,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -1482,7 +1482,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"
@@ -1542,7 +1542,7 @@
     "request": {
       "OCI": {
         "Annotations": {
-          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/bundle-id",
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "io.katacontainers.pkg.oci.container_type": "pod_container",
           "io.kubernetes.cri.container-name": "dummy",
           "io.kubernetes.cri.container-type": "container",
@@ -1675,7 +1675,7 @@
           }
         },
         "Root": {
-          "Path": "/run/kata-containers/bundle-id/rootfs",
+          "Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs",
           "Readonly": false
         },
         "Version": "1.1.0"


### PR DESCRIPTION
The host path of bundles is not portable and could be literally anything
depending on containerd configuration, so we can't rely on a specific
prefix when deriving the bundle-id. Instead, we derive the bundle-id
from the target root path in the guest.

NOTE: fixes https://github.com/kata-containers/kata-containers/issues/10065

@burgerdev, I want you to take a look at this one, as it's not what you have downstream as-is.
@danmihai1, I want you to take a look at this one, as you may have some other approach in mind. One thing that I also considered is a drop-in setting that could override the base path, and we could provide it for different k8s distributions.

These 2 were tested as part of: https://github.com/kata-containers/kata-containers/actions/runs/22440446679

I will open a PR adding a nightly test that can cover different k8s distributions later on, as I'm still putting all the pieces together in order to ensure we can have something that works for all of those (or I will drop the ones that have limitations ... currently working on k0s, but the failures there are **NOT** related to the policies, at least not at the first look).