### PR TITLE
runtime: preserve multifunction VFIO topology

### DIFF
--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -412,6 +412,12 @@ type VFIODev struct {
 	// Bus of VFIO PCIe device
 	Bus string
 
+	// Addr is the guest PCI address on the parent bus.
+	Addr string
+
+	// MultiFunction enables multifunction on the first function in the guest slot.
+	MultiFunction bool
+
 	// Guest PCI path of device
 	GuestPciPath vcTypes.PciPath
 

--- a/src/runtime/pkg/device/drivers/vfio.go
+++ b/src/runtime/pkg/device/drivers/vfio.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -38,6 +39,8 @@ type VFIODevice struct {
 	VfioDevs []*config.VFIODev
 }
 
+const vfioMultiFunctionGuestSlot = "00"
+
 // NewVFIODevice create a new VFIO device
 func NewVFIODevice(devInfo *config.DeviceInfo) *VFIODevice {
 	return &VFIODevice{
@@ -45,6 +48,74 @@ func NewVFIODevice(devInfo *config.DeviceInfo) *VFIODevice {
 			ID:         devInfo.ID,
 			DeviceInfo: devInfo,
 		},
+	}
+}
+
+func hostPCISlotKey(bdf string) (string, int, bool) {
+	functionSep := strings.LastIndexByte(bdf, '.')
+	if functionSep == -1 || functionSep == len(bdf)-1 {
+		return "", 0, false
+	}
+
+	function, err := strconv.ParseUint(bdf[functionSep+1:], 16, 3)
+	if err != nil {
+		return "", 0, false
+	}
+
+	return bdf[:functionSep], int(function), true
+}
+
+func findPCIeBusForHostSlot(port config.PCIePort, slotKey string) string {
+	for _, vfio := range config.PCIeDevicesPerPort[port] {
+		existingSlotKey, _, ok := hostPCISlotKey(vfio.BDF)
+		if ok && existingSlotKey == slotKey {
+			return vfio.Bus
+		}
+	}
+
+	return ""
+}
+
+func assignPCIeTopology(vfioDevs []*config.VFIODev) {
+	slotCounts := make(map[string]int)
+
+	for _, vfio := range vfioDevs {
+		if !vfio.IsPCIe {
+			continue
+		}
+
+		slotKey, _, ok := hostPCISlotKey(vfio.BDF)
+		if ok {
+			slotCounts[slotKey]++
+		}
+	}
+
+	for _, vfio := range vfioDevs {
+		if !vfio.IsPCIe {
+			continue
+		}
+
+		vfio.Addr = ""
+		vfio.MultiFunction = false
+
+		existingBus := ""
+		slotKey, function, ok := hostPCISlotKey(vfio.BDF)
+		if ok {
+			existingBus = findPCIeBusForHostSlot(vfio.Port, slotKey)
+			vfio.Bus = existingBus
+		}
+
+		if vfio.Bus == "" {
+			busIndex := len(config.PCIeDevicesPerPort[vfio.Port])
+			vfio.Bus = fmt.Sprintf("%s%d", config.PCIePortPrefixMapping[vfio.Port], busIndex)
+		}
+
+		if ok && (slotCounts[slotKey] > 1 || existingBus != "") {
+			vfio.Addr = fmt.Sprintf("%s.%x", vfioMultiFunctionGuestSlot, function)
+			vfio.MultiFunction = function == 0
+		}
+
+		config.PCIeDevicesPerPort[vfio.Port] = append(config.PCIeDevicesPerPort[vfio.Port], *vfio)
 	}
 }
 
@@ -88,16 +159,9 @@ func (device *VFIODevice) Attach(ctx context.Context, devReceiver api.DeviceRece
 		if vfio.Port == "" {
 			return fmt.Errorf("cold_plug_vfio= or hot_plug_vfio= port is not set for device %s (BridgePort | RootPort | SwitchPort)", vfio.BDF)
 		}
-
-		if vfio.IsPCIe {
-			busIndex := len(config.PCIeDevicesPerPort[vfio.Port])
-			vfio.Bus = fmt.Sprintf("%s%d", config.PCIePortPrefixMapping[vfio.Port], busIndex)
-			// We need to keep track the number of devices per port to deduce
-			// the corectu bus number, additionally we can use the VFIO device
-			// info to act upon different Vendor IDs and Device IDs.
-			config.PCIeDevicesPerPort[vfio.Port] = append(config.PCIeDevicesPerPort[vfio.Port], *vfio)
-		}
 	}
+
+	assignPCIeTopology(device.VfioDevs)
 
 	coldPlug := device.DeviceInfo.ColdPlug
 	deviceLogger().WithField("cold-plug", coldPlug).Info("Attaching VFIO device")

--- a/src/runtime/pkg/device/drivers/vfio_test.go
+++ b/src/runtime/pkg/device/drivers/vfio_test.go
@@ -48,3 +48,38 @@ func TestGetVFIODetails(t *testing.T) {
 	}
 
 }
