### PR TITLE
runtime-rs: Fix queue_size of zero in block_rootfs

### DIFF
--- a/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
@@ -58,6 +58,10 @@ impl BlockRootfs {
             driver_option: block_driver.clone(),
             path_on_host: rootfs.source.clone(),
             blkdev_aio: BlockDeviceAio::new(&blkdev_info.block_device_aio),
+            num_queues: blkdev_info.num_queues,
+            queue_size: blkdev_info.queue_size,
+            logical_sector_size: blkdev_info.block_device_logical_sector_size,
+            physical_sector_size: blkdev_info.block_device_physical_sector_size,
             ..Default::default()
         };
 


### PR DESCRIPTION
Fix BlockRootfs to save the queue_size, num_queues, logical_sector_size, and physical_sector_size of the hypervisor's block device info in the BlockConfig passed to the vm

Fixes #13210