### PR TITLE
runtime-rs: network: use provided name for virt interface lookup

### DIFF
--- a/src/runtime-rs/crates/resource/src/network/network_pair.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_pair.rs
@@ -49,12 +49,16 @@ impl NetworkPair {
         let unique_id = kata_sys_util::rand::UUID::new();
         let model = network_model::new(model).context("new network model")?;
         let tap_iface_name = format!("tap{idx}{TAP_SUFFIX}");
-        let virt_iface_name = format!("eth{idx}");
+        let virt_iface_name = if name.is_empty() {
+            format!("eth{idx}")
+        } else {
+            String::from(name)
+        };
         let tap_link = create_link(handle, &tap_iface_name, queues)
             .await
             .context("create link")?;
 
-        let virt_link = get_link_by_name(handle, virt_iface_name.clone().as_str())
+        let virt_link = get_link_by_name(handle, virt_iface_name.as_str())
             .await
             .context("get link by name")?;
 
@@ -106,7 +110,7 @@ impl NetworkPair {
             .await
             .context("set link up")?;
 
-        let mut net_pair = NetworkPair {
+        let net_pair = NetworkPair {
             tap: TapInterface {
                 id: String::from(&unique_id),
                 name: format!("br{idx}{TAP_SUFFIX}"),
@@ -124,10 +128,6 @@ impl NetworkPair {
             model,
             network_qos: false,
         };
-
-        if !name.is_empty() {
-            net_pair.virt_iface.name = String::from(name);
-        }
 
         Ok(net_pair)
     }


### PR DESCRIPTION
NetworkPair::new() always constructed the virtual interface name as "eth{idx}" and looked it up in the network namespace. This works for regular veth endpoints created by CNI (which names them eth0, eth1, etc.), but fails for interfaces injected by Multus with different names (e.g. "net1" for mlx5 Scalable Functions).

The `name` parameter was only applied after the lookup to override the stored name, which is too late — the lookup already failed with "No such device (os error 19)".

Use the provided name directly for the lookup when it is non-empty, falling back to "eth{idx}" only when no name is given. This also removes the now-redundant post-creation name override.