### PR TITLE
runtime: allow loopback devices when sandbox_cgroup_only is enabled

### DIFF
--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -888,6 +888,8 @@ func (s *Sandbox) createResourceController() error {
 			nullDeviceExist := false
 			urandomDeviceExist := false
 			ptmxDeviceExist := false
+			loopControlDeviceExist := false
+			loopBlockDeviceExist := false
 			for _, device := range resources.Devices {
 				if device.Type == "c" && device.Major == intptr(1) && device.Minor == intptr(3) {
 					nullDeviceExist = true
@@ -899,6 +901,14 @@ func (s *Sandbox) createResourceController() error {
 
 				if device.Type == "c" && device.Major == intptr(5) && device.Minor == intptr(2) {
 					ptmxDeviceExist = true
+				}
+
+				if device.Type == "c" && device.Major == intptr(10) && device.Minor == intptr(237) {
+					loopControlDeviceExist = true
+				}
+
+				if device.Type == "b" && device.Major == intptr(7) && device.Minor == nil {
+					loopBlockDeviceExist = true
 				}
 			}
 
@@ -925,6 +935,27 @@ func (s *Sandbox) createResourceController() error {
 					{Type: "c", Major: intptr(5), Minor: intptr(2), Access: rwm, Allow: true},
 				}...)
 
+			}
+
+			// When sandbox_cgroup_only is enabled the shim threads inherit
+			// the sandbox device cgroup, so any rootfs whose mount source is
+			// a regular file backed by a loop device (e.g. the blockfile
+			// snapshotter) needs /dev/loop-control and the /dev/loopN block
+			// nodes allowlisted, otherwise containerd's loop setup fails
+			// with EPERM on open("/dev/loop-control").
+			if s.config.SandboxCgroupOnly {
+				if !loopControlDeviceExist {
+					// "/dev/loop-control"
+					resources.Devices = append(resources.Devices, specs.LinuxDeviceCgroup{
+						Type: "c", Major: intptr(10), Minor: intptr(237), Access: rwm, Allow: true,
+					})
+				}
+				if !loopBlockDeviceExist {
+					// "/dev/loop*" (block major 7, any minor)
+					resources.Devices = append(resources.Devices, specs.LinuxDeviceCgroup{
+						Type: "b", Major: intptr(7), Access: rwm, Allow: true,
+					})
+				}
 			}
 
 			if spec.Linux.Resources.CPU != nil {

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -884,31 +884,38 @@ func (s *Sandbox) createResourceController() error {
 			resources.Devices = spec.Linux.Resources.Devices
 
 			intptr := func(i int64) *int64 { return &i }
-			// Determine if device /dev/null and /dev/urandom exist, and add if they don't
+			// Compare existing entries by value (nil-safe). Comparing the
+			// *int64 fields directly against intptr(...) only compares
+			// addresses, which never matches because intptr() returns a fresh
+			// pointer on every call.
 			nullDeviceExist := false
 			urandomDeviceExist := false
 			ptmxDeviceExist := false
 			loopControlDeviceExist := false
 			loopBlockDeviceExist := false
-			for _, device := range resources.Devices {
-				if device.Type == "c" && device.Major == intptr(1) && device.Minor == intptr(3) {
-					nullDeviceExist = true
+			for _, d := range resources.Devices {
+				if d.Major == nil {
+					continue
 				}
-
-				if device.Type == "c" && device.Major == intptr(1) && device.Minor == intptr(9) {
-					urandomDeviceExist = true
-				}
-
-				if device.Type == "c" && device.Major == intptr(5) && device.Minor == intptr(2) {
-					ptmxDeviceExist = true
-				}
-
-				if device.Type == "c" && device.Major == intptr(10) && device.Minor == intptr(237) {
-					loopControlDeviceExist = true
-				}
-
-				if device.Type == "b" && device.Major == intptr(7) && device.Minor == nil {
-					loopBlockDeviceExist = true
+				switch d.Type {
+				case "c":
+					if d.Minor == nil {
+						continue
+					}
+					switch {
+					case *d.Major == 1 && *d.Minor == 3:
+						nullDeviceExist = true
+					case *d.Major == 1 && *d.Minor == 9:
+						urandomDeviceExist = true
+					case *d.Major == 5 && *d.Minor == 2:
+						ptmxDeviceExist = true
+					case *d.Major == 10 && *d.Minor == 237:
+						loopControlDeviceExist = true
+					}
+				case "b":
+					if *d.Major == 7 && d.Minor == nil {
+						loopBlockDeviceExist = true
+					}
 				}
 			}
 


### PR DESCRIPTION
When `sandbox_cgroup_only` is enabled, the kata shim threads inherit the sandbox device cgroup. For container rootfs whose mount source is a regular file backed by a loop device (notably the blockfile snapshotter), containerd's mount package opens /dev/loop-control to allocate a free `/dev/loopN` and then opens that block node to attach the backing file. Neither device is on the sandbox cgroup allowlist, so both opens fail with `EPERM` and the pod creation fails with:
```
failed to create containerd task: failed to create shim task: could not open /dev/loop-control: open /dev/loop-control: operation not permitted
```
The same workload starts fine with `sandbox_cgroup_only=false` because the shim then lives in the unrestricted overhead cgroup.

This change adds /dev/loop-control (char 10:237) and the `/dev/loopN` block nodes (block major 7, any minor) to the sandbox device cgroup allowlist when `sandbox_cgroup_only` is true, mirroring the existing treatment of `/dev/null`, `/dev/urandom` and `/dev/ptmx`. The additions are gated on `sandbox_cgroup_only` because that is the only mode in which the shim itself is constrained by this cgroup.
