### PR TITLE
Confidential tests fixes

### DIFF
--- a/tests/integration/kubernetes/k8s-confidential.bats
+++ b/tests/integration/kubernetes/k8s-confidential.bats
@@ -19,7 +19,6 @@ setup() {
 }
 
 @test "Test unencrypted confidential container launch success and verify that we are running in a secure enclave." {
-	[[ " ${SUPPORTED_NON_TEE_HYPERVISORS} " =~ " ${KATA_HYPERVISOR} " ]] && skip "Test not supported for ${KATA_HYPERVISOR}."
 	# Start the service/deployment/pod
 	kubectl apply -f "${pod_config_dir}/pod-confidential-unencrypted.yaml"
 

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -35,6 +35,7 @@ else
 	# by other cases which are using 'alpine' and 'quay.io/prometheus/busybox:latest' image.
 	# more details https://github.com/kata-containers/kata-containers/issues/8337
 	K8S_TEST_SMALL_HOST_ATTESTATION_REQUIRED_UNION=( \
+		"k8s-confidential.bats" \
 		"k8s-guest-pull-image-encrypted.bats" \
 		"k8s-guest-pull-image-authenticated.bats" \
 		"k8s-guest-pull-image-signature.bats" \
@@ -56,7 +57,6 @@ else
 	K8S_TEST_SMALL_HOST_UNION=( \
 		"k8s-empty-image.bats" \
 		"k8s-guest-pull-image.bats" \
-		"k8s-confidential.bats" \
 		"k8s-sealed-secret.bats" \
 		"k8s-attach-handlers.bats" \
 		"k8s-block-volume.bats" \


### PR DESCRIPTION
There are two fixes here:
- Update the CI scripts to run the confidential tests of TEE (which prevented the second issue from being caught in PR checks)
- Remove the unneeded and incorrect conditional from the tests file. This is breaking tests as `SUPPORTED_NON_TEE_HYPERVISORS` was renamed in the refactor in https://github.com/kata-containers/kata-containers/pull/12812, but I missed this reference