### PR TITLE
runtime-rs: mask systemd-networkd.socket

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
+++ b/src/runtime-rs/crates/hypervisor/src/kernel_param.rs
@@ -131,6 +131,7 @@ impl KernelParams {
             Param::new("panic", "1"),
             Param::new("systemd.unit", "kata-containers.target"),
             Param::new("systemd.mask", "systemd-networkd.service"),
+            Param::new("systemd.mask", "systemd-networkd.socket"),
         ];
 
         if debug {


### PR DESCRIPTION
We are already masking systemd-networkd.service, which causes systemd to log an error about the socket still being enabled. In runtime-go, we're masking the socket, so mask it in runtime-rs, too.