### PR TITLE
runtime-rs: correct uid/gid for K8s secret/configmap copy_file

### DIFF
--- a/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/share_fs_volume.rs
@@ -846,7 +846,7 @@ async fn copy_dir_recursively<P: AsRef<Path>>(
                     uid: metadata.uid() as i32,
                     gid: metadata.gid() as i32,
                     dir_mode: metadata.mode(),
-                    file_mode: SFlag::S_IFDIR.bits(),
+                    file_mode: metadata.mode(),
                     data: vec![],
                     ..Default::default()
                 };
@@ -879,7 +879,7 @@ async fn copy_dir_recursively<P: AsRef<Path>>(
                     file_size: metadata.len() as i64,
                     uid: metadata.uid() as i32,
                     gid: metadata.gid() as i32,
-                    file_mode: SFlag::S_IFREG.bits(),
+                    file_mode: metadata.mode(),
                     data: buffer,
                     ..Default::default()
                 };


### PR DESCRIPTION
In CoCo mode, share_fs is None and K8s secrets/configmap/projected/downward-api volumes are copied into the guest VM via gRPC copy_file(). Currently, with a case, the copied files retain their host ownership (root:root from kubelet). When a container runs as a non-root user (e.g., istio-proxy uid=1337), it cannot access these files, causing startup failures.

The fix enable it, the volumes should retain host file ownership correctly.