### PR TITLE
tests: nvidia: place NIM service into namespace

### DIFF
--- a/tests/integration/kubernetes/k8s-nvidia-nim-service.bats
+++ b/tests/integration/kubernetes/k8s-nvidia-nim-service.bats
@@ -185,7 +185,7 @@ setup() {
 @test "NIMService llama-3.2-1b-instruct serves /v1/models" {
     print_nimservice_namespace_resources "before apply"
     echo "NIMService test: Applying NIM YAML"
-    kubectl apply -f "${NIM_YAML}"
+    kubectl apply -n "${TEST_CLUSTER_NAMESPACE}" -f "${NIM_YAML}"
     echo "NIMService test: Waiting for deployment to exist (operator creates it from NIMService)"
     local wait_exist_timeout=30
     local elapsed=0


### PR DESCRIPTION
Place the NIM service into our test namespace. We are still observing various situations where for some reasons, the NIM service appears in the default namespace in our CI.

Waiting for the NIM operator pod to be fully running didn't help (https://github.com/kata-containers/kata-containers/pull/13007). 

In our CI runs I still see a NIM service placed into the default namespace before the tests starts. This oddly only happens in the non-TEE path. It's been hard to track why this is happening and where it's coming from. In all past nightly CI runs, the service was placed into the proper namespace. 

For now, explicitly set the namespace. If this does not help, we need to investigate more thoroughly. Output from a nightly run:
```
# NIMService setup: Ensuring NIM operator deployment is available
# deployment.apps/nim-operator-k8s-nim-operator condition met
# NIMService setup: Ensuring NIM operator pod is ready: pod/nim-operator-k8s-nim-operator-6c7d668bdc-qndst
# pod/nim-operator-k8s-nim-operator-6c7d668bdc-qndst condition met
# NIM Operator install complete.
# NIMService resources (before apply):
# --- namespace: default ---
# NAME                         STATUS     AGE
# meta-llama-3-2-1b-instruct   NotReady   35h
# NAME                         READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS                       IMAGES                                          SELECTOR
# meta-llama-3-2-1b-instruct   0/1     1            0           14h   meta-llama-3-2-1b-instruct-ctr   nvcr.io/nim/meta/llama-3.2-1b-instruct:1.12.0   app=meta-llama-3-2-1b-instruct
# NAME                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE   SELECTOR
# meta-llama-3-2-1b-instruct   ClusterIP   10.100.198.103   <none>        8000/TCP   14h   app=meta-llama-3-2-1b-instruct
# meta-llama-3-2-1b-instruct-84b4dc7784-9gpsp   0/1     Unknown   0          14h   10.244.0.29   cnt-kata   <none>           <none>
# --- namespace: kata-containers-k8s-tests ---
# NIMService test: Applying NIM YAML
# nimservice.apps.nvidia.com/meta-llama-3-2-1b-instruct created
# secret/ngc-secret-llama-3-2-1b created
# secret/ngc-api-key-llama-3-2-1b created
# NIMService test: Waiting for deployment to exist (operator creates it from NIMService)
# NIMService resources (after deployment appears):
# --- namespace: default ---
# NAME                         STATUS     AGE
# meta-llama-3-2-1b-instruct   NotReady   35h
# NAME                         READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS                       IMAGES                                          SELECTOR
# meta-llama-3-2-1b-instruct   0/1     1            0           14h   meta-llama-3-2-1b-instruct-ctr   nvcr.io/nim/meta/llama-3.2-1b-instruct:1.12.0   app=meta-llama-3-2-1b-instruct
# NAME                         TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE   SELECTOR
# meta-llama-3-2-1b-instruct   ClusterIP   10.100.198.103   <none>        8000/TCP   14h   app=meta-llama-3-2-1b-instruct
# meta-llama-3-2-1b-instruct-84b4dc7784-9gpsp   0/1     Unknown   0          14h   10.244.0.29   cnt-kata   <none>           <none>
# --- namespace: kata-containers-k8s-tests ---
# NAME                         STATUS     AGE
# meta-llama-3-2-1b-instruct   NotReady   5s
# NAME                         READY   UP-TO-DATE   AVAILABLE   AGE   CONTAINERS                       IMAGES                                          SELECTOR
# meta-llama-3-2-1b-instruct   0/1     1            0           5s    meta-llama-3-2-1b-instruct-ctr   nvcr.io/nim/meta/llama-3.2-1b-instruct:1.12.0   app=meta-llama-3-2-1b-instruct
# NAME                         TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE   SELECTOR
# meta-llama-3-2-1b-instruct   ClusterIP   10.110.59.109   <none>        8000/TCP   5s    app=meta-llama-3-2-1b-instruct
# meta-llama-3-2-1b-instruct-84b4dc7784-2qclz   0/1     ContainerCreating   0          5s    <none>   cnt-kata   <none>           <none>
# NIMService test: POD_NAME=meta-llama-3-2-1b-instruct-84b4dc7784-2qclz (waiting for pod ready, timeout 600s)
```