### PR TITLE
runtime-rs: Remove unused msize_9p totally from configurations

### DIFF
--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -359,10 +359,6 @@ extra_monitor_socket = ""
 # Default false
 disable_nesting_checks = false
 
-# This is the msize used for 9p shares. It is the number of bytes
-# used for 9p packet payload.
-msize_9p = @DEFMSIZE9P@
-
 # If false and nvdimm is supported, use nvdimm device to plug guest image.
 # Otherwise virtio-block device is used.
 #

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -349,10 +349,6 @@ extra_monitor_socket = ""
 #
 disable_nesting_checks = false
 
-# This is the msize used for 9p shares. It is the number of bytes
-# used for 9p packet payload.
-msize_9p = @DEFMSIZE9P@
-
 # If false and nvdimm is supported, use nvdimm device to plug guest image.
 # Otherwise virtio-block device is used.
 #

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -333,10 +333,6 @@ enable_debug = false
 #
 disable_nesting_checks = false
 
-# This is the msize used for 9p shares. It is the number of bytes
-# used for 9p packet payload.
-msize_9p = @DEFMSIZE9P@
-
 # If false and nvdimm is supported, use nvdimm device to plug guest image.
 # Otherwise virtio-block device is used.
 #

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -203,10 +203,6 @@ enable_debug = false
 # Default false
 disable_nesting_checks = false
 
-# This is the msize used for 9p shares. It is the number of bytes
-# used for 9p packet payload.
-msize_9p = @DEFMSIZE9P@
-
 # VFIO devices are hotplugged on a bridge by default.
 # Enable hotplugging on root bus. This may be required for devices with
 # a large PCI bar, as this is a current limitation with hotplugging on

--- a/src/runtime-rs/tests/texture/configuration-qemu.toml
+++ b/src/runtime-rs/tests/texture/configuration-qemu.toml
@@ -46,7 +46,6 @@ enable_iommu = true
 enable_iommu_platform = true
 pflashes = ["/proc/mounts"]
 enable_debug = true
-msize_9p = 16384
 disable_image_nvdimm = true
 hotplug_vfio_on_root_bus = true
 pcie_root_port = 2


### PR DESCRIPTION
As virtio-9p is deprecated already, and its msize_9p should be deprecated too. This commit aims to remove the unused msize_9p.