### PR TITLE
runtime-rs: qemu: add CCW network hotplug & retry update_interface

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -72,6 +72,10 @@ impl VirtioBusType {
             VirtioBusType::Ccw => "ccw",
         }
     }
+
+    fn supports_disable_modern(&self) -> bool {
+        matches!(self, VirtioBusType::Pci)
+    }
 }
 
 impl Display for VirtioBusType {
@@ -1134,7 +1138,7 @@ impl ToQemuParams for VhostVsock {
     async fn qemu_params(&self) -> Result<Vec<String>> {
         let mut params = Vec::new();
         params.push(format!("vhost-vsock-{}", self.bus_type));
-        if self.disable_modern {
+        if self.disable_modern && self.bus_type.supports_disable_modern() {
             params.push("disable-modern=true".to_owned());
         }
         if self.iommu_platform {
@@ -1364,7 +1368,7 @@ impl ToQemuParams for DeviceVirtioNet {
 
         params.push(format!("mac={:?}", self.mac_address));
 
-        if self.disable_modern {
+        if self.disable_modern && self.bus_type.supports_disable_modern() {
             params.push("disable-modern=true".to_owned());
         }
         if self.iommu_platform {
@@ -1813,7 +1817,7 @@ impl ToQemuParams for DeviceVirtioScsi {
         let mut params = Vec::new();
         params.push(format!("virtio-scsi-{}", self.bus_type));
         params.push(format!("id={}", self.id));
-        if self.disable_modern {
+        if self.disable_modern && self.bus_type.supports_disable_modern() {
             params.push("disable-modern=true".to_owned());
         }
         if !self.iothread.is_empty() {
@@ -2186,6 +2190,10 @@ fn is_running_in_vm() -> Result<bool> {
 }
 
 fn should_disable_modern() -> bool {
+    if !bus_type().supports_disable_modern() {
+        return false;
+    }
+
     match is_running_in_vm() {
         Ok(retval) => retval,
         Err(err) => {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -486,14 +486,44 @@ impl Qmp {
         netdev: &Netdev,
         virtio_net_device: &DeviceVirtioNet,
     ) -> Result<()> {
-        debug!(
-            sl!(),
-            "hotplug_network_device(): PCI before {}: {:#?}",
-            virtio_net_device.get_netdev_id(),
-            self.qmp.execute(&qapi_qmp::query_pci {})?
-        );
+        let use_ccw_bus = crate::utils::uses_native_ccw_bus();
+        let netdev_id = netdev.get_id().clone();
 
-        let (bus, slot) = self.find_free_slot()?;
+        let mut netdev_frontend_args = Dictionary::new();
+        netdev_frontend_args.insert(
+            "netdev".to_owned(),
+            virtio_net_device.get_netdev_id().clone().into(),
+        );
+        netdev_frontend_args.insert("mac".to_owned(), virtio_net_device.get_mac_addr().into());
+        netdev_frontend_args.insert("mq".to_owned(), true.into());
+
+        let frontend_id = format!("frontend-{}", virtio_net_device.get_netdev_id());
+
+        let bus = if use_ccw_bus {
+            let subchannel = self.ccw_subchannel.as_mut().ok_or_else(|| {
+                anyhow!("CCW subchannel not available for virtio-net-ccw hotplug")
+            })?;
+            let slot = subchannel
+                .add_device(&frontend_id)
+                .map_err(|e| anyhow!("CCW subchannel add_device failed: {:?}", e))?;
+            let devno = subchannel.address_format_ccw(slot);
+            netdev_frontend_args.insert("devno".to_owned(), devno.into());
+            None
+        } else {
+            let (bus, slot) = self.find_free_slot()?;
+            netdev_frontend_args.insert("addr".to_owned(), format!("{slot:02}").into());
+            // As the golang runtime documents the vectors computation, it's
+            // 2N+2 vectors, N for tx queues, N for rx queues, 1 for config,
+            // and one for possible control vq.  PCI-specific (MSI-X).
+            netdev_frontend_args.insert(
+                "vectors".to_owned(),
+                (2 * virtio_net_device.get_num_queues() + 2).into(),
+            );
+            if virtio_net_device.get_disable_modern() {
+                netdev_frontend_args.insert("disable-modern".to_owned(), true.into());
+            }
+            Some(bus)
+        };
 
         let mut fd_names = vec![];
         for (idx, fd) in netdev.get_fds().iter().enumerate() {
@@ -511,7 +541,7 @@ impl Qmp {
 
         self.qmp
             .execute(&qapi_qmp::netdev_add(qapi_qmp::Netdev::tap {
-                id: netdev.get_id().clone(),
+                id: netdev_id.clone(),
                 tap: qapi_qmp::NetdevTapOptions {
                     br: None,
                     downscript: None,
@@ -539,38 +569,48 @@ impl Qmp {
                     vhostforce: None,
                     vnet_hdr: None,
                 },
-            }))?;
+            }))
+            .map_err(|e| {
+                if use_ccw_bus {
+                    if let Some(subchannel) = self.ccw_subchannel.as_mut() {
+                        let _ = subchannel.remove_device(&frontend_id);
+                    }
+                }
 
-        let mut netdev_frontend_args = Dictionary::new();
-        netdev_frontend_args.insert(
-            "netdev".to_owned(),
-            virtio_net_device.get_netdev_id().clone().into(),
-        );
-        netdev_frontend_args.insert("addr".to_owned(), format!("{slot:02}").into());
-        netdev_frontend_args.insert("mac".to_owned(), virtio_net_device.get_mac_addr().into());
-        netdev_frontend_args.insert("mq".to_owned(), true.into());
-        // As the golang runtime documents the vectors computation, it's
-        // 2N+2 vectors, N for tx queues, N for rx queues, 1 for config, and one for possible control vq
-        netdev_frontend_args.insert(
-            "vectors".to_owned(),
-            (2 * virtio_net_device.get_num_queues() + 2).into(),
-        );
-        if virtio_net_device.get_disable_modern() {
-            netdev_frontend_args.insert("disable-modern".to_owned(), true.into());
-        }
+                anyhow!(e)
+            })?;
 
-        self.qmp.execute(&qmp::device_add {
-            bus: Some(bus),
-            id: Some(format!("frontend-{}", virtio_net_device.get_netdev_id())),
+        let device_add_result = self.qmp.execute(&qmp::device_add {
+            bus,
+            id: Some(frontend_id.clone()),
             driver: virtio_net_device.get_device_driver().clone(),
             arguments: netdev_frontend_args,
-        })?;
+        });
+        if let Err(e) = device_add_result {
+            if use_ccw_bus {
+                if let Some(subchannel) = self.ccw_subchannel.as_mut() {
+                    let _ = subchannel.remove_device(&frontend_id);
+                }
+            }
+
+            if let Err(del_err) = self.qmp.execute(&qmp::netdev_del {
+                id: netdev_id.clone(),
+            }) {
+                warn!(
+                    sl!(),
+                    "hotplug_network_device(): netdev_del failed for {} after device_add error {:?}: {:?}",
+                    netdev_id,
+                    e,
+                    del_err
+                );
+            }
+
+            return Err(e.into());
+        }
 
         debug!(
             sl!(),
-            "hotplug_network_device(): PCI after {}: {:#?}",
-            virtio_net_device.get_netdev_id(),
-            self.qmp.execute(&qapi_qmp::query_pci {})?
+            "hotplug_network_device(): successfully added {}", frontend_id
         );
 
         Ok(())

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -7,7 +7,7 @@
 use std::{collections::HashMap, sync::Arc, thread};
 
 use agent::{types::Device, ARPNeighbor, Agent, OnlineCPUMemRequest, Storage};
-use anyhow::{anyhow, Context, Ok, Result};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use hypervisor::{
     device::{
@@ -250,12 +250,42 @@ impl ResourceManagerInner {
 
     async fn handle_interfaces(&self, network: &dyn Network) -> Result<()> {
         for i in network.interfaces().await.context("get interfaces")? {
-            // update interface
             info!(sl!(), "update interface {:?}", i);
-            self.agent
-                .update_interface(agent::UpdateInterfaceRequest { interface: Some(i) })
-                .await
-                .context("update interface")?;
+
+            // After hotplugging a network device, the guest kernel needs time
+            // to probe it before the interface appears.  This is especially
+            // pronounced on s390x (CCW bus) but can also happen on x86 in
+            // slower CI environments.  Retry a few times.
+            let mut last_error = None;
+            for attempt in 0..10u32 {
+                match self
+                    .agent
+                    .update_interface(agent::UpdateInterfaceRequest {
+                        interface: Some(i.clone()),
+                    })
+                    .await
+                {
+                    core::result::Result::Ok(_) => {
+                        last_error = None;
+                        break;
+                    }
+                    core::result::Result::Err(e) => {
+                        debug!(
+                            sl!(),
+                            "update_interface attempt {} failed, retrying: {:?}",
+                            attempt + 1,
+                            e
+                        );
+                        last_error = Some(e);
+                        if attempt < 9 {
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                        }
+                    }
+                }
+            }
+            if let Some(err) = last_error {
+                return Err(err).context("update interface");
+            }
         }
 
         Ok(())


### PR DESCRIPTION
On s390x, QEMU uses the CCW bus instead of PCI.  The network device hotplug path was hardcoded to find a PCI slot, which fails with "no free slots on PCI bridges" on s390x.

Add CCW support to `hotplug_network_device`: when running on a native CCW bus, allocate a CCW subchannel address and use `devno` instead of PCI `bus`/`addr`/`vectors`.

Additionally, after hotplugging a network device, the guest kernel needs time to probe the CCW device before the network interface appears.  Add a retry loop (up to 10 attempts, 100ms apart) to `handle_interfaces` so that `update_interface` succeeds once the guest has created the link.