### PR TITLE
kata-monitor: use full URI for connecting to containerd

### DIFF
--- a/src/runtime/pkg/kata-monitor/cri.go
+++ b/src/runtime/pkg/kata-monitor/cri.go
@@ -9,7 +9,6 @@ package katamonitor
 import (
 	"context"
 	"fmt"
-	"net"
 	"net/url"
 
 	"github.com/pkg/errors"
@@ -25,26 +24,15 @@ const (
 	unixProtocol = "unix"
 )
 
-// getAddressAndDialer returns the address parsed from the given endpoint and a context dialer.
-func getAddressAndDialer(endpoint string) (string, func(ctx context.Context, addr string) (net.Conn, error), error) {
-	protocol, addr, err := parseEndpointWithFallbackProtocol(endpoint, unixProtocol)
-	if err != nil {
-		return "", nil, err
-	}
-	if protocol != unixProtocol {
-		return "", nil, fmt.Errorf("only support unix socket endpoint")
-	}
-
-	return addr, dial, nil
-}
-
 func getConnection(endPoint string) (*grpc.ClientConn, error) {
 	var conn *grpc.ClientConn
-	addr, dialer, err := getAddressAndDialer(endPoint)
+	protocol, addr, err := parseEndpointWithFallbackProtocol(endPoint, unixProtocol)
 	if err != nil {
 		return nil, err
 	}
-	conn, err = grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithContextDialer(dialer))
+	// Pass the full URI to NewClient so it can pick the right resolver based on the scheme
+	addr = protocol + "://" + addr
+	conn, err = grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	if err != nil {
 		errMsg := errors.Wrapf(err, "connect endpoint '%s', make sure you are running as root and the endpoint has been started", endPoint)
 		return nil, errMsg
@@ -74,10 +62,6 @@ func getRuntimeClient(runtimeEndpoint string) (pb.RuntimeServiceClient, *grpc.Cl
 
 	runtimeClient := pb.NewRuntimeServiceClient(conn)
 	return runtimeClient, conn, nil
-}
-
-func dial(ctx context.Context, addr string) (net.Conn, error) {
-	return (&net.Dialer{}).DialContext(ctx, unixProtocol, addr)
 }
 
 func parseEndpointWithFallbackProtocol(endpoint string, fallbackProtocol string) (protocol string, addr string, err error) {

--- a/src/runtime/pkg/kata-monitor/cri_test.go
+++ b/src/runtime/pkg/kata-monitor/cri_test.go
@@ -11,19 +11,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetAddressAndDialer(t *testing.T) {
-	assert := assert.New(t)
-
-	endpoint := "/no/protocol"
-	addr, _, err := getAddressAndDialer(endpoint)
-	assert.Nil(err, "endpoints with no protocol are deprecated but should be accepted")
-	assert.Equal(endpoint, addr, "failed address parsing")
-
-	endpoint = "tcp://hostname:1234"
-	_, _, err = getAddressAndDialer(endpoint)
-	assert.NotNil(err, "only unix endpoints should be accepted")
-}
-
 func TestParseEndpointWithFallbackProtocol(t *testing.T) {
 	assert := assert.New(t)
 

--- a/tools/packaging/kata-monitor/Dockerfile
+++ b/tools/packaging/kata-monitor/Dockerfile
@@ -1,12 +1,26 @@
 # Copyright (c) 2020 Eric Ernst
 # SPDX-License-Identifier: Apache-2.0
-
-FROM golang:1.23-alpine AS builder
+ARG GO_VERSION
+FROM golang:${GO_VERSION}-alpine AS builder
 
 RUN apk add --no-cache bash curl git make build-base
 WORKDIR /go/src/github.com/kata-containers/kata-containers/src/runtime
+
+COPY src/runtime/go.* .
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    go mod download
+
 COPY . /go/src/github.com/kata-containers/kata-containers
-RUN make SKIP_GO_VERSION_CHECK=true monitor
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+	make SKIP_GO_VERSION_CHECK=true monitor
+
+# run tests
+RUN --mount=type=cache,target=/go/pkg/mod \
+    --mount=type=cache,target=/root/.cache/go-build \
+    cd pkg/kata-monitor/ && go test -c -o /tmp/tests
+RUN /tmp/tests
 
 FROM alpine:3.14
 COPY --from=builder /go/src/github.com/kata-containers/kata-containers/src/runtime/kata-monitor /usr/bin/kata-monitor

--- a/tools/packaging/kata-monitor/Makefile
+++ b/tools/packaging/kata-monitor/Makefile
@@ -1,0 +1,12 @@
+# Copyright (c) 2026 Florian Vichot
+# SPDX-License-Identifier: Apache-2.0
+
+all: docker
+
+docker:
+	docker build \
+	       -f Dockerfile \
+	       --ignorefile dockerignore \
+	       --build-arg GO_VERSION=$$(yq '.languages.golang.version' $(CURDIR)/../../../versions.yaml) \
+	       -t kata-monitor:$$(cat $(CURDIR)/../../../VERSION) \
+	       $(CURDIR)/../../..

--- a/tools/packaging/kata-monitor/dockerignore
+++ b/tools/packaging/kata-monitor/dockerignore
@@ -1,0 +1,7 @@
+# Copyright (c) 2026 Florian Vichot
+# SPDX-License-Identifier: Apache-2.0
+
+# Remove everything except the few things we actually need
+*
+!src/runtime/
+!VERSION


### PR DESCRIPTION
Without the protocol in the URI, grpc-go defaults to the DNS resolver, which results in an error for unix sockets (`name resolver error: produced zero addresses`).

We also remove the `getAddressAndDialer(...)` and `dial(...)` functions, as they are no longer necessary, grpc-go supports connecting to unix sockets directly. This also removes the matching tests.

This also adds a `Makefile` and tweaks the Dockerfile to simplify building the kata-monitor Docker image.

This fixes #12398 