### PR TITLE
kata-deploy: only install what will actually be used

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -279,6 +279,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        asset:
+          - shim-v2-go
+          - shim-v2-rust
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-amd64-${{ toJSON(matrix) }}
+      cancel-in-progress: true
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -307,7 +315,7 @@ jobs:
           path: kata-artifacts
           merge-multiple: true
 
-      - name: Build shim-v2
+      - name: Build ${{ matrix.asset }}
         id: build
         run: |
           make install-prebuilt-artifacts
@@ -316,8 +324,8 @@ jobs:
           # store-artifact does not work with symlink
           mkdir -p kata-build && cp "${build_dir}"/kata-static-"${KATA_ASSET}"*.tar.* kata-build/.
         env:
-          KATA_ASSET: shim-v2
-          TAR_OUTPUT: shim-v2.tar.gz
+          KATA_ASSET: ${{ matrix.asset }}
+          TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
           PUSH_TO_REGISTRY: ${{ inputs.push-to-registry }}
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
@@ -326,11 +334,11 @@ jobs:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
           MEASURED_ROOTFS: yes
 
-      - name: store-artifact shim-v2
+      - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: kata-artifacts-amd64-shim-v2${{ inputs.tarball-suffix }}
-          path: kata-build/kata-static-shim-v2.tar.zst
+          name: kata-artifacts-amd64-${{ matrix.asset }}${{ inputs.tarball-suffix }}
+          path: kata-build/kata-static-${{ matrix.asset }}.tar.zst
           retention-days: 15
           if-no-files-found: error
 

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -262,6 +262,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        asset:
+          - shim-v2-go
+          - shim-v2-rust
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-arm64-${{ toJSON(matrix) }}
+      cancel-in-progress: true
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -290,7 +298,7 @@ jobs:
           path: kata-artifacts
           merge-multiple: true
 
-      - name: Build shim-v2
+      - name: Build ${{ matrix.asset }}
         run: |
           make install-prebuilt-artifacts
           make DEPS= "${KATA_ASSET}-tarball"
@@ -298,8 +306,8 @@ jobs:
           # store-artifact does not work with symlink
           mkdir -p kata-build && cp "${build_dir}"/kata-static-"${KATA_ASSET}"*.tar.* kata-build/.
         env:
-          KATA_ASSET: shim-v2
-          TAR_OUTPUT: shim-v2.tar.gz
+          KATA_ASSET: ${{ matrix.asset }}
+          TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
           PUSH_TO_REGISTRY: ${{ inputs.push-to-registry }}
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
@@ -308,11 +316,11 @@ jobs:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
           MEASURED_ROOTFS: yes
 
-      - name: store-artifact shim-v2
+      - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: kata-artifacts-arm64-shim-v2${{ inputs.tarball-suffix }}
-          path: kata-build/kata-static-shim-v2.tar.zst
+          name: kata-artifacts-arm64-${{ matrix.asset }}${{ inputs.tarball-suffix }}
+          path: kata-build/kata-static-${{ matrix.asset }}.tar.zst
           retention-days: 15
           if-no-files-found: error
 

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -188,6 +188,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        asset:
+          - shim-v2-go
+          # Add `shim-v2-rust` here once it builds on ppc64le.
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-ppc64le-${{ toJSON(matrix) }}
+      cancel-in-progress: true
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -216,7 +224,7 @@ jobs:
           path: kata-artifacts
           merge-multiple: true
 
-      - name: Build shim-v2
+      - name: Build ${{ matrix.asset }}
         run: |
           make install-prebuilt-artifacts
           make DEPS= "${KATA_ASSET}-tarball"
@@ -224,8 +232,8 @@ jobs:
           # store-artifact does not work with symlink
           mkdir -p kata-build && cp "${build_dir}"/kata-static-"${KATA_ASSET}"*.tar.* kata-build/.
         env:
-          KATA_ASSET: shim-v2
-          TAR_OUTPUT: shim-v2.tar.gz
+          KATA_ASSET: ${{ matrix.asset }}
+          TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
           PUSH_TO_REGISTRY: ${{ inputs.push-to-registry }}
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
@@ -233,11 +241,11 @@ jobs:
           TARGET_BRANCH: ${{ inputs.target-branch }}
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
 
-      - name: store-artifact shim-v2
+      - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: kata-artifacts-ppc64le-shim-v2${{ inputs.tarball-suffix }}
-          path: kata-build/kata-static-shim-v2.tar.zst
+          name: kata-artifacts-ppc64le-${{ matrix.asset }}${{ inputs.tarball-suffix }}
+          path: kata-build/kata-static-${{ matrix.asset }}.tar.zst
           retention-days: 1
           if-no-files-found: error
 

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -274,6 +274,14 @@ jobs:
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        asset:
+          - shim-v2-go
+          - shim-v2-rust
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-s390x-${{ toJSON(matrix) }}
+      cancel-in-progress: true
     steps:
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.push-to-registry == 'yes' }}
@@ -302,7 +310,7 @@ jobs:
           path: kata-artifacts
           merge-multiple: true
 
-      - name: Build shim-v2
+      - name: Build ${{ matrix.asset }}
         id: build
         run: |
           make install-prebuilt-artifacts
@@ -311,8 +319,8 @@ jobs:
           # store-artifact does not work with symlink
           mkdir -p kata-build && cp "${build_dir}"/kata-static-"${KATA_ASSET}"*.tar.* kata-build/.
         env:
-          KATA_ASSET: shim-v2
-          TAR_OUTPUT: shim-v2.tar.gz
+          KATA_ASSET: ${{ matrix.asset }}
+          TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
           PUSH_TO_REGISTRY: ${{ inputs.push-to-registry }}
           ARTEFACT_REGISTRY: ghcr.io
           ARTEFACT_REGISTRY_USERNAME: ${{ github.actor }}
@@ -321,11 +329,11 @@ jobs:
           RELEASE: ${{ inputs.stage == 'release' && 'yes' || 'no' }}
           MEASURED_ROOTFS: no
 
