### PR TITLE
runtime: support multi-mount rootfs from containerd snapshotters

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -75,7 +75,7 @@ func copyLayersToMounts(rootFs *virtcontainers.RootFs, spec *specs.Spec) error {
 
 func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*container, error) {
 	rootFs := virtcontainers.RootFs{}
-	if len(r.Rootfs) == 1 {
+	if len(r.Rootfs) >= 1 {
 		m := r.Rootfs[0]
 		rootFs.Source = m.Source
 		rootFs.Type = m.Type
@@ -308,7 +308,7 @@ func loadRuntimeConfig(s *service, r *taskAPI.CreateTaskRequest, anno map[string
 }
 
 func checkAndMount(s *service, r *taskAPI.CreateTaskRequest) (bool, error) {
-	if len(r.Rootfs) == 1 {
+	if len(r.Rootfs) >= 1 {
 		m := r.Rootfs[0]
 
 		// Plug the block backed rootfs directly instead of mounting it.
@@ -350,6 +350,7 @@ func doMount(mounts []*containerd_types.Mount, rootfs string) error {
 	for _, rm := range mounts {
 		m := &mount.Mount{
 			Type:    rm.Type,
+			Target:  rm.Target,
 			Source:  rm.Source,
 			Options: rm.Options,
 		}

--- a/src/runtime/virtcontainers/mount_linux.go
+++ b/src/runtime/virtcontainers/mount_linux.go
@@ -44,7 +44,7 @@ func bindMount(ctx context.Context, source, destination string, readonly bool, p
 	}
 	span.SetAttributes(otelLabel.String("source_after_eval", absSource))
 
-	if err := syscall.Mount(absSource, destination, "bind", syscall.MS_BIND, ""); err != nil {
+	if err := syscall.Mount(absSource, destination, "bind", syscall.MS_BIND|syscall.MS_REC, ""); err != nil {
 		return fmt.Errorf("Could not bind mount %v to %v: %v", absSource, destination, err)
 	}
 

--- a/src/runtime/virtcontainers/mount_linux_test.go
+++ b/src/runtime/virtcontainers/mount_linux_test.go
@@ -170,6 +170,46 @@ func TestBindMountReadonlySuccessful(t *testing.T) {
 	assert.Error(err)
 }
 
+func TestBindMountRecursive(t *testing.T) {
+	assert := assert.New(t)
+	if tc.NotValid(ktu.NeedRoot()) {
+		t.Skip(ktu.TestDisabledNeedRoot)
+	}
+
+	source, err := os.MkdirTemp(testDir, "bindRecSrc")
+	assert.NoError(err)
+	defer os.RemoveAll(source)
+
+	dest, err := os.MkdirTemp(testDir, "bindRecDest")
+	assert.NoError(err)
+	defer os.RemoveAll(dest)
+
+	// Create a sub-directory inside source and mount a tmpfs on it.
+	subDir := filepath.Join(source, "submount")
+	err = os.Mkdir(subDir, mountPerm)
+	assert.NoError(err)
+
+	err = syscall.Mount("tmpfs", subDir, "tmpfs", 0, "")
+	assert.NoError(err)
+	defer syscall.Unmount(subDir, syscall.MNT_DETACH)
+
+	// Write a marker file on the tmpfs sub-mount.
+	marker := filepath.Join(subDir, "marker")
+	err = os.WriteFile(marker, []byte("hello"), mountPerm)
+	assert.NoError(err)
+
+	// Bind-mount source to dest; this must be recursive so the tmpfs
+	// sub-mount is visible at dest/submount.
+	err = bindMount(context.Background(), source, dest, false, "private")
+	assert.NoError(err)
+	defer syscall.Unmount(dest, syscall.MNT_DETACH)
+
+	// The marker file should be reachable through the bind destination.
+	content, err := os.ReadFile(filepath.Join(dest, "submount", "marker"))
+	assert.NoError(err)
+	assert.Equal("hello", string(content))
+}
+
 func TestBindMountInvalidPgtypes(t *testing.T) {
 	assert := assert.New(t)
 	if tc.NotValid(ktu.NeedRoot()) {


### PR DESCRIPTION
## Summary

The Go shim silently fails when a containerd snapshotter returns more than one mount (e.g., overlay + bind mounts). This prevents snapshotters like [nix-snapshotter](https://github.com/pdtpartners/nix-snapshotter) — which uses bind mounts to resolve nix store paths at container start — from working with Kata.

Three backward-compatible fixes:

- **`create.go`**: Accept rootfs metadata when `len(Rootfs) >= 1` instead of `== 1`. Single-mount snapshotters work identically.
- **`create.go`**: Copy `Mount.Target` field in `doMount()`. containerd's `Mount()` uses `Target` as a subdirectory specifier via `fs.RootPath()`. Without it, bind mounts targeting subdirectories are mounted at the rootfs root.
- **`mount_linux.go`**: Use `MS_BIND|MS_REC` in `bindMountContainerRootfs()`. Non-recursive bind silently drops sub-mounts when sharing the container rootfs into the VM via virtiofs.

## Motivation

containerd's snapshotter interface allows `Mounts()` to return multiple mounts. The default overlayfs snapshotter returns exactly one, so this path was never exercised. But snapshotters that layer bind mounts on top of overlay (for store-path resolution, content-addressable layers, etc.) return N+1 mounts, and the shim drops them.

## Testing

Tested with nix-snapshotter (overlay + ~70 bind mounts for `/nix/store` paths) on Cloud Hypervisor:

- Before: `failed to create shim task: not a directory`
- After: Container boots with all store paths visible inside the Kata VM via virtiofs, services respond on pod network

Existing single-mount snapshotters are unaffected — the `>= 1` guard is strictly more permissive than `== 1`, and recursive bind is a superset of non-recursive when there are no sub-mounts.

Fixes #12620