### PR TITLE
genpolicy: stop skipping image UID/GID derivation for guest-pull

### DIFF
--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -1214,6 +1214,18 @@ impl Container {
         }
     }
 
+    pub fn run_as_user(&self) -> Option<i64> {
+        self.securityContext
+            .as_ref()
+            .and_then(|context| context.runAsUser)
+    }
+
+    pub fn run_as_group(&self) -> Option<i64> {
+        self.securityContext
+            .as_ref()
+            .and_then(|context| context.runAsGroup)
+    }
+
     // Count NVIDIA passthrough GPU requests using an explicit allowlist of resource keys.
     pub fn get_nvidia_pgpu_count(&self, pgpu_resource_keys: &[String]) -> Option<usize> {
         let limits = self.resources.as_ref()?.limits.as_ref()?;

--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -690,11 +690,9 @@ struct TopologySpreadConstraint {
 }
 
 impl Container {
-    pub async fn init(&mut self, config: &Config, is_pause_container: bool) {
+    pub async fn init(&mut self, config: &Config) {
         // Load container image properties from the registry.
-        self.registry = registry::get_container(config, &self.image, is_pause_container)
-            .await
-            .unwrap();
+        self.registry = registry::get_container(config, &self.image).await.unwrap();
     }
 
     pub fn get_env_variables(
@@ -1267,8 +1265,7 @@ pub async fn add_pause_container(containers: &mut Vec<Container>, config: &Confi
         }),
         ..Default::default()
     };
-    let is_pause_container = true;
-    pause_container.init(config, is_pause_container).await;
+    pause_container.init(config).await;
     containers.insert(0, pause_container);
     debug!("pause container added.");
 }

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -26,6 +26,7 @@ use std::boxed;
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs::read_to_string;
 use std::io::Write;
+use std::process::exit;
 
 /// Intermediary format of policy data.
 pub struct AgentPolicy {
@@ -457,9 +458,7 @@ pub struct ClusterConfig {
     /// Pause container image reference.
     pub pause_container_image: String,
 
-    /// Whether or not the cluster uses the guest pull mechanism
-    /// In guest pull, host can't look into layers to determine GID.
-    /// See issue https://github.com/kata-containers/kata-containers/issues/11162
+    /// Whether or not the cluster uses the guest pull mechanism.
     pub guest_pull: bool,
 
     /// Supported values:
@@ -854,6 +853,103 @@ impl AgentPolicy {
         }
     }
 
+    fn exit_if_guest_pull_needs_security_context(
+        &self,
+        resource: &dyn yaml::K8sResource,
+        yaml_container: &pod::Container,
+        is_pause_container: bool,
+        process: &KataProcess,
+    ) {
+        if is_pause_container || !self.config.settings.cluster_config.guest_pull {
+            return;
+        }
+
+        let pod_security_context = resource.get_pod_security_context();
+        let uid = i64::from(process.User.UID);
+        let gid = i64::from(process.User.GID);
+
+        let effective_run_as_user = yaml_container
+            .run_as_user()
+            .or_else(|| pod_security_context.and_then(|context| context.runAsUser));
+        let explicit_uid = effective_run_as_user == Some(uid);
+
+        let effective_run_as_group = yaml_container
+            .run_as_group()
+            .or_else(|| pod_security_context.and_then(|context| context.runAsGroup));
+        let explicit_gid = effective_run_as_group == Some(gid);
+
+        let mut explicitly_added_gids = BTreeSet::new();
+        if let Some(context) = pod_security_context {
+            if let Some(fs_group) = context.fsGroup {
+                explicitly_added_gids.insert(u32::try_from(fs_group).unwrap());
+            }
+            if let Some(supplemental_groups) = &context.supplementalGroups {
+                explicitly_added_gids.extend(supplemental_groups.iter().copied());
+            }
+        }
+
+        let missing_uid = process.User.UID != 0 && !explicit_uid;
+        let missing_gid = process.User.GID != 0 && !explicit_gid;
+
+        let missing_supplemental_groups: Vec<u32> = process
+            .User
+            .AdditionalGids
+            .iter()
+            .copied()
+            .filter(|additional_gid| {
+                *additional_gid != process.User.GID
+                    && !explicitly_added_gids.contains(additional_gid)
+            })
+            .collect();
+
+        if !missing_uid && !missing_gid && missing_supplemental_groups.is_empty() {
+            return;
+        }
+
+        let mut recommendations = Vec::new();
+        if missing_uid || missing_gid {
+            let mut container_recommendation = format!(
+                "containers:\n  - name: {}\n    securityContext:",
+                yaml_container.name
+            );
+            if process.User.UID != 0 {
+                container_recommendation
+                    .push_str(&format!("\n      runAsUser: {}", process.User.UID));
+            }
+            if process.User.GID != 0 {
+                container_recommendation
+                    .push_str(&format!("\n      runAsGroup: {}", process.User.GID));
+            }
+            recommendations.push(container_recommendation);
+        }
+        if !missing_supplemental_groups.is_empty() {
+            let supplemental_groups = missing_supplemental_groups
+                .iter()
+                .map(|gid| gid.to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            recommendations.push(format!(
+                "securityContext:\n  supplementalGroups: [{supplemental_groups}]"
+            ));
+        }
+        let recommendation = recommendations.join("\n");
+
+        eprintln!(
+            "ERROR: guest_pull is enabled for container '{}' using image '{}'. \
+             The generated policy expects UID={}, GID={}, AdditionalGids={:?}; \
+             containerd may not reproduce image-derived user/group values when image layers are pulled in the guest. \
+             Set explicit Kubernetes securityContext values, for example:\n{}\n\
+             See docs/Limitations.md#guest-pulled-container-images.",
+            yaml_container.name,
+            yaml_container.image,
+            process.User.UID,
+            process.User.GID,
+            process.User.AdditionalGids,
+            recommendation
+        );
+        exit(1);
+    }
+
     fn get_container_process(
         &self,
         resource: &dyn yaml::K8sResource,
@@ -1023,6 +1119,12 @@ impl AgentPolicy {
         debug!(
             "get_container_process: returning: User = {:?}",
             &process.User
+        );
+        self.exit_if_guest_pull_needs_security_context(
+            resource,
+            yaml_container,
+            is_pause_container,
+            &process,
         );
         process
     }

--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -125,7 +125,7 @@ const GROUP_FILE_WHITEOUT_TAR_PATH: &str = "etc/.wh.group";
 pub const WHITEOUT_MARKER: &str = "WHITEOUT";
 
 impl Container {
-    pub async fn new(config: &Config, image: &str, is_pause_container: bool) -> Result<Self> {
+    pub async fn new(config: &Config, image: &str) -> Result<Self> {
         info!("============================================");
         info!("Pulling manifest and config for {image}");
         let image_string = image.to_string();
@@ -166,38 +166,31 @@ impl Container {
         let mut passwd = String::new();
         let mut group = String::new();
 
-        // Nydus/guest_pull doesn't make available passwd/group files from layers properly.
-        // See issue https://github.com/kata-containers/kata-containers/issues/11162
-        let v1_policy = config.settings.cluster_config.pause_container_id_policy == "v1";
-        if config.settings.cluster_config.guest_pull && (v1_policy || !is_pause_container) {
-            info!("Guest pull is enabled, skipping passwd/group file parsing");
-        } else {
-            let image_layers = get_image_layers(
-                &config.layers_cache,
-                &mut client,
-                &reference,
-                &manifest,
-                &config_layer,
-            )
-            .await
-            .unwrap();
+        let image_layers = get_image_layers(
+            &config.layers_cache,
+            &mut client,
+            &reference,
+            &manifest,
+            &config_layer,
+        )
+        .await
+        .unwrap();
 
-            // Find the last layer with an /etc/* file, respecting whiteouts.
-            info!("Parsing users and groups in image layers");
-            for layer in &image_layers {
-                if layer.passwd == WHITEOUT_MARKER {
-                    passwd = String::new();
-                } else if !layer.passwd.is_empty() {
-                    passwd = layer.passwd.clone();
-                    debug!("Container:new: Found in image layer passwd = \n{passwd}");
-                }
+        // Find the last layer with an /etc/* file, respecting whiteouts.
+        info!("Parsing users and groups in image layers");
+        for layer in &image_layers {
+            if layer.passwd == WHITEOUT_MARKER {
+                passwd = String::new();
+            } else if !layer.passwd.is_empty() {
+                passwd = layer.passwd.clone();
+                debug!("Container:new: Found in image layer passwd = \n{passwd}");
+            }
 
-                if layer.group == WHITEOUT_MARKER {
-                    group = String::new();
-                } else if !layer.group.is_empty() {
-                    group = layer.group.clone();
-                    debug!("Container:new: Found in image layer group = \n{group}");
-                }
+            if layer.group == WHITEOUT_MARKER {
+                group = String::new();
+            } else if !layer.group.is_empty() {
+                group = layer.group.clone();
+                debug!("Container:new: Found in image layer group = \n{group}");
             }
         }
 
@@ -652,16 +645,11 @@ pub fn get_users_from_decompressed_layer(path: &Path) -> Result<(String, String)
     Ok((passwd, group))
 }
 
-pub async fn get_container(
-    config: &Config,
-    image: &str,
-    is_pause_container: bool,
-) -> Result<Container> {
+pub async fn get_container(config: &Config, image: &str) -> Result<Container> {
     if let Some(socket_path) = &config.containerd_socket_path {
-        return Container::new_containerd_pull(config, image, socket_path, is_pause_container)
-            .await;
+        return Container::new_containerd_pull(config, image, socket_path).await;
     }
-    Container::new(config, image, is_pause_container).await
+    Container::new(config, image).await
 }
 
 fn build_auth(reference: &Reference) -> RegistryAuth {

--- a/src/tools/genpolicy/src/registry_containerd.rs
+++ b/src/tools/genpolicy/src/registry_containerd.rs
@@ -32,7 +32,6 @@ impl Container {
         config: &Config,
         image: &str,
         containerd_socket_path: &str,
-        is_pause_container: bool,
     ) -> Result<Self> {
         info!("============================================");
         info!("Using containerd socket: {:?}", containerd_socket_path);
@@ -69,31 +68,24 @@ impl Container {
         let mut passwd = String::new();
         let mut group = String::new();
 
-        // Nydus/guest_pull doesn't make available passwd/group files from layers properly.
-        // See issue https://github.com/kata-containers/kata-containers/issues/11162
-        let v1_policy = config.settings.cluster_config.pause_container_id_policy == "v1";
-        if config.settings.cluster_config.guest_pull && (v1_policy || !is_pause_container) {
-            info!("Guest pull is enabled, skipping passwd/group file parsing");
-        } else {
-            let image_layers =
-                get_image_layers(&config.layers_cache, &manifest, &config_layer, &ctrd_client)
-                    .await
-                    .unwrap();
+        let image_layers =
+            get_image_layers(&config.layers_cache, &manifest, &config_layer, &ctrd_client)
+                .await
+                .unwrap();
 
-            // Find the last layer with an /etc/* file, respecting whiteouts.
-            info!("Parsing users and groups in image layers");
-            for layer in &image_layers {
-                if layer.passwd == WHITEOUT_MARKER {
-                    passwd = String::new();
-                } else if !layer.passwd.is_empty() {
-                    passwd = layer.passwd.clone();
-                }
+        // Find the last layer with an /etc/* file, respecting whiteouts.
+        info!("Parsing users and groups in image layers");
+        for layer in &image_layers {
+            if layer.passwd == WHITEOUT_MARKER {
+                passwd = String::new();
+            } else if !layer.passwd.is_empty() {
+                passwd = layer.passwd.clone();
+            }
 
-                if layer.group == WHITEOUT_MARKER {
-                    group = String::new();
-                } else if !layer.group.is_empty() {
-                    group = layer.group.clone();
-                }
+            if layer.group == WHITEOUT_MARKER {
+                group = String::new();
+            } else if !layer.group.is_empty() {
+                group = layer.group.clone();
             }
         }
 

--- a/src/tools/genpolicy/src/yaml.rs
+++ b/src/tools/genpolicy/src/yaml.rs
@@ -278,8 +278,7 @@ pub fn get_yaml_header(yaml: &str) -> anyhow::Result<YamlHeader> {
 
 pub async fn k8s_resource_init(spec: &mut pod::PodSpec, config: &Config) {
     for container in &mut spec.containers {
-        let is_pause_container = false;
-        container.init(config, is_pause_container).await;
+        container.init(config).await;
     }
 
     pod::add_pause_container(&mut spec.containers, config).await;
@@ -287,8 +286,7 @@ pub async fn k8s_resource_init(spec: &mut pod::PodSpec, config: &Config) {
     if let Some(init_containers) = &spec.initContainers {
         for container in init_containers {
             let mut new_container = container.clone();
-            let is_pause_container = false;
-            new_container.init(config, is_pause_container).await;
+            new_container.init(config).await;
             spec.containers.insert(1, new_container);
         }
     }

--- a/src/tools/genpolicy/tests/generate/main.rs
+++ b/src/tools/genpolicy/tests/generate/main.rs
@@ -70,6 +70,226 @@ fn secret_in_separate_file() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 #[test]
+fn guest_pull_missing_supplemental_groups_exits() -> Result<(), Box<dyn std::error::Error>> {
+    let test_case_dir = "guest_pull_missing_supplemental_groups";
+    let workdir = prepare_workdir(test_case_dir, &[]);
+    let pod_yaml_path = workdir.join("missing_supplemental_groups.yaml");
+    fs::write(
+        &pod_yaml_path,
+        r#"---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: missing-supplemental-groups
+spec:
+  restartPolicy: Never
+  runtimeClassName: kata-cc
+  containers:
+    - name: busybox
+      image: "quay.io/prometheus/busybox:latest"
+      command:
+        - /bin/sh
+      args:
+        - "-c"
+        - echo hello
+"#,
+    )?;
+
+    let mut cmd = Command::cargo_bin("genpolicy")?;
+    cmd.arg("--yaml-file").arg(&pod_yaml_path);
+
+    let output = cmd.output()?;
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERROR: guest_pull is enabled"));
+    assert!(stderr.contains("Set explicit Kubernetes securityContext values"));
+    assert!(!stderr.contains("      runAsUser: 0"), "{stderr}");
+    assert!(!stderr.contains("      runAsGroup: 0"), "{stderr}");
+    assert!(stderr.contains("supplementalGroups: [10]"));
+
+    Ok(())
+}
+
+#[test]
+fn guest_pull_run_as_user_requires_non_default_group() -> Result<(), Box<dyn std::error::Error>> {
+    let test_case_dir = "guest_pull_run_as_user_requires_non_default_group";
+    let workdir = prepare_workdir(test_case_dir, &[]);
+    let pod_yaml_path = workdir.join("run_as_user_requires_non_default_group.yaml");
+    fs::write(
+        &pod_yaml_path,
+        r#"---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: run-as-user-requires-non-default-group
+spec:
+  restartPolicy: Never
+  runtimeClassName: kata-cc
+  securityContext:
+    runAsUser: 33
+  containers:
+    - name: busybox
+      image: "quay.io/prometheus/busybox:latest"
+      command:
+        - /bin/sh
+      args:
+        - "-c"
+        - echo hello
+"#,
+    )?;
+
+    let mut cmd = Command::cargo_bin("genpolicy")?;
+    cmd.arg("--yaml-file").arg(&pod_yaml_path);
+
+    let output = cmd.output()?;
+    assert!(!output.status.success());
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("ERROR: guest_pull is enabled"));
+    assert!(stderr.contains("      runAsUser: 33"), "{stderr}");
+    assert!(stderr.contains("      runAsGroup: 33"), "{stderr}");
+    assert!(!stderr.contains("supplementalGroups:"), "{stderr}");
+
+    Ok(())
+}
+
+#[test]
+fn guest_pull_default_zero_values_are_optional() -> Result<(), Box<dyn std::error::Error>> {
+    let cases = &[
+        (
+            "run_as_user_without_run_as_group",
+            r#"---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: run-as-user
+spec:
+  restartPolicy: Never
+  runtimeClassName: kata-cc
+  securityContext:
+    runAsUser: 1000
+  containers:
+    - name: busybox
+      image: "quay.io/prometheus/busybox:latest"
+      command:
+        - /bin/sh
+      args:
+        - "-c"
+        - echo hello
+"#,
+        ),
+        (
+            "supplemental_groups_without_run_as_user_or_group",
+            r#"---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: run-supplemental
+spec:
+  restartPolicy: Never
+  runtimeClassName: kata-cc
+  securityContext:
+    supplementalGroups:
+      - 10
+  containers:
+    - name: busybox
+      image: "quay.io/prometheus/busybox:latest"
+      command:
+        - /bin/sh
+      args:
+        - "-c"
+        - echo hello
+"#,
+        ),
+    ];
+
+    for (name, yaml) in cases {
+        let test_case_dir = format!("guest_pull_default_security_context_values_{name}");
+        let workdir = prepare_workdir(&test_case_dir, &[]);
+        let pod_yaml_path = workdir.join(format!("{name}.yaml"));
+        fs::write(&pod_yaml_path, yaml)?;
+
+        let mut cmd = Command::cargo_bin("genpolicy")?;
+        cmd.arg("--yaml-file").arg(&pod_yaml_path);
+        cmd.assert().success();
+    }
+
+    Ok(())
+}
+
+#[test]
+fn guest_pull_split_security_context_succeeds() -> Result<(), Box<dyn std::error::Error>> {
+    let cases = &[
+        (
+            "split_user_group_security_context",
+            r#"---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: split-user-group-security-context
+spec:
+  restartPolicy: Never
+  runtimeClassName: kata-cc
+  securityContext:
+    runAsUser: 0
+    supplementalGroups:
+      - 10
+  containers:
+    - name: busybox
+      image: "quay.io/prometheus/busybox:latest"
+      command:
+        - /bin/sh
+      args:
+        - "-c"
+        - echo hello
+      securityContext:
+        runAsGroup: 0
+"#,
+        ),
+        (
+            "split_security_context",
+            r#"---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: split-security-context
+spec:
+  restartPolicy: Never
+  runtimeClassName: kata-cc
+  securityContext:
+    supplementalGroups:
+      - 10
+  containers:
+    - name: busybox
+      image: "quay.io/prometheus/busybox:latest"
+      command:
+        - /bin/sh
+      args:
+        - "-c"
+        - echo hello
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+"#,
+        ),
+    ];
+
+    for (name, yaml) in cases {
+        let test_case_dir = format!("guest_pull_{name}");
+        let workdir = prepare_workdir(&test_case_dir, &[]);
+        let pod_yaml_path = workdir.join(format!("{name}.yaml"));
+        fs::write(&pod_yaml_path, yaml)?;
+
+        let mut cmd = Command::cargo_bin("genpolicy")?;
+        cmd.arg("--yaml-file").arg(&pod_yaml_path);
+        cmd.assert().success();
+    }
+
+    Ok(())
+}
+
+#[test]
 fn output_behavior() -> Result<(), Box<dyn std::error::Error>> {
     struct TestCase {
         name: &'static str,

--- a/src/tools/genpolicy/tests/generate/testdata/config_map.yaml
+++ b/src/tools/genpolicy/tests/generate/testdata/config_map.yaml
@@ -23,6 +23,11 @@ metadata:
 spec:
   restartPolicy: Never
   runtimeClassName: kata-cc
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups:
+      - 10
   containers:
     - name: busybox
       image: "quay.io/prometheus/busybox:latest"

--- a/src/tools/genpolicy/tests/generate/testdata/pod_with_config_map_ref.yaml
+++ b/src/tools/genpolicy/tests/generate/testdata/pod_with_config_map_ref.yaml
@@ -8,6 +8,11 @@ metadata:
 spec:
   restartPolicy: Never
   runtimeClassName: kata-cc
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups:
+      - 10
   containers:
     - name: busybox
       image: "quay.io/prometheus/busybox:latest"

--- a/src/tools/genpolicy/tests/generate/testdata/pod_with_secret_ref.yaml
+++ b/src/tools/genpolicy/tests/generate/testdata/pod_with_secret_ref.yaml
@@ -8,6 +8,11 @@ metadata:
 spec:
   restartPolicy: Never
   runtimeClassName: kata-cc
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups:
+      - 10
   containers:
     - name: busybox
       image: "quay.io/prometheus/busybox:latest"

--- a/src/tools/genpolicy/tests/generate/testdata/secret.yaml
+++ b/src/tools/genpolicy/tests/generate/testdata/secret.yaml
@@ -21,6 +21,11 @@ metadata:
 spec:
   restartPolicy: Never
   runtimeClassName: kata-cc
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups:
+      - 10
   containers:
     - name: busybox
       image: "quay.io/prometheus/busybox:latest"

--- a/src/tools/genpolicy/tests/generate/testdata/simple_pod.yaml
+++ b/src/tools/genpolicy/tests/generate/testdata/simple_pod.yaml
@@ -6,6 +6,11 @@ metadata:
 spec:
   restartPolicy: Never
   runtimeClassName: kata-cc
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups:
+      - 10
   containers:
     - name: busybox
       image: "quay.io/prometheus/busybox:latest"

--- a/src/tools/genpolicy/tests/policy/testdata/addarpneighbors/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/addarpneighbors/pod.yaml
@@ -7,3 +7,6 @@ spec:
   containers:
   - name: dummy
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/copyfile/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/copyfile/pod.yaml
@@ -7,3 +7,6 @@ spec:
   containers:
   - name: dummy
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/pod.yaml
@@ -10,3 +10,6 @@ spec:
   containers:
     - name: gid
       image: "ghcr.io/burgerdev/weird-images/gid:latest@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0"
+      securityContext:
+        runAsUser: 2
+        runAsGroup: 1

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/cgroup_mount_extras/testcases.json
@@ -295,10 +295,10 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              1
             ],
-            "GID": 0,
-            "UID": 0,
+            "GID": 1,
+            "UID": 2,
             "Username": ""
           }
         },
@@ -629,10 +629,10 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              1
             ],
-            "GID": 0,
-            "UID": 0,
+            "GID": 1,
+            "UID": 2,
             "Username": ""
           }
         },

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/env_vars/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/env_vars/pod.yaml
@@ -17,3 +17,6 @@ spec:
         fieldRef:
           apiVersion: v1
           fieldPath: metadata.labels['labels.test.com/test-label1']
+    securityContext:
+      runAsUser: 2
+      runAsGroup: 1

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/env_vars/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/env_vars/testcases.json
@@ -286,10 +286,10 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              1
             ],
-            "GID": 0,
-            "UID": 0,
+            "GID": 1,
+            "UID": 2,
             "Username": ""
           }
         },
@@ -612,10 +612,10 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              1
             ],
-            "GID": 0,
-            "UID": 0,
+            "GID": 1,
+            "UID": 2,
             "Username": ""
           }
         },

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/generate_name/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/generate_name/pod.yaml
@@ -8,3 +8,6 @@ spec:
   containers:
     - name: dummy
       image: "registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db"
+      securityContext:
+        runAsUser: 65535
+        runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/gid/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/gid/pod.yaml
@@ -10,3 +10,6 @@ spec:
   containers:
     - name: gid
       image: "ghcr.io/burgerdev/weird-images/gid:latest@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0"
+      securityContext:
+        runAsUser: 2
+        runAsGroup: 1

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/gid/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/gid/testcases.json
@@ -293,10 +293,10 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              1
             ],
-            "GID": 0,
-            "UID": 0,
+            "GID": 1,
+            "UID": 2,
             "Username": ""
           }
         },
@@ -628,8 +628,8 @@
             "AdditionalGids": [
               0
             ],
-            "GID": 0,
-            "UID": 0,
+            "GID": 1,
+            "UID": 2,
             "Username": ""
           }
         },

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/pod.yaml
@@ -15,3 +15,6 @@ spec:
       resources:
         limits:
           nvidia.com/pgpu: "2"
+      securityContext:
+        runAsUser: 65535
+        runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
@@ -7,6 +7,9 @@ spec:
   containers:
   - name: redis
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0
     readinessProbe:
       grpc:
         port: 2379

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/network_namespace/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/network_namespace/pod.yaml
@@ -7,3 +7,6 @@ spec:
   containers:
   - name: dummy
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/pod.yaml
@@ -12,6 +12,9 @@ spec:
     volumeMounts:
     - name: tmp
       mountPath: /mnt
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0
   volumes:
   - name: tmp
     emptyDir: {}

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/sysctls/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/sysctls/pod.yaml
@@ -11,3 +11,6 @@ spec:
   containers:
   - name: redis
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/pod.yaml
@@ -12,6 +12,9 @@ spec:
         - name: config
           mountPath: /config
           readOnly: true
+      securityContext:
+        runAsUser: 65535
+        runAsGroup: 0
   volumes:
     - name: config
       configMap:

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/pod.yaml
@@ -8,3 +8,6 @@ spec:
   containers:
     - name: redis
       image: quay.io/opstree/redis
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/container_image/testcases.json
@@ -108,9 +108,9 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              1000
             ],
-            "GID": 0,
+            "GID": 1000,
             "UID": 1000,
             "Username": ""
           }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/pod.yaml
