### PR TITLE
runtime-rs: fallback to NoProtection when SEV CPU support check fails

### DIFF
--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -153,16 +153,17 @@ pub fn arch_guest_protection(
     let is_snp_available = check_contents(snp_path)?;
     let is_sev_available = is_snp_available || check_contents(sev_path)?;
     if is_snp_available || is_sev_available {
-        let (cbitpos, phys_addr_reduction) = retrieve_sev_params()?;
-        let sev_snp_details = SevSnpDetails {
-            cbitpos,
-            phys_addr_reduction,
-        };
-        return Ok(if is_snp_available {
-            GuestProtection::Snp(sev_snp_details)
-        } else {
-            GuestProtection::Sev(sev_snp_details)
-        });
+        if let Ok((cbitpos, phys_addr_reduction)) = retrieve_sev_params() {
+            let sev_snp_details = SevSnpDetails {
+                cbitpos,
+                phys_addr_reduction,
+            };
+            return Ok(if is_snp_available {
+                GuestProtection::Snp(sev_snp_details)
+            } else {
+                GuestProtection::Sev(sev_snp_details)
+            });
+        }
     }
 
     Ok(GuestProtection::NoProtection)

--- a/src/libs/kata-sys-util/src/protection.rs
+++ b/src/libs/kata-sys-util/src/protection.rs
@@ -153,16 +153,25 @@ pub fn arch_guest_protection(
     let is_snp_available = check_contents(snp_path)?;
     let is_sev_available = is_snp_available || check_contents(sev_path)?;
     if is_snp_available || is_sev_available {
-        if let Ok((cbitpos, phys_addr_reduction)) = retrieve_sev_params() {
-            let sev_snp_details = SevSnpDetails {
-                cbitpos,
-                phys_addr_reduction,
-            };
-            return Ok(if is_snp_available {
-                GuestProtection::Snp(sev_snp_details)
-            } else {
-                GuestProtection::Sev(sev_snp_details)
-            });
+        match retrieve_sev_params() {
+            Ok((cbitpos, phys_addr_reduction)) => {
+                let sev_snp_details = SevSnpDetails {
+                    cbitpos,
+                    phys_addr_reduction,
+                };
+                return Ok(if is_snp_available {
+                    GuestProtection::Snp(sev_snp_details)
+                } else {
+                    GuestProtection::Sev(sev_snp_details)
+                });
+            }
+            Err(e) => {
+                warn!(
+                    crate::sl!(),
+                    "SEV/SNP advertised by KVM module but CPU/firmware check failed ({}); falling back to no protection",
+                    e,
+                );
+            }
         }
     }
 


### PR DESCRIPTION
On hosts where the kvm_amd kernel module has sev=Y (for example, the module was compiled with CONFIG_KVM_AMD_SEV=y and the parameter defaults to enabled), but the CPU or BIOS does not actually support SEV, runtime-rs fails to create a sandbox with:
Failed to check guest protection: SEV not supported This happens in available_guest_protection() in
src/libs/kata-sys-util/src/protection.rs. The function sees sev=Y from /sys/module/kvm_amd/parameters/sev, calls retrieve_sev_params(), which checks CPUID and fails. The error propagates up and aborts VM creation, even when confidential guests are not requested.
Fix this by catching the error from retrieve_sev_params() and falling back to GuestProtection::NoProtection, allowing normal (non-confidential) VMs to run on systems where the kernel module advertises SEV but the hardware/firmware does not actually support it.