### PR TITLE
agent: add mkfs_opts parameter to cdh_secure_mount

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -2322,6 +2322,7 @@ async fn cdh_handler_trusted_storage(oci: &mut Spec) -> Result<()> {
                     &dev_major_minor,
                     "luks2",
                     KATA_IMAGE_WORK_DIR,
+                    "-E lazy_journal_init",
                 )
                 .await?;
                 break;
@@ -2336,6 +2337,7 @@ pub(crate) async fn cdh_secure_mount(
     device_id: &str,
     encrypt_type: &str,
     mount_point: &str,
+    mkfs_opts: &str,
 ) -> Result<()> {
     if !confidential_data_hub::is_cdh_client_initialized() {
         return Ok(());
@@ -2345,11 +2347,12 @@ pub(crate) async fn cdh_secure_mount(
 
     info!(
         sl(),
-        "cdh_secure_mount: device_type {}, device_id {}, encrypt_type {}, integrity {}",
+        "cdh_secure_mount: device_type {}, device_id {}, encrypt_type {}, integrity {}, mkfs_opts {}",
         device_type,
         device_id,
         encrypt_type,
-        integrity
+        integrity,
+        mkfs_opts
     );
 
     let options = std::collections::HashMap::from([
@@ -2357,7 +2360,7 @@ pub(crate) async fn cdh_secure_mount(
         ("sourceType".to_string(), "empty".to_string()),
         ("targetType".to_string(), "fileSystem".to_string()),
         ("filesystemType".to_string(), "ext4".to_string()),
-        ("mkfsOpts".to_string(), "-E lazy_journal_init".to_string()),
+        ("mkfsOpts".to_string(), mkfs_opts.to_string()),
         ("encryptionType".to_string(), encrypt_type.to_string()),
         ("dataIntegrity".to_string(), integrity),
     ]);

--- a/src/agent/src/storage/block_handler.rs
+++ b/src/agent/src/storage/block_handler.rs
@@ -59,8 +59,14 @@ async fn handle_block_storage(
         .contains(&"encryption_key=ephemeral".to_string());
 
     if has_ephemeral_encryption {
-        crate::rpc::cdh_secure_mount("block-device", dev_num, "luks2", &storage.mount_point)
-            .await?;
+        crate::rpc::cdh_secure_mount(
+            "block-device",
+            dev_num,
+            "luks2",
+            &storage.mount_point,
+            "-O ^has_journal -m 0 -i 163840 -I 128",
+        )
+        .await?;
         set_ownership(logger, storage)?;
         new_device(storage.mount_point.clone())
     } else {


### PR DESCRIPTION
Add an mkfs_opts parameter to cdh_secure_mount so that its users can parametrize these options depending on their needs. For now, there is two users providing explicit values (container image layer storage and container data storage features).

This was previously proposed by @sprt in https://github.com/kata-containers/kata-containers/pull/10559 for the luks-encrypt-storage script. Since this script was not replicated in kata-containers in the end and since this script was removed from the guest-components code base, we started by passing `-E lazy_journal_init` to CDH via `mkfsOpts` to have parity with the previous behavior of the luks-encrypt-storage script. We now want to follow up on this again.

Recap on optimizations for container data storage:
- `-O ^has_journal` disables the journal to minimize the host footprint (any non-zero bytes written by mkfs would increase the footprint)
- `-m 0` sets to 0% the space reserved by mkfs in the guest for recovery by root, minimizing the footprint in the guest
- `-i 163840` causes to create 1 inode per 163840 bytes of space (instead of 16384 by default). This decreases the number of inodes and thus decrease the ext4 metadata size
  - Drawback: means we can only create 817K files for a 128Gi host
- `-I 128` uses 128-byte inodes (instead of 256-byte by default) to even further reduce the footprint
  - Drawback: extended attributes not supported

@sprt recalled that "without the -i/-I optimizations alone, for a 128Gi disk the host footprint would be ~2.2Gi instead of ~174Mi".

If we have alignment on optimizations we can consider tightening checks in `@test "Trusted ephemeral data storage"` in `tests\integration\kubernetes\k8s-trusted-ephemeral-data-storage.bats`.
