### PR TITLE
release: correct .cargo/config.toml reference in generate_vendor.sh

### DIFF
--- a/tools/packaging/release/generate_vendor.sh
+++ b/tools/packaging/release/generate_vendor.sh
@@ -40,7 +40,7 @@ create_vendor_tarball() {
 				    Cargo.lock)
 				        [[ -d .cargo ]] || mkdir .cargo
 				        cargo vendor >> .cargo/config.toml
-                                        vendor_dir_list+=" ${dir}/vendor ${dir}/.cargo/config"
+                                        vendor_dir_list+=" ${dir}/vendor ${dir}/.cargo/config.toml"
 				        ;;
 				    go.mod)
                                         go mod tidy


### PR DESCRIPTION
The script was creating .cargo/config.toml but referencing .cargo/config in the vendor_dir_list, causing tar to fail with 'Cannot stat' error.


Generated-By: IBM Bob