### PR TITLE
helm: add overheadEnabled switch for runtimeclass

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -26,10 +26,22 @@ handler: kata-{{ .shim }}-{{ .root.Values.env.multiInstallSuffix }}
 {{- else }}
 handler: kata-{{ .shim }}
 {{- end }}
+{{- /* Overhead section - controlled by global or per-shim overheadEnabled flag (default: true) */ -}}
+{{- $shimOverheadEnabled := true -}}
+{{- if hasKey .root.Values.runtimeClasses "overheadEnabled" -}}
+{{- $shimOverheadEnabled = .root.Values.runtimeClasses.overheadEnabled -}}
+{{- end -}}
+{{- with .shimConfig.runtimeClass -}}
+{{- if hasKey . "overheadEnabled" -}}
+{{- $shimOverheadEnabled = .overheadEnabled -}}
+{{- end -}}
+{{- end -}}
+{{- if $shimOverheadEnabled }}
 overhead:
   podFixed:
     memory: {{ .config.memory | quote }}
     cpu: {{ .config.cpu | quote }}
+{{- end }}
 scheduling:
   nodeSelector:
     katacontainers.io/kata-runtime: "true"

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -69,6 +69,7 @@ snapshotter:
 #       runtimeClass:
 #         nodeSelector:              # extra node selectors added to the RuntimeClass
 #           example.io/feature: "true"
+#         overheadEnabled: true      # enable/disable overhead in RuntimeClass (default: inherits from runtimeClasses.overheadEnabled)
 #         overhead:                  # override pod overhead (falls back to built-in defaults)
 #           memory: "160Mi"
 #           cpu: "250m"
@@ -344,6 +345,10 @@ runtimeClasses:
   enabled: true
   createDefault: false
   defaultName: "kata"
+  # Global switch for overhead in all RuntimeClasses (default: true)
+  # Set to false to disable overhead for all shims globally.
+  # Individual shims can override this via shims.<name>.runtimeClass.overheadEnabled
+  overheadEnabled: true
 
 env:
   installationPrefix: ""


### PR DESCRIPTION
Add global and per-shim overhead control for RuntimeClass:
- Global switch: runtimeClasses.overheadEnabled (default: true)
- Per-shim override: shims.<name>.runtimeClass.overheadEnabled
- Priority: per-shim > global > default(true)

## Related Discussion
https://github.com/kata-containers/kata-containers/discussions/12745