### PR TITLE
docs: Add a Quick Start Guide for new users

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,9 @@ $ kata-runtime check
 
 ## Getting started
 
-See the [installation documentation](docs/install).
+New to Kata Containers? Start with the
+[Quick Start Guide](docs/quick-start-guide.md) to learn the basics and run your
+first workload, then see the [installation documentation](docs/install).
 
 ## Documentation
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ For details of the other Kata Containers repositories, see the
 
 ## Getting Started
 
+* [Quick Start Guide](./quick-start-guide.md): Understand the basics and run your first Kata workload in minutes
 * [Installation guides](./install/README.md): Install and run Kata Containers with Docker or Kubernetes
 
 ## Tracing

--- a/docs/install/README.md
+++ b/docs/install/README.md
@@ -1,20 +1,336 @@
-# Kata Containers installation guides
+# Kata Containers installation guide
 
-The following is an overview of the different installation methods available.
+This guide explains how to install and run [Kata Containers](https://github.com/kata-containers/kata-containers).
+
+Starting with the 4.0.0 release, the default and recommended Kata Containers
+runtime is [`runtime-rs`](../../src/runtime-rs/README.md), the Rust-based
+implementation of the containerd shim v2. This guide focuses on `runtime-rs`.
+Where the behaviour of the legacy Go runtime differs, it is called out
+separately.
+
+> **Note:**
+>
+> The Go runtime is still shipped and supported, but `runtime-rs` is the
+> recommended choice for new deployments.
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Choosing an installation method](#choosing-an-installation-method)
+- [Install on Kubernetes (recommended)](#install-on-kubernetes-recommended)
+- [Install on a Linux system](#install-on-a-linux-system)
+- [Use Kata Containers with Docker](#use-kata-containers-with-docker)
+- [Build and install from source](#build-and-install-from-source)
+- [Verify the installation](#verify-the-installation)
+- [Further information](#further-information)
 
 ## Prerequisites
 
-Kata Containers requires nested virtualization or bare metal. Check
-[hardware requirements](./../../README.md#hardware-requirements) to see if your system is capable of running Kata
-Containers.
+### Hardware
 
-The Kata Deploy Helm chart is the preferred  way to install all of the binaries and
-artifacts required to run Kata Containers on Kubernetes.
+Kata Containers runs on bare metal, or inside a VM that has nested
+virtualization enabled. The following must be true on the host.
 
-[Use Kata Deploy Helm Chart](/tools/packaging/kata-deploy/helm-chart/README.md) to install Kata Containers on a Kubernetes Cluster.
+**CPU virtualization extensions** must be supported and enabled in the
+firmware/BIOS:
+
+| Architecture | Virtualization technology |
+|-|-|
+| `x86_64`, `amd64` | Intel VT-x (`vmx`), AMD-V (`svm`) |
+| `aarch64` (`arm64`) | ARM Hyp |
+| `ppc64le` | IBM Power |
+| `s390x` | IBM Z & LinuxONE SIE |
+
+On `x86_64`, confirm the extensions are exposed to the OS (`vmx` for Intel,
+`svm` for AMD; no output means virtualization is unavailable):
+
+```sh
+grep -E -o '(vmx|svm)' /proc/cpuinfo | sort -u
+```
+
+**KVM** must be available: the `/dev/kvm` device has to exist and be accessible
+to the user that runs the Kata shim (`root`, or a member of the `kvm` group):
+
+```sh
+ls -l /dev/kvm
+```
+
+If `/dev/kvm` is missing on `x86_64`, load the KVM module for your CPU:
+
+```sh
+sudo modprobe kvm_intel   # Intel hosts
+sudo modprobe kvm_amd     # AMD hosts
+```
+
+On hosts backed by the **Microsoft Hypervisor** (Hyper-V, including nested
+Linux VMs on Windows and some Azure instance types), KVM is not available and
+the equivalent device is `/dev/mshv`. You then need a VMM that supports the
+Microsoft Hypervisor, such as Cloud Hypervisor's mshv backend (used by the
+`clh-azure` / `clh-azure-runtime-rs` runtimes):
+
+```sh
+ls -l /dev/mshv
+```
+
+**Nested virtualization** is required when the host is itself a VM: the
+underlying hypervisor must expose the CPU virtualization extensions to the guest
+(for example a `host-passthrough` or `host-model` CPU, with nesting enabled on
+the bare-metal host).
+
+**Host kernel modules** for `vhost` must be loaded. Kata uses VSOCK for the
+communication channel between the runtime and the guest agent, which requires
+`vhost_vsock` (it provides the `/dev/vhost-vsock` device); `vhost_net` is also
+needed for networking:
+
+```sh
+sudo modprobe vhost_vsock
+sudo modprobe vhost_net
+```
+
+Confirm the VSOCK device is present:
+
+```sh
+ls -l /dev/vhost-vsock
+```
+
+To load these modules automatically on boot, add them to a file under
+`/etc/modules-load.d/`:
+
+```sh
+printf 'vhost_vsock\nvhost_net\n' | sudo tee /etc/modules-load.d/kata-containers.conf
+```
+
+These modules are required on every node that runs Kata Containers, regardless
+of the installation method.
+
+For the full list of supported platforms, see the
+[hardware requirements](../../README.md#hardware-requirements).
+
+### Software
+
+Depending on the installation method you choose, you need one or more of the
+following:
+
+- A **Kubernetes** cluster running a supported version. See the
+  [prerequisites document](../prerequisites.md) for more details.
+- A **CRI-compatible container runtime** (containerd or CRI-O). containerd
+  `v2.1.x` or newer is recommended; some Kata features (such as drop-in config
+  merging and `multiInstallSuffix`) require containerd `v2.0` or newer.
+- **Docker** (`v26+`), if you want to run Kata Containers directly with Docker.
+- [`helm`](https://helm.sh/docs/intro/install/), for the recommended Kubernetes
+  installation method.
+
+## Choosing an installation method
+
+| Method | Best for | Notes |
+|-|-|-|
+| [Kata Deploy Helm chart](#install-on-kubernetes-recommended) | Kubernetes | **Recommended.** Installs every required artifact and the Kata `RuntimeClass`es on each node, and handles upgrades and removal via `helm upgrade`/`helm uninstall`. |
+| [Pre-built release tarball](#install-on-a-linux-system) | Docker, single nodes | Manual install; you are responsible for upgrading and removing the artifacts yourself. |
+| [Build from source](#build-and-install-from-source) | Developers and contributors | Build individual components yourself. |
+
+## Install on Kubernetes (recommended)
+
+The [Kata Deploy Helm chart](../../tools/packaging/kata-deploy/helm-chart/README.md)
+is the preferred way to install every binary and artifact required to run Kata
+Containers on Kubernetes. It installs the `kata-deploy` DaemonSet, which lays
+down the Kata artifacts on each node, and creates the Kata `RuntimeClass`
+resources.
+
+### Install the chart
+
+```sh
+# Pick the version you want to install, or use the latest release.
+export VERSION=$(curl -sSL https://api.github.com/repos/kata-containers/kata-containers/releases/latest | jq -r .tag_name)
+export CHART="oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy"
+
+helm install kata-deploy "${CHART}" --version "${VERSION}"
+```
+
+This installs the `kata-deploy` DaemonSet and the default Kata `RuntimeClass`
+resources. To see everything you can configure:
+
+```sh
+helm show values "${CHART}" --version "${VERSION}"
+```
+
+For the full set of configuration options (selecting shims, custom runtimes,
+node selectors, TEE shims, drop-in configuration files and more) see the
+[Helm configuration document](../helm-configuration.md).
+
+### Select a runtime-rs RuntimeClass
+
+The chart creates one `RuntimeClass` per enabled shim. The `runtime-rs`
+based runtimes use the `-runtime-rs` suffix, and `kata-dragonball` (the built-in
+Dragonball VMM) is `runtime-rs` only. For example:
+
+| RuntimeClass | Hypervisor | Runtime |
+|-|-|-|
+| `kata-qemu-runtime-rs` | QEMU | runtime-rs |
+| `kata-clh-runtime-rs` | Cloud Hypervisor | runtime-rs |
+| `kata-dragonball` | Dragonball (built-in) | runtime-rs |
+| `kata-qemu` | QEMU | Go runtime |
+
+List the runtime classes available on your cluster:
+
+```sh
+kubectl get runtimeclasses
+```
+
+### Run a test pod
+
+Create a pod that uses a `runtime-rs` `RuntimeClass`:
+
+```yaml title="kata-qemu-runtime-rs-test.yaml"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kata-runtime-rs-test
+spec:
+  runtimeClassName: kata-qemu-runtime-rs
+  containers:
+    - name: test
+      image: quay.io/libpod/ubuntu:latest
+      command: ["uname", "-r"]
+```
+
+```sh
+kubectl apply -f kata-qemu-runtime-rs-test.yaml
+kubectl logs kata-runtime-rs-test
+```
+
+The kernel version printed is the Kata guest kernel, which is typically
+different from the host kernel, confirming the workload is running inside a
+lightweight VM.
+
+### Uninstall
+
+```sh
+helm uninstall kata-deploy -n kube-system
+```
+
+During uninstall, Helm reports that some cluster-wide resources
+(`ServiceAccount`, `ClusterRole`, `ClusterRoleBinding`) were kept due to the
+resource policy. This is **normal**: a post-delete hook Job removes them so no
+cluster-wide RBAC is left behind.
+
+## Install on a Linux system
+
+When you are not using Kubernetes (for example to run Kata Containers with
+Docker), install Kata from a pre-built release tarball.
+
+> **Note:**
+>
+> If your distribution packages Kata Containers, we recommend installing that
+> version so it is updated when new releases are available. The instructions
+> below install the newest upstream release, which is **your** responsibility to
+> keep up to date.
+
+### Download and unpack a release
+
+Download the archive for your architecture from the
+[releases page](https://github.com/kata-containers/kata-containers/releases).
+Kata Containers uses [semantic versioning](https://semver.org), so install a
+version that does *not* contain a dash (`-`), since that indicates a pre-release.
+
+```sh
+export VERSION=$(curl -sSL https://api.github.com/repos/kata-containers/kata-containers/releases/latest | jq -r .tag_name)
+export ARCH=$(uname -m)
+
+curl -fsSL -o kata-static.tar.zst \
+  "https://github.com/kata-containers/kata-containers/releases/download/${VERSION}/kata-static-${VERSION}-${ARCH}.tar.zst"
+
+# The archive uses an /opt/kata/ prefix.
+sudo tar -xvf kata-static.tar.zst -C /
+```
+
+The release installs both runtimes side by side:
+
+| Path | Runtime |
+|-|-|
+| `/opt/kata/runtime-rs/bin/containerd-shim-kata-v2` | runtime-rs (recommended) |
+| `/opt/kata/bin/containerd-shim-kata-v2` | Go runtime |
+
+The packaged configuration files live under
+`/opt/kata/share/defaults/kata-containers/`. The `runtime-rs` configurations
+use the `-runtime-rs` suffix (for example `configuration-qemu-runtime-rs.toml`),
+and `configuration-dragonball.toml` selects the built-in Dragonball VMM.
+
+## Use Kata Containers with Docker
+
+Newer versions of Docker (`v26+`) can launch containers with the Kata shim
+directly. Kata support with Docker is tested with QEMU as the VMM.
+
+First, [install Kata from a release tarball](#download-and-unpack-a-release).
+Then register a Kata runtime in the Docker daemon configuration. To use
+`runtime-rs`, point Docker at the `runtime-rs` shim binary and select a
+`runtime-rs` configuration with the `ConfigPath` option:
+
+```json title="/etc/docker/daemon.json"
+{
+  "runtimes": {
+    "kata": {
+      "runtimeType": "/opt/kata/runtime-rs/bin/containerd-shim-kata-v2",
+      "options": {
+        "ConfigPath": "/opt/kata/share/defaults/kata-containers/configuration-qemu-runtime-rs.toml"
+      }
+    }
+  }
+}
+```
+
+> **Note:**
+>
+> `ConfigPath` selects which configuration the shim loads (for example
+> `configuration-qemu-runtime-rs.toml` for QEMU, or `configuration-dragonball.toml`
+> for the built-in Dragonball VMM). If you omit it, the shim falls back to its
+> default search path, where `/etc/kata-containers/configuration.toml` takes
+> precedence over the packaged defaults.
+
+Reload the Docker daemon:
+
+```sh
+sudo systemctl reload docker
+```
+
+Launch a Kata container and check the guest kernel version:
+
+```sh
+docker run --runtime kata -it --rm ubuntu:24.04 uname -r
+```
+
+> **Note:**
+>
+> Running `docker` *inside* a Kata Container (Docker-in-Docker) requires extra
+> care. See [How to run Docker in Docker with Kata Containers](../how-to/how-to-run-docker-with-kata.md).
+
+## Build and install from source
+
+Developers and contributors can build Kata Containers components from source:
+
+- [Developer Guide](../Developer-Guide.md): build and install the runtime, agent,
+  guest kernel, rootfs/initrd images and hypervisors.
+- [`runtime-rs` README](../../src/runtime-rs/README.md): build and install the
+  Rust runtime shim, including the built-in Dragonball VMM and external
+  hypervisor options.
+
+## Verify the installation
+
+The most reliable way to confirm Kata Containers is working is to run a workload
+and check that it boots in a VM with its own guest kernel:
+
+- On Kubernetes, run the [test pod](#run-a-test-pod) and inspect its logs.
+- With Docker, run `docker run --runtime kata -it --rm ubuntu:24.04 uname -r`.
+
+In both cases the kernel version reported from inside the container is the Kata
+guest kernel, which is normally different from the host kernel (compare with
+`uname -r` on the host).
 
 ## Further information
 
-* [upgrading document](../Upgrading.md)
-* [developer guide](../Developer-Guide.md)
-* [runtime documentation](../../src/runtime/README.md)
+- [Helm configuration](../helm-configuration.md): advanced `kata-deploy` options
+- [Prerequisites](../prerequisites.md): Kubernetes, containerd and `runc` setup
+- [Upgrading](../Upgrading.md): how to upgrade an existing installation
+- [Developer Guide](../Developer-Guide.md): building, debugging and troubleshooting
+- [runtime-rs documentation](../../src/runtime-rs/README.md)
+- [runtime documentation](../../src/runtime/README.md)
+- [Limitations](../Limitations.md)

--- a/docs/quick-start-guide.md
+++ b/docs/quick-start-guide.md
@@ -1,0 +1,172 @@
+# Kata Containers Quick Start Guide
+
+New to Kata Containers? This guide gives you just enough context and
+terminology to understand what the project is, then points you at the fastest
+way to install it and try it out. It should take only a few minutes to read.
+
+For full installation instructions (prerequisites, all installation methods,
+Docker, building from source, and troubleshooting), see the
+[installation guide](install/README.md). For a deeper understanding of how
+everything fits together, see the [overview](index.md) and the
+[architecture documentation](design/architecture).
+
+## What is Kata Containers?
+
+Kata Containers is an open source runtime that runs each container (or
+Kubernetes pod) inside its own lightweight virtual machine (VM). You get a
+workflow that feels and performs like standard Linux containers, but with the
+stronger workload isolation of hardware virtualization.
+
+With the default `runc` runtime, containers share the host kernel and are
+isolated only by Linux primitives such as namespaces, cgroups, and seccomp.
+With Kata, each pod runs in a VM with its own guest kernel, adding a second
+layer of defense between the workload and the host.
+
+When you schedule a Kata pod, the container manager hands it off to the Kata
+shim, which launches a hypervisor to boot a lightweight VM. The container then
+runs inside that VM, on its own guest kernel. The container's files (including
+its image's root filesystem) are shared into the guest over virtio-fs, served by
+a host daemon (`virtiofsd`, or `nydusd` when using the nydus snapshotter):
+
+```mermaid
+flowchart TB
+    subgraph host["Host"]
+        containerd["containerd / CRI-O"]
+        shim["Kata shim (containerd-shim-kata-v2)"]
+        vmm["Hypervisor / VMM (QEMU, Cloud Hypervisor, ...)"]
+        virtiofs["virtio-fs daemon (virtiofsd / nydusd)"]
+        containerd -->|"1. create pod"| shim
+        shim -->|"2. launch VM"| vmm
+        shim -->|"2. start fs daemon"| virtiofs
+    end
+
+    subgraph vm["Lightweight VM (own guest kernel)"]
+        agent["kata-agent"]
+        workload["Container workload"]
+        agent -->|"4. start & manage"| workload
+    end
+
+    vmm ==>|"3. boot guest"| vm
+    shim <-.->|"control channel over VSOCK"| agent
+    virtiofs ==>|"share host content (virtio-fs)"| workload
+```
+
+> **Note:**
+>
+> The diagram shows the shim, VMM, and virtio-fs daemon as separate host
+> processes, which is the case for external hypervisors such as QEMU and Cloud
+> Hypervisor. With the built-in **Dragonball** VMM, the shim, the VMM, and the
+> virtio-fs daemon all run inside a *single* process.
+
+## Why use Kata Containers?
+
+- **Stronger isolation by default.** Each pod runs in its own VM with a
+  dedicated guest kernel. A container break-out or guest-kernel exploit is
+  contained inside the VM, instead of exposing the host kernel that every other
+  workload shares.
+- **A building block for running untrusted or multi-tenant workloads.** The
+  hardware virtualization boundary is much harder to cross than namespaces and
+  cgroups alone, so you can run third-party code or mutually distrusting tenants
+  on shared infrastructure with more confidence. Note that Kata is a *tool* that
+  helps you achieve multi-tenancy — it strengthens workload isolation, but it
+  does not on its own guarantee multi-tenancy, which also depends on network,
+  storage, and control-plane isolation.
+- **Drop-in compatibility.** Kata implements the OCI and CRI shim interface, so
+  it works with Kubernetes, containerd, CRI-O, and Docker. You opt in per
+  workload via a `RuntimeClass` (or Docker's `--runtime`) — no application
+  changes required.
+- **Reduced host attack surface and flexibility.** Workloads no longer talk
+  directly to the host kernel, and each guest can run its own kernel version and
+  configuration, independent of the host.
+
+## Why use Kata Containers with a TEE?
+
+Kata can boot its lightweight VMs inside a hardware Trusted Execution
+Environment (TEE) — such as Intel TDX, AMD SEV-SNP, or IBM Secure Execution — so
+the guest's memory is encrypted and integrity-protected by the CPU. This
+protects data *in use*: even a compromised or malicious host, hypervisor, or
+cloud operator cannot read or tamper with the workload, and remote attestation
+lets you cryptographically verify the environment before secrets are released to
+it.
+
+This is the foundation of the [Confidential Containers](https://confidentialcontainers.org/)
+project, which builds on Kata Containers. For how to deploy and attest
+confidential workloads, see the
+[Confidential Containers documentation](https://confidentialcontainers.org/docs/).
+
+## Key terminology
+
+A few terms appear throughout the documentation:
+
+- **Runtime / shim**: the `containerd-shim-kata-v2` process that the container
+  manager calls to create and manage the VM that backs a pod. Starting with the
+  4.0 release, the default and recommended runtime is
+  [`runtime-rs`](../src/runtime-rs/README.md), the Rust implementation.
+- **Agent**: a small process (`kata-agent`) running *inside* the guest VM that
+  manages the container's lifecycle on behalf of the runtime.
+- **Hypervisor**: the Virtual Machine Monitor (VMM) that boots the guest, such
+  as QEMU, Cloud Hypervisor, Firecracker, or the built-in Dragonball. See the
+  [hypervisors document](hypervisors.md).
+- **virtio-fs**: the mechanism Kata uses to share directories and files (such as
+  the container's root filesystem) from the host into the guest VM. A host
+  daemon serves the content — `virtiofsd`, or `nydusd` when using the
+  [nydus](how-to/how-to-use-virtio-fs-nydus-with-kata.md) snapshotter for lazy
+  image pulling.
+- **`RuntimeClass`**: the Kubernetes object that tells the cluster to schedule a
+  pod with Kata instead of the default runtime. You select it per pod with
+  `runtimeClassName` (for example, `kata-qemu-runtime-rs`).
+- **`kata-deploy`**: the recommended installer. It is a DaemonSet that lays down
+  all of the Kata binaries and artifacts on each node and wires up the container
+  manager and `RuntimeClass` objects for you.
+
+## Try it out
+
+The fastest way to try Kata Containers is the `kata-deploy` Helm chart on a
+Kubernetes cluster. The steps below are the condensed happy path; the
+[installation guide](install/README.md) covers the
+[prerequisites](install/README.md#prerequisites) (hardware virtualization,
+KVM, kernel modules), other installation methods, and verification in full.
+
+1. **Install the chart** ([details and options](install/README.md#install-on-kubernetes-recommended)):
+
+```sh
+export VERSION=$(curl -sSL https://api.github.com/repos/kata-containers/kata-containers/releases/latest | jq -r .tag_name)
+export CHART="oci://ghcr.io/kata-containers/kata-deploy-charts/kata-deploy"
+
+helm install kata-deploy "${CHART}" --version "${VERSION}"
+```
+
+2. **Run a pod** with a Kata `RuntimeClass`:
+
+```yaml title="kata-quickstart.yaml"
+apiVersion: v1
+kind: Pod
+metadata:
+  name: kata-quickstart
+spec:
+  runtimeClassName: kata-qemu-runtime-rs
+  containers:
+    - name: test
+      image: quay.io/libpod/ubuntu:latest
+      command: ["uname", "-r"]
+```
+
+```sh
+kubectl apply -f kata-quickstart.yaml
+kubectl logs kata-quickstart
+```
+
+The kernel version printed is the Kata guest kernel, which is normally
+different from the host kernel (`uname -r`) — confirming the workload is
+running inside a lightweight VM.
+
+## Next steps
+
+- [Installation guide](install/README.md): prerequisites, every installation
+  method, Docker, building from source, and verification.
+- [Hypervisors](hypervisors.md): choose the VMM that best fits your workload.
+- [Limitations](Limitations.md): differences compared with the default `runc`
+  runtime.
+- [Use cases](README.md#kata-use-cases): GPU passthrough, SR-IOV, confidential
+  containers, and more.
+- [Developer guide](Developer-Guide.md): build Kata from source and contribute.


### PR DESCRIPTION
Add a short Quick Start Guide that gives new users the basic context and
terminology of Kata Containers, plus a condensed happy path to install it
and try it out on Kubernetes.

The detailed prerequisites, installation methods, and verification steps
live in the installation guide, so the Quick Start links to those sections
instead of duplicating them. Link the new guide from the top-level and docs
READMEs so it is discoverable.

Fixes: #12999

Built atop of #13219 