### PR TITLE
ci: try to make it less unreliable

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -101,6 +101,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
           KBUILD_SIGN_PIN: ${{ contains(matrix.asset, 'nvidia') && secrets.KBUILD_SIGN_PIN || '' }}
@@ -212,6 +213,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
           KBUILD_SIGN_PIN: ${{ contains(matrix.asset, 'nvidia') && secrets.KBUILD_SIGN_PIN || '' }}
@@ -306,6 +308,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
           MEASURED_ROOTFS: yes
@@ -417,6 +420,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -89,6 +89,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
           KBUILD_SIGN_PIN: ${{ contains(matrix.asset, 'nvidia') && secrets.KBUILD_SIGN_PIN || '' }}
@@ -195,6 +196,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
           KBUILD_SIGN_PIN: ${{ contains(matrix.asset, 'nvidia') && secrets.KBUILD_SIGN_PIN || '' }}
@@ -286,6 +288,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -76,6 +76,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 
@@ -142,6 +143,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 
@@ -217,6 +219,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 

--- a/.github/workflows/build-kata-static-tarball-riscv64.yaml
+++ b/.github/workflows/build-kata-static-tarball-riscv64.yaml
@@ -63,6 +63,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -84,6 +84,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 
@@ -177,6 +178,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 
@@ -228,6 +230,7 @@ jobs:
           sudo chown -R "$(id -u)":"$(id -g)" "kata-build"
         env:
           HKD_PATH: "host-key-document"
+          GH_TOKEN: ${{ github.token }}
 
       - name: store-artifact boot-image-se
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -304,6 +307,7 @@ jobs:
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
           ARTEFACT_REGISTRY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
           MEASURED_ROOTFS: no

--- a/ci/install_yq.sh
+++ b/ci/install_yq.sh
@@ -107,7 +107,12 @@ function install_yq() {
 
 	## NOTE: ${var,,} => gives lowercase value of var
 	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos}_${goarch}"
-	${precmd} curl -o "${yq_path}" -LSsf "${yq_url}" || die "Download ${yq_url} failed"
+	local gh_auth_header=()
+	local _gh_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+	if [[ -n "${_gh_token}" ]] && [[ "${yq_url}" =~ ^https://github\.com/ ]]; then
+		gh_auth_header=(-H "Authorization: Bearer ${_gh_token}")
+	fi
+	${precmd} curl "${gh_auth_header[@]}" -o "${yq_path}" -LSsf "${yq_url}" || die "Download ${yq_url} failed"
 	${precmd} chmod +x "${yq_path}"
 
 	if ! command -v "${yq_path}" >/dev/null; then

--- a/tools/packaging/.gitignore
+++ b/tools/packaging/.gitignore
@@ -15,3 +15,7 @@ sha256sums.asc
 stage/
 typescript
 kata-linux-*
+
+# Ephemeral copies for docker build (source: docker/apt-ci-tune.sh)
+static-build/**/apt-ci-tune.sh
+kata-debug/apt-ci-tune.sh

--- a/tools/packaging/docker/apt-ci-tune.sh
+++ b/tools/packaging/docker/apt-ci-tune.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Kata Containers contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Harden APT for CI: retries and timeouts apply on all architectures. On GitHub
+# Actions, amd64 images only: rewrite archive.ubuntu.com and security.ubuntu.com
+# to azure.archive.ubuntu.com (typical x86_64 GitHub-hosted runners). Other
+# arches and ports.ubuntu.com URLs are left unchanged.
+#
+# Usage:
+#   apt-ci-tune.sh
+#       Default: write apt CI config and optional Azure mirror rewrite (amd64 only).
+#   apt-ci-tune.sh --mirrors-rewrite
+#       Rewrite mirrors only (after new .list lines; amd64 only).
+
+set -euo pipefail
+
+write_apt_ci_conf() {
+	printf '%s\n' \
+		'Acquire::Retries "5";' \
+		'Acquire::http::Timeout "120";' \
+		'Acquire::https::Timeout "120";' \
+		> /etc/apt/apt.conf.d/99kata-ci
+}
+
+# Debian architecture for this image (dpkg is present in Ubuntu base images).
+kata_deb_arch() {
+	local deb_arch
+	if deb_arch=$(dpkg --print-architecture 2>/dev/null) && [[ -n "${deb_arch}" ]]; then
+		echo "${deb_arch}"
+		return
+	fi
+	case "$(uname -m)" in
+		x86_64) echo amd64 ;;
+		i686 | i586) echo i386 ;;
+		aarch64) echo arm64 ;;
+		armv7l) echo armhf ;;
+		ppc64le | powerpc64le) echo ppc64el ;;
+		riscv64) echo riscv64 ;;
+		s390x) echo s390x ;;
+		*) echo amd64 ;;
+	esac
+}
+
+# Azure CDN for archive/security on amd64 GHA only.
+rewrite_ubuntu_mirrors_for_gha() {
+	if [[ "${GITHUB_ACTIONS:-false}" != "true" ]]; then
+		return 0
+	fi
+	if [[ "$(kata_deb_arch)" != "amd64" ]]; then
+		return 0
+	fi
+
+	local azure_main="azure.archive.ubuntu.com/ubuntu"
+	local mirrors=(
+		"archive.ubuntu.com/ubuntu:${azure_main}"
+		"security.ubuntu.com/ubuntu:${azure_main}"
+	)
+	local sed_args=() m old new
+
+	for m in "${mirrors[@]}"; do
+		old="${m%%:*}"
+		new="${m#*:}"
+		sed_args+=(-e "s|http://${old}|http://${new}|g")
+		sed_args+=(-e "s|https://${old}|https://${new}|g")
+	done
+
+	find /etc/apt -type f \( -name '*.list' -o -name '*.sources' \) \
+		-exec sed -i "${sed_args[@]}" {} + 2>/dev/null || true
+}
+
+case "${1:-}" in
+	--mirrors-rewrite)
+		rewrite_ubuntu_mirrors_for_gha
+		;;
+	"")
+		write_apt_ci_conf
+		rewrite_ubuntu_mirrors_for_gha
+		;;
+	*)
+		echo "usage: ${0##*/} [--mirrors-rewrite]" >&2
+		exit 1
+		;;
+esac

