### PR TITLE
runtime-rs: fix vCPU pinning silently disabled with overhead_vcpus > 0

### DIFF
--- a/src/runtime-rs/crates/resource/src/cgroups/resource_inner.rs
+++ b/src/runtime-rs/crates/resource/src/cgroups/resource_inner.rs
@@ -343,49 +343,63 @@ impl CgroupsResourceInner {
         let num_vcpus = thread_ids.vcpus.len();
         let num_cpus = cpuset_slice.len();
 
-        if num_vcpus == 0 || num_cpus == 0 || num_vcpus != num_cpus {
-            if num_vcpus == 0 {
-                info!(sl!(), "vCPU pinning: no vCPU threads found, skipping");
-            } else if num_cpus == 0 {
-                info!(sl!(), "vCPU pinning: no cpuset configured, skipping");
-            } else {
-                info!(
-                    sl!(),
-                    "vCPU pinning: vCPU count ({}) != cpuset size ({}), pinning not possible",
-                    num_vcpus,
-                    num_cpus
-                );
+        // The pinning decision (which vCPU pins to which host CPU, and which
+        // overhead vCPUs float) is computed by `plan_vcpus_pinning` so it can
+        // be unit-tested without issuing real `sched_setaffinity` syscalls.
+        match plan_vcpus_pinning(&thread_ids.vcpus, &cpuset_slice) {
+            VcpuPinningPlan::Skip => {
+                if num_vcpus == 0 {
+                    info!(sl!(), "vCPU pinning: no vCPU threads found, skipping");
+                } else if num_cpus == 0 {
+                    info!(sl!(), "vCPU pinning: no cpuset configured, skipping");
+                } else {
+                    info!(
+                        sl!(),
+                        "vCPU pinning: vCPU count ({}) < cpuset size ({}), pinning not possible",
+                        num_vcpus,
+                        num_cpus
+                    );
+                }
+                if self.is_vcpus_pinning_on && num_vcpus > 0 {
+                    info!(sl!(), "vCPU pinning: resetting previous pinning");
+                    self.reset_vcpus_pinning(&thread_ids.vcpus, &cpuset_slice)?;
+                    self.is_vcpus_pinning_on = false;
+                }
+                Ok(())
             }
-            if self.is_vcpus_pinning_on && num_vcpus > 0 {
-                info!(sl!(), "vCPU pinning: resetting previous pinning");
-                self.reset_vcpus_pinning(&thread_ids.vcpus, &cpuset_slice)?;
-                self.is_vcpus_pinning_on = false;
+            VcpuPinningPlan::Pin {
+                assignments,
+                floating,
+            } => {
+                for (tid, cpu) in &assignments {
+                    if let Err(e) = Self::set_thread_affinity(*tid, std::slice::from_ref(cpu)) {
+                        // On failure, reset all pinning and propagate the error
+                        let _ = self.reset_vcpus_pinning(&thread_ids.vcpus, &cpuset_slice);
+                        return Err(e)
+                            .context(format!("failed to pin vCPU thread {} to CPU {}", tid, cpu));
+                    }
+                }
+
+                self.is_vcpus_pinning_on = true;
+                if floating.is_empty() {
+                    info!(
+                        sl!(),
+                        "vCPU pinning: pinned {} vCPU threads to cpuset {:?}",
+                        assignments.len(),
+                        cpuset_slice
+                    );
+                } else {
+                    info!(
+                        sl!(),
+                        "vCPU pinning: pinned {} workload vCPU threads to cpuset {:?} ({} overhead vCPU(s) left floating)",
+                        assignments.len(),
+                        cpuset_slice,
+                        floating.len(),
+                    );
+                }
+                Ok(())
             }
-            return Ok(());
         }
-
-        // Pin vCPU i to cpuset_slice[i] (both sorted by index)
-        let mut sorted_vcpus: Vec<(u32, u32)> = thread_ids.vcpus.into_iter().collect();
-        sorted_vcpus.sort_by_key(|(idx, _)| *idx);
-
-        for (i, (_vcpu_idx, tid)) in sorted_vcpus.iter().enumerate() {
-            if let Err(e) = Self::set_thread_affinity(*tid, &cpuset_slice[i..i + 1]) {
-                // On failure, reset all pinning and propagate the error
-                let all_vcpus: HashMap<u32, u32> = sorted_vcpus.iter().copied().collect();
-                let _ = self.reset_vcpus_pinning(&all_vcpus, &cpuset_slice);
-                return Err(e).context(format!(
-                    "failed to pin vCPU thread {} to CPU {}",
-                    tid, cpuset_slice[i]
-                ));
-            }
-        }
-
-        self.is_vcpus_pinning_on = true;
-        info!(
-            sl!(),
-            "vCPU pinning: pinned {} vCPU threads to cpuset {:?}", num_vcpus, cpuset_slice
-        );
-        Ok(())
     }
 
     fn reset_vcpus_pinning(&self, vcpus: &HashMap<u32, u32>, cpuset_slice: &[u32]) -> Result<()> {
@@ -478,6 +492,72 @@ impl CgroupsResourceInner {
         }
 
         Ok(())
+    }
+}
+
+/// The decision produced by [`plan_vcpus_pinning`]: either skip pinning
+/// entirely, or pin a set of vCPU threads 1:1 to host CPUs while leaving any
+/// overhead vCPU threads floating.
+///
+/// Keeping this decision separate from the `sched_setaffinity` syscalls lets
+/// it be unit-tested deterministically — it is the part of the logic that
+/// regressed when `overhead_vcpus > 0` made `num_vcpus > num_cpus`.
+#[derive(Debug, PartialEq, Eq)]
+enum VcpuPinningPlan {
+    /// Pinning is not possible/needed: no vCPU threads, no cpuset, or fewer
+    /// vCPU threads than CPUs in the sandbox cpuset (no 1:1 mapping).
+    Skip,
+    /// Pin each `(tid, host_cpu)` 1:1, ordered by ascending vCPU index, and
+    /// leave the `floating` thread ids unpinned (overhead vCPUs).
+    Pin {
+        assignments: Vec<(u32, u32)>,
+        floating: Vec<u32>,
+    },
+}
+
+/// Decide how to pin vCPU threads to a sandbox cpuset.
+///
+/// `vcpus` maps vCPU index -> host thread id; `cpuset_slice` is the list of
+/// host CPUs in the sandbox cpuset.
+///
+/// Rules:
+/// * Skip when there are no vCPU threads, no cpuset, or fewer vCPU threads
+///   than cpuset CPUs (a 1:1 mapping is impossible).
+/// * Otherwise pin the first `num_cpus` vCPUs — by ascending index, i.e. the
+///   workload vCPUs — 1:1 to `cpuset_slice`, and leave any remaining vCPUs
+///   (overhead, e.g. from `overhead_vcpus > 0`) floating. This is the case
+///   that previously regressed: a strict `num_vcpus == num_cpus` guard turned
+///   it into a Skip, silently disabling pinning for every Guaranteed pod on
+///   configs with a fractional `overhead_vcpus`.
+fn plan_vcpus_pinning(vcpus: &HashMap<u32, u32>, cpuset_slice: &[u32]) -> VcpuPinningPlan {
+    let num_vcpus = vcpus.len();
+    let num_cpus = cpuset_slice.len();
+
+    if num_vcpus == 0 || num_cpus == 0 || num_vcpus < num_cpus {
+        return VcpuPinningPlan::Skip;
+    }
+
+    // Sort by vCPU index so workload vCPUs (lower indices) pin first and any
+    // overhead vCPUs (higher indices) are the ones left floating.
+    let mut sorted_vcpus: Vec<(u32, u32)> =
+        vcpus.iter().map(|(idx, tid)| (*idx, *tid)).collect();
+    sorted_vcpus.sort_by_key(|(idx, _)| *idx);
+
+    let assignments = sorted_vcpus
+        .iter()
+        .take(num_cpus)
+        .enumerate()
+        .map(|(i, (_idx, tid))| (*tid, cpuset_slice[i]))
+        .collect();
+    let floating = sorted_vcpus
+        .iter()
+        .skip(num_cpus)
+        .map(|(_idx, tid)| *tid)
+        .collect();
+
+    VcpuPinningPlan::Pin {
+        assignments,
+        floating,
     }
 }
 
@@ -615,5 +695,121 @@ mod tests {
         let inner = make_inner_for_test(enable);
         assert_eq!(inner.enable_vcpus_pinning, enable);
         assert_eq!(inner.is_vcpus_pinning_on, expected_on);
+    }
+
+    /// Build a VcpuThreadIds with the given (vcpu_index, thread_id) pairs.
+    fn make_thread_ids(pairs: &[(u32, u32)]) -> VcpuThreadIds {
+        let vcpus: HashMap<u32, u32> = pairs.iter().copied().collect();
+        VcpuThreadIds { vcpus }
+    }
+
+    /// check_vcpus_pinning must be a no-op when the feature is disabled.
+    #[test]
+    fn test_check_vcpus_pinning_disabled() {
+        let mut inner = make_inner_for_test(false);
+        inner
+            .resources
+            .insert("c1".to_string(), make_resources_with_cpus("0-3"));
+        let tids = make_thread_ids(&[(0, 1), (1, 2), (2, 3), (3, 4)]);
+        inner.check_vcpus_pinning(tids).unwrap();
+        assert!(!inner.is_vcpus_pinning_on);
+    }
+
+    /// Pinning must be skipped when no cpuset has been configured yet (e.g.
+    /// when setup_after_start_vm fires before any container is added).
+    #[test]
+    fn test_check_vcpus_pinning_no_cpuset_skips() {
+        let mut inner = make_inner_for_test(true);
+        // No resources inserted -> cpuset is empty.
+        let tids = make_thread_ids(&[(0, 1), (1, 2)]);
+        inner.check_vcpus_pinning(tids).unwrap();
+        assert!(!inner.is_vcpus_pinning_on);
+    }
+
+    /// Pinning must be skipped when the vCPU count is less than the cpuset
+    /// size (can't do 1:1 pinning when there are too few vCPUs).
+    #[rstest]
+    #[case::two_vcpus_four_cpus(&[(0, 1), (1, 2)], "0-3")]
+    #[case::one_vcpu_two_cpus(&[(0, 1)], "0,1")]
+    fn test_check_vcpus_pinning_skip_when_fewer_vcpus_than_cpus(
+        #[case] vcpus: &[(u32, u32)],
+        #[case] cpuset: &str,
+    ) {
+        let mut inner = make_inner_for_test(true);
+        inner
+            .resources
+            .insert("c1".to_string(), make_resources_with_cpus(cpuset));
+        let tids = make_thread_ids(vcpus);
+        inner.check_vcpus_pinning(tids).unwrap();
+        assert!(!inner.is_vcpus_pinning_on);
+    }
+
+    /// Deterministic coverage of the pinning *decision* (which vCPU maps to
+    /// which host CPU, and which overhead vCPUs float) without issuing any
+    /// real sched_setaffinity syscalls.
+    ///
+    /// `overhead_one` is the regression case for this fix: 3 vCPU threads
+    /// (e.g. workload 2 + overhead_vcpus 0.5 rounded up) against a 2-CPU
+    /// cpuset must pin vCPU 0 and 1 to the two pod CPUs 1:1 and leave the
+    /// highest-index (overhead) vCPU floating. Before the fix this returned
+    /// Skip, silently disabling pinning.
+    #[rstest]
+    #[case::overhead_one(
+        vec![(0, 100), (1, 101), (2, 102)],
+        vec![4, 6],
+        vec![(100, 4), (101, 6)],
+        vec![102]
+    )]
+    #[case::exact_match(
+        vec![(0, 100), (1, 101)],
+        vec![4, 6],
+        vec![(100, 4), (101, 6)],
+        vec![]
+    )]
+    #[case::unsorted_indices_pin_by_ascending_index(
+        vec![(2, 102), (0, 100), (1, 101)],
+        vec![5, 7],
+        vec![(100, 5), (101, 7)],
+        vec![102]
+    )]
+    #[case::two_overhead(
+        vec![(0, 100), (1, 101), (2, 102), (3, 103)],
+        vec![8, 9],
+        vec![(100, 8), (101, 9)],
+        vec![102, 103]
+    )]
+    fn test_plan_vcpus_pinning_pins(
+        #[case] vcpus: Vec<(u32, u32)>,
+        #[case] cpuset: Vec<u32>,
+        #[case] expected_assignments: Vec<(u32, u32)>,
+        #[case] expected_floating: Vec<u32>,
+    ) {
+        let map: HashMap<u32, u32> = vcpus.into_iter().collect();
+        match plan_vcpus_pinning(&map, &cpuset) {
+            VcpuPinningPlan::Pin {
+                assignments,
+                mut floating,
+            } => {
+                assert_eq!(
+                    assignments, expected_assignments,
+                    "1:1 assignments must follow ascending vCPU index"
+                );
+                floating.sort_unstable();
+                let mut expected = expected_floating.clone();
+                expected.sort_unstable();
+                assert_eq!(floating, expected, "overhead vCPUs left floating");
+            }
+            VcpuPinningPlan::Skip => panic!("expected Pin, got Skip"),
+        }
+    }
+
+    #[rstest]
+    #[case::no_vcpus(vec![], vec![0, 1])]
+    #[case::no_cpuset(vec![(0, 100)], vec![])]
+    #[case::fewer_vcpus_than_cpus(vec![(0, 100)], vec![0, 1, 2])]
+    #[case::both_empty(vec![], vec![])]
+    fn test_plan_vcpus_pinning_skips(#[case] vcpus: Vec<(u32, u32)>, #[case] cpuset: Vec<u32>) {
+        let map: HashMap<u32, u32> = vcpus.into_iter().collect();
+        assert_eq!(plan_vcpus_pinning(&map, &cpuset), VcpuPinningPlan::Skip);
     }
 }