-      - name: store-artifact shim-v2
+      - name: store-artifact ${{ matrix.asset }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
-          name: kata-artifacts-s390x-shim-v2${{ inputs.tarball-suffix }}
-          path: kata-build/kata-static-shim-v2.tar.zst
+          name: kata-artifacts-s390x-${{ matrix.asset }}${{ inputs.tarball-suffix }}
+          path: kata-build/kata-static-${{ matrix.asset }}.tar.zst
           retention-days: 15
           if-no-files-found: error
 

--- a/.github/workflows/publish-kata-deploy-payload.yaml
+++ b/.github/workflows/publish-kata-deploy-payload.yaml
@@ -78,10 +78,12 @@ jobs:
         env:
           TARGET_BRANCH: ${{ inputs.target-branch }}
 
-      - name: get-kata-tarball for ${{ inputs.arch }}
+      - name: get-kata-artifacts for ${{ inputs.arch }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-${{ inputs.arch}}${{ inputs.tarball-suffix }}
+          pattern: kata-artifacts-${{ inputs.arch }}-*${{ inputs.tarball-suffix }}
+          path: tools/packaging/kata-deploy/local-build/build
+          merge-multiple: true
 
       - name: Login to Kata Containers quay.io
         if: ${{ inputs.registry == 'quay.io' }}
@@ -107,6 +109,5 @@ jobs:
           TAG: ${{ inputs.tag }}
         run: |
           ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-          "$(pwd)/kata-static.tar.zst" \
           "${REGISTRY}/${REPO}" \
           "${TAG}"

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -57,10 +57,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: get-kata-tarball
+      - name: get-kata-artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-amd64
+          pattern: kata-artifacts-amd64-*
+          path: tools/packaging/kata-deploy/local-build/build
+          merge-multiple: true
 
       - name: build-and-push-kata-deploy-ci-amd64
         id: build-and-push-kata-deploy-ci-amd64
@@ -78,9 +80,9 @@ jobs:
           fi
           for tag in "${tags[@]}"; do
               ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  "$(pwd)"/kata-static.tar.zst "ghcr.io/kata-containers/kata-deploy" \
+                  "ghcr.io/kata-containers/kata-deploy" \
                   "${tag}-${TARGET_ARCH}"
               ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  "$(pwd)"/kata-static.tar.zst "quay.io/kata-containers/kata-deploy" \
+                  "quay.io/kata-containers/kata-deploy" \
                   "${tag}-${TARGET_ARCH}"
           done

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -57,10 +57,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: get-kata-tarball
+      - name: get-kata-artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-arm64
+          pattern: kata-artifacts-arm64-*
+          path: tools/packaging/kata-deploy/local-build/build
+          merge-multiple: true
 
       - name: build-and-push-kata-deploy-ci-arm64
         id: build-and-push-kata-deploy-ci-arm64
@@ -78,9 +80,9 @@ jobs:
           fi
           for tag in "${tags[@]}"; do
               ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  "$(pwd)"/kata-static.tar.zst "ghcr.io/kata-containers/kata-deploy" \
+                  "ghcr.io/kata-containers/kata-deploy" \
                   "${tag}-${TARGET_ARCH}"
               ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  "$(pwd)"/kata-static.tar.zst "quay.io/kata-containers/kata-deploy" \
+                  "quay.io/kata-containers/kata-deploy" \
                   "${tag}-${TARGET_ARCH}"
           done

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -54,10 +54,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: get-kata-tarball
+      - name: get-kata-artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-ppc64le
+          pattern: kata-artifacts-ppc64le-*
+          path: tools/packaging/kata-deploy/local-build/build
+          merge-multiple: true
 
       - name: build-and-push-kata-deploy-ci-ppc64le
         id: build-and-push-kata-deploy-ci-ppc64le
@@ -75,9 +77,9 @@ jobs:
           fi
           for tag in "${tags[@]}"; do
               ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  "$(pwd)"/kata-static.tar.zst "ghcr.io/kata-containers/kata-deploy" \
+                  "ghcr.io/kata-containers/kata-deploy" \
                   "${tag}-${TARGET_ARCH}"
               ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  "$(pwd)"/kata-static.tar.zst "quay.io/kata-containers/kata-deploy" \
+                  "quay.io/kata-containers/kata-deploy" \
                   "${tag}-${TARGET_ARCH}"
           done

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -58,10 +58,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: get-kata-tarball
+      - name: get-kata-artifacts
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
-          name: kata-static-tarball-s390x
+          pattern: kata-artifacts-s390x-*
+          path: tools/packaging/kata-deploy/local-build/build
+          merge-multiple: true
 
       - name: build-and-push-kata-deploy-ci-s390x
         id: build-and-push-kata-deploy-ci-s390x
@@ -79,9 +81,9 @@ jobs:
           fi
           for tag in "${tags[@]}"; do
               ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  "$(pwd)"/kata-static.tar.zst "ghcr.io/kata-containers/kata-deploy" \
+                  "ghcr.io/kata-containers/kata-deploy" \
                   "${tag}-${TARGET_ARCH}"
               ./tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh \
-                  "$(pwd)"/kata-static.tar.zst "quay.io/kata-containers/kata-deploy" \
+                  "quay.io/kata-containers/kata-deploy" \
                   "${tag}-${TARGET_ARCH}"
           done

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3570,10 +3570,12 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.9.34+deprecated",
  "serial_test 0.10.0",
+ "tar",
  "tempfile",
  "tokio",
  "toml_edit 0.22.27",
  "walkdir",
+ "zstd 0.13.3",
 ]
 
 [[package]]
@@ -4576,7 +4578,7 @@ dependencies = [
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "tokio",
- "zstd",
+ "zstd 0.11.2+zstd.1.5.2",
 ]
 
 [[package]]
@@ -9611,7 +9613,16 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe",
+ "zstd-safe 5.0.2+zstd.1.5.2",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe 7.2.4",
 ]
 
 [[package]]
@@ -9621,6 +9632,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
  "zstd-sys",
 ]
 

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -121,18 +121,18 @@ RUN \
 	rm -rf /kata/target && \
 	cargo clean
 
-#### Extract kata artifacts
-FROM alpine:3.22 AS artifact-extractor
+#### Prepare kata artifact tarballs
+# Individual component tarballs are stored compressed in the image.
+# The installer extracts only those required for the enabled runtime classes.
+FROM alpine:3.22 AS artifact-stage
 
-ARG KATA_ARTIFACTS=tools/packaging/kata-deploy/kata-static.tar.zst
+ARG KATA_ARTIFACTS_DIR=tools/packaging/kata-deploy/kata-artifacts
 ARG DESTINATION=/opt/kata-artifacts
 
