### PR TITLE
ci: k8s: Adjust timeout on free runners

### DIFF
--- a/.github/workflows/run-k8s-tests-on-free-runner.yaml
+++ b/.github/workflows/run-k8s-tests-on-free-runner.yaml
@@ -113,7 +113,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh deploy-kata
 
       - name: Run tests
-        timeout-minutes: 60
+        timeout-minutes: 75
         run: bash tests/integration/kubernetes/gha-run.sh run-tests
 
       - name: Report tests


### PR DESCRIPTION
I've seen several cases of the CLH tests just being killed due to the 60 minutes timeout. Let's bump it to 75 and see how it goes.