### PR TITLE
kata-deploy: Make nydus a soft dep of containerd

### DIFF
--- a/tools/packaging/kata-deploy/nydus-snapshotter/nydus-snapshotter.service
+++ b/tools/packaging/kata-deploy/nydus-snapshotter/nydus-snapshotter.service
@@ -5,6 +5,8 @@ Before=containerd.service
 
 [Service]
 ExecStart=@CONTAINERD_NYDUS_GRPC_BINARY@ --config @CONFIG_GUEST_PULLING@ --log-to-stdout
+Restart=always
+RestartSec=5
 
 [Install]
 WantedBy=containerd.service


### PR DESCRIPTION
Let's relax our RequiredBy and use a WantedBy in the nydus systemd unit file as, in case of a nydus crash, containerd would also be put down, causing the node to become NotReady.

Also, let's make sure nydus-snapshotter restarts in case of failure, following what's done by containerd itself.