### PR TITLE
tests: raise k8s memory/QoS pod limits for TEE runtime-rs CI

### DIFF
--- a/tests/integration/kubernetes/k8s-memory.bats
+++ b/tests/integration/kubernetes/k8s-memory.bats
@@ -41,7 +41,7 @@ setup_yaml() {
 }
 
 @test "Running within memory constraints" {
-	memory_limit_size="600Mi"
+	memory_limit_size="800Mi"
 	allocated_size="150M"
 
 	# Create test .yaml

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-burstable.yaml
@@ -15,6 +15,6 @@ spec:
     command: ["/bin/sh", "-c", "tail -f /dev/null"]
     resources:
       limits:
-        memory: "200Mi"
+        memory: "800Mi"
       requests:
-        memory: "100Mi"
+        memory: "600Mi"

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-guaranteed.yaml
@@ -15,8 +15,8 @@ spec:
     command: ["/bin/sh", "-c", "tail -f /dev/null"]
     resources:
       limits:
-        memory: "200Mi"
+        memory: "600Mi"
         cpu: "700m"
       requests:
-        memory: "200Mi"
+        memory: "600Mi"
         cpu: "700m"

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-memory-limit.yaml
@@ -17,6 +17,6 @@ spec:
       limits:
         memory: "${memory_size}"
       requests:
-        memory: "500Mi"
+        memory: "700Mi"
     command: ["stress"]
     args: ["--vm", "1", "--vm-bytes", "${memory_allocated}", "--vm-hang", "1"]


### PR DESCRIPTION
Increase memory request/limit values used by k8s memory and QoS integration workloads so SNP/TDX static-sized sandboxes boot reliably under the new sizing defaults.