### PR TITLE
genpolicy: ignore additional irrelevant fields

### DIFF
--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -104,6 +104,9 @@ pub struct PodSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     priority: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    schedulerName: Option<String>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -195,6 +195,9 @@ struct Affinity {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct PodAffinity {
     #[serde(skip_serializing_if = "Option::is_none")]
+    preferredDuringSchedulingIgnoredDuringExecution: Option<Vec<WeightedPodAffinityTerm>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     requiredDuringSchedulingIgnoredDuringExecution: Option<Vec<PodAffinityTerm>>,
 }
 
@@ -206,7 +209,6 @@ struct PodAntiAffinity {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     requiredDuringSchedulingIgnoredDuringExecution: Option<Vec<PodAffinityTerm>>,
-    // TODO: additional fields.
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.
@@ -223,7 +225,18 @@ struct PodAffinityTerm {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     labelSelector: Option<yaml::LabelSelector>,
-    // TODO: additional fields.
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    matchLabelKeys: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    mismatchLabelKeys: Option<Vec<String>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    namespaceSelector: Option<yaml::LabelSelector>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    namespaces: Option<Vec<String>>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -98,6 +98,9 @@ pub struct PodSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     priorityClassName: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    preemptionPolicy: Option<String>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -101,6 +101,9 @@ pub struct PodSpec {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     preemptionPolicy: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    priority: Option<i32>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -344,4 +344,9 @@ mod tests {
     async fn test_create_container_gpu_vfio_cdi() {
         runtests("createcontainer/gpu_vfio_cdi").await;
     }
+
+    #[tokio::test]
+    async fn test_create_container_ignored_fields() {
+        runtests("createcontainer/ignored_fields").await;
+    }
 }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
@@ -9,3 +9,27 @@ spec:
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
   priority: 1
   schedulerName: test-scheduler-name
+  affinity:
+    podAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchExpressions:
+          - key: app
+            operator: In
+            values:
+            - database
+        topologyKey: topology.kubernetes.io/zone
+        matchLabelKeys:
+        - pod-template-hash
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+      - mismatchLabelKeys:
+        - tenant
+        labelSelector:
+          matchExpressions:
+          - key: tenant
+            operator: Exists
+        topologyKey: node-pool
+        namespaceSelector: {}
+        namespaces:
+        - shared-services

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: policy-ignored-fields
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+  - name: redis
+    image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+  priority: 1

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
@@ -8,3 +8,4 @@ spec:
   - name: redis
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
   priority: 1
+  schedulerName: test-scheduler-name

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/testcases.json
@@ -1,0 +1,279 @@
+[
+  {
+    "allowed": true,
+    "description": "ignore some of the input YAML fields",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+          "io.katacontainers.pkg.oci.container_type": "pod_sandbox",
+          "io.kubernetes.cri.container-type": "sandbox",
+          "io.kubernetes.cri.podsandbox.image-name": "registry.k8s.io/pause:3.10",
+          "io.kubernetes.cri.sandbox-cpu-period": "100000",
+          "io.kubernetes.cri.sandbox-cpu-quota": "0",
+          "io.kubernetes.cri.sandbox-cpu-shares": "102",
+          "io.kubernetes.cri.sandbox-id": "4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+          "io.kubernetes.cri.sandbox-log-directory": "/var/log/pods/default_policy-ignored-fields_9c64c5bf-298f-46c4-ad63-e2270a2ff44c",
+          "io.kubernetes.cri.sandbox-memory": "0",
+          "io.kubernetes.cri.sandbox-name": "policy-ignored-fields",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "9c64c5bf-298f-46c4-ad63-e2270a2ff44c",
+          "nerdctl/network-namespace": "/var/run/netns/cni-22190131-6f68-2878-6d7b-418baf176cdf"
+        },
+        "Hooks": null,
+        "Hostname": "policy-ignored-fields",
+        "Linux": {
+          "CgroupsPath": "/kubepods/burstable/pod9c64c5bf-298f-46c4-ad63-e2270a2ff44c/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": [
+            "/proc/acpi",
+            "/proc/asound",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap",
+            "/proc/scsi"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {
+              "Cpus": "",
+              "Mems": "",
+              "Period": 0,
+              "Quota": 0,
+              "RealtimePeriod": 0,
+              "RealtimeRuntime": 0,
+              "Shares": 2
+            },
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": null,
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {
+            "net.ipv4.ip_unprivileged_port_start": "0",
+            "net.ipv4.ping_group_range": "0 2147483647"
+          },
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {
+            "destination": "/proc",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "proc",
+            "type_": "proc"
+          },
+          {
+            "destination": "/dev",
+            "options": [
+              "nosuid",
+              "strictatime",
+              "mode=755",
+              "size=65536k"
+            ],
+            "source": "tmpfs",
+            "type_": "tmpfs"
+          },
+          {
+            "destination": "/dev/pts",
+            "options": [
+              "nosuid",
+              "noexec",
+              "newinstance",
+              "ptmxmode=0666",
+              "mode=0620",
+              "gid=5"
+            ],
+            "source": "devpts",
+            "type_": "devpts"
+          },
+          {
+            "destination": "/dev/mqueue",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "mqueue",
+            "type_": "mqueue"
+          },
+          {
+            "destination": "/sys",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "ro"
+            ],
+            "source": "sysfs",
+            "type_": "sysfs"
+          },
+          {
+            "destination": "/dev/shm",
+            "options": [
+              "rbind"
+            ],
+            "source": "/run/kata-containers/sandbox/shm",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/resolv.conf",
+            "options": [
+              "rbind",
+              "ro",
+              "nosuid",
+              "nodev",
+              "noexec"
+            ],
+            "source": "/run/kata-containers/shared/containers/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12-b3930b9af7125931-resolv.conf",
+            "type_": "bind"
+          }
+        ],
+        "Process": {
+          "ApparmorProfile": "",
+          "Args": [
+            "/pause"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+          ],
+          "NoNewPrivileges": true,
+          "OOMScoreAdj": -998,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              65535
+            ],
+            "GID": 65535,
+            "UID": 65535,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12/rootfs",
+          "Readonly": true
+        },
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+      "devices": [],
+      "exec_id": "4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12\",\"io.katacontainers.pkg.oci.container_type\":\"pod_sandbox\",\"io.kubernetes.cri.container-type\":\"sandbox\",\"io.kubernetes.cri.podsandbox.image-name\":\"registry.k8s.io/pause:3.10\",\"io.kubernetes.cri.sandbox-cpu-period\":\"100000\",\"io.kubernetes.cri.sandbox-cpu-quota\":\"0\",\"io.kubernetes.cri.sandbox-cpu-shares\":\"102\",\"io.kubernetes.cri.sandbox-id\":\"4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12\",\"io.kubernetes.cri.sandbox-log-directory\":\"/var/log/pods/default_policy-ignored-fields_9c64c5bf-298f-46c4-ad63-e2270a2ff44c\",\"io.kubernetes.cri.sandbox-memory\":\"0\",\"io.kubernetes.cri.sandbox-name\":\"policy-ignored-fields\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"9c64c5bf-298f-46c4-ad63-e2270a2ff44c\",\"nerdctl/network-namespace\":\"/var/run/netns/cni-22190131-6f68-2878-6d7b-418baf176cdf\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/4bae4a8e74302a8edfe17424aff0b632cae893687f4d9ad2f2115666899f9a12/rootfs",
+          "options": [],
+          "source": "pause"
+        }
+      ],
+      "string_user": null
+    },
+    "state": {
+      "sandbox_name": "policy-ignored-fields"
+    }
+  }
+]

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -69,3 +69,15 @@ spec:
   volumes:
     - name: test-volume1
       emptyDir: {}
+  affinity:
+    podAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 12
+        podAffinityTerm:
+          topologyKey: kubernetes.io/hostname
+          labelSelector:
+            matchExpressions:
+            - key: app
+              operator: In
+              values:
+              - not-a-real-hostname

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-rc.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-rc.yaml
@@ -43,3 +43,4 @@ spec:
       - name: hostpath-vol-read-only
         hostPath:
           path: /tmp/results-read-only
+      preemptionPolicy: PreemptLowerPriority


### PR DESCRIPTION
Ignore:

1. `PodAffinity`'s `preferredDuringSchedulingIgnoredDuringExecution` field
2. Additional fields of `PodAffinityTerm`
3. `preemptionPolicy`
4. `priority`
5. `schedulerName`
