### PR TITLE
test: temp skip failing tests on AKS

### DIFF
--- a/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
@@ -80,6 +80,11 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected GID = 0 for layered securityContext deployment" {
+    if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
+        echo "# Skipping: not supported in AKS because kubectl describe behaviour has changed and we can no longer assess this test" >&3
+        return 0
+    fi
+
     # Change the pod GID to 0 after the policy has been generated using a different
     # runAsGroup value. The policy would use GID = 0 by default, if there weren't
     # a different runAsGroup value in the YAML file.

--- a/tests/integration/kubernetes/k8s-policy-deployment.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment.bats
@@ -49,6 +49,11 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected UID = 0" {
+    if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
+        echo "# Skipping: not supported in AKS because kubectl describe behaviour has changed and we can no longer assess this test" >&3
+        return 0
+    fi
+
     # Change the pod UID to 0 after the policy has been generated using a different
     # runAsUser value. The policy would use UID = 0 by default, if there weren't
     # a different runAsUser value in the YAML file.


### PR DESCRIPTION
"kubectl describe" output has been recently updated in AKS, and this change in behaviour no longer allows us to assess these tests correctly.

failing tests: https://github.com/kata-containers/kata-containers/actions/runs/24809935437/job/72613854358#step:13:609