### PR TITLE
runtime-rs: fix resource leak on container create/start failure

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -324,23 +324,44 @@ impl Container {
         let mut inner = self.inner.write().await;
         match process.process_type {
             ProcessType::Container => {
-                if let Err(err) = inner.start_container(&process.container_id).await {
+                let res: Result<()> = async {
+                    inner.start_container(&process.container_id).await?;
+
+                    if process_uses_passfd_io(&inner, process)? {
+                        inner
+                            .init_process
+                            .passfd_io_wait(containers, self.agent.clone())
+                            .await?;
+                    } else {
+                        let container_io = inner.new_container_io(process).await?;
+                        inner
+                            .init_process
+                            .start_io_and_wait(containers, self.agent.clone(), container_io)
+                            .await?;
+                    }
+                    Ok(())
+                }
+                .await;
+
+                if let Err(err) = res {
                     let device_manager = self.resource_manager.get_device_manager().await;
                     let _ = inner.stop_process(process, true, &device_manager).await;
-                    return Err(err);
-                }
 
-                if process_uses_passfd_io(&inner, process)? {
-                    inner
-                        .init_process
-                        .passfd_io_wait(containers, self.agent.clone())
-                        .await?;
-                } else {
-                    let container_io = inner.new_container_io(process).await?;
-                    inner
-                        .init_process
-                        .start_io_and_wait(containers, self.agent.clone(), container_io)
-                        .await?;
+                    if let Err(e) = self
+                        .resource_manager
+                        .update_linux_resource(
+                            &self.config.container_id,
+                            inner.linux_resources.as_ref(),
+                            ResourceUpdateOp::Del,
+                        )
+                        .await
+                    {
+                        warn!(
+                            self.logger,
+                            "failed to release linux resources after start failure: {:?}", e
+                        );
+                    }
+                    return Err(err);
                 }
             }
             ProcessType::Exec => {
@@ -752,13 +773,27 @@ impl Container {
     pub async fn cleanup(&mut self) -> Result<()> {
         let mut inner = self.inner.write().await;
         let device_manager = self.resource_manager.get_device_manager().await;
-        inner
+        let res = inner
             .cleanup_container(
                 self.container_id.container_id.as_str(),
                 true,
                 &device_manager,
             )
+            .await;
+
+        if let Err(e) = self
+            .resource_manager
+            .update_linux_resource(
+                &self.config.container_id,
+                inner.linux_resources.as_ref(),
+                ResourceUpdateOp::Del,
+            )
             .await
+        {
+            warn!(self.logger, "failed to cleanup linux resources: {:?}", e);
+        }
+
+        res
     }
 }
 


### PR DESCRIPTION
Fixes: #12747 

When a container failed to start (e.g., in CrashLoopBackOff), its memory and CPU limits were accumulating in the ResourceManager without being released. This caused the Sandbox to request impossible memory sizes from the hypervisor, leading to permanent Sandbox lockup or host OOM.

This patch ensures that whenever a container fails to start or is cleaned up after created fails, its tracked linux resources (CPU/Memory) are properly subtracted via `ResourceUpdateOp::Del` from the resource manager.

## E2E Verification Test

### Reproducing the Bug
First, we deployed `containerd-shim-kata-v2` official version 3.28.0 to confirm the issue.

```bash
root:/opt/kata/runtime-rs/bin# ./containerd-shim-kata-v2 --version
Kata Containers containerd shim (Rust): id: io.containerd.kata.v2, version: 3.28.0, commit: 660e3bb6535b141c84430acb25b159857278d596
```

1. Create a pod that keeps crashing.
```
kubectl apply -f - <<EOF
apiVersion: v1
kind: Pod
metadata:
  name: test-pod
  namespace: kata-test
spec:
  restartPolicy: Always
  runtimeClassName: kata-qemu-runtime-rs
  containers:
  - name: default
    image: nginx:latest
    command:
    - slee
    - inf
    resources:
      limits:
        cpu: "32"
        memory: "64Gi"
      requests:
        cpu: "32"
        memory: "64Gi"
EOF
```
This pod will keep crashing because of a typo in the sleep command.

If we then observe the Pod Condition, we will see the real error message was "the file slee was not found":
```
$ ku -n test-directvolume describe po test-pod
Name:         test-pod
Namespace:    kata-test
......
Containers:
  default:
......
    Command:
      slee
      inf
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       StartError
      Message:      failed to create containerd task: failed to create shim task: Others("failed to handle message create container\n\nCaused by:\n    0: agent create container\n    1: rpc status: Status { code: INTERNAL, message: \"the file slee was not found\\n\\nStack backtrace:\\n   0: <unknown>\\n   1: <unknown>\\n   2: <unknown>\\n   3: <unknown>\\n   4: <unknown>\\n   5: <unknown>\\n   6: <unknown>\\n   7: <unknown>\\n   8: <unknown>\\n   9: <unknown>\\n  10: <unknown>\\n  11: <unknown>\\n  12: <unknown>\\n  13: <unknown>\", details: [], special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"): unknown
      Exit Code:    128
      Started:      Thu, 01 Jan 1970 00:00:00 +0000
      Finished:     Mon, 27 Mar 2026 03:02:38 +0000
    Ready:          False
    Restart Count:  1
```


2. Waiting for the Pod to continuously crash

After the Pod was crashed for 35 times:
```
$ kubectl -n kata-test get po  test-pod 
NAME       READY   STATUS             RESTARTS         AGE
test-pod   0/1     CrashLoopBackOff   35 (2m18s ago)   156m
```

3. Observe the Condition of the Pod
```
$ kubectl -n kata-test describe po test-pod
Name:         test-pod
Namespace:    kata-test
......
Containers:
  default:
    Container ID:  containerd://7252269966fabb0d13b3ab7bd1c2f19701706154aa6dbcb61a05b63d7e35fa1c
......
    Command:
      slee
      inf
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       StartError
      Message:      failed to create containerd task: failed to create shim task: Others("failed to handle message create container\n\nCaused by:\n    0: failed to update_mem_resource\n    1: resize memory\n    2: requested memory (2361344 M) is greater than maximum allowed (515622 M)"): unknown
      Exit Code:    128
      Started:      Thu, 01 Jan 1970 00:00:00 +0000
      Finished:     Mon, 30 Mar 2026 06:04:21 +0000
    Ready:          False
    Restart Count:  35
```

We can observe that the error message has changed and it indicating that excessive memory was requested.


### Verification Bug Fixes
Next, we used my modified version `containerd-shim-kata-v2` to verify the issue fix.

```bash
root:/opt/kata/runtime-rs/bin# ./containerd-shim-kata-v2 --version
Kata Containers containerd shim (Rust): id: io.containerd.kata.v2, version: 3.28.0, commit: d787edb3d20062265bbce029a9d7dd958d5c26d7
```

1. Create a pod that keeps crashing.
Same as above Pod. And the error message was also the same.
```
$ kubectl -n kata-test describe po test-pod-fix 
Name:         test-pod-fix
Namespace:    test-directvolume
......
Containers:
  default:
    Container ID:  containerd://a5e48fde42e78a62570f2d0f9511d15fe4a89bff530d78f22fd3e903926c2be1
......
    Command:
      slee
      inf
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       StartError
      Message:      failed to create containerd task: failed to create shim task: Others("failed to handle message create container\n\nCaused by:\n    0: agent create container\n    1: rpc status: Status { code: INTERNAL, message: \"the file slee was not found\\n\\nStack backtrace:\\n   0: <unknown>\\n   1: <unknown>\\n   2: <unknown>\\n   3: <unknown>\\n   4: <unknown>\\n   5: <unknown>\\n   6: <unknown>\\n   7: <unknown>\\n   8: <unknown>\\n   9: <unknown>\\n  10: <unknown>\\n  11: <unknown>\\n  12: <unknown>\\n  13: <unknown>\", details: [], special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"): unknown
      Exit Code:    128
      Started:      Thu, 01 Jan 1970 00:00:00 +0000
      Finished:     Mon, 30 Mar 2026 06:30:47 +0000
    Ready:          False
    Restart Count:  4
```


2. Waiting for the Pod to continuously crash

We are waiting for the pod to continue crashing, exceeding the previous 35 crashes.
```
$ kubectl -n kata-test get po  test-pod-fix
NAME           READY   STATUS             RESTARTS        AGE
test-pod-fix   0/1     CrashLoopBackOff   39 (2m5s ago)   146m
```

3. Observe the Condition of the Pod
```
$ kubectl -n kata-test describe po test-pod-fix
Name:         test-pod-fix
Namespace:    kata-test
......
Containers:
  default:
    Container ID:  containerd://1cf6959c9a49b8262e9c5d9e2bfef40ff00aa8ba272d188a24dfca278208d900
......
    Command:
      slee
      inf
    State:          Waiting
      Reason:       CrashLoopBackOff
    Last State:     Terminated
      Reason:       StartError
      Message:      failed to create containerd task: failed to create shim task: Others("failed to handle message create container\n\nCaused by:\n    0: agent create container\n    1: rpc status: Status { code: INTERNAL, message: \"the file slee was not found\\n\\nStack backtrace:\\n   0: <unknown>\\n   1: <unknown>\\n   2: <unknown>\\n   3: <unknown>\\n   4: <unknown>\\n   5: <unknown>\\n   6: <unknown>\\n   7: <unknown>\\n   8: <unknown>\\n   9: <unknown>\\n  10: <unknown>\\n  11: <unknown>\\n  12: <unknown>\\n  13: <unknown>\", details: [], special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }"): unknown
      Exit Code:    128
      Started:      Thu, 01 Jan 1970 00:00:00 +0000
      Finished:     Mon, 30 Mar 2026 08:53:42 +0000
    Ready:          False
    Restart Count:  39
```

As you can see, the error message no longer changes after multiple crashes. The real error message will no longer be masked by resource accounting  leak problem.

The above verification shows that this patch can indeed fix this problem. 