### PR TITLE
kata-deploy: verify kata-runtime label remains stable on rke2/k3s

### DIFF
--- a/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
+++ b/tests/functional/kata-deploy/kata-deploy-lifecycle.bats
@@ -107,9 +107,21 @@ setup_file() {
 	echo "# Kata RuntimeClasses: ${rc_count}" >&3
 	[[ ${rc_count} -gt 0 ]]
 
-	# Node must have the kata-runtime label
-	local label
-	label=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.katacontainers\.io/kata-runtime}')
+	# Node must have the kata-runtime label.
+	# On rke2/k3s the kubelet can re-publish the node a few seconds after
+	# install completes; even with the in-installer stability check, give
+	# the label a brief polling window here so a one-off blip doesn't fail
+	# the assertion before it self-heals.
+	local label=""
+	local retries=0
+	while [[ ${retries} -lt 90 ]]; do
+		label=$(kubectl get nodes -o jsonpath='{.items[0].metadata.labels.katacontainers\.io/kata-runtime}' 2>/dev/null || echo "")
+		if [[ "${label}" == "true" ]]; then
+			break
+		fi
+		retries=$((retries + 1))
+		sleep 2
+	done
 	echo "# Node label katacontainers.io/kata-runtime: ${label}" >&3
 	[[ "${label}" == "true" ]]
 }

