### PR TITLE
tests: align kata-monitor containerd version selector

### DIFF
--- a/.github/workflows/run-kata-monitor-k8s-tests.yaml
+++ b/.github/workflows/run-kata-monitor-k8s-tests.yaml
@@ -61,7 +61,7 @@ jobs:
       KATA_HYPERVISOR: ${{ matrix.vmm }}
       KUBERNETES: ${{ matrix.k8s }}
       CONTAINER_ENGINE: containerd
-      CONTAINER_ENGINE_VERSION: active
+      CONTAINER_ENGINE_VERSION: latest
       KATA_MONITOR_IMAGE_REFERENCE: ${{ inputs.kata-monitor-image-reference }}
       KATA_MONITOR_IMAGE_TAG: ${{ inputs.kata-monitor-image-tag }}
       GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/run-kata-monitor-tests.yaml
+++ b/.github/workflows/run-kata-monitor-tests.yaml
@@ -38,7 +38,7 @@ jobs:
         container_engine:
           - containerd
         containerd_version:
-          - active
+          - latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.job }}-${{ github.event.pull_request.number || github.ref }}-${{ toJSON(matrix) }}
       cancel-in-progress: true


### PR DESCRIPTION
Switch kata-monitor workflows from the deprecated "active" key to "latest" so CI resolves containerd versions from versions.yaml correctly after the key rename.