### PR TITLE
versions: Update nydus-snapshotter to v0.15.15

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -390,7 +390,7 @@ externals:
   nydus-snapshotter:
     description: "Snapshotter for Nydus image acceleration service"
     url: "https://github.com/containerd/nydus-snapshotter"
-    version: "v0.15.13"
+    version: "v0.15.15"
 
   opa:
     description: "Open Policy Agent"


### PR DESCRIPTION
The release brings in CVEs & security fixes on nydus-snapshotter deps. See: https://github.com/containerd/nydus-snapshotter/releases/tag/v0.15.15