### PR TITLE
ci: Change Azure region to eastus2

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -9,7 +9,7 @@ source "${tests_dir}/common.bash"
 kubernetes_dir="${tests_dir}/integration/kubernetes"
 helm_chart_dir="${repo_root_dir}/tools/packaging/kata-deploy/helm-chart/kata-deploy"
 
-AZ_REGION="${AZ_REGION:-eastus}"
+AZ_REGION="${AZ_REGION:-eastus2}"
 AZ_NODEPOOL_TAGS="${AZ_NODEPOOL_TAGS:-}"
 GENPOLICY_PULL_METHOD="${GENPOLICY_PULL_METHOD:-oci-distribution}"
 GH_PR_NUMBER="${GH_PR_NUMBER:-}"


### PR DESCRIPTION
I'm doing some bookkeeping in the Azure subscription that requires we move from eastus to eastus2. This should have no user-facing impact.