### PR TITLE
genpolicy: Improve emptyDir storage options and mount point validation

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -173,7 +173,7 @@
                 "encryption_key=ephemeral"
             ],
             "source": "",
-            "mount_point": "^$(spath)/$(b64_device_id)$",
+            "mount_point": "$(spath)/$(b64_device_id)",
             "fstype": "ext4",
             "options": [],
             "shared": true

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1306,6 +1306,7 @@ allow_storage_source(p_storage, i_storage, bundle_id) if {
 allow_storage_options(p_storage, i_storage) if {
     print("allow_storage_options 1: start")
 
+    p_storage.driver != "blk"
     p_storage.driver != "overlayfs"
     p_storage.options == i_storage.options
 
@@ -1389,7 +1390,7 @@ allow_mount_point_by_device_id(p_storage, i_storage) if {
     mount3 := replace(mount2, "$(b64_device_id)", base64url.encode(i_storage.source))
     print("allow_mount_point_by_device_id: mount3 =", mount3)
 
-    regex.match(mount3, i_storage.mount_point)
+    mount3 == i_storage.mount_point
 
     print("allow_mount_point_by_device_id: true")
 }

--- a/src/tools/genpolicy/src/mount_and_storage.rs
+++ b/src/tools/genpolicy/src/mount_and_storage.rs
@@ -168,10 +168,10 @@ fn get_empty_dir_mount_and_storage(
             source: settings_empty_dir.source.clone(),
             fstype: settings_empty_dir.fstype.clone(),
             options,
-            mount_point: if settings_empty_dir.mount_point.ends_with('$') {
-                settings_empty_dir.mount_point.clone()
-            } else {
+            mount_point: if settings_empty_dir.mount_point.ends_with('/') {
                 format!("{}{}$", &settings_empty_dir.mount_point, &yaml_mount.name)
+            } else {
+                settings_empty_dir.mount_point.clone()
             },
             fs_group: protobuf::MessageField::none(),
             shared: settings_empty_dir.shared,


### PR DESCRIPTION
```
These are two changes following a Copilot review on #10559:

1. Restore the p_storage.driver != "blk" check in allow_storage_options():
   - An early version of #10599 hardcoded p_storage.driver to "blk".
   - Hence that check needed to be removed to validate "blk" storage options.
   - The final version of #10599 hardcodes p_storage.driver to "" to account for both "blk" and "scsi", and checks storage options in allow_block_storage().
   - Hence that check should be restored to preserve the original behavior.

https://github.com/kata-containers/kata-containers/pull/10559#discussion_r2907646552

2. Don't use a regex to validate emptyDir storage mount points:
   - It's risky to use a regex to validate a path that has base64-encoded components.
   - We can infer the exact path anyway so the regex is redundant.

https://github.com/kata-containers/kata-containers/pull/10559#discussion_r2907646582
```