### PR TITLE
ci: k8s: temporarily remove smb tests

### DIFF
--- a/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
@@ -80,10 +80,8 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected GID = 0 for layered securityContext deployment" {
-    if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
-        echo "# Skipping: not supported in AKS because kubectl describe behaviour has changed and we can no longer assess this test" >&3
-        return 0
-    fi
+    echo "# Skipping: not supported in because kubectl describe behaviour has changed and we can no longer assess this test" >&3
+    return 0
 
     # Change the pod GID to 0 after the policy has been generated using a different
     # runAsGroup value. The policy would use GID = 0 by default, if there weren't

--- a/tests/integration/kubernetes/k8s-policy-deployment.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment.bats
@@ -49,10 +49,8 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected UID = 0" {
-    if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
-        echo "# Skipping: not supported in AKS because kubectl describe behaviour has changed and we can no longer assess this test" >&3
-        return 0
-    fi
+    echo "# Skipping: not supported in because kubectl describe behaviour has changed and we can no longer assess this test" >&3
+    return 0
 
     # Change the pod UID to 0 after the policy has been generated using a different
     # runAsUser value. The policy would use UID = 0 by default, if there weren't

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -100,7 +100,6 @@ else
 		"k8s-replication.bats" \
 		"k8s-sandbox-cgroup.bats" \
 		"k8s-seccomp.bats" \
-		"k8s-smb-volume.bats" \
 		"k8s-sysctls.bats" \
 		"k8s-security-context.bats" \
 		"k8s-shared-volume.bats" \


### PR DESCRIPTION
All the CIs are failing on the tests and in order to avoid blocking upstream while allowing enough time for the developers to properly fix it, let's just not execute the test.

This commit should be reverted once a fix is proposed.