### PR TITLE
build: add kata-deploy-publish target 

### DIFF
--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -190,14 +190,13 @@ jobs:
 
       - name: Push helm chart to the OCI registries
         run: |
-          echo "Adjusting the Chart.yaml and values.yaml"
-          yq eval '.version = "0.0.0-dev" | .appVersion = "0.0.0-dev"' -i tools/packaging/kata-deploy/helm-chart/kata-deploy/Chart.yaml
-          yq eval '.image.reference = "quay.io/kata-containers/kata-deploy-ci" | .image.tag = "kata-containers-latest"' -i tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
-
-          echo "Generating the chart package"
-          helm dependencies update tools/packaging/kata-deploy/helm-chart/kata-deploy
-          helm package tools/packaging/kata-deploy/helm-chart/kata-deploy
-
-          echo "Pushing the chart to the OCI registries"
-          helm push "kata-deploy-0.0.0-dev.tgz" oci://quay.io/kata-containers/kata-deploy-charts
-          helm push "kata-deploy-0.0.0-dev.tgz" oci://ghcr.io/kata-containers/kata-deploy-charts
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-helm-chart.sh \
+            quay.io/kata-containers/kata-deploy-ci \
+            kata-containers-latest \
+            quay.io/kata-containers/kata-deploy-charts \
+            0.0.0-dev
+          ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-helm-chart.sh \
+            quay.io/kata-containers/kata-deploy-ci \
+            kata-containers-latest \
+            ghcr.io/kata-containers/kata-deploy-charts \
+            0.0.0-dev

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -332,3 +332,15 @@ install-prebuilt-artifacts:
 
 install-tarball:
 	tar --zstd -xf ./kata-static.tar.zst -C /
+
+# Push the kata-deploy image and helm chart for the host arch. Caller is
+# responsible for `docker login` / `helm registry login` before invoking.
+# This target expects explicit REGISTRY/TAG/CHART_REGISTRY/CHART_VERSION args.
+kata-deploy-publish:
+	@set -eu; \
+	tmpdir="$$(mktemp -d)"; \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	tar --zstd -xf "$(CURDIR)/kata-static.tar.zst" -C "$$tmpdir"; \
+	"$(MK_DIR)/kata-deploy-build-and-upload-payload.sh" "$(REGISTRY)" "$(TAG)" "$$tmpdir"; \
+	"$(MK_DIR)/kata-deploy-build-and-upload-helm-chart.sh" \
+		"$(REGISTRY)" "$(TAG)" "$(CHART_REGISTRY)" "$(CHART_VERSION)"

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -69,11 +69,17 @@ BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-initrd-tarball
 endif
 
+PUBLISH_COMPONENT_TARBALLS = \
+	kata-deploy-binary-tarball \
+	nydus-snapshotter-for-coco-guest-pull-tarball
+
 ifeq ($(ARCH), x86_64)
+
 NVGPU_BASE_TARBALLS = \
 	agent-tarball \
 	busybox-tarball \
 	coco-guest-components-tarball \
+	$(PUBLISH_COMPONENT_TARBALLS) \
 	kernel-nvidia-gpu-tarball \
 	ovmf-sev-tarball \
 	ovmf-tdx-tarball \
@@ -89,6 +95,7 @@ NVGPU_BASE_TARBALLS = \
 	agent-tarball \
 	busybox-tarball \
 	coco-guest-components-tarball \
+	$(PUBLISH_COMPONENT_TARBALLS) \
 	kernel-nvidia-gpu-tarball \
 	ovmf-tarball \
 	pause-image-tarball \
@@ -96,7 +103,11 @@ NVGPU_BASE_TARBALLS = \
 	virtiofsd-tarball \
 	serial-targets
 endif
+# Include kata-deploy static payload tarballs so `make kata-deploy-publish`
+# can consume a single nvgpu bundle without rebuilding extra components.
 NVGPU_FINAL_TARBALL_INPUTS = \
+	kata-deploy-static-kata-deploy-binary.tar.zst \
+	kata-deploy-static-nydus-snapshotter-for-coco-guest-pull.tar.zst \
 	kata-static-kernel-nvidia-gpu.tar.zst \
 	kata-static-ovmf-sev.tar.zst \
 	kata-static-ovmf-tdx.tar.zst \

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-helm-chart.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-helm-chart.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+[[ -z "${DEBUG:-}" ]] || set -x
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o errtrace
+
+REGISTRY="${1:?REGISTRY required (e.g. quay.io/myuser/kata-deploy)}"
+TAG="${2:?TAG required (image tag)}"
+CHART_REGISTRY="${3:?CHART_REGISTRY required (e.g. quay.io/myuser/kata-deploy-charts)}"
+CHART_VERSION="${4:?CHART_VERSION required (chart semver)}"
+KEEP_TMPDIR="${KEEP_TMPDIR:-}"
+
+CHART_SRC="$(cd "$(dirname "${0}")/../helm-chart/kata-deploy" && pwd)"
+
+tmp="$(mktemp -d)"
+trap '[[ -n "${KEEP_TMPDIR}" ]] && echo "kept: ${tmp}" || rm -rf "${tmp}"' EXIT
+
+cp -r "${CHART_SRC}" "${tmp}/"
+yq eval ".version = \"${CHART_VERSION}\" | .appVersion = \"${CHART_VERSION}\"" -i "${tmp}/kata-deploy/Chart.yaml"
+yq eval ".image.reference = \"${REGISTRY}\" | .image.tag = \"${TAG}\"" -i "${tmp}/kata-deploy/values.yaml"
+helm dependencies update "${tmp}/kata-deploy"
+helm package "${tmp}/kata-deploy" -d "${tmp}"
+helm push "${tmp}/kata-deploy-${CHART_VERSION}.tgz" "oci://${CHART_REGISTRY}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -16,9 +16,9 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
 
 REGISTRY="${1:-"quay.io/kata-containers/kata-deploy"}"
 TAG="${2:-}"
+ARTIFACTS_BUILD_DIR="${3:-${REPO_ROOT}/tools/packaging/kata-deploy/local-build/build}"
 
 KATA_DEPLOY_DIR="${REPO_ROOT}/tools/packaging/kata-deploy"
-ARTIFACTS_BUILD_DIR="${KATA_DEPLOY_DIR}/local-build/build"
 ARTIFACTS_STAGE_DIR="${KATA_DEPLOY_DIR}/kata-artifacts"
 
 # Stage the component tarballs into a directory that is visible to the


### PR DESCRIPTION
Mirrors the CI publish chain (image push + helm chart push) in a single local make target so non-CI flows can validate end-to-end without round-tripping through GitHub Actions.

DependsOn: https://github.com/kata-containers/kata-containers/pull/12955