### PR TITLE
runtime-rs: share block storage source mapping

### DIFF
--- a/src/runtime-rs/crates/resource/src/block_device.rs
+++ b/src/runtime-rs/crates/resource/src/block_device.rs
@@ -1,0 +1,160 @@
+// Copyright Kata Contributors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use anyhow::{anyhow, Result};
+use hypervisor::{
+    BlockConfigModern, KATA_BLK_DEV_TYPE, KATA_CCW_DEV_TYPE, KATA_MMIO_BLK_DEV_TYPE,
+    KATA_NVDIMM_DEV_TYPE, KATA_SCSI_DEV_TYPE,
+};
+
+/// Return the source value to pass to the agent for a hypervisor block device.
+pub(crate) fn agent_storage_source_from_block_config(config: &BlockConfigModern) -> Result<String> {
+    match config.driver_option.as_str() {
+        KATA_BLK_DEV_TYPE => config
+            .pci_path
+            .as_ref()
+            .map(ToString::to_string)
+            .ok_or_else(|| anyhow!("block driver is blk but no pci path exists")),
+        KATA_SCSI_DEV_TYPE => config
+            .scsi_addr
+            .clone()
+            .ok_or_else(|| anyhow!("block driver is scsi but no scsi address exists")),
+        KATA_CCW_DEV_TYPE => config
+            .ccw_addr
+            .clone()
+            .ok_or_else(|| anyhow!("block driver is ccw but no ccw address exists")),
+        KATA_MMIO_BLK_DEV_TYPE | KATA_NVDIMM_DEV_TYPE => Ok(config.virt_path.clone()),
+        driver => Err(anyhow!("unsupported block driver {driver}")),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hypervisor::device::pci_path::PciPath;
+    use std::convert::TryFrom;
+
+    #[test]
+    fn blk_source_uses_pci_path() {
+        let config = BlockConfigModern {
+            driver_option: KATA_BLK_DEV_TYPE.to_string(),
+            pci_path: Some(PciPath::try_from("01/0a/05").unwrap()),
+            virt_path: "/dev/vda".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            agent_storage_source_from_block_config(&config).unwrap(),
+            "01/0a/05"
+        );
+    }
+
+    #[test]
+    fn blk_source_requires_pci_path() {
+        let config = BlockConfigModern {
+            driver_option: KATA_BLK_DEV_TYPE.to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            agent_storage_source_from_block_config(&config)
+                .unwrap_err()
+                .to_string(),
+            "block driver is blk but no pci path exists"
+        );
+    }
+
+    #[test]
+    fn scsi_source_uses_scsi_address() {
+        let config = BlockConfigModern {
+            driver_option: KATA_SCSI_DEV_TYPE.to_string(),
+            scsi_addr: Some("2:1".to_string()),
+            virt_path: "/dev/vda".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            agent_storage_source_from_block_config(&config).unwrap(),
+            "2:1"
+        );
+    }
+
+    #[test]
+    fn scsi_source_requires_scsi_address() {
+        let config = BlockConfigModern {
+            driver_option: KATA_SCSI_DEV_TYPE.to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            agent_storage_source_from_block_config(&config)
+                .unwrap_err()
+                .to_string(),
+            "block driver is scsi but no scsi address exists"
+        );
+    }
+
+    #[test]
+    fn ccw_source_uses_ccw_address() {
+        let config = BlockConfigModern {
+            driver_option: KATA_CCW_DEV_TYPE.to_string(),
+            ccw_addr: Some("0.0.0005".to_string()),
+            virt_path: "/dev/vda".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            agent_storage_source_from_block_config(&config).unwrap(),
+            "0.0.0005"
+        );
+    }
+
+    #[test]
+    fn ccw_source_requires_ccw_address() {
+        let config = BlockConfigModern {
+            driver_option: KATA_CCW_DEV_TYPE.to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            agent_storage_source_from_block_config(&config)
+                .unwrap_err()
+                .to_string(),
+            "block driver is ccw but no ccw address exists"
+        );
+    }
+
+    #[test]
+    fn path_based_sources_use_virt_path() {
+        for driver in [KATA_MMIO_BLK_DEV_TYPE, KATA_NVDIMM_DEV_TYPE] {
+            let config = BlockConfigModern {
+                driver_option: driver.to_string(),
+                virt_path: "/dev/vda".to_string(),
+                ..Default::default()
+            };
+
+            assert_eq!(
+                agent_storage_source_from_block_config(&config).unwrap(),
+                "/dev/vda"
+            );
+        }
+    }
+
+    #[test]
+    fn unknown_driver_is_rejected() {
+        let config = BlockConfigModern {
+            driver_option: "unknown".to_string(),
+            virt_path: "/dev/vda".to_string(),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            agent_storage_source_from_block_config(&config)
+                .unwrap_err()
+                .to_string(),
+            "unsupported block driver unknown"
+        );
+    }
+}

--- a/src/runtime-rs/crates/resource/src/lib.rs
+++ b/src/runtime-rs/crates/resource/src/lib.rs
@@ -12,6 +12,7 @@ extern crate slog;
 
 logging::logger_with_subsystem!(sl, "resource");
 
+mod block_device;
 pub mod cgroups;
 pub mod manager;
 mod manager_inner;

--- a/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/block_rootfs.rs
@@ -5,7 +5,10 @@
 //
 
 use super::{Rootfs, ROOTFS};
-use crate::share_fs::{do_get_guest_path, do_get_host_path};
+use crate::{
+    block_device::agent_storage_source_from_block_config,
+    share_fs::{do_get_guest_path, do_get_host_path},
+};
 use agent::Storage;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -14,9 +17,7 @@ use hypervisor::{
         DeviceConfig, DeviceType, device_manager::{DeviceManager, do_handle_device, get_block_device_info},
     },
 };
