### PR TITLE
runtime: Support VFIO noiommu mode

### DIFF
--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -430,6 +430,11 @@ type VFIODev struct {
 	// HostPath is the path to the device on the host we need it as a reference
 	// to match a /dev/vfio/<num> device to a device in GK mode
 	HostPath string
+
+	// NoIOMMU indicates the device uses VFIO no-IOMMU mode
+	// (enable_unsafe_noiommu_mode). In this mode the device appears as
+	// /dev/vfio/noiommu-<GROUP> on the host and IOMMUFD cannot be used.
+	NoIOMMU bool
 }
 
 // IOMMUFDID returns the IOMMUFD ID if the VFIO device is backed by IOMMUFD

--- a/src/runtime/pkg/device/const.go
+++ b/src/runtime/pkg/device/const.go
@@ -8,4 +8,10 @@ package device
 
 const (
 	IommufdDevPath = "/dev/vfio/devices"
+
+	// VfioNoIOMMUPrefix is the prefix used by the kernel for VFIO group device
+	// files when enable_unsafe_noiommu_mode is active. In this mode devices appear
+	// as /dev/vfio/noiommu-<GROUP> instead of /dev/vfio/<GROUP>, and IOMMUFD
+	// cannot be used.
+	VfioNoIOMMUPrefix = "noiommu-"
 )

--- a/src/runtime/pkg/device/drivers/utils.go
+++ b/src/runtime/pkg/device/drivers/utils.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"syscall"
 
