### PR TITLE
kata-monitor: add TLS support

### DIFF
--- a/docs/how-to/data/kata-monitor-daemonset.yml
+++ b/docs/how-to/data/kata-monitor-daemonset.yml
@@ -5,6 +5,23 @@ metadata:
 
 ---
 
+apiVersion: v1
+kind: Service
+metadata:
+  name: kata-monitor
+  namespace: kata-system
+  labels:
+    app.kubernetes.io/name: kata-monitor
+spec:
+  ports:
+  - name: https
+    port: 8443
+    targetPort: 8443
+  selector:
+    app.kubernetes.io/name: kata-monitor
+
+---
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -22,6 +39,8 @@ spec:
         app.kubernetes.io/name: kata-monitor
       annotations:
         prometheus.io/scrape: "true"
+        prometheus.io/scheme: "https"
+        prometheus.io/port: "8443"
     spec:
       containers:
       - name: kata-monitor
@@ -33,11 +52,13 @@ spec:
         # tip of `main`.
         image: quay.io/kata-containers/kata-monitor:latest
         args:
-          - -listen-address=0.0.0.0:8090
+          - -listen-address=0.0.0.0:8443
           - -log-level=debug
           - -runtime-endpoint=unix:///run/containerd/containerd.sock
+          - -tls-cert-file=/etc/kata-monitor/certs/cert.pem
+          - -tls-key-file=/etc/kata-monitor/certs/key.pem
         ports:
-          - containerPort: 8090
+          - containerPort: 8443
         resources:
           limits:
             cpu: 200m
@@ -52,6 +73,9 @@ spec:
         - name: sbs
           mountPath: /run/vc/sbs/
           readOnly: true
+        - name: certs
+          mountPath: /etc/kata-monitor/certs
+          readOnly: true
       terminationGracePeriodSeconds: 30
       volumes:
       - name: containerd-sock
@@ -62,3 +86,6 @@ spec:
         hostPath:
           path: /run/vc/sbs/
           type: DirectoryOrCreate
+      - name: certs
+        secret:
+          secretName: kata-monitor-certs

--- a/docs/how-to/data/kata-monitor-daemonset.yml
+++ b/docs/how-to/data/kata-monitor-daemonset.yml
@@ -22,6 +22,11 @@ spec:
         app.kubernetes.io/name: kata-monitor
       annotations:
         prometheus.io/scrape: "true"
+        prometheus.io/port: "8090"
+        # To enable TLS, replace the two annotations above with:
+        # prometheus.io/scrape: "true"
+        # prometheus.io/scheme: "https"
+        # prometheus.io/port: "8443"
     spec:
       containers:
       - name: kata-monitor
@@ -36,8 +41,16 @@ spec:
           - -listen-address=0.0.0.0:8090
           - -log-level=debug
           - -runtime-endpoint=unix:///run/containerd/containerd.sock
+          # To enable TLS, replace -listen-address above with:
+          #   -listen-address=0.0.0.0:8443
+          # and add the following args:
+          #   -tls-cert-file=/etc/kata-monitor/certs/cert.pem
+          #   -tls-key-file=/etc/kata-monitor/certs/key.pem
+          # See src/runtime/cmd/kata-monitor/README.md § "TLS" for
+          # certificate generation and Secret creation steps.
         ports:
           - containerPort: 8090
+          # To enable TLS, replace containerPort 8090 above with 8443.
         resources:
           limits:
             cpu: 200m
@@ -52,6 +65,10 @@ spec:
         - name: sbs
           mountPath: /run/vc/sbs/
           readOnly: true
+        # To enable TLS, also add:
+        # - name: certs
+        #   mountPath: /etc/kata-monitor/certs
+        #   readOnly: true
       terminationGracePeriodSeconds: 30
       volumes:
       - name: containerd-sock
@@ -62,3 +79,7 @@ spec:
         hostPath:
           path: /run/vc/sbs/
           type: DirectoryOrCreate
+      # To enable TLS, also add:
+      # - name: certs
+      #   secret:
+      #     secretName: kata-monitor-certs

--- a/docs/how-to/how-to-set-prometheus-in-k8s.md
+++ b/docs/how-to/how-to-set-prometheus-in-k8s.md
@@ -59,6 +59,12 @@ part of every Kata Containers release. Two flavours are available:
 
 `kata-monitor` can be started on the cluster as follows:
 
