### PR TITLE
kata-deploy: Remove arm64 and qemu-cca shim support

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -35,7 +35,6 @@ Shims can also have configuration options specific to them:
     enabled: ~
     supportedArches:
       - amd64
-      - arm64
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
@@ -107,7 +106,6 @@ Includes:
 - `qemu-tdx` - Intel TDX (amd64)
 - `qemu-se` - IBM Secure Execution for Linux (SEL) (s390x)
 - `qemu-se-runtime-rs` - IBM Secure Execution for Linux (SEL) Rust runtime (s390x)
-- `qemu-cca` - Arm Confidential Compute Architecture (arm64)
 - `qemu-coco-dev` - Confidential Containers development (amd64, s390x)
 - `qemu-coco-dev-runtime-rs` - Confidential Containers development Rust runtime (amd64, arm64, s390x)
 
@@ -123,7 +121,7 @@ helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-d
 
 Includes:
 
-- `qemu-nvidia-gpu` - Standard NVIDIA GPU support (amd64, arm64)
+- `qemu-nvidia-gpu` - Standard NVIDIA GPU support (amd64)
 - `qemu-nvidia-gpu-snp` - NVIDIA GPU with AMD SEV-SNP (amd64)
 - `qemu-nvidia-gpu-tdx` - NVIDIA GPU with Intel TDX (amd64)
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu.values.yaml
@@ -21,7 +21,6 @@ shims:
     enabled: true
     supportedArches:
       - amd64
-      - arm64
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
@@ -78,7 +77,6 @@ shims:
 # Default shim per architecture (prefer NVIDIA GPU shims)
 defaultShim:
   amd64: qemu-nvidia-gpu  # Can be changed to qemu-nvidia-gpu-snp or qemu-nvidia-gpu-tdx if preferred
-  arm64: qemu-nvidia-gpu
 
 runtimeClasses:
   enabled: true

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-tee.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-tee.values.yaml
@@ -1,5 +1,5 @@
 # Example values file to enable Trusted Execution Environment (TEE) shims
-# This includes confidential computing shims: SNP, TDX, SE, CCA, and COCO-dev
+# This includes confidential computing shims: SNP, TDX, SE, and COCO-dev
 #
 # Usage:
 #   helm install kata-deploy oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
@@ -16,7 +16,7 @@ snapshotter:
 shims:
   disableAll: true
 
-  # Enable TEE shims (qemu-snp, qemu-snp-runtime-rs, qemu-tdx, qemu-tdx-runtime-rs, qemu-se, qemu-se-runtime-rs, qemu-cca, qemu-coco-dev, qemu-coco-dev-runtime-rs)
+  # Enable TEE shims (qemu-snp, qemu-snp-runtime-rs, qemu-tdx, qemu-tdx-runtime-rs, qemu-se, qemu-se-runtime-rs, qemu-coco-dev, qemu-coco-dev-runtime-rs)
   # NFD TEE labels (snp, tdx, se) are auto-injected into RuntimeClasses when NFD is detected; no need to set nodeSelector here.
   qemu-snp:
     enabled: true
@@ -102,20 +102,6 @@ shims:
       httpsProxy: ""
       noProxy: ""
 
-  qemu-cca:
-    enabled: true
-    supportedArches:
-      - arm64
-    allowedHypervisorAnnotations: []
-    containerd:
-      snapshotter: nydus
-      forceGuestPull: false
-    crio:
-      guestPull: true
-    agent:
-      httpsProxy: ""
-      noProxy: ""
-
   qemu-coco-dev:
     enabled: true
     supportedArches:
@@ -150,7 +136,7 @@ shims:
 # Default shim per architecture (prefer TEE shims)
 defaultShim:
   amd64: qemu-snp  # Can be changed to qemu-tdx if preferred
-  arm64: qemu-cca
+  arm64: qemu-coco-dev-runtime-rs
   s390x: qemu-se
 
 runtimeClasses:

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -94,7 +94,6 @@ shims:
     enabled: ~  # null = use disableAll setting (enabled when false, disabled when true)
     supportedArches:
       - amd64
-      - arm64
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
@@ -103,7 +102,6 @@ shims:
     enabled: ~
     supportedArches:
       - amd64
-      - arm64
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
@@ -112,7 +110,6 @@ shims:
     enabled: ~
     supportedArches:
       - amd64
-      - arm64
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
@@ -121,7 +118,6 @@ shims:
     enabled: ~
     supportedArches:
       - amd64
-      - arm64
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: "devmapper" # requires pre-configuration on the user side
@@ -151,7 +147,6 @@ shims:
     enabled: ~
     supportedArches:
       - amd64
-      - arm64
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
@@ -279,20 +274,6 @@ shims:
     enabled: ~
     supportedArches:
       - s390x
-    allowedHypervisorAnnotations: []
-    containerd:
-      snapshotter: nydus
-      forceGuestPull: false
-    crio:
-      guestPull: true
-    agent:
-      httpsProxy: ""
-      noProxy: ""
-
-  qemu-cca:
-    enabled: ~
-    supportedArches:
-      - arm64
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: nydus


### PR DESCRIPTION
We should not ship configurations that we do not actively test.

This commit drops the following from the kata-deploy helm chart:

values.yaml:
- arm64 from supportedArches for the clh shim
- arm64 from supportedArches for the cloud-hypervisor shim
- arm64 from supportedArches for the dragonball shim
- arm64 from supportedArches for the qemu-nvidia-gpu shim
- the entire qemu-cca shim definition

try-kata-tee.values.yaml:
- CCA from the file description comment
- qemu-cca from the TEE shims list comment
- the entire qemu-cca shim definition
- arm64: qemu-cca from the defaultShim mapping

try-kata-nvidia-gpu.values.yaml:
- arm64 from supportedArches for the qemu-nvidia-gpu shim
- arm64: qemu-nvidia-gpu from the defaultShim mapping

Once arm64 and qemu-cca support are properly tested, they can be
re-added.