### PR TITLE
tests: make k8s-block-volume more robust

### DIFF
--- a/tests/integration/kubernetes/k8s-block-volume.bats
+++ b/tests/integration/kubernetes/k8s-block-volume.bats
@@ -20,23 +20,22 @@ setup() {
 	volume_claim="block-loop-pvc"
 	ctr_dev_path="/dev/xda"
 	vol_capacity="500M"
+}
 
+@test "Block Storage Support" {
 	# Create Loop Device
 	tmp_disk_image=$(exec_host "$node" mktemp --tmpdir disk.XXXXXX.img)
 	exec_host "$node" truncate "$tmp_disk_image" --size "$vol_capacity"
 	loop_dev=$(exec_host "$node" sudo losetup -f)
 	exec_host "$node" sudo losetup "$loop_dev" "$tmp_disk_image"
-}
 
-@test "Block Storage Support" {
 	# Create Storage Class
 	kubectl create -f volume/local-storage.yaml
 
 	# Create Persistent Volume
 	tmp_pv_yaml=$(mktemp --tmpdir block_persistent_vol.XXXXX.yaml)
 	sed -e "s|LOOP_DEVICE|${loop_dev}|" volume/block-loop-pv.yaml > "$tmp_pv_yaml"
-    node_name="$(kubectl get node -o name)"
-	sed -i "s|HOSTNAME|${node_name##node/}|" "$tmp_pv_yaml"
+	sed -i "s|HOSTNAME|${node}|" "$tmp_pv_yaml"
 	sed -i "s|CAPACITY|${vol_capacity}|" "$tmp_pv_yaml"
 	kubectl create -f "$tmp_pv_yaml"
 	cmd="kubectl get pv/${volume_name} | grep Available"


### PR DESCRIPTION
* Put the loop device creation code in the test itself, so that we get proper logs if that part fails (following other tests).
* Reuse the $node variable to fix the test on multi-node clusters.