### PR TITLE
ci: Move measure-rootfs to run on TEE PRs

### DIFF
--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -36,7 +36,12 @@ setup() {
 }
 
 @test "Test cannot launch pod with measured boot enabled and incorrect hash" {
-	pod_config="$(new_pod_config nginx "kata-${KATA_HYPERVISOR}")"
+	ensure_yq
+	nginx_registry=$(get_from_kata_deps ".docker_images.nginx.registry")
+	nginx_digest=$(get_from_kata_deps ".docker_images.nginx.digest")
+	nginx_image="${nginx_registry}@${nginx_digest}"
+
+	pod_config="$(new_pod_config "${nginx_image}" "kata-${KATA_HYPERVISOR}")"
 	auto_generate_policy "${pod_config_dir}" "${pod_config}"
 
 	incorrect_hash="1111111111111111111111111111111111111111111111111111111111111111"

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -45,6 +45,7 @@ else
 		"k8s-guest-pull-image-authenticated.bats" \
 		"k8s-guest-pull-image-signature.bats" \
 		"k8s-confidential-attestation.bats" \
+		"k8s-measured-rootfs.bats" \
 	)
 
 	K8S_TEST_SMALL_HOST_TEE_POLICY_UNION=( \
@@ -84,7 +85,6 @@ else
 		"k8s-kill-all-process-in-container.bats" \
 		"k8s-limit-range.bats" \
 		"k8s-liveness-probes.bats" \
-		"k8s-measured-rootfs.bats" \
 		"k8s-memory.bats" \
 		"k8s-nested-configmap-secret.bats" \
 		"k8s-oom.bats" \


### PR DESCRIPTION
k8s-measured-rootfs only runs on confidential runtime, so we should move it into the subset on tests that run on TEEs