### PR TITLE
kata-deploy: export nydus snapshotter root

### DIFF
--- a/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
+++ b/tools/packaging/kata-deploy/binary/src/artifacts/snapshotters.rs
@@ -127,6 +127,11 @@ pub async fn configure_nydus_snapshotter(
         &format!(".proxy_plugins.\"{nydus}\".address"),
         &format!("\"/run/{containerd_nydus}/containerd-nydus-grpc.sock\""),
     )?;
+    toml_utils::set_toml_value(
+        configuration_file,
+        &format!(".proxy_plugins.\"{nydus}\".exports.root"),
+        &format!("\"/var/lib/{nydus}\""),
+    )?;
 
     Ok(())
 }


### PR DESCRIPTION
containerd uses the proxy plugin root export when reporting CRI image filesystem paths. Without this export, the CRI plugin falls back to /var/lib/containerd/io.containerd.snapshotter.v1.<snapshotter>.

For nydus-for-kata-tee this fallback does not match the actual snapshotter root under /var/lib/nydus-for-kata-tee. Kubelet/cAdvisor then fails stats collection when it tries to inspect the nonexistent fallback path.

Export the nydus proxy snapshotter root so containerd reports the real filesystem path for resource accounting.

When using trusted ephemeral storage or a new ephemeral storage wip feature for providing plain disks, resource accounting would not kick in and pods which exhausted their emptyDir sizeLimits would not get evicted.

This was discovered when working on https://github.com/kata-containers/kata-containers/pull/13127, and the issue was also replicated with the existing trusted ephemeral storage feature.