### PR TITLE
runtime-rs: ch: charge guest memory to the pod cgroup

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner.rs
@@ -78,6 +78,12 @@ pub struct CloudHypervisorInner {
     pub(crate) guest_memory_block_size_mb: u32,
 
     pub(crate) exit_notify: Option<mpsc::Sender<i32>>,
+
+    /// Host cgroup v2 `cgroup.procs` path the VMM joins before the guest
+    /// boots, so the guest RAM faulted during boot is charged to the pod
+    /// cgroup. `None` when spawn-time placement is not requested (e.g.
+    /// cgroup v1, which uses the post-boot vCPU-thread move instead).
+    pub(crate) vmm_cgroup_path: Option<String>,
 }
 
 const CH_DEFAULT_TIMEOUT_SECS: u32 = 10;
@@ -120,7 +126,12 @@ impl CloudHypervisorInner {
             guest_memory_block_size_mb: 0,
 
             exit_notify,
+            vmm_cgroup_path: None,
         }
+    }
+
+    pub(crate) fn set_vmm_cgroup_path(&mut self, cgroup_procs_path: String) {
+        self.vmm_cgroup_path = Some(cgroup_procs_path);
     }
 
     pub fn set_hypervisor_config(&mut self, mut config: HypervisorConfig) {

--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_hypervisor.rs
@@ -391,7 +391,44 @@ impl CloudHypervisorInner {
 
         unsafe {
             let selinux_label = self.config.security_info.selinux_label.clone();
+            let vmm_cgroup_path = self.vmm_cgroup_path.clone();
             let _pre = cmd.pre_exec(move || {
+                // Join the pod sandbox cgroup *before* exec (and therefore
+                // before the guest boots) so that every page the guest RAM
+                // first-touches during boot is charged to the pod cgroup.
+                // Under cgroup v2 there is no re-charging of already-faulted
+                // pages on migration, so placing the VMM here is the only way
+                // to account the guest's memory to the pod rather than to the
+                // cgroup the shim happened to spawn the VMM in.
+                if let Some(cgroup_procs) = &vmm_cgroup_path {
+                    use std::io::Write;
+                    // After fork() this returns the child's own PID, which is
+                    // the VMM process being exec'd next.
+                    let pid = std::process::id();
+                    // Open cgroup.procs write-only (no create/truncate): it is
+                    // a cgroupfs pseudo-file, so O_CREAT/O_TRUNC are pointless
+                    // and only add portability risk. Writing the pid with a
+                    // trailing newline is the conventional form.
+                    let res = std::fs::OpenOptions::new()
+                        .write(true)
+                        .open(cgroup_procs)
+                        .and_then(|mut f| f.write_all(format!("{pid}\n").as_bytes()));
+                    if let Err(e) = res {
+                        error!(
+                            sl!(),
+                            "Failed to move VMM into sandbox cgroup {}: {}", cgroup_procs, e
+                        );
+                        // Don't return error here to avoid breaking VM
+                        // startup; log and continue.
+                    } else {
+                        info!(
+                            sl!(),
+                            "Moved VMM (pid {}) into sandbox cgroup before boot: {}",
+                            pid,
+                            cgroup_procs
+                        );
+                    }
+                }
                 if let Some(netns_path) = &netns {
                     let netns_fd = std::fs::File::open(netns_path);
                     let _ = setns(&netns_fd?, CloneFlags::CLONE_NEWNET).context("set netns failed");

--- a/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/mod.rs
@@ -76,6 +76,12 @@ impl Hypervisor for CloudHypervisor {
         inner.start_vm(timeout).await
     }
 
+    async fn set_vmm_cgroup_path(&self, cgroup_procs_path: String) -> Result<()> {
+        let mut inner = self.inner.write().await;
+        inner.set_vmm_cgroup_path(cgroup_procs_path);
+        Ok(())
+    }
+
     async fn stop_vm(&self) -> Result<()> {
         let mut inner = self.inner.write().await;
         inner.stop_vm().await

--- a/src/runtime-rs/crates/hypervisor/src/lib.rs
+++ b/src/runtime-rs/crates/hypervisor/src/lib.rs
@@ -163,6 +163,22 @@ pub trait Hypervisor: std::fmt::Debug + Send + Sync {
     async fn guest_memory_block_size(&self) -> u32;
     async fn get_passfd_listener_addr(&self) -> Result<(String, u32)>;
 
+    /// Set the host cgroup v2 `cgroup.procs` path that the VMM process should
+    /// join *before* the guest boots.
+    ///
+    /// Under cgroup v2, memory is charged to whichever cgroup first-touches
+    /// each page, and already-faulted pages are not re-charged on migration.
+    /// Placing the VMM into the pod's sandbox cgroup before boot ensures the
+    /// guest RAM faulted during boot is accounted to the pod cgroup rather
+    /// than to the cgroup the VMM happened to be spawned in
+    /// (e.g. `system.slice/containerd.service`).
+    ///
+    /// Default: no-op for hypervisors that do not implement spawn-time
+    /// cgroup placement.
+    async fn set_vmm_cgroup_path(&self, _cgroup_procs_path: String) -> Result<()> {
+        Ok(())
+    }
+
     /// Resolve the in-guest PCIe path for a cold-plugged physical-endpoint VF
     /// by querying QMP (query-pci + device search by QEMU device ID).
     /// Only meaningful after the VM has started and QMP is initialised.

--- a/src/runtime-rs/crates/resource/src/cgroups/resource.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/resource.rs
@@ -66,6 +66,14 @@ impl CgroupsResource {
         let mut inner = self.inner.write().await;
         inner.setup_after_start_vm(hypervisor).await
     }
+
+    /// Absolute path to the sandbox cgroup's `cgroup.procs` file for cgroup
+    /// v2, used to place the VMM into the pod cgroup before the guest boots.
+    /// Returns `None` for cgroup v1.
+    pub async fn sandbox_cgroup_procs_path(&self) -> Option<String> {
+        let inner = self.inner.read().await;
+        inner.sandbox_cgroup_procs_path()
+    }
 }
 
 #[async_trait]

--- a/src/runtime-rs/crates/resource/src/cgroups/resource_inner.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/resource_inner.rs
@@ -220,6 +220,40 @@ impl CgroupsResourceInner {
         Ok(hv_pids.vcpus.len())
     }
 
+    /// Absolute path to the sandbox cgroup's `cgroup.procs` file for cgroup
+    /// v2.
+    ///
+    /// The VMM (e.g. cloud-hypervisor) is moved into this cgroup *at spawn
+    /// time*, before the guest boots, so that the guest RAM faulted during
+    /// boot is charged to the pod cgroup. This is required because cgroup v2
+    /// charges memory to whichever cgroup first-touches each page and never
+    /// re-charges already-faulted pages on migration; moving the VMM after
+    /// the guest has booted (e.g. in `setup_after_start_vm`) leaves the
+    /// guest RAM charged to the cgroup the VMM was spawned in.
+    ///
+    /// Returns `None` for cgroup v1, where the existing vCPU-thread move
+    /// path is used instead, and when an overhead cgroup is in use
+    /// (`sandbox_cgroup_only=false`), where the VMM is deliberately kept out
+    /// of the pod cgroup to avoid pod-limit/OOM risk.
+    pub(crate) fn sandbox_cgroup_procs_path(&self) -> Option<String> {
+        // Spawn-time VMM placement is only required/desired when the sandbox
+        // cgroup is meant to contain all Kata processes
+        // (sandbox_cgroup_only=true, i.e. overhead_cgroup is None).
+        if self.overhead_cgroup.is_some() || !self.sandbox_cgroup.v2() {
+            return None;
+        }
+        match self.sandbox_cgroup.cgroup_path(None) {
+            Ok(dir) => Some(format!("{}/cgroup.procs", dir.trim_end_matches('/'))),
+            Err(e) => {
+                warn!(
+                    sl!(),
+                    "failed to resolve sandbox cgroup path for VMM placement: {}", e
+                );
+                None
+            }
+        }
+    }
+
     async fn update_sandbox_cgroups(&mut self, hypervisor: &dyn Hypervisor) -> Result<bool> {
         let needs_thread_ids = self.overhead_cgroup.is_some() || self.enable_vcpus_pinning;
 

--- a/src/runtime-rs/crates/resource/src/manager_inner.rs
+++ b/src/runtime-rs/crates/resource/src/manager_inner.rs
@@ -230,6 +230,17 @@ impl ResourceManagerInner {
             };
         }
 
+        // Under cgroup v2, tell the hypervisor which sandbox cgroup the VMM
+        // must join at spawn time (before the guest boots) so the guest RAM
+        // is charged to the pod cgroup. No-op for hypervisors that don't
+        // implement spawn-time placement, and skipped for cgroup v1.
+        if let Some(cgroup_procs_path) = self.cgroups_resource.sandbox_cgroup_procs_path().await {
+            self.hypervisor
+                .set_vmm_cgroup_path(cgroup_procs_path)
+                .await
+                .context("set vmm cgroup path before start vm")?;
+        }
+
         Ok(())
     }
 

--- a/tests/integration/kubernetes/k8s-vmm-cgroup-memory.bats
+++ b/tests/integration/kubernetes/k8s-vmm-cgroup-memory.bats
@@ -1,0 +1,141 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Verify that the VMM is placed in the pod sandbox cgroup before the guest
+# boots, so the guest RAM is charged to the pod under cgroup v2 (first-touch
+# accounting) rather than to the cgroup the VMM was spawned in. Applies to
+# any hypervisor that runs the guest in a separate VMM process (e.g.
+# cloud-hypervisor, qemu) when sandbox_cgroup_only=true. Checks the VMM
+# cgroup, the pod cgroup's memory.current and the kubelet working-set, all
+# from the host via exec_host.
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+# Lower bound (bytes) for guest RAM charged to the pod cgroup. 80 MiB
+# separates the fixed runtime (~110-160 MiB) from the regression (~5-12 MiB).
+MIN_GUEST_MEMORY_BYTES="${MIN_GUEST_MEMORY_BYTES:-83886080}"
+
+# kubelet stats lag pod readiness, so poll the stats/summary API.
+KUBELET_STATS_RETRIES="${KUBELET_STATS_RETRIES:-30}"
+KUBELET_STATS_SLEEP="${KUBELET_STATS_SLEEP:-2}"
+
+# True for hypervisors that run the guest in a separate VMM process.
+# dragonball runs the guest in-process in the shim, so it has no separate
+# VMM to place and is out of scope.
+has_separate_vmm() {
+	[[ "${KATA_HYPERVISOR}" != *dragonball* ]]
+}
+
+# True when the node uses the cgroup v2 unified hierarchy.
+host_is_cgroup_v2() {
+	exec_host "${node}" "test -f /sys/fs/cgroup/cgroup.controllers" >/dev/null 2>&1
+}
+
+# True unless the kata config explicitly sets sandbox_cgroup_only = false
+# (the shipped configs default to true).
+sandbox_cgroup_only_enabled() {
+	local cfg val
+	cfg="$(get_kata_runtime_config_file "${node}")" || return 0
+	val="$(exec_host "${node}" "grep -E '^[[:space:]]*sandbox_cgroup_only[[:space:]]*=' '${cfg}' | tail -1" || true)"
+	if echo "${val}" | grep -q 'false'; then
+		return 1
+	fi
+	return 0
+}
+
+# Resolve the running VMM PID on the node. Only one Kata pod runs during the
+# test (setup_common clears existing pods), so the VMM is the sole matching
+# process, identified by its binary name across hypervisors.
+get_vmm_pid() {
+	exec_host "${node}" "pgrep -f 'cloud-hypervisor|qemu-system|firecracker|stratovirt' | head -1"
+}
+
+# Echo the pod's memory.workingSetBytes from the kubelet stats/summary API.
+get_pod_workingset_bytes() {
+	kubectl get --raw "/api/v1/nodes/${node}/proxy/stats/summary" 2>/dev/null \
+		| jq -r --arg p "${pod_name}" \
+			'.pods[] | select(.podRef.name==$p) | .memory.workingSetBytes // empty'
+}
+
+setup() {
+	setup_common || die "setup_common failed"
+
+	has_separate_vmm || skip "test requires a hypervisor with a separate VMM process (KATA_HYPERVISOR=${KATA_HYPERVISOR})"
+	host_is_cgroup_v2 || skip "test requires the cgroup v2 unified hierarchy on the node"
+	sandbox_cgroup_only_enabled || skip "test requires sandbox_cgroup_only=true"
+
+	pod_name="besteffort-test"
+
+	yaml_file="${pod_config_dir}/pod-besteffort.yaml"
+	set_node "$yaml_file" "$node"
+
+	# Add policy to yaml
+	policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+	auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
+}
+
+@test "VMM guest RAM is charged to the pod cgroup and visible to the kubelet" {
+	kubectl create -f "${yaml_file}"
+	kubectl wait --for=condition=Ready --timeout="$timeout" pod "$pod_name"
+
+	local vmm_pid
+	vmm_pid="$(get_vmm_pid)"
+	[[ -n "${vmm_pid}" ]] || die "could not find the VMM process on ${node}"
+	info "VMM pid: ${vmm_pid}"
+
+	# 1. The VMM must be in the pod's kubepods cgroup, not under
+	#    system.slice/containerd.service.
+	local vmm_cgroup
+	vmm_cgroup="$(exec_host "${node}" "cat /proc/${vmm_pid}/cgroup" | awk -F'::' '/^0::/ {print $2}')"
+	[[ -n "${vmm_cgroup}" ]] || die "could not read cgroup v2 path for VMM pid ${vmm_pid}"
+	info "VMM cgroup: ${vmm_cgroup}"
+
+	echo "${vmm_cgroup}" | grep -q "kubepods" \
+		|| die "VMM is not in a kubepods cgroup: ${vmm_cgroup}"
+	if echo "${vmm_cgroup}" | grep -qE 'system\.slice|containerd\.service'; then
+		die "VMM landed in the host cgroup instead of the pod cgroup: ${vmm_cgroup}"
+	fi
+
+	# 2. The pod cgroup's memory.current must account for the guest RAM.
+	local mem_current
+	mem_current="$(exec_host "${node}" "cat /sys/fs/cgroup${vmm_cgroup}/memory.current")"
+	[[ "${mem_current}" =~ ^[0-9]+$ ]] || die "unexpected memory.current value: ${mem_current}"
+	info "pod cgroup memory.current: ${mem_current} bytes (min expected ${MIN_GUEST_MEMORY_BYTES})"
+
+	[[ "${mem_current}" -ge "${MIN_GUEST_MEMORY_BYTES}" ]] \
+		|| die "pod cgroup memory.current (${mem_current}) below expected guest RAM (${MIN_GUEST_MEMORY_BYTES}); guest RAM is not charged to the pod cgroup"
+
+	# 3. The kubelet working-set (backing kubectl top / metrics-server / HPA)
+	#    is derived from the pod cgroup and must also reflect the guest RAM.
+	local workingset=""
+	local i
+	for (( i = 0; i < KUBELET_STATS_RETRIES; i++ )); do
+		workingset="$(get_pod_workingset_bytes)"
+		if [[ "${workingset}" =~ ^[0-9]+$ ]] && [[ "${workingset}" -ge "${MIN_GUEST_MEMORY_BYTES}" ]]; then
+			break
+		fi
+		sleep "${KUBELET_STATS_SLEEP}"
+	done
+	info "kubelet workingSetBytes: ${workingset:-<none>} (min expected ${MIN_GUEST_MEMORY_BYTES})"
+
+	[[ "${workingset}" =~ ^[0-9]+$ ]] \
+		|| die "kubelet reported no working-set for pod ${pod_name}"
+	[[ "${workingset}" -ge "${MIN_GUEST_MEMORY_BYTES}" ]] \
+		|| die "kubelet workingSetBytes (${workingset}) below expected guest RAM (${MIN_GUEST_MEMORY_BYTES}); the guest RAM is not visible to the kubelet"
+}
+
+teardown() {
+	# Skipped tests leave these unset.
+	if [[ -n "${pod_name:-}" ]]; then
+		kubectl describe "pod/${pod_name}" || true
+	fi
+	if [[ -n "${policy_settings_dir:-}" ]]; then
+		delete_tmp_policy_settings_dir "${policy_settings_dir}"
+	fi
+	teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -101,6 +101,7 @@ else
 		"k8s-projected-volume.bats" \
 		"k8s-replication.bats" \
 		"k8s-sandbox-cgroup.bats" \
+		"k8s-vmm-cgroup-memory.bats" \
 		"k8s-seccomp.bats" \
 		"k8s-sysctls.bats" \
 		"k8s-security-context.bats" \


### PR DESCRIPTION
fixes https://github.com/kata-containers/kata-containers/issues/13273

Under cgroup v2, memory is charged to whichever cgroup first-touches each page, and already-faulted pages are not re-charged on migration. cloud-hypervisor faults the guest RAM while booting the VM, so if the VMM isn't in the pod sandbox cgroup at that moment, the guest's ~150 MiB is charged to whatever cgroup it was spawned in (e.g. system.slice/containerd.service) — leaving the pod's memory.current and the kubelet working-set under-reporting the guest by >100 MiB.

This PR plumbs the sandbox cgroup path down to the CH hypervisor and joins the VMM to it in pre_exec, before the guest boots, so the guest RAM is correctly accounted to the pod. Adds a gated k8s integration test that asserts the VMM lives in the pod's kubepods cgroup and that memory.current reflects the full guest footprint.