### PR TITLE
runtime-rs: add build optimization flags

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -22,6 +22,13 @@ PACKAGE_FLAGS := $(patsubst %,-p %,$(PACKAGES))
 
 include ../../utils.mk
 
+##VAR RELEASE_LTO=true|false|thin|fat LTO setting used for release builds
+RELEASE_LTO ?= true
+##VAR RELEASE_CODEGEN_UNITS=<number> codegen units used for release builds
+RELEASE_CODEGEN_UNITS ?= 1
+# Apply release profile overrides only for release builds.
+RELEASE_CARGO_PROFILE_ENV = $(if $(findstring release,$(BUILD_TYPE)),CARGO_PROFILE_RELEASE_LTO=$(RELEASE_LTO) CARGO_PROFILE_RELEASE_CODEGEN_UNITS=$(RELEASE_CODEGEN_UNITS),)
+
 ARCH_DIR = arch
 ARCH_FILE_SUFFIX = -options.mk
 ARCH_FILE = $(ARCH_DIR)/$(ARCH)$(ARCH_FILE_SUFFIX)
@@ -718,7 +725,7 @@ static-checks-build: $(GENERATED_FILES)
 $(TARGET): $(GENERATED_FILES) $(TARGET_PATH)
 
 $(TARGET_PATH): $(SOURCES) | show-summary
-	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build -p runtime-rs --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES)
+	@$(RELEASE_CARGO_PROFILE_ENV) RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build -p runtime-rs --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES)
 
 $(GENERATED_FILES): %: %.in
 	@sed \
@@ -728,7 +735,7 @@ $(GENERATED_FILES): %: %.in
 
 ##TARGET optimize: optimized  build
 optimize: $(SOURCES) | show-summary show-header
-	@RUSTFLAGS="-C link-arg=-s $(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE) $(EXTRA_RUSTFEATURES)
+	@$(RELEASE_CARGO_PROFILE_ENV) RUSTFLAGS="-C link-arg=-s $(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) --$(BUILD_TYPE) $(EXTRA_RUSTFEATURES)
 
 ##TARGET clean: clean build
 clean: clean-generated-files


### PR DESCRIPTION
Enable the following optimizations when building runtime-rs in release mode:
- lto: true
- codegen-units=1:

Setting these reduce the binary size and improve performance at the cost of longer build times.

Without these flags:
- build time: 4m 55s
- binary size: 51 MB

With these flags:
- build time: 7m 21s
- binary size: 38MB

Per https://github.com/kata-containers/kata-containers/issues/1125 and local experiments, a smaller binary size leads to a smaller shim memory footprint.

- https://nnethercote.github.io/perf-book/build-configuration.html#codegen-units
- https://nnethercote.github.io/perf-book/build-configuration.html#link-time-optimization