### PR TITLE
release: fix release workflow concurrency deadlock

### DIFF
--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -12,7 +12,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-release-amd64
   cancel-in-progress: false # Note - don't cancel the in progress build as we could end up with inconsistent results
 
 permissions: {}

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -12,7 +12,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-release-arm64
   cancel-in-progress: false # Note - don't cancel the in progress build as we could end up with inconsistent results
 
 permissions: {}

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -10,7 +10,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-release-ppc64le
   cancel-in-progress: false # Note - don't cancel the in progress build as we could end up with inconsistent results
 
 permissions: {}

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -12,7 +12,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}-release-s390x
   cancel-in-progress: false # Note - don't cancel the in progress build as we could end up with inconsistent results
 
 permissions: {}


### PR DESCRIPTION
Architecture-specific release workflows were using the same concurrency group when called from release.yaml, causing GitHub Actions to detect a deadlock and cancel the builds.

Fix by appending architecture suffix to each workflow's concurrency group, allowing parallel execution without conflicts.

Assisted-by: IBM Bob