### PR TITLE
tests: Update images used for signed tests

### DIFF
--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -335,7 +335,11 @@
         "pause_container_image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",
         "guest_pull": true,
         "pause_container_id_policy": "v1",
-        "encrypted_emptydir": true
+        "encrypted_emptydir": true,
+        "cgroup_mount_extras_allowed": [
+            "nsdelegate",
+            "memory_recursiveprot"
+        ]
     },
     "request_defaults": {
         "CreateContainerRequest": {

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1153,6 +1153,33 @@ check_mount(p_mount, i_mount, bundle_id, sandbox_id) if {
     print("check_mount 3: true")
 }
 
+check_mount(p_mount, i_mount, bundle_id, sandbox_id) if {
+    # Unified cgroup v2 mounts on newer kernels may add flags genpolicy does not
+    # embed (e.g. nsdelegate, memory_recursiveprot). Allow extras listed in
+    # policy_data.cluster_config.cgroup_mount_extras_allowed (from genpolicy-settings.json).
+    i_mount.type_ == "cgroup"
+    p_mount.type_ == "cgroup"
+    p_mount.destination == i_mount.destination
+    p_mount.source == i_mount.source
+
+    allowed_extras := {x | x = policy_data.cluster_config.cgroup_mount_extras_allowed[_]}
+
+    p_opts := {x | x = p_mount.options[_]}
+    i_opts := {x | x = i_mount.options[_]}
+    every opt in p_mount.options {
+        opt in i_opts
+    }
+
+    extras := i_opts - p_opts
+    every extra in extras {
+        extra in allowed_extras
+    }
+
+    mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id)
+
+    print("check_mount 4: true")
+}
+
 mount_source_allows(p_mount, i_mount, bundle_id, sandbox_id) if {
     regex1 := p_mount.source
     print("mount_source_allows 1: regex1 =", regex1)

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -64,6 +64,9 @@ pub struct PolicyData {
 
     /// Device settings read from genpolicy-settings.json.
     pub devices: Devices,
+
+    /// Cluster-level settings read from genpolicy-settings.json.
+    pub cluster_config: ClusterConfig,
 }
 
 /// OCI Container spec. This struct is very similar to the Spec struct from
@@ -470,6 +473,11 @@ pub struct ClusterConfig {
     /// Whether emptyDirs are encrypted with modified metadata in the
     /// mount and a storage object for the block device.
     pub encrypted_emptydir: bool,
+
+    /// Cgroup v2 mount options that may appear beyond what genpolicy embeds
+    /// (e.g. "nsdelegate", "memory_recursiveprot" on newer kernels).
+    #[serde(default)]
+    pub cgroup_mount_extras_allowed: Vec<String>,
 }
 
 /// Describes patterns for supported VFIO devices.
@@ -638,6 +646,7 @@ impl AgentPolicy {
             common: self.config.settings.common.clone(),
             sandbox: self.config.settings.sandbox.clone(),
             devices: self.config.settings.devices.clone(),
+            cluster_config: self.config.settings.cluster_config.clone(),
         };
 
         let json_data = serde_json::to_string_pretty(&policy_data).unwrap();

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -291,6 +291,11 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_container_cgroup_mount_extras() {
+        runtests("createcontainer/cgroup_mount_extras").await;
+    }
+
+    #[tokio::test]
     async fn test_state_create_container() {
         runtests("state/createcontainer").await;
     }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/pod.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gid-experiment
+  labels:
+    app: gid-experiment
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+    - name: gid
+      image: "ghcr.io/burgerdev/weird-images/gid:latest@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0"

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/testcases.json
@@ -1,0 +1,671 @@
+[
+  {
+    "allowed": true,
+    "description": "cgroup mount with allowed extras (nsdelegate, memory_recursiveprot)",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gid",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.kubernetes.cri.container-name": "gid",
+          "io.kubernetes.cri.container-type": "container",
+          "io.kubernetes.cri.image-name": "ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0",
+          "io.kubernetes.cri.sandbox-id": "8667fea11fc4fc70d427cc3645950ac83cc7d33ca515a8774ab95043f0096bb8",
+          "io.kubernetes.cri.sandbox-name": "gid-experiment",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "31df313a-931f-4979-a405-cc3f3ccb6a56"
+        },
+        "Hooks": null,
+        "Hostname": "",
+        "Linux": {
+          "CgroupsPath": "kubepods-burstable-pod31df313a_931f_4979_a405_cc3f3ccb6a56.slice:cri-containerd:gid",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": [
+            "/proc/asound",
+            "/proc/acpi",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/proc/scsi",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {
+              "Cpus": "",
+              "Mems": "",
+              "Period": 100000,
+              "Quota": 0,
+              "RealtimePeriod": 0,
+              "RealtimeRuntime": 0,
+              "Shares": 2
+            },
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": {
+              "DisableOOMKiller": false,
+              "Kernel": 0,
+              "KernelTCP": 0,
+              "Limit": 0,
+              "Reservation": 0,
+              "Swap": 0,
+              "Swappiness": 0
+            },
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {
+            "destination": "/proc",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "proc",
+            "type_": "proc"
+          },
+          {
+            "destination": "/dev",
+            "options": [
+              "nosuid",
+              "strictatime",
+              "mode=755",
+              "size=65536k"
+            ],
+            "source": "tmpfs",
+            "type_": "tmpfs"
+          },
+          {
+            "destination": "/dev/pts",
+            "options": [
+              "nosuid",
+              "noexec",
+              "newinstance",
+              "ptmxmode=0666",
+              "mode=0620",
+              "gid=5"
+            ],
+            "source": "devpts",
+            "type_": "devpts"
+          },
+          {
+            "destination": "/dev/mqueue",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "mqueue",
+            "type_": "mqueue"
+          },
+          {
+            "destination": "/sys",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "ro"
+            ],
+            "source": "sysfs",
+            "type_": "sysfs"
+          },
+          {
+            "destination": "/sys/fs/cgroup",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "relatime",
+              "ro",
+              "nsdelegate",
+              "memory_recursiveprot"
+            ],
+            "source": "cgroup",
+            "type_": "cgroup"
+          },
+          {
+            "destination": "/etc/hosts",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-4a4c20d48254d738-hosts",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/termination-log",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-72cfcc0e64a0d1af-termination-log",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/hostname",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-89f0faae823d569c-hostname",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/resolv.conf",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-8c0d97703dbbb30e-resolv.conf",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/shm",
+            "options": [
+              "rbind"
+            ],
+            "source": "/run/kata-containers/sandbox/shm",
+            "type_": "bind"
+          },
+          {
+            "destination": "/var/run/secrets/kubernetes.io/serviceaccount",
+            "options": [
+              "rbind",
+              "rprivate",
+              "ro"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-be44d3a46e427870-serviceaccount",
+            "type_": "bind"
+          }
+        ],
+        "Process": {
+          "ApparmorProfile": "cri-containerd.apparmor.d",
+          "Args": [
+            "/entrypoint.sh"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HOSTNAME=gid-experiment",
+            "KUBERNETES_PORT_443_TCP=tcp://10.0.0.1:443",
+            "KUBERNETES_PORT_443_TCP_PROTO=tcp",
+            "KUBERNETES_PORT_443_TCP_PORT=443",
+            "KUBERNETES_PORT_443_TCP_ADDR=10.0.0.1",
+            "KUBERNETES_SERVICE_HOST=10.0.0.1",
+            "KUBERNETES_SERVICE_PORT=443",
+            "KUBERNETES_SERVICE_PORT_HTTPS=443",
+            "KUBERNETES_PORT=tcp://10.0.0.1:443"
+          ],
+          "NoNewPrivileges": false,
+          "OOMScoreAdj": 994,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              0
+            ],
+            "GID": 0,
+            "UID": 0,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/gid/rootfs",
+          "Readonly": false
+        },
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "gid",
+      "devices": [],
+      "exec_id": "gid",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/gid\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gid\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0\",\"io.kubernetes.cri.sandbox-id\":\"8667fea11fc4fc70d427cc3645950ac83cc7d33ca515a8774ab95043f0096bb8\",\"io.kubernetes.cri.sandbox-name\":\"gid-experiment\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"31df313a-931f-4979-a405-cc3f3ccb6a56\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/gid/rootfs",
+          "options": [],
+          "source": "ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0"
+        }
+      ],
+      "string_user": null
+    }
+  },
+  {
+    "allowed": false,
+    "description": "cgroup mount with disallowed extra option",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gid",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.kubernetes.cri.container-name": "gid",
+          "io.kubernetes.cri.container-type": "container",
+          "io.kubernetes.cri.image-name": "ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0",
+          "io.kubernetes.cri.sandbox-id": "8667fea11fc4fc70d427cc3645950ac83cc7d33ca515a8774ab95043f0096bb8",
+          "io.kubernetes.cri.sandbox-name": "gid-experiment",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "31df313a-931f-4979-a405-cc3f3ccb6a56"
+        },
+        "Hooks": null,
+        "Hostname": "",
+        "Linux": {
+          "CgroupsPath": "kubepods-burstable-pod31df313a_931f_4979_a405_cc3f3ccb6a56.slice:cri-containerd:gid",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": [
+            "/proc/asound",
+            "/proc/acpi",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/proc/scsi",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {
+              "Cpus": "",
+              "Mems": "",
+              "Period": 100000,
+              "Quota": 0,
+              "RealtimePeriod": 0,
+              "RealtimeRuntime": 0,
+              "Shares": 2
+            },
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": {
+              "DisableOOMKiller": false,
+              "Kernel": 0,
+              "KernelTCP": 0,
+              "Limit": 0,
+              "Reservation": 0,
+              "Swap": 0,
+              "Swappiness": 0
+            },
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {
+            "destination": "/proc",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "proc",
+            "type_": "proc"
+          },
+          {
+            "destination": "/dev",
+            "options": [
+              "nosuid",
+              "strictatime",
+              "mode=755",
+              "size=65536k"
+            ],
+            "source": "tmpfs",
+            "type_": "tmpfs"
+          },
+          {
+            "destination": "/dev/pts",
+            "options": [
+              "nosuid",
+              "noexec",
+              "newinstance",
+              "ptmxmode=0666",
+              "mode=0620",
+              "gid=5"
+            ],
+            "source": "devpts",
+            "type_": "devpts"
+          },
+          {
+            "destination": "/dev/mqueue",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "mqueue",
+            "type_": "mqueue"
+          },
+          {
+            "destination": "/sys",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "ro"
+            ],
+            "source": "sysfs",
+            "type_": "sysfs"
+          },
+          {
+            "destination": "/sys/fs/cgroup",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "relatime",
+              "ro",
+              "memory_hugetlb"
+            ],
+            "source": "cgroup",
+            "type_": "cgroup"
+          },
+          {
+            "destination": "/etc/hosts",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-4a4c20d48254d738-hosts",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/termination-log",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-72cfcc0e64a0d1af-termination-log",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/hostname",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-89f0faae823d569c-hostname",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/resolv.conf",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-8c0d97703dbbb30e-resolv.conf",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/shm",
+            "options": [
+              "rbind"
+            ],
+            "source": "/run/kata-containers/sandbox/shm",
+            "type_": "bind"
+          },
+          {
+            "destination": "/var/run/secrets/kubernetes.io/serviceaccount",
+            "options": [
+              "rbind",
+              "rprivate",
+              "ro"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-be44d3a46e427870-serviceaccount",
+            "type_": "bind"
+          }
+        ],
+        "Process": {
+          "ApparmorProfile": "cri-containerd.apparmor.d",
+          "Args": [
+            "/entrypoint.sh"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HOSTNAME=gid-experiment",
+            "KUBERNETES_PORT_443_TCP=tcp://10.0.0.1:443",
+            "KUBERNETES_PORT_443_TCP_PROTO=tcp",
+            "KUBERNETES_PORT_443_TCP_PORT=443",
+            "KUBERNETES_PORT_443_TCP_ADDR=10.0.0.1",
+            "KUBERNETES_SERVICE_HOST=10.0.0.1",
+            "KUBERNETES_SERVICE_PORT=443",
+            "KUBERNETES_SERVICE_PORT_HTTPS=443",
+            "KUBERNETES_PORT=tcp://10.0.0.1:443"
+          ],
+          "NoNewPrivileges": false,
+          "OOMScoreAdj": 994,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              0
+            ],
+            "GID": 0,
+            "UID": 0,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/gid/rootfs",
+          "Readonly": false
+        },
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "gid",
+      "devices": [],
+      "exec_id": "gid",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/gid\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gid\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0\",\"io.kubernetes.cri.sandbox-id\":\"8667fea11fc4fc70d427cc3645950ac83cc7d33ca515a8774ab95043f0096bb8\",\"io.kubernetes.cri.sandbox-name\":\"gid-experiment\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"31df313a-931f-4979-a405-cc3f3ccb6a56\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/gid/rootfs",
+          "options": [],
+          "source": "ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0"
+        }
+      ],
+      "string_user": null
+    }
+  }
+]

