### PR TITLE
runtime, agent: enable Cloud Hypervisor on RISC-V

### DIFF
--- a/src/agent/Makefile
+++ b/src/agent/Makefile
@@ -126,7 +126,7 @@ $(GENERATED_FILES): %: %.in $(VERSION_FILE)
 	@sed $(foreach r,$(GENERATED_REPLACEMENTS),-e 's|@$r@|$($r)|g') "$<" > "$@"
 
 ##TARGET optimize: optimized  build
-optimize: show-summary show-header
+optimize: $(GENERATED_CODE) show-summary show-header
 	@RUSTFLAGS="-C link-arg=-s $(EXTRA_RUSTFLAGS) --deny warnings" cargo build --target $(TRIPLE) $(if $(findstring release,$(BUILD_TYPE)),--release) $(EXTRA_RUSTFEATURES)
 
 ##TARGET install: install agent

--- a/src/agent/src/device/network_device_handler.rs
+++ b/src/agent/src/device/network_device_handler.rs
@@ -5,18 +5,26 @@
 //
 #[cfg(target_arch = "s390x")]
 use crate::ccw;
+#[cfg(target_arch = "riscv64")]
+use crate::AGENT_CONFIG;
 use crate::linux_abi::*;
 use crate::sandbox::Sandbox;
-use crate::uevent::{wait_for_uevent, Uevent, UeventMatcher};
+#[cfg(not(target_arch = "riscv64"))]
+use crate::uevent::wait_for_uevent;
+use crate::uevent::{Uevent, UeventMatcher};
 #[cfg(not(target_arch = "s390x"))]
 use crate::{device::pcipath_to_sysfs, pci};
 use anyhow::{anyhow, Result};
 use regex::Regex;
 use std::fs;
 use std::sync::Arc;
+#[cfg(target_arch = "riscv64")]
+use std::time::Duration;
 use tokio::sync::Mutex;
+#[cfg(target_arch = "riscv64")]
+use tokio::time::{sleep, Instant};
 
