### PR TITLE
agent: disable ext4 lazy inode init for CDH

### DIFF
--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -2405,6 +2405,11 @@ fn is_sealed_secret_path(source_path: &str) -> bool {
             .any(|suffix| source_path.ends_with(suffix))
 }
 
+// CDH formats unwiped dm-integrity devices. Make ext4 initialize inode tables
+// during mkfs so later metadata operations do not read blocks without integrity
+// tags and fail with EIO.
+const TRUSTED_IMAGE_STORAGE_MKFS_OPTS: &str = "-E lazy_journal_init,lazy_itable_init=0";
+
 async fn cdh_handler_trusted_storage(oci: &mut Spec) -> Result<()> {
     let linux = oci
         .linux()
@@ -2420,7 +2425,7 @@ async fn cdh_handler_trusted_storage(oci: &mut Spec) -> Result<()> {
                     &dev_major_minor,
                     "luks2",
                     KATA_IMAGE_WORK_DIR,
-                    "-E lazy_journal_init",
+                    TRUSTED_IMAGE_STORAGE_MKFS_OPTS,
                 )
                 .await?;
                 break;

--- a/src/agent/src/storage/block_handler.rs
+++ b/src/agent/src/storage/block_handler.rs
@@ -37,6 +37,12 @@ use slog::Logger;
 #[cfg(target_arch = "s390x")]
 use std::str::FromStr;
 
+// CDH formats an unwiped dm-integrity device. Make ext4 initialize inode tables
+// during mkfs so later metadata operations do not read blocks without integrity
+// tags and fail with EIO.
+const SECURE_EPHEMERAL_MKFS_OPTS: &str =
+    "-O ^has_journal -m 0 -i 163840 -I 128 -E lazy_itable_init=0";
+
 fn get_device_number(dev_path: &str, metadata: Option<&fs::Metadata>) -> Result<String> {
     let dev_id = match metadata {
         Some(m) => m.rdev(),
@@ -64,7 +70,7 @@ async fn handle_block_storage(
             dev_num,
             "luks2",
             &storage.mount_point,
-            "-O ^has_journal -m 0 -i 163840 -I 128",
+            SECURE_EPHEMERAL_MKFS_OPTS,
         )
         .await?;
         set_ownership(logger, storage)?;

--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -86,8 +86,6 @@ setup_langchain_flow() {
 # generated policy.rego to it and set it as the cc_init_data annotation.
 # We must overwrite the default empty file AFTER create_tmp_policy_settings_dir()
 # copies it to the temp directory.
-# As we use multiple vCPUs we set `max_concurrent_layer_downloads_per_image = 1`,
-# see: https://github.com/kata-containers/kata-containers/issues/12721
 create_nim_initdata_file() {
     local output_file="$1"
     local cc_kbs_address
@@ -110,7 +108,6 @@ name = "cc_kbc"
 url = "${cc_kbs_address}"
 
 [image]
-max_concurrent_layer_downloads_per_image = 1
 authenticated_registry_credentials_uri = "kbs:///default/credentials/nvcr"
 image_security_policy_uri = "kbs:///default/security-policy/nim"
 '''

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-guest-pull-in-trusted-storage.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-guest-pull-in-trusted-storage.yaml.in
@@ -28,6 +28,9 @@ spec:
       command: ["/bin/sh", "-c"]
       args:
         - sleep 6000
+      resources:
+        limits:
+          cpu: "2"
       volumeDevices:
         - devicePath: /dev/trusted_store
           name: trusted-storage


### PR DESCRIPTION
CDH formats no-wipe dm-integrity devices for trusted image storage and secure ephemeral block storage. ext4's default lazy inode table initialization can leave inode table blocks unwritten during mkfs. Later metadata operations may then read blocks that do not have valid integrity tags yet, causing EIO under parallel activity.

Pass lazy_itable_init=0 for both CDH secure_mount call sites and exercise the image-layer path with concurrent pulls in CI by allowing multiple CPUs and removing the NIM layer-download throttle.