### PR TITLE
 versions: bump golang to 1.25.8

### DIFF
--- a/src/tools/csi-kata-directvolume/go.mod
+++ b/src/tools/csi-kata-directvolume/go.mod
@@ -1,7 +1,7 @@
 module kata-containers/csi-kata-directvolume
 
 // Keep in sync with version in versions.yaml
-go 1.25.7
+go 1.25.8
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/src/tools/log-parser/go.mod
+++ b/src/tools/log-parser/go.mod
@@ -1,7 +1,7 @@
 module github.com/kata-containers/kata-containers/src/tools/log-parser
 
 // Keep in sync with version in versions.yaml
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.1.0

--- a/tests/go.mod
+++ b/tests/go.mod
@@ -1,7 +1,7 @@
 module github.com/kata-containers/tests
 
 // Keep in sync with version in versions.yaml
-go 1.25.7
+go 1.25.8
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020

--- a/tests/metrics/cmd/checkmetrics/go.mod
+++ b/tests/metrics/cmd/checkmetrics/go.mod
@@ -1,7 +1,7 @@
 module example.com/m
 
 // Keep in sync with version in versions.yaml
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/BurntSushi/toml v1.3.2

--- a/tools/testing/kata-webhook/go.mod
+++ b/tools/testing/kata-webhook/go.mod
@@ -1,7 +1,7 @@
 module module-path
 
 // Keep in sync with version in versions.yaml
-go 1.25.7
+go 1.25.8
 
 require (
 	github.com/sirupsen/logrus v1.9.3

--- a/versions.yaml
+++ b/versions.yaml
@@ -468,12 +468,12 @@ languages:
     description: "Google's 'go' language"
     notes: "'version' is the default minimum version used by this project."
     # When updating this, also update in go.mod files.
-    version: "1.25.7"
+    version: "1.25.8"
     meta:
       description: |
         'newest-version' is the latest version known to work when
         building Kata
-      newest-version: "1.25.7"
+      newest-version: "1.25.8"
 
   rust:
     description: "Rust language"


### PR DESCRIPTION
Bump the builder image and versions to resolve CVEs:
- GO-2026-4601
- GO-2026-4602
- GO-2026-4603