### PR TITLE
tests: export target_branch="${branch}"

### DIFF
--- a/tests/common.bash
+++ b/tests/common.bash
@@ -32,6 +32,9 @@ RUNTIME="${RUNTIME:-containerd-shim-kata-v2}"
 
 export branch="${target_branch:-"$(git remote show origin | sed -n '/HEAD branch/s/.*: //p')"}"
 
+# Export target_branch to avoid hitting the remote repository again when this script gets loaded again.
+export target_branch="${branch}"
+
 function die() {
 	local msg="$*"
 


### PR DESCRIPTION
Avoid running "git remote show origin" repeatedly when common.bash gets sourced multiple times and target_branch was not specified by the caller.

Repeated "git remote show origin" calls inflicted the additional overhead of authenticating and communicating with the remote git repository.