### PR TITLE
genpolicy: support env variable values sourced from metadata.labels values

### DIFF
--- a/src/tools/genpolicy/src/cronjob.rs
+++ b/src/tools/genpolicy/src/cronjob.rs
@@ -176,4 +176,11 @@ impl yaml::K8sResource for CronJob {
             .securityContext
             .as_ref()
     }
+
+    fn get_labels(&self) -> &Option<BTreeMap<String, String>> {
+        if let Some(metadata) = &self.spec.jobTemplate.spec.template.metadata {
+            return &metadata.labels;
+        }
+        &None
+    }
 }

--- a/src/tools/genpolicy/src/daemon_set.rs
+++ b/src/tools/genpolicy/src/daemon_set.rs
@@ -171,4 +171,11 @@ impl yaml::K8sResource for DaemonSet {
     fn get_pod_security_context(&self) -> Option<&pod::PodSecurityContext> {
         self.spec.template.spec.securityContext.as_ref()
     }
+
+    fn get_labels(&self) -> &Option<BTreeMap<String, String>> {
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.labels;
+        }
+        &None
+    }
 }

--- a/src/tools/genpolicy/src/deployment.rs
+++ b/src/tools/genpolicy/src/deployment.rs
@@ -182,4 +182,11 @@ impl yaml::K8sResource for Deployment {
     fn get_pod_security_context(&self) -> Option<&pod::PodSecurityContext> {
         self.spec.template.spec.securityContext.as_ref()
     }
+
+    fn get_labels(&self) -> &Option<BTreeMap<String, String>> {
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.labels;
+        }
+        &None
+    }
 }

