### PR TITLE
dragonball: Implement userspace IOAPIC to enable split irqchip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -175,6 +175,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary-int"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993a810118f8f37e9c4411c86f1c4c940a09a7ab34b7bf2d88d06f50c553fab7"
+
+[[package]]
 name = "arc-swap"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +588,29 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bilge"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "279c74986684d5cc7bbbd079aa448e8f852992cd385d85bb3a37e374c087b065"
+dependencies = [
+ "arbitrary-int",
+ "bilge-impl",
+]
+
+[[package]]
+name = "bilge-impl"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1176e49f42fe135cd2b56465e4f7d07038d3728f5e9f27fb2f08ed3fef75339"
+dependencies = [
+ "itertools 0.14.0",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "bit-set"
@@ -1485,6 +1514,7 @@ dependencies = [
 name = "dbs-interrupt"
 version = "0.2.2"
 dependencies = [
+ "bilge",
  "dbs-arch",
  "dbs-device",
  "kvm-bindings",
@@ -3218,6 +3248,15 @@ name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -5375,7 +5414,7 @@ checksum = "355f634b43cdd80724ee7848f95770e7e70eefa6dcf14fea676216573b8fd603"
 dependencies = [
  "bytes 1.11.1",
  "heck 0.3.3",
- "itertools",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "petgraph 0.5.1",
@@ -5393,7 +5432,7 @@ checksum = "119533552c9a7ffacc21e099c24a0ac8bb19c2a2a3f363de84cd9b844feab270"
 dependencies = [
  "bytes 1.11.1",
  "heck 0.4.1",
- "itertools",
+ "itertools 0.10.5",
  "lazy_static",
  "log",
  "multimap",
@@ -5414,7 +5453,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "600d2f334aa05acb02a755e217ef1ab6dea4d51b58b7846588b747edec04efba"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -5427,7 +5466,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 1.0.109",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,7 @@ actix-rt = "2.7.0"
 anyhow = "1.0"
 async-recursion = "0.3.2"
 async-trait = "0.1.48"
+bilge = "0.3.0"
 capctl = "0.2.0"
 cfg-if = "1.0.0"
 cgroups = { package = "cgroups-rs", git = "https://github.com/kata-containers/cgroups-rs", rev = "v0.3.5" }

--- a/src/dragonball/Cargo.toml
+++ b/src/dragonball/Cargo.toml
@@ -18,7 +18,7 @@ dbs-allocator = { workspace = true }
 dbs-arch = { workspace = true }
 dbs-boot = { workspace = true }
 dbs-device = { workspace = true }
-dbs-interrupt = { workspace = true, features = ["kvm-irq"] }
+dbs-interrupt = { workspace = true, features = ["kvm-irq", "split-irq"] }
 dbs-legacy-devices = { workspace = true }
 dbs-upcall = { workspace = true, optional = true }
 dbs-utils = { workspace = true }

--- a/src/dragonball/dbs_interrupt/Cargo.toml
+++ b/src/dragonball/dbs_interrupt/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["dragonball", "secure-sandbox", "device", "interrupt"]
 readme = "README.md"
 
 [dependencies]
+bilge = { workspace = true }
 dbs-device = { workspace = true }
 dbs-arch = { workspace = true }
 kvm-bindings = { workspace = true, optional = true }
@@ -32,3 +33,6 @@ kvm-irq = ["kvm-ioctls", "kvm-bindings"]
 kvm-legacy-irq = ["legacy-irq", "kvm-irq"]
 kvm-msi-generic = ["msi-irq", "kvm-irq"]
 kvm-msi-irq = ["kvm-msi-generic"]
+
+split-irq = ["kvm-ioctls", "kvm-bindings"]
+split-legacy-irq = ["legacy-irq", "split-irq"]

--- a/src/dragonball/dbs_interrupt/src/kvm/mod.rs
+++ b/src/dragonball/dbs_interrupt/src/kvm/mod.rs
@@ -75,13 +75,6 @@ impl KvmIrqManager {
         }
     }
 
-    /// Prepare the interrupt manager for generating interrupts into the target VM.
-    pub fn initialize(&self) -> Result<()> {
-        // Safe to unwrap because there's no legal way to break the mutex.
-        let mgr = self.mgr.lock().unwrap();
-        mgr.initialize()
-    }
-
     /// Set maximum supported MSI interrupts per device.
     pub fn set_max_msi_irqs(&self, max_msi_irqs: InterruptIndex) {
         let mut mgr = self.mgr.lock().unwrap();
@@ -90,6 +83,12 @@ impl KvmIrqManager {
 }
 
 impl InterruptManager for KvmIrqManager {
+    fn initialize(&self) -> Result<()> {
+        // Safe to unwrap because there's no legal way to break the mutex.
+        let mgr = self.mgr.lock().unwrap();
+        mgr.initialize()
+    }
+
     fn create_group(
         &self,
         ty: InterruptSourceType,

--- a/src/dragonball/dbs_interrupt/src/lib.rs
+++ b/src/dragonball/dbs_interrupt/src/lib.rs
@@ -71,6 +71,11 @@ pub mod kvm;
 #[cfg(feature = "kvm-irq")]
 pub use self::kvm::KvmIrqManager;
 
+#[cfg(all(target_arch = "x86_64", feature = "split-irq"))]
+pub mod userspace;
+#[cfg(all(target_arch = "x86_64", feature = "split-irq"))]
+pub use self::userspace::{ioapic::*, manager::UserspaceIoapicManager};
+
 /// Reuse std::io::Result to simplify interoperability among crates.
 pub type Result<T> = std::io::Result<T>;
 
@@ -128,7 +133,13 @@ pub struct MsiIrqSourceConfig {
 ///
 /// The InterruptManager implementations should protect itself from concurrent accesses internally,
 /// so it could be invoked from multi-threaded context.
-pub trait InterruptManager {
+pub trait InterruptManager: Send + Sync {
+    /// Prepare the interrupt manager for generating interrupts into the target VM.
+    /// No-op by default.
+    fn initialize(&self) -> Result<()> {
+        Ok(())
+    }
+
     /// Create an [InterruptSourceGroup](trait.InterruptSourceGroup.html) object to manage interrupt
     /// sources for a virtual device.
     ///
@@ -153,9 +164,37 @@ pub trait InterruptManager {
     /// before calling destroy_group(). This assumption helps to simplify InterruptSourceGroup
     /// implementations.
     fn destroy_group(&self, group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()>;
+
+    /// In cases of userspace irq management, guest kernel might try to query the emulated IOAPIC
+    /// registers via MMIO read operations, and with this function, the manager would be able to
+    /// handle these requests according to the IOAPIC protocol.
+    /// No-op by default.
+    ///
+    /// # Arguments
+    /// * addr: target address for MMIO read operation
+    /// * data: buffer where the query result is stored
+    fn ioapic_read(&self, _addr: u64, _data: &mut [u8]) -> Result<()> {
+        Ok(())
+    }
+
+    /// In cases of userspace irq management, guest kernel might try to update the emulated IOAPIC
+    /// registers via MMIO write operations, and with this function, the manager would be able to
+    /// handle these requests according to the IOAPIC protocol.
+    /// No-op by default.
+    ///
+    /// # Arguments
+    /// * addr: target address for MMIO write operation
+    /// * data: new value for IOAPIC registers
+    fn ioapic_write(&self, _addr: u64, _data: &[u8]) -> Result<()> {
+        Ok(())
+    }
 }
 
 impl<T: InterruptManager> InterruptManager for Arc<T> {
+    fn initialize(&self) -> Result<()> {
+        self.deref().initialize()
+    }
+
     fn create_group(
         &self,
         type_: InterruptSourceType,
@@ -170,6 +209,41 @@ impl<T: InterruptManager> InterruptManager for Arc<T> {
         group: Arc<Box<dyn InterruptSourceGroup>>,
     ) -> std::result::Result<(), Error> {
         self.deref().destroy_group(group)
+    }
+
+    fn ioapic_read(&self, addr: u64, data: &mut [u8]) -> Result<()> {
+        self.deref().ioapic_read(addr, data)
+    }
+
+    fn ioapic_write(&self, addr: u64, data: &[u8]) -> Result<()> {
+        self.deref().ioapic_write(addr, data)
+    }
+}
+
+impl InterruptManager for Arc<Box<dyn InterruptManager>> {
+    fn initialize(&self) -> Result<()> {
+        self.deref().initialize()
+    }
+
+    fn create_group(
+        &self,
+        type_: InterruptSourceType,
+        base: InterruptIndex,
+        count: InterruptIndex,
+    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
+        self.deref().create_group(type_, base, count)
+    }
+
+    fn destroy_group(&self, group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {
+        self.deref().destroy_group(group)
+    }
+
+    fn ioapic_read(&self, addr: u64, data: &mut [u8]) -> Result<()> {
+        self.deref().ioapic_read(addr, data)
+    }
+
+    fn ioapic_write(&self, addr: u64, data: &[u8]) -> Result<()> {
+        self.deref().ioapic_write(addr, data)
     }
 }
 

--- a/src/dragonball/dbs_interrupt/src/userspace/ioapic.rs
+++ b/src/dragonball/dbs_interrupt/src/userspace/ioapic.rs
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use bilge::prelude::*;
+
+use std::convert::TryFrom;
+
+use super::InterruptIndex;
+
+/// Base physical address of IOAPIC range
+pub const IOAPIC_BASE: u32 = 0xfec0_0000;
+/// Size of IOAPIC range
+pub const IOAPIC_SIZE: u32 = 0x1000;
+
+/// Base address for IOAPIC index register (direct)
+pub const IOAPIC_IOREGSEL_BASE: u32 = IOAPIC_BASE;
+/// Base address for IOAPIC data registers (direct)
+pub const IOAPIC_IOWIN_BASE: u32 = IOAPIC_BASE + 0x10;
+
+/// Index for IOAPIC ID register (indirect)
+pub const IOAPIC_IOAPICID_INDEX: u8 = 0x00;
+/// Index for IOAPIC version register (indirect)
+pub const IOAPIC_IOAPICVER_INDEX: u8 = 0x01;
+/// Index for IOAPIC arbitration register (indirect)
+pub const IOAPIC_IOAPICARB_INDEX: u8 = 0x02;
+/// Start index for IOAPIC redirection table (indirect)
+pub const IOAPIC_REDIR_TABLE_START_INDEX: u8 = 0x10;
+/// End index for IOAPIC redirection table (indirect)
+pub const IOAPIC_REDIR_TABLE_END_INDEX: u8 = 0x3f;
+
+/// Max number of userspace IOAPIC redirection entries
+pub const IOAPIC_MAX_NR_REDIR_ENTRIES: InterruptIndex =
+    ((IOAPIC_REDIR_TABLE_END_INDEX - IOAPIC_REDIR_TABLE_START_INDEX + 1) >> 1) as InterruptIndex;
+/// Default number of userspace IOAPIC redirection entries
+pub const IOAPIC_DEFAULT_NR_REDIR_ENTRIES: InterruptIndex = IOAPIC_MAX_NR_REDIR_ENTRIES;
+
+/// Default IOAPIC version
+pub const IOAPIC_DEFAULT_VERSION: u8 = 0x20;
+
+/// MSI message base address
+pub const MSI_BASE_ADDR: u12 = u12::from_u16(0xfee);
+
+/// Bits for IOREGSEL register
+#[bitsize(32)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct IoRegSel {
+    /// Bits 7:0. Selected indirect register index to visit
+    pub(super) register_index: u8,
+    /// Bits 31:8. Reserved
+    pub(super) reserved: u24,
+}
+
+/// Bits for IOAPICID register
+#[bitsize(32)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct IoapicId {
+    /// Bits 13:0. Reserved
+    pub(super) reserved_2: u14,
+    /// Bit 14. Level trigger status
+    pub(super) lts: bool,
+    /// Bit 15. Delivery type
+    pub(super) delivery_type: bool,
+    /// Bits 23:16. Reserved
+    pub(super) reserved_1: u8,
+    /// Bits 31:24. IOAPIC ID
+    pub(super) id: u8,
+}
+
+/// Bits for IOAPICVER register
+#[bitsize(32)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct IoapicVer {
+    /// Bits 7:0. IOAPIC version
+    pub(super) version: u8,
+    /// Bits 14:8. Reserved
+    pub(super) reserved_2: u7,
+    /// Bit 15. Support for Pin Assertion Register
+    pub(super) prq: bool,
+    /// Bits 23:16. Max index for redirection entry (Number of redirection entries - 1)
+    pub(super) entries: u8,
+    /// Bits 31:24. Reserved
+    pub(super) reserved_1: u8,
+}
+
+/// Bits for IOAPICARB register
+#[bitsize(32)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct IoapicArb {
+    /// Bits 23:0. Reserved
+    pub(super) reserved_2: u24,
+    /// Bits 27:24. Arbitration ID
+    pub(super) arbitration: u4,
+    /// Bits 31:28. Reserved
+    pub(super) reserved_1: u4,
+}
+
+/// Bits for IOAPIC redirection entry
+#[bitsize(64)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct IoapicRedirEntry {
+    /// Low word
+    pub(super) low: IoapicRedirEntryLow,
+    /// High word
+    pub(super) high: IoapicRedirEntryHigh,
+}
+
+/// Low word of IOAPIC redirection entry
+#[bitsize(32)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct IoapicRedirEntryLow {
+    /// Bits 7:0. Interrupt vector
+    pub(super) vector: u8,
+    /// Bits 10:8. Delivery mode
+    pub(super) delivery_mode: u3,
+    /// Bit 11. Destination mode, 0 = physical, 1 = logical
+    pub(super) dest_mode_logical: bool,
+    /// Bit 12. Delivery status, 0 = idle, 1 = send pending. Read-only
+    pub(super) delivery_status: bool,
+    /// Bit 13. 0 = active high, 1 = active low
+    pub(super) active_low: bool,
+    /// Bit 14. Remote IRR level trigger status. Read-only
+    pub(super) irr: bool,
+    /// Bit 15. Trigger mode. 0 = edge, 1 = level
+    pub(super) is_level: bool,
+    /// Bit 16. 0 = interrupt unmasked, 1 = interrupt masked
+    pub(super) masked: bool,
+    /// Bits 31:17. Reserved
+    pub(super) reserved_0: u15,
+}
+
+/// High word of IOAPIC redirection entry
+#[bitsize(32)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct IoapicRedirEntryHigh {
+    /// Bits 16:0. Reserved
+    pub(super) reserved_1: u17,
+    /// Bits 23:17. High bits (8-14) for virtual APIC ID
+    pub(super) virt_destid_8_14: u7,
+    /// Bits 31:24. Low bits (0-7) for APIC ID
+    pub(super) destid_0_7: u8,
+}
+
+/// Low word of address field for MSI message
+#[bitsize(32)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct MsiAddressLow {
+    /// Bits 1:0. Reserved
+    pub(super) reserved_0: u2,
+    /// Bit 2. Destination mode, 0 = physical, 1 = logical
+    pub(super) dest_mode_logical: bool,
+    /// Bit 3. Redirection hint
+    pub(super) redirect_hint: bool,
+    /// Bit 4. Reserved
+    pub(super) reserved_1: bool,
+    /// Bits 11:5. High bits (8-14) for virtual APIC ID
+    pub(super) virt_destid_8_14: u7,
+    /// Bits 19:12. Low bits (0-7) for APIC ID
+    pub(super) destid_0_7: u8,
+    /// Bits 31:20 Base address. (Should be 0xfee)
+    pub(super) base_address: u12,
+}
+
+/// High word of address field for MSI message
+#[bitsize(32)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct MsiAddressHigh {
+    /// Bits 7:0. Reserved
+    pub(super) reserved: u8,
+    /// Bits 31:8. High bits (8-31) for APIC ID
+    pub(super) destid_8_31: u24,
+}
+
+/// Data field for MSI message
+#[bitsize(32)]
+#[derive(DebugBits, FromBits, Default, Clone)]
+pub(super) struct MsiData {
+    /// Bits 7:0. Interrupt vector
+    pub(super) vector: u8,
+    /// Bits 10:8. Delivery mode
+    pub(super) delivery_mode: u3,
+    /// Bit 11. Destination mode, 0 = physical, 1 = logical
+    pub(super) dest_mode_logical: bool,
+    /// Bits 13:12. Reserved
+    pub(super) reserved_0: u2,
+    /// Bit 14. 0 = active high, 1 = active low
+    pub(super) active_low: bool,
+    /// Bit 15. Trigger mode. 0 = edge, 1 = level
+    pub(super) is_level: bool,
+    /// Bits 31:16. Reserved
+    pub(super) reserved_1: u16,
+}

--- a/src/dragonball/dbs_interrupt/src/userspace/legacy_irq.rs
+++ b/src/dragonball/dbs_interrupt/src/userspace/legacy_irq.rs
@@ -1,0 +1,272 @@
+// Copyright (c) 2026 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use kvm_bindings::kvm_msi;
+use kvm_ioctls::VmFd;
+use vmm_sys_util::eventfd::EventFd;
+
+use std::sync::{Arc, RwLock};
+
+use super::{
+    ioapic::*, InterruptIndex, InterruptSourceConfig, InterruptSourceGroup, InterruptSourceType,
+    Result,
+};
+
+#[derive(Debug)]
+pub(super) struct UserspaceLegacyIrq {
+    irq: Arc<UserspaceLegacyIrqObj>,
+}
+
+#[derive(Debug)]
+pub(super) struct UserspaceLegacyIrqObj {
+    base: InterruptIndex,
+    vmfd: Arc<VmFd>,
+    enabled: RwLock<bool>,
+    redir_entry: RwLock<IoapicRedirEntry>,
+}
+
+impl UserspaceLegacyIrqObj {
+    pub(super) fn new(base: u32, vmfd: Arc<VmFd>) -> Self {
+        Self {
+            base,
+            vmfd,
+            enabled: RwLock::new(false),
+            redir_entry: RwLock::new(IoapicRedirEntry::default()),
+        }
+    }
+
+    pub(super) fn redir_entry_low(&self) -> IoapicRedirEntryLow {
+        self.redir_entry.read().unwrap().low().clone()
+    }
+
+    pub(super) fn set_redir_entry_low(&self, entry: IoapicRedirEntryLow) {
+        self.redir_entry.write().unwrap().set_low(entry);
+    }
+
+    pub(super) fn redir_entry_high(&self) -> IoapicRedirEntryHigh {
+        self.redir_entry.read().unwrap().high().clone()
+    }
+
+    pub(super) fn set_redir_entry_high(&self, entry: IoapicRedirEntryHigh) {
+        self.redir_entry.write().unwrap().set_high(entry);
+    }
+
+    fn enabled(&self) -> bool {
+        *self.enabled.read().unwrap()
+    }
+
+    fn set_enabled(&self, enabled: bool) {
+        *self.enabled.write().unwrap() = enabled;
+    }
+
+    fn masked(&self) -> bool {
+        self.redir_entry.read().unwrap().low().masked()
+    }
+
+    fn set_masked(&self, masked: bool) {
+        let mut entry = self.redir_entry.write().unwrap();
+        let mut low = entry.low().clone();
+        low.set_masked(masked);
+        entry.set_low(low);
+    }
+
+    fn delivery_status(&self) -> bool {
+        self.redir_entry.read().unwrap().low().delivery_status()
+    }
+
+    fn signal_msi(&self) -> Result<()> {
+        let mut address_lo = MsiAddressLow::default();
+        address_lo.set_dest_mode_logical(self.redir_entry_low().dest_mode_logical());
+        address_lo.set_virt_destid_8_14(self.redir_entry_high().virt_destid_8_14());
+        address_lo.set_destid_0_7(self.redir_entry_high().destid_0_7());
+        address_lo.set_base_address(MSI_BASE_ADDR);
+
+        let mut data = MsiData::default();
+        data.set_vector(self.redir_entry_low().vector());
+        data.set_delivery_mode(self.redir_entry_low().delivery_mode());
+        data.set_dest_mode_logical(self.redir_entry_low().dest_mode_logical());
+        data.set_active_low(self.redir_entry_low().active_low());
+        data.set_is_level(self.redir_entry_low().is_level());
+
+        let kvm_msi = kvm_msi {
+            address_lo: address_lo.into(),
+            data: data.into(),
+            ..Default::default()
+        };
+
+        let ret = self.vmfd.signal_msi(kvm_msi)?;
+        if ret < 0 {
+            return Err(std::io::Error::from_raw_os_error(-ret));
+        }
+
+        Ok(())
+    }
+}
+
+impl UserspaceLegacyIrq {
+    pub fn new(irq: Arc<UserspaceLegacyIrqObj>) -> Self {
+        Self { irq }
+    }
+}
+
+impl InterruptSourceGroup for UserspaceLegacyIrq {
+    fn interrupt_type(&self) -> InterruptSourceType {
+        InterruptSourceType::LegacyIrq
+    }
+
+    fn len(&self) -> u32 {
+        1
+    }
+
+    fn base(&self) -> u32 {
+        self.irq.base
+    }
+
+    fn enable(&self, configs: &[InterruptSourceConfig]) -> Result<()> {
+        if configs.len() != 1 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        self.irq.set_enabled(true);
+
+        Ok(())
+    }
+
+    fn disable(&self) -> Result<()> {
+        self.irq.set_enabled(false);
+
+        Ok(())
+    }
+
+    fn update(&self, index: InterruptIndex, _config: &InterruptSourceConfig) -> Result<()> {
+        // Update of redirection entries would be handled by IOAPIC manager via MMIO write
+        // No-op here.
+        if index != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+        Ok(())
+    }
+
+    fn notifier(&self, _index: InterruptIndex) -> Option<&EventFd> {
+        // KVM would not manage irqfd for split irqchip, and interrupts cannot be injected
+        // via writing to irqfd.
+        // Therefore, we maintain no irqfd here.
+        None
+    }
+
+    fn trigger(&self, index: InterruptIndex) -> Result<()> {
+        if index != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        if !self.irq.enabled() {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        if self.irq.masked() {
+            return Ok(());
+        }
+
+        self.irq.signal_msi()
+    }
+
+    fn mask(&self, index: InterruptIndex) -> Result<()> {
+        if index != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        self.irq.set_masked(true);
+
+        Ok(())
+    }
+
+    fn unmask(&self, index: InterruptIndex) -> Result<()> {
+        if index != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        self.irq.set_masked(false);
+
+        Ok(())
+    }
+
+    fn get_pending_state(&self, index: InterruptIndex) -> bool {
+        if index != 0 {
+            return false;
+        }
+
+        self.irq.delivery_status()
+    }
+}
+
+#[cfg(test)]
+#[cfg(target_arch = "x86_64")]
+mod test {
+    use super::*;
+    use crate::manager::tests::create_vm_fd;
+    use crate::LegacyIrqSourceConfig;
+    use kvm_bindings::{kvm_enable_cap, KVM_CAP_SPLIT_IRQCHIP};
+    use test_utils::skip_if_kvm_unaccessable;
+
+    fn enable_split_irqchip(vmfd: Arc<VmFd>) {
+        let mut enable_split_irqchip = kvm_enable_cap {
+            cap: KVM_CAP_SPLIT_IRQCHIP,
+            ..Default::default()
+        };
+        enable_split_irqchip.args[0] = IOAPIC_MAX_NR_REDIR_ENTRIES as u64;
+        vmfd.enable_cap(&enable_split_irqchip).unwrap();
+    }
+
+    #[test]
+    fn test_userspace_legacy_irq() {
+        skip_if_kvm_unaccessable!();
+        let vmfd = Arc::new(create_vm_fd());
+        enable_split_irqchip(vmfd.clone());
+        let base = 0;
+
+        let inner = Arc::new(UserspaceLegacyIrqObj::new(base, vmfd.clone()));
+        assert_eq!(u32::from(inner.redir_entry_low()), 0);
+        assert_eq!(u32::from(inner.redir_entry_high()), 0);
+
+        let mut low = IoapicRedirEntryLow::default();
+        low.set_vector(0x22);
+        inner.set_redir_entry_low(low);
+        assert_eq!(inner.redir_entry_low().vector(), 0x22);
+
+        let irq = UserspaceLegacyIrq::new(inner);
+        let configs = [InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})];
+        assert_eq!(irq.interrupt_type(), InterruptSourceType::LegacyIrq);
+        assert_eq!(irq.len(), 1);
+        assert_eq!(irq.base(), base);
+        assert!(irq.notifier(0).is_none());
+
+        assert_eq!(
+            irq.trigger(0).unwrap_err().raw_os_error(),
+            Some(libc::EINVAL)
+        );
+
+        irq.enable(&configs).unwrap();
+        // Since the interrupt vector is not officially registered in KVM, KVM_SIGNAL_MSI
+        // will report an error code anyway. But compared to other error codes (e.g., EINVAL),
+        // error code 1 means that all prechecks are passed, and the ioctl only fails because
+        // KVM is not able to find the proper APIC entry
+        assert_eq!(irq.trigger(0).unwrap_err().raw_os_error(), Some(1));
+        assert_eq!(
+            irq.trigger(1).unwrap_err().raw_os_error(),
+            Some(libc::EINVAL)
+        );
+
+        irq.update(0, &configs[0]).unwrap();
+
+        assert!(!irq.irq.masked());
+        irq.mask(0).unwrap();
+        assert!(irq.irq.masked());
+        irq.trigger(0).unwrap();
+        irq.unmask(0).unwrap();
+        assert!(!irq.irq.masked());
+
+        assert!(!irq.get_pending_state(0));
+    }
+}

--- a/src/dragonball/dbs_interrupt/src/userspace/manager.rs
+++ b/src/dragonball/dbs_interrupt/src/userspace/manager.rs
@@ -1,0 +1,382 @@
+// Copyright (c) 2026 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use kvm_ioctls::VmFd;
+
+use std::convert::TryInto;
+use std::sync::{Arc, RwLock};
+
+#[cfg(feature = "split-legacy-irq")]
+use super::legacy_irq::*;
+use super::{
+    ioapic::*, InterruptIndex, InterruptManager, InterruptSourceGroup, InterruptSourceType, Result,
+};
+
+/// Structure to manage interrupt sources for a virtual machine in userspace based on IOAPIC
+/// protocol.
+///
+/// The structure emulates IOAPIC registers, and allows for editing specific IOAPIC entries via
+/// MMIO calls.
+pub struct UserspaceIoapicManager {
+    ioregsel: RwLock<IoRegSel>,
+    ioapicid: RwLock<IoapicId>,
+    // IoapicVer register is read-only
+    ioapicver: IoapicVer,
+    ioapicarb: RwLock<IoapicArb>,
+    #[cfg(feature = "split-legacy-irq")]
+    irqs: Vec<Arc<UserspaceLegacyIrqObj>>,
+}
+
+impl UserspaceIoapicManager {
+    /// Create a new IOAPIC manager instance
+    pub fn create_ioapic_manager(
+        vmfd: Arc<VmFd>,
+        version: u8,
+        nr_redir_entries: InterruptIndex,
+    ) -> Result<Self> {
+        if nr_redir_entries == 0 || nr_redir_entries > IOAPIC_MAX_NR_REDIR_ENTRIES {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        let mut ioapicver = IoapicVer::default();
+        ioapicver.set_version(version);
+        ioapicver.set_entries(nr_redir_entries as u8 - 1);
+
+        #[cfg(feature = "split-legacy-irq")]
+        let irqs = {
+            let mut irqs = Vec::with_capacity(nr_redir_entries as usize);
+            for i in 0..nr_redir_entries {
+                irqs.push(Arc::new(UserspaceLegacyIrqObj::new(i, vmfd.clone())));
+            }
+            irqs
+        };
+
+        Ok(Self {
+            ioregsel: RwLock::new(IoRegSel::default()),
+            ioapicid: RwLock::new(IoapicId::default()),
+            ioapicver,
+            ioapicarb: RwLock::new(IoapicArb::default()),
+            #[cfg(feature = "split-legacy-irq")]
+            irqs,
+        })
+    }
+
+    /// Create a new IOAPIC manager instance with default version and redirection table size
+    pub fn create_default_ioapic_manager(vmfd: Arc<VmFd>) -> Result<Self> {
+        Self::create_ioapic_manager(
+            vmfd,
+            IOAPIC_DEFAULT_VERSION,
+            IOAPIC_DEFAULT_NR_REDIR_ENTRIES,
+        )
+    }
+
+    fn ioregsel(&self) -> u32 {
+        self.ioregsel.read().unwrap().clone().into()
+    }
+
+    fn set_ioregsel(&self, val: u32) -> Result<()> {
+        let val = IoRegSel::from(val);
+        let select = val.register_index();
+        if !(select == IOAPIC_IOAPICID_INDEX
+            || select == IOAPIC_IOAPICVER_INDEX
+            || select == IOAPIC_IOAPICARB_INDEX
+            || (select >= IOAPIC_REDIR_TABLE_START_INDEX
+                && select < IOAPIC_REDIR_TABLE_START_INDEX + 2 * self.nr_redir_entries() as u8))
+        {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        *self.ioregsel.write().unwrap() = val;
+
+        Ok(())
+    }
+
+    fn iowin(&self) -> u32 {
+        match self.ioregsel.read().unwrap().register_index() {
+            IOAPIC_IOAPICID_INDEX => self.ioapicid.read().unwrap().clone().into(),
+            IOAPIC_IOAPICVER_INDEX => self.ioapicver.clone().into(),
+            IOAPIC_IOAPICARB_INDEX => self.ioapicarb.read().unwrap().clone().into(),
+            // We have checked the validity of ioregsel while setting, therefore all values beyond the
+            // special IOAPIC registers above would become a valid redirection entry
+            index => {
+                #[cfg(feature = "split-legacy-irq")]
+                {
+                    let offset = (index - IOAPIC_REDIR_TABLE_START_INDEX) as usize;
+                    let is_low = (offset & 0x1) == 0;
+                    let irq_base = offset >> 1;
+
+                    if is_low {
+                        self.irqs[irq_base].redir_entry_low().into()
+                    } else {
+                        self.irqs[irq_base].redir_entry_high().into()
+                    }
+                }
+                #[cfg(not(feature = "split-legacy-irq"))]
+                0
+            }
+        }
+    }
+
+    fn set_iowin(&self, val: u32) -> Result<()> {
+        match self.ioregsel.read().unwrap().register_index() {
+            IOAPIC_IOAPICID_INDEX => {
+                *self.ioapicid.write().unwrap() = IoapicId::from(val);
+                Ok(())
+            }
+            IOAPIC_IOAPICVER_INDEX => {
+                // IOAPICVER register is read-only
+                Err(std::io::Error::from_raw_os_error(libc::EINVAL))
+            }
+            IOAPIC_IOAPICARB_INDEX => {
+                *self.ioapicarb.write().unwrap() = IoapicArb::from(val);
+                Ok(())
+            }
+            // We have checked the validity of ioregsel while setting, therefore all values beyond the four
+            // special IOAPIC registers above would become a valid redirection entry
+            index => {
+                #[cfg(feature = "split-legacy-irq")]
+                {
+                    let offset = (index - IOAPIC_REDIR_TABLE_START_INDEX) as usize;
+                    let is_low = (offset & 0x1) == 0;
+                    let irq_base = offset >> 1;
+
+                    if is_low {
+                        self.irqs[irq_base].set_redir_entry_low(IoapicRedirEntryLow::from(val));
+                    } else {
+                        self.irqs[irq_base].set_redir_entry_high(IoapicRedirEntryHigh::from(val));
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+
+    fn nr_redir_entries(&self) -> InterruptIndex {
+        self.ioapicver.entries() as InterruptIndex + 1
+    }
+}
+
+impl InterruptManager for UserspaceIoapicManager {
+    fn create_group(
+        &self,
+        ty: InterruptSourceType,
+        base: InterruptIndex,
+        count: u32,
+    ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
+        let group = match ty {
+            #[cfg(feature = "split-legacy-irq")]
+            InterruptSourceType::LegacyIrq => {
+                if count != 1 {
+                    return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+                }
+                if base >= self.nr_redir_entries() {
+                    return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+                }
+                // Irq has already been created while initializing the manager, so we
+                // only return the corresponding entry here.
+                let irq = self.irqs[base as usize].clone();
+                let group: Arc<Box<dyn InterruptSourceGroup>> =
+                    Arc::new(Box::new(UserspaceLegacyIrq::new(irq)));
+                group
+            }
+            _ => {
+                return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+            }
+        };
+
+        Ok(group)
+    }
+
+    fn destroy_group(&self, _group: Arc<Box<dyn InterruptSourceGroup>>) -> Result<()> {
+        Ok(())
+    }
+
+    fn ioapic_read(&self, addr: u64, data: &mut [u8]) -> Result<()> {
+        if data.len() != 4 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        let mut val = 0;
+
+        if addr == IOAPIC_IOREGSEL_BASE as u64 {
+            val = self.ioregsel();
+        } else if addr == IOAPIC_IOWIN_BASE as u64 {
+            val = self.iowin();
+        }
+
+        data.copy_from_slice(&val.to_le_bytes());
+
+        Ok(())
+    }
+
+    fn ioapic_write(&self, addr: u64, data: &[u8]) -> Result<()> {
+        if data.len() != 4 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        // Safe because we have checked that the length of data is 32 bits
+        let val = u32::from_le_bytes(data.try_into().expect("length checked to be 4"));
+
+        if addr == IOAPIC_IOREGSEL_BASE as u64 {
+            self.set_ioregsel(val)?;
+        } else if addr == IOAPIC_IOWIN_BASE as u64 {
+            self.set_iowin(val)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+#[cfg(target_arch = "x86_64")]
+pub(crate) mod test {
+    use super::*;
+    use crate::manager::tests::create_vm_fd;
+    use crate::{InterruptSourceConfig, LegacyIrqSourceConfig};
+    use bilge::prelude::*;
+    use test_utils::skip_if_kvm_unaccessable;
+
+    #[test]
+    fn test_create_userspace_ioapic_manager() {
+        skip_if_kvm_unaccessable!();
+        let vmfd = Arc::new(create_vm_fd());
+
+        assert!(UserspaceIoapicManager::create_ioapic_manager(vmfd.clone(), 0, 0).is_err());
+        assert!(UserspaceIoapicManager::create_ioapic_manager(
+            vmfd.clone(),
+            0,
+            IOAPIC_MAX_NR_REDIR_ENTRIES + 1
+        )
+        .is_err());
+
+        let manager =
+            UserspaceIoapicManager::create_ioapic_manager(vmfd.clone(), IOAPIC_DEFAULT_VERSION, 12)
+                .unwrap();
+        assert_eq!(manager.nr_redir_entries(), 12);
+        assert_eq!(manager.ioregsel.read().unwrap().register_index(), 0);
+        assert_eq!(manager.ioapicid.read().unwrap().id(), 0);
+        assert_eq!(manager.ioapicver.version(), IOAPIC_DEFAULT_VERSION);
+        assert_eq!(manager.ioapicver.entries(), 11);
+        assert_eq!(
+            manager.ioapicarb.read().unwrap().arbitration(),
+            u4::from_u8(0)
+        );
+
+        #[cfg(feature = "split-legacy-irq")]
+        {
+            assert_eq!(manager.irqs.len(), 12);
+            for irq in manager.irqs.iter() {
+                assert_eq!(u32::from(irq.redir_entry_low()), 0);
+                assert_eq!(u32::from(irq.redir_entry_high()), 0);
+            }
+        }
+    }
+
+    #[test]
+    fn test_userspace_ioapic_rw() {
+        skip_if_kvm_unaccessable!();
+        let vmfd = Arc::new(create_vm_fd());
+        let manager = UserspaceIoapicManager::create_default_ioapic_manager(vmfd.clone()).unwrap();
+        let ioapicver = ((IOAPIC_MAX_NR_REDIR_ENTRIES - 1) << 16) + IOAPIC_DEFAULT_VERSION as u32;
+
+        assert_eq!(manager.ioregsel(), 0);
+        assert_eq!(manager.iowin(), 0);
+
+        manager.set_ioregsel(0x01).unwrap();
+        assert_eq!(manager.ioregsel(), 1);
+        assert_eq!(manager.iowin(), ioapicver,);
+
+        manager.set_ioregsel(0x02).unwrap();
+        assert_eq!(manager.iowin(), 0);
+
+        assert!(manager.set_ioregsel(0x04).is_err());
+        assert!(manager.set_ioregsel(0x40).is_err());
+
+        manager.set_ioregsel(0x10).unwrap();
+        assert_eq!(manager.iowin(), 0);
+
+        manager.set_ioregsel(0x00).unwrap();
+        manager.set_iowin(0xffffffff).unwrap();
+        assert_eq!(manager.iowin(), 0xffffffff);
+
+        manager.set_ioregsel(0x01).unwrap();
+        assert!(manager.set_iowin(0xeeeeeeee).is_err());
+        assert_eq!(manager.iowin(), ioapicver);
+
+        manager.set_ioregsel(0x02).unwrap();
+        manager.set_iowin(0xdddddddd).unwrap();
+        assert_eq!(manager.iowin(), 0xdddddddd);
+
+        manager.set_ioregsel(0x12).unwrap();
+        manager.set_iowin(0xcccccccc).unwrap();
+        assert_eq!(manager.iowin(), 0xcccccccc);
+        #[cfg(feature = "split-legacy-irq")]
+        {
+            assert_eq!(u32::from(manager.irqs[1].redir_entry_low()), 0xcccccccc);
+        }
+
+        manager.set_ioregsel(0x15).unwrap();
+        manager.set_iowin(0xbbbbbbbb).unwrap();
+        assert_eq!(manager.iowin(), 0xbbbbbbbb);
+        #[cfg(feature = "split-legacy-irq")]
+        {
+            assert_eq!(u32::from(manager.irqs[2].redir_entry_high()), 0xbbbbbbbb);
+        }
+    }
+
+    #[test]
+    fn test_userspace_interrupt_manager() {
+        skip_if_kvm_unaccessable!();
+        let vmfd = Arc::new(create_vm_fd());
+        let manager = UserspaceIoapicManager::create_default_ioapic_manager(vmfd.clone()).unwrap();
+        manager.initialize().unwrap();
+
+        assert!(manager
+            .create_group(InterruptSourceType::LegacyIrq, 0, 2)
+            .is_err());
+        assert!(manager
+            .create_group(InterruptSourceType::LegacyIrq, 24, 1)
+            .is_err());
+
+        let group = manager
+            .create_group(InterruptSourceType::LegacyIrq, 5, 1)
+            .unwrap();
+        let configs = [InterruptSourceConfig::LegacyIrq(LegacyIrqSourceConfig {})];
+        group.enable(&configs).unwrap();
+        group.mask(0).unwrap();
+        group.trigger(0).unwrap();
+
+        let mut data = [0u8; 3];
+        assert!(manager
+            .ioapic_read(IOAPIC_IOREGSEL_BASE as u64, &mut data)
+            .is_err());
+        assert!(manager
+            .ioapic_write(IOAPIC_IOREGSEL_BASE as u64, &data)
+            .is_err());
+
+        let mut data = 2u32.to_le_bytes();
+        manager
+            .ioapic_write(IOAPIC_IOREGSEL_BASE as u64, &data)
+            .unwrap();
+        data.fill(0);
+        manager
+            .ioapic_read(IOAPIC_IOREGSEL_BASE as u64, &mut data)
+            .unwrap();
+        assert_eq!(u32::from_le_bytes(data.try_into().unwrap()), 2);
+
+        data = 0xffffffffu32.to_le_bytes();
+        manager
+            .ioapic_write(IOAPIC_IOWIN_BASE as u64, &data)
+            .unwrap();
+        data.fill(0);
+        manager
+            .ioapic_read(IOAPIC_IOWIN_BASE as u64, &mut data)
+            .unwrap();
+        assert_eq!(u32::from_le_bytes(data.try_into().unwrap()), 0xffffffff);
+
+        manager.destroy_group(group).unwrap();
+    }
+}

--- a/src/dragonball/dbs_interrupt/src/userspace/mod.rs
+++ b/src/dragonball/dbs_interrupt/src/userspace/mod.rs
@@ -1,0 +1,11 @@
+// Copyright (c) 2026 Ant Group
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+pub mod ioapic;
+#[cfg(feature = "split-legacy-irq")]
+pub mod legacy_irq;
+pub mod manager;
+
+use super::*;

--- a/src/dragonball/dbs_pci/src/lib.rs
+++ b/src/dragonball/dbs_pci/src/lib.rs
@@ -24,7 +24,7 @@
 use std::sync::{Arc, Mutex};
 
 use dbs_device::device_manager::IoManagerContext;
-use dbs_interrupt::KvmIrqManager;
+use dbs_interrupt::InterruptManager;
 
 mod bus;
 pub use bus::PciBus;
@@ -132,7 +132,7 @@ pub trait PciSystemContext: Sync + Send + Clone {
 
     fn get_device_manager_context(&self) -> Self::D;
 
-    fn get_interrupt_manager(&self) -> Arc<KvmIrqManager>;
+    fn get_interrupt_manager(&self) -> Arc<Box<dyn InterruptManager>>;
 }
 
 /// Fill the buffer with all bits set for invalid PCI configuration space access.

--- a/src/dragonball/dbs_pci/src/vfio.rs
+++ b/src/dragonball/dbs_pci/src/vfio.rs
@@ -17,7 +17,7 @@ use dbs_device::resources::{DeviceResources, MsiIrqType, Resource, ResourceConst
 use dbs_device::PioAddress;
 use dbs_device::{DeviceIo, IoAddress};
 use dbs_interrupt::{
-    DeviceInterruptManager, DeviceInterruptMode, InterruptSourceGroup, KvmIrqManager,
+    DeviceInterruptManager, DeviceInterruptMode, InterruptManager, InterruptSourceGroup,
 };
 use kvm_bindings::kvm_userspace_memory_region;
 use kvm_ioctls::VmFd;
@@ -146,7 +146,7 @@ impl VfioMsix {
 
 struct Interrupt {
     vfio_dev: Arc<VfioDevice>,
-    irq_manager: Option<DeviceInterruptManager<Arc<KvmIrqManager>>>,
+    irq_manager: Option<DeviceInterruptManager<Arc<Box<dyn InterruptManager>>>>,
     resources: DeviceResources,
     legacy_enabled: bool,
     // the ability of msi is enabled or not
@@ -181,7 +181,7 @@ impl Interrupt {
         }
     }
 
-    pub(crate) fn initialize(&mut self, irq_mgr: Arc<KvmIrqManager>) -> Result<()> {
+    pub(crate) fn initialize(&mut self, irq_mgr: Arc<Box<dyn InterruptManager>>) -> Result<()> {
         let mut irq_manager = DeviceInterruptManager::new(irq_mgr, &self.resources)
             .map_err(VfioPciError::InterruptManager)?;
 
@@ -474,7 +474,7 @@ impl Interrupt {
         vfio_dev: &Arc<VfioDevice>,
         index: u32,
         count: u32,
-        irq_mgr: &DeviceInterruptManager<Arc<KvmIrqManager>>,
+        irq_mgr: &DeviceInterruptManager<Arc<Box<dyn InterruptManager>>>,
     ) -> Result<Arc<Box<dyn InterruptSourceGroup>>> {
         if let Some(group) = irq_mgr.get_group() {
             if count > group.len() {

--- a/src/dragonball/dbs_pci/src/virtio_pci.rs
+++ b/src/dragonball/dbs_pci/src/virtio_pci.rs
@@ -25,7 +25,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use dbs_address_space::AddressSpace;
 use dbs_device::resources::{DeviceResources, Resource, ResourceConstraint};
 use dbs_device::{DeviceIo, IoAddress};
-use dbs_interrupt::{DeviceInterruptManager, DeviceInterruptMode, KvmIrqManager};
+use dbs_interrupt::{DeviceInterruptManager, DeviceInterruptMode, InterruptManager};
 use kvm_ioctls::{IoEventAddress, NoDatamatch, VmFd};
 use virtio_queue::QueueT;
 use vm_memory::{Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemoryRegion, Le32};
@@ -367,7 +367,7 @@ pub struct VirtioPciDevice<AS: GuestAddressSpace + Clone + 'static, Q: QueueT, R
 
     // MSI-X interrupts.
     msix_state: Mutex<MsixState>,
-    intr_mgr: Mutex<DeviceInterruptManager<Arc<KvmIrqManager>>>,
+    intr_mgr: Mutex<DeviceInterruptManager<Arc<Box<dyn InterruptManager>>>>,
     msix_num: u16,
     // This is the index of MSI-X capability register in the PCI configuration space.
     // Inited when alloc_bars.
@@ -397,7 +397,7 @@ where
         vm_fd: Arc<VmFd>,
         vm_as: AS,
         address_space: AddressSpace,
-        irq_manager: Arc<KvmIrqManager>,
+        irq_manager: Arc<Box<dyn InterruptManager>>,
         device_resource: DeviceResources,
         dev_id: u8,
         device: Box<dyn VirtioDevice<AS, Q, R>>,
@@ -691,7 +691,9 @@ where
         self.msix_state.lock().expect("Poisoned lock of msix_state")
     }
 
-    pub fn intr_mgr(&self) -> MutexGuard<'_, DeviceInterruptManager<Arc<KvmIrqManager>>> {
+    pub fn intr_mgr(
+        &self,
+    ) -> MutexGuard<'_, DeviceInterruptManager<Arc<Box<dyn InterruptManager>>>> {
         // Safe to unwrap() because we don't expect poisoned lock here.
         self.intr_mgr.lock().expect("Poisoned lock of intr_mgr")
     }
@@ -1161,7 +1163,7 @@ pub(crate) mod tests {
     #[cfg(target_arch = "aarch64")]
     use dbs_arch::gic::create_gic;
     use dbs_device::resources::MsiIrqType;
-    use dbs_interrupt::kvm::KvmIrqManager;
+    use dbs_interrupt::{InterruptManager, KvmIrqManager};
     use dbs_utils::epoll_manager::EpollManager;
     use kvm_ioctls::Kvm;
     use test_utils::skip_if_kvm_unaccessable;
@@ -1364,7 +1366,8 @@ pub(crate) mod tests {
         #[cfg(target_arch = "x86_64")]
         vm_fd.create_irq_chip().unwrap();
 
-        let irq_manager = Arc::new(KvmIrqManager::new(vm_fd.clone()));
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            Arc::new(Box::new(KvmIrqManager::new(vm_fd.clone())));
         irq_manager.initialize().unwrap();
 
         let vm_as = Arc::new(GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x1000)]).unwrap());

--- a/src/dragonball/dbs_virtio_devices/Cargo.toml
+++ b/src/dragonball/dbs_virtio_devices/Cargo.toml
@@ -17,6 +17,7 @@ dbs-device = { workspace = true }
 dbs-interrupt = { workspace = true, features = [
     "kvm-legacy-irq",
     "kvm-msi-irq",
+    "split-legacy-irq",
 ] }
 dbs-utils = { workspace = true }
 dbs-address-space = { workspace = true }

--- a/src/dragonball/dbs_virtio_devices/src/lib.rs
+++ b/src/dragonball/dbs_virtio_devices/src/lib.rs
@@ -375,7 +375,7 @@ pub mod tests {
         AddressSpace, AddressSpaceLayout, AddressSpaceRegion, AddressSpaceRegionType,
     };
     use dbs_boot::layout::{GUEST_MEM_END, GUEST_MEM_START, GUEST_PHYS_END};
-    use dbs_interrupt::KvmIrqManager;
+    use dbs_interrupt::{InterruptManager, KvmIrqManager};
     use kvm_ioctls::{Kvm, VmFd};
     use virtio_queue::{QueueSync, QueueT};
     use vm_memory::{

--- a/src/dragonball/dbs_virtio_devices/src/mmio/mmio_state.rs
+++ b/src/dragonball/dbs_virtio_devices/src/mmio/mmio_state.rs
@@ -10,7 +10,9 @@ use std::sync::Arc;
 
 use dbs_address_space::AddressSpace;
 use dbs_device::resources::DeviceResources;
-use dbs_interrupt::{DeviceInterruptManager, DeviceInterruptMode, InterruptIndex, KvmIrqManager};
+use dbs_interrupt::{
+    DeviceInterruptManager, DeviceInterruptMode, InterruptIndex, InterruptManager,
+};
 use kvm_bindings::kvm_userspace_memory_region;
 use kvm_ioctls::{IoEventAddress, NoDatamatch, VmFd};
 use log::{debug, error, info, warn};
@@ -28,7 +30,7 @@ pub struct MmioV2DeviceState<AS: GuestAddressSpace + Clone, Q: QueueT, R: GuestM
     vm_fd: Arc<VmFd>,
     vm_as: AS,
     address_space: AddressSpace,
-    intr_mgr: DeviceInterruptManager<Arc<KvmIrqManager>>,
+    intr_mgr: DeviceInterruptManager<Arc<Box<dyn InterruptManager>>>,
     device_resources: DeviceResources,
     queues: Vec<VirtioQueueConfig<Q>>,
 
@@ -70,7 +72,7 @@ where
         vm_fd: Arc<VmFd>,
         vm_as: AS,
         address_space: AddressSpace,
-        irq_manager: Arc<KvmIrqManager>,
+        irq_manager: Arc<Box<dyn InterruptManager>>,
         device_resources: DeviceResources,
         mmio_base: u64,
         doorbell_enabled: bool,
@@ -605,6 +607,7 @@ where
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use dbs_interrupt::KvmIrqManager;
     use kvm_ioctls::Kvm;
     use test_utils::skip_if_kvm_unaccessable;
     use virtio_queue::QueueSync;
@@ -628,7 +631,8 @@ pub(crate) mod tests {
         let vm_fd = Arc::new(kvm.create_vm().unwrap());
         vm_fd.create_irq_chip().unwrap();
 
-        let irq_manager = Arc::new(KvmIrqManager::new(vm_fd.clone()));
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            Arc::new(Box::new(KvmIrqManager::new(vm_fd.clone())));
         irq_manager.initialize().unwrap();
 
         let device = MmioDevice::new(ctrl_queue_size);

--- a/src/dragonball/dbs_virtio_devices/src/mmio/mmio_v2.rs
+++ b/src/dragonball/dbs_virtio_devices/src/mmio/mmio_v2.rs
@@ -10,7 +10,7 @@ use byteorder::{ByteOrder, LittleEndian};
 use dbs_address_space::AddressSpace;
 use dbs_device::resources::{DeviceResources, Resource};
 use dbs_device::{DeviceIo, IoAddress};
-use dbs_interrupt::{InterruptStatusRegister32, KvmIrqManager};
+use dbs_interrupt::{InterruptManager, InterruptStatusRegister32};
 use kvm_ioctls::VmFd;
 use log::{debug, info, warn};
 use virtio_queue::QueueT;
@@ -62,7 +62,7 @@ where
         vm_fd: Arc<VmFd>,
         vm_as: AS,
         address_space: AddressSpace,
-        irq_manager: Arc<KvmIrqManager>,
+        irq_manager: Arc<Box<dyn InterruptManager>>,
         device: Box<dyn VirtioDevice<AS, Q, R>>,
         resources: DeviceResources,
         mut features: Option<u32>,
@@ -499,6 +499,7 @@ pub(crate) mod tests {
     use byteorder::{ByteOrder, LittleEndian};
     use dbs_device::resources::{MsiIrqType, Resource, ResourceConstraint};
     use dbs_device::{DeviceIo, IoAddress};
+    use dbs_interrupt::KvmIrqManager;
     use dbs_utils::epoll_manager::EpollManager;
     use kvm_bindings::kvm_userspace_memory_region;
     use kvm_ioctls::Kvm;
@@ -679,7 +680,8 @@ pub(crate) mod tests {
         let kvm = Kvm::new().unwrap();
         let vm_fd = Arc::new(kvm.create_vm().unwrap());
         vm_fd.create_irq_chip().unwrap();
-        let irq_manager = Arc::new(KvmIrqManager::new(vm_fd.clone()));
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            Arc::new(Box::new(KvmIrqManager::new(vm_fd.clone())));
         irq_manager.initialize().unwrap();
 
         let features = if doorbell {
@@ -717,7 +719,8 @@ pub(crate) mod tests {
         let kvm = Kvm::new().unwrap();
         let vm_fd = Arc::new(kvm.create_vm().unwrap());
         vm_fd.create_irq_chip().unwrap();
-        let irq_manager = Arc::new(KvmIrqManager::new(vm_fd.clone()));
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            Arc::new(Box::new(KvmIrqManager::new(vm_fd.clone())));
         irq_manager.initialize().unwrap();
         let address_space = create_address_space();
         let ret = MmioV2Device::new(

--- a/src/dragonball/src/api/v1/instance_info.rs
+++ b/src/dragonball/src/api/v1/instance_info.rs
@@ -39,6 +39,16 @@ pub enum AsyncState {
     Failure,
 }
 
+/// Confidential VM type for microvm. Cannot be changed after VMM
+/// is initialized.
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
+pub enum ConfidentialVmType {
+    #[cfg(target_arch = "x86_64")]
+    /// Intel TDX VM
+    TDX,
+}
+
 /// The strongly typed that contains general information about the microVM.
 #[derive(Debug, Deserialize, Serialize)]
 pub struct InstanceInfo {
@@ -58,11 +68,17 @@ pub struct InstanceInfo {
     pub tids: Vec<(u8, u32)>,
     /// Last instance downtime
     pub last_instance_downtime: u64,
+    /// Confidential VM type
+    pub confidential_vm_type: Option<ConfidentialVmType>,
 }
 
 impl InstanceInfo {
     /// create instance info object with given id, version, and platform type
-    pub fn new(id: String, vmm_version: String) -> Self {
+    pub fn new(
+        id: String,
+        vmm_version: String,
+        confidential_vm_type: Option<ConfidentialVmType>,
+    ) -> Self {
         InstanceInfo {
             id,
             state: InstanceState::Uninitialized,
@@ -72,7 +88,14 @@ impl InstanceInfo {
             async_state: AsyncState::Uninitialized,
             tids: Vec::new(),
             last_instance_downtime: 0,
+            confidential_vm_type,
         }
+    }
+
+    /// Whether the microvm requires split irqchip
+    #[cfg(target_arch = "x86_64")]
+    pub fn split_irqchip(&self) -> bool {
+        self.confidential_vm_type == Some(ConfidentialVmType::TDX)
     }
 }
 
@@ -87,6 +110,7 @@ impl Default for InstanceInfo {
             async_state: AsyncState::Uninitialized,
             tids: Vec::new(),
             last_instance_downtime: 0,
+            confidential_vm_type: None,
         }
     }
 }

--- a/src/dragonball/src/api/v1/mod.rs
+++ b/src/dragonball/src/api/v1/mod.rs
@@ -12,7 +12,7 @@ pub use self::boot_source::{BootSourceConfig, BootSourceConfigError, DEFAULT_KER
 
 /// Wrapper over the microVM general information.
 mod instance_info;
-pub use self::instance_info::{InstanceInfo, InstanceState};
+pub use self::instance_info::{ConfidentialVmType, InstanceInfo, InstanceState};
 
 /// Wrapper for configuring the memory and CPU of the microVM.
 mod machine_config;

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -19,7 +19,9 @@ use dbs_device::device_manager::{Error as IoManagerError, IoManager, IoManagerCo
 use dbs_device::resources::DeviceResources;
 use dbs_device::resources::Resource;
 use dbs_device::DeviceIo;
-use dbs_interrupt::KvmIrqManager;
+#[cfg(target_arch = "x86_64")]
+use dbs_interrupt::UserspaceIoapicManager;
+use dbs_interrupt::{InterruptManager, KvmIrqManager};
 use dbs_legacy_devices::ConsoleHandler;
 #[cfg(feature = "dbs-virtio-devices")]
 use dbs_pci::CAPABILITY_BAR_SIZE;
@@ -209,6 +211,10 @@ pub enum DeviceMgrError {
     /// Unsupported pci device type
     #[error("unsupported pci device type")]
     InvalidPciDeviceType,
+    #[cfg(target_arch = "x86_64")]
+    /// Error from Userspace IOAPIC
+    #[error("Userspace IOAPIC error: {0}")]
+    UserspaceIoapicError(#[source] std::io::Error),
 }
 
 /// Specialized version of `std::result::Result` for device manager operations.
@@ -306,7 +312,7 @@ impl IoManagerContext for DeviceManagerContext {
 pub struct DeviceOpContext {
     epoll_mgr: Option<EpollManager>,
     io_context: DeviceManagerContext,
-    irq_manager: Arc<KvmIrqManager>,
+    irq_manager: Arc<Box<dyn InterruptManager>>,
     res_manager: Arc<ResourceManager>,
     vm_fd: Arc<VmFd>,
     vm_as: Option<GuestAddressSpaceImpl>,
@@ -632,7 +638,7 @@ impl DeviceOpContext {
 pub struct DeviceManager {
     io_manager: Arc<ArcSwap<IoManager>>,
     io_lock: Arc<Mutex<()>>,
-    irq_manager: Arc<KvmIrqManager>,
+    irq_manager: Arc<Box<dyn InterruptManager>>,
     res_manager: Arc<ResourceManager>,
     vm_fd: Arc<VmFd>,
     pub(crate) logger: slog::Logger,
@@ -681,7 +687,19 @@ impl DeviceManager {
         logger: &slog::Logger,
         shared_info: Arc<RwLock<InstanceInfo>>,
     ) -> Result<Self> {
-        let irq_manager = Arc::new(KvmIrqManager::new(vm_fd.clone()));
+        #[cfg(not(target_arch = "x86_64"))]
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            Arc::new(Box::new(KvmIrqManager::new(vm_fd.clone())));
+        #[cfg(target_arch = "x86_64")]
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            if shared_info.read().unwrap().split_irqchip() {
+                Arc::new(Box::new(
+                    UserspaceIoapicManager::create_default_ioapic_manager(vm_fd.clone())
+                        .map_err(DeviceMgrError::UserspaceIoapicError)?,
+                ))
+            } else {
+                Arc::new(Box::new(KvmIrqManager::new(vm_fd.clone())))
+            };
         let io_manager = Arc::new(ArcSwap::new(Arc::new(IoManager::new())));
         let io_lock = Arc::new(Mutex::new(()));
         #[cfg(feature = "host-device")]
@@ -744,6 +762,11 @@ impl DeviceManager {
     /// Get the underlying IoManager to dispatch IO read/write requests.
     pub fn io_manager(&self) -> IoManagerCached {
         IoManagerCached::new(self.io_manager.clone())
+    }
+
+    /// Get the irq manager to handle interrupt
+    pub fn irq_manager(&self) -> Arc<Box<dyn InterruptManager>> {
+        self.irq_manager.clone()
     }
 
     /// Create the underline interrupt manager for the device manager.
@@ -1598,9 +1621,11 @@ mod tests {
             let shared_info = Arc::new(RwLock::new(InstanceInfo::new(
                 String::from("dragonball"),
                 String::from("1"),
+                None,
             )));
 
-            let irq_manager = Arc::new(KvmIrqManager::new(vm_fd.clone()));
+            let irq_manager: Arc<Box<dyn InterruptManager>> =
+                Arc::new(Box::new(KvmIrqManager::new(vm_fd.clone())));
             let io_manager = Arc::new(ArcSwap::new(Arc::new(IoManager::new())));
             let io_lock = Arc::new(Mutex::new(()));
 

--- a/src/dragonball/src/device_manager/vfio_dev_mgr/pci_vfio.rs
+++ b/src/dragonball/src/device_manager/vfio_dev_mgr/pci_vfio.rs
@@ -7,7 +7,7 @@ use dbs_boot::layout::{GUEST_MEM_END, GUEST_PHYS_END};
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 use dbs_device::resources::Resource;
 use dbs_device::resources::{DeviceResources, ResourceConstraint};
-use dbs_interrupt::KvmIrqManager;
+use dbs_interrupt::InterruptManager;
 #[cfg(target_arch = "aarch64")]
 use dbs_pci::ECAM_SPACE_LENGTH;
 use dbs_pci::{create_pci_root_bus, PciBus, PciDevice, PciRootDevice, PciSystemContext};
@@ -25,7 +25,7 @@ const PCI_MMIO_DEFAULT_SIZE: u64 = 2048u64 << 30;
 /// PCI pass-through device manager.
 #[derive(Clone)]
 pub struct PciSystemManager {
-    pub irq_manager: Arc<KvmIrqManager>,
+    pub irq_manager: Arc<Box<dyn InterruptManager>>,
     pub io_context: DeviceManagerContext,
     pub pci_root: Arc<PciRootDevice>,
     pub pci_root_bus: Arc<PciBus>,
@@ -34,7 +34,7 @@ pub struct PciSystemManager {
 impl PciSystemManager {
     /// Create a new PCI pass-through device manager.
     pub fn new(
-        irq_manager: Arc<KvmIrqManager>,
+        irq_manager: Arc<Box<dyn InterruptManager>>,
         io_context: DeviceManagerContext,
         res_manager: Arc<ResourceManager>,
     ) -> std::result::Result<Self, DeviceMgrError> {
@@ -176,7 +176,7 @@ impl PciSystemContext for PciSystemManager {
         self.io_context.clone()
     }
 
-    fn get_interrupt_manager(&self) -> Arc<KvmIrqManager> {
+    fn get_interrupt_manager(&self) -> Arc<Box<dyn InterruptManager>> {
         self.irq_manager.clone()
     }
 }

--- a/src/dragonball/src/error.rs
+++ b/src/dragonball/src/error.rs
@@ -223,6 +223,11 @@ pub enum StartMicroVmError {
     /// Cannot build seccomp filters.
     #[error("failure while configuring seccomp filters: {0}")]
     SeccompFilters(#[source] seccompiler::Error),
+
+    #[cfg(target_arch = "x86_64")]
+    /// Cannot enable split irqchip
+    #[error("Failed to enable split irqchip: {0}")]
+    EnableSplitIrqchip(#[source] vmm_sys_util::errno::Error),
 }
 
 /// Errors associated with starting the instance.

--- a/src/dragonball/src/vcpu/vcpu_impl.rs
+++ b/src/dragonball/src/vcpu/vcpu_impl.rs
@@ -15,6 +15,8 @@ use std::sync::mpsc::{Receiver, Sender, TryRecvError};
 use std::sync::{Arc, Barrier};
 use std::thread;
 
+#[cfg(target_arch = "x86_64")]
+use dbs_interrupt::{InterruptManager, IOAPIC_BASE, IOAPIC_SIZE};
 use dbs_utils::metric::IncMetric;
 use dbs_utils::time::TimestampUs;
 use kvm_bindings::{KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN};
@@ -314,6 +316,11 @@ pub struct Vcpu {
     /// Multiprocessor affinity register recorded for aarch64
     #[cfg(target_arch = "aarch64")]
     pub(crate) mpidr: u64,
+
+    // InterruptManager to handle IOAPIC operations for x86_64 CPU when userspace
+    // IOAPIC is used.
+    #[cfg(target_arch = "x86_64")]
+    irq_manager: Arc<Box<dyn InterruptManager>>,
 }
 
 // Using this for easier explicit type-casting to help IDEs interpret the code.
@@ -463,11 +470,27 @@ impl Vcpu {
                         Ok(VcpuEmulation::Handled)
                     }
                     VcpuExit::MmioRead(addr, data) => {
+                        #[cfg(target_arch = "x86_64")]
+                        if addr >= IOAPIC_BASE as u64 && addr < (IOAPIC_BASE + IOAPIC_SIZE) as u64 {
+                            let irq_manager = self.irq_manager.clone();
+                            let _ = irq_manager.ioapic_read(addr, data);
+                            self.metrics.exit_mmio_read.inc();
+                            return Ok(VcpuEmulation::Handled);
+                        }
+
                         let _ = self.io_mgr.mmio_read(addr, data);
                         self.metrics.exit_mmio_read.inc();
                         Ok(VcpuEmulation::Handled)
                     }
                     VcpuExit::MmioWrite(addr, data) => {
+                        #[cfg(target_arch = "x86_64")]
+                        if addr >= IOAPIC_BASE as u64 && addr < (IOAPIC_BASE + IOAPIC_SIZE) as u64 {
+                            let irq_manager = self.irq_manager.clone();
+                            let _ = irq_manager.ioapic_write(addr, data);
+                            self.metrics.exit_mmio_write.inc();
+                            return Ok(VcpuEmulation::Handled);
+                        }
+
                         let _ = self.io_mgr.mmio_write(addr, data);
                         self.metrics.exit_mmio_write.inc();
                         Ok(VcpuEmulation::Handled)
@@ -789,6 +812,8 @@ pub mod tests {
 
     use arc_swap::ArcSwap;
     use dbs_device::device_manager::IoManager;
+    #[cfg(target_arch = "x86_64")]
+    use dbs_interrupt::KvmIrqManager;
     use lazy_static::lazy_static;
     use test_utils::skip_if_kvm_unaccessable;
 
@@ -850,6 +875,8 @@ pub mod tests {
         let vcpu_state_event = EventFd::new(libc::EFD_NONBLOCK).unwrap();
         let (tx, rx) = channel();
         let time_stamp = TimestampUs::default();
+        let irq_manager: Arc<Box<dyn InterruptManager>> =
+            Arc::new(Box::new(KvmIrqManager::new(Arc::new(vm))));
 
         let vcpu = Vcpu::new_x86_64(
             0,
@@ -861,6 +888,7 @@ pub mod tests {
             tx,
             time_stamp,
             false,
+            irq_manager,
         )
         .unwrap();
 

--- a/src/dragonball/src/vcpu/vcpu_manager.rs
+++ b/src/dragonball/src/vcpu/vcpu_manager.rs
@@ -16,6 +16,8 @@ use std::sync::{Arc, Barrier, Mutex, RwLock};
 use std::time::Duration;
 
 use dbs_arch::VpmuFeatureLevel;
+#[cfg(target_arch = "x86_64")]
+use dbs_interrupt::InterruptManager;
 #[cfg(all(feature = "hotplug", feature = "dbs-upcall"))]
 use dbs_upcall::{DevMgrService, UpcallClient};
 use dbs_utils::epoll_manager::{EpollManager, EventOps, EventSet, Events, MutEventSubscriber};
@@ -235,6 +237,9 @@ pub struct VcpuManager {
     // X86 specific fields.
     #[cfg(target_arch = "x86_64")]
     pub(crate) supported_cpuid: kvm_bindings::CpuId,
+
+    #[cfg(target_arch = "x86_64")]
+    irq_manager: Arc<Box<dyn InterruptManager>>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -249,6 +254,7 @@ impl VcpuManager {
         shared_info: Arc<RwLock<InstanceInfo>>,
         io_manager: IoManagerCached,
         epoll_manager: EpollManager,
+        #[cfg(target_arch = "x86_64")] irq_manager: Arc<Box<dyn InterruptManager>>,
     ) -> Result<Arc<Mutex<Self>>> {
         let support_immediate_exit = kvm_context.kvm().check_extension(Cap::ImmediateExit);
         let max_vcpu_count = vm_config_info.max_vcpu_count;
@@ -324,6 +330,8 @@ impl VcpuManager {
             upcall_channel: None,
             #[cfg(target_arch = "x86_64")]
             supported_cpuid,
+            #[cfg(target_arch = "x86_64")]
+            irq_manager,
         }));
 
         let handler = Box::new(VcpuEpollHandler {
@@ -787,6 +795,7 @@ impl VcpuManager {
             self.vcpu_state_sender.clone(),
             request_ts,
             self.support_immediate_exit,
+            self.irq_manager.clone(),
         )
         .map_err(VcpuManagerError::Vcpu)
     }

--- a/src/dragonball/src/vcpu/x86_64.rs
+++ b/src/dragonball/src/vcpu/x86_64.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 use dbs_arch::cpuid::{process_cpuid, VmSpec};
 use dbs_arch::gdt::gdt_entry;
+use dbs_interrupt::InterruptManager;
 use dbs_utils::metric::IncMetric;
 use dbs_utils::time::TimestampUs;
 use kvm_bindings::CpuId;
@@ -53,6 +54,7 @@ impl Vcpu {
         vcpu_state_sender: Sender<VcpuStateEvent>,
         create_ts: TimestampUs,
         support_immediate_exit: bool,
+        irq_manager: Arc<Box<dyn InterruptManager>>,
     ) -> Result<Self> {
         let (event_sender, event_receiver) = channel();
         let (response_sender, response_receiver) = channel();
@@ -72,6 +74,7 @@ impl Vcpu {
             support_immediate_exit,
             metrics: Arc::new(VcpuMetrics::default()),
             cpuid,
+            irq_manager,
         })
     }
 

--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -425,6 +425,8 @@ impl Vm {
             self.shared_info.clone(),
             self.device_manager.io_manager(),
             self.epoll_manager.clone(),
+            #[cfg(target_arch = "x86_64")]
+            self.device_manager.irq_manager(),
         )?;
         self.vcpu_manager = Some(vcpu_manager);
 

--- a/src/dragonball/src/vm/x86_64.rs
+++ b/src/dragonball/src/vm/x86_64.rs
@@ -12,9 +12,13 @@ use std::ops::Deref;
 
 use dbs_address_space::AddressSpace;
 use dbs_boot::{add_e820_entry, bootparam, layout, mptable, BootParamsWrapper, InitrdConfig};
+use dbs_interrupt::IOAPIC_MAX_NR_REDIR_ENTRIES;
 use dbs_utils::epoll_manager::EpollManager;
 use dbs_utils::time::TimestampUs;
-use kvm_bindings::{kvm_irqchip, kvm_pit_config, kvm_pit_state2, KVM_PIT_SPEAKER_DUMMY};
+use kvm_bindings::{
+    kvm_enable_cap, kvm_irqchip, kvm_pit_config, kvm_pit_state2, KVM_CAP_SPLIT_IRQCHIP,
+    KVM_PIT_SPEAKER_DUMMY,
+};
 use linux_loader::cmdline::Cmdline;
 use linux_loader::configurator::{linux::LinuxBootConfigurator, BootConfigurator, BootParams};
 use slog::info;
@@ -264,13 +268,32 @@ impl Vm {
     pub(crate) fn setup_interrupt_controller(
         &mut self,
     ) -> std::result::Result<(), StartMicroVmError> {
-        self.vm_fd
-            .create_irq_chip()
-            .map_err(|e| StartMicroVmError::ConfigureVm(VmError::VmSetup(e)))
+        // In cases of split irqchip, we do not need to invoke KVM ioctl to create an
+        // in-kernel irqchip. We only need to enable the capability of split irqchip,
+        // and manage the interrupts in userspace.
+        if self.split_irqchip() {
+            let mut enable_split_irqchip = kvm_enable_cap {
+                cap: KVM_CAP_SPLIT_IRQCHIP,
+                ..Default::default()
+            };
+            enable_split_irqchip.args[0] = IOAPIC_MAX_NR_REDIR_ENTRIES as u64;
+            self.vm_fd()
+                .enable_cap(&enable_split_irqchip)
+                .map_err(StartMicroVmError::EnableSplitIrqchip)
+        } else {
+            self.vm_fd
+                .create_irq_chip()
+                .map_err(|e| StartMicroVmError::ConfigureVm(VmError::VmSetup(e)))
+        }
     }
 
     /// Creates an in-kernel device model for the PIT.
     pub(crate) fn create_pit(&self) -> std::result::Result<(), StartMicroVmError> {
+        // In-kernel PIT is not allowed for split irqchip
+        if self.split_irqchip() {
+            return Ok(());
+        }
+
         info!(self.logger, "VM: create pit");
         // We need to enable the emulation of a dummy speaker port stub so that writing to port 0x61
         // (i.e. KVM_SPEAKER_BASE_ADDRESS) does not trigger an exit to user space.
@@ -300,5 +323,9 @@ impl Vm {
         self.reset_eventfd = Some(reset_evt);
 
         Ok(())
+    }
+
+    pub(crate) fn split_irqchip(&self) -> bool {
+        self.shared_info.read().unwrap().split_irqchip()
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/vmm_instance.rs
@@ -60,6 +60,7 @@ impl VmmInstance {
         let vmm_shared_info = Arc::new(RwLock::new(InstanceInfo::new(
             String::from(id),
             DRAGONBALL_VERSION.to_string(),
+            None,
         )));
 
         let to_vmm_fd = EventFd::new(libc::EFD_NONBLOCK)


### PR DESCRIPTION
This feature is a prerequisite for dragonball's full support for TDX.

From Linux 6.14, creating a TDX VM requires that split irqchip is enabled. Under this circumstance, device IOAPIC would be managed in userspace, instead of KVM, so a manager is needed to handle MMIO read/write to emulated IOAPIC registers.
Also, with split irqchip, irqfd is no longer able to trigger an interrupt after device IO is completed. Instead, KVM_SIGNAL_MSI is used for interrupt triggering.

Note that only legacy irq with edge-triggered interrupt is implemented here. And split irqchip feature is only enabled when confidential VM type is set to TDX.

Will add unit tests in next commit.