### PR TITLE
runtime-rs: qemu: pass -bios for non-confidential guests

### DIFF
--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -65,13 +65,13 @@ kernel_verity_params = "@KERNELVERITYPARAMS_NV@"
 
 # Path to the firmware.
 # If you want that qemu uses the default firmware leave this option empty
-firmware = "@FIRMWAREPATH@"
+firmware = "@FIRMWAREPATH_NV@"
 
 # Path to the firmware volume.
 # firmware TDVF or OVMF can be split into FIRMWARE_VARS.fd (UEFI variables
 # as configuration) and FIRMWARE_CODE.fd (UEFI program image). UEFI variables
 # can be customized per each user while UEFI code is kept same.
-firmware_volume = "@FIRMWAREVOLUMEPATH@"
+firmware_volume = "@FIRMWAREVOLUMEPATH_NV@"
 
 # Machine accelerators
 # comma-separated list of machine accelerators to pass to the hypervisor.

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -2603,7 +2603,24 @@ impl<'a> QemuCmdLine<'a> {
         {
             qemu_cmd_line.add_seccomp_sandbox(seccomp_sandbox);
         }
+
+        // For confidential guests (SEV/SEV-SNP/TDX), `-bios` is appended later
+        // by `add_{sev,sev_snp,tdx}_protection_device()` via the
+        // ProtectionDevice handling in QemuInner::start_vm(), using the
+        // firmware copied into the ProtectionDeviceConfig. For non-CC guests
+        // there is no such code path, so wire `boot_info.firmware` directly
+        // here. Otherwise the firmware configured in the TOML (e.g. OVMF.fd
+        // for the nvidia-gpu profile) would silently never reach qemu's
+        // command line.
+        if !config.security_info.confidential_guest && !config.boot_info.firmware.is_empty() {
+            qemu_cmd_line.add_bios(&config.boot_info.firmware);
+        }
+
         Ok(qemu_cmd_line)
+    }
+
+    fn add_bios(&mut self, firmware: &str) {
+        self.devices.push(Box::new(Bios::new(firmware.to_owned())));
     }
 
     /// Takes ownership of the CCW subchannel, leaving `None` in its place.


### PR DESCRIPTION
The `boot_info.firmware` field from the hypervisor configuration is
loaded by kata-types and surfaces in the TOML as `firmware = "..."`,
but the qemu cmdline generator never consumed it for non-CC guests.

Today, `-bios <path>` is only appended via the `Bios` device pushed by
`add_{sev,sev_snp,tdx}_protection_device()` in
`QemuInner::start_vm()`, which use the firmware copied into the
`ProtectionDeviceConfig`. That path is taken only when
`confidential_guest = true` and a SEV/SEV-SNP/TDX protection device is
configured. For plain Q35 profiles (notably the nvidia-gpu one, which
needs OVMF to boot the GPU passthrough VM), the `firmware` set in the
TOML was silently dropped and qemu fell back to its default BIOS.

Wire `boot_info.firmware` directly in `QemuCmdLine::new()` when no
protection device path is going to emit `-bios` (i.e. for non-CC
guests). CC paths are left untouched so we don't end up with a
duplicated `-bios` argument.