### PR TITLE
ci: Refactor boot-image-se build and update shim components

### DIFF
--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -47,6 +47,7 @@ jobs:
         asset:
           - agent
           - coco-guest-components
+          - fake-boot-image-se
           - kernel
           - pause-image
           - qemu
@@ -80,10 +81,16 @@ jobs:
       - name: Build ${{ matrix.asset }}
         id: build
         run: |
-          make "${KATA_ASSET}-tarball"
+          if [ "${KATA_ASSET}" = "fake-boot-image-se" ]; then
+            make FAKE_SE_IMAGE=true boot-image-se-tarball
+            TARBALL_NAME="boot-image-se"
+          else
+            make "${KATA_ASSET}-tarball"
+            TARBALL_NAME="${KATA_ASSET}"
+          fi
           build_dir=$(readlink -f build)
           # store-artifact does not work with symlink
-          mkdir -p kata-build && cp "${build_dir}"/kata-static-"${KATA_ASSET}"*.tar.* kata-build/.
+          mkdir -p kata-build && cp "${build_dir}"/kata-static-"${TARBALL_NAME}"*.tar.* kata-build/.
         env:
           KATA_ASSET: ${{ matrix.asset }}
           TAR_OUTPUT: ${{ matrix.asset }}.tar.gz
@@ -96,7 +103,7 @@ jobs:
 
       - name: Parse OCI image name and digest
         id: parse-oci-segments
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ env.PERFORM_ATTESTATION == 'yes' && matrix.asset != 'fake-boot-image-se' }}
         env:
           ASSET: ${{ matrix.asset }}
         run: |
@@ -113,7 +120,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/attest-build-provenance@ef244123eb79f2f7a7e75d99086184180e6d0018 # v1.4.4
-        if: ${{ env.PERFORM_ATTESTATION == 'yes' }}
+        if: ${{ env.PERFORM_ATTESTATION == 'yes' && matrix.asset != 'fake-boot-image-se' }}
         with:
           subject-name: ${{ steps.parse-oci-segments.outputs.oci-name }}
           subject-digest: ${{ steps.parse-oci-segments.outputs.oci-digest }}
@@ -123,7 +130,7 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: kata-artifacts-s390x-${{ matrix.asset }}${{ inputs.tarball-suffix }}
-          path: kata-build/kata-static-${{ matrix.asset }}.tar.zst
+          path: kata-build/kata-static-${{ matrix.asset == 'fake-boot-image-se' && 'boot-image-se' || matrix.asset }}.tar.zst
           retention-days: 15
           if-no-files-found: error
 
@@ -238,60 +245,11 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
-  build-asset-boot-image-se:
-    name: build-asset-boot-image-se
-    runs-on: s390x
-    needs: [build-asset, build-asset-rootfs]
-    permissions:
-      contents: read
-      packages: write
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Rebase atop of the latest target branch
-        run: |
-          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
-        env:
-          TARGET_BRANCH: ${{ inputs.target-branch }}
-
-      - name: get-artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
-        with:
-          pattern: kata-artifacts-s390x-*${{ inputs.tarball-suffix }}
-          path: kata-artifacts
-          merge-multiple: true
-
-      - name: Place a host key document
-        run: |
-          mkdir -p "host-key-document"
-          cp "${CI_HKD_PATH}" "host-key-document"
-        env:
-          CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
-
-      - name: Build boot-image-se
-        run: |
-          make install-prebuilt-artifacts
-          make DEPS= boot-image-se-tarball
-          build_dir=$(readlink -f build)
-          sudo cp -r "${build_dir}" "kata-build"
-          sudo chown -R "$(id -u)":"$(id -g)" "kata-build"
-        env:
-          HKD_PATH: "host-key-document"
-
-      - name: store-artifact boot-image-se
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
-        with:
-          name: kata-artifacts-s390x${{ inputs.tarball-suffix }}
-          path: kata-build/kata-static-boot-image-se.tar.zst
-          retention-days: 1
-          if-no-files-found: error
-
   # We don't need the binaries installed in the rootfs as part of the release tarball, so can delete them now we've built the rootfs
   remove-rootfs-binary-artifacts:
     name: remove-rootfs-binary-artifacts
     runs-on: ubuntu-22.04
-    needs: [build-asset-rootfs, build-asset-boot-image-se]
+    needs: build-asset-rootfs
     strategy:
       matrix:
         asset:
@@ -384,7 +342,6 @@ jobs:
     needs:
       - build-asset
       - build-asset-rootfs
