### PR TITLE
genpolicy: update regorus to 0.9.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4072,6 +4072,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "msvc_spectre_libs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e871a9861f3664f18b7e04e9301d4edd55090c2dadb4b1c602e26ab32b1f5b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5932,18 +5941,22 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regorus"
-version = "0.2.8"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c3d97f07e3b5ac0955d53ad0af4c91fe4a4f8525843ece5bf014f27829b73"
+checksum = "656c9768f1d2113590ebc05e2e342a9f76baa97a445f2928f24eec9ae1fb14ac"
 dependencies = [
  "anyhow",
  "data-encoding",
  "lazy_static",
- "rand 0.8.5",
+ "msvc_spectre_libs",
+ "num-bigint",
+ "num-traits",
+ "rand 0.9.2",
  "regex",
- "scientific",
  "serde",
  "serde_json",
+ "spin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6577,26 +6590,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scientific"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a4b339a8de779ecb098a772ecbba2ace74e23ed959a5b4f30631d8bf1799a8"
-dependencies = [
- "scientific-macro",
-]
-
-[[package]]
-name = "scientific-macro"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ee4885492bb655bfa05d039cd9163eb8fe9f79ddebf00ca23a1637510c2fd2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7166,6 +7159,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,6 +4032,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "msvc_spectre_libs"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29e871a9861f3664f18b7e04e9301d4edd55090c2dadb4b1c602e26ab32b1f5b"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5892,18 +5901,22 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "regorus"
-version = "0.2.8"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843c3d97f07e3b5ac0955d53ad0af4c91fe4a4f8525843ece5bf014f27829b73"
+checksum = "656c9768f1d2113590ebc05e2e342a9f76baa97a445f2928f24eec9ae1fb14ac"
 dependencies = [
  "anyhow",
  "data-encoding",
  "lazy_static",
- "rand 0.8.5",
+ "msvc_spectre_libs",
+ "num-bigint",
+ "num-traits",
+ "rand 0.9.2",
  "regex",
- "scientific",
  "serde",
  "serde_json",
+ "spin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6536,26 +6549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scientific"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38a4b339a8de779ecb098a772ecbba2ace74e23ed959a5b4f30631d8bf1799a8"
-dependencies = [
- "scientific-macro",
-]
-
-[[package]]
-name = "scientific-macro"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ee4885492bb655bfa05d039cd9163eb8fe9f79ddebf00ca23a1637510c2fd2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7125,6 +7118,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "stable_deref_trait"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5942,8 +5942,7 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 [[package]]
 name = "regorus"
 version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656c9768f1d2113590ebc05e2e342a9f76baa97a445f2928f24eec9ae1fb14ac"
+source = "git+https://github.com/microsoft/regorus?rev=898643129e3652efd43e596f978d99f85e770235#898643129e3652efd43e596f978d99f85e770235"
 dependencies = [
  "anyhow",
  "data-encoding",

--- a/src/agent/policy/Cargo.toml
+++ b/src/agent/policy/Cargo.toml
@@ -16,7 +16,7 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Agent Policy
-regorus = { version = "0.2.8", default-features = false, features = [
+regorus = { version = "0.9.1", default-features = false, features = [
     "arc",
     "base64",
     "base64url",

--- a/src/agent/policy/Cargo.toml
+++ b/src/agent/policy/Cargo.toml
@@ -16,7 +16,18 @@ serde.workspace = true
 serde_json.workspace = true
 
 # Agent Policy
-regorus = { version = "0.9.1", default-features = false, features = [
+#
+# Pinned to an upstream commit on `main` instead of a published crate version
+# because the 0.9.1 release hard-caps policy lines at 1024 characters and
+# files at 1 MiB / 20 000 lines, which rejects realistic policies generated
+# by `genpolicy` (e.g. the NVIDIA_REQUIRE_CUDA environment variable on
+# `nvcr.io/nvidia/k8s/cuda-sample` images is ~1.3 KiB on a single line).
+#
+# The pinned commit is microsoft/regorus#624 ("feat: make policy length
+# limits configurable per engine"), which adds Engine::set_policy_length_config.
+# Switch back to a crates.io version once a release > 0.9.1 containing #624
+# is published.
+regorus = { git = "https://github.com/microsoft/regorus", rev = "898643129e3652efd43e596f978d99f85e770235", default-features = false, features = [
     "arc",
     "base64",
     "base64url",

--- a/src/agent/policy/src/policy.rs
+++ b/src/agent/policy/src/policy.rs
@@ -6,12 +6,26 @@
 
 //! Policy evaluation for the kata-agent.
 
+use std::num::{NonZeroU32, NonZeroUsize};
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};
 
 use anyhow::{bail, Error, Result};
 use protocols::agent::CopyFileRequest;
+use regorus::PolicyLengthConfig;
 use slog::{debug, error, info, warn};
 use tokio::io::AsyncWriteExt;
+
+// Regorus' built-in policy length limits (1024 cols / 1 MiB / 20 000 lines)
+// reject realistic policies emitted by `genpolicy`. In particular, container
+// `Env` values such as NVIDIA_REQUIRE_CUDA on the upstream NVIDIA CUDA images
+// can exceed 1 KiB on a single line. These constants raise the per-engine
+// limits to values that comfortably fit any policy we expect to evaluate
+// while still rejecting pathological/minified input.
+//
+// See microsoft/regorus#624 for the upstream API.
+const POLICY_MAX_COL: u32 = 64 * 1024; // 64 KiB per line
+const POLICY_MAX_FILE_BYTES: usize = 16 * 1024 * 1024; // 16 MiB per file
+const POLICY_MAX_LINES: usize = 200_000;
 
 static POLICY_LOG_FILE: &str = "/tmp/policy.jsonl";
 static POLICY_DEFAULT_FILE: &str = "/etc/kata-opa/default-policy.rego";
@@ -56,6 +70,11 @@ impl AgentPolicy {
         let mut engine = regorus::Engine::new();
         engine.set_strict_builtin_errors(false);
         engine.set_gather_prints(true);
+        engine.set_policy_length_config(PolicyLengthConfig {
+            max_col: NonZeroU32::new(POLICY_MAX_COL).unwrap(),
+            max_file_bytes: NonZeroUsize::new(POLICY_MAX_FILE_BYTES).unwrap(),
+            max_lines: NonZeroUsize::new(POLICY_MAX_LINES).unwrap(),
+        });
         // assign a slice of the engine data "pstate" to be used as policy state
         engine
             .add_data(


### PR DESCRIPTION
The version we used before was released in 2024, it's about time to use a newer version. The new version of the crate comes with a license, which addresses a `cargo deny` finding.