### PR TITLE
ci: correct environment variable syntax in stale issues workflow

### DIFF
--- a/.github/workflows/stale_issues.yaml
+++ b/.github/workflows/stale_issues.yaml
@@ -37,9 +37,10 @@ jobs:
         uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           stale-pr-message: 'This issue has had no activity since before ${DATE}. Please comment on the issue, or it will be closed in 30 days'
+          days-before-stale: -1
           days-before-pr-stale: -1
           days-before-pr-close: -1
-          days-before-issue-stale: ${AGE}
+          days-before-issue-stale: ${{ env.AGE }}
           days-before-issue-close: 30
           operations-per-run: 100
         env:


### PR DESCRIPTION
The stale issues workflow was using shell syntax ${AGE} instead of GitHub Actions syntax ${{ env.AGE }} for the days-before-issue-stale parameter. This prevented the workflow from correctly reading the calculated AGE value.

Also added days-before-stale: -1 to disable default stale behavior and ensure only issue-specific settings apply.


Assisted-By: IBM Bob