### PR TITLE
Revert "runtime: Enforce >= 1 queue pairs for tapNetworkPair"

### DIFF
--- a/src/runtime/virtcontainers/network_linux.go
+++ b/src/runtime/virtcontainers/network_linux.go
@@ -856,7 +856,7 @@ func xConnectVMNetwork(ctx context.Context, endpoint Endpoint, h Hypervisor) err
 
 	netPair := endpoint.NetworkPair()
 
-	queues := 1
+	queues := 0
 	caps := h.Capabilities(ctx)
 	if caps.IsMultiQueueSupported() {
 		queues = int(h.HypervisorConfig().NumVCPUs())


### PR DESCRIPTION
We regressed firecracker when we merged this change, see regression: https://github.com/kata-containers/kata-containers/pull/13130 

Revert https://github.com/kata-containers/kata-containers/commit/2799f7d36b987567c92f3db913fef35641ea1b13 and I'll submit a safer change soon. 