### PR TITLE
tests: unskip hard-coded policy tests on qemu-tdx-runtime-rs

### DIFF
--- a/tests/integration/kubernetes/tests_common.sh
+++ b/tests/integration/kubernetes/tests_common.sh
@@ -342,7 +342,7 @@ hard_coded_policy_tests_enabled() {
 	# CI is testing hard-coded policies just on a the platforms listed here. Outside of CI,
 	# users can enable testing of the same policies (plus the auto-generated policies) by
 	# specifying AUTO_GENERATE_POLICY=yes.
-	local -r enabled_hypervisors=("qemu-coco-dev" "qemu-snp" "qemu-snp-runtime-rs" "qemu-tdx" "qemu-coco-dev-runtime-rs")
+	local -r enabled_hypervisors=("qemu-coco-dev" "qemu-snp" "qemu-snp-runtime-rs" "qemu-tdx" "qemu-tdx-runtime-rs" "qemu-coco-dev-runtime-rs")
 	for enabled_hypervisor in "${enabled_hypervisors[@]}"
 	do
 		if [[ "${enabled_hypervisor}" == "${KATA_HYPERVISOR}" ]]; then


### PR DESCRIPTION
Enable the hard-coded init-data policy test gate for qemu-tdx-runtime-rs so runtime-rs and Go TDX variants exercise the same Kubernetes policy coverage.

ci-devel run for tdx runtime-rs with those tests enabled: https://github.com/kata-containers/kata-containers/actions/runs/27060837641/job/79901941303