### PR TITLE
ci: add explanatory comments to workflow permissions

### DIFF
--- a/.github/workflows/build-kata-static-tarball-amd64.yaml
+++ b/.github/workflows/build-kata-static-tarball-amd64.yaml
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     strategy:
       matrix:
         asset:
@@ -203,7 +203,7 @@ jobs:
     needs: build-asset
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -317,7 +317,7 @@ jobs:
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts, remove-rootfs-binary-artifacts-for-release]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -388,7 +388,7 @@ jobs:
     needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -435,7 +435,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -501,7 +501,7 @@ jobs:
     needs: [build-tools-asset]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/build-kata-static-tarball-arm64.yaml
+++ b/.github/workflows/build-kata-static-tarball-arm64.yaml
@@ -38,9 +38,9 @@ jobs:
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     strategy:
       matrix:
         asset:
@@ -197,7 +197,7 @@ jobs:
     needs: build-asset
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -304,7 +304,7 @@ jobs:
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts, remove-rootfs-binary-artifacts-for-release]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -372,7 +372,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -431,7 +431,7 @@ jobs:
     needs: [build-tools-asset]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -480,7 +480,7 @@ jobs:
     needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/build-kata-static-tarball-ppc64le.yaml
+++ b/.github/workflows/build-kata-static-tarball-ppc64le.yaml
@@ -35,7 +35,7 @@ jobs:
     name: build-asset
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-24.04-ppc64le
     strategy:
       matrix:
@@ -141,7 +141,7 @@ jobs:
     needs: build-asset
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -228,7 +228,7 @@ jobs:
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -297,7 +297,7 @@ jobs:
     needs: [build-asset, build-asset-rootfs, build-asset-shim-v2]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     steps:
       - name: Adjust a permission for repo
         run: |

--- a/.github/workflows/build-kata-static-tarball-riscv64.yaml
+++ b/.github/workflows/build-kata-static-tarball-riscv64.yaml
@@ -33,9 +33,9 @@ jobs:
     runs-on: riscv-builder
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     strategy:
       matrix:
         asset:

--- a/.github/workflows/build-kata-static-tarball-s390x.yaml
+++ b/.github/workflows/build-kata-static-tarball-s390x.yaml
@@ -37,9 +37,9 @@ jobs:
     runs-on: ubuntu-24.04-s390x
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     strategy:
       matrix:
         asset:
@@ -180,7 +180,7 @@ jobs:
     needs: build-asset
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -272,7 +272,7 @@ jobs:
     needs: [build-asset, build-asset-rootfs, remove-rootfs-binary-artifacts]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         asset:
@@ -346,7 +346,7 @@ jobs:
       - build-asset-shim-v2
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/build-kubectl-image.yaml
+++ b/.github/workflows/build-kubectl-image.yaml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push the kubectl image to ghcr.io
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/ci-devel.yaml
+++ b/.github/workflows/ci-devel.yaml
@@ -21,9 +21,9 @@ jobs:
   kata-containers-ci-on-push:
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/ci.yaml
     with:
       commit-hash: ${{ github.sha }}

--- a/.github/workflows/ci-nightly-riscv.yaml
+++ b/.github/workflows/ci-nightly-riscv.yaml
@@ -14,9 +14,9 @@ jobs:
   build-kata-static-tarball-riscv:
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/build-kata-static-tarball-riscv64.yaml
     with:
       tarball-suffix: -${{ github.sha }}

--- a/.github/workflows/ci-nightly.yaml
+++ b/.github/workflows/ci-nightly.yaml
@@ -13,9 +13,9 @@ jobs:
   kata-containers-ci-on-push:
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/ci.yaml
     with:
       commit-hash: ${{ github.sha }}

