### PR TITLE
runtime-rs: don't fail VM start when guest protection detection errors

### DIFF
--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -561,23 +561,14 @@ impl VirtSandbox {
         hypervisor_config: &HypervisorConfig,
         init_data: Option<String>,
     ) -> Result<Option<ProtectionDeviceConfig>> {
-        let available_protection = available_guest_protection()?;
-        // We need to cover the following case:
-        // - Required to run Kata containers in TEE environment
-        // E.g., available_guest_protection() returns Se, but confidential_guest is not set.
-        // Unless the configuration is skipped, the VM will fail to start
-        // due to lack of a secure boot image for IBM SEL
-        if available_protection != GuestProtection::NoProtection
-            && !hypervisor_config.security_info.confidential_guest
-        {
-            info!(
-                sl!(),
-                "confidential_guest is not set while {:?} protection is detected, \
-                 skipping protection device config",
-                available_protection
-            );
+        // No guest protection requested: skip host detection and run without
+        // a protection device (also avoids failing on hosts that advertise a
+        // protection they cannot use, e.g. SEV without SEV-SNP).
+        if !hypervisor_config.security_info.confidential_guest {
             return Ok(None);
         }
+
+        let available_protection = available_guest_protection()?;
         info!(
             sl!(),
             "sandbox: available protection: {:?}", available_protection


### PR DESCRIPTION
prepare_protection_device_config() propagated any error from available_guest_protection() before the existing "confidential_guest is not set" check could run.

On AMD hosts where the kvm_amd `sev` module parameter is "Y" but the CPU does not expose the SEV-SNP CPUID bit (8000_001f EAX[4]) -- e.g. consumer Ryzen -- available_guest_protection() returns Err("SEV not supported"). This blocked every non-confidential VM from booting, even though no confidential guest was requested.

When confidential_guest is not set, a detection failure should not prevent the VM from starting, so fall back to running without protection. When confidential_guest is set the error is still returned, since protection is genuinely required in that case.