### PR TITLE
tests: add supplementalGroups to pod-number-cpu for guest-pull

### DIFF
--- a/tests/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
+++ b/tests/integration/kubernetes/runtimeclass_workloads/pod-number-cpu.yaml
@@ -9,6 +9,8 @@ metadata:
   name: cpu-test
 spec:
   runtimeClassName: kata
+  securityContext:
+    supplementalGroups: [10]
   containers:
   - name: c1
     image: quay.io/prometheus/busybox:latest


### PR DESCRIPTION
The genpolicy guest-pull check now fails closed when an image carries supplemental groups that containerd won't reproduce while pulling the layers inside the guest, and quay.io/prometheus/busybox:latest happens to ship gid 10 (wheel).  pod-number-cpu.yaml was simply missed when the other busybox manifests got their securityContext, so genpolicy bails out on the expected/actual gid mismatch.

Let's declare supplementalGroups: [10] explicitly, just like we already do for the other busybox-based pods, so the generated policy lines up with what containerd actually applies.


Assisted-by: Cursor <cursoragent@cursor.com>