### PR TITLE
runtime*: use static_sandbox_resource_mgmt defaults for qemu-se

### DIFF
--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -633,7 +633,7 @@ sandbox_cgroup_only = @DEFSANDBOXCGROUPONLY_QEMU@
 # - When running with pods, sandbox sizing information will only be available if using Kubernetes >= 1.23 and containerd >= 1.6. CRI-O
 #   does not yet support sandbox sizing annotations.
 # - When running single containers using a tool like ctr, container sizing information will be available.
-static_sandbox_resource_mgmt = @DEFSTATICRESOURCEMGMT_QEMU@
+static_sandbox_resource_mgmt = @DEFSTATICRESOURCEMGMT_COCO@
 
 # If specified, sandbox_bind_mounts identifieds host paths to be mounted (ro) into the sandboxes shared path.
 # This is only valid if filesystem sharing is utilized. The provided path(s) will be bindmounted into the shared fs directory.

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -661,7 +661,7 @@ sandbox_cgroup_only = @DEFSANDBOXCGROUPONLY@
 # - When running with pods, sandbox sizing information will only be available if using Kubernetes >= 1.23 and containerd >= 1.6. CRI-O
 #   does not yet support sandbox sizing annotations.
 # - When running single containers using a tool like ctr, container sizing information will be available.
-static_sandbox_resource_mgmt = @DEFSTATICRESOURCEMGMT@
+static_sandbox_resource_mgmt = @DEFSTATICRESOURCEMGMT_TEE@
 
 # If specified, sandbox_bind_mounts identifieds host paths to be mounted (ro) into the sandboxes shared path.
 # This is only valid if filesystem sharing is utilized. The provided path(s) will be bindmounted into the shared fs directory.


### PR DESCRIPTION
Switch qemu-se config templates to use the TEE/CoCo-specific static_sandbox_resource_mgmt defaults instead of the generic QEMU defaults.

qemu-se-runtime-rs config now uses `DEFSTATICRESOURCEMGMT_COCO` while runtime qemu-se config now uses `DEFSTATICRESOURCEMGMT_TEE`. This aligns static sandbox resource management behavior with confidential container expectations for qemu-se variants.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>