--- a/tests/integration/kubernetes/k8s-vcpu-pinning.bats
+++ b/tests/integration/kubernetes/k8s-vcpu-pinning.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Regression test: a Guaranteed-QoS pod's vCPU threads must be pinned 1:1 to
+# host CPUs when enable_vcpus_pinning=true and static_sandbox_resource_mgmt=true.
+#
+# With overhead_vcpus=0.5 the VM boots one more vCPU than the pod has CPUs
+# (ceil(N+0.5)=N+1); the first N "CPU n/KVM" threads must be pinned 1:1 to
+# distinct host CPUs, and the single overhead vCPU is allowed to float.
+#
+# IMPORTANT — what this test can and cannot validate:
+#   The Kata runtime pins vCPU threads to the host cpuset that the kubelet's
+#   static CPU manager assigns to the (Guaranteed) container.  When that
+#   policy is NOT active, the container gets no exclusive cpuset:
+#     * The Go runtime still pins because enable_numa=true gives it a
+#       NUMA-derived host-CPU fallback.
+#     * runtime-rs does NOT implement NUMA yet, so with no cpuset it has
+#       nothing to pin to and correctly skips.
+#   Therefore this test only exercises the pinning path on nodes whose
+#   kubelet runs the *static* CPU manager policy; otherwise it skips.  The
+#   no-cpuset case for runtime-rs will only pin once NUMA support lands.
+#
+# Prerequisites:
+# * KATA_HYPERVISOR ships enable_vcpus_pinning=true (NVIDIA GPU configs).
+# * The node's kubelet runs --cpu-manager-policy=static (test skips otherwise).
+# * The bats runner executes directly on the node with sudo access to
+#   /proc, crictl, and taskset — same requirement as k8s-nvidia-numa.bats.
+
+load "${BATS_TEST_DIRNAME}/lib.sh"
+load "${BATS_TEST_DIRNAME}/../../common.bash"
+load "${BATS_TEST_DIRNAME}/tests_common.sh"
+
+# Hypervisors that ship enable_vcpus_pinning = true by default.
+# Covers both Go ("qemu-nvidia-gpu*") and runtime-rs ("*-runtime-rs") variants.
+VCPU_PINNING_SUPPORTED_BY_DEFAULT=(
+    "qemu-nvidia-gpu"
+    "qemu-nvidia-gpu-snp"
+    "qemu-nvidia-gpu-tdx"
+    "qemu-nvidia-gpu-runtime-rs"
+    "qemu-nvidia-gpu-snp-runtime-rs"
+    "qemu-nvidia-gpu-tdx-runtime-rs"
+)
+
+# Number of exclusive integer CPUs requested by the pod.  The pod YAML must
+# request the same value.
+VCPU_PINNING_TEST_CPUS="${VCPU_PINNING_TEST_CPUS:-2}"
+
+POD_NAME_PIN="vcpu-pinning-test"
+POD_WAIT_TIMEOUT="${POD_WAIT_TIMEOUT:-120s}"
+
+# Retry parameters for the host-side pinning poll.  The runtime pins vCPU
+# threads shortly after sandbox creation; give it up to ~20 s.
+HOST_PINNING_RETRIES="${HOST_PINNING_RETRIES:-20}"
+HOST_PINNING_SLEEP="${HOST_PINNING_SLEEP:-1}"
+
+setup() {
+    setup_common || die "setup_common failed"
+
+    # Only run on hypervisors that have pinning enabled by default.
+    # shellcheck disable=SC2076
+    if [[ ! " ${VCPU_PINNING_SUPPORTED_BY_DEFAULT[*]} " =~ " ${KATA_HYPERVISOR} " ]]; then
+        skip "enable_vcpus_pinning not configured by default on ${KATA_HYPERVISOR}"
+    fi
+
+    yaml_file="${pod_config_dir}/pod-vcpu-pinning.yaml"
+    set_node "${yaml_file}" "${node}"
+
+    policy_settings_dir="$(create_tmp_policy_settings_dir "${pod_config_dir}")"
+    add_requests_to_policy_settings "${policy_settings_dir}" "ReadStreamRequest"
+    auto_generate_policy "${policy_settings_dir}" "${yaml_file}"
+}
+
+# ---------------------------------------------------------------------------
+# Skip / host-side helpers
+# ---------------------------------------------------------------------------
+
+# cpu_manager_policy echoes the kubelet's CPU manager policyName for the
+# target node (e.g. "static" or "none"), or "" if the state file is absent.
+cpu_manager_policy() {
+    local kubelet_data_dir state_file
+    kubelet_data_dir="$(get_kubelet_data_dir)"
+    state_file="${kubelet_data_dir}/cpu_manager_state"
+
+    exec_host "${node}" "test -f '${state_file}'" >/dev/null 2>&1 || return 0
+    exec_host "${node}" \
+        "grep -oE '\"policyName\"[[:space:]]*:[[:space:]]*\"[^\"]*\"' '${state_file}' | head -1" \
+        2>/dev/null | sed -E 's/.*:[[:space:]]*"([^"]*)"/\1/'
+}
+
+# get_qemu_pid_for_pin_pod resolves the running pod's sandbox via crictl
+# and returns the QEMU PID.  Fails the test if either lookup is empty.
+get_qemu_pid_for_pin_pod() {
+    local sandbox_id qemu_pid
+    sandbox_id=$(sudo crictl --runtime-endpoint unix:///run/containerd/containerd.sock \
+        pods --name "${POD_NAME_PIN}" -q | head -1)
+    [[ -n "${sandbox_id}" ]] || die "no sandbox id found for pod ${POD_NAME_PIN}"
+
+    qemu_pid=$(sudo pgrep -f "qemu.*${sandbox_id}" | head -1)
+    [[ -n "${qemu_pid}" ]] || die "no QEMU PID found for sandbox ${sandbox_id}"
+    echo "${qemu_pid}"
+}
+
+# wait_for_vcpu_pinning <qemu_pid> <expected_pinned>
+# Poll vcpu-pinning-check.sh until at least <expected_pinned> vCPU threads
+# report single-CPU affinity, or HOST_PINNING_RETRIES is exhausted.
+# Echoes the final script output regardless of convergence so callers can
+# assert on the full picture.
+wait_for_vcpu_pinning() {
+    local qemu_pid="${1}" expected="${2}"
+    local script="${BATS_TEST_DIRNAME}/vcpu-pinning-check.sh"
+    local output pinned
+    local attempt
+
+    for ((attempt = 1; attempt <= HOST_PINNING_RETRIES; attempt++)); do
+        output=$(sudo bash "${script}" "${qemu_pid}")
+        pinned=$(echo "${output}" | grep -c '^pinned ' || true)
+        if (( pinned >= expected )); then
+            echo "${output}"
+            return 0
+        fi
+        echo "# vCPU pinning attempt ${attempt}/${HOST_PINNING_RETRIES}: ${pinned}/${expected} threads pinned" >&2
+        sleep "${HOST_PINNING_SLEEP}"
+    done
+
+    echo "${output}"
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+@test "vCPU pinning: Guaranteed pod vCPU threads are pinned 1:1 to host CPUs" {
+    # The runtime can only pin to an exclusive cpuset that the kubelet's
+    # static CPU manager assigns.  Without the static policy the container
+    # gets no cpuset; Go would still pin via its NUMA-derived fallback, but
+    # runtime-rs has no NUMA support and (correctly) cannot pin.  Skip here
+    # so the test only asserts where pinning is actually expected to work.
+    # This case will start passing for runtime-rs once NUMA lands.
+    local cpu_policy
+    cpu_policy="$(cpu_manager_policy)"
+    if [[ "${cpu_policy}" != "static" ]]; then
+        skip "kubelet CPU manager policy is '${cpu_policy:-none/absent}', need 'static' for an exclusive cpuset; runtime-rs pinning without one requires NUMA support (not yet implemented) — will pass once NUMA lands"
+    fi
+
+    # Deploy the Guaranteed-QoS pod and wait for it to be ready.
+    kubectl apply -f "${yaml_file}"
+    kubectl wait --for=condition=Ready --timeout="${POD_WAIT_TIMEOUT}" pod "${POD_NAME_PIN}"
+
+    local qemu_pid
+    qemu_pid=$(get_qemu_pid_for_pin_pod)
+    echo "# QEMU PID: ${qemu_pid}"
+
+    # Poll until the runtime has had time to pin the vCPU threads.
+    local pinning_output
+    pinning_output=$(wait_for_vcpu_pinning "${qemu_pid}" "${VCPU_PINNING_TEST_CPUS}")
+    echo "# vCPU pinning check output:"
+    echo "${pinning_output}" | while IFS= read -r line; do echo "#   ${line}"; done
+
+    # --- Assertion 1: at least VCPU_PINNING_TEST_CPUS workload vCPUs are pinned ---
+    #
+    # Before the fix (runtime-rs + overhead_vcpus=0.5): pinned == 0 because
+    # num_vcpus(N+1) != num_cpus(N) caused the runtime to skip pinning.
+    # After the fix: the first N vCPUs (by index) are pinned 1:1.
+    local pinned_count
+    pinned_count=$(echo "${pinning_output}" | grep -c '^pinned ' || true)
+    echo "# Pinned vCPU threads: ${pinned_count} (need >= ${VCPU_PINNING_TEST_CPUS})"
+    (( pinned_count >= VCPU_PINNING_TEST_CPUS )) || \
+        die "vCPU pinning broken: expected >= ${VCPU_PINNING_TEST_CPUS} pinned threads, got ${pinned_count}. Full output: ${pinning_output}"
+
+    # --- Assertion 2: each pinned vCPU maps to a *distinct* host CPU ---
+    #
+    # Verifies true 1:1 pinning, not a degenerate "all pinned to CPU 0".
+    # Extract the host CPU column (field 3) from "pinned <idx> <cpu>" lines.
+    local pinned_cpus distinct_count
+    pinned_cpus=$(echo "${pinning_output}" | awk '/^pinned / {print $3}')
+    distinct_count=$(echo "${pinned_cpus}" | sort -u | wc -l)
+    echo "# Distinct host CPUs used for pinning: ${distinct_count} (need ${pinned_count})"
+    (( distinct_count == pinned_count )) || \
+        die "vCPU pinning is not 1:1: ${pinned_count} pinned threads share only ${distinct_count} distinct host CPUs. Full output: ${pinning_output}"
+
+    # --- Informational: report overhead vCPUs (index >= VCPU_PINNING_TEST_CPUS) ---
+    #
+    # With overhead_vcpus > 0 (e.g. 0.5 on runtime-rs GPU configs) the VM
+    # boots one more vCPU than the pod has CPUs.  After the fix the excess
+    # vCPU is expected to float — it is constrained by the sandbox cgroup
+    # cpuset but is not 1:1 pinned.  That is correct behaviour.
+    local floating_count
+    floating_count=$(echo "${pinning_output}" | grep -c '^floating ' || true)
+    if (( floating_count > 0 )); then
+        echo "# ${floating_count} overhead vCPU thread(s) are floating (expected for overhead_vcpus > 0)"
+    fi
+}
+
+teardown() {
+    # Mirror the setup() skip so teardown does not run against state that
+    # was never initialised (policy_settings_dir, yaml_file, …).
+    # shellcheck disable=SC2076
+    [[ " ${VCPU_PINNING_SUPPORTED_BY_DEFAULT[*]} " =~ " ${KATA_HYPERVISOR} " ]] || return 0
+
+    echo "=== vCPU pinning test pod describe ==="
+    kubectl describe pod "${POD_NAME_PIN}" || true
+
+    kubectl delete pod "${POD_NAME_PIN}" --ignore-not-found --timeout=60s || true
+
+    delete_tmp_policy_settings_dir "${policy_settings_dir}"
+    teardown_common "${node}" "${node_start_time:-}"
+}

--- a/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
+++ b/tests/integration/kubernetes/run_kubernetes_nv_tests.sh
@@ -73,6 +73,7 @@ if [[ -n "${K8S_TEST_NV:-}" ]]; then
 else
 	K8S_TEST_NV=("k8s-confidential-attestation.bats" \
 		"k8s-nvidia-numa.bats" \
+		"k8s-vcpu-pinning.bats" \
 		"k8s-nvidia-cuda.bats" \
 		"k8s-nvidia-nim.bats" \
 		"k8s-nvidia-nim-service.bats")

--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-vcpu-pinning.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-vcpu-pinning.yaml
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Guaranteed-QoS pod for the vCPU pinning regression test.
+#
+# requests == limits on an integer cpu makes the pod Guaranteed QoS, which is
+# what the Kubernetes static CPU manager requires to hand out exclusive host
+# CPUs.  That exclusive cpuset is what the Kata runtime pins vCPU threads to.
+#
+# With overhead_vcpus = 0.5 (the runtime-rs GPU/CoCo default) and 2 CPUs the
+# VM boots ceil(2 + 0.5) = 3 vCPUs while the pod cpuset has 2 CPUs.  This is
+# the exact condition that used to make runtime-rs skip pinning entirely.
+apiVersion: v1
+kind: Pod
+metadata:
+  name: vcpu-pinning-test
+spec:
+  runtimeClassName: kata
+  containers:
+  - name: workload
+    image: quay.io/prometheus/busybox:latest
+    command: ["sleep", "infinity"]
+    resources:
+      requests:
+        cpu: "2"
+        memory: "256Mi"
+      limits:
+        cpu: "2"
+        memory: "256Mi"

--- a/tests/integration/kubernetes/vcpu-pinning-check.sh
+++ b/tests/integration/kubernetes/vcpu-pinning-check.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+#
+# Copyright (c) 2026 NVIDIA Corporation
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# WARNING: This script runs directly on the host, NOT inside a container.
+# It requires privileged access to /proc and taskset to inspect QEMU vCPU
+# thread CPU affinities.
+#
+# Usage: vcpu-pinning-check.sh <qemu_pid>
+#
+# For every "CPU N/KVM" thread found in the QEMU process, print one line:
+#   pinned <vcpu_idx> <host_cpu>     — thread is pinned to exactly one host CPU
+#   floating <vcpu_idx>              — thread affinity spans multiple CPUs
+#
+# Lines are emitted in ascending vCPU-index order.  A thread is counted as
+# pinned only when taskset reports a bare integer (single CPU).
+
+set -o pipefail
+
+QEMU_PID="${1:?Usage: $0 <qemu_pid>}"
+
+if [[ ! -d "/proc/${QEMU_PID}/task" ]]; then
+    echo "ERROR: /proc/${QEMU_PID}/task not found" >&2
+    exit 1
+fi
+
+for tid_dir in "/proc/${QEMU_PID}/task/"*; do
+    tid="${tid_dir##*/}"
+    comm=$(cat "${tid_dir}/comm" 2>/dev/null || true)
+
+    # Only inspect vCPU KVM threads (names like "CPU 0/KVM", "CPU 1/KVM", …).
+    [[ "${comm}" =~ ^CPU\ ([0-9]+)/KVM$ ]] || continue
+    vcpu_idx="${BASH_REMATCH[1]}"
+
+    list=$(taskset -pc "${tid}" 2>/dev/null | sed 's/.*: //')
+    if [[ "${list}" =~ ^[0-9]+$ ]]; then
+        # Pinned to a single host CPU.
+        printf "pinned %d %d\n" "${vcpu_idx}" "${list}"
+    else
+        # Floating across multiple CPUs (not 1:1 pinned).
+        printf "floating %d\n" "${vcpu_idx}"
+    fi
+done | sort -k2 -n


### PR DESCRIPTION
With overhead_vcpus = 0.5 (the default for GPU/CoCo configs) and static_sandbox_resource_mgmt = true, the VM boots with ceil(0.5 + N) = N + 1 vCPUs for any integer-CPU Guaranteed pod. The old check_vcpus_pinning guard used strict equality:

  if num_vcpus != num_cpus { skip }

Since N+1 != N always, pinning was silently skipped for every Guaranteed pod on configs with fractional overhead_vcpus.


Assisted-by: Cursor <cursoragent@cursor.com>