### PR TITLE
agent/remote: add ttrpc connection resilience and re-connection with shim persistence

### DIFF
--- a/src/runtime/pkg/hypervisors/hypervisor_state.go
+++ b/src/runtime/pkg/hypervisors/hypervisor_state.go
@@ -49,4 +49,11 @@ type HypervisorState struct {
 	ColdPlugVFIO      config.PCIePort
 	PCIeRootPort      uint32
 	PCIeSwitchPort    uint32
+
+	// Remote hypervisor specific fields
+
+	// AgentSocketPath is used by the remote hypervisor to persist the agent
+	// tunnel socket path returned by the remote service (e.g. cloud-api-adaptor)
+	// so that it can be restored on shim restart.
+	AgentSocketPath string
 }

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -2766,6 +2766,29 @@ func (k *kataAgent) getReqContext(ctx context.Context, reqName string) (newCtx c
 	return newCtx, cancel
 }
 
+func (k *kataAgent) callWithReconnect(ctx context.Context, fn func() (interface{}, error)) (interface{}, error) {
+	for {
+		if err := k.connect(ctx); err != nil {
+			return nil, err
+		}
+
+		resp, err := fn()
+
+		if err == nil || !isConnectionError(err) {
+			return resp, err
+		}
+
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("connection error and context cancelled: %w", err)
+		}
+
+		k.Logger().WithError(err).Warn("connection error detected, flagging for reconnection")
+		k.Lock()
+		k.dead = true
+		k.Unlock()
+	}
+}
+
 func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (interface{}, error) {
 	start := time.Now()
 
@@ -2785,11 +2808,7 @@ func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (inter
 		agentRPCDurationsHistogram.WithLabelValues(msgName).Observe(float64(time.Since(start).Nanoseconds() / int64(time.Millisecond)))
 	}()
 
-	for {
-		if err := k.connect(spanCtx); err != nil {
-			return nil, err
-		}
-
+	return k.callWithReconnect(spanCtx, func() (interface{}, error) {
 		handler := k.reqHandlers[msgName]
 		if handler == nil {
 			return nil, errors.New("invalid request type")
@@ -2798,24 +2817,11 @@ func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (inter
 		k.Logger().WithField("name", msgName).WithField("req", string(jsonStr)).Trace("sending request")
 
 		ctx, cancel := k.getReqContext(spanCtx, msgName)
-		resp, err := handler(ctx, request)
 		if cancel != nil {
-			cancel()
+			defer cancel()
 		}
-
-		if err == nil || !isConnectionError(err) {
-			return resp, err
-		}
-
-		if spanCtx.Err() != nil {
-			return nil, fmt.Errorf("connection error and context cancelled: %w", err)
-		}
-
-		k.Logger().WithError(err).Warn("connection error detected, flagging for reconnection")
-		k.Lock()
-		k.dead = true
-		k.Unlock()
-	}
+		return handler(ctx, request)
+	})
 }
 
 // readStdout and readStderr are special that we cannot differentiate them with the request types...

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -13,6 +13,8 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -180,7 +182,10 @@ const (
 
 // newKataAgent returns an agent from an agent type.
 func newKataAgent() agent {
-	return &kataAgent{}
+	return &kataAgent{
+		reconnectAttempts: 30,
+		reconnectDelay:    2 * time.Second,
+	}
 }
 
 // The function is declared this way for mocking in unit tests
@@ -209,6 +214,30 @@ func getFSGroupChangePolicy(policy volume.FSGroupChangePolicy) pbTypes.FSGroupCh
 	default:
 		return pbTypes.FSGroupChangePolicy_Always
 	}
+}
+
+func isConnectionError(err error) bool {
+	if err == nil {
+		return false
+	}
+	errStr := err.Error()
+
+	connectionErrors := []string{
+		"ttrpc: closed",
+		"connection refused",
+		"connection reset",
+		"broken pipe",
+		"EOF",
+		"use of closed network connection",
+	}
+	for _, ce := range connectionErrors {
+		if strings.Contains(errStr, ce) {
+			return true
+		}
+	}
+
+	code := grpcStatus.Code(err)
+	return code == codes.Unavailable || code == codes.Aborted
 }
 
 // Shared path handling:
@@ -331,6 +360,9 @@ type kataAgent struct {
 
 	keepConn bool
 	dead     bool
+
+	reconnectAttempts uint
+	reconnectDelay    time.Duration
 }
 
 func (k *kataAgent) Logger() *logrus.Entry {
@@ -2385,33 +2417,110 @@ func (k *kataAgent) statsContainer(ctx context.Context, sandbox *Sandbox, c Cont
 }
 
 func (k *kataAgent) connect(ctx context.Context) error {
-	if k.dead {
-		return errors.New("Dead agent")
-	}
-	// lockless quick pass
-	if k.client != nil {
+	// lockless fast path
+	if !k.dead && k.client != nil {
 		return nil
 	}
 
 	span, _ := katatrace.Trace(ctx, k.Logger(), "connect", kataAgentTracingTags)
 	defer span.End()
 
-	// This is for the first connection only, to prevent race
 	k.Lock()
-	defer k.Unlock()
-	if k.client != nil {
+
+	// re-check under lock
+	if !k.dead && k.client != nil {
+		k.Unlock()
 		return nil
 	}
 
+	if k.dead {
+		if k.state.URL == "" {
+			k.Unlock()
+			return errors.New("dead agent with no URL to reconnect")
+		}
+
+		u, err := url.Parse(k.state.URL)
+		if err != nil {
+			k.Unlock()
+			return fmt.Errorf("dead agent, invalid URL %q: %w", k.state.URL, err)
+		}
+		socketPath := u.Path
+
+		// Release lock while waiting for socket
+		k.Unlock()
+
+		err = retry.Do(
+			func() error {
+				if _, err := os.Stat(socketPath); err != nil {
+					return errors.New("dead agent, socket not available")
+				}
+				conn, err := net.DialTimeout("unix", socketPath, 2*time.Second)
+				if err != nil {
+					return fmt.Errorf("dead agent, socket not connectable: %w", err)
+				}
+				conn.Close()
+				return nil
+			},
+			retry.Attempts(k.reconnectAttempts),
+			retry.Delay(k.reconnectDelay),
+			retry.MaxDelay(10*time.Second),
+			retry.DelayType(retry.BackOffDelay),
+			retry.OnRetry(func(n uint, err error) {
+				k.Logger().WithField("attempt", n+1).WithError(err).Warn("dead agent, waiting for socket...")
+			}),
+			retry.LastErrorOnly(true),
+		)
+		if err != nil {
+			return err
+		}
+
+		k.Logger().Warn("agent was dead but socket is now connectable, attempting reconnection")
+
+		k.Lock()
+		// Another goroutine may have reconnected while we waited
+		if !k.dead && k.client != nil {
+			k.Unlock()
+			return nil
+		}
+		k.dead = false
+	}
+
+	// Lock held, k.dead == false
 	k.Logger().WithField("url", k.state.URL).Info("New client")
-	client, err := kataclient.NewAgentClient(k.ctx, k.state.URL, k.dialTimout)
+
+	// Close old client before creating new one
+	if k.client != nil {
+		k.client.Close()
+	}
+
+	var client *kataclient.AgentClient
+	err := retry.Do(
+		func() error {
+			var err error
+			client, err = kataclient.NewAgentClient(k.ctx, k.state.URL, k.dialTimout)
+			return err
+		},
+		retry.Attempts(k.reconnectAttempts),
+		retry.Delay(k.reconnectDelay),
+		retry.MaxDelay(10*time.Second),
+		retry.DelayType(retry.BackOffDelay),
+		retry.OnRetry(func(n uint, err error) {
+			k.Logger().WithField("attempt", n+1).WithError(err).Warn("agent connection failed, retrying...")
+		}),
+		retry.RetryIf(func(err error) bool {
+			return isConnectionError(err)
+		}),
+		retry.LastErrorOnly(true),
+	)
 	if err != nil {
 		k.dead = true
+		k.Unlock()
 		return err
 	}
 
 	k.installReqFunc(client)
 	k.client = client
+	k.Unlock()
 
 	return nil
 }
@@ -2423,6 +2532,10 @@ func (k *kataAgent) disconnect(ctx context.Context) error {
 	k.Lock()
 	defer k.Unlock()
 
+	return k.disconnectLocked(ctx)
+}
+
+func (k *kataAgent) disconnectLocked(ctx context.Context) error {
 	if k.client == nil {
 		return nil
 	}
@@ -2432,7 +2545,6 @@ func (k *kataAgent) disconnect(ctx context.Context) error {
 	}
 
 	k.client = nil
-	k.reqHandlers = nil
 
 	return nil
 }
@@ -2657,46 +2769,53 @@ func (k *kataAgent) getReqContext(ctx context.Context, reqName string) (newCtx c
 func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (interface{}, error) {
 	start := time.Now()
 
-	if err := k.connect(spanCtx); err != nil {
-		return nil, err
-	}
 	if !k.keepConn {
 		defer k.disconnect(spanCtx)
 	}
 
 	msgName := string(proto.MessageName(request.(proto.Message)))
 
-	k.Lock()
-
-	if k.reqHandlers == nil {
-		k.Unlock()
-		return nil, errors.New("Client has already disconnected")
-	}
-
-	handler := k.reqHandlers[msgName]
-	if msgName == "" || handler == nil {
-		k.Unlock()
-		return nil, errors.New("Invalid request type")
-	}
-
-	k.Unlock()
-
 	message := request.(proto.Message)
-	ctx, cancel := k.getReqContext(spanCtx, msgName)
-	if cancel != nil {
-		defer cancel()
-	}
-
 	jsonStr, err := protojson.Marshal(message)
 	if err != nil {
 		return nil, err
 	}
-	k.Logger().WithField("name", msgName).WithField("req", string(jsonStr)).Trace("sending request")
 
 	defer func() {
 		agentRPCDurationsHistogram.WithLabelValues(msgName).Observe(float64(time.Since(start).Nanoseconds() / int64(time.Millisecond)))
 	}()
-	return handler(ctx, request)
+
+	for {
+		if err := k.connect(spanCtx); err != nil {
+			return nil, err
+		}
+
+		handler := k.reqHandlers[msgName]
+		if handler == nil {
+			return nil, errors.New("invalid request type")
+		}
+
+		k.Logger().WithField("name", msgName).WithField("req", string(jsonStr)).Trace("sending request")
+
+		ctx, cancel := k.getReqContext(spanCtx, msgName)
+		resp, err := handler(ctx, request)
+		if cancel != nil {
+			cancel()
+		}
+
+		if err == nil || !isConnectionError(err) {
+			return resp, err
+		}
+
+		if spanCtx.Err() != nil {
+			return nil, fmt.Errorf("connection error and context cancelled: %w", err)
+		}
+
+		k.Logger().WithError(err).Warn("connection error detected, flagging for reconnection")
+		k.Lock()
+		k.dead = true
+		k.Unlock()
+	}
 }
 
 // readStdout and readStderr are special that we cannot differentiate them with the request types...
@@ -2859,9 +2978,12 @@ func (k *kataAgent) addSwap(ctx context.Context, PCIPath types.PciPath) error {
 }
 
 func (k *kataAgent) markDead(ctx context.Context) {
-	k.Logger().Infof("mark agent dead")
+	k.Lock()
+	defer k.Unlock()
+
+	k.Logger().Info("mark agent dead")
 	k.dead = true
-	k.disconnect(ctx)
+	k.disconnectLocked(ctx)
 }
 
 func (k *kataAgent) cleanup(ctx context.Context) {

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -358,8 +358,9 @@ type kataAgent struct {
 
 	dialTimout uint32
 
-	keepConn bool
-	dead     bool
+	keepConn       bool
+	dead           bool
+	connGeneration uint64
 
 	reconnectAttempts uint
 	reconnectDelay    time.Duration
@@ -2519,6 +2520,7 @@ func (k *kataAgent) connect(ctx context.Context) error {
 	}
 
 	k.installReqFunc(client)
+	k.connGeneration++
 	k.client = client
 	k.Unlock()
 
@@ -2772,6 +2774,10 @@ func (k *kataAgent) callWithReconnect(ctx context.Context, fn func() (interface{
 			return nil, err
 		}
 
+		k.Lock()
+		gen := k.connGeneration
+		k.Unlock()
+
 		resp, err := fn()
 
 		if err == nil || !isConnectionError(err) {
@@ -2782,9 +2788,11 @@ func (k *kataAgent) callWithReconnect(ctx context.Context, fn func() (interface{
 			return nil, fmt.Errorf("connection error and context cancelled: %w", err)
 		}
 
-		k.Logger().WithError(err).Warn("connection error detected, flagging for reconnection")
 		k.Lock()
-		k.dead = true
+		if k.connGeneration == gen {
+			k.Logger().WithError(err).Warn("connection error detected, flagging for reconnection")
+			k.dead = true
+		}
 		k.Unlock()
 	}
 }

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -2824,47 +2824,41 @@ func (k *kataAgent) sendReq(spanCtx context.Context, request interface{}) (inter
 	})
 }
 
-// readStdout and readStderr are special that we cannot differentiate them with the request types...
 func (k *kataAgent) readProcessStdout(ctx context.Context, c *Container, processID string, data []byte) (int, error) {
-	if err := k.connect(ctx); err != nil {
-		return 0, err
-	}
-	if !k.keepConn {
-		defer k.disconnect(ctx)
-	}
-
-	return k.readProcessStream(c.id, processID, data, k.client.AgentServiceClient.ReadStdout)
+	return k.readProcessStreamWithRetry(ctx, c.id, processID, data, false)
 }
 
-// readStdout and readStderr are special that we cannot differentiate them with the request types...
 func (k *kataAgent) readProcessStderr(ctx context.Context, c *Container, processID string, data []byte) (int, error) {
-	if err := k.connect(ctx); err != nil {
-		return 0, err
-	}
+	return k.readProcessStreamWithRetry(ctx, c.id, processID, data, true)
+}
+
+func (k *kataAgent) readProcessStreamWithRetry(ctx context.Context, containerID, processID string, data []byte, stderr bool) (int, error) {
 	if !k.keepConn {
 		defer k.disconnect(ctx)
 	}
 
-	return k.readProcessStream(c.id, processID, data, k.client.AgentServiceClient.ReadStderr)
-}
-
-type readFn func(context.Context, *grpc.ReadStreamRequest) (*grpc.ReadStreamResponse, error)
-
-func (k *kataAgent) readProcessStream(containerID, processID string, data []byte, read readFn) (int, error) {
-	resp, err := read(k.ctx, &grpc.ReadStreamRequest{
+	req := &grpc.ReadStreamRequest{
 		ContainerId: containerID,
 		ExecId:      processID,
-		Len:         uint32(len(data))})
+		Len:         uint32(len(data)),
+	}
+
+	resp, err := k.callWithReconnect(ctx, func() (interface{}, error) {
+		if stderr {
+			return k.client.AgentServiceClient.ReadStderr(k.ctx, req)
+		}
+		return k.client.AgentServiceClient.ReadStdout(k.ctx, req)
+	})
 	if err != nil {
 		return 0, err
 	}
 
-	if len(resp.Data) == 0 {
+	r := resp.(*grpc.ReadStreamResponse)
+	if len(r.Data) == 0 {
 		return 0, io.EOF
 	}
-
-	copy(data, resp.Data)
-	return len(resp.Data), nil
+	copy(data, r.Data)
+	return len(r.Data), nil
 }
 
 func (k *kataAgent) getGuestDetails(ctx context.Context, req *grpc.GuestDetailsRequest) (*grpc.GuestDetailsResponse, error) {

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -8,8 +8,10 @@ package virtcontainers
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path"
 	"path/filepath"
@@ -17,9 +19,12 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
 
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/api"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
@@ -65,6 +70,8 @@ func TestKataAgentConnect(t *testing.T) {
 		state: KataAgentState{
 			URL: url,
 		},
+		reconnectAttempts: 1,
+		reconnectDelay:    100 * time.Millisecond,
 	}
 
 	err = k.connect(context.Background())
@@ -89,6 +96,8 @@ func TestKataAgentDisconnect(t *testing.T) {
 		state: KataAgentState{
 			URL: url,
 		},
+		reconnectAttempts: 1,
+		reconnectDelay:    100 * time.Millisecond,
 	}
 
 	assert.NoError(k.connect(context.Background()))
@@ -127,6 +136,8 @@ func TestKataAgentSendReq(t *testing.T) {
 		state: KataAgentState{
 			URL: url,
 		},
+		reconnectAttempts: 1,
+		reconnectDelay:    100 * time.Millisecond,
 	}
 
 	ctx := context.Background()
@@ -906,6 +917,8 @@ func TestAgentCreateContainer(t *testing.T) {
 		state: KataAgentState{
 			URL: url,
 		},
+		reconnectAttempts: 1,
+		reconnectDelay:    100 * time.Millisecond,
 	}
 
 	dir := t.TempDir()
@@ -935,6 +948,8 @@ func TestAgentNetworkOperation(t *testing.T) {
 		state: KataAgentState{
 			URL: url,
 		},
+		reconnectAttempts: 1,
+		reconnectDelay:    100 * time.Millisecond,
 	}
 
 	_, err = k.updateInterface(k.ctx, nil)
@@ -984,6 +999,8 @@ func TestKataCopyFile(t *testing.T) {
 		state: KataAgentState{
 			URL: url,
 		},
+		reconnectAttempts: 1,
+		reconnectDelay:    100 * time.Millisecond,
 	}
 
 	err = k.copyFile(context.Background(), "/abc/xyz/123", "/tmp")
@@ -1030,6 +1047,8 @@ func TestKataCopyFileWithSymlink(t *testing.T) {
 		state: KataAgentState{
 			URL: url,
 		},
+		reconnectAttempts: 1,
+		reconnectDelay:    100 * time.Millisecond,
 	}
 
 	tempDir := t.TempDir()
@@ -1323,6 +1342,8 @@ func TestKataAgentCreateContainerVFIODevices(t *testing.T) {
 				state: KataAgentState{
 					URL: url,
 				},
+				reconnectAttempts: 1,
+				reconnectDelay:    100 * time.Millisecond,
 			}
 
 			mockReceiver := &api.MockDeviceReceiver{}
@@ -1417,4 +1438,242 @@ func TestTranslateHostMemsToGuestRangeNodes(t *testing.T) {
 
 	result = translateHostMemsToGuest("0,3", numaNodes)
 	assert.Equal("0-1", result)
+}
+
+func TestIsConnectionError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "ttrpc closed",
+			err:      errors.New("ttrpc: closed"),
+			expected: true,
+		},
+		{
+			name:     "connection refused",
+			err:      errors.New("dial unix /path/to/socket: connection refused"),
+			expected: true,
+		},
+		{
+			name:     "connection reset",
+			err:      errors.New("read: connection reset by peer"),
+			expected: true,
+		},
+		{
+			name:     "broken pipe",
+			err:      errors.New("write: broken pipe"),
+			expected: true,
+		},
+		{
+			name:     "EOF",
+			err:      errors.New("unexpected EOF"),
+			expected: true,
+		},
+		{
+			name:     "closed network connection",
+			err:      errors.New("use of closed network connection"),
+			expected: true,
+		},
+		{
+			name:     "grpc unavailable",
+			err:      grpcStatus.Error(codes.Unavailable, "service unavailable"),
+			expected: true,
+		},
+		{
+			name:     "grpc aborted",
+			err:      grpcStatus.Error(codes.Aborted, "operation aborted"),
+			expected: true,
+		},
+		{
+			name:     "grpc not found - not connection error",
+			err:      grpcStatus.Error(codes.NotFound, "not found"),
+			expected: false,
+		},
+		{
+			name:     "normal error",
+			err:      errors.New("some other error"),
+			expected: false,
+		},
+		{
+			name:     "permission denied - not connection error",
+			err:      errors.New("permission denied"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := isConnectionError(tt.err)
+			assert.Equal(t, tt.expected, result, "isConnectionError(%v) = %v, want %v", tt.err, result, tt.expected)
+		})
+	}
+}
+
+func TestConnect_DeadAgentNoURL(t *testing.T) {
+	assert := assert.New(t)
+
+	k := &kataAgent{
+		ctx:  context.Background(),
+		dead: true,
+		state: KataAgentState{
+			URL: "",
+		},
+	}
+
+	err := k.connect(context.Background())
+	assert.Error(err)
+	assert.Contains(err.Error(), "dead agent with no URL to reconnect")
+	assert.True(k.dead, "agent should remain dead")
+}
+
+func TestConnect_DeadAgentNoSocket(t *testing.T) {
+	assert := assert.New(t)
+
+	k := &kataAgent{
+		ctx:               context.Background(),
+		dead:              true,
+		reconnectAttempts: 1,
+		reconnectDelay:    10 * time.Millisecond,
+		state: KataAgentState{
+			URL: "unix:///nonexistent/path/to/socket.sock",
+		},
+	}
+
+	err := k.connect(context.Background())
+	assert.Error(err)
+	assert.Contains(err.Error(), "socket not available")
+	assert.True(k.dead, "agent should remain dead")
+}
+
+func TestConnect_DeadAgentSocketNotConnectable(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpFile, err := os.CreateTemp("", "fake-socket-*")
+	assert.NoError(err)
+	defer os.Remove(tmpFile.Name())
+	tmpFile.Close()
+
+	k := &kataAgent{
+		ctx:               context.Background(),
+		dead:              true,
+		reconnectAttempts: 1,
+		reconnectDelay:    10 * time.Millisecond,
+		state: KataAgentState{
+			URL: "unix://" + tmpFile.Name(),
+		},
+	}
+
+	err = k.connect(context.Background())
+	assert.Error(err)
+	assert.Contains(err.Error(), "socket not connectable")
+	assert.True(k.dead, "agent should remain dead")
+}
+
+func TestConnect_DeadAgentWithSocket(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpDir, err := os.MkdirTemp("", "kata-test-*")
+	assert.NoError(err)
+	defer os.RemoveAll(tmpDir)
+
+	socketPath := filepath.Join(tmpDir, "test.sock")
+	listener, err := net.Listen("unix", socketPath)
+	assert.NoError(err)
+	defer listener.Close()
+
+	k := &kataAgent{
+		ctx:               context.Background(),
+		dead:              true,
+		reconnectAttempts: 1,
+		reconnectDelay:    10 * time.Millisecond,
+		state: KataAgentState{
+			URL: "unix://" + socketPath,
+		},
+	}
+
+	assert.True(k.dead)
+	assert.Nil(k.client)
+
+	err = k.connect(context.Background())
+
+	// Should attempt reconnection, not reject with "Dead agent"
+	assert.Error(err)
+	assert.NotContains(err.Error(), "Dead agent")
+	assert.NotContains(err.Error(), "dead agent with no URL")
+	assert.NotContains(err.Error(), "socket not available")
+	assert.NotContains(err.Error(), "socket not connectable")
+}
+
+func TestMarkDeadNormal(t *testing.T) {
+	assert := assert.New(t)
+
+	k := &kataAgent{
+		ctx:  context.Background(),
+		dead: false,
+	}
+
+	k.markDead(context.Background())
+
+	assert.True(k.dead, "markDead should set dead")
+}
+
+func TestSendReqWithRetry_ReconnectsAfterServerBreak(t *testing.T) {
+	assert := assert.New(t)
+
+	url, err := mock.GenerateKataMockHybridVSock()
+	assert.NoError(err)
+	defer mock.RemoveKataMockHybridVSock(url)
+
+	server := mock.HybridVSockTTRPCMock{}
+	err = server.Start(url)
+	assert.NoError(err)
+
+	k := &kataAgent{
+		ctx: context.Background(),
+		state: KataAgentState{
+			URL: url,
+		},
+		keepConn:          true,
+		reconnectAttempts: 3,
+		reconnectDelay:    100 * time.Millisecond,
+	}
+
+	// Phase 1: Initial RPC succeeds
+	_, err = k.sendReq(context.Background(), &pb.CheckRequest{})
+	assert.NoError(err)
+	assert.False(k.dead)
+	assert.NotNil(k.client)
+	assert.NotNil(k.reqHandlers)
+	originalClient := k.client
+
+	// Server-side close — tears down listener and all active connections
+	err = server.Stop()
+	assert.NoError(err)
+
+	// Phase 2: RPC fails, reconnection also fails (server is down)
+	_, err = k.sendReq(context.Background(), &pb.CheckRequest{})
+	assert.Error(err)
+	assert.True(k.dead)
+	assert.NotNil(k.reqHandlers, "reqHandlers should never be nil'd")
+
+	// Restart server on the same URL
+	server2 := mock.HybridVSockTTRPCMock{}
+	err = server2.Start(url)
+	assert.NoError(err)
+	defer server2.Stop()
+
+	// Phase 3: RPC succeeds — connect() recovers from dead state
+	_, err = k.sendReq(context.Background(), &pb.CheckRequest{})
+	assert.NoError(err)
+	assert.False(k.dead)
+	assert.NotNil(k.client)
+	assert.NotNil(k.reqHandlers)
+	assert.True(k.client != originalClient, "should be a fresh connection")
 }

--- a/src/runtime/virtcontainers/monitor.go
+++ b/src/runtime/virtcontainers/monitor.go
@@ -14,8 +14,9 @@ import (
 )
 
 const (
-	defaultCheckInterval = 5 * time.Second
-	watcherChannelSize   = 128
+	defaultCheckInterval    = 5 * time.Second
+	watcherChannelSize      = 128
+	defaultFailureThreshold = 12
 )
 
 var monitorLog = virtLog.WithField("subsystem", "virtcontainers/monitor")
@@ -31,7 +32,9 @@ type monitor struct {
 	stopCh        chan bool
 	checkInterval time.Duration
 
-	running bool
+	running             bool
+	consecutiveFailures int
+	failureThreshold    int
 }
 
 func newMonitor(s *Sandbox) *monitor {
@@ -39,9 +42,10 @@ func newMonitor(s *Sandbox) *monitor {
 	// so it's safe to let monitorLog as a global variable.
 	monitorLog = monitorLog.WithField("sandbox", s.ID())
 	return &monitor{
-		sandbox:       s,
-		checkInterval: defaultCheckInterval,
-		stopCh:        make(chan bool, 1),
+		sandbox:          s,
+		checkInterval:    defaultCheckInterval,
+		stopCh:           make(chan bool, 1),
+		failureThreshold: defaultFailureThreshold,
 	}
 }
 
@@ -142,8 +146,20 @@ func (m *monitor) stop() {
 func (m *monitor) watchAgent(ctx context.Context) {
 	err := m.sandbox.agent.check(ctx)
 	if err != nil {
-		// TODO: define and export error types
-		m.notify(ctx, errors.Wrapf(err, "failed to ping agent"))
+		m.consecutiveFailures++
+		monitorLog.WithField("consecutive", m.consecutiveFailures).
+			WithField("threshold", m.failureThreshold).
+			WithError(err).Warn("agent health check failed")
+
+		// TODO: define and export error tyoes
+		if m.consecutiveFailures >= m.failureThreshold {
+			m.notify(ctx, errors.Wrapf(err, "failed to ping agent after %d consecutive attempts", m.consecutiveFailures))
+		}
+		return
+	}
+	if m.consecutiveFailures > 0 {
+		monitorLog.WithField("recovered_after", m.consecutiveFailures).Info("agent recovered")
+		m.consecutiveFailures = 0
 	}
 }
 

--- a/src/runtime/virtcontainers/monitor_test.go
+++ b/src/runtime/virtcontainers/monitor_test.go
@@ -37,6 +37,153 @@ func TestMonitorSuccess(t *testing.T) {
 	m.stop()
 }
 
+type failingAgent struct {
+	kataAgent
+	shouldFail     bool
+	markDeadCalled bool
+}
+
+func (a *failingAgent) check(ctx context.Context) error {
+	if a.shouldFail {
+		return errors.New("agent unreachable")
+	}
+	return nil
+}
+
+func (a *failingAgent) markDead(ctx context.Context) {
+	a.markDeadCalled = true
+}
+
+func TestWatchAgentFailureThreshold(t *testing.T) {
+	assert := assert.New(t)
+
+	agent := &failingAgent{shouldFail: true}
+	s := &Sandbox{}
+	s.agent = agent
+
+	m := newMonitor(s)
+	m.failureThreshold = 3
+
+	ch, err := m.newWatcher(context.Background())
+	assert.Nil(err)
+
+	// Simulate check failures below threshold — no notification expected
+	for i := 0; i < 2; i++ {
+		m.watchAgent(context.Background())
+		assert.Equal(i+1, m.consecutiveFailures)
+		select {
+		case <-ch:
+			t.Fatal("should not notify before threshold")
+		default:
+		}
+	}
+
+	// Third failure hits threshold — notification expected
+	m.watchAgent(context.Background())
+	assert.Equal(3, m.consecutiveFailures)
+	select {
+	case err := <-ch:
+		assert.Contains(err.Error(), "failed to ping agent")
+	default:
+		t.Fatal("should have notified at threshold")
+	}
+
+	m.stop()
+}
+
+func TestWatchAgentRecovery(t *testing.T) {
+	assert := assert.New(t)
+
+	agent := &failingAgent{shouldFail: true}
+	s := &Sandbox{}
+	s.agent = agent
+
+	m := newMonitor(s)
+	m.failureThreshold = 5
+
+	_, err := m.newWatcher(context.Background())
+	assert.Nil(err)
+
+	// Accumulate some failures
+	m.watchAgent(context.Background())
+	m.watchAgent(context.Background())
+	assert.Equal(2, m.consecutiveFailures)
+
+	// Simulate recovery
+	agent.shouldFail = false
+	m.watchAgent(context.Background())
+	assert.Equal(0, m.consecutiveFailures)
+
+	m.stop()
+}
+
+func TestWatchAgentRecoveryResetsThreshold(t *testing.T) {
+	assert := assert.New(t)
+
+	agent := &failingAgent{shouldFail: true}
+	s := &Sandbox{}
+	s.agent = agent
+
+	m := newMonitor(s)
+	m.failureThreshold = 3
+
+	ch, err := m.newWatcher(context.Background())
+	assert.Nil(err)
+
+	// Fail twice, then recover
+	m.watchAgent(context.Background())
+	m.watchAgent(context.Background())
+	assert.Equal(2, m.consecutiveFailures)
+
+	agent.shouldFail = false
+	m.watchAgent(context.Background())
+	assert.Equal(0, m.consecutiveFailures)
+
+	// Fail again — should need 3 more failures from zero, not 1
+	agent.shouldFail = true
+	m.watchAgent(context.Background())
+	m.watchAgent(context.Background())
+	assert.Equal(2, m.consecutiveFailures)
+
+	select {
+	case <-ch:
+		t.Fatal("should not notify before threshold after recovery")
+	default:
+	}
+
+	// Third failure post-recovery hits threshold
+	m.watchAgent(context.Background())
+	assert.Equal(3, m.consecutiveFailures)
+
+	select {
+	case err := <-ch:
+		assert.Contains(err.Error(), "failed to ping agent")
+	default:
+		t.Fatal("should have notified at threshold")
+	}
+
+	m.stop()
+}
+
+func TestWatchAgentThresholdCallsMarkDead(t *testing.T) {
+	assert := assert.New(t)
+
+	agent := &failingAgent{shouldFail: true}
+	s := &Sandbox{}
+	s.agent = agent
+
+	m := newMonitor(s)
+	m.failureThreshold = 1
+
+	_, err := m.newWatcher(context.Background())
+	assert.Nil(err)
+
+	m.watchAgent(context.Background())
+	assert.True(agent.markDeadCalled, "notify should have called markDead")
+
+	m.stop()
+}
+
 func TestMonitorClosedChannel(t *testing.T) {
 	contID := "505"
 	contConfig := newTestContainerConfigNoop(contID)

--- a/src/runtime/virtcontainers/pkg/mock/mock.go
+++ b/src/runtime/virtcontainers/pkg/mock/mock.go
@@ -49,7 +49,8 @@ type HybridVSockTTRPCMock struct {
 	// the ttrpc interface we want the mock hybrid-vsock server to serve.
 	HybridVSockTTRPCMockImp
 
-	listener net.Listener
+	listener    net.Listener
+	ttrpcServer *ttrpc.Server
 }
 
 func (hv *HybridVSockTTRPCMock) ttrpcRegister(s *ttrpc.Server) {
@@ -80,6 +81,7 @@ func (hv *HybridVSockTTRPCMock) Start(socketAddr string) error {
 		return err
 	}
 	hv.ttrpcRegister(ttrpcServer)
+	hv.ttrpcServer = ttrpcServer
 
 	go func() {
 		ttrpcServer.Serve(context.Background(), l)
@@ -88,12 +90,14 @@ func (hv *HybridVSockTTRPCMock) Start(socketAddr string) error {
 	return nil
 }
 
-// Stop stops the ttrpc-based mock hybrid-vsock server
+// Stop stops the ttrpc-based mock hybrid-vsock server, closing all active connections.
 func (hv *HybridVSockTTRPCMock) Stop() error {
-	if hv.listener == nil {
-		return fmt.Errorf("Missing mock hvbrid vsock listener")
+	if hv.ttrpcServer != nil {
+		return hv.ttrpcServer.Close()
 	}
-
+	if hv.listener == nil {
+		return fmt.Errorf("Missing mock hybrid vsock listener")
+	}
 	return hv.listener.Close()
 }
 

--- a/src/runtime/virtcontainers/remote.go
+++ b/src/runtime/virtcontainers/remote.go
@@ -21,7 +21,11 @@ import (
 	"github.com/pkg/errors"
 )
 
-const defaultMinTimeout = 60
+const (
+	defaultMinTimeout       = 60
+	defaultRetryAttempts    = 5
+	defaultRetryBaseDelay   = time.Second
+)
 
 type remoteHypervisor struct {
 	sandboxID       remoteHypervisorSandboxID
@@ -37,8 +41,21 @@ type remoteService struct {
 }
 
 func openRemoteService(socketPath string) (*remoteService, error) {
+	return openRemoteServiceWithRetry(socketPath, defaultRetryAttempts, defaultRetryBaseDelay)
+}
 
-	conn, err := net.Dial("unix", socketPath)
+func openRemoteServiceWithRetry(socketPath string, maxAttempts int, baseDelay time.Duration) (*remoteService, error) {
+	var conn net.Conn
+	var err error
+
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		conn, err = net.Dial("unix", socketPath)
+		if err == nil {
+			break
+		}
+		hvLogger.WithField("attempt", attempt+1).WithError(err).Warn("failed to connect to remote hypervisor, retrying...")
+		time.Sleep(time.Duration(1<<attempt) * baseDelay)
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to remote hypervisor socket: %w", err)
 	}
@@ -60,11 +77,16 @@ func (s *remoteService) Close() error {
 }
 
 func (rh *remoteHypervisor) CreateVM(ctx context.Context, id string, network Network, hypervisorConfig *HypervisorConfig) error {
+	if err := rh.setConfig(hypervisorConfig); err != nil {
+		return err
+	}
 
 	rh.sandboxID = remoteHypervisorSandboxID(id)
 
-	if err := rh.setConfig(hypervisorConfig); err != nil {
-		return err
+	// Check if we're reconnecting to an existing sandbox (state was restored via Load())
+	if rh.agentSocketPath != "" {
+		hvLogger.Infof("remoteHypervisor: reconnecting to existing sandbox %s", rh.sandboxID)
+		return nil
 	}
 
 	s, err := openRemoteService(hypervisorConfig.RemoteHypervisorSocket)
@@ -286,12 +308,14 @@ func (rh *remoteHypervisor) Check() error {
 	return nil
 }
 
-func (rh *remoteHypervisor) Save() persistapi.HypervisorState {
-	return persistapi.HypervisorState{}
+func (rh *remoteHypervisor) Save() (s persistapi.HypervisorState) {
+	s.AgentSocketPath = rh.agentSocketPath
+	return
 }
 
-func (rh *remoteHypervisor) Load(persistapi.HypervisorState) {
-	notImplemented("Load")
+func (rh *remoteHypervisor) Load(s persistapi.HypervisorState) {
+	rh.agentSocketPath = s.AgentSocketPath
+	hvLogger.Infof("remoteHypervisor: restored agentSocketPath from state (set=%v)", s.AgentSocketPath)
 }
 
 func (rh *remoteHypervisor) IsRateLimiterBuiltin() bool {

--- a/src/runtime/virtcontainers/remote_test.go
+++ b/src/runtime/virtcontainers/remote_test.go
@@ -4,8 +4,14 @@
 package virtcontainers
 
 import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
+	persistapi "github.com/kata-containers/kata-containers/src/runtime/pkg/hypervisors"
 	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
 	"github.com/stretchr/testify/assert"
 )
@@ -42,4 +48,91 @@ func TestRemoteHypervisorGenerateSocket(t *testing.T) {
 		TunnelSocketPath: socketPath,
 	}
 	assert.Equal(result, expected)
+}
+
+func TestRemoteHypervisorSaveLoad(t *testing.T) {
+	assert := assert.New(t)
+
+	// Create a remote hypervisor with state
+	rh := &remoteHypervisor{
+		sandboxID:       remoteHypervisorSandboxID("test-sandbox-123"),
+		agentSocketPath: "/run/peerpod/pods/test-sandbox-123/agent.sock",
+		config:          newRemoteConfig(),
+	}
+
+	// Save the state
+	savedState := rh.Save()
+
+	// Verify saved state contains expected values
+	assert.Equal("/run/peerpod/pods/test-sandbox-123/agent.sock", savedState.AgentSocketPath)
+
+	// Create a new remote hypervisor (simulating restart)
+	rh2 := &remoteHypervisor{
+		config: newRemoteConfig(),
+	}
+
+	// Verify initial state is empty
+	assert.Empty(rh2.agentSocketPath)
+
+	// Load the saved state
+	rh2.Load(savedState)
+
+	// Verify state was restored
+	assert.Equal("/run/peerpod/pods/test-sandbox-123/agent.sock", rh2.agentSocketPath)
+}
+
+func TestCreateVMReconnectsWithRestoredState(t *testing.T) {
+	assert := assert.New(t)
+
+	rh := &remoteHypervisor{
+		config: newRemoteConfig(),
+	}
+
+	rh.Load(persistapi.HypervisorState{
+		AgentSocketPath: "/run/peerpod/pods/test-sandbox-123/agent.sock",
+	})
+
+	config := newRemoteConfig()
+	err := rh.CreateVM(context.Background(), "test-sandbox-123", nil, &config)
+	assert.NoError(err)
+
+	assert.Equal("/run/peerpod/pods/test-sandbox-123/agent.sock", rh.agentSocketPath)
+	assert.Equal(remoteHypervisorSandboxID("test-sandbox-123"), rh.sandboxID)
+}
+
+func TestOpenRemoteServiceRetry(t *testing.T) {
+	assert := assert.New(t)
+
+	// Test 1: Non-existent socket should fail after retries
+	t.Run("fails after retries on non-existent socket", func(t *testing.T) {
+		start := time.Now()
+		_, err := openRemoteServiceWithRetry("/nonexistent/path/to/socket.sock", 3, 10*time.Millisecond)
+		elapsed := time.Since(start)
+
+		assert.Error(err)
+		assert.Contains(err.Error(), "failed to connect to remote hypervisor socket")
+		assert.True(elapsed >= 10*time.Millisecond, "should have retried with delay, elapsed: %v", elapsed)
+		assert.True(elapsed < 1*time.Second, "should complete quickly with short base delay, elapsed: %v", elapsed)
+	})
+
+	// Test 2: Valid socket connects successfully
+	t.Run("connects to valid socket", func(t *testing.T) {
+		tmpDir, err := os.MkdirTemp("", "remote-test-*")
+		assert.NoError(err)
+		defer os.RemoveAll(tmpDir)
+
+		socketPath := filepath.Join(tmpDir, "test.sock")
+		listener, err := net.Listen("unix", socketPath)
+		assert.NoError(err)
+		defer listener.Close()
+
+		svc, err := openRemoteServiceWithRetry(socketPath, 3, 10*time.Millisecond)
+		assert.NoError(err)
+		assert.NotNil(svc)
+		assert.NotNil(svc.conn)
+		assert.NotNil(svc.client)
+
+		err = svc.Close()
+		assert.NoError(err)
+	})
 }


### PR DESCRIPTION
When cloud-api-adaptor restarts (upgrade, crash, scaling event), the kata shim survives but its ttrpc connection to the agent becomes stale. Today, a broken connection is permanent meaning the agent is marked dead with no recovery, and the only option is to tear down and recreate the sandbox.

This PR makes the kata shim and agent resilient to connection disruptions in peer pod environments, where the cloud-api-adaptor or agent-protocol-forwarder may restart independently and this ensures there are no disruptions on user workloads running in the podVMs.

Closes: rhjira#KATA-4920