### PR TITLE
dragonball: add opt-in KSM (MADV_MERGEABLE) support via mem_merge + mem_type

### DIFF
--- a/src/dragonball/src/address_space_manager.rs
+++ b/src/dragonball/src/address_space_manager.rs
@@ -162,6 +162,7 @@ pub struct AddressSpaceMgrBuilder<'a> {
     mem_index: u32,
     mem_suffix: bool,
     mem_prealloc: bool,
+    mem_merge: bool,
     dirty_page_logging: bool,
     vmfd: Option<Arc<VmFd>>,
 }
@@ -178,6 +179,7 @@ impl<'a> AddressSpaceMgrBuilder<'a> {
             mem_index: 0,
             mem_suffix: true,
             mem_prealloc: false,
+            mem_merge: false,
             dirty_page_logging: false,
             vmfd: None,
         })
@@ -194,6 +196,12 @@ impl<'a> AddressSpaceMgrBuilder<'a> {
     /// Disable this feature may influence performance stability but the cpu resource consumption and start-up time will decrease.
     pub fn toggle_prealloc(&mut self, prealloc: bool) {
         self.mem_prealloc = prealloc;
+    }
+
+    /// Enable/disable KSM page merging via madvise(MADV_MERGEABLE).
+    /// Only effective on anonymous guest memory regions.
+    pub fn toggle_mem_merge(&mut self, mem_merge: bool) {
+        self.mem_merge = mem_merge;
     }
 
     /// Enable/disable KVM dirty page logging.
@@ -241,6 +249,7 @@ pub struct AddressSpaceMgr {
     prealloc_handlers: Vec<thread::JoinHandle<()>>,
     prealloc_exit: Arc<AtomicBool>,
     numa_nodes: BTreeMap<u32, NumaNode>,
+    mem_merge: bool,
 }
 
 impl AddressSpaceMgr {
@@ -269,6 +278,8 @@ impl AddressSpaceMgr {
         numa_region_infos: &[NumaRegionInfo],
         mut param: AddressSpaceMgrBuilder,
     ) -> Result<()> {
+        self.mem_merge = param.mem_merge;
+
         let mut regions = Vec::new();
         let mut start_addr = dbs_boot::layout::GUEST_MEM_START;
 
@@ -484,6 +495,9 @@ impl AddressSpaceMgr {
 
         if region.is_anonpage() {
             self.configure_anon_mem(&mmap_reg)?;
+            if self.mem_merge {
+                self.configure_mergeable(&mmap_reg);
+            }
         }
         if let Some(node_id) = region.host_numa_node_id() {
             self.configure_numa(&mmap_reg, node_id)?;
@@ -509,6 +523,31 @@ impl AddressSpaceMgr {
             )
         }
         .map_err(AddressManagerError::Madvise)
+    }
+
+    fn configure_mergeable(&self, mmap_reg: &MmapRegion) {
+        // SAFETY: MmapRegion's invariants guarantee as_ptr() points to the
+        // start of a valid mapping of exactly size() bytes, which is what
+        // madvise requires. MADV_MERGEABLE is an advisory hint and does not
+        // alter the mapping's address or length. Failure is non-fatal (e.g.
+        // kernel built without CONFIG_KSM): this is an opt-in feature and
+        // the VM runs correctly un-merged.
+        let ret = unsafe {
+            mman::madvise(
+                mmap_reg.as_ptr() as *mut libc::c_void,
+                mmap_reg.size(),
+                mman::MmapAdvise::MADV_MERGEABLE,
+            )
+        };
+        if let Err(e) = ret {
+            warn!(
+                "madvise(MADV_MERGEABLE) failed for region addr {:x?} len {:x?}: {} \
+                 (KSM disabled in kernel? continuing without dedup)",
+                mmap_reg.as_ptr(),
+                mmap_reg.size(),
+                e
+            );
+        }
     }
 
     fn configure_numa(&self, mmap_reg: &MmapRegion, node_id: u32) -> Result<()> {
@@ -689,6 +728,7 @@ impl Default for AddressSpaceMgr {
             prealloc_handlers: Vec::new(),
             prealloc_exit: Arc::new(AtomicBool::new(false)),
             numa_nodes: BTreeMap::new(),
+            mem_merge: false,
         }
     }
 }

--- a/src/dragonball/src/api/v1/vmm_action.rs
+++ b/src/dragonball/src/api/v1/vmm_action.rs
@@ -589,6 +589,7 @@ impl VmmService {
         config.serial_path = machine_config.serial_path;
 
         config.pci_hotplug_enabled = machine_config.pci_hotplug_enabled;
+        config.mem_merge = machine_config.mem_merge;
 
         vm.set_vm_config(config.clone());
         self.machine_config = config;

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -1701,6 +1701,7 @@ mod tests {
             },
             vpmu_feature: 0,
             pci_hotplug_enabled: false,
+            mem_merge: false,
         };
         vm.set_vm_config(vm_config.clone());
         vm.init_guest_memory().unwrap();

--- a/src/dragonball/src/test_utils.rs
+++ b/src/dragonball/src/test_utils.rs
@@ -40,6 +40,7 @@ pub mod tests {
             },
             vpmu_feature: 0,
             pci_hotplug_enabled: false,
+            mem_merge: false,
         };
         vm.set_vm_config(vm_config);
         vm.init_guest_memory().unwrap();

--- a/src/dragonball/src/vcpu/vcpu_manager.rs
+++ b/src/dragonball/src/vcpu/vcpu_manager.rs
@@ -1128,6 +1128,7 @@ mod tests {
             },
             vpmu_feature: 0,
             pci_hotplug_enabled: false,
+            mem_merge: false,
         };
         vm.set_vm_config(vm_config);
         vm.init_guest_memory().unwrap();
