### PR TITLE
runtime: drop host time namespace from OCI spec

### DIFF
--- a/src/runtime-rs/crates/resource/src/coco_data/initdata_block.rs
+++ b/src/runtime-rs/crates/resource/src/coco_data/initdata_block.rs
@@ -276,7 +276,6 @@ pub fn push_data(initdata_path: &Path, data: &str) -> anyhow::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::env;
     use std::io::Read;
 
     #[test]

--- a/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/container_manager/container.rs
@@ -757,8 +757,8 @@ fn amend_spec(
             linux.set_seccomp(None);
         }
 
-        // Host pidns path does not make sense in kata. Let's just align it with
-        // sandbox namespace whenever it is set.
+        // Host pid/net/time namespace paths do not make sense in kata.
+        // Pid is aligned with the sandbox namespace whenever it is set.
         let ns: Vec<oci::LinuxNamespace> = linux
             .namespaces()
             .clone()
@@ -767,6 +767,7 @@ fn amend_spec(
             .filter(|n| {
                 n.typ() != oci::LinuxNamespaceType::Pid
                     && n.typ() != oci::LinuxNamespaceType::Network
+                    && n.typ() != oci::LinuxNamespaceType::Time
             })
             .map(|n| {
                 let mut ns = oci::LinuxNamespace::default();
@@ -869,6 +870,38 @@ mod tests {
         // disable_guest_seccomp = true
         amend_spec(&mut spec, true, false, false, "shared-fs").unwrap();
         assert!(spec.linux().as_ref().unwrap().seccomp().is_none());
+    }
+
+    #[test]
+    fn test_amend_spec_strips_host_time_namespace() {
+        let mut spec = oci::Spec::default();
+        let linux = LinuxBuilder::default()
+            .namespaces(vec![
+                LinuxNamespaceBuilder::default()
+                    .typ(LinuxNamespaceType::Time)
+                    .path("/proc/1/ns/time")
+                    .build()
+                    .unwrap(),
+                LinuxNamespaceBuilder::default()
+                    .typ(LinuxNamespaceType::Uts)
+                    .build()
+                    .unwrap(),
+            ])
+            .build()
+            .unwrap();
+        spec.set_linux(Some(linux));
+
+        amend_spec(&mut spec, false, false, false, "shared-fs").unwrap();
+
+        let namespaces = spec
+            .linux()
+            .as_ref()
+            .unwrap()
+            .namespaces()
+            .as_ref()
+            .unwrap();
+        assert_eq!(namespaces.len(), 1);
+        assert_eq!(namespaces[0].typ(), LinuxNamespaceType::Uts);
     }
 
     #[test]

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -1072,17 +1072,17 @@ func (k *kataAgent) constrainGRPCSpec(grpcSpec *grpc.Spec, passSeccomp bool, dis
 		grpcSpec.Linux.Resources.CPU.Mems = ""
 	}
 
-	// Disable network namespace since it is already handled on the host by
-	// virtcontainers. The network is a complex part which cannot be simply
-	// passed to the agent.
-	// Every other namespaces's paths have to be emptied. This way, there
-	// is no confusion from the agent, trying to find an existing namespace
-	// on the guest.
+	// Disable network and time namespaces since they are handled on the host
+	// (or are unsupported in the guest agent). Docker 29.5+ adds a host time
+	// namespace by default; host namespace paths must not be passed to the agent.
+	// Every other namespace's path has to be emptied so the agent does not try
+	// to join a host namespace inside the guest.
 	var tmpNamespaces []*grpc.LinuxNamespace
 	for _, ns := range grpcSpec.Linux.Namespaces {
 		switch ns.Type {
 		case string(specs.CgroupNamespace):
 		case string(specs.NetworkNamespace):
+		case string(specs.TimeNamespace):
 		default:
 			ns.Path = ""
 			tmpNamespaces = append(tmpNamespaces, ns)

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -603,6 +603,10 @@ func TestConstrainGRPCSpec(t *testing.T) {
 					Path: "/abc/123",
 				},
 				{
+					Type: string(specs.TimeNamespace),
+					Path: "/proc/123/ns/time",
+				},
+				{
 					Type: string(specs.MountNamespace),
 					Path: "/abc/123",
 				},


### PR DESCRIPTION
Docker 29.5+ adds a private time namespace to container bundles by default, but kata agent only supports the classic namespace set and then fails with "invalid namespace type".

Let's strip time namespaces in both the Go and rust runtimes before the spec reaches the agent, matching how network and cgroup namespaces are handled.

Fixes: #13080

@lukaslangrock, would you be able to give it a try?