### PR TITLE
tests: deploy k8s to persist

### DIFF
--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -413,17 +413,42 @@ function install_system_dependencies() {
 }
 
 function load_k8s_needed_modules() {
+	# Load now and on every boot (kube CNI / overlay).
+	sudo tee /etc/modules-load.d/k8s.conf >/dev/null <<'EOF'
+overlay
+br_netfilter
+EOF
 	sudo modprobe overlay
 	sudo modprobe br_netfilter
 }
 
 function set_k8s_network_parameters() {
-	sudo sysctl -w net.bridge.bridge-nf-call-iptables=1
-	sudo sysctl -w net.ipv4.ip_forward=1
-	sudo sysctl -w net.bridge.bridge-nf-call-ip6tables=1
+	# Apply now and persist across reboots (kubelet requires these).
+	sudo tee /etc/sysctl.d/99-k8s.conf >/dev/null <<'EOF'
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
+net.bridge.bridge-nf-call-ip6tables = 1
+EOF
+	sudo sysctl -p /etc/sysctl.d/99-k8s.conf
 }
 
 function disable_swap() {
+	# kubelet fails when swap is on; turn it off now and after reboot.
+	sudo swapoff -a
+	if [[ -f /etc/fstab ]]; then
+		# Keep a single restore point the first time we edit (e.g. for local runs).
+		if [[ ! -f /etc/fstab.k8s.before-kata ]]; then
+			sudo cp -a /etc/fstab /etc/fstab.k8s.before-kata
+		fi
+		# Comment swap lines only if not already commented (safe to re-run).
+		sudo sed -i '/^[[:space:]]*#/!{/[[:space:]]swap[[:space:]]/s/^/#/;}' /etc/fstab
+	fi
+	# Swap may be enabled only via systemd (e.g. zram), not listed in fstab.
+	local _u
+	while read -r _u; do
+		[[ -z "${_u}" || "${_u}" == swap.target ]] && continue
+		sudo systemctl disable --now "${_u}" 2>/dev/null || true
+	done < <(systemctl list-unit-files --type swap --state enabled --no-legend 2>/dev/null | awk '{print $1}' || true)
 	sudo swapoff -a
 }
 
@@ -470,6 +495,8 @@ runtimeRequestTimeout: "600s"
 EOF
 	sudo kubeadm init --config "${kubeadm_config}"
 	rm -f "${kubeadm_config}"
+	# kubeadm usually enables kubelet; ensure it stays enabled after reboot.
+	sudo systemctl enable kubelet
 	mkdir -p $HOME/.kube
 	sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 	sudo chown $(id -u):$(id -g) $HOME/.kube/config
@@ -510,7 +537,9 @@ function deploy_vanilla_k8s() {
 			;;
 		*) die "${container_engine} is not a container engine supported by this script" ;;
 	esac
-	sudo systemctl daemon-reload && sudo systemctl restart "${container_engine}"
+	sudo systemctl daemon-reload
+	sudo systemctl enable "${container_engine}"
+	sudo systemctl restart "${container_engine}"
 	local max_retries=5 retry_wait_sec=180 attempt=1
 	while true; do
 		local errexit_set=0

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -452,6 +452,37 @@ function disable_swap() {
 	sudo swapoff -a
 }
 
+# Optional containerd snapshotter requirements on the host (packages, modules, disk).
+function setup_snapshotter_host() {
+	[[ -z "${SNAPSHOTTER:-}" ]] && return 0
+
+	echo "Host snapshotter setup: SNAPSHOTTER='${SNAPSHOTTER}'"
+	case "${SNAPSHOTTER}" in
+		erofs)
+			echo "Setting up host for erofs snapshotter (packages, erofs module, fsverity)"
+			sudo apt-get update
+			sudo apt-get -y install erofs-utils fsverity
+			sudo tee /etc/modules-load.d/erofs.conf >/dev/null <<'EOF'
+erofs
+EOF
+			sudo modprobe erofs
+			# tune2fs -O verity applies only to ext4; root may be xfs, btrfs, etc. on local machines.
+			local root_src root_fs
+			root_src="$(findmnt -v -n -o SOURCE /)"
+			root_fs="$(findmnt -v -n -o FSTYPE /)"
+			if [[ "${root_fs}" == ext4 ]]; then
+				sudo tune2fs -O verity "${root_src}"
+			elif [[ "${ALLOW_UNSUPPORTED_EROFS_HOST:-false}" == "true" ]]; then
+				>&2 echo "WARN: skipping tune2fs -O verity: root is ${root_fs} (${root_src}), not ext4. Continuing only because ALLOW_UNSUPPORTED_EROFS_HOST=true; erofs/fsverity may fail later on this host."
+			else
+				>&2 echo "ERROR: SNAPSHOTTER=erofs requires fsverity support to be enabled on an ext4 root filesystem, but / is ${root_fs} (${root_src}) so 'tune2fs -O verity' cannot be applied. Set ALLOW_UNSUPPORTED_EROFS_HOST=true only for local development if you intentionally want to continue without this prerequisite."
+				exit 1
+			fi
+			;;
+		*) ;;
+	esac
+}
+
 # Always deploys the latest k8s version
 function do_deploy_k8s() {
 	# Add the pkgs.k8s.io repo
@@ -580,23 +611,7 @@ function deploy_k8s() {
 		rke2) deploy_rke2 ;;
 		microk8s) deploy_microk8s ;;
 		vanilla)
-			if [[ "${SNAPSHOTTER:-}" == "erofs" ]]; then
-				# Install erofs specific dependencies
-				sudo apt-get update
-				sudo apt-get -y install erofs-utils fsverity
-
-				# Load the erofs module
-				sudo modprobe erofs
-
-				# Ensure fsverity is enabled on the disk, otherwise
-				# fsverity won't work on the erofs-snapshotter side.
-				#
-				# Get the root device to enable fsverity on the disk.
-				root_device="$(findmnt -v -n -o SOURCE /)"
-				# This command is not destructive, at all, and that's
-				# the way we should enable verity support on a live disk.
-				sudo tune2fs -O verity "${root_device}"
-			fi
+			setup_snapshotter_host
 			deploy_vanilla_k8s ${CONTAINER_ENGINE} ${CONTAINER_ENGINE_VERSION}
 			;;
 		*) >&2 echo "${KUBERNETES} flavour is not supported"; exit 2 ;;


### PR DESCRIPTION
This doesn't have any affect on upstream, but it'll make the life easier of those running those scripts locally.