### PR TITLE
runtime: Fix concurrent map read/write panic in Wait()

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/container.go
+++ b/src/runtime/pkg/containerd-shim-v2/container.go
@@ -7,6 +7,7 @@ package containerdshim
 
 import (
 	"io"
+	"sync"
 	"time"
 
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
@@ -22,6 +23,7 @@ type container struct {
 	ttyio       *ttyIO
 	spec        *specs.Spec
 	exitTime    time.Time
+	execsMu     sync.RWMutex
 	execs       map[string]*exec
 	exitIOch    chan struct{}
 	stdinPipe   io.WriteCloser

--- a/src/runtime/pkg/containerd-shim-v2/container_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/container_test.go
@@ -6,6 +6,7 @@
 package containerdshim
 
 import (
+	"sync"
 	"testing"
 
 	taskAPI "github.com/containerd/containerd/api/runtime/task/v2"
@@ -28,14 +29,61 @@ func TestGetExec(t *testing.T) {
 	c, err := newContainer(nil, r, "", nil, true)
 	assert.NoError(err)
 
+	// Exec not found on an initialized (but empty) map.
 	_, err = c.getExec("")
 	assert.Error(err)
 
+	// Exec not found when the map is nil.
+	c.execs = nil
+	_, err = c.getExec("")
+	assert.Error(err)
+
+	// Restore the map and verify a set exec can be retrieved.
 	c.execs = make(map[string]*exec)
-	_, err = c.getExec("")
-	assert.Error(err)
-
-	c.execs[TestID] = &exec{}
+	c.setExec(TestID, &exec{})
 	_, err = c.getExec(TestID)
 	assert.NoError(err)
+}
+
+// Regression test for #12825: concurrent map read and map write on c.execs.
+// Run with -race to verify the fix (go test -race).
+func TestConcurrentExecAccess(t *testing.T) {
+	r := &taskAPI.CreateTaskRequest{}
+	c, err := newContainer(nil, r, "", nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const iterations = 500
+	const execID = "concurrent-exec"
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// Writer: alternate between set and delete.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			c.setExec(execID, &exec{})
+			c.deleteExec(execID)
+		}
+	}()
+
+	// Reader 1: continuously try to get the exec.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			c.getExec(execID)
+		}
+	}()
+
+	// Reader 2: another concurrent reader on the same ID.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iterations; i++ {
+			c.getExec(execID)
+		}
+	}()
+
+	wg.Wait()
 }

--- a/src/runtime/pkg/containerd-shim-v2/exec.go
+++ b/src/runtime/pkg/containerd-shim-v2/exec.go
@@ -133,6 +133,9 @@ func newExec(c *container, stdin, stdout, stderr string, terminal bool, jspec *a
 }
 
 func (c *container) getExec(id string) (*exec, error) {
+	c.execsMu.RLock()
+	defer c.execsMu.RUnlock()
+
 	if c.execs == nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrNotFound, "exec does not exist %s", id)
 	}
@@ -144,4 +147,18 @@ func (c *container) getExec(id string) (*exec, error) {
 	}
 
 	return exec, nil
+}
+
+func (c *container) setExec(id string, e *exec) {
+	c.execsMu.Lock()
+	defer c.execsMu.Unlock()
+
+	c.execs[id] = e
+}
+
+func (c *container) deleteExec(id string) {
+	c.execsMu.Lock()
+	defer c.execsMu.Unlock()
+
+	delete(c.execs, id)
 }

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -559,7 +559,7 @@ func (s *service) Delete(ctx context.Context, r *taskAPI.DeleteRequest) (_ *task
 		return nil, err
 	}
 
-	delete(c.execs, r.ExecID)
+	c.deleteExec(r.ExecID)
 
 	return &taskAPI.DeleteResponse{
 		ExitStatus: uint32(execs.exitCode),
@@ -589,7 +589,7 @@ func (s *service) Exec(ctx context.Context, r *taskAPI.ExecProcessRequest) (_ *e
 		return nil, err
 	}
 
-	if execs := c.execs[r.ExecID]; execs != nil {
+	if e, _ := c.getExec(r.ExecID); e != nil {
 		return nil, errdefs.ToGRPCf(errdefs.ErrAlreadyExists, "id %s", r.ExecID)
 	}
 
@@ -598,7 +598,7 @@ func (s *service) Exec(ctx context.Context, r *taskAPI.ExecProcessRequest) (_ *e
 		return nil, errdefs.ToGRPC(err)
 	}
 
-	c.execs[r.ExecID] = execs
+	c.setExec(r.ExecID, execs)
 
 	s.send(&eventstypes.TaskExecAdded{
 		ContainerID: c.id,


### PR DESCRIPTION
Wait() was releasing s.mu immediately after getContainer(), then calling getExec() — which reads c.execs — without holding any lock. Concurrent Exec() or Delete() calls that write to c.execs under s.mu triggered a "concurrent map read and map write" fatal panic.

Add a dedicated sync.RWMutex to the container struct that protects the execs map. getExec() now acquires a read lock internally, and all writes go through new setExec()/deleteExec() helpers that acquire the write lock. This keeps the locking concern local to the map and avoids complicating the s.mu usage in Wait().

Fixes: #12825