### PR TITLE
kata-deploy: support drop-in configs for default runtimes

### DIFF
--- a/docs/helm-configuration.md
+++ b/docs/helm-configuration.md
@@ -35,6 +35,9 @@ Shims can also have configuration options specific to them:
     enabled: ~
     supportedArches:
       - amd64
+    dropIn: |
+      [agent.kata]
+      dial_timeout = 999
     allowedHypervisorAnnotations: []
     containerd:
       snapshotter: ""
@@ -45,6 +48,10 @@ Shims can also have configuration options specific to them:
       # nodeSelector:
         # nvidia.com/cc.ready.state: "false"
 ```
+
+The optional `shims.<shim>.dropIn` field lets you add a custom Kata drop-in for a
+default (non-custom) runtime. kata-deploy writes it as
+`config.d/50-user-overrides.toml` for that shim.
 
 It's best to reference the default `values.yaml` file above for more details.
 

--- a/tests/functional/kata-deploy/kata-deploy-custom-runtimes.bats
+++ b/tests/functional/kata-deploy/kata-deploy-custom-runtimes.bats
@@ -98,6 +98,33 @@ CHART_PATH="$(get_chart_path)"
 	! grep -q "CUSTOM_RUNTIMES_ENABLED" /tmp/rendered.yaml
 }
 
+@test "Helm template: Default runtime drop-in works without custom runtimes" {
+	local values_file
+	values_file=$(mktemp)
+	cat > "${values_file}" <<EOF
+customRuntimes:
+  enabled: false
+shims:
+  qemu:
+    dropIn: |
+      [agent.kata]
+      dial_timeout = 999
+EOF
+
+	helm template kata-deploy "${CHART_PATH}" \
+		-f "${values_file}" \
+		--set image.reference=quay.io/kata-containers/kata-deploy \
+		--set image.tag=latest \
+		> /tmp/rendered.yaml
+	rm -f "${values_file}"
+
+	grep -q "kata-deploy-custom-configs" /tmp/rendered.yaml
+	grep -q "dropin-qemu.toml" /tmp/rendered.yaml
+	grep -q "dial_timeout = 999" /tmp/rendered.yaml
+	grep -q "mountPath: /custom-configs/" /tmp/rendered.yaml
+	! grep -q "CUSTOM_RUNTIMES_ENABLED" /tmp/rendered.yaml
+}
+
 @test "Helm template: Custom runtimes only mode (no standard shims)" {
 	# Test that Helm chart renders correctly when all standard shims are disabled
 	# using shims.disableAll and only custom runtimes are enabled

--- a/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/install.rs
@@ -199,6 +199,50 @@ fn write_common_drop_ins(
     Ok(())
 }
 
+fn install_default_runtime_drop_in(shim: &str, config_d_dir: &str) -> Result<()> {
+    let drop_in_source = format!("/custom-configs/dropin-{}.toml", shim);
+    let drop_in_dest = format!("{}/50-user-overrides.toml", config_d_dir);
+    reconcile_optional_drop_in(
+        Some(&drop_in_source),
+        &drop_in_dest,
+        &format!("user drop-in for shim {shim}"),
+    )
+}
+
+fn reconcile_optional_drop_in(
+    source_file: Option<&str>,
+    destination_file: &str,
+    context: &str,
+) -> Result<()> {
+    let destination_path = Path::new(destination_file);
+
+    if let Some(source_file) = source_file {
+        let source_path = Path::new(source_file);
+        if source_path.exists() {
+            info!(
+                "Copying {}: {} -> {}",
+                context, source_file, destination_file
+            );
+            fs::copy(source_path, destination_path).with_context(|| {
+                format!(
+                    "Failed to copy {} from {} to {}",
+                    context, source_file, destination_file
+                )
+            })?;
+            return Ok(());
+        }
+    }
+
+    // Reconcile upgrades/migrations: remove stale override from previous deployments.
+    if destination_path.exists() {
+        info!("Removing stale {}: {}", context, destination_file);
+        fs::remove_file(destination_path)
+            .with_context(|| format!("Failed to remove stale {}: {}", context, destination_file))?;
+    }
+
+    Ok(())
+}
+
 /// Each custom runtime gets an isolated directory under custom-runtimes/{handler}/
 /// Custom runtimes inherit the same drop-in configurations as standard runtimes
 /// (installation prefix, debug, kernel_params, and for k0s on Go/remote runtime: kubelet root) plus any user-provided overrides.
@@ -257,22 +301,14 @@ fn install_custom_runtime_configs(config: &Config, container_runtime: &str) -> R
             container_runtime,
         )?;
 
-        // Copy user-provided drop-in file if provided (at 50-overrides.toml)
-        if let Some(ref drop_in_src) = runtime.drop_in_file {
-            let drop_in_dest = format!("{}/50-overrides.toml", config_d_dir);
-
-            info!(
-                "Copying drop-in for {}: {} -> {}",
-                runtime.handler, drop_in_src, drop_in_dest
-            );
-
-            fs::copy(drop_in_src, &drop_in_dest).with_context(|| {
-                format!(
-                    "Failed to copy drop-in from {} to {}",
-                    drop_in_src, drop_in_dest
-                )
-            })?;
-        }
+        // Copy user-provided drop-in file if provided (at 50-overrides.toml).
+        // If it was removed from values in a later upgrade/migration, remove stale file.
+        let drop_in_dest = format!("{}/50-overrides.toml", config_d_dir);
+        reconcile_optional_drop_in(
+            runtime.drop_in_file.as_deref(),
+            &drop_in_dest,
+            &format!("custom runtime drop-in for {}", runtime.handler),
+        )?;
     }
 
     info!(
@@ -885,6 +921,9 @@ async fn configure_shim_config(config: &Config, shim: &str, container_runtime: &
 
     // Generate common drop-in files (shared with custom runtimes)
     write_common_drop_ins(config, shim, &config_d_dir, container_runtime)?;
+
+    // Apply user-provided drop-in for default runtimes, if present.
+    install_default_runtime_drop_in(shim, &config_d_dir)?;
 
     configure_hypervisor_annotations(config, shim, &kata_config_file).await?;
 

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/_helpers.tpl
@@ -429,3 +429,40 @@ Note: EXPERIMENTAL_FORCE_GUEST_PULL only checks containerd.forceGuestPull, not c
 {{- end -}}
 {{- join "," $shimNames -}}
 {{- end -}}
+
+{{/*
+Returns "true" when a shim is enabled according to `enabled` + `disableAll`.
+Input:
+  dict:
+    shimConfig: the `.Values.shims.<name>` object
+    disableAll: global `.Values.shims.disableAll`
+*/}}
+{{- define "kata-deploy.isShimEnabled" -}}
+{{- $shimEnabled := false -}}
+{{- if eq .shimConfig.enabled true -}}
+{{- $shimEnabled = true -}}
+{{- else if eq .shimConfig.enabled false -}}
+{{- $shimEnabled = false -}}
+{{- else if not .disableAll -}}
+{{- $shimEnabled = true -}}
+{{- end -}}
+{{- if $shimEnabled -}}true{{- end -}}
+{{- end -}}
+
+{{/*
+Returns "true" when at least one default shim has a non-empty dropIn value.
+*/}}
+{{- define "kata-deploy.hasDefaultRuntimeDropIns" -}}
+{{- $has := false -}}
+{{- $disableAll := .Values.shims.disableAll | default false -}}
+{{- range $shimName := keys .Values.shims | sortAlpha -}}
+{{- if ne $shimName "disableAll" -}}
+{{- $shimConfig := index $.Values.shims $shimName -}}
+{{- $shimEnabled := eq (include "kata-deploy.isShimEnabled" (dict "shimConfig" $shimConfig "disableAll" $disableAll) | trim) "true" -}}
+{{- if and $shimEnabled $shimConfig.dropIn (ne (trim $shimConfig.dropIn) "") -}}
+{{- $has = true -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if $has -}}true{{- end -}}
+{{- end -}}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/custom-runtimes.yaml
@@ -1,6 +1,8 @@
-{{- if and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes }}
+{{- $hasCustomRuntimes := and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes -}}
+{{- $hasDefaultRuntimeDropIns := eq (include "kata-deploy.hasDefaultRuntimeDropIns" . | trim) "true" -}}
+{{- if or $hasCustomRuntimes $hasDefaultRuntimeDropIns }}
 ---
-# ConfigMap containing custom runtime configurations and drop-in files
+# ConfigMap containing custom runtime configuration and runtime drop-ins
 # This is mounted into the kata-deploy pod at /custom-configs/
 apiVersion: v1
 kind: ConfigMap
@@ -14,6 +16,7 @@ metadata:
   labels:
     {{- include "kata-deploy.labels" . | nindent 4 }}
 data:
+{{- if $hasCustomRuntimes }}
   # Format: handler:baseConfig:containerd_snapshotter:crio_pulltype
   custom-runtimes.list: |
 {{- range $name, $runtime := .Values.customRuntimes.runtimes }}
@@ -31,7 +34,7 @@ data:
     {{ $handler }}:{{ $runtime.baseConfig }}:{{ dig "containerd" "snapshotter" "" $runtime }}:{{ dig "crio" "pullType" "" $runtime }}
 {{- end }}
 {{- end }}
-{{- /* Generate drop-in files for each runtime */ -}}
+{{- /* Generate drop-in files for each custom runtime */ -}}
 {{- range $name, $runtime := .Values.customRuntimes.runtimes }}
 {{- $handler := "" }}
 {{- if $runtime.runtimeClass }}
@@ -47,6 +50,20 @@ data:
 {{ $runtime.dropIn | indent 4 }}
 {{- end }}
 {{- end }}
+{{- end }}
+{{- /* Generate drop-in files for enabled default shims */ -}}
+{{- $disableAll := .Values.shims.disableAll | default false -}}
+{{- range $shimName := keys .Values.shims | sortAlpha }}
+{{- if ne $shimName "disableAll" }}
+{{- $shimConfig := index $.Values.shims $shimName -}}
+{{- $shimEnabled := eq (include "kata-deploy.isShimEnabled" (dict "shimConfig" $shimConfig "disableAll" $disableAll) | trim) "true" -}}
+{{- if and $shimEnabled $shimConfig.dropIn (ne (trim $shimConfig.dropIn) "") }}
+  dropin-{{ $shimName }}.toml: |
+{{ $shimConfig.dropIn | indent 4 }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if $hasCustomRuntimes }}
 ---
 # RuntimeClasses for custom runtimes
 {{- $runtimeClassConfigs := fromYaml (include "kata-deploy.runtimeClassConfigs" .) | default dict }}
@@ -64,6 +81,7 @@ data:
 {{- end }}
 {{ toYaml $runtimeClassObj }}
 ---
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-deploy.yaml
@@ -18,6 +18,7 @@
 {{- end -}}
 {{- end -}}
 {{- end -}}
+{{- $hasCustomConfigs := or (and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes) (eq (include "kata-deploy.hasDefaultRuntimeDropIns" . | trim) "true") -}}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -365,7 +366,7 @@ spec:
           mountPath: /custom-containerd-config/
           readOnly: true
 {{- end }}
-{{- if and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes }}
+{{- if $hasCustomConfigs }}
         - name: custom-configs
           mountPath: /custom-configs/
           readOnly: true
@@ -389,7 +390,7 @@ spec:
           name: {{ .Chart.Name }}-containerd-user-dropin
 {{- end }}
 {{- end }}
-{{- if and .Values.customRuntimes.enabled .Values.customRuntimes.runtimes }}
+{{- if $hasCustomConfigs }}
       - name: custom-configs
         configMap:
 {{- if .Values.env.multiInstallSuffix }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -154,6 +154,7 @@ snapshotter:
 #   shims:
 #     <shim-name>:
 #       enabled: ~                    # true | false | ~ (null = follow disableAll)
+#       dropIn: ""                    # optional Kata TOML drop-in applied as 50-user-overrides.toml
 #       supportedArches:              # list of supported architectures
 #         - amd64
 #       allowedHypervisorAnnotations: []  # hypervisor annotations to pass through


### PR DESCRIPTION
Allow operators to provide per-shim drop-in TOML for built-in runtimes and reconcile stale override files so upgrades and migrations remain safe when drop-ins are added or removed.


Assisted-by: Codex