### PR TITLE
fix: update check-markdown heading test expectations

### DIFF
--- a/tests/cmd/check-markdown/heading_test.go
+++ b/tests/cmd/check-markdown/heading_test.go
@@ -32,8 +32,8 @@ func TestNewHeading(t *testing.T) {
 		{"a", "", "", 1, true},
 
 		{"a", "a", "a", 1, false},
-		{"a-b", "`a-b`", "`a-b`", 1, false},
-		{"a_b", "`a_b`", "`a_b`", 1, false},
+		{"a-b", "`a-b`", "a-b", 1, false},
+		{"a_b", "`a_b`", "a_b", 1, false},
 		{"foo (json) bar", "foo `(json)` bar", "foo-json-bar", 1, false},
 		{"func(json)", "`func(json)`", "funcjson", 1, false},
 		{"?", "?", "", 1, false},
@@ -57,9 +57,9 @@ func TestNewHeading(t *testing.T) {
 			continue
 		}
 
-		assert.Equal(h.Name, d.headingName, msg)
-		assert.Equal(h.MDName, d.mdName, msg)
-		assert.Equal(h.Level, d.level, msg)
-		assert.Equal(h.LinkName, d.expectedLinkName, msg)
+		assert.Equal(d.headingName, h.Name, msg)
+		assert.Equal(d.mdName, h.MDName, msg)
+		assert.Equal(d.level, h.Level, msg)
+		assert.Equal(d.expectedLinkName, h.LinkName, msg)
 	}
 }


### PR DESCRIPTION
Small test fix

`TestNewHeading` expected inline-code heading anchors to keep backticks. The tool already strips them when creating link IDs, so `go test ./...` failed in `tests/cmd/check-markdown`.

Repro:
```sh
cd tests/cmd/check-markdown
go test ./...
```

Before this patch it failed on the `a-b` and `a_b` inline-code cases.

Checked:
```sh
go test -run TestNewHeading -count=1 -v
go test -count=1 ./...
```

Also checked a tiny markdown doc with `# `a-b`` and `[link](#a-b)`, still passes, so we good.