### PR TITLE
ci: mariner: use OCI version 1.2.1

### DIFF
--- a/src/tools/genpolicy/drop-in-examples/README.md
+++ b/src/tools/genpolicy/drop-in-examples/README.md
@@ -23,8 +23,8 @@ Drop-ins are layered: `10-*` files set the platform base, `20-*` files overlay O
 | `10-non-coco-drop-in.json` | Non-confidential guest (e.g. standard VMs) |
 | `10-non-coco-aks-drop-in.json` | Non-confidential guest on AKS |
 | `10-non-coco-aks-cbl-mariner-drop-in.json` | Non-confidential guest on AKS with CBL-Mariner host |
-| `20-oci-1.2.0-drop-in.json` | OCI bundle version 1.2.0 (e.g. CBL-Mariner) |
-| `20-oci-1.2.1-drop-in.json` | OCI bundle version 1.2.1 (e.g. k3s, rke2, NVIDIA GPU) |
+| `20-oci-1.2.0-drop-in.json` | OCI bundle version 1.2.0 |
+| `20-oci-1.2.1-drop-in.json` | OCI bundle version 1.2.1 (e.g. k3s, rke2, NVIDIA GPU, CBL-Mariner) |
 | `20-oci-1.3.0-drop-in.json` | OCI bundle version 1.3.0 (e.g. containerd 2.2.x) |
 | `20-experimental-force-guest-pull-drop-in.json` | Disable guest pull |
 

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -151,7 +151,7 @@ install_genpolicy_drop_ins() {
 
 	# 20-* OCI version overlay
 	if [[ "${KATA_HOST_OS:-}" == "cbl-mariner" ]]; then
-		cp "${examples_dir}/20-oci-1.2.0-drop-in.json" "${settings_d}/"
+		cp "${examples_dir}/20-oci-1.2.1-drop-in.json" "${settings_d}/"
 	elif is_k3s_or_rke2 || is_nvidia_gpu_platform || is_snp_hypervisor "${KATA_HYPERVISOR}" || is_tdx_hypervisor "${KATA_HYPERVISOR}" || [[ -n "${CONTAINER_ENGINE_VERSION:-}" ]] || is_arm64_host; then
 		cp "${examples_dir}/20-oci-1.3.0-drop-in.json" "${settings_d}/"
 	fi


### PR DESCRIPTION
Mariner moved from version 1.2.0 to version 1.2.1.