### PR TITLE
runtime: Change default log level from Warn to Info

### DIFF
--- a/src/runtime/pkg/containerd-shim-v2/service.go
+++ b/src/runtime/pkg/containerd-shim-v2/service.go
@@ -82,7 +82,7 @@ func New(ctx context.Context, id string, publisher cdshim.Publisher, shutdown fu
 	logrus.SetOutput(io.Discard)
 	opts := ctx.Value(cdshim.OptsKey{}).(cdshim.Opts)
 	if !opts.Debug {
-		logrus.SetLevel(logrus.WarnLevel)
+		logrus.SetLevel(logrus.InfoLevel)
 	}
 	vci.SetLogger(ctx, shimLog)
 	katautils.SetLogger(ctx, shimLog, shimLog.Logger.Level)


### PR DESCRIPTION
When the kata configuration does not set log_level to debug, the containerd-shim-v2 defaults to WarnLevel, which suppresses important diagnostic information logged at Info level.

Key Info-level logs that are currently hidden:
- QEMU command line (qemu.go:3566) - critical for debugging VM issues
- VM lifecycle events (creation, start, stop)
- Device hotplug operations (VFIO, network, volumes)
- Resource configuration (NUMA, memory)
- QMP socket details

Info level provides significantly better diagnostic data without flooding logs with excessive detail (which would occur at Debug level). This change improves troubleshooting capabilities for production deployments where debug mode is not enabled.

Fixes: #13260