### PR TITLE
runtime-rs: deny unknown fields in config

### DIFF
--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -19,6 +19,7 @@ use super::default::{
 pub const AGENT_NAME_KATA: &str = "kata";
 
 #[derive(Default, Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct MemAgent {
     #[serde(default, alias = "mem_agent_enable")]
     pub enable: bool,
@@ -58,6 +59,7 @@ pub struct MemAgent {
 
 /// Kata agent configuration information.
 #[derive(Debug, Deserialize, Serialize, Clone)]
+#[serde(deny_unknown_fields)]
 pub struct Agent {
     /// If enabled, the agent will log additional debug messages to the system log.
     #[serde(default, rename = "enable_debug")]

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1163,6 +1163,7 @@ impl NetworkInfo {
 
 /// Configuration information for rootless user.
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct RootlessUser {
     /// The UID of the rootless user.
     #[serde(default)]
@@ -1568,6 +1569,7 @@ impl VmTemplateInfo {
 
 /// Configuration information for VM factory (templating, caches, etc.).
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct Factory {
     /// Enable VM templating support.
     /// When enabled, new VMs may be created from a template to speed up creation.

--- a/src/libs/kata-types/src/config/shared_mount.rs
+++ b/src/libs/kata-types/src/config/shared_mount.rs
@@ -8,6 +8,7 @@ use std::io::Result;
 use regex::Regex;
 
 #[derive(Debug, Deserialize, Serialize, Clone, Default)]
+#[serde(deny_unknown_fields)]
 pub struct SharedMount {
     /// Name is used to identify a pair of shared mount points.
     /// This field cannot be omitted.
@@ -143,7 +144,6 @@ mod tests {
                 shared_mount_annotation: r#"
                 {
                     "name": "test",
-                    "src": "sidecar",
                     "src_path": "/mnt/storage",
                     "dst_ctr": "app",
                     "dst_path": "/mnt/storage"
@@ -156,7 +156,6 @@ mod tests {
                 {
                     "name": "test",
                     "src_ctr": "sidecar",
-                    "src_dir": "/mnt/storage",
                     "dst_ctr": "app",
                     "dst_path": "/mnt/storage"
                 }"#,
@@ -169,7 +168,6 @@ mod tests {
                     "name": "test",
                     "src_ctr": "sidecar",
                     "src_path": "/mnt/storage",
-                    "dst_container": "app",
                     "dst_path": "/mnt/storage"
                 }"#,
                 result: false,
@@ -181,8 +179,7 @@ mod tests {
                     "name": "test",
                     "src_ctr": "sidecar",
                     "src_path": "/mnt/storage",
-                    "dst_ctr": "app",
-                    "path": "/mnt/storage"
+                    "dst_ctr": "app"
                 }"#,
                 result: false,
                 message: "shared_mount: field 'dst_path' couldn't be empty.",

--- a/src/libs/kata-types/tests/texture/configuration-anno-0.toml
+++ b/src/libs/kata-types/tests/texture/configuration-anno-0.toml
@@ -65,8 +65,8 @@ enable_guest_swap = true
 [agent.agent0]
 enable_tracing = true
 debug_console_enabled = true
-debug = true
-dial_timeout = 1
+enable_debug = true
+dial_timeout_ms = 1000
 kernel_modules = ["e1000e InterruptThrottleRate=3000,3000,3000 EEE=1","i915_enabled_ppgtt=0"]
 container_pipe_size = 2
 [runtime]

--- a/src/libs/kata-types/tests/texture/configuration-anno-1.toml
+++ b/src/libs/kata-types/tests/texture/configuration-anno-1.toml
@@ -64,8 +64,8 @@ enable_guest_swap = true
 [agent.agent0]
 enable_tracing = true
 debug_console_enabled = true
-debug = true
-dial_timeout = 1
+enable_debug = true
+dial_timeout_ms = 1000
 kernel_modules = ["e1000e InterruptThrottleRate=3000,3000,3000 EEE=1","i915_enabled_ppgtt=0"]
 container_pipe_size = 2
 [runtime]


### PR DESCRIPTION
..where possible. Failing on unknown fields makes migration easier, as we do not silently ignore configuration options that previously worked in runtime-go. However, serde can't deny unknown fields where flatten is used, so this can't be used everywhere sadly.

There were also errors in test fixtures that were unnoticed. These are fixed here, too.