--- a/tools/packaging/kata-deploy/binary/src/main.rs
+++ b/tools/packaging/kata-deploy/binary/src/main.rs
@@ -348,62 +348,102 @@ async fn install(config: &config::Config, runtime: &str) -> Result<()> {
 
 /// Label the node and verify the label sticks, retrying if necessary.
 ///
-/// On rke2/k3s a CRI restart also restarts the kubelet. The kubelet may
-/// briefly re-register the node with its cached label set, clobbering the
-/// label we just applied via the API. We work around this by verifying the
-/// label value after setting it and re-applying if needed.
+/// On rke2/k3s a CRI restart also restarts the kubelet, and `wait_till_node_is_ready`
+/// can return on a *stale* Ready=True observation from before the kubelet has
+/// actually finished restarting (the kubelet only re-publishes node status every
+/// ~10 s by default). That means a naive "apply + verify once" round-trips entirely
+/// inside the window where the kubelet hasn't re-registered yet: we'd happily
+/// confirm the label is set, declare install done, and only then would the kubelet
+/// come back up and clobber the label with its cached set.
+///
+/// To outlive that race we require the label to remain at `label_value` for
+/// `STABILITY_CHECKS` consecutive observations spaced `CHECK_INTERVAL` apart
+/// (≈ 15 s by default — comfortably more than the kubelet's status-update period).
+/// If it ever drifts inside that window we re-apply and restart the stability
+/// counter. The whole thing is bounded by `MAX_APPLY_ATTEMPTS`.
 async fn label_node_with_retry(
     config: &config::Config,
     label_key: &str,
     label_value: &str,
 ) -> Result<()> {
-    const MAX_ATTEMPTS: u32 = 10;
+    const MAX_APPLY_ATTEMPTS: u32 = 12;
+    const STABILITY_CHECKS: u32 = 6;
+    const CHECK_INTERVAL: std::time::Duration = std::time::Duration::from_secs(2);
     const RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 
-    for attempt in 1..=MAX_ATTEMPTS {
+    for attempt in 1..=MAX_APPLY_ATTEMPTS {
         k8s::label_node(config, label_key, Some(label_value), true).await?;
+        info!(
+            "Applied label {}={} (attempt {}/{}); verifying stability ({} checks @ {}s)",
+            label_key,
+            label_value,
+            attempt,
+            MAX_APPLY_ATTEMPTS,
+            STABILITY_CHECKS,
+            CHECK_INTERVAL.as_secs(),
+        );
 
-        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+        let mut stable_count: u32 = 0;
+        let mut needs_reapply = false;
+        while stable_count < STABILITY_CHECKS {
+            tokio::time::sleep(CHECK_INTERVAL).await;
 
-        match k8s::get_node_label(config, label_key).await {
-            Ok(Some(val)) if val == label_value => {
-                info!(
-                    "Label {}={} confirmed on node (attempt {})",
-                    label_key, label_value, attempt
-                );
-                return Ok(());
-            }
-            Ok(actual) => {
-                log::warn!(
-                    "Label {}={} did not stick (got {:?}), retrying ({}/{})",
-                    label_key,
-                    label_value,
-                    actual,
-                    attempt,
-                    MAX_ATTEMPTS
-                );
-            }
-            Err(e) => {
-                log::warn!(
-                    "Failed to verify label {} (attempt {}/{}): {}",
-                    label_key,
-                    attempt,
-                    MAX_ATTEMPTS,
-                    e
-                );
+            match k8s::get_node_label(config, label_key).await {
+                Ok(Some(val)) if val == label_value => {
+                    stable_count += 1;
+                    info!(
+                        "Label {}={} stable {}/{}",
+                        label_key, label_value, stable_count, STABILITY_CHECKS
+                    );
+                }
+                Ok(actual) => {
+                    log::warn!(
+                        "Label {}={} drifted to {:?} after {}/{} stable observation(s); \
+                         re-applying (attempt {}/{})",
+                        label_key,
+                        label_value,
+                        actual,
+                        stable_count,
+                        STABILITY_CHECKS,
+                        attempt,
+                        MAX_APPLY_ATTEMPTS,
+                    );
+                    needs_reapply = true;
+                    break;
+                }
+                Err(e) => {
+                    log::warn!(
+                        "Failed to verify label {} during stability check \
+                         (attempt {}/{}): {}; will re-apply",
+                        label_key,
+                        attempt,
+                        MAX_APPLY_ATTEMPTS,
+                        e,
+                    );
+                    needs_reapply = true;
+                    break;
+                }
             }
         }
 
-        if attempt < MAX_ATTEMPTS {
+        if !needs_reapply {
+            info!(
+                "Label {}={} confirmed stable on node after {} apply attempt(s)",
+                label_key, label_value, attempt
+            );
+            return Ok(());
+        }
+
+        if attempt < MAX_APPLY_ATTEMPTS {
             tokio::time::sleep(RETRY_DELAY).await;
         }
     }
 
     anyhow::bail!(
-        "Failed to set label {}={} after {} attempts",
+        "Label {}={} did not remain stable after {} apply attempts",
         label_key,
         label_value,
-        MAX_ATTEMPTS
+        MAX_APPLY_ATTEMPTS
     );
 }
 


### PR DESCRIPTION
The retry loop added in efd468df3f still allows the install to declare success while inside the kubelet's post-restart re-register window.

On rke2/k3s, `systemctl restart rke2-agent` restarts both containerd and the kubelet, but `wait_till_node_is_ready` polls `.status.conditions[Ready]` every 2 s and returns on the first `True` observation it sees. By default the kubelet only publishes node status every ~10 s, so that first `True` is almost always the stale value from before the restart — the kubelet hasn't actually finished restarting yet. `label_node_with_retry` then applies the label, sleeps 1 s, reads back "true" (still stale, kubelet still down), and returns Ok. Install completes, `/readyz` flips to 200, helm releases its `--wait`, and the bats test starts — and only then does the kubelet finish coming up, re-register the node, and clobber the label with its cached set. The lifecycle test sees an empty `katacontainers.io/kata-runtime` and fails:

```
  # Node label katacontainers.io/kata-runtime:
  not ok 1 Kata artifacts are present on host after install
```

A single-shot verification can't distinguish "still stale true" from "truly stable true after kubelet re-register". Replace it with a stability window: after (re)applying the label, require it to remain at the expected value for STABILITY_CHECKS=6 consecutive observations spaced CHECK_INTERVAL=2 s apart (≈ 12 s — comfortably more than the kubelet's status-update period). If the value ever drifts inside the window, re-apply and restart the stability counter. Bounded by MAX_APPLY_ATTEMPTS=12, so worst case is ~3 min; happy path adds ~12 s to install.

Also add a short polling loop to the test's own label assertion as belt-and-suspenders for any leftover transient race, matching the existing retry pattern used for the container-runtime version check.