@@ -18,6 +18,9 @@ spec:
       readOnly: true
     - mountPath: /mnt/test4
       name: test-volume2
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0
   volumes:
   - name: test-volume
     emptyDir: {}

--- a/src/tools/genpolicy/tests/policy/testdata/createsandbox/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createsandbox/pod.yaml
@@ -7,3 +7,6 @@ spec:
   containers:
   - name: dummy
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/state/createcontainer/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/state/createcontainer/pod.yaml
@@ -7,3 +7,6 @@ spec:
   containers:
   - name: redis
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocess/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocess/pod.yaml
@@ -29,3 +29,8 @@ spec:
         exec:
           command:
             - test2
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups:
+      - 10

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocess/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocess/testcases.json
@@ -278,7 +278,8 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              0,
+              10
             ],
             "GID": 0,
             "UID": 0,
@@ -581,7 +582,8 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              0,
+              10
             ],
             "GID": 0,
             "UID": 0,
@@ -630,7 +632,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -665,7 +668,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -700,7 +704,8 @@
         "Terminal": true,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -743,7 +748,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -778,7 +784,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -813,7 +820,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -883,7 +891,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -918,7 +927,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -1041,7 +1051,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -1076,7 +1087,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,
@@ -1120,7 +1132,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocessdeployment/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocessdeployment/pod.yaml
@@ -23,3 +23,8 @@ spec:
             command:
               - /bin/true
 
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        supplementalGroups:
+          - 10

