### PR TITLE
agent: compact EROFS overlay lowerdirs

### DIFF
--- a/src/agent/src/storage/multi_layer_erofs.rs
+++ b/src/agent/src/storage/multi_layer_erofs.rs
@@ -26,7 +26,7 @@ use crate::mount::baremount;
 use crate::sandbox::Sandbox;
 use crate::storage::{StorageContext, StorageHandler};
 use anyhow::{anyhow, Context, Result};
-use kata_sys_util::mount::create_mount_destination;
+use kata_sys_util::mount::{create_mount_destination, Mounter};
 use kata_types::device::{DRIVER_BLK_PCI_TYPE, DRIVER_SCSI_TYPE};
 use kata_types::mount::StorageDevice;
 use protocols::agent::Storage;
@@ -313,22 +313,21 @@ pub async fn handle_multi_layer_erofs_group(
     )
     .context("failed to create overlay mount destination")?;
 
-    let overlay_options = format!(
-        "upperdir={},lowerdir={},workdir={}",
-        upperdir.display(),
-        lowerdir,
-        workdir.display()
-    );
+    let overlay_mount = kata_types::mount::Mount {
+        source: OVERLAY_TYPE.to_string(),
+        destination: PathBuf::from(&ext4.mount_point),
+        fs_type: OVERLAY_TYPE.to_string(),
+        options: vec![
+            format!("upperdir={}", upperdir.display()),
+            format!("lowerdir={}", lowerdir),
+            format!("workdir={}", workdir.display()),
+        ],
+        ..Default::default()
+    };
 