--- a/.github/workflows/ci-on-push.yaml
+++ b/.github/workflows/ci-on-push.yaml
@@ -32,9 +32,9 @@ jobs:
     if: ${{ needs.skipper.outputs.skip_build != 'yes' }}
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/ci.yaml
     with:
       commit-hash: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,9 +54,9 @@ jobs:
   build-kata-static-tarball-amd64:
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -69,7 +69,7 @@ jobs:
     needs: build-kata-static-tarball-amd64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -87,7 +87,7 @@ jobs:
     needs: build-kata-static-tarball-amd64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -105,9 +105,9 @@ jobs:
   build-kata-static-tarball-arm64:
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -120,7 +120,7 @@ jobs:
     needs: build-kata-static-tarball-arm64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -138,7 +138,7 @@ jobs:
     needs: build-kata-static-tarball-arm64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -156,9 +156,9 @@ jobs:
   build-kata-static-tarball-s390x:
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -170,7 +170,7 @@ jobs:
   build-kata-static-tarball-ppc64le:
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -183,7 +183,7 @@ jobs:
     needs: build-kata-static-tarball-s390x
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -201,7 +201,7 @@ jobs:
     needs: build-kata-static-tarball-s390x
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -220,7 +220,7 @@ jobs:
     needs: build-kata-static-tarball-ppc64le
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -238,7 +238,7 @@ jobs:
     needs: build-kata-static-tarball-ppc64le
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       tarball-suffix: -${{ inputs.tag }}
@@ -257,7 +257,7 @@ jobs:
     name: build-and-publish-tee-confidential-unencrypted-image
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout code

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,14 +36,9 @@ jobs:
     # Consider using larger runners or machines with greater resources for possible analysis time improvements.
     runs-on: ubuntu-24.04
     permissions:
-      # required for all workflows
-      security-events: write
-
-      # required to fetch internal or private CodeQL packs
-      packages: read
-
-      # only required for workflows in private repositories
-      actions: read
+      security-events: write # required to upload SARIF results to code-scanning dashboard
+      packages: read # required to fetch internal or private CodeQL packs
+      actions: read # required to fetch workflow run information
       contents: read
 
     strategy:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -16,8 +16,8 @@ jobs:
     name: Build docs
     permissions:
       contents: read
-      pages: write
-      id-token: write
+      pages: write # needed to build GitHub Pages artifacts
+      id-token: write # needed for OIDC authentication with GitHub Pages
     steps:
       - uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -42,8 +42,8 @@ jobs:
     runs-on: ubuntu-24.04
     name: Deploy docs
     permissions:
-      pages: write
-      id-token: write
+      pages: write # needed to deploy to GitHub Pages
+      id-token: write # needed for OIDC authentication with GitHub Pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/gatekeeper.yaml
+++ b/.github/workflows/gatekeeper.yaml
@@ -25,10 +25,10 @@ jobs:
     name: gatekeeper
     runs-on: ubuntu-22.04
     permissions:
-      actions: read
+      actions: read # needed to check workflow run status
       contents: read
-      issues: read
-      pull-requests: read
+      issues: read # needed to check issue labels
+      pull-requests: read # needed to check PR labels and status
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/payload-after-push.yaml
+++ b/.github/workflows/payload-after-push.yaml
@@ -14,9 +14,9 @@ jobs:
   build-assets-amd64:
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/build-kata-static-tarball-amd64.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -29,9 +29,9 @@ jobs:
   build-assets-arm64:
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/build-kata-static-tarball-arm64.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -44,9 +44,9 @@ jobs:
   build-assets-s390x:
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/build-kata-static-tarball-s390x.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -58,7 +58,7 @@ jobs:
   build-assets-ppc64le:
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/build-kata-static-tarball-ppc64le.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -71,7 +71,7 @@ jobs:
     needs: build-assets-amd64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -89,7 +89,7 @@ jobs:
     needs: build-assets-arm64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -107,7 +107,7 @@ jobs:
     needs: build-assets-s390x
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -125,7 +125,7 @@ jobs:
     needs: build-assets-ppc64le
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -143,7 +143,7 @@ jobs:
     needs: build-assets-amd64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -161,7 +161,7 @@ jobs:
     needs: build-assets-arm64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -179,7 +179,7 @@ jobs:
     needs: build-assets-s390x
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -197,7 +197,7 @@ jobs:
     needs: build-assets-ppc64le
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/publish-kata-images.yaml
     with:
       commit-hash: ${{ github.sha }}
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push manifest images to ghcr.io
     needs: [publish-kata-deploy-image-amd64, publish-kata-deploy-image-arm64, publish-kata-deploy-image-s390x, publish-kata-deploy-image-ppc64le]
     steps:
       - name: Checkout repository
