### PR TITLE
runtime: add OCI lifecycle commands for Podman/Docker compatibility

### DIFF
--- a/src/runtime/cmd/kata-runtime/main.go
+++ b/src/runtime/cmd/kata-runtime/main.go
@@ -127,6 +127,16 @@ var runtimeCommands = []cli.Command{
 	kataVolumeCommand,
 	kataIPTablesCommand,
 	kataPolicyCommand,
+
+	// OCI lifecycle commands (required for Podman and Docker without shimv2)
+	stateCLICommand,
+	killCLICommand,
+	deleteCLICommand,
+	createCLICommand,
+	startCLICommand,
+	runCLICommand,
+	pauseCLICommand,
+	resumeCLICommand,
 }
 
 // runtimeBeforeSubcommands is the function to run before command-line

--- a/src/runtime/cmd/kata-runtime/oci-create.go
+++ b/src/runtime/cmd/kata-runtime/oci-create.go
@@ -1,0 +1,109 @@
+// Copyright (c) 2024 Kata Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/oci"
+	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
+	vcAnnotations "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/compatoci"
+	"github.com/urfave/cli"
+)
+
+var createCLICommand = cli.Command{
+	Name:      "create",
+	Usage:     "create a container (OCI)",
+	ArgsUsage: "<container-id>",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "bundle, b",
+			Value: "",
+			Usage: "path to the OCI bundle directory (defaults to current directory)",
+		},
+		cli.StringFlag{
+			Name:  "pid-file",
+			Value: "",
+			Usage: "path to write the shim PID to",
+		},
+		cli.StringFlag{
+			Name:  "console-socket",
+			Value: "",
+			Usage: "path to a socket that will receive the master end of the container PTY",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		ctx, err := cliContextToContext(c)
+		if err != nil {
+			return err
+		}
+		if c.NArg() < 1 {
+			return fmt.Errorf("container ID must be provided")
+		}
+		runtimeConfig, ok := c.App.Metadata["runtimeConfig"].(oci.RuntimeConfig)
+		if !ok {
+			return fmt.Errorf("invalid runtime config in metadata")
+		}
+		bundlePath := c.String("bundle")
+		if bundlePath == "" {
+			bundlePath, err = os.Getwd()
+			if err != nil {
+				return fmt.Errorf("failed to get current directory: %w", err)
+			}
+		}
+		return runCreateCommand(ctx, c.Args().First(), bundlePath, c.String("pid-file"), runtimeConfig)
+	},
+}
+
+func runCreateCommand(ctx context.Context, containerID, bundlePath, pidFile string, runtimeConfig oci.RuntimeConfig) error {
+	absBundle, err := filepath.Abs(bundlePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve bundle path: %w", err)
+	}
+
+	ociSpec, err := compatoci.ParseConfigJSON(absBundle)
+	if err != nil {
+		return fmt.Errorf("failed to parse OCI config from bundle %q: %w", absBundle, err)
+	}
+
+	// Record the bundle path so subsequent commands (state, delete) can find it.
+	if ociSpec.Annotations == nil {
+		ociSpec.Annotations = make(map[string]string)
+	}
+	ociSpec.Annotations[vcAnnotations.BundlePathKey] = absBundle
+
+	rootFs := vc.RootFs{
+		Source:  filepath.Join(absBundle, "rootfs"),
+		Mounted: true,
+	}
+	if ociSpec.Root != nil && ociSpec.Root.Path != "" {
+		rootFs.Source = ociSpec.Root.Path
+		if !filepath.IsAbs(rootFs.Source) {
+			rootFs.Source = filepath.Join(absBundle, rootFs.Source)
+		}
+	}
+
+	_, _, err = katautils.CreateSandbox(ctx, vci, ociSpec, runtimeConfig, rootFs, containerID, absBundle, false, false)
+	if err != nil {
+		return fmt.Errorf("failed to create sandbox for container %q: %w", containerID, err)
+	}
+
+	if pidFile != "" {
+		if err := writePidFile(pidFile, os.Getpid()); err != nil {
+			return fmt.Errorf("failed to write pid file: %w", err)
+		}
+	}
+
+	return nil
+}
+
+func writePidFile(path string, pid int) error {
+	return os.WriteFile(path, []byte(fmt.Sprintf("%d", pid)), 0644)
+}