-      - build-asset-boot-image-se
       - build-asset-shim-v2
     permissions:
       contents: read

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -21,8 +21,6 @@ on:
         type: string
         default: ""
     secrets:
-      CI_HKD_PATH:
-        required: true
       QUAY_DEPLOYER_PASSWORD:
         required: true
 

--- a/.github/workflows/ci-devel.yaml
+++ b/.github/workflows/ci-devel.yaml
@@ -38,7 +38,6 @@ jobs:
       AZ_APPID: ${{ secrets.AZ_APPID }}
       AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
       AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
-      CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
       KBUILD_SIGN_PIN: ${{ secrets.KBUILD_SIGN_PIN }}

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -29,7 +29,6 @@ jobs:
       AZ_APPID: ${{ secrets.AZ_APPID }}
       AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
       AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
-      CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
       KBUILD_SIGN_PIN: ${{ secrets.KBUILD_SIGN_PIN }}

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -47,7 +47,6 @@ jobs:
       AZ_APPID: ${{ secrets.AZ_APPID }}
       AZ_TENANT_ID: ${{ secrets.AZ_TENANT_ID }}
       AZ_SUBSCRIPTION_ID: ${{ secrets.AZ_SUBSCRIPTION_ID }}
-      CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
       NGC_API_KEY: ${{ secrets.NGC_API_KEY }}
       KBUILD_SIGN_PIN: ${{ secrets.KBUILD_SIGN_PIN }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,8 +37,6 @@ on:
         required: true
       AZ_SUBSCRIPTION_ID:
         required: true
-      CI_HKD_PATH:
-        required: true
       QUAY_DEPLOYER_PASSWORD:
         required: true
       NGC_API_KEY:
@@ -129,7 +127,6 @@ jobs:
       commit-hash: ${{ inputs.commit-hash }}
       target-branch: ${{ inputs.target-branch }}
     secrets:
-      CI_HKD_PATH: ${{ secrets.ci_hkd_path }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
   build-kata-static-tarball-ppc64le:

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -53,7 +53,6 @@ jobs:
       push-to-registry: yes
       target-branch: ${{ github.ref_name }}
     secrets:
-      CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
   build-assets-ppc64le:

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -6,8 +6,6 @@ on:
         required: true
         type: string
     secrets:
-      CI_HKD_PATH:
-        required: true
       QUAY_DEPLOYER_PASSWORD:
         required: true
 
@@ -24,7 +22,6 @@ jobs:
       push-to-registry: yes
       stage: release
     secrets:
-      CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
     permissions:
       contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -66,7 +66,6 @@ jobs:
     with:
       target-arch: s390x
     secrets:
-      CI_HKD_PATH: ${{ secrets.CI_HKD_PATH }}
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
 
   build-and-push-assets-ppc64le:

--- a/tools/packaging/guest-image/build_se_image.sh
+++ b/tools/packaging/guest-image/build_se_image.sh
@@ -21,7 +21,7 @@ source "${packaging_root_dir}/scripts/lib.sh"
 source "${script_dir}/lib_se.sh"
 
 ARCH=${ARCH:-$(uname -m)}
-if [[ "$(uname -m)" == "${ARCH}" ]]; then
+if [[ "${FAKE_SE_IMAGE:-}" != "true" && "$(uname -m)" == "${ARCH}" ]]; then
 	[[ "${ARCH}" == "s390x" ]] || die "Building a Secure Execution image is currently only supported on s390x."
 fi
 usage() {
@@ -34,19 +34,30 @@ Options:
   --destdir=\${destdir}
 
 Environment variables:
-  HKD_PATH (required): a path for a directory which includes at least one host key document
+  HKD_PATH (required unless FAKE_SE_IMAGE=true): a path for a directory which includes at least one host key document
                   for Secure Execution, generally specific to your machine. See
                   https://www.ibm.com/docs/en/linux-on-systems?topic=tasks-verify-host-key-document
                   for information on how to retrieve and verify this document.
   SIGNING_KEY_CERT_PATH: a path for the IBM zSystem signing key certificate
   INTERMEDIATE_CA_CERT_PATH: a path for the intermediate CA certificate signed by the root CA
   HOST_KEY_CRL_PATH: a path for the host key CRL
+  FAKE_SE_IMAGE : If set to "true", creates a dummy kata-containers-se.img via touch command
+                  instead of using genprotimg. Useful for testing without real SE setup.
   DEBUG         : If set, display debug information.
 EOF
 	exit "${1:-0}"
 }
 
 build_image() {
+	# Check if FAKE_SE_IMAGE mode is enabled
+	if [[ "${FAKE_SE_IMAGE:-}" == "true" ]]; then
+		echo "FAKE_SE_IMAGE mode enabled: Skipping tarball extraction"
+		if ! build_secure_image "" "" "${install_dir}"; then
+			usage 1
+		fi
+		return 0
+	fi
+
 	image_source_dir="${builddir}/secure-image"
 	mkdir -p "${image_source_dir}"
 	pushd "${tarball_dir}"

--- a/tools/packaging/guest-image/lib_se.sh
+++ b/tools/packaging/guest-image/lib_se.sh
@@ -29,6 +29,16 @@ build_secure_image() {
 	kernel_params="${1:-}"
 	install_src_dir="${2:-}"
 	install_dest_dir="${3:-}"
+
+	# Check if FAKE_SE_IMAGE mode is enabled
+	if [[ "${FAKE_SE_IMAGE:-}" == "true" ]]; then
+		echo "FAKE_SE_IMAGE mode enabled: Creating dummy kata-containers-se.img via touch command"
+		echo "FAKE_SE_IMAGE mode: Skipping kernel, initrd, parmfile, and host key document checks"
+		mkdir -p "${install_dest_dir}"
+		touch "${install_dest_dir}/kata-containers-se.img"
+		return 0
+	fi
+
 	key_verify_option="--no-verify" # no verification for CI testing purposes
 
 	if [[ -n "${SIGNING_KEY_CERT_PATH:-}" ]] && [[ -n "${INTERMEDIATE_CA_CERT_PATH:-}" ]] && [[ -n "${HOST_KEY_CRL_PATH:-}" ]]; then

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -183,7 +183,11 @@ qemu-tarball:
 
 # DEPS is rebound per target below; prereqs expand at parse time, so each rule
 # freezes the current DEPS. `make DEPS=` from the command line zeros all of them.
+ifeq ($(FAKE_SE_IMAGE),true)
+DEPS :=
+else
 DEPS := kernel-tarball rootfs-initrd-confidential-tarball
+endif
 boot-image-se-tarball: $(DEPS)
 	${MAKE} $@-build
 

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-binaries-in-docker.sh
@@ -161,6 +161,7 @@ docker run \
 	--env AA_KBC="${AA_KBC:-}" \
 	--env HKD_PATH="$(realpath "${HKD_PATH:-}" 2> /dev/null || true)" \
 	--env SE_KERNEL_PARAMS="${SE_KERNEL_PARAMS:-}" \
+	--env FAKE_SE_IMAGE="${FAKE_SE_IMAGE:-}" \
 	--env CROSS_BUILD="${CROSS_BUILD}" \
 	--env TARGET_ARCH="${TARGET_ARCH}" \
 	--env ARCH="${ARCH}" \

--- a/tools/packaging/kata-deploy/shim-components.json
+++ b/tools/packaging/kata-deploy/shim-components.json
@@ -28,10 +28,10 @@
       "x86_64": ["shim-v2-rust", "qemu-tdx-experimental", "virtiofsd", "kernel", "rootfs-image-confidential", "ovmf-tdx"]
     },
     "qemu-se": {
-      "s390x": ["shim-v2-go", "qemu", "virtiofsd", "kernel", "rootfs-image-confidential"]
+      "s390x": ["shim-v2-go", "qemu", "virtiofsd", "kernel", "rootfs-initrd-confidential", "boot-image-se"]
     },
     "qemu-se-runtime-rs": {
-      "s390x": ["shim-v2-rust", "qemu", "virtiofsd", "kernel", "rootfs-image-confidential"]
+      "s390x": ["shim-v2-rust", "qemu", "virtiofsd", "kernel", "rootfs-initrd-confidential", "boot-image-se"]
     },
     "qemu-nvidia-gpu": {
       "x86_64": ["shim-v2-go", "qemu", "virtiofsd", "kernel-nvidia-gpu", "rootfs-image-nvidia-gpu", "ovmf"]


### PR DESCRIPTION
This PR streamlines the s390x SE build process and makes it easier to test without requiring actual Secure Execution infrastructure. This also fixes deployment issues on non-TEE systems where TEE-specific artifacts (like boot-image-se for IBM SEL) are not included in the kata-deploy image, while ensuring TEE systems still get all required components

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>