### PR TITLE
runtime-rs/virtiofsd: read queue size from config

### DIFF
--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -97,6 +97,9 @@ virtio_fs_daemon = "@DEFVIRTIOFSDAEMON@"
 # Default size of DAX cache in MiB
 virtio_fs_cache_size = @DEFVIRTIOFSCACHESIZE@
 
+# Default size of virtqueues
+virtio_fs_queue_size = @DEFVIRTIOFSQUEUESIZE@
+
 # Extra args for virtiofsd daemon
 #
 # Format example:

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -45,9 +45,6 @@ use std::path::PathBuf;
 
 const VIRTIO_FS: &str = "virtio-fs";
 
-pub const DEFAULT_FS_QUEUES: usize = 1;
-const DEFAULT_FS_QUEUE_SIZE: u16 = 1024;
-
 impl CloudHypervisorInner {
     pub(crate) async fn add_device(&mut self, device: DeviceType) -> Result<DeviceType> {
         if self.state != VmmState::VmRunning {
@@ -143,17 +140,8 @@ impl CloudHypervisorInner {
             ));
         }
 
-        let num_queues: usize = if device.config.queue_num > 0 {
-            device.config.queue_num as usize
-        } else {
-            DEFAULT_FS_QUEUES
-        };
-
-        let queue_size: u16 = if device.config.queue_num > 0 {
-            u16::try_from(device.config.queue_size)?
-        } else {
-            DEFAULT_FS_QUEUE_SIZE
-        };
+        let num_queues = device.config.queue_num as usize;
+        let queue_size = u16::try_from(device.config.queue_size)?;
 
         let socket_path = if device.config.sock_path.starts_with('/') {
             PathBuf::from(device.config.sock_path)
@@ -545,17 +533,8 @@ impl TryFrom<ShareFsSettings> for FsConfig {
         let cfg = settings.cfg;
         let vm_path = settings.vm_path;
 
-        let num_queues: usize = if cfg.queue_num > 0 {
-            cfg.queue_num as usize
-        } else {
-            DEFAULT_FS_QUEUES
-        };
-
-        let queue_size: u16 = if cfg.queue_num > 0 {
-            u16::try_from(cfg.queue_size)?
-        } else {
-            DEFAULT_FS_QUEUE_SIZE
-        };
+        let num_queues = cfg.queue_num as usize;
+        let queue_size = u16::try_from(cfg.queue_size)?;
 
         let socket_path = if cfg.sock_path.starts_with('/') {
             PathBuf::from(cfg.sock_path)

--- a/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/device_manager.rs
@@ -12,7 +12,7 @@ use std::{
 
 use anyhow::{anyhow, Context, Result};
 use kata_sys_util::rand::RandomBytes;
-use kata_types::config::hypervisor::{BlockDeviceInfo, TopologyConfigInfo, VIRTIO_SCSI};
+use kata_types::config::hypervisor::{BlockDeviceInfo, SharedFsInfo, TopologyConfigInfo, VIRTIO_SCSI};
 use tokio::sync::{Mutex, RwLock};
 
 use crate::{
@@ -124,6 +124,10 @@ impl DeviceManager {
 
     async fn get_block_device_info(&self) -> BlockDeviceInfo {
         self.hypervisor.hypervisor_config().await.blockdev_info
+    }
+
+    async fn get_shared_fs_info(&self) -> SharedFsInfo {
+        self.hypervisor.hypervisor_config().await.shared_fs
     }
 
     async fn try_add_device(&mut self, device_id: &str) -> Result<()> {
@@ -712,6 +716,10 @@ pub async fn do_update_device(
 
 pub async fn get_block_device_info(d: &RwLock<DeviceManager>) -> BlockDeviceInfo {
     d.read().await.get_block_device_info().await
+}
+
+pub async fn get_shared_fs_info(d: &RwLock<DeviceManager>) -> SharedFsInfo {
+    d.read().await.get_shared_fs_info().await
 }
 
 #[cfg(test)]

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs.rs
@@ -12,7 +12,7 @@ use tokio::sync::RwLock;
 
 use hypervisor::{
     device::{
-        device_manager::{do_handle_device, do_update_device, DeviceManager},
+        device_manager::{do_handle_device, do_update_device, get_shared_fs_info, DeviceManager},
         driver::{ShareFsMountConfig, ShareFsMountOperation, ShareFsMountType},
         DeviceConfig,
     },
@@ -54,8 +54,12 @@ pub(crate) async fn prepare_virtiofs(
         sock_path: generate_sock_path(root),
         mount_tag: String::from(MOUNT_GUEST_TAG),
         fs_type: fs_type.to_string(),
-        queue_size: 0,
-        queue_num: 0,
+        // Pull virtio-fs queue size from the hypervisor config so the value
+        // configured via `virtio_fs_queue_size` in the toml actually reaches
+        // the VMM device line. There is currently no toml knob for the number
+        // of virtqueues, so we use a single queue (matching the prior default).
+        queue_size: get_shared_fs_info(d).await.virtio_fs_queue_size as u64,
+        queue_num: 1,
         options: vec![],
         mount_config: None,
     };


### PR DESCRIPTION
Generated-by: Github Copilot

I'll clean up the commit messages and address any lint when I'm back from vacation, but this draft is a spoiler for when I'll return.

* `virtio_fs_queue_size` wasn't being read from the config for runtime-rs QEMU/CLH.
* Runtime-rs/CLH would hardcode to 1024.
* Runtime-rs/QEMU wouldn't specify a queue size and QEMU would default to 128.