+> **Note**: The manifest below runs kata-monitor over plain HTTP by default.
+> To enable TLS, follow the inline comments in the manifest and create the
+> required `kata-monitor-certs` Secret beforehand. See the
+> [kata-monitor TLS documentation](../../src/runtime/cmd/kata-monitor/README.md#tls)
+> for certificate generation steps.
+
 ```
 $ kubectl apply -f https://raw.githubusercontent.com/kata-containers/kata-containers/main/docs/how-to/data/kata-monitor-daemonset.yml
 ```

--- a/src/runtime/cmd/kata-monitor/README.md
+++ b/src/runtime/cmd/kata-monitor/README.md
@@ -30,14 +30,61 @@ Each `kata-monitor` instance detects and monitors the Kata Container workloads r
 The `kata-monitor` binary accepts the following arguments:
 
 * `--listen-address` _IP:PORT_
-* `--runtime-enpoint` _PATH_TO_THE_CONTAINER_MANAGER_CRI_INTERFACE_
+* `--runtime-endpoint` _PATH_TO_THE_CONTAINER_MANAGER_CRI_INTERFACE_
 * `--log-level` _[ trace | debug | info | warn | error | fatal | panic ]_
+* `--tls-cert-file` _PATH_TO_TLS_CERTIFICATE_ (enables TLS when set, requires `--tls-key-file`)
+* `--tls-key-file` _PATH_TO_TLS_PRIVATE_KEY_ (requires `--tls-cert-file`)
+* `--tls-min-version` _[ VersionTLS12 | VersionTLS13 ]_ (minimum TLS version, defaults to `VersionTLS12` when TLS is enabled)
+* `--tls-cipher-suites` _COMMA_SEPARATED_IANA_CIPHER_NAMES_ (restricts cipher suites for TLS 1.2 and below; must not be set when `--tls-min-version=VersionTLS13` since Go's `crypto/tls` does not allow configuring TLS 1.3 cipher suites)
 
-The **listen-address** specifies the IP and TCP port where the kata-monitor HTTP endpoints will be exposed. It defaults to `127.0.0.1:8090`.
+The **listen-address** specifies the IP and TCP port where the kata-monitor endpoints will be exposed. It defaults to `127.0.0.1:8090`.
 
 The **runtime-endpoint** is the CRI of a CRI compliant container manager: it will be used to retrieve the CRI `PodSandboxMetadata` (`uid`, `name` and `namespace`) which will be attached to the Kata metrics through the labels `cri_uid`, `cri_name` and `cri_namespace`. It defaults to the containerd socket: `/run/containerd/containerd.sock`.
 
 The **log-level** allows the chose how verbose the logs should be. The default is `info`.
+
+### TLS
+
+When `--tls-cert-file` and `--tls-key-file` are both provided, kata-monitor serves over HTTPS instead of plain HTTP.
+
+#### Generating certificates for development/testing
+
+```bash
+# Generate a self-signed CA
+openssl genrsa -out monitorCA.key 2048
+openssl req -x509 -new -nodes -key monitorCA.key \
+  -subj "/CN=Kata Monitor CA" -days 365 -out monitorCA.crt
+
+# Generate the server key and a certificate signed by the CA
+openssl genrsa -out monitor.key 2048
+openssl req -new -key monitor.key -out monitor.csr \
+  -subj "/CN=kata-monitor.kata-system.svc" \
+  -addext "subjectAltName=DNS:kata-monitor.kata-system.svc,DNS:kata-monitor.kata-system.svc.cluster.local"
+openssl x509 -req -in monitor.csr -CA monitorCA.crt -CAkey monitorCA.key \
+  -CAcreateserial -out monitor.crt -days 365 \
+  -extfile <(echo "subjectAltName=DNS:kata-monitor.kata-system.svc,DNS:kata-monitor.kata-system.svc.cluster.local")
+
+# Store the cert and key in a Kubernetes Secret
+kubectl create secret generic kata-monitor-certs \
+  --namespace kata-system \
+  --from-file=cert.pem=./monitor.crt \
+  --from-file=key.pem=./monitor.key
+```
+
+Then deploy using the manifest in [`docs/how-to/data/kata-monitor-daemonset.yml`](../../../../docs/how-to/data/kata-monitor-daemonset.yml) which mounts the secret and passes the `--tls-cert-file`/`--tls-key-file` flags automatically.
+
+#### Verifying TLS
+
+Use `kubectl port-forward` to reach the HTTPS endpoint from your local machine (replace `<pod-name>` and `kata-system` with your values):
+
+```bash
+kubectl -n kata-system port-forward <pod-name> 18443:8443 &
+curl -sk https://localhost:18443/sandboxes
+curl -sk https://localhost:18443/metrics | head -5
+```
+
+The `-s` flag silences progress output and `-k` skips certificate verification (appropriate when using a self-signed cert for testing). In production, pass `--cacert monitorCA.crt` instead of `-k`.
+
 ### Kata monitor HTTP endpoints
 `kata-monitor` exposes the following endpoints:
   * `/metrics`             : get Kata sandboxes metrics.

--- a/src/runtime/cmd/kata-monitor/README.md
+++ b/src/runtime/cmd/kata-monitor/README.md
@@ -30,14 +30,67 @@ Each `kata-monitor` instance detects and monitors the Kata Container workloads r
 The `kata-monitor` binary accepts the following arguments:
 
 * `--listen-address` _IP:PORT_
-* `--runtime-enpoint` _PATH_TO_THE_CONTAINER_MANAGER_CRI_INTERFACE_
+* `--runtime-endpoint` _PATH_TO_THE_CONTAINER_MANAGER_CRI_INTERFACE_
 * `--log-level` _[ trace | debug | info | warn | error | fatal | panic ]_
+* `--tls-cert-file` _PATH_TO_TLS_CERTIFICATE_ (enables TLS when set, requires `--tls-key-file`)
+* `--tls-key-file` _PATH_TO_TLS_PRIVATE_KEY_ (requires `--tls-cert-file`)
+* `--tls-min-version` _[ VersionTLS12 | VersionTLS13 ]_ (minimum TLS version, defaults to `VersionTLS12` when TLS is enabled)
+* `--tls-cipher-suites` _COMMA_SEPARATED_IANA_CIPHER_NAMES_ (restricts cipher suites for TLS 1.2 and below; must not be set when `--tls-min-version=VersionTLS13` since Go's `crypto/tls` does not allow configuring TLS 1.3 cipher suites)
 
-The **listen-address** specifies the IP and TCP port where the kata-monitor HTTP endpoints will be exposed. It defaults to `127.0.0.1:8090`.
+The **listen-address** specifies the IP and TCP port where the kata-monitor endpoints will be exposed. It defaults to `127.0.0.1:8090`.
 
 The **runtime-endpoint** is the CRI of a CRI compliant container manager: it will be used to retrieve the CRI `PodSandboxMetadata` (`uid`, `name` and `namespace`) which will be attached to the Kata metrics through the labels `cri_uid`, `cri_name` and `cri_namespace`. It defaults to the containerd socket: `/run/containerd/containerd.sock`.
 
 The **log-level** allows the chose how verbose the logs should be. The default is `info`.
+
+### TLS
+
+When `--tls-cert-file` and `--tls-key-file` are both provided, kata-monitor serves over HTTPS instead of plain HTTP.
+
+> **To enable TLS in the reference DaemonSet manifest**
+> ([`docs/how-to/data/kata-monitor-daemonset.yml`](../../../../docs/how-to/data/kata-monitor-daemonset.yml)):
+> generate a certificate (see below), store it as a `kata-monitor-certs`
+> Secret in the `kata-system` namespace, then follow the inline comments in
+> the manifest to switch from HTTP to HTTPS.
+
+#### Generating certificates for development/testing
+
+```bash
+# Generate a self-signed CA
+openssl genrsa -out monitorCA.key 2048
+openssl req -x509 -new -nodes -key monitorCA.key \
+  -subj "/CN=Kata Monitor CA" -days 365 -out monitorCA.crt
+
+# Generate the server key and a certificate signed by the CA
+openssl genrsa -out monitor.key 2048
+openssl req -new -key monitor.key -out monitor.csr \
+  -subj "/CN=kata-monitor.kata-system.svc" \
+  -addext "subjectAltName=DNS:kata-monitor.kata-system.svc,DNS:kata-monitor.kata-system.svc.cluster.local"
+openssl x509 -req -in monitor.csr -CA monitorCA.crt -CAkey monitorCA.key \
+  -CAcreateserial -out monitor.crt -days 365 \
+  -extfile <(echo "subjectAltName=DNS:kata-monitor.kata-system.svc,DNS:kata-monitor.kata-system.svc.cluster.local")
+
+# Store the cert and key in a Kubernetes Secret
+kubectl create secret generic kata-monitor-certs \
+  --namespace kata-system \
+  --from-file=cert.pem=./monitor.crt \
+  --from-file=key.pem=./monitor.key
+```
+
+Then deploy using the manifest in [`docs/how-to/data/kata-monitor-daemonset.yml`](../../../../docs/how-to/data/kata-monitor-daemonset.yml) which mounts the secret and passes the `--tls-cert-file`/`--tls-key-file` flags automatically.
+
+#### Verifying TLS
+
+Use `kubectl port-forward` to reach the HTTPS endpoint from your local machine (replace `<pod-name>` and `kata-system` with your values):
+
+```bash
+kubectl -n kata-system port-forward <pod-name> 18443:8443 &
+curl -sk https://localhost:18443/sandboxes
+curl -sk https://localhost:18443/metrics | head -5
+```
+
+The `-s` flag silences progress output and `-k` skips certificate verification (appropriate when using a self-signed cert for testing). In production, pass `--cacert monitorCA.crt` instead of `-k`.
+
 ### Kata monitor HTTP endpoints
 `kata-monitor` exposes the following endpoints:
   * `/metrics`             : get Kata sandboxes metrics.

--- a/src/runtime/cmd/kata-monitor/main.go
+++ b/src/runtime/cmd/kata-monitor/main.go
@@ -6,11 +6,13 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
 	"os"
 	goruntime "runtime"
+	"strings"
 	"text/template"
 	"time"
 
@@ -23,6 +25,10 @@ const defaultListenAddress = "127.0.0.1:8090"
 var monitorListenAddr = flag.String("listen-address", defaultListenAddress, "The address to listen on for HTTP requests.")
 var runtimeEndpoint = flag.String("runtime-endpoint", "/run/containerd/containerd.sock", "Endpoint of CRI container runtime service.")
 var logLevel = flag.String("log-level", "info", "Log level of logrus(trace/debug/info/warn/error/fatal/panic).")
+var tlsCertFile = flag.String("tls-cert-file", "", "Path to TLS certificate file. Enables TLS when set (requires --tls-key-file).")
+var tlsKeyFile = flag.String("tls-key-file", "", "Path to TLS private key file. Enables TLS when set (requires --tls-cert-file).")
+var tlsMinVersion = flag.String("tls-min-version", "", "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12 when TLS is enabled.")
+var tlsCipherSuites = flag.String("tls-cipher-suites", "", "Comma-separated list of TLS cipher suite names (IANA format). Applies to TLS 1.2 and below.")
 
 // These values are overridden via ldflags
 var (
@@ -83,6 +89,10 @@ func main() {
 
 	flag.Parse()
 
+	if (*tlsCertFile == "") != (*tlsKeyFile == "") {
+		logrus.Fatal("--tls-cert-file and --tls-key-file must be set together")
+	}
+
 	// init logrus
 	initLog()
 
@@ -96,9 +106,12 @@ func main() {
 		"git-commit": ver.GitCommit,
 
 		// properties from command-line options
-		"listen-address":   *monitorListenAddr,
-		"runtime-endpoint": *runtimeEndpoint,
-		"log-level":        *logLevel,
+		"listen-address":    *monitorListenAddr,
+		"runtime-endpoint":  *runtimeEndpoint,
+		"log-level":         *logLevel,
+		"tls-cert-file":     *tlsCertFile,
+		"tls-min-version":   *tlsMinVersion,
+		"tls-cipher-suites": *tlsCipherSuites,
 	}
 
 	logrus.WithFields(announceFields).Info("announce")
@@ -171,7 +184,86 @@ func main() {
 		Handler: m,
 		Addr:    *monitorListenAddr,
 	}
-	logrus.Fatal(svr.ListenAndServe())
+
+	if *tlsCertFile != "" {
+		tlsConfig, err := buildTLSConfig(*tlsMinVersion, *tlsCipherSuites)
+		if err != nil {
+			logrus.WithError(err).Fatal("failed to build TLS config")
+		}
+		svr.TLSConfig = tlsConfig
+		logrus.Fatal(svr.ListenAndServeTLS(*tlsCertFile, *tlsKeyFile))
+	} else {
+		logrus.Fatal(svr.ListenAndServe())
+	}
+}
+
+// buildTLSConfig constructs a tls.Config from the given version string and
+// comma-separated IANA cipher suite names. Both arguments are optional; when
+// empty the function returns a config with secure defaults (TLS 1.2 minimum).
+func buildTLSConfig(minVersion, cipherSuites string) (*tls.Config, error) {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if minVersion != "" {
+		v, err := parseTLSVersion(minVersion)
+		if err != nil {
+			return nil, err
+		}
+		cfg.MinVersion = v
+	}
+
+	if cipherSuites != "" {
+		ids, err := parseCipherSuites(cipherSuites)
+		if err != nil {
+			return nil, err
+		}
+		cfg.CipherSuites = ids
+	}
+
+	return cfg, nil
+}
+
+func parseTLSVersion(s string) (uint16, error) {
+	switch s {
+	case "VersionTLS12":
+		return tls.VersionTLS12, nil
+	case "VersionTLS13":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("unsupported TLS version %q (supported: VersionTLS12, VersionTLS13)", s)
+	}
+}
+
+func parseCipherSuites(s string) ([]uint16, error) {
+	known := make(map[string]uint16)
+	for _, cs := range tls.CipherSuites() {
+		known[cs.Name] = cs.ID
+	}
+
+	// Build a set of insecure names for a better error message.
+	insecure := make(map[string]struct{})
+	for _, cs := range tls.InsecureCipherSuites() {
+		insecure[cs.Name] = struct{}{}
+	}
+
+	names := strings.Split(s, ",")
+	ids := make([]uint16, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, bad := insecure[name]; bad {
+			return nil, fmt.Errorf("cipher suite %q is insecure and not allowed", name)
+		}
+		id, ok := known[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown cipher suite %q", name)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
 }
 
 func indexPage(w http.ResponseWriter, r *http.Request) {

--- a/src/runtime/cmd/kata-monitor/main.go
+++ b/src/runtime/cmd/kata-monitor/main.go
@@ -6,11 +6,13 @@
 package main
 
 import (
+	"crypto/tls"
 	"flag"
 	"fmt"
 	"net/http"
 	"os"
 	goruntime "runtime"
+	"strings"
 	"text/template"
 	"time"
 
@@ -23,6 +25,10 @@ const defaultListenAddress = "127.0.0.1:8090"
 var monitorListenAddr = flag.String("listen-address", defaultListenAddress, "The address to listen on for HTTP requests.")
 var runtimeEndpoint = flag.String("runtime-endpoint", "/run/containerd/containerd.sock", "Endpoint of CRI container runtime service.")
 var logLevel = flag.String("log-level", "info", "Log level of logrus(trace/debug/info/warn/error/fatal/panic).")
+var tlsCertFile = flag.String("tls-cert-file", "", "Path to TLS certificate file. Enables TLS when set (requires --tls-key-file).")
+var tlsKeyFile = flag.String("tls-key-file", "", "Path to TLS private key file. Enables TLS when set (requires --tls-cert-file).")
+var tlsMinVersion = flag.String("tls-min-version", "", "Minimum TLS version (VersionTLS12, VersionTLS13). Defaults to VersionTLS12 when TLS is enabled.")
+var tlsCipherSuites = flag.String("tls-cipher-suites", "", "Comma-separated list of TLS cipher suite names (IANA format). Applies to TLS 1.2 and below.")
 
 // These values are overridden via ldflags
 var (
@@ -83,6 +89,10 @@ func main() {
 
 	flag.Parse()
 
+	if (*tlsCertFile == "") != (*tlsKeyFile == "") {
+		logrus.Fatal("--tls-cert-file and --tls-key-file must be set together")
+	}
+
 	// init logrus
 	initLog()
 
@@ -96,9 +106,12 @@ func main() {
 		"git-commit": ver.GitCommit,
 
 		// properties from command-line options
-		"listen-address":   *monitorListenAddr,
-		"runtime-endpoint": *runtimeEndpoint,
-		"log-level":        *logLevel,
+		"listen-address":    *monitorListenAddr,
+		"runtime-endpoint":  *runtimeEndpoint,
+		"log-level":         *logLevel,
+		"tls-cert-file":     *tlsCertFile,
+		"tls-min-version":   *tlsMinVersion,
+		"tls-cipher-suites": *tlsCipherSuites,
 	}
 
 	logrus.WithFields(announceFields).Info("announce")
@@ -171,7 +184,89 @@ func main() {
 		Handler: m,
 		Addr:    *monitorListenAddr,
 	}
-	logrus.Fatal(svr.ListenAndServe())
+
+	if *tlsCertFile != "" {
+		tlsConfig, err := buildTLSConfig(*tlsMinVersion, *tlsCipherSuites)
+		if err != nil {
+			logrus.WithError(err).Fatal("failed to build TLS config")
+		}
+		svr.TLSConfig = tlsConfig
+		logrus.Fatal(svr.ListenAndServeTLS(*tlsCertFile, *tlsKeyFile))
+	} else {
+		logrus.Fatal(svr.ListenAndServe())
+	}
+}
+
+// buildTLSConfig constructs a tls.Config from the given version string and
+// comma-separated IANA cipher suite names. Both arguments are optional; when
+// empty the function returns a config with secure defaults (TLS 1.2 minimum).
+func buildTLSConfig(minVersion, cipherSuites string) (*tls.Config, error) {
+	cfg := &tls.Config{
+		MinVersion: tls.VersionTLS12,
+	}
+
+	if minVersion != "" {
+		v, err := parseTLSVersion(minVersion)
+		if err != nil {
+			return nil, err
+		}
+		cfg.MinVersion = v
+	}
+
+	if cipherSuites != "" {
+		if cfg.MinVersion == tls.VersionTLS13 {
+			return nil, fmt.Errorf("--tls-cipher-suites must not be set when --tls-min-version=VersionTLS13: Go's crypto/tls does not support configuring TLS 1.3 cipher suites")
+		}
+		ids, err := parseCipherSuites(cipherSuites)
+		if err != nil {
+			return nil, err
+		}
+		cfg.CipherSuites = ids
+	}
+
+	return cfg, nil
+}
+
+func parseTLSVersion(s string) (uint16, error) {
+	switch s {
+	case "VersionTLS12":
+		return tls.VersionTLS12, nil
+	case "VersionTLS13":
+		return tls.VersionTLS13, nil
+	default:
+		return 0, fmt.Errorf("unsupported TLS version %q (supported: VersionTLS12, VersionTLS13)", s)
+	}
+}
+
+func parseCipherSuites(s string) ([]uint16, error) {
+	known := make(map[string]uint16)
+	for _, cs := range tls.CipherSuites() {
+		known[cs.Name] = cs.ID
+	}
+
+	// Build a set of insecure names for a better error message.
+	insecure := make(map[string]struct{})
+	for _, cs := range tls.InsecureCipherSuites() {
+		insecure[cs.Name] = struct{}{}
+	}
+
+	names := strings.Split(s, ",")
+	ids := make([]uint16, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		if _, bad := insecure[name]; bad {
+			return nil, fmt.Errorf("cipher suite %q is insecure and not allowed", name)
+		}
+		id, ok := known[name]
+		if !ok {
+			return nil, fmt.Errorf("unknown cipher suite %q", name)
+		}
+		ids = append(ids, id)
+	}
+	return ids, nil
 }
 
 func indexPage(w http.ResponseWriter, r *http.Request) {

--- a/tests/functional/kata-monitor/kata-monitor-tests.sh
+++ b/tests/functional/kata-monitor/kata-monitor-tests.sh
@@ -21,7 +21,8 @@ source "/etc/os-release" || source "/usr/lib/os-release"
 [[ -n "${BASH_VERSION:-}" ]] && set -o errtrace
 [[ -n "${DEBUG:-}" ]] && set -o xtrace
 
-readonly MONITOR_HTTP_ENDPOINT="127.0.0.1:8090"
+readonly MONITOR_HTTP_PORT="8090"
+readonly MONITOR_HTTPS_PORT="8443"
 # we should collect few hundred metrics, let's put a reasonable minimum
 readonly MONITOR_MIN_METRICS_NUM=200
 readonly TIMEOUT="20s"
@@ -38,6 +39,9 @@ KATA_MONITOR_PID=""
 TMPATH=$(mktemp -d -t kata-monitor-test-XXXXXXXXX)
 METRICS_FILE="${TMPATH}/metrics.txt"
 MONITOR_LOG_FILE="${TMPATH}/kata-monitor.log"
+MONITOR_TLS_DIR="${TMPATH}/tls"
+# Set by run_monitor_tests before each round.
+MONITOR_ENDPOINT=""
 CACHE_UPD_TIMEOUT_SEC=${CACHE_UPD_TIMEOUT_SEC:-20}
 POD_ID=""
 CID=""
@@ -61,7 +65,7 @@ echo_ok() {
 	echo "OK: ${msg}"
 }
 
-# quiet crictrl
+# quiet crictl
 qcrictl() {
 	sudo crictl "$@" > /dev/null
 }
@@ -94,15 +98,35 @@ cleanup() {
 	rm -rf "${TMPATH}"
 }
 
+generate_tls_certs() {
+	mkdir -p "${MONITOR_TLS_DIR}"
+
+	openssl genrsa -out "${MONITOR_TLS_DIR}/ca.key" 2048 2>/dev/null
+	openssl req -x509 -new -nodes -key "${MONITOR_TLS_DIR}/ca.key" \
+		-subj "/CN=kata-monitor-test-ca" -days 1 \
+		-out "${MONITOR_TLS_DIR}/ca.crt" 2>/dev/null
+	openssl genrsa -out "${MONITOR_TLS_DIR}/tls.key" 2048 2>/dev/null
+	openssl req -new -key "${MONITOR_TLS_DIR}/tls.key" \
+		-subj "/CN=kata-monitor-test" \
+		-out "${MONITOR_TLS_DIR}/tls.csr" 2>/dev/null
+	openssl x509 -req -in "${MONITOR_TLS_DIR}/tls.csr" \
+		-CA "${MONITOR_TLS_DIR}/ca.crt" \
+		-CAkey "${MONITOR_TLS_DIR}/ca.key" \
+		-CAcreateserial \
+		-out "${MONITOR_TLS_DIR}/tls.crt" -days 1 \
+		-extfile <(echo "subjectAltName=IP:127.0.0.1") 2>/dev/null
+}
+
 start_kata_monitor() {
 	local args="$1"
 
 	if [[ -n "${KATA_MONITOR_IMAGE}" ]]; then
-		# `--network host` keeps the default 127.0.0.1:8090 bind
-		# reachable from the host-side test code without having to
-		# publish a port. Mount /run/containerd so the monitor can
-		# reach containerd's CRI socket, plus the kata sandbox base
-		# path for the per-sandbox shim-monitor sockets.
+		# `--network host` keeps the listen address reachable from the
+		# host-side test code without having to publish a port. Mount
+		# /run/containerd so the monitor can reach containerd's CRI
+		# socket, the kata sandbox base path for per-sandbox shim-monitor
+		# sockets, and the TLS cert dir (harmless when TLS flags are not
+		# in args).
 
 		# Ensure /run/vc/sbs/ exists on the host so the readonly mount
 		# does not fail before the first kata sandbox is created.
@@ -114,6 +138,7 @@ start_kata_monitor() {
 			--network host \
 			-v /run/containerd:/run/containerd:ro \
 			-v /run/vc/sbs:/run/vc/sbs:ro \
+			-v "${MONITOR_TLS_DIR}:${MONITOR_TLS_DIR}:ro" \
 			"${KATA_MONITOR_IMAGE}" \
 			${args} --log-level trace > /dev/null
 		# Stream container logs into the same file the binary path
@@ -141,7 +166,8 @@ stop_kata_monitor() {
 
 	[[ -n "${KATA_MONITOR_PID}" ]] \
 		&& [[ -d "/proc/${KATA_MONITOR_PID}" ]] \
-		&& kill -9 "${KATA_MONITOR_PID}"
+		&& kill -9 "${KATA_MONITOR_PID}" || true
+	KATA_MONITOR_PID=""
 }
 
 create_sandbox_json() {
@@ -228,7 +254,7 @@ is_sandbox_there() {
 	local podid=${1}
 	local sbs s
 
-	sbs=$(sudo curl -s "${MONITOR_HTTP_ENDPOINT}/sandboxes")
+	sbs=$(curl -sk "${MONITOR_ENDPOINT}/sandboxes")
 	if [[ -n "${sbs}" ]]; then
 		for s in ${sbs}; do
 			if [[ "${s}" = "${podid}" ]]; then
@@ -267,6 +293,39 @@ is_sandbox_missing_iterate() {
 	return "${FALSE}"
 }
 
+# run_monitor_tests <scheme> <port>
+#
+# Runs the cache and metrics assertions against a running kata-monitor
+# instance. Sets MONITOR_ENDPOINT from the given scheme and port so that
+# all helper functions use the correct URL for this round.
+run_monitor_tests() {
+	local scheme="$1"
+	local port="$2"
+	MONITOR_ENDPOINT="${scheme}://127.0.0.1:${port}"
+
+	title "kata-monitor cache update checks (${scheme})"
+
+	CURRENT_TASK="retrieve ${POD_ID} in kata-monitor cache"
+	is_sandbox_there_iterate "${POD_ID}" || error_with_msg
+	echo_ok "${CURRENT_TASK}"
+
+	CURRENT_TASK="look for runc pod ${RUNC_POD_ID} in kata-monitor cache"
+	is_sandbox_there_iterate "${RUNC_POD_ID}" && error_with_msg "cache: got runc pod ${RUNC_POD_ID}"
+	echo_ok "runc pod ${RUNC_POD_ID} skipped from kata-monitor cache"
+
+	title "kata-monitor metrics retrieval (${scheme})"
+
+	CURRENT_TASK="retrieve metrics from kata-monitor"
+	curl -sk "${MONITOR_ENDPOINT}/metrics" > "${METRICS_FILE}"
+	echo_ok "${CURRENT_TASK}"
+
+	CURRENT_TASK="retrieve metrics for pod ${POD_ID}"
+	METRICS_COUNT=$(grep -c "${POD_ID}" "${METRICS_FILE}" || true)
+	[[ "${METRICS_COUNT}" -lt "${MONITOR_MIN_METRICS_NUM}" ]] \
+		&& error_with_msg "got too few metrics (#${METRICS_COUNT})"
+	echo_ok "${CURRENT_TASK} - found #${METRICS_COUNT} metrics"
+}
+
 main() {
 	local args=""
 
@@ -295,39 +354,40 @@ main() {
 	echo_ok "${CURRENT_TASK} - POD ID:${POD_ID}, CID:${CID}"
 
 	###########################
-	title "start kata-monitor"
+	title "generate TLS certificates"
 
-	CURRENT_TASK="start kata-monitor"
-	start_kata_monitor "${args}"
+	CURRENT_TASK="generate TLS certificates"
+	generate_tls_certs
+	echo_ok "${CURRENT_TASK}"
+
+	###########################
+	title "start kata-monitor (plain HTTP)"
+
+	CURRENT_TASK="start kata-monitor (plain HTTP)"
+	start_kata_monitor "--listen-address=127.0.0.1:${MONITOR_HTTP_PORT}"
 	if [[ -n "${KATA_MONITOR_IMAGE}" ]]; then
 		echo_ok "${CURRENT_TASK} (image ${KATA_MONITOR_IMAGE})"
 	else
 		echo_ok "${CURRENT_TASK} (pid ${KATA_MONITOR_PID})"
 	fi
 
-	###########################
-	title "kata-monitor cache update checks"
+	run_monitor_tests http "${MONITOR_HTTP_PORT}"
 
-	CURRENT_TASK="retrieve ${POD_ID} in kata-monitor cache"
-	is_sandbox_there_iterate "${POD_ID}" || error_with_msg
-	echo_ok "${CURRENT_TASK}"
-
-	CURRENT_TASK="look for runc pod ${RUNC_POD_ID} in kata-monitor cache"
-	is_sandbox_there_iterate "${RUNC_POD_ID}" && error_with_msg "cache: got runc pod ${RUNC_POD_ID}"
-	echo_ok "runc pod ${RUNC_POD_ID} skipped from kata-monitor cache"
+	stop_kata_monitor
 
 	###########################
-	title "kata-monitor metrics retrieval"
+	title "start kata-monitor (TLS HTTPS)"
 
-	CURRENT_TASK="retrieve metrics from kata-monitor"
-	curl -s "${MONITOR_HTTP_ENDPOINT}/metrics" > "${METRICS_FILE}"
-	echo_ok "${CURRENT_TASK}"
+	CURRENT_TASK="start kata-monitor (TLS HTTPS)"
+	start_kata_monitor \
+		"--listen-address=127.0.0.1:${MONITOR_HTTPS_PORT} --tls-cert-file=${MONITOR_TLS_DIR}/tls.crt --tls-key-file=${MONITOR_TLS_DIR}/tls.key"
+	if [[ -n "${KATA_MONITOR_IMAGE}" ]]; then
+		echo_ok "${CURRENT_TASK} (image ${KATA_MONITOR_IMAGE})"
+	else
+		echo_ok "${CURRENT_TASK} (pid ${KATA_MONITOR_PID})"
+	fi
 
-	CURRENT_TASK="retrieve metrics for pod ${POD_ID}"
-	METRICS_COUNT=$(grep -c "${POD_ID}" "${METRICS_FILE}" || true)
-	[[ "${METRICS_COUNT}" -lt "${MONITOR_MIN_METRICS_NUM}" ]] \
-		&& error_with_msg "got too few metrics (#${METRICS_COUNT})"
-	echo_ok "${CURRENT_TASK} - found #${METRICS_COUNT} metrics"
+	run_monitor_tests https "${MONITOR_HTTPS_PORT}"
 
 	###########################
 	title "remove kata workload"
@@ -342,6 +402,8 @@ main() {
 	CURRENT_TASK="verify removal of ${POD_ID} from kata-monitor cache"
 	is_sandbox_missing_iterate "${POD_ID}" || error_with_msg "pod ${POD_ID} was not removed"
 	echo_ok "${CURRENT_TASK}"
+
+	stop_kata_monitor
 
 	###########################
 	CURRENT_TASK="cleanup"

--- a/tests/functional/kata-monitor/kata-monitor.bats
+++ b/tests/functional/kata-monitor/kata-monitor.bats
@@ -9,7 +9,7 @@
 # Validates that the optional kata-monitor DaemonSet shipped by the
 # kata-deploy helm chart actually rolls out, exercises the per-PR
 # kata-monitor image, and exposes per-sandbox Prometheus metrics for a
-# live kata pod.
+# live kata pod — over both plain HTTP and TLS HTTPS.
 #
 # Required environment variables (mirroring kata-deploy.bats):
 #   DOCKER_REGISTRY                - Registry for kata-deploy image
@@ -38,12 +38,22 @@ KATA_MONITOR_CACHE_TIMEOUT_S="${KATA_MONITOR_CACHE_TIMEOUT_S:-30}"
 # about. Kept fixed so teardown can clean it up unconditionally.
 KATA_MONITOR_PROBE_POD="kata-monitor-probe"
 
+# Local port used by the port-forward in the TLS test.
+KATA_MONITOR_LOCAL_TLS_PORT=18443
+
+# PID of the background kubectl port-forward process (TLS test only).
+KATA_MONITOR_PF_PID=""
+
 setup() {
 	ensure_helm
 
 	: "${KATA_MONITOR_IMAGE_REFERENCE:?KATA_MONITOR_IMAGE_REFERENCE must be set}"
 	: "${KATA_MONITOR_IMAGE_TAG:?KATA_MONITOR_IMAGE_TAG must be set}"
 }
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
 
 # Hit `path` (e.g. /metrics or /sandboxes) on one of the kata-monitor
 # pods via the apiserver pod-proxy. Stdout is the response body; stderr
@@ -83,6 +93,66 @@ wait_for_metrics() {
 	return 1
 }
 
+# ---------------------------------------------------------------------------
+# HTTPS helpers
+# ---------------------------------------------------------------------------
+
+# Start a kubectl port-forward for the first kata-monitor pod on
+# KATA_MONITOR_LOCAL_TLS_PORT → 8443. Stores the background PID in
+# KATA_MONITOR_PF_PID and waits briefly for the tunnel to establish.
+start_monitor_port_forward() {
+	local pod
+
+	pod="$(kubectl -n "${HELM_NAMESPACE}" get pods \
+		-l app.kubernetes.io/name=kata-monitor \
+		-o jsonpath='{.items[0].metadata.name}')"
+	[[ -n "${pod}" ]] || { echo "no kata-monitor pod found" >&2; return 1; }
+
+	kubectl -n "${HELM_NAMESPACE}" \
+		port-forward "${pod}" "${KATA_MONITOR_LOCAL_TLS_PORT}:8443" \
+		>/dev/null 2>&1 &
+	KATA_MONITOR_PF_PID=$!
+	sleep 2
+}
+
+stop_monitor_port_forward() {
+	if [[ -n "${KATA_MONITOR_PF_PID}" ]]; then
+		kill "${KATA_MONITOR_PF_PID}" 2>/dev/null || true
+		wait "${KATA_MONITOR_PF_PID}" 2>/dev/null || true
+		KATA_MONITOR_PF_PID=""
+	fi
+}
+
+# Hit `path` over the active port-forward tunnel with TLS verification skipped.
+kata_monitor_get_https() {
+	local path="$1"
+	curl -sk "https://localhost:${KATA_MONITOR_LOCAL_TLS_PORT}${path}"
+}
+
+# Same semantics as wait_for_metrics but uses the HTTPS tunnel.
+wait_for_metrics_https() {
+	local predicate="$1"
+	local body
+	local deadline=$((SECONDS + KATA_MONITOR_CACHE_TIMEOUT_S))
+
+	while (( SECONDS < deadline )); do
+		if body="$(kata_monitor_get_https /metrics 2>/dev/null)" \
+			&& printf '%s' "${body}" | "${predicate}"; then
+			return 0
+		fi
+		sleep 1
+	done
+
+	echo "Timed out waiting for kata-monitor HTTPS /metrics predicate '${predicate}'" >&2
+	echo "Last response was:" >&2
+	printf '%s\n' "${body:-<none>}" | head -50 >&2
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# Shared metric predicates
+# ---------------------------------------------------------------------------
+
 predicate_has_running_shim() {
 	# Match `kata_monitor_running_shim_count <N>` where N >= 1.
 	grep -E '^kata_monitor_running_shim_count [1-9][0-9]* *$' >/dev/null
@@ -98,11 +168,49 @@ predicate_has_shim_metric() {
 	grep -E '^kata_shim_[a-z_]+\{[^}]*sandbox_id="[0-9a-f-]+' >/dev/null
 }
 
-@test "kata-monitor helm chart rolls out and exposes per-sandbox metrics" {
-	pushd "${repo_root_dir}"
+# ---------------------------------------------------------------------------
+# Shared probe-pod helpers
+# ---------------------------------------------------------------------------
 
+create_probe_pod() {
+	# Give kata-monitor something real to surface metrics about: a kata
+	# pod that just sleeps. Reuses the same image as kata-deploy.bats's
+	# verification pod for cache-warmth on the runner.
+	local probe_yaml
+	probe_yaml=$(mktemp)
+	cat > "${probe_yaml}" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${KATA_MONITOR_PROBE_POD}
+spec:
+  runtimeClassName: kata-${KATA_HYPERVISOR}
+  restartPolicy: Never
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+  containers:
+    - name: probe
+      image: quay.io/kata-containers/alpine-bash-curl:latest
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c", "sleep 600"]
+EOF
+	echo ""
+	echo "Creating kata probe pod ..."
+	kubectl apply -f "${probe_yaml}"
+	rm -f "${probe_yaml}"
+	kubectl wait "pod/${KATA_MONITOR_PROBE_POD}" \
+		--for=condition=Ready --timeout=300s
+}
+
+# ---------------------------------------------------------------------------
+# Shared helm deploy helper
+# ---------------------------------------------------------------------------
+
+deploy_monitor() {
 	local helm_timeout="${KATA_DEPLOY_TIMEOUT:-600s}"
 	local rollout_timeout="${KATA_MONITOR_ROLLOUT_TIMEOUT:-300s}"
+	# Accept extra --set flags forwarded by the caller.
+	local extra_args=("$@")
 
 	echo "Installing kata-deploy with monitor.enabled=true ..."
 	echo "  kata-monitor image: ${KATA_MONITOR_IMAGE_REFERENCE}:${KATA_MONITOR_IMAGE_TAG}"
@@ -110,7 +218,8 @@ predicate_has_shim_metric() {
 	HELM_TIMEOUT="${helm_timeout}" deploy_kata "" \
 		--set monitor.enabled=true \
 		--set "monitor.image.reference=${KATA_MONITOR_IMAGE_REFERENCE}" \
-		--set "monitor.image.tag=${KATA_MONITOR_IMAGE_TAG}"
+		--set "monitor.image.tag=${KATA_MONITOR_IMAGE_TAG}" \
+		"${extra_args[@]}"
 
 	echo ""
 	echo "::group::kata-monitor DaemonSet rollout"
@@ -135,11 +244,6 @@ predicate_has_shim_metric() {
 	kubectl -n "${HELM_NAMESPACE}" rollout status ds/kata-monitor \
 		--timeout="${rollout_timeout}"
 
-	echo ""
-	echo "::group::kata-monitor pods"
-	kubectl -n "${HELM_NAMESPACE}" get pods -l app.kubernetes.io/name=kata-monitor -o wide
-	echo "::endgroup::"
-
 	kubectl -n "${HELM_NAMESPACE}" wait pod \
 		-l app.kubernetes.io/name=kata-monitor \
 		--for=condition=Ready --timeout="${rollout_timeout}"
@@ -155,36 +259,23 @@ predicate_has_shim_metric() {
 			return 1
 		}
 	done <<< "${restarts}"
+}
 
-	# Give kata-monitor something real to surface metrics about: a kata
-	# pod that just sleeps. Reuses the same image as kata-deploy.bats's
-	# verification pod for cache-warmth on the runner.
-	local probe_yaml
-	probe_yaml=$(mktemp)
-	cat > "${probe_yaml}" <<EOF
-apiVersion: v1
-kind: Pod
-metadata:
-  name: ${KATA_MONITOR_PROBE_POD}
-spec:
-  runtimeClassName: kata-${KATA_HYPERVISOR}
-  restartPolicy: Never
-  nodeSelector:
-    katacontainers.io/kata-runtime: "true"
-  containers:
-    - name: probe
-      image: quay.io/kata-containers/alpine-bash-curl:latest
-      imagePullPolicy: IfNotPresent
-      command: ["sh", "-c", "sleep 600"]
-EOF
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@test "kata-monitor: plain HTTP metrics" {
+	pushd "${repo_root_dir}"
+
+	deploy_monitor
 
 	echo ""
-	echo "Creating kata probe pod ..."
-	kubectl apply -f "${probe_yaml}"
-	rm -f "${probe_yaml}"
+	echo "::group::kata-monitor pods"
+	kubectl -n "${HELM_NAMESPACE}" get pods -l app.kubernetes.io/name=kata-monitor -o wide
+	echo "::endgroup::"
 
-	kubectl wait "pod/${KATA_MONITOR_PROBE_POD}" \
-		--for=condition=Ready --timeout=300s
+	create_probe_pod
 
 	echo ""
 	echo "::group::Probe pod status"
@@ -223,11 +314,99 @@ EOF
 	popd
 }
 
+@test "kata-monitor: TLS HTTPS metrics" {
+	pushd "${repo_root_dir}"
+
+	# Generate a self-signed cert and store it as a Secret so the
+	# DaemonSet can mount it. The cert is valid for the pod's localhost
+	# address, which is what the port-forward tunnel exposes.
+	local tls_dir
+	tls_dir="$(mktemp -d)"
+
+	openssl genrsa -out "${tls_dir}/ca.key" 2048 2>/dev/null
+	openssl req -x509 -new -nodes -key "${tls_dir}/ca.key" \
+		-subj "/CN=kata-monitor-test-ca" -days 1 \
+		-out "${tls_dir}/ca.crt" 2>/dev/null
+	openssl genrsa -out "${tls_dir}/tls.key" 2048 2>/dev/null
+	openssl req -new -key "${tls_dir}/tls.key" \
+		-subj "/CN=kata-monitor-test" \
+		-out "${tls_dir}/tls.csr" 2>/dev/null
+	openssl x509 -req -in "${tls_dir}/tls.csr" \
+		-CA "${tls_dir}/ca.crt" \
+		-CAkey "${tls_dir}/ca.key" \
+		-CAcreateserial \
+		-out "${tls_dir}/tls.crt" -days 1 \
+		-extfile <(echo "subjectAltName=IP:127.0.0.1") 2>/dev/null
+
+	kubectl create namespace "${HELM_NAMESPACE}" \
+		--dry-run=client -o yaml | kubectl apply -f -
+	kubectl -n "${HELM_NAMESPACE}" create secret generic kata-monitor-certs \
+		--from-file=cert.pem="${tls_dir}/tls.crt" \
+		--from-file=key.pem="${tls_dir}/tls.key"
+	rm -rf "${tls_dir}"
+
+	deploy_monitor \
+		--set monitor.tls.secretName=kata-monitor-certs \
+		--set monitor.listenAddress=0.0.0.0:8443 \
+		--set monitor.port=8443
+
+	echo ""
+	echo "::group::kata-monitor pods"
+	kubectl -n "${HELM_NAMESPACE}" get pods -l app.kubernetes.io/name=kata-monitor -o wide
+	echo "::endgroup::"
+
+	create_probe_pod
+
+	echo ""
+	echo "::group::Probe pod status"
+	kubectl get "pod/${KATA_MONITOR_PROBE_POD}" -o wide
+	echo "::endgroup::"
+
+	start_monitor_port_forward
+
+	wait_for_metrics_https predicate_has_running_shim
+	wait_for_metrics_https predicate_has_shim_metric
+	echo "kata-monitor HTTPS /metrics surfaced the probe sandbox"
+
+	local sandboxes
+	sandboxes="$(kata_monitor_get_https /sandboxes)"
+	echo "::group::/sandboxes response (HTTPS)"
+	printf '%s\n' "${sandboxes}"
+	echo "::endgroup::"
+	[[ -n "${sandboxes//[[:space:]]/}" ]] || {
+		echo "/sandboxes returned empty body over HTTPS" >&2
+		return 1
+	}
+
+	echo ""
+	echo "Deleting probe pod and asserting cache invalidates ..."
+	kubectl delete "pod/${KATA_MONITOR_PROBE_POD}" --wait=true --timeout=60s
+
+	wait_for_metrics_https predicate_no_running_shim
+	echo "kata-monitor HTTPS /metrics dropped the probe sandbox after deletion"
+
+	stop_monitor_port_forward
+
+	popd
+}
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
 teardown() {
+	# Stop port-forward if the TLS test left it running (e.g. on failure).
+	stop_monitor_port_forward 2>/dev/null || true
+
 	# Best-effort cleanup — the @test deletes the probe pod on the
 	# happy path, but a failure between create and delete would leave
 	# it behind.
-	kubectl delete "pod/${KATA_MONITOR_PROBE_POD}" --ignore-not-found --wait=false 2>/dev/null || true
+	kubectl delete "pod/${KATA_MONITOR_PROBE_POD}" \
+		--ignore-not-found --wait=false 2>/dev/null || true
+
+	# Remove the TLS secret if the TLS test created it.
+	kubectl -n "${HELM_NAMESPACE}" delete secret kata-monitor-certs \
+		--ignore-not-found 2>/dev/null || true
 
 	uninstall_kata
 }

--- a/tests/functional/kata-monitor/kata-monitor.bats
+++ b/tests/functional/kata-monitor/kata-monitor.bats
@@ -9,7 +9,7 @@
 # Validates that the optional kata-monitor DaemonSet shipped by the
 # kata-deploy helm chart actually rolls out, exercises the per-PR
 # kata-monitor image, and exposes per-sandbox Prometheus metrics for a
-# live kata pod.
+# live kata pod — over both plain HTTP and TLS HTTPS.
 #
 # Required environment variables (mirroring kata-deploy.bats):
 #   DOCKER_REGISTRY                - Registry for kata-deploy image
@@ -38,12 +38,22 @@ KATA_MONITOR_CACHE_TIMEOUT_S="${KATA_MONITOR_CACHE_TIMEOUT_S:-30}"
 # about. Kept fixed so teardown can clean it up unconditionally.
 KATA_MONITOR_PROBE_POD="kata-monitor-probe"
 
+# Local port used by the port-forward in the TLS test.
+KATA_MONITOR_LOCAL_TLS_PORT=18443
+
+# PID of the background kubectl port-forward process (TLS test only).
+KATA_MONITOR_PF_PID=""
+
 setup() {
 	ensure_helm
 
 	: "${KATA_MONITOR_IMAGE_REFERENCE:?KATA_MONITOR_IMAGE_REFERENCE must be set}"
 	: "${KATA_MONITOR_IMAGE_TAG:?KATA_MONITOR_IMAGE_TAG must be set}"
 }
+
+# ---------------------------------------------------------------------------
+# HTTP helpers
+# ---------------------------------------------------------------------------
 
 # Hit `path` (e.g. /metrics or /sandboxes) on one of the kata-monitor
 # pods via the apiserver pod-proxy. Stdout is the response body; stderr
@@ -83,6 +93,66 @@ wait_for_metrics() {
 	return 1
 }
 
+# ---------------------------------------------------------------------------
+# HTTPS helpers
+# ---------------------------------------------------------------------------
+
+# Start a kubectl port-forward for the first kata-monitor pod on
+# KATA_MONITOR_LOCAL_TLS_PORT → 8443. Stores the background PID in
+# KATA_MONITOR_PF_PID and waits briefly for the tunnel to establish.
+start_monitor_port_forward() {
+	local pod
+
+	pod="$(kubectl -n "${HELM_NAMESPACE}" get pods \
+		-l app.kubernetes.io/name=kata-monitor \
+		-o jsonpath='{.items[0].metadata.name}')"
+	[[ -n "${pod}" ]] || { echo "no kata-monitor pod found" >&2; return 1; }
+
+	kubectl -n "${HELM_NAMESPACE}" \
+		port-forward "${pod}" "${KATA_MONITOR_LOCAL_TLS_PORT}:8443" \
+		>/dev/null 2>&1 &
+	KATA_MONITOR_PF_PID=$!
+	sleep 2
+}
+
+stop_monitor_port_forward() {
+	if [[ -n "${KATA_MONITOR_PF_PID}" ]]; then
+		kill "${KATA_MONITOR_PF_PID}" 2>/dev/null || true
+		wait "${KATA_MONITOR_PF_PID}" 2>/dev/null || true
+		KATA_MONITOR_PF_PID=""
+	fi
+}
+
+# Hit `path` over the active port-forward tunnel with TLS verification skipped.
+kata_monitor_get_https() {
+	local path="$1"
+	curl -sk "https://localhost:${KATA_MONITOR_LOCAL_TLS_PORT}${path}"
+}
+
+# Same semantics as wait_for_metrics but uses the HTTPS tunnel.
+wait_for_metrics_https() {
+	local predicate="$1"
+	local body
+	local deadline=$((SECONDS + KATA_MONITOR_CACHE_TIMEOUT_S))
+
+	while (( SECONDS < deadline )); do
+		if body="$(kata_monitor_get_https /metrics 2>/dev/null)" \
+			&& printf '%s' "${body}" | "${predicate}"; then
+			return 0
+		fi
+		sleep 1
+	done
+
+	echo "Timed out waiting for kata-monitor HTTPS /metrics predicate '${predicate}'" >&2
+	echo "Last response was:" >&2
+	printf '%s\n' "${body:-<none>}" | head -50 >&2
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# Shared metric predicates
+# ---------------------------------------------------------------------------
+
 predicate_has_running_shim() {
 	# Match `kata_monitor_running_shim_count <N>` where N >= 1.
 	grep -E '^kata_monitor_running_shim_count [1-9][0-9]* *$' >/dev/null
@@ -98,11 +168,65 @@ predicate_has_shim_metric() {
 	grep -E '^kata_shim_[a-z_]+\{[^}]*sandbox_id="[0-9a-f-]+' >/dev/null
 }
 
-@test "kata-monitor helm chart rolls out and exposes per-sandbox metrics" {
-	pushd "${repo_root_dir}"
+# ---------------------------------------------------------------------------
+# Shared probe-pod helpers
+# ---------------------------------------------------------------------------
 
+wait_for_pods_to_exist() {
+	local selector="$1"
+	local deadline=$((SECONDS + 120))
+
+	while (( SECONDS < deadline )); do
+		if [[ -n "$(kubectl -n "${HELM_NAMESPACE}" get pods -l "${selector}" \
+			-o name 2>/dev/null)" ]]; then
+			return 0
+		fi
+		sleep 2
+	done
+
+	echo "Timed out waiting for pods matching '${selector}' to be created" >&2
+	return 1
+}
+
+create_probe_pod() {
+	# Give kata-monitor something real to surface metrics about: a kata
+	# pod that just sleeps. Reuses the same image as kata-deploy.bats's
+	# verification pod for cache-warmth on the runner.
+	local probe_yaml
+	probe_yaml=$(mktemp)
+	cat > "${probe_yaml}" <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${KATA_MONITOR_PROBE_POD}
+spec:
+  runtimeClassName: kata-${KATA_HYPERVISOR}
+  restartPolicy: Never
+  nodeSelector:
+    katacontainers.io/kata-runtime: "true"
+  containers:
+    - name: probe
+      image: quay.io/kata-containers/alpine-bash-curl:latest
+      imagePullPolicy: IfNotPresent
+      command: ["sh", "-c", "sleep 600"]
+EOF
+	echo ""
+	echo "Creating kata probe pod ..."
+	kubectl apply -f "${probe_yaml}"
+	rm -f "${probe_yaml}"
+	kubectl wait "pod/${KATA_MONITOR_PROBE_POD}" \
+		--for=condition=Ready --timeout=300s
+}
+
+# ---------------------------------------------------------------------------
+# Shared helm deploy helper
+# ---------------------------------------------------------------------------
+
+deploy_monitor() {
 	local helm_timeout="${KATA_DEPLOY_TIMEOUT:-600s}"
 	local rollout_timeout="${KATA_MONITOR_ROLLOUT_TIMEOUT:-300s}"
+	# Accept extra --set flags forwarded by the caller.
+	local extra_args=("$@")
 
 	echo "Installing kata-deploy with monitor.enabled=true ..."
 	echo "  kata-monitor image: ${KATA_MONITOR_IMAGE_REFERENCE}:${KATA_MONITOR_IMAGE_TAG}"
@@ -110,7 +234,8 @@ predicate_has_shim_metric() {
 	HELM_TIMEOUT="${helm_timeout}" deploy_kata "" \
 		--set monitor.enabled=true \
 		--set "monitor.image.reference=${KATA_MONITOR_IMAGE_REFERENCE}" \
-		--set "monitor.image.tag=${KATA_MONITOR_IMAGE_TAG}"
+		--set "monitor.image.tag=${KATA_MONITOR_IMAGE_TAG}" \
+		"${extra_args[@]}"
 
 	# deploy_kata's readiness wait is best-effort, so make sure kata-deploy has
 	# really finished here: everything below is written around containerd having
@@ -158,11 +283,6 @@ predicate_has_shim_metric() {
 	kubectl -n "${HELM_NAMESPACE}" rollout status ds/kata-monitor \
 		--timeout="${rollout_timeout}"
 
-	echo ""
-	echo "::group::kata-monitor pods"
-	kubectl -n "${HELM_NAMESPACE}" get pods -l app.kubernetes.io/name=kata-monitor -o wide
-	echo "::endgroup::"
-
 	kubectl -n "${HELM_NAMESPACE}" wait pod \
 		-l app.kubernetes.io/name=kata-monitor \
 		--for=condition=Ready --timeout="${rollout_timeout}"
@@ -178,36 +298,23 @@ predicate_has_shim_metric() {
 			return 1
 		}
 	done <<< "${restarts}"
+}
 
-	# Give kata-monitor something real to surface metrics about: a kata
-	# pod that just sleeps. Reuses the same image as kata-deploy.bats's
-	# verification pod for cache-warmth on the runner.
-	local probe_yaml
-	probe_yaml=$(mktemp)
-	cat > "${probe_yaml}" <<EOF
-apiVersion: v1
-kind: Pod
-metadata:
-  name: ${KATA_MONITOR_PROBE_POD}
-spec:
-  runtimeClassName: kata-${KATA_HYPERVISOR}
-  restartPolicy: Never
-  nodeSelector:
-    katacontainers.io/kata-runtime: "true"
-  containers:
-    - name: probe
-      image: quay.io/kata-containers/alpine-bash-curl:latest
-      imagePullPolicy: IfNotPresent
-      command: ["sh", "-c", "sleep 600"]
-EOF
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@test "kata-monitor: plain HTTP metrics" {
+	pushd "${repo_root_dir}"
+
+	deploy_monitor
 
 	echo ""
-	echo "Creating kata probe pod ..."
-	kubectl apply -f "${probe_yaml}"
-	rm -f "${probe_yaml}"
+	echo "::group::kata-monitor pods"
+	kubectl -n "${HELM_NAMESPACE}" get pods -l app.kubernetes.io/name=kata-monitor -o wide
+	echo "::endgroup::"
 
-	kubectl wait "pod/${KATA_MONITOR_PROBE_POD}" \
-		--for=condition=Ready --timeout=300s
+	create_probe_pod
 
 	echo ""
 	echo "::group::Probe pod status"
@@ -246,11 +353,99 @@ EOF
 	popd
 }
 
+@test "kata-monitor: TLS HTTPS metrics" {
+	pushd "${repo_root_dir}"
+
+	# Generate a self-signed cert and store it as a Secret so the
+	# DaemonSet can mount it. The cert is valid for the pod's localhost
+	# address, which is what the port-forward tunnel exposes.
+	local tls_dir
+	tls_dir="$(mktemp -d)"
+
+	openssl genrsa -out "${tls_dir}/ca.key" 2048 2>/dev/null
+	openssl req -x509 -new -nodes -key "${tls_dir}/ca.key" \
+		-subj "/CN=kata-monitor-test-ca" -days 1 \
+		-out "${tls_dir}/ca.crt" 2>/dev/null
+	openssl genrsa -out "${tls_dir}/tls.key" 2048 2>/dev/null
+	openssl req -new -key "${tls_dir}/tls.key" \
+		-subj "/CN=kata-monitor-test" \
+		-out "${tls_dir}/tls.csr" 2>/dev/null
+	openssl x509 -req -in "${tls_dir}/tls.csr" \
+		-CA "${tls_dir}/ca.crt" \
+		-CAkey "${tls_dir}/ca.key" \
+		-CAcreateserial \
+		-out "${tls_dir}/tls.crt" -days 1 \
+		-extfile <(echo "subjectAltName=IP:127.0.0.1") 2>/dev/null
+
+	kubectl create namespace "${HELM_NAMESPACE}" \
+		--dry-run=client -o yaml | kubectl apply -f -
+	kubectl -n "${HELM_NAMESPACE}" create secret generic kata-monitor-certs \
+		--from-file=cert.pem="${tls_dir}/tls.crt" \
+		--from-file=key.pem="${tls_dir}/tls.key"
+	rm -rf "${tls_dir}"
+
+	deploy_monitor \
+		--set monitor.tls.secretName=kata-monitor-certs \
+		--set monitor.listenAddress=0.0.0.0:8443 \
+		--set monitor.port=8443
+
+	echo ""
+	echo "::group::kata-monitor pods"
+	kubectl -n "${HELM_NAMESPACE}" get pods -l app.kubernetes.io/name=kata-monitor -o wide
+	echo "::endgroup::"
+
+	create_probe_pod
+
+	echo ""
+	echo "::group::Probe pod status"
+	kubectl get "pod/${KATA_MONITOR_PROBE_POD}" -o wide
+	echo "::endgroup::"
+
+	start_monitor_port_forward
+
+	wait_for_metrics_https predicate_has_running_shim
+	wait_for_metrics_https predicate_has_shim_metric
+	echo "kata-monitor HTTPS /metrics surfaced the probe sandbox"
+
+	local sandboxes
+	sandboxes="$(kata_monitor_get_https /sandboxes)"
+	echo "::group::/sandboxes response (HTTPS)"
+	printf '%s\n' "${sandboxes}"
+	echo "::endgroup::"
+	[[ -n "${sandboxes//[[:space:]]/}" ]] || {
+		echo "/sandboxes returned empty body over HTTPS" >&2
+		return 1
+	}
+
+	echo ""
+	echo "Deleting probe pod and asserting cache invalidates ..."
+	kubectl delete "pod/${KATA_MONITOR_PROBE_POD}" --wait=true --timeout=60s
+
+	wait_for_metrics_https predicate_no_running_shim
+	echo "kata-monitor HTTPS /metrics dropped the probe sandbox after deletion"
+
+	stop_monitor_port_forward
+
+	popd
+}
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
 teardown() {
+	# Stop port-forward if the TLS test left it running (e.g. on failure).
+	stop_monitor_port_forward 2>/dev/null || true
+
 	# Best-effort cleanup — the @test deletes the probe pod on the
 	# happy path, but a failure between create and delete would leave
 	# it behind.
-	kubectl delete "pod/${KATA_MONITOR_PROBE_POD}" --ignore-not-found --wait=false 2>/dev/null || true
+	kubectl delete "pod/${KATA_MONITOR_PROBE_POD}" \
+		--ignore-not-found --wait=false 2>/dev/null || true
+
+	# Remove the TLS secret if the TLS test created it.
+	kubectl -n "${HELM_NAMESPACE}" delete secret kata-monitor-certs \
+		--ignore-not-found 2>/dev/null || true
 
 	uninstall_kata
 }

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
@@ -19,6 +19,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         prometheus.io/scrape: "true"
+        prometheus.io/scheme: {{ if .Values.monitor.tls.secretName }}"https"{{ else }}"http"{{ end }}
+        prometheus.io/port: {{ .Values.monitor.port | quote }}
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -45,6 +47,16 @@ spec:
           - -listen-address={{ .Values.monitor.listenAddress }}
           - -log-level={{ .Values.monitor.logLevel }}
           - -runtime-endpoint={{ .Values.monitor.runtimeEndpoint }}
+{{- if .Values.monitor.tls.secretName }}
+          - -tls-cert-file=/etc/kata-monitor/certs/cert.pem
+          - -tls-key-file=/etc/kata-monitor/certs/key.pem
+{{- if .Values.monitor.tls.minVersion }}
+          - -tls-min-version={{ .Values.monitor.tls.minVersion }}
+{{- end }}
+{{- if .Values.monitor.tls.cipherSuites }}
+          - -tls-cipher-suites={{ .Values.monitor.tls.cipherSuites }}
+{{- end }}
+{{- end }}
         ports:
           - containerPort: {{ .Values.monitor.port }}
         resources:
@@ -56,6 +68,11 @@ spec:
         - name: sbs
           mountPath: /run/vc/sbs/
           readOnly: true
+{{- if .Values.monitor.tls.secretName }}
+        - name: certs
+          mountPath: /etc/kata-monitor/certs
+          readOnly: true
+{{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: containerd-sock
@@ -66,4 +83,9 @@ spec:
         hostPath:
           path: /run/vc/sbs/
           type: DirectoryOrCreate
+{{- if .Values.monitor.tls.secretName }}
+      - name: certs
+        secret:
+          secretName: {{ .Values.monitor.tls.secretName }}
+{{- end }}
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/templates/kata-monitor.yaml
@@ -19,6 +19,8 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
       annotations:
         prometheus.io/scrape: "true"
+        prometheus.io/scheme: {{ if .Values.monitor.tls.secretName }}"https"{{ else }}"http"{{ end }}
+        prometheus.io/port: {{ .Values.monitor.port | quote }}
     spec:
 {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -45,6 +47,16 @@ spec:
           - -listen-address={{ .Values.monitor.listenAddress }}
           - -log-level={{ include "monitorLogLevel" . }}
           - -runtime-endpoint={{ include "monitorRuntimeEndpoint" . }}
+{{- if .Values.monitor.tls.secretName }}
+          - -tls-cert-file=/etc/kata-monitor/certs/cert.pem
+          - -tls-key-file=/etc/kata-monitor/certs/key.pem
+{{- if .Values.monitor.tls.minVersion }}
+          - -tls-min-version={{ .Values.monitor.tls.minVersion }}
+{{- end }}
+{{- if .Values.monitor.tls.cipherSuites }}
+          - -tls-cipher-suites={{ .Values.monitor.tls.cipherSuites }}
+{{- end }}
+{{- end }}
         ports:
           - containerPort: {{ .Values.monitor.port }}
         resources:
@@ -56,6 +68,11 @@ spec:
         - name: sbs
           mountPath: /run/vc/sbs/
           readOnly: true
+{{- if .Values.monitor.tls.secretName }}
+        - name: certs
+          mountPath: /etc/kata-monitor/certs
+          readOnly: true
+{{- end }}
       terminationGracePeriodSeconds: 30
       volumes:
       - name: containerd-sock
@@ -66,4 +83,9 @@ spec:
         hostPath:
           path: /run/vc/sbs/
           type: DirectoryOrCreate
+{{- if .Values.monitor.tls.secretName }}
+      - name: certs
+        secret:
+          secretName: {{ .Values.monitor.tls.secretName }}
+{{- end }}
 {{- end }}

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -122,6 +122,17 @@ monitor:
   runtimeEndpoint: "unix:///run/containerd/containerd.sock"
   logLevel: "info"
   port: 8090
+  tls:
+    # Name of a Secret containing cert.pem and key.pem. When set,
+    # kata-monitor serves HTTPS on the configured port instead of plain HTTP.
+    # The Secret must exist in the same namespace before the DaemonSet rolls out.
+    secretName: ""
+    # Minimum TLS version: VersionTLS12 or VersionTLS13. Defaults to VersionTLS12
+    # when TLS is enabled. Ignored when secretName is empty.
+    minVersion: ""
+    # Comma-separated list of IANA cipher suite names for TLS 1.2 and below.
+    # Must not be set when minVersion is VersionTLS13. Ignored when secretName is empty.
+    cipherSuites: ""
   securityContext:
     privileged: false
     runAsUser: 0

--- a/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
+++ b/tools/packaging/kata-deploy/helm-chart/kata-deploy/values.yaml
@@ -229,6 +229,17 @@ monitor:
   # debug:true implies debug; otherwise defaults to info.
   logLevel: ""
   port: 8090
+  tls:
+    # Name of a Secret containing cert.pem and key.pem. When set,
+    # kata-monitor serves HTTPS on the configured port instead of plain HTTP.
+    # The Secret must exist in the same namespace before the DaemonSet rolls out.
+    secretName: ""
+    # Minimum TLS version: VersionTLS12 or VersionTLS13. Defaults to VersionTLS12
+    # when TLS is enabled. Ignored when secretName is empty.
+    minVersion: ""
+    # Comma-separated list of IANA cipher suite names for TLS 1.2 and below.
+    # Must not be set when minVersion is VersionTLS13. Ignored when secretName is empty.
+    cipherSuites: ""
   securityContext:
     privileged: false
     runAsUser: 0


### PR DESCRIPTION
kata-monitor serves plain HTTP, exposing metrics and debug endpoints
to any client that can reach the pod. This prevents operators from
enforcing encrypted communication or site-specific cryptographic policy.

Add --tls-cert-file and --tls-key-file flags to enable HTTPS.
--tls-min-version and --tls-cipher-suites (IANA names, TLS 1.2 and
below only) give operators control over TLS policy without a binary
rebuild. Only stdlib crypto/tls is used; no new dependencies are
introduced.