### PR TITLE
Expose unix sockets to guest workloads (as vsock)

### DIFF
--- a/src/libs/kata-types/src/config/mod.rs
+++ b/src/libs/kata-types/src/config/mod.rs
@@ -20,6 +20,7 @@ pub mod default;
 mod agent;
 mod drop_in;
 pub mod hypervisor;
+mod vsock_uds_forward;
 
 pub use self::agent::Agent;
 use self::default::DEFAULT_AGENT_DBG_CONSOLE_PORT;
@@ -34,6 +35,7 @@ pub use self::runtime::{
     Runtime, RuntimeVendor, EMPTYDIR_MODE_BLOCK_ENCRYPTED, EMPTYDIR_MODE_SHARED_FS,
     RUNTIME_NAME_VIRTCONTAINER,
 };
+pub use self::vsock_uds_forward::{parse_vsock_uds_forward, parse_vsock_uds_forward_list};
 
 pub use self::agent::AGENT_NAME_KATA;
 

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -15,6 +15,8 @@ use crate::validate_path;
 pub mod shared_mount;
 pub use shared_mount::SharedMount;
 
+use super::vsock_uds_forward::parse_vsock_uds_forward_list;
+
 /// Type of runtime VirtContainer.
 pub const RUNTIME_NAME_VIRTCONTAINER: &str = "virt_container";
 
@@ -225,6 +227,10 @@ pub struct Runtime {
     ///              based cold plug.
     #[serde(default)]
     pub pod_resource_api_sock: String,
+
+    /// Bridge guest vsock listeners to host unix sockets (`["port:/absolute/unix/path"]`).
+    #[serde(default)]
+    pub vsock_uds_forward: Vec<String>,
 }
 
 fn default_passfd_listener_port() -> u32 {
@@ -300,6 +306,13 @@ impl ConfigOps for Runtime {
                 real_path.to_owned(),
                 "sandbox bind mount `{}` is invalid: {}"
             )?;
+        }
+
+        if let Err(err) = parse_vsock_uds_forward_list(&conf.runtime.vsock_uds_forward) {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("runtime.vsock_uds_forward: {err}"),
+            ));
         }
 
         Ok(())

--- a/src/libs/kata-types/src/config/vsock_uds_forward.rs
+++ b/src/libs/kata-types/src/config/vsock_uds_forward.rs
@@ -1,0 +1,115 @@
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::{Error, ErrorKind, Result};
+use std::path::Path;
+
+const MIN_VSOCK_UDS_FORWARD_PORT: u32 = 1025;
+
+/// Parse runtime configuration value `port:/absolute/unix/path`.
+/// An empty value disables the feature (returns `Ok(None)`).
+pub fn parse_vsock_uds_forward(val: &str) -> Result<Option<(u32, String)>> {
+    let val = val.trim();
+    if val.is_empty() {
+        return Ok(None);
+    }
+
+    let (port_str, uds) = val.split_once(':').ok_or_else(|| {
+        Error::new(
+            ErrorKind::InvalidInput,
+            format!("{val:?}: expected port:/absolute/unix/path"),
+        )
+    })?;
+
+    let port: u32 = port_str.parse().map_err(|err| {
+        Error::new(
+            ErrorKind::InvalidInput,
+            format!("{port_str:?}: invalid port: {err}"),
+        )
+    })?;
+
+    if port < MIN_VSOCK_UDS_FORWARD_PORT {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("port {port} must be greater than 1024"),
+        ));
+    }
+
+    if uds.is_empty() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            "unix socket path must not be empty".to_string(),
+        ));
+    }
+
+    if !Path::new(uds).is_absolute() {
+        return Err(Error::new(
+            ErrorKind::InvalidInput,
+            format!("unix socket path must be absolute: {uds:?}"),
+        ));
+    }
+
+    Ok(Some((port, uds.to_string())))
+}
+
+/// Parse the first `vsock_uds_forward` list entry. An empty list disables the feature.
+/// Additional entries are ignored until multi-forward support exists.
+pub fn parse_vsock_uds_forward_list(vals: &[String]) -> Result<Option<(u32, String)>> {
+    if vals.is_empty() {
+        return Ok(None);
+    }
+
+    parse_vsock_uds_forward(vals[0].trim())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_vsock_uds_forward() {
+        let cases = [
+            ("empty disables", "", Ok(None)),
+            (
+                "valid",
+                "1234:/tmp/foo.sock",
+                Ok(Some((1234, "/tmp/foo.sock".to_string()))),
+            ),
+            (
+                "port must be greater than 1024",
+                "1024:/tmp/foo.sock",
+                Err(()),
+            ),
+            ("relative path rejected", "1234:tmp/foo.sock", Err(())),
+            (
+                "path with colons",
+                "5000:/tmp/a:b/c.sock",
+                Ok(Some((5000, "/tmp/a:b/c.sock".to_string()))),
+            ),
+        ];
+
+        for (name, val, want) in cases {
+            let got = parse_vsock_uds_forward(val);
+            match want {
+                Ok(None) => assert!(got.as_ref().unwrap().is_none(), "{}", name),
+                Ok(Some((port, uds))) => {
+                    let got = got.unwrap().unwrap();
+                    assert_eq!(got, (port, uds), "{}", name);
+                }
+                Err(()) => assert!(got.is_err(), "{} expected error", name),
+            }
+        }
+    }
+
+    #[test]
+    fn test_parse_vsock_uds_forward_list() {
+        assert!(parse_vsock_uds_forward_list(&[]).unwrap().is_none());
+
+        let got = parse_vsock_uds_forward_list(&["1234:/tmp/foo.sock".to_string()])
+            .unwrap()
+            .unwrap();
+        assert_eq!(got, (1234, "/tmp/foo.sock".to_string()));
+    }
+}

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -791,6 +791,24 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -809,6 +809,24 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -741,6 +741,24 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -717,6 +717,24 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -785,6 +785,24 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #
 emptydir_mode = "@DEFEMPTYDIRMODE@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -671,6 +671,24 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -717,6 +717,24 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -695,6 +695,24 @@ disable_guest_empty_dir = @DEFDISABLEGUESTEMPTYDIR@
 #
 emptydir_mode = "@DEFEMPTYDIRMODE_COCO@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # Enabled experimental feature list, format: ["a", "b"].
 # Experimental features are features not stable enough for production,
 # they may break compatibility, and are prepared for a big version bump.

