### PR TITLE
dragonball: Add VIRTIO_F_ACCESS_PLATFORM for TDX virtio devices

### DIFF
--- a/src/dragonball/crates/dbs_virtio_devices/src/balloon.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/balloon.rs
@@ -34,7 +34,7 @@ use dbs_utils::epoll_manager::{
 use dbs_utils::metric::{IncMetric, SharedIncMetric, SharedStoreMetric, StoreMetric};
 use log::{debug, error, info, trace};
 use serde::Serialize;
-use virtio_bindings::bindings::virtio_config::VIRTIO_F_VERSION_1;
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1};
 use virtio_queue::{QueueOwnedT, QueueSync, QueueT};
 use vm_memory::{
     ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryRegion,
@@ -515,8 +515,16 @@ pub struct BalloonConfig {
 
 impl<AS: GuestAddressSpace> Balloon<AS> {
     // Create a new virtio-balloon.
-    pub fn new(epoll_mgr: EpollManager, cfg: BalloonConfig) -> Result<Self> {
+    pub fn new(
+        epoll_mgr: EpollManager,
+        cfg: BalloonConfig,
+        f_access_platform: bool,
+    ) -> Result<Self> {
         let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
+
+        if f_access_platform {
+            avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
+        }
 
         let mut queue_sizes = QUEUE_SIZES.to_vec();
 
@@ -757,7 +765,7 @@ pub(crate) mod tests {
             f_reporting: true,
         };
 
-        let mut dev = Balloon::<Arc<GuestMemoryMmap>>::new(epoll_mgr, config).unwrap();
+        let mut dev = Balloon::<Arc<GuestMemoryMmap>>::new(epoll_mgr, config, false).unwrap();
 
         assert_eq!(
             VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::device_type(&dev),
@@ -815,7 +823,8 @@ pub(crate) mod tests {
                 f_reporting: true,
             };
 
-            let mut dev = Balloon::<Arc<GuestMemoryMmap>>::new(epoll_mgr.clone(), config).unwrap();
+            let mut dev =
+                Balloon::<Arc<GuestMemoryMmap>>::new(epoll_mgr.clone(), config, false).unwrap();
             let queues = vec![
                 VirtioQueueConfig::<QueueSync>::create(16, 0).unwrap(),
                 VirtioQueueConfig::<QueueSync>::create(16, 0).unwrap(),
@@ -844,7 +853,7 @@ pub(crate) mod tests {
                 f_reporting: true,
             };
 
-            let mut dev = Balloon::<Arc<GuestMemoryMmap>>::new(epoll_mgr, config).unwrap();
+            let mut dev = Balloon::<Arc<GuestMemoryMmap>>::new(epoll_mgr, config, false).unwrap();
 
             let queues = vec![
                 VirtioQueueConfig::<QueueSync>::create(128, 0).unwrap(),
@@ -879,7 +888,7 @@ pub(crate) mod tests {
             f_reporting: true,
         };
 
-        let dev = Balloon::<Arc<GuestMemoryMmap>>::new(epoll_mgr, config).unwrap();
+        let dev = Balloon::<Arc<GuestMemoryMmap>>::new(epoll_mgr, config, false).unwrap();
         let size = 1024;
         assert!(dev.set_size(size).is_ok());
     }

--- a/src/dragonball/crates/dbs_virtio_devices/src/block/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/block/device.rs
@@ -20,7 +20,7 @@ use dbs_utils::{
 };
 use log::{debug, error, info, warn};
 use virtio_bindings::bindings::virtio_blk::*;
-use virtio_bindings::bindings::virtio_config::VIRTIO_F_VERSION_1;
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1};
 use virtio_queue::QueueT;
 use vm_memory::GuestMemoryRegion;
 use vmm_sys_util::eventfd::{EventFd, EFD_NONBLOCK};
@@ -84,6 +84,7 @@ impl<AS: DbsGuestAddressSpace> Block<AS> {
         queue_sizes: Arc<Vec<u16>>,
         epoll_mgr: EpollManager,
         rate_limiters: Vec<RateLimiter>,
+        f_access_platform: bool,
     ) -> Result<Self> {
         let num_queues = disk_images.len();
 
@@ -103,6 +104,10 @@ impl<AS: DbsGuestAddressSpace> Block<AS> {
         let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
         avail_features |= 1u64 << VIRTIO_BLK_F_SIZE_MAX;
         avail_features |= 1u64 << VIRTIO_BLK_F_SEG_MAX;
+
+        if f_access_platform {
+            avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
+        }
 
         if is_disk_read_only {
             avail_features |= 1u64 << VIRTIO_BLK_F_RO;
@@ -986,6 +991,7 @@ mod tests {
             Arc::new(vec![128]),
             epoll_mgr,
             vec![],
+            false,
         )
         .unwrap();
 
@@ -1044,6 +1050,7 @@ mod tests {
                 Arc::new(vec![128]),
                 epoll_mgr.clone(),
                 vec![],
+                false,
             )
             .unwrap();
 
@@ -1082,6 +1089,7 @@ mod tests {
                 Arc::new(vec![128]),
                 epoll_mgr.clone(),
                 vec![],
+                false,
             )
             .unwrap();
             dev.disk_images = vec![];
@@ -1121,6 +1129,7 @@ mod tests {
                 Arc::new(vec![128]),
                 epoll_mgr,
                 vec![],
+                false,
             )
             .unwrap();
 
@@ -1159,6 +1168,7 @@ mod tests {
             Arc::new(vec![128]),
             epoll_mgr,
             vec![],
+            false,
         )
         .unwrap();
 

--- a/src/dragonball/crates/dbs_virtio_devices/src/fs/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/fs/device.rs
@@ -29,7 +29,7 @@ use nydus_api::ConfigV2;
 use nydus_rafs::blobfs::{BlobFs, Config as BlobfsConfig};
 use nydus_rafs::{fs::Rafs, RafsIoRead};
 use rlimit::Resource;
-use virtio_bindings::bindings::virtio_config::VIRTIO_F_VERSION_1;
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1};
 use virtio_queue::QueueT;
 use vm_memory::{
     FileOffset, GuestAddress, GuestAddressSpace, GuestRegionMmap, GuestUsize, MmapRegion,
@@ -139,6 +139,7 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
         handler: Box<dyn VirtioRegionHandler>,
         epoll_mgr: EpollManager,
         rate_limiter: Option<RateLimiter>,
+        f_access_platform: bool,
     ) -> Result<Self> {
         info!(
             "{VIRTIO_FS_NAME}: tag {tag} req_num_queues {req_num_queues} queue_size {queue_size} cache_size {cache_size} cache_policy {cache_policy} thread_pool_size {thread_pool_size} writeback_cache {writeback_cache} no_open {no_open} killpriv_v2 {killpriv_v2} xattr {xattr} drop_sys_resource {drop_sys_resource} no_readdir {no_readdir}"
@@ -195,10 +196,16 @@ impl<AS: GuestAddressSpace> VirtioFs<AS> {
             ..VfsOptions::default()
         };
 
+        let mut avail_features = 1u64 << VIRTIO_F_VERSION_1;
+
+        if f_access_platform {
+            avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
+        }
+
         Ok(VirtioFs {
             device_info: VirtioDeviceInfo::new(
                 VIRTIO_FS_NAME.to_string(),
-                1u64 << VIRTIO_F_VERSION_1,
+                avail_features,
                 Arc::new(vec![queue_size; num_queues]),
                 config_space,
                 epoll_mgr,
@@ -995,6 +1002,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            false,
         )
         .unwrap();
 
@@ -1062,6 +1070,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager.clone(),
             Some(rate_limiter),
+            false,
         );
         assert!(res.is_err());
 
@@ -1083,6 +1092,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            false,
         );
         assert!(res.is_err());
     }
@@ -1107,6 +1117,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            false,
         )
         .unwrap();
 
@@ -1177,6 +1188,7 @@ pub mod tests {
                 new_dummy_handler_helper(),
                 epoll_manager.clone(),
                 Some(rate_limiter),
+                false,
             )
             .unwrap();
 
@@ -1221,6 +1233,7 @@ pub mod tests {
                 new_dummy_handler_helper(),
                 epoll_manager,
                 Some(rate_limiter),
+                false,
             )
             .unwrap();
 
@@ -1632,6 +1645,7 @@ pub mod tests {
                 new_dummy_handler_helper(),
                 epoll_manager,
                 Some(rate_limiter),
+                false,
             )
             .unwrap();
             fs
@@ -1665,6 +1679,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            false,
         )
         .unwrap();
         let kvm = Kvm::new().unwrap();
@@ -1709,6 +1724,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            false,
         )
         .unwrap();
         let mut requirements = vec![
@@ -1753,6 +1769,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            false,
         )
         .unwrap();
         let kvm = Kvm::new().unwrap();

--- a/src/dragonball/crates/dbs_virtio_devices/src/fs/handler.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/fs/handler.rs
@@ -672,6 +672,7 @@ pub mod tests {
             new_dummy_handler_helper(),
             epoll_manager,
             Some(rate_limiter),
+            false,
         )
         .unwrap();
 

--- a/src/dragonball/crates/dbs_virtio_devices/src/mem.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/mem.rs
@@ -30,7 +30,7 @@ use dbs_utils::epoll_manager::{
 };
 use kvm_ioctls::VmFd;
 use log::{debug, error, info, trace, warn};
-use virtio_bindings::bindings::virtio_config::VIRTIO_F_VERSION_1;
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1};
 use virtio_queue::{DescriptorChain, QueueOwnedT, QueueSync, QueueT};
 use vm_memory::{
     ByteValued, Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryError,
@@ -906,6 +906,7 @@ impl<AS: GuestAddressSpace> Mem<AS> {
         epoll_mgr: EpollManager,
         factory: Arc<Mutex<dyn MemRegionFactory>>,
         boot_mem_byte: u64,
+        f_access_platform: bool,
     ) -> Result<Self> {
         trace!(
             target: MEM_DRIVER_NAME,
@@ -913,6 +914,10 @@ impl<AS: GuestAddressSpace> Mem<AS> {
         );
 
         let mut avail_features = 1u64 << VIRTIO_F_VERSION_1 as u64;
+
+        if f_access_platform {
+            avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
+        }
 
         // calculate alignment depending on boot memory size
         // algorithm is from kernel (arch/x86/mm/init_64.c: probe_memory_block_size())
@@ -1704,9 +1709,10 @@ pub(crate) mod tests {
         let epoll_mgr = EpollManager::default();
         let id = "mem0".to_string();
         let factory = Arc::new(Mutex::new(DummyMemRegionFactory {}));
-        let mut dev =
-            Mem::<Arc<GuestMemoryMmap>>::new(id, 200, 200, false, None, epoll_mgr, factory, 200)
-                .unwrap();
+        let mut dev = Mem::<Arc<GuestMemoryMmap>>::new(
+            id, 200, 200, false, None, epoll_mgr, factory, 200, false,
+        )
+        .unwrap();
 
         assert_eq!(
             VirtioDevice::<Arc<GuestMemoryMmap<()>>, QueueSync, GuestRegionMmap>::device_type(&dev),
@@ -1763,7 +1769,7 @@ pub(crate) mod tests {
         let id = "mem0".to_string();
         let factory = Arc::new(Mutex::new(DummyMemRegionFactory {}));
         let dev = Mem::<Arc<GuestMemoryMmap>>::new(
-            id, 0x100, 0x100, false, None, epoll_mgr, factory, 0xc0000000,
+            id, 0x100, 0x100, false, None, epoll_mgr, factory, 0xc0000000, false,
         )
         .unwrap();
         let mut requirements = vec![
@@ -1810,6 +1816,7 @@ pub(crate) mod tests {
                 epoll_mgr.clone(),
                 factory.clone(),
                 0xc0000000,
+                false,
             )
             .unwrap();
 
@@ -1836,7 +1843,7 @@ pub(crate) mod tests {
         // disable multi-region in virtio-mem
         {
             let mut dev = Mem::<Arc<GuestMemoryMmap>>::new(
-                id, 0xc00, 0xc00, false, None, epoll_mgr, factory, 0xc0000000,
+                id, 0xc00, 0xc00, false, None, epoll_mgr, factory, 0xc0000000, false,
             )
             .unwrap();
 
@@ -1864,9 +1871,10 @@ pub(crate) mod tests {
         let epoll_mgr = EpollManager::default();
         let id = "mem0".to_string();
         let factory = Arc::new(Mutex::new(DummyMemRegionFactory {}));
-        let dev =
-            Mem::<Arc<GuestMemoryMmap>>::new(id, 200, 200, false, None, epoll_mgr, factory, 200)
-                .unwrap();
+        let dev = Mem::<Arc<GuestMemoryMmap>>::new(
+            id, 200, 200, false, None, epoll_mgr, factory, 200, false,
+        )
+        .unwrap();
         assert!(dev.set_requested_size(200).is_ok());
     }
 
@@ -1887,6 +1895,7 @@ pub(crate) mod tests {
                 epoll_mgr.clone(),
                 factory.clone(),
                 200,
+                false,
             )
             .unwrap();
 
@@ -1923,6 +1932,7 @@ pub(crate) mod tests {
                 epoll_mgr.clone(),
                 factory.clone(),
                 200,
+                false,
             )
             .unwrap();
 
@@ -1948,7 +1958,7 @@ pub(crate) mod tests {
         // test activate mem device is correct
         {
             let mut dev = Mem::<Arc<GuestMemoryMmap>>::new(
-                id, 200, 200, false, None, epoll_mgr, factory, 200,
+                id, 200, 200, false, None, epoll_mgr, factory, 200, false,
             )
             .unwrap();
 
@@ -1979,9 +1989,10 @@ pub(crate) mod tests {
         let epoll_mgr = EpollManager::default();
         let id = "mem0".to_string();
         let factory = Arc::new(Mutex::new(DummyMemRegionFactory {}));
-        let mut dev =
-            Mem::<Arc<GuestMemoryMmap>>::new(id, 200, 200, false, None, epoll_mgr, factory, 200)
-                .unwrap();
+        let mut dev = Mem::<Arc<GuestMemoryMmap>>::new(
+            id, 200, 200, false, None, epoll_mgr, factory, 200, false,
+        )
+        .unwrap();
 
         let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
         let queues = vec![VirtioQueueConfig::<QueueSync>::create(128, 0).unwrap()];

--- a/src/dragonball/crates/dbs_virtio_devices/src/net.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/net.rs
@@ -22,7 +22,7 @@ use dbs_utils::net::{net_gen, MacAddr, Tap};
 use dbs_utils::rate_limiter::{BucketUpdate, RateLimiter, TokenType};
 use libc;
 use log::{debug, error, info, trace, warn};
-use virtio_bindings::bindings::virtio_config::VIRTIO_F_VERSION_1;
+use virtio_bindings::bindings::virtio_config::{VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_VERSION_1};
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_queue::{QueueOwnedT, QueueSync, QueueT};
 use vm_memory::{Bytes, GuestAddress, GuestAddressSpace, GuestMemoryRegion, GuestRegionMmap};
@@ -612,6 +612,7 @@ impl<AS: GuestAddressSpace> Net<AS> {
         event_mgr: EpollManager,
         rx_rate_limiter: Option<RateLimiter>,
         tx_rate_limiter: Option<RateLimiter>,
+        f_access_platform: bool,
     ) -> Result<Self> {
         trace!(target: "virtio-net", "{NET_DRIVER_NAME}: Net::new_with_tap()");
 
@@ -633,6 +634,10 @@ impl<AS: GuestAddressSpace> Net<AS> {
             | (1u64 << VIRTIO_NET_F_HOST_TSO4)
             | (1u64 << VIRTIO_NET_F_HOST_UFO)
             | (1u64 << VIRTIO_F_VERSION_1);
+
+        if f_access_platform {
+            avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
+        }
 
         let config_space = setup_config_space(
             NET_DRIVER_NAME,
@@ -673,6 +678,7 @@ impl<AS: GuestAddressSpace> Net<AS> {
         epoll_mgr: EpollManager,
         rx_rate_limiter: Option<RateLimiter>,
         tx_rate_limiter: Option<RateLimiter>,
+        f_access_platform: bool,
     ) -> Result<Self> {
         info!("open net tap {host_dev_name}");
         let tap = Tap::open_named(host_dev_name.as_str(), false)
@@ -686,6 +692,7 @@ impl<AS: GuestAddressSpace> Net<AS> {
             epoll_mgr,
             rx_rate_limiter,
             tx_rate_limiter,
+            f_access_platform,
         )
     }
 
@@ -911,6 +918,7 @@ mod tests {
             epoll_mgr,
             None,
             None,
+            false,
         )
         .unwrap();
 
@@ -976,6 +984,7 @@ mod tests {
                 epoll_mgr.clone(),
                 None,
                 None,
+                false,
             )
             .unwrap();
 
@@ -1010,6 +1019,7 @@ mod tests {
                 epoll_mgr.clone(),
                 None,
                 None,
+                false,
             )
             .unwrap();
 
@@ -1047,6 +1057,7 @@ mod tests {
                 epoll_mgr.clone(),
                 None,
                 None,
+                false,
             )
             .unwrap();
             dev.tap = None;
@@ -1083,6 +1094,7 @@ mod tests {
                 epoll_mgr,
                 None,
                 None,
+                false,
             )
             .unwrap();
 
@@ -1125,6 +1137,7 @@ mod tests {
             epoll_mgr,
             None,
             None,
+            false,
         )
         .unwrap();
 

--- a/src/dragonball/crates/dbs_virtio_devices/src/vhost/vhost_kern/net.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vhost/vhost_kern/net.rs
@@ -26,7 +26,9 @@ use vhost_rs::vhost_user::message::VhostUserVringAddrFlags;
 #[cfg(not(test))]
 use vhost_rs::VhostBackend;
 use vhost_rs::{VhostUserMemoryRegionInfo, VringConfigData};
-use virtio_bindings::bindings::virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
+use virtio_bindings::bindings::virtio_config::{
+    VIRTIO_F_ACCESS_PLATFORM, VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1,
+};
 use virtio_bindings::bindings::virtio_net::*;
 use virtio_bindings::bindings::virtio_ring::*;
 use virtio_queue::{DescriptorChain, QueueT};
@@ -137,6 +139,7 @@ where
         guest_mac: Option<&MacAddr>,
         queue_sizes: Arc<Vec<u16>>,
         event_mgr: EpollManager,
+        f_access_platform: bool,
     ) -> VirtioResult<Self> {
         trace!(target: "vhost-net", "{NET_DRIVER_NAME}: Net::new_with_tap()");
 
@@ -160,6 +163,10 @@ where
             | (1u64 << VIRTIO_RING_F_EVENT_IDX)
             | (1u64 << VIRTIO_F_NOTIFY_ON_EMPTY)
             | (1u64 << VIRTIO_F_VERSION_1);
+
+        if f_access_platform {
+            avail_features |= 1u64 << VIRTIO_F_ACCESS_PLATFORM;
+        }
 
         if vq_pairs > 1 {
             avail_features |= ((1 << VIRTIO_NET_F_MQ) | (1 << VIRTIO_NET_F_CTRL_VQ)) as u64;
@@ -209,6 +216,7 @@ where
         guest_mac: Option<&MacAddr>,
         queue_sizes: Arc<Vec<u16>>,
         event_mgr: EpollManager,
+        f_access_platform: bool,
     ) -> VirtioResult<Self> {
         let vq_pairs = queue_sizes.len() / 2;
 
@@ -218,7 +226,7 @@ where
         tap.enable()
             .map_err(|err| VirtioError::VhostNet(Error::TapError(TapError::Enable(err))))?;
 
-        Self::new_with_tap(tap, guest_mac, queue_sizes, event_mgr)
+        Self::new_with_tap(tap, guest_mac, queue_sizes, event_mgr, f_access_platform)
     }
 
     fn do_device_activate(
@@ -735,7 +743,13 @@ mod tests {
         let epoll_mgr = EpollManager::default();
         let tap_name = unique_tap_name("vtap");
         let dev_result: VirtioResult<Net<Arc<GuestMemoryMmap>, QueueSync, GuestRegionMmap>> =
-            Net::new(tap_name.clone(), Some(&guest_mac), queue_sizes, epoll_mgr);
+            Net::new(
+                tap_name.clone(),
+                Some(&guest_mac),
+                queue_sizes,
+                epoll_mgr,
+                false,
+            );
         let mut dev: Net<Arc<GuestMemoryMmap>, QueueSync, GuestRegionMmap> = match dev_result {
             Ok(d) => d,
             Err(e) => {
@@ -780,7 +794,13 @@ mod tests {
             let epoll_mgr = EpollManager::default();
             let tap_name = unique_tap_name("vtap");
             let dev_result: VirtioResult<Net<Arc<GuestMemoryMmap>, QueueSync, GuestRegionMmap>> =
-                Net::new(tap_name.clone(), Some(&guest_mac), queue_sizes, epoll_mgr);
+                Net::new(
+                    tap_name.clone(),
+                    Some(&guest_mac),
+                    queue_sizes,
+                    epoll_mgr,
+                    false,
+                );
             let mut dev: Net<Arc<GuestMemoryMmap>, QueueSync, GuestRegionMmap> = match dev_result {
                 Ok(d) => d,
                 Err(e) => {
@@ -827,7 +847,13 @@ mod tests {
 
             let tap_name = unique_tap_name("vtap");
             let dev_result: VirtioResult<Net<Arc<GuestMemoryMmap>, Queue, GuestRegionMmap>> =
-                Net::new(tap_name.clone(), Some(&guest_mac), queue_sizes, epoll_mgr);
+                Net::new(
+                    tap_name.clone(),
+                    Some(&guest_mac),
+                    queue_sizes,
+                    epoll_mgr,
+                    false,
+                );
             let mut dev: Net<Arc<GuestMemoryMmap>, Queue, GuestRegionMmap> = match dev_result {
                 Ok(d) => d,
                 Err(e) => {

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/device.rs
@@ -61,9 +61,14 @@ pub struct Vsock<AS: GuestAddressSpace, M: VsockGenericMuxer = VsockMuxer> {
 impl<AS: GuestAddressSpace> Vsock<AS> {
     /// Create a new virtio-vsock device with the given VM CID and vsock
     /// backend.
-    pub fn new(cid: u64, queue_sizes: Arc<Vec<u16>>, epoll_mgr: EpollManager) -> Result<Self> {
+    pub fn new(
+        cid: u64,
+        queue_sizes: Arc<Vec<u16>>,
+        epoll_mgr: EpollManager,
+        f_access_platform: bool,
+    ) -> Result<Self> {
         let muxer = VsockMuxer::new(cid).map_err(VsockError::Muxer)?;
-        Self::new_with_muxer(cid, queue_sizes, epoll_mgr, muxer)
+        Self::new_with_muxer(cid, queue_sizes, epoll_mgr, muxer, f_access_platform)
     }
 }
 
@@ -73,10 +78,17 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
         queue_sizes: Arc<Vec<u16>>,
         epoll_mgr: EpollManager,
         muxer: M,
+        f_access_platform: bool,
     ) -> Result<Self> {
         let mut config_space = Vec::with_capacity(VSOCK_CONFIG_SPACE_SIZE);
         for i in 0..VSOCK_CONFIG_SPACE_SIZE {
             config_space.push((cid >> (8 * i as u64)) as u8);
+        }
+
+        let mut avail_features = VSOCK_AVAIL_FEATURES;
+
+        if f_access_platform {
+            avail_features |= 1u64 << uapi::VIRTIO_F_ACCESS_PLATFORM;
         }
 
         Ok(Vsock {
@@ -84,7 +96,7 @@ impl<AS: GuestAddressSpace, M: VsockGenericMuxer> Vsock<AS, M> {
             queue_sizes: queue_sizes.clone(),
             device_info: VirtioDeviceInfo::new(
                 VSOCK_DRIVER_NAME.to_string(),
-                VSOCK_AVAIL_FEATURES,
+                avail_features,
                 queue_sizes,
                 config_space,
                 epoll_mgr,

--- a/src/dragonball/crates/dbs_virtio_devices/src/vsock/mod.rs
+++ b/src/dragonball/crates/dbs_virtio_devices/src/vsock/mod.rs
@@ -51,6 +51,8 @@ mod defs {
         /// The device processes available buffers in the same order in which
         /// the device offers them.
         pub const VIRTIO_F_IN_ORDER: usize = 35;
+        /// The device uses platform DMA tools to access the memory.
+        pub const VIRTIO_F_ACCESS_PLATFORM: usize = 33;
         /// The device conforms to the virtio spec version 1.0.
         pub const VIRTIO_F_VERSION_1: u32 = 32;
 
@@ -334,6 +336,7 @@ mod tests {
                     Arc::new(defs::QUEUE_SIZES.to_vec()),
                     epoll_manager,
                     TestMuxer::new(),
+                    false,
                 )
                 .unwrap(),
             }
@@ -402,6 +405,7 @@ mod tests {
                     Arc::new(defs::QUEUE_SIZES.to_vec()),
                     EpollManager::default(),
                     TestMuxer::new(),
+                    false,
                 )
                 .unwrap(),
                 mem: Arc::new(self.mem.clone()),

--- a/src/dragonball/src/device_manager/balloon_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/balloon_dev_mgr.rs
@@ -8,6 +8,8 @@ use virtio::balloon::{Balloon, BalloonConfig};
 use virtio::Error as VirtioError;
 
 use crate::address_space_manager::GuestAddressSpaceImpl;
+#[cfg(target_arch = "x86_64")]
+use crate::api::v1::ConfidentialVmType;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
 use crate::device_manager::DbsMmioV2Device;
 use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
@@ -165,6 +167,11 @@ impl BalloonDeviceMgr {
                 return Ok(());
             }
 
+            #[cfg(not(target_arch = "x86_64"))]
+            let f_access_platform = false;
+            #[cfg(target_arch = "x86_64")]
+            let f_access_platform = ctx.get_confidential_vm_type() == Some(ConfidentialVmType::TDX);
+
             info!(ctx.logger(), "hotplug balloon device: {}", balloon_cfg.balloon_id; "subsystem" => "balloon_dev_mgr");
             let device = Box::new(
                 virtio::balloon::Balloon::new(
@@ -173,6 +180,7 @@ impl BalloonDeviceMgr {
                         f_deflate_on_oom: balloon_cfg.f_deflate_on_oom,
                         f_reporting: balloon_cfg.f_reporting,
                     },
+                    f_access_platform,
                 )
                 .map_err(BalloonDeviceError::CreateBalloonDevice)?,
             );
@@ -218,12 +226,18 @@ impl BalloonDeviceMgr {
         for info in self.info_list.iter_mut() {
             info!(ctx.logger(), "attach balloon device: {}", info.config.balloon_id; "subsystem" => "balloon_dev_mgr");
 
+            #[cfg(not(target_arch = "x86_64"))]
+            let f_access_platform = false;
+            #[cfg(target_arch = "x86_64")]
+            let f_access_platform = ctx.get_confidential_vm_type() == Some(ConfidentialVmType::TDX);
+
             let device = Balloon::new(
                 epoll_mgr.clone(),
                 BalloonConfig {
                     f_deflate_on_oom: info.config.f_deflate_on_oom,
                     f_reporting: info.config.f_reporting,
                 },
+                f_access_platform,
             )
             .map_err(BalloonDeviceError::CreateBalloonDevice)?;
             METRICS

--- a/src/dragonball/src/device_manager/blk_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/blk_dev_mgr.rs
@@ -31,6 +31,8 @@ use virtio_queue::QueueSync;
 use vm_memory::GuestRegionMmap;
 
 use crate::address_space_manager::GuestAddressSpaceImpl;
+#[cfg(target_arch = "x86_64")]
+use crate::api::v1::ConfidentialVmType;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, RateLimiterConfigInfo};
 use crate::device_manager::blk_dev_mgr::BlockDeviceError::InvalidDeviceId;
 use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
@@ -730,6 +732,11 @@ impl BlockDeviceMgr {
             }
         }
 
+        #[cfg(not(target_arch = "x86_64"))]
+        let f_access_platform = false;
+        #[cfg(target_arch = "x86_64")]
+        let f_access_platform = ctx.get_confidential_vm_type() == Some(ConfidentialVmType::TDX);
+
         Ok(Box::new(Block::new(
             block_files,
             cfg.is_read_only,
@@ -737,6 +744,7 @@ impl BlockDeviceMgr {
             Arc::new(cfg.queue_sizes()),
             epoll_mgr,
             limiters,
+            f_access_platform,
         )?))
     }
 

--- a/src/dragonball/src/device_manager/fs_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/fs_dev_mgr.rs
@@ -11,6 +11,8 @@ use serde_derive::{Deserialize, Serialize};
 use slog::{error, info};
 
 use crate::address_space_manager::GuestAddressSpaceImpl;
+#[cfg(target_arch = "x86_64")]
+use crate::api::v1::ConfidentialVmType;
 use crate::config_manager::{
     ConfigItem, DeviceConfigInfo, DeviceConfigInfos, RateLimiterConfigInfo,
 };
@@ -405,6 +407,11 @@ impl FsDeviceMgr {
             address_space,
         };
 
+        #[cfg(not(target_arch = "x86_64"))]
+        let f_access_platform = false;
+        #[cfg(target_arch = "x86_64")]
+        let f_access_platform = ctx.get_confidential_vm_type() == Some(ConfidentialVmType::TDX);
+
         let device = Box::new(
             virtio::fs::VirtioFs::new(
                 &config.tag,
@@ -422,6 +429,7 @@ impl FsDeviceMgr {
                 Box::new(handler),
                 epoll_mgr,
                 limiter,
+                f_access_platform,
             )
             .map_err(FsDeviceError::CreateFsDevice)?,
         );

--- a/src/dragonball/src/device_manager/mem_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/mem_dev_mgr.rs
@@ -21,6 +21,8 @@ use vm_memory::{
 };
 
 use crate::address_space_manager::GuestAddressSpaceImpl;
+#[cfg(target_arch = "x86_64")]
+use crate::api::v1::ConfidentialVmType;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
 use crate::device_manager::DbsMmioV2Device;
 use crate::device_manager::{DeviceManager, DeviceMgrError, DeviceOpContext};
@@ -293,6 +295,11 @@ impl MemDeviceMgr {
             }
         };
 
+        #[cfg(not(target_arch = "x86_64"))]
+        let f_access_platform = false;
+        #[cfg(target_arch = "x86_64")]
+        let f_access_platform = ctx.get_confidential_vm_type() == Some(ConfidentialVmType::TDX);
+
         virtio::mem::Mem::new(
             config.mem_id.clone(),
             capacity_mib,
@@ -302,6 +309,7 @@ impl MemDeviceMgr {
             epoll_mgr.clone(),
             factory,
             boot_mem_size,
+            f_access_platform,
         )
         .map_err(DeviceMgrError::Virtio)
     }

--- a/src/dragonball/src/device_manager/mod.rs
+++ b/src/dragonball/src/device_manager/mod.rs
@@ -55,7 +55,7 @@ use dbs_upcall::{
 use dbs_virtio_devices::vsock::backend::VsockInnerConnector;
 
 use crate::address_space_manager::GuestAddressSpaceImpl;
-use crate::api::v1::InstanceInfo;
+use crate::api::v1::{ConfidentialVmType, InstanceInfo};
 #[cfg(feature = "host-device")]
 use crate::device_manager::vfio_dev_mgr::PciSystemManager;
 use crate::error::StartMicroVmError;
@@ -425,6 +425,14 @@ impl DeviceOpContext {
 
     pub(crate) fn logger(&self) -> &slog::Logger {
         &self.logger
+    }
+
+    pub(crate) fn get_confidential_vm_type(&self) -> Option<ConfidentialVmType> {
+        self.shared_info
+            .read()
+            .unwrap()
+            .confidential_vm_type
+            .clone()
     }
 
     #[allow(unused_variables)]

--- a/src/dragonball/src/device_manager/net_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/net_dev_mgr.rs
@@ -25,6 +25,8 @@ use dbs_virtio_devices::Error as VirtioError;
 use serde::{Deserialize, Serialize};
 
 use crate::address_space_manager::GuestAddressSpaceImpl;
+#[cfg(target_arch = "x86_64")]
+use crate::api::v1::ConfidentialVmType;
 use crate::config_manager::{ConfigItem, DeviceConfigInfos, RateLimiterConfigInfo};
 use crate::device_manager::{DbsVirtioDevice, DeviceManager, DeviceMgrError, DeviceOpContext};
 use crate::get_bucket_update;
@@ -606,6 +608,11 @@ impl NetworkDeviceMgr {
             None => None,
         };
 
+        #[cfg(not(target_arch = "x86_64"))]
+        let f_access_platform = false;
+        #[cfg(target_arch = "x86_64")]
+        let f_access_platform = ctx.get_confidential_vm_type() == Some(ConfidentialVmType::TDX);
+
         let net_device = virtio::net::Net::new(
             config.host_dev_name.clone(),
             cfg.guest_mac(),
@@ -613,6 +620,7 @@ impl NetworkDeviceMgr {
             epoll_mgr,
             rx_rate_limiter,
             tx_rate_limiter,
+            f_access_platform,
         )
         .map_err(NetworkDeviceError::CreateNetDevice)?;
 
@@ -637,12 +645,18 @@ impl NetworkDeviceMgr {
             .clone()
             .ok_or(NetworkDeviceError::Virtio(VirtioError::InvalidInput))?;
 
+        #[cfg(not(target_arch = "x86_64"))]
+        let f_access_platform = false;
+        #[cfg(target_arch = "x86_64")]
+        let f_access_platform = ctx.get_confidential_vm_type() == Some(ConfidentialVmType::TDX);
+
         Ok(Box::new(
             virtio::vhost::vhost_kern::net::Net::new(
                 config.host_dev_name.clone(),
                 cfg.guest_mac(),
                 Arc::new(cfg.queue_sizes()),
                 epoll_mgr,
+                f_access_platform,
             )
             .map_err(NetworkDeviceError::CreateNetDevice)?,
         ))

--- a/src/dragonball/src/device_manager/vsock_dev_mgr.rs
+++ b/src/dragonball/src/device_manager/vsock_dev_mgr.rs
@@ -18,6 +18,8 @@ use dbs_virtio_devices::Error as VirtioError;
 use serde_derive::{Deserialize, Serialize};
 
 use super::{DeviceMgrError, StartMicroVmError};
+#[cfg(target_arch = "x86_64")]
+use crate::api::v1::ConfidentialVmType;
 use crate::config_manager::{ConfigItem, DeviceConfigInfo, DeviceConfigInfos};
 use crate::device_manager::{DeviceManager, DeviceOpContext};
 
@@ -207,6 +209,11 @@ impl VsockDeviceMgr {
                 virtio::Error::InvalidInput,
             ))?;
 
+        #[cfg(not(target_arch = "x86_64"))]
+        let f_access_platform = false;
+        #[cfg(target_arch = "x86_64")]
+        let f_access_platform = ctx.get_confidential_vm_type() == Some(ConfidentialVmType::TDX);
+
         for info in self.info_list.iter_mut() {
             slog::info!(
                 ctx.logger(),
@@ -221,6 +228,7 @@ impl VsockDeviceMgr {
                     info.config.guest_cid as u64,
                     Arc::new(info.config.queue_sizes()),
                     epoll_mgr.clone(),
+                    f_access_platform,
                 )
                 .map_err(VirtioError::VirtioVsockError)
                 .map_err(StartMicroVmError::CreateVsockDevice)?,


### PR DESCRIPTION
TDX guest VM requires that the feature flag:
 VIRTIO_F_ACCESS_PLATFORM is set for virtio devices