### PR TITLE
docs: Use more accurate wording for /dev hostPath behavior

### DIFF
--- a/docs/Limitations.md
+++ b/docs/Limitations.md
@@ -187,9 +187,10 @@ different compared to `runc` containers:
 into the guest and exposes it directly to the container.
 
 **Mounting guest devices**: When the source path of a hostPath volume is
-under `/dev`, and the path either corresponds to a host device or is not
-accessible by the Kata shim, the Kata agent bind mounts the source path
-directly from the *guest* filesystem into the container.
+under `/dev` (or `/dev` itself), and the path corresponds to a
+non-regular file (i.e., a device, directory, or any other special file)
+or is not accessible by the Kata shim, the Kata agent bind mounts the
+source path directly from the *guest* filesystem into the container.
 
 [runtime-config]: /src/runtime/README.md#configuration
 [k8s-hostpath]: https://kubernetes.io/docs/concepts/storage/volumes/#hostpath


### PR DESCRIPTION
I got lazy when I first added this section in 5c21b1f, so updating the language to specify that any non-regular host file (under /dev) qualifies, not just devices.

This matches the actual code, see:

https://github.com/kata-containers/kata-containers/blob/330bfff4be8913c20b9e887cecae831385131ed1/src/runtime/virtcontainers/mount.go#L57-L83

Likely going to use this trick in the test code of #10559.