### PR TITLE
runtime-rs: enable measured rootfs for qemu-coco-dev-runtime-rs

### DIFF
--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -72,6 +72,11 @@ valid_hypervisor_paths = @QEMUVALIDHYPERVISORPATHS@
 # container and look for 'default-kernel-parameters' log entries.
 kernel_params = "@KERNELPARAMS@"
 
+# Optional dm-verity parameters (comma-separated key=value list):
+# root_hash=...,salt=...,data_blocks=...,data_block_size=...,hash_block_size=...
+# These are used by the runtime to assemble dm-verity kernel params.
+kernel_verity_params = "@KERNELVERITYPARAMS@"
+
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty
 firmware = "@FIRMWAREPATH@"

--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -22,8 +22,6 @@ check_and_skip() {
 	if is_confidential_runtime_class "${KATA_HYPERVISOR}"; then
 		if [[ "$(uname -m)" == "s390x" ]]; then
 			skip "measured rootfs tests not implemented for s390x"
-		elif [[ "${KATA_HYPERVISOR}" == "qemu-coco-dev-runtime-rs" ]]; then
-			skip "measured rootfs not working on qemu-coco-dev-runtime-rs: https://github.com/kata-containers/kata-containers/issues/12851"
 		fi
 		return
 	else


### PR DESCRIPTION
Add kernel_verity_params to the qemu-coco-dev-runtime-rs configuration so the runtime can assemble dm-verity kernel parameters, and remove the test skip that was disabling measured rootfs tests for this hypervisor.

Fixes: #12851