### PR TITLE
ci: remove unnecessary workflow triggers

### DIFF
--- a/.github/workflows/cargo-deny.yaml
+++ b/.github/workflows/cargo-deny.yaml
@@ -1,13 +1,7 @@
 name: Cargo Deny Check
 
 on:
-  workflow_dispatch:
   pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
 
 permissions: {}
 

--- a/.github/workflows/commit-message-check.yaml
+++ b/.github/workflows/commit-message-check.yaml
@@ -1,10 +1,6 @@
 name: Commit Message Check
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 permissions: {}
 

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -1,10 +1,5 @@
 on:
   pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
 
 permissions: {}
 

--- a/.github/workflows/shellcheck_required.yaml
+++ b/.github/workflows/shellcheck_required.yaml
@@ -3,13 +3,7 @@
 name: Shellcheck required
 
 on:
-  workflow_dispatch:
   pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
 
 permissions: {}
 

--- a/.github/workflows/static-checks.yaml
+++ b/.github/workflows/static-checks.yaml
@@ -1,11 +1,5 @@
 on:
   pull_request:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
-  workflow_dispatch:
 
 permissions: {}
 


### PR DESCRIPTION
Remove redundant triggers from PR-only workflow files as identified in #12452.

## Problem

Several workflow files contain unnecessary triggers that waste CI resources and increase the surface area for unintended runs:

1. **`edited` in `pull_request.types`** — These are static analysis / test workflows; re-running them when a PR title or description is edited provides no value since the code has not changed.
2. **`workflow_dispatch` on PR-only workflows** — Manual dispatch runs against the `main` branch, not the PR branch, making it misleading and unnecessary for PR checks.
3. **Redundant explicit default types** — Listing `opened, reopened, synchronize` explicitly is equivalent to omitting `types:` entirely, since those are the `pull_request` defaults.

## Changes

| File | Removed |
|------|--------|
| `cargo-deny.yaml` | `workflow_dispatch`, `edited` + entire `types` block |
| `darwin-tests.yaml` | `edited` + entire `types` block |
| `shellcheck_required.yaml` | `workflow_dispatch`, `edited` + entire `types` block |
| `static-checks.yaml` | `workflow_dispatch`, `edited` + entire `types` block |
| `commit-message-check.yaml` | Redundant `types` block (defaults) |

All five files now use the minimal `on: pull_request:` trigger, relying on the default types (`opened`, `reopened`, `synchronize`).

Fixes #12452