### PR TITLE
runtime/remote: bypass HotplugAddDevice for block devices on peer-pods

### DIFF
--- a/src/runtime/virtcontainers/remote.go
+++ b/src/runtime/virtcontainers/remote.go
@@ -209,10 +209,27 @@ func (rh *remoteHypervisor) AddDevice(ctx context.Context, devInfo interface{}, 
 }
 
 func (rh *remoteHypervisor) HotplugAddDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+	// Peer-pod VMs are remote (e.g. EC2 instances) and don't support
+	// in-flight hardware hotplug. Block devices that backed CSI volumes
+	// are attached to the VM out-of-band by the cloud provider's CSI
+	// driver running inside the guest. Treat HotplugAddDevice as a
+	// no-op for block devices so the rest of kata's storage-volume
+	// handling can proceed; the actual device discovery happens in the
+	// guest via the csi-podvm sidecars.
+	if devType == BlockDev {
+		hvLogger.Infof("HotplugAddDevice: bypassed for block device (peer-pod): devInfo=%#v", devInfo)
+		return nil, nil
+	}
 	return nil, notImplemented("HotplugAddDevice")
 }
 
 func (rh *remoteHypervisor) HotplugRemoveDevice(ctx context.Context, devInfo interface{}, devType DeviceType) (interface{}, error) {
+	// Mirror HotplugAddDevice: nothing was hotplugged for block devices,
+	// so detach is also a no-op.
+	if devType == BlockDev {
+		hvLogger.Infof("HotplugRemoveDevice: bypassed for block device (peer-pod)")
+		return nil, nil
+	}
 	return nil, notImplemented("HotplugRemoveDevice")
 }
 


### PR DESCRIPTION
## Summary

The `remoteHypervisor` driver (used by Confidential Containers'
peer-pods mode on AWS, Azure, etc.) currently returns
`notImplemented` from `HotplugAddDevice` for every device type. This
breaks any pod that has a `volumeMode: Block` PVC on a
remote-hypervisor cloud provider: containerd marks the volume as an
OCI Linux device, kata's storage layer calls
`devReceiver.HotplugAddDevice(... DeviceBlock)`, the driver returns
"HotplugAddDevice: not implemented", and the workload container
fails to start.

Hotplug is genuinely impossible on a remote VM. However, for
block-device CSI volumes the storage is *already* attached to the
guest VM at the cloud-provider level before the peer-pod boots: the
cloud-api-adaptor wires the volume in via (e.g.) AWS `RunInstances`
`BlockDeviceMappings`, and inside the guest it appears as a raw NVMe
disk. Kata's hotplug step is redundant for this flow.

This PR makes `HotplugAddDevice` a silent no-op when `devType ==
BlockDev`, with a mirror change to `HotplugRemoveDevice`. Other
device types (VFIO, vhost-user-blk, etc.) keep returning
`notImplemented` -- this only relaxes the behaviour for plain block
devices.

## Tested

EKS cluster, AWS peer-pods provider, EBS CSI driver,
cloud-api-adaptor csi-wrapper sidecars, `volumeMode: Block` PVC,
LUKS-on-EBS workload. Before this change the pod fails with
`HotplugAddDevice: not implemented`. After, the pod reaches `Running
3/3` and data on the encrypted EBS volume persists across pod
recreation. Filesystem-mode PVCs are unaffected (that path doesn't
go through `HotplugAddDevice`).

## Companion PR

Worker-side csi-wrapper plumbing for `volumeMode: Block` lives in
upstream cloud-api-adaptor PR
[#3122](https://github.com/confidential-containers/cloud-api-adaptor/pull/3122).

## Open question for maintainers

There's an alternative shape for this fix: change `Capabilities()`
to honestly return `false` for `IsBlockDeviceHotplugSupported` on
the remote hypervisor (it currently calls
`SetBlockDeviceHotplugSupport()` which is the lie that triggers the
hotplug call in the first place). That would route block-device
volumes through a different code path in `container.go`. I went with
the no-op-bypass because it's the minimal change that gets things
working without affecting the storage handling of stock kata-shim
flows; happy to revise to the `Capabilities()` approach if that's
preferred.

Filing as draft to gauge direction.