### PR TITLE
genpolicy: honor image user group

### DIFF
--- a/src/tools/genpolicy/src/registry.rs
+++ b/src/tools/genpolicy/src/registry.rs
@@ -258,6 +258,33 @@ impl Container {
         }
     }
 
+    fn get_gid_from_group_name(&self, group: &str) -> Result<u32> {
+        if group.is_empty() {
+            return Err(anyhow!("Group is empty"));
+        }
+
+        if self.group.is_empty() {
+            return Err(anyhow!(
+                "No /etc/group file is available, unable to parse gid from group"
+            ));
+        }
+
+        match parse_group_file(&self.group) {
+            Ok(records) => {
+                if let Some(record) = records.iter().find(|&r| r.name == group) {
+                    debug!(
+                        "parse_group_file: found GID = {} for group = {group} in image layer",
+                        record.gid
+                    );
+                    Ok(record.gid)
+                } else {
+                    Err(anyhow!("Failed to find group {} in /etc/group", group))
+                }
+            }
+            Err(inner_e) => Err(anyhow!("Failed to parse /etc/group - error {inner_e}")),
+        }
+    }
+
     fn get_user_from_passwd_uid(&self, uid: u32) -> Result<String> {
         for record in parse_passwd_file(&self.passwd)? {
             if record.uid == uid {
@@ -328,6 +355,26 @@ impl Container {
         }
     }
 
+    // Unlike parse_user_string(), keep group parsing fallible. If an explicit
+    // image group cannot be resolved, callers can fall back to the historical
+    // UID-to-GID lookup through /etc/passwd instead of silently using GID 0.
+    fn parse_group_string(&self, group: &str) -> Result<u32> {
+        if group.is_empty() {
+            return Err(anyhow!("Group is empty"));
+        }
+
+        match group.parse::<u32>() {
+            Ok(gid) => Ok(gid),
+            Err(outer_e) => {
+                debug!(
+                    "parse_group_string: failed to parse {} as u32, using it as a group name - error {outer_e}",
+                    group
+                );
+                self.get_gid_from_group_name(group)
+            }
+        }
+    }
+
     // Convert Docker image config to policy data.
     pub fn get_process(
         &self,
@@ -353,6 +400,7 @@ impl Container {
          */
         if let Some(image_user) = &docker_config.User {
             if !image_user.is_empty() {
+                let mut explicit_gid = false;
                 if image_user.contains(':') {
                     debug!(
                         "Container::get_process: splitting Docker config user = {:?}",
@@ -372,9 +420,25 @@ impl Container {
                         );
                         process.User.UID = self.parse_user_string(user[0]);
 
-                        debug!(
-                            "Container::get_process: overriding OCI container GID with UID:GID mapping from /etc/passwd"
-                        );
+                        if !user[1].is_empty() {
+                            match self.parse_group_string(user[1]) {
+                                Ok(gid) => {
+                                    process.User.GID = gid;
+                                    process.User.AdditionalGids.insert(gid);
+                                    explicit_gid = true;
+                                    debug!(
+                                        "Container::get_process: set GID = {gid} from explicit image user group = {}",
+                                        user[1]
+                                    );
+                                }
+                                Err(e) => {
+                                    warn!(
+                                        "Container::get_process: failed to parse explicit group from image user = {:?}, error {e}",
+                                        image_user
+                                    );
+                                }
+                            }
+                        }
                     }
                 } else {
                     debug!(
@@ -386,25 +450,30 @@ impl Container {
                     debug!("Container::get_process: Using UID:GID mapping from /etc/passwd");
                 }
 
-                match self.get_gid_from_passwd_uid(process.User.UID) {
-                    Ok(gid) => {
-                        process.User.GID = gid;
-                        debug!(
-                            "Container::get_process: set GID = {gid} from container image for UID = {}",
-                            process.User.UID
-                        );
+                if !explicit_gid {
+                    debug!(
+                        "Container::get_process: no explicit image group resolved, using UID:GID mapping from /etc/passwd"
+                    );
+                    match self.get_gid_from_passwd_uid(process.User.UID) {
+                        Ok(gid) => {
+                            process.User.GID = gid;
+                            debug!(
+                                "Container::get_process: set GID = {gid} from container image for UID = {}",
+                                process.User.UID
+                            );
 
-                        process.User.AdditionalGids.insert(gid);
-                        debug!(
-                            "get_container_process: inserted GID = {gid} into AdditionalGids: User = {:?}",
-                            &process.User
-                        );
-                    }
-                    Err(e) => {
-                        debug!(
-                            "Container::get_process: no GID for UID = {} in container image, error {e}",
-                            process.User.UID
-                        );
+                            process.User.AdditionalGids.insert(gid);
+                            debug!(
+                                "get_container_process: inserted GID = {gid} into AdditionalGids: User = {:?}",
+                                &process.User
+                            );
+                        }
+                        Err(e) => {
+                            debug!(
+                                "Container::get_process: no GID for UID = {} in container image, error {e}",
+                                process.User.UID
+                            );
+                        }
                     }
                 }
             }
@@ -765,4 +834,51 @@ fn parse_group_file(group: &str) -> Result<Vec<GroupRecord>> {
     }
 
     Ok(records)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn container_with_image_user(user: &str) -> Container {
+        // Container.passwd and Container.group hold raw /etc/passwd and
+        // /etc/group contents extracted from image layers. This fixture models
+        // an image where www-data is UID 33/GID 33 and wheel is GID 10.
+        Container {
+            image: "test-image".to_string(),
+            config_layer: DockerConfigLayer {
+                config: DockerImageConfig {
+                    User: Some(user.to_string()),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            passwd: "www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin\n".to_string(),
+            group: "www-data:x:33:\nwheel:x:10:\n".to_string(),
+        }
+    }
+
+    #[test]
+    fn image_user_with_numeric_group_uses_group_component() {
+        let container = container_with_image_user("33:10");
+        let mut process = policy::KataProcess::default();
+
+        container.get_process(&mut process, false, false);
+
+        assert_eq!(process.User.UID, 33);
+        assert_eq!(process.User.GID, 10);
+        assert!(process.User.AdditionalGids.contains(&10));
+    }
+
+    #[test]
+    fn image_user_with_named_group_uses_group_component() {
+        let container = container_with_image_user("www-data:wheel");
+        let mut process = policy::KataProcess::default();
+
+        container.get_process(&mut process, false, false);
+
+        assert_eq!(process.User.UID, 33);
+        assert_eq!(process.User.GID, 10);
+        assert!(process.User.AdditionalGids.contains(&10));
+    }
 }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/gpu_vfio_cdi/testcases.json
@@ -71,7 +71,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -177,7 +177,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -281,7 +281,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -387,7 +387,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -493,7 +493,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -598,7 +598,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -704,7 +704,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -810,7 +810,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -916,7 +916,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -1006,7 +1006,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,
@@ -1095,7 +1095,7 @@
           "Rlimits": [],
           "SelinuxLabel": "",
           "Terminal": false,
-          "User": {"AdditionalGids": [0], "GID": 0, "UID": 65535, "Username": ""}
+          "User": {"AdditionalGids": [65535], "GID": 65535, "UID": 65535, "Username": ""}
         },
         "Root": {"Path": "/run/kata-containers/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/rootfs", "Readonly": false},
         "Solaris": null,

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/security_context/fsgroup/testcases.json
@@ -303,10 +303,10 @@
           "Terminal": false,
           "User": {
             "AdditionalGids": [
-              0,
-              1000
+              1000,
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/config_map/testcases.json
@@ -119,8 +119,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }

--- a/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
+++ b/src/tools/genpolicy/tests/policy/testdata/createcontainer/volumes/emptydir/testcases.json
@@ -151,9 +151,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }
@@ -348,9 +348,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }
@@ -555,9 +555,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }
@@ -747,9 +747,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }
@@ -954,9 +954,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }
@@ -1111,9 +1111,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }
@@ -1298,9 +1298,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }
@@ -1495,9 +1495,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }
@@ -1700,9 +1700,9 @@
           "SelinuxLabel": "",
           "User": {
             "AdditionalGids": [
-              0
+              65535
             ],
-            "GID": 0,
+            "GID": 65535,
             "UID": 65535,
             "Username": ""
           }


### PR DESCRIPTION
When an image User value was set to user:group, genpolicy parsed the user portion but still derived the GID from /etc/passwd. That ignored explicit groups such as 33:10 or www-data:wheel.

Resolve numeric group IDs directly and named groups through /etc/group. Keep the /etc/passwd UID-to-GID lookup as the fallback when no explicit group is available. Update policy fixtures that use pause:3.6 as a normal container image to match the corrected image USER value.

Add unit coverage for numeric and named image groups, and update the policy tests that use pause:3.6 as a regular container image to expect the corrected GID and AdditionalGids values.

Fixes: #13263