### PR TITLE
tests: nvidia: No policy for runtime-rs path

### DIFF
--- a/tests/integration/kubernetes/gha-run.sh
+++ b/tests/integration/kubernetes/gha-run.sh
@@ -475,7 +475,7 @@ function main() {
 		        ( "${TARGET_ARCH}" = "x86_64" || "${TARGET_ARCH}" = "aarch64" ) && \
 		        "${PULL_TYPE}" != "experimental-force-guest-pull" ]]; then
 			AUTO_GENERATE_POLICY="yes"
-		elif [[ "${KATA_HYPERVISOR}" = qemu-nvidia-gpu-* ]]; then
+		elif is_confidential_gpu_hypervisor "${KATA_HYPERVISOR}"; then
 			AUTO_GENERATE_POLICY="yes"
 		fi
 	fi


### PR DESCRIPTION
The current if condition causes agent security policies to be attached to the non-TEE NVIDIA runtime-rs runtime class. While this is good to see that it works, this is not intended. Thus, replacting the condition with is_confidential_gpu_hypervisor.