### PR TITLE
runtime: Configure network num_queues properly for CLH

### DIFF
--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -856,7 +856,7 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) err
 
 	netPair := endpoint.NetworkPair()
 
-	queues := 0
+	queues := 1
 	caps := h.Capabilities(ctx)
 	if caps.IsMultiQueueSupported() {
 		queues = int(h.HypervisorConfig().NumVCPUs())


### PR DESCRIPTION
For cloud-hypervisor, the expected netConfig.num_queues is 2*num_fds (to account for RX,TX). Furthermore, since clh.go wasn't advertising MultiQueueSupport in the Capabilities(), we were getting the default queue pair count (1 for TunTap, 0 for macvtap which breaks). 

In the xConnectVMNetwork path, we have queues = 0 as a baseline,
set to h.HypervisorConfig().NumVCPUs() iff h.Capabilities() advertise
MultiQueueSupport. This is certainly incorrect as we always want, as
a baseline, at least one queue pair. Make queues := 1 by default
to ensure the NetworkPair has at least one queue pair for all
virtio-net paths.
