### PR TITLE
hypervisor: Enable cloud-hypervisor feature by default

### DIFF
--- a/src/runtime-rs/crates/hypervisor/Cargo.toml
+++ b/src/runtime-rs/crates/hypervisor/Cargo.toml
@@ -64,11 +64,9 @@ dragonball = { workspace = true, features = [
 dbs-utils = { workspace = true }
 
 [features]
-default = []
+default = ["cloud-hypervisor"]
 
 dragonball = ["dep:dragonball"]
-# Feature is not yet complete, so not enabled by default.
-# See https://github.com/kata-containers/kata-containers/issues/6264.
 cloud-hypervisor = ["ch-config"]
 
 [dev-dependencies]
@@ -76,9 +74,7 @@ serial_test = "2.0.0"
 tempfile = { workspace = true }
 
 # Local dev-dependencies
-# Force the CH tests to run, even when the feature is not enabled for
-# a normal build.
-hypervisor = { workspace = true, features = ["cloud-hypervisor"] }
+hypervisor = { workspace = true }
 test-utils = { workspace = true }
 
 [build-dependencies]


### PR DESCRIPTION
The cloud-hypervisor feature has been fully functional for some time now: it's enabled by default in virt_container, used by agent-ctl, and exercised in CI.  Drop the stale comments referencing issue #6264 and promote the feature to a default.

Fixes: #6264


Made-with: Cursor