### PR TITLE
virtiofs: make inode file handles configurable

### DIFF
--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -1069,6 +1069,13 @@ pub struct SharedFsInfo {
     #[serde(default)]
     pub virtio_fs_cache: String,
 
+    /// Inode file handles mode for `virtio-fs`:
+    /// - `never`: Do not use file handles.
+    /// - `prefer`: Try to use file handles, but fall back to `O_PATH` if not supported.
+    /// - `mandatory`: Use file handles, fail if not supported.
+    #[serde(default)]
+    pub virtio_fs_inode_file_handles: String,
+
     /// Default size of the DAX cache in MiB for `virtio-fs`.
     #[serde(default)]
     pub virtio_fs_cache_size: u32,
@@ -1170,6 +1177,11 @@ impl SharedFsInfo {
         if !self.virtio_fs_is_dax && self.virtio_fs_cache_size != 0 {
             self.virtio_fs_is_dax = true;
         }
+
+        if self.virtio_fs_inode_file_handles.is_empty() {
+            self.virtio_fs_inode_file_handles = String::from("prefer");
+        }
+
         Ok(())
     }
 
@@ -1200,6 +1212,15 @@ impl SharedFsInfo {
                 &self.virtio_fs_cache_size
             ));
         }
+
+        let l = ["never", "prefer", "mandatory"];
+        if !l.contains(&self.virtio_fs_inode_file_handles.as_str()) {
+            return Err(eother!(
+                "Invalid virtio-fs inode file handles mode: {}",
+                &self.virtio_fs_inode_file_handles
+            ));
+        }
+
         Ok(())
     }
 }

--- a/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
+++ b/src/runtime-rs/config/configuration-cloud-hypervisor.toml.in
@@ -146,6 +146,20 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are cached in guest and never expire.
 virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
+# Inode file handles mode:
+#
+#  - never
+#    Do not use file handles.
+#
+#  - prefer
+#    Try to use file handles, but fall back to O_PATH if not supported.
+#
+#  - mandatory
+#    Use file handles, fail if not supported.
+#
+# Default is "prefer"
+# virtio_fs_inode_file_handles = "prefer"
+
 # Bridges can be used to hot plug devices.
 # Limitations:
 # * Currently only pci bridges are supported

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -235,6 +235,20 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are cached in guest and never expire.
 virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
+# Inode file handles mode:
+#
+#  - never
+#    Do not use file handles.
+#
+#  - prefer
+#    Try to use file handles, but fall back to O_PATH if not supported.
+#
+#  - mandatory
+#    Use file handles, fail if not supported.
+#
+# Default is "prefer"
+# virtio_fs_inode_file_handles = "prefer"
+
 # Block device driver to be used by the hypervisor when a container's
 # storage is backed by a block device or a file. This driver facilitates attaching
 # the storage directly to the guest VM.

--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
@@ -43,6 +43,8 @@ pub struct ShareVirtioFsStandaloneConfig {
     pub virtio_fs_cache: String,
     // virtio_fs_extra_args passes options to virtiofsd daemon
     pub virtio_fs_extra_args: Vec<String>,
+    // virtio_fs_inode_file_handles specifies the inode file handles mode for virtiofsd
+    pub virtio_fs_inode_file_handles: String,
 }
 
 #[derive(Default, Debug)]
@@ -66,6 +68,7 @@ impl ShareVirtioFsStandalone {
                 virtio_fs_daemon: config.virtio_fs_daemon.clone(),
                 virtio_fs_cache: config.virtio_fs_cache.clone(),
                 virtio_fs_extra_args: config.virtio_fs_extra_args.clone(),
+                virtio_fs_inode_file_handles: config.virtio_fs_inode_file_handles.clone(),
             },
             share_fs_mount: Arc::new(VirtiofsShareMount::new(id)),
             mounted_info_set: Arc::new(Mutex::new(HashMap::new())),
