### PR TITLE
tests: Remove skip condition for emptyDir-related tests on IBM SEL

### DIFF
--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -60,8 +60,6 @@ setup() {
 	local pod_file
 	local uid
 
-	[[ "${KATA_HYPERVISOR}" = qemu-se* ]] && \
-		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	# This is a reproducer of k8s e2e "[sig-storage] EmptyDir volumes when FSGroup is specified [LinuxOnly] [NodeFeature:FSGroup] new files should be created with FSGroup ownership when container is non-root" test
 	pod_file="${pod_config_dir}/pod-empty-dir-fsgroup.yaml"
 	agnhost_name="${container_images_agnhost_name}"

--- a/tests/integration/kubernetes/k8s-shared-volume.bats
+++ b/tests/integration/kubernetes/k8s-shared-volume.bats
@@ -10,8 +10,6 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[[ "${KATA_HYPERVISOR}" == qemu-se* ]] && \
-		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	setup_common || die "setup_common failed"
 }
 
@@ -68,8 +66,6 @@ setup() {
 }
 
 teardown() {
-	[[ "${KATA_HYPERVISOR}" == qemu-se* ]] && \
-		skip "See: https://github.com/kata-containers/kata-containers/issues/10002"
 	delete_tmp_policy_settings_dir "${policy_settings_dir}"
 	teardown_common "${node}" "${node_start_time:-}"
 }


### PR DESCRIPTION
Since #11537 resolves the issue, the PR removes the skip conditions for the k8s e2e tests involving emptyDir volume mounts. Please check out the issue for details. 

Fixes: #10002

For reviewers, I've confirmed that the test `k8s-shared-volume.bats` and `k8s-empty-dirs.bats` for the runtime class `qemu-se` and `qemu-se-runtime-rs` passed on IBM SEL.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>