### PR TITLE
runtime: wait for qemu process to exit before cleaning up.

### DIFF
--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -1745,15 +1745,18 @@ func (q *qemu) StopVM(ctx context.Context, waitOnly bool) (err error) {
 	}
 	pid := pids[0]
 	if pid > 0 {
-		if waitOnly {
-			err := utils.WaitLocalProcess(pid, qemuStopSandboxTimeoutSecs, syscall.Signal(0), q.Logger())
-			if err != nil {
-				return err
-			}
-		} else {
+		if !waitOnly {
 			err = syscall.Kill(pid, syscall.SIGKILL)
 			if err != nil {
 				q.Logger().WithError(err).Error("Fail to send SIGKILL to qemu")
+				return err
+			}
+		}
+		// Wait for QEMU to actually exit regardless of whether we issued the kill syscall.
+		// Without this, the caller may proceeds to delete the sandbox cgroup while QEMU threads
+		// are still alive in it, making the cgroup undeletable.
+		if err := utils.WaitLocalProcess(pid, qemuStopSandboxTimeoutSecs, syscall.Signal(0), q.Logger()); err != nil {
+			if waitOnly {
 				return err
 			}
 		}


### PR DESCRIPTION
This PR addresses https://github.com/kata-containers/kata-containers/issues/13265

In production, we have seen issues such as:
```
msg="failed to cleanup the LinuxCgroup:/k8s.io/kata_ctr-test-kata-qemu-BnSNb resource controllers" error="cgroups: unable to remove path \"/sys/fs/cgroup/k8s.io/kata_ctr-test-kata-qemu-BnSNb\": still contains running processes" name=containerd-shim-v2 pid=3241619 sandbox=ctr-test-kata-qemu-BnSNb source=virtcontainers subsystem=sandbox
```

This commit fixes this.