### PR TITLE
kata-agent: Decouple guest-components with kata-agent

### DIFF
--- a/src/agent/src/confidential_data_hub/mod.rs
+++ b/src/agent/src/confidential_data_hub/mod.rs
@@ -9,8 +9,9 @@
 // https://github.com/confidential-containers/guest-components/tree/main/confidential-data-hub
 
 use crate::AGENT_CONFIG;
+use anyhow::anyhow;
 use anyhow::{bail, Context, Result};
-use derivative::Derivative;
+use futures::{stream::FuturesUnordered, StreamExt};
 use protocols::{
     confidential_data_hub,
     confidential_data_hub::GetResourceRequest,
@@ -21,16 +22,17 @@ use protocols::{
     },
 };
 use safe_path::scoped_join;
-use std::fs;
+use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, Read};
 use std::path::Path;
+use std::{fmt, fs};
 use std::{os::unix::fs::symlink, path::PathBuf};
 use tokio::sync::OnceCell;
+use tokio::time::timeout;
+use ttrpc::asynchronous::Client as TtrpcClient;
 
 pub mod image;
-
-pub static CDH_CLIENT: OnceCell<CDHClient> = OnceCell::const_new();
 
 const SEALED_SECRET_PREFIX: &str = "sealed.";
 
@@ -39,126 +41,206 @@ fn sl() -> slog::Logger {
     slog_scope::logger().new(o!("subsystem" => "cdh"))
 }
 
-#[derive(Derivative)]
-#[derivative(Clone, Debug)]
-pub struct CDHClient {
-    #[derivative(Debug = "ignore")]
-    sealed_secret_client: SealedSecretServiceClient,
-    #[derivative(Debug = "ignore")]
-    secure_mount_client: SecureMountServiceClient,
-    #[derivative(Debug = "ignore")]
-    get_resource_client: GetResourceServiceClient,
-    #[derivative(Debug = "ignore")]
-    image_pull_client: ImagePullServiceClient,
-}
+pub static CDH_MULTI_CLIENTS: OnceCell<MultiCdhClients> = OnceCell::const_new();
 
