### PR TITLE
tests: guard teardown in k8s-qos-pods.bats against skipped tests

### DIFF
--- a/tests/integration/kubernetes/k8s-qos-pods.bats
+++ b/tests/integration/kubernetes/k8s-qos-pods.bats
@@ -77,7 +77,7 @@ setup() {
 }
 
 teardown() {
-	kubectl delete pod "$pod_name"
-	delete_tmp_policy_settings_dir "${policy_settings_dir}"
+	[[ -n "${pod_name:-}" ]] && kubectl delete pod "${pod_name}"
+	[[ -n "${policy_settings_dir:-}" ]] && delete_tmp_policy_settings_dir "${policy_settings_dir}"
 	teardown_common "${node}" "${node_start_time:-}"
 }


### PR DESCRIPTION
When a bats test is skipped, teardown() still runs but the test body variables (pod_name, policy_settings_dir) are never set. This causes kubectl delete and delete_tmp_policy_settings_dir to fail, making bats report an error and exit 1 — turning a skip into a failure.

Guard the teardown operations with variable-existence checks so they are no-ops when the test was skipped.

Fixes: #13229. Related #13228.

Assisted By: Claude <noreply@anthropic.com>