### PR TITLE
kata-deploy: move mariner tuning into Azure test profiles

### DIFF
--- a/.github/workflows/run-k8s-tests-on-aks.yaml
+++ b/.github/workflows/run-k8s-tests-on-aks.yaml
@@ -78,6 +78,10 @@ jobs:
       DOCKER_REPO: ${{ inputs.repo }}
       DOCKER_TAG: ${{ inputs.tag }}
       GH_PR_NUMBER: ${{ inputs.pr-number }}
+      # For cbl-mariner AKS jobs with clh/clh-runtime-rs, tests/gha-run-k8s-common.sh
+      # (helm_helper) automatically switches the base chart values file to
+      # tools/packaging/kata-deploy/helm-chart/kata-deploy/azure-tests*.values.yaml
+      # so Azure-specific custom runtimes are tested without patching default values.yaml.
       KATA_HOST_OS: ${{ matrix.host_os }}
       KATA_HYPERVISOR: ${{ matrix.vmm }}
       KUBERNETES: "vanilla"

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -695,6 +695,18 @@ function helm_helper() {
 					base_values_file="${helm_chart_dir}/try-kata-nvidia-gpu.values.yaml"
 				fi
 				;;
+			clh)
+				# On AKS Mariner tests, use dedicated values that make kata default point to clh-azure.
+				if [[ "${HELM_HOST_OS}" == "cbl-mariner" ]] && [[ -f "${helm_chart_dir}/azure-tests.values.yaml" ]]; then
+					base_values_file="${helm_chart_dir}/azure-tests.values.yaml"
+				fi
+				;;
+			clh-runtime-rs)
+				# On AKS Mariner tests, use dedicated values that make kata default point to clh-azure-runtime-rs.
+				if [[ "${HELM_HOST_OS}" == "cbl-mariner" ]] && [[ -f "${helm_chart_dir}/azure-tests-runtime-rs.values.yaml" ]]; then
+					base_values_file="${helm_chart_dir}/azure-tests-runtime-rs.values.yaml"
+				fi
+				;;
 			*)
 				# Use TEE example file for confidential computing hypervisors
 				if is_confidential_runtime_class "${KATA_HYPERVISOR}"; then

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -116,10 +116,6 @@ pub async fn install_artifacts(config: &Config, container_runtime: &str) -> Resu
         install_custom_runtime_configs(config, container_runtime)?;
     }
 
-    if std::env::var("HOST_OS").unwrap_or_default() == "cbl-mariner" {
-        configure_mariner(config).await?;
-    }
-
     let expand_runtime_classes_for_nfd = nfd::setup_nfd_rules(config).await?;
 
     if expand_runtime_classes_for_nfd {
@@ -1270,65 +1266,6 @@ async fn configure_hypervisor_annotations(
 
 async fn configure_experimental_force_guest_pull(config_file: &Path) -> Result<()> {
     set_toml_bool_to_true(config_file, "runtime.experimental_force_guest_pull")
-}
-
-async fn configure_mariner(config: &Config) -> Result<()> {
-    let mariner_hypervisor_name = "clh";
-    let config_paths = [
-        format!(
-            "{}/share/defaults/kata-containers/configuration-clh.toml",
-            config.host_install_dir
-        ),
-        format!(
-            "{}/share/defaults/kata-containers/runtime-rs/configuration-clh-runtime-rs.toml",
-            config.host_install_dir
-        ),
-    ];
-
-    for config_path in config_paths {
-        let config_file = Path::new(&config_path);
-
-        if !config_file.exists() {
-            continue;
-        }
-
-        let static_resource_mgmt_path = "runtime.static_sandbox_resource_mgmt";
-        set_toml_bool_to_true(config_file, static_resource_mgmt_path)?;
-
-        let clh_path = format!("{}/bin/cloud-hypervisor-glibc", config.dest_dir);
-        let valid_paths_field =
-            format!("hypervisor.{mariner_hypervisor_name}.valid_hypervisor_paths");
-        let existing_paths = toml_utils::get_toml_array(config_file, &valid_paths_field)
-            .unwrap_or_else(|_| Vec::new());
-
-        if !existing_paths.iter().any(|p| p == &clh_path) {
-            let mut new_paths = existing_paths.clone();
-            new_paths.push(clh_path.clone());
-            log::debug!(
-                "Updating {} in {}: old={:?} new={:?}",
-                valid_paths_field,
-                config_file.display(),
-                existing_paths,
-                new_paths
-            );
-            toml_utils::set_toml_array(config_file, &valid_paths_field, &new_paths)?;
-        }
-
-        let path_field = format!("hypervisor.{mariner_hypervisor_name}.path");
-        let current_path = toml_utils::get_toml_value(config_file, &path_field).unwrap_or_default();
-        if !current_path.contains(&clh_path) {
-            log::debug!(
-                "Updating {} in {}: old=\"{}\" new=\"{}\"",
-                path_field,
-                config_file.display(),
-                current_path,
-                clh_path
-            );
-            toml_utils::set_toml_value(config_file, &path_field, &format!("\"{clh_path}\""))?;
-        }
-    }
-
-    Ok(())
 }
 
 #[cfg(test)]

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/azure-tests.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/azure-tests.values.yaml
@@ -1,0 +1,32 @@
+runtimeClasses:
+  enabled: false
+  createDefault: false
+
+customRuntimes:
+  enabled: true
+  runtimes:
+    clh-azure:
+      baseConfig: "clh"
+      dropIn: |
+        [runtime]
+        static_sandbox_resource_mgmt = true
+
+        [hypervisor.clh]
+        path = "/opt/kata/bin/cloud-hypervisor-glibc"
+        image = "/opt/kata/share/kata-containers/kata-containers-mariner.img"
+        valid_hypervisor_paths = ["/opt/kata/bin/cloud-hypervisor-glibc"]
+      runtimeClass: |
+        kind: RuntimeClass
+        apiVersion: node.k8s.io/v1
+        metadata:
+          name: kata
+          labels:
+            app.kubernetes.io/managed-by: kata-deploy
+        handler: kata-clh-azure
+        scheduling:
+          nodeSelector:
+            katacontainers.io/kata-runtime: "true"
+      containerd:
+        snapshotter: ""
+      crio:
+        pullType: ""

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -298,10 +298,6 @@ spec:
         - name: CONTAINERD_CONFIG_FILE_NAME
           value: {{ .Values.containerd.configFileName | trim | quote }}
 {{- end }}
-{{- with .Values.env.hostOS }}
-        - name: HOST_OS
-          value: {{ . | quote }}
-{{- end }}
 {{- if and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes }}
         - name: CUSTOM_RUNTIMES_ENABLED
           value: "true"

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -475,7 +475,6 @@ runtimeClasses:
 
 env:
   installationPrefix: ""
-  hostOS: ""
   # Suffix for multi-install deployments to avoid conflicts between multiple Kata installations
   # NOTE: When set, the default RuntimeClass (runtimeClasses.createDefault) will NOT be created
   #       to avoid naming conflicts. Use fully qualified RuntimeClass names (e.g., kata-qemu-suffix1).


### PR DESCRIPTION
Let's stop patching base CLH configs on Mariner hosts and, instead, generate dedicated clh-azure variants taking advantage of the kata-deploy's custom runtimes feature.