### PR TITLE
runtime: check agent readiness before template snapshot

### DIFF
--- a/src/runtime/virtcontainers/factory/template/template_linux.go
+++ b/src/runtime/virtcontainers/factory/template/template_linux.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"syscall"
-	"time"
 
 	pb "github.com/kata-containers/kata-containers/src/runtime/protocols/cache"
 	vc "github.com/kata-containers/kata-containers/src/runtime/virtcontainers"
@@ -24,8 +23,6 @@ type template struct {
 	statePath string
 	config    vc.VMConfig
 }
-
-var templateWaitForAgent = 2 * time.Second
 
 // Fetch finds and returns a pre-built template factory.
 // TODO: save template metadata and fetch from storage.
@@ -147,14 +144,9 @@ func (t *template) createTemplateVM(ctx context.Context) error {
 		return err
 	}
 
-	// Sleep a bit to let the agent grpc server clean up
-	// When we close connection to the agent, it needs sometime to cleanup
-	// and restart listening on the communication( serial or vsock) port.
-	// That time can be saved if we sleep a bit to wait for the agent to
-	// come around and start listening again. The sleep is only done when
-	// creating new vm templates and saves time for every new vm that are
-	// created from template, so it worth the invest.
-	time.Sleep(templateWaitForAgent)
+	if err = vm.CheckAgentReady(ctx); err != nil {
+		return err
+	}
 
 	if err = vm.Pause(ctx); err != nil {
 		return err

--- a/src/runtime/virtcontainers/factory/template/template_test.go
+++ b/src/runtime/virtcontainers/factory/template/template_test.go
@@ -29,8 +29,6 @@ func TestTemplateFactory(t *testing.T) {
 
 	assert := assert.New(t)
 
-	templateWaitForAgent = 1 * time.Microsecond
-
 	testDir := t.TempDir()
 
 	hyperConfig := vc.HypervisorConfig{

--- a/src/runtime/virtcontainers/vm.go
+++ b/src/runtime/virtcontainers/vm.go
@@ -252,6 +252,20 @@ func (v *VM) Disconnect(ctx context.Context) error {
 	return nil
 }
 
+// CheckAgentReady verifies that the guest agent is reachable and serving.
+// It always attempts to disconnect the agent before returning. The disconnect
+// is best-effort and does not change the readiness check result.
+func (v *VM) CheckAgentReady(ctx context.Context) error {
+	v.logger().Info("check agent readiness")
+	defer func() {
+		if err := v.agent.disconnect(ctx); err != nil {
+			v.logger().WithError(err).Warn("failed to disconnect agent after readiness check")
+		}
+	}()
+
+	return v.agent.check(ctx)
+}
+
 // Stop stops a VM process.
 func (v *VM) Stop(ctx context.Context) error {
 	v.logger().Info("stop vm")

--- a/src/runtime/virtcontainers/vm_test.go
+++ b/src/runtime/virtcontainers/vm_test.go
@@ -84,3 +84,52 @@ func TestNewVM(t *testing.T) {
 	_, err = NewVM(ctx, config)
 	assert.Nil(err)
 }
+
+type checkAgentReadyTestAgent struct {
+	mockAgent
+	checkErr      error
+	checked       bool
+	disconnects   int
+	disconnectErr error
+}
+
+func (a *checkAgentReadyTestAgent) check(ctx context.Context) error {
+	a.checked = true
+	return a.checkErr
+}
+
+func (a *checkAgentReadyTestAgent) disconnect(ctx context.Context) error {
+	a.disconnects++
+	return a.disconnectErr
+}
+
+func TestCheckAgentReadyDisconnectIsBestEffort(t *testing.T) {
+	assert := assert.New(t)
+
+	agent := &checkAgentReadyTestAgent{
+		disconnectErr: context.Canceled,
+	}
+	vm := &VM{
+		agent: agent,
+	}
+
+	err := vm.CheckAgentReady(context.Background())
+	assert.NoError(err)
+	assert.True(agent.checked)
+	assert.Equal(1, agent.disconnects)
+}
+
+func TestCheckAgentReadyReturnsCheckError(t *testing.T) {
+	assert := assert.New(t)
+
+	agent := &checkAgentReadyTestAgent{
+		checkErr: context.Canceled,
+	}
+	vm := &VM{
+		agent: agent,
+	}
+
+	err := vm.CheckAgentReady(context.Background())
+	assert.ErrorIs(err, context.Canceled)
+	assert.Equal(1, agent.disconnects)
+}


### PR DESCRIPTION
Template creation currently sleeps for two seconds after disconnecting from the agent before pausing and saving the VM state. The sleep is a fixed heuristic for the time needed by the agent endpoint to become reachable again.

Replace that delay with a readiness probe that sends the agent CheckRequest. The kata agent runs CheckRequest with checkRequestTimeout, currently 30 seconds, so the probe already waits for the endpoint to answer within the existing agent RPC timeout. If the agent is still unavailable after that timeout, template creation should fail instead of hiding the problem behind another retry loop.

After a successful probe, close the agent connection best-effort. This keeps the template snapshot from capturing a host-side agent connection when long-lived agent connections are enabled.