### PR TITLE
Bump guest components and Trustee for CoCo v0.21.0

### DIFF
--- a/versions.yaml
+++ b/versions.yaml
@@ -298,10 +298,10 @@ externals:
   coco-trustee:
     description: "Provides attestation and secret delivery components"
     url: "https://github.com/confidential-containers/trustee"
-    version: "22788122660d6e9be3e4bf52704282de5fcc0a2a"
+    version: "d4e317620c4039c89779b725f74974d8f005da66"
     # image and image_tag must be in sync
     image: "ghcr.io/confidential-containers/staged-images/kbs"
-    image_tag: "22788122660d6e9be3e4bf52704282de5fcc0a2a"
+    image_tag: "d4e317620c4039c89779b725f74974d8f005da66"
     toolchain: "1.90.0"
 
   containerd:

--- a/versions.yaml
+++ b/versions.yaml
@@ -292,7 +292,7 @@ externals:
   coco-guest-components:
     description: "Provides attested key unwrapping for image decryption"
     url: "https://github.com/confidential-containers/guest-components/"
-    version: "1e5c48c9c15bc20a21df3ec6bf76eeefb89fea97"
+    version: "f1561038b9a58d309a3366cc8e25d8e6162424a0"
     toolchain: "1.90.0"
 
   coco-trustee:


### PR DESCRIPTION
We just bumped GC, but let's pick up a couple more pieces.

Trustee has a few more changes. Let's see if the CI likes them.