-COPY ${KATA_ARTIFACTS} /tmp/
-RUN \
-	apk add --no-cache tar zstd util-linux-misc && \
-	mkdir -p "${DESTINATION}" && \
-	tar --zstd -xf "/tmp/$(basename "${KATA_ARTIFACTS}")" -C "${DESTINATION}" && \
-	rm -f "/tmp/$(basename "${KATA_ARTIFACTS}")"
+RUN apk add --no-cache util-linux-misc
+
+COPY ${KATA_ARTIFACTS_DIR}/kata-static-*.tar.zst ${DESTINATION}/tarballs/
+COPY tools/packaging/kata-deploy/shim-components.json ${DESTINATION}/
 
 #### Prepare runtime dependencies (nsenter and required libraries)
 # This stage assembles all runtime dependencies based on architecture
@@ -205,8 +205,8 @@ RUN \
 	esac
 
 # Copy musl nsenter from alpine for amd64/arm64
-COPY --from=artifact-extractor /usr/bin/nsenter /output/usr/bin/nsenter-musl
-COPY --from=artifact-extractor /lib/ld-musl-*.so.1 /output/lib/
+COPY --from=artifact-stage /usr/bin/nsenter /output/usr/bin/nsenter-musl
+COPY --from=artifact-stage /lib/ld-musl-*.so.1 /output/lib/
 
 # For amd64/arm64, use the musl nsenter; for ppc64le/s390x, keep the glibc one
 RUN \
@@ -225,8 +225,8 @@ FROM gcr.io/distroless/static-debian13@sha256:972618ca78034aaddc55864342014a96b8
 
 ARG DESTINATION=/opt/kata-artifacts
 
-# Copy extracted kata artifacts
-COPY --from=artifact-extractor ${DESTINATION} ${DESTINATION}
+# Copy kata component tarballs and component manifest
+COPY --from=artifact-stage ${DESTINATION} ${DESTINATION}
 
 # Copy Rust binary
 COPY --from=rust-builder /kata-deploy/bin/kata-deploy /usr/bin/kata-deploy

--- a/tools/packaging/kata-deploy/binary/Cargo.toml
+++ b/tools/packaging/kata-deploy/binary/Cargo.toml
@@ -34,6 +34,7 @@ log.workspace = true
 regex.workspace = true
 serde_json.workspace = true
 serde_yaml = "0.9"
+tar = "0.4.45"
 tokio = { workspace = true, features = [
     "rt-multi-thread",
     "macros",
@@ -45,6 +46,7 @@ tokio = { workspace = true, features = [
 ] }
 toml_edit = "0.22"
 walkdir = "2"
+zstd = "0.13.3"
 
 [dev-dependencies]
 rstest.workspace = true

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -10,9 +10,11 @@ use crate::utils;
 use crate::utils::toml as toml_utils;
 use anyhow::{Context, Result};
 use log::info;
+use std::collections::HashSet;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+#[cfg(test)]
 use walkdir::WalkDir;
 
 /// All valid shims
@@ -100,7 +102,8 @@ pub async fn install_artifacts(config: &Config, container_runtime: &str) -> Resu
         ));
     }
 
-    copy_artifacts("/opt/kata-artifacts/opt/kata", &config.host_install_dir)?;
+    let mut extracted: HashSet<String> = HashSet::new();
+    extract_component_tarballs(config, &mut extracted)?;
 
     set_executable_permissions(&config.host_install_dir)?;
 
@@ -318,12 +321,11 @@ fn remove_custom_runtime_configs(config: &Config) -> Result<()> {
     Ok(())
 }
 
-/// Note: The src parameter is kept to allow for unit testing with temporary directories,
-/// even though in production it always uses /opt/kata-artifacts/opt/kata
+/// Copy an extracted artifact tree from `src` into `dst`.
 ///
