### PR TITLE
runtime/cgroup: implement Stringer for LinuxCgroup

### DIFF
--- a/src/runtime/pkg/resourcecontrol/cgroups.go
+++ b/src/runtime/pkg/resourcecontrol/cgroups.go
@@ -497,3 +497,7 @@ func (c *LinuxCgroup) ID() string {
 func (c *LinuxCgroup) Parent() string {
 	return filepath.Dir(c.path)
 }
+
+func (c *LinuxCgroup) String() string {
+	return fmt.Sprint(c.Type(), ": ", c.ID())
+}


### PR DESCRIPTION
Without this, error messages from `func (s *Sandbox) Delete()` (see src/runtime/virtcontainers/sandbox.go) will dump the whole struct, making logs quite verbose and hard to read.

For instance:
```
Jun 19 05:33:36 myhost containerd[5434]: time="2026-06-19T05:33:36.156657096Z" level=error msg="failed to cleanup the &{%!s(*v2.Manager=&{/sys/fs/cgroup /sys/fs/cgroup/k8s.io/someid}) /k8s.io/someid %!s(*specs.LinuxCPU=&{<nil> <nil> <nil> <nil> <nil> <nil>   <nil>}) [{%!s(bool=false)  %!s(*int64=<nil>) %!s(*int64=<nil>) rwm} {%!s(bool=true) c %!s(*int64=0xc000311080) %!s(*int64=0xc000311088) rwm} {%!s(bool=true) c %!s(*int64=0xc000311098) %!s(*int64=0xc0003110a0) rwm} {%!s(bool=true) c %!s(*int64=0xc0003110b0) %!s(*int64=0xc0003110b8) rwm} {%!s(bool=true) c %!s(*int64=0xc0003110c8) %!s(*int64=0xc0003110d0) rwm} {%!s(bool=true) c %!s(*int64=0xc0003110e0) %!s(*int64=0xc0003110e8) rwm} {%!s(bool=true) c %!s(*int64=0xc0003110f8) %!s(*int64=0xc000311100) rwm} {%!s(bool=true) c %!s(*int64=0xc000311110) %!s(*int64=0xc000311118) rwm} {%!s(bool=true) c %!s(*int64=0xc000311128) %!s(*int64=<nil>) rwm} {%!s(bool=true) c %!s(*int64=0xc000311138) %!s(*int64=0xc000311140) rwm} {%!s(bool=true) c %!s(*int64=0xc0003107d0) %!s(*int64=0xc0003107d8) rwm} {%!s(bool=true) c %!s(*int64=0xc0003107e0) %!s(*int64=0xc0003107e8) rwm} {%!s(bool=true) c %!s(*int64=0xc000577748) %!s(*int64=0xc000577750) rwm} {%!s(bool=true) c %!s(*int64=0xc000577778) %!s(*int64=0xc000577780) rwm} {%!s(bool=true) c %!s(*int64=0xc000577958) %!s(*int64=0xc000577960) rwm} {%!s(bool=true) c %!s(*int64=0xc000577988) %!s(*int64=0xc000577990) rwm} {%!s(bool=true) c %!s(*int64=0xc0005779b8) %!s(*int64=0xc0005779c0) rwm} {%!s(bool=true) c %!s(*int64=0xc0005779e8) %!s(*int64=0xc0005779f0) rwm} {%!s(bool=true) c %!s(*int64=0xc000577b38) %!s(*int64=0xc000577b40) rwm} {%!s(bool=true) c %!s(*int64=0xc000577b68) %!s(*int64=0xc000577b70) rwm} {%!s(bool=true) c %!s(*int64=0xc000577c58) %!s(*int64=0xc000577c60) rwm} {%!s(bool=true) c %!s(*int64=0xc000577c88) %!s(*int64=0xc000577c90) rwm} {%!s(bool=true) c %!s(*int64=0xc000577cb8) %!s(*int64=0xc000577cc0) rwm} {%!s(bool=true) c %!s(*int64=0xc000311228) %!s(*int64=0xc000311270) m} {%!s(bool=true) b %!s(*int64=0xc000311228) %!s(*int64=0xc000311270) m} {%!s(bool=true) c %!s(*int64=0xc000311278) %!s(*int64=0xc000311270) rwm} {%!s(bool=true) c %!s(*int64=0xc000311280) %!s(*int64=0xc000311288) rwm}] {%!s(int32=0) %!s(uint32=0)}} resource controllers" error="write /sys/fs/cgroup/k8s.io/cgroup.procs: device or resource busy" name=containerd-shim-v2 pid=1272951 sandbox=mysandbox source=virtcontainers subsystem=sandbox
```

I took the liberty to open the PR without an issue due to the size of the fix.