### PR TITLE
workflows: ensure gatekeeper uses only the PR changes

### DIFF
--- a/.github/workflows/gatekeeper-skipper.yaml
+++ b/.github/workflows/gatekeeper-skipper.yaml
@@ -60,6 +60,11 @@ jobs:
           ref: ${{ inputs.commit-hash }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
       - name: Determine gatekeeper ref
         id: gatekeeper-ref
         if: ${{ github.event.pull_request.base.ref == '' && inputs.gatekeeper-ref == '' }}

--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -73,6 +73,11 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || steps.pr-details.outputs.head-sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ github.event.pull_request.base.ref || steps.pr-details.outputs.base-ref }}
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           ref: ${{ github.event.pull_request.base.ref || steps.pr-details.outputs.gatekeeper-ref }}

--- a/tools/testing/gatekeeper/skips.py
+++ b/tools/testing/gatekeeper/skips.py
@@ -81,7 +81,7 @@ class Checks:
         :param target_branch: branch/commit to compare to
         :returns: List of set-of-tests
         """
-        cmd = ["git", "diff", "--name-only", f"origin/{target_branch}"]
+        cmd = ["git", "diff", "--name-only", f"origin/{target_branch}..HEAD"]
         changed_files = [_.decode("utf-8")
                          for _ in subprocess.check_output(cmd).split(b'\n')
                          if _.strip()]


### PR DESCRIPTION
this PR is based on top of the https://github.com/kata-containers/kata-containers/pull/12722 see that one for the first commit motivation.

As for the second commit:

currently the gatekeeper compares the latest (potentially updated)
target branch to the current PR content, which (on update) leads to
comparing all the changes that were already merged into the target
branch.

To address that we could either use the original PR reference (git diff
main...HEAD) or rebase before running the diff. This commit uses the
later as we want to ensure things apply smoothly and that we are
checking only the to-be-left changes (some commits might be already
merged at this time, no need to test them as they'd be skipped).