### PR TITLE
genpolicy: include test binaries in make target build

### DIFF
--- a/src/tools/genpolicy/Makefile
+++ b/src/tools/genpolicy/Makefile
@@ -25,6 +25,7 @@ default: build
 
 build: $(GENERATED_FILES)
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release)
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo test -p genpolicy --no-run --all-targets --all-features --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release)
 
 static-checks-build:
 	@echo "INFO: static-checks-build do nothing.."
@@ -34,7 +35,7 @@ clean:
 	rm -f $(GENERATED_FILES)
 
 test: $(GENERATED_FILES)
-	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo test -p genpolicy --all-targets --all-features --target $(TRIPLE)
+	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo test -p genpolicy --all-targets --all-features --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release)
 
 install: $(GENERATED_FILES)
 	@RUSTFLAGS="$(EXTRA_RUSTFLAGS) --deny warnings" cargo install --locked --target $(TRIPLE) --path .


### PR DESCRIPTION
genpolicy supports building and testing on Darwin, both for Kata developers as well as for users of the tool. In CI, we're currently only testing the binary build on darwin, the test is only executed on Linux. Since we aim to support development on darwin, including test execution, we need to prevent regressions such as [1]. This commit adds the test binaries to the `make build` target, such that they are covered by `ci/darwin-tests.sh`.

In order to avoid unnecessary recompilation between the build and test target, we align the `--release` handling between the two.

[1]: 639ff3578d4d8f01627cbd79400503be814d8f8c