### PR TITLE
runtime: Add support for physical VMBus devices

### DIFF
--- a/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/endpoint_persist.rs
@@ -6,6 +6,10 @@
 
 use serde::{Deserialize, Serialize};
 
+fn default_is_vfio() -> bool {
+    true
+}
+
 #[derive(Serialize, Deserialize, Clone, Default)]
 pub struct PhysicalEndpointState {
     pub bdf: String,
@@ -13,6 +17,13 @@ pub struct PhysicalEndpointState {
     pub vendor_id: String,
     pub device_id: String,
     pub hard_addr: String,
+    #[serde(default = "default_is_vfio")]
+    pub is_vfio: bool,
+    #[serde(default)]
+    pub iface_name: String,
+    /// "pci" or "vmbus"
+    #[serde(default)]
+    pub bus_type: String,
 }
 
 #[derive(Serialize, Deserialize, Clone, Default)]

--- a/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/physical_endpoint.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::io::{self, Error};
 use std::path::Path;
 use std::sync::Arc;
 
@@ -11,8 +12,9 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use futures_lite::stream::StreamExt;
 use hypervisor::device::device_manager::{do_handle_device, DeviceManager};
-use hypervisor::device::DeviceConfig;
-use hypervisor::{device::driver, Hypervisor};
+use hypervisor::device::driver::NetworkConfig;
+use hypervisor::device::{DeviceConfig, DeviceType};
+use hypervisor::{device::driver, Hypervisor, NetworkDevice};
 use hypervisor::{get_vfio_device, VfioConfig};
 use kata_sys_util::netns::NetnsGuard;
 use netlink_packet_core::{NetlinkMessage, NLM_F_ACK, NLM_F_CREATE, NLM_F_EXCL, NLM_F_REQUEST};
@@ -25,8 +27,8 @@ use tokio::sync::RwLock;
 
 use super::endpoint_persist::{EndpointState, PhysicalEndpointState};
 use super::Endpoint;
+use crate::network::network_pair::NetworkPair;
 use crate::network::utils::{self, link};
-pub const SYS_PCI_DEVICES_PATH: &str = "/sys/bus/pci/devices";
 
 #[derive(Debug)]
 pub struct VendorDevice {
@@ -61,6 +63,9 @@ pub struct PhysicalEndpoint {
     bdf: String,
     driver: String,
     vendor_device_id: VendorDevice,
+    is_vfio: bool,
+    bus_type: link::BusType,
+    net_pair: NetworkPair,
     d: Arc<RwLock<DeviceManager>>,
     /// Guest PCI path — populated after QMP resolution in setup_after_start_vm.
     /// The pre-computed topology path from attach() is WRONG for physical
@@ -73,25 +78,61 @@ pub struct PhysicalEndpoint {
 }
 
 impl PhysicalEndpoint {
-    pub fn new(name: &str, hardware_addr: &[u8], d: Arc<RwLock<DeviceManager>>) -> Result<Self> {
-        let driver_info = link::get_driver_info(name).context("get driver info")?;
-        let bdf = driver_info.bus_info;
-        let sys_pci_devices_path = Path::new(SYS_PCI_DEVICES_PATH);
-        // get driver by following symlink /sys/bus/pci/devices/$bdf/driver
-        let driver_path = sys_pci_devices_path.join(&bdf).join("driver");
-        let link = driver_path.read_link().context("read link")?;
-        let driver = link
+    /// Create a new PhysicalEndpoint.
+    ///
+    /// For VFIO-capable (PCI) devices, the NIC will be passed through
+    /// to the VM via VFIO — no tap/bridge pair is needed, so we create a minimal
+    /// stub NetworkPair.
+    ///
+    /// For non-VFIO physical NICs (e.g. VMBus), we need a real tap+bridge pair
+    /// (like veth endpoints use) so that traffic can flow between the host NIC
+    /// and the VM through the hypervisor's TAP backend. The `handle`, `idx`,
+    /// `model`, and `queues` parameters are required to create this pair.
+    pub async fn new(
+        handle: &rtnetlink::Handle,
+        name: &str,
+        hardware_addr: &[u8],
+        idx: u32,
+        model: &str,
+        queues: usize,
+        d: Arc<RwLock<DeviceManager>>,
+    ) -> Result<Self> {
+        // Determine bus type (PCI or VMBus) and resolve the sysfs device path.
+        // For PCI: uses ethtool to get BDF, path = /sys/bus/pci/devices/<bdf>
+        // For VMBus: resolves device symlink, path = /sys/bus/vmbus/devices/<guid>
+        let (sys_iface_device_path, bdf, bus_type) =
+            link::get_iface_device_path(name).context("get iface device path")?;
+        let sys_device_path = Path::new(&sys_iface_device_path);
+
+        // Get driver by following symlink <device_path>/driver
+        let driver_path = sys_device_path.join("driver");
+        let link_target = driver_path.read_link().context("read link")?;
+        let driver = link_target
             .file_name()
             .map_or(String::new(), |v| v.to_str().unwrap().to_owned());
 
-        // get vendor and device id from pci space (sys/bus/pci/devices/$bdf)
-        let iface_device_path = sys_pci_devices_path.join(&bdf).join("device");
+        // Get vendor and device id from sysfs device path
+        let iface_device_path = sys_device_path.join("device");
         let device_id = std::fs::read_to_string(&iface_device_path)
             .with_context(|| format!("read device path {:?}", &iface_device_path))?;
 
-        let iface_vendor_path = sys_pci_devices_path.join(&bdf).join("vendor");
+        let iface_vendor_path = sys_device_path.join("vendor");
         let vendor_id = std::fs::read_to_string(&iface_vendor_path)
             .with_context(|| format!("read vendor path {:?}", &iface_vendor_path))?;
+        let is_vfio = bus_type == link::BusType::Pci;
+
+        // VFIO devices (PCI) use VFIO passthrough — no real tap/bridge needed.
+        // Non-VFIO devices (VMBus) need a real tap+bridge pair for the hypervisor to
+        // connect the host NIC traffic into the VM, matching Go's
+        // createNetworkInterfacePair() call in createPhysicalEndpoint().
+        let net_pair = if is_vfio {
+            NetworkPair::new_for_physical(name, hardware_addr, is_vfio)
+                .context("new network pair for physical vfio endpoint")?
+        } else {
+            NetworkPair::new(handle, idx, name, model, queues)
+                .await
+                .context("new network pair for physical non-vfio endpoint")?
+        };
 
         Ok(Self {
             iface_name: name.to_string(),
@@ -100,9 +141,34 @@ impl PhysicalEndpoint {
                 .context("new vendor device")?,
             driver,
             bdf,
+            is_vfio,
+            bus_type,
+            net_pair,
             d,
             guest_pci_path: std::sync::Mutex::new(None),
             hostdev_id: std::sync::Mutex::new(None),
+        })
+    }
+
+    #[allow(dead_code)]
+    pub fn network_pair(&self) -> &NetworkPair {
+        &self.net_pair
+    }
+
+    fn get_network_config(&self) -> Result<NetworkConfig> {
+        let iface = &self.net_pair.tap.tap_iface;
+        let guest_mac = utils::parse_mac(&iface.hard_addr).ok_or_else(|| {
+            Error::new(
+                io::ErrorKind::InvalidData,
+                format!("hard_addr {}", &iface.hard_addr),
+            )
+        })?;
+
+        Ok(NetworkConfig {
+            host_dev_name: iface.name.clone(),
+            virt_iface_name: self.net_pair.virt_iface.name.clone(),
+            guest_mac: Some(guest_mac),
+            ..Default::default()
         })
     }
 }
@@ -118,93 +184,115 @@ impl Endpoint for PhysicalEndpoint {
     }
 
     async fn attach(&self) -> Result<()> {
-        // Push the desired netdev MAC down to the VF as an "admin MAC" via the
-        // PF before we rebind to vfio-pci. Without this the guest mlx5_core
-        // inherits the VF firmware default MAC, which differs from the
-        // IB port HCA MAC, causing mlx5_ib's GID cache to not populate and
-        // all RoCE verbs needing a GID to fail.
-        // Best-effort: on error we warn and fall back to agent-side MAC
-        // reconciliation (update_interface in rpc.rs).
-        if !self.hard_addr.is_empty() && !self.bdf.is_empty() {
-            let bdf = self.bdf.clone();
-            let mac = self.hard_addr.clone();
-            match tokio::task::spawn_blocking(move || set_vf_admin_mac_sync(&bdf, &mac))
-                .await
-                .context("spawn_blocking set_vf_admin_mac")?
-            {
-                Ok(()) => {}
-                Err(e) => {
-                    warn!(
-                        sl!(),
-                        "set_vf_admin_mac: skipped for {} ({}), \
-                         falling back to in-guest MAC reconciliation",
-                        self.bdf,
-                        e
-                    );
+        if self.is_vfio {
+            // Push the desired netdev MAC down to the VF as an "admin MAC" via the
+            // PF before we rebind to vfio-pci. Without this the guest mlx5_core
+            // inherits the VF firmware default MAC, which differs from the
+            // IB port HCA MAC, causing mlx5_ib's GID cache to not populate and
+            // all RoCE verbs needing a GID to fail.
+            // Best-effort: on error we warn and fall back to agent-side MAC
+            // reconciliation (update_interface in rpc.rs).
+            if !self.hard_addr.is_empty() && !self.bdf.is_empty() {
+                let bdf = self.bdf.clone();
+                let mac = self.hard_addr.clone();
+                match tokio::task::spawn_blocking(move || set_vf_admin_mac_sync(&bdf, &mac))
+                    .await
+                    .context("spawn_blocking set_vf_admin_mac")?
+                {
+                    Ok(()) => {}
+                    Err(e) => {
+                        warn!(
+                            sl!(),
+                            "set_vf_admin_mac: skipped for {} ({}), \
+                            falling back to in-guest MAC reconciliation",
+                            self.bdf,
+                            e
+                        );
+                    }
                 }
             }
-        }
+            // bind physical interface from host driver and bind to vfio
+            driver::bind_device_to_vfio(
+                &self.bdf,
+                &self.driver,
+                &self.vendor_device_id.vendor_device_id(),
+            )
+            .with_context(|| format!("bind physical endpoint from {} to vfio", &self.driver))?;
 
-        // bind physical interface from host driver and bind to vfio
-        driver::bind_device_to_vfio(
-            &self.bdf,
-            &self.driver,
-            &self.vendor_device_id.vendor_device_id(),
-        )
-        .with_context(|| format!("bind physical endpoint from {} to vfio", &self.driver))?;
+            let vfio_device =
+                get_vfio_device(self.bdf.clone()).context("get vfio device failed.")?;
+            let vfio_dev_config = &mut VfioConfig {
+                host_path: vfio_device.clone(),
+                dev_type: "pci".to_string(),
+                hostdev_prefix: "physical_nic_".to_owned(),
+                ..Default::default()
+            };
 
-        let vfio_device = get_vfio_device(self.bdf.clone()).context("get vfio device failed.")?;
-        let vfio_dev_config = &mut VfioConfig {
-            host_path: vfio_device.clone(),
-            dev_type: "pci".to_string(),
-            hostdev_prefix: "physical_nic_".to_owned(),
-            ..Default::default()
-        };
+            // create and insert VFIO device into Kata VM; do_handle_device returns
+            // the DeviceType with guest_pci_path already computed by
+            // do_add_pcie_endpoint() inside VfioDevice::register().
+            let device_type =
+                do_handle_device(&self.d, &DeviceConfig::VfioCfg(vfio_dev_config.clone()))
+                    .await
+                    .context("do handle device failed.")?;
 
-        // create and insert VFIO device into Kata VM; do_handle_device returns
-        // the DeviceType with guest_pci_path already computed by
-        // do_add_pcie_endpoint() inside VfioDevice::register().
-        let device_type =
-            do_handle_device(&self.d, &DeviceConfig::VfioCfg(vfio_dev_config.clone()))
-                .await
-                .context("do handle device failed.")?;
-
-        // Store the QEMU hostdev_id for later QMP-based PCI path resolution.
-        // The topology-computed guest_pci_path from do_add_pcie_endpoint() is
-        // WRONG for physical endpoints (root port has no explicit addr so QEMU
-        // auto-assigns its slot; the correct path requires QMP after VM boot).
-        if let hypervisor::device::DeviceType::Vfio(vfio_dev) = device_type {
-            if let Some(hostdev) = vfio_dev.devices.first() {
-                if let Ok(mut guard) = self.hostdev_id.lock() {
-                    *guard = Some(hostdev.hostdev_id.clone());
+            // Store the QEMU hostdev_id for later QMP-based PCI path resolution.
+            // The topology-computed guest_pci_path from do_add_pcie_endpoint() is
+            // WRONG for physical endpoints (root port has no explicit addr so QEMU
+            // auto-assigns its slot; the correct path requires QMP after VM boot).
+            if let hypervisor::device::DeviceType::Vfio(vfio_dev) = device_type {
+                if let Some(hostdev) = vfio_dev.devices.first() {
+                    if let Ok(mut guard) = self.hostdev_id.lock() {
+                        *guard = Some(hostdev.hostdev_id.clone());
+                    }
                 }
             }
-        }
 
-        Ok(())
+            Ok(())
+        } else {
+            self.net_pair
+                .add_network_model()
+                .await
+                .context("add network model")?;
+            let config = self.get_network_config().context("get network config")?;
+            do_handle_device(&self.d, &DeviceConfig::NetworkCfg(config))
+                .await
+                .context("do handle network Physical endpoint device failed.")?;
+            Ok(())
+        }
     }
 
     // detach for physical endpoint unbinds the physical network interface from vfio-pci
     // and binds it back to the saved host driver.
     async fn detach(&self, _hypervisor: &dyn Hypervisor) -> Result<()> {
-        // bind back the physical network interface to host.
-        // we need to do this even if a new network namespace has not
-        // been created by virt-containers.
-
-        // we do not need to enter the network namespace to bind back the
-        // physical interface to host driver.
-        driver::bind_device_to_host(
-            &self.bdf,
-            &self.driver,
-            &self.vendor_device_id.vendor_device_id(),
-        )
-        .with_context(|| {
-            format!(
-                "bind physical endpoint device from vfio to {}",
-                &self.driver
+        if self.is_vfio {
+            driver::bind_device_to_host(
+                &self.bdf,
+                &self.driver,
+                &self.vendor_device_id.vendor_device_id(),
             )
-        })?;
-        Ok(())
+            .with_context(|| {
+                format!(
+                    "bind physical endpoint device from vfio to {}",
+                    &self.driver
+                )
+            })?;
+            Ok(())
+        } else {
+            self.net_pair
+                .del_network_model()
+                .await
+                .context("del network model")?;
+            let config = self.get_network_config().context("get network config")?;
+            _hypervisor
+                .remove_device(DeviceType::Network(NetworkDevice {
+                    config,
+                    ..Default::default()
+                }))
+                .await
+                .context("remove Physical endpoint device by hypervisor failed.")?;
+            Ok(())
+        }
     }
 
     async fn save(&self) -> Option<EndpointState> {
@@ -215,6 +303,12 @@ impl Endpoint for PhysicalEndpoint {
                 vendor_id: self.vendor_device_id.vendor_id.clone(),
                 device_id: self.vendor_device_id.device_id.clone(),
                 hard_addr: self.hard_addr.clone(),
+                is_vfio: self.is_vfio,
+                iface_name: self.iface_name.clone(),
+                bus_type: match self.bus_type {
+                    link::BusType::Pci => "pci".to_string(),
+                    link::BusType::Vmbus => "vmbus".to_string(),
+                },
             }),
             ..Default::default()
         })

--- a/src/runtime-rs/crates/resource/src/network/network_pair.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_pair.rs
@@ -39,6 +39,35 @@ pub struct NetworkPair {
 }
 
 impl NetworkPair {
+    pub(crate) fn new_for_physical(name: &str, hardware_addr: &[u8], is_vfio: bool) -> Result<Self> {
+        let unique_id = kata_sys_util::rand::UUID::new();
+        let model = network_model::new("none").context("new none model")?;
+        let hard_addr = utils::get_mac_addr(hardware_addr).context("get mac addr")?;
+
+        Ok(Self {
+            tap: TapInterface {
+                id: String::from(&unique_id),
+                name: String::new(),
+                tap_iface: NetworkInterface {
+                    name: if is_vfio {
+                        String::new()
+                    } else {
+                        name.to_string()
+                    },
+                    hard_addr: hard_addr.clone(),
+                    ..Default::default()
+                },
+            },
+            virt_iface: NetworkInterface {
+                name: name.to_string(),
+                hard_addr,
+                ..Default::default()
+            },
+            model,
+            network_qos: false,
+        })
+    }
+
     pub(crate) async fn new(
         handle: &rtnetlink::Handle,
         idx: u32,
@@ -265,5 +294,34 @@ mod tests {
                 assert!(delete_link(&handle, tap_name.as_str()).await.is_ok());
             }
         }
+    }
+
+    #[test]
+    fn test_new_for_physical_vfio() {
+        let name = "enp3s0f1";
+        let hardware_addr = &[0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff];
+        let pair = NetworkPair::new_for_physical(name, hardware_addr, true).unwrap();
+
+        // VFIO: tap_iface.name should be empty (VFIO passthrough, no tap needed)
+        assert!(pair.tap.tap_iface.name.is_empty());
+        // virt_iface should still carry the interface name
+        assert_eq!(pair.virt_iface.name, name);
+        // MAC addresses should be set on both sides
+        assert!(!pair.tap.tap_iface.hard_addr.is_empty());
+        assert_eq!(pair.tap.tap_iface.hard_addr, pair.virt_iface.hard_addr);
+        assert!(!pair.network_qos);
+    }
+
+    #[test]
+    fn test_new_for_physical_non_vfio() {
+        let name = "enp4s0";
+        let hardware_addr = &[0x11, 0x22, 0x33, 0x44, 0x55, 0x66];
+        let pair = NetworkPair::new_for_physical(name, hardware_addr, false).unwrap();
+
+        // Non-VFIO: tap_iface.name should be the interface name (used by hypervisor)
+        assert_eq!(pair.tap.tap_iface.name, name);
+        assert_eq!(pair.virt_iface.name, name);
+        assert!(!pair.tap.tap_iface.hard_addr.is_empty());
+        assert_eq!(pair.tap.tap_iface.hard_addr, pair.virt_iface.hard_addr);
     }
 }

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -287,8 +287,17 @@ async fn create_endpoint(
             &attrs.name,
             nix::unistd::gettid()
         );
-        let t = PhysicalEndpoint::new(&attrs.name, &attrs.hardware_addr, d)
-            .context("new physical endpoint")?;
+        let t = PhysicalEndpoint::new(
+            handle,
+            &attrs.name,
+            &attrs.hardware_addr,
+            idx,
+            &config.network_model,
+            config.queues,
+            d,
+        )
+        .await
+        .context("new physical endpoint")?;
         Arc::new(t)
     } else {
         info!(
@@ -359,9 +368,7 @@ fn is_physical_iface(name: &str) -> Result<bool> {
     if name == "lo" {
         return Ok(false);
     }
-    let driver_info = link::get_driver_info(name)?;
-    if driver_info.bus_info.split(':').count() != 3 {
-        return Ok(false);
-    }
-    Ok(true)
+    // A physical interface is one backed by a PCI or VMBus device.
+    // This mirrors Go's isPhysicalIface which checks ParentDevBus == "pci" || "vmbus".
+    Ok(link::get_bus_type(name)?.is_some())
 }

--- a/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/utils/link/mod.rs
@@ -12,6 +12,93 @@ mod macros;
 mod manager;
 pub use manager::get_link_from_message;
 
+use std::path::Path;
+
+use anyhow::{anyhow, Context, Result};
+
+/// The bus type backing a physical network interface.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BusType {
+    Pci,
+    Vmbus,
+}
+
+/// Determines the bus type of a network interface by reading the
+/// `/sys/class/net/<name>/device/subsystem` symlink.
+///
+/// Returns `Some(BusType)` for PCI or VMBus devices, `None` for virtual
+/// interfaces that have no backing hardware device (veth, bridge, etc.).
+///
+/// Note: this relies on sysfs being available and complete in the caller's
+/// mount namespace. The Go implementation in `isPhysicalIface` /
+/// `getDevicesPath` uses the netlink `ParentDevBus` attribute instead, which
+/// works inside network namespaces where sysfs may not be mounted. If this
+/// Rust code is run in such an environment, prefer a netlink-based
+/// implementation.
+pub fn get_bus_type(name: &str) -> Result<Option<BusType>> {
+    get_bus_type_in("/sys/class/net", name)
+}
+
+/// Inner implementation of [`get_bus_type`] that takes the sysfs base path as
+/// a parameter so tests can substitute a tempdir.
+fn get_bus_type_in<P: AsRef<Path>>(base: P, name: &str) -> Result<Option<BusType>> {
+    let subsystem_path = base.as_ref().join(name).join("device/subsystem");
+    match std::fs::read_link(&subsystem_path) {
+        Ok(target) => {
+            let bus_name = target.file_name().and_then(|f| f.to_str()).unwrap_or("");
+            match bus_name {
+                "pci" => Ok(Some(BusType::Pci)),
+                "vmbus" => Ok(Some(BusType::Vmbus)),
+                _ => Ok(None),
+            }
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(anyhow!(e).context(format!(
+            "failed to read subsystem symlink for interface {}",
+            name
+        ))),
+    }
+}
+
+/// Returns the sysfs device path and device identifier for a network interface.
+///
+/// For PCI devices, uses ethtool to get the BDF (e.g. "0000:01:00.0") and
+/// returns `/sys/bus/pci/devices/<bdf>`.
+///
+/// For VMBus devices, resolves `/sys/class/net/<name>/device` to get the
+/// device GUID and returns `/sys/bus/vmbus/devices/<guid>`.
+///
+/// This corresponds to Go's `getIfaceDevicePath()` which branches on
+/// `link.Attrs().ParentDevBus`. Unlike the Go path, which reaches the bus
+/// type via netlink, this function depends on sysfs (`/sys/class/net` and
+/// `/sys/bus/...`) being mounted and complete in the caller's mount
+/// namespace.
+pub fn get_iface_device_path(name: &str) -> Result<(String, String, BusType)> {
+    let bus_type = get_bus_type(name)?
+        .ok_or_else(|| anyhow!("unsupported or no bus for interface {}", name))?;
+
+    match bus_type {
+        BusType::Pci => {
+            let driver_info = get_driver_info(name).context("get driver info")?;
+            let bdf = driver_info.bus_info;
+            let path = Path::new("/sys/bus/pci/devices").join(&bdf);
+            Ok((path.to_string_lossy().into_owned(), bdf, BusType::Pci))
+        }
+        BusType::Vmbus => {
+            let device_link = Path::new("/sys/class/net").join(name).join("device");
+            let resolved =
+                std::fs::canonicalize(&device_link).context("resolve vmbus device path")?;
+            let guid = resolved
+                .file_name()
+                .and_then(|f| f.to_str())
+                .ok_or_else(|| anyhow!("failed to get vmbus device guid"))?
+                .to_string();
+            let path = Path::new("/sys/bus/vmbus/devices").join(&guid);
+            Ok((path.to_string_lossy().into_owned(), guid, BusType::Vmbus))
+        }
+    }
+}
+
 use std::os::unix::io::RawFd;
 
 use netlink_packet_route::link::State;
@@ -145,4 +232,73 @@ pub trait Link: Send + Sync {
     fn attrs(&self) -> &LinkAttrs;
     fn set_attrs(&mut self, attr: LinkAttrs);
     fn r#type(&self) -> &str;
+}
+
+
+#[cfg(test)]
+mod bus_type_tests {
+    use super::{get_bus_type_in, BusType};
+    use std::os::unix::fs::symlink;
+    use tempfile::tempdir;
+
+    // Build a fake sysfs layout under ase:
+    //   <base>/<iface>/device/subsystem -> <base>/bus/<bus_name>
+    // and return the iface name. If us_name is None, the symlink target
+    // is a non-bus path so the function should return Ok(None).
+    fn make_iface(base: &std::path::Path, iface: &str, bus_name: Option<&str>) {
+        let dev_dir = base.join(iface).join("device");
+        std::fs::create_dir_all(&dev_dir).unwrap();
+        let target = match bus_name {
+            Some(b) => {
+                let bus_dir = base.join("bus").join(b);
+                std::fs::create_dir_all(&bus_dir).unwrap();
+                bus_dir
+            }
+            None => {
+                let other = base.join("other").join("virtual");
+                std::fs::create_dir_all(&other).unwrap();
+                other
+            }
+        };
+        symlink(target, dev_dir.join("subsystem")).unwrap();
+    }
+
+    #[test]
+    fn pci_interface_is_detected() {
+        let tmp = tempdir().unwrap();
+        make_iface(tmp.path(), "eth0", Some("pci"));
+        let bus = get_bus_type_in(tmp.path(), "eth0").unwrap();
+        assert_eq!(bus, Some(BusType::Pci));
+    }
+
+    #[test]
+    fn vmbus_interface_is_detected() {
+        let tmp = tempdir().unwrap();
+        make_iface(tmp.path(), "eth1", Some("vmbus"));
+        let bus = get_bus_type_in(tmp.path(), "eth1").unwrap();
+        assert_eq!(bus, Some(BusType::Vmbus));
+    }
+
+    #[test]
+    fn unknown_bus_returns_none() {
+        let tmp = tempdir().unwrap();
+        make_iface(tmp.path(), "veth0", Some("usb"));
+        let bus = get_bus_type_in(tmp.path(), "veth0").unwrap();
+        assert_eq!(bus, None);
+    }
+
+    #[test]
+    fn virtual_interface_returns_none() {
+        let tmp = tempdir().unwrap();
+        make_iface(tmp.path(), "veth1", None);
+        let bus = get_bus_type_in(tmp.path(), "veth1").unwrap();
+        assert_eq!(bus, None);
+    }
+
+    #[test]
+    fn missing_interface_returns_none() {
+        let tmp = tempdir().unwrap();
+        let bus = get_bus_type_in(tmp.path(), "nosuch").unwrap();
+        assert_eq!(bus, None);
+    }
 }

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -1049,6 +1049,22 @@ func tapNetworkPair(ctx context.Context, endpoint Endpoint, queues int, disableV
 	if err != nil {
 		return err
 	}
+	// Physical NICs (e.g. Azure accelerated networking VFs) require
+	// the link to be down before changing the MAC address; otherwise
+	// the driver returns EBUSY.  Bring it down, swap the MAC, and
+	// it will be brought back up via the deferred LinkSetUp.
+	// Virtual endpoints (veths, etc.) don't need this.
+	if _, isPhysical := endpoint.(*PhysicalEndpoint); isPhysical {
+		if err := netHandle.LinkSetDown(link); err != nil {
+			networkLogger().WithError(err).Error("tapNetworkPair: could not bring link down for MAC swap")
+			return fmt.Errorf("Could not disable %s for MAC swap: %s", netPair.VirtIface.Name, err)
+		}
+		defer func() {
+			if err := netHandle.LinkSetUp(link); err != nil {
+				networkLogger().WithError(err).Warnf("tapNetworkPair: could not bring %s back up", netPair.VirtIface.Name)
+			}
+		}()
+	}
 	if err := netHandle.LinkSetHardwareAddr(link, hardAddr); err != nil {
 		return fmt.Errorf("Could not set MAC address %s for veth interface %s: %s",
 			netPair.VirtIface.HardAddr, netPair.VirtIface.Name, err)

--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -134,39 +134,47 @@ func (n *LinuxNetwork) addSingleEndpoint(ctx context.Context, s *Sandbox, netInf
 
 	// Check if interface is a physical interface. Do not create
 	// tap interface/bridge if it is.
-	isPhysical, err := isPhysicalIface(netInfo.Iface.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	if isPhysical {
-		if s.config.HypervisorConfig.ColdPlugVFIO == config.NoPort {
-			// When `cold_plug_vfio` is set to "no-port", the PhysicalEndpoint's VFIO device cannot be attached to the guest VM.
-			// Fail early to prevent the VF interface from being unbound and rebound to the VFIO driver.
-			return nil, fmt.Errorf("unable to add PhysicalEndpoint %s because cold_plug_vfio is disabled", netInfo.Iface.Name)
+	// netInfo.Link may be nil when coming from the hotplug path
+	// (Sandbox.generateNetInfo does not populate it).  Resolve the link
+	// now so isPhysicalIface() and createPhysicalEndpoint() have access
+	// to its attributes (e.g. ParentDevBus).
+	if netInfo.Link == nil {
+		l, err := netlink.LinkByName(netInfo.Iface.Name)
+		if err != nil {
+			return nil, fmt.Errorf("failed to resolve link %q: %w", netInfo.Iface.Name, err)
 		}
-		networkLogger().WithField("interface", netInfo.Iface.Name).Info("Physical network interface found")
-		endpoint, err = createPhysicalEndpoint(netInfo)
-	} else {
-		var socketPath string
-		idx := len(n.eps)
+		netInfo.Link = l
+	}
+	isPhysical := isPhysicalIface(netInfo.Link)
+	var err error
+	idx := len(n.eps)
 
-		// Avoid endpoint naming conflicts
-		// When creating a new endpoint, we check existing endpoint names and automatically adjust the naming of the new endpoint to ensure uniqueness.
-		lastIdx := -1
-		if len(n.eps) > 0 {
-			lastEndpoint := n.eps[len(n.eps)-1]
-			re := regexp.MustCompile("[0-9]+")
-			matchStr := re.FindString(lastEndpoint.Name())
-			n, err := strconv.ParseInt(matchStr, 10, 64)
+	// Avoid endpoint naming conflicts
+	// When creating a new endpoint, we check existing endpoint names and automatically adjust the naming of the new endpoint to ensure uniqueness.
+	lastIdx := -1
+	if len(n.eps) > 0 {
+		lastEndpoint := n.eps[len(n.eps)-1]
+		re := regexp.MustCompile("[0-9]+")
+		matchStr := re.FindString(lastEndpoint.Name())
+		if matchStr != "" {
+			parsedIdx, err := strconv.ParseInt(matchStr, 10, strconv.IntSize)
 			if err != nil {
 				return nil, err
 			}
-			lastIdx = int(n)
+			lastIdx = int(parsedIdx)
 		}
-		if idx <= lastIdx {
-			idx = lastIdx + 1
-		}
+	}
+	if idx <= lastIdx {
+		idx = lastIdx + 1
+	}
+
+	if isPhysical {
+		networkLogger().WithField("interface", netInfo.Iface.Name).Info("Physical network interface found")
+		isVFIODisabled := (s.config.HypervisorConfig.ColdPlugVFIO == config.NoPort)
+		endpoint, err = createPhysicalEndpoint(idx, netInfo, isVFIODisabled, n.interworkingModel)
+	} else {
+		var socketPath string
+
 		// Check if this is a dummy interface which has a vhost-user socket associated with it
 		socketPath, err = vhostUserSocketPath(netInfo)
 		if err != nil {
@@ -793,6 +801,8 @@ func getLinkForEndpoint(endpoint Endpoint, netHandle *netlink.Handle) (netlink.L
 	name := netPair.VirtIface.Name
 
 	switch endpoint.(type) {
+	case *PhysicalEndpoint:
+		return getLinkByName(netHandle, name, &netlink.Device{})
 	case *VethEndpoint:
 		link, err := netHandle.LinkByName(name)
 		if err != nil {
@@ -820,6 +830,10 @@ func getLinkByName(netHandle *netlink.Handle, name string, expectedLink netlink.
 	}
 
 	switch expectedLink.Type() {
+	case (&netlink.Device{}).Type():
+		if l, ok := link.(*netlink.Device); ok {
+			return l, nil
+		}
 	case (&netlink.Tuntap{}).Type():
 		if l, ok := link.(*netlink.Tuntap); ok {
 			return l, nil
@@ -1454,6 +1468,15 @@ func addRxRateLimiter(endpoint Endpoint, maxRate uint64) error {
 		linkName = netPair.TAPIface.Name
 	case *MacvtapEndpoint, *TapEndpoint:
 		linkName = endpoint.Name()
+	case *PhysicalEndpoint:
+		if ep.IsVFIO {
+			// VFIO endpoints use VFIO passthrough; rate limiting is handled by
+			// the hypervisor / physical function and does not apply here.
+			return nil
+		}
+		// Non-VFIO physical NICs are tap-backed; apply rx limiting on the tap.
+		netPair := endpoint.NetworkPair()
+		linkName = netPair.TapInterface.TAPIface.Name
 	default:
 		return fmt.Errorf("Unsupported endpointType %s for adding rx rate limiter", ep.Type())
 	}
@@ -1626,6 +1649,15 @@ func addTxRateLimiter(endpoint Endpoint, maxRate uint64) error {
 
 	case *MacvtapEndpoint, *TapEndpoint:
 		linkName = endpoint.Name()
+	case *PhysicalEndpoint:
+		if ep.IsVFIO {
+			// VFIO endpoints use VFIO passthrough; rate limiting is handled by
+			// the hypervisor / physical function and does not apply here.
+			return nil
+		}
+		// Non-VFIO physical NICs are tap-backed; apply IFB-based tx limiting via tap.
+		netPair = endpoint.NetworkPair()
+		linkName = netPair.TapInterface.TAPIface.Name
 	default:
 		return fmt.Errorf("Unsupported endpointType %s for adding tx rate limiter", ep.Type())
 	}
@@ -1684,6 +1716,12 @@ func removeRxRateLimiter(endpoint Endpoint, networkNSPath string) error {
 		linkName = netPair.TAPIface.Name
 	case *MacvtapEndpoint, *TapEndpoint:
 		linkName = endpoint.Name()
+	case *PhysicalEndpoint:
+		if ep.IsVFIO {
+			return nil
+		}
+		netPair := endpoint.NetworkPair()
+		linkName = netPair.TapInterface.TAPIface.Name
 	default:
 		return fmt.Errorf("Unsupported endpointType %s for removing rx rate limiter", ep.Type())
 	}
@@ -1716,8 +1754,14 @@ func removeTxRateLimiter(endpoint Endpoint, networkNSPath string) error {
 		}
 	case *MacvtapEndpoint, *TapEndpoint:
 		linkName = endpoint.Name()
+	case *PhysicalEndpoint:
+		if ep.IsVFIO {
+			return nil
+		}
+		netPair := endpoint.NetworkPair()
+		linkName = netPair.TapInterface.TAPIface.Name
 	default:
-		return fmt.Errorf("Unsupported endpointType %s for adding tx rate limiter", ep.Type())
+		return fmt.Errorf("Unsupported endpointType %s for removing tx rate limiter", ep.Type())
 	}
 
 	if err := doNetNS(networkNSPath, func(_ ns.NetNS) error {

--- a/src/runtime/virtcontainers/persist/api/network.go
+++ b/src/runtime/virtcontainers/persist/api/network.go
@@ -44,6 +44,9 @@ type PhysicalEndpoint struct {
 	BDF            string
 	Driver         string
 	VendorDeviceID string
+	NetPair        NetworkInterfacePair
+	BusType        string
+	IsVFIO         bool
 }
 
 type MacvtapEndpoint struct {

--- a/src/runtime/virtcontainers/physical_endpoint.go
+++ b/src/runtime/virtcontainers/physical_endpoint.go
@@ -16,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/containernetworking/plugins/pkg/ns"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/config"
 	"github.com/kata-containers/kata-containers/src/runtime/pkg/device/drivers"
 	resCtrl "github.com/kata-containers/kata-containers/src/runtime/pkg/resourcecontrol"
@@ -32,6 +33,7 @@ var physicalTrace = getNetworkTrace(PhysicalEndpointType)
 // PhysicalEndpoint gathers a physical network interface and its properties
 type PhysicalEndpoint struct {
 	IfaceName          string
+	IsVFIO             bool
 	HardAddr           string
 	EndpointProperties NetworkInfo
 	EndpointType       EndpointType
@@ -40,6 +42,10 @@ type PhysicalEndpoint struct {
 	VendorDeviceID     string
 	PCIPath            vcTypes.PciPath
 	CCWDevice          *vcTypes.CcwDevice
+	NetPair            NetworkInterfacePair
+	BusType            string
+	RxRateLimiter      bool
+	TxRateLimiter      bool
 }
 
 // Properties returns the properties of the physical interface.
@@ -89,7 +95,7 @@ func (endpoint *PhysicalEndpoint) SetProperties(properties NetworkInfo) {
 
 // NetworkPair returns the network pair of the endpoint.
 func (endpoint *PhysicalEndpoint) NetworkPair() *NetworkInterfacePair {
-	return nil
+	return &endpoint.NetPair
 }
 
 // Attach for physical endpoint binds the physical network interface to
@@ -97,54 +103,57 @@ func (endpoint *PhysicalEndpoint) NetworkPair() *NetworkInterfacePair {
 func (endpoint *PhysicalEndpoint) Attach(ctx context.Context, s *Sandbox) error {
 	span, ctx := physicalTrace(ctx, "Attach", endpoint)
 	defer span.End()
-
-	// Push the desired netdev MAC down to the VF as an "admin MAC" via the
-	// PF before we rebind to vfio-pci. Without this the guest's mlx5_core
-	// inherits whatever firmware-default MAC the VF was created with, the
-	// guest netdev MAC ends up different from the IB port's HCA MAC, and
-	// `mlx5_ib`'s GID cache refuses to populate
-	// `/sys/class/infiniband/mlx5_*/ports/N/gids/*`. RoCE then looks like
-	// it works (port = ACTIVE, link_layer = Ethernet) but every actual
-	// verb that needs a GID — RoCEv2 packets, address handles, librdmacm
-	// bind — fails. The bind-to-vfio-pci step is the VF's reset, so the
-	// firmware applies the admin MAC during that transition; the guest
-	// then sees a single consistent MAC across netdev / IB port / HCA.
-	// Best-effort: any failure here is logged and the fallback (agent-side
-	// MAC reconciliation, see rpc.rs::update_interface) still keeps L2/L3
-	// working.
-	if endpoint.HardAddr != "" && endpoint.BDF != "" {
-		if err := setVfAdminMAC(endpoint.BDF, endpoint.HardAddr); err != nil {
-			networkLogger().WithFields(logrus.Fields{
-				"bdf":    endpoint.BDF,
-				"netdev": endpoint.IfaceName,
-				"hwAddr": endpoint.HardAddr,
-			}).WithError(err).Warn("setVfAdminMAC: skipped, falling back to in-guest MAC reconciliation")
+	if endpoint.IsVFIO {
+		// Push the desired netdev MAC down to the VF as an "admin MAC" via the
+		// PF before we rebind to vfio-pci. Without this the guest's mlx5_core
+		// inherits whatever firmware-default MAC the VF was created with, the
+		// guest netdev MAC ends up different from the IB port's HCA MAC, and
+		// `mlx5_ib`'s GID cache refuses to populate
+		// `/sys/class/infiniband/mlx5_*/ports/N/gids/*`. RoCE then looks like
+		// it works (port = ACTIVE, link_layer = Ethernet) but every actual
+		// verb that needs a GID — RoCEv2 packets, address handles, librdmacm
+		// bind — fails. The bind-to-vfio-pci step is the VF's reset, so the
+		// firmware applies the admin MAC during that transition; the guest
+		// then sees a single consistent MAC across netdev / IB port / HCA.
+		// Best-effort: any failure here is logged and the fallback (agent-side
+		// MAC reconciliation, see rpc.rs::update_interface) still keeps L2/L3
+		// working.
+		if endpoint.HardAddr != "" && endpoint.BDF != "" {
+			if err := setVfAdminMAC(endpoint.BDF, endpoint.HardAddr); err != nil {
+				networkLogger().WithFields(logrus.Fields{
+					"bdf":    endpoint.BDF,
+					"netdev": endpoint.IfaceName,
+					"hwAddr": endpoint.HardAddr,
+				}).WithError(err).Warn("setVfAdminMAC: skipped, falling back to in-guest MAC reconciliation")
+			}
 		}
-	}
-
-	// Unbind physical interface from host driver and bind to vfio
-	// so that it can be passed to qemu.
-	vfioPath, err := bindNICToVFIO(endpoint)
-	if err != nil {
+		// Unbind physical interface from host driver and bind to vfio
+		// so that it can be passed to qemu.
+		vfioPath, err := bindNICToVFIO(endpoint)
+		if err != nil {
+			return err
+		}
+		c, err := resCtrl.DeviceToCgroupDeviceRule(vfioPath)
+		if err != nil {
+			return err
+		}
+		d := config.DeviceInfo{
+			ContainerPath: vfioPath,
+			DevType:       string(c.Type),
+			Major:         c.Major,
+			Minor:         c.Minor,
+			ColdPlug:      true,
+			Port:          s.config.HypervisorConfig.ColdPlugVFIO,
+		}
+		_, err = s.AddDevice(ctx, d)
 		return err
+	} else {
+		h := s.hypervisor
+		if err := xConnectVMNetwork(ctx, endpoint, h); err != nil {
+			return err
+		}
+		return h.AddDevice(ctx, endpoint, NetDev)
 	}
-
-	c, err := resCtrl.DeviceToCgroupDeviceRule(vfioPath)
-	if err != nil {
-		return err
-	}
-
-	d := config.DeviceInfo{
-		ContainerPath: vfioPath,
-		DevType:       string(c.Type),
-		Major:         c.Major,
-		Minor:         c.Minor,
-		ColdPlug:      true,
-		Port:          s.config.HypervisorConfig.ColdPlugVFIO,
-	}
-
-	_, err = s.AddDevice(ctx, d)
-	return err
 }
 
 // Detach for physical endpoint unbinds the physical network interface from vfio-pci
@@ -152,167 +161,216 @@ func (endpoint *PhysicalEndpoint) Attach(ctx context.Context, s *Sandbox) error 
 func (endpoint *PhysicalEndpoint) Detach(ctx context.Context, netNsCreated bool, netNsPath string) error {
 	span, _ := physicalTrace(ctx, "Detach", endpoint)
 	defer span.End()
-
-	// Bind back the physical network interface to host.
-	// We need to do this even if a new network namespace has not
-	// been created by virtcontainers.
-
-	// We do not need to enter the network namespace to bind back the
-	// physical interface to host driver.
-	return bindNICToHost(endpoint)
+	if endpoint.IsVFIO {
+		// Bind back the physical network interface to host.
+		// We need to do this even if a new network namespace has not
+		// been created by virtcontainers.
+		// We do not need to enter the network namespace to bind back the
+		// physical interface to host driver.
+		return bindNICToHost(endpoint)
+	} else {
+		// The network namespace would have been deleted at this point
+		// if it has not been created by virtcontainers.
+		if !netNsCreated {
+			return nil
+		}
+		return doNetNS(netNsPath, func(_ ns.NetNS) error {
+			return xDisconnectVMNetwork(ctx, endpoint)
+		})
+	}
 }
 
 // HotAttach for physical endpoint not supported yet
 func (endpoint *PhysicalEndpoint) HotAttach(ctx context.Context, s *Sandbox) error {
 	span, ctx := physicalTrace(ctx, "HotAttach", endpoint)
 	defer span.End()
-
-	// Unbind physical interface from host driver and bind to vfio
-	// so that it can be passed to the hypervisor.
-	vfioPath, err := bindNICToVFIO(endpoint)
-	if err != nil {
+	if endpoint.IsVFIO {
+		// Unbind physical interface from host driver and bind to vfio
+		// so that it can be passed to the hypervisor.
+		vfioPath, err := bindNICToVFIO(endpoint)
+		if err != nil {
+			return err
+		}
+		c, err := resCtrl.DeviceToCgroupDeviceRule(vfioPath)
+		if err != nil {
+			return err
+		}
+		d := config.DeviceInfo{
+			ContainerPath: vfioPath,
+			DevType:       string(c.Type),
+			Major:         c.Major,
+			Minor:         c.Minor,
+			ColdPlug:      false,
+		}
+		_, err = s.AddDevice(ctx, d)
 		return err
+	} else {
+		h := s.hypervisor
+		if err := xConnectVMNetwork(ctx, endpoint, h); err != nil {
+			return err
+		}
+		if _, err := h.HotplugAddDevice(ctx, endpoint, NetDev); err != nil {
+			return err
+		}
+		return nil
 	}
-
-	c, err := resCtrl.DeviceToCgroupDeviceRule(vfioPath)
-	if err != nil {
-		return err
-	}
-
-	d := config.DeviceInfo{
-		ContainerPath: vfioPath,
-		DevType:       string(c.Type),
-		Major:         c.Major,
-		Minor:         c.Minor,
-		ColdPlug:      false,
-	}
-
-	_, err = s.AddDevice(ctx, d)
-	return err
 }
 
 // HotDetach for physical endpoint not supported yet
 func (endpoint *PhysicalEndpoint) HotDetach(ctx context.Context, s *Sandbox, netNsCreated bool, netNsPath string) error {
-	span, _ := physicalTrace(ctx, "HotDetach", endpoint)
+	span, ctx := physicalTrace(ctx, "HotDetach", endpoint)
 	defer span.End()
-
 	var vfioPath string
 	var err error
-
-	if vfioPath, err = drivers.GetVFIODevPath(endpoint.BDF); err != nil {
-		return err
+	if endpoint.IsVFIO {
+		if vfioPath, err = drivers.GetVFIODevPath(endpoint.BDF); err != nil {
+			return err
+		}
+		c, err := resCtrl.DeviceToCgroupDeviceRule(vfioPath)
+		if err != nil {
+			return err
+		}
+		d := config.DeviceInfo{
+			ContainerPath: vfioPath,
+			DevType:       string(c.Type),
+			Major:         c.Major,
+			Minor:         c.Minor,
+			ColdPlug:      false,
+		}
+		device := s.devManager.FindDevice(&d)
+		if device == nil {
+			return fmt.Errorf("failed to find VFIO device for %s during hot detach", endpoint.BDF)
+		}
+		s.devManager.RemoveDevice(device.DeviceID())
+		// We do not need to enter the network namespace to bind back the
+		// physical interface to host driver.
+		return bindNICToHost(endpoint)
+	} else {
+		if !netNsCreated {
+			return nil
+		}
+		if err := doNetNS(netNsPath, func(_ ns.NetNS) error {
+			return xDisconnectVMNetwork(ctx, endpoint)
+		}); err != nil {
+			networkLogger().WithError(err).Warn("Error un-bridging virtual ep")
+		}
+		h := s.hypervisor
+		if _, err := h.HotplugRemoveDevice(ctx, endpoint, NetDev); err != nil {
+			return err
+		}
+		return nil
 	}
-
-	c, err := resCtrl.DeviceToCgroupDeviceRule(vfioPath)
-	if err != nil {
-		return err
-	}
-
-	d := config.DeviceInfo{
-		ContainerPath: vfioPath,
-		DevType:       string(c.Type),
-		Major:         c.Major,
-		Minor:         c.Minor,
-		ColdPlug:      false,
-	}
-
-	device := s.devManager.FindDevice(&d)
-	s.devManager.RemoveDevice(device.DeviceID())
-
-	// We do not need to enter the network namespace to bind back the
-	// physical interface to host driver.
-	return bindNICToHost(endpoint)
 }
 
-// isPhysicalIface checks if an interface is a physical device.
-// We use ethtool here to not rely on device sysfs inside the network namespace.
-func isPhysicalIface(ifaceName string) (bool, error) {
-	if ifaceName == "lo" {
-		return false, nil
-	}
-
-	ethHandle, err := ethtool.NewEthtool()
-	if err != nil {
-		return false, err
-	}
-	defer ethHandle.Close()
-
-	bus, err := ethHandle.BusInfo(ifaceName)
-	if err != nil {
-		return false, nil
-	}
-
-	// Check for a pci bus format
-	tokens := strings.Split(bus, ":")
-	if len(tokens) != 3 {
-		return false, nil
-	}
-
-	return true, nil
+// isPhysicalIface checks if an interface is a physical device by inspecting
+// the link's ParentDevBus attribute. Returns true when the bus is "pci" or
+// "vmbus". ParentDevBus is populated by the kernel via netlink
+// and does not require sysfs access inside the network namespace.
+func isPhysicalIface(link netlink.Link) bool {
+	isParent := (link.Attrs().ParentDevBus == "pci" || link.Attrs().ParentDevBus == "vmbus")
+	return isParent
 }
 
-var sysPCIDevicesPath = "/sys/bus/pci/devices"
+var sysBusPath = "/sys/bus/"
 
-func createPhysicalEndpoint(netInfo NetworkInfo) (*PhysicalEndpoint, error) {
-	// Get ethtool handle to derive driver and bus
-	ethHandle, err := ethtool.NewEthtool()
+// Get vendor and device id from pci space (sys/bus/pci/devices, or sys/bus/vmbus/devices, ...)
+func getDevicesPath(link netlink.Link) string {
+	return filepath.Join(sysBusPath, link.Attrs().ParentDevBus, "devices")
+}
+
+// Get vendor and device id from pci space (sys/bus/pci/devices/$BusDeviceInfo)
+func getIfaceDevicePath(link netlink.Link, deviceInterfaceName string) (string, string, error) {
+	if link.Attrs().ParentDevBus == "pci" {
+		// Get ethtool handle to derive driver and bus
+		ethHandle, err := ethtool.NewEthtool()
+		if err != nil {
+			return "", "", err
+		}
+		defer ethHandle.Close()
+		// Get Bus info
+		bdf, err := ethHandle.BusInfo(deviceInterfaceName)
+		if err != nil {
+			return "", "", err
+		}
+		// Get device by following symlink /sys/bus/pci/devices/$bdf
+		return filepath.Join(getDevicesPath(link), bdf), bdf, nil
+	} else if link.Attrs().ParentDevBus == "vmbus" {
+		parentDev := link.Attrs().ParentDev
+		if parentDev == "" {
+			return "", "", fmt.Errorf("vmbus interface %q has empty ParentDev; cannot resolve sysfs device path", deviceInterfaceName)
+		}
+		return filepath.Join(getDevicesPath(link), parentDev), parentDev, nil
+	} else {
+		return "", "", fmt.Errorf("unsupported ParentDevBus: %s", link.Attrs().ParentDevBus)
+	}
+}
+func createPhysicalEndpoint(idx int, netInfo NetworkInfo, isVFIODisabled bool, interworkingModel NetInterworkingModel) (*PhysicalEndpoint, error) {
+	sysIfaceDevicePath, bdf, err := getIfaceDevicePath(netInfo.Link, netInfo.Iface.Name)
 	if err != nil {
 		return nil, err
 	}
-	defer ethHandle.Close()
-
-	// Get BDF
-	bdf, err := ethHandle.BusInfo(netInfo.Iface.Name)
-	if err != nil {
-		return nil, err
-	}
-
-	// Get driver by following symlink /sys/bus/pci/devices/$bdf/driver
-	driverPath := filepath.Join(sysPCIDevicesPath, bdf, "driver")
+	// Get driver by following symlink /sys/bus/pci/devices/$bdf/driver or /sys/bus/vmbus/devices/$guid/driver
+	driverPath := filepath.Join(sysIfaceDevicePath, "driver")
 	link, err := os.Readlink(driverPath)
 	if err != nil {
 		return nil, err
 	}
-
 	driver := filepath.Base(link)
-
-	// Get vendor and device id from pci space (sys/bus/pci/devices/$bdf)
-
-	ifaceDevicePath := filepath.Join(sysPCIDevicesPath, bdf, "device")
+	// Get device by following symlink /sys/bus/pci/devices/$bdf/device or /sys/bus/vmbus/devices/$guid/device
+	ifaceDevicePath := filepath.Join(sysIfaceDevicePath, "device")
 	contents, err := os.ReadFile(ifaceDevicePath)
 	if err != nil {
 		return nil, err
 	}
-
 	deviceID := strings.TrimSpace(string(contents))
-
-	// Vendor id
-	ifaceVendorPath := filepath.Join(sysPCIDevicesPath, bdf, "vendor")
+	// Vendor id (/sys/bus/pci/devices/$bdf/vendor or /sys/bus/vmbus/devices/$guid/vendor)
+	ifaceVendorPath := filepath.Join(sysIfaceDevicePath, "vendor")
 	contents, err = os.ReadFile(ifaceVendorPath)
 	if err != nil {
 		return nil, err
 	}
-
+	// Determine whether to use VFIO passthrough based on bus type:
+	// PCI devices are passed through via VFIO.
+	// VMBus devices use a network pair (tap/bridge).
+	isVFIO := (netInfo.Link.Attrs().ParentDevBus == "pci")
+	netPair := NetworkInterfacePair{}
+	if isVFIO {
+		if isVFIODisabled {
+			// When `cold_plug_vfio` is set to "no-port", the PhysicalEndpoint's VFIO device cannot be attached to the guest VM.
+			// Fail early to prevent the interface from being unbound and rebound to the VFIO driver.
+			return nil, fmt.Errorf("unable to add physical endpoint %s: cold_plug_vfio is disabled", netInfo.Iface.Name)
+		}
+	} else {
+		if idx < 0 {
+			return nil, fmt.Errorf("invalid network endpoint index: %d", idx)
+		}
+		netPair, err = createNetworkInterfacePair(idx, netInfo.Iface.Name, interworkingModel)
+		if err != nil {
+			return nil, err
+		}
+		if netInfo.Iface.Name != "" {
+			netPair.VirtIface.Name = netInfo.Iface.Name
+		}
+	}
 	vendorID := strings.TrimSpace(string(contents))
 	vendorDeviceID := fmt.Sprintf("%s %s", vendorID, deviceID)
 	vendorDeviceID = strings.TrimSpace(vendorDeviceID)
-
 	physicalEndpoint := &PhysicalEndpoint{
 		IfaceName:      netInfo.Iface.Name,
+		IsVFIO:         isVFIO,
 		HardAddr:       netInfo.Iface.HardwareAddr.String(),
 		VendorDeviceID: vendorDeviceID,
 		EndpointType:   PhysicalEndpointType,
 		Driver:         driver,
 		BDF:            bdf,
+		NetPair:        netPair,
+		BusType:        netInfo.Link.Attrs().ParentDevBus,
 	}
-
 	return physicalEndpoint, nil
 }
-
 func bindNICToVFIO(endpoint *PhysicalEndpoint) (string, error) {
 	return drivers.BindDevicetoVFIO(endpoint.BDF, endpoint.Driver)
 }
-
 func bindNICToHost(endpoint *PhysicalEndpoint) error {
 	return drivers.BindDevicetoHost(endpoint.BDF, endpoint.Driver)
 }
@@ -431,41 +489,64 @@ func pfNetdevName(pfBDF string) (string, error) {
 }
 
 func (endpoint *PhysicalEndpoint) save() persistapi.NetworkEndpoint {
+	// saveNetIfPair returns a non-nil pair when given a non-nil input. For VFIO
+	// physical endpoints the pair is intentionally empty; persist it as-is
+	// without warning.
+	savedPair := *saveNetIfPair(&endpoint.NetPair)
 	return persistapi.NetworkEndpoint{
 		Type: string(endpoint.Type()),
-
 		Physical: &persistapi.PhysicalEndpoint{
 			BDF:            endpoint.BDF,
 			Driver:         endpoint.Driver,
 			VendorDeviceID: endpoint.VendorDeviceID,
+			NetPair:        savedPair,
+			BusType:        endpoint.BusType,
+			IsVFIO:         endpoint.IsVFIO,
 		},
 	}
 }
-
 func (endpoint *PhysicalEndpoint) load(s persistapi.NetworkEndpoint) {
 	endpoint.EndpointType = PhysicalEndpointType
-
 	if s.Physical != nil {
+		if netpair := loadNetIfPair(&s.Physical.NetPair); netpair != nil {
+			endpoint.NetPair = *netpair
+		}
 		endpoint.BDF = s.Physical.BDF
 		endpoint.Driver = s.Physical.Driver
 		endpoint.VendorDeviceID = s.Physical.VendorDeviceID
+		endpoint.BusType = s.Physical.BusType
+		endpoint.IsVFIO = s.Physical.IsVFIO
 	}
 }
 
-// unsupported
 func (endpoint *PhysicalEndpoint) GetRxRateLimiter() bool {
-	return false
+	return endpoint.RxRateLimiter
 }
-
 func (endpoint *PhysicalEndpoint) SetRxRateLimiter() error {
-	return fmt.Errorf("rx rate limiter is unsupported for physical endpoint")
+	if endpoint.IsVFIO {
+		// VFIO endpoints use VFIO passthrough; the runtime has no dataplane in
+		// which to enforce rate limiting. Leave the flag unset so callers can
+		// observe the actual runtime behavior via GetRxRateLimiter().
+		networkLogger().WithField("endpoint", endpoint.Name()).
+			Debug("ignoring SetRxRateLimiter on VFIO physical endpoint")
+		return nil
+	}
+	endpoint.RxRateLimiter = true
+	return nil
 }
 
-// unsupported
 func (endpoint *PhysicalEndpoint) GetTxRateLimiter() bool {
-	return false
+	return endpoint.TxRateLimiter
 }
-
 func (endpoint *PhysicalEndpoint) SetTxRateLimiter() error {
-	return fmt.Errorf("tx rate limiter is unsupported for physical endpoint")
+	if endpoint.IsVFIO {
+		// VFIO endpoints use VFIO passthrough; the runtime has no dataplane in
+		// which to enforce rate limiting. Leave the flag unset so callers can
+		// observe the actual runtime behavior via GetTxRateLimiter().
+		networkLogger().WithField("endpoint", endpoint.Name()).
+			Debug("ignoring SetTxRateLimiter on VFIO physical endpoint")
+		return nil
+	}
+	endpoint.TxRateLimiter = true
+	return nil
 }

--- a/src/runtime/virtcontainers/physical_endpoint_test.go
+++ b/src/runtime/virtcontainers/physical_endpoint_test.go
@@ -10,6 +10,8 @@ package virtcontainers
 import (
 	"context"
 	"net"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/containernetworking/plugins/pkg/ns"
@@ -20,34 +22,129 @@ import (
 	"github.com/vishvananda/netns"
 )
 
-func TestPhysicalEndpoint_HotAttach(t *testing.T) {
+func TestPhysicalEndpoint_HotAttach_VFIO(t *testing.T) {
 	assert := assert.New(t)
 	v := &PhysicalEndpoint{
 		IfaceName: "eth0",
 		HardAddr:  net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x04}.String(),
+		BDF:       "0000:00:1f.0",
+		Driver:    "fake-driver",
+		IsVFIO:    true,
 	}
 
 	s := &Sandbox{
 		hypervisor: &mockHypervisor{},
 	}
 
+	// VFIO path tries to write driver_override in sysfs which fails without real hardware
+	err := v.HotAttach(context.Background(), s)
+	assert.Error(err)
+	assert.Contains(err.Error(), "0000:00:1f.0")
+}
+
+func TestPhysicalEndpoint_HotAttach_NonVFIO(t *testing.T) {
+	assert := assert.New(t)
+	v := &PhysicalEndpoint{
+		IfaceName: "eth0",
+		HardAddr:  net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x04}.String(),
+		IsVFIO:    false,
+	}
+
+	s := &Sandbox{
+		hypervisor: &mockHypervisor{},
+	}
+
+	// Non-VFIO path tries xConnectVMNetwork which fails without tap/bridge setup
 	err := v.HotAttach(context.Background(), s)
 	assert.Error(err)
 }
 
-func TestPhysicalEndpoint_HotDetach(t *testing.T) {
+func TestPhysicalEndpoint_HotDetach_VFIO(t *testing.T) {
 	assert := assert.New(t)
 	v := &PhysicalEndpoint{
 		IfaceName: "eth0",
 		HardAddr:  net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x04}.String(),
+		BDF:       "0000:00:1f.0",
+		Driver:    "fake-driver",
+		IsVFIO:    true,
 	}
 
 	s := &Sandbox{
 		hypervisor: &mockHypervisor{},
 	}
 
+	// VFIO path tries to read iommu_group in sysfs which fails without real hardware
 	err := v.HotDetach(context.Background(), s, true, "")
 	assert.Error(err)
+	assert.Contains(err.Error(), "0000:00:1f.0")
+}
+
+func TestPhysicalEndpoint_HotDetach_NonVFIO_NetNsNotCreated(t *testing.T) {
+	assert := assert.New(t)
+	v := &PhysicalEndpoint{
+		IfaceName: "eth0",
+		HardAddr:  net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x04}.String(),
+		IsVFIO:    false,
+	}
+
+	s := &Sandbox{
+		hypervisor: &mockHypervisor{},
+	}
+
+	// Non-VFIO with netNsCreated=false should return nil immediately
+	err := v.HotDetach(context.Background(), s, false, "")
+	assert.NoError(err)
+}
+
+func TestPhysicalEndpoint_HotDetach_NonVFIO_NetNsCreated(t *testing.T) {
+	assert := assert.New(t)
+	v := &PhysicalEndpoint{
+		IfaceName: "eth0",
+		HardAddr:  net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x04}.String(),
+		IsVFIO:    false,
+	}
+
+	s := &Sandbox{
+		hypervisor: &mockHypervisor{},
+	}
+
+	// Non-VFIO with netNsCreated=true but empty path calls doNetNS("", ...),
+	// xDisconnectVMNetwork error is only logged as a warning (not returned).
+	// mockHypervisor.HotplugRemoveDevice succeeds, so overall returns nil.
+	err := v.HotDetach(context.Background(), s, true, "")
+	assert.NoError(err)
+}
+
+func TestPhysicalEndpoint_NetworkPair(t *testing.T) {
+	assert := assert.New(t)
+
+	netPair := NetworkInterfacePair{
+		VirtIface: NetworkInterface{
+			Name: "eth0",
+		},
+	}
+
+	v := &PhysicalEndpoint{
+		IfaceName: "eth0",
+		NetPair:   netPair,
+	}
+
+	result := v.NetworkPair()
+	assert.NotNil(result)
+	assert.Equal("eth0", result.VirtIface.Name)
+}
+
+func TestPhysicalEndpoint_Detach_NonVFIO_NetNsNotCreated(t *testing.T) {
+	assert := assert.New(t)
+	v := &PhysicalEndpoint{
+		IfaceName: "eth0",
+		HardAddr:  net.HardwareAddr{0x02, 0x00, 0xca, 0xfe, 0x00, 0x04}.String(),
+		IsVFIO:    false,
+	}
+
+	// Non-VFIO with netNsCreated=false should return nil immediately
+	err := v.Detach(context.Background(), false, "")
+	assert.NoError(err)
 }
 
 func TestIsPhysicalIface(t *testing.T) {
@@ -88,12 +185,252 @@ func TestIsPhysicalIface(t *testing.T) {
 	err = netlinkHandle.LinkAdd(link)
 	assert.NoError(err)
 
+	// Fetch the link back from the kernel so its attributes (e.g. ParentDevBus)
+	// reflect reality rather than whatever was set on the local struct.
+	kernelLink, err := netlinkHandle.LinkByName(testNetIface)
+	assert.NoError(err)
+
 	var isPhysical bool
 	err = doNetNS(n.Path(), func(_ ns.NetNS) error {
-		var err error
-		isPhysical, err = isPhysicalIface(testNetIface)
-		return err
+		isPhysical = isPhysicalIface(kernelLink)
+		return nil
 	})
 	assert.NoError(err)
 	assert.False(isPhysical)
+}
+
+func TestIsPhysicalIface_PCI(t *testing.T) {
+	assert := assert.New(t)
+	link := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:         "eth0",
+			ParentDevBus: "pci",
+		},
+	}
+	assert.True(isPhysicalIface(link))
+}
+
+func TestIsPhysicalIface_VMBus(t *testing.T) {
+	assert := assert.New(t)
+	link := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:         "eth0",
+			ParentDevBus: "vmbus",
+		},
+	}
+	assert.True(isPhysicalIface(link))
+}
+
+func TestIsPhysicalIface_NoBus(t *testing.T) {
+	assert := assert.New(t)
+	link := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			Name:         "veth0",
+			ParentDevBus: "",
+		},
+	}
+	assert.False(isPhysicalIface(link))
+}
+
+func TestGetDevicesPath(t *testing.T) {
+	assert := assert.New(t)
+
+	pciLink := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			ParentDevBus: "pci",
+		},
+	}
+	assert.Equal("/sys/bus/pci/devices", getDevicesPath(pciLink))
+
+	vmbusLink := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			ParentDevBus: "vmbus",
+		},
+	}
+	assert.Equal("/sys/bus/vmbus/devices", getDevicesPath(vmbusLink))
+}
+
+func TestGetIfaceDevicePath_UnsupportedBus(t *testing.T) {
+	assert := assert.New(t)
+
+	link := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			ParentDevBus: "usb",
+		},
+	}
+	_, _, err := getIfaceDevicePath(link, "eth0")
+	assert.Error(err)
+	assert.Contains(err.Error(), "unsupported ParentDevBus")
+}
+
+func TestGetIfaceDevicePath_VMBus(t *testing.T) {
+	assert := assert.New(t)
+
+	guid := "00000000-0000-0000-0000-000000000001"
+	link := &netlink.Dummy{
+		LinkAttrs: netlink.LinkAttrs{
+			ParentDevBus: "vmbus",
+			ParentDev:    guid,
+		},
+	}
+	path, bdf, err := getIfaceDevicePath(link, "eth0")
+	assert.NoError(err)
+	assert.Equal(guid, bdf)
+	assert.Equal(filepath.Join("/sys/bus/vmbus/devices", guid), path)
+}
+
+func TestCreatePhysicalEndpoint_NegativeIdx(t *testing.T) {
+	assert := assert.New(t)
+
+	// Create a temp directory to mock sysfs
+	tmpDir := t.TempDir()
+	origSysBusPath := sysBusPath
+	sysBusPath = tmpDir
+	defer func() { sysBusPath = origSysBusPath }()
+
+	guid := "00000000-0000-0000-0000-000000000001"
+	vmbusDevDir := filepath.Join(tmpDir, "vmbus", "devices", guid)
+	assert.NoError(os.MkdirAll(vmbusDevDir, 0755))
+
+	// Create driver symlink
+	driverTarget := filepath.Join(tmpDir, "drivers", "hv_netvsc")
+	assert.NoError(os.MkdirAll(driverTarget, 0755))
+	assert.NoError(os.Symlink(driverTarget, filepath.Join(vmbusDevDir, "driver")))
+
+	// Create device and vendor files
+	assert.NoError(os.WriteFile(filepath.Join(vmbusDevDir, "device"), []byte("0x1572\n"), 0644))
+	assert.NoError(os.WriteFile(filepath.Join(vmbusDevDir, "vendor"), []byte("0x8086\n"), 0644))
+
+	// VMBus device → not VFIO → negative idx should fail
+	hwAddr, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+	netInfo := NetworkInfo{
+		Iface: NetlinkIface{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:         "eth0",
+				ParentDevBus: "vmbus",
+				ParentDev:    guid,
+				HardwareAddr: hwAddr,
+			},
+			Type: "",
+		},
+		Link: &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:         "eth0",
+				ParentDevBus: "vmbus",
+				ParentDev:    guid,
+				HardwareAddr: hwAddr,
+			},
+		},
+	}
+
+	_, err := createPhysicalEndpoint(-1, netInfo, false, DefaultNetInterworkingModel)
+	assert.Error(err)
+	assert.Contains(err.Error(), "invalid network endpoint index")
+}
+
+func TestPhysicalEndpoint_SaveLoad_NonVFIO(t *testing.T) {
+	assert := assert.New(t)
+
+	netPair := NetworkInterfacePair{
+		TapInterface: TapInterface{
+			ID:   "tap-id-1",
+			Name: "br-tap1",
+			TAPIface: NetworkInterface{
+				Name:     "tap1",
+				HardAddr: "aa:bb:cc:dd:ee:ff",
+			},
+		},
+		VirtIface: NetworkInterface{
+			Name:     "eth0",
+			HardAddr: "aa:bb:cc:dd:ee:ff",
+		},
+		NetInterworkingModel: DefaultNetInterworkingModel,
+	}
+
+	endpoint := &PhysicalEndpoint{
+		IfaceName:      "eth0",
+		HardAddr:       "aa:bb:cc:dd:ee:ff",
+		EndpointType:   PhysicalEndpointType,
+		BDF:            "0000:01:00.0",
+		Driver:         "mlx5_core",
+		VendorDeviceID: "0x8086 0x1572",
+		IsVFIO:         false,
+		NetPair:        netPair,
+		BusType:        "pci",
+	}
+
+	saved := endpoint.save()
+	assert.NotNil(saved.Physical)
+	assert.Equal("0000:01:00.0", saved.Physical.BDF)
+	assert.Equal("mlx5_core", saved.Physical.Driver)
+	assert.Equal("pci", saved.Physical.BusType)
+	assert.Equal("tap1", saved.Physical.NetPair.TAPIface.Name)
+	assert.Equal("eth0", saved.Physical.NetPair.VirtIface.Name)
+	assert.False(saved.Physical.IsVFIO)
+
+	loaded := &PhysicalEndpoint{}
+	loaded.load(saved)
+	assert.Equal(PhysicalEndpointType, loaded.EndpointType)
+	assert.Equal("0000:01:00.0", loaded.BDF)
+	assert.Equal("mlx5_core", loaded.Driver)
+	assert.Equal("0x8086 0x1572", loaded.VendorDeviceID)
+	assert.Equal("pci", loaded.BusType)
+	assert.Equal("tap1", loaded.NetPair.TapInterface.TAPIface.Name)
+	assert.Equal("eth0", loaded.NetPair.VirtIface.Name)
+	assert.Equal(DefaultNetInterworkingModel, loaded.NetPair.NetInterworkingModel)
+	assert.False(loaded.IsVFIO)
+}
+
+func TestCreatePhysicalEndpoint_NonVFIO_HappyPath(t *testing.T) {
+	assert := assert.New(t)
+
+	tmpDir := t.TempDir()
+	origSysBusPath := sysBusPath
+	sysBusPath = tmpDir
+	defer func() { sysBusPath = origSysBusPath }()
+
+	guid := "00000000-0000-0000-0000-000000000002"
+	vmbusDevDir := filepath.Join(tmpDir, "vmbus", "devices", guid)
+	assert.NoError(os.MkdirAll(vmbusDevDir, 0755))
+
+	// Create driver symlink
+	driverTarget := filepath.Join(tmpDir, "drivers", "hv_netvsc")
+	assert.NoError(os.MkdirAll(driverTarget, 0755))
+	assert.NoError(os.Symlink(driverTarget, filepath.Join(vmbusDevDir, "driver")))
+
+	// Create device and vendor files
+	assert.NoError(os.WriteFile(filepath.Join(vmbusDevDir, "device"), []byte("0x1572\n"), 0644))
+	assert.NoError(os.WriteFile(filepath.Join(vmbusDevDir, "vendor"), []byte("0x8086\n"), 0644))
+
+	// VMBus device → not VFIO
+	hwAddr, _ := net.ParseMAC("aa:bb:cc:dd:ee:ff")
+	netInfo := NetworkInfo{
+		Iface: NetlinkIface{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:         "eth1",
+				ParentDevBus: "vmbus",
+				ParentDev:    guid,
+				HardwareAddr: hwAddr,
+			},
+			Type: "",
+		},
+		Link: &netlink.Dummy{
+			LinkAttrs: netlink.LinkAttrs{
+				Name:         "eth1",
+				ParentDevBus: "vmbus",
+				ParentDev:    guid,
+				HardwareAddr: hwAddr,
+			},
+		},
+	}
+
+	ep, err := createPhysicalEndpoint(0, netInfo, false, DefaultNetInterworkingModel)
+	assert.NoError(err)
+	assert.NotNil(ep)
+	assert.False(ep.IsVFIO)
+	assert.Equal("eth1", ep.IfaceName)
+	assert.Equal("hv_netvsc", ep.Driver)
+	assert.Equal(guid, ep.BDF)
+	assert.Equal("vmbus", ep.BusType)
+	assert.Equal("eth1", ep.NetPair.VirtIface.Name)
 }


### PR DESCRIPTION
This change adds support for NICs of type VMBus in the physical_endpoint paths. VMBus devices cannot be bound to the vfio-pci driver however, so add handling in physical_endpoint such that PCI devices are passed through via VFIO as normal, but physical NICs of bus type vmbus are handled with a tap + network pair (configurable by the internetworking_model). 