@@ -1177,6 +1178,7 @@ mod tests {
             },
             vpmu_feature: 0,
             pci_hotplug_enabled: false,
+            mem_merge: false,
         };
         vm.set_vm_config(vm_config.clone());
         vm.init_guest_memory().unwrap();

--- a/src/dragonball/src/vm/mod.rs
+++ b/src/dragonball/src/vm/mod.rs
@@ -144,6 +144,11 @@ pub struct VmConfigInfo {
 
     /// Enable PCI device hotplug or not
     pub pci_hotplug_enabled: bool,
+
+    /// Call madvise(MADV_MERGEABLE) on guest memory regions before vCPUs
+    /// start, so host KSM can dedupe identical pages across VMs. Only
+    /// effective when backing is anonymous (e.g. `mem_type = "anon"`).
+    pub mem_merge: bool,
 }
 
 impl Default for VmConfigInfo {
@@ -164,6 +169,7 @@ impl Default for VmConfigInfo {
             mem_size_mib: 128,
             serial_path: None,
             pci_hotplug_enabled: false,
+            mem_merge: false,
         }
     }
 }
@@ -595,6 +601,7 @@ impl Vm {
         let mut address_space_param = AddressSpaceMgrBuilder::new(&mem_type, &mem_file_path)
             .map_err(StartMicroVmError::AddressManagerError)?;
         address_space_param.set_kvm_vm_fd(self.vm_fd.clone());
+        address_space_param.toggle_mem_merge(self.vm_config.mem_merge);
         self.address_space
             .create_address_space(&self.resource_manager, &numa_regions, address_space_param)
             .map_err(StartMicroVmError::AddressManagerError)?;
@@ -965,6 +972,7 @@ pub mod tests {
             },
             vpmu_feature: 0,
             pci_hotplug_enabled: false,
+            mem_merge: false,
         };
 
         let mut vm = create_vm_instance();
@@ -998,6 +1006,7 @@ pub mod tests {
             },
             vpmu_feature: 0,
             pci_hotplug_enabled: false,
+            mem_merge: false,
         };
         vm.set_vm_config(vm_config);
         assert!(vm.init_guest_memory().is_ok());
@@ -1047,6 +1056,7 @@ pub mod tests {
             },
             vpmu_feature: 0,
             pci_hotplug_enabled: false,
+            mem_merge: false,
         };
 
         vm.set_vm_config(vm_config);
@@ -1124,6 +1134,7 @@ pub mod tests {
             },
             vpmu_feature: 0,
             pci_hotplug_enabled: false,
+            mem_merge: false,
         };
 
         vm.set_vm_config(vm_config);
@@ -1157,6 +1168,174 @@ pub mod tests {
                 io::stdout().write_all(b"KVM_EXIT_HLT\n").unwrap();
             }
             r => panic!("unexpected exit reason: {:?}", r),
