### PR TITLE
runtime-rs: Set QEMU as the default hypervisor

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -100,7 +100,7 @@ else
         Specify "USE_BUILTIN_DB=true" to force enable.)
 endif
 
-HYPERVISOR ?= $(HYPERVISOR_DB)
+HYPERVISOR ?= $(HYPERVISOR_QEMU)
 
 ##VAR HYPERVISOR=<hypervisor_name> List of hypervisors this build system can generate configuration for.
 HYPERVISORS := $(HYPERVISOR_DB) $(HYPERVISOR_FC) $(HYPERVISOR_QEMU) $(HYPERVISOR_CLH) $(HYPERVISOR_REMOTE)


### PR DESCRIPTION
Dragonball is only supported on x86_64 and aarch64, so using it as the default hypervisor means architectures like s390x, powerpc64le, and riscv64gc have no working default. Switch to QEMU, which is available across all supported architectures.

Dragonball is still compiled as a feature on x86_64 and aarch64 via USE_BUILTIN_DB, and users can still override the default with HYPERVISOR=dragonball.