### PR TITLE
dragonball: Add handler for VcpuExit of type Hypercall for TDX

### DIFF
--- a/src/dragonball/src/error.rs
+++ b/src/dragonball/src/error.rs
@@ -261,6 +261,11 @@ pub enum StartMicroVmError {
     /// Guest memory error
     #[error("Guest memory error: {0}")]
     GuestMemoryError(#[source] vm_memory::guest_memory::Error),
+
+    #[cfg(target_arch = "x86_64")]
+    /// Cannot enable hypercall map gpa range
+    #[error("Failed to enable hypercall map gpa range: {0}")]
+    EnableHcMapGpaRange(#[source] vmm_sys_util::errno::Error),
 }
 
 /// Errors associated with starting the instance.

--- a/src/dragonball/src/vcpu/aarch64.rs
+++ b/src/dragonball/src/vcpu/aarch64.rs
@@ -44,6 +44,7 @@ impl Vcpu {
     pub fn new_aarch64(
         id: u8,
         vcpu_fd: VcpuFd,
+        vm_fd: Arc<VmFd>,
         io_mgr: IoManagerCached,
         exit_evt: EventFd,
         vcpu_state_event: EventFd,
@@ -56,6 +57,7 @@ impl Vcpu {
 
         Ok(Vcpu {
             fd: vcpu_fd,
+            vm_fd,
             id,
             io_mgr,
             create_ts,

--- a/src/dragonball/src/vcpu/mod.rs
+++ b/src/dragonball/src/vcpu/mod.rs
@@ -13,6 +13,9 @@ pub use vcpu_manager::{VcpuManager, VcpuManagerError, VcpuResizeInfo};
 #[cfg(feature = "hotplug")]
 pub use vcpu_manager::VcpuResizeError;
 
+#[cfg(target_arch = "x86_64")]
+pub use vcpu_impl::{KVM_HC_MAP_GPA_RANGE, KVM_MAP_GPA_RANGE_ENCRYPTED};
+
 /// vcpu config collection
 pub struct VcpuConfig {
     /// initial vcpu count

--- a/src/dragonball/src/vcpu/vcpu_impl.rs
+++ b/src/dragonball/src/vcpu/vcpu_impl.rs
@@ -19,8 +19,10 @@ use std::thread;
 use dbs_interrupt::{InterruptManager, IOAPIC_BASE, IOAPIC_SIZE};
 use dbs_utils::metric::IncMetric;
 use dbs_utils::time::TimestampUs;
+#[cfg(target_arch = "x86_64")]
+use kvm_bindings::{kvm_memory_attributes, KVM_MEMORY_ATTRIBUTE_PRIVATE};
 use kvm_bindings::{KVM_SYSTEM_EVENT_RESET, KVM_SYSTEM_EVENT_SHUTDOWN};
-use kvm_ioctls::{VcpuExit, VcpuFd};
+use kvm_ioctls::{VcpuExit, VcpuFd, VmFd};
 use libc::{c_int, c_void, siginfo_t};
 use log::{error, info};
 use seccompiler::{apply_filter, BpfProgram, Error as SecError};
@@ -35,6 +37,9 @@ use crate::IoManagerCached;
 #[cfg(target_arch = "x86_64")]
 #[path = "x86_64.rs"]
 mod x86_64;
+
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::{KVM_HC_MAP_GPA_RANGE, KVM_MAP_GPA_RANGE_ENCRYPTED};
 
 #[cfg(target_arch = "aarch64")]
 #[path = "aarch64.rs"]
@@ -119,6 +124,11 @@ pub enum VcpuError {
     /// The call to KVM_SET_CPUID2 failed on x86_64.
     #[error("failure while calling KVM_SET_CPUID2 on x86_64")]
     SetSupportedCpusFailed(#[source] kvm_ioctls::Error),
+
+    #[cfg(target_arch = "x86_64")]
+    /// Fail to set memory attributes for hypercall
+    #[error("failure while setting memory attributes")]
+    SetMemoryAttributes(#[source] kvm_ioctls::Error),
 }
 
 #[cfg(target_arch = "aarch64")]
@@ -283,6 +293,8 @@ pub struct Vcpu {
     io_mgr: IoManagerCached,
     // Records vCPU create time stamp
     create_ts: TimestampUs,
+    // VM fd that current vCPU belongs to
+    vm_fd: Arc<VmFd>,
 
     // The receiving end of events channel owned by the vcpu side.
     event_receiver: Receiver<VcpuEvent>,
@@ -529,6 +541,30 @@ impl Vcpu {
                             Err(VcpuError::VcpuUnhandledKvmExit)
                         }
                     },
+                    #[cfg(target_arch = "x86_64")]
+                    VcpuExit::Hypercall(hc_exit) => {
+                        if hc_exit.nr == KVM_HC_MAP_GPA_RANGE {
+                            let gpa = hc_exit.args[0];
+                            let size = hc_exit.args[1] * dbs_boot::PAGE_SIZE as u64;
+                            let attributes = hc_exit.args[2];
+                            let mem_attr = if (attributes & KVM_MAP_GPA_RANGE_ENCRYPTED) != 0 {
+                                KVM_MEMORY_ATTRIBUTE_PRIVATE
+                            } else {
+                                0
+                            };
+                            self.vm_fd
+                                .set_memory_attributes(kvm_memory_attributes {
+                                    address: gpa,
+                                    size,
+                                    attributes: mem_attr as u64,
+                                    flags: 0,
+                                })
+                                .map_err(VcpuError::SetMemoryAttributes)?;
+                            Ok(VcpuEmulation::Handled)
+                        } else {
+                            Err(VcpuError::VcpuUnhandledKvmExit)
+                        }
+                    }
                     r => {
                         self.metrics.failures.inc();
                         // TODO: Are we sure we want to finish running a vcpu upon
@@ -865,7 +901,7 @@ pub mod tests {
     #[cfg(target_arch = "x86_64")]
     fn create_vcpu() -> (Vcpu, Receiver<VcpuStateEvent>) {
         let kvm_context = KvmContext::new(None).unwrap();
-        let vm = kvm_context.kvm().create_vm().unwrap();
+        let vm = Arc::new(kvm_context.kvm().create_vm().unwrap());
         let vcpu_fd = vm.create_vcpu(0).unwrap();
         let io_manager = IoManagerCached::new(Arc::new(ArcSwap::new(Arc::new(IoManager::new()))));
         let supported_cpuid = kvm_context
@@ -876,11 +912,12 @@ pub mod tests {
         let (tx, rx) = channel();
         let time_stamp = TimestampUs::default();
         let irq_manager: Arc<Box<dyn InterruptManager>> =
-            Arc::new(Box::new(KvmIrqManager::new(Arc::new(vm))));
+            Arc::new(Box::new(KvmIrqManager::new(vm.clone())));
 
         let vcpu = Vcpu::new_x86_64(
             0,
             vcpu_fd,
+            vm,
             io_manager,
             supported_cpuid,
             reset_event_fd,
@@ -915,6 +952,7 @@ pub mod tests {
         let vcpu = Vcpu::new_aarch64(
             0,
             vcpu_fd,
+            vm,
             io_manager,
             reset_event_fd,
             vcpu_state_event,

--- a/src/dragonball/src/vcpu/vcpu_manager.rs
+++ b/src/dragonball/src/vcpu/vcpu_manager.rs
@@ -804,6 +804,7 @@ impl VcpuManager {
         Vcpu::new_x86_64(
             cpu_index,
             vcpu_fd,
+            self.vm_fd.clone(),
             // safe to unwrap
             self.io_manager.as_ref().unwrap().clone(),
             self.supported_cpuid.clone(),
@@ -833,6 +834,7 @@ impl VcpuManager {
         Vcpu::new_aarch64(
             cpu_index,
             vcpu_fd,
+            self.vm_fd.clone(),
             // safe to unwrap
             self.io_manager.as_ref().unwrap().clone(),
             self.reset_event_fd.as_ref().unwrap().try_clone().unwrap(),

--- a/src/dragonball/src/vcpu/x86_64.rs
+++ b/src/dragonball/src/vcpu/x86_64.rs
@@ -27,6 +27,14 @@ use crate::vcpu::vcpu_impl::{Result, Vcpu, VcpuError, VcpuStateEvent};
 use crate::vcpu::VcpuConfig;
 use crate::IoManagerCached;
 
+/// Hypercall number for mapping gpa range
+pub const KVM_HC_MAP_GPA_RANGE: u64 = 12;
+
+/// Attribute mask for map_gpa_range hypercall.
+/// If set, the hypercall is going to set the range to private,
+/// otherwise shared.
+pub const KVM_MAP_GPA_RANGE_ENCRYPTED: u64 = 1 << 4;
+
 impl Vcpu {
     /// Constructs a new VCPU for `vm`.
     ///
@@ -48,6 +56,7 @@ impl Vcpu {
     pub fn new_x86_64(
         id: u8,
         vcpu_fd: VcpuFd,
+        vm_fd: Arc<VmFd>,
         io_mgr: IoManagerCached,
         cpuid: CpuId,
         exit_evt: EventFd,
@@ -62,6 +71,7 @@ impl Vcpu {
         // Initially the cpuid per vCPU is the one supported by this VM.
         Ok(Vcpu {
             fd: vcpu_fd,
+            vm_fd,
             id,
             io_mgr,
             create_ts,

--- a/src/dragonball/src/vm/x86_64.rs
+++ b/src/dragonball/src/vm/x86_64.rs
@@ -21,8 +21,8 @@ use dbs_interrupt::IOAPIC_MAX_NR_REDIR_ENTRIES;
 use dbs_utils::epoll_manager::EpollManager;
 use dbs_utils::time::TimestampUs;
 use kvm_bindings::{
-    kvm_enable_cap, kvm_irqchip, kvm_pit_config, kvm_pit_state2, KVM_CAP_SPLIT_IRQCHIP,
-    KVM_PIT_SPEAKER_DUMMY,
+    kvm_enable_cap, kvm_irqchip, kvm_pit_config, kvm_pit_state2, KVM_CAP_EXIT_HYPERCALL,
+    KVM_CAP_SPLIT_IRQCHIP, KVM_PIT_SPEAKER_DUMMY,
 };
 use linux_loader::cmdline::Cmdline;
 use linux_loader::configurator::{linux::LinuxBootConfigurator, BootConfigurator, BootParams};
@@ -34,6 +34,7 @@ use crate::address_space_manager::{GuestAddressSpaceImpl, GuestMemoryImpl};
 use crate::api::v1::ConfidentialVmType;
 use crate::error::{Error, Result, StartMicroVmError};
 use crate::event_manager::EventManager;
+use crate::vcpu::KVM_HC_MAP_GPA_RANGE;
 use crate::vm::{VcpuManagerError, Vm, VmError};
 
 /// Configures the system and should be called once per vm before starting vcpu
@@ -239,6 +240,7 @@ impl Vm {
                 .map_err(StartMicroVmError::Vcpu)?;
 
             if self.confidential_vm_type() == Some(ConfidentialVmType::TDX) {
+                self.enable_hc_map_gpa_range()?;
                 self.tdx_init_vcpus(hob_address)?;
                 self.tdx_init_mem_region(vm_memory.deref(), &sections)?;
                 self.tdx_finalize()?;
@@ -521,6 +523,17 @@ impl Vm {
             .map_err(StartMicroVmError::TdvfError)?;
 
         Ok(())
+    }
+
+    pub(super) fn enable_hc_map_gpa_range(&mut self) -> std::result::Result<(), StartMicroVmError> {
+        let mut enable_hc_map_gpa_range = kvm_enable_cap {
+            cap: KVM_CAP_EXIT_HYPERCALL,
+            ..Default::default()
+        };
+        enable_hc_map_gpa_range.args[0] = 1 << KVM_HC_MAP_GPA_RANGE;
+        self.vm_fd()
+            .enable_cap(&enable_hc_map_gpa_range)
+            .map_err(StartMicroVmError::EnableHcMapGpaRange)
     }
 
     pub(super) fn tdx_init_vm(&mut self) -> std::result::Result<(), StartMicroVmError> {


### PR DESCRIPTION
A TDX guest VM might want to change the encryption status of a certain memory region, and such request is sent via VcpuExit of type Hypercall, with exit number KVM_HC_MAP_GPA_RANGE. Dragonball will trap this VcpuExit, and process the request with ioctl KVM_SET_MEMORY_ATTRIBUTES.