### PR TITLE
runtime-rs: Fix network queues and propagate it to network endpoints

### DIFF
--- a/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/ch/inner_device.rs
@@ -317,8 +317,11 @@ impl CloudHypervisorInner {
         // When using fds to pass the tap device to cloud-hypervisor, tap and id fields should be None
         clh_net_config.tap = None;
         clh_net_config.id = None;
+        // The `config.num_queues` is a queue *pair* count (1 RX + 1 TX per pair).
+        // Convert pairs into the actual queue count.
+        clh_net_config.num_queues = netdev.config.queue_num.max(1) * 2;
 
-        let files = open_named_tuntap(&netdev.config.host_dev_name, netdev.config.queue_num as u32)
+        let files = open_named_tuntap(&netdev.config.host_dev_name, netdev.config.queue_num.max(1) as u32)
             .context("open named tuntap")?;
 
         let fds = files.iter().map(|f| f.as_raw_fd()).collect();

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/inner_device.rs
@@ -287,8 +287,11 @@ impl DragonballInner {
     /// Add vhost-user-net device to Dragonball
     fn add_vhost_user_net_device(&mut self, config: &VhostUserConfig) -> Result<()> {
         let guest_mac = MacAddr::parse_str(&config.mac_address).ok();
+        // `config.num_queues` is a queue *pair* count (1 RX + 1 TX per pair).
+        // Convert pairs into the actual queue count.
+        let num_queues = config.num_queues.max(1) * 2;
         let net_cfg = NetworkInterfaceConfig {
-            num_queues: Some(config.num_queues),
+            num_queues: Some(num_queues),
             queue_size: Some(config.queue_size as u16),
             backend: dragonball::api::v1::Backend::VhostUser(DragonballVhostUserConfig {
                 sock_path: config.socket_path.clone(),

--- a/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
+++ b/src/runtime-rs/crates/hypervisor/src/dragonball/mod.rs
@@ -295,8 +295,11 @@ pub(crate) fn build_dragonball_network_config(
         DragonballBackend::Vhost(virtio_config)
     };
 
+    // `config.num_queues` is a queue *pair* count (1 RX + 1 TX per pair).
+    // Convert pairs into the actual queue count.
+    let num_queues = nconfig.queue_num.max(1) * 2;
     DragonballNetworkConfig {
-        num_queues: Some(nconfig.queue_num),
+        num_queues: Some(num_queues),
         queue_size: Some(nconfig.queue_size as u16),
         backend,
         guest_mac: nconfig.guest_mac.clone().map(|mac| {

--- a/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/cmdline_generator.rs
@@ -3178,12 +3178,18 @@ impl<'a> QemuCmdLine<'a> {
         ));
     }
 
-    pub fn add_network_device(&mut self, host_dev_name: &str, guest_mac: Address) -> Result<()> {
+    pub fn add_network_device(
+        &mut self,
+        host_dev_name: &str,
+        guest_mac: Address,
+        num_queues: u32,
+    ) -> Result<()> {
         let (netdev, virtio_net_device) = get_network_device(
             self.config,
             host_dev_name,
             guest_mac,
             &mut self.ccw_subchannel,
+            num_queues,
         )?;
 
         self.devices.push(Box::new(netdev));
@@ -3692,11 +3698,12 @@ pub fn get_network_device(
     host_dev_name: &str,
     guest_mac: Address,
     ccw_subchannel: &mut Option<CcwSubChannel>,
+    num_queues: u32,
 ) -> Result<(Netdev, DeviceVirtioNet)> {
     let mut netdev = Netdev::new(
         &format!("network-{host_dev_name}"),
         host_dev_name,
-        config.network_info.network_queues,
+        num_queues,
     )?;
     if config.network_info.disable_vhost_net {
         netdev.set_disable_vhost_net(true);
@@ -3711,8 +3718,8 @@ pub fn get_network_device(
     if config.device_info.enable_iommu_platform && bus_type() == VirtioBusType::Ccw {
         virtio_net_device.set_iommu_platform(true);
     }
-    if config.network_info.network_queues > 1 {
-        virtio_net_device.set_num_queues(config.network_info.network_queues);
+    if num_queues > 1 {
+        virtio_net_device.set_num_queues(num_queues);
     }
 
     Ok((netdev, virtio_net_device))

--- a/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
+++ b/src/runtime-rs/crates/hypervisor/src/qemu/inner.rs
@@ -171,6 +171,7 @@ impl QemuInner {
                     cmdline.add_network_device(
                         &network.config.host_dev_name,
                         network.config.guest_mac.clone().unwrap(),
+                        network.config.queue_num.max(1) as u32,
                     )?;
                 }
                 DeviceType::Protection(prot_dev) => match &prot_dev.config {
@@ -1040,6 +1041,7 @@ impl QemuInner {
                     &network_device.config.host_dev_name,
                     network_device.config.guest_mac.clone().unwrap(),
                     &mut None,
+                    network_device.config.queue_num.max(1) as u32,
                 )?;
                 qmp.hotplug_network_device(&netdev, &virtio_net_device)?;
 

--- a/src/runtime-rs/crates/resource/src/network/dan.rs
+++ b/src/runtime-rs/crates/resource/src/network/dan.rs
@@ -68,8 +68,8 @@ impl DanInner {
         let json_str = fs::read_to_string(&config.dan_conf_path)
             .await
             .context("Read DAN config from file")?;
-        let config: DanConfig = serde_json::from_str(&json_str).context("Invalid DAN config")?;
-        info!(sl!(), "Dan config is loaded = {:?}", config);
+        let dan_config: DanConfig = serde_json::from_str(&json_str).context("Invalid DAN config")?;
+        info!(sl!(), "Dan config is loaded = {:?}", dan_config);
 
         let (connection, handle, _) = rtnetlink::new_connection().context("New connection")?;
         let thread_handler = tokio::spawn(connection);
@@ -77,43 +77,45 @@ impl DanInner {
             thread_handler.abort();
         });
 
-        let mut entity_list = Vec::with_capacity(config.devices.len());
-        for (idx, device) in config.devices.iter().enumerate() {
+        let mut entity_list = Vec::with_capacity(dan_config.devices.len());
+        for (idx, device) in dan_config.devices.iter().enumerate() {
             let name = format!("eth{idx}");
+            // The `network_queues` is a queue *pair* count.
+            // Keep `queue_num` as a pair count and the hypervisor backend converts pairs into the actual virtqueue count.
+            // A JSON-provided non-zero `queue_num` (also a pair count) with a higher priority always wins.
+            let (qnum, qsize) = device
+                .device
+                .get_effective_queues(config.network_queues);
             let endpoint: Arc<dyn Endpoint> = match &device.device {
-                Device::VhostUser {
-                    path,
-                    queue_num,
-                    queue_size,
-                } => Arc::new(
-                    VhostUserEndpoint::new(
-                        dev_mgr,
-                        &name,
-                        &device.guest_mac,
-                        path,
-                        *queue_num,
-                        *queue_size,
+                Device::VhostUser { path, .. } => {
+                    Arc::new(
+                        VhostUserEndpoint::new(
+                            dev_mgr,
+                            &name,
+                            &device.guest_mac,
+                            path,
+                            qnum,
+                            qsize,
+                        )
+                        .await
+                        .with_context(|| format!("create a vhost user endpoint, path: {path}"))?,
                     )
-                    .await
-                    .with_context(|| format!("create a vhost user endpoint, path: {path}"))?,
-                ),
-                Device::HostTap {
-                    tap_name,
-                    queue_num,
-                    queue_size,
-                } => Arc::new(
-                    TapEndpoint::new(
-                        &handle,
-                        &name,
-                        tap_name,
-                        &device.guest_mac,
-                        *queue_num,
-                        *queue_size,
-                        dev_mgr,
+                }
+                Device::HostTap { tap_name, .. } => {
+                    Arc::new(
+                        TapEndpoint::new(
+                            &handle,
+                            &name,
+                            tap_name,
+                            &device.guest_mac,
+                            qnum,
+                            qsize,
+                            dev_mgr,
+                        )
+                        .await
+                        .with_context(|| format!("create a {tap_name} tap endpoint"))?,
                     )
-                    .await
-                    .with_context(|| format!("create a {tap_name} tap endpoint"))?,
-                ),
+                }
             };
 
             let network_info = Arc::new(
@@ -129,7 +131,7 @@ impl DanInner {
         }
 
         Ok(Self {
-            netns: config.netns,
+            netns: dan_config.netns,
             entity_list,
         })
     }
@@ -211,6 +213,9 @@ impl Network for Dan {
 #[derive(Debug)]
 pub struct DanNetworkConfig {
     pub dan_conf_path: PathBuf,
+    /// Number of virtio queue pairs (each pair = 1 RX + 1 TX).
+    /// Derived from `network_queues` in the hypervisor TOML config.
+    pub network_queues: usize,
 }
 
 /// Directly attachable network config written by CNI plugins
@@ -257,6 +262,34 @@ pub(crate) enum Device {
         #[serde(default)]
         queue_size: usize,
     },
+}
+
+impl Device {
+    /// get the effective queue-pair count and queue size.
+    pub(crate) fn get_effective_queues(&self, network_queues: usize) -> (usize, usize) {
+        // The `network_queues` comes from hypervisor configurations, and we need to ensure that it is at least 1,
+        // otherwise the network device will not work.
+        let network_queues = network_queues.max(1);
+        let (queue_num, queue_size) = match self {
+            Device::VhostUser {
+                queue_num,
+                queue_size,
+                ..
+            }
+            | Device::HostTap {
+                queue_num,
+                queue_size,
+                ..
+            } => (queue_num, queue_size),
+        };
+        let qnum = if *queue_num == 0 {
+            network_queues
+        } else {
+            *queue_num
+        };
+        let qsize = if *queue_size == 0 { 256 } else { *queue_size };
+        (qnum, qsize)
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/runtime-rs/crates/resource/src/network/endpoint/endpoints_test.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/endpoints_test.rs
@@ -119,6 +119,7 @@ mod tests {
                                 },
                                 model: Arc::new(TcFilterModel::new().unwrap()), // impossible to panic
                                 network_qos: false,
+                                network_queues: 5,
                             },
                         };
 
@@ -159,6 +160,7 @@ mod tests {
                             _ => unreachable!(),
                         }
                         assert_eq!(manual.net_pair.network_qos, result.net_pair.network_qos);
+                        assert_eq!(manual.net_pair.network_queues, result.net_pair.network_queues);
                     }
                     assert!(delete_link(&handle, manual_vlan_iface_name.as_str())
                         .await
@@ -250,6 +252,7 @@ mod tests {
                                 model: network_model::new(model_str)
                                     .expect("failed to create new network model"),
                                 network_qos: false,
+                                network_queues: 5,
                             },
                         };
 
@@ -291,6 +294,7 @@ mod tests {
                             _ => unreachable!(),
                         }
                         assert_eq!(manual.net_pair.network_qos, result.net_pair.network_qos);
+                        assert_eq!(manual.net_pair.network_queues, result.net_pair.network_queues);
                     }
                     // delete the manually created links
                     assert!(delete_link(&handle, manual_macvlan_iface_name.as_str())
@@ -333,7 +337,8 @@ mod tests {
                 .await
                 .context("failed to create manual veth pair")
             {
-                if let Ok(mut result) = IPVlanEndpoint::new(&d, &handle, "", idx, 5)
+                // Test with 0 and fallback default behaviour with 1
+                if let Ok(mut result) = IPVlanEndpoint::new(&d, &handle, "", idx, 0)
                     .await
                     .context("failed to create new ipvlan endpoint")
                 {
@@ -355,6 +360,7 @@ mod tests {
                             },
                             model: Arc::new(TcFilterModel::new().unwrap()), // impossible to panic
                             network_qos: false,
+                            network_queues: 1,
                         },
                     };
 
@@ -395,6 +401,7 @@ mod tests {
                         _ => unreachable!(),
                     }
                     assert_eq!(manual.net_pair.network_qos, result.net_pair.network_qos);
+                    assert_eq!(manual.net_pair.network_queues, result.net_pair.network_queues);
                 }
                 assert!(delete_link(&handle, manual_virt_iface_name.as_str())
                     .await

--- a/src/runtime-rs/crates/resource/src/network/endpoint/endpoints_test.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/endpoints_test.rs
@@ -17,6 +17,7 @@ mod tests {
     use tokio::sync::RwLock;
 
     use crate::network::{
+        dan::Device,
         endpoint::{IPVlanEndpoint, MacVlanEndpoint, VlanEndpoint},
         network_model::{
             self,
@@ -409,5 +410,56 @@ mod tests {
                 assert!(delete_link(&handle, tap_iface_name.as_str()).await.is_ok());
             }
         }
+    }
+
+    // DAN regression test for the minimum-of-1 requirement.
+    #[test]
+    fn test_dan_device_get_effective_queues_min_one() {
+        // Test `network_queues` of 0 to the minimum of 1.
+        let default_network_queues = 0_usize;
+
+        // VhostUser effective pair count falls back to default (1),
+        // queue size falls back to 256.
+        let vhost = Device::VhostUser {
+            path: "/tmp/test".to_owned(),
+            queue_num: 0,
+            queue_size: 0,
+        };
+        assert_eq!(
+            vhost.get_effective_queues(default_network_queues),
+            (1, 256)
+        );
+
+        // HostTap fallback default behaviour.
+        let tap = Device::HostTap {
+            tap_name: "tap0".to_owned(),
+            queue_num: 0,
+            queue_size: 0,
+        };
+        assert_eq!(tap.get_effective_queues(default_network_queues), (1, 256));
+
+        // This catches a regression that would always return 1.
+        let vhost_default4 = Device::VhostUser {
+            path: "/tmp/test".to_owned(),
+            queue_num: 0,
+            queue_size: 0,
+        };
+        assert_eq!(vhost_default4.get_effective_queues(4), (4, 256));
+
+        // A non-zero `queue_num` from the JSON always wins over the default,
+        // even when it equals the minimum — and is never reported as 0.
+        let vhost_nonzero = Device::VhostUser {
+            path: "/tmp/test".to_owned(),
+            queue_num: 1,
+            queue_size: 0,
+        };
+        assert_eq!(vhost_nonzero.get_effective_queues(default_network_queues), (1, 256));
+
+        let tap_explicit = Device::HostTap {
+            tap_name: "tap0".to_owned(),
+            queue_num: 7,
+            queue_size: 512,
+        };
+        assert_eq!(tap_explicit.get_effective_queues(default_network_queues), (7, 512));
     }
 }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/ipvlan_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/ipvlan_endpoint.rs
@@ -58,6 +58,8 @@ impl IPVlanEndpoint {
             host_dev_name: iface.name.clone(),
             virt_iface_name: self.net_pair.virt_iface.name.clone(),
             guest_mac: Some(guest_mac),
+            queue_num: self.net_pair.network_queues,
+            queue_size: 256,
             ..Default::default()
         })
     }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/macvlan_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/macvlan_endpoint.rs
@@ -57,6 +57,8 @@ impl MacVlanEndpoint {
             host_dev_name: iface.name.clone(),
             virt_iface_name: self.net_pair.virt_iface.name.clone(),
             guest_mac: Some(guest_mac),
+            queue_num: self.net_pair.network_queues,
+            queue_size: 256,
             ..Default::default()
         })
     }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/veth_endpoint.rs
@@ -57,6 +57,8 @@ impl VethEndpoint {
             host_dev_name: iface.name.clone(),
             virt_iface_name: self.net_pair.virt_iface.name.clone(),
             guest_mac: Some(guest_mac),
+            queue_num: self.net_pair.network_queues,
+            queue_size: 256,
             ..Default::default()
         })
     }

--- a/src/runtime-rs/crates/resource/src/network/endpoint/vlan_endpoint.rs
+++ b/src/runtime-rs/crates/resource/src/network/endpoint/vlan_endpoint.rs
@@ -57,6 +57,8 @@ impl VlanEndpoint {
             host_dev_name: iface.name.clone(),
             virt_iface_name: self.net_pair.virt_iface.name.clone(),
             guest_mac: Some(guest_mac),
+            queue_num: self.net_pair.network_queues,
+            queue_size: 256,
             ..Default::default()
         })
     }

--- a/src/runtime-rs/crates/resource/src/network/network_pair.rs
+++ b/src/runtime-rs/crates/resource/src/network/network_pair.rs
@@ -36,6 +36,9 @@ pub struct NetworkPair {
     pub virt_iface: NetworkInterface,
     pub model: Arc<dyn network_model::NetworkModel>,
     pub network_qos: bool,
+    /// Number of virtio queue pairs (each pair = 1 RX + 1 TX).
+    /// Derived from `network_queues` in the hypervisor TOML config.
+    pub network_queues: usize,
 }
 
 impl NetworkPair {
@@ -46,6 +49,8 @@ impl NetworkPair {
         model: &str,
         queues: usize,
     ) -> Result<Self> {
+        // Ensure that the queues >= 1
+        let queues = queues.max(1);
         let unique_id = kata_sys_util::rand::UUID::new();
         let model = network_model::new(model).context("new network model")?;
         let tap_iface_name = format!("tap{idx}{TAP_SUFFIX}");
@@ -127,6 +132,7 @@ impl NetworkPair {
             },
             model,
             network_qos: false,
+            network_queues: queues,
         };
 
         Ok(net_pair)

--- a/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
+++ b/src/runtime-rs/crates/runtimes/virt_container/src/sandbox.rs
@@ -549,6 +549,12 @@ impl VirtSandbox {
             Some(ResourceConfig::Network(NetworkConfig::Dan(
                 DanNetworkConfig {
                     dan_conf_path: dan_path,
+                    network_queues: self
+                        .hypervisor
+                        .hypervisor_config()
+                        .await
+                        .network_info
+                        .network_queues as usize,
                 },
             )))
         } else if let Some(netns_path) = network_env.netns.as_ref() {


### PR DESCRIPTION
When creating virtio-net devices in Kata runtime-rs, two multi-queue related fields — `queue_num` and `queue_size` were left missing/default in the device descriptor handed down to the hypervisor. 

Each network endpoint (veth / macvlan / ipvlan / vlan) only populated host_dev_name, virt_iface_name, and guest_mac when building the NetworkPair, while queue_num/queue_size fell back to ..Default::default(). 

As a result, the virtio-net device inside the guest was always created single-queue (queue_num degrading to 1), unable to leverage the host-side multiple vCPUs for parallel RX/TX. 

Consequently, network throughput under high concurrency was limited, and the `network_queues` setting declared in the hypervisor TOML config was never actually consumed by the network path.

This PR aims to address it.