### PR TITLE
rootfs: cdh: Update CDH to new version

### DIFF
--- a/tests/integration/kubernetes/k8s-nvidia-nim.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim.bats
@@ -86,8 +86,6 @@ setup_langchain_flow() {
 # generated policy.rego to it and set it as the cc_init_data annotation.
 # We must overwrite the default empty file AFTER create_tmp_policy_settings_dir()
 # copies it to the temp directory.
-# As we use multiple vCPUs we set `max_concurrent_layer_downloads_per_image = 1`,
-# see: https://github.com/kata-containers/kata-containers/issues/12721
 create_nim_initdata_file() {
     local output_file="$1"
     local cc_kbs_address
@@ -110,7 +108,6 @@ name = "cc_kbc"
 url = "${cc_kbs_address}"
 
 [image]
-max_concurrent_layer_downloads_per_image = 1
 authenticated_registry_credentials_uri = "kbs:///default/credentials/nvcr"
 image_security_policy_uri = "kbs:///default/security-policy/nim"
 '''

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-guest-pull-in-trusted-storage.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-guest-pull-in-trusted-storage.yaml.in
@@ -28,6 +28,9 @@ spec:
       command: ["/bin/sh", "-c"]
       args:
         - sleep 6000
+      resources:
+        limits:
+          cpu: "2"
       volumeDevices:
         - devicePath: /dev/trusted_store
           name: trusted-storage

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -332,34 +332,37 @@ copy_cdh_runtime_deps() {
 	local libdir="lib/${machine_arch}-linux-gnu"
 
 	# Shared libraries required by /usr/local/bin/confidential-data-hub.
-	# Note: libcryptsetup loads some optional helpers (e.g. libpopt/libssh) only
-	# when specific features are used. The current CDH path (LUKS2 + mkfs.ext4)
-	# does not require those optional libs.
-	cp -a "${stage_one}/${libdir}"/libcryptsetup.so.12*    "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libuuid.so.1*           "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libdevmapper.so.1.02.1* "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libselinux.so.1*        "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libpcre2-8.so.0*        "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libudev.so.1*           "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libcap.so.2*            "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libcrypto.so.3*         "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libz.so.1*              "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libzstd.so.1*           "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libjson-c.so.5*         "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libblkid.so.1*          "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libargon2.so.1*         "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libgcc_s.so.1*          "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libm.so.6*              "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libc.so.6*              "${libdir}/."
 
-	# e2fsprogs (mkfs.ext4) runtime libs
-	cp -a "${stage_one}/${libdir}"/libext2fs.so.2*         "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libe2p.so.2*            "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libss.so.2*             "${libdir}/."
-	cp -a "${stage_one}/${libdir}"/libcom_err.so.2*        "${libdir}/."
+	# Shared libraries required by the cryptsetup, mkfs.ext4, and dd binaries
+	# used by CDH secure_mount.
+	#
+	# cryptsetup direct dependencies
+	cp -a "${stage_one}/${libdir}"/libcryptsetup.so.12*    "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libpopt.so.0*           "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libuuid.so.1*           "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libblkid.so.1*          "${libdir}/."
 
-	# mkfs.ext4 and dd are used by CDH secure_mount
-	mkdir -p sbin etc usr/bin bin
+	# libcryptsetup transitive dependencies
+	cp -a "${stage_one}/${libdir}"/libdevmapper.so.1.02.1* "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libcrypto.so.3*         "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libargon2.so.1*         "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libjson-c.so.5*         "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libselinux.so.1*        "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libudev.so.1*           "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libpcre2-8.so.0*        "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libcap.so.2*            "${libdir}/."
+
+	# e2fsprogs (mke2fs/mkfs.ext4) runtime libs
+	cp -a "${stage_one}/${libdir}"/libext2fs.so.2*         "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libcom_err.so.2*        "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libe2p.so.2*            "${libdir}/."
+
+	# cryptsetup, mkfs.ext4, and dd are used by CDH secure_mount.
+	mkdir -p sbin etc bin
+	cp -a "${stage_one}/sbin/cryptsetup" sbin/.
 	cp -a "${stage_one}/sbin/mke2fs" sbin/.
 	cp -a "${stage_one}/sbin/mkfs.ext4" sbin/.
 	cp -a "${stage_one}/etc/mke2fs.conf" etc/.

--- a/tools/packaging/static-build/coco-guest-components/Dockerfile
+++ b/tools/packaging/static-build/coco-guest-components/Dockerfile
@@ -25,7 +25,6 @@ RUN apt-get update && \
 	g++ \
 	gcc \
 	git \
-	libcryptsetup-dev \
 	libssl-dev \
 	libtss2-dev \
 	make \

--- a/versions.yaml
+++ b/versions.yaml
@@ -292,7 +292,7 @@ externals:
   coco-guest-components:
     description: "Provides attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/guest-components/"
-    version: "de3f6ff62aa736619b80d99dfca5bc3d2c9a799d"
+    version: "1e5c48c9c15bc20a21df3ec6bf76eeefb89fea97"
     toolchain: "1.90.0"
 
   coco-trustee:


### PR DESCRIPTION
Update CDH to a newer version and adjust the NVIDIA root filesystem build to reflect the change from using libcryptsetup to using the cryptsetup binary.

The relevant change on CDH side is: https://github.com/confidential-containers/guest-components/pull/1380, see the issue https://github.com/confidential-containers/guest-components/issues/1426