### PR TITLE
tests: strip \r from kubectl exec output for TTY containers

### DIFF
--- a/tests/integration/kubernetes/k8s-exec.bats
+++ b/tests/integration/kubernetes/k8s-exec.bats
@@ -69,11 +69,11 @@ EOF"
 
 	## Cases for target container
 	### First container
-	container_name=$(kubectl exec $pod_name -c $first_container_name -- $env_command | grep CONTAINER_NAME)
+	container_name=$(kubectl exec $pod_name -c $first_container_name -- $env_command | grep CONTAINER_NAME | tr -d '\r')
 	[ "$container_name" == "CONTAINER_NAME=$first_container_name" ]
 
 	### Second container
-	container_name=$(kubectl exec $pod_name -c $second_container_name -- $env_command | grep CONTAINER_NAME)
+	container_name=$(kubectl exec $pod_name -c $second_container_name -- $env_command | grep CONTAINER_NAME | tr -d '\r')
 	[ "$container_name" == "CONTAINER_NAME=$second_container_name" ]
 
 }

--- a/tests/integration/kubernetes/k8s-pid-ns.bats
+++ b/tests/integration/kubernetes/k8s-pid-ns.bats
@@ -35,15 +35,16 @@ setup() {
 	kubectl wait --for=condition=Ready --timeout=$timeout pod $pod_name
 
 	# Check PID from first container
+	# Strip \r — containers with tty: true return \r\n line endings
 	first_pid_container=$(kubectl exec $pod_name -c $first_container_name \
-		-- $ps_command | grep "/pause")
+		-- $ps_command | grep "/pause" | tr -d '\r')
 	# Verify that is not empty
 	check_first_pid=$(echo $first_pid_container | wc -l)
 	[ "$check_first_pid" == "1" ]
 
 	# Check PID from second container
 	second_pid_container=$(kubectl exec $pod_name -c $second_container_name \
-		-- $ps_command | grep "/pause")
+		-- $ps_command | grep "/pause" | tr -d '\r')
 	# Verify that is not empty
 	check_second_pid=$(echo $second_pid_container | wc -l)
 	[ "$check_second_pid" == "1" ]


### PR DESCRIPTION
## Summary

Fix `k8s-exec.bats` and `k8s-pid-ns.bats` failing when the test pod
has a container with `tty: true`.

The `busybox-pod.yaml` fixture sets `tty: true` on the second container.
When a container has a TTY, `kubectl exec` may return `\r\n` line endings.
The invisible `\r` causes string comparisons to silently fail:

```bash
container_name=$(kubectl exec ... -c second-test-container -- env | grep CONTAINER_NAME)
# container_name = "CONTAINER_NAME=second-test-container\r"
[ "$container_name" == "CONTAINER_NAME=second-test-container" ]
# FAILS — trailing \r
```

Fix: pipe through `tr -d '\r'` after grep. Harmless when `\r` is absent.

## Test plan

- [x] `bats k8s-exec.bats` — passes (was failing consistently)
- [x] `bats k8s-pid-ns.bats` — passes (was failing consistently)
- [x] Full BATS suite (24 tests) — 23 pass, 1 unrelated failure (`k8s-oom`)
- Tested on: k3s v1.34 + CRI-O 1.33 + kata-deploy 3.26.0 (qemu-coco-dev)

Fixes #9136