### PR TITLE
kata-deploy: inherit custom RuntimeClass overhead from baseConfig

### DIFF
--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
@@ -49,9 +49,20 @@ data:
 {{- end }}
 ---
 # RuntimeClasses for custom runtimes
+{{- $runtimeClassConfigs := fromYaml (include "kata-deploy.runtimeClassConfigs" .) | default dict }}
 {{- range $name, $runtime := .Values.customRuntimes.runtimes }}
 {{- if $runtime.runtimeClass }}
-{{ $runtime.runtimeClass }}
+{{- $runtimeClassObj := fromYaml $runtime.runtimeClass | default dict }}
+{{- $inheritBaseOverhead := true }}
+{{- if hasKey $runtime "inheritBaseOverhead" }}
+{{- $inheritBaseOverhead = $runtime.inheritBaseOverhead }}
+{{- end }}
+{{- if and $inheritBaseOverhead (hasKey $runtimeClassConfigs (default "" $runtime.baseConfig)) }}
+{{- $defaultOverhead := deepCopy (index $runtimeClassConfigs $runtime.baseConfig) }}
+{{- $runtimeOverhead := dig "overhead" "podFixed" (dict) $runtimeClassObj }}
+{{- $_ := set $runtimeClassObj "overhead" (dict "podFixed" (mergeOverwrite $defaultOverhead $runtimeOverhead)) }}
+{{- end }}
+{{ toYaml $runtimeClassObj }}
 ---
 {{- end }}
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/runtimeclasses.yaml
@@ -1,4 +1,37 @@
 {{- /*
+  Common RuntimeClass overhead defaults keyed by shim/baseConfig.
+*/ -}}
+{{- define "kata-deploy.runtimeClassConfigs" -}}
+{{- toYaml (dict
+  "clh" (dict "memory" "130Mi" "cpu" "250m")
+  "clh-azure" (dict "memory" "130Mi" "cpu" "250m")
+  "clh-runtime-rs" (dict "memory" "130Mi" "cpu" "250m")
+  "clh-azure-runtime-rs" (dict "memory" "130Mi" "cpu" "250m")
+  "dragonball" (dict "memory" "130Mi" "cpu" "250m")
+  "fc" (dict "memory" "130Mi" "cpu" "250m")
+  "qemu" (dict "memory" "160Mi" "cpu" "250m")
+  "qemu-coco-dev" (dict "memory" "160Mi" "cpu" "250m")
+  "qemu-coco-dev-runtime-rs" (dict "memory" "160Mi" "cpu" "250m")
+  "qemu-runtime-rs" (dict "memory" "160Mi" "cpu" "250m")
+  "qemu-se-runtime-rs" (dict "memory" "1024Mi" "cpu" "1.0")
+  "qemu-se" (dict "memory" "1024Mi" "cpu" "1.0")
+  "qemu-snp" (dict "memory" "2048Mi" "cpu" "1.0")
+  "qemu-snp-runtime-rs" (dict "memory" "2048Mi" "cpu" "1.0")
+  "qemu-tdx" (dict "memory" "2048Mi" "cpu" "1.0")
+  "qemu-tdx-runtime-rs" (dict "memory" "2048Mi" "cpu" "1.0")
+  "qemu-nvidia-gpu" (dict "memory" "10240Mi" "cpu" "1.0")
+  "qemu-nvidia-gpu-runtime-rs" (dict "memory" "10240Mi" "cpu" "1.0")
+  "qemu-nvidia-gpu-snp" (dict "memory" "10240Mi" "cpu" "1.0")
+  "qemu-nvidia-gpu-snp-runtime-rs" (dict "memory" "10240Mi" "cpu" "1.0")
+  "qemu-nvidia-gpu-tdx" (dict "memory" "10240Mi" "cpu" "1.0")
+  "qemu-nvidia-gpu-tdx-runtime-rs" (dict "memory" "10240Mi" "cpu" "1.0")
+  "qemu-cca" (dict "memory" "2048Mi" "cpu" "1.0")
+  "stratovirt" (dict "memory" "130Mi" "cpu" "250m")
+  "remote" (dict "memory" "120Mi" "cpu" "250m")
+) -}}
+{{- end -}}
+
+{{- /*
   Render a single RuntimeClass. Params (dict): root (.), shim, config, shimConfig,
   nameOverride (optional; if set, use as metadata.name for default RC), useShimNodeSelectors.
 */ -}}
@@ -95,33 +128,7 @@ scheduling:
 {{- end -}}
 {{- end -}}
 