--- a/src/tools/genpolicy/src/job.rs
+++ b/src/tools/genpolicy/src/job.rs
@@ -171,6 +171,13 @@ impl yaml::K8sResource for Job {
     fn get_pod_security_context(&self) -> Option<&pod::PodSecurityContext> {
         self.spec.template.spec.securityContext.as_ref()
     }
+
+    fn get_labels(&self) -> &Option<BTreeMap<String, String>> {
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.labels;
+        }
+        &None
+    }
 }
 
 pub fn pod_name_regex(job_name: String) -> String {

--- a/src/tools/genpolicy/src/obj_meta.rs
+++ b/src/tools/genpolicy/src/obj_meta.rs
@@ -19,7 +19,7 @@ pub struct ObjectMeta {
     pub generateName: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    labels: Option<BTreeMap<String, String>>,
+    pub labels: Option<BTreeMap<String, String>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub annotations: Option<BTreeMap<String, String>>,

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -640,7 +640,7 @@ impl Container {
         config_maps: &Vec<config_map::ConfigMap>,
         secrets: &Vec<secret::Secret>,
         namespace: &str,
-        annotations: &Option<BTreeMap<String, String>>,
+        resource: &dyn yaml::K8sResource,
         service_account_name: &str,
     ) {
         if let Some(source_env) = &self.env {
@@ -649,7 +649,7 @@ impl Container {
                     config_maps,
                     secrets,
                     namespace,
-                    annotations,
+                    resource,
                     service_account_name,
                 );
                 let src_string = format!("{}={value}", &env_variable.name);
@@ -789,7 +789,7 @@ impl EnvVar {
         config_maps: &Vec<config_map::ConfigMap>,
         secrets: &Vec<secret::Secret>,
         namespace: &str,
-        annotations: &Option<BTreeMap<String, String>>,
+        resource: &dyn yaml::K8sResource,
         service_account_name: &str,
     ) -> String {
         // When neither `value` nor `valueFrom` were specified, the default value is an empty string:
@@ -801,7 +801,7 @@ impl EnvVar {
                 config_maps,
                 secrets,
                 namespace,
-                annotations,
+                resource,
                 service_account_name,
             )
             .unwrap_or_default()
@@ -813,7 +813,7 @@ impl EnvVar {
         config_maps: &Vec<config_map::ConfigMap>,
         secrets: &Vec<secret::Secret>,
         namespace: &str,
-        annotations: &Option<BTreeMap<String, String>>,
+        resource: &dyn yaml::K8sResource,
         service_account_name: &str,
     ) -> Option<String> {
         if let Some(value_from) = &self.valueFrom {
@@ -825,12 +825,9 @@ impl EnvVar {
                 return Some(value);
             }
 
-            if let Some(value) = self.get_value_from_field_ref(
-                value_from,
-                namespace,
-                annotations,
-                service_account_name,
-            ) {
+            if let Some(value) =
+                self.get_value_from_field_ref(value_from, namespace, resource, service_account_name)
+            {
                 return Some(value);
             }
 
@@ -850,7 +847,7 @@ impl EnvVar {
         &self,
         value_from: &EnvVarSource,
         namespace: &str,
-        annotations: &Option<BTreeMap<String, String>>,
+        resource: &dyn yaml::K8sResource,
         service_account_name: &str,
     ) -> Option<String> {
         if let Some(field_ref) = &value_from.fieldRef {
@@ -870,7 +867,7 @@ impl EnvVar {
                 "spec.nodeName" => "$(node-name)",
                 "spec.serviceAccountName" => service_account_name,
                 _ => {
-                    if let Some(value) = self.get_annotation_value(path, annotations) {
+                    if let Some(value) = self.get_annotation_value(path, resource) {
                         &value.to_string()
                     } else {
                         panic!(
@@ -889,12 +886,12 @@ impl EnvVar {
     fn get_annotation_value(
         &self,
         reference: &str,
-        anno: &Option<BTreeMap<String, String>>,
+        resource: &dyn yaml::K8sResource,
     ) -> Option<String> {
         let prefix = "metadata.annotations['";
         let suffix = "']";
         if reference.starts_with(prefix) && reference.ends_with(suffix) {
-            if let Some(annotations) = anno {
+            if let Some(annotations) = resource.get_annotations() {
                 let start = prefix.len();
                 let end = reference.len() - 2;
                 let annotation = reference[start..end].to_string();

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -869,6 +869,8 @@ impl EnvVar {
                 _ => {
                     if let Some(value) = self.get_annotation_value(path, resource) {
                         &value.to_string()
+                    } else if let Some(value) = self.get_label_value(path, resource) {
+                        &value.to_string()
                     } else {
                         panic!(
                             "Env var: unsupported field reference: {}",
@@ -908,6 +910,25 @@ impl EnvVar {
 
             // TODO: should missing annotations be handled differently?
             return Some("$(todo-annotation)".to_string());
+        }
+        None
+    }
+
+    fn get_label_value(&self, reference: &str, resource: &dyn yaml::K8sResource) -> Option<String> {
+        let prefix = "metadata.labels['";
+        let suffix = "']";
+        if reference.starts_with(prefix) && reference.ends_with(suffix) {
+            if let Some(labels) = resource.get_labels() {
+                let start = prefix.len();
+                let end = reference.len() - 2;
+                let label = reference[start..end].to_string();
+
+                if let Some(value) = labels.get(&label) {
+                    return Some(value.clone());
+                } else {
+                    panic!("Can't find the value of label {}.", &label);
+                }
+            }
         }
         None
     }
@@ -1002,6 +1023,10 @@ impl yaml::K8sResource for Pod {
 
     fn get_pod_security_context(&self) -> Option<&PodSecurityContext> {
         self.spec.securityContext.as_ref()
+    }
+
+    fn get_labels(&self) -> &Option<BTreeMap<String, String>> {
+        &self.metadata.labels
     }
 }
 

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -914,7 +914,7 @@ impl AgentPolicy {
             &self.config_maps,
             &self.secrets,
             namespace,
-            resource.get_annotations(),
+            resource,
             service_account_name,
         );
         debug!(

--- a/src/tools/genpolicy/src/replica_set.rs
+++ b/src/tools/genpolicy/src/replica_set.rs
@@ -132,4 +132,11 @@ impl yaml::K8sResource for ReplicaSet {
     fn get_pod_security_context(&self) -> Option<&pod::PodSecurityContext> {
         self.spec.template.spec.securityContext.as_ref()
     }
+
+    fn get_labels(&self) -> &Option<BTreeMap<String, String>> {
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.labels;
+        }
+        &None
+    }
 }

--- a/src/tools/genpolicy/src/replication_controller.rs
+++ b/src/tools/genpolicy/src/replication_controller.rs
@@ -135,4 +135,11 @@ impl yaml::K8sResource for ReplicationController {
     fn get_pod_security_context(&self) -> Option<&pod::PodSecurityContext> {
         self.spec.template.spec.securityContext.as_ref()
     }
+
+    fn get_labels(&self) -> &Option<BTreeMap<String, String>> {
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.labels;
+        }
+        &None
+    }
 }

--- a/src/tools/genpolicy/src/stateful_set.rs
+++ b/src/tools/genpolicy/src/stateful_set.rs
@@ -215,6 +215,13 @@ impl yaml::K8sResource for StatefulSet {
     fn get_pod_security_context(&self) -> Option<&pod::PodSecurityContext> {
         self.spec.template.spec.securityContext.as_ref()
     }
+
+    fn get_labels(&self) -> &Option<BTreeMap<String, String>> {
+        if let Some(metadata) = &self.spec.template.metadata {
+            return &metadata.labels;
+        }
+        &None
+    }
 }
 
 impl StatefulSet {

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -114,6 +114,10 @@ pub trait K8sResource {
     fn get_sysctls(&self) -> Vec<pod::Sysctl> {
         vec![]
     }
+
+    fn get_labels(&self) -> &Option<BTreeMap<String, String>> {
+        panic!("Unsupported");
+    }
 }
 
 /// See Reference / Kubernetes API / Common Definitions / LabelSelector.

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -349,4 +349,9 @@ mod tests {
     async fn test_create_container_ignored_fields() {
         runtests("createcontainer/ignored_fields").await;
     }
+
+    #[tokio::test]
+    async fn test_create_container_env_vars() {
+        runtests("createcontainer/env_vars").await;
+    }
 }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/env_vars/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/env_vars/pod.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: gid-experiment
+  labels:
+    app: gid-experiment
+    labels.test.com/test-label1: test-value1
+spec:
+  runtimeClassName: kata-cc-isolation
+  containers:
+  - name: gid
+    image: "ghcr.io/burgerdev/weird-images/gid:latest@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0"
+    env:
+    - name: TEST_VAR1
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.labels['labels.test.com/test-label1']

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/env_vars/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/env_vars/testcases.json
@@ -1,0 +1,654 @@
+[
+  {
+    "allowed": true,
+    "description": "Environment variable valueFrom.fieldRef.fieldPath + metadata.labels, allowed",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gid",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.kubernetes.cri.container-name": "gid",
+          "io.kubernetes.cri.container-type": "container",
+          "io.kubernetes.cri.image-name": "ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0",
+          "io.kubernetes.cri.sandbox-id": "8667fea11fc4fc70d427cc3645950ac83cc7d33ca515a8774ab95043f0096bb8",
+          "io.kubernetes.cri.sandbox-name": "gid-experiment",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "31df313a-931f-4979-a405-cc3f3ccb6a56"
+        },
+        "Hooks": null,
+        "Hostname": "",
+        "Linux": {
+          "CgroupsPath": "kubepods-burstable-pod31df313a_931f_4979_a405_cc3f3ccb6a56.slice:cri-containerd:gid",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": [
+            "/proc/asound",
+            "/proc/acpi",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/proc/scsi",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {
+              "Cpus": "",
+              "Mems": "",
+              "Period": 100000,
+              "Quota": 0,
+              "RealtimePeriod": 0,
+              "RealtimeRuntime": 0,
+              "Shares": 2
+            },
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": {
+              "DisableOOMKiller": false,
+              "Kernel": 0,
+              "KernelTCP": 0,
+              "Limit": 0,
+              "Reservation": 0,
+              "Swap": 0,
+              "Swappiness": 0
+            },
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {
+            "destination": "/proc",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "proc",
+            "type_": "proc"
+          },
+          {
+            "destination": "/dev",
+            "options": [
+              "nosuid",
+              "strictatime",
+              "mode=755",
+              "size=65536k"
+            ],
+            "source": "tmpfs",
+            "type_": "tmpfs"
+          },
+          {
+            "destination": "/dev/pts",
+            "options": [
+              "nosuid",
+              "noexec",
+              "newinstance",
+              "ptmxmode=0666",
+              "mode=0620",
+              "gid=5"
+            ],
+            "source": "devpts",
+            "type_": "devpts"
+          },
+          {
+            "destination": "/dev/mqueue",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "mqueue",
+            "type_": "mqueue"
+          },
+          {
+            "destination": "/sys",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "ro"
+            ],
+            "source": "sysfs",
+            "type_": "sysfs"
+          },
+          {
+            "destination": "/sys/fs/cgroup",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "relatime",
+              "ro"
+            ],
+            "source": "cgroup",
+            "type_": "cgroup"
+          },
+          {
+            "destination": "/etc/hosts",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-4a4c20d48254d738-hosts",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/termination-log",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-72cfcc0e64a0d1af-termination-log",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/hostname",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-89f0faae823d569c-hostname",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/resolv.conf",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-8c0d97703dbbb30e-resolv.conf",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/shm",
+            "options": [
+              "rbind"
+            ],
+            "source": "/run/kata-containers/sandbox/shm",
+            "type_": "bind"
+          },
+          {
+            "destination": "/var/run/secrets/kubernetes.io/serviceaccount",
+            "options": [
+              "rbind",
+              "rprivate",
+              "ro"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-be44d3a46e427870-serviceaccount",
+            "type_": "bind"
+          }
+        ],
+        "Process": {
+          "ApparmorProfile": "cri-containerd.apparmor.d",
+          "Args": [
+            "/entrypoint.sh"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HOSTNAME=gid-experiment",
+            "TEST_VAR1=test-value1"
+          ],
+          "NoNewPrivileges": false,
+          "OOMScoreAdj": 994,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              0
+            ],
+            "GID": 0,
+            "UID": 0,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/gid/rootfs",
+          "Readonly": false
+        },
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "gid",
+      "devices": [],
+      "exec_id": "gid",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/gid\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gid\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0\",\"io.kubernetes.cri.sandbox-id\":\"8667fea11fc4fc70d427cc3645950ac83cc7d33ca515a8774ab95043f0096bb8\",\"io.kubernetes.cri.sandbox-name\":\"gid-experiment\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"31df313a-931f-4979-a405-cc3f3ccb6a56\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/gid/rootfs",
+          "options": [],
+          "source": "ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0"
+        }
+      ],
+      "string_user": null
+    }
+  },
+  {
+    "allowed": false,
+    "description": "Environment variable valueFrom.fieldRef.fieldPath + metadata.labels, unexpected value",
+    "kind": "CreateContainerRequest",
+    "request": {
+      "OCI": {
+        "Annotations": {
+          "io.katacontainers.pkg.oci.bundle_path": "/run/containerd/io.containerd.runtime.v2.task/k8s.io/gid",
+          "io.katacontainers.pkg.oci.container_type": "pod_container",
+          "io.kubernetes.cri.container-name": "gid",
+          "io.kubernetes.cri.container-type": "container",
+          "io.kubernetes.cri.image-name": "ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0",
+          "io.kubernetes.cri.sandbox-id": "8667fea11fc4fc70d427cc3645950ac83cc7d33ca515a8774ab95043f0096bb8",
+          "io.kubernetes.cri.sandbox-name": "gid-experiment",
+          "io.kubernetes.cri.sandbox-namespace": "default",
+          "io.kubernetes.cri.sandbox-uid": "31df313a-931f-4979-a405-cc3f3ccb6a56"
+        },
+        "Hooks": null,
+        "Hostname": "",
+        "Linux": {
+          "CgroupsPath": "kubepods-burstable-pod31df313a_931f_4979_a405_cc3f3ccb6a56.slice:cri-containerd:gid",
+          "Devices": [],
+          "GIDMappings": [],
+          "IntelRdt": null,
+          "MaskedPaths": [
+            "/proc/asound",
+            "/proc/acpi",
+            "/proc/kcore",
+            "/proc/keys",
+            "/proc/latency_stats",
+            "/proc/timer_list",
+            "/proc/timer_stats",
+            "/proc/sched_debug",
+            "/proc/scsi",
+            "/sys/firmware",
+            "/sys/devices/virtual/powercap"
+          ],
+          "MountLabel": "",
+          "Namespaces": [
+            {
+              "Path": "",
+              "Type": "ipc"
+            },
+            {
+              "Path": "",
+              "Type": "uts"
+            },
+            {
+              "Path": "",
+              "Type": "mount"
+            }
+          ],
+          "ReadonlyPaths": [
+            "/proc/bus",
+            "/proc/fs",
+            "/proc/irq",
+            "/proc/sys",
+            "/proc/sysrq-trigger"
+          ],
+          "Resources": {
+            "BlockIO": null,
+            "CPU": {
+              "Cpus": "",
+              "Mems": "",
+              "Period": 100000,
+              "Quota": 0,
+              "RealtimePeriod": 0,
+              "RealtimeRuntime": 0,
+              "Shares": 2
+            },
+            "Devices": [],
+            "HugepageLimits": [],
+            "Memory": {
+              "DisableOOMKiller": false,
+              "Kernel": 0,
+              "KernelTCP": 0,
+              "Limit": 0,
+              "Reservation": 0,
+              "Swap": 0,
+              "Swappiness": 0
+            },
+            "Network": null,
+            "Pids": null
+          },
+          "RootfsPropagation": "",
+          "Seccomp": null,
+          "Sysctl": {},
+          "UIDMappings": []
+        },
+        "Mounts": [
+          {
+            "destination": "/proc",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "proc",
+            "type_": "proc"
+          },
+          {
+            "destination": "/dev",
+            "options": [
+              "nosuid",
+              "strictatime",
+              "mode=755",
+              "size=65536k"
+            ],
+            "source": "tmpfs",
+            "type_": "tmpfs"
+          },
+          {
+            "destination": "/dev/pts",
+            "options": [
+              "nosuid",
+              "noexec",
+              "newinstance",
+              "ptmxmode=0666",
+              "mode=0620",
+              "gid=5"
+            ],
+            "source": "devpts",
+            "type_": "devpts"
+          },
+          {
+            "destination": "/dev/mqueue",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev"
+            ],
+            "source": "mqueue",
+            "type_": "mqueue"
+          },
+          {
+            "destination": "/sys",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "ro"
+            ],
+            "source": "sysfs",
+            "type_": "sysfs"
+          },
+          {
+            "destination": "/sys/fs/cgroup",
+            "options": [
+              "nosuid",
+              "noexec",
+              "nodev",
+              "relatime",
+              "ro"
+            ],
+            "source": "cgroup",
+            "type_": "cgroup"
+          },
+          {
+            "destination": "/etc/hosts",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-4a4c20d48254d738-hosts",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/termination-log",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-72cfcc0e64a0d1af-termination-log",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/hostname",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-89f0faae823d569c-hostname",
+            "type_": "bind"
+          },
+          {
+            "destination": "/etc/resolv.conf",
+            "options": [
+              "rbind",
+              "rprivate",
+              "rw"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-8c0d97703dbbb30e-resolv.conf",
+            "type_": "bind"
+          },
+          {
+            "destination": "/dev/shm",
+            "options": [
+              "rbind"
+            ],
+            "source": "/run/kata-containers/sandbox/shm",
+            "type_": "bind"
+          },
+          {
+            "destination": "/var/run/secrets/kubernetes.io/serviceaccount",
+            "options": [
+              "rbind",
+              "rprivate",
+              "ro"
+            ],
+            "source": "/run/kata-containers/shared/containers/gid-be44d3a46e427870-serviceaccount",
+            "type_": "bind"
+          }
+        ],
+        "Process": {
+          "ApparmorProfile": "cri-containerd.apparmor.d",
+          "Args": [
+            "/entrypoint.sh"
+          ],
+          "Capabilities": {
+            "Ambient": [],
+            "Bounding": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Effective": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ],
+            "Inheritable": [],
+            "Permitted": [
+              "CAP_CHOWN",
+              "CAP_DAC_OVERRIDE",
+              "CAP_FSETID",
+              "CAP_FOWNER",
+              "CAP_MKNOD",
+              "CAP_NET_RAW",
+              "CAP_SETGID",
+              "CAP_SETUID",
+              "CAP_SETFCAP",
+              "CAP_SETPCAP",
+              "CAP_NET_BIND_SERVICE",
+              "CAP_SYS_CHROOT",
+              "CAP_KILL",
+              "CAP_AUDIT_WRITE"
+            ]
+          },
+          "ConsoleSize": null,
+          "Cwd": "/",
+          "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "HOSTNAME=gid-experiment",
+            "TEST_VAR1=test-value12"
+          ],
+          "NoNewPrivileges": false,
+          "OOMScoreAdj": 994,
+          "Rlimits": [],
+          "SelinuxLabel": "",
+          "Terminal": false,
+          "User": {
+            "AdditionalGids": [
+              0
+            ],
+            "GID": 0,
+            "UID": 0,
+            "Username": ""
+          }
+        },
+        "Root": {
+          "Path": "/run/kata-containers/gid/rootfs",
+          "Readonly": false
+        },
+        "Solaris": null,
+        "Version": "1.1.0",
+        "Windows": null
+      },
+      "container_id": "gid",
+      "devices": [],
+      "exec_id": "gid",
+      "sandbox_pidns": false,
+      "shared_mounts": [],
+      "stderr_port": 0,
+      "stdin_port": 0,
+      "stdout_port": 0,
+      "storages": [
+        {
+          "driver": "image_guest_pull",
+          "driver_options": [
+            "image_guest_pull={\"metadata\":{\"io.katacontainers.pkg.oci.bundle_path\":\"/run/containerd/io.containerd.runtime.v2.task/k8s.io/gid\",\"io.katacontainers.pkg.oci.container_type\":\"pod_container\",\"io.kubernetes.cri.container-name\":\"gid\",\"io.kubernetes.cri.container-type\":\"container\",\"io.kubernetes.cri.image-name\":\"ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0\",\"io.kubernetes.cri.sandbox-id\":\"8667fea11fc4fc70d427cc3645950ac83cc7d33ca515a8774ab95043f0096bb8\",\"io.kubernetes.cri.sandbox-name\":\"gid-experiment\",\"io.kubernetes.cri.sandbox-namespace\":\"default\",\"io.kubernetes.cri.sandbox-uid\":\"31df313a-931f-4979-a405-cc3f3ccb6a56\"}}"
+          ],
+          "fs_group": null,
+          "fstype": "overlay",
+          "mount_point": "/run/kata-containers/gid/rootfs",
+          "options": [],
+          "source": "ghcr.io/burgerdev/weird-images/gid@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0"
+        }
+      ],
+      "string_user": null
+    }
+  }
+]

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -91,11 +91,7 @@ create_and_wait_for_pod_ready() {
 	wait_for_pod_ready
 }
 
-@test "Successful pod with auto-generated policy" {
-	create_and_wait_for_pod_ready
-}
-
-@test "Able to read env variables sourced from configmap using envFrom" {
+@test "Successful pod and able to read env variables sourced from configmap using envFrom" {
 	create_and_wait_for_pod_ready
 
 	expected_env_var=$(kubectl exec "${pod_name}" -- "${exec_command[@]}")

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -20,8 +20,12 @@ setup() {
 
 	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
 
-	exec_command=(printenv data-3)
-	add_exec_to_policy_settings "${policy_settings_dir}" "${exec_command[@]}"
+	print_env_var_data3=(printenv data-3)
+	add_exec_to_policy_settings "${policy_settings_dir}" "${print_env_var_data3[@]}"
+
+	print_env_var_label=(printenv VARIABLE_FROM_LABEL)
+	add_exec_to_policy_settings "${policy_settings_dir}" "${print_env_var_label[@]}"
+
 	add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
 
 	correct_configmap_yaml="${pod_config_dir}/k8s-policy-configmap.yaml"
@@ -92,10 +96,15 @@ create_and_wait_for_pod_ready() {
 }
 
 @test "Successful pod and able to read env variables sourced from configmap using envFrom" {
+	local value
+
 	create_and_wait_for_pod_ready
 
-	expected_env_var=$(kubectl exec "${pod_name}" -- "${exec_command[@]}")
-	[ "$expected_env_var" = "value-3" ] || fail "expected_env_var is not equal to value-3"
+	value=$(kubectl exec "${pod_name}" -- "${print_env_var_data3[@]}")
+	[[ "$value" == "value-3" ]] || fail "value=${value} is not equal to value-3"
+
+	value=$(kubectl exec "${pod_name}" -- "${print_env_var_label[@]}")
+	[[ "$value" == "label-value1" ]] || fail "value=${value} is not equal to label-value1"
 }
 
 @test "Successful pod with auto-generated policy and runtimeClassName filter" {

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod.yaml
@@ -8,6 +8,8 @@ kind: Pod
 metadata:
   name: policy-pod
   uid: policy-pod-uid
+  labels:
+    some-test-label: label-value1
 spec:
   runtimeClassName: kata
   containers:
@@ -30,6 +32,11 @@ spec:
           value: foo
         - name: TEST_DIR2
           value: bar
+        - name: VARIABLE_FROM_LABEL
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['some-test-label']
       securityContext:
         seccompProfile:
           type: RuntimeDefault


### PR DESCRIPTION
Add basic genpolicy support for container environment variables sourced from metadata.labels.

In this implementation, the relevant labels must be available as input to the policy tool. This is slightly different from the way variables sourced from metadata.annotations are treated by the tool: when the relevant annotation is not available as input, the generated Policy allows any value. Depending on metadata.labels use cases that we might encounter maybe the labels will be handled the same way as the annotations in the future.