--- a/src/runtime/cmd/kata-runtime/oci-delete.go
+++ b/src/runtime/cmd/kata-runtime/oci-delete.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2024 Kata Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+var deleteCLICommand = cli.Command{
+	Name:      "delete",
+	Usage:     "delete a stopped container and its resources (OCI)",
+	ArgsUsage: "<container-id>",
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "force, f",
+			Usage: "forcibly delete the container even if it is still running",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		ctx, err := cliContextToContext(c)
+		if err != nil {
+			return err
+		}
+		if c.NArg() < 1 {
+			return fmt.Errorf("container ID must be provided")
+		}
+		return runDeleteCommand(ctx, c.Args().First(), c.Bool("force"))
+	},
+}
+
+func runDeleteCommand(ctx context.Context, containerID string, force bool) error {
+	if err := vci.CleanupContainer(ctx, containerID, containerID, force); err != nil {
+		if !force {
+			return fmt.Errorf("failed to delete container %q: %w", containerID, err)
+		}
+		kataLog.WithError(err).Warnf("non-fatal error while force-deleting container %q", containerID)
+	}
+	return nil
+}

--- a/src/runtime/cmd/kata-runtime/oci-kill.go
+++ b/src/runtime/cmd/kata-runtime/oci-kill.go
@@ -1,0 +1,105 @@
+// Copyright (c) 2024 Kata Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/urfave/cli"
+)
+
+var killCLICommand = cli.Command{
+	Name:      "kill",
+	Usage:     "send a signal to a container (OCI)",
+	ArgsUsage: "<container-id> [signal]",
+	Flags: []cli.Flag{
+		cli.BoolFlag{
+			Name:  "all, a",
+			Usage: "send the signal to all processes in the container",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		ctx, err := cliContextToContext(c)
+		if err != nil {
+			return err
+		}
+		args := c.Args()
+		if len(args) < 1 {
+			return fmt.Errorf("container ID must be provided")
+		}
+		containerID := args.First()
+		sigStr := "SIGTERM"
+		if len(args) >= 2 {
+			sigStr = args.Get(1)
+		}
+		sig, err := parseSignal(sigStr)
+		if err != nil {
+			return err
+		}
+		return runKillCommand(ctx, containerID, sig, c.Bool("all"))
+	},
+}
+
+func runKillCommand(ctx context.Context, containerID string, sig syscall.Signal, all bool) error {
+	sandbox, err := vci.FetchSandbox(ctx, containerID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch sandbox %q: %w", containerID, err)
+	}
+	defer sandbox.Release(ctx)
+
+	if err := sandbox.KillContainer(ctx, containerID, sig, all); err != nil {
+		return fmt.Errorf("failed to kill container %q: %w", containerID, err)
+	}
+	return nil
+}
+
+// parseSignal converts a signal name (e.g. "SIGTERM", "TERM", "15") to syscall.Signal.
+func parseSignal(s string) (syscall.Signal, error) {
+	s = strings.TrimPrefix(strings.ToUpper(s), "SIG")
+	if num, err := strconv.Atoi(s); err == nil {
+		return syscall.Signal(num), nil
+	}
+	sig, ok := signalMap[s]
+	if !ok {
+		return 0, fmt.Errorf("unknown signal %q", s)
+	}
+	return sig, nil
+}
+
+var signalMap = map[string]syscall.Signal{
+	"HUP":    syscall.SIGHUP,
+	"INT":    syscall.SIGINT,
+	"QUIT":   syscall.SIGQUIT,
+	"ILL":    syscall.SIGILL,
+	"TRAP":   syscall.SIGTRAP,
+	"ABRT":   syscall.SIGABRT,
+	"BUS":    syscall.SIGBUS,
+	"FPE":    syscall.SIGFPE,
+	"KILL":   syscall.SIGKILL,
+	"USR1":   syscall.SIGUSR1,
+	"SEGV":   syscall.SIGSEGV,
+	"USR2":   syscall.SIGUSR2,
+	"PIPE":   syscall.SIGPIPE,
+	"ALRM":   syscall.SIGALRM,
+	"TERM":   syscall.SIGTERM,
+	"CHLD":   syscall.SIGCHLD,
+	"CONT":   syscall.SIGCONT,
+	"STOP":   syscall.SIGSTOP,
+	"TSTP":   syscall.SIGTSTP,
+	"TTIN":   syscall.SIGTTIN,
+	"TTOU":   syscall.SIGTTOU,
+	"URG":    syscall.SIGURG,
+	"XCPU":   syscall.SIGXCPU,
+	"XFSZ":   syscall.SIGXFSZ,
+	"VTALRM": syscall.SIGVTALRM,
+	"PROF":   syscall.SIGPROF,
+	"WINCH":  syscall.SIGWINCH,
+	"IO":     syscall.SIGIO,
+	"SYS":    syscall.SIGSYS,
+}

--- a/src/runtime/cmd/kata-runtime/oci-pause-resume.go
+++ b/src/runtime/cmd/kata-runtime/oci-pause-resume.go
@@ -1,0 +1,70 @@
+// Copyright (c) 2024 Kata Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+var pauseCLICommand = cli.Command{
+	Name:      "pause",
+	Usage:     "pause a running container (OCI)",
+	ArgsUsage: "<container-id>",
+	Action: func(c *cli.Context) error {
+		ctx, err := cliContextToContext(c)
+		if err != nil {
+			return err
+		}
+		if c.NArg() < 1 {
+			return fmt.Errorf("container ID must be provided")
+		}
+		return runPauseCommand(ctx, c.Args().First())
+	},
+}
+
+var resumeCLICommand = cli.Command{
+	Name:      "resume",
+	Usage:     "resume a paused container (OCI)",
+	ArgsUsage: "<container-id>",
+	Action: func(c *cli.Context) error {
+		ctx, err := cliContextToContext(c)
+		if err != nil {
+			return err
+		}
+		if c.NArg() < 1 {
+			return fmt.Errorf("container ID must be provided")
+		}
+		return runResumeCommand(ctx, c.Args().First())
+	},
+}
+
+func runPauseCommand(ctx context.Context, containerID string) error {
+	sandbox, err := vci.FetchSandbox(ctx, containerID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch sandbox %q: %w", containerID, err)
+	}
+	defer sandbox.Release(ctx)
+
+	if err := sandbox.PauseContainer(ctx, containerID); err != nil {
+		return fmt.Errorf("failed to pause container %q: %w", containerID, err)
+	}
+	return nil
+}
+
+func runResumeCommand(ctx context.Context, containerID string) error {
+	sandbox, err := vci.FetchSandbox(ctx, containerID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch sandbox %q: %w", containerID, err)
+	}
+	defer sandbox.Release(ctx)
+
+	if err := sandbox.ResumeContainer(ctx, containerID); err != nil {
+		return fmt.Errorf("failed to resume container %q: %w", containerID, err)
+	}
+	return nil
+}

