### PR TITLE
ci: Refactor confidential TEE support

### DIFF
--- a/.github/workflows/run-k8s-tests-on-zvsi.yaml
+++ b/.github/workflows/run-k8s-tests-on-zvsi.yaml
@@ -46,10 +46,9 @@ jobs:
         include:
           - snapshotter: devmapper
             pull-type: default
-            deploy-cmd: configure-snapshotter
+            snapshotter-cmd: configure-snapshotter
           - snapshotter: nydus
             pull-type: guest-pull
-            deploy-cmd: deploy-snapshotter
         exclude:
           - snapshotter: overlayfs
             vmm: qemu
@@ -104,9 +103,9 @@ jobs:
       # See: https://github.com/kata-containers/kata-containers/issues/10066
       - name: Configure the ${{ matrix.snapshotter }} snapshotter
         env:
-          DEPLOY_CMD: ${{ matrix.deploy-cmd }}
-        run: bash tests/integration/kubernetes/gha-run.sh "${DEPLOY_CMD}"
-        if: ${{ matrix.snapshotter != 'overlayfs' }}
+          SNAPSHOTTER_CMD: ${{ matrix.snapshotter-cmd }}
+        run: bash tests/integration/kubernetes/gha-run.sh "${SNAPSHOTTER_CMD}"
+        if: ${{ matrix.snapshotter != 'overlayfs' && matrix.snapshotter-cmd != '' }}
 
       - name: Deploy Kata
         timeout-minutes: 20

--- a/.github/workflows/run-kata-coco-stability-tests.yaml
+++ b/.github/workflows/run-kata-coco-stability-tests.yaml
@@ -122,10 +122,6 @@ jobs:
       - name: Download credentials for the Kubernetes CLI to use them
         run: bash tests/integration/kubernetes/gha-run.sh get-cluster-credentials
 
-      - name: Deploy Snapshotter
-        timeout-minutes: 5
-        run: bash tests/integration/kubernetes/gha-run.sh deploy-snapshotter
-
       - name: Deploy Kata
         timeout-minutes: 10
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata-aks

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -6,7 +6,8 @@
 
 tests_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${tests_dir}/common.bash"
-kubernetes_dir="${tests_dir}/integration/kubernetes"
+source "${tests_dir}/hypervisor_helpers.sh"
+: "${kubernetes_dir:=${tests_dir}/integration/kubernetes}"
 helm_chart_dir="${repo_root_dir}/tools/packaging/kata-deploy/helm-chart/kata-deploy"
 
 AZ_REGION="${AZ_REGION:-eastus2}"
@@ -635,10 +636,12 @@ function helm_helper() {
 					base_values_file="${helm_chart_dir}/try-kata-nvidia-gpu.values.yaml"
 				fi
 				;;
-			qemu-snp|qemu-snp-runtime-rs|qemu-tdx|qemu-se|qemu-se-runtime-rs|qemu-cca|qemu-coco-dev|qemu-coco-dev-runtime-rs)
-				# Use TEE example file
-				if [[ -f "${helm_chart_dir}/try-kata-tee.values.yaml" ]]; then
-					base_values_file="${helm_chart_dir}/try-kata-tee.values.yaml"
+			*)
+				# Use TEE example file for confidential computing hypervisors
+				if is_confidential_runtime_class "${KATA_HYPERVISOR}"; then
+					if [[ -f "${helm_chart_dir}/try-kata-tee.values.yaml" ]]; then
+						base_values_file="${helm_chart_dir}/try-kata-tee.values.yaml"
+					fi
 				fi
 				;;
 		esac
