### PR TITLE
ci: Remove SNP tests from required

### DIFF
--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -91,7 +91,7 @@ mapping:
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-free-runner / run-k8s-tests (cloud-hypervisor, active)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-zvsi / run-k8s-tests (devmapper, qemu, kubeadm)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-zvsi / run-k8s-tests (nydus, qemu-coco-dev, kubeadm)
-      - Kata Containers CI / kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-on-tee (sev-snp, qemu-snp)
+      # - Kata Containers CI / kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-on-tee (sev-snp, qemu-snp)
       - Kata Containers CI / kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-coco-nontee (qemu-coco-dev, nydus, guest-pull)
       - Kata Containers CI / kata-containers-ci-on-push / run-kata-coco-tests / run-k8s-tests-coco-nontee (qemu-coco-dev-runtime-rs, nydus, guest-pull)
       - Kata Containers CI / kata-containers-ci-on-push / run-kata-deploy-tests / run-kata-deploy-tests (qemu, k0s)


### PR DESCRIPTION
The SNP tests have been unstable on nightlies, but even when these it seems to be manually cleaned up or something as PR tests are consistently failing, so we should skip this from the required list until it is reliable.

The nightly has only a 50% pass rate in the last ten days:
<img width="1241" height="94" alt="image" src="https://github.com/user-attachments/assets/f51cf637-10bb-440e-801a-62ab232006ae" />

The PR tests are consistently failing on multiple PRs e.g.
- https://github.com/kata-containers/kata-containers/actions/runs/22610434427/job/65547997486?pr=12611
- https://github.com/kata-containers/kata-containers/actions/runs/22623909131/job/65682080241?pr=12617
- https://github.com/kata-containers/kata-containers/actions/runs/22630231332/job/65581331742?pr=12613