### PR TITLE
runtime: bump go.mod version

### DIFF
--- a/src/runtime/go.mod
+++ b/src/runtime/go.mod
@@ -1,7 +1,7 @@
 module github.com/kata-containers/kata-containers/src/runtime
 
 // Keep in sync with version in versions.yaml
-go 1.25.7
+go 1.25.8
 
 // WARNING: Do NOT use `replace` directives as those break dependabot:
 // https://github.com/kata-containers/kata-containers/issues/11020


### PR DESCRIPTION
Update the runtime's go.mod go version to 1.25.8 to keep in sync with versions.yaml