+        }
+    }
+
+    // --- mem_merge kernel-smoke tests ---------------------------------------
+    //
+    // These exercise the full path:
+    //     VmmService::set_vm_configuration(mem_merge, mem_type)
+    //         -> VmConfigInfo
+    //             -> Vm::init_guest_memory
+    //                 -> AddressSpaceMgr (toggle_mem_merge)
+    //                     -> create_region -> configure_mergeable
+    //                         -> madvise(MADV_MERGEABLE)
+    // and validate the *kernel-visible* outcome via /proc/self/smaps VmFlags.
+    //
+    // The "true" case needs CONFIG_KSM (otherwise madvise returns EINVAL and
+    // the kernel never sets the `mg` flag); on CI runners this is universal,
+    // but the test gates on /sys/kernel/mm/ksm/run being present so it
+    // silently no-ops on exotic kernels rather than flaking.
+
+    #[cfg(target_os = "linux")]
+    fn vmflags_for_host_addr(target: usize) -> Option<String> {
+        let smaps = std::fs::read_to_string("/proc/self/smaps").ok()?;
+        let mut cur_range: Option<(usize, usize)> = None;
+        let mut cur_flags: Option<String> = None;
+        for line in smaps.lines() {
+            if let Some((lo, hi)) = line
+                .split_whitespace()
+                .next()
+                .and_then(|r| r.split_once('-'))
+                .and_then(|(l, h)| {
+                    Some((
+                        usize::from_str_radix(l, 16).ok()?,
+                        usize::from_str_radix(h, 16).ok()?,
+                    ))
+                })
+            {
+                if let (Some((rl, rh)), Some(f)) = (cur_range, cur_flags.as_ref()) {
+                    if target >= rl && target < rh {
+                        return Some(f.clone());
+                    }
+                }
+                cur_range = Some((lo, hi));
+                cur_flags = None;
+            } else if let Some(rest) = line.strip_prefix("VmFlags:") {
+                cur_flags = Some(rest.trim().to_string());
+            }
+        }
+        if let (Some((rl, rh)), Some(f)) = (cur_range, cur_flags) {
+            if target >= rl && target < rh {
+                return Some(f);
+            }
+        }
+        None
+    }
+
+    #[cfg(target_os = "linux")]
+    fn host_addrs_of_guest_memory(vm: &Vm) -> Vec<(usize, usize)> {
+        use vm_memory::{GuestMemoryRegion, MemoryRegionAddress};
+        let mem = match vm.address_space.vm_memory() {
+            Some(m) => m,
+            None => return Vec::new(),
+        };
+        let mut out = Vec::new();
+        mem.iter().for_each(|region| {
+            if let Ok(ptr) = region.get_host_address(MemoryRegionAddress(0)) {
+                out.push((ptr as usize, region.len() as usize));
+            }
+        });
+        out
+    }
+
+    #[cfg(target_os = "linux")]
+    fn ksm_supported() -> bool {
+        std::path::Path::new("/sys/kernel/mm/ksm/run").exists()
+    }
+
+    #[cfg(target_os = "linux")]
+    fn build_vm_with_mem_merge(mem_merge: bool) -> (Arc<Mutex<crate::vmm::Vmm>>, VmConfigInfo) {
+        use crate::vmm::tests::create_vmm_instance;
+        use dbs_utils::epoll_manager::EpollManager;
+        let vmm = Arc::new(Mutex::new(create_vmm_instance(EpollManager::default())));
+        let vm_config = VmConfigInfo {
+            mem_type: "anon".to_string(),
+            mem_merge,
+            mem_size_mib: 16,
+            vcpu_count: 1,
+            max_vcpu_count: 1,
+            ..VmConfigInfo::default()
+        };
+        (vmm, vm_config)
+    }
+
+    #[cfg(target_os = "linux")]
+    fn apply_config_and_init(
+        vmm: &Arc<Mutex<crate::vmm::Vmm>>,
+        vm_config: VmConfigInfo,
+    ) -> Vec<(usize, usize)> {
+        use crate::api::v1::VmmService;
+        use crossbeam_channel::unbounded;
+        let (_tx_req, rx_req) = unbounded();
+        let (tx_resp, _rx_resp) = unbounded();
+        let mut vservice = VmmService::new(rx_req, tx_resp);
+        let mut v = vmm.lock().unwrap();
+        vservice
+            .set_vm_configuration(&mut v, vm_config.clone())
+            .expect("set_vm_configuration");
+        let vm = v.get_vm_mut().unwrap();
+        // Regression guard for vmm_action.rs set_vm_configuration: if a future
+        // change drops this field from the per-field copy, init_guest_memory
+        // would silently see mem_merge=false and the kernel check below would
+        // fail with a less obvious diagnostic.
+        assert_eq!(
+            vm.vm_config().mem_merge,
+            vm_config.mem_merge,
+            "set_vm_configuration did not propagate mem_merge to the Vm config",
+        );
+        vm.init_guest_memory().expect("init_guest_memory");
+        host_addrs_of_guest_memory(vm)
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_mem_merge_enabled_sets_kernel_mergeable_flag() {
+        skip_if_kvm_unaccessable!();
+        if !ksm_supported() {
+            // CONFIG_KSM missing; madvise(MADV_MERGEABLE) returns EINVAL and
+            // the kernel cannot set the `mg` flag. Feature is opt-in and
+            // non-fatal in this configuration, so nothing to assert.
+            return;
+        }
+
+        let (vmm, vm_config) = build_vm_with_mem_merge(true);
+        let ranges = apply_config_and_init(&vmm, vm_config);
+        assert!(!ranges.is_empty(), "no guest memory regions after init");
+
+        let mergeable = ranges.iter().any(|(addr, _)| {
+            vmflags_for_host_addr(*addr)
+                .map(|flags| flags.split_whitespace().any(|f| f == "mg"))
+                .unwrap_or(false)
+        });
+        assert!(
+            mergeable,
+            "expected MADV_MERGEABLE (`mg` VmFlag) on at least one guest-memory \
+             VMA when mem_merge=true; ranges={:?}",
+            ranges,
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_mem_merge_disabled_no_kernel_mergeable_flag() {
+        skip_if_kvm_unaccessable!();
+
+        let (vmm, vm_config) = build_vm_with_mem_merge(false);
+        let ranges = apply_config_and_init(&vmm, vm_config);
+        assert!(!ranges.is_empty(), "no guest memory regions after init");
+
+        for (addr, size) in &ranges {
+            if let Some(flags) = vmflags_for_host_addr(*addr) {
+                assert!(
+                    !flags.split_whitespace().any(|f| f == "mg"),
+                    "mem_merge=false guest memory VMA at {:#x}+{:#x} has `mg` \
+                     VmFlag (MADV_MERGEABLE) set; flags={:?}",
+                    addr,
+                    size,
+                    flags
+                );
+            }
         }
     }
 }

--- a/src/libs/kata-types/src/config/hypervisor/dragonball.rs
+++ b/src/libs/kata-types/src/config/hypervisor/dragonball.rs
@@ -197,6 +197,29 @@ impl ConfigPlugin for DragonballConfig {
                     "dragonball hypervisor has minimal memory limitation {MIN_DRAGONBALL_MEMORY_SIZE_MB}",
                 )));
             }
