### PR TITLE
runtimes: network: handle "device" type interfaces (mlx5 SFs) 

### DIFF
--- a/src/agent/src/device/mod.rs
+++ b/src/agent/src/device/mod.rs
@@ -409,7 +409,7 @@ pub fn update_env_pci(
     // Below code updates both of them in two passes:
     // - 1st pass updates PCIDEVICE_<prefix>_<resource-name> and collects host to guest PCI address mapping
     let mut pci_dev_map: HashMap<String, HashMap<String, String>> = HashMap::new();
-    for envvar in env.iter_mut() {
+    'env_loop: for envvar in env.iter_mut() {
         let eqpos = envvar
             .find('=')
             .ok_or_else(|| anyhow!("Malformed OCI env entry {:?}", envvar))?;
@@ -424,8 +424,17 @@ pub fn update_env_pci(
         let mut addr_map: HashMap<String, String> = HashMap::new();
         let mut guest_addrs = Vec::<String>::new();
         for host_addr_str in val.split(',') {
-            let host_addr = pci::Address::from_str(host_addr_str)
-                .with_context(|| format!("Can't parse {name} environment variable"))?;
+            let host_addr = match pci::Address::from_str(host_addr_str) {
+                Ok(addr) => addr,
+                Err(_) => {
+                    tracing::info!(
+                        name,
+                        host_addr_str,
+                        "skipping non-PCI address in PCIDEVICE env var"
+                    );
+                    continue 'env_loop;
+                }
+            };
             let host_guest = pcimap
                 .get(cid)
                 .ok_or_else(|| anyhow!("No PCI mapping found for container {}", cid))?;
@@ -1084,6 +1093,42 @@ mod tests {
         assert_eq!(env[1], pci_dev_info_expected);
         assert_eq!(env[2], "PCIDEVICE_y=ffff:02:1f.7");
         assert_eq!(env[3], "NOTAPCIDEVICE_blah=abcd:ef:01.0");
+    }
+
+    #[test]
+    fn test_update_env_pci_non_pci_addresses() {
+        let mut env = vec![
+            "PCIDEVICE_NVIDIA_COM_BF_SF=mlx5_core.sf.10".to_string(),
+            "PCIDEVICE_NVIDIA_COM_BF_SF_INFO={\"mlx5_core.sf.10\":{}}".to_string(),
+            "PCIDEVICE_REAL=0000:1a:01.0".to_string(),
+        ];
+
+        let example_map = [("0000:1a:01.0", "0000:01:01.0")];
+        let _pci_fixups: HashMap<pci::Address, pci::Address> = example_map
+            .iter()
+            .map(|(h, g)| {
+                (
+                    pci::Address::from_str(h).unwrap(),
+                    pci::Address::from_str(g).unwrap(),
+                )
+            })
+            .collect();
+
+        let cid = "0".to_string();
+        let mut pci_fixups: HashMap<String, HashMap<pci::Address, pci::Address>> = HashMap::new();
+        pci_fixups.insert(cid.clone(), _pci_fixups);
+
+        let res = update_env_pci(&cid, &mut env, &pci_fixups);
+        assert!(res.is_ok(), "error: {}", res.err().unwrap());
+
+        // Non-PCI addresses should be left untouched
+        assert_eq!(env[0], "PCIDEVICE_NVIDIA_COM_BF_SF=mlx5_core.sf.10");
+        assert_eq!(
+            env[1],
+            "PCIDEVICE_NVIDIA_COM_BF_SF_INFO={\"mlx5_core.sf.10\":{}}"
+        );
+        // Real PCI addresses should still be translated
+        assert_eq!(env[2], "PCIDEVICE_REAL=0000:01:01.0");
     }
 
     #[test]

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -240,7 +240,13 @@ async fn create_endpoint(
             "{} network interface found: {}", &link_type, &attrs.name
         );
         match link_type {
-            "veth" => {
+            // "device" is the generic netlink type for interfaces whose
+            // drivers do not register a more specific kind. This includes
+            // mlx5 Scalable Functions (SFs) and other non-PCI backed
+            // netdevs that is_physical_iface() cannot classify via
+            // ethtool BusInfo. Handle them the same way as veth
+            // endpoints, using the configured network model.
+            "veth" | "device" => {
                 let ret = VethEndpoint::new(
                     &d,
                     handle,
@@ -250,7 +256,7 @@ async fn create_endpoint(
                     config.queues,
                 )
                 .await
-                .context("veth endpoint")?;
+                .context(anyhow!("{link_type} endpoint"))?;
                 Arc::new(ret)
             }
             "vlan" => {

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -202,6 +202,16 @@ func (n *LinuxNetwork) addSingleEndpoint(ctx context.Context, s *Sandbox, netInf
 		} else if netInfo.Iface.Type == "ipvlan" {
 			networkLogger().Info("ipvlan interface found")
 			endpoint, err = createIPVlanNetworkEndpoint(idx, netInfo.Iface.Name)
+		} else if netInfo.Iface.Type == "device" {
+			// "device" is the generic netlink type for interfaces whose
+			// drivers do not register a more specific kind. This includes
+			// mlx5 Scalable Functions (SFs), some SR-IOV VFs on arm64,
+			// and other non-PCI backed netdevs that isPhysicalIface()
+			// cannot classify via ethtool BusInfo. Handle them the same
+			// way as veth endpoints, following the configured interworking
+			// model (TC-filter by default).
+			networkLogger().Info("device interface found")
+			endpoint, err = createVethNetworkEndpoint(idx, netInfo.Iface.Name, n.interworkingModel)
 		} else {
 			return nil, fmt.Errorf("Unsupported network interface: %s", netInfo.Iface.Type)
 		}
@@ -772,22 +782,31 @@ func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Lin
 }
 
 func getLinkForEndpoint(endpoint Endpoint, netHandle *netlink.Handle) (netlink.Link, error) {
-	var link netlink.Link
-
-	switch ep := endpoint.(type) {
-	case *VethEndpoint:
-		link = &netlink.Veth{}
-	case *MacvlanEndpoint:
-		link = &netlink.Macvlan{}
-	case *IPVlanEndpoint:
-		link = &netlink.IPVlan{}
-	case *TuntapEndpoint:
-		link = &netlink.Tuntap{}
-	default:
-		return nil, fmt.Errorf("Unexpected endpointType %s", ep.Type())
+	netPair := endpoint.NetworkPair()
+	if netPair == nil {
+		return nil, fmt.Errorf("endpoint %s has no network pair", endpoint.Type())
 	}
+	name := netPair.VirtIface.Name
 
-	return getLinkByName(netHandle, endpoint.NetworkPair().VirtIface.Name, link)
+	switch endpoint.(type) {
+	case *VethEndpoint:
+		link, err := netHandle.LinkByName(name)
+		if err != nil {
+			return nil, fmt.Errorf("LinkByName() failed for %s: %s", name, err)
+		}
+		// Accept the concrete type returned by the kernel (e.g.
+		// *netlink.Veth for real veths, *netlink.Device for mlx5
+		// SFs / generic netdevs). All callers only need Attrs().
+		return link, nil
+	case *MacvlanEndpoint:
+		return getLinkByName(netHandle, name, &netlink.Macvlan{})
+	case *IPVlanEndpoint:
+		return getLinkByName(netHandle, name, &netlink.IPVlan{})
+	case *TuntapEndpoint:
+		return getLinkByName(netHandle, name, &netlink.Tuntap{})
+	default:
+		return nil, fmt.Errorf("Unexpected endpointType %s", endpoint.Type())
+	}
 }
 
 func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.Link) (netlink.Link, error) {


### PR DESCRIPTION
Interfaces whose drivers do not register a specific netlink kind
(e.g. mlx5 Scalable Functions) are reported with the generic type
"device". The endpoint creation code did not handle this type,
causing sandbox creation to fail with:

  "Unsupported network interface: device"

This is particularly visible on arm64 with Mellanox ConnectX NICs
using Scalable Functions, where the ethtool BusInfo returns a
non-PCI identifier (e.g. "mlx5_core.sf.4") so isPhysicalIface()
cannot classify the interface as physical either.

Handle "device" type interfaces the same way as veth endpoints,
connecting them through a TAP + TC-filter bridge.

Additionally, relax getLinkForEndpoint() for VethEndpoint so it
accepts the concrete link type returned by the kernel instead of
asserting *netlink.Veth. A "device" type interface wrapped in a
VethEndpoint returns *netlink.Device from LinkByName(), which
would fail the strict type assertion. All callers only need
link.Attrs(), so accepting any link type is safe.