### PR TITLE
packaging: Optimize kata-deploy build export using tar output

### DIFF
--- a/tools/packaging/kata-deploy/local-build/kata-deploy-build-components-tarballs.sh
+++ b/tools/packaging/kata-deploy/local-build/kata-deploy-build-components-tarballs.sh
@@ -37,24 +37,24 @@ if [[ -z "${rust_toolchain}" ]]; then
 	exit 1
 fi
 
-rust_builder_out="${build_dir}/kata-deploy-binary-out"
+rust_builder_tar="${build_dir}/kata-deploy-binary-out.tar"
 
 # kata-deploy and kata-deploy-job-dispatcher are produced by the same rust-builder
 # stage. Build it once *per process* and let each component package its own
 # binary, so running both components in a single invocation does not compile the
 # workspace twice. The guard is process-local (not a directory check) on purpose:
-# a fresh invocation must always rebuild, otherwise a stale output dir from an
+# a fresh invocation must always rebuild, otherwise a stale output tar from an
 # earlier run/commit would be silently reused.
 rust_binaries_built="false"
 build_rust_binaries() {
 	if [[ "${rust_binaries_built}" == "true" ]]; then
 		return
 	fi
-	rm -rf "${rust_builder_out}"
+	rm -f "${rust_builder_tar}"
 	docker buildx build \
 		--target rust-builder \
 		--build-arg "RUST_TOOLCHAIN=${rust_toolchain}" \
-		--output "type=local,dest=${rust_builder_out}" \
+		--output "type=tar,dest=${rust_builder_tar}" \
 		-f "${repo_root_dir}/tools/packaging/kata-deploy/Dockerfile.components" \
 		"${repo_root_dir}"
 	rust_binaries_built="true"
@@ -64,8 +64,8 @@ build_kata_deploy_binary() {
 	build_rust_binaries
 
 	mkdir -p "${build_dir}/kata-deploy-binary/usr/bin"
-	cp "${rust_builder_out}/kata-deploy/bin/kata-deploy" \
-		"${build_dir}/kata-deploy-binary/usr/bin/kata-deploy"
+	tar -xf "${rust_builder_tar}" -C "${build_dir}/kata-deploy-binary/usr/bin" \
+		--strip-components=2 kata-deploy/bin/kata-deploy
 	tar --zstd -cf "${build_dir}/kata-deploy-static-kata-deploy-binary.tar.zst" \
 		-C "${build_dir}/kata-deploy-binary" .
 }
@@ -74,8 +74,8 @@ build_kata_deploy_job_dispatcher() {
 	build_rust_binaries
 
 	mkdir -p "${build_dir}/kata-deploy-job-dispatcher/usr/bin"
-	cp "${rust_builder_out}/kata-deploy/bin/kata-deploy-job-dispatcher" \
-		"${build_dir}/kata-deploy-job-dispatcher/usr/bin/kata-deploy-job-dispatcher"
+	tar -xf "${rust_builder_tar}" -C "${build_dir}/kata-deploy-job-dispatcher/usr/bin" \
+		--strip-components=2 kata-deploy/bin/kata-deploy-job-dispatcher
 	tar --zstd -cf "${build_dir}/kata-deploy-static-kata-deploy-job-dispatcher.tar.zst" \
 		-C "${build_dir}/kata-deploy-job-dispatcher" .
 }


### PR DESCRIPTION
Replace `type=local` with `type=tar` in kata-deploy build to reduce export time and avoid build hangs during the export-to-client-directory phase.

Update callers to extract binaries directly from the tar archive instead of copying from an intermediate directory.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>
