### PR TITLE
ci: nvidia: Disable NVRC trace logging on nightly runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -310,6 +310,7 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       pr-number: ${{ inputs.pr-number }}
       target-branch: ${{ inputs.target-branch }}
+      enable-nvrc-trace: ${{ inputs.pr-number != 'nightly' }}
     secrets:
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
 

--- a/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
+++ b/.github/workflows/run-k8s-tests-on-nvidia-gpu.yaml
@@ -24,6 +24,10 @@ on:
         required: false
         type: string
         default: ""
+      enable-nvrc-trace:
+        required: false
+        type: boolean
+        default: true
     secrets:
       NGC_API_KEY:
         required: true
@@ -111,6 +115,7 @@ jobs:
         run: bash tests/integration/kubernetes/gha-run.sh run-nv-tests
         env:
           NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
+          ENABLE_NVRC_TRACE: ${{ inputs.enable-nvrc-trace }}
 
       - name: Report tests
         if: always()


### PR DESCRIPTION
On nightly CI, run the NVIDIA GPU tests without setting nvrc.log=trace. This gives us end-to-end test coverage that more closely matches how users would actually run Kata Containers with NVIDIA GPUs, since trace logging is not enabled by default in production.

NVRC trace logging remains enabled for PR runs, where the extra verbosity is useful for debugging failures.