### PR TITLE
GHA: Use IBM ActionsPZ runners for publish jobs on s390x

### DIFF
--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -115,7 +115,7 @@ jobs:
       repo: kata-containers/kata-deploy-ci
       tag: kata-containers-latest-s390x
       target-branch: ${{ github.ref_name }}
-      runner: s390x
+      runner: ubuntu-24.04-s390x
       arch: s390x
       image-kind: deploy
     secrets:
@@ -187,7 +187,7 @@ jobs:
       repo: kata-containers/kata-monitor-ci
       tag: kata-monitor-latest-s390x
       target-branch: ${{ github.ref_name }}
-      runner: s390x
+      runner: ubuntu-24.04-s390x
       arch: s390x
       image-kind: monitor
     secrets:


### PR DESCRIPTION
Let's use the ActionsPZ runners for the following jobs:
- publish-kata-deploy-image-s390x
- publish-kata-monitor-image-s390x

to improve CI experiences.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>