### PR TITLE
tools.gatekeeper: Allow fetching required-tests from repo

### DIFF
--- a/.github/workflows/gatekeeper-skipper.yaml
+++ b/.github/workflows/gatekeeper-skipper.yaml
@@ -51,5 +51,5 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
         run: |
-          python3 tools/testing/gatekeeper/skips.py | tee -a "$GITHUB_OUTPUT"
+          python3 tools/testing/gatekeeper/skips.py --from-target-branch | tee -a "$GITHUB_OUTPUT"
         shell: /usr/bin/bash -x {0}

--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -43,7 +43,7 @@ jobs:
           GH_PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           #!/usr/bin/env bash -x
-          mapfile -t lines < <(python3 tools/testing/gatekeeper/skips.py -t)
+          mapfile -t lines < <(python3 tools/testing/gatekeeper/skips.py -t --from-target-branch)
           export REQUIRED_JOBS="${lines[0]}"
           export REQUIRED_REGEXPS="${lines[1]}"
           export REQUIRED_LABELS="${lines[2]}"

--- a/tools/testing/gatekeeper/skips.py
+++ b/tools/testing/gatekeeper/skips.py
@@ -10,20 +10,55 @@ and reports feature skips in form of "skip_$feature=yes|no"
 or list of required tests (based on argv[1])
 """
 
+import argparse
 from collections import OrderedDict
 import os
 import re
 import subprocess
 import sys
 
+import requests
 import yaml
 
 
 class Checks:
-    def __init__(self):
-        config_path = os.path.join(os.path.dirname(__file__), "required-tests.yaml")
+    def __init__(self, from_target_branch=False, target_branch=None):
+        config = self._load_config(from_target_branch, target_branch) or {}
+        self._parse_config(config)
+
+    def _load_config(self, from_target_branch, target_branch):
+        """
+        Load the required-tests.yaml config.
+
+        :param from_target_branch: If True, fetch config from the target branch
+            via GitHub raw URL instead of using local file
+        :param target_branch: The target branch to fetch from (required if
+            from_target_branch is True)
+        :returns: Parsed YAML config dict
+        """
+        if from_target_branch:
+            repo = os.environ.get('GITHUB_REPOSITORY')
+            if not repo:
+                raise RuntimeError(
+                    "GITHUB_REPOSITORY env var required when using "
+                    "--from-target-branch")
+            if not target_branch:
+                raise RuntimeError(
+                    "target_branch required when using --from-target-branch")
+            url = (f"https://raw.githubusercontent.com/{repo}/"
+                   f"refs/heads/{target_branch}/"
+                   "tools/testing/gatekeeper/required-tests.yaml")
+            print(f"Fetching config from: {url}", file=sys.stderr)
+            response = requests.get(url, timeout=30)
+            response.raise_for_status()
+            return yaml.load(response.text, Loader=yaml.SafeLoader)
+        config_path = os.path.join(os.path.dirname(__file__),
+                                   "required-tests.yaml")
         with open(config_path, "r", encoding="utf8") as config_fd:
-            config = yaml.load(config_fd, Loader=yaml.SafeLoader)
+            return yaml.load(config_fd, Loader=yaml.SafeLoader)
+
+    def _parse_config(self, config):
+        """Parse the config dict into instance attributes."""
         self.required_tests = config.get('required_tests') or []
         self.required_regexps = config.get('required_regexps') or []
         self.paths = OrderedDict((re.compile(key), value)
@@ -92,8 +127,20 @@ class Checks:
 
 
 if __name__ == "__main__":
-    if len(sys.argv) == 2:
-        _TESTS = sys.argv[1] == '-t'
-    else:
-        _TESTS = False
-    sys.exit(Checks().run(_TESTS, os.getenv("TARGET_BRANCH", "main")))
+    parser = argparse.ArgumentParser(
+        description="Get required tests based on changed files")
+    parser.add_argument(
+        "-t", "--tests", action="store_true",
+        help="Report required tests and regexps instead of skip flags")
+    parser.add_argument(
+        "--from-target-branch", action="store_true",
+        help="Fetch required-tests.yaml from the target branch via GitHub "
+             "raw URL instead of using local file. This prevents PRs from "
+             "modifying the required tests config. Requires GITHUB_REPOSITORY "
+             "and TARGET_BRANCH env vars.")
+    args = parser.parse_args()
+
+    TARGET_BRANCH = os.getenv("TARGET_BRANCH", "main")
+    checks = Checks(from_target_branch=args.from_target_branch,
+                    target_branch=TARGET_BRANCH)
+    sys.exit(checks.run(args.tests, TARGET_BRANCH))


### PR DESCRIPTION
in https://github.com/kata-containers/kata-containers/issues/12632 Steven raised a concern about potential threat in using older
base with outdated required-tests.yaml, or simply outdated PR checks on
re-runs with older base. To mitigate at least the required-tests.yaml
part let's add a support to fetch the required tests from the current's
branch of the current repo, which should ensure we always expect the
latest set of required-tests (similarly to github require).

Note this does not cover the jobs.py/skips.py changes as these should be
fairly stable and changes to this code should be visible in PRs.

Fixes: https://github.com/kata-containers/kata-containers/issues/12632