### PR TITLE
runtime-rs: fix exec when selinux is disabled on guest

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -19,6 +19,7 @@ use common::{
 use kata_sys_util::k8s::update_ephemeral_storage_type;
 use kata_types::{
     annotations::{BUNDLE_PATH_KEY, CONTAINER_TYPE_KEY, KATA_ANNO_CFG_HYPERVISOR_INIT_DATA},
+    config::TomlConfig,
     container::{update_ocispec_annotations, POD_CONTAINER, POD_SANDBOX},
     k8s::{self, container_type},
 };
@@ -103,17 +104,7 @@ impl Container {
         let toml_config = self.resource_manager.config().await;
         let config = &self.config;
         let sandbox_pidns = is_pid_namespace_enabled(&spec);
-        let disable_guest_selinux = match toml_config
-            .hypervisor
-            .get(&toml_config.runtime.hypervisor_name)
-        {
-            Some(hypervisor_config) => hypervisor_config.disable_guest_selinux,
-            // This shouldn't happen due to how logic in the config crate works
-            // but we need to handle it anyway so we stick with the default
-            // value of disable_guest_selinux in configuration.toml which
-            // is 'true'.
-            None => true,
-        };
+        let disable_guest_selinux = get_disable_guest_selinux(&toml_config);
         let annotations = spec.annotations().clone().unwrap_or_default();
         let container_typ = container_type(&spec);
         let pod_type_anno = if container_typ.is_pod_container() {
@@ -770,6 +761,20 @@ fn amend_spec(
     }
 
     Ok(())
+}
+
+fn get_disable_guest_selinux(toml_config: &TomlConfig) -> bool {
+    match toml_config
+        .hypervisor
+        .get(&toml_config.runtime.hypervisor_name)
+    {
+        Some(hypervisor_config) => hypervisor_config.disable_guest_selinux,
+        // This shouldn't happen due to how logic in the config crate works
+        // but we need to handle it anyway so we stick with the default
+        // value of disable_guest_selinux in configuration.toml which
+        // is 'true'.
+        None => true,
+    }
 }
 
 // is_pid_namespace_enabled checks if Pid namespace for a container needs to be shared with its sandbox

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -456,8 +456,13 @@ impl Container {
         stdout: Option<String>,
         stderr: Option<String>,
         terminal: bool,
-        oci_process: OCIProcess,
+        mut oci_process: OCIProcess,
     ) -> Result<()> {
+        let toml_config = self.resource_manager.config().await;
+        if get_disable_guest_selinux(&toml_config) {
+            oci_process.set_selinux_label(None);
+        }
+
         let process = Process::new(
             container_process,
             self.pid,


### PR DESCRIPTION
runtime-rs has been correctly stripping SELinux labels for some time on container create if there's no selinux in the guest.  However the same treatment is necessary for exec since if there was a process label on container create there apparently will be that label on exec, too, under both containerd and cri-o.

This PR adds the same SELinux label stripping logic to exec handling as there has been for create already.  It also fixes several dozen of OpenShift/Kubernetes tests that rely on functioning exec.