### PR TITLE
tests: use limits for Kata workload resources

### DIFF
--- a/tests/integration/kubernetes/k8s-memory.bats
+++ b/tests/integration/kubernetes/k8s-memory.bats
@@ -23,6 +23,9 @@ setup_yaml() {
 
 
 @test "Exceeding memory constraints" {
+	# pod-memory-limit.yaml has a fixed 700Mi request. Rendering a lower
+	# limit makes the pod invalid, so the Kubernetes API rejects it before
+	# the stress workload can start.
 	memory_limit_size="50Mi"
 	allocated_size="250M"
 
@@ -41,6 +44,8 @@ setup_yaml() {
 }
 
 @test "Running within memory constraints" {
+	# Render a limit above the fixed 700Mi request. Kubernetes accepts the
+	# pod, and the workload allocates less than the configured request/limit.
 	memory_limit_size="800Mi"
 	allocated_size="150M"
 

--- a/tests/integration/kubernetes/runtimeclass_workloads/inotify-configmap-pod.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/inotify-configmap-pod.yaml
@@ -15,8 +15,6 @@ spec:
     command: ["bash"]
     args: ["-c", "inotifywait --timeout 120 -r /config/ && [[ -L /config/config.toml ]] && echo success" ]
     resources:
-      requests:
-        memory: 50Mi
       limits:
         memory: 1024Mi
     volumeMounts:

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-layered-sc-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-layered-sc-deployment.yaml
@@ -33,8 +33,8 @@ spec:
         securityContext:
           runAsUser: 3000
         resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 800Mi
         ports:
         - containerPort: 6379

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-deployment.yaml
@@ -31,8 +31,8 @@ spec:
       - name: master
         image: quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48
         resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 800Mi
         ports:
         - containerPort: 6379

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-nobodyupdate-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-nobodyupdate-deployment.yaml
@@ -30,8 +30,8 @@ spec:
       - name: master
         image: quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48
         resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 800Mi
         ports:
         - containerPort: 6379

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-supplementalgroups-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-pod-sc-supplementalgroups-deployment.yaml
@@ -35,8 +35,8 @@ spec:
       - name: master
         image: quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48
         resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 800Mi
         ports:
         - containerPort: 6379

--- a/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/k8s-policy-deployment.yaml
@@ -30,8 +30,8 @@ spec:
       - name: master
         image: quay.io/kata-containers/test-images/opstree/redis:sha256-2642c7b07713df6897fa88cbe6db85170690cf3650018ceb2ab16cfa0b4f8d48
         resources:
-          requests:
-            cpu: 100m
-            memory: 100Mi
+          limits:
+            cpu: 500m
+            memory: 800Mi
         ports:
         - containerPort: 6379

--- a/tests/integration/kubernetes/runtimeclass_workloads/limit-range.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/limit-range.yaml
@@ -10,7 +10,5 @@ metadata:
 spec:
   limits:
   - default:
-      cpu: 1
-    defaultRequest:
       cpu: 0.5
     type: Container

--- a/tests/integration/kubernetes/runtimeclass_workloads/numa-topology-gpu-test.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/numa-topology-gpu-test.yaml.in
@@ -15,9 +15,6 @@ spec:
   - name: numa-check
     image: "quay.io/kata-containers/numa:2026-05-15@sha256:a863fcf95fcbbf63352b0555a61a62537f74399dc4bca826a2e42d001e26accb"
     resources:
-      requests:
-        cpu: "1"
-        memory: "1Gi"
       limits:
         cpu: "${NUMA_TEST_VCPUS}"
         memory: "${NUMA_TEST_MEMORY}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/numa-topology-test.yaml.in
+++ b/tests/integration/kubernetes/runtimeclass_workloads/numa-topology-test.yaml.in
@@ -15,9 +15,6 @@ spec:
   - name: numa-check
     image: "quay.io/kata-containers/numa:2026-05-15@sha256:a863fcf95fcbbf63352b0555a61a62537f74399dc4bca826a2e42d001e26accb"
     resources:
-      requests:
-        cpu: "1"
-        memory: "1Gi"
       limits:
         cpu: "${NUMA_TEST_VCPUS}"
         memory: "${NUMA_TEST_MEMORY}"

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
@@ -16,5 +16,3 @@ spec:
     resources:
       limits:
         memory: "800Mi"
-      requests:
-        memory: "600Mi"

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
@@ -17,6 +17,3 @@ spec:
       limits:
         memory: "600Mi"
         cpu: "700m"
-      requests:
-        memory: "600Mi"
-        cpu: "700m"

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-hugepage.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-hugepage.yaml
@@ -21,9 +21,6 @@ spec:
       limits:
         hugepages-${hugepages_size}: 512Mi
         memory: 512Mi
-      requests:
-        hugepages-${hugepages_size}: 512Mi
-        memory: 512Mi
   volumes:
   - name: hugepage
     emptyDir:

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
@@ -16,6 +16,8 @@ spec:
     resources:
       limits:
         memory: "${memory_size}"
+      # k8s-memory.bats renders different limits against this fixed request:
+      # lower values must be rejected, valid higher values should be accepted.
       requests:
         memory: "700Mi"
     command: ["stress"]

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-oom.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-oom.yaml
@@ -20,8 +20,6 @@ spec:
       resources:
         limits:
           memory: 400Mi
-        requests:
-          memory: 400Mi
     - image: quay.io/kata-containers/sysbench-kata:latest
       imagePullPolicy: IfNotPresent
       name: not-oom
@@ -29,6 +27,4 @@ spec:
       args: ["-c", "sleep inf"]
       resources:
         limits:
-          memory: 500Mi
-        requests:
           memory: 500Mi

--- a/tests/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/redis-master-deployment.yaml
@@ -28,7 +28,7 @@ spec:
       - name: master
         image: quay.io/libpod/redis
         resources:
-          requests:
+          limits:
             cpu: 100m
             memory: 100Mi
         ports:

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-clh.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-clh.yaml
@@ -23,7 +23,7 @@ spec:
         - containerPort: 80
           protocol: TCP
         resources:
-          requests:
+          limits:
             cpu: 200m
       restartPolicy: Always
 ---

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-dragonball.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-dragonball.yaml
@@ -23,7 +23,7 @@ spec:
         - containerPort: 80
           protocol: TCP
         resources:
-          requests:
+          limits:
             cpu: 200m
       restartPolicy: Always
 ---

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-fc.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-fc.yaml
@@ -23,7 +23,7 @@ spec:
         - containerPort: 80
           protocol: TCP
         resources:
-          requests:
+          limits:
             cpu: 200m
       restartPolicy: Always
 ---

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-qemu.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-qemu.yaml
@@ -23,7 +23,7 @@ spec:
         - containerPort: 8080
           protocol: TCP
         resources:
-          requests:
+          limits:
             cpu: 200m
       restartPolicy: Always
 ---

--- a/tools/packaging/kata-deploy/examples/test-deploy-kata-stratovirt.yaml
+++ b/tools/packaging/kata-deploy/examples/test-deploy-kata-stratovirt.yaml
@@ -23,7 +23,7 @@ spec:
         - containerPort: 80
           protocol: TCP
         resources:
-          requests:
+          limits:
             cpu: 200m
       restartPolicy: Always
 ---


### PR DESCRIPTION
Kata sizes VM CPU and memory from OCI limits, not Kubernetes resource requests. As of today, CPU and memory requests are consumed by the Kubernetes control plane,  but they do not drive Kata VM/sandbox sizing.

Keeping these requests in Kata workload manifests therefore makes the control plane account for one shape of workload while Kata provisions the VM from another. Update Kata test workloads and kata-deploy examples so CPU and memory resources are expressed as limits instead of requests. This matches the current resource-management limitation documented in docs/Limitations.md#resource-management.

Update fixtures that depend on Kubernetes defaulting from limits. The environment-variable resourceFieldRef fixture now expects both the memory request and memory limit to report the 512Mi limit, and the LimitRange fixture is limit-only at 500m.

Raise the policy deployment limits to 500m and 800Mi. These tests boot CoCo/runtime-rs sandboxes with policy/initdata, and the former 100m/100Mi values became real runtime limits after the conversion, which is too constrained for the CI environments.

Keep the fixed memory request in pod-memory-limit.yaml, since k8s-memory.bats intentionally uses it as a Kubernetes request/limit validation fixture.

Leave PVC storage requests, explicit request/limit validation fixtures, and non-Kata workload examples unchanged, since those requests are handled outside the Kata shim resource sizing path.

If Kata later grows request-aware sandbox sizing, for example through Sandbox API based resource plumbing, these requests can be reintroduced where they carry the intended semantics.
