### PR TITLE
runtime-rs: Fix typo in share_fs error message

### DIFF
--- a/src/runtime-rs/crates/resource/src/share_fs/mod.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/mod.rs
@@ -165,6 +165,6 @@ pub fn new(id: &str, config: &SharedFsInfo) -> Result<Arc<dyn ShareFs>> {
         VIRTIO_FS => Ok(Arc::new(
             ShareVirtioFsStandalone::new(id, config).context("new standalone virtio fs")?,
         )),
-        _ => Err(anyhow!("unsupported shred fs {:?}", &shared_fs)),
+        _ => Err(anyhow!("unsupported shared fs {:?}", &shared_fs)),
     }
 }


### PR DESCRIPTION
There's a typo in the error message which gets prompted when an unsupported share_fs was configured. Fixed shred -> shared.