### PR TITLE
ci: do not publish a kata-monitor job-dispatcher manifest

### DIFF
--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -267,10 +267,13 @@ jobs:
 
       - name: Push multi-arch monitor manifest
         run: |
+          # kata-monitor has no job-dispatcher sidecar image, so opt out of the
+          # kata-deploy-specific dispatcher manifest derivation.
           ./tools/packaging/release/release.sh publish-multiarch-manifest
         env:
           KATA_DEPLOY_IMAGE_TAGS: "kata-monitor-latest"
           KATA_DEPLOY_REGISTRIES: "quay.io/kata-containers/kata-monitor-ci ghcr.io/${{ github.repository_owner }}/kata-monitor-ci"
+          KATA_DEPLOY_PUBLISH_JOB_DISPATCHER: "false"
 
   upload-helm-chart-tarball:
     name: upload-helm-chart-tarball


### PR DESCRIPTION
The kata-monitor image has no job-dispatcher sidecar, so opt out of the kata-deploy-specific dispatcher manifest derivation in the payload-after-push workflow by setting
KATA_DEPLOY_PUBLISH_JOB_DISPATCHER=false, mirroring the same fix already applied to the release workflows.