### PR TITLE
genpolicy: Fix matching of `..` in paths

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1520,7 +1520,7 @@ strip_cap_prefix(s) := result if {
 }
 
 check_directory_traversal(i_path) if {
-    not regex.match("(^|/)..($|/)", i_path)
+    not regex.match("(^|/)\\.\\.($|/)", i_path)
 }
 
 allow_sandbox_storages(i_storages) if {


### PR DESCRIPTION
When not escaped, the `.` character in a regular expression matches any character. This causes `CopyFileRequest is blocked by policy` for paths like :
```
/run/kata-containers/shared/containers/b8d668e556bc5daf7454de26496a419128d182c5c16d5af6ad03a9e2593f96d4-c9126bd2cf103ae6-secrets/rhsm/ca
```
In this case, the match is `/ca`.