### PR TITLE
runtime-rs: use proper temp dirs in initdata tests

### DIFF
--- a/src/runtime-rs/crates/resource/src/coco_data/initdata_block.rs
+++ b/src/runtime-rs/crates/resource/src/coco_data/initdata_block.rs
@@ -279,16 +279,10 @@ mod tests {
     use std::env;
     use std::io::Read;
 
-    fn setup_test_env() -> PathBuf {
-        let dir = env::temp_dir().join("initimg_test");
-        fs::create_dir_all(&dir).unwrap();
-        dir
-    }
-
     #[test]
     fn test_valid_creation() {
-        let dir = setup_test_env();
-        let path = dir.join("test.img");
+        let dir = tempfile::tempdir().expect("crating temp dir failed");
+        let path = dir.path().join("test.img");
 
         let data = "[config]\nkey = \"value\"\n";
         let result = create_compressed_block(data, &path, Some(6));
@@ -312,8 +306,8 @@ mod tests {
 
     #[test]
     fn test_empty_input() {
-        let dir = setup_test_env();
-        let path = dir.join("empty.img");
+        let dir = tempfile::tempdir().expect("crating temp dir failed");
+        let path = dir.path().join("empty.img");
 
         let result = create_compressed_block("", &path, None);
 
@@ -326,13 +320,13 @@ mod tests {
 
     #[test]
     fn test_different_compression_levels() {
-        let dir = setup_test_env();
+        let dir = tempfile::tempdir().expect("crating temp dir failed");
         let data = "[config]\n".repeat(1000); // Generate large test data
 
         let sizes = vec![0, 3, 9]
             .into_iter()
             .map(|level| {
-                let path = dir.join(format!("test_comp_{}.img", level));
+                let path = dir.path().join(format!("test_comp_{}.img", level));
                 let res = create_compressed_block(&data, &path, Some(level));
                 let size = res.unwrap();
                 fs::remove_file(&path).unwrap();


### PR DESCRIPTION
The test currently uses a static directory at `/tmp/initimg_test`. This introduces non-determinism into the unit test:

* Files that already exist in that dir might alter test results.
* If the directory is owned by root, the test will fail due to permissions.

Switch to using the tempfile crate instead.

Fixes: #13053

---

Note the test failures on one of the ppc64le runners: https://github.com/kata-containers/kata-containers/actions/runs/25962306848/job/76319654980 (cc @fidencio )