### PR TITLE
kata-deploy: prebuild payload-specific component artifacts

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -159,6 +159,46 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
+  build-kata-deploy-components:
+    name: build-kata-deploy-components
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        component:
+          - kata-deploy-binary
+          - nydus-snapshotter-for-coco-guest-pull
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-amd64-${{ toJSON(matrix) }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Build ${{ matrix.component }}
+        run: |
+          make "${KATA_DEPLOY_COMPONENT}-tarball"
+          mkdir -p kata-deploy-build
+          cp "tools/packaging/kata-deploy/local-build/build/kata-deploy-static-${KATA_DEPLOY_COMPONENT}.tar.zst" kata-deploy-build/
+        env:
+          KATA_DEPLOY_COMPONENT: ${{ matrix.component }}
+
+      - name: store-artifact ${{ matrix.component }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: kata-artifacts-amd64-${{ matrix.component }}${{ inputs.tarball-suffix }}
+          path: kata-deploy-build/kata-deploy-static-${{ matrix.component }}.tar.zst
+          retention-days: 15
+          if-no-files-found: error
+
   build-asset-rootfs:
     name: build-asset-rootfs
     runs-on: ubuntu-22.04

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -149,6 +149,46 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
+  build-kata-deploy-components:
+    name: build-kata-deploy-components
+    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        component:
+          - kata-deploy-binary
+          - nydus-snapshotter-for-coco-guest-pull
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-arm64-${{ toJSON(matrix) }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Build ${{ matrix.component }}
+        run: |
+          make "${KATA_DEPLOY_COMPONENT}-tarball"
+          mkdir -p kata-deploy-build
+          cp "tools/packaging/kata-deploy/local-build/build/kata-deploy-static-${KATA_DEPLOY_COMPONENT}.tar.zst" kata-deploy-build/
+        env:
+          KATA_DEPLOY_COMPONENT: ${{ matrix.component }}
+
+      - name: store-artifact ${{ matrix.component }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: kata-artifacts-arm64-${{ matrix.component }}${{ inputs.tarball-suffix }}
+          path: kata-deploy-build/kata-deploy-static-${{ matrix.component }}.tar.zst
+          retention-days: 15
+          if-no-files-found: error
+
   build-asset-rootfs:
     name: build-asset-rootfs
     runs-on: ubuntu-24.04-arm

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -94,6 +94,46 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+  build-kata-deploy-components:
+    name: build-kata-deploy-components
+    runs-on: ubuntu-24.04-ppc64le
+    strategy:
+      matrix:
+        component:
+          - kata-deploy-binary
+          - nydus-snapshotter-for-coco-guest-pull
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-ppc64le-${{ toJSON(matrix) }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Build ${{ matrix.component }}
+        run: |
+          make "${KATA_DEPLOY_COMPONENT}-tarball"
+          mkdir -p kata-deploy-build
+          cp "tools/packaging/kata-deploy/local-build/build/kata-deploy-static-${KATA_DEPLOY_COMPONENT}.tar.zst" kata-deploy-build/
+        env:
+          KATA_DEPLOY_COMPONENT: ${{ matrix.component }}
+
+      - name: store-artifact ${{ matrix.component }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: kata-artifacts-ppc64le-${{ matrix.component }}${{ inputs.tarball-suffix }}
+          path: kata-deploy-build/kata-deploy-static-${{ matrix.component }}.tar.zst
+          retention-days: 1
+          if-no-files-found: error
+
   build-asset-rootfs:
     name: build-asset-rootfs
     runs-on: ubuntu-24.04-ppc64le

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -127,6 +127,46 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
+  build-kata-deploy-components:
+    name: build-kata-deploy-components
+    runs-on: ubuntu-24.04-s390x
+    strategy:
+      matrix:
+        component:
+          - kata-deploy-binary
+          - nydus-snapshotter-for-coco-guest-pull
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-s390x-${{ toJSON(matrix) }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit-hash }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Rebase atop of the latest target branch
+        run: |
+          ./tests/git-helper.sh "rebase-atop-of-the-latest-target-branch"
+        env:
+          TARGET_BRANCH: ${{ inputs.target-branch }}
+
+      - name: Build ${{ matrix.component }}
+        run: |
+          make "${KATA_DEPLOY_COMPONENT}-tarball"
+          mkdir -p kata-deploy-build
+          cp "tools/packaging/kata-deploy/local-build/build/kata-deploy-static-${KATA_DEPLOY_COMPONENT}.tar.zst" kata-deploy-build/
+        env:
+          KATA_DEPLOY_COMPONENT: ${{ matrix.component }}
+
+      - name: store-artifact ${{ matrix.component }}
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: kata-artifacts-s390x-${{ matrix.component }}${{ inputs.tarball-suffix }}
+          path: kata-deploy-build/kata-deploy-static-${{ matrix.component }}.tar.zst
+          retention-days: 15
+          if-no-files-found: error
+
   build-asset-rootfs:
     name: build-asset-rootfs
     runs-on: s390x

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -98,6 +98,30 @@ jobs:
           RUST_BACKTRACE: "1"
           RUST_LIB_BACKTRACE: "0"
 
+  kata-deploy-binary-build-check:
+    name: kata-deploy-binary-build-check
+    runs-on: ubuntu-22.04
+    needs: skipper
+    if: ${{ needs.skipper.outputs.skip_static != 'yes' }}
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install rust
+        run: |
+          export PATH="$PATH:/usr/local/bin"
+          ./tests/install_rust.sh
+      - name: Run kata-deploy rust checks
+        run: |
+          export PATH="$PATH:${HOME}/.cargo/bin"
+          cargo fmt -p kata-deploy --check
+          cargo clippy -p kata-deploy --all-targets --all-features -- -D warnings
+          RUSTFLAGS="-D warnings" cargo test -p kata-deploy -- --test-threads=1
+
   static-checks:
     name: static-checks
     runs-on: ubuntu-22.04

--- a/tools/packaging/kata-deploy/Dockerfile
+++ b/tools/packaging/kata-deploy/Dockerfile
@@ -3,124 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-#### Nydus snapshotter & nydus image
-
-FROM golang:1.24-alpine AS nydus-binary-downloader
-
-COPY versions.yaml /tmp/versions.yaml
-
-RUN \
-	set -e && \
-	apk add --no-cache curl yq-go && \
-	NYDUS_SNAPSHOTTER_VERSION="$(yq eval -e '.externals.nydus-snapshotter.version | explode(.)' /tmp/versions.yaml)" && \
-	NYDUS_SNAPSHOTTER_REPO="$(yq eval -e '.externals.nydus-snapshotter.url | explode(.)' /tmp/versions.yaml)" && \
-	mkdir -p /opt/nydus-snapshotter && \
-	ARCH="$(uname -m)" && \
-	if [ "${ARCH}" = "x86_64" ]; then ARCH=amd64 ; fi && \
-	if [ "${ARCH}" = "aarch64" ]; then ARCH=arm64; fi && \
-	curl -fOL --progress-bar "${NYDUS_SNAPSHOTTER_REPO}/releases/download/${NYDUS_SNAPSHOTTER_VERSION}/nydus-snapshotter-${NYDUS_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz" && \
-	tar xvzpf "nydus-snapshotter-${NYDUS_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz" -C /opt/nydus-snapshotter && \
-	rm "nydus-snapshotter-${NYDUS_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz"
-
-#### Build binary package
-FROM ubuntu:22.04 AS rust-builder
-
-# Default to Rust 1.90.0
-ARG RUST_TOOLCHAIN=1.90.0
-ENV DEBIAN_FRONTEND=noninteractive
-ENV RUSTUP_HOME="/opt/rustup"
-ENV CARGO_HOME="/opt/cargo"
-ENV PATH="/opt/cargo/bin/:${PATH}"
-
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-RUN \
-	mkdir ${RUSTUP_HOME} ${CARGO_HOME} && \
-	chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
-
-RUN \
-	apt-get update && \
-	apt-get --no-install-recommends -y install \
-		ca-certificates \
-		curl \
-		gcc \
-		libc6-dev \
-		musl-tools && \
-	apt-get clean && rm -rf /var/lib/apt/lists/ && \
-	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
-	rustup component add rustfmt clippy
-
-# Build from the repository root so kata-deploy uses the root Cargo workspace:
-#   docker build -f tools/packaging/kata-deploy/Dockerfile .
-WORKDIR /kata
-
-COPY Cargo.toml Cargo.lock ./
-COPY src ./src
-COPY tools/packaging/kata-deploy/binary ./tools/packaging/kata-deploy/binary
-
-# Install target and run tests based on architecture
-# - AMD64/arm64: use musl for fully static binaries
-# - PPC64le/s390x: use glibc (musl has issues on these platforms)
-RUN \
-	HOST_ARCH="$(uname -m)"; \
-	rust_arch=""; \
-	rust_target=""; \
-	case "${HOST_ARCH}" in \
-		"x86_64") \
-			rust_arch="x86_64"; \
-			rust_target="${rust_arch}-unknown-linux-musl"; \
-			echo "Installing musl target for ${rust_target}"; \
-			rustup target add "${rust_target}"; \
-			;; \
-		"aarch64") \
-			rust_arch="aarch64"; \
-			rust_target="${rust_arch}-unknown-linux-musl"; \
-			echo "Installing musl target for ${rust_target}"; \
-			rustup target add "${rust_target}"; \
-			;; \
-		"ppc64le") \
-			rust_arch="powerpc64le"; \
-			rust_target="${rust_arch}-unknown-linux-gnu"; \
-			echo "Using glibc target for ${rust_target} (musl is not well supported on ppc64le)"; \
-			;; \
-		"s390x") \
-			rust_arch="s390x"; \
-			rust_target="${rust_arch}-unknown-linux-gnu"; \
-			echo "Using glibc target for ${rust_target} (musl is not well supported on s390x)"; \
-			;; \
-		*) echo "Unsupported architecture: ${HOST_ARCH}" && exit 1 ;; \
-	esac; \
-	echo "${rust_target}" > /tmp/rust_target
-
-# Verify code formatting and run cargo check before tests and build
-RUN \
-	set -e && \
-	rust_target="$(cat /tmp/rust_target)" && \
-	echo "Checking code formatting..." && \
-	cargo fmt -p kata-deploy --check && \
-	echo "Code formatting check passed!" && \
-	echo "Running cargo clippy with target ${rust_target}..." && \
-	cargo clippy -p kata-deploy --all-targets --all-features --release --locked --target "${rust_target}" -- -D warnings && \
-	echo "Cargo clippy passed!"
-
-# Run tests using --test-threads=1 to prevent environment variable pollution between tests,
-# and this is fine as we'll never ever have multiple binaries running at the same time.
-RUN \
-	rust_target="$(cat /tmp/rust_target)"; \
-	echo "Running binary tests with target ${rust_target}..." && \
-	RUSTFLAGS="-D warnings" cargo test -p kata-deploy --target "${rust_target}" -- --test-threads=1 && \
-	echo "All tests passed!"
-
-RUN \
-	rust_target="$(cat /tmp/rust_target)"; \
-	echo "Building kata-deploy binary for ${rust_target}..." && \
-	RUSTFLAGS="-D warnings" cargo build --release -p kata-deploy --target "${rust_target}" && \
-	mkdir -p /kata-deploy/bin && \
-	cp "/kata/target/${rust_target}/release/kata-deploy" /kata-deploy/bin/kata-deploy && \
-	echo "Cleaning up build artifacts to save disk space..." && \
-	rm -rf /kata/target && \
-	cargo clean
-
 #### Prepare kata artifact tarballs
 # Individual component tarballs are stored compressed in the image.
 # The installer extracts only those required for the enabled runtime classes.
@@ -129,10 +11,18 @@ FROM alpine:3.22 AS artifact-stage
 ARG KATA_ARTIFACTS_DIR=tools/packaging/kata-deploy/kata-artifacts
 ARG DESTINATION=/opt/kata-artifacts
 
-RUN apk add --no-cache util-linux-misc
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
+RUN apk add --no-cache util-linux-misc zstd
 
 COPY ${KATA_ARTIFACTS_DIR}/kata-static-*.tar.zst ${DESTINATION}/tarballs/
+COPY ${KATA_ARTIFACTS_DIR}/kata-deploy-static-*.tar.zst ${DESTINATION}/tarballs/
 COPY tools/packaging/kata-deploy/shim-components.json ${DESTINATION}/
+
+RUN \
+	mkdir -p /opt/prebuilt && \
+	zstd -dc "${DESTINATION}/tarballs/kata-deploy-static-kata-deploy-binary.tar.zst" | tar -xf - -C /opt/prebuilt && \
+	zstd -dc "${DESTINATION}/tarballs/kata-deploy-static-nydus-snapshotter-for-coco-guest-pull.tar.zst" | tar -xf - -C /opt/prebuilt
 
 #### Prepare runtime dependencies (nsenter and required libraries)
 # This stage assembles all runtime dependencies based on architecture
@@ -149,8 +39,8 @@ RUN \
 		util-linux && \
 	apt-get clean && rm -rf /var/lib/apt/lists/
 
-# Copy the built binary to analyze its dependencies
-COPY --from=rust-builder /kata-deploy/bin/kata-deploy /tmp/kata-deploy
+# Copy the prebuilt binary to analyze its dependencies
+COPY --from=artifact-stage /opt/prebuilt/usr/bin/kata-deploy /tmp/kata-deploy
 
 # Create output directories
 RUN mkdir -p /output/lib /output/lib64 /output/usr/bin
@@ -229,7 +119,7 @@ ARG DESTINATION=/opt/kata-artifacts
 COPY --from=artifact-stage ${DESTINATION} ${DESTINATION}
 
 # Copy Rust binary
-COPY --from=rust-builder /kata-deploy/bin/kata-deploy /usr/bin/kata-deploy
+COPY --from=artifact-stage /opt/prebuilt/usr/bin/kata-deploy /usr/bin/kata-deploy
 
 # Copy nsenter and required libraries (assembled based on architecture)
 COPY --from=runtime-assembler /output/usr/bin/nsenter /usr/bin/nsenter
@@ -238,8 +128,8 @@ COPY --from=runtime-assembler /output/lib64/ /lib64/
 
 # Copy nydus snapshotter
 COPY tools/packaging/kata-deploy/nydus-snapshotter ${DESTINATION}/nydus-snapshotter
-COPY --from=nydus-binary-downloader /opt/nydus-snapshotter/bin/containerd-nydus-grpc ${DESTINATION}/nydus-snapshotter/
-COPY --from=nydus-binary-downloader /opt/nydus-snapshotter/bin/nydus-overlayfs ${DESTINATION}/nydus-snapshotter/
+COPY --from=artifact-stage /opt/prebuilt/opt/kata-artifacts/nydus-snapshotter/containerd-nydus-grpc ${DESTINATION}/nydus-snapshotter/
+COPY --from=artifact-stage /opt/prebuilt/opt/kata-artifacts/nydus-snapshotter/nydus-overlayfs ${DESTINATION}/nydus-snapshotter/
 
 # Copy runtimeclasses and node-feature-rules
 COPY tools/packaging/kata-deploy/node-feature-rules ${DESTINATION}/node-feature-rules

--- a/tools/packaging/kata-deploy/Dockerfile.components
+++ b/tools/packaging/kata-deploy/Dockerfile.components
@@ -1,0 +1,122 @@
+# Copyright Intel Corporation, 2022 IBM Corp.
+# Copyright (c) 2025 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#### Nydus snapshotter & nydus image
+
+FROM alpine:3.22 AS nydus-binary-downloader
+
+COPY versions.yaml /tmp/versions.yaml
+
+RUN \
+	set -e && \
+	apk add --no-cache curl yq-go && \
+	NYDUS_SNAPSHOTTER_VERSION="$(yq eval -e '.externals.nydus-snapshotter.version | explode(.)' /tmp/versions.yaml)" && \
+	NYDUS_SNAPSHOTTER_REPO="$(yq eval -e '.externals.nydus-snapshotter.url | explode(.)' /tmp/versions.yaml)" && \
+	mkdir -p /opt/nydus-snapshotter && \
+	ARCH="$(uname -m)" && \
+	if [ "${ARCH}" = "x86_64" ]; then ARCH=amd64 ; fi && \
+	if [ "${ARCH}" = "aarch64" ]; then ARCH=arm64; fi && \
+	curl -fOL --progress-bar "${NYDUS_SNAPSHOTTER_REPO}/releases/download/${NYDUS_SNAPSHOTTER_VERSION}/nydus-snapshotter-${NYDUS_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz" && \
+	tar xvzpf "nydus-snapshotter-${NYDUS_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz" -C /opt/nydus-snapshotter && \
+	rm "nydus-snapshotter-${NYDUS_SNAPSHOTTER_VERSION}-linux-${ARCH}.tar.gz"
+
+#### Build binary package
+FROM ubuntu:22.04 AS rust-builder
+
+# Default to Rust 1.93
+ARG RUST_TOOLCHAIN=1.93
+ENV DEBIAN_FRONTEND=noninteractive
+ENV RUSTUP_HOME="/opt/rustup"
+ENV CARGO_HOME="/opt/cargo"
+ENV PATH="/opt/cargo/bin/:${PATH}"
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+RUN \
+	mkdir ${RUSTUP_HOME} ${CARGO_HOME} && \
+	chmod -R a+rwX ${RUSTUP_HOME} ${CARGO_HOME}
+
+RUN \
+	apt-get update && \
+	apt-get --no-install-recommends -y install \
+		ca-certificates \
+		curl \
+		gcc \
+		libc6-dev \
+		musl-tools && \
+	apt-get clean && rm -rf /var/lib/apt/lists/ && \
+	curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain ${RUST_TOOLCHAIN} && \
+	rustup component add rustfmt clippy
+
+# Build from the repository root so kata-deploy uses the root Cargo workspace:
+#   docker build -f tools/packaging/kata-deploy/Dockerfile.components .
+WORKDIR /kata
+
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+COPY tools/packaging/kata-deploy/binary ./tools/packaging/kata-deploy/binary
+
+# Install target and run tests based on architecture
+# - AMD64/arm64: use musl for fully static binaries
+# - PPC64le/s390x: use glibc (musl has issues on these platforms)
+RUN \
+	HOST_ARCH="$(uname -m)"; \
+	rust_arch=""; \
+	rust_target=""; \
+	case "${HOST_ARCH}" in \
+		"x86_64") \
+			rust_arch="x86_64"; \
+			rust_target="${rust_arch}-unknown-linux-musl"; \
+			echo "Installing musl target for ${rust_target}"; \
+			rustup target add "${rust_target}"; \
+			;; \
+		"aarch64") \
+			rust_arch="aarch64"; \
+			rust_target="${rust_arch}-unknown-linux-musl"; \
+			echo "Installing musl target for ${rust_target}"; \
+			rustup target add "${rust_target}"; \
+			;; \
+		"ppc64le") \
+			rust_arch="powerpc64le"; \
+			rust_target="${rust_arch}-unknown-linux-gnu"; \
+			echo "Using glibc target for ${rust_target} (musl is not well supported on ppc64le)"; \
+			;; \
+		"s390x") \
+			rust_arch="s390x"; \
+			rust_target="${rust_arch}-unknown-linux-gnu"; \
+			echo "Using glibc target for ${rust_target} (musl is not well supported on s390x)"; \
+			;; \
+		*) echo "Unsupported architecture: ${HOST_ARCH}" && exit 1 ;; \
+	esac; \
+	echo "${rust_target}" > /tmp/rust_target
+
+# Verify code formatting and run cargo check before tests and build
+RUN \
+	set -e && \
+	rust_target="$(cat /tmp/rust_target)" && \
+	echo "Checking code formatting..." && \
+	cargo fmt -p kata-deploy --check && \
+	echo "Code formatting check passed!" && \
+	echo "Running cargo clippy with target ${rust_target}..." && \
+	cargo clippy -p kata-deploy --all-targets --all-features --release --locked --target "${rust_target}" -- -D warnings && \
+	echo "Cargo clippy passed!"
+
+# Run tests using --test-threads=1 to prevent environment variable pollution between tests,
+# and this is fine as we'll never ever have multiple binaries running at the same time.
+RUN \
+	rust_target="$(cat /tmp/rust_target)"; \
+	echo "Running binary tests with target ${rust_target}..." && \
+	RUSTFLAGS="-D warnings" cargo test -p kata-deploy --target "${rust_target}" -- --test-threads=1 && \
+	echo "All tests passed!"
+
+RUN \
+	rust_target="$(cat /tmp/rust_target)"; \
+	echo "Building kata-deploy binary for ${rust_target}..." && \
+	RUSTFLAGS="-D warnings" cargo build --release -p kata-deploy --target "${rust_target}" && \
+	mkdir -p /kata-deploy/bin && \
+	cp "/kata/target/${rust_target}/release/kata-deploy" /kata-deploy/bin/kata-deploy && \
+	echo "Cleaning up build artifacts to save disk space..." && \
+	rm -rf /kata/target && \
+	cargo clean

