### PR TITLE
tests: describe pods deployment when testing deployment output

### DIFF
--- a/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
@@ -76,7 +76,7 @@ test_deployment_policy_error() {
     kubectl apply -f "${yaml}"
 
     # Wait for the deployment pod to fail
-    wait_for_blocked_request "CreateContainerRequest" "${deployment_name}"
+    wait_for_blocked_deployment_request "CreateContainerRequest" "policyredis"
 }
 
 @test "Policy failure: unexpected GID = 0 for layered securityContext deployment" {

--- a/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
@@ -80,8 +80,10 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected GID = 0 for layered securityContext deployment" {
-    echo "# Skipping: not supported in because kubectl describe behaviour has changed and we can no longer assess this test" >&3
-    return 0
+    if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
+        echo "# Skipping: not supported in AKS because kubectl describe behaviour has changed and we can no longer assess this test" >&3
+        return 0
+    fi
 
     # Change the pod GID to 0 after the policy has been generated using a different
     # runAsGroup value. The policy would use GID = 0 by default, if there weren't

--- a/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
@@ -80,11 +80,6 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected GID = 0 for layered securityContext deployment" {
-    if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
-        echo "# Skipping: not supported in AKS because kubectl describe behaviour has changed and we can no longer assess this test" >&3
-        return 0
-    fi
-
     # Change the pod GID to 0 after the policy has been generated using a different
     # runAsGroup value. The policy would use GID = 0 by default, if there weren't
     # a different runAsGroup value in the YAML file.

--- a/tests/integration/kubernetes/k8s-policy-deployment.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment.bats
@@ -45,7 +45,7 @@ test_deployment_policy_error() {
     kubectl apply -f "${incorrect_deployment_yaml}"
 
     # Wait for the deployment pod to fail
-    wait_for_blocked_request "CreateContainerRequest" "${deployment_name}"
+    wait_for_blocked_deployment_request "CreateContainerRequest" "policyredis"
 }
 
 @test "Policy failure: unexpected UID = 0" {

--- a/tests/integration/kubernetes/k8s-policy-deployment.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment.bats
@@ -49,11 +49,6 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected UID = 0" {
-    if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
-        echo "# Skipping: not supported in AKS because kubectl describe behaviour has changed and we can no longer assess this test" >&3
-        return 0
-    fi
-
     # Change the pod UID to 0 after the policy has been generated using a different
     # runAsUser value. The policy would use UID = 0 by default, if there weren't
     # a different runAsUser value in the YAML file.

--- a/tests/integration/kubernetes/k8s-policy-deployment.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment.bats
@@ -49,8 +49,10 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected UID = 0" {
-    echo "# Skipping: not supported in because kubectl describe behaviour has changed and we can no longer assess this test" >&3
-    return 0
+    if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
+        echo "# Skipping: not supported in AKS because kubectl describe behaviour has changed and we can no longer assess this test" >&3
+        return 0
+    fi
 
     # Change the pod UID to 0 after the policy has been generated using a different
     # runAsUser value. The policy would use UID = 0 by default, if there weren't

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -431,6 +431,16 @@ add_allow_all_policy_to_yaml() {
 	esac
 }
 
+# Execute "kubectl describe pods -l app=${app_label}, until its output contains "${endpoint} is blocked by policy"
+wait_for_blocked_deployment_request() {
+	local -r endpoint="$1"
+	local -r app_label="$2"
+
+	local -r command="kubectl describe pods -l app=${app_label} | grep \"${endpoint} is blocked by policy\""
+	info "Waiting ${wait_time} seconds for: ${command}"
+	waitForProcess "${wait_time}" "${sleep_time}" "${command}" >/dev/null 2>/dev/null
+}
+
 # Execute "kubectl describe ${pod}" in a loop, until its output contains "${endpoint} is blocked by policy"
 wait_for_blocked_request() {
 	local -r endpoint="$1"


### PR DESCRIPTION
For For k8s 1.36.0, the events of a pod are no longer included in the "kubectl describe pod" output when describing a deployment. Describe using the "app" label instead.

Fixes https://github.com/kata-containers/kata-containers/actions/runs/24809935437/job/72613854358#step:13:609