@@ -696,43 +699,30 @@ function helm_helper() {
 			for shim in ${HELM_SHIMS}; do
 				# Determine supported architectures based on shim name
 				# Most shims support amd64 and arm64, some have specific arch requirements
-				case "${shim}" in
-					qemu-se|qemu-se-runtime-rs)
-						yq -i ".shims.${shim}.enabled = true" "${values_yaml}"
-						yq -i ".shims.${shim}.supportedArches = [\"s390x\"]" "${values_yaml}"
-						;;
-					qemu-cca)
-						yq -i ".shims.${shim}.enabled = true" "${values_yaml}"
-						yq -i ".shims.${shim}.supportedArches = [\"arm64\"]" "${values_yaml}"
-						;;
-					qemu-snp|qemu-snp-runtime-rs|qemu-tdx|qemu-tdx-runtime-rs|qemu-nvidia-gpu-snp|qemu-nvidia-gpu-tdx)
-						yq -i ".shims.${shim}.enabled = true" "${values_yaml}"
-						yq -i ".shims.${shim}.supportedArches = [\"amd64\"]" "${values_yaml}"
-						;;
-					qemu-runtime-rs)
-						yq -i ".shims.${shim}.enabled = true" "${values_yaml}"
-						yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\", \"s390x\"]" "${values_yaml}"
-						;;
-					qemu-coco-dev|qemu-coco-dev-runtime-rs)
-						yq -i ".shims.${shim}.enabled = true" "${values_yaml}"
-						yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"s390x\"]" "${values_yaml}"
-						;;
-					qemu-nvidia-gpu)
-						yq -i ".shims.${shim}.enabled = true" "${values_yaml}"
-						yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\"]" "${values_yaml}"
-						;;
-					*)
-						# Default: support amd64, arm64, s390x, ppc64le
-						yq -i ".shims.${shim}.enabled = true" "${values_yaml}"
-						yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\", \"s390x\", \"ppc64le\"]" "${values_yaml}"
-						;;
-				esac
+				yq -i ".shims.${shim}.enabled = true" "${values_yaml}"
+
+				if is_se_hypervisor "${shim}"; then
+					yq -i ".shims.${shim}.supportedArches = [\"s390x\"]" "${values_yaml}"
+				elif is_cca_hypervisor "${shim}"; then
+					yq -i ".shims.${shim}.supportedArches = [\"arm64\"]" "${values_yaml}"
+				elif is_snp_hypervisor "${shim}" || is_tdx_hypervisor "${shim}" || is_confidential_gpu_hypervisor "${shim}"; then
+					yq -i ".shims.${shim}.supportedArches = [\"amd64\"]" "${values_yaml}"
+				elif [[ "${shim}" == "qemu-runtime-rs" ]]; then
+					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\", \"s390x\"]" "${values_yaml}"
+				elif is_non_tee_hypervisor "${shim}"; then
+					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"s390x\"]" "${values_yaml}"
+				elif [[ "${shim}" == "qemu-nvidia-gpu" ]]; then
+					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\"]" "${values_yaml}"
+				else
+					# Default: support amd64, arm64, s390x, ppc64le
+					yq -i ".shims.${shim}.supportedArches = [\"amd64\", \"arm64\", \"s390x\", \"ppc64le\"]" "${values_yaml}"
+				fi
 
 				# Explicitly unset defaults for TEE shims - these will be set based on env vars:
 				# - snapshotter: nydus if HELM_SNAPSHOTTER_HANDLER_MAPPING is set
 				# - forceGuestPull: true if HELM_EXPERIMENTAL_FORCE_GUEST_PULL is set
 				# - guestPull: true if HELM_PULL_TYPE_MAPPING contains guest-pull
-				if echo "${tee_shims}" | grep -qw "${shim}"; then
+				if is_confidential_runtime_class "${shim}" || is_confidential_gpu_hypervisor "${shim}"; then
 					yq -i ".shims.${shim}.containerd.snapshotter = \"\"" "${values_yaml}"
 					yq -i ".shims.${shim}.containerd.forceGuestPull = false" "${values_yaml}"
 					yq -i ".shims.${shim}.crio.guestPull = false" "${values_yaml}"

