### PR TITLE
runtime: Add VM Templating support for CLH

### DIFF
--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -2062,12 +2062,6 @@ func checkNetNsConfig(config oci.RuntimeConfig) error {
 
 // checkFactoryConfig ensures the VM factory configuration is valid.
 func checkFactoryConfig(config oci.RuntimeConfig) error {
-	if config.FactoryConfig.Template {
-		if config.HypervisorConfig.InitrdPath == "" {
-			return errors.New("Factory option enable_template requires an initrd image")
-		}
-	}
-
 	if config.FactoryConfig.VMCacheNumber > 0 {
 		if config.HypervisorType != vc.QemuHypervisor {
 			return errors.New("VM cache just support qemu")

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -1696,7 +1696,7 @@ func TestCheckFactoryConfig(t *testing.T) {
 		{false, false, "", "initrd"},
 
 		{true, false, "", "initrd"},
-		{true, true, "image", ""},
+		{true, false, "image", ""},
 	}
 
 	for i, d := range data {

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -1377,6 +1377,56 @@ func (clh *cloudHypervisor) SaveVM() error {
 		return openAPIClientError(err)
 	}
 
+	if clh.config.BootToBeTemplate {
+		// Update the config.json file in the snapshotDir to set memory shared=false
+		snapshotConfigPath := filepath.Join(snapshotDir, "config.json")
+		snapshotConfig, err := os.ReadFile(snapshotConfigPath)
+		if err != nil {
+			clh.Logger().WithError(err).Error("Failed to read snapshot config")
+			return err
+		}
+
+		var snapshotConfigData map[string]interface{}
+		if err := json.Unmarshal(snapshotConfig, &snapshotConfigData); err != nil {
+			clh.Logger().WithError(err).Error("Failed to unmarshal snapshot config")
+			return err
+		}
+
+		// Access the memory section and cast it to a map
+		if memorySection, ok := snapshotConfigData["memory"].(map[string]interface{}); ok {
+			memorySection["shared"] = false
+			// Do the same update for each element fo the "zones" array in the memorySection
+			if zones, ok := memorySection["zones"].([]interface{}); ok {
+				for _, zone := range zones {
+					if zoneMap, ok := zone.(map[string]interface{}); ok {
+						zoneMap["shared"] = false
+					} else {
+						clh.Logger().Error("Unable to access zone in snapshot config memory section")
+						return fmt.Errorf("invalid snapshot config structure: zone in memory section not found or invalid")
+					}
+				}
+			} else {
+				clh.Logger().Error("Unable to access zones array in snapshot config memory section")
+				return fmt.Errorf("invalid snapshot config structure: zones array in memory section not found or invalid")
+			}
+		} else {
+			clh.Logger().Error("Unable to access memory section in snapshot config")
+			return fmt.Errorf("invalid snapshot config structure: memory section not found or invalid")
+		}
+
+		// Write the modified config back to file
+		modifiedConfig, err := json.Marshal(snapshotConfigData)
+		if err != nil {
+			clh.Logger().WithError(err).Error("Failed to marshal modified snapshot config")
+			return err
+		}
+
+		if err := os.WriteFile(snapshotConfigPath, modifiedConfig, 0644); err != nil {
+			clh.Logger().WithError(err).Error("Failed to write modified snapshot config")
+			return err
+		}
+	}
+
 	return nil
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -112,6 +112,10 @@ type clhClient interface {
 	VmAddDevicePut(ctx context.Context, deviceConfig chclient.DeviceConfig) (chclient.PciDeviceInfo, *http.Response, error)
 	// Add a new disk device to the VM
 	VmAddDiskPut(ctx context.Context, diskConfig chclient.DiskConfig) (chclient.PciDeviceInfo, *http.Response, error)
+	// Pause the VM
+	VmPausePut(ctx context.Context) (*http.Response, error)
+	// Create a snapshot of the VM
+	VmSnapshotPut(ctx context.Context, vmSnapshotConfig chclient.VmSnapshotConfig) (*http.Response, error)
 	// Remove a device from the VM
 	VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error)
 }
@@ -151,6 +155,14 @@ func (c *clhClientApi) VmAddDevicePut(ctx context.Context, deviceConfig chclient
 
 func (c *clhClientApi) VmAddDiskPut(ctx context.Context, diskConfig chclient.DiskConfig) (chclient.PciDeviceInfo, *http.Response, error) {
 	return c.ApiInternal.VmAddDiskPut(ctx).DiskConfig(diskConfig).Execute()
+}
+
+func (c *clhClientApi) VmPausePut(ctx context.Context) (*http.Response, error) {
+	return c.ApiInternal.PauseVM(ctx).Execute()
+}
+
+func (c *clhClientApi) VmSnapshotPut(ctx context.Context, vmSnapshotConfig chclient.VmSnapshotConfig) (*http.Response, error) {
+	return c.ApiInternal.VmSnapshotPut(ctx).VmSnapshotConfig(vmSnapshotConfig).Execute()
 }
 
 func (c *clhClientApi) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error) {
@@ -1287,11 +1299,41 @@ func (clh *cloudHypervisor) Cleanup(ctx context.Context) error {
 
 func (clh *cloudHypervisor) PauseVM(ctx context.Context) error {
 	clh.Logger().WithField("function", "PauseVM").Info("Pause Sandbox")
+
+	cl := clh.client()
+	ctx, cancel := context.WithTimeout(ctx, clh.getClhAPITimeout()*time.Second)
+	defer cancel()
+
+	_, err := cl.VmPausePut(ctx)
+	if err != nil {
+		clh.Logger().WithError(err).Error("Failed to pause VM")
+		return openAPIClientError(err)
+	}
+
 	return nil
 }
 
 func (clh *cloudHypervisor) SaveVM() error {
-	clh.Logger().WithField("function", "saveSandboxC").Info("Save Sandbox")
+	clh.Logger().WithField("function", "SaveVM").Info("Save Sandbox")
+
+	cl := clh.client()
+	ctx, cancel := context.WithTimeout(context.Background(), clh.getClhAPITimeout()*time.Second)
+	defer cancel()
+
+	// Create snapshot config with file URL to template path
+	// Use MemoryPath as base for snapshot destination
+	// When creating a template, the MemoryPath is set to the template path, so we can use it to save the snapshot.
+	fileURL := "file://" + filepath.Dir(clh.config.MemoryPath)
+
+	vmSnapshotConfig := *chclient.NewVmSnapshotConfig()
+	vmSnapshotConfig.SetDestinationUrl(fileURL)
+
+	_, err := cl.VmSnapshotPut(ctx, vmSnapshotConfig)
+	if err != nil {
+		clh.Logger().WithError(err).Error("Failed to save VM snapshot")
+		return openAPIClientError(err)
+	}
+
 	return nil
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -585,28 +585,57 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 		}
 	}
 
-	// Create the VM memory config via the constructor to ensure default values are properly assigned
-	clh.vmconfig.Memory = chclient.NewMemoryConfig(int64((utils.MemUnit(clh.config.MemorySize) * utils.MiB).ToBytes()))
-	// Memory config shared is to be enabled when using vhost_user backends, ex. virtio-fs
-	// or when using HugePages.
-	// If such features are disabled, turn off shared memory config.
-	if clh.config.SharedFS == config.NoSharedFS && !clh.config.HugePages {
-		clh.vmconfig.Memory.Shared = func(b bool) *bool { return &b }(false)
-	} else {
-		clh.vmconfig.Memory.Shared = func(b bool) *bool { return &b }(true)
-	}
-	// Enable hugepages if needed
-	clh.vmconfig.Memory.Hugepages = func(b bool) *bool { return &b }(clh.config.HugePages)
-	if !clh.config.ConfidentialGuest {
-		hotplugSize := clh.config.DefaultMaxMemorySize
-		// OpenAPI only supports int64 values
-		clh.vmconfig.Memory.HotplugSize = func(i int64) *int64 { return &i }(int64((utils.MemUnit(hotplugSize) * utils.MiB).ToBytes()))
+	// If the VM is booting from a template, or if the VM is going to be used as a template
+	// the memory is to be backed by a file, so we need to configure the memory zones accordingly.
+	if clh.config.BootFromTemplate || clh.config.BootToBeTemplate {
+		// Double-check that the clh.config.MemoryPath file exists before using it in the VM config, to avoid hitting a less clear error from cloud hypervisor when it tries to access the non-existing memory file.
+		if _, err := os.Stat(clh.config.MemoryPath); os.IsNotExist(err) {
+			return fmt.Errorf("memory file %s does not exist", clh.config.MemoryPath)
+		}
 
-		if clh.config.ReclaimGuestFreedMemory {
-			// Create VM with a balloon config so we can enable free page reporting (size of the balloon can be set to zero)
-			clh.vmconfig.Balloon = chclient.NewBalloonConfig(0)
-			// Set the free page reporting flag for ballooning to be true
-			clh.vmconfig.Balloon.SetFreePageReporting(true)
+		// Set the size to be 0 since we are going to configure actual size via zones
+		clh.vmconfig.Memory = chclient.NewMemoryConfig(0)
+
+		memoryZoneConfig := chclient.NewMemoryZoneConfig("mem0", int64((utils.MemUnit(clh.config.MemorySize) * utils.MiB).ToBytes()))
+		if clh.config.BootToBeTemplate {
+			// When BootToBeTemplate is true, the memory file backing the VM memory is shared between multiple VMs created from the same template.
+			// So we need to set shared to true in this case.
+			memoryZoneConfig.SetShared(true)
+			clh.vmconfig.Memory.Shared = func(b bool) *bool { return &b }(true)
+		} else {
+			// When BootFromTemplate is true, set shared=false to ensure Copy-On-Write is used for the memory file.
+			// So that the VM can have its own private memory.
+			memoryZoneConfig.SetShared(false)
+			clh.vmconfig.Memory.Shared = func(b bool) *bool { return &b }(false)
+		}
+		memoryZoneConfig.SetFile(clh.config.MemoryPath)
+		clh.vmconfig.Memory.Zones = &[]chclient.MemoryZoneConfig{
+			*memoryZoneConfig,
+		}
+	} else { // Normal (non-template) VM creation
+		// Create the VM memory config via the constructor to ensure default values are properly assigned
+		clh.vmconfig.Memory = chclient.NewMemoryConfig(int64((utils.MemUnit(clh.config.MemorySize) * utils.MiB).ToBytes()))
+		// Memory config shared is to be enabled when using vhost_user backends, ex. virtio-fs
+		// or when using HugePages.
+		// If such features are disabled, turn off shared memory config.
+		if clh.config.SharedFS == config.NoSharedFS && !clh.config.HugePages {
+			clh.vmconfig.Memory.Shared = func(b bool) *bool { return &b }(false)
+		} else {
+			clh.vmconfig.Memory.Shared = func(b bool) *bool { return &b }(true)
+		}
+		// Enable hugepages if needed
+		clh.vmconfig.Memory.Hugepages = func(b bool) *bool { return &b }(clh.config.HugePages)
+		if !clh.config.ConfidentialGuest {
+			hotplugSize := clh.config.DefaultMaxMemorySize
+			// OpenAPI only supports int64 values
+			clh.vmconfig.Memory.HotplugSize = func(i int64) *int64 { return &i }(int64((utils.MemUnit(hotplugSize) * utils.MiB).ToBytes()))
+
+			if clh.config.ReclaimGuestFreedMemory {
+				// Create VM with a balloon config so we can enable free page reporting (size of the balloon can be set to zero)
+				clh.vmconfig.Balloon = chclient.NewBalloonConfig(0)
+				// Set the free page reporting flag for ballooning to be true
+				clh.vmconfig.Balloon.SetFreePageReporting(true)
+			}
 		}
 	}
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -68,6 +68,7 @@ const (
 const (
 	clhStateCreated = "Created"
 	clhStateRunning = "Running"
+	clhStatePaused  = "Paused"
 )
 
 const (
@@ -84,6 +85,7 @@ const (
 	clhHotPlugAPITimeout                   = 5
 	clhStopSandboxTimeout                  = 3
 	clhStopSandboxTimeoutConfidentialGuest = 10
+	clhRestoreTimeout                      = 2
 	clhSocket                              = "clh.sock"
 	clhAPISocket                           = "clh-api.sock"
 	virtioFsSocket                         = "virtiofsd.sock"
@@ -118,6 +120,8 @@ type clhClient interface {
 	VmSnapshotPut(ctx context.Context, vmSnapshotConfig chclient.VmSnapshotConfig) (*http.Response, error)
 	// Remove a device from the VM
 	VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error)
+	// Restore VM from a snapshot
+	VmRestorePut(ctx context.Context, restoreConfig chclient.RestoreConfig) (*http.Response, error)
 }
 
 type clhClientApi struct {
@@ -167,6 +171,10 @@ func (c *clhClientApi) VmSnapshotPut(ctx context.Context, vmSnapshotConfig chcli
 
 func (c *clhClientApi) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error) {
 	return c.ApiInternal.VmRemoveDevicePut(ctx).VmRemoveDevice(vmRemoveDevice).Execute()
+}
+
+func (c *clhClientApi) VmRestorePut(ctx context.Context, restoreConfig chclient.RestoreConfig) (*http.Response, error) {
+	return c.ApiInternal.VmRestorePut(ctx).RestoreConfig(restoreConfig).Execute()
 }
 
 // This is done in order to be able to override such a function as part of
@@ -1780,6 +1788,58 @@ func (clh *cloudHypervisor) bootVM(ctx context.Context) error {
 		return fmt.Errorf("VM state is not 'Running' after 'BootVM'")
 	}
 
+	return nil
+}
+
+func (clh *cloudHypervisor) restoreVM(ctx context.Context) error {
+	clh.Logger().Info("Restoring VM from template")
+
+	cl := clh.client()
+
+	// use the VMStorePath as the base for the restore source URL
+	snapshotDir := clh.config.VMStorePath
+
+	// check if the snapshot directory contains the state.json and config.json files
+	// which contain the VM state and configuration respectively
+	stateFile := filepath.Join(snapshotDir, "state.json")
+	configFile := filepath.Join(snapshotDir, "config.json")
+
+	if _, err := os.Stat(stateFile); err != nil {
+		return fmt.Errorf("Failed to access state file %s: %v", stateFile, err)
+	}
+
+	if _, err := os.Stat(configFile); err != nil {
+		return fmt.Errorf("Failed to access config file %s: %v", configFile, err)
+	}
+
+	// Prepare restore configuration
+	sourceURL := "file://" + snapshotDir
+	restoreConfig := *chclient.NewRestoreConfig(sourceURL)
+
+	clh.Logger().WithField("sourceURL", sourceURL).Debug("Restore configuration")
+
+	// Restore VM from template
+	ctxWithTimeout, cancelRestore := context.WithTimeout(ctx, clhRestoreTimeout*time.Second)
+	defer cancelRestore()
+	_, err := cl.VmRestorePut(ctxWithTimeout, restoreConfig)
+	if err != nil {
+		clh.Logger().WithError(err).Error("Failed to restore VM from template")
+		return openAPIClientError(err)
+	}
+
+	// Check VM state after restoration
+	info, err := clh.vmInfo()
+	if err != nil {
+		return err
+	}
+
+	clh.Logger().Debugf("VM state after restore: %#v", info)
+
+	if info.State != clhStatePaused {
+		clh.Logger().Warnf("VM state is '%s' after restore, expected 'Paused'", info.State)
+	}
+
+	clh.Logger().Info("Successfully restored VM from template")
 	return nil
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -122,6 +122,8 @@ type clhClient interface {
 	VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error)
 	// Restore VM from a snapshot
 	VmRestorePut(ctx context.Context, restoreConfig chclient.RestoreConfig) (*http.Response, error)
+	// Resume a paused VM
+	ResumeVM(ctx context.Context) (*http.Response, error)
 }
 
 type clhClientApi struct {
@@ -175,6 +177,10 @@ func (c *clhClientApi) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chc
 
 func (c *clhClientApi) VmRestorePut(ctx context.Context, restoreConfig chclient.RestoreConfig) (*http.Response, error) {
 	return c.ApiInternal.VmRestorePut(ctx).RestoreConfig(restoreConfig).Execute()
+}
+
+func (c *clhClientApi) ResumeVM(ctx context.Context) (*http.Response, error) {
+	return c.ApiInternal.ResumeVM(ctx).Execute()
 }
 
 // This is done in order to be able to override such a function as part of
@@ -1347,6 +1353,16 @@ func (clh *cloudHypervisor) SaveVM() error {
 
 func (clh *cloudHypervisor) ResumeVM(ctx context.Context) error {
 	clh.Logger().WithField("function", "ResumeVM").Info("Resume Sandbox")
+	cl := clh.client()
+	ctx, cancel := context.WithTimeout(ctx, clh.getClhAPITimeout()*time.Second)
+	defer cancel()
+
+	_, err := cl.ResumeVM(ctx)
+	if err != nil {
+		clh.Logger().WithError(err).Error("Failed to resume VM")
+		return openAPIClientError(err)
+	}
+
 	return nil
 }
 

--- a/src/runtime/virtcontainers/clh.go
+++ b/src/runtime/virtcontainers/clh.go
@@ -281,12 +281,14 @@ type CloudHypervisorState struct {
 	PID               int
 	VirtiofsDaemonPid int
 	state             clhState
+	isRestoring       bool
 }
 
 func (s *CloudHypervisorState) reset() {
 	s.PID = 0
 	s.VirtiofsDaemonPid = 0
 	s.state = clhNotReady
+	s.isRestoring = false
 }
 
 type cloudHypervisor struct {
@@ -527,7 +529,7 @@ func getNonUserDefinedKernelParams(rootfstype string, disableNvdimm bool, dax bo
 }
 
 // For cloudHypervisor this call only sets the internal structure up.
-// The VM will be created and started through StartVM().
+// The VM will be created and started through StartVM(), or restored from template if template files exist.
 func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Network, hypervisorConfig *HypervisorConfig) error {
 	clh.ctx = ctx
 
@@ -755,7 +757,102 @@ func (clh *cloudHypervisor) CreateVM(ctx context.Context, id string, network Net
 		return err
 	}
 
+	// Check if we should restore from template instead of creating new VM
+	if clh.config.BootFromTemplate && clh.shouldRestoreFromTemplate() {
+		clh.Logger().Info("Template files found, will restore VM instead of creating new")
+		// Mark this as a restore operation for StartVM to use RestoreVM instead
+		clh.state.isRestoring = true
+		return nil
+	}
+
 	return nil
+}
+
+// shouldRestoreFromTemplate checks if template snapshot files exist and we should restore instead of creating new VM
+func (clh *cloudHypervisor) shouldRestoreFromTemplate() bool {
+	// For template restore, we need the snapshot directory to contain the necessary files
+	// The snapshotDir is derived from the MemoryPath directory
+	snapshotDir := filepath.Dir(clh.config.MemoryPath)
+
+	// Check for required template files (config.json and memory file)
+	configFile := filepath.Join(snapshotDir, "config.json")
+	memoryFile := clh.config.MemoryPath
+
+	if _, err := os.Stat(configFile); os.IsNotExist(err) {
+		clh.Logger().WithField("configFile", configFile).Debug("Template config file not found")
+		return false
+	}
+
+	if _, err := os.Stat(memoryFile); os.IsNotExist(err) {
+		clh.Logger().WithField("memoryFile", memoryFile).Debug("Template memory file not found")
+		return false
+	}
+
+	clh.Logger().WithFields(log.Fields{
+		"configFile": configFile,
+		"memoryFile": memoryFile,
+	}).Info("Template files found, can restore VM from template")
+
+	return true
+}
+
+// copyFile copies a file from src to dst
+func (clh *cloudHypervisor) copyFile(src, dst string) error {
+	srcFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer srcFile.Close()
+
+	dstFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer dstFile.Close()
+
+	_, err = io.Copy(dstFile, srcFile)
+	if err != nil {
+		return err
+	}
+
+	return dstFile.Sync()
+}
+
+// updateVsockSocketPath updates the vsock socket path in the config.json file
+func (clh *cloudHypervisor) updateVsockSocketPath(configPath, vmID string) error {
+	// Read the config file
+	configData, err := os.ReadFile(configPath)
+	if err != nil {
+		return err
+	}
+
+	var config map[string]interface{}
+	if err := json.Unmarshal(configData, &config); err != nil {
+		return err
+	}
+
+	// Update vsock socket path if vsock exists
+	if vsock, ok := config["vsock"].(map[string]interface{}); ok {
+		// Generate new vsock socket path for this VM
+		newVsockPath, err := clh.vsockSocketPath(vmID)
+		if err != nil {
+			return err
+		}
+		vsock["socket"] = newVsockPath
+
+		clh.Logger().WithFields(log.Fields{
+			"vmID":         vmID,
+			"newVsockPath": newVsockPath,
+		}).Debug("Updated vsock socket path in config.json")
+	}
+
+	// Write the updated config back to file
+	updatedConfig, err := json.Marshal(config)
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(configPath, updatedConfig, 0644)
 }
 
 // setupInitdata prepares and attaches the initdata disk if present.
@@ -826,8 +923,37 @@ func (clh *cloudHypervisor) StartVM(ctx context.Context, timeout int) error {
 	ctx, cancel := context.WithTimeout(ctx, bootTimeout*time.Second)
 	defer cancel()
 
-	if err := clh.bootVM(ctx); err != nil {
-		return err
+	// Check if we should restore from template or create new VM
+	if clh.state.isRestoring {
+		// Copy template files to VM directory
+		snapshotDir := filepath.Dir(clh.config.MemoryPath)
+
+		// Copy config.json from template to VM directory
+		srcConfig := filepath.Join(snapshotDir, "config.json")
+		dstConfig := filepath.Join(vmPath, "config.json")
+		if err := clh.copyFile(srcConfig, dstConfig); err != nil {
+			return fmt.Errorf("failed to copy config.json: %v", err)
+		}
+
+		// Copy state.json from template to VM directory
+		srcState := filepath.Join(snapshotDir, "state.json")
+		dstState := filepath.Join(vmPath, "state.json")
+		if err := clh.copyFile(srcState, dstState); err != nil {
+			return fmt.Errorf("failed to copy state.json: %v", err)
+		}
+
+		// Update vsock socket path in the copied config.json
+		if err := clh.updateVsockSocketPath(dstConfig, clh.id); err != nil {
+			return fmt.Errorf("failed to update vsock socket path: %v", err)
+		}
+
+		if err := clh.restoreVM(ctx); err != nil {
+			return err
+		}
+	} else {
+		if err := clh.bootVM(ctx); err != nil {
+			return err
+		}
 	}
 
 	clh.state.state = clhReady
@@ -1363,10 +1489,11 @@ func (clh *cloudHypervisor) SaveVM() error {
 	ctx, cancel := context.WithTimeout(context.Background(), clh.getClhAPITimeout()*time.Second)
 	defer cancel()
 
+	snapshotDir := filepath.Dir(clh.config.MemoryPath)
 	// Create snapshot config with file URL to template path
 	// Use MemoryPath as base for snapshot destination
 	// When creating a template, the MemoryPath is set to the template path, so we can use it to save the snapshot.
-	fileURL := "file://" + filepath.Dir(clh.config.MemoryPath)
+	fileURL := "file://" + snapshotDir
 
 	vmSnapshotConfig := *chclient.NewVmSnapshotConfig()
 	vmSnapshotConfig.SetDestinationUrl(fileURL)
@@ -1892,12 +2019,13 @@ func (clh *cloudHypervisor) restoreVM(ctx context.Context) error {
 	cl := clh.client()
 
 	// use the VMStorePath as the base for the restore source URL
-	snapshotDir := clh.config.VMStorePath
+	vmPath := filepath.Join(clh.config.VMStorePath, clh.id)
+	sourceURL := "file://" + vmPath
 
 	// check if the snapshot directory contains the state.json and config.json files
 	// which contain the VM state and configuration respectively
-	stateFile := filepath.Join(snapshotDir, "state.json")
-	configFile := filepath.Join(snapshotDir, "config.json")
+	stateFile := filepath.Join(vmPath, "state.json")
+	configFile := filepath.Join(vmPath, "config.json")
 
 	if _, err := os.Stat(stateFile); err != nil {
 		return fmt.Errorf("Failed to access state file %s: %v", stateFile, err)
@@ -1908,7 +2036,6 @@ func (clh *cloudHypervisor) restoreVM(ctx context.Context) error {
 	}
 
 	// Prepare restore configuration
-	sourceURL := "file://" + snapshotDir
 	restoreConfig := *chclient.NewRestoreConfig(sourceURL)
 
 	clh.Logger().WithField("sourceURL", sourceURL).Debug("Restore configuration")

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -74,8 +74,9 @@ func newClhConfig() (HypervisorConfig, error) {
 }
 
 type clhClientMock struct {
-	vmInfo         chclient.VmInfo
-	restoreRequest *chclient.RestoreConfig
+	vmInfo          chclient.VmInfo
+	restoreRequest  *chclient.RestoreConfig
+	snapshotRequest *chclient.VmSnapshotConfig
 }
 
 func (c *clhClientMock) VmmPingGet(ctx context.Context) (chclient.VmmPingResponse, *http.Response, error) {
@@ -124,6 +125,7 @@ func (c *clhClientMock) VmPausePut(ctx context.Context) (*http.Response, error) 
 
 //nolint:golint
 func (c *clhClientMock) VmSnapshotPut(ctx context.Context, vmSnapshotConfig chclient.VmSnapshotConfig) (*http.Response, error) {
+	c.snapshotRequest = &vmSnapshotConfig
 	return nil, nil
 }
 
@@ -584,6 +586,34 @@ func TestClhRestoreVM(t *testing.T) {
 	info, err := clh.vmInfo()
 	assert.NoError(err)
 	assert.Equal(clhStatePaused, info.State)
+}
+
+func TestClhSaveVM(t *testing.T) {
+	assert := assert.New(t)
+
+	store, err := persist.GetDriver()
+	assert.NoError(err)
+
+	clhConfig, err := newClhConfig()
+	assert.NoError(err)
+	// For testing, assume the memory path is located within the VM store path.
+	clhConfig.MemoryPath = filepath.Join(store.RunVMStoragePath(), "memory")
+	clhConfig.VMStorePath = store.RunVMStoragePath()
+	clhConfig.RunStorePath = store.RunStoragePath()
+
+	mockClient := &clhClientMock{}
+	clh := &cloudHypervisor{
+		config:    clhConfig,
+		APIClient: mockClient,
+	}
+
+	err = clh.SaveVM()
+	assert.NoError(err)
+
+	if assert.NotNil(mockClient.snapshotRequest) {
+		expectedDestinationURL := "file://" + filepath.Dir(clhConfig.MemoryPath)
+		assert.Equal(expectedDestinationURL, mockClient.snapshotRequest.GetDestinationUrl())
+	}
 }
 
 func TestCloudHypervisorStartSandbox(t *testing.T) {

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -118,6 +118,7 @@ func (c *clhClientMock) VmAddDiskPut(ctx context.Context, diskConfig chclient.Di
 
 //nolint:golint
 func (c *clhClientMock) VmPausePut(ctx context.Context) (*http.Response, error) {
+	c.vmInfo.State = clhStatePaused
 	return nil, nil
 }
 
@@ -139,6 +140,7 @@ func (c *clhClientMock) VmRestorePut(ctx context.Context, restoreConfig chclient
 }
 
 func (c *clhClientMock) ResumeVM(ctx context.Context) (*http.Response, error) {
+	c.vmInfo.State = clhStateRunning
 	return nil, nil
 }
 

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -116,6 +116,16 @@ func (c *clhClientMock) VmAddDiskPut(ctx context.Context, diskConfig chclient.Di
 }
 
 //nolint:golint
+func (c *clhClientMock) VmPausePut(ctx context.Context) (*http.Response, error) {
+	return nil, nil
+}
+
+//nolint:golint
+func (c *clhClientMock) VmSnapshotPut(ctx context.Context, vmSnapshotConfig chclient.VmSnapshotConfig) (*http.Response, error) {
+	return nil, nil
+}
+
+//nolint:golint
 func (c *clhClientMock) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error) {
 	return nil, nil
 }

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -74,7 +74,8 @@ func newClhConfig() (HypervisorConfig, error) {
 }
 
 type clhClientMock struct {
-	vmInfo chclient.VmInfo
+	vmInfo         chclient.VmInfo
+	restoreRequest *chclient.RestoreConfig
 }
 
 func (c *clhClientMock) VmmPingGet(ctx context.Context) (chclient.VmmPingResponse, *http.Response, error) {
@@ -127,6 +128,13 @@ func (c *clhClientMock) VmSnapshotPut(ctx context.Context, vmSnapshotConfig chcl
 
 //nolint:golint
 func (c *clhClientMock) VmRemoveDevicePut(ctx context.Context, vmRemoveDevice chclient.VmRemoveDevice) (*http.Response, error) {
+	return nil, nil
+}
+
+func (c *clhClientMock) VmRestorePut(ctx context.Context, restoreConfig chclient.RestoreConfig) (*http.Response, error) {
+	c.restoreRequest = &restoreConfig
+	// restoreVM() verifies Paused after restore.
+	c.vmInfo.State = clhStatePaused
 	return nil, nil
 }
 
@@ -524,6 +532,52 @@ func TestClhCreateVM(t *testing.T) {
 			assert.Exactly(d.config, clh.config, msg)
 		}
 	}
+}
+
+func TestClhRestoreVM(t *testing.T) {
+	assert := assert.New(t)
+
+	store, err := persist.GetDriver()
+	assert.NoError(err)
+
+	clhConfig, err := newClhConfig()
+	assert.NoError(err)
+	clhConfig.VMStorePath = store.RunVMStoragePath()
+	clhConfig.RunStorePath = store.RunStoragePath()
+
+	mockClient := &clhClientMock{}
+	clh := &cloudHypervisor{
+		config:    clhConfig,
+		APIClient: mockClient,
+	}
+
+	// First call restoreVM without the VM snapshot files (state.json, config.json) present.
+	err = clh.restoreVM(context.Background())
+	// An error is expected because restoreVM expects the VM snapshot files to be present.
+	assert.Error(err)
+	assert.Contains(err.Error(), filepath.Join(clhConfig.VMStorePath, "state.json"))
+
+	// Now create the VM snapshot files and call restoreVM again.
+	os.MkdirAll(clhConfig.VMStorePath, os.ModePerm)
+	stateFile := filepath.Join(clhConfig.VMStorePath, "state.json")
+	configFile := filepath.Join(clhConfig.VMStorePath, "config.json")
+	err = os.WriteFile(stateFile, []byte("{}"), 0o600)
+	assert.NoError(err)
+	err = os.WriteFile(configFile, []byte("{}"), 0o600)
+	assert.NoError(err)
+
+	// Call restoreVM again, this time it should succeed.
+	err = clh.restoreVM(context.Background())
+	assert.NoError(err)
+
+	if assert.NotNil(mockClient.restoreRequest) {
+		expectedSourceURL := "file://" + clhConfig.VMStorePath
+		assert.Equal(expectedSourceURL, mockClient.restoreRequest.GetSourceUrl())
+	}
+
+	info, err := clh.vmInfo()
+	assert.NoError(err)
+	assert.Equal(clhStatePaused, info.State)
 }
 
 func TestCloudHypervisorStartSandbox(t *testing.T) {

--- a/src/runtime/virtcontainers/clh_test.go
+++ b/src/runtime/virtcontainers/clh_test.go
@@ -138,6 +138,10 @@ func (c *clhClientMock) VmRestorePut(ctx context.Context, restoreConfig chclient
 	return nil, nil
 }
 
+func (c *clhClientMock) ResumeVM(ctx context.Context) (*http.Response, error) {
+	return nil, nil
+}
+
 func TestCloudHypervisorAddVSock(t *testing.T) {
 	assert := assert.New(t)
 	clh := cloudHypervisor{}

--- a/src/runtime/virtcontainers/factory/factory_linux.go
+++ b/src/runtime/virtcontainers/factory/factory_linux.go
@@ -80,6 +80,9 @@ func resetHypervisorConfig(config *vc.VMConfig) {
 	config.HypervisorConfig.SharedPath = ""
 	config.HypervisorConfig.VMStorePath = ""
 	config.HypervisorConfig.RunStorePath = ""
+	config.HypervisorConfig.SandboxName = ""
+	config.HypervisorConfig.SandboxNamespace = ""
+	config.HypervisorConfig.DefaultMaxVCPUs = 0
 }
 
 // It's important that baseConfig and newConfig are passed by value!

--- a/src/runtime/virtcontainers/factory/template/template_linux.go
+++ b/src/runtime/virtcontainers/factory/template/template_linux.go
@@ -134,6 +134,7 @@ func (t *template) createTemplateVM(ctx context.Context) error {
 	config.HypervisorConfig.BootFromTemplate = false
 	config.HypervisorConfig.MemoryPath = t.statePath + "/memory"
 	config.HypervisorConfig.DevicesStatePath = t.statePath + "/state"
+	config.HypervisorConfig.VMStorePath = t.statePath
 
 	vm, err := vc.NewVM(ctx, config)
 	if err != nil {

--- a/src/runtime/virtcontainers/factory/template/template_linux.go
+++ b/src/runtime/virtcontainers/factory/template/template_linux.go
@@ -115,6 +115,15 @@ func (t *template) prepareTemplateFiles() error {
 	}
 	f.Close()
 
+	// truncate the memory file to the exact size of the VM memory
+	memoryInBytes := int64(t.config.HypervisorConfig.MemorySize) * 1024 * 1024
+	t.Logger().Infof("truncating memory file %s to %d bytes", t.statePath+"/memory", memoryInBytes)
+	err = os.Truncate(t.statePath+"/memory", memoryInBytes)
+	if err != nil {
+		t.close()
+		return err
+	}
+
 	return nil
 }
 

--- a/src/runtime/virtcontainers/factory/template/template_linux.go
+++ b/src/runtime/virtcontainers/factory/template/template_linux.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -133,7 +134,7 @@ func (t *template) createTemplateVM(ctx context.Context) error {
 	config.HypervisorConfig.BootToBeTemplate = true
 	config.HypervisorConfig.BootFromTemplate = false
 	config.HypervisorConfig.MemoryPath = t.statePath + "/memory"
-	config.HypervisorConfig.DevicesStatePath = t.statePath + "/state"
+	config.HypervisorConfig.DevicesStatePath = t.deviceStatePath()
 	config.HypervisorConfig.VMStorePath = t.statePath
 
 	vm, err := vc.NewVM(ctx, config)
@@ -171,7 +172,7 @@ func (t *template) createFromTemplateVM(ctx context.Context, c vc.VMConfig) (*vc
 	config.HypervisorConfig.BootToBeTemplate = false
 	config.HypervisorConfig.BootFromTemplate = true
 	config.HypervisorConfig.MemoryPath = t.statePath + "/memory"
-	config.HypervisorConfig.DevicesStatePath = t.statePath + "/state"
+	config.HypervisorConfig.DevicesStatePath = t.deviceStatePath()
 	config.HypervisorConfig.SharedPath = c.HypervisorConfig.SharedPath
 	config.HypervisorConfig.VMStorePath = c.HypervisorConfig.VMStorePath
 	config.HypervisorConfig.RunStorePath = c.HypervisorConfig.RunStorePath
@@ -185,6 +186,15 @@ func (t *template) checkTemplateVM() error {
 		return err
 	}
 
-	_, err = os.Stat(t.statePath + "/state")
+	_, err = os.Stat(t.deviceStatePath())
 	return err
+}
+
+func (t *template) deviceStatePath() string {
+	stateFileName := "state"
+	if t.config.HypervisorType == vc.ClhHypervisor {
+		stateFileName = "state.json"
+	}
+
+	return filepath.Join(t.statePath, stateFileName)
 }

--- a/src/runtime/virtcontainers/factory/template/template_test.go
+++ b/src/runtime/virtcontainers/factory/template/template_test.go
@@ -87,7 +87,7 @@ func TestTemplateFactory(t *testing.T) {
 	err = tt.checkTemplateVM()
 	assert.Error(err)
 
-	_, err = os.Create(tt.statePath + "/state")
+	_, err = os.Create(tt.deviceStatePath())
 	assert.Nil(err)
 	err = tt.checkTemplateVM()
 	assert.Nil(err)

--- a/src/runtime/virtcontainers/factory/template/template_test.go
+++ b/src/runtime/virtcontainers/factory/template/template_test.go
@@ -57,15 +57,26 @@ func TestTemplateFactory(t *testing.T) {
 	assert.NoError(err)
 	defer hybridVSockTTRPCMock.Stop()
 
-	// New
+	// Create 2 sets of instance-specific directories for per-VM storage
+	runStorePath1 := t.TempDir()
+	vmStorePath1 := t.TempDir()
+	runStorePath2 := t.TempDir()
+	vmStorePath2 := t.TempDir()
+
+	// Create a new Template Factory
 	f, err := New(ctx, vmConfig, testDir)
 	assert.Nil(err)
 
 	// Config
 	assert.Equal(f.Config(), vmConfig)
 
-	// GetBaseVM
-	vm, err := f.GetBaseVM(ctx, vmConfig)
+	// GetBaseVM with first instance paths
+	vmConfig1 := vmConfig
+	vmConfig1.HypervisorConfig.RunStorePath = runStorePath1
+	vmConfig1.HypervisorConfig.VMStorePath = vmStorePath1
+
+	// Test the creation of a new VM from the template factory
+	vm, err := f.GetBaseVM(ctx, vmConfig1)
 	assert.Nil(err)
 
 	err = vm.Stop(ctx)
@@ -79,6 +90,8 @@ func TestTemplateFactory(t *testing.T) {
 
 	assert.Equal(tt.Config(), vmConfig)
 
+	// Checking that template VM check fails
+	// if the corresponding memory and state files are absent
 	err = tt.checkTemplateVM()
 	assert.Error(err)
 
@@ -89,34 +102,45 @@ func TestTemplateFactory(t *testing.T) {
 
 	_, err = os.Create(tt.deviceStatePath())
 	assert.Nil(err)
+
+	// After creating state and memory files, checkTemplateVM should succeed
 	err = tt.checkTemplateVM()
 	assert.Nil(err)
 
+	// Recreate the template VM, which should succeed
 	err = tt.createTemplateVM(ctx)
 	assert.Nil(err)
 
-	vm, err = tt.GetBaseVM(ctx, vmConfig)
+	// Ensuring that directly calling template's GetBaseVM function
+	// returns a VM instance similar to the one returned by the factory's GetBaseVM function
+	vm, err = tt.GetBaseVM(ctx, vmConfig1)
 	assert.Nil(err)
 
 	err = vm.Stop(ctx)
 	assert.Nil(err)
 
-	vm, err = f.GetBaseVM(ctx, vmConfig)
+	vm, err = f.GetBaseVM(ctx, vmConfig1)
 	assert.Nil(err)
 
 	err = vm.Stop(ctx)
 	assert.Nil(err)
 
+	// Overwriting the template VM should succeed
 	err = tt.createTemplateVM(ctx)
 	assert.Nil(err)
 
-	vm, err = tt.GetBaseVM(ctx, vmConfig)
+	// Create second instance with different storage paths
+	vmConfig2 := vmConfig
+	vmConfig2.HypervisorConfig.RunStorePath = runStorePath2
+	vmConfig2.HypervisorConfig.VMStorePath = vmStorePath2
+
+	vm, err = tt.GetBaseVM(ctx, vmConfig2)
 	assert.Nil(err)
 
 	err = vm.Stop(ctx)
 	assert.Nil(err)
 
-	vm, err = f.GetBaseVM(ctx, vmConfig)
+	vm, err = f.GetBaseVM(ctx, vmConfig2)
 	assert.Nil(err)
 
 	err = vm.Stop(ctx)

--- a/tests/integration/kubernetes/k8s-vm-templating-test.bats
+++ b/tests/integration/kubernetes/k8s-vm-templating-test.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2024 Kata Containers
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Tests for Kata VM templating (factory) functionality in Kubernetes integration mode
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+get_shim_config_file() {
+	case "${KATA_HYPERVISOR}" in
+		*-runtime-rs)
+			echo "/opt/kata/share/defaults/kata-containers/runtime-rs/runtimes/${KATA_HYPERVISOR}/configuration-${KATA_HYPERVISOR}.toml"
+			;;
+		*)
+			echo "/opt/kata/share/defaults/kata-containers/runtimes/${KATA_HYPERVISOR}/configuration-${KATA_HYPERVISOR}.toml"
+			;;
+	esac
+}
+
+# With setup_file and teardown_file being used, we use >&3 in some places to direct output to the terminal
+# setup_file is used in BATS for one-time initialization for all tests in the file
+setup_file() {
+	if [[ "${KATA_HYPERVISOR}" == *-runtime-rs ]]; then
+		export skip_vm_templating_tests=true
+		return 0
+	fi
+
+	setup_common || die "setup_common failed"
+	config_file="$(get_shim_config_file)"
+	backup_file="${config_file}.bats-vm-templating.bak"
+
+	# Get ALL kata nodes
+	mapfile -t all_nodes < <(kubectl get nodes -l katacontainers.io/kata-runtime=true -o name | sed 's|^node/||')
+	[[ "${#all_nodes[@]}" -gt 0 ]] || die "No Kata nodes found"
+
+	export all_nodes config_file backup_file
+
+	# Configure and initialize VM templates on all Kata nodes
+	for n in "${all_nodes[@]}"; do
+		echo "Configuring and initializing VM template on node: $n" >&3
+		exec_host "$n" "sudo test -f '${backup_file}' || sudo cp '${config_file}' '${backup_file}'" || die "Failed to backup kata config on node $n"
+		exec_host "$n" "sudo sed -i -e 's|^#\\?enable_template[[:space:]]*=.*$|enable_template = true|g' -e 's|^#\\?template_path[[:space:]]*=.*$|template_path = \"/run/vc/vm/template\"|g' -e 's|^#\\?shared_fs[[:space:]]*=.*$|shared_fs = \"none\"|g' '${config_file}'" || die "Failed to update kata config on node $n"
+		exec_host "$n" "sudo grep -q '^enable_template[[:space:]]*=' '${config_file}' || echo 'enable_template = true' | sudo tee -a '${config_file}' >/dev/null" || die "Failed to set enable_template on node $n"
+		exec_host "$n" "sudo grep -q '^template_path[[:space:]]*=' '${config_file}' || echo 'template_path = \"/run/vc/vm/template\"' | sudo tee -a '${config_file}' >/dev/null" || die "Failed to set template_path on node $n"
+		exec_host "$n" "sudo grep -q '^shared_fs[[:space:]]*=' '${config_file}' || echo 'shared_fs = \"none\"' | sudo tee -a '${config_file}' >/dev/null" || die "Failed to set shared_fs on node $n"
+		exec_host "$n" "sudo kata-runtime factory init" || die "Failed to initialize VM template on node $n"
+	done
+
+	echo "VM templates initialized on ${#all_nodes[@]} nodes" >&3
+}
+
+setup() {
+	if [[ "${skip_vm_templating_tests:-false}" == "true" ]]; then
+		skip "VM templating test is only supported for Go runtime"
+	fi
+
+	# Select one node for this test
+	setup_common || die "setup_common failed"
+}
+
+@test "VM template factory is initialized" {
+	# Verify factory state on each node
+	for n in "${all_nodes[@]}"; do
+		exec_host "$n" "test -d /run/vc/vm/template" || skip "VM template directory not found on $n"
+	done
+}
+
+@test "Pod can be created with templated VM" {
+	pod_name="test-templated-pod"
+	ctr_name="test-container"
+
+	pod_config=$(mktemp --tmpdir pod_config.XXXXXX.yaml)
+	cp "$pod_config_dir/busybox-template.yaml" "$pod_config"
+
+	sed -i "s/POD_NAME/$pod_name/" "$pod_config"
+	sed -i "s/CTR_NAME/$ctr_name/" "$pod_config"
+
+	# Create a simple pod to verify templating works
+	kubectl create -f "${pod_config}"
+	kubectl wait --for=condition=Ready --timeout=120s "pod/${pod_name}" || die "Pod failed to reach Ready state"
+
+	# Verify the pod is running
+	kubectl get pod "${pod_name}" | grep Running || die "Pod is not in Running state"
+
+	# Basic test: verify we can execute a command in the pod
+	kubectl exec "${pod_name}" -- sh -c "echo 'Hello from templated VM' && exit 0"
+}
+
+teardown() {
+	# Clean up pod from previous test
+	kubectl delete pod "test-templated-pod" 2>/dev/null || true
+
+	teardown_common "${node}" "${node_start_time:-}"
+}
+
+teardown_file() {
+	if [[ "${skip_vm_templating_tests:-false}" == "true" ]]; then
+		return 0
+	fi
+
+	# Clean up VM templates on all Kata nodes
+	for n in "${all_nodes[@]}"; do
+		echo "Destroying VM template on node: $n" >&3
+		exec_host "$n" "kata-runtime factory destroy" || echo "Warning: Failed to destroy VM template on node $n" >&3
+		exec_host "$n" "if [ -f '${backup_file}' ]; then sudo mv '${backup_file}' '${config_file}'; fi" || echo "Warning: Failed to restore kata config on node $n" >&3
+	done
+
+	echo "VM templates destroyed on ${#all_nodes[@]} nodes" >&3
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -104,6 +104,7 @@ else
 		"k8s-security-context.bats" \
 		"k8s-shared-volume.bats" \
 		"k8s-volume.bats" \
+		"k8s-vm-templating-test.bats" \
 		"k8s-nginx-connectivity.bats" \
 	)
 


### PR DESCRIPTION
This PR provides the implementation of the VM Templating mechanism for Cloud-Hypervisor sandboxes in the Go Runtime. The code changes are of three types, in the order of commits:
- Add the implementation of key VM management functions for Cloud Hypervisor - Pause, Resume, Restore and Snapshot.
- Add VM Templating logic for Cloud Hypervisor and update general templating flow to fix some bugs.
- Add E2E test for VM Templating (only compatible with a Kubeadm K8s cluster on Ubuntu node)

Constraints:
- VM Templating workflow is incompatible with the use of static_sandbox_resource_mgmt. Therefore `static_sandbox_resource_mgmt = false` should be set in the Kata configuration.
- Testing has only been carried out using the EROFS snapshotter, as the replacement of OverlayFS.

## Testing performed
- End to End testing done on Ubuntu:
  - Ubuntu 24.04.4 LTS
  - Kubeadm K8s cluster
  - KVM hypervisor
  - Kernel version: 6.17.0-1013-azure
  - containerd v2.2.3
  - cloud-hypervisor main branch from upstream: commit 2b61bda35
  - mkfs.erofs (erofs-utils) 1.8.10
- Micro benchmarking with containerd (no K8s) done on AzLinux 3.0:
  -  AzL version 3.0.20260401
  - Kernel version: 6.6.121.mshv2
  - containerd v2.1.6
  - cloud-hypervisor msft-main-3.0 branch from LSG fork: commit b760c1b83
  - mkfs.erofs (erofs-utils) 1.8.5