### PR TITLE
runtime: don't mark single-queue tap as multi-queue (fixes Firecracker TapOpen EINVAL)

### DIFF
--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -733,7 +733,14 @@ func createLink(netHandle *netlink.Handle, name string, expectedLink netlink.Lin
 	switch expectedLink.Type() {
 	case (&netlink.Tuntap{}).Type():
 		flags := netlink.TUNTAP_VNET_HDR | netlink.TUNTAP_NO_PI
-		if queues > 0 {
+		// Only mark the tap multi-queue when more than one queue is actually
+		// requested. Adding IFF_MULTI_QUEUE (TUNTAP_MULTI_QUEUE_DEFAULTS) to a
+		// single-queue tap is harmless for VMMs that consume the pre-opened fd
+		// (QEMU/CLH), but Firecracker opens the tap by name itself without
+		// IFF_MULTI_QUEUE, and opening a multi-queue tap without that flag
+		// fails with EINVAL (TapOpen ... Invalid argument). Keep single-queue
+		// taps plain so all VMMs can open them.
+		if queues > 1 {
 			flags |= netlink.TUNTAP_MULTI_QUEUE_DEFAULTS
 		} else {
 			// We need to enforce `queues = 1` here in case


### PR DESCRIPTION
## Problem

When using the Firecracker hypervisor, pod sandbox creation fails. The kata shim launches Firecracker, but it exits before its API socket appears and `CreateContainer` times out with:

```
failed to create shim task: Failed to connect to firecracker instance (timeout 10s)
```

Firecracker's own log shows it dies while parsing the network device:

```
Error: ...NetDevice(CreateNetworkDevice(TapOpen(IfreqExecuteError(
  Os { code: 22, kind: InvalidInput, message: "Invalid argument" }, "tap0_kata"))))
```

i.e. opening the tap fails with `EINVAL`. The same `firecracker` binary opens a tap fine on its own, so it is specifically the tap that Kata created that it cannot open.

## Root cause

`createLink()` in `virtcontainers/network_linux.go` adds `IFF_MULTI_QUEUE` (`TUNTAP_MULTI_QUEUE_DEFAULTS`) to the tap whenever `queues > 0` — which is effectively always, since `queues` is at least 1.

QEMU and Cloud Hypervisor consume the pre-opened tap fd that Kata hands them, so the extra flag is harmless for them. Firecracker, however, opens the tap **by name** itself, without `IFF_MULTI_QUEUE`. Opening a multi-queue tap without that flag fails with `EINVAL`, so Firecracker exits immediately.

## Fix

Only mark the tap multi-queue when more than one queue is actually requested (`queues > 1`). Single-queue taps are created plain, so every VMM — including Firecracker — can open them. Multi-queue behaviour (`queues > 1`) is unchanged.

## Tested

QEMU, Cloud Hypervisor and Firecracker pods all start and have working networking after this change.
