### PR TITLE
csi-kata-directvolume: advertise VOLUME_MOUNT_GROUP and honour fsGroup

### DIFF
--- a/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
@@ -120,12 +120,27 @@ func (dv *directVolume) NodePublishVolume(ctx context.Context, req *csi.NodePubl
 		return nil, status.Error(codes.Aborted, errMsg)
 	}
 
-	// kata-containers DirectVolume add
+	// kata-containers DirectVolume add.
+	//
+	// Forward the pod's fsGroup (sent by kubelet because we advertise
+	// VOLUME_MOUNT_GROUP in NodeGetCapabilities) into MountInfo.json
+	// under the "fsGroup" key. kata-runtime parses it and forwards it
+	// to kata-agent as Storage.fs_group, which chowns the filesystem
+	// root after the in-guest mount.
+	kataMetadata := attrib
+	if mv := req.GetVolumeCapability().GetMount(); mv != nil && mv.GetVolumeMountGroup() != "" {
+		kataMetadata = make(map[string]string, len(attrib)+1)
+		for k, v := range attrib {
+			kataMetadata[k] = v
+		}
+		kataMetadata["fsGroup"] = mv.GetVolumeMountGroup()
+	}
+
 	mountInfo := utils.MountInfo{
 		VolumeType: volType,
 		Device:     devicePath,
 		FsType:     fsType,
-		Metadata:   attrib,
+		Metadata:   kataMetadata,
 		Options:    options,
 	}
 	if err := utils.AddDirectVolume(targetPath, mountInfo); err != nil {
@@ -344,6 +359,22 @@ func (dv *directVolume) NodeGetCapabilities(ctx context.Context, req *csi.NodeGe
 			Type: &csi.NodeServiceCapability_Rpc{
 				Rpc: &csi.NodeServiceCapability_RPC{
 					Type: csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
+				},
+			},
+		},
+		{
+			// Tells kubelet that NodePublishVolume should be called
+			// with VolumeMountGroup set to the pod's fsGroup. We
+			// write the value into MountInfo.json under the
+			// "fsGroup" key; kata-runtime parses it and forwards
+			// it to kata-agent as Storage.fs_group, so kata-agent
+			// chowns the fresh fs root to that gid after mount
+			// (otherwise the freshly formatted ext4 root is owned
+			// by uid:gid 0:0 and non-root containers fail with
+			// EACCES on first write).
+			Type: &csi.NodeServiceCapability_Rpc{
+				Rpc: &csi.NodeServiceCapability_RPC{
+					Type: csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
 				},
 			},
 		},


### PR DESCRIPTION
## Problem

The CSI driver never sees the pod's `fsGroup`, so the freshly formatted ext4 filesystem stays owned by `root:root`. Any non-root container fails on its first write with `EACCES`, e.g. NVIDIA NIM (uid:gid 1000:1000) crashes with `PermissionError: [Errno 13] Permission denied: '/opt/nim/.cache/local_cache'`.

This is the same UX problem as #3703 (open since 2022) and the use case in #12005, but addressed via the standard Kubernetes mechanism [KEP-2317](https://github.com/kubernetes/enhancements/blob/master/keps/sig-storage/2317-fsgroup-on-mount/README.md) rather than driver-internal `chown`/`chmod` (which #12005 declined).

## How KEP-2317 works

1. Driver advertises `VOLUME_MOUNT_GROUP` in `NodeGetCapabilities`.
2. kubelet then populates `VolumeCapability.MountVolume.VolumeMountGroup` on every `NodePublishVolume` call with the pod's `fsGroup`.
3. Driver forwards the value to the storage layer.

For csi-kata-directvolume the storage layer is the `MountInfo` JSON written under `/run/kata-containers/shared/direct-volumes/`. kata-runtime already parses an `fsGroup` key from `MountInfo.Metadata` (constant `FSGroupMetadataKey = "fsGroup"` in `src/runtime/pkg/direct-volume/utils.go:21`, consumed in `src/runtime/virtcontainers/container.go:682`), translates it to the `Storage.fs_group` proto field (`src/runtime/virtcontainers/kata_agent.go:2037+`), and kata-agent chowns the mount root accordingly (`src/agent/src/storage/mod.rs:441+`). That entire wiring was added by #4042 in 2022. The CSI driver just never forwarded the value, so it sat unused on this path.

## Reproducer

```yaml
apiVersion: v1
kind: Pod
metadata: { name: directvol-fsgroup }
spec:
  runtimeClassName: kata
  securityContext:
    runAsUser: 1000
    runAsGroup: 1000
    fsGroup: 1000
  containers:
  - name: c
    image: busybox
    command: ["sh", "-c", "touch /vol/x && stat -c '%u:%g' /vol/x"]
    volumeMounts:
    - { name: v, mountPath: /vol }
  volumes:
  - name: v
    persistentVolumeClaim: { claimName: directvol }
```

Before: pod exits with `Permission denied`. After: `/vol/x` is owned by `1000:1000`, write succeeds.

## Fix

- Add `NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP` to the capability list returned by `NodeGetCapabilities`.
- In `NodePublishVolume`, copy `VolumeMountGroup` (when set) into `MountInfo.Metadata` under key `fsGroup`. The original `VolumeContext` map is not mutated.

No change to host-side mount behaviour. If the pod has no `fsGroup`, or the kubelet does not send `VolumeMountGroup`, the driver behaves exactly as before.

## References

- #4042 — added the `fsGroup` MountInfo metadata key + kata-runtime + kata-agent wiring for direct-assigned volumes (2022)
- #3703 — fsGroup permission denied on kata PVCs (open since 2022)
- #12005 — closed "not planned"; that issue proposed `chown` inside the driver. This PR takes the orthogonal KEP-2317 path instead, which reuses #4042's existing in-guest plumbing.