-/// Symlinks in the source tree are preserved at the destination (recreated as symlinks
-/// instead of copying the target file). Absolute targets under the source root are
-/// rewritten to the destination root so they remain valid.
+/// Used only by unit tests; production code now uses `extract_component_tarballs`.
+/// Symlinks are preserved; absolute targets under the source root are rewritten to dst.
+#[cfg(test)]
 fn copy_artifacts(src: &str, dst: &str) -> Result<()> {
     let src_path = Path::new(src);
     for entry in WalkDir::new(src).follow_links(false) {
@@ -383,6 +385,281 @@ fn copy_artifacts(src: &str, dst: &str) -> Result<()> {
             fs::copy(src_path_entry, &dst_path)?;
         }
     }
+    Ok(())
+}
+
+/// Path to the shim-components.json manifest inside the kata-deploy container image.
+const SHIM_COMPONENTS_PATH: &str = "/opt/kata-artifacts/shim-components.json";
+
+/// Directory inside the container image where individual component tarballs are stored.
+const TARBALLS_DIR: &str = "/opt/kata-artifacts/tarballs";
+
+/// Common prefix stripped from tarball entries to get the install-relative path.
+const TAR_PREFIX: &str = "opt/kata";
+
+/// Absolute install path embedded in the tarballs (used to rewrite absolute symlink targets).
+const TARBALL_ABS_PREFIX: &str = "/opt/kata";
+
+/// Return the current architecture string as used in shim-components.json.
+fn current_arch() -> &'static str {
+    match std::env::consts::ARCH {
+        "x86_64" => "x86_64",
+        "aarch64" => "aarch64",
+        "s390x" => "s390x",
+        "powerpc64" => "ppc64le",
+        other => other,
+    }
+}
+
+/// Parse shim-components.json and return the union of component tarball names
+/// required by all shims listed in `config.shims_for_arch` for the current arch.
+fn collect_required_tarballs(config: &Config) -> Result<HashSet<String>> {
+    let arch = current_arch();
+    let json_str = fs::read_to_string(SHIM_COMPONENTS_PATH)
+        .with_context(|| format!("Failed to read {SHIM_COMPONENTS_PATH}"))?;
+    let doc: serde_json::Value =
+        serde_json::from_str(&json_str).context("Failed to parse shim-components.json")?;
+    let shims_map = doc["shims"]
+        .as_object()
+        .ok_or_else(|| anyhow::anyhow!("shim-components.json is missing the 'shims' object"))?;
+
+    let mut required: HashSet<String> = HashSet::new();
+    for shim in &config.shims_for_arch {
+        match shims_map
+            .get(shim.as_str())
+            .and_then(|v| v.get(arch))
+            .and_then(|v| v.as_array())
+        {
+            Some(tarballs) => {
+                for t in tarballs {
+                    if let Some(name) = t.as_str() {
+                        required.insert(name.to_string());
+                    }
+                }
+            }
+            None => {
+                log::warn!(
+                    "Shim '{}' has no entry for architecture '{}' in shim-components.json; \
+                     no tarballs will be extracted for it",
+                    shim,
+                    arch
+                );
+            }
+        }
+    }
+    Ok(required)
+}
+
+/// Extract a `.tar.zst` tarball into `dest_dir`, stripping the leading `opt/kata/` prefix
+/// from every entry so files land directly under `dest_dir`.
+///
+/// Absolute symlink targets that point into `/opt/kata` are rewritten to point into
+/// `dest_dir` instead, keeping symlinks valid for non-default installation prefixes.
+fn extract_tarball(tarball_path: &Path, dest_dir: &str) -> Result<()> {
+    use std::path::Component;
+
+    let file = fs::File::open(tarball_path)
+        .with_context(|| format!("Failed to open tarball: {}", tarball_path.display()))?;
+    let decoder = zstd::Decoder::new(file).with_context(|| {
+        format!(
+            "Failed to create zstd decoder for: {}",
+            tarball_path.display()
+        )
+    })?;
+    let mut archive = tar::Archive::new(decoder);
+    let dest_path = Path::new(dest_dir);
+
+    for entry_result in archive.entries()? {
+        let mut entry = entry_result.context("Failed to read tar entry")?;
+        let raw_path = entry
+            .path()
+            .context("Failed to get tar entry path")?
+            .into_owned();
+
+        // Strip the "opt/kata" or "./opt/kata" prefix; skip anything else.
+        let dot_slash_prefix = Path::new("./opt/kata");
+        let stripped = if let Ok(p) = raw_path.strip_prefix(TAR_PREFIX) {
+            p.to_path_buf()
+        } else if let Ok(p) = raw_path.strip_prefix(dot_slash_prefix) {
+            p.to_path_buf()
+        } else {
+            log::debug!(
+                "Skipping entry without expected prefix: {}",
+                raw_path.display()
+            );
+            continue;
+        };
+
+        // The root "opt/kata/" directory itself → just ensure dest_dir exists.
+        if stripped.as_os_str().is_empty() {
+            fs::create_dir_all(dest_path)?;
+            continue;
+        }
+
+        // Reject path traversal attempts.
+        for component in stripped.components() {
+            if component == Component::ParentDir {
+                anyhow::bail!(
+                    "Tarball {} contains path traversal in entry: {}",
+                    tarball_path.display(),
+                    raw_path.display()
+                );
+            }
+        }
+
+        let dest_entry = dest_path.join(&stripped);
+        let entry_type = entry.header().entry_type();
+
+        if entry_type.is_dir() {
+            fs::create_dir_all(&dest_entry)
+                .with_context(|| format!("Failed to create directory: {}", dest_entry.display()))?;
+        } else if entry_type.is_symlink() {
+            let link_target = entry
+                .header()
+                .link_name()?
+                .ok_or_else(|| anyhow::anyhow!("Symlink has no link name: {}", raw_path.display()))?
+                .into_owned();
+
+            // Rewrite absolute symlinks that pointed into /opt/kata so they point into dest_dir.
+            let final_target: std::path::PathBuf = if link_target.is_absolute() {
+                if let Ok(rel) = link_target.strip_prefix(TARBALL_ABS_PREFIX) {
+                    dest_path.join(rel)
+                } else {
+                    link_target
+                }
+            } else {
+                link_target
+            };
+
+            if let Some(parent) = dest_entry.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            match fs::remove_file(&dest_entry) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+            std::os::unix::fs::symlink(&final_target, &dest_entry).with_context(|| {
+                format!(
+                    "Failed to create symlink {} -> {}",
+                    dest_entry.display(),
+                    final_target.display()
+                )
+            })?;
+        } else if entry_type.is_hard_link() {
+            let link_target = entry
+                .header()
+                .link_name()?
+                .ok_or_else(|| {
+                    anyhow::anyhow!("Hard link has no link name: {}", raw_path.display())
+                })?
+                .into_owned();
+
+            // Strip the prefix from the hard link target as well.
+            let link_stripped = if let Ok(p) = link_target.strip_prefix(TAR_PREFIX) {
+                dest_path.join(p)
+            } else if let Ok(p) = link_target.strip_prefix(dot_slash_prefix) {
+                dest_path.join(p)
+            } else {
+                dest_path.join(&link_target)
+            };
+
+            if let Some(parent) = dest_entry.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            match fs::remove_file(&dest_entry) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+            fs::hard_link(&link_stripped, &dest_entry).with_context(|| {
+                format!(
+                    "Failed to create hard link {} -> {}",
+                    dest_entry.display(),
+                    link_stripped.display()
+                )
+            })?;
+        } else {
+            // Regular file
+            if let Some(parent) = dest_entry.parent() {
+                fs::create_dir_all(parent)?;
+            }
+            match fs::remove_file(&dest_entry) {
+                Ok(()) => {}
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e.into()),
+            }
+            entry
+                .unpack(&dest_entry)
+                .with_context(|| format!("Failed to unpack entry to: {}", dest_entry.display()))?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Select and extract the component tarballs required for the configured shims.
+///
+/// Shared components (e.g. kernel, shim-v2-go) are listed by multiple shims.
+/// The `extracted` set tracks which components have already been unpacked in
+/// this install run so that shared components are only extracted once.
+/// Using an in-memory set (rather than on-disk markers) avoids any risk of
+/// stale state surviving across pod restarts.
+fn extract_component_tarballs(config: &Config, extracted: &mut HashSet<String>) -> Result<()> {
+    let required = collect_required_tarballs(config)?;
+
+    if required.is_empty() {
+        log::warn!(
+            "No component tarballs required for the configured shims on '{}'; \
+             check shim-components.json",
+            current_arch()
+        );
+        return Ok(());
+    }
+
+    info!(
+        "Component tarballs required for shims [{}]: {:?}",
+        config.shims_for_arch.join(", "),
+        {
+            let mut sorted: Vec<_> = required.iter().collect();
+            sorted.sort();
+            sorted
+        }
+    );
+
+    let mut sorted_components: Vec<_> = required.iter().collect();
+    sorted_components.sort();
+
+    for component in sorted_components {
+        if extracted.contains(component.as_str()) {
+            info!("Component '{}' already extracted, skipping", component);
+            continue;
+        }
+
+        let tarball_name = format!("kata-static-{}.tar.zst", component);
+        let tarball_path = Path::new(TARBALLS_DIR).join(&tarball_name);
+
+        if !tarball_path.exists() {
+            anyhow::bail!(
+                "Required component tarball not found: {}. \
+                 Ensure the kata-deploy image was built with the '{}' component.",
+                tarball_path.display(),
+                component
+            );
+        }
+
+        info!("Extracting component '{}'", component);
+        extract_tarball(&tarball_path, &config.host_install_dir).with_context(|| {
+            format!(
+                "Failed to extract component '{}' from {}",
+                component,
+                tarball_path.display()
+            )
+        })?;
+
+        extracted.insert(component.clone());
+    }
+
     Ok(())
 }
 

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -340,10 +340,71 @@ async fn install(config: &config::Config, runtime: &str) -> Result<()> {
     runtime::lifecycle::restart_runtime(config, runtime).await?;
     info!("Runtime restart completed successfully");
 
-    k8s::label_node(config, "katacontainers.io/kata-runtime", Some("true"), true).await?;
+    label_node_with_retry(config, "katacontainers.io/kata-runtime", "true").await?;
 
     info!("Kata Containers installation completed successfully");
     Ok(())
+}
+
+/// Label the node and verify the label sticks, retrying if necessary.
+///
+/// On rke2/k3s a CRI restart also restarts the kubelet. The kubelet may
+/// briefly re-register the node with its cached label set, clobbering the
+/// label we just applied via the API. We work around this by verifying the
+/// label value after setting it and re-applying if needed.
+async fn label_node_with_retry(
+    config: &config::Config,
+    label_key: &str,
+    label_value: &str,
+) -> Result<()> {
+    const MAX_ATTEMPTS: u32 = 10;
+    const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
+
+    for attempt in 1..=MAX_ATTEMPTS {
+        k8s::label_node(config, label_key, Some(label_value), true).await?;
+
+        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+
+        match k8s::get_node_label(config, label_key).await {
+            Ok(Some(val)) if val == label_value => {
+                info!(
+                    "Label {}={} confirmed on node (attempt {})",
+                    label_key, label_value, attempt
+                );
+                return Ok(());
+            }
+            Ok(actual) => {
+                log::warn!(
+                    "Label {}={} did not stick (got {:?}), retrying ({}/{})",
+                    label_key,
+                    label_value,
+                    actual,
+                    attempt,
+                    MAX_ATTEMPTS
+                );
+            }
+            Err(e) => {
+                log::warn!(
+                    "Failed to verify label {} (attempt {}/{}): {}",
+                    label_key,
+                    attempt,
+                    MAX_ATTEMPTS,
+                    e
+                );
+            }
+        }
+
+        if attempt < MAX_ATTEMPTS {
+            tokio::time::sleep(RETRY_DELAY).await;
+        }
+    }
+
+    anyhow::bail!(
+        "Failed to set label {}={} after {} attempts",
+        label_key,
+        label_value,
+        MAX_ATTEMPTS
+    );
 }
 
 async fn cleanup(config: &config::Config, runtime: &str) -> Result<()> {

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -32,7 +32,8 @@ BASE_TARBALLS = serial-targets \
 	qemu-tdx-experimental-tarball \
 	qemu-tarball \
 	stratovirt-tarball \
-	shim-v2-tarball \
+	shim-v2-go-tarball \
+	shim-v2-rust-tarball \
 	virtiofsd-tarball
 BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-image-confidential-tarball \
@@ -46,7 +47,8 @@ BASE_TARBALLS = serial-targets \
 	kernel-debug-tarball \
 	kernel-tarball \
 	qemu-tarball \
-	shim-v2-tarball \
+	shim-v2-go-tarball \
+	shim-v2-rust-tarball \
 	virtiofsd-tarball
 BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-initrd-tarball
@@ -57,7 +59,8 @@ BASE_TARBALLS = serial-targets \
 	kernel-tarball \
 	qemu-tarball \
 	qemu-cca-experimental-tarball \
-	shim-v2-tarball \
+	shim-v2-go-tarball \
+	shim-v2-rust-tarball \
 	virtiofsd-tarball
 BASE_SERIAL_TARBALLS = rootfs-image-tarball \
 	rootfs-image-confidential-tarball \
@@ -219,7 +222,10 @@ DEPS := agent-tarball pause-image-tarball coco-guest-components-tarball kernel-c
 rootfs-cca-confidential-initrd-tarball: $(DEPS)
 	${MAKE} $@-build
 
-shim-v2-tarball:
+shim-v2-go-tarball:
+	${MAKE} $@-build
+
+shim-v2-rust-tarball:
 	${MAKE} $@-build
 
 trace-forwarder-tarball: copy-scripts-for-the-tools-build

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries.sh
@@ -139,7 +139,8 @@ options:
 	rootfs-image-mariner
 	rootfs-initrd
 	rootfs-initrd-confidential
-	shim-v2
+	shim-v2-go
+	shim-v2-rust
 	trace-forwarder
 	virtiofsd
 EOF
@@ -181,9 +182,9 @@ get_kernel_modules_dir() {
 	echo "${kernel_modules_dir}"
 }
 
-cleanup_and_fail_shim_v2_specifics() {
+cleanup_and_fail_shim_v2_rust_specifics() {
 	for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
-		local root_hash_file="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/shim-v2-root_hash_${variant}.txt"
+		local root_hash_file="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build/shim-v2-rust-root_hash_${variant}.txt"
 		[[ -f "${root_hash_file}" ]] && rm -f "${root_hash_file}"
 	done
 
@@ -228,7 +229,7 @@ install_cached_shim_v2_tarball_get_root_hash() {
 	return 0
 }
 
-install_cached_shim_v2_tarball_compare_root_hashes() {
+install_cached_shim_v2_rust_tarball_compare_root_hashes() {
 	local found_any=""
 	local tarball_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build"
 
@@ -236,7 +237,7 @@ install_cached_shim_v2_tarball_compare_root_hashes() {
 		# Skip if one or the other does not exist.
 		[[ ! -f "${tarball_dir}/root_hash_${variant}.txt" ]] && continue
 
-		diff "${tarball_dir}/root_hash_${variant}.txt" "shim-v2-root_hash_${variant}.txt" || return 1
+		diff "${tarball_dir}/root_hash_${variant}.txt" "shim-v2-rust-root_hash_${variant}.txt" || return 1
 		found_any="yes"
 	done
 	[[ -z "${found_any}" ]] && return 0
@@ -259,7 +260,7 @@ install_cached_tarball_component() {
 	# "tarball1_name:tarball1_path tarball2_name:tarball2_path ... tarballN_name:tarballN_path"
 	local extra_tarballs="${6:-}"
 
-	if [[ "${component}" = "shim-v2" ]]; then
+	if [[ "${component}" = "shim-v2-rust" ]]; then
 		install_cached_shim_v2_tarball_get_root_hash
 	fi
 
@@ -275,8 +276,8 @@ install_cached_tarball_component() {
 	[[ "${cached_version}" != "${current_version}" ]] && return "$(cleanup_and_fail "${component_tarball_path}" "${extra_tarballs}")"
 	sha256sum -c "${component}-sha256sum" || return "$(cleanup_and_fail "${component_tarball_path}" "${extra_tarballs}")"
 
-	if [[ "${component}" = "shim-v2" ]]; then
-		install_cached_shim_v2_tarball_compare_root_hashes || return "$(cleanup_and_fail_shim_v2_specifics "${component_tarball_path}" "${extra_tarballs}")"
+	if [[ "${component}" = "shim-v2-rust" ]]; then
+		install_cached_shim_v2_rust_tarball_compare_root_hashes || return "$(cleanup_and_fail_shim_v2_rust_specifics "${component_tarball_path}" "${extra_tarballs}")"
 	fi
 
 	info "Using cached tarball of ${component}"
@@ -1042,35 +1043,9 @@ install_nydus() {
 	install -D --mode "${default_binary_permissions}" nydus-static/nydusd "${destdir}/opt/kata/libexec/nydusd"
 }
 
-#Install all components that are not assets
-install_shimv2() {
-	local shim_v2_last_commit
-	shim_v2_last_commit="$(get_last_modification "${repo_root_dir}/src/runtime")"
-	local runtime_rs_last_commit
-	runtime_rs_last_commit="$(get_last_modification "${repo_root_dir}/src/runtime-rs")"
-	local protocols_last_commit
-	protocols_last_commit="$(get_last_modification "${repo_root_dir}/src/libs/protocols")"
-	local GO_VERSION
-	GO_VERSION="$(get_from_kata_deps ".languages.golang.meta.newest-version")"
-	local RUST_VERSION
-	RUST_VERSION="$(get_from_kata_deps ".languages.rust.meta.newest-version")"
-
-	latest_artefact="$(get_kata_version)-${shim_v2_last_commit}-${protocols_last_commit}-${runtime_rs_last_commit}-${GO_VERSION}-${RUST_VERSION}"
-	latest_builder_image="$(get_shim_v2_image_name)"
-
-	install_cached_tarball_component \
-		"shim-v2" \
-		"${latest_artefact}" \
-		"${latest_builder_image}" \
-		"${final_tarball_name}" \
-		"${final_tarball_path}" \
-		&& return 0
-
-	export GO_VERSION
-	export RUST_VERSION
-	export MEASURED_ROOTFS
-	export RUNTIME_CHOICE
-
+# Shared helper: extract measured-rootfs root hashes from confidential image tarballs.
+# These are needed by the Rust runtime (runtime-rs) at build time for dm-verity.
+_collect_root_hashes() {
 	for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
 		local image_conf_tarball
 		image_conf_tarball="$(find "${workdir}" -maxdepth 1 -name "kata-static-rootfs-image-${variant}.tar.zst" 2>/dev/null | head -n 1)"
@@ -1087,6 +1062,70 @@ install_shimv2() {
 
 		mv "root_hash_${variant}.txt" "${workdir}/root_hash_${variant}.txt"
 	done
+}
+
+# Install the Go shim only (containerd-shim-kata-v2 Go runtime + kata-runtime + Go configs).
+install_shim_v2_go() {
+	local shim_v2_last_commit
+	shim_v2_last_commit="$(get_last_modification "${repo_root_dir}/src/runtime")"
+	local protocols_last_commit
+	protocols_last_commit="$(get_last_modification "${repo_root_dir}/src/libs/protocols")"
+	local GO_VERSION
+	GO_VERSION="$(get_from_kata_deps ".languages.golang.meta.newest-version")"
+	local RUST_VERSION
+	RUST_VERSION="$(get_from_kata_deps ".languages.rust.meta.newest-version")"
+
+	latest_artefact="$(get_kata_version)-${shim_v2_last_commit}-${protocols_last_commit}-${GO_VERSION}"
+	latest_builder_image="$(get_shim_v2_image_name)"
+
+	install_cached_tarball_component \
+		"shim-v2-go" \
+		"${latest_artefact}" \
+		"${latest_builder_image}" \
+		"${final_tarball_name}" \
+		"${final_tarball_path}" \
+		&& return 0
+
+	export GO_VERSION
+	export RUST_VERSION
+	export MEASURED_ROOTFS
+	RUNTIME_CHOICE="go"
+	export RUNTIME_CHOICE
+
+	_collect_root_hashes
+
+	DESTDIR="${destdir}" PREFIX="${prefix}" "${shimv2_builder}"
+}
+
+# Install the Rust shim only (containerd-shim-kata-v2 runtime-rs + runtime-rs configs).
+install_shim_v2_rust() {
+	local runtime_rs_last_commit
+	runtime_rs_last_commit="$(get_last_modification "${repo_root_dir}/src/runtime-rs")"
+	local protocols_last_commit
+	protocols_last_commit="$(get_last_modification "${repo_root_dir}/src/libs/protocols")"
+	local GO_VERSION
+	GO_VERSION="$(get_from_kata_deps ".languages.golang.meta.newest-version")"
+	local RUST_VERSION
+	RUST_VERSION="$(get_from_kata_deps ".languages.rust.meta.newest-version")"
+
+	latest_artefact="$(get_kata_version)-${runtime_rs_last_commit}-${protocols_last_commit}-${RUST_VERSION}"
+	latest_builder_image="$(get_shim_v2_image_name)"
+
+	install_cached_tarball_component \
+		"shim-v2-rust" \
+		"${latest_artefact}" \
+		"${latest_builder_image}" \
+		"${final_tarball_name}" \
+		"${final_tarball_path}" \
+		&& return 0
+
+	export GO_VERSION
+	export RUST_VERSION
+	export MEASURED_ROOTFS
+	RUNTIME_CHOICE="rust"
+	export RUNTIME_CHOICE
+
+	_collect_root_hashes
 
 	DESTDIR="${destdir}" PREFIX="${prefix}" "${shimv2_builder}"
 }
@@ -1393,7 +1432,8 @@ handle_build() {
 		install_qemu_snp_experimental
 		install_qemu_tdx_experimental
 		install_stratovirt
-		install_shimv2
+		install_shim_v2_go
+		install_shim_v2_rust
 		install_trace_forwarder
 		install_virtiofsd
 		;;
@@ -1472,7 +1512,9 @@ handle_build() {
 
 	rootfs-cca-confidential-initrd) install_initrd_confidential ;;
 
-	shim-v2) install_shimv2 ;;
+	shim-v2-go) install_shim_v2_go ;;
+
+	shim-v2-rust) install_shim_v2_rust ;;
 
 	trace-forwarder) install_trace_forwarder ;;
 
@@ -1523,10 +1565,10 @@ handle_build() {
 			fi
 			tar --zstd -tvf "${modules_final_tarball_path}"
 			;;
-		shim-v2)
+		shim-v2-go|shim-v2-rust)
 			if [[ "${MEASURED_ROOTFS}" == "yes" ]]; then
 				for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
-					[[ -f "${workdir}/root_hash_${variant}.txt" ]] && mv "${workdir}/root_hash_${variant}.txt" "${workdir}/shim-v2-root_hash_${variant}.txt"
+					[[ -f "${workdir}/root_hash_${variant}.txt" ]] && mv "${workdir}/root_hash_${variant}.txt" "${workdir}/${build_target}-root_hash_${variant}.txt"
 				done
 			fi
 			;;
@@ -1584,18 +1626,17 @@ handle_build() {
 					"kata-static-${build_target}-modules.tar.zst"
 				)
 				;;
-			shim-v2)
-				if [[ "${MEASURED_ROOTFS}" == "yes" ]]; then
-					local found_any=""
-					for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
-						# The variants could be built independently we need to check if
-						# they exist and then push them to the registry
-					[[ -f "${workdir}/shim-v2-root_hash_${variant}.txt" ]] && files_to_push+=("shim-v2-root_hash_${variant}.txt")
-						found_any="yes"
-					done
-					[[ -z "${found_any}" ]] && die "No files to push for shim-v2 with MEASURED_ROOTFS support"
-				fi
-				;;
+		shim-v2-rust)
+			if [[ "${MEASURED_ROOTFS}" == "yes" ]]; then
+				local found_any=""
+				for variant in confidential nvidia-gpu nvidia-gpu-confidential; do
+					# The variants could be built independently we need to check if
+					# they exist and then push them to the registry
+					[[ -f "${workdir}/shim-v2-rust-root_hash_${variant}.txt" ]] && files_to_push+=("shim-v2-rust-root_hash_${variant}.txt") && found_any="yes"
+				done
+				[[ -z "${found_any}" ]] && die "No files to push for shim-v2-rust with MEASURED_ROOTFS support"
+			fi
+			;;
 			*)
 				;;
 		esac
@@ -1642,7 +1683,8 @@ main() {
 		rootfs-initrd
 		rootfs-initrd-confidential
 		rootfs-initrd-mariner
-		shim-v2
+		shim-v2-go
+		shim-v2-rust
 		trace-forwarder
 		virtiofsd
 		dummy

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -13,30 +13,23 @@ set -o errtrace
 
 SCRIPT_DIR="$(cd "$(dirname "${0}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../../.." && pwd)"
-KATA_DEPLOY_DIR="${REPO_ROOT}/tools/packaging/kata-deploy"
-STAGED_ARTIFACT="${KATA_DEPLOY_DIR}/kata-static.tar.zst"
-KATA_DEPLOY_ARTIFACT="${1:-"kata-static.tar.zst"}"
-REGISTRY="${2:-"quay.io/kata-containers/kata-deploy"}"
-TAG="${3:-}"
 
-# Only remove a staged copy we created (skip when source is already the staged path).
-REMOVE_STAGED_ON_EXIT=false
+REGISTRY="${1:-"quay.io/kata-containers/kata-deploy"}"
+TAG="${2:-}"
+
+KATA_DEPLOY_DIR="${REPO_ROOT}/tools/packaging/kata-deploy"
+ARTIFACTS_BUILD_DIR="${KATA_DEPLOY_DIR}/local-build/build"
+ARTIFACTS_STAGE_DIR="${KATA_DEPLOY_DIR}/kata-artifacts"
+
+# Stage the component tarballs into a directory that is visible to the
+# Docker build context (local-build/ is excluded via .dockerignore).
+mkdir -p "${ARTIFACTS_STAGE_DIR}"
+cp "${ARTIFACTS_BUILD_DIR}"/kata-static-*.tar.zst "${ARTIFACTS_STAGE_DIR}/"
+
 cleanup() {
-	if [[ "${REMOVE_STAGED_ON_EXIT}" = true ]]; then
-		rm -f "${STAGED_ARTIFACT}"
-	fi
+	rm -rf "${ARTIFACTS_STAGE_DIR}"
 }
 trap cleanup EXIT
-
-src_rp="$(realpath -e "${KATA_DEPLOY_ARTIFACT}" 2>/dev/null || true)"
-dest_rp="$(realpath -e "${STAGED_ARTIFACT}" 2>/dev/null || true)"
-if [[ -n "${src_rp}" ]] && [[ -n "${dest_rp}" ]] && [[ "${src_rp}" = "${dest_rp}" ]]; then
-	echo "Artifact already at staged path ${STAGED_ARTIFACT}; skipping copy"
-else
-	echo "Copying ${KATA_DEPLOY_ARTIFACT} to ${STAGED_ARTIFACT}"
-	cp "${KATA_DEPLOY_ARTIFACT}" "${STAGED_ARTIFACT}"
-	REMOVE_STAGED_ON_EXIT=true
-fi
 
 pushd "${REPO_ROOT}"
 

--- a/tools/packaging/kata-deploy/shim-components.json
+++ b/tools/packaging/kata-deploy/shim-components.json
@@ -1,0 +1,85 @@
+{
+  "_comment": [
+    "Maps each runtime class to the component tarballs it requires per architecture.",
+    "All names correspond directly to kata-static-<name>.tar.zst build artifacts."
+  ],
+  "shims": {
+    "qemu": {
+      "x86_64":  ["shim-v2-go", "qemu", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd"],
+      "aarch64": ["shim-v2-go", "qemu", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd", "ovmf"],
+      "s390x":   ["shim-v2-go", "qemu", "virtiofsd", "kernel", "rootfs-image", "rootfs-initrd"],
+      "ppc64le": ["shim-v2-go", "qemu", "virtiofsd", "kernel", "rootfs-initrd"]
+    },
+    "qemu-runtime-rs": {
+      "x86_64":  ["shim-v2-rust", "qemu", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd"],
+      "aarch64": ["shim-v2-rust", "qemu", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd", "ovmf"],
+      "s390x":   ["shim-v2-rust", "qemu", "virtiofsd", "kernel", "rootfs-image", "rootfs-initrd"]
+    },
+    "qemu-snp": {
+      "x86_64": ["shim-v2-go", "qemu-snp-experimental", "kernel", "rootfs-image-confidential", "ovmf-sev"]
+    },
+    "qemu-snp-runtime-rs": {
+      "x86_64": ["shim-v2-rust", "qemu-snp-experimental", "kernel", "rootfs-image-confidential", "ovmf-sev"]
+    },
+    "qemu-tdx": {
+      "x86_64": ["shim-v2-go", "qemu-tdx-experimental", "kernel", "rootfs-image-confidential", "ovmf-tdx"]
+    },
+    "qemu-tdx-runtime-rs": {
+      "x86_64": ["shim-v2-rust", "qemu-tdx-experimental", "virtiofsd", "kernel", "rootfs-image-confidential", "ovmf-tdx"]
+    },
+    "qemu-se": {
+      "s390x": ["shim-v2-go", "qemu", "virtiofsd", "kernel", "rootfs-image-confidential"]
+    },
+    "qemu-se-runtime-rs": {
+      "s390x": ["shim-v2-rust", "qemu", "virtiofsd", "kernel", "rootfs-image-confidential"]
+    },
+    "qemu-nvidia-gpu": {
+      "x86_64": ["shim-v2-go", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu", "ovmf"]
+    },
+    "qemu-nvidia-gpu-runtime-rs": {
+      "x86_64":  ["shim-v2-rust", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu", "ovmf"]
+    },
+    "qemu-nvidia-gpu-snp": {
+      "x86_64": ["shim-v2-go", "qemu-snp-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu-confidential", "ovmf-sev"]
+    },
+    "qemu-nvidia-gpu-snp-runtime-rs": {
+      "x86_64": ["shim-v2-rust", "qemu-snp-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu-confidential", "ovmf-sev"]
+    },
+    "qemu-nvidia-gpu-tdx": {
+      "x86_64": ["shim-v2-go", "qemu-tdx-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu-confidential", "ovmf-tdx"]
+    },
+    "qemu-nvidia-gpu-tdx-runtime-rs": {
+      "x86_64": ["shim-v2-rust", "qemu-tdx-experimental", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu-confidential", "ovmf-tdx"]
+    },
+    "qemu-coco-dev": {
+      "x86_64": ["shim-v2-go", "qemu", "kernel", "kernel-debug", "rootfs-image-confidential"],
+      "s390x":  ["shim-v2-go", "qemu", "kernel", "rootfs-image-confidential"]
+    },
+    "qemu-coco-dev-runtime-rs": {
+      "x86_64":  ["shim-v2-rust", "qemu", "kernel", "kernel-debug", "rootfs-image-confidential"],
+      "aarch64": ["shim-v2-rust", "qemu", "kernel", "kernel-debug", "rootfs-image-confidential", "ovmf"],
+      "s390x":   ["shim-v2-rust", "qemu", "kernel", "rootfs-image-confidential"]
+    },
+    "clh": {
+      "x86_64":  ["shim-v2-go", "cloud-hypervisor", "cloud-hypervisor-glibc", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd", "rootfs-image-mariner"],
+      "aarch64": ["shim-v2-go", "cloud-hypervisor", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd"]
+    },
+    "clh-runtime-rs": {
+      "x86_64":  ["shim-v2-rust", "cloud-hypervisor", "cloud-hypervisor-glibc", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd", "rootfs-image-mariner"],
+      "aarch64": ["shim-v2-rust", "cloud-hypervisor", "virtiofsd", "nydus", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd"]
+    },
+    "dragonball": {
+      "x86_64":  ["shim-v2-rust", "virtiofsd", "nydus", "kernel-dragonball-experimental", "rootfs-image", "rootfs-initrd"],
+      "aarch64": ["shim-v2-rust", "virtiofsd", "nydus", "kernel-dragonball-experimental", "rootfs-image", "rootfs-initrd"]
+    },
+    "fc": {
+      "x86_64":  ["shim-v2-go", "firecracker", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd"],
+      "aarch64": ["shim-v2-go", "firecracker", "kernel", "kernel-debug", "rootfs-image", "rootfs-initrd"]
+    },
+    "remote": {
+      "x86_64":  ["shim-v2-go"],
+      "ppc64le": ["shim-v2-go"],
+      "s390x":   ["shim-v2-go"]
+    }
+  }
+}


### PR DESCRIPTION
Currently kata-deploy just drops **ALL** files into the host, which is not exactly the best approach when the users are interested in one specific runtime class.

To avoid wasted space and also the risk of having unneeded / unwanted binaries deployed into the node, let's make sure we install only what's strictly needed by the runtime classes selected by the admin.