### PR TITLE
runtime: SNP img-based rootfs with dm-verity

### DIFF
--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -16,8 +16,7 @@
 [hypervisor.qemu]
 path = "@QEMUPATH@"
 kernel = "@KERNELPATH_COCO@"
-initrd = "@INITRDCONFIDENTIALPATH@"
-# image = "@IMAGECONFIDENTIALPATH@"
+image = "@IMAGECONFIDENTIALPATH@"
 machine_type = "@MACHINETYPE@"
 
 # Enable confidential guest support.
@@ -98,6 +97,11 @@ valid_hypervisor_paths = @QEMUVALIDHYPERVISORPATHS@
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
 kernel_params = "@KERNELPARAMS@"
+
+# Optional dm-verity parameters (comma-separated key=value list):
+# root_hash=...,salt=...,data_blocks=...,data_block_size=...,hash_block_size=...
+# These are used by the runtime to assemble dm-verity kernel params.
+kernel_verity_params = "@KERNELVERITYPARAMS@"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -15,7 +15,7 @@
 [hypervisor.qemu]
 path = "@QEMUPATH@"
 kernel = "@KERNELCONFIDENTIALPATH@"
-initrd = "@INITRDCONFIDENTIALPATH@"
+image = "@IMAGECONFIDENTIALPATH@"
 machine_type = "@MACHINETYPE@"
 
 # rootfs filesystem type:
@@ -90,6 +90,11 @@ snp_guest_policy = 196608
 # To see the list of default parameters, enable hypervisor debug, create a
 # container and look for 'default-kernel-parameters' log entries.
 kernel_params = "@KERNELPARAMS@"
+
+# Optional dm-verity parameters (comma-separated key=value list):
+# root_hash=...,salt=...,data_blocks=...,data_block_size=...,hash_block_size=...
+# These are used by the runtime to assemble dm-verity kernel params.
+kernel_verity_params = "@KERNELVERITYPARAMS@"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty

--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -16,7 +16,7 @@ shim_config_file="/opt/kata/share/defaults/kata-containers/configuration-${KATA_
 
 check_and_skip() {
 	case "${KATA_HYPERVISOR}" in
-		qemu-tdx|qemu-coco-dev)
+		qemu-tdx|qemu-coco-dev|qemu-snp)
 			if [ "$(uname -m)" == "s390x" ]; then
 				skip "measured rootfs tests not implemented for s390x"
 			fi


### PR DESCRIPTION
Follow-on to kata-containers/kata-containers#12396

Switch SNP configs from initrd-based to image-based rootfs with dm-verity. The runtime assembles the dm-mod.create kernel cmdline from kernel_verity_params, and with kernel-hashes=on the root hash is included in the SNP launch measurement.

Also add qemu-snp to the measured rootfs integration test.

Tested both runtimes locally:
- ran `ps` to see the qemu command, I see the new `dm-mod.create` kernel var + device param with .image rootfs
- sanity-checked that VM boots and basic container can do a secret fetch from trustee (though I didn't compare that the measurement changed to include the new kern vars, just assuming that's working correctly...)

cc: @fitzthum @manuelh-dev @hgowda-amd 