### PR TITLE
fix: add click 8.3.3 to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -6,4 +6,4 @@ mkdocs-open-in-new-tab==1.0.8
 mkdocs-redirects==1.2.2
 CairoSVG==2.9.0
 pillow==12.2.0
-click==8.2.1
+click==8.3.3


### PR DESCRIPTION
- Added click==8.3.3 to docs/requirements.txt
- Click 8.3.3 is the latest version for Python >=3.10
- Required for mkdocs toolchain compatibility and resolves vulnerability in indirect dependencies
- Ref : https://www.mend.io/vulnerability-database/CVE-2026-7246/