### PR TITLE
runtime-rs: Fix FC API fields

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/firecracker/fc_api.rs
+++ b/src/runtime-rs/crates/hypervisor/src/firecracker/fc_api.rs
@@ -111,7 +111,7 @@ impl FcInner {
 
         let body_config: String = json!({
             "mem_size_mib": self.config.memory_info.default_memory,
-            "vcpu_count": self.config.cpu_info.default_vcpus,
+            "vcpu_count": self.config.cpu_info.default_vcpus.ceil() as u8,
         })
         .to_string();
         let body_kernel: String = json!({
@@ -191,13 +191,10 @@ impl FcInner {
                 .disk_rate_limiter_ops_one_time_burst,
         );
 
-        let rate_limiter = serde_json::to_string(&block_rate_limit)
-            .with_context(|| format!("serde {block_rate_limit:?} to json"))?;
-
         let body: String = json!({
             "drive_id": format!("drive{drive_id}"),
             "path_on_host": new_drive_path,
-            "rate_limiter": rate_limiter,
+            "rate_limiter": block_rate_limit,
         })
         .to_string();
         self.request_with_retry(


### PR DESCRIPTION
A FC update caused bad requests for the runtime-rs runtime when specifying the vcpu count and block rate limiter fields.