### PR TITLE
Revert "gatekeeper: Unrequire NVIDIA GPU test"

### DIFF
--- a/tools/testing/gatekeeper/required-tests.yaml
+++ b/tools/testing/gatekeeper/required-tests.yaml
@@ -102,7 +102,7 @@ mapping:
       - Kata Containers CI / kata-containers-ci-on-push / run-kata-deploy-tests / run-kata-deploy-tests (qemu, microk8s)
       - Kata Containers CI / kata-containers-ci-on-push / run-kata-deploy-tests / run-kata-deploy-tests (qemu, rke2)
       - Kata Containers CI / kata-containers-ci-on-push / run-kata-monitor-tests / run-monitor (qemu, crio)
-      # - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-nvidia-gpu / run-nvidia-gpu-tests-on-amd64
+      - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-nvidia-gpu / run-nvidia-gpu-tests-on-amd64
       # - Kata Containers CI / kata-containers-ci-on-push / run-k8s-tests-on-nvidia-gpu / run-nvidia-gpu-snp-tests-on-amd64
     required-labels:
       - ok-to-test


### PR DESCRIPTION
This reverts commit edfb6f5716a75a58c54fdb9e714bee22728abba1.

The NVIDIA non-TEE CI job has passed again over the last 5 nightly runs after merging PRs #13007 and #13020.

#13007 places the nim service explicitly into the test namespace while #13020 waits for the NIM operator explicitly to be up and running. #13020 added additional debug output - for the time being I vote for leaving this output in the test code base for a little longer.

Last 5 nightly positive runs:
- https://github.com/kata-containers/kata-containers/actions/runs/25644262661
- https://github.com/kata-containers/kata-containers/actions/runs/25834697081
- https://github.com/kata-containers/kata-containers/actions/runs/25770753712
- https://github.com/kata-containers/kata-containers/actions/runs/25705768865
- https://github.com/kata-containers/kata-containers/actions/runs/25644262661