### PR TITLE
tests: TEMP revert CoCo KBS deployment to kustomize for baseline comp…

### DIFF
--- a/tests/integration/kubernetes/confidential_kbs.sh
+++ b/tests/integration/kubernetes/confidential_kbs.sh
@@ -559,6 +559,12 @@ kbs_k8s_print_logs() {
 	echo "::group::DEBUG - kbs logs since ${start_time}"
 	kubectl -n "${KBS_NS}" logs -l app=kbs --since-time="${iso_start_time}" --timestamps=true || true
 	echo "::endgroup::"
+	echo "::group::DEBUG - as logs since ${start_time}"
+	kubectl -n "${KBS_NS}" logs -l app=attestation-service --since-time="${iso_start_time}" --timestamps=true || true
+	echo "::endgroup::"
+	echo "::group::DEBUG - rvps logs since ${start_time}"
+	kubectl -n "${KBS_NS}" logs -l app=reference-value-provider-service --since-time="${iso_start_time}" --timestamps=true || true
+	echo "::endgroup::"
 }
 
 # Ensure rust is installed in the host.

--- a/versions.yaml
+++ b/versions.yaml
@@ -297,12 +297,18 @@ externals:
 
   coco-trustee:
     description: "Provides attestation and secret delivery components"
-    url: "https://github.com/confidential-containers/trustee"
-    version: "22788122660d6e9be3e4bf52704282de5fcc0a2a"
-    # image and image_tag must be in sync
-    image: "ghcr.io/confidential-containers/staged-images/kbs"
-    image_tag: "22788122660d6e9be3e4bf52704282de5fcc0a2a"
+    url: "https://github.com/fidencio/trustee"
+    version: "bfe370c4643f6cd9673d75d27c9b0994654b27db"
+    # image / ita_image and image_tag / ita_image_tag must be in sync
+    image: "quay.io/fidencio/trustee"
+    image_tag: "kustomize-test"
+    ita_image: "ghcr.io/confidential-containers/staged-images/kbs-ita-as"
+    ita_image_tag: "22788122660d6e9be3e4bf52704282de5fcc0a2a-x86_64"
     toolchain: "1.90.0"
+    # Helm chart deploys three separate images (kbs, as, rvps)
+    image_kbs: "quay.io/fidencio/trustee:helm-tests-kbs-grpc-as"
+    image_as: "quay.io/fidencio/trustee:helm-tests-coco-as-grpc"
+    image_rvps: "quay.io/fidencio/trustee:helm-tests-rvps"
 
   containerd:
     description: |


### PR DESCRIPTION
…arison

Temporarily revert kbs_k8s_deploy/delete to the kustomize single-container approach so we can compare the SNP attestation test results against the Helm multi-pod deployment and isolate whether the failure is in the Helm chart configuration or elsewhere.

NOT intended to be merged.