### PR TITLE
build: add nvgpu-tarball target

### DIFF
--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -118,6 +118,7 @@ nvgpu-tarball:
 		BASE_TARBALLS="$(NVGPU_BASE_TARBALLS)" \
 		BASE_SERIAL_TARBALLS="rootfs-image-nvidia-gpu-tarball rootfs-image-nvidia-gpu-confidential-tarball" \
 		FINAL_TARBALL_INPUTS="$(NVGPU_FINAL_TARBALL_INPUTS)" \
+		FINAL_TARBALL_MERGE_MODE=passthrough \
 		DEPS=
 else
 nvgpu-tarball:
@@ -304,12 +305,15 @@ kata-deploy-binary-tarball:
 nydus-snapshotter-for-coco-guest-pull-tarball:
 	$(call BUILD_KATA_DEPLOY_COMPONENT,nydus-snapshotter-for-coco-guest-pull)
 
+FINAL_TARBALL_MERGE_MODE ?= merge
+
 merge-builds:
 	$(MK_DIR)/kata-deploy-merge-builds.sh \
 		build \
 		"$(MK_DIR)/../../../../versions.yaml" \
 		kata-static.tar.zst \
-		"$(FINAL_TARBALL_INPUTS)"
+		"$(FINAL_TARBALL_INPUTS)" \
+		"$(FINAL_TARBALL_MERGE_MODE)"
 
 .PHONY: install-prebuilt-artifacts
 install-prebuilt-artifacts:

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -247,6 +247,7 @@ nydus-snapshotter-for-coco-guest-pull-tarball:
 merge-builds:
 	$(MK_DIR)/kata-deploy-merge-builds.sh build "$(MK_DIR)/../../../../versions.yaml"
 
+.PHONY: install-prebuilt-artifacts
 install-prebuilt-artifacts:
 	mv kata-artifacts $(MK_DIR)/build
 

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -146,7 +146,7 @@ copy-scripts-for-the-tools-build:
 	${MK_DIR}/kata-deploy-copy-libseccomp-installer.sh "tools"
 
 all-parallel:
-	${MAKE} -f $(MK_PATH) all -j $(shell nproc) V=
+	${MAKE} -f $(MK_PATH) all -j $(shell nproc) --output-sync=target V=
 	${MAKE} -f $(MK_PATH) shim-v2-go-tarball shim-v2-rust-tarball V=
 
 all: ${BASE_TARBALLS}

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -69,6 +69,61 @@ BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-initrd-tarball
 endif
 
+ifeq ($(ARCH), x86_64)
+NVGPU_BASE_TARBALLS = \
+	agent-tarball \
+	busybox-tarball \
+	coco-guest-components-tarball \
+	kernel-nvidia-gpu-tarball \
+	ovmf-sev-tarball \
+	ovmf-tdx-tarball \
+	ovmf-tarball \
+	pause-image-tarball \
+	qemu-snp-experimental-tarball \
+	qemu-tdx-experimental-tarball \
+	qemu-tarball \
+	virtiofsd-tarball \
+	serial-targets
+else ifeq ($(ARCH), aarch64)
+NVGPU_BASE_TARBALLS = \
+	agent-tarball \
+	busybox-tarball \
+	coco-guest-components-tarball \
+	kernel-nvidia-gpu-tarball \
+	ovmf-tarball \
+	pause-image-tarball \
+	qemu-tarball \
+	virtiofsd-tarball \
+	serial-targets
+endif
+NVGPU_FINAL_TARBALL_INPUTS = \
+	kata-static-kernel-nvidia-gpu.tar.zst \
+	kata-static-ovmf-sev.tar.zst \
+	kata-static-ovmf-tdx.tar.zst \
+	kata-static-ovmf.tar.zst \
+	kata-static-pause-image.tar.zst \
+	kata-static-qemu-snp-experimental.tar.zst \
+	kata-static-qemu-tdx-experimental.tar.zst \
+	kata-static-qemu.tar.zst \
+	kata-static-virtiofsd.tar.zst \
+	kata-static-rootfs-image-nvidia-gpu.tar.zst \
+	kata-static-rootfs-image-nvidia-gpu-confidential.tar.zst \
+	kata-static-shim-v2-go.tar.zst \
+	kata-static-shim-v2-rust.tar.zst
+
+
+ifneq ($(NVGPU_BASE_TARBALLS),)
+nvgpu-tarball:
+	${MAKE} -f $(MK_PATH) kata-tarball \
+		BASE_TARBALLS="$(NVGPU_BASE_TARBALLS)" \
+		BASE_SERIAL_TARBALLS="rootfs-image-nvidia-gpu-tarball rootfs-image-nvidia-gpu-confidential-tarball" \
+		FINAL_TARBALL_INPUTS="$(NVGPU_FINAL_TARBALL_INPUTS)" \
+		DEPS=
+else
+nvgpu-tarball:
+	@echo "nvgpu-tarball: unsupported on $(ARCH)"; exit 1
+endif
+
 define BUILD
 	$(MK_DIR)/kata-deploy-binaries-in-docker.sh $(if $(V),,-s) --build=$1
 endef