@@ -243,7 +243,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push manifest images to ghcr.io
     needs: [publish-kata-monitor-image-amd64, publish-kata-monitor-image-arm64, publish-kata-monitor-image-s390x, publish-kata-monitor-image-ppc64le]
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish-kata-images.yaml
+++ b/.github/workflows/publish-kata-images.yaml
@@ -75,7 +75,7 @@ jobs:
     name: kata-image
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push kata images to ghcr.io
     runs-on: ${{ inputs.runner }}
     strategy:
       matrix:

--- a/.github/workflows/push-oras-tarball-cache.yaml
+++ b/.github/workflows/push-oras-tarball-cache.yaml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push the ORAS tarball cache to ghcr.io
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-amd64.yaml
+++ b/.github/workflows/release-amd64.yaml
@@ -28,16 +28,16 @@ jobs:
       KBUILD_SIGN_PIN: ${{ secrets.KBUILD_SIGN_PIN }}
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
 
   kata-deploy:
     name: kata-deploy
     needs: build-kata-static-tarball-amd64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-22.04
     steps:
       - name: Login to Kata Containers ghcr.io

--- a/.github/workflows/release-arm64.yaml
+++ b/.github/workflows/release-arm64.yaml
@@ -28,16 +28,16 @@ jobs:
       KBUILD_SIGN_PIN: ${{ secrets.KBUILD_SIGN_PIN }}
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
 
   kata-deploy:
     name: kata-deploy
     needs: build-kata-static-tarball-arm64
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-24.04-arm
     steps:
       - name: Login to Kata Containers ghcr.io

--- a/.github/workflows/release-kata-images.yaml
+++ b/.github/workflows/release-kata-images.yaml
@@ -44,7 +44,7 @@ jobs:
     needs: resolve-tags
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     strategy:
       matrix:
         include:
@@ -80,7 +80,7 @@ jobs:
     runs-on: ubuntu-22.04
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/release-ppc64le.yaml
+++ b/.github/workflows/release-ppc64le.yaml
@@ -25,16 +25,16 @@ jobs:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
 
   kata-deploy:
     name: kata-deploy
     needs: build-kata-static-tarball-ppc64le
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-24.04-ppc64le
     steps:
       - name: Login to Kata Containers ghcr.io

--- a/.github/workflows/release-s390x.yaml
+++ b/.github/workflows/release-s390x.yaml
@@ -25,9 +25,9 @@ jobs:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
 
 
   kata-deploy:
@@ -35,7 +35,7 @@ jobs:
     needs: build-kata-static-tarball-s390x
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     runs-on: ubuntu-24.04-s390x
     steps:
       - name: Login to Kata Containers ghcr.io

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,9 +31,9 @@ jobs:
     needs: release
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/release-amd64.yaml
     with:
       target-arch: amd64
@@ -45,9 +45,9 @@ jobs:
     needs: release
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/release-arm64.yaml
     with:
       target-arch: arm64
@@ -59,9 +59,9 @@ jobs:
     needs: release
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/release-s390x.yaml
     with:
       target-arch: s390x
@@ -72,9 +72,9 @@ jobs:
     needs: release
     permissions:
       contents: read
-      packages: write
-      id-token: write
-      attestations: write
+      packages: write # needed to push build artifacts to ghcr.io
+      id-token: write # needed to sign images and generate attestations
+      attestations: write # needed to generate artifact attestations
     uses: ./.github/workflows/release-ppc64le.yaml
     with:
       target-arch: ppc64le
@@ -86,7 +86,7 @@ jobs:
     needs: [build-and-push-assets-amd64, build-and-push-assets-arm64, build-and-push-assets-s390x, build-and-push-assets-ppc64le]
     permissions:
       contents: read
-      packages: write
+      packages: write # needed to push build artifacts to ghcr.io
     uses: ./.github/workflows/release-kata-images.yaml
     secrets:
       QUAY_DEPLOYER_PASSWORD: ${{ secrets.QUAY_DEPLOYER_PASSWORD }}

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -24,10 +24,8 @@ jobs:
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
     if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      security-events: write # needed to upload the results to code-scanning dashboard
+      id-token: write # needed to publish results and get a badge
 
     steps:
       - name: "Checkout code"

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,3 +1,1 @@
 rules:
-  undocumented-permissions:
-    disable: true


### PR DESCRIPTION
In 7afdfc738884d1d3839f895c8bc193ac7de76625 we
just disabled the undocumented-permissions zizmor warning, but now with AI we can roll this fix more easily, so remove the disabling of the rule and add the comments

Generated-By: IBM Bob
§