### PR TITLE
runtime: fix container rootfs for CRI-O with containers/storage overlay

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -210,6 +210,20 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 			return nil, fmt.Errorf("BUG: Cannot start the container, since the sandbox hasn't been created")
 		}
 
+		// CRI-O with containers/storage does not pass overlay mount specs for
+		// workload containers (r.Rootfs is empty). The overlay is mounted in
+		// CRI-O's mount namespace, which the shim cannot access. Pre-mount the
+		// overlay here using the layer metadata so bundle/rootfs exists when
+		// ShareRootFilesystem later bind-mounts it into the VM share directory.
+		if len(r.Rootfs) == 0 {
+			bundleRootfsPath := filepath.Join(bundlePath, "rootfs")
+			if _, statErr := os.Stat(bundleRootfsPath); os.IsNotExist(statErr) {
+				if mountErr := preMountOverlayRootfs(ociSpec.Root.Path, bundleRootfsPath); mountErr != nil {
+					shimLog.WithError(mountErr).Debug("pre-mount overlay rootfs skipped")
+				}
+			}
+		}
+
 		if rootFs.Mounted, err = checkAndMount(s, r); err != nil {
 			return nil, err
 		}
@@ -305,6 +319,53 @@ func loadRuntimeConfig(s *service, r *taskAPI.CreateTaskRequest, anno map[string
 	}
 
 	return &runtimeConfig, nil
+}
+
+// preMountOverlayRootfs mounts a containers/storage overlay at destPath.
+// CRI-O mounts workload container overlays only in its own mount namespace;
+// the shim's namespace never sees the merged/ directory. This function reads
+// the layer metadata from the containers/storage layout and mounts the overlay
+// directly so that bundle/rootfs is accessible to the shim.
+func preMountOverlayRootfs(mergedPath, destPath string) error {
+	if !strings.HasSuffix(mergedPath, "/merged") {
+		return fmt.Errorf("not a containers/storage overlay path: %s", mergedPath)
+	}
+	overlayDir := filepath.Dir(mergedPath)
+	storageRoot := filepath.Dir(overlayDir)
+
+	lowerData, err := os.ReadFile(filepath.Join(overlayDir, "lower"))
+	if err != nil {
+		return fmt.Errorf("reading overlay lower file: %w", err)
+	}
+
+	var lowerDirs []string
+	for _, l := range strings.Split(strings.TrimSpace(string(lowerData)), ":") {
+		if l != "" {
+			lowerDirs = append(lowerDirs, filepath.Join(storageRoot, l))
+		}
+	}
+
+	workDir := filepath.Join(overlayDir, "work")
+	// Remove overlayfs internal state left from a previous mount so the kernel
+	// accepts a fresh mount without EBUSY / EINVAL.
+	if err := os.RemoveAll(filepath.Join(workDir, "work")); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("cleaning overlay work state: %w", err)
+	}
+
+	if err := os.MkdirAll(destPath, 0755); err != nil {
+		return fmt.Errorf("creating mount destination: %w", err)
+	}
+
+	m := mount.Mount{
+		Type:   "overlay",
+		Source: "overlay",
+		Options: []string{
+			"lowerdir=" + strings.Join(lowerDirs, ":"),
+			"upperdir=" + filepath.Join(overlayDir, "diff"),
+			"workdir=" + workDir,
+		},
+	}
+	return m.Mount(destPath)
 }
 
 func checkAndMount(s *service, r *taskAPI.CreateTaskRequest) (bool, error) {

--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -139,6 +140,14 @@ func CreateSandbox(ctx context.Context, vci vc.VC, ociSpec specs.Spec, runtimeCo
 			rootFs.Source = realPath
 		}
 		sandboxConfig.Containers[0].RootFs = rootFs
+	} else if rootFs.Mounted && len(sandboxConfig.Containers) == 1 && filepath.IsAbs(ociSpec.Root.Path) {
+		// CRI-O with containers/storage sets root.path to an absolute overlay merged/
+		// directory path, but checkAndMount() mounts the rootfs at <bundle>/rootfs.
+		// Use the actual mount point if it exists.
+		bundleRootfs := filepath.Join(bundlePath, "rootfs")
+		if _, statErr := os.Stat(bundleRootfs); statErr == nil {
+			sandboxConfig.Containers[0].RootFs.Target = bundleRootfs
+		}
 	}
 
 	// Docker 26+ may set up networking before task creation instead of using
@@ -272,6 +281,14 @@ func CreateContainer(ctx context.Context, sandbox vc.VCSandbox, ociSpec specs.Sp
 			rootFs.Source = realPath
 		}
 		contConfig.RootFs = rootFs
+	} else if filepath.IsAbs(ociSpec.Root.Path) {
+		// CRI-O with containers/storage sets root.path to an absolute overlay merged/
+		// directory path, but checkAndMount() mounts the rootfs at <bundle>/rootfs.
+		// Use the actual mount point if it exists.
+		bundleRootfs := filepath.Join(bundlePath, "rootfs")
+		if _, statErr := os.Stat(bundleRootfs); statErr == nil {
+			contConfig.RootFs.Target = bundleRootfs
+		}
 	}
 	sandboxID, err := oci.SandboxID(ociSpec)
 	if err != nil {


### PR DESCRIPTION
This is pretty much wholly done by Claude, because I wanted to test kata-containers with our setup.
Immediately hit issues which seems to relate to https://github.com/kata-containers/kata-containers/issues/12659

With these changes we did get it running, so it has at least been tested in our particular setting. Claude's summary:

--- 
When CRI-O uses the containers/storage backend, it stores container layer data as overlayfs mounts. Two problems arise with kata:

1. CRI-O sets ociSpec.Root.Path to the absolute path of the overlay merged/ directory (e.g. /var/lib/containers/storage/overlay/<id>/merged). The kata shim uses this value as RootFs.Target when binding the rootfs into the VM share directory.  For both the sandbox (pause) container and workload containers, RootFs.Target must be corrected to bundle/rootfs — the path where checkAndMount() actually mounts the filesystem.  Without this, ShareRootFilesystem bind-mounts the wrong source path into the VM.

2. For workload containers CRI-O passes an empty r.Rootfs in CreateTaskRequest, so doMount() is a no-op and bundle/rootfs is never created.  The overlay is only mounted in CRI-O's mount namespace; the shim's private mount namespace (established before CRI-O mounts the overlay) cannot see it.

Fix both issues:

- In CreateSandbox() and CreateContainer() (pkg/katautils/create.go): when rootFs is already marked as mounted and Root.Path is an absolute path, check for bundle/rootfs and use it as RootFs.Target if it exists.

- In the PodContainer case of create() (pkg/containerd-shim-v2/create.go): when r.Rootfs is empty and bundle/rootfs does not yet exist, call preMountOverlayRootfs() to reconstruct and mount the overlay directly. This function reads the containers/storage layer metadata (the 'lower' file, diff/ upper directory and work/ directory) and mounts the overlay at bundle/rootfs from within the shim's namespace.  The existing mount.UnmountAll() call in the delete path cleans this up on container removal.

Tested with CRI-O + containers/storage on RHEL 9, kata runtimeClass, alpine workload container: pod reaches Running state where previously it failed with "the file sleep was not found".