### PR TITLE
runtime-rs: Add cdh_api_timeout configuration parameter

### DIFF
--- a/docs/how-to/how-to-set-sandbox-config-kata.md
+++ b/docs/how-to/how-to-set-sandbox-config-kata.md
@@ -40,7 +40,8 @@ There are several kinds of Kata configurations and they are listed below.
 | `io.katacontainers.config.agent.enable_tracing` | `boolean` | enable tracing for the agent |
 | `io.katacontainers.config.agent.container_pipe_size` | uint32 | specify the size of the std(in/out) pipes created for containers |
 | `io.katacontainers.config.agent.kernel_modules` | string | the list of kernel modules and their parameters that will be loaded in the guest kernel. Semicolon separated list of kernel modules and their parameters. These modules will be loaded in the guest kernel using `modprobe`(8). E.g., `e1000e InterruptThrottleRate=3000,3000,3000 EEE=1; i915 enable_ppgtt=0` |
-| `io.katacontainers.config.agent.cdh_api_timeout` | uint32 | timeout in second for Confidential Data Hub (CDH) API service, default is `50` |
+| `io.katacontainers.config.agent.cdh_api_timeout` | uint32 | Go runtime timeout in seconds for Confidential Data Hub (CDH) API service, default is `50` |
+| `io.katacontainers.config.agent.cdh_api_timeout_ms` | uint32 | runtime-rs timeout in milliseconds for Confidential Data Hub (CDH) API service, default is `50000` |
 
 ### Hypervisor Options
 
@@ -166,7 +167,6 @@ little performance sacrifice. The annotation
 In the following example two PODs are created, but the kernel modules `e1000e`
 and `i915` are inserted only in the POD `pod1`. Also guest `seccomp` is only enabled
 in the POD `pod2`.
