### PR TITLE
generate_vendor: Fix heavily broken logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,16 @@ exclude = [
   # "tools/packaging/kata-deploy/local-build/build" folder, which may mislead
   # those packages to think they are part of the kata root workspace
   "tools/packaging/kata-deploy/local-build/build",
+
+  # Exclude vendor directories created by cargo vendor
+  "vendor",
+  "src/agent/vendor",
+  "src/runtime-rs/vendor",
+  "src/tools/agent-ctl/vendor",
+  "src/tools/genpolicy/vendor",
+  "src/tools/kata-ctl/vendor",
+  "src/tools/trace-forwarder/vendor",
+  "tools/packaging/kata-deploy/binary/vendor",
 ]
 
 [workspace.dependencies]

--- a/tools/packaging/release/generate_vendor.sh
+++ b/tools/packaging/release/generate_vendor.sh
@@ -31,9 +31,10 @@ EOF
 
 create_vendor_tarball() {
 	vendor_dir_list=""
+	tarball_path="$(cd "$(dirname "${1}")" && pwd)/$(basename "${1}")"
 	pushd "${repo_dir}"
 		# shellcheck disable=SC2044
-		for i in $(find . -name 'Cargo.lock'); do
+		for i in $(find . -path './vendor' -prune -o \( -name 'Cargo.lock' -o -name 'go.mod' \) -print); do
 			dir="$(dirname "${i}")"
 			pushd "${dir}"
 				case "$(basename "${i}")" in
@@ -52,10 +53,10 @@ create_vendor_tarball() {
 				echo "${vendor_dir_list}"
 			popd
 		done
-	popd
 
 	# shellcheck disable=SC2086
-	tar -cvzf "${1}" ${vendor_dir_list}
+	tar -cvzf "${tarball_path}" ${vendor_dir_list}
+	popd
 }
 
 main () {


### PR DESCRIPTION
While checking the content of the vendor tarball artifact in the 3.31.0 release page, I realized that it is lacking most of the rust code and all the go code. It turns out that the script is badly broken in many ways :

1. Cargo workspace conflicts: Vendored dependencies were treated as workspace members, causing "current package believes it's in a workspace when it's not" errors. Fixed by adding vendor directory exclusions to root Cargo.toml.

2. Missing Go vendoring: Script only searched for Cargo.lock files, never processing go.mod files despite having a case statement for them. Fixed by adding go.mod to the find command with '-o -name go.mod'.

3. Wrong tar execution directory: Script ran tar from release/ directory but vendor_dir_list contained paths relative to repo root (./vendor, ./src/agent/vendor, etc.), causing "Cannot stat" errors. Fixed by moving tar command before final popd.

4. Relative tarball path: Since tar now runs from repo root, converted tarball path to absolute to ensure it's created in the release directory.

5. Vendored go.mod pollution: Added '-path ./vendor -prune' to find command to exclude vendor directory, preventing the script from finding go.mod files inside vendored Rust dependencies.

The fixes are simple enough they can be squashed into a single commit.