### PR TITLE
gha: k8s: reject unsupported KATA_HYPERVISOR values

### DIFF
--- a/tests/hypervisor_helpers.sh
+++ b/tests/hypervisor_helpers.sh
@@ -13,6 +13,19 @@ TEE_HYPERVISORS=("${SNP_HYPERVISORS[@]}" "${TDX_HYPERVISORS[@]}" "${SE_HYPERVISO
 NON_TEE_HYPERVISORS=("qemu-coco-dev" "qemu-coco-dev-runtime-rs")
 FIRECRACKER_HYPERVISORS=("firecracker" "fc")
 
+ALL_HYPERVISORS=(
+	"clh"
+	"clh-runtime-rs"
+	"dragonball"
+	"qemu"
+	"qemu-runtime-rs"
+	"qemu-nvidia-gpu"
+	"qemu-nvidia-gpu-runtime-rs"
+	"${TEE_HYPERVISORS[@]}"
+	"${NON_TEE_HYPERVISORS[@]}"
+	"${FIRECRACKER_HYPERVISORS[@]}"
+)
+
 function is_snp_hypervisor() {
 	local hypervisor="${1:-${KATA_HYPERVISOR}}"
 	# shellcheck disable=SC2076 # intentionally use literal string matching
@@ -59,6 +72,13 @@ function is_firecracker_hypervisor() {
 	local hypervisor="${1:-${KATA_HYPERVISOR}}"
 	# shellcheck disable=SC2076 # intentionally use literal string matching
 	[[ " ${FIRECRACKER_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
+	return 1
+}
+
+function is_supported_hypervisor() {
+	local hypervisor="${1:-${KATA_HYPERVISOR}}"
+	# shellcheck disable=SC2076 # intentionally use literal string matching
+	[[ " ${ALL_HYPERVISORS[*]} " =~ " ${hypervisor} " ]] && return 0
 	return 1
 }
 

--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -177,6 +177,11 @@ function deploy_coco_kbs() {
 function deploy_kata() {
 	platform="${1:-}"
 
+	if ! is_supported_hypervisor "${KATA_HYPERVISOR}" ; then
+		# shellcheck disable=SC2154
+		die "Unsupported KATA_HYPERVISOR=${KATA_HYPERVISOR}. Supported values: ${ALL_HYPERVISORS[*]}"
+	fi
+
 	[[ "${platform}" = "kcli" ]] && \
 	export KUBECONFIG="${HOME}/.kcli/clusters/${CLUSTER_NAME:-kata-k8s}/auth/kubeconfig"
 


### PR DESCRIPTION
Exit early with an error message instead of starting kata-deploy if the value of KATA_HYPERVISOR is not expected during CI.

For example: "cloud-hypervisor" was renamed recently to "clh-runtime-rs" and user scripts depending on the old name were getting tangled in kata-deploy instead of just rejecting the old value quickly.