### PR TITLE
gatekeeper: require codegen

### DIFF
--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -175,6 +175,7 @@ mapping:
       - Static checks / build-checks / check (sudo -E PATH="$PATH" make test, trace-forwarder, src/tools/trace-forwarder, rust, ubuntu-2...
       - Static checks / build-checks-depending-on-kvm (runtime-rs)
       - Static checks / check-kernel-config-version
+      - Static checks / codegen
       - Static checks / static-checks (make static-checks)
       - Spelling check / check-spelling
       # static-checks-self-hosted.yaml


### PR DESCRIPTION
The codegen check ensures that generated files are up-to-date and correspond to the tool versions used in CI. Requiring this check prevents us from accidentally merging, e.g., proto changes without the corresponding Rust/Go updates.