### PR TITLE
kata-deploy: add per-shim configurable pod overhead

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -110,9 +110,14 @@ scheduling:
 {{- $config := index $runtimeClassConfigs $shim }}
 {{- $shimConfig := index $.Values.shims $shim }}
 {{- if $config }}
-{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $config "shimConfig" $shimConfig "nameOverride" "" "useShimNodeSelectors" $useShimNodeSelectors) }}
+{{- /* Allow per-shim overrides of pod overhead via .shims.<name>.runtimeClass.overhead */ -}}
+{{- $effectiveConfig := deepCopy $config }}
+{{- if and $shimConfig.runtimeClass $shimConfig.runtimeClass.overhead }}
+{{- $effectiveConfig = mergeOverwrite $effectiveConfig $shimConfig.runtimeClass.overhead }}
+{{- end }}
+{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "nameOverride" "" "useShimNodeSelectors" $useShimNodeSelectors) }}
 {{- if and $createDefaultRC (not $multiInstallSuffix) (eq $shim $defaultShim) }}
-{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $config "shimConfig" $shimConfig "nameOverride" $defaultRCName "useShimNodeSelectors" $useShimNodeSelectors) }}
+{{ include "kata-deploy.runtimeclass" (dict "root" $ "shim" $shim "config" $effectiveConfig "shimConfig" $shimConfig "nameOverride" $defaultRCName "useShimNodeSelectors" $useShimNodeSelectors) }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -50,6 +50,28 @@ snapshotter:
 #     disableAll: true
 #     qemu:
 #       enabled: true  # Only qemu is enabled
+#
+# All configurable keys per shim (all optional unless noted):
+#   shims:
+#     <shim-name>:
+#       enabled: ~                    # true | false | ~ (null = follow disableAll)
+#       supportedArches:              # list of supported architectures
+#         - amd64
+#       allowedHypervisorAnnotations: []  # hypervisor annotations to pass through
+#       containerd:
+#         snapshotter: ""             # e.g. nydus, erofs, devmapper, or "" for default
+#         forceGuestPull: false       # force guest-side image pull in containerd
+#       crio:
+#         guestPull: false            # enable guest-pull in CRI-O
+#       agent:
+#         httpsProxy: ""             # HTTPS proxy for the Kata agent
+#         noProxy: ""                # no-proxy list for the Kata agent
+#       runtimeClass:
+#         nodeSelector:              # extra node selectors added to the RuntimeClass
+#           example.io/feature: "true"
+#         overhead:                  # override pod overhead (falls back to built-in defaults)
+#           memory: "160Mi"
+#           cpu: "250m"
 shims:
   disableAll: false
 


### PR DESCRIPTION
The runtime class pod overhead is currently hard-coded for all shims.

This PR allows users to override the default RuntimeClass pod overhead for any shim via `shims.<name>.runtimeClass.overhead.{memory,cpu}`.

When the field is absent the existing hard-coded defaults from the dict are used, so this change is fully backward compatible.

Additionally, it adds some comments in the values about the configurations that can be applied to each shim.