--- a/src/tools/genpolicy/tests/policy/testdata/state/execprocessdeployment/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/state/execprocessdeployment/testcases.json
@@ -294,7 +294,8 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0
+              0,
+              10
             ],
             "GID": 0,
             "UID": 0,
@@ -367,7 +368,8 @@
         "Terminal": false,
         "User": {
           "AdditionalGids": [
-            0
+            0,
+            10
           ],
           "GID": 0,
           "UID": 0,

--- a/src/tools/genpolicy/tests/policy/testdata/updateinterface/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/updateinterface/pod.yaml
@@ -7,3 +7,6 @@ spec:
   containers:
   - name: dummy
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/src/tools/genpolicy/tests/policy/testdata/updateroutes/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/updateroutes/pod.yaml
@@ -7,3 +7,6 @@ spec:
   containers:
   - name: dummy
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    securityContext:
+      runAsUser: 65535
+      runAsGroup: 0

--- a/tests/integration/kubernetes/confidential_common.sh
+++ b/tests/integration/kubernetes/confidential_common.sh
@@ -99,6 +99,9 @@ function cleanup_loop_device(){
 # - $4: guest components procs parameter
 # - $5: guest components rest api parameter
 # - $6: node
+# - $7: runAsUser
+# - $8: runAsGroup
+# - $9: supplementalGroups
 function create_coco_pod_yaml() {
 	image=$1
 	image_policy=${2:-}
@@ -106,6 +109,9 @@ function create_coco_pod_yaml() {
 	guest_components_procs=${4:-}
 	guest_components_rest_api=${5:-}
 	node=${6:-}
+	run_as_user=${7:-}
+	run_as_group=${8:-}
+	supplemental_groups=${9:-}
 
 	local CC_KBS_ADDR
 	CC_KBS_ADDR=$(kbs_k8s_svc_http_addr)
@@ -134,7 +140,7 @@ function create_coco_pod_yaml() {
 	kernel_params_value+=" agent.aa_kbc_params=cc_kbc::${CC_KBS_ADDR}"
 
 	# Note: this is not local as we use it in the caller test
-	kata_pod="$(new_pod_config "${image}" "kata-${KATA_HYPERVISOR}")"
+	kata_pod="$(new_pod_config "${image}" "kata-${KATA_HYPERVISOR}" "${run_as_user}" "${run_as_group}" "${supplemental_groups}")"
 	set_container_command "${kata_pod}" "0" "sleep" "30"
 
 	# Set annotations
@@ -155,17 +161,23 @@ function create_coco_pod_yaml() {
 # - $2: annotation `io.katacontainers.config.hypervisor.kernel_params`
 # - $3: annotation `io.katacontainers.config.hypervisor.cc_init_data`
 # - $4: node
+# - $5: runAsUser
+# - $6: runAsGroup
+# - $7: supplementalGroups
 function create_coco_pod_yaml_with_annotations() {
 	image=$1
 	kernel_params_annotation_value=${2:-}
 	cc_initdata_annotation_value=${3:-}
 	node=${4:-}
+	run_as_user=${5:-}
+	run_as_group=${6:-}
+	supplemental_groups=${7:-}
 
 	kernel_params_annotation_key="io.katacontainers.config.hypervisor.kernel_params"
 	cc_initdata_annotation_key="io.katacontainers.config.hypervisor.cc_init_data"
 
 	# Note: this is not local as we use it in the caller test
-	kata_pod="$(new_pod_config "${image}" "kata-${KATA_HYPERVISOR}")"
+	kata_pod="$(new_pod_config "${image}" "kata-${KATA_HYPERVISOR}" "${run_as_user}" "${run_as_group}" "${supplemental_groups}")"
 	set_container_command "${kata_pod}" "0" "sleep" "30"
 
 	# Set annotations

--- a/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-authenticated.bats
@@ -22,6 +22,7 @@ setup() {
 
     setup_common || die "setup_common failed"
     AUTHENTICATED_IMAGE="${AUTHENTICATED_IMAGE:-quay.io/kata-containers/confidential-containers-auth:test}"
+    authenticated_image_supplemental_groups="10"
     AUTHENTICATED_IMAGE_USER=${AUTHENTICATED_IMAGE_USER:-}
     AUTHENTICATED_IMAGE_PASSWORD=${AUTHENTICATED_IMAGE_PASSWORD:-}
     CREDENTIALS_KBS_URI="kbs:///default/credentials/test"
@@ -90,7 +91,8 @@ EOF
 
     setup_kbs_credentials "${AUTHENTICATED_IMAGE}" ${AUTHENTICATED_IMAGE_USER} ${AUTHENTICATED_IMAGE_PASSWORD}
 
-    create_coco_pod_yaml "${AUTHENTICATED_IMAGE}" "" "kbs:///default/credentials/test" "" "resource" "$node"
+    create_coco_pod_yaml "${AUTHENTICATED_IMAGE}" "" "kbs:///default/credentials/test" "" "resource" "$node" \
+        "" "" "${authenticated_image_supplemental_groups}"
     yq -i ".spec.imagePullSecrets[0].name = \"cococred\"" "${kata_pod}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
@@ -105,7 +107,8 @@ EOF
 
     setup_kbs_credentials "${AUTHENTICATED_IMAGE}" ${AUTHENTICATED_IMAGE_USER} "junk"
 
-    create_coco_pod_yaml "${AUTHENTICATED_IMAGE}" "" "kbs:///default/credentials/test" "" "resource" "$node"
+    create_coco_pod_yaml "${AUTHENTICATED_IMAGE}" "" "kbs:///default/credentials/test" "" "resource" "$node" \
+        "" "" "${authenticated_image_supplemental_groups}"
     yq -i ".spec.imagePullSecrets[0].name = \"cococred\"" "${kata_pod}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
@@ -119,7 +122,8 @@ EOF
 @test "Test that creating a container from an authenticated image, with no credentials fails" {
 
     # Create pod config, but don't add agent.image_registry_auth annotation
-    create_coco_pod_yaml "${AUTHENTICATED_IMAGE}" "" "" "" "resource" "$node"
+    create_coco_pod_yaml "${AUTHENTICATED_IMAGE}" "" "" "" "resource" "$node" \
+        "" "" "${authenticated_image_supplemental_groups}"
     yq -i ".spec.imagePullSecrets[0].name = \"cococred\"" "${kata_pod}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
@@ -136,7 +140,8 @@ EOF
     setup_kbs_credentials "${AUTHENTICATED_IMAGE}" ${AUTHENTICATED_IMAGE_USER} ${AUTHENTICATED_IMAGE_PASSWORD}
 
     initdata=$(get_initdata_with_auth_registry_config)
-    create_coco_pod_yaml_with_annotations "${AUTHENTICATED_IMAGE}" "" "${initdata}" "${node}"
+    create_coco_pod_yaml_with_annotations "${AUTHENTICATED_IMAGE}" "" "${initdata}" "${node}" \
+        "" "" "${authenticated_image_supplemental_groups}"
     yq -i ".spec.imagePullSecrets[0].name = \"cococred\"" "${kata_pod}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
@@ -153,7 +158,8 @@ EOF
     setup_kbs_credentials "${AUTHENTICATED_IMAGE}" ${AUTHENTICATED_IMAGE_USER} "junk"
 
     initdata=$(get_initdata_with_auth_registry_config)
-    create_coco_pod_yaml_with_annotations "${AUTHENTICATED_IMAGE}" "" "${initdata}" "${node}"
+    create_coco_pod_yaml_with_annotations "${AUTHENTICATED_IMAGE}" "" "${initdata}" "${node}" \
+        "" "" "${authenticated_image_supplemental_groups}"
     yq -i ".spec.imagePullSecrets[0].name = \"cococred\"" "${kata_pod}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
@@ -169,7 +175,8 @@ EOF
 
     # Create pod config, but don't add image_registry_auth to initdata
     initdata=$(get_initdata_with_cdh_image_section "")
-    create_coco_pod_yaml_with_annotations "${AUTHENTICATED_IMAGE}" "" "${initdata}" "${node}"
+    create_coco_pod_yaml_with_annotations "${AUTHENTICATED_IMAGE}" "" "${initdata}" "${node}" \
+        "" "" "${authenticated_image_supplemental_groups}"
     yq -i ".spec.imagePullSecrets[0].name = \"cococred\"" "${kata_pod}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 

--- a/tests/integration/kubernetes/k8s-guest-pull-image-signature.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image-signature.bats
@@ -26,6 +26,7 @@ setup() {
     UNSIGNED_PROTECTED_REGISTRY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:unsigned"
     COSIGN_SIGNED_PROTECTED_REGISTRY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:cosign-signed"
     COSIGNED_SIGNED_PROTECTED_REGISTRY_WRONG_KEY_IMAGE="ghcr.io/confidential-containers/test-container-image-rs:cosign-signed-key2"
+    test_image_supplemental_groups="10"
     SECURITY_POLICY_KBS_URI="kbs:///default/security-policy/test"
     policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
 }
@@ -88,7 +89,8 @@ EOF
     # We want to set the default policy to be reject to rule out false positives
     setup_kbs_image_policy "reject"
 
-    create_coco_pod_yaml "${UNSIGNED_UNPROTECTED_REGISTRY_IMAGE}" "${SECURITY_POLICY_KBS_URI}" "" "" "resource" "$node"
+    create_coco_pod_yaml "${UNSIGNED_UNPROTECTED_REGISTRY_IMAGE}" "${SECURITY_POLICY_KBS_URI}" "" "" "resource" "$node" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake
@@ -102,7 +104,8 @@ EOF
     # We want to leave the default policy to be insecureAcceptAnything to rule out false negatives
     setup_kbs_image_policy
 
-    create_coco_pod_yaml "${UNSIGNED_PROTECTED_REGISTRY_IMAGE}" "${SECURITY_POLICY_KBS_URI}" "" "" "resource" "$node"
+    create_coco_pod_yaml "${UNSIGNED_PROTECTED_REGISTRY_IMAGE}" "${SECURITY_POLICY_KBS_URI}" "" "" "resource" "$node" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake
@@ -116,7 +119,8 @@ EOF
     # We want to set the default policy to be reject to rule out false positives
     setup_kbs_image_policy "reject"
 
-    create_coco_pod_yaml "${COSIGN_SIGNED_PROTECTED_REGISTRY_IMAGE}" "${SECURITY_POLICY_KBS_URI}" "" "" "resource" "$node"
+    create_coco_pod_yaml "${COSIGN_SIGNED_PROTECTED_REGISTRY_IMAGE}" "${SECURITY_POLICY_KBS_URI}" "" "" "resource" "$node" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake
@@ -130,7 +134,8 @@ EOF
     # We want to leave the default policy to be insecureAcceptAnything to rule out false negatives
     setup_kbs_image_policy
 
-    create_coco_pod_yaml "${COSIGNED_SIGNED_PROTECTED_REGISTRY_WRONG_KEY_IMAGE}" "${SECURITY_POLICY_KBS_URI}" "" "" "resource" "$node"
+    create_coco_pod_yaml "${COSIGNED_SIGNED_PROTECTED_REGISTRY_WRONG_KEY_IMAGE}" "${SECURITY_POLICY_KBS_URI}" "" "" "resource" "$node" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake
@@ -144,7 +149,8 @@ EOF
     # We want to set the default policy to be reject to rule out false positives
     setup_kbs_image_policy "reject"
 
-    create_coco_pod_yaml "${UNSIGNED_PROTECTED_REGISTRY_IMAGE}" "" "" "" "resource" "$node"
+    create_coco_pod_yaml "${UNSIGNED_PROTECTED_REGISTRY_IMAGE}" "" "" "" "resource" "$node" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake
@@ -161,7 +167,8 @@ EOF
     setup_kbs_image_policy "reject"
 
     initdata=$(get_initdata_with_security_policy)
-    create_coco_pod_yaml_with_annotations "${UNSIGNED_UNPROTECTED_REGISTRY_IMAGE}" "" "${initdata}" "${node}"
+    create_coco_pod_yaml_with_annotations "${UNSIGNED_UNPROTECTED_REGISTRY_IMAGE}" "" "${initdata}" "${node}" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake
@@ -178,7 +185,8 @@ EOF
     setup_kbs_image_policy
 
     initdata=$(get_initdata_with_security_policy)
-    create_coco_pod_yaml_with_annotations "${UNSIGNED_PROTECTED_REGISTRY_IMAGE}" "" "${initdata}" "${node}"
+    create_coco_pod_yaml_with_annotations "${UNSIGNED_PROTECTED_REGISTRY_IMAGE}" "" "${initdata}" "${node}" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake
@@ -195,7 +203,8 @@ EOF
     setup_kbs_image_policy "reject"
 
     initdata=$(get_initdata_with_security_policy)
-    create_coco_pod_yaml_with_annotations "${COSIGN_SIGNED_PROTECTED_REGISTRY_IMAGE}" "" "${initdata}" "${node}"
+    create_coco_pod_yaml_with_annotations "${COSIGN_SIGNED_PROTECTED_REGISTRY_IMAGE}" "" "${initdata}" "${node}" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake
@@ -212,7 +221,8 @@ EOF
     setup_kbs_image_policy
 
     initdata=$(get_initdata_with_security_policy)
-    create_coco_pod_yaml_with_annotations "${COSIGNED_SIGNED_PROTECTED_REGISTRY_WRONG_KEY_IMAGE}" "" "${initdata}" "${node}"
+    create_coco_pod_yaml_with_annotations "${COSIGNED_SIGNED_PROTECTED_REGISTRY_WRONG_KEY_IMAGE}" "" "${initdata}" "${node}" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake
@@ -228,7 +238,8 @@ EOF
     # We want to set the default policy to be reject to rule out false positives
     setup_kbs_image_policy "reject"
 
-    create_coco_pod_yaml_with_annotations "${UNSIGNED_PROTECTED_REGISTRY_IMAGE}" "" "" "${node}"
+    create_coco_pod_yaml_with_annotations "${UNSIGNED_PROTECTED_REGISTRY_IMAGE}" "" "" "${node}" \
+        "" "" "${test_image_supplemental_groups}"
     auto_generate_policy "${policy_settings_dir}" "${kata_pod}"
 
     # For debug sake

--- a/tests/integration/kubernetes/k8s-guest-pull-image.bats
+++ b/tests/integration/kubernetes/k8s-guest-pull-image.bats
@@ -24,6 +24,12 @@ setup() {
     unencrypted_image="quay.io/prometheus/busybox:latest"
     image_pulled_time_less_than_default_time="ghcr.io/confidential-containers/test-container:rust-1.79.0" # unpacked size: 1.41GB
     large_image="quay.io/confidential-containers/test-images:largeimage" # unpacked size: 2.15GB
+    unencrypted_image_supplemental_groups=""
+    large_image_supplemental_groups=""
+    if auto_generate_policy_enabled; then
+        unencrypted_image_supplemental_groups="10"
+        large_image_supplemental_groups="1, 2, 3, 4, 6, 10, 11, 20, 26, 27"
+    fi
     pod_config_template="${pod_config_dir}/pod-guest-pull-in-trusted-storage.yaml.in"
     storage_config_template="${pod_config_dir}/confidential/trusted-storage.yaml.in"
     policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
@@ -49,7 +55,8 @@ setup() {
     kubectl delete -f "$runc_pod_config"
 
     # 2. Create one kata pod with the $unencrypted_image image and nydus annotation
-    kata_pod_with_nydus_config="$(new_pod_config "$unencrypted_image" "kata-${KATA_HYPERVISOR}")"
+    kata_pod_with_nydus_config="$(new_pod_config "$unencrypted_image" "kata-${KATA_HYPERVISOR}" \
+        "" "" "$unencrypted_image_supplemental_groups")"
     set_node "$kata_pod_with_nydus_config" "$node"
     set_container_command "$kata_pod_with_nydus_config" "0" "sleep" "30"
 
@@ -162,6 +169,8 @@ setup() {
 
     pod_config=$(mktemp "${BATS_FILE_TMPDIR}/$(basename "${pod_config_template}").XXXXXX.yaml")
     IMAGE="$large_image" NODE_NAME="$node" envsubst < "$pod_config_template" > "$pod_config"
+    ! auto_generate_policy_enabled || set_pod_spec_security_context "$pod_config" ".spec" \
+        "" "" "$large_image_supplemental_groups"
 
     # Set a short CreateContainerRequest timeout in the annotation to fail to pull image in guest
     create_container_timeout=10
@@ -218,6 +227,8 @@ setup() {
 
     pod_config=$(mktemp "${BATS_FILE_TMPDIR}/$(basename "${pod_config_template}").XXXXXX.yaml")
     IMAGE="$large_image" NODE_NAME="$node" envsubst < "$pod_config_template" > "$pod_config"
+    ! auto_generate_policy_enabled || set_pod_spec_security_context "$pod_config" ".spec" \
+        "" "" "$large_image_supplemental_groups"
 
     # Set CreateContainerRequest timeout in the annotation to pull large image in guest
     # Bare-metal CI runners' kubelets are configured with an equivalent runtimeRequestTimeout of 600s

--- a/tests/integration/kubernetes/k8s-measured-rootfs.bats
+++ b/tests/integration/kubernetes/k8s-measured-rootfs.bats
@@ -41,7 +41,8 @@ setup() {
 	nginx_digest=$(get_from_kata_deps ".docker_images.nginx.digest")
 	nginx_image="${nginx_registry}@${nginx_digest}"
 
-	pod_config="$(new_pod_config "${nginx_image}" "kata-${KATA_HYPERVISOR}")"
+	pod_config="$(new_pod_config "${nginx_image}" "kata-${KATA_HYPERVISOR}" \
+		"" "" "1, 2, 3, 4, 6, 10, 11, 20, 26, 27")"
 	auto_generate_policy "${pod_config_dir}" "${pod_config}"
 
 	incorrect_hash="1111111111111111111111111111111111111111111111111111111111111111"

--- a/tests/integration/kubernetes/k8s-policy-pod.bats
+++ b/tests/integration/kubernetes/k8s-policy-pod.bats
@@ -80,6 +80,7 @@ replace_prometheus_image() {
 	yq -i \
 		'.spec.containers[0].image = "quay.io/prometheus/busybox:latest"' \
 		"${correct_pod_yaml}"
+	set_pod_spec_security_context "${correct_pod_yaml}" ".spec" "" "" "10"
 }
 
 wait_for_pod_ready() {

--- a/tests/integration/kubernetes/lib.sh
+++ b/tests/integration/kubernetes/lib.sh
@@ -316,7 +316,9 @@ assert_rootfs_count() {
 # Parameters:
 #	$1 - the container image.
 #	$2 - the runtimeclass, is not optional.
-#	$3 - the specific node name, optional.
+#	$3 - runAsUser, optional.
+#	$4 - runAsGroup, optional.
+#	$5 - supplementalGroups, optional.
 #
 # Return:
 # 	the path to the configuration file. The caller should not care about
@@ -329,6 +331,9 @@ new_pod_config() {
 	local base_config="${FIXTURES_DIR}/pod-config.yaml.in"
 	local image="${1}"
 	local runtimeclass="${2}"
+	local run_as_user="${3:-}"
+	local run_as_group="${4:-}"
+	local supplemental_groups="${5:-}"
 	local new_config
 
 	[[ -n "${runtimeclass}" ]] || return 1
@@ -337,7 +342,40 @@ new_pod_config() {
 	new_config=$(mktemp "${BATS_FILE_TMPDIR}/pod-config.XXXXXX.yaml")
 	IMAGE="${image}" RUNTIMECLASS="${runtimeclass}" envsubst < "${base_config}" > "${new_config}"
 
+	if [[ -n "${run_as_user}${run_as_group}${supplemental_groups}" ]]; then
+		set_pod_spec_security_context "${new_config}" ".spec" "${run_as_user}" "${run_as_group}" "${supplemental_groups}"
+	fi
+
 	echo "${new_config}"
+}
+
+set_pod_spec_security_context() {
+	local yaml="${1}"
+	local spec_path="${2}"
+	local run_as_user="${3}"
+	local run_as_group="${4}"
+	local supplemental_groups="${5:-}"
+	local expression
+
+	expression=""
+
+	if [[ -n "${run_as_user}" ]]; then
+		expression+="${spec_path}.securityContext.runAsUser = ${run_as_user}"
+	fi
+
+	if [[ -n "${run_as_group}" ]]; then
+		[[ -n "${expression}" ]] && expression+=" | "
+		expression+="${spec_path}.securityContext.runAsGroup = ${run_as_group}"
+	fi
+
+	if [[ -n "${supplemental_groups}" ]]; then
+		[[ -n "${expression}" ]] && expression+=" | "
+		expression+="${spec_path}.securityContext.supplementalGroups = [${supplemental_groups}]"
+	fi
+
+	[[ -n "${expression}" ]] || return 0
+
+	yq -i "${expression}" "${yaml}"
 }
 
 # Set an annotation on configuration metadata.

--- a/tests/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/busybox-pod.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   shareProcessNamespace: true
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: first-test-container
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/busybox-template.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   runtimeClassName: kata
   shareProcessNamespace: true
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: CTR_NAME
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/cron-job.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/cron-job.yaml
@@ -9,6 +9,8 @@ spec:
       template:
         spec:
           runtimeClassName: kata
+          securityContext:
+            supplementalGroups: [10]
           containers:
           - name: pi
             image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/initContainer-shared-volume.yaml
@@ -9,6 +9,8 @@ metadata:
   name: initcontainer-shared-volume
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   initContainers:
   - name: first
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/initcontainer-shareprocesspid.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/initcontainer-shareprocesspid.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   shareProcessNamespace: true
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   initContainers:
   - name: first
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/job-template.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/job-template.yaml
@@ -17,6 +17,8 @@ spec:
         jobgroup: jobtest
     spec:
       runtimeClassName: kata
+      securityContext:
+        supplementalGroups: [10]
       containers:
       - name: test
         image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/job.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/job.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     spec:
       runtimeClassName: kata
+      securityContext:
+        supplementalGroups: [10]
       containers:
       - name: pi
         image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-nobodyupdate-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-nobodyupdate-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       runtimeClassName: kata
       securityContext:
         runAsUser: 65534
+        runAsGroup: 65534
       containers:
       - name: master
         image: quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-deployment.yaml
@@ -26,6 +26,7 @@ spec:
       runtimeClassName: kata
       securityContext:
         runAsUser: 1000
+        runAsGroup: 1000
       containers:
       - name: master
         image: quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-job.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-job.yaml
@@ -11,6 +11,8 @@ spec:
   template:
     spec:
       runtimeClassName: kata
+      securityContext:
+        supplementalGroups: [10]
       containers:
         - name: hello
           image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod-pvc.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-pod-pvc.yaml
@@ -9,6 +9,8 @@ metadata:
   name: policy-pod-pvc
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
     - name: busybox
       image: "quay.io/prometheus/busybox:latest"

--- a/tests/integration/kubernetes/runtimeclass_workloads/numa-topology-gpu-test.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/numa-topology-gpu-test.yaml.in
@@ -11,6 +11,8 @@ metadata:
     app: ${POD_NAME_NUMA}
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
   containers:
   - name: numa-check
     image: "quay.io/kata-containers/numa:2026-05-15@sha256:a863fcf95fcbbf63352b0555a61a62537f74399dc4bca826a2e42d001e26accb"

--- a/tests/integration/kubernetes/runtimeclass_workloads/numa-topology-test.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/numa-topology-test.yaml.in
@@ -11,6 +11,8 @@ metadata:
     app: ${POD_NAME_NUMA}
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
   containers:
   - name: numa-check
     image: "quay.io/kata-containers/numa:2026-05-15@sha256:a863fcf95fcbbf63352b0555a61a62537f74399dc4bca826a2e42d001e26accb"

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-1-8b-instruct-tee.yaml.in
@@ -16,9 +16,8 @@ metadata:
     # cc_init_data annotation will be added by genpolicy with CDH configuration
     # from the custom default-initdata.toml created by create_nim_initdata_file()
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
+  # Explicit user/group IDs keep guest-pull requests aligned with policy.
+  # See docs/Limitations.md#guest-pulled-container-images.
   securityContext:
     runAsUser: 1000
     runAsGroup: 1000

--- a/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/nvidia-nim-llama-3-2-nv-embedqa-1b-v2-tee.yaml.in
@@ -16,9 +16,8 @@ metadata:
     # cc_init_data annotation will be added by genpolicy with CDH configuration
     # from the custom default-initdata.toml created by create_nim_initdata_file()
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
+  # Explicit user/group IDs keep guest-pull requests aligned with policy.
+  # See docs/Limitations.md#guest-pulled-container-images.
   securityContext:
     runAsUser: 1000
     runAsGroup: 1000

--- a/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-client-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-client-pod.yaml
@@ -11,9 +11,8 @@ metadata:
   labels:
     app: openvpn-client
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
+  # Explicit security context values keep guest-pull requests aligned with policy.
+  # See docs/Limitations.md#guest-pulled-container-images.
   securityContext:
     runAsUser: 0
     runAsGroup: 0

--- a/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-server-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/openvpn/openvpn-server-pod.yaml
@@ -11,9 +11,8 @@ metadata:
   labels:
     app: openvpn-server
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
+  # Explicit security context values keep guest-pull requests aligned with policy.
+  # See docs/Limitations.md#guest-pulled-container-images.
   securityContext:
     runAsUser: 0
     runAsGroup: 0

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-besteffort.yaml
@@ -9,6 +9,8 @@ metadata:
   name: besteffort-test
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: qos-besteffort
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
@@ -9,6 +9,8 @@ metadata:
   name: burstable-test
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: qos-burstable
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-caps.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-caps.yaml
@@ -9,6 +9,8 @@ metadata:
   name: pod-caps
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
     - name: test-container
       image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-configmap-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-configmap-volume.yaml
@@ -10,6 +10,8 @@ metadata:
 spec:
   terminationGracePeriodSeconds: 0
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: test-container
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-configmap.yaml
@@ -9,6 +9,8 @@ metadata:
   name: config-env-test-pod
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
     - name: test-container
       image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-cpu-defaults.yaml
@@ -9,6 +9,8 @@ metadata:
   name: default-cpu-test
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: default-cpu-demo-ctr
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-empty-dir.yaml
@@ -9,6 +9,8 @@ metadata:
   name: sharevol-kata
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: test
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-env.yaml
@@ -9,6 +9,8 @@ metadata:
   name: test-env
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
     - name: test-container
       image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-file-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-file-volume.yaml
@@ -9,6 +9,8 @@ metadata:
   name: test-file-volume
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   restartPolicy: Never
   nodeName: NODE
   volumes:

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
@@ -9,6 +9,8 @@ metadata:
   name: qos-test
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: qos-guaranteed
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-hostname.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-hostname.yaml
@@ -10,6 +10,8 @@ metadata:
   name: test-pod-hostname
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   restartPolicy: Never
   containers:
   - image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-hostpath-kmsg.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-hostpath-kmsg.yaml
@@ -10,6 +10,8 @@ metadata:
   name: hostpath-kmsg
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   restartPolicy: Never
   volumes:
   - name: dev-kmsg

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-http-liveness.yaml
@@ -11,6 +11,8 @@ metadata:
   name: liveness-http
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
   containers:
   - name: liveness
     image: ${agnhost_image}

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-liveness.yaml
@@ -11,6 +11,8 @@ metadata:
   name: liveness-exec
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: liveness
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-nested-configmap-secret.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-nested-configmap-secret.yaml
@@ -24,6 +24,8 @@ metadata:
   name: nested-configmap-secret-pod
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
     - name: test-container
       image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-configmap.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-configmap.yaml
@@ -9,6 +9,8 @@ metadata:
   name: optional-empty-config-test-pod
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
     - name: test-container
       image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-secret.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-optional-empty-secret.yaml
@@ -9,6 +9,8 @@ metadata:
   name: optional-empty-secret-test-pod
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
     - name: test-container
       image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-privileged.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-privileged.yaml
@@ -10,6 +10,8 @@ metadata:
   name: privileged
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   restartPolicy: Never
   containers:
   - image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-quota-deployment.yaml
@@ -18,6 +18,8 @@ spec:
         purpose: quota-demo
     spec:
       runtimeClassName: kata
+      securityContext:
+        supplementalGroups: [10]
       containers:
       - name: pod-quota-demo
         image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-sandbox-cgroup.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-sandbox-cgroup.yaml
@@ -12,6 +12,8 @@ metadata:
     io.katacontainers.config.runtime.sandbox_cgroup_only: "false"
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   restartPolicy: Never
   containers:
   - image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-sandbox-vcpus-allocation.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-sandbox-vcpus-allocation.yaml
@@ -12,6 +12,8 @@ metadata:
     io.katacontainers.config.hypervisor.default_vcpus: "0"
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: vcpus-less-than-one-with-no-limits
     image: quay.io/prometheus/busybox:latest
@@ -29,6 +31,8 @@ metadata:
     io.katacontainers.config.hypervisor.default_vcpus: "0.75"
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: vcpus-less-than-one-with-limits
     image: quay.io/prometheus/busybox:latest
@@ -47,6 +51,8 @@ metadata:
     io.katacontainers.config.hypervisor.default_vcpus: "0.75"
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: vcpus-more-than-one-with-limits
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-secret-env.yaml
@@ -9,6 +9,8 @@ metadata:
   name: secret-envars-test-pod
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: envars-test-container
     image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-secret.yaml
@@ -9,6 +9,8 @@ metadata:
   name: secret-test-pod
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
     - name: test-container
       image: quay.io/prometheus/busybox:latest

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-shared-volume.yaml
@@ -9,6 +9,8 @@ metadata:
   name: test-shared-volume
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   restartPolicy: Never
   volumes:
   - name: shared-data

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-sysctl.yaml
@@ -10,6 +10,7 @@ metadata:
 spec:
   runtimeClassName: kata
   securityContext:
+    supplementalGroups: [10]
     sysctls:
     - name: kernel.shm_rmid_forced
       value: "0"

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-tcp-liveness.yaml
@@ -11,6 +11,8 @@ metadata:
     app: tcp-liveness
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
   containers:
   - name: tcp-liveness
     image: ${agnhost_image}

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-termination-log-fail.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-termination-log-fail.yaml
@@ -10,6 +10,8 @@ metadata:
   name: pod-termination-log-fail
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   restartPolicy: Never
   containers:
     - name: termination-log-test

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-termination-log-success.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-termination-log-success.yaml
@@ -10,6 +10,8 @@ metadata:
   name: pod-termination-log-success
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   restartPolicy: Never
   containers:
     - name: termination-log-test

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-trusted-ephemeral-data-storage.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-trusted-ephemeral-data-storage.yaml
@@ -4,9 +4,8 @@ apiVersion: v1
 metadata:
   name: trusted-ephemeral-data-storage
 spec:
-  # Explicit user/group/supplementary groups to support nydus guest-pull.
-  # See issue https://github.com/kata-containers/kata-containers/issues/11162 and
-  # other references to this issue in the genpolicy source folder.
+  # Explicit security context values keep guest-pull requests aligned with policy.
+  # See docs/Limitations.md#guest-pulled-container-images.
   securityContext:
     runAsUser: 0
     runAsGroup: 0

--- a/tests/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pv-pod.yaml
@@ -9,6 +9,8 @@ metadata:
   name: pv-pod
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   nodeName: NODE
   volumes:
     - name: pv-storage

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -738,6 +738,17 @@ set_nginx_image() {
 	nginx_image="${nginx_registry}@${nginx_digest}"
 
 	NGINX_IMAGE="${nginx_image}" envsubst < "${input_yaml}" > "${output_yaml}"
+
+	auto_generate_policy_enabled || return 0
+
+	case "$(yq -r 'select(documentIndex == 0) | .kind' "${output_yaml}")" in
+		Pod)
+			set_pod_spec_security_context "${output_yaml}" ".spec" "" "" "1, 2, 3, 4, 6, 10, 11, 20, 26, 27"
+			;;
+		Deployment|ReplicationController)
+			set_pod_spec_security_context "${output_yaml}" ".spec.template.spec" "" "" "1, 2, 3, 4, 6, 10, 11, 20, 26, 27"
+			;;
+	esac
 }
 
 print_node_journal_since_test_start() {


### PR DESCRIPTION
## What changed

Genpolicy now derives image UID/GID/group information for guest-pull workloads the same way it does for host-pull workloads. Previously, when `guest_pull` was enabled, genpolicy skipped image-layer `/etc/passwd` and `/etc/group` parsing. This PR removes that special case, so that the generated policy is based on the identity declared by the image rather than the degraded host/containerd fallback identity.

Further, this PR makes genpolicy fail when `guest_pull` is enabled and the generated policy expects image-derived UID/GID/supplemental groups that are not explicitly declared in the Kubernetes `securityContext`.

Under guest-pull, this requires users to declare user identities explicitly. When doing so, users should follow best practices and de-privilege containers where possible (see e.g. https://kubernetes.io/docs/concepts/security/application-security-checklist/#security-context-pod or https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted)

## Example genpolicy failure:

```text
guest_pull is enabled for container 'gid' using image 'ghcr.io/burgerdev/weird-images/gid:latest@sha256:bdbb485bb9e3baf381a2957b9369b6051c6113097a5f8dcee27faff17624a2c0'. The generated policy expects UID=2, GID=1, AdditionalGids={1}; containerd may not reproduce image-derived user/group values when image layers are pulled in the guest. Set an explicit Kubernetes securityContext, for example:
securityContext:
  runAsUser: 2
  runAsGroup: 1
See docs/Limitations.md#guest-pulled-container-images.
```

## More background

Image config values such as `USER 1000` are already visible to both genpolicy and containerd. However, named users and group membership require passwd/group data from the image layers. Previously, if genpolicy skipped those layers under guest-pull, it could generate generate policy for root-like values such as `UID=0`, `GID=0`, and `AdditionalGids={0}`, even when the image declares a different runtime identity.

By using the same image identity flow for host-pull and guest-pull, genpolicy can compute the intended UID/GID/supplemental groups from the image. The failure message then points users at the explicit Kubernetes `securityContext` values needed to keep runtime requests and generated policy aligned.

## Outlook

This PR adds the explicit identities required for correctness. A follow-up can refine those values toward less-privileged users where the workloads allow it.

## Test updates

In terms of testing, this required to
- refresh golden policy files for the new image-derived identity values.
- update genpolicy test input manifests to declare the expected `securityContext` values explicitly, so missing guest-pull identity declarations are caught by the new failure path rather than hidden in test fixtures.
- support the injection of pod-level `securityContext` values into generated manifests using our Kubernetes test helpers.
- declare explicit UID/GID/supplemental groups for the affected guest-pull tests and static policy workloads. 
- refresh manifest comments to point at docs/Limitations.md#guest-pulled-container-images instead of issue #11162, clarifying why explicit `securityContext` values are present.