### PR TITLE
tests: Configure devmapper properly regardless of containerd version

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -560,6 +560,63 @@ function ensure_yq() {
 	hash -d yq 2> /dev/null || true # yq is preinstalled on GHA Ubuntu 22.04 runners so we clear Bash's PATH cache.
 }
 
+function ensure_pip() {
+	command -v python3 &> /dev/null || die "python3 is required"
+	python3 -m pip --version &> /dev/null && return
+
+	python3 -m ensurepip --user 2>/dev/null || \
+		(sudo apt-get update && \
+			sudo apt-get install -y python3-pip 2>/dev/null) || \
+		die "failed to bootstrap pip"
+
+	python3 -m pip --version &> /dev/null || die "pip is unavailable after bootstrap"
+}
+
+function install_tomlq() {
+	command -v jq &> /dev/null || die "jq is required by tomlq but was not found"
+	command -v tomlq &> /dev/null && echo "tomlq is already installed." && return
+	ensure_pip
+
+	echo "tomlq is not installed. Installing..."
+	python3 -m pip install --user --upgrade yq tomlkit 2>/dev/null || \
+		python3 -m pip install --user --upgrade --break-system-packages yq tomlkit || \
+		die "failed to install tomlq"
+
+	# Save the original PATH before modifying it
+	export _TOMLQ_ORIGINAL_PATH="${PATH}"
+	export PATH="${HOME}/.local/bin:${PATH}"
+	hash -r
+
+	command -v tomlq &> /dev/null && export _TOMLQ_INSTALLED=true || die "tomlq installation failed"
+}
+
+function uninstall_tomlq() {
+	if [ -z "${_TOMLQ_INSTALLED:-}" ]; then
+		echo "tomlq was not installed by install_tomlq(); skipping uninstall."
+		return
+	fi
+
+	if command -v tomlq &> /dev/null; then
+		echo "Uninstalling tomlq..."
+
+		# Only attempt uninstall if python3 and pip are available
+		if command -v python3 &> /dev/null && python3 -m pip --version &> /dev/null; then
+			python3 -m pip uninstall -y yq tomlkit 2>/dev/null || \
+				python3 -m pip uninstall -y --break-system-packages yq tomlkit || \
+				die "failed to uninstall tomlq"
+		else
+			warn "tomlq found in PATH but python3 or pip unavailable; skipping uninstall (likely preinstalled)"
+		fi
+	fi
+
+	# Restore the original PATH if it was saved by install_tomlq
+	if [ -n "${_TOMLQ_ORIGINAL_PATH}" ]; then
+		export PATH="${_TOMLQ_ORIGINAL_PATH}"
+		unset _TOMLQ_ORIGINAL_PATH
+		hash -r
+	fi
+}
+
 function ensure_helm() {
 	ensure_yq
 	# The get-helm-3 script will take care of downloaading and installing Helm

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -86,30 +86,41 @@ EOF
 		*) >&2 echo "${KUBERNETES} flavour is not supported"; exit 2 ;;
 	esac
 
-	# We're not using this with baremetal machines, so we're fine on cutting
-	# corners here and just append this to the configuration file.
-	# Check if the "devmapper" plugin section exists in the file
-	if grep -q 'plugins."io.containerd.snapshotter.v1.devmapper"' "${containerd_config_file}"; then
-	    echo "devmapper section found. Updating pool_name and base_image_size..."
-	    sudo sed -i '/\[plugins."io.containerd.snapshotter.v1.devmapper"\]/,/\[plugins\./ {
-	        s/pool_name = ".*"/pool_name = "contd-thin-pool"/
-	        s/base_image_size = ".*"/base_image_size = "4096MB"/
-	    }' "${containerd_config_file}"
-	else
-	    echo "devmapper section not found. Appending to the config file..."
-		cat<<EOF | sudo tee -a "${containerd_config_file}"
-[plugins."io.containerd.snapshotter.v1.devmapper"]
-  pool_name = "contd-thin-pool"
-  base_image_size = "4096MB"
-EOF
-	fi
+	# We need to use tomlq to update the containerd config with the devmapper configuration,
+	# as it's a more complex update that involves adding new entries and modifying existing ones
+	# for two different containerd versions.
+	install_tomlq
+
+	containerd_arch="$(uname -m)"
+	case "${containerd_arch}" in
+		x86_64) containerd_arch="amd64" ;;
+		aarch64|arm64) containerd_arch="arm64" ;;
+	esac
+
+	echo "Updating containerd config with tomlq..."
+	config_tmp_file="$(sudo mktemp)"
+	sudo cat "${containerd_config_file}" | tomlq -t --arg platform "linux/${containerd_arch}" '
+		.plugins["io.containerd.snapshotter.v1.devmapper"].pool_name = "contd-thin-pool"
+		| .plugins["io.containerd.snapshotter.v1.devmapper"].base_image_size = "4096MB"
+		| .plugins["io.containerd.transfer.v1.local"].unpack_config =
+			[((.plugins["io.containerd.transfer.v1.local"].unpack_config[0] // {}) + {platform: $platform, snapshotter: "devmapper"})]
+		| if .version == 3 then
+			.plugins["io.containerd.cri.v1.images"].snapshotter = "devmapper"
+		  else
+			.plugins["io.containerd.grpc.v1.cri"].containerd.snapshotter = "devmapper"
+		  end
+	' | sudo tee "${config_tmp_file}" > /dev/null
+	sudo mv "${config_tmp_file}" "${containerd_config_file}"
+
+	# We only need tomlq for this configuration.
+	# yq, installed by install_tomlq, might cause an issue with go-based yq used by CI.
+	# So we uninstall tomlq to remove the yq from PATH and avoid any potential conflict.
+	uninstall_tomlq
 
 	case "${KUBERNETES}" in
 		k3s)
-			sudo sed -i -e 's/snapshotter = "overlayfs"/snapshotter = "devmapper"/g' "${containerd_config_file}"
 			sudo systemctl restart k3s ;;
 		kubeadm)
-			sudo sed -i -e 's/snapshotter = "overlayfs"/snapshotter = "devmapper"/g' "${containerd_config_file}"
 			sudo systemctl restart containerd ;;
 		*) >&2 echo "${KUBERNETES} flavour is not supported"; exit 2 ;;
 	esac


### PR DESCRIPTION
The follow differences are observed between container 1.x and 2.x:

```
[plugins.'io.containerd.snapshotter.v1.devmapper']
snapshotter = 'overlayfs'
```
and
```
[plugins."io.containerd.snapshotter.v1.devmapper"]
snapshotter = "overlayfs"
```

The current devmapper configuration only works with double quotes. Make it work with both single and double quotes via tomlq.

In the default configuration for containerd 2.x, the following configuration block is missing:

```
[[plugins.'io.containerd.transfer.v1.local'.unpack_config]]
  platform = "linux/s390x"     # system architecture
  snapshotter = "devmapper"
```

Ensure the configuration block is added for containerd 2.x.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>