### PR TITLE
runtime-rs: don't modify initdata from annotation

### DIFF
--- a/src/libs/kata-types/src/initdata.rs
+++ b/src/libs/kata-types/src/initdata.rs
@@ -246,7 +246,7 @@ pub fn add_hypervisor_initdata_overrides(initdata_annotation: &str) -> Result<St
         return Ok("".to_string());
     }
 
-    decode_initdata(initdata_annotation)?.to_string()
+    decode_raw_initdata(initdata_annotation).context("decoding initdata annotation failed")
 }
 
 use std::io::Write;
@@ -335,7 +335,9 @@ url = 'http://kbs-service.xxx.cluster.local:8080'
         assert!(result.is_err());
 
         let error = result.unwrap_err();
-        assert!(error.to_string().contains("base64 decode"));
+        assert!(error
+            .chain()
+            .any(|e| e.to_string().contains("base64 decode")));
     }
 
     #[test]
@@ -348,7 +350,9 @@ url = 'http://kbs-service.xxx.cluster.local:8080'
         assert!(result.is_err());
 
         let error = result.unwrap_err();
-        assert!(error.to_string().contains("gz decoder failed"));
+        assert!(error
+            .chain()
+            .any(|e| e.to_string().contains("gz decoder failed")));
     }
 
     #[test]


### PR DESCRIPTION
The initdata is currently being decoded, and then re-encoded with the to_string function. This will usually not preserve the original initdata document, and thus the initdata hash will differ between the annotation and the block device.

This commit changes the logic to only decode the base64, but keep the initdata document intact. Since the error message is now nested, adjust the tests to look for the expected error in the chain.

Fixes: #12951