### PR TITLE
feat(agent): translate CDI_VISIBLE_DEVICES into CDI GPU requests

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -18,6 +18,7 @@ nav:
       - Intel QAT: use-cases/using-Intel-QAT-and-kata.md
     - How To:
       - NUMA Support: how-to/how-to-use-numa-with-kata.md
+      - Local Builds & Deployment: how-to/how-to-build-and-deploy-local-artifacts.md
     - Contributing:
       - Documentation: doc-contributing.md
   - Misc:

--- a/docs/how-to/how-to-build-and-deploy-local-artifacts.md
+++ b/docs/how-to/how-to-build-and-deploy-local-artifacts.md
@@ -1,0 +1,262 @@
+# Building and Deploying Local Kata Artifacts
+
+## Overview
+
+This guide shows how to build Kata guest artifacts (the guest **kernel**,
+**rootfs image**, and **shim**) locally, deploy them to a test node, and run
+them with a custom runtime config.
+
+It also documents two failure modes that are easy to hit and hard to diagnose:
+a rootfs image that builds "successfully" but is empty, and a guest kernel
+panic caused by module signature enforcement. Both are covered in
+[Troubleshooting](#troubleshooting).
+
+!!! note
+
+    Examples use the **NVIDIA GPU** variant (`nvidia-gpu`), which exercises
+    EROFS, measured rootfs (dm-verity), and signed modules. Substitute the
+    variant name for others.
+
+## Build system
+
+Artifacts are built from `tools/packaging/kata-deploy/local-build/`. Each
+target produces a `kata-static-<component>.tar.zst` under `build/`:
+
+```bash
+cd tools/packaging/kata-deploy/local-build
+
+make kernel-nvidia-gpu-tarball          # guest kernel + modules
+make rootfs-image-nvidia-gpu-tarball    # rootfs image (builds the kernel first)
+make shim-v2-tarball                    # shim + configs
+```
+
+### USE_CACHE
+
+`USE_CACHE` defaults to `yes`, which pulls prebuilt artifacts from CI and skips
+the local build whenever a cached version matches. This means a `make` run may
+not contain your changes, and it mixes CI components with your own. Force a
+local build with:
+
+```bash
+export USE_CACHE=no
+make rootfs-image-nvidia-gpu-tarball
+```
+
+!!! note
+
+    `build/<component>-version`, `-sha256sum`, and `-builder-image-version` files
+    are the fingerprint of a cache pull. If you intended a local build and see
+    them, you forgot `USE_CACHE=no`.
+
+The GPU image build sets `FS_TYPE=erofs`, `MEASURED_ROOTFS=yes`, and
+`SKIP_DAX_HEADER=yes` automatically.
+
+## Rebuild only the rootfs image
+
+When the rootfs contents are unchanged and you only need to repackage them
+(for example after editing `image_builder.sh`), build the image directly
+against the populated rootfs directory:
+
+```bash
+cd tools/osbuilder/image-builder
+
+ROOTFS=../../packaging/kata-deploy/local-build/build/rootfs-image-nvidia-gpu/builddir/rootfs-image/ubuntu_rootfs
+
+sudo USE_DOCKER=1 \
+  FS_TYPE=erofs \
+  MEASURED_ROOTFS=yes \
+  SKIP_DAX_HEADER=yes \
+  BUILD_VARIANT=nvidia-gpu \
+  AGENT_INIT=no \
+  ./image_builder.sh -o /tmp/kata-rootfs.image "$ROOTFS"
+```
+
+`USE_DOCKER=1` runs the build in the `image-builder-osbuilder` container, which
+has the required tools and bind-mounts the on-disk `image_builder.sh`, so local
+edits take effect.
+
+Always verify the image is populated (see
+[Verifying an image is populated](#verifying-an-image-is-populated)) before
+deploying.
+
+## Deploy to a node
+
+Artifacts install under `/opt/kata/share/kata-containers/`.
+
+### Replace the default artifacts
+
+Extract the kernel tarball at `/` so its paths land in place and the
+`*-nvidia-gpu.container` symlinks repoint to the new kernel:
+
+```bash
+sudo tar --zstd -xvf kata-static-kernel-nvidia-gpu.tar.zst -C /
+cp kata-rootfs.image /opt/kata/share/kata-containers/<your-image-name>.image
+```
+
+### Use a custom location
+
+To leave the shipped artifacts untouched, extract into a side directory and
+point a custom runtime config at it:
+
+```bash
+sudo mkdir -p /opt/kata/share/kata-containers/custom/
+sudo tar --zstd -xvf kata-static-kernel-nvidia-gpu.tar.zst \
+  -C /opt/kata/share/kata-containers/custom/
+```
+
+```toml
+[hypervisor.qemu]
+image  = "/opt/kata/share/kata-containers/<your-image-name>.image"
+kernel = "/opt/kata/share/kata-containers/custom/opt/kata/share/kata-containers/vmlinux-nvidia-gpu.container"
+# Disable dm-verity so rebuilt test images boot (see Troubleshooting).
+kernel_verity_params = ""
+```
+
+> **Important:**
+>
+> The kernel and rootfs must come from the **same build**. The rootfs ships the
+> kernel modules under `/lib/modules/<version>`, which must match the running
+> kernel's version and, if enforcement is on, its signing key. Deploy them as a
+> pair.
+
+After deploying, recreate the pod. The kernel, image, and `kernel_verity_params`
+are read at sandbox creation, so a running sandbox keeps the old values.
+
+## Troubleshooting
+
+### The rootfs image is empty
+
+**Symptom.** The guest panics early:
+
+```
+VFS: Unable to mount root fs on unknown-block(...)
+erofs (device ...): cannot read erofs superblock
+```
+
+and the firmware falls back to PXE. A hexdump shows a valid partition table but
+zeros where the filesystem should be.
+
+**Cause.** `image_builder.sh` writes the filesystem into the image through a
+loop partition device (`dd ... of=${device}p1`). In nested or unprivileged
+containers that node does not map to the backing file, so the write silently
+lands nowhere and its exit status is not checked. You get a valid, even
+dm-verity-signed, image over an empty partition, and the build reports success.
+
+**Diagnose.** A healthy EROFS image has magic `e2 e1 f5 e0` at offset
+`0x100400`; an empty one is all zeros from `0x200` to EOF. A
+`kata-static-rootfs-image-*.tar.zst` of only tens of KB (566 MB of zeros
+compresses to almost nothing) is another giveaway.
+
+**Fix.** Make the write independent of loop partition devices:
+
+- Build where loop partitions work, such as a `--privileged` container with
+  `-v /dev:/dev`, or directly on a host; or
+- Use a loopless image build that writes the filesystem into the backing file
+  at the partition offset
+  (`dd if=<fsimage> of=<image> bs=1M seek=<rootfs_start> conv=notrunc,fsync`)
+  and runs `veritysetup format` on plain files instead of partition devices.
+
+### dm-verity panic: "metadata block 0 is corrupted"
+
+**Symptom.**
+
+```
+device-mapper: verity: ...: metadata block 0 is corrupted
+erofs (device dm-0): cannot read erofs superblock
+```
+
+**Cause.** The root hash on the kernel command line does not match the hash
+tree in the image. The runtime reads `kernel_verity_params` from
+`configuration-*.toml`, not from `root_hash_<variant>.txt` at boot. That value
+is baked into the config at shim build time, so rebuilding the image without
+rebuilding the config leaves them mismatched. Each rebuild also uses a new
+random salt, so the hash changes every time.
+
+**Fix.**
+
+- Disable verity for testing: set `kernel_verity_params = ""` (empty string and
+  removing the key are equivalent). The runtime then boots `root=/dev/vda1` and
+  ignores the hash partition.
+- Or keep it in sync: rebuild the image and shim/config together and deploy
+  them as a set, so `kernel_verity_params` equals the build's
+  `root_hash_<variant>.txt`.
+
+### Kernel panic: "Loading of module with unavailable key is rejected"
+
+**Symptom.** The rootfs mounts and init runs, then:
+
+```
+Loading of module with unavailable key is rejected
+panic: /sbin/modprobe failed with status: exit status: 1
+```
+
+**Cause.** Module signature enforcement. Built with `KBUILD_SIGN_PIN` set, the
+kernel gets `CONFIG_MODULE_SIG_FORCE=y` and signs modules with a key derived
+from that pin, and `CONFIG_SYSTEM_TRUSTED_KEYS` is empty, so it trusts only its
+own key. "unavailable key" means the module is signed with a key the running
+kernel does not trust, i.e. the kernel and the in-rootfs modules came from
+different builds. This often comes from `USE_CACHE=yes` pulling a CI kernel
+while the modules were signed by another build.
+
+**Fix.**
+
+- Build the kernel and rootfs together with `USE_CACHE=no` so they share one
+  key, and deploy both.
+- Or build without enforcement (simplest for testing): a kernel built without
+  `KBUILD_SIGN_PIN` has no `MODULE_SIG_FORCE` and loads modules regardless of
+  key. Verify with:
+
+  ```bash
+  tar --zstd -xO -f kata-static-kernel-nvidia-gpu.tar.zst \
+    ./opt/kata/share/kata-containers/config-*-nvidia-gpu | grep MODULE_SIG_FORCE
+  # want: # CONFIG_MODULE_SIG_FORCE is not set
+  ```
+
+!!! note
+
+    Even with signing off, the kernel and modules must share the same version
+    (`vermagic`, e.g. `6.18.28-nvidia-gpu`) or `modprobe` fails. Same-build
+    artifacts guarantee this.
+
+### Boots straight to UEFI/PXE with no kernel output
+
+**Symptom.** The guest produces no kernel log lines at all and the firmware
+loops on boot-device selection and PXE:
+
+```
+BdsDxe: failed to load Boot0002 "UEFI Misc Device" ...: Not Found
+>>Start PXE over IPv4.
+BdsDxe: No bootable option or device was found.
+```
+
+**Cause.** `kernel =` points at `vmlinux` (the raw ELF) instead of `vmlinuz`
+(the bzImage). Variants that boot through OVMF firmware (`firmware = .../OVMF.fd`
+in the config, `-bios .../OVMF.fd` in the qemu line) require a `vmlinuz`
+bzImage; OVMF cannot boot a raw `vmlinux` ELF. QEMU loads `-kernel` into fw_cfg
+without validating it, so the VM starts, OVMF fails to boot the kernel, and
+falls through to disk/PXE. The default GPU config uses
+`vmlinuz-nvidia-gpu.container` for this reason; a custom override that sets
+`vmlinux` instead hits this.
+
+**Fix.** Point `kernel =` at the `vmlinuz` symlink:
+
+```toml
+kernel = "/opt/kata/share/kata-containers/vmlinuz-nvidia-gpu.container"
+```
+
+The kernel tarball ships both `vmlinux-*` and `vmlinuz-*` plus their
+`.container` symlinks, so this is a config-only change. Confirm the qemu command
+line then shows `-kernel .../vmlinuz-...`.
+
+## Verifying an image is populated
+
+```bash
+python3 - /path/to/your.image <<'EOF'
+import sys
+f = open(sys.argv[1], 'rb'); f.seek(0x100400); d = f.read(16)
+print("0x100400:", d.hex(' '))
+print("EROFS magic present:", d[:4] == bytes.fromhex('e2e1f5e0'))
+EOF
+```
+
+`EROFS magic present: True` means the filesystem is really in the image.

--- a/src/agent/src/config.rs
+++ b/src/agent/src/config.rs
@@ -26,6 +26,7 @@ const CDH_API_TIMOUT_OPTION: &str = "agent.cdh_api_timeout";
 const CDH_IMAGE_PULL_TIMEOUT_OPTION: &str = "agent.image_pull_timeout";
 const CDI_TIMEOUT_OPTION: &str = "agent.cdi_timeout";
 const LAUNCH_PROCESS_TIMEOUT_OPTION: &str = "agent.launch_process_timeout";
+const VISIBLE_CDI_DEVICES_OPTION: &str = "agent.visible_cdi_devices";
 const DEBUG_CONSOLE_VPORT_OPTION: &str = "agent.debug_console_vport";
 const LOG_VPORT_OPTION: &str = "agent.log_vport";
 const CONTAINER_PIPE_SIZE_OPTION: &str = "agent.container_pipe_size";
@@ -133,6 +134,7 @@ pub struct AgentConfig {
     pub image_pull_timeout: time::Duration,
     pub cdi_timeout: time::Duration,
     pub launch_process_timeout: time::Duration,
+    pub visible_cdi_devices: bool,
     pub debug_console_vport: i32,
     pub log_vport: i32,
     pub container_pipe_size: i32,
@@ -167,6 +169,7 @@ pub struct AgentConfigBuilder {
     pub image_pull_timeout: Option<time::Duration>,
     pub cdi_timeout: Option<time::Duration>,
     pub launch_process_timeout: Option<time::Duration>,
+    pub visible_cdi_devices: Option<bool>,
     pub debug_console_vport: Option<i32>,
     pub log_vport: Option<i32>,
     pub container_pipe_size: Option<i32>,
@@ -262,6 +265,7 @@ impl Default for AgentConfig {
             image_pull_timeout: DEFAULT_IMAGE_PULL_TIMEOUT,
             cdi_timeout: DEFAULT_CDI_TIMEOUT,
             launch_process_timeout: DEFAULT_LAUNCH_PROCESS_TIMEOUT,
+            visible_cdi_devices: false,
             debug_console_vport: 0,
             log_vport: 0,
             container_pipe_size: DEFAULT_CONTAINER_PIPE_SIZE,
@@ -304,6 +308,7 @@ impl FromStr for AgentConfig {
         config_override!(agent_config_builder, agent_config, image_pull_timeout);
         config_override!(agent_config_builder, agent_config, cdi_timeout);
         config_override!(agent_config_builder, agent_config, launch_process_timeout);
+        config_override!(agent_config_builder, agent_config, visible_cdi_devices);
         config_override!(agent_config_builder, agent_config, debug_console_vport);
         config_override!(agent_config_builder, agent_config, log_vport);
         config_override!(agent_config_builder, agent_config, container_pipe_size);
@@ -493,6 +498,13 @@ impl AgentConfig {
                 config.launch_process_timeout,
                 get_timeout,
                 |launch_process_timeout: &time::Duration| launch_process_timeout.as_secs() > 0
+            );
+
+            parse_cmdline_param!(
+                param,
+                VISIBLE_CDI_DEVICES_OPTION,
+                config.visible_cdi_devices,
+                get_bool_value
             );
 
             // vsock port should be positive values

--- a/src/agent/src/device/mod.rs
+++ b/src/agent/src/device/mod.rs
@@ -23,7 +23,7 @@ use oci::{LinuxDeviceCgroup, Spec};
 use oci_spec::runtime as oci;
 use protocols::agent::Device;
 use slog::Logger;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 use std::os::unix::prelude::FileTypeExt;
@@ -300,12 +300,140 @@ pub fn dump_nvidia_cdi_yaml(logger: &Logger) -> Result<()> {
     Ok(())
 }
 
+const VISIBLE_CDI_DEVICES_ENV: &str = "VISIBLE_CDI_DEVICES";
+
+/// Translate a container's VISIBLE_CDI_DEVICES environment variable into a
+/// list of fully-qualified CDI device names (e.g. "nvidia.com/gpu=all" or
+/// "nvidia.com/ib=0"). The variable is a ':'-separated list of
+/// "<cdi-kind>=<devices>" entries.
+/// Returns an empty vector when the variable is unset, empty, or set to one of
+/// the sentinel values "none"/"void" (following the NVIDIA *_VISIBLE_DEVICES
+/// convention) that explicitly request no CDI devices.
+pub fn cdi_devices_from_visible_devices(spec: &Spec) -> Result<Vec<String>> {
+    let prefix = format!("{VISIBLE_CDI_DEVICES_ENV}=");
+    let value = spec
+        .process()
+        .as_ref()
+        .and_then(|p| p.env().as_ref())
+        .and_then(|env| env.iter().find_map(|e| e.strip_prefix(prefix.as_str())));
+
+    let value = match value {
+        Some(v) => v.trim(),
+        None => return Ok(Vec::new()),
+    };
+
+    match value {
+        "" | "none" | "void" => Ok(Vec::new()),
+        list => {
+            let mut devices = Vec::new();
+            for entry in list.split(':').map(str::trim) {
+                devices.extend(cdi_devices_from_entry(entry)?);
+            }
+            Ok(devices)
+        }
+    }
+}
+
+// Translate a single "<cdi-kind>=<devices>" entry (e.g. "nvidia.com/ib=0,1")
+// into a list of fully-qualified CDI device names (e.g.
+// ["nvidia.com/ib=0", "nvidia.com/ib=1"]). <devices> is a comma-separated list
+// of "all" or non-negative device indices. The CDI kind must be specified
+// explicitly, there is no default.
+fn cdi_devices_from_entry(entry: &str) -> Result<Vec<String>> {
+    let (kind, devices) = entry.split_once('=').ok_or_else(|| {
+        anyhow!(
+            "invalid {}: entry {:?} is missing a CDI kind (expected \"<kind>=<devices>\")",
+            VISIBLE_CDI_DEVICES_ENV,
+            entry
+        )
+    })?;
+
+    let kind = kind.trim();
+    if kind.is_empty() {
+        return Err(anyhow!(
+            "invalid {}: entry {:?} has an empty CDI kind",
+            VISIBLE_CDI_DEVICES_ENV,
+            entry
+        ));
+    }
+
+    let devices = devices.trim();
+    if devices.is_empty() {
+        return Err(anyhow!(
+            "invalid {}: CDI kind {:?} has no devices",
+            VISIBLE_CDI_DEVICES_ENV,
+            kind
+        ));
+    }
+
+    let tokens: Vec<&str> = devices.split(',').map(str::trim).collect();
+
+    if tokens.len() > 1 && tokens.contains(&"all") {
+        return Err(anyhow!(
+            "invalid {}: CDI kind {:?} mixes \"all\" with explicit device indices",
+            VISIBLE_CDI_DEVICES_ENV,
+            kind
+        ));
+    }
+
+    tokens
+        .into_iter()
+        .map(|token| token_to_kind_and_device(kind, token))
+        .collect()
+}
+
+// Translate a single device token into a fully-qualified CDI device name. The token must be either
+// "all" or a non-negative integer device index.
+fn token_to_kind_and_device(kind: &str, token: &str) -> Result<String> {
+    if token == "all" {
+        return Ok(format!("{kind}=all"));
+    }
+
+    token
+        .parse::<u32>()
+        .map(|n| format!("{kind}={n}"))
+        .map_err(|_| {
+            anyhow!(
+                "invalid {}: {:?} is not \"all\" or a non-negative device index for CDI kind {:?}",
+                VISIBLE_CDI_DEVICES_ENV,
+                token,
+                kind
+            )
+        })
+}
+
+fn cdi_kind(device: &str) -> Option<&str> {
+    device.split_once('=').map(|(kind, _)| kind)
+}
+
+/// Return the requested devices that can never be injected: those whose CDI
+/// kind is already present in `available` but which name a device the kind does
+/// not provide (e.g. "nvidia.com/gpu=5" when only GPUs 0-3 exist).
+///
+/// A requested device whose kind is entirely absent from `available` is
+/// deliberately omitted: its CDI spec may simply not have been generated yet,
+/// and the caller should keep waiting for it rather than fail.
+fn unsatisfiable_cdi_devices(available: &[String], requested: &[String]) -> Vec<String> {
+    let known_kinds: HashSet<&str> = available.iter().filter_map(|d| cdi_kind(d)).collect();
+    let available: HashSet<&str> = available.iter().map(String::as_str).collect();
+
+    requested
+        .iter()
+        .filter(|d| match cdi_kind(d) {
+            Some(kind) => known_kinds.contains(kind) && !available.contains(d.as_str()),
+            None => false,
+        })
+        .cloned()
+        .collect()
+}
+
 #[instrument]
 pub async fn handle_cdi_devices(
     logger: &Logger,
     spec: &mut Spec,
     spec_dir: &str,
     cdi_timeout: time::Duration,
+    extra_devices: &[String],
 ) -> Result<()> {
     if let Some(container_type) = spec
         .annotations()
@@ -317,7 +445,19 @@ pub async fn handle_cdi_devices(
         }
     }
 
-    let (_, devices) = parse_annotations(spec.annotations().as_ref().unwrap())?;
+    let mut devices = match spec.annotations().as_ref() {
+        Some(annotations) => parse_annotations(annotations)?.1,
+        None => Vec::new(),
+    };
+
+    // Devices requested via the container's VISIBLE_CDI_DEVICES environment
+    // variable are merged with any devices the host injected through
+    // cdi.k8s.io/* annotations.
+    for dev in extra_devices {
+        if !devices.contains(dev) {
+            devices.push(dev.clone());
+        }
+    }
 
     if devices.is_empty() {
         info!(logger, "no CDI annotations, no devices to inject");
@@ -329,7 +469,7 @@ pub async fn handle_cdi_devices(
     let cache: Arc<std::sync::Mutex<cdi::cache::Cache>> = new_cache(options);
 
     for i in 0..=cdi_timeout.as_secs() {
-        let inject_result = {
+        let (unsatisfiable, inject_result) = {
             // Lock cache within this scope, std::sync::Mutex has no Send
             // and await will not work with time::sleep
             let mut cache = cache.lock().unwrap();
@@ -339,7 +479,9 @@ pub async fn handle_cdi_devices(
                     return Err(anyhow!("error refreshing cache: {:?}", e));
                 }
             }
-            cache.inject_devices(Some(spec), devices.clone())
+            let unsatisfiable = unsatisfiable_cdi_devices(&cache.list_devices(), &devices);
+            let inject_result = cache.inject_devices(Some(spec), devices.clone());
+            (unsatisfiable, inject_result)
         };
 
         match inject_result {
@@ -351,6 +493,15 @@ pub async fn handle_cdi_devices(
                 return Ok(());
             }
             Err(e) => {
+                if !unsatisfiable.is_empty() {
+                    return Err(anyhow!(
+                        "CDI device(s) {:?} do not exist; their CDI kind(s) are present \
+                         in {} but do not provide them: {:?}",
+                        unsatisfiable,
+                        spec_dir,
+                        e
+                    ));
+                }
                 info!(
                     logger,
                     "waiting for CDI spec(s) to be generated ({} of {} max tries) {:?}",
@@ -947,6 +1098,78 @@ mod tests {
     use tempfile::tempdir;
 
     const VM_ROOTFS: &str = "/";
+
+    #[test]
+    fn test_cdi_devices_from_visible_devices() {
+        let make_spec = |val: Option<&str>| {
+            let mut spec = Spec::default();
+            if let Some(v) = val {
+                let mut process = oci::Process::default();
+                *process.env_mut() = Some(vec![format!("VISIBLE_CDI_DEVICES={v}")]);
+                spec.set_process(Some(process));
+            }
+            spec
+        };
+
+        assert!(cdi_devices_from_visible_devices(&make_spec(None))
+            .expect("Failed to get CDI devices")
+            .is_empty());
+        for v in ["", "none", "void"] {
+            assert!(
+                cdi_devices_from_visible_devices(&make_spec(Some(v)))
+                    .expect("Failed to get CDI devices")
+                    .is_empty(),
+                "expected no devices for VISIBLE_CDI_DEVICES={:?}",
+                v
+            );
+        }
+
+        assert_eq!(
+            cdi_devices_from_visible_devices(&make_spec(Some("nvidia.com/gpu=all")))
+                .expect("Failed to get CDI devices"),
+            vec!["nvidia.com/gpu=all".to_string()]
+        );
+
+        assert_eq!(
+            cdi_devices_from_visible_devices(&make_spec(Some(
+                "nvidia.com/gpu=all : nvidia.com/ib=0, 1 ,2"
+            )))
+            .expect("Failed to get CDI devices"),
+            vec![
+                "nvidia.com/gpu=all".to_string(),
+                "nvidia.com/ib=0".to_string(),
+                "nvidia.com/ib=1".to_string(),
+                "nvidia.com/ib=2".to_string(),
+            ]
+        );
+
+        assert!(
+            cdi_devices_from_visible_devices(&make_spec(Some("nvidia.com/gpu=0, 1 ,,2"))).is_err()
+        );
+
+        for v in ["all", "0,1"] {
+            assert!(
+                cdi_devices_from_visible_devices(&make_spec(Some(v))).is_err(),
+                "expected an error for kind-less VISIBLE_CDI_DEVICES={:?}",
+                v
+            );
+        }
+
+        assert!(cdi_devices_from_visible_devices(&make_spec(Some("=all"))).is_err());
+        assert!(cdi_devices_from_visible_devices(&make_spec(Some("nvidia.com/gpu="))).is_err());
+
+        for v in [
+            "nvidia.com/gpu=all,0",
+            "nvidia.com/gpu=0,all",
+            "nvidia.com/gpu=all : nvidia.com/ib=0,all",
+        ] {
+            assert!(
+                cdi_devices_from_visible_devices(&make_spec(Some(v))).is_err(),
+                "expected an error for mixed all/index VISIBLE_CDI_DEVICES={:?}",
+                v
+            );
+        }
+    }
 
     #[test]
     fn test_update_device_cgroup() {
@@ -1701,6 +1924,7 @@ mod tests {
             &mut spec,
             temp_dir.path().to_str().unwrap(),
             cdi_timeout,
+            &[],
         )
         .await;
         println!("modfied spec {spec:?}");
@@ -1725,5 +1949,115 @@ mod tests {
         // find TEST_INNER_ENV in env
         let inner_env = env.iter().find(|e| e.starts_with("TEST_INNER_ENV"));
         assert!(inner_env.is_some(), "TEST_INNER_ENV not found in env");
+    }
+
+    #[test]
+    fn test_unsatisfiable_cdi_devices() {
+        let available = vec![
+            "kata.com/gpu=0".to_string(),
+            "kata.com/gpu=1".to_string(),
+            "kata.com/gpu=all".to_string(),
+        ];
+
+        // Devices the kind provides are satisfiable.
+        for d in ["kata.com/gpu=0", "kata.com/gpu=1", "kata.com/gpu=all"] {
+            assert!(
+                unsatisfiable_cdi_devices(&available, &[d.to_string()]).is_empty(),
+                "{} should be satisfiable",
+                d
+            );
+        }
+
+        // A device the (present) kind does not provide is unsatisfiable.
+        assert_eq!(
+            unsatisfiable_cdi_devices(&available, &["kata.com/gpu=5".to_string()]),
+            vec!["kata.com/gpu=5".to_string()]
+        );
+
+        // A kind that is entirely absent is left for the caller to wait on.
+        assert!(
+            unsatisfiable_cdi_devices(&available, &["other.com/gpu=0".to_string()]).is_empty(),
+            "an absent kind must not be reported as unsatisfiable"
+        );
+
+        // Only the offending device of a mixed request is reported.
+        assert_eq!(
+            unsatisfiable_cdi_devices(
+                &available,
+                &[
+                    "kata.com/gpu=0".to_string(),
+                    "kata.com/gpu=5".to_string(),
+                    "other.com/gpu=0".to_string(),
+                ]
+            ),
+            vec!["kata.com/gpu=5".to_string()]
+        );
+    }
+
+    async fn run_handle_cdi_devices(
+        spec_dir: &str,
+        cdi_timeout: Duration,
+        extra_devices: &[String],
+    ) -> Result<()> {
+        let logger = slog::Logger::root(slog::Discard, o!());
+        let mut spec = Spec::default();
+        handle_cdi_devices(&logger, &mut spec, spec_dir, cdi_timeout, extra_devices).await
+    }
+
+    #[tokio::test]
+    async fn test_handle_cdi_devices_missing_device_of_known_kind() {
+        // A CDI spec providing kind "kata.com/gpu" with only devices "0" and "1".
+        let temp_dir = tempdir().expect("Failed to create temporary directory");
+        let spec_dir = temp_dir.path().to_str().unwrap();
+        let cdi_content = r#"{
+            "cdiVersion": "0.6.0",
+            "kind": "kata.com/gpu",
+            "devices": [
+                { "name": "0", "containerEdits": { "deviceNodes": [{ "path": "/dev/null" }] } },
+                { "name": "1", "containerEdits": { "deviceNodes": [{ "path": "/dev/null" }] } }
+            ]
+        }"#;
+        fs::write(temp_dir.path().join("kata.json"), cdi_content)
+            .expect("Failed to write CDI file");
+
+        // The kind is present but device "5" is not. Use a generous timeout: if
+        // the fail-fast path is broken the test would otherwise hang for the
+        // full duration before reporting a timeout instead.
+        let res = run_handle_cdi_devices(
+            spec_dir,
+            Duration::from_secs(30),
+            &["kata.com/gpu=5".to_string()],
+        )
+        .await;
+        let msg = res
+            .expect_err("missing device of a known kind must be rejected")
+            .to_string();
+        assert!(
+            msg.contains("kata.com/gpu=5"),
+            "error should name the missing device, got: {}",
+            msg
+        );
+        assert!(
+            !msg.contains("CDI timeout"),
+            "should fail fast, not via the wait/timeout path, got: {}",
+            msg
+        );
+
+        // An entirely absent kind goes through the wait path and ultimately
+        // times out (cdi_timeout = 0 means a single attempt).
+        let res = run_handle_cdi_devices(
+            spec_dir,
+            Duration::from_secs(0),
+            &["absent.com/gpu=0".to_string()],
+        )
+        .await;
+        let msg = res
+            .expect_err("an unsatisfied absent kind must eventually time out")
+            .to_string();
+        assert!(
+            msg.contains("CDI timeout"),
+            "an absent kind should take the wait/timeout path, got: {}",
+            msg
+        );
     }
 }

--- a/src/agent/src/rpc.rs
+++ b/src/agent/src/rpc.rs
@@ -71,7 +71,10 @@ use crate::device::block_device_handler::get_virtio_blk_pci_device_name;
 use crate::device::network_device_handler::wait_for_ccw_net_interface;
 #[cfg(not(target_arch = "s390x"))]
 use crate::device::network_device_handler::wait_for_pci_net_interface;
-use crate::device::{add_devices, dump_nvidia_cdi_yaml, handle_cdi_devices, update_env_pci};
+use crate::device::{
+    add_devices, cdi_devices_from_visible_devices, dump_nvidia_cdi_yaml, handle_cdi_devices,
+    update_env_pci,
+};
 use crate::features::get_build_features;
 use crate::metrics::get_metrics;
 use crate::mount::baremount;
@@ -251,7 +254,22 @@ impl AgentService {
         // In Kata we only consider the directory "/var/run/cdi", "/etc" may be
         // readonly
         dump_nvidia_cdi_yaml(&sl())?;
-        handle_cdi_devices(&sl(), &mut oci, "/var/run/cdi", AGENT_CONFIG.cdi_timeout).await?;
+        // When enabled, translate the container's VISIBLE_CDI_DEVICES
+        // environment variable into CDI GPU device requests, so that a
+        // container can select which of the VM's GPUs it sees at runtime.
+        let visible_cdi_devices = if AGENT_CONFIG.visible_cdi_devices {
+            cdi_devices_from_visible_devices(&oci)?
+        } else {
+            Vec::new()
+        };
+        handle_cdi_devices(
+            &sl(),
+            &mut oci,
+            "/var/run/cdi",
+            AGENT_CONFIG.cdi_timeout,
+            &visible_cdi_devices,
+        )
+        .await?;
 
         // Handle trusted storage configuration before mounting any storage
         cdh_handler_trusted_storage(&mut oci)

--- a/src/libs/kata-types/src/config/agent.rs
+++ b/src/libs/kata-types/src/config/agent.rs
@@ -93,6 +93,12 @@ pub struct Agent {
     #[serde(default)]
     pub debug_console_enabled: bool,
 
+    /// When enabled, the agent translates a container's VISIBLE_CDI_DEVICES
+    /// environment variable into CDI GPU device requests (nvidia.com/gpu) so
+    /// that the container sees the matching GPUs present in the VM.
+    #[serde(default)]
+    pub visible_cdi_devices: bool,
+
     /// Agent server port
     #[serde(default = "default_server_port")]
     pub server_port: u32,
@@ -180,6 +186,7 @@ impl std::default::Default for Agent {
             log_level: "info".to_string(),
             enable_tracing: false,
             debug_console_enabled: false,
+            visible_cdi_devices: false,
             server_port: DEFAULT_AGENT_VSOCK_PORT,
             log_port: DEFAULT_AGENT_LOG_PORT,
             passfd_listener_port: DEFAULT_PASSFD_LISTENER_PORT,

--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -61,6 +61,8 @@ pub const CONTAINER_PIPE_SIZE_OPTION: &str = "agent.container_pipe_size";
 pub const LAUNCH_PROCESS_TIMEOUT_OPTION: &str = "agent.launch_process_timeout";
 /// Option of setting the fd passthrough io listener port
 pub const PASSFD_LISTENER_PORT: &str = "agent.passfd_listener_port";
+/// Option enabling translation of VISIBLE_CDI_DEVICES into CDI GPU requests
+pub const VISIBLE_CDI_DEVICES_OPTION: &str = "agent.visible_cdi_devices";
 
 /// Trait to manipulate global Kata configuration information.
 pub trait ConfigPlugin: Send + Sync {
@@ -245,6 +247,9 @@ impl TomlConfig {
                     DEBUG_CONSOLE_VPORT_OPTION.to_string(),
                     DEFAULT_AGENT_DBG_CONSOLE_PORT.to_string(),
                 );
+            }
+            if cfg.visible_cdi_devices {
+                kv.insert(VISIBLE_CDI_DEVICES_OPTION.to_string(), "true".to_string());
             }
             if cfg.mem_agent.enable {
                 kv.insert("psi".to_string(), "1".to_string());
@@ -500,6 +505,7 @@ mod tests {
             container_pipe_size: 20,
             debug_console_enabled: true,
             launch_process_timeout: 60,
+            visible_cdi_devices: true,
             ..Default::default()
         };
         let agent_name = "test_agent";
@@ -513,5 +519,6 @@ mod tests {
         kv.get("agent.debug_console").unwrap();
         assert_eq!(kv.get("agent.debug_console_vport").unwrap(), "1026"); // 1026 is the default port
         assert_eq!(kv.get("agent.launch_process_timeout").unwrap(), "60");
+        assert_eq!(kv.get("agent.visible_cdi_devices").unwrap(), "true");
     }
 }

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -565,6 +565,29 @@ reconnect_timeout_ms = @DEFRECONNECTTIMEOUTMS_NV@
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)
 create_container_timeout = @DEFAULTTIMEOUT_NV@
 
+# If enabled, the agent translates a container's VISIBLE_CDI_DEVICES
+# environment variable into CDI GPU device requests (nvidia.com/gpu), resolved
+# against the GPUs present in the VM via the CDI spec generated in the guest at
+# /var/run/cdi/. The format of VISIBLE_CDI_DEVICES is:
+#
+#   <cdi-kind>=<devices>[:<cdi-kind>=<devices>[...]]
+#
+# For example, you may set something like:
+#
+#   VISIBLE_CDI_DEVICES="nvidia.com/gpu=all:nvidia.com/ib=0,1"
+#
+# The devices can be referenced by explicit CDI index or through the "all"
+# keyword.
+#
+# This parameter is useful in the case where multiple containers in a pod need
+# access to the same GPU and do not want to request additional GPUs from the
+# outer runtime. This is especially useful with GPU observability where one
+# workload container performs the CDI request to the outer runtime, and the
+# sidecar observability containers would get access to the same resources by
+# setting VISIBLE_CDI_DEVICES="nvidia.com/gpu=all".
+# (default: false)
+visible_cdi_devices = false
+
 [agent.@PROJECT_TYPE@.mem_agent]
 # Control the mem-agent function enable or disable.
 # Default to false

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -595,6 +595,29 @@ reconnect_timeout_ms = @DEFRECONNECTTIMEOUTMS_NV@
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)
 create_container_timeout = @DEFAULTTIMEOUT_NV@
 
+# If enabled, the agent translates a container's VISIBLE_CDI_DEVICES
+# environment variable into CDI GPU device requests (nvidia.com/gpu), resolved
+# against the GPUs present in the VM via the CDI spec generated in the guest at
+# /var/run/cdi/. The format of VISIBLE_CDI_DEVICES is:
+#
+#   <cdi-kind>=<devices>[:<cdi-kind>=<devices>[...]]
+#
+# For example, you may set something like:
+#
+#   VISIBLE_CDI_DEVICES="nvidia.com/gpu=all:nvidia.com/ib=0,1"
+#
+# The devices can be referenced by explicit CDI index or through the "all"
+# keyword.
+#
+# This parameter is useful in the case where multiple containers in a pod need
+# access to the same GPU and do not want to request additional GPUs from the
+# outer runtime. This is especially useful with GPU observability where one
+# workload container performs the CDI request to the outer runtime, and the
+# sidecar observability containers would get access to the same resources by
+# setting VISIBLE_CDI_DEVICES="nvidia.com/gpu=all".
+# (default: false)
+visible_cdi_devices = false
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -571,6 +571,29 @@ reconnect_timeout_ms = @DEFRECONNECTTIMEOUTMS_NV@
 # Defaults to @DEFCREATECONTAINERTIMEOUT@ second(s)
 create_container_timeout = @DEFAULTTIMEOUT_NV@
 
+# If enabled, the agent translates a container's VISIBLE_CDI_DEVICES
+# environment variable into CDI GPU device requests (nvidia.com/gpu), resolved
+# against the GPUs present in the VM via the CDI spec generated in the guest at
+# /var/run/cdi/. The format of VISIBLE_CDI_DEVICES is:
+#
+#   <cdi-kind>=<devices>[:<cdi-kind>=<devices>[...]]
+#
+# For example, you may set something like:
+#
+#   VISIBLE_CDI_DEVICES="nvidia.com/gpu=all:nvidia.com/ib=0,1"
+#
+# The devices can be referenced by explicit CDI index or through the "all"
+# keyword.
+#
+# This parameter is useful in the case where multiple containers in a pod need
+# access to the same GPU and do not want to request additional GPUs from the
+# outer runtime. This is especially useful with GPU observability where one
+# workload container performs the CDI request to the outer runtime, and the
+# sidecar observability containers would get access to the same resources by
+# setting VISIBLE_CDI_DEVICES="nvidia.com/gpu=all".
+# (default: false)
+visible_cdi_devices = false
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -612,6 +612,29 @@ dial_timeout = @DEFAULTTIMEOUT_NV@
 # (agent default when unset: 6)
 launch_process_timeout = @DEFAULTLAUNCHPROCESSTIMEOUT_NV@
 
+# If enabled, the agent translates a container's VISIBLE_CDI_DEVICES
+# environment variable into CDI GPU device requests (nvidia.com/gpu), resolved
+# against the GPUs present in the VM via the CDI spec generated in the guest at
+# /var/run/cdi/. The format of VISIBLE_CDI_DEVICES is:
+#
+#   <cdi-kind>=<devices>[:<cdi-kind>=<devices>[...]]
+#
+# For example, you may set something like:
+#
+#   VISIBLE_CDI_DEVICES="nvidia.com/gpu=all:nvidia.com/ib=0,1"
+#
+# The devices can be referenced by explicit CDI index or through the "all"
+# keyword.
+#
+# This parameter is useful in the case where multiple containers in a pod need
+# access to the same GPU and do not want to request additional GPUs from the
+# outer runtime. This is especially useful with GPU observability where one
+# workload container performs the CDI request to the outer runtime, and the
+# sidecar observability containers would get access to the same resources by
+# setting VISIBLE_CDI_DEVICES="nvidia.com/gpu=all".
+# (default: false)
+visible_cdi_devices = false
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -589,6 +589,29 @@ dial_timeout = @DEFAULTTIMEOUT_NV@
 # (agent default when unset: 6)
 launch_process_timeout = @DEFAULTLAUNCHPROCESSTIMEOUT_NV@
 
+# If enabled, the agent translates a container's VISIBLE_CDI_DEVICES
+# environment variable into CDI GPU device requests (nvidia.com/gpu), resolved
+# against the GPUs present in the VM via the CDI spec generated in the guest at
+# /var/run/cdi/. The format of VISIBLE_CDI_DEVICES is:
+#
+#   <cdi-kind>=<devices>[:<cdi-kind>=<devices>[...]]
+#
+# For example, you may set something like:
+#
+#   VISIBLE_CDI_DEVICES="nvidia.com/gpu=all:nvidia.com/ib=0,1"
+#
+# The devices can be referenced by explicit CDI index or through the "all"
+# keyword.
+#
+# This parameter is useful in the case where multiple containers in a pod need
+# access to the same GPU and do not want to request additional GPUs from the
+# outer runtime. This is especially useful with GPU observability where one
+# workload container performs the CDI request to the outer runtime, and the
+# sidecar observability containers would get access to the same resources by
+# setting VISIBLE_CDI_DEVICES="nvidia.com/gpu=all".
+# (default: false)
+visible_cdi_devices = false
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -591,6 +591,29 @@ dial_timeout = @DEFAULTTIMEOUT_NV@
 # (agent default when unset: 6)
 launch_process_timeout = @DEFAULTLAUNCHPROCESSTIMEOUT_NV@
 
+# If enabled, the agent translates a container's VISIBLE_CDI_DEVICES
+# environment variable into CDI GPU device requests (nvidia.com/gpu), resolved
+# against the GPUs present in the VM via the CDI spec generated in the guest at
+# /var/run/cdi/. The format of VISIBLE_CDI_DEVICES is:
+#
+#   <cdi-kind>=<devices>[:<cdi-kind>=<devices>[...]]
+#
+# For example, you may set something like:
+#
+#   VISIBLE_CDI_DEVICES="nvidia.com/gpu=all:nvidia.com/ib=0,1"
+#
+# The devices can be referenced by explicit CDI index or through the "all"
+# keyword.
+#
+# This parameter is useful in the case where multiple containers in a pod need
+# access to the same GPU and do not want to request additional GPUs from the
+# outer runtime. This is especially useful with GPU observability where one
+# workload container performs the CDI request to the outer runtime, and the
+# sidecar observability containers would get access to the same resources by
+# setting VISIBLE_CDI_DEVICES="nvidia.com/gpu=all".
+# (default: false)
+visible_cdi_devices = false
+
 [runtime]
 # If enabled, the runtime will log additional debug messages to the
 # system log

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -229,6 +229,7 @@ type agent struct {
 	DialTimeout          uint32   `toml:"dial_timeout"`
 	CdhApiTimeout        uint32   `toml:"cdh_api_timeout"`
 	LaunchProcessTimeout uint32   `toml:"launch_process_timeout"`
+	VisibleCdiDevices    bool     `toml:"visible_cdi_devices"`
 }
 
 func (orig *tomlConfig) Clone() tomlConfig {
@@ -799,6 +800,10 @@ func (a agent) cdhApiTimout() uint32 {
 
 func (a agent) launchProcessTimeout() uint32 {
 	return a.LaunchProcessTimeout
+}
+
+func (a agent) visibleCdiDevices() bool {
+	return a.VisibleCdiDevices
 }
 
 func (a agent) debug() bool {
@@ -1472,6 +1477,7 @@ func updateRuntimeConfigAgent(configPath string, tomlConf tomlConfig, config *oc
 			DialTimeout:          agent.dialTimout(),
 			CdhApiTimeout:        agent.cdhApiTimout(),
 			LaunchProcessTimeout: agent.launchProcessTimeout(),
+			VisibleCdiDevices:    agent.visibleCdiDevices(),
 		}
 	}
 

--- a/src/runtime/virtcontainers/kata_agent.go
+++ b/src/runtime/virtcontainers/kata_agent.go
@@ -303,6 +303,7 @@ type KataAgentConfig struct {
 	Debug                bool
 	Trace                bool
 	EnableDebugConsole   bool
+	VisibleCdiDevices    bool
 	Policy               string
 }
 
@@ -372,6 +373,10 @@ func KataAgentKernelParams(config KataAgentConfig) []Param {
 	if config.LaunchProcessTimeout > 0 {
 		launchProcessTimeout := strconv.FormatUint(uint64(config.LaunchProcessTimeout), 10)
 		params = append(params, Param{Key: vcAnnotations.LaunchProcessTimeoutKernelParam, Value: launchProcessTimeout})
+	}
+
+	if config.VisibleCdiDevices {
+		params = append(params, Param{Key: vcAnnotations.VisibleCdiDevicesKernelParam, Value: "true"})
 	}
 
 	return params

--- a/src/runtime/virtcontainers/kata_agent_test.go
+++ b/src/runtime/virtcontainers/kata_agent_test.go
@@ -1083,14 +1083,14 @@ func TestKataCleanupSandbox(t *testing.T) {
 }
 
 func TestKataAgentKernelParams(t *testing.T) {
-	assert := assert.New(t)
-
 	// nolint: govet
 	type testData struct {
+		name                 string
 		debug                bool
 		trace                bool
 		containerPipeSize    uint32
 		launchProcessTimeout uint32
+		visibleCdiDevices    bool
 		expectedParams       []Param
 	}
 
@@ -1099,60 +1099,57 @@ func TestKataAgentKernelParams(t *testing.T) {
 
 	containerPipeSizeParam := Param{Key: vcAnnotations.ContainerPipeSizeKernelParam, Value: "2097152"}
 	launchProcessTimeoutParam := Param{Key: vcAnnotations.LaunchProcessTimeoutKernelParam, Value: "60"}
+	visibleCdiDevicesParam := Param{Key: "agent.visible_cdi_devices", Value: "true"}
 
 	data := []testData{
-		{false, false, 0, 0, []Param{}},
+		{name: "no options", expectedParams: []Param{}},
 
-		// Debug
-		{true, false, 0, 0, []Param{debugParam}},
+		{name: "debug", debug: true, expectedParams: []Param{debugParam}},
 
-		// Tracing
-		{false, true, 0, 0, []Param{traceParam}},
+		{name: "tracing", trace: true, expectedParams: []Param{traceParam}},
 
-		// Debug + Tracing
-		{true, true, 0, 0, []Param{debugParam, traceParam}},
+		{name: "debug and tracing", debug: true, trace: true, expectedParams: []Param{debugParam, traceParam}},
 
-		// pipesize
-		{false, false, 2097152, 0, []Param{containerPipeSizeParam}},
+		{name: "pipesize", containerPipeSize: 2097152, expectedParams: []Param{containerPipeSizeParam}},
 
-		// Debug + pipesize
-		{true, false, 2097152, 0, []Param{debugParam, containerPipeSizeParam}},
+		{name: "debug and pipesize", debug: true, containerPipeSize: 2097152, expectedParams: []Param{debugParam, containerPipeSizeParam}},
 
-		// Tracing + pipesize
-		{false, true, 2097152, 0, []Param{traceParam, containerPipeSizeParam}},
+		{name: "tracing and pipesize", trace: true, containerPipeSize: 2097152, expectedParams: []Param{traceParam, containerPipeSizeParam}},
 
-		// Debug + Tracing + pipesize
-		{true, true, 2097152, 0, []Param{debugParam, traceParam, containerPipeSizeParam}},
+		{name: "debug, tracing and pipesize", debug: true, trace: true, containerPipeSize: 2097152, expectedParams: []Param{debugParam, traceParam, containerPipeSizeParam}},
 
-		// LaunchProcessTimeout
-		{false, false, 0, 60, []Param{launchProcessTimeoutParam}},
+		{name: "launch process timeout", launchProcessTimeout: 60, expectedParams: []Param{launchProcessTimeoutParam}},
 
-		// Debug + LaunchProcessTimeout
-		{true, false, 0, 60, []Param{debugParam, launchProcessTimeoutParam}},
+		{name: "debug and launch process timeout", debug: true, launchProcessTimeout: 60, expectedParams: []Param{debugParam, launchProcessTimeoutParam}},
+
+		{name: "visible cdi devices", visibleCdiDevices: true, expectedParams: []Param{visibleCdiDevicesParam}},
 	}
 
-	for i, d := range data {
-		config := KataAgentConfig{
-			Debug:                d.debug,
-			Trace:                d.trace,
-			ContainerPipeSize:    d.containerPipeSize,
-			LaunchProcessTimeout: d.launchProcessTimeout,
-		}
+	for _, d := range data {
+		t.Run(d.name, func(t *testing.T) {
+			assert := assert.New(t)
 
-		count := len(d.expectedParams)
+			config := KataAgentConfig{
+				Debug:                d.debug,
+				Trace:                d.trace,
+				ContainerPipeSize:    d.containerPipeSize,
+				LaunchProcessTimeout: d.launchProcessTimeout,
+				VisibleCdiDevices:    d.visibleCdiDevices,
+			}
 
-		params := KataAgentKernelParams(config)
+			params := KataAgentKernelParams(config)
 
-		if count == 0 {
-			assert.Emptyf(params, "test %d (%+v)", i, d)
-			continue
-		}
+			if len(d.expectedParams) == 0 {
+				assert.Empty(params)
+				return
+			}
 
-		assert.Len(params, count)
+			assert.Len(params, len(d.expectedParams))
 
-		for _, p := range d.expectedParams {
-			assert.Containsf(params, p, "test %d (%+v)", i, d)
-		}
+			for _, p := range d.expectedParams {
+				assert.Contains(params, p)
+			}
+		})
 	}
 }
 

--- a/src/runtime/virtcontainers/pkg/annotations/annotations.go
+++ b/src/runtime/virtcontainers/pkg/annotations/annotations.go
@@ -339,6 +339,12 @@ const (
 	LaunchProcessTimeoutOption      = "launch_process_timeout"
 	LaunchProcessTimeoutKernelParam = "agent." + LaunchProcessTimeoutOption
 
+	// VisibleCdiDevices, when enabled, lets the agent translate a
+	// container's VISIBLE_CDI_DEVICES environment variable into CDI GPU
+	// device requests inside the guest.
+	VisibleCdiDevicesOption      = "visible_cdi_devices"
+	VisibleCdiDevicesKernelParam = "agent." + VisibleCdiDevicesOption
+
 	// Policy is an annotation containing the contents of an agent policy file, base64 encoded.
 	Policy = kataAnnotAgentPrefix + "policy"
 )

--- a/tests/spellcheck/kata-dictionary.txt
+++ b/tests/spellcheck/kata-dictionary.txt
@@ -25,6 +25,7 @@ chiplet
 cpuid
 DCAP
 DGPU
+ioctls
 IOMMU
 IOVA
 MDEV
@@ -106,9 +107,11 @@ nerdctl
 crictl
 dockershim
 dentries
+hexdump
 hypercalls
 inodes
 libelf-dev
+loopless
 memcg
 nydus
 patchset


### PR DESCRIPTION
Summary
-------

Add an opt-in `visible_cdi_devices` agent option that lets a container
select which of the VM's GPUs it sees via a `VISIBLE_CDI_DEVICES` env var
(e.g. "all", or "0,1"). When enabled, the agent maps the value to
nvidia.com/gpu CDI device requests and feeds them through the existing
CDI injection path, so device nodes, mounts, env and createContainer
hooks from the guest CDI spec (/var/run/cdi/nvidia.yaml, generated by
NVRC/nvidia-ctk) are applied. The variable is intentionally distinct from
NVIDIA_VISIBLE_DEVICES and does not promise identical semantics.

The option is plumbed through both runtimes for parity: each emits the
agent.visible_cdi_devices=true guest kernel param, consumed by the
single guest agent.

- agent: parse agent.visible_cdi_devices; map env to CDI devices and
  merge with annotation-supplied devices in handle_cdi_devices
- runtime (Go): visible_cdi_devices TOML option, kernel param, wired
  into the nvidia-gpu config templates
- runtime-rs: visible_cdi_devices agent option emitted via
  get_agent_kernel_params

Defaults to false; non-GPU containers and other runtimes are unaffected.

Example
-------

Take a real (but abbreviated/redacted) example of a pod spec that looks
like this:

```
apiVersion: v1
kind: Pod
metadata:
  name: kata-gpu-dual
  labels:
    app: kata-gpu-dual
spec:
  tolerations:
  - operator: Exists
  runtimeClassName: kata
  restartPolicy: Never
  containers:
    - name: dcgm-exporter
      image: nvcr.io/nvidia/k8s/dcgm-exporter:3.3.9-3.6.1-ubuntu22.04
      ports:
        - name: metrics
          containerPort: 9400
      securityContext:
        capabilities:
          add: ["SYS_ADMIN"]
      resources:
        limits:
          nvidia.com/gpu: 1
        requests:
          nvidia.com/gpu: 1
    - name: nvidia-smi
      image: nvcr.io/nvidia/cuda:12.4.1-base-ubuntu22.04
      env:
        - name: VISIBLE_CDI_DEVICES
          value: "all"
      command: ["/bin/bash", "-c"]
      args:
        - |
          nvidia-smi -L
          nvidia-smi
          sleep infinity
```

You can see there are two different sidecar containers. The first
requests GPUs through the normal `requests`/`limits` method. This
induces the devices to be passed into the pod via the outer CDI. The
next container needs access to the GPU, but it doesn't want to request a
device from the outer CDI. It only wants to listen to the devices being
passed through to the inner container. In this case, it asks Kata to
pass in all devices visible in the inner CDI.

What Kata does at this point is it annotates the nvidia-smi container
OCI spec with the CDI requests it needs. This ensures all of the GPU
cdevs, the nvidia driver cdev, NVIDIA client libraries, ldconfig cache
updates, and any other CDI runtime hooks are executed on this container
just as if it had requested a real GPU. The resulting logs give us proof
that nvidia-smi works without requesting a GPU through CDI:

```
nvidia-smi GPU 0: NVIDIA H200 (UUID: GPU-55130803-8ebf-3496-2b2f-df04a69cbb9c)
nvidia-smi Mon Jun  8 16:51:44 2026
nvidia-smi +-----------------------------------------------------------------------------------------+
nvidia-smi | NVIDIA-SMI 595.58.03              Driver Version: 595.58.03      CUDA Version: 13.2     |
nvidia-smi +-----------------------------------------+------------------------+----------------------+
nvidia-smi | GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
nvidia-smi | Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
nvidia-smi |                                         |                        |               MIG M. |
nvidia-smi |=========================================+========================+======================|
nvidia-smi |   0  NVIDIA H200                    On  |   00000000:02:00.0 Off |                    0 |
nvidia-smi | N/A   32C    P0            118W /  700W |       4MiB / 143771MiB |      0%      Default |
nvidia-smi |                                         |                        |             Disabled |
nvidia-smi +-----------------------------------------+------------------------+----------------------+
nvidia-smi
nvidia-smi +-----------------------------------------------------------------------------------------+
nvidia-smi | Processes:                                                                              |
nvidia-smi |  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
nvidia-smi |        ID   ID                                                               Usage      |
nvidia-smi |=========================================================================================|
nvidia-smi |  No running processes found                                                             |
nvidia-smi +-----------------------------------------------------------------------------------------+
dcgm-exporter Failed to set capabilities on file `/usr/bin/dcgm-exporter' (Operation not supported)
dcgm-exporter The value of the capability argument is not permitted for a file. Or the file is not a regular (non-symlink) file
dcgm-exporter Warning https://github.com/kata-containers/kata-containers/issues/1: dcgm-exporter doesn't have sufficient privileges to expose profiling metrics. To get profiling metrics with dcgm-exporter, use --cap-add SYS_ADMIN
dcgm-exporter 2026/06/08 16:51:42 maxprocs: Updating GOMAXPROCS=1: using minimum allowed GOMAXPROCS
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Starting dcgm-exporter"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="DCGM successfully initialized!"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Collecting DCP Metrics"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Falling back to metric file '/etc/dcgm-exporter/default-counters.csv'"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Initializing system entities of type: GPU"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Not collecting NvSwitch metrics; no fields to watch for device type: 3"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Not collecting NvLink metrics; no fields to watch for device type: 6"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Not collecting CPU metrics; no fields to watch for device type: 7"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Not collecting CPU Core metrics; no fields to watch for device type: 8"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Pipeline starting"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Starting webserver"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="Listening on" address="[::]:9400"
dcgm-exporter time="2026-06-08T16:51:42Z" level=info msg="TLS is disabled." address="[::]:9400" http2=false
```