### PR TITLE
tests: launch kata-monitor runc workload with explicit runtime

### DIFF
--- a/tests/functional/kata-monitor/kata-monitor-tests.sh
+++ b/tests/functional/kata-monitor/kata-monitor-tests.sh
@@ -285,7 +285,7 @@ main() {
 	title "create workloads"
 
 	CURRENT_TASK="start workload (runc)"
-	start_workload
+	start_workload runc
 	RUNC_POD_ID="${POD_ID}"
 	RUNC_CID="${CID}"
 	echo_ok "${CURRENT_TASK} - POD ID:${POD_ID}, CID:${CID}"


### PR DESCRIPTION
The kata-monitor negative test creates a non-kata pod and asserts it does not appear in the kata-monitor cache (built from /run/vc/sbs, where only kata sandboxes register).

However, the workload was started without a runtime handler, so it used containerd's default runtime, which in the CI containerd config is set to kata, so the "runc" pod was actually launched as a kata sandbox, registered under /run/vc/sbs, and tripped the assertion ("cache: got runc pod ...").

Start the workload with an explicit runc handler (configurable via RUNC_RUNTIME) so it is a genuine runc sandbox that never touches /run/vc/sbs.