### PR TITLE
Revert "tests: skip Guaranteed QoS test for SNP/TDX runtime-rs"

### DIFF
--- a/tests/integration/kubernetes/k8s-qos-pods.bats
+++ b/tests/integration/kubernetes/k8s-qos-pods.bats
@@ -16,11 +16,6 @@ setup() {
 }
 
 @test "Guaranteed QoS" {
-	# Skip for SNP/TDX runtime-rs until podOverhead issue is resolved
-	# See: https://github.com/kata-containers/kata-containers/pull/13228
-	[ "${KATA_HYPERVISOR}" == "qemu-snp-runtime-rs" ] && skip "Skipping Guaranteed QoS test for SNP runtime-rs - podOverhead needs adjustment"
-	[ "${KATA_HYPERVISOR}" == "qemu-tdx-runtime-rs" ] && skip "Skipping Guaranteed QoS test for TDX runtime-rs - podOverhead needs adjustment"
-
 	pod_name="qos-test"
 	yaml_file="${pod_config_dir}/pod-guaranteed.yaml"
 	# Add policy to the yaml file


### PR DESCRIPTION
This reverts commit 6588014b541b6e74363b96be680cd22563953e59, as the needed PR[0] was merged this morning, allowing us to just revert the image.

[0]: https://github.com/kata-containers/kata-containers/pull/13173