### PR TITLE
nvrc: Bump to the latest Release

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -234,7 +234,7 @@ externals:
   nvrc:
     # yamllint disable-line rule:line-length
     desc: "The NVRC project provides a Rust binary that implements a simple init system for microVMs"
-    version: "v0.1.3"
+    version: "v0.1.4"
     url: "https://github.com/NVIDIA/nvrc/releases/download/"
 
   nvidia:


### PR DESCRIPTION
v0.1.4 has a bugfix for nvrc.log=trace which is now optional.