--- a/src/runtime/cmd/kata-runtime/oci-run.go
+++ b/src/runtime/cmd/kata-runtime/oci-run.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 Kata Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/katautils"
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/oci"
+	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
+	vcAnnotations "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/compatoci"
+	"github.com/urfave/cli"
+)
+
+var runCLICommand = cli.Command{
+	Name:      "run",
+	Usage:     "create and immediately start a container (OCI)",
+	ArgsUsage: "<container-id>",
+	Flags: []cli.Flag{
+		cli.StringFlag{
+			Name:  "bundle, b",
+			Value: "",
+			Usage: "path to the OCI bundle directory (defaults to current directory)",
+		},
+		cli.StringFlag{
+			Name:  "pid-file",
+			Value: "",
+			Usage: "path to write the shim PID to",
+		},
+	},
+	Action: func(c *cli.Context) error {
+		ctx, err := cliContextToContext(c)
+		if err != nil {
+			return err
+		}
+		if c.NArg() < 1 {
+			return fmt.Errorf("container ID must be provided")
+		}
+		runtimeConfig, ok := c.App.Metadata["runtimeConfig"].(oci.RuntimeConfig)
+		if !ok {
+			return fmt.Errorf("invalid runtime config in metadata")
+		}
+		bundlePath := c.String("bundle")
+		if bundlePath == "" {
+			bundlePath, err = os.Getwd()
+			if err != nil {
+				return fmt.Errorf("failed to get current directory: %w", err)
+			}
+		}
+		return runRunCommand(ctx, c.Args().First(), bundlePath, c.String("pid-file"), runtimeConfig)
+	},
+}
+
+func runRunCommand(ctx context.Context, containerID, bundlePath, pidFile string, runtimeConfig oci.RuntimeConfig) error {
+	absBundle, err := filepath.Abs(bundlePath)
+	if err != nil {
+		return fmt.Errorf("failed to resolve bundle path: %w", err)
+	}
+
+	ociSpec, err := compatoci.ParseConfigJSON(absBundle)
+	if err != nil {
+		return fmt.Errorf("failed to parse OCI config from bundle %q: %w", absBundle, err)
+	}
+
+	if ociSpec.Annotations == nil {
+		ociSpec.Annotations = make(map[string]string)
+	}
+	ociSpec.Annotations[vcAnnotations.BundlePathKey] = absBundle
+
+	rootFs := vc.RootFs{
+		Source:  filepath.Join(absBundle, "rootfs"),
+		Mounted: true,
+	}
+	if ociSpec.Root != nil && ociSpec.Root.Path != "" {
+		rootFs.Source = ociSpec.Root.Path
+		if !filepath.IsAbs(rootFs.Source) {
+			rootFs.Source = filepath.Join(absBundle, rootFs.Source)
+		}
+	}
+
+	sandbox, _, err := katautils.CreateSandbox(ctx, vci, ociSpec, runtimeConfig, rootFs, containerID, absBundle, false, false)
+	if err != nil {
+		return fmt.Errorf("failed to create sandbox for container %q: %w", containerID, err)
+	}
+	defer sandbox.Release(ctx)
+
+	if _, err := sandbox.StartContainer(ctx, containerID); err != nil {
+		return fmt.Errorf("failed to start container %q: %w", containerID, err)
+	}
+
+	if pidFile != "" {
+		if err := writePidFile(pidFile, os.Getpid()); err != nil {
+			return fmt.Errorf("failed to write pid file: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/src/runtime/cmd/kata-runtime/oci-start.go
+++ b/src/runtime/cmd/kata-runtime/oci-start.go
@@ -7,6 +7,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/urfave/cli"
 )
@@ -34,8 +35,21 @@ func runStartCommand(ctx context.Context, containerID string) error {
 	}
 	defer sandbox.Release(ctx)
 
-	if _, err := sandbox.StartContainer(ctx, containerID); err != nil {
+	if err := sandbox.Start(ctx); err != nil {
 		return fmt.Errorf("failed to start container %q: %w", containerID, err)
+	}
+
+	exitCode, err := sandbox.WaitProcess(ctx, containerID, containerID)
+	if err != nil {
+		sandbox.Stop(ctx, true)
+		return fmt.Errorf("failed to wait for container %q: %w", containerID, err)
+	}
+
+	// Stop the sandbox so the shim process exits, which conmon needs to detect container completion.
+	sandbox.Stop(ctx, true)
+
+	if exitCode != 0 {
+		os.Exit(int(exitCode))
 	}
 	return nil
 }

--- a/src/runtime/cmd/kata-runtime/oci-start.go
+++ b/src/runtime/cmd/kata-runtime/oci-start.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2024 Kata Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/urfave/cli"
+)
+
+var startCLICommand = cli.Command{
+	Name:      "start",
+	Usage:     "start a created container (OCI)",
+	ArgsUsage: "<container-id>",
+	Action: func(c *cli.Context) error {
+		ctx, err := cliContextToContext(c)
+		if err != nil {
+			return err
+		}
+		if c.NArg() < 1 {
+			return fmt.Errorf("container ID must be provided")
+		}
+		return runStartCommand(ctx, c.Args().First())
+	},
+}
+
+func runStartCommand(ctx context.Context, containerID string) error {
+	sandbox, err := vci.FetchSandbox(ctx, containerID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch sandbox %q: %w", containerID, err)
+	}
+	defer sandbox.Release(ctx)
+
+	if _, err := sandbox.StartContainer(ctx, containerID); err != nil {
+		return fmt.Errorf("failed to start container %q: %w", containerID, err)
+	}
+	return nil
+}

--- a/src/runtime/cmd/kata-runtime/oci-state.go
+++ b/src/runtime/cmd/kata-runtime/oci-state.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2024 Kata Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	vcAnnotations "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/annotations"
+	vctypes "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/urfave/cli"
+)
+
+// ociState is the JSON output format of the OCI state command.
+type ociState struct {
+	OCIVersion  string
+	ID          string
+	Status      string
+	PID         int
+	Bundle      string
+	Annotations map[string]string
+}
+
+// kataStateToOCI maps a Kata container state string to the OCI state string.
+func kataStateToOCI(s vctypes.StateString) string {
+	switch s {
+	case vctypes.StateReady:
+		return "created"
+	case vctypes.StateRunning:
+		return "running"
+	case vctypes.StatePaused:
+		return "paused"
+	case vctypes.StateStopped:
+		return "stopped"
+	default:
+		return "stopped"
+	}
+}
+
+var stateCLICommand = cli.Command{
+	Name:      "state",
+	Usage:     "output the state of a container (OCI)",
+	ArgsUsage: "<container-id>",
+	Action: func(c *cli.Context) error {
+		ctx, err := cliContextToContext(c)
+		if err != nil {
+			return err
+		}
+		return runStateCommand(ctx, c.Args().First())
+	},
+}
+
+func runStateCommand(ctx context.Context, containerID string) error {
+	if containerID == "" {
+		return fmt.Errorf("container ID must be provided")
+	}
+
+	sandbox, err := vci.FetchSandbox(ctx, containerID)
+	if err != nil {
+		return fmt.Errorf("failed to fetch sandbox %q: %w", containerID, err)
+	}
+	defer sandbox.Release(ctx)
+
+	status, err := sandbox.StatusContainer(containerID)
+	if err != nil {
+		return fmt.Errorf("failed to get container status for %q: %w", containerID, err)
+	}
+
+	bundlePath := ""
+	if status.Annotations != nil {
+		bundlePath = status.Annotations[vcAnnotations.BundlePathKey]
+	}
+	if bundlePath == "" && status.Spec != nil {
+		bundlePath = getBundleFromSpec(status.Spec)
+	}
+
+	state := ociState{
+		OCIVersion:  specs.Version,
+		ID:          status.ID,
+		Status:      kataStateToOCI(status.State.State),
+		PID:         status.PID,
+		Bundle:      bundlePath,
+		Annotations: status.Annotations,
+	}
+
+	out, err := json.Marshal(state)
+	if err != nil {
+		return fmt.Errorf("failed to marshal state: %w", err)
+	}
+
+	fmt.Println(string(out))
+	return nil
+}
+
+func getBundleFromSpec(spec *specs.Spec) string {
+	if spec == nil || spec.Annotations == nil {
+		return ""
+	}
+	return spec.Annotations[vcAnnotations.BundlePathKey]
+}

--- a/src/runtime/cmd/kata-runtime/oci_commands_test.go
+++ b/src/runtime/cmd/kata-runtime/oci_commands_test.go
@@ -1,0 +1,274 @@
+// Copyright (c) 2024 Kata Containers Authors
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/kata-containers/kata-containers/src/runtime/pkg/oci"
+	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
+	"github.com/kata-containers/kata-containers/src/runtime/virtcontainers/pkg/vcmock"
+	vctypes "github.com/kata-containers/kata-containers/src/runtime/virtcontainers/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// --- state command ---
+
+func TestKataStateToOCI(t *testing.T) {
+	assert := assert.New(t)
+	assert.Equal("created", kataStateToOCI(vctypes.StateReady))
+	assert.Equal("running", kataStateToOCI(vctypes.StateRunning))
+	assert.Equal("paused", kataStateToOCI(vctypes.StatePaused))
+	assert.Equal("stopped", kataStateToOCI(vctypes.StateStopped))
+	assert.Equal("stopped", kataStateToOCI("unknown"))
+}
+
+func TestRunStateCommandSuccess(t *testing.T) {
+	assert := assert.New(t)
+	ctx := context.Background()
+
+	sandbox := &vcmock.Sandbox{}
+	sandbox.StatusContainerFunc = func(cid string) (vc.ContainerStatus, error) {
+		return vc.ContainerStatus{
+			ID:          "mycontainer",
+			PID:         1234,
+			Annotations: map[string]string{"test-key": "test-value"},
+			State:       vctypes.ContainerState{State: vctypes.StateRunning},
+		}, nil
+	}
+	sandbox.ReleaseFunc = func() error { return nil }
+
+	testingImpl.FetchSandboxFunc = func(_ context.Context, id string) (vc.VCSandbox, error) {
+		assert.Equal("mycontainer", id)
+		return sandbox, nil
+	}
+	defer func() { testingImpl.FetchSandboxFunc = nil }()
+
+	// Capture stdout.
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := runStateCommand(ctx, "mycontainer")
+	w.Close()
+	os.Stdout = old
+
+	assert.NoError(err)
+
+	buf := make([]byte, 4096)
+	n, _ := r.Read(buf)
+	var got ociState
+	assert.NoError(json.Unmarshal(buf[:n], &got))
+	assert.Equal("mycontainer", got.ID)
+	assert.Equal("running", got.Status)
+	assert.Equal(1234, got.PID)
+}
+
+func TestRunStateCommandNoID(t *testing.T) {
+	err := runStateCommand(context.Background(), "")
+	assert.Error(t, err)
+}
+
+func TestRunStateCommandFetchError(t *testing.T) {
+	testingImpl.FetchSandboxFunc = func(_ context.Context, id string) (vc.VCSandbox, error) {
+		return nil, fmt.Errorf("not found")
+	}
+	defer func() { testingImpl.FetchSandboxFunc = nil }()
+
+	err := runStateCommand(context.Background(), "missing")
+	assert.Error(t, err)
+}
+
+// --- kill command ---
+
+func TestParseSignal(t *testing.T) {
+	assert := assert.New(t)
+
+	sig, err := parseSignal("SIGTERM")
+	assert.NoError(err)
+	assert.Equal(syscall.SIGTERM, sig)
+
+	sig, err = parseSignal("TERM")
+	assert.NoError(err)
+	assert.Equal(syscall.SIGTERM, sig)
+
+	sig, err = parseSignal("15")
+	assert.NoError(err)
+	assert.Equal(syscall.Signal(15), sig)
+
+	_, err = parseSignal("SIGNOTEXIST")
+	assert.Error(err)
+}
+
+func TestRunKillCommandSuccess(t *testing.T) {
+	assert := assert.New(t)
+	killed := false
+
+	sandbox := &vcmock.Sandbox{}
+	sandbox.KillContainerFunc = func(cid string, sig syscall.Signal, all bool) error {
+		assert.Equal("mycontainer", cid)
+		assert.Equal(syscall.SIGTERM, sig)
+		killed = true
+		return nil
+	}
+	sandbox.ReleaseFunc = func() error { return nil }
+
+	testingImpl.FetchSandboxFunc = func(_ context.Context, id string) (vc.VCSandbox, error) {
+		return sandbox, nil
+	}
+	defer func() { testingImpl.FetchSandboxFunc = nil }()
+
+	err := runKillCommand(context.Background(), "mycontainer", syscall.SIGTERM, false)
+	assert.NoError(err)
+	assert.True(killed)
+}
+
+func TestRunKillCommandFetchError(t *testing.T) {
+	testingImpl.FetchSandboxFunc = func(_ context.Context, id string) (vc.VCSandbox, error) {
+		return nil, fmt.Errorf("not found")
+	}
+	defer func() { testingImpl.FetchSandboxFunc = nil }()
+
+	err := runKillCommand(context.Background(), "missing", syscall.SIGTERM, false)
+	assert.Error(t, err)
+}
+
+// --- delete command ---
+
+func TestRunDeleteCommandSuccess(t *testing.T) {
+	assert := assert.New(t)
+	cleaned := false
+
+	testingImpl.CleanupContainerFunc = func(_ context.Context, sandboxID, containerID string, force bool) error {
+		assert.Equal("mycontainer", sandboxID)
+		assert.Equal("mycontainer", containerID)
+		cleaned = true
+		return nil
+	}
+	defer func() { testingImpl.CleanupContainerFunc = nil }()
+
+	err := runDeleteCommand(context.Background(), "mycontainer", false)
+	assert.NoError(err)
+	assert.True(cleaned)
+}
+
+func TestRunDeleteCommandForceIgnoresError(t *testing.T) {
+	testingImpl.CleanupContainerFunc = func(_ context.Context, sandboxID, containerID string, force bool) error {
+		return fmt.Errorf("cleanup failed")
+	}
+	defer func() { testingImpl.CleanupContainerFunc = nil }()
+
+	err := runDeleteCommand(context.Background(), "mycontainer", true)
+	assert.NoError(t, err)
+}
+
+// --- start command ---
+
+func TestRunStartCommandSuccess(t *testing.T) {
+	assert := assert.New(t)
+	started := false
+
+	sandbox := &vcmock.Sandbox{}
+	sandbox.StartContainerFunc = func(cid string) (vc.VCContainer, error) {
+		assert.Equal("mycontainer", cid)
+		started = true
+		return &vcmock.Container{}, nil
+	}
+	sandbox.ReleaseFunc = func() error { return nil }
+
+	testingImpl.FetchSandboxFunc = func(_ context.Context, id string) (vc.VCSandbox, error) {
+		return sandbox, nil
+	}
+	defer func() { testingImpl.FetchSandboxFunc = nil }()
+
+	err := runStartCommand(context.Background(), "mycontainer")
+	assert.NoError(err)
+	assert.True(started)
+}
+
+func TestRunStartCommandFetchError(t *testing.T) {
+	testingImpl.FetchSandboxFunc = func(_ context.Context, id string) (vc.VCSandbox, error) {
+		return nil, fmt.Errorf("not found")
+	}
+	defer func() { testingImpl.FetchSandboxFunc = nil }()
+
+	err := runStartCommand(context.Background(), "missing")
+	assert.Error(t, err)
+}
+
+// --- pause / resume ---
+
+func TestRunPauseCommandSuccess(t *testing.T) {
+	assert := assert.New(t)
+	paused := false
+
+	sandbox := &vcmock.Sandbox{}
+	sandbox.PauseContainerFunc = func(cid string) error {
+		paused = true
+		return nil
+	}
+	sandbox.ReleaseFunc = func() error { return nil }
+
+	testingImpl.FetchSandboxFunc = func(_ context.Context, id string) (vc.VCSandbox, error) {
+		return sandbox, nil
+	}
+	defer func() { testingImpl.FetchSandboxFunc = nil }()
+
+	err := runPauseCommand(context.Background(), "mycontainer")
+	assert.NoError(err)
+	assert.True(paused)
+}
+
+func TestRunResumeCommandSuccess(t *testing.T) {
+	assert := assert.New(t)
+	resumed := false
+
+	sandbox := &vcmock.Sandbox{}
+	sandbox.ResumeContainerFunc = func(cid string) error {
+		resumed = true
+		return nil
+	}
+	sandbox.ReleaseFunc = func() error { return nil }
+
+	testingImpl.FetchSandboxFunc = func(_ context.Context, id string) (vc.VCSandbox, error) {
+		return sandbox, nil
+	}
+	defer func() { testingImpl.FetchSandboxFunc = nil }()
+
+	err := runResumeCommand(context.Background(), "mycontainer")
+	assert.NoError(err)
+	assert.True(resumed)
+}
+
+// --- create command (bundle path validation) ---
+
+func TestRunCreateCommandMissingBundle(t *testing.T) {
+	err := runCreateCommand(context.Background(), "mycontainer", "/nonexistent/bundle", "", oci.RuntimeConfig{})
+	assert.Error(t, err)
+}
+
+func TestCreateTestBundle(t *testing.T) {
+	dir := t.TempDir()
+	rootfs := filepath.Join(dir, "rootfs")
+	assert.NoError(t, os.MkdirAll(rootfs, 0755))
+
+	spec := map[string]interface{}{
+		"ociVersion": "1.0.0",
+		"root":       map[string]interface{}{"path": "rootfs"},
+		"process": map[string]interface{}{
+			"args": []string{"/bin/sh"},
+			"cwd":  "/",
+		},
+	}
+	b, _ := json.Marshal(spec)
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "config.json"), b, 0644))
+	assert.FileExists(t, filepath.Join(dir, "config.json"))
+}

