### PR TITLE
agent: check uevent netlink socket creation failure

### DIFF
--- a/src/agent/src/uevent.rs
+++ b/src/agent/src/uevent.rs
@@ -9,8 +9,9 @@ use crate::sandbox::Sandbox;
 use crate::AGENT_CONFIG;
 use slog::Logger;
 
-use anyhow::{anyhow, Result};
-use netlink_sys::{protocols, SocketAddr, TokioSocket};
+use anyhow::{anyhow, Context, Result};
+use netlink_sys::{SocketAddr, TokioSocket};
+use nix::sys::socket::{socket, AddressFamily, SockFlag, SockProtocol, SockType};
 use std::fmt::Debug;
 use std::os::unix::io::FromRawFd;
 use std::sync::Arc;
@@ -159,6 +160,18 @@ pub async fn wait_for_uevent(
     Ok(uev)
 }
 
+fn new_uevent_socket() -> Result<TokioSocket> {
+    let fd = socket(
+        AddressFamily::Netlink,
+        SockType::Datagram,
+        SockFlag::SOCK_CLOEXEC,
+        Some(SockProtocol::NetlinkKObjectUEvent),
+    )
+    .context("failed to create uevent netlink socket")?;
+
+    Ok(unsafe { TokioSocket::from_raw_fd(fd) })
+}
+
 #[instrument]
 pub async fn watch_uevents(
     sandbox: Arc<Mutex<Sandbox>>,
@@ -173,17 +186,7 @@ pub async fn watch_uevents(
 
     info!(logger, "starting uevents handler");
 
-    let mut socket;
-
-    unsafe {
-        let fd = libc::socket(
-            libc::AF_NETLINK,
-            libc::SOCK_DGRAM | libc::SOCK_CLOEXEC,
-            protocols::NETLINK_KOBJECT_UEVENT as libc::c_int,
-        );
-        socket = TokioSocket::from_raw_fd(fd);
-    }
-
+    let mut socket = new_uevent_socket()?;
     socket.bind(&SocketAddr::new(0, 1))?;
 
     loop {


### PR DESCRIPTION
The uevent watcher called `libc::socket()` and immediately wrapped the returned fd with `TokioSocket::from_raw_fd()`. `from_raw_fd()` requires a valid owned file descriptor, so a socket creation failure would hand an invalid fd to unsafe code instead of returning the OS error.

Use `nix::sys::socket::socket()` for the uevent netlink listener so socket creation failures are returned as errors before the fd is wrapped by `TokioSocket`.

Why this matters:
- The affected path is kata-agent startup, when the uevent watcher creates an `AF_NETLINK` / `NETLINK_KOBJECT_UEVENT` socket.
- `socket()` can fail, for example if the syscall is denied by seccomp/LSM policy, the netlink protocol is unavailable, or the process/system is under fd or memory pressure (`EMFILE`, `ENFILE`, `ENOMEM`, etc.).
- Before this patch, a socket creation failure could be passed into `TokioSocket::from_raw_fd()`, which violates the valid-fd ownership requirement and hides the real OS error.
- After this patch, kata-agent returns an error with context: `failed to create uevent netlink socket`.

Testing:
- `git diff --check`
- `rustfmt --edition 2021 src/agent/src/uevent.rs --check`
- `CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p kata-agent uevent` was attempted locally, but this macOS environment cannot compile the Linux-only `vsock` dependency used by `kata-agent` (`VMADDR_CID_LOCAL`, `SOCK_CLOEXEC`, `VsockAddr`, etc. are unavailable on darwin). Linux CI should exercise the kata-agent checks.