-use kata_types::config::hypervisor::{
-    VIRTIO_BLK_CCW, VIRTIO_BLK_MMIO, VIRTIO_BLK_PCI, VIRTIO_PMEM, VIRTIO_SCSI,
-};
+use kata_types::config::hypervisor::VIRTIO_PMEM;
 use kata_types::fs::VM_ROOTFS_FILESYSTEM_XFS;
 use kata_types::mount::Mount;
 use nix::sys::stat::{self, SFlag};
@@ -88,43 +89,16 @@ impl BlockRootfs {
         let mut device_id: String = "".to_owned();
         if let DeviceType::BlockModern(device_mod) = device_info {
             let device = device_mod.lock().await.clone();
-            storage.driver = device.config.driver_option;
-            device_id = device.device_id;
-
-            match block_driver.as_str() {
-                VIRTIO_BLK_PCI => {
-                    storage.source = device
-                        .config
-                        .pci_path
-                        .ok_or("PCI path missing for pci block device")
-                        .map_err(|e| anyhow!(e))?
-                        .to_string();
-                }
-                VIRTIO_BLK_MMIO => {
-                    storage.source = device.config.virt_path;
-                }
-                VIRTIO_BLK_CCW => {
-                    storage.source = device
-                        .config
-                        .ccw_addr
-                        .ok_or_else(|| anyhow!("CCW address missing for ccw block device"))?;
-                }
-                VIRTIO_SCSI => {
-                    storage.source = device
-                        .config
-                        .scsi_addr
-                        .ok_or_else(|| anyhow!("SCSI address missing for scsi block device"))?;
-                }
-                VIRTIO_PMEM => {
-                    return Err(anyhow!(
-                        "Complete support for block driver {} has not been implemented yet",
-                        block_driver
-                    ));
-                }
-                _ => {
-                    return Err(anyhow!("Unknown block driver : {}", block_driver));
-                }
+            if block_driver == VIRTIO_PMEM {
+                return Err(anyhow!(
+                    "Complete support for block driver {} has not been implemented yet",
+                    block_driver
+                ));
             }
+
+            storage.driver = device.config.driver_option.clone();
+            storage.source = agent_storage_source_from_block_config(&device.config)?;
+            device_id = device.device_id;
         }
 
         Ok(Self {

--- a/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
+++ b/src/runtime-rs/crates/resource/src/rootfs/erofs_rootfs.rs
@@ -13,17 +13,17 @@
 // templates in upperdir/workdir.
 
 use super::{Rootfs, ROOTFS};
-use crate::share_fs::{do_get_guest_path, do_get_host_path};
+use crate::{
+    block_device::agent_storage_source_from_block_config,
+    share_fs::{do_get_guest_path, do_get_host_path},
+};
 use agent::Storage;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use hypervisor::{
-    BlockConfigModern, BlockDeviceAio, BlockDeviceFormat, KATA_SCSI_DEV_TYPE, device::{
+    BlockConfigModern, BlockDeviceAio, BlockDeviceFormat, device::{
         DeviceConfig, DeviceType, device_manager::{DeviceManager, do_handle_device, get_block_device_info},
     },
-};
-use kata_types::device::{
-    DRIVER_BLK_CCW_TYPE as KATA_CCW_DEV_TYPE, DRIVER_BLK_PCI_TYPE as KATA_BLK_DEV_TYPE,
 };
 use kata_types::gpt_disk::{
     extract_dmverity_annotation, extract_snapshot_id, generate_dmverity_options,
@@ -472,33 +472,8 @@ async fn extract_block_device_info(
     let mut device_id = String::new();
     if let DeviceType::BlockModern(device_mod) = device_info.clone() {
         let device = device_mod.lock().await.clone();
-        let blk_driver = device.config.driver_option;
-        // blk, mmioblk
-        storage.driver = blk_driver.clone();
-        storage.source = match blk_driver.as_str() {
-            KATA_BLK_DEV_TYPE => {
-                if let Some(pci_path) = device.config.pci_path {
-                    pci_path.to_string()
-                } else {
-                    return Err(anyhow!("block driver is blk but no pci path exists"));
-                }
-            }
-            KATA_SCSI_DEV_TYPE => {
-                if let Some(scsi_addr) = device.config.scsi_addr {
-                    scsi_addr.to_string()
-                } else {
-                    return Err(anyhow!("block driver is scsi but no scsi address exists"));
-                }
-            }
-            KATA_CCW_DEV_TYPE => {
-                if let Some(ccw_addr) = device.config.ccw_addr {
-                    ccw_addr.to_string()
-                } else {
-                    return Err(anyhow!("block driver is ccw but no ccw address exists"));
-                }
-            }
-            _ => device.config.virt_path,
-        };
+        storage.driver = device.config.driver_option.clone();
+        storage.source = agent_storage_source_from_block_config(&device.config)?;
         device_id = device.device_id;
     }
 

--- a/src/runtime-rs/crates/resource/src/volume/utils.rs
+++ b/src/runtime-rs/crates/resource/src/volume/utils.rs
@@ -12,15 +12,12 @@ use std::{
 };
 
 use crate::{
+    block_device::agent_storage_source_from_block_config,
     share_fs::{do_get_guest_path, do_get_host_path},
     volume::share_fs_volume::generate_mount_path,
 };
 use anyhow::{anyhow, Context, Result};
 use kata_sys_util::mount::{get_mount_options, get_mount_path};
-use kata_types::device::{
-    DRIVER_BLK_CCW_TYPE as KATA_CCW_DEV_TYPE, DRIVER_BLK_PCI_TYPE as KATA_BLK_DEV_TYPE,
-    DRIVER_SCSI_TYPE as KATA_SCSI_DEV_TYPE,
-};
 use oci_spec::runtime as oci;
 
 use hypervisor::device::DeviceType;
@@ -123,44 +120,6 @@ pub(crate) async fn generate_shared_path(
     Ok(guest_path)
 }
 
-/// Extract storage source information from block device configuration.
-/// This helper function handles the common logic for determining the storage source
-/// based on the driver type (BLK/SCSI/CCW).
-fn extract_storage_source(
-    driver_option: &str,
-    pci_path: Option<&hypervisor::device::pci_path::PciPath>,
-    scsi_addr: Option<&str>,
-    ccw_addr: Option<&str>,
-    virt_path: &str,
-) -> Result<String> {
-    let source = match driver_option {
-        KATA_BLK_DEV_TYPE => {
-            if let Some(pci_path) = pci_path {
-                pci_path.to_string()
-            } else {
-                return Err(anyhow!("block driver is blk but no pci path exists"));
-            }
-        }
-        KATA_SCSI_DEV_TYPE => {
-            if let Some(scsi_addr) = scsi_addr {
-                scsi_addr.to_string()
-            } else {
-                return Err(anyhow!("block driver is scsi but no scsi address exists"));
-            }
-        }
-        KATA_CCW_DEV_TYPE => {
-            if let Some(ccw_addr) = ccw_addr {
-                ccw_addr.to_string()
-            } else {
-                return Err(anyhow!("block driver is ccw but no ccw address exists"));
-            }
-        }
-        _ => virt_path.to_string(),
-    };
-
-    Ok(source)
-}
-
 pub async fn handle_block_volume(
     device_info: DeviceType,
     m: &oci::Mount,
@@ -191,13 +150,7 @@ pub async fn handle_block_volume(
     if let DeviceType::BlockModern(device_mod) = device_info.clone() {
         let device = &device_mod.lock().await;
         storage.driver = device.config.driver_option.clone();
-        storage.source = extract_storage_source(
-            &device.config.driver_option,
-            device.config.pci_path.as_ref(),
-            device.config.scsi_addr.as_deref(),
-            device.config.ccw_addr.as_deref(),
-            &device.config.virt_path,
-        )?;
+        storage.source = agent_storage_source_from_block_config(&device.config)?;
         device_id = device.device_id.clone();
     }
 


### PR DESCRIPTION
Use a resource-level helper to map modern block device configuration to the Storage.source value passed to the agent. Share it between block rootfs, EROFS rootfs, and block volume handling. Match each supported normalized block driver explicitly. Reject unknown drivers instead of treating them as virt-path based devices.

A recent change was authored here: https://github.com/kata-containers/kata-containers/pull/13324 

The goal of this PR is to provide a single function for the three callers to the same functionality for improved maintainability.