### PR TITLE
genpolicy: add missing probe fields

### DIFF
--- a/src/tools/genpolicy/src/pod.rs
+++ b/src/tools/genpolicy/src/pod.rs
@@ -300,6 +300,9 @@ struct Probe {
     periodSeconds: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
+    terminationGracePeriodSeconds: Option<i32>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
     failureThreshold: Option<i32>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -310,6 +313,9 @@ struct Probe {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     tcpSocket: Option<TCPSocketAction>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    grpc: Option<GRPCAction>,
     // TODO: additional fields.
 }
 
@@ -320,6 +326,15 @@ struct TCPSocketAction {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     host: Option<String>,
+}
+
+/// See Reference / Kubernetes API / Workload Resources / Pod.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct GRPCAction {
+    port: u16,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    service: Option<String>,
 }
 
 /// See Reference / Kubernetes API / Workload Resources / Pod.

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/ignored_fields/pod.yaml
@@ -7,6 +7,24 @@ spec:
   containers:
   - name: redis
     image: registry.k8s.io/pause:3.6@sha256:3d380ca8864549e74af4b29c10f9cb0956236dfb01c40ca076fb6c37253234db
+    readinessProbe:
+      grpc:
+        port: 2379
+        service: BarService
+      initialDelaySeconds: 10
+      successThreshold: 3
+    livenessProbe:
+      tcpSocket:
+        host: foo.bar
+        port: 8080
+      periodSeconds: 10
+      failureThreshold: 2
+    startupProbe:
+      httpGet:
+        path: /healthz
+        port: liveness-port
+      terminationGracePeriodSeconds: 60
+      timeoutSeconds: 10
   priority: 1
   schedulerName: test-scheduler-name
   affinity:


### PR DESCRIPTION
This commit adds fields for readiness/liveness/startup probes that were missing so far, and adds probes to the ignored_fields test to ensure these stay supported. None of these fields has an influence on the generated policy, they just allow parsing valid k8s yaml.