### PR TITLE
kata-deploy: Add a version annotation to runtimeclass

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -44,6 +44,14 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 
 {{/*
+Version annotations for RuntimeClass objects.
+Uses AppVersion (Kata Containers release), matching the default kata-deploy image tag.
+*/}}
+{{- define "kata-deploy.runtimeclassAnnotations" -}}
+katacontainers.io/kata-version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+
+{{/*
 Set the correct containerd conf path depending on the k8s distribution.
 If containerd.configDir is set explicitly, use that instead.
 */}}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -21,6 +21,8 @@ metadata:
 {{- else }}
     kata-deploy/instance: "default"
 {{- end }}
+  annotations:
+{{- include "kata-deploy.runtimeclassAnnotations" .root | nindent 4 }}
 {{- if .root.Values.env.multiInstallSuffix }}
 handler: kata-{{ .shim }}-{{ .root.Values.env.multiInstallSuffix }}
 {{- else }}


### PR DESCRIPTION
Fixes #13123

Enables automations to determine version with a simple read RBAC on the runtime class. Helpful when versions need to match with other tools (e.g. genpolicy) or when simple version determination is needed for other reasons.