### PR TITLE
runtime-rs: Do not mark unsupported builds as successful

### DIFF
--- a/src/runtime-rs/Makefile
+++ b/src/runtime-rs/Makefile
@@ -39,7 +39,7 @@ ifeq ($(filter $(ARCH), $(UNSUPPORTED_ARCHS)),$(ARCH))
 default: runtime show-header
 test:
 	@echo "$(ARCH) is not currently supported"
-	exit 0
+	exit 1
 install: install-runtime install-configs
 else
 ##TARGET default: build code


### PR DESCRIPTION
The `Makefile` for `runtime-rs` reports a build for an unsupported architecure as successful with `exit 0`.

For a maintainer invoking that build on one of these unsupported architectures, that causes the rest of the build to proceed, only for the packaging steps to mysteriously fail later. No `error` message pinpoint the root cause for the build failure.