--- a/src/runtime-rs/crates/agent/src/lib.rs
+++ b/src/runtime-rs/crates/agent/src/lib.rs
@@ -11,7 +11,7 @@ logging::logger_with_subsystem!(sl, "agent");
 
 pub mod kata;
 mod log_forwarder;
-mod sock;
+pub mod sock;
 pub mod types;
 pub use types::{
     ARPNeighbor, ARPNeighbors, AddArpNeighborRequest, AddSwapPathRequest, AddSwapRequest,

--- a/src/runtime-rs/crates/agent/src/sock/vsock.rs
+++ b/src/runtime-rs/crates/agent/src/sock/vsock.rs
@@ -23,12 +23,41 @@ impl Vsock {
     pub fn new(vsock_cid: u32, port: u32) -> Self {
         Self { vsock_cid, port }
     }
+
+    pub async fn connect_once(&self) -> Result<UnixStream> {
+        let sock_addr = VsockAddr::new(self.vsock_cid, self.port);
+        tokio::task::spawn_blocking(move || -> Result<UnixStream> {
+            // Create socket fd
+            let fd = socket(
+                AddressFamily::Vsock,
+                SockType::Stream,
+                SockFlag::empty(),
+                None,
+            )
+            .context("failed to create vsock socket")?;
+
+            // Blocking connect (usually returns quickly for vsock)
+            connect(fd.as_raw_fd(), &sock_addr)
+                .with_context(|| format!("failed to connect to {sock_addr}"))?;
+
+            // Wrap fd so it closes on error
+            let socket = std::os::unix::net::UnixStream::from(fd);
+
+            // Tokio requires non-blocking std socket before from_std()
+            socket
+                .set_nonblocking(true)
+                .context("failed to set non-blocking")?;
+
+            UnixStream::from_std(socket).context("from_std")
+        })
+        .await
+        .context("vsock: connect task join failed")?
+    }
 }
 
 #[async_trait]
 impl Sock for Vsock {
     async fn connect(&self, config: &ConnectConfig) -> Result<Stream> {
-        let sock_addr = VsockAddr::new(self.vsock_cid, self.port);
         let deadline = Instant::now() + Duration::from_millis(config.reconnect_timeout_ms);
 
         let mut backoff = Duration::from_millis(config.dial_timeout_ms);
@@ -47,36 +76,7 @@ impl Sock for Vsock {
         while Instant::now() < deadline {
             attempts += 1;
 
-            let sa = sock_addr;
-            let res: Result<UnixStream> =
-                tokio::task::spawn_blocking(move || -> Result<UnixStream> {
-                    // Create socket fd
-                    let fd = socket(
-                        AddressFamily::Vsock,
-                        SockType::Stream,
-                        SockFlag::empty(),
-                        None,
-                    )
-                    .context("failed to create vsock socket")?;
-
-                    // Blocking connect (usually returns quickly for vsock)
-                    connect(fd.as_raw_fd(), &sa)
-                        .with_context(|| format!("failed to connect to {sa}"))?;
-
-                    // Wrap fd so it closes on error
-                    let socket = std::os::unix::net::UnixStream::from(fd);
-
-                    // Tokio requires non-blocking std socket before from_std()
-                    socket
-                        .set_nonblocking(true)
-                        .context("failed to set non-blocking")?;
-
-                    UnixStream::from_std(socket).context("from_std")
-                })
-                .await
-                .context("vsock: connect task join failed")?;
-
-            match res {
+            match self.connect_once().await {
                 Ok(stream) => {
                     info!(
                         sl!(),

--- a/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/lib.rs
@@ -14,6 +14,7 @@ pub mod factory;
 pub mod health_check;
 pub mod sandbox;
 pub mod sandbox_persist;
+mod vsock_uds_forward;
 
 use std::path::Path;
 use std::sync::Arc;

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -60,7 +60,7 @@ use kata_types::config::hypervisor::Hypervisor as HypervisorConfig;
     any(target_arch = "x86_64", target_arch = "aarch64")
 ))]
 use kata_types::config::hypervisor::HYPERVISOR_NAME_CH;
-use kata_types::config::{hypervisor::Factory, TomlConfig};
+use kata_types::config::{hypervisor::Factory, parse_vsock_uds_forward_list, TomlConfig};
 use kata_types::initdata::{calculate_initdata_digest, ProtectedPlatform};
 use oci_spec::runtime as oci;
 use persist::{self, sandbox_persist::Persist};
@@ -75,6 +75,8 @@ use resource::network::{dan_config_path, DanNetworkConfig, NetworkConfig, Networ
 use resource::{ResourceConfig, ResourceManager};
 use runtime_spec as spec;
 use std::path::{Path, PathBuf};
+
+use crate::vsock_uds_forward::{guest_cid_from_agent_url, VsockUdsForward};
 use std::sync::Arc;
 use std::time::SystemTime;
 use strum::Display;
@@ -110,6 +112,7 @@ struct SandboxInner {
     state: SandboxState,
     exit_info: Option<SandboxExitInfo>,
     created_at: Option<SystemTime>,
+    vsock_uds_forward: Option<VsockUdsForward>,
 }
 
 impl SandboxInner {
@@ -118,6 +121,7 @@ impl SandboxInner {
             state: SandboxState::Init,
             exit_info: None,
             created_at: None,
+            vsock_uds_forward: None,
         }
     }
 }
@@ -729,6 +733,54 @@ impl VirtSandbox {
             network_created: false,
         })
     }
+
+    async fn stop_vsock_uds_forward(&self) {
+        let forwarder = self.inner.write().await.vsock_uds_forward.take();
+        if let Some(forwarder) = forwarder {
+            forwarder.stop().await;
+        }
+    }
+
+    async fn build_vsock_uds_forward(&self) -> Option<VsockUdsForward> {
+        let config = self.resource_manager.config().await;
+        if config.runtime.vsock_uds_forward.len() > 1 {
+            warn!(
+                sl!(),
+                "vsock UDS forward: only one port/socket pair is supported; ignoring additional entries: {:?}",
+                &config.runtime.vsock_uds_forward[1..]
+            );
+        }
+
+        let parsed = match parse_vsock_uds_forward_list(&config.runtime.vsock_uds_forward) {
+            Ok(cfg) => cfg,
+            Err(err) => {
+                warn!(sl!(), "vsock UDS forward: invalid config: {err}");
+                return None;
+            }
+        };
+        let (port, uds) = parsed?;
+
+        let agent_url = match self.hypervisor.get_agent_socket().await {
+            Ok(url) => url,
+            Err(err) => {
+                warn!(sl!(), "vsock UDS forward: cannot get agent URL: {err:#}");
+                return None;
+            }
+        };
+
+        let guest_cid = match guest_cid_from_agent_url(&agent_url) {
+            Ok(cid) => cid,
+            Err(err) => {
+                warn!(
+                    sl!(),
+                    "vsock UDS forward: cannot determine guest CID from {agent_url:?}: {err:#}"
+                );
+                return None;
+            }
+        };
+
+        Some(VsockUdsForward::start(guest_cid, port, PathBuf::from(uds)))
+    }
 }
 
 #[async_trait]
@@ -885,6 +937,10 @@ impl Sandbox for VirtSandbox {
             .create_sandbox(req)
             .await
             .context("create sandbox")?;
+
+        if let Some(forwarder) = self.build_vsock_uds_forward().await {
+            inner.vsock_uds_forward = Some(forwarder);
+        }
 
         inner.state = SandboxState::Running;
         inner.created_at = Some(std::time::SystemTime::now());
@@ -1050,6 +1106,8 @@ impl Sandbox for VirtSandbox {
     }
 
     async fn stop(&self) -> Result<()> {
+        self.stop_vsock_uds_forward().await;
+
         let state = {
             let sandbox_inner = self.inner.read().await;
             sandbox_inner.state

--- a/src/runtime-rs/crates/runtimes/virt_container/src/vsock_uds_forward.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/vsock_uds_forward.rs
@@ -1,0 +1,212 @@
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use agent::sock::Vsock;
+use anyhow::{anyhow, Context, Result};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+use tokio::sync::watch;
+use tokio::task::JoinHandle;
+use url::Url;
+
+const DIAL_RETRY: Duration = Duration::from_secs(2);
+const VSOCK_SCHEME: &str = "vsock";
+
+pub(crate) fn guest_cid_from_agent_url(agent_url: &str) -> Result<u32> {
+    let url = Url::parse(agent_url).context("parse agent url")?;
+    if url.scheme() != VSOCK_SCHEME {
+        return Err(anyhow!(
+            "vsock UDS forward requires {VSOCK_SCHEME} agent URL, got {agent_url:?}"
+        ));
+    }
+
+    url.host_str()
+        .ok_or_else(|| anyhow!("cannot parse guest CID from agent URL {agent_url:?}"))?
+        .parse::<u32>()
+        .with_context(|| format!("invalid guest CID in agent URL {agent_url:?}"))
+}
+
+pub(crate) struct VsockUdsForward {
+    shutdown_tx: watch::Sender<bool>,
+    task: JoinHandle<()>,
+}
+
+impl VsockUdsForward {
+    pub(crate) fn start(guest_cid: u32, port: u32, uds: PathBuf) -> Self {
+        let (shutdown_tx, shutdown_rx) = watch::channel(false);
+        info!(
+            sl!(),
+            "vsock UDS forward: started guest_cid={guest_cid} port={port} uds={}",
+            uds.display()
+        );
+        let task = tokio::spawn(run_dial_loop(guest_cid, port, uds, shutdown_rx));
+
+        Self { shutdown_tx, task }
+    }
+
+    pub(crate) async fn stop(self) {
+        let _ = self.shutdown_tx.send(true);
+        self.task.abort();
+        let _ = self.task.await;
+    }
+}
+
+async fn run_dial_loop(
+    guest_cid: u32,
+    port: u32,
+    uds: PathBuf,
+    mut shutdown_rx: watch::Receiver<bool>,
+) {
+    loop {
+        if *shutdown_rx.borrow() {
+            return;
+        }
+
+        let vsock = Vsock::new(guest_cid, port);
+        match vsock.connect_once().await {
+            Ok(vsock) => {
+                if let Err(err) = bridge(vsock, &uds, &mut shutdown_rx).await {
+                    debug!(
+                        sl!(),
+                        "vsock UDS forward: bridge ended guest_cid={guest_cid} port={port} uds={}: {err:#}",
+                        uds.display()
+                    );
+                }
+            }
+            Err(err) => {
+                debug!(
+                    sl!(),
+                    "vsock UDS forward: guest vsock dial failed guest_cid={guest_cid} port={port}: {err:#}"
+                );
+            }
+        }
+
+        if sleep_or_shutdown(&mut shutdown_rx, DIAL_RETRY).await {
+            return;
+        }
+    }
+}
+
+async fn sleep_or_shutdown(shutdown_rx: &mut watch::Receiver<bool>, dur: Duration) -> bool {
+    tokio::select! {
+        res = shutdown_rx.wait_for(|v| *v) => res.is_ok(),
+        _ = tokio::time::sleep(dur) => false,
+    }
+}
+
+async fn bridge(
+    mut vsock: UnixStream,
+    uds_path: &Path,
+    shutdown_rx: &mut watch::Receiver<bool>,
+) -> Result<()> {
+    let mut first = [0u8; 1];
+    let n = match vsock.read(&mut first).await {
+        Ok(0) => return Ok(()),
+        Ok(n) => n,
+        Err(err) => {
+            debug!(
+                sl!(),
+                "vsock UDS forward: guest vsock closed before first byte uds={}: {err:#}",
+                uds_path.display()
+            );
+            return Ok(());
+        }
+    };
+
+    let mut uds = match UnixStream::connect(uds_path).await {
+        Ok(stream) => stream,
+        Err(err) => {
+            warn!(
+                sl!(),
+                "vsock UDS forward: unix dial failed uds={}: {err:#}",
+                uds_path.display()
+            );
+            return Ok(());
+        }
+    };
+
+    if let Err(err) = uds.write_all(&first[..n]).await {
+        warn!(
+            sl!(),
+            "vsock UDS forward: failed to write first byte to unix socket uds={}: {err:#}",
+            uds_path.display()
+        );
+        let _ = uds.shutdown().await;
+        return Ok(());
+    }
+
+    // When either leg finishes (guest vsock EOF or host UDS close), tear down both
+    // sides so the bridge returns and the dial loop can accept the next guest session.
+    let (mut v_read, mut v_write) = vsock.into_split();
+    let (mut u_read, mut u_write) = uds.into_split();
+
+    let guest_to_host = tokio::spawn(async move {
+        tokio::io::copy(&mut v_read, &mut u_write).await
+    });
+    let host_to_guest = tokio::spawn(async move {
+        tokio::io::copy(&mut u_read, &mut v_write).await
+    });
+    let guest_to_host_abort = guest_to_host.abort_handle();
+    let host_to_guest_abort = host_to_guest.abort_handle();
+
+    tokio::pin! {
+        let guest_to_host = guest_to_host;
+        let host_to_guest = host_to_guest;
+    }
+
+    enum BridgeEnd {
+        Shutdown,
+        GuestToHost,
+        HostToGuest,
+    }
+
+    let bridge_end = tokio::select! {
+        _ = shutdown_rx.wait_for(|v| *v) => {
+            guest_to_host_abort.abort();
+            host_to_guest_abort.abort();
+            BridgeEnd::Shutdown
+        }
+        guest_result = &mut guest_to_host => {
+            host_to_guest_abort.abort();
+            let _ = guest_result;
+            BridgeEnd::GuestToHost
+        }
+        host_result = &mut host_to_guest => {
+            guest_to_host_abort.abort();
+            let _ = host_result;
+            BridgeEnd::HostToGuest
+        }
+    };
+
+    match bridge_end {
+        BridgeEnd::Shutdown => {
+            let _ = guest_to_host.await;
+            let _ = host_to_guest.await;
+        }
+        BridgeEnd::GuestToHost => {
+            let _ = host_to_guest.await;
+        }
+        BridgeEnd::HostToGuest => {
+            let _ = guest_to_host.await;
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::guest_cid_from_agent_url;
+
+    #[test]
+    fn test_guest_cid_from_agent_url() {
+        assert_eq!(guest_cid_from_agent_url("vsock://3:1024").unwrap(), 3);
+        assert_eq!(guest_cid_from_agent_url("vsock://16187:1024").unwrap(), 16187);
+        assert!(guest_cid_from_agent_url("hvsock:///tmp/kata.hvsock:1024").is_err());
+    }
+}

--- a/src/runtime/config/configuration-qemu-cca.toml.in
+++ b/src/runtime/config/configuration-qemu-cca.toml.in
@@ -692,6 +692,24 @@ experimental_force_guest_pull = @DEFFORCEGUESTPULL@
 # (e.g. k0s: /var/lib/k0s/kubelet).
 kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # pod_resource_api_sock specifies the unix socket for the Kubelet's
 # PodResource API endpoint. If empty, kubernetes based cold plug
 # will not be attempted. In order for this feature to work, the

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -755,6 +755,24 @@ experimental_force_guest_pull = @DEFFORCEGUESTPULL@
 # (e.g. k0s: /var/lib/k0s/kubelet).
 kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # pod_resource_api_sock specifies the unix socket for the Kubelet's
 # PodResource API endpoint. If empty, kubernetes based cold plug
 # will not be attempted. In order for this feature to work, the

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -801,6 +801,24 @@ experimental_force_guest_pull = @DEFFORCEGUESTPULL@
 # (e.g. k0s: /var/lib/k0s/kubelet).
 kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # pod_resource_api_sock specifies the unix socket for the Kubelet's
 # PodResource API endpoint. If empty, kubernetes based cold plug
 # will not be attempted. In order for this feature to work, the

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -778,6 +778,24 @@ experimental_force_guest_pull = @DEFFORCEGUESTPULL@
 # (e.g. k0s: /var/lib/k0s/kubelet).
 kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # pod_resource_api_sock specifies the unix socket for the Kubelet's
 # PodResource API endpoint. If empty, kubernetes based cold plug
 # will not be attempted. In order for this feature to work, the

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -775,6 +775,24 @@ dan_conf = "@DEFDANCONF@"
 # (e.g. k0s: /var/lib/k0s/kubelet).
 kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # pod_resource_api_sock specifies the unix socket for the Kubelet's
 # PodResource API endpoint. If empty, kubernetes based cold plug
 # will not be attempted. In order for this feature to work, the

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -733,6 +733,24 @@ experimental_force_guest_pull = @DEFFORCEGUESTPULL@
 # (e.g. k0s: /var/lib/k0s/kubelet).
 kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # pod_resource_api_sock specifies the unix socket for the Kubelet's
 # PodResource API endpoint. If empty, kubernetes based cold plug
 # will not be attempted. In order for this feature to work, the

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -763,6 +763,24 @@ experimental_force_guest_pull = @DEFFORCEGUESTPULL@
 # (e.g. k0s: /var/lib/k0s/kubelet).
 kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # pod_resource_api_sock specifies the unix socket for the Kubelet's
 # PodResource API endpoint. If empty, kubernetes based cold plug
 # will not be attempted. In order for this feature to work, the

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -740,6 +740,24 @@ experimental_force_guest_pull = @DEFFORCEGUESTPULL@
 # (e.g. k0s: /var/lib/k0s/kubelet).
 kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # pod_resource_api_sock specifies the unix socket for the Kubelet's
 # PodResource API endpoint. If empty, kubernetes based cold plug
 # will not be attempted. In order for this feature to work, the

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -744,6 +744,24 @@ dan_conf = "@DEFDANCONF@"
 # (e.g. k0s: /var/lib/k0s/kubelet).
 kubelet_root_dir = "@DEFKUBELETROOTDIR@"
 
+# Expose a host unix socket to the guest as a vsock.
+# When enabled, the shim will dial the guest vsock at guestCID:port.
+# The guest or a sidecar must listen on that port.
+# Once the guest accepts the connection, the workload
+# can send data back to the host which will be forwarded to the
+# host unix socket.
+# When the connection ends, the vsock is torn down and another is created.
+# The guest can continue listening to make more requests.
+# Today, only one port/socket pair is supported.
+# Simultaneous connections on the guest vsock are collapsed into one
+# connection to the host unix socket.
+#
+# Format: ["port:/absolute/unix/socket/path"] (port must be > 1024).
+# Empty list disables the feature.
+# Entries beyond the first one will be ignored.
+# Example: vsock_uds_forward = ["15001:/var/run/server.sock"]
+vsock_uds_forward = []
+
 # pod_resource_api_sock specifies the unix socket for the Kubelet's
 # PodResource API endpoint. If empty, kubernetes based cold plug
 # will not be attempted. In order for this feature to work, the

--- a/src/runtime/pkg/containerd-shim-v2/create.go
+++ b/src/runtime/pkg/containerd-shim-v2/create.go
@@ -202,6 +202,8 @@ func create(ctx context.Context, s *service, r *taskAPI.CreateTaskRequest) (*con
 			defaultStartManagementServerFunc(s, ctx, ociSpec)
 		}
 
+		s.tryStartVsockUDSForwardFromConfig()
+
 	case virtcontainers.PodContainer:
 		span, ctx := katatrace.Trace(s.ctx, shimLog, "create", shimTracingTags)
 		defer span.End()

--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -153,6 +153,10 @@ type service struct {
 
 	// shim's pid
 	pid uint32
+
+	vsockUDSCancel    context.CancelFunc
+	vsockUDSConns     sync.Map
+	vsockUDSForwardWg sync.WaitGroup
 }
 
 func newCommand(ctx context.Context, id, containerdBinary, containerdAddress string) (*sysexec.Cmd, error) {
@@ -984,6 +988,8 @@ func (s *service) Shutdown(ctx context.Context, r *taskAPI.ShutdownRequest) (_ *
 	katatrace.StopTracing(s.rootCtx)
 
 	s.cancel()
+
+	s.stopVsockUDSForward()
 
 	// Since we only send an shutdown qmp command to qemu when do stopSandbox, and
 	// didn't wait until qemu process's exit, thus we'd better to make sure it had

--- a/src/runtime/pkg/containerd-shim-v2/shim_vsock_uds_forward.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_vsock_uds_forward.go
@@ -1,0 +1,217 @@
+//go:build linux
+
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package containerdshim
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/mdlayher/vsock"
+)
+
+const (
+	vsockUDSForwardScheme    = "vsock"
+	vsockUDSForwardDialRetry = 2 * time.Second
+)
+
+func guestCIDFromAgentURL(agentURL string) (uint32, error) {
+	const prefix = vsockUDSForwardScheme + "://"
+	if !strings.HasPrefix(agentURL, prefix) {
+		return 0, fmt.Errorf("vsock UDS forward requires %s agent URL, got %q", vsockUDSForwardScheme, agentURL)
+	}
+
+	rest := strings.TrimPrefix(agentURL, prefix)
+	idx := strings.LastIndex(rest, ":")
+	if idx <= 0 {
+		return 0, fmt.Errorf("cannot parse guest CID from agent URL %q", agentURL)
+	}
+
+	cid, err := strconv.ParseUint(rest[:idx], 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid guest CID in agent URL %q: %w", agentURL, err)
+	}
+
+	return uint32(cid), nil
+}
+
+func (s *service) trackVsockUDSConn(c net.Conn) {
+	s.vsockUDSConns.Store(c, struct{}{})
+}
+
+func (s *service) untrackVsockUDSConn(c net.Conn) {
+	s.vsockUDSConns.Delete(c)
+}
+
+func (s *service) closeAllVsockUDSConns() {
+	s.vsockUDSConns.Range(func(key, _ interface{}) bool {
+		if c, ok := key.(net.Conn); ok {
+			_ = c.Close()
+		}
+		return true
+	})
+}
+
+func (s *service) startVsockUDSForward(guestCID, port uint32, uds string) {
+	if s.vsockUDSCancel != nil {
+		return
+	}
+
+	ctx, cancel := context.WithCancel(s.ctx)
+	s.vsockUDSCancel = cancel
+
+	shimLog.WithFields(map[string]interface{}{
+		"guest_cid": guestCID,
+		"port":      port,
+		"uds":       uds,
+	}).Info("vsock UDS forward: started")
+
+	s.vsockUDSForwardWg.Add(1)
+	go func() {
+		defer s.vsockUDSForwardWg.Done()
+		s.runVsockUDSDialLoop(ctx, guestCID, port, uds)
+	}()
+}
+
+func (s *service) runVsockUDSDialLoop(ctx context.Context, guestCID, port uint32, uds string) {
+	logFields := map[string]interface{}{
+		"guest_cid": guestCID,
+		"port":      port,
+		"uds":       uds,
+	}
+
+	for {
+		if ctx.Err() != nil {
+			return
+		}
+
+		conn, err := vsock.Dial(guestCID, port, nil)
+		if err != nil {
+			shimLog.WithError(err).WithFields(logFields).Debug("vsock UDS forward: guest vsock dial failed, will retry")
+			if !sleepOrDone(ctx, vsockUDSForwardDialRetry) {
+				return
+			}
+			continue
+		}
+
+		s.trackVsockUDSConn(conn)
+		s.bridgeVsockUDS(conn, uds)
+		s.untrackVsockUDSConn(conn)
+		_ = conn.Close()
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		if !sleepOrDone(ctx, vsockUDSForwardDialRetry) {
+			return
+		}
+	}
+}
+
+func sleepOrDone(ctx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
+}
+
+func (s *service) bridgeVsockUDS(vconn net.Conn, uds string) {
+	first := make([]byte, 1)
+	n, err := vconn.Read(first)
+	if err != nil {
+		shimLog.WithError(err).WithField("uds", uds).Debug("vsock UDS forward: guest vsock closed before first byte")
+		return
+	}
+	if n == 0 {
+		return
+	}
+
+	uconn, err := net.Dial("unix", uds)
+	if err != nil {
+		shimLog.WithError(err).WithField("uds", uds).Warn("vsock UDS forward: unix dial failed")
+		return
+	}
+
+	if _, err := uconn.Write(first[:n]); err != nil {
+		shimLog.WithError(err).WithField("uds", uds).Warn("vsock UDS forward: failed to write first byte to unix socket")
+		_ = uconn.Close()
+		return
+	}
+
+	// When either leg finishes (guest vsock EOF or host UDS close), tear down both
+	// sides so the bridge returns and the dial loop can accept the next guest session.
+	var once sync.Once
+	teardown := func() {
+		once.Do(func() {
+			_ = uconn.Close()
+			_ = vconn.Close()
+		})
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(uconn, vconn)
+		teardown()
+	}()
+	go func() {
+		defer wg.Done()
+		_, _ = io.Copy(vconn, uconn)
+		teardown()
+	}()
+	wg.Wait()
+}
+
+func (s *service) stopVsockUDSForward() {
+	if s.vsockUDSCancel == nil {
+		return
+	}
+
+	s.vsockUDSCancel()
+	s.vsockUDSCancel = nil
+	s.closeAllVsockUDSConns()
+	s.vsockUDSForwardWg.Wait()
+}
+
+func (s *service) tryStartVsockUDSForwardFromConfig() {
+	if s.config == nil || s.config.VsockUDSForwardPort == 0 {
+		return
+	}
+
+	if len(s.config.VsockUDSForward) > 1 {
+		shimLog.WithField("ignored_entries", s.config.VsockUDSForward[1:]).Warn(
+			"vsock UDS forward: only one port/socket pair is supported; ignoring additional entries",
+		)
+	}
+
+	agentURL, err := s.sandbox.GetAgentURL()
+	if err != nil {
+		shimLog.WithError(err).Warn("vsock UDS forward: cannot get agent URL")
+		return
+	}
+
+	guestCID, err := guestCIDFromAgentURL(agentURL)
+	if err != nil {
+		shimLog.WithError(err).WithField("agent_url", agentURL).Warn("vsock UDS forward: cannot determine guest CID")
+		return
+	}
+
+	s.startVsockUDSForward(guestCID, s.config.VsockUDSForwardPort, s.config.VsockUDSForwardUDS)
+}

--- a/src/runtime/pkg/containerd-shim-v2/shim_vsock_uds_forward_test.go
+++ b/src/runtime/pkg/containerd-shim-v2/shim_vsock_uds_forward_test.go
@@ -1,0 +1,25 @@
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package containerdshim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGuestCIDFromAgentURL(t *testing.T) {
+	cid, err := guestCIDFromAgentURL("vsock://3:1024")
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(3), cid)
+
+	cid, err = guestCIDFromAgentURL("vsock://16187:1024")
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(16187), cid)
+
+	_, err = guestCIDFromAgentURL("hvsock:///tmp/kata.hvsock:1024")
+	assert.Error(t, err)
+}

--- a/src/runtime/pkg/katautils/config.go
+++ b/src/runtime/pkg/katautils/config.go
@@ -203,6 +203,7 @@ type runtime struct {
 	ForceGuestPull            bool     `toml:"experimental_force_guest_pull"`
 	PodResourceAPISock        string   `toml:"pod_resource_api_sock"`
 	KubeletRootDir            string   `toml:"kubelet_root_dir"`
+	VsockUDSForward           []string `toml:"vsock_uds_forward"`
 }
 
 // emptyDirMode returns a valid emptydir_mode value, defaulting to shared-fs
@@ -1751,6 +1752,14 @@ func LoadConfiguration(configPath string, ignoreLogging bool) (resolvedConfigPat
 	config.ForceGuestPull = tomlConf.Runtime.ForceGuestPull
 	config.PodResourceAPISock = tomlConf.Runtime.PodResourceAPISock
 	config.KubeletRootDir = tomlConf.Runtime.KubeletRootDir
+
+	port, uds, err := ParseVsockUDSForwardList(tomlConf.Runtime.VsockUDSForward)
+	if err != nil {
+		return "", config, fmt.Errorf("runtime.vsock_uds_forward: %w", err)
+	}
+	config.VsockUDSForwardPort = port
+	config.VsockUDSForwardUDS = uds
+	config.VsockUDSForward = tomlConf.Runtime.VsockUDSForward
 
 	return resolved, config, nil
 }

--- a/src/runtime/pkg/katautils/vsock_uds_forward.go
+++ b/src/runtime/pkg/katautils/vsock_uds_forward.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package katautils
+
+import (
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const minVsockUDSForwardPort = 1025
+
+// ParseVsockUDSForward parses runtime configuration value "port:/absolute/unix/path".
+// An empty value disables the feature (returns port 0 and empty uds).
+func ParseVsockUDSForward(val string) (port uint32, uds string, err error) {
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return 0, "", nil
+	}
+
+	parts := strings.SplitN(val, ":", 2)
+	if len(parts) != 2 {
+		return 0, "", fmt.Errorf("%q: expected port:/absolute/unix/path", val)
+	}
+
+	p, err := strconv.ParseUint(parts[0], 10, 32)
+	if err != nil {
+		return 0, "", fmt.Errorf("%q: invalid port: %w", parts[0], err)
+	}
+	if p < minVsockUDSForwardPort {
+		return 0, "", fmt.Errorf("port %d must be greater than 1024", p)
+	}
+
+	uds = parts[1]
+	if uds == "" {
+		return 0, "", fmt.Errorf("unix socket path must not be empty")
+	}
+	if !filepath.IsAbs(uds) {
+		return 0, "", fmt.Errorf("unix socket path must be absolute: %q", uds)
+	}
+
+	return uint32(p), uds, nil
+}
+
+// ParseVsockUDSForwardList parses the first vsock_uds_forward list entry.
+// An empty list disables the feature. Additional entries are ignored.
+func ParseVsockUDSForwardList(vals []string) (port uint32, uds string, err error) {
+	if len(vals) == 0 {
+		return 0, "", nil
+	}
+
+	return ParseVsockUDSForward(vals[0])
+}

--- a/src/runtime/pkg/katautils/vsock_uds_forward_test.go
+++ b/src/runtime/pkg/katautils/vsock_uds_forward_test.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2026 Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+package katautils
+
+import "testing"
+
+func TestParseVsockUDSForward(t *testing.T) {
+	tests := []struct {
+		name    string
+		val     string
+		port    uint32
+		uds     string
+		wantErr bool
+	}{
+		{
+			name: "empty disables",
+			val:  "",
+			port: 0,
+			uds:  "",
+		},
+		{
+			name: "valid",
+			val:  "1234:/tmp/foo.sock",
+			port: 1234,
+			uds:  "/tmp/foo.sock",
+		},
+		{
+			name:    "port must be greater than 1024",
+			val:     "1024:/tmp/foo.sock",
+			wantErr: true,
+		},
+		{
+			name:    "relative path rejected",
+			val:     "1234:tmp/foo.sock",
+			wantErr: true,
+		},
+		{
+			name: "path with colons",
+			val:  "5000:/tmp/a:b/c.sock",
+			port: 5000,
+			uds:  "/tmp/a:b/c.sock",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			port, uds, err := ParseVsockUDSForward(tc.val)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if port != tc.port || uds != tc.uds {
+				t.Fatalf("got port=%d uds=%q, want port=%d uds=%q", port, uds, tc.port, tc.uds)
+			}
+		})
+	}
+}
+
+func TestParseVsockUDSForwardList(t *testing.T) {
+	port, uds, err := ParseVsockUDSForwardList(nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if port != 0 || uds != "" {
+		t.Fatalf("got port=%d uds=%q, want disabled", port, uds)
+	}
+
+	port, uds, err = ParseVsockUDSForwardList([]string{"1234:/tmp/foo.sock"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if port != 1234 || uds != "/tmp/foo.sock" {
+		t.Fatalf("got port=%d uds=%q", port, uds)
+	}
+}

--- a/src/runtime/pkg/oci/utils.go
+++ b/src/runtime/pkg/oci/utils.go
@@ -201,6 +201,13 @@ type RuntimeConfig struct {
 	// KubeletRootDir is the kubelet root directory used to match ConfigMap/Secret
 	// volume paths (e.g. /var/lib/k0s/kubelet for k0s). If empty, default is used.
 	KubeletRootDir string
+
+	// Vsock port that the following below unix domain socket will be exposed on.
+	VsockUDSForwardPort uint32
+	// Unix domain socket that will be proxied to the above vsock port.
+	VsockUDSForwardUDS string
+	// Raw vsock_uds_forward list from configuration (only the first entry is used today).
+	VsockUDSForward []string
 }
 
 // AddKernelParam allows the addition of new kernel parameters to an existing

--- a/tests/gha-run-k8s-common.sh
+++ b/tests/gha-run-k8s-common.sh
@@ -411,10 +411,8 @@ function deploy_microk8s() {
 }
 
 function install_system_dependencies() {
-	dependencies="${1}"
-
 	sudo apt-get update
-	sudo apt-get -y install "${dependencies}"
+	sudo apt-get -y install "$@"
 }
 
 function load_k8s_needed_modules() {
@@ -537,7 +535,7 @@ function deploy_vanilla_k8s() {
 		*) ;;
 	esac
 
-	install_system_dependencies "runc"
+	install_system_dependencies runc
 	load_k8s_needed_modules
 	set_k8s_network_parameters
 	disable_swap

--- a/tests/integration/kubernetes/k8s-vsock-uds-forward.bats
+++ b/tests/integration/kubernetes/k8s-vsock-uds-forward.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 Kata Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+pod_name="vsock-uds-forward-pod"
+echo_pod_name="vsock-uds-forward-echo-pod"
+vsock_fwd_port="15001"
+guest_fwd_sock="/tmp/kata-vsock-fwd.sock"
+uds_dir="/var/run/kata-vsock-uds-test"
+uds_path="${uds_dir}/fwd.sock"
+expected_response="kata-vsock-uds-forward-ok"
+guest_request="test"
+guest_client_hold=2
+vsock_uds_forward_setting="${vsock_fwd_port}:${uds_path}"
+guest_unix_client_cmd=(sh -c "( printf '%s\\n' '${guest_request}'; sleep ${guest_client_hold} ) | socat - UNIX-CONNECT:${guest_fwd_sock}")
+guest_relay_wait_cmd=(test -S "${guest_fwd_sock}")
+
+patch_vsock_uds_forward_dropin() {
+	local local_dropin
+
+	local_dropin="${BATS_FILE_TMPDIR}/99-vsock-uds-forward-test.toml"
+	cat > "${local_dropin}" <<EOF
+[runtime]
+vsock_uds_forward = ["${vsock_uds_forward_setting}"]
+EOF
+
+	VSOCK_UDS_DROPIN_PATH="$(set_kata_runtime_config_dropin_file \
+		"${node}" \
+		"${local_dropin}")" || \
+		die "failed to write Kata runtime config drop-in for ${KATA_HYPERVISOR}"
+	export VSOCK_UDS_DROPIN_PATH
+
+	echo "# Wrote drop-in ${VSOCK_UDS_DROPIN_PATH}"
+}
+
+restore_vsock_uds_forward_dropin() {
+	remove_kata_runtime_config_dropin_file "${node}" "${VSOCK_UDS_DROPIN_PATH:-}" || true
+}
+
+start_uds_echo_server_pod() {
+	local i
+
+	exec_host "${node}" "mkdir -p '${uds_dir}'"
+	kubectl create -f "${echo_yaml}"
+	k8s_wait_pod_be_ready "${echo_pod_name}" "${wait_time}" || {
+		kubectl describe pod "${echo_pod_name}" >&3
+		kubectl logs "${echo_pod_name}" >&3 2>/dev/null || true
+		die "UDS echo server pod did not become ready"
+	}
+
+	for i in $(seq 1 30); do
+		if exec_host "${node}" "test -S '${uds_path}'"; then
+			return 0
+		fi
+		sleep 1
+	done
+
+	kubectl logs "${echo_pod_name}" >&3 2>/dev/null || true
+	die "UDS echo server did not create ${uds_path}"
+}
+
+create_and_wait_test_pod() {
+	kubectl create -f "${yaml_file}"
+	k8s_wait_pod_be_ready "${pod_name}" "${wait_time}" || {
+		kubectl describe pod "${pod_name}" >&3
+		kubectl logs "${pod_name}" >&3 2>/dev/null || true
+		return 1
+	}
+}
+
+wait_for_guest_relay_sock() {
+	local i
+
+	# Dual-listen socat creates the unix socket only after the shim connects on vsock.
+	for i in $(seq 1 60); do
+		if kubectl exec "${pod_name}" -- test -S "${guest_fwd_sock}" 2>/dev/null; then
+			return 0
+		fi
+		sleep 1
+	done
+
+	die "guest relay socket ${guest_fwd_sock} not ready"
+}
+
+guest_unix_request() {
+	kubectl exec "${pod_name}" -- "${guest_unix_client_cmd[@]}"
+}
+
+setup() {
+	[[ "${KATA_HYPERVISOR}" == qemu* ]] || skip "vsock UDS forward requires QEMU (KATA_HYPERVISOR=${KATA_HYPERVISOR})"
+	is_runtime_rs && skip "vsock UDS forward requires the Go shim (KATA_HYPERVISOR=${KATA_HYPERVISOR})"
+
+	setup_common || die "setup_common failed"
+	get_pod_config_dir
+
+	yaml_file="${pod_config_dir}/pod-vsock-uds-forward.yaml"
+	echo_yaml="${pod_config_dir}/pod-vsock-uds-forward-echo.yaml"
+
+	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+	add_exec_to_policy_settings "${policy_settings_dir}" "${guest_unix_client_cmd[@]}"
+	add_exec_to_policy_settings "${policy_settings_dir}" sh socat printf sleep
+	add_exec_to_policy_settings "${policy_settings_dir}" "${guest_relay_wait_cmd[@]}"
+	add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
+	auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
+
+	patch_vsock_uds_forward_dropin
+
+	start_uds_echo_server_pod
+}
+
+@test "guest unix request is forwarded to host UDS and returns response" {
+	create_and_wait_test_pod
+
+	wait_for_guest_relay_sock
+
+	output="$(guest_unix_request)" || {
+		kubectl logs "${echo_pod_name}" >&3 2>/dev/null || true
+		die "guest unix request failed"
+	}
+
+	[[ "${output}" == *"${expected_response}"* ]] || {
+		echo "# guest_unix_request output: ${output}" >&3
+		kubectl logs "${echo_pod_name}" >&3 2>/dev/null || true
+		false
+	}
+}
+
+@test "vsock UDS forward pod shuts down cleanly after guest relay is ready" {
+	create_and_wait_test_pod
+
+	wait_for_guest_relay_sock
+}
+
+teardown() {
+	[[ -z "${node:-}" ]] && return
+
+	restore_vsock_uds_forward_dropin
+
+	kubectl delete -f "${yaml_file}" --ignore-not-found=true
+	kubectl delete -f "${echo_yaml}" --ignore-not-found=true
+
+	delete_tmp_policy_settings_dir "${policy_settings_dir}"
+	teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/k8s-vsock-uds-forward.bats
+++ b/tests/integration/kubernetes/k8s-vsock-uds-forward.bats
@@ -95,7 +95,6 @@ guest_unix_request() {
 
 setup() {
 	[[ "${KATA_HYPERVISOR}" == qemu* ]] || skip "vsock UDS forward requires QEMU (KATA_HYPERVISOR=${KATA_HYPERVISOR})"
-	is_runtime_rs && skip "vsock UDS forward requires the Go shim (KATA_HYPERVISOR=${KATA_HYPERVISOR})"
 
 	setup_common || die "setup_common failed"
 	get_pod_config_dir

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -106,6 +106,7 @@ else
 		"k8s-volume.bats" \
 		"k8s-vm-templating.bats" \
 		"k8s-nginx-connectivity.bats" \
+		"k8s-vsock-uds-forward.bats" \
 	)
 
 	K8S_TEST_NORMAL_HOST_UNION=( \

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-vsock-uds-forward-echo.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-vsock-uds-forward-echo.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2026 Kata Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Privileged runc pod that serves the host UDS endpoint for vsock_uds_forward tests.
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vsock-uds-forward-echo-pod
+spec:
+  restartPolicy: Never
+  containers:
+    - name: vsock-uds-forward-echo
+      image: quay.io/kata-containers/alpine:3.22.0
+      securityContext:
+        privileged: true
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          apk add --no-cache socat
+          rm -f /var/run/kata-vsock-uds-test/fwd.sock
+          exec socat -v -v -d -d UNIX-LISTEN:/var/run/kata-vsock-uds-test/fwd.sock,fork,reuseaddr SYSTEM:'read -r req && echo kata-vsock-uds-forward-ok && sleep 10'
+      volumeMounts:
+        - name: uds-dir
+          mountPath: /var/run/kata-vsock-uds-test
+  volumes:
+    - name: uds-dir
+      hostPath:
+        path: /var/run/kata-vsock-uds-test
+        type: DirectoryOrCreate

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-vsock-uds-forward.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-vsock-uds-forward.yaml
@@ -1,0 +1,32 @@
+#
+# Copyright (c) 2026 Kata Contributors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# vsock_uds_forward is enabled via a config.d drop-in written by k8s-vsock-uds-forward.bats.
+#
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vsock-uds-forward-pod
+spec:
+  runtimeClassName: kata
+  restartPolicy: Never
+  containers:
+    - name: vsock-uds-forward-test
+      image: quay.io/kata-containers/alpine:3.22.0
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          IFS=: read -r major minor _ </sys/class/misc/vsock/dev
+          mknod /dev/vsock c "$major" "$minor"
+          chmod 666 /dev/vsock
+          apk add --no-cache socat
+          GUEST_UDS=/tmp/kata-vsock-fwd.sock
+          (
+          while true; do
+            rm -f "$GUEST_UDS"
+            socat -d -d VSOCK-LISTEN:15001,reuseaddr UNIX-LISTEN:${GUEST_UDS},reuseaddr
+          done
+          ) >>/tmp/kata-guest-socat.log 2>&1 &
+          exec sleep infinity


### PR DESCRIPTION
It's easy to expose a unix socket to a runc container, but it's difficult to do the same thing in Kata. There are several use cases, such as connecting a SPIRE server to a Kata pod, that require this. See https://github.com/spiffe/spire/issues/4531 for one example. 

This PR adds config option that allows users to forward a host unix socket to a vsock in the guest. From there the workload can access the vsock directly or use socat to proxy it to a unix socket. This PR introduces a test that shows how the vsock can be mounted inside the guest.

See commit messages for more details. I will add a rust shim implementation shortly, but let's get the test working first.