### PR TITLE
ci: cache: qemu: Take configure-hypervisor.sh into account

### DIFF
--- a/tools/packaging/scripts/lib.sh
+++ b/tools/packaging/scripts/lib.sh
@@ -172,7 +172,8 @@ calc_qemu_files_sha256sum() {
 	local files="${repo_root_dir}/tools/packaging/qemu \
 		${repo_root_dir}/tools/packaging/static-build/qemu.blacklist \
 		${repo_root_dir}/tools/packaging/static-build/scripts \
-		${repo_root_dir}/tools/packaging/static-build/qemu"
+		${repo_root_dir}/tools/packaging/static-build/qemu \
+		${repo_root_dir}/tools/packaging/scripts/configure-hypervisor.sh"
 
 	sha256sum_from_files "$files"
 }


### PR DESCRIPTION
The script is used to change the options used to build QEMU and **must** be taken into consideration in case something changes, otherwise the QEMU used by the CI would be the old cached one (ignoring any flag newly added).