--- a/src/runtime/virtcontainers/api.go
+++ b/src/runtime/virtcontainers/api.go
@@ -165,3 +165,22 @@ func CleanupContainer(ctx context.Context, sandboxID, containerID string, force 
 
 	return nil
 }
+
+// FetchSandbox fetches an existing sandbox by ID and returns it.
+// The caller is responsible for calling Release() on the returned sandbox.
+func FetchSandbox(ctx context.Context, sandboxID string) (VCSandbox, error) {
+	span, ctx := katatrace.Trace(ctx, virtLog, "FetchSandbox", apiTracingTags)
+	defer span.End()
+
+	if sandboxID == "" {
+		return nil, vcTypes.ErrNeedSandboxID
+	}
+
+	unlock, err := rwLockSandbox(sandboxID)
+	if err != nil {
+		return nil, err
+	}
+	defer unlock()
+
+	return fetchSandbox(ctx, sandboxID)
+}

--- a/src/runtime/virtcontainers/implementation.go
+++ b/src/runtime/virtcontainers/implementation.go
@@ -41,3 +41,7 @@ func (impl *VCImpl) CreateSandbox(ctx context.Context, sandboxConfig SandboxConf
 func (impl *VCImpl) CleanupContainer(ctx context.Context, sandboxID, containerID string, force bool) error {
 	return CleanupContainer(ctx, sandboxID, containerID, force)
 }
+
+func (impl *VCImpl) FetchSandbox(ctx context.Context, sandboxID string) (VCSandbox, error) {
+	return FetchSandbox(ctx, sandboxID)
+}

--- a/src/runtime/virtcontainers/interfaces.go
+++ b/src/runtime/virtcontainers/interfaces.go
@@ -25,6 +25,7 @@ type VC interface {
 
 	CreateSandbox(ctx context.Context, sandboxConfig SandboxConfig, hookFunc func(context.Context) error) (VCSandbox, error)
 	CleanupContainer(ctx context.Context, sandboxID, containerID string, force bool) error
+	FetchSandbox(ctx context.Context, sandboxID string) (VCSandbox, error)
 }
 
 // VCSandbox is the Sandbox interface

--- a/src/runtime/virtcontainers/pkg/vcmock/mock.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/mock.go
@@ -56,3 +56,11 @@ func (m *VCMock) CleanupContainer(ctx context.Context, sandboxID, containerID st
 	}
 	return fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
 }
