### PR TITLE
runtime-rs: qemu: don't set slots/maxmem for confidential guests

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -263,13 +263,24 @@ struct Memory {
 impl Memory {
     fn new(config: &HypervisorConfig) -> Memory {
         let mem_size = config.memory_info.default_memory as u64;
-        let max_mem_size = config.memory_info.default_maxmemory as u64;
+
+        // Don't reserve a memory-hotplug region (slots/maxmem) for confidential
+        // guests, which don't support memory hotplug, mirroring how Smp::new
+        // omits maxcpus and what the Go runtime does in memoryTopology().
+        let (num_slots, max_mem_size) = if config.security_info.confidential_guest {
+            (0, 0)
+        } else {
+            (
+                config.memory_info.memory_slots,
+                config.memory_info.default_maxmemory as u64,
+            )
+        };
 
         // Memory sizes are given in megabytes in configuration.toml so we
         // need to convert them to bytes for storage.
         Memory {
             size: mem_size * MI_B,
-            num_slots: config.memory_info.memory_slots,
+            num_slots,
             max_size: max_mem_size * MI_B,
             memory_backend_file: None,
         }


### PR DESCRIPTION
Smp::new already omits the CPU-hotplug parameter (maxcpus) for confidential guests, but Memory::new unconditionally emitted the memory-hotplug parameters (slots/maxmem) regardless of confidential_guest.

Stop emitting slots/maxmem when confidential_guest is set, so no memory-hotplug region is reserved, mirroring Smp::new and the Go runtime's memoryTopology(). Note this only affects the QEMU command line; the runtime-side memory resize path is left untouched.


Assisted-by: Cursor <cursoragent@cursor.com>