### PR TITLE
agent: wait for logs before aborting

### DIFF
--- a/src/agent/src/main.rs
+++ b/src/agent/src/main.rs
@@ -383,6 +383,8 @@ async fn start_sandbox(
     if let Err(e) = initialize_policy().await {
         error!(logger, "Failed to initialize agent policy: {:?}", e);
         // Continuing execution without a security policy could be dangerous.
+        // Give a brief moment for the logs to flush, then abort the process to stop the VM.
+        tokio::time::sleep(tokio::time::Duration::from_secs(1)).await;
         std::process::abort();
     }
 


### PR DESCRIPTION
If the policy loading encounters an error, we `abort(3)` the agent for safety. Since abort causes the process to stop immediately, the async logs might not be flushed yet, and thus won't make it to the runtime, hiding the reason for the abort. Wait a bit before aborting so that the logs are fully written.

Fixes: #13031