### PR TITLE
runtime: Skip to call sandboxDevices() for remote hypervisor

### DIFF
--- a/src/runtime/pkg/resourcecontrol/cgroups.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups.go
@@ -186,13 +186,15 @@ func NewResourceController(path string, resources *specs.LinuxResources) (Resour
 	}, nil
 }
 
-func NewSandboxResourceController(path string, resources *specs.LinuxResources, sandboxCgroupOnly bool) (ResourceController, error) {
+func NewSandboxResourceController(path string, resources *specs.LinuxResources, sandboxCgroupOnly bool, needsHypervisorDevices bool) (ResourceController, error) {
 	sandboxResources := *resources
-	sandboxDevices, err := sandboxDevices()
-	if err != nil {
-		return nil, err
+	if needsHypervisorDevices {
+		sandboxDevs, err := sandboxDevices()
+		if err != nil {
+			return nil, err
+		}
+		sandboxResources.Devices = append(sandboxResources.Devices, sandboxDevs...)
 	}
-	sandboxResources.Devices = append(sandboxResources.Devices, sandboxDevices...)
 
 	// Currently we know to handle systemd cgroup path only when it's the only cgroup (no overhead group), hence,
 	// if sandboxCgroupOnly is not true we treat it as cgroupfs path as it used to be, although it may be incorrect.

--- a/src/runtime/pkg/resourcecontrol/cgroups_darwin.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups_darwin.go
@@ -21,7 +21,7 @@ func NewResourceController(path string, resources *specs.LinuxResources) (Resour
 	return &DarwinResourceController{}, nil
 }
 
-func NewSandboxResourceController(path string, resources *specs.LinuxResources, sandboxCgroupOnly bool) (ResourceController, error) {
+func NewSandboxResourceController(path string, resources *specs.LinuxResources, sandboxCgroupOnly bool, needsHypervisorDevices bool) (ResourceController, error) {
 	return &DarwinResourceController{}, nil
 }
 

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -870,7 +870,12 @@ func (s *Sandbox) createResourceController() error {
 	// Depending on the SandboxCgroupOnly value, this cgroup
 	// will either hold all the pod threads (SandboxCgroupOnly is true)
 	// or only the virtual CPU ones (SandboxCgroupOnly is false).
-	s.sandboxController, err = resCtrl.NewSandboxResourceController(cgroupPath, &resources, s.config.SandboxCgroupOnly)
+	s.sandboxController, err = resCtrl.NewSandboxResourceController(
+		cgroupPath,
+		&resources,
+		s.config.SandboxCgroupOnly,
+		s.config.HypervisorType != RemoteHypervisor,
+	)
 	if err != nil {
 		return fmt.Errorf("Could not create the sandbox resource controller %v", err)
 	}

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -1483,6 +1483,19 @@ func TestSandbox_Cgroups(t *testing.T) {
 			false,
 			true,
 		},
+		{
+			"sandbox, remote hypervisor (no kvm required)",
+			&Sandbox{
+				config: &SandboxConfig{
+					HypervisorType: RemoteHypervisor,
+					Containers: []ContainerConfig{
+						successfulContainer,
+					},
+				},
+			},
+			false,
+			true,
+		},
 	}
 	for _, tt := range tests {
 		if tt.needRoot && os.Getuid() != 0 {


### PR DESCRIPTION
The remote hypervisor delegates VM creation to a remote service. The VM runs on cloud infrastructure, not the local host kernel. So requiring a KVM/MSHV device is semantically wrong and would cause a hard failure on any host where these devices are absent (e.g., a VM that doesn't expose nested virtualization).

Skip sandboxDevices() entirely when the configured hypervisor type is remoteHypervisor{}.

This will resolve an issue at https://github.com/confidential-containers/cloud-api-adaptor/pull/2874#issuecomment-3984557679

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>