### PR TITLE
tests: skip erofs-incompatible k8s cases

### DIFF
--- a/tests/integration/kubernetes/k8s-attach-handlers.bats
+++ b/tests/integration/kubernetes/k8s-attach-handlers.bats
@@ -10,6 +10,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	pod_name="handlers"
 	setup_common || die "setup_common failed"
 	yaml_file="${pod_config_dir}/test-lifecycle-events.yaml"
@@ -42,6 +44,8 @@ setup() {
 }
 
 teardown(){
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 

--- a/tests/integration/kubernetes/k8s-empty-dirs.bats
+++ b/tests/integration/kubernetes/k8s-empty-dirs.bats
@@ -57,6 +57,8 @@ setup() {
 }
 
 @test "Empty dir volume when FSGroup is specified with non-root container" {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	local agnhost_name
 	local agnhost_version
 	local gid

--- a/tests/integration/kubernetes/k8s-inotify.bats
+++ b/tests/integration/kubernetes/k8s-inotify.bats
@@ -10,6 +10,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	issue_url="https://github.com/kata-containers/kata-containers/issues/8906"
@@ -49,6 +51,8 @@ setup() {
 }
 
 teardown() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	[ "${KATA_HYPERVISOR}" == "firecracker" ] && skip "test not working see: ${fc_limitations}"
 	[ "${KATA_HYPERVISOR}" == "fc" ] && skip "test not working see: ${fc_limitations}"
 	issue_url="https://github.com/kata-containers/kata-containers/issues/8906"

--- a/tests/integration/kubernetes/k8s-ip6tables.bats
+++ b/tests/integration/kubernetes/k8s-ip6tables.bats
@@ -9,6 +9,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	[ "$(uname -m)" == "ppc64le" ] && skip "ip6tables tests for ppc64le"
 
 	setup_common || die "setup_common failed"
@@ -35,6 +37,8 @@ setup() {
 }
 
 teardown() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	[ "$(uname -m)" == "ppc64le" ] && skip "ip6tables tests for ppc64le"
 
 	# Debugging information

--- a/tests/integration/kubernetes/k8s-liveness-probes.bats
+++ b/tests/integration/kubernetes/k8s-liveness-probes.bats
@@ -40,6 +40,8 @@ setup() {
 }
 
 @test "Liveness http probe" {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	pod_name="liveness-http"
 
 	# Create pod specification.
@@ -68,6 +70,8 @@ setup() {
 
 
 @test "Liveness tcp probe" {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	pod_name="tcptest"
 
 	# Create pod specification.

--- a/tests/integration/kubernetes/k8s-memory.bats
+++ b/tests/integration/kubernetes/k8s-memory.bats
@@ -41,6 +41,8 @@ setup_yaml() {
 }
 
 @test "Running within memory constraints" {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	memory_limit_size="600Mi"
 	allocated_size="150M"
 

--- a/tests/integration/kubernetes/k8s-oom.bats
+++ b/tests/integration/kubernetes/k8s-oom.bats
@@ -10,6 +10,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	setup_common || die "setup_common failed"
 	pod_name="pod-oom"
 
@@ -38,6 +40,8 @@ setup() {
 }
 
 teardown() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	# Debugging information
 	kubectl describe "pod/$pod_name"
 	kubectl get "pod/$pod_name" -o yaml

--- a/tests/integration/kubernetes/k8s-openvpn.bats
+++ b/tests/integration/kubernetes/k8s-openvpn.bats
@@ -10,6 +10,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+    [[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
     # cannot build the container image: ERROR: unable to select packages: easy-rsa (no such package) ...
     [ "$(uname -m)" == "ppc64le" ] && skip "required packages for openvpn test not available for ppc64le"
     # built the container image only for x86 and arm64 so far
@@ -74,6 +76,8 @@ setup() {
 }
 
 teardown() {
+    [[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
     [ "$(uname -m)" == "ppc64le" ] && skip "required packages for openvpn test not available for ppc64le"
     [ "$(uname -m)" == "s390x" ] && skip "container image not built for s390x"
 

--- a/tests/integration/kubernetes/k8s-replication.bats
+++ b/tests/integration/kubernetes/k8s-replication.bats
@@ -10,6 +10,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	setup_common || die "setup_common failed"
 	# Create yaml
 	test_yaml="${pod_config_dir}/test-replication-controller.yaml"
@@ -56,6 +58,8 @@ setup() {
 }
 
 teardown() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	# Debugging information
 	kubectl describe replicationcontrollers/"$replication_name"
 	teardown_common "${node}" "${node_start_time:-}"

--- a/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
+++ b/tests/integration/kubernetes/k8s-sandbox-vcpus-allocation.bats
@@ -10,6 +10,8 @@ load "${BATS_TEST_DIRNAME}/lib.sh"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	[[ "${KATA_HYPERVISOR}" == "qemu-tdx" ]] && skip "See: https://github.com/kata-containers/kata-containers/issues/12492"
 
 	setup_common || die "setup_common failed"
@@ -49,6 +51,8 @@ setup() {
 }
 
 teardown() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	[[ "${KATA_HYPERVISOR}" == "qemu-tdx" ]] && skip "See: https://github.com/kata-containers/kata-containers/issues/12492"
 
 	for pod in "${pods[@]}"; do

--- a/tests/integration/kubernetes/k8s-scale-nginx.bats
+++ b/tests/integration/kubernetes/k8s-scale-nginx.bats
@@ -10,6 +10,8 @@ load "${BATS_TEST_DIRNAME}/../../common.bash"
 load "${BATS_TEST_DIRNAME}/tests_common.sh"
 
 setup() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	replicas="3"
 	deployment="nginx-deployment"
 
@@ -34,6 +36,8 @@ setup() {
 }
 
 teardown() {
+	[[ "${SNAPSHOTTER:-}" == "erofs" ]] && skip "Test skipped with erofs snapshotter"
+
 	rm -f "${test_yaml}"
 	kubectl delete deployment "$deployment"
 	kubectl delete service "$deployment"


### PR DESCRIPTION
The CoCo non-TEE erofs snapshotter CI job consistently fails a fixed set of Kubernetes BATS cases. Skip only those affected cases when SNAPSHOTTER=erofs, while keeping passing sibling tests in the same files enabled.

Leave the skips local to the affected BATS files so the scope is easy to audit and does not add shared test-runner state.