### PR TITLE
ci: disable flaking smb-tests

### DIFF
--- a/tests/integration/kubernetes/k8s-smb-volume.bats
+++ b/tests/integration/kubernetes/k8s-smb-volume.bats
@@ -12,6 +12,7 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	skip "test is currently flaking due to failed mounts"
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 


### PR DESCRIPTION
Let's disable the recently merged smb tests for now since they are flaking.