--- a/tools/packaging/kata-deploy/local-build/Makefile
+++ b/tools/packaging/kata-deploy/local-build/Makefile
@@ -73,6 +73,10 @@ define BUILD
 	$(MK_DIR)/kata-deploy-binaries-in-docker.sh $(if $(V),,-s) --build=$1
 endef
 
+define BUILD_KATA_DEPLOY_COMPONENT
+	$(MK_DIR)/kata-deploy-build-components-tarballs.sh $1
+endef
+
 define DUMMY
 	$(call BUILD,"dummy")
 	mv $(MK_DIR)/build/kata-static-dummy.tar.zst $(MK_DIR)/build/kata-static-$(patsubst %-tarball,%,$1).tar.zst
@@ -233,6 +237,12 @@ trace-forwarder-tarball: copy-scripts-for-the-tools-build
 
 virtiofsd-tarball:
 	${MAKE} $@-build
+
+kata-deploy-binary-tarball:
+	$(call BUILD_KATA_DEPLOY_COMPONENT,kata-deploy-binary)
+
+nydus-snapshotter-for-coco-guest-pull-tarball:
+	$(call BUILD_KATA_DEPLOY_COMPONENT,nydus-snapshotter-for-coco-guest-pull)
 
 merge-builds:
 	$(MK_DIR)/kata-deploy-merge-builds.sh build "$(MK_DIR)/../../../../versions.yaml"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-and-upload-payload.sh
