### PR TITLE
tests: fix k8s-number-cpus expectation

### DIFF
--- a/tests/integration/kubernetes/k8s-number-cpus.bats
+++ b/tests/integration/kubernetes/k8s-number-cpus.bats
@@ -31,7 +31,7 @@ setup() {
 # Skip on aarch64 due to missing cpu hotplug related functionality.
 @test "Check number of cpus" {
 	local -r retries="10"
-	local -r max_number_cpus="3"
+	local -r max_number_cpus="2"
 	local number_cpus=""
 
 	# Create pod
@@ -50,6 +50,8 @@ setup() {
 		fi
 		sleep 1
 	done
+
+	[ "$number_cpus" -eq "$max_number_cpus" ]
 }
 
 teardown() {


### PR DESCRIPTION
Fixes #12961.

`k8s-number-cpus.bats` had two stale assumptions:

- it expected three guest CPUs for two 500m containers
- it did not assert the final retry result after the retry loop

The current `kata-qemu` handler uses dynamic sandbox resource management. It adds fractional container quotas first, then adds the configured default vCPU and rounds once when resizing the VM:

`500m + 500m + default_vcpus(1) = 2`

The old value of three appears to match an older per-container rounding model:

`ceil(500m) + ceil(500m) + default_vcpus(1) = 3`

Update the expected guest CPU count to two and add the same post-loop assertion pattern used by `k8s-cpu-ns.bats`, so the test fails if the retry loop never observes the expected value.

With the old expected value plus the post-loop assertion, the live test failed after observing `2` CPUs on all 10 retries. With the old test and no post-loop assertion, the live test passed despite observing `2` CPUs on all 10 retries