--- a/tests/hypervisor_helpers.sh
+++ b/tests/hypervisor_helpers.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Copyright 2026 IBM Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+SNP_HYPERVISORS=("qemu-snp" "qemu-snp-runtime-rs")
+TDX_HYPERVISORS=("qemu-tdx" "qemu-tdx-runtime-rs")
+SE_HYPERVISORS=("qemu-se" "qemu-se-runtime-rs")
+CCA_HYPERVISORS=("qemu-cca")
+GPU_TEE_HYPERVISORS=("qemu-nvidia-gpu-snp" "qemu-nvidia-gpu-tdx")
+TEE_HYPERVISORS=("${SNP_HYPERVISORS[@]}" "${TDX_HYPERVISORS[@]}" "${SE_HYPERVISORS[@]}" "${CCA_HYPERVISORS[@]}" "${GPU_TEE_HYPERVISORS[@]}")
+NON_TEE_HYPERVISORS=("qemu-coco-dev" "qemu-coco-dev-runtime-rs")
+FIRECRACKER_HYPERVISORS=("firecracker" "fc")
+
+function is_snp_hypervisor() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	[[ " ${SNP_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
+	return 1
+}
+
+function is_tdx_hypervisor() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	[[ " ${TDX_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
+	return 1
+}
+
+function is_se_hypervisor() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	[[ " ${SE_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
+	return 1
+}
+
+function is_cca_hypervisor() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	[[ " ${CCA_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
+	return 1
+}
+
+function is_non_tee_hypervisor() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	[[ " ${NON_TEE_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
+	return 1
+}
+
+function is_confidential_gpu_hypervisor() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	[[ " ${GPU_TEE_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
+	return 1
+}
+
+function is_firecracker_hypervisor() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	[[ " ${FIRECRACKER_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
+	return 1
+}
+
+# Common check for confidential hardware (TEE) runtime class.
+function is_confidential_hardware() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	# This check must be done with "<SPACE>${KATA_HYPERVISOR}<SPACE>" to avoid
+	# having substrings, like qemu, being matched with qemu-$something.
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	if [[ " ${TEE_HYPERVISORS[*]} " =~ " ${hypervisor} " ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# Common check for confidential runtime class.
+function is_confidential_runtime_class() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	if is_confidential_hardware "${hypervisor}" || is_non_tee_hypervisor "${hypervisor}"; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+is_hotplug_supported() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	if is_confidential_runtime_class "${hypervisor}"; then
+		echo "Confidential computing hypervisors don't support hotplug" >&2
+		return 1
+	elif is_firecracker_hypervisor "${hypervisor}"; then
+		echo "FC doesn't support hotplug" >&2
+		return 1
+	fi
+	return 0
+}

--- a/tests/integration/kubernetes/confidential_common.sh
+++ b/tests/integration/kubernetes/confidential_common.sh
@@ -1,25 +1,23 @@
 #!/usr/bin/env bash
 # Copyright 2022-2023 Advanced Micro Devices, Inc.
 # Copyright 2023 Intel Corporation
+# Copyright 2026 IBM Corporation
 #
 # SPDX-License-Identifier: Apache-2.0
 #
 
 source "${BATS_TEST_DIRNAME}/tests_common.sh"
 source "${BATS_TEST_DIRNAME}/../../common.bash"
+source "${BATS_TEST_DIRNAME}/../../hypervisor_helpers.sh"
 
 load "${BATS_TEST_DIRNAME}/confidential_kbs.sh"
-
-SUPPORTED_GPU_TEE_HYPERVISORS=("qemu-nvidia-gpu-snp" "qemu-nvidia-gpu-tdx")
-SUPPORTED_TEE_HYPERVISORS=("qemu-snp" "qemu-snp-runtime-rs" "qemu-tdx" "qemu-se" "qemu-se-runtime-rs" "${SUPPORTED_GPU_TEE_HYPERVISORS[@]}")
-SUPPORTED_NON_TEE_HYPERVISORS=("qemu-coco-dev" "qemu-coco-dev-runtime-rs")
 
 function setup_unencrypted_confidential_pod() {
 	get_pod_config_dir
 
 	export SSH_KEY_FILE="${pod_config_dir}/confidential/unencrypted/ssh/unencrypted"
 
-	if [ -n "${GH_PR_NUMBER}" ]; then
+	if [[ -n "${GH_PR_NUMBER}" ]]; then
 		# Use correct address in pod yaml
 		sed -i "s/-nightly/-${GH_PR_NUMBER}/" "${pod_config_dir}/pod-confidential-unencrypted.yaml"
 	fi
@@ -32,84 +30,22 @@ function setup_unencrypted_confidential_pod() {
 # and returns the remote command to be executed to that specific hypervisor
 # in order to identify whether the workload is running on a TEE environment
 function get_remote_command_per_hypervisor() {
-	case "${KATA_HYPERVISOR}" in
-		qemu-se*)
-			echo "cd /sys/firmware/uv; cat prot_virt_guest | grep 1"
-			;;
-		qemu-snp|qemu-snp-runtime-rs)
-			echo "dmesg | grep \"Memory Encryption Features active:.*SEV-SNP\""
-			;;
-		qemu-tdx)
-			echo "cpuid | grep TDX_GUEST"
-			;;
-		*)
-			echo ""
-			;;
-	esac
-}
-
-# This function verifies whether the input hypervisor supports confidential tests and
-# relies on `KATA_HYPERVISOR` being an environment variable
-function check_hypervisor_for_confidential_tests() {
-	local kata_hypervisor="${1}"
-	# This check must be done with "<SPACE>${KATA_HYPERVISOR}<SPACE>" to avoid
-	# having substrings, like qemu, being matched with qemu-$something.
-	if check_hypervisor_for_confidential_tests_tee_only "${kata_hypervisor}" ||\
-	[[ " ${SUPPORTED_NON_TEE_HYPERVISORS[*]} " =~ " ${kata_hypervisor} " ]]; then
-		return 0
+	if is_se_hypervisor "${KATA_HYPERVISOR}"; then
+		echo "cd /sys/firmware/uv; cat prot_virt_guest | grep 1"
+	elif is_snp_hypervisor "${KATA_HYPERVISOR}"; then
+		echo "dmesg | grep \"Memory Encryption Features active:.*SEV-SNP\""
+	elif is_tdx_hypervisor "${KATA_HYPERVISOR}"; then
+		echo "cpuid | grep TDX_GUEST"
+	elif is_cca_hypervisor "${KATA_HYPERVISOR}"; then
+		echo "echo 'Remote TEE verification is not implemented for qemu-cca' >&2; exit 1"
 	else
-		return 1
+		echo ""
 	fi
-}
-
-# This function verifies whether the input hypervisor supports confidential tests and
-# relies on `KATA_HYPERVISOR` being an environment variable
-function check_hypervisor_for_confidential_tests_tee_only() {
-	local kata_hypervisor="${1}"
-	# This check must be done with "<SPACE>${KATA_HYPERVISOR}<SPACE>" to avoid
-	# having substrings, like qemu, being matched with qemu-$something.
-	# shellcheck disable=SC2076 # intentionally use literal string matching
-	if [[ " ${SUPPORTED_TEE_HYPERVISORS[*]} " =~ " ${kata_hypervisor} " ]]; then
-		return 0
-	fi
-
-	return 1
-}
-
-# This function verifies whether the input hypervisor supports confidential GPU tests
-function check_hypervisor_for_confidential_gpu_tests() {
-	local kata_hypervisor="${1}"
-	# This check must be done with "<SPACE>${kata_hypervisor}<SPACE>" to avoid
-	# having substrings being matched incorrectly.
-	# shellcheck disable=SC2076 # intentionally use literal string matching
-	if [[ " ${SUPPORTED_GPU_TEE_HYPERVISORS[*]} " =~ " ${kata_hypervisor} " ]]; then
-		return 0
-	fi
-
-	return 1
-}
-
-# Common check for confidential tests.
-function is_confidential_runtime_class() {
-	if check_hypervisor_for_confidential_tests "${KATA_HYPERVISOR}"; then
-		return 0
-	fi
-
-	return 1
-}
-
-# Common check for confidential hardware tests.
-function is_confidential_hardware() {
-	if check_hypervisor_for_confidential_tests_tee_only "${KATA_HYPERVISOR}"; then
-		return 0
-	fi
-
-	return 1
 }
 
 # Common check for confidential GPU hardware tests.
 function is_confidential_gpu_hardware() {
-	if check_hypervisor_for_confidential_gpu_tests "${KATA_HYPERVISOR}"; then
+	if is_confidential_gpu_hypervisor "${KATA_HYPERVISOR}"; then
 		return 0
 	fi
 

--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -8,7 +8,7 @@
 #
 set -e
 
-kubernetes_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+kubernetes_dir="${kubernetes_dir:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
 # shellcheck disable=1091
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
 # shellcheck disable=1091

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -11,7 +11,7 @@ set -o pipefail
 DEBUG="${DEBUG:-}"
 [[ -n "${DEBUG}" ]] && set -x
 
-kubernetes_dir="$(dirname "$(readlink -f "$0")")"
+kubernetes_dir="${kubernetes_dir:-$(dirname "$(readlink -f "$0")")}"
 source "${kubernetes_dir}/../../gha-run-k8s-common.sh"
 # shellcheck disable=1091
 source "${kubernetes_dir}/confidential_kbs.sh"
@@ -186,15 +186,11 @@ function deploy_kata() {
 	set_default_cluster_namespace
 
 	# Workaround to avoid modifying the workflow yaml files
-	case "${KATA_HYPERVISOR}" in
-		qemu-tdx|qemu-snp|qemu-snp-runtime-rs|qemu-nvidia-gpu-*)
-			USE_EXPERIMENTAL_SETUP_SNAPSHOTTER=true
-			SNAPSHOTTER="nydus"
-			EXPERIMENTAL_FORCE_GUEST_PULL=false
-			;;
-		*)
-			;;
-	esac
+	if is_tdx_hypervisor "${KATA_HYPERVISOR}" || is_snp_hypervisor "${KATA_HYPERVISOR}" || is_confidential_gpu_hypervisor "${KATA_HYPERVISOR}"; then
+		USE_EXPERIMENTAL_SETUP_SNAPSHOTTER=true
+		SNAPSHOTTER="nydus"
+		EXPERIMENTAL_FORCE_GUEST_PULL=false
+	fi
 
 	ANNOTATIONS="default_vcpus"
 	if [[ "${KATA_HOST_OS}" = "cbl-mariner" ]]; then
@@ -447,9 +443,9 @@ function cleanup() {
 }
 
 function deploy_snapshotter() {
-	if [[ "${KATA_HYPERVISOR}" == "qemu-tdx" || "${KATA_HYPERVISOR}" == "qemu-snp" || "${KATA_HYPERVISOR}" == "qemu-snp-runtime-rs" ]]; then
-	       echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
-	       return
+	if is_tdx_hypervisor "${KATA_HYPERVISOR}" || is_snp_hypervisor "${KATA_HYPERVISOR}"; then
+		echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
+		return
 	fi
 
 	echo "::group::Deploying ${SNAPSHOTTER}"
@@ -461,9 +457,9 @@ function deploy_snapshotter() {
 }
 
 function cleanup_snapshotter() {
-	if [[ "${KATA_HYPERVISOR}" == "qemu-tdx" || "${KATA_HYPERVISOR}" == "qemu-snp" || "${KATA_HYPERVISOR}" == "qemu-snp-runtime-rs" ]]; then
-	       echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
-	       return
+	if is_tdx_hypervisor "${KATA_HYPERVISOR}" || is_snp_hypervisor "${KATA_HYPERVISOR}"; then
+		echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
+		return
 	fi
 
 	echo "::group::Cleanuping ${SNAPSHOTTER}"

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -442,42 +442,6 @@ function cleanup() {
 	cleanup_kata_deploy
 }
 
-function deploy_snapshotter() {
-	if is_tdx_hypervisor "${KATA_HYPERVISOR}" || is_snp_hypervisor "${KATA_HYPERVISOR}"; then
-		echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
-		return
-	fi
-
-	echo "::group::Deploying ${SNAPSHOTTER}"
-	case ${SNAPSHOTTER} in
-		nydus) deploy_nydus_snapshotter ;;
-		*) >&2 echo "${SNAPSHOTTER} flavour is not supported"; exit 2 ;;
-	esac
-	echo "::endgroup::"
-}
-
-function cleanup_snapshotter() {
-	if is_tdx_hypervisor "${KATA_HYPERVISOR}" || is_snp_hypervisor "${KATA_HYPERVISOR}"; then
-		echo "[Skip] ${SNAPSHOTTER} is pre-installed in the TEE machine"
-		return
-	fi
-
-	echo "::group::Cleanuping ${SNAPSHOTTER}"
-	case ${SNAPSHOTTER} in
-		nydus) cleanup_nydus_snapshotter ;;
-		*) >&2 echo "${SNAPSHOTTER} flavour is not supported"; exit 2 ;;
-	esac
-	echo "::endgroup::"
-}
-
-function deploy_nydus_snapshotter() {
-	echo "nydus-for-kata-tee is now deployed and managed by kata-deploy; nothing to do here."
-}
-
-function cleanup_nydus_snapshotter() {
-	echo "nydus-for-kata-tee is now deployed and managed by kata-deploy; nothing to do here."
-}
-
 function main() {
 	export KATA_HOST_OS="${KATA_HOST_OS:-}"
 	export K8S_TEST_HOST_TYPE="${K8S_TEST_HOST_TYPE:-}"
@@ -518,7 +482,6 @@ function main() {
 		deploy-kata-kubeadm) deploy_kata "kubeadm" ;;
 		deploy-kata-garm) deploy_kata "garm" ;;
 		deploy-kata-zvsi) deploy_kata "zvsi" ;;
-		deploy-snapshotter) deploy_snapshotter ;;
 		report-tests) report_tests ;;
 		run-tests)
 			K8STESTS=run_kubernetes_tests.sh