-    baremount(
-        Path::new(OVERLAY_TYPE),
-        Path::new(&ext4.mount_point),
-        OVERLAY_TYPE,
-        nix::mount::MsFlags::empty(),
-        &overlay_options,
-        &logger,
-    )
-    .context("failed to mount overlay")?;
+    overlay_mount
+        .mount(Path::new(&ext4.mount_point))
+        .context("failed to mount overlay")?;
 
     info!(
         logger,


### PR DESCRIPTION
Use kata_types::mount::Mount for the final multi-layer EROFS overlay mount instead of calling baremount() directly.

The mount helper detects overlay option strings close to the kernel mount data limit. When lowerdir entries share a common parent, it changes into that directory and rewrites lowerdir to relative paths. That avoids repeating the same long prefix for every layer.

Multi-layer EROFS images can have many lower layers under /run/kata-containers/<cid>/multi-layer. Passing the raw absolute lowerdir list can exceed the mount option buffer and fail the final overlay mount, even after all layer devices mounted successfully.

Reuse the helper so this path follows Kata's normal overlay mount handling, including lowerdir compaction before mount(2).

Note: When testing the NVIDIA NIM samples using the erofs snapshotter, I was chasing down an error manifesting as `failed to mount overlay to /run/kata-containers/shared/containers/passthrough/.../rootfs, with error: ENOENT`. This change enables running the NVIDIA NIM samples using the erofs snapshotter. The NIM image for `k8s-nvidia-nim.bats` has 108 layers at the moment:

```
spec.containers{nvidia-nim-llama-3-1-8b-instruct}: Error: failed to create containerd task: failed to create shim task: Others("failed to handle message create container\n\nCaused by:\n    0: agent create container\n    1: rpc status: Status { code: INTERNAL, message: \"failed to mount overlay\\n\\nCaused by:\\n    failed to mount overlay to /run/kata-containers/shared/containers/passthrough/nvidia-nim-llama-3-1-8b-instruct/rootfs, witherror: ENOENT: No such file or directory\\n\\nStack backtrace:\\n   0: <unknown>\\n   1: <unknown>\\n   2: <unknown>\\n   3: <unknown>\\n   4: <unknown>\\n   5: <unknown>\\n   6: <unknown>\\n   7: <unknown>\\n   8: <unknown>\\n   9: <unknown>\\n  10: <unknown>\\n  11: <unknown>\\n  12: <unknown>\\n  13: <unknown>\\n  14: <unknown>\\n  15: <unknown>\\n  16: <unknown>\\n  17: <unknown>\\n  18: <unknown>\\n  19: <unknown>\\n  20: <unknown>\\n  21: <unknown>\\n  22: <unknown>\\n  23: <unknown>\", details: [], special_fields: SpecialFields { unknown_fields: UnknownFields { fields: None }, cached_size: CachedSize { size: 0 } } }\n\nStack backtrace:\n   0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from\n   1: agent::kata::agent::<impl agent::Agent for agent::kata::KataAgent>::create_container::{{closure}}::{{closure}}\n   2: agent::kata::agent::<impl agent::Agent for agent::kata::KataAgent>::create_container::{{closure}}\n   3: virt_container::container_manager::container::Container::create::{{closure}}\n   4: <virt_container::container_manager::manager::VirtContainerManager as common::container_manager::ContainerManager>::create_container::{{closure}}::{{closure}}\n   5: <virt_container::container_manager::manager::VirtContainerManager as common::container_manager::ContainerManager>::create_container::{{closure}}\n   6: runtimes::manager::RuntimeHandlerManager::handler_task_message::{{closure}}::{{closure}}\n   7: runtimes::manager::RuntimeHandlerManager::handler_task_message::{{closure}}\n   8: <service::task_service::TaskService as containerd_shim_protos::shim::shim_ttrpc_async::Task>::create::{{closure}}\n   9: <containerd_shim_protos::shim::shim_ttrpc_async::CreateMethod as ttrpc::asynchronous::utils::MethodHandler>::handler::{{closure}}\n  10: ttrpc::asynchronous::server::HandlerContext::handle_request::{{closure}}\n  11: <ttrpc::asynchronous::server::ServerReader as ttrpc::asynchronous::connection::ReaderDelegate>::handle_msg::{{closure}}::{{closure}}\n  12: tokio::runtime::task::raw::poll\n  13: tokio::runtime::scheduler::multi_thread::worker::Context::run_task\n  14: tokio::runtime::task::raw::poll\n  15: std::sys::backtrace::__rust_begin_short_backtrace\n  16: core::ops::function::FnOnce::call_once{{vtable.shim}}\n  17: std::sys::thread::unix::Thread::new::thread_start")
```

Note: after this fix I can observe the following for the NIM pod manifest (`kubectl exec`):
```
overlay on / type overlay (rw,relatime,lowerdir=lower-0:lower-1:lower-2:lower-3:lower-4:lower-5:lower-6:lower-7:lower-8:lower-9:lower-10:lower-11:lower-12:lower-13:lower-14:lower-15:lower-16:lower-17:lower-18:lower-19:lower-20:lower-21:lower-22:lower-23:lower-24:lower-25:lower-26:lower-27:lower-28:lower-29:lower-30:lower-31:lower-32:lower-33:lower-34:lower-35:lower-36:lower-37:lower-38:lower-39:lower-40:lower-41:lower-42:lower-43:lower-44:lower-45:lower-46:lower-47:lower-48:lower-49:lower-50:lower-51:lower-52:lower-53:lower-54:lower-55:lower-56:lower-57:lower-58:lower-59:lower-60:lower-61:lower-62:lower-63:lower-64:lower-65:lower-66:lower-67:lower-68:lower-69:lower-70:lower-71:lower-72:lower-73:lower-74:lower-75:lower-76:lower-77:lower-78:lower-79:lower-80:lower-81:lower-82:lower-83:lower-84:lower-85:lower-86:lower-87:lower-88:lower-89:lower-90:lower-91:lower-92:lower-93:lower-94:lower-95:lower-96:lower-97:lower-98:lower-99:lower-100:lower-101:lower-102:lower-103:lower-104:lower-105:lower-106:lower-107,upperdir=/run/kata-containers/eb7d0057f0d987f04f052336627b96991dbbfd4a6e5b2bf80a2c7586cf753fea/multi-layer/upper/upper,workdir=/run/kata-containers/eb7d0057f0d987f04f052336627b96991dbbfd4a6e5b2bf80a2c7586cf753fea/multi-layer/upper/work,index=off,uuid=on,xino=off)
```