### PR TITLE
tests: k8s-cron-job: set runtimeClassName to kata

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/cron-job.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/cron-job.yaml
@@ -8,6 +8,7 @@ spec:
     spec:
       template:
         spec:
+          runtimeClassName: kata
           containers:
           - name: pi
             image: quay.io/prometheus/busybox:latest


### PR DESCRIPTION
The cron-job test workload was missing `runtimeClassName: kata`, which meant the cron job was not actually being executed under the Kata runtime, defeating the purpose of the test.

Set it explicitly, consistent with the sibling `job.yaml` workload.