### PR TITLE
ci: k8s-tests: test mariner and runtime-rs

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -54,6 +54,12 @@ jobs:
           - host_os: cbl-mariner
             vmm: clh
             instance-type: normal
+          - host_os: cbl-mariner
+            vmm: cloud-hypervisor
+            instance-type: small
+          - host_os: cbl-mariner
+            vmm: cloud-hypervisor
+            instance-type: normal
     runs-on: ubuntu-22.04
     permissions:
       contents: read

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -450,7 +450,9 @@ function main() {
 
 	# Auto-generate policy on some Host types, if the caller didn't specify an AUTO_GENERATE_POLICY value.
 	if [[ -z "${AUTO_GENERATE_POLICY}" ]]; then
-		if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
+		# https://github.com/kata-containers/kata-containers/issues/12839
+		if [[ "${KATA_HOST_OS}" = "cbl-mariner" && \
+			  "${KATA_HYPERVISOR}" = "clh" ]]; then
 			AUTO_GENERATE_POLICY="yes"
 		elif [[ "${KATA_HYPERVISOR}" = qemu-coco-dev* && \
 		        ( "${TARGET_ARCH}" = "x86_64" || "${TARGET_ARCH}" = "aarch64" ) && \

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -352,7 +352,9 @@ hard_coded_policy_tests_enabled() {
 		fi
 	done
 
-	if [[ "${enabled}" == "no" && "${KATA_HOST_OS}" == "cbl-mariner" ]]; then
+	# https://github.com/kata-containers/kata-containers/issues/12720
+	if [[ "${enabled}" == "no" && "${KATA_HOST_OS}" == "cbl-mariner" && \
+	 	  "${KATA_HYPERVISOR}" == "clh" ]]; then
 		enabled="yes"
 	fi
 

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -127,7 +127,7 @@ get_kubelet_data_dir() {
 }
 
 is_runtime_rs() {
-	[[ "${KATA_HYPERVISOR}" == *-runtime-rs ]]
+	[[ "${KATA_HYPERVISOR}" == *-runtime-rs || "${KATA_HYPERVISOR}" == "cloud-hypervisor" ]]
 }
 
 # Copy the right combination of drop-ins from drop-in-examples/ into

--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -80,6 +80,8 @@ mapping:
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-aks / run-k8s-tests (cbl-mariner, clh, normal)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-aks / run-k8s-tests (cbl-mariner, clh, small, containerd)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-aks / run-k8s-tests (cbl-mariner, clh, small, oci-distribution)
+      - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-aks / run-k8s-tests (cbl-mariner, cloud-hypervisor, small)
+      - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-aks / run-k8s-tests (cbl-mariner, cloud-hypervisor, normal)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-free-runner / run-k8s-tests (clh, lts)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-free-runner / run-k8s-tests (clh, active)
       - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-free-runner / run-k8s-tests (dragonball, lts)


### PR DESCRIPTION
- Disable policy tests when using mariner and runtime-rs. These are not supported yet
- improve settings selection for runtime-rs hypervisors