### PR TITLE
fix: pin idna and pymdown-extensions to remediate CVEs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -7,3 +7,5 @@ mkdocs-redirects==1.2.2
 CairoSVG==2.9.0
 pillow==12.2.0
 click==8.3.3
+idna==3.15
+pymdown-extensions==10.21.3


### PR DESCRIPTION
Pin idna to 3.15 and pymdown-extensions to 10.21.3 to address security vulnerabilities:

- GHSA-65pc-fj4g-8rjx (idna, severity 6.9)
- GHSA-62q4-447f-wv8h (pymdown-extensions, severity 4.3)
- GHSA-r6h4-mm7h-8pmq (pymdown-extensions, severity 2.7)

These dependencies were previously transitive and vulnerable. They are now explicitly pinned to secure versions.

Generated-by: IBM Bob