@@ -92,12 +147,17 @@ copy-scripts-for-the-tools-build:
 
 all-parallel:
 	${MAKE} -f $(MK_PATH) all -j $(shell nproc) V=
+	${MAKE} -f $(MK_PATH) shim-v2-go-tarball shim-v2-rust-tarball V=
 
 all: ${BASE_TARBALLS}
 
-serial-targets:
+serial-targets: $(filter-out serial-targets,$(BASE_TARBALLS))
 	${MAKE} -f $(MK_PATH) -j 1 V= \
 	${BASE_SERIAL_TARBALLS}
+
+# Optional explicit allowlist for merge-builds input tarballs.
+# Keep empty for normal targets; set explicitly for NVIDIA flow.
+FINAL_TARBALL_INPUTS ?=
 
 %-tarball-build:
 	$(call BUILD,$*)
@@ -245,7 +305,11 @@ nydus-snapshotter-for-coco-guest-pull-tarball:
 	$(call BUILD_KATA_DEPLOY_COMPONENT,nydus-snapshotter-for-coco-guest-pull)
 
 merge-builds:
-	$(MK_DIR)/kata-deploy-merge-builds.sh build "$(MK_DIR)/../../../../versions.yaml"
+	$(MK_DIR)/kata-deploy-merge-builds.sh \
+		build \
+		"$(MK_DIR)/../../../../versions.yaml" \
+		kata-static.tar.zst \
+		"$(FINAL_TARBALL_INPUTS)"
 
 .PHONY: install-prebuilt-artifacts
 install-prebuilt-artifacts:

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -49,8 +49,10 @@ if [[ "${CROSS_BUILD}" == "true" ]]; then
        [[ -z "${r}" ]] && sudo docker run --privileged --rm tonistiigi/binfmt --install "${TARGET_ARCH}"
 fi
 
-if [[ "${script_dir}" != "${PWD}" ]]; then
-	ln -sf "${script_dir}/build" "${PWD}/build"
+if [[ "${script_dir}" != "${PWD}" && ! -L "${PWD}/build" ]]; then
+	# If a parallel job creates the link between the check and our ln,
+	# accept that and move on; any other failure aborts.
+	ln -s "${script_dir}/build" "${PWD}/build" 2>/dev/null || [[ -L "${PWD}/build" ]]
 fi
 
 # This is the gid of the "docker" group on host. In case of docker in docker builds
@@ -66,7 +68,9 @@ fi
 
 remove_dot_docker_dir=false
 if [[ ! -d "${HOME}/.docker" ]]; then
-	mkdir "${HOME}"/.docker
+	# Tolerate the dir being created by a parallel job between the check
+	# above and this mkdir.
+	mkdir -p "${HOME}"/.docker
 	remove_dot_docker_dir=true
 fi
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -16,6 +16,7 @@ repo_root_dir="$(cd "${this_script_dir}/../../../../" && pwd)"
 kata_build_dir=${1:-build}
 kata_versions_yaml_file=${2:-""}
 output_tarball_name=${3:-kata-static.tar.zst}
+known_tarballs=${4:-""}
 
 tar_path=$(readlink -f "${output_tarball_name}")
 [[ -n "${kata_versions_yaml_file}" ]] && kata_versions_yaml_file=$(readlink -f "${kata_versions_yaml_file}")
@@ -25,8 +26,18 @@ tarball_content_dir="${PWD}/kata-tarball-content"
 rm -rf "${tarball_content_dir}"
 mkdir "${tarball_content_dir}"
 
-for c in kata-static-*.tar.zst
-do
+for c in ${known_tarballs:-kata-static-*.tar.zst}; do
+	if [[ ! -f "${c}" ]]; then
+		# When the caller provided an explicit allowlist, a missing entry
+		# means the build produced an incomplete artifact set; fail loudly
+		# instead of silently shipping a partial final tarball.
+		if [[ -n "${known_tarballs}" ]]; then
+			echo "ERROR: required tarball \"${c}\" is missing in ${PWD}" >&2
+			exit 1
+		fi
+		echo "skipping missing tarball \"${c}\""
+		continue
+	fi
 	echo "untarring tarball \"${c}\" into ${tarball_content_dir}"
 	tar --zstd -xvf "${c}" -C "${tarball_content_dir}"
 done

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -17,6 +17,7 @@ kata_build_dir=${1:-build}
 kata_versions_yaml_file=${2:-""}
 output_tarball_name=${3:-kata-static.tar.zst}
 known_tarballs=${4:-""}
