### PR TITLE
runtime-rs: Add extra features with firmwarevolume and pflash

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -477,6 +477,14 @@ pub struct BootInfo {
     #[serde(default)]
     pub firmware: String,
 
+    /// Path to the firmware volume.
+    ///
+    /// For confidential computing VMs (TDX, SEV-SNP), this is the path to the
+    /// firmware volume file (e.g., OVMF_VARS.fd) that contains UEFI variable store.
+    /// This is used together with firmware to provide separated code and variable stores.
+    #[serde(default)]
+    pub firmware_volume: String,
+
     /// Block storage driver to be used for the VM rootfs when backed by a block device.
     /// Options include:
     /// - `virtio-pmem`
@@ -493,6 +501,10 @@ impl BootInfo {
         resolve_path!(self.image, "guest boot image file {} is invalid: {}")?;
         resolve_path!(self.initrd, "guest initrd image file {} is invalid: {}")?;
         resolve_path!(self.firmware, "firmware image file {} is invalid: {}")?;
+        resolve_path!(
+            self.firmware_volume,
+            "firmware volume image file {} is invalid: {}"
+        )?;
 
         if self.vm_rootfs_driver.is_empty() {
             self.vm_rootfs_driver = default::DEFAULT_BLOCK_DEVICE_TYPE.to_string();
@@ -507,6 +519,10 @@ impl BootInfo {
         validate_path!(self.image, "guest boot image file {} is invalid: {}")?;
         validate_path!(self.initrd, "guest initrd image file {} is invalid: {}")?;
         validate_path!(self.firmware, "firmware image file {} is invalid: {}")?;
+        validate_path!(
+            self.firmware_volume,
+            "firmware volume image file {} is invalid: {}"
+        )?;
         if !self.image.is_empty() && !self.initrd.is_empty() {
             return Err(std::io::Error::other(
                 "Can not configure both initrd and image for boot",

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -76,6 +76,12 @@ kernel_params = "@KERNELPARAMS@"
 # If you want that qemu uses the default firmware leave this option empty
 firmware = "@FIRMWAREPATH@"
 
+# Path to the firmware volume.
+# firmware TDVF or OVMF can be split into FIRMWARE_VARS.fd (UEFI variables
+# store) and FIRMWARE_CODE.fd (UEFI program image). This is the path to the
+# FIRMWARE_VARS.fd file.
+firmware_volume = "@FIRMWAREVOLUMEPATH@"
+
 # Machine accelerators
 # comma-separated list of machine accelerators to pass to the hypervisor.
 # For example, `machine_accelerators = "nosmm,nosmbus,nosata,nopit,static-prt,nofw"`

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -81,6 +81,12 @@ kernel_verity_params = "@KERNELVERITYPARAMS@"
 # If you want that qemu uses the default firmware leave this option empty
 firmware = "@FIRMWAREPATH@"
 
+# Path to the firmware volume.
+# firmware TDVF or OVMF can be split into FIRMWARE_VARS.fd (UEFI variables
+# store) and FIRMWARE_CODE.fd (UEFI program image). This is the path to the
+# FIRMWARE_VARS.fd file.
+firmware_volume = "@FIRMWAREVOLUMEPATH@"
+
 # Machine accelerators
 # comma-separated list of machine accelerators to pass to the hypervisor.
 # For example, `machine_accelerators = "nosmm,nosmbus,nosata,nopit,static-prt,nofw"`

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -60,6 +60,12 @@ kernel_params = "@KERNELPARAMS@"
 # If you want that qemu uses the default firmware leave this option empty
 firmware = "@FIRMWAREPATH@"
 
+# Path to the firmware volume.
+# firmware TDVF or OVMF can be split into FIRMWARE_VARS.fd (UEFI variables
+# store) and FIRMWARE_CODE.fd (UEFI program image). This is the path to the
+# FIRMWARE_VARS.fd file.
+firmware_volume = "@FIRMWAREVOLUMEPATH@"
+
 # Machine accelerators
 # comma-separated list of machine accelerators to pass to the hypervisor.
 # For example, `machine_accelerators = "nosmm,nosmbus,nosata,nopit,static-prt,nofw"`

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -69,6 +69,12 @@ kernel_params = "@KERNELPARAMS@"
 # If you want that qemu uses the default firmware leave this option empty
 firmware = "@FIRMWAREPATH@"
 
+# Path to the firmware volume.
+# firmware TDVF or OVMF can be split into FIRMWARE_VARS.fd (UEFI variables
+# store) and FIRMWARE_CODE.fd (UEFI program image). This is the path to the
+# FIRMWARE_VARS.fd file.
+firmware_volume = "@FIRMWAREVOLUMEPATH@"
+
 # Machine accelerators
 # comma-separated list of machine accelerators to pass to the hypervisor.
 # For example, `machine_accelerators = "nosmm,nosmbus,nosata,nopit,static-prt,nofw"`

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -107,6 +107,12 @@ kernel_verity_params = "@KERNELVERITYPARAMS@"
 # If you want that qemu uses the default firmware leave this option empty
 firmware = "@FIRMWARE_SNP_PATH@"
 
+# Path to the firmware volume.
+# firmware TDVF or OVMF can be split into FIRMWARE_VARS.fd (UEFI variables
+# store) and FIRMWARE_CODE.fd (UEFI program image). This is the path to the
+# FIRMWARE_VARS.fd file.
+firmware_volume = "@FIRMWARETDVFVOLUMEPATH@"
+
 # Machine accelerators
 # comma-separated list of machine accelerators to pass to the hypervisor.
 # For example, `machine_accelerators = "nosmm,nosmbus,nosata,nopit,static-prt,nofw"`

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -83,6 +83,12 @@ kernel_verity_params = "@KERNELVERITYPARAMS@"
 # If you want that qemu uses the default firmware leave this option empty
 firmware = "@FIRMWARETDVFPATH@"
 
+# Path to the firmware volume.
+# firmware TDVF or OVMF can be split into FIRMWARE_VARS.fd (UEFI variables
+# store) and FIRMWARE_CODE.fd (UEFI program image). This is the path to the
+# FIRMWARE_VARS.fd file.
+firmware_volume = "@FIRMWARETDVFVOLUMEPATH@"
+
 # Machine accelerators
 # comma-separated list of machine accelerators to pass to the hypervisor.
 # For example, `machine_accelerators = "nosmm,nosmbus,nosata,nopit,static-prt,nofw"`

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -42,6 +42,12 @@ kernel_params = ""
 # If you want that qemu uses the default firmware leave this option empty
 firmware = "@FIRMWAREPATH@"
 
+# Path to the firmware volume.
+# firmware TDVF or OVMF can be split into FIRMWARE_VARS.fd (UEFI variables
+# store) and FIRMWARE_CODE.fd (UEFI program image). This is the path to the
+# FIRMWARE_VARS.fd file.
+firmware_volume = "@FIRMWAREVOLUMEPATH@"
+
 # Default number of vCPUs per SB/VM:
 # unspecified or 0                --> will be set to @DEFVCPUS@
 # < 0                             --> will be set to the actual number of physical cores

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/protection_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/protection_device.rs
@@ -32,6 +32,8 @@ pub struct TdxConfig {
     pub id: String,
     // Firmware path
     pub firmware: String,
+    // Firmware volume path (for UEFI variable store, e.g., OVMF_VARS.fd)
+    pub firmware_volume: String,
     // Quote Qeneration Socket port
     pub qgs_port: u32,
     // mrconfigid

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2601,6 +2601,7 @@ impl<'a> QemuCmdLine<'a> {
         &mut self,
         id: &str,
         firmware: &str,
+        _firmware_volume: &str,
         qgs_port: u32,
         mrconfigid: &Option<String>,
         debug: bool,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2638,7 +2638,12 @@ impl<'a> QemuCmdLine<'a> {
 
         self.devices.push(Box::new(sev_snp_object));
 
-        self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+        // SEV-SNP uses -bios for firmware (not pflash like SEV)
+        // See: https://github.com/kata-containers/kata-containers/blob/main/src/runtime/pkg/govmm/qemu/qemu.go
+        // SNP: config.Bios = object.File (line 440)
+        if !firmware.is_empty() {
+            self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+        }
 
         self.machine
             .set_kernel_irqchip("split")
@@ -2657,9 +2662,16 @@ impl<'a> QemuCmdLine<'a> {
         mrconfigid: &Option<String>,
         debug: bool,
     ) {
+        // For TDX, firmware is passed via -bios parameter (not through tdx-guest object)
+        // firmware_volume is currently not used by QEMU's tdx-guest object
+        // See: https://www.qemu.org/docs/master/system/i386/tdx.html#launching-a-td-tdx-vm
         let tdx_object = ObjectTdxGuest::new(id, mrconfigid.clone(), qgs_port, debug);
         self.devices.push(Box::new(tdx_object));
-        self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+
+        // Add -bios parameter for TDVF firmware
+        if !firmware.is_empty() {
+            self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+        }
 
         self.machine
             .set_kernel_irqchip("split")

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -588,6 +588,33 @@ impl ToQemuParams for Bios {
 }
 
 #[derive(Debug)]
+struct Pflash {
+    filepath: String,
+    readonly: bool,
+}
+
+impl Pflash {
+    fn new(filepath: String, readonly: bool) -> Self {
+        Pflash { filepath, readonly }
+    }
+}
+
+#[async_trait]
+impl ToQemuParams for Pflash {
+    async fn qemu_params(&self) -> Result<Vec<String>> {
+        // For pflash, we use -drive if=pflash,format=raw,readonly=on/off,file=...
+        let readonly_str = if self.readonly { "on" } else { "off" };
+        Ok(vec![
+            "-drive".to_owned(),
+            format!(
+                "if=pflash,format=raw,readonly={},file={}",
+                readonly_str, self.filepath
+            ),
+        ])
+    }
+}
+
+#[derive(Debug)]
 struct Knobs {
     no_user_config: bool,
     nodefaults: bool,
@@ -2274,6 +2301,11 @@ impl<'a> QemuCmdLine<'a> {
             qemu_cmd_line.add_virtio_balloon();
         }
 
+        // Add pflash devices if configured (for arm64 UEFI or x86_64 with pflash)
+        if !config.machine_info.pflashes.is_empty() {
+            qemu_cmd_line.add_pflash_devices(&config.machine_info.pflashes);
+        }
+
         if let Some(seccomp_sandbox) = &config
             .security_info
             .seccomp_sandbox
@@ -2531,6 +2563,20 @@ impl<'a> QemuCmdLine<'a> {
         self.devices.push(Box::new(balloon_device));
     }
 
+    /// Add pflash devices for firmware.
+    /// On arm64, two pflash images are required for UEFI firmware:
+    /// - First pflash (readonly): contains the UEFI firmware code
+    /// - Second pflash (writable): contains the UEFI variable store
+    /// On x86_64, pflash can be used for OVMF firmware with confidential computing.
+    pub fn add_pflash_devices(&mut self, pflashes: &[String]) {
+        for (index, pflash_path) in pflashes.iter().enumerate() {
+            // First pflash is readonly (firmware code), subsequent ones are writable (variable store)
+            let readonly = index == 0;
+            let pflash = Pflash::new(pflash_path.clone(), readonly);
+            self.devices.push(Box::new(pflash));
+        }
+    }
+
     pub fn add_se_protection_device(&mut self) {
         let se_object = ObjectSeGuest::new("pv0");
         self.devices.push(Box::new(se_object));
@@ -2564,7 +2610,12 @@ impl<'a> QemuCmdLine<'a> {
         let sev_object = ObjectSevSnpGuest::new(false, cbitpos, phys_addr_reduction, None);
         self.devices.push(Box::new(sev_object));
 
-        self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+        // SEV uses -drive if=pflash for firmware (not -bios)
+        // See: https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/qemu_amd64.go
+        if !firmware.is_empty() {
+            let pflash = Pflash::new(firmware.to_owned(), true);
+            self.devices.push(Box::new(pflash));
+        }
 
         self.machine
             .set_confidential_guest_support("sev")

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -594,6 +594,33 @@ impl ToQemuParams for Bios {
 }
 
 #[derive(Debug)]
+struct Pflash {
+    filepath: String,
+    readonly: bool,
+}
+
+impl Pflash {
+    fn new(filepath: String, readonly: bool) -> Self {
+        Pflash { filepath, readonly }
+    }
+}
+
+#[async_trait]
+impl ToQemuParams for Pflash {
+    async fn qemu_params(&self) -> Result<Vec<String>> {
+        // For pflash, we use -drive if=pflash,format=raw,readonly=on/off,file=...
+        let readonly_str = if self.readonly { "on" } else { "off" };
+        Ok(vec![
+            "-drive".to_owned(),
+            format!(
+                "if=pflash,format=raw,readonly={},file={}",
+                readonly_str, self.filepath
+            ),
+        ])
+    }
+}
+
+#[derive(Debug)]
 struct Knobs {
     no_user_config: bool,
     nodefaults: bool,
@@ -2595,6 +2622,11 @@ impl<'a> QemuCmdLine<'a> {
             qemu_cmd_line.add_virtio_balloon();
         }
 
+        // Add pflash devices if configured (for arm64 UEFI or x86_64 with pflash)
+        if !config.machine_info.pflashes.is_empty() {
+            qemu_cmd_line.add_pflash_devices(&config.machine_info.pflashes);
+        }
+
         if let Some(seccomp_sandbox) = &config
             .security_info
             .seccomp_sandbox
@@ -2852,6 +2884,20 @@ impl<'a> QemuCmdLine<'a> {
         self.devices.push(Box::new(balloon_device));
     }
 
+    /// Add pflash devices for firmware.
+    /// On arm64, two pflash images are required for UEFI firmware:
+    /// - First pflash (readonly): contains the UEFI firmware code
+    /// - Second pflash (writable): contains the UEFI variable store
+    /// On x86_64, pflash can be used for OVMF firmware with confidential computing.
+    pub fn add_pflash_devices(&mut self, pflashes: &[String]) {
+        for (index, pflash_path) in pflashes.iter().enumerate() {
+            // First pflash is readonly (firmware code), subsequent ones are writable (variable store)
+            let readonly = index == 0;
+            let pflash = Pflash::new(pflash_path.clone(), readonly);
+            self.devices.push(Box::new(pflash));
+        }
+    }
+
     pub fn add_se_protection_device(&mut self) {
         let se_object = ObjectSeGuest::new("pv0");
         self.devices.push(Box::new(se_object));
@@ -2885,7 +2931,12 @@ impl<'a> QemuCmdLine<'a> {
         let sev_object = ObjectSevSnpGuest::new(false, cbitpos, phys_addr_reduction, None);
         self.devices.push(Box::new(sev_object));
 
-        self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+        // SEV uses -drive if=pflash for firmware (not -bios)
+        // See: https://github.com/kata-containers/kata-containers/blob/main/src/runtime/virtcontainers/qemu_amd64.go
+        if !firmware.is_empty() {
+            let pflash = Pflash::new(firmware.to_owned(), true);
+            self.devices.push(Box::new(pflash));
+        }
 
         self.machine
             .set_confidential_guest_support("sev")

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2922,6 +2922,7 @@ impl<'a> QemuCmdLine<'a> {
         &mut self,
         id: &str,
         firmware: &str,
+        _firmware_volume: &str,
         qgs_port: u32,
         mrconfigid: &Option<String>,
         debug: bool,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2959,7 +2959,12 @@ impl<'a> QemuCmdLine<'a> {
 
         self.devices.push(Box::new(sev_snp_object));
 
-        self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+        // SEV-SNP uses -bios for firmware (not pflash like SEV)
+        // See: https://github.com/kata-containers/kata-containers/blob/main/src/runtime/pkg/govmm/qemu/qemu.go
+        // SNP: config.Bios = object.File (line 440)
+        if !firmware.is_empty() {
+            self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+        }
 
         self.machine
             .set_kernel_irqchip("split")
@@ -2978,9 +2983,16 @@ impl<'a> QemuCmdLine<'a> {
         mrconfigid: &Option<String>,
         debug: bool,
     ) {
+        // For TDX, firmware is passed via -bios parameter (not through tdx-guest object)
+        // firmware_volume is currently not used by QEMU's tdx-guest object
+        // See: https://www.qemu.org/docs/master/system/i386/tdx.html#launching-a-td-tdx-vm
         let tdx_object = ObjectTdxGuest::new(id, mrconfigid.clone(), qgs_port, debug);
         self.devices.push(Box::new(tdx_object));
-        self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+
+        // Add -bios parameter for TDVF firmware
+        if !firmware.is_empty() {
+            self.devices.push(Box::new(Bios::new(firmware.to_owned())));
+        }
 
         self.machine
             .set_kernel_irqchip("split")

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -183,6 +183,7 @@ impl QemuInner {
                     ProtectionDeviceConfig::Tdx(tdx_config) => cmdline.add_tdx_protection_device(
                         &tdx_config.id,
                         &tdx_config.firmware,
+                        &tdx_config.firmware_volume,
                         tdx_config.qgs_port,
                         &tdx_config.mrconfigid,
                         tdx_config.debug,

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -186,6 +186,7 @@ impl QemuInner {
                     ProtectionDeviceConfig::Tdx(tdx_config) => cmdline.add_tdx_protection_device(
                         &tdx_config.id,
                         &tdx_config.firmware,
+                        &tdx_config.firmware_volume,
                         tdx_config.qgs_port,
                         &tdx_config.mrconfigid,
                         tdx_config.debug,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -495,6 +495,7 @@ impl VirtSandbox {
                 Ok(Some(ProtectionDeviceConfig::Tdx(TdxConfig {
                     id: "tdx".to_owned(),
                     firmware: hypervisor_config.boot_info.firmware.clone(),
+                    firmware_volume: hypervisor_config.boot_info.firmware_volume.clone(),
                     qgs_port: hypervisor_config.security_info.qgs_port,
                     mrconfigid: init_data,
                     debug: false,

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -625,6 +625,7 @@ impl VirtSandbox {
                 Ok(Some(ProtectionDeviceConfig::Tdx(TdxConfig {
                     id: "tdx".to_owned(),
                     firmware: hypervisor_config.boot_info.firmware.clone(),
+                    firmware_volume: hypervisor_config.boot_info.firmware_volume.clone(),
                     qgs_port: hypervisor_config.security_info.qgs_port,
                     mrconfigid: init_data,
                     debug: false,


### PR DESCRIPTION
- Though firmware_volume is not actually used in runtime-go, I have a try to make it aligned with it. Do we really need it ? Honestly, I have no idea.
- pflash is needed.