### PR TITLE
runtime-rs: Fix build errors with rustc 1.94

### DIFF
--- a/src/dragonball/dbs_arch/src/x86_64/cpuid/brand_string.rs
+++ b/src/dragonball/dbs_arch/src/x86_64/cpuid/brand_string.rs
@@ -101,6 +101,7 @@ impl BrandString {
 
     /// Creates a brand string, initialized from the CPUID leaves 0x80000002 through 0x80000004
     /// of the host CPU.
+    #[allow(unused_unsafe)]
     fn from_host_cpuid() -> Result<Self, Error> {
         let mut this = Self::new();
         let mut cpuid_regs = unsafe { host_cpuid(0x8000_0000) };
@@ -311,6 +312,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[allow(unused_unsafe)]
     fn test_brand_string() {
         #[inline]
         fn pack_u32(src: &[u8]) -> u32 {

--- a/src/dragonball/dbs_arch/src/x86_64/cpuid/common.rs
+++ b/src/dragonball/dbs_arch/src/x86_64/cpuid/common.rs
@@ -16,6 +16,9 @@ pub enum Error {
 }
 
 /// Get CPUID value for (`function`, `count`).
+// TODO: Remove `unsafe` / `#[allow(unused_unsafe)]` when every rustc we build with matches the
+// stdarch change where these intrinsics are safe (rustc 1.94+); keep for older toolchains.
+#[allow(unused_unsafe)]
 pub fn get_cpuid(function: u32, count: u32) -> Result<CpuidResult, Error> {
     #[cfg(target_env = "sgx")]
     {

--- a/src/libs/kata-sys-util/src/mount.rs
+++ b/src/libs/kata-sys-util/src/mount.rs
@@ -760,7 +760,8 @@ pub fn umount_timeout<P: AsRef<Path>>(path: P, timeout: u64) -> Result<()> {
 /// # Safety
 /// Caller needs to ensure safety of the `path` to avoid possible file path based attacks.
 pub fn umount_all<P: AsRef<Path>>(mountpoint: P, lazy_umount: bool) -> Result<()> {
-    if mountpoint.as_ref().as_os_str().is_empty() || !mountpoint.as_ref().exists() {
+    let mp = mountpoint.as_ref();
+    if mp.as_os_str().is_empty() || !mp.exists() {
         return Ok(());
     }
 

--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -126,6 +126,10 @@ pub fn arch_guest_protection(
         // shouldn't hurt to double-check and have better logging if anything
         // goes wrong.
 
+        // TODO: Remove `unsafe` / `#[allow(unused_unsafe)]` when every rustc we build with treats
+        // `core::arch::x86_64::__cpuid` as a safe function (see rust-lang/stdarch#1935); keep for
+        // older toolchains that still require `unsafe` here.
+        #[allow(unused_unsafe)]
         let fn0 = unsafe { x86_64::__cpuid(0) };
         // The values in [ ebx, edx, ecx ] spell out "AuthenticAMD" when
         // interpreted byte-wise as ASCII.  No need to bother here with an
@@ -138,7 +142,8 @@ pub fn arch_guest_protection(
             ));
         }
 
-        // AMD64 Architecture Prgrammer's Manual Fn8000_001f docs on pg. 640
+        // AMD64 Architecture Programmer's Manual Fn8000_001f docs on pg. 640
+        #[allow(unused_unsafe)]
         let fn8000_001f = unsafe { x86_64::__cpuid(0x8000_001f) };
         if fn8000_001f.eax & 0x10 == 0 {
             return Err(ProtectionError::CheckFailed("SEV not supported".to_owned()));


### PR DESCRIPTION
Future-proofing against errors that are not reported by the currently in-use compilers, but that we will run into in the future.

1. Problem with `is_emtpy()` becoming part of the standard library (update: that was independently committed, but leaving my version of the fix as I find it a bit more readable).
2. Unnecessary `unsafe` blocks being reported as errors

Fixes: #12835