+
+            if db.memory_info.mem_merge {
+                if db.memory_info.enable_hugepages {
+                    return Err(std::io::Error::other(
+                        "dragonball: mem_merge is incompatible with enable_hugepages \
+                         (KSM does not merge hugetlb pages)",
+                    ));
+                }
+                match db.memory_info.mem_type.as_str() {
+                    "anon" | "mmap" => {}
+                    "" | "shmem" | "hugeshmem" | "hugetlbfs" => {
+                        return Err(std::io::Error::other(
+                            "dragonball: mem_merge requires mem_type = \"anon\" \
+                             (KSM only merges anonymous private mappings)",
+                        ));
+                    }
+                    other => {
+                        return Err(std::io::Error::other(format!(
+                            "dragonball: unknown mem_type {other:?}"
+                        )));
+                    }
+                }
+            }
         }
 
         Ok(())

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1025,6 +1025,21 @@ pub struct MemoryInfo {
     /// Threshold in seconds before creating swap device.
     #[serde(default = "default_guest_swap_create_threshold_secs")]
     pub guest_swap_create_threshold_secs: u64,
+
+    /// Memory backing override for guest RAM. Dragonball only; other
+    /// drivers ignore this field.
+    /// - `""` (default): driver picks based on `enable_hugepages`.
+    /// - `"anon"` / `"mmap"`: MAP_PRIVATE | MAP_ANONYMOUS (required for
+    ///   `mem_merge`).
+    /// - `"shmem"`: memfd + MAP_SHARED.
+    #[serde(default)]
+    pub mem_type: String,
+
+    /// Enable KSM merging (MADV_MERGEABLE) on guest RAM. Dragonball only
+    /// in v1. Requires `mem_type = "anon"` and is incompatible with
+    /// `enable_hugepages`. Off by default.
+    #[serde(default)]
+    pub mem_merge: bool,
 }
 
 fn default_guest_swap_size_percent() -> u64 {

--- a/src/libs/kata-types/tests/test_config.rs
+++ b/src/libs/kata-types/tests/test_config.rs
@@ -21,8 +21,9 @@ mod tests {
         KATA_ANNO_CFG_HYPERVISOR_VIRTIO_FS_EXTRA_ARGS, KATA_ANNO_CFG_HYPERVISOR_VIRTIO_MEM,
         KATA_ANNO_CFG_KERNEL_MODULES, KATA_ANNO_CFG_RUNTIME_NAME,
     };
+    use kata_types::config::ConfigPlugin;
     use kata_types::config::KataConfig;
-    use kata_types::config::{QemuConfig, TomlConfig};
+    use kata_types::config::{DragonballConfig, QemuConfig, TomlConfig};
     use std::collections::HashMap;
     use std::fs;
     use std::path::Path;
@@ -567,6 +568,75 @@ mod tests {
         let anno = Annotation::new(anno_hash);
         let mut config = TomlConfig::load(content).unwrap();
         assert!(anno.update_config_by_annotation(&mut config).is_err());
+    }
+
+    fn dragonball_toml(body: &str) -> TomlConfig {
+        let content = format!(
+            r#"
+[hypervisor.dragonball]
+kernel = "/dev/null"
+initrd = "/dev/null"
+default_memory = 2048
+disable_block_device_use = true
+{body}
+"#
+        );
+        toml::from_str::<TomlConfig>(&content).expect("toml parse")
+    }
+
+    #[test]
+    fn test_dragonball_mem_merge_parses() {
+        let config = dragonball_toml(
+            r#"mem_type = "anon"
+mem_merge = true
+"#,
+        );
+        let hv = config
+            .hypervisor
+            .get("dragonball")
+            .expect("dragonball section");
+        assert_eq!(hv.memory_info.mem_type, "anon");
+        assert!(hv.memory_info.mem_merge);
+    }
+
+    #[test]
+    fn test_dragonball_mem_merge_defaults_off() {
+        let config = dragonball_toml("");
+        let hv = config.hypervisor.get("dragonball").unwrap();
+        assert_eq!(hv.memory_info.mem_type, "");
+        assert!(!hv.memory_info.mem_merge);
+    }
+
+    #[test]
+    fn test_dragonball_mem_merge_requires_anon_backing() {
+        let config = dragonball_toml("mem_merge = true\n");
+        let err = DragonballConfig::new()
+            .validate(&config)
+            .expect_err("validation should fail when mem_type is not anon");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("mem_merge") && msg.contains("anon"),
+            "unexpected error: {}",
+            msg
+        );
+    }
+
+    #[test]
+    fn test_dragonball_mem_merge_rejects_hugepages() {
+        let config = dragonball_toml(
+            r#"mem_type = "anon"
+mem_merge = true
+enable_hugepages = true
+"#,
+        );
+        let err = DragonballConfig::new()
+            .validate(&config)
+            .expect_err("validation should fail with hugepages + mem_merge");
+        assert!(
+            err.to_string().contains("enable_hugepages"),
+            "unexpected error: {}",
+            err
+        );
     }
 
     #[test]

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -108,6 +108,34 @@ default_bridges = @DEF_DGB_BRIDGES@
 # Default false
 reclaim_guest_freed_memory = false
 