--- a/tests/integration/kubernetes/k8s-guest-pull-image-signature.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-signature.bats
@@ -21,16 +21,11 @@ setup() {
         skip "Either SNAPSHOTTER=nydus or EXPERIMENTAL_FORCE_GUEST_PULL must be set for this test"
     fi
 
-    tag_suffix=""
-    if [ "$(uname -m)" != "x86_64" ]; then
-        tag_suffix="-$(uname -m)"
-    fi
-
     setup_common || die "setup_common failed"
     UNSIGNED_UNPROTECTED_REGISTRY_IMAGE="quay.io/prometheus/busybox:latest"
-    UNSIGNED_PROTECTED_REGISTRY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:unsigned${tag_suffix}"
-    COSIGN_SIGNED_PROTECTED_REGISTRY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:cosign-signed${tag_suffix}"
-    COSIGNED_SIGNED_PROTECTED_REGISTRY_WRONG_KEY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:cosign-signed-key2${tag_suffix}"
+    UNSIGNED_PROTECTED_REGISTRY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:unsigned"
+    COSIGN_SIGNED_PROTECTED_REGISTRY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:cosign-signed"
+    COSIGNED_SIGNED_PROTECTED_REGISTRY_WRONG_KEY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:cosign-signed-key2"
     SECURITY_POLICY_KBS_URI="kbs:///default/security-policy/test"
 }
 
@@ -66,9 +61,8 @@ function setup_kbs_image_policy() {
 EOF
     )
 
-    # This public key is corresponding to a private key that was generated to test signed images in image-rs CI.
     # TODO: Update the CI to generate a signed image together with verification. See issue #9360
-    public_key=$(curl -sSL "https://raw.githubusercontent.com/confidential-containers/guest-components/075b9a9ee77227d9d92b6f3649ef69de5e72d204/image-rs/test_data/signature/cosign/cosign1.pub")
+    public_key=$(curl -sSL "https://raw.githubusercontent.com/confidential-containers/infra/main/container-images/keys/sign/cosign.pub")
 
     if ! is_confidential_hardware; then
         kbs_set_allow_all_resources


### PR DESCRIPTION
I've updaed the images on the Confidential Containers side, in order to add arm64 support, but I didn't realize it'd break tests not using those.

Apologies!