### PR TITLE
ci: enforce SLSA provenance for published artifacts

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -65,7 +65,7 @@ jobs:
           - asset: cloud-hypervisor-glibc
             stage: release
     env:
-      PERFORM_ATTESTATION: ${{ matrix.asset == 'agent' && inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
+      PERFORM_ATTESTATION: ${{ inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}

--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -64,8 +64,6 @@ jobs:
         exclude:
           - asset: cloud-hypervisor-glibc
             stage: release
-    env:
-      PERFORM_ATTESTATION: ${{ matrix.asset == 'agent' && inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -107,7 +105,7 @@ jobs:
 
       - name: Parse OCI image name and digest
         id: parse-oci-segments
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         env:
           KATA_ASSET: ${{ matrix.asset }}
         run: |
@@ -116,20 +114,20 @@ jobs:
           echo "oci-digest=${oci_image#*@}" >> "$GITHUB_OUTPUT"
 
       - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         with:
           version: "1.2.0"
 
       # for pushing attestations to the registry
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         with:
           subject-name: ${{ steps.parse-oci-segments.outputs.oci-name }}
           subject-digest: ${{ steps.parse-oci-segments.outputs.oci-digest }}

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -53,8 +53,6 @@ jobs:
           - ovmf
           - qemu
           - virtiofsd
-    env:
-      PERFORM_ATTESTATION: ${{ matrix.asset == 'agent' && inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -95,7 +93,7 @@ jobs:
 
       - name: Parse OCI image name and digest
         id: parse-oci-segments
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         env:
           KATA_ASSET: ${{ matrix.asset }}
         run: |
@@ -104,20 +102,20 @@ jobs:
           echo "oci-digest=${oci_image#*@}" >> "$GITHUB_OUTPUT"
 
       - uses: oras-project/setup-oras@22ce207df3b08e061f537244349aac6ae1d214f6 # v1.2.4
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         with:
           version: "1.2.0"
 
       # for pushing attestations to the registry
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         with:
           subject-name: ${{ steps.parse-oci-segments.outputs.oci-name }}
           subject-digest: ${{ steps.parse-oci-segments.outputs.oci-digest }}

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -56,7 +56,7 @@ jobs:
           - qemu
           - virtiofsd
     env:
-      PERFORM_ATTESTATION: ${{ matrix.asset == 'agent' && inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
+      PERFORM_ATTESTATION: ${{ inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -47,8 +47,6 @@ jobs:
           - pause-image
           - qemu
           - virtiofsd
-    env:
-      PERFORM_ATTESTATION: ${{ matrix.asset == 'agent' && inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -89,7 +87,7 @@ jobs:
 
       - name: Parse OCI image name and digest
         id: parse-oci-segments
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         env:
           ASSET: ${{ matrix.asset }}
         run: |
@@ -99,14 +97,14 @@ jobs:
 
       # for pushing attestations to the registry
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ inputs.push-to-registry == 'yes' }}
         with:
           subject-name: ${{ steps.parse-oci-segments.outputs.oci-name }}
           subject-digest: ${{ steps.parse-oci-segments.outputs.oci-digest }}

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -48,7 +48,7 @@ jobs:
           - qemu
           - virtiofsd
     env:
-      PERFORM_ATTESTATION: ${{ matrix.asset == 'agent' && inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
+      PERFORM_ATTESTATION: ${{ inputs.push-to-registry == 'yes' && 'yes' || 'no' }}
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}


### PR DESCRIPTION
Published artifacts are consumed as security-critical runtime inputs, so they need verifiable provenance that binds each binary back to the exact source and build context.

Without provenance, downstream users cannot reliably distinguish trusted CI outputs from repackaged or substituted artifacts.

Recording provenance in Sigstore's immutable transparency infrastructure provides auditable evidence that survives mirror/registry movement and strengthens supply-chain forensics and policy enforcement.

This also aligns artifact publication with a zero-trust verification model expected by confidential-computing consumers and automated admission controls.

Remove workflow-level attestation gating so published artifacts are consistently accompanied by build provenance.