+# Memory backing override for guest RAM.
+# - "" (default): dragonball picks based on enable_hugepages
+#                 (shmem when off, hugeshmem/hugetlbfs when on).
+# - "anon":       private anonymous mapping (MAP_PRIVATE|MAP_ANONYMOUS).
+#                 Required when mem_merge = true.
+# - "shmem":      memfd + MAP_SHARED (legacy default when hugepages off).
+mem_type = ""
+
+# Enable KSM (Kernel Samepage Merging) on guest RAM.
+# When true, dragonball calls madvise(MADV_MERGEABLE) on each guest memory
+# region so the host's ksmd daemon (if /sys/kernel/mm/ksm/run=1) can
+# deduplicate identical pages across VMs on this host. Useful when many VMs
+# share a kernel/initrd/workload image; typical savings are 10s of MiB per
+# peer VM beyond the first.
+#
+# Requires mem_type = "anon" (KSM only merges anonymous pages) and is
+# incompatible with enable_hugepages = true (KSM does not merge hugetlb).
+# Has no effect if the host kernel was built without CONFIG_KSM or if ksmd
+# is off.
+#
+# Security note: KSM introduces a timing-based side channel. Tenants sharing
+# a host can in principle probe whether a specific page exists elsewhere by
+# measuring COW-fault latency. Enable only in trust domains where this is
+# acceptable.
+#
+# Default false.
+mem_merge = false
+
 # Default memory size in MiB for SB/VM.
 # If unspecified then it will be set @DEFMEMSZ@ MiB.
 default_memory = @DEFMEMSZ@

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner.rs
@@ -223,7 +223,10 @@ impl DragonballInner {
 
     fn set_vm_base_config(&mut self) -> Result<()> {
         let serial_path = [&self.run_dir, "console.sock"].join("/");
-        let (mem_type, mem_file_path) = if self.config.memory_info.enable_hugepages {
+        let user_mem_type = self.config.memory_info.mem_type.trim();
+        let (mem_type, mem_file_path) = if !user_mem_type.is_empty() {
+            (user_mem_type.to_string(), String::from(""))
+        } else if self.config.memory_info.enable_hugepages {
             match self.config.memory_info.hugepage_type {
                 HugePageType::THP => (String::from(HUGE_SHMEM), String::from("")),
                 HugePageType::Hugetlbfs => (String::from(HUGETLBFS), String::from(DEV_HUGEPAGES)),
@@ -238,6 +241,7 @@ impl DragonballInner {
             max_vcpu_count: self.config.cpu_info.default_maxvcpus as u8,
             mem_type,
             mem_file_path,
+            mem_merge: self.config.memory_info.mem_merge,
             pci_hotplug_enabled: true,
             ..Default::default()
         };


### PR DESCRIPTION
For those super sensitive to memory overhead for many small pods, they might want to turn on Linux' [KSM](https://docs.kernel.org/admin-guide/mm/ksm.html) which will de-duplicate identical pages of memory among all pages on the system, including those used within KVM-managed guests, dragonball-managed guests included! This PR adds optional support for setting the right flags for the memory of the guests to allow KSM deduplication.

## Specifics

Adds two opt-in knobs on `[hypervisor.dragonball]`:

- **`mem_type`**: override guest memory backing.
  - `""` (default): driver picks based on `enable_hugepages` (existing behavior).
  - `"anon"` / `"mmap"`: MAP_PRIVATE | MAP_ANONYMOUS.
  - `"shmem"`: memfd + MAP_SHARED.
- **`mem_merge`**: when true, dragonball calls `madvise(MADV_MERGEABLE)` on each guest memory region before vCPUs start, so the host's `ksmd` can deduplicate identical pages across peer VMs. Requires `mem_type = "anon"` (KSM only merges anonymous mappings) and is incompatible with `enable_hugepages` (KSM doesn't merge hugetlb). Off by default.

Note that the off-by-default config is a wise security posture because enabling KSM enables a side channel timing attack, where attacker guests can figure out what pages of memory are shared with other sibiling guests. See https://www.sentinelone.com/vulnerability-database/cve-2024-0564/ for more details -- there's no mitigation right now other than just turning of KSM AFAIK.

## Motivation

On hosts running many dragonball VMs that share a kernel + initrd + workload image, each VM's host-side RSS independently holds the same bytes for text pages. KSM can fold those duplicates to a single COW page, but only for VMAs that opt in via `MADV_MERGEABLE` and that are anonymous — dragonball today does neither.

`cloud-hypervisor` already does the equivalent via its `mergeable` flag (see `cloud-hypervisor/vmm/src/memory_manager.rs`). This PR is the same thing for dragonball.

I validated using my fork on a test cluster: ~109 MB merged per peer pod across ~25 dragonball VMs sharing the same workload image; `/sys/kernel/mm/ksm/pages_sharing` climbs as peer VMs boot.

## Risk

- Off by default on every surface (config field, `Default` impl, validation).
- No behavior change for users who don't set the new knobs.
- CH/firecracker drivers ignore the new `MemoryInfo` fields.
- madvise failure is non-fatal (logged warning) so a `CONFIG_KSM`-less host still boots.

## Security note

KSM introduces a timing-based side channel. Tenants sharing a host can in principle probe whether a specific page exists elsewhere by measuring COW-fault latency. The config docblock flags this explicitly; enable only in trust domains where it is acceptable.