### PR TITLE
workflows: Remove workflow concurrency

### DIFF
--- a/.github/workflows/build-checks-preview-riscv64.yaml
+++ b/.github/workflows/build-checks-preview-riscv64.yaml
@@ -12,9 +12,9 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-riscv64
-  cancel-in-progress: true
+# Same as `build-checks.yaml`: no workflow-level `concurrency`. Callers (e.g.
+# `ci-nightly-riscv.yaml` matrix over `instance`) must not share one group for all
+# parallel reusable runs; job-level concurrency below is sufficient.
 
 permissions: {}
 

--- a/.github/workflows/build-checks.yaml
+++ b/.github/workflows/build-checks.yaml
@@ -5,12 +5,15 @@ on:
         required: true
         type: string
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-build-checks
-  cancel-in-progress: true
+# No workflow-level `concurrency` here: this file is only `workflow_call`'d. Each
+# caller already uses `concurrency` + `cancel-in-progress` so a new push cancels the
+# whole tree. A top-level group on the reusable workflow was too coarse—it matched
+# every parallel `uses` with the same caller + PR + instance, so self-hosted matrix
+# legs (arm, s390x, ppc64le) cancelled each other. Job-level `concurrency` below is
+# enough to supersede in-flight matrix cells on a new run without blocking unrelated
+# parallel callers that share `inputs.instance`.
 
 permissions: {}
-
 name: Build checks
 jobs:
   check:


### PR DESCRIPTION
It seems like some of our workflow concurrency rules are clashing with the job-level ones and cancelling jobs, so remove these problematic workflow rules.