### PR TITLE
agent - remove intialization of kmem limits

### DIFF
--- a/src/agent/rustjail/src/cgroups/fs/mod.rs
+++ b/src/agent/rustjail/src/cgroups/fs/mod.rs
@@ -473,15 +473,9 @@ fn set_cpu_resources(cg: &cgroups::Cgroup, cpu: &LinuxCpu) -> Result<()> {
     Ok(())
 }
 
-fn set_memory_resources(cg: &cgroups::Cgroup, memory: &LinuxMemory, update: bool) -> Result<()> {
+fn set_memory_resources(cg: &cgroups::Cgroup, memory: &LinuxMemory, _update: bool) -> Result<()> {
     info!(sl(), "cgroup manager set memory");
     let mem_controller: &MemController = cg.controller_of().unwrap();
-
-    if !update {
-        // initialize kmem limits for accounting
-        mem_controller.set_kmem_limit(1)?;
-        mem_controller.set_kmem_limit(-1)?;
-    }
 
     // If the memory update is set to -1 we should also
     // set swap to -1, it means unlimited memory.


### PR DESCRIPTION
We have seen logs in production where containers failed to start with the following error:
```
Error: failed to create containerd task: failed to create shim task: unable to write to a control group file memory.kmem.limit_in_bytes, value 1 caused by: Os { code: 16, kind: ResourceBusy, message: "Resource busy" }
```

After considering implementing different "strategy" based on managers, I took the path of removing the "double write" altogether:

- memory accounting is already was already enabled by default in (at least) 5.4
- the `memory.kmem.limit_in_bytes` is deprecated in https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=0158115f702b0ba208ab0b5adf44cae99b3ebcc7 and removed in https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=58056f77502f3567b760c9a8fc8d2e9081515b2d.

Confirmed with:

```console
$ cat repro3.sh
#!/bin/bash
CGROUP=/sys/fs/cgroup/memory/test-kmem

mkdir -p $CGROUP

echo "kmem usage before adding process: $(cat $CGROUP/memory.kmem.usage_in_bytes)"

echo $$ > $CGROUP/cgroup.procs

echo "kmem usage after adding process:  $(cat $CGROUP/memory.kmem.usage_in_bytes)"

# Move self back before cleanup
echo $$ > /sys/fs/cgroup/memory/cgroup.procs
rmdir $CGROUP
$ sudo ./repro3.sh
kmem usage before adding process: 0
kmem usage after adding process:  135168
```