### PR TITLE
Revert "ci: Only run arm64 k8s tests on nightly builds"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -270,7 +270,7 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
 
   run-k8s-tests-on-arm64:
-    if: ${{ inputs.skip-test != 'yes' && inputs.pr-number == 'nightly' }}
+    if: ${{ inputs.skip-test != 'yes' }}
     needs: publish-kata-deploy-payload-arm64
     uses: ./.github/workflows/run-k8s-tests-on-arm64.yaml
     with:
@@ -282,7 +282,7 @@ jobs:
       target-branch: ${{ inputs.target-branch }}
 
   run-kata-coco-tests-on-arm64:
-    if: ${{ inputs.skip-test != 'yes' && inputs.pr-number == 'nightly' }}
+    if: ${{ inputs.skip-test != 'yes' }}
     needs:
       - publish-kata-deploy-payload-arm64
       - build-and-publish-tee-confidential-unencrypted-image


### PR DESCRIPTION
This reverts commit c5b159c556df97cbdfd5ef7717e20a129a5a6ef0, as now we have 3 runners plugged into the CI.