@@ -25,6 +25,7 @@ ARTIFACTS_STAGE_DIR="${KATA_DEPLOY_DIR}/kata-artifacts"
 # Docker build context (local-build/ is excluded via .dockerignore).
 mkdir -p "${ARTIFACTS_STAGE_DIR}"
 cp "${ARTIFACTS_BUILD_DIR}"/kata-static-*.tar.zst "${ARTIFACTS_STAGE_DIR}/"
+cp "${ARTIFACTS_BUILD_DIR}"/kata-deploy-static-*.tar.zst "${ARTIFACTS_STAGE_DIR}/"
 
 cleanup() {
 	rm -rf "${ARTIFACTS_STAGE_DIR}"

--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-components-tarballs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-components-tarballs.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Copyright (c) 2026 Kata Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root_dir="$(cd "${script_dir}/../../../.." && pwd)"
+build_dir="${repo_root_dir}/tools/packaging/kata-deploy/local-build/build"
+component="${1:-all}"
+versions_yaml="${repo_root_dir}/versions.yaml"
+
+mkdir -p "${build_dir}"
+
+get_rust_toolchain_version() {
+	awk '
+		/^languages:/ { in_languages=1; next }
+		in_languages && /^[^[:space:]]/ { in_languages=0 }
+		in_languages && /^  rust:/ { in_rust=1; next }
+		in_rust && /^  [^[:space:]]/ { in_rust=0 }
+		in_rust && /^    version:/ {
+			gsub(/"/, "", $2)
+			print $2
+			exit
+		}
+	' "${versions_yaml}"
+}
+
+rust_toolchain="$(get_rust_toolchain_version)"
+if [[ -z "${rust_toolchain}" ]]; then
+	echo "Failed to extract languages.rust.version from ${versions_yaml}" >&2
+	exit 1
+fi
+
+build_kata_deploy_binary() {
+	docker buildx build \
+		--target rust-builder \
+		--build-arg "RUST_TOOLCHAIN=${rust_toolchain}" \
+		--output "type=local,dest=${build_dir}/kata-deploy-binary-out" \
+		-f "${repo_root_dir}/tools/packaging/kata-deploy/Dockerfile.components" \
+		"${repo_root_dir}"
+
+	mkdir -p "${build_dir}/kata-deploy-binary/usr/bin"
+	cp "${build_dir}/kata-deploy-binary-out/kata-deploy/bin/kata-deploy" \
+		"${build_dir}/kata-deploy-binary/usr/bin/kata-deploy"
+	tar --zstd -cf "${build_dir}/kata-deploy-static-kata-deploy-binary.tar.zst" \
+		-C "${build_dir}/kata-deploy-binary" .
+}
+
+build_nydus_snapshotter_for_coco_guest_pull() {
+	docker buildx build \
+		--target nydus-binary-downloader \
+		--output "type=local,dest=${build_dir}/nydus-snapshotter-out" \
+		-f "${repo_root_dir}/tools/packaging/kata-deploy/Dockerfile.components" \
+		"${repo_root_dir}"
+
+	mkdir -p "${build_dir}/nydus-snapshotter/opt/kata-artifacts/nydus-snapshotter"
+	cp "${build_dir}/nydus-snapshotter-out/opt/nydus-snapshotter/bin/containerd-nydus-grpc" \
+		"${build_dir}/nydus-snapshotter/opt/kata-artifacts/nydus-snapshotter/"
+	cp "${build_dir}/nydus-snapshotter-out/opt/nydus-snapshotter/bin/nydus-overlayfs" \
+		"${build_dir}/nydus-snapshotter/opt/kata-artifacts/nydus-snapshotter/"
+	tar --zstd -cf "${build_dir}/kata-deploy-static-nydus-snapshotter-for-coco-guest-pull.tar.zst" \
+		-C "${build_dir}/nydus-snapshotter" .
+}
+
+case "${component}" in
+	kata-deploy-binary) build_kata_deploy_binary ;;
+	nydus-snapshotter-for-coco-guest-pull) build_nydus_snapshotter_for_coco_guest_pull ;;
+	all)
+		build_kata_deploy_binary
+		build_nydus_snapshotter_for_coco_guest_pull
+		;;
+	*)
+		echo "Unknown component '${component}'. Expected: kata-deploy-binary, nydus-snapshotter-for-coco-guest-pull, all" >&2
+		exit 1
+		;;
+esac


### PR DESCRIPTION
Build and publish the kata-deploy binary and CoCo guest-pull nydus snapshotter as dedicated per-arch artifacts, then consume those tarballs when assembling the kata-deploy image.

This avoids rebuilding those components in the payload image (which would happen in serial) path and reduces overall CI build time.