### PR TITLE
kata-deploy: add HTTP health probes (healthz/readyz)

### DIFF
--- a/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
+++ b/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
@@ -35,6 +35,9 @@ LIFECYCLE_POD_NAME="kata-lifecycle-test"
 # Run a command on the host node's filesystem using a short-lived privileged pod.
 # The host root is mounted at /host inside the pod.
 # Usage: run_on_host "test -d /host/opt/kata && echo YES || echo NO"
+#
+# We avoid `kubectl run --rm -i` because rke2 injects session-recording banners
+# into interactive pods, polluting stdout. Instead: create, wait, fetch logs, delete.
 run_on_host() {
 	local cmd="$1"
 	local node_name
@@ -43,7 +46,7 @@ run_on_host() {
 
 	kubectl run "${pod_name}" \
 		--image=quay.io/kata-containers/alpine-bash-curl:latest \
-		--restart=Never --rm -i \
+		--restart=Never \
 		--overrides="{
 			\"spec\": {
 				\"nodeName\": \"${node_name}\",
@@ -59,7 +62,21 @@ run_on_host() {
 				}],
 				\"volumes\": [{\"name\": \"host\", \"hostPath\": {\"path\": \"/\"}}]
 			}
-		}"
+		}" > /dev/null 2>&1
+
+	local deadline=$((SECONDS + 60))
+	while (( SECONDS < deadline )); do
+		local phase
+		phase=$(kubectl get pod "${pod_name}" -o jsonpath='{.status.phase}' 2>/dev/null) || true
+		case "${phase}" in
+			Succeeded|Failed) break ;;
+		esac
+		sleep 1
+	done
+
+	kubectl logs "${pod_name}" 2>/dev/null
+	kubectl delete pod "${pod_name}" --ignore-not-found=true > /dev/null 2>&1
+	[[ "${phase}" == "Succeeded" ]]
 }
 
 setup_file() {
@@ -192,9 +209,19 @@ EOF
 	echo "# /opt/kata: ${output}" >&3
 	[[ "${output}" == *"REMOVED"* ]]
 
-	# Containerd must still be healthy and reporting a valid version
-	local container_runtime_version
-	container_runtime_version=$(kubectl get nodes --no-headers -o custom-columns=CONTAINER_RUNTIME:.status.nodeInfo.containerRuntimeVersion)
+	# Containerd must still be healthy and reporting a valid version.
+	# After a CRI restart the kubelet may briefly report "Unknown" until it
+	# re-probes the runtime, so retry for up to 60 seconds.
+	local container_runtime_version=""
+	local retries=0
+	while [[ ${retries} -lt 30 ]]; do
+		container_runtime_version=$(kubectl get nodes --no-headers -o custom-columns=CONTAINER_RUNTIME:.status.nodeInfo.containerRuntimeVersion)
+		if [[ "${container_runtime_version}" != *"Unknown"* ]]; then
+			break
+		fi
+		retries=$((retries + 1))
+		sleep 2
+	done
 	echo "# Container runtime version: ${container_runtime_version}" >&3
 	[[ "${container_runtime_version}" != *"Unknown"* ]]
 

--- a/tests/functional/kata-deploy/lib/helm-deploy.bash
+++ b/tests/functional/kata-deploy/lib/helm-deploy.bash
@@ -101,7 +101,14 @@ deploy_kata() {
 		--wait --timeout "${HELM_TIMEOUT:-10m}"
 	)
 
-	# Run helm install
+	# Run helm install.
+	# --wait makes helm block until all DaemonSet pods are Ready. The readiness
+	# probe returns 200 only after install completes (artifacts extracted, CRI
+	# restarted, node labeled), so no extra rollout/sleep polling is needed.
+	#
+	# Exception: on single-node clusters with maxUnavailable=1, helm --wait can
+	# consider the DaemonSet ready with 0 ready pods. Belt-and-suspenders: also
+	# kubectl wait on the pod readiness condition.
 	"${helm_cmd[@]}"
 	local ret=$?
 
@@ -112,11 +119,8 @@ deploy_kata() {
 		return "${ret}"
 	fi
 
-	# Wait for daemonset to be ready
-	kubectl -n "${HELM_NAMESPACE}" rollout status daemonset/kata-deploy --timeout=300s
-
-	# Give it a moment to configure runtimes
-	sleep 60
+	kubectl -n "${HELM_NAMESPACE}" wait pod -l name=kata-deploy \
+		--for=condition=Ready --timeout="${HELM_TIMEOUT:-10m}" 2>/dev/null || true
 
 	return 0
 }

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -1049,17 +1049,23 @@ VERIFICATION_POD_EOF
 		return 1
 	fi
 
-	# `helm install --wait` does not take effect on single replicas and maxUnavailable=1 DaemonSets
-	# like kata-deploy on CI. So wait for pods being Running in the "traditional" way.
-	local cmd
-	cmd="kubectl -n kube-system get -l name=kata-deploy pod 2>/dev/null | grep '\<Running\>'"
-	waitForProcess "${KATA_DEPLOY_WAIT_TIMEOUT}" 10 "${cmd}"
-
-	# FIXME: This is needed as the kata-deploy pod will be set to "Ready"
-	# when it starts running, which may cause issues like not having the
-	# node properly labeled or the artefacts properly deployed when the
-	# tests actually start running.
-	sleep 60s
+	# helm --wait is ineffective for single-node clusters with maxUnavailable=1
+	# (the DaemonSet is considered ready with 0 ready pods). First wait until at
+	# least one kata-deploy pod exists, then wait on the pod readiness condition
+	# instead — the readiness probe (/readyz) returns 200 only after install
+	# completes (artifacts extracted, CRI restarted, node labeled).
+	local pod_wait_deadline=$((SECONDS + KATA_DEPLOY_WAIT_TIMEOUT))
+	while true; do
+		if [[ -n "$(kubectl -n kube-system get pod -l name=kata-deploy -o name 2>/dev/null)" ]]; then
+			break
+		fi
+		if (( SECONDS >= pod_wait_deadline )); then
+			echo "ERROR: Timed out waiting for kata-deploy pod to be created"
+			return 1
+		fi
+		sleep 1
+	done
+	kubectl -n kube-system wait pod -l name=kata-deploy --for=condition=Ready --timeout="${KATA_DEPLOY_WAIT_TIMEOUT}s"
 
 	echo "::group::kata-deploy logs"
 	kubectl_retry -n kube-system logs -l name=kata-deploy

--- a/tools/packaging/kata-deploy/binary/Cargo.toml
+++ b/tools/packaging/kata-deploy/binary/Cargo.toml
@@ -28,6 +28,8 @@ tokio = { workspace = true, features = [
     "macros",
     "signal",
     "time",
+    "net",
+    "io-util",
 ] }
 toml_edit = "0.22"
 walkdir = "2"

--- a/tools/packaging/kata-deploy/binary/src/health.rs
+++ b/tools/packaging/kata-deploy/binary/src/health.rs
@@ -1,0 +1,256 @@
+// Copyright (c) 2025 Kata Containers community
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use log::{debug, error, info};
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpListener;
+
+/// Installation lifecycle states exposed via the health endpoints.
+///
+/// Liveness (`/healthz`) returns 200 for any state — it only proves the process
+/// is alive and the async runtime can accept connections.
+///
+/// Readiness (`/readyz`) returns 200 only when the state is `Ready`.
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    Installing = 0,
+    Ready = 1,
+}
+
+impl std::fmt::Display for State {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            State::Installing => write!(f, "installing"),
+            State::Ready => write!(f, "ready"),
+        }
+    }
+}
+
+/// Shared handle used by `main` to signal state transitions.
+#[derive(Clone)]
+pub struct HealthState(Arc<AtomicU8>);
+
+impl HealthState {
+    pub fn new() -> Self {
+        Self(Arc::new(AtomicU8::new(State::Installing as u8)))
+    }
+
+    pub fn set(&self, state: State) {
+        self.0.store(state as u8, Ordering::SeqCst);
+    }
+
+    fn get(&self) -> State {
+        match self.0.load(Ordering::SeqCst) {
+            1 => State::Ready,
+            _ => State::Installing,
+        }
+    }
+}
+
+const DEFAULT_HEALTH_PORT: u16 = 8090;
+
+/// Timeout for reading the HTTP request line from an accepted connection.
+/// Prevents a slow/stuck client from blocking other probe requests.
+const READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub fn health_port_from_env() -> u16 {
+    std::env::var("HEALTH_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_HEALTH_PORT)
+}
+
+/// Bind the health server listener. Called from `main` so that bind failures
+/// are caught early (before install starts) instead of silently ignored.
+pub async fn bind_health(port: u16) -> anyhow::Result<TcpListener> {
+    let addr = format!("0.0.0.0:{port}");
+    let listener = TcpListener::bind(&addr)
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to bind health server on {addr}: {e}"))?;
+    info!("Health server listening on {addr}");
+    Ok(listener)
+}
+
+/// Minimal HTTP/1.1 health server. Runs until the task is cancelled.
+pub async fn serve_health(listener: TcpListener, state: HealthState) {
+    loop {
+        let (stream, _peer) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(e) => {
+                error!("Health server accept error: {e}");
+                continue;
+            }
+        };
+
+        let state = state.clone();
+        tokio::spawn(async move {
+            handle_connection(stream, &state).await;
+        });
+    }
+}
+
+async fn handle_connection(stream: tokio::net::TcpStream, state: &HealthState) {
+    let mut reader = BufReader::new(stream);
+    let mut request_line = String::new();
+
+    let result = tokio::time::timeout(READ_TIMEOUT, reader.read_line(&mut request_line)).await;
+
+    match result {
+        Ok(Ok(n)) if n > 0 => {}
+        _ => return,
+    }
+
+    let path = request_line.split_whitespace().nth(1).unwrap_or("/");
+
+    let (status, body) = build_response(path, state);
+
+    let response = format!(
+        "HTTP/1.1 {status}\r\nContent-Type: text/plain\r\n\
+         Content-Length: {}\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+
+    let mut stream = reader.into_inner();
+    let _ = stream.write_all(response.as_bytes()).await;
+    let _ = stream.shutdown().await;
+}
+
+fn build_response(path: &str, state: &HealthState) -> (&'static str, String) {
+    let current = state.get();
+    match path {
+        "/healthz" => {
+            debug!("Health check: liveness probe, state={current}");
+            ("200 OK", format!("ok {current}\n"))
+        }
+        "/readyz" => {
+            if current == State::Ready {
+                debug!("Health check: readiness probe, state={current}");
+                ("200 OK", format!("ok {current}\n"))
+            } else {
+                debug!("Health check: readiness probe NOT ready, state={current}");
+                ("503 Service Unavailable", format!("not_ready {current}\n"))
+            }
+        }
+        _ => ("404 Not Found", "not found\n".to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+
+    #[test]
+    fn test_state_display() {
+        assert_eq!(State::Installing.to_string(), "installing");
+        assert_eq!(State::Ready.to_string(), "ready");
+    }
+
+    #[test]
+    fn test_health_state_initial() {
+        let hs = HealthState::new();
+        assert_eq!(hs.get(), State::Installing);
+    }
+
+    #[test]
+    fn test_health_state_transitions() {
+        let hs = HealthState::new();
+        assert_eq!(hs.get(), State::Installing);
+
+        hs.set(State::Ready);
+        assert_eq!(hs.get(), State::Ready);
+
+        hs.set(State::Installing);
+        assert_eq!(hs.get(), State::Installing);
+    }
+
+    #[test]
+    fn test_health_state_clone_shares_state() {
+        let hs1 = HealthState::new();
+        let hs2 = hs1.clone();
+
+        hs1.set(State::Ready);
+        assert_eq!(hs2.get(), State::Ready);
+    }
+
+    #[test]
+    fn test_healthz_always_200() {
+        let state = HealthState::new();
+
+        let (status, body) = build_response("/healthz", &state);
+        assert_eq!(status, "200 OK");
+        assert!(body.contains("ok"));
+        assert!(body.contains("installing"));
+
+        state.set(State::Ready);
+        let (status, body) = build_response("/healthz", &state);
+        assert_eq!(status, "200 OK");
+        assert!(body.contains("ready"));
+    }
+
+    #[test]
+    fn test_readyz_503_while_installing() {
+        let state = HealthState::new();
+
+        let (status, body) = build_response("/readyz", &state);
+        assert_eq!(status, "503 Service Unavailable");
+        assert!(body.contains("not_ready"));
+        assert!(body.contains("installing"));
+    }
+
+    #[test]
+    fn test_readyz_200_when_ready() {
+        let state = HealthState::new();
+        state.set(State::Ready);
+
+        let (status, body) = build_response("/readyz", &state);
+        assert_eq!(status, "200 OK");
+        assert!(body.contains("ok"));
+        assert!(body.contains("ready"));
+    }
+
+    #[test]
+    fn test_unknown_path_404() {
+        let state = HealthState::new();
+
+        let (status, body) = build_response("/unknown", &state);
+        assert_eq!(status, "404 Not Found");
+        assert!(body.contains("not found"));
+    }
+
+    #[serial]
+    #[test]
+    fn test_health_port_from_env_default() {
+        std::env::remove_var("HEALTH_PORT");
+        assert_eq!(health_port_from_env(), DEFAULT_HEALTH_PORT);
+    }
+
+    #[serial]
+    #[test]
+    fn test_health_port_from_env_valid() {
+        std::env::set_var("HEALTH_PORT", "9090");
+        assert_eq!(health_port_from_env(), 9090);
+        std::env::remove_var("HEALTH_PORT");
+    }
+
+    #[serial]
+    #[test]
+    fn test_health_port_from_env_invalid_falls_back() {
+        std::env::set_var("HEALTH_PORT", "not-a-number");
+        assert_eq!(health_port_from_env(), DEFAULT_HEALTH_PORT);
+        std::env::remove_var("HEALTH_PORT");
+    }
+
+    #[serial]
+    #[test]
+    fn test_health_port_from_env_empty_falls_back() {
+        std::env::set_var("HEALTH_PORT", "");
+        assert_eq!(health_port_from_env(), DEFAULT_HEALTH_PORT);
+        std::env::remove_var("HEALTH_PORT");
+    }
+}

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -5,6 +5,7 @@
 
 mod artifacts;
 mod config;
+mod health;
 mod k8s;
 mod runtime;
 mod utils;
@@ -78,6 +79,11 @@ async fn main() -> Result<()> {
                 }
             };
 
+            let health_state = health::HealthState::new();
+            let health_port = health::health_port_from_env();
+            let health_listener = health::bind_health(health_port).await?;
+            tokio::spawn(health::serve_health(health_listener, health_state.clone()));
+
             // Race install against SIGTERM so cleanup always runs, even if
             // SIGTERM arrives during install (e.g. helm uninstall while the
             // container is restarting after a failed install attempt).
@@ -93,6 +99,7 @@ async fn main() -> Result<()> {
             };
 
             install_result?;
+            health_state.set(health::State::Ready);
 
             // DEPLOYMENT MODEL: Install runs as DaemonSet. Stay alive to maintain
             // the kata-runtime label and artifacts. On SIGTERM (pod termination),
@@ -148,8 +155,9 @@ async fn install(config: &config::Config, runtime: &str) -> Result<()> {
     ];
 
     if !SUPPORTED_RUNTIMES.contains(&runtime) {
-        error!("Runtime {runtime} not supported, skipping installation");
-        return Ok(());
+        return Err(anyhow::anyhow!(
+            "Runtime {runtime} is not supported for Kata Containers installation"
+        ));
     }
 
     if runtime != "crio" {

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -303,8 +303,45 @@ spec:
         - name: CUSTOM_RUNTIMES_ENABLED
           value: "true"
 {{- end }}
+{{- $healthDefaults := dict
+    "port" 8090
+    "startupProbe" (dict "enabled" true "initialDelaySeconds" 1 "periodSeconds" 10 "failureThreshold" 60 "timeoutSeconds" 3)
+    "livenessProbe" (dict "enabled" true "periodSeconds" 30 "failureThreshold" 3 "timeoutSeconds" 3)
+    "readinessProbe" (dict "enabled" true "periodSeconds" 10 "failureThreshold" 3 "timeoutSeconds" 3)
+}}
+{{- $health := merge (.Values.health | default dict) $healthDefaults }}
+        - name: HEALTH_PORT
+          value: {{ $health.port | quote }}
         securityContext:
           privileged: true
+{{- if $health.startupProbe.enabled }}
+        startupProbe:
+          httpGet:
+            path: /readyz
+            port: {{ $health.port }}
+          initialDelaySeconds: {{ $health.startupProbe.initialDelaySeconds }}
+          periodSeconds: {{ $health.startupProbe.periodSeconds }}
+          failureThreshold: {{ $health.startupProbe.failureThreshold }}
+          timeoutSeconds: {{ $health.startupProbe.timeoutSeconds }}
+{{- end }}
+{{- if $health.livenessProbe.enabled }}
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: {{ $health.port }}
+          periodSeconds: {{ $health.livenessProbe.periodSeconds }}
+          failureThreshold: {{ $health.livenessProbe.failureThreshold }}
+          timeoutSeconds: {{ $health.livenessProbe.timeoutSeconds }}
+{{- end }}
+{{- if $health.readinessProbe.enabled }}
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: {{ $health.port }}
+          periodSeconds: {{ $health.readinessProbe.periodSeconds }}
+          failureThreshold: {{ $health.readinessProbe.failureThreshold }}
+          timeoutSeconds: {{ $health.readinessProbe.timeoutSeconds }}
+{{- end }}
         volumeMounts:
         - name: crio-conf
           mountPath: /etc/crio/

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -54,6 +54,37 @@ updateStrategy:
 
 debug: false
 
+# Health probes for the kata-deploy DaemonSet.
+# The binary runs an HTTP health server exposing /healthz (liveness) and /readyz (readiness).
+# /healthz returns 200 as soon as the server starts (process is alive).
+# /readyz returns 200 only after install completes; 503 while installing.
+#
+# The startup probe uses /readyz so it only passes once install completes. While
+# the startup probe is active the liveness probe is suppressed, giving install up
+# to failureThreshold * periodSeconds (default 10 min) before the kubelet kills
+# the container. Without a startup probe the liveness probe would fire immediately.
+#
+# The readiness probe makes rolling updates safer: the DaemonSet controller waits for
+# a pod to become ready before proceeding to the next node (respecting maxUnavailable).
+health:
+  port: 8090
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 10
+    failureThreshold: 60
+    timeoutSeconds: 3
+  livenessProbe:
+    enabled: true
+    periodSeconds: 30
+    failureThreshold: 3
+    timeoutSeconds: 3
+  readinessProbe:
+    enabled: true
+    periodSeconds: 10
+    failureThreshold: 3
+    timeoutSeconds: 3
+
 snapshotter:
   setup: ["nydus"]  # ["nydus", "erofs"] or []
 


### PR DESCRIPTION
The kata-deploy DaemonSet pod had no Kubernetes health probes, so the
kubelet could not distinguish between "still installing" and "crashed",
and rolling updates would proceed to the next node before install
actually finished.

Add a lightweight HTTP health server (built on raw tokio TcpListener,
no new crate dependencies) that starts immediately in the install path:

  /healthz — liveness: returns 200 as soon as the server binds
  /readyz  — readiness: returns 503 while installing, 200 after
             install completes (artifacts extracted, CRI restarted,
             node labeled)

Wire the Helm chart with startup, liveness, and readiness probes
(all individually toggleable). The startup probe allows up to 10
minutes for install to complete before the liveness probe takes over.