### PR TITLE
runtime-rs: fix setting directio via config file

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -858,7 +858,12 @@ impl QemuInner {
                         block_device.config.index,
                         &block_device.config.path_on_host,
                         &block_device.config.blkdev_aio.to_string(),
-                        block_device.config.is_direct,
+                        Some(
+                            block_device
+                                .config
+                                .is_direct
+                                .unwrap_or(self.config.blockdev_info.block_device_cache_direct),
+                        ),
                         block_device.config.is_readonly,
                         block_device.config.no_drop,
                     )


### PR DESCRIPTION
Hotplugging block devices didn't fall back to the configuration value for `is_direct`, simillar to how coldplugging works. 
This PR fixes that. 