--- a/tools/packaging/kata-debug/Dockerfile
+++ b/tools/packaging/kata-debug/Dockerfile
@@ -5,12 +5,17 @@
 
 FROM ubuntu:22.04
 
+ARG GITHUB_ACTIONS=false
+
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
+
 COPY debug.sh /usr/bin/debug.sh
 
 RUN \
 apt-get update && \
 apt-get install -y --no-install-recommends tree && \
 apt-get clean && \
-rm -rf /var/lib/apt/lists/
+rm -rf /var/lib/apt/lists/*
 
 CMD ["/usr/bin/debug.sh"]

--- a/tools/packaging/kata-debug/kata-debug-build-and-upload-payload.sh
+++ b/tools/packaging/kata-debug/kata-debug-build-and-upload-payload.sh
@@ -22,8 +22,15 @@ IMAGE_TAG="${REGISTRY}:$(git rev-parse HEAD)-${arch}"
 
 pushd ${KATA_DEBUG_DIR}
 
+cp "${KATA_DEBUG_DIR}/../docker/apt-ci-tune.sh" "${KATA_DEBUG_DIR}/apt-ci-tune.sh"
+
+docker_gha=()
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+	docker_gha=(--build-arg "GITHUB_ACTIONS=true")
+fi
+
 echo "Building the image"
-docker build --tag ${IMAGE_TAG} .
+docker build "${docker_gha[@]}" --tag ${IMAGE_TAG} .
 
 echo "Pushing the image to the registry"
 docker push ${IMAGE_TAG}
@@ -33,7 +40,7 @@ if [ -n "${TAG}" ]; then
 
 	echo "Building the ${ADDITIONAL_TAG} image"
 
-	docker build --tag ${ADDITIONAL_TAG} .
+	docker build "${docker_gha[@]}" --tag ${ADDITIONAL_TAG} .
 
 	echo "Pushing the image ${ADDITIONAL_TAG} to the registry"
 	docker push ${ADDITIONAL_TAG}

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -27,12 +27,16 @@ FROM ubuntu:22.04 AS rust-builder
 
 # Default to Rust 1.90.0
 ARG RUST_TOOLCHAIN=1.90.0
+ARG GITHUB_ACTIONS=false
 ENV DEBIAN_FRONTEND=noninteractive
 ENV RUSTUP_HOME="/opt/rustup"
 ENV CARGO_HOME="/opt/cargo"
 ENV PATH="/opt/cargo/bin/:${PATH}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY tools/packaging/docker/apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
 
 RUN \
 	mkdir ${RUSTUP_HOME} ${CARGO_HOME} && \
@@ -46,7 +50,7 @@ RUN \
 		gcc \
 		libc6-dev \
 		musl-tools && \
-	apt-get clean && rm -rf /var/lib/apt/lists/ && \
+	apt-get clean && rm -rf /var/lib/apt/lists/* && \
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
 	rustup component add rustfmt clippy
 
@@ -140,14 +144,18 @@ RUN \
 FROM debian:trixie-slim AS runtime-assembler
 
 ARG DESTINATION=/opt/kata-artifacts
+ARG GITHUB_ACTIONS=false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY tools/packaging/docker/apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
 
 RUN \
 	apt-get update && \
 	apt-get --no-install-recommends -y install \
 		util-linux && \
-	apt-get clean && rm -rf /var/lib/apt/lists/
+	apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Copy the built binary to analyze its dependencies
 COPY --from=rust-builder /kata-deploy/bin/kata-deploy /tmp/kata-deploy

--- a/tools/packaging/kata-deploy/local-build/.gitignore
+++ b/tools/packaging/kata-deploy/local-build/.gitignore
@@ -1,2 +1,3 @@
 build/
 dockerbuild/install_yq.sh
+dockerbuild/apt-ci-tune.sh

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -8,6 +8,9 @@ ENV INSTALL_IN_GOPATH=false
 # Required for libxml2-dev
 ENV TZ=Etc/UTC
 ARG ARCH
+# Optional: authenticated GitHub release downloads. Passed as ARG (not BuildKit secrets)
+# so a plain `docker build` works; the value may appear in image build history/cache metadata.
+ARG GH_TOKEN=
 
 COPY install_yq.sh /usr/bin/install_yq.sh
 COPY install_oras.sh /usr/bin/install_oras.sh

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/Dockerfile
@@ -8,17 +8,27 @@ ENV INSTALL_IN_GOPATH=false
 # Required for libxml2-dev
 ENV TZ=Etc/UTC
 ARG ARCH
+ARG GITHUB_ACTIONS=false
 # Optional: authenticated GitHub release downloads. Passed as ARG (not BuildKit secrets)
 # so a plain `docker build` works; the value may appear in image build history/cache metadata.
 ARG GH_TOKEN=
 
 COPY install_yq.sh /usr/bin/install_yq.sh
 COPY install_oras.sh /usr/bin/install_oras.sh
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Install yq, oras, and docker
-RUN apt-get update && \
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
+
+# Install yq, oras, and docker (retry apt-get update for transient mirror/index mismatches on CI).
+RUN set -eux; \
+    for i in 1 2 3; do \
+        apt-get update && break; \
+        echo "apt-get update failed, retry ${i}/3" >&2; \
+        [ "${i}" -eq 3 ] && exit 1; \
+        sleep 15; \
+    done; \
     apt-get install -y --no-install-recommends \
         ca-certificates \
         docker.io \
@@ -27,7 +37,7 @@ RUN apt-get update && \
         git \
         wget \
         sudo && \
-    apt-get clean && rm -rf /var/lib/apt/lists/ && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     install_yq.sh && \
     install_oras.sh
 
@@ -51,7 +61,13 @@ RUN if [ "${ARCH}" != "$(uname -m)" ] && [ "${ARCH}" == "s390x" ]; then sed -i '
     echo "deb [arch=s390x] http://ports.ubuntu.com/ jammy-updates main multiverse universe" >> /etc/apt/sources.list; fi
 
 #FIXME: gcc is required as agent is build out of a container build.
-RUN apt-get update && \
+RUN set -eux; \
+    for i in 1 2 3; do \
+        apt-get update && break; \
+        echo "apt-get update failed, retry ${i}/3" >&2; \
+        [ "${i}" -eq 3 ] && exit 1; \
+        sleep 15; \
+    done; \
     apt-get install --no-install-recommends -y \
     build-essential \
     cpio \
@@ -78,7 +94,7 @@ RUN apt-get update && \
         libglib2.0-0:s390x \
         libglib2.0-dev:s390x; \
     elif uname -m | grep -Eq 's390x'; then apt-get install -y s390-tools; fi && \
-    apt-get clean && rm -rf /var/lib/apt/lists
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 RUN if [ "${ARCH}" != "$(uname -m)" ] && [ "${ARCH}" == "s390x" ]; then \
         git clone -b v2.25.0 https://github.com/ibm-s390-linux/s390-tools.git && cd s390-tools && \

--- a/tools/packaging/kata-deploy/local-build/dockerbuild/install_oras.sh
+++ b/tools/packaging/kata-deploy/local-build/dockerbuild/install_oras.sh
@@ -35,9 +35,15 @@ if [ "${arch}" = "aarch64" ]; then
 	arch="arm64"
 fi
 oras_tarball="oras_${oras_required_version#v}_linux_${arch}.tar.gz"
+oras_url="https://github.com/oras-project/oras/releases/download/${oras_required_version}/${oras_tarball}"
 
 echo "Downloading ORAS ${oras_required_version}"
-curl -OL https://github.com/oras-project/oras/releases/download/${oras_required_version}/${oras_tarball}
+curl_opts=(-fSL -O)
+_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+if [[ -n "${_token}" ]]; then
+	curl_opts+=(-H "Authorization: Bearer ${_token}")
+fi
+curl "${curl_opts[@]}" "${oras_url}"
 
 echo "Installing ORAS to ${install_dest}"
 sudo mkdir -p "${install_dest}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -69,6 +69,15 @@ if [ ! -d "$HOME/.docker" ]; then
 fi
 
 "${script_dir}"/kata-deploy-copy-yq-installer.sh
+
+: "${GH_TOKEN:=${GITHUB_TOKEN:-}}"
+
+# GH_TOKEN as build-arg (not BuildKit): keeps plain `docker build` working; value may appear in image history.
+docker_build_gh_token=()
+if [ -n "${GH_TOKEN}" ]; then
+	docker_build_gh_token=(--build-arg "GH_TOKEN=${GH_TOKEN}")
+fi
+
 docker build -q -t build-kata-deploy \
 	--build-arg IMG_USER="${USER}" \
 	--build-arg UID=${uid} \
@@ -77,6 +86,7 @@ docker build -q -t build-kata-deploy \
 	--build-arg https_proxy="${https_proxy}" \
 	--build-arg HOST_DOCKER_GID=${docker_gid} \
 	--build-arg ARCH="${ARCH}" \
+	"${docker_build_gh_token[@]}" \
 	"${script_dir}/dockerbuild/"
 
 ARTEFACT_REGISTRY="${ARTEFACT_REGISTRY:-}"
@@ -162,6 +172,7 @@ docker run \
 	--env CROSS_BUILD="${CROSS_BUILD}" \
 	--env TARGET_ARCH="${TARGET_ARCH}" \
 	--env ARCH="${ARCH}" \
+	--env GH_TOKEN="${GH_TOKEN:-}" \
 	--rm \
 	-w ${script_dir} \
 	build-kata-deploy "${kata_deploy_create}" "$@"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -72,6 +72,11 @@ fi
 
 : "${GH_TOKEN:=${GITHUB_TOKEN:-}}"
 
+docker_build_gha=()
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+	docker_build_gha=(--build-arg "GITHUB_ACTIONS=true")
+fi
+
 # GH_TOKEN as build-arg (not BuildKit): keeps plain `docker build` working; value may appear in image history.
 docker_build_gh_token=()
 if [ -n "${GH_TOKEN}" ]; then
@@ -86,6 +91,7 @@ docker build -q -t build-kata-deploy \
 	--build-arg https_proxy="${https_proxy}" \
 	--build-arg HOST_DOCKER_GID=${docker_gid} \
 	--build-arg ARCH="${ARCH}" \
+	"${docker_build_gha[@]}" \
 	"${docker_build_gh_token[@]}" \
 	"${script_dir}/dockerbuild/"
 
@@ -130,6 +136,7 @@ docker run \
 	-v $HOME/.docker:/root/.docker \
 	-v /var/run/docker.sock:/var/run/docker.sock \
 	-v "${kata_dir}:${kata_dir}" \
+	--env GITHUB_ACTIONS="${GITHUB_ACTIONS:-false}" \
 	--env USER=${USER} \
 	--env ARTEFACT_REGISTRY="${ARTEFACT_REGISTRY}" \
 	--env ARTEFACT_REPOSITORY="${ARTEFACT_REPOSITORY}" \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -50,9 +50,15 @@ IMAGE_TAG="${REGISTRY}:kata-containers-$(git -C "${REPO_ROOT}" rev-parse HEAD)-$
 
 DOCKERFILE="${REPO_ROOT}/tools/packaging/kata-deploy/Dockerfile"
 
+gha_bargs=()
+if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+	gha_bargs=(--build-arg "GITHUB_ACTIONS=true")
+fi
+
 echo "Building the image"
 docker buildx build --platform "${PLATFORM}" --provenance false --sbom false \
 	-f "${DOCKERFILE}" \
+	"${gha_bargs[@]}" \
 	--tag "${IMAGE_TAG}" --push .
 
 if [ -n "${TAG}" ]; then
@@ -61,6 +67,7 @@ if [ -n "${TAG}" ]; then
 	echo "Building the ${ADDITIONAL_TAG} image"
 	docker buildx build --platform "${PLATFORM}" --provenance false --sbom false \
 		-f "${DOCKERFILE}" \
+		"${gha_bargs[@]}" \
 		--tag "${ADDITIONAL_TAG}" --push .
 fi
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-copy-yq-installer.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-copy-yq-installer.sh
@@ -15,3 +15,12 @@ script_dir=$(dirname "$(readlink -f "$0")")
 install_yq_script_path="${script_dir}/../../../../ci/install_yq.sh"
 
 cp "${install_yq_script_path}" "${script_dir}/dockerbuild/install_yq.sh"
+
+# tools/packaging (not kata-deploy/docker): local-build -> kata-deploy -> packaging
+packaging_dir="$(cd "${script_dir}/../.." && pwd)"
+apt_ci_tune_src="${packaging_dir}/docker/apt-ci-tune.sh"
+[[ -f "${apt_ci_tune_src}" ]] || {
+	echo >&2 "ERROR: missing ${apt_ci_tune_src}"
+	exit 1
+}
+cp "${apt_ci_tune_src}" "${script_dir}/dockerbuild/apt-ci-tune.sh"

--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -56,6 +56,30 @@ warn() {
 	echo >&2 "WARN: $*"
 }
 
+# Faster Ubuntu mirrors on GitHub-hosted runners; pair with ARG GITHUB_ACTIONS in Dockerfiles.
+# Usage: gha=(); packaging_github_actions_docker_append gha; docker build "${gha[@]}" ...
+# Uses eval instead of namerefs so Bash 3.2 (e.g. macOS /bin/bash) callers do not break.
+packaging_github_actions_docker_append() {
+	local dest_name="${1:?destination array name required}"
+	[[ "${dest_name}" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || die "invalid destination array name: ${dest_name}"
+	if [ "${GITHUB_ACTIONS:-}" = "true" ]; then
+		eval "${dest_name}+=(--build-arg \"GITHUB_ACTIONS=true\")"
+	fi
+}
+
+# Copy docker/apt-ci-tune.sh into a docker build context directory before building.
+packaging_copy_apt_ci_tune_to() {
+	local src dest
+	src="${this_script_dir}/../docker/apt-ci-tune.sh"
+	[[ -f "${src}" ]] || die "apt-ci-tune source missing: ${src}"
+	dest=$(readlink -f "${1}") || die "failed to resolve destination directory: ${1}"
+	[[ -d "${dest}" ]] || die "destination is not an existing directory: ${1}"
+
+	if [[ ! -f "${dest}/apt-ci-tune.sh" ]] || ! cmp -s "${src}" "${dest}/apt-ci-tune.sh"; then
+		cp "${src}" "${dest}/apt-ci-tune.sh"
+	fi
+}
+
 get_repo_hash() {
 	local repo_dir=${1:-}
 	[ -d "${repo_dir}" ] || die "${repo_dir} is not a directory"

--- a/tools/packaging/static-build/agent/Dockerfile
+++ b/tools/packaging/static-build/agent/Dockerfile
@@ -4,6 +4,7 @@
 
 FROM ubuntu:22.04
 ARG RUST_TOOLCHAIN
+ARG GITHUB_ACTIONS=false
 
 COPY install_libseccomp.sh /usr/bin/install_libseccomp.sh
 
@@ -20,6 +21,9 @@ ENV LIBSECCOMP_LIB_PATH=${OPT_LIB}
 ENV PKG_CONFIG_PATH=${OPT_LIB}/pkgconfig:$PKG_CONFIG_PATH
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
 
 RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME} && chmod -R a+rwX /opt
 
@@ -38,7 +42,7 @@ RUN apt-get update && \
 		openssl \
 		perl \
 		protobuf-compiler && \
-	apt-get clean && rm -rf /var/lib/apt/lists/ && \
+	apt-get clean && rm -rf /var/lib/apt/lists/* && \
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
 
 # Install ORAS CLI for tarball caching

--- a/tools/packaging/static-build/agent/build.sh
+++ b/tools/packaging/static-build/agent/build.sh
@@ -16,9 +16,14 @@ source "${script_dir}/../../scripts/lib.sh"
 container_image="${AGENT_CONTAINER_BUILDER:-$(get_agent_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
+gha_docker_args=()
+packaging_github_actions_docker_append gha_docker_args
+
 docker pull ${container_image} || \
-	(docker $BUILDX build $PLATFORM \
+	(packaging_copy_apt_ci_tune_to "${script_dir}" && \
+	docker $BUILDX build $PLATFORM \
 	    	--build-arg RUST_TOOLCHAIN="$(get_from_kata_deps ".languages.rust.meta.newest-version")" \
+		"${gha_docker_args[@]}" \
 		-t "${container_image}" "${script_dir}" && \
 	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"
 	 push_to_registry "${container_image}")

--- a/tools/packaging/static-build/coco-guest-components/Dockerfile
+++ b/tools/packaging/static-build/coco-guest-components/Dockerfile
@@ -5,6 +5,7 @@
 
 FROM ubuntu:24.04
 ARG RUST_TOOLCHAIN
+ARG GITHUB_ACTIONS=false
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -13,6 +14,9 @@ ENV CARGO_HOME="/opt/cargo"
 ENV PATH="/opt/cargo/bin/:${PATH}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
 
 RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME}
 
@@ -35,7 +39,7 @@ RUN apt-get update && \
 	perl \
 	pkg-config \
 	protobuf-compiler && \
-	apt-get clean && rm -rf /var/lib/apt/lists/ && \
+	apt-get clean && rm -rf /var/lib/apt/lists/* && \
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN}
 
 ARG NVAT_VERSION
@@ -48,7 +52,7 @@ RUN if [ "$(uname -m)" = "x86_64" ] && [ -n "${NVAT_VERSION}" ]; then \
 	git checkout FETCH_HEAD && pushd nv-attestation-sdk-cpp && cmake . && make install && \
 	mkdir -p /usr/include && ln -sf /usr/local/include/nvat.h /usr/include/nvat.h && ldconfig && \
 	popd && popd && popd && rm -rf "$tmpdir" && \
-	apt-get clean && rm -rf /var/lib/apt/lists/; fi
+	apt-get clean && rm -rf /var/lib/apt/lists/*; fi
 
 ENV LIBC="gnu"
 RUN ARCH=$(uname -m); \

--- a/tools/packaging/static-build/coco-guest-components/build.sh
+++ b/tools/packaging/static-build/coco-guest-components/build.sh
@@ -34,10 +34,15 @@ nvat_version="${nvat_version:-}"
 container_image="${COCO_GUEST_COMPONENTS_CONTAINER_BUILDER:-$(get_coco_guest_components_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
+gha_docker_args=()
+packaging_github_actions_docker_append gha_docker_args
+
 docker pull ${container_image} || \
-	(docker $BUILDX build $PLATFORM \
+	(packaging_copy_apt_ci_tune_to "${script_dir}" && \
+	docker $BUILDX build $PLATFORM \
 	    	--build-arg RUST_TOOLCHAIN="${coco_guest_components_toolchain}" \
 		--build-arg NVAT_VERSION="${nvat_version}" \
+		"${gha_docker_args[@]}" \
 		-t "${container_image}" "${script_dir}" && \
 	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"
 	 push_to_registry "${container_image}")

--- a/tools/packaging/static-build/kernel/Dockerfile
+++ b/tools/packaging/static-build/kernel/Dockerfile
@@ -7,9 +7,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV INSTALL_IN_GOPATH=false
 
 ARG ARCH
+ARG GITHUB_ACTIONS=false
 # Optional: authenticated GitHub release downloads. Passed as ARG (not BuildKit secrets)
 # so a plain `docker build` works; the value may appear in image build history/cache metadata.
 ARG GH_TOKEN=
+
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
 
 COPY install_yq.sh /usr/bin/install_yq.sh
 

--- a/tools/packaging/static-build/kernel/Dockerfile
+++ b/tools/packaging/static-build/kernel/Dockerfile
@@ -7,6 +7,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 ENV INSTALL_IN_GOPATH=false
 
 ARG ARCH
+# Optional: authenticated GitHub release downloads. Passed as ARG (not BuildKit secrets)
+# so a plain `docker build` works; the value may appear in image build history/cache metadata.
+ARG GH_TOKEN=
 
 COPY install_yq.sh /usr/bin/install_yq.sh
 

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -60,6 +60,10 @@ fi
 
 container_build+=" --build-arg ARCH=${ARCH:-}"
 
+if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+	container_build+=" --build-arg GITHUB_ACTIONS=true"
+fi
+
 kernel_gh_build_args=()
 # GH_TOKEN as build-arg (not BuildKit): keeps plain `docker build` working; value may appear in image history.
 if [[ -n "${GH_TOKEN:-}" ]] || [[ -n "${GITHUB_TOKEN:-}" ]]; then
@@ -69,6 +73,7 @@ fi
 
 "${container_engine}" pull "${container_image}" || \
 	{
+		packaging_copy_apt_ci_tune_to "${script_dir}"
 		${container_build} "${kernel_gh_build_args[@]}" -t "${container_image}" "${script_dir}" && \
 		# No-op unless PUSH_TO_REGISTRY is exported as "yes"
 		push_to_registry "${container_image}";

--- a/tools/packaging/static-build/kernel/build.sh
+++ b/tools/packaging/static-build/kernel/build.sh
@@ -60,9 +60,16 @@ fi
 
 container_build+=" --build-arg ARCH=${ARCH:-}"
 
+kernel_gh_build_args=()
+# GH_TOKEN as build-arg (not BuildKit): keeps plain `docker build` working; value may appear in image history.
+if [[ -n "${GH_TOKEN:-}" ]] || [[ -n "${GITHUB_TOKEN:-}" ]]; then
+	export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+	kernel_gh_build_args+=(--build-arg "GH_TOKEN=${GH_TOKEN}")
+fi
+
 "${container_engine}" pull "${container_image}" || \
 	{
-		${container_build} -t "${container_image}" "${script_dir}" && \
+		${container_build} "${kernel_gh_build_args[@]}" -t "${container_image}" "${script_dir}" && \
 		# No-op unless PUSH_TO_REGISTRY is exported as "yes"
 		push_to_registry "${container_image}";
 	}

--- a/tools/packaging/static-build/kernel/install_yq.sh
+++ b/tools/packaging/static-build/kernel/install_yq.sh
@@ -107,7 +107,12 @@ function install_yq() {
 
 	## NOTE: ${var,,} => gives lowercase value of var
 	local yq_url="https://${yq_pkg}/releases/download/${yq_version}/yq_${goos}_${goarch}"
-	${precmd} curl -o "${yq_path}" -LSsf "${yq_url}" || die "Download ${yq_url} failed"
+	local gh_auth_header=()
+	local _gh_token="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+	if [[ -n "${_gh_token}" ]] && [[ "${yq_url}" =~ ^https://github\.com/ ]]; then
+		gh_auth_header=(-H "Authorization: Bearer ${_gh_token}")
+	fi
+	${precmd} curl "${gh_auth_header[@]}" -o "${yq_path}" -LSsf "${yq_url}" || die "Download ${yq_url} failed"
 	${precmd} chmod +x "${yq_path}"
 
 	if ! command -v "${yq_path}" >/dev/null; then

--- a/tools/packaging/static-build/ovmf/Dockerfile
+++ b/tools/packaging/static-build/ovmf/Dockerfile
@@ -5,6 +5,11 @@
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG GITHUB_ACTIONS=false
+
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
+
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         ca-certificates \
@@ -19,4 +24,4 @@ RUN apt-get update && \
         python3 \
         python3-distutils \
         uuid-dev && \
-    apt-get clean && rm -rf /var/lib/lists/
+    apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/tools/packaging/static-build/ovmf/build.sh
+++ b/tools/packaging/static-build/ovmf/build.sh
@@ -57,8 +57,12 @@ fi
 [ -n "$ovmf_package" ] || die "failed to get ovmf package or commit"
 [ -n "$package_output_dir" ] || die "failed to get ovmf package or commit"
 
+gha_docker_args=()
+packaging_github_actions_docker_append gha_docker_args
+
 docker pull ${container_image} || \
-	(docker build -t "${container_image}" "${script_dir}" && \
+	(packaging_copy_apt_ci_tune_to "${script_dir}" && \
+	docker build "${gha_docker_args[@]}" -t "${container_image}" "${script_dir}" && \
 	# No-op unless PUSH_TO_REGISTRY is exported as "yes"
 	push_to_registry "${container_image}")
 

--- a/tools/packaging/static-build/pause-image/Dockerfile
+++ b/tools/packaging/static-build/pause-image/Dockerfile
@@ -5,7 +5,13 @@ FROM ubuntu:22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG GITHUB_ACTIONS=false
+
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
+
 RUN apt-get update && \
     apt-get --no-install-recommends -y install \
     ca-certificates \

--- a/tools/packaging/static-build/pause-image/build.sh
+++ b/tools/packaging/static-build/pause-image/build.sh
@@ -28,8 +28,13 @@ package_output_dir="${package_output_dir:-}"
 container_image="${PAUSE_IMAGE_CONTAINER_BUILDER:-$(get_pause_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
+gha_docker_args=()
+packaging_github_actions_docker_append gha_docker_args
+
 docker pull ${container_image} || \
-	(docker $BUILDX build $PLATFORM \
+	(packaging_copy_apt_ci_tune_to "${script_dir}" && \
+	docker $BUILDX build $PLATFORM \
+		"${gha_docker_args[@]}" \
 		-t "${container_image}" "${script_dir}" && \
 	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"
 	 push_to_registry "${container_image}")

--- a/tools/packaging/static-build/qemu/Dockerfile
+++ b/tools/packaging/static-build/qemu/Dockerfile
@@ -12,8 +12,15 @@ ARG DPKG_ARCH
 ARG ARCH
 ARG GCC_ARCH
 ARG PREFIX
+ARG GITHUB_ACTIONS=false
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+# Context is tools/packaging (see build-base-qemu.sh: docker build "${packaging_dir}").
+# apt-ci-tune.sh lives at tools/packaging/docker/apt-ci-tune.sh in the tree.
+COPY docker/apt-ci-tune.sh /tmp/apt-ci-tune.sh
+# Keep script for --mirrors-rewrite after noble.list adds archive.ubuntu.com (amd64 GHA).
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh
 
 RUN if [ "${ARCH}" != "$(uname -m)" ]; then sed -i 's/^deb/deb [arch=amd64]/g' /etc/apt/sources.list && \
     dpkg --add-architecture "${DPKG_ARCH#:}" && \
@@ -70,7 +77,7 @@ RUN apt-get update && apt-get upgrade -y && \
     if [ "${ARCH}" != s390x ]; then apt-get install -y --no-install-recommends libpmem-dev${DPKG_ARCH}; fi && \
     GCC_ARCH="${ARCH}" && if [ "${ARCH}" = "ppc64le" ]; then GCC_ARCH="powerpc64le"; fi && \
     if [ "${ARCH}" != "$(uname -m)" ]; then apt-get install --no-install-recommends -y gcc-"${GCC_ARCH}"-linux-gnu; fi && \
-    apt-get clean && rm -rf /var/lib/apt/lists/
+    apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Detect architecture and set appropriate Ubuntu mirror
 RUN ARCH=$(dpkg --print-architecture) && \
@@ -84,7 +91,8 @@ RUN ARCH=$(dpkg --print-architecture) && \
 # Backup sources list and add Noble (24.04) repository
 RUN . /etc/ubuntu_mirror.env && \
     cp /etc/apt/sources.list /etc/apt/sources.list.backup && \
-    echo "deb ${UBUNTU_MIRROR} noble main universe" > /etc/apt/sources.list.d/noble.list
+    echo "deb ${UBUNTU_MIRROR} noble main universe" > /etc/apt/sources.list.d/noble.list && \
+    GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh --mirrors-rewrite
 
 # Set up APT pinning to prefer Jammy packages by default, but allow liburing from Noble
 RUN mkdir -p /etc/apt/preferences.d && \

--- a/tools/packaging/static-build/qemu/build-base-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-base-qemu.sh
@@ -27,6 +27,7 @@ dpkg_arch=":${ARCH}"
 [[ "${dpkg_arch}" == ":x86_64" ]] && dpkg_arch=""
 [[ "${dpkg_arch}" == ":ppc64le" ]] && dpkg_arch=":ppc64el"
 
+# Docker build context for qemu/Dockerfile: tools/packaging (includes docker/apt-ci-tune.sh).
 packaging_dir="${script_dir}/../.."
 qemu_destdir="/tmp/qemu-static/"
 container_engine="${USE_PODMAN:+podman}"
@@ -54,12 +55,16 @@ CACHE_TIMEOUT=$(date +"%Y-%m-%d")
 container_image="${QEMU_CONTAINER_BUILDER:-$(get_qemu_image_name)}"
 [[ "${CROSS_BUILD}" == "true" ]] && container_image="${container_image}-cross-build"
 
+gha_docker_args=()
+packaging_github_actions_docker_append gha_docker_args
+
 "${container_engine}" pull "${container_image}" || ("${container_engine}" build \
 	--build-arg CACHE_TIMEOUT="${CACHE_TIMEOUT}" \
 	--build-arg http_proxy="${http_proxy}" \
 	--build-arg https_proxy="${https_proxy}" \
 	--build-arg DPKG_ARCH="${dpkg_arch}" \
 	--build-arg ARCH="${ARCH}" \
+	"${gha_docker_args[@]}" \
 	"${packaging_dir}" \
 	-f "${script_dir}/Dockerfile" \
 	-t "${container_image}" && \

--- a/tools/packaging/static-build/shim-v2/Dockerfile
+++ b/tools/packaging/static-build/shim-v2/Dockerfile
@@ -5,6 +5,8 @@
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG GITHUB_ACTIONS=false
+
 ENV GO_HOME="/opt"
 ENV GOCACHE="${GO_HOME}/.cache"
 ENV RUSTUP_HOME="/opt/rustup"
@@ -12,6 +14,9 @@ ENV CARGO_HOME="/opt/cargo"
 ENV PATH="/opt/cargo/bin/:/opt/go/bin:${PATH}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
 
 RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME} ${GOCACHE} && \
     chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME} ${GO_HOME}
@@ -31,7 +36,7 @@ RUN apt-get update && \
         musl-tools \
         protobuf-compiler \
         sudo && \
-        apt-get clean && rm -rf /var/lib/apt/lists/&& \
+        apt-get clean && rm -rf /var/lib/apt/lists/* && \
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_VERSION}
 
 RUN ARCH=$(uname -m); \

--- a/tools/packaging/static-build/shim-v2/build.sh
+++ b/tools/packaging/static-build/shim-v2/build.sh
@@ -62,10 +62,15 @@ for entry in "${verity_variants[@]}"; do
 	EXTRA_OPTS+=" ${param_var}=${root_measure_config}"
 done
 
+gha_docker_args=()
+packaging_github_actions_docker_append gha_docker_args
+
 docker pull ${container_image} || \
-	(docker ${BUILDX} build ${PLATFORM}  \
+	(packaging_copy_apt_ci_tune_to "${script_dir}" && \
+	docker ${BUILDX} build ${PLATFORM}  \
 		--build-arg GO_VERSION="${GO_VERSION}" \
 		--build-arg RUST_VERSION="${RUST_VERSION}" \
+		"${gha_docker_args[@]}" \
 		-t "${container_image}" \
 		"${script_dir}" && \
 	 push_to_registry "${container_image}")

--- a/tools/packaging/static-build/tools/Dockerfile
+++ b/tools/packaging/static-build/tools/Dockerfile
@@ -5,6 +5,7 @@
 FROM ubuntu:22.04
 ARG GO_TOOLCHAIN
 ARG RUST_TOOLCHAIN
+ARG GITHUB_ACTIONS=false
 
 COPY install_libseccomp.sh /usr/bin/install_libseccomp.sh
 
@@ -25,6 +26,9 @@ ENV PKG_CONFIG_PATH=${OPT_LIB}/pkgconfig:$PKG_CONFIG_PATH
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
+
 RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME}
 
 RUN apt-get update && \
@@ -42,7 +46,7 @@ RUN apt-get update && \
 		musl-tools \
 		perl \
 		protobuf-compiler && \
-	apt-get clean && rm -rf /var/lib/apt/lists/ && \
+	apt-get clean && rm -rf /var/lib/apt/lists/* && \
 	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
 	chmod -R a+rwX /opt
 

--- a/tools/packaging/static-build/tools/build.sh
+++ b/tools/packaging/static-build/tools/build.sh
@@ -18,10 +18,15 @@ tool="${1}"
 container_image="${TOOLS_CONTAINER_BUILDER:-$(get_tools_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
+gha_docker_args=()
+packaging_github_actions_docker_append gha_docker_args
+
 docker pull ${container_image} || \
-	(docker $BUILDX build $PLATFORM \
+	(packaging_copy_apt_ci_tune_to "${script_dir}" && \
+	docker $BUILDX build $PLATFORM \
 	    	--build-arg GO_TOOLCHAIN="$(get_from_kata_deps ".languages.golang.meta.newest-version")" \
 	    	--build-arg RUST_TOOLCHAIN="$(get_from_kata_deps ".languages.rust.meta.newest-version")" \
+		"${gha_docker_args[@]}" \
 		-t "${container_image}" "${script_dir}" && \
 	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"
 	 push_to_registry "${container_image}")

--- a/tools/packaging/static-build/virtiofsd/build.sh
+++ b/tools/packaging/static-build/virtiofsd/build.sh
@@ -53,12 +53,21 @@ esac
 container_image="${VIRTIOFSD_CONTAINER_BUILDER:-$(get_virtiofsd_image_name)}"
 [ "${CROSS_BUILD}" == "true" ] && container_image="${container_image}-cross-build"
 
+gha_docker_args=()
+packaging_github_actions_docker_append gha_docker_args
+
 docker pull ${container_image} || \
-	(docker $BUILDX build $PLATFORM \
-		--build-arg RUST_TOOLCHAIN="${virtiofsd_toolchain}" \
-		-t "${container_image}" "${script_dir}/${libc}" && \
-	 # No-op unless PUSH_TO_REGISTRY is exported as "yes"
-	 push_to_registry "${container_image}")
+	(
+		if [ "${libc}" = "gnu" ]; then
+			packaging_copy_apt_ci_tune_to "${script_dir}/gnu"
+		fi
+		docker $BUILDX build $PLATFORM \
+			--build-arg RUST_TOOLCHAIN="${virtiofsd_toolchain}" \
+			"${gha_docker_args[@]}" \
+			-t "${container_image}" "${script_dir}/${libc}" && \
+		# No-op unless PUSH_TO_REGISTRY is exported as "yes"
+		push_to_registry "${container_image}"
+	)
 
 docker run --rm -i -v "${repo_root_dir}:${repo_root_dir}" \
 	-w "${PWD}" \

--- a/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
+++ b/tools/packaging/static-build/virtiofsd/gnu/Dockerfile
@@ -5,12 +5,16 @@
 FROM ubuntu:22.04
 ENV DEBIAN_FRONTEND=noninteractive
 ARG RUST_TOOLCHAIN
+ARG GITHUB_ACTIONS=false
 
 ENV RUSTUP_HOME="/opt/rustup"
 ENV CARGO_HOME="/opt/cargo"
 ENV PATH="/opt/cargo/bin/:${PATH}"
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+COPY apt-ci-tune.sh /tmp/apt-ci-tune.sh
+RUN GITHUB_ACTIONS="${GITHUB_ACTIONS}" bash /tmp/apt-ci-tune.sh && rm -f /tmp/apt-ci-tune.sh
 
 RUN mkdir ${RUSTUP_HOME} ${CARGO_HOME}
 
@@ -23,7 +27,7 @@ RUN apt-get update && \
         libcap-ng-dev \
         libseccomp-dev \
         unzip && \
-    apt-get clean && rm -rf /var/lib/lists/ && \
+    apt-get clean && rm -rf /var/lib/apt/lists/* && \
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
     chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
 


### PR DESCRIPTION
Basically by using Azure mirrors of Ubuntu when on GitHub provided runners, and trying to pass down the GH_TOKEN to the build containers.