### PR TITLE
runtime: ignore false positive CRI-O vulnerabilities

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -6,3 +6,18 @@ id = "RUSTSEC-2024-0320"
 ignoreUntil = 2026-10-01 # TODO(burgerdev): revisit yml library ecosystem
 reason = "No alternative currently supports 'yes' strings correctly; genpolicy processes only trusted input."
 
+[[IgnoredVulns]]
+# CRI-O Path Traversal vulnerability in log management functions.
+# False positive: kata-containers only imports github.com/cri-o/cri-o/pkg/annotations
+# for string constants. The vulnerable code (UnMountPodLogs, LinkContainerLogs) is not
+# imported or used.
+id = "GO-2025-3426"
+reason = "False positive: only imports pkg/annotations for constants, not vulnerable log management code"
+
+[[IgnoredVulns]]
+# CRI-O High Memory Consumption from File Read vulnerability.
+# False positive: kata-containers only imports github.com/cri-o/cri-o/pkg/annotations
+# for string constants. The vulnerable code (user creation, /etc/passwd reading) is not
+# imported or used.
+id = "GO-2025-3897"
+reason = "False positive: only imports pkg/annotations for constants, not vulnerable user creation code"


### PR DESCRIPTION
Add osv-scanner ignores for GO-2025-3426 (CVE-2025-0750) and GO-2025-3897 (CVE-2025-4437), which are false positives for kata-containers.

The vulnerabilities have been open for 10 and 16 months and there is no indication that the cri-o community have any intension of addressing the situation. They also only affect the main CRI-O runtime code (log management and user creation functions), but kata-containers only imports github.com/cri-o/cri-o/pkg/annotations for string constant definitions. The vulnerable code paths are not imported or used, therefore we should just filter these out.

GO-2025-3426: Path traversal in UnMountPodLogs/LinkContainerLogs
GO-2025-3897: Memory exhaustion when reading /etc/passwd


Generated-By: IBM Bob