### PR TITLE
tests: skip Guaranteed QoS test for SNP/TDX runtime-rs

### DIFF
--- a/tests/integration/kubernetes/k8s-qos-pods.bats
+++ b/tests/integration/kubernetes/k8s-qos-pods.bats
@@ -16,6 +16,11 @@ setup() {
 }
 
 @test "Guaranteed QoS" {
+	# Skip for SNP/TDX runtime-rs until podOverhead issue is resolved
+	# See: https://github.com/kata-containers/kata-containers/pull/13228
+	[ "${KATA_HYPERVISOR}" == "qemu-snp-runtime-rs" ] && skip "Skipping Guaranteed QoS test for SNP runtime-rs - podOverhead needs adjustment"
+	[ "${KATA_HYPERVISOR}" == "qemu-tdx-runtime-rs" ] && skip "Skipping Guaranteed QoS test for TDX runtime-rs - podOverhead needs adjustment"
+
 	pod_name="qos-test"
 	yaml_file="${pod_config_dir}/pod-guaranteed.yaml"
 	# Add policy to the yaml file


### PR DESCRIPTION
The Guaranteed QoS test is currently failing for SNP and TDX runtime-rs due to a podOverhead configuration issue. The test requests 600Mi of memory which, combined with the 2048Mi podOverhead, exceeds 2GiB and triggers memory management issues in confidential guests.

The PR https://github.com/kata-containers/kata-containers/pull/13171 exposed an issue with the podOverhead, which will only be solved when https://github.com/kata-containers/kata-containers/pull/13173 gets merged. The PR is still under review. 

So, @fidencio suggested that we skip the QOS tests for SNP and TDX runtime-rs for now,  until the podOverhead fix is merged

Related: https://github.com/kata-containers/kata-containers/pull/13228

@fidencio recommended to disable the the SNP and TDX qos tests until . 