### PR TITLE
runtime: fix multi-node pxb-pcie topology for dual-socket GPU pods

### DIFF
--- a/src/runtime/pkg/govmm/qemu/qemu.go
+++ b/src/runtime/pkg/govmm/qemu/qemu.go
@@ -1808,6 +1808,11 @@ type PXBPCIeDevice struct {
 	// ID is the QEMU device identifier (e.g. "pxb-numa0").
 	ID string
 
+	// Bus is the parent root bus (default pcie.0). Each pxb-pcie must be
+	// plugged directly into the machine root complex, not into another
+	// pxb-pcie bus.
+	Bus string
+
 	// BusNr is the guest PCI bus number for this root complex.
 	// Use values spaced apart (e.g. 0x20, 0x40) to leave room for
 	// bridges beneath each pxb-pcie.
@@ -1819,9 +1824,13 @@ type PXBPCIeDevice struct {
 
 // QemuParams returns the QEMU parameters for a pxb-pcie device.
 func (dev PXBPCIeDevice) QemuParams(_ *Config) []string {
+	bus := dev.Bus
+	if bus == "" {
+		bus = "pcie.0"
+	}
 	return []string{
 		"-device",
-		fmt.Sprintf("pxb-pcie,id=%s,bus_nr=%d,numa_node=%d", dev.ID, dev.BusNr, dev.NUMANode),
+		fmt.Sprintf("pxb-pcie,id=%s,bus=%s,bus_nr=%d,numa_node=%d", dev.ID, bus, dev.BusNr, dev.NUMANode),
 	}
 }
 

--- a/src/runtime/pkg/govmm/qemu/qemu_test.go
+++ b/src/runtime/pkg/govmm/qemu/qemu_test.go
@@ -380,6 +380,15 @@ func TestAppendDeviceVFIO(t *testing.T) {
 	testAppend(vfioDevice, deviceVFIOString, t)
 }
 
+func TestAppendDevicePXBPCIe(t *testing.T) {
+	pxb := PXBPCIeDevice{
+		ID:       "pxb-numa1",
+		BusNr:    64,
+		NUMANode: 1,
+	}
+	testAppend(pxb, "-device pxb-pcie,id=pxb-numa1,bus=pcie.0,bus_nr=64,numa_node=1", t)
+}
+
 func TestAppendVSOCK(t *testing.T) {
 	vsockDevice := VSOCKDevice{
 		ID:            "vhost-vsock-pci0",

--- a/src/runtime/virtcontainers/qemu.go
+++ b/src/runtime/virtcontainers/qemu.go
@@ -399,6 +399,38 @@ func vfioHostNUMANodes(devices []config.DeviceInfo, log *logrus.Entry) map[int]s
 	return nodes
 }
 
+// vfioGuestNUMANodesFromHostSet maps VFIO-bearing host NUMA nodes to the
+// guest NUMA node indices that cover them.
+func vfioGuestNUMANodesFromHostSet(covered map[int]uint32, vfioHostSet map[int]struct{}) map[uint32]struct{} {
+	guestNodes := make(map[uint32]struct{})
+	for hostNode := range vfioHostSet {
+		if guestIdx, ok := covered[hostNode]; ok {
+			guestNodes[guestIdx] = struct{}{}
+		}
+	}
+	return guestNodes
+}
+
+// vfioSpansMultipleGuestNUMANodes reports whether attached VFIO devices
+// reside on host NUMA nodes mapped to more than one guest NUMA node.
+func vfioSpansMultipleGuestNUMANodes(numaNodes []types.GuestNUMANode, vfioDevices []config.DeviceInfo, log *logrus.Entry) bool {
+	covered := buildCoveredHostNodes(numaNodes)
+	vfioHostSet := vfioHostNUMANodes(vfioDevices, log)
+	return len(vfioGuestNUMANodesFromHostSet(covered, vfioHostSet)) > 1
+}
+
+// numaMemoryOnlyTopologyNeeded reports whether the guest must expose multiple
+// NUMA nodes with memory but fewer vCPUs than nodes because VFIO devices
+// span more than one guest node.
+func numaMemoryOnlyTopologyNeeded(numaNodes []types.GuestNUMANode, vcpus uint32, vfioHostSet map[int]struct{}) bool {
+	numNodes := uint32(len(numaNodes))
+	if numNodes <= 1 || len(vfioHostSet) == 0 || vcpus >= numNodes {
+		return false
+	}
+	covered := buildCoveredHostNodes(numaNodes)
+	return len(vfioGuestNUMANodesFromHostSet(covered, vfioHostSet)) > 1
+}
+
 // guestNodeCoversAny reports whether the HostNodes of guestNode references
 // any host NUMA ID present in the given set.
 func guestNodeCoversAny(guestNode types.GuestNUMANode, hostSet map[int]struct{}) bool {
@@ -578,6 +610,11 @@ func maybeRightSizeAutoNUMA(hc *HypervisorConfig, log *logrus.Entry) {
 }
 
 func (q *qemu) buildNUMATopology() ([]govmmQemu.NUMANode, []govmmQemu.NUMADist, error) {
+	vfioHostSet := vfioHostNUMANodes(q.config.VFIODevices, q.Logger())
+	return q.buildNUMATopologyForVFIOHostSet(vfioHostSet)
+}
+
+func (q *qemu) buildNUMATopologyForVFIOHostSet(vfioHostSet map[int]struct{}) ([]govmmQemu.NUMANode, []govmmQemu.NUMADist, error) {
 	// q.config.GuestNUMANodes has already been right-sized (when applicable)
 	// by maybeRightSizeAutoNUMA() at hypervisor setup time.  Empty means
 	// no NUMA topology; a single node may still carry a HostNodes binding
@@ -609,24 +646,43 @@ func (q *qemu) buildNUMATopology() ([]govmmQemu.NUMANode, []govmmQemu.NUMADist, 
 	// skip the ceiling and distribute exactly DefaultMaxVCPUs. An uneven vCPU
 	// count simply means one node gets one fewer CPU — no hotplug slot needed.
 	numNodes := uint32(len(numaNodes))
-	if q.config.DefaultMaxVCPUs < numNodes {
+	memoryOnlyNodes := numaMemoryOnlyTopologyNeeded(numaNodes, q.config.DefaultMaxVCPUs, vfioHostSet)
+
+	if q.config.DefaultMaxVCPUs < numNodes && !memoryOnlyNodes {
 		hvLogger.WithFields(logrus.Fields{
 			"vcpus":      q.config.DefaultMaxVCPUs,
 			"numa-nodes": numNodes,
 		}).Warn("DefaultMaxVCPUs < NUMA node count; skipping multi-NUMA topology")
 		return nil, nil, nil
 	}
-	var maxVCPUs uint32
-	if q.config.ConfidentialGuest {
-		maxVCPUs = q.config.DefaultMaxVCPUs
-	} else {
-		coresPerSocket := (q.config.DefaultMaxVCPUs + numNodes - 1) / numNodes
-		maxVCPUs = numNodes * coresPerSocket
+	if memoryOnlyNodes {
+		q.Logger().WithFields(logrus.Fields{
+			"vcpus":      q.config.DefaultMaxVCPUs,
+			"numa-nodes": numNodes,
+		}).Info("VFIO devices span multiple guest NUMA nodes; emitting memory-only NUMA nodes for pxb-pcie placement")
 	}
 
-	vcpusPerNode, err := utils.DistributeVCPUsProportionally(numaNodes, maxVCPUs)
-	if err != nil {
-		return nil, nil, fmt.Errorf("failed to distribute vCPUs across NUMA nodes: %w", err)
+	var maxVCPUs uint32
+	var vcpusPerNode []uint32
+	var err error
+	if memoryOnlyNodes {
+		maxVCPUs = q.config.DefaultMaxVCPUs
+		vcpusPerNode = make([]uint32, numNodes)
+		if maxVCPUs > 0 {
+			vcpusPerNode[0] = maxVCPUs
+		}
+	} else {
+		if q.config.ConfidentialGuest {
+			maxVCPUs = q.config.DefaultMaxVCPUs
+		} else {
+			coresPerSocket := (q.config.DefaultMaxVCPUs + numNodes - 1) / numNodes
+			maxVCPUs = numNodes * coresPerSocket
+		}
+
+		vcpusPerNode, err = utils.DistributeVCPUsProportionally(numaNodes, maxVCPUs)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to distribute vCPUs across NUMA nodes: %w", err)
+		}
 	}
 
 	memMb := uint64(q.config.MemorySize)
@@ -651,16 +707,29 @@ func (q *qemu) buildNUMATopology() ([]govmmQemu.NUMANode, []govmmQemu.NUMADist, 
 		}
 	}
 
-	// Distribute memory proportionally to vCPU counts, aligned to memAlign.
+	// Distribute memory across nodes. When vCPUs cannot cover every node
+	// but VFIO devices require multi-node pxb-pcie placement, split memory
+	// evenly so each guest NUMA node exists for GPU affinity.
 	memPerNode := make([]uint64, numNodes)
 	var memAssigned uint64
-	for i := uint32(0); i < numNodes; i++ {
-		raw := memMb * uint64(vcpusPerNode[i]) / uint64(maxVCPUs)
-		memPerNode[i] = (raw / memAlign) * memAlign
-		if memPerNode[i] == 0 {
-			memPerNode[i] = memAlign
+	if memoryOnlyNodes {
+		baseMem := (memMb / uint64(numNodes) / memAlign) * memAlign
+		if baseMem == 0 {
+			baseMem = memAlign
 		}
-		memAssigned += memPerNode[i]
+		for i := uint32(0); i < numNodes; i++ {
+			memPerNode[i] = baseMem
+			memAssigned += baseMem
+		}
+	} else {
+		for i := uint32(0); i < numNodes; i++ {
+			raw := memMb * uint64(vcpusPerNode[i]) / uint64(maxVCPUs)
+			memPerNode[i] = (raw / memAlign) * memAlign
+			if memPerNode[i] == 0 {
+				memPerNode[i] = memAlign
+			}
+			memAssigned += memPerNode[i]
+		}
 	}
 	// Give the remainder to the last node (must also be aligned).
 	if memAssigned < memMb {
@@ -678,10 +747,13 @@ func (q *qemu) buildNUMATopology() ([]govmmQemu.NUMANode, []govmmQemu.NUMADist, 
 	var nodes []govmmQemu.NUMANode
 	var cpuOffset uint32
 	for i, gn := range numaNodes {
-		startCPU := cpuOffset
-		endCPU := startCPU + vcpusPerNode[i] - 1
-		cpuOffset = endCPU + 1
-		cpuRange := fmt.Sprintf("%d-%d", startCPU, endCPU)
+		var cpuRange string
+		if vcpusPerNode[i] > 0 {
+			startCPU := cpuOffset
+			endCPU := startCPU + vcpusPerNode[i] - 1
+			cpuOffset = endCPU + 1
+			cpuRange = fmt.Sprintf("%d-%d", startCPU, endCPU)
+		}
 
 		nodes = append(nodes, govmmQemu.NUMANode{
 			NodeID:         uint32(i),

--- a/src/runtime/virtcontainers/qemu_test.go
+++ b/src/runtime/virtcontainers/qemu_test.go
@@ -1602,6 +1602,77 @@ func TestBuildCoveredHostNodesInvalidParse(t *testing.T) {
 	assert.Equal(uint32(1), covered[1])
 }
 
+func TestVfioGuestNUMANodesFromHostSet(t *testing.T) {
+	assert := assert.New(t)
+
+	covered := buildCoveredHostNodes(twoNodeAutoTopology())
+	guestNodes := vfioGuestNUMANodesFromHostSet(covered, map[int]struct{}{0: {}, 1: {}})
+	assert.Len(guestNodes, 2)
+
+	guestNodes = vfioGuestNUMANodesFromHostSet(covered, map[int]struct{}{1: {}})
+	assert.Len(guestNodes, 1)
+	assert.Contains(guestNodes, uint32(1))
+}
+
+func TestNumaMemoryOnlyTopologyNeeded(t *testing.T) {
+	assert := assert.New(t)
+	topology := twoNodeAutoTopology()
+	bothNodes := map[int]struct{}{0: {}, 1: {}}
+	oneNode := map[int]struct{}{0: {}}
+
+	assert.True(numaMemoryOnlyTopologyNeeded(topology, 1, bothNodes))
+	assert.False(numaMemoryOnlyTopologyNeeded(topology, 2, bothNodes))
+	assert.False(numaMemoryOnlyTopologyNeeded(topology, 1, oneNode))
+	assert.False(numaMemoryOnlyTopologyNeeded(topology, 1, nil))
+}
+
+func TestBuildNUMATopologySkipsWhenLowVCPUsNoVFIO(t *testing.T) {
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+		t.Skipf("multi-NUMA not supported on %s", runtime.GOARCH)
+	}
+	assert := assert.New(t)
+	q := &qemu{
+		config: HypervisorConfig{
+			DefaultMaxVCPUs: 1,
+			MemorySize:      65536,
+			GuestNUMANodes:  twoNodeAutoTopology(),
+		},
+	}
+	nodes, dists, err := q.buildNUMATopology()
+	assert.NoError(err)
+	assert.Nil(nodes)
+	assert.Nil(dists)
+}
+
+func TestBuildNUMATopologyMemoryOnlyNodesForMultiNodeVFIO(t *testing.T) {
+	if runtime.GOARCH != "amd64" && runtime.GOARCH != "arm64" {
+		t.Skipf("multi-NUMA not supported on %s", runtime.GOARCH)
+	}
+	assert := assert.New(t)
+
+	// Mirror the 8-GPU dual-socket case: 1 vCPU, 64Gi, VFIO on both host
+	// nodes. The guest must still get two NUMA nodes (memory-only on node 1)
+	// so pxb-pcie can use numa_node=0 and numa_node=1.
+	q := &qemu{
+		config: HypervisorConfig{
+			DefaultMaxVCPUs:   1,
+			MemorySize:        65536,
+			ConfidentialGuest: true,
+			GuestNUMANodes:    twoNodeAutoTopology(),
+		},
+	}
+
+	nodes, _, err := q.buildNUMATopologyForVFIOHostSet(map[int]struct{}{0: {}, 1: {}})
+	assert.NoError(err)
+	assert.Len(nodes, 2)
+	assert.Equal("0-0", nodes[0].CPUs)
+	assert.Equal("", nodes[1].CPUs)
+	assert.Equal("32768M", nodes[0].MemSize)
+	assert.Equal("32768M", nodes[1].MemSize)
+	assert.Equal("0", nodes[0].HostNodes)
+	assert.Equal("1", nodes[1].HostNodes)
+}
+
 // silentLogger returns a logrus.Entry that discards all output, suitable
 // for use in unit tests that exercise NUMA right-sizing decisions.
 func silentLogger() *logrus.Entry {

--- a/src/runtime/virtcontainers/sandbox.go
+++ b/src/runtime/virtcontainers/sandbox.go
@@ -3100,13 +3100,29 @@ func (s *Sandbox) checkVCPUsPinning(ctx context.Context) error {
 func (s *Sandbox) checkVCPUsPinningNUMA(ctx context.Context, vCPUThreadsMap VcpuThreadIDs, numaNodes []types.GuestNUMANode, cpuSetSlice []int) error {
 	numVCPUs := uint32(len(vCPUThreadsMap.vcpus))
 	numNodes := uint32(len(numaNodes))
-	if numVCPUs < numNodes {
-		return fmt.Errorf("number of vCPUs (%d) must be >= NUMA node count (%d) for NUMA pinning", numVCPUs, numNodes)
-	}
 
-	vcpusPerNode, err := utils.DistributeVCPUsProportionally(numaNodes, numVCPUs)
-	if err != nil {
-		return fmt.Errorf("failed to compute NUMA vCPU distribution for pinning: %v", err)
+	var vcpusPerNode []uint32
+	if numVCPUs >= numNodes {
+		var err error
+		vcpusPerNode, err = utils.DistributeVCPUsProportionally(numaNodes, numVCPUs)
+		if err != nil {
+			return fmt.Errorf("failed to compute NUMA vCPU distribution for pinning: %v", err)
+		}
+	} else {
+		// Fewer vCPUs than NUMA nodes.  This is expected when a memory-only
+		// NUMA topology is emitted to enable multi-node pxb-pcie placement
+		// for VFIO GPUs (e.g. default_vcpus=1 on a dual-socket DGX).  Give
+		// 1 vCPU to each of the first numVCPUs nodes and 0 to the rest; the
+		// loop below skips nodes with 0 vCPUs so no pinning is attempted for
+		// memory-only nodes.
+		s.Logger().WithFields(logrus.Fields{
+			"vcpus":      numVCPUs,
+			"numa-nodes": numNodes,
+		}).Warn("fewer vCPUs than NUMA nodes (memory-only topology); pinning available vCPU(s) to first node(s)")
+		vcpusPerNode = make([]uint32, numNodes)
+		for i := uint32(0); i < numVCPUs; i++ {
+			vcpusPerNode[i] = 1
+		}
 	}
 
 	cpuSetAll := cpuset.NewCPUSet(cpuSetSlice...)

--- a/src/runtime/virtcontainers/sandbox_test.go
+++ b/src/runtime/virtcontainers/sandbox_test.go
@@ -1680,17 +1680,31 @@ func TestSandboxHugepageLimit(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestCheckVCPUsPinningNUMATooFewVCPUs(t *testing.T) {
+// TestCheckVCPUsPinningNUMAMemoryOnly verifies that when vCPUs < NUMA nodes
+// (memory-only topology for pxb-pcie GPU placement), the function does not
+// return a vCPU-distribution error — the single vCPU is assigned to the first
+// node, memory-only nodes receive 0 vCPUs and are skipped in the pinning loop.
+// SetThreadAffinity may fail in the test environment (no real thread to pin),
+// so we accept any low-level affinity error but must not see a topology error.
+func TestCheckVCPUsPinningNUMAMemoryOnly(t *testing.T) {
 	assert := assert.New(t)
 	s := &Sandbox{}
+	// 1 vCPU, 2 NUMA nodes — simulates memory-only node 1 for pxb-pcie.
 	vCPUThreadsMap := VcpuThreadIDs{vcpus: map[int]int{0: 100}}
 	numaNodes := []types.GuestNUMANode{
 		{HostNodes: "0", HostCPUs: "0-3"},
 		{HostNodes: "1", HostCPUs: "4-7"},
 	}
 	err := s.checkVCPUsPinningNUMA(context.Background(), vCPUThreadsMap, numaNodes, []int{0, 1, 2, 3, 4, 5, 6, 7})
-	assert.Error(err)
-	assert.Contains(err.Error(), "must be >= NUMA node count")
+	if err != nil {
+		// The only permissible failure here is a low-level affinity syscall
+		// error (no real thread in the test process).  A NUMA-topology error
+		// — "no NUMA nodes", "HostCPUs … must not be empty", or a vCPU
+		// distribution failure — must never be returned.
+		assert.NotContains(err.Error(), "no NUMA nodes")
+		assert.NotContains(err.Error(), "HostCPUs")
+		assert.NotContains(err.Error(), "failed to compute NUMA vCPU distribution")
+	}
 }
 
 func TestCheckVCPUsPinningNUMABadHostCPUs(t *testing.T) {


### PR DESCRIPTION
When VFIO GPUs span both host NUMA nodes, emit guest NUMA nodes even
if vCPUs < node count (memory-only nodes), and pin each pxb-pcie to
bus=pcie.0 so QEMU does not attach the second expander to the first.

Also fix checkVCPUsPinningNUMA to tolerate vCPUs < NUMA node count.
The memory-only NUMA topology (emitted for pxb-pcie placement when
default_vcpus=1) creates more guest NUMA nodes than there are vCPUs;
the previous hard error silently tore down every sandbox.  Now the
available vCPU(s) are pinned to the first node(s) and memory-only
nodes are skipped.