### PR TITLE
rootfs: Suppress condition check failure errors in cbl-mariner/config.sh

### DIFF
--- a/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
@@ -11,6 +11,6 @@ OS_VERSION=${OS_VERSION:-3.0}
 LIBC="gnu"
 PACKAGES="kata-packages-uvm"
 # shellcheck disable=SC2154
-[[ "${AGENT_INIT}" = no ]] && PACKAGES+=" systemd"
+if [[ "${AGENT_INIT}" = "no" ]]; then PACKAGES+=" systemd"; fi
 # shellcheck disable=SC2154
-[[ "${SECCOMP}" = yes ]] && PACKAGES+=" libseccomp"
+if [[ "${SECCOMP}" = "yes" ]]; then PACKAGES+=" libseccomp"; fi


### PR DESCRIPTION
When building the RootFS for `cbl-mariner` distro with `SECCOMP=no`, the `rootfs.sh` script fails trying to source `cbl-mariner/config.sh`.

```bash
[ ~/kata-containers/tools/osbuilder/rootfs-builder ]$ script -fec 'sudo -E EXTRA_PKGS="bash vim net-tools" USE_DOCKER=true SECCOMP=no ./rootfs.sh "${distro}"'
Script started, output log file is 'typescript'.
Failed at 431: source "${rootfs_config}"
Script done.
```

This is because the `cbl-mariner/config.sh` script contains the following as its last command
```bash
[ "$SECCOMP" = yes ] && PACKAGES+=" libseccomp"
```

The condition check fails, and the command returns exit code `1`. Since that is the last command of the script, it becomes the return value of the source script. This causes failure of the parent `rootfs.sh` script.

This PR adds `|| true` clause to each such line in the `cbl-mariner/config.sh` script to ensure that the `source` command always succeeds, no matter what the env vars are.