### PR TITLE
runtime-rs: ch: disable nested vCPUs on MSHV

### DIFF
--- a/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/convert.rs
@@ -19,7 +19,7 @@ use kata_types::config::hypervisor::{
 };
 use kata_types::config::BootInfo;
 use std::convert::TryFrom;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::errors::*;
 
@@ -36,6 +36,17 @@ pub const DEFAULT_NUM_PCI_SEGMENTS: u16 = 1;
 
 pub const DEFAULT_DISK_QUEUES: usize = 1;
 pub const DEFAULT_DISK_QUEUE_SIZE: u16 = 128;
+
+const MSHV_DEVICE_PATH: &str = "/dev/mshv";
+
+fn cpu_nested_config() -> Option<bool> {
+    if Path::new(MSHV_DEVICE_PATH).exists() {
+        // Nested vCPUs are not supported on MSHV yet.
+        Some(false)
+    } else {
+        None
+    }
+}
 
 // TDX requires all rootfs's be mounted using a block device. This test
 // ensures that the user has a correct set of values for the following Kata
@@ -354,6 +365,7 @@ impl TryFrom<(CpuInfo, GuestProtection)> for CpusConfig {
         let cfg = CpusConfig {
             boot_vcpus,
             max_vcpus,
+            nested: cpu_nested_config(),
             max_phys_bits,
             topology: Some(topology),
             features,
@@ -647,6 +659,7 @@ mod tests {
         let cpus_config = CpusConfig {
             boot_vcpus: cpu_default,
             max_vcpus,
+            nested: cpu_nested_config(),
             topology: Some(CpuTopology {
                 cores_per_die: max_vcpus,
 
@@ -1219,6 +1232,7 @@ mod tests {
                 result: Ok(CpusConfig {
                     boot_vcpus: 1,
                     max_vcpus: 1,
+                    nested: cpu_nested_config(),
                     topology: Some(CpuTopology {
                         cores_per_die: 1,
 
@@ -1239,6 +1253,7 @@ mod tests {
                 result: Ok(CpusConfig {
                     boot_vcpus: 1,
                     max_vcpus: 3,
+                    nested: cpu_nested_config(),
                     topology: Some(CpuTopology {
                         cores_per_die: 3,
 
@@ -1259,6 +1274,7 @@ mod tests {
                 result: Ok(CpusConfig {
                     boot_vcpus: 1,
                     max_vcpus: 1,
+                    nested: cpu_nested_config(),
                     topology: Some(CpuTopology {
                         cores_per_die: 1,
 

--- a/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/ch-config/src/lib.rs
@@ -75,6 +75,9 @@ pub struct CpusConfig {
     pub topology: Option<CpuTopology>,
     #[serde(default)]
     pub kvm_hyperv: bool,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nested: Option<bool>,
     #[serde(skip_serializing_if = "u8_is_zero")]
     pub max_phys_bits: u8,
     #[serde(default)]


### PR DESCRIPTION
This is a runtime-rs port for https://github.com/kata-containers/kata-containers/commit/7973e4e2a88fcda9fd137d84b6a7d6ac56e5739e

The recently-added nested property is true by default, but is not supported yet on MSHV.

See https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7408 for additional information.