### PR TITLE
versions: Bump nydus-snapshotter to v0.15.13

### DIFF
--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -9,7 +9,7 @@ FROM golang:1.24-alpine AS nydus-binary-downloader
 
 # Keep the version here aligned with "ndyus-snapshotter.version"
 # in versions.yaml
-ARG NYDUS_SNAPSHOTTER_VERSION=v0.15.10
+ARG NYDUS_SNAPSHOTTER_VERSION=v0.15.13
 ARG NYDUS_SNAPSHOTTER_REPO=https://github.com/containerd/nydus-snapshotter
 
 RUN \

--- a/versions.yaml
+++ b/versions.yaml
@@ -388,7 +388,7 @@ externals:
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.15.10"
+    version: "v0.15.13"
 
   opa:
     description: "Open Policy Agent"


### PR DESCRIPTION
As this brings in a fix for using images with too many layers. 

https://github.com/containerd/nydus-snapshotter/releases/tag/v0.15.13