### PR TITLE
runtime-rs: align virtiofsd args on runtime-go

### DIFF
--- a/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
+++ b/src/runtime-rs/crates/resource/src/share_fs/share_virtio_fs_standalone.rs
@@ -86,10 +86,6 @@ impl ShareVirtioFsStandalone {
             String::from(shared_dir),
             String::from("--cache"),
             self.config.virtio_fs_cache.clone(),
-            String::from("--sandbox"),
-            String::from("none"),
-            String::from("--seccomp"),
-            String::from("none"),
         ];
 
         if !self.config.virtio_fs_extra_args.is_empty() {

--- a/src/tools/agent-ctl/src/vm/share_fs_utils.rs
+++ b/src/tools/agent-ctl/src/vm/share_fs_utils.rs
@@ -104,8 +104,6 @@ fn virtiofsd_args(cfg: SharedFsInfo, shared_dir: &str, sock_path: &str) -> Resul
         String::from(shared_dir),
         String::from("--cache"),
         cfg.virtio_fs_cache.clone(),
-        String::from("--sandbox"),
-        String::from("none"),
     ];
 
     if !cfg.virtio_fs_extra_args.is_empty() {


### PR DESCRIPTION
Runtime-go doesn't hardcode `--sandbox none --seccomp none`, so mirror that in runtime-rs.