-fn check_existing(re: Regex) -> Result<bool> {
+fn check_existing(re: &Regex) -> Result<bool> {
     // Check if the interface is already added in case network is cold-plugged
     // or the uevent loop is started before network is added.
     // We check for the device in the sysfs directory for network devices.
@@ -49,13 +57,44 @@ pub async fn wait_for_pci_net_interface(
         matcher.devpath.as_str()
     );
     let re = Regex::new(&pattern).expect("BUG: Failed to compile regex for NetPciMatcher");
-    if check_existing(re)? {
+    if check_existing(&re)? {
         return Ok(());
     }
 
-    let _uev = wait_for_uevent(sandbox, matcher).await?;
+    #[cfg(target_arch = "riscv64")]
+    {
+        let _ = sandbox;
+        // Some virtual PCI network devices can be visible in sysfs without a net
+        // uevent reaching the agent watcher. Poll the same sysfs symlink pattern
+        // used for cold-plug detection so UpdateInterface can still proceed.
+        let timeout = AGENT_CONFIG.hotplug_timeout;
+        let deadline = Instant::now() + timeout;
+        let interval = Duration::from_millis(100);
 
-    Ok(())
+        loop {
+            if check_existing(&re)? {
+                return Ok(());
+            }
+
+            if Instant::now() >= deadline {
+                break;
+            }
+
+            sleep(interval).await;
+        }
+
+        Err(anyhow!(
+            "Timeout after {:?} waiting for net interface {:?}",
+            timeout,
+            matcher
+        ))
+    }
+
+    #[cfg(not(target_arch = "riscv64"))]
+    {
+        let _uev = wait_for_uevent(sandbox, matcher).await?;
+        Ok(())
+    }
 }
 
 #[cfg(not(target_arch = "s390x"))]
@@ -91,7 +130,7 @@ pub async fn wait_for_ccw_net_interface(
     device: &ccw::Device,
 ) -> Result<()> {
     let matcher = NetCcwMatcher::new(CCW_ROOT_BUS_PATH, device);
-    if check_existing(matcher.re.clone())? {
+    if check_existing(&matcher.re)? {
         return Ok(());
     }
     let _uev = wait_for_uevent(sandbox, matcher).await?;

--- a/src/agent/src/linux_abi.rs
+++ b/src/agent/src/linux_abi.rs
@@ -9,13 +9,12 @@ use cfg_if::cfg_if;
 use std::str::FromStr;
 // Linux ABI related constants.
 
-#[cfg(target_arch = "aarch64")]
+#[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use std::fs;
 
 pub const SYSFS_DIR: &str = "/sys";
 #[cfg(any(
     all(target_arch = "powerpc64", target_endian = "little"),
-    target_arch = "riscv64",
     target_arch = "s390x",
     target_arch = "x86_64",
     target_arch = "x86"
@@ -24,6 +23,36 @@ pub const SYSFS_DIR: &str = "/sys";
 // defined by the pxb-pcie driver.
 pub fn create_pci_root_bus_path(root_complex: &str) -> String {
     format!("/devices/pci0000:{root_complex}")
+}
+
+#[cfg(target_arch = "riscv64")]
+pub fn create_pci_root_bus_path(root_complex: &str) -> String {
+    let acpi_root_bus_path = format!("/devices/pci0000:{root_complex}");
+    let acpi_sysfs_dir = format!("{SYSFS_DIR}{acpi_root_bus_path}");
+    if fs::metadata(acpi_sysfs_dir).is_ok() {
+        return acpi_root_bus_path;
+    }
+
+    let fallback = format!("/devices/platform/30000000.pci/pci0000:{root_complex}");
+    let platform_sysfs_dir = format!("{SYSFS_DIR}/devices/platform");
+    let entries = match fs::read_dir(platform_sysfs_dir) {
+        Ok(entries) => entries,
+        Err(_) => return fallback,
+    };
+
+    for entry in entries.flatten() {
+        let dir_name = entry.file_name();
+        let root_bus_path = format!(
+            "/devices/platform/{}/pci0000:{root_complex}",
+            dir_name.to_string_lossy()
+        );
+        let sysfs_dir = format!("{SYSFS_DIR}{root_bus_path}");
+        if fs::metadata(sysfs_dir).is_ok() {
+            return root_bus_path;
+        }
+    }
+
+    fallback
 }
 
 // This is used in several modules, let's create a helper function to parse the

--- a/src/runtime/arch/riscv64-options.mk
+++ b/src/runtime/arch/riscv64-options.mk
@@ -11,3 +11,4 @@ MACHINEACCELERATORS :=
 CPUFEATURES :=
 
 QEMUCMD := qemu-system-riscv64
+CLHCMD := cloud-hypervisor

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -76,9 +76,10 @@ const (
 	clhTimeout                     = 10
 	clhAPITimeout                  = 1
 	clhAPITimeoutConfidentialGuest = 20
-	// Minimum timout for calling CreateVM followed by BootVM. Executing these two APIs
+	// Minimum timeout for calling CreateVM followed by BootVM. Executing these two APIs
 	// might take longer than the value returned by getClhAPITimeout().
-	clhCreateAndBootVMMinimumTimeout = 10
+	clhCreateAndBootVMMinimumTimeout        = 10
+	clhRiscv64CreateAndBootVMMinimumTimeout = 60
 	// Timeout for hot-plug - hotplug devices can take more time, than usual API calls
 	// Use longer time timeout for it.
 	clhHotPlugAPITimeout                   = 5
@@ -316,6 +317,20 @@ func (clh *cloudHypervisor) getClhAPITimeout() time.Duration {
 	}
 
 	return clhAPITimeout
+}
+
+func (clh *cloudHypervisor) getClhCreateAndBootVMTimeout() time.Duration {
+	minimumTimeout := time.Duration(clhCreateAndBootVMMinimumTimeout)
+	if runtime.GOARCH == "riscv64" {
+		minimumTimeout = time.Duration(clhRiscv64CreateAndBootVMMinimumTimeout)
+	}
+
+	apiTimeout := clh.getClhAPITimeout()
+	if apiTimeout < minimumTimeout {
+		return minimumTimeout
+	}
+
+	return apiTimeout
 }
 
 func (clh *cloudHypervisor) getClhStopSandboxTimeout() time.Duration {
@@ -764,10 +779,7 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
 		return fmt.Errorf("failed to launch cloud-hypervisor: %q", err)
 	}
 
-	bootTimeout := clh.getClhAPITimeout()
-	if bootTimeout < clhCreateAndBootVMMinimumTimeout {
-		bootTimeout = clhCreateAndBootVMMinimumTimeout
-	}
+	bootTimeout := clh.getClhCreateAndBootVMTimeout()
 	ctx, cancel := context.WithTimeout(ctx, bootTimeout*time.Second)
 	defer cancel()
 


### PR DESCRIPTION
Enable the Cloud Hypervisor runtime path on RISC-V and handle RISC-V PCI network discovery for platform PCI root bus paths.

Non-RISC-V PCI network hotplug keeps the existing uevent path. The only cross-architecture change is a build-only dependency that generates agent files before optimized builds.

Validation: an equivalent patch set was deployed on openRuyi Creek riscv64 and started a Kata + Cloud Hypervisor BusyBox container. It reported riscv64, pinged the bridge gateway and 1.1.1.1, and completed in 31 seconds.

AI assistance is disclosed in the commit trailers.