### PR TITLE
csi-kata-directvolume: don't forward host-side bind options to kata-agent

### DIFF
--- a/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
@@ -120,13 +120,21 @@ func (dv *directVolume) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 		return nil, status.Error(codes.Aborted, errMsg)
 	}
 
-	// kata-containers DirectVolume add
+	// kata-containers DirectVolume add.
+	//
+	// The "options" slice above is for the host-side CSI bind-mount
+	// only — it always contains "bind" plus "ro"/"rw". Forwarding it
+	// to kata-agent is wrong: kata-agent calls parse_mount_options(),
+	// which turns "bind" into MS_BIND, and mount(2) with MS_BIND on a
+	// block device is rejected by the kernel (see #11296). Send no
+	// options here; the in-guest mount is a plain fsType mount of the
+	// attached block device.
 	mountInfo := utils.MountInfo{
 		VolumeType: volType,
 		Device:     devicePath,
 		FsType:     fsType,
 		Metadata:   attrib,
-		Options:    options,
+		Options:    nil,
 	}
 	if err := utils.AddDirectVolume(targetPath, mountInfo); err != nil {
 		klog.Errorf("add direct volume with source %s and mountInfo %v failed", targetPath, mountInfo)


### PR DESCRIPTION
## Problem

`NodePublishVolume` constructs a single `options` slice for two different purposes:

1. As the mount flags for the host-side CSI bind-mount it performs immediately, via `dv.config.safeMounter.DoBindmount(stagingTargetPath, targetPath, "", options)`. For that purpose, `["bind", "rw"]` or `["bind", "ro"]` is correct.
2. As `MountInfo.Options` in the direct-volume JSON it writes for kata, which kata-agent later reads when mounting the block device inside the PodVM.

The second use is incorrect. Those options describe the host-side bind-mount of the staging path onto the target path. They do not describe the in-guest mount of the attached block device. When kata-agent receives them and calls `parse_mount_options()` (`src/libs/kata-sys-util/src/mount.rs:399`), it turns `"bind"` into `MsFlags::MS_BIND` (`mount.rs:462`). The subsequent `mount(2)` syscall is then issued with `MS_BIND` against a block device, which the kernel rejects: `MS_BIND` requires the source to be an existing mount point, not a block device path.

This is exactly the failure reported in #11296.

## Reproducer

Any pod using a PVC provisioned by `directvolume.csi.katacontainers.io` is affected, because the driver always emits `["bind", "ro|rw"]` regardless of pod or volume configuration. See #11296 for a minimal scenario.

## Fix

Pass `nil` as `MountInfo.Options` when registering the volume with kata. The in-guest mount is then a plain `mount(devicePath, target, fsType, 0, "")` of the attached block device — the same shape the trusted-ephemeral-storage path uses (`src/runtime/virtcontainers/container.go:948` writes `MountInfo` with no `Options` for its block-encrypted emptyDir).

The host-side `DoBindmount` above the changed line is unaffected: it still receives the original `options` slice with `"bind"` + read-only flag. Only the *cross-boundary* propagation is removed.

## What this PR does not do

It does not touch `VolumeType`. The Go runtime accepts the current `"directvol"` string and the Rust runtime (`src/runtime-rs/crates/resource/src/volume/direct_volumes/rawblock_volume.rs:42`) explicitly requires it (`if mount_info.volume_type != KATA_DIRECT_VOLUME_TYPE { return Err("volume type {:?} is invalid") }`). An earlier draft swapped `"directvol"` to `"blk"`; that would have broken every csi-kata-directvolume PVC on runtime-rs and is intentionally not part of this change.

PR #11304 was a similar attempt (drop the `"bind"` option from the same call site) and was closed after 180 days without merge. It dropped only `"bind"`, leaving `"rw"` behind — kata-agent's `parse_mount_flags` does not recognise `"rw"` either, so it would land in the `data` string of the mount, with no clearly defined meaning for a block device. Setting `Options: nil` cleans both up at once.