@@ -535,7 +498,6 @@ function main() {
 		cleanup-kubeadm) cleanup "kubeadm" ;;
 		cleanup-garm) cleanup "garm" ;;
 		cleanup-zvsi) cleanup "zvsi" ;;
-		cleanup-snapshotter) cleanup_snapshotter ;;
 		delete-coco-kbs) delete_coco_kbs ;;
 		delete-cluster) cleanup "aks" ;;
 		delete-cluster-kcli) delete_cluster_kcli ;;

--- a/tests/integration/kubernetes/k8s-cpu-ns.bats
+++ b/tests/integration/kubernetes/k8s-cpu-ns.bats
@@ -7,16 +7,11 @@
 
 load "${BATS_TEST_DIRNAME}/lib.sh"
 load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/../../hypervisor_helpers.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
-	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
-	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
-	[ "${KATA_HYPERVISOR}" == "qemu-se-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
-	[[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]] && skip "Requires CPU hotplug which disabled by static_sandbox_resource_mgmt"
-	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
-		[ "${KATA_HYPERVISOR}" == "qemu-snp-runtime-rs" ] || [ "${KATA_HYPERVISOR}" == "qemu-se" ] ) \
-		&& skip "TEEs do not support memory / CPU hotplug"
+	is_hotplug_supported "${KATA_HYPERVISOR}" || skip "${KATA_HYPERVISOR} doesn't support memory / CPU hotplug"
 
 	pod_name="constraints-cpu-test"
 	container_name="first-cpu-container"
