### PR TITLE
csi-kata-directvolume: move raw-disk teardown from NodeUnstage to DeleteVolume

### DIFF
--- a/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/controllerserver.go
@@ -211,6 +211,19 @@ func (dv *directVolume) DeleteVolume(ctx context.Context, req *csi.DeleteVolumeR
 				klog.Infof("Removed backing file %s for volume %s", backingFile, volId)
 			}
 		}
+	} else {
+		// Non-SPDK directvol: release the upper storage directory
+		// that holds the rawdisk backing file. This is the CSI-spec
+		// place for backing-storage teardown; NodeUnstage must not
+		// do it because that would silently turn every PV into an
+		// ephemeral one (ignoring reclaimPolicy: Retain).
+		if storagePath, err := utils.GetStoragePath(dv.config.StoragePath, volId); err != nil {
+			klog.Warningf("Failed to resolve storage path for volume %s: %v", volId, err)
+		} else if err := os.RemoveAll(storagePath); err != nil {
+			klog.Warningf("Failed to remove storage path %s for volume %s: %v", storagePath, volId, err)
+		} else {
+			klog.Infof("Removed storage path %s for volume %s", storagePath, volId)
+		}
 	}
 
 	if err := dv.deleteVolume(volId); err != nil {

--- a/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
+++ b/src/tools/csi-kata-directvolume/pkg/directvolume/nodeserver.go
@@ -281,14 +281,10 @@ func (dv *directVolume) NodeUnstageVolume(ctx context.Context, req *csi.NodeUnst
 		}
 	}
 
-	if deviceUpperPath, err := utils.GetStoragePath(dv.config.StoragePath, volumeID); err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("get device UpperPath %s failed: %v", deviceUpperPath, err))
-	} else {
-		if err = os.RemoveAll(deviceUpperPath); err != nil {
-			return nil, status.Error(codes.Internal, fmt.Sprintf("remove device upper path: %s failed %v", deviceUpperPath, err.Error()))
-		}
-		klog.Infof("direct volume %s has been removed.", deviceUpperPath)
-	}
+	// NB: do not delete the raw disk here. The CSI spec reserves backing
+	// storage teardown for ControllerDeleteVolume; deleting it on
+	// NodeUnstage makes the volume effectively ephemeral, ignoring
+	// reclaimPolicy: Retain and losing any data the workload wrote.
 
 	if err := os.RemoveAll(stagingTargetPath); err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("remove staging target path: %v", err))


### PR DESCRIPTION
## Problem

The backing-storage lifecycle in csi-kata-directvolume is split incorrectly between the Node and Controller services. The result is two distinct bugs that mask each other:

1. **`NodeUnstageVolume` deletes the rawdisk.** It calls `os.RemoveAll` on the upper storage directory (the directory that holds the `directvol-rawdisk.<size>M` backing file) every time a pod releases the volume. This is a CSI-spec violation — backing-storage teardown belongs to `ControllerDeleteVolume`, not the Node service. The user-visible symptom: when the next pod is scheduled, `NodeStage` recreates the upper dir, re-runs `mkfs.ext4`, and the pod mounts a fresh empty filesystem. Data written by the previous pod is gone, no error surfaces, and the PV behaves as if it were ephemeral. This also breaks `reclaimPolicy: Retain` (#3703-style UX: PV stays `Bound` but the data is silently gone).

2. **`ControllerDeleteVolume` never released the backing storage.** `DeleteVolume` calls `deleteVolume(volID)`, which does `os.RemoveAll(getVolumePath(volID))`. But `getVolumePath` returns `StateDir/<volID>` (state-dir metadata), not the rawdisk's storage path. The rawdisk lives at `StoragePath/<volID>/directvol-rawdisk.<size>M`. So `DeleteVolume` only removed state, never the actual disk. Today this is masked because `NodeUnstage` already removed the rawdisk (bug 1). Once we fix bug 1, naive removal of the `NodeUnstage` cleanup would leak rawdisks forever for `reclaimPolicy: Delete` PVCs.

## Reproducer

```
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: directvol-retain
provisioner: directvolume.csi.katacontainers.io
reclaimPolicy: Retain
---
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: keep-me
spec:
  accessModes: [ReadWriteOnce]
  storageClassName: directvol-retain
  resources:
    requests:
      storage: 1Gi
```

1. Start a pod that mounts the PVC, write a file, delete the pod.
2. PV is still `Bound`, PVC is still `Bound` — but the `directvol-rawdisk.*` backing file under the driver's storage pool is already gone (deleted by `NodeUnstage`).
3. Start a new pod with the same PVC. It comes up successfully, but the mount is a fresh empty filesystem. The file written in step 1 is silently gone.

## Fix

Move backing-storage teardown from the Node service to the Controller service, where the CSI spec puts it:

- **`nodeserver.go:NodeUnstageVolume`** — drop the `os.RemoveAll(GetStoragePath(StoragePath, volumeID))`. The staging mount path cleanup (the line below it) is unchanged.
- **`controllerserver.go:DeleteVolume`** — for the non-SPDK path, add `os.RemoveAll(GetStoragePath(StoragePath, volId))` before `deleteVolume(volId)`. Errors are warn-logged (not fatal), mirroring the existing SPDK backing-file removal in the same function.

After this:
- `reclaimPolicy: Retain` behaves as documented: the rawdisk survives until an operator explicitly deletes the PV.
- `reclaimPolicy: Delete` invokes `ControllerDeleteVolume`, which now actually releases the rawdisk under `StoragePath/<volID>/`.
- `NodeUnstage` is restricted to per-node staging state, as the spec requires.

## Notes

- The SPDK path is unchanged; its existing `os.Remove(backingFile)` already handled SPDK-specific cleanup.
- The Node-side `RemoveAll` was previously masking the missing Controller-side cleanup. Both halves of this PR are necessary; landing only one half either keeps the original bug (drop only Controller addition) or leaks storage (drop only Node removal).
