### PR TITLE
helm-chart: add priorityClassName to prevent kata-deploy eviction

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -61,6 +61,9 @@ spec:
       tolerations:
 {{- toYaml . | nindent 8 }}
 {{- end }}
+{{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+{{- end }}
 {{- if index .Values "node-feature-discovery" "enabled" }}
       # When node-feature-discovery is managed by this chart (enabled: true), enforce virtualization requirements.
       # Kata Containers requires hardware virtualization support to function.

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -38,6 +38,23 @@ containerd:
 nodeSelector: {}
 tolerations: []
 
+# Priority class name for the kata-deploy DaemonSet pods.
+#
+# kata-deploy is an infrastructure DaemonSet that installs Kata runtime
+# artifacts on every node. If it gets evicted under node pressure, the
+# node loses its Kata runtime until the pod is rescheduled. Setting a
+# high-priority class prevents the kubelet from evicting kata-deploy
+# before lower-priority workloads.
+#
+# Kubernetes ships "system-node-critical" and "system-cluster-critical"
+# PriorityClasses by default. You can also create your own.
+#
+# Examples:
+# priorityClassName: system-node-critical
+# priorityClassName: system-cluster-critical
+# priorityClassName: my-custom-priority-class
+priorityClassName: "system-node-critical"
+
 # Update strategy for the kata-deploy DaemonSet
 # Default is RollingUpdate with maxUnavailable: 1
 # Examples:


### PR DESCRIPTION
kata-deploy is a per-node infrastructure DaemonSet; if it gets evicted under node memory/CPU pressure the node loses its Kata runtime until the pod is rescheduled. Default to system-node-critical so the kubelet evicts lower-priority workloads first.

The value is configurable via `priorityClassName` in values.yaml.

Fixes: #13068