### PR TITLE
genpolicy: set fs_group for encrypted emptyDir volumes

### DIFF
--- a/src/tools/genpolicy/src/mount_and_storage.rs
+++ b/src/tools/genpolicy/src/mount_and_storage.rs
@@ -114,10 +114,12 @@ pub fn get_mount_and_storage(
 
     if let Some(emptyDir) = &yaml_volume.emptyDir {
         let settings_volumes = &settings.volumes;
-        let volume = match emptyDir.medium.as_deref() {
-            Some("Memory") => &settings_volumes.emptyDir_memory,
-            _ if settings.cluster_config.encrypted_emptydir => &settings_volumes.emptyDir_encrypted,
-            _ => &settings_volumes.emptyDir,
+        let (volume, block_encrypted_emptydir) = match emptyDir.medium.as_deref() {
+            Some("Memory") => (&settings_volumes.emptyDir_memory, false),
+            _ if settings.cluster_config.encrypted_emptydir => {
+                (&settings_volumes.emptyDir_encrypted, true)
+            }
+            _ => (&settings_volumes.emptyDir, false),
         };
 
         get_empty_dir_mount_and_storage(
@@ -127,6 +129,7 @@ pub fn get_mount_and_storage(
             yaml_mount,
             volume,
             pod_security_context,
+            block_encrypted_emptydir,
         );
     } else if yaml_volume.persistentVolumeClaim.is_some() || yaml_volume.azureFile.is_some() {
         get_shared_bind_mount(yaml_mount, p_mounts, "rprivate", "rw");
@@ -150,18 +153,42 @@ fn get_empty_dir_mount_and_storage(
     yaml_mount: &pod::VolumeMount,
     settings_empty_dir: &settings::EmptyDirVolume,
     pod_security_context: &Option<pod::PodSecurityContext>,
+    block_encrypted_emptydir: bool,
 ) {
     debug!("Settings emptyDir: {:?}", settings_empty_dir);
 
     if yaml_mount.subPathExpr.is_none() {
         let mut options = settings_empty_dir.options.clone();
-        if let Some(gid) = pod_security_context.as_ref().and_then(|sc| sc.fsGroup) {
-            // This matches the runtime behavior of only setting the fsgid if the mountpoint GID is not 0.
-            // https://github.com/kata-containers/kata-containers/blob/b69da5f3ba8385c5833b31db41a846a203812675/src/runtime/virtcontainers/kata_agent.go#L1602-L1607
-            if gid != 0 {
-                options.push(format!("fsgid={gid}"));
+        // Pod fsGroup in policy must mirror how the shim encodes it on Storage:
+        // - block-encrypted host emptyDirs become virtio-blk/scsi volumes; the runtime sets
+        //   Storage.fs_group from mount metadata (handleDeviceBlockVolume in kata_agent.go).
+        // - shared-fs / guest-local emptyDirs use Storage.options: the runtime appends
+        //   fsgid=<host GID> when the volume is not root-owned (handleEphemeralStorage and
+        //   handleLocalStorage in kata_agent.go). Genpolicy uses pod fsGroup when non-zero as
+        //   the usual kubelet-applied GID for that stat.
+        let pod_gid = pod_security_context.as_ref().and_then(|sc| sc.fsGroup);
+        let fs_group = if block_encrypted_emptydir {
+            match pod_gid {
+                Some(gid) if gid > 0 => protobuf::MessageField::some(agent::FSGroup {
+                    group_id: u32::try_from(gid).unwrap_or_else(|_| {
+                        panic!(
+                            "get_empty_dir_mount_and_storage: securityContext.fsGroup {gid} \
+                             must be <= {}",
+                            u32::MAX
+                        )
+                    }),
+                    ..Default::default()
+                }),
+                _ => protobuf::MessageField::none(),
             }
-        }
+        } else {
+            if let Some(gid) = pod_gid {
+                if gid != 0 {
+                    options.push(format!("fsgid={gid}"));
+                }
+            }
+            protobuf::MessageField::none()
+        };
         storages.push(agent::Storage {
             driver: settings_empty_dir.driver.clone(),
             driver_options: settings_empty_dir.driver_options.clone(),
@@ -173,7 +200,7 @@ fn get_empty_dir_mount_and_storage(
             } else {
                 settings_empty_dir.mount_point.clone()
             },
-            fs_group: protobuf::MessageField::none(),
+            fs_group,
             shared: settings_empty_dir.shared,
             special_fields: ::protobuf::SpecialFields::new(),
         });

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/testcases.json
@@ -345,12 +345,12 @@
           "driver_options": [
             "encryption_key=ephemeral"
           ],
-          "fs_group": null,
+          "fs_group": {
+            "group_id": 1000
+          },
           "fstype": "ext4",
           "mount_point": "/run/kata-containers/sandbox/storage/MDAvMDA=",
-          "options": [
-            "fsgid=1000"
-          ],
+          "options": [],
           "source": "00/00",
           "shared": true
         }

--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -10,6 +10,7 @@ load "${BATS_TEST_DIRNAME}/confidential_common.sh"
 
 export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu-nvidia-gpu}"
 
+# when using hostPath, ensure directory is writable by container user
 export LOCAL_NIM_CACHE="/opt/nim/.cache"
 
 SKIP_MULTI_GPU_TESTS=${SKIP_MULTI_GPU_TESTS:-false}

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
@@ -16,14 +16,18 @@ metadata:
     # cc_init_data annotation will be added by genpolicy with CDH configuration
     # from the custom default-initdata.toml created by create_nim_initdata_file()
 spec:
+  # Explicit user/group/supplementary groups to support nydus guest-pull.
+  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
+  # other references to this issue in the genpolicy source folder.
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
+    supplementalGroups: [4, 20, 24, 25, 27, 29, 30, 44, 46]
   restartPolicy: Never
   runtimeClassName: kata
   imagePullSecrets:
     - name: ngc-secret-instruct
-  securityContext:
-    runAsUser: 0
-    runAsGroup: 0
-    fsGroup: 0
   containers:
   - name: ${POD_NAME_INSTRUCT}
     image: nvcr.io/nim/meta/llama-3.1-8b-instruct:1.13.1

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct.yaml.in
@@ -14,10 +14,6 @@ spec:
   runtimeClassName: kata
   imagePullSecrets:
     - name: ngc-secret-instruct
-  securityContext:
-    runAsUser: 0
-    runAsGroup: 0
-    fsGroup: 0
   containers:
   - name: ${POD_NAME_INSTRUCT}
     image: nvcr.io/nim/meta/llama-3.1-8b-instruct:1.13.1

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
@@ -16,15 +16,18 @@ metadata:
     # cc_init_data annotation will be added by genpolicy with CDH configuration
     # from the custom default-initdata.toml created by create_nim_initdata_file()
 spec:
+  # Explicit user/group/supplementary groups to support nydus guest-pull.
+  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
+  # other references to this issue in the genpolicy source folder.
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
+    fsGroup: 1000
   restartPolicy: Always
   runtimeClassName: kata
   serviceAccountName: default
   imagePullSecrets:
     - name: ngc-secret-embedqa
-  securityContext:
-    fsGroup: 0
-    runAsGroup: 0
-    runAsUser: 0
   containers:
   - name: ${POD_NAME_EMBEDQA}
     image: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.10.1

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2.yaml.in
@@ -10,15 +10,16 @@ metadata:
   labels:
     app: ${POD_NAME_EMBEDQA}
 spec:
+  # unlike the instruct manifest, this image needs securityContext to
+  # avoid NVML/GPU permission failures
+  securityContext:
+    runAsUser: 1000
+    runAsGroup: 1000
   restartPolicy: Always
   runtimeClassName: kata
   serviceAccountName: default
   imagePullSecrets:
     - name: ngc-secret-embedqa
-  securityContext:
-    fsGroup: 0
-    runAsGroup: 0
-    runAsUser: 0
   containers:
   - name: ${POD_NAME_EMBEDQA}
     image: nvcr.io/nim/nvidia/llama-3.2-nv-embedqa-1b-v2:1.10.1


### PR DESCRIPTION
**Scenario:**
We never tested policy against scenarios where the new encrypted emptyDir solution was tested with the `securityContext.fsGroup` field. I tried this by adapting a NIM test case against the NVIDIA handler. My goal was to not run the container privileged, but as user 1000. With this, I needed to use securityContext.fsGroup which revealed an issue with the security policy (blocked CreateContainerRequest).

**Problem:**
The shim uses `Storage.fs_group` on block/scsi encrypted emptyDir while genpolicy used `fsgid=` in `options` and null for `fs_group`, leading to denying `CreateContainerRequest` when using the `block-encrypted` emptyDir mode in combination with `fsGroup`.

**Solution:**
Emit `fs_group` in the `block-encrypted` emptyDir mode scenario and keep `fsgid=` for the existing shared-fs/local emptyDir scenario.

**Consequence:**
This allows us to avoid running the NIM containers part of the NVIDIA tests without elevated privileges. Note that, using emptyDir does require setting a proper fsGroup ID (unless running as root user).

**Other notes:**
- Once issue 11162 is resolved, we can further refine the securityContext fields for the TEE manifests. This is unrelated to this PR.
- The use of hostPath requires proper host folder permissions. On our NVIDIA runners these are pre-configured by us, not configured in CI logic