### PR TITLE
runtime-rs: L3 forwarding network model for runtime-rs

### DIFF
--- a/docs/design/architecture/networking.md
+++ b/docs/design/architecture/networking.md
@@ -14,9 +14,12 @@ This is a very namespace-centric approach as many hypervisors or VM
 Managers (VMMs) such as `virt-manager` cannot handle `veth`
 interfaces. Typically, [`TAP`](https://www.kernel.org/doc/Documentation/networking/tuntap.txt)
 interfaces are created for VM connectivity.
+There are various internetworking models that overcome incompatibility between typical
+container engines expectations and virtual machines,
 
-To overcome incompatibility between typical container engines expectations
-and virtual machines, Kata Containers networking transparently connects `veth`
+### TC-Filter
+
+Kata Containers networking transparently connects `veth`
 interfaces with `TAP` ones using [Traffic Control](https://man7.org/linux/man-pages/man8/tc.8.html):
 
 ![Kata Containers networking](../arch-images/network.png)
@@ -28,6 +31,8 @@ Kata Containers will create a tap device for the VM, `tap0_kata`,
 and setup a TC redirection filter to redirect traffic from `eth0`'s ingress to `tap0_kata`'s egress,
 and a second TC filter to redirect traffic from `tap0_kata`'s ingress to `eth0`'s egress.
 
+### MACVTAP
+
 Kata Containers maintains support for MACVTAP, which was an earlier implementation used in Kata.
 With this method, Kata created a MACVTAP device to connect directly to the `eth0` device.
 TC-filter is the default because it allows for simpler configuration, better CNI plugin
@@ -38,6 +43,12 @@ Kata Containers has deprecated support for bridge due to lacking performance rel
 Kata Containers supports both
 [CNM](https://github.com/moby/libnetwork/blob/master/docs/design.md#the-container-network-model)
 and [CNI](https://github.com/containernetworking/cni) for networking management.
+
+### L3 Forwarding (Experimental)
+
+With L3 forwarding, we modify the route table on the host-side network namespace to route traffic to the pod IP through the tap device.
+This is useful for integrating with service meshes such as Istio Ambient, where the CNI sets up iptables rules and a node proxy listens on the host-side network namespace.
+This model only supports IPv4 and only one IP address per pod.
 
 ## Network Hotplug
 

--- a/docs/design/architecture_4.0/architecture.md
+++ b/docs/design/architecture_4.0/architecture.md
@@ -327,7 +327,7 @@ graph LR
     RM --> Volume
 
     Network --> Endpoint["endpoint\n(veth / physical)"]
-    Network --> NetModel["model\n(tcfilter / route)"]
+    Network --> NetModel["model\n(tcfilter / l3forwarding)"]
     SharedFs --> InlineVirtioFs["inline virtiofs"]
     SharedFs --> StandaloneVirtioFs["standalone virtiofs"]
 

--- a/docs/how-to/how-to-set-sandbox-config-kata.md
+++ b/docs/how-to/how-to-set-sandbox-config-kata.md
@@ -26,7 +26,7 @@ There are several kinds of Kata configurations and they are listed below.
 | `io.katacontainers.config.runtime.experimental` | `boolean` | determines if experimental features enabled |
 | `io.katacontainers.config.runtime.disable_guest_seccomp`| `boolean` | determines if `seccomp` should be applied inside guest |
 | `io.katacontainers.config.runtime.disable_new_netns` | `boolean` | determines if a new netns is created for the hypervisor process |
-| `io.katacontainers.config.runtime.internetworking_model` | string| determines how the VM should be connected to the container network interface. Valid values are `macvtap`, `tcfilter` and `none` |
+| `io.katacontainers.config.runtime.internetworking_model` | string| determines how the VM should be connected to the container network interface. Valid values are `macvtap`, `tcfilter`, `l3forwarding` (runtime-rs only, experimental) and `none` |
 | `io.katacontainers.config.runtime.sandbox_cgroup_only`| `boolean` | determines if Kata processes are managed only in sandbox cgroup |
 | `io.katacontainers.config.runtime.enable_pprof` | `boolean` | enables Golang `pprof` for `containerd-shim-kata-v2` process |
 | `io.katacontainers.config.runtime.create_container_timeout` | `uint64` | the timeout for create a container in `seconds`, default is `60` |

--- a/src/libs/kata-types/src/config/runtime.rs
+++ b/src/libs/kata-types/src/config/runtime.rs
@@ -68,6 +68,8 @@ pub struct Runtime {
     ///
     /// Options:
     /// - macvtap: used when the Container network interface can be bridged using macvtap.
+    /// - l3forwarding: for Istio Ambient-style service mesh integration with node proxies.
+    ///   Experimental, IPv4 only.
     /// - none: used when customize network. Only creates a tap device. No veth pair.
     /// - tcfilter: uses tc filter rules to redirect traffic from the network interface provided
     ///   by plugin to a tap interface connected to the VM.
@@ -79,8 +81,7 @@ pub struct Runtime {
     /// This option may have some potential impacts to your host. It should only be used when you
     /// know what you're doing.
     ///
-    /// `disable_new_netns` conflicts with `internetworking_model=tcfilter` and
-    /// `internetworking_model=macvtap`. It works only with `internetworking_model=none`.
+    /// `disable_new_netns` only works with `internetworking_model=none`.
     /// The tap device will be in the host network namespace and can connect to a bridge (like OVS)
     /// directly.
     ///
@@ -265,6 +266,7 @@ impl ConfigOps for Runtime {
             && net_model != "macvtap"
             && net_model != "none"
             && net_model != "tcfilter"
+            && net_model != "l3forwarding"
         {
             return Err(std::io::Error::other(format!(
                 "Invalid internetworking_model `{net_model}` in configuration file",

--- a/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-azure-runtime-rs.toml.in
@@ -478,6 +478,14 @@ keep_abnormal = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_CLH@"
 
 name = "@RUNTIMENAME@"
@@ -508,8 +516,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=bridged` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-clh-runtime-rs.toml.in
@@ -478,6 +478,14 @@ keep_abnormal = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_CLH@"
 
 name = "@RUNTIMENAME@"
@@ -508,8 +516,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=bridged` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-dragonball.toml.in
+++ b/src/runtime-rs/config/configuration-dragonball.toml.in
@@ -479,6 +479,14 @@ keep_abnormal = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_DB@"
 
 name = "@RUNTIMENAME@"
@@ -509,8 +517,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=bridged` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-coco-dev-runtime-rs.toml.in
@@ -604,6 +604,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_QEMU@"
 
 name = "@RUNTIMENAME@"
@@ -639,8 +647,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-runtime-rs.toml.in
@@ -718,6 +718,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_QEMU@"
 
 name = "@RUNTIMENAME@"
@@ -753,8 +761,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-snp-runtime-rs.toml.in
@@ -650,6 +650,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_QEMU@"
 
 name = "@RUNTIMENAME@"
@@ -685,8 +693,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-nvidia-gpu-tdx-runtime-rs.toml.in
@@ -626,6 +626,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_QEMU@"
 
 name = "@RUNTIMENAME@"
@@ -661,8 +669,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-runtime-rs.toml.in
@@ -701,6 +701,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_QEMU@"
 
 name = "@RUNTIMENAME@"
@@ -736,8 +744,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-se-runtime-rs.toml.in
@@ -586,6 +586,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_QEMU@"
 
 name = "@RUNTIMENAME@"
@@ -621,8 +629,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-snp-runtime-rs.toml.in
@@ -633,6 +633,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model="@DEFNETWORKMODEL_QEMU@"
 
 name="@RUNTIMENAME@"
@@ -668,8 +676,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
+++ b/src/runtime-rs/config/configuration-qemu-tdx-runtime-rs.toml.in
@@ -611,6 +611,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_QEMU@"
 
 name="@RUNTIMENAME@"
@@ -646,8 +654,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/config/configuration-remote.toml.in
+++ b/src/runtime-rs/config/configuration-remote.toml.in
@@ -189,6 +189,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 # Note: The remote hypervisor, uses it's own network, so "none" is required
 internetworking_model = "none"
 
@@ -222,8 +230,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 # Note: The remote hypervisor has a different networking model, which requires true

--- a/src/runtime-rs/config/configuration-rs-fc.toml.in
+++ b/src/runtime-rs/config/configuration-rs-fc.toml.in
@@ -343,6 +343,14 @@ enable_debug = false
 #     Uses tc filter rules to redirect traffic from the network interface
 #     provided by plugin to a tap interface connected to the VM.
 #
+#   - l3forwarding
+#     Uses L3 routing and proxy ARP to forward traffic between the network
+#     interface provided by the plugin and a tap interface connected to the
+#     VM.
+#     Useful for Istio Ambient-style service mesh integration with node
+#     proxies. Supports a single network interface per network namespace.
+#     Experimental feature, IPv4 only.
+#
 internetworking_model = "@DEFNETWORKMODEL_FC@"
 
 name = "@RUNTIMENAME@"
@@ -373,8 +381,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime-rs/crates/resource/src/network/network_model/l3_forwarding_model.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_model/l3_forwarding_model.rs
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::fs;
+use std::net::{IpAddr, Ipv4Addr};
+
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use futures::TryStreamExt;
+use netlink_packet_route::route::{RouteAddress, RouteAttribute, RouteScope};
+use rtnetlink::{Handle, RouteMessageBuilder};
+use scopeguard::defer;
+
+use super::{
+    port_forwarding::{configure_port_forwarding, TAP_IPV4_ADDR},
+    NetworkModel, NetworkModelType,
+};
+use crate::network::NetworkPair;
+
+#[derive(Debug)]
+pub(crate) struct L3ForwardingModel {}
+
+impl L3ForwardingModel {
+    pub fn new() -> Result<Self> {
+        Ok(Self {})
+    }
+}
+
+#[async_trait]
+impl NetworkModel for L3ForwardingModel {
+    fn model_type(&self) -> NetworkModelType {
+        NetworkModelType::L3Forwarding
+    }
+
+    async fn add(&self, pair: &NetworkPair) -> Result<()> {
+        let (connection, handle, _) = rtnetlink::new_connection().context("new connection")?;
+        let thread_handler = tokio::spawn(connection);
+
+        defer!({
+            thread_handler.abort();
+        });
+
+        let tap_index = fetch_index(&handle, pair.tap.tap_iface.name.as_str())
+            .await
+            .context("fetch tap by index")?;
+        let virt_index = fetch_index(&handle, pair.virt_iface.name.as_str())
+            .await
+            .context("fetch virt by index")?;
+
+        let pod_addrs =
+            ipv4_workload_addresses(pair.virt_iface.addrs.iter().map(|address| address.addr))?;
+        if pod_addrs.is_empty() {
+            anyhow::bail!("no IP addresses found on virt iface");
+        }
+        let pod_ipv4 = pod_addrs.first().copied();
+
+        // Enable proxy arp so we can respond to ARP requests using the tap and virt interfaces.
+        fs::write(
+            format!(
+                "/proc/sys/net/ipv4/conf/{}/proxy_arp",
+                pair.tap.tap_iface.name
+            ),
+            "1",
+        )
+        .context(
+                format!("enable proxy arp on {}", pair.tap.tap_iface.name)
+            )?;
+        fs::write(
+            format!("/proc/sys/net/ipv4/conf/{}/proxy_arp", pair.virt_iface.name),
+            "1",
+        )
+        .context(
+                format!("enable proxy arp on {}", pair.virt_iface.name)
+            )?;
+        fs::write("/proc/sys/net/ipv4/ip_forward", "1").context("enable ip forward")?;
+
+        // We need the tap interface to have an address different from the pod ip for arp proxying
+        // to work. If this didn't have an ip, when the host-side netns gets an arp request it will
+        // forward it into the guest. However, it will set the src ip of the arp request to the pod
+        // ip. This is a gratuitous ARP request since the request and response address are the same,
+        // and the guest will not respond.
+        // This also allows for SNATing link local connections from the host.
+        // TODO: What if there are multiple tap interfaces? They would get the same address?
+        //  Maybe that's fine?
+        ignore_eexist(
+            handle
+                .address()
+                .add(tap_index, IpAddr::V4(TAP_IPV4_ADDR), 32)
+                .execute()
+                .await,
+        )
+        .context("add link-local address to tap")?;
+
+        // Remove rules in the local route table that have to do with our pod ips.
+        const ROUTE_TABLE_LOCAL: u8 = 255;
+        let local_query = RouteMessageBuilder::<std::net::Ipv4Addr>::new()
+            .table_id(ROUTE_TABLE_LOCAL as u32)
+            .build();
+        let mut local_routes = handle.route().get(local_query).execute();
+        while let Some(route) = local_routes.try_next().await? {
+            if route.header.table != ROUTE_TABLE_LOCAL {
+                continue;
+            }
+            let mut dst_matches = false;
+            let mut oif_matches = false;
+            for attr in &route.attributes {
+                match attr {
+                    RouteAttribute::Destination(RouteAddress::Inet(v4))
+                        if pod_addrs.contains(v4) =>
+                    {
+                        dst_matches = true;
+                    }
+                    RouteAttribute::Oif(idx) if *idx == virt_index => {
+                        oif_matches = true;
+                    }
+                    _ => {}
+                }
+            }
+            if dst_matches && oif_matches && route.header.destination_prefix_length == 32 {
+                handle
+                    .route()
+                    .del(route)
+                    .execute()
+                    .await
+                    .context("delete local route for pod ip on virt iface")?;
+            }
+        }
+
+        // Add a route for each pod ip via the tap interface.
+        for pod_addr in pod_addrs {
+            let route_msg = RouteMessageBuilder::<std::net::Ipv4Addr>::new()
+                .destination_prefix(pod_addr, 32)
+                .output_interface(tap_index)
+                .scope(RouteScope::Link)
+                .build();
+            ignore_eexist(handle.route().add(route_msg).execute().await)
+                .with_context(|| format!("add route for pod ip {pod_addr} via tap"))?;
+        }
+
+        configure_port_forwarding(&pair.tap.tap_iface.name, pod_ipv4, TAP_IPV4_ADDR).await;
+
+        Ok(())
+    }
+
+    async fn del(&self, _pair: &NetworkPair) -> Result<()> {
+        // Nothing to do: every resource added by `add()` lives inside the
+        // pod netns (link-local addr on tap, /32 route via tap, proxy_arp
+        // on tap+virt, ip_forward sysctl) and is destroyed when the netns
+        // is torn down with the sandbox.
+        Ok(())
+    }
+}
+
+fn ipv4_workload_addresses(addresses: impl IntoIterator<Item = IpAddr>) -> Result<Vec<Ipv4Addr>> {
+    let mut ipv4_addresses = Vec::new();
+    for address in addresses {
+        match address {
+            IpAddr::V4(address) => ipv4_addresses.push(address),
+            IpAddr::V6(address) if address.is_unicast_link_local() => {}
+            IpAddr::V6(address) => anyhow::bail!(
+                "l3forwarding does not support IPv6 yet, but the virt iface has {}",
+                address
+            ),
+        }
+    }
+    Ok(ipv4_addresses)
+}
+
+fn ignore_eexist(result: Result<(), rtnetlink::Error>) -> Result<(), rtnetlink::Error> {
+    match result {
+        Err(err) if is_eexist(&err) => Ok(()),
+        result => result,
+    }
+}
+
+fn is_eexist(err: &rtnetlink::Error) -> bool {
+    match err {
+        rtnetlink::Error::NetlinkError(message) => {
+            message.code.is_some_and(|code| code.get() == -libc::EEXIST)
+        }
+        _ => false,
+    }
+}
+
+pub async fn fetch_index(handle: &Handle, name: &str) -> Result<u32> {
+    let link = crate::network::network_pair::get_link_by_name(handle, name)
+        .await
+        .context("get link by name")?;
+    let base = link.attrs();
+    Ok(base.index)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ignores_ipv6_link_local_addresses() {
+        let addresses =
+            ipv4_workload_addresses(["10.244.0.8".parse().unwrap(), "fe80::1234".parse().unwrap()])
+                .unwrap();
+
+        assert_eq!(addresses, vec!["10.244.0.8".parse::<Ipv4Addr>().unwrap()]);
+    }
+
+    #[test]
+    fn rejects_non_link_local_ipv6_addresses() {
+        let error = ipv4_workload_addresses(["fd00::8".parse().unwrap()]).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "l3forwarding does not support IPv6 yet, but the virt iface has fd00::8"
+        );
+    }
+}

--- a/src/runtime-rs/crates/resource/src/network/network_model/mod.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_model/mod.rs
@@ -4,7 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+pub mod l3_forwarding_model;
 pub mod none_model;
+mod port_forwarding;
 pub mod tc_filter_model;
 pub mod test_network_model;
 use std::sync::Arc;
@@ -15,10 +17,12 @@ use async_trait::async_trait;
 use super::NetworkPair;
 
 pub(crate) const TC_FILTER_NET_MODEL_STR: &str = "tcfilter";
+pub(crate) const L3_FORWARDING_NET_MODEL_STR: &str = "l3forwarding";
 
 pub enum NetworkModelType {
     NoneModel,
     TcFilter,
+    L3Forwarding,
 }
 
 #[async_trait]
@@ -32,6 +36,9 @@ pub fn new(model: &str) -> Result<Arc<dyn NetworkModel>> {
     match model {
         TC_FILTER_NET_MODEL_STR => Ok(Arc::new(
             tc_filter_model::TcFilterModel::new().context("new tc filter model")?,
+        )),
+        L3_FORWARDING_NET_MODEL_STR => Ok(Arc::new(
+            l3_forwarding_model::L3ForwardingModel::new().context("new l3 forwarding model")?,
         )),
         _ => Ok(Arc::new(
             none_model::NoneModel::new().context("new none model")?,

--- a/src/runtime-rs/crates/resource/src/network/network_model/port_forwarding.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_model/port_forwarding.rs
@@ -1,0 +1,176 @@
+// Copyright (c) 2026 Microsoft Corporation
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::net::Ipv4Addr;
+
+use anyhow::{anyhow, Result};
+use tokio::process::Command;
+
+const IPV4_LOOPBACK: &str = "127.0.0.1/32";
+const KATA_OUTPUT_CHAIN: &str = "KATA_PORTFW_OUTPUT";
+const KATA_POSTROUTING_CHAIN: &str = "KATA_PORTFW_POSTRT";
+const XTABLES_LOCK_WAIT_SECONDS: &str = "5";
+pub(crate) const TAP_IPV4_ADDR: Ipv4Addr = Ipv4Addr::new(169, 254, 0, 1);
+
+pub(crate) async fn configure_port_forwarding(
+    tap_name: &str,
+    pod_ipv4: Option<Ipv4Addr>,
+    tap_ipv4: Ipv4Addr,
+) {
+    if let Some(pod_ip) = pod_ipv4 {
+        if let Err(err) = configure_ipv4(tap_name, pod_ip, tap_ipv4).await {
+            warn!(
+                sl!(),
+                "failed to configure IPv4 port-forward NAT; continuing without it: {}", err
+            );
+        }
+    }
+}
+
+async fn configure_ipv4(tap_name: &str, pod_ip: Ipv4Addr, tap_ip: Ipv4Addr) -> Result<()> {
+    let iptables = detect_iptables_binary().await?;
+    let pod_cidr = format!("{pod_ip}/32");
+    let tap_ip = tap_ip.to_string();
+    let pod_ip = pod_ip.to_string();
+
+    run_iptables(iptables, &["-t", "nat", "-N", KATA_POSTROUTING_CHAIN]).await?;
+    run_iptables(iptables, &["-t", "nat", "-N", KATA_OUTPUT_CHAIN]).await?;
+
+    // Make replies from the guest routable back to the host-side pod
+    // namespace. Install this before DNAT so a partial failure cannot leave
+    // destination rewriting active without a valid reply path.
+    run_iptables(
+        iptables,
+        &[
+            "-t",
+            "nat",
+            "-A",
+            KATA_POSTROUTING_CHAIN,
+            "-s",
+            IPV4_LOOPBACK,
+            "-d",
+            &pod_cidr,
+            "-o",
+            tap_name,
+            "-p",
+            "tcp",
+            "-j",
+            "SNAT",
+            "--to-source",
+            &tap_ip,
+        ],
+    )
+    .await?;
+    run_iptables(
+        iptables,
+        &[
+            "-t",
+            "nat",
+            "-A",
+            "POSTROUTING",
+            "-j",
+            KATA_POSTROUTING_CHAIN,
+        ],
+    )
+    .await?;
+
+    // containerd port-forward connects to localhost inside the pod network
+    // namespace. Preserve the requested port while redirecting that
+    // connection to the workload inside the guest.
+    run_iptables(
+        iptables,
+        &[
+            "-t",
+            "nat",
+            "-A",
+            KATA_OUTPUT_CHAIN,
+            "-s",
+            IPV4_LOOPBACK,
+            "-d",
+            IPV4_LOOPBACK,
+            "-p",
+            "tcp",
+            "-j",
+            "DNAT",
+            "--to-destination",
+            &pod_ip,
+        ],
+    )
+    .await?;
+    run_iptables(
+        iptables,
+        &["-t", "nat", "-A", "OUTPUT", "-j", KATA_OUTPUT_CHAIN],
+    )
+    .await
+}
+
+async fn run_iptables(binary: &str, args: &[&str]) -> Result<()> {
+    // Note that "-w" is a no-op for iptables-nft.
+    let output = Command::new(binary)
+        .args(["-w", XTABLES_LOCK_WAIT_SECONDS])
+        .args(args)
+        .output()
+        .await
+        .map_err(|err| anyhow!("failed to execute {binary}: {err}"))?;
+    if !output.status.success() {
+        return Err(anyhow!(
+            "{} {} failed: {}",
+            binary,
+            args.join(" "),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(())
+}
+
+// Simplified version of what Istio does in
+// https://github.com/istio/istio/blob/1ef2d93c3b1ba12922d2e8e1384e4ec7317a973f/tools/istio-iptables/pkg/dependencies/implementation.go#L179-L210
+// In short, if "iptables-legacy" is available and has rules, use it.
+// If "iptables-nft" is available, use it.
+// If "iptables" (which symlinks to iptables-nft or iptables) is available, use it.
+// Finally, fail.
+// This error should be caught and logged, but should not be fatal.
+async fn detect_iptables_binary() -> Result<&'static str> {
+    let [legacy, plain, nft] = ["iptables-legacy", "iptables", "iptables-nft"];
+
+    let legacy_output = probe_binary(legacy).await;
+    if legacy_output.as_deref().is_some_and(has_rules) {
+        return Ok(legacy);
+    }
+
+    let nft_output = probe_binary(nft).await;
+    if nft_output.is_some() {
+        return Ok(nft);
+    }
+
+    if probe_binary(plain).await.is_some() {
+        return Ok(plain);
+    }
+
+    Err(anyhow!(
+        "no usable IPv4 iptables binary found (tried {}, {}, {})",
+        legacy,
+        nft,
+        plain
+    ))
+}
+
+// Check if the output of iptablesxxx-save has any rules.
+// Istio does the same heuristic.
+// https://github.com/istio/istio/blob/1ef2d93c3b1ba12922d2e8e1384e4ec7317a973f/tools/istio-iptables/pkg/dependencies/implementation_linux.go#L140-L144
+fn has_rules(output: &str) -> bool {
+    output.matches('\n').count() >= 3
+}
+
+// We assume that iptablesxxx-save runs iff iptablesxxx is usable.
+async fn probe_binary(binary: &'static str) -> Option<String> {
+    let save_binary = format!("{binary}-save");
+    match Command::new(save_binary).output().await {
+        Ok(output) if output.status.success() => {
+            Some(String::from_utf8_lossy(&output.stdout).into_owned())
+        }
+        _ => None,
+    }
+}

--- a/src/runtime-rs/crates/resource/src/network/network_model/test_network_model.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_model/test_network_model.rs
@@ -4,10 +4,15 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+//  TODO(burgerdev): These tests don't do much since they don't run .await.
+//  Also, its not clear if running such network operations would belong in unit tests.
 #[cfg(test)]
 mod tests {
     use crate::network::{
-        network_model::{tc_filter_model::fetch_index, TC_FILTER_NET_MODEL_STR},
+        network_model::{
+            l3_forwarding_model, tc_filter_model, L3_FORWARDING_NET_MODEL_STR,
+            TC_FILTER_NET_MODEL_STR,
+        },
         network_pair::NetworkPair,
     };
     use anyhow::Context;
@@ -28,7 +33,31 @@ mod tests {
             if let Ok(net_pair) =
                 NetworkPair::new(&handle, 1, "bar", TC_FILTER_NET_MODEL_STR, 2).await
             {
-                if let Ok(index) = fetch_index(&handle, "bar").await {
+                if let Ok(index) = tc_filter_model::fetch_index(&handle, "bar").await {
+                    assert!(net_pair.add_network_model().await.is_ok());
+                    assert!(net_pair.del_network_model().await.is_ok());
+                    assert!(handle.link().del(index).execute().await.is_ok());
+                }
+            }
+        }
+    }
+
+    #[actix_rt::test]
+    async fn test_l3_redirect_network() {
+        if let Ok((connection, handle, _)) = rtnetlink::new_connection().context("new connection") {
+            let thread_handler = tokio::spawn(connection);
+            defer!({
+                thread_handler.abort();
+            });
+
+            let veth = LinkVeth::new("foo", "bar").build();
+
+            handle.link().add(veth);
+
+            if let Ok(net_pair) =
+                NetworkPair::new(&handle, 1, "bar", L3_FORWARDING_NET_MODEL_STR, 2).await
+            {
+                if let Ok(index) = l3_forwarding_model::fetch_index(&handle, "bar").await {
                     assert!(net_pair.add_network_model().await.is_ok());
                     assert!(net_pair.del_network_model().await.is_ok());
                     assert!(handle.link().del(index).execute().await.is_ok());

--- a/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_with_netns.rs
@@ -269,6 +269,16 @@ async fn get_entity_from_netns(
         entity_list.push(NetworkEntity::new(endpoint, network_info));
     }
 
+    // Currently, l3forwarding configures the host netns for a single pod interface.
+    if config.network_model == crate::network::network_model::L3_FORWARDING_NET_MODEL_STR
+        && entity_list.len() > 1
+    {
+        return Err(anyhow!(
+            "l3forwarding supports only a single interface per network namespace, found {}",
+            entity_list.len()
+        ));
+    }
+
     Ok(entity_list)
 }
 

--- a/src/runtime/config/configuration-clh-azure.toml.in
+++ b/src/runtime/config/configuration-clh-azure.toml.in
@@ -415,8 +415,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-clh.toml.in
+++ b/src/runtime/config/configuration-clh.toml.in
@@ -415,8 +415,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-fc.toml.in
+++ b/src/runtime/config/configuration-fc.toml.in
@@ -327,8 +327,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-qemu-coco-dev.toml.in
+++ b/src/runtime/config/configuration-qemu-coco-dev.toml.in
@@ -651,8 +651,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-qemu-nvidia-cpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-cpu.toml.in
@@ -669,8 +669,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-snp.toml.in
@@ -697,8 +697,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu-tdx.toml.in
@@ -674,8 +674,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
+++ b/src/runtime/config/configuration-qemu-nvidia-gpu.toml.in
@@ -676,8 +676,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-qemu-se.toml.in
+++ b/src/runtime/config/configuration-qemu-se.toml.in
@@ -629,8 +629,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-qemu-snp.toml.in
+++ b/src/runtime/config/configuration-qemu-snp.toml.in
@@ -659,8 +659,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-qemu-tdx.toml.in
+++ b/src/runtime/config/configuration-qemu-tdx.toml.in
@@ -636,8 +636,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-qemu.toml.in
+++ b/src/runtime/config/configuration-qemu.toml.in
@@ -645,8 +645,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/src/runtime/config/configuration-remote.toml.in
+++ b/src/runtime/config/configuration-remote.toml.in
@@ -211,8 +211,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 # Note: The remote hypervisor has a different networking model, which requires true

--- a/src/runtime/config/configuration-stratovirt.toml.in
+++ b/src/runtime/config/configuration-stratovirt.toml.in
@@ -380,8 +380,7 @@ jaeger_password = ""
 
 # If enabled, the runtime will not create a network namespace for shim and hypervisor processes.
 # This option may have some potential impacts to your host. It should only be used when you know what you're doing.
-# `disable_new_netns` conflicts with `internetworking_model=tcfilter` and `internetworking_model=macvtap`. It works only
-# with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
+# `disable_new_netns` only works with `internetworking_model=none`. The tap device will be in the host network namespace and can connect to a bridge
 # (like OVS) directly.
 # (default: false)
 disable_new_netns = false

--- a/tests/integration/kubernetes/k8s-l3forwarding-connectivity.bats
+++ b/tests/integration/kubernetes/k8s-l3forwarding-connectivity.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 Microsoft Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+setup() {
+	# The l3forwarding network model is only implemented in runtime-rs.
+	is_runtime_rs || skip "l3forwarding is only supported by runtime-rs"
+
+	[ "${CONTAINER_RUNTIME}" == "crio" ] && skip "test not working see: https://github.com/kata-containers/kata-containers/issues/10414"
+
+	setup_common || die "setup_common failed"
+
+	busybox_image="quay.io/prometheus/busybox:latest"
+	# Matches metadata.name in nginx-deployment.yaml (set_nginx_image only
+	# rewrites the image, not the resource name).
+	deployment="nginx-deployment"
+
+	# Switch the guest network model to l3forwarding via a runtime config
+	# drop-in, so the pods created below exercise that model instead of the
+	# default. Paired with removal in teardown to avoid leaking the drop-in
+	# onto every subsequent pod on the node.
+	local dropin_file="${BATS_FILE_TMPDIR}/99-k8s-l3forwarding.toml"
+	cat > "${dropin_file}" <<EOF
+[runtime]
+internetworking_model = "l3forwarding"
+EOF
+	runtime_config_dropin="$(set_kata_runtime_config_dropin_file \
+		"${node}" \
+		"${dropin_file}")" || \
+		skip "No Kata runtime config found for ${KATA_HYPERVISOR}"
+
+	# Create test .yaml
+	yaml_file="${pod_config_dir}/test-${deployment}.yaml"
+	set_nginx_image "${pod_config_dir}/nginx-deployment.yaml" "${yaml_file}"
+
+	auto_generate_policy "${pod_config_dir}" "${yaml_file}"
+}
+
+@test "Verify nginx connectivity between pods under l3forwarding" {
+	kubectl create -f "${yaml_file}"
+	kubectl wait --for=condition=Available --timeout=$timeout deployment/${deployment}
+	kubectl expose deployment/${deployment}
+
+	busybox_pod="test-nginx-l3fwd"
+	# We need to use `-O index.html` as the busybox' wget has a different behaviour
+	# than GNU's wget, which would just append a .n to the file name instead of bailing.
+	kubectl run $busybox_pod --restart=Never -it --image="$busybox_image" \
+		-- sh -c 'i=1; while [ $i -le '"$wait_time"' ]; do wget -O index.html --timeout=5 '"$deployment"' && break; sleep 1; i=$(expr $i + 1); done'
+
+	# check pod's status, it should be Succeeded.
+	[ $(kubectl get pods/$busybox_pod -o jsonpath="{.status.phase}") = "Succeeded" ]
+	kubectl logs "$busybox_pod" | grep "index.html"
+}
+
+teardown() {
+	is_runtime_rs || skip "l3forwarding is only supported by runtime-rs"
+	[ "${CONTAINER_RUNTIME}" == "crio" ] && skip "test not working see: https://github.com/kata-containers/kata-containers/issues/10414"
+
+	# Debugging information
+	kubectl describe "pod/$busybox_pod" || true
+	kubectl logs "$busybox_pod" || true
+	kubectl get deployment/${deployment} -o yaml || true
+
+	rm -f "${yaml_file}"
+	kubectl delete deployment "$deployment" || true
+	kubectl delete service "$deployment" || true
+	kubectl delete pod "$busybox_pod" || true
+
+	remove_kata_runtime_config_dropin_file "${node}" "${runtime_config_dropin:-}"
+	teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_tests.sh
@@ -115,6 +115,7 @@ else
 		"k8s-volume.bats" \
 		"k8s-vm-templating.bats" \
 		"k8s-nginx-connectivity.bats" \
+		"k8s-l3forwarding-connectivity.bats" \
 	)
 
 	K8S_TEST_NORMAL_HOST_UNION=( \


### PR DESCRIPTION
See #13208

Note, this does not implement ambient integration by itself. Rather, it creates nice integration points ambient/ztunnel based service meshes.