### PR TITLE
agent-ctl: CLH virtio fs queue size fix

### DIFF
--- a/src/tools/agent-ctl/src/vm/share_fs_utils.rs
+++ b/src/tools/agent-ctl/src/vm/share_fs_utils.rs
@@ -65,13 +65,23 @@ pub(crate) async fn setup_virtio_fs(
     std::fs::create_dir_all(&host_path).context("virtio-fs:: failed to create root path")?;
 
     // plugin the device
+    // Use queue size and num from hypervisor config, with fallback to sensible defaults
+    // if not configured (e.g., 1024 queue size, 1 queue as per previous CH defaults)
+    let queue_size: u64 = if shared_fs_info.virtio_fs_queue_size > 0 {
+        shared_fs_info.virtio_fs_queue_size as u64
+    } else {
+        1024 // Default queue size matching previous CH behavior
+    };
+
+    let queue_num: u64 = 1; // Default to 1 queue (previous CH default)
+
     let share_fs_config = ShareFsConfig {
         host_shared_path: host_path.clone(),
         sock_path: generate_sock_path(&host_path),
         mount_tag: String::from(MOUNT_GUEST_TAG),
         fs_type: VIRTIO_FS.to_string(),
-        queue_size: 0,
-        queue_num: 0,
+        queue_size,
+        queue_num,
         options: vec![],
         mount_config: None,
     };

--- a/tests/functional/kata-agent-apis/setup_common.sh
+++ b/tests/functional/kata-agent-apis/setup_common.sh
@@ -83,8 +83,10 @@ run_agent_ctl()
 
 	local server_address="--server-address ${local_agent_server_addr}"
 
+	info "Running agent-ctl with commands: ${cmds}"
+
 	# shellcheck disable=SC2086
-	eval \
+	if ! eval \
 		sudo \
 		RUST_BACKTRACE=full \
 		"${agent_ctl_path}" \
@@ -93,6 +95,13 @@ run_agent_ctl()
 		${server_address} \
 		${cmds} \
 		${redirect}
+	then
+		warn "agent-ctl command failed. Last 50 lines of agent-ctl log:"
+		tail -n 50 "${ctl_log_file}" >&2 || true
+		warn "Last 50 lines of agent log:"
+		tail -n 50 "${agent_log_file}" >&2 || true
+		return 1
+	fi
 }
 
 get_agent_pid()


### PR DESCRIPTION
After commit https://github.com/stevenhorsman/kata-containers/commit/e2240b694a648019f6c44637f049e63200074b24 ("runtime-rs: ch: source virtio-fs queue size
from toml"), Cloud Hypervisor no longer provides fallback defaults for
virtio-fs queue configuration. When queue_size or queue_num are 0, CH
now uses those values directly instead of substituting defaults, which
causes a panic in the device manager.

The agent-ctl tool was hardcoding queue_size=0 and queue_num=0 in
share_fs_utils.rs, relying on CH's fallback behavior. This broke the
agent-api tests for Cloud Hypervisor while QEMU tests continued to pass.

Fix by reading virtio_fs_queue_size from the hypervisor config and
falling back to sensible defaults (1024 queue size, 1 queue) when not
configured, matching the previous CH default behavior.