### PR TITLE
release: do not publish a kata-monitor-job-dispatcher manifest

### DIFF
--- a/.github/workflows/release-kata-images.yaml
+++ b/.github/workflows/release-kata-images.yaml
@@ -106,6 +106,9 @@ jobs:
           TAGS: ${{ needs.resolve-tags.outputs.tags }}
           REGISTRIES: ${{ inputs.registries }}
         run: |
+          # kata-monitor has no job-dispatcher sidecar image, so opt out of the
+          # kata-deploy-specific dispatcher manifest derivation.
           KATA_DEPLOY_IMAGE_TAGS="${TAGS}" \
           KATA_DEPLOY_REGISTRIES="${REGISTRIES}" \
+          KATA_DEPLOY_PUBLISH_JOB_DISPATCHER="false" \
           ./tools/packaging/release/release.sh publish-multiarch-manifest

--- a/tools/packaging/release/release.sh
+++ b/tools/packaging/release/release.sh
@@ -151,13 +151,18 @@ function _publish_multiarch_manifest()
 	_check_required_env_var "KATA_DEPLOY_IMAGE_TAGS"
 	_check_required_env_var "KATA_DEPLOY_REGISTRIES"
 
-	# The dispatcher is shipped as a separate, minimal image alongside kata-deploy
-	# with the same tags. When no dedicated registries are given, derive them from
-	# each kata-deploy registry by inserting "-job-dispatcher" before any "-ci"
+	# The dispatcher is a kata-deploy-specific sidecar image, shipped alongside
+	# kata-deploy with the same tags. It does not exist for other images (e.g.
+	# kata-monitor), so callers publishing a non-kata-deploy manifest must opt
+	# out by setting KATA_DEPLOY_PUBLISH_JOB_DISPATCHER=false.
+	#
+	# When enabled and no dedicated registries are given, derive them from each
+	# kata-deploy registry by inserting "-job-dispatcher" before any "-ci"
 	# suffix, so the "-ci" stays last:
 	#   .../kata-deploy     -> .../kata-deploy-job-dispatcher
 	#   .../kata-deploy-ci  -> .../kata-deploy-job-dispatcher-ci
-	if [[ ${#JOB_DISPATCHER_REGISTRIES[@]} -eq 0 ]]; then
+	if [[ "${KATA_DEPLOY_PUBLISH_JOB_DISPATCHER:-true}" == "true" \
+		&& ${#JOB_DISPATCHER_REGISTRIES[@]} -eq 0 ]]; then
 		JOB_DISPATCHER_REGISTRIES=()
 		for registry in "${REGISTRIES[@]}"; do
 			if [[ "${registry}" == *-ci ]]; then


### PR DESCRIPTION
The shared _publish_multiarch_manifest() helper always derived a "-job-dispatcher" registry from the registries it was given. However, the dispatcher is a kata-deploy-specific sidecar image, so when the helper was reused to publish the kata-monitor multi-arch manifest it wrongly tried to push a non-existent kata-monitor-job-dispatcher image.

Let's gate the dispatcher derivation behind
KATA_DEPLOY_PUBLISH_JOB_DISPATCHER (defaulting to true so the kata-deploy path is unchanged) and opt out of it when publishing the kata-monitor manifest.


Assisted-by: Cursor <cursoragent@cursor.com>