-impl CDHClient {
-    pub fn new(cdh_socket_uri: &str) -> Result<Self> {
-        let client = ttrpc::asynchronous::Client::connect(cdh_socket_uri)?;
-        let sealed_secret_client =
-            confidential_data_hub_ttrpc_async::SealedSecretServiceClient::new(client.clone());
-        let image_pull_client =
-            confidential_data_hub_ttrpc_async::ImagePullServiceClient::new(client.clone());
-        let secure_mount_client =
-            confidential_data_hub_ttrpc_async::SecureMountServiceClient::new(client.clone());
-        let get_resource_client =
-            confidential_data_hub_ttrpc_async::GetResourceServiceClient::new(client);
-        Ok(CDHClient {
-            sealed_secret_client,
-            secure_mount_client,
-            get_resource_client,
-            image_pull_client,
-        })
-    }
-
-    pub async fn unseal_secret_async(&self, sealed_secret: &str) -> Result<Vec<u8>> {
-        let mut input = confidential_data_hub::UnsealSecretInput::new();
-        input.set_secret(sealed_secret.into());
-
-        let unsealed_secret = self
-            .sealed_secret_client
-            .unseal_secret(
-                ttrpc::context::with_timeout(AGENT_CONFIG.cdh_api_timeout.as_nanos() as i64),
-                &input,
-            )
-            .await?;
-        Ok(unsealed_secret.plaintext)
-    }
-
-    pub async fn secure_mount(
-        &self,
-        volume_type: &str,
-        options: &std::collections::HashMap<String, String>,
-        flags: Vec<String>,
-        mount_point: &str,
-    ) -> Result<()> {
-        let req = confidential_data_hub::SecureMountRequest {
-            volume_type: volume_type.to_string(),
-            options: options.clone(),
-            flags,
-            mount_point: mount_point.to_string(),
-            ..Default::default()
-        };
-        self.secure_mount_client
-            .secure_mount(
-                ttrpc::context::with_timeout(AGENT_CONFIG.cdh_api_timeout.as_nanos() as i64),
-                &req,
-            )
-            .await?;
-        Ok(())
-    }
-
-    pub async fn get_resource(&self, resource_path: &str) -> Result<Vec<u8>> {
-        let req = GetResourceRequest {
-            ResourcePath: format!("kbs://{resource_path}"),
-            ..Default::default()
-        };
-        let res = self
-            .get_resource_client
-            .get_resource(
-                ttrpc::context::with_timeout(AGENT_CONFIG.cdh_api_timeout.as_nanos() as i64),
-                &req,
-            )
-            .await?;
-        Ok(res.Resource)
-    }
-
-    pub async fn pull_image(&self, image: &str, bundle_path: &str) -> Result<()> {
-        let req = confidential_data_hub::ImagePullRequest {
-            image_url: image.to_string(),
-            bundle_path: bundle_path.to_string(),
-            ..Default::default()
-        };
-
-        let _ = self
-            .image_pull_client
-            .pull_image(
-                ttrpc::context::with_timeout(AGENT_CONFIG.image_pull_timeout.as_nanos() as i64),
-                &req,
-            )
-            .await?;
-
-        Ok(())
-    }
-}
-
-pub async fn init_cdh_client(cdh_socket_uri: &str) -> Result<()> {
-    CDH_CLIENT
+pub async fn init_multi_cdh_clients() -> Result<()> {
+    CDH_MULTI_CLIENTS
         .get_or_try_init(|| async {
-            CDHClient::new(cdh_socket_uri).context("Failed to create CDH Client")
+            let mgr = MultiCdhClientsManager::new().await?;
+            mgr.probe().await?;
+            MultiCdhClients::new(&mgr)
         })
         .await?;
-
     Ok(())
 }
 
 /// Check if the CDH client is initialized
-pub fn is_cdh_client_initialized() -> bool {
-    CDH_CLIENT.get().is_some() // Returns true if CDH_CLIENT is initialized, false otherwise
+pub fn is_multi_cdh_clients_initialized() -> bool {
+    CDH_MULTI_CLIENTS.get().is_some()
+}
+
+#[macro_export]
+macro_rules! skip_if_cdh_client_uninitialized {
+    // return Ok(())
+    () => {{
+        $crate::skip_if_cdh_client_uninitialized!(());
+    }};
+
+    // return Ok($ret)
+    ($ret:expr) => {{
+        if !$crate::confidential_data_hub::is_multi_cdh_clients_initialized() {
+            eprintln!(
+                "INFO: skipping {} because CDH_MULTI_CLIENTS is not initialized",
+                module_path!()
+            );
+            return Ok($ret);
+        }
+    }};
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Service {
+    ImagePull,
+    SealedSecrets,
+    SecureMount,
+    GetResource,
+}
+
+impl Service {
+    pub fn socket_path(&self) -> &'static str {
+        match self {
+            Service::ImagePull => "/run/guest-services/imagepull.socket",
+            Service::SealedSecrets => "/run/guest-services/sealedsecrets.socket",
+            Service::SecureMount => "/run/guest-services/securemount.socket",
+            Service::GetResource => "/run/guest-services/getresource.socket",
+        }
+    }
+}
+
+impl fmt::Display for Service {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        match self {
+            Service::ImagePull => write!(f, "imagepull"),
+            Service::SealedSecrets => write!(f, "sealedsecrets"),
+            Service::SecureMount => write!(f, "securemount"),
+            Service::GetResource => write!(f, "getresource"),
+        }
+    }
+}
+
+const REQUIRED_SERVICES: &[Service] = &[
+    Service::GetResource,
+    Service::ImagePull,
+    Service::SealedSecrets,
+    Service::SecureMount,
+];
+
+#[derive(Clone)]
+pub struct MultiCdhClientsManager {
+    connections: HashMap<Service, TtrpcClient>,
+}
+
+impl MultiCdhClientsManager {
+    pub async fn new() -> Result<Self> {
+        let mut connections = HashMap::new();
+
+        for svc in [
+            Service::ImagePull,
+            Service::SealedSecrets,
+            Service::SecureMount,
+            Service::GetResource,
+        ] {
+            match Self::connect_to_service(svc).await {
+                Ok(client) => {
+                    info!(
+                        sl(),
+                        "Connected cdh client {} at {}",
+                        svc,
+                        svc.socket_path()
+                    );
+                    connections.insert(svc, client);
+                }
+                Err(e) => {
+                    info!(
+                        sl(),
+                        "Failed to connect cdh client {} at {}: {:#}",
+                        svc,
+                        svc.socket_path(),
+                        e
+                    );
+                }
+            }
+        }
+
+        Ok(Self { connections })
+    }
+
+    async fn connect_to_service(service: Service) -> Result<TtrpcClient> {
+        let socket_path = service.socket_path();
+
+        if !Path::new(socket_path).exists() {
+            return Err(anyhow!("socket path does not exist: {socket_path}"));
+        }
+
+        let sock_addr = format!("unix://{}", socket_path);
+        let client = TtrpcClient::connect(&sock_addr).with_context(|| {
+            format!(
+                "failed to connect to socket '{sock_addr}' (service={})",
+                service
+            )
+        })?;
+
+        Ok(client)
+    }
+
+    pub fn get_client(&self, service: Service) -> Option<&TtrpcClient> {
+        self.connections.get(&service)
+    }
+
+    pub fn has_required_clients_connected(&self) -> Result<()> {
+        let missing: Vec<String> = REQUIRED_SERVICES
+            .iter()
+            .copied()
+            .filter(|s| !self.connections.contains_key(s))
+            .map(|s| s.to_string())
+            .collect();
+
+        if missing.is_empty() {
+            Ok(())
+        } else {
+            Err(anyhow!("missing required cdh clients: {:?}", missing))
+        }
+    }
+
+    pub async fn probe(&self) -> Result<()> {
+        self.has_required_clients_connected()?;
+
+        // Concurrently probe the "RPC reachability" of each service
+        let mut futs = FuturesUnordered::new();
+        for svc in REQUIRED_SERVICES.iter().copied() {
+            futs.push(async move { (svc, self.probe_one(svc).await) });
+        }
+
+        while let Some((svc, res)) = futs.next().await {
+            if let Err(e) = res {
+                return Err(anyhow!("probe {} failed: {:#}", svc, e));
+            }
+        }
+        Ok(())
+    }
+
+    async fn probe_one(&self, svc: Service) -> Result<()> {
+        let t = AGENT_CONFIG.cdh_api_timeout;
+
+        match svc {
+            Service::GetResource => {
+                let client = self.get_client(Service::GetResource).unwrap().clone();
+                let c = confidential_data_hub_ttrpc_async::GetResourceServiceClient::new(client);
+                let req = GetResourceRequest {
+                    ResourcePath: "kbs://__kata_probe__/non-existent".to_string(), // FIXME
+                    ..Default::default()
+                };
+
+                // Regardless of the error details, we consider the service reachable if it responds within the timeout.
+                // The service itself will return an error for the non-existent resource, but that still means the service is up and reachable.
+                let r = timeout(
+                    t,
+                    c.get_resource(ttrpc::context::with_timeout(t.as_nanos() as i64), &req),
+                )
+                .await;
+                match r {
+                    Ok(Ok(_)) => Ok(()),
+                    Ok(Err(_e)) => Ok(()),
+                    Err(_) => Err(anyhow!("timeout after {:?}", t)),
+                }
+            }
+            Service::ImagePull | Service::SealedSecrets | Service::SecureMount => Ok(()),
+        }
+    }
 }
 
 pub async fn unseal_env(env: &str) -> Result<String> {
-    let cdh_client = CDH_CLIENT
+    let cdh_client = CDH_MULTI_CLIENTS
         .get()
         .expect("Confidential Data Hub not initialized");
 
@@ -184,7 +266,7 @@ pub async fn pull_image(image: &str, bundle_path: PathBuf) -> Result<String> {
     fs::create_dir_all(&bundle_path)?;
     info!(sl(), "pull image {image:?}, bundle path {bundle_path:?}");
 
-    let cdh_client = CDH_CLIENT
+    let cdh_client = CDH_MULTI_CLIENTS
         .get()
         .expect("Confidential Data Hub not initialized");
 
@@ -197,7 +279,7 @@ pub async fn pull_image(image: &str, bundle_path: PathBuf) -> Result<String> {
 }
 
 pub async fn unseal_file(path: &str) -> Result<()> {
-    let cdh_client = CDH_CLIENT
+    let cdh_client = CDH_MULTI_CLIENTS
         .get()
         .expect("Confidential Data Hub not initialized");
 
@@ -281,7 +363,7 @@ pub async fn secure_mount(
     flags: Vec<String>,
     mount_point: &str,
 ) -> Result<()> {
-    let cdh_client = CDH_CLIENT
+    let cdh_client = CDH_MULTI_CLIENTS
         .get()
         .expect("Confidential Data Hub not initialized");
 
@@ -293,170 +375,123 @@ pub async fn secure_mount(
 
 #[allow(dead_code)]
 pub async fn get_cdh_resource(resource_path: &str) -> Result<Vec<u8>> {
-    let cdh_client = CDH_CLIENT
+    let cdh_client = CDH_MULTI_CLIENTS
         .get()
         .expect("Confidential Data Hub not initialized");
 
     cdh_client.get_resource(resource_path).await
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use async_trait::async_trait;
-    use std::fs::File;
-    use std::io::{Read, Write};
-    use std::sync::Arc;
-    use tempfile::{tempdir, NamedTempFile};
-    use test_utils::skip_if_not_root;
-    use tokio::signal::unix::{signal, SignalKind};
-    struct TestService;
+#[derive(Clone)]
+pub struct MultiCdhClients {
+    sealed_secret_client: SealedSecretServiceClient,
+    secure_mount_client: SecureMountServiceClient,
+    get_resource_client: GetResourceServiceClient,
+    image_pull_client: ImagePullServiceClient,
+}
 
-    #[async_trait]
-    impl confidential_data_hub_ttrpc_async::SealedSecretService for TestService {
-        async fn unseal_secret(
-            &self,
-            _ctx: &::ttrpc::asynchronous::TtrpcContext,
-            _req: confidential_data_hub::UnsealSecretInput,
-        ) -> ttrpc::error::Result<confidential_data_hub::UnsealSecretOutput> {
-            let mut output = confidential_data_hub::UnsealSecretOutput::new();
-            output.set_plaintext("unsealed".into());
-            Ok(output)
-        }
+impl MultiCdhClients {
+    pub fn new(mgr: &MultiCdhClientsManager) -> Result<Self> {
+        // Ensure all required services are connected, otherwise return an error
+        mgr.has_required_clients_connected()?;
+
+        let sealed = mgr
+            .get_client(Service::SealedSecrets)
+            .ok_or_else(|| anyhow!("SealedSecrets service not connected"))?
+            .clone();
+        let secure = mgr
+            .get_client(Service::SecureMount)
+            .ok_or_else(|| anyhow!("SecureMount service not connected"))?
+            .clone();
+        let getres = mgr
+            .get_client(Service::GetResource)
+            .ok_or_else(|| anyhow!("GetResource service not connected"))?
+            .clone();
+        let image = mgr
+            .get_client(Service::ImagePull)
+            .ok_or_else(|| anyhow!("ImagePull service not connected"))?
+            .clone();
+
+        Ok(Self {
+            sealed_secret_client: SealedSecretServiceClient::new(sealed),
+            secure_mount_client: SecureMountServiceClient::new(secure),
+            get_resource_client: GetResourceServiceClient::new(getres),
+            image_pull_client: ImagePullServiceClient::new(image),
+        })
     }
 
-    #[async_trait]
-    impl confidential_data_hub_ttrpc_async::ImagePullService for TestService {
-        async fn pull_image(
-            &self,
-            _ctx: &::ttrpc::asynchronous::TtrpcContext,
-            _req: confidential_data_hub::ImagePullRequest,
-        ) -> ttrpc::error::Result<confidential_data_hub::ImagePullResponse> {
-            let output = confidential_data_hub::ImagePullResponse::new();
-            Ok(output)
-        }
+    pub async fn unseal_secret_async(&self, sealed_secret: &str) -> Result<Vec<u8>> {
+        let mut input = confidential_data_hub::UnsealSecretInput::new();
+        input.set_secret(sealed_secret.into());
+
+        let res = self
+            .sealed_secret_client
+            .unseal_secret(
+                ttrpc::context::with_timeout(AGENT_CONFIG.cdh_api_timeout.as_nanos() as i64),
+                &input,
+            )
+            .await?;
+        Ok(res.plaintext)
     }
 
-    fn remove_if_sock_exist(sock_addr: &str) -> std::io::Result<()> {
-        let path = sock_addr
-            .strip_prefix("unix://")
-            .expect("socket address does not have the expected format.");
+    pub async fn secure_mount(
+        &self,
+        volume_type: &str,
+        options: &std::collections::HashMap<String, String>,
+        flags: Vec<String>,
+        mount_point: &str,
+    ) -> Result<()> {
+        let req = confidential_data_hub::SecureMountRequest {
+            volume_type: volume_type.to_string(),
+            options: options.clone(),
+            flags,
+            mount_point: mount_point.to_string(),
+            ..Default::default()
+        };
 
-        if std::path::Path::new(path).exists() {
-            std::fs::remove_file(path)?;
-        }
-
+        self.secure_mount_client
+            .secure_mount(
+                ttrpc::context::with_timeout(AGENT_CONFIG.cdh_api_timeout.as_nanos() as i64),
+                &req,
+            )
+            .await?;
         Ok(())
     }
 
-    fn start_ttrpc_server(cdh_socket_uri: String) {
-        tokio::spawn(async move {
-            let ss = Box::new(TestService {});
-            let ss = Arc::new(*ss);
-            let ss_service = confidential_data_hub_ttrpc_async::create_sealed_secret_service(ss);
+    pub async fn get_resource(&self, resource_path: &str) -> Result<Vec<u8>> {
+        let req = GetResourceRequest {
+            ResourcePath: format!("kbs://{resource_path}"),
+            ..Default::default()
+        };
 
-            remove_if_sock_exist(&cdh_socket_uri).unwrap();
-
-            let mut server = ttrpc::asynchronous::Server::new()
-                .bind(&cdh_socket_uri)
-                .unwrap()
-                .register_service(ss_service);
-
-            server.start().await.unwrap();
-
-            let mut interrupt = signal(SignalKind::interrupt()).unwrap();
-            tokio::select! {
-                _ = interrupt.recv() => {
-                    server.shutdown().await.unwrap();
-                }
-            };
-        });
+        let res = self
+            .get_resource_client
+            .get_resource(
+                ttrpc::context::with_timeout(AGENT_CONFIG.cdh_api_timeout.as_nanos() as i64),
+                &req,
+            )
+            .await?;
+        Ok(res.Resource)
     }
 
-    #[tokio::test]
-    async fn test_sealed_secret() {
-        skip_if_not_root!();
-        let test_dir = tempdir().expect("failed to create tmpdir");
-        let test_dir_path = test_dir.path();
-        let cdh_sock_uri = &format!(
-            "unix://{}",
-            test_dir_path.join("cdh.sock").to_str().unwrap()
-        );
+    pub async fn pull_image(&self, image: &str, bundle_path: &str) -> Result<()> {
+        let req = confidential_data_hub::ImagePullRequest {
+            image_url: image.to_string(),
+            bundle_path: bundle_path.to_string(),
+            ..Default::default()
+        };
 
-        let rt = tokio::runtime::Runtime::new().unwrap();
-        let _guard = rt.enter();
-        start_ttrpc_server(cdh_sock_uri.to_string());
-        std::thread::sleep(std::time::Duration::from_secs(2));
-        init_cdh_client(cdh_sock_uri).await.unwrap();
-
-        // Test sealed secret as env vars
-        let sealed_env = String::from("key=sealed.testdata");
-        let unsealed_env = unseal_env(&sealed_env).await.unwrap();
-        assert_eq!(unsealed_env, String::from("key=unsealed"));
-        let normal_env = String::from("key=testdata");
-        let unchanged_env = unseal_env(&normal_env).await.unwrap();
-        assert_eq!(unchanged_env, String::from("key=testdata"));
-
-        // Test sealed secret as files
-        let sealed_dir = test_dir_path.join("..test");
-        fs::create_dir(&sealed_dir).unwrap();
-        let sealed_filename = sealed_dir.join("secret");
-        let mut sealed_file = File::create(sealed_filename.clone()).unwrap();
-        sealed_file.write_all(b"sealed.testdata").unwrap();
-        let secret_symlink = test_dir_path.join("secret");
-        symlink(&sealed_filename, &secret_symlink).unwrap();
-
-        unseal_file(test_dir_path.to_str().unwrap()).await.unwrap();
-
-        let unsealed_filename = test_dir_path.join("secret");
-        let mut unsealed_file = File::open(unsealed_filename.clone()).unwrap();
-        let mut contents = String::new();
-        unsealed_file.read_to_string(&mut contents).unwrap();
-        assert_eq!(contents, String::from("unsealed"));
-        fs::remove_file(sealed_filename).unwrap();
-        fs::remove_file(unsealed_filename).unwrap();
-
-        let normal_filename = test_dir_path.join("secret");
-        let mut normal_file = File::create(normal_filename.clone()).unwrap();
-        normal_file.write_all(b"testdata").unwrap();
-        unseal_file(test_dir_path.to_str().unwrap()).await.unwrap();
-        let mut contents = String::new();
-        let mut normal_file = File::open(normal_filename.clone()).unwrap();
-        normal_file.read_to_string(&mut contents).unwrap();
-        assert_eq!(contents, String::from("testdata"));
-        fs::remove_file(normal_filename).unwrap();
-
-        rt.shutdown_background();
-        std::thread::sleep(std::time::Duration::from_secs(2));
+        self.image_pull_client
+            .pull_image(
+                ttrpc::context::with_timeout(AGENT_CONFIG.image_pull_timeout.as_nanos() as i64),
+                &req,
+            )
+            .await?;
+        Ok(())
     }
+}
 
-    #[tokio::test]
-    async fn test_content_starts_with_prefix() {
-        // Normal case: content matches the prefix
-        let mut f = NamedTempFile::new().unwrap();
-        write!(f, "sealed.hello_world").unwrap();
-        assert!(content_starts_with_prefix(f.path(), "sealed.")
-            .await
-            .unwrap());
-
-        // Does not match the prefix
-        let mut f2 = NamedTempFile::new().unwrap();
-        write!(f2, "notsealed.hello_world").unwrap();
-        assert!(!content_starts_with_prefix(f2.path(), "sealed.")
-            .await
-            .unwrap());
-
-        // File length < prefix.len()
-        let mut f3 = NamedTempFile::new().unwrap();
-        write!(f3, "seal").unwrap();
-        assert!(!content_starts_with_prefix(f3.path(), "sealed.")
-            .await
-            .unwrap());
-
-        // Empty file
-        let f4 = NamedTempFile::new().unwrap();
-        assert!(!content_starts_with_prefix(f4.path(), "sealed.")
-            .await
-            .unwrap());
-    }
+#[cfg(test)]
+mod tests {
+    // TODO: add tests for MultiCdhClientsManager and MultiCdhClients
 }

--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -31,7 +31,7 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs::{self, File};
 use std::io::ErrorKind;
-use std::os::unix::fs::{self as unixfs, FileTypeExt};
+use std::os::unix::fs::{self as unixfs};
 use std::os::unix::io::AsRawFd;
 use std::path::Path;
 use std::process::exit;
@@ -103,7 +103,7 @@ const AA_ATTESTATION_URI: &str = concatcp!(UNIX_SOCKET_PREFIX, AA_ATTESTATION_SO
 
 const CDH_PATH: &str = "/usr/local/bin/confidential-data-hub";
 const CDH_SOCKET: &str = "/run/confidential-containers/cdh.sock";
-const CDH_SOCKET_URI: &str = concatcp!(UNIX_SOCKET_PREFIX, CDH_SOCKET);
+//const CDH_SOCKET_URI: &str = concatcp!(UNIX_SOCKET_PREFIX, CDH_SOCKET);
 
 const API_SERVER_PATH: &str = "/usr/local/bin/api-server-rest";
 
@@ -405,16 +405,22 @@ async fn start_sandbox(
     let (tx, rx) = tokio::sync::oneshot::channel();
     sandbox.lock().await.sender = Some(tx);
 
-    let initdata_return_value = initdata::initialize_initdata(logger).await?;
+    init_multi_cdh_clients().await?;
+    // TODO:
+    let initdata_return_value: Option<InitdataReturnValue> = None;
+    {
+        // TODO: will be removed
+        let _initdata_return_value = initdata::initialize_initdata(logger).await?;
 
-    let gc_procs = config.guest_components_procs;
-    if !attestation_binaries_available(logger, &gc_procs) {
-        warn!(
-            logger,
-            "attestation binaries requested for launch not available"
-        );
-    } else {
-        init_attestation_components(logger, config, &initdata_return_value).await?;
+        let gc_procs = config.guest_components_procs;
+        if !attestation_binaries_available(logger, &gc_procs) {
+            warn!(
+                logger,
+                "attestation binaries requested for launch not available"
+            );
+        } else {
+            init_attestation_components(logger, config, &initdata_return_value).await?;
+        }
     }
 
     // if policy is given via initdata, use it
@@ -569,20 +575,20 @@ async fn init_attestation_components(
 ) -> Result<()> {
     launch_guest_component_procs(logger, config, initdata_return_value).await?;
 
-    // If a CDH socket exists, initialize the CDH client and enable ocicrypt
-    match tokio::fs::metadata(CDH_SOCKET).await {
-        Ok(md) => {
-            if md.file_type().is_socket() {
-                confidential_data_hub::init_cdh_client(CDH_SOCKET_URI).await?;
-            } else {
-                debug!(logger, "File {} is not a socket", CDH_SOCKET);
-            }
-        }
-        Err(err) => warn!(
-            logger,
-            "Failed to probe CDH socket file {}: {:?}", CDH_SOCKET, err
-        ),
-    }
+    // // If a CDH socket exists, initialize the CDH client and enable ocicrypt
+    // match tokio::fs::metadata(CDH_SOCKET).await {
+    //     Ok(md) => {
+    //         if md.file_type().is_socket() {
+    //             confidential_data_hub::init_cdh_client(CDH_SOCKET_URI).await?;
+    //         } else {
+    //             debug!(logger, "File {} is not a socket", CDH_SOCKET);
+    //         }
+    //     }
+    //     Err(err) => warn!(
+    //         logger,
+    //         "Failed to probe CDH socket file {}: {:?}", CDH_SOCKET, err
+    //     ),
+    // }
 
     Ok(())
 }
@@ -703,6 +709,7 @@ fn reset_sigpipe() {
     }
 }
 
+use crate::confidential_data_hub::init_multi_cdh_clients;
 use crate::config::AgentConfig;
 use std::os::unix::io::{FromRawFd, RawFd};
 

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -71,7 +71,6 @@ use crate::metrics::get_metrics;
 use crate::mount::baremount;
 use crate::namespace::{NSTYPEIPC, NSTYPEPID, NSTYPEUTS};
 use crate::network::setup_guest_dns;
-use crate::passfd_io;
 use crate::pci;
 use crate::random;
 use crate::sandbox::{Sandbox, SandboxError};
@@ -80,6 +79,7 @@ use crate::util;
 use crate::version::{AGENT_VERSION, API_VERSION};
 use crate::AGENT_CONFIG;
 use crate::{confidential_data_hub, linux_abi::*};
+use crate::{passfd_io, skip_if_cdh_client_uninitialized};
 
 use crate::trace_rpc_call;
 use crate::tracer::extract_carrier_from_ttrpc;
@@ -2308,9 +2308,8 @@ fn is_sealed_secret_path(source_path: &str) -> bool {
 }
 
 async fn cdh_handler_trusted_storage(oci: &mut Spec) -> Result<()> {
-    if !confidential_data_hub::is_cdh_client_initialized() {
-        return Ok(());
-    }
+    skip_if_cdh_client_uninitialized!(());
+
     let linux = oci
         .linux()
         .as_ref()
@@ -2348,9 +2347,8 @@ async fn cdh_handler_trusted_storage(oci: &mut Spec) -> Result<()> {
 }
 
 async fn cdh_handler_sealed_secrets(oci: &mut Spec) -> Result<()> {
-    if !confidential_data_hub::is_cdh_client_initialized() {
-        return Ok(());
-    }
+    skip_if_cdh_client_uninitialized!(());
+
     let process = oci
         .process_mut()
         .as_mut()

--- a/src/agent/systemd-services/Makefile
+++ b/src/agent/systemd-services/Makefile
@@ -1,0 +1,13 @@
+
+.PHONY: systemd-install
+
+PREFIX ?= /usr
+BINDIR ?= $(PREFIX)/bin
+SYSTEMD_DIR ?= /etc/systemd/system
+
+systemd-install:
+	install -D -m 644 guest-components.target $(DESTDIR)$(SYSTEMD_DIR)/guest-components.target
+	install -D -m 644 guest-components-imagepull.service $(DESTDIR)$(SYSTEMD_DIR)/guest-components-imagepull.service
+	install -D -m 644 guest-components-sealedsecrets.service $(DESTDIR)$(SYSTEMD_DIR)/guest-components-sealedsecrets.service
+	install -D -m 644 guest-components-securemount.service $(DESTDIR)$(SYSTEMD_DIR)/guest-components-securemount.service
+	install -D -m 644 guest-components-getresource.service $(DESTDIR)$(SYSTEMD_DIR)/guest-components-getresource.service

--- a/src/agent/systemd-services/guest-components-getresource.service
+++ b/src/agent/systemd-services/guest-components-getresource.service
@@ -1,0 +1,24 @@
+
+# /etc/systemd/system/guest-services-getresource.service
+[Unit]
+Description=Guest Components Get Resource Service
+Documentation=https://github.com/kata-containers/kata-containers
+PartOf=guest-services.target
+Requires=initdata-processor.service
+After=initdata-processor.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/guest-services get-resource --socket /run/guest-services/getresource.sock
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+User=root
+Group=root
+
+RuntimeDirectory=guest-services
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=guest-services.target

--- a/src/agent/systemd-services/guest-components-imagepull.service
+++ b/src/agent/systemd-services/guest-components-imagepull.service
@@ -1,0 +1,24 @@
+# /etc/systemd/system/guest-services-imagepull.service
+[Unit]
+Description=Guest Components Image Pull Service
+Documentation=https://github.com/kata-containers/kata-containers
+PartOf=guest-services.target
+Requires=initdata-processor.service
+After=initdata-processor.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/guest-services image-pull --socket /run/guest-services/imagepull.sock
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+User=root
+Group=root
+
+# Socket configuration
+RuntimeDirectory=guest-services
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=guest-services.target

--- a/src/agent/systemd-services/guest-components-sealedsecrets.service
+++ b/src/agent/systemd-services/guest-components-sealedsecrets.service
@@ -1,0 +1,24 @@
+
+# /etc/systemd/system/guest-services-sealedsecrets.service
+[Unit]
+Description=Guest Components Sealed Secrets Service
+Documentation=https://github.com/kata-containers/kata-containers
+PartOf=guest-services.target
+Requires=initdata-processor.service
+After=initdata-processor.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/guest-services sealed-secrets --socket /run/guest-services/sealedsecrets.sock
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+User=root
+Group=root
+
+RuntimeDirectory=guest-services
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=guest-services.target

--- a/src/agent/systemd-services/guest-components-securemount.service
+++ b/src/agent/systemd-services/guest-components-securemount.service
@@ -1,0 +1,23 @@
+# /etc/systemd/system/guest-services-securemount.service
+[Unit]
+Description=Guest Components Secure Mount Service
+Documentation=https://github.com/kata-containers/kata-containers
+PartOf=guest-services.target
+Requires=initdata-processor.service
+After=initdata-processor.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/guest-services secure-mount --socket /run/guest-services/securemount.sock
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+User=root
+Group=root
+
+RuntimeDirectory=guest-services
+RuntimeDirectoryMode=0755
+
+[Install]
+WantedBy=guest-services.target

--- a/src/agent/systemd-services/guest-components.target
+++ b/src/agent/systemd-services/guest-components.target
@@ -1,0 +1,20 @@
+# /etc/systemd/system/guest-services.target
+[Unit]
+Description=Guest Components Target
+Documentation=https://github.com/kata-containers/kata-containers
+Requires=initdata-processor.service
+After=initdata-processor.service
+
+# target is for four guest components
+Wants=guest-services-imagepull.service
+Wants=guest-services-sealedsecrets.service
+Wants=guest-services-securemount.service
+Wants=guest-services-getresource.service
+
+Requires=guest-services-imagepull.service
+Requires=guest-services-sealedsecrets.service
+Requires=guest-services-securemount.service
+Requires=guest-services-getresource.service
+
+[Install]
+WantedBy=kata-guest-os.target


### PR DESCRIPTION
It's just a draft implementation and it was part of the previous PR #11655. Now it will be splited out from #11655 and becomes one PR to specially handle guest components service. 

And it's now under developed by @Apokleos  and @burgerdev following the plan laid out in https://docs.google.com/document/d/1LEE6p0qL61MUCNQw3fh9dhpFeN-Uv4d4AuOBp4ftK34/edit?usp=sharing.

Fixes #11532