@@ -90,6 +93,8 @@ impl ShareVirtioFsStandalone {
             String::from("none"),
             String::from("--seccomp"),
             String::from("none"),
+            String::from("--inode-file-handles"),
+            self.config.virtio_fs_inode_file_handles.clone(),
         ];
 
         if !self.config.virtio_fs_extra_args.is_empty() {

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -176,6 +176,20 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are cached in guest and never expire.
 virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
+# Inode file handles mode:
+#
+#  - never
+#    Do not use file handles.
+#
+#  - prefer
+#    Try to use file handles, but fall back to O_PATH if not supported.
+#
+#  - mandatory
+#    Use file handles, fail if not supported.
+#
+# Default is "prefer"
+# virtio_fs_inode_file_handles = "prefer"
+
 # Block storage driver to be used for the hypervisor in case the container
 # rootfs is backed by a block device. This is virtio-blk.
 block_device_driver = "virtio-blk"

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -224,6 +224,20 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are cached in guest and never expire.
 virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
+# Inode file handles mode:
+#
+#  - never
+#    Do not use file handles.
+#
+#  - prefer
+#    Try to use file handles, but fall back to O_PATH if not supported.
+#
+#  - mandatory
+#    Use file handles, fail if not supported.
+#
+# Default is "prefer"
+# virtio_fs_inode_file_handles = "prefer"
+
 # Block storage driver to be used for the hypervisor in case the container
 # rootfs is backed by a block device. This is virtio-scsi, virtio-blk
 # or nvdimm.

--- a/src/runtime/config/configuration-stratovirt.toml.in
+++ b/src/runtime/config/configuration-stratovirt.toml.in
@@ -157,6 +157,20 @@ virtio_fs_extra_args = @DEFVIRTIOFSEXTRAARGS@
 #    Metadata, data, and pathname lookup are cached in guest and never expire.
 virtio_fs_cache = "@DEFVIRTIOFSCACHE@"
 
+# Inode file handles mode:
+#
+#  - never
+#    Do not use file handles.
+#
+#  - prefer
+#    Try to use file handles, but fall back to O_PATH if not supported.
+#
+#  - mandatory
+#    Use file handles, fail if not supported.
+#
+# Default is "prefer"
+# virtio_fs_inode_file_handles = "prefer"
+
 # Block storage driver to be used for the hypervisor in case the container
 # rootfs is backed by a block device. This is virtio-scsi, virtio-blk
 # or nvdimm.

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -115,6 +115,7 @@ type hypervisor struct {
 	JailerPathList                 []string                  `toml:"valid_jailer_paths"`
 	VirtioFSDaemonList             []string                  `toml:"valid_virtio_fs_daemon_paths"`
 	VirtioFSExtraArgs              []string                  `toml:"virtio_fs_extra_args"`
+	VirtioFSInodeFileHandles       string                    `toml:"virtio_fs_inode_file_handles"`
 	PFlashList                     []string                  `toml:"pflashes"`
 	VhostUserStorePathList         []string                  `toml:"valid_vhost_user_store_paths"`
 	FileBackedMemRootList          []string                  `toml:"valid_file_mem_backends"`
@@ -550,6 +551,14 @@ func (h hypervisor) defaultVirtioFSCache() string {
 	return h.VirtioFSCache
 }
 
+func (h hypervisor) defaultVirtioFSInodeFileHandles() string {
+	if h.VirtioFSInodeFileHandles == "" {
+		return vc.VirtioFSInodeFileHandlesPrefer
+	}
+
+	return h.VirtioFSInodeFileHandles
+}
+
 func (h hypervisor) blockDeviceDriver() (string, error) {
 	supportedBlockDrivers := []string{config.VirtioSCSI, config.VirtioBlock, config.VirtioMmio, config.Nvdimm, config.VirtioBlockCCW}
 
@@ -958,6 +967,7 @@ func newQemuHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		VirtioFSCache:            h.defaultVirtioFSCache(),
 		VirtioFSQueueSize:        h.VirtioFSQueueSize,
 		VirtioFSExtraArgs:        h.VirtioFSExtraArgs,
+		VirtioFSInodeFileHandles: h.defaultVirtioFSInodeFileHandles(),
 		MemPrealloc:              h.MemPrealloc,
 		ReclaimGuestFreedMemory:  h.ReclaimGuestFreedMemory,
 		HugePages:                h.HugePages,
@@ -1114,6 +1124,7 @@ func newClhHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		DisableVhostNet:                true,
 		GuestHookPath:                  h.guestHookPath(),
 		VirtioFSExtraArgs:              h.VirtioFSExtraArgs,
+		VirtioFSInodeFileHandles:       h.defaultVirtioFSInodeFileHandles(),
 		SGXEPCSize:                     defaultSGXEPCSize,
 		EnableAnnotations:              h.EnableAnnotations,
 		DisableSeccomp:                 h.DisableSeccomp,
@@ -1253,6 +1264,7 @@ func newStratovirtHypervisorConfig(h hypervisor) (vc.HypervisorConfig, error) {
 		VirtioFSCacheSize:     h.VirtioFSCacheSize,
 		VirtioFSCache:         h.defaultVirtioFSCache(),
 		VirtioFSExtraArgs:     h.VirtioFSExtraArgs,
+		VirtioFSInodeFileHandles: h.defaultVirtioFSInodeFileHandles(),
 		HugePages:             h.HugePages,
 		Debug:                 h.Debug,
 		DisableNestingChecks:  h.DisableNestingChecks,

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -362,11 +362,12 @@ func (clh *cloudHypervisor) createVirtiofsDaemon(sharedPath string) (VirtiofsDae
 
 	// default: use virtiofsd
 	return &virtiofsd{
-		path:       clh.config.VirtioFSDaemon,
-		sourcePath: sharedPath,
-		socketPath: virtiofsdSocketPath,
-		extraArgs:  clh.config.VirtioFSExtraArgs,
-		cache:      clh.config.VirtioFSCache,
+		path:             clh.config.VirtioFSDaemon,
+		sourcePath:       sharedPath,
+		socketPath:       virtiofsdSocketPath,
+		extraArgs:        clh.config.VirtioFSExtraArgs,
+		cache:            clh.config.VirtioFSCache,
+		inodeFileHandles: clh.config.VirtioFSInodeFileHandles,
 	}, nil
 }
 

--- a/src/runtime/virtcontainers/hypervisor.go
+++ b/src/runtime/virtcontainers/hypervisor.go
@@ -439,6 +439,9 @@ type HypervisorConfig struct {
 	// VirtioFSExtraArgs passes options to virtiofsd daemon
 	VirtioFSExtraArgs []string
 
+	// VirtioFSInodeFileHandles specifies the inode file handles mode for virtiofsd
+	VirtioFSInodeFileHandles string
+
 	// Enable annotations by name
 	EnableAnnotations []string
 

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -536,11 +536,12 @@ func (q *qemu) createVirtiofsDaemon(sharedPath string) (VirtiofsDaemon, error) {
 
 	// default use virtiofsd
 	return &virtiofsd{
-		path:       q.config.VirtioFSDaemon,
-		sourcePath: sharedPath,
-		socketPath: virtiofsdSocketPath,
-		extraArgs:  q.config.VirtioFSExtraArgs,
-		cache:      q.config.VirtioFSCache,
+		path:             q.config.VirtioFSDaemon,
+		sourcePath:       sharedPath,
+		socketPath:       virtiofsdSocketPath,
+		extraArgs:        q.config.VirtioFSExtraArgs,
+		cache:            q.config.VirtioFSCache,
+		inodeFileHandles: q.config.VirtioFSInodeFileHandles,
 	}, nil
 }
 

--- a/src/runtime/virtcontainers/stratovirt.go
+++ b/src/runtime/virtcontainers/stratovirt.go
@@ -944,11 +944,12 @@ func (s *stratovirt) createVirtiofsDaemon(sharedPath string) (VirtiofsDaemon, er
 
 	// default use virtiofsd
 	return &virtiofsd{
-		path:       s.config.VirtioFSDaemon,
-		sourcePath: sharedPath,
-		socketPath: virtiofsdSocketPath,
-		extraArgs:  s.config.VirtioFSExtraArgs,
-		cache:      s.config.VirtioFSCache,
+		path:             s.config.VirtioFSDaemon,
+		sourcePath:       sharedPath,
+		socketPath:       virtiofsdSocketPath,
+		extraArgs:        s.config.VirtioFSExtraArgs,
+		cache:            s.config.VirtioFSCache,
+		inodeFileHandles: s.config.VirtioFSInodeFileHandles,
 	}, nil
 }
 

--- a/src/runtime/virtcontainers/virtiofsd.go
+++ b/src/runtime/virtcontainers/virtiofsd.go
@@ -42,6 +42,13 @@ const (
 	typeVirtioFSCacheModeMetadata = "metadata"
 	typeVirtioFSCacheModeAlways   = "always"
 	typeVirtioFSCacheModeAuto     = "auto"
+
+	typeVirtioFSInodeFileHandlesNever     = "never"
+	typeVirtioFSInodeFileHandlesPrefer    = "prefer"
+	typeVirtioFSInodeFileHandlesMandatory = "mandatory"
+
+	// VirtioFSInodeFileHandlesPrefer is the exported default value for inode file handles mode.
+	VirtioFSInodeFileHandlesPrefer = typeVirtioFSInodeFileHandlesPrefer
 )
 
 type VirtiofsDaemon interface {
@@ -77,6 +84,8 @@ type virtiofsd struct {
 	sourcePath string
 	// extraArgs list of extra args to append to virtiofsd command
 	extraArgs []string
+	// inodeFileHandles mode for virtiofsd
+	inodeFileHandles string
 	// PID process ID of virtiosd process
 	PID int
 }
@@ -191,6 +200,10 @@ func (v *virtiofsd) args(FdSocketNumber uint) ([]string, error) {
 		"--shared-dir=" + v.sourcePath,
 		// fd number of vhost-user socket
 		fmt.Sprintf("--fd=%v", FdSocketNumber),
+	}
+
+	if v.inodeFileHandles != "" {
+		args = append(args, "--inode-file-handles="+v.inodeFileHandles)
 	}
 
 	if len(v.extraArgs) != 0 {

--- a/src/runtime/virtcontainers/virtiofsd_test.go
+++ b/src/runtime/virtcontainers/virtiofsd_test.go
@@ -74,17 +74,18 @@ func TestVirtiofsdArgs(t *testing.T) {
 	assert := assert.New(t)
 
 	v := &virtiofsd{
-		path:       "/usr/bin/virtiofsd",
-		sourcePath: "/run/kata-shared/foo",
-		cache:      "never",
+		path:             "/usr/bin/virtiofsd",
+		sourcePath:       "/run/kata-shared/foo",
+		cache:            "never",
+		inodeFileHandles: "prefer",
 	}
 
-	expected := "--syslog --cache=never --shared-dir=/run/kata-shared/foo --fd=123"
+	expected := "--syslog --cache=never --shared-dir=/run/kata-shared/foo --fd=123 --inode-file-handles=prefer"
 	args, err := v.args(123)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))
 
-	expected = "--syslog --cache=never --shared-dir=/run/kata-shared/foo --fd=456"
+	expected = "--syslog --cache=never --shared-dir=/run/kata-shared/foo --fd=456 --inode-file-handles=prefer"
 	args, err = v.args(456)
 	assert.NoError(err)
 	assert.Equal(expected, strings.Join(args, " "))

--- a/src/tools/agent-ctl/src/vm/share_fs_utils.rs
+++ b/src/tools/agent-ctl/src/vm/share_fs_utils.rs
@@ -108,6 +108,10 @@ fn virtiofsd_args(cfg: SharedFsInfo, shared_dir: &str, sock_path: &str) -> Resul
         String::from("none"),
     ];
 
+    if !cfg.virtio_fs_inode_file_handles.is_empty() {
+        args.push(format!("--inode-file-handles={}", cfg.virtio_fs_inode_file_handles));
+    }
+
     if !cfg.virtio_fs_extra_args.is_empty() {
         let mut extra_args: Vec<String> = cfg.virtio_fs_extra_args.clone();
         args.append(&mut extra_args);


### PR DESCRIPTION
This change introduces the 'virtio_fs_inode_file_handles' configuration parameter for virtiofsd, moving it from a hardcoded implementation to a user-defined setting in the TOML configuration files.

Using file handles reduces the number of file descriptors virtiofsd keeps open, which is not only helpful with resources, but may also be important in cases where virtiofsd should only have file descriptors open for files that are open in the guest, e.g. to get around bad interactions with NFS's silly renaming (see NFS FAQ, Section D2: 'What is a silly rename?').

The default is set to 'prefer', which attempts to generate file handles but falls back to O_PATH file descriptors where the underlying filesystem does not support them. This ensures safety across different filesystems.

Note: Using file handles requires the CAP_DAC_READ_SEARCH capability.

Fixes: #3708