### PR TITLE
runtime-rs: preserve ccw address for modern block devices

### DIFF
--- a/src/agent/src/storage/block_handler.rs
+++ b/src/agent/src/storage/block_handler.rs
@@ -163,8 +163,8 @@ impl StorageHandler for VirtioBlkCcwHandler {
         let ccw_device = ccw::Device::from_str(&storage.source)?;
         let dev_path = get_virtio_blk_ccw_device_name(ctx.sandbox, &ccw_device).await?;
         storage.source = dev_path;
-        let path = common_storage_handler(ctx.logger, &storage)?;
-        new_device(path)
+        let dev_num = get_device_number(&storage.source, None)?;
+        handle_block_storage(ctx.logger, &storage, &dev_num).await
     }
 
     #[cfg(not(target_arch = "s390x"))]

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk_modern.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk_modern.rs
@@ -53,6 +53,9 @@ pub struct BlockConfigModern {
     /// scsi_addr is of the format SCSI-Id:LUN
     pub scsi_addr: Option<String>,
 
+    /// CCW device address for virtio-blk-ccw on s390x (e.g., "0.0.0005")
+    pub ccw_addr: Option<String>,
+
     /// device attach count
     pub attach_count: u64,
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -978,7 +978,7 @@ impl QemuInner {
                 };
 
                 // Second, execute the asynchronous hotplug without holding the lock.
-                let (pci_path, scsi_addr) = qmp
+                let (pci_path, addr_str) = qmp
                     .hotplug_block_device(
                         &driver,
                         index,
@@ -1000,8 +1000,12 @@ impl QemuInner {
                     if let Some(p) = pci_path {
                         cfg.pci_path = Some(p);
                     }
-                    if let Some(s) = scsi_addr {
-                        cfg.scsi_addr = Some(s);
+                    if let Some(addr) = addr_str {
+                        if driver == VIRTIO_BLK_CCW {
+                            cfg.ccw_addr = Some(addr);
+                        } else {
+                            cfg.scsi_addr = Some(addr);
+                        }
                     }
                     info!(sl!(), "Completed BlockModern hotplug: {:?}", &cfg);
                 }

--- a/src/runtime-rs/crates/resource/src/volume/utils.rs
+++ b/src/runtime-rs/crates/resource/src/volume/utils.rs
@@ -107,6 +107,13 @@ pub async fn handle_block_volume(
                     return Err(anyhow!("block driver is scsi but no scsi address exists"));
                 }
             }
+            KATA_CCW_DEV_TYPE => {
+                if let Some(ccw_addr) = &device.config.ccw_addr {
+                    ccw_addr.to_string()
+                } else {
+                    return Err(anyhow!("block driver is ccw but no ccw address exists"));
+                }
+            }
             _ => device.config.virt_path.clone(),
         };
         device_id = device.device_id.clone();


### PR DESCRIPTION
Store the hotplugged CCW address in BlockModern configs and use it when building storage sources so s390x encrypted emptyDir paths no longer fall back to /dev/vda.