### PR TITLE
ci: increase stale issues workflow frequency

### DIFF
--- a/.github/workflows/stale_issues.yaml
+++ b/.github/workflows/stale_issues.yaml
@@ -1,7 +1,10 @@
 name: 'Stale issues with activity before a fixed date'
 on:
   schedule:
-    - cron: '0 0 * * *'
+    # Weekdays (Mon-Fri): Run every 4 hours
+    - cron: '0 0,4,8,12,16,20 * * 1-5'
+    # Weekends (Sat-Sun): Run every hour
+    - cron: '0 * * * 0,6'
   workflow_dispatch:
     inputs:
       date:


### PR DESCRIPTION
Update the stale issues workflow to run more frequently:
- Weekdays: Every 4 hours (6x per day) at 00:00, 06:00, 12:00, 18:00 UTC
- Weekends: Every hour (24x per day)

Previously ran once daily at midnight UTC. This change reduces the time it will take for us to get through our backlog, particularly increasing the runs at the weekend, when we should have less other CI running, which it could impact due to GH API rate limiting.

Assisted-by: IBM Bob