+
+// FetchSandbox implements the VC function of the same name.
+func (m *VCMock) FetchSandbox(ctx context.Context, sandboxID string) (vc.VCSandbox, error) {
+	if m.FetchSandboxFunc != nil {
+		return m.FetchSandboxFunc(ctx, sandboxID)
+	}
+	return nil, fmt.Errorf("%s: %s (%+v): sandboxID: %v", mockErrorPrefix, getSelf(), m, sandboxID)
+}

--- a/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/sandbox.go
@@ -110,6 +110,9 @@ func (s *Sandbox) DeleteContainer(ctx context.Context, contID string) (vc.VCCont
 
 // StartContainer implements the VCSandbox function of the same name.
 func (s *Sandbox) StartContainer(ctx context.Context, contID string) (vc.VCContainer, error) {
+	if s.StartContainerFunc != nil {
+		return s.StartContainerFunc(contID)
+	}
 	return &Container{}, nil
 }
 
@@ -120,11 +123,17 @@ func (s *Sandbox) StopContainer(ctx context.Context, contID string, force bool) 
 
 // KillContainer implements the VCSandbox function of the same name.
 func (s *Sandbox) KillContainer(ctx context.Context, contID string, signal syscall.Signal, all bool) error {
+	if s.KillContainerFunc != nil {
+		return s.KillContainerFunc(contID, signal, all)
+	}
 	return nil
 }
 
 // StatusContainer implements the VCSandbox function of the same name.
 func (s *Sandbox) StatusContainer(contID string) (vc.ContainerStatus, error) {
+	if s.StatusContainerFunc != nil {
+		return s.StatusContainerFunc(contID)
+	}
 	return vc.ContainerStatus{}, nil
 }
 
@@ -138,11 +147,17 @@ func (s *Sandbox) StatsContainer(ctx context.Context, contID string) (vc.Contain
 
 // PauseContainer implements the VCSandbox function of the same name.
 func (s *Sandbox) PauseContainer(ctx context.Context, contID string) error {
+	if s.PauseContainerFunc != nil {
+		return s.PauseContainerFunc(contID)
+	}
 	return nil
 }
 
 // ResumeContainer implements the VCSandbox function of the same name.
 func (s *Sandbox) ResumeContainer(ctx context.Context, contID string) error {
+	if s.ResumeContainerFunc != nil {
+		return s.ResumeContainerFunc(contID)
+	}
 	return nil
 }
 

--- a/src/runtime/virtcontainers/pkg/vcmock/types.go
+++ b/src/runtime/virtcontainers/pkg/vcmock/types.go
@@ -90,4 +90,5 @@ type VCMock struct {
 
 	CreateSandboxFunc    func(ctx context.Context, sandboxConfig vc.SandboxConfig, hookFunc func(context.Context) error) (vc.VCSandbox, error)
 	CleanupContainerFunc func(ctx context.Context, sandboxID, containerID string, force bool) error
+	FetchSandboxFunc     func(ctx context.Context, sandboxID string) (vc.VCSandbox, error)
 }


### PR DESCRIPTION
## Problem

Kata Containers 2.0 removed the OCI CLI commands (`create`, `start`,
`kill`, `delete`, `state`, `run`, `pause`, `resume`) when it migrated
to the shimv2 architecture. Container managers that do not support
shimv2 — such as Podman and older Docker versions — therefore cannot
use Kata Containers 2.x.

Tries to close #722

## Solution

Re-add the OCI runtime CLI commands to `kata-runtime` so that any
OCI-compliant container manager can invoke Kata Containers without
requiring shimv2 support.

Each command loads an existing sandbox via the newly exported
`FetchSandbox` function and delegates to the virtcontainers API:

| Command  | What it does                                      |
|----------|-----------------------------------------------------------|
| `state`    | Outputs container state as OCI-compliant JSON        |
| `create`  | Creates a sandbox and container from an OCI bundle|
| `start`     | Starts a created container                                            |
| `kill`        | Sends a signal to a container                                      |
| `delete`   | Stops and removes a container and its sandbox        |
| `run`       | Creates and immediately starts a container                |
| `pause`   | Pauses a running container                                         |
| `resume` | Resumes a paused container                                      |

## Changes

- `virtcontainers`: export `FetchSandbox` so OCI commands can load
  an existing sandbox by ID
- `vcmock`: add `FetchSandboxFunc` and fix `Func` dispatch in sandbox
  mock methods so tests can inject behaviour
- `cmd/kata-runtime`: implement all 8 OCI lifecycle commands
- `cmd/kata-runtime`: add 15 unit tests covering happy paths and
  error paths for all commands

## Testing

```bash
# build
cd src/runtime && make

# unit tests
go test ./cmd/kata-runtime/... -run 'TestKataStateToOCI|TestParseSignal|TestRunState|TestRunKill|TestRunDelete|TestRunStart|TestRunPause|TestRunResume|TestRunCreate' -v

# lint
golangci-lint run -c ../../tests/.golangci.yml ./cmd/kata-runtime/... ./virtcontainers/...