### PR TITLE
runtime: close NetNS fd  in SetupNetworkNamespace()

### DIFF
--- a/src/runtime/pkg/katautils/network_linux.go
+++ b/src/runtime/pkg/katautils/network_linux.go
@@ -56,6 +56,7 @@ func SetupNetworkNamespace(config *vc.NetworkConfig) error {
 		if err != nil {
 			return err
 		}
+		defer n.Close()
 
 		config.NetworkID = n.Path()
 		config.NetworkCreated = true


### PR DESCRIPTION
The network namespace handle created by NewNS() was not being closed, causing a file descriptor leak.