### PR TITLE
wip: policy: introduce a policy-provided mode for User field handling

### DIFF
--- a/src/agent/policy/src/policy.rs
+++ b/src/agent/policy/src/policy.rs
@@ -10,7 +10,7 @@ use std::num::{NonZeroU32, NonZeroUsize};
 use std::{ffi::OsStr, os::unix::ffi::OsStrExt as _};
 
 use anyhow::{bail, Error, Result};
-use protocols::agent::CopyFileRequest;
+use protocols::{agent::CopyFileRequest, oci::User};
 use regorus::PolicyLengthConfig;
 use slog::{debug, error, info, warn};
 use tokio::io::AsyncWriteExt;
@@ -54,6 +54,15 @@ pub struct AgentPolicy {
 struct MetadataResponse {
     allowed: bool,
     ops: Option<json_patch::Patch>,
+    policy_user: Option<User>,
+}
+
+/// Response from evaluating an agent policy request.
+#[derive(Debug)]
+pub struct PolicyRequestResponse {
+    pub allowed: bool,
+    pub prints: String,
+    pub policy_user: Option<User>,
 }
 
 impl AgentPolicy {
@@ -146,7 +155,11 @@ impl AgentPolicy {
     }
 
     /// Ask regorus if an API call should be allowed or not.
-    pub async fn allow_request(&mut self, ep: &str, ep_input: &str) -> Result<(bool, String)> {
+    pub async fn allow_request_with_metadata(
+        &mut self,
+        ep: &str,
+        ep_input: &str,
+    ) -> Result<PolicyRequestResponse> {
         debug!(sl!(), "policy check: {ep}");
         self.log_eval_input(ep, ep_input).await;
 
@@ -163,7 +176,11 @@ impl AgentPolicy {
         if results.result.len() != 1 {
             // Results are empty when AllowRequestsFailingPolicy is used to allow a Request that hasn't been defined in the policy
             if self.allow_failures {
-                return Ok((true, prints));
+                return Ok(PolicyRequestResponse {
+                    allowed: true,
+                    prints,
+                    policy_user: None,
+                });
             }
             bail!(
                 "policy check: unexpected eval_query result len {:?}",
@@ -178,8 +195,8 @@ impl AgentPolicy {
             );
         }
 
-        let mut allow = match &results.result[0].expressions[0].value {
-            regorus::Value::Bool(b) => *b,
+        let (mut allow, mut policy_user) = match &results.result[0].expressions[0].value {
+            regorus::Value::Bool(b) => (*b, None),
 
             // Match against a specific variant that could be interpreted as MetadataResponse
             regorus::Value::Object(obj) => {
@@ -188,13 +205,18 @@ impl AgentPolicy {
                 self.log_eval_input(ep, &json_str).await;
 
                 let metadata_response: MetadataResponse = serde_json::from_str(&json_str)?;
+                let MetadataResponse {
+                    allowed,
+                    ops,
+                    policy_user,
+                } = metadata_response;
 
-                if metadata_response.allowed {
-                    if let Some(ops) = metadata_response.ops {
+                if allowed {
+                    if let Some(ops) = ops {
                         self.apply_patch_to_state(ops).await?;
                     }
                 }
-                metadata_response.allowed
+                (allowed, policy_user)
             }
 
             _ => {
@@ -209,9 +231,20 @@ impl AgentPolicy {
         if !allow && self.allow_failures {
             warn!(sl!(), "policy: ignoring error for {ep}");
             allow = true;
+            policy_user = None;
         }
 
-        Ok((allow, prints))
+        Ok(PolicyRequestResponse {
+            allowed: allow,
+            prints,
+            policy_user,
+        })
+    }
+
+    /// Ask regorus if an API call should be allowed or not.
+    pub async fn allow_request(&mut self, ep: &str, ep_input: &str) -> Result<(bool, String)> {
+        let response = self.allow_request_with_metadata(ep, ep_input).await?;
+        Ok((response.allowed, response.prints))
     }
 
     /// Replace the Policy in regorus.
@@ -489,6 +522,46 @@ mod tests {
                     output_res
                 )
             }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_allow_request_with_policy_user_metadata() {
+        let mut policy = AgentPolicy::new();
+        policy
+            .set_policy(
+                r#"
+package agent_policy
+
+default AllowRequestsFailingPolicy := false
+
+CreateContainerRequest := {
+    "allowed": true,
+    "policy_user": {
+        "UID": 1000,
+        "GID": 1000,
+        "AdditionalGids": [1000, 2000],
+        "Username": ""
+    }
+}
+
+ExecProcessRequest := CreateContainerRequest
+"#,
+            )
+            .await
+            .unwrap();
+
+        for ep in ["CreateContainerRequest", "ExecProcessRequest"] {
+            let response = policy.allow_request_with_metadata(ep, "{}").await.unwrap();
+
+            assert!(response.allowed);
+            let user = response
+                .policy_user
+                .expect("policy user should be returned");
+            assert_eq!(user.UID, 1000);
+            assert_eq!(user.GID, 1000);
+            assert_eq!(user.AdditionalGids, vec![1000, 2000]);
+            assert_eq!(user.Username, "");
         }
     }
 }

--- a/src/agent/src/policy.rs
+++ b/src/agent/src/policy.rs
@@ -8,19 +8,25 @@ use protobuf::MessageDyn;
 use crate::rpc::ttrpc_error;
 use crate::AGENT_POLICY;
 use kata_agent_policy::policy::AgentPolicy;
+use protocols::oci::User;
 
 async fn allow_request(policy: &mut AgentPolicy, ep: &str, request: &str) -> ttrpc::Result<()> {
-    match policy.allow_request(ep, request).await {
-        Ok((allowed, prints)) => {
-            if allowed {
-                Ok(())
-            } else {
-                Err(ttrpc_error(
-                    ttrpc::Code::PERMISSION_DENIED,
-                    format!("{ep} is blocked by policy: {prints}"),
-                ))
-            }
-        }
+    allow_request_with_metadata(policy, ep, request)
+        .await
+        .map(|_| ())
+}
+
+async fn allow_request_with_metadata(
+    policy: &mut AgentPolicy,
+    ep: &str,
+    request: &str,
+) -> ttrpc::Result<Option<User>> {
+    match policy.allow_request_with_metadata(ep, request).await {
+        Ok(response) if response.allowed => Ok(response.policy_user),
+        Ok(response) => Err(ttrpc_error(
+            ttrpc::Code::PERMISSION_DENIED,
+            format!("{ep} is blocked by policy: {}", response.prints),
+        )),
         Err(e) => Err(ttrpc_error(
             ttrpc::Code::INTERNAL,
             format!("{ep}: internal error {e}"),
@@ -30,6 +36,14 @@ async fn allow_request(policy: &mut AgentPolicy, ep: &str, request: &str) -> ttr
 
 pub async fn is_allowed(req: &(impl MessageDyn + serde::Serialize)) -> ttrpc::Result<()> {
     is_allowed_with_entrypoint(req.descriptor_dyn().name(), &req).await
+}
+
+pub async fn is_allowed_with_policy_user(
+    req: &(impl MessageDyn + serde::Serialize),
+) -> ttrpc::Result<Option<User>> {
+    let request = serde_json::to_string(req).unwrap();
+    let mut policy = AGENT_POLICY.lock().await;
+    allow_request_with_metadata(&mut policy, req.descriptor_dyn().name(), &request).await
 }
 
 pub async fn is_allowed_with_entrypoint(

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -91,7 +91,9 @@ use crate::trace_rpc_call;
 use crate::tracer::extract_carrier_from_ttrpc;
 
 #[cfg(feature = "agent-policy")]
-use crate::policy::{do_set_policy, is_allowed, is_allowed_with_entrypoint};
+use crate::policy::{
+    do_set_policy, is_allowed, is_allowed_with_entrypoint, is_allowed_with_policy_user,
+};
 
 use opentelemetry::global;
 use tracing::span;
@@ -872,9 +874,17 @@ impl agent_ttrpc::AgentService for AgentService {
     async fn create_container(
         &self,
         ctx: &TtrpcContext,
-        req: protocols::agent::CreateContainerRequest,
+        mut req: protocols::agent::CreateContainerRequest,
     ) -> ttrpc::Result<Empty> {
         trace_rpc_call!(ctx, "create_container", req);
+        #[cfg(feature = "agent-policy")]
+        {
+            let policy_user = is_allowed_with_policy_user(&req).await?;
+            if let Some(user) = policy_user {
+                req.mut_OCI().mut_Process().set_User(user);
+            }
+        }
+        #[cfg(not(feature = "agent-policy"))]
         is_allowed(&req).await?;
         self.do_create_container(req).await.map_ttrpc_err(same)?;
         Ok(Empty::new())
@@ -905,9 +915,17 @@ impl agent_ttrpc::AgentService for AgentService {
     async fn exec_process(
         &self,
         ctx: &TtrpcContext,
-        req: protocols::agent::ExecProcessRequest,
+        mut req: protocols::agent::ExecProcessRequest,
     ) -> ttrpc::Result<Empty> {
         trace_rpc_call!(ctx, "exec_process", req);
+        #[cfg(feature = "agent-policy")]
+        {
+            let policy_user = is_allowed_with_policy_user(&req).await?;
+            if let Some(user) = policy_user {
+                req.mut_process().set_User(user);
+            }
+        }
+        #[cfg(not(feature = "agent-policy"))]
         is_allowed(&req).await?;
         self.do_exec_process(req).await.map_ttrpc_err(same)?;
         Ok(Empty::new())

--- a/src/tools/genpolicy/drop-in-examples/20-guest-pull-policy-provided-drop-in.json
+++ b/src/tools/genpolicy/drop-in-examples/20-guest-pull-policy-provided-drop-in.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/cluster_config/id_verification_policy",
+    "value": "policy-provided"
+  }
+]

--- a/src/tools/genpolicy/drop-in-examples/README.md
+++ b/src/tools/genpolicy/drop-in-examples/README.md
@@ -26,6 +26,7 @@ Drop-ins are layered: `10-*` files set the platform base, `20-*` files overlay O
 | `20-oci-1.2.0-drop-in.json` | OCI bundle version 1.2.0 |
 | `20-oci-1.2.1-drop-in.json` | OCI bundle version 1.2.1 (e.g. k3s, rke2, NVIDIA GPU, CBL-Mariner) |
 | `20-oci-1.3.0-drop-in.json` | OCI bundle version 1.3.0 (e.g. containerd 2.2.x) |
+| `20-guest-pull-policy-provided-drop-in.json` | Use policy-provided ID values for guest-pull configurations where the host cannot resolve image users/groups |
 | `20-experimental-force-guest-pull-drop-in.json` | Disable guest pull |
 
 Request/exec overrides (e.g. allowing `kubectl exec` or specific ttRPC requests) are not shipped as drop-in examples; build your own drop-in or merge the needed `request_defaults` into a local file in `genpolicy-settings.d/`.

--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -334,6 +334,7 @@
     "cluster_config": {
         "pause_container_image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",
         "guest_pull": true,
+        "id_verification_policy": "verify-host-input",
         "pause_container_id_policy": "v1",
         "encrypted_emptydir": true,
         "cgroup_mount_extras_allowed": [

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -60,7 +60,7 @@ S_NAMESPACE_KEY = "io.kubernetes.cri.sandbox-namespace"
 CDI_VFIO_ANNOTATION_PREFIX = "cdi.k8s.io/vfio"
 VFIO_PCI_ADDRESS_REGEX = "^[0-9a-fA-F]{4}:[0-9a-fA-F]{2}:[01][0-9a-fA-F]\\.[0-7]=[0-9a-fA-F]{2}/[0-9a-fA-F]{2}$"
 
-CreateContainerRequest := {"ops": ops, "allowed": true} if {
+CreateContainerRequest := {"ops": ops, "allowed": true, "policy_user": policy_user} if {
     # Check if the input request should be rejected even before checking the
     # policy_data.containers information.
     allow_create_container_input
@@ -111,6 +111,7 @@ CreateContainerRequest := {"ops": ops, "allowed": true} if {
 
     ret := allow_linux(ops_builder2, p_oci, i_oci)
     ret.allowed
+    policy_user := request_policy_user(p_oci.Process)
 
     # save to policy state
     # key: input.container_id
@@ -822,10 +823,28 @@ allow_process_common(p_process, i_process, s_name, s_namespace) if {
     p_process.Cwd == i_process.Cwd
     p_process.NoNewPrivileges == i_process.NoNewPrivileges
 
-    allow_user(p_process, i_process)
+    allow_process_user(p_process, i_process)
     allow_env(p_process, i_process, s_name, s_namespace)
 
     print("allow_process_common: true")
+}
+
+allow_process_user(p_process, i_process) if {
+    policy_data.cluster_config.id_verification_policy == "verify-host-input"
+    allow_user(p_process, i_process)
+}
+
+allow_process_user(p_process, i_process) if {
+    policy_data.cluster_config.id_verification_policy == "policy-provided"
+    print("allow_process_user: using policy user")
+}
+
+request_policy_user(p_process) = null if {
+    policy_data.cluster_config.id_verification_policy == "verify-host-input"
+}
+
+request_policy_user(p_process) = p_process.User if {
+    policy_data.cluster_config.id_verification_policy == "policy-provided"
 }
 
 # Compare the OCI Process field of a policy container with the input OCI Process from a CreateContainerRequest
@@ -1636,7 +1655,7 @@ get_state_container(container_id):= p_container if {
     p_container := policy_data.containers[idx]
 }
 
-ExecProcessRequest if {
+ExecProcessRequest := {"allowed": true, "policy_user": policy_user} if {
     print("ExecProcessRequest 1: input =", input)
     allow_exec_process_input
 
@@ -1646,10 +1665,11 @@ ExecProcessRequest if {
 
     p_container := get_state_container(input.container_id)
     allow_interactive_exec(p_container, input.process)
+    policy_user := request_policy_user(p_container.OCI.Process)
 
     print("ExecProcessRequest 1: true")
 }
-ExecProcessRequest if {
+ExecProcessRequest := {"allowed": true, "policy_user": policy_user} if {
     print("ExecProcessRequest 2: input =", input)
     allow_exec_process_input
 
@@ -1661,10 +1681,11 @@ ExecProcessRequest if {
     p_command == input.process.Args
 
     allow_exec(p_container, input.process)
+    policy_user := request_policy_user(p_container.OCI.Process)
 
     print("ExecProcessRequest 2: true")
 }
-ExecProcessRequest if {
+ExecProcessRequest := {"allowed": true, "policy_user": policy_user} if {
     print("ExecProcessRequest 3: input =", input)
     allow_exec_process_input
 
@@ -1679,6 +1700,7 @@ ExecProcessRequest if {
     p_container := get_state_container(input.container_id)
 
     allow_interactive_exec(p_container, input.process)
+    policy_user := request_policy_user(p_container.OCI.Process)
 
     print("ExecProcessRequest 3: true")
 }

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -627,11 +627,9 @@ struct TopologySpreadConstraint {
 }
 
 impl Container {
-    pub async fn init(&mut self, config: &Config, is_pause_container: bool) {
+    pub async fn init(&mut self, config: &Config) {
         // Load container image properties from the registry.
-        self.registry = registry::get_container(config, &self.image, is_pause_container)
-            .await
-            .unwrap();
+        self.registry = registry::get_container(config, &self.image).await.unwrap();
     }
 
     pub fn get_env_variables(
@@ -1182,8 +1180,7 @@ pub async fn add_pause_container(containers: &mut Vec<Container>, config: &Confi
         }),
         ..Default::default()
     };
-    let is_pause_container = true;
-    pause_container.init(config, is_pause_container).await;
+    pause_container.init(config).await;
     containers.insert(0, pause_container);
     debug!("pause container added.");
 }

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -16,7 +16,7 @@ use crate::secret;
 use crate::utils;
 use crate::yaml;
 
-use anyhow::Result;
+use anyhow::{bail, Result};
 use log::debug;
 use oci_spec::runtime as oci;
 use protocols::agent;
@@ -379,6 +379,20 @@ pub struct AddARPNeighborsRequestDefaults {
     allowed_states: Vec<u32>,
 }
 
+fn validate_id_verification_policy(policy: &str) -> Result<()> {
+    match policy {
+        "verify-host-input" | "policy-provided" => Ok(()),
+        _ => bail!(
+            "Unsupported id_verification_policy = {} - must be verify-host-input or policy-provided in the settings file",
+            policy
+        ),
+    }
+}
+
+fn default_id_verification_policy() -> String {
+    "verify-host-input".to_string()
+}
+
 /// Settings specific to each kata agent endpoint, loaded from
 /// genpolicy-settings.json.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -458,9 +472,16 @@ pub struct ClusterConfig {
     pub pause_container_image: String,
 
     /// Whether or not the cluster uses the guest pull mechanism
-    /// In guest pull, host can't look into layers to determine GID.
-    /// See issue https://github.com/kata-containers/kata-containers/issues/11162
     pub guest_pull: bool,
+
+    /// Supported values:
+    ///
+    /// "verify-host-input" - The Agent verifies that the CreateContainerRequest
+    ///         user/group IDs match the IDs calculated by genpolicy.
+    /// "policy-provided" - The Agent uses the user/group IDs calculated by
+    ///         genpolicy and ignores the IDs from CreateContainerRequest.
+    #[serde(default = "default_id_verification_policy")]
+    pub id_verification_policy: String,
 
     /// Supported values:
     ///
@@ -539,6 +560,14 @@ enum K8sEnvFromSource {
 
 impl AgentPolicy {
     pub async fn from_files(config: &utils::Config) -> Result<AgentPolicy> {
+        validate_id_verification_policy(
+            config
+                .settings
+                .cluster_config
+                .id_verification_policy
+                .as_str(),
+        )?;
+
         let mut config_maps = Vec::new();
         let mut secrets = Vec::new();
         let mut resources = Vec::new();

--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -125,7 +125,7 @@ const GROUP_FILE_WHITEOUT_TAR_PATH: &str = "etc/.wh.group";
 pub const WHITEOUT_MARKER: &str = "WHITEOUT";
 
 impl Container {
-    pub async fn new(config: &Config, image: &str, is_pause_container: bool) -> Result<Self> {
+    pub async fn new(config: &Config, image: &str) -> Result<Self> {
         info!("============================================");
         info!("Pulling manifest and config for {image}");
         let image_string = image.to_string();
@@ -166,38 +166,31 @@ impl Container {
         let mut passwd = String::new();
         let mut group = String::new();
 
-        // Nydus/guest_pull doesn't make available passwd/group files from layers properly.
-        // See issue https://github.com/kata-containers/kata-containers/issues/11162
-        let v1_policy = config.settings.cluster_config.pause_container_id_policy == "v1";
-        if config.settings.cluster_config.guest_pull && (v1_policy || !is_pause_container) {
-            info!("Guest pull is enabled, skipping passwd/group file parsing");
-        } else {
-            let image_layers = get_image_layers(
-                &config.layers_cache,
-                &mut client,
-                &reference,
-                &manifest,
-                &config_layer,
-            )
-            .await
-            .unwrap();
+        let image_layers = get_image_layers(
+            &config.layers_cache,
+            &mut client,
+            &reference,
+            &manifest,
+            &config_layer,
+        )
+        .await
+        .unwrap();
 
-            // Find the last layer with an /etc/* file, respecting whiteouts.
-            info!("Parsing users and groups in image layers");
-            for layer in &image_layers {
-                if layer.passwd == WHITEOUT_MARKER {
-                    passwd = String::new();
-                } else if !layer.passwd.is_empty() {
-                    passwd = layer.passwd.clone();
-                    debug!("Container:new: Found in image layer passwd = \n{passwd}");
-                }
+        // Find the last layer with an /etc/* file, respecting whiteouts.
+        info!("Parsing users and groups in image layers");
+        for layer in &image_layers {
+            if layer.passwd == WHITEOUT_MARKER {
+                passwd = String::new();
+            } else if !layer.passwd.is_empty() {
+                passwd = layer.passwd.clone();
+                debug!("Container:new: Found in image layer passwd = \n{passwd}");
+            }
 
-                if layer.group == WHITEOUT_MARKER {
-                    group = String::new();
-                } else if !layer.group.is_empty() {
-                    group = layer.group.clone();
-                    debug!("Container:new: Found in image layer group = \n{group}");
-                }
+            if layer.group == WHITEOUT_MARKER {
+                group = String::new();
+            } else if !layer.group.is_empty() {
+                group = layer.group.clone();
+                debug!("Container:new: Found in image layer group = \n{group}");
             }
         }
 
@@ -652,16 +645,11 @@ pub fn get_users_from_decompressed_layer(path: &Path) -> Result<(String, String)
     Ok((passwd, group))
 }
 
-pub async fn get_container(
-    config: &Config,
-    image: &str,
-    is_pause_container: bool,
-) -> Result<Container> {
+pub async fn get_container(config: &Config, image: &str) -> Result<Container> {
     if let Some(socket_path) = &config.containerd_socket_path {
-        return Container::new_containerd_pull(config, image, socket_path, is_pause_container)
-            .await;
+        return Container::new_containerd_pull(config, image, socket_path).await;
     }
-    Container::new(config, image, is_pause_container).await
+    Container::new(config, image).await
 }
 
 fn build_auth(reference: &Reference) -> RegistryAuth {

--- a/src/tools/genpolicy/src/registry_containerd.rs
+++ b/src/tools/genpolicy/src/registry_containerd.rs
@@ -32,7 +32,6 @@ impl Container {
         config: &Config,
         image: &str,
         containerd_socket_path: &str,
-        is_pause_container: bool,
     ) -> Result<Self> {
         info!("============================================");
         info!("Using containerd socket: {:?}", containerd_socket_path);
@@ -69,31 +68,24 @@ impl Container {
         let mut passwd = String::new();
         let mut group = String::new();
 
-        // Nydus/guest_pull doesn't make available passwd/group files from layers properly.
-        // See issue https://github.com/kata-containers/kata-containers/issues/11162
-        let v1_policy = config.settings.cluster_config.pause_container_id_policy == "v1";
-        if config.settings.cluster_config.guest_pull && (v1_policy || !is_pause_container) {
-            info!("Guest pull is enabled, skipping passwd/group file parsing");
-        } else {
-            let image_layers =
-                get_image_layers(&config.layers_cache, &manifest, &config_layer, &ctrd_client)
-                    .await
-                    .unwrap();
+        let image_layers =
+            get_image_layers(&config.layers_cache, &manifest, &config_layer, &ctrd_client)
+                .await
+                .unwrap();
 
-            // Find the last layer with an /etc/* file, respecting whiteouts.
-            info!("Parsing users and groups in image layers");
-            for layer in &image_layers {
-                if layer.passwd == WHITEOUT_MARKER {
-                    passwd = String::new();
-                } else if !layer.passwd.is_empty() {
-                    passwd = layer.passwd.clone();
-                }
+        // Find the last layer with an /etc/* file, respecting whiteouts.
+        info!("Parsing users and groups in image layers");
+        for layer in &image_layers {
+            if layer.passwd == WHITEOUT_MARKER {
+                passwd = String::new();
+            } else if !layer.passwd.is_empty() {
+                passwd = layer.passwd.clone();
+            }
 
-                if layer.group == WHITEOUT_MARKER {
-                    group = String::new();
-                } else if !layer.group.is_empty() {
-                    group = layer.group.clone();
-                }
+            if layer.group == WHITEOUT_MARKER {
+                group = String::new();
+            } else if !layer.group.is_empty() {
+                group = layer.group.clone();
             }
         }
 

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -274,8 +274,7 @@ pub fn get_yaml_header(yaml: &str) -> anyhow::Result<YamlHeader> {
 
 pub async fn k8s_resource_init(spec: &mut pod::PodSpec, config: &Config) {
     for container in &mut spec.containers {
-        let is_pause_container = false;
-        container.init(config, is_pause_container).await;
+        container.init(config).await;
     }
 
     pod::add_pause_container(&mut spec.containers, config).await;
@@ -283,8 +282,7 @@ pub async fn k8s_resource_init(spec: &mut pod::PodSpec, config: &Config) {
     if let Some(init_containers) = &spec.initContainers {
         for container in init_containers {
             let mut new_container = container.clone();
-            let is_pause_container = false;
-            new_container.init(config, is_pause_container).await;
+            new_container.init(config).await;
             spec.containers.insert(1, new_container);
         }
     }

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -113,9 +113,7 @@ mod tests {
             raw_out: false,
             rego_rules_path: workdir.join("rules.rego").to_str().unwrap().to_string(),
             runtime_class_names: Vec::new(),
-            settings: genpolicy::settings::Settings::new(
-                workdir.join("genpolicy-settings.json").to_str().unwrap(),
-            ),
+            settings: genpolicy::settings::Settings::new(workdir.to_str().unwrap()),
             silent_unsupported_fields: false,
             use_cache: false,
             version: false,
@@ -217,7 +215,12 @@ mod tests {
         // Make sure that workdir is empty.
         for entry in fs::read_dir(&workdir).expect("should be able to read directories") {
             let entry = entry.expect("should be able to read directory entries");
-            fs::remove_file(entry.path()).expect("should be able to remove files");
+            let path = entry.path();
+            if path.is_dir() {
+                fs::remove_dir_all(path).expect("should be able to remove directories");
+            } else {
+                fs::remove_file(path).expect("should be able to remove files");
+            }
         }
 
         for file in files_to_copy {
@@ -240,6 +243,21 @@ mod tests {
                     workdir.join(base)
                 ))
                 .expect("copying files around should not fail");
+        }
+
+        let drop_in_dir = testdata_dir.join("genpolicy-settings.d");
+        if drop_in_dir.is_dir() {
+            let workdir_drop_in_dir = workdir.join("genpolicy-settings.d");
+            fs::create_dir_all(&workdir_drop_in_dir)
+                .expect("should be able to create settings drop-in dir");
+
+            for entry in fs::read_dir(&drop_in_dir).expect("should be able to read drop-in dir") {
+                let entry = entry.expect("should be able to read drop-in entries");
+                if entry.path().is_file() {
+                    fs::copy(entry.path(), workdir_drop_in_dir.join(entry.file_name()))
+                        .expect("copying settings drop-in should not fail");
+                }
+            }
         }
 
         (workdir, testdata_dir)
@@ -303,6 +321,11 @@ mod tests {
     #[tokio::test]
     async fn test_state_exec_process() {
         runtests("state/execprocess").await;
+    }
+
+    #[tokio::test]
+    async fn test_state_exec_process_policy_provided() {
+        runtests("state/execprocess_policy_provided").await;
     }
 
     #[tokio::test]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/genpolicy-settings.d/10-id-verification-policy.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/genpolicy-settings.d/10-id-verification-policy.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/cluster_config/id_verification_policy",
+    "value": "policy-provided"
+  }
+]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/gid/genpolicy-settings.d/10-id-verification-policy.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/gid/genpolicy-settings.d/10-id-verification-policy.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/cluster_config/id_verification_policy",
+    "value": "policy-provided"
+  }
+]

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/genpolicy-settings.d/10-id-verification-policy.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/genpolicy-settings.d/10-id-verification-policy.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/cluster_config/id_verification_policy",
+    "value": "policy-provided"
+  }
+]

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocess_policy_provided/genpolicy-settings.d/10-id-verification-policy.json
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocess_policy_provided/genpolicy-settings.d/10-id-verification-policy.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/cluster_config/id_verification_policy",
+    "value": "policy-provided"
+  }
+]

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocess_policy_provided/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocess_policy_provided/pod.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: busybox
+spec:
+  runtimeClassName: kata-cc
+  containers:
+    - name: first-test-container
+      image: "quay.io/prometheus/busybox:latest"
+      env:
+        - name: CONTAINER_NAME
+          value: first-test-container
+      command:
+        - sleep
+        - "3600"
+      livenessProbe:
+        exec:
+          command:
+            - test1
+    - name: second-test-container
+      image: "quay.io/prometheus/busybox:latest"
+      env:
+        - name: CONTAINER_NAME
+          value: second-test-container
+      command:
+        - sleep
+        - "3600"
+      livenessProbe:
+        exec:
+          command:
+            - test2

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocess_policy_provided/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocess_policy_provided/testcases.json
@@ -632,8 +632,7 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0,
-            10
+            0
           ],
           "GID": 0,
           "UID": 0,
@@ -832,7 +831,7 @@
     }
   },
   {
-    "allowed": false,
+    "allowed": true,
     "description": "test exec process in first container with non-null/different User",
     "kind": "ExecProcessRequest",
     "request": {

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocessdeployment/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocessdeployment/testcases.json
@@ -294,7 +294,8 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              0,
+              10
             ],
             "GID": 0,
             "UID": 0,
@@ -367,7 +368,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,

--- a/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment-sc.bats
@@ -80,6 +80,8 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected GID = 0 for layered securityContext deployment" {
+    [[ "${SNAPSHOTTER:-}" == "nydus" ]] && skip "Policy-provided ID mode ignores host-provided GID values"
+
     # Change the pod GID to 0 after the policy has been generated using a different
     # runAsGroup value. The policy would use GID = 0 by default, if there weren't
     # a different runAsGroup value in the YAML file.
@@ -91,6 +93,8 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: malicious root group added via supplementalGroups deployment" {
+    [[ "${SNAPSHOTTER:-}" == "nydus" ]] && skip "Policy-provided ID mode ignores host-provided supplementalGroups values"
+
     # Inject a supplementalGroup of 0 (root) after the policy has been generated
     yq -i \
         '.spec.template.spec.securityContext.supplementalGroups += 0' \

--- a/tests/integration/kubernetes/k8s-policy-deployment.bats
+++ b/tests/integration/kubernetes/k8s-policy-deployment.bats
@@ -49,6 +49,8 @@ test_deployment_policy_error() {
 }
 
 @test "Policy failure: unexpected UID = 0" {
+    [[ "${SNAPSHOTTER:-}" == "nydus" ]] && skip "Policy-provided ID mode ignores host-provided UID values"
+
     # Change the pod UID to 0 after the policy has been generated using a different
     # runAsUser value. The policy would use UID = 0 by default, if there weren't
     # a different runAsUser value in the YAML file.

--- a/tests/integration/kubernetes/k8s-policy-job.bats
+++ b/tests/integration/kubernetes/k8s-policy-job.bats
@@ -142,6 +142,8 @@ test_job_policy_error() {
 }
 
 @test "Policy failure: unexpected UID = 222" {
+    [[ "${SNAPSHOTTER:-}" == "nydus" ]] && skip "Policy-provided ID mode ignores host-provided UID values"
+
     # Changing the job spec after generating its policy will cause CreateContainer to be denied.
     yq -i \
         '.spec.template.spec.securityContext.runAsUser = 222' \

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -255,6 +255,7 @@ test_pod_policy_error() {
 
 @test "Policy failure: unexpected UID = 0" {
 	prometheus_image_supported || skip "Test case not supported due to ${issue}"
+	[[ "${SNAPSHOTTER:-}" == "nydus" ]] && skip "Policy-provided ID mode ignores host-provided UID values"
 
 	# Change the container UID to 0 after the policy has been generated, and verify that the
 	# change gets rejected by the policy. UID = 0 is the default value from genpolicy, but
@@ -267,6 +268,8 @@ test_pod_policy_error() {
 }
 
 @test "Policy failure: unexpected UID = 1234" {
+	[[ "${SNAPSHOTTER:-}" == "nydus" ]] && skip "Policy-provided ID mode ignores host-provided UID values"
+
 	# Change the container UID to 1234 after the policy has been generated, and verify that the
 	# change gets rejected by the policy. This container image specifies user = "nobody" that
 	# corresponds to UID = 65534.

--- a/tests/integration/kubernetes/k8s-policy-rc.bats
+++ b/tests/integration/kubernetes/k8s-policy-rc.bats
@@ -149,6 +149,8 @@ test_rc_policy() {
 }
 
 @test "Policy failure: unexpected UID = 1000" {
+    [[ "${SNAPSHOTTER:-}" == "nydus" ]] && skip "Policy-provided ID mode ignores host-provided UID values"
+
     # Changing the template spec after generating its policy will cause CreateContainer to be denied.
     yq -i \
       '.spec.template.spec.securityContext.runAsUser = 1000' \

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
@@ -16,14 +16,8 @@ metadata:
     # cc_init_data annotation will be added by genpolicy with CDH configuration
     # from the custom default-initdata.toml created by create_nim_initdata_file()
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
   securityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
     fsGroup: 1000
-    supplementalGroups: [4, 20, 24, 25, 27, 29, 30, 44, 46]
   restartPolicy: Never
   runtimeClassName: kata
   imagePullSecrets:

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
@@ -16,12 +16,7 @@ metadata:
     # cc_init_data annotation will be added by genpolicy with CDH configuration
     # from the custom default-initdata.toml created by create_nim_initdata_file()
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
   securityContext:
-    runAsUser: 1000
-    runAsGroup: 1000
     fsGroup: 1000
   restartPolicy: Always
   runtimeClassName: kata

--- a/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-client-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-client-pod.yaml
@@ -11,13 +11,6 @@ metadata:
   labels:
     app: openvpn-client
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
-  securityContext:
-    runAsUser: 0
-    runAsGroup: 0
-    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
   containers:
   - name: openvpn-client
     image: quay.io/kata-containers/alpine:3.22.1-openvpn

--- a/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-server-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-server-pod.yaml
@@ -11,13 +11,6 @@ metadata:
   labels:
     app: openvpn-server
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
-  securityContext:
-    runAsUser: 0
-    runAsGroup: 0
-    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
   containers:
   - name: openvpn-server
     image: quay.io/kata-containers/alpine:3.22.1-openvpn

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-trusted-ephemeral-data-storage.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-trusted-ephemeral-data-storage.yaml
@@ -4,13 +4,6 @@ apiVersion: v1
 metadata:
   name: trusted-ephemeral-data-storage
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
-  securityContext:
-    runAsUser: 0
-    runAsGroup: 0
-    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
   runtimeClassName: kata
   restartPolicy: Never
   containers:

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -161,6 +161,11 @@ install_genpolicy_drop_ins() {
 		cp "${examples_dir}/20-experimental-force-guest-pull-drop-in.json" "${settings_d}/"
 	fi
 
+	# 20-* guest-pull ID verification overlay
+	if [[ "${SNAPSHOTTER:-}" == "nydus" ]]; then
+		cp "${examples_dir}/20-guest-pull-policy-provided-drop-in.json" "${settings_d}/"
+	fi
+
 	# 20-* runtime-rs overlay (disable encrypted emptyDir, not supported yet)
 	if is_runtime_rs; then
 		cp "${examples_dir}/20-runtime-rs-drop-in.json" "${settings_d}/"


### PR DESCRIPTION
**tl;dr**
This is a very early WIP draft going back to a slack discussion on the kata-dev Slack channel on how to find solution to issue 11162 and 12139 by introducing a policy-provide mode for the User field handling of the CreateContainerRequest and ExecProcessRequest.

**High-level description for this change set:**
Introduce a new, additional scheme for process user ID verification called 'policy-provided' (we call the existing verification scheme 'verify-host-input'). The new mode is currently targeted for use for the nydus snapshotter i.e. for snapshotter scenarios where the host cannot reliably derive the ID values at pod deployment time. The goal is to find solution to issues 11162 and 12139. The following changes are proposed:
- Agent and rules.rego:
  - verify-host-input mode: Validate User field in allow_process_user (as of today)
  - policy-provided mode: Overwrite User field in OCI SPEC with contents from User field from the policy document (via OCI.Process.set_User - the Process.User information is returned from the rego evaluation to the agent)
  - The validation of User happens both in CreateContainerRequest and ExecProcessRequest - in both calls, the shim provides the User field.
- Genpolicy and genpolicy-settings:
  - Add a new field to genpolicy called id_verification_policy defaulting to verify-host-input
  - Change the genpolicy tool to obtain container image layers unconditionally - i.e. do not skip acquiring container image layers in the nydus case.
- Test logic
  - End-to-end CI:
    - Create a drop-in example which overwrites the default verify-host-input mode with policy-provided mode. Use this sample in CI when we test against the nydus snapshotter.
    - Skip existing tests which prevent against host ID modifications in policy-provided mode (these would expect failure state but with the policy-provided mode these would not fail)
    - Remove the securityContext field from various pod samples. These were annotated with a reference to issue 11162
  - Policy integration tests:
    - Add capability to read configuration drop-in directories
    - Rectify various existing tests which were encoding the 'wrong/incomplete' nydus based IDs (add IDs which are actually encoded in layers)
    - Add new test samples (which use ExecProcessRequest)