-{{- $runtimeClassConfigs := dict
-  "clh" (dict "memory" "130Mi" "cpu" "250m")
-  "clh-azure" (dict "memory" "130Mi" "cpu" "250m")
-  "clh-runtime-rs" (dict "memory" "130Mi" "cpu" "250m")
-  "clh-azure-runtime-rs" (dict "memory" "130Mi" "cpu" "250m")
-  "dragonball" (dict "memory" "130Mi" "cpu" "250m")
-  "fc" (dict "memory" "130Mi" "cpu" "250m")
-  "qemu" (dict "memory" "160Mi" "cpu" "250m")
-  "qemu-coco-dev" (dict "memory" "160Mi" "cpu" "250m")
-  "qemu-coco-dev-runtime-rs" (dict "memory" "160Mi" "cpu" "250m")
-  "qemu-runtime-rs" (dict "memory" "160Mi" "cpu" "250m")
-  "qemu-se-runtime-rs" (dict "memory" "1024Mi" "cpu" "1.0")
-  "qemu-se" (dict "memory" "1024Mi" "cpu" "1.0")
-  "qemu-snp" (dict "memory" "2048Mi" "cpu" "1.0")
-  "qemu-snp-runtime-rs" (dict "memory" "2048Mi" "cpu" "1.0")
-  "qemu-tdx" (dict "memory" "2048Mi" "cpu" "1.0")
-  "qemu-tdx-runtime-rs" (dict "memory" "2048Mi" "cpu" "1.0")
-  "qemu-nvidia-gpu" (dict "memory" "10240Mi" "cpu" "1.0")
-  "qemu-nvidia-gpu-runtime-rs" (dict "memory" "10240Mi" "cpu" "1.0")
-  "qemu-nvidia-gpu-snp" (dict "memory" "10240Mi" "cpu" "1.0")
-  "qemu-nvidia-gpu-snp-runtime-rs" (dict "memory" "10240Mi" "cpu" "1.0")
-  "qemu-nvidia-gpu-tdx" (dict "memory" "10240Mi" "cpu" "1.0")
-  "qemu-nvidia-gpu-tdx-runtime-rs" (dict "memory" "10240Mi" "cpu" "1.0")
-  "qemu-cca" (dict "memory" "2048Mi" "cpu" "1.0")
-  "stratovirt" (dict "memory" "130Mi" "cpu" "250m")
-  "remote" (dict "memory" "120Mi" "cpu" "250m")
-}}
+{{- $runtimeClassConfigs := fromYaml (include "kata-deploy.runtimeClassConfigs" .) }}
 
 {{- /* Create RuntimeClass for each enabled shim; when default RC is requested, emit it by reusing the same template with nameOverride */ -}}
 {{- $defaultShim := index .Values.defaultShim "amd64" | default (index .Values.defaultShim "arm64") | default (index .Values.defaultShim "s390x") | default (index .Values.defaultShim "ppc64le") }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -569,6 +569,8 @@ verification:
 #
 # IMPORTANT: The base config is copied AFTER kata-deploy has applied its modifications
 # (debug, proxy, annotations). Custom runtimes inherit these settings from their base.
+# RuntimeClass overhead defaults are also inherited from baseConfig when not set.
+# Set inheritBaseOverhead: false to disable that inheritance for a custom runtime.
 #
 # Usage with values file (recommended):
 #   Create a custom-runtimes.values.yaml file:
@@ -597,6 +599,7 @@ verification:
 #           scheduling:
 #             nodeSelector:
 #               katacontainers.io/kata-runtime: "true"
+#         inheritBaseOverhead: true        # Optional: set false to remove inherited overhead
 #         # Optional: CRI-specific configuration
 #         containerd:
 #           snapshotter: "nydus"  # Configure containerd snapshotter (nydus, erofs, etc.)
@@ -619,6 +622,7 @@ customRuntimes:
   #     dropIn: ""                      # Optional: TOML overrides for config.d
   #     runtimeClass: |
   #       <full RuntimeClass YAML>
+  #     inheritBaseOverhead: true       # Optional: set false to avoid baseConfig overhead inheritance
   #     containerd:
   #       snapshotter: ""  # Optional: nydus, erofs, or empty for default
   #     crio:


### PR DESCRIPTION
Default custom runtime RuntimeClass overhead.podFixed to the selected baseConfig values, so equivalent runtimes behave consistently without repeating boilerplate.

In case the user wants to enforce that no overhead is set on the custom RuntimeClass, disable inheritance with inheritBaseOverhead=false.

This is a pre-req for https://github.com/kata-containers/kata-containers/pull/12735, which I will be revisiting soon.