### PR TITLE
feat(kata-deploy): add try-kata-nvidia-gpu-cc.values.yaml for CC guest pull

### DIFF
--- a/docs/how-to/how-to-pull-images-in-guest-with-kata.md
+++ b/docs/how-to/how-to-pull-images-in-guest-with-kata.md
@@ -310,3 +310,31 @@ $ free -m
 Mem:           1989          52          43           0        1893        1904
 Swap:             0           0           0
 ```
+
+## Large images and Confidential GPU workloads (NIM / KBS guest pull)
+
+Confidential GPU pods (Intel TDX + NVIDIA passthrough + KBS guest image pull) often
+need **longer timeouts** than the NVIDIA shim defaults (`create_container_timeout = 1200`,
+`agent.image_pull_timeout = 1200`). Effective guest-pull time is bounded by the **minimum**
+of:
+
+| Layer | Setting | Typical CC production value |
+|-------|---------|----------------------------|
+| Kubelet | `--runtime-request-timeout` | `2h` |
+| Kata shim | `create_container_timeout` in runtime TOML | `7200` or higher |
+| Kata agent | `agent.image_pull_timeout` kernel param / TOML | `7200` |
+| Per-pod | `io.katacontainers.config.runtime.create_container_timeout` annotation | `7200` |
+
+Recommended cluster setup:
+
+1. Set kubelet `runtime-request-timeout=2h` on GPU worker nodes.
+2. Deploy kata-deploy with extended timeouts — see
+   [`try-kata-nvidia-gpu-cc.values.yaml`](../../tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu-cc.values.yaml)
+   (requires kata-deploy `shims.<shim>.dropIn`; see [kata-containers#13183](https://github.com/kata-containers/kata-containers/pull/13183)).
+3. Set pod `resources.limits.memory` high enough for guest `/run` tmpfs during unpack
+   (see [kata-containers#13179](https://github.com/kata-containers/kata-containers/issues/13179)).
+
+When KBS attestation succeeds but image pull fails, distinguish **Trustee/KBS** issues
+(`ttrpc request error`, missing NVCR credentials) from **CDH guest pull** timeouts
+(`[CDH] Image Pull error`, `create container timeout`). See
+[CoCo troubleshooting — Trustee vs CDH](https://github.com/confidential-containers/confidential-containers/blob/main/guides/troubleshooting.md#trustee-kbs-vs-cdh-guest-image-pull).

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu-cc.values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/try-kata-nvidia-gpu-cc.values.yaml
@@ -1,0 +1,87 @@
+# Example values for Confidential Containers + NVIDIA GPU TDX (Intel TDX + guest pull)
+#
+# Extends try-kata-nvidia-gpu.values.yaml with CC-oriented timeouts for large
+# guest image pulls (e.g. NVIDIA NIM containers via KBS + CDH).
+#
+# Requires kata-deploy with shims.<shim>.dropIn support (kata-containers PR #13183
+# or later). Until merged upstream, use customRuntimes dropIn as fallback.
+#
+# Also set kubelet runtime-request-timeout=2h on GPU nodes (RKE2 machineSelectorConfig).
+#
+# Usage:
+#   helm upgrade --install kata-deploy \
+#     oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy \
+#     --version VERSION \
+#     -n kube-system \
+#     -f try-kata-nvidia-gpu.values.yaml \
+#     -f try-kata-nvidia-gpu-cc.values.yaml
+
+debug: false
+
+snapshotter:
+  setup: ["nydus"]
+
+shims:
+  disableAll: true
+
+  qemu-nvidia-gpu-tdx:
+    enabled: true
+    supportedArches:
+      - amd64
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: "nydus"
+      forceGuestPull: false
+    crio:
+      guestPull: true
+    agent:
+      httpsProxy: ""
+      noProxy: ""
+    # Cluster-wide CC timeouts — complements per-pod
+    # io.katacontainers.config.runtime.create_container_timeout (see kata-containers#13180)
+    dropIn: |
+      [runtime]
+      create_container_timeout = 7200
+      [agent.kata]
+      dial_timeout = 7200
+      launch_process_timeout = 120
+    runtimeClass:
+      nodeSelector:
+        nvidia.com/cc.ready.state: "true"
+        intel.feature.node.kubernetes.io/tdx: "true"
+      overhead:
+        memory: "51200Mi"
+        cpu: "1.0"
+
+  qemu-nvidia-gpu-tdx-runtime-rs:
+    enabled: true
+    supportedArches:
+      - amd64
+    allowedHypervisorAnnotations: []
+    containerd:
+      snapshotter: "nydus"
+      forceGuestPull: false
+    crio:
+      guestPull: true
+    agent:
+      httpsProxy: ""
+      noProxy: ""
+    dropIn: |
+      [agent.kata]
+      dial_timeout_ms = 7200000
+      launch_process_timeout = 120
+    runtimeClass:
+      nodeSelector:
+        nvidia.com/cc.ready.state: "true"
+        intel.feature.node.kubernetes.io/tdx: "true"
+      overhead:
+        memory: "51200Mi"
+        cpu: "1.0"
+
+defaultShim:
+  amd64: qemu-nvidia-gpu-tdx
+
+runtimeClasses:
+  enabled: true
+  createDefault: false
+  defaultName: "kata"


### PR DESCRIPTION
## Summary

Adds example Helm values for Intel TDX + NVIDIA GPU passthrough confidential workloads that pull large images in the guest via KBS/CDH (e.g. NVIDIA NIM containers).

- New `try-kata-nvidia-gpu-cc.values.yaml` with 7200s `create_container_timeout` / `dial_timeout` / `launch_process_timeout` via `shims.qemu-nvidia-gpu-tdx.dropIn`
- Documents timeout layering in `docs/how-to/how-to-pull-images-in-guest-with-kata.md`

Depends on / complements #13183 (`shims.<shim>.dropIn` for default runtimes).

Related: #13180 (per-pod annotation vs TOML default on 8×GPU CC sandboxes)

## Test plan

- [ ] `helm template` with `try-kata-nvidia-gpu-cc.values.yaml` renders expected RuntimeClass overhead
- [ ] After #13183 merges: verify drop-in TOML mounted for `qemu-nvidia-gpu-tdx`
- [ ] Confidential NIM pod completes guest image pull on TDX + GPU node with kubelet `runtime-request-timeout=2h`

Made with [Cursor](https://cursor.com)