@@ -116,13 +111,7 @@ setup() {
 }
 
 teardown() {
-	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
-	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
-	[ "${KATA_HYPERVISOR}" == "qemu-se-runtime-rs" ] && skip "Requires CPU hotplug which isn't supported on ${KATA_HYPERVISOR} yet"
-	[[ "${KATA_HYPERVISOR}" == qemu-coco-dev* ]] && skip "Requires CPU hotplug which disabled by static_sandbox_resource_mgmt"
-	( [ "${KATA_HYPERVISOR}" == "qemu-tdx" ] || [ "${KATA_HYPERVISOR}" == "qemu-snp" ] || \
-		[ "${KATA_HYPERVISOR}" == "qemu-snp-runtime-rs" ] || [ "${KATA_HYPERVISOR}" == "qemu-se" ] ) \
-		&& skip "TEEs do not support memory / CPU hotplug"
+	is_hotplug_supported "${KATA_HYPERVISOR}" || skip "${KATA_HYPERVISOR} doesn't support memory / CPU hotplug"
 
 	# Debugging information
 	kubectl describe "pod/$pod_name"

--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -19,17 +19,16 @@ case "${KATA_HYPERVISOR}" in
 esac
 
 check_and_skip() {
-	case "${KATA_HYPERVISOR}" in
-		qemu-tdx|qemu-coco-dev|qemu-snp|qemu-snp-runtime-rs)
-			if [ "$(uname -m)" == "s390x" ]; then
-				skip "measured rootfs tests not implemented for s390x"
-			fi
-			return
-			;;
-		*)
-			skip "measured rootfs tests not implemented for hypervisor: $KATA_HYPERVISOR"
-			;;
-	esac
+	if is_confidential_runtime_class "${KATA_HYPERVISOR}"; then
+		if [[ "$(uname -m)" == "s390x" ]]; then
+			skip "measured rootfs tests not implemented for s390x"
+		elif [[ "${KATA_HYPERVISOR}" == "qemu-coco-dev-runtime-rs" ]]; then
+			skip "measured rootfs not working on qemu-coco-dev-runtime-rs: https://github.com/kata-containers/kata-containers/issues/12851"
+		fi
+		return
+	else
+		skip "measured rootfs tests not implemented for hypervisor: ${KATA_HYPERVISOR}"
+	fi
 }
 
 setup() {

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -8,7 +8,7 @@
 set -e
 set -o pipefail
 
-kubernetes_dir=$(dirname "$(readlink -f "$0")")
+kubernetes_dir="${kubernetes_dir:-$(dirname "$(readlink -f "$0")")}"
 # shellcheck disable=SC1091 # import based on variable
 source "${kubernetes_dir}/../../common.bash"
 

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -8,7 +8,7 @@
 set -e
 set -o pipefail
 
-kubernetes_dir=$(dirname "$(readlink -f "$0")")
+kubernetes_dir="${kubernetes_dir:-$(dirname "$(readlink -f "$0")")}"
 source "${kubernetes_dir}/../../common.bash"
 
 cleanup() {

--- a/tests/integration/kubernetes/setup.sh
+++ b/tests/integration/kubernetes/setup.sh
@@ -137,16 +137,15 @@ add_runtime_handler_annotations() {
 		return
 	fi
 
-	case "${KATA_HYPERVISOR}" in
-		qemu-coco-dev | qemu-snp | qemu-snp-runtime-rs | qemu-tdx | qemu-coco-dev-runtime-rs)
-			info "Add runtime handler annotations for ${KATA_HYPERVISOR}"
-			local handler_value="kata-${KATA_HYPERVISOR}"
-			for K8S_TEST_YAML in runtimeclass_workloads_work/*.yaml
-			do
-				add_annotations_to_yaml "${K8S_TEST_YAML}" "${handler_annotation}" "${handler_value}"
-			done
-			;;
-	esac
+	# Add runtime handler annotations for confidential computing hypervisors
+	if is_confidential_runtime_class "${KATA_HYPERVISOR}"; then
+		info "Add runtime handler annotations for ${KATA_HYPERVISOR}"
+		local handler_value="kata-${KATA_HYPERVISOR}"
+		for K8S_TEST_YAML in runtimeclass_workloads_work/*.yaml
+		do
+			add_annotations_to_yaml "${K8S_TEST_YAML}" "${handler_annotation}" "${handler_value}"
+		done
+	fi
 }
 
 main() {

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -8,6 +8,7 @@
 # which will contain the Kata Containers installation into a given destination
 # directory.
 #
+
 # This contains variables and functions common to all e2e tests.
 
 # Variables used by the kubernetes tests
@@ -34,6 +35,8 @@ export dragonball_limitations="https://github.com/kata-containers/kata-container
 export KUBECONFIG="${KUBECONFIG:-${HOME}/.kube/config}"
 
 K8S_TEST_DIR="${kubernetes_dir:-"${BATS_TEST_DIRNAME}"}"
+
+source "${K8S_TEST_DIR}/../../gha-run-k8s-common.sh"
 
 AUTO_GENERATE_POLICY="${AUTO_GENERATE_POLICY:-}"
 GENPOLICY_PULL_METHOD="${GENPOLICY_PULL_METHOD:-}"
@@ -81,13 +84,7 @@ auto_generate_policy_enabled() {
 }
 
 is_coco_platform() {
-	case "${KATA_HYPERVISOR}" in
-		"qemu-tdx"|"qemu-snp"|"qemu-snp-runtime-rs"|"qemu-coco-dev"|"qemu-coco-dev-runtime-rs"|"qemu-nvidia-gpu-tdx"|"qemu-nvidia-gpu-snp")
-			return 0
-			;;
-		*)
-			return 1
-	esac
+	is_confidential_runtime_class "${KATA_HYPERVISOR}"
 }
 
 is_nvidia_gpu_platform() {
@@ -148,7 +145,7 @@ install_genpolicy_drop_ins() {
 	# 20-* OCI version overlay
 	if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
 		cp "${examples_dir}/20-oci-1.2.0-drop-in.json" "${settings_d}/"
-	elif is_k3s_or_rke2 || is_nvidia_gpu_platform || [[ "${KATA_HYPERVISOR}" == "qemu-snp" ]] || [[ "${KATA_HYPERVISOR}" == "qemu-snp-runtime-rs" ]] || [[ "${KATA_HYPERVISOR}" == "qemu-tdx" ]] || [[ -n "${CONTAINER_ENGINE_VERSION:-}" ]]; then
+	elif is_k3s_or_rke2 || is_nvidia_gpu_platform || is_snp_hypervisor "${KATA_HYPERVISOR}" || is_tdx_hypervisor "${KATA_HYPERVISOR}" || [[ -n "${CONTAINER_ENGINE_VERSION:-}" ]]; then
 		cp "${examples_dir}/20-oci-1.3.0-drop-in.json" "${settings_d}/"
 	fi
 

--- a/tests/stability/gha-stability-run.sh
+++ b/tests/stability/gha-stability-run.sh
@@ -32,7 +32,6 @@ function main() {
 		install-bats) install_bats ;;
 		install-kata-tools) install_kata_tools "${2:-}" ;;
 		get-cluster-credentials) get_cluster_credentials ;;
-		deploy-snapshotter) deploy_snapshotter ;;
 		deploy-kata-aks) deploy_kata "aks" ;;
 		deploy-coco-kbs) deploy_coco_kbs ;;
 		install-kbs-client) install_kbs_client ;;


### PR DESCRIPTION
As discussed in #12806 I felt like we could do a clearer job with some of our tests relating to consolidating runtime-rs and go runtime confidential tests

Also delete the old deploy_snapshotter and cleanup_snapshotter as they are handled by kata-deploy, so no-ops now.