+merge_mode=${5:-merge}
 
 tar_path=$(readlink -f "${output_tarball_name}")
 if [[ -n "${kata_versions_yaml_file}" ]]; then
@@ -45,26 +46,35 @@ for c in ${known_tarballs:-kata-static-*.tar.zst}; do
 		echo "skipping missing tarball \"${c}\""
 		continue
 	fi
-	echo "untarring tarball \"${c}\" into ${tarball_content_dir}"
-	tar --zstd -xvf "${c}" -C "${tarball_content_dir}"
+	if [[ "${merge_mode}" == "passthrough" ]]; then
+		echo "copying tarball \"${c}\" into ${tarball_content_dir}"
+		cp "${c}" "${tarball_content_dir}/"
+	else
+		echo "untarring tarball \"${c}\" into ${tarball_content_dir}"
+		tar --zstd -xvf "${c}" -C "${tarball_content_dir}"
+	fi
 done
 
 pushd "${tarball_content_dir}"
-	any_binary=$(find . -path "*/opt/kata/bin/*" -type f | head -1)
-	if [[ -z "${any_binary}" ]]; then
-		echo "Error: No binaries found in opt/kata/bin/" >&2
-		exit 1
-	fi
-	prefix=${any_binary%bin/*}
-
-	if [[ "${RELEASE:-no}" == "yes" ]] && [[ -f "${repo_root_dir}/VERSION" ]]; then
-		# In this case the tag was not published yet,
-		# thus we need to rely on the VERSION file.
-		cp "${repo_root_dir}/VERSION" "${prefix}/"
+	if [[ "${merge_mode}" == "passthrough" ]]; then
+		[[ -n "${kata_versions_yaml_file}" ]] && cp "${kata_versions_yaml_file}" .
 	else
-		git describe --tags > "${prefix}/VERSION"
+		any_binary=$(find . -path "*/opt/kata/bin/*" -type f | head -1)
+		if [[ -z "${any_binary}" ]]; then
+			echo "Error: No binaries found in opt/kata/bin/" >&2
+			exit 1
+		fi
+		prefix=${any_binary%bin/*}
+
+		if [[ "${RELEASE:-no}" == "yes" ]] && [[ -f "${repo_root_dir}/VERSION" ]]; then
+			# In this case the tag was not published yet,
+			# thus we need to rely on the VERSION file.
+			cp "${repo_root_dir}/VERSION" "${prefix}/"
+		else
+			git describe --tags > "${prefix}/VERSION"
+		fi
+		[[ -n "${kata_versions_yaml_file}" ]] && cp "${kata_versions_yaml_file}" "${prefix}/"
 	fi
-	[[ -n "${kata_versions_yaml_file}" ]] && cp "${kata_versions_yaml_file}" "${prefix}/"
 popd
 
 echo "create ${tar_path}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-merge-builds.sh
@@ -19,7 +19,14 @@ output_tarball_name=${3:-kata-static.tar.zst}
 known_tarballs=${4:-""}
 
 tar_path=$(readlink -f "${output_tarball_name}")
-[[ -n "${kata_versions_yaml_file}" ]] && kata_versions_yaml_file=$(readlink -f "${kata_versions_yaml_file}")
+if [[ -n "${kata_versions_yaml_file}" ]]; then
+	# We pushd into ${kata_build_dir} below, so resolve this path before that.
+	case "${kata_versions_yaml_file}" in
+		/*) ;;
+		*) kata_versions_yaml_file="${PWD}/${kata_versions_yaml_file}" ;;
+	esac
+	kata_versions_yaml_file=$(readlink -f "${kata_versions_yaml_file}")
+fi
 
 pushd "${kata_build_dir}"
 tarball_content_dir="${PWD}/kata-tarball-content"

--- a/tools/packaging/static-build/qemu/build-qemu.sh
+++ b/tools/packaging/static-build/qemu/build-qemu.sh
@@ -27,6 +27,7 @@ kata_static_build_scripts="${kata_static_build_dir}/scripts"
 
 ARCH=${ARCH:-$(uname -m)}
 
+rm -rf qemu
 git clone --depth=1 "${QEMU_REPO}" qemu
 pushd qemu
 git fetch --depth=1 origin "${QEMU_VERSION_NUM}"


### PR DESCRIPTION
`serial-targets` now waits for the other BASE_TARBALLS items, so the inner rootfs assembly runs with DEPS= set against already-built artifacts. This also fixes a pre-existing race in the main flows where the outer parallel and inner `-j 1`  `make` could both build the kernel tarball at the same time.

DependsOn: https://github.com/kata-containers/kata-containers/pull/12954