+
+func TestAssignPCIeTopologyKeepsMultifunctionDevicesOnSameBus(t *testing.T) {
+	saved := config.PCIeDevicesPerPort
+	config.PCIeDevicesPerPort = map[config.PCIePort][]config.VFIODev{
+		config.RootPort:   {},
+		config.SwitchPort: {},
+		config.BridgePort: {},
+	}
+	defer func() {
+		config.PCIeDevicesPerPort = saved
+	}()
+
+	vfioDevs := []*config.VFIODev{
+		{
+			BDF:    "0000:01:00.0",
+			IsPCIe: true,
+			Port:   config.RootPort,
+		},
+		{
+			BDF:    "0000:01:00.1",
+			IsPCIe: true,
+			Port:   config.RootPort,
+		},
+	}
+
+	assignPCIeTopology(vfioDevs)
+
+	assert.Equal(t, "rp0", vfioDevs[0].Bus)
+	assert.Equal(t, "rp0", vfioDevs[1].Bus)
+	assert.Equal(t, "00.0", vfioDevs[0].Addr)
+	assert.Equal(t, "00.1", vfioDevs[1].Addr)
+	assert.True(t, vfioDevs[0].MultiFunction)
+	assert.False(t, vfioDevs[1].MultiFunction)
+	assert.Len(t, config.PCIeDevicesPerPort[config.RootPort], 2)
+}

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -1961,6 +1961,12 @@ type VFIODevice struct {
 	// Bus specifies device bus
 	Bus string
 
+	// Addr specifies the guest PCI address on the parent bus.
+	Addr string
+
+	// MultiFunction enables multifunction on the first guest PCI function.
+	MultiFunction bool
+
 	// Transport is the virtio transport for this device.
 	Transport VirtioTransport
 
@@ -2017,6 +2023,12 @@ func (vfioDev VFIODevice) QemuParams(config *Config) []string {
 
 	if vfioDev.Bus != "" {
 		deviceParams = append(deviceParams, fmt.Sprintf("bus=%s", vfioDev.Bus))
+	}
+	if vfioDev.Transport.isVirtioPCI(config) && vfioDev.Addr != "" {
+		deviceParams = append(deviceParams, fmt.Sprintf("addr=%s", vfioDev.Addr))
+	}
+	if vfioDev.Transport.isVirtioPCI(config) && vfioDev.MultiFunction {
+		deviceParams = append(deviceParams, "multifunction=on")
 	}
 
 	if vfioDev.Transport.isVirtioCCW(config) {

--- a/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_arch_base_test.go
@@ -21,6 +21,7 @@ var (
 	devicePCIeRootPortFullString   = "-device pcie-root-port,id=rp2,bus=pcie.0,chassis=0x0,slot=0x1,addr=0x2,multifunction=on,bus-reserve=0x3,pref64-reserve=16G,mem-reserve=1G,io-reserve=512M,romfile=efi-virtio.rom"
 	deviceVFIOPCIeSimpleString     = "-device vfio-pci,host=02:00.0,bus=rp0"
 	deviceVFIOPCIeFullString       = "-device vfio-pci,host=02:00.0,x-pci-vendor-id=0x10de,x-pci-device-id=0x15f8,romfile=efi-virtio.rom,bus=rp1"
+	deviceVFIOPCIeMultiString      = "-device vfio-pci,host=02:00.0,bus=rp1,addr=00.0,multifunction=on"
 	deviceSCSIControllerStr        = "-device virtio-scsi-pci,id=foo,disable-modern=false,romfile=efi-virtio.rom"
 	deviceSCSIControllerBusAddrStr = "-device virtio-scsi-pci,id=foo,bus=pci.0,addr=00:04.0,disable-modern=true,iothread=iothread1,romfile=efi-virtio.rom"
 	deviceVhostUserSCSIString      = "-chardev socket,id=char1,path=/tmp/nonexistentsocket.socket -device vhost-user-scsi-pci,id=scsi1,chardev=char1,romfile=efi-virtio.rom"
@@ -211,4 +212,12 @@ func TestAppendDeviceVFIOPCIe(t *testing.T) {
 		DeviceID: "0x15f8",
 	}
 	testAppend(vfioDevice, deviceVFIOPCIeFullString, t)
+
+	vfioDevice = VFIODevice{
+		BDF:           "02:00.0",
+		Bus:           "rp1",
+		Addr:          "00.0",
+		MultiFunction: true,
+	}
+	testAppend(vfioDevice, deviceVFIOPCIeMultiString, t)
 }

--- a/src/runtime/pkg/govmm/qemu/qmp.go
+++ b/src/runtime/pkg/govmm/qemu/qmp.go
@@ -1187,8 +1187,9 @@ func (q *QMP) ExecutePCIVhostUserDevAdd(ctx context.Context, driver, devID, char
 // devID is the id of the device to add. Must be valid QMP identifier.
 // bdf is the PCI bus-device-function of the pci device.
 // bus is optional. When hot plugging a PCIe device, the bus can be the ID of the pcie-root-port.
+// addr is optional. When set, it describes the guest PCI address on the parent bus.
 // iommufdID is the ID of the iommufd object to be created for this device. If empty, no iommufd object will be created.
-func (q *QMP) ExecuteVFIODeviceAdd(ctx context.Context, devID, bdf, bus, romfile string, iommufdID string) error {
+func (q *QMP) ExecuteVFIODeviceAdd(ctx context.Context, devID, bdf, bus, addr, romfile string, multifunction bool, iommufdID string) error {
 	var driver string
 	var transport VirtioTransport
 
@@ -1206,6 +1207,12 @@ func (q *QMP) ExecuteVFIODeviceAdd(ctx context.Context, devID, bdf, bus, romfile
 	}
 	if bus != "" {
 		args["bus"] = bus
+	}
+	if addr != "" {
+		args["addr"] = addr
+	}
+	if multifunction {
+		args["multifunction"] = true
 	}
 	if iommufdID != "" {
 		iommufdIDFull := "iommufd" + iommufdID

--- a/src/runtime/pkg/govmm/qemu/qmp_test.go
+++ b/src/runtime/pkg/govmm/qemu/qmp_test.go
@@ -1244,7 +1244,7 @@ func TestExecuteVFIODeviceAdd(t *testing.T) {
 			q := startQMPLoop(buf, cfg, connectedCh, disconnectedCh)
 			checkVersion(t, connectedCh)
 
-			err := q.ExecuteVFIODeviceAdd(context.Background(), "devID", bdf, "rp1", romfile, tc.iommufdID)
+			err := q.ExecuteVFIODeviceAdd(context.Background(), "devID", bdf, "rp1", "00.1", romfile, true, tc.iommufdID)
 			if err != nil {
 				t.Fatalf("Unexpected error %v", err)
 			}

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1899,7 +1899,7 @@ func (q *qemu) executePCIVFIODeviceAdd(device *config.VFIODev, addr string, brid
 func (q *qemu) executeVFIODeviceAdd(device *config.VFIODev) error {
 	switch device.Type {
 	case config.VFIOPCIDeviceNormalType:
-		return q.qmpMonitorCh.qmp.ExecuteVFIODeviceAdd(q.qmpMonitorCh.ctx, device.ID, device.BDF, device.Bus, romFile, device.IOMMUFDID())
+		return q.qmpMonitorCh.qmp.ExecuteVFIODeviceAdd(q.qmpMonitorCh.ctx, device.ID, device.BDF, device.Bus, device.Addr, romFile, device.MultiFunction, device.IOMMUFDID())
 	case config.VFIOPCIDeviceMediatedType:
 		return q.qmpMonitorCh.qmp.ExecutePCIVFIOMediatedDeviceAdd(q.qmpMonitorCh.ctx, device.ID, device.SysfsDev, "", device.Bus, romFile)
 	case config.VFIOAPDeviceMediatedType:

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -712,13 +712,15 @@ func (q *qemuArchBase) appendVFIODevice(devices []govmmQemu.Device, vfioDev conf
 
 	devices = append(devices,
 		govmmQemu.VFIODevice{
-			ID:       vfioDev.ID,
-			BDF:      vfioDev.BDF,
-			VendorID: vfioDev.VendorID,
-			DeviceID: vfioDev.DeviceID,
-			Bus:      vfioDev.Bus,
-			SysfsDev: vfioDev.SysfsDev,
-			DevfsDev: vfioDev.DevfsDev,
+			ID:            vfioDev.ID,
+			BDF:           vfioDev.BDF,
+			VendorID:      vfioDev.VendorID,
+			DeviceID:      vfioDev.DeviceID,
+			Bus:           vfioDev.Bus,
+			Addr:          vfioDev.Addr,
+			MultiFunction: vfioDev.MultiFunction,
+			SysfsDev:      vfioDev.SysfsDev,
+			DevfsDev:      vfioDev.DevfsDev,
 		},
 	)
 

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -532,6 +532,30 @@ func TestQemuArchBaseAppendVFIODeviceWithVendorDeviceID(t *testing.T) {
 	testQemuArchBaseAppend(t, vfDevice, expectedOut)
 }
 
+func TestQemuArchBaseAppendVFIODeviceWithGuestPCIAddress(t *testing.T) {
+	bdf := "02:10.0"
+	bus := "rp0"
+	addr := "00.0"
+
+	expectedOut := []govmmQemu.Device{
+		govmmQemu.VFIODevice{
+			BDF:           bdf,
+			Bus:           bus,
+			Addr:          addr,
+			MultiFunction: true,
+		},
+	}
+
+	vfDevice := config.VFIODev{
+		BDF:           bdf,
+		Bus:           bus,
+		Addr:          addr,
+		MultiFunction: true,
+	}
+
+	testQemuArchBaseAppend(t, vfDevice, expectedOut)
+}
+
 func TestQemuArchBaseAppendSCSIController(t *testing.T) {
 	var devices []govmmQemu.Device
 	assert := assert.New(t)

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -2280,8 +2280,11 @@ func (s *Sandbox) AppendDevice(ctx context.Context, device api.Device) error {
 	case config.DeviceVFIO:
 		vfioDevs := device.GetDeviceInfo().([]*config.VFIODev)
 		for _, d := range vfioDevs {
-			return s.hypervisor.AddDevice(ctx, *d, VfioDev)
+			if err := s.hypervisor.AddDevice(ctx, *d, VfioDev); err != nil {
+				return err
+			}
 		}
+		return nil
 	default:
 		s.Logger().WithField("device-type", device.DeviceType()).
 			Warn("Could not append device: unsupported device type")

--- a/src/runtime/virtcontainers/sandbox_vfio_test.go
+++ b/src/runtime/virtcontainers/sandbox_vfio_test.go
@@ -1,0 +1,65 @@
+//go:build linux
+
+// Copyright (c) 2026
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package virtcontainers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/api"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
+	"github.com/stretchr/testify/assert"
+)
+
+type testVFIODevice struct {
+	info []*config.VFIODev
+}
+
+func (d testVFIODevice) Attach(context.Context, api.DeviceReceiver) error { return nil }
+func (d testVFIODevice) Detach(context.Context, api.DeviceReceiver) error { return nil }
+
+func (d testVFIODevice) DeviceID() string              { return "vfio-test" }
+func (d testVFIODevice) DeviceType() config.DeviceType { return config.DeviceVFIO }
+func (d testVFIODevice) GetMajorMinor() (int64, int64) { return 0, 0 }
+func (d testVFIODevice) GetHostPath() string           { return "" }
+func (d testVFIODevice) GetDeviceInfo() interface{}    { return d.info }
+func (d testVFIODevice) GetAttachCount() uint          { return 0 }
+func (d testVFIODevice) Reference() uint               { return 0 }
+func (d testVFIODevice) Dereference() uint             { return 0 }
+func (d testVFIODevice) Save() config.DeviceState      { return config.DeviceState{} }
+func (d testVFIODevice) Load(config.DeviceState)       {}
+
+type recordingHypervisor struct {
+	mockHypervisor
+	added []config.VFIODev
+}
+
+func (h *recordingHypervisor) AddDevice(_ context.Context, devInfo interface{}, devType DeviceType) error {
+	if devType == VfioDev {
+		h.added = append(h.added, devInfo.(config.VFIODev))
+	}
+	return nil
+}
+
+func TestSandboxAppendDeviceAddsAllVFIOFunctions(t *testing.T) {
+	hypervisor := &recordingHypervisor{}
+	s := &Sandbox{hypervisor: hypervisor}
+
+	device := testVFIODevice{
+		info: []*config.VFIODev{
+			{BDF: "0000:01:00.0"},
+			{BDF: "0000:01:00.1"},
+		},
+	}
+
+	err := s.AppendDevice(context.Background(), device)
+	assert.NoError(t, err)
+	assert.Len(t, hypervisor.added, 2)
+	assert.Equal(t, "0000:01:00.0", hypervisor.added[0].BDF)
+	assert.Equal(t, "0000:01:00.1", hypervisor.added[1].BDF)
+}


### PR DESCRIPTION
## Summary
- append every VFIO function from the same IOMMU group instead of returning after the first one
- keep multifunction PCIe VFIO siblings on the same guest bus and assign explicit guest function addresses
- pass `addr` / `multifunction` through the qemu VFIO path and cover the behavior with unit tests

## Problem
On a host with an RTX 3080 exposed as `01:00.0` (VGA) and `01:00.1` (HDA), Kata was still timing out at `vsock :1024` even after fixing the earlier `AppendDevice()` bug that only appended the first VFIO function.

QMP showed that both host functions were attached to QEMU, but they were split across different guest root ports / buses:
- `01:00.0` landed on one guest bus
- `01:00.1` landed on another guest bus

That breaks the original multifunction PCI topology. In the current code this happens because `pkg/device/drivers/vfio.go` allocates a fresh guest bus for every `VFIODev` with `len(PCIeDevicesPerPort[port])`, while the qemu VFIO path only carries a `Bus` field and cannot express guest function addresses.

## Fix
This patch keeps PCIe VFIO devices that share the same host slot key (for example `0000:01:00.x`) on the same guest bus, assigns explicit guest addresses like `00.0` / `00.1`, and enables `multifunction=on` on function 0. It also preserves the earlier fix in `Sandbox.AppendDevice()` so all VFIO functions are actually appended to the hypervisor.

## Validation
- `go test ./pkg/device/drivers ./pkg/govmm/qemu`
- `GOOS=linux GOARCH=amd64 go test -c -o /tmp/virtcontainers.test ./virtcontainers`
