### PR TITLE
tests: nvidia: Increase run test timeout

### DIFF
--- a/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
+++ b/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
@@ -98,7 +98,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh install-bats
 
       - name: Run tests ${{ matrix.environment.vmm }}
-        timeout-minutes: 30
+        timeout-minutes: 60
         run: bash tests/integration/kubernetes/gha-run.sh run-nv-tests
         env:
           NGC_API_KEY: ${{ secrets.NGC_API_KEY }}


### PR DESCRIPTION
Increase the timeout as a few new features and tests are going to be onboarded for the NVIDIA GPU CI.

Examples:
- [tests: gpu: use container data storage feature](https://github.com/kata-containers/kata-containers/pull/12676)
- [tests: nvidia: onboard NIM service test](https://github.com/kata-containers/kata-containers/pull/12645)
- [tests: nvidia: onboard NIM service test](https://github.com/kata-containers/kata-containers/pull/12645)