-
 
 ```yaml
 apiVersion: v1

--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -79,6 +79,9 @@ pub const KATA_ANNO_CFG_AGENT_CONTAINER_PIPE_SIZE: &str =
     "io.katacontainers.config.agent.container_pipe_size";
 /// An annotation key to specify the size of the pipes created for containers.
 pub const CONTAINER_PIPE_SIZE_KERNEL_PARAM: &str = "agent.container_pipe_size";
+/// An annotation to specify the Confidential Data Hub API timeout in milliseconds.
+pub const KATA_ANNO_CFG_AGENT_CDH_API_TIMEOUT: &str =
+    "io.katacontainers.config.agent.cdh_api_timeout_ms";
 
 // Hypervisor related annotations
 /// Prefix for Hypervisor configurations.
@@ -1080,6 +1083,14 @@ impl Annotation {
                     KATA_ANNO_CFG_AGENT_CONTAINER_PIPE_SIZE => match self.get_value::<u32>(key) {
                         Ok(v) => {
                             ag.container_pipe_size = v.unwrap_or_default();
+                        }
+                        Err(_e) => {
+                            return Err(u32_err);
+                        }
+                    },
+                    KATA_ANNO_CFG_AGENT_CDH_API_TIMEOUT => match self.get_value::<u32>(key) {
+                        Ok(v) => {
+                            ag.cdh_api_timeout_ms = v.unwrap_or_default();
                         }
                         Err(_e) => {
                             return Err(u32_err);

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -113,6 +113,13 @@ pub struct Agent {
     #[serde(default = "default_reconnect_timeout")]
     pub reconnect_timeout_ms: u32,
 
+    /// Confidential Data Hub API timeout value in seconds
+    #[serde(
+        default = "default_cdh_api_timeout",
+        deserialize_with = "deserialize_secs_to_millis"
+    )]
+    pub cdh_api_timeout: u32,
+
     /// Agent request timeout value in millisecond
     /// This timeout value is used to set the maximum duration for the agent to process a CreateContainerRequest.
     /// It's also used to ensure that workloads, especially those involving large image pulls within the guest,
@@ -180,9 +187,10 @@ impl std::default::Default for Agent {
             log_port: DEFAULT_AGENT_LOG_PORT,
             passfd_listener_port: DEFAULT_PASSFD_LISTENER_PORT,
             dial_timeout_ms: DEFAULT_AGENT_DIAL_TIMEOUT_MS,
-            reconnect_timeout_ms: 3_000,
-            request_timeout_ms: 30_000,
-            health_check_request_timeout_ms: 90_000,
+            reconnect_timeout_ms: default_reconnect_timeout(),
+            cdh_api_timeout: default_cdh_api_timeout(),
+            request_timeout_ms: default_request_timeout(),
+            health_check_request_timeout_ms: default_health_check_timeout(),
             kernel_modules: Default::default(),
             container_pipe_size: 0,
             launch_process_timeout: 0,
@@ -216,6 +224,11 @@ fn default_dial_timeout() -> u32 {
 fn default_reconnect_timeout() -> u32 {
     // ms
     3_000
+}
+
+fn default_cdh_api_timeout() -> u32 {
+    // ms (converted from 50 seconds)
+    50_000
 }
 
 fn default_request_timeout() -> u32 {

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -113,6 +113,10 @@ pub struct Agent {
     #[serde(default = "default_reconnect_timeout")]
     pub reconnect_timeout_ms: u32,
 
+    /// Confidential Data Hub API timeout value in milliseconds
+    #[serde(default = "default_cdh_api_timeout_ms")]
+    pub cdh_api_timeout_ms: u32,
+
     /// Agent request timeout value in millisecond
     /// This timeout value is used to set the maximum duration for the agent to process a CreateContainerRequest.
     /// It's also used to ensure that workloads, especially those involving large image pulls within the guest,
@@ -180,9 +184,10 @@ impl std::default::Default for Agent {
             log_port: DEFAULT_AGENT_LOG_PORT,
             passfd_listener_port: DEFAULT_PASSFD_LISTENER_PORT,
             dial_timeout_ms: DEFAULT_AGENT_DIAL_TIMEOUT_MS,
-            reconnect_timeout_ms: 3_000,
-            request_timeout_ms: 30_000,
-            health_check_request_timeout_ms: 90_000,
+            reconnect_timeout_ms: default_reconnect_timeout(),
+            cdh_api_timeout_ms: default_cdh_api_timeout_ms(),
+            request_timeout_ms: default_request_timeout(),
+            health_check_request_timeout_ms: default_health_check_timeout(),
             kernel_modules: Default::default(),
             container_pipe_size: 0,
             launch_process_timeout: 0,
@@ -216,6 +221,11 @@ fn default_dial_timeout() -> u32 {
 fn default_reconnect_timeout() -> u32 {
     // ms
     3_000
+}
+
+fn default_cdh_api_timeout_ms() -> u32 {
+    // ms
+    50_000
 }
 
 fn default_request_timeout() -> u32 {

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -228,6 +228,14 @@ impl TomlConfig {
                     launch_process_timeout,
                 );
             }
+            if cfg.cdh_api_timeout_ms > 0 {
+                // Convert milliseconds to seconds for agent kernel parameter
+                let cdh_api_timeout_secs = cfg.cdh_api_timeout_ms / 1000;
+                kv.insert(
+                    "agent.cdh_api_timeout".to_string(),
+                    cdh_api_timeout_secs.to_string(),
+                );
+            }
             if cfg.debug_console_enabled {
                 kv.insert(DEBUG_CONSOLE_FLAG.to_string(), "".to_string());
                 kv.insert(

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -574,6 +574,10 @@ launch_process_timeout = 6
 # Defaults to @DEFCREATECONTAINERTIMEOUT_COCO@ second(s)
 create_container_timeout = @DEFCREATECONTAINERTIMEOUT_COCO@
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+cdh_api_timeout = 50
+
 [agent.@PROJECT_TYPE@.mem_agent]
 # Control the mem-agent function enable or disable.
 # Default to false

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -574,6 +574,10 @@ launch_process_timeout = 6
 # Defaults to @DEFCREATECONTAINERTIMEOUT_COCO@ second(s)
 create_container_timeout = @DEFCREATECONTAINERTIMEOUT_COCO@
 
+# Confidential Data Hub API timeout value in milliseconds
+# (default: 50000)
+cdh_api_timeout_ms = 50000
+
 [agent.@PROJECT_TYPE@.mem_agent]
 # Control the mem-agent function enable or disable.
 # Default to false

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -551,6 +551,10 @@ launch_process_timeout = 6
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)
 create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -551,6 +551,10 @@ launch_process_timeout = 6
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)
 create_container_timeout = @DEFCREATECONTAINERTIMEOUT@
 
+# Confidential Data Hub API timeout value in milliseconds
+# (default: 50000)
+cdh_api_timeout_ms = 50000
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -593,6 +593,10 @@ launch_process_timeout = 6
 # Defaults to @DEFCREATECONTAINERTIMEOUT_COCO@ second(s)
 create_container_timeout = @DEFCREATECONTAINERTIMEOUT_COCO@
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -593,6 +593,10 @@ launch_process_timeout = 6
 # Defaults to @DEFCREATECONTAINERTIMEOUT_COCO@ second(s)
 create_container_timeout = @DEFCREATECONTAINERTIMEOUT_COCO@
 
+# Confidential Data Hub API timeout value in milliseconds
+# (default: 50000)
+cdh_api_timeout_ms = 50000
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -569,6 +569,10 @@ launch_process_timeout = 6
 # Defaults to @DEFCREATECONTAINERTIMEOUT_COCO@ second(s)
 create_container_timeout = @DEFCREATECONTAINERTIMEOUT_COCO@
 
+# Confidential Data Hub API timeout value in seconds
+# (default: 50)
+cdh_api_timeout = 50
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log
@@ -697,4 +701,3 @@ enable_pprof = false
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
-

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -569,6 +569,10 @@ launch_process_timeout = 6
 # Defaults to @DEFCREATECONTAINERTIMEOUT_COCO@ second(s)
 create_container_timeout = @DEFCREATECONTAINERTIMEOUT_COCO@
 
+# Confidential Data Hub API timeout value in milliseconds
+# (default: 50000)
+cdh_api_timeout_ms = 50000
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log
@@ -702,4 +706,3 @@ enable_pprof = false
 # to the hypervisor.
 # (default: /run/kata-containers/dans)
 dan_conf = "@DEFDANCONF@"
-

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -314,9 +314,9 @@ debug_console_enabled = false
 # (default: 45000)
 dial_timeout_ms = 45000
 
-# Confidential Data Hub API timeout value in seconds
-# (default: 50)
-cdh_api_timeout = 50
+# Confidential Data Hub API timeout value in milliseconds
+# (default: 50000)
+cdh_api_timeout_ms = 50000
 
 # Create Container Request Timeout
 # This timeout value is used to set the maximum duration for the agent to process a CreateContainerRequest.


### PR DESCRIPTION
Add the cdh_api_timeout parameter to runtime-rs to match the Go runtime implementation. This parameter controls the timeout for Confidential Data Hub API timeout in the agent.

Changes:
- Add cdh_api_timeout field to Agent config struct in kata-types
  - Defaults to 50 seconds (50,000 milliseconds internally)
  - Uses deserialize_secs_to_millis for TOML parsing
- Add cdh_api_timeout to confidential computing configuration files:
  - configuration-qemu-coco-dev-runtime-rs.toml.in
  - configuration-qemu-se-runtime-rs.toml.in
  - configuration-qemu-snp-runtime-rs.toml.in
  - configuration-qemu-tdx-runtime-rs.toml.in

The parameter is only added to confidential computing configurations where the Confidential Data Hub is used.

Assisted-by: IBM Bob