### PR TITLE
storage: add block-plain emptyDir mode

### DIFF
--- a/src/agent/src/storage/block_handler.rs
+++ b/src/agent/src/storage/block_handler.rs
@@ -16,7 +16,7 @@ use kata_types::device::DRIVER_BLK_CCW_TYPE;
 use kata_types::device::{
     DRIVER_BLK_MMIO_TYPE, DRIVER_BLK_PCI_TYPE, DRIVER_NVDIMM_TYPE, DRIVER_SCSI_TYPE,
 };
-use kata_types::mount::StorageDevice;
+use kata_types::mount::{StorageDevice, KATA_BLOCK_VOLUME_CREATE_FS};
 use nix::sys::stat::{major, minor};
 use protocols::agent::Storage;
 use tracing::instrument;
@@ -37,6 +37,17 @@ use slog::Logger;
 #[cfg(target_arch = "s390x")]
 use std::str::FromStr;
 
+const EPHEMERAL_ENCRYPTION_DRIVER_OPTION: &str = "encryption_key=ephemeral";
+const MKFS_EXT4: &str = "mkfs.ext4";
+const BLOCK_EMPTYDIR_EXT4_MKFS_OPTS: [&str; 8] =
+    ["-O", "^has_journal", "-m", "0", "-i", "163840", "-I", "128"];
+
+#[derive(Debug, Eq, PartialEq)]
+struct BlockStorageDriverOptions {
+    has_ephemeral_encryption: bool,
+    should_create_filesystem: bool,
+}
+
 fn get_device_number(dev_path: &str, metadata: Option<&fs::Metadata>) -> Result<String> {
     let dev_id = match metadata {
         Some(m) => m.rdev(),
@@ -54,24 +65,169 @@ async fn handle_block_storage(
     storage: &Storage,
     dev_num: &str,
 ) -> Result<Arc<dyn StorageDevice>> {
-    let has_ephemeral_encryption = storage
-        .driver_options
-        .contains(&"encryption_key=ephemeral".to_string());
+    let options = block_storage_driver_options(storage)?;
 
-    if has_ephemeral_encryption {
+    if options.has_ephemeral_encryption {
+        let mkfs_opts = BLOCK_EMPTYDIR_EXT4_MKFS_OPTS.join(" ");
         crate::rpc::cdh_secure_mount(
             "block-device",
             dev_num,
             "luks2",
             &storage.mount_point,
-            "-O ^has_journal -m 0 -i 163840 -I 128",
+            &mkfs_opts,
         )
         .await?;
         set_ownership(logger, storage)?;
         new_device(storage.mount_point.clone())
     } else {
+        if options.should_create_filesystem {
+            ensure_block_filesystem(logger, storage).await?;
+        }
         let path = common_storage_handler(logger, storage)?;
         new_device(path)
+    }
+}
+
+fn block_storage_driver_options(storage: &Storage) -> Result<BlockStorageDriverOptions> {
+    let has_ephemeral_encryption = storage
+        .driver_options
+        .iter()
+        .any(|opt| opt == EPHEMERAL_ENCRYPTION_DRIVER_OPTION);
+    let should_create_filesystem = should_create_block_filesystem(storage);
+
+    if has_ephemeral_encryption && !should_create_filesystem {
+        return Err(anyhow!(
+            "{} requires {} for block storage",
+            EPHEMERAL_ENCRYPTION_DRIVER_OPTION,
+            KATA_BLOCK_VOLUME_CREATE_FS
+        ));
+    }
+
+    Ok(BlockStorageDriverOptions {
+        has_ephemeral_encryption,
+        should_create_filesystem,
+    })
+}
+
+fn should_create_block_filesystem(storage: &Storage) -> bool {
+    storage
+        .driver_options
+        .iter()
+        .any(|opt| opt == KATA_BLOCK_VOLUME_CREATE_FS)
+}
+
+async fn ensure_block_filesystem(logger: &Logger, storage: &Storage) -> Result<()> {
+    match storage.fstype.as_str() {
+        "ext4" => ensure_ext4_filesystem(logger, &storage.source).await,
+        _ => Err(anyhow!(
+            "creating filesystem {} for block storage is unsupported",
+            storage.fstype
+        )),
+    }
+}
+
+async fn ensure_ext4_filesystem(logger: &Logger, source: &str) -> Result<()> {
+    // This option is emitted for block emptyDir volumes, whose backing device
+    // is ephemeral and freshly allocated for the pod.
+    info!(logger, "creating ext4 filesystem"; "source" => source);
+    let output = {
+        // Keep the agent SIGCHLD handler from reaping this child before
+        // tokio::process observes it.
+        let _locker = rustjail::container::WAIT_PID_LOCKER.lock().await;
+        // BLOCK_EMPTYDIR_EXT4_MKFS_OPTS mirrors CDH's EXT4_INTEGRITY_MKFS_OPTS
+        // from confidential-data-hub/hub/src/storage/volume_type/blockdevice/mod.rs.
+        // CDH's FsFormatter adds "-F" and its mapped device path separately in
+        // confidential-data-hub/hub/src/storage/drivers/filesystem.rs; here the
+        // agent invokes mkfs.ext4 directly, so add "-F" and source below.
+        tokio::process::Command::new(MKFS_EXT4)
+            .arg("-F")
+            .args(BLOCK_EMPTYDIR_EXT4_MKFS_OPTS)
+            .arg(source)
+            .output()
+            .await
+            .with_context(|| format!("run {MKFS_EXT4} for {source}"))?
+    };
+
+    if output.status.success() {
+        return Ok(());
+    }
+
+    Err(anyhow!(
+        "{} failed for {}: status={}, stdout={}, stderr={}",
+        MKFS_EXT4,
+        source,
+        output.status,
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn storage_with_driver_options(options: &[&str]) -> Storage {
+        Storage {
+            driver_options: options.iter().map(|opt| opt.to_string()).collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn block_storage_options_allow_normal_existing_storage() {
+        let storage = storage_with_driver_options(&[]);
+
+        let options = block_storage_driver_options(&storage).unwrap();
+
+        assert_eq!(
+            options,
+            BlockStorageDriverOptions {
+                has_ephemeral_encryption: false,
+                should_create_filesystem: false,
+            }
+        );
+    }
+
+    #[test]
+    fn block_storage_options_allow_plain_fresh_storage() {
+        let storage = storage_with_driver_options(&[KATA_BLOCK_VOLUME_CREATE_FS]);
+
+        let options = block_storage_driver_options(&storage).unwrap();
+
+        assert_eq!(
+            options,
+            BlockStorageDriverOptions {
+                has_ephemeral_encryption: false,
+                should_create_filesystem: true,
+            }
+        );
+    }
+
+    #[test]
+    fn block_storage_options_allow_encrypted_fresh_storage() {
+        let storage = storage_with_driver_options(&[
+            EPHEMERAL_ENCRYPTION_DRIVER_OPTION,
+            KATA_BLOCK_VOLUME_CREATE_FS,
+        ]);
+
+        let options = block_storage_driver_options(&storage).unwrap();
+
+        assert_eq!(
+            options,
+            BlockStorageDriverOptions {
+                has_ephemeral_encryption: true,
+                should_create_filesystem: true,
+            }
+        );
+    }
+
+    #[test]
+    fn block_storage_options_reject_encryption_without_filesystem_creation() {
+        let storage = storage_with_driver_options(&[EPHEMERAL_ENCRYPTION_DRIVER_OPTION]);
+
+        let err = block_storage_driver_options(&storage).unwrap_err();
+
+        assert!(err.to_string().contains(KATA_BLOCK_VOLUME_CREATE_FS));
     }
 }
 
@@ -96,8 +252,8 @@ impl StorageHandler for VirtioBlkMmioHandler {
                 .await
                 .context("failed to get mmio device name")?;
         }
-        let path = common_storage_handler(ctx.logger, &storage)?;
-        new_device(path)
+        let dev_num = get_device_number(&storage.source, None)?;
+        handle_block_storage(ctx.logger, &storage, &dev_num).await
     }
 }
 

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -31,8 +31,8 @@ pub use self::hypervisor::{
 
 mod runtime;
 pub use self::runtime::{
-    Runtime, RuntimeVendor, EMPTYDIR_MODE_BLOCK_ENCRYPTED, EMPTYDIR_MODE_SHARED_FS,
-    RUNTIME_NAME_VIRTCONTAINER,
+    Runtime, RuntimeVendor, EMPTYDIR_MODE_BLOCK_ENCRYPTED, EMPTYDIR_MODE_BLOCK_PLAIN,
+    EMPTYDIR_MODE_SHARED_FS, RUNTIME_NAME_VIRTCONTAINER,
 };
 
 pub use self::agent::AGENT_NAME_KATA;

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -24,6 +24,9 @@ pub const EMPTYDIR_MODE_SHARED_FS: &str = "shared-fs";
 /// EmptyDir mode: plug a block device to be encrypted in the guest.
 pub const EMPTYDIR_MODE_BLOCK_ENCRYPTED: &str = "block-encrypted";
 
+/// EmptyDir mode: plug a block device to be mounted directly in the guest.
+pub const EMPTYDIR_MODE_BLOCK_PLAIN: &str = "block-plain";
+
 /// Kata runtime configuration information.
 #[derive(Debug, Default, Deserialize, Serialize)]
 pub struct Runtime {
@@ -149,6 +152,7 @@ pub struct Runtime {
     /// - shared-fs (default): shares the emptyDir folder with the guest using the method
     ///   given by the shared_fs setting.
     /// - block-encrypted: plugs a block device to be encrypted in the guest via CDH/LUKS2.
+    /// - block-plain: plugs a block device to be mounted directly in the guest.
     #[serde(default)]
     pub emptydir_mode: String,
 
@@ -277,6 +281,7 @@ impl ConfigOps for Runtime {
         let emptydir_mode = &conf.runtime.emptydir_mode;
         if emptydir_mode != EMPTYDIR_MODE_SHARED_FS
             && emptydir_mode != EMPTYDIR_MODE_BLOCK_ENCRYPTED
+            && emptydir_mode != EMPTYDIR_MODE_BLOCK_PLAIN
         {
             return Err(std::io::Error::other(format!(
                 "Invalid emptydir_mode `{emptydir_mode}` in configuration file",
@@ -408,6 +413,14 @@ emptydir_mode = "block-encrypted"
         let config: TomlConfig = TomlConfig::load(content).unwrap();
         config.validate().unwrap();
         assert_eq!(&config.runtime.emptydir_mode, "block-encrypted");
+
+        let content = r#"
+[runtime]
+emptydir_mode = "block-plain"
+"#;
+        let config: TomlConfig = TomlConfig::load(content).unwrap();
+        config.validate().unwrap();
+        assert_eq!(&config.runtime.emptydir_mode, "block-plain");
     }
 
     #[test]

--- a/src/libs/kata-types/src/mount.rs
+++ b/src/libs/kata-types/src/mount.rs
@@ -40,6 +40,9 @@ pub const DEFAULT_KATA_DIRECT_VOLUME_ROOT_PATH: &str = "/run/kata-containers/sha
 pub const KATA_VOLUME_OVERLAYFS_CREATE_DIR: &str =
     "io.katacontainers.volume.overlayfs.create_directory";
 
+/// Key to request filesystem creation for a fresh block volume.
+pub const KATA_BLOCK_VOLUME_CREATE_FS: &str = "create_filesystem";
+
 /// SANDBOX_BIND_MOUNTS_DIR is for sandbox bindmounts
 pub const SANDBOX_BIND_MOUNTS_DIR: &str = "sandbox-mounts";
 

--- a/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
@@ -522,6 +522,21 @@ disable_new_netns = false
 # See: https://pkg.go.dev/github.com/kata-containers/kata-containers/src/runtime/virtcontainers#ContainerType
 sandbox_cgroup_only = @DEFSANDBOXCGROUPONLY_CLH@
 
+# Specifies how Kubernetes emptyDir volumes are handled.
+# Options:
+#
+#   - shared-fs (default)
+#     Shares the emptyDir folder with the guest using the method given
+#     by the `shared_fs` setting.
+#
+#   - block-encrypted
+#     Plugs a block device to be encrypted in the guest.
+#
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
+emptydir_mode = "@DEFEMPTYDIRMODE@"
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -522,6 +522,21 @@ disable_new_netns = false
 # See: https://pkg.go.dev/github.com/kata-containers/kata-containers/src/runtime/virtcontainers#ContainerType
 sandbox_cgroup_only = @DEFSANDBOXCGROUPONLY_CLH@
 
+# Specifies how Kubernetes emptyDir volumes are handled.
+# Options:
+#
+#   - shared-fs (default)
+#     Shares the emptyDir folder with the guest using the method given
+#     by the `shared_fs` setting.
+#
+#   - block-encrypted
+#     Plugs a block device to be encrypted in the guest.
+#
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
+emptydir_mode = "@DEFEMPTYDIRMODE@"
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -523,6 +523,21 @@ disable_new_netns = false
 # See: https://pkg.go.dev/github.com/kata-containers/kata-containers/src/runtime/virtcontainers#ContainerType
 sandbox_cgroup_only = @DEFSANDBOXCGROUPONLY_DB@
 
+# Specifies how Kubernetes emptyDir volumes are handled.
+# Options:
+#
+#   - shared-fs (default)
+#     Shares the emptyDir folder with the guest using the method given
+#     by the `shared_fs` setting.
+#
+#   - block-encrypted
+#     Plugs a block device to be encrypted in the guest.
+#
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
+emptydir_mode = "@DEFEMPTYDIRMODE@"
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -706,6 +706,9 @@ vfio_mode = "@DEFVFIOMODE@"
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -820,6 +820,9 @@ vfio_mode = "@DEFVFIOMODE_NV@"
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -752,6 +752,9 @@ vfio_mode = "@DEFVFIOMODE_NV@"
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -728,6 +728,9 @@ vfio_mode = "@DEFVFIOMODE_NV@"
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -796,6 +796,9 @@ vfio_mode = "@DEFVFIOMODE@"
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -682,6 +682,9 @@ vfio_mode = "@DEFVFIOMODE_SE@"
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -728,6 +728,9 @@ vfio_mode = "@DEFVFIOMODE@"
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -706,6 +706,9 @@ vfio_mode = "@DEFVFIOMODE@"
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -268,6 +268,21 @@ static_sandbox_resource_mgmt = true
 #
 vfio_mode = "@DEFVFIOMODE@"
 
+# Specifies how Kubernetes emptyDir volumes are handled.
+# Options:
+#
+#   - shared-fs (default)
+#     Shares the emptyDir folder with the guest using the method given
+#     by the `shared_fs` setting.
+#
+#   - block-encrypted
+#     Plugs a block device to be encrypted in the guest.
+#
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
+emptydir_mode = "@DEFEMPTYDIRMODE@"
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -413,6 +413,9 @@ static_sandbox_resource_mgmt = @DEFSTATICRESOURCEMGMT_FC@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk.rs
@@ -85,6 +85,9 @@ pub struct BlockConfig {
     /// drive is opened as read-write.
     pub is_readonly: bool,
 
+    /// Enables discard/unmap support for this block device.
+    pub discard_unmap: bool,
+
     /// Don't close `path_on_host` file when dropping the device.
     pub no_drop: bool,
 

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk_modern.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/virtio_blk_modern.rs
@@ -26,6 +26,9 @@ pub struct BlockConfigModern {
     /// drive is opened as read-write.
     pub is_readonly: bool,
 
+    /// Enables discard/unmap support for this block device.
+    pub discard_unmap: bool,
+
     /// Don't close `path_on_host` file when dropping the device.
     pub no_drop: bool,
 

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -943,6 +943,7 @@ struct BlockBackend {
     cache_direct: bool,
     cache_no_flush: bool,
     read_only: bool,
+    discard_unmap: bool,
 }
 
 impl BlockBackend {
@@ -955,6 +956,7 @@ impl BlockBackend {
             cache_direct,
             cache_no_flush: false,
             read_only: true,
+            discard_unmap: false,
         }
     }
 
@@ -987,6 +989,12 @@ impl BlockBackend {
         self.read_only = read_only;
         self
     }
+
+    #[allow(dead_code)]
+    fn set_discard_unmap(&mut self, discard_unmap: bool) -> &mut Self {
+        self.discard_unmap = discard_unmap;
+        self
+    }
 }
 
 #[async_trait]
@@ -1011,6 +1019,9 @@ impl ToQemuParams for BlockBackend {
             params.push("auto-read-only=on".to_owned());
         } else {
             params.push("auto-read-only=off".to_owned());
+        }
+        if self.discard_unmap {
+            params.push("discard=unmap".to_owned());
         }
         Ok(vec!["-blockdev".to_owned(), params.join(",")])
     }
@@ -1070,6 +1081,7 @@ struct DeviceVirtioBlk {
     id: String,
     config_wce: bool,
     share_rw: bool,
+    discard: bool,
     devno: Option<String>,
 }
 
@@ -1080,6 +1092,7 @@ impl DeviceVirtioBlk {
             id: id.to_owned(),
             config_wce: false,
             share_rw: true,
+            discard: false,
             devno,
         }
     }
@@ -1093,6 +1106,12 @@ impl DeviceVirtioBlk {
     #[allow(dead_code)]
     fn set_share_rw(&mut self, share_rw: bool) -> &mut Self {
         self.share_rw = share_rw;
+        self
+    }
+
+    #[allow(dead_code)]
+    fn set_discard(&mut self, discard: bool) -> &mut Self {
+        self.discard = discard;
         self
     }
 }
@@ -1112,6 +1131,9 @@ impl ToQemuParams for DeviceVirtioBlk {
             params.push("share-rw=on".to_owned());
         } else {
             params.push("share-rw=off".to_owned());
+        }
+        if self.discard {
+            params.push("discard=on".to_owned());
         }
         params.push(format!("serial=image-{}", self.id));
         if let Some(devno) = &self.devno {
@@ -2870,16 +2892,19 @@ impl<'a> QemuCmdLine<'a> {
         path: &str,
         is_direct: bool,
         is_scsi: bool,
+        discard_unmap: bool,
     ) -> Result<()> {
-        self.devices
-            .push(Box::new(BlockBackend::new(device_id, path, is_direct)));
+        let mut backend = BlockBackend::new(device_id, path, is_direct);
+        backend.set_discard_unmap(discard_unmap);
+        self.devices.push(Box::new(backend));
         let devno = get_devno_ccw(&mut self.ccw_subchannel, device_id);
         if is_scsi {
             self.devices
                 .push(Box::new(DeviceScsiHd::new(device_id, "scsi0.0", devno)));
         } else {
-            self.devices
-                .push(Box::new(DeviceVirtioBlk::new(device_id, bus_type(), devno)));
+            let mut device = DeviceVirtioBlk::new(device_id, bus_type(), devno);
+            device.set_discard(discard_unmap);
+            self.devices.push(Box::new(device));
         }
 
         Ok(())
@@ -3466,5 +3491,34 @@ impl SeccompSandbox {
 impl ToQemuParams for SeccompSandbox {
     async fn qemu_params(&self) -> Result<Vec<String>> {
         Ok(vec!["-sandbox".to_owned(), self.param.clone()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn contains_param(params: &[String], expected: &str) -> bool {
+        params
+            .iter()
+            .flat_map(|param| param.split(','))
+            .any(|param| param == expected)
+    }
+
+    #[actix_rt::test]
+    async fn test_qemu_block_discard_unmap_params() {
+        let mut backend = BlockBackend::new("blk0", "/tmp/disk.img", true);
+        backend.set_discard_unmap(true);
+        let backend_params = backend.qemu_params().await.unwrap();
+        assert!(contains_param(&backend_params, "discard=unmap"));
+
+        let mut virtio_blk = DeviceVirtioBlk::new("blk0", VirtioBusType::Pci, None);
+        virtio_blk.set_discard(true);
+        let virtio_blk_params = virtio_blk.qemu_params().await.unwrap();
+        assert!(contains_param(&virtio_blk_params, "discard=on"));
+
+        let scsi_hd = DeviceScsiHd::new("blk0", "scsi0.0", None);
+        let scsi_hd_params = scsi_hd.qemu_params().await.unwrap();
+        assert!(!contains_param(&scsi_hd_params, "discard=on"));
     }
 }

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -150,6 +150,7 @@ impl QemuInner {
                                     .is_direct
                                     .unwrap_or(self.config.blockdev_info.block_device_cache_direct),
                                 block_dev.config.driver_option.as_str() == KATA_SCSI_DEV_TYPE,
+                                block_dev.config.discard_unmap,
                             )?,
                         unsupported => {
                             info!(sl!(), "unsupported block device driver: {}", unsupported)
@@ -1027,6 +1028,7 @@ impl QemuInner {
                         ),
                         block_device.config.is_readonly,
                         block_device.config.no_drop,
+                        block_device.config.discard_unmap,
                         block_device.config.logical_sector_size,
                         block_device.config.physical_sector_size,
                         &block_device.config.format,
@@ -1079,6 +1081,7 @@ impl QemuInner {
                     is_direct,
                     is_readonly,
                     no_drop,
+                    discard_unmap,
                     driver,
                     logical_sector_size,
                     physical_sector_size,
@@ -1094,6 +1097,7 @@ impl QemuInner {
                         ),
                         cfg.is_readonly,
                         cfg.no_drop,
+                        cfg.discard_unmap,
                         self.config.blockdev_info.block_device_driver.clone(),
                         cfg.logical_sector_size,
                         cfg.physical_sector_size,
@@ -1110,6 +1114,7 @@ impl QemuInner {
                         is_direct,
                         is_readonly,
                         no_drop,
+                        discard_unmap,
                         logical_sector_size,
                         physical_sector_size,
                         &BlockDeviceFormat::default(),

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -14,7 +14,7 @@ use kata_types::config::hypervisor::{VIRTIO_BLK_CCW, VIRTIO_SCSI};
 use kata_types::rootless::is_rootless;
 use nix::sys::socket::{sendmsg, ControlMessage, MsgFlags};
 use qapi_qmp::{
-    self as qmp, BlockdevAioOptions, BlockdevOptions, BlockdevOptionsBase,
+    self as qmp, BlockdevAioOptions, BlockdevDiscardOptions, BlockdevOptions, BlockdevOptionsBase,
     BlockdevOptionsGenericCOWFormat, BlockdevOptionsGenericFormat, BlockdevOptionsRaw, BlockdevRef,
     MigrationInfo, PciDeviceInfo,
 };
@@ -775,6 +775,7 @@ impl Qmp {
         is_direct: Option<bool>,
         is_readonly: bool,
         no_drop: bool,
+        discard_unmap: bool,
         logical_block_size: u32,
         physical_block_size: u32,
         format: &BlockDeviceFormat,
@@ -782,6 +783,7 @@ impl Qmp {
     ) -> Result<(Option<PciPath>, Option<String>)> {
         // `blockdev-add`
         let node_name = block_node_name(index);
+        let discard_option = || discard_unmap.then_some(BlockdevDiscardOptions::unmap);
 
         let create_base_options = || qapi_qmp::BlockdevOptionsBase {
             auto_read_only: None,
@@ -794,7 +796,7 @@ impl Qmp {
                 })
             },
             detect_zeroes: None,
-            discard: None,
+            discard: discard_option(),
             force_share: None,
             node_name: None,
             read_only: Some(is_readonly),
@@ -832,7 +834,7 @@ impl Qmp {
                 base: BlockdevOptionsBase {
                     detect_zeroes: None,
                     cache: None,
-                    discard: None,
+                    discard: discard_option(),
                     force_share: if is_readonly { Some(true) } else { None },
                     auto_read_only: None,
                     node_name: Some(node_name.clone()),
@@ -857,7 +859,7 @@ impl Qmp {
                     base: BlockdevOptionsBase {
                         detect_zeroes: None,
                         cache: None,
-                        discard: None,
+                        discard: discard_option(),
                         force_share: Some(true),
                         auto_read_only: None,
                         node_name: Some(node_name.clone()),
@@ -882,6 +884,9 @@ impl Qmp {
         // `device_add`
         let mut blkdev_add_args = Dictionary::new();
         blkdev_add_args.insert("drive".to_owned(), node_name.clone().into());
+        if discard_unmap && block_driver != VIRTIO_SCSI {
+            blkdev_add_args.insert("discard".to_owned(), true.into());
+        }
 
         if logical_block_size > 0 {
             blkdev_add_args.insert("logical_block_size".to_owned(), logical_block_size.into());

--- a/src/runtime-rs/crates/resource/src/volume/block_emptydir_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/block_emptydir_volume.rs
@@ -19,9 +19,11 @@ use hypervisor::{
     BlockConfigModern, BlockDeviceAio,
 };
 use kata_sys_util::k8s::is_disk_empty_dir;
-use kata_types::config::EMPTYDIR_MODE_BLOCK_ENCRYPTED;
-use kata_types::mount::DEFAULT_KATA_GUEST_SANDBOX_DIR;
-use kata_types::mount::{add_volume_mount_info, is_volume_mounted, DirectVolumeMountInfo};
+use kata_types::config::{EMPTYDIR_MODE_BLOCK_ENCRYPTED, EMPTYDIR_MODE_BLOCK_PLAIN};
+use kata_types::mount::{
+    add_volume_mount_info, is_volume_mounted, DirectVolumeMountInfo,
+    DEFAULT_KATA_GUEST_SANDBOX_DIR, KATA_BLOCK_VOLUME_CREATE_FS,
+};
 use nix::sys::statfs::statfs;
 use oci_spec::runtime as oci;
 use tokio::sync::RwLock;
@@ -31,8 +33,10 @@ use crate::volume::utils::KATA_MOUNT_BIND_TYPE;
 const DISK_IMG: &str = "disk.img";
 const ENCRYPTION_KEY_DRIVER_OPTION: &str = "encryption_key";
 const ENCRYPTION_KEY_VALUE: &str = "ephemeral";
+const METADATA_CREATE_FILESYSTEM: &str = "createFilesystem";
 const METADATA_ENCRYPTION_KEY: &str = "encryptionKey";
 const METADATA_FS_GROUP: &str = "fsGroup";
+const DISCARD_MOUNT_OPTION: &str = "discard";
 
 /// Information about an ephemeral disk created on the host, needed for
 /// sandbox-level cleanup.
@@ -43,19 +47,26 @@ pub(crate) struct EphemeralDiskInfo {
 }
 
 #[derive(Clone)]
-pub(crate) struct EncryptedEmptyDirVolume {
+pub(crate) struct BlockEmptyDirVolume {
     storage: Option<agent::Storage>,
     mount: oci::Mount,
     device_id: String,
     pub(crate) disk_info: EphemeralDiskInfo,
 }
 
-impl EncryptedEmptyDirVolume {
-    pub(crate) async fn new(d: &RwLock<DeviceManager>, m: &oci::Mount, sid: &str) -> Result<Self> {
+impl BlockEmptyDirVolume {
+    pub(crate) async fn new(
+        d: &RwLock<DeviceManager>,
+        m: &oci::Mount,
+        sid: &str,
+        emptydir_mode: &str,
+    ) -> Result<Self> {
+        let encrypted = emptydir_mode == EMPTYDIR_MODE_BLOCK_ENCRYPTED;
+        let discard_unmap = emptydir_mode == EMPTYDIR_MODE_BLOCK_PLAIN;
         let source = m
             .source()
             .as_ref()
-            .ok_or_else(|| anyhow!("encrypted emptyDir mount has no source"))?
+            .ok_or_else(|| anyhow!("block emptyDir mount has no source"))?
             .display()
             .to_string();
 
@@ -77,21 +88,12 @@ impl EncryptedEmptyDirVolume {
             f.set_len(capacity)
                 .with_context(|| format!("truncate sparse disk to {capacity} bytes"))?;
 
-            let mut metadata = HashMap::new();
-            metadata.insert(
-                METADATA_ENCRYPTION_KEY.to_string(),
-                ENCRYPTION_KEY_VALUE.to_string(),
-            );
-            if dir_gid != 0 {
-                metadata.insert(METADATA_FS_GROUP.to_string(), dir_gid.to_string());
-            }
-
             let mount_info = DirectVolumeMountInfo {
                 volume_type: "blk".to_string(),
                 device: disk_path.display().to_string(),
                 fs_type: "ext4".to_string(),
-                metadata,
-                options: vec![],
+                metadata: block_emptydir_metadata(encrypted, dir_gid),
+                options: block_emptydir_mount_options(discard_unmap),
             };
 
             add_volume_mount_info(&source, &mount_info)
@@ -107,28 +109,25 @@ impl EncryptedEmptyDirVolume {
             queue_size: blkdev_info.queue_size,
             logical_sector_size: blkdev_info.block_device_logical_sector_size,
             physical_sector_size: blkdev_info.block_device_physical_sector_size,
+            discard_unmap,
             ..Default::default()
         };
 
         let device_info = do_handle_device(d, &DeviceConfig::BlockCfgModern(block_config))
             .await
-            .context("plug encrypted emptyDir block device")?;
+            .context("plug block emptyDir block device")?;
 
         let (storage, mut mount, device_id) =
             crate::volume::utils::handle_block_volume(device_info, m, false, sid, "ext4")
                 .await
-                .context("handle encrypted emptyDir block volume")?;
+                .context("handle block emptyDir block volume")?;
 
         // genpolicy generates a "bind" type mount for emptyDir volumes; keep
         // the OCI mount type as "bind" so the agent policy allows the request.
         mount.set_typ(Some("bind".to_string()));
 
         let mut storage = storage;
-        storage.driver_options.push(format!(
-            "{}={}",
-            ENCRYPTION_KEY_DRIVER_OPTION, ENCRYPTION_KEY_VALUE
-        ));
-        storage.shared = true;
+        configure_block_emptydir_storage(&mut storage, encrypted);
 
         // Mirror the Go runtime's handleBlkOCIMounts: the agent mounts the
         // block device at $(spath)/$(b64_device_id) which genpolicy expands to
@@ -166,8 +165,47 @@ impl EncryptedEmptyDirVolume {
     }
 }
 
+fn block_emptydir_metadata(encrypted: bool, dir_gid: u32) -> HashMap<String, String> {
+    let mut metadata = HashMap::new();
+    metadata.insert(METADATA_CREATE_FILESYSTEM.to_string(), true.to_string());
+    if encrypted {
+        metadata.insert(
+            METADATA_ENCRYPTION_KEY.to_string(),
+            ENCRYPTION_KEY_VALUE.to_string(),
+        );
+    }
+    if dir_gid != 0 {
+        metadata.insert(METADATA_FS_GROUP.to_string(), dir_gid.to_string());
+    }
+    metadata
+}
+
+fn block_emptydir_mount_options(discard_unmap: bool) -> Vec<String> {
+    if discard_unmap {
+        vec![DISCARD_MOUNT_OPTION.to_string()]
+    } else {
+        vec![]
+    }
+}
+
+fn configure_block_emptydir_storage(storage: &mut agent::Storage, encrypted: bool) {
+    if encrypted {
+        storage.driver_options.push(format!(
+            "{}={}",
+            ENCRYPTION_KEY_DRIVER_OPTION, ENCRYPTION_KEY_VALUE
+        ));
+    }
+    storage
+        .driver_options
+        .push(KATA_BLOCK_VOLUME_CREATE_FS.to_string());
+    if !encrypted {
+        storage.options.push(DISCARD_MOUNT_OPTION.to_string());
+    }
+    storage.shared = true;
+}
+
 #[async_trait]
-impl Volume for EncryptedEmptyDirVolume {
+impl Volume for BlockEmptyDirVolume {
     fn get_volume_mount(&self) -> Result<Vec<oci::Mount>> {
         Ok(vec![self.mount.clone()])
     }
@@ -192,8 +230,8 @@ impl Volume for EncryptedEmptyDirVolume {
     }
 }
 
-pub(crate) fn is_encrypted_emptydir_volume(m: &oci::Mount, emptydir_mode: &str) -> bool {
-    if emptydir_mode != EMPTYDIR_MODE_BLOCK_ENCRYPTED {
+pub(crate) fn is_block_emptydir_volume(m: &oci::Mount, emptydir_mode: &str) -> bool {
+    if !is_block_emptydir_mode(emptydir_mode) {
         return false;
     }
     // Kubelet always presents emptyDir mounts as "bind" type in the OCI spec.
@@ -211,6 +249,10 @@ pub(crate) fn is_encrypted_emptydir_volume(m: &oci::Mount, emptydir_mode: &str) 
     }
 }
 
+pub(crate) fn is_block_emptydir_mode(emptydir_mode: &str) -> bool {
+    emptydir_mode == EMPTYDIR_MODE_BLOCK_ENCRYPTED || emptydir_mode == EMPTYDIR_MODE_BLOCK_PLAIN
+}
+
 fn get_filesystem_capacity(path: &Path) -> Result<u64> {
     let stat = statfs(path).with_context(|| format!("statfs {:?}", path))?;
     let total = stat.blocks() as u64 * stat.block_size() as u64;
@@ -218,4 +260,66 @@ fn get_filesystem_capacity(path: &Path) -> Result<u64> {
         return Err(anyhow!("filesystem at {:?} reports zero capacity", path));
     }
     Ok(total)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn block_plain_emptydir_requests_filesystem_creation_and_discard() {
+        let metadata = block_emptydir_metadata(false, 0);
+
+        assert_eq!(
+            metadata.get(METADATA_CREATE_FILESYSTEM).map(String::as_str),
+            Some("true")
+        );
+        assert!(!metadata.contains_key(METADATA_ENCRYPTION_KEY));
+        assert!(!metadata.contains_key(METADATA_FS_GROUP));
+        assert_eq!(
+            block_emptydir_mount_options(true),
+            vec![DISCARD_MOUNT_OPTION.to_string()]
+        );
+
+        let mut storage = agent::Storage::default();
+
+        configure_block_emptydir_storage(&mut storage, false);
+
+        assert_eq!(
+            storage.driver_options,
+            vec![KATA_BLOCK_VOLUME_CREATE_FS.to_string()]
+        );
+        assert_eq!(storage.options, vec![DISCARD_MOUNT_OPTION.to_string()]);
+        assert!(storage.shared);
+    }
+
+    #[test]
+    fn block_encrypted_emptydir_requests_encryption_and_filesystem_creation() {
+        let metadata = block_emptydir_metadata(true, 0);
+
+        assert_eq!(
+            metadata.get(METADATA_CREATE_FILESYSTEM).map(String::as_str),
+            Some("true")
+        );
+        assert_eq!(
+            metadata.get(METADATA_ENCRYPTION_KEY).map(String::as_str),
+            Some(ENCRYPTION_KEY_VALUE)
+        );
+        assert!(!metadata.contains_key(METADATA_FS_GROUP));
+        assert!(block_emptydir_mount_options(false).is_empty());
+
+        let mut storage = agent::Storage::default();
+
+        configure_block_emptydir_storage(&mut storage, true);
+
+        assert_eq!(
+            storage.driver_options,
+            vec![
+                format!("{}={}", ENCRYPTION_KEY_DRIVER_OPTION, ENCRYPTION_KEY_VALUE),
+                KATA_BLOCK_VOLUME_CREATE_FS.to_string(),
+            ]
+        );
+        assert!(storage.options.is_empty());
+        assert!(storage.shared);
+    }
 }

--- a/src/runtime-rs/crates/resource/src/volume/mod.rs
+++ b/src/runtime-rs/crates/resource/src/volume/mod.rs
@@ -5,8 +5,8 @@
 //
 
 mod block_volume;
+pub(crate) mod block_emptydir_volume;
 mod default_volume;
-pub(crate) mod encrypted_emptydir_volume;
 mod ephemeral_volume;
 pub mod hugepage;
 mod local_volume;
@@ -27,7 +27,6 @@ use anyhow::{Context, Result};
 use async_trait::async_trait;
 use hypervisor::device::device_manager::DeviceManager;
 use kata_sys_util::{k8s::is_disk_empty_dir, mount::get_mount_options};
-use kata_types::config::EMPTYDIR_MODE_BLOCK_ENCRYPTED;
 use oci_spec::runtime as oci;
 use tokio::sync::RwLock;
 
@@ -53,7 +52,7 @@ pub trait Volume: Send + Sync {
 #[derive(Default)]
 pub struct VolumeResourceInner {
     volumes: Vec<Arc<dyn Volume>>,
-    ephemeral_disks: Vec<encrypted_emptydir_volume::EphemeralDiskInfo>,
+    ephemeral_disks: Vec<block_emptydir_volume::EphemeralDiskInfo>,
 }
 
 #[derive(Default)]
@@ -101,18 +100,19 @@ impl VolumeResource {
                     ephemeral_volume::EphemeralVolume::new(m)
                         .with_context(|| format!("new ephemeral volume {m:?}"))?,
                 )
-            } else if encrypted_emptydir_volume::is_encrypted_emptydir_volume(m, emptydir_mode) {
-                let vol = encrypted_emptydir_volume::EncryptedEmptyDirVolume::new(d, m, sid)
+            } else if block_emptydir_volume::is_block_emptydir_volume(m, emptydir_mode) {
+                let vol = block_emptydir_volume::BlockEmptyDirVolume::new(d, m, sid, emptydir_mode)
                     .await
-                    .with_context(|| format!("new encrypted emptydir volume {m:?}"))?;
+                    .with_context(|| format!("new block emptydir volume {m:?}"))?;
                 let vol_arc: Arc<dyn Volume> = Arc::new(vol.clone());
                 let mut inner = self.inner.write().await;
                 inner.ephemeral_disks.push(vol.disk_info);
                 drop(inner);
                 vol_arc
             } else if need_local_volume(m, fs_sharing_supported, emptydir_mode) {
-                // This branch comes after the is_encrypted_emptydir_volume() branch
-                // to ensure encrypted handling takes precedence.
+                // This branch comes after is_block_emptydir_volume() so
+                // block-encrypted and block-plain emptyDirs are handled as
+                // block devices before falling back to guest-local storage.
                 warn!(
                     sl!(),
                     "handling emptyDir as guest-local volume because fs sharing is unsupported; Kubelet cannot enforce sizeLimit-based eviction",
@@ -224,7 +224,7 @@ impl VolumeResource {
 /// starve the host storage.
 fn need_local_volume(m: &oci::Mount, fs_sharing_supported: bool, emptydir_mode: &str) -> bool {
     !fs_sharing_supported
-        && emptydir_mode != EMPTYDIR_MODE_BLOCK_ENCRYPTED
+        && !block_emptydir_volume::is_block_emptydir_mode(emptydir_mode)
         && m.source()
             .as_ref()
             .is_some_and(|src| is_disk_empty_dir(&src.display().to_string()))

--- a/src/runtime/config/configuration-clh-azure.toml.in
+++ b/src/runtime/config/configuration-clh-azure.toml.in
@@ -479,6 +479,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -479,6 +479,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -364,6 +364,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-qemu-cca.toml.in
+++ b/src/runtime/config/configuration-qemu-cca.toml.in
@@ -652,6 +652,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -715,6 +715,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -761,6 +761,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -738,6 +738,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -740,6 +740,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -693,6 +693,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -723,6 +723,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -700,6 +700,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -709,6 +709,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-remote.toml.in
+++ b/src/runtime/config/configuration-remote.toml.in
@@ -272,6 +272,9 @@ disable_guest_empty_dir = false
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/config/configuration-stratovirt.toml.in
+++ b/src/runtime/config/configuration-stratovirt.toml.in
@@ -417,6 +417,9 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #   - block-encrypted
 #     Plugs a block device to be encrypted in the guest.
 #
+#   - block-plain
+#     Plugs a block device to be mounted directly in the guest.
+#
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
 # Enabled experimental feature list, format: ["a", "b"].

--- a/src/runtime/pkg/device/config/config.go
+++ b/src/runtime/pkg/device/config/config.go
@@ -290,6 +290,9 @@ type DeviceInfo struct {
 	// If applicable, should this device be considered RO
 	ReadOnly bool
 
+	// DiscardUnmap enables discard/unmap support for this block device.
+	DiscardUnmap bool
+
 	// ColdPlug specifies whether the device must be cold plugged (true)
 	// or hot plugged (false).
 	ColdPlug bool
@@ -337,6 +340,9 @@ type BlockDrive struct {
 
 	// ReadOnly sets the device file readonly
 	ReadOnly bool
+
+	// DiscardUnmap enables discard/unmap support for this block device.
+	DiscardUnmap bool
 
 	// Pmem enables persistent memory. Use File as backing file
 	// for a nvdimm device in the guest

--- a/src/runtime/pkg/device/drivers/block.go
+++ b/src/runtime/pkg/device/drivers/block.go
@@ -61,12 +61,13 @@ func (device *BlockDevice) Attach(ctx context.Context, devReceiver api.DeviceRec
 	}
 
 	drive := &config.BlockDrive{
-		File:     device.DeviceInfo.HostPath,
-		Format:   "raw",
-		ID:       utils.MakeNameID("drive", device.DeviceInfo.ID, maxDevIDSize),
-		Index:    index,
-		Pmem:     device.DeviceInfo.Pmem,
-		ReadOnly: device.DeviceInfo.ReadOnly,
+		File:         device.DeviceInfo.HostPath,
+		Format:       "raw",
+		ID:           utils.MakeNameID("drive", device.DeviceInfo.ID, maxDevIDSize),
+		Index:        index,
+		Pmem:         device.DeviceInfo.Pmem,
+		ReadOnly:     device.DeviceInfo.ReadOnly,
+		DiscardUnmap: device.DeviceInfo.DiscardUnmap,
 	}
 
 	if fs, ok := device.DeviceInfo.DriverOptions[config.FsTypeOpt]; ok {

--- a/src/runtime/pkg/direct-volume/utils.go
+++ b/src/runtime/pkg/direct-volume/utils.go
@@ -18,8 +18,10 @@ const (
 	mountInfoFileName = "mountInfo.json"
 
 	EncryptionKeyMetadataKey       = "encryptionKey"
+	CreateFilesystemMetadataKey    = "createFilesystem"
 	FSGroupMetadataKey             = "fsGroup"
 	FSGroupChangePolicyMetadataKey = "fsGroupChangePolicy"
+	BlockVolumeCreateFsDriverKey   = "create_filesystem"
 )
 
 // FSGroupChangePolicy holds policies that will be used for applying fsGroup to a volume.

--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -1378,6 +1378,9 @@ type BlockDevice struct {
 	// ReadOnly sets the block device in readonly mode
 	ReadOnly bool
 
+	// DiscardUnmap enables discard/unmap support for this block device.
+	DiscardUnmap bool
+
 	// Transport is the virtio transport for this device.
 	Transport VirtioTransport
 }
@@ -1425,6 +1428,9 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 	if blkdev.ShareRW {
 		deviceParams = append(deviceParams, "share-rw=on")
 	}
+	if blkdev.DiscardUnmap {
+		deviceParams = append(deviceParams, "discard=on")
+	}
 
 	deviceParams = append(deviceParams, fmt.Sprintf("serial=%s", blkdev.ID))
 
@@ -1436,6 +1442,9 @@ func (blkdev BlockDevice) QemuParams(config *Config) []string {
 
 	if blkdev.ReadOnly {
 		blkParams = append(blkParams, "readonly=on")
+	}
+	if blkdev.DiscardUnmap {
+		blkParams = append(blkParams, "discard=unmap")
 	}
 
 	qemuParams = append(qemuParams, "-device")

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -342,6 +342,29 @@ func TestAppendDeviceBlock(t *testing.T) {
 	testAppend(blkdev, deviceBlockString, t)
 }
 
+func TestAppendDeviceBlockDiscardUnmap(t *testing.T) {
+	blkdev := BlockDevice{
+		Driver:        VirtioBlock,
+		ID:            "hd0",
+		File:          "/var/lib/vm.img",
+		AIO:           Threads,
+		Format:        QCOW2,
+		Interface:     NoInterface,
+		WCE:           false,
+		DisableModern: true,
+		ROMFile:       romfile,
+		ShareRW:       true,
+		ReadOnly:      true,
+		DiscardUnmap:  true,
+	}
+	params := strings.Join(blkdev.QemuParams(&Config{}), " ")
+	for _, opt := range []string{"discard=on", "discard=unmap"} {
+		if !strings.Contains(params, opt) {
+			t.Fatalf("missing %s in block device params: %s", opt, params)
+		}
+	}
+}
+
 func TestAppendDeviceVFIO(t *testing.T) {
 	vfioDevice := VFIODevice{
 		BDF:      "02:10.0",

--- a/src/runtime/pkg/govmm/qemu/qmp.go
+++ b/src/runtime/pkg/govmm/qemu/qmp.go
@@ -800,6 +800,10 @@ func (q *QMP) blockdevAddBaseArgs(driver string, blockDevice *BlockDevice) map[s
 	}
 
 	blockdevArgs["node-name"] = blockDevice.ID
+	if blockDevice.DiscardUnmap {
+		blockdevArgs["discard"] = "unmap"
+		blockdevArgs["file"].(map[string]interface{})["discard"] = "unmap"
+	}
 
 	return blockdevArgs
 }
@@ -863,6 +867,16 @@ func (q *QMP) ExecuteBlockdevAddWithDriverCache(ctx context.Context, driver stri
 // the logical and physical block sizes for the device; if either is 0, the
 // hypervisor default is used for that size.
 func (q *QMP) ExecuteDeviceAdd(ctx context.Context, blockdevID, devID, driver, bus, romfile string, shared, disableModern bool, logicalBlockSize, physicalBlockSize uint32) error {
+	return q.executeDeviceAdd(ctx, blockdevID, devID, driver, bus, romfile, shared, disableModern, false, logicalBlockSize, physicalBlockSize)
+}
+
+// ExecuteDeviceAddWithDiscard is like ExecuteDeviceAdd, with explicit virtio-blk
+// discard support.
+func (q *QMP) ExecuteDeviceAddWithDiscard(ctx context.Context, blockdevID, devID, driver, bus, romfile string, shared, disableModern, discardUnmap bool, logicalBlockSize, physicalBlockSize uint32) error {
+	return q.executeDeviceAdd(ctx, blockdevID, devID, driver, bus, romfile, shared, disableModern, discardUnmap, logicalBlockSize, physicalBlockSize)
+}
+
+func (q *QMP) executeDeviceAdd(ctx context.Context, blockdevID, devID, driver, bus, romfile string, shared, disableModern, discardUnmap bool, logicalBlockSize, physicalBlockSize uint32) error {
 	args := map[string]interface{}{
 		"id":     devID,
 		"driver": driver,
@@ -879,6 +893,9 @@ func (q *QMP) ExecuteDeviceAdd(ctx context.Context, blockdevID, devID, driver, b
 
 	if shared {
 		args["share-rw"] = true
+	}
+	if discardUnmap && strings.HasPrefix(driver, "virtio-blk") {
+		args["discard"] = true
 	}
 	if transport.isVirtioPCI(nil) {
 		args["romfile"] = romfile
@@ -1121,6 +1138,16 @@ func (q *QMP) ExecuteDeviceDel(ctx context.Context, devID string) error {
 // 1.0 in nested environments. logicalBlockSize and physicalBlockSize specify the logical and
 // physical sector sizes reported to the guest; set to 0 to use the hypervisor default.
 func (q *QMP) ExecutePCIDeviceAdd(ctx context.Context, blockdevID, devID, driver, addr, bus, romfile string, queues int, shared, disableModern bool, iothreadID string, logicalBlockSize, physicalBlockSize uint32) error {
+	return q.executePCIDeviceAdd(ctx, blockdevID, devID, driver, addr, bus, romfile, queues, shared, disableModern, false, iothreadID, logicalBlockSize, physicalBlockSize)
+}
+
+// ExecutePCIDeviceAddWithDiscard is like ExecutePCIDeviceAdd, with explicit
+// virtio-blk discard support.
+func (q *QMP) ExecutePCIDeviceAddWithDiscard(ctx context.Context, blockdevID, devID, driver, addr, bus, romfile string, queues int, shared, disableModern, discardUnmap bool, iothreadID string, logicalBlockSize, physicalBlockSize uint32) error {
+	return q.executePCIDeviceAdd(ctx, blockdevID, devID, driver, addr, bus, romfile, queues, shared, disableModern, discardUnmap, iothreadID, logicalBlockSize, physicalBlockSize)
+}
+
+func (q *QMP) executePCIDeviceAdd(ctx context.Context, blockdevID, devID, driver, addr, bus, romfile string, queues int, shared, disableModern, discardUnmap bool, iothreadID string, logicalBlockSize, physicalBlockSize uint32) error {
 	args := map[string]interface{}{
 		"id":     devID,
 		"driver": driver,
@@ -1132,6 +1159,9 @@ func (q *QMP) ExecutePCIDeviceAdd(ctx context.Context, blockdevID, devID, driver
 	}
 	if shared {
 		args["share-rw"] = true
+	}
+	if discardUnmap && strings.HasPrefix(driver, "virtio-blk") {
+		args["discard"] = true
 	}
 	if queues > 0 {
 		args["num-queues"] = queues

--- a/src/runtime/pkg/govmm/qemu/qmp_test.go
+++ b/src/runtime/pkg/govmm/qemu/qmp_test.go
@@ -508,6 +508,25 @@ func TestQMPBlockdevAddWithCache(t *testing.T) {
 	<-disconnectedCh
 }
 
+func TestQMPBlockdevAddDiscardUnmapArgs(t *testing.T) {
+	q := &QMP{}
+	dev := BlockDevice{
+		ID:           fmt.Sprintf("drive_%s", volumeUUID),
+		File:         "/tmp/disk.img",
+		AIO:          Native,
+		DiscardUnmap: true,
+	}
+
+	args := q.blockdevAddBaseArgs("file", &dev)
+	if got := args["discard"]; got != "unmap" {
+		t.Fatalf("unexpected discard option: got %v, expecting unmap", got)
+	}
+	fileArgs := args["file"].(map[string]interface{})
+	if got := fileArgs["discard"]; got != "unmap" {
+		t.Fatalf("unexpected file discard option: got %v, expecting unmap", got)
+	}
+}
+
 // Checks that the netdev_add command is correctly sent.
 //
 // We start a QMPLoop, send the netdev_add command and stop the loop.

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -213,11 +213,11 @@ func (r runtime) emptyDirMode() (string, error) {
 	}
 
 	switch r.EmptyDirMode {
-	case vc.EmptyDirModeSharedFs, vc.EmptyDirModeVirtioBlkEncrypted:
+	case vc.EmptyDirModeSharedFs, vc.EmptyDirModeVirtioBlkEncrypted, vc.EmptyDirModeVirtioBlkPlain:
 		return r.EmptyDirMode, nil
 	default:
-		return "", fmt.Errorf("invalid emptydir_mode=%q, allowed values: %q, %q",
-			r.EmptyDirMode, vc.EmptyDirModeSharedFs, vc.EmptyDirModeVirtioBlkEncrypted)
+		return "", fmt.Errorf("invalid emptydir_mode=%q, allowed values: %q, %q, %q",
+			r.EmptyDirMode, vc.EmptyDirModeSharedFs, vc.EmptyDirModeVirtioBlkEncrypted, vc.EmptyDirModeVirtioBlkPlain)
 	}
 }
 

--- a/src/runtime/pkg/katautils/config_test.go
+++ b/src/runtime/pkg/katautils/config_test.go
@@ -1660,6 +1660,11 @@ func TestCheckEmptyDirMode(t *testing.T) {
 	assert.NoError(err)
 	assert.Equal(vc.EmptyDirModeVirtioBlkEncrypted, mode)
 
+	r = runtime{EmptyDirMode: vc.EmptyDirModeVirtioBlkPlain}
+	mode, err = r.emptyDirMode()
+	assert.NoError(err)
+	assert.Equal(vc.EmptyDirModeVirtioBlkPlain, mode)
+
 	r = runtime{}
 	mode, err = r.emptyDirMode()
 	assert.NoError(err)
@@ -1675,6 +1680,10 @@ func TestCheckEmptyDirMode(t *testing.T) {
 	assert.Error(err)
 
 	r = runtime{EmptyDirMode: "block_encrypted"}
+	_, err = r.emptyDirMode()
+	assert.Error(err)
+
+	r = runtime{EmptyDirMode: "block_plain"}
 	_, err = r.emptyDirMode()
 	assert.Error(err)
 }

--- a/src/runtime/pkg/katautils/create.go
+++ b/src/runtime/pkg/katautils/create.go
@@ -107,7 +107,9 @@ func SetEphemeralStorageType(ociSpec specs.Spec, disableGuestEmptyDir bool, empt
 			//   disableGuestEmptyDir and emptyDirMode.
 			if vc.IsHugePageEmptyDir(mnt.Source) {
 				ociSpec.Mounts[idx].Type = vc.KataLocalDevType
-			} else if !disableGuestEmptyDir && emptyDirMode != vc.EmptyDirModeVirtioBlkEncrypted {
+			} else if !disableGuestEmptyDir &&
+				emptyDirMode != vc.EmptyDirModeVirtioBlkEncrypted &&
+				emptyDirMode != vc.EmptyDirModeVirtioBlkPlain {
 				ociSpec.Mounts[idx].Type = vc.KataLocalDevType
 			}
 		}

--- a/src/runtime/pkg/katautils/create_test.go
+++ b/src/runtime/pkg/katautils/create_test.go
@@ -148,6 +148,35 @@ func TestSetEphemeralStorageType(t *testing.T) {
 		"Unexpected mount type, got %s expected ephemeral", mountType)
 }
 
+func TestSetEphemeralStorageTypeHostEmptyDirModes(t *testing.T) {
+	assert := assert.New(t)
+
+	dir := t.TempDir()
+	emptyDirPath := filepath.Join(dir, vc.K8sEmptyDir, "disk-volume")
+	err := os.MkdirAll(emptyDirPath, testDirMode)
+	assert.NoError(err)
+
+	newSpec := func() specs.Spec {
+		return specs.Spec{
+			Mounts: []specs.Mount{
+				{
+					Source: emptyDirPath,
+					Type:   "bind",
+				},
+			},
+		}
+	}
+
+	ociSpec := SetEphemeralStorageType(newSpec(), false, vc.EmptyDirModeSharedFs)
+	assert.Equal(vc.KataLocalDevType, ociSpec.Mounts[0].Type)
+
+	ociSpec = SetEphemeralStorageType(newSpec(), false, vc.EmptyDirModeVirtioBlkEncrypted)
+	assert.Equal("bind", ociSpec.Mounts[0].Type)
+
+	ociSpec = SetEphemeralStorageType(newSpec(), false, vc.EmptyDirModeVirtioBlkPlain)
+	assert.Equal("bind", ociSpec.Mounts[0].Type)
+}
+
 func TestSetKernelParams(t *testing.T) {
 	assert := assert.New(t)
 

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -166,7 +166,7 @@ type RuntimeConfig struct {
 	DisableGuestEmptyDir bool
 
 	// EmptyDirMode specifies how Kubernetes emptyDir volumes are handled.
-	// Valid values are "shared-fs" (default) or "block-encrypted".
+	// Valid values are "shared-fs" (default), "block-encrypted", or "block-plain".
 	EmptyDirMode string
 
 	// CreateContainer timeout which, if provided, indicates the createcontainer request timeout

--- a/src/runtime/virtcontainers/container.go
+++ b/src/runtime/virtcontainers/container.go
@@ -622,9 +622,9 @@ func (c *Container) createBlockDevices(ctx context.Context) error {
 	// iterate all mounts and create block device if it's block based.
 	for i := range c.mounts {
 		// If block devices are disabled, we selectively only hotplug if
-		// the mount is an encrypted block-based emptyDir, to avoid
+		// the mount is a block-based emptyDir, to avoid
 		// cases that could regress 20ca4d2.
-		if !c.checkBlockDeviceSupport(ctx) && (c.sandbox.config.EmptyDirMode != EmptyDirModeVirtioBlkEncrypted || !IsNonTmpFSEmptyDir(c.mounts[i].Source)) {
+		if !c.checkBlockDeviceSupport(ctx) && (!isBlockEmptyDirMode(c.sandbox.config.EmptyDirMode) || !IsDiskEmptyDir(c.mounts[i].Source)) {
 			c.Logger().Warn("Block device not supported")
 			continue
 		}
@@ -679,6 +679,13 @@ func (c *Container) createBlockDevices(ctx context.Context) error {
 				switch key {
 				case volume.EncryptionKeyMetadataKey:
 					c.mounts[i].EncryptionKey = value
+				case volume.CreateFilesystemMetadataKey:
+					createFs, err := strconv.ParseBool(value)
+					if err != nil {
+						c.Logger().WithError(err).Errorf("invalid create filesystem value %s provided for key %s", value, volume.CreateFilesystemMetadataKey)
+						continue
+					}
+					c.mounts[i].BlockDeviceCreateFs = createFs
 				case volume.FSGroupMetadataKey:
 					gid, err := strconv.Atoi(value)
 					if err != nil {
@@ -702,6 +709,8 @@ func (c *Container) createBlockDevices(ctx context.Context) error {
 		// instead of passing this as a shared mount.
 		di, err := c.createDeviceInfo(c.mounts[i].Source, c.mounts[i].Destination, c.mounts[i].ReadOnly, isBlockFile)
 		if err == nil && di != nil {
+			di.DiscardUnmap = c.mounts[i].BlockDeviceCreateFs && slices.Contains(c.mounts[i].Options, blockVolumeDiscardOption)
+
 			b, err := c.sandbox.devManager.NewDevice(*di)
 			if err != nil {
 				// Do not return an error, try to create
@@ -878,12 +887,12 @@ func getFilesystemCapacity(path string) (uint64, error) {
 }
 
 func (c *Container) createEphemeralDisks() error {
-	if c.sandbox.config.EmptyDirMode != EmptyDirModeVirtioBlkEncrypted {
+	if !isBlockEmptyDirMode(c.sandbox.config.EmptyDirMode) {
 		return nil
 	}
 
 	for i := range c.mounts {
-		if !IsNonTmpFSEmptyDir(c.mounts[i].Source) {
+		if !IsDiskEmptyDir(c.mounts[i].Source) {
 			continue
 		}
 
@@ -896,7 +905,7 @@ func (c *Container) createEphemeralDisks() error {
 			continue
 		}
 
-		diskPath, err := c.setupEphemeralDisk(c.mounts[i].Source)
+		diskPath, err := c.setupEphemeralDisk(c.mounts[i].Source, c.sandbox.config.EmptyDirMode)
 		if err != nil {
 			return err
 		}
@@ -914,7 +923,7 @@ func (c *Container) createEphemeralDisks() error {
 // inside the given emptyDir. It returns the path to the created disk
 // image. The fd is always closed and the disk image is removed if any
 // step after creation fails.
-func (c *Container) setupEphemeralDisk(emptyDirPath string) (diskPath string, err error) {
+func (c *Container) setupEphemeralDisk(emptyDirPath, emptyDirMode string) (diskPath string, err error) {
 	// Create the disk file in the same folder as the original
 	// emptyDir mount so that Kubelet can enforce the sizeLimit.
 	diskPath = filepath.Join(emptyDirPath, "disk.img")
@@ -950,8 +959,15 @@ func (c *Container) setupEphemeralDisk(emptyDirPath string) (diskPath string, er
 		return
 	}
 
-	metadata := map[string]string{
-		volume.EncryptionKeyMetadataKey: "ephemeral",
+	metadata := map[string]string{}
+	var options []string
+	if isBlockEmptyDirMode(emptyDirMode) {
+		metadata[volume.CreateFilesystemMetadataKey] = strconv.FormatBool(true)
+	}
+	if emptyDirMode == EmptyDirModeVirtioBlkEncrypted {
+		metadata[volume.EncryptionKeyMetadataKey] = "ephemeral"
+	} else if emptyDirMode == EmptyDirModeVirtioBlkPlain {
+		options = []string{blockVolumeDiscardOption}
 	}
 	if sourceStat.Gid != 0 {
 		metadata[volume.FSGroupMetadataKey] = strconv.FormatUint(uint64(sourceStat.Gid), 10)
@@ -962,6 +978,7 @@ func (c *Container) setupEphemeralDisk(emptyDirPath string) (diskPath string, er
 		Device:     diskPath,
 		FsType:     "ext4",
 		Metadata:   metadata,
+		Options:    options,
 	}); err != nil {
 		c.Logger().WithError(err).Errorf("failed to assign direct volume for mount %s", emptyDirPath)
 		return

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -73,6 +73,12 @@ const (
 	// EmptyDirModeVirtioBlkEncrypted is the emptydir_mode value for encrypted virtio-blk emptyDir.
 	EmptyDirModeVirtioBlkEncrypted = "block-encrypted"
 
+	// EmptyDirModeVirtioBlkPlain is the emptydir_mode value for plain virtio-blk emptyDir.
+	EmptyDirModeVirtioBlkPlain = "block-plain"
+
+	// blockVolumeDiscardOption requests discard support for block volume mounts.
+	blockVolumeDiscardOption = "discard"
+
 	// encryptionKeyDriverOption is the driver option used to specify
 	// an encryption key for a Storage struct.
 	encryptionKeyDriverOption = "encryption_key"
@@ -2057,6 +2063,9 @@ func (k *kataAgent) handleDeviceBlockVolume(c *Container, m Mount, device api.De
 	if m.EncryptionKey != "" {
 		option := fmt.Sprintf("%s=%s", encryptionKeyDriverOption, m.EncryptionKey)
 		vol.DriverOptions = append(vol.DriverOptions, option)
+	}
+	if m.BlockDeviceCreateFs {
+		vol.DriverOptions = append(vol.DriverOptions, volume.BlockVolumeCreateFsDriverKey)
 	}
 
 	vol.Shared = m.Shared

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -338,6 +338,46 @@ func TestHandleDeviceBlockVolume(t *testing.T) {
 				},
 			},
 		},
+		{
+			BlockDeviceDriver: config.VirtioBlock,
+			inputMount: Mount{
+				BlockDeviceCreateFs: true,
+				Options:             []string{blockVolumeDiscardOption},
+			},
+			inputDev: &drivers.BlockDevice{
+				BlockDrive: &config.BlockDrive{
+					PCIPath:  testPCIPath,
+					VirtPath: testVirtPath,
+				},
+			},
+			resultVol: &pb.Storage{
+				Driver:        kataBlkDevType,
+				Source:        testPCIPath.String(),
+				DriverOptions: []string{volume.BlockVolumeCreateFsDriverKey},
+				Options:       []string{blockVolumeDiscardOption},
+			},
+		},
+		{
+			BlockDeviceDriver: config.VirtioBlock,
+			inputMount: Mount{
+				EncryptionKey:       "ephemeral",
+				BlockDeviceCreateFs: true,
+			},
+			inputDev: &drivers.BlockDevice{
+				BlockDrive: &config.BlockDrive{
+					PCIPath:  testPCIPath,
+					VirtPath: testVirtPath,
+				},
+			},
+			resultVol: &pb.Storage{
+				Driver: kataBlkDevType,
+				Source: testPCIPath.String(),
+				DriverOptions: []string{
+					encryptionKeyDriverOption + "=ephemeral",
+					volume.BlockVolumeCreateFsDriverKey,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/src/runtime/virtcontainers/mount.go
+++ b/src/runtime/virtcontainers/mount.go
@@ -278,6 +278,10 @@ type Mount struct {
 	// to instruct the agent to generate a one-time key.
 	EncryptionKey string
 
+	// BlockDeviceCreateFs requests filesystem creation before mounting a
+	// fresh block volume. The filesystem type comes from the Storage Fstype.
+	BlockDeviceCreateFs bool
+
 	// Shared indicates whether the mount is shared across containers.
 	Shared bool
 }

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -2097,10 +2097,11 @@ func (q *qemu) hotplugAddBlockDevice(ctx context.Context, drive *config.BlockDri
 	}
 
 	qblkDevice := govmmQemu.BlockDevice{
-		ID:       drive.ID,
-		File:     drive.File,
-		ReadOnly: drive.ReadOnly,
-		AIO:      govmmQemu.BlockDeviceAIO(q.config.BlockDeviceAIO),
+		ID:           drive.ID,
+		File:         drive.File,
+		ReadOnly:     drive.ReadOnly,
+		DiscardUnmap: drive.DiscardUnmap,
+		AIO:          govmmQemu.BlockDeviceAIO(q.config.BlockDeviceAIO),
 	}
 
 	if drive.Swap {
@@ -2157,7 +2158,7 @@ func (q *qemu) hotplugAddBlockDevice(ctx context.Context, drive *config.BlockDri
 			iothreadID = fmt.Sprintf("%s_%d", indepIOThreadsPrefix, 0)
 		}
 
-		if err = q.qmpMonitorCh.qmp.ExecutePCIDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, addr, bridge.ID, romFile, queues, true, defaultDisableModern, iothreadID, q.config.BlockDeviceLogicalSectorSize, q.config.BlockDevicePhysicalSectorSize); err != nil {
+		if err = q.qmpMonitorCh.qmp.ExecutePCIDeviceAddWithDiscard(q.qmpMonitorCh.ctx, drive.ID, devID, driver, addr, bridge.ID, romFile, queues, true, defaultDisableModern, drive.DiscardUnmap, iothreadID, q.config.BlockDeviceLogicalSectorSize, q.config.BlockDevicePhysicalSectorSize); err != nil {
 			return err
 		}
 	case q.config.BlockDeviceDriver == config.VirtioBlockCCW:
@@ -2176,7 +2177,7 @@ func (q *qemu) hotplugAddBlockDevice(ctx context.Context, drive *config.BlockDri
 		if err != nil {
 			return err
 		}
-		if err = q.qmpMonitorCh.qmp.ExecuteDeviceAdd(q.qmpMonitorCh.ctx, drive.ID, devID, driver, devNoHotplug, "", true, false, q.config.BlockDeviceLogicalSectorSize, q.config.BlockDevicePhysicalSectorSize); err != nil {
+		if err = q.qmpMonitorCh.qmp.ExecuteDeviceAddWithDiscard(q.qmpMonitorCh.ctx, drive.ID, devID, driver, devNoHotplug, "", true, false, drive.DiscardUnmap, q.config.BlockDeviceLogicalSectorSize, q.config.BlockDevicePhysicalSectorSize); err != nil {
 			return err
 		}
 	case q.config.BlockDeviceDriver == config.VirtioSCSI:

--- a/src/runtime/virtcontainers/qemu_arch_base.go
+++ b/src/runtime/virtcontainers/qemu_arch_base.go
@@ -692,6 +692,7 @@ func genericBlockDevice(drive config.BlockDrive, nestedRun bool) (govmmQemu.Bloc
 		DisableModern: nestedRun,
 		ShareRW:       drive.ShareRW,
 		ReadOnly:      drive.ReadOnly,
+		DiscardUnmap:  drive.DiscardUnmap,
 	}, nil
 }
 

--- a/src/runtime/virtcontainers/qemu_arch_base_test.go
+++ b/src/runtime/virtcontainers/qemu_arch_base_test.go
@@ -526,6 +526,21 @@ func TestQemuArchBaseAppendBlockDevice(t *testing.T) {
 	testQemuArchBaseAppend(t, drive, expectedOut)
 }
 
+func TestGenericBlockDeviceDiscardUnmap(t *testing.T) {
+	assert := assert.New(t)
+
+	drive := config.BlockDrive{
+		File:         "/root",
+		Format:       "raw",
+		ID:           "blockDevTest",
+		DiscardUnmap: true,
+	}
+
+	blockDevice, err := genericBlockDevice(drive, false)
+	assert.NoError(err)
+	assert.True(blockDevice.DiscardUnmap)
+}
+
 func TestQemuArchBaseAppendVhostUserDevice(t *testing.T) {
 	socketPath := "nonexistentpath.sock"
 	macAddress := "00:11:22:33:44:55:66"

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -184,7 +184,7 @@ type SandboxConfig struct {
 	DisableGuestSeccomp bool
 
 	// EmptyDirMode specifies how Kubernetes emptyDir volumes are handled.
-	// Valid values are "shared-fs" (default) or "block-encrypted".
+	// Valid values are "shared-fs" (default), "block-encrypted", or "block-plain".
 	EmptyDirMode string
 
 	// EnableVCPUsPinning controls whether each vCPU thread should be scheduled to a fixed CPU
@@ -1129,7 +1129,7 @@ func (s *Sandbox) Delete(ctx context.Context) error {
 
 // cleanupEphemeralDisks removes ephemeral disk images and their mount info.
 func (s *Sandbox) cleanupEphemeralDisks() error {
-	if s.config.EmptyDirMode != EmptyDirModeVirtioBlkEncrypted {
+	if !isBlockEmptyDirMode(s.config.EmptyDirMode) {
 		return nil
 	}
 
@@ -1143,6 +1143,10 @@ func (s *Sandbox) cleanupEphemeralDisks() error {
 	}
 
 	return nil
+}
+
+func isBlockEmptyDirMode(mode string) bool {
+	return mode == EmptyDirModeVirtioBlkEncrypted || mode == EmptyDirModeVirtioBlkPlain
 }
 
 func (s *Sandbox) createNetwork(ctx context.Context) error {

--- a/src/tools/genpolicy/drop-in-examples/10-non-coco-aks-cbl-mariner-drop-in.json
+++ b/src/tools/genpolicy/drop-in-examples/10-non-coco-aks-cbl-mariner-drop-in.json
@@ -6,8 +6,8 @@
   },
   {
     "op": "replace",
-    "path": "/cluster_config/encrypted_emptydir",
-    "value": false
+    "path": "/cluster_config/emptydir_type",
+    "value": "shared-fs"
   },
   {
     "op": "replace",

--- a/src/tools/genpolicy/drop-in-examples/10-non-coco-aks-drop-in.json
+++ b/src/tools/genpolicy/drop-in-examples/10-non-coco-aks-drop-in.json
@@ -6,8 +6,8 @@
   },
   {
     "op": "replace",
-    "path": "/cluster_config/encrypted_emptydir",
-    "value": false
+    "path": "/cluster_config/emptydir_type",
+    "value": "shared-fs"
   },
   {
     "op": "replace",

--- a/src/tools/genpolicy/drop-in-examples/10-non-coco-drop-in.json
+++ b/src/tools/genpolicy/drop-in-examples/10-non-coco-drop-in.json
@@ -6,8 +6,8 @@
   },
   {
     "op": "replace",
-    "path": "/cluster_config/encrypted_emptydir",
-    "value": false
+    "path": "/cluster_config/emptydir_type",
+    "value": "shared-fs"
   },
   {
     "op": "replace",

--- a/src/tools/genpolicy/genpolicy-settings.json
+++ b/src/tools/genpolicy/genpolicy-settings.json
@@ -170,12 +170,28 @@
             "mount_type": "bind",
             "driver": "",
             "driver_options": [
-                "encryption_key=ephemeral"
+                "encryption_key=ephemeral",
+                "create_filesystem"
             ],
             "source": "",
             "mount_point": "$(spath)/$(b64_device_id)",
             "fstype": "ext4",
             "options": [],
+            "shared": true
+        },
+        "emptyDir_plain": {
+            "mount_source": "",
+            "mount_type": "bind",
+            "driver": "",
+            "driver_options": [
+                "create_filesystem"
+            ],
+            "source": "",
+            "mount_point": "$(spath)/$(b64_device_id)",
+            "fstype": "ext4",
+            "options": [
+                "discard"
+            ],
             "shared": true
         },
         "emptyDir_memory": {
@@ -335,7 +351,7 @@
         "pause_container_image": "mcr.microsoft.com/oss/kubernetes/pause:3.6",
         "guest_pull": true,
         "pause_container_id_policy": "v1",
-        "encrypted_emptydir": true,
+        "emptydir_type": "block-encrypted",
         "cgroup_mount_extras_allowed": [
             "nsdelegate",
             "memory_recursiveprot"

--- a/src/tools/genpolicy/rules.rego
+++ b/src/tools/genpolicy/rules.rego
@@ -1274,7 +1274,7 @@ allow_storage(p_storages, i_storage, bundle_id, sandbox_id) if {
     print("allow_storage with blk: start")
 
     i_storage.driver == "blk"
-    regex.match("^[0-9]{2}/[0-9]{2}$", i_storage.source)
+    regex.match("^[0-9a-f]{2}(/[0-9a-f]{2})?$", i_storage.source)
 
     allow_block_storage(p_storages, i_storage, bundle_id, sandbox_id)
 

--- a/src/tools/genpolicy/src/mount_and_storage.rs
+++ b/src/tools/genpolicy/src/mount_and_storage.rs
@@ -17,6 +17,10 @@ use std::ffi::OsString;
 use std::path::Path;
 use std::str;
 
+const EMPTYDIR_TYPE_SHARED_FS: &str = "shared-fs";
+const EMPTYDIR_TYPE_BLOCK_ENCRYPTED: &str = "block-encrypted";
+const EMPTYDIR_TYPE_BLOCK_PLAIN: &str = "block-plain";
+
 pub fn get_policy_mounts(
     settings: &settings::Settings,
     p_mounts: &mut Vec<policy::KataMount>,
@@ -145,15 +149,24 @@ fn get_empty_dir_mount(
     pod_security_context: &Option<pod::PodSecurityContext>,
 ) {
     let settings_volumes = &settings.volumes;
-    let (volume, block_encrypted_emptydir) = match emptyDir.medium.as_deref() {
+    let (volume, block_emptydir) = match emptyDir.medium.as_deref() {
         Some("Memory") => (&settings_volumes.emptyDir_memory, false),
-        _ if settings.cluster_config.encrypted_emptydir => {
+        _ if settings.cluster_config.emptydir_type == EMPTYDIR_TYPE_BLOCK_ENCRYPTED => {
             (&settings_volumes.emptyDir_encrypted, true)
         }
-        _ => (&settings_volumes.emptyDir, false),
+        _ if settings.cluster_config.emptydir_type == EMPTYDIR_TYPE_BLOCK_PLAIN => {
+            (&settings_volumes.emptyDir_plain, true)
+        }
+        _ if settings.cluster_config.emptydir_type == EMPTYDIR_TYPE_SHARED_FS => {
+            (&settings_volumes.emptyDir, false)
+        }
+        _ => panic!(
+            "Unsupported emptydir_type {:?}",
+            settings.cluster_config.emptydir_type
+        ),
     };
 
-    if emptyDir.medium.as_deref() == Some("Memory") || block_encrypted_emptydir {
+    if emptyDir.medium.as_deref() == Some("Memory") || block_emptydir {
         get_guest_empty_dir_mount_and_storage(
             settings,
             p_mounts,
@@ -161,7 +174,7 @@ fn get_empty_dir_mount(
             yaml_mount,
             volume,
             pod_security_context,
-            block_encrypted_emptydir,
+            block_emptydir,
         );
     } else {
         let access = if yaml_mount.readOnly == Some(true) {
@@ -181,21 +194,21 @@ fn get_guest_empty_dir_mount_and_storage(
     yaml_mount: &pod::VolumeMount,
     settings_empty_dir: &settings::EmptyDirVolume,
     pod_security_context: &Option<pod::PodSecurityContext>,
-    block_encrypted_emptydir: bool,
+    block_emptydir: bool,
 ) {
     debug!("Settings emptyDir: {:?}", settings_empty_dir);
 
     if yaml_mount.subPathExpr.is_none() {
         let mut options = settings_empty_dir.options.clone();
         // Pod fsGroup in policy must mirror how the shim encodes it on Storage:
-        // - block-encrypted host emptyDirs become virtio-blk/scsi volumes; the runtime sets
+        // - block host emptyDirs become virtio-blk/scsi volumes; the runtime sets
         //   Storage.fs_group from mount metadata (handleDeviceBlockVolume in kata_agent.go).
         // - shared-fs / guest-local emptyDirs use Storage.options: the runtime appends
         //   fsgid=<host GID> when the volume is not root-owned (handleEphemeralStorage and
         //   handleLocalStorage in kata_agent.go). Genpolicy uses pod fsGroup when non-zero as
         //   the usual kubelet-applied GID for that stat.
         let pod_gid = pod_security_context.as_ref().and_then(|sc| sc.fsGroup);
-        let fs_group = if block_encrypted_emptydir {
+        let fs_group = if block_emptydir {
             match pod_gid {
                 Some(gid) if gid > 0 => protobuf::MessageField::some(agent::FSGroup {
                     group_id: u32::try_from(gid).unwrap_or_else(|_| {

--- a/src/tools/genpolicy/src/policy.rs
+++ b/src/tools/genpolicy/src/policy.rs
@@ -476,9 +476,9 @@ pub struct ClusterConfig {
     ///           as the only value* in AdditionalGids.
     pub pause_container_id_policy: String,
 
-    /// Whether emptyDirs are encrypted with modified metadata in the
-    /// mount and a storage object for the block device.
-    pub encrypted_emptydir: bool,
+    /// How emptyDirs are represented in the policy.
+    /// Supported values are "shared-fs", "block-encrypted", and "block-plain".
+    pub emptydir_type: String,
 
     /// Cgroup v2 mount options that may appear beyond what genpolicy embeds
     /// (e.g. "nsdelegate", "memory_recursiveprot" on newer kernels).

--- a/src/tools/genpolicy/src/settings.rs
+++ b/src/tools/genpolicy/src/settings.rs
@@ -35,6 +35,7 @@ pub struct Settings {
 pub struct Volumes {
     pub emptyDir: EmptyDirVolume,
     pub emptyDir_encrypted: EmptyDirVolume,
+    pub emptyDir_plain: EmptyDirVolume,
     pub emptyDir_memory: EmptyDirVolume,
     pub configMap: ConfigMapVolume,
     pub image_volume: ImageVolume,

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/testcases.json
@@ -343,7 +343,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": {
             "group_id": 1000

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
@@ -168,7 +168,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -180,7 +181,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -192,7 +194,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -204,7 +207,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -365,7 +369,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -377,7 +382,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -389,7 +395,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -401,7 +408,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -572,7 +580,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -584,7 +593,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -596,7 +606,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -608,7 +619,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -764,7 +776,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -776,7 +789,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -788,7 +802,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -800,7 +815,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -1315,7 +1331,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -1327,7 +1344,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -1339,7 +1357,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -1351,7 +1370,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -1512,7 +1532,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -1526,7 +1547,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -1540,7 +1562,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -1554,7 +1577,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "ext4",
@@ -1717,7 +1741,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "invalid_fstype",
@@ -1729,7 +1754,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "invalid_fstype",
@@ -1741,7 +1767,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "invalid_fstype",
@@ -1753,7 +1780,8 @@
         {
           "driver": "blk",
           "driver_options": [
-            "encryption_key=ephemeral"
+            "encryption_key=ephemeral",
+            "create_filesystem"
           ],
           "fs_group": null,
           "fstype": "invalid_fstype",

--- a/tests/integration/kubernetes/k8s-plain-ephemeral-data-storage.bats
+++ b/tests/integration/kubernetes/k8s-plain-ephemeral-data-storage.bats
@@ -20,9 +20,6 @@ skip_unsupported_runtime() {
 		clh-runtime-rs|clh-azure-runtime-rs|dragonball)
 			skip "block-plain emptyDir uses runtime-rs BlockModern, whose VMM glue is missing for ${KATA_HYPERVISOR}"
 			;;
-		clh-azure)
-			skip "block-plain emptyDir requires guest mkfs.ext4, which is not included in the Azure Linux UVM rootfs"
-			;;
 	esac
 }
 

--- a/tests/integration/kubernetes/k8s-plain-ephemeral-data-storage.bats
+++ b/tests/integration/kubernetes/k8s-plain-ephemeral-data-storage.bats
@@ -1,0 +1,304 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+export KATA_HYPERVISOR="${KATA_HYPERVISOR:-qemu}"
+
+skip_unsupported_runtime() {
+	# The runtime-rs block emptyDir path uses BlockModern, inherited from the
+	# older block-encrypted implementation. The encrypted test is CoCo-only, so
+	# it never reached clh-runtime-rs or dragonball in CI; this generic
+	# block-plain test would, so skip those unsupported VMM paths explicitly.
+	case "${KATA_HYPERVISOR}" in
+		clh-runtime-rs|clh-azure-runtime-rs|dragonball)
+			skip "block-plain emptyDir uses runtime-rs BlockModern, whose VMM glue is missing for ${KATA_HYPERVISOR}"
+			;;
+		clh-azure)
+			skip "block-plain emptyDir requires guest mkfs.ext4, which is not included in the Azure Linux UVM rootfs"
+			;;
+	esac
+}
+
+# Return the full mountinfo row whose field 5 is the tested mount point.
+mountinfo_for_mountpoint() {
+	pod_exec "${pod_name}" sh -c \
+		"awk -v mp='${mountpoint}' '\$5 == mp {print; exit}' /proc/self/mountinfo"
+}
+
+# Return a field after the "-" separator: 1 = fs type, 2 = source, 3 = super options.
+mountinfo_after_separator_field() {
+	local field_offset="$1"
+
+	pod_exec "${pod_name}" sh -c \
+		"awk -v mp='${mountpoint}' '\$5 == mp {for (i = 1; i <= NF; i++) if (\$i == \"-\") {print \$(i + ${field_offset}); exit}}' /proc/self/mountinfo"
+}
+
+# Return field 6 mount options plus super options, which are three fields after "-".
+mount_options() {
+	pod_exec "${pod_name}" sh -c \
+		"awk -v mp='${mountpoint}' '\$5 == mp {for (i = 1; i <= NF; i++) if (\$i == \"-\") {print \$6 \",\" \$(i + 3); exit}}' /proc/self/mountinfo"
+}
+
+# Return the allocated host bytes for a disk image, not its apparent size.
+host_disk_allocated_bytes() {
+	local disk_path="$1"
+	exec_host "${node}" "du -B1 '${disk_path}' | awk 'NR == 1 {print \$1}'"
+}
+
+host_disk_path() {
+	local pod_uid
+	pod_uid="$(kubectl get pod "${pod_name}" -o jsonpath='{.metadata.uid}')"
+	echo "$(get_kubelet_data_dir)/pods/${pod_uid}/volumes/kubernetes.io~empty-dir/${volume_name}/disk.img"
+}
+
+pod_evicted() {
+	kubectl get pod "${pod_name}" -o jsonpath='{.status.reason}' 2>/dev/null | grep -q '^Evicted$'
+}
+
+pod_eviction_message() {
+	kubectl get pod "${pod_name}" -o jsonpath='{.status.message}' 2>/dev/null || true
+}
+
+pod_events() {
+	kubectl get events \
+		--field-selector "involvedObject.kind=Pod,involvedObject.name=${pod_name}" \
+		-o jsonpath='{range .items[*]}{.reason}{" "}{.message}{"\n"}{end}' 2>/dev/null || true
+}
+
+size_limit_eviction_observed() {
+	local events
+	local message
+	local size_limit_pattern="(exceed|exceeded|exceeds).*(emptyDir|ephemeral|limit|sizeLimit|${volume_name})"
+
+	if pod_evicted; then
+		return 0
+	fi
+
+	message="$(pod_eviction_message)"
+	if echo "${message}" | grep -Eqi "${size_limit_pattern}"; then
+		return 0
+	fi
+
+	events="$(pod_events)"
+	echo "${events}" | grep -Eqi "evict" || return 1
+	echo "${events}" | grep -Eqi "${size_limit_pattern}"
+}
+
+host_disk_exceeds_allocated_bytes_or_pod_evicted() {
+	local allocated_bytes
+	local disk_path="$1"
+	local min_allocated_bytes="$2"
+
+	if pod_evicted; then
+		info "pod ${pod_name} is already evicted while waiting for sizeLimit accounting: $(pod_eviction_message)"
+		return 0
+	fi
+
+	if ! exec_host "${node}" "test -f '${disk_path}'" >/dev/null 2>&1; then
+		info "host disk image is not present while waiting for sizeLimit accounting: ${disk_path}"
+		if pod_evicted; then
+			info "pod ${pod_name} was evicted after host disk image disappeared: $(pod_eviction_message)"
+			return 0
+		fi
+
+		pod_evicted
+		return $?
+	fi
+
+	allocated_bytes="$(host_disk_allocated_bytes "${disk_path}" 2>/dev/null || echo 0)"
+	info "host disk allocated bytes while waiting for sizeLimit accounting: ${allocated_bytes}"
+	[[ "${allocated_bytes}" =~ ^[0-9]+$ ]] || return 1
+	(( allocated_bytes > min_allocated_bytes )) || pod_evicted
+}
+
+set_emptydir_size_limit() {
+	local size_limit="$1"
+
+	yq -i "(.spec.volumes[] | select(.name == \"${volume_name}\").emptyDir.sizeLimit) = \"${size_limit}\"" "${yaml_file}"
+}
+
+apply_plain_ephemeral_pod() {
+	auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
+	kubectl apply -f "${yaml_file}"
+}
+
+guest_discard_max_bytes() {
+	pod_exec "${pod_name}" sh -c \
+		"src=\$(awk -v mp='${mountpoint}' '\$5 == mp {for (i = 1; i <= NF; i++) if (\$i == \"-\") {print \$(i + 2); exit}}' /proc/self/mountinfo); \
+		blk=\${src#/dev/}; blk=\${blk##*/}; \
+		if [ -e \"/sys/class/block/\${blk}/partition\" ]; then blk=\$(basename \"\$(readlink -f \"/sys/class/block/\${blk}/..\")\"); fi; \
+		cat \"/sys/class/block/\${blk}/queue/discard_max_bytes\" 2>/dev/null || echo 0"
+}
+
+setup() {
+	local runtime_config_dropin_file
+
+	skip_unsupported_runtime
+	setup_common || die "setup_common failed"
+
+	pod_name="plain-ephemeral-data-storage"
+	volume_name="temp-plain"
+	mountpoint="/mnt/temp-plain"
+	yaml_template="${pod_config_dir}/pod-plain-ephemeral-data-storage.yaml.in"
+	yaml_file="${pod_config_dir}/pod-plain-ephemeral-data-storage.yaml"
+
+	RUNTIMECLASS="kata-${KATA_HYPERVISOR}" envsubst "\${RUNTIMECLASS}" \
+		< "${yaml_template}" > "${yaml_file}"
+
+	runtime_config_dropin_file="${BATS_FILE_TMPDIR}/99-k8s-plain-ephemeral-data-storage.toml"
+	cat > "${runtime_config_dropin_file}" <<EOF
+[runtime]
+emptydir_mode = "block-plain"
+EOF
+	runtime_config_dropin="$(set_kata_runtime_config_dropin_file \
+		"${node}" \
+		"${runtime_config_dropin_file}")" || \
+		skip "No Kata runtime config found for ${KATA_HYPERVISOR}"
+
+	if [[ "${PULL_TYPE:-default}" == "guest-pull" ]] && is_confidential_runtime_class "${KATA_HYPERVISOR}"; then
+		set_metadata_annotation "${yaml_file}" \
+			"io.containerd.cri.runtime-handler" \
+			"kata-${KATA_HYPERVISOR}"
+	fi
+
+	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+	set_genpolicy_emptydir_type "${policy_settings_dir}" "block-plain"
+	allow_requests "${policy_settings_dir}" "ExecProcessRequest" "ReadStreamRequest"
+}
+
+@test "Plain ephemeral data storage" {
+	apply_plain_ephemeral_pod
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_name}"
+
+	# Verify that emptyDir is mounted as a plain ext4 block device.
+	mountinfo="$(mountinfo_for_mountpoint)"
+	info "mountinfo for ${mountpoint}: ${mountinfo}"
+	[[ -n "${mountinfo}" ]]
+
+	fs_type="$(mountinfo_after_separator_field 1)"
+	source="$(mountinfo_after_separator_field 2)"
+	info "mount source: ${source}"
+	info "mount filesystem type: ${fs_type}"
+
+	[[ "${fs_type}" == "ext4" ]]
+	[[ "${source}" == /dev/* ]]
+	[[ "${source}" != /dev/mapper/* ]]
+	[[ "${source}" != "tmpfs" ]]
+
+	[[ "$(pod_exec "${pod_name}" sh -c "echo foo > '${mountpoint}/foo.txt' && cat '${mountpoint}/foo.txt'")" == "foo" ]]
+	pod_exec "${pod_name}" sh -c "dd if=/dev/zero of='${mountpoint}/blob' bs=1M count=32 && sync"
+}
+
+@test "Plain ephemeral data storage sizeLimit evicts pod" {
+	local accounting_wait_time="${wait_time}"
+	local disk_path
+	local eviction_wait_time=120
+	local events
+	local size_limit="512Mi"
+	local size_limit_bytes=$((512 * 1024 * 1024))
+	local write_mib=2048
+
+	set_emptydir_size_limit "${size_limit}"
+	apply_plain_ephemeral_pod
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_name}"
+
+	disk_path="$(host_disk_path)"
+
+	pod_exec "${pod_name}" sh -c "dd if=/dev/zero of='${mountpoint}/size-limit-test.bin' bs=1M count=${write_mib} conv=fsync" || true
+
+	# First wait for proof that the oversized write crossed the emptyDir limit:
+	# either the host disk image exceeds the limit, or kubelet already evicted the
+	# pod and may have removed disk.img. This distinguishes "we did not write too
+	# much" from "we wrote too much, but eviction evidence did not appear".
+	waitForProcess "${accounting_wait_time}" "${sleep_time}" \
+		"host_disk_exceeds_allocated_bytes_or_pod_evicted '${disk_path}' '${size_limit_bytes}'"
+
+	# Eviction has been observed to take slightly more than the generic 90s wait.
+	waitForProcess "${eviction_wait_time}" "${sleep_time}" size_limit_eviction_observed
+	info "pod ${pod_name} reason: $(kubectl get pod "${pod_name}" -o jsonpath='{.status.reason}' 2>/dev/null || true)"
+	info "pod ${pod_name} eviction message: $(pod_eviction_message)"
+
+	events="$(pod_events)"
+	info "events for ${pod_name}: ${events}"
+}
+
+@test "Plain ephemeral data storage discard reclaims host blocks" {
+	local allocated_after_delete
+	local allocated_after_write
+	local allocated_before
+	local apparent_size
+	local discard_max
+	local disk_path
+	local min_delta
+	local options
+
+	apply_plain_ephemeral_pod
+	kubectl wait --for=condition=Ready --timeout="${timeout}" pod "${pod_name}"
+
+	# Reclaim requires discard support in the guest and discard on the mount.
+	discard_max="$(guest_discard_max_bytes | tr -d '\r\n')"
+	[[ "${discard_max}" =~ ^[0-9]+$ ]] || discard_max=0
+	(( discard_max > 0 )) || skip "Block device for ${mountpoint} does not advertise discard support"
+
+	options="$(mount_options)"
+	info "mount options for ${mountpoint}: ${options}"
+	[[ ",${options}," == *",discard,"* ]]
+
+	# Track the sparse host disk image backing this emptyDir volume.
+	disk_path="$(host_disk_path)"
+	exec_host "${node}" "test -f '${disk_path}'" || die "Missing host disk image ${disk_path}"
+
+	apparent_size="$(exec_host "${node}" "stat -c %s '${disk_path}'")"
+	allocated_before="$(host_disk_allocated_bytes "${disk_path}")"
+	info "host disk apparent size before write: ${apparent_size}"
+	info "host disk allocated bytes before write: ${allocated_before}"
+	(( allocated_before < apparent_size ))
+
+	# Write enough data to force host allocation growth.
+	pod_exec "${pod_name}" sh -c "dd if=/dev/zero of='${mountpoint}/discard-test.bin' bs=1M count=96 conv=fsync"
+	exec_host "${node}" sync
+
+	allocated_after_write="$(host_disk_allocated_bytes "${disk_path}")"
+	info "host disk allocated bytes after write: ${allocated_after_write}"
+
+	min_delta=$((32 * 1024 * 1024))
+	(( allocated_after_write >= allocated_before + min_delta ))
+
+	# Removing the guest file should discard blocks from the host image.
+	wait_for_host_disk_reclaim() {
+		allocated_after_delete="$(host_disk_allocated_bytes "${disk_path}")"
+		info "host disk allocated bytes after delete: ${allocated_after_delete}"
+		(( allocated_after_delete <= allocated_after_write - min_delta ))
+	}
+
+	pod_exec "${pod_name}" sh -c "rm -f '${mountpoint}/discard-test.bin' && sync"
+	exec_host "${node}" sync
+
+	waitForProcess "${wait_time}" "${sleep_time}" wait_for_host_disk_reclaim
+}
+
+teardown() {
+	skip_unsupported_runtime
+
+	echo "=== Plain ephemeral data storage pod describe ==="
+	kubectl describe pod "${pod_name:-plain-ephemeral-data-storage}" || true
+
+	echo "=== Plain ephemeral data storage pod logs ==="
+	kubectl logs "${pod_name:-plain-ephemeral-data-storage}" || true
+
+	# Always restore the Kata config (no-op if no drop-in was applied).
+	remove_kata_runtime_config_dropin_file "${node}" "${runtime_config_dropin:-}" || true
+
+	delete_tmp_policy_settings_dir "${policy_settings_dir:-}"
+
+	[[ -f "${yaml_file:-}" ]] && kubectl delete -f "${yaml_file}" --ignore-not-found=true
+
+	print_node_journal_since_test_start "${node}" "${node_start_time:-}" "${BATS_TEST_COMPLETED:-}"
+}

--- a/tests/integration/kubernetes/k8s-trusted-ephemeral-data-storage.bats
+++ b/tests/integration/kubernetes/k8s-trusted-ephemeral-data-storage.bats
@@ -23,6 +23,7 @@ setup() {
 
     yaml_file="${pod_config_dir}/pod-trusted-ephemeral-data-storage.yaml"
     policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+    set_genpolicy_emptydir_type "${policy_settings_dir}" "block-encrypted"
 
     # The policy would only block container creation, so allow these
     # requests to make writing tests easier.

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -94,6 +94,7 @@ else
 		"k8s-optional-empty-configmap.bats" \
 		"k8s-optional-empty-secret.bats" \
 		"k8s-pid-ns.bats" \
+		"k8s-plain-ephemeral-data-storage.bats" \
 		"k8s-pod-quota.bats" \
 		"k8s-port-forward.bats" \
 		"k8s-privileged.bats" \

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-plain-ephemeral-data-storage.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-plain-ephemeral-data-storage.yaml.in
@@ -1,0 +1,27 @@
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+kind: Pod
+apiVersion: v1
+metadata:
+  name: plain-ephemeral-data-storage
+spec:
+  securityContext:
+    runAsUser: 0
+    runAsGroup: 0
+    supplementalGroups: [1, 2, 3, 4, 6, 10, 11, 20, 26, 27]
+  runtimeClassName: ${RUNTIMECLASS}
+  restartPolicy: Never
+  containers:
+  - image: quay.io/prometheus/busybox:latest
+    name: test
+    command: ["sleep", "infinity"]
+    volumeMounts:
+    - name: temp-plain
+      mountPath: /mnt/temp-plain
+  volumes:
+  - name: temp-plain
+    emptyDir:
+      sizeLimit: 10G

--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -395,6 +395,30 @@ add_requests_to_policy_settings() {
 	done
 }
 
+# Change genpolicy settings to use the requested emptyDir storage type.
+# Appends a "replace" op to 99-test-overrides.json.
+set_genpolicy_emptydir_type() {
+	declare -r settings_dir="$1"
+	declare -r emptydir_type="$2"
+
+	auto_generate_policy_enabled || return 0
+
+	case "${emptydir_type}" in
+		shared-fs|block-encrypted|block-plain) ;;
+		*) die "Unsupported genpolicy emptydir_type ${emptydir_type}" ;;
+	esac
+
+	local drop_in_dir="${settings_dir}/genpolicy-settings.d"
+	mkdir -p "${drop_in_dir}"
+	local overrides_file="${drop_in_dir}/99-test-overrides.json"
+	[[ -f "${overrides_file}" ]] || echo '[]' > "${overrides_file}"
+
+	info "Setting genpolicy emptydir_type to ${emptydir_type} in ${overrides_file}"
+	jq --arg emptydir_type "${emptydir_type}" \
+		'. + [{"op":"replace","path":"/cluster_config/emptydir_type","value":$emptydir_type}]' \
+		"${overrides_file}" > "${overrides_file}.tmp" && mv "${overrides_file}.tmp" "${overrides_file}"
+}
+
 # Change Rego rules to allow one or more ttrpc requests from the Host to the Guest.
 allow_requests() {
 	declare -r settings_dir="$1"

--- a/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
+++ b/tools/osbuilder/rootfs-builder/cbl-mariner/config.sh
@@ -9,7 +9,7 @@ OS_NAME=cbl-mariner
 OS_VERSION=${OS_VERSION:-3.0}
 # shellcheck disable=SC2034
 LIBC="gnu"
-PACKAGES="kata-packages-uvm"
+PACKAGES="kata-packages-uvm e2fsprogs"
 # shellcheck disable=SC2154
 if [[ "${AGENT_INIT}" = "no" ]]; then PACKAGES+=" systemd"; fi
 # shellcheck disable=SC2154

--- a/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
+++ b/tools/osbuilder/rootfs-builder/nvidia/nvidia_rootfs.sh
@@ -355,18 +355,29 @@ copy_cdh_runtime_deps() {
 	cp -a "${stage_one}/${libdir}"/libpcre2-8.so.0*        "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libcap.so.2*            "${libdir}/."
 
+	copy_mkfs_ext4_runtime_deps
+
+	# cryptsetup and dd are used by CDH secure_mount.
+	mkdir -p sbin bin
+	cp -a "${stage_one}/sbin/cryptsetup" sbin/.
+	cp -a "${stage_one}/usr/bin/dd" bin/.
+}
+
+copy_mkfs_ext4_runtime_deps() {
+	local libdir="lib/${machine_arch}-linux-gnu"
+
 	# e2fsprogs (mke2fs/mkfs.ext4) runtime libs
+	cp -a "${stage_one}/${libdir}"/libuuid.so.1*           "${libdir}/."
+	cp -a "${stage_one}/${libdir}"/libblkid.so.1*          "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libext2fs.so.2*         "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libcom_err.so.2*        "${libdir}/."
 	cp -a "${stage_one}/${libdir}"/libe2p.so.2*            "${libdir}/."
 
-	# cryptsetup, mkfs.ext4, and dd are used by CDH secure_mount.
-	mkdir -p sbin etc bin
-	cp -a "${stage_one}/sbin/cryptsetup" sbin/.
+	# The agent uses mkfs.ext4 for block-plain emptyDir volumes.
+	mkdir -p sbin etc
 	cp -a "${stage_one}/sbin/mke2fs" sbin/.
 	cp -a "${stage_one}/sbin/mkfs.ext4" sbin/.
 	cp -a "${stage_one}/etc/mke2fs.conf" etc/.
-	cp -a "${stage_one}/usr/bin/dd" bin/.
 }
 
 coco_guest_components() {
@@ -444,6 +455,7 @@ setup_nvidia_gpu_rootfs_stage_two() {
 		chisseled_nvat
 	fi
 
+	copy_mkfs_ext4_runtime_deps
 	compress_rootfs
 	chroot . ldconfig
 


### PR DESCRIPTION
## Overview

This PR adds a new `block-plain` emptyDir storage mode. In this mode, Kubernetes disk-backed `emptyDir` volumes are backed by a sparse `disk.img` file in the kubelet emptyDir directory, hotplugged into the guest as a block device, and formatted as ext4 by the agent. This follows the existing `block-encrypted` block-backed emptyDir, but without CDH encryption.

The PR includes:

- Go and rust runtime support for `block-plain` mode
- QEMU discard/unmap plumbing in both runtime implementations
- agent support for formatting fresh block emptyDir volumes
- genpolicy support for `shared-fs`, `block-encrypted`, and `block-plain` emptyDir policy modelling
- NVIDIA rootfs builder updates so `mkfs.ext4` is available in the guest
- Kubernetes integration coverage for block-plain emptyDir storage and reclaim behavior

## Why

`block-encrypted` emptyDir support already gives Kata a block-backed ephemeral storage path, but it depends on the encrypted/CDH flow. For non-encrypted use cases, we want a plain block-backed mode that can be used without key-broker plumbing while still exercising the same kind of guest-visible block device behavior. An example is when filesystem sharing is disabled for non-TEE handlers.

This also lets us test discard/unmap based reclaim for sparse emptyDir disk images. The guest formats and mounts the block device, writes data, removes it, runs discard, and the test verifies that the backing image can be reclaimed on the host.

## Testing

Added Kubernetes end-to-end test coverage in `tests/integration/kubernetes/k8s-plain-ephemeral-data-storage.bats`. The test verifies that the guest sees an ext4 block-backed emptyDir mount and that discard reclaims space from the sparse backing image.

Added/extended unit coverage for: a) Go runtime `emptydir_mode` parsing and sandbox config propagation, b) runtime-rs Kubernetes emptyDir mount type handling, c) Go QEMU command-line discard/unmap arguments, d) Go QMP blockdev discard/unmap hotplug arguments, e) Go virtcontainers block-device discard propagation, f) runtime-rs QEMU block discard/unmap parameters.

## Coverage

The new Kubernetes test is added to the regular small-host Kubernetes test set. It validates the `block-plain` flow on VMM/runtime combinations where that test set is scheduled and where the runtime can create the required block emptyDir device.

The test deliberately skips `clh-runtime-rs` and `dragonball`. The runtime-rs block emptyDir path uses `BlockModern`, inherited from the older `block-encrypted` implementation, and those VMM paths do not yet have the required VMM glue for this scenario.

Other VMM/runtime combinations that do not run this Kubernetes test in the current CI matrix are not "claimed" as covered by this PR.