+	pkgDevice "github.com/kata-containers/kata-containers/src/runtime/pkg/device"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/api"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/utils"
@@ -255,7 +256,17 @@ func GetAllVFIODevicesFromIOMMUGroup(device config.DeviceInfo) ([]*config.VFIODe
 	vfioDevs := []*config.VFIODev{}
 
 	vfioGroup := filepath.Base(device.HostPath)
-	iommuDevicesPath := filepath.Join(config.SysIOMMUGroupPath, vfioGroup, "devices")
+
+	// When enable_unsafe_noiommu_mode is active the kernel names the group
+	// device file /dev/vfio/noiommu-<N>, but the sysfs IOMMU group directory
+	// is still at /sys/kernel/iommu_groups/<N> (without the prefix).
+	noIOMMU := strings.HasPrefix(vfioGroup, pkgDevice.VfioNoIOMMUPrefix)
+	sysfsGroup := vfioGroup
+	if noIOMMU {
+		sysfsGroup = strings.TrimPrefix(vfioGroup, pkgDevice.VfioNoIOMMUPrefix)
+	}
+
+	iommuDevicesPath := filepath.Join(config.SysIOMMUGroupPath, sysfsGroup, "devices")
 
 	deviceFiles, err := os.ReadDir(iommuDevicesPath)
 	if err != nil {
@@ -303,6 +314,7 @@ func GetAllVFIODevicesFromIOMMUGroup(device config.DeviceInfo) ([]*config.VFIODe
 				DeviceID: deviceID,
 				Port:     device.Port,
 				HostPath: device.HostPath,
+				NoIOMMU:  noIOMMU,
 			}
 
 		case config.VFIOAPDeviceMediatedType:
@@ -316,6 +328,7 @@ func GetAllVFIODevicesFromIOMMUGroup(device config.DeviceInfo) ([]*config.VFIODe
 				Type:      config.VFIOAPDeviceMediatedType,
 				APDevices: devices,
 				Port:      device.Port,
+				NoIOMMU:   noIOMMU,
 			}
 		default:
 			return nil, fmt.Errorf("Failed to append device: VFIO device type unrecognized")

--- a/src/runtime/pkg/device/drivers/vfio.go
+++ b/src/runtime/pkg/device/drivers/vfio.go
@@ -69,13 +69,22 @@ func (device *VFIODevice) Attach(ctx context.Context, devReceiver api.DeviceRece
 	// In the case of IOMMUFD the device.HostPath will look like
 	// /dev/vfio/devices/vfio0
 	// (1) Check if we have the new IOMMUFD or old container based VFIO
+	hostPathBase := filepath.Base(device.DeviceInfo.HostPath)
+	isNoIOMMU := strings.HasPrefix(hostPathBase, pkgDevice.VfioNoIOMMUPrefix)
 	if strings.HasPrefix(device.DeviceInfo.HostPath, pkgDevice.IommufdDevPath) {
+		// IOMMUFD does not support no-IOMMU mode; a path like
+		// /dev/vfio/noiommu-<GROUP> must not reach this branch, but
+		// guard defensively anyway.
+		if isNoIOMMU {
+			return fmt.Errorf("IOMMUFD cannot be used with no-IOMMU VFIO device %s", device.DeviceInfo.HostPath)
+		}
 		device.VfioDevs, err = GetDeviceFromVFIODev(*device.DeviceInfo)
 		if err != nil {
 			return err
 		}
 	} else {
-		// Once we have
+		// Legacy VFIO group path (/dev/vfio/<GROUP>) and no-IOMMU mode
+		// (/dev/vfio/noiommu-<GROUP>) both use the IOMMU-group code path.
 		device.VfioDevs, err = GetAllVFIODevicesFromIOMMUGroup(*device.DeviceInfo)
 		if err != nil {
 			return err

--- a/src/runtime/pkg/device/manager/utils_test.go
+++ b/src/runtime/pkg/device/manager/utils_test.go
@@ -22,6 +22,8 @@ func TestIsVFIO(t *testing.T) {
 	data := []testData{
 		{"/dev/vfio/16", true},
 		{"/dev/vfio/1", true},
+		{"/dev/vfio/noiommu-16", true},
+		{"/dev/vfio/noiommu-0", true},
 		{"/dev/vfio/", false},
 		{"/dev/vfio", false},
 		{"/dev/vf", false},

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	pkgDevice "github.com/kata-containers/kata-containers/src/runtime/pkg/device"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
 	deviceUtils "github.com/kata-containers/kata-containers/src/runtime/pkg/device/drivers"
 	deviceManager "github.com/kata-containers/kata-containers/src/runtime/pkg/device/manager"
@@ -1358,9 +1359,13 @@ func (c *Container) siblingAnnotation(devPath string, siblings []DeviceRelation)
 		class := deviceUtils.GetPCIDeviceProperty(bdf, deviceUtils.PCISysFsDevicesClass)
 		_, isKnownCDIDevice = cdiKindForDevice(vendorID, class)
 	} else {
-		// Legacy VFIO group (/dev/vfio/<GROUP>): may contain multiple devices
+		// Legacy VFIO group (/dev/vfio/<GROUP>) and no-IOMMU VFIO group
+		// (/dev/vfio/noiommu-<GROUP>): may contain multiple devices.
+		// The kernel names the sysfs directory by the bare group number,
+		// so strip the "noiommu-" prefix before constructing the path.
 		vfioGroup := filepath.Base(devPath)
-		iommuDevicesPath := filepath.Join(config.SysIOMMUGroupPath, vfioGroup, "devices")
+		sysfsGroup := strings.TrimPrefix(vfioGroup, pkgDevice.VfioNoIOMMUPrefix)
+		iommuDevicesPath := filepath.Join(config.SysIOMMUGroupPath, sysfsGroup, "devices")
 		deviceFiles, err := os.ReadDir(iommuDevicesPath)
 		if err != nil {
 			return err


### PR DESCRIPTION
The vfio-pci device driver can be put into enable_unsafe_noiommu_mode mode. When this is set, VFIO ignores the lack of an enabled IOMMU on the host and exposes the device cdevs at `/dev/vfio/noiommu-${GROUP}`. This mode, while unsafe (as it allows arbitrary DMA), is necessary if you want to do device passthrough on systems that do not have IOMMUs.

When operating under this mode, IOMMUFD cannot be used as this subsystem does not yet support noiommu mode.

A related PR has been submitted to the NVIDIA sandbox-device-plugin that will advertise such devices to K8s and create the appropriate CDI spec file.

https://github.com/NVIDIA/sandbox-device-plugin/pull/64

References:
- https://lwn.net/Articles/660745/
- https://lwn.net/ml/all/20251201173012.18371-1-jacob.pan@linux.microsoft.com/