### PR TITLE
runtime-rs: Add support Spdk vhost blk for Qemu

### DIFF
--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -303,6 +303,11 @@ pub const KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_NUM_QUEUES: &str =
 pub const KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_QUEUE_SIZE: &str =
     "io.katacontainers.config.hypervisor.block_device_queue_size";
 
+/// It is a sandbox annotation to specify the timeout for reconnecting on
+/// non-server sockets when the remote end goes away.
+pub const KATA_ANNO_CFG_HYPERVISOR_VHOST_USER_RECONNECT_TIMEOUT: &str =
+    "io.katacontainers.config.hypervisor.vhost_user_reconnect_timeout_sec";
+
 // Runtime related annotations
 /// Prefix for Runtime configurations.
 pub const KATA_ANNO_CFG_RUNTIME_PREFIX: &str = "io.katacontainers.config.runtime.";
@@ -1018,6 +1023,16 @@ impl Annotation {
                         match self.get_value::<u32>(key) {
                             Ok(v) => {
                                 hv.blockdev_info.queue_size = v.unwrap_or_default();
+                            }
+                            Err(_e) => {
+                                return Err(u32_err);
+                            }
+                        }
+                    }
+                    KATA_ANNO_CFG_HYPERVISOR_VHOST_USER_RECONNECT_TIMEOUT => {
+                        match self.get_value::<u32>(key) {
+                            Ok(v) => {
+                                hv.blockdev_info.vhost_user_reconnect_timeout_sec = v.unwrap_or_default();
                             }
                             Err(_e) => {
                                 return Err(u32_err);

--- a/src/libs/kata-types/src/annotations/mod.rs
+++ b/src/libs/kata-types/src/annotations/mod.rs
@@ -310,6 +310,11 @@ pub const KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_NUM_QUEUES: &str =
 pub const KATA_ANNO_CFG_HYPERVISOR_BLOCK_DEV_QUEUE_SIZE: &str =
     "io.katacontainers.config.hypervisor.block_device_queue_size";
 
+/// It is a sandbox annotation to specify the timeout for reconnecting on
+/// non-server sockets when the remote end goes away.
+pub const KATA_ANNO_CFG_HYPERVISOR_VHOST_USER_RECONNECT_TIMEOUT: &str =
+    "io.katacontainers.config.hypervisor.vhost_user_reconnect_timeout_sec";
+
 // Runtime related annotations
 /// Prefix for Runtime configurations.
 pub const KATA_ANNO_CFG_RUNTIME_PREFIX: &str = "io.katacontainers.config.runtime.";
@@ -1043,6 +1048,16 @@ impl Annotation {
                         match self.get_value::<u32>(key) {
                             Ok(v) => {
                                 hv.blockdev_info.queue_size = v.unwrap_or_default();
+                            }
+                            Err(_e) => {
+                                return Err(u32_err);
+                            }
+                        }
+                    }
+                    KATA_ANNO_CFG_HYPERVISOR_VHOST_USER_RECONNECT_TIMEOUT => {
+                        match self.get_value::<u32>(key) {
+                            Ok(v) => {
+                                hv.blockdev_info.vhost_user_reconnect_timeout_sec = v.unwrap_or_default();
                             }
                             Err(_e) => {
                                 return Err(u32_err);

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -310,6 +310,11 @@ pub struct BlockDeviceInfo {
     #[serde(default)]
     pub vhost_user_store_path: String,
 
+    /// The timeout for reconnecting on non-server spdk sockets when the remote
+    /// end goes away. Zero disables reconnecting, and is the default.
+    #[serde(default)]
+    pub vhost_user_reconnect_timeout_sec: u32,
+
     /// List of valid annotations values for the vhost user store path.
     ///
     /// The default if not set is empty (all annotations rejected.)

--- a/src/libs/kata-types/src/config/hypervisor/mod.rs
+++ b/src/libs/kata-types/src/config/hypervisor/mod.rs
@@ -313,6 +313,11 @@ pub struct BlockDeviceInfo {
     #[serde(default)]
     pub vhost_user_store_path: String,
 
+    /// The timeout for reconnecting on non-server spdk sockets when the remote
+    /// end goes away. Zero disables reconnecting, and is the default.
+    #[serde(default)]
+    pub vhost_user_reconnect_timeout_sec: u32,
+
     /// List of valid annotations values for the vhost user store path.
     ///
     /// The default if not set is empty (all annotations rejected.)

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -312,6 +312,11 @@ enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 # simulated block device nodes for vhost-user devices to live.
 vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 
+# The timeout for reconnecting on non-server spdk sockets when the remote end goes away.
+# qemu will delay this many seconds and then attempt to reconnect.
+# Zero disables reconnecting, and the default is zero.
+vhost_user_reconnect_timeout_sec = 0
+
 # Enable vIOMMU, default false
 # Enabling this will result in the VM having a vIOMMU device
 # This will also add the following options to the kernel's

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -328,6 +328,11 @@ enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 # simulated block device nodes for vhost-user devices to live.
 vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 
+# The timeout for reconnecting on non-server spdk sockets when the remote end goes away.
+# qemu will delay this many seconds and then attempt to reconnect.
+# Zero disables reconnecting, and the default is zero.
+vhost_user_reconnect_timeout_sec = 0
+
 # Enable vIOMMU, default false
 # Enabling this will result in the VM having a vIOMMU device
 # This will also add the following options to the kernel's

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -320,6 +320,11 @@ enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 # simulated block device nodes for vhost-user devices to live.
 vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 
+# The timeout for reconnecting on non-server spdk sockets when the remote end goes away.
+# qemu will delay this many seconds and then attempt to reconnect.
+# Zero disables reconnecting, and the default is zero.
+vhost_user_reconnect_timeout_sec = 0
+
 # Enable vIOMMU, default false
 # Enabling this will result in the VM having a vIOMMU device
 # This will also add the following options to the kernel's

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -303,6 +303,11 @@ enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 # simulated block device nodes for vhost-user devices to live.
 vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 
+# The timeout for reconnecting on non-server spdk sockets when the remote end goes away.
+# qemu will delay this many seconds and then attempt to reconnect.
+# Zero disables reconnecting, and the default is zero.
+vhost_user_reconnect_timeout_sec = 0
+
 # Enable vIOMMU, default false
 # Enabling this will result in the VM having a vIOMMU device
 # This will also add the following options to the kernel's

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -337,6 +337,11 @@ enable_hugepages = false
 # major range 240-254 being chosen to represent vhost-user devices.
 enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 
+# The timeout for reconnecting on non-server spdk sockets when the remote end goes away.
+# qemu will delay this many seconds and then attempt to reconnect.
+# Zero disables reconnecting, and the default is zero.
+vhost_user_reconnect_timeout_sec = 0
+
 # The base directory specifically used for vhost-user devices.
 # Its sub-path "block" is used for block devices; "block/sockets" is
 # where we expect vhost-user sockets to live; "block/devices" is where

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -353,6 +353,11 @@ enable_hugepages = false
 # major range 240-254 being chosen to represent vhost-user devices.
 enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 
+# The timeout for reconnecting on non-server spdk sockets when the remote end goes away.
+# qemu will delay this many seconds and then attempt to reconnect.
+# Zero disables reconnecting, and the default is zero.
+vhost_user_reconnect_timeout_sec = 0
+
 # The base directory specifically used for vhost-user devices.
 # Its sub-path "block" is used for block devices; "block/sockets" is
 # where we expect vhost-user sockets to live; "block/devices" is where

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -320,6 +320,11 @@ enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 # simulated block device nodes for vhost-user devices to live.
 vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 
+# The timeout for reconnecting on non-server spdk sockets when the remote end goes away.
+# qemu will delay this many seconds and then attempt to reconnect.
+# Zero disables reconnecting, and the default is zero.
+vhost_user_reconnect_timeout_sec = 0
+
 # Enable vIOMMU, default false
 # Enabling this will result in the VM having a vIOMMU device
 # This will also add the following options to the kernel's

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -336,6 +336,11 @@ enable_vhost_user_store = @DEFENABLEVHOSTUSERSTORE@
 # simulated block device nodes for vhost-user devices to live.
 vhost_user_store_path = "@DEFVHOSTUSERSTOREPATH@"
 
+# The timeout for reconnecting on non-server spdk sockets when the remote end goes away.
+# qemu will delay this many seconds and then attempt to reconnect.
+# Zero disables reconnecting, and the default is zero.
+vhost_user_reconnect_timeout_sec = 0
+
 # Enable vIOMMU, default false
 # Enabling this will result in the VM having a vIOMMU device
 # This will also add the following options to the kernel's

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user.rs
@@ -57,6 +57,10 @@ pub struct VhostUserConfig {
 
     /// device path in guest
     pub virt_path: String,
+
+    /// Reconnect timeout in seconds for the vhost-user socket.
+    /// Zero disables reconnecting. Only meaningful for QEMU chardev sockets.
+    pub reconnect_time: u32,
 }
 
 #[derive(Debug, Clone, Default)]

--- a/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user_blk.rs
+++ b/src/runtime-rs/crates/hypervisor/src/device/driver/vhost_user_blk.rs
@@ -63,13 +63,18 @@ impl Device for VhostUserBlkDevice {
             return Ok(());
         }
 
-        if let Err(e) = h.add_device(DeviceType::VhostUserBlk(self.clone())).await {
-            self.decrease_attach_count().await?;
-
-            return Err(e);
+        match h.add_device(DeviceType::VhostUserBlk(self.clone())).await {
+            Ok(dev) => {
+                if let DeviceType::VhostUserBlk(blk) = dev {
+                    self.config = blk.config;
+                }
+                Ok(())
+            }
+            Err(e) => {
+                self.decrease_attach_count().await?;
+                Err(e)
+            }
         }
-
-        return Ok(());
     }
 
     async fn detach(

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -959,10 +959,12 @@ impl QemuInner {
                 qmp.hotunplug_block_device(&driver, index)
                     .context("hotunplug block device")?;
             }
+            DeviceType::VhostUserBlk(vhu_blk_dev) => {
+                qmp.hotunplug_vhost_user_blk_device(&vhu_blk_dev.device_id)?;
+            }
             DeviceType::Network(_)
             | DeviceType::Vfio(_)
             | DeviceType::VfioModern(_)
-            | DeviceType::VhostUserBlk(_)
             | DeviceType::VhostUserNetwork(_)
             | DeviceType::ShareFs(_)
             | DeviceType::HybridVsock(_)

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -1192,6 +1192,17 @@ impl QemuInner {
                     );
                 }
             }
+            DeviceType::VhostUserBlk(mut vhu_blk_dev) => {
+                let pci_path = qmp.hotplug_vhost_user_blk_device(
+                    &vhu_blk_dev.device_id,
+                    &vhu_blk_dev.config.socket_path,
+                    vhu_blk_dev.config.num_queues,
+                    vhu_blk_dev.config.queue_size,
+                    vhu_blk_dev.config.reconnect_time,
+                )?;
+                vhu_blk_dev.config.pci_path = Some(pci_path);
+                return Ok(DeviceType::VhostUserBlk(vhu_blk_dev));
+            }
             _ => info!(
                 sl!(),
                 "Hotplugging for {:#?} is currently unsupported", device

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -1122,10 +1122,12 @@ impl QemuInner {
                 qmp.hotunplug_block_device(&driver, index)
                     .context("hotunplug block device")?;
             }
+            DeviceType::VhostUserBlk(vhu_blk_dev) => {
+                qmp.hotunplug_vhost_user_blk_device(&vhu_blk_dev.device_id)?;
+            }
             DeviceType::Network(_)
             | DeviceType::Vfio(_)
             | DeviceType::VfioModern(_)
-            | DeviceType::VhostUserBlk(_)
             | DeviceType::VhostUserNetwork(_)
             | DeviceType::ShareFs(_)
             | DeviceType::HybridVsock(_)

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -1350,6 +1350,17 @@ impl QemuInner {
                     );
                 }
             }
+            DeviceType::VhostUserBlk(mut vhu_blk_dev) => {
+                let pci_path = qmp.hotplug_vhost_user_blk_device(
+                    &vhu_blk_dev.device_id,
+                    &vhu_blk_dev.config.socket_path,
+                    vhu_blk_dev.config.num_queues,
+                    vhu_blk_dev.config.queue_size,
+                    vhu_blk_dev.config.reconnect_time,
+                )?;
+                vhu_blk_dev.config.pci_path = Some(pci_path);
+                return Ok(DeviceType::VhostUserBlk(vhu_blk_dev));
+            }
             _ => info!(
                 sl!(),
                 "Hotplugging for {:#?} is currently unsupported", device

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -1257,6 +1257,30 @@ impl Qmp {
         Ok(pci_path)
     }
 
+    pub fn hotunplug_vhost_user_blk_device(&mut self, device_id: &str) -> Result<()> {
+        let chardev_id = format!("char-{device_id}");
+
+        self.qmp
+            .execute(&qmp::device_del {
+                id: device_id.to_string(),
+            })
+            .map_err(|e| anyhow!("device_del {}: {:?}", device_id, e))?;
+
+        // device_del is asynchronous — wait for the guest to acknowledge
+        // before tearing down the chardev backend.
+        self.wait_for_device_deleted(device_id, DEVICE_DELETED_TIMEOUT)
+            .context("hotunplug_vhost_user_blk_device: waiting for DEVICE_DELETED")?;
+
+        self.qmp
+            .execute(&qmp::chardev_remove {
+                id: chardev_id.clone(),
+            })
+            .map_err(|e| anyhow!("chardev-remove {}: {:?}", chardev_id, e))
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
     pub fn qmp_stop(&mut self) -> Result<()> {
         self.qmp
             .execute(&qmp::stop {})

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -16,7 +16,8 @@ use nix::sys::socket::{sendmsg, ControlMessage, MsgFlags};
 use qapi_qmp::{
     self as qmp, BlockdevAioOptions, BlockdevOptions, BlockdevOptionsBase,
     BlockdevOptionsGenericCOWFormat, BlockdevOptionsGenericFormat, BlockdevOptionsRaw, BlockdevRef,
-    MigrationInfo, PciDeviceInfo,
+    ChardevBackend, ChardevCommon, ChardevSocket as QmpChardevSocket, ChardevSocketWrapper,
+    MigrationInfo, PciDeviceInfo, SocketAddressLegacy, UnixSocketAddress, UnixSocketAddressWrapper,
 };
 use qapi_qmp::{migrate, migrate_incoming, migrate_set_capabilities};
 use qapi_qmp::{MigrationCapability, MigrationCapabilityStatus};
@@ -1174,6 +1175,86 @@ impl Qmp {
             .context("get device by qdev_id failed")?;
 
         Ok(Some(pci_path))
+    }
+
+    pub fn hotplug_vhost_user_blk_device(
+        &mut self,
+        device_id: &str,
+        socket_path: &str,
+        num_queues: usize,
+        queue_size: u32,
+        reconnect_timeout: u32,
+    ) -> Result<PciPath> {
+        let unix_path = socket_path
+            .split_once("://")
+            .map(|(_, p)| p)
+            .unwrap_or(socket_path);
+
+        let chardev_id = format!("char-{device_id}");
+
+        let chardev_socket = QmpChardevSocket {
+            base: ChardevCommon {
+                logappend: None,
+                logfile: None,
+            },
+            addr: SocketAddressLegacy::unix(UnixSocketAddressWrapper::from(UnixSocketAddress {
+                path: unix_path.to_owned(),
+                abstract_: None,
+                tight: None,
+            })),
+            server: Some(false),
+            reconnect: if reconnect_timeout > 0 {
+                Some(reconnect_timeout as i64)
+            } else {
+                None
+            },
+            nodelay: None,
+            telnet: None,
+            tls_authz: None,
+            tls_creds: None,
+            tn3270: None,
+            wait: None,
+            websocket: None,
+        };
+
+        self.qmp
+            .execute(&qmp::chardev_add {
+                id: chardev_id.clone(),
+                backend: ChardevBackend::socket(ChardevSocketWrapper::from(chardev_socket)),
+            })
+            .map_err(|e| anyhow!("chardev-add {:?}", e))
+            .map(|_| ())?;
+
+        let mut device_args = Dictionary::new();
+        device_args.insert("chardev".to_owned(), chardev_id.clone().into());
+        if num_queues > 0 {
+            device_args.insert("num-queues".to_owned(), (num_queues as i64).into());
+        }
+        if queue_size > 0 {
+            device_args.insert("queue-size".to_owned(), (queue_size as i64).into());
+        }
+
+        let (bus, slot) = self.find_free_slot()?;
+        device_args.insert("addr".to_owned(), format!("{slot:02}").into());
+
+        let result = self.qmp.execute(&qmp::device_add {
+            bus: Some(bus),
+            id: Some(device_id.to_string()),
+            driver: "vhost-user-blk-pci".to_string(),
+            arguments: device_args,
+        });
+        if let Err(e) = result {
+            let _ = self.qmp.execute(&qmp::chardev_remove {
+                id: chardev_id,
+            });
+            return Err(anyhow!("device_add vhost-user-blk-pci {:?}", e));
+        }
+
+        let pci_path = self
+            .get_device_by_qdev_id(device_id)
+            .context("get device by qdev_id failed")?;
+
+        Ok(pci_path)
     }
 
     pub fn qmp_stop(&mut self) -> Result<()> {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -1615,6 +1615,30 @@ impl Qmp {
         Ok(pci_path)
     }
 
+    pub fn hotunplug_vhost_user_blk_device(&mut self, device_id: &str) -> Result<()> {
+        let chardev_id = format!("char-{device_id}");
+
+        self.qmp
+            .execute(&qmp::device_del {
+                id: device_id.to_string(),
+            })
+            .map_err(|e| anyhow!("device_del {}: {:?}", device_id, e))?;
+
+        // device_del is asynchronous — wait for the guest to acknowledge
+        // before tearing down the chardev backend.
+        self.wait_for_device_deleted(device_id, DEVICE_DELETED_TIMEOUT)
+            .context("hotunplug_vhost_user_blk_device: waiting for DEVICE_DELETED")?;
+
+        self.qmp
+            .execute(&qmp::chardev_remove {
+                id: chardev_id.clone(),
+            })
+            .map_err(|e| anyhow!("chardev-remove {}: {:?}", chardev_id, e))
+            .map(|_| ())?;
+
+        Ok(())
+    }
+
     pub fn qmp_stop(&mut self) -> Result<()> {
         self.qmp
             .execute(&qmp::stop {})

--- a/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/qmp.rs
@@ -16,7 +16,8 @@ use nix::sys::socket::{sendmsg, ControlMessage, MsgFlags};
 use qapi_qmp::{
     self as qmp, BlockdevAioOptions, BlockdevDiscardOptions, BlockdevOptions, BlockdevOptionsBase,
     BlockdevOptionsGenericCOWFormat, BlockdevOptionsGenericFormat, BlockdevOptionsRaw, BlockdevRef,
-    MigrationInfo, PciDeviceInfo,
+    ChardevBackend, ChardevCommon, ChardevSocket as QmpChardevSocket, ChardevSocketWrapper,
+    MigrationInfo, PciDeviceInfo, SocketAddressLegacy, UnixSocketAddress, UnixSocketAddressWrapper,
 };
 use qapi_qmp::{migrate, migrate_incoming, migrate_set_capabilities};
 use qapi_qmp::{MigrationCapability, MigrationCapabilityStatus};
@@ -1532,6 +1533,86 @@ impl Qmp {
             .context("get device by qdev_id failed")?;
 
         Ok(Some(pci_path))
+    }
+
+    pub fn hotplug_vhost_user_blk_device(
+        &mut self,
+        device_id: &str,
+        socket_path: &str,
+        num_queues: usize,
+        queue_size: u32,
+        reconnect_timeout: u32,
+    ) -> Result<PciPath> {
+        let unix_path = socket_path
+            .split_once("://")
+            .map(|(_, p)| p)
+            .unwrap_or(socket_path);
+
+        let chardev_id = format!("char-{device_id}");
+
+        let chardev_socket = QmpChardevSocket {
+            base: ChardevCommon {
+                logappend: None,
+                logfile: None,
+            },
+            addr: SocketAddressLegacy::unix(UnixSocketAddressWrapper::from(UnixSocketAddress {
+                path: unix_path.to_owned(),
+                abstract_: None,
+                tight: None,
+            })),
+            server: Some(false),
+            reconnect: if reconnect_timeout > 0 {
+                Some(reconnect_timeout as i64)
+            } else {
+                None
+            },
+            nodelay: None,
+            telnet: None,
+            tls_authz: None,
+            tls_creds: None,
+            tn3270: None,
+            wait: None,
+            websocket: None,
+        };
+
+        self.qmp
+            .execute(&qmp::chardev_add {
+                id: chardev_id.clone(),
+                backend: ChardevBackend::socket(ChardevSocketWrapper::from(chardev_socket)),
+            })
+            .map_err(|e| anyhow!("chardev-add {:?}", e))
+            .map(|_| ())?;
+
+        let mut device_args = Dictionary::new();
+        device_args.insert("chardev".to_owned(), chardev_id.clone().into());
+        if num_queues > 0 {
+            device_args.insert("num-queues".to_owned(), (num_queues as i64).into());
+        }
+        if queue_size > 0 {
+            device_args.insert("queue-size".to_owned(), (queue_size as i64).into());
+        }
+
+        let (bus, slot) = self.find_free_slot()?;
+        device_args.insert("addr".to_owned(), format!("{slot:02}").into());
+
+        let result = self.qmp.execute(&qmp::device_add {
+            bus: Some(bus),
+            id: Some(device_id.to_string()),
+            driver: "vhost-user-blk-pci".to_string(),
+            arguments: device_args,
+        });
+        if let Err(e) = result {
+            let _ = self.qmp.execute(&qmp::chardev_remove {
+                id: chardev_id,
+            });
+            return Err(anyhow!("device_add vhost-user-blk-pci {:?}", e));
+        }
+
+        let pci_path = self
+            .get_device_by_qdev_id(device_id)
+            .context("get device by qdev_id failed")?;
+
+        Ok(pci_path)
     }
 
     pub fn qmp_stop(&mut self) -> Result<()> {

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
@@ -74,12 +74,13 @@ impl SPDKVolume {
             }
         }
 
-        let block_driver = get_block_device_info(d).await.block_device_driver;
+        let block_dev_info = get_block_device_info(d).await;
 
         let vhu_blk_config = &mut VhostUserConfig {
             socket_path: device,
             device_type: VhostUserType::Blk,
-            driver_option: block_driver,
+            driver_option: block_dev_info.block_device_driver,
+            reconnect_time: block_dev_info.vhost_user_reconnect_timeout_sec,
             ..Default::default()
         };
 

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
@@ -113,10 +113,14 @@ impl SPDKVolume {
 
         let mut device_id = String::new();
         if let DeviceType::VhostUserBlk(device) = device_info {
-            // blk, mmioblk
-            storage.driver = device.config.driver_option;
-            // /dev/vdX
-            storage.source = device.config.virt_path;
+            storage.driver = device.config.driver_option.clone();
+            // Use PCI path so the agent can wait for the device to appear,
+            // falling back to virt_path (/dev/vdX) for non-PCI transports.
+            storage.source = if let Some(ref pci_path) = device.config.pci_path {
+                pci_path.to_string()
+            } else {
+                device.config.virt_path.clone()
+            };
             device_id = device.device_id;
         }
 

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
@@ -77,12 +77,13 @@ impl SPDKVolume {
             }
         }
 
-        let block_driver = get_block_device_info(d).await.block_device_driver;
+        let block_dev_info = get_block_device_info(d).await;
 
         let vhu_blk_config = &mut VhostUserConfig {
             socket_path: device,
             device_type: VhostUserType::Blk,
-            driver_option: block_driver,
+            driver_option: block_dev_info.block_device_driver,
+            reconnect_time: block_dev_info.vhost_user_reconnect_timeout_sec,
             ..Default::default()
         };
 

--- a/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
+++ b/src/runtime-rs/crates/resource/src/volume/direct_volumes/spdk_volume.rs
@@ -124,10 +124,14 @@ impl SPDKVolume {
 
         let mut device_id = String::new();
         if let DeviceType::VhostUserBlk(device) = device_info {
-            // blk, mmioblk
-            storage.driver = device.config.driver_option;
-            // /dev/vdX
-            storage.source = device.config.virt_path;
+            storage.driver = device.config.driver_option.clone();
+            // Use PCI path so the agent can wait for the device to appear,
+            // falling back to virt_path (/dev/vdX) for non-PCI transports.
+            storage.source = if let Some(ref pci_path) = device.config.pci_path {
+                pci_path.to_string()
+            } else {
+                device.config.virt_path.clone()
+            };
             device_id = device.device_id;
         }
 


### PR DESCRIPTION
# The test steps and the result report
```shell
root@kata-dev:/home/spdk# build/bin/vhost -S /var/tmp -m 0x4 -r /var/tmp/spdk_vhost.sock &
[1] 157
root@kata-dev:/home/spdk# [2026-06-23 17:24:50.038841] Starting SPDK v26.09-pre git sha1 d50ed6832 / DPDK 26.03.0 initialization...
[2026-06-23 17:24:50.038950] [ DPDK EAL parameters: vhost --no-shconf -l 2 --huge-unlink --no-telemetry --log-level=lib.eal:6 --log-level=lib.cryptodev:5 --log-level=lib.power:5 --log-level=user1:6 --base-virtaddr=0x200000000000 --match-allocations --file-prefix=spdk_pid157 ]
[2026-06-23 17:24:50.386307] app.c: 993:spdk_app_start: *NOTICE*: Total cores available: 1
[2026-06-23 17:24:50.409355] reactor.c: 996:reactor_run: *NOTICE*: Reactor started on core 2
root@kata-dev:/home/spdk# dd if=/dev/zero of=/var/tmp/raw.disk bs=1M count=2048
2048+0 records in
2048+0 records out
2147483648 bytes (2.1 GB, 2.0 GiB) copied, 13.654 s, 157 MB/s
root@kata-dev:/home/spdk# mkfs.ext4  /var/tmp/raw.disk
mke2fs 1.47.2 (1-Jan-2025)
Discarding device blocks: done                            
Creating filesystem with 524288 4k blocks and 131072 inodes
Filesystem UUID: 649a3394-dd85-4a9f-b325-00e94113ad0a
Superblock backups stored on blocks: 
	32768, 98304, 163840, 229376, 294912

Allocating group tables: done                            
Writing inode tables: done                            
Creating journal (16384 blocks): done
Writing superblocks and filesystem accounting information: done 

root@kata-dev:/home/spdk# ./scripts/rpc.py -s /var/tmp/spdk_vhost.sock bdev_aio_create /var/tmp/raw.disk aio0 512
aio0
root@kata-dev:/home/spdk# ./scripts/rpc.py -s /var/tmp/spdk_vhost.sock vhost_create_blk_controller vhost-target1.sock aio0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) logging feature is disabled in async copy mode
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vhost-user server: socket created, fd: 220
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) binding succeeded
root@kata-dev:/home/spdk# ls /var/tmp/vhost-target1.sock
/var/tmp/vhost-target1.sock
root@kata-dev:/home/spdk# 

JSON='{"volume-type":"spdkvol","device":"/var/tmp/vhost-target1.sock","fstype":"ext4","metadata":{"num_queues":"4","queue_size":"1024"}}'
root@kata-dev# kata-ctl direct-volume add /xxx/spdk-disk "$JSON"
root@kata-dev# cat /run/kata-containers/shared/direct-volumes/L3h4eC9zcGRrLWRpc2s\=/mountInfo.json |jq
{
  "volume-type": "spdkvol",
  "device": "/var/tmp/vhost-target1.sock",
  "fstype": "ext4",
  "metadata": {
    "num_queues": "4",
    "queue_size": "1024"
  }
}

# ctr run -t --rm --runtime io.containerd.kata.v2 --mount type=spdkvol,src=/xxx/spdk-disk,dst=/disk001,options=rbind:rw "$image" kata-spdk-vol-6 /bin/bash
WARN[0000] DEPRECATION: The support for cgroup v1 is deprecated since containerd v2.2 and will be removed by no later than May 2029. Upgrade the host to use cgroup v2. 
[root@ad791292e96e /]# cd disk001/
[root@ad791292e96e disk001]# pwd
/disk001
[root@ad791292e96e disk001]# 

# SPDK log

```shell
root@kata-dev:/home/spdk# VHOST_CONFIG: (/var/tmp/vhost-target1.sock) new vhost user connection is 45
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) new device, handle is 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_GET_FEATURES
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_GET_PROTOCOL_FEATURES
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_PROTOCOL_FEATURES
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) negotiated Vhost-user protocol features: 0x11ebf
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_GET_QUEUE_NUM
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_BACKEND_REQ_FD
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_OWNER
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_GET_FEATURES
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_CALL
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring call idx:0 file:224
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_ERR
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_CALL
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring call idx:1 file:225
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_ERR
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_CALL
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring call idx:2 file:226
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_ERR
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_CALL
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring call idx:3 file:227
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_ERR
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_GET_CONFIG
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_FEATURES
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) negotiated Virtio features: 0x150005646
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_GET_STATUS
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_STATUS
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) new device status(0x00000008):
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-RESET: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-ACKNOWLEDGE: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-DRIVER: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-FEATURES_OK: 1
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-DRIVER_OK: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-DEVICE_NEED_RESET: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-FAILED: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_GET_INFLIGHT_FD
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) get_inflight_fd num_queues: 4
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) get_inflight_fd queue_size: 1024
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) send inflight mmap_size: 65792
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) send inflight mmap_offset: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) send inflight fd: 228
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_INFLIGHT_FD
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set_inflight_fd mmap_size: 65792
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set_inflight_fd mmap_offset: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set_inflight_fd num_queues: 4
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set_inflight_fd queue_size: 1024
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set_inflight_fd fd: 229
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set_inflight_fd pervq_inflight_size: 16448
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_CALL
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring call idx:0 file:228
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_CALL
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring call idx:1 file:224
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_CALL
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring call idx:2 file:225
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_CALL
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring call idx:3 file:226
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_FEATURES
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) negotiated Virtio features: 0x150005646
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_GET_STATUS
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_MEM_TABLE
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) guest memory region size: 0x80000000
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	 guest physical addr: 0x0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	 guest virtual  addr: 0x7fa92ffff000
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	 host  virtual  addr: 0x7fa600000000
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	 mmap addr : 0x7fa600000000
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	 mmap size : 0x80000000
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	 mmap align: 0x1000
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	 mmap off  : 0x0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_NUM
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_BASE
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring base idx:0 last_used_idx:0 last_avail_idx:0.
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_ADDR
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_KICK
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) vring kick idx:0 file:231
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) reallocated virtqueue on node 7
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) reallocated device on node 7
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_ENABLE
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set queue enable: 1 to qp idx: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_ENABLE
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set queue enable: 1 to qp idx: 1
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_ENABLE
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set queue enable: 1 to qp idx: 2
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_VRING_ENABLE
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) set queue enable: 1 to qp idx: 3
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_GET_STATUS
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) read message VHOST_USER_SET_STATUS
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) new device status(0x0000000f):
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-RESET: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-ACKNOWLEDGE: 1
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-DRIVER: 1
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-FEATURES_OK: 1
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-DRIVER_OK: 1
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-DEVICE_NEED_RESET: 0
VHOST_CONFIG: (/var/tmp/vhost-target1.sock) 	-FAILED: 0
```

# Reference
- https://github.com/kata-containers/kata-containers/blob/main/docs/how-to/how-to-run-kata-containers-with-kinds-of-Block-Volumes.md#spdk-device-based-block-volume
- https://spdk.io/doc/vhost.html