### PR TITLE
genpolicy: lock reference digests, gate image references

### DIFF
--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -106,6 +106,9 @@ CreateContainerRequest := {"ops": ops, "allowed": true} if {
     p_storages := p_container.storages
     allow_by_anno(p_oci, i_oci, p_storages, i_storages)
 
+    allow_image(p_oci, i_oci)
+    allow_image_storages(p_oci, i_oci, i_storages)
+
     p_devices := p_container.devices
     allow_devices(p_devices, i_devices, i_oci)
 
@@ -307,6 +310,108 @@ allow_by_anno(p_oci, i_oci, p_storages, i_storages) if {
     allow_by_sandbox_name(p_oci, i_oci, p_storages, i_storages, i_s_name, i_s_namespace)
 
     print("allow_by_anno 2: true")
+}
+
+# Allow the pause container.
+allow_image(p_oci, i_oci) if {
+    print("allow_image 1: start")
+    i_oci.Annotations["io.kubernetes.cri.container-type"] == "sandbox"
+    print("allow_image 1: sandbox container, skipping image gate, true")
+}
+
+# Other containers:
+#
+# Input forms:
+# - REGISTRY/NAME:TAG
+# - REGISTRY/NAME:DIGEST
+#
+# Policy forms:
+# - REGISTRY/NAME:TAG
+# - REGISTRY/NAME:DIGEST
+# - NAME:TAG
+# - NAME:DIGEST
+#
+# - If DIGEST in input, require DIGEST matches policy (REGISTRY/NAME do not matter)
+# - If no DIGEST in input:
+#   - If REGISTRY in input and REGISTRY in policy, match exactly
+#   - If REGISTRY in input but no REGISTRY in policy, match NAME:TAG
+#     - At runtime, input always has REGISTRY
+allow_image(p_oci, i_oci) if {
+    print("allow_image 2: start")
+    i_oci.Annotations["io.kubernetes.cri.container-type"] == "container"
+
+    p_image := p_oci.Annotations["io.kubernetes.cri.image-name"]
+    i_image := i_oci.Annotations["io.kubernetes.cri.image-name"]
+    print("allow_image 2: p_image =", p_image, "i_image =", i_image)
+
+    allow_image_name(p_image, i_image)
+
+    print("allow_image 2: true")
+}
+
+# Extract the "ALGO:HASH" from a digest-pinned reference
+# (e.g. "registry/repo@sha256:abc" → "sha256:abc").
+# Undefined when ref has no "@".
+image_digest(ref) := digest if {
+    parts := split(ref, "@")
+    count(parts) == 2
+    digest := parts[1]
+}
+
+# Primary path: both refs carry a digest: Compare only the digest component,
+# registry/name differences don't matter.
+allow_image_name(p_image, i_image) if {
+    image_digest(p_image) == image_digest(i_image)
+}
+# Fallback path (floating tag): Exact equality.
+allow_image_name(p_image, i_image) if {
+    not contains(p_image, "@")
+    p_image == i_image
+}
+# Fallback path (floating tag): Policy carries a short name (e.g. "nginx:1.27")
+# and the runtime or storage source provides the fully-qualified form
+# (e.g. "docker.io/library/nginx:1.27").
+allow_image_name(p_image, i_image) if {
+    not contains(p_image, "@")
+    endswith(i_image, concat("", ["/", p_image]))
+}
+
+# The Kata Agent reads storage.source.
+allow_image_storages(p_oci, i_oci, i_storages) if {
+    print("allow_image_storages 1: start")
+    i_oci.Annotations["io.kubernetes.cri.container-type"] == "sandbox"
+    print("allow_image_storages 1: sandbox container, skipping storage image gate, true")
+}
+allow_image_storages(p_oci, i_oci, i_storages) if {
+    print("allow_image_storages 2: start")
+    i_oci.Annotations["io.kubernetes.cri.container-type"] == "container"
+
+    p_image := p_oci.Annotations["io.kubernetes.cri.image-name"]
+    print("allow_image_storages 2: p_image =", p_image)
+
+    every i_storage in i_storages {
+        allow_image_storage(p_image, i_storage)
+    }
+
+    print("allow_image_storages 2: true")
+}
+
+# Non-image_guest_pull storages carry no image reference; nothing to gate.
+allow_image_storage(p_image, i_storage) if {
+    i_storage.driver != "image_guest_pull"
+}
+# image_guest_pull: the agent pulls via storage.source, gate on that alone.
+# storage.source always carries the fully-qualified reference; reuse
+# allow_image_name so that digest and short-name cases are handled the same as
+# the annotation check.
+allow_image_storage(p_image, i_storage) if {
+    print("allow_image_storage: start")
+    i_storage.driver == "image_guest_pull"
+
+    print("allow_image_storage: p_image =", p_image, "i_storage.source =", i_storage.source)
+    allow_image_name(p_image, i_storage.source)
+
+    print("allow_image_storage: true")
 }
 
 allow_by_sandbox_name(p_oci, i_oci, p_storages, i_storages, s_name, s_namespace) if {

--- a/src/tools/genpolicy/src/cronjob.rs
+++ b/src/tools/genpolicy/src/cronjob.rs
@@ -73,6 +73,20 @@ impl yaml::K8sResource for CronJob {
     ) {
         yaml::k8s_resource_init(&mut self.spec.jobTemplate.spec.template.spec, config).await;
         self.doc_mapping = doc_mapping.clone();
+        if config.lock_digests {
+            if let Some(spec_val) = self.doc_mapping
+                .get_mut("spec")
+                .and_then(|v| v.get_mut("jobTemplate"))
+                .and_then(|v| v.get_mut("spec"))
+                .and_then(|v| v.get_mut("template"))
+                .and_then(|v| v.get_mut("spec"))
+            {
+                yaml::rewrite_container_images(
+                    spec_val,
+                    &self.spec.jobTemplate.spec.template.spec.containers,
+                );
+            }
+        }
     }
 
     fn get_sandbox_name(&self) -> Option<String> {

--- a/src/tools/genpolicy/src/daemon_set.rs
+++ b/src/tools/genpolicy/src/daemon_set.rs
@@ -79,6 +79,15 @@ impl yaml::K8sResource for DaemonSet {
     ) {
         yaml::k8s_resource_init(&mut self.spec.template.spec, config).await;
         self.doc_mapping = doc_mapping.clone();
+        if config.lock_digests {
+            if let Some(spec_val) = self.doc_mapping
+                .get_mut("spec")
+                .and_then(|v| v.get_mut("template"))
+                .and_then(|v| v.get_mut("spec"))
+            {
+                yaml::rewrite_container_images(spec_val, &self.spec.template.spec.containers);
+            }
+        }
     }
 
     fn get_sandbox_name(&self) -> Option<String> {

--- a/src/tools/genpolicy/src/deployment.rs
+++ b/src/tools/genpolicy/src/deployment.rs
@@ -88,6 +88,15 @@ impl yaml::K8sResource for Deployment {
     ) {
         yaml::k8s_resource_init(&mut self.spec.template.spec, config).await;
         self.doc_mapping = doc_mapping.clone();
+        if config.lock_digests {
+            if let Some(spec_val) = self.doc_mapping
+                .get_mut("spec")
+                .and_then(|v| v.get_mut("template"))
+                .and_then(|v| v.get_mut("spec"))
+            {
+                yaml::rewrite_container_images(spec_val, &self.spec.template.spec.containers);
+            }
+        }
     }
 
     fn get_sandbox_name(&self) -> Option<String> {

--- a/src/tools/genpolicy/src/job.rs
+++ b/src/tools/genpolicy/src/job.rs
@@ -89,6 +89,15 @@ impl yaml::K8sResource for Job {
     ) {
         yaml::k8s_resource_init(&mut self.spec.template.spec, config).await;
         self.doc_mapping = doc_mapping.clone();
+        if config.lock_digests {
+            if let Some(spec_val) = self.doc_mapping
+                .get_mut("spec")
+                .and_then(|v| v.get_mut("template"))
+                .and_then(|v| v.get_mut("spec"))
+            {
+                yaml::rewrite_container_images(spec_val, &self.spec.template.spec.containers);
+            }
+        }
     }
 
     fn get_sandbox_name(&self) -> Option<String> {

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -677,6 +677,21 @@ impl Container {
         self.registry = registry::get_container(config, &self.image, is_pause_container)
             .await
             .unwrap();
+
+        if config.lock_digests && !self.image.contains("@") {
+            let digest = self.registry.manifest_digest.clone();
+            let image_ref = if !digest.is_empty() {
+                let base = self.image.rfind('/').map(|p| p + 1).unwrap_or(0);
+                let rest = self.image[base..]
+                    .find(':')
+                    .map(|colon| &self.image[..base + colon])
+                    .unwrap_or(&self.image);
+                format!("{}@{}", rest, digest)
+            } else {
+                self.image.clone()
+            };
+            self.image = image_ref;
+        }
     }
 
     pub fn get_env_variables(

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -999,6 +999,11 @@ impl yaml::K8sResource for Pod {
     async fn init(&mut self, config: &Config, doc_mapping: &serde_yaml::Value, _silent: bool) {
         yaml::k8s_resource_init(&mut self.spec, config).await;
         self.doc_mapping = doc_mapping.clone();
+        if config.lock_digests {
+            if let Some(spec_val) = self.doc_mapping.get_mut("spec") {
+                yaml::rewrite_container_images(spec_val, &self.spec.containers);
+            }
+        }
     }
 
     fn get_sandbox_name(&self) -> Option<String> {

--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -32,6 +32,7 @@ pub struct Container {
     pub config_layer: DockerConfigLayer,
     pub passwd: String,
     pub group: String,
+    pub manifest_digest: String,
 }
 
 /// Image config layer properties.
@@ -206,6 +207,7 @@ impl Container {
             config_layer,
             passwd,
             group,
+            manifest_digest: digest_hash,
         })
     }
 

--- a/src/tools/genpolicy/src/registry_containerd.rs
+++ b/src/tools/genpolicy/src/registry_containerd.rs
@@ -55,7 +55,7 @@ impl Container {
         pull_image(&image_ref, k8_cri_image_client.clone()).await?;
 
         let image_ref_str = &image_ref.to_string();
-        let manifest = get_image_manifest(image_ref_str, &ctrd_client).await?;
+        let (manifest, manifest_digest) = get_image_manifest(image_ref_str, &ctrd_client).await?;
         debug!(
             "manifest: {}",
             serde_json::to_string_pretty(&manifest).unwrap()
@@ -102,6 +102,7 @@ impl Container {
             config_layer,
             passwd,
             group,
+            manifest_digest,
         })
     }
 }
@@ -133,7 +134,7 @@ pub async fn get_content(
 pub async fn get_image_manifest(
     image_ref: &str,
     client: &containerd_client::Client,
-) -> Result<serde_json::Value> {
+) -> Result<(serde_json::Value, String)> {
     let mut imageChannel = client.images();
 
     let req = GetImageRequest {
@@ -151,7 +152,7 @@ pub async fn get_image_manifest(
     let is_image_manifest = content.get("layers").is_some();
 
     if is_image_manifest {
-        return Ok(content);
+        return Ok((content, image_digest));
     }
 
     // else, content is an image index
@@ -171,9 +172,9 @@ pub async fn get_image_manifest(
         }
     }
 
-    let image_digest = manifestAmd64["digest"].as_str().unwrap();
+    let image_digest = manifestAmd64["digest"].as_str().unwrap().to_string();
 
-    get_content(image_digest, client).await
+    Ok((get_content(&image_digest, client).await?, image_digest))
 }
 
 pub async fn get_config_layer(

--- a/src/tools/genpolicy/src/replica_set.rs
+++ b/src/tools/genpolicy/src/replica_set.rs
@@ -49,6 +49,15 @@ impl yaml::K8sResource for ReplicaSet {
     async fn init(&mut self, config: &Config, doc_mapping: &serde_yaml::Value, _silent: bool) {
         yaml::k8s_resource_init(&mut self.spec.template.spec, config).await;
         self.doc_mapping = doc_mapping.clone();
+        if config.lock_digests {
+            if let Some(spec_val) = self.doc_mapping
+                .get_mut("spec")
+                .and_then(|v| v.get_mut("template"))
+                .and_then(|v| v.get_mut("spec"))
+            {
+                yaml::rewrite_container_images(spec_val, &self.spec.template.spec.containers);
+            }
+        }
     }
 
     fn get_sandbox_name(&self) -> Option<String> {

--- a/src/tools/genpolicy/src/replication_controller.rs
+++ b/src/tools/genpolicy/src/replication_controller.rs
@@ -51,6 +51,15 @@ impl yaml::K8sResource for ReplicationController {
     async fn init(&mut self, config: &Config, doc_mapping: &serde_yaml::Value, _silent: bool) {
         yaml::k8s_resource_init(&mut self.spec.template.spec, config).await;
         self.doc_mapping = doc_mapping.clone();
+        if config.lock_digests {
+            if let Some(spec_val) = self.doc_mapping
+                .get_mut("spec")
+                .and_then(|v| v.get_mut("template"))
+                .and_then(|v| v.get_mut("spec"))
+            {
+                yaml::rewrite_container_images(spec_val, &self.spec.template.spec.containers);
+            }
+        }
     }
 
     fn get_sandbox_name(&self) -> Option<String> {

--- a/src/tools/genpolicy/src/stateful_set.rs
+++ b/src/tools/genpolicy/src/stateful_set.rs
@@ -99,6 +99,15 @@ impl yaml::K8sResource for StatefulSet {
     async fn init(&mut self, config: &Config, doc_mapping: &serde_yaml::Value, _silent: bool) {
         yaml::k8s_resource_init(&mut self.spec.template.spec, config).await;
         self.doc_mapping = doc_mapping.clone();
+        if config.lock_digests {
+            if let Some(spec_val) = self.doc_mapping
+                .get_mut("spec")
+                .and_then(|v| v.get_mut("template"))
+                .and_then(|v| v.get_mut("spec"))
+            {
+                yaml::rewrite_container_images(spec_val, &self.spec.template.spec.containers);
+            }
+        }
     }
 
     fn get_sandbox_name(&self) -> Option<String> {

--- a/src/tools/genpolicy/src/utils.rs
+++ b/src/tools/genpolicy/src/utils.rs
@@ -104,6 +104,12 @@ struct CommandLineOptions {
         require_equals = true
     )]
     layers_cache_file_path: Option<String>,
+    #[clap(
+        long,
+        help = "Rewrite image tags to digest-pinned references in both the output YAML and the policy"
+    )]
+    lock_digests: bool,
+
     #[clap(short, long, help = "Print version information and exit")]
     version: bool,
 
@@ -124,6 +130,7 @@ pub struct Config {
     pub settings: settings::Settings,
     pub config_files: Option<Vec<String>>,
 
+    pub lock_digests: bool,
     pub silent_unsupported_fields: bool,
     pub raw_out: bool,
     pub base64_out: bool,
@@ -175,6 +182,7 @@ impl Config {
             rego_rules_path: args.rego_rules_path,
             settings,
             config_files,
+            lock_digests: args.lock_digests,
             silent_unsupported_fields: args.silent_unsupported_fields,
             raw_out: args.raw_out,
             base64_out: args.base64_out,

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -276,6 +276,32 @@ pub fn get_yaml_header(yaml: &str) -> anyhow::Result<YamlHeader> {
     Ok(serde_yaml::from_str(yaml)?)
 }
 
+pub fn rewrite_container_images(
+    spec_mapping: &mut serde_yaml::Value,
+    containers: &[pod::Container],
+) {
+    for key in &["containers", "initContainers"] {
+        if let Some(arr) = spec_mapping
+            .get_mut(*key)
+            .and_then(|v| v.as_sequence_mut())
+        {
+            for item in arr.iter_mut() {
+                let name = item
+                    .get("name")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                if let Some(name) = name {
+                    if let Some(c) = containers.iter().find(|c| c.name == name) {
+                        if let Some(image_val) = item.get_mut("image") {
+                            *image_val = serde_yaml::Value::String(c.image.clone());
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 pub async fn k8s_resource_init(spec: &mut pod::PodSpec, config: &Config) {
     for container in &mut spec.containers {
         let is_pause_container = false;

--- a/src/tools/genpolicy/tests/policy/main.rs
+++ b/src/tools/genpolicy/tests/policy/main.rs
@@ -121,6 +121,7 @@ mod tests {
             version: false,
             yaml_file: workdir.join("pod.yaml").to_str().map(|s| s.to_string()),
             initdata: kata_types::initdata::InitData::new("sha256", "0.1.0"),
+            lock_digests: false,
         };
 
         // The container repos/network calls can be unreliable, so retry


### PR DESCRIPTION
Add a new flag to `genpolicy` called `--lock-digests`.

When this flag is specified, the tool:

1. Where floating image tags (or no tags) are present in the input resource, emits resolved manifest digests in the policy;
2. Where floating image tags (or no tags) are present in the input resource, replaces those with the corresponding resolved manifest digests.

Additionally, and besides the flag, add rules to the policy in general to match:

1. The `io.kubernetes.cri.image-name` annotation against:
   1. Digests, if present, or;
   2. Registry, name, and tag, or;
   3. Name and tag, all as appropriate.
2. The `source` field in the storages where driver is `image_guest_pull` against that annotation's value in the policy:
   1. Via the same rules as above.

--

In general, my goal is to add workload enforcement to the policy such that any tampering with a container image is detected and the pod is prevented from starting. Checking container reference names and tags is fine, but that doesn't guarantee that someone didn't overwrite the tag with another, modified image, hence my interest in the digests.

**Note:** I only use Peer Pods with CoCo, no local/nested CVMs.